### PR TITLE
VideoPlayer: Increase correction trigger threshold to 1000ms

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2469,7 +2469,7 @@ bool CVideoPlayer::CheckContinuity(CCurrentStream& current, DemuxPacket* pPacket
   }
 
   /* if it's large scale jump, correct for it after having confirmed the jump */
-  if(pPacket->dts + DVD_MSEC_TO_TIME(500) < current.dts_end())
+  if (pPacket->dts + DVD_MSEC_TO_TIME(1000) < current.dts_end())
   {
     CLog::Log(
         LOGDEBUG,

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4210,10 +4210,6 @@ void CVideoPlayer::FlushBuffers(double pts, bool accurate, bool sync)
     m_CurrentSubtitle.inited = false;
     m_CurrentTeletext.inited = false;
     m_CurrentRadioRDS.inited  = false;
-
-    // Reset offset_pts to prevent accumulation of timestamp corrections across seeks
-    // This fixes desync issues with external subtitles after multiple seeks (issue #26647)
-    m_offset_pts = 0.0;
   }
 
   m_CurrentAudio.dts         = DVD_NOPTS_VALUE;


### PR DESCRIPTION
## Description
As per pull request title, increases correction threshold to 1s.

## Motivation and context
This aims to fix #26647 increasing the threshold to trigger jump correction from 500ms to 1000ms to avoid needlessly correcting timestamps for all videos having the first keyframe between 500ms and 1000ms.

I also reverted 39e9da724491061312294c4d5a6f3b5e7d756678 in a separate commit since it was not needed for the fix to work and was originally targeted at this issue. Since it is a separate commit it should be easy to remove if considered good or necessary anyway to have the offset reset on buffer sync, since it does not produces relevant changes in this fix.

A full and more detailed explanation can be found in my comment here https://github.com/xbmc/xbmc/issues/26647#issuecomment-3770345490 .

## How has this been tested?
Tested with sample provided in the original issue #26647 and many other videos with first keyframes in both 0-500ms and 500-1000ms ranges. The sample has been reuploaded [here](https://drive.google.com/drive/folders/1Rcf73AbpQMWX9xfu8I4P1XIiZn-fQhEQ?usp=sharing)

## What is the effect on users?
Solves #26647 and both seekbar and external subtitles start and stay in sync on playback and seeks.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed