### PR TITLE
VideoPlayer Chapter Change Accuracy

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -11,6 +11,7 @@
 #include "Interface/StreamInfo.h"
 #include "cores/FFmpeg.h"
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -282,10 +283,13 @@ public:
   virtual void GetChapterName(std::string& strChapterName, int chapterIdx = -1) {}
 
   /*
-   * Get the position of a chapter
-   * \param chapterIdx -1 for current chapter, else a chapter index
+   * Get the position of a chapter in milliseconds
+   * \param[in] chapterIdx -1 for current chapter, else a chapter index
    */
-  virtual int64_t GetChapterPos(int chapterIdx = -1) { return 0; }
+  virtual std::chrono::milliseconds GetChapterPos(int chapterIdx = -1)
+  {
+    return std::chrono::milliseconds(0);
+  }
 
   /*
    * Set the playspeed, if demuxer can handle different

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -2083,10 +2083,9 @@ std::chrono::milliseconds CDVDDemuxFFmpeg::GetChapterPos(int chapterIdx)
   if (chapterIdx <= 0)
     return 0ms;
 
-  //! @todo get ms precision
   std::shared_ptr<CDVDInputStream::IChapter> ich = std::dynamic_pointer_cast<CDVDInputStream::IChapter>(m_pInput);
   if (ich)
-    return std::chrono::seconds(ich->GetChapterPos(chapterIdx));
+    return ich->GetChapterPos(chapterIdx);
 
   std::chrono::duration<float> fsec(m_pFormatContext->chapters[chapterIdx - 1]->start *
                                     av_q2d(m_pFormatContext->chapters[chapterIdx - 1]->time_base));
@@ -2107,7 +2106,8 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
 
     if (startpts)
     {
-      *startpts = DVD_SEC_TO_TIME(static_cast<double>(ich->GetChapterPos(chapter)));
+      *startpts =
+          DVD_SEC_TO_TIME(std::chrono::duration<double>(ich->GetChapterPos(chapter)).count());
     }
 
     Flush();

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -2074,18 +2074,23 @@ void CDVDDemuxFFmpeg::GetChapterName(std::string& strChapterName, int chapterIdx
   }
 }
 
-int64_t CDVDDemuxFFmpeg::GetChapterPos(int chapterIdx)
+std::chrono::milliseconds CDVDDemuxFFmpeg::GetChapterPos(int chapterIdx)
 {
+  using namespace std::chrono_literals;
+
   if (chapterIdx <= 0 || chapterIdx > GetChapterCount())
     chapterIdx = GetChapter();
   if (chapterIdx <= 0)
-    return 0;
+    return 0ms;
 
+  //! @todo get ms precision
   std::shared_ptr<CDVDInputStream::IChapter> ich = std::dynamic_pointer_cast<CDVDInputStream::IChapter>(m_pInput);
   if (ich)
-    return ich->GetChapterPos(chapterIdx);
+    return std::chrono::seconds(ich->GetChapterPos(chapterIdx));
 
-  return static_cast<int64_t>(m_pFormatContext->chapters[chapterIdx - 1]->start * av_q2d(m_pFormatContext->chapters[chapterIdx - 1]->time_base));
+  std::chrono::duration<float> fsec(m_pFormatContext->chapters[chapterIdx - 1]->start *
+                                    av_q2d(m_pFormatContext->chapters[chapterIdx - 1]->time_base));
+  return std::chrono::duration_cast<std::chrono::milliseconds>(fsec);
 }
 
 bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -2027,16 +2027,29 @@ int CDVDDemuxFFmpeg::GetChapter()
   if (ich)
     return ich->GetChapter();
 
-  if (m_pFormatContext == NULL
-  || m_currentPts == DVD_NOPTS_VALUE)
+  if (m_pFormatContext == NULL || m_currentPts == DVD_NOPTS_VALUE)
     return 0;
 
-  for(unsigned i = 0; i < m_pFormatContext->nb_chapters; i++)
+  for (unsigned i = 0; i < m_pFormatContext->nb_chapters; i++)
   {
-    AVChapter* chapter = m_pFormatContext->chapters[i];
-    if (m_currentPts >= ConvertTimestamp(chapter->start, chapter->time_base.den, chapter->time_base.num)
-    && m_currentPts <  ConvertTimestamp(chapter->end,   chapter->time_base.den, chapter->time_base.num))
-      return i + 1;
+    const AVChapter* chapter = m_pFormatContext->chapters[i];
+    const double startPts =
+        ConvertTimestamp(chapter->start, chapter->time_base.den, chapter->time_base.num);
+
+    if (i == m_pFormatContext->nb_chapters - 1)
+    {
+      if (m_currentPts >= startPts)
+        return i + 1;
+    }
+    else
+    {
+      const AVChapter* nextChapter = m_pFormatContext->chapters[i + 1];
+      const double nextStartPts = ConvertTimestamp(nextChapter->start, nextChapter->time_base.den,
+                                                   nextChapter->time_base.num);
+
+      if (m_currentPts >= startPts && m_currentPts < nextStartPts)
+        return i + 1;
+    }
   }
 
   return 0;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -108,7 +108,7 @@ public:
   int GetChapterCount() override;
   int GetChapter() override;
   void GetChapterName(std::string& strChapterName, int chapterIdx=-1) override;
-  int64_t GetChapterPos(int chapterIdx = -1) override;
+  std::chrono::milliseconds GetChapterPos(int chapterIdx = -1) override;
   std::string GetStreamCodecName(int iStreamId) override;
 
   bool Aborted();

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -165,7 +165,7 @@ std::unique_ptr<CTexture> CDVDFileInfo::ExtractThumbToTexture(const CFileItem& f
 
       bool seekToChapter = chapterNumber > 0 && demuxer->GetChapterCount() > 0;
       int64_t nSeekTo =
-          seekToChapter ? demuxer->GetChapterPos(chapterNumber) * 1000 : nTotalLen / 3;
+          seekToChapter ? demuxer->GetChapterPos(chapterNumber).count() : nTotalLen / 3;
 
       CLog::LogF(LOGDEBUG, "seeking to pos {}ms (total: {}ms) in {}", nSeekTo, nTotalLen,
                  redactPath);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -89,8 +89,8 @@ public:
   {
   public:
     virtual ~IChapter() = default;
-    virtual int  GetChapter() = 0;
-    virtual int  GetChapterCount() = 0;
+    virtual int GetChapter() = 0;
+    virtual int GetChapterCount() = 0;
     virtual void GetChapterName(std::string& name, int ch=-1) = 0;
     virtual int64_t GetChapterPos(int ch=-1) = 0;
     virtual bool SeekChapter(int ch) = 0;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -91,8 +91,8 @@ public:
     virtual ~IChapter() = default;
     virtual int GetChapter() = 0;
     virtual int GetChapterCount() = 0;
-    virtual void GetChapterName(std::string& name, int ch=-1) = 0;
-    virtual int64_t GetChapterPos(int ch=-1) = 0;
+    virtual void GetChapterName(std::string& name, int ch = -1) = 0;
+    virtual std::chrono::milliseconds GetChapterPos(int ch = -1) = 0;
     virtual bool SeekChapter(int ch) = 0;
   };
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -987,15 +987,15 @@ bool CDVDInputStreamBluray::SeekChapter(int ch)
   return true;
 }
 
-int64_t CDVDInputStreamBluray::GetChapterPos(int ch)
+std::chrono::milliseconds CDVDInputStreamBluray::GetChapterPos(int ch)
 {
   if (ch == -1 || ch > GetChapterCount())
     ch = GetChapter();
 
   if (m_titleInfo && m_titleInfo->chapters)
-    return m_titleInfo->chapters[ch - 1].start / 90000;
+    return std::chrono::milliseconds{m_titleInfo->chapters[ch - 1].start / 90};
   else
-    return 0;
+    return std::chrono::milliseconds{0};
 }
 
 int64_t CDVDInputStreamBluray::Seek(int64_t offset, int whence)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -117,7 +117,7 @@ public:
   int GetChapter() override;
   int GetChapterCount() override;
   void GetChapterName(std::string& name, int ch=-1) override {};
-  int64_t GetChapterPos(int ch) override;
+  std::chrono::milliseconds GetChapterPos(int ch) override;
   bool SeekChapter(int ch) override;
 
   CDVDInputStream::IDisplayTime* GetIDisplayTime() override { return this; }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -547,11 +547,12 @@ int CDVDInputStreamNavigator::ProcessBlock(uint8_t* dest_buffer, int* read)
 
           if (times)
           {
-            // the times array stores the end timestamps of the chapters, e.g., times[0] stores the position/beginning of chapter 2
+            // the times array stores the duration of the chapters
+            // e.g. times[0] stores the end timestamp of the 1st chapter / beginning of chapter 2
             m_mapTitleChapters[m_iTitle][1] = 0;
             for (int i = 0; i < entries - 1; ++i)
             {
-              m_mapTitleChapters[m_iTitle][i + 2] = times[i] / 90000;
+              m_mapTitleChapters[m_iTitle][i + 2] = times[i] / 90;
             }
             free(times);
           }
@@ -1433,7 +1434,7 @@ std::string CDVDInputStreamNavigator::GetDVDVolIdString()
   return "";
 }
 
-int64_t CDVDInputStreamNavigator::GetChapterPos(int ch)
+std::chrono::milliseconds CDVDInputStreamNavigator::GetChapterPos(int ch)
 {
   if (ch == -1 || ch > GetChapterCount())
     ch = GetChapter();
@@ -1443,9 +1444,9 @@ int64_t CDVDInputStreamNavigator::GetChapterPos(int ch)
   {
     std::map<int, int64_t>::iterator chapter = title->second.find(ch);
     if (chapter != title->second.end())
-      return chapter->second;
+      return std::chrono::milliseconds{chapter->second};
   }
-  return 0;
+  return std::chrono::milliseconds{0};
 }
 
 void CDVDInputStreamNavigator::GetVideoResolution(uint32_t* width, uint32_t* height)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.h
@@ -117,8 +117,8 @@ public:
 
   int GetChapter() override { return m_iPart; } // the current part in the current title
   int GetChapterCount() override { return m_iPartCount; } // the number of parts in the current title
-  void GetChapterName(std::string& name, int idx=-1) override {};
-  int64_t GetChapterPos(int ch=-1) override;
+  void GetChapterName(std::string& name, int idx = -1) override {};
+  std::chrono::milliseconds GetChapterPos(int ch = -1) override;
   bool SeekChapter(int iChapter) override;
 
   CDVDInputStream::IDisplayTime* GetIDisplayTime() override { return this; }
@@ -196,6 +196,9 @@ protected:
   uint8_t m_lastblock[DVD_VIDEO_BLOCKSIZE];
   int m_lastevent;
 
+  /*!
+   * \brief Chapters start timestamps in milliseconds, per title. Chapter numbers are 1-based.
+   */
   std::map<int, std::map<int, int64_t>> m_mapTitleChapters;
 
   /*! DVD state serializer handler */

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -704,12 +704,13 @@ void CInputStreamAddon::GetChapterName(std::string& name, int ch)
   }
 }
 
