### PR TITLE
[Games] Improvements for libretro shader presets support

### DIFF
--- a/xbmc/cores/RetroPlayer/shaders/IShader.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShader.h
@@ -29,20 +29,22 @@ public:
   /*!
    * \brief Construct the video shader instance
    *
-   * \param shaderSource Source code of the shader (both vertex and pixel/fragment)
+   * \param passIdx Index of the video shader pass in the preset
+   * \param passAlias Alias name for the video shader pass
    * \param shaderPath Full path to the shader file
+   * \param shaderSource Source code of the shader (both vertex and pixel/fragment)
    * \param shaderParameters Struct with all parameters pertaining to the shader
    * \param luts Look-up textures pertaining to the shader
-   * \param passIdx Index of the video shader pass
    * \param frameCountMod Modulo applied to the frame count before sending it to the shader
    *
    * \return Returns false if creating the shader failed, true otherwise
    */
-  virtual bool Create(std::string shaderSource,
+  virtual bool Create(unsigned int passIdx,
+                      std::string passAlias,
                       std::string shaderPath,
+                      std::string shaderSource,
                       ShaderParameterMap shaderParameters,
                       std::vector<std::shared_ptr<IShaderLut>> luts,
-                      unsigned int passIdx,
                       unsigned int frameCountMod = 0) = 0;
 
   /*!

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -27,11 +27,12 @@ CShaderGL::~CShaderGL()
   Destroy();
 }
 
-bool CShaderGL::Create(std::string shaderSource,
+bool CShaderGL::Create(unsigned int passIdx,
+                       std::string passAlias,
                        std::string shaderPath,
+                       std::string shaderSource,
                        ShaderParameterMap shaderParameters,
                        std::vector<std::shared_ptr<IShaderLut>> luts,
-                       unsigned int passIdx,
                        unsigned int frameCountMod)
 {
   if (shaderPath.empty())
@@ -40,11 +41,12 @@ bool CShaderGL::Create(std::string shaderSource,
     return false;
   }
 
-  m_shaderSource = CShaderUtils::StripParameterPragmas(std::move(shaderSource));
+  m_passIdx = passIdx;
+  m_passAlias = std::move(passAlias);
   m_shaderPath = std::move(shaderPath);
+  m_shaderSource = CShaderUtils::StripParameterPragmas(std::move(shaderSource));
   m_shaderParameters = std::move(shaderParameters);
   m_luts = std::move(luts);
-  m_passIdx = passIdx;
   m_frameCountMod = frameCountMod;
   m_shaderProgram = glCreateProgram();
 

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -334,7 +334,7 @@ CShaderGL::UniformInputs CShaderGL::GetInputData(uint64_t frameCount) const
       // Current frame count that can be modulo'ed
       static_cast<GLint>(frameCount), // frame_count
       // Time always flows forward
-      1.0f // frame_direction
+      1 // frame_direction
   };
   return input;
 }
@@ -362,7 +362,7 @@ void CShaderGL::GetUniformLocs()
 void CShaderGL::SetShaderParameters(CShaderTextureGL& sourceTexture)
 {
   // Set shader uniforms
-  glUniform1f(m_FrameDirectionLoc, m_uniformInputs.frame_direction);
+  glUniform1i(m_FrameDirectionLoc, m_uniformInputs.frame_direction);
   glUniform1i(m_FrameCountLoc, m_uniformInputs.frame_count);
   glUniform2f(m_OutputSizeLoc, m_uniformInputs.output_size.x, m_uniformInputs.output_size.y);
   glUniform2f(m_TextureSizeLoc, m_uniformInputs.texture_size.x, m_uniformInputs.texture_size.y);

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -68,6 +68,7 @@ private:
     float2 input_size;
     float2 texture_size;
     GLuint texture;
+    std::string alias;
   };
 
   void UpdateUniformInputs(IShaderTexture& sourceTexture,

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -31,11 +31,12 @@ public:
   CShaderGL& operator=(CShaderGL&&) = delete;
 
   // Implementation of IShader
-  bool Create(std::string shaderSource,
+  bool Create(unsigned int passIdx,
+              std::string passAlias,
               std::string shaderPath,
+              std::string shaderSource,
               ShaderParameterMap shaderParameters,
               std::vector<std::shared_ptr<IShaderLut>> luts,
-              unsigned int passIdx,
               unsigned int frameCountMod = 0) override;
   void Render(IShaderTexture& source, IShaderTexture& target) override;
   void SetSizes(const float2& prevSize,
@@ -79,17 +80,23 @@ private:
   void GetUniformLocs();
   void SetShaderParameters(CShaderTextureGL& sourceTexture);
 
-  // Currently loaded shader's source code
-  std::string m_shaderSource;
+  // Index of the video shader pass in the preset
+  unsigned int m_passIdx{0};
+
+  // Alias name for the video shader pass
+  std::string m_passAlias;
 
   // Currently loaded shader's relative path
   std::string m_shaderPath;
+
+  // Currently loaded shader's source code
+  std::string m_shaderSource;
 
   // Struct with all parameters pertaining to the shader
   ShaderParameterMap m_shaderParameters;
 
   // Look-up textures pertaining to the shader
-  std::vector<std::shared_ptr<IShaderLut>> m_luts; //! @todo Back to DX maybe
+  std::vector<std::shared_ptr<IShaderLut>> m_luts;
 
   // Resolution of the input of the shader
   float2 m_inputSize;
@@ -105,9 +112,6 @@ private:
 
   // Projection matrix
   std::array<std::array<GLfloat, 4>, 4> m_MVP;
-
-  // Index of the video shader pass
-  unsigned int m_passIdx{0};
 
   // Value to modulo (%) frame count with (unused if 0)
   unsigned int m_frameCountMod{0};

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -59,7 +59,7 @@ private:
     float2 texture_size;
     float2 output_size;
     GLint frame_count;
-    GLfloat frame_direction;
+    GLint frame_direction;
   };
 
   struct UniformFrameInputs

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
@@ -31,13 +31,13 @@ bool CShaderPresetGL::CreateShaders()
 {
   const auto numPasses = static_cast<unsigned int>(m_passes.size());
 
-  //! @todo Is this pass specific?
-  std::vector<std::shared_ptr<IShaderLut>> passLUTsGL;
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
     const ShaderPass& pass = m_passes[shaderIdx];
     const auto numPassLuts = static_cast<unsigned int>(pass.luts.size());
 
+    //! @todo Is this pass specific?
+    std::vector<std::shared_ptr<IShaderLut>> passLUTsGL;
     for (unsigned int i = 0; i < numPassLuts; ++i)
     {
       const ShaderLut& lutStruct = pass.luts[i];
@@ -56,8 +56,8 @@ bool CShaderPresetGL::CreateShaders()
     // Get only the parameters belonging to this specific shader
     ShaderParameterMap passParameters = GetShaderParameters(pass.parameters, pass.vertexSource);
 
-    if (!videoShader->Create(shaderSource, shaderPath, passParameters, passLUTsGL, shaderIdx,
-                             pass.frameCountMod))
+    if (!videoShader->Create(shaderIdx, pass.alias, shaderPath, shaderSource,
+                             std::move(passParameters), std::move(passLUTsGL), pass.frameCountMod))
     {
       CLog::Log(LOGERROR, "CShaderPresetGL::CreateShaders: Couldn't create a video shader");
       return false;

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
@@ -319,7 +319,7 @@ CShaderGLES::UniformInputs CShaderGLES::GetInputData(uint64_t frameCount)
       // Current frame count that can be modulo'ed
       static_cast<GLint>(frameCount), // frame_count
       // Time always flows forward
-      1.0f // frame_direction
+      1 // frame_direction
   };
   return input;
 }
@@ -347,7 +347,7 @@ void CShaderGLES::GetUniformLocs()
 void CShaderGLES::SetShaderParameters(CShaderTextureGLES& sourceTexture)
 {
   // Set shader uniforms
-  glUniform1f(m_FrameDirectionLoc, m_uniformInputs.frame_direction);
+  glUniform1i(m_FrameDirectionLoc, m_uniformInputs.frame_direction);
   glUniform1i(m_FrameCountLoc, m_uniformInputs.frame_count);
   glUniform2f(m_OutputSizeLoc, m_uniformInputs.output_size.x, m_uniformInputs.output_size.y);
   glUniform2f(m_TextureSizeLoc, m_uniformInputs.texture_size.x, m_uniformInputs.texture_size.y);

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
@@ -27,11 +27,12 @@ CShaderGLES::~CShaderGLES()
   Destroy();
 }
 
-bool CShaderGLES::Create(std::string shaderSource,
+bool CShaderGLES::Create(unsigned int passIdx,
+                         std::string passAlias,
                          std::string shaderPath,
+                         std::string shaderSource,
                          ShaderParameterMap shaderParameters,
                          std::vector<std::shared_ptr<IShaderLut>> luts,
-                         unsigned int passIdx,
                          unsigned int frameCountMod)
 {
   if (shaderPath.empty())
@@ -40,11 +41,12 @@ bool CShaderGLES::Create(std::string shaderSource,
     return false;
   }
 
-  m_shaderSource = CShaderUtils::StripParameterPragmas(std::move(shaderSource));
+  m_passIdx = passIdx;
+  m_passAlias = std::move(passAlias);
   m_shaderPath = std::move(shaderPath);
+  m_shaderSource = CShaderUtils::StripParameterPragmas(std::move(shaderSource));
   m_shaderParameters = std::move(shaderParameters);
   m_luts = std::move(luts);
-  m_passIdx = passIdx;
   m_frameCountMod = frameCountMod;
   m_shaderProgram = glCreateProgram();
 
@@ -307,7 +309,7 @@ void CShaderGLES::UpdateUniformInputs(
   }
 }
 
-CShaderGLES::UniformInputs CShaderGLES::GetInputData(uint64_t frameCount)
+CShaderGLES::UniformInputs CShaderGLES::GetInputData(uint64_t frameCount) const
 {
   if (m_frameCountMod != 0)
     frameCount %= m_frameCountMod;
@@ -324,7 +326,7 @@ CShaderGLES::UniformInputs CShaderGLES::GetInputData(uint64_t frameCount)
   return input;
 }
 
-CShaderGLES::UniformFrameInputs CShaderGLES::GetFrameInputData(GLuint texture)
+CShaderGLES::UniformFrameInputs CShaderGLES::GetFrameInputData(GLuint texture) const
 {
   const UniformFrameInputs frameInput = {
       {m_inputSize}, // input_size

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
@@ -31,11 +31,12 @@ public:
   CShaderGLES& operator=(CShaderGLES&&) = delete;
 
   // Implementation of IShader
-  bool Create(std::string shaderSource,
+  bool Create(unsigned int passIdx,
+              std::string passAlias,
               std::string shaderPath,
+              std::string shaderSource,
               ShaderParameterMap shaderParameters,
               std::vector<std::shared_ptr<IShaderLut>> luts,
-              unsigned int passIdx,
               unsigned int frameCountMod = 0) override;
   void Render(IShaderTexture& source, IShaderTexture& target) override;
   void SetSizes(const float2& prevSize,
@@ -73,23 +74,29 @@ private:
                            const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
                            const std::vector<std::unique_ptr<IShader>>& pShaders,
                            uint64_t frameCount);
-  UniformInputs GetInputData(uint64_t frameCount = 0);
-  UniformFrameInputs GetFrameInputData(GLuint texture);
+  UniformInputs GetInputData(uint64_t frameCount = 0) const;
+  UniformFrameInputs GetFrameInputData(GLuint texture) const;
   UniformFrameInputs GetFrameUniformInputs() const { return m_uniformFrameInputs; }
   void GetUniformLocs();
   void SetShaderParameters(CShaderTextureGLES& sourceTexture);
 
-  // Currently loaded shader's source code
-  std::string m_shaderSource;
+  // Index of the video shader pass in the preset
+  unsigned int m_passIdx{0};
+
+  // Alias name for the video shader pass
+  std::string m_passAlias;
 
   // Currently loaded shader's relative path
   std::string m_shaderPath;
+
+  // Currently loaded shader's source code
+  std::string m_shaderSource;
 
   // Struct with all parameters pertaining to the shader
   ShaderParameterMap m_shaderParameters;
 
   // Look-up textures pertaining to the shader
-  std::vector<std::shared_ptr<IShaderLut>> m_luts; //! @todo Back to DX maybe
+  std::vector<std::shared_ptr<IShaderLut>> m_luts;
 
   // Resolution of the input of the shader
   float2 m_inputSize;
@@ -105,9 +112,6 @@ private:
 
   // Projection matrix
   std::array<std::array<GLfloat, 4>, 4> m_MVP;
-
-  // Index of the video shader pass
-  unsigned int m_passIdx{0};
 
   // Value to modulo (%) frame count with (unused if 0)
   unsigned int m_frameCountMod{0};

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
@@ -68,6 +68,7 @@ private:
     float2 input_size;
     float2 texture_size;
     GLuint texture;
+    std::string alias;
   };
 
   void UpdateUniformInputs(IShaderTexture& sourceTexture,

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
@@ -59,7 +59,7 @@ private:
     float2 texture_size;
     float2 output_size;
     GLint frame_count;
-    GLfloat frame_direction;
+    GLint frame_direction;
   };
 
   struct UniformFrameInputs

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
@@ -31,13 +31,13 @@ bool CShaderPresetGLES::CreateShaders()
 {
   const auto numPasses = static_cast<unsigned int>(m_passes.size());
 
-  //! @todo Is this pass specific?
-  std::vector<std::shared_ptr<IShaderLut>> passLUTsGL;
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
     const ShaderPass& pass = m_passes[shaderIdx];
     const auto numPassLuts = static_cast<unsigned int>(pass.luts.size());
 
+    //! @todo Is this pass specific?
+    std::vector<std::shared_ptr<IShaderLut>> passLUTsGL;
     for (unsigned int i = 0; i < numPassLuts; ++i)
     {
       const ShaderLut& lutStruct = pass.luts[i];
@@ -56,8 +56,8 @@ bool CShaderPresetGLES::CreateShaders()
     // Get only the parameters belonging to this specific shader
     ShaderParameterMap passParameters = GetShaderParameters(pass.parameters, pass.vertexSource);
 
-    if (!videoShader->Create(shaderSource, shaderPath, passParameters, passLUTsGL, shaderIdx,
-                             pass.frameCountMod))
+    if (!videoShader->Create(shaderIdx, pass.alias, shaderPath, shaderSource,
+                             std::move(passParameters), std::move(passLUTsGL), pass.frameCountMod))
     {
       CLog::Log(LOGERROR, "CShaderPresetGLES::CreateShaders: Couldn't create a video shader");
       return false;

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
@@ -31,11 +31,12 @@ CShaderDX::~CShaderDX()
     m_pInputBuffer->Release();
 }
 
-bool CShaderDX::Create(std::string shaderSource,
+bool CShaderDX::Create(unsigned int passIdx,
+                       std::string passAlias,
                        std::string shaderPath,
+                       std::string shaderSource,
                        ShaderParameterMap shaderParameters,
                        std::vector<std::shared_ptr<IShaderLut>> luts,
-                       unsigned int passIdx,
                        unsigned int frameCountMod)
 {
   if (shaderPath.empty())
@@ -44,11 +45,12 @@ bool CShaderDX::Create(std::string shaderSource,
     return false;
   }
 
-  m_shaderSource = std::move(shaderSource);
+  m_passIdx = passIdx;
+  m_passAlias = std::move(passAlias);
   m_shaderPath = std::move(shaderPath);
+  m_shaderSource = std::move(shaderSource);
   m_shaderParameters = std::move(shaderParameters);
   m_luts = std::move(luts);
-  m_passIdx = passIdx;
   m_frameCountMod = frameCountMod;
   //m_pSampler = reinterpret_cast<ID3D11SamplerState*>(sampler);
 

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
@@ -30,11 +30,12 @@ public:
   ~CShaderDX() override;
 
   // Implementation of IShader
-  bool Create(std::string shaderSource,
+  bool Create(unsigned int passIdx,
+              std::string passAlias,
               std::string shaderPath,
+              std::string shaderSource,
               ShaderParameterMap shaderParameters,
               std::vector<std::shared_ptr<IShaderLut>> luts,
-              unsigned int passIdx,
               unsigned int frameCountMod = 0) override;
   void Render(IShaderTexture& source, IShaderTexture& target) override;
   void SetSizes(const float2& prevSize,
@@ -90,17 +91,23 @@ private:
   cbInput GetInputData(uint64_t frameCount = 0) const;
   void SetShaderParameters(const CD3DTexture& sourceTexture);
 
-  // Currently loaded shader's source code
-  std::string m_shaderSource;
+  // Index of the video shader pass
+  unsigned int m_passIdx{0};
+
+  // Alias name for the video shader pass
+  std::string m_passAlias;
 
   // Currently loaded shader's relative path
   std::string m_shaderPath;
+
+  // Currently loaded shader's source code
+  std::string m_shaderSource;
 
   // Struct with all parameters pertaining to the shader
   ShaderParameterMap m_shaderParameters;
 
   // Look-up textures pertaining to the shader
-  std::vector<std::shared_ptr<IShaderLut>> m_luts; //! @todo Back to DX maybe
+  std::vector<std::shared_ptr<IShaderLut>> m_luts;
 
   // Resolution of the input of the shader
   float2 m_inputSize;
@@ -117,11 +124,7 @@ private:
   // Projection matrix
   DirectX::XMFLOAT4X4 m_MVP{};
 
-  // Index of the video shader pass
-  unsigned int m_passIdx{0};
-
-  // Value to modulo (%) frame count with
-  // Unused if 0
+  // Value to modulo (%) frame count with (unused if 0)
   unsigned int m_frameCountMod{0};
 
   // Holds the data bound to the input cbuffer (cbInput here)

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
@@ -31,14 +31,13 @@ bool CShaderPresetDX::CreateShaders()
 {
   const auto numPasses = static_cast<unsigned int>(m_passes.size());
 
-  //! @todo Is this pass specific?
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
-    std::vector<std::shared_ptr<IShaderLut>> passLUTsDX;
-
     const ShaderPass& pass = m_passes[shaderIdx];
     const auto numPassLuts = static_cast<unsigned int>(pass.luts.size());
 
+    //! @todo Is this pass specific?
+    std::vector<std::shared_ptr<IShaderLut>> passLUTsDX;
     for (unsigned int i = 0; i < numPassLuts; ++i)
     {
       const ShaderLut& lutStruct = pass.luts[i];
@@ -57,8 +56,8 @@ bool CShaderPresetDX::CreateShaders()
     // Get only the parameters belonging to this specific shader
     ShaderParameterMap passParameters = GetShaderParameters(pass.parameters, pass.vertexSource);
 
-    if (!videoShader->Create(shaderSource, shaderPath, std::move(passParameters),
-                             std::move(passLUTsDX), shaderIdx, pass.frameCountMod))
+    if (!videoShader->Create(shaderIdx, pass.alias, shaderPath, shaderSource,
+                             std::move(passParameters), std::move(passLUTsDX), pass.frameCountMod))
     {
       CLog::Log(LOGERROR, "CShaderPresetDX::CreateShaders: Couldn't create a video shader");
       return false;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR adds support for the video shader pass aliases and fixes wrong _FrameDirection_ GL uniform type.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There was a hope that adding the shader pass alias support will make the _CRT-Royale_ shader work, but unfortunately, it turned out that it is not enough (it still renders black screen). At least we've got a few steps closer to the full RetroArch shader compatibility and I've found and fixed several other minor issues along the way.

Most notable is the fix for the _FrameDirection_ GL uniform type. It was copied from the Windows version, but the Windows version is using _CG_ shaders and the specification for the _CG_ shaders differs from the _GLSL_ (_float_ vs _int_). The _VHS_ shader preset was triggering a GL error because of the wrong type. There are no more GL errors after the fix and the _VHS_ preset now shows the blinking "Play" OSD like in RetroArch.

EDIT: There are two more items remaining on my _TODO_ list regarding the video shader preset support:

1. The LUTs are currently being loaded for each pass separately, but according to the specification they should be common for all passes in the preset.

2. We should move all calls to `glGetUniformLocation()` from the `CShaderGL::SetShaderParameters()` (which is called every frame) to the `CShaderGL::GetUniformLocs()`. We need to cache the values in some kind of array and reuse them when doing the rendering.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Linux / Wayland / OpenGL and GLES

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Fully working _VHS_ shader preset (and possibly other presets using the _FrameDirection_ uniform) and added support for shader preset pass aliases.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
