### PR TITLE
[Globals] Kill g_zipmanager

### DIFF
--- a/cmake/treedata/common/subdirs.txt
+++ b/cmake/treedata/common/subdirs.txt
@@ -10,6 +10,7 @@ xbmc/addons/interfaces/gui/controls             addons_interfaces_gui_controls
 xbmc/addons/interfaces/gui/dialogs              addons_interfaces_gui_dialogs
 xbmc/addons/settings                            addons_settings
 xbmc/application                                application
+xbmc/cache                                      cache
 xbmc/commons                                    commons
 xbmc/dbwrappers                                 dbwrappers
 xbmc/dialogs                                    dialogs

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -299,6 +299,21 @@ CApplicationComponents& CServiceBroker::GetAppComponents()
   return g_application;
 }
 
+CCacheComponent* CServiceBroker::GetCacheComponent()
+{
+  return g_serviceBroker.m_pCacheComponent;
+}
+
+void CServiceBroker::RegisterCacheComponent(CCacheComponent* cache)
+{
+  g_serviceBroker.m_pCacheComponent = cache;
+}
+
+void CServiceBroker::UnregisterCacheComponent()
+{
+  g_serviceBroker.m_pCacheComponent = nullptr;
+}
+
 CGUIComponent* CServiceBroker::GetGUI()
 {
   return g_serviceBroker.m_pGUI;

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -69,6 +69,7 @@ class CWeatherManager;
 class CPlayerCoreFactory;
 class CDatabaseManager;
 class CEventLog;
+class CCacheComponent;
 class CGUIComponent;
 class CResourcesComponent;
 class CAppInboundProtocol;
@@ -181,6 +182,10 @@ public:
   static CMediaManager& GetMediaManager();
   static CComponentContainer<IApplicationComponent>& GetAppComponents();
 
+  static CCacheComponent* GetCacheComponent();
+  static void RegisterCacheComponent(CCacheComponent* cache);
+  static void UnregisterCacheComponent();
+
   static CGUIComponent* GetGUI();
   static void RegisterGUI(CGUIComponent* gui);
   static void UnregisterGUI();
@@ -248,6 +253,7 @@ private:
   std::shared_ptr<CAppParams> m_appParams;
   std::unique_ptr<CLog> m_logging;
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
+  CCacheComponent* m_pCacheComponent = nullptr;
   CGUIComponent* m_pGUI = nullptr;
   std::unique_ptr<CResourcesComponent> m_pResourcesComponent;
   CWinSystemBase* m_pWinSystem = nullptr;

--- a/xbmc/SystemGlobals.cpp
+++ b/xbmc/SystemGlobals.cpp
@@ -17,11 +17,8 @@
 #include "interfaces/python/XBPython.h"
 #endif
 
-// Guarantee that CSpecialProtocol is initialized before and uninitialized after ZipManager
 #include "filesystem/SpecialProtocol.h"
 std::map<std::string, std::string> CSpecialProtocol::m_pathMap;
-
-#include "filesystem/ZipManager.h"
 
 CLangCodeExpander g_LangCodeExpander;
 
@@ -34,5 +31,3 @@ CPartyModeManager g_partyModeManager;
 
 CAlarmClock g_alarmClock;
 CSectionLoader g_sectionLoader;
-
-CZipManager g_ZipManager;

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -70,6 +70,7 @@
 #ifdef HAS_FILESYSTEM_NFS
 #include "filesystem/NFSFile.h"
 #endif
+#include "cache/CacheComponent.h"
 #include "filesystem/PluginDirectory.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GUIAudioManager.h"
@@ -274,6 +275,9 @@ bool CApplication::Create()
   CServiceBroker::RegisterKeyboardLayoutManager(keyboardLayoutManager);
 
   CServiceBroker::RegisterDNSNameCache(std::make_shared<CDNSNameCache>());
+
+  m_pCacheComponent = std::make_unique<CCacheComponent>();
+  m_pCacheComponent->Init();
 
   m_ServiceManager = std::make_unique<CServiceManager>();
 
@@ -1686,6 +1690,12 @@ bool CApplication::Cleanup()
     {
       m_pGUI->Deinit();
       m_pGUI.reset();
+    }
+
+    if (m_pCacheComponent)
+    {
+      m_pCacheComponent->Deinit();
+      m_pCacheComponent.reset();
     }
 
     if (winSystem)

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -30,6 +30,7 @@
 class CAction;
 class CApplicationMessageHandling;
 class CBookmark;
+class CCacheComponent;
 class CFileItem;
 class CFileItemList;
 class CGUIComponent;
@@ -206,6 +207,7 @@ protected:
   void ResetPlayerEvent() { m_playerEvent.Reset(); }
 
   std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_pAnnouncementManager;
+  std::unique_ptr<CCacheComponent> m_pCacheComponent;
   std::unique_ptr<CGUIComponent> m_pGUI;
   std::unique_ptr<CWinSystemBase> m_pWinSystem;
   std::unique_ptr<ActiveAE::CActiveAE> m_pActiveAE;

--- a/xbmc/cache/CMakeLists.txt
+++ b/xbmc/cache/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(SOURCES CacheComponent.cpp)
+
+set(HEADERS CacheComponent.h
+            FileSystemCache.h)
+
+core_add_library(caches)

--- a/xbmc/cache/CacheComponent.cpp
+++ b/xbmc/cache/CacheComponent.cpp
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "CacheComponent.h"
+
+#include "FileSystemCache.h"
+#include "ServiceBroker.h"
+#include "filesystem/Zip.h"
+
+CCacheComponent::CCacheComponent() : m_zipCache(std::make_unique<CFileSystemCache<SZipEntry>>())
+{
+}
+
+CCacheComponent::~CCacheComponent()
+{
+  Deinit();
+}
+
+void CCacheComponent::Init()
+{
+  CServiceBroker::RegisterCacheComponent(this);
+}
+
+void CCacheComponent::Deinit()
+{
+  CServiceBroker::UnregisterCacheComponent();
+}
+
+CFileSystemCache<SZipEntry>& CCacheComponent::GetZipCache()
+{
+  return *m_zipCache;
+}

--- a/xbmc/cache/CacheComponent.h
+++ b/xbmc/cache/CacheComponent.h
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <memory>
+
+struct SZipEntry;
+template<typename TEntry>
+class CFileSystemCache;
+
+class CCacheComponent
+{
+public:
+  CCacheComponent();
+  ~CCacheComponent();
+
+  void Init();
+  void Deinit();
+
+  CFileSystemCache<SZipEntry>& GetZipCache();
+
+private:
+  std::unique_ptr<CFileSystemCache<SZipEntry>> m_zipCache;
+};

--- a/xbmc/cache/FileSystemCache.h
+++ b/xbmc/cache/FileSystemCache.h
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "threads/CriticalSection.h"
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+/*!
+ * \brief Format-agnostic cache for archive file system entries.
+ *
+ * Manages cache storage, lookup, invalidation (by mtime), and eviction.
+ * Thread-safe via CCriticalSection (recursive mutex).
+ */
+template<typename TEntry>
+class CFileSystemCache
+{
+public:
+  /*!
+   * \brief Returns true and fills items if path is cached and mtime matches.
+   */
+  bool GetCachedList(const std::string& path, int64_t currentMtime, std::vector<TEntry>& items)
+  {
+    std::unique_lock lock(m_lock);
+    auto it = m_cache.find(path);
+    if (it == m_cache.end())
+      return false;
+
+    auto dateIt = m_dates.find(path);
+    if (dateIt == m_dates.end() || dateIt->second != currentMtime)
+    {
+      // mtime changed — invalidate
+      m_cache.erase(it);
+      if (dateIt != m_dates.end())
+        m_dates.erase(dateIt);
+      return false;
+    }
+
+    items = it->second;
+    return true;
+  }
+
+  /*!
+   * \brief Stores parsed entries in cache.
+   */
+  void StoreList(const std::string& path, int64_t mtime, std::vector<TEntry> items)
+  {
+    std::unique_lock lock(m_lock);
+    m_cache[path] = std::move(items);
+    m_dates[path] = mtime;
+  }
+
+  /*!
+   * \brief Evicts a path from the cache.
+   */
+  void Release(const std::string& path)
+  {
+    std::unique_lock lock(m_lock);
+    m_cache.erase(path);
+    m_dates.erase(path);
+  }
+
+private:
+  std::map<std::string, std::vector<TEntry>> m_cache;
+  std::map<std::string, int64_t> m_dates;
+  mutable CCriticalSection m_lock;
+};

--- a/xbmc/filesystem/CMakeLists.txt
+++ b/xbmc/filesystem/CMakeLists.txt
@@ -59,7 +59,7 @@ set(SOURCES AddonsDirectory.cpp
             ZeroconfDirectory.cpp
             ZipDirectory.cpp
             ZipFile.cpp
-            ZipManager.cpp)
+            Zip.cpp)
 
 set(HEADERS AddonsDirectory.h
             CacheStrategy.h
@@ -124,7 +124,7 @@ set(HEADERS AddonsDirectory.h
             ZeroconfDirectory.h
             ZipDirectory.h
             ZipFile.h
-            ZipManager.h)
+            Zip.h)
 
 if(TARGET ${APP_NAME_LC}::Iso9660pp)
   list(APPEND SOURCES ISO9660Directory.cpp

--- a/xbmc/filesystem/ZipDirectory.h
+++ b/xbmc/filesystem/ZipDirectory.h
@@ -10,6 +10,8 @@
 
 #include "IFileDirectory.h"
 
+#include <string>
+
 namespace XFILE
 {
   class CZipDirectory : public IFileDirectory
@@ -20,5 +22,8 @@ namespace XFILE
     bool GetDirectory(const CURL& url, CFileItemList& items) override;
     bool ContainsFiles(const CURL& url) override;
     CacheType GetCacheType(const CURL& url) const override { return CacheType::ALWAYS; }
+
+    static bool ExtractArchive(const std::string& strArchive, const std::string& strPath);
+    static bool ExtractArchive(const CURL& archive, const std::string& strPath);
   };
 }

