### PR TITLE
Fix short description of CInterfaceAndroidSystem::GetClassName() function

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/platform/android/System.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/platform/android/System.h
@@ -86,7 +86,8 @@ public:
 
   //============================================================================
   /// @ingroup cpp_kodi_platform_CInterfaceAndroidSystem
-  /// @brief Request the android main class name e.g. <b>`org.xbmc.kodi`</b>.
+  /// @brief Request the android main class name using the internal slash notation
+  /// format e.g. <b>`org/xbmc/kodi`</b>.
   ///
   /// @return package class name
   ///


### PR DESCRIPTION
## Description
The function returns the class name using slash notation (`org/xbmc/kodi`) instead of dots (`org.xbmc.kodi`)

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
