### PR TITLE
[cmake][depends] Add FindZSTD.cmake and enable ZSTD support in CURL

### DIFF
--- a/cmake/modules/FindCurl.cmake
+++ b/cmake/modules/FindCurl.cmake
@@ -12,6 +12,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
   macro(buildmacroCurl)
     find_package(Brotli REQUIRED ${SEARCH_QUIET})
+    find_package(ZSTD REQUIRED ${SEARCH_QUIET})
     find_package(NGHttp2 REQUIRED ${SEARCH_QUIET})
     find_package(OpenSSL REQUIRED ${SEARCH_QUIET})
 
@@ -46,6 +47,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                    -DCURL_USE_OPENSSL=ON
                    -DOPENSSL_ROOT_DIR=${DEPENDS_PATH}
                    -DCURL_BROTLI=ON
+                   -DCURL_ZSTD=ON
                    -DUSE_NGHTTP2=ON
                    -DUSE_LIBIDN2=OFF
                    -DCURL_USE_LIBSSH2=OFF
@@ -57,6 +59,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
     # Link libraries for target interface
     list(APPEND ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LINK_LIBRARIES LIBRARY::Brotli
+                                                                    LIBRARY::ZSTD
                                                                     LIBRARY::NGHttp2
                                                                     OpenSSL::Crypto
                                                                     OpenSSL::SSL
@@ -64,6 +67,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
     # Add dependencies to build target
     add_dependencies(${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME} LIBRARY::Brotli
+                                                                        LIBRARY::ZSTD
                                                                         LIBRARY::NGHttp2
                                                                         OpenSSL::SSL
                                                                         OpenSSL::Crypto
@@ -76,6 +80,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   if(ENABLE_INTERNAL_CURL)
     # Dependency list of this find module for an INTERNAL build
     set(${CMAKE_FIND_PACKAGE_NAME}_DEPLIST Brotli
+                                           ZSTD
                                            NGHttp2
                                            OpenSSL
                                            ZLIB)

--- a/cmake/modules/FindZSTD.cmake
+++ b/cmake/modules/FindZSTD.cmake
@@ -8,20 +8,24 @@
 #   LIBRARY::ZSTD   - The App specific library dependency target
 #
 
-if(NOT TARGET LIBRARY::ZSTD)
+if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
 
   macro(buildmacroZSTD)
+    if(APPLE)
+      set(EXTRA_ARGS "-DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}")
+    endif()
 
     set(PATCH_COMMAND ${CMAKE_COMMAND} -E copy
                       ${CORE_SOURCE_DIR}/tools/depends/target/zstd/CMakeLists.txt
                       <SOURCE_DIR>)
 
-    set(CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
+    set(CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON
                    -DZSTD_BUILD_STATIC=ON
                    -DZSTD_BUILD_SHARED=OFF
                    -DZSTD_LEGACY_SUPPORT=OFF
                    -DZSTD_BUILD_PROGRAMS=OFF
-                   -DZSTD_BUILD_TESTS=OFF)
+                   -DZSTD_BUILD_TESTS=OFF
+                   ${EXTRA_ARGS})
 
     BUILD_DEP_TARGET()
   endmacro()

--- a/cmake/modules/FindZSTD.cmake
+++ b/cmake/modules/FindZSTD.cmake
@@ -12,6 +12,10 @@ if(NOT TARGET LIBRARY::ZSTD)
 
   macro(buildmacroZSTD)
 
+    set(PATCH_COMMAND ${CMAKE_COMMAND} -E copy
+                      ${CORE_SOURCE_DIR}/tools/depends/target/zstd/CMakeLists.txt
+                      <SOURCE_DIR>)
+
     set(CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
                    -DZSTD_BUILD_STATIC=ON
                    -DZSTD_BUILD_SHARED=OFF

--- a/cmake/modules/FindZSTD.cmake
+++ b/cmake/modules/FindZSTD.cmake
@@ -1,0 +1,83 @@
+#.rst:
+# FindZSTD
+# ----------
+# Finds the ZSTD library
+#
+# This will define the following target:
+#
+#   LIBRARY::ZSTD   - The App specific library dependency target
+#
+
+if(NOT TARGET LIBRARY::ZSTD)
+
+  macro(buildmacroZSTD)
+
+    set(CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release
+                   -DZSTD_BUILD_STATIC=ON
+                   -DZSTD_BUILD_SHARED=OFF
+                   -DZSTD_LEGACY_SUPPORT=OFF
+                   -DZSTD_BUILD_PROGRAMS=OFF
+                   -DZSTD_BUILD_TESTS=OFF)
+
+    BUILD_DEP_TARGET()
+  endmacro()
+
+  include(cmake/scripts/common/ModuleHelpers.cmake)
+
+  set(${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC zstd)
+
+  SETUP_BUILD_VARS()
+
+  SETUP_FIND_SPECS()
+
+  # Search for cmake config. Suitable for all platforms including windows
+  find_package(${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME} ${CONFIG_${CMAKE_FIND_PACKAGE_NAME}_FIND_SPEC} CONFIG ${SEARCH_QUIET}
+                                                         HINTS ${DEPENDS_PATH}/lib/cmake
+                                                         ${${CORE_SYSTEM_NAME}_SEARCH_CONFIG})
+
+  # cmake config may not be available. fallback to pkgconfig for non windows platforms
+  if(NOT ${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_FOUND)
+    find_package(PkgConfig ${SEARCH_QUIET})
+
+    if(PKG_CONFIG_FOUND AND NOT (WIN32 OR WINDOWSSTORE))
+      pkg_check_modules(${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME} libzstd${PC_${CMAKE_FIND_PACKAGE_NAME}_FIND_SPEC} ${SEARCH_QUIET} IMPORTED_TARGET)
+    endif()
+  endif()
+
+  # Check for existing Zstd. If version < ZSTD-VERSION file version, build it
+  if("${${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_VERSION}" VERSION_LESS ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER} AND ZSTD_FIND_REQUIRED)
+    message(STATUS "Building ${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}: \(version \"${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER}\"\)")
+    cmake_language(EVAL CODE "
+      buildmacro${CMAKE_FIND_PACKAGE_NAME}()
+    ")
+  endif()
+
+  if(${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_FOUND)
+    if((TARGET zstd::libzstd_static OR TARGET zstd::libzstd_shared) AND NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      # Preference for static lib if available
+      if(TARGET zstd::libzstd_static)
+        set(_target zstd::libzstd_static)
+      else()
+        set(_target zstd::libzstd_shared)
+      endif()
+
+      add_library(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ALIAS ${_target})
+    elseif(TARGET PkgConfig::${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME} AND NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      add_library(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ALIAS PkgConfig::${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME})
+    else()
+      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_TYPE LIBRARY)
+      SETUP_BUILD_TARGET()
+
+      add_dependencies(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+
+      # Set LIB_BUILD property to allow calling modules to know we will be building
+      set_target_properties(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES LIB_BUILD ON)
+    endif()
+
+    ADD_MULTICONFIG_BUILDMACRO()
+  else()
+    if(ZSTD_FIND_REQUIRED)
+      message(FATAL_ERROR "ZSTD libraries were not found.")
+    endif()
+  endif()
+endif()

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -150,7 +150,7 @@ download: $(DOWNLOAD_TARGETS)
 
 cec: p8-platform
 crossguid: $(LIBUUID)
-curl: brotli openssl nghttp2 $(ZLIB)
+curl: brotli openssl nghttp2 zstd $(ZLIB)
 dbus: expat
 exiv2: $(ICONV) $(ZLIB) expat
 ffmpeg: $(ICONV) $(ZLIB) bzip2 gnutls dav1d $(LIBVA)

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -15,6 +15,7 @@ CMAKE_OPTIONS=-DCMAKE_INSTALL_PREFIX=$(PREFIX) \
               -DCURL_USE_OPENSSL=ON \
               -DOPENSSL_ROOT_DIR=$(PREFIX) \
               -DCURL_BROTLI=ON \
+              -DCURL_ZSTD=ON \
               -DUSE_NGHTTP2=ON \
               -DUSE_LIBIDN2=OFF \
               -DCURL_USE_LIBSSH2=OFF \

--- a/tools/depends/target/zstd/CMakeLists.txt
+++ b/tools/depends/target/zstd/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.10)
+project(zstd_shim)
+add_subdirectory(build/cmake)

--- a/tools/depends/target/zstd/CMakeLists.txt
+++ b/tools/depends/target/zstd/CMakeLists.txt
@@ -1,3 +1,19 @@
-cmake_minimum_required(VERSION 3.10)
-project(zstd_shim)
+cmake_minimum_required(VERSION 3.18)
+project(zstd_shim VERSION 1.5.7)
+
 add_subdirectory(build/cmake)
+
+if(TARGET libzstd_static)
+  set_target_properties(libzstd_static PROPERTIES OUTPUT_NAME zstd)
+  if(NOT TARGET zstd::libzstd_static)
+    add_library(zstd::libzstd_static ALIAS libzstd_static)
+  endif()
+endif()
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/zstd-config-version.cmake
+                                 VERSION ${PROJECT_VERSION}
+                                 COMPATIBILITY AnyNewerVersion)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/zstd-config-version.cmake
+        DESTINATION lib/cmake/zstd)

--- a/tools/depends/target/zstd/CMakeLists.txt
+++ b/tools/depends/target/zstd/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.18)
 project(zstd_shim VERSION 1.5.7)
 
+if(ANDROID AND NOT DEFINED ANDROID_PLATFORM_LEVEL)
+  set(ANDROID_PLATFORM_LEVEL 23)
+endif()
+
 add_subdirectory(build/cmake)
 
 if(TARGET libzstd_static)

--- a/tools/depends/target/zstd/Makefile
+++ b/tools/depends/target/zstd/Makefile
@@ -11,20 +11,21 @@ CMAKE_OPTIONS = -DCMAKE_BUILD_TYPE=Release \
                   -DZSTD_BUILD_TESTS=OFF
 
 
-LIBDYLIB=$(PLATFORM)/builddir/lib/$(BYPRODUCT)
+LIBDYLIB=$(PLATFORM)/build/lib/$(BYPRODUCT)
 
 all: .installed-$(PLATFORM)
 
 $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
-	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)/builddir
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)/build
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
-	cd $(PLATFORM)/builddir; $(CMAKE) ../build/cmake ${CMAKE_OPTIONS} ..
+	cd $(PLATFORM); cp ../CMakeLists.txt ./
+	cd $(PLATFORM)/build; $(CMAKE) ${CMAKE_OPTIONS} ..
 
 $(LIBDYLIB): $(PLATFORM)
-	$(MAKE) -C $(PLATFORM)/builddir
+	$(MAKE) -C $(PLATFORM)/build
 
 .installed-$(PLATFORM): $(LIBDYLIB)
-	$(MAKE) -C $(PLATFORM)/builddir install
+	$(MAKE) -C $(PLATFORM)/build install
 	touch $@
 
 clean:

--- a/tools/depends/target/zstd/Makefile
+++ b/tools/depends/target/zstd/Makefile
@@ -1,0 +1,34 @@
+include ../../Makefile.include ZSTD-VERSION ../../download-files.include
+DEPS = ../../Makefile.include Makefile ZSTD-VERSION ../../download-files.include
+
+CMAKE_OPTIONS = -DCMAKE_BUILD_TYPE=Release \
+                  -DCMAKE_INSTALL_PREFIX=$(PREFIX) \
+                  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                  -DZSTD_BUILD_STATIC=ON \
+                  -DZSTD_BUILD_SHARED=OFF \
+                  -DZSTD_LEGACY_SUPPORT=OFF \
+                  -DZSTD_BUILD_PROGRAMS=OFF \
+                  -DZSTD_BUILD_TESTS=OFF
+
+
+LIBDYLIB=$(PLATFORM)/builddir/lib/$(BYPRODUCT)
+
+all: .installed-$(PLATFORM)
+
+$(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)/builddir
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM)/builddir; $(CMAKE) ../build/cmake ${CMAKE_OPTIONS} ..
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(PLATFORM)/builddir
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(PLATFORM)/builddir install
+	touch $@
+
+clean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/zstd/ZSTD-VERSION
+++ b/tools/depends/target/zstd/ZSTD-VERSION
@@ -1,0 +1,8 @@
+LIBNAME=libzstd
+BASE_URL=https://github.com/facebook/zstd
+VERSION=1.5.7
+FULL_URL=$(BASE_URL)/releases/download/v$(VERSION)/zstd-$(VERSION).tar.gz
+ARCHIVE=zstd-$(VERSION).tar.gz
+SHA512=b4de208f179b68d4c6454139ca60d66ed3ef3893a560d6159a056640f83d3ee67cdf6ffb88971cdba35449dba4b597eaa8b4ae908127ef7fd58c89f40bf9a705
+BYPRODUCT=libzstd.a
+BYPRODUCT_WIN=zstd.lib


### PR DESCRIPTION
## Description

This PR introduces the `FindZSTD.cmake` module and implements the `buildmacroZSTD` for integration with the `tools/depends` system. This allows the build system to either detect a system-wide ZSTD installation or build it from source when necessary.

**Technical Note:** The FindZSTD.cmake module was specifically authored by using the FindNGHTTP2.cmake module as a template and adapting its logic for ZSTD.

## Motivation and context

Zstandard (ZSTD) provides high-performance compression which is beneficial for various core components of the application. This change standardizes the detection and compilation of ZSTD, ensuring a consistent build environment for developers using Linux/Ubuntu.

## How has this been tested?

* **Environment:** Ubuntu 22.04 / 24.04 (Linux x86_64).
* **Test Case 1:** Successfully built ZSTD from source using the `tools/depends` system.
* **Status:** Verified that the library links correctly and the binary executes without shared library errors on Linux.

> **Note:** Testing has **not** yet been performed on macOS, Windows, Android, or webOS. Community feedback or CI runs for these platforms are welcomed.

## What is the effect on users?

This is a build-system improvement. It has no direct impact on end-users but simplifies the dependency management for Linux contributors.

---

## Types of change

* [ ] **Bug fix**
* [ ] **Clean up**
* [x] **Improvement**
* [x] **New feature**
* [ ] **Breaking change**
* [ ] **Cosmetic change**
* [ ] **Student submission**
* [ ] **None of the above**

## Checklist:

* [x] My code follows the **[[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
* [ ] My change requires a change to the documentation
* [ ] I have updated the documentation accordingly
* [x] I have read the **[[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
* [ ] I have added tests to cover my change (Unit tests not applicable, build tests performed)
* [ ] All new and existing tests passed