### PR TITLE
[ActiveAE] Fix audio stall and infinite loop during tempo seek

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -163,7 +163,7 @@ void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
     {
       std::unique_lock lock(stream->m_statsLock);
       float buffertime = static_cast<float>(str.m_bufferedTime) + stream->m_bufferedTime;
-      status.delay += static_cast<double>(buffertime) / str.m_resampleRatio;
+      status.delay += static_cast<double>(buffertime) * str.m_resampleRatio;
       return;
     }
   }
@@ -189,7 +189,7 @@ void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
     {
       std::unique_lock lock(stream->m_statsLock);
       float buffertime = static_cast<float>(str.m_bufferedTime) + stream->m_bufferedTime;
-      status.delay += static_cast<double>(buffertime) / str.m_resampleRatio;
+      status.delay += static_cast<double>(buffertime) * str.m_resampleRatio;
       info.delay = status.GetDelay();
       info.error = str.m_syncError;
       info.errortime = str.m_errorTime;
@@ -211,7 +211,7 @@ float CEngineStats::GetCacheTime(CActiveAEStream *stream)
     {
       std::unique_lock lock(stream->m_statsLock);
       float buffertime = static_cast<float>(str.m_bufferedTime) + stream->m_bufferedTime;
-      delay += buffertime / static_cast<float>(str.m_resampleRatio);
+      delay += buffertime * static_cast<float>(str.m_resampleRatio);
       break;
     }
   }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1562,6 +1562,14 @@ void CActiveAE::SFlushStream(CActiveAEStream *stream)
   stream->m_lastPtsJump = 0.0;
   stream->m_errorInterval = std::chrono::milliseconds(1000);
 
+  // Synchronously reset servo state to prevent stale cache interaction.
+  // This MUST be done before m_stats.UpdateStream(stream) is called.
+  stream->m_resampleIntegral = 0.0;
+  if (stream->m_processingBuffers)
+  {
+    stream->m_processingBuffers->SetRR(1.0, m_settings.atempoThreshold);
+  }
+
   // flush the engine if we only have a single stream
   if (m_streams.size() == 1)
   {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1557,6 +1557,11 @@ void CActiveAE::SFlushStream(CActiveAEStream *stream)
   stream->m_syncError.Flush();
   stream->ResetFreeBuffers();
 
+  // Reset Logic State Variables to revive Servo
+  stream->m_lastPts = 0.0;
+  stream->m_lastPtsJump = 0.0;
+  stream->m_errorInterval = std::chrono::milliseconds(1000);
+
   // flush the engine if we only have a single stream
   if (m_streams.size() == 1)
   {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -587,10 +587,11 @@ bool CActiveAEBufferPoolAtempo::ProcessBuffers()
         }
 
         // check if draining is finished
-        if (m_drain && m_procSample->pkt->nb_samples == 0)
+        if (m_procSample->pkt->nb_samples == 0)
         {
           m_procSample->Return();
-          busy = false;
+          if (m_drain)
+            busy = false;
         }
         else
           m_outputSamples.push_back(m_procSample);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -605,7 +605,14 @@ bool CActiveAEBufferPoolAtempo::ProcessBuffers()
       // some methods like encode require completely filled packets
       else if (!m_fillPackets || (m_procSample->pkt->nb_samples == m_procSample->pkt->max_nb_samples))
       {
-        m_outputSamples.push_back(m_procSample);
+        if (m_procSample->pkt->nb_samples == 0)
+        {
+          m_procSample->Return();
+        }
+        else
+        {
+          m_outputSamples.push_back(m_procSample);
+        }
         m_procSample = nullptr;
       }
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEFilter.cpp
@@ -254,6 +254,12 @@ int CActiveAEFilter::ProcessFilter(uint8_t **dst_buffer, int dst_samples, uint8_
       m_filterEof = true;
       return -1;
     }
+
+    if (!m_started)
+    {
+      m_filterEof = true;
+      return 0;
+    }
   }
 
   if (!m_hasData && m_started)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
**[ActiveAE] Fix audio stall and infinite loop during tempo seek**

This PR fixes a cluster of intertwined bugs in `ActiveAE` that cause audio stalls, deadlocks, and infinite loops when seeking backwards or forwards while playing video at a modified tempo (e.g., 1.3x).

The issues fixed include:
1. **Math Error**: Fixed buffer duration miscalculation in `GetDelay()` that caused premature throttling / dropped samples by changing division to multiplication for `m_resampleRatio`.
2. **Stale State Servo Crash**: Synchronously reset `m_lastPts`, `m_errorInterval`, and `m_resampleIntegral` during `SFlushStream` to prevent false "Messy Timestamp" errors from crippling the sync servo post-seek.
3. **Ghost Packets**: Guarded `ProcessBuffers()` against 0-sample packets with stale PTS emitted by `atempo` after a flush. Previously, these generated massive artificial sync errors (-11k+ ms) that permanently starved the buffer cache.
4. **Infinite Spin Loop**: Instantly set `m_filterEof` to true when flushing an unstarted `atempo` filter. Without this, pushing a `nullptr` EOF into an unstarted filter bypassed the EOF state, causing an infinite thread lock.
5. **Dimensional Math Timeout**: Changed the `AddPackets` timeout to use `steady_clock` wall-time rather than multiplying an absolute timestamp by variable `ClockSpeed`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Playback of standard files at tempos like 1.1x to 1.5x is a common feature. Without this fix, seeking backward or forward multiple times at a modified tempo almost guarantees an eventual thread lock or persistent audio dropout. This PR untangles the math and state logic so that `atempo` buffering recovers correctly.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have built and run this on LibreELEC on a Raspberry Pi 4. The video now plays smoothly when setting tempo=1.3x and executing multiple consecutive seeks, whereas the video and audio would previously get permanently stuck before this fix.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users utilizing the "Playback Speed / Tempo" feature will no longer experience Kodi completely freezing or dropping audio permanently when they seek skip around the timeline.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed