### PR TITLE
[Android] Suppress compiler deprecation warnings in Java code

### DIFF
--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -112,6 +112,7 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public void onCreate(Bundle savedInstanceState)
   {
     System.loadLibrary("@APP_NAME_LC@");
@@ -221,6 +222,7 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public void onResume()
   {
     super.onResume();

--- a/tools/android/packaging/xbmc/src/XBMCMediaSession.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCMediaSession.java.in
@@ -118,9 +118,11 @@ public class XBMCMediaSession
   public XBMCMediaSession()
   {
     Log.d(TAG, "XBMCMediaSession init");
-    this.mSession = new MediaSession(Main.MainActivity, "XBMC_session");
+    mSession = new MediaSession(Main.MainActivity, "XBMC_session");
     if (Build.VERSION.SDK_INT < 26) {
-      this.mSession.setFlags(MediaSession.FLAG_HANDLES_MEDIA_BUTTONS | MediaSession.FLAG_HANDLES_TRANSPORT_CONTROLS);
+      @SuppressWarnings("deprecation")
+      int flags = MediaSession.FLAG_HANDLES_MEDIA_BUTTONS | MediaSession.FLAG_HANDLES_TRANSPORT_CONTROLS;
+      mSession.setFlags(flags);
     }
 
     Main.MainActivity.runOnUiThread(new Runnable()

--- a/tools/android/packaging/xbmc/src/XBMCRecommendationBuilder.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCRecommendationBuilder.java.in
@@ -101,6 +101,7 @@ public class XBMCRecommendationBuilder
       extras.putString(API_NOTIFICATION_EXTRA_BACKGROUND_IMAGE_URI, mBackgroundUri);
     }
 
+    @SuppressWarnings("deprecation")
     Notification notification = new Notification.BigPictureStyle(
             new Notification.Builder(mContext)
                     .setContentTitle(mTitle)

--- a/tools/android/packaging/xbmc/src/XBMCSearchableActivity.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCSearchableActivity.java.in
@@ -49,6 +49,7 @@ public class XBMCSearchableActivity extends Activity
 
     // Create a simple cursor adapter for the definitions and apply them to the
     // ListView
+    @SuppressWarnings("deprecation")
     SimpleCursorAdapter words = new SimpleCursorAdapter(this, R.layout.result,
             c, from, to);
     mListView.setAdapter(words);


### PR DESCRIPTION
## Description
The warnings being suppressed refer to obsolete code used to support legacy devices. This code is explicitly protected by version checks or is part of a function that is already protected.

## Motivation and context
Compiles without warnings and improves the visibility of potential new warnings.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
