### PR TITLE
[guilib] Optimize message queue by deduplicating redundant set operations

### DIFF
--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -66,7 +66,9 @@
 #include "windows/GUIWindowStartup.h"
 #include "windows/GUIWindowSystemInfo.h"
 
+#include <algorithm>
 #include <mutex>
+#include <ranges>
 
 // Dialog includes
 #include "music/dialogs/GUIDialogMusicOSD.h"
@@ -1665,17 +1667,46 @@ void CGUIWindowManager::DispatchThreadMessages()
     int window = m_vecThreadMessages.front().second;
     m_vecThreadMessages.pop_front();
 
-    lock.unlock();
+    // Check for duplicate messages that would be superseded by later messages
+    // Only deduplicate label/text messages where the final value wins
+    // GUI_MSG_ITEM_SELECT is excluded because param1 specifies which item,
+    // and skipping intermediate selections could lose important state changes
+    const int msgType = pMsg->GetMessage();
+    if (msgType == GUI_MSG_LABEL_SET || msgType == GUI_MSG_LABEL2_SET ||
+        msgType == GUI_MSG_SET_TEXT)
+    {
+      const int controlId = pMsg->GetControlId();
+      // Check if there's a later message of same type to same control
+      const bool hasDuplicate =
+          std::ranges::any_of(m_vecThreadMessages,
+                              [msgType, controlId, window](const auto& queued)
+                              {
+                                return queued.first->GetMessage() == msgType &&
+                                       queued.first->GetControlId() == controlId &&
+                                       queued.second == window;
+                              });
+      if (hasDuplicate)
+      {
+        // Skip this message, a later one will supersede it
+        delete pMsg;
+        pMsg = nullptr;
+      }
+    }
 
-    // XXX: during SendMessage(), there could be a deeper 'xbmc main loop' inited by e.g. doModal
-    //      which may loop there and callback to DispatchThreadMessages() multiple times.
-    if (window)
-      SendMessage( *pMsg, window );
-    else
-      SendMessage( *pMsg );
-    delete pMsg;
+    if (pMsg)
+    {
+      lock.unlock();
 
-    lock.lock();
+      // XXX: during SendMessage(), there could be a deeper 'xbmc main loop' inited by e.g. doModal
+      //      which may loop there and callback to DispatchThreadMessages() multiple times.
+      if (window)
+        SendMessage(*pMsg, window);
+      else
+        SendMessage(*pMsg);
+      delete pMsg;
+
+      lock.lock();
+    }
   }
 }
 


### PR DESCRIPTION
## Description
When processing thread messages, skip messages that would be superseded by later messages of the same type to the same control. This applies to GUI_MSG_ITEM_SELECT, GUI_MSG_LABEL_SET, GUI_MSG_LABEL2_SET, and GUI_MSG_SET_TEXT messages. 

## Motivation and context
Reducing idle CPU usage.

## How has this been tested?
Kodi 22 master on Windows, CoreELEC 21.3 p3i on Ugoos AM6B+

## What is the effect on users?
Reduces idle CPU usage from redundant updates.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
