### PR TITLE
TexturePacker: allow build with giflib 6.x

### DIFF
--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.cpp
@@ -52,7 +52,7 @@ GifHelper::~GifHelper()
 bool GifHelper::Open(GifFileType*& gif, void *dataPtr, InputFunc readFunc)
 {
   int err = 0;
-#if GIFLIB_MAJOR == 5
+#if GIFLIB_MAJOR >= 5
   gif = DGifOpen(dataPtr, readFunc, &err);
 #else
   gif = DGifOpen(dataPtr, readFunc);
@@ -73,7 +73,7 @@ void GifHelper::Close(GifFileType* gif)
 {
   int err = 0;
   int reason = 0;
-#if GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1
+#if (GIFLIB_MAJOR == 5 && GIFLIB_MINOR >= 1) || GIFLIB_MAJOR >= 6
   err = DGifCloseFile(gif, &reason);
 #else
   err = DGifCloseFile(gif);
@@ -181,7 +181,7 @@ bool GifHelper::Slurp(GifFileType* gif)
   if (DGifSlurp(gif) == GIF_ERROR)
   {
     int reason = 0;
-#if GIFLIB_MAJOR == 5
+#if GIFLIB_MAJOR >= 5
     reason = gif->Error;
 #else
     reason = GifLastError();
@@ -246,7 +246,7 @@ bool GifHelper::GcbToFrame(GifFrame &frame, unsigned int imgIdx)
 
   if (m_gif->ImageCount > 0)
   {
-#if GIFLIB_MAJOR == 5
+#if GIFLIB_MAJOR >= 5
     GraphicsControlBlock gcb;
     if (DGifSavedExtensionToGCB(m_gif, imgIdx, &gcb))
     {

--- a/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
+++ b/tools/depends/native/TexturePacker/src/decoder/GifHelper.h
@@ -128,7 +128,7 @@ private:
   bool PrepareTemplate(GifFrame &frame);
   void Release();
 
-#if GIFLIB_MAJOR != 5
+#if GIFLIB_MAJOR < 5
   /*
   taken from giflib 5.1.0
   */


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
TexturePacker will not build with giflib-6.1.2

Current #if clauses are written with a maximum of giflib 5 written in, update the to >= to allow for newer versions of the giflib api.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Update #if conditions to set a minimum of version 5.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build on Ubuntu and with LibreELEC master

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
