### PR TITLE
[dbwrappers] Remove Database class member last_err

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -579,9 +579,9 @@ long MysqlDatabase::nextid(const char* sname)
   int id;
   std::string sqlcmd{
       StringUtils::Format("SELECT nextid FROM {} WHERE seq_name = '{}'", seq_table, sname)};
-  last_err = query_with_reconnect(sqlcmd.c_str());
+  int err = query_with_reconnect(sqlcmd.c_str());
   CLog::LogFC(LOGDEBUG, LOGDATABASE, "will request");
-  if (last_err != 0)
+  if (err != 0)
   {
     return DB_UNEXPECTED_RESULT;
   }
@@ -594,8 +594,8 @@ long MysqlDatabase::nextid(const char* sname)
       sqlcmd = StringUtils::Format("INSERT INTO {} (nextid,seq_name) VALUES ({},'{}')", seq_table,
                                    id, sname);
       mysql_free_result(res);
-      last_err = query_with_reconnect(sqlcmd.c_str());
-      if (last_err != 0)
+      err = query_with_reconnect(sqlcmd.c_str());
+      if (err != 0)
         return DB_UNEXPECTED_RESULT;
 
       return id;
@@ -606,8 +606,8 @@ long MysqlDatabase::nextid(const char* sname)
       sqlcmd = StringUtils::Format("UPDATE {} SET nextid=%d WHERE seq_name = '{}'", seq_table, id,
                                    sname);
       mysql_free_result(res);
-      last_err = query_with_reconnect(sqlcmd.c_str());
-      if (last_err != 0)
+      err = query_with_reconnect(sqlcmd.c_str());
+      if (err != 0)
         return DB_UNEXPECTED_RESULT;
 
       return id;

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -31,7 +31,6 @@ protected:
   /* connect descriptor */
   MYSQL* conn{nullptr};
   bool _in_transaction{false};
