### PR TITLE
[Estuary] Change the display of tagline in DialogVideoInfo

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -393,7 +393,7 @@
 		<value>$INFO[ListItem.Label]$INFO[ListItem.Year, ([COLOR grey],[/COLOR])]</value>
 	</variable>
 	<variable name="VideoInfoPlotVar">
-		<value condition="!String.IsEmpty(ListItem.Plot)">$INFO[ListItem.Plot]</value>
+		<value condition="!String.IsEmpty(ListItem.Tagline) | !String.IsEmpty(ListItem.Plot)">$INFO[ListItem.Tagline,[B][I],[/I][/B][CR]]$INFO[ListItem.Plot]</value>
 		<value condition="String.IsEqual(ListItem.DBType,season)">$INFO[Container.ShowPlot]</value>
 	</variable>
 	<variable name="VideoInfoPlayButtonLabelVar">
@@ -403,7 +403,6 @@
 	<variable name="VideoInfoSubLabelVar">
 		<value condition="String.IsEqual(ListItem.DBType,episode)">$INFO[ListItem.Season]$INFO[ListItem.Episode,[COLOR grey]x[/COLOR],: ]$INFO[ListItem.Title]</value>
 		<value condition="String.IsEqual(ListItem.DBType,season)">$INFO[ListItem.Label]</value>
-		<value condition="String.IsEqual(ListItem.DBType,movie)">$INFO[ListItem.Tagline,[I],[/I]]</value>
 		<value>$INFO[ListItem.Genre]</value>
 	</variable>
 	<variable name="PictureInfoMainLabelVar">


### PR DESCRIPTION
## Description
Skins including Estuary have the ability to display a tagline for movies, however a new addition by @CrystalP in https://github.com/xbmc/xbmc/pull/27566 has also given the ability for skins to display a tagline for TV Shows. However for the new TV Show tagline to be displayed changes in Estuary are needed, so this PR introduces the necessary changes.

## Motivation and context
Allow Estuary to display the new TV Show tagline.

## How has this been tested?
Tested locally on Windows

## What is the effect on users?
Show the new TV Show tagline and show more characters per line within the text viewer.

## Screenshots (if appropriate):

### Addition of tagline to plot textbox and plot dialog

TV Show info with tagline wthin the plot textbox

<img width="1919" height="1004" alt="image" src="https://github.com/user-attachments/assets/340b1393-f592-4e21-8974-3002e0938c3f" />

TV Show plot

![tv_font37](https://github.com/user-attachments/assets/e2f3c29c-f3a9-41ee-8305-594def177dcb)

Movie plot
![movie_font37](https://github.com/user-attachments/assets/72902576-2c5a-4f2a-83a4-2c9d250df18a)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
