### PR TITLE
CLangInfo: move to tinyxml2

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -29,7 +29,7 @@
 #include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
-#include "utils/XBMCTinyXML.h"
+#include "utils/XBMCTinyXML2.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 #include "weather/WeatherManager.h"
@@ -410,11 +410,11 @@ bool CLangInfo::Load(const std::string& strLanguage)
 
   std::string strFileName = GetLanguageInfoPath(strLanguage);
 
-  CXBMCTinyXML xmlDoc;
+  CXBMCTinyXML2 xmlDoc;
   if (!xmlDoc.LoadFile(strFileName))
   {
-    CLog::Log(LOGERROR, "unable to load {}: {} at line {}", strFileName, xmlDoc.ErrorDesc(),
-              xmlDoc.ErrorRow());
+    CLog::Log(LOGERROR, "unable to load {}: {} at line {}", strFileName, xmlDoc.ErrorStr(),
+              xmlDoc.ErrorLineNum());
     return false;
   }
 
@@ -435,8 +435,8 @@ bool CLangInfo::Load(const std::string& strLanguage)
   m_strDVDSubtitleLanguage = m_languageAddon->GetDvdSubtitleLanguage();
   m_sortTokens = m_languageAddon->GetSortTokens();
 
-  TiXmlElement* pRootElement = xmlDoc.RootElement();
-  if (pRootElement->ValueStr() != "language")
+  const auto* pRootElement = xmlDoc.RootElement();
+  if (std::string(pRootElement->Value()) != "language")
   {
     CLog::Log(LOGERROR, "{} Doesn't contain <language>", strFileName);
     return false;
@@ -469,10 +469,10 @@ bool CLangInfo::Load(const std::string& strLanguage)
   if (g_LangCodeExpander.ConvertToISO6391(m_defaultRegion.m_strLangLocaleName, tmp))
     m_defaultRegion.m_strLangLocaleCodeTwoChar = tmp;
 
-  const TiXmlNode *pRegions = pRootElement->FirstChild("regions");
+  const auto* pRegions = pRootElement->FirstChildElement("regions");
   if (pRegions && !pRegions->NoChildren())
   {
-    const TiXmlElement *pRegion=pRegions->FirstChildElement("region");
+    const auto* pRegion = pRegions->FirstChildElement("region");
     while (pRegion)
     {
       CRegion region(m_defaultRegion);
@@ -493,15 +493,15 @@ bool CLangInfo::Load(const std::string& strLanguage)
       }
 #endif
 
-      const TiXmlNode *pDateLong=pRegion->FirstChild("datelong");
+      const auto* pDateLong = pRegion->FirstChildElement("datelong");
       if (pDateLong && !pDateLong->NoChildren())
-        region.m_strDateFormatLong=pDateLong->FirstChild()->ValueStr();
+        region.m_strDateFormatLong = pDateLong->FirstChild()->Value();
 
-      const TiXmlNode *pDateShort=pRegion->FirstChild("dateshort");
+      const auto* pDateShort = pRegion->FirstChildElement("dateshort");
       if (pDateShort && !pDateShort->NoChildren())
-        region.m_strDateFormatShort=pDateShort->FirstChild()->ValueStr();
+        region.m_strDateFormatShort = pDateShort->FirstChild()->Value();
 
-      const TiXmlElement *pTime=pRegion->FirstChildElement("time");
+      const auto* pTime = pRegion->FirstChildElement("time");
       if (pTime && !pTime->NoChildren())
       {
         region.m_strTimeFormat=pTime->FirstChild()->Value();
@@ -511,19 +511,19 @@ bool CLangInfo::Load(const std::string& strLanguage)
             XMLUtils::GetAttribute(pTime, "symbolPM");
       }
 
-      const TiXmlNode *pTempUnit=pRegion->FirstChild("tempunit");
+      const auto* pTempUnit = pRegion->FirstChildElement("tempunit");
       if (pTempUnit && !pTempUnit->NoChildren())
-        region.SetTemperatureUnit(pTempUnit->FirstChild()->ValueStr());
+        region.SetTemperatureUnit(pTempUnit->FirstChild()->Value());
 
-      const TiXmlNode *pSpeedUnit=pRegion->FirstChild("speedunit");
+      const auto* pSpeedUnit = pRegion->FirstChildElement("speedunit");
       if (pSpeedUnit && !pSpeedUnit->NoChildren())
-        region.SetSpeedUnit(pSpeedUnit->FirstChild()->ValueStr());
+        region.SetSpeedUnit(pSpeedUnit->FirstChild()->Value());
 
-      const TiXmlNode *pTimeZone=pRegion->FirstChild("timezone");
+      const auto* pTimeZone = pRegion->FirstChildElement("timezone");
       if (pTimeZone && !pTimeZone->NoChildren())
-        region.SetTimeZone(pTimeZone->FirstChild()->ValueStr());
+        region.SetTimeZone(pTimeZone->FirstChild()->Value());
 
-      const TiXmlElement *pThousandsSep = pRegion->FirstChildElement("thousandsseparator");
+      const auto* pThousandsSep = pRegion->FirstChildElement("thousandsseparator");
       if (pThousandsSep)
       {
         if (!pThousandsSep->NoChildren())
@@ -541,7 +541,7 @@ bool CLangInfo::Load(const std::string& strLanguage)
         region.m_strGrouping = "\3";
       }
 
-      const TiXmlElement *pDecimalSep = pRegion->FirstChildElement("decimalseparator");
+      const auto* pDecimalSep = pRegion->FirstChildElement("decimalseparator");
       if (pDecimalSep)
       {
         if (!pDecimalSep->NoChildren())
@@ -552,7 +552,7 @@ bool CLangInfo::Load(const std::string& strLanguage)
 
       m_regions.insert(PAIR_REGIONS(region.m_strName, region));
 
-      pRegion=pRegion->NextSiblingElement("region");
+      pRegion = pRegion->NextSiblingElement("region");
     }
 
     const std::string& strName = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_LOCALE_COUNTRY);

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -1047,7 +1047,7 @@ const std::string& CLangInfo::MeridiemSymbolToString(MeridiemSymbol symbol)
 }
 
 // Fills the array with the region names available for this language
