### PR TITLE
[LocalizeStrings] Remove unused g_localizeStringsTemp

### DIFF
--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -25,8 +25,7 @@ std::map<std::string, std::string> CSpecialProtocol::m_pathMap;
 #include "filesystem/ZipManager.h"
 
   CLangCodeExpander  g_LangCodeExpander;
-  CLocalizeStrings   g_localizeStrings;
-  CLocalizeStrings   g_localizeStringsTemp;
+  CLocalizeStrings g_localizeStrings;
 
   XFILE::CDirectoryCache g_directoryCache;
 

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -68,5 +68,3 @@ protected:
  \brief
  */
 extern CLocalizeStrings g_localizeStrings;
-extern CLocalizeStrings g_localizeStringsTemp;
-

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
@@ -243,10 +243,7 @@ bool CGUIInfoLabel::ReplaceSpecialKeywordReferences(std::string& work,
 
 std::string LocalizeReplacer(const std::string& str)
 {
-  std::string replace = g_localizeStringsTemp.Get(atoi(str.c_str()));
-  if (replace.empty())
-    replace = g_localizeStrings.Get(atoi(str.c_str()));
-  return replace;
+  return g_localizeStrings.Get(atoi(str.c_str()));
 }
 
 std::string AddonReplacer(const std::string& str)

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -163,15 +163,7 @@ namespace XBMCAddon
     String getLocalizedString(int id)
     {
       XBMC_TRACE;
-      String label;
-      if (id >= 30000 && id <= 30999)
-        label = g_localizeStringsTemp.Get(id);
-      else if (id >= 32000 && id <= 32999)
-        label = g_localizeStringsTemp.Get(id);
-      else
-        label = g_localizeStrings.Get(id);
-
-      return label;
+      return g_localizeStrings.Get(id);
     }
 
     String getSkinDir()


### PR DESCRIPTION
## Description
This removes `g_localizeStringsTemp` which is dead code by now. Looking at the code it seems that at some point in the past addons (plugins and scripts just loaded strings into the main `m_strings` of `g_localizeStrings` (hence the copy/temp). Addon now load strings into their own maps:

`xbmcaddon.getLocalizedString` (gets a string in the scope of an addon - https://xbmc.github.io/docs.kodi.tv/master/kodi-base/dd/dae/group__python__xbmcaddon.html#ga0e535d57695a07ed11d3b6355f3e480f)
`xbmc.getLocalizedString` (gets a core string - https://xbmc.github.io/docs.kodi.tv/master/kodi-base/d6/db2/group__python__xbmc.html#ga82834997987f068af982d91feb40bf9f)

## Motivation and context
It's simply dead code, we keep a copy of strings in memory for no reason. Most likely a leftover from a previous implementation (pre-frodo)

## How has this been tested?
Runtime tested with addons

## What is the effect on users?
None
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

