### PR TITLE
CArtist: drop related typedefs

### DIFF
--- a/xbmc/music/Album.h
+++ b/xbmc/music/Album.h
@@ -148,7 +148,7 @@ public:
   std::string strReleaseGroupMBID;
   std::string strArtistDesc;
   std::string strArtistSort;
-  VECARTISTCREDITS artistCredits;
+  std::vector<CArtistCredit> artistCredits;
   std::vector<std::string> genre;
   CScraperUrl thumbURL;
   std::vector<std::string> moods;

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -12,7 +12,6 @@
 #include "utils/Artwork.h"
 #include "utils/ScraperUrl.h"
 
-#include <map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -221,8 +220,3 @@ private:
   std::string m_strArtist;
   int idArtist;
 };
-
-typedef std::vector<CMusicRole> VECMUSICROLES;
-
-
-

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -13,6 +13,7 @@
 #include "utils/ScraperUrl.h"
 
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -181,10 +182,10 @@ private:
   bool m_bScrapedMBID = false; // Flag that mbid is from album merge of scarper results not derived from tags
 };
 
-inline const std::string BLANKARTIST_FAKEMUSICBRAINZID = "Artist Tag Missing";
-inline const std::string BLANKARTIST_NAME = "[Missing Tag]";
+static constexpr std::string_view BLANKARTIST_FAKEMUSICBRAINZID = "Artist Tag Missing";
+static constexpr std::string_view BLANKARTIST_NAME = "[Missing Tag]";
 static constexpr int BLANKARTIST_ID = 1;
-inline const std::string VARIOUSARTISTS_MBID = "89ad4ac3-39f7-470e-963a-56509c546377";
+static constexpr std::string_view VARIOUSARTISTS_MBID = "89ad4ac3-39f7-470e-963a-56509c546377";
 
 static constexpr int ROLE_ARTIST = 1; // Default role
 

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -181,7 +181,6 @@ private:
   bool m_bScrapedMBID = false; // Flag that mbid is from album merge of scarper results not derived from tags
 };
 
-typedef std::vector<CArtist> VECARTISTS;
 typedef std::vector<CArtistCredit> VECARTISTCREDITS;
 
 inline const std::string BLANKARTIST_FAKEMUSICBRAINZID = "Artist Tag Missing";

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -181,8 +181,6 @@ private:
   bool m_bScrapedMBID = false; // Flag that mbid is from album merge of scarper results not derived from tags
 };
 
-typedef std::vector<CArtistCredit> VECARTISTCREDITS;
-
 inline const std::string BLANKARTIST_FAKEMUSICBRAINZID = "Artist Tag Missing";
 inline const std::string BLANKARTIST_NAME = "[Missing Tag]";
 const int BLANKARTIST_ID = 1;

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -183,10 +183,10 @@ private:
 
 inline const std::string BLANKARTIST_FAKEMUSICBRAINZID = "Artist Tag Missing";
 inline const std::string BLANKARTIST_NAME = "[Missing Tag]";
-const int BLANKARTIST_ID = 1;
+static constexpr int BLANKARTIST_ID = 1;
 inline const std::string VARIOUSARTISTS_MBID = "89ad4ac3-39f7-470e-963a-56509c546377";
 
-#define ROLE_ARTIST 1  //Default role
+static constexpr int ROLE_ARTIST = 1; // Default role
 
 class CMusicRole
 {

--- a/xbmc/music/Artist.h
+++ b/xbmc/music/Artist.h
@@ -194,7 +194,8 @@ class CMusicRole
 public:
   CMusicRole() = default;
   CMusicRole(std::string strRole, std::string strArtist)
-    : idRole(-1), m_strRole(std::move(strRole)), m_strArtist(std::move(strArtist)), idArtist(-1)
+    : m_strRole(std::move(strRole)),
+      m_strArtist(std::move(strArtist))
   {
   }
   CMusicRole(int role, std::string strRole, std::string strArtist, int ArtistId)
@@ -213,8 +214,8 @@ public:
   bool operator==(const CMusicRole& a) const;
 
 private:
-  int idRole;
+  int idRole = -1;
   std::string m_strRole;
   std::string m_strArtist;
-  int idArtist;
+  int idArtist = -1;
 };

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2482,7 +2482,7 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
   return false;
 }
 
-int CMusicDatabase::AddRole(const std::string& strRole)
+int CMusicDatabase::AddRole(std::string_view strRole)
 {
   int idRole = -1;
   std::string strSQL;
@@ -2493,7 +2493,7 @@ int CMusicDatabase::AddRole(const std::string& strRole)
       return -1;
     if (nullptr == m_pDS)
       return -1;
-    strSQL = PrepareSQL("SELECT idRole FROM role WHERE strRole LIKE '%s'", strRole.c_str());
+    strSQL = PrepareSQL("SELECT idRole FROM role WHERE strRole LIKE '%s'", strRole.data());
     m_pDS->query(strSQL);
     if (m_pDS->num_rows() > 0)
       idRole = m_pDS->fv("idRole").get_asInt();
@@ -2501,7 +2501,7 @@ int CMusicDatabase::AddRole(const std::string& strRole)
 
     if (idRole < 0)
     {
-      strSQL = PrepareSQL("INSERT INTO role (strRole) VALUES ('%s')", strRole.c_str());
+      strSQL = PrepareSQL("INSERT INTO role (strRole) VALUES ('%s')", strRole.data());
       m_pDS->exec(strSQL);
       idRole = static_cast<int>(m_pDS->lastinsertid());
       m_pDS->close();
@@ -2515,19 +2515,19 @@ int CMusicDatabase::AddRole(const std::string& strRole)
 }
 
 bool CMusicDatabase::AddSongArtist(
-    int idArtist, int idSong, const std::string& strRole, const std::string& strArtist, int iOrder)
+    int idArtist, int idSong, std::string_view strRole, std::string_view strArtist, int iOrder)
 {
   int idRole = AddRole(strRole);
   return AddSongArtist(idArtist, idSong, idRole, strArtist, iOrder);
 }
 
 bool CMusicDatabase::AddSongArtist(
-    int idArtist, int idSong, int idRole, const std::string& strArtist, int iOrder)
+    int idArtist, int idSong, int idRole, std::string_view strArtist, int iOrder)
 {
   std::string strSQL;
   strSQL = PrepareSQL("REPLACE INTO song_artist (idArtist, idSong, idRole, strArtist, iOrder) "
                       "VALUES(%i, %i, %i,'%s', %i)",
-                      idArtist, idSong, idRole, strArtist.c_str(), iOrder);
+                      idArtist, idSong, idRole, strArtist.data(), iOrder);
   return ExecuteQuery(strSQL);
 }
 
@@ -2675,13 +2675,13 @@ bool CMusicDatabase::DeleteSongArtistsBySong(int idSong)
 
 bool CMusicDatabase::AddAlbumArtist(int idArtist,
                                     int idAlbum,
-                                    const std::string& strArtist,
+                                    std::string_view strArtist,
                                     int iOrder)
 {
   std::string strSQL;
   strSQL = PrepareSQL("REPLACE INTO album_artist (idArtist, idAlbum, strArtist, iOrder) "
                       "VALUES(%i,%i,'%s',%i)",
-                      idArtist, idAlbum, strArtist.c_str(), iOrder);
+                      idArtist, idAlbum, strArtist.data(), iOrder);
   return ExecuteQuery(strSQL);
 }
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2776,7 +2776,7 @@ bool CMusicDatabase::GetArtistsByAlbum(int idAlbum, CFileItem* item)
     }
 
     // Get album artist credits
-    VECARTISTCREDITS artistCredits;
+    std::vector<CArtistCredit> artistCredits;
     while (!m_pDS->eof())
     {
       artistCredits.emplace_back(GetArtistCreditFromDataset(m_pDS->get_sql_record(), 0));
@@ -3240,7 +3240,7 @@ void CMusicDatabase::GetFileItemFromDataset(const dbiplus::sql_record* const rec
   }
 }
 
