### PR TITLE
SortOrder: convert to enum class

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -183,7 +183,7 @@ bool CAutorun::RunDisc(IDirectory* pDir,
   }
 
   // Sorting necessary for easier HDDVD handling
-  vecItems.Sort(SortByLabel, SortOrderAscending);
+  vecItems.Sort(SortByLabel, SortOrder::ASCENDING);
 
   bool bAllowVideo = true;
 //  bool bAllowPictures = true;
@@ -290,7 +290,7 @@ bool CAutorun::RunDisc(IDirectory* pDir,
           {
             // HD DVD Standard says the highest numbered playlist has to be handled first.
             CLog::Log(LOGINFO,"HD DVD: Playlist found. Set filetypes to *.xpl for external player.");
-            items.Sort(SortByLabel, SortOrderDescending);
+            items.Sort(SortByLabel, SortOrder::DESCENDING);
             phddvdItem = pItem;
             hddvdname = URIUtils::GetFileName(items[0]->GetPath());
             CLog::Log(LOGINFO, "HD DVD: {}", items[0]->GetPath());
@@ -310,7 +310,7 @@ bool CAutorun::RunDisc(IDirectory* pDir,
             {
               // HD DVD Standard says the lowest numbered ifo has to be handled first.
               CLog::Log(LOGINFO,"HD DVD: IFO found. Set filename to HV* and filetypes to *.ifo for external player.");
-              items.Sort(SortByLabel, SortOrderAscending);
+              items.Sort(SortByLabel, SortOrder::ASCENDING);
               phddvdItem = pItem;
               hddvdname = URIUtils::GetFileName(items[0]->GetPath());
               CLog::Log(LOGINFO, "HD DVD: {}", items[0]->GetPath());
@@ -323,7 +323,7 @@ bool CAutorun::RunDisc(IDirectory* pDir,
           if (items.Size())
           {
             // Sort *.evo files in alphabetical order.
-            items.Sort(SortByLabel, SortOrderAscending);
+            items.Sort(SortByLabel, SortOrder::ASCENDING);
             int64_t asize = 0;
             int ecount = 0;
             // calculate average size of elements above 1gb
@@ -345,7 +345,7 @@ bool CAutorun::RunDisc(IDirectory* pDir,
                 sitems.Add (items[j]);
             }
             // Sort *.evo files by size.
-            items.Sort(SortBySize, SortOrderDescending);
+            items.Sort(SortBySize, SortOrder::DESCENDING);
             // Add other files with descending size to bottom of new list.
             for (int j = 0; j < items.Size(); j++)
             {
@@ -406,7 +406,7 @@ bool CAutorun::RunDisc(IDirectory* pDir,
           CDirectory::GetDirectory(pItem->GetPath(), items, strExt, DIR_FLAG_DEFAULTS);
           if (items.Size())
           {
-            items.Sort(SortByLabel, SortOrderAscending);
+            items.Sort(SortByLabel, SortOrder::ASCENDING);
             CServiceBroker::GetPlaylistPlayer().ClearPlaylist(PLAYLIST::Id::TYPE_VIDEO);
             CServiceBroker::GetPlaylistPlayer().Add(PLAYLIST::Id::TYPE_VIDEO, items);
             CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST::Id::TYPE_VIDEO);

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -107,7 +107,7 @@ void CFileItemList::Clear()
 
   ClearItems();
   m_sortDescription.sortBy = SortByNone;
-  m_sortDescription.sortOrder = SortOrderNone;
+  m_sortDescription.sortOrder = SortOrder::NONE;
   m_sortDescription.sortAttributes = SortAttributeNone;
   m_sortIgnoreFolders = false;
   m_cacheToDisc = CacheType::IF_SLOW;
@@ -698,7 +698,7 @@ void CFileItemList::Stack()
   SetProperty("isstacked", true);
 
   // items needs to be sorted for stuff below to work properly
-  Sort(SortByLabel, SortOrderAscending);
+  Sort(SortByLabel, SortOrder::ASCENDING);
 
   // Convert folder paths containing disc images to files (INDEX.BDMV or VIDEO_TS.IFO)
   ConvertDiscFoldersToFiles(m_items);
@@ -875,7 +875,7 @@ bool CFileItemList::Load(int windowID)
       ar >> *this;
       CLog::Log(LOGDEBUG, "Loading items: {}, directory: {} sort method: {}, ascending: {}", Size(),
                 CURL::GetRedacted(GetPath()), m_sortDescription.sortBy,
-                m_sortDescription.sortOrder == SortOrderAscending ? "true" : "false");
+                m_sortDescription.sortOrder == SortOrder::ASCENDING ? "true" : "false");
       ar.Close();
       file.Close();
       return true;
@@ -913,7 +913,7 @@ bool CFileItemList::Save(int windowID)
     ar << *this;
     CLog::Log(LOGDEBUG, "  -- items: {}, sort method: {}, ascending: {}", iSize,
               m_sortDescription.sortBy,
-              m_sortDescription.sortOrder == SortOrderAscending ? "true" : "false");
+              m_sortDescription.sortOrder == SortOrder::ASCENDING ? "true" : "false");
     ar.Close();
     file.Close();
     return true;
@@ -1039,6 +1039,6 @@ void CFileItemList::SetReplaceListing(bool replace)
 void CFileItemList::ClearSortState()
 {
   m_sortDescription.sortBy = SortByNone;
-  m_sortDescription.sortOrder = SortOrderNone;
+  m_sortDescription.sortOrder = SortOrder::NONE;
   m_sortDescription.sortAttributes = SortAttributeNone;
 }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -11000,12 +11000,12 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
       }
       if (prop.Name() == "sortdirection")
       {
-        SortOrder order = SortOrderNone;
+        SortOrder order = SortOrder::NONE;
         if (StringUtils::EqualsNoCase(prop.param(), "ascending"))
-          order = SortOrderAscending;
+          order = SortOrder::ASCENDING;
         else if (StringUtils::EqualsNoCase(prop.param(), "descending"))
-          order = SortOrderDescending;
-        return AddMultiInfo(CGUIInfo(CONTAINER_SORT_DIRECTION, order));
+          order = SortOrder::DESCENDING;
+        return AddMultiInfo(CGUIInfo(CONTAINER_SORT_DIRECTION, static_cast<int>(order)));
       }
     }
     else if (cat.Name() == "listitem" || cat.Name() == "listitemposition" ||

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -186,12 +186,12 @@ void PrunePackageCache()
   db.Open();
   for (const auto& [_, files] : packs)
   {
-    files->Sort(SortByLabel, SortOrderDescending);
+    files->Sort(SortByLabel, SortOrder::DESCENDING);
     for (int j = 2; j < files->Size(); j++)
       items.Add(std::make_shared<CFileItem>(*files->Get(j)));
   }
 
-  items.Sort(SortBySize, SortOrderDescending);
+  items.Sort(SortBySize, SortOrder::DESCENDING);
   int i = 0;
   while (size > limit && i < items.Size())
   {
@@ -211,7 +211,7 @@ void PrunePackageCache()
         items.Add(std::make_shared<CFileItem>(*files->Get(1)));
     }
 
-    items.Sort(SortByDate, SortOrderAscending);
+    items.Sort(SortByDate, SortOrder::ASCENDING);
     i = 0;
     while (size > limit && i < items.Size())
     {

--- a/xbmc/addons/gui/GUIViewStateAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIViewStateAddonBrowser.cpp
@@ -31,7 +31,7 @@ CGUIViewStateAddonBrowser::CGUIViewStateAddonBrowser(const CFileItemList& items)
   else if (URIUtils::PathEquals(items.GetPath(), "addons://recently_updated/", true))
   {
     AddSortMethod(SortByLastUpdated, 12014, LABEL_MASKS("%L", "%v", "%L", "%v"),
-                  SortAttributeIgnoreFolders, SortOrderDescending);
+                  SortAttributeIgnoreFolders, SortOrder::DESCENDING);
   }
   else
   {
@@ -40,12 +40,12 @@ CGUIViewStateAddonBrowser::CGUIViewStateAddonBrowser(const CFileItemList& items)
 
     if (StringUtils::StartsWith(items.GetPath(), "addons://sources/"))
       AddSortMethod(SortByLastUsed, 12012, LABEL_MASKS("%L", "%u", "%L", "%u"),
-                    SortAttributeIgnoreFolders, SortOrderDescending); //Label, Last used
+                    SortAttributeIgnoreFolders, SortOrder::DESCENDING); //Label, Last used
 
     if (StringUtils::StartsWith(items.GetPath(), "addons://user/") &&
         items.GetContent() == "addons")
       AddSortMethod(SortByInstallDate, 12013, LABEL_MASKS("%L", "%i", "%L", "%i"),
-                    SortAttributeIgnoreFolders, SortOrderDescending);
+                    SortAttributeIgnoreFolders, SortOrder::DESCENDING);
 
     SetSortMethod(SortByLabel);
   }

--- a/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
+++ b/xbmc/addons/gui/GUIWindowAddonBrowser.cpp
@@ -579,7 +579,7 @@ int CGUIWindowAddonBrowser::SelectAddonID(const std::vector<AddonType>& types,
     item->SetSpecialSort(SortSpecialOnTop);
     items.Add(std::move(item));
   }
-  items.Sort(SortByLabel, SortOrderAscending);
+  items.Sort(SortByLabel, SortOrder::ASCENDING);
 
   if (!addonIDs.empty())
   {

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -334,7 +334,7 @@ void CGUIDialogFileBrowser::ClearFileItems()
 void CGUIDialogFileBrowser::OnSort()
 {
   if (!m_singleList)
-    m_vecItems->Sort(SortByLabel, SortOrderAscending);
+    m_vecItems->Sort(SortByLabel, SortOrder::ASCENDING);
 }
 
 void CGUIDialogFileBrowser::Update(const std::string &strDirectory)

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -740,7 +740,7 @@ int CGUIDialogMediaFilter::GetItems(const Filter &filter, std::vector<std::strin
   }
 
   // sort the items
-  selectItems.Sort(SortByLabel, SortOrderAscending);
+  selectItems.Sort(SortByLabel, SortOrder::ASCENDING);
 
   for (int index = 0; index < size; ++index)
     items.push_back(selectItems.Get(index)->GetLabel());

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -265,7 +265,7 @@ bool CGUIDialogSelect::IsButton2Pressed()
 
 void CGUIDialogSelect::Sort(bool bSortOrder /*=true*/)
 {
-  m_vecList->Sort(SortByLabel, bSortOrder ? SortOrderAscending : SortOrderDescending);
+  m_vecList->Sort(SortByLabel, bSortOrder ? SortOrder::ASCENDING : SortOrder::DESCENDING);
 }
 
 void CGUIDialogSelect::SetSelected(int iSelected)

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -368,10 +368,10 @@ void CGUIDialogSmartPlaylistEditor::OnOrder()
 
 void CGUIDialogSmartPlaylistEditor::OnOrderDirection()
 {
-  if (m_playlist.m_orderDirection == SortOrderDescending)
-    m_playlist.m_orderDirection = SortOrderAscending;
+  if (m_playlist.m_orderDirection == SortOrder::DESCENDING)
+    m_playlist.m_orderDirection = SortOrder::ASCENDING;
   else
-    m_playlist.m_orderDirection = SortOrderDescending;
+    m_playlist.m_orderDirection = SortOrder::DESCENDING;
   UpdateButtons();
 }
 
@@ -455,7 +455,7 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
   OnMessage(msg);
   SendMessage(GUI_MSG_ITEM_SELECT, GetID(), CONTROL_RULE_LIST, currentItem);
 
-  if (m_playlist.m_orderDirection != SortOrderDescending)
+  if (m_playlist.m_orderDirection != SortOrder::DESCENDING)
   {
     SET_CONTROL_LABEL2(CONTROL_ORDER_DIRECTION,
                        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21430));

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -362,7 +362,11 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   }
 
   // sort the items
-  items.Sort(SortByLabel, SortOrderAscending, CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
+  items.Sort(SortByLabel, SortOrder::ASCENDING,
+             CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                 CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
+                 ? SortAttributeIgnoreArticle
+                 : SortAttributeNone);
 
   CGUIDialogSelect* pDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
   pDialog->Reset();

--- a/xbmc/events/windows/GUIViewStateEventLog.cpp
+++ b/xbmc/events/windows/GUIViewStateEventLog.cpp
@@ -21,7 +21,7 @@ CGUIViewStateEventLog::CGUIViewStateEventLog(const CFileItemList& items) : CGUIV
   SetSortMethod(SortByDate);
   SetViewAsControl(DEFAULT_VIEW_AUTO);
 
-  SetSortOrder(SortOrderDescending);
+  SetSortOrder(SortOrder::DESCENDING);
   LoadViewState(items.GetPath(), WINDOW_EVENT_LOG);
 }
 

--- a/xbmc/filesystem/LibraryDirectory.cpp
+++ b/xbmc/filesystem/LibraryDirectory.cpp
@@ -131,7 +131,7 @@ bool CLibraryDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       items.Add(item);
     }
   }
-  items.Sort(SortByPlaylistOrder, SortOrderAscending);
+  items.Sort(SortByPlaylistOrder, SortOrder::ASCENDING);
   return true;
 }
 

