### PR TITLE
GBM/EGL: enable 10-bit framebuffer for single-plane rendering

### DIFF
--- a/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag
+++ b/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag
@@ -50,6 +50,13 @@ void main()
              texture2D(m_sampV, m_cordV).a,
              1.0);
 
+#elif defined(XBMC_YV12_HI)
+
+  yuv = vec4(texture2D(m_sampY, m_cordY).r,
+             texture2D(m_sampU, m_cordU).r,
+             texture2D(m_sampV, m_cordV).r,
+             1.0);
+
 #elif defined(XBMC_NV12_RRG)
 
   yuv = vec4(texture2D(m_sampY, m_cordY).r,

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
@@ -40,3 +40,14 @@ EINTERLACEMETHOD CProcessInfoGBM::GetFallbackDeintMethod()
   return CProcessInfo::GetFallbackDeintMethod();
 #endif
 }
+
+std::vector<AVPixelFormat> CProcessInfoGBM::GetRenderFormats()
+{
+  return {
+      AV_PIX_FMT_YUV420P,   AV_PIX_FMT_NV12,      AV_PIX_FMT_YUV420P9,  AV_PIX_FMT_YUV420P10,
+      AV_PIX_FMT_YUV420P12, AV_PIX_FMT_YUV420P14, AV_PIX_FMT_YUV420P16,
+      // TODO: verify YUV422 on existing GL renderer, add support to GLES renderer
+      // AV_PIX_FMT_YUYV422,
+      // AV_PIX_FMT_UYVY422,
+  };
+}

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
@@ -10,8 +10,10 @@
 
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/Buffers/VideoBufferPoolDMA.h"
+#include "rendering/RenderSystem.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/log.h"
 
 using namespace VIDEOPLAYER;
 
@@ -43,11 +45,36 @@ EINTERLACEMETHOD CProcessInfoGBM::GetFallbackDeintMethod()
 
 std::vector<AVPixelFormat> CProcessInfoGBM::GetRenderFormats()
 {
-  return {
-      AV_PIX_FMT_YUV420P,   AV_PIX_FMT_NV12,      AV_PIX_FMT_YUV420P9,  AV_PIX_FMT_YUV420P10,
-      AV_PIX_FMT_YUV420P12, AV_PIX_FMT_YUV420P14, AV_PIX_FMT_YUV420P16,
-      // TODO: verify YUV422 on existing GL renderer, add support to GLES renderer
-      // AV_PIX_FMT_YUYV422,
-      // AV_PIX_FMT_UYVY422,
+  std::vector<AVPixelFormat> formats = {
+      AV_PIX_FMT_YUV420P,
+      AV_PIX_FMT_NV12,
   };
+
+  // For software decode, the ffmpeg codec queries GetRenderFormats before any
+  // renderer is created. Since GLES 2.0 vs 3.0+ is a runtime (not compile-time)
+  // issue, this method gates >8-bit formats on behalf of the eventual renderer.
+  // >8-bit requires GL_EXT_texture_norm16; without it, ffmpeg downconverts to
+  // 8-bit, preserving existing behavior.
+#if defined(HAS_GLES)
+  auto renderSystem = CServiceBroker::GetRenderSystem();
+  if (!renderSystem)
+  {
+    CLog::Log(LOGERROR, "CProcessInfoGBM::GetRenderFormats: render system not initialized");
+    return formats;
+  }
+  if (renderSystem->IsExtSupported("GL_EXT_texture_norm16"))
+#endif
+  {
+    formats.push_back(AV_PIX_FMT_YUV420P9);
+    formats.push_back(AV_PIX_FMT_YUV420P10);
+    formats.push_back(AV_PIX_FMT_YUV420P12);
+    formats.push_back(AV_PIX_FMT_YUV420P14);
+    formats.push_back(AV_PIX_FMT_YUV420P16);
+  }
+
+  // TODO: verify YUV422 on existing GL renderer, add support to GLES renderer
+  // formats.push_back(AV_PIX_FMT_YUYV422);
+  // formats.push_back(AV_PIX_FMT_UYVY422);
+
+  return formats;
 }

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h
@@ -22,6 +22,7 @@ public:
 
   CProcessInfoGBM();
   EINTERLACEMETHOD GetFallbackDeintMethod() override;
+  std::vector<AVPixelFormat> GetRenderFormats() override;
 };
 
 } // namespace VIDEOPLAYER

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -49,9 +49,6 @@ CLinuxRendererGLES::CLinuxRendererGLES()
     m_pixelStoreKey = GL_UNPACK_ROW_LENGTH_EXT;
   }
 #endif
