### PR TITLE
[guilib] Optimize GUIButtonControl focus pulse alpha updates

### DIFF
--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -89,8 +89,14 @@ void CGUIButtonControl::Process(unsigned int currentTime, CDirtyRegionList &dirt
       alphaChannel += 192;
       alphaChannel = (unsigned int)((float)m_alpha * (float)alphaChannel / 255.0f);
     }
-    if (m_imgFocus->SetAlpha((unsigned char)alphaChannel))
-      MarkDirtyRegion();
+
+    const auto newAlpha = static_cast<unsigned char>(alphaChannel);
+    if (m_lastFocusAlpha != newAlpha)
+    {
+      if (m_imgFocus->SetAlpha(newAlpha))
+        MarkDirtyRegion();
+      m_lastFocusAlpha = newAlpha;
+    }
 
     m_imgFocus->SetVisible(true);
     m_imgNoFocus->SetVisible(false);
@@ -413,6 +419,7 @@ void CGUIButtonControl::OnFocus()
 void CGUIButtonControl::OnUnFocus()
 {
   m_unfocusActions.ExecuteActions(GetID(), GetParentID());
+  m_lastFocusAlpha.reset();
 }
 
 void CGUIButtonControl::SetSelected(bool bSelected)

--- a/xbmc/guilib/GUIButtonControl.h
+++ b/xbmc/guilib/GUIButtonControl.h
@@ -20,6 +20,8 @@
 #include "guilib/guiinfo/GUIInfoLabel.h"
 #include "utils/ColorUtils.h"
 
+#include <optional>
+
 /*!
  \ingroup controls
  \brief
@@ -93,6 +95,7 @@ protected:
   std::unique_ptr<CGUITexture> m_imgNoFocus;
   unsigned int  m_focusCounter;
   unsigned char m_alpha;
+  std::optional<unsigned char> m_lastFocusAlpha;
 
   float m_minWidth;
   float m_maxWidth;


### PR DESCRIPTION
## Description
Cache the last focus alpha value to avoid redundant SetAlpha calls and unnecessary MarkDirtyRegion calls when the alpha hasn't changed. 

## Motivation and context
Reducing idle CPU usage.

## How has this been tested?
Kodi 22 master on Windows, CoreELEC 21.3 p3i on Ugoos AM6B+

## What is the effect on users?
This reduces idle CPU usage during button focus pulse animation.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
