### PR TITLE
[iOS/tvOS] force disable hardware acceleration for real-time interlac…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
@@ -132,7 +132,7 @@ IHardwareDecoder* CDecoder::Create(CDVDStreamInfo &hint, CProcessInfo &processIn
 #if defined(TARGET_DARWIN_EMBEDDED)
   // force disable HW acceleration for live streams
   // to avoid absent image issue on interlaced videos
-  if (processInfo.IsRealtimeStream())
+  if (processInfo.IsRealtimeStream() && hint.interlaced)
     return nullptr;
 #endif
 


### PR DESCRIPTION
## Description

This PR refines the VideoToolbox (VTB) hardware decoding behavior on **iOS/tvOS**.

Previously, hardware acceleration was effectively disabled in a blanket manner on iOS/tvOS due to historical issues with **deinterlacing**, regardless of the actual stream characteristics.
This change removes the coarse platform-only restriction and instead makes the decision based on whether the **current video stream requires deinterlacing**.

As a result, progressive streams (e.g. 720p/1080p/4K) can benefit from VideoToolbox hardware decoding, while interlaced streams continue to fall back to software decoding to avoid known issues.

---

## Motivation and context

The original platform-wide disablement of VideoToolbox on iOS/tvOS was introduced to avoid deinterlacing-related problems (see commit `da2a6f3`).
While valid at the time, this approach has become increasingly restrictive for modern use cases:

* Many IPTV and PVR streams today are **progressive-only**
* 4K HEVC IPTV channels are becoming common
* Software decoding on iOS/tvOS often leads to **severe frame drops and high CPU usage**, making playback impractical

By basing the decision on **stream properties rather than device type**, this change allows users who do not consume interlaced content to regain hardware decoding performance, without reintroducing the original deinterlacing issues.

Related discussion:

* [https://github.com/xbmc/xbmc/commit/da2a6f3acb72cc56efcfd473a5d06c5cdc5ec4cd](https://github.com/xbmc/xbmc/commit/da2a6f3acb72cc56efcfd473a5d06c5cdc5ec4cd)

---

## How has this been tested?

* Tested on **iOS and tvOS** devices
* Verified playback behavior with:

  * Progressive H.264 and HEVC streams (hardware decoding enabled)
  * Interlaced 1080i streams (hardware decoding correctly disabled)
* Confirmed via codec info and debug logs that:

  * VideoToolbox is used for progressive streams
  * ffmpeg software decoding is used when deinterlacing is required
* No regressions observed in playback stability

---

## What is the effect on users?

* Users on iOS/tvOS can again benefit from **hardware decoding** for progressive streams
* Significantly improved playback performance for **4K HEVC IPTV**
* Reduced CPU usage and fewer dropped frames
* Interlaced content remains unaffected and continues to use the safer software path

---

## Screenshots (if appropriate):

N/A

---

## Types of change

* [x] **Improvement** (non-breaking change which improves existing functionality)
* [ ] Bug fix
* [ ] Clean up
* [ ] New feature
* [ ] Breaking change
* [ ] Cosmetic change
* [ ] Student submission
* [ ] None of the above

---

## Checklist:

* [x] My code follows the **Code Guidelines** of this project
* [ ] My change requires a change to the documentation, either Doxygen or wiki
* [ ] I have updated the documentation accordingly
* [x] I have read the **Contributing** document
* [ ] I have added tests to cover my change
* [x] All new and existing tests passed

