### PR TITLE
[Windows] D3D11 Implementation of Front to Back Rendering

### DIFF
--- a/system/shaders/convolution_d3d.fx
+++ b/system/shaders/convolution_d3d.fx
@@ -51,7 +51,7 @@ VS_OUTPUT VS(VS_INPUT In)
   VS_OUTPUT output  = (VS_OUTPUT)0;
   output.Position.x =  (In.Position.x / (g_viewPort.x  / 2.0)) - 1;
   output.Position.y = -(In.Position.y / (g_viewPort.y / 2.0)) + 1;
-  output.Position.z = output.Position.z;
+  output.Position.z = 0;
   output.Position.w = 1.0;
   output.TextureUV  = In.TextureUV;
 

--- a/system/shaders/guishader_common.hlsl
+++ b/system/shaders/guishader_common.hlsl
@@ -51,6 +51,7 @@ cbuffer cbWorld : register(b0)
   float colorRange;
   float sdrPeakLum;
   int PQ;
+  float depth;
 };
 
 inline float3 transferPQ(float3 x)

--- a/system/shaders/guishader_vert.hlsl
+++ b/system/shaders/guishader_vert.hlsl
@@ -24,6 +24,7 @@ PS_INPUT VS(VS_INPUT input)
 {
   PS_INPUT output = (PS_INPUT)0;
   output.pos   = mul(input.pos, worldViewProj);
+  output.pos.z = depth * output.pos.w;
   output.color = input.color;
   output.tex   = input.tex;
   output.tex2  = input.tex2;

--- a/system/shaders/rp_output_d3d.fx
+++ b/system/shaders/rp_output_d3d.fx
@@ -53,7 +53,7 @@ VS_OUTPUT OUTPUT_VS(VS_INPUT In)
   VS_OUTPUT output  = (VS_OUTPUT)0;
   output.Position.x =  (In.Position.x / (g_viewPort.x  / 2.0)) - 1;
   output.Position.y = -(In.Position.y / (g_viewPort.y / 2.0)) + 1;
-  output.Position.z = output.Position.z;
+  output.Position.z = 0;
   output.Position.w = 1.0;
   output.TextureUV  = In.TextureUV;
 

--- a/system/shaders/yuv2rgb_d3d.fx
+++ b/system/shaders/yuv2rgb_d3d.fx
@@ -54,7 +54,7 @@ VS_OUTPUT VS(VS_INPUT In)
   VS_OUTPUT output = (VS_OUTPUT)0;
   output.Position.x =  (In.Position.x / (g_viewPort.x  / 2.0)) - 1;
   output.Position.y = -(In.Position.y / (g_viewPort.y / 2.0)) + 1;
-  output.Position.z = output.Position.z;
+  output.Position.z = 0;
   output.Position.w = 1.0;
   output.TextureY   = In.TextureY;
   output.TextureUV  = In.TextureUV;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererGuiTexture.cpp
@@ -140,6 +140,7 @@ void CRPRendererGuiTexture::RenderInternal(bool clear, uint8_t alpha)
     auto dxTexture = static_cast<CDXTexture*>(renderBuffer->GetTexture());
     ID3D11ShaderResourceView* shaderRes = dxTexture->GetShaderResource();
     pGUIShader->SetShaderViews(1, &shaderRes);
+    pGUIShader->SetDepth(-1.f);
     pGUIShader->DrawQuad(vertex[0], vertex[1], vertex[2], vertex[3]);
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererDX.cpp
@@ -191,6 +191,7 @@ void COverlayQuadsDX::Render(SRenderState &state)
   pContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
   DX::Windowing()->SetAlphaBlendEnable(true);
+  pGUIShader->SetDepth(-1.f);
   pGUIShader->Begin(SHADER_METHOD_RENDER_FONT);
 
   pGUIShader->SetShaderViews(1, m_texture.GetAddressOfSRV());
@@ -356,6 +357,7 @@ void COverlayImageDX::Render(SRenderState &state)
   pContext->IASetVertexBuffers(0, 1, &vertexBuffer, &stride, &offset);
   pContext->IASetPrimitiveTopology(D3D10_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
 
+  pGUIShader->SetDepth(-1.f);
   pGUIShader->Begin(SHADER_METHOD_RENDER_TEXTURE_NOBLEND);
   DX::Windowing()->SetAlphaBlendEnable(true);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2007-2018 Team Kodi
+ *  Copyright (C) 2007-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -29,6 +29,13 @@ using namespace DirectX;
 
 class CWinShader
 {
+public:
+  /*!
+   * Set to true for the shader at the end of the chain that outputs to the back buffer.
+   * This will ensure that the depth buffer is bound.
+   */
+  void SetFinalShader(bool final) { m_isFinalShader = final; }
+
 protected:
   CWinShader() = default;
   virtual ~CWinShader() = default;
@@ -45,13 +52,14 @@ protected:
   CD3DTexture* m_target = nullptr;
 
 private:
-  void SetTarget(CD3DTexture* target);
+  void SetTarget(CD3DTexture* target, ID3D11DepthStencilView* dsv);
 
   CD3DBuffer m_vb;
   CD3DBuffer m_ib;
   unsigned int m_vbsize = 0;
   unsigned int m_vertsize = 0;
   Microsoft::WRL::ComPtr<ID3D11InputLayout> m_inputLayout = nullptr;
+  bool m_isFinalShader{false};
 };
 
 class COutputShader : public CWinShader

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -56,6 +56,8 @@ protected:
   int NextBuffer() const;
   CRendererBase* SelectRenderer(const VideoPicture &picture);
   CRect GetScreenRect() const;
+  void ClearBackBuffer() const;
+  void ClearBackBufferQuad() const;
 
   bool m_bConfigured = false;
   std::unique_ptr<CRendererBase> m_renderer;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- *  Copyright (C) 2017-2019 Team Kodi
+ *  Copyright (C) 2017-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -444,9 +444,11 @@ void CRendererBase::UpdateVideoFilters()
       CLog::LogF(LOGDEBUG, "unable to create output shader.");
       m_outputShader.reset();
     }
-    else if (m_pLUTView && m_lutSize)
+    else
     {
-      m_outputShader->SetLUT(m_lutSize, m_pLUTView.Get());
+      m_outputShader->SetFinalShader(true);
+      if (m_pLUTView && m_lutSize)
+        m_outputShader->SetLUT(m_lutSize, m_pLUTView.Get());
     }
   }
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererHQ.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererHQ.cpp
@@ -1,5 +1,5 @@
 ﻿/*
- *  Copyright (C) 2017-2019 Team Kodi
+ *  Copyright (C) 2017-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -137,6 +137,8 @@ void CRendererHQ::UpdateVideoFilters()
       }
     }
   }
+  if (m_scalerShader)
+    m_scalerShader->SetFinalShader(true);
 }
 
 void CRendererHQ::FinalOutput(CD3DTexture& source, CD3DTexture& target, const CRect& sourceRect, const CPoint(&destPoints)[4])

--- a/xbmc/guilib/D3DResource.cpp
+++ b/xbmc/guilib/D3DResource.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -488,7 +488,8 @@ void CD3DTexture::DrawQuad(const CPoint points[4],
                            KODI::UTILS::COLOR::Color color,
                            CD3DTexture* texture,
                            const CRect* texCoords,
-                           SHADER_METHOD options)
+                           SHADER_METHOD options,
+                           float depth)
 {
   unsigned numViews = 0;
   ID3D11ShaderResourceView* views = nullptr;
@@ -499,23 +500,23 @@ void CD3DTexture::DrawQuad(const CPoint points[4],
     views = texture->GetShaderResource();
   }
 
-  DrawQuad(points, color, numViews, &views, texCoords, options);
+  DrawQuad(points, color, numViews, &views, texCoords, options, depth);
 }
 
 void CD3DTexture::DrawQuad(const CRect& rect,
                            KODI::UTILS::COLOR::Color color,
                            CD3DTexture* texture,
                            const CRect* texCoords,
-                           SHADER_METHOD options)
+                           SHADER_METHOD options,
+                           float depth)
 {
-  CPoint points[] =
-  {
-    { rect.x1, rect.y1 },
-    { rect.x2, rect.y1 },
-    { rect.x2, rect.y2 },
-    { rect.x1, rect.y2 },
+  CPoint points[] = {
+      {rect.x1, rect.y1},
+      {rect.x2, rect.y1},
+      {rect.x2, rect.y2},
+      {rect.x1, rect.y2},
   };
-  DrawQuad(points, color, texture, texCoords, options);
+  DrawQuad(points, color, texture, texCoords, options, depth);
 }
 
 void CD3DTexture::DrawQuad(const CPoint points[4],
@@ -523,24 +524,28 @@ void CD3DTexture::DrawQuad(const CPoint points[4],
                            unsigned numViews,
                            ID3D11ShaderResourceView** view,
                            const CRect* texCoords,
-                           SHADER_METHOD options)
+                           SHADER_METHOD options,
+                           float depth)
 {
   XMFLOAT4 xcolor;
   CD3DHelper::XMStoreColor(&xcolor, color);
   CRect coords = texCoords ? *texCoords : CRect(0.0f, 0.0f, 1.0f, 1.0f);
 
+  // clang-format off
   Vertex verts[4] = {
     { XMFLOAT3(points[0].x, points[0].y, 0), xcolor, XMFLOAT2(coords.x1, coords.y1), XMFLOAT2(0.0f, 0.0f) },
     { XMFLOAT3(points[1].x, points[1].y, 0), xcolor, XMFLOAT2(coords.x2, coords.y1), XMFLOAT2(0.0f, 0.0f) },
     { XMFLOAT3(points[2].x, points[2].y, 0), xcolor, XMFLOAT2(coords.x2, coords.y2), XMFLOAT2(0.0f, 0.0f) },
     { XMFLOAT3(points[3].x, points[3].y, 0), xcolor, XMFLOAT2(coords.x1, coords.y2), XMFLOAT2(0.0f, 0.0f) },
   };
+  // clang-format on
 
   CGUIShaderDX* pGUIShader = DX::Windowing()->GetGUIShader();
 
   pGUIShader->Begin(view && numViews > 0 ? options : SHADER_METHOD_RENDER_DEFAULT);
   if (view && numViews > 0)
     pGUIShader->SetShaderViews(numViews, view);
+  pGUIShader->SetDepth(depth);
   pGUIShader->DrawQuad(verts[0], verts[1], verts[2], verts[3]);
 }
 
@@ -549,16 +554,16 @@ void CD3DTexture::DrawQuad(const CRect& rect,
                            unsigned numViews,
                            ID3D11ShaderResourceView** view,
                            const CRect* texCoords,
-                           SHADER_METHOD options)
+                           SHADER_METHOD options,
+                           float depth)
 {
-  CPoint points[] =
-  {
-    { rect.x1, rect.y1 },
-    { rect.x2, rect.y1 },
-    { rect.x2, rect.y2 },
-    { rect.x1, rect.y2 },
+  CPoint points[] = {
+      {rect.x1, rect.y1},
+      {rect.x2, rect.y1},
+      {rect.x2, rect.y2},
+      {rect.x1, rect.y2},
   };
-  DrawQuad(points, color, numViews, view, texCoords, options);
+  DrawQuad(points, color, numViews, view, texCoords, options, depth);
 }
 
 CD3DEffect::CD3DEffect()

--- a/xbmc/guilib/D3DResource.h
+++ b/xbmc/guilib/D3DResource.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -121,27 +121,31 @@ public:
                        KODI::UTILS::COLOR::Color color,
                        CD3DTexture* texture,
                        const CRect* texCoords,
-                       SHADER_METHOD options = SHADER_METHOD_RENDER_TEXTURE_BLEND);
+                       SHADER_METHOD options,
+                       float depth);
 
   static void DrawQuad(const CPoint points[4],
                        KODI::UTILS::COLOR::Color color,
                        unsigned numViews,
                        ID3D11ShaderResourceView** view,
                        const CRect* texCoords,
-                       SHADER_METHOD options = SHADER_METHOD_RENDER_TEXTURE_BLEND);
+                       SHADER_METHOD options,
+                       float depth);
 
   static void DrawQuad(const CRect& coords,
                        KODI::UTILS::COLOR::Color color,
                        CD3DTexture* texture,
                        const CRect* texCoords,
-                       SHADER_METHOD options = SHADER_METHOD_RENDER_TEXTURE_BLEND);
+                       SHADER_METHOD options,
+                       float depth);
 
   static void DrawQuad(const CRect& coords,
                        KODI::UTILS::COLOR::Color color,
                        unsigned numViews,
                        ID3D11ShaderResourceView** view,
                        const CRect* texCoords,
-                       SHADER_METHOD options = SHADER_METHOD_RENDER_TEXTURE_BLEND);
+                       SHADER_METHOD options,
+                       float depth);
 
   void OnDestroyDevice(bool fatal) override;
   void OnCreateDevice() override;

--- a/xbmc/guilib/GUIFontTTFDX.cpp
+++ b/xbmc/guilib/GUIFontTTFDX.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -91,6 +91,8 @@ void CGUIFontTTFDX::LastEnd()
   unsigned int stride = sizeof(SVertex);
 
   CGUIShaderDX* pGUIShader = DX::Windowing()->GetGUIShader();
+  pGUIShader->SetDepth(CServiceBroker::GetWinSystem()->GetGfxContext().GetTransformDepth());
+
   // Set font texture as shader resource
   pGUIShader->SetShaderViews(1, m_speedupTexture->GetAddressOfSRV());
   // Enable alpha blend

--- a/xbmc/guilib/GUIShaderDX.cpp
+++ b/xbmc/guilib/GUIShaderDX.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -339,6 +339,12 @@ void CGUIShaderDX::SetProjection(const XMMATRIX &value)
   m_cbWorldViewProj.projection = value;
 }
 
+void CGUIShaderDX::SetDepth(const float depth)
+{
+  m_bIsWVPDirty = true;
+  m_depth = depth;
+}
+
 void CGUIShaderDX::ApplyChanges(void)
 {
   ComPtr<ID3D11DeviceContext> pContext = DX::DeviceResources::Get()->GetD3DContext();
@@ -359,6 +365,8 @@ void CGUIShaderDX::ApplyChanges(void)
         buffer->sdrPeakLum = 10000.0f / DX::Windowing()->GetGuiSdrPeakLuminance();
       buffer->PQ = (DX::Windowing()->IsTransferPQ() ? 1 : 0);
 
+      // Translate from GL convention (-1 far 1 near) to D3D (0 far 1 near)
+      buffer->depth = m_depth / 2.f + 0.5f;
       pContext->Unmap(m_pWVPBuffer.Get(), 0);
       m_bIsWVPDirty = false;
     }

--- a/xbmc/guilib/GUIShaderDX.h
+++ b/xbmc/guilib/GUIShaderDX.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -63,6 +63,12 @@ public:
   void XM_CALLCONV SetProjection(const DirectX::XMMATRIX &value);
   void Project(float& x, float& y, float& z) const;
 
+  /*!
+   * \brief Sets the depth value of the primitives to be drawn (overrides z of the vertices)
+   * \param[in] depth value -1=far to 1=near (GL convention).
+   */
+  void SetDepth(float depth);
+
   void DrawQuad(Vertex& v1, Vertex& v2, Vertex& v3, Vertex& v4);
   void DrawIndexed(unsigned int indexCount, unsigned int startIndex, unsigned int startVertex);
   void Draw(unsigned int vertexCount, unsigned int startVertex);
