### PR TITLE
[Database] Fix existing zip:// and rar:// paths in database following recent paths PR.

### DIFF
--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -27,6 +27,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <cctype>
 #include <functional>
 #include <map>
 #include <memory>
@@ -66,6 +67,38 @@ void InitializeVideoVersionTypeTableV123(CDatabase& db)
     CLog::LogF(LOGERROR, "failed");
     throw;
   }
+}
+
+static std::string LowerCaseEncodingV143(std::string_view in)
+{
+  std::string out;
+  out.reserve(in.size());
+
+  constexpr auto is_hex = [](char c) noexcept
+  { return ('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F'); };
+
+  for (auto it = in.begin(); it != in.end(); ++it)
+  {
+    if (*it == '%' && std::ranges::distance(it, in.end()) > 2)
+    {
+      if (is_hex(it[1]) && is_hex(it[2]))
+      {
+        out += '%';
+        out += StringUtils::ToLowerAscii(it[1]);
+        out += StringUtils::ToLowerAscii(it[2]);
+        std::ranges::advance(it, 2);
+      }
+      else
+      {
+        CLog::LogF(LOGDEBUG, "Invalid encoding in path {}", CURL::GetRedacted(std::string(in)));
+        out += *it;
+      }
+    }
+    else
+      out += *it;
+  }
+
+  return out;
 }
 } // namespace KODI::DATABASE::MIGRATION
 
@@ -1055,9 +1088,68 @@ void CVideoDatabase::UpdateTables(int iVersion)
     }
     m_pDS->close();
   }
+
+  if (iVersion < 143)
+  {
+    m_pDS->query("SELECT f.idFile, f.strFilename, f.dateAdded, f.idPath FROM files AS f "
+                 "WHERE f.strFilename LIKE 'rar://%' OR f.strFilename LIKE 'zip://%'");
+
+    while (!m_pDS->eof())
+    {
+      const int idFile = m_pDS->fv(0).get_asInt();
+      const std::string oldFile = m_pDS->fv(1).get_asString();
+      const std::string oldDate = m_pDS->fv(2).get_asString();
+      const int oldIdPath = m_pDS->fv(3).get_asInt();
+
+      // Same prefix length for zip and rar protocols
+      constexpr std::size_t protLength{std::char_traits<char>::length("zip://")};
+      const std::size_t firstSep{oldFile.find('/', protLength)};
+      if (firstSep != std::string::npos)
+      {
+        const std::size_t lastSep{oldFile.rfind('/')};
+        // Convert the case of the encoded part of the url only, append the rest unchanged.
+        const std::string newPath{
+            KODI::DATABASE::MIGRATION::LowerCaseEncodingV143(oldFile.substr(0, firstSep)) +
+            oldFile.substr(firstSep, lastSep + 1 - firstSep)};
+        const std::string newFile{oldFile.substr(lastSep + 1)};
+
+        if (!newFile.empty())
+        {
+          // See if path exists
+          int idPath = -1;
+          std::string strSQL =
+              PrepareSQL("SELECT idPath FROM path WHERE path.strPath = '%s'", newPath.c_str());
+          m_pDS2->query(strSQL);
+          if (!m_pDS2->eof())
+            idPath = m_pDS2->fv(0).get_asInt(); // Existing path
+          else
+          {
+            // Create new path (zip:// etc..) as we still need the original parent path to remain for scanning/hash purposes
+            // For example - whilst zip:// still counts as a folder (as the Kodi vfs supports 'files as folders') the hash is taken from the
+            //  parent path (the physical folder on disc) - eg. the path to the media might be zip://c:\my movies\movie/movie.zip but the hash
+            //  is on c:\my movies\movie - so we need to keep both.
+            strSQL = PrepareSQL("INSERT INTO path (idPath, strPath, dateAdded, idParentPath) "
+                                "VALUES (NULL, '%s', '%s', %i)",
+                                newPath.c_str(), oldDate.c_str(), oldIdPath);
+            m_pDS2->exec(strSQL);
+            idPath = static_cast<int>(m_pDS2->lastinsertid());
+          }
+
+          // Update file with new idPath and filename
+          if (idPath > 0)
+            m_pDS2->exec(
+                PrepareSQL("UPDATE files SET idPath = %i, strFilename = '%s' WHERE idFile = %i",
+                           idPath, newFile.c_str(), idFile));
+        }
+        m_pDS2->close();
+      }
+      m_pDS->next();
+    }
+    m_pDS->close();
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 142;
+  return 143;
 }


### PR DESCRIPTION
There was a commit missing from #27580.

Any existing rar:// or zip:// paths in the database need to be converted (see pictures in previous commit).

Old:
path table contained the base path
files table contained the entire zip:// or rar:// path with filename.

(This was not consistent with bluray://, and archive://)

New::
path table contains the zip:// or rar:// path without the filename (like bluray:// and archive://)
file table contains just the filename (as with all other paths (ie. DOS, linux etc..)

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This impliments the above changes.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Reported in forum - https://forum.kodi.tv/showthread.php?tid=384424&pid=3263986

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally, and confirmed fix in the thread.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
