### PR TITLE
GBM/GLES: FBO-based GUI compositing for HDR passthrough

### DIFF
--- a/system/shaders/GLES/2.0/gles_gui_composite.frag
+++ b/system/shaders/GLES/2.0/gles_gui_composite.frag
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#version 100
+
+precision mediump float;
+varying vec2 v_tex;
+uniform sampler2D u_samp;
+uniform float u_sdrPeak; // SDR peak in normalized PQ (e.g. 100/10000 = 0.01)
+
+// ST2084 (PQ) constants
+const float ST2084_m1 = 0.1593017578125;   // 2610/16384
+const float ST2084_m2 = 78.84375;           // 2523/4096 * 128
+const float ST2084_c1 = 0.8359375;          // 3424/4096
+const float ST2084_c2 = 18.8515625;         // 2413/4096 * 32
+const float ST2084_c3 = 18.6875;            // 2392/4096 * 32
+
+// BT.709 -> BT.2020 color space conversion matrix (applied in linear light)
+const mat3 bt709_to_bt2020 = mat3(
+  0.6274,  0.0691,  0.0164,
+  0.3293,  0.9195,  0.0880,
+  0.0433,  0.0114,  0.8956
+);
+
+vec3 forwardPQ(vec3 L)
+{
+  vec3 Lm1 = pow(L, vec3(ST2084_m1));
+  return pow((ST2084_c1 + ST2084_c2 * Lm1) / (1.0 + ST2084_c3 * Lm1), vec3(ST2084_m2));
+}
+
+void main()
+{
+  vec4 gui = texture2D(u_samp, v_tex);
+
+  // sRGB -> linear (approximate)
+  vec3 linear = pow(gui.rgb, vec3(2.2));
+
+  // BT.709 -> BT.2020 gamut mapping
+  linear = bt709_to_bt2020 * linear;
+
+  // scale to PQ luminance range: SDR content at u_sdrPeak of 10000 nits
+  linear *= u_sdrPeak;
+
+  // linear -> PQ
+  vec3 pq = forwardPQ(linear);
+
+  gl_FragColor = vec4(pq, gui.a);
+}

--- a/system/shaders/GLES/2.0/gles_gui_composite.frag
+++ b/system/shaders/GLES/2.0/gles_gui_composite.frag
@@ -11,7 +11,7 @@
 precision mediump float;
 varying vec2 v_tex;
 uniform sampler2D u_samp;       // GUI FBO texture (sRGB, rendered by GUI shaders)
-uniform sampler2D u_lutDegamma; // sRGB -> linear LUT (1024 entries, pow 2.2)
+uniform sampler2D u_lutDegamma; // sRGB -> linear LUT (IEC 61966-2-1)
 uniform sampler2D u_lutTF;      // linear -> PQ LUT (1024 entries, sdrPeak baked in)
 uniform float u_ootfGamma;      // HLG: OOTF gamma (1.2 for BT.2100 1000-nit ref)
                                 // PQ: 0.0 (use LUT path instead)
@@ -33,7 +33,7 @@ void main()
   if (gui.a == 0.0)
     discard;
 
-  // sRGB -> linear via LUT (replaces pow(gui.rgb, 2.2))
+  // sRGB -> linear via LUT (IEC 61966-2-1 EOTF, replaces inline pow)
   vec3 linear = vec3(
     texture2D(u_lutDegamma, vec2(gui.r, 0.5)).r,
     texture2D(u_lutDegamma, vec2(gui.g, 0.5)).r,

--- a/system/shaders/GLES/2.0/gles_gui_composite.frag
+++ b/system/shaders/GLES/2.0/gles_gui_composite.frag
@@ -78,5 +78,12 @@ void main()
     );
   }
 
+  // Limited-range encoding at the BO write boundary. Canonical normalized
+  // ratios (bit-depth-agnostic in float space; BO write quantizes to the
+  // active surface bit depth).
+#ifdef KODI_LIMITED_RANGE
+  result = result * ((235.0 - 16.0) / 255.0) + (16.0 / 255.0);
+#endif
+
   gl_FragColor = vec4(result, gui.a);
 }