@@ -108,6 +114,7 @@ private:
     float colorRange;
     float sdrPeakLum;
     int PQ;
+    float depth;
   };
 
   void Release(void);
@@ -120,6 +127,7 @@ private:
   // GUI constants
   cbViewPort m_cbViewPort = {};
   cbWorldViewProj m_cbWorldViewProj = {};
+  float m_depth = 1.f;
 
   bool  m_bCreated;
   size_t m_currentShader;

--- a/xbmc/guilib/GUITextureD3D.cpp
+++ b/xbmc/guilib/GUITextureD3D.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -139,6 +139,7 @@ void CGUITextureD3D::Draw(float *x, float *y, float *z, const CRect &texture, co
     ID3D11ShaderResourceView* resource = tex->GetShaderResource();
     pGUIShader->SetShaderViews(1, &resource);
   }
+  pGUIShader->SetDepth(m_depth);
   pGUIShader->DrawQuad(verts[0], verts[1], verts[2], verts[3]);
 }
 
@@ -156,8 +157,10 @@ void CGUITextureD3D::DrawQuad(const CRect& rect,
   {
     texture->LoadToGPU();
     numViews = 1;
-    views = ((CDXTexture *)texture)->GetShaderResource();
+    views = ((CDXTexture*)texture)->GetShaderResource();
   }
 
-  CD3DTexture::DrawQuad(rect, color, numViews, &views, texCoords, texture ? SHADER_METHOD_RENDER_TEXTURE_BLEND : SHADER_METHOD_RENDER_DEFAULT);
+  CD3DTexture::DrawQuad(rect, color, numViews, &views, texCoords,
+                        texture ? SHADER_METHOD_RENDER_TEXTURE_BLEND : SHADER_METHOD_RENDER_DEFAULT,
+                        depth);
 }

