### PR TITLE
[Android] Exclude Kotlin-related files from the APK

### DIFF
--- a/tools/android/packaging/xbmc/build.gradle.in
+++ b/tools/android/packaging/xbmc/build.gradle.in
@@ -51,6 +51,9 @@ android {
       jniLibs {
           useLegacyPackaging = true
       }
+      exclude '**/*.kotlin_builtins'
+      exclude 'META-INF/kotlinx_coroutines*'
+      exclude 'DebugProbesKt.bin'
     }
 }
 


### PR DESCRIPTION
## Description
The `kotlinx-coroutines-core` artifact contains a resource file (`DebugProbesKt.bin`) that is only used for coroutines debugger in IDEA. This functionality does not work with Android debugging at all, so no debugging capabilities are lost when excluding it from the package.

The `*.kotlin_builtins` and `META-INF/kotlinx_coroutines*` files are metadata required by the compiler, not for the final execution. These can be safely excluded from the package.

## Screenshots

Kodi APK package contents:

<img width="814" height="619" alt="kotlin" src="https://github.com/user-attachments/assets/53bdfd43-990d-4987-8c11-6377b371cdb8" />


## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