-
-  if (m_renderSystem && m_renderSystem->IsExtSupported("GL_EXT_texture_norm16"))
-    m_hasTextureNorm16 = true;
 }
 
 CLinuxRendererGLES::~CLinuxRendererGLES()
@@ -1439,7 +1436,7 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
     default:
       break;
   }
-  if (buf.m_srcTextureBits > 8 && m_hasTextureNorm16)
+  if (buf.m_srcTextureBits > 8)
     im.bpp = 2;
   else
     im.bpp = 1;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -49,6 +49,9 @@ CLinuxRendererGLES::CLinuxRendererGLES()
     m_pixelStoreKey = GL_UNPACK_ROW_LENGTH_EXT;
   }
 #endif
+
+  if (m_renderSystem && m_renderSystem->IsExtSupported("GL_EXT_texture_norm16"))
+    m_hasTextureNorm16 = true;
 }
 
 CLinuxRendererGLES::~CLinuxRendererGLES()
@@ -307,7 +310,8 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
       pixelData = m_planeBuffer;
     }
   }
-  glTexSubImage2D(m_textureTarget, 0, 0, 0, width, height, type, GL_UNSIGNED_BYTE, pixelData);
+  GLenum datatype = (bpp == 2) ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE;
+  glTexSubImage2D(m_textureTarget, 0, 0, 0, width, height, type, datatype, pixelData);
 
   if (m_pixelStoreKey > 0 && pixelStoreChanged)
     glPixelStorei(m_pixelStoreKey, 0);
