### PR TITLE
ActiveAE: transcode to E-AC3 when eac3passthrough is enabled

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -3175,7 +3175,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#667"
-msgid "Enable Dolby Digital (AC3) transcoding"
+msgid "Enable Dolby Digital transcoding"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -21434,7 +21434,7 @@ msgstr ""
 #. Description of setting with label #667 "Enable Dolby Digital transcoding"
 #: system/settings/settings.xml
 msgctxt "#36429"
-msgid "Select this if the audio out connection only supports multichannel audio as Dolby Digital 5.1 (AC-3), such as a S/PDIF connection. If your system supports PCM multichannel audio via HDMI, leave this disabled."
+msgid "Select this if the audio out connection only supports multichannel audio as Dolby Digital 5.1 (AC-3), such as a S/PDIF connection. When E-AC3 passthrough is also enabled, Dolby Digital Plus (E-AC3) is used for higher quality. If your system supports PCM multichannel audio via HDMI, leave this disabled."
 msgstr ""
 
 #. Description for setting category #14101: "Video Acceleration"

--- a/tools/depends/target/ffmpeg/win_ffmpeg_options.txt
+++ b/tools/depends/target/ffmpeg/win_ffmpeg_options.txt
@@ -9,7 +9,7 @@
 --disable-openssl
 --disable-programs
 --disable-shared
---enable-encoder=ac3,aac,wmav2,png,mjpeg
+--enable-encoder=ac3,eac3,aac,wmav2,png,mjpeg
 --enable-muxer=spdif,adts,asf,ipod
 --enable-protocol=http
 --enable-runtime-cpudetect

--- a/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
+++ b/xbmc/cores/AudioEngine/Encoders/AEEncoderFFmpeg.cpp
@@ -12,11 +12,8 @@
 
 #include "cores/AudioEngine/Encoders/AEEncoderFFmpeg.h"
 
-#include "ServiceBroker.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "cores/FFmpeg.h"
-#include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
 #include "utils/log.h"
 
 extern "C"
@@ -90,9 +87,6 @@ bool CAEEncoderFFmpeg::Initialize(AEAudioFormat& format, bool allow_planar_input
 {
   Reset();
 
-  const bool ac3 = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-      CSettings::SETTING_AUDIOOUTPUT_AC3PASSTHROUGH);
-
   const AVCodec* codec = nullptr;
 
   if (format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_EAC3)
@@ -101,8 +95,15 @@ bool CAEEncoderFFmpeg::Initialize(AEAudioFormat& format, bool allow_planar_input
     m_CodecID = AV_CODEC_ID_EAC3;
     m_BitRate = EAC3_ENCODE_BITRATE;
     codec = avcodec_find_encoder(m_CodecID);
+    if (!codec)
+    {
+      CLog::Log(LOGWARNING,
+                "CAEEncoderFFmpeg::Initialize - EAC3 encoder not available, falling back to AC3");
+      format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_AC3;
+    }
   }
-  else if (ac3 || format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_AC3)
+
+  if (format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_AC3)
   {
     m_CodecName = "AC3";
     m_CodecID = AV_CODEC_ID_AC3;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1280,6 +1280,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
       outputFormat = inputFormat;
       outputFormat.m_dataFormat = AE_FMT_FLOATP;
       outputFormat.m_sampleRate = 48000;
+      outputFormat.m_streamInfo.m_type = m_sinkRequestFormat.m_streamInfo.m_type;
 
       // setup encoder
       if (!m_encoder)
@@ -1295,14 +1296,16 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
       outputFormat.m_frames = m_encoderFormat.m_frames;
 
       // encoder buffer
-      if (m_encoder->GetCodecID() == AV_CODEC_ID_AC3)
+      if (m_encoder->GetCodecID() == AV_CODEC_ID_AC3 || m_encoder->GetCodecID() == AV_CODEC_ID_EAC3)
       {
         AEAudioFormat format;
         format.m_channelLayout += AE_CH_FC;
         format.m_dataFormat = AE_FMT_RAW;
         format.m_sampleRate = 48000;
         format.m_channelLayout = AE_CH_LAYOUT_2_0;
-        format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_AC3;
+        format.m_streamInfo.m_type = (m_encoder->GetCodecID() == AV_CODEC_ID_EAC3)
+                                         ? CAEStreamInfo::STREAM_TYPE_EAC3
+                                         : CAEStreamInfo::STREAM_TYPE_AC3;
         format.m_streamInfo.m_channels = 2;
         format.m_streamInfo.m_sampleRate = 48000;
         format.m_streamInfo.m_frameSize = m_encoderFormat.m_frames;
@@ -1732,7 +1735,8 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat& format,
     format.m_dataFormat = AE_FMT_RAW;
     format.m_sampleRate = 48000;
     format.m_channelLayout = AE_CH_LAYOUT_2_0;
-    format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_AC3;
+    format.m_streamInfo.m_type =
+        settings.eac3passthrough ? CAEStreamInfo::STREAM_TYPE_EAC3 : CAEStreamInfo::STREAM_TYPE_AC3;
     format.m_streamInfo.m_channels = 2;
     format.m_streamInfo.m_sampleRate = 48000;
     if (mode)


### PR DESCRIPTION
 ## Description
  Use the existing E-AC3 encoder support (added for webOS in #27541) for all
  platforms. When AC3 transcoding and E-AC3 passthrough are both enabled,
  automatically transcode to E-AC3 instead of AC3.

  ## Motivation and context
  The webOS E-AC3 transcoding added in #27541 is platform-specific, gated behind
  `WebOSTVPlatformConfig::SupportsEAC3()`. This change makes the same capability
  available on all platforms by using the existing `eac3passthrough` setting to
  determine codec selection — if the receiver supports E-AC3, use it.

  ~~Also raises E-AC3 encode bitrate from 768kbps to 1024kbps (tested maximum for
  the ffmpeg EAC3 encoder).~~

  Relates to #27991

  There are no new settings, which could be _slightly_ misleading as the existing transcode
  settings says "Transcode to AC3".  But I wanted to minimize the changes here.

  ## How has this been tested?
  Tested on Intel NUC (i3-8109U) with HDMI output to receiver supporting both
  AC3 and E-AC3 passthrough. Verified transcoding activates for multichannel
  content with both AC3 (eac3passthrough off) and E-AC3 (eac3passthrough on).
  Confirmed 1024kbps is the maximum working bitrate for the ffmpeg EAC3 encoder.

  ## What is the effect on users?
  Users with E-AC3-capable receivers will automatically get higher quality
  transcoded audio without any new settings. Behaviour is unchanged when
  E-AC3 passthrough is not enabled.

  ## Screenshots (if appropriate):

  ## Types of change
  - [ ] **Bug fix** (non-breaking change which fixes an issue)
  - [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
  - [X] **Improvement** (non-breaking change which improves existing functionality)
  - [ ] **New feature** (non-breaking change which adds functionality)
  - [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
  - [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
  - [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
  - [ ] **None of the above** (please explain below)

  ## Checklist:
  - [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
  - [ ] My change requires a change to the documentation, either Doxygen or wiki
  - [ ] I have updated the documentation accordingly
  - [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
  - [ ] I have added tests to cover my change
  - [X] All new and existing tests passed