--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -242,7 +242,7 @@ void CMultiPathDirectory::MergeItems(CFileItemList &items)
     return;
   // sort items by label
   // folders are before files in this sort method
-  items.Sort(SortByLabel, SortOrderAscending);
+  items.Sort(SortByLabel, SortOrder::ASCENDING);
   int i = 0;
 
   // if first item in the sorted list is a file, just abort

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -67,7 +67,7 @@ namespace XFILE
     if (playlist.GetLimit() > 0)
       sorting.limitEnd = playlist.GetLimit();
     sorting.sortBy = playlist.GetOrder();
-    sorting.sortOrder = playlist.GetOrderAscending() ? SortOrderAscending : SortOrderDescending;
+    sorting.sortOrder = playlist.GetOrderAscending() ? SortOrder::ASCENDING : SortOrder::DESCENDING;
     sorting.sortAttributes = playlist.GetOrderAttributes();
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
       sorting.sortAttributes = (SortAttribute)(sorting.sortAttributes | SortAttributeIgnoreArticle);
@@ -290,7 +290,8 @@ namespace XFILE
       items.SetContent(playlist.GetType());
 
     items.SetProperty(PROPERTY_SORT_ORDER, (int)playlist.GetOrder());
-    items.SetProperty(PROPERTY_SORT_ASCENDING, playlist.GetOrderDirection() == SortOrderAscending);
+    items.SetProperty(PROPERTY_SORT_ASCENDING,
+                      playlist.GetOrderDirection() == SortOrder::ASCENDING);
     if (!group.empty())
     {
       items.SetProperty(PROPERTY_GROUP_BY, group);
@@ -302,13 +303,13 @@ namespace XFILE
     {
       if (playlist.GetOrder() == SortByRandom && group == "actors" &&
           playlist.GetType() == "musicvideos")
-        items.Sort(SortByRandom, SortOrderAscending,
+        items.Sort(SortByRandom, SortOrder::ASCENDING,
                    CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
                        CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
                        ? SortAttributeIgnoreArticle
                        : SortAttributeNone);
       else
-        items.Sort(SortByLabel, SortOrderAscending,
+        items.Sort(SortByLabel, SortOrder::ASCENDING,
                    CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
                        CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
                        ? SortAttributeIgnoreArticle

--- a/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
+++ b/xbmc/games/dialogs/GUIDialogSelectGameClient.cpp
@@ -56,8 +56,8 @@ std::string CGUIDialogSelectGameClient::ShowAndGetGameClient(const std::string& 
       CFileItemPtr item(XFILE::CAddonsDirectory::FileItemFromAddon(addon, addon->ID()));
       installableItems.Add(std::move(item));
     }
-    items.Sort(SortByLabel, SortOrderAscending);
-    installableItems.Sort(SortByLabel, SortOrderAscending);
+    items.Sort(SortByLabel, SortOrder::ASCENDING);
+    installableItems.Sort(SortByLabel, SortOrder::ASCENDING);
 
     items.Append(installableItems);
 

--- a/xbmc/games/dialogs/osd/DialogGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameSaves.cpp
@@ -334,7 +334,7 @@ bool CDialogGameSaves::Open(const std::string& gamePath)
   if (items.IsEmpty())
     return false;
 
-  items.Sort(SortByDate, SortOrderDescending);
+  items.Sort(SortByDate, SortOrder::DESCENDING);
 
   SetItems(items);
 

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -110,7 +110,7 @@ void CDialogInGameSaves::InitSavedGames()
   db.GetSavestatesNav(m_savestateItems, gameSettings->GetPlayingGame(),
                       gameSettings->GameClientID());
 
-  m_savestateItems.Sort(SortByDate, SortOrderDescending);
+  m_savestateItems.Sort(SortByDate, SortOrder::DESCENDING);
 }
 
 void CDialogInGameSaves::GetItems(CFileItemList& items)

--- a/xbmc/games/windows/GUIViewStateWindowGames.cpp
+++ b/xbmc/games/windows/GUIViewStateWindowGames.cpp
@@ -32,7 +32,7 @@ CGUIViewStateWindowGames::CGUIViewStateWindowGames(const CFileItemList& items)
     AddSortMethod(SortByLabel, 551, LABEL_MASKS());
     AddSortMethod(SortByDriveType, 564, LABEL_MASKS());
     SetSortMethod(SortByLabel);
-    SetSortOrder(SortOrderAscending);
+    SetSortOrder(SortOrder::ASCENDING);
     SetViewAsControl(DEFAULT_VIEW_LIST);
   }
   else

--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -515,7 +515,7 @@ void CDirectoryProvider::Reset()
     m_currentUrl.clear();
     m_itemTypes.clear();
     m_currentSort.sortBy = SortByNone;
-    m_currentSort.sortOrder = SortOrderAscending;
+    m_currentSort.sortOrder = SortOrder::ASCENDING;
     m_currentLimit = 0;
     m_currentBrowse = BrowseMode::AUTO;
     m_updateState = UpdateState::OK;
@@ -791,8 +791,8 @@ bool CDirectoryProvider::UpdateSort()
   std::unique_lock lock(m_section);
   SortBy sortMethod(SortUtils::SortMethodFromString(m_sortMethod.GetLabel(GetParentId(), false)));
   SortOrder sortOrder(SortUtils::SortOrderFromString(m_sortOrder.GetLabel(GetParentId(), false)));
-  if (sortOrder == SortOrderNone)
-    sortOrder = SortOrderAscending;
+  if (sortOrder == SortOrder::NONE)
+    sortOrder = SortOrder::ASCENDING;
 
   if (sortMethod == m_currentSort.sortBy && sortOrder == m_currentSort.sortOrder)
     return false;

--- a/xbmc/input/keymaps/ButtonTranslator.cpp
+++ b/xbmc/input/keymaps/ButtonTranslator.cpp
@@ -86,7 +86,7 @@ bool CButtonTranslator::Load()
       CFileItemList files;
       XFILE::CDirectory::GetDirectory(dir, files, ".xml", XFILE::DIR_FLAG_DEFAULTS);
       // Sort the list for filesystem based priorities, e.g. 01-keymap.xml, 02-keymap-overrides.xml
-      files.Sort(SortByFile, SortOrderAscending);
+      files.Sort(SortByFile, SortOrder::ASCENDING);
       for (int fileIndex = 0; fileIndex < files.Size(); ++fileIndex)
       {
         if (!files[fileIndex]->IsFolder())
@@ -105,7 +105,7 @@ bool CButtonTranslator::Load()
           XFILE::CDirectory::GetDirectory(devicedir, files, ".xml", XFILE::DIR_FLAG_DEFAULTS);
           // Sort the list for filesystem based priorities, e.g. 01-keymap.xml,
           // 02-keymap-overrides.xml
-          files.Sort(SortByFile, SortOrderAscending);
+          files.Sort(SortByFile, SortOrder::ASCENDING);
           for (int fileIndex = 0; fileIndex < files.Size(); ++fileIndex)
           {
             if (!files[fileIndex]->IsFolder())

--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -1165,15 +1165,22 @@ bool CAudioLibrary::FillFileItemList(const CVariant &parameterObject, CFileItemL
     // If we retrieved the list of songs by "artistid"
     // we sort by album (and implicitly by track number)
     if (artistID != -1)
-      list.Sort(SortByAlbum, SortOrderAscending, CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
+      list.Sort(SortByAlbum, SortOrder::ASCENDING,
+                CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                    CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
+                    ? SortAttributeIgnoreArticle
+                    : SortAttributeNone);
     // If we retrieve the list of songs by "genreid"
     // we sort by artist (and implicitly by album and track number)
     else if (genreID != -1)
-      list.Sort(SortByArtist, SortOrderAscending, CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
+      list.Sort(SortByArtist, SortOrder::ASCENDING,
+                CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                    CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
+                    ? SortAttributeIgnoreArticle
+                    : SortAttributeNone);
     // otherwise we sort by track number
     else
-      list.Sort(SortByTrackNumber, SortOrderAscending);
-
+      list.Sort(SortByTrackNumber, SortOrder::ASCENDING);
   }
 
   return success;

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -383,7 +383,7 @@ bool CFileOperations::FillFileItemList(const CVariant &parameterObject, CFileIte
         // but leave items from a playlist, smartplaylist or upnp container in order supplied
         if (!PLAYLIST::IsPlayList(items) && !PLAYLIST::IsSmartPlayList(items) &&
             !URIUtils::IsUPnP(items.GetPath()))
-          items.Sort(SortByFile, SortOrderAscending);
+          items.Sort(SortByFile, SortOrder::ASCENDING);
 
         CFileItemList filteredDirectories;
         for (unsigned int i = 0; i < (unsigned int)items.Size(); i++)

--- a/xbmc/interfaces/json-rpc/JSONUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONUtils.h
@@ -95,7 +95,7 @@ namespace JSONRPC
 
       // parse the sort order
       sortOrder = SortUtils::SortOrderFromString(order);
-      if (sortOrder == SortOrderNone)
+      if (sortOrder == SortOrder::NONE)
         return false;
 
       // parse the sort method

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -109,7 +109,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
 
       SetViewAsControl(DEFAULT_VIEW_LIST);
 
-      SetSortOrder(SortOrderNone);
+      SetSortOrder(SortOrder::NONE);
     }
     break;
     case NodeType::TOP100:
@@ -119,7 +119,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
 
       SetViewAsControl(DEFAULT_VIEW_LIST);
 
-      SetSortOrder(SortOrderNone);
+      SetSortOrder(SortOrder::NONE);
     }
     break;
     case NodeType::GENRE:
@@ -129,7 +129,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
 
       SetViewAsControl(DEFAULT_VIEW_LIST);
 
-      SetSortOrder(SortOrderAscending);
+      SetSortOrder(SortOrder::ASCENDING);
     }
     break;
     case NodeType::ROLE:
@@ -140,7 +140,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
 
       SetViewAsControl(DEFAULT_VIEW_LIST);
 
-      SetSortOrder(SortOrderNone);
+      SetSortOrder(SortOrder::NONE);
     }
     break;
     case NodeType::YEAR:
@@ -151,7 +151,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
 
       SetViewAsControl(DEFAULT_VIEW_LIST);
 
-      SetSortOrder(SortOrderAscending);
+      SetSortOrder(SortOrder::ASCENDING);
     }
     break;
     case NodeType::ARTIST:
@@ -209,7 +209,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
 
       SetViewAsControl(CViewStateSettings::GetInstance().Get("musicnavalbums")->m_viewMode);
 
-      SetSortOrder(SortOrderNone);
+      SetSortOrder(SortOrder::NONE);
     }
     break;
     case NodeType::ALBUM_RECENTLY_ADDED_SONGS:
@@ -219,7 +219,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
 
       SetViewAsControl(CViewStateSettings::GetInstance().Get("musicnavsongs")->m_viewMode);
 
-      SetSortOrder(SortOrderNone);
+      SetSortOrder(SortOrder::NONE);
     }
     break;
     case NodeType::ALBUM_RECENTLY_PLAYED:
@@ -242,7 +242,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
       SetSortMethod(SortByNone);
 
       SetViewAsControl(DEFAULT_VIEW_LIST);
-      SetSortOrder(SortOrderNone);
+      SetSortOrder(SortOrder::NONE);
     }
     break;
     case NodeType::SINGLES:
@@ -313,7 +313,7 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
 
       SetViewAsControl(CViewStateSettings::GetInstance().Get("musicnavsongs")->m_viewMode);
 
-      SetSortOrder(SortOrderNone);
+      SetSortOrder(SortOrder::NONE);
     }
     break;
     case NodeType::DISC:
@@ -500,7 +500,7 @@ CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& it
 
     SetViewAsControl(DEFAULT_VIEW_LIST);
 
-    SetSortOrder(SortOrderNone);
+    SetSortOrder(SortOrder::NONE);
   }
   else if (items.GetPath() == "special://musicplaylists/")
   { // playlists list sorts by label only, ignoring folders
@@ -559,7 +559,7 @@ CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& it
     SetViewAsControl(viewState->m_viewMode);
     SetSortOrder(viewState->m_sortDescription.sortOrder);
 
-    SetSortOrder(SortOrderAscending);
+    SetSortOrder(SortOrder::ASCENDING);
   }
   LoadViewState(items.GetPath(), WINDOW_MUSIC_NAV);
 }
@@ -617,7 +617,7 @@ CGUIViewStateWindowMusicPlaylist::CGUIViewStateWindowMusicPlaylist(const CFileIt
 
   SetViewAsControl(DEFAULT_VIEW_LIST);
 
-  SetSortOrder(SortOrderNone);
+  SetSortOrder(SortOrder::NONE);
 
   LoadViewState(items.GetPath(), WINDOW_MUSIC_PLAYLIST);
 }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -8388,7 +8388,7 @@ std::string CMusicDatabase::AlphanumericSortSQL(const std::string& strField,
   stored in the db.
   */
   std::string DESC;
-  if (sortOrder == SortOrderDescending)
+  if (sortOrder == SortOrder::DESCENDING)
     DESC = " DESC";
   std::string strSort;
 
@@ -13161,7 +13161,7 @@ int CMusicDatabase::GetOrderFilter(const std::string& type,
   std::vector<std::string> orderfields;
   std::string DESC;
 
-  if (sorting.sortOrder == SortOrderDescending)
+  if (sorting.sortOrder == SortOrder::DESCENDING)
     DESC = " DESC";
 
   if (sorting.sortBy == SortByRandom)
@@ -13266,7 +13266,7 @@ bool CMusicDatabase::GetFilter(CDbUrl& musicUrl, Filter& filter, SortDescription
         sorting.limitEnd = xsp.GetLimit();
       if (xsp.GetOrder() != SortByNone)
         sorting.sortBy = xsp.GetOrder();
-      sorting.sortOrder = xsp.GetOrderAscending() ? SortOrderAscending : SortOrderDescending;
+      sorting.sortOrder = xsp.GetOrderAscending() ? SortOrder::ASCENDING : SortOrder::DESCENDING;
       if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
               CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
         sorting.sortAttributes = SortAttributeIgnoreArticle;

--- a/xbmc/music/MusicUtils.cpp
+++ b/xbmc/music/MusicUtils.cpp
@@ -476,7 +476,7 @@ SortDescription GetSortDescription(const CGUIViewState& state, const CFileItemLi
         {
           // First choice for folders containing a single album
           sortDescTrackNumber = sortDescription;
-          sortDescTrackNumber.sortOrder = SortOrderAscending;
+          sortDescTrackNumber.sortOrder = SortOrder::ASCENDING;
           break; // leave items loop. we can still find ByArtistThenYear. so, no return here.
         }
       }
@@ -493,7 +493,7 @@ SortDescription GetSortDescription(const CGUIViewState& state, const CFileItemLi
           if (lastAlbumId != -1 && tag->GetAlbumId() != lastAlbumId)
           {
             // First choice for folders containing multiple albums
-            sortDescription.sortOrder = SortOrderAscending;
+            sortDescription.sortOrder = SortOrder::ASCENDING;
             return sortDescription;
           }
           lastAlbumId = tag->GetAlbumId();

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -510,7 +510,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
   // sort and get the path hash.  Note that we don't filter .cue sheet items here as we want
   // to detect changes in the .cue sheet as well.  The .cue sheet items only need filtering
   // if we have a changed hash.
-  items.Sort(SortByLabel, SortOrderAscending);
+  items.Sort(SortByLabel, SortOrder::ASCENDING);
   std::string hash;
   GetPathHash(items, hash);
 
@@ -531,7 +531,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
 
     // filter items in the sub dir (for .cue sheet support)
     items.FilterCueItems();
-    items.Sort(SortByLabel, SortOrderAscending);
+    items.Sort(SortByLabel, SortOrder::ASCENDING);
 
     // and then scan in the new information from tags
     if (RetrieveMusicInfo(strDirectory, items) > 0)

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -824,7 +824,7 @@ NPT_Result CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference& action,
       item->SetLabelPreformatted(true);
       items.Add(item);
 
-      items.Sort(SortByLabel, SortOrderAscending);
+      items.Sort(SortByLabel, SortOrder::ASCENDING);
     }
     else
     {

--- a/xbmc/pictures/GUIViewStatePictures.cpp
+++ b/xbmc/pictures/GUIViewStatePictures.cpp
@@ -33,7 +33,7 @@ CGUIViewStateWindowPictures::CGUIViewStateWindowPictures(const CFileItemList& it
 
     SetViewAsControl(DEFAULT_VIEW_LIST);
 
-    SetSortOrder(SortOrderAscending);
+    SetSortOrder(SortOrder::ASCENDING);
   }
   else
   {

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -1320,12 +1320,16 @@ void CGUIWindowSlideShow::AddFromPath(const std::string &strPath,
   }
 }
 
-void CGUIWindowSlideShow::RunSlideShow(const std::string &strPath,
-                                       bool bRecursive /* = false */, bool bRandom /* = false */,
-                                       bool bNotRandom /* = false */, const std::string &beginSlidePath /* = "" */,
-                                       bool startSlideShow /* = true */, SortBy method /* = SortByLabel */,
-                                       SortOrder order /* = SortOrderAscending */, SortAttribute sortAttributes /* = SortAttributeNone */,
-                                       const std::string &strExtensions)
+void CGUIWindowSlideShow::RunSlideShow(const std::string& strPath,
+                                       bool bRecursive /* = false */,
+                                       bool bRandom /* = false */,
+                                       bool bNotRandom /* = false */,
+                                       const std::string& beginSlidePath /* = "" */,
+                                       bool startSlideShow /* = true */,
+                                       SortBy method /* = SortByLabel */,
+                                       SortOrder order /* = SortOrder::ASCENDING */,
+                                       SortAttribute sortAttributes /* = SortAttributeNone */,
+                                       const std::string& strExtensions)
 {
   // stop any video
   const auto& components = CServiceBroker::GetAppComponents();

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -78,13 +78,13 @@ public:
                     const std::string& beginSlidePath = "",
                     bool startSlideShow = true,
                     SortBy method = SortByLabel,
-                    SortOrder order = SortOrderAscending,
+                    SortOrder order = SortOrder::ASCENDING,
                     SortAttribute sortAttributes = SortAttributeNone,
                     const std::string& strExtensions = "") override;
   void AddFromPath(const std::string& strPath,
                    bool bRecursive,
                    SortBy method = SortByLabel,
-                   SortOrder order = SortOrderAscending,
+                   SortOrder order = SortOrder::ASCENDING,
                    SortAttribute sortAttributes = SortAttributeNone,
                    const std::string& strExtensions = "") override;
   void Shuffle() override;
@@ -118,9 +118,10 @@ private:
   void SetDirection(int direction); // -1: rewind, 1: forward
 
   typedef std::set<std::string> path_set;  // set to track which paths we're adding
-  void AddItems(const std::string &strPath, path_set *recursivePaths,
+  void AddItems(const std::string& strPath,
+                path_set* recursivePaths,
                 SortBy method = SortByLabel,
-                SortOrder order = SortOrderAscending,
+                SortOrder order = SortOrder::ASCENDING,
                 SortAttribute sortAttributes = SortAttributeNone);
   bool PlayVideo();
   CSlideShowPic::DISPLAY_EFFECT GetDisplayEffect(int iSlideNumber) const;

--- a/xbmc/pictures/PictureThumbLoader.cpp
+++ b/xbmc/pictures/PictureThumbLoader.cpp
@@ -201,7 +201,7 @@ void CPictureThumbLoader::ProcessFoldersAndArchives(CFileItem *pItem)
 
       if (items.Size() < 4 || pItem->IsCBR() || pItem->IsCBZ())
       { // less than 4 items, so just grab the first thumb
-        items.Sort(SortByLabel, SortOrderAscending);
+        items.Sort(SortByLabel, SortOrder::ASCENDING);
         std::string thumb = IMAGE_FILES::URLFromFile(items[0]->GetPath());
         db.SetTextureForPath(pItem->GetPath(), "thumb", thumb);
         CServiceBroker::GetTextureCache()->BackgroundCacheImage(thumb);

--- a/xbmc/pictures/SlideShowDelegator.h
+++ b/xbmc/pictures/SlideShowDelegator.h
@@ -46,13 +46,13 @@ public:
                     const std::string& beginSlidePath = "",
                     bool startSlideShow = true,
                     SortBy method = SortByLabel,
-                    SortOrder order = SortOrderAscending,
+                    SortOrder order = SortOrder::ASCENDING,
                     SortAttribute sortAttributes = SortAttributeNone,
                     const std::string& strExtensions = "") override;
   void AddFromPath(const std::string& strPath,
                    bool bRecursive,
                    SortBy method = SortByLabel,
-                   SortOrder order = SortOrderAscending,
+                   SortOrder order = SortOrder::ASCENDING,
                    SortAttribute sortAttributes = SortAttributeNone,
                    const std::string& strExtensions = "") override;
 

--- a/xbmc/pictures/interfaces/ISlideShowDelegate.h
+++ b/xbmc/pictures/interfaces/ISlideShowDelegate.h
@@ -44,14 +44,14 @@ public:
                             const std::string& beginSlidePath = "",
                             bool startSlideShow = true,
                             SortBy method = SortByLabel,
-                            SortOrder order = SortOrderAscending,
+                            SortOrder order = SortOrder::ASCENDING,
                             SortAttribute sortAttributes = SortAttributeNone,
                             const std::string& strExtensions = "") = 0;
   //! @todo - refactor to use an options struct. Methods with so many arguments are a sign of a bad design...
   virtual void AddFromPath(const std::string& strPath,
                            bool bRecursive,
                            SortBy method = SortByLabel,
-                           SortOrder order = SortOrderAscending,
+                           SortOrder order = SortOrder::ASCENDING,
                            SortAttribute sortAttributes = SortAttributeNone,
                            const std::string& strExtensions = "") = 0;
 };

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1423,7 +1423,9 @@ bool CSmartPlaylist::Load(const CVariant &obj)
   {
     const CVariant &order = obj["order"];
     if (order.isMember("direction") && order["direction"].isString())
-      m_orderDirection = StringUtils::EqualsNoCase(order["direction"].asString(), "ascending") ? SortOrderAscending : SortOrderDescending;
+      m_orderDirection = StringUtils::EqualsNoCase(order["direction"].asString(), "ascending")
+                             ? SortOrder::ASCENDING
+                             : SortOrder::DESCENDING;
 
     if (order.isMember("ignorefolders") && obj["ignorefolders"].isBoolean())
       m_orderAttributes = obj["ignorefolders"].asBoolean() ? SortAttributeIgnoreFolders : SortAttributeNone;
@@ -1480,7 +1482,8 @@ bool CSmartPlaylist::LoadFromXML(const TiXmlNode *root, const std::string &encod
   {
     const char *direction = order->Attribute("direction");
     if (direction)
-      m_orderDirection = StringUtils::EqualsNoCase(direction, "ascending") ? SortOrderAscending : SortOrderDescending;
+      m_orderDirection = StringUtils::EqualsNoCase(direction, "ascending") ? SortOrder::ASCENDING
+                                                                           : SortOrder::DESCENDING;
 
     const char *ignorefolders = order->Attribute("ignorefolders");
     if (ignorefolders != NULL)
@@ -1547,7 +1550,8 @@ bool CSmartPlaylist::Save(const std::string &path) const
   {
     TiXmlText order(CSmartPlaylistRule::TranslateOrder(m_orderField).c_str());
     TiXmlElement nodeOrder("order");
-    nodeOrder.SetAttribute("direction", m_orderDirection == SortOrderDescending ? "descending" : "ascending");
+    nodeOrder.SetAttribute("direction",
+                           m_orderDirection == SortOrder::DESCENDING ? "descending" : "ascending");
     if (m_orderAttributes & SortAttributeIgnoreFolders)
       nodeOrder.SetAttribute("ignorefolders", "true");
     nodeOrder.InsertEndChild(order);
@@ -1586,7 +1590,8 @@ bool CSmartPlaylist::Save(CVariant &obj, bool full /* = true */) const
   {
     obj["order"] = CVariant(CVariant::VariantTypeObject);
     obj["order"]["method"] = CSmartPlaylistRule::TranslateOrder(m_orderField);
-    obj["order"]["direction"] = m_orderDirection == SortOrderDescending ? "descending" : "ascending";
+    obj["order"]["direction"] =
+        m_orderDirection == SortOrder::DESCENDING ? "descending" : "ascending";
     obj["order"]["ignorefolders"] = (m_orderAttributes & SortAttributeIgnoreFolders);
   }
 
@@ -1607,7 +1612,7 @@ void CSmartPlaylist::Reset()
   m_ruleCombination.clear();
   m_limit = 0;
   m_orderField = SortByNone;
-  m_orderDirection = SortOrderNone;
+  m_orderDirection = SortOrder::NONE;
   m_orderAttributes = SortAttributeNone;
   m_playlistType = "songs"; // sane default
   m_group.clear();
@@ -1684,7 +1689,7 @@ bool CSmartPlaylist::IsEmpty(bool ignoreSortAndLimit /* = true */) const
 {
   bool empty = m_ruleCombination.empty();
   if (empty && !ignoreSortAndLimit)
-    empty = m_limit <= 0 && m_orderField == SortByNone && m_orderDirection == SortOrderNone;
+    empty = m_limit == 0 && m_orderField == SortByNone && m_orderDirection == SortOrder::NONE;
 
   return empty;
 }

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -139,9 +139,9 @@ public:
   SortBy GetOrder() const { return m_orderField; }
   void SetOrderAscending(bool orderAscending)
   {
-    m_orderDirection = orderAscending ? SortOrderAscending : SortOrderDescending;
+    m_orderDirection = orderAscending ? SortOrder::ASCENDING : SortOrder::DESCENDING;
   }
-  bool GetOrderAscending() const { return m_orderDirection != SortOrderDescending; }
+  bool GetOrderAscending() const { return m_orderDirection != SortOrder::DESCENDING; }
   SortOrder GetOrderDirection() const { return m_orderDirection; }
   void SetOrderAttributes(SortAttribute attributes) { m_orderAttributes = attributes; }
   SortAttribute GetOrderAttributes() const { return m_orderAttributes; }

--- a/xbmc/playlists/SmartPlaylistFileItemListModifier.cpp
+++ b/xbmc/playlists/SmartPlaylistFileItemListModifier.cpp
@@ -43,7 +43,7 @@ bool CSmartPlaylistFileItemListModifier::Modify(CFileItemList &items) const
     return false;
 
   items.SetProperty(PROPERTY_SORT_ORDER, (int)xsp.GetOrder());
-  items.SetProperty(PROPERTY_SORT_ASCENDING, xsp.GetOrderDirection() == SortOrderAscending);
+  items.SetProperty(PROPERTY_SORT_ASCENDING, xsp.GetOrderDirection() == SortOrder::ASCENDING);
 
   return true;
 }

--- a/xbmc/pvr/windows/GUIViewStatePVR.cpp
+++ b/xbmc/pvr/windows/GUIViewStatePVR.cpp
@@ -37,7 +37,7 @@ CGUIViewStateWindowPVRChannels::CGUIViewStateWindowPVRChannels(const int windowI
       LABEL_MASKS("%L", "%p", "%L", "%p")); // Filename, LastPlayed | Foldername, LastPlayed
   AddSortMethod(SortByDateAdded, 570, // "Date added"
                 LABEL_MASKS("%L", "%a", "%L", "%a"), // Filename, DateAdded | Foldername, DateAdded
-                SortAttributeNone, SortOrderDescending);
+                SortAttributeNone, SortOrder::DESCENDING);
   AddSortMethod(SortByClientChannelOrder, 19315, // "Backend number"
                 LABEL_MASKS("%L", "", "%L", "")); // Filename, empty | Foldername, empty
   AddSortMethod(SortByProvider, 19348, // "Provider"
@@ -114,7 +114,7 @@ CGUIViewStateWindowPVRGuide::CGUIViewStateWindowPVRGuide(const int windowId,
       LABEL_MASKS("%L", "%p", "%L", "%p")); // Filename, LastPlayed | Foldername, LastPlayed
   AddSortMethod(SortByDateAdded, 570, // "Date added"
                 LABEL_MASKS("%L", "%a", "%L", "%a"), // Filename, DateAdded | Foldername, DateAdded
-                SortAttributeNone, SortOrderDescending);
+                SortAttributeNone, SortOrder::DESCENDING);
   AddSortMethod(SortByClientChannelOrder, 19315, // "Backend number"
                 LABEL_MASKS("%L", "", "%L", "")); // Filename, empty | Foldername, empty
   AddSortMethod(SortByProvider, 19348, // "Provider"
@@ -172,9 +172,9 @@ CGUIViewStateWindowPVRSearch::CGUIViewStateWindowPVRSearch(const int windowId,
 
   // Default sorting
   if (CPVREpgSearchPath(m_items.GetPath()).IsSavedSearchesRoot())
-    SetSortMethod(SortByDate, SortOrderDescending);
+    SetSortMethod(SortByDate, SortOrder::DESCENDING);
   else
-    SetSortMethod(SortByDate, SortOrderAscending);
+    SetSortMethod(SortByDate, SortOrder::ASCENDING);
 
   LoadViewState(m_items.GetPath(), GetWindowId());
 }
@@ -203,11 +203,11 @@ CGUIViewStateWindowPVRProviders::CGUIViewStateWindowPVRProviders(const int windo
     AddSortMethod(SortByProvider, 19348, // "Provider"
                   LABEL_MASKS("%L", "", "%L", "")); // Filename, empty | Foldername, empty
 
-    SetSortMethod(SortByProvider, SortOrderAscending);
+    SetSortMethod(SortByProvider, SortOrder::ASCENDING);
   }
   else
   {
-    SetSortMethod(SortByLabel, SortOrderAscending);
+    SetSortMethod(SortByLabel, SortOrder::ASCENDING);
   }
 
   LoadViewState(m_items.GetPath(), GetWindowId());

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -496,7 +496,7 @@ void CAdvancedSettings::Initialize()
   m_iPVRTimeshiftThreshold = 10;
   m_bPVRTimeshiftSimpleOSD = true;
   m_PVRDefaultSortOrder.sortBy = SortByDate;
-  m_PVRDefaultSortOrder.sortOrder = SortOrderDescending;
+  m_PVRDefaultSortOrder.sortOrder = SortOrder::DESCENDING;
 
   m_addonPackageFolderSize = 200;
 
@@ -1256,8 +1256,9 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
       if (validSortMethods.contains(static_cast<SortBy>(sortMethod)))
       {
         int sortOrder;
-        if (XMLUtils::GetInt(pSortDecription, XML_SORTORDER, sortOrder, SortOrderAscending,
-                             SortOrderDescending))
+        if (XMLUtils::GetInt(pSortDecription, XML_SORTORDER, sortOrder,
+                             static_cast<int>(SortOrder::ASCENDING),
+                             static_cast<int>(SortOrder::DESCENDING)))
         {
           m_PVRDefaultSortOrder.sortBy = static_cast<SortBy>(sortMethod);
           m_PVRDefaultSortOrder.sortOrder = static_cast<SortOrder>(sortOrder);

--- a/xbmc/utils/SortUtils.cpp
+++ b/xbmc/utils/SortUtils.cpp
@@ -1113,17 +1113,19 @@ const SortUtils::SortPreparator& SortUtils::getPreparator(SortBy sortBy)
 SortUtils::Sorter SortUtils::getSorter(SortOrder sortOrder, SortAttribute attributes)
 {
   if (attributes & SortAttributeIgnoreFolders)
-    return sortOrder == SortOrderDescending ? SorterIgnoreFoldersDescending : SorterIgnoreFoldersAscending;
+    return sortOrder == SortOrder::DESCENDING ? SorterIgnoreFoldersDescending
+                                              : SorterIgnoreFoldersAscending;
 
-  return sortOrder == SortOrderDescending ? SorterDescending : SorterAscending;
+  return sortOrder == SortOrder::DESCENDING ? SorterDescending : SorterAscending;
 }
 
 SortUtils::SorterIndirect SortUtils::getSorterIndirect(SortOrder sortOrder, SortAttribute attributes)
 {
   if (attributes & SortAttributeIgnoreFolders)
-    return sortOrder == SortOrderDescending ? SorterIndirectIgnoreFoldersDescending : SorterIndirectIgnoreFoldersAscending;
+    return sortOrder == SortOrder::DESCENDING ? SorterIndirectIgnoreFoldersDescending
+                                              : SorterIndirectIgnoreFoldersAscending;
 
-  return sortOrder == SortOrderDescending ? SorterIndirectDescending : SorterIndirectAscending;
+  return sortOrder == SortOrder::DESCENDING ? SorterIndirectDescending : SorterIndirectAscending;
 }
 
 const Fields& SortUtils::GetFieldsForSorting(SortBy sortBy)
@@ -1377,14 +1379,12 @@ const std::string& SortUtils::SortMethodToString(SortBy sortMethod)
   return TypeToString<SortBy>(sortMethods, sortMethod);
 }
 
-const std::map<std::string, SortOrder> sortOrders = {
-  { "ascending", SortOrderAscending },
-  { "descending", SortOrderDescending }
-};
+const std::map<std::string, SortOrder> sortOrders = {{"ascending", SortOrder::ASCENDING},
+                                                     {"descending", SortOrder::DESCENDING}};
 
 SortOrder SortUtils::SortOrderFromString(const std::string& sortOrder)
 {
-  return TypeFromString<SortOrder>(sortOrders, sortOrder, SortOrderNone);
+  return TypeFromString<SortOrder>(sortOrders, sortOrder, SortOrder::NONE);
 }
 
 const std::string& SortUtils::SortOrderToString(SortOrder sortOrder)

--- a/xbmc/utils/SortUtils.h
+++ b/xbmc/utils/SortUtils.h
@@ -18,11 +18,12 @@
 
 enum class SortMethod;
 
-typedef enum {
-  SortOrderNone = 0,
-  SortOrderAscending,
-  SortOrderDescending
-} SortOrder;
+enum class SortOrder
+{
+  NONE,
+  ASCENDING,
+  DESCENDING,
+};
 
 typedef enum
 {
@@ -178,7 +179,7 @@ typedef enum
 
 typedef struct SortDescription {
   SortBy sortBy = SortByNone;
-  SortOrder sortOrder = SortOrderAscending;
+  SortOrder sortOrder = SortOrder::ASCENDING;
   SortAttribute sortAttributes = SortAttributeNone;
   int limitStart = 0;
   int limitEnd = -1;

--- a/xbmc/utils/test/TestSortUtils.cpp
+++ b/xbmc/utils/test/TestSortUtils.cpp
@@ -45,7 +45,7 @@ TEST(TestSortUtils, Sort_SortBy)
   items.push_back(item6);
   items.push_back(item7);
 
-  SortUtils::Sort(SortByArtist, SortOrderAscending, SortAttributeNone, items);
+  SortUtils::Sort(SortByArtist, SortOrder::ASCENDING, SortAttributeNone, items);
 
   EXPECT_STREQ("A Artist", (*items.at(0))[FieldArtist].asString().c_str());
   EXPECT_STREQ("B Artist", (*items.at(1))[FieldArtist].asString().c_str());

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -73,7 +73,7 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
 
     SetViewAsControl(DEFAULT_VIEW_LIST);
 
-    SetSortOrder(SortOrderNone);
+    SetSortOrder(SortOrder::NONE);
   }
   else if (VIDEO::IsVideoDb(items))
   {
@@ -94,7 +94,7 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
 
         SetViewAsControl(DEFAULT_VIEW_LIST);
 
-        SetSortOrder(SortOrderNone);
+        SetSortOrder(SortOrder::NONE);
       }
       break;
       case NodeType::DIRECTOR:
@@ -237,7 +237,7 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
         SetSortMethod(SortByNone);
 
         SetViewAsControl(CViewStateSettings::GetInstance().Get("videonavepisodes")->m_viewMode);
-        SetSortOrder(SortOrderNone);
+        SetSortOrder(SortOrder::NONE);
 
         break;
       }
@@ -270,7 +270,7 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
         if (params.GetSetId() > -1)
         {
           SetSortMethod(SortByYear);
-          SetSortOrder(SortOrderAscending);
+          SetSortOrder(SortOrder::ASCENDING);
         }
         else
         {
@@ -310,7 +310,7 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
 
         SetViewAsControl(CViewStateSettings::GetInstance().Get("videonavtitles")->m_viewMode);
 
-        SetSortOrder(SortOrderNone);
+        SetSortOrder(SortOrder::NONE);
       }
       break;
       case NodeType::RECENTLY_ADDED_MUSICVIDEOS:
@@ -320,7 +320,7 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
 
         SetViewAsControl(CViewStateSettings::GetInstance().Get("videonavmusicvideos")->m_viewMode);
 
-        SetSortOrder(SortOrderNone);
+        SetSortOrder(SortOrder::NONE);
       }
       break;
       case NodeType::MOVIE_ASSETS:
@@ -494,7 +494,7 @@ CGUIViewStateWindowVideoPlaylist::CGUIViewStateWindowVideoPlaylist(const CFileIt
 
   SetViewAsControl(DEFAULT_VIEW_LIST);
 
-  SetSortOrder(SortOrderNone);
+  SetSortOrder(SortOrder::NONE);
 
   LoadViewState(items.GetPath(), WINDOW_VIDEO_PLAYLIST);
 }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11765,7 +11765,7 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
         sorting.limitEnd = xsp.GetLimit();
       if (xsp.GetOrder() != SortByNone)
         sorting.sortBy = xsp.GetOrder();
-      if (xsp.GetOrderDirection() != SortOrderNone)
+      if (xsp.GetOrderDirection() != SortOrder::NONE)
         sorting.sortOrder = xsp.GetOrderDirection();
       if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING))
         sorting.sortAttributes = SortAttributeIgnoreArticle;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -487,7 +487,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
         // force sorting consistency to avoid hash mismatch between platforms
         // sort by filename as always present for any files, but keep case sensitivity
-        items.Sort(SortByFile, SortOrderAscending, SortAttributeNone);
+        items.Sort(SortByFile, SortOrder::ASCENDING, SortAttributeNone);
 
         // check whether to re-use previously computed fast hash
         if (!CanFastHash(items, regexps) || fastHash.empty())
@@ -537,7 +537,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
         // force sorting consistency to avoid hash mismatch between platforms
         // sort by filename as always present for any files, but keep case sensitivity
-        items.Sort(SortByFile, SortOrderAscending, SortAttributeNone);
+        items.Sort(SortByFile, SortOrder::ASCENDING, SortAttributeNone);
 
         GetPathHash(items, hash);
         bSkip = true;
@@ -1330,7 +1330,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         {
           // force sorting consistency to avoid hash mismatch between platforms
           // sort by filename as always present for any files, but keep case sensitivity
-          items.Sort(SortByFile, SortOrderAscending, SortAttributeNone);
+          items.Sort(SortByFile, SortOrder::ASCENDING, SortAttributeNone);
           GetPathHash(items, hash);
           if (StringUtils::EqualsNoCase(dbHash, hash))
           {
@@ -1381,7 +1381,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     */
 
     // since we're doing this now anyway, should other items be stacked?
-    items.Sort(SortByPath, SortOrderAscending);
+    items.Sort(SortByPath, SortOrder::ASCENDING);
 
     // If found VIDEO_TS.IFO or INDEX.BDMV then we are dealing with Blu-ray or DVD files on disc
     // somewhere in the directory tree. Assume that all other files/folders in the same folder

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -412,7 +412,7 @@ void CGUIDialogVideoInfo::SetMovie(const CFileItem *item)
     database.GetMoviesNav(m_movieItem->GetPath(), *m_castList, -1, -1, -1, -1, -1, -1,
                           m_movieItem->GetVideoInfoTag()->m_set.GetID(), -1, SortDescription(),
                           VideoDbDetailsAll);
-    m_castList->Sort(SortBySortTitle, SortOrderDescending);
+    m_castList->Sort(SortBySortTitle, SortOrder::DESCENDING);
     CVideoThumbLoader loader;
     for (auto& item : *m_castList)
       loader.LoadItem(item.get());
@@ -1523,7 +1523,11 @@ bool CGUIDialogVideoInfo::GetMoviesForSet(const CFileItem *setItem, CFileItemLis
   if (dialog == nullptr)
     return false;
 
-  listItems.Sort(SortByLabel, SortOrderAscending, CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
+  listItems.Sort(SortByLabel, SortOrder::ASCENDING,
+                 CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                     CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
+                     ? SortAttributeIgnoreArticle
+                     : SortAttributeNone);
 
   dialog->Reset();
   dialog->SetMultiSelection(true);
@@ -1576,7 +1580,11 @@ bool CGUIDialogVideoInfo::GetSetForMovie(const CFileItem* movieItem,
 
   if (!CDirectory::GetDirectory(baseDir, listItems, "", DIR_FLAG_DEFAULTS))
     return false;
-  listItems.Sort(SortByLabel, SortOrderAscending, CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
+  listItems.Sort(SortByLabel, SortOrder::ASCENDING,
+                 CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                     CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
+                     ? SortAttributeIgnoreArticle
+                     : SortAttributeNone);
 
   int currentSetId = 0;
   std::string currentSetLabel;
@@ -1728,7 +1736,11 @@ bool CGUIDialogVideoInfo::GetItemsForTag(const std::string &strHeading, const st
   if (dialog == nullptr)
     return false;
 
-  listItems.Sort(SortByLabel, SortOrderAscending, CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
+  listItems.Sort(SortByLabel, SortOrder::ASCENDING,
+                 CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                     CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
+                     ? SortAttributeIgnoreArticle
+                     : SortAttributeNone);
 
   dialog->Reset();
   dialog->SetMultiSelection(true);
@@ -2098,7 +2110,11 @@ bool CGUIDialogVideoInfo::LinkMovieToTvShow(const std::shared_ptr<CFileItem>& it
   int iSelectedLabel = 0;
   if (list.Size() > 1 || (!bRemove && !list.IsEmpty()))
   {
-    list.Sort(SortByLabel, SortOrderAscending, CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
+    list.Sort(SortByLabel, SortOrder::ASCENDING,
+              CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                  CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
+                  ? SortAttributeIgnoreArticle
+                  : SortAttributeNone);
     CGUIDialogSelect* pDialog = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(WINDOW_DIALOG_SELECT);
     if (pDialog)
     {

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -554,7 +554,7 @@ bool CGUIDialogVideoManagerVersions::GetAllOtherMovies(const std::shared_ptr<CFi
   if (list.Size() < 2)
     return false;
 
-  list.Sort(SortByLabel, SortOrderAscending,
+  list.Sort(SortByLabel, SortOrder::ASCENDING,
             CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
                 CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
                 ? SortAttributeIgnoreArticle

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -97,7 +97,7 @@ SortDescription GetSortDescription(const CGUIViewState& state, const CFileItemLi
         if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->m_iEpisode > 0)
         {
           // first choice for folders containing episodes
-          sortDescription.sortOrder = SortOrderAscending;
+          sortDescription.sortOrder = SortOrder::ASCENDING;
           return sortDescription;
         }
       }
@@ -111,7 +111,7 @@ SortDescription GetSortDescription(const CGUIViewState& state, const CFileItemLi
         if (item->HasVideoInfoTag() && item->GetVideoInfoTag()->HasYear())
         {
           // first choice for folders containing movies
-          sortDescription.sortOrder = SortOrderAscending;
+          sortDescription.sortOrder = SortOrder::ASCENDING;
           return sortDescription;
         }
       }
@@ -125,7 +125,7 @@ SortDescription GetSortDescription(const CGUIViewState& state, const CFileItemLi
         {
           // fallback, if neither ByEpisode nor ByYear is available
           sortDescDate = sortDescription;
-          sortDescDate.sortOrder = SortOrderAscending;
+          sortDescDate.sortOrder = SortOrder::ASCENDING;
           break; // leave items loop. we can still find ByEpisode or ByYear. so, no return here.
         }
       }
@@ -203,7 +203,7 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
         if (m_mode != ContentUtils::PlayMode::PLAY_FROM_HERE &&
             (sortDesc.sortBy == SortByDate || sortDesc.sortBy == SortByYear ||
              sortDesc.sortBy == SortByEpisodeNumber))
-          sortDesc.sortOrder = SortOrderAscending;
+          sortDesc.sortOrder = SortOrder::ASCENDING;
       }
       else
         sortDesc = GetSortDescription(*state, items);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1389,7 +1389,11 @@ void CGUIWindowVideoBase::AppendAndClearSearchItems(CFileItemList &searchItems, 
   if (!searchItems.Size())
     return;
 
-  searchItems.Sort(SortByLabel, SortOrderAscending, CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone);
+  searchItems.Sort(SortByLabel, SortOrder::ASCENDING,
+                   CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                       CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING)
+                       ? SortAttributeIgnoreArticle
+                       : SortAttributeNone);
   for (int i = 0; i < searchItems.Size(); i++)
     searchItems[i]->SetLabel(prependLabel + searchItems[i]->GetLabel());
   results.Append(searchItems);

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -204,10 +204,10 @@ CGUIViewState::~CGUIViewState() = default;
 
 SortOrder CGUIViewState::SetNextSortOrder()
 {
-  if (GetSortOrder() == SortOrderAscending)
-    SetSortOrder(SortOrderDescending);
+  if (GetSortOrder() == SortOrder::ASCENDING)
+    SetSortOrder(SortOrder::DESCENDING);
   else
-    SetSortOrder(SortOrderAscending);
+    SetSortOrder(SortOrder::ASCENDING);
 
   SaveViewState();
 
@@ -219,13 +219,13 @@ SortOrder CGUIViewState::GetSortOrder() const
   if (m_currentSortMethod >= 0 && m_currentSortMethod < (int)m_sortMethods.size())
     return m_sortMethods[m_currentSortMethod].m_sortDescription.sortOrder;
 
-  return SortOrderAscending;
+  return SortOrder::ASCENDING;
 }
 
 int CGUIViewState::GetSortOrderLabel() const
 {
   if (m_currentSortMethod >= 0 && m_currentSortMethod < (int)m_sortMethods.size())
-    if (m_sortMethods[m_currentSortMethod].m_sortDescription.sortOrder == SortOrderDescending)
+    if (m_sortMethods[m_currentSortMethod].m_sortDescription.sortOrder == SortOrder::DESCENDING)
       return 585;
 
   return 584; // default sort order label 'Ascending'
@@ -297,28 +297,36 @@ std::vector<SortDescription> CGUIViewState::GetSortDescriptions() const
   return descriptions;
 }
 
-void CGUIViewState::AddSortMethod(SortBy sortBy, int buttonLabel, const LABEL_MASKS &labelMasks, SortAttribute sortAttributes /* = SortAttributeNone */, SortOrder sortOrder /* = SortOrderNone */)
+void CGUIViewState::AddSortMethod(SortBy sortBy,
+                                  int buttonLabel,
+                                  const LABEL_MASKS& labelMasks,
+                                  SortAttribute sortAttributes /* = SortAttributeNone */,
+                                  SortOrder sortOrder /* = SortOrder::NONE */)
 {
   AddSortMethod(sortBy, sortAttributes, buttonLabel, labelMasks, sortOrder);
 }
 
-void CGUIViewState::AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, int buttonLabel, const LABEL_MASKS &labelMasks, SortOrder sortOrder /* = SortOrderNone */)
+void CGUIViewState::AddSortMethod(SortBy sortBy,
+                                  SortAttribute sortAttributes,
+                                  int buttonLabel,
+                                  const LABEL_MASKS& labelMasks,
+                                  SortOrder sortOrder /* = SortOrder::NONE */)
 {
   for (size_t i = 0; i < m_sortMethods.size(); ++i)
     if (m_sortMethods[i].m_sortDescription.sortBy == sortBy)
       return;
 
   // handle unspecified sort order
-  if (sortBy != SortByNone && sortOrder == SortOrderNone)
+  if (sortBy != SortByNone && sortOrder == SortOrder::NONE)
   {
     // the following sort methods are sorted in descending order by default
     if (sortBy == SortByDate || sortBy == SortBySize || sortBy == SortByPlaycount ||
         sortBy == SortByRating || sortBy == SortByProgramCount ||
         sortBy == SortByBitrate || sortBy == SortByListeners ||
         sortBy == SortByUserRating || sortBy == SortByLastPlayed)
-      sortOrder = SortOrderDescending;
+      sortOrder = SortOrder::DESCENDING;
     else
-      sortOrder = SortOrderAscending;
+      sortOrder = SortOrder::ASCENDING;
   }
 
   GUIViewSortDetails sort;
@@ -347,7 +355,7 @@ void CGUIViewState::SetCurrentSortMethod(int method)
   SaveViewState();
 }
 
-void CGUIViewState::SetSortMethod(SortBy sortBy, SortOrder sortOrder /* = SortOrderNone */)
+void CGUIViewState::SetSortMethod(SortBy sortBy, SortOrder sortOrder /* = SortOrder::NONE */)
 {
   for (int i = 0; i < (int)m_sortMethods.size(); ++i)
   {
@@ -358,7 +366,7 @@ void CGUIViewState::SetSortMethod(SortBy sortBy, SortOrder sortOrder /* = SortOr
     }
   }
 
-  if (sortOrder != SortOrderNone)
+  if (sortOrder != SortOrder::NONE)
     SetSortOrder(sortOrder);
 }
 
@@ -375,7 +383,7 @@ bool CGUIViewState::ChooseSortMethod()
     return false;
   dialog->Reset();
   dialog->SetHeading(CVariant{ 39010 }); // Label "Sort by"
-  for (auto &sortMethod : m_sortMethods)
+  for (const auto& sortMethod : m_sortMethods)
     dialog->Add(
         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(sortMethod.m_buttonLabel));
   dialog->SetSelected(m_currentSortMethod);
@@ -491,7 +499,7 @@ void CGUIViewState::AddLiveTVSources()
 
 void CGUIViewState::SetSortOrder(SortOrder sortOrder)
 {
-  if (sortOrder == SortOrderNone)
+  if (sortOrder == SortOrder::NONE)
     return;
 
   if (m_currentSortMethod < 0 || m_currentSortMethod >= (int)m_sortMethods.size())
@@ -546,14 +554,15 @@ void CGUIViewState::AddPlaylistOrder(const CFileItemList& items, const LABEL_MAS
 {
   SortBy sortBy = SortByPlaylistOrder;
   int sortLabel = 559;
-  SortOrder sortOrder = SortOrderAscending;
+  SortOrder sortOrder = SortOrder::ASCENDING;
   if (items.HasProperty(PROPERTY_SORT_ORDER))
   {
     sortBy = (SortBy)items.GetProperty(PROPERTY_SORT_ORDER).asInteger();
     if (sortBy != SortByNone)
     {
       sortLabel = SortUtils::GetSortLabel(sortBy);
-      sortOrder = items.GetProperty(PROPERTY_SORT_ASCENDING).asBoolean() ? SortOrderAscending : SortOrderDescending;
+      sortOrder = items.GetProperty(PROPERTY_SORT_ASCENDING).asBoolean() ? SortOrder::ASCENDING
+                                                                         : SortOrder::DESCENDING;
     }
   }
 

--- a/xbmc/view/GUIViewState.h
+++ b/xbmc/view/GUIViewState.h
@@ -76,12 +76,20 @@ protected:
    */
   void AddPlaylistOrder(const CFileItemList& items, const LABEL_MASKS& label_masks);
 
-  void AddSortMethod(SortBy sortBy, int buttonLabel, const LABEL_MASKS &labelMasks, SortAttribute sortAttributes = SortAttributeNone, SortOrder sortOrder = SortOrderNone);
-  void AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, int buttonLabel, const LABEL_MASKS &labelMasks, SortOrder sortOrder = SortOrderNone);
+  void AddSortMethod(SortBy sortBy,
+                     int buttonLabel,
+                     const LABEL_MASKS& labelMasks,
+                     SortAttribute sortAttributes = SortAttributeNone,
+                     SortOrder sortOrder = SortOrder::NONE);
+  void AddSortMethod(SortBy sortBy,
+                     SortAttribute sortAttributes,
+                     int buttonLabel,
+                     const LABEL_MASKS& labelMasks,
+                     SortOrder sortOrder = SortOrder::NONE);
   void AddSortMethod(const SortDescription& sortDescription,
                      int buttonLabel,
                      const LABEL_MASKS& labelMasks);
-  void SetSortMethod(SortBy sortBy, SortOrder sortOrder = SortOrderNone);
+  void SetSortMethod(SortBy sortBy, SortOrder sortOrder = SortOrder::NONE);
   void SetSortMethod(const SortDescription& sortDescription);
   void SetSortOrder(SortOrder sortOrder);
 

--- a/xbmc/view/ViewState.h
+++ b/xbmc/view/ViewState.h
@@ -32,7 +32,7 @@ public:
   {
     m_viewMode = 0;
     m_sortDescription.sortBy = SortByLabel;
-    m_sortDescription.sortOrder = SortOrderAscending;
+    m_sortDescription.sortOrder = SortOrder::ASCENDING;
   };
 
   int m_viewMode;

--- a/xbmc/view/ViewStateSettings.cpp
+++ b/xbmc/view/ViewStateSettings.cpp
@@ -110,7 +110,8 @@ bool CViewStateSettings::Load(const TiXmlNode *settings)
     }
 
     int sortOrder;
-    if (XMLUtils::GetInt(pViewState, XML_SORTORDER, sortOrder, SortOrderNone, SortOrderDescending))
+    if (XMLUtils::GetInt(pViewState, XML_SORTORDER, sortOrder, static_cast<int>(SortOrder::NONE),
+                         static_cast<int>(SortOrder::DESCENDING)))
       viewState->second->m_sortDescription.sortOrder = (SortOrder)sortOrder;
   }
 
@@ -246,7 +247,7 @@ void CViewStateSettings::SetEventLevel(EventLevel eventLevel)
 {
   if (eventLevel < EventLevel::Basic)
     m_eventLevel = EventLevel::Basic;
-  if (eventLevel > EventLevel::Error)
+  else if (eventLevel > EventLevel::Error)
     m_eventLevel = EventLevel::Error;
   else
     m_eventLevel = eventLevel;
@@ -270,7 +271,7 @@ void CViewStateSettings::AddViewState(const std::string& strTagName, int default
   if (strTagName.empty() || m_viewStates.contains(strTagName))
     return;
 
-  CViewState *viewState = new CViewState(defaultView, defaultSort, SortOrderAscending);
+  CViewState* viewState = new CViewState(defaultView, defaultSort, SortOrder::ASCENDING);
   if (viewState == NULL)
     return;
 

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -566,14 +566,15 @@ void CGUIMediaWindow::UpdateButtons()
   if (m_guiState)
   {
     // Update sorting controls
-    if (m_guiState->GetSortOrder() == SortOrderNone)
+    if (m_guiState->GetSortOrder() == SortOrder::NONE)
     {
       CONTROL_DISABLE(CONTROL_BTNSORTASC);
     }
     else
     {
       CONTROL_ENABLE(CONTROL_BTNSORTASC);
-      SET_CONTROL_SELECTED(GetID(), CONTROL_BTNSORTASC, m_guiState->GetSortOrder() != SortOrderAscending);
+      SET_CONTROL_SELECTED(GetID(), CONTROL_BTNSORTASC,
+                           m_guiState->GetSortOrder() != SortOrder::ASCENDING);
     }
 
     // Update list/thumb control
@@ -632,13 +633,16 @@ void CGUIMediaWindow::SortItems(CFileItemList &items)
       if (sortBy != SortByNone && sortBy != SortByPlaylistOrder && sortBy != SortByProgramCount)
       {
         sorting.sortBy = sortBy;
-        sorting.sortOrder = items.GetProperty(PROPERTY_SORT_ASCENDING).asBoolean() ? SortOrderAscending : SortOrderDescending;
+        sorting.sortOrder = items.GetProperty(PROPERTY_SORT_ASCENDING).asBoolean()
+                                ? SortOrder::ASCENDING
+                                : SortOrder::DESCENDING;
         sorting.sortAttributes = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_IGNORETHEWHENSORTING) ? SortAttributeIgnoreArticle : SortAttributeNone;
 
         // if the sort order is descending, we need to switch the original sort order, as we assume
         // in CGUIViewState::AddPlaylistOrder that SortByPlaylistOrder is ascending.
-        if (guiState->GetSortOrder() == SortOrderDescending)
-          sorting.sortOrder = sorting.sortOrder == SortOrderDescending ? SortOrderAscending : SortOrderDescending;
+        if (guiState->GetSortOrder() == SortOrder::DESCENDING)
+          sorting.sortOrder = sorting.sortOrder == SortOrder::DESCENDING ? SortOrder::ASCENDING
+                                                                         : SortOrder::DESCENDING;
       }
     }
 

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -357,7 +357,7 @@ void CGUIWindowFileManager::OnSort(int iList)
 
   }
 
-  m_vecItems[iList]->Sort(SortByLabel, SortOrderAscending);
+  m_vecItems[iList]->Sort(SortByLabel, SortOrder::ASCENDING);
 }
 
 void CGUIWindowFileManager::ClearFileItems(int iList)


### PR DESCRIPTION
## Description
Convert enum to enum class.

## Motivation and context
Make it forwardable, moar modern

## How has this been tested?
It builds

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
