### PR TITLE
Fix use-after-free in CGUIControlGroup::ClearAll()

### DIFF
--- a/xbmc/guilib/GUIControlGroup.cpp
+++ b/xbmc/guilib/GUIControlGroup.cpp
@@ -549,18 +549,14 @@ bool CGUIControlGroup::RemoveControl(const CGUIControl *control)
 
 void CGUIControlGroup::ClearAll()
 {
-  // first remove from the lookup table
-  RemoveLookup();
-
-  // and delete all our children
-  for (auto *control : m_children)
-  {
+  // Delete all children
+  for (auto* control : m_children)
     delete control;
-  }
+
   m_focusedControl = 0;
   m_children.clear();
+  // Clear lookup after deletion is complete
   ClearLookup();
-  SetInvalid();
 }
 
 #ifdef _DEBUG


### PR DESCRIPTION
Fixes #27758

The crash occurs when CGUIControlGroup::ClearAll() calls RemoveLookup() before deleting child controls. In nested control groups, RemoveLookup() can attempt to access already-freed memory during dynamic_cast in the parent's lookup table cleanup.

The fix removes the explicit RemoveLookup() call from ClearAll(), as each child control already removes itself from the parent's lookup table in its destructor via ~CGUIControl() → RemoveLookup(this). This prevents the use-after-free while maintaining correct cleanup order.