### PR TITLE
Games: Fix playing m3u files for multi-disc games

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1920,7 +1920,7 @@ bool CApplication::PlayMedia(CFileItem& item, const std::string& player, PLAYLIS
       return ProcessAndStartPlaylist(smartpl.GetName(), playlist, smartplPlaylistId);
     }
   }
-  else if (PLAYLIST::IsPlayList(item) || NETWORK::IsInternetStream(item))
+  else if ((PLAYLIST::IsPlayList(item) && !item.IsGame()) || NETWORK::IsInternetStream(item))
   {
     // Not owner. Dialog auto-deletes itself.
     CGUIDialogCache* dlgCache = new CGUIDialogCache(

--- a/xbmc/application/ApplicationPlay.cpp
+++ b/xbmc/application/ApplicationPlay.cpp
@@ -301,8 +301,8 @@ CApplicationPlay::GatherPlaybackDetailsResult CApplicationPlay::GatherPlaybackDe
   if (VIDEO::IsDiscStub(m_item))
     return GatherPlaybackDetailsResult::RESULT_SUCCESS; // all done
 
-  if (PLAYLIST::IsPlayList(m_item))
-    return GatherPlaybackDetailsResult::RESULT_ERROR; // playlists not supported
+  if (PLAYLIST::IsPlayList(m_item) && !m_item.IsGame())
+    return GatherPlaybackDetailsResult::RESULT_ERROR; // non-game playlists not supported
 
   if (!ResolvePath())
     return GatherPlaybackDetailsResult::RESULT_ERROR;

--- a/xbmc/cores/playercorefactory/PlayerCoreConfig.h
+++ b/xbmc/cores/playercorefactory/PlayerCoreConfig.h
@@ -45,6 +45,8 @@ public:
     return m_bPlaysVideo;
   }
 
+  bool PlaysGame() const { return m_bPlaysGame; }
+
   std::shared_ptr<IPlayer> CreatePlayer(IPlayerCallback& callback) const;
 
   std::string m_name;
@@ -52,5 +54,6 @@ public:
   std::string m_type;
   bool m_bPlaysAudio{false};
   bool m_bPlaysVideo{false};
+  bool m_bPlaysGame{false};
   std::unique_ptr<TiXmlElement> m_config;
 };

--- a/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
+++ b/xbmc/cores/playercorefactory/PlayerCoreFactory.cpp
@@ -77,7 +77,7 @@ void CPlayerCoreFactory::GetPlayers(std::vector<std::string>&players) const
   players.clear();
   for (auto& conf : m_vecPlayerConfigs)
   {
-    if (conf->m_bPlaysAudio || conf->m_bPlaysVideo)
+    if (conf->m_bPlaysAudio || conf->m_bPlaysVideo || conf->m_bPlaysGame)
       players.emplace_back(conf->m_name);
   }
 }
@@ -189,8 +189,8 @@ void CPlayerCoreFactory::GetPlayers(const CFileItem& item, std::vector<std::stri
 
   if (item.IsGame())
   {
-    CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: adding retroplayer");
-    players.emplace_back("RetroPlayer");
+    CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: forcing retroplayer");
+    players = {"RetroPlayer"};
   }
 
   CLog::Log(LOGDEBUG, "CPlayerCoreFactory::GetPlayers: added {0} players", players.size());
@@ -379,6 +379,7 @@ bool CPlayerCoreFactory::LoadConfiguration(const std::string &file, bool clear)
     m_vecPlayerConfigs.emplace_back(std::move(paplayer));
 
     auto retroPlayer = std::make_unique<CPlayerCoreConfig>("RetroPlayer", "game", nullptr);
+    retroPlayer->m_bPlaysGame = true;
     m_vecPlayerConfigs.emplace_back(std::move(retroPlayer));
   }
 

--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -6,25 +6,28 @@
  *  See LICENSES/README.md for more information.
  */
 
-#include <stdlib.h>
-#include "network/Network.h"
 #include "DirectoryFactory.h"
-#include "SpecialProtocolDirectory.h"
-#include "MultiPathDirectory.h"
-#include "StackDirectory.h"
+
+#include "AddonsDirectory.h"
+#include "DAVDirectory.h"
+#include "EventsDirectory.h"
+#include "FTPDirectory.h"
+#include "FavouritesDirectory.h"
+#include "File.h"
 #include "FileDirectoryFactory.h"
-#include "PlaylistDirectory.h"
+#include "HTTPDirectory.h"
+#include "LibraryDirectory.h"
+#include "MultiPathDirectory.h"
 #include "MusicDatabaseDirectory.h"
 #include "MusicSearchDirectory.h"
-#include "VideoDatabaseDirectory.h"
-#include "FavouritesDirectory.h"
-#include "LibraryDirectory.h"
-#include "EventsDirectory.h"
-#include "AddonsDirectory.h"
+#include "PlaylistDirectory.h"
 #include "SourcesDirectory.h"
-#include "FTPDirectory.h"
-#include "HTTPDirectory.h"
-#include "DAVDirectory.h"
+#include "SpecialProtocolDirectory.h"
+#include "StackDirectory.h"
+#include "VideoDatabaseDirectory.h"
+#include "network/Network.h"
+
+#include <stdlib.h>
 #if defined(HAS_UDFREAD)
 #include "UDFDirectory.h"
 #endif
@@ -34,6 +37,7 @@
 #ifdef TARGET_POSIX
 #include "platform/posix/filesystem/PosixDirectory.h"
 #elif defined(TARGET_WINDOWS)
+#include "platform/win32/dirent.h" // For S_ISDIR compatability macro
 #include "platform/win32/filesystem/Win32Directory.h"
 #ifdef TARGET_WINDOWS_STORE
 #include "platform/win10/filesystem/WinLibraryDirectory.h"
@@ -86,6 +90,7 @@
 #include "ServiceBroker.h"
 #include "addons/VFSEntry.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 
 using namespace ADDON;
 
@@ -121,7 +126,21 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
     return NULL;
 
   CFileItem item(url.Get(), true);
-  IFileDirectory* pDir = CFileDirectoryFactory::Create(url, &item);
+
+  // Load directory flag from the VFS. If the url is truly a directory, don't
+  // attempt to use a file-directory loader.
+  bool canBeFileDirectory = true;
+
+  struct __stat64 st = {};
+  if (CFile::Stat(URIUtils::SubstitutePath(url), &st) == 0)
+  {
+    item.SetFolder(S_ISDIR(st.st_mode));
+    canBeFileDirectory = !item.IsFolder();
+  }
+
+  IFileDirectory* pDir = nullptr;
+  if (canBeFileDirectory)
+    pDir = CFileDirectoryFactory::Create(url, &item);
   if (pDir)
     return pDir;
 

--- a/xbmc/games/windows/GUIWindowGames.cpp
+++ b/xbmc/games/windows/GUIWindowGames.cpp
@@ -26,6 +26,7 @@
 #include "guilib/WindowIDs.h"
 #include "input/actions/ActionIDs.h"
 #include "media/MediaLockState.h"
+#include "playlists/PlayListFileItemClassify.h"
 #include "playlists/PlayListTypes.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
@@ -384,7 +385,11 @@ bool CGUIWindowGames::PlayGame(const CFileItem& item)
     itemCopy.GetGameInfoTag();
   }
 
-  return g_application.PlayMedia(itemCopy, "", PLAYLIST::Id::TYPE_NONE);
+  PLAYLIST::Id playlistId = PLAYLIST::Id::TYPE_NONE;
+  if (PLAYLIST::IsPlayList(item))
+    playlistId = PLAYLIST::Id::TYPE_GAME;
+
+  return g_application.PlayMedia(itemCopy, "", playlistId);
 }
 
 bool CGUIWindowGames::CanPlay(const CFileItem& item) const

--- a/xbmc/playlists/PlayListTypes.h
+++ b/xbmc/playlists/PlayListTypes.h
@@ -16,7 +16,8 @@ enum class Id : int
   TYPE_NONE = -1,
   TYPE_MUSIC = 0,
   TYPE_VIDEO = 1,
-  TYPE_PICTURE = 2
+  TYPE_PICTURE = 2,
+  TYPE_GAME = 3
 };
 
 /*!


### PR DESCRIPTION
## Description

Currently Kodi crashes when playing m3u files (multi-disk game lists) from the My Games window. This PR fixes the crash, and allows m3u files to be played. Along with the Disc Manager in https://github.com/xbmc/xbmc/pull/27984, m3u files can be disc-swapped as well.

It also fixes the directory-existence check for directories that end in ".m3u". These folders are created for savestates, named after the game's filename.

Note that this PR just bypasses the segfault. The correct fix for the segfault is in https://github.com/xbmc/xbmc/pull/27990.

Also note, there are a myriad of ways to play files, some of which lose "gameness" context. I hacked the code for the worst-case scenario of no context beyond the path, and Kodi falls back to playing the first file in the m3u. In this case, the remaining files can be added manually in the Disc Manager. But note this is worst-case playback scenario

## Motivation and context

Fixes https://github.com/xbmc/xbmc/issues/24068

## How has this been tested?

To be included in upcoming test builds.

Tested with the following `Metal Gear Solid (Europe).m3u` file:

```
Metal Gear Solid (Europe) (Disc 1)/Metal Gear Solid (Europe) (Disc 1).cue
Metal Gear Solid (Europe) (Disc 2)/Metal Gear Solid (Europe) (Disc 2).cue
```

Before:

Kodi go boom

After:

Kodi correctly plays the m3u as a game:

<img width="1360" height="753" alt="Screenshot 2026-03-12 at 1 00 58 PM" src="https://github.com/user-attachments/assets/883df9f9-4d51-4659-9214-ec3a16544710" />

Savestates are associated with the m3u file:

<img width="1363" height="755" alt="Screenshot 2026-03-12 at 12 45 51 PM" src="https://github.com/user-attachments/assets/3292570f-bbbf-42d6-a397-56e73bb229e1" />

With the Disc Manager, the disc list is correctly populated from the core, after it loads the m3u directly:

<img width="1362" height="755" alt="Screenshot 2026-03-12 at 12 46 16 PM" src="https://github.com/user-attachments/assets/d2f4996a-702c-494a-8acb-4b4dcb9069fb" />

## What is the effect on users?

* Fixed playing m3u files from the My Games window

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
