### PR TITLE
[xbmc] Add CurlFile HTTP 501 handling

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1386,21 +1386,14 @@ bool CCurlFile::Exists(const CURL& url)
     long code;
     if(g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_RESPONSE_CODE, &code) == CURLE_OK && code != 404 )
     {
-      if (code == 405)
+      if (code == 405 || code == 501)
       {
-        // If we get a Method Not Allowed response, retry with a GET Request
-        g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_NOBODY, 0);
+        // If we get a Method Not Allowed or Not Implemented response, retry with a GET Request
+        g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_HTTPGET, 1);
 
-        g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_FILETIME, 1);
-        g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_XFERINFOFUNCTION, transfer_abort_callback);
-        g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_NOPROGRESS, 0);
-
-        curl_slist *list = NULL;
-        list = g_curlInterface.slist_append(list, "Range: bytes=0-1"); /* try to only request 1 byte */
-        g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_HTTPHEADER, list);
+        g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_RANGE, "0-199");
 
         CURLcode result = g_curlInterface.easy_perform(m_state->m_easyHandle);
-        g_curlInterface.slist_free_all(list);
 
         if (result == CURLE_WRITE_ERROR || result == CURLE_OK)
         {


### PR DESCRIPTION
## Description
  Handle HTTP 501 (Not Implemented) responses in CCurlFile::Exists() by falling back to a GET request, the same way 405 (Method Not Allowed) is already handled. Also simplifies the retry logic by using CURLOPT_HTTPGET and CURLOPT_RANGE instead of manually managing a curl_slist for the Range header.

## Motivation and context
  Some HTTP servers respond to HEAD requests with 501 (Not Implemented) rather than 405 (Method Not Allowed). The existing fallback-to-GET logic only covered 405, causing Exists() to incorrectly report that a resource does not exist when the server returns 501.

  The retry path is also simplified:
  - CURLOPT_HTTPGET is the correct way to switch from HEAD back to GET (instead of unsetting CURLOPT_NOBODY)
  - CURLOPT_RANGE replaces the manual curl_slist allocation for the Range header, removing the need for slist_append/slist_free_all
  - The CURLOPT_FILETIME, CURLOPT_XFERINFOFUNCTION, and CURLOPT_NOPROGRESS options were unnecessary for a simple existence-check retry and have been removed

## How has this been tested?
  Tested against a WEBDAV server that returns 501 for HEAD requests, confirming that Exists() now correctly falls back to a ranged GET and returns true.

## What is the effect on users?
  Files hosted on HTTP/WEBDAV servers that reject HEAD requests with 501 will now be correctly detected as existing. This can fix issues with media sources, add-on repositories, or UPnP servers that do not implement the HEAD method.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
