### PR TITLE
[VideoDatabase][Video] Fix episode duration in database and track streamdetails source.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -343,6 +343,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
   {
     CStreamDetailSubtitle* sub = new CStreamDetailSubtitle();
     sub->m_strLanguage = subs[i].m_strLanguage;
+    sub->SetSource(CStreamDetail::MEDIA);
     details.AddStream(sub);
     result = true;
   }
@@ -482,6 +483,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
         if (!GetDetailsFromFrame(vstream, pDemux, *p))
           CLog::LogF(LOGERROR, "Failed to get HDR details from frame");
       }
+      p->SetSource(CStreamDetail::MEDIA);
 
       // stack handling
       if (URIUtils::IsStack(path))
@@ -528,6 +530,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
       p->m_iChannels = static_cast<CDemuxStreamAudio*>(stream)->iChannels;
       p->m_strLanguage = stream->language;
       p->m_strCodec = pDemux->GetStreamCodecName(stream->demuxerId, stream->uniqueId);
+      p->SetSource(CStreamDetail::MEDIA);
       details.AddStream(p);
       retVal = true;
     }
@@ -536,6 +539,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
     {
       CStreamDetailSubtitle *p = new CStreamDetailSubtitle();
       p->m_strLanguage = stream->language;
+      p->SetSource(CStreamDetail::MEDIA);
       details.AddStream(p);
       retVal = true;
     }
@@ -604,6 +608,7 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const std::string &path, CStream
       CStreamDetailSubtitle *dsub = new CStreamDetailSubtitle();
       std::string lang = stream->language;
       dsub->m_strLanguage = g_LangCodeExpander.ConvertToISO6392B(lang);
+      dsub->SetSource(CStreamDetail::MEDIA);
       details.AddStream(dsub);
     }
     return true;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5520,20 +5520,20 @@ void CVideoPlayer::UpdateFileItemStreamDetails(CFileItem& item, UpdateStreamDeta
   CVideoInfoTag* info = item.GetVideoInfoTag();
   GetVideoStreamInfo(CURRENT_STREAM, videoInfo);
   info->m_streamDetails.SetStreams(videoInfo, m_processInfo->GetMaxTime() / 1000, audioInfo,
-                                   subtitleInfo);
+                                   subtitleInfo, CStreamDetail::MEDIA);
 
   //grab all the audio and subtitle info and save it
 
   for (int i = 0; i < GetAudioStreamCount(); i++)
   {
     GetAudioStreamInfo(i, audioInfo);
-    info->m_streamDetails.AddStream(new CStreamDetailAudio(audioInfo));
+    info->m_streamDetails.AddStream(new CStreamDetailAudio(audioInfo, CStreamDetail::MEDIA));
   }
 
   for (int i = 0; i < GetSubtitleCount(); i++)
   {
     GetSubtitleStreamInfo(i, subtitleInfo);
-    info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitleInfo));
+    info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitleInfo, CStreamDetail::MEDIA));
   }
 }
 

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -165,10 +165,8 @@ bool CGUIDialogSimpleMenu::ShowPlaylistSelection(CFileItem& item)
       item.SetProperty("original_listitem_url", originalDynPath);
 
       // If streamdetails are already present they are from an nfo and should not be overwritten
-      //  unless forced playlist selection (ie. choose playlist selected from the context menu) - given we
-      //  don't know the source of the original streamdetails (nfo or previous playlist) we always overwrite
-      // @todo - update when streamdetails source tracking is added
-      if (!item.GetVideoInfoTag()->HasStreamDetails() || forcePlaylistSelection)
+      //  unless forced playlist selection (ie. choose playlist selected from the context menu)
+      if (!item.GetVideoInfoTag()->HasNFOStreamDetails() || forcePlaylistSelection)
         item.GetVideoInfoTag()->m_streamDetails = item_new->GetVideoInfoTag()->m_streamDetails;
 
       return true;

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -248,17 +248,18 @@ void SetStreamDetails(const CURL& url,
   if (!title.videoStreams.empty())
     info->m_streamDetails.SetStreams(title.videoStreams[0],
                                      static_cast<int>(title.duration.count() / 1000),
-                                     AudioStreamInfo{}, SubtitleStreamInfo{});
+                                     AudioStreamInfo{}, SubtitleStreamInfo{}, CStreamDetail::MEDIA);
   else
