### PR TITLE
GUI: Add optional scissor clipping and transform detachment to GUIControlGroup

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -911,6 +911,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
   int rulerUnit = 12;
   bool useControlCoords = false;
   bool renderFocusedLast = false;
+  bool clipping = false;
 
   CRect hitRect;
   CPoint camera;
@@ -1173,6 +1174,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
 
   XMLUtils::GetBoolean(pControlNode, "usecontrolcoords", useControlCoords);
   XMLUtils::GetBoolean(pControlNode, "renderfocusedlast", renderFocusedLast);
+  XMLUtils::GetBoolean(pControlNode, "clipping", clipping);
   XMLUtils::GetBoolean(pControlNode, "resetonlabelchange", resetOnLabelChange);
 
   XMLUtils::GetBoolean(pControlNode, "password", bPassword);
@@ -1265,6 +1267,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
         static_cast<CGUIControlGroup*>(control)->SetDefaultControl(defaultControl, defaultAlways);
         static_cast<CGUIControlGroup*>(control)->SetRenderFocusedLast(renderFocusedLast);
       }
+      static_cast<CGUIControlGroup*>(control)->SetClipping(clipping);
+
       break;
     }
     case CGUIControl::GUICONTROL_GROUPLIST:

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -912,6 +912,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
   bool useControlCoords = false;
   bool renderFocusedLast = false;
   bool clipping = false;
+  bool transformChildren = true;
 
   CRect hitRect;
   CPoint camera;
@@ -1175,6 +1176,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
   XMLUtils::GetBoolean(pControlNode, "usecontrolcoords", useControlCoords);
   XMLUtils::GetBoolean(pControlNode, "renderfocusedlast", renderFocusedLast);
   XMLUtils::GetBoolean(pControlNode, "clipping", clipping);
+  XMLUtils::GetBoolean(pControlNode, "transformchildren", transformChildren);
   XMLUtils::GetBoolean(pControlNode, "resetonlabelchange", resetOnLabelChange);
 
   XMLUtils::GetBoolean(pControlNode, "password", bPassword);
@@ -1268,6 +1270,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
         static_cast<CGUIControlGroup*>(control)->SetRenderFocusedLast(renderFocusedLast);
       }
       static_cast<CGUIControlGroup*>(control)->SetClipping(clipping);
+      static_cast<CGUIControlGroup*>(control)->SetTransformChildren(transformChildren);
 
       break;
     }

--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -24,6 +24,7 @@ CGUIControlGroup::CGUIControlGroup()
   m_defaultAlways = false;
   m_focusedControl = 0;
   m_renderFocusedLast = false;
+  m_clipping = false;
   ControlType = GUICONTROL_GROUP;
 }
 
@@ -34,6 +35,7 @@ CGUIControlGroup::CGUIControlGroup(int parentID, int controlID, float posX, floa
   m_defaultAlways = false;
   m_focusedControl = 0;
   m_renderFocusedLast = false;
+  m_clipping = false;
   ControlType = GUICONTROL_GROUP;
 }
 
@@ -43,6 +45,7 @@ CGUIControlGroup::CGUIControlGroup(const CGUIControlGroup &from)
   m_defaultControl = from.m_defaultControl;
   m_defaultAlways = from.m_defaultAlways;
   m_renderFocusedLast = from.m_renderFocusedLast;
+  m_clipping = from.m_clipping;
 
   // run through and add our controls
   for (auto *i : from.m_children)
@@ -109,6 +112,16 @@ void CGUIControlGroup::Render()
 {
   CPoint pos(GetPosition());
   CServiceBroker::GetWinSystem()->GetGfxContext().SetOrigin(pos.x, pos.y);
+  CRect prevScissors;
+  if (m_clipping)
+  {
+    prevScissors = CServiceBroker::GetWinSystem()->GetGfxContext().GetScissors();
+    const CRect localRect(0.0f, 0.0f, m_width, m_height);
+    CRect aabb = CServiceBroker::GetWinSystem()->GetGfxContext().GenerateAABB(localRect);
+    if (!prevScissors.IsEmpty())
+      aabb.Intersect(prevScissors);
+    CServiceBroker::GetWinSystem()->GetGfxContext().SetScissors(aabb);
+  }
   CGUIControl *focusedControl = NULL;
   if (CServiceBroker::GetWinSystem()->GetGfxContext().GetRenderOrder() ==
       RENDER_ORDER_FRONT_TO_BACK)
@@ -134,6 +147,13 @@ void CGUIControlGroup::Render()
   if (focusedControl)
     focusedControl->DoRender();
   CGUIControl::Render();
+  if (m_clipping)
+  {
+    if (prevScissors.IsEmpty())
+      CServiceBroker::GetWinSystem()->GetGfxContext().ResetScissors();
+    else
+      CServiceBroker::GetWinSystem()->GetGfxContext().SetScissors(prevScissors);
+  }
   CServiceBroker::GetWinSystem()->GetGfxContext().RestoreOrigin();
 }
 
