### PR TITLE
[guilib] Consolidate GUIFadeLabelControl dirty marking during scroll/fade

### DIFF
--- a/xbmc/guilib/GUIFadeLabelControl.cpp
+++ b/xbmc/guilib/GUIFadeLabelControl.cpp
@@ -120,8 +120,9 @@ void CGUIFadeLabelControl::Process(unsigned int currentTime, CDirtyRegionList &d
     else if (m_scrollInfo.m_pixelPos > m_scrollInfo.m_textWidth)
       moveToNextLabel = true;
 
-    if (m_scrollInfo.m_pixelSpeed || m_fadeAnim.GetState() == ANIM_STATE_IN_PROCESS)
-      MarkDirtyRegion();
+    // Track if any animation/scrolling is active for dirty marking
+    const bool animating =
+        m_scrollInfo.m_pixelSpeed || m_fadeAnim.GetState() == ANIM_STATE_IN_PROCESS;
 
     // apply the fading animation
     TransformMatrix matrix;
@@ -150,10 +151,11 @@ void CGUIFadeLabelControl::Process(unsigned int currentTime, CDirtyRegionList &d
     }
 
     if (m_scroll)
-    {
       m_textLayout.UpdateScrollinfo(m_scrollInfo);
+
+    // Mark dirty once if any animation or scrolling is active
+    if (animating)
       MarkDirtyRegion();
-    }
 
     CServiceBroker::GetWinSystem()->GetGfxContext().RemoveTransform();
   }


### PR DESCRIPTION
## Description
Previously, the scrolling text section had two MarkDirtyRegion() calls that could both fire during active scrolling:
1. When pixelSpeed or fade animation was active
2. Unconditionally after UpdateScrollinfo when m_scroll was true

Consolidated into a single dirty region mark at the end of the scrolling text processing block, triggered only when animation/scrolling is active.

## Motivation and context
Performance

## How has this been tested?
Kodi 22 master on Windows, CoreELEC 21.3 p3i on Ugoos AM6B+

## What is the effect on users?
Better performance

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
