### PR TITLE
WinSystemGbm: Fix direct-to-plane video tearing

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -119,10 +119,11 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
 
   if (rendered || videoLayer)
   {
+    bool async = !videoLayer && m_eglFence;
     if (rendered)
     {
 #if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
-      if (m_eglFence)
+      if (async)
       {
         int fd = m_DRM->TakeOutFenceFd();
         if (fd != -1)
@@ -142,7 +143,7 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
       }
 
 #if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
-      if (m_eglFence)
+      if (async)
       {
         int fd = m_eglFence->FlushFence();
         m_DRM->SetInFenceFd(fd);
@@ -151,7 +152,8 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
       }
 #endif
     }
-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
+
+    CWinSystemGbm::FlipPage(rendered, videoLayer, async);
 
     if (m_dispReset && m_dispResetTimer.IsTimePast())
     {

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -128,10 +128,11 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
 
   if (rendered || videoLayer)
   {
+    bool async = !videoLayer && m_eglFence;
     if (rendered)
     {
 #if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
-      if (m_eglFence)
+      if (async)
       {
         int fd = m_DRM->TakeOutFenceFd();
         if (fd != -1)
@@ -151,7 +152,7 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
       }
 
 #if defined(EGL_ANDROID_native_fence_sync) && defined(EGL_KHR_fence_sync)
-      if (m_eglFence)
+      if (async)
       {
         int fd = m_eglFence->FlushFence();
         m_DRM->SetInFenceFd(fd);
@@ -161,7 +162,7 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
 #endif
     }
 
-    CWinSystemGbm::FlipPage(rendered, videoLayer, static_cast<bool>(m_eglFence));
+    CWinSystemGbm::FlipPage(rendered, videoLayer, async);
 
     if (m_dispReset && m_dispResetTimer.IsTimePast())
     {


### PR DESCRIPTION
## Description
The commit e9710033029d ("CDRMAtomic: add support for using DRM_MODE_ATOMIC_NONBLOCK") part of PR #23921 ("windowing/gbm: add EGL fencing for atomic drm") introduced use of EGL fencing and use of non-blocking page-flips.

Use of non-blocking page-flips works fine if we have something rendered. However, when direct-to-plane rendering is used and there is a videoLayer active the use of non-blocking page-flips leads to video tearing when the GUI overlay is flipping between being rendered or not.

Video tearing happens because the videoLayerBridge releases video frame buffers back to the free pool as soon as next frame is ready, resulting in it only supporting double buffer rendering and not triple buffer needed when using non-blocking page-flips.

Fix video tearing when videoLayer is used by enforcing use of blocking page-flips to ensure double buffer rendering is used and that rendering is not running ahead causing the frame currently being shown on screen being used as target for next frame being decoded.

## Motivation and context
Projects using kodi-gbm with direct-to-plane rendering, e.g. LibreELEC, typically contain a patch to revert use of EGL fencing to fix video tearing on embedded devices.

## How has this been tested?
Current LibreELEC master (Rockchip project) have been carrying this fix instead of a full revert of EGL fencing for the past two months.
https://github.com/LibreELEC/LibreELEC.tv/blob/master/projects/Rockchip/patches/kodi/0004-WinSystemGbm-Fix-video-layer-tearing.patch

## What is the effect on users?
No video tearing when e.g. flipping OSD menu to be show / not shown when full screen video is played using kodi-gbm and direct-to-plane video rendering is being used.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed