### PR TITLE
[PVR] PVR components power management improvements

### DIFF
--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -638,6 +638,7 @@ void CPVRManager::OnSleep()
   if (!m_sleepConfirmedEvent.Wait(5s))
     CLog::LogFC(LOGWARNING, LOGPVR, "Timeout waiting for sleep confirmed event");
 
+  m_guiInfo->OnSleep();
   m_epgContainer->OnSleep();
   m_timers->OnSleep();
   m_addons->OnSleep();
@@ -648,6 +649,7 @@ void CPVRManager::OnWake()
   m_addons->OnWake();
   m_timers->OnWake();
   m_epgContainer->OnWake();
+  m_guiInfo->OnWake();
 
   CPowerState::OnWake();
   m_wakeEvent.Set(); // wake the worker thread

--- a/xbmc/pvr/PVRManager.h
+++ b/xbmc/pvr/PVRManager.h
@@ -458,5 +458,9 @@ private:
   const std::shared_ptr<CPVRPlaybackState> m_playbackState;
   CPVRGUIActionListener m_actionListener;
   std::unique_ptr<CPVRSettings> m_settings;
+
+  CEvent m_sleepConfirmedEvent{false,
+                               false}; // Event to sync with worker thread on power state transition
+  CEvent m_wakeEvent{true, false}; // event to wake worker thread on power state transition
 };
 } // namespace PVR

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -124,12 +124,6 @@ std::shared_ptr<CPVREpgDatabase> CPVREpgContainer::GetEpgDatabase() const
   return m_database;
 }
 
-bool CPVREpgContainer::IsStarted() const
-{
-  std::unique_lock lock(m_critSection);
-  return m_bStarted;
-}
-
 int CPVREpgContainer::NextEpgId()
 {
   std::unique_lock lock(m_critSection);
@@ -146,19 +140,12 @@ void CPVREpgContainer::Start()
 
     Create();
     SetPriority(ThreadPriority::BELOW_NORMAL);
-
-    m_bStarted = true;
   }
 }
 
 void CPVREpgContainer::Stop()
 {
   StopThread();
-
-  {
-    std::unique_lock lock(m_critSection);
-    m_bStarted = false;
-  }
 }
 
 void CPVREpgContainer::Unload()

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -148,6 +148,18 @@ void CPVREpgContainer::Stop()
   StopThread();
 }
 
