### PR TITLE
LibInputKeyboard: trim newlines from [xkb] debug log messages

### DIFF
--- a/xbmc/platform/linux/input/LibInputHandler.cpp
+++ b/xbmc/platform/linux/input/LibInputHandler.cpp
@@ -14,6 +14,7 @@
 #include "LibInputTouch.h"
 #include "ServiceBroker.h"
 #include "interfaces/AnnouncementManager.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <algorithm>
@@ -64,7 +65,11 @@ static void LogHandler(libinput  __attribute__((unused)) *libinput, libinput_log
     char buf[512];
     int n = vsnprintf(buf, sizeof(buf), format, args);
     if (n > 0)
-      CLog::Log(LOGDEBUG, "libinput: {}", buf);
+    {
+      std::string message(buf);
+      StringUtils::TrimRight(message);
+      CLog::Log(LOGDEBUG, "libinput: {}", message);
+    }
   }
 }
 

--- a/xbmc/platform/linux/input/LibInputKeyboard.cpp
+++ b/xbmc/platform/linux/input/LibInputKeyboard.cpp
@@ -213,7 +213,8 @@ static void xkbLogger(xkb_context* context,
                       const char* format,
                       va_list args)
 {
-  const std::string message = StringUtils::FormatV(format, args);
+  std::string message = StringUtils::FormatV(format, args);
+  StringUtils::TrimRight(message);
   auto logLevel = logLevelMap.find(priority);
   CLog::Log(logLevel != logLevelMap.cend() ? logLevel->second : LOGDEBUG, "[xkb] {}", message);
 }


### PR DESCRIPTION
## Description
The xkbLogger function in `LibInputKeyboard.cpp` is using StringUtils::FormatV(format, args) which formats the message from the xkb library. The xkb logging function sends messages containing newline characters, then the logger adds additional formatting so we end up with a blank line betwen log events in kodi.log.

Change const std::string message to std::string message so it can be modified, then use StringUtils::TrimRight(message); to remove trailing whitespace/newlines from the formatted message before it is passed to CLog::Log(). Also fix the same issue in `LibInputHandler.cpp` with the initial libinput device open.

## Motivation and context
OCD about unnecessary blank lines in debug logs :)