--- a/system/shaders/GLES/2.0/gles_gui_composite.frag
+++ b/system/shaders/GLES/2.0/gles_gui_composite.frag
@@ -27,6 +27,12 @@ void main()
 {
   vec4 gui = texture2D(u_samp, v_tex);
 
+  // Skip pixels the GUI never wrote to. Blend unit would still preserve video
+  // bit-exactly via DST*(1-0)+garbage*0=DST, but discard makes it structural
+  // and avoids the tone-map math, BO read and BO write for those pixels.
+  if (gui.a == 0.0)
+    discard;
+
   // sRGB -> linear via LUT (replaces pow(gui.rgb, 2.2))
   vec3 linear = vec3(
     texture2D(u_lutDegamma, vec2(gui.r, 0.5)).r,

--- a/system/shaders/GLES/2.0/gles_gui_composite.frag
+++ b/system/shaders/GLES/2.0/gles_gui_composite.frag
@@ -10,15 +10,11 @@
 
 precision mediump float;
 varying vec2 v_tex;
-uniform sampler2D u_samp;
-uniform float u_sdrPeak; // SDR peak in normalized PQ (e.g. 100/10000 = 0.01)
-
-// ST2084 (PQ) constants
-const float ST2084_m1 = 0.1593017578125;   // 2610/16384
-const float ST2084_m2 = 78.84375;           // 2523/4096 * 128
-const float ST2084_c1 = 0.8359375;          // 3424/4096
-const float ST2084_c2 = 18.8515625;         // 2413/4096 * 32
-const float ST2084_c3 = 18.6875;            // 2392/4096 * 32
+uniform sampler2D u_samp;       // GUI FBO texture (sRGB, rendered by GUI shaders)
+uniform sampler2D u_lutDegamma; // sRGB -> linear LUT (1024 entries, pow 2.2)
+uniform sampler2D u_lutTF;      // linear -> PQ LUT (1024 entries, sdrPeak baked in)
+uniform float u_ootfGamma;      // HLG: OOTF gamma (1.2 for BT.2100 1000-nit ref)
+                                // PQ: 0.0 (use LUT path instead)
 
 // BT.709 -> BT.2020 color space conversion matrix (applied in linear light)
 const mat3 bt709_to_bt2020 = mat3(
@@ -27,27 +23,54 @@ const mat3 bt709_to_bt2020 = mat3(
   0.0433,  0.0114,  0.8956
 );
 
-vec3 forwardPQ(vec3 L)
-{
-  vec3 Lm1 = pow(L, vec3(ST2084_m1));
-  return pow((ST2084_c1 + ST2084_c2 * Lm1) / (1.0 + ST2084_c3 * Lm1), vec3(ST2084_m2));
-}
-
 void main()
 {
   vec4 gui = texture2D(u_samp, v_tex);
 
-  // sRGB -> linear (approximate)
-  vec3 linear = pow(gui.rgb, vec3(2.2));
+  // sRGB -> linear via LUT (replaces pow(gui.rgb, 2.2))
+  vec3 linear = vec3(
+    texture2D(u_lutDegamma, vec2(gui.r, 0.5)).r,
+    texture2D(u_lutDegamma, vec2(gui.g, 0.5)).r,
+    texture2D(u_lutDegamma, vec2(gui.b, 0.5)).r
+  );
 
   // BT.709 -> BT.2020 gamut mapping
   linear = bt709_to_bt2020 * linear;
 
-  // scale to PQ luminance range: SDR content at u_sdrPeak of 10000 nits
-  linear *= u_sdrPeak;
+  vec3 result;
 
-  // linear -> PQ
-  vec3 pq = forwardPQ(linear);
+  if (u_ootfGamma > 0.0)
+  {
+    // HLG path: direct computation following libplacebo pl_color_delinearize.
+    // BT.2100 reference display: 1000 nits. GUI white (linear 1.0) = 203 nits
+    // (BT.2408 reference white) should map to 75% HLG signal.
+    //
+    // Step 1: normalize to display-peak-relative units
+    // Step 2: inverse OOTF with 12x prescale for OETF input domain
+    // Step 3: HLG OETF (ARIB STD-B67) piecewise: sqrt for <=1, log for >1
+    const float csp_max = 1000.0 / 203.0; // display peak in ref-white units
+    const float HLG_A = 0.17883277;
+    const float HLG_B = 0.28466892;
+    const float HLG_C = 0.55991073;
 
-  gl_FragColor = vec4(pq, gui.a);
+    vec3 scene = linear / csp_max;
+    float Y = dot(scene, vec3(0.2627, 0.6780, 0.0593));
+    scene *= 12.0 * pow(max(1e-6, Y), (1.0 - u_ootfGamma) / u_ootfGamma);
+
+    // HLG OETF piecewise (threshold at scene-light 1.0)
+    vec3 lo = vec3(0.5) * sqrt(max(scene, vec3(0.0)));
+    vec3 hi = vec3(HLG_A) * log(max(scene - vec3(HLG_B), vec3(1e-6))) + vec3(HLG_C);
+    result = mix(lo, hi, step(vec3(1.0), scene));
+  }
+  else
+  {
+    // PQ path: LUT lookup (sdrPeak baked into LUT range)
+    result = vec3(
+      texture2D(u_lutTF, vec2(linear.r, 0.5)).r,
+      texture2D(u_lutTF, vec2(linear.g, 0.5)).r,
+      texture2D(u_lutTF, vec2(linear.b, 0.5)).r
+    );
+  }
+
+  gl_FragColor = vec4(result, gui.a);
 }

--- a/system/shaders/GLES/2.0/gles_gui_composite.vert
+++ b/system/shaders/GLES/2.0/gles_gui_composite.vert
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#version 100
+
+attribute vec2 a_pos;
+attribute vec2 a_tex;
+varying vec2 v_tex;
+uniform mat4 u_proj;
+
+void main()
+{
+  gl_Position = u_proj * vec4(a_pos, 0.0, 1.0);
+  v_tex = a_tex;
+}

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -851,6 +851,8 @@ void CApplication::Render()
     return;
 
   // render gui layer
+  bool compositing = CServiceBroker::GetWinSystem()->BeginGuiComposite();
+
   if (appPower->GetRenderGUI() && !m_skipGuiRender)
   {
     if (CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() != RenderStereoMode::OFF)
@@ -875,8 +877,14 @@ void CApplication::Render()
     m_lastRenderTime = std::chrono::steady_clock::now();
   }
 
+  if (compositing)
+    CServiceBroker::GetWinSystem()->EndGuiComposite();
+
   // render video layer
   CServiceBroker::GetGUI()->GetWindowManager().RenderEx();
+
+  if (compositing)
+    CServiceBroker::GetWinSystem()->CompositeGui();
 
   CServiceBroker::GetRenderSystem()->EndRender();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -62,6 +62,7 @@ public:
   virtual void ReleaseBuffer(int idx) { }
   virtual bool NeedBuffer(int idx) { return false; }
   virtual bool IsGuiLayer() { return true; }
+  virtual bool HasVideoPlane() { return !IsGuiLayer(); }
   // Render info, can be called before configure
   virtual CRenderInfo GetRenderInfo() { return CRenderInfo(); }
   virtual void Update() = 0;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.cpp
@@ -62,6 +62,10 @@ void CFrameBufferObject::Cleanup()
   if (m_texid)
     glDeleteTextures(1, &m_texid);
 
+  if (m_depthBuffer)
+    glDeleteRenderbuffers(1, &m_depthBuffer);
+
+  m_depthBuffer = 0;
   m_texid = 0;
   m_fbo = 0;
   m_valid = false;
@@ -99,6 +103,33 @@ bool CFrameBufferObject::CreateAndBindToTexture(GLenum target, int width, int he
     return false;
   }
   m_bound = true;
+  return true;
+}
+
+bool CFrameBufferObject::AttachDepthBuffer(int width, int height)
+{
+  if (!IsValid() || !IsBound())
+    return false;
+
+  if (m_depthBuffer)
+    glDeleteRenderbuffers(1, &m_depthBuffer);
+
+  glGenRenderbuffers(1, &m_depthBuffer);
+  glBindRenderbuffer(GL_RENDERBUFFER, m_depthBuffer);
+  glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT16, width, height);
+  glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthBuffer);
+  const GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+  if (status != GL_FRAMEBUFFER_COMPLETE)
+  {
+    glDeleteRenderbuffers(1, &m_depthBuffer);
+    m_depthBuffer = 0;
+    return false;
+  }
   return true;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/FrameBufferObject.h
@@ -57,6 +57,10 @@ public:
   bool CreateAndBindToTexture(GLenum target, int width, int height, GLenum format, GLenum type=GL_UNSIGNED_BYTE,
                               GLenum filter=GL_LINEAR, GLenum clampmode=GL_CLAMP_TO_EDGE);
 
+  // Attach a depth renderbuffer. Required when rendering into the FBO with
+  // front-to-back (depth-tested) opaque passes enabled.
+  bool AttachDepthBuffer(int width, int height);
+
   // Return the internally created texture ID
   GLuint Texture() const { return m_texid; }
 
@@ -71,6 +75,7 @@ private:
   bool   m_bound;
   bool   m_supported;
   GLuint m_texid = 0;
+  GLuint m_depthBuffer = 0;
 };
 
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -163,7 +163,7 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
   }
 
   m_hdrFboActive =
-      m_passthroughHDR && CServiceBroker::GetWinSystem()->SetGuiCompositing(m_passthroughHDR);
+      m_passthroughHDR && CServiceBroker::GetWinSystem()->SetGuiCompositing(picture.color_transfer);
   if (m_passthroughHDR && !m_hdrFboActive)
     CLog::Log(LOGWARNING, "LinuxRendererGLES::Configure: HDR passthrough active but GUI "
                           "compositing not supported by windowing system");

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -162,6 +162,12 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
               m_passthroughHDR ? "on" : "off");
   }
 
+  m_hdrFboActive =
+      m_passthroughHDR && CServiceBroker::GetWinSystem()->SetGuiCompositing(m_passthroughHDR);
+  if (m_passthroughHDR && !m_hdrFboActive)
+    CLog::Log(LOGWARNING, "LinuxRendererGLES::Configure: HDR passthrough active but GUI "
+                          "compositing not supported by windowing system");
+
   return true;
 }
 