+void CPVREpgContainer::OnSleep()
+{
+  CPowerState::OnSleep();
+  Stop();
+}
+
+void CPVREpgContainer::OnWake()
+{
+  CPowerState::OnWake();
+  Start();
+}
+
 void CPVREpgContainer::Unload()
 {
   {
@@ -310,7 +322,7 @@ void CPVREpgContainer::Process()
     CDateTime::GetCurrentDateTime().GetAsUTCDateTime().GetAsTime(iNow);
     {
       std::unique_lock lock(m_critSection);
-      bUpdateEpg = (iNow >= m_iNextEpgUpdate) && IsAwake();
+      bUpdateEpg = !m_bStop && (iNow >= m_iNextEpgUpdate);
       iLastEpgCleanup = m_iLastEpgCleanup;
     }
 
@@ -319,15 +331,14 @@ void CPVREpgContainer::Process()
       m_bIsInitialising = false;
 
     /* clean up old entries */
-    if (!m_bStop && IsAwake() &&
-        iNow >= iLastEpgCleanup + CServiceBroker::GetSettingsComponent()
-                                      ->GetAdvancedSettings()
-                                      ->m_iEpgCleanupInterval)
+    if (!m_bStop && iNow >= iLastEpgCleanup + CServiceBroker::GetSettingsComponent()
+                                                  ->GetAdvancedSettings()
+                                                  ->m_iEpgCleanupInterval)
       RemoveOldEntries();
 
     /* check for pending manual EPG updates */
 
-    while (!m_bStop && IsAwake())
+    while (!m_bStop)
     {
       CEpgUpdateRequest request;
       std::shared_ptr<CPVREpg> epg;
@@ -354,7 +365,7 @@ void CPVREpgContainer::Process()
 
     /* check for pending EPG tag changes */
 
-    if (!m_bStop && IsAwake())
+    if (!m_bStop)
     {
       unsigned int iProcessed = 0;
       XbmcThreads::EndTime<> processTimeslice(
@@ -393,7 +404,7 @@ void CPVREpgContainer::Process()
       }
     }
 
-    if (!m_bStop && IsAwake())
+    if (!m_bStop)
     {
       bool bHasPendingUpdates = false;
 
@@ -422,19 +433,23 @@ void CPVREpgContainer::Process()
     }
 
     /* check for changes that need to be saved every 60 seconds */
-    if ((iNow - iLastSave > 60) && !InterruptUpdate())
+    if (!m_bStop && (iNow - iLastSave > 60) && !InterruptUpdate())
     {
       PersistAll(1000);
       iLastSave = iNow;
     }
 
-    CThread::Sleep(1000ms);
+    if (!m_bStop)
+      CThread::Sleep(1000ms);
   }
 
-  // store data on exit
-  CLog::Log(LOGINFO, "EPG Container: Persisting unsaved events...");
-  PersistAll(std::numeric_limits<unsigned int>::max());
-  CLog::Log(LOGINFO, "EPG Container: Persisting events done");
+  if (!IsSleeping())
+  {
+    // store data on exit
+    CLog::Log(LOGINFO, "EPG Container: Persisting unsaved events...");
+    PersistAll(std::numeric_limits<unsigned int>::max());
+    CLog::Log(LOGINFO, "EPG Container: Persisting events done");
+  }
 }
 
 std::vector<std::shared_ptr<CPVREpg>> CPVREpgContainer::GetAllEpgs() const

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -73,7 +73,17 @@ public:
    */
   void Stop();
 
-  /**
+  /*!
+   * @brief Propagate event on system sleep
+   */
+  void OnSleep() override;
+
+  /*!
+   * @brief Propagate event on system wake
+   */
+  void OnWake() override;
+
+  /*!
    * @brief unload all EPG data.
    */
   void Unload();

--- a/xbmc/pvr/epg/EpgContainer.h
+++ b/xbmc/pvr/epg/EpgContainer.h
@@ -79,12 +79,6 @@ public:
   void Unload();
 
   /*!
-   * @brief Check whether the EpgContainer has fully started.
-   * @return True if started, false otherwise.
-   */
-  bool IsStarted() const;
-
-  /*!
    * @brief Queue the deletion of the given EPG tables from this container.
    * @param epg The tables to delete.
    * @return True on success, false otherwise.
@@ -324,7 +318,6 @@ private:
   bool m_bIsUpdating = false; /*!< true while an update is running */
   std::atomic<bool> m_bIsInitialising = {
       true}; /*!< true while the epg manager hasn't loaded all tables */
-  bool m_bStarted = false; /*!< true if EpgContainer has fully started */
   bool m_bLoaded = false; /*!< true after epg data is initially loaded from the database */
   bool m_bPreventUpdates = false; /*!< true to prevent EPG updates */
   bool m_bPlaying = false; /*!< true if Kodi is currently playing something */

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "guilib/guiinfo/GUIInfoProvider.h"
+#include "powermanagement/PowerState.h"
 #include "pvr/PVRDescrambleInfo.h"
 #include "pvr/PVRSignalStatus.h"
 #include "pvr/addons/PVRClients.h"
@@ -30,7 +31,9 @@ class CGUIInfo;
 
 namespace PVR
 {
-class CPVRGUIInfo : public KODI::GUILIB::GUIINFO::CGUIInfoProvider, private CThread
+class CPVRGUIInfo : public KODI::GUILIB::GUIINFO::CGUIInfoProvider,
+                    private CThread,
+                    public CPowerState
 {
 public:
   CPVRGUIInfo();
@@ -38,6 +41,16 @@ public:
 
   void Start();
   void Stop();
+
+  /*!
+   * @brief Propagate event on system sleep
+   */
+  void OnSleep() override;
+
+  /*!
+   * @brief Propagate event on system wake
+   */
+  void OnWake() override;
 
   // KODI::GUILIB::GUIINFO::IGUIInfoProvider implementation
   bool InitCurrentItem(CFileItem* item) override;
@@ -186,7 +199,5 @@ private:
    * information.
    */
   mutable std::atomic<bool> m_updateBackendCacheRequested;
-
-  bool m_bRegistered;
 };
 } // namespace PVR

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -137,36 +137,24 @@ void CPVRTimers::Unload()
 void CPVRTimers::Start()
 {
   Stop();
-
-  CServiceBroker::GetPVRManager().Events().Subscribe(
-      this,
-      [this](const PVREvent& event)
-      {
-        switch (event)
-        {
-          using enum PVREvent;
-
-          case EpgContainer:
-            CServiceBroker::GetPVRManager().TriggerTimersUpdate();
-            break;
-          case Epg:
-          case EpgItemUpdate:
-          {
-            std::unique_lock lock(m_critSection);
-            m_bReminderRulesUpdatePending = true;
-            break;
-          }
-          default:
-            break;
-        }
-      });
   Create();
 }
 
 void CPVRTimers::Stop()
 {
   StopThread();
-  CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
+}
+
+void CPVRTimers::OnSleep()
+{
+  CPowerState::OnSleep();
+  Stop();
+}
+
+void CPVRTimers::OnWake()
+{
+  CPowerState::OnWake();
+  Start();
 }
 
 bool CPVRTimers::UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>>& clients)