-void CLangInfo::GetRegionNames(std::vector<std::string>& array)
+void CLangInfo::GetRegionNames(std::vector<std::string>& array) const
 {
   for (const auto &region : m_regions)
   {

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -239,7 +239,7 @@ void CLangInfo::CRegion::SetTimeZone(const std::string& strTimeZone)
   m_strTimeZone = strTimeZone;
 }
 
-void CLangInfo::CRegion::SetGlobalLocale()
+void CLangInfo::CRegion::SetGlobalLocale(CLangInfo& langInfo)
 {
   std::string strLocale;
   if (!m_strRegionLocaleName.empty())
@@ -256,7 +256,8 @@ void CLangInfo::CRegion::SetGlobalLocale()
     strLocale += ".UTF-8";
 #endif
   }
-  g_langInfo.m_originalLocale = std::locale(std::locale::classic(), new custom_numpunct(m_cDecimalSep, m_cThousandsSep, m_strGrouping));
+  langInfo.m_originalLocale = std::locale(
+      std::locale::classic(), new custom_numpunct(m_cDecimalSep, m_cThousandsSep, m_strGrouping));
 
   CLog::Log(LOGDEBUG, "trying to set locale to {}", strLocale);
 
@@ -284,8 +285,8 @@ void CLangInfo::CRegion::SetGlobalLocale()
     strLocale = "C";
   }
 
-  g_langInfo.m_systemLocale = current_locale; //! @todo move to CLangInfo class
-  g_langInfo.m_collationtype = 0;
+  langInfo.m_systemLocale = current_locale; //! @todo move to CLangInfo class
+  langInfo.m_collationtype = 0;
   std::locale::global(current_locale);
 #endif
 
@@ -1071,7 +1072,7 @@ void CLangInfo::SetCurrentRegion(const std::string& strName)
   else
     m_currentRegion=&m_defaultRegion;
 