-void CMusicDatabase::GetFileItemFromArtistCredits(VECARTISTCREDITS& artistCredits,
+void CMusicDatabase::GetFileItemFromArtistCredits(std::vector<CArtistCredit>& artistCredits,
                                                   CFileItem* item) const
 {
   // Populate fileitem with artists from vector of artist credits
@@ -3841,7 +3841,7 @@ bool CMusicDatabase::GetRecentlyPlayedAlbumSongs(const std::string& strBaseDir,
     // Gather artist credits, rather than append to item as go along, so can return array of artistIDs too
     int songArtistOffset = song_enumCount;
     int songId = -1;
-    VECARTISTCREDITS artistCredits;
+    std::vector<CArtistCredit> artistCredits;
     while (!m_pDS->eof())
     {
       const dbiplus::sql_record* const record = m_pDS->get_sql_record();
@@ -3994,7 +3994,7 @@ bool CMusicDatabase::GetRecentlyAddedAlbumSongs(const std::string& strBaseDir,
     // Get songs from returned rows. Join means there is a row for every song artist
     int songArtistOffset = song_enumCount;
     int songId = -1;
-    VECARTISTCREDITS artistCredits;
+    std::vector<CArtistCredit> artistCredits;
     while (!m_pDS->eof())
     {
       const dbiplus::sql_record* const record = m_pDS->get_sql_record();
@@ -6358,7 +6358,7 @@ bool CMusicDatabase::GetSongsFullByWhere(
     items.Reserve(total);
     int songArtistOffset = song_enumCount;
     int songId = -1;
-    VECARTISTCREDITS artistCredits;
+    std::vector<CArtistCredit> artistCredits;
     const dbiplus::query_data& data = m_pDS->get_result_set().records;
     int count = 0;
     for (const auto& i : results)

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -148,8 +148,8 @@ void CMusicDatabase::CreateTables()
   std::string strSQL =
       PrepareSQL("INSERT INTO artist (idArtist, strArtist, strSortName, strMusicBrainzArtistID) "
                  "VALUES( %i, '%s', '%s', '%s' )",
-                 BLANKARTIST_ID, BLANKARTIST_NAME.c_str(), BLANKARTIST_NAME.c_str(),
-                 BLANKARTIST_FAKEMUSICBRAINZID.c_str());
+                 BLANKARTIST_ID, BLANKARTIST_NAME.data(), BLANKARTIST_NAME.data(),
+                 BLANKARTIST_FAKEMUSICBRAINZID.data());
   m_pDS->exec(strSQL);
 
   CLog::Log(LOGINFO, "create album table");
@@ -8927,7 +8927,7 @@ void CMusicDatabase::UpdateTables(int version)
     // Fake MusicbrainzId assures uniqueness and avoids updates from scanned songs
     strSQL = PrepareSQL(
         "INSERT INTO artist (idArtist, strArtist, strMusicBrainzArtistID) VALUES( %i, '%s', '%s' )",
-        BLANKARTIST_ID, BLANKARTIST_NAME.c_str(), BLANKARTIST_FAKEMUSICBRAINZID.c_str());
+        BLANKARTIST_ID, BLANKARTIST_NAME.data(), BLANKARTIST_FAKEMUSICBRAINZID.data());
     m_pDS->exec(strSQL);
 
     // Indices have been dropped making transactions very slow, so create temp index
@@ -8949,7 +8949,7 @@ void CMusicDatabase::UpdateTables(int version)
                             "SELECT %i, idSong, %i, '%s', 0 FROM song "
                             "WHERE NOT EXISTS(SELECT idSong FROM song_artist "
                             "WHERE song_artist.idsong = song.idsong AND song_artist.idRole = %i)",
-                            BLANKARTIST_ID, ROLE_ARTIST, BLANKARTIST_NAME.c_str(), ROLE_ARTIST);
+                            BLANKARTIST_ID, ROLE_ARTIST, BLANKARTIST_NAME.data(), ROLE_ARTIST);
         ExecuteQuery(strSQL);
       }
       catch (...)
@@ -8973,7 +8973,7 @@ void CMusicDatabase::UpdateTables(int version)
                             "SELECT %i, idAlbum, '%s', 0 FROM album "
                             "WHERE NOT EXISTS(SELECT idAlbum FROM album_artist "
                             "WHERE album_artist.idAlbum = album.idAlbum)",
-                            BLANKARTIST_ID, BLANKARTIST_NAME.c_str());
+                            BLANKARTIST_ID, BLANKARTIST_NAME.data());
         ExecuteQuery(strSQL);
       }
       catch (...)

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2575,7 +2575,7 @@ int CMusicDatabase::AddSongContributor(int idSong,
 }
 
 void CMusicDatabase::AddSongContributors(int idSong,
-                                         const VECMUSICROLES& contributors,
+                                         const std::vector<CMusicRole>& contributors,
                                          const std::string& strSort)
 {
   std::vector<std::string> composerSort;

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -25,6 +25,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -471,20 +472,16 @@ public:
   /////////////////////////////////////////////////
   // Link tables
   /////////////////////////////////////////////////
-  bool AddAlbumArtist(int idArtist, int idAlbum, const std::string& strArtist, int iOrder);
+  bool AddAlbumArtist(int idArtist, int idAlbum, std::string_view strArtist, int iOrder);
   bool GetAlbumsByArtist(int idArtist, std::vector<int>& albums);
   bool GetArtistsByAlbum(int idAlbum, CFileItem* item);
   bool GetArtistsByAlbum(int idAlbum, std::vector<std::string>& artistIDs);
   bool DeleteAlbumArtistsByAlbum(int idAlbum);
 
-  int AddRole(const std::string& strRole);
-  bool AddSongArtist(int idArtist,
-                     int idSong,
-                     const std::string& strRole,
-                     const std::string& strArtist,
-                     int iOrder);
+  int AddRole(std::string_view strRole);
   bool AddSongArtist(
-      int idArtist, int idSong, int idRole, const std::string& strArtist, int iOrder);
+      int idArtist, int idSong, std::string_view strRole, std::string_view strArtist, int iOrder);
+  bool AddSongArtist(int idArtist, int idSong, int idRole, std::string_view strArtist, int iOrder);
   int AddSongContributor(int idSong,
                          const std::string& strRole,
                          const std::string& strArtist,

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -912,7 +912,8 @@ private:
   void GetFileItemFromDataset(const dbiplus::sql_record* const record,
                               CFileItem* item,
                               const CMusicDbUrl& baseUrl) const;
-  void GetFileItemFromArtistCredits(VECARTISTCREDITS& artistCredits, CFileItem* item) const;
+  void GetFileItemFromArtistCredits(std::vector<CArtistCredit>& artistCredits,
+                                    CFileItem* item) const;
 
   bool DeleteRemovedLinks();
 

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -80,7 +80,7 @@ class CFileItemList;
  Here is the database layout:
   \image html musicdatabase.png
 
- \sa CAlbum, CSong, CMapSong, VECARTISTS, VECALBUMS
+ \sa CAlbum, CSong, CMapSong, VECALBUMS
  */
 class CMusicDatabase : public CDatabase
 {

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -490,7 +490,7 @@ public:
                          const std::string& strArtist,
                          const std::string& strSort);
   void AddSongContributors(int idSong,
-                           const VECMUSICROLES& contributors,
+                           const std::vector<CMusicRole>& contributors,
                            const std::string& strSort);
   int GetRoleByName(const std::string& strRole);
   bool GetRolesByArtist(int idArtist, CFileItem* item);

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -171,7 +171,7 @@ public:
   std::string strTitle;
   std::string strArtistSort;
   std::string strArtistDesc;
-  VECARTISTCREDITS artistCredits;
+  std::vector<CArtistCredit> artistCredits;
   std::string strAlbum;
   std::vector<std::string> genre;
   std::string strThumb;

--- a/xbmc/music/Song.h
+++ b/xbmc/music/Song.h
@@ -123,7 +123,7 @@ public:
     or ALBUMARTIST, e.g. COMPOSER or CONDUCTOR etc.
   \return a vector of all contributing artist names and their roles
   */
-  const VECMUSICROLES& GetContributors() const { return m_musicRoles; }
+  const std::vector<CMusicRole>& GetContributors() const { return m_musicRoles; }
   //void AddArtistRole(const int &role, const std::string &artist);
   void AppendArtistRole(const CMusicRole& musicRole);
 
@@ -211,5 +211,5 @@ private:
   std::vector<std::string> m_albumArtist; // Album artist from tag for album processing, no desc or MBID
   std::string m_strAlbumArtistSort; // Albumartist sort string from tag for album processing by CMusicInfoScanner::FileItemsToAlbums
   std::string m_strComposerSort;
-  VECMUSICROLES m_musicRoles;
+  std::vector<CMusicRole> m_musicRoles;
 };

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -781,8 +781,8 @@ void CMusicInfoScanner::FileItemsToAlbums(
                                : "there is more than one unique artist");
       // Clear song artists from artists map, put songs under "various artists" mbid entry
       artists.clear();