--- a/xbmc/guilib/GUITextureD3D.h
+++ b/xbmc/guilib/GUITextureD3D.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later

--- a/xbmc/pictures/SlideShowPictureDX.cpp
+++ b/xbmc/pictures/SlideShowPictureDX.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -79,7 +79,7 @@ void CSlideShowPicDX::Render(float* x,
 
   CGUIShaderDX* pGUIShader = DX::Windowing()->GetGUIShader();
   pGUIShader->Begin(SHADER_METHOD_RENDER_TEXTURE_BLEND);
-
+  pGUIShader->SetDepth(-1.f);
   // Set state to render the image
   if (pTexture)
   {

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -21,11 +21,11 @@
  *   This interface is very basic since a lot of the actual details will go in to the derived classes
  */
 
-enum DEPTH_CULLING
+enum class DEPTH_CULLING
 {
-  DEPTH_CULLING_OFF = 0,
-  DEPTH_CULLING_BACK_TO_FRONT,
-  DEPTH_CULLING_FRONT_TO_BACK,
+  OFF,
+  BACK_TO_FRONT,
+  FRONT_TO_BACK,
 };
 
 class CGUIImage;

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -1027,7 +1027,8 @@ void DX::DeviceResources::Present()
 
 void DX::DeviceResources::ClearDepthStencil() const
 {
-  m_deferrContext->ClearDepthStencilView(m_d3dDepthStencilView.Get(), D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0, 0);
+  const UINT flags = D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL;
+  m_deferrContext->ClearDepthStencilView(m_d3dDepthStencilView.Get(), flags, 0.0f, 0);
 }
 
 void DX::DeviceResources::ClearRenderTarget(ID3D11RenderTargetView* pRTView, float color[4]) const

--- a/xbmc/rendering/dx/DeviceResources.cpp
+++ b/xbmc/rendering/dx/DeviceResources.cpp
@@ -223,15 +223,8 @@ void DX::DeviceResources::GetDisplayMode(DXGI_MODE_DESC* mode) const
 void DX::DeviceResources::SetViewPort(D3D11_VIEWPORT& viewPort) const
 {
   // convert logical viewport to real
-  D3D11_VIEWPORT realViewPort =
-  {
-    viewPort.TopLeftX,
-    viewPort.TopLeftY,
-    viewPort.Width,
-    viewPort.Height,
-    viewPort.MinDepth,
-    viewPort.MinDepth
-  };
+  D3D11_VIEWPORT realViewPort = {viewPort.TopLeftX, viewPort.TopLeftY, viewPort.Width,
+                                 viewPort.Height,   viewPort.MinDepth, viewPort.MaxDepth};
 
   m_deferrContext->RSSetViewports(1, &realViewPort);
 }

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -7,9 +7,9 @@
  */
 #include "RenderSystemDX.h"
 
+#include "ServiceBroker.h"
 #include "application/Application.h"
 
-#include <mutex>
 #if defined(TARGET_WINDOWS_DESKTOP)
 #include "cores/RetroPlayer/process/windows/RPProcessInfoWin.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h"
@@ -22,18 +22,23 @@
 #include "cores/VideoPlayer/Process/windows/ProcessInfoWin.h"
 #endif
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
-#include "cores/VideoPlayer/VideoRenderers/WinRenderer.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
+#include "cores/VideoPlayer/VideoRenderers/WinRenderer.h"
 #include "guilib/D3DResource.h"
 #include "guilib/GUIShaderDX.h"
 #include "guilib/GUITextureD3D.h"
 #include "guilib/GUIWindowManager.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/MathUtils.h"
 #include "utils/log.h"
 
+#include <mutex>
+
 #include <DirectXPackedVector.h>
 
-extern "C" {
+extern "C"
+{
 #include <libavutil/pixfmt.h>
 }
 
@@ -138,6 +143,8 @@ bool CRenderSystemDX::DestroyRenderSystem()
   m_RSScissorDisable = nullptr;
   m_RSScissorEnable = nullptr;
   m_depthStencilState = nullptr;
+  m_depthStencilStateRO = nullptr;
+  m_depthStencilStateRW = nullptr;
 
   return true;
 }
@@ -208,6 +215,19 @@ bool CRenderSystemDX::CreateStates()
   if(FAILED(hr))
     return false;
 
+  // Front to back pass - read & write depth
+  depthStencilDesc.DepthEnable = true;
+  depthStencilDesc.DepthFunc = D3D11_COMPARISON_GREATER;
+  if (FAILED(m_pD3DDev->CreateDepthStencilState(&depthStencilDesc, &m_depthStencilStateRW)))
+    return false;
+
+  // Back to front pass - read depth, don't write it
+  depthStencilDesc.DepthWriteMask = D3D11_DEPTH_WRITE_MASK_ZERO;
+  depthStencilDesc.DepthFunc = D3D11_COMPARISON_GREATER_EQUAL;
+
+  if (FAILED(m_pD3DDev->CreateDepthStencilState(&depthStencilDesc, &m_depthStencilStateRO)))
+    return false;
+
   // Set the depth stencil state.
   m_pContext->OMSetDepthStencilState(m_depthStencilState.Get(), 0);
 
@@ -275,7 +295,7 @@ void CRenderSystemDX::PresentRender(bool rendered, bool videoLayer)
                            ? SHADER_METHOD_RENDER_STEREO_INTERLACED_RIGHT
                            : SHADER_METHOD_RENDER_STEREO_CHECKERBOARD_RIGHT;
     SetAlphaBlendEnable(true);
-    CD3DTexture::DrawQuad(destRect, 0, &m_rightEyeTex, nullptr, method);
+    CD3DTexture::DrawQuad(destRect, 0, &m_rightEyeTex, nullptr, method, 1.f);
     CD3DHelper::PSClearShaderResources(m_pContext);
   }
 
@@ -326,6 +346,28 @@ bool CRenderSystemDX::EndRender()
   return true;
 }
 
