### PR TITLE
Optimize emplace_back calls

### DIFF
--- a/xbmc/cores/RetroPlayer/streams/memory/DeltaPairMemoryStream.cpp
+++ b/xbmc/cores/RetroPlayer/streams/memory/DeltaPairMemoryStream.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2016-2018 Team Kodi
+ *  Copyright (C) 2016-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -22,8 +22,7 @@ void CDeltaPairMemoryStream::Reset()
 
 void CDeltaPairMemoryStream::SubmitFrameInternal()
 {
-  m_rewindBuffer.emplace_back();
-  MemoryFrame& frame = m_rewindBuffer.back();
+  MemoryFrame& frame = m_rewindBuffer.emplace_back();
 
   // Record frame history
   frame.frameHistoryCount = m_currentFrameHistory++;

--- a/xbmc/cores/VideoPlayer/Edl/EdlParser.h
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParser.h
@@ -63,15 +63,15 @@ public:
   const std::vector<EditEntry>& GetEdits() const { return m_edits; }
   const std::vector<SceneMarkerEntry>& GetSceneMarkers() const { return m_sceneMarkers; }
 
-  void AddEdit(const Edit& edit, std::optional<EdlSourceLocation> source = std::nullopt)
+  void AddEdit(const Edit& edit, const std::optional<EdlSourceLocation>& source = std::nullopt)
   {
-    m_edits.emplace_back(EditEntry{edit, source});
+    m_edits.emplace_back(edit, source);
   }
 
   void AddSceneMarker(std::chrono::milliseconds marker,
-                      std::optional<EdlSourceLocation> source = std::nullopt)
+                      const std::optional<EdlSourceLocation>& source = std::nullopt)
   {
-    m_sceneMarkers.emplace_back(SceneMarkerEntry{marker, source});
+    m_sceneMarkers.emplace_back(marker, source);
   }
 
   bool IsEmpty() const { return m_edits.empty() && m_sceneMarkers.empty(); }

--- a/xbmc/cores/VideoPlayer/Edl/EdlParser.h
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParser.h
@@ -50,12 +50,27 @@ class CEdlParserResult
 public:
   struct EditEntry
   {
+    // user-defined ctor required for XCode 15.2 and emplace_back
+    EditEntry(const Edit& newEdit, const std::optional<EdlSourceLocation>& newSource)
+      : edit(newEdit),
+        source(newSource)
+    {
+    }
+
     Edit edit;
     std::optional<EdlSourceLocation> source;
   };
 
   struct SceneMarkerEntry
   {
+    // user-defined ctor required for XCode 15.2 and emplace_back
+    SceneMarkerEntry(std::chrono::milliseconds newMarker,
+                     const std::optional<EdlSourceLocation>& newSource)
+      : marker(newMarker),
+        source(newSource)
+    {
+    }
+
     std::chrono::milliseconds marker;
     std::optional<EdlSourceLocation> source;
   };

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -32,6 +32,7 @@
 
 #include <mutex>
 #include <sstream>
+#include <utility>
 
 #define PLAYERCOREFACTORY_XML "playercorefactory.xml"
 
@@ -149,15 +150,16 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
       (defaultInputstreamPlayerOverride == ForcedPlayer::NONE &&
        (VIDEO::IsVideo(item) || (!MUSIC::IsAudio(item) && !item.IsGame()))))
   {
-    int idx = GetPlayerIndex("videodefaultplayer");
+    const int idx = GetPlayerIndex("videodefaultplayer");
     if (idx > -1)
     {
-      const std::string videoDefault = GetPlayerName(idx);
+      // non-const for move
+      std::string videoDefault = GetPlayerName(idx);
       if (std::ranges::find(players, videoDefault) == players.cend())
       {
-        players.emplace_back(videoDefault);
         CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: adding videodefaultplayer ({})",
                   videoDefault);
+        players.push_back(std::move(videoDefault));
       }
     }
     GetPlayers(players, false, true);  // Video-only players
@@ -169,15 +171,16 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
   if (defaultInputstreamPlayerOverride == ForcedPlayer::AUDIO_DEFAULT ||
       (defaultInputstreamPlayerOverride == ForcedPlayer::NONE && MUSIC::IsAudio(item)))
   {
-    int idx = GetPlayerIndex("audiodefaultplayer");
+    const int idx = GetPlayerIndex("audiodefaultplayer");
     if (idx > -1)
     {
-      const std::string audioDefault = GetPlayerName(idx);
+      // non-const for move
+      std::string audioDefault = GetPlayerName(idx);
       if (std::ranges::find(players, audioDefault) == players.cend())
       {
-        players.emplace_back(audioDefault);
         CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: adding audiodefaultplayer ({})",
                   audioDefault);
+        players.push_back(std::move(audioDefault));
       }
     }
     GetPlayers(players, true, false); // Audio-only players

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <cassert>
 #include <climits>