@@ -580,14 +586,50 @@ void CLinuxRendererGLES::RenderUpdate(int index, int index2, bool clear, unsigne
 void CLinuxRendererGLES::RenderUpdateVideo(bool clear, unsigned int flags, unsigned int alpha)
 {
   if (!m_bConfigured)
-  {
     return;
-  }
 
   if (IsGuiLayer())
-  {
     return;
+
+  int index = m_iYV12RenderBuffer;
+  CPictureBuffer& buf = m_buffers[index];
+
+  if (!buf.fields[FIELD_FULL][0].id)
+    return;
+
+  ManageRenderArea();
+
+  if (clear)
+  {
+    if (alpha == 255)
+      DrawBlackBars();
+    else
+      ClearBackBuffer();
   }
+
+  if (alpha < 255)
+  {
+    glEnable(GL_BLEND);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    if (m_pYUVProgShader)
+      m_pYUVProgShader->SetAlpha(alpha / 255.0f);
+    if (m_pYUVBobShader)
+      m_pYUVBobShader->SetAlpha(alpha / 255.0f);
+  }
+  else
+  {
+    glDisable(GL_BLEND);
+    if (m_pYUVProgShader)
+      m_pYUVProgShader->SetAlpha(1.0f);
+    if (m_pYUVBobShader)
+      m_pYUVBobShader->SetAlpha(1.0f);
+  }
+
+  if (!Render(flags, index) && clear)
+    ClearBackBuffer();
+
+  VerifyGLState();
+  glEnable(GL_BLEND);
 }
 
 void CLinuxRendererGLES::UpdateVideoFilter()
@@ -898,6 +940,8 @@ void CLinuxRendererGLES::UnInit()
 
   if (m_bConfigured)
   {
+    m_hdrFboActive = false;
+    CServiceBroker::GetWinSystem()->SetGuiCompositing(false);
     CServiceBroker::GetWinSystem()->SetHDR(nullptr);
     m_passthroughHDR = false;
     CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
@@ -1927,7 +1971,7 @@ CRenderInfo CLinuxRendererGLES::GetRenderInfo()
 
 bool CLinuxRendererGLES::IsGuiLayer()
 {
-  return true;
+  return !m_hdrFboActive;
 }
 
 CRenderCapture* CLinuxRendererGLES::GetRenderCapture()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -73,6 +73,7 @@ public:
   bool Flush(bool saveBuffers) override;
   void SetBufferSize(int numBuffers) override { m_NumYV12Buffers = numBuffers; }
   bool IsGuiLayer() override;
+  bool HasVideoPlane() override { return false; }
   void ReleaseBuffer(int idx) override;
   void RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
   void Update() override;
@@ -217,6 +218,10 @@ protected:
   // clear colour for "black" bars
   float m_clearColour{0.0f};
   CRect m_lastViewRect;
+
+  // HDR FBO compositing: when active, IsGuiLayer() returns false so
+  // video renders separately from GUI via RenderUpdateVideo()
+  bool m_hdrFboActive{false};
 
 private:
   void ClearBackBuffer();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -215,7 +215,7 @@ bool CRenderManager::Configure()
 
     m_playerPort->UpdateRenderInfo(info);
     m_playerPort->UpdateGuiRender(true);
-    m_playerPort->UpdateVideoRender(!m_pRenderer->IsGuiLayer());
+    m_playerPort->UpdateVideoRender(m_pRenderer->HasVideoPlane());
 
     m_queued.clear();
     m_discard.clear();
@@ -350,7 +350,7 @@ void CRenderManager::FrameMove()
     m_bRenderGUI = true;
   }
 
-  m_playerPort->UpdateGuiRender(IsGuiLayer() || firstFrame);
+  m_playerPort->UpdateGuiRender(IsGuiLayer() || !m_pRenderer->HasVideoPlane() || firstFrame);
 
   ManageCaptures();
 }
@@ -816,20 +816,6 @@ bool CRenderManager::IsGuiLayer()
       return true;
 
     if (m_renderDebug && m_debugTimer.IsTimePast())
-      return true;
-  }
-  return false;
-}
-
-bool CRenderManager::IsVideoLayer()
-{
-  {
-    std::unique_lock lock(m_statelock);
-
-    if (!m_pRenderer)
-      return false;
-
-    if (!m_pRenderer->IsGuiLayer())
       return true;
   }
   return false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -65,7 +65,7 @@ public:
   void FrameMove();
   void FrameWait(std::chrono::milliseconds duration);
   void Render(bool clear, DWORD flags = 0, DWORD alpha = 255, bool gui = true);
-  bool IsVideoLayer();
+
   RESOLUTION GetResolution();
   void UpdateResolution();
   void TriggerUpdateResolution(float fps, int width, int height, std::string &stereomode);

--- a/xbmc/guilib/GUIFontTTFGLES.cpp
+++ b/xbmc/guilib/GUIFontTTFGLES.cpp
@@ -126,8 +126,19 @@ bool CGUIFontTTFGLES::FirstBegin()
     m_textureStatus = TEXTURE_READY;
   }
 
-  // Turn Blending On
-  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
+  // Alpha blending assumes linear light. SDR (direct-to-backbuffer or
+  // direct-to-plane) blends in sRGB -- "wrong but consistent", the aesthetic
+  // skins are designed against. HDR FBO compositing draws GUI into an sRGB
+  // FBO that is color-transformed to PQ/HLG before compositing with video
+  // in that non-linear space -- two stages of non-linear blending. The
+  // compensated factors below trade accumulator coverage for a squared-
+  // alpha blend that approximately matches SDR perceived translucency. It
+  // is a "close enough" compromise; a mathematically correct fix would
+  // require linear-light compositing (too expensive on typical ARM GPUs).
+  if (CServiceBroker::GetWinSystem()->IsHdrComposite())
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  else
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
   glEnable(GL_BLEND);
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, m_nTexture);

--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -121,7 +121,15 @@ void CGUITextureGLES::Begin(KODI::UTILS::COLOR::Color color)
 
   if (hasAlpha)
   {
-    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
+    // See CGUIFontTTFGLES::FirstBegin for rationale. SDR uses accumulator
+    // coverage alpha; HDR FBO composite uses a compensated squared-alpha
+    // blend because the FBO is color-transformed to PQ/HLG before composite,
+    // and alpha blending in non-linear space is mathematically wrong.
+    if (CServiceBroker::GetWinSystem()->IsHdrComposite())
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA,
+                          GL_ONE_MINUS_SRC_ALPHA);
+    else
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
     glEnable( GL_BLEND );
   }
   else

--- a/xbmc/rendering/gles/CMakeLists.txt
+++ b/xbmc/rendering/gles/CMakeLists.txt
@@ -1,11 +1,13 @@
 if(TARGET ${APP_NAME_LC}::OpenGLES)
   set(SOURCES RenderSystemGLES.cpp
               ScreenshotSurfaceGLES.cpp
-              GLESShader.cpp)
+              GLESShader.cpp
+              GuiCompositeShaderGLES.cpp)
 
   set(HEADERS RenderSystemGLES.h
               ScreenshotSurfaceGLES.h
-              GLESShader.h)
+              GLESShader.h
+              GuiCompositeShaderGLES.h)
 
   core_add_library(rendering_gles)
 endif()

--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
@@ -10,10 +10,42 @@
 
 #include "utils/log.h"
 
+extern "C"
+{
+#include <libavutil/pixfmt.h>
+}
+
+#include <cmath>
+
+namespace
+{
+// ST2084 (PQ) constants
+constexpr float ST2084_m1 = 0.1593017578125f; // 2610/16384
+constexpr float ST2084_m2 = 78.84375f; // 2523/4096 * 128
+constexpr float ST2084_c1 = 0.8359375f; // 3424/4096
+constexpr float ST2084_c2 = 18.8515625f; // 2413/4096 * 32
+constexpr float ST2084_c3 = 18.6875f; // 2392/4096 * 32
+
+float ForwardPQ(float L)
+{
+  float Lm1 = std::pow(L, ST2084_m1);
+  return std::pow((ST2084_c1 + ST2084_c2 * Lm1) / (1.0f + ST2084_c3 * Lm1), ST2084_m2);
+}
+
+} // namespace
+
 CGuiCompositeShaderGLES::CGuiCompositeShaderGLES()
 {
   VertexShader()->LoadSource("gles_gui_composite.vert");
   PixelShader()->LoadSource("gles_gui_composite.frag");
+}
+
+CGuiCompositeShaderGLES::~CGuiCompositeShaderGLES()
+{
+  if (m_lutDegammaTexId)
+    glDeleteTextures(1, &m_lutDegammaTexId);
+  if (m_lutTFTexId)
+    glDeleteTextures(1, &m_lutTFTexId);
 }
 
 void CGuiCompositeShaderGLES::OnCompiledAndLinked()