+void CRenderSystemDX::InvalidateColorBuffer()
+{
+  if (!m_bRenderCreated)
+    return;
+
+  /* clear is not affected by stipple pattern, so we can only clear on first frame */
+  if (m_stereoMode == RENDER_STEREO_MODE_INTERLACED && m_stereoView == RENDER_STEREO_VIEW_RIGHT)
+    return;
+
+  // some platforms prefer a clear, instead of rendering over
+  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiGeometryClear)
+  {
+    ClearBuffers(0);
+    return;
+  }
+
+  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiFrontToBackRendering)
+    return;
+
+  m_deviceResources->ClearDepthStencil();
+}
+
 bool CRenderSystemDX::ClearBuffers(KODI::UTILS::COLOR::Color color)
 {
   if (!m_bRenderCreated)
@@ -335,8 +377,7 @@ bool CRenderSystemDX::ClearBuffers(KODI::UTILS::COLOR::Color color)
   CD3DHelper::XMStoreColor(fColor, color);
   ID3D11RenderTargetView* pRTView = m_deviceResources->GetBackBuffer().GetRenderTarget();
 
-  if ( m_stereoMode != RENDER_STEREO_MODE_OFF
-    && m_stereoMode != RENDER_STEREO_MODE_MONO)
+  if (m_stereoMode != RENDER_STEREO_MODE_OFF && m_stereoMode != RENDER_STEREO_MODE_MONO)
   {
     // if stereo anaglyph/tab/sbs, data was cleared when left view was rendered
     if (m_stereoView == RENDER_STEREO_VIEW_RIGHT)
@@ -345,46 +386,47 @@ bool CRenderSystemDX::ClearBuffers(KODI::UTILS::COLOR::Color color)
       m_deviceResources->FinishCommandList();
 
       // do not clear RT for anaglyph modes
-      if ( m_stereoMode == RENDER_STEREO_MODE_ANAGLYPH_GREEN_MAGENTA
-        || m_stereoMode == RENDER_STEREO_MODE_ANAGLYPH_RED_CYAN
-        || m_stereoMode == RENDER_STEREO_MODE_ANAGLYPH_YELLOW_BLUE)
+      if (m_stereoMode == RENDER_STEREO_MODE_ANAGLYPH_GREEN_MAGENTA ||
+          m_stereoMode == RENDER_STEREO_MODE_ANAGLYPH_RED_CYAN ||
+          m_stereoMode == RENDER_STEREO_MODE_ANAGLYPH_YELLOW_BLUE)
       {
         pRTView = nullptr;
       }
       // for interlaced/checkerboard clear view for right texture
-      else if (m_stereoMode == RENDER_STEREO_MODE_INTERLACED
-            || m_stereoMode == RENDER_STEREO_MODE_CHECKERBOARD)
+      else if (m_stereoMode == RENDER_STEREO_MODE_INTERLACED ||
+               m_stereoMode == RENDER_STEREO_MODE_CHECKERBOARD)
       {
         pRTView = m_rightEyeTex.GetRenderTarget();
       }
     }
   }
 
