### PR TITLE
[Video][Library] Check for parsing nfos to ensure episode grouping respected when adding additional episodes.

### DIFF
--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -178,6 +178,7 @@ namespace KODI::VIDEO
                                       CGUIDialogProgress* pDlgProgress);
     InfoRet RetrieveInfoForEpisodes(CFileItem* item,
                                     long showID,
+                                    EPISODELIST& files,
                                     const ADDON::ScraperPtr& scraper,
                                     bool useLocal,
                                     CGUIDialogProgress* progress = nullptr,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Moved the determination of episodes to be added (which includes checking directory hashes) to the beginning of RetrieveInfoForTvShow() - it was at the start of RetrieveInfoForEpisodes().

Then moved the addition of new episodes to an existing TV show to after the nfo parsing - to ensure any parsing nfos containg urls for alternate episode grouping are detected on these subsequent additions.

I can't see any obvious downside from moving the episode hash checks earlier but I've marked it as beta 1 so it has a chance to sit in the nightlies for a while to pick up any unintended consequences.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix https://forum.kodi.tv/showthread.php?tid=384475&pid=326463.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally and by @pkscout.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
