### PR TITLE
StreamDetails: Implement HDR type priority for stream details

### DIFF
--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -587,19 +587,11 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
         return true;
       case VIDEOPLAYER_HDR_TYPE:
       case LISTITEM_VIDEO_HDR_TYPE:
-        if (tag->m_streamDetails.GetStreamCount(CStreamDetail::VIDEO) > 1 &&
-            tag->m_streamDetails.GetVideoHdrType(2) == "dolbyvision")
-          value = "dolbyvision";
-        else
-          value = tag->m_streamDetails.GetVideoHdrType();
+        value = tag->m_streamDetails.GetVideoHdrType();
         return true;
       case VIDEOPLAYER_HDR_DETAIL:
       case LISTITEM_VIDEO_HDR_DETAIL:
-        if (tag->m_streamDetails.GetStreamCount(CStreamDetail::VIDEO) > 1 &&
-            tag->m_streamDetails.GetVideoHdrType(2) == "dolbyvision")
-          value = tag->m_streamDetails.GetVideoHdrDetail(2);
-        else
-          value = tag->m_streamDetails.GetVideoHdrDetail();
+        value = tag->m_streamDetails.GetVideoHdrDetail();
         return true;
       default:
         break;

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -82,9 +82,10 @@ bool CStreamDetailVideo::IsWorseThan(const CStreamDetail &that) const
   if (that.m_eType != CStreamDetail::VIDEO)
     return true;
 
-  // Best video stream is that with the most pixels
+  // Best video stream is that with the most pixels and best hdr type
   const auto& sdv = static_cast<const CStreamDetailVideo&>(that);
-  return (sdv.m_iWidth * sdv.m_iHeight) > (m_iWidth * m_iHeight);
+  return (sdv.m_iWidth * sdv.m_iHeight * CStreamDetails::GetHdrPriority(sdv.m_strHdrType)) >
+         (m_iWidth * m_iHeight * CStreamDetails::GetHdrPriority(m_strHdrType));
 }
 
 CStreamDetailAudio::CStreamDetailAudio() :
@@ -713,4 +714,18 @@ std::string CStreamDetails::HdrTypeToString(StreamHdrType hdrType)
     default:
       return "";
   }
+}
+
+int CStreamDetails::GetHdrPriority(const std::string& hdrType)
+{
+  if (hdrType == "dolbyvision")
+    return 50;
+  if (hdrType == "hdr10plus")
+    return 4;
+  if (hdrType == "hdr10")
+    return 3;
+  if (hdrType == "hlg")
+    return 2;
+
+  return 1;
 }

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -110,6 +110,7 @@ public:
   int GetVideoStreamCount(void) const;
   int GetAudioStreamCount(void) const;
   int GetSubtitleStreamCount(void) const;
+  static int GetHdrPriority(const std::string& hdrType);
   static std::string HdrTypeToString(StreamHdrType hdrType);
   const CStreamDetail* GetNthStream(CStreamDetail::StreamType type, int idx) const;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
StreamDetails: Implement HDR type priority for streamdetails database table

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For streams that has multiple HDR types or more that one video track, this allows display "best" HDR type in places that are intended only to display only one HDR type (as media flags).

Currently this almost not has use case because HDR streams usually only has one main video stream with hybrid HDR (e.g Dolby Vision / HDR10+) but with https://github.com/xbmc/xbmc/pull/27914 multiple HDR types are stored as separated stream details in database.

My main concern with https://github.com/xbmc/xbmc/pull/27914 is that hybrid Dolby Vision / HDR10+ files are displayed only as HDR10+ depending on the order in which the data is stored or obtained (random). 

The skin can translate the string "hdr10plus" to HDR10+, but should not decide between Dolby Vision and HDR10+, etc.

This PR implements HDR priority similar to audio codecs priority: the best video stream is the stream with more pixels and in case of several with the same resolution, wins the one with best HDR type.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in master branch where it has no effect, also tested with https://github.com/xbmc/xbmc/pull/27914 and allows Dolby Vision 8.1 files displayed always as "Dolby Vision" (not HDR10+ only). While videos that are only HDR10+ are displayed as "HDR10+".

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Allows display the best HDR type for video files with several HDR types (hybrid) or hypothetical case of a stream with multiple video tracks with same resolution and different HDR types.

## Screenshots (if appropriate):
**current master**
<img width="844" height="63" alt="master" src="https://github.com/user-attachments/assets/a94b2ac6-754d-4366-a7ea-fec6ebef2a37" />

**master with "hack code" removed**
<img width="827" height="94" alt="code_removed" src="https://github.com/user-attachments/assets/0e428c2f-e85d-4322-9417-508d6ce5963f" />

**PR**
<img width="848" height="67" alt="pr" src="https://github.com/user-attachments/assets/ef8874f6-6df0-4937-b6d4-44f22bc10aef" />

No difference with current master, but allows remove "hack code".

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