-int64_t CInputStreamAddon::GetChapterPos(int ch)
+std::chrono::milliseconds CInputStreamAddon::GetChapterPos(int ch)
 {
+  //! @todo add API for ms precision
   if (m_ifc.inputstream->toAddon->get_chapter_pos)
-    return m_ifc.inputstream->toAddon->get_chapter_pos(m_ifc.inputstream, ch);
+    return std::chrono::seconds{m_ifc.inputstream->toAddon->get_chapter_pos(m_ifc.inputstream, ch)};
 
-  return 0;
+  return std::chrono::milliseconds{0};
 }
 
 bool CInputStreamAddon::SeekChapter(int ch)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -100,7 +100,7 @@ public:
   int GetChapter() override;
   int GetChapterCount() override;
   void GetChapterName(std::string& name, int ch = -1) override;
-  int64_t GetChapterPos(int ch = -1) override;
+  std::chrono::milliseconds GetChapterPos(int ch = -1) override;
   bool SeekChapter(int ch) override;
 
 protected:

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5122,10 +5122,9 @@ void CVideoPlayer::UpdatePlayState(double timeout)
       {
         for (int i = 0, ie = pChapter->GetChapterCount(); i < ie; ++i)
         {
-          std::string name;
-          pChapter->GetChapterName(name, i + 1);
-          //! @todo get better than second resolution
-          state.chapters.emplace_back(name, pChapter->GetChapterPos(i + 1) * 1000);
+          auto& p =
+              state.chapters.emplace_back(std::string{}, pChapter->GetChapterPos(i + 1).count());
+          pChapter->GetChapterName(p.first, i + 1);
         }
       }
     }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5081,20 +5081,13 @@ void CVideoPlayer::UpdatePlayState(double timeout)
   else if (m_CurrentAudio.startpts != DVD_NOPTS_VALUE)
     state.dts = m_CurrentAudio.startpts;
 
-  state.startTime = 0;
-  state.timeMin = 0;
-
   std::shared_ptr<CDVDInputStream::IMenus> pMenu = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInputStream);
 
   bool chapterNbEnabled{false};
 
   if (m_pDemuxer)
   {
-    if (IsInMenuInternal() && pMenu && !pMenu->CanSeek())
-    {
-      state.chapter = 0;
-    }
-    else
+    if (!(IsInMenuInternal() && pMenu && !pMenu->CanSeek()))
     {
       state.chapter = m_pDemuxer->GetChapter();
       chapterNbEnabled = true;
@@ -5107,7 +5100,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
       {
         std::string name;
         m_pDemuxer->GetChapterName(name, i + 1);
-        //! @todo get better than second resolution from the stream?
+        //! @todo get better than second resolution
         std::chrono::milliseconds position{m_pDemuxer->GetChapterPos(i + 1) * 1000};
         state.chapters.emplace_back(name, m_Edl.GetTimeWithoutCuts(position).count());
       }
@@ -5116,22 +5109,12 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     state.timeMax = m_pDemuxer->GetStreamLength();
   }
 
-  state.canpause = false;
-  state.canseek = false;
-  state.cantempo = false;
-  state.isInMenu = false;
-  state.menuType = MenuType::NONE;
-
   if (m_pInputStream)
   {
     CDVDInputStream::IChapter* pChapter = m_pInputStream->GetIChapter();
     if (pChapter)
     {
-      if (IsInMenuInternal() && pMenu && !pMenu->CanSeek())
-      {
-        state.chapter = 0;
-      }
-      else
+      if (!(IsInMenuInternal() && pMenu && !pMenu->CanSeek()))
       {
         state.chapter = pChapter->GetChapter();
         chapterNbEnabled = true;
@@ -5144,7 +5127,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
         {
           std::string name;
           pChapter->GetChapterName(name, i + 1);
-          //! @todo get better than second resolution from the stream?
+          //! @todo get better than second resolution
           state.chapters.emplace_back(name, pChapter->GetChapterPos(i + 1) * 1000);
         }
       }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5040,6 +5040,29 @@ int CVideoPlayer::AddSubtitleFile(const std::string& filename, const std::string
   return m_SelectionStreams.TypeIndexOf(StreamType::SUBTITLE, s.source, s.demuxerId, s.id);
 }
 
+namespace
+{
+int CalculateCurrentChapter(int64_t currentTime,
+                            const std::vector<std::pair<std::string, int64_t>>& chapters)
+{
+  // Chapters are assumed to be sorted in increasing timestamp order
+  if (chapters.empty() || currentTime < chapters[0].second)
+    return 0;
+
+  const std::size_t end = chapters.size() - 1;
+
+  for (std::size_t i = 0; i < end; ++i)
+  {
+    if (currentTime >= chapters[i].second && currentTime < chapters[i + 1].second)
+      return static_cast<int>(i + 1);
+  }
+  if (currentTime >= chapters[end].second)
+    return static_cast<int>(end + 1);
+
+  return 0;
+}
+} // namespace
+
 void CVideoPlayer::UpdatePlayState(double timeout)
 {
   if (m_State.timestamp != 0 &&
@@ -5063,12 +5086,19 @@ void CVideoPlayer::UpdatePlayState(double timeout)
 
   std::shared_ptr<CDVDInputStream::IMenus> pMenu = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInputStream);
 
+  bool chapterNbEnabled{false};
+
   if (m_pDemuxer)
   {
     if (IsInMenuInternal() && pMenu && !pMenu->CanSeek())
+    {
       state.chapter = 0;
+    }
     else
+    {
       state.chapter = m_pDemuxer->GetChapter();
+      chapterNbEnabled = true;
+    }
 
     state.chapters.clear();
     if (m_pDemuxer->GetChapterCount() > 0)
@@ -5077,14 +5107,11 @@ void CVideoPlayer::UpdatePlayState(double timeout)
       {
         std::string name;
         m_pDemuxer->GetChapterName(name, i + 1);
+        //! @todo get better than second resolution from the stream?
         std::chrono::milliseconds position{m_pDemuxer->GetChapterPos(i + 1) * 1000};
-        state.chapters.emplace_back(
-            name,
-            std::chrono::round<std::chrono::seconds>(m_Edl.GetTimeWithoutCuts(position)).count());
+        state.chapters.emplace_back(name, m_Edl.GetTimeWithoutCuts(position).count());
       }
     }
-    CServiceBroker::GetDataCacheCore().SetChapters(state.chapters);
-
     state.time = m_clock.GetClock(false) * 1000 / DVD_TIME_BASE;
     state.timeMax = m_pDemuxer->GetStreamLength();
   }
@@ -5101,9 +5128,14 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     if (pChapter)
     {
       if (IsInMenuInternal() && pMenu && !pMenu->CanSeek())
+      {
         state.chapter = 0;
+      }
       else
+      {
         state.chapter = pChapter->GetChapter();
+        chapterNbEnabled = true;
+      }
 
       state.chapters.clear();
       if (pChapter->GetChapterCount() > 0)
@@ -5112,10 +5144,10 @@ void CVideoPlayer::UpdatePlayState(double timeout)
         {
           std::string name;
           pChapter->GetChapterName(name, i + 1);
-          state.chapters.emplace_back(name, pChapter->GetChapterPos(i + 1));
+          //! @todo get better than second resolution from the stream?
+          state.chapters.emplace_back(name, pChapter->GetChapterPos(i + 1) * 1000);
         }
       }
-      CServiceBroker::GetDataCacheCore().SetChapters(state.chapters);
     }
 
     CDVDInputStream::ITimes* pTimes = m_pInputStream->GetITimes();
@@ -5197,6 +5229,30 @@ void CVideoPlayer::UpdatePlayState(double timeout)
         m_Edl.GetTimeWithoutCuts(std::chrono::milliseconds(std::lround(state.time))).count());
     state.timeMax = state.timeMax - static_cast<double>(m_Edl.GetTotalCutTime().count());
   }
