### PR TITLE
Reorder parameters and drop default value

### DIFF
--- a/xbmc/PartyModeManager.cpp
+++ b/xbmc/PartyModeManager.cpp
@@ -338,8 +338,8 @@ bool CPartyModeManager::AddRandomSongs()
       CMusicDatabase database;
       if (database.Open())
       {
-        database.GetSongsFullByWhere("musicdb://songs/", CDatabase::Filter(sqlWhereMusic),
-          items, SortDescription, true);
+        database.GetSongsFullByWhere("musicdb://songs/", items, SortDescription,
+                                     CDatabase::Filter(sqlWhereMusic), true);
 
         // Get artist and album properties for songs
         for (auto& item : items)

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -715,7 +715,8 @@ int CGUIDialogMediaFilter::GetItems(const Filter &filter, std::vector<std::strin
     if (filter.field == FieldGenre)
       musicdb.GetGenresNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
     else if (filter.field == FieldArtist || filter.field == FieldAlbumArtist)
-      musicdb.GetArtistsNav(m_dbUrl->ToString(), selectItems, m_mediaType == "albums", -1, -1, -1, dbfilter, SortDescription(), countOnly);
+      musicdb.GetArtistsNav(m_dbUrl->ToString(), selectItems, SortDescription(),
+                            m_mediaType == "albums", -1, -1, -1, dbfilter, countOnly);
     else if (filter.field == FieldAlbum)
       musicdb.GetAlbumsNav(m_dbUrl->ToString(), selectItems, -1, -1, dbfilter, SortDescription(), countOnly);
     else if (filter.field == FieldAlbumType)

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -718,7 +718,8 @@ int CGUIDialogMediaFilter::GetItems(const Filter &filter, std::vector<std::strin
       musicdb.GetArtistsNav(m_dbUrl->ToString(), selectItems, SortDescription(),
                             m_mediaType == "albums", -1, -1, -1, dbfilter, countOnly);
     else if (filter.field == FieldAlbum)
-      musicdb.GetAlbumsNav(m_dbUrl->ToString(), selectItems, -1, -1, dbfilter, SortDescription(), countOnly);
+      musicdb.GetAlbumsNav(m_dbUrl->ToString(), selectItems, SortDescription(), -1, -1, dbfilter,
+                           countOnly);
     else if (filter.field == FieldAlbumType)
       musicdb.GetAlbumTypesNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
     else if (filter.field == FieldMusicLabel)

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -182,7 +182,8 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   else if (m_rule.m_field == FieldArtist || m_rule.m_field == FieldAlbumArtist)
   {
     if (PLAYLIST::CSmartPlaylist::IsMusicType(m_type))
-      database.GetArtistsNav("musicdb://artists/", items, m_rule.m_field == FieldAlbumArtist, -1);
+      database.GetArtistsNav("musicdb://artists/", items, SortDescription(),
+                             m_rule.m_field == FieldAlbumArtist, -1);
     if (m_type == "musicvideos" ||
         m_type == "mixed")
     {

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -196,7 +196,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   else if (m_rule.m_field == FieldAlbum)
   {
     if (PLAYLIST::CSmartPlaylist::IsMusicType(m_type))
-      database.GetAlbumsNav("musicdb://albums/", items);
+      database.GetAlbumsNav("musicdb://albums/", items, SortDescription());
     if (m_type == "musicvideos" ||
         m_type == "mixed")
     {

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -253,7 +253,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   {
     if (m_type == "songs" || m_type == "mixed")
     {
-      database.GetSongsNav("musicdb://songs/", items, -1, -1, -1);
+      database.GetSongsNav("musicdb://songs/", items, SortDescription(), -1, -1, -1);
       iLabel = 134;
     }
     if (m_type == "movies")

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeAlbum.cpp
@@ -46,7 +46,8 @@ bool CDirectoryNodeAlbum::GetContent(CFileItemList& items) const
   CQueryParams params;
   CollectQueryParams(params);
 
-  bool bSuccess=musicdatabase.GetAlbumsNav(BuildPath(), items, params.GetGenreId(), params.GetArtistId());
+  bool bSuccess = musicdatabase.GetAlbumsNav(BuildPath(), items, SortDescription(),
+                                             params.GetGenreId(), params.GetArtistId());
 
   musicdatabase.Close();
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeArtist.cpp
@@ -54,7 +54,11 @@ bool CDirectoryNodeArtist::GetContent(CFileItemList& items) const
   CQueryParams params;
   CollectQueryParams(params);
 
-  bool bSuccess = musicdatabase.GetArtistsNav(BuildPath(), items, !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICLIBRARY_SHOWCOMPILATIONARTISTS), params.GetGenreId());
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  bool bSuccess = musicdatabase.GetArtistsNav(
+      BuildPath(), items, SortDescription(),
+      !settings->GetBool(CSettings::SETTING_MUSICLIBRARY_SHOWCOMPILATIONARTISTS),
+      params.GetGenreId());
 
   musicdatabase.Close();
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeDiscs.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeDiscs.cpp
@@ -50,7 +50,8 @@ bool CDirectoryNodeDiscs::GetContent(CFileItemList& items) const
   CQueryParams params;
   CollectQueryParams(params);
 
-  bool bSuccess = musicdatabase.GetDiscsNav(BuildPath(), items, params.GetAlbumId());
+  bool bSuccess =
+      musicdatabase.GetDiscsNav(BuildPath(), items, SortDescription(), params.GetAlbumId());
 
   musicdatabase.Close();
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeGrouped.cpp
@@ -40,7 +40,7 @@ bool CDirectoryNodeGrouped::GetContent(CFileItemList& items) const
   if (!musicdatabase.Open())
     return false;
 
-  return musicdatabase.GetItems(BuildPath(), GetContentType(), items);
+  return musicdatabase.GetItems(BuildPath(), GetContentType(), items, SortDescription());
 }
 
 std::string CDirectoryNodeGrouped::GetContentType() const

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSingles.cpp
@@ -24,7 +24,8 @@ bool CDirectoryNodeSingles::GetContent(CFileItemList& items) const
   if (!musicdatabase.Open())
     return false;
 
-  bool bSuccess = musicdatabase.GetSongsFullByWhere(BuildPath(), CDatabase::Filter(), items, SortDescription(), true);
+  bool bSuccess = musicdatabase.GetSongsFullByWhere(BuildPath(), items, SortDescription(),
+                                                    CDatabase::Filter(), true);
 
   musicdatabase.Close();
 

--- a/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory/DirectoryNodeSong.cpp
@@ -29,7 +29,9 @@ bool CDirectoryNodeSong::GetContent(CFileItemList& items) const
   CollectQueryParams(params);
 
   std::string strBaseDir=BuildPath();
-  bool bSuccess=musicdatabase.GetSongsNav(strBaseDir, items, params.GetGenreId(), params.GetArtistId(), params.GetAlbumId());
+  bool bSuccess =
+      musicdatabase.GetSongsNav(strBaseDir, items, SortDescription(), params.GetGenreId(),
+                                params.GetArtistId(), params.GetAlbumId());
 
   musicdatabase.Close();
 

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -208,7 +208,7 @@ namespace XFILE
           musicUrl.RemoveOption(option);
 
         CDatabase::Filter dbfilter;
-        success = db.GetItems(musicUrl.ToString(), items, dbfilter, sorting);
+        success = db.GetItems(musicUrl.ToString(), items, sorting, dbfilter);
         db.Close();
 
         items.SetProperty(PROPERTY_PATH_DB, musicUrl.ToString());

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -186,7 +186,8 @@ JSONRPC_STATUS CAudioLibrary::GetArtistDetails(const std::string &method, ITrans
 
   CFileItemList items;
   CDatabase::Filter filter;
-  if (!musicdatabase.GetArtistsByWhere(musicUrl.ToString(), filter, items) || items.Size() != 1)
+  if (!musicdatabase.GetArtistsByWhere(musicUrl.ToString(), items, SortDescription(), filter) ||
+      items.Size() != 1)
     return InvalidParams;
 
   // Add "artist" to "properties" array by default

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -1145,7 +1145,8 @@ bool CAudioLibrary::FillFileItemList(const CVariant &parameterObject, CFileItemL
   }
 
   if (artistID != -1 || albumID != -1 || genreID != -1)
-    success |= musicdatabase.GetSongsNav("musicdb://songs/", list, genreID, artistID, albumID);
+    success |= musicdatabase.GetSongsNav("musicdb://songs/", list, SortDescription(), genreID,
+                                         artistID, albumID);
 
   int songID = (int)parameterObject["songid"].asInteger(-1);
   if (songID != -1)

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5540,7 +5540,7 @@ bool CMusicDatabase::GetArtistsNav(const std::string& strBaseDir,
     if (!musicUrl.HasOption("albumartistsonly"))
       musicUrl.AddOption("albumartistsonly", albumArtistsOnly);
 
-    bool result = GetArtistsByWhere(musicUrl.ToString(), filter, items, sortDescription, countOnly);
+    bool result = GetArtistsByWhere(musicUrl.ToString(), items, sortDescription, filter, countOnly);
 
     return result;
   }
@@ -5552,12 +5552,11 @@ bool CMusicDatabase::GetArtistsNav(const std::string& strBaseDir,
   return false;
 }
 
-bool CMusicDatabase::GetArtistsByWhere(
-    const std::string& strBaseDir,
-    const Filter& filter,
-    CFileItemList& items,
-    const SortDescription& sortDescription /* = SortDescription() */,
-    bool countOnly /* = false */)
+bool CMusicDatabase::GetArtistsByWhere(const std::string& strBaseDir,
+                                       CFileItemList& items,
+                                       const SortDescription& sortDescription,
+                                       const Filter& filter,
+                                       bool countOnly /* = false */)
 {
   if (nullptr == m_pDB)
     return false;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5510,12 +5510,12 @@ bool CMusicDatabase::GetMusicLabelsNav(const std::string& strBaseDir,
 
 bool CMusicDatabase::GetArtistsNav(const std::string& strBaseDir,
                                    CFileItemList& items,
+                                   const SortDescription& sortDescription,
                                    bool albumArtistsOnly /* = false */,
                                    int idGenre /* = -1 */,
                                    int idAlbum /* = -1 */,
                                    int idSong /* = -1 */,
                                    const Filter& filter /* = Filter() */,
-                                   const SortDescription& sortDescription /* = SortDescription() */,
                                    bool countOnly /* = false */)
 {
   if (nullptr == m_pDB)
@@ -11774,10 +11774,10 @@ bool CMusicDatabase::GetItems(const std::string& strBaseDir,
   else if (StringUtils::EqualsNoCase(itemType, "roles"))
     return GetRolesNav(strBaseDir, items, filter);
   else if (StringUtils::EqualsNoCase(itemType, "artists"))
-    return GetArtistsNav(strBaseDir, items,
+    return GetArtistsNav(strBaseDir, items, sortDescription,
                          !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
                              CSettings::SETTING_MUSICLIBRARY_SHOWCOMPILATIONARTISTS),
-                         -1, -1, -1, filter, sortDescription);
+                         -1, -1, -1, filter, false);
   else if (StringUtils::EqualsNoCase(itemType, "albums"))
     return GetAlbumsByWhere(strBaseDir, filter, items, sortDescription);
   else if (StringUtils::EqualsNoCase(itemType, "discs"))

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5967,9 +5967,9 @@ bool CMusicDatabase::GetAlbumsByWhere(
 
 bool CMusicDatabase::GetDiscsNav(const std::string& strBaseDir,
                                  CFileItemList& items,
+                                 const SortDescription& sortDescription,
                                  int idAlbum,
                                  const Filter& filter,
-                                 const SortDescription& sortDescription,
                                  bool countOnly)
 {
   CMusicDbUrl musicUrl;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -6535,12 +6535,11 @@ const std::array<TranslateJSONField, 35> JSONtoDBArtist = {{
 // clang-format on
 } // unnamed namespace
 
-bool CMusicDatabase::GetArtistsByWhereJSON(
-    const std::set<std::string, std::less<>>& fields,
-    const std::string& baseDir,
-    CVariant& result,
-    int& total,
-    const SortDescription& sortDescription /* = SortDescription() */)
+bool CMusicDatabase::GetArtistsByWhereJSON(const std::set<std::string, std::less<>>& fields,
+                                           const std::string& baseDir,
+                                           CVariant& result,
+                                           int& total,
+                                           const SortDescription& sortDescription)
 {
   if (nullptr == m_pDB)
     return false;

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5978,25 +5978,25 @@ bool CMusicDatabase::GetDiscsNav(const std::string& strBaseDir,
   if (idAlbum > 0)
     musicUrl.AddOption("albumid", idAlbum);
 
-  return GetDiscsByWhere(musicUrl, filter, items, sortDescription, countOnly);
+  return GetDiscsByWhere(musicUrl, items, sortDescription, filter, countOnly);
 }
 
 bool CMusicDatabase::GetDiscsByWhere(const std::string& baseDir,
-                                     const Filter& filter,
                                      CFileItemList& items,
                                      const SortDescription& sortDescription,
+                                     const Filter& filter,
                                      bool countOnly)
 {
   CMusicDbUrl musicUrl;
   if (!musicUrl.FromString(baseDir))
     return false;
-  return GetDiscsByWhere(musicUrl, filter, items, sortDescription, countOnly);
+  return GetDiscsByWhere(musicUrl, items, sortDescription, filter, countOnly);
 }
 
 bool CMusicDatabase::GetDiscsByWhere(CMusicDbUrl& musicUrl,
-                                     const Filter& filter,
                                      CFileItemList& items,
                                      const SortDescription& sortDescription,
+                                     const Filter& filter,
                                      bool countOnly)
 {
   if (m_pDB == nullptr || m_pDS == nullptr)
@@ -6186,7 +6186,7 @@ int CMusicDatabase::GetDiscsCount(const std::string& baseDir, const Filter& filt
 {
   int iDiscTotal = -1;
   CFileItemList itemscount;
-  if (GetDiscsByWhere(baseDir, filter, itemscount, SortDescription(), true))
+  if (GetDiscsByWhere(baseDir, itemscount, SortDescription(), filter, true))
     iDiscTotal = itemscount.GetProperty("total").asInteger32();
   return iDiscTotal;
 }
@@ -11779,7 +11779,7 @@ bool CMusicDatabase::GetItems(const std::string& strBaseDir,
   else if (StringUtils::EqualsNoCase(itemType, "albums"))
     return GetAlbumsByWhere(strBaseDir, items, sortDescription, filter);
   else if (StringUtils::EqualsNoCase(itemType, "discs"))
-    return GetDiscsByWhere(strBaseDir, filter, items, sortDescription);
+    return GetDiscsByWhere(strBaseDir, items, sortDescription, filter);
   else if (StringUtils::EqualsNoCase(itemType, "songs"))
     return GetSongsFullByWhere(strBaseDir, items, sortDescription, filter, true);
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5398,7 +5398,7 @@ bool CMusicDatabase::GetAlbumsByYear(const std::string& strBaseDir, CFileItemLis
   musicUrl.AddOption("show_singles", true); // allow singles to be listed
 
   Filter filter;
-  return GetAlbumsByWhere(musicUrl.ToString(), filter, items);
+  return GetAlbumsByWhere(musicUrl.ToString(), items, SortDescription(), filter);
 }
 
 bool CMusicDatabase::GetCommonNav(const std::string& strBaseDir,
@@ -5790,15 +5790,14 @@ bool CMusicDatabase::GetAlbumsNav(const std::string& strBaseDir,
   if (idArtist > 0)
     musicUrl.AddOption("artistid", idArtist);
 
-  return GetAlbumsByWhere(musicUrl.ToString(), filter, items, sortDescription, countOnly);
+  return GetAlbumsByWhere(musicUrl.ToString(), items, sortDescription, filter, countOnly);
 }
 
-bool CMusicDatabase::GetAlbumsByWhere(
-    const std::string& baseDir,
-    const Filter& filter,
-    CFileItemList& items,
-    const SortDescription& sortDescription /* = SortDescription() */,
-    bool countOnly /* = false */)
+bool CMusicDatabase::GetAlbumsByWhere(const std::string& baseDir,
+                                      CFileItemList& items,
+                                      const SortDescription& sortDescription,
+                                      const Filter& filter,
+                                      bool countOnly /* = false */)
 {
   if (m_pDB == nullptr || m_pDS == nullptr)
     return false;
@@ -11778,7 +11777,7 @@ bool CMusicDatabase::GetItems(const std::string& strBaseDir,
                              CSettings::SETTING_MUSICLIBRARY_SHOWCOMPILATIONARTISTS),
                          -1, -1, -1, filter, false);
   else if (StringUtils::EqualsNoCase(itemType, "albums"))
-    return GetAlbumsByWhere(strBaseDir, filter, items, sortDescription);
+    return GetAlbumsByWhere(strBaseDir, items, sortDescription, filter);
   else if (StringUtils::EqualsNoCase(itemType, "discs"))
     return GetDiscsByWhere(strBaseDir, filter, items, sortDescription);
   else if (StringUtils::EqualsNoCase(itemType, "songs"))

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -7271,12 +7271,11 @@ const std::array<TranslateJSONField, 35> JSONtoDBAlbum = {{
 // clang-format on
 } //unnamed namespace
 
-bool CMusicDatabase::GetAlbumsByWhereJSON(
-    const std::set<std::string, std::less<>>& fields,
-    const std::string& baseDir,
-    CVariant& result,
-    int& total,
-    const SortDescription& sortDescription /* = SortDescription() */)
+bool CMusicDatabase::GetAlbumsByWhereJSON(const std::set<std::string, std::less<>>& fields,
+                                          const std::string& baseDir,
+                                          CVariant& result,
+                                          int& total,
+                                          const SortDescription& sortDescription)
 {
 
   if (nullptr == m_pDB)
@@ -11745,21 +11744,21 @@ bool CMusicDatabase::ScraperInUse(const std::string& scraperID) const
 
 bool CMusicDatabase::GetItems(const std::string& strBaseDir,
                               CFileItemList& items,
-                              const Filter& filter /* = Filter() */,
-                              const SortDescription& sortDescription /* = SortDescription() */)
+                              const SortDescription& sortDescription,
+                              const Filter& filter /* = Filter() */)
 {
   CMusicDbUrl musicUrl;
   if (!musicUrl.FromString(strBaseDir))
     return false;
 
-  return GetItems(strBaseDir, musicUrl.GetType(), items, filter, sortDescription);
+  return GetItems(strBaseDir, musicUrl.GetType(), items, sortDescription, filter);
 }
 
 bool CMusicDatabase::GetItems(const std::string& strBaseDir,
                               const std::string& itemType,
                               CFileItemList& items,
-                              const Filter& filter /* = Filter() */,
-                              const SortDescription& sortDescription /* = SortDescription() */)
+                              const SortDescription& sortDescription,
+                              const Filter& filter /* = Filter() */)
 {
   if (StringUtils::EqualsNoCase(itemType, "genres"))
     return GetGenresNav(strBaseDir, items, filter);

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -6454,10 +6454,10 @@ bool CMusicDatabase::GetSongsByYear(const std::string& baseDir, CFileItemList& i
 
 bool CMusicDatabase::GetSongsNav(const std::string& strBaseDir,
                                  CFileItemList& items,
+                                 const SortDescription& sortDescription,
                                  int idGenre,
                                  int idArtist,
-                                 int idAlbum,
-                                 const SortDescription& sortDescription /* = SortDescription() */)
+                                 int idAlbum)
 {
   CMusicDbUrl musicUrl;
   if (!musicUrl.FromString(strBaseDir))

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -6192,12 +6192,11 @@ int CMusicDatabase::GetDiscsCount(const std::string& baseDir, const Filter& filt
   return iDiscTotal;
 }
 
-bool CMusicDatabase::GetSongsFullByWhere(
-    const std::string& baseDir,
-    const Filter& filter,
-    CFileItemList& items,
-    const SortDescription& sortDescription /* = SortDescription() */,
-    bool artistData /* = false*/)
+bool CMusicDatabase::GetSongsFullByWhere(const std::string& baseDir,
+                                         CFileItemList& items,
+                                         const SortDescription& sortDescription,
+                                         const Filter& filter,
+                                         bool artistData /* = false*/)
 {
   if (m_pDB == nullptr || m_pDS == nullptr)
     return false;
@@ -6449,7 +6448,7 @@ bool CMusicDatabase::GetSongsByYear(const std::string& baseDir, CFileItemList& i
   musicUrl.AddOption("year", year);
 
   Filter filter;
-  return GetSongsFullByWhere(baseDir, filter, items, SortDescription(), true);
+  return GetSongsFullByWhere(baseDir, items, SortDescription(), filter, true);
 }
 
 bool CMusicDatabase::GetSongsNav(const std::string& strBaseDir,
@@ -6473,7 +6472,7 @@ bool CMusicDatabase::GetSongsNav(const std::string& strBaseDir,
     musicUrl.AddOption("artistid", idArtist);
 
   Filter filter;
-  return GetSongsFullByWhere(musicUrl.ToString(), filter, items, sortDescription, true);
+  return GetSongsFullByWhere(musicUrl.ToString(), items, sortDescription, filter, true);
 }
 
 namespace
@@ -11783,7 +11782,7 @@ bool CMusicDatabase::GetItems(const std::string& strBaseDir,
   else if (StringUtils::EqualsNoCase(itemType, "discs"))
     return GetDiscsByWhere(strBaseDir, filter, items, sortDescription);
   else if (StringUtils::EqualsNoCase(itemType, "songs"))
-    return GetSongsFullByWhere(strBaseDir, filter, items, sortDescription, true);
+    return GetSongsFullByWhere(strBaseDir, items, sortDescription, filter, true);
 
   return false;
 }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -5773,10 +5773,10 @@ bool CMusicDatabase::GetAlbumFromSong(int idSong, CAlbum& album)
 
 bool CMusicDatabase::GetAlbumsNav(const std::string& strBaseDir,
                                   CFileItemList& items,
+                                  const SortDescription& sortDescription,
                                   int idGenre /* = -1 */,
                                   int idArtist /* = -1 */,
                                   const Filter& filter /* = Filter() */,
-                                  const SortDescription& sortDescription /* = SortDescription() */,
                                   bool countOnly /* = false */)
 {
   CMusicDbUrl musicUrl;

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -658,7 +658,7 @@ public:
                              const std::string& baseDir,
                              CVariant& result,
                              int& total,
-                             const SortDescription& sortDescription = SortDescription());
+                             const SortDescription& sortDescription);
   bool GetAlbumsByWhereJSON(const std::set<std::string, std::less<>>& fields,
                             const std::string& baseDir,
                             CVariant& result,

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -611,9 +611,9 @@ public:
                    int idAlbum);
   bool GetSongsByYear(const std::string& baseDir, CFileItemList& items, int year);
   bool GetSongsFullByWhere(const std::string& baseDir,
-                           const Filter& filter,
                            CFileItemList& items,
-                           const SortDescription& sortDescription = SortDescription(),
+                           const SortDescription& sortDescription,
+                           const Filter& filter,
                            bool artistData = false);
   bool GetAlbumsByWhere(const std::string& baseDir,
                         const Filter& filter,

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -598,9 +598,9 @@ public:
                     bool countOnly = false);
   bool GetDiscsNav(const std::string& strBaseDir,
                    CFileItemList& items,
+                   const SortDescription& sortDescription,
                    int idAlbum,
                    const Filter& filter = Filter(),
-                   const SortDescription& sortDescription = SortDescription(),
                    bool countOnly = false);
   bool GetAlbumsByYear(const std::string& strBaseDir, CFileItemList& items, int year);
   bool GetSongsNav(const std::string& strBaseDir,

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -605,10 +605,10 @@ public:
   bool GetAlbumsByYear(const std::string& strBaseDir, CFileItemList& items, int year);
   bool GetSongsNav(const std::string& strBaseDir,
                    CFileItemList& items,
+                   const SortDescription& sortDescription,
                    int idGenre,
                    int idArtist,
-                   int idAlbum,
-                   const SortDescription& sortDescription = SortDescription());
+                   int idAlbum);
   bool GetSongsByYear(const std::string& baseDir, CFileItemList& items, int year);
   bool GetSongsFullByWhere(const std::string& baseDir,
                            const Filter& filter,

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -621,14 +621,14 @@ public:
                         const Filter& filter,
                         bool countOnly = false);
   bool GetDiscsByWhere(const std::string& baseDir,
-                       const Filter& filter,
                        CFileItemList& items,
-                       const SortDescription& sortDescription = SortDescription(),
+                       const SortDescription& sortDescription,
+                       const Filter& filter,
                        bool countOnly = false);
   bool GetDiscsByWhere(CMusicDbUrl& musicUrl,
-                       const Filter& filter,
                        CFileItemList& items,
-                       const SortDescription& sortDescription = SortDescription(),
+                       const SortDescription& sortDescription,
+                       const Filter& filter,
                        bool countOnly = false);
   bool GetArtistsByWhere(const std::string& strBaseDir,
                          const Filter& filter,

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -631,9 +631,9 @@ public:
                        const Filter& filter,
                        bool countOnly = false);
   bool GetArtistsByWhere(const std::string& strBaseDir,
-                         const Filter& filter,
                          CFileItemList& items,
-                         const SortDescription& sortDescription = SortDescription(),
+                         const SortDescription& sortDescription,
+                         const Filter& filter,
                          bool countOnly = false);
   int GetDiscsCount(const std::string& baseDir, const Filter& filter = Filter());
   int GetSongsCount(const Filter& filter = Filter());

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -688,13 +688,13 @@ public:
   /////////////////////////////////////////////////
   bool GetItems(const std::string& strBaseDir,
                 CFileItemList& items,
-                const Filter& filter = Filter(),
-                const SortDescription& sortDescription = SortDescription());
+                const SortDescription& sortDescription,
+                const Filter& filter = Filter());
   bool GetItems(const std::string& strBaseDir,
                 const std::string& itemType,
                 CFileItemList& items,
-                const Filter& filter = Filter(),
-                const SortDescription& sortDescription = SortDescription());
+                const SortDescription& sortDescription,
+                const Filter& filter = Filter());
   std::string GetItemById(const std::string& itemType, int id) const;
 
   /////////////////////////////////////////////////

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -668,7 +668,7 @@ public:
                            const std::string& baseDir,
                            CVariant& result,
                            int& total,
-                           const SortDescription& sortDescription = SortDescription());
+                           const SortDescription& sortDescription);
 
   /////////////////////////////////////////////////
   // Scraper

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -591,10 +591,10 @@ public:
                          bool countOnly = false);
   bool GetAlbumsNav(const std::string& strBaseDir,
                     CFileItemList& items,
+                    const SortDescription& sortDescription,
                     int idGenre = -1,
                     int idArtist = -1,
                     const Filter& filter = Filter(),
-                    const SortDescription& sortDescription = SortDescription(),
                     bool countOnly = false);
   bool GetDiscsNav(const std::string& strBaseDir,
                    CFileItemList& items,

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -568,12 +568,12 @@ public:
                    const Filter& filter = Filter());
   bool GetArtistsNav(const std::string& strBaseDir,
                      CFileItemList& items,
+                     const SortDescription& sortDescription,
                      bool albumArtistsOnly = false,
                      int idGenre = -1,
                      int idAlbum = -1,
                      int idSong = -1,
                      const Filter& filter = Filter(),
-                     const SortDescription& sortDescription = SortDescription(),
                      bool countOnly = false);
   bool GetCommonNav(const std::string& strBaseDir,
                     const std::string& table,

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -616,9 +616,9 @@ public:
                            const Filter& filter,
                            bool artistData = false);
   bool GetAlbumsByWhere(const std::string& baseDir,
-                        const Filter& filter,
                         CFileItemList& items,
-                        const SortDescription& sortDescription = SortDescription(),
+                        const SortDescription& sortDescription,
+                        const Filter& filter,
                         bool countOnly = false);
   bool GetDiscsByWhere(const std::string& baseDir,
                        const Filter& filter,

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -663,7 +663,7 @@ public:
                             const std::string& baseDir,
                             CVariant& result,
                             int& total,
-                            const SortDescription& sortDescription = SortDescription());
+                            const SortDescription& sortDescription);
   bool GetSongsByWhereJSON(const std::set<std::string, std::less<>>& fields,
                            const std::string& baseDir,
                            CVariant& result,

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -340,7 +340,7 @@ void CMusicInfoScanner::FetchAlbumInfo(const std::string& strDirectory,
   if (strDirectory.empty())
   {
     m_musicDatabase.Open();
-    m_musicDatabase.GetAlbumsNav("musicdb://albums/", items);
+    m_musicDatabase.GetAlbumsNav("musicdb://albums/", items, SortDescription());
     m_musicDatabase.Close();
   }
   else

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -402,7 +402,10 @@ void CMusicInfoScanner::FetchArtistInfo(const std::string& strDirectory,
   if (strDirectory.empty())
   {
     m_musicDatabase.Open();
-    m_musicDatabase.GetArtistsNav("musicdb://artists/", items, !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MUSICLIBRARY_SHOWCOMPILATIONARTISTS), -1);
+    const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+    m_musicDatabase.GetArtistsNav(
+        "musicdb://artists/", items, SortDescription(),
+        !settings->GetBool(CSettings::SETTING_MUSICLIBRARY_SHOWCOMPILATIONARTISTS), -1);
     m_musicDatabase.Close();
   }
   else

--- a/xbmc/utils/RecentlyAddedJob.cpp
+++ b/xbmc/utils/RecentlyAddedJob.cpp
@@ -341,7 +341,7 @@ bool CRecentlyAddedJob::UpdateTotal()
 
   CFileItemList items;
   CDatabase::Filter filter;
-  musicdatabase.GetArtistsByWhere(musicUrl.ToString(), filter, items, SortDescription(), true);
+  musicdatabase.GetArtistsByWhere(musicUrl.ToString(), items, SortDescription(), filter, true);
   int MusArtistTotals = 0;
   if (items.Size() == 1 && items.Get(0)->HasProperty("total"))
     MusArtistTotals = static_cast<int>(items.Get(0)->GetProperty("total").asInteger());


### PR DESCRIPTION
## Description
This is a necessary but not sufficient step in getting rid of SortUtils.h includes in a header. This is a stupidly hot header as is now, forcing almost a complete rebuild, and any such include that can be avoid should be avoided. By not specifying a default value, we do not need the definition of the struct in the header, at a cost of having to specify an additional parameter at a few call sites.

## Motivation and context
Enable reducing the dependency graph for SortUtils.h

## How has this been tested?
It builds

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
