### PR TITLE
TextureCache: fix use-after-free in CleanTimer()

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -55,6 +55,7 @@ void CTextureCache::Initialize()
 
 void CTextureCache::Deinitialize()
 {
+  m_cleanTimer.Stop(true);
   CancelJobs();
 
   std::unique_lock lock(m_databaseSection);
@@ -440,14 +441,13 @@ void CTextureCache::CleanTimer()
     return;
   }
 
-  CServiceBroker::GetJobManager()->Submit(
+  Submit(
       [this]()
       {
         auto next = m_cleaningInProgress.test_and_set() ? 1h : ScanOldestCache();
         m_cleaningInProgress.clear();
         m_cleanTimer.Start(next);
-      },
-      CJob::PRIORITY_LOW_PAUSABLE);
+      });
 }
 
 std::chrono::milliseconds CTextureCache::ScanOldestCache()


### PR DESCRIPTION
Closes #27971

## What

`CTextureCache::CleanTimer()` was submitting a `[this]` lambda to the **global** job manager (`CServiceBroker::GetJobManager()`). `Deinitialize()` only called `CancelJobs()`, which clears the **local** `CJobQueue` — it has no effect on jobs already handed to the global manager. Additionally, `m_cleanTimer` was never stopped in `Deinitialize()`, so the timer could fire and enqueue a new global job after teardown had begun.

After `CTextureCache` is destroyed, the pending lambda runs on the global job manager's worker thread and accesses freed `m_cleaningInProgress` and `m_cleanTimer` members (heap-use-after-free).

## Fix

1. **Stop the timer first**: call `m_cleanTimer.Stop(true)` at the top of `Deinitialize()` so no further `CleanTimer()` invocations can be enqueued after teardown starts.
2. **Use the local job queue**: change `CleanTimer()` to submit via `Submit()` (the local `CJobQueue`) instead of `CServiceBroker::GetJobManager()`, so `CancelJobs()` and the `CJobQueue` destructor properly govern the lambda's lifetime — the `[this]` capture cannot outlive `*this`.

## Testing

Confirmed with AddressSanitizer: heap-use-after-free on `m_cleaningInProgress` reproduced reliably before the fix, and is absent after.