-  m_currentRegion->SetGlobalLocale();
+  m_currentRegion->SetGlobalLocale(*this);
 
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   if (settings->GetString(CSettings::SETTING_LOCALE_SHORTDATEFORMAT) == SETTING_REGIONAL_DEFAULT)
@@ -1310,10 +1311,11 @@ void CLangInfo::SettingOptionsSubtitleDownloadlanguagesFiller(
 
 void CLangInfo::SettingOptionsRegionsFiller(const SettingConstPtr& setting,
                                             std::vector<StringSettingOption>& list,
-                                            std::string& current)
+                                            std::string& current,
+                                            const CLangInfo& langInfo)
 {
   std::vector<std::string> regions;
-  g_langInfo.GetRegionNames(regions);
+  langInfo.GetRegionNames(regions);
   std::sort(regions.begin(), regions.end(), sortstringbyname());
 
   bool match = false;
@@ -1335,7 +1337,8 @@ void CLangInfo::SettingOptionsRegionsFiller(const SettingConstPtr& setting,
 
 void CLangInfo::SettingOptionsShortDateFormatsFiller(const SettingConstPtr& setting,
                                                      std::vector<StringSettingOption>& list,
-                                                     std::string& current)
+                                                     std::string& current,
+                                                     const CLangInfo& langInfo)
 {
   bool match = false;
   const std::string& shortDateFormatSetting = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
@@ -1345,7 +1348,7 @@ void CLangInfo::SettingOptionsShortDateFormatsFiller(const SettingConstPtr& sett
   list.emplace_back(
       StringUtils::Format(
           CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20035),
-          GetDateStringWithFormat(now, g_langInfo.m_currentRegion->m_strDateFormatShort)),
+          GetDateStringWithFormat(now, langInfo.m_currentRegion->m_strDateFormatShort)),
       SETTING_REGIONAL_DEFAULT);
 
   if (shortDateFormatSetting == SETTING_REGIONAL_DEFAULT)
@@ -1371,7 +1374,8 @@ void CLangInfo::SettingOptionsShortDateFormatsFiller(const SettingConstPtr& sett
 
 void CLangInfo::SettingOptionsLongDateFormatsFiller(const SettingConstPtr& setting,
                                                     std::vector<StringSettingOption>& list,
-                                                    std::string& current)
+                                                    std::string& current,
+                                                    const CLangInfo& langInfo)
 {
   bool match = false;
   const std::string& longDateFormatSetting = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
@@ -1381,7 +1385,7 @@ void CLangInfo::SettingOptionsLongDateFormatsFiller(const SettingConstPtr& setti
   list.emplace_back(
       StringUtils::Format(
           CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20035),
-          GetDateStringWithFormat(now, g_langInfo.m_currentRegion->m_strDateFormatLong)),
+          GetDateStringWithFormat(now, langInfo.m_currentRegion->m_strDateFormatLong)),
       SETTING_REGIONAL_DEFAULT);
 
   if (longDateFormatSetting == SETTING_REGIONAL_DEFAULT)
@@ -1407,17 +1411,18 @@ void CLangInfo::SettingOptionsLongDateFormatsFiller(const SettingConstPtr& setti
 
 void CLangInfo::SettingOptionsTimeFormatsFiller(const SettingConstPtr& setting,
                                                 std::vector<StringSettingOption>& list,
-                                                std::string& current)
+                                                std::string& current,
+                                                const CLangInfo& langInfo)
 {
   bool match = false;
   const std::string& timeFormatSetting = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
 
   CDateTime now = CDateTime::GetCurrentDateTime();
-  bool use24hourFormat = g_langInfo.Use24HourClock();
+  bool use24hourFormat = langInfo.Use24HourClock();
 
   list.emplace_back(
       StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20035),
-                          ToSettingTimeFormat(now, g_langInfo.m_currentRegion->m_strTimeFormat)),
+                          ToSettingTimeFormat(now, langInfo.m_currentRegion->m_strTimeFormat)),
       SETTING_REGIONAL_DEFAULT);
   if (timeFormatSetting == SETTING_REGIONAL_DEFAULT)
   {
@@ -1480,13 +1485,16 @@ void CLangInfo::SettingOptionsTimeFormatsFiller(const SettingConstPtr& setting,
 
 void CLangInfo::SettingOptions24HourClockFormatsFiller(const SettingConstPtr& setting,
                                                        std::vector<StringSettingOption>& list,
-                                                       std::string& current)
+                                                       std::string& current,
+                                                       const CLangInfo& langInfo)
 {
   bool match = false;
   const std::string& clock24HourFormatSetting = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
 
   // determine the 24-hour clock format of the regional setting
-  int regionalClock24HourFormatLabel = DetermineUse24HourClockFromTimeFormat(g_langInfo.m_currentRegion->m_strTimeFormat) ? 12384 : 12383;
+  int regionalClock24HourFormatLabel =
+      DetermineUse24HourClockFromTimeFormat(langInfo.m_currentRegion->m_strTimeFormat) ? 12384
+                                                                                       : 12383;
   list.emplace_back(
       StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20035),
                           CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
@@ -1514,20 +1522,21 @@ void CLangInfo::SettingOptions24HourClockFormatsFiller(const SettingConstPtr& se
     match = true;
   }
 
-  if (!match && !list.empty())
+  if (!match)
     current = list[0].value;
 }
 
 void CLangInfo::SettingOptionsTemperatureUnitsFiller(const SettingConstPtr& setting,
                                                      std::vector<StringSettingOption>& list,
-                                                     std::string& current)
+                                                     std::string& current,
+                                                     const CLangInfo& langInfo)
 {
   bool match = false;
   const std::string& temperatureUnitSetting = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
 
   list.emplace_back(
       StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20035),
-                          GetTemperatureUnitString(g_langInfo.m_currentRegion->m_tempUnit)),
+                          GetTemperatureUnitString(langInfo.m_currentRegion->m_tempUnit)),
       SETTING_REGIONAL_DEFAULT);
   if (temperatureUnitSetting == SETTING_REGIONAL_DEFAULT)
   {
@@ -1552,14 +1561,15 @@ void CLangInfo::SettingOptionsTemperatureUnitsFiller(const SettingConstPtr& sett
 
 void CLangInfo::SettingOptionsSpeedUnitsFiller(const SettingConstPtr& setting,
                                                std::vector<StringSettingOption>& list,
-                                               std::string& current)
+                                               std::string& current,
+                                               const CLangInfo& langInfo)
 {
   bool match = false;
   const std::string& speedUnitSetting = std::static_pointer_cast<const CSettingString>(setting)->GetValue();
 
   list.emplace_back(
       StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(20035),
-                          GetSpeedUnitString(g_langInfo.m_currentRegion->m_speedUnit)),
+                          GetSpeedUnitString(langInfo.m_currentRegion->m_speedUnit)),
       SETTING_REGIONAL_DEFAULT);
   if (speedUnitSetting == SETTING_REGIONAL_DEFAULT)
   {

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -35,7 +35,7 @@
 #include "weather/WeatherManager.h"
 
 #include <algorithm>
-#include <stdexcept>
+#include <array>
 
 namespace
 {
@@ -108,16 +108,14 @@ struct TemperatureInfo
   std::string name;
 };
 
-static TemperatureInfo temperatureInfo[] = {
-  { CTemperature::UnitFahrenheit, "f" },
-  { CTemperature::UnitKelvin,     "k" },
-  { CTemperature::UnitCelsius,    "c" },
-  { CTemperature::UnitReaumur,    "re" },
-  { CTemperature::UnitRankine,    "ra" },
-  { CTemperature::UnitRomer,      "ro" },
-  { CTemperature::UnitDelisle,    "de" },
-  { CTemperature::UnitNewton,     "n" }
-};
+static const auto temperatureInfo = std::array{TemperatureInfo{CTemperature::UnitFahrenheit, "f"},
+                                               TemperatureInfo{CTemperature::UnitKelvin, "k"},
+                                               TemperatureInfo{CTemperature::UnitCelsius, "c"},
+                                               TemperatureInfo{CTemperature::UnitReaumur, "re"},
+                                               TemperatureInfo{CTemperature::UnitRankine, "ra"},
+                                               TemperatureInfo{CTemperature::UnitRomer, "ro"},
+                                               TemperatureInfo{CTemperature::UnitDelisle, "de"},
+                                               TemperatureInfo{CTemperature::UnitNewton, "n"}};
 
 #define TEMP_UNIT_STRINGS         20027
 
@@ -127,19 +125,19 @@ struct SpeedInfo
   std::string name;
 };
 
