### PR TITLE
dbwrappers: support Fedora MariaDB header layout

### DIFF
--- a/cmake/modules/FindMariaDBClient.cmake
+++ b/cmake/modules/FindMariaDBClient.cmake
@@ -96,6 +96,10 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
     BUILD_DEP_TARGET()
 
+    # Make INCLUDE_DIR match cmake config output
+    string(APPEND ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR "/mariadb")
+    file(MAKE_DIRECTORY ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR})
+
     add_dependencies(${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME} LIBRARY::OpenSSL
                                                                         LIBRARY::ZLIB)
 

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -27,7 +27,7 @@
 #ifdef HAS_MYSQL
 #include <mysql/errmsg.h>
 #elif defined(HAS_MARIADB)
-#include <mariadb/errmsg.h>
+#include <errmsg.h>
 #endif
 
 #ifdef TARGET_POSIX

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -15,7 +15,7 @@
 #ifdef HAS_MYSQL
 #include <mysql/mysql.h>
 #elif defined(HAS_MARIADB)
-#include <mariadb/mysql.h>
+#include <mysql.h>
 #endif
 
 namespace dbiplus


### PR DESCRIPTION
## Description                                                                                                                                                         
When MariaDB is detected (`HAS_MARIADB`), Kodi includes headers from `<mariadb/>`. On Fedora, the MariaDB client package installs its headers under `<mysql/>` instead, causing compilation to fail with missing header errors.

This adds a `__has_include` check to fall back to `<mysql/>` paths when the `<mariadb/>` headers are not found.

## Motivation and context                                                                                                                                              
Kodi fails to compile on Fedora when using the system MariaDB client libraries, because Fedora's `mariadb-connector-c-devel` package places headers in `/usr/include/mysql/` rather than `/usr/include/mariadb/`.

## How has this been tested?
Tested on Fedora 43 (Rawhide) with `mariadb-connector-c-devel` installed. Compilation succeeds with this change where it previously failed on the `#include <mariadb/errmsg.h>` and `#include <mariadb/mysql.h>` directives. Also tested in conjunction with the fix-crossguid PR (#27820) for a full build.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed