### PR TITLE
[database][mysql] Change MySQL/MariaDB charset/collation to utf8mb4/utf8mb4_general_ci

### DIFF
--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002, Leo Seib, Hannover
+ *  Copyright (C) 2002-2026, Leo Seib, Hannover
  *
  *  Project:Dataset C++ Dynamic Library
  *  Module: Dataset abstraction layer header file
@@ -58,7 +58,6 @@ protected:
   std::string login;
   std::string passwd; // Login info
   std::string sequence_table{"db_sequence"}; // Sequence table for nextid
-  std::string default_charset; // Default character set
   std::string key;
   std::string cert;
   std::string ca;
@@ -98,8 +97,6 @@ public:
   void setSequenceTable(const char* new_seq_table) { sequence_table = new_seq_table; }
   /* Get name of sequence table */
   const char* getSequenceTable() const { return sequence_table.c_str(); }
-  /* Get the default character set */
-  const char* getDefaultCharset() const { return default_charset.c_str(); }
   /* Sets configuration */
   virtual void setConfig(const char* newKey,
                          const char* newCert,

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -49,6 +49,20 @@ constexpr unsigned long MIN_MYSQL = 50709;
 constexpr std::string_view MIN_MYSQL_STR = "5.7.9";
 constexpr unsigned long MIN_MARIADB = 100205;
 constexpr std::string_view MIN_MARIADB_STR = "10.2.5";
+
+/*!
+ * \brief Validation of unquoted identifiers
+ * \param id Identifier to validate
+ * \return true = valid, false = not valid
+ */
+bool IsValidIdentifier(std::string_view id)
+{
+  if (id.size() > 64)
+    return false;
+
+  return std::ranges::all_of(id, [](char c)
+                             { return StringUtils::isasciialphanum(c) || c == '_' || c == '$'; });
+}
 } // unnamed namespace
 
 namespace dbiplus
@@ -366,6 +380,12 @@ int MysqlDatabase::copy(const char* backup_name)
     // duplicate each table from old db to new db
     while ((row = mysql_fetch_row(res)) != nullptr)
     {
+      if (!IsValidIdentifier(row[0]))
+      {
+        CLog::LogF(LOGERROR, "Invalid table name {} - skipped.", row[0]);
+        continue;
+      }
+
       // copy the table definition
       sqlcmd = StringUtils::Format("CREATE TABLE `{}`.{} LIKE {}", backup_name, row[0], row[0]);
       ret = query_with_reconnect(sqlcmd.c_str());

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -43,6 +43,12 @@ constexpr int ER_BAD_DB_ERROR = 1049;
 #define DEF_COLLATION "utf8mb4_general_ci"
 constexpr std::string_view SQL_CHARSET_COLLATION =
     "CHARACTER SET " DEF_CHARSET " COLLATE " DEF_COLLATION;
+
+// Minimum MySQL and MariaDB versions required for the default large index size needed by utf8mb4
+constexpr unsigned long MIN_MYSQL = 50709;
+constexpr std::string_view MIN_MYSQL_STR = "5.7.9";
+constexpr unsigned long MIN_MARIADB = 100205;
+constexpr std::string_view MIN_MARIADB_STR = "10.2.5";
 } // unnamed namespace
 
 namespace dbiplus
