### PR TITLE
Input: remove broken EventServer legacy ASCII handling

### DIFF
--- a/xbmc/input/keyboard/Key.cpp
+++ b/xbmc/input/keyboard/Key.cpp
@@ -173,8 +173,5 @@ float CKey::GetRepeat() const
 
 void CKey::SetFromEventServer(bool fromEventServer)
 {
-  if (fromEventServer && (m_buttonCode & KEY_VKEY))
-    m_unicode = m_buttonCode - KEY_VKEY;
-
   m_fromEventServer = fromEventServer;
 }


### PR DESCRIPTION
Historically Kodi supported injecting ASCII codes via 0xf100-0xf17f button codes (KEY_ASCII in KeyIDs.h) which CKey::SetFromService then mapped to unicode.

When KEY_ASCII was finally removed in 2020 with commit 71cdf2164329c the unicode mapping from the legacy ASCII button codes was broken, changing KEY_ASCII to KEY_VKEY meant m_unicode was set to unicode codepoints 0x0100-0x017f instead of 0x0000-0x007f.

As no one seems to have complained about that likely all event clients have long switched from the deprecated ASCII button codes to unicode which was added to EventServer in 2012 and it's safe to drop this broken legacy handling.

## Description
Remove long broken legacy ASCII mapping code in CKey

## Motivation and context
Cleanup kodi's input handling  and get rid of ancient cruft

## How has this been tested?
Using the keyboard function of Yatse to input characters one-by-one (also tried Kore but it doesn' seem to have such a function, only a "send text" one)

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