-  if (pRTView == nullptr)
-    return true;
-
-  auto outputSize = m_deviceResources->GetOutputSize();
-  CRect clRect(0.0f, 0.0f,
-    static_cast<float>(outputSize.Width),
-    static_cast<float>(outputSize.Height));
-
-  // Unlike Direct3D 9, D3D11 ClearRenderTargetView always clears full extent of the resource view.
-  // Viewport and scissor settings are not applied. So clear RT by drawing full sized rect with clear color
-  if (m_ScissorsEnabled && m_scissor != clRect)
+  if (pRTView)
   {
-    bool alphaEnabled = m_BlendEnabled;
-    if (alphaEnabled)
-      SetAlphaBlendEnable(false);
+    const auto outputSize = m_deviceResources->GetOutputSize();
+    CRect clRect(0.0f, 0.0f, static_cast<float>(outputSize.Width),
+                 static_cast<float>(outputSize.Height));
 
-    CGUITextureD3D::DrawQuad(clRect, color);
+    // Unlike Direct3D 9, D3D11 ClearRenderTargetView always clears full extent of the resource view.
+    // Viewport and scissor settings are not applied. So clear RT by drawing full sized rect with clear color
+    if (m_ScissorsEnabled && m_scissor != clRect)
+    {
+      bool alphaEnabled = m_BlendEnabled;
+      if (alphaEnabled)
+        SetAlphaBlendEnable(false);
 
-    if (alphaEnabled)
-      SetAlphaBlendEnable(true);
+      CGUITextureD3D::DrawQuad(clRect, color);
+
+      if (alphaEnabled)
+        SetAlphaBlendEnable(true);
+    }
+    else
+      m_deviceResources->ClearRenderTarget(pRTView, fColor);
   }
