### PR TITLE
Android: Fix display mode matching with padded hardware decoder surfaces

### DIFF
--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -120,9 +120,10 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
     const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
 
     // allow resolutions that are exact and have the correct refresh rate
-    // allow macroblock alignment / padding errors (e.g. 1080 mod16 == 8)
+    // allow hardware decoder surface padding due to codec block alignment and GPU requirements
+    // note: height has greater tolerance due to 32/64px boundaries e.g. 1080→1088 or 2160→2176
     if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
-         (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
+         (width == info.iScreenWidth && height <= info.iScreenHeight + 32)) &&
         (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
         MathUtils::FloatEquals(info.fRefreshRate, fps, 0.01f))
     {
@@ -154,9 +155,10 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
       const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
 
       // allow resolutions that are exact and have double the refresh rate
-      // allow macroblock alignment / padding errors (e.g. 1080 mod16 == 8)
+      // allow hardware decoder surface padding due to codec block alignment and GPU requirements
+      // note: height has greater tolerance due to 32/64px boundaries e.g. 1080→1088 or 2160→2176
       if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
-           (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
+           (width == info.iScreenWidth && height <= info.iScreenHeight + 32)) &&
           (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
           MathUtils::FloatEquals(info.fRefreshRate, fps * 2, 0.01f))
       {
@@ -193,9 +195,10 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
       const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(i);
 
       // allow resolutions that are exact and have 2.5 times the refresh rate
-      // allow macroblock alignment / padding errors (e.g. 1080 mod16 == 8)
+      // allow hardware decoder surface padding due to codec block alignment and GPU requirements
+      // note: height has greater tolerance due to 32/64px boundaries e.g. 1080→1088 or 2160→2176
       if (((height == info.iScreenHeight && width <= info.iScreenWidth + 8) ||
-           (width == info.iScreenWidth && height <= info.iScreenHeight + 8)) &&
+           (width == info.iScreenWidth && height <= info.iScreenHeight + 32)) &&
           (info.dwFlags & D3DPRESENTFLAG_MODEMASK) == (curr.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
           MathUtils::FloatEquals(info.fRefreshRate, fps * 2.5f, 0.01f))
       {


### PR DESCRIPTION
## Description

This PR relaxes the resolution matching tolerance used when selecting display modes to account for hardware decoder output surface alignment padding.

Some hardware decoder pipelines (notably Android MediaCodec with HEVC/VP9) pad decoded output surfaces beyond the coded video dimensions due to codec block size and GPU texture alignment requirements. The previous hardcoded 8-pixel tolerance is insufficient for modern 4K content and can cause valid display modes to be incorrectly rejected.

The tolerance has been increased to handle these cases correctly while preserving existing exact-match behavior.

Also see https://forum.kodi.tv/showthread.php?tid=375814 for much of the background

## Motivation and context
On Android devices, especially when decoding HEVC 4K content, hardware decoders frequently align output surfaces to 32-pixel boundaries. This results in decoded surfaces being larger than the coded resolution (for example, 2160p content producing a 2176px-high surface).

The existing 8-pixel tolerance was originally sufficient for H.264 macroblock padding (1080p → 1088), but is too restrictive for HEVC and modern GPU alignment requirements. This causes display mode matching to fail, potentially preventing optimal fullscreen playback or triggering unnecessary scaling.

Android decoders often align to codec block size, not display size.

Here is an AI summary on this subject:

**Modern Android hardware decoders (MediaCodec) frequently align output buffers to:**

Codec	Alignment
H.264	16
HEVC	32
VP9	32 or 64
AV1	64

So while 2160 % 16 == 0:

HEVC alignment example
2160 % 32 = 16
→ padded to 2176

Many 4K streams today are HEVC — especially on Android.

**GPU texture alignment requirements**

Even after decode, surfaces are often placed into GPU textures:

Common constraints:

Mali: 16 or 32
Adreno: 32
PowerVR: 32

These drivers silently round up buffer strides and heights.

So even if codec is fine:

GPU requires height multiple of 32
2160 → 2176

**YUV chroma plane constraints**

For 4:2:0 formats:

UV planes are half resolution

Some hardware aligns UV separately

Which forces even larger rounding:

Example:

Luma must be multiple of 32
Chroma must be multiple of 16
→ Final composite surface padded further

**Android reports “crop rect” vs “buffer size”**

Important detail:

MediaCodec exposes:

Visible size (crop rectangle)

Actual buffer size (aligned surface)

If you’re reading:

MediaFormat.KEY_WIDTH
MediaFormat.KEY_HEIGHT


vs actual surface texture size — they may differ.

Typical example:

Crop: 3840 x 2160
Buffer: 3840 x 2176

Apps that read the buffer size instead of crop size will see the padding.

**Vendor bugs (yes, literally)**

Some Android firmware versions simply:

Ignore spec crop rect
Over-allocate
Return padded size

Seen on:

Samsung Exynos
MediaTek
Some Snapdragon firmwares
Especially with HDR + HEVC + SurfaceTexture paths.

This change ensures Kodi correctly handles padded hardware decoder output without relying on codec-specific assumptions.

## How has this been tested?

Tested on Android devices decoding HEVC 4K content (2160p) using hardware acceleration.
Verified that display mode selection no longer fails when decoder output surfaces are padded to 2176px.
Confirmed that 1080p and lower resolution content continue to match correctly with no regressions observed.
Manual playback testing performed with resolution switching enabled.

Test environment:

Platform: Android  (Firestick 4k Max)
Codec: HEVC (hardware decode)
Display resolution: 3840x2160
Renderer: Default Android rendering path

## What is the effect on users?

Improves reliability of resolution matching and fullscreen playback for hardware-decoded 4K content, particularly on Android devices. Prevents incorrect display mode rejection caused by decoder surface padding, reducing unnecessary scaling and potential playback issues.

## Screenshots (if appropriate):

N/A

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
