### PR TITLE
[Video][Settings] Fix advanced stacking settings not respected and roman numeral part numbers not supported.

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -52,13 +52,6 @@ bool ValidateVideoStackRegex(const CRegExp& regex)
   return true;
 };
 
-std::vector<CRegExp> CompileRegexesFromXML(const TiXmlElement* folderStacking)
-{
-  std::vector<std::string> patterns;
-  CAdvancedSettings::GetCustomRegexps(folderStacking, patterns);
-  return CompileRegexes(patterns);
-}
-
 void ParseDatabaseSettings(const TiXmlElement* element, DatabaseSettings& settings)
 {
   XMLUtils::GetString(element, "type", settings.type);
@@ -310,19 +303,21 @@ void CAdvancedSettings::Initialize()
                                         m_allExcludeFromScanRegExps.begin(),
                                         m_allExcludeFromScanRegExps.end());
 
-  m_folderStackRegExps = CompileRegexes({
+  m_folderStackStrings = {
       "^(.*?)[ _.-]*((?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[0-9])$",
       "()((?:p(?:(?:ar)?t)[ _.-]*[0-9]))$",
-  });
+  };
+  m_folderStackRegExps = CompileRegexes(m_folderStackStrings);
 
-  m_videoStackRegExps = CompileRegexes({
+  m_videoStackStrings = {
       "(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck]|file)[ _.-]*[0-9]+)(.*?)(\\.[^.]+)$",
       "(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[a-h])(.*?)(\\.[^.]+)$",
       "^(.+)((?:[ ._-]|(?<=\\)))[a-h])()(\\.[^.]+)$",
       // This one is a bit too greedy to enable by default.  It will stack sequels
       // in a flat dir structure, but is perfectly safe in a dir-per-vid one.
       // "(.*?)([ ._-]*[0-9])(.*?)(\\.[^.]+)$",
-  });
+  };
+  m_videoStackRegExps = CompileRegexes(m_videoStackStrings);
 
   m_tvshowEnumRegExps.clear();
   // foo.s01.e01, foo.s01_e01, S01E02 foo, S01 - E02, S01xE02
@@ -1104,17 +1099,17 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   const TiXmlElement* videoStacking = pRootElement->FirstChildElement("moviestacking");
   if (videoStacking)
   {
-    std::vector<CRegExp> regexes = CompileRegexesFromXML(videoStacking);
-    std::erase_if(regexes, std::not_fn(ValidateVideoStackRegex));
-    std::ranges::move(regexes, std::back_inserter(m_videoStackRegExps));
+    GetCustomRegexps(videoStacking, m_videoStackStrings);
+    m_videoStackRegExps = CompileRegexes(m_videoStackStrings);
+    std::erase_if(m_videoStackRegExps, std::not_fn(ValidateVideoStackRegex));
   }
 
   // folder stacking regexps
   const TiXmlElement* folderStacking = pRootElement->FirstChildElement("folderstacking");
   if (folderStacking)
   {
-    std::vector<CRegExp> regexes = CompileRegexesFromXML(folderStacking);
-    std::ranges::move(regexes, std::back_inserter(m_folderStackRegExps));
+    GetCustomRegexps(folderStacking, m_folderStackStrings);
+    m_folderStackRegExps = CompileRegexes(m_folderStackStrings);
   }
 
   //tv stacking regexps

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -317,8 +317,8 @@ void CAdvancedSettings::Initialize()
 
   m_videoStackRegExps = CompileRegexes({
       "(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck]|file)[ _.-]*[0-9]+)(.*?)(\\.[^.]+)$",
-      "(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[a-z])(.*?)(\\.[^.]+)$",
-      "^(.+)((?:[ ._-]|(?<=\\)))[a-z])()(\\.[^.]+)$",
+      "(.*?)([ _.-]*(?:cd|dvd|p(?:(?:ar)?t)|dis[ck])[ _.-]*[a-h])(.*?)(\\.[^.]+)$",
+      "^(.+)((?:[ ._-]|(?<=\\)))[a-h])()(\\.[^.]+)$",
       // This one is a bit too greedy to enable by default.  It will stack sequels
       // in a flat dir structure, but is perfectly safe in a dir-per-vid one.
       // "(.*?)([ ._-]*[0-9])(.*?)(\\.[^.]+)$",

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -424,6 +424,9 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     void Clear();
     void SetExtraArtwork(const TiXmlElement* arttypes, std::vector<std::string>& artworkMap) const;
 
+    std::vector<std::string> m_videoStackStrings;
+    std::vector<std::string> m_folderStackStrings;
+
     mutable CCriticalSection m_listCritSection;
     std::map<int, AdvancedSettingsCallback> m_settingsLoadedCallbacks;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Prevent erronous processing of roman numeral stack parts.
Properly process `append` and `action` attributes in `<moviestacking>` and `<folderstacking>` advanced settings.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #27936.

https://kodi.wiki/view/Advancedsettings.xml#moviestacking describes how the `<moviestacking>` and `<folderstacking>` advanced settings can have an `append` or `action` attribute.

These are currently not processed properly.

Secondly - the filenames shouldn't really stacked anyway so i've changed one of the file stack regexs from a-z to a-h to avoid stacking those with 'Part I', 'Part II' etc.. as roman numerals are not supported.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
