### PR TITLE
[Wayland] add support for fractional scaling protocol

### DIFF
--- a/cmake/scripts/linux/ExtraTargets.cmake
+++ b/cmake/scripts/linux/ExtraTargets.cmake
@@ -20,6 +20,7 @@ if("wayland" IN_LIST CORE_PLATFORM_NAME_LC)
   # to already be resolved
   set(PROTOCOL_XMLS "${WAYLANDPP_PROTOCOLS_DIR}/presentation-time.xml"
                     "${WAYLANDPP_PROTOCOLS_DIR}/xdg-shell.xml"
+                    "${WAYLAND_PROTOCOLS_DIR}/stable/viewporter/viewporter.xml"
                     "${WAYLAND_PROTOCOLS_DIR}/unstable/xdg-shell/xdg-shell-unstable-v6.xml"
                     "${WAYLAND_PROTOCOLS_DIR}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml")
 

--- a/cmake/scripts/linux/ExtraTargets.cmake
+++ b/cmake/scripts/linux/ExtraTargets.cmake
@@ -21,6 +21,7 @@ if("wayland" IN_LIST CORE_PLATFORM_NAME_LC)
   set(PROTOCOL_XMLS "${WAYLANDPP_PROTOCOLS_DIR}/presentation-time.xml"
                     "${WAYLANDPP_PROTOCOLS_DIR}/xdg-shell.xml"
                     "${WAYLAND_PROTOCOLS_DIR}/stable/viewporter/viewporter.xml"
+                    "${WAYLAND_PROTOCOLS_DIR}/staging/fractional-scale/fractional-scale-v1.xml"
                     "${WAYLAND_PROTOCOLS_DIR}/unstable/xdg-shell/xdg-shell-unstable-v6.xml"
                     "${WAYLAND_PROTOCOLS_DIR}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml")
 

--- a/xbmc/windowing/wayland/InputProcessorPointer.h
+++ b/xbmc/windowing/wayland/InputProcessorPointer.h
@@ -38,7 +38,7 @@ class CInputProcessorPointer final : public IRawInputHandlerPointer
 {
 public:
   CInputProcessorPointer(wayland::surface_t const& surface, IInputHandlerPointer& handler);
-  void SetCoordinateScale(std::int32_t scale) { m_coordinateScale = scale; }
+  void SetCoordinateScale(double scale) { m_coordinateScale = scale; }
 
   void OnPointerEnter(CSeat* seat,
                       std::uint32_t serial,
@@ -68,7 +68,7 @@ private:
 
   // Pointer position in *scaled* coordinates
   CPointGen<std::uint16_t> m_pointerPosition;
-  std::int32_t m_coordinateScale{1};
+  double m_coordinateScale{1.0};
 };
 
 }

--- a/xbmc/windowing/wayland/InputProcessorTouch.h
+++ b/xbmc/windowing/wayland/InputProcessorTouch.h
@@ -33,7 +33,7 @@ class CInputProcessorTouch final : public IRawInputHandlerTouch
 public:
   CInputProcessorTouch(wayland::surface_t const& surface);
   ~CInputProcessorTouch() noexcept;
-  void SetCoordinateScale(std::int32_t scale) { m_coordinateScale = scale; }
+  void SetCoordinateScale(double scale) { m_coordinateScale = scale; }
 
   void OnTouchDown(CSeat* seat,
                    std::uint32_t serial,
@@ -71,7 +71,7 @@ private:
   void AbortTouches();
 
   wayland::surface_t m_surface;
-  std::int32_t m_coordinateScale{1};
+  double m_coordinateScale{1.0};
 
   /// Map of wl_touch point id to data
   std::map<std::int32_t, TouchPoint> m_touchPoints;

--- a/xbmc/windowing/wayland/SeatInputProcessing.cpp
+++ b/xbmc/windowing/wayland/SeatInputProcessing.cpp
@@ -74,7 +74,7 @@ void CSeatInputProcessing::OnKeyboardEvent(XBMC_Event& event)
   m_handler.OnEvent(InputType::KEYBOARD, event);
 }
 
