### PR TITLE
Fix segfaults when GUI can't be created

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -229,6 +229,9 @@ bool CServiceManager::InitStageThree(const std::shared_ptr<CProfileManager>& pro
 
 void CServiceManager::DeinitStageThree()
 {
+  if (init_level < 3)
+    return;
+
   init_level = 2;
 #if !defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
   m_DetectDVDType->StopThread();
@@ -245,6 +248,9 @@ void CServiceManager::DeinitStageThree()
 
 void CServiceManager::DeinitStageTwo()
 {
+  if (init_level < 2)
+    return;
+
   init_level = 1;
 
   m_subTagRegistryManager.reset();
@@ -281,6 +287,9 @@ void CServiceManager::DeinitStageTwo()
 
 void CServiceManager::DeinitStageOne()
 {
+  if (init_level < 1)
+    return;
+
   init_level = 0;
 
   m_network.reset();

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1791,9 +1791,12 @@ bool CApplication::Stop(int exitCode)
     // either a bug in core or misbehaving addons. so try saving
     // skin settings early
     CLog::Log(LOGINFO, "Saving skin settings");
-    auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
-    if (skin)
-      skin->SaveSettings();
+    if (CGUIComponent* gui = CServiceBroker::GetGUI())
+    {
+      auto skin = gui->GetSkinInfo();
+      if (skin)
+        skin->SaveSettings();
+    }
 
     m_bStop = true;
     // Add this here to keep the same ordering behaviour for now
@@ -1844,8 +1847,7 @@ bool CApplication::Stop(int exitCode)
     appListener->UnregisterActionListener(&GetComponent<CApplicationPlayer>()->GetSeekHandler());
     appListener->UnregisterActionListener(&CPlayerController::GetInstance());
 
-    CGUIComponent *gui = CServiceBroker::GetGUI();
-    if (gui)
+    if (CGUIComponent* gui = CServiceBroker::GetGUI())
       gui->GetAudioManager().DeInitialize();
 
     // shutdown the AudioEngine

--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -225,7 +225,11 @@ bool CApplicationSkinHandling::LoadSkin(const std::string& skinID)
 
 void CApplicationSkinHandling::UnloadSkin()
 {
-  auto skin = CServiceBroker::GetGUI()->GetSkinInfo();
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (gui == nullptr)
+    return;
+
+  std::shared_ptr<ADDON::CSkinInfo> skin = gui->GetSkinInfo();
   if (skin && m_saveSkinOnUnloading)
     skin->SaveSettings();
   else if (!m_saveSkinOnUnloading)
@@ -237,29 +241,25 @@ void CApplicationSkinHandling::UnloadSkin()
     CServiceBroker::GetResourcesComponent().GetLocalizeStrings().ClearAddonStrings(skin->ID());
   }
 
-  CGUIComponent* gui = CServiceBroker::GetGUI();
-  if (gui)
-  {
-    gui->GetAudioManager().Enable(false);
+  gui->GetAudioManager().Enable(false);
 
-    gui->GetWindowManager().DeInitialize();
+  gui->GetWindowManager().DeInitialize();
 
-    const std::shared_ptr<CTextureCache> textureCache{CServiceBroker::GetTextureCache()};
-    if (textureCache)
-      textureCache->Deinitialize();
+  const std::shared_ptr<CTextureCache> textureCache{CServiceBroker::GetTextureCache()};
+  if (textureCache)
+    textureCache->Deinitialize();
 
-    // remove the skin-dependent window
-    gui->GetWindowManager().Delete(WINDOW_DIALOG_FULLSCREEN_INFO);
+  // remove the skin-dependent window
+  gui->GetWindowManager().Delete(WINDOW_DIALOG_FULLSCREEN_INFO);
 
-    gui->GetTextureManager().Cleanup();
-    gui->GetLargeTextureManager().CleanupUnusedImages(true);
+  gui->GetTextureManager().Cleanup();
+  gui->GetLargeTextureManager().CleanupUnusedImages(true);
 
-    g_fontManager.Clear();
+  g_fontManager.Clear();
 
-    gui->GetColorManager().Clear();
+  gui->GetColorManager().Clear();
 
-    gui->GetInfoManager().Clear();
-  }
+  gui->GetInfoManager().Clear();
 
   gui->UnloadSkin();
   CLog::Log(LOGINFO, "Unloaded skin");

--- a/xbmc/pvr/channels/PVRChannelGroups.cpp
+++ b/xbmc/pvr/channels/PVRChannelGroups.cpp
@@ -75,8 +75,12 @@ void CPVRChannelGroups::Unload()
   for (const auto& group : m_groups)
     group->Unload();
 
-  CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
-  m_isSubscribed = false;
+  // During shutdown (esp. early abort), ServiceBroker may no longer be safe to use
+  if (m_isSubscribed && CServiceBroker::IsAddonInterfaceUp())
+  {
+    CServiceBroker::GetPVRManager().Events().Unsubscribe(this);
+    m_isSubscribed = false;
+  }
 
   m_groups.clear();
   m_allChannelsGroup.reset();


### PR DESCRIPTION
## Description

I'm testing on my Steam Deck, and when a GUI can't be created, Kodi segfaults in the debugger. I continued to solve crashes until Kodi shut down correctly when no GUI is present.

This PR contains four crash fixes. Basically, I fixed one crash, went on to the next. After the fourth, Kodi exits with no more crash.

## Motivation and context

Kodi won't start without a GUI, but at least it shouldn't crash.

## How has this been tested?

Before: Kodi crashes. Applying each patch in order gets further into the shutdown process.

After, Kodi exits successfully:

```
ERROR: Unable to create GUI. Exiting
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
