### PR TITLE
[Games] RetroPlayer OpenGL rendering cleanup

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -52,8 +52,6 @@ CRPRendererDMAOpenGLES::CRPRendererDMAOpenGLES(const CRenderSettings& renderSett
 
 void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
 {
-  const ViewportCoordinates dest{m_rotatedDestCoords};
-
   auto renderBuffer = static_cast<CRenderBufferDMA*>(m_renderBuffer);
   if (renderBuffer == nullptr)
     return;
@@ -97,7 +95,8 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight}, *source, *target))
+    if (!m_shaderPreset->RenderUpdate(m_rotatedDestCoords, {m_fullDestWidth, m_fullDestHeight},
+                                      *source, *target))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
@@ -106,15 +105,6 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
   // Use GUI shader
   else
   {
-    CRect rect = m_sourceRect;
-
-    rect.x1 /= renderBuffer->GetWidth();
-    rect.x2 /= renderBuffer->GetWidth();
-    rect.y1 /= renderBuffer->GetHeight();
-    rect.y2 /= renderBuffer->GetHeight();
-
-    const uint32_t color = (alpha << 24) | 0xFFFFFF;
-
     GLint filter = GL_NEAREST;
     if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
       filter = GL_LINEAR;
@@ -127,24 +117,35 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
 
     m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
 
-    GLubyte colour[4];
-    GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
-    PackedVertex vertex[4];
-
-    GLint vertLoc = m_context.GUIShaderGetPos();
-    GLint loc = m_context.GUIShaderGetCoord0();
+    GLint posLoc = m_context.GUIShaderGetPos();
+    GLint tex0Loc = m_context.GUIShaderGetCoord0();
     GLint uniColLoc = m_context.GUIShaderGetUniCol();
     GLint depthLoc = m_context.GUIShaderGetDepth();
 
     // Setup color values
-    colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
-    colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
-    colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
-    colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
+    GLubyte col[4];
+    const uint32_t color = (alpha << 24) | 0xFFFFFF;
+    col[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+    col[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+    col[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+    col[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
 
+    glUniform4f(uniColLoc, (col[0] / 255.0f), (col[1] / 255.0f), (col[2] / 255.0f),
+                (col[3] / 255.0f));
+    glUniform1f(depthLoc, -1.0f);
+
+    // Setup destination rectangle
+    CRect rect = m_sourceRect;
+    rect.x1 /= renderBuffer->GetWidth();
+    rect.x2 /= renderBuffer->GetWidth();
+    rect.y1 /= renderBuffer->GetHeight();
+    rect.y2 /= renderBuffer->GetHeight();
+
+    PackedVertex vertex[4];
+
+    // Setup vertex position values
     for (unsigned int i = 0; i < 4; i++)
     {
-      // Setup vertex position values
       vertex[i].x = m_rotatedDestCoords[i].x;
       vertex[i].y = m_rotatedDestCoords[i].y;
       vertex[i].z = 0.0f;
@@ -157,26 +158,21 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
     vertex[2].v1 = vertex[3].v1 = rect.y2;
 
     glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_STATIC_DRAW);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_DYNAMIC_DRAW);
 
-    glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
+    glVertexAttribPointer(posLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
                           reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
-    glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
+    glEnableVertexAttribArray(posLoc);
+    glVertexAttribPointer(tex0Loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
                           reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
-
-    glEnableVertexAttribArray(vertLoc);
-    glEnableVertexAttribArray(loc);
+    glEnableVertexAttribArray(tex0Loc);
 
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
 
-    glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
-                (colour[3] / 255.0f));
-    glUniform1f(depthLoc, -1.0f);
     glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
-    glDisableVertexAttribArray(vertLoc);
-    glDisableVertexAttribArray(loc);
+    glDisableVertexAttribArray(posLoc);
+    glDisableVertexAttribArray(tex0Loc);
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -13,6 +13,7 @@
 
 #include <map>
 #include <memory>
+#include <stdint.h>
 
 #include "system_gl.h"
 
@@ -25,7 +26,6 @@ class CShaderTextureGLRef;
 
 namespace RETRO
 {
-class CRenderContext;
 class CRenderBufferOpenGL;
 
 class CRendererFactoryOpenGL : public IRendererFactory
@@ -104,7 +104,7 @@ protected:
   GLuint m_blackbarsVertexVBO;
 
   GLenum m_textureTarget = GL_TEXTURE_2D;
-  float m_clearColour = 0.0f;
+  float m_clearColor = 0.0f;
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -11,13 +11,12 @@
 #include "cores/RetroPlayer/buffers/RenderBufferOpenGLES.h"
 #include "cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
-#include "cores/RetroPlayer/rendering/RenderVideoSettings.h"
 #include "cores/RetroPlayer/shaders/gles/ShaderPresetGLES.h"
 #include "cores/RetroPlayer/shaders/gles/ShaderTextureGLESRef.h"
 #include "utils/GLUtils.h"
 #include "utils/log.h"
 
-#include <cstring>
+#include <cstddef>
 
 using namespace KODI;
 using namespace RETRO;
@@ -54,8 +53,21 @@ CRPRendererOpenGLES::CRPRendererOpenGLES(const CRenderSettings& renderSettings,
   // Initialize CRPBaseRenderer
   m_shaderPreset = std::make_unique<SHADER::CShaderPresetGLES>(m_context);
 
-  glGenBuffers(1, &m_mainIndexVBO);
+  // Initialize CRPRendererOpenGLES
+  m_clearColor = m_context.UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
+
+  const GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
+
+  // Set up main screen VBO
   glGenBuffers(1, &m_mainVertexVBO);
+
+  glGenBuffers(1, &m_mainIndexVBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
+
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+
+  // Set up black bars VBO
   glGenBuffers(1, &m_blackbarsVertexVBO);
 
   m_context.ApplyStateBlock();
@@ -65,6 +77,7 @@ CRPRendererOpenGLES::~CRPRendererOpenGLES()
 {
   glDeleteBuffers(1, &m_mainIndexVBO);
   glDeleteBuffers(1, &m_mainVertexVBO);
+
   glDeleteBuffers(1, &m_blackbarsVertexVBO);
 }
 
@@ -91,7 +104,6 @@ void CRPRendererOpenGLES::RenderInternal(bool clear, uint8_t alpha)
   Render(alpha);
 
   glEnable(GL_BLEND);
-  glFlush();
 }
 
 void CRPRendererOpenGLES::FlushInternal()
@@ -116,7 +128,7 @@ bool CRPRendererOpenGLES::SupportsScalingMethod(SCALINGMETHOD method)
 
 void CRPRendererOpenGLES::ClearBackBuffer()
 {
-  glClearColor(m_clearColour, m_clearColour, m_clearColour, 0.0f);
+  glClearColor(m_clearColor, m_clearColor, m_clearColor, 0.0f);
   glClear(GL_COLOR_BUFFER_BIT);
   glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
 }
@@ -125,16 +137,17 @@ void CRPRendererOpenGLES::DrawBlackBars()
 {
   glDisable(GL_BLEND);
 
-  Svertex vertices[24];
-  GLubyte count = 0;
-
   m_context.EnableGUIShader(GL_SHADER_METHOD::DEFAULT);
+
   GLint posLoc = m_context.GUIShaderGetPos();
-  GLint uniCol = m_context.GUIShaderGetUniCol();
+  GLint uniColLoc = m_context.GUIShaderGetUniCol();
   GLint depthLoc = m_context.GUIShaderGetDepth();
 
-  glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
+  glUniform4f(uniColLoc, m_clearColor / 255.0f, m_clearColor / 255.0f, m_clearColor / 255.0f, 1.0f);
   glUniform1f(depthLoc, -1.0f);
+
+  Svertex vertices[24];
+  GLubyte count = 0;
 
   // top quad
   if (m_rotatedDestCoords[0].y > 0.0f)
@@ -221,7 +234,7 @@ void CRPRendererOpenGLES::DrawBlackBars()
   }
 
   glBindBuffer(GL_ARRAY_BUFFER, m_blackbarsVertexVBO);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(Svertex) * count, &vertices[0], GL_STATIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(Svertex) * count, &vertices[0], GL_DYNAMIC_DRAW);
 
   glVertexAttribPointer(posLoc, 3, GL_FLOAT, GL_FALSE, sizeof(Svertex), 0);
   glEnableVertexAttribArray(posLoc);
@@ -237,8 +250,6 @@ void CRPRendererOpenGLES::DrawBlackBars()
 
 void CRPRendererOpenGLES::Render(uint8_t alpha)
 {
-  const ViewportCoordinates dest{m_rotatedDestCoords};
-
   auto renderBuffer = static_cast<CRenderBufferOpenGLES*>(m_renderBuffer);
   if (renderBuffer == nullptr)
     return;
@@ -282,7 +293,8 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight}, *source, *target))
+    if (!m_shaderPreset->RenderUpdate(m_rotatedDestCoords, {m_fullDestWidth, m_fullDestHeight},
+                                      *source, *target))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
@@ -291,15 +303,6 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
   // Use GUI shader
   else
   {
-    CRect rect = m_sourceRect;
-
-    rect.x1 /= renderBuffer->GetWidth();
-    rect.x2 /= renderBuffer->GetWidth();
-    rect.y1 /= renderBuffer->GetHeight();
-    rect.y2 /= renderBuffer->GetHeight();
-
-    const uint32_t color = (alpha << 24) | 0xFFFFFF;
-
     GLint filter = GL_NEAREST;
     if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
       filter = GL_LINEAR;
@@ -310,26 +313,37 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE_NOALPHA);
+    m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
 
-    GLubyte colour[4];
-    GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
-    PackedVertex vertex[4];
-
-    GLint vertLoc = m_context.GUIShaderGetPos();
-    GLint loc = m_context.GUIShaderGetCoord0();
+    GLint posLoc = m_context.GUIShaderGetPos();
+    GLint tex0Loc = m_context.GUIShaderGetCoord0();
     GLint uniColLoc = m_context.GUIShaderGetUniCol();
     GLint depthLoc = m_context.GUIShaderGetDepth();
 
     // Setup color values
-    colour[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
-    colour[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
-    colour[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
-    colour[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
+    GLubyte col[4];
+    const uint32_t color = (alpha << 24) | 0xFFFFFF;
+    col[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+    col[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+    col[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+    col[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
 
+    glUniform4f(uniColLoc, (col[0] / 255.0f), (col[1] / 255.0f), (col[2] / 255.0f),
+                (col[3] / 255.0f));
+    glUniform1f(depthLoc, -1.0f);
+
+    // Setup destination rectangle
+    CRect rect = m_sourceRect;
+    rect.x1 /= renderBuffer->GetWidth();
+    rect.x2 /= renderBuffer->GetWidth();
+    rect.y1 /= renderBuffer->GetHeight();
+    rect.y2 /= renderBuffer->GetHeight();
+
+    PackedVertex vertex[4];
+
+    // Setup vertex position values
     for (unsigned int i = 0; i < 4; i++)
     {
-      // Setup vertex position values
       vertex[i].x = m_rotatedDestCoords[i].x;
       vertex[i].y = m_rotatedDestCoords[i].y;
       vertex[i].z = 0.0f;
@@ -342,26 +356,21 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
     vertex[2].v1 = vertex[3].v1 = rect.y2;
 
     glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_STATIC_DRAW);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_DYNAMIC_DRAW);
 
-    glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
+    glVertexAttribPointer(posLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
                           reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
-    glVertexAttribPointer(loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
+    glEnableVertexAttribArray(posLoc);
+    glVertexAttribPointer(tex0Loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
                           reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
-
-    glEnableVertexAttribArray(vertLoc);
-    glEnableVertexAttribArray(loc);
+    glEnableVertexAttribArray(tex0Loc);
 
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
-    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte) * 4, idx, GL_STATIC_DRAW);
 
-    glUniform4f(uniColLoc, (colour[0] / 255.0f), (colour[1] / 255.0f), (colour[2] / 255.0f),
-                (colour[3] / 255.0f));
-    glUniform1f(depthLoc, -1.0f);
     glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
 
-    glDisableVertexAttribArray(vertLoc);
-    glDisableVertexAttribArray(loc);
+    glDisableVertexAttribArray(posLoc);
+    glDisableVertexAttribArray(tex0Loc);
 
     glBindBuffer(GL_ARRAY_BUFFER, 0);
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -9,16 +9,11 @@
 #pragma once
 
 #include "RPBaseRenderer.h"
-#include "cores/GameSettings.h"
-#include "cores/RetroPlayer/buffers/BaseRenderBufferPool.h"
-#include "cores/RetroPlayer/buffers/video/RenderBufferSysMem.h"
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
 
-#include <atomic>
 #include <map>
 #include <memory>
 #include <stdint.h>
-#include <vector>
 
 #include "system_gl.h"
 
@@ -103,9 +98,11 @@ protected:
 
   GLuint m_mainIndexVBO;
   GLuint m_mainVertexVBO;
+
   GLuint m_blackbarsVertexVBO;
+
   GLenum m_textureTarget = GL_TEXTURE_2D;
-  float m_clearColour = 0.0f;
+  float m_clearColor = 0.0f;
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -118,7 +118,6 @@ private:
   unsigned int m_frameCountMod{0};
 
   GLuint m_shaderProgram{0};
-  std::array<GLubyte, 4> m_indices;
   std::array<std::array<float, 3>, 4> m_VertexCoords;
   std::array<std::array<float, 3>, 4> m_colors;
   std::array<std::array<float, 2>, 4> m_TexCoords;

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
@@ -118,7 +118,6 @@ private:
   unsigned int m_frameCountMod{0};
 
   GLuint m_shaderProgram{0};
-  std::array<GLubyte, 4> m_indices;
   std::array<std::array<float, 3>, 4> m_VertexCoords;
   std::array<std::array<float, 3>, 4> m_colors;
   std::array<std::array<float, 2>, 4> m_TexCoords;

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -96,6 +96,7 @@ void CGUITextureGL::Begin(KODI::UTILS::COLOR::Color color)
   {
     glDisable(GL_BLEND);
   }
+
   m_packedVertices.clear();
   m_idx.clear();
 }
@@ -283,7 +284,7 @@ void CGUITextureGL::DrawQuad(const CRect& rect,
   VerifyGLState();
 
   GLubyte col[4];
-  GLubyte idx[4] = {0, 1, 3, 2};  //determines order of the vertices
+  GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
   GLuint vertexVBO;
   GLuint indexVBO;
 
@@ -291,7 +292,7 @@ void CGUITextureGL::DrawQuad(const CRect& rect,
   {
     float x, y, z;
     float u1, v1;
-  }vertex[4];
+  } vertex[4];
 
   if (texture)
     renderSystem->EnableShader(ShaderMethodGL::SM_TEXTURE);
@@ -334,6 +335,7 @@ void CGUITextureGL::DrawQuad(const CRect& rect,
 
   if (texture)
   {
+    // Setup texture coordinates
     CRect coords = texCoords ? *texCoords : CRect(0.0f, 0.0f, 1.0f, 1.0f);
     vertex[0].u1 = vertex[3].u1 = coords.x1;
     vertex[0].v1 = vertex[1].v1 = coords.y1;
@@ -373,4 +375,3 @@ void CGUITextureGL::DrawQuad(const CRect& rect,
 
   renderSystem->DisableShader();
 }
-

--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -126,7 +126,7 @@ void CGUITextureGLES::Begin(KODI::UTILS::COLOR::Color color)
     texture->BindToUnit(0);
   }
 
-  if ( hasAlpha )
+  if (hasAlpha)
   {
     glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
     glEnable( GL_BLEND );
@@ -135,6 +135,7 @@ void CGUITextureGLES::Begin(KODI::UTILS::COLOR::Color color)
   {
     glDisable(GL_BLEND);
   }
+
   m_packedVertices.clear();
 }
 
@@ -182,6 +183,7 @@ void CGUITextureGLES::End()
   if (m_diffuse.size())
     glActiveTexture(GL_TEXTURE0);
   glEnable(GL_BLEND);
+
   m_renderSystem->DisableGUIShader();
 }
 
@@ -190,10 +192,11 @@ void CGUITextureGLES::Draw(float *x, float *y, float *z, const CRect &texture, c
   PackedVertex vertices[4];
 
   // Setup texture coordinates
-  //TopLeft
+  // TopLeft
   vertices[0].u1 = texture.x1;
   vertices[0].v1 = texture.y1;
-  //TopRight
+
+  // TopRight
   if (orientation & 4)
   {
     vertices[1].u1 = texture.x1;
@@ -204,10 +207,12 @@ void CGUITextureGLES::Draw(float *x, float *y, float *z, const CRect &texture, c
     vertices[1].u1 = texture.x2;
     vertices[1].v1 = texture.y1;
   }
-  //BottomRight
+
+  // BottomRight
   vertices[2].u1 = texture.x2;
   vertices[2].v1 = texture.y2;
-  //BottomLeft
+
+  // BottomLeft
   if (orientation & 4)
   {
     vertices[3].u1 = texture.x2;
@@ -221,10 +226,11 @@ void CGUITextureGLES::Draw(float *x, float *y, float *z, const CRect &texture, c
 
   if (m_diffuse.size())
   {
-    //TopLeft
+    // TopLeft
     vertices[0].u2 = diffuse.x1;
     vertices[0].v2 = diffuse.y1;
-    //TopRight
+
+    // TopRight
     if (m_info.orientation & 4)
     {
       vertices[1].u2 = diffuse.x1;
@@ -235,10 +241,12 @@ void CGUITextureGLES::Draw(float *x, float *y, float *z, const CRect &texture, c
       vertices[1].u2 = diffuse.x2;
       vertices[1].v2 = diffuse.y1;
     }
-    //BottomRight
+
+    // BottomRight
     vertices[2].u2 = diffuse.x2;
     vertices[2].v2 = diffuse.y2;
-    //BottomLeft
+
+    // BottomLeft
     if (m_info.orientation & 4)
     {
       vertices[3].u2 = diffuse.x2;
@@ -300,7 +308,7 @@ void CGUITextureGLES::DrawQuad(const CRect& rect,
   GLubyte col[4];
   GLfloat ver[4][3];
   GLfloat tex[4][2];
-  GLubyte idx[4] = {0, 1, 3, 2};        //determines order of triangle strip
+  GLubyte idx[4] = {0, 1, 3, 2}; // Determines order of triangle strip
 
   if (texture)
     renderSystem->EnableGUIShader(ShaderMethodGLES::SM_TEXTURE);
@@ -344,6 +352,7 @@ void CGUITextureGLES::DrawQuad(const CRect& rect,
     tex[1][0] = tex[2][0] = coords.x2;
     tex[2][1] = tex[3][1] = coords.y2;
   }
+
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
 
   glDisableVertexAttribArray(posLoc);
@@ -352,4 +361,3 @@ void CGUITextureGLES::DrawQuad(const CRect& rect,
 
   renderSystem->DisableGUIShader();
 }
-


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR contains overall cleanup of OpenGL rendering in RetroPlayer.

Summary:
1. General cosmetic cleanup (synced code between renderers, white spaces, reordered calls, renamed vars, ...)
Changed order of some GL functions to match the OpenGL best practices (e.g. always call `glEnableVertexAttribArray()` after `glVertexAttribPointer()` etc.). 
Renamed variables, so we don't have 2 variables named `color` and `colour` in the same scope etc.

2. Removed unused includes

3. Removed explicit `glFlush()` from `RenderInternal()`
This seems to fix the issue https://github.com/xbmc/xbmc/issues/27670.

4. Stop updating the index VBO with static data in every `Render()` call
We have our private index VBO and we always upload the same array of `{0, 1, 3, 2}` to it, so lets upload it once in the renderer initialization and stop updating it with each `Render()` call.

5. Changed the GL hint for the vertex VBO update from `GL_STATIC_DRAW` to `GL_DYNAMIC_DRAW`
The buffer gets updated with every `Render()` call (even several times per frame when rendering thumbnails in OSD), so lets give the GL a correct hint.

6. ~~Changed the shader type from `TEXTURE` to `TEXTURE_NOALPHA` for GLES DMA renderer
It seems that this is a forgotten leftover from the GL and GLES DMA renderer split. For the GLES we use `TEXTURE_NOALPHA`, so lets use it for DMA GLES as well.~~
After the discussion we went the opposite way, we get rid of the obsolete `TEXTURE_NOALPHA` and switch to `TEXTURE` for the GLES renderer to get the alpha working for rendering GUI controls with game thumbnails.
This PR reveals the history: https://github.com/xbmc/xbmc/pull/17640

7. Added check for `UseLimitedColor()` to GLES renderers
It seems that some GLES devices can support limited color space, so lets add the support for it for consistency with the GL Core Profile.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cleanup, optimizations and fixes.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Linux / Wayland / OpenGL and GLES

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Fixes issue https://github.com/xbmc/xbmc/issues/27670.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