-    info->m_streamDetails.SetStreams(VideoStreamInfo{}, 0, AudioStreamInfo{}, SubtitleStreamInfo{});
+    info->m_streamDetails.SetStreams(VideoStreamInfo{}, 0, AudioStreamInfo{}, SubtitleStreamInfo{},
+                                     CStreamDetail::MEDIA);
 
   // Audio streams
   for (const auto& audio : title.audioStreams)
-    info->m_streamDetails.AddStream(new CStreamDetailAudio(audio));
+    info->m_streamDetails.AddStream(new CStreamDetailAudio(audio, CStreamDetail::MEDIA));
 
   // Subtitles
   for (const auto& subtitle : title.pgStreams)
-    info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitle));
+    info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitle, CStreamDetail::MEDIA));
 }
 
 std::shared_ptr<CFileItem> GetFileItem(const CURL& url,

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -1082,6 +1082,7 @@ namespace XBMCAddon
 
     void InfoTagVideo::addStreamRaw(CVideoInfoTag* infoTag, CStreamDetail* stream)
     {
+      infoTag->m_streamDetails.SetSources(CStreamDetail::MEDIA);
       infoTag->m_streamDetails.AddStream(stream);
     }
 

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1154,6 +1154,7 @@ int PopulateTagFromObject(CVideoInfoTag& tag,
       detail->m_iChannels = resource->m_NbAudioChannels;
       tag.m_streamDetails.AddStream(detail);
     }
+    tag.m_streamDetails.SetSources(CStreamDetail::MEDIA);
   }
   return NPT_SUCCESS;
 }

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -14,16 +14,28 @@
 #include "utils/LangCodeExpander.h"
 #include "utils/Variant.h"
 
-#include <math.h>
+#include <algorithm>
+#include <cmath>
+#include <ranges>
 
 const float VIDEOASPECT_EPSILON = 0.025f;
+
+CStreamDetail::Source CStreamDetail::GetSource() const
+{
+  return m_source;
+}
+
+void CStreamDetail::SetSource(Source source)
+{
+  m_source = source;
+}
 
 CStreamDetailVideo::CStreamDetailVideo() :
   CStreamDetail(CStreamDetail::VIDEO)
 {
 }
 
-CStreamDetailVideo::CStreamDetailVideo(const VideoStreamInfo& info, int duration)
+CStreamDetailVideo::CStreamDetailVideo(const VideoStreamInfo& info, int duration, Source source)
   : CStreamDetail(CStreamDetail::VIDEO),
     m_iWidth(info.width),
     m_iHeight(info.height),
@@ -35,6 +47,7 @@ CStreamDetailVideo::CStreamDetailVideo(const VideoStreamInfo& info, int duration
     m_strHdrType(CStreamDetails::HdrTypeToString(info.hdrType)),
     m_strHdrDetail(info.hdrDetail)
 {
+  m_source = source;
 }
 
 void CStreamDetailVideo::Archive(CArchive& ar)
@@ -50,6 +63,7 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     ar << m_strLanguage;
     ar << m_strHdrType;
     ar << m_strHdrDetail;
+    ar << m_source;
   }
   else
   {
@@ -62,6 +76,9 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     ar >> m_strLanguage;
     ar >> m_strHdrType;
     ar >> m_strHdrDetail;
+    int s;
+    ar >> s;
+    m_source = static_cast<Source>(s);
   }
 }
 void CStreamDetailVideo::Serialize(CVariant& value) const