-      for (auto& song : songs)
-        artists[VARIOUSARTISTS_MBID].push_back(&song);
+      auto& artist = artists[std::string(VARIOUSARTISTS_MBID)];
+      std::ranges::transform(songs, std::back_inserter(artist), [](auto& song) { return &song; });
     }
 
     /*
@@ -873,7 +873,7 @@ void CMusicInfoScanner::FileItemsToAlbums(
           artist read from tags when 3a, or the localized value for "various artists" when not 3a.
           This means that tag values are no longer translated into the current language.
           */
-          album.artistCredits.emplace_back(various, VARIOUSARTISTS_MBID);
+          album.artistCredits.emplace_back(various, std::string(VARIOUSARTISTS_MBID));
         else
         {
           album.artistCredits.emplace_back(StringUtils::Trim(common[i]));

--- a/xbmc/music/tags/MusicInfoTag.cpp
+++ b/xbmc/music/tags/MusicInfoTag.cpp
@@ -1312,13 +1312,12 @@ std::string CMusicInfoTag::GetContributorsAndRolesText() const
   return StringUtils::TrimRight(strLabel, "\n");
 }
 
-
-const VECMUSICROLES &CMusicInfoTag::GetContributors()  const
+const std::vector<CMusicRole>& CMusicInfoTag::GetContributors() const
 {
   return m_musicRoles;
 }
 