-  else
-    m_deviceResources->ClearRenderTarget(pRTView, fColor);
 
-  m_deviceResources->ClearDepthStencil();
+  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiFrontToBackRendering)
+    m_deviceResources->ClearDepthStencil();
+
   return true;
 }
 
@@ -402,9 +444,10 @@ void CRenderSystemDX::ApplyStateBlock()
   auto m_pContext = m_deviceResources->GetD3DContext();
 
   m_pContext->RSSetState(m_ScissorsEnabled ? m_RSScissorEnable.Get() : m_RSScissorDisable.Get());
-  m_pContext->OMSetDepthStencilState(m_depthStencilState.Get(), 0);
+  m_pContext->OMSetDepthStencilState(GetDepthStencilState(), 0);
   float factors[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
-  m_pContext->OMSetBlendState(m_BlendEnabled ? m_BlendEnableState.Get() : m_BlendDisableState.Get(), factors, 0xFFFFFFFF);
+  m_pContext->OMSetBlendState(m_BlendEnabled ? m_BlendEnableState.Get() : m_BlendDisableState.Get(),
+                              factors, 0xFFFFFFFF);
 
   m_pGUIShader->ApplyStateBlock();
 }
@@ -539,6 +582,28 @@ void CRenderSystemDX::ResetScissors()
 
   m_pContext->RSSetState(m_RSScissorDisable.Get());
   m_ScissorsEnabled = false;
