### PR TITLE
[ffmpeg][libavcodec] Fix skipping first frames of musepack v7 encoded audio files

### DIFF
--- a/tools/depends/target/ffmpeg/007-ffmpeg-all-mpc7-avoid-skipping-start-frames.patch
+++ b/tools/depends/target/ffmpeg/007-ffmpeg-all-mpc7-avoid-skipping-start-frames.patch
@@ -1,0 +1,14 @@
+diff --git a/libavcodec/mpc7.c b/libavcodec/mpc7.c
+index 98ef1732cf..9bbfea4939 100644
+--- a/libavcodec/mpc7.c
++++ b/libavcodec/mpc7.c
+@@ -302,7 +302,8 @@ static av_cold void mpc7_decode_flush(AVCodecContext *avctx)
+     MPCContext *c = avctx->priv_data;
+ 
+     memset(c->oldDSCF, 0, sizeof(c->oldDSCF));
+-    c->frames_to_skip = 32;
++    /* Do not skip frames if we are at the start of a track when flush() is called. */
++    c->frames_to_skip = avctx->frame_number > 0 ? 32 : 0;
+ }
+ 
+ static av_cold int mpc7_decode_close(AVCodecContext *avctx)

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -150,6 +150,7 @@ endif()
 
 if(NOT DISABLE_FFMPEG_SOURCE_PLUGINS)
   set(sourceplugin_patch PATCH_COMMAND patch -p1 -i <SOURCE_DIR>/001-ffmpeg-all-libpostproc-plugin.patch)
+  set(sourceplugin_patch PATCH_COMMAND patch -p1 -i <SOURCE_DIR>/007-ffmpeg-all-mpc7-avoid-skipping-start-frames.patch)
 endif()
 
 include(ExternalProject)

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -2,7 +2,8 @@
 include FFMPEG-VERSION
 DEPS = FFMPEG-VERSION Makefile ../../download-files.include \
                       CMakeLists.txt \
-                      001-ffmpeg-all-libpostproc-plugin.patch
+                      001-ffmpeg-all-libpostproc-plugin.patch \
+                      007-ffmpeg-all-mpc7-avoid-skipping-start-frames.patch
 
 BUILD_TYPE = Release
 ifeq ($(DEBUG_BUILD),yes)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The function `mpc7_decode_flush` is used when attempting to seek to a frame position > 32. If this function is called, the next 32 frames are muted (which is needed for musepack v7 due to the nature of this format). Kodi calls this function twice at the beginning of each track, resulting in skipping the first 32 frames of each track.
This PR adds a check to only skip the 32 frames, if `mpc7_decode_flush` is not called for the very first frame. This resolves the missing frames in the context of playback through Kodi.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The first 32 frames of "musepack v7" encoded files are skipped when playing them with Kodi. This equals about 0.8 seconds at 44.1 kHz. For tracks which have audible content in these first frames, this is audible.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested the fix on my Linux setup with a "musepack v7" encoded track which starts with sound right at the start. Without this fix, the first fraction of a second is missing, with this fix the track is played back correctly.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Fixes https://github.com/xbmc/xbmc/issues/15945 which was closed by a PR which got merged and later reverted.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
