### PR TITLE
[Games] Fix rendering gamewindow elements with alpha

### DIFF
--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -980,10 +980,13 @@
 						<control type="image">
 							<width>444</width>
 							<height>250</height>
-							<aspectratio>scale</aspectratio>
+							<texture colordiffuse="border_alpha">colors/black.png</texture>
+						</control>
+						<control type="image">
+							<width>444</width>
+							<height>250</height>
+							<aspectratio>keep</aspectratio>
 							<texture>$INFO[ListItem.Icon]</texture>
-							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
-							<bordersize>4</bordersize>
 						</control>
 						<control type="gamewindow">
 							<visible>!String.IsEmpty(ListItem.Property(game.videofilter))</visible>
@@ -1012,10 +1015,13 @@
 						<control type="image">
 							<width>444</width>
 							<height>250</height>
-							<aspectratio>scale</aspectratio>
+							<texture colordiffuse="border_alpha">colors/black.png</texture>
+						</control>
+						<control type="image">
+							<width>444</width>
+							<height>250</height>
+							<aspectratio>keep</aspectratio>
 							<texture>$INFO[ListItem.Icon]</texture>
-							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
-							<bordersize>4</bordersize>
 						</control>
 						<control type="gamewindow">
 							<visible>!String.IsEmpty(ListItem.Property(game.videofilter))</visible>
@@ -1077,10 +1083,13 @@
 						<control type="image">
 							<width>444</width>
 							<height>250</height>
-							<aspectratio>scale</aspectratio>
-							<texture border="4">DefaultVideo.png</texture>
-							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
-							<bordersize>4</bordersize>
+							<texture colordiffuse="border_alpha">colors/black.png</texture>
+						</control>
+						<control type="image">
+							<width>444</width>
+							<height>250</height>
+							<aspectratio>keep</aspectratio>
+							<texture>$INFO[ListItem.Icon]</texture>
 						</control>
 						<control type="gamewindow">
 							<width>444</width>
@@ -1108,10 +1117,13 @@
 						<control type="image">
 							<width>444</width>
 							<height>250</height>
-							<aspectratio>scale</aspectratio>
-							<texture border="4">DefaultVideo.png</texture>
-							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
-							<bordersize>4</bordersize>
+							<texture colordiffuse="border_alpha">colors/black.png</texture>
+						</control>
+						<control type="image">
+							<width>444</width>
+							<height>250</height>
+							<aspectratio>keep</aspectratio>
+							<texture>$INFO[ListItem.Icon]</texture>
 						</control>
 						<control type="gamewindow">
 							<width>444</width>
@@ -1172,18 +1184,13 @@
 						<control type="image">
 							<width>444</width>
 							<height>250</height>
-							<aspectratio>scale</aspectratio>
-							<texture border="4">$INFO[ListItem.Icon]</texture>
-							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
-							<bordersize>4</bordersize>
+							<texture colordiffuse="border_alpha">colors/black.png</texture>
 						</control>
 						<control type="image">
 							<width>444</width>
 							<height>250</height>
-							<aspectratio>scale</aspectratio>
-							<texture border="4">$INFO[ListItem.Art(screenshot)]</texture>
-							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
-							<bordersize>4</bordersize>
+							<aspectratio>keep</aspectratio>
+							<texture>$INFO[ListItem.Icon]</texture>
 						</control>
 						<control type="gamewindow">
 							<width>444</width>
@@ -1209,18 +1216,13 @@
 						<control type="image">
 							<width>444</width>
 							<height>250</height>
-							<aspectratio>scale</aspectratio>
-							<texture border="4">$INFO[ListItem.Icon]</texture>
-							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
-							<bordersize>4</bordersize>
+							<texture colordiffuse="border_alpha">colors/black.png</texture>
 						</control>
 						<control type="image">
 							<width>444</width>
 							<height>250</height>
-							<aspectratio>scale</aspectratio>
-							<texture border="4">$INFO[ListItem.Art(screenshot)]</texture>
-							<bordertexture colordiffuse="border_alpha">colors/black.png</bordertexture>
-							<bordersize>4</bordersize>
+							<aspectratio>keep</aspectratio>
+							<texture>$INFO[ListItem.Icon]</texture>
 						</control>
 						<control type="gamewindow">
 							<width>444</width>
@@ -1240,6 +1242,7 @@
 							<width>444</width>
 							<height>250</height>
 							<texture border="4" infill="false" colordiffuse="button_focus">colors/white.png</texture>
+							<visible>Control.HasFocus(10811)</visible>
 						</control>
 					</control>
 				</focusedlayout>

--- a/system/shaders/rp_output_d3d.fx
+++ b/system/shaders/rp_output_d3d.fx
@@ -21,6 +21,7 @@
 texture2D g_Texture;
 float2    g_viewPort;
 float     m_params[1]; // 0 - range (0 - full, 1 - limited)
+float     g_alpha = 1.0;
 
 SamplerState TextureSampler : IMMUTABLE
 {
@@ -64,9 +65,9 @@ float4 OUTPUT_PS(VS_OUTPUT In) : SV_TARGET
 {
   float4 color = g_Texture.Sample(TextureSampler, In.TextureUV);
   [flatten] if (m_params[0])
-    color = saturate(0.0625 + color * 219.0 / 255.0);
+    color.rgb = saturate(0.0625 + color.rgb * 219.0 / 255.0);
 
-  color.a = 1.0;
+  color.a = g_alpha;
 
   return color;
 }

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
@@ -75,11 +75,16 @@ void CRenderBufferDMA::CreateTexture()
   glGenTextures(1, &m_textureId);
 
   glBindTexture(m_textureTarget, m_textureId);
-
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  // Force alpha to 1, because game client can leave it undefined
+#if defined(HAS_GL) || defined(GL_ES_VERSION_3_0)
+  if (m_fourcc == DRM_FORMAT_ARGB8888 || m_fourcc == DRM_FORMAT_ARGB1555)
+    glTexParameteri(m_textureTarget, GL_TEXTURE_SWIZZLE_A, GL_ONE);
+#endif
 
   glBindTexture(m_textureTarget, 0);
 }

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGL.cpp
@@ -34,14 +34,17 @@ void CRenderBufferOpenGL::CreateTexture()
   glGenTextures(1, &m_textureId);
 
   glBindTexture(m_textureTarget, m_textureId);
-
-  glTexImage2D(m_textureTarget, 0, m_internalFormat, m_width, m_height, 0, m_pixelFormat,
-               m_pixelType, NULL);
-
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  // Force alpha to 1, because game client can leave it undefined
+  if (m_internalFormat == GL_RGBA8)
+    glTexParameteri(m_textureTarget, GL_TEXTURE_SWIZZLE_A, GL_ONE);
+
+  glTexImage2D(m_textureTarget, 0, m_internalFormat, m_width, m_height, 0, m_pixelFormat,
+               m_pixelType, nullptr);
 
   glBindTexture(m_textureTarget, 0);
 }

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGLES.cpp
@@ -36,14 +36,19 @@ void CRenderBufferOpenGLES::CreateTexture()
   glGenTextures(1, &m_textureId);
 
   glBindTexture(m_textureTarget, m_textureId);
-
-  glTexImage2D(m_textureTarget, 0, m_internalFormat, m_width, m_height, 0, m_pixelFormat,
-               m_pixelType, NULL);
-
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  // Force alpha to 1, because game client can leave it undefined
+#if defined(GL_ES_VERSION_3_0)
+  if (m_internalFormat == GL_RGBA || m_internalFormat == GL_BGRA_EXT)
+    glTexParameteri(m_textureTarget, GL_TEXTURE_SWIZZLE_A, GL_ONE);
+#endif
+
+  glTexImage2D(m_textureTarget, 0, m_internalFormat, m_width, m_height, 0, m_pixelFormat,
+               m_pixelType, nullptr);
 
   glBindTexture(m_textureTarget, 0);
 }

