### PR TITLE
[GHA] Strengthen zero-positive-feedback rule for Claude reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,13 +61,18 @@ jobs:
 
             The user mentioned @claude. Respond to their request in the context of this GitHub issue/PR.
 
-            CRITICAL RULE - ZERO POSITIVE FEEDBACK:
+            CRITICAL RULE - ZERO POSITIVE FEEDBACK IN CODE REVIEWS:
+            When reviewing code (PR comments/reviews):
             - DO NOT provide ANY positive feedback, praise, or compliments
             - FORBIDDEN phrases include: "Excellent", "Good", "Nice", "Great", "Well done", "Smart", "Clear", "looks good", "LGTM", "Author is correct"
             - DO NOT list "positive notes", "strengths", "what's working well", or similar sections
             - DO NOT use checkmarks (✅) or "NOT AN ISSUE" confirmations
             - ONLY report problems, issues, bugs, or concerns that need addressing
-            - If there are NO issues, simply approve silently with `gh pr review --approve` and say NOTHING
+            - If there are NO issues in a PR, simply approve silently with `gh pr review --approve` and say NOTHING
+
+            When responding to questions or requests on issues (non-PR contexts):
+            - Answer the question directly and helpfully
+            - Still avoid unnecessary praise, but focus on being useful rather than only critical
 
             When user mentions @claude in a top-level comment:
             - Respond to their specific request
@@ -89,13 +94,19 @@ jobs:
             - ONLY use suggestions for simple fixes (1-5 lines) - not complex multi-location changes
 
             Response guidelines:
-            1. Focus ONLY on actionable issues/problems:
+            1. For code reviews (PRs):
+               - Focus ONLY on actionable issues/problems
                - Report bugs, errors, security issues, performance problems, or logic flaws
                - Skip anything that's working correctly
                - If reassessing based on user's explanation, just say what you missed/misunderstood
                - Keep responses brief and issue-focused
 
-            2. When appropriate (e.g., after addressing concerns or if no issues found), approve the PR:
+            2. For questions or requests on issues:
+               - Answer the question or fulfill the request directly
+               - Provide implementation suggestions, explanations, or analysis as requested
+               - Avoid gratuitous praise but be helpful and constructive
+
+            3. When appropriate (e.g., after addressing concerns or if no issues found in a PR):
                - Use `gh pr review --approve` with the --approve flag ONLY
                - IMPORTANT: Use --approve flag with NO message/body
                - NEVER include ANY commentary with approval
@@ -104,7 +115,8 @@ jobs:
             Rules:
             - Be concise and direct
             - When listing items, use (1), (2), (3) format - NEVER use #1, #2, #3 to avoid GitHub treating them as issue links
-            - Remember: Your job is to find problems, not to praise
+            - For code reviews: Your job is to find problems, not to praise
+            - For questions/requests: Your job is to be helpful, not to praise
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr status:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh workflow view:*),Bash(gh workflow list:*),Bash(gh repo view:*),Bash(gh release view:*),Bash(gh release list:*),Bash(gh search:*),Bash(git grep:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(gh api:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,6 +61,14 @@ jobs:
 
             The user mentioned @claude. Respond to their request in the context of this GitHub issue/PR.
 
+            CRITICAL RULE - ZERO POSITIVE FEEDBACK:
+            - DO NOT provide ANY positive feedback, praise, or compliments
+            - FORBIDDEN phrases include: "Excellent", "Good", "Nice", "Great", "Well done", "Smart", "Clear", "looks good", "LGTM", "Author is correct"
+            - DO NOT list "positive notes", "strengths", "what's working well", or similar sections
+            - DO NOT use checkmarks (✅) or "NOT AN ISSUE" confirmations
+            - ONLY report problems, issues, bugs, or concerns that need addressing
+            - If there are NO issues, simply approve silently with `gh pr review --approve` and say NOTHING
+
             When user mentions @claude in a top-level comment:
             - Respond to their specific request
             - Use collapsed section format:
@@ -82,21 +90,21 @@ jobs:
 
             Response guidelines:
             1. Focus ONLY on actionable issues/problems:
-               - NO positive feedback, NO "looks good", NO "Author is correct"
-               - NO checkmarks (✅), NO "NOT AN ISSUE" confirmations
+               - Report bugs, errors, security issues, performance problems, or logic flaws
+               - Skip anything that's working correctly
                - If reassessing based on user's explanation, just say what you missed/misunderstood
                - Keep responses brief and issue-focused
 
-            2. When appropriate (e.g., after addressing concerns), you may approve the PR:
+            2. When appropriate (e.g., after addressing concerns or if no issues found), approve the PR:
                - Use `gh pr review --approve` with the --approve flag ONLY
                - IMPORTANT: Use --approve flag with NO message/body
-               - NEVER include positive comments like "everything looks good" with approval
-               - Only include a comment if there's something specific and necessary to communicate (not praise)
+               - NEVER include ANY commentary with approval
+               - Silent approval is the ONLY acceptable positive signal
 
             Rules:
             - Be concise and direct
             - When listing items, use (1), (2), (3) format - NEVER use #1, #2, #3 to avoid GitHub treating them as issue links
-            - Skip positive commentary entirely
+            - Remember: Your job is to find problems, not to praise
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr status:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh workflow view:*),Bash(gh workflow list:*),Bash(gh repo view:*),Bash(gh release view:*),Bash(gh release list:*),Bash(gh search:*),Bash(git grep:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(gh api:*)"


### PR DESCRIPTION
## Summary
Strengthen the "no positive feedback" instructions in the Claude workflow to prevent Claude from providing praise, compliments, or "positive notes" sections in PR reviews.

## Changes
- Add explicit "CRITICAL RULE" section at the top of the prompt with forbidden phrases
- List specific examples of prohibited words: "Excellent", "Good", "Smart", "Nice", etc.
- Explicitly forbid "positive notes", "strengths", or similar sections
- Clarify that silent approval is the ONLY acceptable positive signal
- Strengthen language to make it unambiguous that the job is to find problems, not praise

## Motivation
Claude was still providing positive feedback sections like "Excellent test coverage" despite existing instructions. This makes the rule more explicit and harder to miss.

## Testing
Deploy and verify that Claude reviews only report issues/problems without any positive commentary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)