@@ -204,25 +210,22 @@ int MysqlDatabase::connect(bool create_new)
       static bool showed_ver_info = false;
       if (!showed_ver_info)
       {
-        std::string version_string = mysql_get_server_info(conn);
+        const std::string version_string = mysql_get_server_info(conn);
         CLog::Log(LOGINFO, "MYSQL: Connected to version {}", version_string);
         showed_ver_info = true;
-        unsigned long version = mysql_get_server_version(conn);
-        // Minimum for MySQL: 5.6 (5.5 is EOL)
-        unsigned long min_version = 50600;
-        if (version_string.find("MariaDB") != std::string::npos)
-        {
-          // Minimum for MariaDB: 5.5 (still supported)
-          min_version = 50500;
-        }
 
-        if (version < min_version)
+        const unsigned long version = mysql_get_server_version(conn);
+        const unsigned long minVersion =
+            version_string.find("MariaDB") != std::string::npos ? MIN_MARIADB : MIN_MYSQL;
+
+        if (version < minVersion)
         {
-          CLog::Log(
-              LOGWARNING,
-              "MYSQL: Your database server version {} is very old and might not be supported in "
-              "future Kodi versions. Please consider upgrading to MySQL 5.7 or MariaDB 10.2.",
-              version_string);
+          CLog::Log(LOGERROR,
+                    "MYSQL: Your database server version {} is very old. Kodi requires at least "
+                    "MySQL {} or MariaDB {}.",
+                    version_string, MIN_MYSQL_STR, MIN_MARIADB_STR);
+
+          throw DbErrors("database server version %s too old", version_string.c_str());
         }
       }
 

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -55,7 +55,6 @@ MysqlDatabase::MysqlDatabase()
   db = "mysql";
   login = "root";
   passwd = "null";
-  default_charset = "";
 }
 
 MysqlDatabase::~MysqlDatabase()
@@ -226,7 +225,6 @@ int MysqlDatabase::connect(bool create_new)
       //mysql_autocommit(conn, false);
 
       // enforce utf8 charset usage