-void CSeatInputProcessing::SetCoordinateScale(std::int32_t scale)
+void CSeatInputProcessing::SetCoordinateScale(double scale)
 {
   for (auto& seatPair : m_seats)
   {

--- a/xbmc/windowing/wayland/SeatInputProcessing.h
+++ b/xbmc/windowing/wayland/SeatInputProcessing.h
@@ -102,7 +102,7 @@ public:
    *
    * \param scale new buffer-to-surface pixel ratio
    */
-  void SetCoordinateScale(std::int32_t scale);
+  void SetCoordinateScale(double scale);
 
 private:
   wayland::surface_t m_inputSurface;

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -166,6 +166,7 @@ bool CWinSystemWayland::InitWindowSystem()
 
   m_registry->RequestSingleton(m_compositor, 1, 4);
   m_registry->RequestSingleton(m_shm, 1, 1);
+  m_registry->RequestSingleton(m_viewporter, 1, 1, false);
   m_registry->RequestSingleton(m_presentation, 1, 1, false);
   // version 2 adds done() -> required
   // version 3 adds destructor -> optional
@@ -275,6 +276,11 @@ bool CWinSystemWayland::CreateNewWindow(const std::string& name,
       CLog::Log(LOGWARNING, "Leaving output that was not configured yet, ignoring");
     }
   };
+
+  if (m_viewporter)
+  {
+    m_viewport = m_viewporter.get_viewport(m_surface);
+  }
 
   m_windowDecorator = std::make_unique<CWindowDecorator>(*this, *m_connection, m_surface);
 
@@ -394,6 +400,7 @@ bool CWinSystemWayland::DestroyWindow()
 
   m_shellSurface.reset();
   // waylandpp automatically calls wl_surface_destroy when the last reference is removed
+  m_viewport = wayland::viewport_t();
   m_surface = wayland::surface_t();
   m_windowDecorator.reset();
   m_seats.clear();
@@ -644,6 +651,10 @@ void CWinSystemWayland::ApplySizeUpdate(SizeUpdateInformation update)
   }
   if (update.surfaceSizeChanged)
   {
+    if (m_viewport)
+    {
+      ApplyViewportSizes();
+    }
     // Update opaque region here so size always matches the configured egl surface
     ApplyOpaqueRegion();
   }
@@ -1291,9 +1302,22 @@ void CWinSystemWayland::UpdateBufferScale()
 void CWinSystemWayland::ApplyBufferScale()
 {
   CLog::LogF(LOGINFO, "Setting Wayland buffer scale to {}", m_scale);
-  m_surface.set_buffer_scale(m_scale);
+  if (m_viewport)
+  {
+    ApplyViewportSizes();
+  }
+  else if (m_surface.can_set_buffer_scale())
+  {
+    m_surface.set_buffer_scale(m_scale);
+  }
   m_windowDecorator->SetState(m_configuredSize, m_scale, m_shellSurfaceState);
   m_seatInputProcessing->SetCoordinateScale(m_scale);
+}
+
+void CWinSystemWayland::ApplyViewportSizes()
+{
+  m_viewport.set_destination(m_surfaceSize.Width(), m_surfaceSize.Height());
+  m_viewport.set_source(0.0, 0.0, m_bufferSize.Width(), m_bufferSize.Height());
 }
 
 void CWinSystemWayland::UpdateTouchDpi()

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -127,7 +127,7 @@ struct MsgConfigure
 
 struct MsgBufferScale
 {
-  int scale;
+  double scale;
 };
 
 };
@@ -698,7 +698,7 @@ void CWinSystemWayland::ProcessMessages()
   Actor::Message* message{};
   MessageHandle lastConfigureMessage;
   int skippedConfigures{-1};
-  int newScale{m_scale};
+  double newScale{m_scale};
 
   while (m_protocol.ReceiveOutMessage(&message))
   {
@@ -780,7 +780,8 @@ void CWinSystemWayland::ProcessMessages()
         auto const& windowed = CDisplaySettings::GetInstance().GetResolutionInfo(RES_WINDOW);
         // Kodi resolution is buffer size, but SetResolutionInternal expects
         // surface size, so divide by m_scale
-        size = CSizeInt{windowed.iWidth, windowed.iHeight} / newScale;
+        size.SetWidth(std::round(static_cast<double>(windowed.iWidth) / newScale));
+        size.SetHeight(std::round(static_cast<double>(windowed.iHeight) / newScale));
         CLog::LogF(LOGDEBUG, "Adapting Kodi windowed size {}x{}", size.Width(), size.Height());
         sizeIncludesDecoration = false;
       }