+
+  // Attempt to calculate the current chapter from the currently known playing position
+  // The current chapter provided by the demuxer/inputstream is ahead by a cache duration most of the time.
+  if (chapterNbEnabled)
+  {
+    const int64_t currentTime = llrint(m_State.time);
+    const int playPosChapter = CalculateCurrentChapter(currentTime, state.chapters);
+
+    // Successfully calculated a current chapter from the play position?
+    // Overwrite the current chapter reported by the demuxer/inputstream
+    if (playPosChapter > 0)
+      state.chapter = playPosChapter;
+  }
+
+  // transform the timestamps to rounded seconds per original code
+  // TODO
+  std::ranges::for_each(state.chapters,
+                        [](auto& chapter)
+                        {
+                          std::chrono::milliseconds ms{chapter.second};
+                          chapter.second = std::chrono::round<std::chrono::seconds>(ms).count();
+                        });
+
+  CServiceBroker::GetDataCacheCore().SetChapters(state.chapters);
 
   if (m_caching > CACHESTATE_DONE && m_caching < CACHESTATE_PLAY)
     state.caching = true;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -64,6 +64,7 @@
 #include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
+#include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <iterator>
@@ -4901,8 +4902,9 @@ int CVideoPlayer::SeekChapter(int iChapter)
 int64_t CVideoPlayer::GetChapterPos(int chapterIdx) const
 {
   std::unique_lock lock(m_StateSection);
-  if (chapterIdx > 0 && chapterIdx <= (int) m_State.chapters.size())
-    return m_State.chapters[chapterIdx - 1].second;
+  if (chapterIdx > 0 && chapterIdx <= static_cast<int>(m_State.chapters.size()))
+    return std::chrono::round<std::chrono::seconds>(m_State.chapters[chapterIdx - 1].second)
+        .count();
 
   return -1;
 }