@@ -315,17 +319,13 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
   // check if we need to load any border pixels
   if (height < plane.texheight)
   {
-    glTexSubImage2D(m_textureTarget, 0,
-                    0, height, width, 1,
-                    type, GL_UNSIGNED_BYTE,
+    glTexSubImage2D(m_textureTarget, 0, 0, height, width, 1, type, datatype,
                     static_cast<const unsigned char*>(pixelData) + stride * (height - 1));
   }
 
   if (width  < plane.texwidth)
   {
-    glTexSubImage2D(m_textureTarget, 0,
-                    width, 0, 1, height,
-                    type, GL_UNSIGNED_BYTE,
+    glTexSubImage2D(m_textureTarget, 0, width, 0, 1, height, type, datatype,
                     static_cast<const unsigned char*>(pixelData) + bps * (width - 1));
   }
 
@@ -1339,22 +1339,32 @@ bool CLinuxRendererGLES::UploadYV12Texture(int source)
 
   VerifyGLState();
 
-  glPixelStorei(GL_UNPACK_ALIGNMENT,1);
+  glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
-  // load Y plane
-  LoadPlane(buf.fields[FIELD_FULL][0], GL_LUMINANCE,
-            im->width, im->height,
-            im->stride[0], im->bpp, im->plane[0]);
+  if (im->bpp == 2)
+  {
+    // >8-bit: three separate GL_R16_EXT planes
+    LoadPlane(buf.fields[FIELD_FULL][0], GL_RED, im->width, im->height, im->stride[0], im->bpp,
+              im->plane[0]);
 
-  // load U plane
-  LoadPlane(buf.fields[FIELD_FULL][1], GL_LUMINANCE,
-            im->width >> im->cshift_x, im->height >> im->cshift_y,
-            im->stride[1], im->bpp, im->plane[1]);
+    LoadPlane(buf.fields[FIELD_FULL][1], GL_RED, im->width >> im->cshift_x,
+              im->height >> im->cshift_y, im->stride[1], im->bpp, im->plane[1]);
 
-  // load V plane
-  LoadPlane(buf.fields[FIELD_FULL][2], GL_ALPHA,
-            im->width >> im->cshift_x, im->height >> im->cshift_y,
-            im->stride[2], im->bpp, im->plane[2]);
+    LoadPlane(buf.fields[FIELD_FULL][2], GL_RED, im->width >> im->cshift_x,
+              im->height >> im->cshift_y, im->stride[2], im->bpp, im->plane[2]);
+  }
+  else
+  {
+    // 8-bit: GL_LUMINANCE for Y/U, GL_ALPHA for V
+    LoadPlane(buf.fields[FIELD_FULL][0], GL_LUMINANCE, im->width, im->height, im->stride[0],
+              im->bpp, im->plane[0]);
+
+    LoadPlane(buf.fields[FIELD_FULL][1], GL_LUMINANCE, im->width >> im->cshift_x,
+              im->height >> im->cshift_y, im->stride[1], im->bpp, im->plane[1]);
+
+    LoadPlane(buf.fields[FIELD_FULL][2], GL_ALPHA, im->width >> im->cshift_x,
+              im->height >> im->cshift_y, im->stride[2], im->bpp, im->plane[2]);
+  }
 
   VerifyGLState();
 
@@ -1399,7 +1409,8 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
 {
   // since we also want the field textures, pitch must be texture aligned
   unsigned p;
-  YuvImage &im = m_buffers[index].image;
+  CPictureBuffer& buf = m_buffers[index];
+  YuvImage& im = buf.image;
 
   DeleteYV12Texture(index);
 
@@ -1407,7 +1418,31 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
   im.width = m_sourceWidth;
   im.cshift_x = 1;
   im.cshift_y = 1;
-  im.bpp = 1;
+
+  switch (m_format)
+  {
+    case AV_PIX_FMT_YUV420P16:
+      buf.m_srcTextureBits = 16;
+      break;
+    case AV_PIX_FMT_YUV420P14:
+      buf.m_srcTextureBits = 14;
+      break;
+    case AV_PIX_FMT_YUV420P12:
+      buf.m_srcTextureBits = 12;
+      break;
+    case AV_PIX_FMT_YUV420P10:
+      buf.m_srcTextureBits = 10;
+      break;
+    case AV_PIX_FMT_YUV420P9:
+      buf.m_srcTextureBits = 9;
+      break;
+    default:
+      break;
+  }
+  if (buf.m_srcTextureBits > 8 && m_hasTextureNorm16)
+    im.bpp = 2;
+  else
+    im.bpp = 1;
 
   im.stride[0] = im.bpp * im.width;
   im.stride[1] = im.bpp * (im.width >> im.cshift_x);
@@ -1464,17 +1499,23 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
 
       glBindTexture(m_textureTarget, plane.id);
 
-      GLint format;
-      if (p == 2) // V plane needs an alpha texture
+      if (im.bpp == 2)
       {
-        format = GL_ALPHA;
+        glTexImage2D(m_textureTarget, 0, GL_R16_EXT, plane.texwidth, plane.texheight, 0, GL_RED,
+                     GL_UNSIGNED_SHORT, nullptr);
       }
       else
       {
-        format = GL_LUMINANCE;
+        GLint format;
+        if (p == 2) // V plane needs an alpha texture
+          format = GL_ALPHA;
+        else
+          format = GL_LUMINANCE;
+
+        glTexImage2D(m_textureTarget, 0, format, plane.texwidth, plane.texheight, 0, format,
+                     GL_UNSIGNED_BYTE, nullptr);
       }
 
-      glTexImage2D(m_textureTarget, 0, format, plane.texwidth, plane.texheight, 0, format, GL_UNSIGNED_BYTE, nullptr);
       glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
       glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
       glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -150,6 +150,7 @@ protected:
   int m_reloadShaders{0};
   CRenderSystemGLES *m_renderSystem{nullptr};
   GLenum m_pixelStoreKey{0};
+  bool m_hasTextureNorm16{false};
 
   struct CYuvPlane
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -150,7 +150,6 @@ protected:
   int m_reloadShaders{0};
   CRenderSystemGLES *m_renderSystem{nullptr};
   GLenum m_pixelStoreKey{0};
-  bool m_hasTextureNorm16{false};
 
   struct CYuvPlane
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -43,6 +43,9 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format,
 
   if (m_format == SHADER_YV12)
     m_defines += "#define XBMC_YV12\n";
+  else if (m_format == SHADER_YV12_9 || m_format == SHADER_YV12_10 || m_format == SHADER_YV12_12 ||
+           m_format == SHADER_YV12_14 || m_format == SHADER_YV12_16)
+    m_defines += "#define XBMC_YV12_HI\n";
   else if (m_format == SHADER_NV12)
     m_defines += "#define XBMC_NV12\n";
   else if (m_format == SHADER_NV12_RRG)

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -271,7 +271,7 @@ bool CEGLContextUtils::InitializeDisplay(EGLint renderingApi)
   return true;
 }
 
-bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId, bool hdr)
+bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId, bool hdr, int alpha)
 {
   EGLint numMatched{0};
 
@@ -282,28 +282,11 @@ bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId, bool
 
   EGLint surfaceType = EGL_WINDOW_BIT;
 
-  // Match EGL color sizes to 10-bit DRM FourCC visual IDs when requested.
-  // These are from drm_fourcc.h which is not available on all EGL platforms.
-  constexpr EGLint DRM_FORMAT_XRGB2101010 = 0x30335258; // XR30
-  constexpr EGLint DRM_FORMAT_ARGB2101010 = 0x30335241; // AR30
-
-  EGLint redSize = 8;
-  EGLint greenSize = 8;
-  EGLint blueSize = 8;
-  EGLint alphaSize = 8;
-  if (visualId == DRM_FORMAT_XRGB2101010 || visualId == DRM_FORMAT_ARGB2101010)
-  {
-    redSize = 10;
-    greenSize = 10;
-    blueSize = 10;
-    alphaSize = (visualId == DRM_FORMAT_XRGB2101010) ? 0 : 2;
-  }
-
   CEGLAttributesVec attribs;
-  attribs.Add({{EGL_RED_SIZE, redSize},
-               {EGL_GREEN_SIZE, greenSize},
-               {EGL_BLUE_SIZE, blueSize},
-               {EGL_ALPHA_SIZE, alphaSize},
+  attribs.Add({{EGL_RED_SIZE, 8},
+               {EGL_GREEN_SIZE, 8},
+               {EGL_BLUE_SIZE, 8},
+               {EGL_ALPHA_SIZE, alpha},
                {EGL_DEPTH_SIZE, 16},
                {EGL_STENCIL_SIZE, 0},
                {EGL_SAMPLE_BUFFERS, 0},

--- a/xbmc/utils/EGLUtils.cpp
+++ b/xbmc/utils/EGLUtils.cpp
@@ -282,11 +282,28 @@ bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId, bool
 
   EGLint surfaceType = EGL_WINDOW_BIT;
 
+  // Match EGL color sizes to 10-bit DRM FourCC visual IDs when requested.
+  // These are from drm_fourcc.h which is not available on all EGL platforms.
+  constexpr EGLint DRM_FORMAT_XRGB2101010 = 0x30335258; // XR30
+  constexpr EGLint DRM_FORMAT_ARGB2101010 = 0x30335241; // AR30
+
+  EGLint redSize = 8;
+  EGLint greenSize = 8;
+  EGLint blueSize = 8;
+  EGLint alphaSize = 8;
+  if (visualId == DRM_FORMAT_XRGB2101010 || visualId == DRM_FORMAT_ARGB2101010)
+  {
+    redSize = 10;
+    greenSize = 10;
+    blueSize = 10;
+    alphaSize = (visualId == DRM_FORMAT_XRGB2101010) ? 0 : 2;
+  }
+
   CEGLAttributesVec attribs;
-  attribs.Add({{EGL_RED_SIZE, 8},
-               {EGL_GREEN_SIZE, 8},
-               {EGL_BLUE_SIZE, 8},
-               {EGL_ALPHA_SIZE, 8},
+  attribs.Add({{EGL_RED_SIZE, redSize},
+               {EGL_GREEN_SIZE, greenSize},
+               {EGL_BLUE_SIZE, blueSize},
+               {EGL_ALPHA_SIZE, alphaSize},
                {EGL_DEPTH_SIZE, 16},
                {EGL_STENCIL_SIZE, 0},
                {EGL_SAMPLE_BUFFERS, 0},
@@ -341,7 +358,7 @@ bool CEGLContextUtils::ChooseConfig(EGLint renderableType, EGLint visualId, bool
 
   if (visualId != 0 && visualId != id)
   {
-    CLog::Log(LOGDEBUG, "failed to find EGL config with EGL_NATIVE_VISUAL_ID={}", visualId);
+    CLog::Log(LOGDEBUG, "failed to find EGL config with EGL_NATIVE_VISUAL_ID={:x}", visualId);
     return false;
   }
 

--- a/xbmc/utils/EGLUtils.h
+++ b/xbmc/utils/EGLUtils.h
@@ -196,7 +196,7 @@ public:
   bool CreateSurface(EGLNativeWindowType nativeWindow, EGLint HDRcolorSpace = EGL_NONE);
   bool CreatePlatformSurface(void* nativeWindow, EGLNativeWindowType nativeWindowLegacy);
   bool InitializeDisplay(EGLint renderingApi);
-  bool ChooseConfig(EGLint renderableType, EGLint visualId = 0, bool hdr = false);
+  bool ChooseConfig(EGLint renderableType, EGLint visualId = 0, bool hdr = false, int alpha = 8);
   bool CreateContext(CEGLAttributesVec contextAttribs);
   bool BindContext();
   void Destroy();

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -257,15 +257,15 @@ int KODI::UTILS::GL::glFormatElementByteCount(GLenum format)
 #ifdef HAS_GL
   case GL_BGRA:
     return 4;
-  case GL_RED:
-    return 1;
   case GL_GREEN:
     return 1;
-  case GL_RG:
-    return 2;
   case GL_BGR:
     return 3;
 #endif
+  case GL_RED:
+    return 1;
+  case GL_RG:
+    return 2;
   case GL_RGBA:
     return 4;
   case GL_RGB:

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -34,6 +34,8 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
   }
 
   auto plane = m_DRM->GetGuiPlane();
+  // TODO: GetGuiPlane() should never be null here (FindPlanes would have failed).
+  // The DRM_FORMAT_XRGB2101010 fallback is suspect — consider DRM_FORMAT_XRGB8888.
   uint32_t visualId = plane != nullptr ? plane->GetFormat() : DRM_FORMAT_XRGB2101010;
 
   // prefer alpha visual id, fallback to non-alpha visual id

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -38,9 +38,15 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
   // The DRM_FORMAT_XRGB2101010 fallback is suspect — consider DRM_FORMAT_XRGB8888.
   uint32_t visualId = plane != nullptr ? plane->GetFormat() : DRM_FORMAT_XRGB2101010;
 
+  // Determine alpha size based on plane format. 10-bit formats (ARGB2101010) only
+  // have 2-bit alpha; 8-bit formats (ARGB8888) have full 8-bit alpha.
+  bool is10bit = (visualId == DRM_FORMAT_XRGB2101010 || visualId == DRM_FORMAT_ARGB2101010);
+  int alphaWithAlpha = is10bit ? 2 : 8;
+
   // prefer alpha visual id, fallback to non-alpha visual id
-  if (!m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithAlpha(visualId)) &&
-      !m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithoutAlpha(visualId)))
+  if (!m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithAlpha(visualId), false,
+                                 alphaWithAlpha) &&
+      !m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithoutAlpha(visualId), false, 0))
   {
     // fallback to 8bit format if no EGL config was found for 10bit
     if (plane)
@@ -49,7 +55,8 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
     visualId = plane != nullptr ? plane->GetFormat() : DRM_FORMAT_XRGB8888;
 
     if (!m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithAlpha(visualId)) &&
-        !m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithoutAlpha(visualId)))
+        !m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithoutAlpha(visualId), false,
+                                   0))
     {
       return false;
     }

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -18,7 +18,7 @@ using namespace KODI::WINDOWING::LINUX;
 
 bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint apiType)
 {
-  if (!CWinSystemGbm::InitWindowSystem())
+  if (!m_DRM && !CWinSystemGbm::InitWindowSystem())
   {
     return false;
   }
@@ -30,8 +30,11 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
 
   if (!m_eglContext.InitializeDisplay(apiType))
   {
+    m_eglContext.Destroy();
     return false;
   }
+
+  m_renderableType = renderableType;
 
   auto plane = m_DRM->GetGuiPlane();
   // TODO: GetGuiPlane() should never be null here (FindPlanes would have failed).
@@ -58,12 +61,14 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
         !m_eglContext.ChooseConfig(renderableType, CDRMUtils::FourCCWithoutAlpha(visualId), false,
                                    0))
     {
+      m_eglContext.Destroy();
       return false;
     }
   }
 
   if (!CreateContext())
   {
+    m_eglContext.Destroy();
     return false;
   }
 

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
@@ -55,6 +55,8 @@ protected:
   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
   virtual bool CreateContext() = 0;
 
+  EGLint m_renderableType{0};
+
   std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
 
   struct delete_CVaapiProxy

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -62,9 +62,13 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
 
   // GLES 3.0 required for 10-bit texture format support (GL_RGB10_A2, GL_R16UI, etc.)
+  // Fall back to GLES 2.0 for devices that don't support GLES 3.0 (e.g. lima driver)
   if (!CWinSystemGbmEGLContext::InitWindowSystemEGL(EGL_OPENGL_ES3_BIT, EGL_OPENGL_ES_API))
   {
-    return false;
+    if (!CWinSystemGbmEGLContext::InitWindowSystemEGL(EGL_OPENGL_ES2_BIT, EGL_OPENGL_ES_API))
+    {
+      return false;
+    }
   }
 
   bool general, deepColor;

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -61,7 +61,8 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryDMAOpenGLES);
   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
 
-  if (!CWinSystemGbmEGLContext::InitWindowSystemEGL(EGL_OPENGL_ES2_BIT, EGL_OPENGL_ES_API))
+  // GLES 3.0 required for 10-bit texture format support (GL_RGB10_A2, GL_R16UI, etc.)
+  if (!CWinSystemGbmEGLContext::InitWindowSystemEGL(EGL_OPENGL_ES3_BIT, EGL_OPENGL_ES_API))
   {
     return false;
   }

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -188,8 +188,10 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
 
 bool CWinSystemGbmGLESContext::CreateContext()
 {
+  const EGLint version = (m_renderableType == EGL_OPENGL_ES3_BIT) ? 3 : 2;
+
   CEGLAttributesVec contextAttribs;
-  contextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, 2}});
+  contextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, version}});
 
   if (!m_eglContext.CreateContext(contextAttribs))
   {

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -222,7 +222,18 @@ bool CDRMUtils::FindPlanes()
   if (m_video_plane)
     CLog::LogF(LOGDEBUG, "Using video plane {}", m_video_plane->GetPlaneId());
 
-  if (m_gui_plane->SupportsFormat(DRM_FORMAT_XRGB2101010))
+  // Use 10-bit GUI plane when available, unless dual-plane Direct-To-Plane
+  // rendering will be used (RendererDRMPRIME — the only DRM dual-plane renderer).
+  // Dual-plane DRM compositing requires 8-bit alpha (ARGB8888) for GUI overlay transparency.
+  // 10-bit formats only offer 2-bit alpha (ARGB2101010) which causes visible banding in dual-plane.
+  // Dual-plane requires both DRMPRIME decoding and Direct-To-Plane render method.
+  bool useDualPlane = m_video_plane &&
+                      CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                          "videoplayer.useprimedecoder") &&
+                      CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                          "videoplayer.useprimerenderer") == 0;
+
+  if (!useDualPlane && m_gui_plane->SupportsFormat(DRM_FORMAT_XRGB2101010))
   {
     m_gui_plane->SetFormat(DRM_FORMAT_XRGB2101010);
     CLog::LogF(LOGDEBUG, "Using 10bit gui plane {}", m_gui_plane->GetPlaneId());

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -222,18 +222,19 @@ bool CDRMUtils::FindPlanes()
   if (m_video_plane)
     CLog::LogF(LOGDEBUG, "Using video plane {}", m_video_plane->GetPlaneId());
 
-  // Use 10-bit GUI plane when available, unless dual-plane Direct-To-Plane
-  // rendering will be used (RendererDRMPRIME — the only DRM dual-plane renderer).
-  // Dual-plane DRM compositing requires 8-bit alpha (ARGB8888) for GUI overlay transparency.
-  // 10-bit formats only offer 2-bit alpha (ARGB2101010) which causes visible banding in dual-plane.
-  // Dual-plane requires both DRMPRIME decoding and Direct-To-Plane render method.
-  bool useDualPlane = m_video_plane &&
-                      CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-                          "videoplayer.useprimedecoder") &&
-                      CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-                          "videoplayer.useprimerenderer") == 0;
+  // Use 10-bit GUI plane when available, unless Direct-to-Plane (dual-plane)
+  // rendering will be used (RendererDRMPRIME — the only Direct-To-Plane renderer).
+  // Direct-to-Plane DRM compositing requires 8-bit alpha (ARGB8888) for GUI overlay transparency.
+  // 10-bit formats only offer 2-bit alpha (ARGB2101010) which causes visible banding in
+  // Direct-to-Plane.  Direct-to-Plane is triggered by settings for both DRMPRIME decoding and
+  // Direct-To-Plane rendering method.
+  bool useDirectToPlane = m_video_plane &&
+                          CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                              "videoplayer.useprimedecoder") &&
+                          CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+                              "videoplayer.useprimerenderer") == 0;
 
-  if (!useDualPlane && m_gui_plane->SupportsFormat(DRM_FORMAT_XRGB2101010))
+  if (!useDirectToPlane && m_gui_plane->SupportsFormat(DRM_FORMAT_XRGB2101010))
   {
     m_gui_plane->SetFormat(DRM_FORMAT_XRGB2101010);
     CLog::LogF(LOGDEBUG, "Using 10bit gui plane {}", m_gui_plane->GetPlaneId());


### PR DESCRIPTION
## Description

Scope: EGL single-plane rendering.  This does not impact Direct-to-Plane rendering. 

Currently all GBM+EGL rendering is coerced to 8-bit (XRGB8888) even when the hardware supports 10-bit and HDR content is being passed through. This means 10-bit content (HDR or SDR) rendered via VAAPI+GLES or DRMPRIME+GLES is quantized to 8-bit before reaching the display, despite HDR metadata being correctly signaled to the TV.

Set EGL color size attributes to match 10-bit visual IDs (XR30/AR30) so the driver selects a 10-bit EGL config when the DRM primary plane supports it. Request EGL_OPENGL_ES3_BIT for 10-bit texture support.

For dual-plane Direct-To-Plane rendering (RendererDRMPRIME), force the GUI plane to 8-bit (XRGB8888) so DRM hardware compositing gets a full 8-bit alpha channel. This is a longer-term fix for the issue addressed by #27257, which hardcoded EGL_ALPHA_SIZE=8 globally. That workaround prevented 10-bit configs from ever being selected. This commit instead handles it at the caller: InitWindowSystemEGL forces 8-bit only when dual-plane compositing is active, allowing single-plane renderers to use 10-bit.

Note: a follow-up commit will add FBO-based GUI tone mapping (sRGB to PQ) for correct GUI appearance during HDR playback, which depends on the 10-bit framebuffer enabled here. Together these PR's would address #27988 

## Motivation and context

  - Fixes the root cause of #27257 at the caller level rather than inside ChooseConfig
  - Enables true 10-bit video output for single-plane GBM renderers (VAAPI+GLES, DRMPRIMEGLES)
  - Prerequisite for FBO-based HDR GUI compositing

## How has this been tested?

  Tested on Intel NUC (i3-8109U, Coffee Lake) with GBM+GLES output over HDMI 2.0 (LSPCON). Verified 10-bit EGL config is selected when DRM primary plane supports
  XRGB2101010. Both 8-bit and 10-bit content plays correctly. No RPi5 hardware available for Direct-To-Plane testing — requesting testing from RPi/Amlogic users, hoping especially that @popcornmix @chewitt try this out.

## What is the effect on users?

 Single-plane GBM renderers (VAAPI+GLES, DRMPRIMEGLES) now get a 10-bit framebuffer when the hardware supports it, enabling full 10-bit HDR video output. Users with
  Direct-To-Plane enabled continue to get 8-bit with full alpha, preserving correct GUI transparency.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
