### PR TITLE
[LocalizedStrings] Remove special handling for skins

### DIFF
--- a/xbmc/addons/Skin.h
+++ b/xbmc/addons/Skin.h
@@ -28,6 +28,15 @@ struct StringSettingOption;
 namespace ADDON
 {
 
+// Skin string ID range constants
+inline constexpr uint32_t SKIN_STRING_RANGE_START = 31000;
+inline constexpr uint32_t SKIN_STRING_RANGE_END = 31999;
+
+constexpr bool IsSkinStringId(uint32_t id) noexcept
+{
+  return id >= SKIN_STRING_RANGE_START && id <= SKIN_STRING_RANGE_END;
+}
+
 class CSkinSettingUpdateHandler;
 
 class CSkinSetting

--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -141,12 +141,11 @@ bool CApplicationSkinHandling::LoadSkin(const std::string& skinID)
 
   g_fontManager.LoadFonts(settings->GetString(CSettings::SETTING_LOOKANDFEEL_FONT));
 
-  // load in the skin strings
-  std::string langPath = URIUtils::AddFileToFolder(skin->Path(), "language");
-  URIUtils::AddSlashAtEnd(langPath);
-
-  g_localizeStrings.LoadSkinStrings(langPath,
-                                    settings->GetString(CSettings::SETTING_LOCALE_LANGUAGE));
+  // load the skin strings in
+  //! @todo Move skin language files to resources/language/ to match other addon structure
+  const std::string langPath = URIUtils::AddFileToFolder(skin->Path(), "language/");
+  g_localizeStrings.LoadAddonStrings(
+      langPath, settings->GetString(CSettings::SETTING_LOCALE_LANGUAGE), skin->ID());
   skin->LoadTimers();
 
   const auto start = std::chrono::steady_clock::now();
@@ -231,7 +230,10 @@ void CApplicationSkinHandling::UnloadSkin()
     m_saveSkinOnUnloading = true;
 
   if (skin)
+  {
     skin->Unload();
+    g_localizeStrings.ClearAddonStrings(skin->ID());
+  }
 
   CGUIComponent* gui = CServiceBroker::GetGUI();
   if (gui)

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -647,6 +647,20 @@ void CGUIControlFactory::GetInfoLabel(const TiXmlNode* pControlNode,
     infoLabel = labels[0];
 }
 
+namespace
+{
+std::string GetLocalizedString(uint32_t id)
+{
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (skin && ADDON::IsSkinStringId(id))
+  {
+    return g_localizeStrings.GetAddonString(skin->ID(), id);
+  }
+
+  return g_localizeStrings.Get(id);
+}
+} // namespace
+
 bool CGUIControlFactory::GetInfoLabelFromElement(const TiXmlElement* element,
                                                  GUIINFO::CGUIInfoLabel& infoLabel,
                                                  int parentID)
@@ -660,9 +674,10 @@ bool CGUIControlFactory::GetInfoLabelFromElement(const TiXmlElement* element,
 
   std::string fallback = XMLUtils::GetAttribute(element, "fallback");
   if (StringUtils::IsNaturalNumber(label))
-    label = g_localizeStrings.Get(atoi(label.c_str()));
+    label = GetLocalizedString(std::atoi(label.c_str()));
+
   if (StringUtils::IsNaturalNumber(fallback))
-    fallback = g_localizeStrings.Get(atoi(fallback.c_str()));
+    fallback = GetLocalizedString(std::atoi(fallback.c_str()));
   else
     g_charsetConverter.unknownToUTF8(fallback);
   infoLabel.SetLabel(label, fallback, parentID);

--- a/xbmc/guilib/LocalizeStrings.cpp
+++ b/xbmc/guilib/LocalizeStrings.cpp
@@ -30,8 +30,11 @@
  \param bSourceLanguage If we are loading the source English strings.po.
  \return false if no strings.po file was loaded.
  */
-static bool LoadPO(const std::string &filename, std::map<uint32_t, LocStr>& strings,
-    std::string &encoding, uint32_t offset = 0 , bool bSourceLanguage = false)
+static bool LoadPO(const std::string& filename,
+                   std::unordered_map<uint32_t, LocStr>& strings,
+                   std::string& encoding,
+                   uint32_t offset = 0,
+                   bool bSourceLanguage = false)
 {
   CPODocument PODoc;
   if (!PODoc.LoadFile(filename))
@@ -95,8 +98,11 @@ static bool LoadPO(const std::string &filename, std::map<uint32_t, LocStr>& stri
  \param offset An offset value to place strings from the id value.
  \return false if no strings.po file was loaded.
  */
-static bool LoadStr2Mem(const std::string &pathname_in, const std::string &language,
-    std::map<uint32_t, LocStr>& strings,  std::string &encoding, uint32_t offset = 0 )
+static bool LoadStr2Mem(const std::string& pathname_in,
+                        const std::string& language,
+                        std::unordered_map<uint32_t, LocStr>& strings,
+                        std::string& encoding,
+                        uint32_t offset = 0)
 {
   std::string pathname = CSpecialProtocol::TranslatePathConvertCase(pathname_in + language);
   if (!XFILE::CDirectory::Exists(pathname))
@@ -119,7 +125,9 @@ static bool LoadStr2Mem(const std::string &pathname_in, const std::string &langu
   return LoadPO(URIUtils::AddFileToFolder(pathname, "strings.po"), strings, encoding, offset, useSourceLang);
 }
 
-static bool LoadWithFallback(const std::string& path, const std::string& language, std::map<uint32_t, LocStr>& strings)
+static bool LoadWithFallback(const std::string& path,
+                             const std::string& language,
+                             std::unordered_map<uint32_t, LocStr>& strings)
 {
   std::string encoding;
   if (!LoadStr2Mem(path, language, strings, encoding))
@@ -141,7 +149,7 @@ CLocalizeStrings::~CLocalizeStrings(void) = default;
 
 bool CLocalizeStrings::Load(const std::string& strPathName, const std::string& strLanguage)
 {
-  std::map<uint32_t, LocStr> strings;
+  std::unordered_map<uint32_t, LocStr> strings;
   if (!LoadWithFallback(strPathName, strLanguage, strings))
     return false;
 
@@ -194,7 +202,7 @@ void CLocalizeStrings::Clear()
 
 bool CLocalizeStrings::LoadAddonStrings(const std::string& path, const std::string& language, const std::string& addonId)
 {
-  std::map<uint32_t, LocStr> strings;
+  std::unordered_map<uint32_t, LocStr> strings;
   if (!LoadWithFallback(path, language, strings))
     return false;
 

--- a/xbmc/guilib/LocalizeStrings.cpp
+++ b/xbmc/guilib/LocalizeStrings.cpp
@@ -204,7 +204,7 @@ bool CLocalizeStrings::LoadAddonStrings(const std::string& path, const std::stri
   return m_addonStrings.insert_or_assign(addonId, std::move(strings)).second;
 }
 
-std::string CLocalizeStrings::GetAddonString(const std::string& addonId, uint32_t code) const
+const std::string& CLocalizeStrings::GetAddonString(const std::string& addonId, uint32_t code) const
 {
   std::shared_lock<CSharedSection> lock(m_addonStringsMutex);
   auto i = m_addonStrings.find(addonId);

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -16,9 +16,9 @@
 #include "threads/SharedSection.h"
 #include "utils/ILocalizer.h"
 
-#include <map>
 #include <stdint.h>
 #include <string>
+#include <unordered_map>
 
 /*!
  \ingroup strings
@@ -61,10 +61,10 @@ public:
   std::string Localize(std::uint32_t code) const override { return Get(code); }
 
 protected:
-  std::map<uint32_t, LocStr> m_strings;
-  std::map<std::string, std::map<uint32_t, LocStr>> m_addonStrings;
-  typedef std::map<uint32_t, LocStr>::const_iterator ciStrings;
-  typedef std::map<uint32_t, LocStr>::iterator       iStrings;
+  std::unordered_map<uint32_t, LocStr> m_strings;
+  std::unordered_map<std::string, std::unordered_map<uint32_t, LocStr>> m_addonStrings;
+  typedef std::unordered_map<uint32_t, LocStr>::const_iterator ciStrings;
+  typedef std::unordered_map<uint32_t, LocStr>::iterator iStrings;
 
   mutable CSharedSection m_stringsMutex;
   mutable CSharedSection m_addonStringsMutex;

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -41,26 +41,33 @@ public:
   CLocalizeStrings(void);
   ~CLocalizeStrings(void) override;
   bool Load(const std::string& strPathName, const std::string& strLanguage);
-  bool LoadSkinStrings(const std::string& path, const std::string& language);
-  bool LoadAddonStrings(const std::string& path, const std::string& language, const std::string& addonId);
-  void ClearSkinStrings();
+  bool LoadAddonStrings(const std::string& path,
+                        const std::string& language,
+                        const std::string& addonId);
   const std::string& Get(uint32_t code) const;
-  std::string GetAddonString(const std::string& addonId, uint32_t code);
+  std::string GetAddonString(const std::string& addonId, uint32_t code) const;
+
+  /*! \brief Clear all strings for a specific addon
+   *  \param addonId the addon ID whose strings should be cleared
+   *  \note Currently only skins call this on unload. Other addons don't cleanup strings on
+   *        uninstall/deactivate, which should be addressed in a future PR.
+   *  \todo Extend addon lifecycle to call ClearAddonStrings when any addon is uninstalled or disabled
+   */
+  void ClearAddonStrings(const std::string& addonId);
+
   void Clear();
 
   // implementation of ILocalizer
   std::string Localize(std::uint32_t code) const override { return Get(code); }
 
 protected:
-  void Clear(uint32_t start, uint32_t end);
-
   std::map<uint32_t, LocStr> m_strings;
   std::map<std::string, std::map<uint32_t, LocStr>> m_addonStrings;
   typedef std::map<uint32_t, LocStr>::const_iterator ciStrings;
   typedef std::map<uint32_t, LocStr>::iterator       iStrings;
 
   mutable CSharedSection m_stringsMutex;
-  CSharedSection m_addonStringsMutex;
+  mutable CSharedSection m_addonStringsMutex;
 };
 
 /*!

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -45,7 +45,7 @@ public:
                         const std::string& language,
                         const std::string& addonId);
   const std::string& Get(uint32_t code) const;
-  std::string GetAddonString(const std::string& addonId, uint32_t code) const;
+  const std::string& GetAddonString(const std::string& addonId, uint32_t code) const;
 
   /*! \brief Clear all strings for a specific addon
    *  \param addonId the addon ID whose strings should be cleared

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
@@ -243,7 +243,14 @@ bool CGUIInfoLabel::ReplaceSpecialKeywordReferences(std::string& work,
 
 std::string LocalizeReplacer(const std::string& str)
 {
-  return g_localizeStrings.Get(atoi(str.c_str()));
+  const uint32_t id = std::atoi(str.c_str());
+  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  if (skin && ADDON::IsSkinStringId(id))
+  {
+    return g_localizeStrings.GetAddonString(skin->ID(), id);
+  }
+
+  return g_localizeStrings.Get(id);
 }
 
 std::string AddonReplacer(const std::string& str)


### PR DESCRIPTION
## Description
I am planing to kill `g_localizeStrings` and move it out of guilib (likely to a ResourcesComponent). `CLocalizeStrings` doesn't really depend on GUI at the moment but still has special handling for skin strings. Historically, Skin strings are loaded into the main string map along with the core strings - even though special ranges are required for skins.
However, skins are just another type of addons and `CLocalizeStrings` already holds addon strings in a proper map. So this PR removes the special handling of skin strings making it behave just like any other addon.
Skin strings were loaded into the main strings map so that `$LOCALIZE` or simply `<element>INT</element>` would work for both skin strings and core strings. This PR keeps the existing behaviour by adding the range check in `GetInfoLabelFromElement` and `LocalizeReplacer` (the handler for $LOCALIZE). Regardless I think skins should probably use `$ADDON[addon.id INT]` instead of localize to make it clear they are trying to display an addon string.

While working on this PR I also found a couple of issues/minors (not in the scope of this PR):
- Skins don't use the same language folder layout that other addons use (`language/` instead of `resources\language`. Do we want to add support to the later and move estuary while keep support for the former with a warning to allow proper migration of other skins?
- Addons when uninstalled/disabled never remove strings from the addon map, skins are the first addons to do it...
- The LOCALIZE vs ADDON can probably be enforced but unsure if it's too much work for skinners for no reason. Let's keep the fallback working for now.

## Motivation and context
Decouple GUI from other components, `LocalizeStrings` are a global/common string registry and skins are regular addons.

## How has this been tested?
Runtime tested, checked skin strings.
Also changed skins, reloaded skins, etc.

## What is the effect on users?
None, internal refactoring

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
