### PR TITLE
[GHA] Make Claude Code Review comments collapsed by default

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -69,7 +69,14 @@ jobs:
             Note: The PR branch is already checked out in the current working directory.
 
             After your review:
-            1. If you found issues: Use `gh pr comment` for top-level summary, and `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues
+            1. If you found issues: Use `gh pr comment` for top-level summary wrapped in a collapsed section like this:
+               <details>
+               <summary>🤖 Claude Code Review</summary>
+
+               [Your review content here]
+
+               </details>
+               Also use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues
             2. If everything looks good: Use `gh pr review --approve` with NO message (just the approval checkmark)
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## Description
Wraps Claude Code Review workflow output in `<details>` tags so comments appear collapsed by default with just a summary header visible.

## Motivation and context
Improves readability of PR comment threads by collapsing verbose review output until users choose to expand it.

## How has this been tested?
- Workflow configuration change only
- Will be tested on next PR that triggers the claude-code-review workflow

## What is the effect on users?
Claude Code Review comments will now appear collapsed in PRs, showing only "🤖 Claude Code Review" header. Users can click to expand and view full review details.

## Types of change
- [X] **Improvement** (non-breaking change which improves existing functionality)