### PR TITLE
[Threading][Windows] Log app/thread priorities and use MMCSS for AE Sink

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2018 Team Kodi
+ *  Copyright (C) 2010-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -596,6 +596,11 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
   } // for
 }
 
+void CActiveAESink::OnStartup()
+{
+  SetTask(ThreadTask::AUDIO);
+}
+
 void CActiveAESink::Process()
 {
   Message *msg = nullptr;
@@ -670,6 +675,11 @@ void CActiveAESink::Process()
       }
     }
   }
+}
+
+void CActiveAESink::OnExit()
+{
+  RevertTask();
 }
 
 void CActiveAESink::EnumerateSinkList(bool force, std::string driver)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2010-2018 Team Kodi
+ *  Copyright (C) 2010-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -109,8 +109,10 @@ public:
   CSinkDataProtocol m_dataPort;
 
 protected:
+  void OnStartup() override;
   void Process() override;
-  void StateMachine(int signal, Protocol *port, Message *msg);
+  void OnExit() override;
+  void StateMachine(int signal, Protocol* port, Message* msg);
   void PrintSinks(std::string& driver);
   void GetDeviceFriendlyName(const std::string& device);
   void OpenSink();

--- a/xbmc/platform/win32/threads/ThreadImplWin.cpp
+++ b/xbmc/platform/win32/threads/ThreadImplWin.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -15,26 +15,43 @@
 
 #include <array>
 #include <mutex>
+#include <string_view>
 
 #include <process.h>
+#include <processthreadsapi.h>
 #include <windows.h>
 
 namespace
 {
 
-constexpr auto nativeThreadPriorityMap = make_map<ThreadPriority, int>({
-    {ThreadPriority::LOWEST, THREAD_PRIORITY_IDLE},
-    {ThreadPriority::BELOW_NORMAL, THREAD_PRIORITY_BELOW_NORMAL},
-    {ThreadPriority::NORMAL, THREAD_PRIORITY_NORMAL},
-    {ThreadPriority::ABOVE_NORMAL, THREAD_PRIORITY_ABOVE_NORMAL},
-    {ThreadPriority::HIGHEST, THREAD_PRIORITY_HIGHEST},
+struct NativeThreadPriority
+{
+  int priority;
+  std::string_view name;
+};
+
+constexpr auto nativeThreadPriorityMap = make_map<ThreadPriority, NativeThreadPriority>({
+    {ThreadPriority::LOWEST, {THREAD_PRIORITY_IDLE, "idle"}},
+    {ThreadPriority::BELOW_NORMAL, {THREAD_PRIORITY_BELOW_NORMAL, "below normal"}},
+    {ThreadPriority::NORMAL, {THREAD_PRIORITY_NORMAL, "normal"}},
+    {ThreadPriority::ABOVE_NORMAL, {THREAD_PRIORITY_ABOVE_NORMAL, "above normal"}},
+    {ThreadPriority::HIGHEST, {THREAD_PRIORITY_HIGHEST, "highest"}},
 });
 
 static_assert(static_cast<size_t>(ThreadPriority::PRIORITY_COUNT) == nativeThreadPriorityMap.size(),
               "nativeThreadPriorityMap doesn't match the size of ThreadPriority, did you forget to "
               "add/remove a mapping?");
 
-constexpr int ThreadPriorityToNativePriority(const ThreadPriority& priority)
+constexpr auto priorityClasses = make_map<DWORD, std::string_view>({
+    {IDLE_PRIORITY_CLASS, "idle"},
+    {BELOW_NORMAL_PRIORITY_CLASS, "below normal"},
+    {NORMAL_PRIORITY_CLASS, "normal"},
+    {ABOVE_NORMAL_PRIORITY_CLASS, "above normal"},
+    {HIGH_PRIORITY_CLASS, "high"},
+    {REALTIME_PRIORITY_CLASS, "realtime"},
+});
+
+constexpr NativeThreadPriority ThreadPriorityToNativePriority(ThreadPriority priority)
 {
   const auto it = nativeThreadPriorityMap.find(priority);
   if (it != nativeThreadPriorityMap.cend())
@@ -46,6 +63,24 @@ constexpr int ThreadPriorityToNativePriority(const ThreadPriority& priority)
     throw std::range_error("Priority not found");
   }
 }
+
+void LogProcessPriorityClass()
+{
+  const DWORD prioClass = GetPriorityClass(GetCurrentProcess());
+
+  if (prioClass == 0)
+  {
+    CLog::LogF(LOGERROR, "unable to retrieve the process priority class ({})", GetLastError());
+    return;
+  }
+
+  if (const auto it = priorityClasses.find(prioClass); it != priorityClasses.end())
+    CLog::Log(LOGDEBUG, "[threads] app priority: {}", it->second);
+  else
+    CLog::Log(LOGDEBUG, "[threads] app priority: unrecognized (0x{:08X})", prioClass);
+}
+
+std::once_flag flag;
 
 } // namespace
 
@@ -90,16 +125,33 @@ void CThreadImplWin::SetThreadInfo(const std::string& name)
     }
   }
 
