### PR TITLE
depends/target: Allow extending `PKG_CONFIG_LIBDIR`

### DIFF
--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -131,6 +131,16 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_FRAMEWORK LAST)
 set(ENV{PKG_CONFIG_LIBDIR} @prefix@/@deps_dir@/lib/pkgconfig:@prefix@/@deps_dir@/share/pkgconfig)
 
+#
+# Allow dev builds to extend pkg-config search paths
+#
+# Example:
+#   export PKG_CONFIG_LIBDIR_EXTRA="/usr/lib/pkgconfig:/usr/share/pkgconfig"
+#
+if(DEFINED ENV{PKG_CONFIG_LIBDIR_EXTRA} AND NOT "$ENV{PKG_CONFIG_LIBDIR_EXTRA}" STREQUAL "")
+  set(ENV{PKG_CONFIG_LIBDIR} "$ENV{PKG_CONFIG_LIBDIR}:$ENV{PKG_CONFIG_LIBDIR_EXTRA}")
+endif()
+
 # Binary Addons
 if(NOT CORE_SYSTEM_NAME STREQUAL linux)
   set(ADDONS_PREFER_STATIC_LIBS ON)


### PR DESCRIPTION
## Description

The depends toolchain sets `PKG_CONFIG_LIBDIR` to the depends prefix to keep builds hermetic and avoid pulling in host libraries.

If `PKG_CONFIG_LIBDIR_EXTRA` is set, append it to `PKG_CONFIG_LIBDIR` so CMake and pkg-config can discover host .pc files when explicitly opted in.

## Motivation and context

For local development (e.g. Steam Deck), some system-only pkg-config packages may be required.

## How has this been tested?

Before: Kody silently fails to find GBM, causing link errors.

If I do this:

```patch

--- a/cmake/modules/FindGBM.cmake
+++ b/cmake/modules/FindGBM.cmake
@@ -5,6 +5,14 @@
 # This will define the following target:
 #
 #   ${APP_NAME_LC}::GBM   - The GBM library
+#
+# It will also define:
+#
+#   GBM_FOUND             - TRUE if GBM was found
+#
+# Notes:
+# - This module must either create the target when found, or fail cleanly
+#   when REQUIRED is used, instead of letting generation fail later.
 
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   include(cmake/scripts/common/ModuleHelpers.cmake)
@@ -18,6 +26,8 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
   SEARCH_EXISTING_PACKAGES()
 
+  set(_gbm_found FALSE)
+
   if(${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_FOUND)
 
     include(CheckCSourceCompiles)
@@ -52,5 +62,17 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     endif()
 
     ADD_TARGET_COMPILE_DEFINITION()
+
+    set(_gbm_found TRUE)
   endif()
+
+  # Proper REQUIRED / QUIET behavior for find_package(GBM [REQUIRED])
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(${CMAKE_FIND_PACKAGE_NAME}
+    REQUIRED_VARS _gbm_found
+  )
+
+  set(${CMAKE_FIND_PACKAGE_NAME}_FOUND ${_gbm_found})
+  unset(_gbm_found)
+
 endif()
```

Then I can see that the find is truly failing:

```
CMake Error at /home/deck/kodi-deps/x86_64-linux-gnu-native/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
  Could NOT find GBM (missing: _gbm_found)
Call Stack (most recent call first):
  /home/deck/kodi-deps/x86_64-linux-gnu-native/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:603 (_FPHSA_FAILURE_MESSAGE)
  cmake/modules/FindGBM.cmake:71 (find_package_handle_standard_args)
  cmake/scripts/common/Macros.cmake:378 (find_package)
  cmake/scripts/common/Macros.cmake:390 (find_package_with_ver)
  CMakeLists.txt:301 (core_require_dep)

-- Configuring incomplete, errors occurred!
make: *** [Makefile:37: all] Error 1
```

Then I expose my pkg-config path:

```
export PKG_CONFIG_LIBDIR_EXTRA="/usr/lib/pkgconfig:/usr/share/pkgconfig"
```

Then I run CMake again:

```
$ make -C tools/depends/target/cmakebuildsys
...
-- Found GBM: TRUE
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
