### PR TITLE
[Datacachecore] do reset audio cache only on format change

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -18,6 +18,7 @@
 #include "cores/AudioEngine/Utils/AEStreamData.h"
 #include "cores/AudioEngine/Utils/AEStreamInfo.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
+#include "cores/DataCacheCore.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/log.h"
@@ -1194,6 +1195,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
        !CompareFormat(m_sinkRequestFormat, oldSinkRequestFormat)) ||
       m_currDevice.compare(dev.name) != 0 || m_settings.driver.compare(dev.driver) != 0)
   {
+    CServiceBroker::GetDataCacheCore().ResetAudioCache();
     FlushEngine();
     if (!InitSink())
       return;

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -38,10 +38,6 @@ void CDataCacheCore::Reset()
     std::unique_lock lock(m_videoPlayerSection);
     m_playerVideoInfo = {};
   }
-  {
-    std::unique_lock lock(m_audioPlayerSection);
-    m_playerAudioInfo = {};
-  }
   m_hasAVInfoChanges = false;
   {
     std::unique_lock lock(m_renderSection);
@@ -52,6 +48,14 @@ void CDataCacheCore::Reset()
     m_contentInfo.Reset();
   }
   m_timeInfo = {};
+}
+
+void CDataCacheCore::ResetAudioCache()
+{
+  {
+    std::unique_lock lock(m_audioPlayerSection);
+    m_playerAudioInfo = {};
+  }
 }
 
 bool CDataCacheCore::HasAVInfoChanges()

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -23,6 +23,7 @@ public:
   virtual ~CDataCacheCore();
   static CDataCacheCore& GetInstance();
   void Reset();
+  void ResetAudioCache();
   bool HasAVInfoChanges();
   void SignalVideoInfoChange();
   void SignalAudioInfoChange();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The audio sink is only reinitialized when the audio format or output device actually changes.
However, the cache is cleared every time on media playback start.
Issue got introduced by https://github.com/xbmc/xbmc/commit/03e1badf7389310b2c54e5241cdd4b08c15070f6. Before this commit the audio cache data was not cleared on reset.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Keep audio cache items like `channels_sink` as example when start media playback.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On CoreELEC with GUI PCM 2.0 48kHz and playback video file with same audio format/device PCM 2.0 48kHz.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Don't loose audio cache items when sink reinitialization is not needed.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