@@ -75,6 +92,7 @@ void CStreamDetailVideo::Serialize(CVariant& value) const
   value["language"] = m_strLanguage;
   value["hdrtype"] = m_strHdrType;
   value["hdrdetail"] = m_strHdrDetail;
+  value["source"] = m_source;
 }
 
 bool CStreamDetailVideo::IsWorseThan(const CStreamDetail &that) const
@@ -92,12 +110,13 @@ CStreamDetailAudio::CStreamDetailAudio() :
 {
 }
 
-CStreamDetailAudio::CStreamDetailAudio(const AudioStreamInfo &info) :
-  CStreamDetail(CStreamDetail::AUDIO),
-  m_iChannels(info.channels),
-  m_strCodec(info.codecName),
-  m_strLanguage(info.language)
+CStreamDetailAudio::CStreamDetailAudio(const AudioStreamInfo& info, Source source)
+  : CStreamDetail(CStreamDetail::AUDIO),
+    m_iChannels(info.channels),
+    m_strCodec(info.codecName),
+    m_strLanguage(info.language)
 {
+  m_source = source;
 }
 
 void CStreamDetailAudio::Archive(CArchive& ar)
@@ -107,12 +126,16 @@ void CStreamDetailAudio::Archive(CArchive& ar)
     ar << m_strCodec;
     ar << m_strLanguage;
     ar << m_iChannels;
+    ar << m_source;
   }
   else
   {
     ar >> m_strCodec;
     ar >> m_strLanguage;
     ar >> m_iChannels;
+    int s;
+    ar >> s;
+    m_source = static_cast<Source>(s);
   }
 }
 void CStreamDetailAudio::Serialize(CVariant& value) const
@@ -120,6 +143,7 @@ void CStreamDetailAudio::Serialize(CVariant& value) const
   value["codec"] = m_strCodec;
   value["language"] = m_strLanguage;
   value["channels"] = m_iChannels;
+  value["source"] = m_source;
 }
 
 bool CStreamDetailAudio::IsWorseThan(const CStreamDetail &that) const
@@ -143,10 +167,11 @@ CStreamDetailSubtitle::CStreamDetailSubtitle() :
 {
 }
 
-CStreamDetailSubtitle::CStreamDetailSubtitle(const SubtitleStreamInfo &info) :
-  CStreamDetail(CStreamDetail::SUBTITLE),
-  m_strLanguage(info.language)
+CStreamDetailSubtitle::CStreamDetailSubtitle(const SubtitleStreamInfo& info, Source source)
+  : CStreamDetail(CStreamDetail::SUBTITLE),
+    m_strLanguage(info.language)
 {
+  m_source = source;
 }
 
 void CStreamDetailSubtitle::Archive(CArchive& ar)
@@ -154,10 +179,14 @@ void CStreamDetailSubtitle::Archive(CArchive& ar)
   if (ar.IsStoring())
   {
     ar << m_strLanguage;
+    ar << m_source;
   }
   else
   {
     ar >> m_strLanguage;
+    int s;
+    ar >> s;
+    m_source = static_cast<Source>(s);
   }
 }
 void CStreamDetailSubtitle::Serialize(CVariant& value) const
@@ -175,9 +204,10 @@ bool CStreamDetailSubtitle::IsWorseThan(const CStreamDetail &that) const
 
   // the best subtitle should be the one in the user's preferred language
   // If preferred language is set to "original" this is "eng"
-  return m_strLanguage.empty() || g_LangCodeExpander.CompareISO639Codes(
-                                      static_cast<const CStreamDetailSubtitle&>(that).m_strLanguage,
-                                      g_langInfo.GetSubtitleLanguage(true));
+  return m_strLanguage.empty() ||
+         g_LangCodeExpander.CompareISO639Codes(
+             dynamic_cast<const CStreamDetailSubtitle&>(that).m_strLanguage,
+             g_langInfo.GetSubtitleLanguage(true));
 }
 
 CStreamDetailVideo& CStreamDetailVideo::operator=(const CStreamDetailVideo& that)
