### PR TITLE
GUI: add opt-in rounded clipping for control groups (scissor, transform-detach, offscreen mask)

### DIFF
--- a/system/shaders/GL/1.5/gl_shader_frag_roundrect_mask.glsl
+++ b/system/shaders/GL/1.5/gl_shader_frag_roundrect_mask.glsl
@@ -1,0 +1,48 @@
+#version 150
+
+uniform sampler2D m_samp0;
+
+// Viewport in framebuffer pixels: x, y, w, h (bottom-left origin)
+uniform vec4  m_viewport;
+
+// Rect in framebuffer pixels, bottom-left origin: x1,y1,x2,y2
+uniform vec4  m_maskRect;
+uniform vec4  m_radii;    // corner radii in framebuffer pixels: tl,tr,br,bl
+uniform float m_aaWidth;  // AA width in framebuffer pixels
+
+out vec4 fragColor;
+
+float sdRoundRect(vec2 p, vec2 b, float r)
+{
+  vec2 q = abs(p) - b;
+  return length(max(q, vec2(0.0))) + min(max(q.x, q.y), 0.0) - r;
+}
+
+void main()
+{
+  vec2 p = gl_FragCoord.xy;
+
+  vec2 center   = 0.5 * (m_maskRect.xy + m_maskRect.zw);
+  vec2 halfSize = 0.5 * (m_maskRect.zw - m_maskRect.xy);
+  vec2 d = p - center;
+
+  float rSel = (d.x < 0.0)
+                 ? ((d.y < 0.0) ? m_radii.w : m_radii.x)
+                 : ((d.y < 0.0) ? m_radii.z : m_radii.y);
+
+  float r = clamp(rSel, 0.0, min(halfSize.x, halfSize.y));
+  vec2  b = halfSize - vec2(r);
+
+  vec2 vpSize = max(m_viewport.zw, vec2(1.0, 1.0));
+  vec2 uv = (p - m_viewport.xy) / vpSize;
+  uv = clamp(uv, vec2(0.0), vec2(1.0));
+
+  vec4 src = texture(m_samp0, uv);
+
+  float dist = sdRoundRect(d, b, r);
+
+  float aa  = max(m_aaWidth, 0.0001);
+  float cov = 1.0 - smoothstep(0.0, aa, dist);
+
+  fragColor = vec4(src.rgb * cov, src.a * cov);
+}

--- a/system/shaders/GL/1.5/gl_shader_vert_roundrect_mask.glsl
+++ b/system/shaders/GL/1.5/gl_shader_vert_roundrect_mask.glsl
@@ -1,0 +1,9 @@
+#version 150
+
+in vec4 m_attrpos;
+uniform mat4 m_matrix;
+
+void main()
+{
+  gl_Position = m_matrix * vec4(m_attrpos.xy, 0.0, 1.0);
+}

--- a/system/shaders/GLES/2.0/gles_shader_roundrect_mask.frag
+++ b/system/shaders/GLES/2.0/gles_shader_roundrect_mask.frag
@@ -1,0 +1,51 @@
+#version 100
+precision highp float;
+
+uniform sampler2D m_samp0;
+
+// Viewport in framebuffer pixels: x, y, w, h (bottom-left origin)
+uniform vec4  m_viewport;
+
+// Rect in framebuffer pixels, bottom-left origin: x1,y1,x2,y2
+uniform vec4  m_maskRect;
+uniform vec4  m_radii;    // corner radii in framebuffer pixels: tl,tr,br,bl
+uniform float m_aaWidth;  // AA width in framebuffer pixels (e.g. 1.0)
+
+float sdRoundRect(vec2 p, vec2 b, float r)
+{
+  vec2 q = abs(p) - b;
+  return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - r;
+}
+
+void main()
+{
+  vec2 p = gl_FragCoord.xy;
+
+  // Local point relative to rect center (bottom-left origin in gl_FragCoord).
+  vec2 center   = 0.5 * (m_maskRect.xy + m_maskRect.zw);
+  vec2 halfSize = 0.5 * (m_maskRect.zw - m_maskRect.xy);
+  vec2 d = p - center;
+
+  // Pick the radius for the current quadrant (TL,TR,BR,BL).
+  float rSel = (d.x < 0.0)
+                 ? ((d.y < 0.0) ? m_radii.w : m_radii.x)
+                 : ((d.y < 0.0) ? m_radii.z : m_radii.y);
+
+  float r = clamp(rSel, 0.0, min(halfSize.x, halfSize.y));
+  vec2  b = halfSize - vec2(r);
+
+
+  // Sample full-screen offscreen buffer using framebuffer-relative UVs.
+  vec2 vpSize = max(m_viewport.zw, vec2(1.0, 1.0));
+  vec2 uv = (p - m_viewport.xy) / vpSize;
+  uv = clamp(uv, vec2(0.0, 0.0), vec2(1.0, 1.0));
+  vec4 src = texture2D(m_samp0, uv);
+
+  float dist = sdRoundRect(d, b, r);
+
+  float aa = max(m_aaWidth, 0.0001);
+  float cov = 1.0 - smoothstep(0.0, aa, dist); // inside=1, outside=0
+
+  // Apply coverage to BOTH rgb and alpha (straight alpha pipeline).
+  gl_FragColor = vec4(src.rgb * cov, src.a * cov);
+}

