### PR TITLE
[guilib] Optimize GUIControlGroupList page control message caching

### DIFF
--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -15,6 +15,8 @@
 
 #include "GUIControlGroup.h"
 
+#include <optional>
+
 struct SGUIControlAndOffset
 {
   CGUIControl* control{nullptr};
@@ -29,6 +31,7 @@ class CGUIControlGroupList : public CGUIControlGroup
 {
 public:
   CGUIControlGroupList(int parentID, int controlID, float posX, float posY, float width, float height, float itemGap, int pageControl, ORIENTATION orientation, bool useControlPositions, uint32_t alignment, const CScroller& scroller);
+  CGUIControlGroupList(const CGUIControlGroupList& other);
   ~CGUIControlGroupList(void) override;
   CGUIControlGroupList* Clone() const override { return new CGUIControlGroupList(*this); }
 
@@ -116,7 +119,9 @@ protected:
   float m_totalSize;
 
   CScroller m_scroller;
-  int m_lastScrollerValue;
+  std::optional<int> m_lastScrollerValue;
+  std::optional<int> m_lastPageControlSize;
+  std::optional<int> m_lastPageControlTotalSize;
 
   bool m_useControlPositions;
   ORIENTATION m_orientation;


### PR DESCRIPTION
## Description
Cache page control size, total size, and scroller values to avoid sending redundant GUI_MSG_LABEL_RESET and GUI_MSG_ITEM_SELECT messages when values haven't changed.

## Motivation and context
Reducing idle CPU usage.

## How has this been tested?
Kodi 22 master on Windows, CoreELEC 21.3 p3i on Ugoos AM6B+

## What is the effect on users?
This reduces idle CPU usage.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
