### PR TITLE
[FreeBSD][Zip] Change temporary directory location from RAM to disc to avoid issues decompressing large compressed files.

### DIFF
--- a/xbmc/platform/posix/Filesystem.cpp
+++ b/xbmc/platform/posix/Filesystem.cpp
@@ -68,7 +68,13 @@ std::string temp_directory_path(std::error_code &ec)
   if (result)
     return URIUtils::AppendSlash(result);
 
+#if defined(TARGET_FREEBSD)
+  // Use /var/tmp on FreeBSD as /tmp can be created in RAM
+  // This can be limiting for decompressing archives with large compressed files
+  return "/var/tmp/";
+#else
   return "/tmp/";
+#endif
 }
 
 std::string create_temp_directory(std::error_code &ec)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The issue appears to be with the use of /tmp as the temporary directory - which is where compressed files are decompressed to as part of CFIle::Open() - is in memory - and this means the decompression of large files fails and hence file.Open fails in the BigRead64 test.

By changing to /var/tmp this seems to fix it.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

TestZipFile.BigRead64 failed on BSD (failed to open file) - although Jenkins didn't make it that obvious:
<img width="1530" height="401" alt="image" src="https://github.com/user-attachments/assets/abe144b3-535f-4d3e-92a8-03cd6e9242cb" />

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally builds. Passes tests on Jenkins FreeBSD.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
