### PR TITLE
[JobManager] Prevent deadlock in `OnJobComplete()`

### DIFF
--- a/xbmc/jobs/JobManager.h
+++ b/xbmc/jobs/JobManager.h
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <queue>
 #include <string>
 #include <unordered_map>
@@ -245,5 +246,5 @@ private:
   bool m_running{true};
 
   // Tracks pending callback count for jobs in completion phase, used by CJob::IsShared()
-  std::unordered_map<const CJob*, size_t> m_pendingCallbacks;
+  std::unordered_map<const CJob*, std::atomic<size_t>> m_pendingCallbacks;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Calling `CWorkItem::FreeJob()` while holding the `CJobManager` can be dangerous as can be seen in #27685. The easiest fix would have been this:
```patch
diff --git a/xbmc/jobs/JobManager.cpp b/xbmc/jobs/JobManager.cpp
index ccc82b28732..b63d69179d2 100644
--- a/xbmc/jobs/JobManager.cpp
+++ b/xbmc/jobs/JobManager.cpp
@@ -343,6 +343,7 @@ void CJobManager::OnJobComplete(bool success, CJob* job)
     // Handle cancelled jobs (no callbacks remaining)
     if (item.GetCallbacks().empty())
     {
+      lock.unlock();
       item.FreeJob();
       return;
     }
@@ -368,6 +369,7 @@ void CJobManager::OnJobComplete(bool success, CJob* job)
     }
 
     m_pendingCallbacks.erase(job);
+    lock.unlock();
     item.FreeJob();
   }
 }
```
But I personally prefer to avoid manual calls to `lock()`/`unlock()` so I restructured the function to handle locking solely via the scope of the locks. But if this too confusing I'm file with using the above approach.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #27685.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

For me the deadlock was hit reproducibly by simply scrolling through the library view. With this change the problem is gone.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Prevent hang of the application.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