@@ -205,6 +235,7 @@ CStreamDetailSubtitle& CStreamDetailSubtitle::operator=(const CStreamDetailSubti
   {
     this->m_pParent = that.m_pParent;
     this->m_strLanguage = that.m_strLanguage;
+    this->m_source = that.m_source;
   }
   return *this;
 }
@@ -219,13 +250,13 @@ CStreamDetails& CStreamDetails::operator=(const CStreamDetails &that)
       switch (iter->m_eType)
       {
       case CStreamDetail::VIDEO:
-        AddStream(new CStreamDetailVideo(static_cast<const CStreamDetailVideo&>(*iter)));
+        AddStream(new CStreamDetailVideo(dynamic_cast<const CStreamDetailVideo&>(*iter)));
         break;
       case CStreamDetail::AUDIO:
-        AddStream(new CStreamDetailAudio(static_cast<const CStreamDetailAudio&>(*iter)));
+        AddStream(new CStreamDetailAudio(dynamic_cast<const CStreamDetailAudio&>(*iter)));
         break;
       case CStreamDetail::SUBTITLE:
-        AddStream(new CStreamDetailSubtitle(static_cast<const CStreamDetailSubtitle&>(*iter)));
+        AddStream(new CStreamDetailSubtitle(dynamic_cast<const CStreamDetailSubtitle&>(*iter)));
         break;
       }
     }
@@ -682,17 +713,21 @@ std::string CStreamDetails::VideoAspectToAspectDescription(float fAspect)
   return "2.76";
 }
 
-bool CStreamDetails::SetStreams(const VideoStreamInfo& videoInfo, int videoDuration, const AudioStreamInfo& audioInfo, const SubtitleStreamInfo& subtitleInfo)
+bool CStreamDetails::SetStreams(const VideoStreamInfo& videoInfo,
+                                int videoDuration,
+                                const AudioStreamInfo& audioInfo,
+                                const SubtitleStreamInfo& subtitleInfo,
+                                CStreamDetail::Source source)
 {
   if (!videoInfo.valid && !audioInfo.valid && !subtitleInfo.valid)
     return false;
   Reset();
   if (videoInfo.valid)
-    AddStream(new CStreamDetailVideo(videoInfo, videoDuration));
+    AddStream(new CStreamDetailVideo(videoInfo, videoDuration, source));
   if (audioInfo.valid)
-    AddStream(new CStreamDetailAudio(audioInfo));
+    AddStream(new CStreamDetailAudio(audioInfo, source));
   if (subtitleInfo.valid)
-    AddStream(new CStreamDetailSubtitle(subtitleInfo));
+    AddStream(new CStreamDetailSubtitle(subtitleInfo, source));
   DetermineBestStreams();
   return true;
 }
@@ -713,4 +748,49 @@ std::string CStreamDetails::HdrTypeToString(StreamHdrType hdrType)
     default:
       return "";
   }
+}
+
+CStreamDetail::Source CStreamDetails::GetSource(CStreamDetail::StreamType type, int idx) const
+{
+  switch (type)
+  {
+    case CStreamDetail::VIDEO:
+    {
+      const CStreamDetailVideo* item =
+          dynamic_cast<const CStreamDetailVideo*>(GetNthStream(CStreamDetail::VIDEO, idx));
+      if (item)
+        return item->GetSource();
+      break;
+    }
+    case CStreamDetail::AUDIO:
+    {
+      const CStreamDetailAudio* item =
+          dynamic_cast<const CStreamDetailAudio*>(GetNthStream(CStreamDetail::AUDIO, idx));
+      if (item)
+        return item->GetSource();
+      break;
+    }
+    case CStreamDetail::SUBTITLE:
+    {
+      const CStreamDetailSubtitle* item =
+          dynamic_cast<const CStreamDetailSubtitle*>(GetNthStream(CStreamDetail::SUBTITLE, idx));
+      if (item)
+        return item->GetSource();
+      break;
+    }
+  }
+  return CStreamDetail::UNDEFINED;
+}
+
+CStreamDetail::Source CStreamDetails::GetSources() const
+{
+  if (!HasItems())
+    return CStreamDetail::UNDEFINED;
+  return std::ranges::max(m_vecItems | std::views::transform(&CStreamDetail::m_source));
+}
+
+void CStreamDetails::SetSources(CStreamDetail::Source source)
+{
+  for (const auto& s : m_vecItems)
+    s->SetSource(source);
 }

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -31,11 +31,24 @@ public:
     SUBTITLE
   };
 
+  // Source of the stream information
+  // Order is important - higher values (towards end of list) take precedence lower values
+  // when updating stream details
+  enum Source : uint8_t
+  {
+    UNDEFINED = 0,
+    MEDIA,
+    NFO
+  };
+
   explicit CStreamDetail(StreamType type) : m_eType(type), m_pParent(NULL) {}
   virtual ~CStreamDetail() = default;
   virtual bool IsWorseThan(const CStreamDetail &that) const = 0;
+  Source GetSource() const;
+  void SetSource(Source source);
 
   const StreamType m_eType;
+  Source m_source{UNDEFINED};
 
 protected:
   CStreamDetails *m_pParent;
@@ -46,7 +59,7 @@ class CStreamDetailVideo final : public CStreamDetail
 {
 public:
   CStreamDetailVideo();
-  CStreamDetailVideo(const VideoStreamInfo &info, int duration = 0);
+  CStreamDetailVideo(const VideoStreamInfo &info, int duration, Source source);
   CStreamDetailVideo(const CStreamDetailVideo&) = default;
   CStreamDetailVideo& operator=(const CStreamDetailVideo& that);
   void Archive(CArchive& ar) override;
@@ -69,7 +82,8 @@ class CStreamDetailAudio final : public CStreamDetail
 {
 public:
   CStreamDetailAudio();
-  CStreamDetailAudio(const AudioStreamInfo &info);
+  CStreamDetailAudio(const AudioStreamInfo& info, Source source);
+  CStreamDetailAudio(const CStreamDetailAudio&) = default;
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
   bool IsWorseThan(const CStreamDetail &that) const override;
@@ -83,7 +97,7 @@ class CStreamDetailSubtitle final : public CStreamDetail
 {
 public:
   CStreamDetailSubtitle();
-  CStreamDetailSubtitle(const SubtitleStreamInfo &info);
+  CStreamDetailSubtitle(const SubtitleStreamInfo& info, Source source);
   CStreamDetailSubtitle(const CStreamDetailSubtitle&) = default;
   CStreamDetailSubtitle& operator=(const CStreamDetailSubtitle &that);
   void Archive(CArchive& ar) override;
@@ -137,7 +151,16 @@ public:
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
 
-  bool SetStreams(const VideoStreamInfo& videoInfo, int videoDuration, const AudioStreamInfo& audioInfo, const SubtitleStreamInfo& subtitleInfo);
+  bool SetStreams(const VideoStreamInfo& videoInfo,
+                  int videoDuration,
+                  const AudioStreamInfo& audioInfo,
+                  const SubtitleStreamInfo& subtitleInfo,
+                  CStreamDetail::Source source);
+
+  CStreamDetail::Source GetSource(CStreamDetail::StreamType type, int idx) const;
+  CStreamDetail::Source GetSources() const;
+  void SetSources(CStreamDetail::Source source);
+
 private:
   CStreamDetail *NewStream(CStreamDetail::StreamType type);
   std::vector<std::unique_ptr<CStreamDetail>> m_vecItems;

--- a/xbmc/utils/test/TestStreamDetails.cpp
+++ b/xbmc/utils/test/TestStreamDetails.cpp
@@ -24,12 +24,15 @@ TEST(TestStreamDetails, General)
   video->m_strCodec = "h264";
   video->m_strStereoMode = "left_right";
   video->m_strLanguage = "eng";
+  video->SetSource(CStreamDetail::MEDIA);
 
   audio->m_iChannels = 2;
   audio->m_strCodec = "aac";
   audio->m_strLanguage = "eng";
+  audio->SetSource(CStreamDetail::MEDIA);
 
   subtitle->m_strLanguage = "eng";
+  subtitle->SetSource(CStreamDetail::MEDIA);
 
   a.AddStream(video);
   a.AddStream(audio);
@@ -44,6 +47,7 @@ TEST(TestStreamDetails, General)
   EXPECT_EQ(0, a.GetVideoHeight());
   EXPECT_EQ(0, a.GetVideoDuration());
   EXPECT_STREQ("", a.GetStereoMode().c_str());
+  EXPECT_EQ(CStreamDetail::MEDIA, a.GetSources());
 
   EXPECT_EQ(1, a.GetStreamCount(CStreamDetail::AUDIO));
   EXPECT_EQ(1, a.GetAudioStreamCount());

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3145,35 +3145,37 @@ bool CVideoDatabase::SetStreamDetailsForFileId(const CStreamDetails& details, in
   {
     m_pDS->exec(PrepareSQL("DELETE FROM streamdetails WHERE idFile = %i", idFile));
 
-    for (int i=1; i<=details.GetVideoStreamCount(); i++)
+    for (int i = 1; i <= details.GetVideoStreamCount(); i++)
     {
       m_pDS->exec(PrepareSQL(
           "INSERT INTO streamdetails "
           "(idFile, iStreamType, strVideoCodec, fVideoAspect, iVideoWidth, iVideoHeight, "
-          "iVideoDuration, strStereoMode, strVideoLanguage, strHdrType, strHdrDetail) "
-          "VALUES (%i,%i,'%s',%f,%i,%i,%i,'%s','%s','%s','%s')",
+          "iVideoDuration, strStereoMode, strVideoLanguage, strHdrType, strHdrDetail, iSource) "
+          "VALUES (%i,%i,'%s',%f,%i,%i,%i,'%s','%s','%s','%s',%i)",
           idFile, static_cast<int>(CStreamDetail::VIDEO), details.GetVideoCodec(i).c_str(),
           static_cast<double>(details.GetVideoAspect(i)), details.GetVideoWidth(i),
           details.GetVideoHeight(i), details.GetVideoDuration(i), details.GetStereoMode(i).c_str(),
           details.GetVideoLanguage(i).c_str(), details.GetVideoHdrType(i).c_str(),
-          details.GetVideoHdrDetail(i).c_str()));
+          details.GetVideoHdrDetail(i).c_str(), static_cast<int>(details.GetSource(CStreamDetail::VIDEO, i))));
     }
-    for (int i=1; i<=details.GetAudioStreamCount(); i++)
+    for (int i = 1; i <= details.GetAudioStreamCount(); i++)
     {
       m_pDS->exec(PrepareSQL(
           "INSERT INTO streamdetails "
-          "(idFile, iStreamType, strAudioCodec, iAudioChannels, strAudioLanguage) "
-          "VALUES (%i,%i,'%s',%i,'%s')",
+          "(idFile, iStreamType, strAudioCodec, iAudioChannels, strAudioLanguage, iSource) "
+          "VALUES (%i,%i,'%s',%i,'%s',%i)",
           idFile, static_cast<int>(CStreamDetail::AUDIO), details.GetAudioCodec(i).c_str(),
-          details.GetAudioChannels(i), details.GetAudioLanguage(i).c_str()));
+          details.GetAudioChannels(i), details.GetAudioLanguage(i).c_str(),
+          static_cast<int>(details.GetSource(CStreamDetail::AUDIO, i))));
     }
-    for (int i=1; i<=details.GetSubtitleStreamCount(); i++)
+    for (int i = 1; i <= details.GetSubtitleStreamCount(); i++)
     {
       m_pDS->exec(PrepareSQL("INSERT INTO streamdetails "
-                             "(idFile, iStreamType, strSubtitleLanguage) "
-                             "VALUES (%i,%i,'%s')",
+                             "(idFile, iStreamType, strSubtitleLanguage, iSource) "
+                             "VALUES (%i,%i,'%s',%i)",
                              idFile, static_cast<int>(CStreamDetail::SUBTITLE),
-                             details.GetSubtitleLanguage(i).c_str()));
+                             details.GetSubtitleLanguage(i).c_str(),
+                             static_cast<int>(details.GetSource(CStreamDetail::SUBTITLE, i))));
     }
 
     // update the runtime information, if empty
@@ -4418,6 +4420,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
           p->m_strLanguage = pDS->fv(12).get_asString();
           p->m_strHdrType = pDS->fv(13).get_asString();
           p->m_strHdrDetail = pDS->fv(14).get_asString();
+          p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
           details.AddStream(p);
           retVal = true;
           break;
@@ -4431,6 +4434,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
           else
             p->m_iChannels = pDS->fv(7).get_asInt();
           p->m_strLanguage = pDS->fv(8).get_asString();
+          p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
           details.AddStream(p);
           retVal = true;
           break;
@@ -4439,6 +4443,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
         {
           auto* p = new CStreamDetailSubtitle();
           p->m_strLanguage = pDS->fv(9).get_asString();
+          p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
           details.AddStream(p);
           retVal = true;
           break;

--- a/xbmc/video/VideoDatabaseDDL.cpp
+++ b/xbmc/video/VideoDatabaseDDL.cpp
@@ -156,7 +156,7 @@ void CVideoDatabaseDDL::CreateTables(CDatabase& db)
       "strVideoCodec text, fVideoAspect float, iVideoWidth integer, iVideoHeight integer, "
       "strAudioCodec text, iAudioChannels integer, strAudioLanguage text, "
       "strSubtitleLanguage text, iVideoDuration integer, strStereoMode text, "
-      "strVideoLanguage text, strHdrType text, strHdrDetail text)");
+      "strVideoLanguage text, strHdrType text, strHdrDetail text, iSource integer)");
 
   CLog::Log(LOGINFO, "create sets table");
   db.ExecuteQuery("CREATE TABLE sets ( idSet integer primary key, strSet text, strOverview text, "

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -1181,6 +1181,8 @@ void CVideoDatabase::UpdateTables(int iVersion)
                      "              AND e.c%02d = streamdetails.iVideoDuration)",
                      LOCAL_VIDEODB_ID_EPISODE_RUNTIME, LOCAL_VIDEODB_ID_EPISODE_RUNTIME);
     m_pDS->exec(sql);