@@ -5041,8 +5043,9 @@ int CVideoPlayer::AddSubtitleFile(const std::string& filename, const std::string
 
 namespace
 {
-int CalculateCurrentChapter(int64_t currentTime,
-                            const std::vector<std::pair<std::string, int64_t>>& chapters)
+int CalculateCurrentChapter(
+    std::chrono::milliseconds currentTime,
+    const std::vector<std::pair<std::string, std::chrono::milliseconds>>& chapters)
 {
   // Chapters are assumed to be sorted in increasing timestamp order
   if (chapters.empty() || currentTime < chapters[0].second)
@@ -5053,7 +5056,7 @@ int CalculateCurrentChapter(int64_t currentTime,
   for (std::size_t i = 0; i < end; ++i)
   {
     if (currentTime >= chapters[i].second && currentTime < chapters[i + 1].second)
-      return static_cast<int>(i + 1);
+      return i + 1;
   }
   if (currentTime >= chapters[end].second)
     return static_cast<int>(end + 1);
@@ -5098,7 +5101,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
       for (int i = 0, ie = m_pDemuxer->GetChapterCount(); i < ie; ++i)
       {
         auto& p = state.chapters.emplace_back(
-            std::string{}, m_Edl.GetTimeWithoutCuts(m_pDemuxer->GetChapterPos(i + 1)).count());
+            std::string{}, m_Edl.GetTimeWithoutCuts(m_pDemuxer->GetChapterPos(i + 1)));
         m_pDemuxer->GetChapterName(p.first, i + 1);
       }
     }
@@ -5122,8 +5125,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
       {
         for (int i = 0, ie = pChapter->GetChapterCount(); i < ie; ++i)
         {
-          auto& p =
-              state.chapters.emplace_back(std::string{}, pChapter->GetChapterPos(i + 1).count());
+          auto& p = state.chapters.emplace_back(std::string{}, pChapter->GetChapterPos(i + 1));
           pChapter->GetChapterName(p.first, i + 1);
         }
       }
@@ -5213,7 +5215,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
   // The current chapter provided by the demuxer/inputstream is ahead by a cache duration most of the time.
   if (chapterNbEnabled)
   {
-    const int64_t currentTime = llrint(m_State.time);
+    const std::chrono::milliseconds currentTime{llrint(m_State.time)};
     const int playPosChapter = CalculateCurrentChapter(currentTime, state.chapters);
 
     // Successfully calculated a current chapter from the play position?
@@ -5222,16 +5224,16 @@ void CVideoPlayer::UpdatePlayState(double timeout)
       state.chapter = playPosChapter;
   }
 
-  // transform the timestamps to rounded seconds per original code
-  // TODO
-  std::ranges::for_each(state.chapters,
-                        [](auto& chapter)
-                        {
-                          std::chrono::milliseconds ms{chapter.second};
-                          chapter.second = std::chrono::round<std::chrono::seconds>(ms).count();
-                        });
+  // Convert to second resolution used outside of VideoPlayer for chapter positions
+  std::vector<std::pair<std::string, int64_t>> chapters;
+  for (const auto& chapter : state.chapters)
+  {
+    chapters.emplace_back(
+        chapter.first,
+        static_cast<int64_t>(std::chrono::round<std::chrono::seconds>(chapter.second).count()));
+  };
 
-  CServiceBroker::GetDataCacheCore().SetChapters(state.chapters);
+  CServiceBroker::GetDataCacheCore().SetChapters(chapters);
 
   if (m_caching > CACHESTATE_DONE && m_caching < CACHESTATE_PLAY)
     state.caching = true;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2939,8 +2939,7 @@ void CVideoPlayer::HandleMessages()
       {
         // SeekChapter does not know about EDL cuts as demuxers are EDL agnostic
         // So get and adjust chapter time
-        const std::chrono::milliseconds position{m_pDemuxer->GetChapterPos(msg.GetChapter()) *
-                                                 1000};
+        const std::chrono::milliseconds position{m_pDemuxer->GetChapterPos(msg.GetChapter())};
         const auto hasEdit{m_Edl.InEdit(position)};
         double time{static_cast<double>(position.count())};
         if (hasEdit)
@@ -5098,11 +5097,9 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     {
       for (int i = 0, ie = m_pDemuxer->GetChapterCount(); i < ie; ++i)
       {
-        std::string name;
-        m_pDemuxer->GetChapterName(name, i + 1);
-        //! @todo get better than second resolution
-        std::chrono::milliseconds position{m_pDemuxer->GetChapterPos(i + 1) * 1000};
-        state.chapters.emplace_back(name, m_Edl.GetTimeWithoutCuts(position).count());
+        auto& p = state.chapters.emplace_back(
+            std::string{}, m_Edl.GetTimeWithoutCuts(m_pDemuxer->GetChapterPos(i + 1)).count());
+        m_pDemuxer->GetChapterName(p.first, i + 1);
       }
     }
     state.time = m_clock.GetClock(false) * 1000 / DVD_TIME_BASE;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -56,6 +56,7 @@ struct SPlayerState
     cache_bytes = 0;
     cache_level = 0.0;
     cache_offset = 0.0;
+    cache_time = 0.0;
     lastSeek = 0;
     streamsReady = false;
   }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -77,7 +77,8 @@ struct SPlayerState
   bool streamsReady;
 
   int chapter;              // current chapter
-  std::vector<std::pair<std::string, int64_t>> chapters; // name and position for chapters
+  // name and position for chapters
+  std::vector<std::pair<std::string, std::chrono::milliseconds>> chapters;
 
   bool canpause;            // pvr: can pause the current playing item
   bool canseek;             // pvr: can seek in the current playing item


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Use the current play position to calculate the current chapter number and name reported through info labels for display.

It used to be the demuxer position, which is ahead of the play position (up to 8 seconds in v21, up to 4 seconds in v22), so the displayed info used to change too early!
For inputstream the addon must be trusted to provide accurate information.
Reason for not modifying GetChapter(): it's a simple but flawed API for the purpose. The info comes from the demuxer, which only knows the current demux position and cannot possibly know the currently displayed time.
Maybe later could be evolved into a GetChapter(timestamp), not sure of the benefits. EDL complicates things a bit.

Used the opportunity to increase the accuracy of the chapter timestamps within videoplayer to millisecond resolution for more accurate chapter skips. Chapter timestamps usually align with key frames and the extra precision will help avoid seeking a bit too late or early and show a flash of a different scene.
For inputstream an API change would required and I will leave it to someone who uses that part of Kodi.

Addressed issues with some chapter timestamp situations that were badly handled: start=end is allowed for mkv, there may be gaps between chapters.

The PR revealed a pre-existing issue: after skipping, the time / chapter number / chapter name of the previous chapter is very briefly displayed. I'm not sure what can be done about it or whether the seek is too early on purpose. It's possible I missed a start offset or similar but lack the knowledge.
@kodiai any ideas for that last point?

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Multiple reasons:
- Noticed that the chapter number and name changed seconds early while watching videos with info displayed.
- Due to the rounding of the chapter timestamps to the second, chapter skips are a bit inaccurate and sometimes reveal a flash of the previous/next scene.
- mkv specifications allow start timestamp = end timestamp for "chapter markers" but Kodi wasn't handling it well.
gaps between chapters caused problems (ie start of chapter 1 + duration of chapter 1 != start of chapter 2)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local / remote files, DVD, Bluray.
chapter skipping is currently broken for DVD, nothing to do with this PR.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

More accurate current chapter/chaptername and chapter skips.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
