### PR TITLE
[Python] Look for skin string ids in xbmc.getLocalizedstring

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -17,6 +17,7 @@
 #include "LanguageHook.h"
 #include "ServiceBroker.h"
 #include "Util.h"
+#include "addons/Skin.h"
 #include "aojsonrpc.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPowerHandling.h"
@@ -164,6 +165,17 @@ namespace XBMCAddon
     String getLocalizedString(int id)
     {
       XBMC_TRACE;
+      if (ADDON::IsSkinStringId(id))
+      {
+        auto gui = CServiceBroker::GetGUI();
+        if (gui)
+        {
+          auto skin = gui->GetSkinInfo();
+          if (skin)
+            return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().GetAddonString(
+                skin->ID(), id);
+        }
+      }
       return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(id);
     }
 


### PR DESCRIPTION
## Description
To keep compatibility with current skin helper scripts and other addons that expect to get skin strings from `xbmc.getLocalizedString`. Not a big fan of it (xbmc is a common module) but the interface is legacy anyway and full of gui references - so keep the workaround to avoid regressions.

## Motivation and context
Avoid regressions caused by https://github.com/xbmc/xbmc/pull/27712

## How has this been tested?
Runtime tested

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [x] **None of the above** (please explain below)

Compatibility fallback to ensure previous behaviour 
