### PR TITLE
[GUI] Kill g_SkinInfo global, move to CGUIComponent

### DIFF
--- a/xbmc/addons/LanguageResource.cpp
+++ b/xbmc/addons/LanguageResource.cpp
@@ -10,8 +10,8 @@
 #include "LangInfo.h"
 #include "ServiceBroker.h"
 #include "addons/AddonManager.h"
-#include "addons/Skin.h"
 #include "addons/addoninfo/AddonType.h"
+#include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "settings/Settings.h"
@@ -100,7 +100,7 @@ bool CLanguageResource::IsInUse() const
 
 void CLanguageResource::OnPostInstall(bool update, bool modal)
 {
-  if (!g_SkinInfo)
+  if (!CServiceBroker::GetGUI())
     return;
 
   if (IsInUse() || (!update && !modal &&

--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -289,5 +289,3 @@ private:
 };
 
 } /*namespace ADDON*/
-
-extern std::shared_ptr<ADDON::CSkinInfo> g_SkinInfo;

--- a/xbmc/addons/interfaces/gui/Window.cpp
+++ b/xbmc/addons/interfaces/gui/Window.cpp
@@ -136,8 +136,12 @@ KODI_GUI_WINDOW_HANDLE Interface_GUIWindow::create(KODI_HANDLE kodiBase,
                CAddonInfo::TranslateType(addon->Type()), addon->Name(), addon->Author());
   }
 
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return nullptr;
+
   RESOLUTION_INFO res;
-  std::string strSkinPath = g_SkinInfo->GetSkinPath(xml_filename, &res);
+  std::string strSkinPath = skin->GetSkinPath(xml_filename, &res);
 
   if (!CFileUtils::Exists(strSkinPath))
   {
@@ -147,9 +151,9 @@ KODI_GUI_WINDOW_HANDLE Interface_GUIWindow::create(KODI_HANDLE kodiBase,
 
     // Check for the matching folder for the skin in the fallback skins folder
     const std::string fallbackPath{URIUtils::AddFileToFolder(addon->Path(), "resources", "skins")};
-    const std::string basePath{URIUtils::AddFileToFolder(fallbackPath, g_SkinInfo->ID())};
+    const std::string basePath{URIUtils::AddFileToFolder(fallbackPath, skin->ID())};
 
-    strSkinPath = g_SkinInfo->GetSkinPath(xml_filename, &res, basePath);
+    strSkinPath = skin->GetSkinPath(xml_filename, &res, basePath);
 
     // Check for the matching folder for the skin in the fallback skins folder (if it exists)
     if (CFileUtils::Exists(basePath))

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -744,7 +744,8 @@ bool CApplication::Initialize()
     else
     {
       // activate the configured start window
-      int firstWindow = g_SkinInfo->GetFirstWindow();
+      auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+      int firstWindow = skin ? skin->GetFirstWindow() : WINDOW_HOME;
       CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(firstWindow);
 
       if (CServiceBroker::GetGUI()->GetWindowManager().IsWindowActive(WINDOW_STARTUP_ANIM))
@@ -1776,8 +1777,9 @@ bool CApplication::Stop(int exitCode)
     // either a bug in core or misbehaving addons. so try saving
     // skin settings early
     CLog::Log(LOGINFO, "Saving skin settings");
-    if (g_SkinInfo != nullptr)
-      g_SkinInfo->SaveSettings();
+    auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+    if (skin)
+      skin->SaveSettings();
 
     m_bStop = true;
     // Add this here to keep the same ordering behaviour for now

--- a/xbmc/guilib/GUIColorManager.cpp
+++ b/xbmc/guilib/GUIColorManager.cpp
@@ -10,6 +10,7 @@
 
 #include "addons/Skin.h"
 #include "filesystem/SpecialProtocol.h"
+#include "guilib/GUIComponent.h"
 #include "utils/ColorUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -33,13 +34,17 @@ void CGUIColorManager::Load(const std::string &colorFile)
 {
   Clear();
 
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return;
+
   // load the global color map if it exists
   CXBMCTinyXML xmlDoc;
   if (xmlDoc.LoadFile(CSpecialProtocol::TranslatePathConvertCase("special://xbmc/system/colors.xml")))
     LoadXML(xmlDoc);
 
   // first load the default color map if it exists
-  std::string path = URIUtils::AddFileToFolder(g_SkinInfo->Path(), "colors", "defaults.xml");
+  std::string path = URIUtils::AddFileToFolder(skin->Path(), "colors", "defaults.xml");
 
   if (xmlDoc.LoadFile(CSpecialProtocol::TranslatePathConvertCase(path)))
     LoadXML(xmlDoc);
@@ -48,7 +53,7 @@ void CGUIColorManager::Load(const std::string &colorFile)
   if (StringUtils::EqualsNoCase(colorFile, "SKINDEFAULT"))
     return; // nothing to do
 
-  path = URIUtils::AddFileToFolder(g_SkinInfo->Path(), "colors", colorFile);
+  path = URIUtils::AddFileToFolder(skin->Path(), "colors", colorFile);
   if (!URIUtils::HasExtension(path))
     path += ".xml";
   CLog::Log(LOGINFO, "Loading colors from {}", path);

--- a/xbmc/guilib/GUIComponent.cpp
+++ b/xbmc/guilib/GUIComponent.cpp
@@ -60,6 +60,9 @@ void CGUIComponent::Deinit()
 
   if (m_pWindowManager)
     m_pWindowManager->DeInitialize();
+
+  // Now safe to release skin - all windows deinitialized
+  m_skinInfo.reset();
 }
 
 CGUIWindowManager& CGUIComponent::GetWindowManager()
@@ -100,6 +103,21 @@ CGUIColorManager &CGUIComponent::GetColorManager()
 CGUIAudioManager &CGUIComponent::GetAudioManager()
 {
   return *m_guiAudioManager;
+}
+
+std::shared_ptr<ADDON::CSkinInfo> CGUIComponent::GetSkinInfo()
+{
+  return m_skinInfo;
+}
+
+void CGUIComponent::SetSkinInfo(std::shared_ptr<ADDON::CSkinInfo> skin)
+{
+  m_skinInfo = std::move(skin);
+}
+
+void CGUIComponent::UnloadSkin()
+{
+  m_skinInfo.reset();
 }
 
 bool CGUIComponent::ConfirmDelete(const std::string& path)

--- a/xbmc/guilib/GUIComponent.h
+++ b/xbmc/guilib/GUIComponent.h
@@ -21,6 +21,11 @@ class CGUIColorManager;
 class CGUIAudioManager;
 class CGUIAnnouncementHandlerContainer;
 
+namespace ADDON
+{
+class CSkinInfo;
+}
+
 class CGUIComponent
 {
 public:
@@ -39,6 +44,10 @@ public:
   CGUIColorManager &GetColorManager();
   CGUIAudioManager &GetAudioManager();
 
+  void SetSkinInfo(std::shared_ptr<ADDON::CSkinInfo> skin);
+  std::shared_ptr<ADDON::CSkinInfo> GetSkinInfo();
+  void UnloadSkin();
+
   bool ConfirmDelete(const std::string& path);
 
 protected:
@@ -52,4 +61,5 @@ protected:
   std::unique_ptr<CGUIColorManager> m_guiColorManager;
   std::unique_ptr<CGUIAudioManager> m_guiAudioManager;
   std::unique_ptr<CGUIAnnouncementHandlerContainer> m_announcementHandlerContainer;
+  std::shared_ptr<ADDON::CSkinInfo> m_skinInfo;
 };

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -422,7 +422,9 @@ bool GUIFontManager::LoadFontsFromFile(const std::string& fontsetFilePath,
   if (LoadXMLData(fontsetFilePath, xmlDoc))
   {
     TiXmlElement* rootElement = xmlDoc.RootElement();
-    g_SkinInfo->ResolveIncludes(rootElement);
+    auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+    if (skin)
+      skin->ResolveIncludes(rootElement);
     const TiXmlElement* fontsetElement = rootElement->FirstChildElement("fontset");
     while (fontsetElement)
     {
@@ -450,9 +452,13 @@ bool GUIFontManager::LoadFontsFromFile(const std::string& fontsetFilePath,
 
 void GUIFontManager::LoadFonts(const std::string& fontSet)
 {
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return;
+
   std::string firstFontset;
   // Try to load the fontset from Font.xml
-  const std::string fontsetFilePath = g_SkinInfo->GetSkinPath("Font.xml", &m_skinResolution);
+  const std::string fontsetFilePath = skin->GetSkinPath("Font.xml", &m_skinResolution);
   if (LoadFontsFromFile(fontsetFilePath, fontSet, firstFontset))
     return;
 

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -214,7 +214,8 @@ void CGUIIncludes::LoadIncludes(const TiXmlElement *node)
     }
     else if (child->Attribute("file"))
     {
-      std::string file = g_SkinInfo->GetSkinPath(child->Attribute("file"));
+      auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+      std::string file = skin ? skin->GetSkinPath(child->Attribute("file")) : "";
       const char *condition = child->Attribute("condition");
 
       if (condition)
@@ -419,7 +420,9 @@ void CGUIIncludes::ResolveIncludes(TiXmlElement *node, std::map<INFO::InfoPtr, b
       }
       else
       {
-        Load(g_SkinInfo->GetSkinPath(file));
+        auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+        if (skin)
+          Load(skin->GetSkinPath(file));
       }
     }
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -70,7 +70,8 @@ CGUIWindow::~CGUIWindow()
 
 bool CGUIWindow::Load(const std::string& strFileName, bool bContainsPath)
 {
-  if (m_windowLoaded || !g_SkinInfo)
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (m_windowLoaded || !skin)
     return true;      // no point loading if it's already there
 
 #ifdef _DEBUG
@@ -103,8 +104,8 @@ bool CGUIWindow::Load(const std::string& strFileName, bool bContainsPath)
     // FIXME: strLowerPath needs to eventually go since resToUse can get incorrectly overridden
     std::string strFileNameLower = strFileName;
     StringUtils::ToLower(strFileNameLower);
-    strLowerPath =  g_SkinInfo->GetSkinPath(strFileNameLower, &m_coordsRes);
-    strPath = g_SkinInfo->GetSkinPath(strFileName, &m_coordsRes);
+    strLowerPath = skin->GetSkinPath(strFileNameLower, &m_coordsRes);
+    strPath = skin->GetSkinPath(strFileName, &m_coordsRes);
   }
 
   bool ret = LoadXML(strPath, strLowerPath);
@@ -166,7 +167,9 @@ std::unique_ptr<TiXmlElement> CGUIWindow::Prepare(const std::unique_ptr<TiXmlEle
 
   // Resolve any includes, constants, expressions that may be present
   // and save include's conditions to the given map
-  g_SkinInfo->ResolveIncludes(preparedRoot.get(), &m_xmlIncludeConditions);
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (skin)
+    skin->ResolveIncludes(preparedRoot.get(), &m_xmlIncludeConditions);
 
   return preparedRoot;
 }

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -829,7 +829,9 @@ void CGUIWindowManager::ActivateWindow_Internal(int iWindowID, const std::vector
   // translate virtual windows
   if (iWindowID == WINDOW_START)
   { // virtual start window
-    iWindowID = g_SkinInfo->GetStartWindow();
+    auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+    if (skin)
+      iWindowID = skin->GetStartWindow();
   }
 
   // debug

--- a/xbmc/guilib/VisibleEffect.cpp
+++ b/xbmc/guilib/VisibleEffect.cpp
@@ -30,9 +30,13 @@ CAnimEffect::CAnimEffect(const TiXmlElement *node, EFFECT_TYPE effect)
   m_pTweener.reset();
   // time and delay
 
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  float slowdown = skin ? skin->GetEffectsSlowdown() : 1.0f;
   float temp;
-  if (TIXML_SUCCESS == node->QueryFloatAttribute("time", &temp)) m_length = (unsigned int)(temp * g_SkinInfo->GetEffectsSlowdown());
-  if (TIXML_SUCCESS == node->QueryFloatAttribute("delay", &temp)) m_delay = (unsigned int)(temp * g_SkinInfo->GetEffectsSlowdown());
+  if (TIXML_SUCCESS == node->QueryFloatAttribute("time", &temp))
+    m_length = (unsigned int)(temp * slowdown);
+  if (TIXML_SUCCESS == node->QueryFloatAttribute("delay", &temp))
+    m_delay = (unsigned int)(temp * slowdown);
 
   m_pTweener = GetTweener(node);
 }

--- a/xbmc/guilib/guiinfo/GUIInfoColor.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoColor.cpp
@@ -56,7 +56,11 @@ void CGUIInfoColor::Parse(const std::string& label, int context)
     label2 = label.substr(5, label.length() - 6);
     m_info = infoMgr.TranslateSkinVariableString(label2, context);
     if (!m_info)
-      m_info = infoMgr.RegisterSkinVariableString(g_SkinInfo->CreateSkinVariable(label2, context));
+    {
+      auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+      if (skin)
+        m_info = infoMgr.RegisterSkinVariableString(skin->CreateSkinVariable(label2, context));
+    }
     return;
   }
 

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
@@ -365,8 +365,12 @@ void CGUIInfoLabel::Parse(const std::string& label,
           {
             info = infoMgr.TranslateSkinVariableString(params[0], context);
             if (info == 0)
-              info = infoMgr.RegisterSkinVariableString(
-                  g_SkinInfo->CreateSkinVariable(params[0], context));
+            {
+              auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+              if (skin)
+                info = infoMgr.RegisterSkinVariableString(
+                    skin->CreateSkinVariable(params[0], context));
+            }
             if (info == 0) // skinner didn't define this conditional label!
               CLog::Log(LOGWARNING, "Label Formatting: $VAR[{}] is not defined", params[0]);
           }

--- a/xbmc/guilib/guiinfo/SkinGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SkinGUIInfo.cpp
@@ -10,6 +10,7 @@
 
 #include "ServiceBroker.h"
 #include "addons/Skin.h"
+#include "guilib/GUIComponent.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
@@ -66,9 +67,10 @@ bool CSkinGUIInfo::GetLabel(std::string& value,
     }
     case SKIN_ASPECT_RATIO:
     {
-      if (g_SkinInfo)
+      auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+      if (skin)
       {
-        value = g_SkinInfo->GetCurrentAspect();
+        value = skin->GetCurrentAspect();
         return true;
       }
       break;
@@ -81,7 +83,8 @@ bool CSkinGUIInfo::GetLabel(std::string& value,
     }
     case SKIN_TIMER_ELAPSEDSECS:
     {
-      value = std::to_string(g_SkinInfo->GetTimerElapsedSeconds(info.GetData3()));
+      auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+      value = std::to_string(skin ? skin->GetTimerElapsedSeconds(info.GetData3()) : 0.0f);
       return true;
     }
     default:
@@ -105,7 +108,8 @@ bool CSkinGUIInfo::GetInt(int& value,
     }
     case SKIN_TIMER_ELAPSEDSECS:
     {
-      value = g_SkinInfo->GetTimerElapsedSeconds(info.GetData3());
+      auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+      value = skin ? skin->GetTimerElapsedSeconds(info.GetData3()) : 0;
       return true;
     }
     default:
@@ -150,7 +154,8 @@ bool CSkinGUIInfo::GetBool(bool& value,
     }
     case SKIN_TIMER_IS_RUNNING:
     {
-      value = g_SkinInfo->TimerIsRunning(info.GetData3());
+      auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+      value = skin ? skin->TimerIsRunning(info.GetData3()) : false;
       return true;
     }
     default:

--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -461,7 +461,9 @@ static int SkinResetAll(const std::vector<std::string>& params)
  */
 static int SkinDebug(const std::vector<std::string>& params)
 {
-  g_SkinInfo->ToggleDebug();
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (skin)
+    skin->ToggleDebug();
 
   return 0;
 }
@@ -478,7 +480,9 @@ static int SkinTimerStart(const std::vector<std::string>& params)
     return -1;
   }
 
-  g_SkinInfo->TimerStart(params[0]);
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (skin)
+    skin->TimerStart(params[0]);
   return 0;
 }
 
@@ -494,7 +498,9 @@ static int SkinTimerStop(const std::vector<std::string>& params)
     return -1;
   }
 
-  g_SkinInfo->TimerStop(params[0]);
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (skin)
+    skin->TimerStop(params[0]);
   return 0;
 }
 

--- a/xbmc/interfaces/legacy/AddonUtils.cpp
+++ b/xbmc/interfaces/legacy/AddonUtils.cpp
@@ -11,6 +11,7 @@
 #include "LanguageHook.h"
 #include "addons/Skin.h"
 #include "application/Application.h"
+#include "guilib/GUIComponent.h"
 #include "utils/XBMCTinyXML.h"
 #ifdef ENABLE_XBMC_TRACE_API
 #include "utils/log.h"
@@ -51,7 +52,9 @@ namespace XBMCAddonUtils
     control.SetAttribute("type", cControlType);
     TiXmlElement filler("description");
     control.InsertEndChild(filler);
-    g_SkinInfo->ResolveIncludes(&control);
+    auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+    if (skin)
+      skin->ResolveIncludes(&control);
 
     // ok, now check for our texture type
     TiXmlElement *pTexture = control.FirstChildElement(cTextureType);

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -99,8 +99,12 @@ namespace XBMCAddon
       Window(true)
     {
       XBMC_TRACE;
+      auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+      if (!skin)
+        return;
+
       RESOLUTION_INFO res;
-      std::string strSkinPath = g_SkinInfo->GetSkinPath(xmlFilename, &res);
+      std::string strSkinPath = skin->GetSkinPath(xmlFilename, &res);
       m_isMedia = isMedia;
 
       if (!CFileUtils::Exists(strSkinPath))
@@ -112,9 +116,9 @@ namespace XBMCAddon
 
         // Check for the matching folder for the skin in the fallback skins folder
         std::string fallbackPath = URIUtils::AddFileToFolder(scriptPath, "resources", "skins");
-        std::string basePath = URIUtils::AddFileToFolder(fallbackPath, g_SkinInfo->ID());
+        std::string basePath = URIUtils::AddFileToFolder(fallbackPath, skin->ID());
 
-        strSkinPath = g_SkinInfo->GetSkinPath(xmlFilename, &res, basePath);
+        strSkinPath = skin->GetSkinPath(xmlFilename, &res, basePath);
 
         // Check for the matching folder for the skin in the fallback skins folder (if it exists)
         if (CFileUtils::Exists(basePath))

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -199,7 +199,8 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
   }
 
   m_initialising = true;
-  bool usePopup = g_SkinInfo->HasSkinFile("DialogSlider.xml");
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  const bool usePopup = skin && skin->HasSkinFile("DialogSlider.xml");
 
   PeripheralPtr peripheral = CServiceBroker::GetPeripherals().GetByPath(m_item->GetPath());
   if (!peripheral)

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -299,8 +299,9 @@ bool CProfileManager::LoadProfile(unsigned int index)
 
   // save any settings of the currently used skin but only if the (master)
   // profile hasn't just been loaded as a temporary profile for login
-  if (g_SkinInfo != nullptr && !m_previousProfileLoadedForLogin)
-    g_SkinInfo->SaveSettings();
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (skin && !m_previousProfileLoadedForLogin)
+    skin->SaveSettings();
 
   // @todo: why is m_settings not used here?
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
@@ -425,7 +426,8 @@ void CProfileManager::FinalizeLoadProfile()
   stereoscopicsManager.Initialize();
 
   // Load initial window
-  int firstWindow = g_SkinInfo->GetFirstWindow();
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  int firstWindow = skin ? skin->GetFirstWindow() : WINDOW_HOME;
 
   CServiceBroker::GetGUI()->GetWindowManager().ChangeActiveWindow(firstWindow);
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -704,7 +704,8 @@ bool CGUIWindowPVRGuideBase::OnContextButtonNavigate(CONTEXT_BUTTON button)
 
   if (button == CONTEXT_BUTTON_NAVIGATE)
   {
-    if (g_SkinInfo->HasSkinFile("DialogPVRGuideControls.xml"))
+    auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+    if (skin && skin->HasSkinFile("DialogPVRGuideControls.xml"))
     {
       // use controls dialog
       CGUIDialog* dialog =

--- a/xbmc/settings/SkinSettings.cpp
+++ b/xbmc/settings/SkinSettings.cpp
@@ -42,63 +42,101 @@ CSkinSettings& CSkinSettings::GetInstance()
 
 int CSkinSettings::TranslateString(const std::string& setting) const
 {
-  return g_SkinInfo->TranslateString(setting);
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return -1;
+  return skin->TranslateString(setting);
 }
 
 const std::string& CSkinSettings::GetString(int setting) const
 {
-  return g_SkinInfo->GetString(setting);
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  static const std::string empty;
+  if (!skin)
+    return empty;
+  return skin->GetString(setting);
 }
 
 void CSkinSettings::SetString(int setting, const std::string& label) const
 {
-  g_SkinInfo->SetString(setting, label);
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return;
+  skin->SetString(setting, label);
 }
 
 int CSkinSettings::TranslateBool(const std::string& setting) const
 {
-  return g_SkinInfo->TranslateBool(setting);
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return -1;
+  return skin->TranslateBool(setting);
 }
 
 bool CSkinSettings::GetBool(int setting) const
 {
-  return g_SkinInfo->GetBool(setting);
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return false;
+  return skin->GetBool(setting);
 }
 
 int CSkinSettings::GetInt(int setting) const
 {
-  return g_SkinInfo->GetInt(setting);
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return 0;
+  return skin->GetInt(setting);
 }
 
 void CSkinSettings::SetBool(int setting, bool set) const
 {
-  g_SkinInfo->SetBool(setting, set);
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return;
+  skin->SetBool(setting, set);
 }
 
 void CSkinSettings::Reset(const std::string& setting) const
 {
-  g_SkinInfo->Reset(setting);
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return;
+  skin->Reset(setting);
 }
 
 std::set<ADDON::CSkinSettingPtr> CSkinSettings::GetSettings() const
 {
-  return g_SkinInfo->GetSkinSettings();
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return {};
+  return skin->GetSkinSettings();
 }
 
 ADDON::CSkinSettingPtr CSkinSettings::GetSetting(const std::string& settingId)
 {
-  return g_SkinInfo->GetSkinSetting(settingId);
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return nullptr;
+  return skin->GetSkinSetting(settingId);
 }
 
 std::shared_ptr<const ADDON::CSkinSetting> CSkinSettings::GetSetting(
     const std::string& settingId) const
 {
-  return g_SkinInfo->GetSkinSetting(settingId);
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return nullptr;
+  return skin->GetSkinSetting(settingId);
 }
 
 void CSkinSettings::Reset() const
 {
-  g_SkinInfo->Reset();
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (!skin)
+    return;
+
+  skin->Reset();
 
   CGUIInfoManager& infoMgr = CServiceBroker::GetGUI()->GetInfoManager();
   infoMgr.ResetCache();

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -17,6 +17,7 @@
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "cores/IPlayer.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/LocalizeStrings.h"
 #include "profiles/ProfileManager.h"
@@ -226,7 +227,8 @@ void CGUIDialogAudioSettings::InitializeSettings()
     return;
   }
 
-  bool usePopup = g_SkinInfo->HasSkinFile("DialogSlider.xml");
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  const bool usePopup = skin && skin->HasSkinFile("DialogSlider.xml");
 
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();

--- a/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogCMSSettings.cpp
@@ -16,6 +16,7 @@
 #include "cores/VideoPlayer/VideoRenderers/ColorManager.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
 #include "filesystem/Directory.h"
+#include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "profiles/ProfileManager.h"
 #include "settings/Settings.h"
@@ -75,7 +76,8 @@ void CGUIDialogCMSSettings::InitializeSettings()
     return;
   }
 
-  bool usePopup = g_SkinInfo->HasSkinFile("DialogSlider.xml");
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  const bool usePopup = skin && skin->HasSkinFile("DialogSlider.xml");
 
   TranslatableIntegerSettingOptions entries;
 

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -285,7 +285,8 @@ void CGUIDialogSubtitleSettings::InitializeSettings()
     return;
   }
 
-  bool usePopup = g_SkinInfo->HasSkinFile("DialogSlider.xml");
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  const bool usePopup = skin && skin->HasSkinFile("DialogSlider.xml");
 
   const CVideoSettings videoSettings = appPlayer->GetVideoSettings();
 

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -322,7 +322,8 @@ void CGUIDialogVideoSettings::InitializeSettings()
     return;
   }
 
-  bool usePopup = g_SkinInfo->HasSkinFile("DialogSlider.xml");
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  const bool usePopup = skin && skin->HasSkinFile("DialogSlider.xml");
 
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();

--- a/xbmc/windows/GUIWindowDebugInfo.cpp
+++ b/xbmc/windows/GUIWindowDebugInfo.cpp
@@ -42,7 +42,10 @@ CGUIWindowDebugInfo::~CGUIWindowDebugInfo(void) = default;
 
 void CGUIWindowDebugInfo::UpdateVisibility()
 {
-  if (LOG_LEVEL_DEBUG_FREEMEM <= CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_logLevel || g_SkinInfo->IsDebugging())
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (LOG_LEVEL_DEBUG_FREEMEM <=
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_logLevel ||
+      (skin && skin->IsDebugging()))
     Open();
   else
     Close();
@@ -132,7 +135,8 @@ void CGUIWindowDebugInfo::Process(unsigned int currentTime, CDirtyRegionList &di
   }
 
   // render the skin debug info
-  if (g_SkinInfo->IsDebugging())
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (skin && skin->IsDebugging())
   {
     if (!info.empty())
       info += "\n";


### PR DESCRIPTION
## Description
This PR kills `g_SkinInfo` which the order of initialization/destruction can't be controlled and moves it to the GUI component. This goes in line with similar PRs. Also has the benefit of requiring to include `GUIComponent` so it's easier to see which components depend on what (can't simply check for `g_SkinInfo` which would rather get unnoticed). Dependency injection would be a next step but for now keep this simple.

## Motivation and context
Decouple components, being able to build Kodi without GUI someday.

## How has this been tested?
Runtime tested, load skin, unload skin, reload skin, change skin, etc.

## What is the effect on users?
None, internal refactoring

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