--- a/system/shaders/GLES/2.0/gles_shader_roundrect_mask.vert
+++ b/system/shaders/GLES/2.0/gles_shader_roundrect_mask.vert
@@ -1,0 +1,8 @@
+#version 100
+
+attribute vec4 m_attrpos;
+uniform mat4 m_matrix;
+void main()
+{
+  gl_Position = m_matrix * vec4(m_attrpos.xy, 0.0, 1.0);
+}

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -144,7 +144,16 @@ void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
 
   if (IsVisible())
   {
-    m_cachedTransform = CServiceBroker::GetWinSystem()->GetGfxContext().AddTransform(m_transform);
+    auto& gfx = CServiceBroker::GetWinSystem()->GetGfxContext();
+    m_cachedTransform = gfx.AddTransform(m_transform);
+    bool transformActive = true;
+
+    if (!TransformChildren())
+    {
+      // Keep m_cachedTransform for this control's own render, but do NOT let children bake-in our transform.
+      gfx.RemoveTransform();
+      transformActive = false;
+    }
     if (m_hasCamera)
       CServiceBroker::GetWinSystem()->GetGfxContext().SetCameraPosition(m_camera);
 
@@ -159,7 +168,8 @@ void CGUIControl::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyreg
 
     if (m_hasCamera)
       CServiceBroker::GetWinSystem()->GetGfxContext().RestoreCameraPosition();
-    CServiceBroker::GetWinSystem()->GetGfxContext().RemoveTransform();
+    if (transformActive)
+      gfx.RemoveTransform();
   }
 
   UpdateControlStats();

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -251,6 +251,7 @@ public:
   virtual void SetPushUpdates(bool pushUpdates) { m_pushedUpdates = pushUpdates; }
 
   virtual bool IsGroup() const { return false; }
+  virtual bool TransformChildren() const { return true; }
   virtual bool IsContainer() const { return false; }
   virtual bool GetCondition(int condition, int data) const { return false; }
 

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -15,6 +15,7 @@
 
 #include "GUIControlLookup.h"
 