## How has this been tested?
Before:
```
2026-02-08 13:01:50.180 T:967     debug <general>: [xkb] Compiling from RMLVO: rules 'evdev', model 'pc105', layout 'us', variant '(null)', options '(null)'
                                                   
2026-02-08 13:01:50.185 T:967     debug <general>: [xkb] Compiling from KcCGST: keycodes 'evdev+aliases(qwerty)', types 'complete', compat 'complete', symbols 'pc+us+inet(evdev)'
                                                   
2026-02-08 13:01:50.185 T:967     debug <general>: [xkb] Compiling xkb_keycodes "(unnamed map)"
                                                   
2026-02-08 13:01:50.191 T:967     debug <general>: [xkb] Compiling xkb_types "(unnamed map)"
                                                   
2026-02-08 13:01:50.198 T:967     debug <general>: [xkb] Compiling xkb_compatibility "(unnamed map)"
                                                   
2026-02-08 13:01:50.200 T:967     debug <general>: [xkb] The "group" statement in compat is unsupported; Ignored
                                                   
2026-02-08 13:01:50.200 T:967      info <general>: Skipped 2 duplicate messages..
2026-02-08 13:01:50.200 T:967     debug <general>: [xkb] The "allowExplicit" field in indicator statements is unsupported; Ignored
                                                   
2026-02-08 13:01:50.202 T:967      info <general>: Skipped 3 duplicate messages..
2026-02-08 13:01:50.202 T:967     debug <general>: [xkb] The "indicatorDrivesKeyboard" field in indicator statements is unsupported; Ignored
                                                   
2026-02-08 13:01:50.203 T:967     debug <general>: [xkb] The "allowExplicit" field in indicator statements is unsupported; Ignored
                                                   
2026-02-08 13:01:50.204 T:967     debug <general>: [xkb] Indicator name "Shift Lock" was not declared in the keycodes section; Adding new indicator
                                                   
2026-02-08 13:01:50.205 T:967     debug <general>: [xkb] Indicator name "Group 2" was not declared in the keycodes section; Adding new indicator
                                                   
2026-02-08 13:01:50.205 T:967     debug <general>: [xkb] Indicator name "Mouse Keys" was not declared in the keycodes section; Adding new indicator
                                                   
2026-02-08 13:01:50.205 T:967     debug <general>: [xkb] Compiling xkb_symbols "(unnamed map)"
                                                   
2026-02-08 13:01:50.216 T:967     error <general>: [xkb] couldn't find a Compose file for locale "C" (mapped to "C")
                                                   
2026-02-08 13:01:50.216 T:967   warning <general>: CLibInputKeyboard: Failed to compile localized compose table, composed key support will be disabled
2026-02-08 13:01:50.231 T:972     debug <general>: Thread libinput start, auto delete: false
2026-02-08 13:01:50.231 T:967     debug <general>: [threads] name: 'libinput' priority: '1'
```
After (not from the same device):
```
2026-02-09 10:25:40.008 T:748     debug <general>: libinput: event0: device is ignored
2026-02-09 10:25:40.071 T:748     debug <general>: [xkb] Compiling from RMLVO: rules 'evdev', model 'pc105', layout 'us', variant '(null)', options '(null)'
2026-02-09 10:25:40.071 T:748      info <general>: [xkb] Include path failed: "/storage/.config/xkb" (No such file or directory)
2026-02-09 10:25:40.071 T:748      info <general>: [xkb] Include path failed: "/storage/.xkb" (No such file or directory)
2026-02-09 10:25:40.072 T:748      info <general>: [xkb] Include path failed: "/etc/xkb" (No such file or directory)
2026-02-09 10:25:40.072 T:748     debug <general>: [xkb] Include extensions path failed: /usr/share/xkeyboard-config-2.d (No such file or directory)
2026-02-09 10:25:40.072 T:748     debug <general>: [xkb] Include extensions path failed: /usr/share/xkeyboard-config.d (No such file or directory)
2026-02-09 10:25:40.072 T:748      info <general>: [xkb] Include path added: /usr/share/xkeyboard-config-2
2026-02-09 10:25:40.081 T:748     debug <general>: [xkb] Compiling from KcCGST: keycodes 'evdev+aliases(qwerty)', types 'complete', compat 'complete', symbols 'pc+us+inet(evdev)'
2026-02-09 10:25:40.081 T:748     debug <general>: [xkb] Compiling xkb_keycodes "(unnamed map)"
2026-02-09 10:25:40.084 T:748     debug <general>: [xkb] Compiling xkb_types "(unnamed map)"
2026-02-09 10:25:40.098 T:748     debug <general>: [xkb] Compiling xkb_compatibility "(unnamed map)"
2026-02-09 10:25:40.100 T:748     debug <general>: [xkb] The "group" statement in compat is unsupported; Ignored
2026-02-09 10:25:40.102 T:748     debug <general>: Skipped 2 duplicate messages..
2026-02-09 10:25:40.102 T:748     debug <general>: [xkb] The "allowExplicit" field in indicator statements is unsupported; Ignored
2026-02-09 10:25:40.105 T:748     debug <general>: Skipped 3 duplicate messages..
2026-02-09 10:25:40.105 T:748     debug <general>: [xkb] The "indicatorDrivesKeyboard" field in indicator statements is unsupported; Ignored
2026-02-09 10:25:40.108 T:748     debug <general>: [xkb] The "allowExplicit" field in indicator statements is unsupported; Ignored
2026-02-09 10:25:40.112 T:748     debug <general>: [xkb] Indicator name "Shift Lock" was not declared in the keycodes section; Adding new indicator
2026-02-09 10:25:40.112 T:748     debug <general>: [xkb] Indicator name "Group 2" was not declared in the keycodes section; Adding new indicator
2026-02-09 10:25:40.112 T:748     debug <general>: [xkb] Indicator name "Mouse Keys" was not declared in the keycodes section; Adding new indicator
2026-02-09 10:25:40.112 T:748     debug <general>: [xkb] Compiling xkb_symbols "(unnamed map)"
2026-02-09 10:25:40.129 T:748     error <general>: [xkb] [XKB-679] No Compose file for locale "en_US.UTF-8": locale is either invalid or not installed
2026-02-09 10:25:40.129 T:748     error <general>: [xkb] [XKB-679] couldn't find a Compose file for locale "C" (mapped to "C")
2026-02-09 10:25:40.129 T:748   warning <general>: CLibInputKeyboard::CLibInputKeyboard(): Failed to compile localized compose table, composed key support will be disabled
2026-02-09 10:25:40.139 T:754     debug <general>: Thread libinput start, auto delete: false
2026-02-09 10:25:40.139 T:748     debug <general>: [threads] name: 'libinput' priority: '1'
```

## What is the effect on users?
Cleaner looking logs

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
