### PR TITLE
Playlists: Fix segfault when loading playlist

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1873,23 +1873,24 @@ namespace
 class CCreateAndLoadPlayList : public IRunnable
 {
 public:
-  CCreateAndLoadPlayList(CFileItem& item, std::unique_ptr<PLAYLIST::CPlayList>& playlist)
-    : m_item(item), m_playlist(playlist)
+  CCreateAndLoadPlayList(const CFileItem& item, std::unique_ptr<PLAYLIST::CPlayList>& playlist)
+    : m_item(item),
+      m_playlist(playlist)
   {
   }
 
   void Run() override
   {
-    const std::unique_ptr<PLAYLIST::CPlayList> playlist(PLAYLIST::CPlayListFactory::Create(m_item));
+    std::unique_ptr<PLAYLIST::CPlayList> playlist(PLAYLIST::CPlayListFactory::Create(m_item));
     if (playlist)
     {
       if (playlist->Load(m_item.GetPath()))
-        *m_playlist = *playlist;
+        m_playlist = std::move(playlist);
     }
   }
 
 private:
-  CFileItem& m_item;
+  const CFileItem& m_item;
   std::unique_ptr<PLAYLIST::CPlayList>& m_playlist;
 };
 } // namespace


### PR DESCRIPTION
## Description

This PR fixes a segfault when loading a playlist. It was the cause of Kodi crashing when loading a game playlist, which incorrectly took this code path.

The problem is that we call the loader with an empty pointer:

```c++
std::unique_ptr<PLAYLIST::CPlayList> playlist;
CCreateAndLoadPlayList getPlaylist(item, playlist);
```

The old code then attempted to copy-construct the playlist into an empty pointer:

```c++
if (playlist->Load(m_item.GetPath()))
  *m_playlist = *playlist;
```

 The correct way to do this is to transfer the wrapping pointer:

```c++
m_playlist = std::move(playlist);
```

## Motivation and context

Encountered when working on https://github.com/xbmc/xbmc/pull/27989.

## How has this been tested?

To be included in upcoming test builds.

Tested as part of https://github.com/xbmc/xbmc/pull/27989.

## What is the effect on users?

* Fix possible crash when playing files with a playlist extension.

## Screenshots (if appropriate):

See https://github.com/xbmc/xbmc/pull/27989

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
