### PR TITLE
[i18n] Fix pcre2 assert/crash in BCP47 full parser

### DIFF
--- a/xbmc/utils/i18n/Bcp47Parser.cpp
+++ b/xbmc/utils/i18n/Bcp47Parser.cpp
@@ -8,6 +8,7 @@
 
 #include "utils/i18n/Bcp47Parser.h"
 
+#include "threads/CriticalSection.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "utils/i18n/Bcp47.h"
@@ -85,6 +86,11 @@ std::optional<ParsedBcp47Tag> CBcp47Parser::TryGenericParse(const std::string& s
 
   static CRegExp regLangCode;
   static bool initialized = regLangCode.RegComp(bcp47Regexp);
+
+  // Serialize regexp matching, not thread-safe
+  //! @todo make CRegExp::RegFind thread-safe and remove the mutex
+  static CCriticalSection critSection;
+  std::lock_guard lock{critSection};
 
   if (!initialized || regLangCode.RegFind(str) < 0)
     return {};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The BCP47 full parser uses a large regexp, cached to avoid compilation for each use (ex. audio and subtitle tracks language)

CRegExp is not thread-safe when attempting to match a string, even though the underlying pcre2 library is, resulting in assertions in pcre2 in debug mode and possibly crashes in release.

The PR protects regexp matching with a mutex, which stopped the issues.

Future: modify CRegExp to support thread-safe use and remove the mutex.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Assert/crash with this scenario:
- play internet stream with subs that have multipart language tags (ex. cmn-Hans)
- open stream selection dialog
- stop the video
- play the stream again > assertion / crash

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

same scenario > no crash
there are not many other ways to activate the BCP47 full parser at this time (ffmpeg mkv limitations)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Avoid crash when playing a video with audio or subs that have multipart language tags.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
