### PR TITLE
chore: add .kodiai.yml to enable kodiai write mode

### DIFF
--- a/.kodiai.yml
+++ b/.kodiai.yml
@@ -1,0 +1,2 @@
+write:
+  enabled: true


### PR DESCRIPTION
## Summary
- Adds `.kodiai.yml` configuration file to enable kodiai's write mode for this repository
- When write mode is enabled, kodiai can create PRs with code changes when explicitly asked (e.g., `@kodiai apply: fix the null check in PlayerController`)
- Without this file, kodiai operates in read-only mode and can only provide analysis and suggestions

## Context
kodiai is a GitHub App that provides AI-assisted code review and mentoring. Write mode allows it to go beyond analysis and actually submit patches when requested. All write operations require explicit user intent (prefixed commands or recognized implementation requests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)