### PR TITLE
LibInputKeyboard: log xkb keysym and name

### DIFF
--- a/xbmc/platform/linux/input/LibInputKeyboard.cpp
+++ b/xbmc/platform/linux/input/LibInputKeyboard.cpp
@@ -329,8 +329,16 @@ void CLibInputKeyboard::ProcessKey(libinput_event_keyboard *e)
   if (!m_ctx || !m_keymap || !m_state)
     return;
 
-  const uint32_t xkbkey = libinput_event_keyboard_get_key(e) + 8;
+  const uint32_t evkey = libinput_event_keyboard_get_key(e);
+  const uint32_t xkbkey = evkey + 8;
   const xkb_keysym_t keysym = xkb_state_key_get_one_sym(m_state.get(), xkbkey);
+
+  char keyname[64];
+  if (xkb_keysym_get_name(keysym, keyname, sizeof(keyname)) < 0)
+    keyname[0] = 0;
+
+  CLog::LogF(LOGDEBUG, "libinput key: {:#02x}, xkb keysym: {:#04x} ({})", evkey, keysym, keyname);
+
   const bool pressed = libinput_event_keyboard_get_key_state(e) == LIBINPUT_KEY_STATE_PRESSED;
   xkb_state_update_key(m_state.get(), xkbkey, pressed ? XKB_KEY_DOWN : XKB_KEY_UP);
 


### PR DESCRIPTION
Currently it's impossible to tell from debug logs if xkb was unable to map an evdev keycode to a xkb keysym or if the xkb keysym is missing in LibInputKeyboard's xkbMap table.

Both cases result in an XBMCK_UNKNOWN (0) kodi symbol which get logged together with the original evdev keycode (as "scancode") but the info about xkb symbol is only locally available to LibInputKeyboard and is lost in logs.

As it would be a bit over the top to extend XBMC_keysym just to preserve the xkb keysym and log it in KeyboardStat simply log the xkb symbol and name in LibInputKeyboard so we know where the "missing key" comes from.

## Description

Extend LibInput logging so users and devs know if their non-working key/button is caused by xkb (eg via old libxkbcommon / xkeyboard-config packages in their distro) or by kodi.

## Motivation and context

Trying to extend LibInput handling for the newly added multimedia keys/buttons in xkb turned out to be very painful as kodi logs contained no information about which xkb keysym needs to be added to kodi's LibInput handling.

It's also quite hard to help users on the forums with input-issues if the important xkb keysym info is missing

## How has this been tested?

Using the "DVD" button on an MCE IR remote which xkb can map but LibInputKeyboard doesn't support yet shows the mapped xkb sym - and we know we need to to support `XKB_KEY_XF86DVD` in kodi:
```
2026-03-05 15:59:12.764 T:966     debug <general>: void CLibInputKeyboard::ProcessKey(libinput_event_keyboard*): libinput key: 0x185, xkb keysym: 0x10081185 (XF86DVD)
2026-03-05 15:59:12.764 T:966     debug <general>: CLibInputKeyboard::ProcessKey - using delay: 500ms repeat: 125ms
2026-03-05 15:59:12.765 T:1015    debug <general>: Thread Timer start, auto delete: false
2026-03-05 15:59:12.770 T:937     debug <general>: Keyboard: scancode: 0x185, sym: 0x00 (), unicode: 0x00, modifier: 0x0
2026-03-05 15:59:12.770 T:937     debug <general>: bool CInputManager::HandleKey(const CKey&): 0 (0xf200, obc-61697) pressed, window 10000, action is
```

Switching to a about half a year old xkeyboard-config release that didn't support the "OK" button yet shows that it cannot map the "OK" key - and we know we need to look into xkb (config) first:
```
2026-03-05 15:55:34.454 T:968     debug <general>: void CLibInputKeyboard::ProcessKey(libinput_event_keyboard*): libinput key: 0x160, xkb keysym: 0x00 (NoSymbol)
2026-03-05 15:55:34.454 T:908     debug <general>: Keyboard: scancode: 0x160, sym: 0x00 (), unicode: 0x00, modifier: 0x0
2026-03-05 15:55:34.454 T:908     debug <general>: bool CInputManager::HandleKey(const CKey&): 0 (0xf200, obc-61697) pressed, window 10000, action is
```

Before we only got the "Keyboard: scancode" and "HandleKey" lines.

## What is the effect on users?

Ideally it gives users a clue what's going wrong so they can fix xkb/input related issues themselves, or at least they are now able to provide more useful logs in bugreports.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