-  CWIN32Util::SetThreadLocalLocale(true); // avoid crashing with setlocale(), see https://connect.microsoft.com/VisualStudio/feedback/details/794122
+  // avoid crashing with setlocale(), see https://connect.microsoft.com/VisualStudio/feedback/details/794122
+  CWIN32Util::SetThreadLocalLocale(true);
+
+  m_name = name;
 }
 
 bool CThreadImplWin::SetPriority(const ThreadPriority& priority)
 {
+  std::call_once(flag, LogProcessPriorityClass);
+
   bool bReturn = false;
 
   std::unique_lock lock(m_criticalSection);
   if (m_handle)
-    bReturn = SetThreadPriority(m_handle, ThreadPriorityToNativePriority(priority)) == TRUE;
+  {
+    const NativeThreadPriority native = ThreadPriorityToNativePriority(priority);
 
+    if (SetThreadPriority(m_handle, native.priority) == 0)
+    {
+      CLog::LogF(LOGERROR, "unable to set the priority of thread {} ({})", m_name, GetLastError());
+      bReturn = false;
+    }
+    else
+    {
+      CLog::Log(LOGDEBUG, "[threads] name: '{}' priority: {}", m_name, native.name);
+      bReturn = true;
+    }
+  }
   return bReturn;
 }

--- a/xbmc/platform/win32/threads/ThreadImplWin.h
+++ b/xbmc/platform/win32/threads/ThreadImplWin.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -24,4 +24,5 @@ public:
 
 private:
   CCriticalSection m_criticalSection;
+  std::string m_name;
 };

--- a/xbmc/platform/win32/threads/ThreadImplWin.h
+++ b/xbmc/platform/win32/threads/ThreadImplWin.h
@@ -11,6 +11,8 @@
 #include "threads/IThreadImpl.h"
 #include "threads/SingleLock.h"
 
+#include <string>
+
 class CThreadImplWin : public IThreadImpl
 {
 public:
@@ -22,7 +24,12 @@ public:
 
   bool SetPriority(const ThreadPriority& priority) override;
 
+  bool SetTask(const ThreadTask& task) override;
+  bool RevertTask() override;
+
 private:
   CCriticalSection m_criticalSection;
   std::string m_name;
+  HANDLE m_hTask{0};
+  DWORD m_taskIndex{0};
 };

--- a/xbmc/threads/IThreadImpl.h
+++ b/xbmc/threads/IThreadImpl.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2022 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -32,6 +32,19 @@ public:
    *
    */
   virtual bool SetPriority(const ThreadPriority& priority) = 0;
