### PR TITLE
Revert "[tools/depends][target] Pythonmodule-pil set install location"

### DIFF
--- a/tools/depends/target/pythonmodule-pil/Makefile
+++ b/tools/depends/target/pythonmodule-pil/Makefile
@@ -23,8 +23,6 @@ else ifeq ($(OS),darwin_embedded)
   PILPATH=$(PREFIX)/share/$(APP_NAME)/addons/script.module.pil
   PILPATHLIB=$(PILPATH)/lib
   PYTHONPATH=$(PILPATH):$(PYTHON_SITE_PKG)
-else ifeq ($(TARGET_PLATFORM),webos)
-  PILPATHLIB=$(PILPATH)
 endif
 
 SED_FLAG=-i
@@ -78,12 +76,10 @@ ifeq ($(OS),android)
 	mkdir -p $(PILPATHLIB)
 else ifeq ($(OS),darwin_embedded)
 	mkdir -p $(PILPATHLIB)
-else ifeq ($(TARGET_PLATFORM),webos)
-	mkdir -p $(PILPATHLIB)
 endif
 
 .installed-$(PLATFORM): $(PLATFORM) $(PILPATHLIB)
-	cd $(PLATFORM); $(NATIVEPREFIX)/bin/python3 setup.py build build_py build_ext $(BUILD_OPTS) install --install-lib $(PILPATHLIB) bdist_egg
+	cd $(PLATFORM); $(NATIVEPREFIX)/bin/python3 setup.py build build_py build_ext $(BUILD_OPTS) install --install-lib $(PILPATH) bdist_egg
 ifeq ($(OS),android)
 	unzip -o $(PLATFORM)/dist/pillow-*.egg -d $(PILPATHLIB)
 	cd $(PILPATHLIB)/PIL && \
@@ -95,7 +91,7 @@ ifeq ($(OS),android)
 else ifeq ($(OS),darwin_embedded)
 	unzip -o $(PLATFORM)/dist/pillow-*.egg -d $(PILPATHLIB)
 else ifeq ($(TARGET_PLATFORM),webos)
-	unzip -o $(PLATFORM)/dist/pillow-*.egg -d $(PILPATHLIB)
+	unzip -o $(PLATFORM)/dist/pillow-*.egg -d $(PILPATH)
 endif
 	touch $@
 


### PR DESCRIPTION
## Description

This reverts commit cec2c6e8938f5876c5bc64f9fcb14c8c92870543.

## Motivation and context
The change to the installation directory seems to be causing issues on macOS, see related https://github.com/xbmc/xbmc/pull/27715#issuecomment-3905447952

A few days earlier, an adjustment had also been made to make it work on webOS.

It would be best to leave it as it was and ensure that this change works correctly on all platforms.

## How has this been tested?
Verified that the add-on works correctly on Android

## Types of change
- [Z] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
