### PR TITLE
[pictures] catch exiv2 exceptions

### DIFF
--- a/xbmc/pictures/metadata/ImageMetadataParser.cpp
+++ b/xbmc/pictures/metadata/ImageMetadataParser.cpp
@@ -77,18 +77,26 @@ std::unique_ptr<ImageMetadata> CImageMetadataParser::ExtractMetadata(const std::
   }
 
   // read image metadata
-  auto image = Exiv2::ImageFactory::open(outputBuffer.data(), readbytes);
-  image->readMetadata();
+  try
+  {
+    auto image = Exiv2::ImageFactory::open(outputBuffer.data(), readbytes);
+    image->readMetadata();
 
-  CImageMetadataParser parser;
+    CImageMetadataParser parser;
 
-  // extract metadata
-  parser.ExtractCommonMetadata(*image);
+    // extract metadata
+    parser.ExtractCommonMetadata(*image);
 
-  parser.ExtractExif(image->exifData());
-  parser.ExtractIPTC(image->iptcData());
+    parser.ExtractExif(image->exifData());
+    parser.ExtractIPTC(image->iptcData());
 
-  return std::move(parser.m_imageMetadata);
+    return std::move(parser.m_imageMetadata);
+  }
+  catch (const std::exception& e)
+  {
+    CLog::LogF(LOGERROR, "Failed to extract metadata from {}: {}", picFileName, e.what());
+    return nullptr;
+  }
 }
 
 void CImageMetadataParser::ExtractCommonMetadata(Exiv2::Image& image)


### PR DESCRIPTION
## Description
Found by @notspiff, exiv2 may throw when extracting metadata. `Exiv2::Error` covers all possible exceptions and inherits from `std::exception`.