### PR TITLE
CMusicRole::operator==: move to TU

### DIFF
--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -27,6 +27,7 @@
 #include "utils/FileExtensionProvider.h"
 #include "utils/Random.h"
 #include "utils/RegExp.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoFileItemClassify.h"

--- a/xbmc/addons/AudioDecoder.cpp
+++ b/xbmc/addons/AudioDecoder.cpp
@@ -16,6 +16,7 @@
 #include "music/tags/MusicInfoTag.h"
 #include "music/tags/TagLoaderTagLib.h"
 #include "utils/Mime.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 

--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -28,6 +28,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"

--- a/xbmc/music/Artist.cpp
+++ b/xbmc/music/Artist.cpp
@@ -12,6 +12,7 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Fanart.h"
+#include "utils/StringUtils.h"
 #include "utils/XMLUtils.h"
 
 #include <algorithm>
@@ -266,3 +267,10 @@ void CArtist::SetDateNew(const std::string& strDateNew)
   dateNew.SetFromDBDateTime(strDateNew);
 }
 
+bool CMusicRole::operator==(const CMusicRole& a) const
+{
+  if (StringUtils::EqualsNoCase(m_strRole, a.m_strRole))
+    return StringUtils::EqualsNoCase(m_strArtist, a.m_strArtist);
+  else
+    return false;
+}

--- a/xbmc/music/Artist.cpp
+++ b/xbmc/music/Artist.cpp
@@ -269,8 +269,6 @@ void CArtist::SetDateNew(const std::string& strDateNew)
 
 bool CMusicRole::operator==(const CMusicRole& a) const
 {
-  if (StringUtils::EqualsNoCase(m_strRole, a.m_strRole))
-    return StringUtils::EqualsNoCase(m_strArtist, a.m_strArtist);
-  else
-    return false;
+  return StringUtils::EqualsNoCase(m_strRole, a.m_strRole) &&
+         StringUtils::EqualsNoCase(m_strArtist, a.m_strArtist);
 }

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -11,7 +11,6 @@
 #include "XBDateTime.h"
 #include "utils/Artwork.h"
 #include "utils/ScraperUrl.h"
-#include "utils/StringUtils.h"
 
 #include <map>
 #include <string>
@@ -214,13 +213,8 @@ public:
   int GetArtistId() const { return idArtist; }
   void SetArtistId(int iArtistId) { idArtist = iArtistId;  }
 
-  bool operator==(const CMusicRole& a) const
-  {
-    if (StringUtils::EqualsNoCase(m_strRole, a.m_strRole))
-      return StringUtils::EqualsNoCase(m_strArtist, a.m_strArtist);
-    else
-      return false;
-  }
+  bool operator==(const CMusicRole& a) const;
+
 private:
   int idRole;
   std::string m_strRole;

--- a/xbmc/music/test/TestMusicFileItemClassify.cpp
+++ b/xbmc/music/test/TestMusicFileItemClassify.cpp
@@ -13,6 +13,7 @@
 #include "music/tags/MusicInfoTag.h"
 #include "pictures/PictureInfoTag.h"
 #include "utils/FileExtensionProvider.h"
+#include "utils/StringUtils.h"
 #include "video/VideoInfoTag.h"
 
 #include <array>

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -18,6 +18,7 @@
 #include "addons/addoninfo/AddonType.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 
 #include <string>

--- a/xbmc/video/VideoItemArtworkHandler.cpp
+++ b/xbmc/video/VideoItemArtworkHandler.cpp
@@ -21,6 +21,7 @@
 #include "utils/ArtUtils.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/FileUtils.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"

--- a/xbmc/video/test/TestVideoFileItemClassify.cpp
+++ b/xbmc/video/test/TestVideoFileItemClassify.cpp
@@ -16,6 +16,7 @@
 #include "test/TestUtils.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/FileUtils.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"


### PR DESCRIPTION
avoid include in header

## Description
Avoid pulling in StringUtils.h in header

## Motivation and context
Improve dependency graph

## How has this been tested?
It builds

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
