### PR TITLE
Addons: Clear addon strings on addon removal

### DIFF
--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -29,6 +29,7 @@
 #include "events/NotificationEvent.h"
 #include "filesystem/Directory.h"
 #include "filesystem/SpecialProtocol.h"
+#include "guilib/LocalizeStrings.h"
 #include "jobs/JobManager.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
@@ -794,6 +795,7 @@ void CAddonMgr::OnPostUnInstall(const std::string& id)
   std::unique_lock lock(m_critSection);
   m_disabled.erase(id);
   RemoveAllUpdateRulesFromList(id);
+  g_localizeStrings.ClearAddonStrings(id);
   m_events.Publish(AddonEvents::UnInstalled(id));
 }
 

--- a/xbmc/guilib/LocalizeStrings.h
+++ b/xbmc/guilib/LocalizeStrings.h
@@ -49,9 +49,6 @@ public:
 
   /*! \brief Clear all strings for a specific addon
    *  \param addonId the addon ID whose strings should be cleared
-   *  \note Currently only skins call this on unload. Other addons don't cleanup strings on
-   *        uninstall/deactivate, which should be addressed in a future PR.
-   *  \todo Extend addon lifecycle to call ClearAddonStrings when any addon is uninstalled or disabled
    */
   void ClearAddonStrings(const std::string& addonId);
 


### PR DESCRIPTION
## Description
Found while working on https://github.com/xbmc/xbmc/pull/27712. Currently when addons are uninstalled the strings of the addon are left on the LocalizedStrings map. Since the addon is no longer in use, clear them from the map when the addon is uninstalled.
Please ignore the fact LocalizedStrings is a guilib class, i plan to remove it from there shortly.

## Motivation and context
Avoid storing strings in memory for addons that are no longer in the system.

## How has this been tested?
Runtime tested while uninstalling addons.

## What is the effect on users?
Shouldn't notice any change in behaviour at all.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