@@ -190,19 +178,42 @@ bool CPVRTimers::UpdateFromClients(const std::vector<std::shared_ptr<CPVRClient>
 
 void CPVRTimers::Process()
 {
+  auto& mgr = CServiceBroker::GetPVRManager();
+  mgr.Events().Subscribe(this,
+                         [this, &mgr](const PVREvent& event)
+                         {
+                           switch (event)
+                           {
+                             using enum PVREvent;
+
+                             case EpgContainer:
+                               mgr.TriggerTimersUpdate();
+                               break;
+                             case Epg:
+                             case EpgItemUpdate:
+                             {
+                               std::unique_lock lock(m_critSection);
+                               m_bReminderRulesUpdatePending = true;
+                               break;
+                             }
+                             default:
+                               break;
+                           }
+                         });
+
   while (!m_bStop)
   {
-    if (IsSleeping())
+    if (!m_bStop)
     {
-      CThread::Sleep(10s);
-      continue;
+      // update all timers not owned by a client (e.g. reminders)
+      UpdateEntries(MAX_NOTIFICATION_DELAY.count());
     }
 
-    // update all timers not owned by a client (e.g. reminders)
-    UpdateEntries(MAX_NOTIFICATION_DELAY.count());
-
-    CThread::Sleep(MAX_NOTIFICATION_DELAY);
+    if (!m_bStop)
+      CThread::Sleep(1s);
   }
+
+  mgr.Events().Unsubscribe(this);
 }
 
 bool CPVRTimers::IsRecording() const

--- a/xbmc/pvr/timers/PVRTimers.h
+++ b/xbmc/pvr/timers/PVRTimers.h
@@ -82,6 +82,16 @@ public:
   void Stop();
 
   /*!
+   * @brief Propagate event on system sleep
+   */
+  void OnSleep() override;
+
+  /*!
+   * @brief Propagate event on system wake
+   */
+  void OnWake() override;
+
+  /*!
    * @brief Update all timers from PVR database and from given clients.
    * @param clients The PVR clients data should be loaded for. Leave empty for all clients.
    * @return True on success, false otherwise.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Improve PVR components power management by change from worker threads polling for resume from suspend to an event based approach to stop worker threads on suspend and to restart them on resume. This saves resources and ensures clean re-initialization on resume.  

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Wanted to get rid of polling.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually over a period of 2 months using my living room Kodi setup.
 
## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Hopefully none.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
