### PR TITLE
[PVR] Fix range lookup for channel group

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -39,6 +39,8 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 
+#include <algorithm>
+#include <iterator>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -482,21 +484,13 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog()
   }
   else
   {
-    const std::shared_ptr<const CPVRChannelGroup> channelGroup = GetChannelGroup();
+    const auto channelGroup = GetChannelGroup();
     if (channelGroup)
     {
-      int idx = 0;
-      const std::string selectedGroup{channelGroup->GetPath().AsString()};
-      for (const auto& group : options)
-      {
-        // select currently active channel group
-        if (group->GetPath() == selectedGroup)
-        {
-          dialog->SetSelected(idx);
-          break;
-        }
-        idx++;
-      }
+      const auto selectedGroup = channelGroup->GetPath().AsString();
+      const auto it = std::ranges::find(options, selectedGroup, &CFileItem::GetPath);
+      if (it != options.end())
+        dialog->SetSelected(static_cast<int>(std::distance(options.begin(), it)));
     }
   }
 

--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -485,7 +485,7 @@ bool CGUIWindowPVRBase::OpenChannelGroupSelectionDialog()
     const std::shared_ptr<const CPVRChannelGroup> channelGroup = GetChannelGroup();
     if (channelGroup)
     {
-      int idx = -1;
+      int idx = 0;
       const std::string selectedGroup{channelGroup->GetPath().AsString()};
       for (const auto& group : options)
       {


### PR DESCRIPTION
## Description
Found while selecting channel groups in the side menu with only one provider installed. It seems that the range lookup starts at -1 (unlike the `usedetails` branch) and the idx increment is only done after comparison. As a result, we always result with having the wrong channel group selected by default when opening the dialog - exactly by 1 item difference.
Added a second commit to modernize the code on this particular branch.