--- a/xbmc/cores/RetroPlayer/guibridge/GUIRenderTarget.cpp
+++ b/xbmc/cores/RetroPlayer/guibridge/GUIRenderTarget.cpp
@@ -31,7 +31,7 @@ CGUIRenderControl::CGUIRenderControl(IRenderManager* renderManager, CGUIGameCont
 
 void CGUIRenderControl::Render()
 {
-  m_renderManager->RenderControl(true, true, m_gameControl.GetRenderRegion(),
+  m_renderManager->RenderControl(false, true, m_gameControl.GetRenderRegion(),
                                  m_gameControl.GetRenderSettings());
 }
 

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -433,6 +433,11 @@ void CRPRenderManager::RenderControl(bool bClear,
   if (renderBuffer == nullptr)
     return;
 
+  // Calculate alpha (before SetTransform overrides the accumulated alpha)
+  UTILS::COLOR::Color alpha = 255;
+  if (bUseAlpha)
+    alpha = m_renderContext.MergeAlpha(UTILS::COLOR::BLACK) >> 24;
+
   // Set fullscreen
   const bool bWasFullscreen = m_renderContext.IsFullScreenVideo();
   if (bWasFullscreen)
@@ -454,11 +459,6 @@ void CRPRenderManager::RenderControl(bool bClear,
     m_renderContext.Clear(UTILS::COLOR::BLACK);
     m_renderContext.SetScissors(old);
   }
-
-  // Calculate alpha
-  UTILS::COLOR::Color alpha = 255;
-  if (bUseAlpha)
-    alpha = m_renderContext.MergeAlpha(UTILS::COLOR::BLACK) >> 24;
 
   RenderInternal(renderer, renderBuffer, false, alpha);
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h
@@ -97,6 +97,8 @@ protected:
   CRect m_sourceRect;
   float m_fullDestWidth{0.0f};
   float m_fullDestHeight{0.0f};
+  float m_lastTargetWidth{0.0f};
+  float m_lastTargetHeight{0.0f};
   ViewportCoordinates m_rotatedDestCoords{};
 
   // Video shaders

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
@@ -12,6 +12,7 @@
 #include "cores/RetroPlayer/buffers/RenderBufferPoolDMA.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
 #include "cores/RetroPlayer/shaders/gl/ShaderPresetGL.h"
+#include "cores/RetroPlayer/shaders/gl/ShaderTextureGL.h"
 #include "cores/RetroPlayer/shaders/gl/ShaderTextureGLRef.h"
 #include "utils/BufferObjectFactory.h"
 #include "utils/GLUtils.h"
@@ -57,37 +58,46 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
   if (renderBuffer == nullptr)
     return;
 
-  RenderBufferTextures* rbTextures;
-  const auto it = m_RBTexturesMap.find(renderBuffer);
-  if (it != m_RBTexturesMap.end())
-  {
-    rbTextures = it->second.get();
-  }
-  else
-  {
-    rbTextures = new RenderBufferTextures{
-        // Source texture
-        std::make_shared<SHADER::CShaderTextureGLRef>(
-            static_cast<unsigned int>(renderBuffer->GetWidth()),
-            static_cast<unsigned int>(renderBuffer->GetHeight()), renderBuffer->TextureID()),
-        // Target texture is empty wrapper used to pass target width and height
-        std::make_shared<SHADER::CShaderTextureGLRef>(
-            static_cast<unsigned int>(m_context.GetScreenWidth()),
-            static_cast<unsigned int>(m_context.GetScreenHeight())),
-    };
-    m_RBTexturesMap.emplace(renderBuffer, rbTextures);
-  }
-
-  std::shared_ptr<SHADER::CShaderTextureGLRef> sourceTexture = rbTextures->sourceTexture;
-  std::shared_ptr<SHADER::CShaderTextureGLRef> targetTexture = rbTextures->targetTexture;
-
   Updateshaders();
 
   // Use video shader preset
   if (m_bUseShaderPreset)
   {
+    RenderBufferTextures* rbTextures;
+
+    // Drop cached textures if target size is changed
+    if (m_fullDestWidth != m_lastTargetWidth || m_fullDestHeight != m_lastTargetHeight)
+    {
+      m_RBTexturesMap.clear();
+      m_lastTargetWidth = m_fullDestWidth;
+      m_lastTargetHeight = m_fullDestHeight;
+    }
+
+    const auto it = m_RBTexturesMap.find(renderBuffer);
+    if (it != m_RBTexturesMap.end())
+    {
+      rbTextures = it->second.get();
+    }
+    else
+    {
+      rbTextures = new RenderBufferTextures{
+          // Source texture
+          std::make_shared<SHADER::CShaderTextureGLRef>(
+              static_cast<unsigned int>(renderBuffer->GetWidth()),
+              static_cast<unsigned int>(renderBuffer->GetHeight()), renderBuffer->TextureID()),
+          // Target texture
+          std::make_shared<SHADER::CShaderTextureGL>(static_cast<unsigned int>(m_fullDestWidth),
+                                                     static_cast<unsigned int>(m_fullDestHeight),
+                                                     GL_UNSIGNED_BYTE, GL_RGBA8, GL_BGRA, false)};
+      rbTextures->targetTexture->CreateTexture(); // Create new internal texture
+      m_RBTexturesMap.emplace(renderBuffer, rbTextures);
+    }
+
+    std::shared_ptr<SHADER::CShaderTextureGLRef> sourceTexture = rbTextures->sourceTexture;
+    std::shared_ptr<SHADER::CShaderTextureGL> targetTexture = rbTextures->targetTexture;
+
     GLint filter = GL_NEAREST;
-    if (m_shaderPreset->GetPasses()[0].filterType == SHADER::FilterType::LINEAR)
+    if (m_shaderPreset->GetPasses().front().filterType == SHADER::FilterType::LINEAR)
       filter = GL_LINEAR;
 
     glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
@@ -96,76 +106,89 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if (!m_shaderPreset->RenderUpdate(m_rotatedDestCoords, {m_fullDestWidth, m_fullDestHeight},
-                                      *sourceTexture, *targetTexture))
+    if (!m_shaderPreset->RenderUpdate(*sourceTexture, *targetTexture))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
     }
+
+    glActiveTexture(GL_TEXTURE0); // GUI shader samples from texture unit 0
+    glBindTexture(m_textureTarget, targetTexture->GetTextureID());
   }
-  // Use GUI shader
   else
   {
     GLint filter = GL_NEAREST;
     if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glActiveTexture(GL_TEXTURE0); // GUI shader samples from texture unit 0
+    glBindTexture(m_textureTarget, renderBuffer->TextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-    m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
-
-    GLint uniColLoc = m_context.GUIShaderGetUniCol();
-    GLint depthLoc = m_context.GUIShaderGetDepth();
-
-    // Setup color values
-    GLubyte col[4];
-    const uint32_t color = (alpha << 24) | 0xFFFFFF;
-    col[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
-    col[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
-    col[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
-    col[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
-
-    glUniform4f(uniColLoc, (col[0] / 255.0f), (col[1] / 255.0f), (col[2] / 255.0f),
-                (col[3] / 255.0f));
-    glUniform1f(depthLoc, -1.0f);
-
-    // Setup destination rectangle
-    CRect rect = m_sourceRect;
-    rect.x1 /= renderBuffer->GetWidth();
-    rect.x2 /= renderBuffer->GetWidth();
-    rect.y1 /= renderBuffer->GetHeight();
-    rect.y2 /= renderBuffer->GetHeight();
-
-    PackedVertex vertex[4];
-
-    // Setup vertex position values
-    for (unsigned int i = 0; i < 4; i++)
-    {
-      vertex[i].x = m_rotatedDestCoords[i].x;
-      vertex[i].y = m_rotatedDestCoords[i].y;
-      vertex[i].z = 0.0f;
-    }
-
-    // Setup texture coordinates
-    vertex[0].u1 = vertex[3].u1 = rect.x1;
-    vertex[0].v1 = vertex[1].v1 = rect.y1;
-    vertex[1].u1 = vertex[2].u1 = rect.x2;
-    vertex[2].v1 = vertex[3].v1 = rect.y2;
-
-    glBindVertexArray(m_mainVAO);
-
-    glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_DYNAMIC_DRAW);
-
-    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
-
-    glBindVertexArray(0);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-    m_context.DisableGUIShader();
   }
+
+  if (alpha < 255)
+  {
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  }
+  else
+  {
+    glDisable(GL_BLEND);
+  }
+
+  // Use GUI shader
+  m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
+
+  GLint uniColLoc = m_context.GUIShaderGetUniCol();
+  GLint depthLoc = m_context.GUIShaderGetDepth();
+
+  // Setup color values
+  GLubyte col[4];
+  const uint32_t color = (alpha << 24) | 0xFFFFFF;
+  col[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+  col[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+  col[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+  col[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
+
+  glUniform4f(uniColLoc, (col[0] / 255.0f), (col[1] / 255.0f), (col[2] / 255.0f),
+              (col[3] / 255.0f));
+  glUniform1f(depthLoc, -1.0f);
+
+  // Setup destination rectangle
+  CRect rect = m_sourceRect;
+  rect.x1 /= renderBuffer->GetWidth();
+  rect.x2 /= renderBuffer->GetWidth();
+  rect.y1 /= renderBuffer->GetHeight();
+  rect.y2 /= renderBuffer->GetHeight();
+
+  PackedVertex vertex[4];
+
+  // Setup vertex position values
+  for (unsigned int i = 0; i < 4; i++)
+  {
+    vertex[i].x = m_rotatedDestCoords[i].x;
+    vertex[i].y = m_rotatedDestCoords[i].y;
+    vertex[i].z = 0.0f;
+  }
+
+  // Setup texture coordinates
+  vertex[0].u1 = vertex[3].u1 = rect.x1;
+  vertex[0].v1 = vertex[1].v1 = rect.y1;
+  vertex[1].u1 = vertex[2].u1 = rect.x2;
+  vertex[2].v1 = vertex[3].v1 = rect.y2;
+
+  glBindVertexArray(m_mainVAO);
+
+  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_DYNAMIC_DRAW);
+
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
+
+  glBindVertexArray(0);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+  m_context.DisableGUIShader();
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -12,6 +12,7 @@
 #include "cores/RetroPlayer/buffers/RenderBufferPoolDMA.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
 #include "cores/RetroPlayer/shaders/gles/ShaderPresetGLES.h"
+#include "cores/RetroPlayer/shaders/gles/ShaderTextureGLES.h"
 #include "cores/RetroPlayer/shaders/gles/ShaderTextureGLESRef.h"
 #include "utils/BufferObjectFactory.h"
 #include "utils/GLUtils.h"
@@ -57,37 +58,46 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
   if (renderBuffer == nullptr)
     return;
 
-  RenderBufferTextures* rbTextures;
-  const auto it = m_RBTexturesMap.find(renderBuffer);
-  if (it != m_RBTexturesMap.end())
-  {
-    rbTextures = it->second.get();
-  }
-  else
-  {
-    rbTextures = new RenderBufferTextures{
-        // Source texture
-        std::make_shared<SHADER::CShaderTextureGLESRef>(
-            static_cast<unsigned int>(renderBuffer->GetWidth()),
-            static_cast<unsigned int>(renderBuffer->GetHeight()), renderBuffer->TextureID()),
-        // Target texture is empty wrapper used to pass target width and height
-        std::make_shared<SHADER::CShaderTextureGLESRef>(
-            static_cast<unsigned int>(m_context.GetScreenWidth()),
-            static_cast<unsigned int>(m_context.GetScreenHeight())),
-    };
-    m_RBTexturesMap.emplace(renderBuffer, rbTextures);
-  }
-
-  std::shared_ptr<SHADER::CShaderTextureGLESRef> sourceTexture = rbTextures->sourceTexture;
-  std::shared_ptr<SHADER::CShaderTextureGLESRef> targetTexture = rbTextures->targetTexture;
-
   Updateshaders();
 
   // Use video shader preset
   if (m_bUseShaderPreset)
   {
+    RenderBufferTextures* rbTextures;
+
+    // Drop cached textures if target size is changed
+    if (m_fullDestWidth != m_lastTargetWidth || m_fullDestHeight != m_lastTargetHeight)
+    {
+      m_RBTexturesMap.clear();
+      m_lastTargetWidth = m_fullDestWidth;
+      m_lastTargetHeight = m_fullDestHeight;
+    }
+
+    const auto it = m_RBTexturesMap.find(renderBuffer);
+    if (it != m_RBTexturesMap.end())
+    {
+      rbTextures = it->second.get();
+    }
+    else
+    {
+      rbTextures = new RenderBufferTextures{
+          // Source texture
+          std::make_shared<SHADER::CShaderTextureGLESRef>(
+              static_cast<unsigned int>(renderBuffer->GetWidth()),
+              static_cast<unsigned int>(renderBuffer->GetHeight()), renderBuffer->TextureID()),
+          // Target texture
+          std::make_shared<SHADER::CShaderTextureGLES>(static_cast<unsigned int>(m_fullDestWidth),
+                                                       static_cast<unsigned int>(m_fullDestHeight),
+                                                       GL_UNSIGNED_BYTE, GL_RGBA, GL_RGBA, false)};
+      rbTextures->targetTexture->CreateTexture(); // Create new internal texture
+      m_RBTexturesMap.emplace(renderBuffer, rbTextures);
+    }
+
+    std::shared_ptr<SHADER::CShaderTextureGLESRef> sourceTexture = rbTextures->sourceTexture;
+    std::shared_ptr<SHADER::CShaderTextureGLES> targetTexture = rbTextures->targetTexture;
+
     GLint filter = GL_NEAREST;
-    if (m_shaderPreset->GetPasses()[0].filterType == SHADER::FilterType::LINEAR)
+    if (m_shaderPreset->GetPasses().front().filterType == SHADER::FilterType::LINEAR)
       filter = GL_LINEAR;
 
     glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
@@ -96,88 +106,101 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if (!m_shaderPreset->RenderUpdate(m_rotatedDestCoords, {m_fullDestWidth, m_fullDestHeight},
-                                      *sourceTexture, *targetTexture))
+    if (!m_shaderPreset->RenderUpdate(*sourceTexture, *targetTexture))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
     }
+
+    glActiveTexture(GL_TEXTURE0); // GUI shader samples from texture unit 0
+    glBindTexture(m_textureTarget, targetTexture->GetTextureID());
   }
-  // Use GUI shader
   else
   {
     GLint filter = GL_NEAREST;
     if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glActiveTexture(GL_TEXTURE0); // GUI shader samples from texture unit 0
+    glBindTexture(m_textureTarget, renderBuffer->TextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-    m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
-
-    GLint posLoc = m_context.GUIShaderGetPos();
-    GLint tex0Loc = m_context.GUIShaderGetCoord0();
-    GLint uniColLoc = m_context.GUIShaderGetUniCol();
-    GLint depthLoc = m_context.GUIShaderGetDepth();
-
-    // Setup color values
-    GLubyte col[4];
-    const uint32_t color = (alpha << 24) | 0xFFFFFF;
-    col[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
-    col[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
-    col[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
-    col[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
-
-    glUniform4f(uniColLoc, (col[0] / 255.0f), (col[1] / 255.0f), (col[2] / 255.0f),
-                (col[3] / 255.0f));
-    glUniform1f(depthLoc, -1.0f);
-
-    // Setup destination rectangle
-    CRect rect = m_sourceRect;
-    rect.x1 /= renderBuffer->GetWidth();
-    rect.x2 /= renderBuffer->GetWidth();
-    rect.y1 /= renderBuffer->GetHeight();
-    rect.y2 /= renderBuffer->GetHeight();
-
-    PackedVertex vertex[4];
-
-    // Setup vertex position values
-    for (unsigned int i = 0; i < 4; i++)
-    {
-      vertex[i].x = m_rotatedDestCoords[i].x;
-      vertex[i].y = m_rotatedDestCoords[i].y;
-      vertex[i].z = 0.0f;
-    }
-
-    // Setup texture coordinates
-    vertex[0].u1 = vertex[3].u1 = rect.x1;
-    vertex[0].v1 = vertex[1].v1 = rect.y1;
-    vertex[1].u1 = vertex[2].u1 = rect.x2;
-    vertex[2].v1 = vertex[3].v1 = rect.y2;
-
-    glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_DYNAMIC_DRAW);
-
-    glVertexAttribPointer(posLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
-                          reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
-    glEnableVertexAttribArray(posLoc);
-    glVertexAttribPointer(tex0Loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
-                          reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
-    glEnableVertexAttribArray(tex0Loc);
-
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
-
-    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
-
-    glDisableVertexAttribArray(posLoc);
-    glDisableVertexAttribArray(tex0Loc);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-
-    m_context.DisableGUIShader();
   }
+
+  if (alpha < 255)
+  {
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  }
+  else
+  {
+    glDisable(GL_BLEND);
+  }
+
+  // Use GUI shader
+  m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
+
+  GLint posLoc = m_context.GUIShaderGetPos();
+  GLint tex0Loc = m_context.GUIShaderGetCoord0();
+  GLint uniColLoc = m_context.GUIShaderGetUniCol();
+  GLint depthLoc = m_context.GUIShaderGetDepth();
+
+  // Setup color values
+  GLubyte col[4];
+  const uint32_t color = (alpha << 24) | 0xFFFFFF;
+  col[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+  col[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+  col[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+  col[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
+
+  glUniform4f(uniColLoc, (col[0] / 255.0f), (col[1] / 255.0f), (col[2] / 255.0f),
+              (col[3] / 255.0f));
+  glUniform1f(depthLoc, -1.0f);
+
+  // Setup destination rectangle
+  CRect rect = m_sourceRect;
+  rect.x1 /= renderBuffer->GetWidth();
+  rect.x2 /= renderBuffer->GetWidth();
+  rect.y1 /= renderBuffer->GetHeight();
+  rect.y2 /= renderBuffer->GetHeight();
+
+  PackedVertex vertex[4];
+
+  // Setup vertex position values
+  for (unsigned int i = 0; i < 4; i++)
+  {
+    vertex[i].x = m_rotatedDestCoords[i].x;
+    vertex[i].y = m_rotatedDestCoords[i].y;
+    vertex[i].z = 0.0f;
+  }
+
+  // Setup texture coordinates
+  vertex[0].u1 = vertex[3].u1 = rect.x1;
+  vertex[0].v1 = vertex[1].v1 = rect.y1;
+  vertex[1].u1 = vertex[2].u1 = rect.x2;
+  vertex[2].v1 = vertex[3].v1 = rect.y2;
+
+  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_DYNAMIC_DRAW);
+
+  glVertexAttribPointer(posLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
+                        reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
+  glEnableVertexAttribArray(posLoc);
+  glVertexAttribPointer(tex0Loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
+                        reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
+  glEnableVertexAttribArray(tex0Loc);
+
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
+
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
+
+  glDisableVertexAttribArray(posLoc);
+  glDisableVertexAttribArray(tex0Loc);
+
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+
+  m_context.DisableGUIShader();
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -12,6 +12,7 @@
 #include "cores/RetroPlayer/buffers/RenderBufferPoolOpenGL.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
 #include "cores/RetroPlayer/shaders/gl/ShaderPresetGL.h"
+#include "cores/RetroPlayer/shaders/gl/ShaderTextureGL.h"
 #include "cores/RetroPlayer/shaders/gl/ShaderTextureGLRef.h"
 #include "utils/GLUtils.h"
 #include "utils/log.h"
@@ -112,9 +113,9 @@ CRPRendererOpenGL::~CRPRendererOpenGL()
 {
   glDeleteBuffers(1, &m_mainIndexVBO);
   glDeleteBuffers(1, &m_mainVertexVBO);
-  glDeleteBuffers(1, &m_blackbarsVertexVBO);
-
   glDeleteVertexArrays(1, &m_mainVAO);
+
+  glDeleteBuffers(1, &m_blackbarsVertexVBO);
   glDeleteVertexArrays(1, &m_blackbarsVAO);
 }
 
@@ -126,16 +127,6 @@ void CRPRendererOpenGL::RenderInternal(bool clear, uint8_t alpha)
       DrawBlackBars();
     else
       ClearBackBuffer();
-  }
-
-  if (alpha < 255)
-  {
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  }
-  else
-  {
-    glDisable(GL_BLEND);
   }
 
   Render(alpha);
@@ -286,37 +277,46 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
   if (renderBuffer == nullptr)
     return;
 
-  RenderBufferTextures* rbTextures;
-  const auto it = m_RBTexturesMap.find(renderBuffer);
-  if (it != m_RBTexturesMap.end())
-  {
-    rbTextures = it->second.get();
-  }
-  else
-  {
-    rbTextures = new RenderBufferTextures{
-        // Source texture
-        std::make_shared<SHADER::CShaderTextureGLRef>(
-            static_cast<unsigned int>(renderBuffer->GetWidth()),
-            static_cast<unsigned int>(renderBuffer->GetHeight()), renderBuffer->TextureID()),
-        // Target texture is empty wrapper used to pass target width and height
-        std::make_shared<SHADER::CShaderTextureGLRef>(
-            static_cast<unsigned int>(m_context.GetScreenWidth()),
-            static_cast<unsigned int>(m_context.GetScreenHeight())),
-    };
-    m_RBTexturesMap.emplace(renderBuffer, rbTextures);
-  }
-
-  std::shared_ptr<SHADER::CShaderTextureGLRef> sourceTexture = rbTextures->sourceTexture;
-  std::shared_ptr<SHADER::CShaderTextureGLRef> targetTexture = rbTextures->targetTexture;
-
   Updateshaders();
 
   // Use video shader preset
   if (m_bUseShaderPreset)
   {
+    RenderBufferTextures* rbTextures;
+
+    // Drop cached textures if target size is changed
+    if (m_fullDestWidth != m_lastTargetWidth || m_fullDestHeight != m_lastTargetHeight)
+    {
+      m_RBTexturesMap.clear();
+      m_lastTargetWidth = m_fullDestWidth;
+      m_lastTargetHeight = m_fullDestHeight;
+    }
+
+    const auto it = m_RBTexturesMap.find(renderBuffer);
+    if (it != m_RBTexturesMap.end())
+    {
+      rbTextures = it->second.get();
+    }
+    else
+    {
+      rbTextures = new RenderBufferTextures{
+          // Source texture
+          std::make_shared<SHADER::CShaderTextureGLRef>(
+              static_cast<unsigned int>(renderBuffer->GetWidth()),
+              static_cast<unsigned int>(renderBuffer->GetHeight()), renderBuffer->TextureID()),
+          // Target texture
+          std::make_shared<SHADER::CShaderTextureGL>(static_cast<unsigned int>(m_fullDestWidth),
+                                                     static_cast<unsigned int>(m_fullDestHeight),
+                                                     GL_UNSIGNED_BYTE, GL_RGBA8, GL_BGRA, false)};
+      rbTextures->targetTexture->CreateTexture(); // Create new internal texture
+      m_RBTexturesMap.emplace(renderBuffer, rbTextures);
+    }
+
+    std::shared_ptr<SHADER::CShaderTextureGLRef> sourceTexture = rbTextures->sourceTexture;
+    std::shared_ptr<SHADER::CShaderTextureGL> targetTexture = rbTextures->targetTexture;
+
     GLint filter = GL_NEAREST;
-    if (m_shaderPreset->GetPasses()[0].filterType == SHADER::FilterType::LINEAR)
+    if (m_shaderPreset->GetPasses().front().filterType == SHADER::FilterType::LINEAR)
       filter = GL_LINEAR;
 
     glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
@@ -325,76 +325,89 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if (!m_shaderPreset->RenderUpdate(m_rotatedDestCoords, {m_fullDestWidth, m_fullDestHeight},
-                                      *sourceTexture, *targetTexture))
+    if (!m_shaderPreset->RenderUpdate(*sourceTexture, *targetTexture))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
     }
+
+    glActiveTexture(GL_TEXTURE0); // GUI shader samples from texture unit 0
+    glBindTexture(m_textureTarget, targetTexture->GetTextureID());
   }
-  // Use GUI shader
   else
   {
     GLint filter = GL_NEAREST;
     if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glActiveTexture(GL_TEXTURE0); // GUI shader samples from texture unit 0
+    glBindTexture(m_textureTarget, renderBuffer->TextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-    m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
-
-    GLint uniColLoc = m_context.GUIShaderGetUniCol();
-    GLint depthLoc = m_context.GUIShaderGetDepth();
-
-    // Setup color values
-    GLubyte col[4];
-    const uint32_t color = (alpha << 24) | 0xFFFFFF;
-    col[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
-    col[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
-    col[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
-    col[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
-
-    glUniform4f(uniColLoc, (col[0] / 255.0f), (col[1] / 255.0f), (col[2] / 255.0f),
-                (col[3] / 255.0f));
-    glUniform1f(depthLoc, -1.0f);
-
-    // Setup destination rectangle
-    CRect rect = m_sourceRect;
-    rect.x1 /= renderBuffer->GetWidth();
-    rect.x2 /= renderBuffer->GetWidth();
-    rect.y1 /= renderBuffer->GetHeight();
-    rect.y2 /= renderBuffer->GetHeight();
-
-    PackedVertex vertex[4];
-
-    // Setup vertex position values
-    for (unsigned int i = 0; i < 4; i++)
-    {
-      vertex[i].x = m_rotatedDestCoords[i].x;
-      vertex[i].y = m_rotatedDestCoords[i].y;
-      vertex[i].z = 0.0f;
-    }
-
-    // Setup texture coordinates
-    vertex[0].u1 = vertex[3].u1 = rect.x1;
-    vertex[0].v1 = vertex[1].v1 = rect.y1;
-    vertex[1].u1 = vertex[2].u1 = rect.x2;
-    vertex[2].v1 = vertex[3].v1 = rect.y2;
-
-    glBindVertexArray(m_mainVAO);
-
-    glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_DYNAMIC_DRAW);
-
-    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
-
-    glBindVertexArray(0);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-    m_context.DisableGUIShader();
   }
+
+  if (alpha < 255)
+  {
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  }
+  else
+  {
+    glDisable(GL_BLEND);
+  }
+
+  // Use GUI shader
+  m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
+
+  GLint uniColLoc = m_context.GUIShaderGetUniCol();
+  GLint depthLoc = m_context.GUIShaderGetDepth();
+
+  // Setup color values
+  GLubyte col[4];
+  const uint32_t color = (alpha << 24) | 0xFFFFFF;
+  col[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+  col[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+  col[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+  col[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
+
+  glUniform4f(uniColLoc, (col[0] / 255.0f), (col[1] / 255.0f), (col[2] / 255.0f),
+              (col[3] / 255.0f));
+  glUniform1f(depthLoc, -1.0f);
+
+  // Setup destination rectangle
+  CRect rect = m_sourceRect;
+  rect.x1 /= renderBuffer->GetWidth();
+  rect.x2 /= renderBuffer->GetWidth();
+  rect.y1 /= renderBuffer->GetHeight();
+  rect.y2 /= renderBuffer->GetHeight();
+
+  PackedVertex vertex[4];
+
+  // Setup vertex position values
+  for (unsigned int i = 0; i < 4; i++)
+  {
+    vertex[i].x = m_rotatedDestCoords[i].x;
+    vertex[i].y = m_rotatedDestCoords[i].y;
+    vertex[i].z = 0.0f;
+  }
+
+  // Setup texture coordinates
+  vertex[0].u1 = vertex[3].u1 = rect.x1;
+  vertex[0].v1 = vertex[1].v1 = rect.y1;
+  vertex[1].u1 = vertex[2].u1 = rect.x2;
+  vertex[2].v1 = vertex[3].v1 = rect.y2;
+
+  glBindVertexArray(m_mainVAO);
+
+  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_DYNAMIC_DRAW);
+
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
+
+  glBindVertexArray(0);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+  m_context.DisableGUIShader();
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -21,6 +21,7 @@ namespace KODI
 {
 namespace SHADER
 {
+class CShaderTextureGL;
 class CShaderTextureGLRef;
 } // namespace SHADER
 
@@ -72,7 +73,7 @@ protected:
   struct RenderBufferTextures
   {
     std::shared_ptr<SHADER::CShaderTextureGLRef> sourceTexture;
-    std::shared_ptr<SHADER::CShaderTextureGLRef> targetTexture;
+    std::shared_ptr<SHADER::CShaderTextureGL> targetTexture;
   };
 
   // Implementation of CRPBaseRenderer
@@ -103,7 +104,7 @@ protected:
   GLuint m_blackbarsVAO;
   GLuint m_blackbarsVertexVBO;
 
-  GLenum m_textureTarget = GL_TEXTURE_2D;
+  const GLenum m_textureTarget = GL_TEXTURE_2D;
   float m_clearColor = 0.0f;
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -12,6 +12,7 @@
 #include "cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
 #include "cores/RetroPlayer/shaders/gles/ShaderPresetGLES.h"
+#include "cores/RetroPlayer/shaders/gles/ShaderTextureGLES.h"
 #include "cores/RetroPlayer/shaders/gles/ShaderTextureGLESRef.h"
 #include "utils/GLUtils.h"
 #include "utils/log.h"
@@ -89,16 +90,6 @@ void CRPRendererOpenGLES::RenderInternal(bool clear, uint8_t alpha)
       DrawBlackBars();
     else
       ClearBackBuffer();
-  }
-
-  if (alpha < 255)
-  {
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  }
-  else
-  {
-    glDisable(GL_BLEND);
   }
 
   Render(alpha);
@@ -254,37 +245,46 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
   if (renderBuffer == nullptr)
     return;
 
-  RenderBufferTextures* rbTextures;
-  const auto it = m_RBTexturesMap.find(renderBuffer);
-  if (it != m_RBTexturesMap.end())
-  {
-    rbTextures = it->second.get();
-  }
-  else
-  {
-    rbTextures = new RenderBufferTextures{
-        // Source texture
-        std::make_shared<SHADER::CShaderTextureGLESRef>(
-            static_cast<unsigned int>(renderBuffer->GetWidth()),
-            static_cast<unsigned int>(renderBuffer->GetHeight()), renderBuffer->TextureID()),
-        // Target texture is empty wrapper used to pass target width and height
-        std::make_shared<SHADER::CShaderTextureGLESRef>(
-            static_cast<unsigned int>(m_context.GetScreenWidth()),
-            static_cast<unsigned int>(m_context.GetScreenHeight())),
-    };
-    m_RBTexturesMap.emplace(renderBuffer, rbTextures);
-  }
-
-  std::shared_ptr<SHADER::CShaderTextureGLESRef> sourceTexture = rbTextures->sourceTexture;
-  std::shared_ptr<SHADER::CShaderTextureGLESRef> targetTexture = rbTextures->targetTexture;
-
   Updateshaders();
 
   // Use video shader preset
   if (m_bUseShaderPreset)
   {
+    RenderBufferTextures* rbTextures;
+
+    // Drop cached textures if target size is changed
+    if (m_fullDestWidth != m_lastTargetWidth || m_fullDestHeight != m_lastTargetHeight)
+    {
+      m_RBTexturesMap.clear();
+      m_lastTargetWidth = m_fullDestWidth;
+      m_lastTargetHeight = m_fullDestHeight;
+    }
+
+    const auto it = m_RBTexturesMap.find(renderBuffer);
+    if (it != m_RBTexturesMap.end())
+    {
+      rbTextures = it->second.get();
+    }
+    else
+    {
+      rbTextures = new RenderBufferTextures{
+          // Source texture
+          std::make_shared<SHADER::CShaderTextureGLESRef>(
+              static_cast<unsigned int>(renderBuffer->GetWidth()),
+              static_cast<unsigned int>(renderBuffer->GetHeight()), renderBuffer->TextureID()),
+          // Target texture
+          std::make_shared<SHADER::CShaderTextureGLES>(static_cast<unsigned int>(m_fullDestWidth),
+                                                       static_cast<unsigned int>(m_fullDestHeight),
+                                                       GL_UNSIGNED_BYTE, GL_RGBA, GL_RGBA, false)};
+      rbTextures->targetTexture->CreateTexture(); // Create new internal texture
+      m_RBTexturesMap.emplace(renderBuffer, rbTextures);
+    }
+
+    std::shared_ptr<SHADER::CShaderTextureGLESRef> sourceTexture = rbTextures->sourceTexture;
+    std::shared_ptr<SHADER::CShaderTextureGLES> targetTexture = rbTextures->targetTexture;
+
     GLint filter = GL_NEAREST;
-    if (m_shaderPreset->GetPasses()[0].filterType == SHADER::FilterType::LINEAR)
+    if (m_shaderPreset->GetPasses().front().filterType == SHADER::FilterType::LINEAR)
       filter = GL_LINEAR;
 
     glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
@@ -293,88 +293,101 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if (!m_shaderPreset->RenderUpdate(m_rotatedDestCoords, {m_fullDestWidth, m_fullDestHeight},
-                                      *sourceTexture, *targetTexture))
+    if (!m_shaderPreset->RenderUpdate(*sourceTexture, *targetTexture))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
     }
+
+    glActiveTexture(GL_TEXTURE0); // GUI shader samples from texture unit 0
+    glBindTexture(m_textureTarget, targetTexture->GetTextureID());
   }
-  // Use GUI shader
   else
   {
     GLint filter = GL_NEAREST;
     if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
+    glActiveTexture(GL_TEXTURE0); // GUI shader samples from texture unit 0
+    glBindTexture(m_textureTarget, renderBuffer->TextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-    m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
-
-    GLint posLoc = m_context.GUIShaderGetPos();
-    GLint tex0Loc = m_context.GUIShaderGetCoord0();
-    GLint uniColLoc = m_context.GUIShaderGetUniCol();
-    GLint depthLoc = m_context.GUIShaderGetDepth();
-
-    // Setup color values
-    GLubyte col[4];
-    const uint32_t color = (alpha << 24) | 0xFFFFFF;
-    col[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
-    col[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
-    col[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
-    col[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
-
-    glUniform4f(uniColLoc, (col[0] / 255.0f), (col[1] / 255.0f), (col[2] / 255.0f),
-                (col[3] / 255.0f));
-    glUniform1f(depthLoc, -1.0f);
-
-    // Setup destination rectangle
-    CRect rect = m_sourceRect;
-    rect.x1 /= renderBuffer->GetWidth();
-    rect.x2 /= renderBuffer->GetWidth();
-    rect.y1 /= renderBuffer->GetHeight();
-    rect.y2 /= renderBuffer->GetHeight();
-
-    PackedVertex vertex[4];
-
-    // Setup vertex position values
-    for (unsigned int i = 0; i < 4; i++)
-    {
-      vertex[i].x = m_rotatedDestCoords[i].x;
-      vertex[i].y = m_rotatedDestCoords[i].y;
-      vertex[i].z = 0.0f;
-    }
-
-    // Setup texture coordinates
-    vertex[0].u1 = vertex[3].u1 = rect.x1;
-    vertex[0].v1 = vertex[1].v1 = rect.y1;
-    vertex[1].u1 = vertex[2].u1 = rect.x2;
-    vertex[2].v1 = vertex[3].v1 = rect.y2;
-
-    glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_DYNAMIC_DRAW);
-
-    glVertexAttribPointer(posLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
-                          reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
-    glEnableVertexAttribArray(posLoc);
-    glVertexAttribPointer(tex0Loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
-                          reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
-    glEnableVertexAttribArray(tex0Loc);
-
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
-
-    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
-
-    glDisableVertexAttribArray(posLoc);
-    glDisableVertexAttribArray(tex0Loc);
-
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-
-    m_context.DisableGUIShader();
   }
+
+  if (alpha < 255)
+  {
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  }
+  else
+  {
+    glDisable(GL_BLEND);
+  }
+
+  // Use GUI shader
+  m_context.EnableGUIShader(GL_SHADER_METHOD::TEXTURE);
+
+  GLint posLoc = m_context.GUIShaderGetPos();
+  GLint tex0Loc = m_context.GUIShaderGetCoord0();
+  GLint uniColLoc = m_context.GUIShaderGetUniCol();
+  GLint depthLoc = m_context.GUIShaderGetDepth();
+
+  // Setup color values
+  GLubyte col[4];
+  const uint32_t color = (alpha << 24) | 0xFFFFFF;
+  col[0] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::R, color);
+  col[1] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::G, color);
+  col[2] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::B, color);
+  col[3] = UTILS::GL::GetChannelFromARGB(UTILS::GL::ColorChannel::A, color);
+
+  glUniform4f(uniColLoc, (col[0] / 255.0f), (col[1] / 255.0f), (col[2] / 255.0f),
+              (col[3] / 255.0f));
+  glUniform1f(depthLoc, -1.0f);
+
+  // Setup destination rectangle
+  CRect rect = m_sourceRect;
+  rect.x1 /= renderBuffer->GetWidth();
+  rect.x2 /= renderBuffer->GetWidth();
+  rect.y1 /= renderBuffer->GetHeight();
+  rect.y2 /= renderBuffer->GetHeight();
+
+  PackedVertex vertex[4];
+
+  // Setup vertex position values
+  for (unsigned int i = 0; i < 4; i++)
+  {
+    vertex[i].x = m_rotatedDestCoords[i].x;
+    vertex[i].y = m_rotatedDestCoords[i].y;
+    vertex[i].z = 0.0f;
+  }
+
+  // Setup texture coordinates
+  vertex[0].u1 = vertex[3].u1 = rect.x1;
+  vertex[0].v1 = vertex[1].v1 = rect.y1;
+  vertex[1].u1 = vertex[2].u1 = rect.x2;
+  vertex[2].v1 = vertex[3].v1 = rect.y2;
+
+  glBindBuffer(GL_ARRAY_BUFFER, m_mainVertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(PackedVertex) * 4, &vertex[0], GL_DYNAMIC_DRAW);
+
+  glVertexAttribPointer(posLoc, 3, GL_FLOAT, 0, sizeof(PackedVertex),
+                        reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, x)));
+  glEnableVertexAttribArray(posLoc);
+  glVertexAttribPointer(tex0Loc, 2, GL_FLOAT, 0, sizeof(PackedVertex),
+                        reinterpret_cast<const GLvoid*>(offsetof(PackedVertex, u1)));
+  glEnableVertexAttribArray(tex0Loc);
+
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_mainIndexVBO);
+
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
+
+  glDisableVertexAttribArray(posLoc);
+  glDisableVertexAttribArray(tex0Loc);
+
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+
+  m_context.DisableGUIShader();
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -21,6 +21,7 @@ namespace KODI
 {
 namespace SHADER
 {
+class CShaderTextureGLES;
 class CShaderTextureGLESRef;
 } // namespace SHADER
 
@@ -72,7 +73,7 @@ protected:
   struct RenderBufferTextures
   {
     std::shared_ptr<SHADER::CShaderTextureGLESRef> sourceTexture;
-    std::shared_ptr<SHADER::CShaderTextureGLESRef> targetTexture;
+    std::shared_ptr<SHADER::CShaderTextureGLES> targetTexture;
   };
 
   // Implementation of CRPBaseRenderer
@@ -101,7 +102,7 @@ protected:
 
   GLuint m_blackbarsVertexVBO;
 
-  GLenum m_textureTarget = GL_TEXTURE_2D;
+  const GLenum m_textureTarget = GL_TEXTURE_2D;
   float m_clearColor = 0.0f;
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.cpp
@@ -271,10 +271,7 @@ void CRPWinRenderer::RenderInternal(bool clear, uint8_t alpha)
 {
   CRenderSystemDX* renderingDx = static_cast<CRenderSystemDX*>(m_context.Rendering());
 
-  // Set alpha blend state
-  renderingDx->SetAlphaBlendEnable(alpha < 0xFF);
-
-  Render(renderingDx->GetBackBuffer());
+  Render(renderingDx->GetBackBuffer(), alpha);
 }
 
 bool CRPWinRenderer::Supports(RENDERFEATURE feature) const
@@ -295,8 +292,9 @@ bool CRPWinRenderer::SupportsScalingMethod(SCALINGMETHOD method)
   return false;
 }
 
-void CRPWinRenderer::Render(CD3DTexture& target)
+void CRPWinRenderer::Render(CD3DTexture& target, uint8_t alpha)
 {
+  CRenderSystemDX* renderingDx = static_cast<CRenderSystemDX*>(m_context.Rendering());
   const ViewportCoordinates dest{m_rotatedDestCoords};
 
   auto renderBuffer = static_cast<CWinRenderBuffer*>(m_renderBuffer);
@@ -309,24 +307,69 @@ void CRPWinRenderer::Render(CD3DTexture& target)
 
   Updateshaders();
 
+  CD3DTexture* outputTexture = &renderBufferTarget->GetTexture();
+  CRect sourceRect = m_sourceRect;
+
   // Use video shader preset
   if (m_bUseShaderPreset)
   {
-    SHADER::CShaderTextureDXRef targetTexture{target};
+    RenderBufferTextures* rbTextures = nullptr;
 
-    // Render shaders and ouput to display
-    if (!m_shaderPreset->RenderUpdate(dest, {m_fullDestWidth, m_fullDestHeight},
-                                      *renderBufferTarget, targetTexture))
+    // Drop cached textures if target size is changed
+    if (m_fullDestWidth != m_lastTargetWidth || m_fullDestHeight != m_lastTargetHeight)
     {
-      m_bShadersNeedUpdate = false;
-      m_bUseShaderPreset = false;
+      m_RBTexturesMap.clear();
+      m_lastTargetWidth = m_fullDestWidth;
+      m_lastTargetHeight = m_fullDestHeight;
+    }
+
+    const auto it = m_RBTexturesMap.find(renderBuffer);
+    if (it != m_RBTexturesMap.end())
+    {
+      rbTextures = it->second.get();
+    }
+    else
+    {
+      auto presetTargetTexture = std::make_shared<CD3DTexture>();
+      if (!presetTargetTexture->Create(static_cast<UINT>(m_fullDestWidth),
+                                       static_cast<UINT>(m_fullDestHeight), 1, D3D11_USAGE_DEFAULT,
+                                       DXGI_FORMAT_B8G8R8A8_UNORM))
+      {
+        CLog::Log(LOGERROR, "RPWinRenderer: Shader preset target texture creation failed");
+        m_bShadersNeedUpdate = false;
+        m_bUseShaderPreset = false;
+      }
+      else
+      {
+        rbTextures = new RenderBufferTextures{
+            std::make_shared<SHADER::CShaderTextureDX>(std::move(presetTargetTexture))};
+        m_RBTexturesMap.emplace(renderBuffer, rbTextures);
+      }
+    }
+
+    if (m_bUseShaderPreset && rbTextures != nullptr)
+    {
+      std::shared_ptr<SHADER::CShaderTextureDX> presetTarget = rbTextures->targetTexture;
+
+      renderingDx->SetAlphaBlendEnable(false);
+
+      // Render shaders to an intermediate texture. The output shader handles
+      // the final transform and alpha.
+      if (!m_shaderPreset->RenderUpdate(*renderBufferTarget, *presetTarget))
+      {
+        m_bShadersNeedUpdate = false;
+        m_bUseShaderPreset = false;
+      }
+      else
+      {
+        outputTexture = &presetTarget->GetTexture();
+        sourceRect = CRect(0.0f, 0.0f, presetTarget->GetWidth(), presetTarget->GetHeight());
+      }
     }
   }
-  // Use output shader
-  else
-  {
-    CD3DTexture& intermediateTarget = renderBufferTarget->GetTexture();
 
+  // Use output shader
+  {
     CRect viewPort;
     m_context.GetViewPort(viewPort);
 
@@ -339,8 +382,9 @@ void CRPWinRenderer::Render(CD3DTexture& target)
     // Use the picked output shader to render to the target
     if (outputShader != nullptr)
     {
-      outputShader->Render(intermediateTarget, m_sourceRect, dest, viewPort, target,
-                           m_context.UseLimitedColor() ? 1 : 0);
+      renderingDx->SetAlphaBlendEnable(alpha < 0xFF);
+      outputShader->Render(*outputTexture, sourceRect, dest, viewPort, target,
+                           m_context.UseLimitedColor() ? 1 : 0, alpha);
     }
   }
 }

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPWinRenderer.h
@@ -128,12 +128,18 @@ public:
   static const SCALINGMETHOD DEFAULT_SCALING_METHOD = SCALINGMETHOD::NEAREST;
 
 protected:
-  // implementation of CRPBaseRenderer
+  struct RenderBufferTextures
+  {
+    std::shared_ptr<SHADER::CShaderTextureDX> targetTexture;
+  };
+
+  // Implementation of CRPBaseRenderer
   bool ConfigureInternal() override;
   void RenderInternal(bool clear, uint8_t alpha) override;
 
-private:
-  void Render(CD3DTexture& target);
+  void Render(CD3DTexture& target, uint8_t alpha);
+
+  std::map<CWinRenderBuffer*, std::unique_ptr<RenderBufferTextures>> m_RBTexturesMap;
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/shaders/IShader.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShader.h
@@ -11,8 +11,8 @@
 #include "ShaderTypes.h"
 #include "cores/RetroPlayer/RetroPlayerTypes.h"
 
-#include <map>
-#include <stdint.h>
+#include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -58,13 +58,13 @@ public:
   /*!
    * \brief Sets the input and output sizes in pixels
    *
+   * \param nextSize Output image size of the shader in pixels
    * \param prevSize Input image size of the shader in pixels
    * \param prevTextureSize Power-of-two input texture size in pixels
-   * \param nextSize Output image size of the shader in pixels
    */
-  virtual void SetSizes(const float2& prevSize,
-                        const float2& prevTextureSize,
-                        const float2& nextSize) = 0;
+  virtual void SetSizes(const float2& nextSize,
+                        const float2& prevSize = float2{},
+                        const float2& prevTextureSize = float2{}) = 0;
 
   /*!
    * \brief Called before rendering
@@ -72,16 +72,12 @@ public:
    * Updates any internal state needed to ensure that correct data is passed to
    * the shader when rendering.
    *
-   * \param dest Coordinates of the 4 corners of the destination rectangle
-   * \param fullDestSize Destination rectangle size for the fullscreen game window
    * \param sourceTexture Source texture of the first shader pass
    * \param pShaderTextures Intermediate textures used for all shader passes
    * \param pShaders All shader passes
    * \param frameCount Number of frames that have passed
    */
   virtual void PrepareParameters(
-      const RETRO::ViewportCoordinates& dest,
-      const float2 fullDestSize,
       IShaderTexture& sourceTexture,
       const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
       const std::vector<std::unique_ptr<IShader>>& pShaders,

--- a/xbmc/cores/RetroPlayer/shaders/IShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShaderPreset.h
@@ -23,7 +23,6 @@ class IShaderPreset
 public:
   virtual ~IShaderPreset() = default;
 
-  //! @todo Implement once and for all
   /*!
    * \brief Reads/parses a shader preset file and loads its state to the object
    *
@@ -38,17 +37,12 @@ public:
   /*!
    * \brief Updates state if needed and renders the preset to the target texture
    *
-   * \param dest Coordinates of the 4 corners of the destination rectangle
-   * \param fullDestSize Destination rectangle size for the fullscreen game window
    * \param source The source of the video frame, in its original resolution (unscaled)
    * \param target The target texture that the final result will be rendered to
    *
    * \return Returns false if updating or rendering failed, true if both succeeded
    */
-  virtual bool RenderUpdate(const RETRO::ViewportCoordinates& dest,
-                            const float2 fullDestSize,
-                            IShaderTexture& sourceTexture,
-                            IShaderTexture& targetTexture) = 0;
+  virtual bool RenderUpdate(IShaderTexture& sourceTexture, IShaderTexture& targetTexture) = 0;
 
   /*!
    * \brief Informs about the speed of playback

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
@@ -39,42 +39,36 @@ bool CShaderPreset::ReadPresetFile(const std::string& presetPath)
   return CServiceBroker::GetGameServices().VideoShaders().LoadPreset(presetPath, *this);
 }
 
-bool CShaderPreset::RenderUpdate(const RETRO::ViewportCoordinates& dest,
-                                 const float2 fullDestSize,
-                                 IShaderTexture& sourceTexture,
-                                 IShaderTexture& targetTexture)
+bool CShaderPreset::RenderUpdate(IShaderTexture& sourceTexture, IShaderTexture& targetTexture)
 {
   // Save the viewport
   CRect viewPort;
   m_context.GetViewPort(viewPort);
 
-  // Handle resizing of the viewport (window)
-  UpdateViewPort(viewPort, fullDestSize);
+  // Handle target resizing
+  UpdateOutputSize({targetTexture.GetWidth(), targetTexture.GetHeight()});
 
   // Update shaders/shader textures if required
   if (!Update())
     return false;
 
-  PrepareParameters(dest, sourceTexture);
+  PrepareParameters(sourceTexture);
 
-  // Apply all passes except the last one (which needs to be applied to the backbuffer)
+  // Apply all passes
   IShaderTexture* currentTexture = &sourceTexture;
   const auto numPasses = static_cast<unsigned int>(m_pShaders.size());
-  for (unsigned shaderIdx = 0; shaderIdx + 1 < numPasses; ++shaderIdx)
+  for (unsigned shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
     IShader& shader = *m_pShaders[shaderIdx];
-    IShaderTexture& nextTexture = *m_pShaderTextures[shaderIdx];
-    RenderShader(shader, *currentTexture, nextTexture);
-    currentTexture = &nextTexture;
+    IShaderTexture& texture =
+        shaderIdx + 1 == numPasses ? targetTexture : *m_pShaderTextures[shaderIdx];
+    RenderShader(shader, *currentTexture, texture);
+    currentTexture = &texture;
   }
 
   // Restore our viewport
   m_context.SetViewPort(viewPort);
   m_context.SetScissors(viewPort);
-
-  // Apply the last pass and write to target (backbuffer) instead of the last texture
-  IShader* lastShader = m_pShaders.back().get();
-  lastShader->Render(*currentTexture, targetTexture);
 
   m_frameCount += static_cast<float>(m_speed);
   return true;
@@ -101,7 +95,6 @@ bool CShaderPreset::SetShaderPreset(const std::string& shaderPresetPath)
   };
 
   m_presetPath = shaderPresetPath;
-  m_bPresetNeedsUpdate = true;
 
   if (m_presetPath.empty())
     // No preset should load, just return false, we shouldn't add "" to the failed paths
@@ -132,6 +125,7 @@ bool CShaderPreset::SetShaderPreset(const std::string& shaderPresetPath)
   if (m_pShaders.empty())
     return false;
 
+  m_bPresetNeedsUpdate = true;
   return true;
 }
 
@@ -154,24 +148,32 @@ bool CShaderPreset::Update()
   {
     if (!CreateShaderTextures())
       return updateFailed("A shader texture failed to init");
-  }
 
-  // Each pass except the last one must have its own texture and the opposite is also true
-  if (m_pShaders.size() != m_pShaderTextures.size() + 1)
-    return updateFailed("A shader or texture failed to init");
+    // Each pass except the last one must have its own texture and the opposite is also true
+    if (m_pShaders.size() != m_pShaderTextures.size() + 1)
+      return updateFailed("A shader or texture failed to init");
+  }
 
   m_bPresetNeedsUpdate = false;
   return true;
 }
 
-void CShaderPreset::UpdateViewPort(CRect viewPort, const float2 fullDestSize)
+void CShaderPreset::UpdateOutputSize(const float2 outputSize)
 {
-  const float2 currentViewPortSize = {viewPort.Width(), viewPort.Height()};
-  if (currentViewPortSize != m_outputSize || fullDestSize != m_fullDestSize)
+  if (outputSize != m_outputSize)
   {
-    m_outputSize = currentViewPortSize;
-    m_fullDestSize = fullDestSize;
-    m_bPresetNeedsUpdate = true;
+    m_outputSize = outputSize;
+
+    // Notify the last pass of new output size
+    if (!m_pShaders.empty())
+    {
+      m_pShaders.back()->SetSizes(outputSize);
+      m_pShaders.back()->UpdateMVP();
+    }
+
+    // If intermediate textures depend on output size, full update is needed
+    if (m_bTexturesNeedSizeUpdate)
+      m_bPresetNeedsUpdate = true;
   }
 }
 
@@ -181,16 +183,15 @@ void CShaderPreset::UpdateMVPs()
     videoShader->UpdateMVP();
 }
 
-void CShaderPreset::PrepareParameters(const RETRO::ViewportCoordinates& dest,
-                                      IShaderTexture& sourceTexture)
+void CShaderPreset::PrepareParameters(IShaderTexture& sourceTexture)
 {
   // Prepare parameters for all shader passes
   const auto numPasses = static_cast<unsigned int>(m_pShaders.size());
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
     std::unique_ptr<IShader>& videoShader = m_pShaders[shaderIdx];
-    videoShader->PrepareParameters(dest, m_fullDestSize, sourceTexture, m_pShaderTextures,
-                                   m_pShaders, static_cast<uint64_t>(m_frameCount));
+    videoShader->PrepareParameters(sourceTexture, m_pShaderTextures, m_pShaders,
+                                   static_cast<uint64_t>(m_frameCount));
   }
 }
 
@@ -204,8 +205,9 @@ void CShaderPreset::CalculateScaledSize(const KODI::SHADER::ShaderPass& pass,
       scaledSize.x = static_cast<float>(pass.fbo.scaleX.abs);
       break;
     case ScaleType::VIEWPORT:
-      scaledSize.x = pass.fbo.scaleX.scale != 0.0f ? pass.fbo.scaleX.scale * m_fullDestSize.x
-                                                   : m_fullDestSize.x;
+      scaledSize.x =
+          pass.fbo.scaleX.scale != 0.0f ? pass.fbo.scaleX.scale * m_outputSize.x : m_outputSize.x;
+      m_bTexturesNeedSizeUpdate = true;
       break;
     case ScaleType::INPUT:
     default:
@@ -220,8 +222,9 @@ void CShaderPreset::CalculateScaledSize(const KODI::SHADER::ShaderPass& pass,
       scaledSize.y = static_cast<float>(pass.fbo.scaleY.abs);
       break;
     case ScaleType::VIEWPORT:
-      scaledSize.y = pass.fbo.scaleY.scale != 0.0f ? pass.fbo.scaleY.scale * m_fullDestSize.y
-                                                   : m_fullDestSize.y;
+      scaledSize.y =
+          pass.fbo.scaleY.scale != 0.0f ? pass.fbo.scaleY.scale * m_outputSize.y : m_outputSize.y;
+      m_bTexturesNeedSizeUpdate = true;
       break;
     case ScaleType::INPUT:
     default:

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
@@ -40,10 +40,7 @@ public:
 
   // Implementation of IShaderPreset
   bool ReadPresetFile(const std::string& presetPath) override;
-  bool RenderUpdate(const RETRO::ViewportCoordinates& dest,
-                    const float2 fullDestSize,
-                    IShaderTexture& sourceTexture,
-                    IShaderTexture& targetTexture) override;
+  bool RenderUpdate(IShaderTexture& sourceTexture, IShaderTexture& targetTexture) override;
   void SetSpeed(double speed) override { m_speed = speed; }
   void SetVideoSize(unsigned int videoWidth, unsigned int videoHeight) override;
   bool SetShaderPreset(const std::string& shaderPresetPath) override;
@@ -63,9 +60,9 @@ protected:
 
   // Helper functions
   bool Update();
-  void UpdateViewPort(CRect viewPort, const float2 fullDestSize);
+  void UpdateOutputSize(const float2 outputSize);
   void UpdateMVPs();
-  void PrepareParameters(const RETRO::ViewportCoordinates& dest, IShaderTexture& sourceTexture);
+  void PrepareParameters(IShaderTexture& sourceTexture);
   void CalculateScaledSize(const KODI::SHADER::ShaderPass& pass,
                            const float2& prevSize,
                            float2& scaledSize);
@@ -98,11 +95,11 @@ protected:
   // Was the shader preset changed during the last frame?
   bool m_bPresetNeedsUpdate = true;
 
-  // Resolution of the output viewport
-  float2 m_outputSize;
+  // Do we need to update the intermediate shader textures when the output size is changed?
+  bool m_bTexturesNeedSizeUpdate = false;
 
-  // Resolution of the destination rectangle for the fullscreen game window
-  float2 m_fullDestSize;
+  // Resolution of the output
+  float2 m_outputSize;
 
   // Size of the actual source video data (ie. 160x144 for the Game Boy)
   float2 m_videoSize;

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -9,6 +9,7 @@
 #include "ShaderGL.h"
 
 #include "ShaderTextureGL.h"
+#include "ShaderTextureGLRef.h"
 #include "ShaderUtilsGL.h"
 #include "application/Application.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
@@ -24,7 +25,7 @@ CShaderGL::CShaderGL() = default;
 
 CShaderGL::~CShaderGL()
 {
-  Destroy();
+  Delete();
 }
 
 bool CShaderGL::Create(unsigned int passIdx,
@@ -160,11 +161,11 @@ bool CShaderGL::Create(unsigned int passIdx,
 
 void CShaderGL::Render(IShaderTexture& sourceTexture, IShaderTexture& targetTexture)
 {
-  auto& sourceGL = static_cast<CShaderTextureGL&>(sourceTexture);
+  glDisable(GL_BLEND);
 
   glUseProgram(m_shaderProgram);
 
-  SetShaderParameters(sourceGL);
+  SetShaderParameters(sourceTexture);
 
   glBindVertexArray(m_shaderVAO);
 
@@ -185,59 +186,40 @@ void CShaderGL::Render(IShaderTexture& sourceTexture, IShaderTexture& targetText
   glUseProgram(0);
 }
 
-void CShaderGL::SetSizes(const float2& prevSize,
-                         const float2& prevTextureSize,
-                         const float2& nextSize)
+void CShaderGL::SetSizes(const float2& nextSize,
+                         const float2& prevSize,
+                         const float2& prevTextureSize)
 {
-  m_inputSize = prevSize;
-  m_inputTextureSize = prevTextureSize;
   m_outputSize = nextSize;
+
+  if (prevSize.x > 0 && prevSize.y > 0)
+    m_inputSize = prevSize;
+
+  if (prevTextureSize.x > 0 && prevTextureSize.y > 0)
+    m_inputTextureSize = prevTextureSize;
 }
 
 void CShaderGL::PrepareParameters(
-    const RETRO::ViewportCoordinates& dest,
-    const float2 fullDestSize,
     IShaderTexture& sourceTexture,
     const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
     const std::vector<std::unique_ptr<IShader>>& pShaders,
     uint64_t frameCount)
 {
-  if (m_passIdx + 1 != pShaders.size()) // Not last pass
-  {
-    // bottom left x,y
-    m_VertexCoords[0][0] = -m_outputSize.x / 2;
-    m_VertexCoords[0][1] = -m_outputSize.y / 2;
-    // bottom right x,y
-    m_VertexCoords[1][0] = m_outputSize.x / 2;
-    m_VertexCoords[1][1] = -m_outputSize.y / 2;
-    // top right x,y
-    m_VertexCoords[2][0] = m_outputSize.x / 2;
-    m_VertexCoords[2][1] = m_outputSize.y / 2;
-    // top left x,y
-    m_VertexCoords[3][0] = -m_outputSize.x / 2;
-    m_VertexCoords[3][1] = m_outputSize.y / 2;
+  // Set destination rectangle size
+  m_destSize = m_outputSize;
 
-    // Set destination rectangle size
-    m_destSize = m_outputSize;
-  }
-  else // Last pass
-  {
-    // bottom left x,y
-    m_VertexCoords[0][0] = dest[3].x - m_outputSize.x / 2;
-    m_VertexCoords[0][1] = dest[3].y - m_outputSize.y / 2;
-    // bottom right x,y
-    m_VertexCoords[1][0] = dest[2].x - m_outputSize.x / 2;
-    m_VertexCoords[1][1] = dest[2].y - m_outputSize.y / 2;
-    // top right x,y
-    m_VertexCoords[2][0] = dest[1].x - m_outputSize.x / 2;
-    m_VertexCoords[2][1] = dest[1].y - m_outputSize.y / 2;
-    // top left x,y
-    m_VertexCoords[3][0] = dest[0].x - m_outputSize.x / 2;
-    m_VertexCoords[3][1] = dest[0].y - m_outputSize.y / 2;
-
-    // Set destination rectangle size for the last pass
-    m_destSize = fullDestSize;
-  }
+  // bottom left x,y
+  m_VertexCoords[0][0] = -m_outputSize.x / 2;
+  m_VertexCoords[0][1] = -m_outputSize.y / 2;
+  // bottom right x,y
+  m_VertexCoords[1][0] = m_outputSize.x / 2;
+  m_VertexCoords[1][1] = -m_outputSize.y / 2;
+  // top right x,y
+  m_VertexCoords[2][0] = m_outputSize.x / 2;
+  m_VertexCoords[2][1] = m_outputSize.y / 2;
+  // top left x,y
+  m_VertexCoords[3][0] = -m_outputSize.x / 2;
+  m_VertexCoords[3][1] = m_outputSize.y / 2;
 
   // bottom left z, tu, tv, r, g, b
   m_VertexCoords[0][2] = 0;
@@ -280,17 +262,16 @@ void CShaderGL::UpdateMVP()
   m_MVP = {{{xScale, 0, 0, 0}, {0, yScale, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}};
 }
 
-void CShaderGL::Destroy()
+void CShaderGL::Delete()
 {
   glDeleteProgram(m_shaderProgram);
   m_shaderProgram = 0;
 
   glDeleteBuffers(1, &m_shaderIndexVBO);
   glDeleteBuffers(3, m_shaderVertexVBO.data());
+  glDeleteVertexArrays(1, &m_shaderVAO);
   m_shaderIndexVBO = 0;
   m_shaderVertexVBO = {0, 0, 0};
-
-  glDeleteVertexArrays(1, &m_shaderVAO);
   m_shaderVAO = 0;
 }
 
@@ -304,13 +285,13 @@ void CShaderGL::UpdateUniformInputs(
 
   if (m_passIdx > 0) // Not first pass
   {
-    auto& shaderTextureGL = static_cast<CShaderTextureGL&>(*pShaderTextures[m_passIdx - 1]);
-    m_uniformFrameInputs = GetFrameInputData(shaderTextureGL.GetTextureID());
+    auto& sourceGL = static_cast<CShaderTextureGL&>(*pShaderTextures[m_passIdx - 1]);
+    m_uniformFrameInputs = GetFrameInputData(sourceGL.GetTextureID());
   }
   else // First pass
   {
-    auto& shaderTextureGL = static_cast<CShaderTextureGL&>(sourceTexture);
-    m_uniformFrameInputs = GetFrameInputData(shaderTextureGL.GetTextureID());
+    auto& sourceGLRef = static_cast<CShaderTextureGLRef&>(sourceTexture);
+    m_uniformFrameInputs = GetFrameInputData(sourceGLRef.GetTextureID());
   }
 
   // Set frame uniforms of previous passes
@@ -338,6 +319,7 @@ CShaderGL::UniformInputs CShaderGL::GetInputData(uint64_t frameCount) const
       // Time always flows forward
       1 // frame_direction
   };
+
   return input;
 }
 
@@ -349,6 +331,7 @@ CShaderGL::UniformFrameInputs CShaderGL::GetFrameInputData(GLuint texture) const
       texture, // texture
       m_passAlias // alias
   };
+
   return frameInput;
 }
 
@@ -362,7 +345,7 @@ void CShaderGL::GetUniformLocs()
   m_MVPMatrixLoc = glGetUniformLocation(m_shaderProgram, "MVPMatrix");
 }
 
-void CShaderGL::SetShaderParameters(CShaderTextureGL& sourceTexture)
+void CShaderGL::SetShaderParameters(IShaderTexture& sourceTexture)
 {
   // Set shader uniforms
   glUniform1i(m_FrameDirectionLoc, m_uniformInputs.frame_direction);
@@ -381,12 +364,25 @@ void CShaderGL::SetShaderParameters(CShaderTextureGL& sourceTexture)
 
   // Set source texture
   unsigned int textureUnit = 0;
-  sourceTexture.BindToUnit(textureUnit);
-  textureUnit++;
 
-  // Regenerate source texture mipmaps
-  if (sourceTexture.IsMipmapped())
-    glGenerateMipmap(GL_TEXTURE_2D);
+  //! @todo Handle ref textures better
+  auto* sourceGL = dynamic_cast<CShaderTextureGL*>(&sourceTexture);
+  auto* sourceGLRef = dynamic_cast<CShaderTextureGLRef*>(&sourceTexture);
+
+  if (sourceGL != nullptr)
+  {
+    sourceGL->BindToUnit(textureUnit);
+    textureUnit++;
+
+    // Regenerate source texture mipmaps
+    if (sourceGL->IsMipmapped())
+      glGenerateMipmap(GL_TEXTURE_2D);
+  }
+  else if (sourceGLRef != nullptr)
+  {
+    sourceGLRef->BindToUnit(textureUnit);
+    textureUnit++;
+  }
 
   // Set lookup textures
   for (const std::shared_ptr<IShaderLut>& lut : m_luts)
@@ -405,7 +401,6 @@ void CShaderGL::SetShaderParameters(CShaderTextureGL& sourceTexture)
   for (unsigned int i = 0; i < m_passIdx + 1; ++i)
   {
     GLint paramLoc;
-
     std::string paramPass = i ? "Pass" + std::to_string(i) : "Orig";
     paramLoc = glGetUniformLocation(m_shaderProgram, (paramPass + "InputSize").c_str());
     glUniform2f(paramLoc, m_passesUniformFrameInputs[i].input_size.x,

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -39,19 +39,17 @@ public:
               std::vector<std::shared_ptr<IShaderLut>> luts,
               unsigned int frameCountMod = 0) override;
   void Render(IShaderTexture& sourceTexture, IShaderTexture& targetTexture) override;
-  void SetSizes(const float2& prevSize,
-                const float2& prevTextureSize,
-                const float2& nextSize) override;
-  void PrepareParameters(const RETRO::ViewportCoordinates& dest,
-                         const float2 fullDestSize,
-                         IShaderTexture& sourceTexture,
+  void SetSizes(const float2& nextSize,
+                const float2& prevSize = float2{},
+                const float2& prevTextureSize = float2{}) override;
+  void PrepareParameters(IShaderTexture& sourceTexture,
                          const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
                          const std::vector<std::unique_ptr<IShader>>& pShaders,
                          uint64_t frameCount) override;
   void UpdateMVP() override;
 
   // OpenGL interface
-  void Destroy();
+  void Delete();
 
 private:
   struct UniformInputs
@@ -79,7 +77,7 @@ private:
   UniformFrameInputs GetFrameInputData(GLuint texture) const;
   UniformFrameInputs GetFrameUniformInputs() const { return m_uniformFrameInputs; }
   void GetUniformLocs();
-  void SetShaderParameters(CShaderTextureGL& sourceTexture);
+  void SetShaderParameters(IShaderTexture& sourceTexture);
 
   // Index of the video shader pass in the preset
   unsigned int m_passIdx{0};

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderLutGL.cpp
@@ -57,13 +57,11 @@ std::unique_ptr<CTexture> CShaderLutGL::CreateLUTTexture(const ShaderLut& lut)
   textureGL->LoadToGPU();
 
   const GLint wrapType = CShaderUtilsGL::TranslateWrapType(lut.wrapType);
+  const GLfloat blackBorder[4] = {0.0f, 0.0f, 0.0f, 0.0f};
 
   glBindTexture(GL_TEXTURE_2D, textureGL->GetTextureID());
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrapType);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrapType);
-
-  const GLfloat blackBorder[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-
   glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, blackBorder);
 
   return texture;

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
@@ -73,6 +73,8 @@ bool CShaderPresetGL::CreateShaderTextures()
 {
   DisposeShaderTextures();
 
+  m_bTexturesNeedSizeUpdate = false;
+
   unsigned int major{0};
   unsigned int minor{0};
   CServiceBroker::GetRenderSystem()->GetRenderVersion(major, minor);
@@ -116,10 +118,38 @@ bool CShaderPresetGL::CreateShaderTextures()
     }
     else
     {
-      auto shaderTextureGL = std::make_unique<CShaderTextureGL>(
-          static_cast<unsigned int>(textureSize.x), static_cast<unsigned int>(textureSize.y));
+      // Determine the framebuffer data format
+      GLuint pixelType;
+      GLint internalFormat;
+      GLenum pixelFormat;
+      if (pass.fbo.floatFramebuffer && major >= 3)
+      {
+        // Give priority to float framebuffer parameter (we can't use both float and sRGB)
+        pixelType = GL_FLOAT;
+        internalFormat = GL_RGBA32F;
+        pixelFormat = GL_RGBA;
+      }
+      else
+      {
+        if (pass.fbo.sRgbFramebuffer && major >= 3)
+        {
+          pixelType = GL_UNSIGNED_BYTE;
+          internalFormat = GL_SRGB8_ALPHA8;
+          pixelFormat = GL_RGBA;
+        }
+        else
+        {
+          pixelType = GL_UNSIGNED_BYTE;
+          internalFormat = GL_RGBA8;
+          pixelFormat = GL_BGRA;
+        }
+      }
 
-      shaderTextureGL->CreateTextureObject(); // Create new internal texture
+      auto shaderTextureGL = std::make_unique<CShaderTextureGL>(
+          static_cast<unsigned int>(textureSize.x), static_cast<unsigned int>(textureSize.y),
+          pixelType, internalFormat, pixelFormat, true);
+
+      shaderTextureGL->CreateTexture(); // Create new internal texture
 
       const ShaderPass& nextPass = m_passes[shaderIdx + 1];
 
@@ -130,56 +160,28 @@ bool CShaderPresetGL::CreateShaderTextures()
         shaderTextureGL->SetMipmapping();
 
       const GLint wrapType = CShaderUtilsGL::TranslateWrapType(nextPass.wrapType);
-
       const GLuint magFilterType =
           (nextPass.filterType == FilterType::LINEAR ? GL_LINEAR : GL_NEAREST);
-
       const GLuint minFilterType =
           (nextPass.mipmap ? (nextPass.filterType == FilterType::LINEAR ? GL_LINEAR_MIPMAP_LINEAR
                                                                         : GL_NEAREST_MIPMAP_NEAREST)
                            : magFilterType);
+      const GLfloat blackBorder[4] = {0.0f, 0.0f, 0.0f, 0.0f};
 
       glBindTexture(GL_TEXTURE_2D, shaderTextureGL->GetTextureID());
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, magFilterType);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, minFilterType);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrapType);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrapType);
-
-      // Determine the framebuffer data format
-      GLint internalFormat;
-      GLenum pixelFormat;
-      if (pass.fbo.floatFramebuffer && major >= 3)
-      {
-        // Give priority to float framebuffer parameter (we can't use both float and sRGB)
-        internalFormat = GL_RGBA32F;
-        pixelFormat = GL_RGBA;
-      }
-      else
-      {
-        if (pass.fbo.sRgbFramebuffer && major >= 3)
-        {
-          internalFormat = GL_SRGB8_ALPHA8;
-          pixelFormat = GL_RGBA;
-        }
-        else
-        {
-          internalFormat = GL_RGBA8;
-          pixelFormat = GL_BGRA;
-        }
-      }
-
-      glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, textureSize.x, textureSize.y, 0, pixelFormat,
-                   internalFormat == GL_RGBA32F ? GL_FLOAT : GL_UNSIGNED_BYTE, nullptr);
-
-      const GLfloat blackBorder[4] = {0.0f, 0.0f, 0.0f, 0.0f};
-
       glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, blackBorder);
+
+      glBindTexture(GL_TEXTURE_2D, 0);
 
       m_pShaderTextures.emplace_back(std::move(shaderTextureGL));
     }
 
-    // Notify shader of its source and dest size
-    m_pShaders[shaderIdx]->SetSizes(prevSize, prevTextureSize, scaledSize);
+    // Notify shader of its target and source sizes
+    m_pShaders[shaderIdx]->SetSizes(scaledSize, prevSize, prevTextureSize);
 
     prevSize = scaledSize;
     prevTextureSize = textureSize;
@@ -196,11 +198,17 @@ void CShaderPresetGL::RenderShader(IShader& shader,
   if (static_cast<CShaderTextureGL&>(targetTexture).BindFBO())
   {
     const CRect newViewPort(0.f, 0.f, targetTexture.GetWidth(), targetTexture.GetHeight());
+
     glViewport((GLsizei)newViewPort.x1, (GLsizei)newViewPort.y1, (GLsizei)newViewPort.x2,
                (GLsizei)newViewPort.y2);
     glScissor((GLsizei)newViewPort.x1, (GLsizei)newViewPort.y1, (GLsizei)newViewPort.x2,
               (GLsizei)newViewPort.y2);
+
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
     shader.Render(sourceTexture, targetTexture);
+
     static_cast<CShaderTextureGL&>(targetTexture).UnbindFBO();
   }
 }

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.cpp
@@ -10,20 +10,27 @@
 
 #include "utils/log.h"
 
-#include <cassert>
-
 using namespace KODI::SHADER;
 
-CShaderTextureGL::CShaderTextureGL(uint32_t textureWidth, uint32_t textureHeight)
+CShaderTextureGL::CShaderTextureGL(uint32_t textureWidth,
+                                   uint32_t textureHeight,
+                                   GLuint pixelType,
+                                   GLuint internalFormat,
+                                   GLuint pixelFormat,
+                                   bool bUseAlpha)
   : m_textureWidth(textureWidth),
-    m_textureHeight(textureHeight)
+    m_textureHeight(textureHeight),
+    m_pixelType(pixelType),
+    m_internalFormat(internalFormat),
+    m_pixelFormat(pixelFormat),
+    m_useAlpha(bUseAlpha)
 {
 }
 
 CShaderTextureGL::~CShaderTextureGL()
 {
-  DestroyFBO();
-  DestroyTextureObject();
+  DeleteFBO();
+  DeleteTexture();
 }
 
 float CShaderTextureGL::GetWidth() const
@@ -36,12 +43,27 @@ float CShaderTextureGL::GetHeight() const
   return static_cast<float>(m_textureHeight);
 }
 
-void CShaderTextureGL::CreateTextureObject()
+void CShaderTextureGL::CreateTexture()
 {
   glGenTextures(1, &m_texture);
+
+  glBindTexture(m_textureTarget, m_texture);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  // Force alpha to 1, because shader can leave it undefined
+  if (!m_useAlpha && m_internalFormat == GL_RGBA8)
+    glTexParameteri(m_textureTarget, GL_TEXTURE_SWIZZLE_A, GL_ONE);
+
+  glTexImage2D(m_textureTarget, 0, m_internalFormat, m_textureWidth, m_textureHeight, 0,
+               m_pixelFormat, m_pixelType, nullptr);
+
+  glBindTexture(m_textureTarget, 0);
 }
 
-void CShaderTextureGL::DestroyTextureObject()
+void CShaderTextureGL::DeleteTexture()
 {
   if (m_texture != 0)
     glDeleteTextures(1, &m_texture);
@@ -61,7 +83,7 @@ void CShaderTextureGL::CreateFBO()
     glGenFramebuffers(1, &m_FBO);
 }
 
-void CShaderTextureGL::DestroyFBO()
+void CShaderTextureGL::DeleteFBO()
 {
   if (m_FBO != 0)
     glDeleteFramebuffers(1, &m_FBO);
@@ -79,6 +101,7 @@ bool CShaderTextureGL::BindFBO()
 
   glBindFramebuffer(GL_FRAMEBUFFER, m_FBO);
   glBindTexture(GL_TEXTURE_2D, m_texture);
+
   glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0);
 
   if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGL.h
@@ -10,8 +10,6 @@
 
 #include "cores/RetroPlayer/shaders/IShaderTexture.h"
 
-#include <memory>
-
 #include "system_gl.h"
 
 namespace KODI::SHADER
@@ -20,7 +18,12 @@ namespace KODI::SHADER
 class CShaderTextureGL : public IShaderTexture
 {
 public:
-  CShaderTextureGL(uint32_t textureWidth, uint32_t textureHeight);
+  CShaderTextureGL(uint32_t textureWidth,
+                   uint32_t textureHeight,
+                   GLuint pixelType,
+                   GLuint internalFormat,
+                   GLuint pixelFormat,
+                   bool bUseAlpha);
   ~CShaderTextureGL() override;
 
   // Disallow copy and move (this object owns raw GL IDs)
@@ -34,8 +37,8 @@ public:
   float GetHeight() const override;
 
   // OpenGL interface
-  void CreateTextureObject();
-  void DestroyTextureObject();
+  void CreateTexture();
+  void DeleteTexture();
   void BindToUnit(unsigned int unit);
   GLuint GetTextureID() const { return m_texture; }
 
@@ -47,13 +50,20 @@ public:
 
   // Frame buffer interface
   void CreateFBO();
-  void DestroyFBO();
+  void DeleteFBO();
   bool BindFBO();
   void UnbindFBO() const;
 
 private:
-  uint32_t m_textureWidth{0};
-  uint32_t m_textureHeight{0};
+  // Construction parameters
+  const uint32_t m_textureWidth;
+  const uint32_t m_textureHeight;
+  const GLuint m_pixelType;
+  const GLuint m_internalFormat;
+  const GLuint m_pixelFormat;
+  const bool m_useAlpha;
+
+  const GLenum m_textureTarget = GL_TEXTURE_2D; //! @todo
   GLuint m_texture{0};
   GLuint m_FBO{0};
   bool m_sRgbFramebuffer{false};

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGLRef.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderTextureGLRef.h
@@ -35,8 +35,8 @@ public:
   GLuint GetTextureID() const { return m_texture; }
 
 private:
-  uint32_t m_textureWidth{0};
-  uint32_t m_textureHeight{0};
+  const uint32_t m_textureWidth;
+  const uint32_t m_textureHeight;
   GLuint m_texture{0};
 };
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
@@ -9,6 +9,7 @@
 #include "ShaderGLES.h"
 
 #include "ShaderTextureGLES.h"
+#include "ShaderTextureGLESRef.h"
 #include "ShaderUtilsGLES.h"
 #include "application/Application.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
@@ -24,7 +25,7 @@ CShaderGLES::CShaderGLES() = default;
 
 CShaderGLES::~CShaderGLES()
 {
-  Destroy();
+  Delete();
 }
 
 bool CShaderGLES::Create(unsigned int passIdx,
@@ -142,11 +143,11 @@ bool CShaderGLES::Create(unsigned int passIdx,
 
 void CShaderGLES::Render(IShaderTexture& sourceTexture, IShaderTexture& targetTexture)
 {
-  auto& sourceGL = static_cast<CShaderTextureGLES&>(sourceTexture);
+  glDisable(GL_BLEND);
 
   glUseProgram(m_shaderProgram);
 
-  SetShaderParameters(sourceGL);
+  SetShaderParameters(sourceTexture);
 
   glBindBuffer(GL_ARRAY_BUFFER, m_shaderVertexVBO[0]);
   glBufferData(GL_ARRAY_BUFFER, sizeof(m_VertexCoords), m_VertexCoords.data(), GL_DYNAMIC_DRAW);
@@ -180,59 +181,40 @@ void CShaderGLES::Render(IShaderTexture& sourceTexture, IShaderTexture& targetTe
   glUseProgram(0);
 }
 
-void CShaderGLES::SetSizes(const float2& prevSize,
-                           const float2& prevTextureSize,
-                           const float2& nextSize)
+void CShaderGLES::SetSizes(const float2& nextSize,
+                           const float2& prevSize,
+                           const float2& prevTextureSize)
 {
-  m_inputSize = prevSize;
-  m_inputTextureSize = prevTextureSize;
   m_outputSize = nextSize;
+
+  if (prevSize.x > 0 && prevSize.y > 0)
+    m_inputSize = prevSize;
+
+  if (prevTextureSize.x > 0 && prevTextureSize.y > 0)
+    m_inputTextureSize = prevTextureSize;
 }
 
 void CShaderGLES::PrepareParameters(
-    const RETRO::ViewportCoordinates& dest,
-    const float2 fullDestSize,
     IShaderTexture& sourceTexture,
     const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
     const std::vector<std::unique_ptr<IShader>>& pShaders,
     uint64_t frameCount)
 {
-  if (m_passIdx + 1 != pShaders.size()) // Not last pass
-  {
-    // bottom left x,y
-    m_VertexCoords[0][0] = -m_outputSize.x / 2;
-    m_VertexCoords[0][1] = -m_outputSize.y / 2;
-    // bottom right x,y
-    m_VertexCoords[1][0] = m_outputSize.x / 2;
-    m_VertexCoords[1][1] = -m_outputSize.y / 2;
-    // top right x,y
-    m_VertexCoords[2][0] = m_outputSize.x / 2;
-    m_VertexCoords[2][1] = m_outputSize.y / 2;
-    // top left x,y
-    m_VertexCoords[3][0] = -m_outputSize.x / 2;
-    m_VertexCoords[3][1] = m_outputSize.y / 2;
+  // Set destination rectangle size
+  m_destSize = m_outputSize;
 
-    // Set destination rectangle size
-    m_destSize = m_outputSize;
-  }
-  else // Last pass
-  {
-    // bottom left x,y
-    m_VertexCoords[0][0] = dest[3].x - m_outputSize.x / 2;
-    m_VertexCoords[0][1] = dest[3].y - m_outputSize.y / 2;
-    // bottom right x,y
-    m_VertexCoords[1][0] = dest[2].x - m_outputSize.x / 2;
-    m_VertexCoords[1][1] = dest[2].y - m_outputSize.y / 2;
-    // top right x,y
-    m_VertexCoords[2][0] = dest[1].x - m_outputSize.x / 2;
-    m_VertexCoords[2][1] = dest[1].y - m_outputSize.y / 2;
-    // top left x,y
-    m_VertexCoords[3][0] = dest[0].x - m_outputSize.x / 2;
-    m_VertexCoords[3][1] = dest[0].y - m_outputSize.y / 2;
-
-    // Set destination rectangle size for the last pass
-    m_destSize = fullDestSize;
-  }
+  // bottom left x,y
+  m_VertexCoords[0][0] = -m_outputSize.x / 2;
+  m_VertexCoords[0][1] = -m_outputSize.y / 2;
+  // bottom right x,y
+  m_VertexCoords[1][0] = m_outputSize.x / 2;
+  m_VertexCoords[1][1] = -m_outputSize.y / 2;
+  // top right x,y
+  m_VertexCoords[2][0] = m_outputSize.x / 2;
+  m_VertexCoords[2][1] = m_outputSize.y / 2;
+  // top left x,y
+  m_VertexCoords[3][0] = -m_outputSize.x / 2;
+  m_VertexCoords[3][1] = m_outputSize.y / 2;
 
   // bottom left z, tu, tv, r, g, b
   m_VertexCoords[0][2] = 0;
@@ -275,7 +257,7 @@ void CShaderGLES::UpdateMVP()
   m_MVP = {{{xScale, 0, 0, 0}, {0, yScale, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}};
 }
 
-void CShaderGLES::Destroy()
+void CShaderGLES::Delete()
 {
   glDeleteProgram(m_shaderProgram);
   m_shaderProgram = 0;
@@ -296,13 +278,13 @@ void CShaderGLES::UpdateUniformInputs(
 
   if (m_passIdx > 0) // Not first pass
   {
-    auto& shaderTextureGL = static_cast<CShaderTextureGLES&>(*pShaderTextures[m_passIdx - 1]);
-    m_uniformFrameInputs = GetFrameInputData(shaderTextureGL.GetTextureID());
+    auto& sourceGL = static_cast<CShaderTextureGLES&>(*pShaderTextures[m_passIdx - 1]);
+    m_uniformFrameInputs = GetFrameInputData(sourceGL.GetTextureID());
   }
   else // First pass
   {
-    auto& sourceTextureGL = static_cast<CShaderTextureGLES&>(sourceTexture);
-    m_uniformFrameInputs = GetFrameInputData(sourceTextureGL.GetTextureID());
+    auto& sourceGLRef = static_cast<CShaderTextureGLESRef&>(sourceTexture);
+    m_uniformFrameInputs = GetFrameInputData(sourceGLRef.GetTextureID());
   }
 
   // Set frame uniforms of previous passes
@@ -356,7 +338,7 @@ void CShaderGLES::GetUniformLocs()
   m_MVPMatrixLoc = glGetUniformLocation(m_shaderProgram, "MVPMatrix");
 }
 
-void CShaderGLES::SetShaderParameters(CShaderTextureGLES& sourceTexture)
+void CShaderGLES::SetShaderParameters(IShaderTexture& sourceTexture)
 {
   // Set shader uniforms
   glUniform1i(m_FrameDirectionLoc, m_uniformInputs.frame_direction);
@@ -375,12 +357,25 @@ void CShaderGLES::SetShaderParameters(CShaderTextureGLES& sourceTexture)
 
   // Set source texture
   unsigned int textureUnit = 0;
-  sourceTexture.BindToUnit(textureUnit);
-  textureUnit++;
 
-  // Regenerate source texture mipmaps
-  if (sourceTexture.IsMipmapped())
-    glGenerateMipmap(GL_TEXTURE_2D);
+  //! @todo Handle ref textures better
+  auto* sourceGL = dynamic_cast<CShaderTextureGLES*>(&sourceTexture);
+  auto* sourceGLRef = dynamic_cast<CShaderTextureGLESRef*>(&sourceTexture);
+
+  if (sourceGL != nullptr)
+  {
+    sourceGL->BindToUnit(textureUnit);
+    textureUnit++;
+
+    // Regenerate source texture mipmaps
+    if (sourceGL->IsMipmapped())
+      glGenerateMipmap(GL_TEXTURE_2D);
+  }
+  else if (sourceGLRef != nullptr)
+  {
+    sourceGLRef->BindToUnit(textureUnit);
+    textureUnit++;
+  }
 
   // Set lookup textures
   for (const std::shared_ptr<IShaderLut>& lut : m_luts)

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
@@ -39,19 +39,17 @@ public:
               std::vector<std::shared_ptr<IShaderLut>> luts,
               unsigned int frameCountMod = 0) override;
   void Render(IShaderTexture& sourceTexture, IShaderTexture& targetTexture) override;
-  void SetSizes(const float2& prevSize,
-                const float2& prevTextureSize,
-                const float2& nextSize) override;
-  void PrepareParameters(const RETRO::ViewportCoordinates& dest,
-                         const float2 fullDestSize,
-                         IShaderTexture& sourceTexture,
+  void SetSizes(const float2& nextSize,
+                const float2& prevSize = float2{},
+                const float2& prevTextureSize = float2{}) override;
+  void PrepareParameters(IShaderTexture& sourceTexture,
                          const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
                          const std::vector<std::unique_ptr<IShader>>& pShaders,
                          uint64_t frameCount) override;
   void UpdateMVP() override;
 
   // OpenGL interface
-  void Destroy();
+  void Delete();
 
 private:
   struct UniformInputs
@@ -79,7 +77,7 @@ private:
   UniformFrameInputs GetFrameInputData(GLuint texture) const;
   UniformFrameInputs GetFrameUniformInputs() const { return m_uniformFrameInputs; }
   void GetUniformLocs();
-  void SetShaderParameters(CShaderTextureGLES& sourceTexture);
+  void SetShaderParameters(IShaderTexture& sourceTexture);
 
   // Index of the video shader pass in the preset
   unsigned int m_passIdx{0};

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
@@ -73,6 +73,8 @@ bool CShaderPresetGLES::CreateShaderTextures()
 {
   DisposeShaderTextures();
 
+  m_bTexturesNeedSizeUpdate = false;
+
   unsigned int major{0};
   unsigned int minor{0};
   CServiceBroker::GetRenderSystem()->GetRenderVersion(major, minor);
@@ -116,10 +118,38 @@ bool CShaderPresetGLES::CreateShaderTextures()
     }
     else
     {
-      auto shaderTextureGLES = std::make_unique<CShaderTextureGLES>(
-          static_cast<unsigned int>(textureSize.x), static_cast<unsigned int>(textureSize.y));
+      // Determine the framebuffer data format
+      GLuint pixelType;
+      GLint internalFormat;
+      GLenum pixelFormat;
+      if (pass.fbo.floatFramebuffer && major >= 3)
+      {
+        // Give priority to float framebuffer parameter (we can't use both float and sRGB)
+        pixelType = GL_FLOAT;
+        internalFormat = GL_RGBA32F;
+        pixelFormat = GL_RGBA;
+      }
+      else
+      {
+        if (pass.fbo.sRgbFramebuffer && major >= 3)
+        {
+          pixelType = GL_UNSIGNED_BYTE;
+          internalFormat = GL_SRGB8_ALPHA8;
+          pixelFormat = GL_RGBA;
+        }
+        else
+        {
+          pixelType = GL_UNSIGNED_BYTE;
+          internalFormat = GL_RGBA;
+          pixelFormat = GL_RGBA;
+        }
+      }
 
-      shaderTextureGLES->CreateTextureObject(); // Create new internal texture
+      auto shaderTextureGLES = std::make_unique<CShaderTextureGLES>(
+          static_cast<unsigned int>(textureSize.x), static_cast<unsigned int>(textureSize.y),
+          pixelType, internalFormat, pixelFormat, true);
+
+      shaderTextureGLES->CreateTexture(); // Create new internal texture
 
       const ShaderPass& nextPass = m_passes[shaderIdx + 1];
 
@@ -130,10 +160,8 @@ bool CShaderPresetGLES::CreateShaderTextures()
         shaderTextureGLES->SetMipmapping();
 
       const GLint wrapType = CShaderUtilsGLES::TranslateWrapType(nextPass.wrapType);
-
       const GLuint magFilterType =
           (nextPass.filterType == FilterType::LINEAR ? GL_LINEAR : GL_NEAREST);
-
       const GLuint minFilterType =
           (nextPass.mipmap ? (nextPass.filterType == FilterType::LINEAR ? GL_LINEAR_MIPMAP_LINEAR
                                                                         : GL_NEAREST_MIPMAP_NEAREST)
@@ -145,37 +173,13 @@ bool CShaderPresetGLES::CreateShaderTextures()
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, wrapType);
       glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, wrapType);
 
-      // Determine the framebuffer data format
-      GLint internalFormat;
-      GLenum pixelFormat;
-      if (pass.fbo.floatFramebuffer && major >= 3)
-      {
-        // Give priority to float framebuffer parameter (we can't use both float and sRGB)
-        internalFormat = GL_RGBA32F;
-        pixelFormat = GL_RGBA;
-      }
-      else
-      {
-        if (pass.fbo.sRgbFramebuffer && major >= 3)
-        {
-          internalFormat = GL_SRGB8_ALPHA8;
-          pixelFormat = GL_RGBA;
-        }
-        else
-        {
-          internalFormat = GL_RGBA;
-          pixelFormat = GL_RGBA;
-        }
-      }
-
-      glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, textureSize.x, textureSize.y, 0, pixelFormat,
-                   internalFormat == GL_RGBA32F ? GL_FLOAT : GL_UNSIGNED_BYTE, nullptr);
+      glBindTexture(GL_TEXTURE_2D, 0);
 
       m_pShaderTextures.emplace_back(std::move(shaderTextureGLES));
     }
 
-    // Notify shader of its source and dest size
-    m_pShaders[shaderIdx]->SetSizes(prevSize, prevTextureSize, scaledSize);
+    // Notify shader of its target and source sizes
+    m_pShaders[shaderIdx]->SetSizes(scaledSize, prevSize, prevTextureSize);
 
     prevSize = scaledSize;
     prevTextureSize = textureSize;
@@ -192,11 +196,17 @@ void CShaderPresetGLES::RenderShader(IShader& shader,
   if (static_cast<CShaderTextureGLES&>(targetTexture).BindFBO())
   {
     const CRect newViewPort(0.f, 0.f, targetTexture.GetWidth(), targetTexture.GetHeight());
+
     glViewport((GLsizei)newViewPort.x1, (GLsizei)newViewPort.y1, (GLsizei)newViewPort.x2,
                (GLsizei)newViewPort.y2);
     glScissor((GLsizei)newViewPort.x1, (GLsizei)newViewPort.y1, (GLsizei)newViewPort.x2,
               (GLsizei)newViewPort.y2);
+
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
     shader.Render(sourceTexture, targetTexture);
+
     static_cast<CShaderTextureGLES&>(targetTexture).UnbindFBO();
   }
 }

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLES.cpp
@@ -10,20 +10,27 @@
 
 #include "utils/log.h"
 
-#include <cassert>
-
 using namespace KODI::SHADER;
 
-CShaderTextureGLES::CShaderTextureGLES(uint32_t textureWidth, uint32_t textureHeight)
+CShaderTextureGLES::CShaderTextureGLES(uint32_t textureWidth,
+                                       uint32_t textureHeight,
+                                       GLuint pixelType,
+                                       GLuint internalFormat,
+                                       GLuint pixelFormat,
+                                       bool bUseAlpha)
   : m_textureWidth(textureWidth),
-    m_textureHeight(textureHeight)
+    m_textureHeight(textureHeight),
+    m_pixelType(pixelType),
+    m_internalFormat(internalFormat),
+    m_pixelFormat(pixelFormat),
+    m_useAlpha(bUseAlpha)
 {
 }
 
 CShaderTextureGLES::~CShaderTextureGLES()
 {
-  DestroyFBO();
-  DestroyTextureObject();
+  DeleteFBO();
+  DeleteTexture();
 }
 
 float CShaderTextureGLES::GetWidth() const
@@ -36,12 +43,29 @@ float CShaderTextureGLES::GetHeight() const
   return static_cast<float>(m_textureHeight);
 }
 
-void CShaderTextureGLES::CreateTextureObject()
+void CShaderTextureGLES::CreateTexture()
 {
   glGenTextures(1, &m_texture);
+
+  glBindTexture(m_textureTarget, m_texture);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+  // Force alpha to 1, because shader can leave it undefined
+#if defined(GL_ES_VERSION_3_0)
+  if (!m_useAlpha && m_internalFormat == GL_RGBA)
+    glTexParameteri(m_textureTarget, GL_TEXTURE_SWIZZLE_A, GL_ONE);
+#endif
+
+  glTexImage2D(m_textureTarget, 0, m_internalFormat, m_textureWidth, m_textureHeight, 0,
+               m_pixelFormat, m_pixelType, nullptr);
+
+  glBindTexture(m_textureTarget, 0);
 }
 
-void CShaderTextureGLES::DestroyTextureObject()
+void CShaderTextureGLES::DeleteTexture()
 {
   if (m_texture != 0)
     glDeleteTextures(1, &m_texture);
@@ -61,7 +85,7 @@ void CShaderTextureGLES::CreateFBO()
     glGenFramebuffers(1, &m_FBO);
 }
 
-void CShaderTextureGLES::DestroyFBO()
+void CShaderTextureGLES::DeleteFBO()
 {
   if (m_FBO != 0)
     glDeleteFramebuffers(1, &m_FBO);
@@ -79,6 +103,7 @@ bool CShaderTextureGLES::BindFBO()
 
   glBindFramebuffer(GL_FRAMEBUFFER, m_FBO);
   glBindTexture(GL_TEXTURE_2D, m_texture);
+
   glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0);
 
   if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLES.h
@@ -10,8 +10,6 @@
 
 #include "cores/RetroPlayer/shaders/IShaderTexture.h"
 
-#include <memory>
-
 #include "system_gl.h"
 
 namespace KODI::SHADER
@@ -20,7 +18,12 @@ namespace KODI::SHADER
 class CShaderTextureGLES : public IShaderTexture
 {
 public:
-  CShaderTextureGLES(uint32_t textureWidth, uint32_t textureHeight);
+  CShaderTextureGLES(uint32_t textureWidth,
+                     uint32_t textureHeight,
+                     GLuint pixelType,
+                     GLuint internalFormat,
+                     GLuint pixelFormat,
+                     bool bUseAlpha);
   ~CShaderTextureGLES() override;
 
   // Disallow copy and move (this object owns raw GL IDs)
@@ -34,8 +37,8 @@ public:
   float GetHeight() const override;
 
   // OpenGLES interface
-  void CreateTextureObject();
-  void DestroyTextureObject();
+  void CreateTexture();
+  void DeleteTexture();
   void BindToUnit(unsigned int unit);
   GLuint GetTextureID() const { return m_texture; }
 
@@ -47,13 +50,20 @@ public:
 
   // Frame buffer interface
   void CreateFBO();
-  void DestroyFBO();
+  void DeleteFBO();
   bool BindFBO();
   void UnbindFBO() const;
 
 private:
-  uint32_t m_textureWidth{0};
-  uint32_t m_textureHeight{0};
+  // Construction parameters
+  const uint32_t m_textureWidth;
+  const uint32_t m_textureHeight;
+  const GLuint m_pixelType;
+  const GLuint m_internalFormat;
+  const GLuint m_pixelFormat;
+  const bool m_useAlpha;
+
+  const GLenum m_textureTarget = GL_TEXTURE_2D; //! @todo
   GLuint m_texture{0};
   GLuint m_FBO{0};
   bool m_sRgbFramebuffer{false};

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLESRef.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderTextureGLESRef.h
@@ -35,8 +35,8 @@ public:
   GLuint GetTextureID() const { return m_texture; }
 
 private:
-  uint32_t m_textureWidth{0};
-  uint32_t m_textureHeight{0};
+  const uint32_t m_textureWidth;
+  const uint32_t m_textureHeight;
   GLuint m_texture{0};
 };
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.cpp
@@ -188,10 +188,11 @@ void CRPWinOutputShader::Render(CD3DTexture& sourceTexture,
                                 const KODI::RETRO::ViewportCoordinates& points,
                                 CRect& viewPort,
                                 CD3DTexture& target,
-                                unsigned int range /* = 0 */)
+                                unsigned int range /* = 0 */,
+                                uint8_t alpha /* = 0xFF */)
 {
   PrepareParameters(sourceTexture.GetWidth(), sourceTexture.GetHeight(), sourceRect, points);
-  SetShaderParameters(sourceTexture, range, viewPort);
+  SetShaderParameters(sourceTexture, range, alpha, viewPort);
   Execute({&target}, 4);
 }
 
@@ -247,6 +248,7 @@ void CRPWinOutputShader::PrepareParameters(unsigned int sourceWidth,
 
 void CRPWinOutputShader::SetShaderParameters(CD3DTexture& sourceTexture,
                                              unsigned int range,
+                                             uint8_t alpha,
                                              CRect& viewPort)
 {
   m_effect.SetTechnique("OUTPUT_T");
@@ -255,6 +257,9 @@ void CRPWinOutputShader::SetShaderParameters(CD3DTexture& sourceTexture,
   const float viewPortArray[2] = {viewPort.Width(), viewPort.Height()};
   m_effect.SetFloatArray("g_viewPort", viewPortArray, 2);
 
-  const float params[3] = {static_cast<float>(range)};
+  const float params[1] = {static_cast<float>(range)};
   m_effect.SetFloatArray("m_params", params, 1);
+
+  const float outputAlpha = static_cast<float>(alpha) / 255.0f;
+  m_effect.SetFloatArray("g_alpha", &outputAlpha, 1);
 }

--- a/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.h
@@ -12,6 +12,7 @@
 #include "cores/RetroPlayer/RetroPlayerTypes.h"
 #include "guilib/D3DResource.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -60,14 +61,18 @@ public:
               const KODI::RETRO::ViewportCoordinates& points,
               CRect& viewPort,
               CD3DTexture& target,
-              unsigned int range = 0);
+              unsigned int range = 0,
+              uint8_t alpha = 0xFF);
 
 private:
   void PrepareParameters(unsigned int sourceWidth,
                          unsigned int sourceHeight,
                          CRect sourceRect,
                          const KODI::RETRO::ViewportCoordinates& points);
-  void SetShaderParameters(CD3DTexture& sourceTexture, unsigned int range, CRect& viewPort);
+  void SetShaderParameters(CD3DTexture& sourceTexture,
+                           unsigned int range,
+                           uint8_t alpha,
+                           CRect& viewPort);
 
   unsigned int m_sourceWidth{0};
   unsigned int m_sourceHeight{0};

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
@@ -80,78 +80,55 @@ bool CShaderDX::Create(unsigned int passIdx,
 void CShaderDX::Render(IShaderTexture& sourceTexture, IShaderTexture& targetTexture)
 {
   auto& sourceDX = static_cast<CShaderTextureDX&>(sourceTexture);
+  auto& targetDX = static_cast<CShaderTextureDX&>(targetTexture);
 
   // Get source texture object
-  const CD3DTexture& sourceD3dTexture = sourceDX.GetTexture();
+  const CD3DTexture& sourceD3DTexture = sourceDX.GetTexture();
 
-  //! @todo Handle ref textures better
-  auto* targetDX = dynamic_cast<CShaderTextureDX*>(&targetTexture);
-  auto* targetDXRef = dynamic_cast<CShaderTextureDXRef*>(&targetTexture);
+  // Get target texture object
+  CD3DTexture& targetD3DTexture = targetDX.GetTexture();
 
-  CD3DTexture& targetD3dTexture =
-      targetDX != nullptr ? targetDX->GetTexture() : targetDXRef->GetTexture();
-
-  //! @todo Check for nullptr
-  SetShaderParameters(sourceD3dTexture);
-  Execute({&targetD3dTexture}, 4);
+  SetShaderParameters(sourceD3DTexture);
+  Execute({&targetD3DTexture}, 4);
 }
 
-void CShaderDX::SetSizes(const float2& prevSize,
-                         const float2& prevTextureSize,
-                         const float2& nextSize)
+void CShaderDX::SetSizes(const float2& nextSize,
+                         const float2& prevSize,
+                         const float2& prevTextureSize)
 {
-  m_inputSize = prevSize;
-  m_inputTextureSize = prevTextureSize;
   m_outputSize = nextSize;
+
+  if (prevSize.x > 0 && prevSize.y > 0)
+    m_inputSize = prevSize;
+
+  if (prevTextureSize.x > 0 && prevTextureSize.y > 0)
+    m_inputTextureSize = prevTextureSize;
 }
 
 void CShaderDX::PrepareParameters(
-    const RETRO::ViewportCoordinates& dest,
-    const float2 fullDestSize,
     IShaderTexture& sourceTexture,
     const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
     const std::vector<std::unique_ptr<IShader>>& pShaders,
     uint64_t frameCount)
 {
+  // Set destination rectangle size
+  m_destSize = m_outputSize;
+
   CUSTOMVERTEX* v;
   LockVertexBuffer(reinterpret_cast<void**>(&v));
 
-  if (m_passIdx + 1 != static_cast<unsigned int>(pShaders.size())) // Not last pass
-  {
-    // top left
-    v[0].x = -m_outputSize.x / 2;
-    v[0].y = -m_outputSize.y / 2;
-    // top right
-    v[1].x = m_outputSize.x / 2;
-    v[1].y = -m_outputSize.y / 2;
-    // bottom right
-    v[2].x = m_outputSize.x / 2;
-    v[2].y = m_outputSize.y / 2;
-    // bottom left
-    v[3].x = -m_outputSize.x / 2;
-    v[3].y = m_outputSize.y / 2;
-
-    // Set destination rectangle size
-    m_destSize = m_outputSize;
-  }
-  else // Last pass
-  {
-    // top left
-    v[0].x = dest[0].x - m_outputSize.x / 2;
-    v[0].y = dest[0].y - m_outputSize.y / 2;
-    // top right
-    v[1].x = dest[1].x - m_outputSize.x / 2;
-    v[1].y = dest[1].y - m_outputSize.y / 2;
-    // bottom right
-    v[2].x = dest[2].x - m_outputSize.x / 2;
-    v[2].y = dest[2].y - m_outputSize.y / 2;
-    // bottom left
-    v[3].x = dest[3].x - m_outputSize.x / 2;
-    v[3].y = dest[3].y - m_outputSize.y / 2;
-
-    // Set destination rectangle size for the last pass
-    m_destSize = fullDestSize;
-  }
+  // top left
+  v[0].x = -m_outputSize.x / 2;
+  v[0].y = -m_outputSize.y / 2;
+  // top right
+  v[1].x = m_outputSize.x / 2;
+  v[1].y = -m_outputSize.y / 2;
+  // bottom right
+  v[2].x = m_outputSize.x / 2;
+  v[2].y = m_outputSize.y / 2;
+  // bottom left
+  v[3].x = -m_outputSize.x / 2;
+  v[3].y = m_outputSize.y / 2;
 
   // top left
   v[0].z = 0;

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
@@ -38,12 +38,10 @@ public:
               std::vector<std::shared_ptr<IShaderLut>> luts,
               unsigned int frameCountMod = 0) override;
   void Render(IShaderTexture& sourceTexture, IShaderTexture& targetTexture) override;
-  void SetSizes(const float2& prevSize,
-                const float2& prevTextureSize,
-                const float2& nextSize) override;
-  void PrepareParameters(const RETRO::ViewportCoordinates& dest,
-                         const float2 fullDestSize,
-                         IShaderTexture& sourceTexture,
+  void SetSizes(const float2& nextSize,
+                const float2& prevSize = float2{},
+                const float2& prevTextureSize = float2{}) override;
+  void PrepareParameters(IShaderTexture& sourceTexture,
                          const std::vector<std::unique_ptr<IShaderTexture>>& pShaderTextures,
                          const std::vector<std::unique_ptr<IShader>>& pShaders,
                          uint64_t frameCount) override;

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
@@ -119,6 +119,8 @@ bool CShaderPresetDX::CreateShaderTextures()
 {
   DisposeShaderTextures();
 
+  m_bTexturesNeedSizeUpdate = false;
+
   float2 prevSize = m_videoSize;
   float2 prevTextureSize = m_videoSize;
 
@@ -131,6 +133,24 @@ bool CShaderPresetDX::CreateShaderTextures()
     float2 scaledSize;
     float2 textureSize;
     CalculateScaledSize(pass, prevSize, scaledSize);
+
+    //! @todo Enable usage of optimal texture sizes once multi-pass preset
+    // geometry and LUT rendering are fixed.
+    //
+    // Current issues:
+    //   - Enabling optimal texture sizes breaks geometry for many multi-pass
+    //     presets
+    //   - LUTs render incorrectly due to missing per-pass and per-LUT
+    //     TexCoord attributes.
+    //
+    // Planned solution:
+    //   - Implement additional TexCoord attributes for each pass and LUT,
+    //     setting coordinates to `xamt` and `yamt` instead of 1
+    //
+    // Reference implementation in RetroArch:
+    //   https://github.com/libretro/RetroArch/blob/09a59edd6b415b7bd124b03bda68ccc4d60b0ea8/gfx/drivers/gl2.c#L3018
+    //
+    textureSize = scaledSize; // CShaderUtils::GetOptimalTextureSize(scaledSize)
 
     if (shaderIdx + 1 == numPasses)
     {
@@ -155,24 +175,6 @@ bool CShaderPresetDX::CreateShaderTextures()
           textureFormat = DXGI_FORMAT_B8G8R8A8_UNORM;
       }
 
-      //! @todo Enable usage of optimal texture sizes once multi-pass preset
-      // geometry and LUT rendering are fixed.
-      //
-      // Current issues:
-      //   - Enabling optimal texture sizes breaks geometry for many multi-pass
-      //     presets
-      //   - LUTs render incorrectly due to missing per-pass and per-LUT
-      //     TexCoord attributes.
-      //
-      // Planned solution:
-      //   - Implement additional TexCoord attributes for each pass and LUT,
-      //     setting coordinates to `xamt` and `yamt` instead of 1
-      //
-      // Reference implementation in RetroArch:
-      //   https://github.com/libretro/RetroArch/blob/09a59edd6b415b7bd124b03bda68ccc4d60b0ea8/gfx/drivers/gl2.c#L3018
-      //
-      textureSize = scaledSize; // CShaderUtils::GetOptimalTextureSize(scaledSize)
-
       auto textureDX = std::make_shared<CD3DTexture>();
 
       if (!textureDX->Create(static_cast<UINT>(textureSize.x), static_cast<UINT>(textureSize.y), 1,
@@ -188,8 +190,8 @@ bool CShaderPresetDX::CreateShaderTextures()
       m_pShaderTextures.emplace_back(std::make_unique<CShaderTextureDX>(std::move(textureDX)));
     }
 
-    // Notify shader of its source and dest size
-    m_pShaders[shaderIdx]->SetSizes(prevSize, prevTextureSize, scaledSize);
+    // Notify shader of its target and source sizes
+    m_pShaders[shaderIdx]->SetSizes(scaledSize, prevSize, prevTextureSize);
 
     prevSize = scaledSize;
     prevTextureSize = textureSize;
@@ -234,5 +236,11 @@ void CShaderPresetDX::RenderShader(IShader& shader,
   const CRect newViewPort(0.f, 0.f, targetTexture.GetWidth(), targetTexture.GetHeight());
   m_context.SetViewPort(newViewPort);
   m_context.SetScissors(newViewPort);
+
+  auto& targetDX = static_cast<CShaderTextureDX&>(targetTexture);
+  const FLOAT clearColor[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+  DX::DeviceResources::Get()->GetD3DContext()->ClearRenderTargetView(
+      targetDX.GetTexture().GetRenderTarget(), clearColor);
+
   shader.Render(sourceTexture, targetTexture);
 }

--- a/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
@@ -46,7 +46,7 @@ namespace
 {
 
 constexpr const char* PRESETS_ADDON_NAME = "game.shader.presets";
-constexpr const char* ICON_VIDEO = "DefaultVideo.png";
+constexpr const char* ICON_VIDEO = "";
 constexpr const char* ICON_GET_MORE = "DefaultAddSource.png";
 
 struct ScalingMethodProperties


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This PR introduces several changes needed to fix rendering of `<control type="gamewindow">` with alpha, which is supposed to be used by fade animations in Estuary and possibly may be used differently in other skins.

There were several points of failure, which are all addressed in this PR:

1. Some elements in the skin were changed or removed, because they would now become visible under the transparent _gamewindow_ during the fading animation (like static savestate pictures).

2. _DefaultVideo.png_ icons were removed from the lists, because they would become visible under the transparent _gamewindow_ elements as well (icons are only set for items without thumbnails).

3. The `bClear` flag for `CRPRenderManager::RenderControl()` was changed to `false` when being called from the GUI bridge, because if we clear the area below, then there is nothing left to be seen under the semi-transparent thumbnails, just black.

4. New semi-transparent black rectangle was added to the skin below the thumbnails to supplement the black bars for non-fullscreen stretch modes.

5. Computation of the alpha value was fixed in the `CRPRenderManager::RenderControl()` (it was being called too late, when the accumulated alpha from the animation was already reset by another `SetTransform()` call).

6. Finally, the biggest change was needed in the renderer itself to apply the transformation and the alpha to the libretro shader presets.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I just wanted to try to make the alpha working, but I ended up doing more complex changes and a cleanup to the shader preset rendering.

The main idea is to simplify and cleanup the _ShaderPreset_ class (specifically the rendering of the last pass) and let the GUI shader handle the final transformation and the alpha.

This is the most important change from the diff:
```diff
-    if (!m_shaderPreset->RenderUpdate(m_rotatedDestCoords, {m_fullDestWidth, m_fullDestHeight},
-                                      *source, *target))

+    if (!m_shaderPreset->RenderUpdate(*source, *target))
```

In the original code the _target_ is the screen (a texture for DirectX or a dummy object with size of the backbuffer for OpenGL). Therefore we needed to pass a lot of geometry information, so the preset can render the last pass directly to the destination coordinates.

In the new version, the _target_ is the real _ShaderTexture_ (with attached FBO for OpenGL). The shader preset renders to the full size of the provided texture and then we use this texture instead of the _renderBuffer_ as a source for the GUI shader, which handles all the final transformations and also the alpha along the way. The duplicated logic for handling the final transformation of the last pass can be removed from the _ShaderPreset_ class.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
**The current code is only finished for OpenGL Core Profile!**

I wanted to get some feedback for the overall idea before implementing it for OpenGL ES and DirectX.

The OpenGL should work for both Linux and macOS.
The GLES and the DirectX versions are expected to not even build, because of the changed interfaces.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
New semi-transparent black bars (using _Integer_ scaling to show empty space around thumbs):
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/39e84764-1207-4ee2-8d62-d90f532dcaa9" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/09ea52ed-4fbb-4374-a138-6cb8e3def37e" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/94331821-38b8-46aa-a6ad-6ae8521e8614" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/57df4db7-716a-43c1-9c06-af7bb6f4f53b" />

Working fade animation:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2bceab22-fa20-46ea-9e5b-343be2a0d6aa" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/415236ad-dba8-4092-9def-88df275986ad" />

Consistent look between the GUI shaders and the libretro shader presets:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c997f969-a306-4176-9299-283f727ec0e4" />

Before:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/508d012d-e49e-46ac-b5ec-9b11dd64b675" />

Broken fading:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7fb020ed-8dd9-46e7-8d1d-54b030b4bfd4" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
