### PR TITLE
RetroPlayer: Fix crash on stream close/re-open

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -92,7 +92,12 @@ void CRPRenderManager::Deinitialize()
   }
   m_savestateBuffers.clear();
 
-  m_renderers.clear();
+  // Renderers may still hold GPU resources, so defer cleanup to the rendering
+  // or destructor thread
+  {
+    std::unique_lock<std::mutex> lock{m_oldRenderersMutex};
+    m_oldRenderers.merge(m_renderers);
+  }
 
   m_state = RENDER_STATE::UNCONFIGURED;
 }
@@ -370,6 +375,12 @@ void CRPRenderManager::CheckFlush()
 
 void CRPRenderManager::RenderWindow(bool bClear, const RESOLUTION_INFO& coordsRes)
 {
+  // Clear any old renderers on the rendering thread
+  {
+    std::unique_lock<std::mutex> lock{m_oldRenderersMutex};
+    m_oldRenderers.clear();
+  }
+
   // Get a renderer for the fullscreen window
   std::shared_ptr<CRPBaseRenderer> renderer = GetRendererForSettings(nullptr);
   if (!renderer)
@@ -390,6 +401,12 @@ void CRPRenderManager::RenderControl(bool bClear,
                                      const CRect& renderRegion,
                                      const IGUIRenderSettings* renderSettings)
 {
+  // Clear any old renderers on the rendering thread
+  {
+    std::unique_lock<std::mutex> lock{m_oldRenderersMutex};
+    m_oldRenderers.clear();
+  }
+
   // Get a renderer for the control
   std::shared_ptr<CRPBaseRenderer> renderer = GetRendererForSettings(renderSettings);
   if (!renderer)

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -22,6 +22,7 @@ extern "C"
 #include <future>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
 #include <vector>
@@ -244,6 +245,8 @@ private:
 
   // Render resources
   std::set<std::shared_ptr<CRPBaseRenderer>> m_renderers;
+  std::set<std::shared_ptr<CRPBaseRenderer>> m_oldRenderers;
+  std::mutex m_oldRenderersMutex;
   std::vector<IRenderBuffer*> m_pendingBuffers; // Only access from game thread
   std::vector<IRenderBuffer*> m_renderBuffers;
   std::map<AVPixelFormat, std::map<AVPixelFormat, SwsContext*>> m_scalers; // From -> to -> context


### PR DESCRIPTION
## Description

This PR fixes a crash when video streams are closed or re-opened (which closes the stream). The cause is calling into OpenGL functions from the stream destructor in the game loop thread.

CC @KOPRajs

## Motivation and context

I've hit this bug a lot before when resolutions change, but I was helping a user fix input in Beetle-PSX, and games were immediately crashing on playback for me. I investigated the problem, and this change is sufficient to fix the bug.

## How has this been tested?

Before, loading Beetle-PSX on my macbook crashes instantly:

<img width="969" height="994" alt="Screenshot 2026-02-01 at 11 27 07 AM" src="https://github.com/user-attachments/assets/36a1eb80-53a9-4143-a062-d0c6a48bd5e2" />

After, game successfully starts and exits:

<img width="1337" height="774" alt="Screenshot 2026-02-01 at 11 29 01 AM" src="https://github.com/user-attachments/assets/c3afdef2-32bd-4273-9bd3-e146eff21e60" />

## What is the effect on users?

* Fixes crash when emulators change resolution

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