-      default_charset = mysql_character_set_name(conn);
       if (mysql_set_character_set(conn, "utf8")) // returns 0 on success
       {
         CLog::Log(LOGERROR, "Unable to set utf8 charset: {} [{}]({})", db, mysql_errno(conn),

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -186,21 +186,24 @@ int MysqlDatabase::connect(bool create_new)
   {
     disconnect();
 
-    if (!conn)
+    conn = mysql_init(nullptr);
+    if (conn == nullptr)
+      return DB_CONNECTION_NONE;
+
+    if (!key.empty() || !cert.empty() || !ca.empty() || !capath.empty() || !ciphers.empty())
     {
-      conn = mysql_init(conn);
-      if (!key.empty() || !cert.empty() || !ca.empty() || !capath.empty() || !ciphers.empty())
-      {
-        mysql_ssl_set(conn, key.empty() ? nullptr : key.c_str(),
-                      cert.empty() ? nullptr : cert.c_str(), ca.empty() ? nullptr : ca.c_str(),
-                      capath.empty() ? nullptr : capath.c_str(),
-                      ciphers.empty() ? nullptr : ciphers.c_str());
-      }
-      mysql_options(conn, MYSQL_OPT_CONNECT_TIMEOUT, &connect_timeout);
+      mysql_ssl_set(conn, key.empty() ? nullptr : key.c_str(),
+                    cert.empty() ? nullptr : cert.c_str(), ca.empty() ? nullptr : ca.c_str(),
+                    capath.empty() ? nullptr : capath.c_str(),
+                    ciphers.empty() ? nullptr : ciphers.c_str());
     }
+    mysql_options(conn, MYSQL_OPT_CONNECT_TIMEOUT, &connect_timeout);
 
     if (!CWakeOnAccess::GetInstance().WakeUpHost(host, "MySQL : " + db))
+    {
+      disconnect();
       return DB_CONNECTION_NONE;
+    }
 
     // establish connection with just user credentials
     if (mysql_real_connect(conn, host.c_str(), login.c_str(), passwd.c_str(), nullptr,
@@ -280,13 +283,13 @@ int MysqlDatabase::connect(bool create_new)
 
     CLog::Log(LOGERROR, "Unable to open database: {} [{}]({})", db, mysql_errno(conn),
               mysql_error(conn));
-
-    return DB_CONNECTION_NONE;
   }
   catch (...)
   {
     CLog::Log(LOGERROR, "Unable to open database: {} ({})", db, GetLastError());
   }
+
+  disconnect();
   return DB_CONNECTION_NONE;
 }
 

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1867,29 +1867,6 @@ int MysqlDataset::exec(const std::string& sql)
     qry = qry.insert(loc + 19, " auto_increment ");
   }
 
-  // force the charset and collation to UTF-8
-  if (ci_find(qry, "CREATE TABLE") != std::string::npos ||
-      ci_find(qry, "CREATE TEMPORARY TABLE") != std::string::npos)
-  {
-    // If CREATE TABLE ... SELECT Syntax is used we need to add the encoding after the table before the select
-    // e.g. CREATE TABLE x CHARACTER SET utf8 COLLATE utf8_general_ci [AS] SELECT * FROM y
-    loc = qry.find(" AS SELECT ");
-    if (loc == std::string::npos)
-    {
-      loc = qry.find(" SELECT ");
-    }
-    if (loc != std::string::npos)
-    {
-      qry = qry.insert(loc, SQL_CHARSET_COLLATION);
-      qry = qry.insert(loc, " ");
-    }
-    else
-    {
-      qry.append(" ");
-      qry.append(SQL_CHARSET_COLLATION);
-    }
-  }
-
   const auto start = std::chrono::steady_clock::now();
 
   const int res =

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -38,6 +38,11 @@ namespace
 {
 constexpr int MYSQL_OK = 0;
 constexpr int ER_BAD_DB_ERROR = 1049;
+
+#define DEF_CHARSET "utf8mb4"
+#define DEF_COLLATION "utf8mb4_general_ci"
+constexpr std::string_view SQL_CHARSET_COLLATION =
+    "CHARACTER SET " DEF_CHARSET " COLLATE " DEF_COLLATION;
 } // unnamed namespace
 
 namespace dbiplus
@@ -224,11 +229,11 @@ int MysqlDatabase::connect(bool create_new)
       // disable mysql autocommit since we handle it
       //mysql_autocommit(conn, false);
 
-      // enforce utf8 charset usage
-      if (mysql_set_character_set(conn, "utf8")) // returns 0 on success
+      // enforce charset usage
+      if (mysql_set_character_set(conn, DEF_CHARSET)) // returns 0 on success
       {
-        CLog::Log(LOGERROR, "Unable to set utf8 charset: {} [{}]({})", db, mysql_errno(conn),
-                  mysql_error(conn));
+        CLog::Log(LOGERROR, "Unable to set {} charset: {} [{}]({})", DEF_CHARSET, db,
+                  mysql_errno(conn), mysql_error(conn));
       }
 
       configure_connection();
@@ -240,8 +245,8 @@ int MysqlDatabase::connect(bool create_new)
       }
       else if (create_new)
       {
-        const std::string sqlcmd{StringUtils::Format(
-            "CREATE DATABASE `{}` CHARACTER SET utf8 COLLATE utf8_general_ci", db)};
+        const std::string sqlcmd{
+            StringUtils::Format("CREATE DATABASE `{}` {}", db, SQL_CHARSET_COLLATION)};
         const int ret = query_with_reconnect(sqlcmd.c_str());
         if (ret != MYSQL_OK)
         {
@@ -342,8 +347,7 @@ int MysqlDatabase::copy(const char* backup_name)
     }
 
     // create the new database
-    sqlcmd = StringUtils::Format("CREATE DATABASE `{}` CHARACTER SET utf8 COLLATE utf8_general_ci",
-                                 backup_name);
+    sqlcmd = StringUtils::Format("CREATE DATABASE `{}` {}", backup_name, SQL_CHARSET_COLLATION);
     ret = query_with_reconnect(sqlcmd.c_str());
     if (ret != MYSQL_OK)
     {
@@ -363,6 +367,17 @@ int MysqlDatabase::copy(const char* backup_name)
       {
         mysql_free_result(res);
         throw DbErrors("Can't copy schema for table '%s' (%d)", row[0], ret);
+      }
+
+      // copied tables inherit the charset and collation of the original.
+      // set the character set and collation of the table (including current and future columns)
+      sqlcmd = StringUtils::Format("ALTER TABLE `{}`.{} CONVERT TO {}", backup_name, row[0],
+                                   SQL_CHARSET_COLLATION);
+      ret = query_with_reconnect(sqlcmd.c_str());
+      if (ret != MYSQL_OK)
+      {
+        mysql_free_result(res);
+        throw DbErrors("Can't set character set and collation for table '%s' (%d)", row[0], ret);
       }
 
       // copy the table data
@@ -731,7 +746,7 @@ std::string MysqlDatabase::vprepare(std::string_view format, va_list args)
   }
 
   // Remove COLLATE NOCASE the SQLite case insensitive collation.
-  // In MySQL all tables are defined with case insensitive collation utf8_general_ci
+  // In MySQL all tables are defined with case insensitive collation utf8mb4_general_ci
   pos = 0;
   static std::string_view collateNoCase = " COLLATE NOCASE";
   while ((pos = strResult.find(collateNoCase, pos)) != std::string::npos)
@@ -1865,10 +1880,14 @@ int MysqlDataset::exec(const std::string& sql)
     }
     if (loc != std::string::npos)
     {
-      qry = qry.insert(loc, " CHARACTER SET utf8 COLLATE utf8_general_ci");
+      qry = qry.insert(loc, SQL_CHARSET_COLLATION);
+      qry = qry.insert(loc, " ");
     }
     else
-      qry += " CHARACTER SET utf8 COLLATE utf8_general_ci";
+    {
+      qry.append(" ");
+      qry.append(SQL_CHARSET_COLLATION);
+    }
   }
 
   const auto start = std::chrono::steady_clock::now();

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -9381,7 +9381,7 @@ void CMusicDatabase::UpdateTables(int version)
 
 int CMusicDatabase::GetSchemaVersion() const
 {
-  return 83;
+  return 84;
 }
 
 int CMusicDatabase::GetMusicNeedsTagScan()

