### PR TITLE
Fix crash and art issues caused by DialogVideoInfo item changes

### DIFF
--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2025 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -533,7 +533,7 @@ bool CGUIWindowVideoBase::ShowInfoAndRefresh(const CFileItemPtr& item, const Scr
       if (IsActive())
       {
         const int selectedItem{m_viewControl.GetSelectedItem()};
-        Refresh();
+        Refresh(true);
         m_viewControl.SetSelectedItem(selectedItem);
       }
       return true;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Kodi saves the contents of slow-loading directories under cache/archive_cache of the user profile to speedup display refreshes. This is triggered by medium-large libraries on external db for example.

However that cache was not cleared after making changes to an item with the Info dialog (key i).
Stale information was then reloaded and resulted in a crash (see scenario in motivation and context), but likely also explains incorrect artwork and similar glitches after editing an item with the Info dialog.

The fix clears the cache for the directory containing the modified item.

Downside: since refreshes are not fine grained, all items are reloaded from the DB > fresh and accurate but slower. There is no other way at this time.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed a strange crash with medium size library on MariaDB (takes a second or two to display Movies):
- Go to Movies
- Open Information on an item
- Press Refresh - doesn't matter from nfo or internet
- Close Info dialog
- Open Info dialog on same item > crash

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The described crash doesn't happen anymore, no issue with sqlite or small database.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Avoid glitches and crash after changing items using the Info dialog for a medium-large library.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