@@ -848,7 +849,12 @@ void CWinSystemWayland::AckConfigure(std::uint32_t serial)
  * \param scale new buffer scale
  * \param sizeIncludesDecoration whether size includes the size of the window decorations if present
  */
-void CWinSystemWayland::SetResolutionInternal(CSizeInt size, std::int32_t scale, IShellSurface::StateBitset state, bool sizeIncludesDecoration, bool mustAck, std::uint32_t configureSerial)
+void CWinSystemWayland::SetResolutionInternal(CSizeInt size,
+                                              double scale,
+                                              IShellSurface::StateBitset state,
+                                              bool sizeIncludesDecoration,
+                                              bool mustAck,
+                                              std::uint32_t configureSerial)
 {
   // This should never be called while a size set is pending
   assert(!m_waitingForApply);
@@ -901,8 +907,7 @@ void CWinSystemWayland::SetResolutionInternal(CSizeInt size, std::int32_t scale,
       {
         XBMC_Event msg{};
         msg.type = XBMC_VIDEORESIZE;
-        msg.resize = {sizes.surfaceSize.Width(), sizes.surfaceSize.Height(),
-                      static_cast<double>(scale)};
+        msg.resize = {sizes.surfaceSize.Width(), sizes.surfaceSize.Height(), scale};
         // FIXME
         dynamic_cast<CWinEventsWayland&>(*m_winEvents).MessagePush(&msg);
         m_waitingForApply = true;
@@ -976,7 +981,10 @@ void CWinSystemWayland::ApplyNextState()
   }
 }
 
-CWinSystemWayland::Sizes CWinSystemWayland::CalculateSizes(CSizeInt size, int scale, IShellSurface::StateBitset state, bool sizeIncludesDecoration)
+CWinSystemWayland::Sizes CWinSystemWayland::CalculateSizes(CSizeInt size,
+                                                           double scale,
+                                                           IShellSurface::StateBitset state,
+                                                           bool sizeIncludesDecoration)
 {
   Sizes result;
 
@@ -1007,7 +1015,8 @@ CWinSystemWayland::Sizes CWinSystemWayland::CalculateSizes(CSizeInt size, int sc
     result.configuredSize = m_windowDecorator->CalculateFullSurfaceSize(size, state);
   }
 
-  result.bufferSize = result.surfaceSize * scale;
+  result.bufferSize.SetWidth(std::round(static_cast<double>(result.surfaceSize.Width()) * scale));
+  result.bufferSize.SetHeight(std::round(static_cast<double>(result.surfaceSize.Height()) * scale));
 
   return result;
 }
@@ -1022,7 +1031,8 @@ CWinSystemWayland::Sizes CWinSystemWayland::CalculateSizes(CSizeInt size, int sc
  * \param sizeIncludesDecoration if true, given size includes potential window decorations
  * \return whether main buffer (not surface) size changed
  */
-CWinSystemWayland::SizeUpdateInformation CWinSystemWayland::UpdateSizeVariables(CSizeInt size, int scale, IShellSurface::StateBitset state, bool sizeIncludesDecoration)
+CWinSystemWayland::SizeUpdateInformation CWinSystemWayland::UpdateSizeVariables(
+    CSizeInt size, double scale, IShellSurface::StateBitset state, bool sizeIncludesDecoration)
 {
   CLog::LogF(LOGDEBUG, "Set size {}x{} scale {} {} decorations with state {}", size.Width(),
              size.Height(), scale, sizeIncludesDecoration ? "including" : "excluding",
@@ -1294,7 +1304,8 @@ void CWinSystemWayland::UpdateBufferScale()
   auto const maxBufferScaleIt = std::max_element(m_surfaceOutputs.cbegin(), m_surfaceOutputs.cend(), OutputScaleComparer());
   if (maxBufferScaleIt != m_surfaceOutputs.cend())
   {
-    WinSystemWaylandProtocol::MsgBufferScale msg{(*maxBufferScaleIt)->GetScale()};
+    WinSystemWaylandProtocol::MsgBufferScale msg{
+        static_cast<double>((*maxBufferScaleIt)->GetScale())};
     m_protocol.SendOutMessage(WinSystemWaylandProtocol::BUFFER_SCALE, &msg, sizeof(msg));
   }
 }
@@ -1308,7 +1319,7 @@ void CWinSystemWayland::ApplyBufferScale()
   }
   else if (m_surface.can_set_buffer_scale())
   {
-    m_surface.set_buffer_scale(m_scale);
+    m_surface.set_buffer_scale(std::round(m_scale));
   }
   m_windowDecorator->SetState(m_configuredSize, m_scale, m_shellSurfaceState);
   m_seatInputProcessing->SetCoordinateScale(m_scale);

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -167,6 +167,7 @@ bool CWinSystemWayland::InitWindowSystem()
   m_registry->RequestSingleton(m_compositor, 1, 4);
   m_registry->RequestSingleton(m_shm, 1, 1);
   m_registry->RequestSingleton(m_viewporter, 1, 1, false);
+  m_registry->RequestSingleton(m_fractionalScaleManager, 1, 1, false);
   m_registry->RequestSingleton(m_presentation, 1, 1, false);
   // version 2 adds done() -> required
   // version 3 adds destructor -> optional
@@ -188,6 +189,11 @@ bool CWinSystemWayland::InitWindowSystem()
   if (m_outputs.empty())
   {
     throw std::runtime_error("No outputs received from compositor");
+  }
+
+  if (!m_viewporter)
+  {
+    m_fractionalScaleManager = wayland::fractional_scale_manager_v1_t();
   }
 
   // Event loop is started in CreateWindow
@@ -282,6 +288,22 @@ bool CWinSystemWayland::CreateNewWindow(const std::string& name,
     m_viewport = m_viewporter.get_viewport(m_surface);
   }
 
+  if (m_fractionalScaleManager)
+  {
+    m_fractionalScale = m_fractionalScaleManager.get_fractional_scale(m_surface);
+    m_fractionalScale.on_preferred_scale() = [this](std::uint32_t scale)
+    {
+      constexpr double WAYLAND_SCALE_FACTOR = 120.0;
+      const double newScale = scale / WAYLAND_SCALE_FACTOR;
+      CLog::LogF(LOGINFO, "Received new preferred scale: {}", newScale);
+      if (newScale > 0.0)
+      {
+        WinSystemWaylandProtocol::MsgBufferScale msg{newScale};
+        m_protocol.SendOutMessage(WinSystemWaylandProtocol::BUFFER_SCALE, &msg, sizeof(msg));
+      }
+    };
+  }
+
   m_windowDecorator = std::make_unique<CWindowDecorator>(*this, *m_connection, m_surface);
 
   m_seatInputProcessing = std::make_unique<CSeatInputProcessing>(m_surface, *this);
@@ -316,7 +338,7 @@ bool CWinSystemWayland::CreateNewWindow(const std::string& name,
     auto wlOutput = output ? output->GetWaylandOutput() : wayland::output_t{};
     m_lastSetOutput = wlOutput;
     m_shellSurface->SetFullScreen(wlOutput, res.fRefreshRate);
-    if (output && m_surface.can_set_buffer_scale())
+    if (!m_fractionalScaleManager && output && m_surface.can_set_buffer_scale())
     {
       m_scale = output->GetScale();
       ApplyBufferScale();
@@ -401,6 +423,7 @@ bool CWinSystemWayland::DestroyWindow()
   m_shellSurface.reset();
   // waylandpp automatically calls wl_surface_destroy when the last reference is removed
   m_viewport = wayland::viewport_t();
+  m_fractionalScale = wayland::fractional_scale_v1_t();
   m_surface = wayland::surface_t();
   m_windowDecorator.reset();
   m_seats.clear();
@@ -1299,6 +1322,11 @@ void CWinSystemWayland::OnSetCursor(std::uint32_t seatGlobalName, std::uint32_t 
 
 void CWinSystemWayland::UpdateBufferScale()
 {
+  if (m_fractionalScaleManager)
+  {
+    return;
+  }
+
   // Adjust our surface size to the output with the biggest scale in order
   // to get the best quality
   auto const maxBufferScaleIt = std::max_element(m_surfaceOutputs.cbegin(), m_surfaceOutputs.cend(), OutputScaleComparer());

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -153,14 +153,22 @@ private:
   void LoadDefaultCursor();
   void SendFocusChange(bool focus);
   bool SetResolutionExternal(bool fullScreen, RESOLUTION_INFO const& res);
-  void SetResolutionInternal(CSizeInt size, int scale, IShellSurface::StateBitset state, bool sizeIncludesDecoration, bool mustAck = false, std::uint32_t configureSerial = 0u);
+  void SetResolutionInternal(CSizeInt size,
+                             double scale,
+                             IShellSurface::StateBitset state,
+                             bool sizeIncludesDecoration,
+                             bool mustAck = false,
+                             std::uint32_t configureSerial = 0u);
   struct Sizes
   {
     CSizeInt surfaceSize;
     CSizeInt bufferSize;
     CSizeInt configuredSize;
   };
-  Sizes CalculateSizes(CSizeInt size, int scale, IShellSurface::StateBitset state, bool sizeIncludesDecoration);
+  Sizes CalculateSizes(CSizeInt size,
+                       double scale,
+                       IShellSurface::StateBitset state,
+                       bool sizeIncludesDecoration);
   struct SizeUpdateInformation
   {
     bool surfaceSizeChanged : 1;
@@ -168,7 +176,10 @@ private:
     bool configuredSizeChanged : 1;
     bool bufferScaleChanged : 1;
   };
-  SizeUpdateInformation UpdateSizeVariables(CSizeInt size, int scale, IShellSurface::StateBitset state, bool sizeIncludesDecoration);
+  SizeUpdateInformation UpdateSizeVariables(CSizeInt size,
+                                            double scale,
+                                            IShellSurface::StateBitset state,
+                                            bool sizeIncludesDecoration);
   void ApplySizeUpdate(SizeUpdateInformation update);
   void ApplyNextState();
 
@@ -281,7 +292,7 @@ private:
   /// Size of the whole window including window decorations as given by configure
   CSizeInt m_configuredSize;
   /// Scale in use for main surface buffer
-  int m_scale{1};
+  double m_scale{1.0};
   /// Shell surface state last acked
   IShellSurface::StateBitset m_shellSurfaceState;
   /// Whether the shell surface is waiting for initial configure
@@ -291,7 +302,7 @@ private:
     bool mustBeAcked{false};
     std::uint32_t configureSerial{};
     CSizeInt configuredSize;
-    int scale{1};
+    double scale{1.0};
     IShellSurface::StateBitset shellSurfaceState;
   } m_next;
   bool m_waitingForApply{false};

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -217,6 +217,8 @@ private:
   wayland::compositor_t m_compositor;
   wayland::shm_t m_shm;
   wayland::viewporter_t m_viewporter;
+  wayland::fractional_scale_manager_v1_t m_fractionalScaleManager;
+  wayland::fractional_scale_v1_t m_fractionalScale;
   wayland::presentation_t m_presentation;
 
   std::unique_ptr<IShellSurface> m_shellSurface;

--- a/xbmc/windowing/wayland/WinSystemWayland.h
+++ b/xbmc/windowing/wayland/WinSystemWayland.h
@@ -181,6 +181,7 @@ private:
   void OnOutputDone(std::uint32_t name);
   void UpdateBufferScale();
   void ApplyBufferScale();
+  void ApplyViewportSizes();
   void ApplyOpaqueRegion();
   void ApplyWindowGeometry();
   void UpdateTouchDpi();
@@ -204,6 +205,7 @@ private:
   std::unique_ptr<CRegistry> m_seatRegistry;
   wayland::compositor_t m_compositor;
   wayland::shm_t m_shm;
+  wayland::viewporter_t m_viewporter;
   wayland::presentation_t m_presentation;
 
   std::unique_ptr<IShellSurface> m_shellSurface;
@@ -265,6 +267,7 @@ private:
   // Surface state
   // -------------
   wayland::surface_t m_surface;
+  wayland::viewport_t m_viewport;
   wayland::output_t m_lastSetOutput;
   /// Set of outputs that show some part of our main surface as indicated by
   /// compositor

--- a/xbmc/windowing/wayland/WindowDecorator.cpp
+++ b/xbmc/windowing/wayland/WindowDecorator.cpp
@@ -420,6 +420,7 @@ CWindowDecorator::CWindowDecorator(IWindowDecorationHandler& handler, CConnectio
 
   m_registry.RequestSingleton(m_compositor, 1, 4);
   m_registry.RequestSingleton(m_subcompositor, 1, 1, false);
+  m_registry.RequestSingleton(m_viewporter, 1, 1, false);
   m_registry.RequestSingleton(m_shm, 1, 1);
 
   m_registry.Bind();
@@ -584,13 +585,23 @@ void CWindowDecorator::UpdateSeatCursor(SeatState& seatState)
   if (!seatState.cursor)
   {
     seatState.cursor = m_compositor.create_surface();
+    if (m_viewporter)
+    {
+      seatState.cursorViewport = m_viewporter.get_viewport(seatState.cursor);
+    }
   }
-  int calcScale{seatState.cursor.can_set_buffer_scale() ? m_scale : 1};
+  int calcScale{seatState.cursorViewport || seatState.cursor.can_set_buffer_scale() ? m_scale : 1};
 
   seatState.seat->SetCursor(seatState.pointerEnterSerial, seatState.cursor, cursorImage.hotspot_x() / calcScale, cursorImage.hotspot_y() / calcScale);
   seatState.cursor.attach(cursorImage.get_buffer(), 0, 0);
-  seatState.cursor.damage(0, 0, cursorImage.width() / calcScale, cursorImage.height() / calcScale);
-  if (seatState.cursor.can_set_buffer_scale())
+  seatState.cursor.damage_buffer(0, 0, cursorImage.width(), cursorImage.height());
+  if (seatState.cursorViewport)
+  {
+    seatState.cursorViewport.set_destination(cursorImage.width() / m_scale,
+                                             cursorImage.height() / m_scale);
+    seatState.cursorViewport.set_source(0.0, 0.0, cursorImage.width(), cursorImage.height());
+  }
+  else if (seatState.cursor.can_set_buffer_scale())
   {
     seatState.cursor.set_buffer_scale(m_scale);
   }
@@ -673,6 +684,10 @@ CWindowDecorator::BorderSurface CWindowDecorator::MakeBorderSurface()
   CWindowDecorator::BorderSurface boarderSurface;
   boarderSurface.surface = surface;
   boarderSurface.subsurface = subsurface;
+  if (m_viewporter)
+  {
+    boarderSurface.viewport = m_viewporter.get_viewport(surface.wlSurface);
+  }
 
   return boarderSurface;
 }
@@ -953,7 +968,14 @@ void CWindowDecorator::AllocateBuffers()
       auto region = m_compositor.create_region();
       region.add(opaqueRegionGeometry.x1, opaqueRegionGeometry.y1, opaqueRegionGeometry.Width(), opaqueRegionGeometry.Height());
       borderSurface.surface.wlSurface.set_opaque_region(region);
-      if (borderSurface.surface.wlSurface.can_set_buffer_scale())
+      if (borderSurface.viewport)
+      {
+        borderSurface.viewport.set_destination(borderSurface.geometry.Width(),
+                                               borderSurface.geometry.Height());
+        borderSurface.viewport.set_source(0.0, 0.0, borderSurface.surface.buffer.size.Width(),
+                                          borderSurface.surface.buffer.size.Height());
+      }
+      else if (borderSurface.surface.wlSurface.can_set_buffer_scale())
       {
         borderSurface.surface.wlSurface.set_buffer_scale(m_scale);
       }

--- a/xbmc/windowing/wayland/WindowDecorator.cpp
+++ b/xbmc/windowing/wayland/WindowDecorator.cpp
@@ -731,11 +731,14 @@ CSizeInt CWindowDecorator::CalculateFullSurfaceSize(CSizeInt size, IShellSurface
   }
 }
 
-void CWindowDecorator::SetState(CSizeInt size, int scale, IShellSurface::StateBitset state)
+void CWindowDecorator::SetState(CSizeInt size, double scale, IShellSurface::StateBitset state)
 {
+  // Round to the nearest integer as manually drawing primitives with fractional scaling is hard to implement.
+  // It requires techniques like anti-aliasing, etc. Rely on the compositor to do the proper scaling
+  const int intScale = std::max(std::round(scale), 1.0);
   CSizeInt mainSurfaceSize{CalculateMainSurfaceSize(size, state)};
   std::unique_lock lock(m_mutex);
-  if (mainSurfaceSize == m_mainSurfaceSize && scale == m_scale && state == m_windowState)
+  if (mainSurfaceSize == m_mainSurfaceSize && intScale == m_scale && state == m_windowState)
   {
     return;
   }
@@ -748,12 +751,13 @@ void CWindowDecorator::SetState(CSizeInt size, int scale, IShellSurface::StateBi
   CLog::Log(LOGDEBUG,
             "CWindowDecorator::SetState: Setting full surface size {}x{} scale {} (main surface "
             "size {}x{}), decorations active: {}",
-            size.Width(), size.Height(), scale, mainSurfaceSize.Width(), mainSurfaceSize.Height(),
-            IsDecorationActive());
+            size.Width(), size.Height(), intScale, mainSurfaceSize.Width(),
+            mainSurfaceSize.Height(), IsDecorationActive());
 
-  if (mainSurfaceSize != m_mainSurfaceSize || scale != m_scale || wasDecorations != IsDecorationActive())
+  if (mainSurfaceSize != m_mainSurfaceSize || intScale != m_scale ||
+      wasDecorations != IsDecorationActive())
   {
-    if (scale != m_scale)
+    if (intScale != m_scale)
     {
       // Reload cursor theme
       CLog::Log(LOGDEBUG, "CWindowDecorator::SetState: Buffer scale changed, reloading cursor theme");
@@ -765,7 +769,7 @@ void CWindowDecorator::SetState(CSizeInt size, int scale, IShellSurface::StateBi
     }
 
     m_mainSurfaceSize = mainSurfaceSize;
-    m_scale = scale;
+    m_scale = intScale;
     CLog::Log(LOGDEBUG, "CWindowDecorator::SetState: Resetting decorations");
     Reset(true);
   }

--- a/xbmc/windowing/wayland/WindowDecorator.h
+++ b/xbmc/windowing/wayland/WindowDecorator.h
@@ -85,7 +85,7 @@ public:
    *
    * Call only from main thread
    */
-  void SetState(CSizeInt size, int scale, IShellSurface::StateBitset state);
+  void SetState(CSizeInt size, double scale, IShellSurface::StateBitset state);
   /**
    * Get calculated size of main surface
    */

--- a/xbmc/windowing/wayland/WindowDecorator.h
+++ b/xbmc/windowing/wayland/WindowDecorator.h
@@ -25,6 +25,7 @@
 
 #include <wayland-client-protocol.hpp>
 #include <wayland-cursor.hpp>
+#include <wayland-extra-protocols.hpp>
 
 namespace KODI
 {
@@ -192,6 +193,7 @@ private:
   wayland::shm_pool_t m_shmPool;
   wayland::compositor_t m_compositor;
   wayland::subcompositor_t m_subcompositor;
+  wayland::viewporter_t m_viewporter;
   wayland::surface_t m_mainSurface;
 
   std::unique_ptr<KODI::UTILS::POSIX::CSharedMemory> m_memory;
@@ -201,6 +203,7 @@ private:
   {
     Surface surface;
     wayland::subsurface_t subsurface;
+    wayland::viewport_t viewport;
     CRectInt geometry;
     /// Region of the surface that should count as being part of the window
     CRectInt windowRect;
@@ -231,6 +234,7 @@ private:
     std::uint32_t pointerEnterSerial{};
     std::string cursorName;
     wayland::surface_t cursor;
+    wayland::viewport_t cursorViewport;
 
     explicit SeatState(CSeat* seat)
     : seat{seat}


### PR DESCRIPTION
## Description
This PR introduces support for the Wayland fractional scaling protocol in Kodi.

## Motivation and context
On Wayland-based desktops with fractional scaling enabled, Kodi previously relied on integer surface scaling followed by compositor downscaling. For instance, on a 1440p monitor with 1.25x scaling, Kodi would upscale buffers to 2x, forcing the compositor to downscale back to the target resolution.

This PR should:
* Reduce GPU memory usage: because of smaller surface buffers,
* Improve performance: because of lower GPU memory bandwidth requirements.

Before this PR, amdgpu_top reports around 190 MiB in Kodi home screen. After PR it's down to around 90 MiB. Tested on 1.25 fractional scaling, on 1440p monitor.

## How has this been tested?
Testing was done on Arch Linux with Plasma Desktop 6.6.

## What is the effect on users?
Hopefully it will make Kodi more snappy on weaker GPUs on Wayland-based environments.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