+}
+
+ID3D11DepthStencilState* CRenderSystemDX::GetDepthStencilState()
+{
+  switch (m_depthCulling)
+  {
+    case DEPTH_CULLING::BACK_TO_FRONT:
+      return m_depthStencilStateRO.Get();
+    case DEPTH_CULLING::FRONT_TO_BACK:
+      return m_depthStencilStateRW.Get();
+    default:
+      return m_depthStencilState.Get();
+  }
+}
+
+void CRenderSystemDX::SetDepthCulling(DEPTH_CULLING culling)
+{
+  if (!m_bRenderCreated)
+    return;
+
+  m_depthCulling = culling;
+  m_deviceResources->GetD3DContext()->OMSetDepthStencilState(GetDepthStencilState(), 0);
 }
 
 void CRenderSystemDX::OnDXDeviceLost()

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -34,6 +34,7 @@ public:
   bool BeginRender() override;
   bool EndRender() override;
   void PresentRender(bool rendered, bool videoLayer) override;
+  void InvalidateColorBuffer() override;
   bool ClearBuffers(KODI::UTILS::COLOR::Color color) override;
   void SetViewPort(const CRect& viewPort) override;
   void GetViewPort(CRect& viewPort) override;
@@ -42,6 +43,7 @@ public:
   bool ScissorsCanEffectClipping() override;
   void SetScissors(const CRect &rect) override;
   void ResetScissors() override;
+  void SetDepthCulling(DEPTH_CULLING culling) override;
   void CaptureStateBlock() override;
   void ApplyStateBlock() override;
   void SetCameraPosition(const CPoint &camera, int screenWidth, int screenHeight, float stereoFactor = 0.f) override;
@@ -77,6 +79,7 @@ protected:
   void OnResize();
   void CheckInterlacedStereoView(void);
   void CheckDeviceCaps();
+  ID3D11DepthStencilState* GetDepthStencilState();
 
   CCriticalSection m_resourceSection;
   CCriticalSection m_decoderSection;
@@ -89,6 +92,9 @@ protected:
   CRect m_scissor;
   CGUIShaderDX* m_pGUIShader{ nullptr };
   Microsoft::WRL::ComPtr<ID3D11DepthStencilState> m_depthStencilState;
+  Microsoft::WRL::ComPtr<ID3D11DepthStencilState> m_depthStencilStateRO;
+  Microsoft::WRL::ComPtr<ID3D11DepthStencilState> m_depthStencilStateRW;
+
   Microsoft::WRL::ComPtr<ID3D11BlendState> m_BlendEnableState;
   Microsoft::WRL::ComPtr<ID3D11BlendState> m_BlendDisableState;
   Microsoft::WRL::ComPtr<ID3D11RasterizerState> m_RSScissorDisable;
