### PR TITLE
[Settings] Add Advanced Settings Reload Notification + Use in FileExtensionsProvider and Renderers

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -911,7 +911,7 @@ bool CFileItem::IsFileFolder(FileFolderType types) const
 
   if (CServiceBroker::IsAddonInterfaceUp() &&
       IsType(CServiceBroker::GetFileExtensionProvider().GetFileFolderExtensions().c_str()) &&
-      CServiceBroker::GetFileExtensionProvider().CanOperateExtension(m_strPath))
+      CFileExtensionProvider::CanOperateExtension(m_strPath))
     return true;
 
   if (static_cast<int>(types) & static_cast<int>(FileFolderType::ONBROWSE))

--- a/xbmc/rendering/RenderSystem.cpp
+++ b/xbmc/rendering/RenderSystem.cpp
@@ -21,12 +21,6 @@
 
 CRenderSystemBase::CRenderSystemBase()
 {
-  m_bRenderCreated = false;
-  m_bVSync = true;
-  m_maxTextureSize = 2048;
-  m_RenderVersionMajor = 0;
-  m_RenderVersionMinor = 0;
-  m_minDXTPitch = 0;
 }
 
 CRenderSystemBase::~CRenderSystemBase() = default;

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -23,7 +23,7 @@
  *   This interface is very basic since a lot of the actual details will go in to the derived classes
  */
 
-enum class DEPTH_CULLING
+enum class DepthCulling
 {
   OFF,
   BACK_TO_FRONT,
@@ -65,7 +65,7 @@ public:
   virtual void SetScissors(const CRect& rect) = 0;
   virtual void ResetScissors() = 0;
 
-  virtual void SetDepthCulling(DEPTH_CULLING culling) {}
+  virtual void SetDepthCulling(DepthCulling culling) {}
 
   virtual void CaptureStateBlock() = 0;
   virtual void ApplyStateBlock() = 0;

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -88,19 +88,19 @@ public:
   virtual void ShowSplash(const std::string& message);
 
 protected:
-  bool                m_bRenderCreated;
-  bool                m_bVSync;
-  unsigned int        m_maxTextureSize;
-  unsigned int        m_minDXTPitch;
+  bool m_bRenderCreated{false};
+  bool m_bVSync{true};
+  unsigned int m_maxTextureSize{2048};
+  unsigned int m_minDXTPitch{0};
 
-  std::string   m_RenderRenderer;
-  std::string   m_RenderVendor;
-  std::string   m_RenderVersion;
-  int          m_RenderVersionMinor;
-  int          m_RenderVersionMajor;
-  RenderStereoView m_stereoView = RenderStereoView::OFF;
-  RenderStereoMode m_stereoMode = RenderStereoMode::OFF;
-  bool m_limitedColorRange = false;
+  std::string m_RenderRenderer;
+  std::string m_RenderVendor;
+  std::string m_RenderVersion;
+  int m_RenderVersionMinor{0};
+  int m_RenderVersionMajor{0};
+  RenderStereoView m_stereoView{RenderStereoView::OFF};
+  RenderStereoMode m_stereoMode{RenderStereoMode::OFF};
+  bool m_limitedColorRange{false};
   bool m_transferPQ{false};
 
   std::unique_ptr<CGUIImage> m_splashImage;

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -585,16 +585,16 @@ ID3D11DepthStencilState* CRenderSystemDX::GetDepthStencilState()
 {
   switch (m_depthCulling)
   {
-    case DEPTH_CULLING::BACK_TO_FRONT:
+    case DepthCulling::BACK_TO_FRONT:
       return m_depthStencilStateRO.Get();
-    case DEPTH_CULLING::FRONT_TO_BACK:
+    case DepthCulling::FRONT_TO_BACK:
       return m_depthStencilStateRW.Get();
     default:
       return m_depthStencilState.Get();
   }
 }
 
-void CRenderSystemDX::SetDepthCulling(DEPTH_CULLING culling)
+void CRenderSystemDX::SetDepthCulling(DepthCulling culling)
 {
   if (!m_bRenderCreated)
     return;

--- a/xbmc/rendering/dx/RenderSystemDX.cpp
+++ b/xbmc/rendering/dx/RenderSystemDX.cpp
@@ -28,8 +28,6 @@
 #include "guilib/GUIShaderDX.h"
 #include "guilib/GUITextureD3D.h"
 #include "guilib/GUIWindowManager.h"
-#include "settings/AdvancedSettings.h"
-#include "settings/SettingsComponent.h"
 #include "utils/MathUtils.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
@@ -355,13 +353,13 @@ void CRenderSystemDX::InvalidateColorBuffer()
     return;
 
   // some platforms prefer a clear, instead of rendering over
-  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiGeometryClear)
+  if (GetClearFunction() == ClearFunction::FIXED_FUNCTION)
   {
     ClearBuffers(0);
     return;
   }
 
-  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiFrontToBackRendering)
+  if (!GetEnabledFrontToBackRendering())
     return;
 
   m_deviceResources->ClearDepthStencil();
