### PR TITLE
CLangCodeExpander: Cleanup and add another test

### DIFF
--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -116,7 +116,7 @@ bool CLangCodeExpander::ConvertISO6391ToISO6392B(const std::string& strISO6391,
   StringUtils::ToLower(strISO6391Lower);
   StringUtils::Trim(strISO6391Lower);
 
-  auto it = std::ranges::lower_bound(LanguageCodes, strISO6391Lower, {}, &ISO639::iso639_1);
+  const auto it = std::ranges::lower_bound(LanguageCodes, strISO6391Lower, {}, &ISO639::iso639_1);
   if (it != LanguageCodes.end() && it->iso639_1 == strISO6391Lower)
   {
     if (checkWin32Locales && !it->win_id.empty())
@@ -235,7 +235,7 @@ bool CLangCodeExpander::ConvertToISO6392T(const std::string& strCharCode,
     return false;
 
   {
-    auto it =
+    const auto it =
         std::ranges::lower_bound(LanguageCodesByIso639_2b, strISO6392B, {}, &ISO639::iso639_2b);
     if (it != LanguageCodesByIso639_2b.end() && it->iso639_2b == strISO6392B &&
         !it->iso639_2t.empty())
@@ -247,7 +247,8 @@ bool CLangCodeExpander::ConvertToISO6392T(const std::string& strCharCode,
 
   if (checkWin32Locales)
   {
-    auto it = std::ranges::lower_bound(LanguageCodesByWin_Id, strISO6392B, {}, &ISO639::win_id);
+    const auto it =
+        std::ranges::lower_bound(LanguageCodesByWin_Id, strISO6392B, {}, &ISO639::win_id);
     if (it != LanguageCodesByWin_Id.end() && it->win_id == strISO6392B && !it->iso639_2t.empty())
     {
       strISO6392T = it->iso639_2t;
@@ -282,7 +283,7 @@ bool CLangCodeExpander::ConvertISO31661Alpha2ToISO31661Alpha3(const std::string&
   StringUtils::ToLower(lower);
   StringUtils::Trim(lower);
 
-  auto ret = CIso3166_1::Alpha2ToAlpha3(lower);
+  const auto ret = CIso3166_1::Alpha2ToAlpha3(lower);
   if (ret)
   {
     strISO31661Alpha3 = *ret;
@@ -300,7 +301,7 @@ bool CLangCodeExpander::ConvertWindowsLanguageCodeToISO6392B(
   std::string lower(strWindowsLanguageCode);
   StringUtils::ToLower(lower);
 
-  auto it = std::ranges::lower_bound(LanguageCodesByWin_Id, lower, {}, &ISO639::win_id);
+  const auto it = std::ranges::lower_bound(LanguageCodesByWin_Id, lower, {}, &ISO639::win_id);
   if (it != LanguageCodesByWin_Id.end() && it->win_id == lower)
   {
     strISO6392B = it->iso639_2b;
@@ -340,7 +341,8 @@ bool CLangCodeExpander::ConvertToISO6391(const std::string& lang, std::string& c
     StringUtils::ToLower(lower);
 
     {
-      auto it = std::ranges::lower_bound(LanguageCodesByIso639_2b, lower, {}, &ISO639::iso639_2b);
+      const auto it =
+          std::ranges::lower_bound(LanguageCodesByIso639_2b, lower, {}, &ISO639::iso639_2b);
       if (it != LanguageCodesByIso639_2b.end() && it->iso639_2b == lower)
       {
         code = it->iso639_1;
@@ -348,7 +350,7 @@ bool CLangCodeExpander::ConvertToISO6391(const std::string& lang, std::string& c
       }
     }
     {
-      auto it = std::ranges::lower_bound(LanguageCodesByWin_Id, lower, {}, &ISO639::win_id);
+      const auto it = std::ranges::lower_bound(LanguageCodesByWin_Id, lower, {}, &ISO639::win_id);
       if (it != LanguageCodesByWin_Id.end() && it->win_id == lower)
       {
         code = it->iso639_1;
@@ -356,7 +358,7 @@ bool CLangCodeExpander::ConvertToISO6391(const std::string& lang, std::string& c
       }
     }
     {
-      auto ret = CIso3166_1::Alpha3ToAlpha2(lower);
+      const auto ret = CIso3166_1::Alpha3ToAlpha2(lower);
       if (ret)
       {
         code = *ret;
@@ -445,7 +447,7 @@ bool CLangCodeExpander::LookupInUserMap(const std::string& code, std::string& de
   StringUtils::ToLower(sCode);
   StringUtils::Trim(sCode);
 
-  STRINGLOOKUPTABLE::iterator it = m_mapUser.find(sCode);
+  const auto it = m_mapUser.find(sCode);
   if (it != m_mapUser.end())
   {
     desc = it->second;
@@ -480,7 +482,7 @@ bool CLangCodeExpander::LookupInISO639Tables(const std::string& code, std::strin
 
   if (sCode.length() == 2)
   {
-    auto ret = CIso639_1::LookupByCode(StringToLongCode(sCode));
+    const auto ret = CIso639_1::LookupByCode(StringToLongCode(sCode));
     if (ret)
     {
       desc = *ret;
@@ -492,12 +494,12 @@ bool CLangCodeExpander::LookupInISO639Tables(const std::string& code, std::strin
     uint32_t longCode = StringToLongCode(sCode);
 
     // Map B to T for the few codes that have differences
-    auto tCode = CIso639_2::BCodeToTCode(longCode);
+    const auto tCode = CIso639_2::BCodeToTCode(longCode);
     if (tCode.has_value())
       longCode = *tCode;
 
     // Lookup the T code
-    auto ret = CIso639_2::LookupByCode(longCode);
+    const auto ret = CIso639_2::LookupByCode(longCode);
     if (ret)
     {
       desc = *ret;
@@ -660,12 +662,12 @@ bool CLangCodeExpander::ConvertToBcp47(const std::string& text, std::string& bcp
 
 std::string CLangCodeExpander::FindLanguageCodeWithSubtag(const std::string& str)
 {
-  std::size_t begin = str.find("{");
+  const std::size_t begin = str.find("{");
 
   if (begin == std::string::npos)
     return "";
 
-  std::size_t end = str.find("}", begin + 1);
+  const std::size_t end = str.find("}", begin + 1);
 
   if (end == std::string::npos)
     return "";

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -10,7 +10,6 @@
 
 #include "LangInfo.h"
 #include "ServiceBroker.h"
-#include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/i18n/Bcp47.h"
@@ -20,7 +19,6 @@
 #include "utils/i18n/Iso639_1.h"
 #include "utils/i18n/Iso639_2.h"
 #include "utils/i18n/TableLanguageCodes.h"
-#include "utils/log.h"
 
 #include <algorithm>
 #include <cassert>

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -662,12 +662,12 @@ bool CLangCodeExpander::ConvertToBcp47(const std::string& text, std::string& bcp
 
 std::string CLangCodeExpander::FindLanguageCodeWithSubtag(const std::string& str)
 {
-  const std::size_t begin = str.find("{");
+  const std::size_t begin = str.find('{');
 
   if (begin == std::string::npos)
     return "";
 
-  const std::size_t end = str.find("}", begin + 1);
+  const std::size_t end = str.find('}', begin + 1);
 
   if (end == std::string::npos)
     return "";

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -49,7 +49,8 @@ void CLangCodeExpander::LoadUserCodes(const TiXmlElement* pRootElement)
     {
       const TiXmlNode* pShort = pLangCode->FirstChildElement("short");
       const TiXmlNode* pLong = pLangCode->FirstChildElement("long");
-      if (pShort != nullptr && pLong != nullptr)
+      if (pShort != nullptr && pShort->FirstChild() != nullptr && pLong != nullptr &&
+          pLong->FirstChild() != nullptr)
       {
         sShort = pShort->FirstChild()->Value();
         sLong = pLong->FirstChild()->Value();

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -261,13 +261,16 @@ bool CLangCodeExpander::ConvertToISO6392T(const std::string& strCharCode,
 
 bool CLangCodeExpander::LookupUserCode(const std::string& desc, std::string& userCode)
 {
-  for (STRINGLOOKUPTABLE::const_iterator it = m_mapUser.begin(); it != m_mapUser.end(); ++it)
+  const auto it = std::ranges::find_if(m_mapUser,
+                                       [&desc](const auto& it)
+                                       {
+                                         return StringUtils::EqualsNoCase(desc, it.first) ||
+                                                StringUtils::EqualsNoCase(desc, it.second);
+                                       });
+  if (it != m_mapUser.end())
   {
-    if (StringUtils::EqualsNoCase(desc, it->first) || StringUtils::EqualsNoCase(desc, it->second))
-    {
-      userCode = it->first;
-      return true;
-    }
+    userCode = it->first;
+    return true;
   }
   return false;
 }
@@ -399,13 +402,12 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
   StringUtils::Trim(descTmp);
 
   // First find to user-defined languages
-  for (STRINGLOOKUPTABLE::const_iterator it = m_mapUser.begin(); it != m_mapUser.end(); ++it)
+  const auto it = std::ranges::find_if(m_mapUser, [&descTmp](const auto& it)
+                                       { return StringUtils::EqualsNoCase(descTmp, it.second); });
+  if (it != m_mapUser.end())
   {
-    if (StringUtils::EqualsNoCase(descTmp, it->second))
-    {
-      code = it->first;
-      return true;
-    }
+    code = it->first;
+    return true;
   }
 
   if (const auto ret = CIso639_1::LookupByName(descTmp); ret.has_value())
@@ -549,20 +551,15 @@ std::vector<std::string> CLangCodeExpander::GetLanguageNames(
   // User-defined languages can override existing ones
   if (list == LANG_LIST::INCLUDE_USERDEFINED || list == LANG_LIST::INCLUDE_ADDONS_USERDEFINED)
   {
-    for (const auto& value : m_mapUser)
-    {
-      langMap[value.first] = value.second;
-    }
+    std::ranges::copy(m_mapUser, std::inserter(langMap, langMap.end()));
   }
 
   // Sort by name and remove duplicates
   std::set<std::string, sortstringbyname> languages;
-  for (const auto& lang : langMap)
-  {
-    languages.insert(lang.second);
-  }
+  std::ranges::transform(langMap, std::inserter(languages, languages.end()),
+                         [](const auto& lang) { return lang.second; });
 
-  return std::vector<std::string>(languages.begin(), languages.end());
+  return {languages.begin(), languages.end()};
 }
 
 bool CLangCodeExpander::CompareISO639Codes(const std::string& code1, const std::string& code2)

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -40,18 +40,18 @@ void CLangCodeExpander::Clear()
 
 void CLangCodeExpander::LoadUserCodes(const TiXmlElement* pRootElement)
 {
-  if (pRootElement != NULL)
+  if (pRootElement != nullptr)
   {
     m_mapUser.clear();
 
     std::string sShort, sLong;
 
     const TiXmlNode* pLangCode = pRootElement->FirstChild("code");
-    while (pLangCode != NULL)
+    while (pLangCode != nullptr)
     {
       const TiXmlNode* pShort = pLangCode->FirstChildElement("short");
       const TiXmlNode* pLong = pLangCode->FirstChildElement("long");
-      if (pShort != NULL && pLong != NULL)
+      if (pShort != nullptr && pLong != nullptr)
       {
         sShort = pShort->FirstChild()->Value();
         sLong = pLong->FirstChild()->Value();

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -7,9 +7,52 @@
  */
 
 #include "utils/LangCodeExpander.h"
-#include "utils/StringUtils.h"
+#include "utils/XBMCTinyXML.h"
 
 #include <gtest/gtest.h>
+
+namespace
+{
+
+class CLangCodeExpanderTest : public CLangCodeExpander
+{
+public:
+  bool LookupUC(const std::string& desc, std::string& userCode)
+  {
+    return LookupUserCode(desc, userCode);
+  }
+};
+
+} // namespace
+
+TEST(TestLangCodeExpander, ParseUserCodes)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <languagecodes>
+             <code>
+              <short>1</short>
+              <long>2</long>
+             </code>
+             <code>
+              <short>3</short>
+              <long>4</long>
+             </code>
+           </languagecodes>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CLangCodeExpanderTest exp;
+  ASSERT_TRUE(doc.RootElement() != nullptr);
+  ASSERT_TRUE(doc.RootElement()->FirstChildElement("languagecodes") != nullptr);
+  exp.LoadUserCodes(doc.RootElement()->FirstChildElement("languagecodes"));
+  std::string code;
+  EXPECT_TRUE(exp.LookupUC("2", code));
+  EXPECT_EQ(code, "1");
+  EXPECT_TRUE(exp.LookupUC("4", code));
+  EXPECT_EQ(code, "3");
+}
 
 TEST(TestLangCodeExpander, ConvertISO6391ToISO6392B)
 {


### PR DESCRIPTION
## Description
Various cleanup and modernization in CLangCodeExpander.
Also adds a test for user code parsing from XML to have basic regression
test for changing it to tinyxml2.

## Motivation and context
Drive-by stuff + test to prepare for tinyxml2 update.

## How has this been tested?
It builds, existing tests pass and a new test is added.

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
