### PR TITLE
[VideoPlayer] Avoid renderer teardown if only fps changes midstream

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -76,6 +76,7 @@ public:
 
   virtual bool WantsDoublePass() { return false; }
 
+  void SetFps(float fps) { m_fps = fps; }
   void SetViewMode(int viewMode);
 
   /*! \brief Get video rectangle and view window

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -97,10 +97,21 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
     if (!m_bRenderGUI)
       return true;
 
-    if (m_picture.IsSameParams(picture) && m_fps == fps && m_orientation == orientation &&
-        m_NumberBuffers == buffers && m_pRenderer != nullptr &&
-        !m_pRenderer->ConfigChanged(picture))
+    if (m_pRenderer != nullptr && m_picture.IsSameParams(picture) && m_orientation == orientation &&
+        m_NumberBuffers == buffers && !m_pRenderer->ConfigChanged(picture))
     {
+      if (m_fps != fps)
+      {
+        CLog::Log(LOGDEBUG, "CRenderManager::Configure - framerate changed from {:4.2f} to {:4.2f}",
+                  m_fps, fps);
+        m_fps = fps;
+        m_pRenderer->SetFps(fps);
+        m_bTriggerUpdateResolution = true;
+        // Clear stale vsync/late-frame state from the old framerate; CheckEnableClockSync() will recalibrate on the next FrameMove on the main thread.
+        m_clockSync.Reset();
+        m_dvdClock.SetVsyncAdjust(0);
+        m_lateframes = -1;
+      }
       return true;
     }
   }


### PR DESCRIPTION
## Description
If the framerate changes mid-stream, even if adjust refresh rate is disabled Kodi still does a complete teardown of the renderer which results in a temporary black screen for no reason. As far as I can tell FPS changes should not affect render resources - I suspect this is done because the only way to reconfigure m_fps on the render is to a `Configure` call.
So this avoids the current path by adding an early-return block in Configure expanded to handle fps-only changes, so they no longer fall through to the full teardown if an fps change occurs midstream. Also add `SetFPS` to the base renderer so values stay in-sync.
A few notes:
- Other params like orientation, buffer count, and renderer config are all unchanged - still trigger the full Configure path
- `m_bTriggerUpdateResolution` is updated in such cases so that the display refresh rate still adjusts
- Auto-scalling heuristics still work as before as they depend on `m_fps` and `UpdateVideoFilter()` is called every frame

Unsure who can provide feedback on this. Maybe I need to invoke @FernetMenta (hope life is going well) :)

## Motivation and context
Temporary black screen seen in a few recordings (from live tv)

## How has this been tested?
Runtime tested on macOS

## What is the effect on users?
No temporary black screen (render teardown) if a simple fps change mid-stream and adjust refresh rate is disabled.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