-static SpeedInfo speedInfo[] = {
-  { CSpeed::UnitKilometresPerHour,    "kmh" },
-  { CSpeed::UnitMetresPerMinute,      "mpmin" },
-  { CSpeed::UnitMetresPerSecond,      "mps" },
-  { CSpeed::UnitFeetPerHour,          "fth" },
-  { CSpeed::UnitFeetPerMinute,        "ftm" },
-  { CSpeed::UnitFeetPerSecond,        "fts" },
-  { CSpeed::UnitMilesPerHour,         "mph" },
-  { CSpeed::UnitKnots,                "kts" },
-  { CSpeed::UnitBeaufort,             "beaufort" },
-  { CSpeed::UnitInchPerSecond,        "inchs" },
-  { CSpeed::UnitYardPerSecond,        "yards" },
-  { CSpeed::UnitFurlongPerFortnight,  "fpf" }
+static const auto speedInfo = std::array{
+    SpeedInfo{CSpeed::UnitKilometresPerHour, "kmh"},
+    SpeedInfo{CSpeed::UnitMetresPerMinute, "mpmin"},
+    SpeedInfo{CSpeed::UnitMetresPerSecond, "mps"},
+    SpeedInfo{CSpeed::UnitFeetPerHour, "fth"},
+    SpeedInfo{CSpeed::UnitFeetPerMinute, "ftm"},
+    SpeedInfo{CSpeed::UnitFeetPerSecond, "fts"},
+    SpeedInfo{CSpeed::UnitMilesPerHour, "mph"},
+    SpeedInfo{CSpeed::UnitKnots, "kts"},
+    SpeedInfo{CSpeed::UnitBeaufort, "beaufort"},
+    SpeedInfo{CSpeed::UnitInchPerSecond, "inchs"},
+    SpeedInfo{CSpeed::UnitYardPerSecond, "yards"},
+    SpeedInfo{CSpeed::UnitFurlongPerFortnight, "fpf"},
 };
 
 #define SPEED_UNIT_STRINGS        20200

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -102,10 +102,11 @@ static std::string longDateFormats[] = {
 #define TIME_FORMAT_12HOURS       "12hours"
 #define TIME_FORMAT_24HOURS       "24hours"
 
-typedef struct TemperatureInfo {
+struct TemperatureInfo
+{
   CTemperature::Unit unit;
   std::string name;
-} TemperatureInfo;
+};
 
 static TemperatureInfo temperatureInfo[] = {
   { CTemperature::UnitFahrenheit, "f" },
@@ -120,10 +121,11 @@ static TemperatureInfo temperatureInfo[] = {
 
 #define TEMP_UNIT_STRINGS         20027
 
-typedef struct SpeedInfo {
+struct SpeedInfo
+{
   CSpeed::Unit unit;
   std::string name;
-} SpeedInfo;
+};
 
 static SpeedInfo speedInfo[] = {
   { CSpeed::UnitKilometresPerHour,    "kmh" },

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -169,13 +169,9 @@ static CTemperature::Unit StringToTemperatureUnit(const std::string& temperature
   std::string unit(temperatureUnit);
   StringUtils::ToLower(unit);
 
-  for (const TemperatureInfo& info : temperatureInfo)
-  {
-    if (info.name == unit)
-      return info.unit;
-  }
-
-  return CTemperature::UnitCelsius;
+  const auto it = std::ranges::find_if(temperatureInfo,
+                                       [&unit](const auto& info) { return info.name == unit; });
+  return it != temperatureInfo.end() ? it->unit : CTemperature::UnitCelsius;
 }
 
 static CSpeed::Unit StringToSpeedUnit(const std::string& speedUnit)
@@ -183,13 +179,9 @@ static CSpeed::Unit StringToSpeedUnit(const std::string& speedUnit)
   std::string unit(speedUnit);
   StringUtils::ToLower(unit);
 
-  for (const SpeedInfo& info : speedInfo)
-  {
-    if (info.name == unit)
-      return info.unit;
-  }
-
-  return CSpeed::UnitKilometresPerHour;
+  const auto it =
+      std::ranges::find_if(speedInfo, [&unit](const auto& info) { return info.name == unit; });
+  return it != speedInfo.end() ? it->unit : CSpeed::UnitKilometresPerHour;
 }
 
 struct SortLanguage
@@ -660,34 +652,34 @@ void CLangInfo::SetDefaults()
 
 std::string CLangInfo::GetGuiCharSet() const
 {
-  std::shared_ptr<CSettingString> charsetSetting = std::static_pointer_cast<CSettingString>(CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_LOCALE_CHARSET));
-  if (charsetSetting == nullptr || charsetSetting->IsDefault())
-    return m_strGuiCharSet;
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  const auto setting = settings->GetSetting(CSettings::SETTING_LOCALE_CHARSET);
+  const auto charsetSetting = std::static_pointer_cast<CSettingString>(setting);
 
-  return charsetSetting->GetValue();
+  return charsetSetting->IsDefault() ? m_strGuiCharSet : charsetSetting->GetValue();
 }
 
 std::string CLangInfo::GetSubtitleCharSet() const
 {
-  std::shared_ptr<CSettingString> charsetSetting = std::static_pointer_cast<CSettingString>(CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_SUBTITLES_CHARSET));
-  if (charsetSetting->IsDefault())
-    return m_strSubtitleCharSet;
-
-  return charsetSetting->GetValue();
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  const auto setting = settings->GetSetting(CSettings::SETTING_SUBTITLES_CHARSET);
+  const auto charsetSetting = std::static_pointer_cast<CSettingString>(setting);
+  return charsetSetting->IsDefault() ? m_strSubtitleCharSet : charsetSetting->GetValue();
 }
 
 void CLangInfo::GetAddonsLanguageCodes(std::map<std::string, std::string>& languages)
 {
   ADDON::VECADDONS addons;
   CServiceBroker::GetAddonMgr().GetAddons(addons, ADDON::AddonType::RESOURCE_LANGUAGE);
-  for (const auto& addon : addons)
-  {
-    const LanguageResourcePtr langAddon =
-        std::dynamic_pointer_cast<ADDON::CLanguageResource>(addon);
-    std::string langCode{langAddon->GetLocale().ToShortStringLC()};
-    StringUtils::Replace(langCode, '_', '-');
-    languages.emplace(langCode, addon->Name());
-  }
+  std::ranges::transform(addons, std::inserter(languages, languages.end()),
+                         [](const auto& addon)
+                         {
+                           const LanguageResourcePtr langAddon =
+                               std::dynamic_pointer_cast<ADDON::CLanguageResource>(addon);
+                           std::string langCode{langAddon->GetLocale().ToShortStringLC()};
+                           StringUtils::Replace(langCode, '_', '-');
+                           return std::pair{std::move(langCode), addon->Name()};
+                         });
 }
 
 LanguageResourcePtr CLangInfo::GetLanguageAddon(const std::string& locale /* = "" */) const
@@ -714,17 +706,18 @@ std::string CLangInfo::ConvertEnglishNameToAddonLocale(const std::string& langNa
 {
   ADDON::VECADDONS addons;
   CServiceBroker::GetAddonMgr().GetAddons(addons, ADDON::AddonType::RESOURCE_LANGUAGE);
-  for (const auto& addon : addons)
+  const auto it =
+      std::ranges::find_if(addons, [&langName](const auto& addon)
+                           { return StringUtils::CompareNoCase(addon->Name(), langName) == 0; });
+
+  if (it != addons.end())
   {
-    if (StringUtils::CompareNoCase(addon->Name(), langName) == 0)
-    {
-      const LanguageResourcePtr langAddon =
-          std::dynamic_pointer_cast<ADDON::CLanguageResource>(addon);
-      std::string locale = langAddon->GetLocale().ToShortStringLC();
-      StringUtils::Replace(locale, '_', '-');
-      return locale;
-    }
+    const LanguageResourcePtr langAddon = std::dynamic_pointer_cast<ADDON::CLanguageResource>(*it);
+    std::string locale = langAddon->GetLocale().ToShortStringLC();
+    StringUtils::Replace(locale, '_', '-');
+    return locale;
   }
+
   return "";
 }
 
@@ -787,11 +780,13 @@ bool CLangInfo::SetLanguage(std::string language /* = "" */, bool reloadServices
   if (CServiceBroker::GetAddonMgr().GetInstalledAddons(addons))
   {
     const std::string locale = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_LOCALE_LANGUAGE);
-    for (const auto& addon : addons)
-    {
-      const std::string path = URIUtils::AddFileToFolder(addon->Path(), "resources", "language/");
-      resources.GetLocalizeStrings().LoadAddonStrings(path, locale, addon->ID());
-    }
+    std::ranges::for_each(addons,
+                          [&resources, &locale](const auto& ad)
+                          {
+                            const std::string path =
+                                URIUtils::AddFileToFolder(ad->Path(), "resources", "language/");
+                            resources.GetLocalizeStrings().LoadAddonStrings(path, locale, ad->ID());
+                          });
   }
 
   if (reloadServices)
@@ -1045,14 +1040,13 @@ const std::string& CLangInfo::MeridiemSymbolToString(MeridiemSymbol symbol)
 // Fills the array with the region names available for this language
 void CLangInfo::GetRegionNames(std::vector<std::string>& array) const
 {
-  for (const auto &region : m_regions)
-  {
-    std::string strName=region.first;
-    if (strName=="N/A")
-      strName =
-          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(10005); // Not available
-    array.emplace_back(std::move(strName));
-  }
+  std::ranges::transform(m_regions, std::back_inserter(array),
+                         [&rc = CServiceBroker::GetResourcesComponent()](const auto& region)
+                         {
+                           return region.first == "N/A"
+                                      ? rc.GetLocalizeStrings().Get(10005) // Not available
+                                      : region.first;
+                         });
 }
 
 // Set the current region by its name, names from GetRegionNames() are valid.
@@ -1236,8 +1230,8 @@ void CLangInfo::SettingOptionsLanguageNamesFiller(const SettingConstPtr& /*setti
   if (!CServiceBroker::GetAddonMgr().GetAddons(addons, ADDON::AddonType::RESOURCE_LANGUAGE))
     return;
 
-  for (const auto &addon : addons)
-    list.emplace_back(addon->Name(), addon->Name());
+  std::ranges::transform(addons, std::back_inserter(list), [](const auto& addon)
+                         { return StringSettingOption{addon->Name(), addon->Name()}; });
 
   sort(list.begin(), list.end(), SortLanguage());
 }
@@ -1249,8 +1243,8 @@ void CLangInfo::SettingOptionsISO6391LanguagesFiller(const SettingConstPtr& /*se
   std::vector<std::string> languages = g_LangCodeExpander.GetLanguageNames(
       CLangCodeExpander::ISO_639_1, CLangCodeExpander::LANG_LIST::INCLUDE_USERDEFINED);
 
-  for (const auto &language : languages)
-    list.emplace_back(language, language);
+  std::ranges::transform(languages, std::back_inserter(list), [](const auto& language)
+                         { return StringSettingOption{language, language}; });
 }
 
 void CLangInfo::SettingOptionsAudioStreamLanguagesFiller(const SettingConstPtr& /*setting*/,
@@ -1583,6 +1577,6 @@ void CLangInfo::AddLanguages(std::vector<StringSettingOption> &list)
   std::vector<std::string> languages = g_LangCodeExpander.GetLanguageNames(
       CLangCodeExpander::ISO_639_1, CLangCodeExpander::LANG_LIST::INCLUDE_ADDONS_USERDEFINED);
 
-  for (const auto& language : languages)
-    list.emplace_back(language, language);
+  std::ranges::transform(languages, std::back_inserter(list), [](const auto& language)
+                         { return StringSettingOption{language, language}; });
 }

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -909,10 +909,7 @@ const std::string CLangInfo::GetDVDSubtitleLanguage() const
 const CLocale& CLangInfo::GetLocale() const
 {
   LanguageResourcePtr language = GetLanguageAddon();
-  if (language != nullptr)
-    return language->GetLocale();
-
-  return CLocale::Empty;
+  return language != nullptr ? language->GetLocale() : CLocale::Empty;
 }
 
 const std::string& CLangInfo::GetRegionLocale() const
@@ -928,10 +925,7 @@ const std::locale& CLangInfo::GetOriginalLocale() const
 // Returns the format string for the date of the current language
 const std::string& CLangInfo::GetDateFormat(bool bLongDate /* = false */) const
 {
-  if (bLongDate)
-    return GetLongDateFormat();
-
-  return GetShortDateFormat();
+  return bLongDate ? GetLongDateFormat() : GetShortDateFormat();
 }
 
 void CLangInfo::SetDateFormat(const std::string& dateFormat, bool bLongDate /* = false */)
@@ -1121,13 +1115,9 @@ void CLangInfo::SetTemperatureUnit(CTemperature::Unit temperatureUnit)
 
 void CLangInfo::SetTemperatureUnit(const std::string& temperatureUnit)
 {
-  CTemperature::Unit unit = CTemperature::UnitCelsius;
-  if (temperatureUnit == SETTING_REGIONAL_DEFAULT)
-    unit = m_currentRegion->m_tempUnit;
-  else
-    unit = StringToTemperatureUnit(temperatureUnit);
-
-  SetTemperatureUnit(unit);
+  SetTemperatureUnit(temperatureUnit == SETTING_REGIONAL_DEFAULT
+                         ? m_currentRegion->m_tempUnit
+                         : StringToTemperatureUnit(temperatureUnit));
 }
 
 std::string CLangInfo::GetTemperatureAsString(const CTemperature& temperature) const
@@ -1167,13 +1157,8 @@ void CLangInfo::SetSpeedUnit(CSpeed::Unit speedUnit)
 
 void CLangInfo::SetSpeedUnit(const std::string& speedUnit)
 {
-  CSpeed::Unit unit = CSpeed::UnitKilometresPerHour;
-  if (speedUnit == SETTING_REGIONAL_DEFAULT)
-    unit = m_currentRegion->m_speedUnit;
-  else
-    unit = StringToSpeedUnit(speedUnit);
-
-  SetSpeedUnit(unit);
+  SetSpeedUnit(speedUnit == SETTING_REGIONAL_DEFAULT ? m_currentRegion->m_speedUnit
+                                                     : StringToSpeedUnit(speedUnit));
 }
 
 CSpeed::Unit CLangInfo::GetSpeedUnit() const

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -291,9 +291,9 @@ void CLangInfo::CRegion::SetGlobalLocale(CLangInfo& langInfo)
 #endif
 
 #ifndef TARGET_WINDOWS
-  if (setlocale(LC_COLLATE, strLocale.c_str()) == NULL ||
-      setlocale(LC_CTYPE, strLocale.c_str()) == NULL ||
-      setlocale(LC_TIME, strLocale.c_str()) == NULL)
+  if (setlocale(LC_COLLATE, strLocale.c_str()) == nullptr ||
+      setlocale(LC_CTYPE, strLocale.c_str()) == nullptr ||
+      setlocale(LC_TIME, strLocale.c_str()) == nullptr)
   {
     strLocale = "C";
     setlocale(LC_COLLATE, strLocale.c_str());
@@ -303,9 +303,9 @@ void CLangInfo::CRegion::SetGlobalLocale(CLangInfo& langInfo)
 #else
   std::wstring strLocaleW;
   g_charsetConverter.utf8ToW(strLocale, strLocaleW);
-  if (_wsetlocale(LC_COLLATE, strLocaleW.c_str()) == NULL ||
-      _wsetlocale(LC_CTYPE, strLocaleW.c_str()) == NULL ||
-      _wsetlocale(LC_TIME, strLocaleW.c_str()) == NULL)
+  if (_wsetlocale(LC_COLLATE, strLocaleW.c_str()) == nullptr ||
+      _wsetlocale(LC_CTYPE, strLocaleW.c_str()) == nullptr ||
+      _wsetlocale(LC_TIME, strLocaleW.c_str()) == nullptr)
   {
     strLocale = "C";
     strLocaleW = L"C";
@@ -340,7 +340,7 @@ CLangInfo::~CLangInfo() = default;
 
 void CLangInfo::OnSettingChanged(const std::shared_ptr<const CSetting>& setting)
 {
-  if (setting == NULL)
+  if (setting == nullptr)
     return;
 
   auto settingsComponent = CServiceBroker::GetSettingsComponent();
@@ -420,7 +420,7 @@ bool CLangInfo::Load(const std::string& strLanguage)
 
   // get the matching language addon
   m_languageAddon = GetLanguageAddon(strLanguage);
-  if (m_languageAddon == NULL)
+  if (m_languageAddon == nullptr)
   {
     CLog::Log(LOGERROR, "Unknown language {}", strLanguage);
     return false;
@@ -661,7 +661,7 @@ void CLangInfo::SetDefaults()
 std::string CLangInfo::GetGuiCharSet() const
 {
   std::shared_ptr<CSettingString> charsetSetting = std::static_pointer_cast<CSettingString>(CServiceBroker::GetSettingsComponent()->GetSettings()->GetSetting(CSettings::SETTING_LOCALE_CHARSET));
-  if (charsetSetting == NULL || charsetSetting->IsDefault())
+  if (charsetSetting == nullptr || charsetSetting->IsDefault())
     return m_strGuiCharSet;
 
   return charsetSetting->GetValue();
@@ -693,7 +693,8 @@ void CLangInfo::GetAddonsLanguageCodes(std::map<std::string, std::string>& langu
 LanguageResourcePtr CLangInfo::GetLanguageAddon(const std::string& locale /* = "" */) const
 {
   if (locale.empty() ||
-     (m_languageAddon != NULL && (locale.compare(m_languageAddon->ID()) == 0 || m_languageAddon->GetLocale().Equals(locale))))
+      (m_languageAddon != nullptr &&
+       (locale.compare(m_languageAddon->ID()) == 0 || m_languageAddon->GetLocale().Equals(locale))))
     return m_languageAddon;
 
   std::string addonId = ADDON::CLanguageResource::GetAddonId(locale);
@@ -703,10 +704,10 @@ LanguageResourcePtr CLangInfo::GetLanguageAddon(const std::string& locale /* = "
   ADDON::AddonPtr addon;
   if (CServiceBroker::GetAddonMgr().GetAddon(addonId, addon, ADDON::AddonType::RESOURCE_LANGUAGE,
                                              ADDON::OnlyEnabled::CHOICE_YES) &&
-      addon != NULL)
+      addon != nullptr)
     return std::dynamic_pointer_cast<ADDON::CLanguageResource>(addon);
 
-  return NULL;
+  return nullptr;
 }
 
 std::string CLangInfo::ConvertEnglishNameToAddonLocale(const std::string& langName)
@@ -730,7 +731,7 @@ std::string CLangInfo::ConvertEnglishNameToAddonLocale(const std::string& langNa
 std::string CLangInfo::GetEnglishLanguageName(const std::string& locale /* = "" */) const
 {
   LanguageResourcePtr addon = GetLanguageAddon(locale);
-  if (addon == NULL)
+  if (addon == nullptr)
     return "";
 
   return addon->Name();
@@ -908,7 +909,7 @@ const std::string CLangInfo::GetDVDSubtitleLanguage() const
 const CLocale& CLangInfo::GetLocale() const
 {
   LanguageResourcePtr language = GetLanguageAddon();
-  if (language != NULL)
+  if (language != nullptr)
     return language->GetLocale();
 
   return CLocale::Empty;

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -221,25 +221,32 @@ public:
                                                    std::string& current);
   static void SettingOptionsRegionsFiller(const std::shared_ptr<const CSetting>& setting,
                                           std::vector<StringSettingOption>& list,
-                                          std::string& current);
+                                          std::string& current,
+                                          const CLangInfo& langInfo);
   static void SettingOptionsShortDateFormatsFiller(const std::shared_ptr<const CSetting>& setting,
                                                    std::vector<StringSettingOption>& list,
-                                                   std::string& current);
+                                                   std::string& current,
+                                                   const CLangInfo& langInfo);
   static void SettingOptionsLongDateFormatsFiller(const std::shared_ptr<const CSetting>& setting,
                                                   std::vector<StringSettingOption>& list,
-                                                  std::string& current);
+                                                  std::string& current,
+                                                  const CLangInfo& langInfo);
   static void SettingOptionsTimeFormatsFiller(const std::shared_ptr<const CSetting>& setting,
                                               std::vector<StringSettingOption>& list,
-                                              std::string& current);
+                                              std::string& current,
+                                              const CLangInfo& langInfo);
   static void SettingOptions24HourClockFormatsFiller(const std::shared_ptr<const CSetting>& setting,
                                                      std::vector<StringSettingOption>& list,
-                                                     std::string& current);
+                                                     std::string& current,
+                                                     const CLangInfo& langInfo);
   static void SettingOptionsTemperatureUnitsFiller(const std::shared_ptr<const CSetting>& setting,
                                                    std::vector<StringSettingOption>& list,
-                                                   std::string& current);
+                                                   std::string& current,
+                                                   const CLangInfo& langInfo);
   static void SettingOptionsSpeedUnitsFiller(const std::shared_ptr<const CSetting>& setting,
                                              std::vector<StringSettingOption>& list,
-                                             std::string& current);
+                                             std::string& current,
+                                             const CLangInfo& langInfo);
 
 protected:
   void SetDefaults();
@@ -279,7 +286,7 @@ protected:
     Set the locale associated with this region global. This affects string
     sorting & transformations.
     */
-    void SetGlobalLocale();
+    void SetGlobalLocale(CLangInfo& langInfo);
     std::string m_strLangLocaleName;
     std::string m_strLangLocaleCodeTwoChar;
     std::string m_strRegionLocaleName;

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -187,7 +187,7 @@ public:
   static const std::string& GetSpeedUnitString(CSpeed::Unit speedUnit);
   std::string GetSpeedAsString(const CSpeed& speed) const;
 
-  void GetRegionNames(std::vector<std::string>& array);
+  void GetRegionNames(std::vector<std::string>& array) const;
   void SetCurrentRegion(const std::string& strName);
   const std::string& GetCurrentRegion() const;
 

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -297,8 +297,8 @@ protected:
     std::string m_strMeridiemSymbols[2];
     std::string m_strTimeZone;
     std::string m_strGrouping;
-    char m_cDecimalSep;
-    char m_cThousandsSep;
+    char m_cDecimalSep{'.'};
+    char m_cThousandsSep{'.'};
 
     CTemperature::Unit m_tempUnit;
     CSpeed::Unit m_speedUnit;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -381,13 +381,35 @@ void CSettings::InitializeOptionFillers()
   GetSettingsManager()->RegisterSettingOptionsFiller("languagenames", CLangInfo::SettingOptionsLanguageNamesFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("refreshchangedelays", CDisplaySettings::SettingOptionsRefreshChangeDelaysFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("refreshrates", CDisplaySettings::SettingOptionsRefreshRatesFiller);
-  GetSettingsManager()->RegisterSettingOptionsFiller("regions", CLangInfo::SettingOptionsRegionsFiller);
-  GetSettingsManager()->RegisterSettingOptionsFiller("shortdateformats", CLangInfo::SettingOptionsShortDateFormatsFiller);
-  GetSettingsManager()->RegisterSettingOptionsFiller("longdateformats", CLangInfo::SettingOptionsLongDateFormatsFiller);
-  GetSettingsManager()->RegisterSettingOptionsFiller("timeformats", CLangInfo::SettingOptionsTimeFormatsFiller);
-  GetSettingsManager()->RegisterSettingOptionsFiller("24hourclockformats", CLangInfo::SettingOptions24HourClockFormatsFiller);
-  GetSettingsManager()->RegisterSettingOptionsFiller("speedunits", CLangInfo::SettingOptionsSpeedUnitsFiller);
-  GetSettingsManager()->RegisterSettingOptionsFiller("temperatureunits", CLangInfo::SettingOptionsTemperatureUnitsFiller);
+
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "regions", [](const std::shared_ptr<const CSetting>& setting, StringSettingOptions& list,
+                    std::string& current)
+      { CLangInfo::SettingOptionsRegionsFiller(setting, list, current, g_langInfo); });
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "shortdateformats", [](const std::shared_ptr<const CSetting>& setting,
+                             StringSettingOptions& list, std::string& current)
+      { CLangInfo::SettingOptionsShortDateFormatsFiller(setting, list, current, g_langInfo); });
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "longdateformats", [](const std::shared_ptr<const CSetting>& setting,
+                            StringSettingOptions& list, std::string& current)
+      { CLangInfo::SettingOptionsLongDateFormatsFiller(setting, list, current, g_langInfo); });
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "timeformats", [](const std::shared_ptr<const CSetting>& setting, StringSettingOptions& list,
+                        std::string& current)
+      { CLangInfo::SettingOptionsTimeFormatsFiller(setting, list, current, g_langInfo); });
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "24hourclockformats", [](const std::shared_ptr<const CSetting>& setting,
+                               StringSettingOptions& list, std::string& current)
+      { CLangInfo::SettingOptions24HourClockFormatsFiller(setting, list, current, g_langInfo); });
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "speedunits", [](const std::shared_ptr<const CSetting>& setting, StringSettingOptions& list,
+                       std::string& current)
+      { CLangInfo::SettingOptionsSpeedUnitsFiller(setting, list, current, g_langInfo); });
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "temperatureunits", [](const std::shared_ptr<const CSetting>& setting,
+                             StringSettingOptions& list, std::string& current)
+      { CLangInfo::SettingOptionsTemperatureUnitsFiller(setting, list, current, g_langInfo); });
   GetSettingsManager()->RegisterSettingOptionsFiller("rendermethods", CBaseRenderer::SettingOptionsRenderMethodsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("modes", CDisplaySettings::SettingOptionsModesFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("resolutions", CDisplaySettings::SettingOptionsResolutionsFiller);

--- a/xbmc/test/CMakeLists.txt
+++ b/xbmc/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES TestAutoSwitch.cpp
             TestDateTime.cpp
             TestDateTimeSpan.cpp
             TestFileItem.cpp
+            TestLangInfo.cpp
             TestMediaSource.cpp
             TestURL.cpp
             TestUtil.cpp

--- a/xbmc/test/TestLangInfo.cpp
+++ b/xbmc/test/TestLangInfo.cpp
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "LangInfo.h"
+
+#include <algorithm>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+class CLangInfoTest : public CLangInfo
+{
+public:
+  bool LoadLang(const std::string& language) { return Load(language); }
+};
+
+} // namespace
+
+TEST(TestLangInfo, Load)
+{
+  CLangInfoTest langInfo;
+
+  ASSERT_TRUE(langInfo.LoadLang("en_gb"));
+  std::vector<std::string> regions;
+  langInfo.GetRegionNames(regions);
+  std::ranges::sort(regions);
+
+  using namespace std::string_literals;
+  const auto ref = std::set{
+      "USA (12h)"s,       "USA (24h)"s,       "UK (12h)"s,       "UK (24h)"s,    "Canada"s,
+      "Australia (12h)"s, "Australia (24h)"s, "Central Europe"s, "India (12h)"s, "India (24h)"s,
+  };
+
+  EXPECT_TRUE(std::ranges::includes(regions, ref));
+
+  langInfo.SetCurrentRegion("USA (12h)");
+
+  // Compares easily accessible only
+#ifdef TARGET_WINDOWS
+  EXPECT_EQ(langInfo.GetRegionLocale(), "usa");
+#else
+  EXPECT_EQ(langInfo.GetRegionLocale(), "US");
+#endif
+  EXPECT_EQ(langInfo.GetSpeedUnit(), CSpeed::UnitMilesPerHour);
+  EXPECT_EQ(langInfo.GetTemperatureUnit(), CTemperature::UnitFahrenheit);
+}


### PR DESCRIPTION
## Description
Some preparations and then moving CLangInfo to use tinyxml2

## Motivation and context
We want to use tinyxml2 everywhere

## How has this been tested?
Simple test added + started kodi and flipped some language things.

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