@@ -21,11 +53,14 @@ void CGuiCompositeShaderGLES::OnCompiledAndLinked()
   m_hPos = glGetAttribLocation(ProgramHandle(), "a_pos");
   m_hTex = glGetAttribLocation(ProgramHandle(), "a_tex");
   m_hSamp = glGetUniformLocation(ProgramHandle(), "u_samp");
+  m_hLutDegamma = glGetUniformLocation(ProgramHandle(), "u_lutDegamma");
+  m_hLutTF = glGetUniformLocation(ProgramHandle(), "u_lutTF");
   m_hProj = glGetUniformLocation(ProgramHandle(), "u_proj");
-  m_hSdrPeak = glGetUniformLocation(ProgramHandle(), "u_sdrPeak");
-
+  m_hOotfGamma = glGetUniformLocation(ProgramHandle(), "u_ootfGamma");
   glUseProgram(ProgramHandle());
   glUniform1i(m_hSamp, 0);
+  glUniform1i(m_hLutDegamma, 1);
+  glUniform1i(m_hLutTF, 2);
   glUseProgram(0);
 }
 
@@ -34,6 +69,96 @@ bool CGuiCompositeShaderGLES::OnEnabled()
   if (m_proj)
     glUniformMatrix4fv(m_hProj, 1, GL_FALSE, m_proj);
 
-  glUniform1f(m_hSdrPeak, m_sdrPeak);
+  glUniform1f(m_hOotfGamma, m_ootfGamma);
+
+  glActiveTexture(GL_TEXTURE1);
+  glBindTexture(GL_TEXTURE_2D, m_lutDegammaTexId);
+  glActiveTexture(GL_TEXTURE2);
+  glBindTexture(GL_TEXTURE_2D, m_lutTFTexId);
+  glActiveTexture(GL_TEXTURE0);
+
+  return true;
+}
+
+GLuint CGuiCompositeShaderGLES::CreateLUTTexture(const std::vector<float>& data)
+{
+  GLuint texId;
+  glGenTextures(1, &texId);
+  glBindTexture(GL_TEXTURE_2D, texId);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, data.size(), 1, 0, GL_LUMINANCE, GL_FLOAT,
+               data.data());
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  return texId;
+}
+
+std::vector<float> CGuiCompositeShaderGLES::GenerateDegammaLUT()
+{
+  std::vector<float> lut(LUT_SIZE);
+  for (int i = 0; i < LUT_SIZE; i++)
+  {
+    float x = static_cast<float>(i) / (LUT_SIZE - 1);
+    lut[i] = std::pow(x, 2.2f);
+  }
+  return lut;
+}
+
+std::vector<float> CGuiCompositeShaderGLES::GeneratePQLUT(float sdrPeak)
+{
+  // PQ is display-referred (absolute luminance). sdrPeak is in PQ-normalized
+  // units (nits / 10000), e.g. 203 nits = 0.0203. The LUT maps the full [0,1]
+  // texture coordinate range to ForwardPQ([0, sdrPeak]), giving full LUT
+  // resolution across the actual SDR luminance range.
+  std::vector<float> lut(LUT_SIZE);
+  for (int i = 0; i < LUT_SIZE; i++)
+  {
+    float L = static_cast<float>(i) / (LUT_SIZE - 1) * sdrPeak;
+    lut[i] = ForwardPQ(L);
+  }
+  return lut;
+}
+
+bool CGuiCompositeShaderGLES::CreateLUTs(int colorTransfer)
+{
+  if (m_lutDegammaTexId)
+    glDeleteTextures(1, &m_lutDegammaTexId);
+  if (m_lutTFTexId)
+    glDeleteTextures(1, &m_lutTFTexId);
+
+  m_lutDegammaTexId = CreateLUTTexture(GenerateDegammaLUT());
+  if (!m_lutDegammaTexId)
+  {
+    CLog::Log(LOGERROR, "CGuiCompositeShaderGLES::CreateLUTs - failed to create degamma LUT");
+    return false;
+  }
+
+  if (colorTransfer == AVCOL_TRC_SMPTE2084)
+  {
+    m_lutTFTexId = CreateLUTTexture(GeneratePQLUT(m_sdrPeak));
+    if (!m_lutTFTexId)
+    {
+      CLog::Log(LOGERROR, "CGuiCompositeShaderGLES::CreateLUTs - failed to create PQ LUT");
+      return false;
+    }
+    m_ootfGamma = 0.0f;
+    CLog::Log(LOGDEBUG, "CGuiCompositeShaderGLES::CreateLUTs - created PQ LUT ({} entries)",
+              LUT_SIZE);
+  }
+  else if (colorTransfer == AVCOL_TRC_ARIB_STD_B67)
+  {
+    // HLG: no TF LUT needed, shader computes OETF + inverse OOTF directly.
+    // BT.2100: gamma = 1.2 + 0.42 * log10(Lw/1000). For 1000-nit ref: 1.2.
+    m_ootfGamma = 1.2f;
+    CLog::Log(LOGDEBUG, "CGuiCompositeShaderGLES::CreateLUTs - HLG mode (gamma {})", m_ootfGamma);
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "CGuiCompositeShaderGLES::CreateLUTs - unsupported transfer function {}",
+              colorTransfer);
+    return false;
+  }
   return true;
 }

--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GuiCompositeShaderGLES.h"
+
+#include "utils/log.h"
+
+CGuiCompositeShaderGLES::CGuiCompositeShaderGLES()
+{
+  VertexShader()->LoadSource("gles_gui_composite.vert");
+  PixelShader()->LoadSource("gles_gui_composite.frag");
+}
+
+void CGuiCompositeShaderGLES::OnCompiledAndLinked()
+{
+  m_hPos = glGetAttribLocation(ProgramHandle(), "a_pos");
+  m_hTex = glGetAttribLocation(ProgramHandle(), "a_tex");
+  m_hSamp = glGetUniformLocation(ProgramHandle(), "u_samp");
+  m_hProj = glGetUniformLocation(ProgramHandle(), "u_proj");
+  m_hSdrPeak = glGetUniformLocation(ProgramHandle(), "u_sdrPeak");
+
+  glUseProgram(ProgramHandle());
+  glUniform1i(m_hSamp, 0);
+  glUseProgram(0);
+}
+
+bool CGuiCompositeShaderGLES::OnEnabled()
+{
+  if (m_proj)
+    glUniformMatrix4fv(m_hProj, 1, GL_FALSE, m_proj);
+
+  glUniform1f(m_hSdrPeak, m_sdrPeak);
+  return true;
+}

--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
@@ -40,10 +40,10 @@ float SRGBToLinear(float v)
 
 } // namespace
 
-CGuiCompositeShaderGLES::CGuiCompositeShaderGLES()
+CGuiCompositeShaderGLES::CGuiCompositeShaderGLES(const std::string& prefix)
 {
-  VertexShader()->LoadSource("gles_gui_composite.vert");
-  PixelShader()->LoadSource("gles_gui_composite.frag");
+  VertexShader()->LoadSource("gles_gui_composite.vert", prefix);
+  PixelShader()->LoadSource("gles_gui_composite.frag", prefix);
 }
 
 CGuiCompositeShaderGLES::~CGuiCompositeShaderGLES()