+#include <utility>
 #include <vector>
 
 #ifdef TARGET_POSIX
@@ -2167,9 +2168,8 @@ const std::vector<std::string> CCurlFile::GetPropertyValues(XFILE::FileProperty 
   std::vector<std::string> values;
   std::string value = GetProperty(type, name);
   if (!value.empty())
-  {
-    values.emplace_back(value);
-  }
+    values.push_back(std::move(value));
+
   return values;
 }
 

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -22,6 +22,7 @@
 #include <array>
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace XFILE
@@ -85,7 +86,7 @@ std::string CStackDirectory::GetStackTitlePath(const std::string& strPath)
       {
         if (regExp.RegFind(path) != -1)
         {
-          stackParts.emplace_back(StackPart{.title = regExp.GetMatch(1)});
+          stackParts.emplace_back(regExp.GetMatch(1));
           break;
         }
       }
@@ -107,8 +108,7 @@ std::string CStackDirectory::GetStackTitlePath(const std::string& strPath)
       {
         if (regExp.RegFind(fileName) != -1)
         {
-          stackParts.emplace_back(
-              StackPart{.title = regExp.GetMatch(1), .volume = regExp.GetMatch(3)});
+          stackParts.emplace_back(regExp.GetMatch(1), regExp.GetMatch(3));
           break;
         }
       }

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -27,6 +27,12 @@
 
 namespace XFILE
 {
+CStackDirectory::StackPart::StackPart(std::string&& newTitle, std::string&& newVolume)
+  : title(std::move(newTitle)),
+    volume(std::move(newVolume))
+{
+}
+
 bool CStackDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 {
   items.Clear();

--- a/xbmc/filesystem/StackDirectory.h
+++ b/xbmc/filesystem/StackDirectory.h
@@ -20,7 +20,7 @@ namespace XFILE
     typedef struct StackPart
     {
       std::string title;
-      std::string volume{};
+      std::string volume;
 
       auto operator<=>(const StackPart&) const = default;
     } StackPart;

--- a/xbmc/filesystem/StackDirectory.h
+++ b/xbmc/filesystem/StackDirectory.h
@@ -19,6 +19,9 @@ namespace XFILE
   {
     typedef struct StackPart
     {
+      // user-defined ctor required for XCode 15.2 and emplace_back
+      StackPart(std::string&& newTitle, std::string&& newVolume = {});
+
       std::string title;
       std::string volume;
 

--- a/xbmc/filesystem/bluray/M2TSParser.cpp
+++ b/xbmc/filesystem/bluray/M2TSParser.cpp
@@ -1913,6 +1913,13 @@ bool ParseTSPacket(const std::span<std::byte>& packet,
 }
 } // namespace
 
+Descriptor::Descriptor(unsigned int newTag, int newLength, std::vector<std::byte>&& newData)
+  : tag(newTag),
+    length(newLength),
+    data(std::move(newData))
+{
+}
+
 bool CM2TSParser::GetStreamsFromFile(const std::string& path,
                                      unsigned int clip,
                                      const std::string& clipExtension,

--- a/xbmc/filesystem/bluray/M2TSParser.cpp
+++ b/xbmc/filesystem/bluray/M2TSParser.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2025 Team Kodi
+ *  Copyright (C) 2025-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -539,11 +539,8 @@ void ProcessPMTEntry(std::vector<std::byte>& section,
       if (descriptorOffset + 2 + desc_length > static_cast<int>(section.size()))
         break;
 
-      descriptors.emplace_back(
-          Descriptor{.tag = desc_tag,
-                     .length = desc_length,
-                     .data = std::vector(section.begin() + descriptorOffset + 2,
-                                         section.begin() + descriptorOffset + 2 + desc_length)});
+      const auto itDesc = section.begin() + descriptorOffset + 2;
+      descriptors.emplace_back(desc_tag, desc_length, std::vector(itDesc, itDesc + desc_length));
 
       // ISO 639 language descriptor
       if (desc_tag == 0x0A && desc_length >= 4)

--- a/xbmc/filesystem/bluray/M2TSParser.h
+++ b/xbmc/filesystem/bluray/M2TSParser.h
@@ -23,6 +23,9 @@ struct BlurayPlaylistInformation;
 
 struct Descriptor
 {
+  // user-defined ctor required for XCode 15.2 and emplace_back
+  Descriptor(unsigned int newTag, int newLength, std::vector<std::byte>&& newData);
+
   unsigned int tag;
   int length;
   std::vector<std::byte> data;

--- a/xbmc/filesystem/bluray/MPLSParser.cpp
+++ b/xbmc/filesystem/bluray/MPLSParser.cpp
@@ -1009,6 +1009,34 @@ bool ParseMPLS(const CURL& url,
 }
 } // namespace
 
+ClipInformation::ClipInformation(unsigned int newClip, std::string&& newCodec)
+  : clip(newClip),
+    codec(std::move(newCodec))
+{
+}
+
+PlaylistMarkInformation::PlaylistMarkInformation(BLURAY_MARK_TYPE newMarkType,
+                                                 unsigned int newPlayItemReference,
+                                                 std::chrono::milliseconds newTime,
+                                                 unsigned int newElementaryStreamPacketIdentifier,
+                                                 std::chrono::milliseconds newDuration)
+  : markType(newMarkType),
+    playItemReference(newPlayItemReference),
+    time(newTime),
+    elementaryStreamPacketIdentifier(newElementaryStreamPacketIdentifier),
+    duration(newDuration)
+{
+}
+
+ChapterInformation::ChapterInformation(unsigned int newChapter,
+                                       std::chrono::milliseconds newStart,
+                                       std::chrono::milliseconds newDuration)
+  : chapter(newChapter),
+    start(newStart),
+    duration(newDuration)
+{
+}
+
 bool CMPLSParser::ReadMPLS(const CURL& url,
                            unsigned int playlist,
                            BlurayPlaylistInformation& playlistInformation,

--- a/xbmc/filesystem/bluray/MPLSParser.h
+++ b/xbmc/filesystem/bluray/MPLSParser.h
@@ -109,6 +109,10 @@ struct ProgramInformation
 
 struct ClipInformation
 {
+  // user-defined ctor required for XCode 15.2 and emplace_back
+  ClipInformation() = default;
+  ClipInformation(unsigned int newClip, std::string&& newCodec);
+
   unsigned int clip{0};
   std::string version;
   std::string codec;
@@ -119,6 +123,13 @@ struct ClipInformation
 
 struct PlaylistMarkInformation
 {
+  // user-defined ctor required for XCode 15.2 and emplace_back
+  PlaylistMarkInformation(BLURAY_MARK_TYPE newMarkType,
+                          unsigned int newPlayItemReference,
+                          std::chrono::milliseconds newTime,
+                          unsigned int newElementaryStreamPacketIdentifier,
+                          std::chrono::milliseconds newDuration);
+
   BLURAY_MARK_TYPE markType{0};
   unsigned int playItemReference{0};
   std::chrono::milliseconds time{0ms};
@@ -128,6 +139,11 @@ struct PlaylistMarkInformation
 
 struct ChapterInformation
 {
+  // user-defined ctor required for XCode 15.2 and emplace_back
+  ChapterInformation(unsigned int newChapter,
+                     std::chrono::milliseconds newStart,
+                     std::chrono::milliseconds newDuration);
+
   unsigned int chapter{0};
   std::chrono::milliseconds start{0ms};
   std::chrono::milliseconds duration{0ms};

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -43,9 +43,28 @@ using namespace KODI;
 #define SCROLLING_GAP   200U
 #define SCROLLING_THRESHOLD 300U
 
-CGUIBaseContainer::CGUIBaseContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems)
-    : IGUIContainer(parentID, controlID, posX, posY, width, height)
-    , m_scroller(scroller)
+CGUIBaseContainer::RENDERITEM::RENDERITEM(float newPosX,
+                                          float newPosY,
+                                          std::shared_ptr<CGUIListItem> newItem,
+                                          bool newFocused)
+  : posX(newPosX),
+    posY(newPosY),
+    item(newItem),
+    focused(newFocused)
+{
+}
+
+CGUIBaseContainer::CGUIBaseContainer(int parentID,
+                                     int controlID,
+                                     float posX,
+                                     float posY,
+                                     float width,
+                                     float height,
+                                     ORIENTATION orientation,
+                                     const CScroller& scroller,
+                                     int preloadItems)
+  : IGUIContainer(parentID, controlID, posX, posY, width, height),
+    m_scroller(scroller)
 {
   m_cursor = 0;
   m_offset = 0;

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -307,9 +307,9 @@ void CGUIBaseContainer::Render()
         else
         {
           if (m_orientation == VERTICAL)
-            renderitems.emplace_back(RENDERITEM{origin.x, pos, item, false});
+            renderitems.emplace_back(origin.x, pos, item, false);
           else
-            renderitems.emplace_back(RENDERITEM{pos, origin.y, item, false});
+            renderitems.emplace_back(pos, origin.y, item, false);
         }
       }
       // increment our position
@@ -320,9 +320,9 @@ void CGUIBaseContainer::Render()
     if (focusedItem)
     {
       if (m_orientation == VERTICAL)
-        renderitems.emplace_back(RENDERITEM{origin.x, focusedPos, focusedItem, true});
+        renderitems.emplace_back(origin.x, focusedPos, focusedItem, true);
       else
-        renderitems.emplace_back(RENDERITEM{focusedPos, origin.y, focusedItem, true});
+        renderitems.emplace_back(focusedPos, origin.y, focusedItem, true);
     }
 
     if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -220,6 +220,12 @@ protected:
 
   struct RENDERITEM
   {
+    // user-defined ctor for XCode 15.2 and emplace_back
+    RENDERITEM(float newPosX,
+               float newPosY,
+               std::shared_ptr<CGUIListItem> newItem,
+               bool newFocused);
+
     float posX;
     float posY;
     std::shared_ptr<CGUIListItem> item;

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -278,13 +278,19 @@ CGUIListContainer::CGUIListContainer(int parentID, int controlID, float posX, fl
                                  float textureHeight, float itemWidth, float itemHeight, float spaceBetweenItems)
 : CGUIBaseContainer(parentID, controlID, posX, posY, width, height, VERTICAL, 200, 0)
 {
-  m_layouts.emplace_back();
-  m_layouts.back().CreateListControlLayouts(width, textureHeight + spaceBetweenItems, false, labelInfo, labelInfo2, textureButton, textureButtonFocus, textureHeight, itemWidth, itemHeight, "", "");
+  CGUIListItemLayout& layout = m_layouts.emplace_back();
+  layout.CreateListControlLayouts(width, textureHeight + spaceBetweenItems, false, labelInfo,
+                                  labelInfo2, textureButton, textureButtonFocus, textureHeight,
+                                  itemWidth, itemHeight, "", "");
   std::string condition = StringUtils::Format("control.hasfocus({})", controlID);
   std::string condition2 = "!" + condition;
-  m_focusedLayouts.emplace_back();
-  m_focusedLayouts.back().CreateListControlLayouts(width, textureHeight + spaceBetweenItems, true, labelInfo, labelInfo2, textureButton, textureButtonFocus, textureHeight, itemWidth, itemHeight, condition2, condition);
-  m_height = floor(m_height / (textureHeight + spaceBetweenItems)) * (textureHeight + spaceBetweenItems);
+
+  CGUIListItemLayout& focusedLayout = m_focusedLayouts.emplace_back();
+  focusedLayout.CreateListControlLayouts(
+      width, textureHeight + spaceBetweenItems, true, labelInfo, labelInfo2, textureButton,
+      textureButtonFocus, textureHeight, itemWidth, itemHeight, condition2, condition);
+  m_height =
+      floor(m_height / (textureHeight + spaceBetweenItems)) * (textureHeight + spaceBetweenItems);
   ControlType = GUICONTAINER_LIST;
 }
 //#endif

--- a/xbmc/guilib/GUIPanelContainer.cpp
+++ b/xbmc/guilib/GUIPanelContainer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -135,11 +135,9 @@ void CGUIPanelContainer::Render()
         else
         {
           if (m_orientation == VERTICAL)
-            renderitems.emplace_back(
-                RENDERITEM{origin.x + col * m_layout->Size(HORIZONTAL), pos, item, false});
+            renderitems.emplace_back(origin.x + col * m_layout->Size(HORIZONTAL), pos, item, false);
           else
-            renderitems.emplace_back(
-                RENDERITEM{pos, origin.y + col * m_layout->Size(VERTICAL), item, false});
+            renderitems.emplace_back(pos, origin.y + col * m_layout->Size(VERTICAL), item, false);
         }
       }
       // increment our position
@@ -156,11 +154,11 @@ void CGUIPanelContainer::Render()
     if (focusedItem)
     {
       if (m_orientation == VERTICAL)
-        renderitems.emplace_back(RENDERITEM{origin.x + focusedCol * m_layout->Size(HORIZONTAL),
-                                            focusedPos, focusedItem, true});
+        renderitems.emplace_back(origin.x + focusedCol * m_layout->Size(HORIZONTAL), focusedPos,
+                                 focusedItem, true);
       else
-        renderitems.emplace_back(RENDERITEM{
-            focusedPos, origin.y + focusedCol * m_layout->Size(VERTICAL), focusedItem, true});
+        renderitems.emplace_back(focusedPos, origin.y + focusedCol * m_layout->Size(VERTICAL),
+                                 focusedItem, true);
     }
 
     if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -41,6 +41,26 @@ using namespace KODI::MESSAGING;
 #define SETTING_PASSWORD        "password"
 #define SETTING_REMOTE_PATH     "remotepath"
 
+CGUIDialogNetworkSetup::Protocol::Protocol(bool newSupportPath,
+                                           bool newSupportUsername,
+                                           bool newSupportPassword,
+                                           bool newSupportPort,
+                                           bool newSupportBrowsing,
+                                           int newDefaultPort,
+                                           std::string newType,
+                                           int newLabel,
+                                           std::string newAddonId)
+  : supportUsername(newSupportUsername),
+    supportPassword(newSupportPassword),
+    supportPort(newSupportPort),
+    supportBrowsing(newSupportBrowsing),
+    defaultPort(newDefaultPort),
+    type(newType),
+    label(newLabel),
+    addonId(newAddonId)
+{
+}
+
 CGUIDialogNetworkSetup::CGUIDialogNetworkSetup(void)
     : CGUIDialogSettingsManualBase(WINDOW_DIALOG_NETWORK_SETUP, "DialogSettings.xml")
 {

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -435,7 +435,7 @@ void CGUIDialogNetworkSetup::UpdateAvailableProtocols()
   m_protocols.clear();
 #ifdef HAS_FILESYSTEM_SMB
   // most popular protocol at the first place
-  m_protocols.emplace_back(Protocol{true, true, true, false, true, 0, "smb", 20171, ""});
+  m_protocols.emplace_back(true, true, true, false, true, 0, "smb", 20171, "");
 #endif
   // protocols from vfs addon next
   if (CServiceBroker::IsAddonInterfaceUp())
@@ -447,9 +447,9 @@ void CGUIDialogNetworkSetup::UpdateAvailableProtocols()
       {
         // only use first protocol
         auto prots = StringUtils::Split(info.type, "|");
-        m_protocols.emplace_back(Protocol{
-            info.supportPath, info.supportUsername, info.supportPassword, info.supportPort,
-            info.supportBrowsing, info.defaultPort, prots.front(), info.label, addon->ID()});
+        m_protocols.emplace_back(info.supportPath, info.supportUsername, info.supportPassword,
+                                 info.supportPort, info.supportBrowsing, info.defaultPort,
+                                 prots.front(), info.label, addon->ID());
       }
     }
   }
@@ -466,6 +466,6 @@ void CGUIDialogNetworkSetup::UpdateAvailableProtocols()
 
   m_protocols.insert(m_protocols.end(), defaults.begin(), defaults.end());
 #ifdef HAS_FILESYSTEM_NFS
-  m_protocols.emplace_back(Protocol{true, false, false, false, true, 0, "nfs", 20259, ""});
+  m_protocols.emplace_back(true, false, false, false, true, 0, "nfs", 20259, "");
 #endif
 }

--- a/xbmc/network/GUIDialogNetworkSetup.h
+++ b/xbmc/network/GUIDialogNetworkSetup.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -16,6 +16,17 @@ public:
   //! \brief A structure encapsulating properties of a supported protocol.
   struct Protocol
   {
+    // user-defined ctor for XCode 15.2 and emplace_back
+    Protocol(bool newSupportPath,
+             bool newSupportUsername,
+             bool newSupportPassword,
+             bool newSupportPort,
+             bool newSupportBrowsing,
+             int newDefaultPort,
+             std::string newType,
+             int newLabel,
+             std::string newAddonId);
+
     bool supportPath;      //!< Protocol has path in addition to server name
     bool supportUsername;  //!< Protocol uses logins
     bool supportPassword;  //!< Protocol supports passwords

--- a/xbmc/utils/CharsetConverter.cpp
+++ b/xbmc/utils/CharsetConverter.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -907,6 +907,9 @@ void CCharsetConverter::SettingOptionsCharsetsFiller(const SettingConstPtr& sett
 
   list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13278),
                     "DEFAULT"); // "Default"
-  for (int i = 0; i < (int) vecCharsets.size(); ++i)
-    list.emplace_back(vecCharsets[i], g_charsetConverter.getCharsetNameByLabel(vecCharsets[i]));
+  for (auto& label : vecCharsets)
+  {
+    std::string name = g_charsetConverter.getCharsetNameByLabel(label);
+    list.emplace_back(std::move(label), std::move(name));
+  }
 }

--- a/xbmc/utils/HttpHeader.cpp
+++ b/xbmc/utils/HttpHeader.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -9,6 +9,8 @@
 #include "HttpHeader.h"
 
 #include "utils/StringUtils.h"
+
+#include <utility>
 
 // header white space characters according to RFC 2616
 const char* const CHttpHeader::m_whitespaceChars = " \t";
@@ -81,7 +83,7 @@ bool CHttpHeader::ParseLine(const std::string& headerLine)
     StringUtils::Trim(strValue, m_whitespaceChars);
 
     if (!strParam.empty() && !strValue.empty())
-      m_params.emplace_back(strParam, strValue);
+      m_params.emplace_back(std::move(strParam), std::move(strValue));
     else
       return false;
   }
@@ -117,7 +119,7 @@ void CHttpHeader::AddParam(const std::string& param, const std::string& value, c
   if (valueTrim.empty())
     return;
 
-  m_params.emplace_back(paramLower, valueTrim);
+  m_params.emplace_back(std::move(paramLower), std::move(valueTrim));
 }
 
 std::string CHttpHeader::GetValue(const std::string& strParam) const

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2016-2025 Team Kodi
+ *  Copyright (C) 2016-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -75,6 +75,7 @@
 #include <set>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 using namespace dbiplus;
@@ -3307,7 +3308,7 @@ void CVideoDatabase::GetBookMarksForFile(const std::string& strFilenameAndPath, 
     m_pDS->query(strSQL);
     while (!m_pDS->eof())
     {
-      CBookmark bookmark;
+      CBookmark& bookmark = bookmarks.emplace_back();
       bookmark.timeInSeconds = m_pDS->fv("timeInSeconds").get_asDouble();
       bookmark.partNumber = partNumber;
       bookmark.totalTimeInSeconds = m_pDS->fv("totalTimeInSeconds").get_asDouble();
@@ -3327,7 +3328,6 @@ void CVideoDatabase::GetBookMarksForFile(const std::string& strFilenameAndPath, 
         bookmark.seasonNumber = m_pDS2->fv(1).get_asInt();
         m_pDS2->close();
       }
-      bookmarks.emplace_back(bookmark);
       m_pDS->next();
     }
     //sort(bookmarks.begin(), bookmarks.end(), SortBookmarks);
@@ -3440,7 +3440,7 @@ void CVideoDatabase::GetEpisodesByFileId(int idFile, std::vector<CVideoInfoTag>&
       m_pDS->goto_rec(episode.index);
       CVideoInfoTag tag{GetDetailsForEpisode(*m_pDS)};
       tag.m_duration = episode.duration;
-      episodes.emplace_back(tag);
+      episodes.push_back(std::move(tag));
     }
     m_pDS->close();
   }
@@ -5526,10 +5526,9 @@ std::vector<CScraperUrl::SUrlEntry> GetBasicItemAvailableArt(int mediaId,
     tag.m_fanart.Unpack();
     for (unsigned int i = 0; i < tag.m_fanart.GetNumFanarts(); i++)
     {
-      CScraperUrl::SUrlEntry url(tag.m_fanart.GetImageURL(i));
+      CScraperUrl::SUrlEntry& url = result.emplace_back(tag.m_fanart.GetImageURL(i));
       url.m_preview = tag.m_fanart.GetPreviewURL(i);
       url.m_aspect = "fanart";
-      result.emplace_back(url);
     }
   }
   tag.m_strPictureURL.Parse();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -10287,11 +10287,11 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
         ConstructPath(fullPath, filePath, fileName);
         if (URIUtils::IsBlurayPath(fullPath))
           fullPath = URIUtils::GetDiscFile(fullPath);
-        const std::string hash{fmt::format("{}{}", fileId, fullPath)};
+        // non-const for move
+        std::string hash{fmt::format("{}{}", fileId, fullPath)};
 
-        versions.emplace_back(
-            FileInformation{.path = fullPath, .fileId = fileId, .vvId = vvId, .hash = hash});
         fileHashMap[hash]++;
+        versions.emplace_back(std::move(fullPath), fileId, vvId, std::move(hash));
 
         pDS3->next();
       }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -87,6 +87,17 @@ using namespace KODI::GUILIB;
 using namespace KODI::VIDEO;
 using namespace std::chrono_literals;
 
+CVideoDatabase::FileInformation::FileInformation(std::string&& newPath,
+                                                 int newFileId,
+                                                 int newVvId,
+                                                 std::string&& newHash)
+  : path(std::move(newPath)),
+    fileId(newFileId),
+    vvId(newVvId),
+    hash(std::move(newHash))
+{
+}
+
 //********************************************************************************************************************************
 CVideoDatabase::CVideoDatabase() = default;
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -151,6 +151,9 @@ class CVideoDatabase : public CDatabase
 {
   struct FileInformation
   {
+    // user-defined ctor required for XCode 15.2 and emplace_back
+    FileInformation(std::string&& newPath, int newFileId, int newVvId, std::string&& newHash);
+
     std::string path;
     int fileId{0};
     int vvId{0};

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2025 Team Kodi
+ *  Copyright (C) 2025-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -137,13 +137,13 @@ void CVideoDatabase::UpdateTables(int iVersion)
     std::vector<CShowItem> shows;
     while (!m_pDS->eof())
     {
-      CShowItem show;
+      CShowItem& show = shows.emplace_back();
       show.id = m_pDS->fv(0).get_asInt();
       show.path = m_pDS->fv(1).get_asInt();
       show.title = m_pDS->fv(2).get_asString();
       show.year = m_pDS->fv(3).get_asString();
       show.ident = m_pDS->fv(4).get_asString();
-      shows.emplace_back(std::move(show));
+
       m_pDS->next();
     }
     m_pDS->close();
@@ -194,11 +194,11 @@ void CVideoDatabase::UpdateTables(int iVersion)
     std::vector<CShowLink> shows;
     while (!m_pDS->eof())
     {
-      CShowLink link;
+      CShowLink& link = shows.emplace_back();
       link.show = m_pDS->fv(0).get_asInt();
       link.pathId = m_pDS->fv(1).get_asInt();
       link.path = m_pDS->fv(2).get_asString();
-      shows.emplace_back(std::move(link));
+
       m_pDS->next();
     }
     m_pDS->close();

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -642,15 +642,14 @@ void CVideoInfoTag::Archive(CArchive& ar)
     m_cast.reserve(iCastSize);
     for (int i = 0; i < iCastSize; ++i)
     {
-      SActorInfo info;
+      SActorInfo& info = m_cast.emplace_back();
       ar >> info.strName;
       ar >> info.strRole;
       ar >> info.order;
       ar >> info.thumb;
       std::string strXml;
       ar >> strXml;
-      info.thumbUrl.ParseFromData(strXml);
-      m_cast.emplace_back(std::move(info));
+      info.thumbUrl.ParseFromData(std::move(strXml));
     }
 
     m_set.Archive(ar);
@@ -1314,7 +1313,8 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     const TiXmlNode *actor = node->FirstChild("name");
     if (actor && actor->FirstChild())
     {
-      SActorInfo info;
+      SActorInfo& info = m_cast.emplace_back();
+
       info.strName = actor->FirstChild()->Value();
 
       if (XMLUtils::GetString(node, "role", value))
@@ -1330,7 +1330,6 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
       const char* clear=node->Attribute("clear");
       if (clear && StringUtils::CompareNoCase(clear, "true"))
         m_cast.clear();
-      m_cast.emplace_back(std::move(info));
     }
     node = node->NextSiblingElement("actor");
   }

--- a/xbmc/video/VideoItemArtworkHandler.cpp
+++ b/xbmc/video/VideoItemArtworkHandler.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2023 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -153,10 +153,9 @@ void CVideoItemArtworkHandler::AddItemPathStringToFileBrowserSources(
 {
   if (!itemDir.empty() && CDirectory::Exists(itemDir))
   {
-    CMediaSource itemSource;
+    CMediaSource& itemSource = sources.emplace_back();
     itemSource.strName = label;
     itemSource.strPath = itemDir;
-    sources.emplace_back(itemSource);
   }
 }
 

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -37,6 +37,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #define SETTING_AUDIO_VOLUME                   "audio.volume"
@@ -384,23 +385,22 @@ void CGUIDialogAudioSettings::AudioStreamsOptionFiller(const SettingConstPtr& se
   // cycle through each audio stream and add it to our list control
   for (int i = 0; i < audioStreamCount; ++i)
   {
-    std::string strLanguage;
+    std::string textInfo;
 
     AudioStreamInfo info;
     appPlayer->GetAudioStreamInfo(i, info);
 
-    if (!g_LangCodeExpander.Lookup(info.language, strLanguage))
-      strLanguage = "[" + CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205) +
-                    "]"; // Unknown
+    if (!g_LangCodeExpander.Lookup(info.language, textInfo))
+      textInfo = "[" + CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205) +
+                 "]"; // Unknown
 
-    std::string textInfo = strLanguage;
     if (!info.name.empty())
       textInfo += " - " + info.name;
 
     textInfo += FormatCodec(info);
     textInfo += FormatFlags(info.flags);
     textInfo += StringUtils::Format(" ({}/{})", i + 1, audioStreamCount);
-    list.emplace_back(textInfo, i);
+    list.emplace_back(std::move(textInfo), i);
   }
 
   if (list.empty())

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2023 Team Kodi
+ *  Copyright (C) 2023-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -465,11 +465,10 @@ void CGUIDialogVideoManager::AppendItemFolderToFileBrowserSources(
   const std::string itemDir{URIUtils::GetParentPath(m_videoAsset->GetDynPath())};
   if (!itemDir.empty() && XFILE::CDirectory::Exists(itemDir))
   {
-    CMediaSource itemSource{};
+    CMediaSource& itemSource = sources.emplace_back();
     itemSource.strName =
         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36041); // * Item folder
     itemSource.strPath = itemDir;
-    sources.emplace_back(itemSource);
   }
 }
 

--- a/xbmc/weather/GUIWindowWeather.cpp
+++ b/xbmc/weather/GUIWindowWeather.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -168,11 +168,12 @@ void CGUIWindowWeather::UpdateLocations()
     {
       strLabel = StringUtils::Format("AreaCode {}", i);
     }
-    labels.emplace_back(strLabel, i);
 
     // in case it's a button, set the label
     if (i == iCurWeather)
       SET_CONTROL_LABEL(CONTROL_SELECTLOCATION, strLabel);
+
+    labels.emplace_back(std::move(strLabel), i);
   }
 
   SET_CONTROL_LABELS(CONTROL_SELECTLOCATION, iCurWeather, &labels);

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -89,7 +89,6 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
               "[WHITELIST] Using the default whitelist because the user whitelist is empty");
     std::vector<RESOLUTION> candidates;
     RESOLUTION_INFO info;
-    std::string resString;
     CServiceBroker::GetWinSystem()->GetGfxContext().GetAllowedResolutions(candidates);
     for (const auto& c : candidates)
     {
@@ -102,10 +101,7 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
         // and this causes ugly double switching.
         // This won't allow 25p / 30p playback on native refreshrate by default
         if ((info.fRefreshRate > 30) || (MathUtils::FloatEquals(info.fRefreshRate, 24.0f, 0.1f)))
-        {
-          resString = CDisplaySettings::GetInstance().GetStringFromRes(c);
-          indexList.emplace_back(resString);
-        }
+          indexList.push_back(CDisplaySettings::GetInstance().GetStringFromRes(c));
       }
     }
   }

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -26,6 +26,23 @@
 
 const char* CWinSystemBase::SETTING_WINSYSTEM_IS_HDR_DISPLAY = "winsystem.ishdrdisplay";
 
