### PR TITLE
[Windows] FromW/ToW Improvements

### DIFF
--- a/cmake/treedata/windows/tests.txt
+++ b/cmake/treedata/windows/tests.txt
@@ -1,0 +1,1 @@
+xbmc/platform/win32/test test/win32

--- a/xbmc/platform/win32/CharsetConverter.cpp
+++ b/xbmc/platform/win32/CharsetConverter.cpp
@@ -8,8 +8,8 @@
 
 #include "CharsetConverter.h"
 
+#include <cassert>
 #include <limits>
-#include <memory>
 
 #include <Windows.h>
 
@@ -21,19 +21,30 @@ namespace WINDOWS
 {
 std::string FromW(const wchar_t* str, size_t length)
 {
+  std::string newStr;
+
   if (length == 0 || length > std::numeric_limits<int>::max())
-    return std::string();
+    return newStr;
 
-  int result = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, str, length, nullptr, 0, nullptr, nullptr);
-  if (result == 0)
-    return std::string();
+  const int result1 =
+      WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, str, length, nullptr, 0, nullptr, nullptr);
+  if (result1 == 0)
+    return newStr;
 
-  auto newStr = std::make_unique<char[]>(result);
-  result = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, str, length, newStr.get(), result, nullptr, nullptr);
-  if (result == 0)
-    return std::string();
+  newStr.resize(result1, '\0');
+  const int result2 = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, str, length, newStr.data(),
+                                          result1, nullptr, nullptr);
+  assert(result1 == result2);
 
-  return std::string(newStr.get(), result);
+  if (result1 != result2)
+  {
+    if (result2 < result1) // less data written than expected is recoverable though still a problem
+      newStr.resize(result2, '\0');
+    else
+      newStr.clear();
+  }
+
+  return newStr;
 }
 
 std::string FromW(std::wstring_view str)
@@ -43,20 +54,29 @@ std::string FromW(std::wstring_view str)
 
 std::wstring ToW(const char* str, size_t length)
 {
+  std::wstring newStr;
+
   if (length == 0 || length > std::numeric_limits<int>::max())
-    return std::wstring();
+    return newStr;
 
-  int result = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, length, nullptr, 0);
-  if (result == 0)
-    return std::wstring();
+  const int result1 = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, length, nullptr, 0);
+  if (result1 == 0)
+    return newStr;
 
-  auto newStr = std::make_unique<wchar_t[]>(result);
-  result = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, length, newStr.get(), result);
+  newStr.resize(result1, L'\0');
+  const int result2 =
+      MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, length, newStr.data(), result1);
+  assert(result1 == result2);
 
-  if (result == 0)
-    return std::wstring();
+  if (result1 != result2)
+  {
+    if (result2 < result1) // less data written than expected is recoverable though still a problem
+      newStr.resize(result2, L'\0');
+    else
+      newStr.clear();
+  }
 
-  return std::wstring(newStr.get(), result);
+  return newStr;
 }
 
 std::wstring ToW(std::string_view str)

--- a/xbmc/platform/win32/CharsetConverter.cpp
+++ b/xbmc/platform/win32/CharsetConverter.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -9,6 +9,9 @@
 #include "CharsetConverter.h"
 
 #include <memory>
+
+#include <Windows.h>
+
 namespace KODI
 {
 namespace PLATFORM

--- a/xbmc/platform/win32/CharsetConverter.cpp
+++ b/xbmc/platform/win32/CharsetConverter.cpp
@@ -36,9 +36,9 @@ std::string FromW(const wchar_t* str, size_t length)
   return std::string(newStr.get(), result);
 }
 
-std::string FromW(const std::wstring& str)
+std::string FromW(std::wstring_view str)
 {
-  return FromW(str.c_str(), str.length());
+  return FromW(str.data(), str.length());
 }
 
 std::wstring ToW(const char* str, size_t length)
@@ -59,9 +59,9 @@ std::wstring ToW(const char* str, size_t length)
   return std::wstring(newStr.get(), result);
 }
 
-std::wstring ToW(const std::string& str)
+std::wstring ToW(std::string_view str)
 {
-  return ToW(str.c_str(), str.length());
+  return ToW(str.data(), str.length());
 }
 
 }

--- a/xbmc/platform/win32/CharsetConverter.cpp
+++ b/xbmc/platform/win32/CharsetConverter.cpp
@@ -8,6 +8,7 @@
 
 #include "CharsetConverter.h"
 
+#include <limits>
 #include <memory>
 
 #include <Windows.h>