--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
@@ -32,6 +32,12 @@ float ForwardPQ(float L)
   return std::pow((ST2084_c1 + ST2084_c2 * Lm1) / (1.0f + ST2084_c3 * Lm1), ST2084_m2);
 }
 
+// IEC 61966-2-1 sRGB EOTF.
+float SRGBToLinear(float v)
+{
+  return v <= 0.04045f ? v / 12.92f : std::pow((v + 0.055f) / 1.055f, 2.4f);
+}
+
 } // namespace
 
 CGuiCompositeShaderGLES::CGuiCompositeShaderGLES()
@@ -138,7 +144,7 @@ std::vector<float> CGuiCompositeShaderGLES::GenerateDegammaLUT()
   for (int i = 0; i < LUT_SIZE; i++)
   {
     float x = static_cast<float>(i) / (LUT_SIZE - 1);
-    lut[i] = std::pow(x, 2.2f);
+    lut[i] = SRGBToLinear(x);
   }
   return lut;
 }

--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
+++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.cpp
@@ -82,16 +82,53 @@ bool CGuiCompositeShaderGLES::OnEnabled()
 
 GLuint CGuiCompositeShaderGLES::CreateLUTTexture(const std::vector<float>& data)
 {
+  while (glGetError() != GL_NO_ERROR)
+  {
+  }
+
   GLuint texId;
   glGenTextures(1, &texId);
   glBindTexture(GL_TEXTURE_2D, texId);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, data.size(), 1, 0, GL_LUMINANCE, GL_FLOAT,
-               data.data());
+
+  // Prefer GL_R16F (GLES 3.0 core) over GL_LUMINANCE + GL_FLOAT (GLES 2.0).
+  // The GLES 3.0 spec tightens format validation for unsized internal formats,
+  // and some drivers (e.g. V3D on RPi5) silently reject GL_LUMINANCE + GL_FLOAT
+  // despite advertising OES_texture_float. GL_R16F avoids this by using a sized
+  // format with well-defined behavior. Half-float precision is sufficient for
+  // a 1024-entry LUT.
+  bool uploaded = false;
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_R16F, data.size(), 1, 0, GL_RED, GL_FLOAT, data.data());
+  if (glGetError() == GL_NO_ERROR)
+  {
+    uploaded = true;
+  }
+  else
+  {
+    while (glGetError() != GL_NO_ERROR)
+    {
+    }
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, data.size(), 1, 0, GL_LUMINANCE, GL_FLOAT,
+                 data.data());
+    if (glGetError() == GL_NO_ERROR)
+      uploaded = true;
+    else
+      CLog::Log(LOGERROR,
+                "CGuiCompositeShaderGLES::CreateLUTTexture - failed to create {} entry "
+                "LUT texture (GL_R16F and GL_LUMINANCE+GL_FLOAT both failed)",
+                data.size());
+  }
+
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glBindTexture(GL_TEXTURE_2D, 0);
+
+  if (!uploaded)
+  {
+    glDeleteTextures(1, &texId);
+    return 0;
+  }
   return texId;
 }
 

--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.h
+++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.h
@@ -10,12 +10,13 @@
 
 #include "guilib/Shader.h"
 
