### PR TITLE
[MySQL/MariaDB] Fix build

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -627,7 +627,7 @@ CDatabase::ConnectionState CDatabase::Connect(const std::string& dbName,
   // set configuration regardless if any are empty
   m_pDB->setConfig(dbSettings.key.c_str(), dbSettings.cert.c_str(), dbSettings.ca.c_str(),
                    dbSettings.capath.c_str(), dbSettings.ciphers.c_str(), dbSettings.connecttimeout,
-                   dbSettings.enforceSsl, dbSettings.compression);
+                   dbSettings.compression);
 
   // create the datasets
   m_pDS.reset(m_pDB->CreateDataset());

--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -46,7 +46,6 @@ int Database::connectFull(const char* newHost,
                           const char* newCA,
                           const char* newCApath,
                           const char* newCiphers,
-                          bool newEnforceSsl,
                           bool newCompression)
 {
   host = newHost;
@@ -59,7 +58,6 @@ int Database::connectFull(const char* newHost,
   ca = newCA;
   capath = newCApath;
   ciphers = newCiphers;
-  enforceSsl = newEnforceSsl;
   compression = newCompression;
 
   return connect(true);

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -64,7 +64,6 @@ protected:
   std::string ca;
   std::string capath;
   std::string ciphers; // SSL - Encryption info
-  bool enforceSsl{false};
   unsigned int connect_timeout; // seconds
 
 public:
@@ -108,7 +107,6 @@ public:
                          const char* newCApath,
                          const char* newCiphers,
                          unsigned int newConnectTimeout,
-                         bool newEnforceSsl,
                          bool newCompression)
   {
     key = newKey;
@@ -117,7 +115,6 @@ public:
     capath = newCApath;
     ciphers = newCiphers;
     connect_timeout = newConnectTimeout;
-    enforceSsl = newEnforceSsl;
     compression = newCompression;
   }
 
@@ -139,7 +136,6 @@ public:
                           const char* newCA = nullptr,
                           const char* newCApath = nullptr,
                           const char* newCiphers = nullptr,
-                          bool newEnforceSsl = false,
                           bool newCompression = false);
   virtual void disconnect() { active = false; }
   virtual int postconnect() { return DB_COMMAND_OK; }

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -183,8 +183,6 @@ int MysqlDatabase::connect(bool create_new)
                     cert.empty() ? nullptr : cert.c_str(), ca.empty() ? nullptr : ca.c_str(),
                     capath.empty() ? nullptr : capath.c_str(),
                     ciphers.empty() ? nullptr : ciphers.c_str());
-      my_bool enforce_tls = enforceSsl;
-      mysql_options(conn, MYSQL_OPT_SSL_ENFORCE, (void*)&enforce_tls);
       mysql_options(conn, MYSQL_OPT_CONNECT_TIMEOUT, &connect_timeout);
     }
 

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -179,10 +179,13 @@ int MysqlDatabase::connect(bool create_new)
     if (!conn)
     {
       conn = mysql_init(conn);
-      mysql_ssl_set(conn, key.empty() ? nullptr : key.c_str(),
-                    cert.empty() ? nullptr : cert.c_str(), ca.empty() ? nullptr : ca.c_str(),
-                    capath.empty() ? nullptr : capath.c_str(),
-                    ciphers.empty() ? nullptr : ciphers.c_str());
+      if (!key.empty() || !cert.empty() || !ca.empty() || !capath.empty() || !ciphers.empty())
+      {
+        mysql_ssl_set(conn, key.empty() ? nullptr : key.c_str(),
+                      cert.empty() ? nullptr : cert.c_str(), ca.empty() ? nullptr : ca.c_str(),
+                      capath.empty() ? nullptr : capath.c_str(),
+                      ciphers.empty() ? nullptr : ciphers.c_str());
+      }
       mysql_options(conn, MYSQL_OPT_CONNECT_TIMEOUT, &connect_timeout);
     }
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -72,7 +72,6 @@ void ParseDatabaseSettings(const TiXmlElement* element, DatabaseSettings& settin
   XMLUtils::GetString(element, "capath", settings.capath);
   XMLUtils::GetString(element, "ciphers", settings.ciphers);
   XMLUtils::GetUInt(element, "connecttimeout", settings.connecttimeout, 1, 300);
-  XMLUtils::GetBoolean(element, "enforcessl", settings.enforceSsl);
   XMLUtils::GetBoolean(element, "compression", settings.compression);
 }
 } // unnamed namespace

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -51,7 +51,6 @@ public:
     capath.clear();
     ciphers.clear();
     connecttimeout = DEFAULT_CONNECT_TIMEOUT;
-    enforceSsl = false;
     compression = false;
   };
   std::string type;
@@ -66,7 +65,6 @@ public:
   std::string capath;
   std::string ciphers;
   unsigned int connecttimeout{DEFAULT_CONNECT_TIMEOUT};
-  bool enforceSsl{false};
   bool compression;
 };
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Partially revert #27649 in favour of a lower impact fix for the performance regression.

Call mysql_ssl_set() for new connections only when needed (ie the user provided SSL-related parameters in advanced settings).

- Unencrypted connections with MariaDB client are still fast because MYSQL_OPT_SSL_ENFORCE is not engaged when mysql_ssl_set is not called.
- Build with the MySQL client will succeed again since the parts of the MySQL API that were deprecated are not used anymore.

Removed the now useless advanced setting "enforcessl" added by the previous solution.
Will be completely removed from the Wiki since it hasn't been used in an official release.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It was reported in Slack that build was broken with the MySQL client since #27649 due to MySQL having deprecated the MYSQL_OPT_SSL_ENFORCE option and the my_bool type in the 5.8 client.

Until MariaDB and MySQL clients have compatible options again, it's best to avoid the incompatible options and fortunately I found a fix that doesn't need options and preserves the good performance of unencrypted connections.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

MariaDB client only since Windows platform, with MariaDB and MySQL servers: performance maintained for unencrypted connections.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Reverts the build breakage for Linux users with the MySQL client.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