+RESOLUTION_WHR::RESOLUTION_WHR(int newWidth,
+                               int newHeight,
+                               int screenWidth,
+                               int screenHeight,
+                               int newflags,
+                               int newIdx,
+                               std::string&& newId)
+  : width(newWidth),
+    height(newHeight),
+    m_screenWidth(screenWidth),
+    m_screenHeight(screenHeight),
+    flags(newflags),
+    ResInfo_Index(newIdx),
+    id(std::move(newId))
+{
+}
+
 CWinSystemBase::CWinSystemBase() : m_gfxContext(std::make_unique<CGraphicContext>())
 {
 }

--- a/xbmc/windowing/WinSystem.cpp
+++ b/xbmc/windowing/WinSystem.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -122,13 +122,13 @@ void CWinSystemBase::SetWindowResolution(int width, int height)
 
 static void AddResolution(std::vector<RESOLUTION_WHR> &resolutions, unsigned int addindex, float bestRefreshrate)
 {
+  // non-const for move
   RESOLUTION_INFO resInfo = CDisplaySettings::GetInstance().GetResolutionInfo(addindex);
   const int width = resInfo.iWidth;
   const int height = resInfo.iHeight;
   const int screenWidth = resInfo.iScreenWidth;
   const int screenHeight = resInfo.iScreenHeight;
-  int flags  = resInfo.dwFlags & D3DPRESENTFLAG_MODEMASK;
-  const std::string id = resInfo.strId;
+  const int flags = resInfo.dwFlags & D3DPRESENTFLAG_MODEMASK;
   float refreshrate = resInfo.fRefreshRate;
 
   // don't touch RES_DESKTOP
@@ -149,9 +149,8 @@ static void AddResolution(std::vector<RESOLUTION_WHR> &resolutions, unsigned int
     }
   }
 