--- a/xbmc/pvr/PVRDatabase.h
+++ b/xbmc/pvr/PVRDatabase.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2018 Team Kodi
+ *  Copyright (C) 2012-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -65,7 +65,7 @@ public:
    * @brief Get the minimal database version that is required to operate correctly.
    * @return The minimal database version.
    */
-  int GetSchemaVersion() const override { return 47; }
+  int GetSchemaVersion() const override { return 48; }
 
   /*!
    * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2018 Team Kodi
+ *  Copyright (C) 2012-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -66,7 +66,7 @@ public:
    * @brief Get the minimal database version that is required to operate correctly.
    * @return The minimal database version.
    */
-  int GetSchemaVersion() const override { return 20; }
+  int GetSchemaVersion() const override { return 21; }
 
   /*!
    * @brief Get the default sqlite database filename.

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -1059,5 +1059,5 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 141;
+  return 142;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Set the MySQL/MariaDB character set to utf8mb4 and the collation to utf8mb4_general_ci
They are 4-byte extensions of the currently used utf8 (aliased to utf8mb3 / utf8mb3_general_ci), with support for all unicode characters (including emojis). No change for the characters that were already suppported.

Bump the databases that can be configured as external per advancedsettings (VideoDB MusicDB EPG TV) to recreate the DBs with the new charset and collation.

Increase the minimum MySQL and MariaDB server requirements to versions that enable a large index prefix size by default. utf8mb4 needs larger index pages for varchar(255) and the server supports that with the ROW_FORMAT=DYNAMIC + innodb_large_prefix=TRUE settings.
MySQL: version 5.7.9 from release notes
MariaDB: sometime between 10.2.2 and 13.0. The release notes don't have the detail. An internet post identifies 10.2.5 as the first suitable version (https://docs.bestpractical.com/rt/5.0.0/README.MariaDB.html)
Both are unsupported (released 10 years ago) and users should upgrade to the latest LTS version anyway.
Kodi stops on version check failure.

Removed some unnecessary code: default charset, setting charset and collation in individual CREATE TABLE statements. The database and connection have the correct settings, inherited by the tables and their columns.

Added a validation of the table names and free connection resources earlier when connect() fails.

Wiki: find a place to write the server version requirements

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Feature parity with Sqlite databases, handle all unicode characters.

Work started in #23346, which closes #23312 and #16328
It needed the DB bumps, server requirement bump, charset/collation conversion when upgrading a DB.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With mariadb 11.8, tested a new database and a database upgrade from utf8m3.
Verified the charset and collation of the database, table and column attributes afterwards with db admin tool.
Quick runtime test of Kodi is OK.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Feature parity with Sqlite local databases.
All Japanese/Chinese characters, emojis! Requires compatible fonts for the display, not included here.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
