### PR TITLE
[WASAPI] Improve Drain() - Allow write pending frames in m_buffer

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
@@ -42,6 +42,7 @@ private:
     bool InitializeExclusive(AEAudioFormat &format);
     static void BuildWaveFormatExtensibleIEC61397(AEAudioFormat& format,
                                                   WAVEFORMATEXTENSIBLE_IEC61937& wfxex);
+    void WriteLastBuffer();
 
     HANDLE m_needDataEvent{0};
     IAEWASAPIDevice* m_pDevice{nullptr};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
[WASAPI] Improve Drain() - Allow write pending frames in `m_buffer`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Complete implementation of `Drain()` taking into account what is missing in https://github.com/xbmc/xbmc/pull/27719:

> future: Drain still discards the data queued in m_buffer but it should be played. I haven't found an elegant way yet to get it played before shutting down the output without much code duplication.

Based on Microsoft sample code where Sleep() time is constant:

```c++
 // Wait for last data in buffer to play before stopping.
 Sleep((DWORD)(hnsActualDuration/REFTIMES_PER_MILLISEC/2));
```
https://learn.microsoft.com/en-us/windows/win32/coreaudio/rendering-a-stream


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested PCM and PT.
Tested pausing/resume and seek to force accumulate pending frames in `m_buffer`.
Observed clean finish playback with no audio glitch.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Prevents last pending audio frames in `m_buffer` discarded at end of playback.
Assures audio ends with silence.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
