### PR TITLE
VideoPlayer: Fix embedded subtitle delay

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3089,6 +3089,21 @@ void CVideoPlayer::HandleMessages()
         {
           CloseStream(m_CurrentSubtitle, false);
           OpenStream(m_CurrentSubtitle, st.demuxerId, st.id, st.source);
+
+          // For embedded subtitles the demuxer is ahead of playback (AV buffers
+          // are full), so the subtitle packets for the current playback time have
+          // already been read and discarded. Seek back to the current time so they
+          // get re-read, mirroring what audio stream switching does.
+          if (STREAM_SOURCE_MASK(st.source) == STREAM_SOURCE_DEMUX)
+          {
+            CDVDMsgPlayerSeek::CMode mode;
+            mode.time = static_cast<double>(GetUpdatedTime());
+            mode.backward = true;
+            mode.accurate = true;
+            mode.trickplay = true;
+            mode.sync = true;
+            m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
+          }
         }
       }
     }


### PR DESCRIPTION
## Description
Switching between embedded subtitle streams used to leave the newly selected subtitle blank for 10-20 seconds. The demuxer runs ahead of playback, so by the time you pick a different stream, its packets for the current position have already been read and thrown away. Nothing re-reads them until the demuxer happens to come back around.

This seeks the demuxer back to the current playback time when an embedded subtitle stream is changed, which is exactly what VideoPlayer already does when you switch audio streams. The packets get re-read and the subtitle shows up right away. There is a brief blip on the switch, the same trade-off audio switching already makes, and it was considered acceptable in the discussion given the alternative.

An earlier revision of this PR cached recent subtitle packets from every stream and replayed them on switch to avoid the blip. It didn't hold up across all content, so per the maintainer discussion it has been dropped in favour of the seek.

## Motivation and context
Embedded subtitles have shown up too late for years. For anyone who relies on subtitles for accessibility, a 10-20 second gap on every switch is a real problem, not a cosmetic one.

## How has this been tested?
Running in the CoreELEC p3i dev build. Internal and external subtitles appear immediately on switch, and users on that build have not reported any objectionable side effects.

## What is the effect on users?
Embedded subtitles appear in sync as soon as you select them, instead of after a long delay.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
