### PR TITLE
[dbwrappers] add previously implicit include for va_list/va_start/va_end

### DIFF
--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -14,6 +14,7 @@
 
 #include "qry_dat.h"
 
+#include <cstdarg>
 #include <list>
 #include <map>
 #include <memory>


### PR DESCRIPTION
GCC-16 fails without the explicit include.

xbmc/dbwrappers/test/TestVPrepare.cpp:28:3: error: there are no arguments to ‘va_start’ that depend on a template parameter, so a declaration of ‘va_start’ must be available [-Wtemplate-body]
   28 |   va_start(args, sqlFormat);
      |   ^~~~~~~~

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add missing header for the used va_list, va_start and va_end.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The header was apparently implicit in older compilers, in gcc-16 it isn't implicit so an explicit include is required. 

https://en.cppreference.com/w/cpp/utility/variadic/va_arg.html

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Building it locally with gcc-16

```
$ gcc --version
gcc (Gentoo 16.0.9999 p, commit 9f776b2cbc66523f9c3ca137661dfad4ea68a6c6) 16.0.1 20260313 (experimental) 453482db659716a3016827a3fcccb9459eb9c5b3
Copyright (C) 2026 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
None. Its a build time fix.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