+
+    m_pDS->exec("ALTER TABLE streamdetails ADD iSource INTEGER DEFAULT 0");
   }
 }
 

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -1150,9 +1150,41 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
   if (iVersion < 144)
     m_pDS->exec("ALTER TABLE streamdetails ADD strHdrDetail text");
+
+  if (iVersion < 145)
+  {
+    constexpr int LOCAL_VIDEODB_ID_EPISODE_RUNTIME = 9;
+
+    std::string sql{PrepareSQL("UPDATE episode "
+                               "SET c%02d = (SELECT iVideoDuration FROM streamdetails AS s "
+                               "WHERE s.idFile = episode.idFile "
+                               " AND s.iStreamType = 0 "
+                               " AND s.iVideoDuration > 0 "
+                               "LIMIT 1) "
+                               "WHERE episode.c%02d = 0 "
+                               " AND (SELECT iVideoDuration FROM streamdetails AS s "
+                               "      WHERE s.idFile = episode.idFile "
+                               "       AND s.iStreamType = 0 "
+                               "       AND s.iVideoDuration > 0 "
+                               "      LIMIT 1) IS NOT NULL",
+                               LOCAL_VIDEODB_ID_EPISODE_RUNTIME, LOCAL_VIDEODB_ID_EPISODE_RUNTIME)};
+    m_pDS->exec(sql);
+
+    sql = PrepareSQL("DELETE FROM streamdetails "
+                     "WHERE iVideoHeight = 0 AND iVideoWidth = 0 AND iStreamType = 0 "
+                     " AND (SELECT COUNT(*) FROM streamdetails AS s "
+                     "      WHERE s.idFile = streamdetails.idFile"
+                     "      ) = 1 "
+                     " AND EXISTS (SELECT 1 FROM episode e "
+                     "             WHERE e.idFile = streamdetails.idFile "
+                     "              AND e.c%02d > 0 "
+                     "              AND e.c%02d = streamdetails.iVideoDuration)",
+                     LOCAL_VIDEODB_ID_EPISODE_RUNTIME, LOCAL_VIDEODB_ID_EPISODE_RUNTIME);
+    m_pDS->exec(sql);
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 144;
+  return 145;
 }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1896,23 +1896,18 @@ CVideoInfoScanner::~CVideoInfoScanner()
                                      movieDetails.m_iSeason, movieDetails.m_iEpisode, strTitle);
     }
 