-  int last_err;
 
 public:
   /* default constructor */

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -1,5 +1,5 @@
 /**********************************************************************
- *  Copyright (C) 2004, Leo Seib, Hannover
+ *  Copyright (C) 2004-2026, Leo Seib, Hannover
  *
  *  Project:SQLiteDataset C++ Dynamic Library
  *  Module: SQLiteDataset class realisation file
@@ -387,8 +387,9 @@ bool SqliteDatabase::exists()
 
   // performing a select all on the sqlite_master will return rows if there are tables
   // defined indicating it's not empty and therefore must "exist".
-  last_err = sqlite3_exec(getHandle(), "SELECT * FROM sqlite_master", &callback, &res, nullptr);
-  if (last_err == SQLITE_OK)
+  const int err =
+      sqlite3_exec(getHandle(), "SELECT * FROM sqlite_master", &callback, &res, nullptr);
+  if (err == SQLITE_OK)
   {
     bRet = !res.records.empty();
   }
@@ -481,48 +482,48 @@ int SqliteDatabase::drop_analytics()
   result_set res;
 
   CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning indexes from database {} at {}", db, host);
-  last_err =
+  int err =
       sqlite3_exec(conn, "SELECT name FROM sqlite_master WHERE type == 'index' AND sql IS NOT NULL",
                    &callback, &res, nullptr);
-  if (last_err != SQLITE_OK)
+  if (err != SQLITE_OK)
     return DB_UNEXPECTED_RESULT;
 
   std::string sqlcmd;
   for (const auto record : res.records)
   {
     sqlcmd = StringUtils::Format("DROP INDEX '{}'", record->at(0).get_asString().c_str());
-    last_err = sqlite3_exec(conn, sqlcmd.c_str(), nullptr, nullptr, nullptr);
-    if (last_err != SQLITE_OK)
+    err = sqlite3_exec(conn, sqlcmd.c_str(), nullptr, nullptr, nullptr);
+    if (err != SQLITE_OK)
       return DB_UNEXPECTED_RESULT;
   }
   res.clear();
 
   CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning views from database {} at {}", db, host);
-  last_err = sqlite3_exec(conn, "SELECT name FROM sqlite_master WHERE type == 'view'", &callback,
-                          &res, nullptr);
-  if (last_err != SQLITE_OK)
+  err = sqlite3_exec(conn, "SELECT name FROM sqlite_master WHERE type == 'view'", &callback, &res,
+                     nullptr);
+  if (err != SQLITE_OK)
     return DB_UNEXPECTED_RESULT;
 
   for (const auto& record : res.records)
   {
     sqlcmd = StringUtils::Format("DROP VIEW '{}'", record->at(0).get_asString().c_str());
-    last_err = sqlite3_exec(conn, sqlcmd.c_str(), nullptr, nullptr, nullptr);
-    if (last_err != SQLITE_OK)
+    err = sqlite3_exec(conn, sqlcmd.c_str(), nullptr, nullptr, nullptr);
+    if (err != SQLITE_OK)
       return DB_UNEXPECTED_RESULT;
   }
   res.clear();
 
   CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning triggers from database {} at {}", db, host);
-  last_err = sqlite3_exec(conn, "SELECT name FROM sqlite_master WHERE type == 'trigger'", &callback,
-                          &res, nullptr);
-  if (last_err != SQLITE_OK)
+  err = sqlite3_exec(conn, "SELECT name FROM sqlite_master WHERE type == 'trigger'", &callback,
+                     &res, nullptr);
+  if (err != SQLITE_OK)
     return DB_UNEXPECTED_RESULT;
 
   for (const auto& record : res.records)
   {
     sqlcmd = StringUtils::Format("DROP TRIGGER '{}'", record->at(0).get_asString().c_str());
-    last_err = sqlite3_exec(conn, sqlcmd.c_str(), nullptr, nullptr, nullptr);
-    if (last_err != SQLITE_OK)
+    err = sqlite3_exec(conn, sqlcmd.c_str(), nullptr, nullptr, nullptr);
+    if (err != SQLITE_OK)
       return DB_UNEXPECTED_RESULT;
   }
   // res would be cleared on destruct
@@ -553,8 +554,8 @@ long SqliteDatabase::nextid(const char* sname)
   result_set res;
   std::string sqlcmd{
       StringUtils::Format("SELECT nextid FROM {} WHERE seq_name = '{}'", sequence_table, sname)};
-  last_err = sqlite3_exec(getHandle(), sqlcmd.c_str(), &callback, &res, nullptr);
-  if (last_err != SQLITE_OK)
+  int err = sqlite3_exec(getHandle(), sqlcmd.c_str(), &callback, &res, nullptr);
+  if (err != SQLITE_OK)
   {
     return DB_UNEXPECTED_RESULT;
   }
@@ -563,8 +564,8 @@ long SqliteDatabase::nextid(const char* sname)
     id = 1;
     sqlcmd = StringUtils::Format("INSERT INTO {} (nextid,seq_name) VALUES ({},'{}')",
                                  sequence_table, id, sname);
-    last_err = sqlite3_exec(conn, sqlcmd.c_str(), nullptr, nullptr, nullptr);
-    if (last_err != SQLITE_OK)
+    err = sqlite3_exec(conn, sqlcmd.c_str(), nullptr, nullptr, nullptr);
+    if (err != SQLITE_OK)
       return DB_UNEXPECTED_RESULT;
     return id;
   }
@@ -573,8 +574,8 @@ long SqliteDatabase::nextid(const char* sname)
     id = res.records[0]->at(0).get_asInt() + 1;
     sqlcmd = StringUtils::Format("UPDATE {} SET nextid={} WHERE seq_name = '{}'", sequence_table,
                                  id, sname);
-    last_err = sqlite3_exec(conn, sqlcmd.c_str(), nullptr, nullptr, nullptr);
-    if (last_err != SQLITE_OK)
+    err = sqlite3_exec(conn, sqlcmd.c_str(), nullptr, nullptr, nullptr);
+    if (err != SQLITE_OK)
       return DB_UNEXPECTED_RESULT;
     return id;
   }

--- a/xbmc/dbwrappers/sqlitedataset.h
+++ b/xbmc/dbwrappers/sqlitedataset.h
@@ -31,7 +31,6 @@ protected:
   /* connect descriptor */
   sqlite3* conn{nullptr};
   bool _in_transaction{false};
-  int last_err;
 
 public:
   /* default constructor */


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Error numbers returned by Sqlite / MySQL /MariaDB were not treated consistently - some were stored in a function local variable `err`, some in the class member `last_err`.
Since there is no need to have the info at class level, reduced the scope so all such variable are local to the functions.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

inconsistency noticed while making other mysql changes.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

sqlite/mysql run.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

none

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
