### PR TITLE
GBM: clear stale HDR metadata on startup

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -164,6 +164,8 @@ bool CWinSystemGbm::InitWindowSystem()
   if (setting)
     setting->SetVisible(true);
 
+  SetHDR(nullptr);
+
   CLog::Log(LOGDEBUG, "CWinSystemGbm::{} - initialized DRM", __FUNCTION__);
   return CWinSystemBase::InitWindowSystem();
 }


### PR DESCRIPTION
DRM connector properties (HDR_OUTPUT_METADATA) persist in the kernel across processes. 

This PR only addresses GBM rendering (GL or GLES) on Linux, not X11 or Wayland.

## Description
Call `SetHDR(nullptr)` during `InitWindowSystem()` to ensure a clean state when Kodi starts, preventing stale HDR metadata (typically from a previous session) from affecting the display.

## Motivation and context
DRM connector properties persist in the kernel across processes. If a previous Kodi session (or another application) set HDR_OUTPUT_METADATA and exited without clearing it,  the TV remains in HDR mode when Kodi restarts. This causes incorrect display output until video playback triggers a new SetHDR() call

## How has this been tested?

Tested on Intel NUC (i3-8109U, Coffee Lake) with GBM+GLES output over HDMI 2.0 (LSPCON). Verified that HDR metadata is cleared on startup after a previous HDR playback session.

## What is the effect on users?

Prevents the TV from staying in HDR mode when Kodi starts after a previous HDR session crashed or exited without cleanup.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
