### PR TITLE
LocalizeStrings: drop typedefs

### DIFF
--- a/xbmc/resources/LocalizeStrings.cpp
+++ b/xbmc/resources/LocalizeStrings.cpp
@@ -12,7 +12,6 @@
 #include "filesystem/Directory.h"
 #include "filesystem/SpecialProtocol.h"
 #include "threads/SharedSection.h"
-#include "utils/CharsetConverter.h"
 #include "utils/POUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"

--- a/xbmc/resources/LocalizeStrings.cpp
+++ b/xbmc/resources/LocalizeStrings.cpp
@@ -44,10 +44,10 @@ static bool LoadPO(const std::string& filename,
 
   while ((PODoc.GetNextEntry()))
   {
-    uint32_t id;
     if (PODoc.GetEntryType() == ID_FOUND)
     {
-      bool bStrInMem = strings.contains((id = PODoc.GetEntryID()) + offset);
+      const uint32_t id = PODoc.GetEntryID();
+      bool bStrInMem = strings.contains(id + offset);
       PODoc.ParseEntry(bSourceLanguage);
 
       if (bSourceLanguage && !PODoc.GetMsgid().empty())

--- a/xbmc/resources/LocalizeStrings.cpp
+++ b/xbmc/resources/LocalizeStrings.cpp
@@ -188,11 +188,7 @@ const std::string& CLocalizeStrings::Get(uint32_t dwCode) const
 {
   std::shared_lock<CSharedSection> lock(m_stringsMutex);
   const auto i = m_strings.find(dwCode);
-  if (i == m_strings.end())
-  {
-    return StringUtils::Empty;
-  }
-  return i->second.strTranslated;
+  return i == m_strings.end() ? StringUtils::Empty : i->second.strTranslated;
 }
 
 void CLocalizeStrings::Clear()
@@ -218,15 +214,12 @@ bool CLocalizeStrings::LoadAddonStrings(const std::string& path,
 const std::string& CLocalizeStrings::GetAddonString(const std::string& addonId, uint32_t code) const
 {
   std::shared_lock<CSharedSection> lock(m_addonStringsMutex);
-  auto i = m_addonStrings.find(addonId);
+  const auto i = m_addonStrings.find(addonId);
   if (i == m_addonStrings.end())
     return StringUtils::Empty;
 
-  auto j = i->second.find(code);
-  if (j == i->second.end())
-    return StringUtils::Empty;
-
-  return j->second.strTranslated;
+  const auto j = i->second.find(code);
+  return j == i->second.end() ? StringUtils::Empty : j->second.strTranslated;
 }
 
 void CLocalizeStrings::ClearAddonStrings(const std::string& addonId)

--- a/xbmc/resources/LocalizeStrings.cpp
+++ b/xbmc/resources/LocalizeStrings.cpp
@@ -188,7 +188,7 @@ bool CLocalizeStrings::Load(const std::string& strPathName, const std::string& s
 const std::string& CLocalizeStrings::Get(uint32_t dwCode) const
 {
   std::shared_lock<CSharedSection> lock(m_stringsMutex);
-  ciStrings i = m_strings.find(dwCode);
+  const auto i = m_strings.find(dwCode);
   if (i == m_strings.end())
   {
     return StringUtils::Empty;

--- a/xbmc/resources/LocalizeStrings.h
+++ b/xbmc/resources/LocalizeStrings.h
@@ -60,8 +60,6 @@ public:
 protected:
   std::unordered_map<uint32_t, LocStr> m_strings;
   std::unordered_map<std::string, std::unordered_map<uint32_t, LocStr>> m_addonStrings;
-  typedef std::unordered_map<uint32_t, LocStr>::const_iterator ciStrings;
-  typedef std::unordered_map<uint32_t, LocStr>::iterator iStrings;
 
   mutable CSharedSection m_stringsMutex;
   mutable CSharedSection m_addonStringsMutex;


### PR DESCRIPTION
## Description
Drop typedefs for iterators, a capital offense since 2011.

## Motivation and context
enen92 made me do it!

## How has this been tested?
It builds

## What is the effect on users?
They can finally sleep at night, knowing these evil types have been banished. 

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
