### PR TITLE
[guilib] Optimize CGUITexture to only mark dirty on ready state transitions

### DIFF
--- a/xbmc/guilib/GUITexture.cpp
+++ b/xbmc/guilib/GUITexture.cpp
@@ -167,7 +167,15 @@ bool CGUITexture::Process(unsigned int currentTime)
     changed |= CalculateSize();
 
   if (m_isAllocated)
-    changed |= !ReadyToRender();
+  {
+    // Only report change on ready state transition, not every frame while loading
+    const bool ready = ReadyToRender();
+    if (ready != m_lastReadyState)
+    {
+      m_lastReadyState = ready;
+      changed = true;
+    }
+  }
 
   return changed;
 }
@@ -547,6 +555,7 @@ void CGUITexture::FreeResources(bool immediately /* = false */)
   Free();
 
   m_isAllocated = NO;
+  m_lastReadyState.reset(); // reset for next allocation cycle
 }
 
 void CGUITexture::DynamicResourceAlloc(bool allocateDynamically)

--- a/xbmc/guilib/GUITexture.h
+++ b/xbmc/guilib/GUITexture.h
@@ -16,6 +16,7 @@
 #include "utils/Geometry.h"
 
 #include <functional>
+#include <optional>
 
 class CTextureInfo
 {
@@ -177,6 +178,7 @@ protected:
   CRect m_vertex;       // vertex coords to render
   bool m_invalid;       // if true, we need to recalculate
   bool m_use_cache;
+  std::optional<bool> m_lastReadyState; // cached ready state for change detection
   unsigned char m_alpha;
 
   float m_frameWidth, m_frameHeight;          // size in pixels of the actual frame within the texture


### PR DESCRIPTION
## Description
Previously, Process() marked dirty every frame while a texture was allocated but not ready to render. This caused constant dirty region marking during texture loading phases.

Now we cache the ready state and only report changes when transitioning between ready/not-ready states. This is correct because:
- While not ready, the texture can't render anyway (Render() early-exits)
- When becoming ready, we mark dirty to trigger the actual render
- AllocateOnDemand() already handles marking dirty when allocation occurs

## Motivation and context
Performance improvements 

## How has this been tested?
Kodi 22 master on Windows, CoreELEC 21.3 p3i on Ugoos AM6B+

## What is the effect on users?
Faster UI rendering

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
