### PR TITLE
Fix loading savestate when starting Mupen64Plus-NX

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -318,6 +318,7 @@ bool CGameClient::InitializeGameplay(const std::string& gamePath,
     Input().Start(input);
 
     m_bIsPlaying = true;
+    m_hasFrameRun = false;
     m_gamePath = gamePath;
     m_input = input;
 
@@ -491,6 +492,7 @@ void CGameClient::CloseFile()
     m_inGameSaves.reset();
 
     m_bIsPlaying = false;
+    m_hasFrameRun = false;
     m_gamePath.clear();
     m_serializeSize = 0;
     m_input = nullptr;
@@ -529,6 +531,7 @@ void CGameClient::RunFrame()
     try
     {
       LogError(m_ifc.game->toAddon->RunFrame(m_ifc.game), "RunFrame()");
+      m_hasFrameRun = true;
     }
     catch (...)
     {
@@ -565,11 +568,11 @@ bool CGameClient::Deserialize(const uint8_t* data, size_t size)
   if (data == nullptr || size == 0)
     return false;
 
-  std::unique_lock lock(m_critSection);
-
   bool bSuccess = false;
   if (m_bIsPlaying)
   {
+    std::unique_lock lock(m_critSection);
+
     try
     {
       bSuccess =
@@ -579,6 +582,17 @@ bool CGameClient::Deserialize(const uint8_t* data, size_t size)
     {
       LogException("Deserialize()");
     }
+  }
+
+  // Some cores, like Mupen64Plus-NX, initialize on the first frame, so run
+  // a frame and try again
+  if (!bSuccess && !m_hasFrameRun)
+  {
+    RunFrame();
+
+    std::unique_lock lock(m_critSection);
+
+    bSuccess = LogError(m_ifc.game->toAddon->Deserialize(m_ifc.game, data, size), "Deserialize()");
   }
 
   return bSuccess;

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -256,6 +256,7 @@ private:
 
   // Properties of the current playing file
   std::atomic_bool m_bIsPlaying; // True between OpenFile() and CloseFile()
+  std::atomic_bool m_hasFrameRun{false};
   std::string m_gamePath;
   bool m_bRequiresGameLoop = false;
   size_t m_serializeSize = 0;


### PR DESCRIPTION
## Description

Some cores (e.g. Mupen64Plus-NX) don't fully initialize until the first frame is executed, causing an initial Deserialize() to fail.

To fix this, we track whether a frame has run and, on the first failure before any frame, run one frame and retry Deserialize() once.

## Motivation and context

Testing Mupen64Plus-NX on my macbook, noticed that savestates didn't load at game start, but did load in-game.

## How has this been tested?

Tested on my macbook M2.

Before: Selecting a savestate starts at the beginning of the ROM

After: Selecting a savestate loads successfully, starting gameplay at that point.

## Screenshots (if appropriate):

<img width="1360" height="757" alt="Screenshot 2026-03-03 at 8 31 37 PM" src="https://github.com/user-attachments/assets/c3081ee1-811a-46ec-b267-7fa1877a14a0" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
