### PR TITLE
[GUI] Fix some regressions regarding skin strings

### DIFF
--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -17,6 +17,7 @@
 #include "filesystem/Directory.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIComponent.h"
+#include "guilib/GUIUtils.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "guilib/WindowIDs.h"
@@ -531,7 +532,7 @@ void GetFontsetsFromFile(const std::string& fontsetFilePath,
         if (idAttr)
         {
           if (idLocAttr)
-            list.emplace_back(g_localizeStrings.Get(atoi(idLocAttr)), idAttr);
+            list.emplace_back(CGUIUtils::GetLocalizedString(std::atoi(idLocAttr)), idAttr);
           else
             list.emplace_back(idAttr, idAttr);
 
@@ -628,7 +629,7 @@ void CSkinInfo::SettingOptionsStartupWindowsFiller(const SettingConstPtr& settin
   {
     std::string windowName = window.m_name;
     if (StringUtils::IsNaturalNumber(windowName))
-      windowName = g_localizeStrings.Get(std::atoi(windowName.c_str()));
+      windowName = CGUIUtils::GetLocalizedString(std::atoi(windowName.c_str()));
     const int windowID = window.m_id;
 
     list.emplace_back(windowName, windowID);

--- a/xbmc/guilib/CMakeLists.txt
+++ b/xbmc/guilib/CMakeLists.txt
@@ -55,6 +55,7 @@ set(SOURCES DDSImage.cpp
             GUITexture.cpp
             GUITextureCallbackManager.cpp
             GUIToggleButtonControl.cpp
+            GUIUtils.cpp
             GUIVideoControl.cpp
             GUIVisualisationControl.cpp
             GUIWindow.cpp
@@ -136,6 +137,7 @@ set(HEADERS AspectRatio.h
             GUITexture.h
             GUITextureCallbackManager.h
             GUIToggleButtonControl.h
+            GUIUtils.h
             GUIVideoControl.h
             GUIVisualisationControl.h
             GUIWindow.h

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -41,6 +41,7 @@
 #include "GUISpinControlEx.h"
 #include "GUITextBox.h"
 #include "GUIToggleButtonControl.h"
+#include "GUIUtils.h"
 #include "GUIVideoControl.h"
 #include "GUIVisualisationControl.h"
 #include "GUIWrappingListContainer.h"
@@ -647,20 +648,6 @@ void CGUIControlFactory::GetInfoLabel(const TiXmlNode* pControlNode,
     infoLabel = labels[0];
 }
 
-namespace
-{
-std::string GetLocalizedString(uint32_t id)
-{
-  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
-  if (skin && ADDON::IsSkinStringId(id))
-  {
-    return g_localizeStrings.GetAddonString(skin->ID(), id);
-  }
-
-  return g_localizeStrings.Get(id);
-}
-} // namespace
-
 bool CGUIControlFactory::GetInfoLabelFromElement(const TiXmlElement* element,
                                                  GUIINFO::CGUIInfoLabel& infoLabel,
                                                  int parentID)
@@ -674,10 +661,10 @@ bool CGUIControlFactory::GetInfoLabelFromElement(const TiXmlElement* element,
 
   std::string fallback = XMLUtils::GetAttribute(element, "fallback");
   if (StringUtils::IsNaturalNumber(label))
-    label = GetLocalizedString(std::atoi(label.c_str()));
+    label = CGUIUtils::GetLocalizedString(std::atoi(label.c_str()));
 
   if (StringUtils::IsNaturalNumber(fallback))
-    fallback = GetLocalizedString(std::atoi(fallback.c_str()));
+    fallback = CGUIUtils::GetLocalizedString(std::atoi(fallback.c_str()));
   else
     g_charsetConverter.unknownToUTF8(fallback);
   infoLabel.SetLabel(label, fallback, parentID);
@@ -733,7 +720,7 @@ std::string CGUIControlFactory::FilterLabel(const std::string& label)
 {
   std::string viewLabel = label;
   if (StringUtils::IsNaturalNumber(viewLabel))
-    viewLabel = g_localizeStrings.Get(atoi(label.c_str()));
+    viewLabel = CGUIUtils::GetLocalizedString(std::atoi(label.c_str()));
   else
     g_charsetConverter.unknownToUTF8(viewLabel);
   return viewLabel;
@@ -746,7 +733,7 @@ bool CGUIControlFactory::GetString(const TiXmlNode* pRootNode,
   if (!XMLUtils::GetString(pRootNode, strTag, text))
     return false;
   if (StringUtils::IsNaturalNumber(text))
-    text = g_localizeStrings.Get(atoi(text.c_str()));
+    text = CGUIUtils::GetLocalizedString(std::atoi(text.c_str()));
   return true;
 }
 

--- a/xbmc/guilib/GUIUtils.cpp
+++ b/xbmc/guilib/GUIUtils.cpp
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GUIUtils.h"
+
+#include "ServiceBroker.h"
+#include "addons/Skin.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/LocalizeStrings.h"
+
+std::string CGUIUtils::GetLocalizedString(uint32_t id)
+{
+  if (ADDON::IsSkinStringId(id))
+  {
+    auto gui = CServiceBroker::GetGUI();
+    if (gui)
+    {
+      auto skin = gui->GetSkinInfo();
+      if (skin)
+        return g_localizeStrings.GetAddonString(skin->ID(), id);
+    }
+  }
+  return g_localizeStrings.Get(id);
+}

--- a/xbmc/guilib/GUIUtils.h
+++ b/xbmc/guilib/GUIUtils.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+/*!
+ \ingroup guilib
+ \brief GUI utility functions
+ */
+class CGUIUtils
+{
+public:
+  /*!
+   * \brief Get a localized string, with support for skin strings
+   * \param id The string ID to look up
+   * \return The localized string, or empty string if not found
+   *
+   * This function handles both core strings and skin-specific strings (range 31000-31999).
+   * For skin strings, it retrieves them from the active skin's string map.
+   * For core strings, it retrieves them from the main localization map.
+   */
+  static std::string GetLocalizedString(uint32_t id);
+};

--- a/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
+++ b/xbmc/guilib/guiinfo/GUIInfoLabel.cpp
@@ -15,6 +15,7 @@
 #include "games/GameServices.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIListItem.h"
+#include "guilib/GUIUtils.h"
 #include "guilib/LocalizeStrings.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -243,14 +244,7 @@ bool CGUIInfoLabel::ReplaceSpecialKeywordReferences(std::string& work,
 
 std::string LocalizeReplacer(const std::string& str)
 {
-  const uint32_t id = std::atoi(str.c_str());
-  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
-  if (skin && ADDON::IsSkinStringId(id))
-  {
-    return g_localizeStrings.GetAddonString(skin->ID(), id);
-  }
-
-  return g_localizeStrings.Get(id);
+  return CGUIUtils::GetLocalizedString(std::atoi(str.c_str()));
 }
 
 std::string AddonReplacer(const std::string& str)

--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -23,6 +23,7 @@
 #include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
+#include "guilib/GUIUtils.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/LocalizeStrings.h"
 #include "settings/Settings.h"
@@ -112,14 +113,14 @@ static int SelectBool(const std::vector<std::string>& params)
 
   CGUIDialogSelect* pDlgSelect = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
   pDlgSelect->Reset();
-  pDlgSelect->SetHeading(CVariant{g_localizeStrings.Get(atoi(params[0].c_str()))});
+  pDlgSelect->SetHeading(CVariant{CGUIUtils::GetLocalizedString(std::atoi(params[0].c_str()))});
 
   for (unsigned int i = 1 ; i < params.size() ; i++)
   {
     if (params[i].find('|') != std::string::npos)
     {
       std::vector<std::string> values = StringUtils::Split(params[i], '|');
-      std::string label = g_localizeStrings.Get(atoi(values[0].c_str()));
+      std::string label = CGUIUtils::GetLocalizedString(std::atoi(values[0].c_str()));
       settings.emplace_back(label, values[1].c_str());
       pDlgSelect->Add(label);
     }
@@ -331,7 +332,8 @@ static int SetColor(const std::vector<std::string>& params)
       CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogColorPicker>(
           WINDOW_DIALOG_COLOR_PICKER);
   pDlgColorPicker->Reset();
-  pDlgColorPicker->SetHeading(CVariant{g_localizeStrings.Get(atoi(params[1].c_str()))});
+  pDlgColorPicker->SetHeading(
+      CVariant{CGUIUtils::GetLocalizedString(std::atoi(params[1].c_str()))});
 
   if (params.size() > 3)
   {


### PR DESCRIPTION
## Description
This fixes a few regressions caused by https://github.com/xbmc/xbmc/pull/27712 since there are other places where skin strings might be also used.

## Motivation and context
Fix https://github.com/xbmc/xbmc/issues/27753 

## How has this been tested?
Runtime tested

## What is the effect on users?
Some skins strings should now be restored

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

