### PR TITLE
AdvancedSettings: use standard algorithms and change to string

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -1239,23 +1239,19 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     const TiXmlElement* pSortDecription = pPVR->FirstChildElement("pvrrecordings");
     if (pSortDecription)
     {
-      constexpr const char* XML_SORTMETHOD = "sortmethod";
-      auto sortMethod = static_cast<int>(SortBy::NONE);
       static constexpr CSet validSortMethods{SortBy::LABEL,          SortBy::DATE,
                                              SortBy::SIZE,           SortBy::FILE,
                                              SortBy::EPISODE_NUMBER, SortBy::PROVIDER};
-      XMLUtils::GetInt(pSortDecription, XML_SORTMETHOD, sortMethod, static_cast<int>(SortBy::NONE),
-                       static_cast<int>(SortBy::USER_PREFERENCE));
-      if (validSortMethods.contains(static_cast<SortBy>(sortMethod)))
+      std::string smString;
+      XMLUtils::GetString(pSortDecription, "sortmethod", smString);
+      const auto sortMethod = SortUtils::SortMethodFromString(smString);
+      if (validSortMethods.contains(sortMethod))
       {
-        int sortOrder;
-        constexpr const char* XML_SORTORDER = "sortorder";
-        if (XMLUtils::GetInt(pSortDecription, XML_SORTORDER, sortOrder,
-                             static_cast<int>(SortOrder::ASCENDING),
-                             static_cast<int>(SortOrder::DESCENDING)))
+        std::string soString;
+        if (XMLUtils::GetString(pSortDecription, "sortorder", soString))
         {
-          m_PVRDefaultSortOrder.sortBy = static_cast<SortBy>(sortMethod);
-          m_PVRDefaultSortOrder.sortOrder = static_cast<SortOrder>(sortOrder);
+          m_PVRDefaultSortOrder.sortBy = sortMethod;
+          m_PVRDefaultSortOrder.sortOrder = SortUtils::SortOrderFromString(soString);
         }
       }
     }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -109,8 +109,7 @@ void CAdvancedSettings::OnSettingsLoaded()
     std::ranges::transform(m_settingsLoadedCallbacks, std::back_inserter(callbacks),
                            [](const auto& pair) { return pair.second; });
   }
-  for (const auto& callback : callbacks)
-    callback();
+  std::ranges::for_each(callbacks, &AdvancedSettingsCallback::operator());
 }
 
 void CAdvancedSettings::OnSettingsUnloaded()
@@ -1301,9 +1300,18 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   if (!seekSteps.empty())
   {
     m_seekSteps.clear();
-    std::vector<std::string> steps = StringUtils::Split(seekSteps, ',');
-    for (const auto& step : steps)
-      m_seekSteps.emplace_back(std::atoi(step.c_str()));
+    const auto steps = StringUtils::Split(seekSteps, ',');
+    try
+    {
+      std::ranges::transform(steps, std::back_inserter(m_seekSteps),
+                             [](const auto& step) { return std::stoi(step); });
+    }
+    catch (const std::exception& e)
+    {
+      CLog::Log(LOGERROR, R"(Error parsing seeksteps (="{}"): {}\n Clearing all values)", seekSteps,
+                e.what());
+      m_seekSteps.clear();
+    }
   }
 
   XMLUtils::GetBoolean(pRootElement, "opengldebugging", m_openGlDebugging);


### PR DESCRIPTION
## Description
Two changes, separated as they may be more controversial.
First changes to standard algorithms. Some may think the change to
for_each with pointer-to-member is less readable.

Second changes some settings from ints to strings. The old enums
were stable, ie, the integer representations were explicitly given.
New enum class is not stable, as in, there is no explicit specification
of integer values. So change to using strings in the xml file.

## Motivation and context
Cleaner code

## How has this been tested?
It builds and passes basic sanity checks.

## What is the effect on users?
User using the pvr sort settings will have to change to strings.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [x] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