@@ -423,7 +421,7 @@ bool CRenderSystemDX::ClearBuffers(KODI::UTILS::COLOR::Color color)
       m_deviceResources->ClearRenderTarget(pRTView, fColor);
   }
 
-  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiFrontToBackRendering)
+  if (GetEnabledFrontToBackRendering())
     m_deviceResources->ClearDepthStencil();
 
   return true;

--- a/xbmc/rendering/dx/RenderSystemDX.h
+++ b/xbmc/rendering/dx/RenderSystemDX.h
@@ -43,7 +43,7 @@ public:
   bool ScissorsCanEffectClipping() override;
   void SetScissors(const CRect &rect) override;
   void ResetScissors() override;
-  void SetDepthCulling(DEPTH_CULLING culling) override;
+  void SetDepthCulling(DepthCulling culling) override;
   void CaptureStateBlock() override;
   void ApplyStateBlock() override;
   void SetCameraPosition(const CPoint &camera, int screenWidth, int screenHeight, float stereoFactor = 0.f) override;
@@ -106,5 +106,5 @@ protected:
   XbmcThreads::ConditionVariable m_decodingEvent;
 
   std::shared_ptr<DX::DeviceResources> m_deviceResources;
-  DEPTH_CULLING m_depthCulling{DEPTH_CULLING::OFF};
+  DepthCulling m_depthCulling{DepthCulling::OFF};
 };

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2024 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -292,13 +292,13 @@ void CRenderSystemGL::InvalidateColorBuffer()
     return;
 
   // some platforms prefer a clear, instead of rendering over
-  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiGeometryClear)
+  if (GetClearFunction() == ClearFunction::FIXED_FUNCTION)
   {
     ClearBuffers(0);
     return;
   }
 
-  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiFrontToBackRendering)
+  if (!GetEnabledFrontToBackRendering())
     return;
 
   glClearDepthf(0);
@@ -324,7 +324,7 @@ bool CRenderSystemGL::ClearBuffers(KODI::UTILS::COLOR::Color color)
 
   GLbitfield flags = GL_COLOR_BUFFER_BIT;
 
-  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiFrontToBackRendering)
+  if (GetEnabledFrontToBackRendering())
   {
     glClearDepthf(0);
     glDepthMask(GL_TRUE);

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -553,20 +553,20 @@ void CRenderSystemGL::ResetScissors()
   SetScissors(CRect(0, 0, (float)m_width, (float)m_height));
 }
 