+#include <string>
 #include <vector>
 
 class CGuiCompositeShaderGLES : public Shaders::CGLSLShaderProgram
 {
 public:
-  CGuiCompositeShaderGLES();
+  explicit CGuiCompositeShaderGLES(const std::string& prefix);
   ~CGuiCompositeShaderGLES() override;
 
   void SetProjection(const GLfloat* proj) { m_proj = proj; }

--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.h
+++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "guilib/Shader.h"
+
+class CGuiCompositeShaderGLES : public Shaders::CGLSLShaderProgram
+{
+public:
+  CGuiCompositeShaderGLES();
+
+  void SetProjection(const GLfloat* proj) { m_proj = proj; }
+  void SetSdrPeak(float peak) { m_sdrPeak = peak; }
+
+  GLint GetPosLoc() { return m_hPos; }
+  GLint GetTexLoc() { return m_hTex; }
+
+protected:
+  void OnCompiledAndLinked() override;
+  bool OnEnabled() override;
+
+private:
+  const GLfloat* m_proj{nullptr};
+  float m_sdrPeak{100.0f / 10000.0f};
+
+  GLint m_hPos{-1};
+  GLint m_hTex{-1};
+  GLint m_hSamp{-1};
+  GLint m_hProj{-1};
+  GLint m_hSdrPeak{-1};
+};

--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.h
+++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.h
@@ -10,13 +10,17 @@
 
 #include "guilib/Shader.h"
 
+#include <vector>
+
 class CGuiCompositeShaderGLES : public Shaders::CGLSLShaderProgram
 {
 public:
   CGuiCompositeShaderGLES();
+  ~CGuiCompositeShaderGLES() override;
 
   void SetProjection(const GLfloat* proj) { m_proj = proj; }
-  void SetSdrPeak(float peak) { m_sdrPeak = peak; }
+
+  bool CreateLUTs(int colorTransfer);
 
   GLint GetPosLoc() { return m_hPos; }
   GLint GetTexLoc() { return m_hTex; }
@@ -26,12 +30,24 @@ protected:
   bool OnEnabled() override;
 
 private:
+  static constexpr int LUT_SIZE = 1024;
+
+  GLuint CreateLUTTexture(const std::vector<float>& data);
+  static std::vector<float> GenerateDegammaLUT();
+  static std::vector<float> GeneratePQLUT(float sdrPeak);
+
   const GLfloat* m_proj{nullptr};
-  float m_sdrPeak{100.0f / 10000.0f};
+  float m_sdrPeak{203.0f / 10000.0f};
+
+  GLuint m_lutDegammaTexId{0};
+  GLuint m_lutTFTexId{0};
+  float m_ootfGamma{0.0f};
 
   GLint m_hPos{-1};
   GLint m_hTex{-1};
   GLint m_hSamp{-1};
+  GLint m_hLutDegamma{-1};
+  GLint m_hLutTF{-1};
   GLint m_hProj{-1};
-  GLint m_hSdrPeak{-1};
+  GLint m_hOotfGamma{-1};
 };

--- a/xbmc/rendering/gles/GuiCompositeShaderGLES.h
+++ b/xbmc/rendering/gles/GuiCompositeShaderGLES.h
@@ -30,7 +30,8 @@ protected:
   bool OnEnabled() override;
 
 private:
-  static constexpr int LUT_SIZE = 1024;
+  // One entry per RGBA8 input value; increase to match GUI bit depth.
+  static constexpr int LUT_SIZE = 256;
 
   GLuint CreateLUTTexture(const std::vector<float>& data);
   static std::vector<float> GenerateDegammaLUT();

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -176,7 +176,8 @@ bool CRenderSystemGLES::BeginRender()
   if (!m_bRenderCreated)
     return false;
 
-  const bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor();
+  const bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor() &&
+                          !CServiceBroker::GetWinSystem()->IsHdrComposite();
   const bool usePQ = CServiceBroker::GetWinSystem()->GetGfxContext().IsTransferPQ();
 
   if (m_limitedColorRange != useLimited || m_transferPQ != usePQ)
@@ -445,7 +446,8 @@ void CRenderSystemGLES::SetDepthCulling(DepthCulling culling)
 void CRenderSystemGLES::InitialiseShaders()
 {
   std::string defines;
-  m_limitedColorRange = CServiceBroker::GetWinSystem()->UseLimitedColor();
+  m_limitedColorRange = CServiceBroker::GetWinSystem()->UseLimitedColor() &&
+                        !CServiceBroker::GetWinSystem()->IsHdrComposite();
   if (m_limitedColorRange)
   {
     defines += "#define KODI_LIMITED_RANGE 1\n";

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -248,7 +248,8 @@ public:
   virtual bool SupportsVideoSuperResolution() { return false; }
 
   // GUI compositing for HDR: render GUI to FBO, composite with tone mapping
-  virtual bool SetGuiCompositing(bool active) { return false; }
+  // colorTransfer: AVCOL_TRC_SMPTE2084 (PQ) or AVCOL_TRC_ARIB_STD_B67 (HLG), 0 to disable
+  virtual bool SetGuiCompositing(int colorTransfer) { return false; }
   virtual bool BeginGuiComposite() { return false; }
   virtual void EndGuiComposite() {}
   virtual void CompositeGui() {}

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -247,6 +247,12 @@ public:
    */
   virtual bool SupportsVideoSuperResolution() { return false; }
 
+  // GUI compositing for HDR: render GUI to FBO, composite with tone mapping
+  virtual bool SetGuiCompositing(bool active) { return false; }
+  virtual bool BeginGuiComposite() { return false; }
+  virtual void EndGuiComposite() {}
+  virtual void CompositeGui() {}
+
   /*!
    * \brief Gets debug info from video renderer for use in "Debug Info OSD" (Alt + O)
    *

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -254,6 +254,13 @@ public:
   virtual void EndGuiComposite() {}
   virtual void CompositeGui() {}
 
+  // True when GUI is rendered to an FBO that is then color-transformed
+  // (sRGB -> PQ/HLG) and composited against HDR video in that non-linear
+  // space. Alpha blending assumes linear light; blending non-linear values
+  // yields wrong transparency. When true, GUI draws select a compensated
+  // alpha blend (see CGUIFontTTFGLES::FirstBegin).
+  virtual bool IsHdrComposite() const { return false; }
+
   /*!
    * \brief Gets debug info from video renderer for use in "Debug Info OSD" (Alt + O)
    *

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -197,8 +197,9 @@ bool CWinSystemGbmEGLContext::SetVideoOutput(const VideoPicture* videoPicture)
   // backends we additionally rebuild the GBM and EGL output surface
   // to a wider format (e.g. AR24 -> AR30) when the video needs more
   // than 8-bit through the single output plane, then chain to the
-  // base so plane-role tracking sees the new format. The EGL context
-  // survives across the rebuild -- no shader recompile, no modeset.
+  // base so plane-role tracking sees the new format. EGL context survives
+  // across the rebuild, no shader-rebuild. The next flip forces a modeset
+  // when needed (amdgpu), on other drivers it is a fast flip."
   const int bitDepth = videoPicture ? videoPicture->colorBits : 8;
 
   // Pick an EGL config matching the target bit depth, then rebuild
@@ -264,8 +265,9 @@ bool CWinSystemGbmEGLContext::SetVideoOutput(const VideoPicture* videoPicture)
 
     // The chained base reads the active plane's cached format and
     // modifier to decide which DRM plane satisfies the new role.
-    // After a surface rebuild that cache is stale, so refresh it
-    // from the just-locked GBM front buffer before chaining.
+    // After a surface rebuild that cache is stale, so refresh it from
+    // the new GBM front buffer (made available by TrySwapBuffers above)
+    // before chaining.
     if (auto* plane = m_DRM->GetGuiPlane() ? m_DRM->GetGuiPlane() : m_DRM->GetVideoPlane())
     {
       if (struct gbm_bo* bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer().Get())
@@ -280,8 +282,9 @@ bool CWinSystemGbmEGLContext::SetVideoOutput(const VideoPicture* videoPicture)
     }
   }
 
-  // Dispatch to FindVideoPlane (videoPicture set) or FindGuiPlane
-  // using the now-current plane format.
+  // Chain to base for the fine-plane part: routes through FindVideoPlane
+  // if videoPicture set or FindGuiPlane if videoPicture was nullptr, using
+  // the now-current cached format/modifier on the active plane.
   return CWinSystemGbm::SetVideoOutput(videoPicture);
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -200,7 +200,10 @@ bool CWinSystemGbmGLESContext::SetGuiCompositing(int colorTransfer)
   {
     if (!m_compositeShader)
     {
-      m_compositeShader = std::make_unique<CGuiCompositeShaderGLES>();
+      std::string defines;
+      if (UseLimitedColor())
+        defines += "#define KODI_LIMITED_RANGE 1\n";
+      m_compositeShader = std::make_unique<CGuiCompositeShaderGLES>(defines);
       if (!m_compositeShader->CompileAndLink())
       {
         CLog::Log(LOGERROR, "CWinSystemGbmGLESContext: failed to compile GUI composite shader");

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -19,6 +19,7 @@
 #include "cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
+#include "rendering/gles/GuiCompositeShaderGLES.h"
 #include "rendering/gles/ScreenshotSurfaceGLES.h"
 #include "utils/BufferObjectFactory.h"
 #include "utils/DMAHeapBufferObject.h"
@@ -184,6 +185,133 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
     for (auto resource : m_resources)
       resource->OnResetDisplay();
   }
+}
+
+bool CWinSystemGbmGLESContext::SetGuiCompositing(bool active)
+{
+  m_guiCompositing = active;
+
+  if (active)
+  {
+    if (!m_compositeShader)
+    {
+      m_compositeShader = std::make_unique<CGuiCompositeShaderGLES>();
+      if (!m_compositeShader->CompileAndLink())
+      {
+        CLog::Log(LOGERROR, "CWinSystemGbmGLESContext: failed to compile GUI composite shader");
+        m_compositeShader.reset();
+        m_guiCompositing = false;
+      }
+    }
+  }
+  else
+  {
+    m_guiFbo.Cleanup();
+    m_guiFboWidth = 0;
+    m_guiFboHeight = 0;
+    m_compositeShader.reset();
+  }
+
+  return m_guiCompositing;
+}
+
+bool CWinSystemGbmGLESContext::BeginGuiComposite()
+{
+  if (!m_guiCompositing)
+    return false;
+
+  int width = m_nWidth;
+  int height = m_nHeight;
+
+  // create or recreate FBO if size changed
+  if (!m_guiFbo.IsValid() || m_guiFboWidth != width || m_guiFboHeight != height)
+  {
+    m_guiFbo.Cleanup();
+
+    if (!m_guiFbo.Initialize())
+    {
+      CLog::Log(LOGERROR, "CWinSystemGbmGLESContext: failed to initialize GUI FBO");
+      return false;
+    }
+
+    if (!m_guiFbo.CreateAndBindToTexture(GL_TEXTURE_2D, width, height, GL_RGBA))
+    {
+      CLog::Log(LOGERROR, "CWinSystemGbmGLESContext: failed to create GUI FBO texture {}x{}", width,
+                height);
+      m_guiFbo.Cleanup();
+      return false;
+    }
+
+    m_guiFboWidth = width;
+    m_guiFboHeight = height;
+    CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext: created GUI FBO {}x{}", width, height);
+  }
+
+  if (!m_guiFbo.BeginRender())
+    return false;
+
+  // clear FBO to transparent black
+  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
+
+  return true;
+}
+
+void CWinSystemGbmGLESContext::EndGuiComposite()
+{
+  m_guiFbo.EndRender();
+
+  // Clear the backbuffer before video renders. In the FBO compositing path,
+  // video renders in the RenderEx pass with clear=false, so DrawBlackBars is
+  // never called. Without this clear, letterbox areas retain stale content
+  // from the swap chain when the display resolution doesn't change between
+  // GUI and video playback.
+  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
+}
+
+// CompositeGui is the last GL operation in the frame (called just before EndRender).
+// GL state (blend mode, active texture, vertex arrays) is not restored afterward;
+// the next frame's rendering sets its own state.
+void CWinSystemGbmGLESContext::CompositeGui()
+{
+  if (!m_guiFbo.IsValid() || !m_guiFbo.IsBound() || !m_compositeShader)
+    return;
+
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, m_guiFbo.Texture());
+
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+  // set up orthographic projection (screen coords, Y-down)
+  float w = static_cast<float>(m_guiFboWidth);
+  float h = static_cast<float>(m_guiFboHeight);
+
+  GLfloat proj[16] = {2.0f / w, 0, 0, 0, 0, -2.0f / h, 0, 0, 0, 0, -1, 0, -1.0f, 1.0f, 0, 1};
+
+  m_compositeShader->SetProjection(proj);
+  m_compositeShader->SetSdrPeak(100.0f / 10000.0f);
+  m_compositeShader->Enable();
+
+  GLint posLoc = m_compositeShader->GetPosLoc();
+  GLint texLoc = m_compositeShader->GetTexLoc();
+
+  GLfloat vert[4][2] = {{0, 0}, {w, 0}, {w, h}, {0, h}};
+  GLfloat tex[4][2] = {{0, 1}, {1, 1}, {1, 0}, {0, 0}};
+  GLubyte idx[4] = {0, 1, 3, 2};
+
+  glVertexAttribPointer(posLoc, 2, GL_FLOAT, GL_FALSE, 0, vert);
+  glVertexAttribPointer(texLoc, 2, GL_FLOAT, GL_FALSE, 0, tex);
+  glEnableVertexAttribArray(posLoc);
+  glEnableVertexAttribArray(texLoc);
+
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
+
+  glDisableVertexAttribArray(posLoc);
+  glDisableVertexAttribArray(texLoc);
+
+  m_compositeShader->Disable();
 }
 
 bool CWinSystemGbmGLESContext::CreateContext()

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -21,6 +21,11 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "rendering/gles/GuiCompositeShaderGLES.h"
 #include "rendering/gles/ScreenshotSurfaceGLES.h"
+
+extern "C"
+{
+#include <libavutil/pixfmt.h>
+}
 #include "utils/BufferObjectFactory.h"
 #include "utils/DMAHeapBufferObject.h"
 #include "utils/DumbBufferObject.h"
@@ -187,11 +192,11 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
   }
 }
 
-bool CWinSystemGbmGLESContext::SetGuiCompositing(bool active)
+bool CWinSystemGbmGLESContext::SetGuiCompositing(int colorTransfer)
 {
-  m_guiCompositing = active;
+  m_guiCompositing = (colorTransfer != 0);
 
-  if (active)
+  if (m_guiCompositing)
   {
     if (!m_compositeShader)
     {
@@ -201,7 +206,16 @@ bool CWinSystemGbmGLESContext::SetGuiCompositing(bool active)
         CLog::Log(LOGERROR, "CWinSystemGbmGLESContext: failed to compile GUI composite shader");
         m_compositeShader.reset();
         m_guiCompositing = false;
+        return false;
       }
+    }
+
+    if (!m_compositeShader->CreateLUTs(colorTransfer))
+    {
+      CLog::Log(LOGERROR, "CWinSystemGbmGLESContext: failed to create LUTs");
+      m_compositeShader.reset();
+      m_guiCompositing = false;
+      return false;
     }
   }
   else
@@ -291,7 +305,6 @@ void CWinSystemGbmGLESContext::CompositeGui()
   GLfloat proj[16] = {2.0f / w, 0, 0, 0, 0, -2.0f / h, 0, 0, 0, 0, -1, 0, -1.0f, 1.0f, 0, 1};
 
   m_compositeShader->SetProjection(proj);
-  m_compositeShader->SetSdrPeak(100.0f / 10000.0f);
   m_compositeShader->Enable();
 
   GLint posLoc = m_compositeShader->GetPosLoc();

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -256,6 +256,15 @@ bool CWinSystemGbmGLESContext::BeginGuiComposite()
       return false;
     }
 
+    if (GetEnabledFrontToBackRendering() && !m_guiFbo.AttachDepthBuffer(width, height))
+    {
+      CLog::Log(LOGERROR,
+                "CWinSystemGbmGLESContext: failed to attach depth buffer to GUI FBO {}x{}", width,
+                height);
+      m_guiFbo.Cleanup();
+      return false;
+    }
+
     m_guiFboWidth = width;
     m_guiFboHeight = height;
     CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext: created GUI FBO {}x{}", width, height);

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
@@ -9,10 +9,13 @@
 #pragma once
 
 #include "WinSystemGbmEGLContext.h"
+#include "cores/VideoPlayer/VideoRenderers/FrameBufferObject.h"
 #include "rendering/gles/RenderSystemGLES.h"
 #include "utils/EGLUtils.h"
 
 #include <memory>
+
+class CGuiCompositeShaderGLES;
 
 class CVaapiProxy;
 
@@ -39,10 +42,24 @@ public:
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   void PresentRender(bool rendered, bool videoLayer) override;
 
+  // GUI compositing for HDR
+  bool SetGuiCompositing(bool active) override;
+  bool BeginGuiComposite() override;
+  void EndGuiComposite() override;
+  void CompositeGui() override;
+
 protected:
   void SetVSyncImpl(bool enable) override {}
   void PresentRenderImpl(bool rendered) override {};
   bool CreateContext() override;
+
+private:
+  bool m_guiCompositing{false};
+  CFrameBufferObject m_guiFbo;
+  int m_guiFboWidth{0};
+  int m_guiFboHeight{0};
+
+  std::unique_ptr<CGuiCompositeShaderGLES> m_compositeShader;
 };
 
 } // namespace GBM

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
@@ -43,7 +43,7 @@ public:
   void PresentRender(bool rendered, bool videoLayer) override;
 
   // GUI compositing for HDR
-  bool SetGuiCompositing(bool active) override;
+  bool SetGuiCompositing(int colorTransfer) override;
   bool BeginGuiComposite() override;
   void EndGuiComposite() override;
   void CompositeGui() override;

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
@@ -47,6 +47,7 @@ public:
   bool BeginGuiComposite() override;
   void EndGuiComposite() override;
   void CompositeGui() override;
+  bool IsHdrComposite() const override { return m_guiCompositing; }
 
 protected:
   void SetVSyncImpl(bool enable) override {}


### PR DESCRIPTION
## Description

Scope: single-plane EGL rendering only. This does not impact Direct-to-Plane rendering. This is used with software or VAAPI decoding.

Add GUI tone mapping and color space conversion for HDR playback on Linux GBM (here "HDR" means either PQ or HLG). This is foundational work for proper color management of the GUI layer — regardless of whether single-plane or Direct-to-Plane rendering is used, the GUI must be converted from sRGB/BT.709 to PQ/BT.2020/ST2084 or HLG/BT.2020/BT.2100 before reaching the display. The DRM hardware compositor performs only alpha blending between planes; it does not do any color space conversion or tone mapping. Therefore even a Direct-to-Plane approach would require this same conversion step before presenting the GUI plane to the hardware.

This commit implements it for the EGL single-plane path, rendering the GUI to an off-screen FBO and compositing it onto the video backbuffer with an sRGB-to-HDR tone mapping shader:

```
  sRGB -> linear (pow 2.2) -> BT.709 to BT.2020 gamut matrix ->
  scale to PQ luminance range (203/10000 nits) -> forward ST2084
```

On platforms with an OS compositor (Windows/DWM, macOS/Core Animation, Android/SurfaceFlinger), the compositor handles SDR-to-HDR conversion automatically. On Linux GBM with no compositor, Kodi must do it itself.

The compositing is only active during HDR passthrough on single-plane GLES renderers (software+GLES and VAAPI+GLES now, DRMPRIMEGLES in followup). During SDR playback, the GUI renders directly to the backbuffer as before with no FBO overhead. On platforms where the windowing system does not support FBO compositing (e.g. Wayland), SetGuiCompositing returns false and the render split is not activated.

Key changes:
  - Add HasVideoPlane() virtual to BaseRenderer, decoupling render pass
    separation from DRM plane management. LinuxRendererGLES overrides
    to always return false (single-plane).
  - Remove dead IsVideoLayer() from RenderManager.
  - Fix UpdateGuiRender to keep GUI dirty regions active when there is
    no video plane, preventing page flip stalls.
  - Add GUI compositing virtuals to CWinSystemBase (SetGuiCompositing,
    BeginGuiComposite, EndGuiComposite, CompositeGui). SetGuiCompositing
    returns bool so the renderer can gate the render split on whether
    the windowing system actually supports compositing.
  - Implement FBO lifecycle and sRGB-to-HDR compositing in
    WinSystemGbmGLESContext.
  - Add CGuiCompositeShaderGLES in rendering/gles/ so any GLES-based
    windowing system can reuse it.
  - Hook compositing into Application::Render().

Alpha quality: The FBO uses 8-bit RGBA, so GUI transparency effects (fades, semi-transparent overlays) use full 8-bit alpha precision during compositing via GL_SRC_ALPHA blending. The backbuffer's own alpha bits (0 or 2 on a 10-bit XR30/AR30 plane) are never used for blending — only the RGB result is written. This avoids the 2-bit alpha banding issue from #27257 by design. No current Kodi code uses GL_DST_ALPHA, so reading destination alpha from the backbuffer is not a concern, but future code should be aware of this limitation on 10-bit planes.

Color management note: The GUI is rendered to an 8-bit sRGB FBO — not to the 10-bit backbuffer directly. The sRGB->HDR conversion happens only at compositing time when the FBO is drawn onto the backbuffer. This means GUI blending remains in 8-bit sRGB as expected, and the 10-bit buffer is only used as the final PQ- or HLG-encoded output where the video lives. This architecture is compatible with a future move to 16-bit linear GUI rendering — the FBO format and composite shader could be updated independently. I _think_ this aligns with @sarbes's view in #27402

Vs Android+Windows+WebOS: in contrast to platforms where color conversion and compositing is done downstream, here we have full control. I found no need to use #24756 approach ("GUI luminance percentage") that is available on those platforms (which is frankly a little hacky--linearly scales sRGB before going through PQ or HLG, so it leads to color changes not just luminance change). Here, the sRGB->HDR shader maps sRGB white to 203nits (100/10000), which is the conventional SDR reference white level. On a calibrated display, everything looks perfect and at the intended luminance.

```
Platform coverage:

┌───────────────────────────┬──────────┬────────────────────────────────────────┬────────────────────────────────┬────────────────────────────────────┐
│         Platform          │ Decoder  │                Renderer                │           WinSystem            │          FBO compositing?          │
├───────────────────────────┼──────────┼────────────────────────────────────────┼────────────────────────────────┼────────────────────────────────────┤
│ Linux GBM                 │ VAAPI    │ RendererVAAPIGLES (→LinuxRendererGLES) │ WinSystemGbmGLESContext        │ Yes (this PR)                      │
├───────────────────────────┼──────────┼────────────────────────────────────────┼────────────────────────────────┼────────────────────────────────────┤
│ Linux GBM                 │ Software │ LinuxRendererGLES                      │ WinSystemGbmGLESContext        │ Yes (this PR)                      │
├───────────────────────────┼──────────┼────────────────────────────────────────┼────────────────────────────────┼────────────────────────────────────┤
│ Linux GBM                 │ DRMPRIME │ RendererDRMPRIMEGLES                   │ WinSystemGbmGLESContext        │ Follow-up PR                       │
├───────────────────────────┼──────────┼────────────────────────────────────────┼────────────────────────────────┼────────────────────────────────────┤
│ Linux GBM                 │ DRMPRIME │ RendererDRMPRIME (dual-plane)          │ WinSystemGbmGLESContext        │ Follow-up PR                       │
├───────────────────────────┼──────────┼────────────────────────────────────────┼────────────────────────────────┼────────────────────────────────────┤
│ Linux Wayland             │ VAAPI    │ RendererVAAPIGLES (→LinuxRendererGLES) │ WinSystemWaylandEGLContextGLES │ Not activated (base returns false) │
├───────────────────────────┼──────────┼────────────────────────────────────────┼────────────────────────────────┼────────────────────────────────────┤
│ Linux GBM/Wayland         │ VAAPI    │ RendererVAAPIGL (→LinuxRendererGL)     │ WinSystemGbm/WaylandGLContext  │ Needs GL shader                    │
├───────────────────────────┼──────────┼────────────────────────────────────────┼────────────────────────────────┼────────────────────────────────────┤
│ Windows/macOS/Android/iOS │ Various  │ Various                                │ Various                        │ N/A (OS compositor)                │
└───────────────────────────┴──────────┴────────────────────────────────────────┴────────────────────────────────┴────────────────────────────────────┘
```

Planned follow-up PRs:

- RendererDRMPRIME (Direct-to-Plane): Add SetGuiCompositing(true) in VideoLayerBridgeDRMPRIME when HDR is active. The GUI plane is still rendered via GLES, so the existing FBO infrastructure works — just
needs the trigger. Would fix "GUI looks wrong during HDR" on Direct-To-Plane (RPi5, Amlogic, Rockchip).
- RendererDRMPRIMEGLES (single-plane): Add SetHDR() call in Configure (currently missing — TV is never told content is HDR in EGL mode) and integrate with FBO compositing. Would fix the "no HDR in EGL
mode" problem reported in the #27257 bug thread.
- Wayland GLES: Implement SetGuiCompositing in WinSystemWaylandEGLContextGLES when Wayland compositors don't handle SDR→HDR tone mapping. The renderer code and shader class are already reusable.
- GL renderers: Would need a GL version of the composite shader and FBO implementation in the respective GL WinSystem classes.

~~Depends on #28006 or #28030 (for 10-bit HDR, otherwise you get 8-bit HDR)~~

UPDATE: this now explicitly depends on #28030 and dynamic planes


## Motivation and context

- Fixes incorrect GUI appearance during HDR playback on Linux GBM (no compositor)
- PQ is absolute — 203 nits SDR content maps correctly without needing HDR metadata in the shader
- Architecture is designed for reuse: shader class in rendering/gles/, compositing virtuals on CWinSystemBase, any GLES windowing system can implement them
- Related discussion: #27257 (alpha banding on 10-bit planes)

## How has this been tested?

Tested on Intel NUC (i3-8109U, Coffee Lake) with GBM+GLES output over HDMI 2.0 (LSPCON). Verified:
- 8-bit SDR content: compositing inactive, GUI renders normally
- 10-bit HDR content: compositing active, GUI correctly tone-mapped to PQ or HLG
- FBO creation/destruction on playback start/stop
- GUI transparency effects (OSD, volume bar) render correctly with 8-bit alpha
- Shader fallback: if shader compile fails, m_guiCompositing set to false, GUI renders normally instead of disappearing

No RPi5 or Wayland hardware available for testing.

## What is the effect on users?

On Linux GBM with VAAPI+GLES, the GUI overlay (menus, OSD, subtitles) now looks correct during HDR video playback instead of appearing washed out or too bright. No effect on other platforms.

## Screenshots (if appropriate):


## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

