### PR TITLE
[Skin] Check GUI in reloadskin

### DIFF
--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -387,15 +387,18 @@ bool CApplicationSkinHandling::LoadCustomWindows()
 
 void CApplicationSkinHandling::ReloadSkin(bool confirm)
 {
-  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  auto gui = CServiceBroker::GetGUI();
+  if (gui == nullptr)
+    return;
+
+  auto skin = gui->GetSkinInfo();
   if (!skin || m_bInitializing)
     return; // Don't allow reload before skin is loaded by system
 
   std::string oldSkin = skin->ID();
 
-  CGUIMessage msg(GUI_MSG_LOAD_SKIN, -1,
-                  CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow());
-  CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+  CGUIMessage msg(GUI_MSG_LOAD_SKIN, -1, gui->GetWindowManager().GetActiveWindow());
+  gui->GetWindowManager().SendMessage(msg);
 
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   std::string newSkin = settings->GetString(CSettings::SETTING_LOOKANDFEEL_SKIN);
@@ -412,7 +415,7 @@ void CApplicationSkinHandling::ReloadSkin(bool confirm)
         settings->SetString(CSettings::SETTING_LOOKANDFEEL_SKIN, oldSkin);
       }
       else
-        CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_STARTUP_ANIM);
+        gui->GetWindowManager().ActivateWindow(WINDOW_STARTUP_ANIM);
     }
   }
   else


### PR DESCRIPTION
## Description
It looks like Kodi is crashing on X11 since setfullscreen triggers ReloadSkin. Before we were checking the global skininfo, now since it belongs to gui we need to check gui first before evaluating the skin object.
Caught by @howie-f 

## Motivation and context
Fix crash caused by https://github.com/xbmc/xbmc/pull/27707

## How has this been tested?
Runtime tested, confirmed fixed by howie

## What is the effect on users?
No crashes

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)


