### PR TITLE
Fix build for libfmt < 10.0

### DIFF
--- a/xbmc/utils/i18n/Bcp47Registry/RegistryRecordProvider.h
+++ b/xbmc/utils/i18n/Bcp47Registry/RegistryRecordProvider.h
@@ -13,6 +13,8 @@
 #include <string>
 #include <vector>
 
+#include <fmt/format.h> //! \todo remove after upgrade to libfmt >= 10.0
+
 namespace KODI::UTILS::I18N
 {
 struct RegistryFileField
@@ -49,7 +51,7 @@ struct RegistryFileRecord
 };
 
 /*!
- * \brief fmt/std::format formatter for RegistryFileRecord
+ * \brief RegistryFileRecord formatter for libfmt / future std
  */
 std::string format_as(const RegistryFileRecord& record);
 
@@ -61,3 +63,16 @@ public:
   virtual ~IRegistryRecordProvider() {}
 };
 } // namespace KODI::UTILS::I18N
+
+#if FMT_VERSION < 100000
+// user-type formatters for libfmt < 10.0
+//! \todo remove after libfmt upgrade
+template<>
+struct fmt::formatter<KODI::UTILS::I18N::RegistryFileRecord> : fmt::formatter<std::string>
+{
+  auto format(const KODI::UTILS::I18N::RegistryFileRecord& p, format_context& ctx) const
+  {
+    return fmt::formatter<std::string>::format(KODI::UTILS::I18N::format_as(p), ctx);
+  }
+};
+#endif

--- a/xbmc/utils/i18n/Bcp47Registry/SubTagRegistryTypes.h
+++ b/xbmc/utils/i18n/Bcp47Registry/SubTagRegistryTypes.h
@@ -19,7 +19,7 @@ struct RegistryFileRecord;
 /*!
  * \brief Registry record scopes defined in RFC5646 + special value Unknown
  */
-enum SubTagScope
+enum class SubTagScope
 {
   Unknown,
   Individual, //!< Scope not defined for the record.

--- a/xbmc/utils/i18n/Bcp47Registry/SubTagRegistryTypes.h
+++ b/xbmc/utils/i18n/Bcp47Registry/SubTagRegistryTypes.h
@@ -12,6 +12,8 @@
 #include <string_view>
 #include <vector>
 
+#include <fmt/format.h> //! \todo remove after upgrade to libfmt >= 10.0
+
 namespace KODI::UTILS::I18N
 {
 struct RegistryFileRecord;
@@ -31,7 +33,7 @@ enum class SubTagScope
 
 SubTagScope FindSubTagScope(std::string_view str);
 /*!
- * \brief fmt/std::format formatter for SubTagScope
+ * \brief SubTagScope formatter for libfmt / future std
  */
 std::string_view format_as(SubTagScope scope);
 
@@ -52,7 +54,7 @@ enum class SubTagType
 
 SubTagType FindSubTagType(std::string_view str);
 /*!
- * \brief fmt/std::format formatter for SubTagType
+ * \brief SubTagType formatter for libfmt / future std
  */
 std::string_view format_as(SubTagType type);
 
@@ -135,3 +137,25 @@ struct RedundantTag : BaseSubTag
 {
 };
 } // namespace KODI::UTILS::I18N
+
+#if FMT_VERSION < 100000
+// user-type formatters for libfmt < 10.0
+//! \todo remove after libfmt upgrade
+template<>
+struct fmt::formatter<KODI::UTILS::I18N::SubTagScope> : fmt::formatter<std::string_view>
+{
+  auto format(const KODI::UTILS::I18N::SubTagScope& p, format_context& ctx) const
+  {
+    return fmt::formatter<std::string_view>::format(KODI::UTILS::I18N::format_as(p), ctx);
+  }
+};
+
+template<>
+struct fmt::formatter<KODI::UTILS::I18N::SubTagType> : fmt::formatter<std::string_view>
+{
+  auto format(const KODI::UTILS::I18N::SubTagType& p, format_context& ctx) const
+  {
+    return fmt::formatter<std::string_view>::format(KODI::UTILS::I18N::format_as(p), ctx);
+  }
+};
+#endif


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add compatibility with libfmt versions older than 10.0, using old-style user-type fmt::formatter specializations compiled conditionally.

Unfortunately the FMT_VERSION cannot be tested without including libfmt in the first place...

Used the opportunity to fix a miss in #27893 that defined SubTagScope as an enum instead of enum class.

I think format_as() is the better way for the future as it doesn't require inclusion of headers and is not tied to fmt or std namespace. The formatting lib locates the format_as() function.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Broken build reported in #27893 (which added the new-style format_as() formatters) and #27914.

The libfmt packaged in some linux distributions such as Ubuntu 24.04 and Mint 22.2 is old (v9.1) and doesn't support format_as() formatters well enough. The feature was added in 9.0.0 but improved over a few iterations.
Kodi internal libfmt v12.1.0 has no issue.

From what I gather usage of internal libs should be avoided on those distributions and a workaround to restore compatibility exists (this PR).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It builds on Windows after disabling the version checks, but I can't verify the impacted platforms directly.

I need help to confirm the minimum libfmt version requirement. I'd guess 10.0.0 based on the release note.
edit: received confirmation.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

none

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
