### PR TITLE
GUIDialogProgress: skip animation wait loop when called from non-main thread

### DIFF
--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -12,6 +12,7 @@
 #include "guilib/GUIProgressControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
+#include "messaging/ApplicationMessenger.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "threads/Event.h"
@@ -77,6 +78,11 @@ void CGUIDialogProgress::Open(const std::string &param /* = "" */)
   }
 
   CGUIDialog::Open(false, param);
+
+  // Only wait for animation on main thread - background threads cannot drive
+  // the render loop, so spinning here would be a busy-wait at 100% CPU
+  if (!CServiceBroker::GetAppMessenger()->IsProcessThread())
+    return;
 
   while (m_active && IsAnimating(ANIM_TYPE_WINDOW_OPEN))
   {


### PR DESCRIPTION

## Description
fix for issue #27733 _[GUIDialogCache] Thread stuck at 100% CPU usage (current master)_

- `CGUIDialogCache` runs on a background thread and calls `OpenDialog()` -> `CGUIDialogProgress::Open()`
- `Open()` has a while loop that spins calling `Progress()` -> `ProcessRenderLoop()` waiting for the open animation to finish
- `ProcessRenderLoop()` is a no-op on non-main threads (the `IsProcessThread()` guard skips all real work), but it still calls - `CServiceBroker::GetAppMessenger()` which returns a shared_ptr by value, causing millions of atomic ref-count increment/decrement operations per second resulting on 100% CPU
- Fix: Return early from `Open()` when not on the main thread. The background thread cannot drive the render loop anyway, so the animation wait loop is pointless there.

trace during spin

```
(gdb) bt
#0  0x000055e3af6bdc6d in __gnu_cxx::__exchange_and_add_dispatch (__mem=0x55e3c5f1e008, __val=-1) at /usr/include/c++/14/ext/atomicity.h:101
#1  std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x55e3c5f1e000) at /usr/include/c++/14/bits/shared_ptr_base.h:350
#2  0x000055e3afd7a9d5 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x7fb5713a1788, __in_chrg=<optimized out>) at /usr/include/c++/14/bits/shared_ptr_base.h:1069
#3  std::__shared_ptr<KODI::MESSAGING::CApplicationMessenger, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0x7fb5713a1780, __in_chrg=<optimized out>) at /usr/include/c++/14/bits/shared_ptr_base.h:1525
#4  std::shared_ptr<KODI::MESSAGING::CApplicationMessenger>::~shared_ptr (this=0x7fb5713a1780, __in_chrg=<optimized out>) at /usr/include/c++/14/bits/shared_ptr.h:175
#5  CGUIWindowManager::ProcessRenderLoop (this=0x7fb5d80128a0, renderOnly=renderOnly@entry=false) at /tmp/xbmc/xbmc/guilib/GUIWindowManager.cpp:1514
#6  0x000055e3afd0910c in CGUIDialog::ProcessRenderLoop (this=this@entry=0x55e3c78e5e90, renderOnly=renderOnly@entry=false) at /tmp/xbmc/xbmc/guilib/GUIDialog.cpp:239
#7  0x000055e3afdf503a in CGUIDialogProgress::Progress (this=0x55e3c78e5e90) at /tmp/xbmc/xbmc/dialogs/GUIDialogProgress.cpp:93
#8  CGUIDialogProgress::Progress (this=0x55e3c78e5e90) at /tmp/xbmc/xbmc/dialogs/GUIDialogProgress.cpp:89
#9  CGUIDialogProgress::Open (this=0x55e3c78e5e90, param="") at /tmp/xbmc/xbmc/dialogs/GUIDialogProgress.cpp:79
#10 0x000055e3afdbcbf2 in CGUIDialogCache::OpenDialog (this=this@entry=0x7fb584089020) at /usr/include/c++/14/bits/basic_string.tcc:242
#11 0x000055e3afdbce24 in CGUIDialogCache::Process (this=0x7fb584089020) at /tmp/xbmc/xbmc/dialogs/GUIDialogCache.cpp:148
#12 0x000055e3afc179d5 in CThread::Action (this=0x7fb584089020) at /tmp/xbmc/xbmc/threads/Thread.cpp:282
#13 0x000055e3afc1886c in operator() (__closure=<optimized out>, pThread=0x7fb584089020, promise=...) at /tmp/xbmc/xbmc/threads/Thread.cpp:151
#14 std::__invoke_impl<void, CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> > (__f=<optimized out>) at /usr/include/c++/14/bits/invoke.h:61
#15 std::__invoke<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> > (__fn=<optimized out>) at /usr/include/c++/14/bits/invoke.h:96
#16 std::thread::_Invoker<std::tuple<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> > >::_M_invoke<0, 1, 2> (this=<optimized out>) at /usr/include/c++/14/bits/std_thread.h:301
#17 std::thread::_Invoker<std::tuple<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> > >::operator() (this=<optimized out>) at /usr/include/c++/14/bits/std_thread.h:308
#18 std::thread::_State_impl<std::thread::_Invoker<std::tuple<CThread::Create(bool)::<lambda(CThread*, std::promise<bool>)>, CThread*, std::promise<bool> > > >::_M_run(void) (this=<optimized out>) at /usr/include/c++/14/bits/std_thread.h:253
#19 0x00007fb5fa8fa224 in ??? () at /lib/x86_64-linux-gnu/libstdc++.so.6
#20 0x00007fb5fa689b7b in ??? () at /lib/x86_64-linux-gnu/libc.so.6
#21 0x00007fb5fa7075f0 in clone () at /lib/x86_64-linux-gnu/libc.so.6
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Running for a few weeks on my media center.  without issue. Without the patch 100% CPU usage gets triggered within hours. 

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->


## Screenshots (if appropriate):



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
