### PR TITLE
[Stacks] Fix playback of a regular stack does not automatically advance to the next item in the stack.

### DIFF
--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -313,6 +313,11 @@ void UpdateStackAndItem(const CFileItem& file,
   }
   else
   {
+    constexpr double FINISH_THRESHOLD{1.0}; // 1 second from end is considered finished
+    const bool currentPartFinished{bookmark.timeInSeconds + FINISH_THRESHOLD >
+                                   bookmark.totalTimeInSeconds};
+    stackHelper->SetCurrentPartFinished(currentPartFinished);
+
     ConvertRelativeStackTimesToAbsolute(bookmark, file, stackHelper);
   }
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

stackHelper->SetCurrentPartFinished() was not getting called for regular (non-disc) stacks so playback ended at the end of the current part.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #27699 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally
Confirmed by bug reporter - thanks.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