@@ -20,6 +21,9 @@ namespace WINDOWS
 {
 std::string FromW(const wchar_t* str, size_t length)
 {
+  if (length == 0 || length > std::numeric_limits<int>::max())
+    return std::string();
+
   int result = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, str, length, nullptr, 0, nullptr, nullptr);
   if (result == 0)
     return std::string();
@@ -39,6 +43,9 @@ std::string FromW(const std::wstring& str)
 
 std::wstring ToW(const char* str, size_t length)
 {
+  if (length == 0 || length > std::numeric_limits<int>::max())
+    return std::wstring();
+
   int result = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, length, nullptr, 0);
   if (result == 0)
     return std::wstring();

--- a/xbmc/platform/win32/CharsetConverter.h
+++ b/xbmc/platform/win32/CharsetConverter.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace KODI
 {
@@ -22,7 +23,7 @@ namespace WINDOWS
  * and locking issues that are unique to Windows as API calls
  * expect UTF-16 strings
  * \param str[in] string to be converted
- * \param length[in] length in characters of the string
+ * \param length[in] number of characters to convert
  * \returns utf8 string, empty string on failure
  */
 std::string FromW(const wchar_t* str, size_t length);
@@ -35,7 +36,7 @@ std::string FromW(const wchar_t* str, size_t length);
  * \param str[in] string to be converted
  * \returns utf8 string, empty string on failure
  */
-std::string FromW(const std::wstring& str);
+std::string FromW(std::wstring_view str);
 
 /**
  * Convert UTF-8 to UTF-16 strings
@@ -43,7 +44,7 @@ std::string FromW(const std::wstring& str);
  * and locking issues that are unique to Windows as API calls
  * expect UTF-16 strings
  * \param str[in] string to be converted
- * \param length[in] length in characters of the string
+ * \param length[in] number of characters to convert
  * \returns UTF-16 string, empty string on failure
  */
 std::wstring ToW(const char* str, size_t length);
@@ -56,7 +57,7 @@ std::wstring ToW(const char* str, size_t length);
  * \param str[in] string to be converted
  * \returns UTF-16 string, empty string on failure
  */
-std::wstring ToW(const std::string& str);
+std::wstring ToW(std::string_view str);
 }
 }
 }

--- a/xbmc/platform/win32/test/CMakeLists.txt
+++ b/xbmc/platform/win32/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+list(APPEND SOURCES TestCharsetConverter.cpp)
+
+core_add_test_library(win32_test)

--- a/xbmc/platform/win32/test/TestCharsetConverter.cpp
+++ b/xbmc/platform/win32/test/TestCharsetConverter.cpp
@@ -29,6 +29,11 @@ TEST(TestWin32CharsetConverter, FromW)
 
   EXPECT_EQ(expected, result);
 
+  std::wstring_view wsv(L"foo");
+  result = FromW(wsv);
+
+  EXPECT_EQ(expected, result);
+
   wchar_t ca[] = L"foo";
 
   // substring - not-null terminated
@@ -55,6 +60,11 @@ TEST(TestWin32CharsetConverter, ToW)
   s = "foo";
   result = ToW(s);
   expected = L"foo";
+
+  EXPECT_EQ(expected, result);
+
+  std::string_view sv("foo");
+  result = ToW(sv);
 
   EXPECT_EQ(expected, result);
 

--- a/xbmc/platform/win32/test/TestCharsetConverter.cpp
+++ b/xbmc/platform/win32/test/TestCharsetConverter.cpp
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "platform/win32/CharsetConverter.h"
+
+#include <string>
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+using namespace KODI::PLATFORM::WINDOWS;
+
+TEST(TestWin32CharsetConverter, FromW)
+{
+  std::wstring ws;
+  std::string expected;
+  std::string result = FromW(ws);
+
+  EXPECT_EQ(expected, result);
+
+  ws = L"foo";
+  result = FromW(ws);
+  expected = "foo";
+
+  EXPECT_EQ(expected, result);
+
+  wchar_t ca[] = L"foo";
+
+  // substring - not-null terminated
+  expected = "fo";
+  result = FromW(ca, 2);
+  EXPECT_EQ(expected, result);
+
+  // calling the function that way is usually a mistake
+  // including the null terminator converts it with the rest of the string
+  result = FromW(ca, 4);
+  using namespace std::string_literals;
+  expected = "foo\0"s;
+  EXPECT_EQ(expected, result);
+}
+
+TEST(TestWin32CharsetConverter, ToW)
+{
+  std::string s;
+  std::wstring expected;
+  std::wstring result = ToW(s);
+
+  EXPECT_EQ(expected, result);
+
+  s = "foo";
+  result = ToW(s);
+  expected = L"foo";
+
+  EXPECT_EQ(expected, result);
+
+  char ca[] = "foo";
+
+  // substring - not-null terminated
+  expected = L"fo";
+  result = ToW(ca, 2);
+  EXPECT_EQ(expected, result);
+
+  // calling the function that way is usually a mistake
+  // including the null terminator converts it with the rest of the string
+  result = ToW(ca, 4);
+  using namespace std::string_literals;
+  expected = L"foo\0"s;
+  EXPECT_EQ(expected, result);
+}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

A few improvements of the FromW and ToW functions of the Windows platform, with separate commits.

- Added unit tests
- Added early exit of FromW/ToW for empty strings since MS doc guarantees failure of WideCharToMultiByte and MultiByteToWideChar for that input.
- Also exit early in case of string too long (length > MAX_INT). Clamping the length wouldn't be better, there is no valid use case since the functions are used to convert parameters to/from the Windows API.
- Changed FromW/ToW to accept a more universal string_view / wstring_view parameter
- Speed improvement by having the Win API fill the constructed result object, instead of a copy from a temporary array + use copy ellision for the return value.

Last one should be safe since C++17 and the addition of a non-const data() function.
Current approach:
create a temporary array of the expected number of characters. the characters are value-initialized.
Win API updates the contents of the temp array
the result string is created with a copy from the temp array

New approach: create the result string for the expected result size, initialized with 0 characters.
Win API updates the string's buffer through the data() pointer.
copy ellision > the return string is built in the caller, no copy or move.

alternative improvement in case issue with last change: use of `std::make_unique_for_overwrite` added in C++20 instead of `std::make_unique` to change from value-initialization to default-initialization, a noop for builtin value types.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

modernize with usage of string_view, add unit tests

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

step by step debugging, unit tests run, Kodi appears to work normally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Slight speedup.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