-    /* As HasStreamDetails() returns true for TV shows (because the scraper calls SetVideoInfoTag()
-     * directly to set the duration) a better test is just to see if we have any common flag info
-     * missing.  If we have already read an nfo file then this data should be populated, otherwise
-     * get it from the video file */
-
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
             CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
     {
       const auto& strmdetails = movieDetails.m_streamDetails;
-      if (strmdetails.GetVideoCodec(1).empty() || strmdetails.GetVideoHeight(1) == 0 ||
-          strmdetails.GetVideoWidth(1) == 0 || strmdetails.GetVideoDuration(1) == 0)
-
+      if (strmdetails.GetSources() < CStreamDetail::NFO)
       {
         CDVDFileInfo::GetFileStreamDetails(pItem);
-        CLog::Log(LOGDEBUG, "VideoInfoScanner: Extracted filestream details from video file {}",
-                  CURL::GetRedacted(path));
+        CLog::LogF(LOGDEBUG, "Extracted filestream details from video file {}",
+                   CURL::GetRedacted(path));
       }
+      else
+        CLog::LogF(LOGDEBUG, "Filestream details from NFO file");
     }
 
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to {}:{}", content,

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1544,6 +1544,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
         m_streamDetails.AddStream(p);
       }
     }
+    m_streamDetails.SetSources(CStreamDetail::NFO);
     m_streamDetails.DetermineBestStreams();
   }  /* if fileinfo */
 
@@ -1608,6 +1609,14 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
 bool CVideoInfoTag::HasStreamDetails() const
 {
   return m_streamDetails.HasItems();
+}
+
+bool CVideoInfoTag::HasNFOStreamDetails() const
+{
+  if (!HasStreamDetails())
+    return false;
+
+  return m_streamDetails.GetSources() >= CStreamDetail::NFO;
 }
 
 bool CVideoInfoTag::IsEmpty() const

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -96,6 +96,7 @@ public:
   const CDateTime& GetFirstAired() const;
   std::string GetCast(const std::string& separator, bool bIncludeRole = false) const;
   bool HasStreamDetails() const;
+  bool HasNFOStreamDetails() const;
   bool IsEmpty() const;
 
   const std::string& GetPath() const


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Following on from #27606.

Further examination suggests that bluray episodes scanned with TMDB TV Shows had their duration (from the scraper) stored in streamdetails where height/width = 0 and the duration field in episodes (c09) is 0.

However scanning with TheTVDB episodes.c09 is set correctly to the duration and there is no superfluous entry in streamdetails.

Commit 1 - Whilst @pkscout kindly looks into the scraper (now fixed), this is part of the fix to adjust the database.

Commit 2 - Track streamdetails origin (from media file or nfo)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