@@ -100,5 +106,5 @@ protected:
   XbmcThreads::ConditionVariable m_decodingEvent;
 
   std::shared_ptr<DX::DeviceResources> m_deviceResources;
+  DEPTH_CULLING m_depthCulling{DEPTH_CULLING::OFF};
 };
-

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -555,18 +555,18 @@ void CRenderSystemGL::ResetScissors()
 
 void CRenderSystemGL::SetDepthCulling(DEPTH_CULLING culling)
 {
-  if (culling == DEPTH_CULLING_OFF)
+  if (culling == DEPTH_CULLING::OFF)
   {
     glDisable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
   }
-  else if (culling == DEPTH_CULLING_BACK_TO_FRONT)
+  else if (culling == DEPTH_CULLING::BACK_TO_FRONT)
   {
     glEnable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
     glDepthFunc(GL_GEQUAL);
   }
-  else if (culling == DEPTH_CULLING_FRONT_TO_BACK)
+  else if (culling == DEPTH_CULLING::FRONT_TO_BACK)
   {
     glEnable(GL_DEPTH_TEST);
     glDepthMask(GL_TRUE);

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -421,18 +421,18 @@ void CRenderSystemGLES::ResetScissors()
 
 void CRenderSystemGLES::SetDepthCulling(DEPTH_CULLING culling)
 {
-  if (culling == DEPTH_CULLING_OFF)
+  if (culling == DEPTH_CULLING::OFF)
   {
     glDisable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
   }
-  else if (culling == DEPTH_CULLING_BACK_TO_FRONT)
+  else if (culling == DEPTH_CULLING::BACK_TO_FRONT)
   {
     glEnable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
     glDepthFunc(GL_GEQUAL);
   }
-  else if (culling == DEPTH_CULLING_FRONT_TO_BACK)
+  else if (culling == DEPTH_CULLING::FRONT_TO_BACK)
   {
     glEnable(GL_DEPTH_TEST);
     glDepthMask(GL_TRUE);

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -1033,11 +1033,11 @@ void CGraphicContext::SetRenderOrder(RENDER_ORDER renderOrder)
 {
   m_renderOrder = renderOrder;
   if (renderOrder == RENDER_ORDER_ALL_BACK_TO_FRONT)
-    CServiceBroker::GetRenderSystem()->SetDepthCulling(DEPTH_CULLING_OFF);
+    CServiceBroker::GetRenderSystem()->SetDepthCulling(DEPTH_CULLING::OFF);
   else if (renderOrder == RENDER_ORDER_BACK_TO_FRONT)
-    CServiceBroker::GetRenderSystem()->SetDepthCulling(DEPTH_CULLING_BACK_TO_FRONT);
+    CServiceBroker::GetRenderSystem()->SetDepthCulling(DEPTH_CULLING::BACK_TO_FRONT);
   else if (renderOrder == RENDER_ORDER_FRONT_TO_BACK)
-    CServiceBroker::GetRenderSystem()->SetDepthCulling(DEPTH_CULLING_FRONT_TO_BACK);
+    CServiceBroker::GetRenderSystem()->SetDepthCulling(DEPTH_CULLING::FRONT_TO_BACK);
 }
 
 uint32_t CGraphicContext::GetDepth(uint32_t addLayers)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Implement front to back rendering (#22919) for Windows (D3D11), see most details in the original PR.


For D3D11 I mimicked the GL/GLES implementations best I could.

Depth buffers are combined with stencil buffers in D3D11. The read/write action and the comparison function are controlled by depth stencil states activated at the right time.
Depth is  -1 far to 1 near in GL but D3D uses 0 to 1. The conversion is done immediately before uploading shader parameters, in order to have as much of the code similar as possible.

@sarbes there were a few differences between my last rebase and the merged version of your PR, I fixed things up best I could
In particular `ClearBuffers()` used to have forceClearColor and forceClearDepth parameters, not anymore, and there is a new `InvalidateColorBuffer()` that I copied more or less from RenderSystemGLES.

Those last changes added direct access of the renderers to advanced settings, which seems like a bad idea (though convenient). Fixing that is outside of the scope of the PR and to be tackled after.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Feature parity of Windows
It was high time to get this bit rotting branch of my repo.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Navigation in Estuary, play video and music, open osd/player process info/seekbar/settings, display subtitles ASS and PGS
Video playback with all render methods and scalers.
geometryclear on and off.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Better performance of the GUI

## Screenshots (if appropriate):
No difference that I could find.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
