### PR TITLE
Fix: Refresh visibility of all setting controls when a setting value changes

### DIFF
--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -506,7 +506,15 @@ void CGUIDialogSettingsBase::OnSettingChanged(const std::shared_ptr<const CSetti
       setting->GetType() == SettingType::Action)
     return;
 
-  UpdateSettingControl(setting->GetId(), true);
+  // Update all visible setting controls — not just the changed one —
+  // because other controls may have visibility conditions that depend
+  // on the value of the setting that just changed (e.g. addon settings
+  // using <dependency type="visible" setting="...">">.
+  for (const auto& control : m_settingControls)
+  {
+    if (control)
+      UpdateSettingControl(control, control->GetSetting() != setting);
+  }
 }
 
 void CGUIDialogSettingsBase::OnSettingPropertyChanged(

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -524,7 +524,7 @@ void CGUIDialogSettingsBase::OnSettingChanged(const std::shared_ptr<const CSetti
     const auto& deps = control->GetSetting()->GetDependencies();
     for (const auto& dep : deps)
     {
-      if (dep.GetSettings().count(setting->GetId()) > 0)
+      if (dep.GetSettings().contains(setting->GetId()))
       {
         UpdateSettingControl(control, true);
         break;

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -515,13 +515,17 @@ void CGUIDialogSettingsBase::OnSettingChanged(const std::shared_ptr<const CSetti
     if (!control || control == m_delayedSetting)
       continue;
 
-    if (control->GetSetting() == setting)
+    const auto& controlSetting = control->GetSetting();
+    if (!controlSetting)
+      continue;
+
+    if (controlSetting == setting)
     {
       UpdateSettingControl(control, false);
       continue;
     }
 
-    const auto& deps = control->GetSetting()->GetDependencies();
+    const auto& deps = controlSetting->GetDependencies();
     for (const auto& dep : deps)
     {
       if (dep.GetSettings().contains(setting->GetId()))

--- a/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
+++ b/xbmc/settings/dialogs/GUIDialogSettingsBase.cpp
@@ -512,7 +512,22 @@ void CGUIDialogSettingsBase::OnSettingChanged(const std::shared_ptr<const CSetti
   // using <dependency type="visible" setting="...">">.
   for (const auto& control : m_settingControls)
   {
-    if (control)
+    if (!control || control == m_delayedSetting)
+      continue;
+
+    // Only update controls that depend on the changed setting
+    auto deps = control->GetSetting()->GetDependencies();
+    bool dependsOnChanged = false;
+    for (const auto& dep : deps)
+    {
+      if (dep.GetSettings().count(setting->GetId()) > 0)
+      {
+        dependsOnChanged = true;
+        break;
+      }
+    }
+
+    if (dependsOnChanged || control->GetSetting() == setting)
       UpdateSettingControl(control, control->GetSetting() != setting);
   }
 }


### PR DESCRIPTION
## Description

When a setting value changes (e.g. selecting a different option in a dropdown), only the changed control's display is updated via `UpdateSettingControl()`. However, other controls whose visibility depends on the changed setting — via `<dependency type="visible" setting="...">` — are **not** refreshed. This forces users to close and reopen the settings dialog to see controls appear or disappear based on the new value.

This is particularly noticeable in addon settings that use visibility dependencies to show/hide API key fields based on a selected service.

## The Fix

In `CGUIDialogSettingsBase::OnSettingChanged()`, instead of only updating the single changed control:

```cpp
UpdateSettingControl(setting->GetId(), true);
```

We now iterate over **all** setting controls and update them:

```cpp
for (const auto& control : m_settingControls)
{
  if (control)
    UpdateSettingControl(control, control->GetSetting() != setting);
}
```

Controls that own the changed setting get a full update (`updateDisplayOnly = false`), while all other controls get a display-only update that re-evaluates their visibility conditions.

## How to Reproduce

1. Install any addon that uses `<dependency type="visible">` in `settings.xml`
2. Open the addon's settings
3. Change the value of the setting that controls visibility (e.g. a service selector dropdown)
4. **Before fix:** Dependent fields don't appear/disappear until settings dialog is closed and reopened
5. **After fix:** Dependent fields update immediately

## Testing

- Tested with addon settings using multiple `<dependency type="visible" setting="translation_service" operator="contains">` conditions
- No regressions observed in core Kodi settings dialogs
