### PR TITLE
Fix Claude using wrong command for PR comments (missing collapsed sections)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -78,14 +78,18 @@ jobs:
             Note: The PR branch is already checked out in the current working directory.
 
             After your review:
-            1. If you found issues: MUST post comment using `gh pr comment` for top-level summary wrapped in a collapsed section like this:
-               <details>
-               <summary>🤖 Claude Code Review</summary>
+            1. If you found issues:
+               - MUST post comment using `gh pr comment` for top-level summary
+               - Do NOT use `gh pr review --comment` (doesn't support collapsed sections)
+               - Do NOT post as plain PR review body (not collapsed)
+               - Use this exact format:
+                 <details>
+                 <summary>🤖 Claude Code Review</summary>
 
-               [Your review content here]
+                 [Your review content here]
 
-               </details>
-               Also use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues
+                 </details>
+               - Also use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues
             2. If NO issues found: MUST run `gh pr review --approve` (with --approve flag but NO --body flag)
                - Do NOT post any separate comment or acknowledgment
                - The approval itself is the only response needed
@@ -93,4 +97,4 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr review --approve*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,7 +69,7 @@ jobs:
             - DO NOT list "positive notes", "strengths", "what's working well", or similar sections
             - DO NOT use checkmarks (✅) or "NOT AN ISSUE" confirmations
             - ONLY report problems, issues, bugs, or concerns that need addressing
-            - If issues found: MUST post comment with the issues in a collapsed section
+            - If issues found: MUST use `gh pr comment` to post collapsed section with issues
             - If NO issues found: MUST run `gh pr review --approve` with NO --body flag (silent approval, no comment)
 
             When responding to questions or requests on issues (non-PR contexts):
@@ -78,7 +78,7 @@ jobs:
 
             When user mentions @claude in a top-level comment on a PR:
             - If they ask for a review: perform the review and take appropriate action (approval or issues comment)
-            - For other requests: respond in collapsed section format:
+            - For other requests: respond using `gh pr comment` in collapsed section format:
               <details>
               <summary>🤖 Claude Response</summary>
 
@@ -98,7 +98,16 @@ jobs:
 
             Response guidelines:
             1. For code reviews (PRs) - if issues found:
-               - MUST post comment in collapsed section with list of issues
+               - MUST use `gh pr comment` to post comment in collapsed section with list of issues
+               - Do NOT use `gh pr review --comment` (doesn't support collapsed sections)
+               - Do NOT post as plain PR review body (not collapsed)
+               - Use this exact format:
+                 <details>
+                 <summary>🤖 Claude Response</summary>
+
+                 [issues here]
+
+                 </details>
                - Focus ONLY on actionable issues/problems
                - Report bugs, errors, security issues, performance problems, or logic flaws
                - Skip anything that's working correctly
@@ -122,4 +131,4 @@ jobs:
             - For questions/requests: Your job is to be helpful, not to praise
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr review:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr status:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh workflow view:*),Bash(gh workflow list:*),Bash(gh repo view:*),Bash(gh release view:*),Bash(gh release list:*),Bash(gh search:*),Bash(git grep:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(gh api:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr review --approve*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh pr status:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh workflow view:*),Bash(gh workflow list:*),Bash(gh repo view:*),Bash(gh release view:*),Bash(gh release list:*),Bash(gh search:*),Bash(git grep:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(gh api:*)"


### PR DESCRIPTION
## Summary

Fixes [workflow run 21554749853](https://github.com/xbmc/xbmc/actions/runs/21554749853) which posted a PR review instead of a comment, resulting in a response that wasn't in a collapsed section.

See: https://github.com/xbmc/xbmc/pull/27780 - Claude's review was posted but not collapsed.

## Root Cause

The instructions said "MUST post comment in collapsed section" but didn't specify **which command** to use.

Claude used `gh pr review --comment` instead of `gh pr comment`, and **PR reviews don't support collapsed sections** in their body.

## Changes

Both workflows (`claude.yml` and `claude-code-review.yml`) now:

1. **Specify the exact command**: "MUST use `gh pr comment`"
2. **Provide format template**: `<details><summary>🤖 Claude Response</summary>\n\n[issues]\n\n</details>`
3. **Add explicit warning**: "Do NOT use `gh pr review --comment` (doesn't support collapsed sections)"

## What This Fixes

**Before**: Claude could use `gh pr review --comment` → Response posted without collapsed section ❌

**After**: Claude must use `gh pr comment` → Response properly collapsed ✅

## Test Plan

1. Create a PR with issues
2. Comment "@claude please review"
3. Verify Claude uses `gh pr comment` (not `gh pr review --comment`)
4. Verify response appears in collapsed `<details>` section
5. Verify format matches template

## Related

- Follows up on #27781 which fixed Claude not posting at all
- This PR fixes Claude posting in the wrong format

🤖 Generated with [Claude Code](https://claude.com/claude-code)