-void CRenderSystemGL::SetDepthCulling(DEPTH_CULLING culling)
+void CRenderSystemGL::SetDepthCulling(DepthCulling culling)
 {
-  if (culling == DEPTH_CULLING::OFF)
+  if (culling == DepthCulling::OFF)
   {
     glDisable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
   }
-  else if (culling == DEPTH_CULLING::BACK_TO_FRONT)
+  else if (culling == DepthCulling::BACK_TO_FRONT)
   {
     glEnable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
     glDepthFunc(GL_GEQUAL);
   }
-  else if (culling == DEPTH_CULLING::FRONT_TO_BACK)
+  else if (culling == DepthCulling::FRONT_TO_BACK)
   {
     glEnable(GL_DEPTH_TEST);
     glDepthMask(GL_TRUE);

--- a/xbmc/rendering/gl/RenderSystemGL.h
+++ b/xbmc/rendering/gl/RenderSystemGL.h
@@ -90,7 +90,7 @@ public:
   void SetScissors(const CRect &rect) override;
   void ResetScissors() override;
 
-  void SetDepthCulling(DEPTH_CULLING culling) override;
+  void SetDepthCulling(DepthCulling culling) override;
 
   void CaptureStateBlock() override;
   void ApplyStateBlock() override;

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -421,20 +421,20 @@ void CRenderSystemGLES::ResetScissors()
   SetScissors(CRect(0, 0, (float)m_width, (float)m_height));
 }
 
-void CRenderSystemGLES::SetDepthCulling(DEPTH_CULLING culling)
+void CRenderSystemGLES::SetDepthCulling(DepthCulling culling)
 {
-  if (culling == DEPTH_CULLING::OFF)
+  if (culling == DepthCulling::OFF)
   {
     glDisable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
   }
-  else if (culling == DEPTH_CULLING::BACK_TO_FRONT)
+  else if (culling == DepthCulling::BACK_TO_FRONT)
   {
     glEnable(GL_DEPTH_TEST);
     glDepthMask(GL_FALSE);
     glDepthFunc(GL_GEQUAL);
   }
-  else if (culling == DEPTH_CULLING::FRONT_TO_BACK)
+  else if (culling == DepthCulling::FRONT_TO_BACK)
   {
     glEnable(GL_DEPTH_TEST);
     glDepthMask(GL_TRUE);

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2024 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -206,10 +206,10 @@ void CRenderSystemGLES::InvalidateColorBuffer()
     return;
 
   // some platforms prefer a clear, instead of rendering over
-  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiGeometryClear)
+  if (GetClearFunction() == ClearFunction::FIXED_FUNCTION)
     ClearBuffers(0);
 
-  if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiFrontToBackRendering)
+  if (!GetEnabledFrontToBackRendering())
     return;
 
   glClearDepthf(0);
@@ -231,7 +231,7 @@ bool CRenderSystemGLES::ClearBuffers(KODI::UTILS::COLOR::Color color)
 
   GLbitfield flags = GL_COLOR_BUFFER_BIT;
 
-  if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiFrontToBackRendering)
+  if (GetEnabledFrontToBackRendering())
   {
     glClearDepthf(0);
     glDepthMask(GL_TRUE);

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -110,7 +110,7 @@ public:
   void SetScissors(const CRect& rect) override;
   void ResetScissors() override;
 
-  void SetDepthCulling(DEPTH_CULLING culling) override;
+  void SetDepthCulling(DepthCulling culling) override;
 
   void CaptureStateBlock() override;
   void ApplyStateBlock() override;

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -12,6 +12,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -87,9 +88,12 @@ private:
   void SetAddonExtensions();
   void SetAddonExtensions(ADDON::AddonType type);
 
+  void OnAdvancedSettingsLoaded();
+
   // Construction properties
   std::shared_ptr<CAdvancedSettings> m_advancedSettings;
   ADDON::CAddonMgr &m_addonManager;
+  std::optional<int> m_callbackId;
 
   mutable CCriticalSection m_critSection;
 
@@ -99,4 +103,14 @@ private:
 
   // Protocols from add-ons with encoded host names
   std::vector<std::string> m_encoded;
+
+  // Cached extensions lists
+  mutable std::optional<std::string> m_discStubExtensions;
+  mutable std::optional<std::string> m_musicExtensions;
+  mutable std::optional<std::string> m_pictureExtensions;
+  mutable std::optional<std::string> m_subtitlesExtensions;
+  mutable std::optional<std::string> m_videoExtensions;
+  mutable std::optional<std::string> m_archiveExtensions;
+  mutable std::optional<std::string> m_compoundArchiveExtensions;
+  mutable std::optional<std::string> m_fileFolderExtensions;
 };

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2018 Team Kodi
+ *  Copyright (C) 2012-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -7,6 +7,8 @@
  */
 
 #pragma once
+
+#include "threads/CriticalSection.h"
 
 #include <map>
 #include <memory>
@@ -77,7 +79,7 @@ public:
    *
    * @note Thought for cases e.g. by ISO, where can be a video or also a SACD.
    */
-  bool CanOperateExtension(const std::string& path) const;
+  static bool CanOperateExtension(const std::string& path);
 
 private:
   std::string GetAddonExtensions(ADDON::AddonType type) const;
@@ -88,6 +90,8 @@ private:
   // Construction properties
   std::shared_ptr<CAdvancedSettings> m_advancedSettings;
   ADDON::CAddonMgr &m_addonManager;
+
+  mutable CCriticalSection m_critSection;
 
   // File extension properties
   std::map<ADDON::AddonType, std::string> m_addonExtensions;

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -53,7 +53,7 @@ public:
   /*!
    * @brief Returns a list of disc stub extensions
    */