@@ -396,11 +416,21 @@ EVENT_RESULT CGUIControlGroup::SendMouseEvent(const CPoint& point, const MOUSE::
   if (CGUIControl::CanFocus())
   {
     CPoint pos(GetPosition());
+    CPoint localPoint = childPoint - pos;
+    // If the group is clipped, ignore mouse events outside its bounding box
+    if (m_clipping)
+    {
+      if (localPoint.x < 0.0f || localPoint.x > m_width ||
+          localPoint.y < 0.0f || localPoint.y > m_height)
+      {
+        return EVENT_RESULT_UNHANDLED;
+      }
+    }
     // run through our controls in reverse order (so that last rendered is checked first)
     for (rControls i = m_children.rbegin(); i != m_children.rend(); ++i)
     {
       CGUIControl *child = *i;
-      EVENT_RESULT ret = child->SendMouseEvent(childPoint - pos, event);
+      EVENT_RESULT ret = child->SendMouseEvent(localPoint, event);
       if (ret)
       { // we've handled the action, and/or have focused an item
         return ret;
@@ -420,9 +450,15 @@ void CGUIControlGroup::UnfocusFromPoint(const CPoint &point)
   CPoint controlCoords(point);
   m_transform.InverseTransformPosition(controlCoords.x, controlCoords.y);
   controlCoords -= GetPosition();
+  // Check if the pointer is physically outside the group's clipping boundaries
+  bool isOutsideClip = m_clipping && (controlCoords.x < 0.0f || controlCoords.x > m_width ||
+                                      controlCoords.y < 0.0f || controlCoords.y > m_height);
   for (auto *child : m_children)
   {
-    child->UnfocusFromPoint(controlCoords);
+    if (isOutsideClip)
+      child->UnfocusFromPoint(CPoint(-9999.0f, -9999.0f));
+    else
+      child->UnfocusFromPoint(controlCoords);
   }
   CGUIControl::UnfocusFromPoint(point);
 }

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -17,6 +17,18 @@
 
 #include <vector>
 
+class TransformMatrix;
+
+class CTransformDetachGuard
+{
+public:
+  CTransformDetachGuard(bool transformChildren, const TransformMatrix& transform);
+  ~CTransformDetachGuard();
+private:
+  const TransformMatrix& m_transform;
+  bool m_detached;
+};
+
 /*!
  \ingroup controls
  \brief group of controls, useful for remembering last control + animating/hiding together
@@ -69,6 +81,7 @@ public:
   }
   void SetRenderFocusedLast(bool renderLast) { m_renderFocusedLast = renderLast; }
   void SetClipping(bool clip) { m_clipping = clip; }
+  void SetTransformChildren(bool transform) { m_transformChildren = transform; }
 
   void SaveStates(std::vector<CControlState> &states) override;
 
@@ -91,6 +104,7 @@ protected:
   int m_focusedControl;
   bool m_renderFocusedLast;
   bool m_clipping{false};
+  bool m_transformChildren{true};
 private:
   typedef std::vector< std::vector<CGUIControl *> * > COLLECTORTYPE;
 

--- a/xbmc/guilib/GUIControlGroup.h
+++ b/xbmc/guilib/GUIControlGroup.h
@@ -68,6 +68,7 @@ public:
     m_defaultAlways = always;
   }
   void SetRenderFocusedLast(bool renderLast) { m_renderFocusedLast = renderLast; }
+  void SetClipping(bool clip) { m_clipping = clip; }
 
   void SaveStates(std::vector<CControlState> &states) override;
 
@@ -89,6 +90,7 @@ protected:
   bool m_defaultAlways;
   int m_focusedControl;
   bool m_renderFocusedLast;
+  bool m_clipping{false};
 private:
   typedef std::vector< std::vector<CGUIControl *> * > COLLECTORTYPE;
 


### PR DESCRIPTION
## Description
This PR makes a few minor extensions to CGUIControlGroup by exposing existing render states (scissors and transforms) to the skinning engine.

### 1. Scissor Clipping (`<clipping>true</clipping>`)

Uses the engine's existing SetScissors() state to constrain the rendering of child controls to the group's bounding box.

Updates SendMouseEvent and UnfocusFromPoint so that visually clipped children cannot intercept mouse input or hold focus when the pointer is outside the physical bounds.

### 2. Transform Detachment (`<transformchildren>false</transformchildren>`)

Temporarily removes the group’s transformation matrix (animations, scaling) from the render context before processing child controls, then restores it afterward.

Updates the mouse hit-testing logic to bypass the parent transform when children are detached, ensuring input maps correctly to the untransformed children.

## Motivation and context
This is a revised, much simpler approach to the clipping and masking issues I attempted to solve in #27796. Taking @sarbes' feedback into account regarding the overhead of offscreen FBOs and avoiding major rendering pipeline overhauls, this PR abandons the render target approach entirely.

Instead, it strictly reuses Kodi's existing hardware scissor stack and transform matrix stack.

By exposing these existing pipelines to CGUIControlGroup:
- Skinners gain a lightweight way to strictly clip group contents during static rendering and transforms
- Skinners can animate a parent group (like a sliding mask) while keeping the children pinned in place, without requiring complex engine overhauls.

## How has this been tested?

- Tested on Mac and Android builds.
- Rendering: Tested with custom XMLs using heavily nested clipped groups to ensure the software scissor stack intersects and restores correctly without corrupting the render state for the rest of the GUI tree.
- Input: Verified mouse hover and unfocus states drop off exactly at the boundary of the parent group.
- Transforms: Combined <transformchildren>false</transformchildren> with <animation effect="slide"> to confirm children remain visually and logically static while the parent boundary moves.

## What is the effect on users?
No effect on end users unless the skinner explicitly opts in to the features by adding the new xml tags to a group.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed