### PR TITLE
[Subtitles] Fix WebVTT subtitles that make use of persistent overlay not shown after seek.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlay.h
@@ -59,7 +59,8 @@ public:
     constexpr double epsilon{0.1};
     return std::abs(iPTSStartTime - other.iPTSStartTime) < epsilon &&
            std::abs(iPTSStopTime - other.iPTSStopTime) < epsilon && bForced == other.bForced &&
-           replace == other.replace;
+           replace == other.replace &&
+           m_overlayContainerFlushable == other.m_overlayContainerFlushable;
   }
 
   bool IsOverlayType(DVDOverlayType type) const { return (m_type == type); }

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
@@ -46,6 +46,7 @@ std::shared_ptr<CDVDOverlayGroup> InitialiseNewOverlayGroup(std::shared_ptr<CDVD
   group->iPTSStopTime = overlay->iPTSStopTime;
   group->bForced = overlay->bForced;
   group->replace = overlay->replace;
+  group->SetOverlayContainerFlushable(overlay->IsOverlayContainerFlushable());
   group->m_overlays.emplace_back(overlay);
   return group;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The flushable state was not being properly set and was assumed to be true.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #27700.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