--- a/xbmc/filesystem/ZipFile.h
+++ b/xbmc/filesystem/ZipFile.h
@@ -10,7 +10,7 @@
 
 #include "File.h"
 #include "IFile.h"
-#include "ZipManager.h"
+#include "Zip.h"
 
 #include <zlib.h>
 

--- a/xbmc/filesystem/test/TestZipFile.cpp
+++ b/xbmc/filesystem/test/TestZipFile.cpp
@@ -10,6 +10,7 @@
 #include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "cache/CacheComponent.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/ZipFile.h"
@@ -32,6 +33,16 @@ protected:
   {
     CServiceBroker::GetSettingsComponent()->GetSettings()->Unload();
   }
+
+  void SetUp() override
+  {
+    m_cacheComponent = std::make_unique<CCacheComponent>();
+    m_cacheComponent->Init();
+  }
+
+  void TearDown() override { m_cacheComponent.reset(); }
+
+  std::unique_ptr<CCacheComponent> m_cacheComponent;
 };
 
 TEST_F(TestZipFile, Read)

--- a/xbmc/filesystem/test/TestZipManager.cpp
+++ b/xbmc/filesystem/test/TestZipManager.cpp
@@ -6,7 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include "filesystem/ZipManager.h"
+#include "filesystem/Zip.h"
 #include "utils/RegExp.h"
 
 #include <gtest/gtest.h>

