### PR TITLE
RetroPlayer: Fix race condition when changing resolution

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -342,6 +342,7 @@ void CRPRenderManager::FrameMove()
 
   if (bIsConfigured)
   {
+    std::unique_lock<std::mutex> lock{m_oldRenderersMutex};
     for (auto& renderer : m_renderers)
       renderer->FrameMove();
   }
@@ -364,8 +365,11 @@ void CRPRenderManager::CheckFlush()
       m_bHasCachedFrame = false;
     }
 
-    for (const auto& renderer : m_renderers)
-      renderer->Flush();
+    {
+      std::unique_lock<std::mutex> lock{m_oldRenderersMutex};
+      for (const auto& renderer : m_renderers)
+        renderer->Flush();
+    }
 
     m_processInfo.GetBufferManager().FlushPools();
 
@@ -474,6 +478,8 @@ void CRPRenderManager::ClearBackground()
 bool CRPRenderManager::SupportsRenderFeature(RENDERFEATURE feature) const
 {
   //! @todo Move to ProcessInfo
+  std::unique_lock<std::mutex> lock{m_oldRenderersMutex};
+
   for (const auto& renderer : m_renderers)
   {
     if (renderer->Supports(feature))
@@ -567,6 +573,8 @@ std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRendererForPool(
     CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: buffer pool is not compatible with renderer");
     return renderer;
   }
+
+  std::unique_lock<std::mutex> lock{m_oldRenderersMutex};
 
   // Get compatible renderer for this buffer pool
   for (const auto& it : m_renderers)

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -246,7 +246,7 @@ private:
   // Render resources
   std::set<std::shared_ptr<CRPBaseRenderer>> m_renderers;
   std::set<std::shared_ptr<CRPBaseRenderer>> m_oldRenderers;
-  std::mutex m_oldRenderersMutex;
+  mutable std::mutex m_oldRenderersMutex;
   std::vector<IRenderBuffer*> m_pendingBuffers; // Only access from game thread
   std::vector<IRenderBuffer*> m_renderBuffers;
   std::map<AVPixelFormat, std::map<AVPixelFormat, SwsContext*>> m_scalers; // From -> to -> context


### PR DESCRIPTION
## Description

Follow-up to https://github.com/xbmc/xbmc/pull/27791. While it fixed the GL crash, it introduces a possible race condition due to insufficient mutex coverage.

The race happened when the renderers were moved to oldRenderers, but Flush() was still accessing the renderers. The race can only happen when moving to oldRenderers, so we can just use the oldRenderer mutex when m_renderers is accessed.

## Motivation and context

Found while testing PSX games for the new Disc Manager.

## How has this been tested?

Included in latest test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-22alpha3-20260311

## What is the effect on users?

* Fixed crash due to race condition when games change resolution.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