-  RESOLUTION_WHR res = {width, height, screenWidth, screenHeight, flags, static_cast<int>(addindex),
-                        id};
-  resolutions.emplace_back(res);
+  resolutions.emplace_back(width, height, screenWidth, screenHeight, flags,
+                           static_cast<int>(addindex), std::move(resInfo.strId));
 }
 
 static bool resSortPredicate(const RESOLUTION_WHR& i, const RESOLUTION_WHR& j)

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -24,6 +24,14 @@
 
 struct RESOLUTION_WHR
 {
+  // user-defined ctor required for XCode 15.2 and emplace_back
+  RESOLUTION_WHR(int newWidth,
+                 int newHeight,
+                 int screenWidth,
+                 int screenHeight,
+                 int newflags,
+                 int newIdx,
+                 std::string&& newId);
   int width;
   int height;
   int m_screenWidth;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Optimized usage of some emplace_back calls, no intended functionality changes.
Depending on the situation, moved the call, added std::move to some arguments, ...
Changed a few emplace_back to push_back in a situation where the parameter is moved at best since it's simpler/faster for the compiler

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Save some CPU cycles by fine-tuning the existing emplace_back calls.

Noticed the pattern
`renderitems.emplace_back(RENDERITEM{origin.x, pos, item, false});`
in a few GUI components, which denies the benefits of emplace_back as far as I know.
Looked for other occurence and subtoptimal usage.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Kodi builds and runs basic functions. 
I tested in more details the sections of the code I knew how to trigger.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Slight speedup.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
