### PR TITLE
[powermanagement] Option to disable playback on wakeup

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4972,7 +4972,12 @@ msgctxt "#1450"
 msgid "Put display to sleep when idle"
 msgstr ""
 
-#empty strings from id 1451 to 2049
+#: system/settings/settings.xml
+msgctxt "#1451"
+msgid "Restart playback after waking up"
+msgstr ""
+
+#empty strings from id 1452 to 2049
 #strings through to 1470 reserved for power-saving
 
 msgctxt "#2050"
@@ -21369,7 +21374,13 @@ msgctxt "#36415"
 msgid "No info available yet."
 msgstr ""
 
-#empty strings from id 36416 to 36417
+#. Description of setting with label #1451 "Restart playback after waking up"
+#: system/settings/settings.xml
+msgctxt "#36416"
+msgid "Restarts playback of the last played file when woken up."
+msgstr ""
+
+#empty strings from id 36417 to 36417
 
 #. Description of setting with label #295 "Low latency mode"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3665,6 +3665,11 @@
             <formatlabel>14044</formatlabel>
           </control>
         </setting>
+        <setting id="powermanagement.restartplayer" type="boolean" label="1451" help="36416">
+          <level>1</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="powermanagement.shutdowntime" type="integer" label="357" help="36389">
           <level>2</level>
           <default>0</default>

--- a/xbmc/powermanagement/PowerManager.cpp
+++ b/xbmc/powermanagement/PowerManager.cpp
@@ -301,7 +301,9 @@ void CPowerManager::RestorePlayerState()
   CLog::Log(LOGDEBUG,
             "CPowerManager::RestorePlayerState - resume last played item (startOffset: {} ms)",
             m_lastPlayedFileItem->GetStartOffset());
-  g_application.PlayFile(*m_lastPlayedFileItem, m_lastUsedPlayer);
+  bool restartPlayer = m_settings->GetBool(CSettings::SETTING_POWERMANAGEMENT_RESTARTPLAYER);
+  if (restartPlayer)
+    g_application.PlayFile(*m_lastPlayedFileItem, m_lastUsedPlayer);
 }
 
 void CPowerManager::SettingOptionsShutdownStatesFiller(const SettingConstPtr& setting,

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -442,6 +442,7 @@ public:
   static constexpr auto SETTING_POWERMANAGEMENT_SHUTDOWNSTATE = "powermanagement.shutdownstate";
   static constexpr auto SETTING_POWERMANAGEMENT_WAKEONACCESS = "powermanagement.wakeonaccess";
   static constexpr auto SETTING_POWERMANAGEMENT_WAITFORNETWORK = "powermanagement.waitfornetwork";
+  static constexpr auto SETTING_POWERMANAGEMENT_RESTARTPLAYER = "powermanagement.restartplayer";
   static constexpr auto SETTING_DEBUG_SHOWLOGINFO = "debug.showloginfo";
   static constexpr auto SETTING_DEBUG_EXTRALOGGING = "debug.extralogging";
   static constexpr auto SETTING_DEBUG_SETEXTRALOGLEVEL = "debug.setextraloglevel";


### PR DESCRIPTION
Created a new option to disable automatic playback on wake up. Does not change the default behaviour

## Description
Adds a new option to optionally stop kodi from restarting playback after being woken up from sleep

## Motivation and context
The current behavioiur is a bit frustrating, because I expect the playback to stop after putting the PC to sleep. It's nice to have an option to disable it.

## How has this been tested?
I compiled it for arch + wayland, and tested it by changing the option, putting my pc to sleep, and seeing the results

## What is the effect on users?
Doesn't affect users when the option is unchanged.


## Types of change
- [x] **New feature** (non-breaking change which adds functionality)

## Checklist:
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed