### PR TITLE
Fix skin reload from addon versions dialog

### DIFF
--- a/xbmc/addons/Skin.cpp
+++ b/xbmc/addons/Skin.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -45,6 +45,8 @@
 #include <set>
 #include <string>
 #include <vector>
+
+#include <fmt/format.h>
 
 using namespace XFILE;
 using namespace KODI::MESSAGING;
@@ -416,9 +418,12 @@ void CSkinInfo::OnPreInstall()
 
 void CSkinInfo::OnPostInstall(bool update, bool modal)
 {
-  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
-  if (!skin)
+  if (CServiceBroker::GetGUI()->GetSkinInfo() == nullptr)
+  {
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
+                                               fmt::format("LoadSkin({})", ID()));
     return;
+  }
 
   if (IsInUse() || (!update && !modal &&
                     HELPERS::ShowYesNoDialogText(CVariant{Name()}, CVariant{24099}) ==

--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later

--- a/xbmc/application/ApplicationSkinHandling.h
+++ b/xbmc/application/ApplicationSkinHandling.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -33,9 +33,9 @@ public:
 
   bool OnSettingChanged(const CSetting& setting);
   void ReloadSkin(bool confirm = false);
+  bool LoadSkin(const std::string& skinID);
 
 protected:
-  bool LoadSkin(const std::string& skinID);
   bool LoadCustomWindows();
 
   /*!

--- a/xbmc/interfaces/builtins/SkinBuiltins.cpp
+++ b/xbmc/interfaces/builtins/SkinBuiltins.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -33,6 +33,7 @@
 #include "storage/MediaManager.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/log.h"
 
 using namespace ADDON;
 
@@ -59,6 +60,25 @@ static int UnloadSkin(const std::vector<std::string>& params)
   const auto appSkin = components.GetComponent<CApplicationSkinHandling>();
   appSkin->UnloadSkin();
 
+  return 0;
+}
+
+/*! \brief Load the provided skin.
+ *  \param params[0] = skinId of the skin to load
+ */
+static int LoadSkin(const std::vector<std::string>& params)
+{
+  if (!params.empty())
+  {
+    auto& components = CServiceBroker::GetAppComponents();
+    const auto appSkin = components.GetComponent<CApplicationSkinHandling>();
+    if (!appSkin->LoadSkin(params[0]))
+      CLog::Log(LOGERROR, "SkinBuiltins: error loading the skin {}", params[0]);
+  }
+  else
+  {
+    CLog::LogF(LOGDEBUG, "empty params - abort.");
+  }
   return 0;
 }
 
@@ -543,6 +563,12 @@ static int SkinTimerStop(const std::vector<std::string>& params)
 ///     Unloads the current skin
 ///   }
 ///   \table_row2_l{
+///     <b>`LoadSkin(skinId)`</b>
+///     ,
+///     Loads the skin passed as a parameter
+///     @param[in] skinId               Addon skin id of the skin.
+///   }
+///   \table_row2_l{
 ///     <b>`Skin.Reset(setting)`</b>
 ///     ,
 ///     Resets the skin `setting`. If `setting` is a bool setting (i.e. set via
@@ -701,6 +727,7 @@ CBuiltins::CommandMap CSkinBuiltins::GetOperations() const
 {
   return {{"reloadskin", {"Reload Kodi's skin", 0, ReloadSkin}},
           {"unloadskin", {"Unload Kodi's skin", 0, UnloadSkin}},
+          {"loadskin", {"Load Kodi's skin", 0, LoadSkin}},
           {"skin.reset", {"Resets a skin setting to default", 1, SkinReset}},
           {"skin.resetsettings", {"Resets all skin settings", 0, SkinResetAll}},
           {"skin.setaddon", {"Prompts and set an addon", 2, SetAddon}},


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Reloading a skin through the versions panel of its addon dialog is a hidden feature for the convenience of skin developpers and it stopped working properly at some point apparently.

The current skin is unloaded as the pre-install step, but the rest of the code assumes that a skin is always loaded, and the skin was not reloaded in the post-install step.

Solution: mimick application startup in the addon post-install to get the skin loaded.

Since I don't really understand the process flows around addons I left the existing code as unchanged as possible, even though simplifications seem possible in the post-install.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #27805

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

changing skin through settings or the "use" button of skins' addon gui dialog is not impacted by the change > confirmed in testing
selecting a skin version of the active skin works correctly instead of going to black screen.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

makes development easier for skinners.

## Screenshots (if appropriate):

Select a version
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/5c1ad406-344b-4e7f-9145-0cb85801a71c" />

Skin reloaded
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/901b60d1-cef7-4e32-97ac-524ee2f4425f" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
