### PR TITLE
[guilib] Optimize GUIScrollBarControl to reduce constant dirty region marking

### DIFF
--- a/xbmc/guilib/GUIScrollBarControl.cpp
+++ b/xbmc/guilib/GUIScrollBarControl.cpp
@@ -72,10 +72,18 @@ void GUIScrollBarControl::Process(unsigned int currentTime, CDirtyRegionList &di
     changed |= UpdateBarSize();
 
   changed |= m_guiBackground->Process(currentTime);
-  changed |= m_guiBarNoFocus->Process(currentTime);
-  changed |= m_guiBarFocus->Process(currentTime);
-  changed |= m_guiNibNoFocus->Process(currentTime);
-  changed |= m_guiNibFocus->Process(currentTime);
+
+  // Only process textures that will actually be rendered based on focus state
+  if (m_bHasFocus)
+  {
+    changed |= m_guiBarFocus->Process(currentTime);
+    changed |= m_guiNibFocus->Process(currentTime);
+  }
+  else
+  {
+    changed |= m_guiBarNoFocus->Process(currentTime);
+    changed |= m_guiNibNoFocus->Process(currentTime);
+  }
 
   if (changed)
     MarkDirtyRegion();
@@ -236,6 +244,14 @@ void GUIScrollBarControl::SetInvalid()
 
 bool GUIScrollBarControl::UpdateBarSize()
 {
+  // Skip recalculation if scroll parameters haven't changed
+  if (m_offset == m_lastOffset && m_pageSize == m_lastPageSize && m_numItems == m_lastNumItems)
+    return false;
+
+  m_lastOffset = m_offset;
+  m_lastPageSize = m_pageSize;
+  m_lastNumItems = m_numItems;
+
   bool changed = false;
 
   // scale our textures to suit

--- a/xbmc/guilib/GUIScrollBarControl.h
+++ b/xbmc/guilib/GUIScrollBarControl.h
@@ -16,6 +16,8 @@
 #include "GUIControl.h"
 #include "GUITexture.h"
 
+#include <optional>
+
 /*!
  \ingroup controls
  \brief
@@ -65,6 +67,11 @@ protected:
 
   bool m_showOnePage;
   ORIENTATION m_orientation;
+
+  // Cached values for UpdateBarSize() optimization
+  std::optional<int> m_lastOffset;
+  std::optional<int> m_lastPageSize;
+  std::optional<int> m_lastNumItems;
 
 private:
   GUIScrollBarControl(const GUIScrollBarControl& control);


### PR DESCRIPTION
## Description
- Only process textures matching current focus state (3 instead of 5)
- Cache scroll parameters in UpdateBarSize() to skip redundant recalculations when offset/pageSize/numItems unchanged

## Motivation and context
Reducing idle CPU usage.

## How has this been tested?
Kodi 22 master on Windows, CoreELEC 21.3 p3i on Ugoos AM6B+

## What is the effect on users?
Reduces (idle) CPU usage in views with scrollbars (that have a page control attached)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
