### PR TITLE
[PVR] Parse daily wake-up time as a local time

### DIFF
--- a/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPowerManagement.cpp
@@ -101,6 +101,13 @@ bool CPVRGUIActionsPowerManagement::CanSystemPowerdown(bool bAskUser /*= true*/)
           CDateTime dailywakeuptime;
           dailywakeuptime.SetFromDBTime(
               m_settings->GetStringValue(CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUPTIME));
+
+          const CDateTime nowAsLocalTime{CDateTime::GetCurrentDateTime()};
+
+          dailywakeuptime.SetDateTime(nowAsLocalTime.GetYear(), nowAsLocalTime.GetMonth(),
+                                      nowAsLocalTime.GetDay(), dailywakeuptime.GetHour(),
+                                      dailywakeuptime.GetMinute(), dailywakeuptime.GetSecond());
+
           dailywakeuptime = dailywakeuptime.GetAsUTCDateTime();
 
           const CDateTimeSpan diff(dailywakeuptime - now);

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -1326,11 +1326,14 @@ CDateTime CPVRTimers::GetNextEventTime() const
     CDateTime dailywakeuptime;
     dailywakeuptime.SetFromDBTime(
         m_settings->GetStringValue(CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUPTIME));
-    dailywakeuptime = dailywakeuptime.GetAsUTCDateTime();
 
-    dailywakeuptime.SetDateTime(now.GetYear(), now.GetMonth(), now.GetDay(),
-                                dailywakeuptime.GetHour(), dailywakeuptime.GetMinute(),
-                                dailywakeuptime.GetSecond());
+    const CDateTime nowAsLocalTime{CDateTime::GetCurrentDateTime()};
+
+    dailywakeuptime.SetDateTime(nowAsLocalTime.GetYear(), nowAsLocalTime.GetMonth(),
+                                nowAsLocalTime.GetDay(), dailywakeuptime.GetHour(),
+                                dailywakeuptime.GetMinute(), dailywakeuptime.GetSecond());
+
+    dailywakeuptime = dailywakeuptime.GetAsUTCDateTime();
 
     if ((dailywakeuptime - idle) < now)
     {

--- a/xbmc/pvr/timers/PVRTimers.cpp
+++ b/xbmc/pvr/timers/PVRTimers.cpp
@@ -1300,7 +1300,7 @@ std::shared_ptr<CPVRTimerInfoTag> CPVRTimers::GetTimerRule(
 
 CDateTime CPVRTimers::GetNextEventTime() const
 {
-  const bool dailywakup{
+  const bool dailywakeup{
       m_settings->GetBoolValue(CSettings::SETTING_PVRPOWERMANAGEMENT_DAILYWAKEUP)};
   const CDateTime now = CDateTime::GetUTCDateTime();
   const CDateTimeSpan prewakeup{
@@ -1321,7 +1321,7 @@ CDateTime CPVRTimers::GetNextEventTime() const
   }
 
   /* check daily wake up */
-  if (dailywakup)
+  if (dailywakeup)
   {
     CDateTime dailywakeuptime;
     dailywakeuptime.SetFromDBTime(


### PR DESCRIPTION
## Description
This patch fixes the PVR timer management so Kodi parses the user-specified daily wake-up time as a local time. This is a breaking change.

## Motivation and context
Kodi currently treats the user-specified daily wake-up time as though it is a UTC time, not a local time.
As a user, I expect the system to wake at the (local) time I set, not at a seemingly unrelated time.

## How has this been tested?
- Extensive logging added to various functions to track time conversions and offset.
- Code tested on Debian Sid (Unstable) on latest git master with system timezone (and Kodi regional settings) set to UTC+11, UTC+8, UTC+1, UTC, and UTC-8.
- Testing completed successfully with active recordings, recording timers about to start (i.e. within the backend idle time), recording timers with no backend idle time set, and wake time-only events (within the backend idle time and also with no backend idle time).
- No indication of impacts elsewhere.

## What is the effect on users?
Systems with a wake alarm set by Kodi will activate at the local time set (and expected) by the user.

## Screenshots (if appropriate):
N/A

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [X ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