+#include <array>
 #include <vector>
 
 /*!
@@ -69,9 +70,17 @@ public:
   }
   void SetRenderFocusedLast(bool renderLast) { m_renderFocusedLast = renderLast; }
 
+  // Clip children to this group's bounds using render-space scissor rectangles.
+  // This constrains both static rendering and animated transforms.
+  void SetClipping(bool clip) { m_clipping = clip; }
+  // Optional rounded clipping radii (in screen pixels): tl,tr,br,bl. 0 disables offscreen clipping.
+  void SetCornerRadius(float radius) { m_cornerRadii = {radius, radius, radius, radius}; }
+  void SetCornerRadii(const std::array<float, 4>& radii) { m_cornerRadii = radii; }
+  void SetTransformChildren(bool transform) { m_transformChildren = transform; }
   void SaveStates(std::vector<CControlState> &states) override;
 
   bool IsGroup() const override { return true; }
+  bool TransformChildren() const override { return m_transformChildren; }
 
 #ifdef _DEBUG
   void DumpTextureUse() override;
@@ -89,6 +98,10 @@ protected:
   bool m_defaultAlways;
   int m_focusedControl;
   bool m_renderFocusedLast;
+  bool m_clipping{false};
+  std::array<float, 4> m_cornerRadii{0.0f, 0.0f, 0.0f, 0.0f};
+  bool m_transformChildren{true};
+
 private:
   typedef std::vector< std::vector<CGUIControl *> * > COLLECTORTYPE;
 

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -12,6 +12,7 @@
 #include "utils/ColorUtils.h"
 #include "utils/Geometry.h"
 
+#include <array>
 #include <memory>
 #include <string>
 
@@ -56,6 +57,18 @@ public:
   virtual CRect ClipRectToScissorRect(const CRect &rect) { return CRect(); }
   virtual void SetScissors(const CRect &rect) = 0;
   virtual void ResetScissors() = 0;
+
+  // Render group to an offscreen target and composite it back with a round-rect mask (AA-capable).
+  virtual bool BeginOffscreenRoundedGroup(const CRect& rectScreenTL, float radiusPx)
+  {
+    return false;
+  }
+  virtual bool BeginOffscreenRoundedGroup(const CRect& rectScreenTL,
+                                          const std::array<float, 4>& radiiPx)
+  {
+    return BeginOffscreenRoundedGroup(rectScreenTL, radiiPx[0]);
+  }
+  virtual void EndOffscreenRoundedGroup() {}
 
   virtual void SetDepthCulling(DEPTH_CULLING culling) {}
 
@@ -106,4 +119,3 @@ protected:
   std::unique_ptr<CGUIImage> m_splashImage;
   std::unique_ptr<CGUITextLayout> m_splashMessageLayout;
 };
-

--- a/xbmc/rendering/RoundRectCompositeUtils.h
+++ b/xbmc/rendering/RoundRectCompositeUtils.h
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/Geometry.h" // CRect
+
+#include <algorithm>
+#include <array>
+#include <utility>
+
+namespace ROUNDRECT
+{
+inline CRect ScreenTLToFramebufferBL(const CRect& rectScreenTL, const GLint vp[4])
+{
+  const float vpX = static_cast<float>(vp[0]);
+  const float vpY = static_cast<float>(vp[1]);
+  const float vpH = static_cast<float>(vp[3]);
+
+  CRect rectFbBL(rectScreenTL.x1 + vpX, vpY + (vpH - rectScreenTL.y2), rectScreenTL.x2 + vpX,
+                 vpY + (vpH - rectScreenTL.y1));
+
+  if (rectFbBL.x2 < rectFbBL.x1)
+    std::swap(rectFbBL.x1, rectFbBL.x2);
+  if (rectFbBL.y2 < rectFbBL.y1)
+    std::swap(rectFbBL.y1, rectFbBL.y2);
+
+  return rectFbBL;
+}
+
+inline float ClampRadiusToRect(float radiusPx, const CRect& rectFbBL)
+{
+  const float maxR = std::min(rectFbBL.Width(), rectFbBL.Height()) * 0.5f;
+  return std::max(0.0f, std::min(radiusPx, maxR));
+}
+
+struct GLCompositeStateGuardBase
+{
+  GLint program{0};
+  GLint arrayBuffer{0};
+  GLint activeTex{0};
+  GLint tex2D{0};
+
+  GLboolean blend{GL_FALSE};
+  GLint blendSrcRGB{0};
+  GLint blendDstRGB{0};
+  GLint blendSrcA{0};
+  GLint blendDstA{0};
+
+  GLboolean scissor{GL_FALSE};
+  std::array<GLint, 4> scissorBox{{0, 0, 0, 0}};
+
+  GLCompositeStateGuardBase()
+  {
+    glGetIntegerv(GL_CURRENT_PROGRAM, &program);
+    glGetIntegerv(GL_ARRAY_BUFFER_BINDING, &arrayBuffer);
+
+    glGetIntegerv(GL_ACTIVE_TEXTURE, &activeTex);
+    glActiveTexture(GL_TEXTURE0);
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &tex2D);
+    glActiveTexture(activeTex);
+
+    blend = glIsEnabled(GL_BLEND);
+    glGetIntegerv(GL_BLEND_SRC_RGB, &blendSrcRGB);
+    glGetIntegerv(GL_BLEND_DST_RGB, &blendDstRGB);
+    glGetIntegerv(GL_BLEND_SRC_ALPHA, &blendSrcA);
+    glGetIntegerv(GL_BLEND_DST_ALPHA, &blendDstA);
+
+    scissor = glIsEnabled(GL_SCISSOR_TEST);
+    glGetIntegerv(GL_SCISSOR_BOX, scissorBox.data());
+  }
+
+  void RestoreCommon() const
+  {
+    if (scissor)
+      glEnable(GL_SCISSOR_TEST);
+    else
+      glDisable(GL_SCISSOR_TEST);
+    glScissor(scissorBox[0], scissorBox[1], scissorBox[2], scissorBox[3]);
+
+    if (blend)
+      glEnable(GL_BLEND);
+    else
+      glDisable(GL_BLEND);
+    glBlendFuncSeparate(static_cast<GLenum>(blendSrcRGB), static_cast<GLenum>(blendDstRGB),
+                        static_cast<GLenum>(blendSrcA), static_cast<GLenum>(blendDstA));
+
+    glUseProgram(static_cast<GLuint>(program));
+    glBindBuffer(GL_ARRAY_BUFFER, static_cast<GLuint>(arrayBuffer));
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, static_cast<GLuint>(tex2D));
+    glActiveTexture(static_cast<GLenum>(activeTex));
+  }
+};
+} // namespace ROUNDRECT

--- a/xbmc/windowing/GraphicContext.h
+++ b/xbmc/windowing/GraphicContext.h
@@ -15,6 +15,8 @@
 #include "utils/Geometry.h" // for CRect/CPoint
 #include "utils/TransformMatrix.h" // for the members m_guiTransform etc.
 
+#include <array>
+#include <map>
 #include <stack>
 #include <string>
 #include <vector>
@@ -200,6 +202,13 @@ public:
   void RestoreClipRegion();
   void ClipRect(CRect &vertex, CRect &texture, CRect *diffuse = NULL);
   CRect GetClipRegion();
+  bool SetClipRegionScissor(float x, float y, float w, float h);
+  void RestoreClipRegionScissor();
+  bool BeginOffscreenRoundedGroup(float x, float y, float w, float h, float radiusGui);
+  bool BeginOffscreenRoundedGroup(
+      float x, float y, float w, float h, const std::array<float, 4>& radiiGui);
+  void EndOffscreenRoundedGroup();
+
   void AddGUITransform();
   TransformMatrix AddTransform(const TransformMatrix &matrix);
   void SetTransform(const TransformMatrix &matrix);
@@ -240,6 +249,7 @@ protected:
   std::stack<CPoint> m_cameras;
   std::stack<CPoint> m_origins;
   std::stack<CRect> m_clipRegions;
+  std::stack<CRect> m_scissorRegions;
   std::stack<float> m_stereoFactors;
   std::stack<CRect> m_viewStack;
   CRect m_scissors;


### PR DESCRIPTION
## Description
This change introduces an **opt-in clipping system for `CGUIControlGroup`** that supports:

- Rectangular scissor clipping  
- Ability to detach group child controls from parent animations  
- Anti-aliased rounded-corner clipping via an offscreen compositing pass  

A new `<clipping>` XML flag enables clipping for group controls.

- When enabled **without a corner radius**, groups are clipped using the existing render-space scissor path.
- When `<cornerradius>` is specified and greater than zero, the group is rendered into an offscreen framebuffer and composited back using a dedicated round-rect mask shader.
- The shader supports both **uniform** and **per-corner** radii.

Children inherit group animations by default. By setting an optional `<transformchildren>` flag to false, skinners can opt out of this behavior for a given group. Doing so enables children to be rendered without observing group transform animations, while keeping clipping/positioning driven by the group.”

### Key aspects of the implementation

- Unified clip setup/teardown via a scoped helper in `CGUIControlGroup`
- Per-corner radius parsing from XML (single value or `tl,tr,br,bl`)
- Renderer-agnostic API additions to `CGraphicContext` and `RenderSystem`
- GLES and GL implementations using offscreen FBO compositing with AA mask shaders
- Safe fallback to scissor clipping when offscreen rendering is unavailable
- Full GL state preservation to avoid leakage across GUI rendering passes
- Support for nested clipped groups via a stack-based state model

All functionality is fully opt-in and does **not** affect existing controls unless explicitly enabled in XML.

## Motivation and context
Currently, there is no reliable way to clip child controls to a group boundary unless you rely on container layouts (`<itemlayout>` / `<focusedlayout>`) or nested group controls. This becomes problematic for any UI that requires **independent animation or movement** within a confined region.

In particular:

- Animations applied to elements inside a `grouplist` or container are evaluated in **fullscreen render space**, not relative to their parent group or layout.
- This makes advanced transitions (parallax, masked reveals, sliding panels, zoomed cards, etc.) difficult or impossible to implement cleanly.
- Attempts to work around this using containers or layout hacks break down quickly once transforms or scroll-driven motion is involved.

A failed parallax experiment demonstrating these limitations can be found here:  
[https://forum.kodi.tv/showthread.php?tid=383437](https://forum.kodi.tv/showthread.php?tid=383437)

Rounded corners are currently achievable on image controls via diffuse masks, but this approach has several limitations:

- The mask shape must exactly match the image aspect ratio, otherwise corners warp.
- This often requires **a seperate mask texture** per control (per size / aspect ratio).
- To achieve acceptable edge quality, masks must be relatively large, increasing texture memory usage.
- Masked images scale and stretch along with transform animations, degrading visual quality.

These constraints make diffuse-mask-based approaches unsuitable for dynamic, animated, or layout-agnostic UI elements.

This change introduces a **proper group-level clipping primitive**, allowing child controls to animate freely while respecting a defined clipping region, including optional anti-aliased rounded corners.

## How has this been tested?
- Manual testing across **GL and GLES renderers**
- Verified correct behaviour with:
  - Static groups
  - Animated groups (scale, translate)
  - Nested clipped groups
  - Mixed scissor-only and rounded-corner clipping
- Confirmed correct fallback to scissor clipping when offscreen compositing is unavailable
- Verified no GL/GLES state leakage across GUI rendering passes
- Confirmed no behavioural changes to existing skins unless `<clipping>` is explicitly enabled

Testing was performed on:
- macOS Apple Silicon (OpenGL)
- Android Arm64v8a (GLES)
- Test builds available here: [https://github.com/realcopacetic/xbmc/releases/tag/pr-rounded-clipping](https://github.com/realcopacetic/xbmc/releases/tag/pr-rounded-clipping)
- Test drop-in skin code for Estuary MyVideoNav.xml available here [https://github.com/realcopacetic/xbmc/releases/tag/pr-rounded-clipping](https://github.com/realcopacetic/xbmc/releases/tag/pr-rounded-clipping) - Either replace Estuary's MyVideoNav.xml with the file, or add lines 177 - 418 to the very end of the <controls> section. 4 tests present with explanatory notes.

## What is the effect on users?
There is **no visible change** for users unless a skin explicitly opts in.
For skinners, this enables:
- Properly clipped animated panels
- Clean parallax and reveal effects
- Rounded containers without texture-based masks and with higher-quality implementation (no blurring on curves)
- More controllable transform animation behaviour within grouped UI elements

The feature is fully backwards-compatible and does not alter existing rendering paths unless requested via XML.

## Screenshots (if appropriate):
- Video of rounded corner testing on Mac (Apple Silicon): [https://youtu.be/SfJ8JAd7Pzs](https://youtu.be/SfJ8JAd7Pzs)
- Video of animation transform detachment: [https://youtu.be/lNuXHjYtlcM](https://youtu.be/lNuXHjYtlcM)
- Video of nested clipping groups: [https://youtube.com/KwA1CVTENSA](https://youtube.com/KwA1CVTENSA)

<img width="1680" height="1050" alt="Screenshot 2026-02-02 at 13 57 18" src="https://github.com/user-attachments/assets/631e5e89-6808-41cd-9d70-24a611d551ab" />

Screenshot shows a clipped group with rectangular fanart that has been given rounded edges via XML tags only. Also a white square texture turned into a circle with high quality AA edge using the new `<cornerradius>` tag. Lastly, a blue square texture given independent corner radiuses using `10,30,0,150` in the `<cornerradius>` tag.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [ ] All new and existing tests passed
