### PR TITLE
[guilib] Fix heap corruption from sws_scale SIMD buffer overrun in texture allocation

### DIFF
--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -413,10 +413,11 @@ bool CTexture::UploadFromMemory(unsigned int width,
   else if (!m_pixels)
   {
     size_t size = GetPitch() * GetRows();
-    m_pixels = static_cast<unsigned char*>(KODI::MEMORY::AlignedMalloc(size, 32));
+    constexpr size_t simdPadding{32};
+    m_pixels = static_cast<unsigned char*>(KODI::MEMORY::AlignedMalloc(size + simdPadding, 32));
     if (m_pixels == nullptr)
     {
-      CLog::LogF(LOGERROR, "Could not allocate {} bytes. Out of memory.", size);
+      CLog::LogF(LOGERROR, "Could not allocate {} bytes. Out of memory.", size + simdPadding);
       return false;
     }
     std::memcpy(m_pixels, pixels, size);

--- a/xbmc/guilib/TextureBase.cpp
+++ b/xbmc/guilib/TextureBase.cpp
@@ -61,10 +61,16 @@ void CTextureBase::Allocate(uint32_t width, uint32_t height, XB_FMT format)
   if (size == 0)
     return;
 
-  m_pixels = static_cast<unsigned char*>(KODI::MEMORY::AlignedMalloc(size, 32));
+  // Allocate extra padding bytes beyond the texture data. SIMD-optimized scaling
+  // filters (e.g. ffmpeg sws_scale with AVX2/SSE) can write a few bytes past the
+  // end of the output buffer. Without padding this corrupts adjacent heap metadata.
+  // See also CPicture::CacheTexture which adds equivalent padding for sws_scale.
+  constexpr size_t simdPadding{32};
+  m_pixels = static_cast<unsigned char*>(KODI::MEMORY::AlignedMalloc(size + simdPadding, 32));
 
   if (m_pixels == nullptr)
-    CLog::Log(LOGERROR, "{} - Could not allocate {} bytes. Out of memory.", __FUNCTION__, size);
+    CLog::Log(LOGERROR, "{} - Could not allocate {} bytes. Out of memory.", __FUNCTION__,
+              size + simdPadding);
 }
 
 uint32_t CTextureBase::PadPow2(uint32_t x)


### PR DESCRIPTION
## Description

Adds 32-byte SIMD padding to `m_pixels` allocations in `CTextureBase::Allocate()` and `CTexture::UploadFromMemory()`.

SIMD-optimized `sws_scale` filters (AVX2/SSE) can write past the output buffer. `m_pixels` is allocated as exactly `pitch * height` with no slack.

`CPicture::CacheTexture` (Picture.cpp:244-249) already does this. References the [FFmpeg swscale test suite](https://github.com/FFmpeg/FFmpeg/blob/75638fe9402f70645bdde4d95672fa640a327300/libswscale/tests/swscale.c#L157). The texture allocation paths were missing it.

## Motivation and context

Heap corruption crash. Shows up as an access violation (`0xc0000421` AVRF stop) in `CDXTexture::~CDXTexture` when `AlignedFree(m_pixels)` hits corrupted metadata.

**Crash path:**
`CJobWorker::Process` -> texture cache job -> `CFFmpegImage::DecodeFrame` -> `sws_scale` overwrites buffer tail -> ... later ... -> `shared_ptr` release -> `CDXTexture::~CDXTexture` -> `AlignedFree(m_pixels)` -> heap corruption detected

**Root cause** (via Windows Page Heap / Application Verifier):
- AVRF Code `0xF`: corrupted suffix fill pattern (buffer overrun)
- Block size: `0x54627` (345,639 bytes = 345,600 pixel data + 39 bytes `_aligned_malloc` overhead)
- Corruption at the exact end of the buffer. Suffix guard bytes overwritten.
- Trigger: image width already a multiple of 16, so `pitch == linesize`. `DecodeFrame` takes the aligned shortcut (FFmpegImage.cpp:487) and uses `m_pixels` directly as the `sws_scale` output

**Reproducer:** Library scan with thumbnail generation. Crashes within minutes with Page Heap enabled.

### Stack trace (Windows Page Heap crash dump)

```
Child-SP          RetAddr               Call Site
000000e0`611fe9f0 00007fff`8b887642     verifier!VerifierCaptureContextAndReportStop+0xa3
000000e0`611fefc0 00007fff`8b885d57     verifier!VerifierStopMessage+0x2f2
000000e0`611ff080 00007fff`8b884191     verifier!AVrfpDphReportCorruptedBlock+0x2f3
000000e0`611ff140 00007fff`8b884642     verifier!AVrfpDphCheckPageHeapBlock+0x171
000000e0`611ff1b0 00007fff`8b88468f     verifier!AVrfpDphFindBusyMemory+0xca
000000e0`611ff1f0 00007fff`8b882f7d     verifier!AVrfpDphFindBusyMemoryAndRemoveFromBusyList+0x2b
000000e0`611ff220 00007fff`9e94b1a3     verifier!AVrfDebugPageHeapFree+0x8d
000000e0`611ff280 00007fff`9e8e370c     ntdll!RtlDebugFreeHeap+0x37
000000e0`611ff2e0 00007fff`9e9391d0     ntdll!RtlpFreeHeap+0x178c
000000e0`611ff4c0 00007fff`9c01e0fb     ntdll!RtlFreeHeap+0x620
000000e0`611ff5b0 00007fff`9c069266     ucrtbase!free_base+0x1b
000000e0`611ff5e0 00007ff7`81e88c1c     ucrtbase!aligned_free+0x16
                                        kodi!CTextureBase::~CTextureBase  [AlignedFree(m_pixels)]
                                        kodi!CDXTexture::~CDXTexture
                                        kodi![shared_ptr release / texture update]
                                        kodi![CTextureCacheJob]
                                        kodi!CJobWorker::Process
```

### Page Heap analysis (`!analyze -v`)

```
AVRF_ACTION:           5 (heap corruption detected)
AVRF Code:             0xF — corrupted suffix fill pattern (buffer overrun)
Heap block:            0x20b256989d0
Block size:            0x54627 (345,639 bytes)
                       = 345,600 pixel data + 39 bytes _aligned_malloc overhead
Corruption address:    0x20b256ecff7 (exact END of buffer, offset == size)
Damaged stamp:         0xBAD0BAD0 (expected 0xDCBADCBA)
```

### Existing precedent

`CPicture::CacheTexture` (Picture.cpp:244-249):
```cpp
// Let's align so that stride is always divisible by 16, and then add some 32 bytes more on top
// See: https://github.com/FFmpeg/FFmpeg/blob/75638fe9402f70645bdde4d95672fa640a327300/libswscale/tests/swscale.c#L157
uint32_t dest_width_aligned = ((dest_width + 15) & ~0x0f);
uint32_t stride = dest_width_aligned * sizeof(uint32_t);
auto buffer = std::make_unique<uint32_t[]>(dest_width_aligned * dest_height + 4);
```

The `+ 4` (16 bytes of `uint32_t`) is the same idea as the `+ 32` padding here.

### Bug trigger path

`CFFmpegImage::DecodeFrame()` (FFmpegImage.cpp:487-527):
```cpp
if (aligned && size == pixelsSize && (int)pitch == pictureRGB->linesize[0])
{
    // We can use the pixels buffer directly
    pictureRGB->data[0] = pixels;  // m_pixels used as sws_scale output
}
```

When image width is a multiple of 16, `pitch == linesize` and `DecodeFrame` uses `m_pixels` directly as the `sws_scale` destination. Zero padding.

## How has this been tested?

- Windows 10 Build 26100, VS 2026 (MSVC v145), 13900K / 64GB
- Full page heap enabled for `kodi.exe` via Application Verifier
- Before: crashes within minutes of a library scan with thumbnail generation. Page Heap confirms AVRF code 0xF at the buffer boundary.
- After: full library scan of entire media drive, heavy thumbnail generation, zero crashes or AVRF stops. Previously crashed consistently.
- Covers both places where `m_pixels` gets passed to `sws_scale`.

## What is the effect on users?

Fixes a crash during thumbnail generation. Mostly hit during library scans or browsing with lots of uncached thumbnails. You need heap debugging tools to trace it back to the root cause.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed