### PR TITLE
[database] Add MySQL 9.6 compatibility

### DIFF
--- a/xbmc/dbwrappers/Database.cpp
+++ b/xbmc/dbwrappers/Database.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -130,7 +130,7 @@ bool CDatabase::ExistsSubQuery::BuildSQL(std::string& strSQL) const
 {
   if (tablename.empty())
     return false;
-  strSQL = "EXISTS (SELECT 1 FROM " + tablename;
+  strSQL = "EXISTS (SELECT 1 FROM `" + tablename + "`";
   if (!join.empty())
     strSQL += " " + join;
   std::string strWhere;
@@ -300,7 +300,7 @@ std::string CDatabase::GetSingleValue(const std::string& strTable,
   if (!m_pDS)
     return {};
 
-  std::string query = PrepareSQL("SELECT %s FROM %s", strColumn.c_str(), strTable.c_str());
+  std::string query = PrepareSQL("SELECT %s FROM `%s`", strColumn.c_str(), strTable.c_str());
   if (!strWhereClause.empty())
     query += " WHERE " + strWhereClause;
   if (!strOrderBy.empty())
@@ -357,7 +357,7 @@ int CDatabase::GetSingleValueInt(const std::string& query) const
 bool CDatabase::DeleteValues(const std::string& strTable, const Filter& filter /* = Filter() */)
 {
   std::string strQuery;
-  BuildSQL(PrepareSQL("DELETE FROM %s ", strTable.c_str()), filter, strQuery);
+  BuildSQL(PrepareSQL("DELETE FROM `%s` ", strTable.c_str()), filter, strQuery);
   return ExecuteQuery(strQuery);
 }
 

--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -117,7 +117,7 @@ public:
   /*!
    * @brief Get a single value from a table.
    * @remarks The values of the strWhereClause and strOrderBy parameters have to be FormatSQL'ed when used.
-   * @param strTable The table to get the value from.
+   * @param strTable The table to get the value from. Cannot be a complex expression with joins for example.
    * @param strColumn The column to get.
    * @param strWhereClause If set, use this WHERE clause.
    * @param strOrderBy If set, use this ORDER BY clause.
@@ -139,7 +139,7 @@ public:
   /*!
  * @brief Get a single integer value from a table.
  * @remarks The values of the strWhereClause and strOrderBy parameters have to be FormatSQL'ed when used.
- * @param strTable The table to get the value from.
+ * @param strTable The table to get the value from. Cannot be a complex expression with joins for example.
  * @param strColumn The column to get.
  * @param strWhereClause If set, use this WHERE clause.
  * @param strOrderBy If set, use this ORDER BY clause.

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -428,7 +428,7 @@ int MysqlDatabase::copy(const char* backup_name)
       }
 
       // copy the table definition
-      sqlcmd = StringUtils::Format("CREATE TABLE `{}`.{} LIKE {}", backup_name, row[0], row[0]);
+      sqlcmd = StringUtils::Format("CREATE TABLE `{}`.`{}` LIKE `{}`", backup_name, row[0], row[0]);
       ret = query_with_reconnect(sqlcmd.c_str());
       if (ret != MYSQL_OK)
       {
@@ -448,8 +448,8 @@ int MysqlDatabase::copy(const char* backup_name)
       }
 
       // copy the table data
-      sqlcmd =
-          StringUtils::Format("INSERT INTO `{}`.{} SELECT * FROM {}", backup_name, row[0], row[0]);
+      sqlcmd = StringUtils::Format("INSERT INTO `{}`.`{}` SELECT * FROM `{}`", backup_name, row[0],
+                                   row[0]);
       ret = query_with_reconnect(sqlcmd.c_str());
       if (ret != MYSQL_OK)
       {
@@ -495,7 +495,7 @@ int MysqlDatabase::drop_analytics()
   {
     while ((row = mysql_fetch_row(res)) != nullptr)
     {
-      sqlcmd = StringUtils::Format("ALTER TABLE `{}`.{} DROP INDEX {}", db, row[0], row[1]);
+      sqlcmd = StringUtils::Format("ALTER TABLE `{}`.`{}` DROP INDEX `{}`", db, row[0], row[1]);
       ret = query_with_reconnect(sqlcmd.c_str());
 
       if (ret != MYSQL_OK)
@@ -523,7 +523,7 @@ int MysqlDatabase::drop_analytics()
     while ((row = mysql_fetch_row(res)) != nullptr)
     {
       /* we do not need IF EXISTS because these views are exist */
-      sqlcmd = StringUtils::Format("DROP VIEW `{}`.{}", db, row[0]);
+      sqlcmd = StringUtils::Format("DROP VIEW `{}`.`{}`", db, row[0]);
       ret = query_with_reconnect(sqlcmd.c_str());
       if (ret != MYSQL_OK)
       {
@@ -549,7 +549,7 @@ int MysqlDatabase::drop_analytics()
   {
     while ((row = mysql_fetch_row(res)) != nullptr)
     {
-      sqlcmd = StringUtils::Format("DROP TRIGGER `{}`.{}", db, row[0]);
+      sqlcmd = StringUtils::Format("DROP TRIGGER `{}`.`{}`", db, row[0]);
       ret = query_with_reconnect(sqlcmd.c_str());
       if (ret != MYSQL_OK)
       {
@@ -576,7 +576,7 @@ int MysqlDatabase::drop_analytics()
   {
     while ((row = mysql_fetch_row(res)) != nullptr)
     {
-      sqlcmd = StringUtils::Format("DROP FUNCTION `{}`.{}", db, row[0]);
+      sqlcmd = StringUtils::Format("DROP FUNCTION `{}`.`{}`", db, row[0]);
       ret = query_with_reconnect(sqlcmd.c_str());
       if (ret != MYSQL_OK)
       {
@@ -1908,7 +1908,7 @@ bool MysqlDataset::dropIndex(const char* table, const char* index)
 
   if (num_rows())
   {
-    sql = "ALTER TABLE %s DROP INDEX %s";
+    sql = "ALTER TABLE `%s` DROP INDEX `%s`";
     sql_prepared = static_cast<MysqlDatabase*>(db)->prepare(sql.c_str(), table, index);
 
     if (exec(sql_prepared) != MYSQL_OK)

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -158,11 +158,6 @@ int MysqlDatabase::setErr(int err_code, const char* qry)
   return err_code;
 }
 
-const char* MysqlDatabase::getErrorMsg()
-{
-  return error.c_str();
-}
-
 void MysqlDatabase::configure_connection()
 {
   // MySQL 5.7.5+: See #8393

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -45,8 +45,6 @@ public:
   /* func. returns current status about MySQL-server connection */
   int status() override;
   int setErr(int err_code, const char* qry) override;
-  /* func. returns error message if error occurs */
-  const char* getErrorMsg() override;
 
   /* func. connects to database-server */
   int connect(bool create) override;

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -318,6 +318,16 @@ int SqliteDatabase::connect(bool create)
   if (host.empty() || db.empty())
     return DB_CONNECTION_NONE;
 
+  {
+    static bool showed_ver_info = false;
+    if (!showed_ver_info)
+    {
+      const char* version_string = sqlite3_libversion();
+      CLog::Log(LOGINFO, "SqliteDatabase: library version {}", version_string);
+      showed_ver_info = true;
+    }
+  }
+
   //CLog::Log(LOGDEBUG, "Connecting to sqlite:{}:{}", host, db);
 
   std::string db_fullpath = URIUtils::AddFileToFolder(host, db);

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -301,14 +301,10 @@ int SqliteDatabase::setErr(int err_code, const char* qry)
   }
   if (conn)
     ss << " (" << sqlite3_errmsg(conn) << ")";
-  ss << "\nQuery: " << qry;
+  if (qry != nullptr)
+    ss << "\nQuery: " << qry;
   error = ss.str();
   return err_code;
-}
-
-const char* SqliteDatabase::getErrorMsg()
-{
-  return error.c_str();
 }
 
 static int AlphaNumericCollation(

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -497,7 +497,7 @@ int SqliteDatabase::drop_analytics()
   std::string sqlcmd;
   for (const auto record : res.records)
   {
-    sqlcmd = StringUtils::Format("DROP INDEX '{}'", record->at(0).get_asString().c_str());
+    sqlcmd = StringUtils::Format("DROP INDEX `{}`", record->at(0).get_asString().c_str());
     err = sqlite3_exec(conn, sqlcmd.c_str(), nullptr, nullptr, nullptr);
     if (err != SQLITE_OK)
       return DB_UNEXPECTED_RESULT;
@@ -512,7 +512,7 @@ int SqliteDatabase::drop_analytics()
 
   for (const auto& record : res.records)
   {
-    sqlcmd = StringUtils::Format("DROP VIEW '{}'", record->at(0).get_asString().c_str());
+    sqlcmd = StringUtils::Format("DROP VIEW `{}`", record->at(0).get_asString().c_str());
     err = sqlite3_exec(conn, sqlcmd.c_str(), nullptr, nullptr, nullptr);
     if (err != SQLITE_OK)
       return DB_UNEXPECTED_RESULT;
@@ -527,7 +527,7 @@ int SqliteDatabase::drop_analytics()
 
   for (const auto& record : res.records)
   {
-    sqlcmd = StringUtils::Format("DROP TRIGGER '{}'", record->at(0).get_asString().c_str());
+    sqlcmd = StringUtils::Format("DROP TRIGGER `{}`", record->at(0).get_asString().c_str());
     err = sqlite3_exec(conn, sqlcmd.c_str(), nullptr, nullptr, nullptr);
     if (err != SQLITE_OK)
       return DB_UNEXPECTED_RESULT;

--- a/xbmc/dbwrappers/sqlitedataset.h
+++ b/xbmc/dbwrappers/sqlitedataset.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2004, Leo Seib, Hannover
+ *  Copyright (C) 2004-2026, Leo Seib, Hannover, Team Kodi
  *
  *  Project:SQLiteDataset C++ Dynamic Library
  *  Module: SQLiteDataset class header file
@@ -45,8 +45,6 @@ public:
   /* func. returns current status about SQLite-server connection */
   int status() override;
   int setErr(int err_code, const char* qry) override;
-  /* func. returns error message if error occurs */
-  const char* getErrorMsg() override;
   /* sets a new host name */
   void setHostName(const char* newHost) override;
   /* sets a database name */

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1404,13 +1404,13 @@ int CVideoDatabase::AddSet(const std::string& strSet,
       return -1;
 
     std::string strSQL =
-        PrepareSQL("SELECT idSet FROM sets WHERE strOriginalSet='%s'",
+        PrepareSQL("SELECT idSet FROM `sets` WHERE strOriginalSet='%s'",
                    strOriginalSet.empty() ? strSet.c_str() : strOriginalSet.c_str());
     m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
-      strSQL = PrepareSQL("INSERT INTO sets (idSet, strSet, strOverview, strOriginalSet) "
+      strSQL = PrepareSQL("INSERT INTO `sets` (idSet, strSet, strOverview, strOriginalSet) "
                           "VALUES(NULL, '%s', '%s', '%s')",
                           strSet.c_str(), strOverview.c_str(),
                           strOriginalSet.empty() ? strSet.c_str() : strOriginalSet.c_str());
@@ -1424,10 +1424,10 @@ int CVideoDatabase::AddSet(const std::string& strSet,
 
       // update set data
       if (updateOverview)
-        strSQL = PrepareSQL("UPDATE sets SET strSet = '%s', strOverview = '%s' WHERE idSet = %i",
+        strSQL = PrepareSQL("UPDATE `sets` SET strSet = '%s', strOverview = '%s' WHERE idSet = %i",
                             strSet.c_str(), strOverview.c_str(), id);
       else
-        strSQL = PrepareSQL("UPDATE sets SET strSet = '%s' WHERE idSet = %i", strSet.c_str(), id);
+        strSQL = PrepareSQL("UPDATE `sets` SET strSet = '%s' WHERE idSet = %i", strSet.c_str(), id);
 
       m_pDS->exec(strSQL);
 
@@ -2127,7 +2127,7 @@ bool CVideoDatabase::GetSetInfo(int idSet, CVideoInfoTag& details, CFileItem* it
       return false;
 
     Filter filter;
-    filter.where = PrepareSQL("sets.idSet=%d", idSet);
+    filter.where = PrepareSQL("`sets`.`idSet`=%d", idSet);
     CFileItemList items;
     if (!GetSetsByWhere("videodb://movies/sets/", filter, items) ||
         items.Size() != 1 ||
@@ -2501,7 +2501,8 @@ int CVideoDatabase::SetDetailsForMovieSet(const CVideoInfoTag& details,
     }
 
     // and insert the new row
-    std::string sql = PrepareSQL("UPDATE sets SET strSet='%s', strOverview='%s' WHERE idSet=%i", details.m_strTitle.c_str(), details.m_strPlot.c_str(), idSet);
+    std::string sql = PrepareSQL("UPDATE `sets` SET strSet='%s', strOverview='%s' WHERE idSet=%i",
+                                 details.m_strTitle.c_str(), details.m_strPlot.c_str(), idSet);
     m_pDS->exec(sql);
 
     if (!inTransaction)
@@ -4014,9 +4015,9 @@ void CVideoDatabase::DeleteSet(int idSet)
       return;
 
     std::string strSQL;
-    strSQL=PrepareSQL("delete from sets where idSet = %i", idSet);
+    strSQL = PrepareSQL("delete from `sets` where idSet = %i", idSet);
     m_pDS->exec(strSQL);
-    strSQL=PrepareSQL("update movie set idSet = null where idSet = %i", idSet);
+    strSQL = PrepareSQL("update movie set idSet = null where idSet = %i", idSet);
     m_pDS->exec(strSQL);
   }
   catch (...)
@@ -6236,7 +6237,8 @@ void CVideoDatabase::UpdateMovieTitle(int idMovie,
     else if (iType == VideoDbContentType::MOVIE_SETS)
     {
       CLog::Log(LOGINFO, "Changing Movie set:id:{} New Title:{}", idMovie, strNewMovieTitle);
-      std::string strSQL = PrepareSQL("UPDATE sets SET strSet='%s' WHERE idSet=%i", strNewMovieTitle.c_str(), idMovie );
+      std::string strSQL = PrepareSQL("UPDATE `sets` SET strSet='%s' WHERE idSet=%i",
+                                      strNewMovieTitle.c_str(), idMovie);
       m_pDS->exec(strSQL);
     }
 
@@ -6616,10 +6618,10 @@ bool CVideoDatabase::GetSetsByWhere(const std::string& strBaseDir, const Filter 
       return false;
 
     Filter setFilter = filter;
-    setFilter.join += " JOIN sets ON movie_view.idSet = sets.idSet";
+    setFilter.join += " JOIN `sets` ON movie_view.idSet = `sets`.idSet";
     if (!setFilter.order.empty())
       setFilter.order += ",";
-    setFilter.order += "sets.idSet";
+    setFilter.order += "`sets`.idSet";
 
     if (!GetMoviesByWhere(strBaseDir, setFilter, items))
       return false;
@@ -8218,7 +8220,7 @@ bool CVideoDatabase::HasSets() const
       return false;
 
     m_pDS->query("SELECT movie_view.idSet,COUNT(1) AS c FROM movie_view "
-                 "JOIN sets ON sets.idSet = movie_view.idSet "
+                 "JOIN `sets` ON `sets`.idSet = movie_view.idSet "
                  "GROUP BY movie_view.idSet HAVING c>1");
 
     bool bResult = (m_pDS->num_rows() > 0);
@@ -9958,8 +9960,8 @@ void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
       m_pDS->exec(sql);
 
       CLog::LogFC(LOGDEBUG, LOGDATABASE, "Cleaning set table");
-      sql = "DELETE FROM sets "
-            "WHERE NOT EXISTS (SELECT 1 FROM movie WHERE movie.idSet = sets.idSet)";
+      sql = "DELETE FROM `sets` "
+            "WHERE NOT EXISTS (SELECT 1 FROM movie WHERE movie.idSet = `sets`.idSet)";
       m_pDS->exec(sql);
 
       CommitTransaction();
@@ -10463,7 +10465,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
     if (!movieSetsDir.empty())
     {
       // find all movie sets
-      sql = "select * from sets";
+      sql = "select * from `sets`";
       m_pDS->query(sql);
       total = m_pDS->num_rows();
 

--- a/xbmc/video/VideoDatabaseDDL.cpp
+++ b/xbmc/video/VideoDatabaseDDL.cpp
@@ -159,7 +159,7 @@ void CVideoDatabaseDDL::CreateTables(CDatabase& db)
       "strVideoLanguage text, strHdrType text, strHdrDetail text)");
 
   CLog::Log(LOGINFO, "create sets table");
-  db.ExecuteQuery("CREATE TABLE sets ( idSet integer primary key, strSet text, strOverview text, "
+  db.ExecuteQuery("CREATE TABLE `sets` ( idSet integer primary key, strSet text, strOverview text, "
                   "strOriginalSet text)");
 
   CLog::Log(LOGINFO, "create seasons table");
@@ -352,7 +352,7 @@ void CVideoDatabaseDDL::CreateTriggers(CDatabase& db)
   db.ExecuteQuery("CREATE TRIGGER delete_season AFTER DELETE ON seasons FOR EACH ROW BEGIN "
                   "DELETE FROM art WHERE media_id=old.idSeason AND media_type='season'; "
                   "END");
-  db.ExecuteQuery("CREATE TRIGGER delete_set AFTER DELETE ON sets FOR EACH ROW BEGIN "
+  db.ExecuteQuery("CREATE TRIGGER delete_set AFTER DELETE ON `sets` FOR EACH ROW BEGIN "
                   "DELETE FROM art WHERE media_id=old.idSet AND media_type='set'; "
                   "END");
   db.ExecuteQuery("CREATE TRIGGER delete_person AFTER DELETE ON actor FOR EACH ROW BEGIN "
@@ -565,9 +565,9 @@ void CVideoDatabaseDDL::CreateViews(CDatabase& db)
   const std::string movieview = db.PrepareSQL(
       "CREATE VIEW movie_view AS SELECT"
       "  movie.*,"
-      "  sets.strSet AS strSet,"
-      "  sets.strOverview AS strSetOverview,"
-      "  sets.strOriginalSet as strOriginalSet,"
+      "  `sets`.`strSet` AS strSet,"
+      "  `sets`.`strOverview` AS strSetOverview,"
+      "  `sets`.`strOriginalSet` as strOriginalSet,"
       "  files.strFileName AS strFileName,"
       "  path.strPath AS strPath,"
       "  files.playCount AS playCount,"
@@ -605,8 +605,8 @@ void CVideoDatabaseDDL::CreateViews(CDatabase& db)
       "  vvt.name AS videoVersionTypeName,"
       "  vvt.itemType AS videoVersionTypeItemType "
       "FROM movie"
-      "  LEFT JOIN sets ON"
-      "    sets.idSet = movie.idSet"
+      "  LEFT JOIN `sets` ON"
+      "    `sets`.idSet = movie.idSet"
       "  LEFT JOIN rating ON"
       "    rating.rating_id = movie.c%02d"
       "  LEFT JOIN uniqueid ON"

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -493,7 +493,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
   }
 
   if (iVersion < 97)
-    m_pDS->exec("ALTER TABLE sets ADD strOverview TEXT");
+    m_pDS->exec("ALTER TABLE `sets` ADD strOverview TEXT");
 
   if (iVersion < 98)
     m_pDS->exec("ALTER TABLE seasons ADD name text");
@@ -1015,10 +1015,10 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
   if (iVersion < 136)
   {
-    m_pDS->exec("ALTER TABLE sets ADD strOriginalSet TEXT");
+    m_pDS->exec("ALTER TABLE `sets` ADD strOriginalSet TEXT");
 
     // Copy current set title for existing sets
-    m_pDS->exec("UPDATE sets SET strOriginalSet = strSet");
+    m_pDS->exec("UPDATE `sets` SET strOriginalSet = strSet");
   }
 
   if (iVersion < 138)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Added table name quoting to generic db wrapper queries and queries that explicitly use the table 'sets'.
This is unfortunately a quick'n dirty fix - a better generic solution would address the quoting of all table names wherever they appear in all SQL queries, not only those that started failing with MySQL 9.6, Maybe in a future modernization PR.

There are two quote character options: the double quote and the backtick.
For simplicity and convenience, the backtick quote character is used here, as it is native to both MySQL, MariaDB and Sqlite.

If another db engine is needed at some point in the future, it will be easy to activate the ANSI quotes mode (per DB connection)
For future reference, Sqlite config SQLITE_DBCONFIG_DQS_DDL and SQLITE_DBCONFIG_DQS_DML to disable double-quote misfeature, and execution of `SET SESSION sql_mode = (SELECT CONCAT(@@SESSION.sql_mode,',ANSI_QUOTES'))` for MySQL/MariaDB available since 5.0.0

Another consideration in the choice of the quick'n dirty fix approach was the possibility of a backport to v21, also unable to create the video db with MySQL 9.6 or execute some queries.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

MySQL 9.6 cannot be used to store the video database because 'sets', used as a table name in the video db, is now a reserved keyword, and table names are not quoted in the dbwrappers or the queries of the various *Database classes.

That type of issue would have been avoided with an ORM but that's much too big of a change with no hope of a backport.

fix #27901 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

SQlite 3.50.4 (current Windows), MySQL 9.6, MariaDB 11.8, navigation through the libray, videos, smartplaylist.

I may have missed places in Kodi that assemble dynamic SQL queries piece by piece

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Kodi runs with MySQL 9.6 database servers.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
