### PR TITLE
[Estuary] Fix duplicate display of tagline

### DIFF
--- a/addons/skin.estuary/xml/MyVideoNav.xml
+++ b/addons/skin.estuary/xml/MyVideoNav.xml
@@ -50,7 +50,7 @@
 						<width>525</width>
 						<bottom>100</bottom>
 						<visible>![ListItem.IsCollection + String.IsEmpty(ListItem.Plot) + String.IsEqual(ListItem.DBType,season) + String.IsEmpty(Container.ShowPlot)]</visible>
-						<label>$INFO[ListItem.Tagline,[I],[/I][CR][CR]]$VAR[VideoInfoPlotVar][CR][CR]</label>
+						<label>$VAR[VideoInfoPlotVar]</label>
 						<autoscroll delay="10000" time="3000" repeat="10000">Skin.HasSetting(autoscroll)</autoscroll>
 					</control>
 					<control type="textbox">


### PR DESCRIPTION
## Description
Fix duplicate display of tagline after https://github.com/xbmc/xbmc/pull/27867 

## Motivation and context
Reported by @CrystalP at https://github.com/xbmc/xbmc/pull/27867#issuecomment-4035896555

## How has this been tested?
Tested locally with the List and InfoWall views where the duplicate could be seen.

## What is the effect on users?
Remove a bug causing duplicate tagline to be displayed.

## Screenshots (if appropriate):
**InfoWall View Before**
![infowall_before](https://github.com/user-attachments/assets/f602da19-dca4-4c36-b598-895a75b75861)

**InfoWall View After**
![infowall_after](https://github.com/user-attachments/assets/710a301b-8046-4303-9fe4-c51ac4d49737)

**List View Before**
![list_before](https://github.com/user-attachments/assets/7272d0f7-7608-4e0e-b507-d0e2a62ba15a)

**List View After**
![list_after](https://github.com/user-attachments/assets/9bee56ce-bbb3-4f93-8bb7-f2ebaa09fbd7)


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)