-void CMusicInfoTag::SetContributors(const VECMUSICROLES& contributors)
+void CMusicInfoTag::SetContributors(const std::vector<CMusicRole>& contributors)
 {
   m_musicRoles = contributors;
 }

--- a/xbmc/music/tags/MusicInfoTag.h
+++ b/xbmc/music/tags/MusicInfoTag.h
@@ -189,8 +189,8 @@ public:
   std::string GetArtistStringForRole(const std::string& strRole) const;
   std::string GetContributorsText() const;
   std::string GetContributorsAndRolesText() const;
-  const VECMUSICROLES &GetContributors() const;
-  void SetContributors(const VECMUSICROLES& contributors);
+  const std::vector<CMusicRole>& GetContributors() const;
+  void SetContributors(const std::vector<CMusicRole>& contributors);
   bool HasContributors() const { return !m_musicRoles.empty(); }
 
   void Archive(CArchive& ar) override;
@@ -225,7 +225,8 @@ private:
   std::vector<std::string> m_musicBrainzAlbumArtistHints;
   std::string m_strMusicBrainzReleaseGroupID;
   std::string m_strMusicBrainzReleaseType;
-  VECMUSICROLES m_musicRoles; //Artists contributing to the recording and role (from tags other than ARTIST or ALBUMARTIST)
+  std::vector<CMusicRole>
+      m_musicRoles; // Artists contributing to the recording and role (from tags other than ARTIST or ALBUMARTIST)
   std::string m_strComment;
   std::string m_strMood;
   std::string m_strRecordLabel;


### PR DESCRIPTION
## Description
Drop typedefs for CArtist, add missing initializers, prefer constexpr

## Motivation and context
Modernization, less  SCREAMING.

## How has this been tested?
It builds

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
