### PR TITLE
Fix crash of addon install from 0 byte .zip

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2011-2018 Team Kodi
+ *  Copyright (C) 2011-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -48,6 +48,8 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+
+#include <fmt/format.h>
 
 using namespace XFILE;
 using namespace ADDON;
@@ -504,10 +506,10 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
           24045, StringUtils::Format(g_localizeStrings.Get(24143), path),
           "special://xbmc/media/icon256x256.png", EventLevel::Error));
 
-    CLog::Log(
-        LOGERROR,
-        "CAddonInstaller: installing addon failed '{}' - itemsize: {}, first item is folder: {}",
-        CURL::GetRedacted(path), items.Size(), items[0]->IsFolder());
+    CLog::Log(LOGERROR, "CAddonInstaller: installing addon failed '{}' - item count: {}{}",
+              CURL::GetRedacted(path), items.Size(),
+              items.Size() > 0 ? fmt::format(", first item is folder: {}", items[0]->IsFolder())
+                               : "");
     return false;
   }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Check that the items vector has elements before accessing the first one.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Attempting to install a 0-byte file as an addon .zip crashes the app.

Fix #27802

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

0 byte .zip file, addon .zip and non-addon .zip file

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

no crash when attempting to install an invalid .zip as an addon.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
