### PR TITLE
[ActiveAE] Allow configure "Low latency mode" during playback

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -326,6 +326,7 @@ protected:
   void SStopSound(CActiveAESound *sound);
   void DiscardSound(CActiveAESound *sound);
   void ChangeResamplers();
+  void ConfigureLowLatency();
 
   bool RunStages();
   bool HasWork();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
[ActiveAE] Allow configure "Low latency mode" during playback.

Fixes https://github.com/xbmc/xbmc/issues/27690

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Follow-up of https://github.com/xbmc/xbmc/pull/27701

Previous PR has the correct logic and values to fix Low latency issues with resample mode but only applied at `Configure()` time.

In some very specific cases resample mode is enabled after playback initiated and after `ActiveAE::Configure()`, then the correct buffer levels are not applied.

The fix consist on move same initialization code to a function and call it from `Configure()` AND from `CActiveAE::StateMachine`  --> `case CActiveAEControlProtocol::STREAMRESAMPLEMODE: ` , so configuration is applied also when is received the notification.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with `inputstream.adaptive` and sample stream:

```
#KODIPROP:mimetype=application/dash+xml
#KODIPROP:inputstream=inputstream.adaptive
https://livesim.dashif.org/livesim/chunkdur_1/ato_7/testpic4_8s/Manifest.mpd
```
(.strm file)

The relevant log lines are:

```
2026-01-23 16:16:17.823 T:22584   debug <inputstream.adaptive>: Open()
2026-01-23 16:16:17.825 T:15144   debug <general>: Loading settings for nfs://192.168.50.13/volume1/NAS/TEST-MEDIA/strm/DASH_Live.strm
2026-01-23 16:16:18.284 T:22584    info <inputstream.adaptive>: Manifest successfully parsed (Periods: 1, Streams in first period: 2, Type: live) 

Stream manifest signals as type "live"

2026-01-23 16:16:18.343 T:22584    info <general>: CDVDAudioCodecFFmpeg::Open() Successful opened audio decoder aac
2026-01-23 16:16:18.344 T:22584    info <general>: CVideoPlayerAudio::OpenStream: Allowing max Out-Of-Sync Value of 50 ms
2026-01-23 16:16:18.344 T:22584    info <general>: Creating audio thread

VideoPlayerAudio initially starts with SYNC type DISCON (no resample)

2026-01-23 16:16:18.610 T:8036    debug <general>: CurlFile::XFILE::CCurlFile::Open - <https://livesim.dashif.org/livesim2/chunkdur_1/ato_7/testpic4_8s/A48/221147670.m4s>
2026-01-23 16:16:18.616 T:18520   debug <general>: CVideoPlayerAudio: stream props changed, checking for passthrough
2026-01-23 16:16:18.617 T:18520    info <general>: CDVDAudioCodecFFmpeg::Open() Successful opened audio decoder aac
2026-01-23 16:16:18.617 T:18520    info <general>: Creating audio stream (codec id: 86018, channels: 2, sample rate: 48000, no pass-through)
2026-01-23 16:16:18.617 T:18520   debug <general>: CVideoPlayerAudio:: synctype set to 1: resample

One second latter is changed to resample and sink is reopened

2026-01-23 16:16:19.170 T:20208   debug <general>: CActiveAESink::OpenSink - WASAPI Initialized:
2026-01-23 16:16:19.170 T:20208   debug <general>:   Output Device : default
2026-01-23 16:16:19.170 T:20208   debug <general>:   Sample Rate   : 48000
2026-01-23 16:16:19.170 T:20208   debug <general>:   Sample Format : AE_FMT_S32NE
2026-01-23 16:16:19.170 T:20208   debug <general>:   Channel Count : 2
2026-01-23 16:16:19.170 T:20208   debug <general>:   Channel Layout: FL, FR
2026-01-23 16:16:19.170 T:20208   debug <general>:   Frames        : 960
2026-01-23 16:16:19.170 T:20208   debug <general>:   Frame Size    : 8

Low latency mode is reconfigured with 100ms initial buffer level

2026-01-23 16:16:19.171 T:10008   debug <general>: ActiveAE::CActiveAE::ConfigureLowLatency: Low latency mode: true - Initial buffer level: 100ms (resample: true)
2026-01-23 16:16:19.171 T:10008   debug <general>: CActiveAE::ClearDiscardedBuffers - buffer pool deleted
2026-01-23 16:16:19.175 T:22584   debug <general>: CVideoPlayer::HandleMessages - player started 1
2026-01-23 16:16:19.175 T:22584   debug <general>: CDVDClock::SetSpeedAdjust - adjusted:0.000000
2026-01-23 16:16:19.175 T:15144   debug <general>: CApplicationPlayerCallback::OnAVChange: call
2026-01-23 16:16:19.176 T:22584   debug <general>: VideoPlayer::Sync - Audio - pts: 1769181352298666.000000, cache: 358993.696378, totalcache: 640000.045300
2026-01-23 16:16:19.176 T:22584   debug <general>: VideoPlayer::Sync - Video - pts: 1769181352099999.250000, cache: 50000.000000, totalcache: 100000.000000
2026-01-23 16:16:19.176 T:18520   debug <general>: CVideoPlayerAudio - CDVDMsg::GENERAL_RESYNC(1769181351258666.000000), level: 92, cache: 354710.396378
2026-01-23 16:16:19.176 T:20960   debug <general>: CVideoPlayerVideo - CDVDMsg::GENERAL_RESYNC(1769181351258666.000000)
2026-01-23 16:16:19.176 T:18520   debug <general>: CDVDAudio::Resume - resume audio stream
2026-01-23 16:16:19.176 T:10008   debug <general>: ActiveAE - start sync of audio stream
```

The user log posted in https://github.com/xbmc/xbmc/issues/27690#issuecomment-3786114997 also confirms the same.




## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Fix "Low latency mode" not works correctly when resample mode is disabled in GUI settings but is forced during playback of Live / Realtime streams.

Note that inputstream.adaptive not opens all remote streams as "live" this depends entirely of stream manifest (the stream characteristics itself).

e.g:
`Manifest successfully parsed (Periods: 1, Streams in first period: 2, Type: live) `



## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
