### PR TITLE
ContextMenus: some cleanups

### DIFF
--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -27,6 +27,24 @@ std::string CStaticContextMenuAction::GetLabel(const CFileItem& item) const
   return g_localizeStrings.Get(m_label);
 }
 
+CContextMenuItem::CContextMenuItem(CGroup groupData)
+  : m_label(std::move(groupData.label)),
+    m_parent(std::move(groupData.parent)),
+    m_groupId(std::move(groupData.groupId)),
+    m_addonId(std::move(groupData.addonId))
+{
+}
+
+CContextMenuItem::CContextMenuItem(CItem itemData)
+  : m_label(std::move(itemData.label)),
+    m_parent(std::move(itemData.parent)),
+    m_library(std::move(itemData.library)),
+    m_addonId(std::move(itemData.addonId)),
+    m_args(std::move(itemData.args)),
+    m_visibilityCondition(std::move(itemData.condition))
+{
+}
+
 bool CContextMenuItem::IsVisible(const CFileItem& item) const
 {
   if (!m_infoBoolRegistered)
@@ -93,28 +111,4 @@ std::string CContextMenuItem::ToString() const
   else
     return StringUtils::Format("CContextMenuItem[item, parent={}, library={}, addon={}]", m_parent,
                                m_library, m_addonId);
-}
-
-CContextMenuItem CContextMenuItem::CreateGroup(const std::string& label, const std::string& parent,
-    const std::string& groupId, const std::string& addonId)
-{
-  CContextMenuItem menuItem;
-  menuItem.m_label = label;
-  menuItem.m_parent = parent;
-  menuItem.m_groupId = groupId;
-  menuItem.m_addonId = addonId;
-  return menuItem;
-}
-
-CContextMenuItem CContextMenuItem::CreateItem(const std::string& label, const std::string& parent,
-    const std::string& library, const std::string& condition, const std::string& addonId, const std::vector<std::string>& args)
-{
-  CContextMenuItem menuItem;
-  menuItem.m_label = label;
-  menuItem.m_parent = parent;
-  menuItem.m_library = library;
-  menuItem.m_visibilityCondition = condition;
-  menuItem.m_addonId = addonId;
-  menuItem.m_args = args;
-  return menuItem;
 }

--- a/xbmc/ContextMenuItem.h
+++ b/xbmc/ContextMenuItem.h
@@ -52,7 +52,27 @@ private:
 class CContextMenuItem : public IContextMenuItem
 {
 public:
+  struct CGroup
+  {
+    std::string label{};
+    std::string parent{};
+    std::string groupId{};
+    std::string addonId{};
+  };
+
+  struct CItem
+  {
+    std::string label{};
+    std::string parent{};
+    std::string library{};
+    std::string condition{};
+    std::string addonId{};
+    std::vector<std::string> args{};
+  };
+
   CContextMenuItem() = default;
+  CContextMenuItem(CItem item);
+  CContextMenuItem(CGroup item);
 
   std::string GetLabel(const CFileItem& item) const  override { return m_label; }
   bool IsVisible(const CFileItem& item) const override ;
@@ -63,20 +83,6 @@ public:
   bool operator==(const CContextMenuItem& other) const;
   std::string ToString() const;
 
-  static CContextMenuItem CreateGroup(
-    const std::string& label,
-    const std::string& parent,
-    const std::string& groupId,
-    const std::string& addonId);
-
-  static CContextMenuItem CreateItem(
-    const std::string& label,
-    const std::string& parent,
-    const std::string& library,
-    const std::string& condition,
-    const std::string& addonId, 
-    const std::vector<std::string>& args = std::vector<std::string>());
-  
   friend class ADDON::CContextMenuAddon;
 
 private:

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -35,9 +35,12 @@
 using namespace ADDON;
 using namespace PVR;
 
-const CContextMenuItem CContextMenuManager::MAIN = CContextMenuItem::CreateGroup("", "", "kodi.core.main", "");
-const CContextMenuItem CContextMenuManager::MANAGE = CContextMenuItem::CreateGroup("", "", "kodi.core.manage", "");
-
+const CContextMenuItem CContextMenuManager::MAIN(CContextMenuItem::CGroup{
+    .groupId = "kodi.core.main",
+});
+const CContextMenuItem CContextMenuManager::MANAGE(CContextMenuItem::CGroup{
+    .groupId = "kodi.core.manage",
+});
 
 CContextMenuManager::CContextMenuManager(CAddonMgr& addonMgr)
   : m_addonMgr(addonMgr) {}

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -115,9 +115,8 @@ void CContextMenuManager::Init()
 
   ReloadAddonItems();
 
-  const std::vector<std::shared_ptr<IContextMenuItem>> pvrItems(CPVRContextMenuManager::GetInstance().GetMenuItems());
-  for (const auto &item : pvrItems)
-    m_items.emplace_back(item);
+  std::ranges::copy(CPVRContextMenuManager::GetInstance().GetMenuItems(),
+                    std::back_inserter(m_items));
 }
 
 void CContextMenuManager::ReloadAddonItems()
@@ -129,12 +128,8 @@ void CContextMenuManager::ReloadAddonItems()
   for (const auto& addon : addons)
   {
     auto items = std::static_pointer_cast<CContextMenuAddon>(addon)->GetItems();
-    for (auto& item : items)
-    {
-      auto it = std::ranges::find(addonItems, item);
-      if (it == addonItems.end())
-        addonItems.push_back(item);
-    }
+    std::ranges::copy_if(items, std::back_inserter(addonItems), [&addonItems](const auto& item)
+                         { return std::ranges::find(addonItems, item) == addonItems.end(); });
   }
 
   std::unique_lock lock(m_criticalSection);


### PR DESCRIPTION
## Description
Allow for some more emplacement, and drop some loops

## Motivation and context
Prettier, more expressive

## How has this been tested?
It builds, I got visible menus trying the build.

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
