### PR TITLE
[guilib] GUIScrollBarControl Fix SetInvalid()

### DIFF
--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -228,7 +228,7 @@ void GUIScrollBarControl::SetInvalid()
 {
   CGUIControl::SetInvalid();
   m_guiBackground->SetInvalid();
-  m_guiBarFocus->SetInvalid();
+  m_guiBarNoFocus->SetInvalid();
   m_guiBarFocus->SetInvalid();
   m_guiNibNoFocus->SetInvalid();
   m_guiNibFocus->SetInvalid();


### PR DESCRIPTION
## Description
Fix SetInvalid() bug where m_guiBarNoFocus was never invalidated (m_guiBarFocus was incorrectly called twice)

## Motivation and context
Squashing those creepy-crawlies!

## How has this been tested?
Windows x64, CoreELEC (Ugoos AM6B+)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