--- a/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
+++ b/xbmc/interfaces/builtins/ApplicationBuiltins.cpp
@@ -12,7 +12,7 @@
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPowerHandling.h"
 #include "application/ApplicationVolumeHandling.h"
-#include "filesystem/ZipManager.h"
+#include "filesystem/ZipDirectory.h"
 #include "input/actions/ActionIDs.h"
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/ApplicationMessenger.h"
@@ -46,7 +46,7 @@ static int Extract(const std::vector<std::string>& params)
     URIUtils::AddSlashAtEnd(strDestDirect);
 
     if (URIUtils::IsZIP(params[0]))
-      g_ZipManager.ExtractArchive(params[0],strDestDirect);
+      XFILE::CZipDirectory::ExtractArchive(params[0], strDestDirect);
     else
       CLog::Log(LOGERROR, "Extract, No archive given");
 

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -18,6 +18,8 @@
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
+#include "cache/CacheComponent.h"
+#include "cache/FileSystemCache.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "dialogs/GUIDialogBusy.h"
 #include "dialogs/GUIDialogContextMenu.h"
@@ -29,7 +31,7 @@
 #include "filesystem/Directory.h"
 #include "filesystem/FileDirectoryFactory.h"
 #include "filesystem/VirtualDirectory.h"
-#include "filesystem/ZipManager.h"
+#include "filesystem/Zip.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIKeyboardFactory.h"
 #include "guilib/GUIWindowManager.h"
@@ -864,7 +866,7 @@ void CGUIWindowFileManager::GoParentFolder(int iList)
     // check for step-below, if, unmount rar
     if (url.GetFileName().empty())
       if (url.IsProtocol("zip"))
-        g_ZipManager.release(m_Directory[iList]->GetPath()); // release resources
+        CServiceBroker::GetCacheComponent()->GetZipCache().Release(url.GetHostName());
   }
 
   std::string strPath(m_strParentPath[iList]), strOldPath(m_Directory[iList]->GetPath());


### PR DESCRIPTION
## Description
- Splits the zipmanager code to decouple the cache from the actual zip processing logic
- Introduce a CacheComponent into service broker and hold the zipcache there (in the future datacache core, bluray cache, etc can be moved there)
- Keep Zip (old zipmanager simple)
- Dilute some of the logic to the respective vfs components (zip file and zip directory)
- kill the g_zipManager global, the only long lived component is the zip cache.

## Motivation and context
Kill globals

## How has this been tested?
Compiled, more testing is needed

## What is the effect on users?
Hopefully none

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