-  const std::string& GetDiscStubExtensions() const;
+  std::string GetDiscStubExtensions() const;
 
   /*!
    * @brief Returns a list of archive extensions with a single dot (eg. .zip)
@@ -104,13 +104,17 @@ private:
   // Protocols from add-ons with encoded host names
   std::vector<std::string> m_encoded;
 
-  // Cached extensions lists
-  mutable std::optional<std::string> m_discStubExtensions;
-  mutable std::optional<std::string> m_musicExtensions;
-  mutable std::optional<std::string> m_pictureExtensions;
-  mutable std::optional<std::string> m_subtitlesExtensions;
-  mutable std::optional<std::string> m_videoExtensions;
-  mutable std::optional<std::string> m_archiveExtensions;
-  mutable std::optional<std::string> m_compoundArchiveExtensions;
-  mutable std::optional<std::string> m_fileFolderExtensions;
+  // Cached extensions lists - use through atomic operations only
+  //
+  // @todo: use the safer C++20 std::atomic<std::shared_ptr<std::string>> partial specialization
+  // once available for all platform builders
+  // std::atomic_load/store of std::shared_ptr<T> is deprecated in C++20 and removed in C++26
+  mutable std::shared_ptr<const std::string> m_discStubExtensions;
+  mutable std::shared_ptr<const std::string> m_musicExtensions;
+  mutable std::shared_ptr<const std::string> m_pictureExtensions;
+  mutable std::shared_ptr<const std::string> m_subtitlesExtensions;
+  mutable std::shared_ptr<const std::string> m_videoExtensions;
+  mutable std::shared_ptr<const std::string> m_archiveExtensions;
+  mutable std::shared_ptr<const std::string> m_compoundArchiveExtensions;
+  mutable std::shared_ptr<const std::string> m_fileFolderExtensions;
 };

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -1032,11 +1032,11 @@ void CGraphicContext::SetRenderOrder(RENDER_ORDER renderOrder)
 {
   m_renderOrder = renderOrder;
   if (renderOrder == RENDER_ORDER_ALL_BACK_TO_FRONT)
-    CServiceBroker::GetRenderSystem()->SetDepthCulling(DEPTH_CULLING::OFF);
+    CServiceBroker::GetRenderSystem()->SetDepthCulling(DepthCulling::OFF);
   else if (renderOrder == RENDER_ORDER_BACK_TO_FRONT)
-    CServiceBroker::GetRenderSystem()->SetDepthCulling(DEPTH_CULLING::BACK_TO_FRONT);
+    CServiceBroker::GetRenderSystem()->SetDepthCulling(DepthCulling::BACK_TO_FRONT);
   else if (renderOrder == RENDER_ORDER_FRONT_TO_BACK)
-    CServiceBroker::GetRenderSystem()->SetDepthCulling(DEPTH_CULLING::FRONT_TO_BACK);
+    CServiceBroker::GetRenderSystem()->SetDepthCulling(DepthCulling::FRONT_TO_BACK);
 }
 
 uint32_t CGraphicContext::GetDepth(uint32_t addLayers)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add a callback mechanism that allows users of advanced settings to cache values safely and refresh them as needed when advanced settings are reloaded (ex. user profile switch).

- Added a cache to FileExtensionProvider for the strings that were created partially from advanced settings text for every call.
- Used the opportunity to protect the existing functions/members of FileExtensionProvider from concurrent access, and provided read-only lock-free access
- Modified RenderSystem/GL/GLES/DX to cache a few front-to-back settings used in every frame render. Took the opportunity to do the same for the showSplashImage setting.

RenderSystem change: I believe it's already a valuable improvement but there is room for future improvement and the settings should be DI'd. I didn't find an appropriate parent/owner to inject the settings values, advanced settings itself doesn't seem appropriate.

FileExtensionProvider change: 
note 1: the cache invalidation triggers could get out of sync with the actual dependencies of each list. I looked for refactoring that would eliminate the risk but my couple attempts turned into full rewrites so I stopped. It's beyond the scope of the PR. It already refactors things to make it more tractable.
note 2: the partial speciatlization std::atomic<std::shared_ptr<T>> is not supported by all build environments, the older (and now deprecated, slated for removal in C++26) atomic free functions had to be used instead.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Retrieving over and over settings that don't change or change very slowly is not efficient.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Kodi starts, stops, seems to run without any impact.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Slight performance improvement.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
