### PR TITLE
[application] Fix video info not available when playing strm files.

### DIFF
--- a/xbmc/application/ApplicationPlay.cpp
+++ b/xbmc/application/ApplicationPlay.cpp
@@ -114,14 +114,17 @@ void CApplicationPlay::GetOptionsAndUpdateItem()
       return;
 
     // Get path
-    std::string path{m_item.GetPath()};
+    std::string path{m_item.GetDynPath()};
     if (m_item.HasVideoInfoTag())
     {
       const std::string videoInfoTagPath{m_item.GetVideoInfoTag()->m_strFileNameAndPath};
-      // removable:// may be embedded in bluray:// path
-      if (CURL::Decode(videoInfoTagPath).find("removable://") != std::string::npos ||
-          VIDEO::IsVideoDb(m_item))
-        path = videoInfoTagPath;
+      if (!videoInfoTagPath.empty())
+      {
+        // removable:// may be embedded in bluray:// path
+        if (VIDEO::IsVideoDb(m_item) ||
+            CURL::Decode(videoInfoTagPath).find("removable://") != std::string::npos)
+          path = videoInfoTagPath;
+      }
     }
     else if (m_item.HasProperty("original_listitem_url") &&
              URIUtils::IsPlugin(m_item.GetProperty("original_listitem_url").asString()))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When playing strm files contained in video library, OSD video info was missing. This PR fixes that issue. I think this is a regression introduced in Piers codeline.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Want video info for strm files back.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually, by looking at the screen before and after the fix. :-)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
They get video info for strm files back.

## Screenshots (if appropriate):
Select a strm file for playback:
<img width="1710" height="1107" alt="Screenshot 2025-12-18 at 15 40 19" src="https://github.com/user-attachments/assets/60570538-4b19-43f7-b387-b9eaded98fbe" />

Before:
<img width="1920" height="1200" alt="Screenshot 2025-12-18 at 15 40 32" src="https://github.com/user-attachments/assets/ff99f1e8-acc2-45c8-9346-d0802163160d" />

After:
<img width="1920" height="1200" alt="Screenshot 2025-12-18 at 15 42 02" src="https://github.com/user-attachments/assets/9578cd67-2f57-4b22-9ce4-d37106748d3d" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
