### PR TITLE
Input: remove legacy "Hardy keycode" fallback

### DIFF
--- a/xbmc/input/keymaps/ButtonTranslator.cpp
+++ b/xbmc/input/keymaps/ButtonTranslator.cpp
@@ -217,17 +217,6 @@ bool CButtonTranslator::HasLongpressMapping_Internal(int window, const CKey& key
 
     if (it2 != (*it).second.end())
       return it2->second.id != ACTION_NOOP;
-
-#ifdef TARGET_POSIX
-    // Some buttoncodes changed in Hardy
-    if ((code & KEY_VKEY) == KEY_VKEY && (code & 0x0F00))
-    {
-      code &= ~0x0F00;
-      it2 = (*it).second.find(code);
-      if (it2 != (*it).second.end())
-        return true;
-    }
-#endif
   }
 
   // no key mapping found for the current window do the fallback handling
@@ -269,21 +258,6 @@ unsigned int CButtonTranslator::GetActionCode(int window,
     action = (*it2).second.id;
     strAction = (*it2).second.strID;
   }
-
-#ifdef TARGET_POSIX
-  // Some buttoncodes changed in Hardy
-  if (action == ACTION_NONE && (code & KEY_VKEY) == KEY_VKEY && (code & 0x0F00))
-  {
-    CLog::Log(LOGDEBUG, "{}: Trying Hardy keycode for {:#04x}", __FUNCTION__, code);
-    code &= ~0x0F00;
-    it2 = (*it).second.find(code);
-    if (it2 != (*it).second.end())
-    {
-      action = (*it2).second.id;
-      strAction = (*it2).second.strID;
-    }
-  }
-#endif
 
   return action;
 }


### PR DESCRIPTION
This change was introduced almost 18 years ago when XBMC was still using SDL: https://sourceforge.net/p/xbmc/svn/13561

There's not much info available about this historic issue, but likely something had changed in SDL and this workaround seemed like a good idea to support older and newer SDL versions.

Kodi has long switched away from SDL but this code block was never removed.

Nowadays this change doesn't make any sense. The vkeys are well defined and the condition only triggers on KEY_UNICODE (0xf200) which results in rather meaningless "Trying Hardy keycode for 0xf200" messages in debug log - but the code won't ever match anything as there's no vkey with value 0x00 defined.

So drop the code, it's time has long passed and it's only creating logspam.

## Description
Remove old legacy fallback that does nothing nowadays and only creates logspam

## Motivation and context
Cleanup kodi's input handling code

## How has this been tested?
Running LibreELEC on RPi5 (GBM) and x86 (X11) and verified input handling, including the volume buttons on a keyboard and on an IR remote still work

## What is the effect on users?
Reduced logspam

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
