### PR TITLE
Smoke: Kodiai fork write-mode

### DIFF
--- a/.kodiai.yml
+++ b/.kodiai.yml
@@ -1,0 +1,10 @@
+review:
+  enabled: true
+
+mention:
+  enabled: true
+
+write:
+  enabled: true
+  allowPaths:
+    - docs/**

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,3 +22,4 @@ Kodi uses CMake as its building system but instructions are highly dependent on 
   <a href="README.Windows.md" title="Windows"><img src="resources/windows.svg" height="78"></a>
 </p>
 
+\nKodiai fork write-mode smoke test.


### PR DESCRIPTION
Adds .kodiai.yml enabling write-mode for docs/** to smoke test bot PR fallback on fork PRs.