### PR TITLE
[LocalizeStrings] Introduce ResourcesComponent, move localized string…

### DIFF
--- a/cmake/treedata/common/subdirs.txt
+++ b/cmake/treedata/common/subdirs.txt
@@ -29,6 +29,7 @@ xbmc/playlists                                  playlists
 xbmc/powermanagement                            powermanagement
 xbmc/programs                                   programs
 xbmc/rendering                                  rendering
+xbmc/resources                                  resources
 xbmc/speech                                     speech
 xbmc/storage                                    storage
 xbmc/threads                                    threads

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -24,11 +24,12 @@
 #include "filesystem/StackDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "music/MusicFileItemClassify.h"
 #include "playlists/PlayList.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -595,9 +596,12 @@ void CAutorun::SettingOptionAudioCdActionsFiller(const SettingConstPtr& setting,
                                                  std::vector<IntegerSettingOption>& list,
                                                  int& current)
 {
-  list.emplace_back(g_localizeStrings.Get(16018), static_cast<int>(AutoCDAction::NONE));
-  list.emplace_back(g_localizeStrings.Get(14098), static_cast<int>(AutoCDAction::PLAY));
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16018),
+                    static_cast<int>(AutoCDAction::NONE));
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14098),
+                    static_cast<int>(AutoCDAction::PLAY));
 #ifdef HAS_CDDA_RIPPER
-  list.emplace_back(g_localizeStrings.Get(14096), static_cast<int>(AutoCDAction::RIP));
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14096),
+                    static_cast<int>(AutoCDAction::RIP));
 #endif
 }

--- a/xbmc/ContextMenuItem.cpp
+++ b/xbmc/ContextMenuItem.cpp
@@ -13,7 +13,8 @@
 #include "addons/AddonManager.h"
 #include "addons/IAddon.h"
 #include "guilib/GUIComponent.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #ifdef HAS_PYTHON
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "interfaces/python/ContextItemAddonInvoker.h"
@@ -24,7 +25,7 @@
 
 std::string CStaticContextMenuAction::GetLabel(const CFileItem& item) const
 {
-  return g_localizeStrings.Get(m_label);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(m_label);
 }
 
 CContextMenuItem::CContextMenuItem(CGroup groupData)

--- a/xbmc/ContextMenus.cpp
+++ b/xbmc/ContextMenus.cpp
@@ -12,9 +12,10 @@
 #include "favourites/FavouritesService.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/WindowTranslator.h"
 #include "music/MusicFileItemClassify.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -74,9 +75,10 @@ int GetTargetWindowID(const CFileItem& item)
 
 std::string CAddRemoveFavourite::GetLabel(const CFileItem& item) const
 {
-  return g_localizeStrings.Get(CServiceBroker::GetFavouritesService().IsFavourited(item, GetTargetWindowID(item))
-                               ? 14077   /* Remove from favourites */
-                               : 14076); /* Add to favourites */
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      CServiceBroker::GetFavouritesService().IsFavourited(item, GetTargetWindowID(item))
+          ? 14077 /* Remove from favourites */
+          : 14076); /* Add to favourites */
 }
 
 bool CAddRemoveFavourite::IsVisible(const CFileItem& item) const

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -24,7 +24,7 @@
 #include "filesystem/VideoDatabaseDirectory/QueryParams.h"
 #include "games/GameUtils.h"
 #include "games/tags/GameInfoTag.h"
-#include "guilib/LocalizeStrings.h"
+#include "media/MediaLockState.h"
 #include "music/Album.h"
 #include "music/Artist.h"
 #include "music/MusicDatabase.h"
@@ -47,6 +47,8 @@
 #include "pvr/providers/PVRProvider.h"
 #include "pvr/recordings/PVRRecording.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingUtils.h"
 #include "settings/Settings.h"
@@ -2003,7 +2005,8 @@ bool CFileItem::LoadMusicTag()
     const int iTrack = GetMusicInfoTag()->GetTrackNumber();
     if (iTrack >= 1)
     {
-      std::string strText = g_localizeStrings.Get(554); // "Track"
+      std::string strText =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(554); // "Track"
       if (!strText.empty() && strText[strText.size() - 1] != ' ')
         strText += " ";
       const std::string strTrack = StringUtils::Format((strText + "{}"), iTrack);

--- a/xbmc/GUIPassword.cpp
+++ b/xbmc/GUIPassword.cpp
@@ -19,13 +19,14 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "media/MediaLockState.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
 #include "profiles/dialogs/GUIDialogProfileSettings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -125,9 +126,11 @@ bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string& strType)
   const std::string strLabel = pItem->GetLabel();
   std::string strHeading;
   if (pItem->IsFolder())
-    strHeading = g_localizeStrings.Get(12325); // "Locked! Enter code..."
+    strHeading = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        12325); // "Locked! Enter code..."
   else
-    strHeading = g_localizeStrings.Get(12348); // "Item locked"
+    strHeading =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12348); // "Item locked"
 
   return IsItemUnlocked<CFileItem*>(pItem, strType, strLabel, strHeading);
 }
@@ -135,7 +138,8 @@ bool CGUIPassword::IsItemUnlocked(CFileItem* pItem, const std::string& strType)
 bool CGUIPassword::IsItemUnlocked(CMediaSource* pItem, const std::string& strType)
 {
   const std::string strLabel = pItem->strName;
-  const std::string& strHeading = g_localizeStrings.Get(12325); // "Locked! Enter code..."
+  const std::string& strHeading = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      12325); // "Locked! Enter code..."
 
   return IsItemUnlocked<CMediaSource*>(pItem, strType, strLabel, strHeading);
 }
@@ -145,7 +149,8 @@ bool CGUIPassword::CheckStartUpLock()
   // prompt user for mastercode if the mastercode was set b4 or by xml
   int iVerifyPasswordResult = -1;
 
-  const std::string& strHeader = g_localizeStrings.Get(20075); // "Enter master lock code"
+  const std::string& strHeader = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      20075); // "Enter master lock code"
 
   if (iMasterLockRetriesLeft == -1)
     iMasterLockRetriesLeft = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MASTERLOCK_MAXRETRIES);
@@ -167,7 +172,8 @@ bool CGUIPassword::CheckStartUpLock()
       if (iVerifyPasswordResult != 0 )
       {
         std::string strLabel1;
-        strLabel1 = g_localizeStrings.Get(12343); // "retries left"
+        strLabel1 = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            12343); // "retries left"
         int iLeft = g_passwordManager.iMasterLockRetriesLeft-i;
         std::string strLabel = StringUtils::Format("{} {}", iLeft, strLabel1);
 
@@ -290,7 +296,8 @@ bool CGUIPassword::IsMasterLockUnlocked(bool bPromptUser, bool& bCanceled)
   }
 
   // no, unlock since we are allowed to prompt
-  const std::string& strHeading = g_localizeStrings.Get(20075);
+  const std::string& strHeading =
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20075);
   std::string strPassword = profileManager->GetMasterProfile().getLockCode();
 
   int iVerifyPasswordResult = VerifyPassword(profileManager->GetMasterProfile().getLockMode(), strPassword, strHeading);
@@ -334,8 +341,10 @@ void CGUIPassword::UpdateMasterLockRetryCount(bool bResetCount)
     }
     std::string dlgLine1 = "";
     if (0 < g_passwordManager.iMasterLockRetriesLeft)
-      dlgLine1 = StringUtils::Format("{} {}", g_passwordManager.iMasterLockRetriesLeft,
-                                     g_localizeStrings.Get(12343)); // "retries left"
+      dlgLine1 =
+          StringUtils::Format("{} {}", g_passwordManager.iMasterLockRetriesLeft,
+                              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                  12343)); // "retries left"
     // prompt user for master lock code
     HELPERS::ShowOKDialogLines(CVariant{20075}, CVariant{12345}, CVariant{std::move(dlgLine1)}, CVariant{0});
   }
@@ -365,7 +374,8 @@ bool CGUIPassword::CheckLock(LockMode btnType,
     return true;
   }
 
-  const std::string& strHeading = g_localizeStrings.Get(iHeading);
+  const std::string& strHeading =
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(iHeading);
   int iVerifyPasswordResult = VerifyPassword(btnType, strPassword, strHeading);
 
   if (iVerifyPasswordResult == -1)

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -16,9 +16,10 @@
 #include "addons/LanguageResource.h"
 #include "addons/RepositoryUpdater.h"
 #include "addons/addoninfo/AddonType.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
 #include "pvr/PVRManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -151,13 +152,16 @@ static std::string ToTimeFormat(bool use24HourClock, bool singleHour, bool merid
   if (!meridiem)
     return singleHour ? TIME_FORMAT_SINGLE_12 : TIME_FORMAT_DOUBLE_12;
 
-  return StringUtils::Format(g_localizeStrings.Get(12382), ToTimeFormat(false, singleHour, false));
+  return StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12382),
+      ToTimeFormat(false, singleHour, false));
 }
 
 static std::string ToSettingTimeFormat(const CDateTime& time, const std::string& timeFormat)
 {
-  return StringUtils::Format(g_localizeStrings.Get(20036),
-                             time.GetAsLocalizedTime(timeFormat, true), timeFormat);
+  return StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20036),
+      time.GetAsLocalizedTime(timeFormat, true), timeFormat);
 }
 
 static CTemperature::Unit StringToTemperatureUnit(const std::string& temperatureUnit)
@@ -473,7 +477,8 @@ bool CLangInfo::Load(const std::string& strLanguage)
       CRegion region(m_defaultRegion);
       region.m_strName = XMLUtils::GetAttribute(pRegion, "name");
       if (region.m_strName.empty())
-        region.m_strName=g_localizeStrings.Get(10005); // Not available
+        region.m_strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            10005); // Not available
 
       if (pRegion->Attribute("locale"))
         region.m_strRegionLocaleName = pRegion->Attribute("locale");
@@ -769,7 +774,8 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
   }
 
   CLog::Log(LOGINFO, "CLangInfo: loading {} language strings...", language);
-  if (!g_localizeStrings.Load(GetLanguagePath(), language))
+  auto& resources = CServiceBroker::GetResourcesComponent();
+  if (!resources.GetLocalizeStrings().Load(GetLanguagePath(), language))
   {
     CLog::LogF(LOGFATAL, "Failed to load {} language strings", language);
     return false;
@@ -782,7 +788,7 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
     for (const auto& addon : addons)
     {
       const std::string path = URIUtils::AddFileToFolder(addon->Path(), "resources", "language/");
-      g_localizeStrings.LoadAddonStrings(path, locale, addon->ID());
+      resources.GetLocalizeStrings().LoadAddonStrings(path, locale, addon->ID());
     }
   }
 
@@ -1028,10 +1034,10 @@ const std::string& CLangInfo::MeridiemSymbolToString(MeridiemSymbol symbol)
   switch (symbol)
   {
     case MeridiemSymbol::AM:
-      return g_localizeStrings.Get(378);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(378);
 
     case MeridiemSymbol::PM:
-      return g_localizeStrings.Get(379);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(379);
 
     default:
       break;
@@ -1047,7 +1053,8 @@ void CLangInfo::GetRegionNames(std::vector<std::string>& array)
   {
     std::string strName=region.first;
     if (strName=="N/A")
-      strName=g_localizeStrings.Get(10005); // Not available
+      strName =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10005); // Not available
     array.emplace_back(std::move(strName));
   }
 }
@@ -1124,7 +1131,7 @@ void CLangInfo::SetTemperatureUnit(const std::string& temperatureUnit)
 std::string CLangInfo::GetTemperatureAsString(const CTemperature& temperature) const
 {
   if (!temperature.IsValid())
-    return g_localizeStrings.Get(13205); // "Unknown"
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // "Unknown"
 
   CTemperature::Unit temperatureUnit = GetTemperatureUnit();
   return StringUtils::Format("{}{}", temperature.ToString(temperatureUnit),
@@ -1139,7 +1146,8 @@ const std::string& CLangInfo::GetTemperatureUnitString() const
 
 const std::string& CLangInfo::GetTemperatureUnitString(CTemperature::Unit temperatureUnit)
 {
-  return g_localizeStrings.Get(TEMP_UNIT_STRINGS + temperatureUnit);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(TEMP_UNIT_STRINGS +
+                                                                          temperatureUnit);
 }
 
 void CLangInfo::SetSpeedUnit(CSpeed::Unit speedUnit)
@@ -1174,7 +1182,7 @@ CSpeed::Unit CLangInfo::GetSpeedUnit() const
 std::string CLangInfo::GetSpeedAsString(const CSpeed& speed) const
 {
   if (!speed.IsValid())
-    return g_localizeStrings.Get(13205); // "Unknown"
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // "Unknown"
 
   return StringUtils::Format("{}{}", speed.ToString(GetSpeedUnit()), GetSpeedUnitString());
 }
@@ -1187,7 +1195,8 @@ const std::string& CLangInfo::GetSpeedUnitString() const
 
 const std::string& CLangInfo::GetSpeedUnitString(CSpeed::Unit speedUnit)
 {
-  return g_localizeStrings.Get(SPEED_UNIT_STRINGS + speedUnit);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(SPEED_UNIT_STRINGS +
+                                                                          speedUnit);
 }
 
 CLangInfo::Tokens CLangInfo::GetSortTokens() const
@@ -1261,9 +1270,12 @@ void CLangInfo::SettingOptionsAudioStreamLanguagesFiller(const SettingConstPtr& 
                                                          std::vector<StringSettingOption>& list,
                                                          std::string& /*current*/)
 {
-  list.emplace_back(g_localizeStrings.Get(307), "mediadefault");
-  list.emplace_back(g_localizeStrings.Get(308), "original");
-  list.emplace_back(g_localizeStrings.Get(309), "default");
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(307),
+                    "mediadefault");
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(308),
+                    "original");
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(309),
+                    "default");
 
   AddLanguages(list);
 }
@@ -1272,10 +1284,13 @@ void CLangInfo::SettingOptionsSubtitleStreamLanguagesFiller(const SettingConstPt
                                                             std::vector<StringSettingOption>& list,
                                                             std::string& /*current*/)
 {
-  list.emplace_back(g_localizeStrings.Get(231), "none");
-  list.emplace_back(g_localizeStrings.Get(13207), "forced_only");
-  list.emplace_back(g_localizeStrings.Get(308), "original");
-  list.emplace_back(g_localizeStrings.Get(309), "default");
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231), "none");
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13207),
+                    "forced_only");
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(308),
+                    "original");
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(309),
+                    "default");
 
   AddLanguages(list);
 }
@@ -1285,8 +1300,10 @@ void CLangInfo::SettingOptionsSubtitleDownloadlanguagesFiller(
     std::vector<StringSettingOption>& list,
     std::string& /*current*/)
 {
-  list.emplace_back(g_localizeStrings.Get(308), "original");
-  list.emplace_back(g_localizeStrings.Get(309), "default");
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(308),
+                    "original");
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(309),
+                    "default");
 
   AddLanguages(list);
 }
@@ -1325,10 +1342,11 @@ void CLangInfo::SettingOptionsShortDateFormatsFiller(const SettingConstPtr& sett
 
   CDateTime now = CDateTime::GetCurrentDateTime();
 
-  list.emplace_back(StringUtils::Format(g_localizeStrings.Get(20035),
-                                        GetDateStringWithFormat(
-                                            now, g_langInfo.m_currentRegion->m_strDateFormatShort)),
-                    SETTING_REGIONAL_DEFAULT);
+  list.emplace_back(
+      StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20035),
+          GetDateStringWithFormat(now, g_langInfo.m_currentRegion->m_strDateFormatShort)),
+      SETTING_REGIONAL_DEFAULT);
 
   if (shortDateFormatSetting == SETTING_REGIONAL_DEFAULT)
   {
@@ -1360,10 +1378,11 @@ void CLangInfo::SettingOptionsLongDateFormatsFiller(const SettingConstPtr& setti
 
   CDateTime now = CDateTime::GetCurrentDateTime();
 
-  list.emplace_back(StringUtils::Format(g_localizeStrings.Get(20035),
-                                        GetDateStringWithFormat(
-                                            now, g_langInfo.m_currentRegion->m_strDateFormatLong)),
-                    SETTING_REGIONAL_DEFAULT);
+  list.emplace_back(
+      StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20035),
+          GetDateStringWithFormat(now, g_langInfo.m_currentRegion->m_strDateFormatLong)),
+      SETTING_REGIONAL_DEFAULT);
 
   if (longDateFormatSetting == SETTING_REGIONAL_DEFAULT)
   {
@@ -1397,7 +1416,7 @@ void CLangInfo::SettingOptionsTimeFormatsFiller(const SettingConstPtr& setting,
   bool use24hourFormat = g_langInfo.Use24HourClock();
 
   list.emplace_back(
-      StringUtils::Format(g_localizeStrings.Get(20035),
+      StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20035),
                           ToSettingTimeFormat(now, g_langInfo.m_currentRegion->m_strTimeFormat)),
       SETTING_REGIONAL_DEFAULT);
   if (timeFormatSetting == SETTING_REGIONAL_DEFAULT)
@@ -1468,23 +1487,27 @@ void CLangInfo::SettingOptions24HourClockFormatsFiller(const SettingConstPtr& se
 
   // determine the 24-hour clock format of the regional setting
   int regionalClock24HourFormatLabel = DetermineUse24HourClockFromTimeFormat(g_langInfo.m_currentRegion->m_strTimeFormat) ? 12384 : 12383;
-  list.emplace_back(StringUtils::Format(g_localizeStrings.Get(20035),
-                                        g_localizeStrings.Get(regionalClock24HourFormatLabel)),
-                    SETTING_REGIONAL_DEFAULT);
+  list.emplace_back(
+      StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20035),
+                          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                              regionalClock24HourFormatLabel)),
+      SETTING_REGIONAL_DEFAULT);
   if (clock24HourFormatSetting == SETTING_REGIONAL_DEFAULT)
   {
     match = true;
     current = SETTING_REGIONAL_DEFAULT;
   }
 
-  list.emplace_back(g_localizeStrings.Get(12383), TIME_FORMAT_12HOURS);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12383),
+                    TIME_FORMAT_12HOURS);
   if (clock24HourFormatSetting == TIME_FORMAT_12HOURS)
   {
     current = TIME_FORMAT_12HOURS;
     match = true;
   }
 
-  list.emplace_back(g_localizeStrings.Get(12384), TIME_FORMAT_24HOURS);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12384),
+                    TIME_FORMAT_24HOURS);
   if (clock24HourFormatSetting == TIME_FORMAT_24HOURS)
   {
     current = TIME_FORMAT_24HOURS;
@@ -1503,7 +1526,7 @@ void CLangInfo::SettingOptionsTemperatureUnitsFiller(const SettingConstPtr& sett
   const std::string& temperatureUnitSetting = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
 
   list.emplace_back(
-      StringUtils::Format(g_localizeStrings.Get(20035),
+      StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20035),
                           GetTemperatureUnitString(g_langInfo.m_currentRegion->m_tempUnit)),
       SETTING_REGIONAL_DEFAULT);
   if (temperatureUnitSetting == SETTING_REGIONAL_DEFAULT)
@@ -1535,7 +1558,7 @@ void CLangInfo::SettingOptionsSpeedUnitsFiller(const SettingConstPtr& setting,
   const std::string& speedUnitSetting = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
 
   list.emplace_back(
-      StringUtils::Format(g_localizeStrings.Get(20035),
+      StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20035),
                           GetSpeedUnitString(g_langInfo.m_currentRegion->m_speedUnit)),
       SETTING_REGIONAL_DEFAULT);
   if (speedUnitSetting == SETTING_REGIONAL_DEFAULT)

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -24,7 +24,6 @@
 #include "filesystem/VideoDatabaseFile.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "interfaces/AnnouncementManager.h"
@@ -34,6 +33,8 @@
 #include "music/tags/MusicInfoTag.h"
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFileItemClassify.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -198,7 +199,10 @@ bool CPlayListPlayer::PlayNext(int offset, bool bAutoPlay)
   if ((iSong < 0) || (iSong >= playlist.size()) || (playlist.GetPlayable() <= 0))
   {
     if(!bAutoPlay)
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(559), g_localizeStrings.Get(34201));
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Info,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(559),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34201));
 
     CGUIMessage msg(GUI_MSG_PLAYLISTPLAYER_STOPPED, 0, 0, static_cast<int>(m_iCurrentPlayList),
                     m_iCurrentSong);
@@ -231,7 +235,10 @@ bool CPlayListPlayer::PlayPrevious()
 
   if (iSong < 0 || playlist.size() <= 0)
   {
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(559), g_localizeStrings.Get(34202));
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Info,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(559),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34202));
     return false;
   }
 
@@ -565,10 +572,13 @@ void CPlayListPlayer::SetShuffle(Id playlistId, bool bYesNo, bool bNotify /* = f
 
     if (bNotify)
     {
-      std::string shuffleStr =
-          StringUtils::Format("{}: {}", g_localizeStrings.Get(191),
-                              g_localizeStrings.Get(bYesNo ? 593 : 591)); // Shuffle: All/Off
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(559),  shuffleStr);
+      std::string shuffleStr = StringUtils::Format(
+          "{}: {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(191),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              bYesNo ? 593 : 591)); // Shuffle: All/Off
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Info,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(559), shuffleStr);
     }
 
     // find the previous order value and fix the current song marker
@@ -623,7 +633,10 @@ void CPlayListPlayer::SetRepeat(Id playlistId, RepeatState state, bool bNotify /
       iLocalizedString = 596; // Repeat: One
     else
       iLocalizedString = 597; // Repeat: All
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(559), g_localizeStrings.Get(iLocalizedString));
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Info,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(559),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(iLocalizedString));
   }
 
   m_repeatState[playlistId] = state;

--- a/xbmc/SeekHandler.cpp
+++ b/xbmc/SeekHandler.cpp
@@ -16,10 +16,11 @@
 #include "cores/DataCacheCore.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "music/MusicFileItemClassify.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -244,9 +245,11 @@ void CSeekHandler::SettingOptionsSeekStepsFiller(const SettingConstPtr& setting,
   for (int seconds : CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_seekSteps)
   {
     if (seconds > 60)
-      label = StringUtils::Format(g_localizeStrings.Get(14044), seconds / 60);
+      label = StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14044), seconds / 60);
     else
-      label = StringUtils::Format(g_localizeStrings.Get(14045), seconds);
+      label = StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14045), seconds);
 
     list.insert(list.begin(), IntegerSettingOption("-" + label, seconds * -1));
     list.emplace_back(label, seconds);

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -11,6 +11,7 @@
 #include "ServiceManager.h"
 #include "application/Application.h"
 #include "profiles/ProfileManager.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
@@ -311,6 +312,21 @@ void CServiceBroker::RegisterGUI(CGUIComponent* gui)
 void CServiceBroker::UnregisterGUI()
 {
   g_serviceBroker.m_pGUI = nullptr;
+}
+
+CResourcesComponent& CServiceBroker::GetResourcesComponent()
+{
+  return *g_serviceBroker.m_pResourcesComponent;
+}
+
+void CServiceBroker::RegisterResourcesComponent(std::unique_ptr<CResourcesComponent> resources)
+{
+  g_serviceBroker.m_pResourcesComponent = std::move(resources);
+}
+
+void CServiceBroker::UnregisterResourcesComponent()
+{
+  g_serviceBroker.m_pResourcesComponent.reset();
 }
 
 // audio

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -70,6 +70,7 @@ class CPlayerCoreFactory;
 class CDatabaseManager;
 class CEventLog;
 class CGUIComponent;
+class CResourcesComponent;
 class CAppInboundProtocol;
 class CSettingsComponent;
 class CDecoderFilterManager;
@@ -184,6 +185,10 @@ public:
   static void RegisterGUI(CGUIComponent* gui);
   static void UnregisterGUI();
 
+  static CResourcesComponent& GetResourcesComponent();
+  static void RegisterResourcesComponent(std::unique_ptr<CResourcesComponent> resources);
+  static void UnregisterResourcesComponent();
+
   static void RegisterSettingsComponent(const std::shared_ptr<CSettingsComponent>& settings);
   static void UnregisterSettingsComponent();
   static std::shared_ptr<CSettingsComponent> GetSettingsComponent();
@@ -244,6 +249,7 @@ private:
   std::unique_ptr<CLog> m_logging;
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
   CGUIComponent* m_pGUI = nullptr;
+  std::unique_ptr<CResourcesComponent> m_pResourcesComponent;
   CWinSystemBase* m_pWinSystem = nullptr;
   IAE* m_pActiveAE = nullptr;
   std::shared_ptr<CAppInboundProtocol> m_pAppPort;

--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -5,15 +5,14 @@
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSES/README.md for more information.
  */
-#include "SectionLoader.h"
-#include "utils/AlarmClock.h"
 #include "GUIInfoManager.h"
-#include "filesystem/DllLibCurl.h"
-#include "filesystem/DirectoryCache.h"
 #include "GUIPassword.h"
-#include "utils/LangCodeExpander.h"
 #include "PartyModeManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "SectionLoader.h"
+#include "filesystem/DirectoryCache.h"
+#include "filesystem/DllLibCurl.h"
+#include "utils/AlarmClock.h"
+#include "utils/LangCodeExpander.h"
 #ifdef HAS_PYTHON
 #include "interfaces/python/XBPython.h"
 #endif
@@ -24,17 +23,16 @@ std::map<std::string, std::string> CSpecialProtocol::m_pathMap;
 
 #include "filesystem/ZipManager.h"
 
-  CLangCodeExpander  g_LangCodeExpander;
-  CLocalizeStrings g_localizeStrings;
+CLangCodeExpander g_LangCodeExpander;
 
-  XFILE::CDirectoryCache g_directoryCache;
+XFILE::CDirectoryCache g_directoryCache;
 
-  CGUIPassword       g_passwordManager;
+CGUIPassword g_passwordManager;
 
-  XCURL::DllLibCurlGlobal g_curlInterface;
-  CPartyModeManager     g_partyModeManager;
+XCURL::DllLibCurlGlobal g_curlInterface;
+CPartyModeManager g_partyModeManager;
 
-  CAlarmClock        g_alarmClock;
-  CSectionLoader     g_sectionLoader;
+CAlarmClock g_alarmClock;
+CSectionLoader g_sectionLoader;
 
-  CZipManager g_ZipManager;
+CZipManager g_ZipManager;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -71,13 +71,14 @@
 #ifdef HAS_UPNP
 #include "filesystem/UPnPDirectory.h"
 #endif
-#include "guilib/LocalizeStrings.h"
 #include "guilib/TextureManager.h"
 #include "network/Network.h"
 #include "network/NetworkFileItemClassify.h"
 #include "platform/Environment.h"
 #include "playlists/PlayListFileItemClassify.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
@@ -360,9 +361,10 @@ std::string CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false *
     const std::string strFileNameAndPath = url.Get();
     const size_t genre = strFileNameAndPath.find_first_of('=');
     if(genre == std::string::npos)
-      strFilename = g_localizeStrings.Get(260);
+      strFilename = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(260);
     else
-      strFilename = g_localizeStrings.Get(260) + " - " + strFileNameAndPath.substr(genre+1).c_str();
+      strFilename = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(260) + " - " +
+                    strFileNameAndPath.substr(genre + 1).c_str();
   }
 
   // Windows SMB Network (SMB)
@@ -370,7 +372,7 @@ std::string CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false *
   {
     if (url.GetHostName().empty())
     {
-      strFilename = g_localizeStrings.Get(20171);
+      strFilename = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20171);
     }
     else
     {
@@ -380,15 +382,15 @@ std::string CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false *
 
   // Root file views
   else if (url.IsProtocol("sources"))
-    strFilename = g_localizeStrings.Get(744);
+    strFilename = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(744);
 
   // Music Playlists
   else if (StringUtils::StartsWith(path, "special://musicplaylists"))
-    strFilename = g_localizeStrings.Get(136);
+    strFilename = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(136);
 
   // Video Playlists
   else if (StringUtils::StartsWith(path, "special://videoplaylists"))
-    strFilename = g_localizeStrings.Get(136);
+    strFilename = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(136);
 
   else if (URIUtils::HasParentInHostname(url) && strFilename.empty())
     strFilename = URIUtils::GetFileName(url.GetHostName());
@@ -2281,7 +2283,7 @@ ExternalStreamInfo CUtil::GetExternalStreamDetailsFromFilename(const std::string
     }
   }
   name += " ";
-  name += g_localizeStrings.Get(21602); // External
+  name += CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21602); // External
   StringUtils::Trim(name);
   info.name = StringUtils::RemoveDuplicatedSpacesAndTabs(name);
   if (info.flag == 0)

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -9,7 +9,9 @@
 #include "XBDateTime.h"
 
 #include "LangInfo.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
 #include "utils/Archive.h"
@@ -1426,7 +1428,8 @@ std::string CDateTime::GetAsLocalizedDate(const std::string& strFormat,
         int wday = dateTime.dayOfWeek;
         if (wday < 1 || wday > 7) wday = 7;
         {
-          str = g_localizeStrings.Get((c == 'd' ? 40 : 10) + wday);
+          str = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              (c == 'd' ? 40 : 10) + wday);
           fmtOut += (c == 'd' ? "%a" : "%A");
         }
       }
@@ -1467,7 +1470,8 @@ std::string CDateTime::GetAsLocalizedDate(const std::string& strFormat,
         int wmonth = dateTime.month;
         if (wmonth < 1 || wmonth > 12) wmonth = 12;
         {
-          str = g_localizeStrings.Get((c == 'm' ? 50 : 20) + wmonth);
+          str = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              (c == 'm' ? 50 : 20) + wmonth);
           fmtOut += (c == 'm' ? "%b" : "%B");
         }
       }

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -30,10 +30,11 @@
 #include "filesystem/File.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h" // for callback
-#include "guilib/LocalizeStrings.h"
 #include "jobs/JobManager.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -501,7 +502,9 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
   {
     if (eventLog)
       eventLog->AddWithNotification(std::make_shared<const CNotificationEvent>(
-          24045, StringUtils::Format(g_localizeStrings.Get(24143), path),
+          24045,
+          StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24143), path),
           "special://xbmc/media/icon256x256.png", EventLevel::Error));
 
     CLog::Log(
@@ -519,7 +522,9 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
 
   if (eventLog)
     eventLog->AddWithNotification(std::make_shared<const CNotificationEvent>(
-        24045, StringUtils::Format(g_localizeStrings.Get(24143), path),
+        24045,
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24143),
+                            path),
         "special://xbmc/media/icon256x256.png", EventLevel::Error));
   return false;
 }
@@ -686,16 +691,18 @@ bool CAddonInstallJob::DoWork()
 {
   m_currentType = CAddonInstallJob::TYPE_DOWNLOAD;
 
-  SetTitle(StringUtils::Format(g_localizeStrings.Get(24057), m_addon->Name()));
+  SetTitle(StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24057), m_addon->Name()));
   SetProgress(0);
 
   // check whether all the dependencies are available or not
-  SetText(g_localizeStrings.Get(24058));
+  SetText(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24058));
   std::pair<std::string, std::string> failedDep;
   if (!CAddonInstaller::GetInstance().CheckDependencies(m_addon, failedDep))
   {
     std::string details =
-        StringUtils::Format(g_localizeStrings.Get(24142), failedDep.first, failedDep.second);
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24142),
+                            failedDep.first, failedDep.second);
     CLog::Log(LOGERROR, "CAddonInstallJob[{}]: {}", m_addon->ID(), details);
     ReportInstallError(m_addon->ID(), m_addon->ID(), details);
     return false;
@@ -775,7 +782,7 @@ bool CAddonInstallJob::DoWork()
       }
 
       // at this point we have the package - check that it is valid
-      SetText(g_localizeStrings.Get(24077));
+      SetText(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24077));
       if (!hash.Empty())
       {
         TypedDigest actualHash{hash.type, CUtil::GetFileDigest(package, hash.type)};
@@ -837,7 +844,7 @@ bool CAddonInstallJob::DoWork()
     return false;
   }
 
-  g_localizeStrings.LoadAddonStrings(
+  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().LoadAddonStrings(
       URIUtils::AddFileToFolder(m_addon->Path(), "resources/language/"),
       CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
           CSettings::SETTING_LOCALE_LANGUAGE),
@@ -987,7 +994,8 @@ bool CAddonInstallJob::DoWork()
     CLog::Log(LOGDEBUG, "CAddonInstallJob[{}]: installed addon marked as deprecated",
               m_addon->ID());
     std::string text =
-        StringUtils::Format(g_localizeStrings.Get(24168), m_addon->LifecycleStateDescription());
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24168),
+                            m_addon->LifecycleStateDescription());
     if (eventLog)
       eventLog->Add(std::make_shared<const CAddonManagementEvent>(m_addon, text), true, false);
   }
@@ -1002,7 +1010,7 @@ bool CAddonInstallJob::DownloadPackage(const std::string &path, const std::strin
   if (ShouldCancel(0, 1))
     return false;
 
-  SetText(g_localizeStrings.Get(24078));
+  SetText(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24078));
 
   // need to download/copy the package first
   CFileItemList list;
@@ -1061,12 +1069,13 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
     {
       CLog::LogF(LOGERROR, "failed to install repository [{}]. It has dependencies defined",
                  m_addon->ID());
-      ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24088));
+      ReportInstallError(m_addon->ID(), m_addon->ID(),
+                         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24088));
       return false;
     }
   }
 
-  SetText(g_localizeStrings.Get(24079));
+  SetText(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24079));
   unsigned int totalSteps = static_cast<unsigned int>(deps.size()) + 1;
   if (ShouldCancel(0, totalSteps))
     return false;
@@ -1104,7 +1113,9 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
           {
             CLog::Log(LOGERROR, "CAddonInstallJob[{}]: failed to install dependency {}",
                       m_addon->ID(), addonID);
-            ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24085));
+            ReportInstallError(
+                m_addon->ID(), m_addon->ID(),
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24085));
             return false;
           }
         }
@@ -1124,7 +1135,9 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
           {
             CLog::Log(LOGERROR, "CAddonInstallJob[{}]: failed to find dependency {}", m_addon->ID(),
                       addonID);
-            ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24085));
+            ReportInstallError(
+                m_addon->ID(), m_addon->ID(),
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24085));
             return false;
           }
           else
@@ -1136,7 +1149,9 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
                         "version [{}]",
                         m_addon->ID(), addonID, dependencyToInstall->Version().asString(),
                         versionMin.asString());
-              ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24085));
+              ReportInstallError(
+                  m_addon->ID(), m_addon->ID(),
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24085));
               return false;
             }
           }
@@ -1156,7 +1171,9 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
             {
               CLog::Log(LOGERROR, "CAddonInstallJob[{}]: failed to install dependency {}",
                         m_addon->ID(), addonID);
-              ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24085));
+              ReportInstallError(
+                  m_addon->ID(), m_addon->ID(),
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24085));
               return false;
             }
           }
@@ -1165,7 +1182,9 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
           {
             CLog::Log(LOGERROR, "CAddonInstallJob[{}]: failed to install dependency {}",
                       m_addon->ID(), dependencyToInstall->ID());
-            ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24085));
+            ReportInstallError(
+                m_addon->ID(), m_addon->ID(),
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24085));
             return false;
           }
         }
@@ -1176,7 +1195,7 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryP
       return false;
   }
 
-  SetText(g_localizeStrings.Get(24086));
+  SetText(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24086));
   SetProgress(100.0f * (static_cast<float>(totalSteps) - 1.0f) / static_cast<float>(totalSteps));
 
   CFilesystemInstaller fsInstaller;
@@ -1206,7 +1225,8 @@ void CAddonInstallJob::ReportInstallError(const std::string& addonID, const std:
     bool success = CServiceBroker::GetAddonMgr().GetAddon(addonID, addon2, OnlyEnabled::CHOICE_YES);
     if (msg.empty())
     {
-      msg = g_localizeStrings.Get(addon2 != nullptr && success ? 113 : 114);
+      msg = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          addon2 != nullptr && success ? 113 : 114);
     }
 
     activity = std::make_shared<const CAddonManagementEvent>(addon, EventLevel::Error, msg);
@@ -1216,7 +1236,11 @@ void CAddonInstallJob::ReportInstallError(const std::string& addonID, const std:
   else
   {
     activity = std::make_shared<const CNotificationEvent>(
-        24045, !msg.empty() ? msg : StringUtils::Format(g_localizeStrings.Get(24143), fileName),
+        24045,
+        !msg.empty() ? msg
+                     : StringUtils::Format(
+                           CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24143),
+                           fileName),
         EventLevel::Error);
 
     if (IsModal())

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -29,8 +29,9 @@
 #include "events/NotificationEvent.h"
 #include "filesystem/Directory.h"
 #include "filesystem/SpecialProtocol.h"
-#include "guilib/LocalizeStrings.h"
 #include "jobs/JobManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -795,7 +796,7 @@ void CAddonMgr::OnPostUnInstall(const std::string& id)
   std::unique_lock lock(m_critSection);
   m_disabled.erase(id);
   RemoveAllUpdateRulesFromList(id);
-  g_localizeStrings.ClearAddonStrings(id);
+  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().ClearAddonStrings(id);
   m_events.Publish(AddonEvents::UnInstalled(id));
 }
 

--- a/xbmc/addons/AddonSystemSettings.cpp
+++ b/xbmc/addons/AddonSystemSettings.cpp
@@ -16,9 +16,10 @@
 #include "addons/addoninfo/AddonType.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -73,8 +74,9 @@ void CAddonSystemSettings::OnSettingAction(const std::shared_ptr<const CSetting>
     const auto removedItems = CAddonInstaller::GetInstance().RemoveOrphanedDepsRecursively();
     if (!removedItems.empty())
     {
-      const auto message =
-          StringUtils::Format(g_localizeStrings.Get(36641), StringUtils::Join(removedItems, ", "));
+      const auto message = StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36641),
+          StringUtils::Join(removedItems, ", "));
 
       ShowOKDialogText(CVariant{36640}, CVariant{message}); // "following orphaned were removed..."
     }

--- a/xbmc/addons/ContextMenuAddon.cpp
+++ b/xbmc/addons/ContextMenuAddon.cpp
@@ -10,8 +10,10 @@
 
 #include "ContextMenuItem.h"
 #include "ContextMenuManager.h"
+#include "ServiceBroker.h"
 #include "addons/addoninfo/AddonType.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
@@ -44,7 +46,8 @@ CContextMenuAddon::CContextMenuAddon(const AddonInfoPtr& addonInfo)
 
       std::string label = elem->GetValue("label").asString();
       if (StringUtils::IsNaturalNumber(label))
-        label = g_localizeStrings.GetAddonString(ID(), atoi(label.c_str()));
+        label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+            ID(), atoi(label.c_str()));
 
       m_items.emplace_back(CContextMenuItem::CItem{
           .label = std::move(label),
@@ -67,7 +70,8 @@ void CContextMenuAddon::ParseMenu(
   std::string menuId = elem->GetValue("@id").asString();
   std::string menuLabel = elem->GetValue("label").asString();
   if (StringUtils::IsNaturalNumber(menuLabel))
-    menuLabel = g_localizeStrings.GetAddonString(ID(), std::stoi(menuLabel));
+    menuLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+        ID(), std::stoi(menuLabel));
 
   if (menuId.empty())
   {
@@ -90,7 +94,8 @@ void CContextMenuAddon::ParseMenu(
     std::string library = addonExtensions.GetValue("@library").asString();
     std::string label = addonExtensions.GetValue("label").asString();
     if (StringUtils::IsNaturalNumber(label))
-      label = g_localizeStrings.GetAddonString(ID(), std::atoi(label.c_str()));
+      label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+          ID(), std::atoi(label.c_str()));
 
     std::vector<std::string> args;
     args.emplace_back(ID());

--- a/xbmc/addons/ExtsMimeSupportList.cpp
+++ b/xbmc/addons/ExtsMimeSupportList.cpp
@@ -13,7 +13,8 @@
 #include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonType.h"
 #include "addons/kodi-dev-kit/include/kodi/addon-instance/AudioDecoder.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
@@ -268,7 +269,8 @@ std::vector<AddonSupportEntry> CExtsMimeSupportList::GetSupportedExtsAndMimeType
     supportEntry.m_type = AddonSupportType::Extension;
     supportEntry.m_name = name;
     supportEntry.m_description =
-        g_localizeStrings.GetAddonString(addonId, supportValue.m_description);
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+            addonId, supportValue.m_description);
     supportEntry.m_icon = supportValue.m_icon;
     list.emplace_back(std::move(supportEntry));
   }
@@ -278,7 +280,8 @@ std::vector<AddonSupportEntry> CExtsMimeSupportList::GetSupportedExtsAndMimeType
     supportEntry.m_type = AddonSupportType::Mimetype;
     supportEntry.m_name = name;
     supportEntry.m_description =
-        g_localizeStrings.GetAddonString(addonId, supportValue.m_description);
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+            addonId, supportValue.m_description);
     supportEntry.m_icon = supportValue.m_icon;
     list.emplace_back(std::move(supportEntry));
   }

--- a/xbmc/addons/RepositoryUpdater.cpp
+++ b/xbmc/addons/RepositoryUpdater.cpp
@@ -24,8 +24,9 @@
 #include "events/EventLog.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "jobs/JobManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -167,13 +168,15 @@ void CRepositoryUpdater::OnJobComplete(unsigned int jobID, bool success, CJob* j
         CAddonSystemSettings::GetInstance().GetAddonAutoUpdateMode() == AUTO_UPDATES_NOTIFY)
     {
       if (updates.size() == 1)
-        CGUIDialogKaiToast::QueueNotification(updates[0]->Icon(), updates[0]->Name(),
-                                              g_localizeStrings.Get(24068), TOAST_DISPLAY_TIME,
-                                              false, TOAST_DISPLAY_TIME);
+        CGUIDialogKaiToast::QueueNotification(
+            updates[0]->Icon(), updates[0]->Name(),
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24068),
+            TOAST_DISPLAY_TIME, false, TOAST_DISPLAY_TIME);
       else
-        CGUIDialogKaiToast::QueueNotification("", g_localizeStrings.Get(24001),
-                                              g_localizeStrings.Get(24061), TOAST_DISPLAY_TIME,
-                                              false, TOAST_DISPLAY_TIME);
+        CGUIDialogKaiToast::QueueNotification(
+            "", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24001),
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24061),
+            TOAST_DISPLAY_TIME, false, TOAST_DISPLAY_TIME);
 
       auto eventLog = CServiceBroker::GetEventLog();
       for (const auto& addon : updates)
@@ -213,7 +216,9 @@ static void SetProgressIndicator(CRepositoryUpdateJob* job)
 {
   auto dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogExtendedProgressBar>(WINDOW_DIALOG_EXT_PROGRESS);
   if (dialog)
-    job->SetProgressIndicators(dialog->GetHandle(g_localizeStrings.Get(24092)), nullptr);
+    job->SetProgressIndicators(
+        dialog->GetHandle(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24092)),
+        nullptr);
 }
 
 void CRepositoryUpdater::CheckForUpdates(const ADDON::RepositoryPtr& repo, bool showProgress)

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -21,12 +21,13 @@
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/PluginDirectory.h"
-#include "guilib/LocalizeStrings.h"
 #include "music/Album.h"
 #include "music/Artist.h"
 #include "music/MusicDatabase.h"
 #include "music/infoscanner/MusicAlbumInfo.h"
 #include "music/infoscanner/MusicArtistInfo.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/SettingsValueFlatJsonSerializer.h"
@@ -93,7 +94,7 @@ std::string TranslateContent(ContentType type, bool pretty /*=false*/)
     if (type == map.type)
     {
       if (pretty && map.pretty)
-        return g_localizeStrings.Get(map.pretty);
+        return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(map.pretty);
       else
         return map.name;
     }
@@ -1327,7 +1328,8 @@ VIDEO::EPISODELIST CScraper::GetEpisodeList(XFILE::CCurlFile& fcurl, const CScra
         ep.iSubepisode = (dot != std::string::npos) ? atoi(strEpNum.substr(dot + 1).c_str()) : 0;
         std::string title;
         if (!XMLUtils::GetString(pxeMovie, "title", title) || title.empty())
-          title = g_localizeStrings.Get(10005); // Not available
+          title = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              10005); // Not available
         scurlEp.SetTitle(title);
         std::string id;
         if (XMLUtils::GetString(pxeMovie, "id", id))

--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -19,10 +19,11 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIUtils.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -480,7 +481,8 @@ void CSkinInfo::SettingOptionsSkinColorsFiller(const SettingConstPtr& setting,
   // any other *.xml files are additional color themes on top of this one.
 
   // add the default label
-  list.emplace_back(g_localizeStrings.Get(15109), "SKINDEFAULT"); // the standard defaults.xml will be used!
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15109),
+                    "SKINDEFAULT"); // the standard defaults.xml will be used!
 
   // Search for colors in the Current skin!
   std::vector<std::string> vecColors;
@@ -573,7 +575,7 @@ void CSkinInfo::SettingOptionsSkinFontsFiller(const SettingConstPtr& setting,
   if (list.empty())
   { // Since no fontset is defined, there is no selection of a fontset, so disable the component
     CLog::LogF(LOGERROR, "No fontsets found");
-    list.emplace_back(g_localizeStrings.Get(13278), "");
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13278), "");
     current = "";
     currentValueSet = true;
   }
@@ -595,7 +597,8 @@ void CSkinInfo::SettingOptionsSkinThemesFiller(const SettingConstPtr& setting,
   // any other *.xbt files are additional themes on top of this one.
 
   // add the default Label
-  list.emplace_back(g_localizeStrings.Get(15109), "SKINDEFAULT"); // the standard Textures.xbt will be used
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15109),
+                    "SKINDEFAULT"); // the standard Textures.xbt will be used
 
   // search for themes in the current skin!
   std::vector<std::string> vecTheme;

--- a/xbmc/addons/addoninfo/AddonInfo.cpp
+++ b/xbmc/addons/addoninfo/AddonInfo.cpp
@@ -16,7 +16,8 @@
 #include "addons/IAddon.h"
 #include "addons/addoninfo/AddonType.h"
 #include "filesystem/Directory.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
@@ -110,7 +111,7 @@ std::string CAddonInfo::TranslateType(AddonType type, bool pretty /*= false*/)
     if (type == map.type)
     {
       if (pretty && map.pretty)
-        return g_localizeStrings.Get(map.pretty);
+        return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(map.pretty);
       else
         return std::string(map.name.data(), map.name.size());
     }

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -31,13 +31,14 @@
 #include "games/GameUtils.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "interfaces/builtins/Builtins.h"
 #include "jobs/JobManager.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "pictures/GUIWindowSlideShow.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Digest.h"
@@ -300,7 +301,9 @@ int CGUIDialogAddonInfo::AskForVersion(
 
   for (const auto& [version, origin] : versions)
   {
-    CFileItem item(StringUtils::Format(g_localizeStrings.Get(21339), version.asString()));
+    CFileItem item(
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21339),
+                            version.asString()));
     if (m_localAddon && m_localAddon->Version() == version &&
         m_item->GetAddonInfo()->Origin() == origin)
       item.Select(true);
@@ -308,7 +311,7 @@ int CGUIDialogAddonInfo::AskForVersion(
     AddonPtr repo;
     if (origin == LOCAL_CACHE)
     {
-      item.SetLabel2(g_localizeStrings.Get(24095));
+      item.SetLabel2(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24095));
       item.SetArt("icon", "DefaultAddonRepository.png");
       dialog->Add(item);
     }
@@ -474,11 +477,15 @@ void CGUIDialogAddonInfo::OnInstall()
       CAddonSystemSettings::GetInstance().GetAddonRepoUpdateMode() !=
           AddonRepoUpdateMode::ANY_REPOSITORY)
   {
-    const std::string& header = g_localizeStrings.Get(19098); // Warning!
+    const std::string& header =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19098); // Warning!
     const std::string originStr =
-        !m_localAddon->Origin().empty() ? m_localAddon->Origin() : g_localizeStrings.Get(39029);
-    const std::string text = StringUtils::Format(g_localizeStrings.Get(39028), m_localAddon->Name(),
-                                                 originStr, m_localAddon->Version().asString());
+        !m_localAddon->Origin().empty()
+            ? m_localAddon->Origin()
+            : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39029);
+    const std::string text =
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39028),
+                            m_localAddon->Name(), originStr, m_localAddon->Version().asString());
 
     if (CGUIDialogYesNo::ShowAndGetInput(header, text))
     {
@@ -576,7 +583,9 @@ bool CGUIDialogAddonInfo::PromptIfDependency(int heading, int line2) const
 
   if (!deps.empty())
   {
-    std::string line0 = StringUtils::Format(g_localizeStrings.Get(24046), m_localAddon->Name());
+    std::string line0 =
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24046),
+                            m_localAddon->Name());
     std::string line1 = StringUtils::Join(deps, ", ");
     HELPERS::ShowOKDialogLines(CVariant{heading}, CVariant{std::move(line0)},
                                CVariant{std::move(line1)}, CVariant{line2});
@@ -624,7 +633,9 @@ void CGUIDialogAddonInfo::OnEnableDisable()
       return; //required. can't disable
 
     if (CServiceBroker::GetAddonMgr().DisableAddon(m_localAddon->ID(), AddonDisabledReason::USER))
-      m_item->SetProperty("Addon.Status", g_localizeStrings.Get(24023)); // Disabled
+      m_item->SetProperty(
+          "Addon.Status",
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24023)); // Disabled
   }
   else
   {
@@ -633,7 +644,9 @@ void CGUIDialogAddonInfo::OnEnableDisable()
       return;
 
     if (CServiceBroker::GetAddonMgr().EnableAddon(m_localAddon->ID()))
-      m_item->SetProperty("Addon.Status", g_localizeStrings.Get(305)); // Enabled
+      m_item->SetProperty(
+          "Addon.Status",
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(305)); // Enabled
   }
 
   UpdateControls(PerformButtonFocus::CHOICE_NO);
@@ -701,10 +714,13 @@ bool CGUIDialogAddonInfo::ShowDependencyList(Reactivate reactivate, EntryPoint e
               !CAddonRepos::IsFromOfficialRepo(infoAddon, CheckAddonPath::CHOICE_NO))
           {
             item->SetLabel2(StringUtils::Format(
-                g_localizeStrings.Get(messageId), it.m_depInfo.versionMin.asString(),
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(messageId),
+                it.m_depInfo.versionMin.asString(),
                 it.m_installed ? it.m_installed->Version().asString() : "",
                 it.m_available ? it.m_available->Version().asString() : "",
-                it.m_depInfo.optional ? g_localizeStrings.Get(24184) : ""));
+                it.m_depInfo.optional
+                    ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24184)
+                    : ""));
 
             item->SetArt("icon", infoAddon->Icon());
             item->SetProperty("addon_id", it.m_depInfo.id);
@@ -715,7 +731,8 @@ bool CGUIDialogAddonInfo::ShowDependencyList(Reactivate reactivate, EntryPoint e
       else
       {
         auto item{std::make_shared<CFileItem>(it.m_depInfo.id)};
-        item->SetLabel2(g_localizeStrings.Get(10005)); // Not available
+        item->SetLabel2(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            10005)); // Not available
         items.Add(std::move(item));
       }
     }
@@ -780,9 +797,11 @@ void CGUIDialogAddonInfo::ShowSupportList() const
 
     std::string label;
     if (entry.m_type == AddonSupportType::Extension)
-      label = StringUtils::Format(g_localizeStrings.Get(21346), entry.m_name);
+      label = StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21346), entry.m_name);
     else if (entry.m_type == AddonSupportType::Mimetype)
-      label = StringUtils::Format(g_localizeStrings.Get(21347), entry.m_name);
+      label = StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21347), entry.m_name);
     else
       label = entry.m_name;
 

--- a/xbmc/addons/gui/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonSettings.cpp
@@ -22,11 +22,12 @@
 #include "games/addons/GameClient.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/SettingSection.h"
@@ -242,14 +243,15 @@ bool CGUIDialogAddonSettings::ShowForMultipleInstances(const ADDON::AddonPtr& ad
       std::string name;
       addon->GetSettingString(ADDON_SETTING_INSTANCE_NAME_VALUE, name, id);
       if (name.empty())
-        name = g_localizeStrings.Get(13205); // Unknown
+        name = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
 
       bool enabled = false;
       addon->GetSettingBool(ADDON_SETTING_INSTANCE_ENABLED_VALUE, enabled, id);
 
       const std::string label = StringUtils::Format(
-          g_localizeStrings.Get(10020), name,
-          g_localizeStrings.Get(enabled ? 305 : 13106)); // Edit "config name" [enabled state]
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10020), name,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              enabled ? 305 : 13106)); // Edit "config name" [enabled state]
 
       const CFileItemPtr item = std::make_shared<CFileItem>(label);
       item->SetProperty("id", id);
@@ -265,22 +267,26 @@ bool CGUIDialogAddonSettings::ShowForMultipleInstances(const ADDON::AddonPtr& ad
     const ADDON::AddonInstanceId addInstanceId = highestId + 1;
     const ADDON::AddonInstanceId removeInstanceId = highestId + 2;
 
-    auto item{
-        std::make_shared<CFileItem>(g_localizeStrings.Get(10014))}; // Add add-on configuration
+    auto item{std::make_shared<CFileItem>(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            10014))}; // Add add-on configuration
     item->SetProperty("id", addInstanceId);
     itemsGeneral.Add(std::move(item));
 
     if (ids.size() > 1) // Forbid removal of last instance
     {
-      item =
-          std::make_shared<CFileItem>(g_localizeStrings.Get(10015)); // Remove add-on configuration
+      item = std::make_shared<CFileItem>(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              10015)); // Remove add-on configuration
       item->SetProperty("id", removeInstanceId);
       itemsGeneral.Add(std::move(item));
     }
 
     if (addon->HasSettings(ADDON_SETTINGS_ID))
     {
-      item = std::make_shared<CFileItem>(g_localizeStrings.Get(10013)); // Edit Add-on settings
+      item = std::make_shared<CFileItem>(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              10013)); // Edit Add-on settings
       item->SetProperty("id", ADDON_SETTINGS_ID);
       itemsGeneral.Add(std::move(item));
     }
@@ -346,7 +352,7 @@ bool CGUIDialogAddonSettings::ShowForMultipleInstances(const ADDON::AddonPtr& ad
       {
         item = dialog->GetSelectedFileItem();
         const std::string label = StringUtils::Format(
-            g_localizeStrings.Get(10019),
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10019),
             item->GetProperty("name")
                 .asString()); // Do you want to remove the add-on configuration "config name"?
 
@@ -461,7 +467,8 @@ void CGUIDialogAddonSettings::SetupView()
 
 std::string CGUIDialogAddonSettings::GetLocalizedString(uint32_t labelId) const
 {
-  std::string label = g_localizeStrings.GetAddonString(m_addon->ID(), labelId);
+  std::string label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+      m_addon->ID(), labelId);
   if (!label.empty())
     return label;
 

--- a/xbmc/addons/gui/GUIHelpers.cpp
+++ b/xbmc/addons/gui/GUIHelpers.cpp
@@ -8,10 +8,12 @@
 
 #include "GUIHelpers.h"
 
+#include "ServiceBroker.h"
 #include "addons/IAddon.h"
 #include "addons/addoninfo/AddonInfo.h"
 #include "dialogs/GUIDialogYesNo.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 using namespace ADDON;
@@ -38,9 +40,11 @@ bool CHelpers::DialogAddonLifecycleUseAsk(const std::shared_ptr<const IAddon>& a
   }
   if (header_nr > 0)
   {
-    std::string header = StringUtils::Format(g_localizeStrings.Get(header_nr), addon->ID());
-    std::string text =
-        StringUtils::Format(g_localizeStrings.Get(text_nr), addon->LifecycleStateDescription());
+    std::string header = StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(header_nr), addon->ID());
+    std::string text = StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(text_nr),
+        addon->LifecycleStateDescription());
     if (!CGUIDialogYesNo::ShowAndGetInput(header, text))
       return false;
   }

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -29,10 +29,11 @@
 #include "filesystem/AddonsDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "platform/Platform.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -171,8 +172,10 @@ bool CGUIWindowAddonBrowser::OnMessage(CGUIMessage& message)
 void CGUIWindowAddonBrowser::SetProperties()
 {
   auto lastUpdated = CServiceBroker::GetRepositoryUpdater().LastUpdated();
-  SetProperty("Updated", lastUpdated.IsValid() ? lastUpdated.GetAsLocalizedDateTime()
-                                               : g_localizeStrings.Get(21337));
+  SetProperty("Updated",
+              lastUpdated.IsValid()
+                  ? lastUpdated.GetAsLocalizedDateTime()
+                  : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21337));
 }
 
 class UpdateAddons : public IRunnable
@@ -214,7 +217,9 @@ void CGUIWindowAddonBrowser::InstallFromZip()
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
     CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
     std::string path;
-    if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "*.zip", g_localizeStrings.Get(24041), path))
+    if (CGUIDialogFileBrowser::ShowAndGetFile(
+            shares, "*.zip",
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24041), path))
     {
       CAddonInstaller::GetInstance().InstallFromZip(path);
     }
@@ -356,7 +361,9 @@ void CGUIWindowAddonBrowser::UpdateStatus(const CFileItemPtr& item) const
                                                  downloadFinshed))
   {
     std::string progress = StringUtils::Format(
-        !downloadFinshed ? g_localizeStrings.Get(24042) : g_localizeStrings.Get(24044), percent);
+        !downloadFinshed ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24042)
+                         : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24044),
+        percent);
     item->SetProperty("Addon.Status", progress);
     item->SetProperty("Addon.Downloading", true);
   }
@@ -566,8 +573,8 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<AddonType>& types,
   if (showNone)
   {
     auto item{std::make_shared<CFileItem>("", false)};
-    item->SetLabel(g_localizeStrings.Get(231));
-    item->SetLabel2(g_localizeStrings.Get(24040));
+    item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231));
+    item->SetLabel2(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24040));
     item->SetArt("icon", "DefaultAddonNone.png");
     item->SetSpecialSort(SortSpecialOnTop);
     items.Add(std::move(item));

--- a/xbmc/addons/interfaces/AddonBase.cpp
+++ b/xbmc/addons/interfaces/AddonBase.cpp
@@ -21,7 +21,8 @@
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/lib/Setting.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -255,10 +256,11 @@ char* Interface_Base::get_localized_string(const KODI_ADDON_BACKEND_HDL hdl, lon
   if (g_application.m_bStop)
     return nullptr;
 
-  std::string label =
-      g_localizeStrings.GetAddonString(addon->ID(), static_cast<uint32_t>(label_id));
+  std::string label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+      addon->ID(), static_cast<uint32_t>(label_id));
   if (label.empty())
-    label = g_localizeStrings.Get(static_cast<uint32_t>(label_id));
+    label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        static_cast<uint32_t>(label_id));
   char* buffer = strdup(label.c_str());
   return buffer;
 }

--- a/xbmc/addons/settings/AddonSettings.cpp
+++ b/xbmc/addons/settings/AddonSettings.cpp
@@ -20,8 +20,9 @@
 #include "addons/settings/SettingUrlEncodedString.h"
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/SettingAddon.h"
 #include "settings/SettingConditions.h"
 #include "settings/SettingControl.h"
@@ -793,7 +794,9 @@ std::shared_ptr<CSettingCategory> CAddonSettings::ParseOldCategoryElement(
 
   // try to get the category's label and fall back to "General"
   int categoryLabel = 128;
-  ParseOldLabel(categoryElement, g_localizeStrings.Get(categoryLabel), categoryLabel);
+  ParseOldLabel(categoryElement,
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(categoryLabel),
+                categoryLabel);
   category->SetLabel(categoryLabel);
 
   // prepare a setting group
@@ -1313,7 +1316,9 @@ SettingPtr CAddonSettings::InitializeFromOldSettingEnums(
       for (uint32_t i = 0; i < values.size(); ++i)
       {
         const int label{static_cast<int>(std::strtol(values[i].c_str(), nullptr, 0))};
-        std::string value{g_localizeStrings.GetAddonString(m_addonId, label)};
+        std::string value{
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(m_addonId,
+                                                                                        label)};
         if (settingEntries.size() > i)
           value = settingEntries[i];
 

--- a/xbmc/application/AppEnvironment.cpp
+++ b/xbmc/application/AppEnvironment.cpp
@@ -9,6 +9,7 @@
 #include "AppEnvironment.h"
 
 #include "ServiceBroker.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
 
@@ -16,6 +17,8 @@ void CAppEnvironment::SetUp(const std::shared_ptr<CAppParams>& appParams)
 {
   CServiceBroker::RegisterAppParams(appParams);
   CServiceBroker::CreateLogging();
+  CServiceBroker::RegisterResourcesComponent(std::make_unique<CResourcesComponent>());
+
   const auto settingsComponent = std::make_shared<CSettingsComponent>();
   settingsComponent->Initialize();
   CServiceBroker::RegisterSettingsComponent(settingsComponent);
@@ -28,5 +31,8 @@ void CAppEnvironment::TearDown()
   CServiceBroker::UnregisterSettingsComponent();
   CServiceBroker::GetLogging().Deinitialize();
   CServiceBroker::DestroyLogging();
+
+  CServiceBroker::UnregisterResourcesComponent();
+
   CServiceBroker::UnregisterAppParams();
 }

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -77,7 +77,6 @@
 #include "guilib/GUIControlProfiler.h"
 #include "guilib/GUIFontManager.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
 #include "guilib/TextureManager.h"
 #include "input/InertialScrollingHandler.h"
@@ -122,6 +121,8 @@
 #include "pvr/guilib/PVRGUIActionsPlayback.h"
 #include "pvr/guilib/PVRGUIActionsPowerManagement.h"
 #include "rendering/RenderSystem.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
@@ -568,8 +569,10 @@ bool CApplication::Initialize()
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
   profileManager->GetEventLog().Add(EventPtr(new CNotificationEvent(
-      StringUtils::Format(g_localizeStrings.Get(177), g_sysinfo.GetAppName()),
-      StringUtils::Format(g_localizeStrings.Get(178), g_sysinfo.GetAppName()),
+      StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(177),
+                          g_sysinfo.GetAppName()),
+      StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(178),
+                          g_sysinfo.GetAppName()),
       "special://xbmc/media/icon256x256.png", EventLevel::Basic)));
 
   m_ServiceManager->GetNetwork().WaitForNet();
@@ -586,8 +589,10 @@ bool CApplication::Initialize()
         event.Set();
       });
 
-  const std::string& connecting{g_localizeStrings.Get(24186)};
-  const std::string& updating{g_localizeStrings.Get(24150)};
+  const std::string& connecting{
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24186)};
+  const std::string& updating{
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24150)};
   int iDots = 1;
   while (!event.Wait(1000ms))
   {
@@ -610,7 +615,8 @@ bool CApplication::Initialize()
     // Bail out if any of the databases failed to initialize properly.
     CLog::Log(LOGFATAL, "Failed to initialize databases");
 
-    const std::string& dbInitFailedExiting{g_localizeStrings.Get(24187)};
+    const std::string& dbInitFailedExiting{
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24187)};
 
     unsigned int secondsLeftUntilExit{10};
     while (secondsLeftUntilExit)
@@ -632,7 +638,7 @@ bool CApplication::Initialize()
     event.Set();
   });
 
-  std::string localizedStr{g_localizeStrings.Get(39175)};
+  std::string localizedStr{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39175)};
   iDots = 1;
   while (!event.Wait(1000ms))
   {
@@ -679,7 +685,7 @@ bool CApplication::Initialize()
               event.Set();
             },
             CJob::PRIORITY_DEDICATED);
-        localizedStr = g_localizeStrings.Get(24151);
+        localizedStr = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24151);
         iDots = 1;
         while (!event.Wait(1000ms))
         {
@@ -977,13 +983,17 @@ bool CApplication::OnAction(const CAction &action)
 
     if (hdrStatus == HDR_STATUS::HDR_OFF)
     {
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(34220),
-                                            g_localizeStrings.Get(34221));
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Info,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34220),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34221));
     }
     else if (hdrStatus == HDR_STATUS::HDR_ON)
     {
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(34220),
-                                            g_localizeStrings.Get(34222));
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Info,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34220),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34222));
     }
     return true;
   }
@@ -1019,8 +1029,10 @@ bool CApplication::OnAction(const CAction &action)
         default:
           throw std::logic_error("Tonemapping method not found. Did you forget to add a mapping?");
       }
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(34224),
-                                            g_localizeStrings.Get(code), 1000, false, 500);
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Info,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34224),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(code), 1000, false, 500);
     }
     return true;
   }
@@ -1647,7 +1659,7 @@ bool CApplication::Cleanup()
     //  shown are no real leaks, as parts of the app
     //  are still allocated.
 
-    g_localizeStrings.Clear();
+    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Clear();
     g_LangCodeExpander.Clear();
     g_charsetConverter.clear();
     g_directoryCache.Clear();
@@ -1911,8 +1923,9 @@ bool CApplication::PlayMedia(CFileItem& item, const std::string& player, PLAYLIS
   else if (PLAYLIST::IsPlayList(item) || NETWORK::IsInternetStream(item))
   {
     // Not owner. Dialog auto-deletes itself.
-    CGUIDialogCache* dlgCache =
-        new CGUIDialogCache(5s, g_localizeStrings.Get(10214), item.GetLabel());
+    CGUIDialogCache* dlgCache = new CGUIDialogCache(
+        5s, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10214),
+        item.GetLabel());
 
     //is or could be a playlist
     std::unique_ptr<PLAYLIST::CPlayList> playlist;
@@ -2217,7 +2230,8 @@ void CApplication::ConfigureAndEnableAddons()
 
     // migration (incompatible addons) dialog
     auto addonList = StringUtils::Join(disabledAddonNames, ", ");
-    auto msg = StringUtils::Format(g_localizeStrings.Get(24149), addonList);
+    auto msg = StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24149), addonList);
     HELPERS::ShowOKDialogText(CVariant{24148}, CVariant{std::move(msg)});
     m_incompatibleAddons.clear();
   }

--- a/xbmc/application/ApplicationMessageHandling.cpp
+++ b/xbmc/application/ApplicationMessageHandling.cpp
@@ -33,7 +33,6 @@
 #include "filesystem/UPnPDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "interfaces/AnnouncementManager.h"
 #include "interfaces/builtins/Builtins.h"
@@ -54,6 +53,8 @@
 #include "pvr/PVRManager.h"
 #include "pvr/guilib/PVRGUIActionsPowerManagement.h"
 #include "pvr/guilib/PVRGUIActionsRecordings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/ContentUtils.h"
@@ -615,8 +616,8 @@ bool CApplicationMessageHandling::OnMessage(const CGUIMessage& message)
         return false;
       }
 
-      std::unique_ptr<CFileItem> trailerItem =
-          ContentUtils::GeneratePlayableTrailerItem(*item, g_localizeStrings.Get(20410));
+      std::unique_ptr<CFileItem> trailerItem = ContentUtils::GeneratePlayableTrailerItem(
+          *item, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20410));
 
       if (PLAYLIST::IsPlayList(*item))
       {

--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -34,10 +34,11 @@
 #include "guilib/GUIFontManager.h"
 #include "guilib/GUITextureCallbackManager.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/SkinSettings.h"
@@ -145,7 +146,7 @@ bool CApplicationSkinHandling::LoadSkin(const std::string& skinID)
   // load the skin strings in
   //! @todo Move skin language files to resources/language/ to match other addon structure
   const std::string langPath = URIUtils::AddFileToFolder(skin->Path(), "language/");
-  g_localizeStrings.LoadAddonStrings(
+  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().LoadAddonStrings(
       langPath, settings->GetString(CSettings::SETTING_LOCALE_LANGUAGE), skin->ID());
   skin->LoadTimers();
 
@@ -233,7 +234,7 @@ void CApplicationSkinHandling::UnloadSkin()
   if (skin)
   {
     skin->Unload();
-    g_localizeStrings.ClearAddonStrings(skin->ID());
+    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().ClearAddonStrings(skin->ID());
   }
 
   CGUIComponent* gui = CServiceBroker::GetGUI();
@@ -436,8 +437,10 @@ void CApplicationSkinHandling::ReloadSkin(bool confirm)
     {
       m_confirmSkinChange = false;
       setting->Reset();
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(24102),
-                                            g_localizeStrings.Get(24103));
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Error,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24102),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24103));
     }
   }
   m_confirmSkinChange = true;

--- a/xbmc/cdrip/CDDARipJob.cpp
+++ b/xbmc/cdrip/CDDARipJob.cpp
@@ -21,8 +21,9 @@
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "network/NetworkFileItemClassify.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -90,7 +91,8 @@ bool CCDDARipJob::DoWork()
   CGUIDialogExtendedProgressBar* pDlgProgress =
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogExtendedProgressBar>(
           WINDOW_DIALOG_EXT_PROGRESS);
-  CGUIDialogProgressBarHandle* handle = pDlgProgress->GetHandle(g_localizeStrings.Get(605));
+  CGUIDialogProgressBarHandle* handle = pDlgProgress->GetHandle(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(605));
 
   int iTrack = atoi(m_input.substr(13, m_input.size() - 13 - 5).c_str());
   std::string strLine0 =

--- a/xbmc/cdrip/CDDARipper.cpp
+++ b/xbmc/cdrip/CDDARipper.cpp
@@ -18,7 +18,6 @@
 #include "addons/addoninfo/AddonType.h"
 #include "filesystem/CDDADirectory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "music/MusicDatabase.h"
 #include "music/MusicDbUrl.h"
@@ -26,6 +25,8 @@
 #include "music/infoscanner/MusicInfoScanner.h"
 #include "music/tags/MusicInfoTag.h"
 #include "music/tags/MusicInfoTagLoaderFactory.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingPath.h"
@@ -153,7 +154,8 @@ bool CCDDARipper::CreateAlbumDir(const MUSIC_INFO::CMusicInfoTag& infoTag,
     strDirectory = recordingpathSetting->GetValue();
     if (strDirectory.empty())
     {
-      if (CGUIControlButtonSetting::GetPath(recordingpathSetting, &g_localizeStrings))
+      if (CGUIControlButtonSetting::GetPath(
+              recordingpathSetting, &CServiceBroker::GetResourcesComponent().GetLocalizeStrings()))
         strDirectory = recordingpathSetting->GetValue();
     }
   }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESettings.cpp
@@ -12,7 +12,8 @@
 #include "ServiceBroker.h"
 #include "cores/AudioEngine/Engines/ActiveAE/ActiveAE.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/SettingDefinitions.h"
@@ -100,15 +101,20 @@ void CActiveAESettings::SettingOptionsAudioQualityLevelsFiller(
   std::unique_lock lock(m_instance->m_cs);
 
   if (m_instance->m_audioEngine.SupportsQualityLevel(AE_QUALITY_LOW))
-    list.emplace_back(g_localizeStrings.Get(13506), AE_QUALITY_LOW);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13506),
+                      AE_QUALITY_LOW);
   if (m_instance->m_audioEngine.SupportsQualityLevel(AE_QUALITY_MID))
-    list.emplace_back(g_localizeStrings.Get(13507), AE_QUALITY_MID);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13507),
+                      AE_QUALITY_MID);
   if (m_instance->m_audioEngine.SupportsQualityLevel(AE_QUALITY_HIGH))
-    list.emplace_back(g_localizeStrings.Get(13508), AE_QUALITY_HIGH);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13508),
+                      AE_QUALITY_HIGH);
   if (m_instance->m_audioEngine.SupportsQualityLevel(AE_QUALITY_REALLYHIGH))
-    list.emplace_back(g_localizeStrings.Get(13509), AE_QUALITY_REALLYHIGH);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13509),
+                      AE_QUALITY_REALLYHIGH);
   if (m_instance->m_audioEngine.SupportsQualityLevel(AE_QUALITY_GPU))
-    list.emplace_back(g_localizeStrings.Get(38010), AE_QUALITY_GPU);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38010),
+                      AE_QUALITY_GPU);
 }
 
 void CActiveAESettings::SettingOptionsAudioStreamsilenceFiller(
@@ -116,16 +122,22 @@ void CActiveAESettings::SettingOptionsAudioStreamsilenceFiller(
 {
   std::unique_lock lock(m_instance->m_cs);
 
-  list.emplace_back(g_localizeStrings.Get(20422),
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20422),
                     XbmcThreads::EndTime<std::chrono::minutes>::Max().count());
-  list.emplace_back(g_localizeStrings.Get(13551), 0);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13551), 0);
 
   if (m_instance->m_audioEngine.SupportsSilenceTimeout())
   {
-    list.emplace_back(StringUtils::Format(g_localizeStrings.Get(13554), 1), 1);
+    list.emplace_back(
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13554),
+                            1),
+        1);
     for (int i = 2; i <= 10; i++)
     {
-      list.emplace_back(StringUtils::Format(g_localizeStrings.Get(13555), i), i);
+      list.emplace_back(
+          StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13555), i),
+          i);
     }
   }
 }

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -39,13 +39,14 @@
 #include "games/tags/GameInfoTag.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "interfaces/AnnouncementManager.h"
 #include "jobs/JobManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
@@ -176,8 +177,11 @@ bool CRetroPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options
           // overwrite the save
           bool dummy;
           if (!CGUIDialogYesNo::ShowAndGetInput(
-                  438, StringUtils::Format(g_localizeStrings.Get(35217), addon->Name()), dummy, 222,
-                  35218, 0))
+                  438,
+                  StringUtils::Format(
+                      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35217),
+                      addon->Name()),
+                  dummy, 222, 35218, 0))
             bSuccess = false;
         }
       }

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -11,13 +11,15 @@
 #include "FileItem.h"
 #include "FileItemList.h"
 #include "SavestateFlatBuffer.h"
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "XBDateTime.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/IFileTypes.h"
 #include "games/dialogs/DialogGameDefines.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
@@ -171,7 +173,7 @@ void CSavestateDatabase::GetSavestateItem(const ISavestate& savestate,
   if (savestate.Type() == SAVE_TYPE::AUTO)
   {
     label2 = std::move(label);
-    label = g_localizeStrings.Get(15316); // "Autosave"
+    label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15316); // "Autosave"
   }
 
   item.SetLabel(label);

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -8,7 +8,9 @@
 
 #include "DVDDemux.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StreamUtils.h"
 #include "utils/StringUtils.h"
 
@@ -135,7 +137,7 @@ std::string CDemuxStreamAudio::GetStreamType() const
     strInfo = "PCM";
 
   if (strInfo.empty())
-    strInfo = g_localizeStrings.Get(13205); // "Unknown"
+    strInfo = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // "Unknown"
 
   strInfo.append(" ");
   strInfo.append(StreamUtils::GetLayout(iChannels));

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxCC.cpp
@@ -14,7 +14,8 @@
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/DVDCodecs/Overlay/contrib/cc_decoder708.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/ColorUtils.h"
@@ -234,7 +235,8 @@ void CDVDDemuxCC::Handler(int service, void *userdata)
   {
     CDemuxStreamSubtitle stream;
     stream.source = STREAM_SOURCE_VIDEOMUX;
-    stream.name = g_localizeStrings.Get(39206); // Closed Caption "CC"
+    stream.name = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        39206); // Closed Caption "CC"
     stream.language = "und";
 
     auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -16,7 +16,6 @@
 #include "URL.h"
 #include "filesystem/BlurayCallback.h"
 #include "filesystem/SpecialProtocol.h"
-#include "guilib/LocalizeStrings.h"
 #include "settings/DiscSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -15,7 +15,8 @@
 #if defined(TARGET_WINDOWS_STORE)
 #include "filesystem/SpecialProtocol.h"
 #endif
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #if defined(TARGET_WINDOWS_STORE)
 #include "platform/Environment.h"
 #endif
@@ -967,7 +968,7 @@ void CDVDInputStreamNavigator::SetSubtitleStreamName(SubtitleStreamInfo &info, c
       case DVD_SUBPICTURE_LANG_EXT_NORMALDIRECTORSCOMMENTS:
       case DVD_SUBPICTURE_LANG_EXT_BIGDIRECTORSCOMMENTS:
       case DVD_SUBPICTURE_LANG_EXT_CHILDRENDIRECTORSCOMMENTS:
-        info.name = g_localizeStrings.Get(37001);
+        info.name = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37001);
         break;
       default:
         break;
@@ -1016,14 +1017,14 @@ void CDVDInputStreamNavigator::SetAudioStreamName(AudioStreamInfo &info, const a
   switch( audio_attributes.code_extension )
   {
     case DVD_AUDIO_LANG_EXT_VISUALLYIMPAIRED:
-      info.name = g_localizeStrings.Get(37000);
+      info.name = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37000);
       info.flags = StreamFlags::FLAG_VISUAL_IMPAIRED;
       break;
     case DVD_AUDIO_LANG_EXT_DIRECTORSCOMMENTS1:
-      info.name = g_localizeStrings.Get(37001);
+      info.name = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37001);
       break;
     case DVD_AUDIO_LANG_EXT_DIRECTORSCOMMENTS2:
-      info.name = g_localizeStrings.Get(37002);
+      info.name = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37002);
       break;
     case DVD_AUDIO_LANG_EXT_NOTSPECIFIED:
     case DVD_AUDIO_LANG_EXT_NORMALCAPTIONS:
@@ -1038,7 +1039,8 @@ void CDVDInputStreamNavigator::SetAudioStreamName(AudioStreamInfo &info, const a
     info.codecName = "ac3";
     break;
   case DVD_AUDIO_FORMAT_UNKNOWN_1:
-    info.codecDesc = g_localizeStrings.Get(13205); // "Unknown"
+    info.codecDesc =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // "Unknown"
     CLog::LogF(LOGINFO, "unknown dvd audio codec DVD_AUDIO_FORMAT_UNKNOWN_1");
     break;
   case DVD_AUDIO_FORMAT_MPEG:
@@ -1054,7 +1056,8 @@ void CDVDInputStreamNavigator::SetAudioStreamName(AudioStreamInfo &info, const a
     info.codecName = "pcm";
     break;
   case DVD_AUDIO_FORMAT_UNKNOWN_5:
-    info.codecDesc = g_localizeStrings.Get(13205); // "Unknown"
+    info.codecDesc =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // "Unknown"
     CLog::LogF(LOGINFO, "unknown dvd audio codec DVD_AUDIO_FORMAT_UNKNOWN_5");
     break;
   case DVD_AUDIO_FORMAT_DTS:
@@ -1065,7 +1068,8 @@ void CDVDInputStreamNavigator::SetAudioStreamName(AudioStreamInfo &info, const a
     info.codecDesc = "SDDS";
     break;
   default:
-    info.codecDesc = g_localizeStrings.Get(13205); // "Unknown"
+    info.codecDesc =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // "Unknown"
     CLog::LogF(LOGINFO, "unknown dvd audio codec");
     break;
   }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -39,13 +39,14 @@
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
 #include "guilib/GUIComponent.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "interfaces/AnnouncementManager.h"
 #include "jobs/JobQueue.h"
 #include "messaging/ApplicationMessenger.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -599,7 +600,8 @@ void CSelectionStreams::Update(const std::shared_ptr<CDVDInputStream>& input,
       s.width = info.width;
       s.height = info.height;
       s.codec = info.codecName;
-      s.name = StringUtils::Format("{} {}", g_localizeStrings.Get(38032), i);
+      s.name = StringUtils::Format(
+          "{} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38032), i);
       Update(s);
     }
   }

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -32,11 +32,12 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
 #include "music/tags/MusicInfoTag.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRRadioRDSInfoTag.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/CharsetConverter.h"
@@ -884,7 +885,10 @@ unsigned int CDVDRadioRDSData::DecodeTA_TP(const uint8_t* msgElement)
 
   if (traffic_announcement && !m_TA_TP_TrafficAdvisory && traffic_programme && dsn == 0 && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool("pvrplayback.trafficadvisory"))
   {
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(19021), g_localizeStrings.Get(29930));
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Warning,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19021),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(29930));
     m_TA_TP_TrafficAdvisory = true;
     auto& components = CServiceBroker::GetAppComponents();
     const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
@@ -979,14 +983,23 @@ unsigned int CDVDRadioRDSData::DecodePTY(const uint8_t* msgElement)
     // save info
     m_currentInfoTag->SetRadioStyle(pty_skin_info_table[m_PTY][m_RDS_IsRBDS].style_name);
     if (!m_RTPlus_GenrePresent && !m_PTYN_Present)
-      SetRadioStyle(g_localizeStrings.Get(pty_skin_info_table[m_PTY][m_RDS_IsRBDS].name));
+      SetRadioStyle(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          pty_skin_info_table[m_PTY][m_RDS_IsRBDS].name));
 
     if (m_PTY == RDS_PTY_ALARM_TEST)
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(29931), g_localizeStrings.Get(29970), TOAST_DISPLAY_TIME, false);
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Info,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(29931),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(29970),
+          TOAST_DISPLAY_TIME, false);
 
     if (m_PTY == RDS_PTY_ALARM)
     {
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(29931), g_localizeStrings.Get(29971), TOAST_DISPLAY_TIME*2, true);
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Warning,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(29931),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(29971),
+          TOAST_DISPLAY_TIME * 2, true);
     }
   }
 
@@ -1008,8 +1021,11 @@ unsigned int CDVDRadioRDSData::DecodePTYN(uint8_t *msgElement)
 
   if (!m_RTPlus_GenrePresent)
   {
-    std::string progTypeName = StringUtils::Format(
-        "{}: {}", g_localizeStrings.Get(pty_skin_info_table[m_PTY][m_RDS_IsRBDS].name), m_PTYN);
+    std::string progTypeName =
+        StringUtils::Format("{}: {}",
+                            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                pty_skin_info_table[m_PTY][m_RDS_IsRBDS].name),
+                            m_PTYN);
     SetRadioStyle(progTypeName);
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -12,7 +12,8 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -518,11 +519,17 @@ void CBaseRenderer::SettingOptionsRenderMethodsFiller(
     std::vector<IntegerSettingOption>& list,
     int& current)
 {
-  list.emplace_back(g_localizeStrings.Get(13416), RENDER_METHOD_AUTO);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13416),
+                    RENDER_METHOD_AUTO);
 
 #ifdef HAS_DX
-  list.push_back(IntegerSettingOption(g_localizeStrings.Get(16319), RENDER_METHOD_DXVA));
-  list.push_back(IntegerSettingOption(g_localizeStrings.Get(13431), RENDER_METHOD_D3D_PS));
-  list.push_back(IntegerSettingOption(g_localizeStrings.Get(13419), RENDER_METHOD_SOFTWARE));
+  list.push_back(IntegerSettingOption(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16319), RENDER_METHOD_DXVA));
+  list.push_back(
+      IntegerSettingOption(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13431),
+                           RENDER_METHOD_D3D_PS));
+  list.push_back(
+      IntegerSettingOption(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13419),
+                           RENDER_METHOD_SOFTWARE));
 #endif
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererHQ.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererHQ.cpp
@@ -10,9 +10,10 @@
 
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "guilib/LocalizeStrings.h"
 #include "rendering/dx/DeviceResources.h"
 #include "rendering/dx/RenderContext.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -133,7 +134,10 @@ void CRendererHQ::UpdateVideoFilters()
         // we are in a big trouble
         m_scalerShader.reset();
         m_bUseHQScaler = false;
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(34400), g_localizeStrings.Get(34401));
+        CGUIDialogKaiToast::QueueNotification(
+            CGUIDialogKaiToast::Error,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34400),
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34401));
       }
     }
   }

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -16,9 +16,10 @@
 #include "cores/IPlayerCallback.h"
 #include "cores/VideoPlayer/Interface/InputStreamConstants.h"
 #include "dialogs/GUIDialogContextMenu.h"
-#include "guilib/LocalizeStrings.h"
 #include "music/MusicFileItemClassify.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -311,7 +312,7 @@ std::string CPlayerCoreFactory::SelectPlayerDialog(const std::vector<std::string
     //Add default player
     std::string strCaption = players[0];
     strCaption += " (";
-    strCaption += g_localizeStrings.Get(13278);
+    strCaption += CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13278);
     strCaption += ")";
     choices.Add(0, strCaption);
 

--- a/xbmc/dbwrappers/DatabaseQuery.cpp
+++ b/xbmc/dbwrappers/DatabaseQuery.cpp
@@ -9,8 +9,10 @@
 #include "DatabaseQuery.h"
 
 #include "Database.h"
+#include "ServiceBroker.h"
 #include "XBDateTime.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
@@ -212,8 +214,8 @@ std::string CDatabaseQueryRule::GetLocalizedOperator(SearchOperator oper)
 {
   for (const auto& o : operators)
     if (oper == o.op)
-      return g_localizeStrings.Get(o.localizedName);
-  return g_localizeStrings.Get(16018);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(o.localizedName);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16018);
 }
 
 void CDatabaseQueryRule::GetAvailableOperators(std::vector<std::string>& operatorList)

--- a/xbmc/dialogs/GUIDialogBoxBase.cpp
+++ b/xbmc/dialogs/GUIDialogBoxBase.cpp
@@ -8,8 +8,10 @@
 
 #include "GUIDialogBoxBase.h"
 
+#include "ServiceBroker.h"
 #include "guilib/GUIMessage.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
@@ -183,14 +185,16 @@ std::string CGUIDialogBoxBase::GetLocalized(const CVariant &var) const
   if (var.isString())
     return var.asString();
   else if (var.isInteger() && var.asInteger())
-    return g_localizeStrings.Get((uint32_t)var.asInteger());
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        (uint32_t)var.asInteger());
   return "";
 }
 
 std::string CGUIDialogBoxBase::GetDefaultLabel(int controlId) const
 {
   int labelId = GetDefaultLabelID(controlId);
-  return labelId != -1 ? g_localizeStrings.Get(labelId) : "";
+  return labelId != -1 ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(labelId)
+                       : "";
 }
 
 int CGUIDialogBoxBase::GetDefaultLabelID(int controlId) const

--- a/xbmc/dialogs/GUIDialogCache.cpp
+++ b/xbmc/dialogs/GUIDialogCache.cpp
@@ -12,8 +12,9 @@
 #include "dialogs/GUIDialogProgress.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "threads/SystemClock.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -89,7 +90,7 @@ void CGUIDialogCache::SetHeader(const std::string& strHeader)
 
 void CGUIDialogCache::SetHeader(int nHeader)
 {
-  SetHeader(g_localizeStrings.Get(nHeader));
+  SetHeader(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(nHeader));
 }
 
 void CGUIDialogCache::SetMessage(const std::string& strMessage)

--- a/xbmc/dialogs/GUIDialogColorPicker.cpp
+++ b/xbmc/dialogs/GUIDialogColorPicker.cpp
@@ -10,11 +10,13 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
+#include "ServiceBroker.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIColorManager.h"
 #include "guilib/GUIMessage.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/ActionIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/ColorUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -230,10 +232,13 @@ void CGUIDialogColorPicker::OnInitWindow()
   m_viewControl.SetItems(*m_vecList);
   m_viewControl.SetCurrentView(CONTROL_ICON_LIST);
 
-  SET_CONTROL_LABEL(CONTROL_NUMBER_OF_ITEMS,
-                    StringUtils::Format("{} {}", m_vecList->Size(), g_localizeStrings.Get(127)));
+  SET_CONTROL_LABEL(
+      CONTROL_NUMBER_OF_ITEMS,
+      StringUtils::Format("{} {}", m_vecList->Size(),
+                          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(127)));
 
-  SET_CONTROL_LABEL(CONTROL_CANCEL_BUTTON, g_localizeStrings.Get(222));
+  SET_CONTROL_LABEL(CONTROL_CANCEL_BUTTON,
+                    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(222));
 
   CGUIDialogBoxBase::OnInitWindow();
 

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -24,13 +24,14 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIControlGroupList.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "media/MediaLockState.h"
 #include "music/MusicFileItemClassify.h"
 #include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -62,7 +63,8 @@ void CContextButtons::Add(unsigned int button, int label)
   for (const auto& i : *this)
     if (i.first == button)
       return; // already have added this button
-  push_back(std::pair<unsigned int, std::string>(button, g_localizeStrings.Get(label)));
+  push_back(std::pair<unsigned int, std::string>(
+      button, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(label)));
 }
 
 CGUIDialogContextMenu::CGUIDialogContextMenu(void)
@@ -414,14 +416,14 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       {
         CFileItemPtr current(new CFileItem("thumb://Current", false));
         current->SetArt("thumb", share->m_strThumbnailImage);
-        current->SetLabel(g_localizeStrings.Get(20016));
+        current->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20016));
         items.Add(current);
       }
       else if (item->HasArt("thumb"))
       { // already have a thumb that the share doesn't know about - must be a local one, so we mayaswell reuse it.
         CFileItemPtr current(new CFileItem("thumb://Current", false));
         current->SetArt("thumb", item->GetArt("thumb"));
-        current->SetLabel(g_localizeStrings.Get(20016));
+        current->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20016));
         items.Add(current);
       }
       // see if there's a local thumb for this item
@@ -430,19 +432,21 @@ bool CGUIDialogContextMenu::OnContextButton(const std::string &type, const CFile
       {
         CFileItemPtr local(new CFileItem("thumb://Local", false));
         local->SetArt("thumb", folderThumb);
-        local->SetLabel(g_localizeStrings.Get(20017));
+        local->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20017));
         items.Add(local);
       }
       // and add a "no thumb" entry as well
       CFileItemPtr nothumb(new CFileItem("thumb://None", false));
       nothumb->SetArt("icon", item->GetArt("icon"));
-      nothumb->SetLabel(g_localizeStrings.Get(20018));
+      nothumb->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20018));
       items.Add(nothumb);
 
       std::string strThumb;
       std::vector<CMediaSource> shares;
       CServiceBroker::GetMediaManager().GetLocalDrives(shares);
-      if (!CGUIDialogFileBrowser::ShowAndGetImage(items, shares, g_localizeStrings.Get(1030), strThumb))
+      if (!CGUIDialogFileBrowser::ShowAndGetImage(
+              items, shares, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1030),
+              strThumb))
         return false;
 
       if (strThumb == "thumb://Current")

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -26,13 +26,14 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "network/GUIDialogNetworkSetup.h"
 #include "network/Network.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
@@ -245,7 +246,10 @@ bool CGUIDialogFileBrowser::OnMessage(CGUIMessage& message)
       else if (message.GetSenderId() == CONTROL_NEWFOLDER)
       {
         std::string strInput;
-        if (CGUIKeyboardFactory::ShowAndGetInput(strInput, CVariant{g_localizeStrings.Get(119)}, false))
+        if (CGUIKeyboardFactory::ShowAndGetInput(
+                strInput,
+                CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(119)},
+                false))
         {
           std::string strPath = URIUtils::AddFileToFolder(m_vecItems->GetPath(), strInput);
           if (CDirectory::Create(strPath))
@@ -439,14 +443,16 @@ void CGUIDialogFileBrowser::Update(const std::string &strDirectory)
        CServiceBroker::GetSettingsComponent()->GetProfileManager()->IsMasterProfile() ||
        g_passwordManager.bMasterUser))
   { // we are in the virtual directory - add the "Add Network Location" item
-    CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(1032)));
+    CFileItemPtr pItem(
+        new CFileItem(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1032)));
     pItem->SetPath("net://");
     pItem->SetFolder(true);
     m_vecItems->Add(pItem);
   }
   if (m_Directory->GetPath().empty() && !m_addSourceType.empty())
   {
-    CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(21359)));
+    CFileItemPtr pItem(
+        new CFileItem(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21359)));
     pItem->SetPath("source://");
     pItem->SetFolder(true);
     m_vecItems->Add(pItem);
@@ -496,7 +502,9 @@ void CGUIDialogFileBrowser::FrameMove()
       m_selectedPath = (*m_vecItems)[item]->GetPath();
     if (m_selectedPath == "net://")
     {
-      SET_CONTROL_LABEL(CONTROL_LABEL_PATH, g_localizeStrings.Get(1032)); // "Add Network Location..."
+      SET_CONTROL_LABEL(CONTROL_LABEL_PATH,
+                        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                            1032)); // "Add Network Location..."
     }
     else
     {
@@ -650,7 +658,7 @@ bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList& items,
   if (true)
   {
     CFileItemPtr item(new CFileItem("image://Browse", false));
-    item->SetLabel(g_localizeStrings.Get(20153));
+    item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20153));
     item->SetArt("icon", "DefaultFolder.png");
     browser->m_vecItems->Add(item);
   }
@@ -664,7 +672,8 @@ bool CGUIDialogFileBrowser::ShowAndGetImage(const CFileItemList& items,
     if (result == "image://Browse")
     { // "Browse for thumb"
       CServiceBroker::GetGUI()->GetWindowManager().Delete(browser->GetID());
-      return ShowAndGetImage(shares, g_localizeStrings.Get(label), result);
+      return ShowAndGetImage(
+          shares, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(label), result);
     }
   }
 
@@ -775,7 +784,7 @@ bool CGUIDialogFileBrowser::ShowAndGetFile(const std::string &directory, const s
     browser->m_vecItems->Clear();
     CDirectory::GetDirectory(directory,*browser->m_vecItems, "", DIR_FLAG_DEFAULTS);
     CFileItemPtr item(new CFileItem("file://Browse", false));
-    item->SetLabel(g_localizeStrings.Get(20153));
+    item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20153));
     item->SetArt("icon", "DefaultFolder.png");
     browser->m_vecItems->Add(item);
     browser->m_singleList = true;
@@ -882,7 +891,7 @@ bool CGUIDialogFileBrowser::ShowAndGetSource(
   }
   else
   {
-    browser->SetHeading(g_localizeStrings.Get(1023));
+    browser->SetHeading(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1023));
 
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
 

--- a/xbmc/dialogs/GUIDialogGamepad.cpp
+++ b/xbmc/dialogs/GUIDialogGamepad.cpp
@@ -12,11 +12,12 @@
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "input/keyboard/KeyIDs.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/Digest.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
@@ -153,7 +154,8 @@ bool CGUIDialogGamepad::OnMessage(CGUIMessage& message)
     {
       m_bConfirmed = false;
       m_bCanceled = false;
-      m_cHideInputChar = g_localizeStrings.Get(12322).c_str()[0];
+      m_cHideInputChar =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12322).c_str()[0];
       CGUIDialog::OnMessage(message);
       return true;
     }
@@ -236,13 +238,17 @@ int CGUIDialogGamepad::ShowAndVerifyPassword(std::string& strPassword, const std
   if (0 < iRetries)
   {
     // Show a string telling user they have iRetries retries left
-    strLine2 = StringUtils::Format("{} {} {}", g_localizeStrings.Get(12342), iRetries,
-                                   g_localizeStrings.Get(12343));
+    strLine2 = StringUtils::Format(
+        "{} {} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12342),
+        iRetries, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12343));
   }
 
   // make a copy of strPassword to prevent from overwriting it later
   std::string strPassTemp = strPassword;
-  if (ShowAndVerifyInput(strPassTemp, dlgHeading, g_localizeStrings.Get(12330), g_localizeStrings.Get(12331), strLine2, true, true))
+  if (ShowAndVerifyInput(strPassTemp, dlgHeading,
+                         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12330),
+                         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12331),
+                         strLine2, true, true))
   {
     // user entered correct password
     return 0;

--- a/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardGeneric.cpp
@@ -16,7 +16,6 @@
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUILabelControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/InputCodingTable.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
@@ -25,6 +24,8 @@
 #include "input/keyboard/XBMC_vkeys.h"
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "speech/ISpeechRecognition.h"
@@ -74,9 +75,10 @@ public:
 
   void OnReadyForSpeech() override
   {
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
-                                          g_localizeStrings.Get(39177), // Speech to text
-                                          g_localizeStrings.Get(39179)); // Listening...
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Info,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39177), // Speech to text
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39179)); // Listening...
   }
 
   void OnError(int recognitionError) override
@@ -98,9 +100,10 @@ public:
         break;
     }
 
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
-                                          g_localizeStrings.Get(39177), // Speech to text
-                                          g_localizeStrings.Get(msgId));
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Error,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39177), // Speech to text
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(msgId));
   }
 
   void OnResults(const std::vector<std::string>& results) override
@@ -216,7 +219,8 @@ void CGUIDialogKeyboardGeneric::OnInitWindow()
   if (m_hiddenInput)
   {
     SET_CONTROL_VISIBLE(CTL_BUTTON_REVEAL);
-    SET_CONTROL_LABEL(CTL_BUTTON_REVEAL, g_localizeStrings.Get(12308));
+    SET_CONTROL_LABEL(CTL_BUTTON_REVEAL,
+                      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12308));
   }
   else
     SET_CONTROL_HIDDEN(CTL_BUTTON_REVEAL);
@@ -612,7 +616,9 @@ void CGUIDialogKeyboardGeneric::OnSymbols()
 void CGUIDialogKeyboardGeneric::OnReveal()
 {
   m_hiddenInput = !m_hiddenInput;
-  SET_CONTROL_LABEL(CTL_BUTTON_REVEAL, g_localizeStrings.Get(m_hiddenInput ? 12308 : 12309));
+  SET_CONTROL_LABEL(CTL_BUTTON_REVEAL,
+                    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                        m_hiddenInput ? 12308 : 12309));
   CGUIMessage msg(GUI_MSG_SET_TYPE, GetID(), CTL_EDIT,
                   m_hiddenInput ? CGUIEditControl::INPUT_TYPE_PASSWORD
                                 : CGUIEditControl::INPUT_TYPE_TEXT);
@@ -642,7 +648,8 @@ void CGUIDialogKeyboardGeneric::OnIPAddress()
   }
   else
     start = text.size();
-  if (CGUIDialogNumeric::ShowAndGetIPAddress(ip, g_localizeStrings.Get(14068)))
+  if (CGUIDialogNumeric::ShowAndGetIPAddress(
+          ip, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14068)))
     SetEditText(text.substr(0, start) + ip + text.substr(start + length));
 }
 

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -16,10 +16,11 @@
 #include "XBDateTime.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "music/MusicDatabase.h"
 #include "music/MusicDbUrl.h"
 #include "playlists/SmartPlayList.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/SettingUtils.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDefinitions.h"
@@ -375,8 +376,11 @@ void CGUIDialogMediaFilter::SetupView()
     localizedMediaId = 134;
 
   // set the heading
-  SET_CONTROL_LABEL(CONTROL_HEADING, StringUtils::Format(g_localizeStrings.Get(1275),
-                                                         g_localizeStrings.Get(localizedMediaId)));
+  SET_CONTROL_LABEL(
+      CONTROL_HEADING,
+      StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1275),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(localizedMediaId)));
 
   SET_CONTROL_LABEL(CONTROL_OKAY_BUTTON, 186);
   SET_CONTROL_LABEL(CONTROL_CLEAR_BUTTON, 192);
@@ -616,7 +620,8 @@ void CGUIDialogMediaFilter::UpdateControls()
     std::vector<std::string> items;
     int size = GetItems(itFilter.second, items, true);
 
-    std::string label = g_localizeStrings.Get(itFilter.second.label);
+    std::string label =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(itFilter.second.label);
     BaseSettingControlPtr control = GetSettingControl(itFilter.second.setting->GetId());
     if (control == NULL)
       continue;
@@ -627,7 +632,8 @@ void CGUIDialogMediaFilter::UpdateControls()
     else
     {
       CONTROL_ENABLE(control->GetID());
-      label = StringUtils::Format(g_localizeStrings.Get(21470), label, size);
+      label = StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21470), label, size);
     }
     SET_CONTROL_LABEL(control->GetID(), label);
   }

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -21,10 +21,11 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/ActionIDs.h"
 #include "music/windows/GUIWindowMusicBase.h"
 #include "pvr/recordings/PVRRecordingsPath.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -243,6 +244,8 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     m_bNameChanged = true;
   path.clear();
 
+  auto& localizeStrings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
+
   if (m_type == "music")
   {
     CMediaSource share1;
@@ -253,7 +256,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
         CDirectory::Exists(path))
     {
       share1.strPath = path;
-      share1.strName = g_localizeStrings.Get(20240);
+      share1.strName = localizeStrings.Get(20240);
       share1.m_ignore = true;
       extraShares.push_back(share1);
     }
@@ -265,7 +268,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     if (XFILE::CWinLibraryDirectory::GetStoragePath(m_type, path) && !path.empty() && CDirectory::Exists(path))
     {
       share1.strPath = path;
-      share1.strName = g_localizeStrings.Get(20245);
+      share1.strName = localizeStrings.Get(20245);
       share1.m_ignore = true;
       extraShares.push_back(share1);
     }
@@ -273,7 +276,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
 
     // add the music playlist location
     share1.strPath = "special://musicplaylists/";
-    share1.strName = g_localizeStrings.Get(20011);
+    share1.strName = localizeStrings.Get(20011);
     share1.m_ignore = true;
     extraShares.push_back(share1);
 
@@ -281,13 +284,13 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     if (CPVRDirectory::HasRadioRecordings())
     {
       share1.strPath = PVR::CPVRRecordingsPath::PATH_ACTIVE_RADIO_RECORDINGS;
-      share1.strName = g_localizeStrings.Get(19017); // Recordings
+      share1.strName = localizeStrings.Get(19017); // Recordings
       extraShares.push_back(share1);
     }
     if (CPVRDirectory::HasDeletedRadioRecordings())
     {
       share1.strPath = PVR::CPVRRecordingsPath::PATH_DELETED_RADIO_RECORDINGS;
-      share1.strName = g_localizeStrings.Get(19184); // Deleted recordings
+      share1.strName = localizeStrings.Get(19184); // Deleted recordings
       extraShares.push_back(share1);
     }
 
@@ -297,7 +300,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
              .empty())
     {
       share1.strPath = "special://recordings/";
-      share1.strName = g_localizeStrings.Get(21883);
+      share1.strName = localizeStrings.Get(21883);
       extraShares.push_back(share1);
     }
   }
@@ -311,7 +314,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
         CFileUtils::Exists(path))
     {
       share1.strPath = path;
-      share1.strName = g_localizeStrings.Get(20241);
+      share1.strName = localizeStrings.Get(20241);
       share1.m_ignore = true;
       extraShares.push_back(share1);
     }
@@ -322,7 +325,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     if (XFILE::CWinLibraryDirectory::GetStoragePath(m_type, path) && !path.empty() && CDirectory::Exists(path))
     {
       share1.strPath = path;
-      share1.strName = g_localizeStrings.Get(20246);
+      share1.strName = localizeStrings.Get(20246);
       share1.m_ignore = true;
       extraShares.push_back(share1);
     }
@@ -331,20 +334,20 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     // add the video playlist location
     share1.m_ignore = true;
     share1.strPath = "special://videoplaylists/";
-    share1.strName = g_localizeStrings.Get(20012);
+    share1.strName = localizeStrings.Get(20012);
     extraShares.push_back(share1);
 
     // add the recordings dir as needed
     if (CPVRDirectory::HasTVRecordings())
     {
       share1.strPath = PVR::CPVRRecordingsPath::PATH_ACTIVE_TV_RECORDINGS;
-      share1.strName = g_localizeStrings.Get(19017); // Recordings
+      share1.strName = localizeStrings.Get(19017); // Recordings
       extraShares.push_back(share1);
     }
     if (CPVRDirectory::HasDeletedTVRecordings())
     {
       share1.strPath = PVR::CPVRRecordingsPath::PATH_DELETED_TV_RECORDINGS;
-      share1.strName = g_localizeStrings.Get(19184); // Deleted recordings
+      share1.strName = localizeStrings.Get(19184); // Deleted recordings
       extraShares.push_back(share1);
     }
   }
@@ -358,7 +361,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
         CFileUtils::Exists(path))
     {
       share1.strPath = path;
-      share1.strName = g_localizeStrings.Get(20242);
+      share1.strName = localizeStrings.Get(20242);
       share1.m_ignore = true;
       extraShares.push_back(share1);
     }
@@ -368,7 +371,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
         CFileUtils::Exists(path))
     {
       share1.strPath = path;
-      share1.strName = g_localizeStrings.Get(20243);
+      share1.strName = localizeStrings.Get(20243);
       share1.m_ignore = true;
       extraShares.push_back(share1);
     }
@@ -379,7 +382,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     if (XFILE::CWinLibraryDirectory::GetStoragePath(m_type, path) && !path.empty() && CDirectory::Exists(path))
     {
       share1.strPath = path;
-      share1.strName = g_localizeStrings.Get(20247);
+      share1.strName = localizeStrings.Get(20247);
       share1.m_ignore = true;
       extraShares.push_back(share1);
     }
@@ -387,7 +390,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
     if (XFILE::CWinLibraryDirectory::GetStoragePath("photos", path) && !path.empty() && CDirectory::Exists(path))
     {
       share1.strPath = path;
-      share1.strName = g_localizeStrings.Get(20248);
+      share1.strName = localizeStrings.Get(20248);
       share1.m_ignore = true;
       extraShares.push_back(share1);
     }
@@ -400,7 +403,7 @@ void CGUIDialogMediaSource::OnPathBrowse(int item)
              .empty())
     {
       share1.strPath = "special://screenshots/";
-      share1.strName = g_localizeStrings.Get(20008);
+      share1.strName = localizeStrings.Get(20008);
       extraShares.push_back(share1);
     }
   }
@@ -436,7 +439,9 @@ void CGUIDialogMediaSource::OnPath(int item)
   if (m_name != CUtil::GetTitleFromPath(path))
     m_bNameChanged = true;
 
-  CGUIKeyboardFactory::ShowAndGetInput(path, CVariant{ g_localizeStrings.Get(1021) }, false);
+  CGUIKeyboardFactory::ShowAndGetInput(
+      path, CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1021)},
+      false);
   m_paths->Get(item)->SetPath(path);
 
   if (!m_bNameChanged || m_name.empty())
@@ -496,7 +501,8 @@ void CGUIDialogMediaSource::UpdateButtons()
     CURL url(item->GetPath());
     path = url.GetWithoutUserDetails();
     if (path.empty())
-      path = g_localizeStrings.Get(1020); // "Enter path..."
+      path =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1020); // "Enter path..."
     item->SetLabel(path);
   }
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_PATH, 0, 0, m_paths);
@@ -526,36 +532,37 @@ void CGUIDialogMediaSource::SetShare(const CMediaSource &share)
 void CGUIDialogMediaSource::SetTypeOfMedia(const std::string &type, bool editNotAdd)
 {
   m_type = type;
+  auto& localizeStrings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
   std::string heading;
   if (editNotAdd)
   {
     if (type == "video")
-      heading = g_localizeStrings.Get(10053);
+      heading = localizeStrings.Get(10053);
     else if (type == "music")
-      heading = g_localizeStrings.Get(10054);
+      heading = localizeStrings.Get(10054);
     else if (type == "pictures")
-      heading = g_localizeStrings.Get(10055);
+      heading = localizeStrings.Get(10055);
     else if (type == "games")
-      heading = g_localizeStrings.Get(35252); // "Edit game source"
+      heading = localizeStrings.Get(35252); // "Edit game source"
     else if (type == "programs")
-      heading = g_localizeStrings.Get(10056);
+      heading = localizeStrings.Get(10056);
     else
-      heading = g_localizeStrings.Get(10057);
+      heading = localizeStrings.Get(10057);
   }
   else
   {
     if (type == "video")
-      heading = g_localizeStrings.Get(10048);
+      heading = localizeStrings.Get(10048);
     else if (type == "music")
-      heading = g_localizeStrings.Get(10049);
+      heading = localizeStrings.Get(10049);
     else if (type == "pictures")
-      heading = g_localizeStrings.Get(13006);
+      heading = localizeStrings.Get(13006);
     else if (type == "games")
-      heading = g_localizeStrings.Get(35251); // "Add game source"
+      heading = localizeStrings.Get(35251); // "Add game source"
     else if (type == "programs")
-      heading = g_localizeStrings.Get(10051);
+      heading = localizeStrings.Get(10051);
     else
-      heading = g_localizeStrings.Get(10052);
+      heading = localizeStrings.Get(10052);
   }
   SET_CONTROL_LABEL(CONTROL_HEADING, heading);
 }

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -13,13 +13,14 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUILabelControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "input/keyboard/KeyIDs.h"
 #include "input/keyboard/XBMC_vkeys.h"
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/Digest.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
@@ -558,7 +559,8 @@ bool CGUIDialogNumeric::ShowAndVerifyNewPassword(std::string& strNewPassword)
 {
   // Prompt user for password input
   std::string strUserInput;
-  InputVerificationResult ret = ShowAndVerifyInput(strUserInput, g_localizeStrings.Get(12340), false);
+  InputVerificationResult ret = ShowAndVerifyInput(
+      strUserInput, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12340), false);
   if (ret != InputVerificationResult::SUCCESS)
   {
     if (ret == InputVerificationResult::FAILED)
@@ -574,7 +576,8 @@ bool CGUIDialogNumeric::ShowAndVerifyNewPassword(std::string& strNewPassword)
     return false;
 
   // Prompt again for password input, this time sending previous input as the password to verify
-  ret = ShowAndVerifyInput(strUserInput, g_localizeStrings.Get(12341), true);
+  ret = ShowAndVerifyInput(
+      strUserInput, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12341), true);
   if (ret != InputVerificationResult::SUCCESS)
   {
     if (ret == InputVerificationResult::FAILED)
@@ -601,8 +604,10 @@ int CGUIDialogNumeric::ShowAndVerifyPassword(std::string& strPassword, const std
   if (iRetries > 0)
   {
     // Show a string telling user they have iRetries retries left
-    strTempHeading = StringUtils::Format("{}. {} {} {}", strHeading, g_localizeStrings.Get(12342),
-                                         iRetries, g_localizeStrings.Get(12343));
+    strTempHeading = StringUtils::Format(
+        "{}. {} {} {}", strHeading,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12342), iRetries,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12343));
   }
 
   // make a copy of strPassword to prevent from overwriting it later

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -11,8 +11,9 @@
 #include "ServiceBroker.h"
 #include "guilib/GUIProgressControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "threads/Event.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -118,7 +119,8 @@ bool CGUIDialogProgress::OnMessage(CGUIMessage& message)
           {
             std::string strHeading = m_strHeading;
             strHeading.append(" : ");
-            strHeading.append(g_localizeStrings.Get(16024));
+            strHeading.append(
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16024));
             CGUIDialogBoxBase::SetHeading(CVariant{strHeading});
             m_iChoice = CHOICE_CANCELED;
           }

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -10,9 +10,11 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
+#include "ServiceBroker.h"
 #include "guilib/GUIMessage.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/ActionIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 #include <memory>
@@ -230,7 +232,7 @@ const std::vector<int>& CGUIDialogSelect::GetSelectedItems() const
 void CGUIDialogSelect::EnableButton(bool enable, int label)
 {
   m_bButtonEnabled = enable;
-  m_buttonLabel = g_localizeStrings.Get(label);
+  m_buttonLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(label);
 }
 
 void CGUIDialogSelect::EnableButton(bool enable, const std::string& label)
@@ -242,7 +244,7 @@ void CGUIDialogSelect::EnableButton(bool enable, const std::string& label)
 void CGUIDialogSelect::EnableButton2(bool enable, int label)
 {
   m_bButton2Enabled = enable;
-  m_button2Label = g_localizeStrings.Get(label);
+  m_button2Label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(label);
 }
 
 void CGUIDialogSelect::EnableButton2(bool enable, const std::string& label)
@@ -354,8 +356,10 @@ void CGUIDialogSelect::OnInitWindow()
   }
   m_viewControl.SetCurrentView(m_useDetails ? CONTROL_DETAILED_LIST : CONTROL_SIMPLE_LIST);
 
-  SET_CONTROL_LABEL(CONTROL_NUMBER_OF_ITEMS,
-                    StringUtils::Format("{} {}", m_vecList->Size(), g_localizeStrings.Get(127)));
+  SET_CONTROL_LABEL(
+      CONTROL_NUMBER_OF_ITEMS,
+      StringUtils::Format("{} {}", m_vecList->Size(),
+                          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(127)));
 
   if (m_multiSelection)
     EnableButton(true, 186);
@@ -376,7 +380,8 @@ void CGUIDialogSelect::OnInitWindow()
   else
     SET_CONTROL_HIDDEN(CONTROL_EXTRA_BUTTON2);
 
-  SET_CONTROL_LABEL(CONTROL_CANCEL_BUTTON, g_localizeStrings.Get(222));
+  SET_CONTROL_LABEL(CONTROL_CANCEL_BUTTON,
+                    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(222));
 
   CGUIDialogBoxBase::OnInitWindow();
 

--- a/xbmc/dialogs/GUIDialogSlider.cpp
+++ b/xbmc/dialogs/GUIDialogSlider.cpp
@@ -12,9 +12,10 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUISliderControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 #define CONTROL_HEADING 10
 #define CONTROL_SLIDER  11
@@ -120,7 +121,8 @@ void CGUIDialogSlider::Display(int label, float value, float min, float delta, f
   // set the label and value
   slider->Initialize();
   slider->SetAutoClose(1000);
-  slider->SetSlider(g_localizeStrings.Get(label), value, min, delta, max, callback, NULL);
+  slider->SetSlider(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(label), value,
+                    min, delta, max, callback, NULL);
   slider->SetModalityType(DialogModalityType::MODELESS);
   slider->Open();
 }

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -19,9 +19,10 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/ActionIDs.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/SortUtils.h"
@@ -227,7 +228,10 @@ void CGUIDialogSmartPlaylistEditor::OnOK()
   {
     std::string filename(CUtil::MakeLegalFileName(m_playlist.m_playlistName));
     std::string path;
-    if (CGUIKeyboardFactory::ShowAndGetInput(filename, CVariant{g_localizeStrings.Get(16013)}, false))
+    if (CGUIKeyboardFactory::ShowAndGetInput(
+            filename,
+            CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16013)},
+            false))
     {
       path = URIUtils::AddFileToFolder(systemPlaylistsPath, m_playlist.GetSaveLocation(),
                                        CUtil::MakeLegalFileName(std::move(filename)));
@@ -300,9 +304,10 @@ void CGUIDialogSmartPlaylistEditor::OnLimit()
     if (*limit == static_cast<int>(m_playlist.m_limit))
       selected = std::distance(limits.begin(), limit);
     if (*limit == 0)
-      dialog->Add(g_localizeStrings.Get(21428));
+      dialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21428));
     else
-      dialog->Add(StringUtils::Format(g_localizeStrings.Get(21436), *limit));
+      dialog->Add(StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21436), *limit));
   }
   dialog->SetHeading(CVariant{ 21427 });
   dialog->SetSelected(selected);
@@ -348,9 +353,11 @@ void CGUIDialogSmartPlaylistEditor::OnOrder()
   CGUIDialogSelect* dialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
   dialog->Reset();
   for (auto order: orders)
-    dialog->Add(g_localizeStrings.Get(SortUtils::GetSortLabel(order)));
+    dialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        SortUtils::GetSortLabel(order)));
   dialog->SetHeading(CVariant{ 21429 });
-  dialog->SetSelected(g_localizeStrings.Get(SortUtils::GetSortLabel(m_playlist.m_orderField)));
+  dialog->SetSelected(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      SortUtils::GetSortLabel(m_playlist.m_orderField)));
   dialog->Open();
   int newSelected = dialog->GetSelectedItem();
   if (!dialog->IsConfirmed() || newSelected < 0 || orders[newSelected] == m_playlist.m_orderField)
@@ -403,7 +410,8 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
 
   if (m_mode == "partyvideo" || m_mode == "partymusic")
   {
-    SET_CONTROL_LABEL2(CONTROL_NAME, g_localizeStrings.Get(16035));
+    SET_CONTROL_LABEL2(CONTROL_NAME,
+                       CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16035));
     CONTROL_DISABLE(CONTROL_NAME);
   }
   else
@@ -412,15 +420,23 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
   UpdateRuleControlButtons();
 
   if (m_playlist.m_ruleCombination.GetType() == CDatabaseQueryRuleCombination::Type::COMBINATION_OR)
-    SET_CONTROL_LABEL2(CONTROL_MATCH, g_localizeStrings.Get(21426)); // one or more of the rules
+    SET_CONTROL_LABEL2(CONTROL_MATCH,
+                       CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                           21426)); // one or more of the rules
   else
-    SET_CONTROL_LABEL2(CONTROL_MATCH, g_localizeStrings.Get(21425)); // all of the rules
+    SET_CONTROL_LABEL2(CONTROL_MATCH,
+                       CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                           21425)); // all of the rules
   CONTROL_ENABLE_ON_CONDITION(CONTROL_MATCH, m_playlist.m_ruleCombination.GetRulesAmount() > 1);
   if (m_playlist.m_limit == 0)
-    SET_CONTROL_LABEL2(CONTROL_LIMIT, g_localizeStrings.Get(21428)); // no limit
+    SET_CONTROL_LABEL2(
+        CONTROL_LIMIT,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21428)); // no limit
   else
-    SET_CONTROL_LABEL2(CONTROL_LIMIT,
-                       StringUtils::Format(g_localizeStrings.Get(21436), m_playlist.m_limit));
+    SET_CONTROL_LABEL2(
+        CONTROL_LIMIT,
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21436),
+                            m_playlist.m_limit));
   int currentItem = GetSelectedItem();
   CGUIMessage msgReset(GUI_MSG_LABEL_RESET, GetID(), CONTROL_RULE_LIST);
   OnMessage(msgReset);
@@ -433,7 +449,7 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
     m_ruleLabels->Add(item);
   }
   CFileItemPtr item(new CFileItem("", false));
-  item->SetLabel(g_localizeStrings.Get(21423));
+  item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21423));
   m_ruleLabels->Add(item);
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_RULE_LIST, 0, 0, m_ruleLabels);
   OnMessage(msg);
@@ -441,14 +457,18 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
 
   if (m_playlist.m_orderDirection != SortOrderDescending)
   {
-    SET_CONTROL_LABEL2(CONTROL_ORDER_DIRECTION, g_localizeStrings.Get(21430));
+    SET_CONTROL_LABEL2(CONTROL_ORDER_DIRECTION,
+                       CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21430));
   }
   else
   {
-    SET_CONTROL_LABEL2(CONTROL_ORDER_DIRECTION, g_localizeStrings.Get(21431));
+    SET_CONTROL_LABEL2(CONTROL_ORDER_DIRECTION,
+                       CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21431));
   }
 
-  SET_CONTROL_LABEL2(CONTROL_ORDER_FIELD, g_localizeStrings.Get(SortUtils::GetSortLabel(m_playlist.m_orderField)));
+  SET_CONTROL_LABEL2(CONTROL_ORDER_FIELD,
+                     CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                         SortUtils::GetSortLabel(m_playlist.m_orderField)));
   SET_CONTROL_LABEL2(CONTROL_TYPE, GetLocalizedType(ConvertType(m_playlist.GetType())));
 
   // setup groups
@@ -533,7 +553,7 @@ std::string CGUIDialogSmartPlaylistEditor::GetLocalizedType(PLAYLIST_TYPE type)
 {
   for (const translateType& t : types)
     if (t.type == type)
-      return g_localizeStrings.Get(t.localizedString);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(t.localizedString);
   assert(false);
   return "";
 }

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -17,8 +17,9 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "music/MusicDatabase.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -324,7 +325,9 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     CServiceBroker::GetMediaManager().GetLocalDrives(sources);
 
     std::string path = m_rule.GetParameter();
-    CGUIDialogFileBrowser::ShowAndGetDirectory(sources, g_localizeStrings.Get(657), path, false);
+    CGUIDialogFileBrowser::ShowAndGetDirectory(
+        sources, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(657), path,
+        false);
     if (!m_rule.m_parameter.empty())
       m_rule.m_parameter.clear();
     if (!path.empty())
@@ -364,7 +367,8 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   pDialog->Reset();
   pDialog->SetItems(items);
   std::string strHeading =
-      StringUtils::Format(g_localizeStrings.Get(13401), g_localizeStrings.Get(iLabel));
+      StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13401),
+                          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(iLabel));
   pDialog->SetHeading(CVariant{std::move(strHeading)});
   pDialog->SetMultiSelection(m_rule.m_field != FieldPlaylist && m_rule.m_field != FieldVirtualFolder);
 

--- a/xbmc/events/AddonManagementEvent.cpp
+++ b/xbmc/events/AddonManagementEvent.cpp
@@ -8,9 +8,11 @@
 
 #include "AddonManagementEvent.h"
 
+#include "ServiceBroker.h"
 #include "addons/gui/GUIDialogAddonInfo.h"
 #include "filesystem/AddonsDirectory.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/URIUtils.h"
 
 CAddonManagementEvent::CAddonManagementEvent(const ADDON::AddonPtr& addon,
@@ -58,7 +60,7 @@ std::string CAddonManagementEvent::GetExecutionLabel() const
   if (!executionLabel.empty())
     return executionLabel;
 
-  return g_localizeStrings.Get(24139);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24139);
 }
 
 bool CAddonManagementEvent::Execute() const

--- a/xbmc/events/BaseEvent.cpp
+++ b/xbmc/events/BaseEvent.cpp
@@ -8,7 +8,9 @@
 
 #include "BaseEvent.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 #include <chrono>
@@ -93,9 +95,11 @@ std::string CBaseEvent::VariantToLocalizedString(const CVariant& variant)
     return variant.asString();
 
   if (variant.isInteger() && variant.asInteger() > 0)
-    return g_localizeStrings.Get(static_cast<uint32_t>(variant.asInteger()));
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        static_cast<uint32_t>(variant.asInteger()));
   if (variant.isUnsignedInteger() && variant.asUnsignedInteger() > 0)
-    return g_localizeStrings.Get(static_cast<uint32_t>(variant.asUnsignedInteger()));
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        static_cast<uint32_t>(variant.asUnsignedInteger()));
 
   return "";
 }

--- a/xbmc/events/MediaLibraryEvent.cpp
+++ b/xbmc/events/MediaLibraryEvent.cpp
@@ -11,8 +11,9 @@
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/URIUtils.h"
 
 CMediaLibraryEvent::CMediaLibraryEvent(const MediaType& mediaType, const std::string& mediaPath, const CVariant& label, const CVariant& description, EventLevel level /* = EventLevel::Information */)
@@ -45,7 +46,7 @@ std::string CMediaLibraryEvent::GetExecutionLabel() const
   if (!executionLabel.empty())
     return executionLabel;
 
-  return g_localizeStrings.Get(24140);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24140);
 }
 
 bool CMediaLibraryEvent::Execute() const

--- a/xbmc/events/windows/GUIWindowEventLog.cpp
+++ b/xbmc/events/windows/GUIWindowEventLog.cpp
@@ -16,9 +16,10 @@
 #include "events/EventLog.h"
 #include "filesystem/EventsDirectory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "input/actions/ActionIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -154,7 +155,8 @@ void CGUIWindowEventLog::GetContextButtons(int itemNumber, CContextButtons &butt
   if (eventPtr == nullptr)
     return;
 
-  buttons.Add(CONTEXT_BUTTON_DELETE, g_localizeStrings.Get(1210));
+  buttons.Add(CONTEXT_BUTTON_DELETE,
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1210));
 }
 
 bool CGUIWindowEventLog::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
@@ -185,9 +187,11 @@ void CGUIWindowEventLog::UpdateButtons()
 
   EventLevel eventLevel = CViewStateSettings::GetInstance().GetEventLevel();
   // set the label of the "level" button
-  SET_CONTROL_LABEL(CONTROL_BUTTON_LEVEL,
-                    StringUtils::Format(g_localizeStrings.Get(14119),
-                                        g_localizeStrings.Get(14115 + (int)eventLevel)));
+  SET_CONTROL_LABEL(
+      CONTROL_BUTTON_LEVEL,
+      StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14119),
+                          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                              14115 + (int)eventLevel)));
 
   // set the label, value and enabled state of the "level only" button
   SET_CONTROL_LABEL(CONTROL_BUTTON_LEVEL_ONLY, 14120);

--- a/xbmc/favourites/ContextMenus.cpp
+++ b/xbmc/favourites/ContextMenus.cpp
@@ -14,7 +14,8 @@
 #include "favourites/FavouritesService.h"
 #include "favourites/FavouritesURL.h"
 #include "favourites/FavouritesUtils.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/guilib/GUIBuiltinsUtils.h"
@@ -160,9 +161,10 @@ std::string CFavouritesTargetPlay::GetLabel(const CFileItem& item) const
 {
   const std::shared_ptr<CFileItem> targetItem{ResolveFavouriteItem(item)};
   if (targetItem && VIDEO::UTILS::GetItemResumeInformation(*targetItem).isResumable)
-    return g_localizeStrings.Get(12021); // Play from beginning
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        12021); // Play from beginning
 
-  return g_localizeStrings.Get(208); // Play
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(208); // Play
 }
 
 bool CFavouritesTargetPlay::IsVisible(const CFileItem& item) const

--- a/xbmc/favourites/FavouritesURL.cpp
+++ b/xbmc/favourites/FavouritesURL.cpp
@@ -13,8 +13,9 @@
 #include "URL.h"
 #include "addons/AddonManager.h"
 #include "addons/IAddon.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/WindowTranslator.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/ExecString.h"
 #include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"
@@ -127,9 +128,10 @@ bool CFavouritesURL::Parse(CFavouritesURL::Action action, const std::vector<std:
         // optional: target url/path
         m_target = StringUtils::DeParamify(params[1]);
       }
-      m_actionLabel =
-          StringUtils::Format(g_localizeStrings.Get(15220), // Show content in '<windowname>'
-                              g_localizeStrings.Get(m_windowId));
+      m_actionLabel = StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              15220), // Show content in '<windowname>'
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(m_windowId));
       break;
     case Action::PLAY_MEDIA:
       if (params.empty())
@@ -138,7 +140,8 @@ bool CFavouritesURL::Parse(CFavouritesURL::Action action, const std::vector<std:
         return false;
       }
       m_target = StringUtils::DeParamify(params[0]);
-      m_actionLabel = g_localizeStrings.Get(15218); // Play media
+      m_actionLabel =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15218); // Play media
       break;
     case Action::SHOW_PICTURE:
       if (params.empty())
@@ -147,7 +150,8 @@ bool CFavouritesURL::Parse(CFavouritesURL::Action action, const std::vector<std:
         return false;
       }
       m_target = StringUtils::DeParamify(params[0]);
-      m_actionLabel = g_localizeStrings.Get(15219); // Show picture
+      m_actionLabel =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15219); // Show picture
       break;
     case Action::RUN_SCRIPT:
       if (params.empty())
@@ -156,7 +160,8 @@ bool CFavouritesURL::Parse(CFavouritesURL::Action action, const std::vector<std:
         return false;
       }
       m_target = StringUtils::DeParamify(params[0]);
-      m_actionLabel = g_localizeStrings.Get(15221); // Execute script
+      m_actionLabel =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15221); // Execute script
       pathIsAddonID = true;
       break;
     case Action::RUN_ADDON:
@@ -166,7 +171,8 @@ bool CFavouritesURL::Parse(CFavouritesURL::Action action, const std::vector<std:
         return false;
       }
       m_target = StringUtils::DeParamify(params[0]);
-      m_actionLabel = g_localizeStrings.Get(15223); // Execute add-on
+      m_actionLabel =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15223); // Execute add-on
       pathIsAddonID = true;
       break;
     case Action::START_ANDROID_ACTIVITY:
@@ -176,7 +182,8 @@ bool CFavouritesURL::Parse(CFavouritesURL::Action action, const std::vector<std:
         return false;
       }
       m_target = StringUtils::DeParamify(params[0]);
-      m_actionLabel = g_localizeStrings.Get(15222); // Execute Android app
+      m_actionLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          15222); // Execute Android app
       break;
     default:
       if (params.empty())
@@ -186,7 +193,8 @@ bool CFavouritesURL::Parse(CFavouritesURL::Action action, const std::vector<std:
       }
       m_action = CFavouritesURL::Action::UNKNOWN;
       m_target = StringUtils::DeParamify(params[0]);
-      m_actionLabel = g_localizeStrings.Get(15224); // Other / Unknown
+      m_actionLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          15224); // Other / Unknown
       break;
   }
 

--- a/xbmc/favourites/FavouritesUtils.cpp
+++ b/xbmc/favourites/FavouritesUtils.cpp
@@ -18,7 +18,8 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/Variant.h"
 #include "utils/guilib/GUIBuiltinsUtils.h"
@@ -33,8 +34,9 @@ namespace FAVOURITES_UTILS
 bool ChooseAndSetNewName(CFileItem& item)
 {
   std::string label = item.GetLabel();
-  if (CGUIKeyboardFactory::ShowAndGetInput(label, CVariant{g_localizeStrings.Get(16008)},
-                                           false)) // Enter new title
+  if (CGUIKeyboardFactory::ShowAndGetInput(
+          label, CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16008)},
+          false)) // Enter new title
   {
     item.SetLabel(label);
     return true;
@@ -49,20 +51,24 @@ bool ChooseAndSetNewThumbnail(CFileItem& item)
   {
     const auto current = std::make_shared<CFileItem>("thumb://Current", false);
     current->SetArt("thumb", item.GetArt("thumb"));
-    current->SetLabel(g_localizeStrings.Get(20016)); // Current thumb
+    current->SetLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20016)); // Current thumb
     prefilledItems.Add(current);
   }
 
   const auto none = std::make_shared<CFileItem>("thumb://None", false);
   none->SetArt("icon", item.GetArt("icon"));
-  none->SetLabel(g_localizeStrings.Get(20018)); // No thumb
+  none->SetLabel(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20018)); // No thumb
   prefilledItems.Add(none);
 
   std::string thumb;
   std::vector<CMediaSource> sources;
   CServiceBroker::GetMediaManager().GetLocalDrives(sources);
-  if (CGUIDialogFileBrowser::ShowAndGetImage(prefilledItems, sources, g_localizeStrings.Get(1030),
-                                             thumb)) // Browse for image
+  if (CGUIDialogFileBrowser::ShowAndGetImage(
+          prefilledItems, sources,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1030),
+          thumb)) // Browse for image
   {
     item.SetArt("thumb", thumb);
     return true;

--- a/xbmc/filesystem/AddonsDirectory.cpp
+++ b/xbmc/filesystem/AddonsDirectory.cpp
@@ -23,10 +23,11 @@
 #include "addons/addoninfo/AddonType.h"
 #include "games/GameUtils.h"
 #include "games/addons/GameClient.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/TextureManager.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -186,6 +187,8 @@ static void GenerateTypeListing(const CURL& path,
 // Creates categories for game add-ons, if we have any game add-ons
 static void GenerateGameListing(const CURL& path, const VECADDONS& addons, CFileItemList& items)
 {
+  auto& localizeStrings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
+
   // Game controllers
   for (const auto& addon : addons)
   {
@@ -208,7 +211,7 @@ static void GenerateGameListing(const CURL& path, const VECADDONS& addons, CFile
   {
     if (IsEmulator(addon))
     {
-      CFileItemPtr item(new CFileItem(g_localizeStrings.Get(35207))); // Emulators
+      CFileItemPtr item(new CFileItem(localizeStrings.Get(35207))); // Emulators
       CURL itemPath = path;
       itemPath.SetFileName(CATEGORY_EMULATORS);
       item->SetPath(itemPath.Get());
@@ -225,7 +228,7 @@ static void GenerateGameListing(const CURL& path, const VECADDONS& addons, CFile
   {
     if (IsStandaloneGame(addon))
     {
-      CFileItemPtr item(new CFileItem(g_localizeStrings.Get(35208))); // Standalone games
+      CFileItemPtr item(new CFileItem(localizeStrings.Get(35208))); // Standalone games
       CURL itemPath = path;
       itemPath.SetFileName(CATEGORY_STANDALONE_GAMES);
       item->SetPath(itemPath.Get());
@@ -242,7 +245,7 @@ static void GenerateGameListing(const CURL& path, const VECADDONS& addons, CFile
   {
     if (IsGameProvider(addon))
     {
-      CFileItemPtr item(new CFileItem(g_localizeStrings.Get(35220))); // Game providers
+      CFileItemPtr item(new CFileItem(localizeStrings.Get(35220))); // Game providers
       CURL itemPath = path;
       itemPath.SetFileName(CATEGORY_GAME_PROVIDERS);
       item->SetPath(itemPath.Get());
@@ -259,7 +262,7 @@ static void GenerateGameListing(const CURL& path, const VECADDONS& addons, CFile
   {
     if (IsGameResource(addon))
     {
-      CFileItemPtr item(new CFileItem(g_localizeStrings.Get(35209))); // Game resources
+      CFileItemPtr item(new CFileItem(localizeStrings.Get(35209))); // Game resources
       CURL itemPath = path;
       itemPath.SetFileName(CATEGORY_GAME_RESOURCES);
       item->SetPath(itemPath.Get());
@@ -276,7 +279,7 @@ static void GenerateGameListing(const CURL& path, const VECADDONS& addons, CFile
   {
     if (IsGameSupportAddon(addon))
     {
-      CFileItemPtr item(new CFileItem(g_localizeStrings.Get(35216))); // Support add-ons
+      CFileItemPtr item(new CFileItem(localizeStrings.Get(35216))); // Support add-ons
       CURL itemPath = path;
       itemPath.SetFileName(CATEGORY_GAME_SUPPORT_ADDONS);
       item->SetPath(itemPath.Get());
@@ -296,7 +299,8 @@ static void GenerateMainCategoryListing(const CURL& path, const VECADDONS& addon
 {
   if (std::ranges::any_of(addons, IsInfoProviderTypeAddon))
   {
-    CFileItemPtr item(new CFileItem(g_localizeStrings.Get(24993)));
+    CFileItemPtr item(
+        new CFileItem(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24993)));
     item->SetPath(URIUtils::AddFileToFolder(path.Get(), CATEGORY_INFO_PROVIDERS));
     item->SetFolder(true);
     const std::string thumb = "DefaultAddonInfoProvider.png";
@@ -306,7 +310,8 @@ static void GenerateMainCategoryListing(const CURL& path, const VECADDONS& addon
   }
   if (std::ranges::any_of(addons, IsLookAndFeelTypeAddon))
   {
-    CFileItemPtr item(new CFileItem(g_localizeStrings.Get(24997)));
+    CFileItemPtr item(
+        new CFileItem(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24997)));
     item->SetPath(URIUtils::AddFileToFolder(path.Get(), CATEGORY_LOOK_AND_FEEL));
     item->SetFolder(true);
     const std::string thumb = "DefaultAddonLookAndFeel.png";
@@ -350,17 +355,20 @@ static void GenerateMainCategoryListing(const CURL& path, const VECADDONS& addon
 static void GenerateCategoryListing(const CURL& path, VECADDONS& addons,
     CFileItemList& items)
 {
+  auto& localizeStrings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
   const std::string& category = path.GetFileName();
   if (category == CATEGORY_INFO_PROVIDERS)
   {
-    items.SetProperty("addoncategory", g_localizeStrings.Get(24993));
-    items.SetLabel(g_localizeStrings.Get(24993));
+    std::string label = localizeStrings.Get(24993);
+    items.SetProperty("addoncategory", label);
+    items.SetLabel(label);
     GenerateTypeListing(path, infoProviderTypes, addons, items);
   }
   else if (category == CATEGORY_LOOK_AND_FEEL)
   {
-    items.SetProperty("addoncategory", g_localizeStrings.Get(24997));
-    items.SetLabel(g_localizeStrings.Get(24997));
+    std::string label = localizeStrings.Get(24997);
+    items.SetProperty("addoncategory", label);
+    items.SetLabel(label);
     GenerateTypeListing(path, lookAndFeelTypes, addons, items);
   }
   else if (category == CATEGORY_GAME_ADDONS)
@@ -371,38 +379,43 @@ static void GenerateCategoryListing(const CURL& path, VECADDONS& addons,
   }
   else if (category == CATEGORY_EMULATORS)
   {
-    items.SetProperty("addoncategory", g_localizeStrings.Get(35207)); // Emulators
+    std::string label = localizeStrings.Get(35207); // Emulators
+    items.SetProperty("addoncategory", label);
     addons.erase(std::remove_if(addons.begin(), addons.end(),
         [](const AddonPtr& addon){ return !IsEmulator(addon); }), addons.end());
-    CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(35207)); // Emulators
+    CAddonsDirectory::GenerateAddonListing(path, addons, items, label);
   }
   else if (category == CATEGORY_STANDALONE_GAMES)
   {
-    items.SetProperty("addoncategory", g_localizeStrings.Get(35208)); // Standalone games
+    std::string label = localizeStrings.Get(35208); // Standalone games
+    items.SetProperty("addoncategory", label);
     addons.erase(std::remove_if(addons.begin(), addons.end(),
         [](const AddonPtr& addon){ return !IsStandaloneGame(addon); }), addons.end());
-    CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(35208)); // Standalone games
+    CAddonsDirectory::GenerateAddonListing(path, addons, items, label);
   }
   else if (category == CATEGORY_GAME_PROVIDERS)
   {
-    items.SetProperty("addoncategory", g_localizeStrings.Get(35220)); // Game providers
+    std::string label = localizeStrings.Get(35220); // Game providers
+    items.SetProperty("addoncategory", label);
     addons.erase(std::remove_if(addons.begin(), addons.end(),
                                 [](const AddonPtr& addon){ return !IsGameProvider(addon); }), addons.end());
-    CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(35220)); // Game providers
+    CAddonsDirectory::GenerateAddonListing(path, addons, items, label);
   }
   else if (category == CATEGORY_GAME_RESOURCES)
   {
-    items.SetProperty("addoncategory", g_localizeStrings.Get(35209)); // Game resources
+    std::string label = localizeStrings.Get(35209); // Game resources
+    items.SetProperty("addoncategory", label);
     addons.erase(std::remove_if(addons.begin(), addons.end(),
                                 [](const AddonPtr& addon){ return !IsGameResource(addon); }), addons.end());
-    CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(35209)); // Game resources
+    CAddonsDirectory::GenerateAddonListing(path, addons, items, label);
   }
   else if (category == CATEGORY_GAME_SUPPORT_ADDONS)
   {
-    items.SetProperty("addoncategory", g_localizeStrings.Get(35216)); // Support add-ons
+    std::string label = localizeStrings.Get(35216); // Support add-ons
+    items.SetProperty("addoncategory", label);
     addons.erase(std::remove_if(addons.begin(), addons.end(),
       [](const AddonPtr& addon) { return !IsGameSupportAddon(addon); }), addons.end());
-    CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(35216)); // Support add-ons
+    CAddonsDirectory::GenerateAddonListing(path, addons, items, label);
   }
   else
   { // fallback to addon type
@@ -426,7 +439,8 @@ bool CAddonsDirectory::GetSearchResults(const CURL& path, CFileItemList &items)
 
   VECADDONS addons;
   database.Search(search, addons);
-  CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(283));
+  CAddonsDirectory::GenerateAddonListing(
+      path, addons, items, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(283));
   CURL searchPath(path);
   searchPath.SetFileName(search);
   items.SetPath(searchPath.Get());
@@ -436,7 +450,7 @@ bool CAddonsDirectory::GetSearchResults(const CURL& path, CFileItemList &items)
 static void UserInstalledAddons(const CURL& path, CFileItemList &items)
 {
   items.ClearItems();
-  items.SetLabel(g_localizeStrings.Get(24998));
+  items.SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24998));
 
   VECADDONS addons;
   CServiceBroker::GetAddonMgr().GetInstalledAddons(addons);
@@ -457,12 +471,14 @@ static void UserInstalledAddons(const CURL& path, CFileItemList &items)
     CURL itemPath = path;
     itemPath.SetFileName("all");
     item->SetPath(itemPath.Get());
-    item->SetLabel(g_localizeStrings.Get(593));
+    item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(593));
     item->SetSpecialSort(SortSpecialOnTop);
     items.Add(item);
   }
   else if (category == "all")
-    CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24998));
+    CAddonsDirectory::GenerateAddonListing(
+        path, addons, items,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24998));
   else
     GenerateCategoryListing(path, addons, items);
 }
@@ -476,7 +492,8 @@ static void DependencyAddons(const CURL& path, CFileItemList &items)
   std::ranges::copy_if(all, std::back_inserter(deps),
                        [&](const AddonPtr& a) { return !IsUserInstalled(a); });
 
-  CAddonsDirectory::GenerateAddonListing(path, deps, items, g_localizeStrings.Get(24996));
+  CAddonsDirectory::GenerateAddonListing(
+      path, deps, items, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24996));
 
   //Set orphaned status
   std::set<std::string> orphaned;
@@ -490,7 +507,8 @@ static void DependencyAddons(const CURL& path, CFileItemList &items)
   {
     if (orphaned.contains(items[i]->GetProperty("Addon.ID").asString()))
     {
-      items[i]->SetProperty("Addon.Status", g_localizeStrings.Get(24995));
+      items[i]->SetProperty(
+          "Addon.Status", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24995));
       items[i]->SetProperty("Addon.Orphaned", true);
     }
   }
@@ -499,7 +517,8 @@ static void DependencyAddons(const CURL& path, CFileItemList &items)
 static void OutdatedAddons(const CURL& path, CFileItemList &items)
 {
   VECADDONS addons = CServiceBroker::GetAddonMgr().GetAvailableUpdates();
-  CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24043));
+  CAddonsDirectory::GenerateAddonListing(
+      path, addons, items, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24043));
 
   if (!items.IsEmpty())
   {
@@ -507,13 +526,15 @@ static void OutdatedAddons(const CURL& path, CFileItemList &items)
     {
       const CFileItemPtr itemUpdateAllowed(
           std::make_shared<CFileItem>("addons://update_allowed/", false));
-      itemUpdateAllowed->SetLabel(g_localizeStrings.Get(24137));
+      itemUpdateAllowed->SetLabel(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24137));
       itemUpdateAllowed->SetSpecialSort(SortSpecialOnTop);
       items.Add(itemUpdateAllowed);
     }
 
     const CFileItemPtr itemUpdateAll(std::make_shared<CFileItem>("addons://update_all/", false));
-    itemUpdateAll->SetLabel(g_localizeStrings.Get(24122));
+    itemUpdateAll->SetLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24122));
     itemUpdateAll->SetSpecialSort(SortSpecialOnTop);
     items.Add(itemUpdateAll);
   }
@@ -526,7 +547,8 @@ static void RunningAddons(const CURL& path, CFileItemList &items)
 
   addons.erase(std::remove_if(addons.begin(), addons.end(),
       [](const AddonPtr& addon){ return !CScriptInvocationManager::GetInstance().IsRunning(addon->LibPath()); }), addons.end());
-  CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24994));
+  CAddonsDirectory::GenerateAddonListing(
+      path, addons, items, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24994));
 }
 
 static bool Browse(const CURL& path, CFileItemList &items)
@@ -544,8 +566,9 @@ static bool Browse(const CURL& path, CFileItemList &items)
     // get all latest addon versions by repo
     addonRepos.GetLatestAddonVersionsFromAllRepos(addons);
 
-    items.SetProperty("reponame", g_localizeStrings.Get(24087));
-    items.SetLabel(g_localizeStrings.Get(24087));
+    items.SetProperty("reponame",
+                      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24087));
+    items.SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24087));
   }
   else
   {
@@ -594,7 +617,7 @@ static bool HasRecentlyUpdatedAddons()
 
 static bool Repos(const CURL& path, CFileItemList &items)
 {
-  items.SetLabel(g_localizeStrings.Get(24033));
+  items.SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24033));
 
   VECADDONS addons;
   CServiceBroker::GetAddonMgr().GetAddons(addons, AddonType::REPOSITORY);
@@ -603,7 +626,7 @@ static bool Repos(const CURL& path, CFileItemList &items)
   else if (addons.size() == 1)
     return Browse(CURL("addons://" + addons[0]->ID()), items);
   CFileItemPtr item(new CFileItem("addons://all/", true));
-  item->SetLabel(g_localizeStrings.Get(24087));
+  item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24087));
   item->SetSpecialSort(SortSpecialOnTop);
   items.Add(item);
   for (const auto& repo : addons)
@@ -617,24 +640,25 @@ static bool Repos(const CURL& path, CFileItemList &items)
 
 static void RootDirectory(CFileItemList& items)
 {
-  items.SetLabel(g_localizeStrings.Get(10040));
+  auto& localizeStrings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
+  items.SetLabel(localizeStrings.Get(10040));
   {
     CFileItemPtr item(new CFileItem("addons://user/", true));
-    item->SetLabel(g_localizeStrings.Get(24998));
+    item->SetLabel(localizeStrings.Get(24998));
     item->SetArt("icon", "DefaultAddonsInstalled.png");
     items.Add(item);
   }
   if (CServiceBroker::GetAddonMgr().HasAvailableUpdates())
   {
     CFileItemPtr item(new CFileItem("addons://outdated/", true));
-    item->SetLabel(g_localizeStrings.Get(24043));
+    item->SetLabel(localizeStrings.Get(24043));
     item->SetArt("icon", "DefaultAddonsUpdates.png");
     items.Add(item);
   }
   if (CAddonInstaller::GetInstance().IsDownloading())
   {
     CFileItemPtr item(new CFileItem("addons://downloading/", true));
-    item->SetLabel(g_localizeStrings.Get(24067));
+    item->SetLabel(localizeStrings.Get(24067));
     item->SetArt("icon", "DefaultNetwork.png");
     items.Add(item);
   }
@@ -642,26 +666,26 @@ static void RootDirectory(CFileItemList& items)
       && HasRecentlyUpdatedAddons())
   {
     CFileItemPtr item(new CFileItem("addons://recently_updated/", true));
-    item->SetLabel(g_localizeStrings.Get(24004));
+    item->SetLabel(localizeStrings.Get(24004));
     item->SetArt("icon", "DefaultAddonsRecentlyUpdated.png");
     items.Add(item);
   }
   if (CServiceBroker::GetAddonMgr().HasAddons(AddonType::REPOSITORY))
   {
     CFileItemPtr item(new CFileItem("addons://repos/", true));
-    item->SetLabel(g_localizeStrings.Get(24033));
+    item->SetLabel(localizeStrings.Get(24033));
     item->SetArt("icon", "DefaultAddonsRepo.png");
     items.Add(item);
   }
   {
     CFileItemPtr item(new CFileItem("addons://install/", false));
-    item->SetLabel(g_localizeStrings.Get(24041));
+    item->SetLabel(localizeStrings.Get(24041));
     item->SetArt("icon", "DefaultAddonsZip.png");
     items.Add(item);
   }
   {
     CFileItemPtr item(new CFileItem("addons://search/", true));
-    item->SetLabel(g_localizeStrings.Get(137));
+    item->SetLabel(localizeStrings.Get(137));
     item->SetArt("icon", "DefaultAddonsSearch.png");
     items.Add(item);
   }
@@ -742,14 +766,18 @@ bool CAddonsDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     if (!GetRecentlyUpdatedAddons(addons))
       return false;
 
-    CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24004));
+    CAddonsDirectory::GenerateAddonListing(
+        path, addons, items,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24004));
     return true;
   }
   else if (endpoint == "downloading")
   {
     VECADDONS addons;
     CAddonInstaller::GetInstance().GetInstallList(addons);
-    CAddonsDirectory::GenerateAddonListing(path, addons, items, g_localizeStrings.Get(24067));
+    CAddonsDirectory::GenerateAddonListing(
+        path, addons, items,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24067));
     return true;
   }
   else if (endpoint == "more")
@@ -835,15 +863,20 @@ void CAddonsDirectory::GenerateAddonListing(const CURL& path,
     pItem->SetProperty("Addon.IsBinary", addon->IsBinary());
 
     if (installed)
-      pItem->SetProperty("Addon.Status", g_localizeStrings.Get(305));
+      pItem->SetProperty("Addon.Status",
+                         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(305));
     if (disabled)
-      pItem->SetProperty("Addon.Status", g_localizeStrings.Get(24023));
+      pItem->SetProperty("Addon.Status",
+                         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24023));
     if (hasUpdate)
-      pItem->SetProperty("Addon.Status", g_localizeStrings.Get(24068));
+      pItem->SetProperty("Addon.Status",
+                         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24068));
     else if (addon->LifecycleState() == AddonLifecycleState::BROKEN)
-      pItem->SetProperty("Addon.Status", g_localizeStrings.Get(24098));
+      pItem->SetProperty("Addon.Status",
+                         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24098));
     else if (addon->LifecycleState() == AddonLifecycleState::DEPRECATED)
-      pItem->SetProperty("Addon.Status", g_localizeStrings.Get(24170));
+      pItem->SetProperty("Addon.Status",
+                         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24170));
 
     items.Add(pItem);
   }
@@ -953,7 +986,8 @@ bool CAddonsDirectory::GetScriptsAndPlugins(const std::string &content, CFileIte
   }
 
   items.SetContent("addons");
-  items.SetLabel(g_localizeStrings.Get(24001)); // Add-ons
+  items.SetLabel(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24001)); // Add-ons
 
   return true;
 }

--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -14,8 +14,9 @@
 #include "Util.h"
 #include "cores/FFmpeg.h"
 #include "filesystem/File.h"
-#include "guilib/LocalizeStrings.h"
 #include "imagefiles/ImageFileURL.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Mp4ChplReader.h"
@@ -195,7 +196,8 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
   for (size_t i=0;i<m_fctx->nb_chapters;++i)
   {
     tag=nullptr;
-    std::string chaptitle = StringUtils::Format(g_localizeStrings.Get(25010), i + 1);
+    std::string chaptitle = StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25010), i + 1);
     std::string chapauthor;
     std::string chapalbum;
 

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -22,7 +22,8 @@
 #include "filesystem/BlurayCallback.h"
 #include "filesystem/Directory.h"
 #include "filesystem/DirectoryFactory.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/LangCodeExpander.h"
@@ -274,8 +275,9 @@ std::shared_ptr<CFileItem> GetFileItem(const CURL& url,
   const std::string buf{StringUtils::Format(label, title.playlist)};
   item->SetTitle(buf);
   item->SetLabel(buf);
-  const std::string chap{StringUtils::Format(g_localizeStrings.Get(25007), title.chapters.size(),
-                                             StringUtils::SecondsToTimeString(duration))};
+  const std::string chap{
+      StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25007),
+                          title.chapters.size(), StringUtils::SecondsToTimeString(duration))};
   item->SetLabel2(chap);
   item->SetSize(0);
   item->SetArt("icon", "DefaultVideo.png");
@@ -380,11 +382,13 @@ void AddPlaylists(const CURL& url,
   {
     if (IncludePlaylist(job, title, minDuration, mainPlaylist, maxPlaylist))
     {
-      items.Add(GetFileItem(url, realPath, title,
-                            title.playlist == static_cast<unsigned int>(mainPlaylist)
-                                ? g_localizeStrings.Get(25004) /* Main Title */
-                                : g_localizeStrings.Get(25005) /* Title */,
-                            clipCache));
+      items.Add(GetFileItem(
+          url, realPath, title,
+          title.playlist == static_cast<unsigned int>(mainPlaylist)
+              ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                    25004) /* Main Title */
+              : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25005) /* Title */,
+          clipCache));
     }
   }
 }
@@ -434,8 +438,10 @@ bool GetPlaylists(const CURL& url,
 
     if (mainPlaylist >= 0)
     {
-      items.Add(GetFileItem(url, realPath, playlists[0], g_localizeStrings.Get(25005) /* Title */,
-                            clipCache));
+      items.Add(GetFileItem(
+          url, realPath, playlists[0],
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25005) /* Title */,
+          clipCache));
     }
     else
     {

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -9,8 +9,10 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
+#include "ServiceBroker.h"
 #include "URL.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -836,22 +838,29 @@ void CDiscDirectoryHelper::GenerateItem(const CURL& url,
   if (isSpecial == IsSpecial::SPECIAL)
   {
     if (title.empty())
-      buf = g_localizeStrings.Get(21350); /* Special */
+      buf = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21350); /* Special */
     else
       /* Special xx - title */
-      buf = StringUtils::Format(g_localizeStrings.Get(21348), tag.m_iEpisode, tag.GetTitle());
+      buf = StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21348), tag.m_iEpisode,
+          tag.GetTitle());
   }
   else
     /* Episode xx - title */
-    buf = StringUtils::Format(g_localizeStrings.Get(21349), tag.m_iEpisode, tag.GetTitle());
+    buf =
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21349),
+                            tag.m_iEpisode, tag.GetTitle());
   item->SetTitle(buf);
   item->SetLabel(buf);
 
   item->SetLabel2(StringUtils::Format(
-      g_localizeStrings.Get(25005) /* Title: {0:d} */ + " - {1:s}: {2:s}\n\r{3:s}: {4:s}", playlist,
-      g_localizeStrings.Get(180) /* Duration */,
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25005) /* Title: {0:d} */ +
+          " - {1:s}: {2:s}\n\r{3:s}: {4:s}",
+      playlist,
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(180) /* Duration */,
       StringUtils::SecondsToTimeString(static_cast<int>(duration.count() / 1000)),
-      g_localizeStrings.Get(24026) /* Languages */, langs));
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24026) /* Languages */,
+      langs));
   item->SetSize(0);
   item->SetArt("icon", "DefaultVideo.png");
 }
@@ -945,7 +954,8 @@ void CDiscDirectoryHelper::AddRootOptions(const CURL& url,
   path.SetFileName(URIUtils::AddFileToFolder("root", "titles"));
 
   auto item{std::make_shared<CFileItem>(path.Get(), true)};
-  item->SetLabel(g_localizeStrings.Get(25002) /* All titles */);
+  item->SetLabel(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25002) /* All titles */);
   item->SetArt("icon", "DefaultVideoPlaylists.png");
   items.Add(item);
 
@@ -953,7 +963,8 @@ void CDiscDirectoryHelper::AddRootOptions(const CURL& url,
   {
     path.SetFileName("menu");
     item = {std::make_shared<CFileItem>(path.Get(), false)};
-    item->SetLabel(g_localizeStrings.Get(25003) /* Menu */);
+    item->SetLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25003) /* Menu */);
     item->SetArt("icon", "DefaultProgram.png");
     items.Add(item);
   }

--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -14,10 +14,11 @@
 #include "MusicDatabaseDirectory/QueryParams.h"
 #include "ServiceBroker.h"
 #include "filesystem/File.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/TextureManager.h"
 #include "music/MusicDatabase.h"
 #include "music/MusicDbUrl.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Crc32.h"
@@ -217,46 +218,52 @@ bool CMusicDatabaseDirectory::GetLabel(const std::string& strDirectory, std::str
     switch (pNode->GetChildType())
     {
       case NodeType::TOP100:
-        strLabel = g_localizeStrings.Get(271); // Top 100
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(271); // Top 100
         break;
       case NodeType::GENRE:
-        strLabel = g_localizeStrings.Get(135); // Genres
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(135); // Genres
         break;
       case NodeType::SOURCE:
-        strLabel = g_localizeStrings.Get(39030); // Sources
+        strLabel =
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39030); // Sources
         break;
       case NodeType::ROLE:
-        strLabel = g_localizeStrings.Get(38033); // Roles
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38033); // Roles
         break;
       case NodeType::ARTIST:
-        strLabel = g_localizeStrings.Get(133); // Artists
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(133); // Artists
         break;
       case NodeType::ALBUM:
-        strLabel = g_localizeStrings.Get(132); // Albums
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(132); // Albums
         break;
       case NodeType::ALBUM_RECENTLY_ADDED:
       case NodeType::ALBUM_RECENTLY_ADDED_SONGS:
-        strLabel = g_localizeStrings.Get(359); // Recently Added Albums
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            359); // Recently Added Albums
         break;
       case NodeType::ALBUM_RECENTLY_PLAYED:
       case NodeType::ALBUM_RECENTLY_PLAYED_SONGS:
-        strLabel = g_localizeStrings.Get(517); // Recently Played Albums
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            517); // Recently Played Albums
         break;
       case NodeType::ALBUM_TOP100:
       case NodeType::ALBUM_TOP100_SONGS:
-        strLabel = g_localizeStrings.Get(10505); // Top 100 Albums
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            10505); // Top 100 Albums
         break;
       case NodeType::SINGLES:
-        strLabel = g_localizeStrings.Get(1050); // Singles
+        strLabel =
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1050); // Singles
         break;
       case NodeType::SONG:
-        strLabel = g_localizeStrings.Get(134); // Songs
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(134); // Songs
         break;
       case NodeType::SONG_TOP100:
-        strLabel = g_localizeStrings.Get(10504); // Top 100 Songs
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            10504); // Top 100 Songs
         break;
       case NodeType::YEAR:
-        strLabel = g_localizeStrings.Get(652); // Years
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(652); // Years
         break;
       case NodeType::OVERVIEW:
         strLabel = "";

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
@@ -9,8 +9,10 @@
 #include "DirectoryNodeAlbum.h"
 
 #include "QueryParams.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "music/MusicDatabase.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
@@ -28,7 +30,7 @@ NodeType CDirectoryNodeAlbum::GetChildType() const
 std::string CDirectoryNodeAlbum::GetLocalizedName() const
 {
   if (GetID() == -1)
-    return g_localizeStrings.Get(15102); // All Albums
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15102); // All Albums
   CMusicDatabase db;
   if (db.Open())
     return db.GetAlbumById(GetID());

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyAdded.cpp
@@ -10,8 +10,10 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "music/MusicDatabase.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
@@ -34,7 +36,7 @@ NodeType CDirectoryNodeAlbumRecentlyAdded::GetChildType() const
 std::string CDirectoryNodeAlbumRecentlyAdded::GetLocalizedName() const
 {
   if (GetID() == -1)
-    return g_localizeStrings.Get(15102); // All Albums
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15102); // All Albums
   CMusicDatabase db;
   if (db.Open())
     return db.GetAlbumById(GetID());

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbumRecentlyPlayed.cpp
@@ -10,8 +10,10 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "music/MusicDatabase.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
@@ -34,7 +36,7 @@ NodeType CDirectoryNodeAlbumRecentlyPlayed::GetChildType() const
 std::string CDirectoryNodeAlbumRecentlyPlayed::GetLocalizedName() const
 {
   if (GetID() == -1)
-    return g_localizeStrings.Get(15102); // All Albums
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15102); // All Albums
   CMusicDatabase db;
   if (db.Open())
     return db.GetAlbumById(GetID());

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
@@ -10,8 +10,9 @@
 
 #include "QueryParams.h"
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "music/MusicDatabase.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -37,7 +38,7 @@ NodeType CDirectoryNodeArtist::GetChildType() const
 std::string CDirectoryNodeArtist::GetLocalizedName() const
 {
   if (GetID() == -1)
-    return g_localizeStrings.Get(15103); // All Artists
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15103); // All Artists
   CMusicDatabase db;
   if (db.Open())
     return db.GetArtistById(GetID());

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeDiscs.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeDiscs.cpp
@@ -9,8 +9,10 @@
 #include "DirectoryNodeDiscs.h"
 
 #include "QueryParams.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "music/MusicDatabase.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
 
@@ -34,7 +36,7 @@ std::string CDirectoryNodeDiscs::GetLocalizedName() const
     title = db.GetAlbumDiscTitle(params.GetAlbumId(), params.GetDisc());
   db.Close();
   if (title.empty())
-    title = g_localizeStrings.Get(15102); // All Albums
+    title = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15102); // All Albums
 
   return title;
 }

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -10,8 +10,10 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "music/MusicDatabase.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 namespace XFILE
@@ -57,7 +59,7 @@ std::string CDirectoryNodeOverview::GetLocalizedName() const
 {
   for (const Node& node : OverviewChildren)
     if (GetName() == node.id)
-      return g_localizeStrings.Get(node.label);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(node.label);
   return "";
 }
 
@@ -76,7 +78,9 @@ bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
     if (i == 9 && !hasCompilations)
       continue;
 
-    CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(OverviewChildren[i].label)));
+    CFileItemPtr pItem(
+        new CFileItem(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            OverviewChildren[i].label)));
     std::string strDir = StringUtils::Format("{}/", OverviewChildren[i].id);
     pItem->SetPath(BuildPath() + strDir);
     pItem->SetFolder(true);

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeTop100.cpp
@@ -10,7 +10,9 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 using namespace XFILE::MUSICDATABASEDIRECTORY;
@@ -39,7 +41,7 @@ std::string CDirectoryNodeTop100::GetLocalizedName() const
 {
   for (const Node& node : Top100Children)
     if (GetName() == node.id)
-      return g_localizeStrings.Get(node.label);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(node.label);
   return "";
 }
 
@@ -47,7 +49,8 @@ bool CDirectoryNodeTop100::GetContent(CFileItemList& items) const
 {
   for (const Node& node : Top100Children)
   {
-    CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(node.label)));
+    CFileItemPtr pItem(new CFileItem(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(node.label)));
     std::string strDir = StringUtils::Format("{}/", node.id);
     pItem->SetPath(BuildPath() + strDir);
     pItem->SetFolder(true);

--- a/xbmc/filesystem/MusicFileDirectory.cpp
+++ b/xbmc/filesystem/MusicFileDirectory.cpp
@@ -10,8 +10,10 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
+#include "ServiceBroker.h"
 #include "URL.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
@@ -36,8 +38,9 @@ bool CMusicFileDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
   for (int i=0; i<iStreams; ++i)
   {
-    std::string strLabel =
-        StringUtils::Format("{} - {} {:02}", strFileName, g_localizeStrings.Get(554), i + 1);
+    std::string strLabel = StringUtils::Format(
+        "{} - {} {:02}", strFileName,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(554), i + 1);
     CFileItemPtr pItem(new CFileItem(strLabel));
     strLabel = StringUtils::Format("{}{}-{}.{}", strPath, strFileName, i + 1, m_strExt);
     pItem->SetPath(strLabel);

--- a/xbmc/filesystem/MusicSearchDirectory.cpp
+++ b/xbmc/filesystem/MusicSearchDirectory.cpp
@@ -10,9 +10,11 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
+#include "ServiceBroker.h"
 #include "URL.h"
-#include "guilib/LocalizeStrings.h"
 #include "music/MusicDatabase.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/log.h"
 
 using namespace XFILE;
@@ -43,7 +45,7 @@ bool CMusicSearchDirectory::GetDirectory(const CURL& url, CFileItemList &items)
 
   CLog::Log(LOGDEBUG, "{} ({}) took {} ms", __FUNCTION__, url.GetRedacted(), duration.count());
 
-  items.SetLabel(g_localizeStrings.Get(137)); // Search
+  items.SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(137)); // Search
   return true;
 }
 

--- a/xbmc/filesystem/VideoDatabaseDirectory.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -14,8 +14,9 @@
 #include "ServiceBroker.h"
 #include "VideoDatabaseDirectory/DirectoryNode.h"
 #include "VideoDatabaseDirectory/QueryParams.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/TextureManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Crc32.h"
@@ -248,70 +249,70 @@ bool CVideoDatabaseDirectory::GetLabel(const std::string& strDirectory, std::str
       case NodeType::TITLE_MOVIES:
       case NodeType::TITLE_TVSHOWS:
       case NodeType::TITLE_MUSICVIDEOS:
-        strLabel = g_localizeStrings.Get(369);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(369);
         break;
       case NodeType::ACTOR: // Actor
-        strLabel = g_localizeStrings.Get(344);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(344);
         break;
       case NodeType::GENRE: // Genres
-        strLabel = g_localizeStrings.Get(135);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(135);
         break;
       case NodeType::COUNTRY: // Countries
-        strLabel = g_localizeStrings.Get(20451);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20451);
         break;
       case NodeType::YEAR: // Year
-        strLabel = g_localizeStrings.Get(562);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(562);
         break;
       case NodeType::DIRECTOR: // Director
-        strLabel = g_localizeStrings.Get(20348);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20348);
         break;
       case NodeType::SETS: // Sets
-        strLabel = g_localizeStrings.Get(20434);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20434);
         break;
       case NodeType::TAGS: // Tags
-        strLabel = g_localizeStrings.Get(20459);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20459);
         break;
       case NodeType::VIDEOVERSIONS: // Video versions
-        strLabel = g_localizeStrings.Get(40000);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40000);
         break;
       case NodeType::MOVIES_OVERVIEW: // Movies
-        strLabel = g_localizeStrings.Get(342);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(342);
         break;
       case NodeType::TVSHOWS_OVERVIEW: // TV Shows
-        strLabel = g_localizeStrings.Get(20343);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20343);
         break;
       case NodeType::RECENTLY_ADDED_MOVIES: // Recently Added Movies
-        strLabel = g_localizeStrings.Get(20386);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20386);
         break;
       case NodeType::RECENTLY_ADDED_EPISODES: // Recently Added Episodes
-        strLabel = g_localizeStrings.Get(20387);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20387);
         break;
       case NodeType::STUDIO: // Studios
-        strLabel = g_localizeStrings.Get(20388);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20388);
         break;
       case NodeType::MUSICVIDEOS_OVERVIEW: // Music Videos
-        strLabel = g_localizeStrings.Get(20389);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20389);
         break;
       case NodeType::RECENTLY_ADDED_MUSICVIDEOS: // Recently Added Music Videos
-        strLabel = g_localizeStrings.Get(20390);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20390);
         break;
       case NodeType::SEASONS: // Seasons
-        strLabel = g_localizeStrings.Get(33054);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(33054);
         break;
       case NodeType::EPISODES: // Episodes
-        strLabel = g_localizeStrings.Get(20360);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20360);
         break;
       case NodeType::INPROGRESS_TVSHOWS: // InProgress TvShows
-        strLabel = g_localizeStrings.Get(626);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(626);
         break;
       case NodeType::MOVIE_ASSETS: // Video assets
-        strLabel = g_localizeStrings.Get(40209);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40209);
         break;
       case NodeType::MOVIE_ASSETS_VERSIONS: // Video versions
-        strLabel = g_localizeStrings.Get(40210);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40210);
         break;
       case NodeType::MOVIE_ASSETS_EXTRAS: // Video extras
-        strLabel = g_localizeStrings.Get(40211);
+        strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40211);
         break;
 
       default:

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMovieAssets.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMovieAssets.cpp
@@ -11,7 +11,9 @@
 #include "FileItem.h"
 #include "FileItemList.h"
 #include "QueryParams.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
@@ -59,7 +61,8 @@ bool CDirectoryNodeMovieAssets::GetContent(CFileItemList& items) const
         URIUtils::GetParentPath(path), std::to_string(static_cast<int>(VideoAssetType::EXTRA)))};
 
     const auto item{std::make_shared<CFileItem>(pathExtras, true)};
-    item->SetLabel(g_localizeStrings.Get(40211)); // "Extras"
+    item->SetLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40211)); // "Extras"
     item->SetLabelPreformatted(true); //! @todo not sure, but used elsewhere
 
     //! @todo icon too small for nice display, add new skin icon in bigger size? ex. DefaultAddSource.png

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMoviesOverview.cpp
@@ -10,7 +10,9 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoDbUrl.h"
@@ -52,7 +54,7 @@ std::string CDirectoryNodeMoviesOverview::GetLocalizedName() const
 {
   for (const Node& node : MovieChildren)
     if (GetName() == node.id)
-      return g_localizeStrings.Get(node.label);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(node.label);
   return "";
 }
 
@@ -76,7 +78,8 @@ bool CDirectoryNodeMoviesOverview::GetContent(CFileItemList& items) const
     itemUrl.AppendPath(strDir);
 
     CFileItemPtr pItem(new CFileItem(itemUrl.ToString(), true));
-    pItem->SetLabel(g_localizeStrings.Get(MovieChildren[i].label));
+    pItem->SetLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(MovieChildren[i].label));
     pItem->SetCanQueue(false);
     items.Add(pItem);
   }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeMusicVideosOverview.cpp
@@ -10,7 +10,9 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "video/VideoDbUrl.h"
 
@@ -45,7 +47,7 @@ std::string CDirectoryNodeMusicVideosOverview::GetLocalizedName() const
 {
   for (const Node& node : MusicVideoChildren)
     if (GetName() == node.id)
-      return g_localizeStrings.Get(node.label);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(node.label);
   return "";
 }
 
@@ -57,7 +59,8 @@ bool CDirectoryNodeMusicVideosOverview::GetContent(CFileItemList& items) const
 
   for (const Node& node : MusicVideoChildren)
   {
-    CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(node.label)));
+    CFileItemPtr pItem(new CFileItem(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(node.label)));
 
     CVideoDbUrl itemUrl = videoUrl;
     std::string strDir = StringUtils::Format("{}/", node.id);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeOverview.cpp
@@ -11,7 +11,8 @@
 #include "FileItem.h"
 #include "FileItemList.h"
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "video/VideoDatabase.h"
@@ -49,7 +50,7 @@ std::string CDirectoryNodeOverview::GetLocalizedName() const
 {
   for (const Node& node : OverviewChildren)
     if (GetName() == node.id)
-      return g_localizeStrings.Get(node.label);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(node.label);
   return "";
 }
 
@@ -97,7 +98,8 @@ bool CDirectoryNodeOverview::GetContent(CFileItemList& items) const
   for (unsigned int i = 0; i < vec.size(); ++i)
   {
     CFileItemPtr pItem(new CFileItem(path + vec[i].first + "/", true));
-    pItem->SetLabel(g_localizeStrings.Get(vec[i].second));
+    pItem->SetLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(vec[i].second));
     pItem->SetLabelPreformatted(true);
     pItem->SetCanQueue(false);
     items.Add(pItem);

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeSeasons.cpp
@@ -10,7 +10,9 @@
 
 #include "FileItem.h"
 #include "QueryParams.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "video/VideoDatabase.h"
 
@@ -32,9 +34,9 @@ std::string CDirectoryNodeSeasons::GetLocalizedName() const
   switch (GetID())
   {
     case 0:
-      return g_localizeStrings.Get(20381); // Specials
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20381); // Specials
     case -1:
-      return g_localizeStrings.Get(20366); // All Seasons
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20366); // All Seasons
     case -2:
     {
       CDirectoryNode* pParent = GetParent();
@@ -59,7 +61,9 @@ std::string CDirectoryNodeSeasons::GetSeasonTitle() const
     season = db.GetTvShowNamedSeasonById(params.GetTvShowId(), params.GetSeason());
   }
   if (season.empty())
-    season = StringUtils::Format(g_localizeStrings.Get(20358), GetID()); // Season <n>
+    season =
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20358),
+                            GetID()); // Season <n>
 
   return season;
 }

--- a/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
+++ b/xbmc/filesystem/VideoDatabaseDirectory/DirectoryNodeTvShowsOverview.cpp
@@ -10,7 +10,9 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "video/VideoDbUrl.h"
 
@@ -44,7 +46,7 @@ std::string CDirectoryNodeTvShowsOverview::GetLocalizedName() const
 {
   for (const Node& node : TvShowChildren)
     if (GetName() == node.id)
-      return g_localizeStrings.Get(node.label);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(node.label);
   return "";
 }
 
@@ -56,7 +58,8 @@ bool CDirectoryNodeTvShowsOverview::GetContent(CFileItemList& items) const
 
   for (const Node& node : TvShowChildren)
   {
-    CFileItemPtr pItem(new CFileItem(g_localizeStrings.Get(node.label)));
+    CFileItemPtr pItem(new CFileItem(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(node.label)));
 
     CVideoDbUrl itemUrl = videoUrl;
     std::string strDir = StringUtils::Format("{}/", node.id);

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -27,12 +27,13 @@
 #include "games/addons/streams/GameClientStreams.h"
 #include "games/addons/streams/IGameClientStream.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -209,7 +210,9 @@ bool CGameClient::OpenFile(const CFileItem& file,
 
     // Failed to play game
     // The required files can't be found.
-    MESSAGING::HELPERS::ShowOKDialogText(CVariant{35210}, CVariant{g_localizeStrings.Get(35219)});
+    MESSAGING::HELPERS::ShowOKDialogText(
+        CVariant{35210},
+        CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35219)});
     return false;
   }
 
@@ -420,14 +423,18 @@ void CGameClient::NotifyError(GAME_ERROR error)
     // This game requires the following add-on: %s
     MESSAGING::HELPERS::ShowOKDialogText(
         CVariant{35210},
-        CVariant{StringUtils::Format(g_localizeStrings.Get(35211), missingResource)});
+        CVariant{StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35211),
+            missingResource)});
   }
   else
   {
     // Failed to play game
     // The emulator "%s" had an internal error.
     MESSAGING::HELPERS::ShowOKDialogText(
-        CVariant{35210}, CVariant{StringUtils::Format(g_localizeStrings.Get(35213), Name())});
+        CVariant{35210},
+        CVariant{StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35213), Name())});
   }
 }
 

--- a/xbmc/games/addons/GameClientProperties.cpp
+++ b/xbmc/games/addons/GameClientProperties.cpp
@@ -25,9 +25,10 @@
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -282,7 +283,8 @@ bool CGameClientProperties::GetProxyAddons(ADDON::VECADDONS& addons)
   if (!missingDependencies.empty())
   {
     std::string strDependencies = StringUtils::Join(missingDependencies, ", ");
-    std::string dialogText = StringUtils::Format(g_localizeStrings.Get(35223), strDependencies);
+    std::string dialogText = StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35223), strDependencies);
 
     // "Failed to play game"
     // "Add-on is incompatible due to unmet dependencies."
@@ -390,7 +392,9 @@ bool CGameClientProperties::InstallDependencies(const std::vector<std::string>& 
     const AddonPtr& addon = installableAddons.at(installedCount);
 
     // Set dialog text
-    const std::string& progressTemplate = g_localizeStrings.Get(24057); // "Installing {0:s}..."
+    const std::string& progressTemplate =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            24057); // "Installing {0:s}..."
     const std::string progressText = StringUtils::Format(progressTemplate, addon->Name());
     progressDialog->SetLine(0, CVariant{progressText});
 

--- a/xbmc/games/agents/windows/GUIAgentControllerList.cpp
+++ b/xbmc/games/agents/windows/GUIAgentControllerList.cpp
@@ -27,12 +27,13 @@
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindow.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "peripherals/Peripherals.h"
 #include "peripherals/devices/Peripheral.h"
 #include "peripherals/dialogs/GUIDialogPeripheralSettings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/log.h"
 #include "view/GUIViewControl.h"
 #include "view/ViewState.h"
@@ -160,8 +161,9 @@ void CGUIAgentControllerList::Refresh()
   // Add a "No controllers connected" item if no agents are available
   if (m_vecItems->IsEmpty())
   {
-    CFileItemPtr item =
-        std::make_shared<CFileItem>(g_localizeStrings.Get(35173)); // "No controllers connected"
+    CFileItemPtr item = std::make_shared<CFileItem>(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            35173)); // "No controllers connected"
     m_vecItems->Add(std::move(item));
   }
 

--- a/xbmc/games/controllers/ControllerLayout.cpp
+++ b/xbmc/games/controllers/ControllerLayout.cpp
@@ -11,8 +11,10 @@
 #include "Controller.h"
 #include "ControllerDefinitions.h"
 #include "ControllerTranslator.h"
+#include "ServiceBroker.h"
 #include "games/controllers/input/PhysicalTopology.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/URIUtils.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
@@ -75,7 +77,8 @@ std::string CControllerLayout::Label(void) const
   std::string label;
 
   if (m_labelId >= 0 && m_controller != nullptr)
-    label = g_localizeStrings.GetAddonString(m_controller->ID(), m_labelId);
+    label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+        m_controller->ID(), m_labelId);
 
   return label;
 }

--- a/xbmc/games/controllers/dialogs/ControllerInstaller.cpp
+++ b/xbmc/games/controllers/dialogs/ControllerInstaller.cpp
@@ -19,9 +19,10 @@
 #include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -101,7 +102,9 @@ void CControllerInstaller::Process()
     const auto& addon = installableAddons[installedCount];
 
     // Set dialog text
-    const std::string& progressTemplate = g_localizeStrings.Get(24057); // "Installing {0:s}..."
+    const std::string& progressTemplate =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            24057); // "Installing {0:s}..."
     const std::string progressText = StringUtils::Format(progressTemplate, addon->Name());
     pProgressDialog->SetLine(0, CVariant{progressText});
 

--- a/xbmc/games/controllers/dialogs/ControllerSelect.cpp
+++ b/xbmc/games/controllers/dialogs/ControllerSelect.cpp
@@ -17,8 +17,9 @@
 #include "games/controllers/ControllerTypes.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
@@ -97,7 +98,8 @@ void CControllerSelect::Process()
   if (m_showDisconnect)
   {
     // Add a button to disconnect the port
-    CFileItemPtr item(new CFileItem(g_localizeStrings.Get(13298))); // "Disconnected"
+    CFileItemPtr item(new CFileItem(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13298))); // "Disconnected"
     item->SetArt("icon", "DefaultAddonNone.png");
     items.Add(std::move(item));
 

--- a/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
@@ -8,10 +8,12 @@
 
 #include "GUIDialogAxisDetection.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "input/joysticks/DriverPrimitive.h"
 #include "input/joysticks/JoystickTranslator.h"
 #include "input/joysticks/interfaces/IButtonMap.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 #include <algorithm>
@@ -22,7 +24,8 @@ using namespace GAME;
 std::string CGUIDialogAxisDetection::GetDialogText()
 {
   // "Press all analog buttons now to detect them:[CR][CR]%s"
-  const std::string& dialogText = g_localizeStrings.Get(35020);
+  const std::string& dialogText =
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35020);
 
   std::vector<std::string> primitives;
 
@@ -37,7 +40,8 @@ std::string CGUIDialogAxisDetection::GetDialogText()
 
 std::string CGUIDialogAxisDetection::GetDialogHeader()
 {
-  return g_localizeStrings.Get(35058); // "Controller Configuration"
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      35058); // "Controller Configuration"
 }
 
 bool CGUIDialogAxisDetection::MapPrimitiveInternal(JOYSTICK::IButtonMap* buttonMap,

--- a/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
@@ -8,10 +8,12 @@
 
 #include "GUIDialogIgnoreInput.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "input/joysticks/JoystickTranslator.h"
 #include "input/joysticks/interfaces/IButtonMap.h"
 #include "input/joysticks/interfaces/IButtonMapCallback.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -39,7 +41,8 @@ std::string CGUIDialogIgnoreInput::GetDialogText()
 {
   // "Some controllers have buttons and axes that interfere with mapping. Press
   // these now to disable them:[CR]%s"
-  const std::string& dialogText = g_localizeStrings.Get(35014);
+  const std::string& dialogText =
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35014);
 
   std::vector<std::string> primitives;
 
@@ -53,7 +56,7 @@ std::string CGUIDialogIgnoreInput::GetDialogText()
 std::string CGUIDialogIgnoreInput::GetDialogHeader()
 {
 
-  return g_localizeStrings.Get(35019); // "Ignore input"
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35019); // "Ignore input"
 }
 
 bool CGUIDialogIgnoreInput::MapPrimitiveInternal(JOYSTICK::IButtonMap* buttonMap,

--- a/xbmc/games/controllers/guicontrols/GUICardinalFeatureButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUICardinalFeatureButton.cpp
@@ -8,7 +8,9 @@
 
 #include "GUICardinalFeatureButton.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 #include <string>
 
@@ -36,20 +38,28 @@ bool CGUICardinalFeatureButton::PromptForInput(CEvent& waitEvent)
   switch (m_state)
   {
     case STATE::CARDINAL_DIRECTION_UP:
-      strPrompt = g_localizeStrings.Get(35092); // "Move %s up"
-      strWarn = g_localizeStrings.Get(35093); // "Move %s up (%d)"
+      strPrompt =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35092); // "Move %s up"
+      strWarn = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          35093); // "Move %s up (%d)"
       break;
     case STATE::CARDINAL_DIRECTION_RIGHT:
-      strPrompt = g_localizeStrings.Get(35096); // "Move %s right"
-      strWarn = g_localizeStrings.Get(35097); // "Move %s right (%d)"
+      strPrompt = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          35096); // "Move %s right"
+      strWarn = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          35097); // "Move %s right (%d)"
       break;
     case STATE::CARDINAL_DIRECTION_DOWN:
-      strPrompt = g_localizeStrings.Get(35094); // "Move %s down"
-      strWarn = g_localizeStrings.Get(35095); // "Move %s down (%d)"
+      strPrompt =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35094); // "Move %s down"
+      strWarn = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          35095); // "Move %s down (%d)"
       break;
     case STATE::CARDINAL_DIRECTION_LEFT:
-      strPrompt = g_localizeStrings.Get(35098); // "Move %s left"
-      strWarn = g_localizeStrings.Get(35099); // "Move %s left (%d)"
+      strPrompt =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35098); // "Move %s left"
+      strWarn = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          35099); // "Move %s left (%d)"
       break;
     default:
       break;

--- a/xbmc/games/controllers/guicontrols/GUIScalarFeatureButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIScalarFeatureButton.cpp
@@ -8,7 +8,9 @@
 
 #include "GUIScalarFeatureButton.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 #include <string>
 
@@ -32,8 +34,10 @@ bool CGUIScalarFeatureButton::PromptForInput(CEvent& waitEvent)
   {
     case STATE::NEED_INPUT:
     {
-      const std::string& strPrompt = g_localizeStrings.Get(35090); // "Press %s"
-      const std::string& strWarn = g_localizeStrings.Get(35091); // "Press %s (%d)"
+      const std::string& strPrompt =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35090); // "Press %s"
+      const std::string& strWarn = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          35091); // "Press %s (%d)"
 
       bInterrupted = DoPrompt(strPrompt, strWarn, m_feature.Label(), waitEvent);
 

--- a/xbmc/games/controllers/guicontrols/GUISelectKeyButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUISelectKeyButton.cpp
@@ -8,7 +8,9 @@
 
 #include "GUISelectKeyButton.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 #include <string>
 
@@ -38,8 +40,10 @@ bool CGUISelectKeyButton::PromptForInput(CEvent& waitEvent)
   {
     case STATE::NEED_KEY:
     {
-      const std::string& strPrompt = g_localizeStrings.Get(35169); // "Press a key"
-      const std::string& strWarn = g_localizeStrings.Get(35170); // "Press a key ({1:d})"
+      const std::string& strPrompt =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35169); // "Press a key"
+      const std::string& strWarn = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          35170); // "Press a key ({1:d})"
 
       bInterrupted = DoPrompt(strPrompt, strWarn, "", waitEvent);
 
@@ -49,8 +53,10 @@ bool CGUISelectKeyButton::PromptForInput(CEvent& waitEvent)
     }
     case STATE::NEED_INPUT:
     {
-      const std::string& strPrompt = g_localizeStrings.Get(35090); // "Press {0:s}"
-      const std::string& strWarn = g_localizeStrings.Get(35091); // "Press {0:s} ({1:d})"
+      const std::string& strPrompt =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35090); // "Press {0:s}"
+      const std::string& strWarn = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          35091); // "Press {0:s} ({1:d})"
 
       bInterrupted = DoPrompt(strPrompt, strWarn, m_selectedKey.Label(), waitEvent);
 

--- a/xbmc/games/controllers/guicontrols/GUIThrottleButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIThrottleButton.cpp
@@ -8,7 +8,9 @@
 
 #include "GUIThrottleButton.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 #include <string>
 
@@ -36,12 +38,16 @@ bool CGUIThrottleButton::PromptForInput(CEvent& waitEvent)
   switch (m_state)
   {
     case STATE::THROTTLE_UP:
-      strPrompt = g_localizeStrings.Get(35092); // "Move %s up"
-      strWarn = g_localizeStrings.Get(35093); // "Move %s up (%d)"
+      strPrompt =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35092); // "Move %s up"
+      strWarn = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          35093); // "Move %s up (%d)"
       break;
     case STATE::THROTTLE_DOWN:
-      strPrompt = g_localizeStrings.Get(35094); // "Move %s down"
-      strWarn = g_localizeStrings.Get(35095); // "Move %s down (%d)"
+      strPrompt =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35094); // "Move %s down"
+      strWarn = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          35095); // "Move %s down (%d)"
       break;
     default:
       break;

--- a/xbmc/games/controllers/guicontrols/GUIWheelButton.cpp
+++ b/xbmc/games/controllers/guicontrols/GUIWheelButton.cpp
@@ -8,7 +8,9 @@
 
 #include "GUIWheelButton.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 #include <string>
 
@@ -36,12 +38,16 @@ bool CGUIWheelButton::PromptForInput(CEvent& waitEvent)
   switch (m_state)
   {
     case STATE::WHEEL_LEFT:
-      strPrompt = g_localizeStrings.Get(35098); // "Move %s left"
-      strWarn = g_localizeStrings.Get(35099); // "Move %s left (%d)"
+      strPrompt =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35098); // "Move %s left"
+      strWarn = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          35099); // "Move %s left (%d)"
       break;
     case STATE::WHEEL_RIGHT:
-      strPrompt = g_localizeStrings.Get(35096); // "Move %s right"
-      strWarn = g_localizeStrings.Get(35097); // "Move %s right (%d)"
+      strPrompt = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          35096); // "Move %s right"
+      strWarn = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          35097); // "Move %s right (%d)"
       break;
     default:
       break;

--- a/xbmc/games/controllers/input/PhysicalFeature.cpp
+++ b/xbmc/games/controllers/input/PhysicalFeature.cpp
@@ -8,11 +8,13 @@
 
 #include "PhysicalFeature.h"
 
+#include "ServiceBroker.h"
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerDefinitions.h"
 #include "games/controllers/ControllerTranslator.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/keyboard/KeyboardTranslator.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
@@ -56,10 +58,12 @@ std::string CPhysicalFeature::CategoryLabel() const
   std::string categoryLabel;
 
   if (m_categoryLabelId >= 0 && m_controller != nullptr)
-    categoryLabel = g_localizeStrings.GetAddonString(m_controller->ID(), m_categoryLabelId);
+    categoryLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+        m_controller->ID(), m_categoryLabelId);
 
   if (categoryLabel.empty())
-    categoryLabel = g_localizeStrings.Get(m_categoryLabelId);
+    categoryLabel =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(m_categoryLabelId);
 
   return categoryLabel;
 }
@@ -69,10 +73,11 @@ std::string CPhysicalFeature::Label() const
   std::string label;
 
   if (m_labelId >= 0 && m_controller != nullptr)
-    label = g_localizeStrings.GetAddonString(m_controller->ID(), m_labelId);
+    label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+        m_controller->ID(), m_labelId);
 
   if (label.empty())
-    label = g_localizeStrings.Get(m_labelId);
+    label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(m_labelId);
 
   return label;
 }

--- a/xbmc/games/controllers/windows/GUIFeatureList.cpp
+++ b/xbmc/games/controllers/windows/GUIFeatureList.cpp
@@ -10,6 +10,7 @@
 
 #include "GUIConfigurationWizard.h"
 #include "GUIControllerDefines.h"
+#include "ServiceBroker.h"
 #include "games/addons/GameClient.h"
 #include "games/addons/input/GameClientInput.h"
 #include "games/controllers/Controller.h"
@@ -23,7 +24,8 @@
 #include "guilib/GUIImage.h"
 #include "guilib/GUILabelControl.h"
 #include "guilib/GUIWindow.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 using namespace KODI;
 using namespace GAME;
@@ -222,7 +224,8 @@ std::vector<CGUIFeatureList::FeatureGroup> CGUIFeatureList::GetFeatureGroups(
       if (feature.Category() == JOYSTICK::FEATURE_CATEGORY::KEY)
       {
         FeatureGroup virtualGroup;
-        virtualGroup.groupName = g_localizeStrings.Get(35166); // "All keys"
+        virtualGroup.groupName =
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35166); // "All keys"
         virtualGroup.bIsVirtualKey = true;
         virtualGroup.features.emplace_back(feature);
         groups.emplace_back(std::move(virtualGroup));
@@ -240,7 +243,8 @@ std::vector<CGUIFeatureList::FeatureGroup> CGUIFeatureList::GetFeatureGroups(
   if (groups.empty())
   {
     FeatureGroup group;
-    group.groupName = g_localizeStrings.Get(35022); // "Nothing to map"
+    group.groupName =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35022); // "Nothing to map"
     groups.emplace_back(std::move(group));
   }
 

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -16,8 +16,9 @@
 #include "games/addons/GameClient.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -36,8 +37,8 @@ std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const std::string& 
   std::string extension = URIUtils::GetExtension(gamePath);
 
   // "Select emulator for {0:s}"
-  CGUIDialogSelect* dialog =
-      GetDialog(StringUtils::Format(g_localizeStrings.Get(35258), extension));
+  CGUIDialogSelect* dialog = GetDialog(StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35258), extension));
   if (dialog != nullptr)
   {
     // Turn the addons into items
@@ -46,7 +47,8 @@ std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const std::string& 
     for (const auto& candidate : candidates)
     {
       CFileItemPtr item(XFILE::CAddonsDirectory::FileItemFromAddon(candidate, candidate->ID()));
-      item->SetLabel2(g_localizeStrings.Get(35257)); // "Installed"
+      item->SetLabel2(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35257)); // "Installed"
       items.Add(std::move(item));
     }
     for (const auto& addon : installable)

--- a/xbmc/games/dialogs/osd/DialogGameOSDHelp.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameOSDHelp.cpp
@@ -9,9 +9,11 @@
 #include "DialogGameOSDHelp.h"
 
 #include "DialogGameOSD.h"
+#include "ServiceBroker.h"
 #include "guilib/GUIMessage.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 using namespace KODI;
@@ -33,7 +35,8 @@ void CDialogGameOSDHelp::OnInitWindow()
 {
   // Set help text
   // "Press {0:s} to open the menu."
-  std::string helpText = StringUtils::Format(g_localizeStrings.Get(35235), HELP_COMBO);
+  std::string helpText = StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35235), HELP_COMBO);
 
   CGUIMessage msg(GUI_MSG_LABEL_SET, WINDOW_DIALOG_GAME_OSD, CONTROL_ID_HELP_TEXT);
   msg.SetLabel(helpText);

--- a/xbmc/games/dialogs/osd/DialogGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.cpp
@@ -25,9 +25,10 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "input/actions/ActionIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/FileUtils.h"
 #include "utils/Variant.h"
 #include "view/GUIViewControl.h"
@@ -411,7 +412,9 @@ void CDialogGameSaves::OnRename(CFileItem& item)
   std::string label(savestate->Label());
 
   // "Enter new filename"
-  if (CGUIKeyboardFactory::ShowAndGetInput(label, CVariant{g_localizeStrings.Get(16013)}, true) &&
+  if (CGUIKeyboardFactory::ShowAndGetInput(
+          label, CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16013)},
+          true) &&
       label != savestate->Label())
   {
     std::unique_ptr<RETRO::ISavestate> newSavestate = db.RenameSavestate(savestatePath, label);

--- a/xbmc/games/dialogs/osd/DialogGameStretchMode.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameStretchMode.cpp
@@ -10,10 +10,12 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
+#include "ServiceBroker.h"
 #include "cores/RetroPlayer/RetroPlayerUtils.h"
 #include "cores/RetroPlayer/guibridge/GUIGameVideoHandle.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/GameSettings.h"
 #include "settings/MediaSettings.h"
 #include "utils/Variant.h"
@@ -42,7 +44,7 @@ CDialogGameStretchMode::CDialogGameStretchMode()
 
 std::string CDialogGameStretchMode::GetHeading()
 {
-  return g_localizeStrings.Get(35233); // "Stretch mode"
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35233); // "Stretch mode"
 }
 
 void CDialogGameStretchMode::PreInit()
@@ -86,7 +88,8 @@ void CDialogGameStretchMode::GetItems(CFileItemList& items)
 {
   for (const auto& stretchMode : m_stretchModes)
   {
-    CFileItemPtr item = std::make_shared<CFileItem>(g_localizeStrings.Get(stretchMode.stringIndex));
+    CFileItemPtr item = std::make_shared<CFileItem>(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(stretchMode.stringIndex));
 
     const std::string stretchModeId =
         RETRO::CRetroPlayerUtils::StretchModeToIdentifier(stretchMode.stretchMode);

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -23,9 +23,10 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "jobs/JobManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/GameSettings.h"
 #include "settings/MediaSettings.h"
 #include "threads/SystemClock.h"
@@ -75,7 +76,7 @@ CDialogGameVideoFilter::CDialogGameVideoFilter()
 
 std::string CDialogGameVideoFilter::GetHeading()
 {
-  return g_localizeStrings.Get(35225); // "Video filter"
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35225); // "Video filter"
 }
 
 void CDialogGameVideoFilter::PreInit()
@@ -88,7 +89,8 @@ void CDialogGameVideoFilter::PreInit()
 
   if (m_items.Size() == 0)
   {
-    CFileItemPtr item = std::make_shared<CFileItem>(g_localizeStrings.Get(231)); // "None"
+    CFileItemPtr item = std::make_shared<CFileItem>(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231)); // "None"
     m_items.Add(std::move(item));
   }
 }
@@ -104,9 +106,11 @@ void CDialogGameVideoFilter::InitScalingMethods()
         RETRO::CRenderVideoSettings videoSettings;
         videoSettings.SetScalingMethod(scalingMethodProps.scalingMethod);
 
-        CFileItemPtr item =
-            std::make_shared<CFileItem>(g_localizeStrings.Get(scalingMethodProps.nameIndex));
-        item->SetLabel2(g_localizeStrings.Get(scalingMethodProps.categoryIndex));
+        CFileItemPtr item = std::make_shared<CFileItem>(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                scalingMethodProps.nameIndex));
+        item->SetLabel2(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            scalingMethodProps.categoryIndex));
         item->SetProperty("game.videofilter", CVariant{videoSettings.GetVideoFilter()});
         item->SetArt("icon", ICON_VIDEO);
         m_items.Add(std::move(item));
@@ -242,7 +246,8 @@ void CDialogGameVideoFilter::InitGetMoreButton()
 
   if (showGetMore)
   {
-    auto item = std::make_shared<CFileItem>(g_localizeStrings.Get(21452)); // "Get more..."
+    auto item = std::make_shared<CFileItem>(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21452)); // "Get more..."
     item->SetArt("icon", ICON_GET_MORE);
     m_items.Add(std::move(item));
   }
@@ -333,7 +338,8 @@ void CDialogGameVideoFilter::RefreshList()
 
 std::string CDialogGameVideoFilter::GetLocalizedString(uint32_t code)
 {
-  return g_localizeStrings.GetAddonString(PRESETS_ADDON_NAME, code);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+      PRESETS_ADDON_NAME, code);
 }
 
 void CDialogGameVideoFilter::OnGetMore()

--- a/xbmc/games/dialogs/osd/DialogGameVideoRotation.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoRotation.cpp
@@ -10,8 +10,10 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "guilib/WindowIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/GameSettings.h"
 #include "settings/MediaSettings.h"
 #include "utils/Variant.h"
@@ -26,7 +28,7 @@ CDialogGameVideoRotation::CDialogGameVideoRotation()
 
 std::string CDialogGameVideoRotation::GetHeading()
 {
-  return g_localizeStrings.Get(35227); // "Rotation"
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35227); // "Rotation"
 }
 
 void CDialogGameVideoRotation::PreInit()
@@ -95,13 +97,13 @@ std::string CDialogGameVideoRotation::GetRotationLabel(unsigned int rotationDegC
   switch (rotationDegCCW)
   {
     case 0:
-      return g_localizeStrings.Get(35228); // 0
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35228); // 0
     case 90:
-      return g_localizeStrings.Get(35231); // 270
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35231); // 270
     case 180:
-      return g_localizeStrings.Get(35230); // 180
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35230); // 180
     case 270:
-      return g_localizeStrings.Get(35229); // 90
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35229); // 90
     default:
       break;
   }

--- a/xbmc/games/dialogs/osd/DialogGameVolume.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVolume.cpp
@@ -17,9 +17,10 @@
 #include "guilib/GUIMessage.h"
 #include "guilib/GUISliderControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "interfaces/AnnouncementManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/Variant.h"
 
 #include <cmath>
@@ -145,5 +146,5 @@ float CDialogGameVolume::GetVolumePercent() const
 
 std::string CDialogGameVolume::GetLabel()
 {
-  return g_localizeStrings.Get(13376); // "Volume"
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13376); // "Volume"
 }

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -23,8 +23,9 @@
 #include "games/dialogs/DialogGameDefines.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIMessage.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/GameSettings.h"
 #include "settings/MediaSettings.h"
 #include "utils/log.h"
@@ -37,13 +38,15 @@ namespace
 {
 CFileItemPtr CreateNewSaveItem()
 {
-  CFileItemPtr item = std::make_shared<CFileItem>(g_localizeStrings.Get(15314)); // "Save"
+  CFileItemPtr item = std::make_shared<CFileItem>(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15314)); // "Save"
 
   // A nonexistent path ensures a gamewindow control won't render any pixels
   item->SetPath(NO_PIXEL_DATA);
   item->SetArt("icon", "DefaultAddSource.png");
   item->SetProperty(SAVESTATE_CAPTION,
-                    g_localizeStrings.Get(15315)); // "Save progress to a new save file"
+                    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                        15315)); // "Save progress to a new save file"
 
   return item;
 }
@@ -89,7 +92,7 @@ bool CDialogInGameSaves::OnMessage(CGUIMessage& message)
 
 std::string CDialogInGameSaves::GetHeading()
 {
-  return g_localizeStrings.Get(35249); // "Save / Load"
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35249); // "Save / Load"
 }
 
 void CDialogInGameSaves::PreInit()
@@ -358,7 +361,9 @@ void CDialogInGameSaves::OnRename(CFileItem& focusedItem)
     label = savestate->Label();
 
   // "Enter new filename"
-  if (CGUIKeyboardFactory::ShowAndGetInput(label, CVariant{g_localizeStrings.Get(16013)}, true) &&
+  if (CGUIKeyboardFactory::ShowAndGetInput(
+          label, CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16013)},
+          true) &&
       label != savestate->Label())
   {
     std::unique_ptr<RETRO::ISavestate> newSavestate = db.RenameSavestate(savestatePath, label);

--- a/xbmc/games/ports/windows/GUIPortList.cpp
+++ b/xbmc/games/ports/windows/GUIPortList.cpp
@@ -25,9 +25,10 @@
 #include "games/ports/types/PortNode.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindow.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "view/GUIViewControl.h"
@@ -224,7 +225,8 @@ bool CGUIPortList::AddItems(const CPortNode& port,
   {
     // Create the list item
     CFileItemPtr item = std::make_shared<CFileItem>(itemLabel);
-    item->SetLabel2(g_localizeStrings.Get(13298)); // "Disconnected"
+    item->SetLabel2(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13298)); // "Disconnected"
     item->SetPath(port.GetAddress());
     item->SetArt("icon", "DefaultAddonNone.png");
     m_vecItems->Add(std::move(item));
@@ -320,7 +322,9 @@ void CGUIPortList::OnControllerSelected(const CPortNode& port, const ControllerP
       // "The emulator "%s" had an internal error."
       MESSAGING::HELPERS::ShowOKDialogText(
           CVariant{35114},
-          CVariant{StringUtils::Format(g_localizeStrings.Get(35213), m_gameClient->Name())});
+          CVariant{StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35213),
+              m_gameClient->Name())});
     }
 
     // Send a GUI message to reload the port list
@@ -337,12 +341,12 @@ std::string CGUIPortList::GetLabel(const CPortNode& port)
     case PORT_TYPE::KEYBOARD:
     {
       // "Keyboard"
-      return g_localizeStrings.Get(35150);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35150);
     }
     case PORT_TYPE::MOUSE:
     {
       // "Mouse"
-      return g_localizeStrings.Get(35171);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35171);
     }
     case PORT_TYPE::CONTROLLER:
     {
@@ -355,7 +359,8 @@ std::string CGUIPortList::GetLabel(const CPortNode& port)
       else
       {
         // "Port {0:s}"
-        const std::string& portString = g_localizeStrings.Get(35112);
+        const std::string& portString =
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35112);
         return StringUtils::Format(portString, portId);
       }
       break;

--- a/xbmc/games/windows/GUIViewStateWindowGames.cpp
+++ b/xbmc/games/windows/GUIViewStateWindowGames.cpp
@@ -11,7 +11,6 @@
 #include "FileItem.h"
 #include "FileItemList.h"
 #include "games/GameUtils.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "settings/MediaSourceSettings.h"
 #include "utils/StringUtils.h"

--- a/xbmc/guilib/CMakeLists.txt
+++ b/xbmc/guilib/CMakeLists.txt
@@ -64,7 +64,6 @@ set(SOURCES DDSImage.cpp
             imagefactory.cpp
             ImageSettings.cpp
             IWindowManagerCallback.cpp
-            LocalizeStrings.cpp
             StereoscopicsManager.cpp
             TextureBundle.cpp
             TextureBundleXBT.cpp
@@ -153,7 +152,6 @@ set(HEADERS AspectRatio.h
             IRenderingCallback.h
             ISliderCallback.h
             IWindowManagerCallback.h
-            LocalizeStrings.h
             StereoscopicsManager.h
             Texture.h
             TextureBase.h

--- a/xbmc/guilib/GUIColorButtonControl.cpp
+++ b/xbmc/guilib/GUIColorButtonControl.cpp
@@ -9,7 +9,6 @@
 #include "GUIColorButtonControl.h"
 
 #include "GUIInfoManager.h"
-#include "LocalizeStrings.h"
 #include "ServiceBroker.h"
 #include "input/keyboard/Key.h"
 #include "utils/ColorUtils.h"

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -45,7 +45,6 @@
 #include "GUIVideoControl.h"
 #include "GUIVisualisationControl.h"
 #include "GUIWrappingListContainer.h"
-#include "LocalizeStrings.h"
 #include "ServiceBroker.h"
 #include "addons/Skin.h"
 #include "cores/RetroPlayer/guicontrols/GUIGameControl.h"
@@ -53,6 +52,8 @@
 #include "games/controllers/guicontrols/GUIGameControllerList.h"
 #include "input/actions/ActionIDs.h"
 #include "pvr/guilib/GUIEPGGridContainer.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/CharsetConverter.h"
 #include "utils/RssManager.h"
 #include "utils/StringUtils.h"
@@ -1179,20 +1180,23 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
   // view type
   VIEW_TYPE viewType = VIEW_TYPE_NONE;
   std::string viewLabel;
+
+  const auto& localizeStrings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
+
   if (type == CGUIControl::GUICONTAINER_PANEL)
   {
     viewType = VIEW_TYPE_ICON;
-    viewLabel = g_localizeStrings.Get(536);
+    viewLabel = localizeStrings.Get(536);
   }
   else if (type == CGUIControl::GUICONTAINER_LIST)
   {
     viewType = VIEW_TYPE_LIST;
-    viewLabel = g_localizeStrings.Get(535);
+    viewLabel = localizeStrings.Get(535);
   }
   else
   {
     viewType = VIEW_TYPE_WRAP;
-    viewLabel = g_localizeStrings.Get(541);
+    viewLabel = localizeStrings.Get(541);
   }
   TiXmlElement* itemElement = pControlNode->FirstChildElement("viewtype");
   if (itemElement && itemElement->FirstChild())

--- a/xbmc/guilib/GUIEditControl.cpp
+++ b/xbmc/guilib/GUIEditControl.cpp
@@ -12,7 +12,6 @@
 #include "GUIKeyboardFactory.h"
 #include "GUIUserMessages.h"
 #include "GUIWindowManager.h"
-#include "LocalizeStrings.h"
 #include "ServiceBroker.h"
 #include "XBDateTime.h"
 #include "dialogs/GUIDialogNumeric.h"
@@ -20,6 +19,8 @@
 #include "input/actions/ActionIDs.h"
 #include "input/keyboard/KeyIDs.h"
 #include "input/keyboard/XBMC_vkeys.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/CharsetConverter.h"
 #include "utils/ColorUtils.h"
 #include "utils/Digest.h"
@@ -80,7 +81,7 @@ void CGUIEditControl::DefaultConstructor()
   m_textOffset = 0;
   m_cursorPos = 0;
   m_cursorBlink = 0;
-  m_inputHeading = g_localizeStrings.Get(16028);
+  m_inputHeading = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16028);
   m_inputType = INPUT_TYPE_TEXT;
   m_smsLastKey = 0;
   m_smsKeyIndex = 0;
@@ -335,7 +336,8 @@ void CGUIEditControl::OnClick()
       textChanged = CGUIDialogNumeric::ShowAndGetNumber(utf8, m_inputHeading);
       break;
     case INPUT_TYPE_SECONDS:
-      textChanged = CGUIDialogNumeric::ShowAndGetSeconds(utf8, g_localizeStrings.Get(21420));
+      textChanged = CGUIDialogNumeric::ShowAndGetSeconds(
+          utf8, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21420));
       break;
     case INPUT_TYPE_TIME:
     {
@@ -343,7 +345,10 @@ void CGUIEditControl::OnClick()
       dateTime.SetFromDBTime(utf8);
       KODI::TIME::SystemTime time;
       dateTime.GetAsSystemTime(time);
-      if (CGUIDialogNumeric::ShowAndGetTime(time, !m_inputHeading.empty() ? m_inputHeading : g_localizeStrings.Get(21420)))
+      if (CGUIDialogNumeric::ShowAndGetTime(
+              time, !m_inputHeading.empty()
+                        ? m_inputHeading
+                        : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21420)))
       {
         dateTime = CDateTime(time);
         utf8 = dateTime.GetAsLocalizedTime("", false);
@@ -360,7 +365,10 @@ void CGUIEditControl::OnClick()
       else
         KODI::TIME::GetLocalTime(&date);
 
-      if (CGUIDialogNumeric::ShowAndGetDate(date, !m_inputHeading.empty() ? m_inputHeading : g_localizeStrings.Get(21420)))
+      if (CGUIDialogNumeric::ShowAndGetDate(
+              date, !m_inputHeading.empty()
+                        ? m_inputHeading
+                        : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21420)))
       {
         dateTime = CDateTime(date);
         utf8 = dateTime.GetAsDBDate();
@@ -420,7 +428,8 @@ void CGUIEditControl::SetInputType(CGUIEditControl::INPUT_TYPE type, const CVari
   if (heading.isString())
     m_inputHeading = heading.asString();
   else if (heading.isInteger() && heading.asInteger())
-    m_inputHeading = g_localizeStrings.Get(static_cast<uint32_t>(heading.asInteger()));
+    m_inputHeading = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        static_cast<uint32_t>(heading.asInteger()));
   ValidateInput();
 }
 

--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -6,21 +6,22 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "ServiceBroker.h"
-#include "GUIComponent.h"
-#include "messaging/ApplicationMessenger.h"
-#include "LocalizeStrings.h"
 #include "GUIKeyboardFactory.h"
+
+#include "GUIComponent.h"
 #include "GUIUserMessages.h"
 #include "GUIWindowManager.h"
+#include "ServiceBroker.h"
+#include "dialogs/GUIDialogKeyboardGeneric.h"
+#include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Digest.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
-
-#include "dialogs/GUIDialogKeyboardGeneric.h"
 #if defined(TARGET_DARWIN_EMBEDDED)
 #include "dialogs/GUIDialogKeyboardTouch.h"
 
@@ -86,7 +87,8 @@ bool CGUIKeyboardFactory::ShowAndGetInput(std::string& aTextString,
   if (heading.isString())
     headingStr = heading.asString();
   else if (heading.isInteger() && heading.asInteger())
-    headingStr = g_localizeStrings.Get((uint32_t)heading.asInteger());
+    headingStr = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        (uint32_t)heading.asInteger());
 
   bool useKodiKeyboard = true;
 #if defined(TARGET_DARWIN_EMBEDDED)
@@ -192,7 +194,8 @@ bool CGUIKeyboardFactory::ShowAndVerifyNewPassword(std::string& newPassword,
 // \return true if successful display and user input entry/re-entry. false if unsuccessful display, no user input, or canceled editing.
 bool CGUIKeyboardFactory::ShowAndVerifyNewPassword(std::string& newPassword, unsigned int autoCloseMs /* = 0 */)
 {
-  const std::string& heading = g_localizeStrings.Get(12340);
+  const std::string& heading =
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12340);
   return ShowAndVerifyNewPassword(newPassword, heading, false, autoCloseMs);
 }
 
@@ -207,12 +210,12 @@ int CGUIKeyboardFactory::ShowAndVerifyPassword(std::string& strPassword, const s
   if (1 > iRetries && !strHeading.empty())
     strHeadingTemp = strHeading;
   else
-    strHeadingTemp =
-        StringUtils::Format("{} - {} {}", g_localizeStrings.Get(12326),
-                            CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-                                CSettings::SETTING_MASTERLOCK_MAXRETRIES) -
-                                iRetries,
-                            g_localizeStrings.Get(12343));
+    strHeadingTemp = StringUtils::Format(
+        "{} - {} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12326),
+        CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+            CSettings::SETTING_MASTERLOCK_MAXRETRIES) -
+            iRetries,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12343));
 
   std::string strUserInput;
   //! @todo GUI Setting to enable disable this feature y/n?

--- a/xbmc/guilib/GUIMessage.cpp
+++ b/xbmc/guilib/GUIMessage.cpp
@@ -8,7 +8,9 @@
 
 #include "GUIMessage.h"
 
-#include "LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 std::string CGUIMessage::empty_string;
 
@@ -128,7 +130,7 @@ const std::string& CGUIMessage::GetLabel() const
 
 void CGUIMessage::SetLabel(int iString)
 {
-  m_strLabel = g_localizeStrings.Get(iString);
+  m_strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(iString);
 }
 
 void CGUIMessage::SetStringParam(const std::string& strParam)

--- a/xbmc/guilib/GUIRadioButtonControl.cpp
+++ b/xbmc/guilib/GUIRadioButtonControl.cpp
@@ -9,10 +9,11 @@
 #include "GUIRadioButtonControl.h"
 
 #include "GUIInfoManager.h"
-#include "LocalizeStrings.h"
 #include "ServiceBroker.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 CGUIRadioButtonControl::CGUIRadioButtonControl(int parentID,
                                                int controlID,
@@ -111,7 +112,8 @@ void CGUIRadioButtonControl::Process(unsigned int currentTime, CDirtyRegionList 
   m_imgRadioOffDisabled->Process(currentTime);
 
   if (m_useLabel2)
-    SetLabel2(g_localizeStrings.Get(m_bSelected ? 16041 : 351));
+    SetLabel2(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(m_bSelected ? 16041
+                                                                                           : 351));
 
   CGUIButtonControl::Process(currentTime, dirtyregions);
 }

--- a/xbmc/guilib/GUIUtils.cpp
+++ b/xbmc/guilib/GUIUtils.cpp
@@ -11,7 +11,8 @@
 #include "ServiceBroker.h"
 #include "addons/Skin.h"
 #include "guilib/GUIComponent.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 std::string CGUIUtils::GetLocalizedString(uint32_t id)
 {
@@ -22,8 +23,9 @@ std::string CGUIUtils::GetLocalizedString(uint32_t id)
     {
       auto skin = gui->GetSkinInfo();
       if (skin)
-        return g_localizeStrings.GetAddonString(skin->ID(), id);
+        return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+            skin->ID(), id);
     }
   }
-  return g_localizeStrings.Get(id);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(id);
 }

--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -22,11 +22,12 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "rendering/RenderSystem.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -212,7 +213,8 @@ RenderStereoMode CStereoscopicsManager::GetStereoModeByUserChoice() const
   pDlgSelect->Reset();
 
   // "Select stereoscopic 3D mode"
-  pDlgSelect->SetHeading(CVariant{g_localizeStrings.Get(36528)});
+  pDlgSelect->SetHeading(
+      CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36528)});
 
   // prepare selectable stereo modes
   std::vector<RenderStereoMode> selectableModes;
@@ -291,7 +293,7 @@ std::string CStereoscopicsManager::GetLabelForStereoMode(const RenderStereoMode 
       msgId = 36502 + static_cast<int>(mode);
   }
 
-  return g_localizeStrings.Get(msgId);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(msgId);
 }
 
 RenderStereoMode CStereoscopicsManager::GetPreferredPlaybackMode(void) const
@@ -507,7 +509,10 @@ void CStereoscopicsManager::ApplyStereoMode(const RenderStereoMode mode, bool no
     CLog::Log(LOGDEBUG, "StereoscopicsManager: stereo mode changed to {}",
               ConvertGuiStereoModeToString(mode));
     if (notify)
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(36501), GetLabelForStereoMode(mode));
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Info,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36501),
+          GetLabelForStereoMode(mode));
   }
 }
 
@@ -580,27 +585,28 @@ void CStereoscopicsManager::OnStreamChange()
 
       CGUIDialogSelect* pDlgSelect = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
       pDlgSelect->Reset();
-      pDlgSelect->SetHeading(CVariant{g_localizeStrings.Get(36527)});
+      pDlgSelect->SetHeading(
+          CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36527)});
 
       int idx_playing   = -1;
 
       // add choices
-      int idx_preferred = pDlgSelect->Add(g_localizeStrings.Get(36524) // preferred
-                                     + " ("
-                                     + GetLabelForStereoMode(preferred)
-                                     + ")");
+      int idx_preferred = pDlgSelect->Add(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36524) // preferred
+          + " (" + GetLabelForStereoMode(preferred) + ")");
 
       int idx_mono = pDlgSelect->Add(GetLabelForStereoMode(RenderStereoMode::MONO)); // mono / 2d
 
       if (playing != RenderStereoMode::OFF && playing != preferred &&
           preferred != RenderStereoMode::AUTO &&
           CServiceBroker::GetRenderSystem()->SupportsStereo(playing)) // same as movie
-        idx_playing = pDlgSelect->Add(g_localizeStrings.Get(36532)
-                                    + " ("
-                                    + GetLabelForStereoMode(playing)
-                                    + ")");
+        idx_playing = pDlgSelect->Add(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36532) + " (" +
+            GetLabelForStereoMode(playing) + ")");
 
-      int idx_select = pDlgSelect->Add( g_localizeStrings.Get(36531) ); // other / select
+      int idx_select =
+          pDlgSelect->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              36531)); // other / select
 
       pDlgSelect->Open();
 

--- a/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/AddonsGUIInfo.cpp
@@ -13,9 +13,10 @@
 #include "addons/Addon.h"
 #include "addons/AddonManager.h"
 #include "addons/addoninfo/AddonInfo.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 using namespace KODI::GUILIB::GUIINFO;
@@ -77,14 +78,17 @@ bool CAddonsGUIInfo::GetLabel(std::string& value,
           using enum ADDON::AddonLifecycleState;
 
           case BROKEN:
-            value = g_localizeStrings.Get(24171); // "Broken"
+            value =
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24171); // "Broken"
             break;
           case DEPRECATED:
-            value = g_localizeStrings.Get(24170); // "Deprecated"
+            value = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                24170); // "Deprecated"
             break;
           case NORMAL:
           default:
-            value = g_localizeStrings.Get(24169); // "Normal"
+            value =
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24169); // "Normal"
             break;
         }
         return true;
@@ -116,7 +120,7 @@ bool CAddonsGUIInfo::GetLabel(std::string& value,
       {
         if (item->GetAddonInfo()->Origin() == ADDON::ORIGIN_SYSTEM)
         {
-          value = g_localizeStrings.Get(24992);
+          value = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24992);
           return true;
         }
         if (!item->GetAddonInfo()->OriginName().empty())
@@ -129,7 +133,7 @@ bool CAddonsGUIInfo::GetLabel(std::string& value,
           value = item->GetAddonInfo()->Origin();
           return true;
         }
-        value = g_localizeStrings.Get(25014);
+        value = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25014);
         return true;
       }
       case LISTITEM_ADDON_SIZE:

--- a/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GUIControlsGUIInfo.cpp
@@ -19,13 +19,14 @@
 #include "guilib/GUITextBox.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/IGUIContainer.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoHelper.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "music/dialogs/GUIDialogMusicInfo.h"
 #include "music/dialogs/GUIDialogSongInfo.h"
 #include "music/tags/MusicInfoTag.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -127,12 +128,14 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value,
         {
           if (info.GetInfo() == CONTAINER_SORT_METHOD)
           {
-            value = g_localizeStrings.Get(viewState->GetSortMethodLabel());
+            value = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                viewState->GetSortMethodLabel());
             return true;
           }
           else if (info.GetInfo() == CONTAINER_SORT_ORDER)
           {
-            value = g_localizeStrings.Get(viewState->GetSortOrderLabel());
+            value = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                viewState->GetSortOrderLabel());
             return true;
           }
         }
@@ -320,7 +323,7 @@ bool CGUIControlsGUIInfo::GetLabel(std::string& value,
     // SYSTEM_*
     ///////////////////////////////////////////////////////////////////////////////////////////////
     case SYSTEM_CURRENT_WINDOW:
-      value = g_localizeStrings.Get(
+      value = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
           CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindowOrDialog());
       return true;
     case SYSTEM_STARTUP_WINDOW:

--- a/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoHelper.cpp
@@ -15,9 +15,10 @@
 #include "guilib/GUIWindow.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/IGUIContainer.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "playlists/PlayList.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "windows/GUIMediaWindow.h"
@@ -52,19 +53,19 @@ std::string GetPlaylistLabel(int item, PLAYLIST::Id playlistId /* = TYPE_NONE */
     case PLAYLIST_RANDOM:
     {
       if (player.IsShuffled(playlistId))
-        return g_localizeStrings.Get(16041); // 16041: On
+        return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16041); // 16041: On
       else
-        return g_localizeStrings.Get(591); // 591: Off
+        return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(591); // 591: Off
     }
     case PLAYLIST_REPEAT:
     {
       PLAYLIST::RepeatState state = player.GetRepeat(playlistId);
       if (state == PLAYLIST::RepeatState::ONE)
-        return g_localizeStrings.Get(592); // 592: One
+        return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(592); // 592: One
       else if (state == PLAYLIST::RepeatState::ALL)
-        return g_localizeStrings.Get(593); // 593: All
+        return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(593); // 593: All
       else
-        return g_localizeStrings.Get(594); // 594: Off
+        return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(594); // 594: Off
     }
     default:
       break;

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
@@ -16,7 +16,8 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIListItem.h"
 #include "guilib/GUIUtils.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -253,7 +254,8 @@ std::string AddonReplacer(const std::string& str)
   size_t length = str.find(' ');
   const std::string addonid = str.substr(0, length);
   const int stringid{std::stoi(str.substr(length + 1))};
-  return g_localizeStrings.GetAddonString(addonid, stringid);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(addonid,
+                                                                                     stringid);
 }
 
 std::string ControllerFeatureReplacer(const std::string& str)

--- a/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/MusicGUIInfo.cpp
@@ -17,7 +17,6 @@
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoHelper.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
@@ -28,6 +27,8 @@
 #include "music/tags/MusicInfoTag.h"
 #include "network/NetworkFileItemClassify.h"
 #include "playlists/PlayList.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/URIUtils.h"
@@ -225,9 +226,9 @@ bool CMusicGUIInfo::GetLabel(std::string& value,
           if (votes <= 0)
             value = StringUtils::FormatNumber(rating);
           else
-            value =
-                StringUtils::Format(g_localizeStrings.Get(20350), StringUtils::FormatNumber(rating),
-                                    StringUtils::FormatNumber(votes));
+            value = StringUtils::Format(
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20350),
+                StringUtils::FormatNumber(rating), StringUtils::FormatNumber(votes));
           return true;
         }
         break;

--- a/xbmc/guilib/guiinfo/SkinGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SkinGUIInfo.cpp
@@ -11,9 +11,10 @@
 #include "ServiceBroker.h"
 #include "addons/Skin.h"
 #include "guilib/GUIComponent.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/SkinSettings.h"
@@ -43,7 +44,7 @@ bool CSkinGUIInfo::GetLabel(std::string& value,
       bool bInfo = CSkinSettings::GetInstance().GetBool(info.GetData1());
       if (bInfo)
       {
-        value = g_localizeStrings.Get(20122); // True
+        value = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20122); // True
         return true;
       }
       break;

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -20,13 +20,14 @@
 #include "application/ApplicationPowerHandling.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoHelper.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "powermanagement/PowerManager.h"
 #include "profiles/ProfileManager.h"
 #include "rendering/RenderSystem.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/SettingUtils.h"
@@ -71,10 +72,12 @@ std::string CSystemGUIInfo::GetSystemHeatInfo(int info) const
   {
     case SYSTEM_CPU_TEMPERATURE:
       return m_cpuTemp.IsValid() ? g_langInfo.GetTemperatureAsString(m_cpuTemp)
-                                 : g_localizeStrings.Get(10005); // Not available
+                                 : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                       10005); // Not available
     case SYSTEM_GPU_TEMPERATURE:
-      return m_gpuTemp.IsValid() ? g_langInfo.GetTemperatureAsString(m_gpuTemp)
-                                 : g_localizeStrings.Get(10005);
+      return m_gpuTemp.IsValid()
+                 ? g_langInfo.GetTemperatureAsString(m_gpuTemp)
+                 : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10005);
     case SYSTEM_FAN_SPEED:
       text = StringUtils::Format("{}%", m_fanSpeed * 2);
       break;
@@ -86,7 +89,8 @@ std::string CSystemGUIInfo::GetSystemHeatInfo(int info) const
         text = CServiceBroker::GetCPUInfo()->GetCoresUsageString();
 #endif
       else
-        text = g_localizeStrings.Get(10005); // Not available
+        text = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            10005); // Not available
       break;
     default:
       break;
@@ -175,12 +179,14 @@ bool CSystemGUIInfo::GetLabel(std::string& value,
         const RESOLUTION_INFO& resInfo = winSystem->GetGfxContext().GetResInfo();
 
         if (winSystem->IsFullScreen())
-          value = StringUtils::Format("{}x{} @ {:.2f} Hz - {}", resInfo.iScreenWidth,
-                                      resInfo.iScreenHeight, resInfo.fRefreshRate,
-                                      g_localizeStrings.Get(244));
+          value = StringUtils::Format(
+              "{}x{} @ {:.2f} Hz - {}", resInfo.iScreenWidth, resInfo.iScreenHeight,
+              resInfo.fRefreshRate,
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(244));
         else
-          value = StringUtils::Format("{}x{} - {}", resInfo.iScreenWidth, resInfo.iScreenHeight,
-                                      g_localizeStrings.Get(242));
+          value = StringUtils::Format(
+              "{}x{} - {}", resInfo.iScreenWidth, resInfo.iScreenHeight,
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(242));
       }
       else
       {
@@ -255,11 +261,13 @@ bool CSystemGUIInfo::GetLabel(std::string& value,
       {
         double fTime = g_alarmClock.GetRemaining("shutdowntimer");
         if (fTime > 60.0)
-          value = StringUtils::Format(g_localizeStrings.Get(13213),
-                                      g_alarmClock.GetRemaining("shutdowntimer") / 60.0);
+          value = StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13213),
+              g_alarmClock.GetRemaining("shutdowntimer") / 60.0);
         else
-          value = StringUtils::Format(g_localizeStrings.Get(13214),
-                                      g_alarmClock.GetRemaining("shutdowntimer"));
+          value = StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13214),
+              g_alarmClock.GetRemaining("shutdowntimer"));
       }
       return true;
     case SYSTEM_PROFILENAME:
@@ -279,7 +287,8 @@ bool CSystemGUIInfo::GetLabel(std::string& value,
           CServiceBroker::GetSettingsComponent()->GetProfileManager();
       int iProfileId = profileManager->GetAutoLoginProfileId();
       if ((iProfileId < MASTER_PROFILE_ID) || !profileManager->GetProfileName(iProfileId, value))
-        value = g_localizeStrings.Get(37014); // Last used profile
+        value = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            37014); // Last used profile
       return true;
     }
     case SYSTEM_PROFILETHUMB:

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -20,7 +20,6 @@
 #include "cores/VideoPlayer/VideoRenderers/BaseRenderer.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
 #include "guilib/WindowIDs.h"
 #include "guilib/guiinfo/GUIInfo.h"
@@ -29,6 +28,8 @@
 #include "guilib/guiinfo/GUIInfoUtils.h"
 #include "network/NetworkFileItemClassify.h"
 #include "playlists/PlayList.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingUtils.h"
 #include "settings/Settings.h"
@@ -210,9 +211,9 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
           if (rating.rating > 0.f && rating.votes == 0)
             value = StringUtils::FormatNumber(rating.rating);
           else if (rating.votes > 0)
-            value = StringUtils::Format(g_localizeStrings.Get(20350),
-                                        StringUtils::FormatNumber(rating.rating),
-                                        StringUtils::FormatNumber(rating.votes));
+            value = StringUtils::Format(
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20350),
+                StringUtils::FormatNumber(rating.rating), StringUtils::FormatNumber(rating.votes));
           else
             break;
           return true;
@@ -411,7 +412,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
               !CSettingUtils::FindIntInList(
                   setting, CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES))))
         {
-          value = g_localizeStrings.Get(20370);
+          value = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20370);
         }
         else
         {

--- a/xbmc/guilib/handlers/player/GUIPlayerAnnouncementHandler.cpp
+++ b/xbmc/guilib/handlers/player/GUIPlayerAnnouncementHandler.cpp
@@ -13,8 +13,9 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 
@@ -39,18 +40,22 @@ void CGUIPlayerAnnouncementHandler::Announce(ANNOUNCEMENT::AnnouncementFlag flag
         CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
     if (advancedSettings && advancedSettings->m_EdlDisplayCommbreakNotifications)
     {
-      CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011), data.asString());
+      CGUIDialogKaiToast::QueueNotification(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25011), data.asString());
     }
   }
   else if (message == "SourceSlow")
   {
-    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(21454),
-                                          g_localizeStrings.Get(21455));
+    CGUIDialogKaiToast::QueueNotification(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21454),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21455));
   }
   else if (message == "OnToggleSkipCommercials")
   {
-    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25011),
-                                          g_localizeStrings.Get(data.asBoolean() ? 25013 : 25012));
+    CGUIDialogKaiToast::QueueNotification(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25011),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(data.asBoolean() ? 25013
+                                                                                          : 25012));
   }
   else if (message == "OnProcessInfo")
   {
@@ -63,19 +68,22 @@ void CGUIPlayerAnnouncementHandler::Announce(ANNOUNCEMENT::AnnouncementFlag flag
   }
   else if (message == "OnPlaybackFailed")
   {
-    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(16026),
-                                          g_localizeStrings.Get(16029));
+    CGUIDialogKaiToast::QueueNotification(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16026),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16029));
   }
 #if defined(HAVE_LIBBLURAY)
   else if (message == "OnBlurayMenuError")
   {
-    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(25008),
-                                          g_localizeStrings.Get(25009));
+    CGUIDialogKaiToast::QueueNotification(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25008),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25009));
   }
   else if (message == "OnBlurayEncryptedError")
   {
-    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(16026),
-                                          g_localizeStrings.Get(29805));
+    CGUIDialogKaiToast::QueueNotification(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16026),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(29805));
   }
 #endif
   else if (message == "OnMenu")

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -16,7 +16,6 @@
 #include "addons/RepositoryUpdater.h"
 #include "favourites/FavouritesService.h"
 #include "filesystem/Directory.h"
-#include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
 #include "interfaces/IAnnouncer.h"
 #include "jobs/JobManager.h"
@@ -25,6 +24,8 @@
 #include "pictures/PictureThumbLoader.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRThumbLoader.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/ExecString.h"
@@ -285,7 +286,8 @@ public:
         if (!m_target.empty())
         {
           CFileItem item(m_url, true);
-          item.SetLabel(g_localizeStrings.Get(22082)); // More...
+          item.SetLabel(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(22082)); // More...
           item.SetArt("icon", "DefaultFolder.png");
           item.SetProperty("node.target", m_target);
           item.SetProperty("node.type", "target_folder"); // make item identifiable, e.g. by skins

--- a/xbmc/guilib/test/TestGUIControlFactory.cpp
+++ b/xbmc/guilib/test/TestGUIControlFactory.cpp
@@ -15,8 +15,9 @@
 #include "guilib/GUIFont.h"
 #include "guilib/GUILabelControl.h"
 #include "guilib/GUITexture.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfoLabel.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/SystemInfo.h"
 #include "utils/XBMCTinyXML.h"
 
@@ -799,7 +800,8 @@ INSTANTIATE_TEST_SUITE_P(TestGUIControlFactory, TestGetHitRect, testing::ValuesI
 TEST_P(TestGetInfoLabel, GetInfoLabel)
 {
   CGUITestComponent comp;
-  ASSERT_TRUE(g_localizeStrings.Load(g_langInfo.GetLanguagePath(), "resource.language.en_gb"));
+  ASSERT_TRUE(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Load(
+      g_langInfo.GetLanguagePath(), "resource.language.en_gb"));
   CXBMCTinyXML doc;
   doc.Parse(GetParam().def);
   KODI::GUILIB::GUIINFO::CGUIInfoLabel infoLabel;
@@ -816,7 +818,8 @@ INSTANTIATE_TEST_SUITE_P(TestGUIControlFactory,
 TEST_P(TestGetInfoLabels, GetInfoLabels)
 {
   CGUITestComponent comp;
-  ASSERT_TRUE(g_localizeStrings.Load(g_langInfo.GetLanguagePath(), "resource.language.en_gb"));
+  ASSERT_TRUE(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Load(
+      g_langInfo.GetLanguagePath(), "resource.language.en_gb"));
   CXBMCTinyXML doc;
   doc.Parse(GetParam().def);
   std::vector<KODI::GUILIB::GUIINFO::CGUIInfoLabel> infoLabel;
@@ -897,7 +900,8 @@ INSTANTIATE_TEST_SUITE_P(TestGUIControlFactory, TestGetScroller, testing::Values
 
 TEST_P(TestGetString, GetString)
 {
-  ASSERT_TRUE(g_localizeStrings.Load(g_langInfo.GetLanguagePath(), "resource.language.en_gb"));
+  ASSERT_TRUE(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Load(
+      g_langInfo.GetLanguagePath(), "resource.language.en_gb"));
   CXBMCTinyXML doc;
   doc.Parse(GetParam().def);
   std::string value;

--- a/xbmc/input/joysticks/JoystickTranslator.cpp
+++ b/xbmc/input/joysticks/JoystickTranslator.cpp
@@ -8,8 +8,10 @@
 
 #include "JoystickTranslator.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "input/joysticks/DriverPrimitive.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 using namespace KODI;
@@ -162,10 +164,12 @@ std::string CJoystickTranslator::GetPrimitiveName(const CDriverPrimitive& primit
   switch (primitive.Type())
   {
     case PRIMITIVE_TYPE::BUTTON:
-      primitiveTemplate = g_localizeStrings.Get(35015); // "Button %d"
+      primitiveTemplate =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35015); // "Button %d"
       break;
     case PRIMITIVE_TYPE::SEMIAXIS:
-      primitiveTemplate = g_localizeStrings.Get(35016); // "Axis %d"
+      primitiveTemplate =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35016); // "Axis %d"
       break;
     default:
       break;

--- a/xbmc/input/keyboard/KeyboardLayout.cpp
+++ b/xbmc/input/keyboard/KeyboardLayout.cpp
@@ -8,8 +8,10 @@
 
 #include "KeyboardLayout.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "input/InputCodingTableFactory.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -127,7 +129,8 @@ std::string CKeyboardLayout::GetIdentifier() const
 
 std::string CKeyboardLayout::GetName() const
 {
-  return StringUtils::Format(g_localizeStrings.Get(311), m_language, m_layout);
+  return StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(311),
+                             m_language, m_layout);
 }
 
 std::string CKeyboardLayout::GetCharAt(unsigned int row,

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -17,13 +17,14 @@
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
 #include "input/WindowTranslator.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "input/actions/ActionTranslator.h"
 #include "messaging/ApplicationMessenger.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/AlarmClock.h"
@@ -188,9 +189,9 @@ static int AlarmClock(const std::vector<std::string>& params)
   { // check if shutdown is specified in particular, and get the time for it
     std::string strHeading;
     if (StringUtils::EqualsNoCase(params[0], "shutdowntimer"))
-      strHeading = g_localizeStrings.Get(20145);
+      strHeading = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20145);
     else
-      strHeading = g_localizeStrings.Get(13209);
+      strHeading = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13209);
     std::string strTime;
     if( CGUIDialogNumeric::ShowAndGetNumber(strTime, strHeading) )
       seconds = static_cast<float>(atoi(strTime.c_str())*60);

--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -15,12 +15,13 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "music/MusicDbUrl.h"
 #include "music/MusicLibraryQueue.h"
 #include "music/infoscanner/MusicInfoScanner.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/LibExportSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -207,8 +208,9 @@ static int ExportLibrary(const std::vector<std::string>& params)
   if (params.size() > 2)
     path=params[2];
   if (!singleFile || !path.empty() ||
-      CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(661),
-                                                 path, true))
+      CGUIDialogFileBrowser::ShowAndGetDirectory(
+          shares, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(661), path,
+          true))
   {
     if (StringUtils::EqualsNoCase(params[0], "video"))
     {

--- a/xbmc/interfaces/builtins/ProfileBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ProfileBuiltins.cpp
@@ -16,9 +16,10 @@
 #include "favourites/FavouritesService.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 
@@ -68,7 +69,10 @@ static int MasterMode(const std::vector<std::string>& params)
     // master mode turned OFF => refresh favourites due to possible visibility changes
     CServiceBroker::GetFavouritesService().RefreshFavourites();
 
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(20052),g_localizeStrings.Get(20053));
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Warning,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20052),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20053));
   }
   else if (g_passwordManager.IsMasterLockUnlocked(true)) // prompt user for code
   {
@@ -78,7 +82,10 @@ static int MasterMode(const std::vector<std::string>& params)
     // master mode turned ON => refresh favourites due to possible visibility changes
     CServiceBroker::GetFavouritesService().RefreshFavourites();
 
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(20052),g_localizeStrings.Get(20054));
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Warning,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20052),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20054));
   }
 
   CUtil::DeleteVideoDatabaseDirectoryCache();

--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -25,7 +25,8 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIUtils.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/SkinSettings.h"
@@ -177,7 +178,8 @@ static int SetNumeric(const std::vector<std::string>& params)
 {
   int string = CSkinSettings::GetInstance().TranslateString(params[0]);
   std::string value = CSkinSettings::GetInstance().GetString(string);
-  if (CGUIDialogNumeric::ShowAndGetNumber(value, g_localizeStrings.Get(611)))
+  if (CGUIDialogNumeric::ShowAndGetNumber(
+          value, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(611)))
     CSkinSettings::GetInstance().SetString(string, value);
 
   return 0;
@@ -195,6 +197,9 @@ static int SetPath(const std::vector<std::string>& params)
   std::vector<CMediaSource> localShares;
   CServiceBroker::GetMediaManager().GetLocalDrives(localShares);
   CServiceBroker::GetMediaManager().GetNetworkLocations(localShares);
+
+  const auto& localizeStrings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
+
   if (params.size() > 1)
   {
     value = params[1];
@@ -203,13 +208,13 @@ static int SetPath(const std::vector<std::string>& params)
     if (CUtil::GetMatchingSource(value,localShares,bIsSource) < 0) // path is outside shares - add it as a separate one
     {
       CMediaSource share;
-      share.strName = g_localizeStrings.Get(13278);
+      share.strName = localizeStrings.Get(13278);
       share.strPath = value;
       localShares.push_back(share);
     }
   }
 
-  if (CGUIDialogFileBrowser::ShowAndGetDirectory(localShares, g_localizeStrings.Get(657), value))
+  if (CGUIDialogFileBrowser::ShowAndGetDirectory(localShares, localizeStrings.Get(657), value))
     CSkinSettings::GetInstance().SetString(string, value);
 
   CServiceBroker::GetSettingsComponent()->GetSettings()->Save();
@@ -230,6 +235,8 @@ static int SetFile(const std::vector<std::string>& params)
   std::string value = CSkinSettings::GetInstance().GetString(string);
   std::vector<CMediaSource> localShares;
   CServiceBroker::GetMediaManager().GetLocalDrives(localShares);
+
+  const auto& localizeStrings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
 
   // Note. can only browse one addon type from here
   // if browsing for addons, required param[1] is addontype string, with optional param[2]
@@ -269,12 +276,13 @@ static int SetFile(const std::vector<std::string>& params)
       if (CUtil::GetMatchingSource(value,localShares,bIsSource) < 0) // path is outside shares - add it as a separate one
       {
         CMediaSource share;
-        share.strName = g_localizeStrings.Get(13278);
+        share.strName = localizeStrings.Get(13278);
         share.strPath = value;
         localShares.push_back(share);
       }
     }
-    if (CGUIDialogFileBrowser::ShowAndGetFile(localShares, strMask, g_localizeStrings.Get(1033), value))
+    if (CGUIDialogFileBrowser::ShowAndGetFile(localShares, strMask, localizeStrings.Get(1033),
+                                              value))
       CSkinSettings::GetInstance().SetString(string, value);
   }
 
@@ -292,6 +300,9 @@ static int SetImage(const std::vector<std::string>& params)
   std::string value = CSkinSettings::GetInstance().GetString(string);
   std::vector<CMediaSource> localShares;
   CServiceBroker::GetMediaManager().GetLocalDrives(localShares);
+
+  const auto& localizeStrings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
+
   if (params.size() > 1)
   {
     value = params[1];
@@ -300,12 +311,12 @@ static int SetImage(const std::vector<std::string>& params)
     if (CUtil::GetMatchingSource(value,localShares,bIsSource) < 0) // path is outside shares - add it as a separate one
     {
       CMediaSource share;
-      share.strName = g_localizeStrings.Get(13278);
+      share.strName = localizeStrings.Get(13278);
       share.strPath = value;
       localShares.push_back(share);
     }
   }
-  if (CGUIDialogFileBrowser::ShowAndGetImage(localShares, g_localizeStrings.Get(1030), value))
+  if (CGUIDialogFileBrowser::ShowAndGetImage(localShares, localizeStrings.Get(1030), value))
     CSkinSettings::GetInstance().SetString(string, value);
 
   return 0;
@@ -377,7 +388,9 @@ static int SetString(const std::vector<std::string>& params)
     string = CSkinSettings::GetInstance().TranslateString(params[0]);
 
   std::string value = CSkinSettings::GetInstance().GetString(string);
-  if (CGUIKeyboardFactory::ShowAndGetInput(value, CVariant{g_localizeStrings.Get(1029)}, true))
+  if (CGUIKeyboardFactory::ShowAndGetInput(
+          value, CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1029)},
+          true))
     CSkinSettings::GetInstance().SetString(string, value);
 
   return 0;

--- a/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
+++ b/xbmc/interfaces/json-rpc/ProfilesOperations.cpp
@@ -12,7 +12,6 @@
 #include "FileItemList.h"
 #include "GUIPassword.h"
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
 #include "profiles/ProfileManager.h"
 #include "settings/SettingsComponent.h"

--- a/xbmc/interfaces/json-rpc/SettingsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/SettingsOperations.cpp
@@ -12,7 +12,8 @@
 #include "addons/Addon.h"
 #include "addons/Skin.h"
 #include "addons/addoninfo/AddonInfo.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/SettingAddon.h"
 #include "settings/SettingControl.h"
 #include "settings/SettingDateTime.h"
@@ -361,9 +362,11 @@ bool CSettingsOperations::SerializeSettingSection(
   if (!SerializeISetting(setting, obj))
     return false;
 
-  obj["label"] = g_localizeStrings.Get(setting->GetLabel());
+  obj["label"] =
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(setting->GetLabel());
   if (setting->GetHelp() >= 0)
-    obj["help"] = g_localizeStrings.Get(setting->GetHelp());
+    obj["help"] =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(setting->GetHelp());
 
   return true;
 }
@@ -374,9 +377,11 @@ bool CSettingsOperations::SerializeSettingCategory(
   if (!SerializeISetting(setting, obj))
     return false;
 
-  obj["label"] = g_localizeStrings.Get(setting->GetLabel());
+  obj["label"] =
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(setting->GetLabel());
   if (setting->GetHelp() >= 0)
-    obj["help"] = g_localizeStrings.Get(setting->GetHelp());
+    obj["help"] =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(setting->GetHelp());
 
   return true;
 }
@@ -393,9 +398,11 @@ bool CSettingsOperations::SerializeSetting(const std::shared_ptr<const CSetting>
   if (!SerializeISetting(setting, obj))
     return false;
 
-  obj["label"] = g_localizeStrings.Get(setting->GetLabel());
+  obj["label"] =
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(setting->GetLabel());
   if (setting->GetHelp() >= 0)
-    obj["help"] = g_localizeStrings.Get(setting->GetHelp());
+    obj["help"] =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(setting->GetHelp());
 
   switch (setting->GetLevel())
   {
@@ -500,7 +507,8 @@ bool CSettingsOperations::SerializeSettingInt(const std::shared_ptr<const CSetti
       for (const auto& itOption : options)
       {
         CVariant varOption(CVariant::VariantTypeObject);
-        varOption["label"] = g_localizeStrings.Get(itOption.label);
+        varOption["label"] =
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(itOption.label);
         varOption["value"] = itOption.value;
         obj["options"].push_back(varOption);
       }
@@ -586,7 +594,8 @@ bool CSettingsOperations::SerializeSettingString(
       for (const auto& itOption : options)
       {
         CVariant varOption(CVariant::VariantTypeObject);
-        varOption["label"] = g_localizeStrings.Get(itOption.first);
+        varOption["label"] =
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(itOption.first);
         varOption["value"] = itOption.second;
         obj["options"].push_back(varOption);
       }
@@ -746,11 +755,13 @@ bool CSettingsOperations::SerializeSettingControl(
   {
     std::shared_ptr<const CSettingControlSpinner> spinner = std::static_pointer_cast<const CSettingControlSpinner>(control);
     if (spinner->GetFormatLabel() >= 0)
-      obj["formatlabel"] = g_localizeStrings.Get(spinner->GetFormatLabel());
+      obj["formatlabel"] = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          spinner->GetFormatLabel());
     else if (!spinner->GetFormatString().empty() && spinner->GetFormatString() != "{:d}")
       obj["formatlabel"] = spinner->GetFormatString();
     if (spinner->GetMinimumLabel() >= 0)
-      obj["minimumlabel"] = g_localizeStrings.Get(spinner->GetMinimumLabel());
+      obj["minimumlabel"] = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          spinner->GetMinimumLabel());
   }
   else if (type == "edit")
   {
@@ -758,29 +769,34 @@ bool CSettingsOperations::SerializeSettingControl(
     obj["hidden"] = edit->IsHidden();
     obj["verifynewvalue"] = edit->VerifyNewValue();
     if (edit->GetHeading() >= 0)
-      obj["heading"] = g_localizeStrings.Get(edit->GetHeading());
+      obj["heading"] =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(edit->GetHeading());
   }
   else if (type == "button")
   {
     std::shared_ptr<const CSettingControlButton> button = std::static_pointer_cast<const CSettingControlButton>(control);
     if (button->GetHeading() >= 0)
-      obj["heading"] = g_localizeStrings.Get(button->GetHeading());
+      obj["heading"] =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(button->GetHeading());
   }
   else if (type == "list")
   {
     std::shared_ptr<const CSettingControlList> list = std::static_pointer_cast<const CSettingControlList>(control);
     if (list->GetHeading() >= 0)
-      obj["heading"] = g_localizeStrings.Get(list->GetHeading());
+      obj["heading"] =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(list->GetHeading());
     obj["multiselect"] = list->CanMultiSelect();
   }
   else if (type == "slider")
   {
     std::shared_ptr<const CSettingControlSlider> slider = std::static_pointer_cast<const CSettingControlSlider>(control);
     if (slider->GetHeading() >= 0)
-      obj["heading"] = g_localizeStrings.Get(slider->GetHeading());
+      obj["heading"] =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(slider->GetHeading());
     obj["popup"] = slider->UsePopup();
     if (slider->GetFormatLabel() >= 0)
-      obj["formatlabel"] = g_localizeStrings.Get(slider->GetFormatLabel());
+      obj["formatlabel"] = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          slider->GetFormatLabel());
     else
       obj["formatlabel"] = slider->GetFormatString();
   }
@@ -788,11 +804,13 @@ bool CSettingsOperations::SerializeSettingControl(
   {
     std::shared_ptr<const CSettingControlRange> range = std::static_pointer_cast<const CSettingControlRange>(control);
     if (range->GetFormatLabel() >= 0)
-      obj["formatlabel"] = g_localizeStrings.Get(range->GetFormatLabel());
+      obj["formatlabel"] =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(range->GetFormatLabel());
     else
       obj["formatlabel"] = "";
     if (range->GetValueFormatLabel() >= 0)
-      obj["formatvalue"] = g_localizeStrings.Get(range->GetValueFormatLabel());
+      obj["formatvalue"] = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          range->GetValueFormatLabel());
     else
       obj["formatvalue"] = range->GetValueFormat();
   }

--- a/xbmc/interfaces/legacy/Addon.cpp
+++ b/xbmc/interfaces/legacy/Addon.cpp
@@ -17,7 +17,8 @@
 #include "addons/settings/AddonSettings.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 using namespace ADDON;
@@ -78,7 +79,8 @@ namespace XBMCAddon
 
     String Addon::getLocalizedString(int id)
     {
-      return g_localizeStrings.GetAddonString(pAddon->ID(), id);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+          pAddon->ID(), id);
     }
 
     Settings* Addon::getSettings()

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -23,13 +23,14 @@
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "guilib/GUIAudioManager.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/TextureManager.h"
 #include "input/WindowTranslator.h"
 #include "messaging/ApplicationMessenger.h"
 #include "network/Network.h"
 #include "network/NetworkServices.h"
 #include "playlists/PlayListTypes.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
@@ -163,7 +164,7 @@ namespace XBMCAddon
     String getLocalizedString(int id)
     {
       XBMC_TRACE;
-      return g_localizeStrings.Get(id);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(id);
     }
 
     String getSkinDir()

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -22,11 +22,12 @@
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "interfaces/python/PyContext.h"
 #include "interfaces/python/pythreadstate.h"
 #include "interfaces/python/swig.h"
 #include "messaging/ApplicationMessenger.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "threads/SingleLock.h"
 #include "threads/SystemClock.h"
 #include "utils/CharsetConverter.h"
@@ -698,10 +699,13 @@ void CPythonInvoker::onError(const std::string& exceptionType /* = "" */,
   {
     std::string message;
     if (m_addon && !m_addon->Name().empty())
-      message = StringUtils::Format(g_localizeStrings.Get(2102), m_addon->Name());
+      message = StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(2102), m_addon->Name());
     else
-      message = g_localizeStrings.Get(2103);
-    pDlgToast->QueueNotification(CGUIDialogKaiToast::Error, message, g_localizeStrings.Get(2104));
+      message = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(2103);
+    pDlgToast->QueueNotification(
+        CGUIDialogKaiToast::Error, message,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(2104));
   }
 }
 

--- a/xbmc/media/MediaType.cpp
+++ b/xbmc/media/MediaType.cpp
@@ -8,7 +8,9 @@
 
 #include "MediaType.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 #include <utility>
@@ -103,7 +105,8 @@ std::string CMediaTypes::GetLocalization(const MediaType &mediaType)
     mediaTypeIt->second.localizationSingular <= 0)
     return "";
 
-  return g_localizeStrings.Get(mediaTypeIt->second.localizationSingular);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      mediaTypeIt->second.localizationSingular);
 }
 
 std::string CMediaTypes::GetPluralLocalization(const MediaType &mediaType)
@@ -113,7 +116,8 @@ std::string CMediaTypes::GetPluralLocalization(const MediaType &mediaType)
     mediaTypeIt->second.localizationPlural <= 0)
     return "";
 
-  return g_localizeStrings.Get(mediaTypeIt->second.localizationPlural);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      mediaTypeIt->second.localizationPlural);
 }
 
 std::string CMediaTypes::GetCapitalLocalization(const MediaType &mediaType)
@@ -123,7 +127,8 @@ std::string CMediaTypes::GetCapitalLocalization(const MediaType &mediaType)
     mediaTypeIt->second.localizationSingular <= 0)
     return "";
 
-  return g_localizeStrings.Get(mediaTypeIt->second.localizationSingularCapital);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      mediaTypeIt->second.localizationSingularCapital);
 }
 
 std::string CMediaTypes::GetCapitalPluralLocalization(const MediaType &mediaType)
@@ -133,5 +138,6 @@ std::string CMediaTypes::GetCapitalPluralLocalization(const MediaType &mediaType
     mediaTypeIt->second.localizationPlural <= 0)
     return "";
 
-  return g_localizeStrings.Get(mediaTypeIt->second.localizationPluralCapital);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      mediaTypeIt->second.localizationPluralCapital);
 }

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -16,7 +16,6 @@
 #include "filesystem/MusicDatabaseDirectory/DirectoryNode.h"
 #include "filesystem/VideoDatabaseDirectory.h"
 #include "filesystem/VideoDatabaseDirectory/QueryParams.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "playlists/PlayListFileItemClassify.h"
 #include "playlists/PlayListTypes.h"

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -36,7 +36,6 @@
 #include "filesystem/MusicDatabaseDirectory/DirectoryNode.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "imagefiles/ImageFileURL.h"
 #include "interfaces/AnnouncementManager.h"
@@ -46,6 +45,8 @@
 #include "music/MusicLibraryQueue.h"
 #include "music/tags/MusicInfoTag.h"
 #include "network/Network.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #ifdef HAS_OPTICAL_DRIVE
 #include "network/cddb.h"
 #endif // HAS_OPTICAL_DRIVE
@@ -769,7 +770,9 @@ bool CMusicDatabase::AddAlbum(CAlbum& album, int idSource)
         // no title or just numbers  (1, 02, 003 etc) - generate a better one
         if (StringUtils::IsNaturalNumber(chapter.name) || chapter.name.empty())
           song->strTitle = StringUtils::Format(
-              "{} {:03}", g_localizeStrings.Get(21396) /* Chapter */, index + 1);
+              "{} {:03}",
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21396) /* Chapter */,
+              index + 1);
         else
           song->strTitle = chapter.name;
 
@@ -932,7 +935,9 @@ bool CMusicDatabase::UpdateAlbum(CAlbum& album)
           std::string currentTitle = GetSingleValue(strSQL);
           if (currentTitle.empty())
           {
-            currentTitle = StringUtils::Format("{} {}", g_localizeStrings.Get(427), discValue);
+            currentTitle = StringUtils::Format(
+                "{} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(427),
+                discValue);
             strSQL =
                 PrepareSQL("UPDATE song SET strDiscSubtitle = '%s' WHERE song.idAlbum = %i AND "
                            "song.iTrack >> 16 = %i",
@@ -1106,7 +1111,8 @@ int CMusicDatabase::AddSong(const int idSong,
       if (isBoxset && strDiscSubtitle.empty())
       {
         int discno = iTrack >> 16;
-        strDiscSubtitle = StringUtils::Format("{} {}", g_localizeStrings.Get(427), discno);
+        strDiscSubtitle = StringUtils::Format(
+            "{} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(427), discno);
       }
 
       // Validate ISO8601 dates and ensure none missing
@@ -1726,7 +1732,7 @@ int CMusicDatabase::AddGenre(std::string& strGenre)
     StringUtils::Trim(strGenre);
 
     if (strGenre.empty())
-      strGenre = g_localizeStrings.Get(13205); // Unknown
+      strGenre = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
 
     if (nullptr == m_pDB)
       return -1;
@@ -3283,7 +3289,7 @@ CAlbum CMusicDatabase::GetAlbumFromDataset(const dbiplus::sql_record* const reco
   album.idAlbum = record->at(offset + album_idAlbum).get_asInt();
   album.strAlbum = record->at(offset + album_strAlbum).get_asString();
   if (album.strAlbum.empty())
-    album.strAlbum = g_localizeStrings.Get(1050);
+    album.strAlbum = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1050);
   album.strMusicBrainzAlbumID = record->at(offset + album_strMusicBrainzAlbumID).get_asString();
   album.strReleaseGroupMBID = record->at(offset + album_strReleaseGroupMBID).get_asString();
   album.strArtistDesc = record->at(offset + album_strArtists).get_asString();
@@ -3365,7 +3371,8 @@ CArtist CMusicDatabase::GetArtistFromDataset(const dbiplus::sql_record* const re
   CArtist artist;
   artist.idArtist = record->at(offset + artist_idArtist).get_asInt();
   if (artist.idArtist == BLANKARTIST_ID && m_translateBlankArtist)
-    artist.strArtist = g_localizeStrings.Get(38042); //Missing artist tag in current language
+    artist.strArtist = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        38042); //Missing artist tag in current language
   else
     artist.strArtist = record->at(offset + artist_strArtist).get_asString();
   artist.strSortName = record->at(offset + artist_strSortName).get_asString();
@@ -3513,7 +3520,8 @@ bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList& art
     if (nullptr == m_pDS)
       return false;
 
-    std::string strVariousArtists = g_localizeStrings.Get(340).c_str();
+    std::string strVariousArtists =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(340).c_str();
     std::string strSQL;
     if (search.size() >= MIN_FULL_SEARCH_LENGTH)
       strSQL = PrepareSQL("SELECT * FROM artist "
@@ -3533,7 +3541,8 @@ bool CMusicDatabase::SearchArtists(const std::string& search, CFileItemList& art
       return false;
     }
 
-    const std::string& artistLabel(g_localizeStrings.Get(557)); // Artist
+    const std::string& artistLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(557)); // Artist
     while (!m_pDS->eof())
     {
       std::string path = StringUtils::Format("musicdb://artists/{}/", m_pDS->fv(0).get_asInt());
@@ -4217,7 +4226,8 @@ bool CMusicDatabase::SearchAlbums(const std::string& search, CFileItemList& albu
     if (!m_pDS->query(strSQL))
       return false;
 
-    const std::string& albumLabel(g_localizeStrings.Get(558)); // Album
+    const std::string& albumLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(558)); // Album
     while (!m_pDS->eof())
     {
       CAlbum album = GetAlbumFromDataset(m_pDS.get());
@@ -4910,7 +4920,8 @@ void CMusicDatabase::DeleteCDDBInfo() const
       WINDOW_DIALOG_SELECT);
   if (pDlg)
   {
-    pDlg->SetHeading(CVariant{g_localizeStrings.Get(181)});
+    pDlg->SetHeading(
+        CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(181)});
     pDlg->Reset();
 
     std::map<uint32_t, std::string> mapCDDBIds;
@@ -6110,7 +6121,9 @@ bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
         std::string strDiscSubtitle = record->at(1).get_asString();
         if (strDiscSubtitle.empty())
         { // Make (fake) disc title from disc number, group by disc number as no real title to match
-          strDiscSubtitle = StringUtils::Format("{} {}", g_localizeStrings.Get(427), discnum);
+          strDiscSubtitle = StringUtils::Format(
+              "{} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(427),
+              discnum);
           useTitle = false;
         }
         else if (oldDiscTitle == strDiscSubtitle)
@@ -11202,7 +11215,9 @@ std::string CMusicDatabase::GetAlbumDiscTitle(int idAlbum, int idDisc) const
     disctitle = GetSingleValue("song", "strDiscSubtitle",
                                PrepareSQL("idAlbum = %i AND iTrack >> 16 = %i", idAlbum, idDisc));
     if (disctitle.empty())
-      disctitle = StringUtils::Format("{} {}", g_localizeStrings.Get(427), idDisc); // "Disc 1" etc.
+      disctitle = StringUtils::Format(
+          "{} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(427),
+          idDisc); // "Disc 1" etc.
     if (albumtitle.empty())
       albumtitle = disctitle;
     else
@@ -12066,9 +12081,10 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                 if (!xmlDoc.SaveFile(nfoFile))
                 {
                   CLog::LogF(LOGERROR, "Album nfo export failed! ('{}')", nfoFile);
-                  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
-                                                        g_localizeStrings.Get(20302),
-                                                        CURL::GetRedacted(nfoFile));
+                  CGUIDialogKaiToast::QueueNotification(
+                      CGUIDialogKaiToast::Error,
+                      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20302),
+                      CURL::GetRedacted(nfoFile));
                   iFailCount++;
                 }
               }
@@ -12209,9 +12225,10 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
                   if (!xmlDoc.SaveFile(nfoFile))
                   {
                     CLog::LogF(LOGERROR, "Artist nfo export failed! ('{}')", nfoFile);
-                    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
-                                                          g_localizeStrings.Get(20302),
-                                                          CURL::GetRedacted(nfoFile));
+                    CGUIDialogKaiToast::QueueNotification(
+                        CGUIDialogKaiToast::Error,
+                        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20302),
+                        CURL::GetRedacted(nfoFile));
                     iFailCount++;
                   }
                 }
@@ -12276,7 +12293,9 @@ void CMusicDatabase::ExportToXML(const CLibExportSettings& settings,
 
   if (iFailCount > 0 && progressDialog)
     HELPERS::ShowOKDialogLines(
-        CVariant{20196}, CVariant{StringUtils::Format(g_localizeStrings.Get(15011), iFailCount)});
+        CVariant{20196},
+        CVariant{StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15011), iFailCount)});
 }
 
 bool CMusicDatabase::ExportSongHistory(TiXmlNode* pNode, CGUIDialogProgress* progressDialog)
@@ -12782,7 +12801,8 @@ bool CMusicDatabase::ImportSongHistory(const std::string& xmlFile,
     // Write event log entry
     // "Importing song history {1} of {2} songs matched", total - unmatched, total)
     std::string strLine =
-        StringUtils::Format(g_localizeStrings.Get(38353), total - unmatched, total);
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38353),
+                            total - unmatched, total);
 
     auto eventLog = CServiceBroker::GetEventLog();
     if (eventLog)

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -26,7 +26,6 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "jobs/JobManager.h"
 #include "media/MediaType.h"
 #include "music/MusicDatabase.h"
@@ -38,6 +37,8 @@
 #include "playlists/PlayListFactory.h"
 #include "playlists/PlayListFileItemClassify.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/IRunnable.h"
@@ -298,13 +299,13 @@ bool FillArtTypesList(CFileItem& musicitem, CFileItemList& artlist)
     CFileItemPtr artitem(new CFileItem(type, false));
     // Localise the names of common types of art
     if (type == "banner")
-      artitem->SetLabel(g_localizeStrings.Get(20020));
+      artitem->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20020));
     else if (type == "fanart")
-      artitem->SetLabel(g_localizeStrings.Get(20445));
+      artitem->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20445));
     else if (type == "poster")
-      artitem->SetLabel(g_localizeStrings.Get(20021));
+      artitem->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20021));
     else if (type == "thumb")
-      artitem->SetLabel(g_localizeStrings.Get(21371));
+      artitem->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21371));
     else
       artitem->SetLabel(type);
     // Set art type as art item property
@@ -339,8 +340,10 @@ std::string ShowSelectArtTypeDialog(CFileItemList& artitems)
   {
     // Get the new art type name
     std::string strArtTypeName;
-    if (!CGUIKeyboardFactory::ShowAndGetInput(strArtTypeName,
-                                              CVariant{g_localizeStrings.Get(13516)}, false))
+    if (!CGUIKeyboardFactory::ShowAndGetInput(
+            strArtTypeName,
+            CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13516)},
+            false))
       return "";
     // Add new type to the list of art types
     CFileItemPtr artitem(new CFileItem(strArtTypeName, false));
@@ -362,9 +365,10 @@ int ShowSelectRatingDialog(int iSelected)
   if (dialog)
   {
     dialog->SetHeading(CVariant{38023});
-    dialog->Add(g_localizeStrings.Get(38022));
+    dialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38022));
     for (int i = 1; i <= 10; i++)
-      dialog->Add(StringUtils::Format("{}: {}", g_localizeStrings.Get(563), i));
+      dialog->Add(StringUtils::Format(
+          "{}: {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(563), i));
     dialog->SetSelected(iSelected);
     dialog->Open();
 
@@ -647,8 +651,9 @@ void ShowToastNotification(const CFileItem& item, int titleId)
   const std::string message =
       localizedMediaType.empty() ? title : localizedMediaType + ": " + title;
 
-  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(titleId),
-                                        message);
+  CGUIDialogKaiToast::QueueNotification(
+      CGUIDialogKaiToast::Info,
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(titleId), message);
 }
 
 std::string GetMusicDbItemPath(const CFileItem& item)

--- a/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
+++ b/xbmc/music/dialogs/GUIDialogInfoProviderSettings.cpp
@@ -21,8 +21,9 @@
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "interfaces/builtins/Builtins.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -103,7 +104,10 @@ int CGUIDialogInfoProviderSettings::Show(ADDON::ScraperPtr& scraper)
     dialog->SetArtistScraper(scraper);
   // toast selected but disabled scrapers
   if (CServiceBroker::GetAddonMgr().IsAddonDisabled(scraper->ID()))
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(24024), scraper->Name(), 2000, true);
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Error,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24024), scraper->Name(),
+        2000, true);
 
   dialog->Open();
 
@@ -241,7 +245,7 @@ void CGUIDialogInfoProviderSettings::OnSettingAction(const std::shared_ptr<const
       if (CUtil::GetMatchingSource(strDirectory, shares, bIsSource) < 0) // path is outside shares - add it as a separate one
       {
         CMediaSource share;
-        share.strName = g_localizeStrings.Get(13278);
+        share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13278);
         share.strPath = strDirectory;
         shares.push_back(share);
       }
@@ -249,7 +253,9 @@ void CGUIDialogInfoProviderSettings::OnSettingAction(const std::shared_ptr<const
     else
       strDirectory = "default location";
 
-    if (CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(20223), strDirectory, true))
+    if (CGUIDialogFileBrowser::ShowAndGetDirectory(
+            shares, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20223),
+            strDirectory, true))
     {
       if (!strDirectory.empty())
       {
@@ -317,7 +323,9 @@ void CGUIDialogInfoProviderSettings::SetupView()
       }
       else
       {
-        SetLabel2(CSettings::SETTING_MUSICLIBRARY_ALBUMSSCRAPER, g_localizeStrings.Get(231)); //Set label2 to "None"
+        SetLabel2(CSettings::SETTING_MUSICLIBRARY_ALBUMSSCRAPER,
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                      231)); //Set label2 to "None"
         ToggleState(SETTING_ALBUMSCRAPER_SETTINGS, false);
       }
       // Artist scraper
@@ -332,7 +340,9 @@ void CGUIDialogInfoProviderSettings::SetupView()
       }
       else
       {
-        SetLabel2(CSettings::SETTING_MUSICLIBRARY_ARTISTSSCRAPER, g_localizeStrings.Get(231)); //Set label2 to "None"
+        SetLabel2(CSettings::SETTING_MUSICLIBRARY_ARTISTSSCRAPER,
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                      231)); //Set label2 to "None"
         ToggleState(SETTING_ARTISTSCRAPER_SETTINGS, false);
       }
       // Artist Information Folder
@@ -354,7 +364,9 @@ void CGUIDialogInfoProviderSettings::SetupView()
     }
     else
     {
-      SetLabel2(CSettings::SETTING_MUSICLIBRARY_ALBUMSSCRAPER, g_localizeStrings.Get(231)); //Set label2 to "None"
+      SetLabel2(CSettings::SETTING_MUSICLIBRARY_ALBUMSSCRAPER,
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                    231)); //Set label2 to "None"
       ToggleState(SETTING_ALBUMSCRAPER_SETTINGS, false);
     }
   }
@@ -373,7 +385,9 @@ void CGUIDialogInfoProviderSettings::SetupView()
     }
     else
     {
-      SetLabel2(CSettings::SETTING_MUSICLIBRARY_ARTISTSSCRAPER, g_localizeStrings.Get(231)); //Set label2 to "None"
+      SetLabel2(CSettings::SETTING_MUSICLIBRARY_ARTISTSSCRAPER,
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                    231)); //Set label2 to "None"
       ToggleState(SETTING_ARTISTSCRAPER_SETTINGS, false);
     }
     // Artist Information Folder when default settings

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -23,7 +23,6 @@
 #include "filesystem/MusicDatabaseDirectory/QueryParams.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "imagefiles/ImageFileURL.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
@@ -39,6 +38,8 @@
 #include "music/tags/MusicInfoTag.h"
 #include "music/windows/GUIWindowMusicBase.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -735,7 +736,7 @@ void CGUIDialogMusicInfo::AddItemPathToFileBrowserSources(std::vector<CMediaSour
   if (!itemDir.empty() && CDirectory::Exists(itemDir))
   {
     CMediaSource itemSource;
-    itemSource.strName = g_localizeStrings.Get(36041);
+    itemSource.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36041);
     itemSource.strPath = itemDir;
     sources.push_back(itemSource);
   }
@@ -744,7 +745,8 @@ void CGUIDialogMusicInfo::AddItemPathToFileBrowserSources(std::vector<CMediaSour
   if (!artistFolder.empty() && CDirectory::Exists(artistFolder))
   {
     CMediaSource itemSource;
-    itemSource.strName = "* " + g_localizeStrings.Get(20223);
+    itemSource.strName =
+        "* " + CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20223);
     itemSource.strPath = artistFolder;
     sources.push_back(itemSource);
   }
@@ -790,7 +792,7 @@ void CGUIDialogMusicInfo::OnGetArt()
     CFileItemPtr item(new CFileItem("thumb://Current", false));
     item->SetArt("thumb", m_item->GetArt(type));
     item->SetArt("icon", "DefaultPicture.png");
-    item->SetLabel(g_localizeStrings.Get(13512));
+    item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13512));
     items.Add(item);
   }
 
@@ -811,7 +813,7 @@ void CGUIDialogMusicInfo::OnGetArt()
     CFileItemPtr item(new CFileItem(strItemPath, false));
     item->SetArt("thumb", remotethumbs[i]);
     item->SetArt("icon", "DefaultPicture.png");
-    item->SetLabel(g_localizeStrings.Get(13513));
+    item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13513));
 
     items.Add(item);
   }
@@ -864,7 +866,8 @@ void CGUIDialogMusicInfo::OnGetArt()
   {
     CFileItemPtr item(new CFileItem("Local Art: " + localArt, false));
     item->SetArt("thumb", localArt);
-    item->SetLabel(g_localizeStrings.Get(13514)); // "Local art"
+    item->SetLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13514)); // "Local art"
     items.Add(item);
   }
 
@@ -877,7 +880,7 @@ void CGUIDialogMusicInfo::OnGetArt()
       item->SetArt("icon", "DefaultArtist.png");
     else
       item->SetArt("icon", "DefaultAlbumCover.png");
-    item->SetLabel(g_localizeStrings.Get(13515));
+    item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13515));
     items.Add(item);
   }
 
@@ -909,8 +912,10 @@ void CGUIDialogMusicInfo::OnGetArt()
   std::vector<CMediaSource> sources(*CMediaSourceSettings::GetInstance().GetSources("music"));
   CGUIDialogMusicInfo::AddItemPathToFileBrowserSources(sources, *m_item);
   CServiceBroker::GetMediaManager().GetLocalDrives(sources);
-  if (CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(13511), result) &&
-    result != "thumb://Current")
+  if (CGUIDialogFileBrowser::ShowAndGetImage(
+          items, sources, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13511),
+          result) &&
+      result != "thumb://Current")
   {
     // User didn't choose the one they have.
     // Overwrite with the new art or clear it

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -18,7 +18,6 @@
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "jobs/JobManager.h"
@@ -28,6 +27,8 @@
 #include "music/tags/MusicInfoTag.h"
 #include "music/windows/GUIWindowMusicBase.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
@@ -358,7 +359,8 @@ void CGUIDialogSongInfo::OnGetArt()
     CFileItemPtr item(new CFileItem("thumb://Current", false));
     item->SetArt("thumb", m_song->GetArt(type));
     item->SetArt("icon", "DefaultPicture.png");
-    item->SetLabel(g_localizeStrings.Get(13512));  //! @todo: label fallback art so user knows?
+    item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        13512)); //! @todo: label fallback art so user knows?
     items.Add(item);
   }
   else if (m_song->HasArt("thumb"))
@@ -369,7 +371,7 @@ void CGUIDialogSongInfo::OnGetArt()
       CFileItemPtr item(new CFileItem("thumb://Thumb", false));
       item->SetArt("thumb", m_song->GetArt("thumb"));
       item->SetArt("icon", "DefaultAlbumCover.png");
-      item->SetLabel(g_localizeStrings.Get(21371));
+      item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21371));
       items.Add(item);
     }
   }
@@ -387,7 +389,7 @@ void CGUIDialogSongInfo::OnGetArt()
     {
       CFileItemPtr item(new CFileItem("thumb://Local", false));
       item->SetArt("thumb", localThumb);
-      item->SetLabel(g_localizeStrings.Get(20017));
+      item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20017));
       items.Add(item);
     }
   }
@@ -407,7 +409,7 @@ void CGUIDialogSongInfo::OnGetArt()
     // allow the user to delete it by selecting "no art".
     CFileItemPtr item(new CFileItem("thumb://None", false));
     item->SetArt("thumb", "DefaultAlbumCover.png");
-    item->SetLabel(g_localizeStrings.Get(13515));
+    item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13515));
     items.Add(item);
   }
 
@@ -426,8 +428,10 @@ void CGUIDialogSongInfo::OnGetArt()
   else  // Add parent folder of song
     CGUIDialogMusicInfo::AddItemPathToFileBrowserSources(sources, *m_song);
   CServiceBroker::GetMediaManager().GetLocalDrives(sources);
-  if (CGUIDialogFileBrowser::ShowAndGetImage(items, sources, g_localizeStrings.Get(13511), result) &&
-    result != "thumb://Current")
+  if (CGUIDialogFileBrowser::ShowAndGetImage(
+          items, sources, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13511),
+          result) &&
+      result != "thumb://Current")
   {
     // User didn't choose the one they have, or the fallback image.
     // Overwrite with the new art or clear it

--- a/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
+++ b/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
@@ -14,7 +14,8 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIVisualisationControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
@@ -54,14 +55,15 @@ void CGUIDialogVisualisationPresetList::SetVisualisation(CGUIVisualisationContro
   if (!m_viz)
   { // No viz, but show something if this dialog activated
     SetHeading(CVariant{ 10122 });
-    CFileItem item(g_localizeStrings.Get(13389));
+    CFileItem item(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13389));
     Add(item);
   }
   else
   {
     SetUseDetails(false);
     SetMultiSelection(false);
-    SetHeading(CVariant{StringUtils::Format(g_localizeStrings.Get(13407), m_viz->Name())});
+    SetHeading(CVariant{StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13407), m_viz->Name())});
     std::vector<std::string> presets;
     if (m_viz->GetPresetList(presets))
     {
@@ -76,7 +78,7 @@ void CGUIDialogVisualisationPresetList::SetVisualisation(CGUIVisualisationContro
     else
     { // Viz does not have any presets
       // "There are no presets available for this visualisation"
-      CFileItem item(g_localizeStrings.Get(13389));
+      CFileItem item(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13389));
       Add(item);
     }
   }

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -36,7 +36,6 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "imagefiles/ImageFileURL.h"
 #include "interfaces/AnnouncementManager.h"
 #include "music/MusicFileItemClassify.h"
@@ -46,6 +45,8 @@
 #include "music/tags/MusicInfoTag.h"
 #include "music/tags/MusicInfoTagLoaderFactory.h"
 #include "playlists/PlayListFileItemClassify.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -91,7 +92,8 @@ void CMusicInfoScanner::Process()
       CGUIDialogExtendedProgressBar* dialog =
         CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogExtendedProgressBar>(WINDOW_DIALOG_EXT_PROGRESS);
       if (dialog)
-        m_handle = dialog->GetHandle(g_localizeStrings.Get(314));
+        m_handle = dialog->GetHandle(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(314));
     }
 
     // check if we only need to perform a cleaning
@@ -113,7 +115,7 @@ void CMusicInfoScanner::Process()
       CLog::Log(LOGDEBUG, "{} - Starting scan", __FUNCTION__);
 
       if (m_handle)
-        m_handle->SetTitle(g_localizeStrings.Get(505));
+        m_handle->SetTitle(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(505));
 
       // Reset progress vars
       m_currentItem=0;
@@ -181,7 +183,8 @@ void CMusicInfoScanner::Process()
         {
           if (m_handle)
           {
-            m_handle->SetTitle(g_localizeStrings.Get(700));
+            m_handle->SetTitle(
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(700));
             m_handle->SetText("");
           }
 
@@ -189,7 +192,8 @@ void CMusicInfoScanner::Process()
           m_musicDatabase.CheckArtistLinksChanged();
 
           if (m_handle)
-            m_handle->SetTitle(g_localizeStrings.Get(331));
+            m_handle->SetTitle(
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(331));
 
           m_musicDatabase.Compress(false);
         }
@@ -476,7 +480,8 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
 {
   if (m_handle)
   {
-    m_handle->SetTitle(g_localizeStrings.Get(506)); //"Checking media files..."
+    m_handle->SetTitle(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        506)); //"Checking media files..."
     m_handle->SetText(Prettify(strDirectory));
   }
 
@@ -518,7 +523,8 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
                 CURL::GetRedacted(strDirectory));
 
     if (m_handle)
-      m_handle->SetTitle(g_localizeStrings.Get(505)); //"Loading media information from files..."
+      m_handle->SetTitle(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          505)); //"Loading media information from files..."
 
     // filter items in the sub dir (for .cue sheet support)
     items.FilterCueItems();
@@ -746,7 +752,8 @@ void CMusicInfoScanner::FileItemsToAlbums(const CFileItemList& items,
     OR
     3b. we have at least two primary artists and no album artist specified.
     */
-    std::string various = g_localizeStrings.Get(340); // Various Artists
+    std::string various =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(340); // Various Artists
     bool compilation =
         !songsByAlbumName.first.empty() && (isCompilation || !tracksOverlap); // 1+2b+2a
     if (artists.size() == 1)
@@ -1186,8 +1193,9 @@ void MUSIC_INFO::CMusicInfoScanner::RetrieveLocalArt()
 {
   if (m_handle)
   {
-    m_handle->SetTitle(g_localizeStrings.Get(506)); //"Checking media files..."
-   //!@todo: title = Checking for local art
+    m_handle->SetTitle(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        506)); //"Checking media files..."
+    //!@todo: title = Checking for local art
   }
 
   std::set<int> artistsArtDone; // artists processed to avoid unsuccessful repeats
@@ -1316,12 +1324,18 @@ CInfoScanner::InfoRet CMusicInfoScanner::UpdateDatabaseAlbumInfo(
       if (pDialog && bAllowSelection)
       {
         std::string strTempAlbum(album.strAlbum);
-        if (!CGUIKeyboardFactory::ShowAndGetInput(strTempAlbum, CVariant{ g_localizeStrings.Get(16011) }, false))
+        if (!CGUIKeyboardFactory::ShowAndGetInput(
+                strTempAlbum,
+                CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16011)},
+                false))
           albumDownloadStatus = InfoRet::CANCELLED;
         else
         {
           std::string strTempArtist(album.GetAlbumArtistString());
-          if (!CGUIKeyboardFactory::ShowAndGetInput(strTempArtist, CVariant{ g_localizeStrings.Get(16025) }, false))
+          if (!CGUIKeyboardFactory::ShowAndGetInput(
+                  strTempArtist,
+                  CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16025)},
+                  false))
             albumDownloadStatus = InfoRet::CANCELLED;
           else
           {
@@ -1337,7 +1351,9 @@ CInfoScanner::InfoRet CMusicInfoScanner::UpdateDatabaseAlbumInfo(
         if (eventLog)
           eventLog->Add(EventPtr(new CMediaLibraryEvent(
               MediaTypeAlbum, album.strPath, 24146,
-              StringUtils::Format(g_localizeStrings.Get(24147), MediaTypeAlbum, album.strAlbum),
+              StringUtils::Format(
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24147),
+                  MediaTypeAlbum, album.strAlbum),
               CScraperUrl::GetThumbUrl(album.thumbURL.GetFirstUrlByType()),
               CURL::GetRedacted(album.strPath), EventLevel::Warning)));
       }
@@ -1396,7 +1412,10 @@ CInfoScanner::InfoRet CMusicInfoScanner::UpdateDatabaseArtistInfo(
     {
       if (pDialog && bAllowSelection)
       {
-        if (!CGUIKeyboardFactory::ShowAndGetInput(artist.strArtist, CVariant{ g_localizeStrings.Get(16025) }, false))
+        if (!CGUIKeyboardFactory::ShowAndGetInput(
+                artist.strArtist,
+                CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16025)},
+                false))
           artistDownloadStatus = InfoRet::CANCELLED;
         else
           stop = false;
@@ -1407,7 +1426,9 @@ CInfoScanner::InfoRet CMusicInfoScanner::UpdateDatabaseArtistInfo(
         if (eventLog)
           eventLog->Add(EventPtr(new CMediaLibraryEvent(
               MediaTypeArtist, artist.strPath, 24146,
-              StringUtils::Format(g_localizeStrings.Get(24147), MediaTypeArtist, artist.strArtist),
+              StringUtils::Format(
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24147),
+                  MediaTypeArtist, artist.strArtist),
               CScraperUrl::GetThumbUrl(artist.thumbURL.GetFirstUrlByType()),
               CURL::GetRedacted(artist.strPath), EventLevel::Warning)));
       }
@@ -1464,7 +1485,8 @@ CInfoScanner::InfoRet CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
 {
   if (m_handle)
   {
-    m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20321), info->Name()));
+    m_handle->SetTitle(StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20321), info->Name()));
     m_handle->SetText(album.GetAlbumArtistString() + " - " + album.strAlbum);
   }
 
@@ -1578,7 +1600,8 @@ CInfoScanner::InfoRet CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
         if (pDialog)
         {
           pDlg = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
-          pDlg->SetHeading(CVariant{g_localizeStrings.Get(181)});
+          pDlg->SetHeading(
+              CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(181)});
           pDlg->Reset();
           pDlg->EnableButton(true, 413); // manual
           pDlg->SetUseDetails(true);
@@ -1641,13 +1664,21 @@ CInfoScanner::InfoRet CMusicInfoScanner::DownloadAlbumInfo(const CAlbum& album,
 
             // manual button pressed
             std::string strNewAlbum = album.strAlbum;
-            if (!CGUIKeyboardFactory::ShowAndGetInput(strNewAlbum, CVariant{g_localizeStrings.Get(16011)}, false))
+            if (!CGUIKeyboardFactory::ShowAndGetInput(
+                    strNewAlbum,
+                    CVariant{
+                        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16011)},
+                    false))
               return InfoRet::CANCELLED;
             if (strNewAlbum.empty())
               return InfoRet::CANCELLED;
 
             std::string strNewArtist = album.GetAlbumArtistString();
-            if (!CGUIKeyboardFactory::ShowAndGetInput(strNewArtist, CVariant{g_localizeStrings.Get(16025)}, false))
+            if (!CGUIKeyboardFactory::ShowAndGetInput(
+                    strNewArtist,
+                    CVariant{
+                        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16025)},
+                    false))
               return InfoRet::CANCELLED;
 
             pDialog->SetLine(0, CVariant{strNewAlbum});
@@ -1722,7 +1753,8 @@ CInfoScanner::InfoRet CMusicInfoScanner::DownloadArtistInfo(
 {
   if (m_handle)
   {
-    m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20320), info->Name()));
+    m_handle->SetTitle(StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20320), info->Name()));
     m_handle->SetText(artist.strArtist);
   }
 
@@ -1847,7 +1879,8 @@ CInfoScanner::InfoRet CMusicInfoScanner::DownloadArtistInfo(
         CGUIDialogSelect *pDlg = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
         if (pDlg)
         {
-          pDlg->SetHeading(CVariant{g_localizeStrings.Get(21890)});
+          pDlg->SetHeading(
+              CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21890)});
           pDlg->Reset();
           pDlg->EnableButton(true, 413); // manual
 
@@ -1881,7 +1914,11 @@ CInfoScanner::InfoRet CMusicInfoScanner::DownloadArtistInfo(
 
             // manual button pressed
             std::string strNewArtist = artist.strArtist;
-            if (!CGUIKeyboardFactory::ShowAndGetInput(strNewArtist, CVariant{g_localizeStrings.Get(16025)}, false))
+            if (!CGUIKeyboardFactory::ShowAndGetInput(
+                    strNewArtist,
+                    CVariant{
+                        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16025)},
+                    false))
               return InfoRet::CANCELLED;
 
             if (pDialog)

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -9,7 +9,6 @@
 #include "MusicInfoTag.h"
 
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "music/Artist.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -40,7 +40,6 @@
 #include "filesystem/MusicDatabaseDirectory/QueryParams.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
@@ -56,6 +55,8 @@
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
@@ -854,14 +855,15 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
       const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
       CFileItemPtr newPlaylist(new CFileItem(profileManager->GetUserDataItem("PartyMode.xsp"),false));
-      newPlaylist->SetLabel(g_localizeStrings.Get(16035));
+      newPlaylist->SetLabel(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16035));
       newPlaylist->SetLabelPreformatted(true);
       newPlaylist->SetArt("icon", "DefaultPartyMode.png");
       newPlaylist->SetFolder(true);
       items.Add(newPlaylist);
 
       newPlaylist = std::make_shared<CFileItem>("newplaylist://", false);
-      newPlaylist->SetLabel(g_localizeStrings.Get(525));
+      newPlaylist->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(525));
       newPlaylist->SetArt("icon", "DefaultAddSource.png");
       newPlaylist->SetLabelPreformatted(true);
       newPlaylist->SetSpecialSort(SortSpecialOnBottom);
@@ -869,7 +871,8 @@ bool CGUIWindowMusicBase::GetDirectory(const std::string &strDirectory, CFileIte
       items.Add(newPlaylist);
 
       newPlaylist = std::make_shared<CFileItem>("newsmartplaylist://music", false);
-      newPlaylist->SetLabel(g_localizeStrings.Get(21437));
+      newPlaylist->SetLabel(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21437));
       newPlaylist->SetArt("icon", "DefaultAddSource.png");
       newPlaylist->SetLabelPreformatted(true);
       newPlaylist->SetSpecialSort(SortSpecialOnBottom);
@@ -922,9 +925,11 @@ bool CGUIWindowMusicBase::OnSelect(int iItem)
         // ask the user if they want to play or resume
         CContextButtons choices;
         choices.Add(MUSIC_SELECT_ACTION_PLAY, 208); // 208 = Play
-        choices.Add(MUSIC_SELECT_ACTION_RESUME,
-                    StringUtils::Format(g_localizeStrings.Get(12022), // 12022 = Resume from ...
-                                        (*itemIt)->GetMusicInfoTag()->GetTitle()));
+        choices.Add(
+            MUSIC_SELECT_ACTION_RESUME,
+            StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                    12022), // 12022 = Resume from ...
+                                (*itemIt)->GetMusicInfoTag()->GetTitle()));
 
         auto choice = CGUIDialogContextMenu::Show(choices);
         if (choice == MUSIC_SELECT_ACTION_RESUME)

--- a/xbmc/music/windows/GUIWindowMusicNav.cpp
+++ b/xbmc/music/windows/GUIWindowMusicNav.cpp
@@ -28,7 +28,6 @@
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "jobs/JobManager.h"
@@ -43,6 +42,8 @@
 #include "playlists/PlayListFactory.h"
 #include "playlists/PlayListFileItemClassify.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -512,7 +513,8 @@ void CGUIWindowMusicNav::UpdateButtons()
       StringUtils::StartsWith(m_vecItems->Get(m_vecItems->Size()-1)->GetPath(), "/-1/"))
       iItems--;
   }
-  std::string items = StringUtils::Format("{} {}", iItems, g_localizeStrings.Get(127));
+  std::string items = StringUtils::Format(
+      "{} {}", iItems, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(127));
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   // set the filter label
@@ -520,7 +522,7 @@ void CGUIWindowMusicNav::UpdateButtons()
 
   // "Playlists"
   if (m_vecItems->IsPath("special://musicplaylists/"))
-    strLabel = g_localizeStrings.Get(136);
+    strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(136);
   // "{Playlist Name}"
   else if (PLAYLIST::IsPlayList(*m_vecItems))
   {
@@ -941,7 +943,8 @@ void CGUIWindowMusicNav::AddSearchFolder()
     {
       // add search share
       CMediaSource share;
-      share.strName=g_localizeStrings.Get(137); // Search
+      share.strName =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(137); // Search
       share.strPath = "musicsearch://";
       share.m_iDriveType = SourceType::LOCAL;
       sources.push_back(share);

--- a/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylist.cpp
@@ -22,13 +22,14 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "playlists/PlayListM3U.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -304,8 +305,9 @@ bool CGUIWindowMusicPlayList::MoveCurrentPlayListItem(int iItem,
 void CGUIWindowMusicPlayList::SavePlayList()
 {
   std::string strNewFileName;
-  if (CGUIKeyboardFactory::ShowAndGetInput(strNewFileName, CVariant{g_localizeStrings.Get(16012)},
-                                           false))
+  if (CGUIKeyboardFactory::ShowAndGetInput(
+          strNewFileName,
+          CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16012)}, false))
   {
     // need 2 rename it
     strNewFileName = CUtil::MakeLegalFileName(std::move(strNewFileName));
@@ -445,11 +447,14 @@ void CGUIWindowMusicPlayList::UpdateButtons()
   else
     iLocalizedString = 597; // Repeat: All
 
-  SET_CONTROL_LABEL(CONTROL_BTNREPEAT, g_localizeStrings.Get(iLocalizedString));
+  SET_CONTROL_LABEL(
+      CONTROL_BTNREPEAT,
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(iLocalizedString));
 
   // Update object count label
   std::string items =
-      StringUtils::Format("{} {}", m_vecItems->GetObjectCount(), g_localizeStrings.Get(127));
+      StringUtils::Format("{} {}", m_vecItems->GetObjectCount(),
+                          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(127));
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   MarkPlaying();

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -19,11 +19,12 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "filesystem/PlaylistFileDirectory.h"
 #include "guilib/GUIKeyboardFactory.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "music/MusicUtils.h"
 #include "playlists/PlayListM3U.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -182,20 +183,20 @@ bool CGUIWindowMusicPlaylistEditor::GetDirectory(const std::string &strDirectory
   if (strDirectory.empty())
   { // root listing - list files:// and musicdb://
     CFileItemPtr files(new CFileItem("sources://music/", true));
-    files->SetLabel(g_localizeStrings.Get(744));
+    files->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(744));
     files->SetLabelPreformatted(true);
     files->SetIsShareOrDrive(true);
     items.Add(files);
 
     CFileItemPtr mdb(new CFileItem("library://music/", true));
-    mdb->SetLabel(g_localizeStrings.Get(14022));
+    mdb->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14022));
     mdb->SetLabelPreformatted(true);
     mdb->SetIsShareOrDrive(true);
     items.SetPath("");
     items.Add(mdb);
 
     CFileItemPtr vdb(new CFileItem("videodb://musicvideos/", true));
-    vdb->SetLabel(g_localizeStrings.Get(20389));
+    vdb->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20389));
     vdb->SetLabelPreformatted(true);
     vdb->SetIsShareOrDrive(true);
     items.SetPath("");
@@ -225,8 +226,9 @@ void CGUIWindowMusicPlaylistEditor::UpdateButtons()
   CGUIWindowMusicBase::UpdateButtons();
 
   // Update object count label
-  std::string items = StringUtils::Format("{} {}", m_vecItems->GetObjectCount(),
-                                          g_localizeStrings.Get(127)); // " 14 Objects"
+  std::string items = StringUtils::Format(
+      "{} {}", m_vecItems->GetObjectCount(),
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(127)); // " 14 Objects"
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 }
 
@@ -304,8 +306,9 @@ void CGUIWindowMusicPlaylistEditor::UpdatePlaylist()
   OnMessage(msg);
 
   // indicate how many songs we have
-  std::string items = StringUtils::Format("{} {}", m_playlist->Size(),
-                                          g_localizeStrings.Get(134)); // "123 Songs"
+  std::string items = StringUtils::Format(
+      "{} {}", m_playlist->Size(),
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(134)); // "123 Songs"
   SET_CONTROL_LABEL(CONTROL_LABEL_PLAYLIST, items);
 
   m_playlistThumbLoader.Load(*m_playlist);
@@ -346,9 +349,9 @@ void CGUIWindowMusicPlaylistEditor::OnLoadPlaylist()
 {
   // Prompt user for file to load from music playlists folder
   std::string playlist;
-  if (CGUIDialogFileBrowser::ShowAndGetFile("special://musicplaylists/",
-                                            ".m3u|.m3u8|.pls|.b4s|.wpl|.xspf", g_localizeStrings.Get(656),
-                                            playlist))
+  if (CGUIDialogFileBrowser::ShowAndGetFile(
+          "special://musicplaylists/", ".m3u|.m3u8|.pls|.b4s|.wpl|.xspf",
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(656), playlist))
     LoadPlaylist(playlist);
 }
 
@@ -382,7 +385,9 @@ void CGUIWindowMusicPlaylistEditor::OnSavePlaylist()
   else
     URIUtils::RemoveExtension(name);
 
-  if (CGUIKeyboardFactory::ShowAndGetInput(name, CVariant{g_localizeStrings.Get(16012)}, false))
+  if (CGUIKeyboardFactory::ShowAndGetInput(
+          name, CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16012)},
+          false))
   {
     PLAYLIST::CPlayListM3U playlist;
     playlist.Add(*m_playlist);
@@ -393,9 +398,10 @@ void CGUIWindowMusicPlaylistEditor::OnSavePlaylist()
 
     playlist.Save(path);
     m_strLoadedPlaylist = name;
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
-                                          g_localizeStrings.Get(559), // "Playlist"
-                                          g_localizeStrings.Get(35259)); // "Saved"
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Info,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(559), // "Playlist"
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35259)); // "Saved"
   }
 }
 

--- a/xbmc/music/windows/MusicFileItemListModifier.cpp
+++ b/xbmc/music/windows/MusicFileItemListModifier.cpp
@@ -12,9 +12,10 @@
 #include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "filesystem/MusicDatabaseDirectory/DirectoryNode.h"
-#include "guilib/LocalizeStrings.h"
 #include "music/MusicDbUrl.h"
 #include "music/MusicFileItemClassify.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -79,7 +80,8 @@ void CMusicFileItemListModifier::AddQueuingFolder(CFileItemList& items)
   switch (nodeChildType)
   {
     case NodeType::ARTIST:
-      pItem = std::make_shared<CFileItem>(g_localizeStrings.Get(15103)); // "All Artists"
+      pItem = std::make_shared<CFileItem>(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15103)); // "All Artists"
       musicUrl.AppendPath("-1/");
       pItem->SetPath(musicUrl.ToString());
       break;
@@ -89,14 +91,16 @@ void CMusicFileItemListModifier::AddQueuingFolder(CFileItemList& items)
     case NodeType::ALBUM_RECENTLY_PLAYED:
     case NodeType::ALBUM_RECENTLY_ADDED:
     case NodeType::ALBUM_TOP100:
-      pItem = std::make_shared<CFileItem>(g_localizeStrings.Get(15102)); // "All Albums"
+      pItem = std::make_shared<CFileItem>(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15102)); // "All Albums"
       musicUrl.AppendPath("-1/");
       pItem->SetPath(musicUrl.ToString());
       break;
 
     //  Disc node
     case NodeType::DISC:
-      pItem = std::make_shared<CFileItem>(g_localizeStrings.Get(38075)); // "All Discs"
+      pItem = std::make_shared<CFileItem>(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38075)); // "All Discs"
       musicUrl.AppendPath("-1/");
       pItem->SetPath(musicUrl.ToString());
       break;

--- a/xbmc/network/EventClient.cpp
+++ b/xbmc/network/EventClient.cpp
@@ -12,12 +12,13 @@
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "filesystem/File.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/keyboard/KeyIDs.h"
 #include "input/keymaps/ButtonTranslator.h"
 #include "input/keymaps/joysticks/GamepadTranslator.h"
 #include "input/keymaps/keyboard/KeyboardTranslator.h"
 #include "input/keymaps/remote/IRTranslator.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -292,11 +293,14 @@ bool CEventClient::OnPacketHELO(CEventPacket *packet)
   m_bGreeted = true;
   if (m_eLogoType == LT_NONE)
   {
-    CGUIDialogKaiToast::QueueNotification(g_localizeStrings.Get(33200), m_deviceName);
+    CGUIDialogKaiToast::QueueNotification(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(33200), m_deviceName);
   }
   else
   {
-    CGUIDialogKaiToast::QueueNotification(iconfile, g_localizeStrings.Get(33200), m_deviceName);
+    CGUIDialogKaiToast::QueueNotification(
+        iconfile, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(33200),
+        m_deviceName);
   }
   return true;
 }

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -15,8 +15,9 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/lib/Setting.h"
 #include "settings/windows/GUIControlSettings.h"
 #include "utils/StringUtils.h"
@@ -24,7 +25,6 @@
 #include "utils/log.h"
 
 #include <utility>
-
 
 using namespace ADDON;
 using namespace KODI::MESSAGING;
@@ -224,7 +224,8 @@ void CGUIDialogNetworkSetup::OnServerBrowse()
   CURL url(share.strPath);
   share.strName = url.GetWithoutUserDetails();
   shares.push_back(share);
-  if (CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(1015), path))
+  if (CGUIDialogFileBrowser::ShowAndGetDirectory(
+          shares, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1015), path))
   {
     SetPath(path);
     UpdateButtons();

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -12,7 +12,6 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "interfaces/json-rpc/JSONRPC.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
@@ -20,6 +19,8 @@
 #include "network/EventServer.h"
 #include "network/Network.h"
 #include "network/TCPServer.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -538,9 +539,15 @@ void CNetworkServices::Start()
   if (m_settings->GetBool(CSettings::SETTING_SERVICES_UPNP))
     StartUPnP();
   if (m_settings->GetBool(CSettings::SETTING_SERVICES_ESENABLED) && !StartEventServer())
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Warning,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(33102),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(33100));
   if (m_settings->GetBool(CSettings::SETTING_SERVICES_ESENABLED) && !StartJSONRPCServer())
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(33103), g_localizeStrings.Get(33100));
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Warning,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(33103),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(33100));
 
 #ifdef HAS_WEB_SERVER
   // Start web server after eventserver and JSON-RPC server, so users can use these interfaces
@@ -564,7 +571,9 @@ void CNetworkServices::Start()
     // Only try to start server if configuration is OK
     else if (!StartWebserver())
       CGUIDialogKaiToast::QueueNotification(
-          CGUIDialogKaiToast::Warning, g_localizeStrings.Get(33101), g_localizeStrings.Get(33100));
+          CGUIDialogKaiToast::Warning,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(33101),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(33100));
   }
 #endif // HAS_WEB_SERVER
 

--- a/xbmc/network/WakeOnAccess.cpp
+++ b/xbmc/network/WakeOnAccess.cpp
@@ -17,10 +17,11 @@
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "jobs/JobManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "network/Network.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
@@ -72,7 +73,7 @@ static unsigned long HostToIP(const std::string& host)
   return inet_addr(ip.c_str());
 }
 
-#define LOCALIZED(id) g_localizeStrings.Get(id)
+#define LOCALIZED(id) CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(id)
 
 static void ShowDiscoveryMessage(const char* function, const char* server_name, bool new_entry)
 {

--- a/xbmc/network/mdns/ZeroconfMDNS.cpp
+++ b/xbmc/network/mdns/ZeroconfMDNS.cpp
@@ -8,8 +8,10 @@
 
 #include "ZeroconfMDNS.h"
 
+#include "ServiceBroker.h"
 #include "dialogs/GUIDialogKaiToast.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/log.h"
 
 #include <mutex>
@@ -66,7 +68,10 @@ bool CZeroconfMDNS::IsZCdaemonRunning()
   if(err != kDNSServiceErr_NoError)
   {
     CLog::Log(LOGERROR, "ZeroconfMDNS: Zeroconf can't be started probably because Apple's Bonjour Service isn't installed. You can get it by either installing Itunes or Apple's Bonjour Print Service for Windows (http://support.apple.com/kb/DL999)");
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(34300), g_localizeStrings.Get(34301), 10000, true);
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Error,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34300),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34301), 10000, true);
     return false;
   }
   CLog::Log(LOGDEBUG, "ZeroconfMDNS:Bonjour version is {}.{}", version / 10000,

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -24,7 +24,6 @@
 #include "filesystem/VideoDatabaseDirectory/QueryParams.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "imagefiles/ImageFileURL.h"
 #include "interfaces/AnnouncementManager.h"
@@ -35,6 +34,8 @@
 #include "music/MusicThumbLoader.h"
 #include "music/tags/MusicInfoTag.h"
 #include "playlists/PlayListFileItemClassify.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Digest.h"
@@ -854,7 +855,7 @@ NPT_Result CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference& action,
   if (items.GetPath() == "musicdb://")
   {
     CFileItemPtr playlists(new CFileItem("special://musicplaylists/", true));
-    playlists->SetLabel(g_localizeStrings.Get(136));
+    playlists->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(136));
     items.Add(playlists);
 
     CVideoDatabase database;
@@ -862,7 +863,7 @@ NPT_Result CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference& action,
     if (database.HasContent(VideoDbContentType::MUSICVIDEOS))
     {
       CFileItemPtr mvideos(new CFileItem("library://video/musicvideos/", true));
-      mvideos->SetLabel(g_localizeStrings.Get(20389));
+      mvideos->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20389));
       items.Add(mvideos);
     }
   }

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -67,7 +67,8 @@
 #include "bus/virtual/PeripheralBusCEC.h"
 #else
 #include "dialogs/GUIDialogKaiToast.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #endif
 
 using namespace KODI;
@@ -354,9 +355,10 @@ void CPeripherals::CreatePeripheral(CPeripheralBus& bus, const PeripheralScanRes
             LOGWARNING,
             "{} - libCEC support has not been compiled in, so the CEC adapter cannot be used.",
             __FUNCTION__);
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning,
-                                              g_localizeStrings.Get(36000),
-                                              g_localizeStrings.Get(36017));
+        CGUIDialogKaiToast::QueueNotification(
+            CGUIDialogKaiToast::Warning,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36000),
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36017));
       }
 #endif
       break;
@@ -408,7 +410,7 @@ void CPeripherals::OnDeviceAdded(const CPeripheralBus& bus, const CPeripheral& p
     bNotify = false;
 
   if (bNotify)
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(35005), peripheral.DeviceName());
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35005), peripheral.DeviceName());
 #endif
 }
 
@@ -421,7 +423,7 @@ void CPeripherals::OnDeviceDeleted(const CPeripheralBus& bus, const CPeripheral&
   bool bNotify = true;
 
   if (bNotify)
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(35006), peripheral.DeviceName());
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35006), peripheral.DeviceName());
 #endif
 }
 

--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -10,9 +10,11 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "peripherals/Peripherals.h"
 #include "peripherals/devices/Peripheral.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -316,14 +318,17 @@ void CPeripheralBus::GetDirectory(const std::string& strPath, CFileItemList& ite
     std::string strDetails;
 
     if (peripheral->GetBusType() == PERIPHERAL_BUS_CEC && !peripheral->GetSettingBool("enabled"))
-      strDetails =
-          StringUtils::Format("{}: {}", g_localizeStrings.Get(126), g_localizeStrings.Get(13106));
+      strDetails = StringUtils::Format(
+          "{}: {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(126),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13106));
 
     if (strDetails.empty())
     {
       std::string strVersion(peripheral->GetVersionInfo());
       if (!strVersion.empty())
-        strDetails = StringUtils::Format("{} {}", g_localizeStrings.Get(24051), strVersion);
+        strDetails = StringUtils::Format(
+            "{} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24051),
+            strVersion);
     }
 
     peripheralFile->SetProperty("version", strVersion);

--- a/xbmc/peripherals/bus/virtual/PeripheralBusApplication.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusApplication.cpp
@@ -16,8 +16,9 @@
 #include "games/controllers/ControllerIDs.h"
 #include "games/controllers/ControllerLayout.h"
 #include "games/controllers/ControllerManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "peripherals/Peripherals.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -44,7 +45,8 @@ bool CPeripheralBusApplication::PerformDeviceScan(PeripheralScanResults& results
   {
     PeripheralScanResult result(Type());
     result.m_type = PERIPHERAL_KEYBOARD;
-    result.m_strDeviceName = g_localizeStrings.Get(35150); // "Keyboard"
+    result.m_strDeviceName =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35150); // "Keyboard"
     result.m_strLocation = PeripheralTypeTranslator::TypeToString(PERIPHERAL_KEYBOARD);
     result.m_iVendorId = 0;
     result.m_iProductId = 0;
@@ -67,7 +69,8 @@ bool CPeripheralBusApplication::PerformDeviceScan(PeripheralScanResults& results
   {
     PeripheralScanResult result(Type());
     result.m_type = PERIPHERAL_MOUSE;
-    result.m_strDeviceName = g_localizeStrings.Get(35171); // "Mouse"
+    result.m_strDeviceName =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35171); // "Mouse"
     result.m_strLocation = PeripheralTypeTranslator::TypeToString(PERIPHERAL_MOUSE);
     result.m_iVendorId = 0;
     result.m_iProductId = 0;

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -17,7 +17,6 @@
 #include "games/controllers/Controller.h"
 #include "games/controllers/ControllerLayout.h"
 #include "games/controllers/ControllerManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/joysticks/interfaces/IInputHandler.h"
 #include "input/keyboard/generic/DefaultKeyboardHandling.h"
 #include "input/mouse/generic/DefaultMouseHandling.h"

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -17,7 +17,6 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "input/remote/IRRemote.h"
@@ -25,6 +24,8 @@
 #include "jobs/JobManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "pictures/GUIWindowSlideShow.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
@@ -262,10 +263,11 @@ bool CPeripheralCecAdapter::InitialiseFeature(const PeripheralFeature feature)
 
       // display warning: incompatible libCEC
       std::string strMessage = StringUtils::Format(
-          g_localizeStrings.Get(36040), m_cecAdapter ? m_configuration.serverVersion : -1,
-          CEC_LIB_SUPPORTED_VERSION);
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(36000),
-                                            strMessage);
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36040),
+          m_cecAdapter ? m_configuration.serverVersion : -1, CEC_LIB_SUPPORTED_VERSION);
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Error,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36000), strMessage);
       m_bError = true;
       if (m_cecAdapter)
         CECDestroy(m_cecAdapter);
@@ -320,9 +322,11 @@ bool CPeripheralCecAdapter::OpenConnection(void)
   // scanning the CEC bus takes about 5 seconds, so display a notification to inform users that
   // we're busy
   std::string strMessage =
-      StringUtils::Format(g_localizeStrings.Get(21336), g_localizeStrings.Get(36000));
-  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(36000),
-                                        strMessage);
+      StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21336),
+                          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36000));
+  CGUIDialogKaiToast::QueueNotification(
+      CGUIDialogKaiToast::Info,
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36000), strMessage);
 
   bool bConnectionFailedDisplayed(false);
 
@@ -334,7 +338,9 @@ bool CPeripheralCecAdapter::OpenConnection(void)
       CLog::Log(LOGERROR, "{} - could not opening a connection to the CEC adapter", __FUNCTION__);
       if (!bConnectionFailedDisplayed)
         CGUIDialogKaiToast::QueueNotification(
-            CGUIDialogKaiToast::Error, g_localizeStrings.Get(36000), g_localizeStrings.Get(36012));
+            CGUIDialogKaiToast::Error,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36000),
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36012));
       bConnectionFailedDisplayed = true;
 
       CThread::Sleep(10000ms);
@@ -775,11 +781,13 @@ void CPeripheralCecAdapter::CecAlert(void* cbParam,
   // display the alert
   if (iAlertString)
   {
-    std::string strLog(g_localizeStrings.Get(iAlertString));
+    std::string strLog(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(iAlertString));
     if (data.paramType == CEC_PARAMETER_TYPE_STRING && data.paramData)
       strLog += StringUtils::Format(" - {}", (const char*)data.paramData);
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(36000),
-                                          strLog);
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Info,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36000), strLog);
   }
 
   if (bReopenConnection)
@@ -1658,7 +1666,8 @@ bool CPeripheralCecAdapterUpdateThread::SetInitialConfiguration(void)
   // request the OSD name of the TV
   std::string strNotification;
   std::string tvName(m_adapter->m_cecAdapter->GetDeviceOSDName(CECDEVICE_TV));
-  strNotification = StringUtils::Format("{}: {}", g_localizeStrings.Get(36016), tvName);
+  strNotification = StringUtils::Format(
+      "{}: {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36016), tvName);
 
   std::string strAmpName = UpdateAudioSystemStatus();
   if (!strAmpName.empty())
@@ -1667,8 +1676,9 @@ bool CPeripheralCecAdapterUpdateThread::SetInitialConfiguration(void)
   m_adapter->m_bIsReady = true;
 
   // and let the gui know that we're done
-  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(36000),
-                                        strNotification);
+  CGUIDialogKaiToast::QueueNotification(
+      CGUIDialogKaiToast::Info,
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36000), strNotification);
 
   std::unique_lock lock(m_critSection);
   m_bIsUpdating = false;
@@ -1715,8 +1725,11 @@ void CPeripheralCecAdapterUpdateThread::Process(void)
         UpdateAudioSystemStatus();
       }
 
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(36000),
-                                            g_localizeStrings.Get(bConfigSet ? 36023 : 36024));
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Info,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36000),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(bConfigSet ? 36023
+                                                                                      : 36024));
 
       {
         std::unique_lock lock(m_critSection);

--- a/xbmc/peripherals/devices/PeripheralDisk.cpp
+++ b/xbmc/peripherals/devices/PeripheralDisk.cpp
@@ -8,7 +8,9 @@
 
 #include "PeripheralDisk.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 using namespace PERIPHERALS;
 
@@ -17,7 +19,8 @@ CPeripheralDisk::CPeripheralDisk(CPeripherals& manager,
                                  CPeripheralBus* bus)
   : CPeripheral(manager, scanResult, bus)
 {
-  m_strDeviceName = scanResult.m_strDeviceName.empty() ? g_localizeStrings.Get(35003)
-                                                       : scanResult.m_strDeviceName;
+  m_strDeviceName = scanResult.m_strDeviceName.empty()
+                        ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35003)
+                        : scanResult.m_strDeviceName;
   m_features.push_back(FEATURE_DISK);
 }

--- a/xbmc/peripherals/devices/PeripheralHID.cpp
+++ b/xbmc/peripherals/devices/PeripheralHID.cpp
@@ -8,9 +8,11 @@
 
 #include "PeripheralHID.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "input/InputManager.h"
 #include "peripherals/Peripherals.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/log.h"
 
 using namespace PERIPHERALS;
@@ -20,8 +22,9 @@ CPeripheralHID::CPeripheralHID(CPeripherals& manager,
                                CPeripheralBus* bus)
   : CPeripheral(manager, scanResult, bus)
 {
-  m_strDeviceName = scanResult.m_strDeviceName.empty() ? g_localizeStrings.Get(35001)
-                                                       : scanResult.m_strDeviceName;
+  m_strDeviceName = scanResult.m_strDeviceName.empty()
+                        ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35001)
+                        : scanResult.m_strDeviceName;
   m_features.push_back(FEATURE_HID);
 }
 

--- a/xbmc/peripherals/devices/PeripheralNIC.cpp
+++ b/xbmc/peripherals/devices/PeripheralNIC.cpp
@@ -8,7 +8,9 @@
 
 #include "PeripheralNIC.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 using namespace PERIPHERALS;
 
@@ -17,7 +19,8 @@ CPeripheralNIC::CPeripheralNIC(CPeripherals& manager,
                                CPeripheralBus* bus)
   : CPeripheral(manager, scanResult, bus)
 {
-  m_strDeviceName = scanResult.m_strDeviceName.empty() ? g_localizeStrings.Get(35002)
-                                                       : scanResult.m_strDeviceName;
+  m_strDeviceName = scanResult.m_strDeviceName.empty()
+                        ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35002)
+                        : scanResult.m_strDeviceName;
   m_features.push_back(FEATURE_NIC);
 }

--- a/xbmc/pictures/GUIDialogPictureInfo.cpp
+++ b/xbmc/pictures/GUIDialogPictureInfo.cpp
@@ -14,10 +14,11 @@
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 #include <array>
 
@@ -148,7 +149,8 @@ void CGUIDialogPictureInfo::UpdatePictureInfo()
         CServiceBroker::GetGUI()->GetInfoManager().GetLabel(info, INFO::DEFAULT_CONTEXT);
     if (!picInfo.empty())
     {
-      auto item{std::make_shared<CFileItem>(g_localizeStrings.Get(code))};
+      auto item{std::make_shared<CFileItem>(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(code))};
       item->SetLabel2(picInfo);
       m_pictureInfo->Add(item);
     }

--- a/xbmc/pictures/GUIViewStatePictures.cpp
+++ b/xbmc/pictures/GUIViewStatePictures.cpp
@@ -12,7 +12,6 @@
 #include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "filesystem/Directory.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -23,7 +23,6 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUILabelControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/Texture.h"
 #include "imagefiles/ImageFileURL.h"
 #include "input/actions/Action.h"
@@ -35,6 +34,8 @@
 #include "pictures/SlideShowDelegator.h"
 #include "playlists/PlayListTypes.h"
 #include "rendering/RenderSystem.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -1022,7 +1023,11 @@ void CGUIWindowSlideShow::RenderErrorMessage()
   }
 
   CGUIFont *pFont = static_cast<const CGUILabelControl*>(control)->GetLabelInfo().font;
-  CGUITextLayout::DrawText(pFont, 0.5f*CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(), 0.5f*CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight(), 0xffffffff, 0, g_localizeStrings.Get(747), XBFONT_CENTER_X | XBFONT_CENTER_Y);
+  CGUITextLayout::DrawText(pFont, 0.5f * CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth(),
+                           0.5f * CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight(),
+                           0xffffffff, 0,
+                           CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(747),
+                           XBFONT_CENTER_X | XBFONT_CENTER_Y);
 }
 
 bool CGUIWindowSlideShow::OnMessage(CGUIMessage& message)

--- a/xbmc/platform/android/storage/AndroidStorageProvider.cpp
+++ b/xbmc/platform/android/storage/AndroidStorageProvider.cpp
@@ -8,10 +8,12 @@
 
 #include "AndroidStorageProvider.h"
 
+#include "ServiceBroker.h"
 #include "Util.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -134,14 +136,14 @@ void CAndroidStorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDri
   if (GetExternalStorage(path) && !path.empty() && XFILE::CDirectory::Exists(path))
   {
     share.strPath = path;
-    share.strName = g_localizeStrings.Get(21456);
+    share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21456);
     share.m_ignore = true;
     localDrives.push_back(share);
   }
 
   // root directory
   share.strPath = "/";
-  share.strName = g_localizeStrings.Get(21453);
+  share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21453);
   localDrives.push_back(share);
 }
 

--- a/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.mm
+++ b/xbmc/platform/darwin/ios-common/storage/IOSStorageProvider.mm
@@ -8,7 +8,9 @@
 
 #include "IOSStorageProvider.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 #import <Foundation/Foundation.h>
@@ -24,7 +26,7 @@ void CIOSStorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDrives)
 
   // User home folder
   share.strPath = "special://envhome/";
-  share.strName = g_localizeStrings.Get(21440);
+  share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21440);
   share.m_ignore = true;
   localDrives.push_back(share);
 
@@ -48,8 +50,9 @@ std::vector<std::string> CIOSStorageProvider::GetDiskUsage()
   for (const auto& pair :
        {std::make_pair(NSFileSystemFreeSize, 160), std::make_pair(NSFileSystemSize, 20161)})
     if (auto sizeStr = [formatter stringForObjectValue:fileSystemAttributes[pair.first]])
-      result.push_back(
-          StringUtils::Format("{}: {}", g_localizeStrings.Get(pair.second), sizeStr.UTF8String));
+      result.push_back(StringUtils::Format(
+          "{}: {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(pair.second),
+          sizeStr.UTF8String));
 
   return result;
 }

--- a/xbmc/platform/darwin/ios/IOSExternalTouchController.mm
+++ b/xbmc/platform/darwin/ios/IOSExternalTouchController.mm
@@ -8,11 +8,13 @@
 
 #import "IOSExternalTouchController.h"
 
+#include "ServiceBroker.h"
 #include "Util.h"
 #import "XBMCController.h"
 #include "filesystem/SpecialProtocol.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/mouse/MouseStat.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 //dim the touchscreen after 15 secs without touch event
 const CGFloat touchScreenDimTimeoutSecs       = 15.0;
@@ -70,11 +72,12 @@ const CGFloat timeFadeSecs                    = 2.0;
     [descriptionLabel setLineBreakMode:(NSLineBreakMode)NSLineBreakByTruncatingTail];
 
     [descriptionLabel setNumberOfLines:5];
-    std::string descText    = g_localizeStrings.Get(34404) + "\n";
-    descText              += g_localizeStrings.Get(34405) + "\n";
-    descText              += g_localizeStrings.Get(34406) + "\n";
-    descText              += g_localizeStrings.Get(34407) + "\n";
-    descText              += g_localizeStrings.Get(34408) + "\n";
+    std::string descText =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34404) + "\n";
+    descText += CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34405) + "\n";
+    descText += CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34406) + "\n";
+    descText += CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34407) + "\n";
+    descText += CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(34408) + "\n";
 
     NSString *stringFromUTFString = [[NSString alloc] initWithUTF8String:descText.c_str()];
 

--- a/xbmc/platform/darwin/osx/storage/OSXStorageProvider.mm
+++ b/xbmc/platform/darwin/osx/storage/OSXStorageProvider.mm
@@ -8,8 +8,10 @@
 
 #include "OSXStorageProvider.h"
 
+#include "ServiceBroker.h"
 #include "Util.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/RegExp.h"
 
 #include "platform/darwin/osx/CocoaInterface.h"
@@ -41,7 +43,7 @@ void COSXStorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDrives)
 
   // User home folder
   share.strPath = getenv("HOME");
-  share.strName = g_localizeStrings.Get(21440);
+  share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21440);
   share.m_ignore = true;
   localDrives.push_back(share);
 
@@ -236,7 +238,7 @@ std::vector<std::string> COSXStorageProvider::GetDiskUsage()
         [volumeURL getResourceValue:&spaceTotal forKey:NSURLVolumeTotalCapacityKey error:nullptr];
 
         line2.append(StringUtils::Format(
-            "{}: {} / {}", g_localizeStrings.Get(160),
+            "{}: {} / {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(160),
             [byteFormatter stringForObjectValue:spaceAvailable].UTF8String ?: "-",
             [byteFormatter stringForObjectValue:spaceTotal].UTF8String ?: "-"));
       }

--- a/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
+++ b/xbmc/platform/darwin/tvos/TVOSTopShelf.mm
@@ -15,8 +15,9 @@
 #include "application/Application.h"
 #include "filesystem/File.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/ApplicationMessenger.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "tvosShared.h"
 #include "utils/Base64.h"
 #include "utils/StringUtils.h"
@@ -158,8 +159,10 @@ void CTVOSTopShelf::SetTopShelfItems(CFileItemList& items, TVOSTopShelfItemsCate
     {
       case TVOSTopShelfItemsCategory::MOVIES:
         fillSharedDicts(
-            items, @"movies", @(g_localizeStrings.Get(20386).c_str()),
-            [](const CFileItemPtr& videoItem) {
+            items, @"movies",
+            @(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20386).c_str()),
+            [](const CFileItemPtr& videoItem)
+            {
               if (videoItem->HasArt("poster"))
                 return videoItem->GetArt("poster");
               else
@@ -171,7 +174,8 @@ void CTVOSTopShelf::SetTopShelfItems(CFileItemList& items, TVOSTopShelfItemsCate
         CVideoDatabase videoDb;
         videoDb.Open();
         fillSharedDicts(
-            items, @"tvshows", @(g_localizeStrings.Get(20387).c_str()),
+            items, @"tvshows",
+            @(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20387).c_str()),
             [&videoDb](const CFileItemPtr& videoItem)
             {
               int season = videoItem->GetVideoInfoTag()->m_iIdSeason;

--- a/xbmc/platform/linux/storage/LinuxStorageProvider.cpp
+++ b/xbmc/platform/linux/storage/LinuxStorageProvider.cpp
@@ -7,8 +7,11 @@
  */
 
 #include "LinuxStorageProvider.h"
-#include "guilib/LocalizeStrings.h"
+
+#include "ServiceBroker.h"
 #include "UDevProvider.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #ifdef HAS_DBUS
 #include "UDisksProvider.h"
 #include "UDisks2Provider.h"
@@ -59,12 +62,12 @@ void CLinuxStorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDrive
   // Home directory
   CMediaSource share;
   share.strPath = getenv("HOME");
-  share.strName = g_localizeStrings.Get(21440);
+  share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21440);
   share.m_ignore = true;
   share.m_iDriveType = SourceType::LOCAL;
   localDrives.push_back(share);
   share.strPath = "/";
-  share.strName = g_localizeStrings.Get(21453);
+  share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21453);
   localDrives.push_back(share);
 
   m_instance->GetLocalDrives(localDrives);

--- a/xbmc/platform/linux/storage/UDisks2Provider.cpp
+++ b/xbmc/platform/linux/storage/UDisks2Provider.cpp
@@ -8,7 +8,8 @@
 #include "UDisks2Provider.h"
 
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -172,7 +173,8 @@ std::string CUDisks2Provider::Filesystem::GetDisplayName() const
   if (m_block->m_label.empty())
   {
     std::string strSize = StringUtils::SizeToString(m_block->m_size);
-    return StringUtils::Format("{} {}", strSize, g_localizeStrings.Get(155));
+    return StringUtils::Format(
+        "{} {}", strSize, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(155));
   }
   else
     return m_block->m_label;

--- a/xbmc/platform/linux/storage/UDisksProvider.cpp
+++ b/xbmc/platform/linux/storage/UDisksProvider.cpp
@@ -8,7 +8,8 @@
 #include "UDisksProvider.h"
 
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -130,7 +131,8 @@ CMediaSource CUDiskDevice::ToMediaShare() const
   if (m_Label.empty())
   {
     std::string strSize = StringUtils::SizeToString(m_PartitionSize);
-    source.strName = StringUtils::Format("{} {}", strSize, g_localizeStrings.Get(155));
+    source.strName = StringUtils::Format(
+        "{} {}", strSize, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(155));
   }
   else
     source.strName = m_Label;

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -23,7 +23,8 @@
 #include "FileItemList.h"
 #include "PasswordManager.h"
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -276,7 +277,9 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
     }
 
     if (errno == ENODEV || errno == ENOENT)
-      cError = fmt::format(fmt::runtime(g_localizeStrings.Get(770)), errno);
+      cError = fmt::format(
+          fmt::runtime(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(770)),
+          errno);
     else
       cError = strerror(errno);
 

--- a/xbmc/platform/win10/storage/Win10StorageProvider.cpp
+++ b/xbmc/platform/win10/storage/Win10StorageProvider.cpp
@@ -9,7 +9,8 @@
 
 #include "ServiceBroker.h"
 #include "filesystem/SpecialProtocol.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -70,7 +71,7 @@ void CStorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDrives)
 {
   CMediaSource share;
   share.strPath = CSpecialProtocol::TranslatePath("special://home");
-  share.strName = g_localizeStrings.Get(21440);
+  share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21440);
   share.m_ignore = true;
   share.m_iDriveType = SourceType::LOCAL;
   localDrives.push_back(share);
@@ -148,8 +149,10 @@ std::vector<std::string> CStorageProvider::GetDiskUsage()
 
   auto localfolder = winrt::Windows::Storage::ApplicationData::Current().LocalFolder().Path();
   GetDiskFreeSpaceExW(localfolder.c_str(), nullptr, &ULTotal, &ULTotalFree);
-  strRet = StringUtils::Format("{}: {} MB {}", g_localizeStrings.Get(21440),
-                               (ULTotalFree.QuadPart / (1024 * 1024)), g_localizeStrings.Get(160));
+  strRet = StringUtils::Format(
+      "{}: {} MB {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21440),
+      (ULTotalFree.QuadPart / (1024 * 1024)),
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(160));
   result.push_back(strRet);
 
   DWORD drivesBits = GetLogicalDrives();
@@ -169,9 +172,9 @@ std::vector<std::string> CStorageProvider::GetDiskUsage()
     if (DRIVE_FIXED == GetDriveTypeA(strDrive.c_str())
       && GetDiskFreeSpaceExA((strDrive.c_str()), nullptr, &ULTotal, &ULTotalFree))
     {
-      strRet =
-          StringUtils::Format("{} {} MB {}", strDrive, int(ULTotalFree.QuadPart / (1024 * 1024)),
-                              g_localizeStrings.Get(160));
+      strRet = StringUtils::Format(
+          "{} {} MB {}", strDrive, int(ULTotalFree.QuadPart / (1024 * 1024)),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(160));
       result.push_back(strRet);
     }
   }
@@ -242,11 +245,15 @@ void CStorageProvider::GetDrivesByType(std::vector<CMediaSource>& localDrives,
       switch (uDriveType)
       {
       case DRIVE_CDROM:
-        share.strName = StringUtils::Format("{} ({})", share.strPath, g_localizeStrings.Get(218));
+        share.strName = StringUtils::Format(
+            "{} ({})", share.strPath,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(218));
         break;
       case DRIVE_REMOVABLE:
         if (share.strName.empty())
-          share.strName = StringUtils::Format("{} ({})", g_localizeStrings.Get(437), share.strPath);
+          share.strName = StringUtils::Format(
+              "{} ({})", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(437),
+              share.strPath);
         break;
       default:
         if (share.strName.empty())

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -13,7 +13,6 @@
 #include "Util.h"
 #include "WindowHelper.h"
 #include "application/AppParams.h"
-#include "guilib/LocalizeStrings.h"
 #include "my_ntddscsi.h"
 #include "rendering/dx/DirectXHelper.h"
 #include "storage/MediaManager.h"

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -9,8 +9,9 @@
 
 #include "ServiceBroker.h"
 #include "filesystem/SpecialProtocol.h"
-#include "guilib/LocalizeStrings.h"
 #include "jobs/JobManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -57,7 +58,7 @@ void CWin32StorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDrive
     share.strPath = KODI::PLATFORM::WINDOWS::FromW(profilePath);
   else
     share.strPath = CSpecialProtocol::TranslatePath("special://home");
-  share.strName = g_localizeStrings.Get(21440);
+  share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21440);
   share.m_ignore = true;
   share.m_iDriveType = SourceType::LOCAL;
   localDrives.push_back(share);
@@ -157,9 +158,10 @@ std::vector<std::string > CWin32StorageProvider::GetDiskUsage()
       if( DRIVE_FIXED == GetDriveType( strDrive.c_str()  ) &&
         GetDiskFreeSpaceEx( ( strDrive.c_str() ), nullptr, &ULTotal, &ULTotalFree ) )
       {
-        strRet = KODI::PLATFORM::WINDOWS::FromW(
-            StringUtils::Format(L"{} {} MB {}", strDrive, int(ULTotalFree.QuadPart / (1024 * 1024)),
-                                KODI::PLATFORM::WINDOWS::ToW(g_localizeStrings.Get(160))));
+        strRet = KODI::PLATFORM::WINDOWS::FromW(StringUtils::Format(
+            L"{} {} MB {}", strDrive, int(ULTotalFree.QuadPart / (1024 * 1024)),
+            KODI::PLATFORM::WINDOWS::ToW(
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(160))));
         result.push_back(strRet);
       }
       iPos += (wcslen( pcBuffer.get() + iPos) + 1 );
@@ -260,13 +262,15 @@ void CWin32StorageProvider::GetDrivesByType(std::vector<CMediaSource>& localDriv
           switch(uDriveType)
           {
           case DRIVE_CDROM:
-            share.strName =
-                StringUtils::Format("{} ({})", share.strPath, g_localizeStrings.Get(218));
+            share.strName = StringUtils::Format(
+                "{} ({})", share.strPath,
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(218));
             break;
           case DRIVE_REMOVABLE:
             if(share.strName.empty())
-              share.strName =
-                  StringUtils::Format("{} ({})", g_localizeStrings.Get(437), share.strPath);
+              share.strName = StringUtils::Format(
+                  "{} ({})", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(437),
+                  share.strPath);
             break;
           default:
             if(share.strName.empty())
@@ -390,7 +394,7 @@ bool CDetectDisc::DoWork()
   if (CServiceBroker::GetMediaManager().IsAudio(share.strPath))
     share.strStatus = "Audio-CD";
   else if(share.strStatus == "")
-    share.strStatus = g_localizeStrings.Get(446);
+    share.strStatus = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(446);
   share.strName = share.strPath;
   share.m_ignore = true;
   share.m_iDriveType = SourceType::OPTICAL_DISC;

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -14,7 +14,8 @@
 #include "dbwrappers/Database.h"
 #include "filesystem/File.h"
 #include "filesystem/SmartPlaylistDirectory.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/DatabaseUtils.h"
@@ -228,8 +229,9 @@ std::string CSmartPlaylistRule::TranslateGroup(Field group)
 std::string CSmartPlaylistRule::GetLocalizedField(int field)
 {
   for (const translateField& f : fields)
-    if (field == f.field) return g_localizeStrings.Get(f.localizedString);
-  return g_localizeStrings.Get(16018);
+    if (field == f.field)
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(f.localizedString);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16018);
 }
 
 CDatabaseQueryRule::FieldType CSmartPlaylistRule::GetFieldType(int field) const
@@ -783,10 +785,11 @@ std::string CSmartPlaylistRule::GetLocalizedGroup(Field group)
   for (const auto & i : groups)
   {
     if (group == i.field)
-      return g_localizeStrings.Get(i.localizedString);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(i.localizedString);
   }
 
-  return g_localizeStrings.Get(groups[0].localizedString);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      groups[0].localizedString);
 }
 
 bool CSmartPlaylistRule::CanGroupMix(Field group)

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -24,10 +24,11 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
 #include "network/Network.h"
 #include "pvr/PVRManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -257,7 +258,9 @@ void CPowerManager::OnLowBattery()
 {
   CLog::Log(LOGINFO, "{}: Running low battery jobs", __FUNCTION__);
 
-  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13050), "");
+  CGUIDialogKaiToast::QueueNotification(
+      CGUIDialogKaiToast::Warning,
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13050), "");
 
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::System, "OnLowBattery");
 }
@@ -309,16 +312,21 @@ void CPowerManager::SettingOptionsShutdownStatesFiller(const SettingConstPtr& se
                                                        int& current)
 {
   if (CServiceBroker::GetPowerManager().CanPowerdown())
-    list.emplace_back(g_localizeStrings.Get(13005), POWERSTATE_SHUTDOWN);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13005),
+                      POWERSTATE_SHUTDOWN);
   if (CServiceBroker::GetPowerManager().CanHibernate())
-    list.emplace_back(g_localizeStrings.Get(13010), POWERSTATE_HIBERNATE);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13010),
+                      POWERSTATE_HIBERNATE);
   if (CServiceBroker::GetPowerManager().CanSuspend())
-    list.emplace_back(g_localizeStrings.Get(13011), POWERSTATE_SUSPEND);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13011),
+                      POWERSTATE_SUSPEND);
   if (!CServiceBroker::GetAppParams()->IsStandAlone())
   {
-    list.emplace_back(g_localizeStrings.Get(13009), POWERSTATE_QUIT);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13009),
+                      POWERSTATE_QUIT);
 #if !defined(TARGET_DARWIN_EMBEDDED)
-    list.emplace_back(g_localizeStrings.Get(13014), POWERSTATE_MINIMIZE);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13014),
+                      POWERSTATE_MINIMIZE);
 #endif
   }
 }

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -33,7 +33,6 @@
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h" //! @todo Remove me
 #include "input/InputManager.h"
 #include "interfaces/json-rpc/JSONRPC.h" //! @todo Remove me
@@ -41,6 +40,8 @@
 #include "network/Network.h" //! @todo Remove me
 #include "network/NetworkServices.h" //! @todo Remove me
 #include "pvr/PVRManager.h" //! @todo Remove me
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/SettingsManager.h"
@@ -463,7 +464,10 @@ void CProfileManager::LogOff()
   CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_LOGIN_SCREEN, {}, false);
 
   if (!CServiceBroker::GetNetwork().GetServices().StartEventServer()) // event server could be needed in some situations
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(33102), g_localizeStrings.Get(33100));
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Warning,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(33102),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(33100));
 }
 
 bool CProfileManager::DeleteProfile(unsigned int index)

--- a/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogLockSettings.cpp
@@ -17,7 +17,8 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingSection.h"
 #include "settings/windows/GUIControlSettings.h"
@@ -156,10 +157,10 @@ void CGUIDialogLockSettings::OnSettingAction(const std::shared_ptr<const CSettin
 
     dialog->Reset();
     dialog->SetHeading(CVariant{12360});
-    dialog->Add(g_localizeStrings.Get(1223));
-    dialog->Add(g_localizeStrings.Get(12337));
-    dialog->Add(g_localizeStrings.Get(12338));
-    dialog->Add(g_localizeStrings.Get(12339));
+    dialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1223));
+    dialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12337));
+    dialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12338));
+    dialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12339));
     dialog->SetSelected(GetLockModeLabel());
     dialog->Open();
 
@@ -221,7 +222,9 @@ void CGUIDialogLockSettings::SetupView()
 
   // set the title
   if (m_getUser)
-    SetHeading(StringUtils::Format(g_localizeStrings.Get(20152), CURL::Decode(m_url)));
+    SetHeading(
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20152),
+                            CURL::Decode(m_url)));
   else
   {
     SetHeading(20066);
@@ -294,7 +297,7 @@ void CGUIDialogLockSettings::InitializeSettings()
 
 std::string CGUIDialogLockSettings::GetLockModeLabel()
 {
-  return g_localizeStrings.Get(
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
       m_locks.mode == LockMode::EVERYONE ? 1223 : 12336 + static_cast<int>(m_locks.mode));
 }
 

--- a/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
+++ b/xbmc/profiles/dialogs/GUIDialogProfileSettings.cpp
@@ -20,9 +20,10 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogLockSettings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "settings/windows/GUIControlSettings.h"
@@ -82,7 +83,11 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
 
     // prompt for a name
     std::string profileName;
-    if (!CGUIKeyboardFactory::ShowAndGetInput(profileName, CVariant{g_localizeStrings.Get(20093)}, false) || profileName.empty())
+    if (!CGUIKeyboardFactory::ShowAndGetInput(
+            profileName,
+            CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20093)},
+            false) ||
+        profileName.empty())
       return false;
     dialog->m_name = profileName;
 
@@ -127,7 +132,7 @@ bool CGUIDialogProfileSettings::ShowForProfile(unsigned int iProfile, bool first
         return false;
 
       /*std::string strLabel;
-      strLabel.Format(g_localizeStrings.Get(20047),dialog->m_strName);
+      strLabel.Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20047),dialog->m_strName);
       if (!CGUIDialogYesNo::ShowAndGetInput(20058, strLabel, dialog->m_strDirectory, ""))
       {
         CDirectory::Remove(URIUtils::AddFileToFolder(profileManager.GetUserDataFolder(), dialog->m_strDirectory));
@@ -236,17 +241,19 @@ void CGUIDialogProfileSettings::OnSettingAction(const std::shared_ptr<const CSet
     {
       CFileItemPtr item(new CFileItem("thumb://Current", false));
       item->SetArt("thumb", m_thumb);
-      item->SetLabel(g_localizeStrings.Get(20016));
+      item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20016));
       items.Add(item);
     }
 
     CFileItemPtr item(new CFileItem("thumb://None", false));
     item->SetArt("thumb", "DefaultUser.png");
-    item->SetLabel(g_localizeStrings.Get(20018));
+    item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20018));
     items.Add(item);
 
     std::string thumb;
-    if (CGUIDialogFileBrowser::ShowAndGetImage(items, shares, g_localizeStrings.Get(1030), thumb) &&
+    if (CGUIDialogFileBrowser::ShowAndGetImage(
+            items, shares, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1030),
+            thumb) &&
         !StringUtils::EqualsNoCase(thumb, "thumb://Current"))
     {
       m_needsSaving = true;
@@ -368,7 +375,7 @@ bool CGUIDialogProfileSettings::GetProfilePath(std::string &directory, bool isDe
 {
   std::vector<CMediaSource> shares;
   CMediaSource share;
-  share.strName = g_localizeStrings.Get(13200);
+  share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13200);
   share.strPath = "special://masterprofile/profiles/";
   shares.push_back(share);
 
@@ -378,7 +385,9 @@ bool CGUIDialogProfileSettings::GetProfilePath(std::string &directory, bool isDe
   else
     strDirectory = URIUtils::AddFileToFolder("special://masterprofile/", directory);
 
-  if (!CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(657), strDirectory, true))
+  if (!CGUIDialogFileBrowser::ShowAndGetDirectory(
+          shares, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(657),
+          strDirectory, true))
     return false;
 
   directory = strDirectory;

--- a/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
+++ b/xbmc/profiles/windows/GUIWindowSettingsProfile.cpp
@@ -17,13 +17,14 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "profiles/Profile.h"
 #include "profiles/ProfileManager.h"
 #include "profiles/dialogs/GUIDialogProfileSettings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -75,8 +76,9 @@ void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
     // Reload of active profile?
     if (iItem == static_cast<int>(profileManager->GetCurrentProfileIndex()))
     {
-      const std::string msg{StringUtils::Format(g_localizeStrings.Get(13202),
-                                                profileManager->GetProfile(iItem)->getName())};
+      const std::string msg{StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13202),
+          profileManager->GetProfile(iItem)->getName())};
       using namespace KODI::MESSAGING::HELPERS;
       if (ShowYesNoDialogText(CVariant{13200} /* Profiles */, CVariant{msg} /* Reload profile?*/) !=
           DialogResponse::CHOICE_YES)
@@ -88,8 +90,9 @@ void CGUIWindowSettingsProfile::OnPopupMenu(int iItem)
 
   if (choice == 2)
   {
-    const std::string msg{StringUtils::Format(g_localizeStrings.Get(13201),
-                                              profileManager->GetProfile(iItem)->getName())};
+    const std::string msg{
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13201),
+                            profileManager->GetProfile(iItem)->getName())};
     using namespace KODI::MESSAGING::HELPERS;
     if (ShowYesNoDialogText(CVariant{13200} /* Profiles */, CVariant{msg} /* Delete profile?*/) !=
         DialogResponse::CHOICE_YES)
@@ -219,7 +222,8 @@ void CGUIWindowSettingsProfile::LoadList()
     m_listItems->Add(item);
   }
   {
-    CFileItemPtr item(new CFileItem(g_localizeStrings.Get(20058)));
+    CFileItemPtr item(
+        new CFileItem(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20058)));
     m_listItems->Add(item);
   }
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_PROFILES, 0, 0, m_listItems);
@@ -261,15 +265,16 @@ bool CGUIWindowSettingsProfile::GetAutoLoginProfileChoice(int &iProfile)
   int autoLoginProfileId = profileManager->GetAutoLoginProfileId() + 1;
   CFileItemList items;
   CFileItemPtr item(new CFileItem());
-  item->SetLabel(g_localizeStrings.Get(37014)); // Last used profile
+  item->SetLabel(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37014)); // Last used profile
   item->SetArt("icon", "DefaultUser.png");
   items.Add(item);
 
   for (unsigned int i = 0; i < profileManager->GetNumberOfProfiles(); i++)
   {
     const CProfile *profile = profileManager->GetProfile(i);
-    const std::string& locked =
-        g_localizeStrings.Get(static_cast<int>(profile->getLockMode()) > 0 ? 20166 : 20165);
+    const std::string& locked = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        static_cast<int>(profile->getLockMode()) > 0 ? 20166 : 20165);
     CFileItemPtr item(new CFileItem(profile->getName()));
     item->SetLabel2(locked); // lock setting
     std::string thumb = profile->getThumb();

--- a/xbmc/programs/GUIViewStatePrograms.cpp
+++ b/xbmc/programs/GUIViewStatePrograms.cpp
@@ -12,9 +12,10 @@
 #include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "filesystem/Directory.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/TextureManager.h"
 #include "guilib/WindowIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -57,7 +58,7 @@ std::vector<CMediaSource>& CGUIViewStateWindowPrograms::GetSources()
   {
     CMediaSource source;
     source.strPath = "androidapp://sources/apps/";
-    source.strName = g_localizeStrings.Get(20244);
+    source.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20244);
     if (CServiceBroker::GetGUI()->GetTextureManager().HasTexture("DefaultProgram.png"))
       source.m_strThumbnailImage = "DefaultProgram.png";
     source.m_iDriveType = SourceType::LOCAL;

--- a/xbmc/pvr/PVRContextMenus.cpp
+++ b/xbmc/pvr/PVRContextMenus.cpp
@@ -11,7 +11,6 @@
 #include "ContextMenuItem.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/addons/PVRClientMenuHooks.h"
@@ -30,6 +29,8 @@
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
 #include "pvr/timers/PVRTimersPath.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/URIUtils.h"
@@ -140,9 +141,11 @@ std::string PlayEpgTagFromHere::GetLabel(const CFileItem& item) const
 {
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
           CSettings::SETTING_PVRPLAYBACK_AUTOPLAYNEXTPROGRAMME))
-    return g_localizeStrings.Get(19354); /* Play only this programme */
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        19354); /* Play only this programme */
 
-  return g_localizeStrings.Get(19353); /* Play programmes from here */
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      19353); /* Play programmes from here */
 }
 
 bool PlayEpgTagFromHere::IsVisible(const CFileItem& item) const
@@ -194,9 +197,11 @@ bool PlayRecording::Execute(const CFileItemPtr& item) const
 std::string ShowInformation::GetLabel(const CFileItem& item) const
 {
   if (item.GetPVRRecordingInfoTag())
-    return g_localizeStrings.Get(19053); /* Recording Information */
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        19053); /* Recording Information */
 
-  return g_localizeStrings.Get(19047); /* Programme information */
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      19047); /* Programme information */
 }
 
 bool ShowInformation::IsVisible(const CFileItem& item) const
@@ -386,12 +391,14 @@ std::string DeleteRecording::GetLabel(const CFileItem& item) const
 {
   const std::shared_ptr<const CPVRRecording> recording{item.GetPVRRecordingInfoTag()};
   if (recording && recording->IsDeleted())
-    return g_localizeStrings.Get(19291); // Delete permanently
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        19291); // Delete permanently
 
   if (recording || item.IsFolder())
-    return g_localizeStrings.Get(117); // Delete
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(117); // Delete
 
-  return g_localizeStrings.Get(19357); // Delete recording
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      19357); // Delete recording
 }
 
 bool DeleteRecording::IsVisible(const CFileItem& item) const
@@ -483,9 +490,9 @@ std::string ToggleTimerState::GetLabel(const CFileItem& item) const
 {
   const std::shared_ptr<const CPVRTimerInfoTag> timer(item.GetPVRTimerInfoTag());
   if (timer && !timer->IsDisabled())
-    return g_localizeStrings.Get(844); /* Deactivate */
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(844); /* Deactivate */
 
-  return g_localizeStrings.Get(843); /* Activate */
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(843); /* Activate */
 }
 
 bool ToggleTimerState::IsVisible(const CFileItem& item) const
@@ -531,11 +538,13 @@ std::string EditTimerRule::GetLabel(const CFileItem& item) const
     if (parentTimer)
     {
       if (!parentTimer->GetTimerType()->IsReadOnly())
-        return g_localizeStrings.Get(19243); /* Edit timer rule */
+        return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            19243); /* Edit timer rule */
     }
   }
 
-  return g_localizeStrings.Get(19304); /* View timer rule */
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+      19304); /* View timer rule */
 }
 
 bool EditTimerRule::IsVisible(const CFileItem& item) const
@@ -591,16 +600,19 @@ std::string EditTimer::GetLabel(const CFileItem& item) const
     if (item.GetEPGInfoTag())
     {
       if (timerType->IsReminder())
-        return g_localizeStrings.Get(timerType->IsReadOnly() ? 829 /* View reminder */
-                                                             : 830); /* Edit reminder */
+        return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            timerType->IsReadOnly() ? 829 /* View reminder */
+                                    : 830); /* Edit reminder */
       else
-        return g_localizeStrings.Get(timerType->IsReadOnly() ? 19241 /* View timer */
-                                                             : 19242); /* Edit timer */
+        return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            timerType->IsReadOnly() ? 19241 /* View timer */
+                                    : 19242); /* Edit timer */
     }
     else
-      return g_localizeStrings.Get(timerType->IsReadOnly() ? 21483 : 21450); /* View/Edit */
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          timerType->IsReadOnly() ? 21483 : 21450); /* View/Edit */
   }
-  return g_localizeStrings.Get(19241); /* View timer */
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19241); /* View timer */
 }
 
 bool EditTimer::IsVisible(const CFileItem& item) const
@@ -621,7 +633,7 @@ bool EditTimer::Execute(const CFileItemPtr& item) const
 std::string DeleteTimer::GetLabel(const CFileItem& item) const
 {
   if (item.GetPVRTimerInfoTag())
-    return g_localizeStrings.Get(117); /* Delete */
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(117); /* Delete */
 
   const std::shared_ptr<const CPVREpgInfoTag> epg = item.GetEPGInfoTag();
   if (epg)
@@ -629,9 +641,10 @@ std::string DeleteTimer::GetLabel(const CFileItem& item) const
     const std::shared_ptr<const CPVRTimerInfoTag> timer =
         CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(epg);
     if (timer && timer->IsReminder())
-      return g_localizeStrings.Get(827); /* Delete reminder */
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          827); /* Delete reminder */
   }
-  return g_localizeStrings.Get(19060); /* Delete timer */
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19060); /* Delete timer */
 }
 
 bool DeleteTimer::IsVisible(const CFileItem& item) const

--- a/xbmc/pvr/PVRManager.cpp
+++ b/xbmc/pvr/PVRManager.cpp
@@ -10,7 +10,6 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
 #include "jobs/JobManager.h"
 #include "messaging/ApplicationMessenger.h"
@@ -40,6 +39,8 @@
 #include "pvr/settings/PVRSettings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "utils/Stopwatch.h"
 #include "utils/StringUtils.h"
@@ -674,7 +675,8 @@ void CPVRManager::UpdateComponents(ManagerState stateToCheck)
 {
   XbmcThreads::EndTime<> progressTimeout(30s);
   auto progressHandler{std::make_unique<CPVRGUIProgressHandler>(
-      g_localizeStrings.Get(19235))}; // PVR manager is starting up
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          19235))}; // PVR manager is starting up
 
   // Wait for at least one client to come up and load/update data
   while (!UpdateComponents(stateToCheck, progressHandler.get()) && m_addons->HasCreatedClients() &&
@@ -725,7 +727,9 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
 
   // Load all channels and groups
   if (progressHandler)
-    progressHandler->UpdateProgress(g_localizeStrings.Get(19236), 0); // Loading channels and groups
+    progressHandler->UpdateProgress(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19236),
+        0); // Loading channels and groups
 
   if (!m_providers->Update(newClients))
   {
@@ -748,7 +752,9 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
 
   // Load all timers
   if (progressHandler)
-    progressHandler->UpdateProgress(g_localizeStrings.Get(19237), 50); // Loading timers
+    progressHandler->UpdateProgress(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19237),
+        50); // Loading timers
 
   if (!m_timers->Update(newClients))
   {
@@ -760,7 +766,9 @@ bool CPVRManager::UpdateComponents(ManagerState stateToCheck,
 
   // Load all recordings
   if (progressHandler)
-    progressHandler->UpdateProgress(g_localizeStrings.Get(19238), 75); // Loading recordings
+    progressHandler->UpdateProgress(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19238),
+        75); // Loading recordings
 
   if (!m_recordings->Update(newClients))
   {

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -17,7 +17,6 @@
 #include "events/EventLog.h"
 #include "events/NotificationEvent.h"
 #include "filesystem/SpecialProtocol.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRDescrambleInfo.h"
@@ -42,6 +41,8 @@
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimerType.h"
 #include "pvr/timers/PVRTimers.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/MathUtils.h"
@@ -2400,8 +2401,10 @@ void CPVRClient::cb_recording_notification(void* kodiInstance,
           return;
         }
 
-        const std::string strLine1 = StringUtils::Format(
-            g_localizeStrings.Get(bOnOff ? 19197 : 19198), client->GetFullClientName());
+        const std::string strLine1 =
+            StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                    bOnOff ? 19197 : 19198),
+                                client->GetFullClientName());
         const std::string strLine2{strName ? strName : strFileName};
 
         // display a notification for 5 seconds

--- a/xbmc/pvr/addons/PVRClientCapabilities.cpp
+++ b/xbmc/pvr/addons/PVRClientCapabilities.cpp
@@ -8,7 +8,9 @@
 
 #include "PVRClientCapabilities.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 #include <algorithm>
@@ -68,8 +70,10 @@ void CPVRClientCapabilities::InitRecordingsLifetimeValues()
     // No values given by addon, but lifetime supported. Use default values 1..365
     for (int i = 1; i < 366; ++i)
     {
-      m_recordingsLifetimeValues.emplace_back(StringUtils::Format(g_localizeStrings.Get(17999), i),
-                                              i); // "{} days"
+      m_recordingsLifetimeValues.emplace_back(
+          StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(17999), i),
+          i); // "{} days"
     }
   }
   else

--- a/xbmc/pvr/addons/PVRClientMenuHooks.cpp
+++ b/xbmc/pvr/addons/PVRClientMenuHooks.cpp
@@ -8,9 +8,11 @@
 
 #include "PVRClientMenuHooks.h"
 
+#include "ServiceBroker.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_menu_hook.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRContextMenus.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/log.h"
 
 #include <memory>
@@ -86,7 +88,8 @@ unsigned int CPVRClientMenuHook::GetLabelId() const
 
 std::string CPVRClientMenuHook::GetLabel() const
 {
-  return g_localizeStrings.GetAddonString(m_addonId, m_hook->iLocalizedStringId);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+      m_addonId, m_hook->iLocalizedStringId);
 }
 
 void CPVRClientMenuHooks::AddHook(const PVR_MENUHOOK& addonHook)

--- a/xbmc/pvr/addons/PVRClients.cpp
+++ b/xbmc/pvr/addons/PVRClients.cpp
@@ -13,7 +13,6 @@
 #include "addons/AddonManager.h"
 #include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonType.h"
-#include "guilib/LocalizeStrings.h"
 #include "jobs/JobManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
@@ -23,6 +22,8 @@
 #include "pvr/addons/PVRClient.h"
 #include "pvr/addons/PVRClientUID.h"
 #include "pvr/guilib/PVRGUIProgressHandler.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -226,7 +227,8 @@ void CPVRClients::UpdateClients(const std::string& changedAddonId /* = "" */)
     CServiceBroker::GetPVRManager().Stop();
 
     auto progressHandler = std::make_unique<CPVRGUIProgressHandler>(
-        g_localizeStrings.Get(19239)); // Creating PVR clients
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            19239)); // Creating PVR clients
 
     size_t i = 0;
     for (const auto& client : clientsToCreate)
@@ -242,8 +244,10 @@ void CPVRClients::UpdateClients(const std::string& changedAddonId /* = "" */)
         CServiceBroker::GetAddonMgr().DisableAddon(client->ID(),
                                                    AddonDisabledReason::PERMANENT_FAILURE);
         CServiceBroker::GetJobManager()->AddJob(
-            new CPVREventLogJob(true, EventLevel::Error, client->Name(),
-                                g_localizeStrings.Get(24070), client->Icon()),
+            new CPVREventLogJob(
+                true, EventLevel::Error, client->Name(),
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24070),
+                client->Icon()),
             nullptr);
       }
     }
@@ -913,7 +917,7 @@ void CPVRClients::ConnectionStateChange(const CPVRClient* client,
   if (!strMessage.empty())
     strMsg = strMessage;
   else
-    strMsg = g_localizeStrings.Get(iMsg);
+    strMsg = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(iMsg);
 
   if (!strConnectionString.empty())
     strMsg = StringUtils::Format("{} ({})", strMsg, strConnectionString);

--- a/xbmc/pvr/channels/PVRChannel.cpp
+++ b/xbmc/pvr/channels/PVRChannel.cpp
@@ -10,7 +10,6 @@
 
 #include "ServiceBroker.h"
 #include "XBDateTime.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
@@ -19,6 +18,8 @@
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/providers/PVRProviders.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -69,7 +70,9 @@ CPVRChannel::CPVRChannel(const PVR_CHANNEL& channel, unsigned int iClientId)
     m_iClientProviderUid(channel.iClientProviderUid)
 {
   if (m_strChannelName.empty())
-    m_strChannelName = StringUtils::Format("{} {}", g_localizeStrings.Get(19029), m_iUniqueId);
+    m_strChannelName = StringUtils::Format(
+        "{} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19029),
+        m_iUniqueId);
 
   UpdateEncryptionName();
 }
@@ -348,8 +351,9 @@ bool CPVRChannel::SetChannelName(const std::string& strChannelName, bool bIsUser
   std::string strName(strChannelName);
 
   if (strName.empty())
-    strName = StringUtils::Format(g_localizeStrings.Get(19085),
-                                  m_clientChannelNumber.FormattedChannelNumber());
+    strName =
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19085),
+                            m_clientChannelNumber.FormattedChannelNumber());
 
   std::unique_lock lock(m_critSection);
   if (m_strChannelName != strName || m_bIsUserSetName != bIsUserSetName)
@@ -417,16 +421,18 @@ std::string CPVRChannel::GetEncryptionName(int iCaid)
 {
   // http://www.dvb.org/index.php?id=174
   // http://en.wikipedia.org/wiki/Conditional_access_system
-  std::string strName(g_localizeStrings.Get(13205)); /* Unknown */
+  std::string strName(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205)); /* Unknown */
 
   if (iCaid == 0x0000)
-    strName = g_localizeStrings.Get(19013); /* Free To Air */
+    strName =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19013); /* Free To Air */
   else if (iCaid >= 0x0001 && iCaid <= 0x009F)
-    strName = g_localizeStrings.Get(19014); /* Fixed */
+    strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19014); /* Fixed */
   else if (iCaid >= 0x00A0 && iCaid <= 0x00A1)
-    strName = g_localizeStrings.Get(338); /* Analog */
+    strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(338); /* Analog */
   else if (iCaid >= 0x00A2 && iCaid <= 0x00FF)
-    strName = g_localizeStrings.Get(19014); /* Fixed */
+    strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19014); /* Fixed */
   else if (iCaid >= 0x0100 && iCaid <= 0x01FF)
     strName = "SECA Mediaguard";
   else if (iCaid == 0x0464)

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannels.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannels.cpp
@@ -9,13 +9,14 @@
 #include "PVRChannelGroupAllChannels.h"
 
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/epg/EpgContainer.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
@@ -29,7 +30,10 @@ using namespace PVR;
 
 CPVRChannelGroupAllChannels::CPVRChannelGroupAllChannels(bool bRadio)
   : CPVRChannelGroup(
-        CPVRChannelsPath(bRadio, g_localizeStrings.Get(19287), PVR_GROUP_CLIENT_ID_LOCAL), nullptr)
+        CPVRChannelsPath(bRadio,
+                         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19287),
+                         PVR_GROUP_CLIENT_ID_LOCAL),
+        nullptr)
 {
 }
 
@@ -45,7 +49,8 @@ void CPVRChannelGroupAllChannels::CheckGroupName()
   //! @todo major design flaw to fix: channel and group URLs must not contain the group name!
 
   // Ensure the group name is still correct, or channels may fail to load after a locale change
-  if (!IsUserSetName() && SetGroupName(g_localizeStrings.Get(19287)))
+  if (!IsUserSetName() &&
+      SetGroupName(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19287)))
     Persist();
 }
 

--- a/xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupAllChannelsSingleClient.cpp
@@ -9,11 +9,12 @@
 #include "PVRChannelGroupAllChannelsSingleClient.h"
 
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/channels/PVRChannelsPath.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -64,7 +65,8 @@ std::vector<std::shared_ptr<CPVRChannelGroup>> CPVRChannelGroupAllChannelsSingle
     if (it == allChannelGroups.cend())
     {
       const std::string name{
-          StringUtils::Format(g_localizeStrings.Get(859), client->GetFullClientName())};
+          StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(859),
+                              client->GetFullClientName())};
       const CPVRChannelsPath path{allChannelsGroup->IsRadio(), name, client->GetID()};
       addedGroups.emplace_back(
           std::make_shared<CPVRChannelGroupAllChannelsSingleClient>(path, allChannelsGroup));

--- a/xbmc/pvr/channels/PVRChannelGroupMergedByName.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroupMergedByName.cpp
@@ -8,8 +8,10 @@
 
 #include "PVRChannelGroupMergedByName.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "pvr/channels/PVRChannelGroupMember.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 #include <unordered_map>
@@ -117,7 +119,8 @@ std::vector<std::shared_ptr<CPVRChannelGroup>> CPVRChannelGroupMergedByName::Cre
   const std::vector<std::string> names{GetGroupNames(allChannelGroups)};
   for (const auto& name : names)
   {
-    const std::string groupName{StringUtils::Format(g_localizeStrings.Get(859), name)};
+    const std::string groupName{StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(859), name)};
     const CPVRChannelsPath path{allChannelsGroup->IsRadio(), groupName, PVR_GROUP_CLIENT_ID_LOCAL};
     const std::shared_ptr<CPVRChannelGroup> mergedByNameGroup{
         std::make_shared<CPVRChannelGroupMergedByName>(path, allChannelsGroup)};

--- a/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRChannelManager.cpp
@@ -22,7 +22,6 @@
 #include "guilib/GUIMessage.h"
 #include "guilib/GUISpinControlEx.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/helpers/DialogOKHelper.h"
@@ -36,6 +35,8 @@
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/dialogs/GUIDialogPVRGroupManager.h"
 #include "pvr/guilib/PVRGUIActionsParentalControl.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
@@ -399,7 +400,7 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo()
   {
     auto current{std::make_shared<CFileItem>("thumb://Current", false)};
     current->SetArt("thumb", pItem->GetPVRChannelInfoTag()->IconPath());
-    current->SetLabel(g_localizeStrings.Get(19282));
+    current->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19282));
     items.Add(std::move(current));
   }
   else if (pItem->HasArt("thumb"))
@@ -407,14 +408,14 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo()
     // already have a thumb that the share doesn't know about - must be a local one, so we mayaswell reuse it.
     auto current{std::make_shared<CFileItem>("thumb://Current", false)};
     current->SetArt("thumb", pItem->GetArt("thumb"));
-    current->SetLabel(g_localizeStrings.Get(19282));
+    current->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19282));
     items.Add(std::move(current));
   }
 
   // and add a "no thumb" entry as well
   auto nothumb{std::make_shared<CFileItem>("thumb://None", false)};
   nothumb->SetArt("icon", pItem->GetArt("icon"));
-  nothumb->SetLabel(g_localizeStrings.Get(19283));
+  nothumb->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19283));
   items.Add(std::move(nothumb));
 
   std::string strThumb;
@@ -424,12 +425,13 @@ bool CGUIDialogPVRChannelManager::OnClickButtonChannelLogo()
   {
     CMediaSource share1;
     share1.strPath = settings->GetString(CSettings::SETTING_PVRMENU_ICONPATH);
-    share1.strName = g_localizeStrings.Get(19066);
+    share1.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19066);
     shares.push_back(share1);
   }
   CServiceBroker::GetMediaManager().GetLocalDrives(shares);
-  if (!CGUIDialogFileBrowser::ShowAndGetImage(items, shares, g_localizeStrings.Get(19285), strThumb,
-                                              nullptr, 19285))
+  if (!CGUIDialogFileBrowser::ShowAndGetImage(
+          items, shares, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19285),
+          strThumb, nullptr, 19285))
     return false;
 
   if (strThumb == "thumb://Current")
@@ -536,7 +538,8 @@ bool CGUIDialogPVRChannelManager::OnClickButtonNewChannel()
     int iClientID = m_clientsWithSettingsList[iSelection]->GetID();
 
     const auto channel{std::make_shared<CPVRChannel>(m_bIsRadio)};
-    channel->SetChannelName(g_localizeStrings.Get(19204)); // New channel
+    channel->SetChannelName(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19204)); // New channel
     channel->SetClientID(iClientID);
 
     PVR_ERROR ret = PVR_ERROR_UNKNOWN;
@@ -857,7 +860,7 @@ void CGUIDialogPVRChannelManager::Update()
 
   {
     std::vector<std::pair<std::string, int>> labels;
-    labels.emplace_back(g_localizeStrings.Get(19210), 0);
+    labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19210), 0);
     //! @todo Add Labels for EPG scrapers here
     SET_CONTROL_LABELS(SPIN_EPGSOURCE_SELECTION, 0, &labels);
   }
@@ -898,7 +901,8 @@ void CGUIDialogPVRChannelManager::ClearChannelOptions()
   SET_CONTROL_FILENAME(BUTTON_CHANNEL_LOGO, "");
   CONTROL_DESELECT(RADIOBUTTON_USEEPG);
 
-  std::vector<std::pair<std::string, int>> labels = {{g_localizeStrings.Get(19210), 0}};
+  std::vector<std::pair<std::string, int>> labels = {
+      {CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19210), 0}};
   SET_CONTROL_LABELS(SPIN_EPGSOURCE_SELECTION, 0, &labels);
 
   CONTROL_DESELECT(RADIOBUTTON_PARENTAL_LOCK);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
@@ -18,7 +18,6 @@
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/helpers/DialogOKHelper.h"
@@ -31,6 +30,8 @@
 #include "pvr/channels/PVRChannelGroups.h"
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/filesystem/PVRGUIDirectory.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -149,8 +150,10 @@ bool CGUIDialogPVRGroupManager::ActionButtonNewGroup(const CGUIMessage& message)
   if (iControl == BUTTON_NEWGROUP)
   {
     std::string strGroupName;
-    if (CGUIKeyboardFactory::ShowAndGetInput(strGroupName, CVariant{g_localizeStrings.Get(19139)},
-                                             false) &&
+    if (CGUIKeyboardFactory::ShowAndGetInput(
+            strGroupName,
+            CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19139)},
+            false) &&
         !strGroupName.empty())
     {
       // add the group if it doesn't already exist
@@ -221,8 +224,10 @@ bool CGUIDialogPVRGroupManager::ActionButtonRenameGroup(const CGUIMessage& messa
       return bReturn;
 
     std::string strGroupName(m_selectedGroup->GroupName());
-    if (CGUIKeyboardFactory::ShowAndGetInput(strGroupName, CVariant{g_localizeStrings.Get(19139)},
-                                             true /* allow empty result */))
+    if (CGUIKeyboardFactory::ShowAndGetInput(
+            strGroupName,
+            CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19139)},
+            true /* allow empty result */))
     {
       // if an empty string was given we reset the name to the client-supplied name, if available
       const bool resetName = strGroupName.empty() && !m_selectedGroup->ClientGroupName().empty();
@@ -630,10 +635,13 @@ void CGUIDialogPVRGroupManager::Update()
     CONTROL_ENABLE_ON_CONDITION(CONTROL_LIST_CHANNELS_RIGHT,
                                 m_selectedGroup->SupportsMemberRemove());
 
-    SET_CONTROL_LABEL(CONTROL_UNGROUPED_LABEL, g_localizeStrings.Get(19219));
+    SET_CONTROL_LABEL(CONTROL_UNGROUPED_LABEL,
+                      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19219));
     SET_CONTROL_LABEL(
         CONTROL_IN_GROUP_LABEL,
-        StringUtils::Format("{} {}", g_localizeStrings.Get(19220), m_selectedGroup->GroupName()));
+        StringUtils::Format("{} {}",
+                            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19220),
+                            m_selectedGroup->GroupName()));
 
     const std::vector<std::shared_ptr<CPVRChannelGroupMember>> groupMembers =
         m_selectedGroup->GetMembers(CPVRChannelGroup::Include::ONLY_VISIBLE);

--- a/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRGuideSearch.cpp
@@ -12,7 +12,6 @@
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIMessage.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroupMember.h"
@@ -20,6 +19,8 @@
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/epg/EpgContainer.h"
 #include "pvr/epg/EpgSearchFilter.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 #include <cstdio>
@@ -76,9 +77,11 @@ void CGUIDialogPVRGuideSearch::UpdateChannelSpin()
 
   std::vector<std::pair<std::string, int>> labels;
   if (m_searchFilter->IsRadio())
-    labels.emplace_back(g_localizeStrings.Get(19216), EPG_SEARCH_UNSET); // All radio channels
+    labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19216),
+                        EPG_SEARCH_UNSET); // All radio channels
   else
-    labels.emplace_back(g_localizeStrings.Get(19217), EPG_SEARCH_UNSET); // All TV channels
+    labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19217),
+                        EPG_SEARCH_UNSET); // All TV channels
 
   std::shared_ptr<CPVRChannelGroup> group;
   if (iChannelGroup != EPG_SEARCH_UNSET)
@@ -129,19 +132,32 @@ void CGUIDialogPVRGuideSearch::UpdateGroupsSpin()
 void CGUIDialogPVRGuideSearch::UpdateGenreSpin()
 {
   std::vector<std::pair<std::string, int>> labels;
-  labels.emplace_back(g_localizeStrings.Get(593), EPG_SEARCH_UNSET);
-  labels.emplace_back(g_localizeStrings.Get(19500), EPG_EVENT_CONTENTMASK_MOVIEDRAMA);
-  labels.emplace_back(g_localizeStrings.Get(19516), EPG_EVENT_CONTENTMASK_NEWSCURRENTAFFAIRS);
-  labels.emplace_back(g_localizeStrings.Get(19532), EPG_EVENT_CONTENTMASK_SHOW);
-  labels.emplace_back(g_localizeStrings.Get(19548), EPG_EVENT_CONTENTMASK_SPORTS);
-  labels.emplace_back(g_localizeStrings.Get(19564), EPG_EVENT_CONTENTMASK_CHILDRENYOUTH);
-  labels.emplace_back(g_localizeStrings.Get(19580), EPG_EVENT_CONTENTMASK_MUSICBALLETDANCE);
-  labels.emplace_back(g_localizeStrings.Get(19596), EPG_EVENT_CONTENTMASK_ARTSCULTURE);
-  labels.emplace_back(g_localizeStrings.Get(19612), EPG_EVENT_CONTENTMASK_SOCIALPOLITICALECONOMICS);
-  labels.emplace_back(g_localizeStrings.Get(19628), EPG_EVENT_CONTENTMASK_EDUCATIONALSCIENCE);
-  labels.emplace_back(g_localizeStrings.Get(19644), EPG_EVENT_CONTENTMASK_LEISUREHOBBIES);
-  labels.emplace_back(g_localizeStrings.Get(19660), EPG_EVENT_CONTENTMASK_SPECIAL);
-  labels.emplace_back(g_localizeStrings.Get(19499), EPG_EVENT_CONTENTMASK_USERDEFINED);
+  labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(593),
+                      EPG_SEARCH_UNSET);
+  labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19500),
+                      EPG_EVENT_CONTENTMASK_MOVIEDRAMA);
+  labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19516),
+                      EPG_EVENT_CONTENTMASK_NEWSCURRENTAFFAIRS);
+  labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19532),
+                      EPG_EVENT_CONTENTMASK_SHOW);
+  labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19548),
+                      EPG_EVENT_CONTENTMASK_SPORTS);
+  labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19564),
+                      EPG_EVENT_CONTENTMASK_CHILDRENYOUTH);
+  labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19580),
+                      EPG_EVENT_CONTENTMASK_MUSICBALLETDANCE);
+  labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19596),
+                      EPG_EVENT_CONTENTMASK_ARTSCULTURE);
+  labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19612),
+                      EPG_EVENT_CONTENTMASK_SOCIALPOLITICALECONOMICS);
+  labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19628),
+                      EPG_EVENT_CONTENTMASK_EDUCATIONALSCIENCE);
+  labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19644),
+                      EPG_EVENT_CONTENTMASK_LEISUREHOBBIES);
+  labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19660),
+                      EPG_EVENT_CONTENTMASK_SPECIAL);
+  labels.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19499),
+                      EPG_EVENT_CONTENTMASK_USERDEFINED);
 
   SET_CONTROL_LABELS(CONTROL_SPIN_GENRE, m_searchFilter->GetGenreType(), &labels);
 }
@@ -153,7 +169,10 @@ void CGUIDialogPVRGuideSearch::UpdateDurationSpin()
 
   labels.emplace_back("-", EPG_SEARCH_UNSET);
   for (int i = 1; i < 12 * 60 / 5; ++i)
-    labels.emplace_back(StringUtils::Format(g_localizeStrings.Get(14044), i * 5), i * 5);
+    labels.emplace_back(
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14044),
+                            i * 5),
+        i * 5);
 
   SET_CONTROL_LABELS(CONTROL_SPIN_MIN_DURATION, m_searchFilter->GetMinimumDuration(), &labels);
 
@@ -162,7 +181,10 @@ void CGUIDialogPVRGuideSearch::UpdateDurationSpin()
 
   labels.emplace_back("-", EPG_SEARCH_UNSET);
   for (int i = 1; i < 12 * 60 / 5; ++i)
-    labels.emplace_back(StringUtils::Format(g_localizeStrings.Get(14044), i * 5), i * 5);
+    labels.emplace_back(
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14044),
+                            i * 5),
+        i * 5);
 
   SET_CONTROL_LABELS(CONTROL_SPIN_MAX_DURATION, m_searchFilter->GetMaximumDuration(), &labels);
 }
@@ -209,12 +231,15 @@ bool CGUIDialogPVRGuideSearch::OnMessage(CGUIMessage& message)
         {
           title = m_searchFilter->GetSearchTerm();
           if (title.empty())
-            title = g_localizeStrings.Get(137); // "Search"
+            title =
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(137); // "Search"
           else
             StringUtils::Trim(title, "\"");
 
           if (!CGUIKeyboardFactory::ShowAndGetInput(
-                  title, CVariant{g_localizeStrings.Get(528)}, // "Enter title"
+                  title,
+                  CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                      528)}, // "Enter title"
                   false))
           {
             return false;

--- a/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRadioRDSInfo.cpp
@@ -13,11 +13,12 @@
 #include "guilib/GUIMessage.h"
 #include "guilib/GUISpinControl.h"
 #include "guilib/GUITextBox.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRRadioRDSInfoTag.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 using namespace PVR;
 
@@ -211,7 +212,9 @@ bool CGUIDialogPVRRadioRDSInfo::InfoControl::Update(const std::string& textboxVa
   {
     if (!m_bSpinLabelPresent)
     {
-      m_spinControl->AddLabel(g_localizeStrings.Get(m_iSpinLabelId), m_iSpinControlId);
+      m_spinControl->AddLabel(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(m_iSpinLabelId),
+          m_iSpinControlId);
       m_bSpinLabelPresent = true;
     }
 

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -11,11 +11,12 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "guilib/GUIMessage.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/recordings/PVRRecording.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/dialogs/GUIDialogSettingsBase.h"
 #include "settings/lib/Setting.h"
 #include "utils/StringUtils.h"
@@ -140,9 +141,11 @@ bool CGUIDialogPVRRecordingSettings::OnSettingChanging(
   {
     int iNewLifetime = std::static_pointer_cast<const CSettingInt>(setting)->GetValue();
     if (m_recording->WillBeExpiredWithNewLifetime(iNewLifetime) &&
-        HELPERS::ShowYesNoDialogText(CVariant{19068}, // "Recording settings"
-                                     StringUtils::Format(g_localizeStrings.Get(19147),
-                                                         iNewLifetime)) // "Setting the lifetime..."
+        HELPERS::ShowYesNoDialogText(
+            CVariant{19068}, // "Recording settings"
+            StringUtils::Format(
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19147),
+                iNewLifetime)) // "Setting the lifetime..."
             != HELPERS::DialogResponse::CHOICE_YES)
     {
       return false;
@@ -223,7 +226,10 @@ void CGUIDialogPVRRecordingSettings::LifetimesFiller(const SettingConstPtr& sett
   if (it == list.end())
   {
     // PVR backend supplied value is not in the list of predefined values. Insert it.
-    list.emplace(it, StringUtils::Format(g_localizeStrings.Get(17999), current) /* {} days */,
-                 current);
+    list.emplace(
+        it,
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(17999),
+                            current) /* {} days */,
+        current);
   }
 }

--- a/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRTimerSettings.cpp
@@ -11,7 +11,6 @@
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogNumeric.h"
 #include "guilib/GUIMessage.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "pvr/PVRConstants.h" // PVR_CLIENT_INVALID_UID
 #include "pvr/PVRManager.h"
@@ -26,6 +25,8 @@
 #include "pvr/settings/PVRSettings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimerType.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/SettingUtils.h"
 #include "settings/dialogs/GUIDialogSettingsBase.h"
 #include "settings/lib/Setting.h"
@@ -687,7 +688,9 @@ void CGUIDialogPVRTimerSettings::OnSettingAction(const std::shared_ptr<const CSe
   {
     KODI::TIME::SystemTime timerStartTime;
     m_startLocalTime.GetAsSystemTime(timerStartTime);
-    if (CGUIDialogNumeric::ShowAndGetTime(timerStartTime, g_localizeStrings.Get(14066)))
+    if (CGUIDialogNumeric::ShowAndGetTime(
+            timerStartTime,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14066)))
     {
       SetTimeFromSystemTime(m_startLocalTime, timerStartTime);
       m_timerStartTimeStr = m_startLocalTime.GetAsLocalizedTime("", false);
@@ -698,7 +701,8 @@ void CGUIDialogPVRTimerSettings::OnSettingAction(const std::shared_ptr<const CSe
   {
     KODI::TIME::SystemTime timerEndTime;
     m_endLocalTime.GetAsSystemTime(timerEndTime);
-    if (CGUIDialogNumeric::ShowAndGetTime(timerEndTime, g_localizeStrings.Get(14066)))
+    if (CGUIDialogNumeric::ShowAndGetTime(
+            timerEndTime, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14066)))
     {
       SetTimeFromSystemTime(m_endLocalTime, timerEndTime);
       m_timerEndTimeStr = m_endLocalTime.GetAsLocalizedTime("", false);
@@ -864,7 +868,8 @@ bool CGUIDialogPVRTimerSettings::Save()
   m_timerInfoTag->m_customProps = m_customTimerSettings->GetProperties();
 
   // Set the timer's title to the channel name if it's empty or 'New Timer'
-  if (m_strTitle.empty() || m_strTitle == g_localizeStrings.Get(19056))
+  if (m_strTitle.empty() ||
+      m_strTitle == CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19056))
   {
     const std::string channelName = m_timerInfoTag->ChannelName();
     if (!channelName.empty())
@@ -1018,7 +1023,8 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
   if (clients.size() > 1)
   {
     m_channelEntries.try_emplace(index, PVR_CHANNEL_INVALID_UID, PVR_CLIENT_INVALID_UID,
-                                 g_localizeStrings.Get(854)); // Any channel from any client
+                                 CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                     854)); // Any channel from any client
     index++;
   }
 
@@ -1027,8 +1033,9 @@ void CGUIDialogPVRTimerSettings::InitializeChannelsList()
     m_channelEntries.try_emplace(
         index, PVR_CHANNEL_INVALID_UID, client->GetID(),
         clients.size() == 1
-            ? g_localizeStrings.Get(809) // Any channel
-            : StringUtils::Format(g_localizeStrings.Get(853), // Any channel from client "X"
+            ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(809) // Any channel
+            : StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                      853), // Any channel from client "X"
                                   client->GetFullClientName()));
     index++;
   }
@@ -1197,13 +1204,20 @@ void CGUIDialogPVRTimerSettings::WeekdaysFiller(const SettingConstPtr& setting,
                                                 int& current) const
 {
   list.clear();
-  list.emplace_back(g_localizeStrings.Get(831), PVR_WEEKDAY_MONDAY); // "Mondays"
-  list.emplace_back(g_localizeStrings.Get(832), PVR_WEEKDAY_TUESDAY); // "Tuesdays"
-  list.emplace_back(g_localizeStrings.Get(833), PVR_WEEKDAY_WEDNESDAY); // "Wednesdays"
-  list.emplace_back(g_localizeStrings.Get(834), PVR_WEEKDAY_THURSDAY); // "Thursdays"
-  list.emplace_back(g_localizeStrings.Get(835), PVR_WEEKDAY_FRIDAY); // "Fridays"
-  list.emplace_back(g_localizeStrings.Get(836), PVR_WEEKDAY_SATURDAY); // "Saturdays"
-  list.emplace_back(g_localizeStrings.Get(837), PVR_WEEKDAY_SUNDAY); // "Sundays"
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(831),
+                    PVR_WEEKDAY_MONDAY); // "Mondays"
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(832),
+                    PVR_WEEKDAY_TUESDAY); // "Tuesdays"
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(833),
+                    PVR_WEEKDAY_WEDNESDAY); // "Wednesdays"
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(834),
+                    PVR_WEEKDAY_THURSDAY); // "Thursdays"
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(835),
+                    PVR_WEEKDAY_FRIDAY); // "Fridays"
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(836),
+                    PVR_WEEKDAY_SATURDAY); // "Saturdays"
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(837),
+                    PVR_WEEKDAY_SUNDAY); // "Sundays"
 
   current = m_iWeekdays;
 }
@@ -1260,8 +1274,11 @@ void CGUIDialogPVRTimerSettings::LifetimesFiller(const SettingConstPtr& setting,
   if (it == list.end())
   {
     // PVR backend supplied value is not in the list of predefined values. Insert it.
-    list.emplace(it, StringUtils::Format(g_localizeStrings.Get(17999), current) /* {} days */,
-                 current);
+    list.emplace(
+        it,
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(17999),
+                            current) /* {} days */,
+        current);
   }
 }
 
@@ -1336,8 +1353,11 @@ void CGUIDialogPVRTimerSettings::MarginTimeFiller(const SettingConstPtr& setting
   if (bInsertValue)
   {
     // PVR backend supplied value is not in the list of predefined values. Insert it.
-    list.emplace(it, StringUtils::Format(g_localizeStrings.Get(14044), current) /* {} min */,
-                 current);
+    list.emplace(
+        it,
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14044),
+                            current) /* {} min */,
+        current);
   }
 }
 

--- a/xbmc/pvr/epg/Epg.cpp
+++ b/xbmc/pvr/epg/Epg.cpp
@@ -9,13 +9,14 @@
 #include "Epg.h"
 
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRCachedImages.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/epg/EpgChannelData.h"
 #include "pvr/epg/EpgDatabase.h"
 #include "pvr/epg/EpgInfoTag.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -487,7 +488,7 @@ const std::string& CPVREpg::ConvertGenreIdToString(int iID, int iSubID)
       break;
   }
 
-  return g_localizeStrings.Get(iLabelId);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(iLabelId);
 }
 
 std::shared_ptr<CPVREpgChannelData> CPVREpg::GetChannelData() const

--- a/xbmc/pvr/epg/EpgContainer.cpp
+++ b/xbmc/pvr/epg/EpgContainer.cpp
@@ -10,7 +10,6 @@
 
 #include "ServiceBroker.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_channels.h" // PVR_CHANNEL_INVALID_UID
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgChannelData.h"
@@ -20,6 +19,8 @@
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/guilib/PVRGUIProgressHandler.h"
 #include "pvr/settings/PVRSettings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -770,7 +771,8 @@ bool CPVREpgContainer::UpdateEPG(bool bOnlyPending /* = false */)
   std::unique_ptr<CPVRGUIProgressHandler> progressHandler;
   if (bShowProgress && !bOnlyPending && !epgsToUpdate.empty())
     progressHandler = std::make_unique<CPVRGUIProgressHandler>(
-        g_localizeStrings.Get(19004)); // Loading programme guide
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            19004)); // Loading programme guide
 
   size_t counter = 0;
   for (const auto& [_, epg] : epgsToUpdate)

--- a/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
+++ b/xbmc/pvr/filesystem/PVRGUIDirectory.cpp
@@ -14,7 +14,6 @@
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "input/WindowTranslator.h"
 #include "jobs/Job.h"
@@ -43,6 +42,8 @@
 #include "pvr/timers/PVRTimers.h"
 #include "pvr/timers/PVRTimersPath.h"
 #include "pvr/utils/PVRPathUtils.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -136,7 +137,8 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
   {
     item = std::make_shared<CFileItem>(
         StringUtils::Format("pvr://guide/{}/", bRadio ? "radio" : "tv"), true);
-    item->SetLabel(g_localizeStrings.Get(19069)); // Guide
+    item->SetLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19069)); // Guide
     item->SetProperty("node.target", CWindowTranslator::TranslateWindow(bRadio ? WINDOW_RADIO_GUIDE
                                                                                : WINDOW_TV_GUIDE));
     item->SetArt("icon", "DefaultPVRGuide.png");
@@ -146,7 +148,8 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
   // Channels
   item = std::make_shared<CFileItem>(
       bRadio ? CPVRChannelsPath::PATH_RADIO_CHANNELS : CPVRChannelsPath::PATH_TV_CHANNELS, true);
-  item->SetLabel(g_localizeStrings.Get(19019)); // Channels
+  item->SetLabel(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19019)); // Channels
   item->SetProperty("node.target", CWindowTranslator::TranslateWindow(bRadio ? WINDOW_RADIO_CHANNELS
                                                                              : WINDOW_TV_CHANNELS));
   item->SetArt("icon", "DefaultPVRChannels.png");
@@ -158,7 +161,8 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
     item = std::make_shared<CFileItem>(bRadio ? CPVRRecordingsPath::PATH_ACTIVE_RADIO_RECORDINGS
                                               : CPVRRecordingsPath::PATH_ACTIVE_TV_RECORDINGS,
                                        true);
-    item->SetLabel(g_localizeStrings.Get(19017)); // Recordings
+    item->SetLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19017)); // Recordings
     item->SetProperty("node.target", CWindowTranslator::TranslateWindow(
                                          bRadio ? WINDOW_RADIO_RECORDINGS : WINDOW_TV_RECORDINGS));
     item->SetArt("icon", "DefaultPVRRecordings.png");
@@ -171,7 +175,8 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
     item = std::make_shared<CFileItem>(bRadio ? CPVRProvidersPath::PATH_RADIO_PROVIDERS
                                               : CPVRProvidersPath::PATH_TV_PROVIDERS,
                                        true);
-    item->SetLabel(g_localizeStrings.Get(19334)); // Providers
+    item->SetLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19334)); // Providers
     item->SetProperty("node.target", CWindowTranslator::TranslateWindow(
                                          bRadio ? WINDOW_RADIO_PROVIDERS : WINDOW_TV_PROVIDERS));
     item->SetArt("icon", "DefaultPVRProviders.png");
@@ -182,7 +187,7 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
   // - always present, because Reminders are always available, no client support needed for this
   item = std::make_shared<CFileItem>(
       bRadio ? CPVRTimersPath::PATH_RADIO_TIMERS : CPVRTimersPath::PATH_TV_TIMERS, true);
-  item->SetLabel(g_localizeStrings.Get(19040)); // Timers
+  item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19040)); // Timers
   item->SetProperty("node.target", CWindowTranslator::TranslateWindow(bRadio ? WINDOW_RADIO_TIMERS
                                                                              : WINDOW_TV_TIMERS));
   item->SetArt("icon", "DefaultPVRTimers.png");
@@ -190,7 +195,8 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
 
   item = std::make_shared<CFileItem>(
       bRadio ? CPVRTimersPath::PATH_RADIO_TIMER_RULES : CPVRTimersPath::PATH_TV_TIMER_RULES, true);
-  item->SetLabel(g_localizeStrings.Get(19138)); // Timer rules
+  item->SetLabel(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19138)); // Timer rules
   item->SetProperty("node.target", CWindowTranslator::TranslateWindow(
                                        bRadio ? WINDOW_RADIO_TIMER_RULES : WINDOW_TV_TIMER_RULES));
   item->SetArt("icon", "DefaultPVRTimerRules.png");
@@ -201,7 +207,7 @@ bool GetRootDirectory(bool bRadio, CFileItemList& results)
   {
     item = std::make_shared<CFileItem>(
         bRadio ? CPVREpgSearchPath::PATH_RADIO_SEARCH : CPVREpgSearchPath::PATH_TV_SEARCH, true);
-    item->SetLabel(g_localizeStrings.Get(137)); // Search
+    item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(137)); // Search
     item->SetProperty("node.target", CWindowTranslator::TranslateWindow(bRadio ? WINDOW_RADIO_SEARCH
                                                                                : WINDOW_TV_SEARCH));
     item->SetArt("icon", "DefaultPVRSearch.png");
@@ -230,17 +236,20 @@ bool CPVRGUIDirectory::GetDirectory(CFileItemList& results) const
       std::shared_ptr<CFileItem> item;
 
       item = std::make_shared<CFileItem>(base + "channels/", true);
-      item->SetLabel(g_localizeStrings.Get(19019)); // Channels
+      item->SetLabel(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19019)); // Channels
       item->SetLabelPreformatted(true);
       results.Add(item);
 
       item = std::make_shared<CFileItem>(base + "recordings/active/", true);
-      item->SetLabel(g_localizeStrings.Get(19017)); // Recordings
+      item->SetLabel(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19017)); // Recordings
       item->SetLabelPreformatted(true);
       results.Add(item);
 
       item = std::make_shared<CFileItem>(base + "recordings/deleted/", true);
-      item->SetLabel(g_localizeStrings.Get(19184)); // Deleted recordings
+      item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          19184)); // Deleted recordings
       item->SetLabelPreformatted(true);
       results.Add(item);
 
@@ -834,13 +843,14 @@ bool CPVRGUIDirectory::GetChannelsDirectory(CFileItemList& results) const
 
       // all tv channels
       item = std::make_shared<CFileItem>(CPVRChannelsPath::PATH_TV_CHANNELS, true);
-      item->SetLabel(g_localizeStrings.Get(19020)); // TV
+      item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19020)); // TV
       item->SetLabelPreformatted(true);
       results.Add(item);
 
       // all radio channels
       item = std::make_shared<CFileItem>(CPVRChannelsPath::PATH_RADIO_CHANNELS, true);
-      item->SetLabel(g_localizeStrings.Get(19021)); // Radio
+      item->SetLabel(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19021)); // Radio
       item->SetLabelPreformatted(true);
       results.Add(item);
 
@@ -1038,7 +1048,8 @@ bool CPVRGUIDirectory::GetProvidersDirectory(CFileItemList& results) const
         const CPVRProvidersPath channelsPath{path.GetKind(), path.GetClientId(),
                                              path.GetProviderUid(), CPVRProvidersPath::CHANNELS};
         auto channelsItem{std::make_shared<CFileItem>(channelsPath.AsString(), true)};
-        channelsItem->SetLabel(g_localizeStrings.Get(19019)); // Channels
+        channelsItem->SetLabel(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19019)); // Channels
         channelsItem->SetArt("icon", "DefaultPVRChannels.png");
         channelsItem->SetProperty("totalcount", channelCount);
         results.Add(std::move(channelsItem));
@@ -1054,7 +1065,8 @@ bool CPVRGUIDirectory::GetProvidersDirectory(CFileItemList& results) const
                                                path.GetProviderUid(),
                                                CPVRProvidersPath::RECORDINGS};
         auto recordingsItem{std::make_shared<CFileItem>(recordingsPath.AsString(), true)};
-        recordingsItem->SetLabel(g_localizeStrings.Get(19017)); // Recordings
+        recordingsItem->SetLabel(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19017)); // Recordings
         recordingsItem->SetArt("icon", "DefaultPVRRecordings.png");
         recordingsItem->SetProperty("totalcount", recordingCount);
         results.Add(std::move(recordingsItem));

--- a/xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsDatabase.cpp
@@ -16,7 +16,6 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "pvr/PVRDatabase.h"
@@ -27,6 +26,8 @@
 #include "pvr/guilib/PVRGUIActionsParentalControl.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/recordings/PVRRecordingsPath.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -58,52 +59,55 @@ public:
 
     CFileItemList options;
 
-    const auto itemAll{
-        std::make_shared<CFileItem>(StringUtils::Format(g_localizeStrings.Get(593)))}; // All
+    const auto itemAll{std::make_shared<CFileItem>(StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(593)))}; // All
     itemAll->SetPath("all");
     options.Add(itemAll);
 
     // if channels are cleared, groups, EPG data and providers must also be cleared
-    const auto itemChannels{std::make_shared<CFileItem>(
-        StringUtils::Format("{}, {}, {}, {}",
-                            g_localizeStrings.Get(19019), // Channels
-                            g_localizeStrings.Get(19146), // Groups
-                            g_localizeStrings.Get(19069), // Guide
-                            g_localizeStrings.Get(19334)))}; // Providers
+    const auto itemChannels{std::make_shared<CFileItem>(StringUtils::Format(
+        "{}, {}, {}, {}",
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19019), // Channels
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19146), // Groups
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19069), // Guide
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19334)))}; // Providers
     itemChannels->SetPath("channels");
     itemChannels->Select(true); // preselect this item in dialog
     options.Add(itemChannels);
 
-    const auto itemGroups{std::make_shared<CFileItem>(g_localizeStrings.Get(19146))}; // Groups
+    const auto itemGroups{std::make_shared<CFileItem>(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19146))}; // Groups
     itemGroups->SetPath("groups");
     options.Add(itemGroups);
 
-    const auto itemGuide{std::make_shared<CFileItem>(g_localizeStrings.Get(19069))}; // Guide
+    const auto itemGuide{std::make_shared<CFileItem>(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19069))}; // Guide
     itemGuide->SetPath("guide");
     options.Add(itemGuide);
 
-    const auto itemProviders{
-        std::make_shared<CFileItem>(g_localizeStrings.Get(19334))}; // Providers
+    const auto itemProviders{std::make_shared<CFileItem>(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19334))}; // Providers
     itemProviders->SetPath("providers");
     options.Add(itemProviders);
 
-    const auto itemReminders{
-        std::make_shared<CFileItem>(g_localizeStrings.Get(19215))}; // Reminders
+    const auto itemReminders{std::make_shared<CFileItem>(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19215))}; // Reminders
     itemReminders->SetPath("reminders");
     options.Add(itemReminders);
 
-    const auto itemRecordings{
-        std::make_shared<CFileItem>(g_localizeStrings.Get(19017))}; // Recordings
+    const auto itemRecordings{std::make_shared<CFileItem>(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19017))}; // Recordings
     itemRecordings->SetPath("recordings");
     options.Add(itemRecordings);
 
-    const auto itemClients{
-        std::make_shared<CFileItem>(g_localizeStrings.Get(24019))}; // PVR clients
+    const auto itemClients{std::make_shared<CFileItem>(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24019))}; // PVR clients
     itemClients->SetPath("clients");
     options.Add(itemClients);
 
     pDlgSelect->Reset();
-    pDlgSelect->SetHeading(CVariant{g_localizeStrings.Get(19185)}); // "Clear data"
+    pDlgSelect->SetHeading(CVariant{
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19185)}); // "Clear data"
     pDlgSelect->SetItems(options);
     pDlgSelect->SetMultiSelection(true);
     pDlgSelect->Open();
@@ -207,7 +211,9 @@ bool CPVRGUIActionsDatabase::ResetDatabase(bool bResetEPGOnly) const
   CLog::LogFC(LOGDEBUG, LOGPVR, "PVR clearing {} database", bResetEPGOnly ? "EPG" : "PVR and EPG");
 
   pDlgProgress->SetHeading(CVariant{313}); // "Cleaning database"
-  pDlgProgress->SetLine(0, CVariant{g_localizeStrings.Get(19187)}); // "Clearing all related data."
+  pDlgProgress->SetLine(0,
+                        CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                            19187)}); // "Clearing all related data."
   pDlgProgress->SetLine(1, CVariant{""});
   pDlgProgress->SetLine(2, CVariant{""});
 

--- a/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsEPG.cpp
@@ -16,7 +16,6 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "pvr/PVRItem.h"
 #include "pvr/PVRManager.h"
@@ -27,6 +26,8 @@
 #include "pvr/epg/EpgSearchFilter.h"
 #include "pvr/guilib/PVRGUIActionsParentalControl.h"
 #include "pvr/windows/GUIWindowPVRSearch.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
@@ -193,9 +194,11 @@ bool CPVRGUIActionsEPG::RenameSavedSearch(const CFileItem& item) const
   }
 
   std::string title = searchFilter->GetTitle();
-  if (CGUIKeyboardFactory::ShowAndGetInput(title,
-                                           CVariant{g_localizeStrings.Get(528)}, // "Enter title"
-                                           false))
+  if (CGUIKeyboardFactory::ShowAndGetInput(
+          title,
+          CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              528)}, // "Enter title"
+          false))
   {
     searchFilter->SetTitle(title);
     CServiceBroker::GetPVRManager().EpgContainer().PersistSavedSearch(*searchFilter);
@@ -221,21 +224,25 @@ bool CPVRGUIActionsEPG::ChooseIconForSavedSearch(const CFileItem& item) const
   const std::string iconPath{searchFilter->GetIconPath()};
   auto current{std::make_shared<CFileItem>("icon://Current", false)};
   current->SetArt("icon", iconPath.empty() ? "DefaultPVRSearch.png" : iconPath);
-  current->SetLabel(g_localizeStrings.Get(19282)); // Current icon
+  current->SetLabel(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19282)); // Current icon
   items.Add(std::move(current));
 
   // And add a "No icon" entry as well.
   auto nothumb{std::make_shared<CFileItem>("icon://None", false)};
   nothumb->SetArt("icon", "DefaultPVRSearch.png");
-  nothumb->SetLabel(g_localizeStrings.Get(19283)); // No icon
+  nothumb->SetLabel(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19283)); // No icon
   items.Add(std::move(nothumb));
 
   std::string icon;
   std::vector<CMediaSource> sources;
   CServiceBroker::GetMediaManager().GetLocalDrives(sources);
-  if (!CGUIDialogFileBrowser::ShowAndGetImage(items, sources,
-                                              g_localizeStrings.Get(19285), // Browse for icon
-                                              icon))
+  if (!CGUIDialogFileBrowser::ShowAndGetImage(
+          items, sources,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              19285), // Browse for icon
+          icon))
     return false;
 
   if (icon == "icon://Current")
@@ -261,8 +268,9 @@ bool CPVRGUIActionsEPG::DuplicateSavedSearch(const CFileItem& item) const
 
   const auto dupedSearchFilter{std::make_shared<CPVREpgSearchFilter>(*searchFilter)};
   dupedSearchFilter->SetDatabaseId(PVR_EPG_SEARCH_INVALID_DATABASE_ID); // force new db entry
-  dupedSearchFilter->SetTitle(StringUtils::Format(g_localizeStrings.Get(19356), // Copy of '<title>'
-                                                  searchFilter->GetTitle()));
+  dupedSearchFilter->SetTitle(StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19356), // Copy of '<title>'
+      searchFilter->GetTitle()));
   CServiceBroker::GetPVRManager().EpgContainer().PersistSavedSearch(*dupedSearchFilter);
   return true;
 }
@@ -292,14 +300,16 @@ std::string CPVRGUIActionsEPG::GetTitleForEpgTag(
   if (tag)
   {
     if (CServiceBroker::GetPVRManager().IsParentalLocked(tag))
-      return g_localizeStrings.Get(19266); // Parental locked
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          19266); // Parental locked
     else if (!tag->Title().empty())
       return tag->Title();
   }
 
   if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
           CSettings::SETTING_EPG_HIDENOINFOAVAILABLE))
-    return g_localizeStrings.Get(19055); // no information available
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        19055); // no information available
 
   return {};
 }

--- a/xbmc/pvr/guilib/PVRGUIActionsParentalControl.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsParentalControl.cpp
@@ -10,11 +10,12 @@
 
 #include "ServiceBroker.h"
 #include "dialogs/GUIDialogNumeric.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "pvr/PVRManager.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/settings/PVRSettings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -58,7 +59,8 @@ ParentalCheckResult CPVRGUIActionsParentalControl::CheckParentalPIN() const
     return ParentalCheckResult::SUCCESS;
 
   InputVerificationResult ret = CGUIDialogNumeric::ShowAndVerifyInput(
-      pinCode, g_localizeStrings.Get(19262), true); // "Parental control. Enter PIN:"
+      pinCode, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19262),
+      true); // "Parental control. Enter PIN:"
 
   if (ret == InputVerificationResult::SUCCESS)
   {

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -17,7 +17,6 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "pvr/PVRItem.h"
@@ -34,6 +33,8 @@
 #include "pvr/recordings/PVRRecording.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/settings/PVRSettings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
@@ -246,12 +247,17 @@ bool CPVRGUIActionsPlayback::SwitchToChannel(const CFileItem& item) const
   else if (result == ParentalCheckResult::FAILED)
   {
     const std::string channelName =
-        channel ? channel->ChannelName() : g_localizeStrings.Get(19029); // Channel
-    const std::string msg = StringUtils::Format(g_localizeStrings.Get(19035),
-                                                channelName); // CHANNELNAME could not be played.
+        channel
+            ? channel->ChannelName()
+            : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19029); // Channel
+    const std::string msg =
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19035),
+                            channelName); // CHANNELNAME could not be played.
 
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(19166),
-                                          msg); // PVR information
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Error,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19166),
+        msg); // PVR information
   }
 
   return false;
@@ -331,10 +337,10 @@ bool CPVRGUIActionsPlayback::SwitchToChannel(PlaybackType type) const
 
   CGUIDialogKaiToast::QueueNotification(
       CGUIDialogKaiToast::Error,
-      g_localizeStrings.Get(19166), // PVR information
-      StringUtils::Format(
-          g_localizeStrings.Get(19035),
-          g_localizeStrings.Get(bIsRadio ? 19021 : 19020))); // Radio/TV could not be played.
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19166), // PVR information
+      StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19035),
+                          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                              bIsRadio ? 19021 : 19020))); // Radio/TV could not be played.
   return false;
 }
 

--- a/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
@@ -10,7 +10,6 @@
 
 #include "FileItem.h"
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "network/Network.h"
 #include "pvr/PVRManager.h"
@@ -18,6 +17,8 @@
 #include "pvr/settings/PVRSettings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
@@ -55,7 +56,8 @@ bool CPVRGUIActionsPowerManagement::CanSystemPowerdown(bool bAskUser /*= true*/)
           if (cause->IsRecording())
           {
             text = StringUtils::Format(
-                g_localizeStrings.Get(19691), // "PVR is currently recording...."
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                    19691), // "PVR is currently recording...."
                 cause->Title(), cause->ChannelName());
           }
           else
@@ -73,18 +75,21 @@ bool CPVRGUIActionsPowerManagement::CanSystemPowerdown(bool bAskUser /*= true*/)
             if (mins > 1)
             {
               // "%d minutes"
-              dueStr = StringUtils::Format(g_localizeStrings.Get(19694), mins);
+              dueStr = StringUtils::Format(
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19694), mins);
             }
             else
             {
               // "about a minute"
-              dueStr = g_localizeStrings.Get(19695);
+              dueStr = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19695);
             }
 
             text = StringUtils::Format(
                 cause->IsReminder()
-                    ? g_localizeStrings.Get(19690) // "PVR has scheduled a reminder...."
-                    : g_localizeStrings.Get(19692), // "PVR will start recording...."
+                    ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                          19690) // "PVR has scheduled a reminder...."
+                    : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                          19692), // "PVR will start recording...."
                 cause->Title(), cause->ChannelName(), dueStr);
           }
         }
@@ -105,16 +110,19 @@ bool CPVRGUIActionsPowerManagement::CanSystemPowerdown(bool bAskUser /*= true*/)
           if (mins > 1)
           {
             // "%d minutes"
-            dueStr = StringUtils::Format(g_localizeStrings.Get(19694), mins);
+            dueStr = StringUtils::Format(
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19694), mins);
           }
           else
           {
             // "about a minute"
-            dueStr = g_localizeStrings.Get(19695);
+            dueStr = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19695);
           }
 
-          text = StringUtils::Format(g_localizeStrings.Get(19693), // "Daily wakeup is due in...."
-                                     dueStr);
+          text =
+              StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                      19693), // "Daily wakeup is due in...."
+                                  dueStr);
         }
 
         // Inform user about PVR being busy. Ask if user wants to powerdown anyway.

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
@@ -17,7 +17,6 @@
 #include "filesystem/IDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "jobs/JobManager.h"
 #include "messaging/helpers/DialogHelper.h"
@@ -32,6 +31,8 @@
 #include "pvr/recordings/PVRRecording.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/settings/PVRSettings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "threads/IRunnable.h"
 #include "utils/StringUtils.h"
@@ -420,12 +421,15 @@ bool CPVRGUIActionsRecordings::ProcessDeleteAfterWatch(const CFileItem& item) co
     if (AsyncDeleteRecording().Execute(item))
     {
       auto* job{new CPVREventLogJob};
-      job->AddEvent(true, // display a toast, and log event
-                    EventLevel::Information, // info, no error
-                    g_localizeStrings.Get(860), // "Delete after watching"
-                    StringUtils::Format(g_localizeStrings.Get(866), // Recording deleted: <title>
-                                        item.GetPVRRecordingInfoTag()->GetTitle()),
-                    item.GetPVRRecordingInfoTag()->IconPath());
+      job->AddEvent(
+          true, // display a toast, and log event
+          EventLevel::Information, // info, no error
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              860), // "Delete after watching"
+          StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                  866), // Recording deleted: <title>
+                              item.GetPVRRecordingInfoTag()->GetTitle()),
+          item.GetPVRRecordingInfoTag()->IconPath());
       CServiceBroker::GetJobManager()->AddJob(job, nullptr);
     }
     else

--- a/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsTimers.cpp
@@ -16,7 +16,6 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "jobs/JobManager.h"
 #include "messaging/helpers/DialogHelper.h"
@@ -37,6 +36,8 @@
 #include "pvr/settings/PVRSettings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "threads/IRunnable.h"
 #include "utils/StringUtils.h"
@@ -376,29 +377,34 @@ void InstantRecordingActionSelector::AddAction(PVRRECORD_INSTANTRECORDACTION eAc
     switch (eAction)
     {
       case RECORD_INSTANTRECORDTIME:
-        m_pDlgSelect->Add(
-            StringUtils::Format(g_localizeStrings.Get(19090),
-                                m_iInstantRecordTime)); // Record next <default duration> minutes
+        m_pDlgSelect->Add(StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19090),
+            m_iInstantRecordTime)); // Record next <default duration> minutes
         break;
       case RECORD_30_MINUTES:
-        m_pDlgSelect->Add(
-            StringUtils::Format(g_localizeStrings.Get(19090), 30)); // Record next 30 minutes
+        m_pDlgSelect->Add(StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19090),
+            30)); // Record next 30 minutes
         break;
       case RECORD_60_MINUTES:
-        m_pDlgSelect->Add(
-            StringUtils::Format(g_localizeStrings.Get(19090), 60)); // Record next 60 minutes
+        m_pDlgSelect->Add(StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19090),
+            60)); // Record next 60 minutes
         break;
       case RECORD_120_MINUTES:
-        m_pDlgSelect->Add(
-            StringUtils::Format(g_localizeStrings.Get(19090), 120)); // Record next 120 minutes
+        m_pDlgSelect->Add(StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19090),
+            120)); // Record next 120 minutes
         break;
       case RECORD_CURRENT_SHOW:
-        m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19091),
-                                              title)); // Record current show (<title>)
+        m_pDlgSelect->Add(StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19091),
+            title)); // Record current show (<title>)
         break;
       case RECORD_NEXT_SHOW:
-        m_pDlgSelect->Add(StringUtils::Format(g_localizeStrings.Get(19092),
-                                              title)); // Record next show (<title>)
+        m_pDlgSelect->Add(StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19092),
+            title)); // Record next show (<title>)
         break;
       case NONE:
       case ASK:
@@ -506,7 +512,9 @@ bool CPVRGUIActionsTimers::SetRecordingOnChannel(const std::shared_ptr<CPVRChann
 
             // "now"
             const std::string currentTitle =
-                bLocked ? g_localizeStrings.Get(19266) /* Parental locked */ : epgTag->Title();
+                bLocked ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                              19266) /* Parental locked */
+                        : epgTag->Title();
             selector.AddAction(RECORD_CURRENT_SHOW, currentTitle);
             ePreselect = RECORD_CURRENT_SHOW;
 
@@ -514,9 +522,10 @@ bool CPVRGUIActionsTimers::SetRecordingOnChannel(const std::shared_ptr<CPVRChann
             epgTagNext = channel->GetEPGNext();
             if (epgTagNext)
             {
-              const std::string nextTitle = bLocked
-                                                ? g_localizeStrings.Get(19266) /* Parental locked */
-                                                : epgTagNext->Title();
+              const std::string nextTitle =
+                  bLocked ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                19266) /* Parental locked */
+                          : epgTagNext->Title();
               selector.AddAction(RECORD_NEXT_SHOW, nextTitle);
 
               // be smart. if current show is almost over, preselect next show.
@@ -865,15 +874,16 @@ std::string GetAnnouncerText(const std::shared_ptr<const CPVRTimerInfoTag>& time
   std::string text;
   if (timer->IsEpgBased())
   {
-    text = StringUtils::Format(g_localizeStrings.Get(idEpg),
-                               timer->Title(), // tv show title
-                               timer->ChannelName(),
-                               timer->StartAsLocalTime().GetAsLocalizedDateTime(false, false));
+    text = StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(idEpg),
+        timer->Title(), // tv show title
+        timer->ChannelName(), timer->StartAsLocalTime().GetAsLocalizedDateTime(false, false));
   }
   else
   {
-    text = StringUtils::Format(g_localizeStrings.Get(idNoEpg), timer->ChannelName(),
-                               timer->StartAsLocalTime().GetAsLocalizedDateTime(false, false));
+    text = StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(idNoEpg),
+        timer->ChannelName(), timer->StartAsLocalTime().GetAsLocalizedDateTime(false, false));
   }
   return text;
 }
@@ -946,7 +956,7 @@ void CPVRGUIActionsTimers::AnnounceReminder(const std::shared_ptr<CPVRTimerInfoT
     if (autoRecord)
     {
       // (Auto-close of this reminder will schedule a recording...)
-      text += "\n\n" + g_localizeStrings.Get(19309);
+      text += "\n\n" + CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19309);
     }
   }
 
@@ -958,7 +968,7 @@ void CPVRGUIActionsTimers::AnnounceReminder(const std::shared_ptr<CPVRTimerInfoT
     if (autoSwitch)
     {
       // (Auto-close of this reminder will switch to channel...)
-      text += "\n\n" + g_localizeStrings.Get(19331);
+      text += "\n\n" + CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19331);
     }
   }
 

--- a/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
+++ b/xbmc/pvr/guilib/PVRGUIChannelIconUpdater.cpp
@@ -13,11 +13,12 @@
 #include "ServiceBroker.h"
 #include "Util.h"
 #include "filesystem/Directory.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/channels/PVRChannel.h"
 #include "pvr/channels/PVRChannelGroup.h"
 #include "pvr/channels/PVRChannelGroupMember.h"
 #include "pvr/guilib/PVRGUIProgressHandler.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -63,7 +64,8 @@ void CPVRGUIChannelIconUpdater::SearchAndUpdateMissingChannelIcons() const
   std::unique_ptr<CPVRGUIProgressHandler> progressHandler;
   if (!m_groups.empty())
     progressHandler = std::make_unique<CPVRGUIProgressHandler>(
-        g_localizeStrings.Get(19286)); // Searching for channel icons
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            19286)); // Searching for channel icons
 
   for (const auto& group : m_groups)
   {

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -16,7 +16,6 @@
 #include "application/ApplicationPlayer.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "pvr/PVRItem.h"
@@ -41,6 +40,8 @@
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -109,7 +110,8 @@ void CPVRGUIInfo::ResetProperties()
 
 void CPVRGUIInfo::ClearQualityInfo(CPVRSignalStatus& qualityInfo) const
 {
-  qualityInfo = {g_localizeStrings.Get(13106), g_localizeStrings.Get(13106)};
+  qualityInfo = {CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13106),
+                 CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13106)};
 }
 
 void CPVRGUIInfo::ClearDescrambleInfo(CPVRDescrambleInfo& descrambleInfo) const
@@ -642,7 +644,8 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
         lastExecLocal.SetFromUTCDateTime(filter->GetLastExecutedDateTime());
         strValue = GetAsLocalizedDateTimeString(lastExecLocal);
         if (strValue.empty())
-          strValue = g_localizeStrings.Get(10006); // "N/A"
+          strValue =
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10006); // "N/A"
         return true;
       }
       default:
@@ -667,13 +670,16 @@ bool CPVRGUIInfo::GetListItemAndPlayerLabel(const CFileItem* item,
             using enum CPVRChannelGroup::Origin;
 
             case CLIENT:
-              strValue = g_localizeStrings.Get(856); // Client
+              strValue =
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(856); // Client
               return true;
             case SYSTEM:
-              strValue = g_localizeStrings.Get(857); // System
+              strValue =
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(857); // System
               return true;
             case USER:
-              strValue = g_localizeStrings.Get(858); // User
+              strValue =
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(858); // User
               return true;
             default:
               break;
@@ -1968,10 +1974,11 @@ void CPVRGUIInfo::CharInfoBackendNumber(std::string& strValue) const
   size_t numBackends = m_backendProperties.size();
 
   if (numBackends > 0)
-    strValue = StringUtils::Format("{0} {1} {2}", m_iCurrentActiveClient + 1,
-                                   g_localizeStrings.Get(20163), numBackends);
+    strValue = StringUtils::Format(
+        "{0} {1} {2}", m_iCurrentActiveClient + 1,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20163), numBackends);
   else
-    strValue = g_localizeStrings.Get(14023);
+    strValue = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14023);
 }
 
 void CPVRGUIInfo::CharInfoTotalDiskSpace(std::string& strValue) const
@@ -2003,14 +2010,14 @@ void CPVRGUIInfo::CharInfoFrontendName(std::string& strValue) const
 {
   strValue = m_qualityInfo.AdapterName();
   if (strValue.empty())
-    strValue = g_localizeStrings.Get(13205);
+    strValue = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
 }
 
 void CPVRGUIInfo::CharInfoFrontendStatus(std::string& strValue) const
 {
   strValue = m_qualityInfo.AdapterStatus();
   if (strValue.empty())
-    strValue = g_localizeStrings.Get(13205);
+    strValue = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
 }
 
 void CPVRGUIInfo::CharInfoClientName(std::string& strValue) const
@@ -2052,12 +2059,12 @@ void CPVRGUIInfo::CharInfoBackendDiskspace(std::string& strValue) const
 
   if (diskTotal > 0)
   {
-    strValue = StringUtils::Format(g_localizeStrings.Get(802),
-                                   StringUtils::SizeToString(diskTotal - diskUsed),
-                                   StringUtils::SizeToString(diskTotal));
+    strValue = StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(802),
+        StringUtils::SizeToString(diskTotal - diskUsed), StringUtils::SizeToString(diskTotal));
   }
   else
-    strValue = g_localizeStrings.Get(13205);
+    strValue = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
 }
 
 void CPVRGUIInfo::CharInfoBackendProviders(std::string& strValue) const
@@ -2099,7 +2106,7 @@ void CPVRGUIInfo::CharInfoBackendDeletedRecordings(std::string& strValue) const
 void CPVRGUIInfo::CharInfoPlayingClientName(std::string& strValue) const
 {
   if (m_strPlayingClientName.empty())
-    strValue = g_localizeStrings.Get(13205);
+    strValue = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
   else
     strValue = m_strPlayingClientName;
 }
@@ -2130,21 +2137,21 @@ void CPVRGUIInfo::CharInfoService(std::string& strValue) const
 {
   strValue = m_qualityInfo.ServiceName();
   if (strValue.empty())
-    strValue = g_localizeStrings.Get(13205);
+    strValue = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
 }
 
 void CPVRGUIInfo::CharInfoMux(std::string& strValue) const
 {
   strValue = m_qualityInfo.MuxName();
   if (strValue.empty())
-    strValue = g_localizeStrings.Get(13205);
+    strValue = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
 }
 
 void CPVRGUIInfo::CharInfoProvider(std::string& strValue) const
 {
   strValue = m_qualityInfo.ProviderName();
   if (strValue.empty())
-    strValue = g_localizeStrings.Get(13205);
+    strValue = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
 }
 
 void CPVRGUIInfo::UpdateBackendCache()
@@ -2166,17 +2173,19 @@ void CPVRGUIInfo::UpdateBackendCache()
   }
 
   // Store some defaults
-  m_strClientName = g_localizeStrings.Get(13205);
-  m_strInstanceName = g_localizeStrings.Get(13205);
-  m_strBackendName = g_localizeStrings.Get(13205);
-  m_strBackendVersion = g_localizeStrings.Get(13205);
-  m_strBackendHost = g_localizeStrings.Get(13205);
-  m_strBackendProviders = g_localizeStrings.Get(13205);
-  m_strBackendChannelGroups = g_localizeStrings.Get(13205);
-  m_strBackendChannels = g_localizeStrings.Get(13205);
-  m_strBackendTimers = g_localizeStrings.Get(13205);
-  m_strBackendRecordings = g_localizeStrings.Get(13205);
-  m_strBackendDeletedRecordings = g_localizeStrings.Get(13205);
+  m_strClientName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
+  m_strInstanceName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
+  m_strBackendName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
+  m_strBackendVersion = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
+  m_strBackendHost = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
+  m_strBackendProviders = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
+  m_strBackendChannelGroups =
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
+  m_strBackendChannels = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
+  m_strBackendTimers = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
+  m_strBackendRecordings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
+  m_strBackendDeletedRecordings =
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205);
   m_iBackendDiskTotal = 0;
   m_iBackendDiskUsed = 0;
 

--- a/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUITimerInfo.cpp
@@ -9,10 +9,11 @@
 #include "PVRGUITimerInfo.h"
 
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -142,10 +143,11 @@ void CPVRGUITimerInfo::UpdateNextTimer()
     strNextRecordingChannelIcon = timer->ChannelIcon();
     strNextRecordingTime = timer->StartAsLocalTime().GetAsLocalizedDateTime(false, false);
 
-    strNextTimerInfo = StringUtils::Format("{} {} {} {}", g_localizeStrings.Get(19106),
-                                           timer->StartAsLocalTime().GetAsLocalizedDate(true),
-                                           g_localizeStrings.Get(19107),
-                                           timer->StartAsLocalTime().GetAsLocalizedTime("", false));
+    strNextTimerInfo = StringUtils::Format(
+        "{} {} {} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19106),
+        timer->StartAsLocalTime().GetAsLocalizedDate(true),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19107),
+        timer->StartAsLocalTime().GetAsLocalizedTime("", false));
   }
 
   std::unique_lock lock(m_critSection);

--- a/xbmc/pvr/providers/PVRProvider.cpp
+++ b/xbmc/pvr/providers/PVRProvider.cpp
@@ -9,7 +9,6 @@
 #include "PVRProvider.h"
 
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -10,7 +10,6 @@
 
 #include "ServiceBroker.h"
 #include "cores/EdlEdit.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/channels/PVRChannel.h"
@@ -21,6 +20,8 @@
 #include "pvr/recordings/PVRRecordingsPath.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimers.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/MathUtils.h"
@@ -479,7 +480,8 @@ void CPVRRecording::Update(const CPVRRecording& tag, const CPVRClient& client)
   }
 
   //Old Method of identifying TV show title and subtitle using m_strDirectory and strPlotOutline (deprecated)
-  std::string strShow = StringUtils::Format("{} - ", g_localizeStrings.Get(20364));
+  std::string strShow = StringUtils::Format(
+      "{} - ", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20364));
   if (StringUtils::StartsWithNoCase(m_strPlotOutline, strShow))
   {
     CLog::Log(LOGWARNING, "PVR addon provides episode name in strPlotOutline which is deprecated");

--- a/xbmc/pvr/settings/PVRIntSettingValues.cpp
+++ b/xbmc/pvr/settings/PVRIntSettingValues.cpp
@@ -8,8 +8,10 @@
 
 #include "PVRIntSettingValues.h"
 
+#include "ServiceBroker.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_defines.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 #include <string>
@@ -34,8 +36,11 @@ CPVRIntSettingValues::CPVRIntSettingValues(const struct PVR_ATTRIBUTE_INT_VALUE*
       {
         // No description given by addon. Create one from value.
         if (defaultDescriptionResourceId > 0)
-          description = StringUtils::Format(
-              "{} {}", g_localizeStrings.Get(defaultDescriptionResourceId), value);
+          description =
+              StringUtils::Format("{} {}",
+                                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                      defaultDescriptionResourceId),
+                                  value);
         else
           description = std::to_string(value);
       }

--- a/xbmc/pvr/settings/PVRSettings.cpp
+++ b/xbmc/pvr/settings/PVRSettings.cpp
@@ -9,10 +9,11 @@
 #include "PVRSettings.h"
 
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/guilib/PVRGUIActionsParentalControl.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/SettingsManager.h"
@@ -183,8 +184,10 @@ void CPVRSettings::MarginTimeFiller(const SettingConstPtr& /*setting*/,
 
   for (int iValue : marginTimeValues)
   {
-    list.emplace_back(StringUtils::Format(g_localizeStrings.Get(14044), iValue) /* {} min */,
-                      iValue);
+    list.emplace_back(
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14044),
+                            iValue) /* {} min */,
+        iValue);
   }
 }
 

--- a/xbmc/pvr/settings/PVRStringSettingValues.cpp
+++ b/xbmc/pvr/settings/PVRStringSettingValues.cpp
@@ -8,8 +8,10 @@
 
 #include "PVRStringSettingValues.h"
 
+#include "ServiceBroker.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_defines.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 #include <string>
@@ -34,8 +36,11 @@ CPVRStringSettingValues::CPVRStringSettingValues(const struct PVR_ATTRIBUTE_STRI
       {
         // No description given by addon. Create one from value.
         if (defaultDescriptionResourceId > 0)
-          description = StringUtils::Format(
-              "{} {}", g_localizeStrings.Get(defaultDescriptionResourceId), value);
+          description =
+              StringUtils::Format("{} {}",
+                                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                      defaultDescriptionResourceId),
+                                  value);
         else
           description = value;
       }

--- a/xbmc/pvr/timers/PVRTimerInfoTag.cpp
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.cpp
@@ -9,7 +9,6 @@
 #include "PVRTimerInfoTag.h"
 
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRDatabase.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
@@ -20,6 +19,8 @@
 #include "pvr/epg/Epg.h"
 #include "pvr/epg/EpgInfoTag.h"
 #include "pvr/timers/PVRTimersPath.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -36,7 +37,8 @@
 using namespace PVR;
 
 CPVRTimerInfoTag::CPVRTimerInfoTag(bool bRadio /* = false */)
-  : m_strTitle(g_localizeStrings.Get(19056)), // New Timer
+  : m_strTitle(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19056)), // New Timer
     m_iClientId(CServiceBroker::GetPVRManager().Clients()->GetFirstCreatedClientID()),
     m_iClientIndex(PVR_TIMER_NO_CLIENT_INDEX),
     m_iParentClientIndex(PVR_TIMER_NO_PARENT),
@@ -334,6 +336,7 @@ void CPVRTimerInfoTag::UpdateSummary()
   std::unique_lock lock(m_critSection);
   m_strSummary.clear();
 
+  auto& localizeStrings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
   const std::string startDate(StartAsLocalTime().GetAsLocalizedDate());
   const std::string endDate(EndAsLocalTime().GetAsLocalizedDate());
 
@@ -349,34 +352,31 @@ void CPVRTimerInfoTag::UpdateSummary()
         "{} {} {}",
         m_iWeekdays != PVR_WEEKDAY_NONE ? GetWeekdaysString()
                                         : startDate, //for "Any day" set PVR_WEEKDAY_ALLDAYS
-        g_localizeStrings.Get(19107), // "at"
-        m_bStartAnyTime ? g_localizeStrings.Get(19161) /* "any time" */
+        localizeStrings.Get(19107), // "at"
+        m_bStartAnyTime ? localizeStrings.Get(19161) /* "any time" */
                         : StartAsLocalTime().GetAsLocalizedTime("", false));
   }
   else if ((m_iWeekdays != PVR_WEEKDAY_NONE) || (startDate == endDate))
   {
+    const std::string anyTime = localizeStrings.Get(19161); // "any time"
     m_strSummary = StringUtils::Format(
         "{} {} {} {} {}",
         m_iWeekdays != PVR_WEEKDAY_NONE ? GetWeekdaysString()
                                         : startDate, //for "Any day" set PVR_WEEKDAY_ALLDAYS
-        g_localizeStrings.Get(19159), // "from"
-        m_bStartAnyTime ? g_localizeStrings.Get(19161) /* "any time" */
-                        : StartAsLocalTime().GetAsLocalizedTime("", false),
-        g_localizeStrings.Get(19160), // "to"
-        m_bEndAnyTime ? g_localizeStrings.Get(19161) /* "any time" */
-                      : EndAsLocalTime().GetAsLocalizedTime("", false));
+        localizeStrings.Get(19159), // "from"
+        m_bStartAnyTime ? anyTime : StartAsLocalTime().GetAsLocalizedTime("", false),
+        localizeStrings.Get(19160), // "to"
+        m_bEndAnyTime ? anyTime : EndAsLocalTime().GetAsLocalizedTime("", false));
   }
   else
   {
-    m_strSummary =
-        StringUtils::Format("{} {} {} {} {} {}", startDate,
-                            g_localizeStrings.Get(19159), // "from"
-                            m_bStartAnyTime ? g_localizeStrings.Get(19161) /* "any time" */
-                                            : StartAsLocalTime().GetAsLocalizedTime("", false),
-                            g_localizeStrings.Get(19160), // "to"
-                            endDate,
-                            m_bEndAnyTime ? g_localizeStrings.Get(19161) /* "any time" */
-                                          : EndAsLocalTime().GetAsLocalizedTime("", false));
+    const std::string anyTime = localizeStrings.Get(19161); // "any time"
+    m_strSummary = StringUtils::Format(
+        "{} {} {} {} {} {}", startDate,
+        localizeStrings.Get(19159), // "from"
+        m_bStartAnyTime ? anyTime : StartAsLocalTime().GetAsLocalizedTime("", false),
+        localizeStrings.Get(19160), // "to"
+        endDate, m_bEndAnyTime ? anyTime : EndAsLocalTime().GetAsLocalizedTime("", false));
   }
 }
 
@@ -403,40 +403,41 @@ void CPVRTimerInfoTag::SetTimerType(const std::shared_ptr<CPVRTimerType>& type)
 
 std::string CPVRTimerInfoTag::GetStatus(bool bRadio) const
 {
-  std::string strReturn = g_localizeStrings.Get(305);
+  auto& localizeStrings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
+  std::string strReturn = localizeStrings.Get(305);
   std::unique_lock lock(m_critSection);
   if (URIUtils::PathEquals(m_strFileNameAndPath, CPVRTimersPath::PATH_ADDTIMER))
-    strReturn = g_localizeStrings.Get(19026);
+    strReturn = localizeStrings.Get(19026);
   else if (m_state == PVR_TIMER_STATE_CANCELLED || m_state == PVR_TIMER_STATE_ABORTED)
-    strReturn = g_localizeStrings.Get(13106);
+    strReturn = localizeStrings.Get(13106);
   else if (m_state == PVR_TIMER_STATE_RECORDING)
-    strReturn = g_localizeStrings.Get(19162);
+    strReturn = localizeStrings.Get(19162);
   else if (m_state == PVR_TIMER_STATE_CONFLICT_OK)
-    strReturn = g_localizeStrings.Get(19275);
+    strReturn = localizeStrings.Get(19275);
   else if (m_state == PVR_TIMER_STATE_CONFLICT_NOK)
-    strReturn = g_localizeStrings.Get(19276);
+    strReturn = localizeStrings.Get(19276);
   else if (m_state == PVR_TIMER_STATE_ERROR)
-    strReturn = g_localizeStrings.Get(257);
+    strReturn = localizeStrings.Get(257);
   else if (m_state == PVR_TIMER_STATE_DISABLED)
-    strReturn = g_localizeStrings.Get(13106);
+    strReturn = localizeStrings.Get(13106);
   else if (m_state == PVR_TIMER_STATE_COMPLETED)
   {
     if ((m_iTVChildTimersRecording > 0 && !bRadio) || (m_iRadioChildTimersRecording > 0 && bRadio))
-      strReturn = g_localizeStrings.Get(19162); // "Recording active"
+      strReturn = localizeStrings.Get(19162); // "Recording active"
     else
-      strReturn = g_localizeStrings.Get(19256); // "Completed"
+      strReturn = localizeStrings.Get(19256); // "Completed"
   }
   else if (m_state == PVR_TIMER_STATE_SCHEDULED || m_state == PVR_TIMER_STATE_NEW)
   {
     if ((m_iTVChildTimersRecording > 0 && !bRadio) || (m_iRadioChildTimersRecording > 0 && bRadio))
-      strReturn = g_localizeStrings.Get(19162); // "Recording active"
+      strReturn = localizeStrings.Get(19162); // "Recording active"
     else if ((m_iTVChildTimersErrors > 0 && !bRadio) || (m_iRadioChildTimersErrors > 0 && bRadio))
-      strReturn = g_localizeStrings.Get(257); // "Error"
+      strReturn = localizeStrings.Get(257); // "Error"
     else if ((m_iTVChildTimersConflictNOK > 0 && !bRadio) ||
              (m_iRadioChildTimersConflictNOK > 0 && bRadio))
-      strReturn = g_localizeStrings.Get(19276); // "Conflict error"
+      strReturn = localizeStrings.Get(19276); // "Conflict error"
     else if ((m_iTVChildTimersActive > 0 && !bRadio) || (m_iRadioChildTimersActive > 0 && bRadio))
-      strReturn = StringUtils::Format(g_localizeStrings.Get(19255),
+      strReturn = StringUtils::Format(localizeStrings.Get(19255),
                                       bRadio ? m_iRadioChildTimersActive
                                              : m_iTVChildTimersActive); // "{} scheduled"
   }
@@ -461,7 +462,7 @@ void AppendDay(std::string& strReturn, unsigned int iId)
     strReturn += "-";
 
   if (iId > 0)
-    strReturn += g_localizeStrings.Get(iId).c_str();
+    strReturn += CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(iId).c_str();
   else
     strReturn += "__";
 }
@@ -475,23 +476,26 @@ std::string CPVRTimerInfoTag::GetWeekdaysString(unsigned int iWeekdays,
 
   if (iWeekdays == PVR_WEEKDAY_NONE)
     return strReturn;
-  else if (iWeekdays == PVR_WEEKDAY_ALLDAYS)
-    strReturn = bEpgBased ? g_localizeStrings.Get(807) // "Any day"
-                          : g_localizeStrings.Get(808); // "Every day"
+
+  auto& localizeStrings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
+
+  if (iWeekdays == PVR_WEEKDAY_ALLDAYS)
+    strReturn = bEpgBased ? localizeStrings.Get(807) // "Any day"
+                          : localizeStrings.Get(808); // "Every day"
   else if (iWeekdays == PVR_WEEKDAY_MONDAY)
-    strReturn = g_localizeStrings.Get(831); // "Mondays"
+    strReturn = localizeStrings.Get(831); // "Mondays"
   else if (iWeekdays == PVR_WEEKDAY_TUESDAY)
-    strReturn = g_localizeStrings.Get(832); // "Tuesdays"
+    strReturn = localizeStrings.Get(832); // "Tuesdays"
   else if (iWeekdays == PVR_WEEKDAY_WEDNESDAY)
-    strReturn = g_localizeStrings.Get(833); // "Wednesdays"
+    strReturn = localizeStrings.Get(833); // "Wednesdays"
   else if (iWeekdays == PVR_WEEKDAY_THURSDAY)
-    strReturn = g_localizeStrings.Get(834); // "Thursdays"
+    strReturn = localizeStrings.Get(834); // "Thursdays"
   else if (iWeekdays == PVR_WEEKDAY_FRIDAY)
-    strReturn = g_localizeStrings.Get(835); // "Fridays"
+    strReturn = localizeStrings.Get(835); // "Fridays"
   else if (iWeekdays == PVR_WEEKDAY_SATURDAY)
-    strReturn = g_localizeStrings.Get(836); // "Saturdays"
+    strReturn = localizeStrings.Get(836); // "Saturdays"
   else if (iWeekdays == PVR_WEEKDAY_SUNDAY)
-    strReturn = g_localizeStrings.Get(837); // "Sundays"
+    strReturn = localizeStrings.Get(837); // "Sundays"
   else
   {
     // Any other combination. Assemble custom string.
@@ -720,7 +724,9 @@ std::string CPVRTimerInfoTag::ChannelName() const
   if (channeltag)
     strReturn = channeltag->ChannelName();
   else if (m_timerType->IsEpgBasedTimerRule())
-    strReturn = StringUtils::Format("({})", g_localizeStrings.Get(809)); // "Any channel"
+    strReturn = StringUtils::Format(
+        "({})",
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(809)); // "Any channel"
 
   return strReturn;
 }
@@ -868,7 +874,9 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimerInfoTag::CreateFromDate(
   if (bInstantStart)
   {
     // "Instant recording: <summary>
-    newTimer->m_strSummary = StringUtils::Format(g_localizeStrings.Get(19093), newTimer->Summary());
+    newTimer->m_strSummary =
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19093),
+                            newTimer->Summary());
 
     // now that we have a nice summary, we can set the "special" start time value that indicates an instant recording
     newTimer->SetStartFromUTC(start);
@@ -1114,7 +1122,9 @@ std::string CPVRTimerInfoTag::GetNotificationText() const
   }
 
   if (stringID != 0)
-    return StringUtils::Format("{}: '{}'", g_localizeStrings.Get(stringID), m_strTitle);
+    return StringUtils::Format(
+        "{}: '{}'", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(stringID),
+        m_strTitle);
 
   return {};
 }
@@ -1137,7 +1147,9 @@ std::string CPVRTimerInfoTag::GetDeletedNotificationText() const
       stringID = 19228; // Timer deleted
   }
 
-  return StringUtils::Format("{}: '{}'", g_localizeStrings.Get(stringID), m_strTitle);
+  return StringUtils::Format(
+      "{}: '{}'", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(stringID),
+      m_strTitle);
 }
 
 void CPVRTimerInfoTag::SetEpgInfoTag(const std::shared_ptr<CPVREpgInfoTag>& tag)

--- a/xbmc/pvr/timers/PVRTimerType.cpp
+++ b/xbmc/pvr/timers/PVRTimerType.cpp
@@ -9,11 +9,12 @@
 #include "PVRTimerType.h"
 
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "pvr/PVRManager.h"
 #include "pvr/addons/PVRClient.h"
 #include "pvr/addons/PVRClients.h"
 #include "pvr/settings/PVRTimerSettingDefinition.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -62,7 +63,8 @@ std::vector<std::shared_ptr<CPVRTimerType>> CPVRTimerType::GetAllTypes()
       PVR_TIMER_TYPE_IS_MANUAL | PVR_TIMER_TYPE_IS_REMINDER |
           PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
           PVR_TIMER_TYPE_SUPPORTS_START_TIME | PVR_TIMER_TYPE_SUPPORTS_END_TIME,
-      g_localizeStrings.Get(819))); // One time (Scheduled by timer rule)
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          819))); // One time (Scheduled by timer rule)
 
   // epg-based reminder rule
   iTypeId++;
@@ -83,7 +85,8 @@ std::vector<std::shared_ptr<CPVRTimerType>> CPVRTimerType::GetAllTypes()
       PVR_TIMER_TYPE_IS_REMINDER | PVR_TIMER_TYPE_REQUIRES_EPG_TAG_ON_CREATE |
           PVR_TIMER_TYPE_SUPPORTS_ENABLE_DISABLE | PVR_TIMER_TYPE_SUPPORTS_CHANNELS |
           PVR_TIMER_TYPE_SUPPORTS_START_TIME | PVR_TIMER_TYPE_SUPPORTS_START_MARGIN,
-      g_localizeStrings.Get(819))); // One time (Scheduled by timer rule)
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          819))); // One time (Scheduled by timer rule)
 
   return allTypes;
 }
@@ -212,14 +215,15 @@ void CPVRTimerType::InitDescription()
       id = (m_iAttributes & PVR_TIMER_TYPE_IS_MANUAL) ? 820 // "One time"
                                                       : 821; // "One time (guide-based)
     }
-    m_strDescription = g_localizeStrings.Get(id);
+    m_strDescription = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(id);
   }
 
   // add reminder/recording prefix
   int prefixId = (m_iAttributes & PVR_TIMER_TYPE_IS_REMINDER) ? 824 // Reminder: ...
                                                               : 825; // Recording: ...
 
-  m_strDescription = StringUtils::Format(g_localizeStrings.Get(prefixId), m_strDescription);
+  m_strDescription = StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(prefixId), m_strDescription);
 }
 
 void CPVRTimerType::InitAttributeValues(const PVR_TIMER_TYPE& type)
@@ -265,8 +269,10 @@ void CPVRTimerType::InitLifetimeValues(const PVR_TIMER_TYPE& type)
     std::vector<SettingIntValue> values;
     for (int i = 1; i < 366; ++i)
     {
-      values.emplace_back(StringUtils::Format(g_localizeStrings.Get(17999), i),
-                          i); // "{} days"
+      values.emplace_back(
+          StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(17999), i),
+          i); // "{} days"
     }
     m_lifetimeValues = {values, DEFAULT_RECORDING_LIFETIME};
   }
@@ -293,8 +299,12 @@ void CPVRTimerType::InitPreventDuplicateEpisodesValues(const PVR_TIMER_TYPE& typ
   {
     // No values given by addon, but prevent duplicate episodes supported. Use default values 0..1
     m_preventDupEpisodesValues = {
-        {{g_localizeStrings.Get(815) /* "Record all episodes" */, 0},
-         {g_localizeStrings.Get(816) /* "Record only new episodes" */, 1}},
+        {{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              815) /* "Record all episodes" */,
+          0},
+         {CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+              816) /* "Record only new episodes" */,
+          1}},
         DEFAULT_RECORDING_DUPLICATEHANDLING};
   }
   else

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -20,7 +20,6 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
@@ -35,6 +34,8 @@
 #include "pvr/channels/PVRChannelGroupsContainer.h"
 #include "pvr/filesystem/PVRGUIDirectory.h"
 #include "pvr/guilib/PVRGUIActionsChannels.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
@@ -285,7 +286,8 @@ void CGUIWindowPVRBase::OnInitWindow()
   {
     CGUIWindow::
         OnInitWindow(); // do not call CGUIMediaWindow as it will do a Refresh which in no case works in this state (no channelgroup!)
-    ShowProgressDialog(g_localizeStrings.Get(19235), 0); // PVR manager is starting up
+    ShowProgressDialog(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19235),
+                       0); // PVR manager is starting up
   }
 }
 
@@ -436,7 +438,8 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog()
   CPVRGUIDirectory::GetChannelGroupsDirectory(m_bRadio, true, options);
 
   dialog->Reset();
-  dialog->SetHeading(CVariant{g_localizeStrings.Get(19146)});
+  dialog->SetHeading(
+      CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19146)});
   dialog->SetMultiSelection(false);
   dialog->SetItems(options);
 
@@ -648,7 +651,8 @@ void CGUIWindowPVRBase::UpdateButtons()
   if (channelGroup)
   {
     SET_CONTROL_LABEL(CONTROL_BTNCHANNELGROUPS,
-                      g_localizeStrings.Get(19141) + ": " + channelGroup->GroupName());
+                      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19141) +
+                          ": " + channelGroup->GroupName());
   }
 
   m_channelGroupsSelector->SelectChannelGroup(channelGroup);
@@ -667,7 +671,8 @@ void CGUIWindowPVRBase::ShowProgressDialog(const std::string& strText, int iProg
       return;
     }
     m_progressHandle = loadingProgressDialog->GetHandle(
-        g_localizeStrings.Get(19235)); // PVR manager is starting up
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            19235)); // PVR manager is starting up
   }
 
   m_progressHandle->SetPercentage(static_cast<float>(iProgress));

--- a/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRChannels.cpp
@@ -20,7 +20,6 @@
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "pvr/PVRManager.h"
@@ -37,6 +36,8 @@
 #include "pvr/guilib/PVRGUIActionsEPG.h"
 #include "pvr/guilib/PVRGUIActionsPlayback.h"
 #include "pvr/utils/PVRPathUtils.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
@@ -139,8 +140,10 @@ void CGUIWindowPVRChannelsBase::UpdateButtons()
 
   CGUIWindowPVRBase::UpdateButtons();
 
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, m_bShowHiddenChannels ? g_localizeStrings.Get(19022)
-                                                                 : GetChannelGroup()->GroupName());
+  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1,
+                    m_bShowHiddenChannels
+                        ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19022)
+                        : GetChannelGroup()->GroupName());
 
   // If we are filtering by client id / provider id, expose provider's name.
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, UTILS::GetProviderNameFromPath(m_vecItems->GetPath()));
@@ -365,21 +368,27 @@ void CGUIWindowPVRChannelsBase::UpdateEpg(const std::shared_ptr<CFileItem>& item
 
     const std::string strMessage =
         StringUtils::Format("{}: '{}'",
-                            g_localizeStrings.Get(19253), // "Guide update scheduled for channel"
+                            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                19253), // "Guide update scheduled for channel"
                             channel->ChannelName());
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
-                                          g_localizeStrings.Get(19166), // "PVR information"
-                                          strMessage);
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Info,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            19166), // "PVR information"
+        strMessage);
   }
   else
   {
     const std::string strMessage =
         StringUtils::Format("{}: '{}'",
-                            g_localizeStrings.Get(19254), // "Guide update failed for channel"
+                            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                19254), // "Guide update failed for channel"
                             channel->ChannelName());
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
-                                          g_localizeStrings.Get(19166), // "PVR information"
-                                          strMessage);
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Error,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            19166), // "PVR information"
+        strMessage);
   }
 }
 

--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -18,7 +18,6 @@
 #include "dialogs/GUIDialogNumeric.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
@@ -41,6 +40,8 @@
 #include "pvr/guilib/PVRGUIActionsTimers.h"
 #include "pvr/recordings/PVRRecordings.h"
 #include "pvr/timers/PVRTimers.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "video/guilib/VideoPlayActionProcessor.h"
@@ -225,7 +226,8 @@ void CGUIWindowPVRGuideBase::UpdateButtons()
 {
   CGUIWindowPVRBase::UpdateButtons();
 
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, g_localizeStrings.Get(19032));
+  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1,
+                    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19032));
 
   const std::shared_ptr<const CPVRChannelGroup> group = GetChannelGroup();
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, group ? group->GroupName() : "");
@@ -854,7 +856,9 @@ bool CGUIWindowPVRGuideBase::OpenDateSelectionDialog()
   CGUIEPGGridContainer* epgGridContainer = GetGridControl();
   epgGridContainer->GetSelectedDate().GetAsSystemTime(date);
 
-  if (CGUIDialogNumeric::ShowAndGetDate(date, g_localizeStrings.Get(19288))) /* Go to date */
+  if (CGUIDialogNumeric::ShowAndGetDate(
+          date,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19288))) /* Go to date */
   {
     epgGridContainer->GoToDate(CDateTime(date));
     bReturn = true;

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -16,7 +16,6 @@
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "pvr/PVRManager.h"
@@ -26,6 +25,8 @@
 #include "pvr/recordings/PVRRecordingsPath.h"
 #include "pvr/settings/PVRSettings.h"
 #include "pvr/utils/PVRPathUtils.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -233,7 +234,8 @@ void CGUIWindowPVRRecordingsBase::UpdateButtons()
   else if (iWatchMode == WatchedModeWatched)
     iStringId = 16102; // "Watched"
 
-  SET_CONTROL_LABEL(CONTROL_BTNSHOWMODE, g_localizeStrings.Get(iStringId));
+  SET_CONTROL_LABEL(CONTROL_BTNSHOWMODE,
+                    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(iStringId));
 
   const bool bGroupRecordings{
       !m_forceUngrouped && m_settings->GetBoolValue(CSettings::SETTING_PVRRECORD_GROUPRECORDINGS)};

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -16,7 +16,6 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/helpers/DialogOKHelper.h"
@@ -32,6 +31,8 @@
 #include "pvr/guilib/PVRGUIActionsEPG.h"
 #include "pvr/guilib/PVRGUIActionsTimers.h"
 #include "pvr/recordings/PVRRecording.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "threads/IRunnable.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -148,7 +149,7 @@ void CGUIWindowPVRSearchBase::OnPrepareFileItems(CFileItemList& items)
   if (items.IsEmpty())
   {
     auto item = std::make_shared<CFileItem>(CPVREpgSearchPath::PATH_SEARCH_DIALOG, false);
-    item->SetLabel(g_localizeStrings.Get(
+    item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
         m_searchfilter == nullptr ? 19335 : 19336)); // "New search..." / "Edit search..."
     item->SetLabelPreformatted(true);
     item->SetSpecialSort(SortSpecialOnTop);
@@ -158,7 +159,8 @@ void CGUIWindowPVRSearchBase::OnPrepareFileItems(CFileItemList& items)
     item = std::make_shared<CFileItem>(IsRadio() ? CPVREpgSearchPath::PATH_RADIO_SAVEDSEARCHES
                                                  : CPVREpgSearchPath::PATH_TV_SAVEDSEARCHES,
                                        true);
-    item->SetLabel(g_localizeStrings.Get(19337)); // "Saved searches"
+    item->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        19337)); // "Saved searches"
     item->SetLabelPreformatted(true);
     item->SetSpecialSort(SortSpecialOnTop);
     item->SetArt("icon", "DefaultFolder.png");
@@ -353,7 +355,8 @@ void CGUIWindowPVRSearchBase::UpdateButtons()
   if (path.IsValid() && path.IsSavedSearchesRoot())
   {
     bSavedSearchesRoot = true;
-    header = g_localizeStrings.Get(19337); // "Saved searches"
+    header =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19337); // "Saved searches"
   }
 
   if (header.empty() && m_searchfilter)
@@ -368,9 +371,13 @@ void CGUIWindowPVRSearchBase::UpdateButtons()
   SET_CONTROL_LABEL(CONTROL_LABEL_HEADER1, header);
 
   if (!bSavedSearchesRoot && m_searchfilter && m_searchfilter->IsChanged())
-    SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, g_localizeStrings.Get(19342)); // "[not saved]"
+    SET_CONTROL_LABEL(
+        CONTROL_LABEL_HEADER2,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19342)); // "[not saved]"
   else if (!bSavedSearchesRoot && m_searchfilter)
-    SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, g_localizeStrings.Get(19343)); // "[saved]"
+    SET_CONTROL_LABEL(
+        CONTROL_LABEL_HEADER2,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19343)); // "[saved]"
   else
     SET_CONTROL_LABEL(CONTROL_LABEL_HEADER2, "");
 }
@@ -485,7 +492,7 @@ void CGUIWindowPVRSearchBase::SetSearchFilter(
       {
         title = m_searchfilter->GetSearchTerm();
         if (title.empty())
-          title = g_localizeStrings.Get(137); // "Search"
+          title = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(137); // "Search"
         else
           StringUtils::Trim(title, "\"");
 

--- a/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRTimersBase.cpp
@@ -14,13 +14,14 @@
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "pvr/PVRManager.h"
 #include "pvr/guilib/PVRGUIActionsTimers.h"
 #include "pvr/timers/PVRTimerInfoTag.h"
 #include "pvr/timers/PVRTimersPath.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/URIUtils.h"
@@ -66,7 +67,8 @@ void CGUIWindowPVRTimersBase::OnPrepareFileItems(CFileItemList& items)
   if (path.IsValid() && path.IsTimersRoot())
   {
     const auto item = std::make_shared<CFileItem>(CPVRTimersPath::PATH_ADDTIMER, false);
-    item->SetLabel(g_localizeStrings.Get(19026)); // "Add timer..."
+    item->SetLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19026)); // "Add timer..."
     item->SetLabelPreformatted(true);
     item->SetSpecialSort(SortSpecialOnTop);
     item->SetArt("icon", "DefaultTVShows.png");

--- a/xbmc/resources/CMakeLists.txt
+++ b/xbmc/resources/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(SOURCES LocalizeStrings.cpp
+            ResourcesComponent.cpp)
+
+set(HEADERS LocalizeStrings.h
+            ResourcesComponent.h)
+
+core_add_library(resources)

--- a/xbmc/resources/LocalizeStrings.cpp
+++ b/xbmc/resources/LocalizeStrings.cpp
@@ -120,9 +120,11 @@ static bool LoadStr2Mem(const std::string& pathname_in,
       return false;
   }
 
-  bool useSourceLang = StringUtils::EqualsNoCase(language, LANGUAGE_DEFAULT) || StringUtils::EqualsNoCase(language, LANGUAGE_OLD_DEFAULT);
+  bool useSourceLang = StringUtils::EqualsNoCase(language, LANGUAGE_DEFAULT) ||
+                       StringUtils::EqualsNoCase(language, LANGUAGE_OLD_DEFAULT);
 
-  return LoadPO(URIUtils::AddFileToFolder(pathname, "strings.po"), strings, encoding, offset, useSourceLang);
+  return LoadPO(URIUtils::AddFileToFolder(pathname, "strings.po"), strings, encoding, offset,
+                useSourceLang);
 }
 
 static bool LoadWithFallback(const std::string& path,
@@ -200,7 +202,9 @@ void CLocalizeStrings::Clear()
   m_strings.clear();
 }
 
-bool CLocalizeStrings::LoadAddonStrings(const std::string& path, const std::string& language, const std::string& addonId)
+bool CLocalizeStrings::LoadAddonStrings(const std::string& path,
+                                        const std::string& language,
+                                        const std::string& addonId)
 {
   std::unordered_map<uint32_t, LocStr> strings;
   if (!LoadWithFallback(path, language, strings))

--- a/xbmc/resources/LocalizeStrings.h
+++ b/xbmc/resources/LocalizeStrings.h
@@ -28,7 +28,7 @@
 struct LocStr
 {
   std::string strTranslated; // string to be used in xbmc GUI
-  std::string strOriginal;   // the original English string the translation is based on
+  std::string strOriginal; // the original English string the translation is based on
 };
 
 // The default fallback language is fixed to be English
@@ -66,9 +66,3 @@ protected:
   mutable CSharedSection m_stringsMutex;
   mutable CSharedSection m_addonStringsMutex;
 };
-
-/*!
- \ingroup strings
- \brief
- */
-extern CLocalizeStrings g_localizeStrings;

--- a/xbmc/resources/ResourcesComponent.cpp
+++ b/xbmc/resources/ResourcesComponent.cpp
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ResourcesComponent.h"
+
+#include "LocalizeStrings.h"
+
+#include <memory>
+
+CResourcesComponent::CResourcesComponent() : m_localizeStrings(std::make_unique<CLocalizeStrings>())
+{
+}
+
+CResourcesComponent::~CResourcesComponent()
+{
+  Deinit();
+}
+
+void CResourcesComponent::Init()
+{
+}
+
+void CResourcesComponent::Deinit()
+{
+  m_localizeStrings->Clear();
+}
+
+CLocalizeStrings& CResourcesComponent::GetLocalizeStrings()
+{
+  return *m_localizeStrings;
+}

--- a/xbmc/resources/ResourcesComponent.h
+++ b/xbmc/resources/ResourcesComponent.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <memory>
+
+class CLocalizeStrings;
+
+class CResourcesComponent
+{
+public:
+  CResourcesComponent();
+  virtual ~CResourcesComponent();
+  void Init();
+  void Deinit();
+
+  CLocalizeStrings& GetLocalizeStrings();
+
+protected:
+  // members are pointers in order to avoid includes
+  std::unique_ptr<CLocalizeStrings> m_localizeStrings;
+};

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -13,9 +13,10 @@
 #include "URL.h"
 #include "application/AppParams.h"
 #include "filesystem/SpecialProtocol.h"
-#include "guilib/LocalizeStrings.h"
 #include "network/DNSNameCache.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -329,7 +330,7 @@ void CAdvancedSettings::Initialize()
 
   // Build regex inserting local specific spelling of disc (xxx)
   // [ _.-]*\((?:xxx|dis[ck])[ _.-]*\d{1,3}\)$
-  std::string localeDiscStr{g_localizeStrings.Get(427)};
+  std::string localeDiscStr{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(427)};
   if (!localeDiscStr.empty())
     localeDiscStr = EscapeSpecialChars(localeDiscStr) + "|";
   m_titleTrailingPartNumberRegExp =

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -12,10 +12,11 @@
 #include "cores/VideoPlayer/VideoRenderers/ColorManager.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "guilib/GUIComponent.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/StereoscopicsManager.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "rendering/RenderSystem.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -227,7 +228,9 @@ void CDisplaySettings::OnSettingAction(const std::shared_ptr<const CSetting>& se
     std::string path = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
     std::vector<CMediaSource> shares;
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
-    if (CGUIDialogFileBrowser::ShowAndGetFile(shares, ".3dlut", g_localizeStrings.Get(36580), path))
+    if (CGUIDialogFileBrowser::ShowAndGetFile(
+            shares, ".3dlut",
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36580), path))
     {
       std::static_pointer_cast<CSettingString>(std::const_pointer_cast<CSetting>(setting))->SetValue(path);
     }
@@ -237,7 +240,9 @@ void CDisplaySettings::OnSettingAction(const std::shared_ptr<const CSetting>& se
     std::string path = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
     std::vector<CMediaSource> shares;
     CServiceBroker::GetMediaManager().GetLocalDrives(shares);
-    if (CGUIDialogFileBrowser::ShowAndGetFile(shares, ".icc|.icm", g_localizeStrings.Get(36581), path))
+    if (CGUIDialogFileBrowser::ShowAndGetFile(
+            shares, ".icc|.icm",
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36581), path))
     {
       std::static_pointer_cast<CSettingString>(std::const_pointer_cast<CSetting>(setting))->SetValue(path);
     }
@@ -734,11 +739,13 @@ void CDisplaySettings::SettingOptionsModesFiller(const std::shared_ptr<const CSe
 void CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller(
     const SettingConstPtr& /*setting*/, std::vector<IntegerSettingOption>& list, int& /*current*/)
 {
-  list.emplace_back(g_localizeStrings.Get(13551), 0);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13551), 0);
 
   for (int i = 1; i <= MAX_REFRESH_CHANGE_DELAY; i++)
     list.emplace_back(
-        StringUtils::Format(g_localizeStrings.Get(13553), static_cast<double>(i) / 10.0), i);
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13553),
+                            static_cast<double>(i) / 10.0),
+        i);
 }
 
 void CDisplaySettings::SettingOptionsRefreshRatesFiller(const SettingConstPtr& setting,
@@ -754,7 +761,8 @@ void CDisplaySettings::SettingOptionsRefreshRatesFiller(const SettingConstPtr& s
   if (res == RES_WINDOW)
   {
     current = "WINDOW";
-    list.emplace_back(g_localizeStrings.Get(242), current);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(242),
+                      current);
     return;
   }
 
@@ -785,7 +793,7 @@ void CDisplaySettings::SettingOptionsResolutionsFiller(const SettingConstPtr& se
   if (res == RES_WINDOW)
   {
     current = res;
-    list.emplace_back(g_localizeStrings.Get(242), res);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(242), res);
   }
   else
   {
@@ -836,9 +844,11 @@ void CDisplaySettings::SettingOptionsDispModeFiller(const SettingConstPtr& /*set
   // does not support windowed modes, we would just shoot ourselves in the foot
   // by offering the option.
   if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_canWindowed && CServiceBroker::GetWinSystem()->CanDoWindowed())
-    list.emplace_back(g_localizeStrings.Get(242), DM_WINDOWED);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(242),
+                      DM_WINDOWED);
 
-  list.emplace_back(g_localizeStrings.Get(244), DM_FULLSCREEN);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(244),
+                    DM_FULLSCREEN);
 }
 
 void CDisplaySettings::SettingOptionsStereoscopicModesFiller(
@@ -928,9 +938,11 @@ void CDisplaySettings::SettingOptionsCmsModesFiller(const SettingConstPtr& /*set
                                                     std::vector<IntegerSettingOption>& list,
                                                     int& /*current*/)
 {
-  list.emplace_back(g_localizeStrings.Get(36580), CMS_MODE_3DLUT);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36580),
+                    CMS_MODE_3DLUT);
 #ifdef HAVE_LCMS2
-  list.emplace_back(g_localizeStrings.Get(36581), CMS_MODE_PROFILE);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36581),
+                    CMS_MODE_PROFILE);
 #endif
 }
 
@@ -938,30 +950,43 @@ void CDisplaySettings::SettingOptionsCmsWhitepointsFiller(const SettingConstPtr&
                                                           std::vector<IntegerSettingOption>& list,
                                                           int& /*current*/)
 {
-  list.emplace_back(g_localizeStrings.Get(36586), CMS_WHITEPOINT_D65);
-  list.emplace_back(g_localizeStrings.Get(36587), CMS_WHITEPOINT_D93);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36586),
+                    CMS_WHITEPOINT_D65);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36587),
+                    CMS_WHITEPOINT_D93);
 }
 
 void CDisplaySettings::SettingOptionsCmsPrimariesFiller(const SettingConstPtr& /*setting*/,
                                                         std::vector<IntegerSettingOption>& list,
                                                         int& /*current*/)
 {
-  list.emplace_back(g_localizeStrings.Get(36588), CMS_PRIMARIES_AUTO);
-  list.emplace_back(g_localizeStrings.Get(36589), CMS_PRIMARIES_BT709);
-  list.emplace_back(g_localizeStrings.Get(36579), CMS_PRIMARIES_BT2020);
-  list.emplace_back(g_localizeStrings.Get(36590), CMS_PRIMARIES_170M);
-  list.emplace_back(g_localizeStrings.Get(36591), CMS_PRIMARIES_BT470M);
-  list.emplace_back(g_localizeStrings.Get(36592), CMS_PRIMARIES_BT470BG);
-  list.emplace_back(g_localizeStrings.Get(36593), CMS_PRIMARIES_240M);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36588),
+                    CMS_PRIMARIES_AUTO);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36589),
+                    CMS_PRIMARIES_BT709);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36579),
+                    CMS_PRIMARIES_BT2020);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36590),
+                    CMS_PRIMARIES_170M);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36591),
+                    CMS_PRIMARIES_BT470M);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36592),
+                    CMS_PRIMARIES_BT470BG);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36593),
+                    CMS_PRIMARIES_240M);
 }
 
 void CDisplaySettings::SettingOptionsCmsGammaModesFiller(const SettingConstPtr& /*setting*/,
                                                          std::vector<IntegerSettingOption>& list,
                                                          int& /*current*/)
 {
-  list.emplace_back(g_localizeStrings.Get(36582), CMS_TRC_BT1886);
-  list.emplace_back(g_localizeStrings.Get(36583), CMS_TRC_INPUT_OFFSET);
-  list.emplace_back(g_localizeStrings.Get(36584), CMS_TRC_OUTPUT_OFFSET);
-  list.emplace_back(g_localizeStrings.Get(36585), CMS_TRC_ABSOLUTE);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36582),
+                    CMS_TRC_BT1886);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36583),
+                    CMS_TRC_INPUT_OFFSET);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36584),
+                    CMS_TRC_OUTPUT_OFFSET);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36585),
+                    CMS_TRC_ABSOLUTE);
 }
 

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -13,12 +13,13 @@
 #include "TextureCache.h"
 #include "cores/RetroPlayer/RetroPlayerUtils.h"
 #include "dialogs/GUIDialogFileBrowser.h"
-#include "guilib/LocalizeStrings.h"
 #include "interfaces/AnnouncementManager.h"
 #include "interfaces/builtins/Builtins.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "music/MusicLibraryQueue.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/dialogs/GUIDialogLibExportSettings.h"
 #include "settings/lib/Setting.h"
@@ -314,7 +315,9 @@ void CMediaSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
     CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
     CServiceBroker::GetMediaManager().GetRemovableDrives(shares);
 
-    if (CGUIDialogFileBrowser::ShowAndGetFile(shares, "musicdb.xml", g_localizeStrings.Get(651) , path))
+    if (CGUIDialogFileBrowser::ShowAndGetFile(
+            shares, "musicdb.xml",
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(651), path))
     {
       // Import data to music library showing progress dialog
       CMusicLibraryQueue::GetInstance().ImportLibrary(path, true);
@@ -338,7 +341,8 @@ void CMediaSettings::OnSettingAction(const std::shared_ptr<const CSetting>& sett
     CServiceBroker::GetMediaManager().GetNetworkLocations(shares);
     CServiceBroker::GetMediaManager().GetRemovableDrives(shares);
 
-    if (CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(651) , path))
+    if (CGUIDialogFileBrowser::ShowAndGetDirectory(
+            shares, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(651), path))
     {
       CVideoDatabase videodatabase;
       videodatabase.Open();

--- a/xbmc/settings/PlayerSettings.cpp
+++ b/xbmc/settings/PlayerSettings.cpp
@@ -8,16 +8,21 @@
 
 #include "PlayerSettings.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 void CPlayerSettings::SettingOptionsQueueTimeSizesFiller(const SettingConstPtr& setting,
                                                          std::vector<IntegerSettingOption>& list,
                                                          int& current)
 {
-  const std::string& secFloat = g_localizeStrings.Get(13553);
-  const std::string& seconds = g_localizeStrings.Get(37129);
-  const std::string& second = g_localizeStrings.Get(37128);
+  const std::string& secFloat =
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13553);
+  const std::string& seconds =
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37129);
+  const std::string& second =
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37128);
 
   list.emplace_back(StringUtils::Format(secFloat, 0.5), 5);
   list.emplace_back(StringUtils::Format(second, 1), 10);
@@ -31,8 +36,8 @@ void CPlayerSettings::SettingOptionsQueueDataSizesFiller(const SettingConstPtr& 
                                                          std::vector<IntegerSettingOption>& list,
                                                          int& /*current*/)
 {
-  const std::string& mb = g_localizeStrings.Get(37122);
-  const std::string& gb = g_localizeStrings.Get(37123);
+  const std::string& mb = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37122);
+  const std::string& gb = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37123);
 
   list.emplace_back(StringUtils::Format(mb, 16), 16);
   list.emplace_back(StringUtils::Format(mb, 32), 32);

--- a/xbmc/settings/ServicesSettings.cpp
+++ b/xbmc/settings/ServicesSettings.cpp
@@ -8,8 +8,10 @@
 
 #include "ServicesSettings.h"
 
+#include "ServiceBroker.h"
 #include "filesystem/IFileTypes.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 using namespace XFILE;
@@ -18,8 +20,8 @@ void CServicesSettings::SettingOptionsChunkSizesFiller(const SettingConstPtr& /*
                                                        std::vector<IntegerSettingOption>& list,
                                                        int& /*current*/)
 {
-  const std::string& kb = g_localizeStrings.Get(37121);
-  const std::string& mb = g_localizeStrings.Get(37122);
+  const std::string& kb = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37121);
+  const std::string& mb = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37122);
 
   list.emplace_back(StringUtils::Format(kb, 16), 16);
   list.emplace_back(StringUtils::Format(kb, 32), 32);
@@ -34,19 +36,24 @@ void CServicesSettings::SettingOptionsBufferModesFiller(const SettingConstPtr& /
                                                         std::vector<IntegerSettingOption>& list,
                                                         int& /*current*/)
 {
-  list.emplace_back(g_localizeStrings.Get(37110), static_cast<int>(CacheBufferMode::NONE));
-  list.emplace_back(g_localizeStrings.Get(37111), static_cast<int>(CacheBufferMode::TRUE_INTERNET));
-  list.emplace_back(g_localizeStrings.Get(37112), static_cast<int>(CacheBufferMode::INTERNET));
-  list.emplace_back(g_localizeStrings.Get(37113), static_cast<int>(CacheBufferMode::NETWORK));
-  list.emplace_back(g_localizeStrings.Get(37114), static_cast<int>(CacheBufferMode::ALL));
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37110),
+                    static_cast<int>(CacheBufferMode::NONE));
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37111),
+                    static_cast<int>(CacheBufferMode::TRUE_INTERNET));
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37112),
+                    static_cast<int>(CacheBufferMode::INTERNET));
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37113),
+                    static_cast<int>(CacheBufferMode::NETWORK));
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37114),
+                    static_cast<int>(CacheBufferMode::ALL));
 }
 
 void CServicesSettings::SettingOptionsMemorySizesFiller(const SettingConstPtr& /*setting*/,
                                                         std::vector<IntegerSettingOption>& list,
                                                         int& /*current*/)
 {
-  const std::string& mb = g_localizeStrings.Get(37122);
-  const std::string& gb = g_localizeStrings.Get(37123);
+  const std::string& mb = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37122);
+  const std::string& gb = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37123);
 
   list.emplace_back(StringUtils::Format(mb, 16), 16);
   list.emplace_back(StringUtils::Format(mb, 20), 20);
@@ -62,14 +69,14 @@ void CServicesSettings::SettingOptionsMemorySizesFiller(const SettingConstPtr& /
   list.emplace_back(StringUtils::Format(mb, 512), 512);
   list.emplace_back(StringUtils::Format(mb, 768), 768);
   list.emplace_back(StringUtils::Format(gb, 1), 1024);
-  list.emplace_back(g_localizeStrings.Get(37115), 0);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37115), 0);
 }
 
 void CServicesSettings::SettingOptionsReadFactorsFiller(const SettingConstPtr& /*setting*/,
                                                         std::vector<IntegerSettingOption>& list,
                                                         int& /*current*/)
 {
-  list.emplace_back(g_localizeStrings.Get(37116), 0);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37116), 0);
   list.emplace_back("1.1x", 110);
   list.emplace_back("1.25x", 125);
   list.emplace_back("1.5x", 150);
@@ -91,9 +98,9 @@ void CServicesSettings::SettingOptionsCacheChunkSizesFiller(const SettingConstPt
                                                             std::vector<IntegerSettingOption>& list,
                                                             int& /*current*/)
 {
-  const std::string& byte = g_localizeStrings.Get(37120);
-  const std::string& kb = g_localizeStrings.Get(37121);
-  const std::string& mb = g_localizeStrings.Get(37122);
+  const std::string& byte = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37120);
+  const std::string& kb = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37121);
+  const std::string& mb = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(37122);
 
   list.emplace_back(StringUtils::Format(byte, 256), 256);
   list.emplace_back(StringUtils::Format(byte, 512), 512);
@@ -114,9 +121,9 @@ void CServicesSettings::SettingOptionsSmbVersionsFiller(const SettingConstPtr& /
                                                         std::vector<IntegerSettingOption>& list,
                                                         int& /*current*/)
 {
-  list.emplace_back(g_localizeStrings.Get(36623), 0);
-  list.emplace_back(g_localizeStrings.Get(36624), 1);
-  list.emplace_back(g_localizeStrings.Get(36625), 2);
-  list.emplace_back(g_localizeStrings.Get(36637), 21);
-  list.emplace_back(g_localizeStrings.Get(36626), 3);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36623), 0);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36624), 1);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36625), 2);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36637), 21);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36626), 3);
 }

--- a/xbmc/settings/SubtitlesSettings.cpp
+++ b/xbmc/settings/SubtitlesSettings.cpp
@@ -8,8 +8,10 @@
 
 #include "SubtitlesSettings.h"
 
+#include "ServiceBroker.h"
 #include "guilib/GUIFontManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/lib/Setting.h"
 #include "utils/FileUtils.h"
@@ -185,7 +187,9 @@ void CSubtitlesSettings::SettingOptionsSubtitleFontsFiller(const SettingConstPtr
     std::string familyName = UTILS::FONT::GetFontFamily(defaultFontPath);
     if (!familyName.empty())
     {
-      list.emplace_back(g_localizeStrings.Get(571) + " " + familyName, FONT_DEFAULT_FAMILYNAME);
+      list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(571) +
+                            " " + familyName,
+                        FONT_DEFAULT_FAMILYNAME);
     }
   }
   // Add additional fonts from the user fonts folder

--- a/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogContentSettings.cpp
@@ -18,7 +18,8 @@
 #include "filesystem/AddonsDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"
 #include "settings/windows/GUIControlSettings.h"
@@ -94,7 +95,10 @@ bool CGUIDialogContentSettings::Show(ADDON::ScraperPtr& scraper,
     dialog->SetScraper(scraper);
     // toast selected but disabled scrapers
     if (CServiceBroker::GetAddonMgr().IsAddonDisabled(scraper->ID()))
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, g_localizeStrings.Get(24024), scraper->Name(), 2000, true);
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Error,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24024), scraper->Name(),
+          2000, true);
   }
 
   dialog->SetScanSettings(settings);
@@ -306,7 +310,9 @@ void CGUIDialogContentSettings::SetupView()
     }
     else
     {
-      SetLabel2(SETTING_SCRAPER_LIST, g_localizeStrings.Get(231)); //Set label2 to "None"
+      SetLabel2(SETTING_SCRAPER_LIST,
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                    231)); //Set label2 to "None"
       ToggleState(SETTING_SCRAPER_SETTINGS, false);
     }
   }

--- a/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
+++ b/xbmc/settings/dialogs/GUIDialogLibExportSettings.cpp
@@ -14,9 +14,10 @@
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -161,7 +162,7 @@ void CGUIDialogLibExportSettings::OnSettingAction(const std::shared_ptr<const CS
       if (CUtil::GetMatchingSource(strDirectory, shares, bIsSource) < 0) // path is outside shares - add it as a separate one
       {
         CMediaSource share;
-        share.strName = g_localizeStrings.Get(13278);
+        share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13278);
         share.strPath = strDirectory;
         shares.push_back(share);
       }
@@ -169,8 +170,9 @@ void CGUIDialogLibExportSettings::OnSettingAction(const std::shared_ptr<const CS
     else
       strDirectory = "default location";
 
-    if (CGUIDialogFileBrowser::ShowAndGetDirectory(shares, g_localizeStrings.Get(661), strDirectory,
-                                                   true) &&
+    if (CGUIDialogFileBrowser::ShowAndGetDirectory(
+            shares, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(661),
+            strDirectory, true) &&
         !strDirectory.empty())
     {
       m_destinationChecked = true;
@@ -289,13 +291,15 @@ void CGUIDialogLibExportSettings::UpdateToggles()
       !m_settings.IsArtwork())
   {
     //"Output information to NFO files (currently exporting artist folders only)"
-    SetLabel(CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO, g_localizeStrings.Get(38310));
+    SetLabel(CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO,
+             CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38310));
     ToggleState(CSettings::SETTING_MUSICLIBRARY_EXPORT_OVERWRITE, false);
   }
   else
   {
     //"Output information to NFO files"
-    SetLabel(CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO, g_localizeStrings.Get(38309));
+    SetLabel(CSettings::SETTING_MUSICLIBRARY_EXPORT_SKIPNFO,
+             CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38309));
     ToggleState(CSettings::SETTING_MUSICLIBRARY_EXPORT_OVERWRITE, true);
   }
 }
@@ -309,25 +313,30 @@ void CGUIDialogLibExportSettings::UpdateDescription()
     if (m_settings.IsItemExported(ELIBEXPORT_ALBUMS))
       if (m_settings.IsArtists())
         //"Artists exported to Artist Information Folder and albums to music folders"
-        SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, g_localizeStrings.Get(38322));
+        SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER,
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38322));
       else
         //"Albums exported to music folders"
-        SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, g_localizeStrings.Get(38323));
+        SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER,
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38323));
     else
       // "Artists exported to Artist Information Folder"
-      SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, g_localizeStrings.Get(38324));
+      SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER,
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38324));
   }
   else if (m_settings.IsArtistFoldersOnly())
   {
     // Destination button is description of what artist folders means
     SetLabel(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, "");
     //"Artists folders created in Artist Information Folder"
-    SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, g_localizeStrings.Get(38325));
+    SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER,
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38325));
   }
   else
   {
     SetLabel2(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, m_settings.GetPath());
-    SetLabel(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER, g_localizeStrings.Get(38305));
+    SetLabel(CSettings::SETTING_MUSICLIBRARY_EXPORT_FOLDER,
+             CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38305));
   }
 }
 

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -22,9 +22,10 @@
 #include "guilib/GUISpinControlEx.h"
 #include "guilib/GUIToggleButtonControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/SettingControl.h"
 #include "settings/lib/SettingSection.h"
 #include "settings/windows/GUIControlSettings.h"
@@ -519,7 +520,7 @@ void CGUIDialogSettingsBase::OnSettingPropertyChanged(
 
 std::string CGUIDialogSettingsBase::GetLocalizedString(uint32_t labelId) const
 {
-  return g_localizeStrings.Get(labelId);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(labelId);
 }
 
 void CGUIDialogSettingsBase::SetupView()
@@ -650,7 +651,8 @@ CGUIControl* CGUIDialogSettingsBase::AddSetting(const std::shared_ptr<CSetting>&
     std::string indentation;
     for (int index = 1; index < parentLevels; index++)
       indentation.append("  ");
-    label = StringUtils::Format(g_localizeStrings.Get(168), indentation, label);
+    label = StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(168), indentation, label);
   }
 
   // create the proper controls

--- a/xbmc/settings/windows/GUIControlSettings.cpp
+++ b/xbmc/settings/windows/GUIControlSettings.cpp
@@ -30,7 +30,8 @@
 #include "guilib/GUISettingsSliderControl.h"
 #include "guilib/GUISpinControlEx.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingAddon.h"
 #include "settings/SettingControl.h"
@@ -61,7 +62,8 @@ std::string Localize(std::uint32_t code,
 
   if (!addonId.empty())
   {
-    const std::string label = g_localizeStrings.GetAddonString(addonId, code);
+    const std::string label =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(addonId, code);
     if (!label.empty())
       return label;
   }
@@ -1089,7 +1091,8 @@ void CGUIControlButtonSetting::Update(bool fromControl, bool updateDisplayOnly)
             }
 
             if (addonNames.empty())
-              strText = g_localizeStrings.Get(231); // None
+              strText =
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231); // None
             else
               strText = StringUtils::Join(addonNames, ", ");
           }
@@ -1106,7 +1109,8 @@ void CGUIControlButtonSetting::Update(bool fromControl, bool updateDisplayOnly)
             {
               strText = strValue;
               if (strText.empty())
-                strText = g_localizeStrings.Get(231); // None
+                strText =
+                    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231); // None
             }
             else
               strText = strValue;

--- a/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
+++ b/xbmc/settings/windows/GUIWindowSettingsScreenCalibration.cpp
@@ -16,9 +16,10 @@
 #include "guilib/GUIMoverControl.h"
 #include "guilib/GUIResizeControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -70,7 +71,7 @@ void CGUIWindowSettingsScreenCalibration::ResetCalibration()
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogYesNo>(WINDOW_DIALOG_YES_NO);
   pDialog->SetHeading(CVariant{20325});
   std::string strText = StringUtils::Format(
-      g_localizeStrings.Get(20326),
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20326),
       CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(m_Res[m_iCurRes]).strMode);
   pDialog->SetText(CVariant{std::move(strText)});
   pDialog->SetChoice(0, CVariant{222});
@@ -423,10 +424,12 @@ bool CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
       // recenter our control...
       pControl->SetPosition((static_cast<float>(info.iWidth) - pControl->GetWidth()) / 2,
                             (static_cast<float>(info.iHeight) - pControl->GetHeight()) / 2);
-      labelDescription = StringUtils::Format("[B]{}[/B][CR]{}", g_localizeStrings.Get(272),
-                                             g_localizeStrings.Get(273));
+      labelDescription = StringUtils::Format(
+          "[B]{}[/B][CR]{}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(272),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(273));
       labelValue = StringUtils::Format("{:5.3f}", info.fPixelRatio);
-      labelValue = StringUtils::Format(g_localizeStrings.Get(20327), labelValue);
+      labelValue = StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20327), labelValue);
     }
   }
   else
@@ -440,11 +443,14 @@ bool CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
         {
           info.Overscan.left = pControl->GetXLocation();
           info.Overscan.top = pControl->GetYLocation();
-          labelDescription = StringUtils::Format("[B]{}[/B][CR]{}", g_localizeStrings.Get(274),
-                                                 g_localizeStrings.Get(276));
+          labelDescription = StringUtils::Format(
+              "[B]{}[/B][CR]{}",
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(274),
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(276));
           labelValue =
               StringUtils::Format("{}, {}", pControl->GetXLocation(), pControl->GetYLocation());
-          labelValue = StringUtils::Format(g_localizeStrings.Get(20327), labelValue);
+          labelValue = StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20327), labelValue);
           // Update reset control position
           auto* moverControl = dynamic_cast<CGUIMoverControl*>(GetControl(CONTROL_RESET));
           if (moverControl)
@@ -466,10 +472,13 @@ bool CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
           info.Overscan.bottom = pControl->GetYLocation();
           int iXOff1 = info.iWidth - pControl->GetXLocation();
           int iYOff1 = info.iHeight - pControl->GetYLocation();
-          labelDescription = StringUtils::Format("[B]{}[/B][CR]{}", g_localizeStrings.Get(275),
-                                                 g_localizeStrings.Get(276));
+          labelDescription = StringUtils::Format(
+              "[B]{}[/B][CR]{}",
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(275),
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(276));
           labelValue = StringUtils::Format("{}, {}", iXOff1, iYOff1);
-          labelValue = StringUtils::Format(g_localizeStrings.Get(20327), labelValue);
+          labelValue = StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20327), labelValue);
           // Update reset control position
           pControl = dynamic_cast<CGUIMoverControl*>(GetControl(CONTROL_RESET));
           if (pControl)
@@ -492,22 +501,28 @@ bool CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
             info.iSubtitles =
                 pControl->GetYLocation() - m_subtitlesHalfSpace + m_subtitleVerticalMargin;
 
-            labelDescription = StringUtils::Format("[B]{}[/B][CR]{}", g_localizeStrings.Get(277),
-                                                   g_localizeStrings.Get(278));
-            labelValue = StringUtils::Format(g_localizeStrings.Get(39184), info.iSubtitles,
-                                             info.iSubtitles - m_subtitleVerticalMargin);
+            labelDescription = StringUtils::Format(
+                "[B]{}[/B][CR]{}",
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(277),
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(278));
+            labelValue = StringUtils::Format(
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39184),
+                info.iSubtitles, info.iSubtitles - m_subtitleVerticalMargin);
           }
           else
           {
-            labelDescription = StringUtils::Format("[B]{}[/B][CR]{}", g_localizeStrings.Get(277),
-                                                   g_localizeStrings.Get(39189));
+            labelDescription = StringUtils::Format(
+                "[B]{}[/B][CR]{}",
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(277),
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39189));
           }
           break;
         }
 
         case CONTROL_RESET:
         {
-          labelDescription = g_localizeStrings.Get(20325);
+          labelDescription =
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20325);
           break;
         }
 
@@ -525,13 +540,17 @@ bool CGUIWindowSettingsScreenCalibration::UpdateFromControl(int iControl)
   if (CServiceBroker::GetWinSystem()->IsFullScreen())
   {
     resInfo =
-        StringUtils::Format("{} {}x{}@{:.2f} - {}", g_localizeStrings.Get(13287), info.iScreenWidth,
-                            info.iScreenHeight, info.fRefreshRate, g_localizeStrings.Get(244));
+        StringUtils::Format("{} {}x{}@{:.2f} - {}",
+                            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13287),
+                            info.iScreenWidth, info.iScreenHeight, info.fRefreshRate,
+                            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(244));
   }
   else
   {
-    resInfo = StringUtils::Format("{} {}x{} - {}", g_localizeStrings.Get(13287), info.iScreenWidth,
-                                  info.iScreenHeight, g_localizeStrings.Get(242));
+    resInfo = StringUtils::Format(
+        "{} {}x{} - {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13287),
+        info.iScreenWidth, info.iScreenHeight,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(242));
   }
   SET_CONTROL_LABEL(CONTROL_LABEL_RES, resInfo);
 

--- a/xbmc/storage/AutorunMediaJob.cpp
+++ b/xbmc/storage/AutorunMediaJob.cpp
@@ -13,8 +13,9 @@
 #include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "interfaces/builtins/Builtins.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
@@ -37,12 +38,13 @@ bool CAutorunMediaJob::DoWork()
   if (!m_label.empty())
     pDialog->SetHeading(CVariant{m_label});
   else
-    pDialog->SetHeading(CVariant{g_localizeStrings.Get(21331)});
+    pDialog->SetHeading(
+        CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21331)});
 
-  pDialog->Add(g_localizeStrings.Get(21332));
-  pDialog->Add(g_localizeStrings.Get(21333));
-  pDialog->Add(g_localizeStrings.Get(21334));
-  pDialog->Add(g_localizeStrings.Get(21335));
+  pDialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21332));
+  pDialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21333));
+  pDialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21334));
+  pDialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21335));
 
   pDialog->Open();
 

--- a/xbmc/storage/DetectDVDType.cpp
+++ b/xbmc/storage/DetectDVDType.cpp
@@ -15,7 +15,8 @@
 #include "cdioSupport.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "storage/MediaManager.h"
@@ -111,7 +112,7 @@ void CDetectDVDMedia::UpdateDvdrom()
       {
         // Send Message to GUI that disc been ejected
         SetNewDVDShareUrl(CServiceBroker::GetMediaManager().TranslateDevicePath(m_diskPath), false,
-                          g_localizeStrings.Get(502));
+                          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(502));
         CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_REMOVED_MEDIA);
         CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
         // Clear all stored info
@@ -126,7 +127,7 @@ void CDetectDVDMedia::UpdateDvdrom()
       {
         // Drive is not ready (closing, opening)
         SetNewDVDShareUrl(CServiceBroker::GetMediaManager().TranslateDevicePath(m_diskPath), false,
-                          g_localizeStrings.Get(503));
+                          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(503));
         m_DriveState = DriveState::NOT_READY;
         // DVD-ROM in undefined state
         // Better delete old CD Information
@@ -148,7 +149,7 @@ void CDetectDVDMedia::UpdateDvdrom()
       {
         // Nothing in there...
         SetNewDVDShareUrl(CServiceBroker::GetMediaManager().TranslateDevicePath(m_diskPath), false,
-                          g_localizeStrings.Get(504));
+                          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(504));
         m_DriveState = DriveState::CLOSED_NO_MEDIA;
         // Send Message to GUI that disc has changed
         CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -12,7 +12,8 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "guilib/GUIComponent.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/URIUtils.h"
 
 #include <mutex>
@@ -191,20 +192,21 @@ void CMediaManager::GetNetworkLocations(std::vector<CMediaSource>& locations, bo
     share.m_ignore = true;
 #ifdef HAS_FILESYSTEM_SMB
     share.strPath = "smb://";
-    share.strName = g_localizeStrings.Get(20171);
+    share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20171);
     locations.push_back(share);
 #endif
 
 #ifdef HAS_FILESYSTEM_NFS
     share.strPath = "nfs://";
-    share.strName = g_localizeStrings.Get(20259);
+    share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20259);
     locations.push_back(share);
 #endif// HAS_FILESYSTEM_NFS
 
 #ifdef HAS_UPNP
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_SERVICES_UPNP))
     {
-      const std::string& strDevices = g_localizeStrings.Get(33040); //"% Devices"
+      const std::string& strDevices =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(33040); //"% Devices"
       share.strPath = "upnp://";
       share.strName = StringUtils::Format(strDevices, "UPnP"); //"UPnP Devices"
       locations.push_back(share);
@@ -213,7 +215,7 @@ void CMediaManager::GetNetworkLocations(std::vector<CMediaSource>& locations, bo
 
 #ifdef HAS_ZEROCONF
     share.strPath = "zeroconf://";
-    share.strName = g_localizeStrings.Get(20262);
+    share.strName = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20262);
     locations.push_back(share);
 #endif
 
@@ -225,9 +227,12 @@ void CMediaManager::GetNetworkLocations(std::vector<CMediaSource>& locations, bo
         if (!info.type.empty() && info.supportBrowsing)
         {
           share.strPath = info.type + "://";
-          share.strName = g_localizeStrings.GetAddonString(addon->ID(), info.label);
+          share.strName =
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+                  addon->ID(), info.label);
           if (share.strName.empty())
-            share.strName = g_localizeStrings.Get(info.label);
+            share.strName =
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(info.label);
           locations.push_back(share);
         }
       }
@@ -301,27 +306,33 @@ CMediaSource CMediaManager::GetRootAddonTypeSource(const std::string& type) cons
 {
   if (type == "programs" || type == "myprograms")
   {
-    return ComputeRootAddonTypeSource("executable", g_localizeStrings.Get(1043),
-                                      "DefaultAddonProgram.png");
+    return ComputeRootAddonTypeSource(
+        "executable", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1043),
+        "DefaultAddonProgram.png");
   }
   else if (type == "video" || type == "videos")
   {
-    return ComputeRootAddonTypeSource("video", g_localizeStrings.Get(1037),
-                                      "DefaultAddonVideo.png");
+    return ComputeRootAddonTypeSource(
+        "video", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1037),
+        "DefaultAddonVideo.png");
   }
   else if (type == "music")
   {
-    return ComputeRootAddonTypeSource("audio", g_localizeStrings.Get(1038),
-                                      "DefaultAddonMusic.png");
+    return ComputeRootAddonTypeSource(
+        "audio", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1038),
+        "DefaultAddonMusic.png");
   }
   else if (type == "pictures")
   {
-    return ComputeRootAddonTypeSource("image", g_localizeStrings.Get(1039),
-                                      "DefaultAddonPicture.png");
+    return ComputeRootAddonTypeSource(
+        "image", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1039),
+        "DefaultAddonPicture.png");
   }
   else if (type == "games")
   {
-    return ComputeRootAddonTypeSource("game", g_localizeStrings.Get(35049), "DefaultAddonGame.png");
+    return ComputeRootAddonTypeSource(
+        "game", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35049),
+        "DefaultAddonGame.png");
   }
   else
   {
@@ -795,22 +806,27 @@ void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& d
   }
   else
   {
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13021),
-                                          device.label, TOAST_DISPLAY_TIME, false);
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Info,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13021), device.label,
+        TOAST_DISPLAY_TIME, false);
   }
 #endif
 }
 
 void CMediaManager::OnStorageSafelyRemoved(const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
-  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(13023),
-                                        device.label, TOAST_DISPLAY_TIME, false);
+  CGUIDialogKaiToast::QueueNotification(
+      CGUIDialogKaiToast::Info,
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13023), device.label,
+      TOAST_DISPLAY_TIME, false);
 }
 
 void CMediaManager::OnStorageUnsafelyRemoved(const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
-  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning, g_localizeStrings.Get(13022),
-                                        device.label);
+  CGUIDialogKaiToast::QueueNotification(
+      CGUIDialogKaiToast::Warning,
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13022), device.label);
 }
 
 UTILS::DISCS::DiscInfo CMediaManager::GetDiscInfo(const std::string& mediaPath)
@@ -864,8 +880,8 @@ bool CMediaManager::playStubFile(const CFileItem& item)
   std::string strLine1, strLine2;
 
   // use generic message by default
-  strLine1 = g_localizeStrings.Get(435).c_str();
-  strLine2 = g_localizeStrings.Get(436).c_str();
+  strLine1 = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(435).c_str();
+  strLine2 = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(436).c_str();
 
   CXBMCTinyXML2 discStubXML;
   if (discStubXML.LoadFile(item.GetPath()))

--- a/xbmc/test/TestDateTime.cpp
+++ b/xbmc/test/TestDateTime.cpp
@@ -7,9 +7,11 @@
  */
 
 #include "LangInfo.h"
+#include "ServiceBroker.h"
 #include "XBDateTime.h"
-#include "guilib/LocalizeStrings.h"
 #include "interfaces/legacy/ModuleXbmc.h" //Needed to test getRegion()
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 #include <array>
 #include <iostream>
@@ -409,7 +411,8 @@ TEST_F(TestDateTime, GetAsLocalized)
   // "DD. MMMM. YYYY",
   // "YYYY. MMMM. D"
 
-  ASSERT_TRUE(g_localizeStrings.Load(g_langInfo.GetLanguagePath(), "resource.language.en_gb"));
+  ASSERT_TRUE(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Load(
+      g_langInfo.GetLanguagePath(), "resource.language.en_gb"));
 
   // 24 hour clock must be set before time format
   g_langInfo.Set24HourClock(false);

--- a/xbmc/utils/AlarmClock.cpp
+++ b/xbmc/utils/AlarmClock.cpp
@@ -12,9 +12,10 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "events/EventLog.h"
 #include "events/NotificationEvent.h"
-#include "guilib/LocalizeStrings.h"
 #include "log.h"
 #include "messaging/ApplicationMessenger.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 
 #include <mutex>
@@ -60,8 +61,9 @@ void CAlarmClock::Start(const std::string& strName, float n_secs, const std::str
 
   EventPtr alarmClockActivity(new CNotificationEvent(
       labelAlarmClock,
-      StringUtils::Format(g_localizeStrings.Get(labelStarted), static_cast<int>(event.m_fSecs) / 60,
-                          static_cast<int>(event.m_fSecs) % 60)));
+      StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(labelStarted),
+          static_cast<int>(event.m_fSecs) / 60, static_cast<int>(event.m_fSecs) % 60)));
 
   auto eventLog = CServiceBroker::GetEventLog();
   if (eventLog)
@@ -102,12 +104,13 @@ void CAlarmClock::Stop(const std::string& strName, bool bSilent /* false */)
     elapsed = iter->second.watch.GetElapsedSeconds();
 
   if (elapsed > static_cast<float>(iter->second.m_fSecs))
-    strMessage = g_localizeStrings.Get(13211);
+    strMessage = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13211);
   else
   {
     float remaining = static_cast<float>(iter->second.m_fSecs) - elapsed;
-    strMessage = StringUtils::Format(g_localizeStrings.Get(13212), static_cast<int>(remaining) / 60,
-                                     static_cast<int>(remaining) % 60);
+    strMessage =
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13212),
+                            static_cast<int>(remaining) / 60, static_cast<int>(remaining) % 60);
   }
 
   if (iter->second.m_strCommand.empty() || static_cast<float>(iter->second.m_fSecs) > elapsed)

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -9,8 +9,10 @@
 #include "CharsetConverter.h"
 
 #include "LangInfo.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
 #include "log.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDefinitions.h"
@@ -903,7 +905,8 @@ void CCharsetConverter::SettingOptionsCharsetsFiller(const SettingConstPtr& sett
   std::vector<std::string> vecCharsets = g_charsetConverter.getCharsetLabels();
   sort(vecCharsets.begin(), vecCharsets.end(), sortstringbyname());
 
-  list.emplace_back(g_localizeStrings.Get(13278), "DEFAULT"); // "Default"
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13278),
+                    "DEFAULT"); // "Default"
   for (int i = 0; i < (int) vecCharsets.size(); ++i)
     list.emplace_back(vecCharsets[i], g_charsetConverter.getCharsetNameByLabel(vecCharsets[i]));
 }

--- a/xbmc/utils/FileOperationJob.cpp
+++ b/xbmc/utils/FileOperationJob.cpp
@@ -17,7 +17,8 @@
 #include "filesystem/FileDirectoryFactory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -225,20 +226,20 @@ std::string CFileOperationJob::GetActionString(FileAction action)
   {
     case ActionCopy:
     case ActionReplace:
-      result = g_localizeStrings.Get(115);
+      result = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(115);
       break;
 
     case ActionMove:
-      result = g_localizeStrings.Get(116);
+      result = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(116);
       break;
 
     case ActionDelete:
     case ActionDeleteFolder:
-      result = g_localizeStrings.Get(117);
+      result = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(117);
       break;
 
     case ActionCreateFolder:
-      result = g_localizeStrings.Get(119);
+      result = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(119);
       break;
 
     default:

--- a/xbmc/utils/FileUtils.cpp
+++ b/xbmc/utils/FileUtils.cpp
@@ -21,8 +21,9 @@
 #include "filesystem/StackDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
-#include "guilib/LocalizeStrings.h"
 #include "imagefiles/ImageFileURL.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -72,7 +73,9 @@ bool CFileUtils::RenameFile(const std::string &strFile)
   URIUtils::RemoveSlashAtEnd(strFileAndPath);
   std::string strFileName = URIUtils::GetFileName(strFileAndPath);
   std::string strPath = URIUtils::GetDirectory(strFileAndPath);
-  if (CGUIKeyboardFactory::ShowAndGetInput(strFileName, CVariant{g_localizeStrings.Get(16013)}, false))
+  if (CGUIKeyboardFactory::ShowAndGetInput(
+          strFileName,
+          CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16013)}, false))
   {
     strPath = URIUtils::AddFileToFolder(strPath, strFileName);
     CLog::Log(LOGINFO, "FileUtils: rename {}->{}", strFileAndPath, strPath);

--- a/xbmc/utils/InfoLoader.cpp
+++ b/xbmc/utils/InfoLoader.cpp
@@ -10,8 +10,9 @@
 
 #include "ServiceBroker.h"
 #include "TimeUtils.h"
-#include "guilib/LocalizeStrings.h"
 #include "jobs/JobManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 CInfoLoader::CInfoLoader(unsigned int timeToRefresh)
 {
@@ -52,7 +53,7 @@ std::string CInfoLoader::GetInfo(int info)
 
 std::string CInfoLoader::BusyInfo(int info) const
 {
-  return g_localizeStrings.Get(503);
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(503);
 }
 
 std::string CInfoLoader::TranslateInfo(int info) const

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -16,9 +16,10 @@
 #include "Util.h"
 #include "Variant.h"
 #include "addons/IAddon.h"
-#include "guilib/LocalizeStrings.h"
 #include "music/tags/MusicInfoTag.h"
 #include "pictures/PictureInfoTag.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -272,7 +273,8 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
   case 'M':
     if (movie && movie->m_iEpisode > 0)
       value = StringUtils::Format("{} {}", movie->m_iEpisode,
-                                  g_localizeStrings.Get(movie->m_iEpisode == 1 ? 20452 : 20453));
+                                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                      movie->m_iEpisode == 1 ? 20452 : 20453));
     break;
   case 'E':
     if (movie && movie->m_iEpisode > 0)
@@ -324,9 +326,9 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     break;
    case 'W': // Listeners
      if (!item->IsFolder() && music && music->GetListeners() != 0)
-       value =
-           StringUtils::Format("{} {}", music->GetListeners(),
-                               g_localizeStrings.Get(music->GetListeners() == 1 ? 20454 : 20455));
+       value = StringUtils::Format("{} {}", music->GetListeners(),
+                                   CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                       music->GetListeners() == 1 ? 20454 : 20455));
      break;
   case 'a': // Date Added
     if (movie && movie->m_dateAdded.IsValid())

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -14,9 +14,10 @@
 #include "filesystem/CurlFile.h"
 #include "filesystem/File.h"
 #include "guilib/GUIRSSControl.h"
-#include "guilib/LocalizeStrings.h"
 #include "log.h"
 #include "network/Network.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/SystemClock.h"
@@ -136,7 +137,9 @@ void CRssReader::Process()
         !CServiceBroker::GetNetwork().IsAvailable())
     {
       CLog::Log(LOGWARNING, "RSS: No network connection");
-      strXML = "<rss><item><title>"+g_localizeStrings.Get(15301)+"</title></item></rss>";
+      strXML = "<rss><item><title>" +
+               CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15301) +
+               "</title></item></rss>";
     }
     else
     {

--- a/xbmc/utils/ScraperParser.cpp
+++ b/xbmc/utils/ScraperParser.cpp
@@ -8,14 +8,16 @@
 
 #include "ScraperParser.h"
 
-#include "guilib/LocalizeStrings.h"
-#include "RegExp.h"
-#include "HTMLUtil.h"
-#include "addons/Scraper.h"
-#include "URL.h"
-#include "utils/StringUtils.h"
-#include "log.h"
 #include "CharsetConverter.h"
+#include "HTMLUtil.h"
+#include "RegExp.h"
+#include "ServiceBroker.h"
+#include "URL.h"
+#include "addons/Scraper.h"
+#include "log.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
+#include "utils/StringUtils.h"
 #ifdef HAVE_LIBXSLT
 #include "utils/XSLTUtils.h"
 #endif
@@ -170,7 +172,8 @@ void CScraperParser::ReplaceBuffers(std::string& strDest)
     std::string strInfo = strDest.substr(iIndex+10, iEnd - iIndex - 10);
     std::string strReplace;
     if (m_scraper)
-      strReplace = g_localizeStrings.GetAddonString(m_scraper->ID(), strtol(strInfo.c_str(),NULL,10));
+      strReplace = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+          m_scraper->ID(), strtol(strInfo.c_str(), NULL, 10));
     strDest.replace(strDest.begin()+iIndex,strDest.begin()+iEnd+1,strReplace);
     iIndex += strReplace.length();
   }

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -12,9 +12,10 @@
 #include "URL.h"
 #include "Util.h"
 #include "filesystem/File.h"
-#include "guilib/LocalizeStrings.h"
 #include "jobs/JobManager.h"
 #include "pictures/Picture.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/SettingPath.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -92,7 +93,8 @@ void CScreenShot::TakeScreenshot()
   std::string strDir = screenshotSetting->GetValue();
   if (strDir.empty())
   {
-    if (!CGUIControlButtonSetting::GetPath(screenshotSetting, &g_localizeStrings))
+    if (!CGUIControlButtonSetting::GetPath(
+            screenshotSetting, &CServiceBroker::GetResourcesComponent().GetLocalizeStrings()))
       return;
 
     strDir = screenshotSetting->GetValue();

--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -8,7 +8,9 @@
 
 #include "StreamUtils.h"
 
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 
 #include <array>
 
@@ -145,7 +147,8 @@ std::string StreamUtils::GetLayout(unsigned int channels)
   {
     layout = std::to_string(channels);
     layout.append(" ");
-    layout.append(g_localizeStrings.Get(10127)); // "channels"
+    layout.append(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10127)); // "channels"
   }
 
   return layout;

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -18,11 +18,12 @@
 #include "ServiceBroker.h"
 #include "filesystem/CurlFile.h"
 #include "filesystem/File.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "network/Network.h"
 #include "platform/Filesystem.h"
 #include "rendering/RenderSystem.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/CPUInfo.h"
@@ -318,7 +319,8 @@ std::string CSysInfoJob::GetMACAddress()
   {
     mac = iface->GetMacAddress();
     if (mac.empty())
-      mac = g_localizeStrings.Get(10005); // Not available
+      mac =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10005); // Not available
   }
   return mac;
 }
@@ -355,16 +357,16 @@ std::string CSysInfoJob::GetGatewayAddress()
 
 std::string CSysInfoJob::GetNetworkLinkState()
 {
-  std::string linkStatus = g_localizeStrings.Get(151);
+  std::string linkStatus = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(151);
   linkStatus += " ";
   CNetworkInterface* iface = CServiceBroker::GetNetwork().GetFirstConnectedInterface();
   if (iface && iface->IsConnected())
   {
-    linkStatus += g_localizeStrings.Get(15207);
+    linkStatus += CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15207);
   }
   else
   {
-    linkStatus += g_localizeStrings.Get(15208);
+    linkStatus += CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15208);
   }
   return linkStatus;
 }
@@ -423,18 +425,23 @@ std::string CSysInfoJob::GetSystemUpTime(bool bTotalUptime)
   SystemUpTime(iInputMinutes,iMinutes, iHours, iDays);
   if (iDays > 0)
   {
-    strSystemUptime =
-        StringUtils::Format("{} {}, {} {}, {} {}", iDays, g_localizeStrings.Get(12393), iHours,
-                            g_localizeStrings.Get(12392), iMinutes, g_localizeStrings.Get(12391));
+    strSystemUptime = StringUtils::Format(
+        "{} {}, {} {}, {} {}", iDays,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12393), iHours,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12392), iMinutes,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12391));
   }
   else if (iDays == 0 && iHours >= 1 )
   {
-    strSystemUptime = StringUtils::Format("{} {}, {} {}", iHours, g_localizeStrings.Get(12392),
-                                          iMinutes, g_localizeStrings.Get(12391));
+    strSystemUptime = StringUtils::Format(
+        "{} {}, {} {}", iHours,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12392), iMinutes,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12391));
   }
   else if (iDays == 0 && iHours == 0 &&  iMinutes >= 0)
   {
-    strSystemUptime = StringUtils::Format("{} {}", iMinutes, g_localizeStrings.Get(12391));
+    strSystemUptime = StringUtils::Format(
+        "{} {}", iMinutes, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12391));
   }
   return strSystemUptime;
 }
@@ -454,9 +461,13 @@ std::string CSysInfo::TranslateInfo(int info) const
   case NETWORK_GATEWAY_ADDRESS:
     return m_info.gatewayAddress;
   case NETWORK_DNS1_ADDRESS:
-    return !m_info.dnsServers.empty() ? m_info.dnsServers.at(0) : g_localizeStrings.Get(231);
+    return !m_info.dnsServers.empty()
+               ? m_info.dnsServers.at(0)
+               : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231);
   case NETWORK_DNS2_ADDRESS:
-    return m_info.dnsServers.size() > 1 ? m_info.dnsServers.at(1) : g_localizeStrings.Get(231);
+    return m_info.dnsServers.size() > 1
+               ? m_info.dnsServers.at(1)
+               : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231);
   case NETWORK_LINK_STATE:
     return m_info.networkLinkState;
   case SYSTEM_OS_VERSION_INFO:
@@ -469,9 +480,9 @@ std::string CSysInfo::TranslateInfo(int info) const
     return m_info.systemTotalUptime;
   case SYSTEM_INTERNET_STATE:
     if (m_info.internetState == CSysData::CONNECTED)
-      return g_localizeStrings.Get(13296);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13296);
     else
-      return g_localizeStrings.Get(13297);
+      return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13297);
   case SYSTEM_BATTERY_LEVEL:
     return m_info.batteryLevel;
   default:
@@ -1154,19 +1165,29 @@ std::string CSysInfo::GetHddSpaceInfo(int& percent, int drive, bool shortText)
       switch(drive)
       {
       case SYSTEM_FREE_SPACE:
-        strRet = StringUtils::Format("{} MB {}", totalFree, g_localizeStrings.Get(160));
+        strRet = StringUtils::Format(
+            "{} MB {}", totalFree,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(160));
         break;
       case SYSTEM_USED_SPACE:
-        strRet = StringUtils::Format("{} MB {}", totalUsed, g_localizeStrings.Get(20162));
+        strRet = StringUtils::Format(
+            "{} MB {}", totalUsed,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20162));
         break;
       case SYSTEM_TOTAL_SPACE:
-        strRet = StringUtils::Format("{} MB {}", total, g_localizeStrings.Get(20161));
+        strRet = StringUtils::Format(
+            "{} MB {}", total,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20161));
         break;
       case SYSTEM_FREE_SPACE_PERCENT:
-        strRet = StringUtils::Format("{} % {}", percentFree, g_localizeStrings.Get(160));
+        strRet = StringUtils::Format(
+            "{} % {}", percentFree,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(160));
         break;
       case SYSTEM_USED_SPACE_PERCENT:
-        strRet = StringUtils::Format("{} % {}", percentused, g_localizeStrings.Get(20162));
+        strRet = StringUtils::Format(
+            "{} % {}", percentused,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20162));
         break;
       }
     }
@@ -1174,9 +1195,10 @@ std::string CSysInfo::GetHddSpaceInfo(int& percent, int drive, bool shortText)
   else
   {
     if (shortText)
-      strRet = g_localizeStrings.Get(10006); // N/A
+      strRet = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10006); // N/A
     else
-      strRet = g_localizeStrings.Get(10005); // Not available
+      strRet =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10005); // Not available
   }
   return strRet;
 }
@@ -1536,7 +1558,7 @@ std::string CSysInfo::GetPrivacyPolicy()
       m_privacyPolicy = std::string(reinterpret_cast<char*>(buf.data()), buf.size());
     }
     else
-      m_privacyPolicy = g_localizeStrings.Get(19055);
+      m_privacyPolicy = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19055);
   }
   return m_privacyPolicy;
 }

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -11,7 +11,8 @@
 #include "CompileInfo.h"
 #include "ServiceBroker.h"
 #include "filesystem/File.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/SettingUtils.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -252,7 +253,8 @@ void CLog::SettingOptionsLoggingComponentsFiller(const SettingConstPtr& setting,
   for (const auto& [id, names] : componentMap)
   {
     // localized component setting name, component id
-    list.emplace_back(g_localizeStrings.Get(names.stringId), id);
+    list.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(names.stringId), id);
   }
 }
 

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -15,8 +15,9 @@
 #include "application/Application.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "music/MusicFileItemClassify.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/PlayerUtils.h"
@@ -291,10 +292,12 @@ std::string CVideoPlay::GetLabel(const CFileItem& itemIn) const
 {
   CFileItem item(itemIn.GetItemToPlay());
   if (item.IsLiveTV())
-    return g_localizeStrings.Get(19000); // Switch to channel
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        19000); // Switch to channel
   if (VIDEO::UTILS::GetItemResumeInformation(item).isResumable)
-    return g_localizeStrings.Get(12021); // Play from beginning
-  return g_localizeStrings.Get(208); // Play
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        12021); // Play from beginning
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(208); // Play
 }
 
 bool CVideoPlay::IsVisible(const CFileItem& item) const
@@ -413,9 +416,11 @@ bool CVideoPlayNext::Execute(const std::shared_ptr<CFileItem>& item) const
 std::string CVideoPlayAndQueue::GetLabel(const CFileItem& item) const
 {
   if (VIDEO::UTILS::IsAutoPlayNextItem(item))
-    return g_localizeStrings.Get(13434); // Play only this
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        13434); // Play only this
   else
-    return g_localizeStrings.Get(13412); // Play from here
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        13412); // Play from here
 }
 
 bool CVideoPlayAndQueue::IsVisible(const CFileItem& item) const

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -18,9 +18,10 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUISliderControl.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
 #include "settings/MediaSettings.h"
@@ -69,8 +70,10 @@ bool CPlayerController::OnAction(const CAction &action)
         if (appPlayer->GetSubtitleCount() == 0)
         {
           CGUIDialogKaiToast::QueueNotification(
-              CGUIDialogKaiToast::Info, g_localizeStrings.Get(287), g_localizeStrings.Get(10005),
-              DisplTime, false, MsgTime);
+              CGUIDialogKaiToast::Info,
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(287),
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10005), DisplTime,
+              false, MsgTime);
           return true;
         }
 
@@ -83,7 +86,8 @@ bool CPlayerController::OnAction(const CAction &action)
           SubtitleStreamInfo info;
           appPlayer->GetSubtitleStreamInfo(CURRENT_STREAM, info);
           if (!g_LangCodeExpander.Lookup(info.language, lang))
-            lang = g_localizeStrings.Get(13205); // Unknown
+            lang =
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
 
           if (info.name.empty())
             sub = lang;
@@ -91,9 +95,11 @@ bool CPlayerController::OnAction(const CAction &action)
             sub = StringUtils::Format("{} - {}", lang, info.name);
         }
         else
-          sub = g_localizeStrings.Get(1223);
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
-                                              g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
+          sub = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1223);
+        CGUIDialogKaiToast::QueueNotification(
+            CGUIDialogKaiToast::Info,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(287), sub, DisplTime,
+            false, MsgTime);
         return true;
       }
 
@@ -137,7 +143,8 @@ bool CPlayerController::OnAction(const CAction &action)
           SubtitleStreamInfo info;
           appPlayer->GetSubtitleStreamInfo(currentSub, info);
           if (!g_LangCodeExpander.Lookup(info.language, lang))
-            lang = g_localizeStrings.Get(13205); // Unknown
+            lang =
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
 
           if (info.name.empty())
             sub = lang;
@@ -145,8 +152,11 @@ bool CPlayerController::OnAction(const CAction &action)
             sub = StringUtils::Format("{} - {}", lang, info.name);
         }
         else
-          sub = g_localizeStrings.Get(1223);
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
+          sub = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1223);
+        CGUIDialogKaiToast::QueueNotification(
+            CGUIDialogKaiToast::Info,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(287), sub, DisplTime,
+            false, MsgTime);
         return true;
       }
 
@@ -256,7 +266,7 @@ bool CPlayerController::OnAction(const CAction &action)
         AudioStreamInfo info;
         appPlayer->GetAudioStreamInfo(currentAudio, info);
         if (!g_LangCodeExpander.Lookup(info.language, lan))
-          lan = g_localizeStrings.Get(13205); // Unknown
+          lan = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
 
         std::string textInfo = lan;
         if (!info.name.empty())
@@ -264,7 +274,7 @@ bool CPlayerController::OnAction(const CAction &action)
         if (!info.codecDesc.empty())
           textInfo += " (" + info.codecDesc + ")";
 
-        std::string caption = g_localizeStrings.Get(460);
+        std::string caption = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(460);
         caption += StringUtils::Format(" ({}/{})", currentAudio + 1, audioStreamCount);
         CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, caption, textInfo,
                                               DisplTime, false, MsgTime);
@@ -290,7 +300,8 @@ bool CPlayerController::OnAction(const CAction &action)
         appPlayer->SetVideoStream(currentVideo);
         VideoStreamInfo info;
         appPlayer->GetVideoStreamInfo(currentVideo, info);
-        std::string caption = g_localizeStrings.Get(38031);
+        std::string caption =
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38031);
         caption += StringUtils::Format(" ({}/{})", currentVideo + 1, videoStreamCount);
         CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, caption, info.name, DisplTime, false, MsgTime);
         return true;
@@ -461,8 +472,11 @@ bool CPlayerController::OnAction(const CAction &action)
 
         settings->SetAlignment(align);
         CGUIDialogKaiToast::QueueNotification(
-            CGUIDialogKaiToast::Info, g_localizeStrings.Get(21460),
-            g_localizeStrings.Get(21461 + static_cast<int>(align)), TOAST_DISPLAY_TIME, false);
+            CGUIDialogKaiToast::Info,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21460),
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                21461 + static_cast<int>(align)),
+            TOAST_DISPLAY_TIME, false);
         return true;
       }
 
@@ -472,10 +486,11 @@ bool CPlayerController::OnAction(const CAction &action)
         // Don't allow change with passthrough audio
         if (appPlayer->IsPassthrough())
         {
-          CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning,
-                                                g_localizeStrings.Get(660),
-                                                g_localizeStrings.Get(29802),
-                                                TOAST_DISPLAY_TIME, false);
+          CGUIDialogKaiToast::QueueNotification(
+              CGUIDialogKaiToast::Warning,
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(660),
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(29802),
+              TOAST_DISPLAY_TIME, false);
           return false;
         }
 
@@ -522,7 +537,8 @@ bool CPlayerController::OnAction(const CAction &action)
               playing = idx;
             idx++;
           }
-          dialog->SetHeading(CVariant{g_localizeStrings.Get(39109)});
+          dialog->SetHeading(
+              CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39109)});
           dialog->SetSelected(playing);
           dialog->Open();
           idx = dialog->GetSelectedItem();
@@ -551,7 +567,8 @@ bool CPlayerController::OnAction(const CAction &action)
               current = idx;
             idx++;
           }
-          dialog->SetHeading(CVariant{g_localizeStrings.Get(39110)});
+          dialog->SetHeading(
+              CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39110)});
           dialog->SetSelected(current);
           dialog->Open();
           idx = dialog->GetSelectedItem();
@@ -575,7 +592,9 @@ void CPlayerController::ShowSlider(int action, int label, float value, float min
 {
   m_sliderAction = action;
   if (modal)
-    CGUIDialogSlider::ShowAndGetInput(g_localizeStrings.Get(label), value, min, delta, max, this);
+    CGUIDialogSlider::ShowAndGetInput(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(label), value, min, delta,
+        max, this);
   else
     CGUIDialogSlider::Display(label, value, min, delta, max, this);
 }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -32,7 +32,6 @@
 #include "filesystem/StackDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "imagefiles/ImageFileURL.h"
 #include "interfaces/AnnouncementManager.h"
@@ -40,6 +39,8 @@
 #include "music/Artist.h"
 #include "playlists/SmartPlayList.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
@@ -2006,9 +2007,10 @@ bool CVideoDatabase::GetSeasonInfo(int idSeason,
     if (name.empty())
     {
       if (season == 0)
-        name = g_localizeStrings.Get(20381);
+        name = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20381);
       else
-        name = StringUtils::Format(g_localizeStrings.Get(20358), season);
+        name = StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20358), season);
     }
 
     details.m_strTitle = name;
@@ -7423,9 +7425,10 @@ bool CVideoDatabase::GetSeasonsByWhere(const std::string& strBaseDir, const Filt
         if (strLabel.empty())
         {
           if (iSeason == 0)
-            strLabel = g_localizeStrings.Get(20381);
+            strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20381);
           else
-            strLabel = StringUtils::Format(g_localizeStrings.Get(20358), iSeason);
+            strLabel = StringUtils::Format(
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20358), iSeason);
         }
         auto pItem = std::make_shared<CFileItem>(strLabel);
 
@@ -9594,7 +9597,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
 
     if (handle)
     {
-      handle->SetTitle(g_localizeStrings.Get(700));
+      handle->SetTitle(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(700));
       handle->SetText("");
     }
     else if (showProgress)
@@ -9946,7 +9949,7 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
       CommitTransaction();
 
       if (handle)
-        handle->SetTitle(g_localizeStrings.Get(331));
+        handle->SetTitle(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(331));
 
       Compress(false);
 
@@ -10078,8 +10081,9 @@ std::vector<int> CVideoDatabase::CleanMediaType(const std::string &mediaType, co
             {
               CURL sourceUrl(sourcePath);
               pDialog->SetHeading(CVariant{15012});
-              pDialog->SetText(CVariant{StringUtils::Format(g_localizeStrings.Get(15013),
-                                                            sourceUrl.GetWithoutUserDetails())});
+              pDialog->SetText(CVariant{StringUtils::Format(
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15013),
+                  sourceUrl.GetWithoutUserDetails())});
               pDialog->SetChoice(0, CVariant{15015});
               pDialog->SetChoice(1, CVariant{15014});
               pDialog->Open();
@@ -10422,9 +10426,10 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           else
           {
             CLog::Log(LOGERROR, "Movie nfo export failed! ('{}')", nfoFile);
-            CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
-                                                  g_localizeStrings.Get(20302),
-                                                  CURL::GetRedacted(nfoFile));
+            CGUIDialogKaiToast::QueueNotification(
+                CGUIDialogKaiToast::Error,
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20302),
+                CURL::GetRedacted(nfoFile));
             iFailCount++;
           }
         }
@@ -10492,9 +10497,10 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
               else
               {
                 CLog::Log(LOGERROR, "Set nfo export failed! ('{}')", nfoFile);
-                CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
-                                                      g_localizeStrings.Get(20302),
-                                                      CURL::GetRedacted(nfoFile));
+                CGUIDialogKaiToast::QueueNotification(
+                    CGUIDialogKaiToast::Error,
+                    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20302),
+                    CURL::GetRedacted(nfoFile));
                 iFailCount++;
               }
             }
@@ -10588,9 +10594,10 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
             else
             {
               CLog::Log(LOGERROR, "Musicvideo nfo export failed! ('{}')", nfoFile);
-              CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
-                                                    g_localizeStrings.Get(20302),
-                                                    CURL::GetRedacted(nfoFile));
+              CGUIDialogKaiToast::QueueNotification(
+                  CGUIDialogKaiToast::Error,
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20302),
+                  CURL::GetRedacted(nfoFile));
               iFailCount++;
             }
           }
@@ -10696,9 +10703,10 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
             else
             {
               CLog::Log(LOGERROR, "TVShow nfo export failed! ('{}')", nfoFile);
-              CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
-                                                    g_localizeStrings.Get(20302),
-                                                    CURL::GetRedacted(nfoFile));
+              CGUIDialogKaiToast::QueueNotification(
+                  CGUIDialogKaiToast::Error,
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20302),
+                  CURL::GetRedacted(nfoFile));
               iFailCount++;
             }
           }
@@ -10805,9 +10813,10 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
             else
             {
               CLog::Log(LOGERROR, "Episode nfo export failed! ('{}')", nfoFile);
-              CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error,
-                                                    g_localizeStrings.Get(20302),
-                                                    CURL::GetRedacted(nfoFile));
+              CGUIDialogKaiToast::QueueNotification(
+                  CGUIDialogKaiToast::Error,
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20302),
+                  CURL::GetRedacted(nfoFile));
               iFailCount++;
             }
           }
@@ -10909,7 +10918,9 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
 
   if (iFailCount > 0)
     HELPERS::ShowOKDialogText(
-        CVariant{647}, CVariant{StringUtils::Format(g_localizeStrings.Get(15011), iFailCount)});
+        CVariant{647},
+        CVariant{StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(15011), iFailCount)});
 }
 
 void CVideoDatabase::ExportArt(const CFileItem& item,
@@ -11935,7 +11946,8 @@ void CVideoDatabase::UpdateVideoVersionTypeTable()
 
     for (int id = VIDEO_VERSION_ID_BEGIN; id <= VIDEO_VERSION_ID_END; ++id)
     {
-      const std::string& type = g_localizeStrings.Get(id);
+      const std::string& type =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(id);
       m_pDS->exec(PrepareSQL("UPDATE videoversiontype SET name = '%s', owner = %i WHERE id = '%i'",
                              type.c_str(), VideoAssetTypeOwner::SYSTEM, id));
     }

--- a/xbmc/video/VideoDatabaseDDL.cpp
+++ b/xbmc/video/VideoDatabaseDDL.cpp
@@ -8,9 +8,11 @@
 
 #include "video/VideoDatabaseDDL.h"
 
+#include "ServiceBroker.h"
 #include "dbwrappers/dataset.h"
-#include "guilib/LocalizeStrings.h"
 #include "media/MediaType.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabaseColumns.h"
@@ -30,7 +32,7 @@ void CVideoDatabaseDDL::InitializeVideoVersionTypeTable(CDatabase& db)
       if (id == 40405 || (id >= 40418 && id <= 40430))
         continue;
 
-      const std::string& type{g_localizeStrings.Get(id)};
+      const std::string& type{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(id)};
       db.ExecuteQuery(db.PrepareSQL(
           "INSERT INTO videoversiontype (id, name, owner, itemType) VALUES(%i, '%s', %i, %i)", id,
           type.c_str(), VideoAssetTypeOwner::SYSTEM, VideoAssetType::VERSION));

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -14,11 +14,13 @@
  *  Examples of external changes: functional changes, bug fixes, constants value changes, ...
  */
 
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "VideoDatabase.h"
 #include "dbwrappers/dataset.h"
 #include "filesystem/MultiPathDirectory.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/i18n/TableLanguageCodes.h"
@@ -53,7 +55,7 @@ void InitializeVideoVersionTypeTableV123(CDatabase& db)
   {
     for (int id = VIDEO_VERSION_ID_BEGIN; id <= VIDEO_VERSION_ID_END; ++id)
     {
-      const std::string& type{g_localizeStrings.Get(id)};
+      const std::string& type{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(id)};
       db.ExecuteQuery(
           db.PrepareSQL("INSERT INTO videoversiontype (id, name, owner) VALUES(%i, '%s', %i)", id,
                         type.c_str(), VideoAssetTypeOwner_SYSTEM));

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -29,12 +29,13 @@
 #include "filesystem/PluginDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "imagefiles/ImageFileURL.h"
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "playlists/PlayListFileItemClassify.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -263,7 +264,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
         CGUIDialogExtendedProgressBar* dialog =
           CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogExtendedProgressBar>(WINDOW_DIALOG_EXT_PROGRESS);
         if (dialog)
-           m_handle = dialog->GetHandle(g_localizeStrings.Get(314));
+          m_handle = dialog->GetHandle(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(314));
       }
 
       // check if we only need to perform a cleaning
@@ -332,7 +334,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
         else
         {
           if (m_handle)
-            m_handle->SetTitle(g_localizeStrings.Get(331));
+            m_handle->SetTitle(
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(331));
           m_database.Compress(false);
         }
       }
@@ -408,7 +411,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
   {
     if (m_handle)
     {
-      m_handle->SetText(g_localizeStrings.Get(20415));
+      m_handle->SetText(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20415));
     }
 
     /*
@@ -460,7 +463,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (m_handle)
       {
         int str = content == ContentType::MOVIES ? 20317 : 20318;
-        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(str), info->Name()));
+        m_handle->SetTitle(StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(str), info->Name()));
       }
 
       std::string fastHash;
@@ -522,7 +526,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
     else if (content == ContentType::TVSHOWS)
     {
       if (m_handle)
-        m_handle->SetTitle(StringUtils::Format(g_localizeStrings.Get(20319), info->Name()));
+        m_handle->SetTitle(StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20319), info->Name()));
 
       if (foundDirectly && !settings.parent_name_root)
       {
@@ -778,7 +783,9 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
           eventLog->Add(EventPtr(new CMediaLibraryEvent(
               mediaType, pItem->GetPath(), 24145,
-              StringUtils::Format(g_localizeStrings.Get(24147), mediaType, itemlogpath),
+              StringUtils::Format(
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24147),
+                  mediaType, itemlogpath),
               EventLevel::Warning)));
         }
       }
@@ -1947,8 +1954,9 @@ CVideoInfoScanner::~CVideoInfoScanner()
           }
 
           // Add '(Disc n)' to title (in local language)
-          movieDetails.m_strTitle =
-              StringUtils::Format(g_localizeStrings.Get(29995), movieDetails.m_strTitle, discNum);
+          movieDetails.m_strTitle = StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(29995),
+              movieDetails.m_strTitle, discNum);
         }
       }
 
@@ -2333,10 +2341,14 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (pDlgProgress)
       {
         pDlgProgress->SetLine(1, CVariant{20361}); // Loading episode details
-        pDlgProgress->SetLine(2, StringUtils::Format("{} {}", g_localizeStrings.Get(20373),
-                                                     file->iSeason)); // Season x
-        pDlgProgress->SetLine(3, StringUtils::Format("{} {}", g_localizeStrings.Get(20359),
-                                                     file->iEpisode)); // Episode y
+        pDlgProgress->SetLine(
+            2, StringUtils::Format(
+                   "{} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20373),
+                   file->iSeason)); // Season x
+        pDlgProgress->SetLine(
+            3, StringUtils::Format(
+                   "{} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20359),
+                   file->iEpisode)); // Episode y
         pDlgProgress->SetPercentage((int)((float)(iCurr++)/iMax*100));
         pDlgProgress->Progress();
       }
@@ -2349,7 +2361,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (m_database.GetEpisodeId(file->strPath, file->iEpisode, file->iSeason) > -1)
       {
         if (m_handle)
-          m_handle->SetText(g_localizeStrings.Get(20415));
+          m_handle->SetText(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20415));
         continue;
       }
 

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -9,8 +9,9 @@
 #include "VideoInfoTag.h"
 
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
 #include "imagefiles/ImageFileURL.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Archive.h"
@@ -1027,8 +1028,10 @@ std::string CVideoInfoTag::GetCast(const std::string& separator,
     if (it->strRole.empty() || !bIncludeRole)
       character = StringUtils::Format("{}{}", it->strName, sep);
     else
-      character = StringUtils::Format("{} {} {}{}", it->strName, g_localizeStrings.Get(20347),
-                                      it->strRole, sep);
+      character = StringUtils::Format(
+          "{} {} {}{}", it->strName,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20347), it->strRole,
+          sep);
     strLabel += character;
   }
   return StringUtils::TrimRight(strLabel, sep);

--- a/xbmc/video/VideoItemArtworkHandler.cpp
+++ b/xbmc/video/VideoItemArtworkHandler.cpp
@@ -13,9 +13,10 @@
 #include "MediaSource.h"
 #include "ServiceBroker.h"
 #include "filesystem/Directory.h"
-#include "guilib/LocalizeStrings.h"
 #include "imagefiles/ImageFileURL.h"
 #include "music/MusicDatabase.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/ArtUtils.h"
@@ -127,8 +128,9 @@ void CVideoItemArtworkHandler::AddItemPathToFileBrowserSources(std::vector<CMedi
   if (IsVideo(itemTmp))
     itemDir = URIUtils::GetParentPath(itemDir);
 
-  AddItemPathStringToFileBrowserSources(sources, itemDir,
-                                        g_localizeStrings.Get(36041) /* * Item folder */);
+  AddItemPathStringToFileBrowserSources(
+      sources, itemDir,
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36041) /* * Item folder */);
 }
 
 void CVideoItemArtworkHandler::PersistArt(const std::string& art)
@@ -426,12 +428,13 @@ void CVideoItemArtworkMovieSetHandler::AddItemPathToFileBrowserSources(
 {
   AddItemPathStringToFileBrowserSources(
       sources, VIDEO::CVideoInfoScanner::GetMovieSetInfoFolder(m_item->GetLabel()),
-      g_localizeStrings.Get(36041) /* * Item folder */);
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36041) /* * Item folder */);
   AddItemPathStringToFileBrowserSources(
       sources,
       CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(
           CSettings::SETTING_VIDEOLIBRARY_MOVIESETSFOLDER),
-      "* " + g_localizeStrings.Get(20226) /* Movie set information folder */);
+      "* " + CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                 20226) /* Movie set information folder */);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/xbmc/video/ViewModeSettings.cpp
+++ b/xbmc/video/ViewModeSettings.cpp
@@ -8,8 +8,10 @@
 
 #include "ViewModeSettings.h"
 
+#include "ServiceBroker.h"
 #include "cores/VideoSettings.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/lib/SettingDefinitions.h"
 
 struct ViewModeProperties
@@ -96,6 +98,8 @@ void CViewModeSettings::ViewModesFiller(const std::shared_ptr<const CSetting>& s
   for (const auto &item : viewModes)
   {
     if (!item.hideFromList)
-      list.emplace_back(g_localizeStrings.Get(item.stringIndex), item.viewMode);
+      list.emplace_back(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(item.stringIndex),
+          item.viewMode);
   }
 }

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -19,8 +19,9 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
-#include "guilib/LocalizeStrings.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
@@ -79,21 +80,27 @@ void CGUIDialogAudioSettings::FrameMove()
 std::string CGUIDialogAudioSettings::FormatDelay(float value, float interval)
 {
   if (fabs(value) < 0.5f * interval)
-    return StringUtils::Format(g_localizeStrings.Get(22003), 0.0);
+    return StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(22003), 0.0);
   if (value < 0)
-    return StringUtils::Format(g_localizeStrings.Get(22004), fabs(value));
+    return StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(22004), fabs(value));
 
-  return StringUtils::Format(g_localizeStrings.Get(22005), value);
+  return StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(22005), value);
 }
 
 std::string CGUIDialogAudioSettings::FormatDecibel(float value)
 {
-  return StringUtils::Format(g_localizeStrings.Get(14054), value);
+  return StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14054), value);
 }
 
 std::string CGUIDialogAudioSettings::FormatPercentAsDecibel(float value)
 {
-  return StringUtils::Format(g_localizeStrings.Get(14054), CAEUtil::PercentToGain(value));
+  return StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14054),
+      CAEUtil::PercentToGain(value));
 }
 
 void CGUIDialogAudioSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
@@ -351,11 +358,13 @@ std::string FormatCodec(const AudioStreamInfo& info)
   }
   else
   {
-    codec += StringUtils::Format("{} - {} {}",
-                                 info.codecName.empty() ? g_localizeStrings.Get(13205) // unknown
-                                                        : info.codecName,
-                                 info.channels,
-                                 g_localizeStrings.Get(10127) // channels
+    codec += StringUtils::Format(
+        "{} - {} {}",
+        info.codecName.empty()
+            ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205) // unknown
+            : info.codecName,
+        info.channels,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10127) // channels
     );
   }
   codec += ")";
@@ -381,7 +390,8 @@ void CGUIDialogAudioSettings::AudioStreamsOptionFiller(const SettingConstPtr& se
     appPlayer->GetAudioStreamInfo(i, info);
 
     if (!g_LangCodeExpander.Lookup(info.language, strLanguage))
-      strLanguage = "[" + g_localizeStrings.Get(13205) + "]"; // Unknown
+      strLanguage = "[" + CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205) +
+                    "]"; // Unknown
 
     std::string textInfo = strLanguage;
     if (!info.name.empty())
@@ -395,7 +405,7 @@ void CGUIDialogAudioSettings::AudioStreamsOptionFiller(const SettingConstPtr& se
 
   if (list.empty())
   {
-    list.emplace_back(g_localizeStrings.Get(231), -1);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231), -1);
     current = -1;
   }
 }
@@ -414,11 +424,14 @@ std::string CGUIDialogAudioSettings::SettingFormatterDelay(
   float fStep = step.asFloat();
 
   if (fabs(fValue) < 0.5f * fStep)
-    return StringUtils::Format(g_localizeStrings.Get(22003), 0.0);
+    return StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(22003), 0.0);
   if (fValue < 0)
-    return StringUtils::Format(g_localizeStrings.Get(22004), fabs(fValue));
+    return StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(22004), fabs(fValue));
 
-  return StringUtils::Format(g_localizeStrings.Get(22005), fValue);
+  return StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(22005), fValue);
 }
 
 std::string CGUIDialogAudioSettings::SettingFormatterPercentAsDecibel(
@@ -433,7 +446,8 @@ std::string CGUIDialogAudioSettings::SettingFormatterPercentAsDecibel(
 
   std::string formatString = control->GetFormatString();
   if (control->GetFormatLabel() > -1)
-    formatString = g_localizeStrings.Get(control->GetFormatLabel());
+    formatString =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(control->GetFormatLabel());
 
   return StringUtils::Format(formatString, CAEUtil::PercentToGain(value.asFloat()));
 }
@@ -442,15 +456,20 @@ std::string CGUIDialogAudioSettings::FormatFlags(StreamFlags flags)
 {
   std::vector<std::string> localizedFlags;
   if (flags & StreamFlags::FLAG_DEFAULT)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39105));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39105));
   if (flags & StreamFlags::FLAG_FORCED)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39106));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39106));
   if (flags & StreamFlags::FLAG_HEARING_IMPAIRED)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39107));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39107));
   if (flags &  StreamFlags::FLAG_VISUAL_IMPAIRED)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39108));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39108));
   if (flags & StreamFlags::FLAG_ORIGINAL)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39111));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39111));
 
   std::string formated = StringUtils::Join(localizedFlags, ", ");
 

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -23,8 +23,9 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
@@ -160,13 +161,16 @@ std::string CGUIDialogSubtitleSettings::BrowseForSubtitle()
       paths.push_back(URIUtils::GetDirectory(strPath));
     }
     paths.push_back(CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_SUBTITLES_CUSTOMPATH));
-    share.FromNameAndPaths(g_localizeStrings.Get(21367), paths);
+    share.FromNameAndPaths(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21367),
+                           paths);
     shares.push_back(share);
     strPath = share.strPath;
     URIUtils::AddSlashAtEnd(strPath);
   }
 
-  if (CGUIDialogFileBrowser::ShowAndGetFile(shares, strMask, g_localizeStrings.Get(293), strPath, false, true)) // "subtitles"
+  if (CGUIDialogFileBrowser::ShowAndGetFile(
+          shares, strMask, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(293),
+          strPath, false, true)) // "subtitles"
   {
     if (URIUtils::HasExtension(strPath, ".sub"))
     {
@@ -372,7 +376,8 @@ void CGUIDialogSubtitleSettings::SubtitleStreamsOptionFiller(
     std::string strLanguage;
 
     if (!g_LangCodeExpander.Lookup(info.language, strLanguage))
-      strLanguage = g_localizeStrings.Get(13205); // Unknown
+      strLanguage =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
 
     if (info.name.empty())
       strItem = strLanguage;
@@ -388,7 +393,7 @@ void CGUIDialogSubtitleSettings::SubtitleStreamsOptionFiller(
   // no subtitle streams - just add a "None" entry
   if (list.empty())
   {
-    list.emplace_back(g_localizeStrings.Get(231), -1);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231), -1);
     current = -1;
   }
 }
@@ -407,26 +412,34 @@ std::string CGUIDialogSubtitleSettings::SettingFormatterDelay(
   float fStep = step.asFloat();
 
   if (fabs(fValue) < 0.5f * fStep)
-    return StringUtils::Format(g_localizeStrings.Get(22003), 0.0);
+    return StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(22003), 0.0);
   if (fValue < 0)
-    return StringUtils::Format(g_localizeStrings.Get(22004), fabs(fValue));
+    return StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(22004), fabs(fValue));
 
-  return StringUtils::Format(g_localizeStrings.Get(22005), fValue);
+  return StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(22005), fValue);
 }
 
 std::string CGUIDialogSubtitleSettings::FormatFlags(StreamFlags flags)
 {
   std::vector<std::string> localizedFlags;
   if (flags & StreamFlags::FLAG_DEFAULT)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39105));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39105));
   if (flags & StreamFlags::FLAG_FORCED)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39106));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39106));
   if (flags & StreamFlags::FLAG_HEARING_IMPAIRED)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39107));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39107));
   if (flags &  StreamFlags::FLAG_VISUAL_IMPAIRED)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39108));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39108));
   if (flags & StreamFlags::FLAG_ORIGINAL)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39111));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39111));
 
   std::string formated = StringUtils::Join(localizedFlags, ", ");
 

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -32,9 +32,10 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/ActionIDs.h"
 #include "jobs/Job.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -170,7 +171,10 @@ bool CGUIDialogSubtitles::OnMessage(CGUIMessage& message)
     else if (iControl == CONTROL_MANUALSEARCH)
     {
       //manual search
-      if (CGUIKeyboardFactory::ShowAndGetInput(m_strManualSearch, CVariant{g_localizeStrings.Get(24121)}, true))
+      if (CGUIKeyboardFactory::ShowAndGetInput(
+              m_strManualSearch,
+              CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24121)},
+              true))
       {
         Search(m_strManualSearch);
         return true;
@@ -436,10 +440,10 @@ void CGUIDialogSubtitles::OnSubtitleServiceContextMenu(int itemIdx)
   CContextButtons buttons;
   // Subtitle addon settings
   buttons.Add(static_cast<int>(SUBTITLE_SERVICE_CONTEXT_BUTTONS::ADDON_SETTINGS),
-              g_localizeStrings.Get(21417));
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21417));
   // Disable addon
   buttons.Add(static_cast<int>(SUBTITLE_SERVICE_CONTEXT_BUTTONS::ADDON_DISABLE),
-              g_localizeStrings.Get(24021));
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24021));
 
   auto idx = static_cast<SUBTITLE_SERVICE_CONTEXT_BUTTONS>(CGUIDialogContextMenu::Show(buttons));
   switch (idx)
@@ -491,19 +495,21 @@ void CGUIDialogSubtitles::UpdateStatus(STATUS status)
   switch (status)
   {
     case NO_SERVICES:
-      label = g_localizeStrings.Get(24114);
+      label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24114);
       break;
     case SEARCHING:
-      label = g_localizeStrings.Get(24107);
+      label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24107);
       break;
     case SEARCH_COMPLETE:
       if (!m_subtitles->IsEmpty())
-        label = StringUtils::Format(g_localizeStrings.Get(24108), m_subtitles->Size());
+        label = StringUtils::Format(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24108),
+            m_subtitles->Size());
       else
-        label = g_localizeStrings.Get(24109);
+        label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24109);
       break;
     case DOWNLOADING:
-      label = g_localizeStrings.Get(24110);
+      label = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24110);
       break;
     default:
       break;
@@ -534,7 +540,9 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
   {
     CFileItemPtr service = GetService();
     if (service)
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, service->GetLabel(), g_localizeStrings.Get(24113));
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Error, service->GetLabel(),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24113));
     UpdateStatus(SEARCH_COMPLETE);
     return;
   }
@@ -618,7 +626,9 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
 
     if (!CFile::Copy(strUrl, strDownloadFile))
     {
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, strSubName, g_localizeStrings.Get(24113));
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Error, strSubName,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24113));
       CLog::Log(LOGERROR, "{} - Saving of subtitle {} to {} failed", __FUNCTION__, strUrl,
                 strDownloadFile);
     }

--- a/xbmc/video/dialogs/GUIDialogTeletext.cpp
+++ b/xbmc/video/dialogs/GUIDialogTeletext.cpp
@@ -14,8 +14,9 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUITexture.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/Texture.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/ColorUtils.h"
@@ -60,7 +61,9 @@ bool CGUIDialogTeletext::OnMessage(CGUIMessage& message)
     if (!appPlayer->HasTeletextCache())
     {
       Close();
-      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(23049), "", 1500, false);
+      CGUIDialogKaiToast::QueueNotification(
+          CGUIDialogKaiToast::Info,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(23049), "", 1500, false);
       return true;
     }
   }

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -19,13 +19,14 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "imagefiles/ImageFileURL.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "pictures/Picture.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -250,13 +251,16 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
   {
     std::string bookmarkTime;
     if (m_bookmarks[i].type == CBookmark::EPISODE)
-      bookmarkTime = StringUtils::Format("{} {} {} {}", g_localizeStrings.Get(20373),
-                                         m_bookmarks[i].seasonNumber, g_localizeStrings.Get(20359),
-                                         m_bookmarks[i].episodeNumber);
+      bookmarkTime = StringUtils::Format(
+          "{} {} {} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20373),
+          m_bookmarks[i].seasonNumber,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20359),
+          m_bookmarks[i].episodeNumber);
     else
       bookmarkTime = StringUtils::SecondsToTimeString((long)m_bookmarks[i].timeInSeconds, TIME_FORMAT_HH_MM_SS);
 
-    CFileItemPtr item(new CFileItem(StringUtils::Format(g_localizeStrings.Get(299), i + 1)));
+    CFileItemPtr item(new CFileItem(StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(299), i + 1)));
     item->SetLabel2(bookmarkTime);
     item->SetArt("thumb", m_bookmarks[i].thumbNailImage);
     item->SetProperty("resumepoint", m_bookmarks[i].timeInSeconds);
@@ -280,7 +284,8 @@ void CGUIDialogVideoBookmarks::OnRefreshList()
     if (chapterName.empty() ||
         StringUtils::StartsWithNoCase(chapterName, time) ||
         StringUtils::IsNaturalNumber(chapterName))
-      chapterName = StringUtils::Format(g_localizeStrings.Get(25010), i);
+      chapterName = StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25010), i);
 
     CFileItemPtr item(new CFileItem(chapterName));
     item->SetLabel2(time);
@@ -544,9 +549,11 @@ bool CGUIDialogVideoBookmarks::AddEpisodeBookmark()
     CContextButtons choices;
     for (unsigned int i=0; i < episodes.size(); ++i)
     {
-      std::string strButton =
-          StringUtils::Format("{} {}, {} {}", g_localizeStrings.Get(20373), episodes[i].m_iSeason,
-                              g_localizeStrings.Get(20359), episodes[i].m_iEpisode);
+      std::string strButton = StringUtils::Format(
+          "{} {}, {} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20373),
+          episodes[i].m_iSeason,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20359),
+          episodes[i].m_iEpisode);
       choices.Add(i, strButton);
     }
 
@@ -570,9 +577,11 @@ bool CGUIDialogVideoBookmarks::OnAddBookmark()
   if (CGUIDialogVideoBookmarks::AddBookmark())
   {
     CServiceBroker::GetGUI()->GetWindowManager().SendMessage(GUI_MSG_REFRESH_LIST, 0, WINDOW_DIALOG_VIDEO_BOOKMARKS);
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
-                                          g_localizeStrings.Get(298),   // "Bookmarks"
-                                          g_localizeStrings.Get(21362));// "Bookmark created"
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Info,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(298), // "Bookmarks"
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            21362)); // "Bookmark created"
     return true;
   }
   return false;
@@ -594,10 +603,11 @@ bool CGUIDialogVideoBookmarks::OnAddEpisodeBookmark()
       if(bReturn)
       {
         CServiceBroker::GetGUI()->GetWindowManager().SendMessage(GUI_MSG_REFRESH_LIST, 0, WINDOW_DIALOG_VIDEO_BOOKMARKS);
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
-                                              g_localizeStrings.Get(298),   // "Bookmarks"
-                                              g_localizeStrings.Get(21363));// "Episode Bookmark created"
-
+        CGUIDialogKaiToast::QueueNotification(
+            CGUIDialogKaiToast::Info,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(298), // "Bookmarks"
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                21363)); // "Episode Bookmark created"
       }
     }
     videoDatabase.Close();

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -29,7 +29,6 @@
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindow.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "imagefiles/ImageFileURL.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
@@ -37,6 +36,8 @@
 #include "music/MusicDatabase.h"
 #include "music/dialogs/GUIDialogMusicInfo.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/SettingUtils.h"
@@ -373,7 +374,7 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
       if (!thumb.empty())
         item->SetArt("thumb", thumb);
       item->SetArt("icon", "DefaultArtist.png");
-      item->SetLabel2(g_localizeStrings.Get(29904));
+      item->SetLabel2(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(29904));
       m_castList->Add(item);
     }
     // get performers in the music video (added as actors)
@@ -490,7 +491,7 @@ void CGUIDialogVideoInfo::Update()
          (m_movieItem->GetVideoInfoTag()->m_type == MediaTypeEpisode &&
           !CSettingUtils::FindIntInList(
               setting, CSettings::VIDEOLIBRARY_PLOTS_SHOW_UNWATCHED_TVSHOWEPISODES))))
-      strTmp = g_localizeStrings.Get(20370);
+      strTmp = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20370);
 
   StringUtils::Trim(strTmp);
   SetLabel(CONTROL_TEXTAREA, strTmp);
@@ -597,7 +598,8 @@ void CGUIDialogVideoInfo::OnSearch(std::string& strSearch)
       {
         if (items[i]->HasVideoInfoTag() &&
           items[i]->GetVideoInfoTag()->GetPlayCount() > 0)
-          items[i]->SetLabel2(g_localizeStrings.Get(16102));
+          items[i]->SetLabel2(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16102));
 
         loader.LoadItem(items[i].get());
         pDlgSelect->Add(*items[i]);
@@ -634,7 +636,9 @@ void CGUIDialogVideoInfo::DoSearch(std::string& strSearch, CFileItemList& items)
       label += StringUtils::Format(" ({})", movies[i]->GetVideoInfoTag()->GetYear());
     movies[i]->SetLabel(label);
   }
-  CGUIWindowVideoBase::AppendAndClearSearchItems(movies, "[" + g_localizeStrings.Get(20338) + "] ", items);
+  CGUIWindowVideoBase::AppendAndClearSearchItems(
+      movies, "[" + CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20338) + "] ",
+      items);
 
   db.GetTvShowsByActor(strSearch, movies);
   for (int i = 0; i < movies.Size(); ++i)
@@ -644,7 +648,9 @@ void CGUIDialogVideoInfo::DoSearch(std::string& strSearch, CFileItemList& items)
       label += StringUtils::Format(" ({})", movies[i]->GetVideoInfoTag()->GetYear());
     movies[i]->SetLabel(label);
   }
-  CGUIWindowVideoBase::AppendAndClearSearchItems(movies, "[" + g_localizeStrings.Get(20364) + "] ", items);
+  CGUIWindowVideoBase::AppendAndClearSearchItems(
+      movies, "[" + CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20364) + "] ",
+      items);
 
   db.GetEpisodesByActor(strSearch, movies);
   for (int i = 0; i < movies.Size(); ++i)
@@ -652,7 +658,9 @@ void CGUIDialogVideoInfo::DoSearch(std::string& strSearch, CFileItemList& items)
     std::string label = movies[i]->GetVideoInfoTag()->m_strTitle + " (" +  movies[i]->GetVideoInfoTag()->m_strShowTitle + ")";
     movies[i]->SetLabel(label);
   }
-  CGUIWindowVideoBase::AppendAndClearSearchItems(movies, "[" + g_localizeStrings.Get(20359) + "] ", items);
+  CGUIWindowVideoBase::AppendAndClearSearchItems(
+      movies, "[" + CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20359) + "] ",
+      items);
 
   db.GetMusicVideosByArtist(strSearch, movies);
   for (int i = 0; i < movies.Size(); ++i)
@@ -662,7 +670,9 @@ void CGUIDialogVideoInfo::DoSearch(std::string& strSearch, CFileItemList& items)
       label += StringUtils::Format(" ({})", movies[i]->GetVideoInfoTag()->GetYear());
     movies[i]->SetLabel(label);
   }
-  CGUIWindowVideoBase::AppendAndClearSearchItems(movies, "[" + g_localizeStrings.Get(20391) + "] ", items);
+  CGUIWindowVideoBase::AppendAndClearSearchItems(
+      movies, "[" + CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20391) + "] ",
+      items);
   db.Close();
 
   // Search for music albums by artist with name matching search string
@@ -678,7 +688,9 @@ void CGUIDialogVideoInfo::DoSearch(std::string& strSearch, CFileItemList& items)
       movies[i]->GetVideoInfoTag()->m_type = MediaTypeAlbum;
     }
     CGUIWindowVideoBase::AppendAndClearSearchItems(
-        movies, "[" + g_localizeStrings.Get(36918) + "] ", items);
+        movies,
+        "[" + CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36918) + "] ",
+        items);
   }
   music_database.Close();
 }
@@ -928,7 +940,10 @@ bool CArtTypeChooser::ChooseArtType()
         item->SetArt("thumb", m_item->GetArt(type));
 
       const auto it = name2idMap.find(type);
-      item->SetLabel(it == name2idMap.cend() ? type : g_localizeStrings.Get((*it).second));
+      item->SetLabel(
+          it == name2idMap.cend()
+              ? type
+              : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get((*it).second));
 
       m_items.Add(item);
     }
@@ -943,8 +958,10 @@ bool CArtTypeChooser::ChooseArtType()
   {
     // "Add art type" button pressed. Get the new artwork name.
     std::string artworkName;
-    if (!CGUIKeyboardFactory::ShowAndGetInput(artworkName, CVariant{g_localizeStrings.Get(13516)},
-                                              false))
+    if (!CGUIKeyboardFactory::ShowAndGetInput(
+            artworkName,
+            CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13516)},
+            false))
       return false;
 
     m_artType = artworkName;
@@ -987,9 +1004,10 @@ void CGUIDialogVideoInfo::OnSetUserrating() const
   if (dialog)
   {
     dialog->SetHeading(CVariant{ 38023 });
-    dialog->Add(g_localizeStrings.Get(38022));
+    dialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38022));
     for (int i = 1; i <= 10; i++)
-      dialog->Add(StringUtils::Format("{}: {}", g_localizeStrings.Get(563), i));
+      dialog->Add(StringUtils::Format(
+          "{}: {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(563), i));
 
     dialog->SetSelected(m_movieItem->GetVideoInfoTag()->m_iUserRating);
 
@@ -1095,10 +1113,15 @@ int CGUIDialogVideoInfo::ManageVideoItem(const std::shared_ptr<CFileItem>& item)
     {
       const std::string &mediaType = videoUrl.GetItemType();
 
+      buttons.Add(CONTEXT_BUTTON_TAGS_ADD_ITEMS,
+                  StringUtils::Format(
+                      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20460),
+                      GetLocalizedVideoType(mediaType)));
       buttons.Add(
-          CONTEXT_BUTTON_TAGS_ADD_ITEMS,
-          StringUtils::Format(g_localizeStrings.Get(20460), GetLocalizedVideoType(mediaType)));
-      buttons.Add(CONTEXT_BUTTON_TAGS_REMOVE_ITEMS, StringUtils::Format(g_localizeStrings.Get(20461).c_str(), GetLocalizedVideoType(mediaType).c_str()));
+          CONTEXT_BUTTON_TAGS_REMOVE_ITEMS,
+          StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20461).c_str(),
+              GetLocalizedVideoType(mediaType).c_str()));
     }
   }
 
@@ -1245,7 +1268,9 @@ bool CGUIDialogVideoInfo::UpdateVideoItemTitle(const std::shared_ptr<CFileItem>&
   }
 
   // get the new title
-  if (!CGUIKeyboardFactory::ShowAndGetInput(title, CVariant{ g_localizeStrings.Get(16105) }, false))
+  if (!CGUIKeyboardFactory::ShowAndGetInput(
+          title, CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16105)},
+          false))
     return false;
 
   if (mediaType == MediaTypeSeason)
@@ -1334,14 +1359,17 @@ bool CGUIDialogVideoInfo::DeleteVideoItemFromDatabase(const std::shared_ptr<CFil
 
   if (unavailable)
   {
-    pDialog->SetLine(0, CVariant{g_localizeStrings.Get(662)});
-    pDialog->SetLine(1, CVariant{g_localizeStrings.Get(663)});
+    pDialog->SetLine(
+        0, CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(662)});
+    pDialog->SetLine(
+        1, CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(663)});
   }
   else
   {
-    pDialog->SetLine(
-        0, CVariant{StringUtils::Format(
-               g_localizeStrings.Get(item->HasVideoVersions() ? 40021 : 433), item->GetLabel())});
+    pDialog->SetLine(0, CVariant{StringUtils::Format(
+                            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                item->HasVideoVersions() ? 40021 : 433),
+                            item->GetLabel())});
     pDialog->SetLine(1, CVariant{""});
   }
   pDialog->SetLine(2, CVariant{""});
@@ -1499,7 +1527,8 @@ bool CGUIDialogVideoInfo::GetMoviesForSet(const CFileItem *setItem, CFileItemLis
 
   dialog->Reset();
   dialog->SetMultiSelection(true);
-  dialog->SetHeading(CVariant{g_localizeStrings.Get(20457)});
+  dialog->SetHeading(
+      CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20457)});
   dialog->SetItems(listItems);
   std::vector<int> selectedIndices;
   for (int i = 0; i < originalMovies.Size(); i++)
@@ -1570,12 +1599,14 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem* movieItem,
       }
     }
     // add clear item
-    std::string strClear = StringUtils::Format(g_localizeStrings.Get(20467), currentSetLabel);
+    std::string strClear = StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20467), currentSetLabel);
     CFileItemPtr clearItem(new CFileItem(strClear));
     clearItem->GetVideoInfoTag()->m_iDbId = -1; // -1 will be used to clear set
     listItems.AddFront(clearItem, 0);
     // add keep current set item
-    std::string strKeep = StringUtils::Format(g_localizeStrings.Get(20469), currentSetLabel);
+    std::string strKeep = StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20469), currentSetLabel);
     CFileItemPtr keepItem(new CFileItem(strKeep));
     keepItem->GetVideoInfoTag()->m_iDbId = currentSetId;
     listItems.AddFront(keepItem, 1);
@@ -1586,7 +1617,8 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem* movieItem,
     return false;
 
   dialog->Reset();
-  dialog->SetHeading(CVariant{g_localizeStrings.Get(20466)});
+  dialog->SetHeading(
+      CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20466)});
   dialog->SetItems(listItems);
   if (currentSetId >= 0)
   {
@@ -1605,7 +1637,10 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem* movieItem,
   if (dialog->IsButtonPressed())
   { // creating new set
     std::string newSetTitle;
-    if (!CGUIKeyboardFactory::ShowAndGetInput(newSetTitle, CVariant{g_localizeStrings.Get(20468)}, false))
+    if (!CGUIKeyboardFactory::ShowAndGetInput(
+            newSetTitle,
+            CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20468)},
+            false))
       return false;
     int idSet = videodb.AddSet(newSetTitle);
     KODI::ART::Artwork movieArt;
@@ -1725,7 +1760,8 @@ bool CGUIDialogVideoInfo::AddItemsToTag(const std::shared_ptr<CFileItem>& tagIte
 
   CFileItemList items;
   std::string localizedType = GetLocalizedVideoType(mediaType);
-  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20464), localizedType);
+  std::string strLabel = StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20464), localizedType);
   if (!GetItemsForTag(strLabel, mediaType, items, tagItem->GetVideoInfoTag()->m_iDbId))
     return true;
 
@@ -1758,7 +1794,8 @@ bool CGUIDialogVideoInfo::RemoveItemsFromTag(const std::shared_ptr<CFileItem>& t
 
   CFileItemList items;
   std::string localizedType = GetLocalizedVideoType(mediaType);
-  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20464), localizedType);
+  std::string strLabel = StringUtils::Format(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20464), localizedType);
   if (!GetItemsForTag(strLabel, mediaType, items, tagItem->GetVideoInfoTag()->m_iDbId, false))
     return true;
 
@@ -1861,7 +1898,7 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem
   {
     const auto itemCurrent = std::make_shared<CFileItem>("thumb://Current", false);
     itemCurrent->SetArt("thumb", currentArt);
-    itemCurrent->SetLabel(g_localizeStrings.Get(13512));
+    itemCurrent->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13512));
     items.Add(itemCurrent);
   }
 
@@ -1870,7 +1907,7 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem
   {
     const auto itemEmbedded = std::make_shared<CFileItem>("thumb://Embedded", false);
     itemEmbedded->SetArt("thumb", embeddedArt);
-    itemEmbedded->SetLabel(g_localizeStrings.Get(13519));
+    itemEmbedded->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13519));
     items.Add(itemEmbedded);
   }
 
@@ -1881,7 +1918,7 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem
         std::make_shared<CFileItem>(StringUtils::Format("thumb://Remote{0}", i), false);
     itemRemote->SetArt("thumb", remoteArt[i]);
     itemRemote->SetArt("icon", "DefaultPicture.png");
-    itemRemote->SetLabel(g_localizeStrings.Get(13513));
+    itemRemote->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13513));
     items.Add(itemRemote);
 
     //! @todo Do we need to clear the cached image?
@@ -1892,13 +1929,13 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem
   if (!localArt.empty())
   {
     const auto itemLocal = std::make_shared<CFileItem>("thumb://Local", false);
-    itemLocal->SetLabel(g_localizeStrings.Get(13514));
+    itemLocal->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13514));
     itemLocal->SetArt("thumb", localArt);
     items.Add(itemLocal);
   }
 
   const auto itemNone = std::make_shared<CFileItem>("thumb://None", false);
-  itemNone->SetLabel(g_localizeStrings.Get(13515));
+  itemNone->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13515));
   itemNone->SetArt("icon", artHandler->GetDefaultIcon());
   items.Add(itemNone);
 
@@ -1909,8 +1946,9 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem
 
   bool flip = false;
   if (!CGUIDialogFileBrowser::ShowAndGetImage(
-          items, sources, g_localizeStrings.Get(13511) /* Choose art */, result,
-          artHandler->SupportsFlippedArt() ? &flip : nullptr, 39123 /* Artwork */))
+          items, sources,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13511) /* Choose art */,
+          result, artHandler->SupportsFlippedArt() ? &flip : nullptr, 39123 /* Artwork */))
     return false; // user cancelled
 
   if (result == "thumb://Current")
@@ -1964,13 +2002,13 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem
 std::string CGUIDialogVideoInfo::GetLocalizedVideoType(const std::string &strType)
 {
   if (CMediaTypes::IsMediaType(strType, MediaTypeMovie))
-    return g_localizeStrings.Get(20342);
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20342);
   else if (CMediaTypes::IsMediaType(strType, MediaTypeTvShow))
-    return g_localizeStrings.Get(20343);
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20343);
   else if (CMediaTypes::IsMediaType(strType, MediaTypeEpisode))
-    return g_localizeStrings.Get(20359);
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20359);
   else if (CMediaTypes::IsMediaType(strType, MediaTypeMusicVideo))
-    return g_localizeStrings.Get(20391);
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20391);
 
   return "";
 }
@@ -2004,7 +2042,9 @@ bool CGUIDialogVideoInfo::UpdateVideoItemSortTitle(const std::shared_ptr<CFileIt
     currentTitle = detail.m_strSortTitle;
 
   // get the new sort title
-  if (!CGUIKeyboardFactory::ShowAndGetInput(currentTitle, CVariant{g_localizeStrings.Get(16107)}, false))
+  if (!CGUIKeyboardFactory::ShowAndGetInput(
+          currentTitle,
+          CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16107)}, false))
     return false;
 
   return database.UpdateVideoSortTitle(iDbId, currentTitle, iType);

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -20,9 +20,10 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -117,9 +118,11 @@ void CGUIDialogVideoManager::OnInitWindow()
 
   CGUIDialog::OnInitWindow();
 
-  SET_CONTROL_LABEL(CONTROL_LABEL_TITLE,
-                    StringUtils::Format(g_localizeStrings.Get(GetHeadingId()),
-                                        m_videoAsset->GetVideoInfoTag()->GetTitle()));
+  SET_CONTROL_LABEL(
+      CONTROL_LABEL_TITLE,
+      StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(GetHeadingId()),
+          m_videoAsset->GetVideoInfoTag()->GetTitle()));
 
   CGUIMessage msg{GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST_ASSETS, 0, 0, m_videoAssetsList.get()};
   OnMessage(msg);
@@ -287,8 +290,9 @@ void CGUIDialogVideoManager::Remove()
   // confirm the removal
   if (!CGUIDialogYesNo::ShowAndGetInput(
           titleMsgId,
-          StringUtils::Format(g_localizeStrings.Get(textMsgId),
-                              m_selectedVideoAsset->GetVideoInfoTag()->GetAssetInfo().GetTitle())))
+          StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(textMsgId),
+              m_selectedVideoAsset->GetVideoInfoTag()->GetAssetInfo().GetTitle())))
   {
     return;
   }
@@ -410,8 +414,11 @@ int CGUIDialogVideoManager::ChooseVideoAsset(const std::shared_ptr<CFileItem>& i
     {
       // create a new asset
       assetTitle = defaultName;
-      if (CGUIKeyboardFactory::ShowAndGetInput(assetTitle,
-                                               g_localizeStrings.Get(dialogNewHeadingMsgId), false))
+      if (CGUIKeyboardFactory::ShowAndGetInput(
+              assetTitle,
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                  dialogNewHeadingMsgId),
+              false))
       {
         assetTitle = StringUtils::Trim(assetTitle);
         //! @todo db refactor: should not be version, but asset
@@ -440,8 +447,10 @@ int CGUIDialogVideoManager::ChooseVideoAsset(const std::shared_ptr<CFileItem>& i
     if (std::ranges::any_of(assets, [assetId](const std::shared_ptr<CFileItem>& asset)
                             { return asset->GetVideoInfoTag()->m_iDbId == assetId; }))
     {
-      CGUIDialogOK::ShowAndGetInput(CVariant{40005},
-                                    StringUtils::Format(g_localizeStrings.Get(40007), assetTitle));
+      CGUIDialogOK::ShowAndGetInput(
+          CVariant{40005},
+          StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40007), assetTitle));
     }
     else
       break;
@@ -457,7 +466,8 @@ void CGUIDialogVideoManager::AppendItemFolderToFileBrowserSources(
   if (!itemDir.empty() && XFILE::CDirectory::Exists(itemDir))
   {
     CMediaSource itemSource{};
-    itemSource.strName = g_localizeStrings.Get(36041); // * Item folder
+    itemSource.strName =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36041); // * Item folder
     itemSource.strPath = itemDir;
     sources.emplace_back(itemSource);
   }

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -19,7 +19,8 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -119,7 +120,7 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
   std::string path;
   if (CGUIDialogFileBrowser::ShowAndGetFile(
           sources, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(),
-          g_localizeStrings.Get(40015), path))
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40015), path))
   {
     const int dbId{m_videoAsset->GetVideoInfoTag()->m_iDbId};
     const VideoDbContentType itemType = m_videoAsset->GetVideoContentType();
@@ -149,7 +150,9 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
 
         CGUIDialogOK::ShowAndGetInput(
             CVariant{40015},
-            StringUtils::Format(g_localizeStrings.Get(msgid), newAsset.m_assetTypeName));
+            StringUtils::Format(
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(msgid),
+                newAsset.m_assetTypeName));
         return false;
       }
 
@@ -157,8 +160,10 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
 
       // The video is a version, ask for confirmation of the asset type change
       if (newAsset.m_assetType == VideoAssetType::VERSION &&
-          !CGUIDialogYesNo::ShowAndGetInput(CVariant{40015},
-                                            StringUtils::Format(g_localizeStrings.Get(40036))))
+          !CGUIDialogYesNo::ShowAndGetInput(
+              CVariant{40015},
+              StringUtils::Format(
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40036))))
       {
         return false;
       }
@@ -186,8 +191,10 @@ bool CGUIDialogVideoManagerExtras::AddVideoExtra()
         }
 
         if (!CGUIDialogYesNo::ShowAndGetInput(
-                CVariant{40015}, StringUtils::Format(g_localizeStrings.Get(msgid),
-                                                     newAsset.m_assetTypeName, videoTitle)))
+                CVariant{40015},
+                StringUtils::Format(
+                    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(msgid),
+                    newAsset.m_assetTypeName, videoTitle)))
         {
           return false;
         }

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -22,7 +22,8 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -593,8 +594,10 @@ bool CGUIDialogVideoManagerVersions::ProcessVideoVersion(VideoDbContentType item
   videodb.GetFilePathById(dbId, path, itemType);
 
   if (!CGUIDialogYesNo::ShowAndGetInput(
-          CVariant{40008}, StringUtils::Format(g_localizeStrings.Get(40009),
-                                               item.GetVideoInfoTag()->GetTitle(), path)))
+          CVariant{40008},
+          StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40009),
+              item.GetVideoInfoTag()->GetTitle(), path)))
   {
     return false;
   }
@@ -622,7 +625,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
   std::string path;
   if (CGUIDialogFileBrowser::ShowAndGetFile(
           sources, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(),
-          g_localizeStrings.Get(40014), path))
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40014), path))
   {
     const int dbId{m_videoAsset->GetVideoInfoTag()->m_iDbId};
     const VideoDbContentType itemType{m_videoAsset->GetVideoContentType()};
@@ -650,7 +653,9 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
 
         CGUIDialogOK::ShowAndGetInput(
             CVariant{40014},
-            StringUtils::Format(g_localizeStrings.Get(msgid), newAsset.m_assetTypeName));
+            StringUtils::Format(
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(msgid),
+                newAsset.m_assetTypeName));
         return false;
       }
 
@@ -658,8 +663,10 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
 
       // The video is an extra, ask for confirmation of the asset type change
       if (newAsset.m_assetType == VideoAssetType::EXTRA &&
-          !CGUIDialogYesNo::ShowAndGetInput(CVariant{40014},
-                                            StringUtils::Format(g_localizeStrings.Get(40035))))
+          !CGUIDialogYesNo::ShowAndGetInput(
+              CVariant{40014},
+              StringUtils::Format(
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40035))))
       {
         return false;
       }
@@ -687,8 +694,10 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
         }
 
         if (!CGUIDialogYesNo::ShowAndGetInput(
-                CVariant{40014}, StringUtils::Format(g_localizeStrings.Get(msgid),
-                                                     newAsset.m_assetTypeName, videoTitle)))
+                CVariant{40014},
+                StringUtils::Format(
+                    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(msgid),
+                    newAsset.m_assetTypeName, videoTitle)))
         {
           return false;
         }

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -16,8 +16,9 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -532,7 +533,7 @@ void CGUIDialogVideoSettings::VideoStreamsOptionFiller(
 
   if (list.empty())
   {
-    list.emplace_back(g_localizeStrings.Get(231), -1);
+    list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231), -1);
     current = -1;
   }
 }
@@ -542,23 +543,27 @@ void CGUIDialogVideoSettings::VideoOrientationFiller(
     std::vector<IntegerSettingOption>& list,
     int& /*current*/)
 {
-  list.emplace_back(g_localizeStrings.Get(687), 0);
-  list.emplace_back(g_localizeStrings.Get(35229), 90);
-  list.emplace_back(g_localizeStrings.Get(35230), 180);
-  list.emplace_back(g_localizeStrings.Get(35231), 270);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(687), 0);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35229), 90);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35230), 180);
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(35231), 270);
 }
 
 std::string CGUIDialogVideoSettings::FormatFlags(StreamFlags flags)
 {
   std::vector<std::string> localizedFlags;
   if (flags & StreamFlags::FLAG_DEFAULT)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39105));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39105));
   if (flags & StreamFlags::FLAG_FORCED)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39106));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39106));
   if (flags & StreamFlags::FLAG_HEARING_IMPAIRED)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39107));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39107));
   if (flags &  StreamFlags::FLAG_VISUAL_IMPAIRED)
-    localizedFlags.emplace_back(g_localizeStrings.Get(39108));
+    localizedFlags.emplace_back(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39108));
 
   std::string formated = StringUtils::Join(localizedFlags, ", ");
 

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -23,12 +23,13 @@
 #include "filesystem/VideoDatabaseDirectory/DirectoryNode.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "music/MusicFileItemClassify.h"
 #include "network/NetworkFileItemClassify.h"
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFileItemClassify.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -661,7 +662,7 @@ std::string GetResumeString(int64_t startOffset, unsigned int partNumber)
   if (startOffset > 0)
   {
     resumeString =
-        StringUtils::Format(g_localizeStrings.Get(12022),
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12022),
                             StringUtils::SecondsToTimeString(
                                 static_cast<long>(CUtil::ConvertMilliSecsToSecsInt(startOffset)),
                                 TIME_FORMAT_HH_MM_SS)); // Resume from ##:##:##
@@ -669,14 +670,17 @@ std::string GetResumeString(int64_t startOffset, unsigned int partNumber)
   else
   {
     if (partNumber > 0)
-      resumeString = g_localizeStrings.Get(12023); // Resume from
+      resumeString =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12023); // Resume from
     else
-      resumeString = g_localizeStrings.Get(13362); // Continue watching
+      resumeString = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+          13362); // Continue watching
   }
   if (partNumber > 0)
   {
     const std::string partString{
-        StringUtils::Format(g_localizeStrings.Get(23051), partNumber)}; // Part #
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(23051),
+                            partNumber)}; // Part #
     resumeString += startOffset > 0 ? " (" + partString + ")" : " " + partString;
   }
   return resumeString;

--- a/xbmc/video/guilib/VideoPlayActionProcessor.cpp
+++ b/xbmc/video/guilib/VideoPlayActionProcessor.cpp
@@ -17,8 +17,9 @@
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "playlists/PlayListTypes.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/PlayerUtils.h"
@@ -159,7 +160,8 @@ unsigned int CVideoPlayActionProcessor::ChooseStackPart() const
 
   for (int i = 0; i < parts.Size(); ++i)
   {
-    parts[i]->SetLabel(StringUtils::Format(g_localizeStrings.Get(23051), i + 1)); // Part #
+    parts[i]->SetLabel(StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(23051), i + 1)); // Part #
   }
 
   CGUIDialogSelect* dialog{CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(

--- a/xbmc/video/guilib/VideoStreamSelectHelper.cpp
+++ b/xbmc/video/guilib/VideoStreamSelectHelper.cpp
@@ -16,7 +16,8 @@
 #include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/StreamDetails.h"
 #include "utils/StreamUtils.h"
@@ -31,7 +32,8 @@ constexpr int STREAM_ID_NONE = -1; // Stream id referred to item for "none" stre
 // \brief Make a FileItem entry with "Disable" label, allow to disable a stream
 const std::shared_ptr<CFileItem> MakeFileItemDisable(bool isSelected)
 {
-  const auto fileItem{std::make_shared<CFileItem>(g_localizeStrings.Get(24021))};
+  const auto fileItem{std::make_shared<CFileItem>(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(24021))};
   fileItem->Select(isSelected);
   fileItem->SetProperty("stream.id", STREAM_ID_DISABLE);
   return fileItem;
@@ -40,7 +42,8 @@ const std::shared_ptr<CFileItem> MakeFileItemDisable(bool isSelected)
 // \brief Make a FileItem entry with "None" label, signal an empty list
 const std::shared_ptr<CFileItem> MakeFileItemNone()
 {
-  const auto fileItem{std::make_shared<CFileItem>(g_localizeStrings.Get(231))};
+  const auto fileItem{std::make_shared<CFileItem>(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231))};
   fileItem->SetProperty("stream.id", STREAM_ID_NONE);
   return fileItem;
 }
@@ -111,7 +114,8 @@ struct AudioStreamInfoExt : AudioStreamInfo
     streamId = id;
 
     if (!g_LangCodeExpander.Lookup(info.language, languageDesc))
-      languageDesc = g_localizeStrings.Get(13205); // Unknown
+      languageDesc =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
 
     isDefault = info.flags & StreamFlags::FLAG_DEFAULT;
     isForced = info.flags & StreamFlags::FLAG_FORCED;
@@ -136,7 +140,8 @@ struct SubtitleStreamInfoExt : SubtitleStreamInfo
     streamId = id;
 
     if (!g_LangCodeExpander.Lookup(info.language, languageDesc))
-      languageDesc = g_localizeStrings.Get(13205); // Unknown
+      languageDesc =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
 
     isDefault = info.flags & StreamFlags::FLAG_DEFAULT;
     isForced = info.flags & StreamFlags::FLAG_FORCED;

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -22,9 +22,10 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "media/MediaType.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Artwork.h"
@@ -279,7 +280,8 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
     // if we don't have an url or need to refresh anyway do the web search
     if (!hasDetails && (needsRefresh || !scraperUrl.HasUrls()))
     {
-      SetTitle(StringUtils::Format(g_localizeStrings.Get(197), scraper->Name()));
+      SetTitle(StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(197), scraper->Name()));
       SetText(itemTitle);
       SetProgress(0);
 
@@ -341,7 +343,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
               // ask the user to input a title to use
               if (!CGUIKeyboardFactory::ShowAndGetInput(
                       itemTitle,
-                      g_localizeStrings.Get(
+                      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
                           scraper->Content() == ADDON::ContentType::TVSHOWS ? 20357 : 16009),
                       false))
                 return false;
@@ -375,8 +377,8 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
         // ask the user to input a title to use
         if (!CGUIKeyboardFactory::ShowAndGetInput(
                 itemTitle,
-                g_localizeStrings.Get(scraper->Content() == ADDON::ContentType::TVSHOWS ? 20357
-                                                                                        : 16009),
+                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                    scraper->Content() == ADDON::ContentType::TVSHOWS ? 20357 : 16009),
                 false))
           return false;
 
@@ -444,7 +446,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
       headingLabel = 20394;
 
     // prepare the progress dialog for downloading all the necessary information
-    SetTitle(g_localizeStrings.Get(headingLabel));
+    SetTitle(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(headingLabel));
     SetText(itemTitle);
     SetProgress(0);
 

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -18,10 +18,11 @@
 #include "cores/IPlayer.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "input/mouse/MouseEvent.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
@@ -298,10 +299,12 @@ void CGUIWindowFullScreen::FrameMove()
 
     {
       // get the "View Mode" string
-      const std::string& strTitle = g_localizeStrings.Get(629);
+      const std::string& strTitle =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(629);
       const auto& vs = appPlayer->GetVideoSettings();
       int sId = CViewModeSettings::GetViewModeStringIndex(vs.m_ViewMode);
-      const std::string& strMode = g_localizeStrings.Get(sId);
+      const std::string& strMode =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(sId);
       std::string strInfo = StringUtils::Format("{} : {}", strTitle, strMode);
       CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW1);
       msg.SetLabel(strInfo);
@@ -316,7 +319,8 @@ void CGUIWindowFullScreen::FrameMove()
       float yscale = (float)res.iScreenHeight / (float)res.iHeight;
 
       std::string strSizing = StringUtils::Format(
-          g_localizeStrings.Get(245), (int)info.SrcRect.Width(), (int)info.SrcRect.Height(),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(245),
+          (int)info.SrcRect.Width(), (int)info.SrcRect.Height(),
           (int)(info.DestRect.Width() * xscale), (int)(info.DestRect.Height() * yscale),
           CDisplaySettings::GetInstance().GetZoomAmount(),
           info.videoAspectRatio * CDisplaySettings::GetInstance().GetPixelRatio(),
@@ -330,13 +334,17 @@ void CGUIWindowFullScreen::FrameMove()
     {
       std::string strStatus;
       if (CServiceBroker::GetWinSystem()->IsFullScreen())
-        strStatus = StringUtils::Format("{} {}x{}@{:.2f}Hz - {}", g_localizeStrings.Get(13287),
-                                        res.iScreenWidth, res.iScreenHeight, res.fRefreshRate,
-                                        g_localizeStrings.Get(244));
+        strStatus = StringUtils::Format(
+            "{} {}x{}@{:.2f}Hz - {}",
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13287),
+            res.iScreenWidth, res.iScreenHeight, res.fRefreshRate,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(244));
       else
-        strStatus =
-            StringUtils::Format("{} {}x{} - {}", g_localizeStrings.Get(13287), res.iScreenWidth,
-                                res.iScreenHeight, g_localizeStrings.Get(242));
+        strStatus = StringUtils::Format(
+            "{} {}x{} - {}",
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13287),
+            res.iScreenWidth, res.iScreenHeight,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(242));
 
       CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), LABEL_ROW3);
       msg.SetLabel(strStatus);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -34,7 +34,6 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/helpers/DialogOKHelper.h"
@@ -44,6 +43,8 @@
 #include "playlists/PlayListFactory.h"
 #include "playlists/PlayListFileItemClassify.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -1131,19 +1132,20 @@ bool CGUIWindowVideoBase::GetDirectory(const std::string &strDirectory, CFileIte
     const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
     CFileItemPtr newPlaylist(new CFileItem(profileManager->GetUserDataItem("PartyMode-Video.xsp"),false));
-    newPlaylist->SetLabel(g_localizeStrings.Get(16035));
+    newPlaylist->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16035));
     newPlaylist->SetLabelPreformatted(true);
     newPlaylist->SetArt("icon", "DefaultPartyMode.png");
     newPlaylist->SetFolder(true);
     items.Add(newPlaylist);
 
-/*    newPlaylist.reset(new CFileItem("newplaylist://", false));
-    newPlaylist->SetLabel(g_localizeStrings.Get(525));
+    /*    newPlaylist.reset(new CFileItem("newplaylist://", false));
+    newPlaylist->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(525));
     newPlaylist->SetLabelPreformatted(true);
     items.Add(newPlaylist);
 */
     newPlaylist = std::make_shared<CFileItem>("newsmartplaylist://video", false);
-    newPlaylist->SetLabel(g_localizeStrings.Get(21437));  // "new smart playlist..."
+    newPlaylist->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+        21437)); // "new smart playlist..."
     newPlaylist->SetArt("icon", "DefaultAddSource.png");
     newPlaylist->SetLabelPreformatted(true);
     items.Add(newPlaylist);
@@ -1234,7 +1236,9 @@ bool CGUIWindowVideoBase::CanContainFilter(const std::string &strDirectory) cons
 void CGUIWindowVideoBase::OnSearch()
 {
   std::string strSearch;
-  if (!CGUIKeyboardFactory::ShowAndGetInput(strSearch, CVariant{g_localizeStrings.Get(16017)}, false))
+  if (!CGUIKeyboardFactory::ShowAndGetInput(
+          strSearch,
+          CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16017)}, false))
     return ;
 
   StringUtils::ToLower(strSearch);

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -24,7 +24,6 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
@@ -32,6 +31,8 @@
 #include "music/MusicDatabase.h"
 #include "playlists/PlayListFileItemClassify.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
@@ -526,7 +527,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
       if (items.GetContent() == "tags" && !items.Contains("newtag://" + videoUrl.GetType()))
       {
         const auto newTag{std::make_shared<CFileItem>("newtag://" + videoUrl.GetType(), false)};
-        newTag->SetLabel(g_localizeStrings.Get(20462));
+        newTag->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20462));
         newTag->SetLabelPreformatted(true);
         newTag->SetSpecialSort(SortSpecialOnTop);
         items.Add(newTag);
@@ -557,7 +558,8 @@ void CGUIWindowVideoNav::UpdateButtons()
       StringUtils::StartsWith(m_vecItems->Get(m_vecItems->Size()-1)->GetPath(), "/-1/"))
       iItems--;
   }
-  std::string items = StringUtils::Format("{} {}", iItems, g_localizeStrings.Get(127));
+  std::string items = StringUtils::Format(
+      "{} {}", iItems, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(127));
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   // set the filter label
@@ -565,7 +567,7 @@ void CGUIWindowVideoNav::UpdateButtons()
 
   // "Playlists"
   if (m_vecItems->IsPath("special://videoplaylists/"))
-    strLabel = g_localizeStrings.Get(136);
+    strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(136);
   // "{Playlist Name}"
   else if (PLAYLIST::IsPlayList(*m_vecItems))
   {
@@ -574,7 +576,7 @@ void CGUIWindowVideoNav::UpdateButtons()
     URIUtils::Split(m_vecItems->GetPath(), strDummy, strLabel);
   }
   else if (m_vecItems->IsPath("sources://video/"))
-    strLabel = g_localizeStrings.Get(744);
+    strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(744);
   // everything else is from a videodb:// path
   else if (VIDEO::IsVideoDb(*m_vecItems))
   {
@@ -587,7 +589,9 @@ void CGUIWindowVideoNav::UpdateButtons()
   SET_CONTROL_LABEL(CONTROL_FILTER, strLabel);
 
   int watchMode = CMediaSettings::GetInstance().GetWatchedMode(m_vecItems->GetContent());
-  SET_CONTROL_LABEL(CONTROL_BTNSHOWMODE, g_localizeStrings.Get(16100 + watchMode));
+  SET_CONTROL_LABEL(
+      CONTROL_BTNSHOWMODE,
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16100 + watchMode));
 
   SET_CONTROL_SELECTED(GetID(), CONTROL_BTNSHOWALL, watchMode != WatchedModeAll);
 
@@ -686,11 +690,14 @@ void CGUIWindowVideoNav::DoSearch(const std::string& strSearch, CFileItemList& i
     std::string msg;
     if (entry.prefix > 0)
     {
-      msg = fmt::format("[{} - {}] ", g_localizeStrings.Get(entry.prefix),
-                        g_localizeStrings.Get(entry.id));
+      msg = fmt::format(
+          "[{} - {}] ",
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(entry.prefix),
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(entry.id));
     }
     else
-      msg = fmt::format("[{}] ", g_localizeStrings.Get(entry.id));
+      msg = fmt::format("[{}] ",
+                        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(entry.id));
 
     this->AppendAndClearSearchItems(tempItems, msg, items);
   });
@@ -716,8 +723,10 @@ void CGUIWindowVideoNav::OnDeleteItem(const CFileItemPtr& pItem)
       return;
 
     pDialog->SetHeading(CVariant{432});
-    std::string strLabel = StringUtils::Format(
-        g_localizeStrings.Get(pItem->HasVideoVersions() ? 40021 : 433), pItem->GetLabel());
+    std::string strLabel =
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                pItem->HasVideoVersions() ? 40021 : 433),
+                            pItem->GetLabel());
     pDialog->SetLine(1, CVariant{std::move(strLabel)});
     pDialog->SetLine(2, CVariant{""});
     pDialog->Open();
@@ -993,7 +1002,10 @@ bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
 
     //Get the new title
     std::string strTag;
-    if (!CGUIKeyboardFactory::ShowAndGetInput(strTag, CVariant{g_localizeStrings.Get(20462)}, false))
+    if (!CGUIKeyboardFactory::ShowAndGetInput(
+            strTag,
+            CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20462)},
+            false))
       return true;
 
     CVideoDatabase videodb;
@@ -1009,14 +1021,16 @@ bool CGUIWindowVideoNav::OnClick(int iItem, const std::string &player)
 
     if (!videodb.GetSingleValue("tag", "tag.tag_id", videodb.PrepareSQL("tag.name = '%s' AND tag.tag_id IN (SELECT tag_link.tag_id FROM tag_link WHERE tag_link.media_type = '%s')", strTag.c_str(), mediaType.c_str())).empty())
     {
-      std::string strError = StringUtils::Format(g_localizeStrings.Get(20463), strTag);
+      std::string strError = StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20463), strTag);
       HELPERS::ShowOKDialogText(CVariant{20462}, CVariant{std::move(strError)});
       return true;
     }
 
     int idTag = videodb.AddTag(strTag);
     CFileItemList items;
-    std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20464), localizedType);
+    std::string strLabel = StringUtils::Format(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20464), localizedType);
     if (CGUIDialogVideoInfo::GetItemsForTag(strLabel, mediaType, items, idTag))
     {
       for (int index = 0; index < items.Size(); index++)

--- a/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
+++ b/xbmc/video/windows/GUIWindowVideoPlaylist.cpp
@@ -20,10 +20,11 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "playlists/PlayListM3U.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
@@ -371,7 +372,9 @@ void CGUIWindowVideoPlaylist::UpdateButtons()
   else
     iLocalizedString = 597; // Repeat: All
 
-  SET_CONTROL_LABEL(CONTROL_BTNREPEAT, g_localizeStrings.Get(iLocalizedString));
+  SET_CONTROL_LABEL(
+      CONTROL_BTNREPEAT,
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(iLocalizedString));
 
   MarkPlaying();
 }
@@ -467,8 +470,9 @@ void CGUIWindowVideoPlaylist::RemovePlayListItem(int iItem)
 void CGUIWindowVideoPlaylist::SavePlayList()
 {
   std::string strNewFileName;
-  if (CGUIKeyboardFactory::ShowAndGetInput(strNewFileName, CVariant{g_localizeStrings.Get(16012)},
-                                           false))
+  if (CGUIKeyboardFactory::ShowAndGetInput(
+          strNewFileName,
+          CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16012)}, false))
   {
     // need 2 rename it
     strNewFileName = CUtil::MakeLegalFileName(std::move(strNewFileName));

--- a/xbmc/video/windows/VideoFileItemListModifier.cpp
+++ b/xbmc/video/windows/VideoFileItemListModifier.cpp
@@ -12,7 +12,8 @@
 #include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "filesystem/VideoDatabaseDirectory/DirectoryNode.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -69,7 +70,8 @@ void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
   {
     case NodeType::SEASONS:
     {
-      const std::string& strLabel = g_localizeStrings.Get(20366);
+      const std::string& strLabel =
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20366);
       pItem = std::make_shared<CFileItem>(strLabel); // "All Seasons"
       videoUrl.AppendPath("-1/");
       pItem->SetPath(videoUrl.ToString());
@@ -127,7 +129,9 @@ void CVideoFileItemListModifier::AddQueuingFolder(CFileItemList& items)
   }
   break;
   case NodeType::MUSICVIDEOS_ALBUM:
-    pItem = std::make_shared<CFileItem>("* " + g_localizeStrings.Get(16100)); // "* All Videos"
+    pItem = std::make_shared<CFileItem>(
+        "* " +
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16100)); // "* All Videos"
     videoUrl.AppendPath("-1/");
     pItem->SetPath(videoUrl.ToString());
     break;

--- a/xbmc/view/GUIViewControl.cpp
+++ b/xbmc/view/GUIViewControl.cpp
@@ -15,8 +15,9 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/IGUIContainer.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
@@ -317,8 +318,9 @@ void CGUIViewControl::UpdateViewAsControl(const std::string &viewLabel)
   for (unsigned int i = 0; i < m_visibleViews.size(); i++)
   {
     IGUIContainer *view = static_cast<IGUIContainer*>(m_visibleViews[i]);
-    std::string label = StringUtils::Format(g_localizeStrings.Get(534),
-                                            view->GetLabel()); // View: {}
+    std::string label =
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(534),
+                            view->GetLabel()); // View: {}
     labels.emplace_back(std::move(label), i);
   }
   CGUIMessage msg(GUI_MSG_SET_LABELS, m_parentWindow, m_viewAsControl, m_currentView);
@@ -326,7 +328,9 @@ void CGUIViewControl::UpdateViewAsControl(const std::string &viewLabel)
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg, m_parentWindow);
 
   // otherwise it's just a normal button
-  std::string label = StringUtils::Format(g_localizeStrings.Get(534), viewLabel); // View: {}
+  std::string label =
+      StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(534),
+                          viewLabel); // View: {}
   CGUIMessage msgSet(GUI_MSG_LABEL_SET, m_parentWindow, m_viewAsControl);
   msgSet.SetLabel(label);
   CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msgSet, m_parentWindow);

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -27,7 +27,6 @@
 #include "games/windows/GUIViewStateWindowGames.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/TextureManager.h"
 #include "music/GUIViewStateMusic.h"
 #include "pictures/GUIViewStatePictures.h"
@@ -35,6 +34,8 @@
 #include "profiles/ProfileManager.h"
 #include "programs/GUIViewStatePrograms.h"
 #include "pvr/windows/GUIViewStatePVR.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -375,7 +376,8 @@ bool CGUIViewState::ChooseSortMethod()
   dialog->Reset();
   dialog->SetHeading(CVariant{ 39010 }); // Label "Sort by"
   for (auto &sortMethod : m_sortMethods)
-    dialog->Add(g_localizeStrings.Get(sortMethod.m_buttonLabel));
+    dialog->Add(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(sortMethod.m_buttonLabel));
   dialog->SetSelected(m_currentSortMethod);
   dialog->Open();
   int newSelected = dialog->GetSelectedItem();

--- a/xbmc/weather/WeatherJob.cpp
+++ b/xbmc/weather/WeatherJob.cpp
@@ -17,10 +17,11 @@
 #include "addons/addoninfo/AddonType.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "network/Network.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -198,12 +199,12 @@ void CWeatherJob::SetFromProperties()
           CSpeed::CreateFromKilometresPerHour(std::strtod(wind.asString().c_str(), nullptr))};
       std::string direction{window->GetProperty("Current.WindDirection").asString()};
       if (direction == "CALM")
-        m_info.currentWind = g_localizeStrings.Get(1410);
+        m_info.currentWind = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1410);
       else
       {
         direction = m_localizer.LocalizeOverviewToken(direction);
         m_info.currentWind = StringUtils::Format(
-            g_localizeStrings.Get(434), direction,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(434), direction,
             static_cast<int>(speed.To(g_langInfo.GetSpeedUnit())), g_langInfo.GetSpeedUnitString());
       }
       const std::string windspeed{

--- a/xbmc/weather/WeatherManager.cpp
+++ b/xbmc/weather/WeatherManager.cpp
@@ -17,7 +17,6 @@
 #include "addons/gui/GUIDialogAddonSettings.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "messaging/ApplicationMessenger.h"
 #include "settings/Settings.h"

--- a/xbmc/weather/WeatherPropertyHelper.cpp
+++ b/xbmc/weather/WeatherPropertyHelper.cpp
@@ -9,8 +9,10 @@
 #include "WeatherPropertyHelper.h"
 
 #include "LangInfo.h"
+#include "ServiceBroker.h"
 #include "guilib/GUIWindow.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/Map.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -176,7 +178,7 @@ std::string CWeatherPropertyHelper::FormatWind(const std::string& direction, con
 {
   if (direction == "CALM")
   {
-    return g_localizeStrings.Get(1410); // Calm
+    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1410); // Calm
   }
   else
   {
@@ -190,7 +192,8 @@ std::string CWeatherPropertyHelper::FormatWind(const std::string& direction, con
     }
     else
     {
-      return StringUtils::Format(g_localizeStrings.Get(434), // From {direction} at {speed} {unit}
+      return StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                     434), // From {direction} at {speed} {unit}
                                  direction, static_cast<int>(speed.To(g_langInfo.GetSpeedUnit())),
                                  g_langInfo.GetSpeedUnitString());
     }

--- a/xbmc/weather/WeatherTokenLocalizer.cpp
+++ b/xbmc/weather/WeatherTokenLocalizer.cpp
@@ -10,7 +10,8 @@
 
 #include "LangInfo.h"
 #include "ServiceBroker.h"
-#include "guilib/LocalizeStrings.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -45,7 +46,7 @@ std::string CWeatherTokenLocalizer::LocalizeOverviewToken(const std::string& tok
   {
     const auto it{m_localizedTokens.find(token)};
     if (it != m_localizedTokens.cend())
-      locStr = g_localizeStrings.Get(it->second);
+      locStr = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(it->second);
   }
 
   if (locStr.empty())

--- a/xbmc/windowing/linux/OSScreenSaverFreedesktop.cpp
+++ b/xbmc/windowing/linux/OSScreenSaverFreedesktop.cpp
@@ -9,7 +9,9 @@
 #include "OSScreenSaverFreedesktop.h"
 
 #include "CompileInfo.h"
-#include "guilib/LocalizeStrings.h"
+#include "ServiceBroker.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "utils/log.h"
 
 #include "platform/linux/DBusMessage.h"
@@ -42,8 +44,9 @@ void COSScreenSaverFreedesktop::Inhibit()
   }
 
   CDBusMessage inhibitMessage(SCREENSAVER_INTERFACE, SCREENSAVER_OBJECT, SCREENSAVER_INTERFACE, "Inhibit");
-  inhibitMessage.AppendArguments(std::string(CCompileInfo::GetAppName()),
-                                 g_localizeStrings.Get(14086));
+  inhibitMessage.AppendArguments(
+      std::string(CCompileInfo::GetAppName()),
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14086));
   if (!inhibitMessage.SendSession())
   {
     // DBus call failed

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -26,11 +26,12 @@
 #include "cores/VideoPlayer/Process/wayland/ProcessInfoWayland.h"
 #include "cores/VideoPlayer/VideoReferenceClock.h"
 #include "guilib/DispResource.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/InputManager.h"
 #include "input/touch/generic/GenericTouchActionHandler.h"
 #include "input/touch/generic/GenericTouchInputHandler.h"
 #include "messaging/ApplicationMessenger.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
@@ -1066,7 +1067,7 @@ std::string CWinSystemWayland::UserFriendlyOutputName(std::shared_ptr<COutput> c
   if (parts.empty())
   {
     // Fallback to "unknown" if no name received from compositor
-    parts.emplace_back(g_localizeStrings.Get(13205));
+    parts.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205));
   }
 
   // Add position

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -43,7 +43,6 @@
 #include "guilib/GUIEditControl.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "interfaces/generic/ScriptInvocationManager.h"
@@ -54,6 +53,8 @@
 #include "network/Network.h"
 #include "playlists/PlayList.h"
 #include "profiles/ProfileManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -584,13 +585,16 @@ void CGUIMediaWindow::UpdateButtons()
     else
       CONTROL_ENABLE(CONTROL_BTNSORTBY);
 
-    std::string sortLabel = StringUtils::Format(
-        g_localizeStrings.Get(550), g_localizeStrings.Get(m_guiState->GetSortMethodLabel()));
+    std::string sortLabel =
+        StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(550),
+                            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                m_guiState->GetSortMethodLabel()));
     SET_CONTROL_LABEL(CONTROL_BTNSORTBY, sortLabel);
   }
 
   std::string items =
-      StringUtils::Format("{} {}", m_vecItems->GetObjectCount(), g_localizeStrings.Get(127));
+      StringUtils::Format("{} {}", m_vecItems->GetObjectCount(),
+                          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(127));
   SET_CONTROL_LABEL(CONTROL_LABELFILES, items);
 
   SET_CONTROL_LABEL2(CONTROL_BTN_FILTER, GetProperty("filter").asString());
@@ -881,7 +885,8 @@ bool CGUIMediaWindow::Update(const std::string &strDirectory, bool updateFilterP
   if (showLabel && (m_vecItems->Size() == 0 || !m_guiState->DisableAddSourceButtons()) &&
       iWindow != WINDOW_MUSIC_PLAYLIST_EDITOR)
   {
-    const std::string& strLabel = g_localizeStrings.Get(showLabel);
+    const std::string& strLabel =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(showLabel);
     CFileItemPtr pItem(new CFileItem(strLabel));
     pItem->SetPath("add");
     pItem->SetArt("icon", "DefaultAddSource.png");
@@ -1271,7 +1276,10 @@ bool CGUIMediaWindow::GoParentFolder()
   // No items to show so go another level up
   if (!m_vecItems->GetPath().empty() && (m_filter.IsEmpty() ? m_vecItems->Size() : m_unfilteredItems->Size()) <= 0)
   {
-    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(2080), g_localizeStrings.Get(2081));
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Info,
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(2080),
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(2081));
     return GoParentFolder();
   }
   return true;

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -33,7 +33,6 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/InputManager.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
@@ -48,6 +47,8 @@
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
 #include "playlists/PlayListFileItemClassify.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -373,7 +374,8 @@ void CGUIWindowFileManager::UpdateButtons()
   std::string strDir = CURL(m_Directory[0]->GetPath()).GetWithoutUserDetails();
   if (strDir.empty())
   {
-    SET_CONTROL_LABEL(CONTROL_CURRENTDIRLABEL_LEFT,g_localizeStrings.Get(20108));
+    SET_CONTROL_LABEL(CONTROL_CURRENTDIRLABEL_LEFT,
+                      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20108));
   }
   else
   {
@@ -382,7 +384,8 @@ void CGUIWindowFileManager::UpdateButtons()
   strDir = CURL(m_Directory[1]->GetPath()).GetWithoutUserDetails();
   if (strDir.empty())
   {
-    SET_CONTROL_LABEL(CONTROL_CURRENTDIRLABEL_RIGHT,g_localizeStrings.Get(20108));
+    SET_CONTROL_LABEL(CONTROL_CURRENTDIRLABEL_RIGHT,
+                      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20108));
   }
   else
   {
@@ -415,9 +418,12 @@ void CGUIWindowFileManager::UpdateItemCounts()
     if (selectedCount > 0)
       items =
           StringUtils::Format("{}/{} {} ({})", selectedCount, totalCount,
-                              g_localizeStrings.Get(127), StringUtils::SizeToString(selectedSize));
+                              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(127),
+                              StringUtils::SizeToString(selectedSize));
     else
-      items = StringUtils::Format("{} {}", totalCount, g_localizeStrings.Get(127));
+      items = StringUtils::Format(
+          "{} {}", totalCount,
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(127));
     SET_CONTROL_LABEL(CONTROL_NUMFILES_LEFT + i, items);
   }
 }
@@ -470,7 +476,8 @@ bool CGUIWindowFileManager::Update(int iList, const std::string &strDirectory)
   URIUtils::GetParentPath(strDirectory, strParentPath);
   if (strDirectory.empty() && (m_vecItems[iList]->Size() == 0 || CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_SHOWADDSOURCEBUTTONS)))
   { // add 'add source button'
-    const std::string& strLabel = g_localizeStrings.Get(1026);
+    const std::string& strLabel =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1026);
     CFileItemPtr pItem(new CFileItem(strLabel));
     pItem->SetPath("add");
     pItem->SetArt("icon", "DefaultAddSource.png");
@@ -494,7 +501,7 @@ bool CGUIWindowFileManager::Update(int iList, const std::string &strDirectory)
   if (strDirectory.empty())
   {
     CFileItemPtr pItem(new CFileItem("special://profile/", true));
-    pItem->SetLabel(g_localizeStrings.Get(20070));
+    pItem->SetLabel(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20070));
     pItem->SetArt("thumb", "DefaultFolder.png");
     pItem->SetLabelPreformatted(true);
     m_vecItems[iList]->Add(pItem);
@@ -554,7 +561,9 @@ void CGUIWindowFileManager::OnClick(int iList, int iItem)
   if ( iItem < 0 || iItem >= m_vecItems[iList]->Size() ) return ;
 
   CFileItemPtr pItem = m_vecItems[iList]->Get(iItem);
-  if (pItem->GetPath() == "add" && pItem->GetLabel() == g_localizeStrings.Get(1026)) // 'add source button' in empty root
+  if (pItem->GetPath() == "add" &&
+      pItem->GetLabel() == CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                               1026)) // 'add source button' in empty root
   {
     if (CGUIDialogMediaSource::ShowAndAddMediaSource("files"))
     {
@@ -785,7 +794,9 @@ void CGUIWindowFileManager::OnSelectAll(int iList)
 void CGUIWindowFileManager::OnNewFolder(int iList)
 {
   std::string strNewFolder = "";
-  if (CGUIKeyboardFactory::ShowAndGetInput(strNewFolder, CVariant{g_localizeStrings.Get(16014)}, false))
+  if (CGUIKeyboardFactory::ShowAndGetInput(
+          strNewFolder,
+          CVariant{CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16014)}, false))
   {
     std::string strNewPath = m_Directory[iList]->GetPath();
     URIUtils::AddSlashAtEnd(strNewPath);

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -17,7 +17,6 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/LocalizeStrings.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "interfaces/builtins/Builtins.h"
@@ -28,6 +27,8 @@
 #include "profiles/dialogs/GUIDialogProfileSettings.h"
 #include "pvr/PVRManager.h"
 #include "pvr/guilib/PVRGUIActionsPowerManagement.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
@@ -153,8 +154,9 @@ void CGUIWindowLoginScreen::FrameMove()
 
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  std::string strLabel = StringUtils::Format(g_localizeStrings.Get(20114), m_iSelectedItem + 1,
-                                             profileManager->GetNumberOfProfiles());
+  std::string strLabel =
+      StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20114),
+                          m_iSelectedItem + 1, profileManager->GetNumberOfProfiles());
   SET_CONTROL_LABEL(CONTROL_LABEL_SELECTED_PROFILE,strLabel);
   CGUIWindow::FrameMove();
 }
@@ -169,7 +171,8 @@ void CGUIWindowLoginScreen::OnInitWindow()
   m_viewControl.SetCurrentView(DEFAULT_VIEW_LIST);
   Update();
   m_viewControl.SetFocused();
-  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER,g_localizeStrings.Get(20115));
+  SET_CONTROL_LABEL(CONTROL_LABEL_HEADER,
+                    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20115));
   SET_CONTROL_VISIBLE(CONTROL_BIG_LIST);
 
   CGUIWindow::OnInitWindow();
@@ -203,9 +206,11 @@ void CGUIWindowLoginScreen::Update()
 
     std::string strLabel;
     if (profile->getDate().empty())
-      strLabel = g_localizeStrings.Get(20113);
+      strLabel = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20113);
     else
-      strLabel = StringUtils::Format(g_localizeStrings.Get(20112), profile->getDate());
+      strLabel = StringUtils::Format(
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20112),
+          profile->getDate());
 
     item->SetLabel2(strLabel);
     item->SetArt("thumb", profile->getThumb());

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -12,11 +12,12 @@
 #include "ServiceBroker.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
-#include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "pvr/PVRManager.h"
 #include "rendering/RenderSystem.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "storage/MediaManager.h"
 #include "utils/CPUInfo.h"
 #include "utils/StringUtils.h"
@@ -116,7 +117,7 @@ void CGUIWindowSystemInfo::FrameMove()
   int i = CONTROL_TEXT_START;
   if (m_section == CONTROL_BT_DEFAULT)
   {
-    SET_CONTROL_LABEL(40, g_localizeStrings.Get(20154));
+    SET_CONTROL_LABEL(40, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20154));
     SetControlLabel(i++, "{}: {}", 158, SYSTEM_FREE_MEMORY);
     SetControlLabel(i++, "{}: {}", 150, NETWORK_IP_ADDRESS);
     SetControlLabel(i++, "{} {}", 13287, SYSTEM_SCREEN_RESOLUTION);
@@ -128,7 +129,7 @@ void CGUIWindowSystemInfo::FrameMove()
 
   else if (m_section == CONTROL_BT_STORAGE)
   {
-    SET_CONTROL_LABEL(40, g_localizeStrings.Get(20155));
+    SET_CONTROL_LABEL(40, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20155));
     if (m_diskUsage.empty())
       m_diskUsage = CServiceBroker::GetMediaManager().GetDiskUsage();
 
@@ -140,7 +141,7 @@ void CGUIWindowSystemInfo::FrameMove()
 
   else if (m_section == CONTROL_BT_NETWORK)
   {
-    SET_CONTROL_LABEL(40,g_localizeStrings.Get(20158));
+    SET_CONTROL_LABEL(40, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20158));
     SET_CONTROL_LABEL(i++, CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
                                NETWORK_LINK_STATE, INFO::DEFAULT_CONTEXT));
     SetControlLabel(i++, "{}: {}", 149, NETWORK_MAC_ADDRESS);
@@ -154,7 +155,7 @@ void CGUIWindowSystemInfo::FrameMove()
 
   else if (m_section == CONTROL_BT_VIDEO)
   {
-    SET_CONTROL_LABEL(40,g_localizeStrings.Get(20159));
+    SET_CONTROL_LABEL(40, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20159));
     SET_CONTROL_LABEL(i++, CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
                                SYSTEM_VIDEO_ENCODER_INFO, INFO::DEFAULT_CONTEXT));
     SetControlLabel(i++, "{} {}", 13287, SYSTEM_SCREEN_RESOLUTION);
@@ -164,7 +165,11 @@ void CGUIWindowSystemInfo::FrameMove()
     {
       static std::string vendor = renderingSystem->GetRenderVendor();
       if (!vendor.empty())
-        SET_CONTROL_LABEL(i++, StringUtils::Format("{} {}", g_localizeStrings.Get(22007), vendor));
+        SET_CONTROL_LABEL(
+            i++,
+            StringUtils::Format(
+                "{} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(22007),
+                vendor));
 
 #if defined(HAS_DX)
       int renderVersionLabel = 22024;
@@ -173,8 +178,11 @@ void CGUIWindowSystemInfo::FrameMove()
 #endif
       static std::string version = renderingSystem->GetRenderVersionString();
       if (!version.empty())
-        SET_CONTROL_LABEL(
-            i++, StringUtils::Format("{} {}", g_localizeStrings.Get(renderVersionLabel), version));
+        SET_CONTROL_LABEL(i++, StringUtils::Format(
+                                   "{} {}",
+                                   CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                       renderVersionLabel),
+                                   version));
     }
 
     auto windowSystem = CServiceBroker::GetWinSystem();
@@ -182,8 +190,11 @@ void CGUIWindowSystemInfo::FrameMove()
     {
       static std::string platform = windowSystem->GetName();
       if (platform != "platform default")
-        SET_CONTROL_LABEL(i++,
-                          StringUtils::Format("{} {}", g_localizeStrings.Get(39153), platform));
+        SET_CONTROL_LABEL(
+            i++,
+            StringUtils::Format(
+                "{} {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39153),
+                platform));
     }
 
     SetControlLabel(i++, "{} {}", 22010, SYSTEM_GPU_TEMPERATURE);
@@ -191,13 +202,16 @@ void CGUIWindowSystemInfo::FrameMove()
     const std::string hdrTypes = CServiceBroker::GetGUI()->GetInfoManager().GetLabel(
         SYSTEM_SUPPORTED_HDR_TYPES, INFO::DEFAULT_CONTEXT);
     SET_CONTROL_LABEL(
-        i++, StringUtils::Format("{}: {}", g_localizeStrings.Get(39174),
-                                 hdrTypes.empty() ? g_localizeStrings.Get(231) : hdrTypes));
+        i++,
+        StringUtils::Format(
+            "{}: {}", CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(39174),
+            hdrTypes.empty() ? CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231)
+                             : hdrTypes));
   }
 
   else if (m_section == CONTROL_BT_HARDWARE)
   {
-    SET_CONTROL_LABEL(40,g_localizeStrings.Get(20160));
+    SET_CONTROL_LABEL(40, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20160));
 
     auto cpuInfo = CServiceBroker::GetCPUInfo();
     if (cpuInfo)
@@ -240,7 +254,7 @@ void CGUIWindowSystemInfo::FrameMove()
 
   else if (m_section == CONTROL_BT_PVR)
   {
-    SET_CONTROL_LABEL(40, g_localizeStrings.Get(19166));
+    SET_CONTROL_LABEL(40, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(19166));
     int i = CONTROL_TEXT_START;
 
     SetControlLabel(i++, "{}: {}", 19120, PVR_BACKEND_NUMBER);
@@ -260,7 +274,7 @@ void CGUIWindowSystemInfo::FrameMove()
 
   else if (m_section == CONTROL_BT_POLICY)
   {
-    SET_CONTROL_LABEL(40, g_localizeStrings.Get(12389));
+    SET_CONTROL_LABEL(40, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(12389));
   }
   CGUIWindow::FrameMove();
 }
@@ -280,7 +294,7 @@ void CGUIWindowSystemInfo::ResetLabels()
 void CGUIWindowSystemInfo::SetControlLabel(int id, const char *format, int label, int info)
 {
   std::string tmpStr = StringUtils::Format(
-      format, g_localizeStrings.Get(label),
+      format, CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(label),
       CServiceBroker::GetGUI()->GetInfoManager().GetLabel(info, INFO::DEFAULT_CONTEXT));
   SET_CONTROL_LABEL(id, tmpStr);
 }


### PR DESCRIPTION
…s out of guilib and kill the global

Just opening the PR to see if it builds on all platforms.

## Description
- Introduces a `ResourcesComponent` to hold resources that are shared across different components (strings, color registry, font registry, etc.). Those resources don't require GUI but assume the presence of a presentation layer of any kind (cli/terminal, json-rpc, gui, etc). They are common resources to the whole application.
- Resources are initialized early in the application lifecycle (in APP Environment), strings for example are used by the logging component and the settings component.
- Kill the g_localizedStrings global by moving it to the new created component
- Update all call sites (yeah this is massive...)
- Try to cache the pointer to avoid multiple indirections on the same method

## Motivation and context
Decouple GUI from common code, being able to run kodi without a GUI at some point in the future. Kill globals.

## How has this been tested?
Runtime tested on macOS, will test other platforms too.

## What is the effect on users?
None, internal refactoring

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
