### PR TITLE
[guilib] Optimize GUIBorderedImage border position recalculation

### DIFF
--- a/xbmc/guilib/GUIBorderedImage.cpp
+++ b/xbmc/guilib/GUIBorderedImage.cpp
@@ -45,9 +45,15 @@ void CGUIBorderedImage::Process(unsigned int currentTime, CDirtyRegionList &dirt
                        m_textureCurrent->GetXPosition() + m_textureCurrent->GetWidth(),
                        m_textureCurrent->GetYPosition() + m_textureCurrent->GetHeight());
     rect.Intersect(m_textureCurrent->GetRenderRect());
-    m_borderImage->SetPosition(rect.x1 - m_borderSize.x1, rect.y1 - m_borderSize.y1);
-    m_borderImage->SetWidth(rect.Width() + m_borderSize.x1 + m_borderSize.x2);
-    m_borderImage->SetHeight(rect.Height() + m_borderSize.y1 + m_borderSize.y2);
+
+    if (m_lastBorderRect != rect)
+    {
+      m_borderImage->SetPosition(rect.x1 - m_borderSize.x1, rect.y1 - m_borderSize.y1);
+      m_borderImage->SetWidth(rect.Width() + m_borderSize.x1 + m_borderSize.x2);
+      m_borderImage->SetHeight(rect.Height() + m_borderSize.y1 + m_borderSize.y2);
+      m_lastBorderRect = rect;
+    }
+
     m_borderImage->SetDiffuseColor(m_diffuseColor);
     if (m_borderImage->Process(currentTime))
       MarkDirtyRegion();
@@ -79,12 +85,14 @@ void CGUIBorderedImage::AllocResources()
 {
   m_borderImage->AllocResources();
   CGUIImage::AllocResources();
+  m_lastBorderRect.reset();
 }
 
 void CGUIBorderedImage::FreeResources(bool immediately)
 {
   m_borderImage->FreeResources(immediately);
   CGUIImage::FreeResources(immediately);
+  m_lastBorderRect.reset();
 }
 
 void CGUIBorderedImage::DynamicResourceAlloc(bool bOnOff)

--- a/xbmc/guilib/GUIBorderedImage.h
+++ b/xbmc/guilib/GUIBorderedImage.h
@@ -12,6 +12,8 @@
 #include "GUIImage.h"
 #include "TextureManager.h"
 
+#include <optional>
+
 class CGUIBorderedImage : public CGUIImage
 {
 public:
@@ -30,6 +32,7 @@ public:
 protected:
   std::unique_ptr<CGUITexture> m_borderImage;
   CRect m_borderSize;
+  std::optional<CRect> m_lastBorderRect;
 
 private:
   CGUIBorderedImage(const CGUIBorderedImage& right);


### PR DESCRIPTION
## Description
Cache the last border rect to avoid redundant SetPosition, SetWidth, and SetHeight calls when the texture position/size hasn't changed.

## Motivation and context
Reducing idle CPU usage.

## How has this been tested?
Kodi 22 master on Windows, CoreELEC 21.3 p3i on Ugoos AM6B+

## What is the effect on users?
This reduces idle CPU usage.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