+
+  /*!
+   * \brief Assign the current thread a task for OS scheduling (platform dependent)
+   * \param[in] task Type of task
+   * \return true for success, false for failure
+   */
+  virtual bool SetTask(const ThreadTask& task) { return true; }
+
+  /*!
+   * \brief Revert the current thread to normal scheduling (platform dependent)
+   * \return true for success, false for failure
+   */
+  virtual bool RevertTask() { return true; }
 
 protected:
   IThreadImpl(std::thread::native_handle_type handle) : m_handle(handle) {}

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -1,7 +1,7 @@
 /*
  *  Copyright (c) 2002 Frodo
  *      Portions Copyright (c) by the authors of ffmpeg and xvid
- *  Copyright (C) 2002-2018 Team Kodi
+ *  Copyright (C) 2002-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -195,6 +195,16 @@ bool CThread::IsRunning() const
 bool CThread::SetPriority(const ThreadPriority& priority)
 {
   return m_impl->SetPriority(priority);
+}
+
+bool CThread::SetTask(const ThreadTask& task)
+{
+  return m_impl->SetTask(task);
+}
+
+bool CThread::RevertTask()
+{
+  return m_impl->RevertTask();
 }
 
 bool CThread::IsAutoDelete() const

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -37,6 +37,11 @@ enum class ThreadPriority
    *
    */
   PRIORITY_COUNT,
+};
+
+enum class ThreadTask
+{
+  AUDIO,
 };
 
 class IRunnable;
@@ -78,6 +83,19 @@ public:
    *
    */
   bool SetPriority(const ThreadPriority& priority);
+
+  /*!
+   * \brief Assign the current thread a task for OS scheduling (platform dependent)
+   * \param[in] task Type of task
+   * \return true for success, false for failure
+   */
+  bool SetTask(const ThreadTask& task);
+
+  /*!
+   * \brief Revert the current thread to normal scheduling (platform dependent)
+   * \return true for success, false for failure
+   */
+  bool RevertTask();
 
   static CThread* GetCurrentThread();
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

PR split from #27719, see some initial discussion there.

Created methods SetTask/RevertTask to register/unregister audio threads that needs guaranteed timely access to the CPU.
note: the functions must be called by the thread itself, unlike SetPriority

In the future a similar change could be applied to the threads that use the GPU (MMCSS task Playback)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Add application/thread priority logging similar to linux
Have the AE sink thread use MMCSS to guarantee CPU access, per MS recommendations.

It doesn't change anything on powerful system but could make a difference on constrained boxes.

MS documentation leads to think that the system takes care of increasing thread priorities when using audio APIs, but that's only true for the related system threads, not user threads, as testing revealed. See the screenshots.
The presence of the elevated system threads can be confusing in Process Explorer.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Checked thread priority with Process Explorer for all sinks.
Windows 10: played some media and didn't notice anything unusual.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Theoretically more reliable audio (no underruns) on less powerful systems.

## Screenshots (if appropriate):

With the PR, one run covering all sinks.
New lines in the log and we can see that the sink thread number is 8828:
```
2026-01-25 10:16:35.107 T:14436   debug <general>: Thread ActiveAE start, auto delete: false
2026-01-25 10:16:35.108 T:8828    debug <general>: Thread AESink start, auto delete: false
2026-01-25 10:16:35.108 T:14436   debug <general>: [threads] name: 'AESink' priority: above normal
2026-01-25 10:16:35.108 T:8828   debug <general>: [threads] name: 'AESink' task: Audio
```

WASAPI (Win 10 screenshot - Win 11 adds a system thread of slightly higher priority)
<img width="917" height="77" alt="image" src="https://github.com/user-attachments/assets/8c58c02c-5cea-493e-8c7a-e614937a7224" />

XAudio - a system thread at a slightly higher priority than the sink
<img width="1038" height="55" alt="image" src="https://github.com/user-attachments/assets/093b41ce-84f3-4eee-ba40-f490908960d6" />

DirectSound - a few additional system threads surround the sink
<img width="919" height="149" alt="image" src="https://github.com/user-attachments/assets/d0c388ff-7a05-4275-8583-4de7c66da932" />


Before the PR: AE sink thread at above normal priority, the system xaudio thread has Audio priority.
in that run, the audio sink thread is 5188.
<img width="918" height="111" alt="image" src="https://github.com/user-attachments/assets/a1ddb6f1-4367-4309-ad80-3f9976dac6d5" />


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
FreeBSD unit tests failure created by other PR.