### PR TITLE
[cmake][Windows] Fix groovy / apache commons are downloaded each time Kodi is build

### DIFF
--- a/xbmc/interfaces/swig/CMakeLists.txt
+++ b/xbmc/interfaces/swig/CMakeLists.txt
@@ -70,6 +70,12 @@ set(APACHE_COMMONS_TEXT_VER 1.13.0)
 set(APACHE_COMMONS_TEXT_URL ${KODI_MIRROR}/build-deps/sources/commons-text-${APACHE_COMMONS_TEXT_VER}-bin.tar.gz)
 set(APACHE_COMMONS_TEXT_URL_HASH URL_HASH SHA512=a51667463e88b2d017c3baebb9bbe42c4e50cba96ffe19c89680e82002a4db8b9007daff75f8dbf8bf3725be13a3f03f3c2bc4e1f11e8e02dcab4408abdb44a1)
 
+# On Windows, CMake ignores DOWNLOAD_DIR parameter and downloads are stored
+# in ${CMAKE_BINARY_DIR}/_deps, causing re-download each time Kodi is build.
+if(CORE_SYSTEM_NAME MATCHES windows)
+  set(FETCHCONTENT_BASE_DIR ${TARBALL_DIR})
+endif()
+
 include(FetchContent)
 FetchContent_Declare(
   groovy


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix groovy / apache commons are downloaded each time Kodi is build.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For some reason CMake ignores `DOWNLOAD_DIR` option in this case and downloads are stored in build dir instead of correct location in Windows:

`${CMAKE_SOURCE_DIR}/project/BuildDependencies/downloads`

This causes download again and again in every Jenkins build. This also has consequences for developers, since Kodi cannot be compiled if the mirrors are down (even with all dependencies cached locally).

This seems very specific CMake Windows only bug because works well in other planforms (tested Android). 

Therefore, this PR should be taken as a "temporary workaround".... since I have not been able to find the true cause or a better fix.

**Before:**
https://paste.kodi.tv/hopibabifi

**After:**
```
-- Found NASM: V:/kodi/project/BuildDependencies/tools/bin/nasm.exe (found version "3.01")
-- Found Meson: V:/kodi/project/BuildDependencies/tools/bin/Meson/meson.exe (found version "1.9.1")
-- Found Ninja: V:/kodi/project/BuildDependencies/tools/bin/Meson/ninja.EXE (found version "1.12.1")
-- Building ffmpeg: (version "8.0.1")
-- Building flatbuffers: (version "23.3.3")
-- Building fmt: (version "12.1.0")
-- Building pcre2: (version "10.45")
-- Building nlohmann_json: (version "3.12.0")
-- Building spdlog: (version "1.16.0")
-- Building utfcpp: (version "4.0.6")
-- Building taglib: (version "2.0.2")
-- Building tinyxml2: (version "9.0.0")
-- Building effects11: (version "11.29")
-- Building mariadb: (version "3.3.17")
-- #---- CONFIGURATION ----#
-- Platforms: windows
-- App package: org.xbmc.kodi
-- -- PATH config --
-- Prefix: C:/Program Files/kodi
-- Libdir: C:/Program Files/kodi/lib
-- Bindir: C:/Program Files/kodi/bin
-- Includedir: C:/Program Files/kodi/include
-- Datarootdir: C:/Program Files/kodi/share
-- Datadir: C:/Program Files/kodi/share
-- CCACHE enabled: Yes
-- CLANGFORMAT enabled: No
-- CLANGTIDY enabled: No
-- CPPCHECK enabled: No
-- INCLUDEWHATYOUUSE enabled: No
-- ALSA enabled: No
-- AVAHI enabled: No
-- BLUETOOTH enabled: No
-- BLURAY enabled: Yes
-- CAP enabled: No
-- CEC enabled: Yes
-- DBUS enabled: No
-- ISO9660PP enabled: No
-- LCMS2 enabled: No
-- LIRCCLIENT enabled: No
-- MDNS enabled: Yes
-- MICROHTTPD enabled: Yes
-- NFS enabled: Yes
-- PIPEWIRE enabled: No
-- PLIST enabled: Yes
-- PULSEAUDIO enabled: No
-- PYTHON enabled: Yes
-- SMBCLIENT enabled: Yes
-- SNDIO enabled: No
-- UDEV enabled: No
-- UDFREAD enabled: Yes
-- XSLT enabled: Yes
-- LIBAACS enabled: Yes
-- LIBBDPLUS enabled: Yes
-- MARIADBCLIENT enabled: Yes
-- LIBUSB enabled: No
-- Configuring done (9.5s)
-- Generating done (1.2s)
-- Build files have been written to: V:/kodi-build
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally Windows x64.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Faster CMake configuration and less annoying output text.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
