### PR TITLE
[libUPnP] Restore removed source

### DIFF
--- a/lib/libUPnP/Neptune/Source/System/Apple/NptAppleAutoreleasePool.mm
+++ b/lib/libUPnP/Neptune/Source/System/Apple/NptAppleAutoreleasePool.mm
@@ -1,0 +1,61 @@
+/*****************************************************************
+|
+|      Neptune - Autorelease Pool :: Apple Implementation
+|
+|      (c) 2001-2008 Gilles Boccon-Gibod
+|      Author: Gilles Boccon-Gibod (bok@bok.net)
+|
+****************************************************************/
+
+/*----------------------------------------------------------------------
+|   includes
++---------------------------------------------------------------------*/
+#include <Foundation/Foundation.h>
+#include "NptAutoreleasePool.h"
+
+/*----------------------------------------------------------------------
+|   AppleAutoReleasePool
++---------------------------------------------------------------------*/
+class AppleAutoreleasePool : public NPT_AutoreleasePoolInterface 
+{
+public:
+    AppleAutoreleasePool();
+    virtual ~AppleAutoreleasePool();
+
+private:
+    NSAutoreleasePool* m_Pool;
+};
+
+/*----------------------------------------------------------------------
+|   AppleAutoreleasePool::AppleAutoreleasePool
++---------------------------------------------------------------------*/
+AppleAutoreleasePool::AppleAutoreleasePool() 
+{
+    m_Pool = [[NSAutoreleasePool alloc] init];
+}
+
+/*----------------------------------------------------------------------
+|   AppleAutoreleasePool::~AppleAutoreleasePool
++---------------------------------------------------------------------*/
+AppleAutoreleasePool::~AppleAutoreleasePool() 
+{
+    [m_Pool drain];
+    m_Pool = NULL;
+}
+
+/*----------------------------------------------------------------------
+|   NPT_AutoreleasePool::NPT_AutoreleasePool
++---------------------------------------------------------------------*/
+NPT_AutoreleasePool::NPT_AutoreleasePool()
+{
+    m_Delegate = new AppleAutoreleasePool;
+}
+
+/*----------------------------------------------------------------------
+|   NPT_AutoreleasePool::~NPT_AutoreleasePool
++---------------------------------------------------------------------*/
+NPT_AutoreleasePool::~NPT_AutoreleasePool()
+{
+    delete m_Delegate;
+    m_Delegate = NULL;
+}


### PR DESCRIPTION
## Description

Master is broke by my hand. This PR fixes the build for me by restoring a removed Apple file in https://github.com/xbmc/xbmc/pull/27846.

## How has this been tested?

Tested on macOS ARM.

Before:

```
CMake Error at cmake/scripts/common/Macros.cmake:36 (set_target_properties):
  Cannot find source file:

    Neptune/Source/System/Apple/NptAppleAutoreleasePool.mm

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm
  .ccm .cxxm .c++m .h .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90
  .f95 .f03 .hip .ispc
Call Stack (most recent call first):
  lib/libUPnP/CMakeLists.txt:129 (source_group_by_folder)


CMake Error at lib/libUPnP/CMakeLists.txt:106 (add_library):
  No SOURCES given to target: upnp
```

After: `cmake` succeeds.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
