### PR TITLE
webOS: prefix gcc for LTO plugin

### DIFF
--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -300,6 +300,9 @@ case $host in
       use_linker=wasm-ld
     fi
   ;;
+  arm-webos-linux-gnueabi|arm-starfish-linux-gnueabi)
+    lto_wrap_prefix=gcc-
+  ;;
   *darwin*)
     # Again we set CC to find toolchain path for use in AC_PATH_TOOL macros further down
     CC=[`$use_xcrun --find clang`]
@@ -318,13 +321,13 @@ else
   PATH_FOR_HOST=$PATH
 fi
 
-AC_PATH_TOOL([RANLIB], [${platform_tool_prefix}ranlib],, $PATH_FOR_HOST)
+AC_PATH_TOOL([RANLIB], [${platform_tool_prefix}${lto_wrap_prefix}ranlib],, $PATH_FOR_HOST)
 AC_PATH_TOOL([LD], [${use_linker}],, $PATH_FOR_HOST)
-AC_PATH_TOOL([AR], [${platform_tool_prefix}ar],, $PATH_FOR_HOST)
+AC_PATH_TOOL([AR], [${platform_tool_prefix}${lto_wrap_prefix}ar],, $PATH_FOR_HOST)
 AC_PATH_TOOL([READELF], [${platform_tool_prefix}readelf],, $PATH_FOR_HOST)
 AC_PATH_TOOL([STRIP], [${platform_tool_prefix}strip],, $PATH_FOR_HOST)
 AC_PATH_TOOL([AS], [${platform_tool_prefix}as],, $PATH_FOR_HOST)
-AC_PATH_TOOL([NM], [${platform_tool_prefix}nm],, $PATH_FOR_HOST)
+AC_PATH_TOOL([NM], [${platform_tool_prefix}${lto_wrap_prefix}nm],, $PATH_FOR_HOST)
 AC_PATH_TOOL([OBJDUMP], [${platform_tool_prefix}objdump],, $PATH_FOR_HOST)
 AC_PATH_TOOL([CC],[$platform_cc],,$PATH_FOR_HOST)
 AC_PATH_TOOL([CXX],[$platform_cxx],,$PATH_FOR_HOST)


### PR DESCRIPTION
## Description
Fix usage of USE_LTO for webOS toolchain build. I was looking into making a smaller build but found that LTO would not compile in the first place.

## Motivation and context
Compiling with USE_LTO=ON will result in a failure as it is unable to find the LTO plugin.

AR, NM and RANLIB have the wrappers that automatically find and load the LTO plugin with resolves this issue.

e.g. arm-webos-linux-gnueabi-gcc-ar instead of arm-webos-linux-gnueabi-ar

Compilation sizes produced (after strip):

- **Default with -Os:** 67mb
-  **-Os plus LTO:** = 67mb
- **-O2 without LTO:** = 81mb
- **-O2 with LTO:** - 75mb
- **LTO + optimize_flags:** "-O2 -fdata-sections -ffunction-sections -Wl,--gc-sections" = 74mb
- **LTO + optimize_flags:**  "-O2 -fdata-sections -ffunction-sections -Wl,--gc-sections -fno-inline-small-functions -fno-unroll-loops" = 72mb
- **LTO + optimize_flags**="-Os -fdata-sections -ffunction-sections -Wl,--gc-sections" = 66mb

## How has this been tested?
Compile for depends for webOS
Compile kodi binary for webOS using USE_LTO=ON

## What is the effect on users?
Smaller binary potentially depending on other compiler parameters used.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
