### PR TITLE
[Games] Make LUTs not pass specific

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
@@ -11,7 +11,6 @@
 #include "cores/RetroPlayer/buffers/RenderBufferDMA.h"
 #include "cores/RetroPlayer/buffers/RenderBufferPoolDMA.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
-#include "cores/RetroPlayer/rendering/RenderVideoSettings.h"
 #include "cores/RetroPlayer/shaders/gl/ShaderPresetGL.h"
 #include "cores/RetroPlayer/shaders/gl/ShaderTextureGLRef.h"
 #include "utils/BufferObjectFactory.h"

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -11,7 +11,6 @@
 #include "cores/RetroPlayer/buffers/RenderBufferDMA.h"
 #include "cores/RetroPlayer/buffers/RenderBufferPoolDMA.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
-#include "cores/RetroPlayer/rendering/RenderVideoSettings.h"
 #include "cores/RetroPlayer/shaders/gles/ShaderPresetGLES.h"
 #include "cores/RetroPlayer/shaders/gles/ShaderTextureGLESRef.h"
 #include "utils/BufferObjectFactory.h"

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
@@ -57,10 +57,9 @@ bool CShaderPreset::RenderUpdate(const RETRO::ViewportCoordinates& dest,
 
   PrepareParameters(dest, source);
 
-  const auto numPasses = static_cast<unsigned int>(m_pShaders.size());
-
   // Apply all passes except the last one (which needs to be applied to the backbuffer)
   IShaderTexture* sourceTexture = &source;
+  const auto numPasses = static_cast<unsigned int>(m_pShaders.size());
   for (unsigned shaderIdx = 0; shaderIdx + 1 < numPasses; ++shaderIdx)
   {
     IShader& shader = *m_pShaders[shaderIdx];
@@ -185,9 +184,8 @@ void CShaderPreset::UpdateMVPs()
 void CShaderPreset::PrepareParameters(const RETRO::ViewportCoordinates& dest,
                                       IShaderTexture& source)
 {
-  const auto numPasses = static_cast<unsigned int>(m_pShaders.size());
-
   // Prepare parameters for all shader passes
+  const auto numPasses = static_cast<unsigned int>(m_pShaders.size());
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
     std::unique_ptr<IShader>& videoShader = m_pShaders[shaderIdx];
@@ -215,6 +213,7 @@ void CShaderPreset::CalculateScaledSize(const KODI::SHADER::ShaderPass& pass,
           pass.fbo.scaleX.scale != 0.0f ? pass.fbo.scaleX.scale * prevSize.x : prevSize.x;
       break;
   }
+
   switch (pass.fbo.scaleY.scaleType)
   {
     case ScaleType::ABSOLUTE_SCALE:
@@ -254,9 +253,10 @@ ShaderParameterMap CShaderPreset::GetShaderParameters(
     const std::vector<ShaderParameter>& parameters, const std::string& sourceStr) const
 {
   static const std::regex pragmaParamRegex("#pragma parameter ([a-zA-Z_][a-zA-Z0-9_]*)");
-  std::smatch matches;
 
   std::vector<std::string> validParams;
+  std::smatch matches;
+
   auto searchStart(sourceStr.cbegin());
   while (regex_search(searchStart, sourceStr.cend(), matches, pragmaParamRegex))
   {
@@ -283,5 +283,6 @@ ShaderParameterMap CShaderPreset::GetShaderParameters(
       }
     }
   }
+
   return matchParams;
 }

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
@@ -29,26 +29,25 @@ CShaderPresetGLES::CShaderPresetGLES(RETRO::CRenderContext& context,
 
 bool CShaderPresetGLES::CreateShaders()
 {
-  const auto numPasses = static_cast<unsigned int>(m_passes.size());
+  std::vector<std::shared_ptr<IShaderLut>> presetLUTsGL;
 
+  if (!m_passes.empty())
+  {
+    const auto numLuts = static_cast<unsigned int>(m_passes[0].luts.size());
+    for (unsigned int i = 0; i < numLuts; ++i)
+    {
+      const ShaderLut& lutStruct = m_passes[0].luts[i];
+
+      auto presetLut = std::make_shared<CShaderLutGLES>(lutStruct.strId, lutStruct.path);
+      if (presetLut->Create(lutStruct))
+        presetLUTsGL.emplace_back(std::move(presetLut));
+    }
+  }
+
+  const auto numPasses = static_cast<unsigned int>(m_passes.size());
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
     const ShaderPass& pass = m_passes[shaderIdx];
-    const auto numPassLuts = static_cast<unsigned int>(pass.luts.size());
-
-    //! @todo Is this pass specific?
-    std::vector<std::shared_ptr<IShaderLut>> passLUTsGL;
-    for (unsigned int i = 0; i < numPassLuts; ++i)
-    {
-      const ShaderLut& lutStruct = pass.luts[i];
-
-      auto passLut = std::make_shared<CShaderLutGLES>(lutStruct.strId, lutStruct.path);
-      if (passLut->Create(lutStruct))
-        passLUTsGL.emplace_back(std::move(passLut));
-    }
-
-    // Create the shader
-    auto videoShader = std::make_unique<CShaderGLES>();
 
     const std::string& shaderSource = pass.vertexSource; // Also contains fragment source
     const std::string& shaderPath = pass.sourcePath;
@@ -56,8 +55,10 @@ bool CShaderPresetGLES::CreateShaders()
     // Get only the parameters belonging to this specific shader
     ShaderParameterMap passParameters = GetShaderParameters(pass.parameters, pass.vertexSource);
 
+    // Create the shader
+    auto videoShader = std::make_unique<CShaderGLES>();
     if (!videoShader->Create(shaderIdx, pass.alias, shaderPath, shaderSource,
-                             std::move(passParameters), std::move(passLUTsGL), pass.frameCountMod))
+                             std::move(passParameters), presetLUTsGL, pass.frameCountMod))
     {
       CLog::Log(LOGERROR, "CShaderPresetGLES::CreateShaders: Couldn't create a video shader");
       return false;
@@ -80,7 +81,6 @@ bool CShaderPresetGLES::CreateShaderTextures()
   float2 prevTextureSize = m_videoSize;
 
   const auto numPasses = static_cast<unsigned int>(m_passes.size());
-
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
     const auto& pass = m_passes[shaderIdx];


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Make LUTs not pass specific for libretro video shader presets.
This PR fixes issue https://github.com/xbmc/xbmc/issues/27852.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current code works, but it duplicates LUTs from the preset to all shader passes. The libretro shader presets specify common LUTs for the preset, not per pass. For advanced presets like _CRT Royale_ this brings the number of loaded external textures down from 104 to 8.

More details are available in the issue: https://github.com/xbmc/xbmc/issues/27852

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Linux / Wayland / OpenGL and GLES
I'm currently not able to test the DirectX version.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Faster preset loading and less resources used.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
