### PR TITLE
[guilib] Cache scroll offset in GUIPanelContainer between Process and Render

### DIFF
--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -40,7 +40,9 @@ void CGUIPanelContainer::Process(unsigned int currentTime, CDirtyRegionList &dir
 
   UpdateScrollOffset(currentTime);
 
-  int offset = (int)(m_scroller.GetValue() / m_layout->Size(m_orientation));
+  // Calculate and cache offset for reuse in Render()
+  m_cachedScrollOffset = static_cast<int>(m_scroller.GetValue() / m_layout->Size(m_orientation));
+  const int offset = *m_cachedScrollOffset;
 
   int cacheBefore, cacheAfter;
   GetCacheOffsets(cacheBefore, cacheAfter);
@@ -96,7 +98,9 @@ void CGUIPanelContainer::Render()
   if (!m_layout || !m_focusedLayout)
     return;
 
-  int offset = (int)(m_scroller.GetValue() / m_layout->Size(m_orientation));
+  // Use cached offset from Process(), fall back to calculating if not yet cached
+  const int offset = m_cachedScrollOffset.value_or(
+      static_cast<int>(m_scroller.GetValue() / m_layout->Size(m_orientation)));
 
   int cacheBefore, cacheAfter;
   GetCacheOffsets(cacheBefore, cacheAfter);

--- a/xbmc/guilib/GUIPanelContainer.h
+++ b/xbmc/guilib/GUIPanelContainer.h
@@ -15,6 +15,8 @@
 
 #include "GUIBaseContainer.h"
 
+#include <optional>
+
 /*!
  \ingroup controls
  \brief
@@ -59,5 +61,8 @@ protected:
   int GetCurrentColumn() const;
 
   int m_itemsPerRow;
+
+  // Cached offset calculated in Process() and reused in Render()
+  std::optional<int> m_cachedScrollOffset;
 };
 


### PR DESCRIPTION
## Description
The same offset calculation (m_scroller.GetValue() / m_layout->Size()) was performed identically in both Process() and Render(). Cache the result from Process() and reuse it in Render() to avoid the redundant floating-point division.

## Motivation and context
Performance

## How has this been tested?
Kodi 22 master on Windows, CoreELEC 21.3 p3i on Ugoos AM6B+

## What is the effect on users?
Better performance

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
