### PR TITLE
Use bullet (U+2022) instead of math dot as UI separator

### DIFF
--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -967,7 +967,7 @@
 		</control>
 	</include>
 	<include name="TopBar">
-		<param name="sublabel">$INFO[Container.SortMethod,$LOCALIZE[31022]: ,  ∙  ]$INFO[Container.CurrentItem,, / ]$INFO[Container.NumItems]</param>
+		<param name="sublabel">$INFO[Container.SortMethod,$LOCALIZE[31022]: ,  •  ]$INFO[Container.CurrentItem,, / ]$INFO[Container.NumItems]</param>
 		<definition>
 			<control type="group">
 				<animation effect="slide" end="0,-112" time="300" tween="sine" easing="inout" condition="$EXP[infodialog_active]">conditional</animation>

--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -914,7 +914,7 @@
 	<include name="WeatherHourlyItem">
 		<item>
 			<label>$INFO[Weather.Data(Hourly.$PARAM[item_index].Time)]</label>
-			<label2>$INFO[Weather.Data(Hourly.$PARAM[item_index].Temperature)]$INFO[Weather.Data(Hourly.$PARAM[item_index].Precipitation), ∙ ]</label2>
+			<label2>$INFO[Weather.Data(Hourly.$PARAM[item_index].Temperature)]$INFO[Weather.Data(Hourly.$PARAM[item_index].Precipitation), • ]</label2>
 			<property name="Temperature">$INFO[Weather.Data(Hourly.$PARAM[item_index].Temperature)]</property>
 			<property name="Outlook">$INFO[Weather.Data(Hourly.$PARAM[item_id].Outlook)]</property>
 			<property name="Cloudiness">$INFO[Weather.Data(Hourly.$PARAM[item_index].Cloudiness)]</property>
@@ -928,7 +928,7 @@
 	<include name="WeatherDailyItem">
 		<item>
 			<label>$INFO[Weather.Data(Daily.$PARAM[item_index].ShortDay)]</label>
-			<label2>[COLOR blue]$INFO[Weather.Data(Daily.$PARAM[item_index].LowTemperature)][/COLOR]$INFO[Weather.Data(Daily.$PARAM[item_index].HighTemperature), ∙ [COLOR red],[/COLOR]]</label2>
+			<label2>[COLOR blue]$INFO[Weather.Data(Daily.$PARAM[item_index].LowTemperature)][/COLOR]$INFO[Weather.Data(Daily.$PARAM[item_index].HighTemperature), • [COLOR red],[/COLOR]]</label2>
 			<property name="LongDay">$INFO[Weather.Data(Daily.$PARAM[item_index].LongDay)]</property>
 			<property name="TempDay">$INFO[Weather.Data(Daily.$PARAM[item_index].TempDay)]</property>
 			<property name="Cloudiness">$INFO[Weather.Data(Daily.$PARAM[item_index].Cloudiness)]</property>
@@ -943,7 +943,7 @@
 	<include name="WeatherDayItem">
 		<item>
 			<label>$INFO[Weather.Data(Day$PARAM[item_index].Title)]</label>
-			<label2>[COLOR blue]$INFO[Weather.Data(Day$PARAM[item_index].LowTemp)][/COLOR] ∙ [COLOR red]$INFO[Weather.Data(Day$PARAM[item_index].HighTemp)][/COLOR]</label2>
+			<label2>[COLOR blue]$INFO[Weather.Data(Day$PARAM[item_index].LowTemp)][/COLOR] • [COLOR red]$INFO[Weather.Data(Day$PARAM[item_index].HighTemp)][/COLOR]</label2>
 			<property name="LongDay"></property>
 			<property name="TempDay"></property>
 			<property name="Cloudiness"></property>

--- a/addons/skin.estuary/xml/MyPlaylist.xml
+++ b/addons/skin.estuary/xml/MyPlaylist.xml
@@ -18,7 +18,7 @@
 			</control>
 			<include content="TopBar" condition="Window.IsActive(videoplaylist)">
 				<param name="breadcrumbs_label" value="$LOCALIZE[31065]" />
-				<param name="sublabel">$LOCALIZE[31073] - $INFO[Container.TotalTime,,  ∙  ]$INFO[Container.CurrentItem,,/]$INFO[Container.NumItems]</param>
+				<param name="sublabel">$LOCALIZE[31073] - $INFO[Container.TotalTime,,  •  ]$INFO[Container.CurrentItem,,/]$INFO[Container.NumItems]</param>
 			</include>
 			<include content="TopBar" condition="Window.IsActive(musicplaylist)">
 				<param name="breadcrumbs_label" value="$LOCALIZE[31066]" />


### PR DESCRIPTION
## Description
Replace the UI text separator from a mathematical dot operator (U+2219) to a proper bullet character (U+2022).

The current separator uses a math operator character, which is semantically incorrect for UI text and not reliably supported by many fonts. This change replaces it with the standard Unicode bullet.

## Motivation and context
The UI separator was previously implemented using U+2219 (BULLET OPERATOR), a character intended for mathematical notation.

Many CJK, UI, and minimal fonts do not include this glyph, which can result in missing-glyph squares when users use custom or non-default fonts.

U+2022 (BULLET) is the correct Unicode character for list items and UI separators and has significantly better font coverage across platforms.

## How has this been tested?
- Tested with the default Kodi skin on Linux and macOS
- Verified visual appearance before and after the change
- Tested with both system fonts and custom CJK fonts to ensure the separator renders correctly
- Confirmed no layout regressions or spacing issues

## What is the effect on users?
- Improves cross-platform font compatibility
- Prevents missing-glyph squares when using custom or minimal fonts
- No functional changes
- Minimal visual difference, improved robustness