### PR TITLE
RendererDRMPRIMEGLES: enable HDR, colorspace conversion and GUI compositing

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -133,3 +133,201 @@ void CDRMPRIMETexture::Unmap()
   m_primebuffer->Release();
   m_primebuffer = nullptr;
 }
+
+namespace
+{
+
+// Maps a source DRM fourcc to the per-plane import descriptors used by
+// CDRMPRIMETextureYUV. planeWidthShift / planeHeightShift describe
+// chroma subsampling relative to the full Y-plane resolution.
+struct PlaneLayout
+{
+  int numPlanes;
+  uint32_t planeFourcc[CDRMPRIMETextureYUV::MAX_PLANES];
+  int planeWidthShift[CDRMPRIMETextureYUV::MAX_PLANES];
+  int planeHeightShift[CDRMPRIMETextureYUV::MAX_PLANES];
+};
+
+bool GetPlaneLayout(uint32_t sourceFormat, PlaneLayout& layout)
+{
+  switch (sourceFormat)
+  {
+    case DRM_FORMAT_NV12:
+      layout = {2, {DRM_FORMAT_R8, DRM_FORMAT_GR88, 0}, {0, 1, 0}, {0, 1, 0}};
+      return true;
+    case DRM_FORMAT_P010:
+    case DRM_FORMAT_P012:
+    case DRM_FORMAT_P016:
+      layout = {2, {DRM_FORMAT_R16, DRM_FORMAT_GR1616, 0}, {0, 1, 0}, {0, 1, 0}};
+      return true;
+    case DRM_FORMAT_YUV420:
+      layout = {3, {DRM_FORMAT_R8, DRM_FORMAT_R8, DRM_FORMAT_R8}, {0, 1, 1}, {0, 1, 1}};
+      return true;
+#if defined(DRM_FORMAT_S010)
+    case DRM_FORMAT_S010:
+#endif
+#if defined(DRM_FORMAT_S012)
+    case DRM_FORMAT_S012:
+#endif
+#if defined(DRM_FORMAT_S016)
+    case DRM_FORMAT_S016:
+#endif
+#if defined(DRM_FORMAT_S010) || defined(DRM_FORMAT_S012) || defined(DRM_FORMAT_S016)
+      layout = {3, {DRM_FORMAT_R16, DRM_FORMAT_R16, DRM_FORMAT_R16}, {0, 1, 1}, {0, 1, 1}};
+      return true;
+#endif
+    default:
+      return false;
+  }
+}
+
+} // namespace
+
+bool CDRMPRIMETextureYUV::SupportsFormat(uint32_t fourcc)
+{
+  PlaneLayout dummy;
+  return GetPlaneLayout(fourcc, dummy);
+}
+
+// Cleanup pattern taken from CDRMPRIMETexture::~CDRMPRIMETexture (above),
+// extended to the per-plane texture array.
+CDRMPRIMETextureYUV::~CDRMPRIMETextureYUV()
+{
+  // Release any active mapping (EGL images, descriptor, buffer ref).
+  Unmap();
+  // Delete the GL texture objects that Map() may have generated.
+  for (int i = 0; i < MAX_PLANES; i++)
+  {
+    if (m_textures[i])
+      glDeleteTextures(1, &m_textures[i]);
+  }
+}
+
+void CDRMPRIMETextureYUV::Init(EGLDisplay eglDisplay)
+{
+  m_eglDisplay = eglDisplay;
+}
+
+// Descriptor acquire/release lifecycle and the per-plane
+// glIsTexture/glGenTextures + glBindTexture + glTexParameteri x4 +
+// UploadImage + unbind sequence are taken from CDRMPRIMETexture::Map
+// (above) and CVaapi2Texture::Map (VaapiEGL.cpp:438-560). What is new
+// here is the per-plane DRM fourcc derivation (single-layer N-plane
+// descriptor split into N separate EGL images) and the multi-plane
+// loop. Single-layer-N-plane is the shape ffmpeg HW decoders and the
+// SW-decode -> DMA path produce.
+bool CDRMPRIMETextureYUV::Map(CVideoBufferDRMPRIME* buffer)
+{
+  if (m_primebuffer)
+    return true;
+
+  if (!buffer->AcquireDescriptor())
+  {
+    CLog::Log(LOGERROR, "CDRMPRIMETextureYUV::{} - failed to acquire descriptor", __FUNCTION__);
+    return false;
+  }
+
+  AVDRMFrameDescriptor* descriptor = buffer->GetDescriptor();
+  if (!descriptor || descriptor->nb_layers < 1)
+  {
+    buffer->ReleaseDescriptor();
+    return false;
+  }
+
+  // Only the single-layer-multi-plane descriptor shape is supported.
+  // ffmpeg HW decoders and the SW decode -> DMA path both produce this shape.
+  if (descriptor->nb_layers != 1)
+  {
+    CLog::Log(LOGWARNING,
+              "CDRMPRIMETextureYUV::{} - {} layers, only single-layer descriptors supported",
+              __FUNCTION__, descriptor->nb_layers);
+    buffer->ReleaseDescriptor();
+    return false;
+  }
+
+  AVDRMLayerDescriptor* layer = &descriptor->layers[0];
+
+  PlaneLayout planeLayout;
+  if (!GetPlaneLayout(layer->format, planeLayout))
+  {
+    CLog::Log(LOGWARNING, "CDRMPRIMETextureYUV::{} - unsupported source fourcc {:#x}", __FUNCTION__,
+              layer->format);
+    buffer->ReleaseDescriptor();
+    return false;
+  }
+
+  if (layer->nb_planes != planeLayout.numPlanes)
+  {
+    CLog::Log(LOGERROR,
+              "CDRMPRIMETextureYUV::{} - layer has {} planes, expected {} for fourcc {:#x}",
+              __FUNCTION__, layer->nb_planes, planeLayout.numPlanes, layer->format);
+    buffer->ReleaseDescriptor();
+    return false;
+  }
+
+  m_texWidth = buffer->GetWidth();
+  m_texHeight = buffer->GetHeight();
+  m_sourceFormat = layer->format;
+  m_numPlanes = planeLayout.numPlanes;
+
+  for (int i = 0; i < m_numPlanes; i++)
+  {
+    AVDRMPlaneDescriptor& plane = layer->planes[i];
+    AVDRMObjectDescriptor& object = descriptor->objects[plane.object_index];
+
+    CEGLImage::EglAttrs attribs{};
+    attribs.width = m_texWidth >> planeLayout.planeWidthShift[i];
+    attribs.height = m_texHeight >> planeLayout.planeHeightShift[i];
+    attribs.format = planeLayout.planeFourcc[i];
+    attribs.planes[0].fd = object.fd;
+    attribs.planes[0].modifier = object.format_modifier;
+    attribs.planes[0].offset = static_cast<int>(plane.offset);
+    attribs.planes[0].pitch = static_cast<int>(plane.pitch);
+
+    if (!m_eglImages[i])
+      m_eglImages[i] = std::make_unique<CEGLImage>(m_eglDisplay);
+
+    if (!m_eglImages[i]->CreateImage(attribs))
+    {
+      // Roll back any planes we already imported in this Map() call.
+      for (int j = 0; j < i; j++)
+        m_eglImages[j]->DestroyImage();
+      m_numPlanes = 0;
+      buffer->ReleaseDescriptor();
+      return false;
+    }
+
+    if (!glIsTexture(m_textures[i]))
+      glGenTextures(1, &m_textures[i]);
+    glBindTexture(GL_TEXTURE_2D, m_textures[i]);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    m_eglImages[i]->UploadImage(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, 0);
+  }
+
+  m_primebuffer = buffer;
+  m_primebuffer->Acquire();
+  return true;
+}
+
+// DestroyImage + ReleaseDescriptor + buffer Release + null sequence is
+// taken from CDRMPRIMETexture::Unmap (above), looped over planes.
+void CDRMPRIMETextureYUV::Unmap()
+{
+  if (!m_primebuffer)
+    return;
+
+  for (int i = 0; i < m_numPlanes; i++)
+  {
+    if (m_eglImages[i])
+      m_eglImages[i]->DestroyImage();
+  }
+  m_numPlanes = 0;
+
+  m_primebuffer->ReleaseDescriptor();
+  m_primebuffer->Release();
+  m_primebuffer = nullptr;
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
@@ -12,6 +12,8 @@
 #include "utils/EGLImage.h"
 #include "utils/Geometry.h"
 
+#include <array>
+
 #include "system_gl.h"
 
 class CDRMPRIMETexture
@@ -35,4 +37,50 @@ protected:
   GLuint m_texture{0};
   int m_texWidth{0};
   int m_texHeight{0};
+};
+
+/*
+ * CDRMPRIMETextureYUV: import a DRMPRIME dma-buf as separate per-plane
+ * GL_TEXTURE_2D textures, the same way VAAPIGLES handles VA-API surfaces
+ * (see CVaapi2Texture::Map). Used by the limited-range render path on
+ * CRendererDRMPRIMEGLES so the YUV->RGB matrix can be applied in a
+ * standard BaseYUV2RGBGLSLShader instead of being baked in by the OES
+ * external sampler's full-range-only Mesa matrix.
+ *
+ * Supports a fixed set of source DRM fourccs (NV12 / P010 / P012 / P016 /
+ * YUV420). For other formats, SupportsFormat returns false and the
+ * caller is expected to fall back to the OES path.
+ */
+class CDRMPRIMETextureYUV
+{
+public:
+  static constexpr int MAX_PLANES = 3;
+
+  CDRMPRIMETextureYUV() = default;
+  ~CDRMPRIMETextureYUV();
+
+  CDRMPRIMETextureYUV(const CDRMPRIMETextureYUV&) = delete;
+  CDRMPRIMETextureYUV& operator=(const CDRMPRIMETextureYUV&) = delete;
+
+  void Init(EGLDisplay eglDisplay);
+  bool Map(CVideoBufferDRMPRIME* buffer);
+  void Unmap();
+
+  GLuint GetTexture(int plane) const { return m_textures[plane]; }
+  int GetNumPlanes() const { return m_numPlanes; }
+  CSizeInt GetTextureSize() const { return {m_texWidth, m_texHeight}; }
+  uint32_t GetSourceFormat() const { return m_sourceFormat; }
+
+  // Returns true if the given DRM fourcc can be imported by this class.
+  static bool SupportsFormat(uint32_t fourcc);
+
+protected:
+  CVideoBufferDRMPRIME* m_primebuffer{nullptr};
+  EGLDisplay m_eglDisplay{nullptr};
+  std::array<std::unique_ptr<CEGLImage>, MAX_PLANES> m_eglImages;
+  std::array<GLuint, MAX_PLANES> m_textures{{0, 0, 0}};
+  int m_numPlanes{0};
+  int m_texWidth{0};
+  int m_texHeight{0};
+  uint32_t m_sourceFormat{0};
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -13,6 +13,8 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderCapture.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
+#include "cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h"
+#include "rendering/MatrixGL.h"
 #include "rendering/gles/RenderSystemGLES.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -126,23 +128,107 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
     if (!buf.fence)
     {
       buf.texture.Init(eglDisplay);
+      buf.yuvTexture.Init(eglDisplay);
       buf.fence = std::make_unique<CEGLFence>(eglDisplay);
     }
   }
 
   m_configured = true;
 
-  //! @todo limited-range color management is broken on the DRMPRIMEGLES path.
-  //! The OES_EGL_image_external sampler (samplerExternalOES) does YUV->RGB
-  //! conversion in mesa with hardcoded matrices that always output full-range
-  //! RGB regardless of source range. So `videoscreen.limitedrange=true` is
-  //! silently ignored for video pixels here, while GUI pixels go through the
-  //! GLES shader chain that does honor the setting -- producing a range
-  //! mismatch in the BO when both are composited. The clean fix is to migrate
-  //! from OES_EGL_image_external to EXT_YUV_target's __samplerExternal2DY2YEXT
-  //! (sampler returns raw YUV) and apply the conversion matrix in our own
-  //! shader, the way RendererVAAPIGLES does. Tracked in
-  //! project_limited_range_hdr.md.
+  // Two render paths, selected per-frame in Render():
+  //  - Full-range: OES samplerExternalOES (always available).
+  //  - Limited-range: per-plane sampler2D + BaseYUV2RGBGLSLShader, built
+  //    here when the source fourcc is one we can per-plane import.
+  m_yuvShader.reset();
+
+  uint32_t sourceFourcc = 0;
+  auto* drmBuf = dynamic_cast<CVideoBufferDRMPRIME*>(picture.videoBuffer);
+  if (drmBuf && drmBuf->AcquireDescriptor())
+  {
+    auto* desc = drmBuf->GetDescriptor();
+    if (desc && desc->nb_layers == 1)
+      sourceFourcc = desc->layers[0].format;
+    drmBuf->ReleaseDescriptor();
+  }
+
+  if (CDRMPRIMETextureYUV::SupportsFormat(sourceFourcc))
+  {
+    using namespace Shaders::GLES;
+    // Both src and dst primaries equal disables the in-shader primary-matrix
+    // path (`if (dstPrimaries != srcPrimaries)`); we want pass-through, same
+    // as the OES path does. No tone mapping either.
+    //! @todo SHADER_YV12_10 is the WRONG token here for 8-bit YUV420 content.
+    //! The EShaderFormat enum conflates two things: the shader sampling
+    //! pattern (.r/.g/.a legacy CPU-upload vs .r/.r/.r per-plane R8/R16) and
+    //! the source bit depth. Per-plane EGL import always wants the
+    //! single-channel sampling pattern (XBMC_YV12_HI define) regardless of
+    //! bit depth, but the only way to get that today is to pick one of
+    //! SHADER_YV12_9 / _10 / _12 / _14 / _16. Picking _10 here just routes
+    //! through the right shader define; the actual bit depth is handled by
+    //! SetColParams below. Clean up by either (a) adding a
+    //! SHADER_YV12_PLANAR enum value that activates XBMC_YV12_HI without
+    //! implying a bit depth, or (b) dropping 3-plane YUV420 from this path
+    //! entirely (NV12/P010/P012/P016 via SHADER_NV12_RRG cover the realistic
+    //! DRMPRIME cases).
+    //! @todo SHADER_YV12_10 is the WRONG token here for 8-bit YUV420 content.
+    //! The EShaderFormat enum conflates two things: the shader sampling
+    //! pattern (.r/.g/.a legacy CPU-upload vs .r/.r/.r per-plane R8/R16) and
+    //! the source bit depth. Per-plane EGL import always wants the
+    //! single-channel sampling pattern (XBMC_YV12_HI define) regardless of
+    //! bit depth, but the only way to get that today is to pick one of
+    //! SHADER_YV12_9 / _10 / _12 / _14 / _16. Picking _10 here just routes
+    //! through the right shader define; the actual bit depth is handled by
+    //! SetColParams below. Clean up by either (a) adding a
+    //! SHADER_YV12_PLANAR enum value that activates XBMC_YV12_HI without
+    //! implying a bit depth, or (b) dropping 3-plane YUV420 from this path
+    //! entirely (NV12/P010/P012/P016 via SHADER_NV12_RRG cover the realistic
+    //! DRMPRIME cases).
+    const bool planar3 = (sourceFourcc == DRM_FORMAT_YUV420
+#if defined(DRM_FORMAT_S010)
+                          || sourceFourcc == DRM_FORMAT_S010
+#endif
+#if defined(DRM_FORMAT_S012)
+                          || sourceFourcc == DRM_FORMAT_S012
+#endif
+#if defined(DRM_FORMAT_S016)
+                          || sourceFourcc == DRM_FORMAT_S016
+#endif
+    );
+    EShaderFormat fmt = planar3 ? SHADER_YV12_10 : SHADER_NV12_RRG;
+    auto shader = std::make_unique<YUV2RGBProgressiveShader>(
+        fmt, picture.color_primaries, picture.color_primaries,
+        /*toneMap*/ false, VS_TONEMAPMETHOD_OFF);
+    if (shader->CompileAndLink())
+    {
+      // P010/P012/P016 are MSB-aligned -> textureBits=8 (no rescale).
+      // S010/S012/S016 are LSB-aligned -> textureBits=colorBits (matrix rescales).
+      const bool lsbAligned =
+#if defined(DRM_FORMAT_S010)
+          sourceFourcc == DRM_FORMAT_S010 ||
+#endif
+#if defined(DRM_FORMAT_S012)
+          sourceFourcc == DRM_FORMAT_S012 ||
+#endif
+#if defined(DRM_FORMAT_S016)
+          sourceFourcc == DRM_FORMAT_S016 ||
+#endif
+          false;
+      const int textureBits = lsbAligned ? picture.colorBits : 8;
+      shader->SetColParams(picture.color_space, picture.colorBits, picture.color_range != 1,
+                           textureBits);
+      m_yuvShader = std::move(shader);
+      CLog::Log(LOGINFO,
+                "RendererDRMPRIMEGLES::Configure: limited-range YUV path "
+                "available (src bits {}, src {} range, fourcc {:#x})",
+                picture.colorBits, picture.color_range ? "full" : "limited", sourceFourcc);
+    }
+    else
+    {
+      CLog::Log(LOGWARNING, "RendererDRMPRIMEGLES::Configure: limited-range "
+                            "YUV shader compile/link failed; OES path will "
+                            "be used regardless of user setting");
+    }
+  }
 
   if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
       picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
@@ -178,6 +264,7 @@ void CRendererDRMPRIMEGLES::UnInit()
     CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
   }
 
+  m_yuvShader.reset();
   m_configured = false;
 }
 
@@ -190,6 +277,7 @@ void CRendererDRMPRIMEGLES::AddVideoPicture(const VideoPicture& picture, int ind
     if (buf.fence)
       buf.fence->DestroyFence();
     buf.texture.Unmap();
+    buf.yuvTexture.Unmap();
     buf.videoBuffer->Release();
   }
   buf.videoBuffer = picture.videoBuffer;
@@ -213,6 +301,7 @@ void CRendererDRMPRIMEGLES::ReleaseBuffer(int index)
     buf.fence->DestroyFence();
 
   buf.texture.Unmap();
+  buf.yuvTexture.Unmap();
 
   if (buf.videoBuffer)
   {
@@ -370,6 +459,105 @@ void CRendererDRMPRIMEGLES::Render(unsigned int flags, int index)
   if (!renderSystem)
     return;
 
+  // Per-frame path selection. m_yuvShader is only alive if the source
+  // fourcc was importable; UseLimitedColor() is checked every frame so
+  // the user can toggle the setting at runtime and the next frame picks
+  // up the new path without any rebuild.
+  auto* winSystem = CServiceBroker::GetWinSystem();
+  const bool useYUVPath =
+      m_yuvShader && winSystem && winSystem->UseLimitedColor() && buf.yuvTexture.Map(buffer);
+
+  if (useYUVPath)
+  {
+    // Limited-range YUV path: per-plane sampler2D + BaseYUV2RGBGLSLShader.
+    // Vertex/cord array setup is taken from CLinuxRendererGLES::RenderSinglePass
+    // (LinuxRendererGLES.cpp:1100-1183). The texture-unit binding pattern is
+    // taken from CRendererVAAPIGLES::UploadTexture (RendererVAAPIGLES.cpp:270-282)
+    // -- specifically, the SHADER_NV12_RRG case binds the UV texture to BOTH
+    // U and V samplers so .r returns U and .g returns V via the GR88 / GR1616
+    // import.
+    const int numPlanes = buf.yuvTexture.GetNumPlanes();
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, buf.yuvTexture.GetTexture(0));
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, buf.yuvTexture.GetTexture(1));
+    glActiveTexture(GL_TEXTURE2);
+    // 3-plane (YV12_HI): plane 2 is V. 2-plane (NV12_RRG): rebind plane 1
+    // (UV) so sampV samples the same texture as sampU.
+    glBindTexture(GL_TEXTURE_2D, buf.yuvTexture.GetTexture(numPlanes == 3 ? 2 : 1));
+    glActiveTexture(GL_TEXTURE0);
+
+    const CSizeInt texSize = buf.yuvTexture.GetTextureSize();
+    m_yuvShader->SetWidth(texSize.Width());
+    m_yuvShader->SetHeight(texSize.Height());
+    m_yuvShader->SetAlpha(1.0f);
+    m_yuvShader->SetMatrices(glMatrixProject.Get(), glMatrixModview.Get());
+    // SetConvertFullColorRange(false) was set at Configure time -> matrix
+    // produces limited-range RGB. No per-frame setter needed.
+    m_yuvShader->Enable();
+
+    GLubyte idx[4] = {0, 1, 3, 2};
+    GLfloat vert[4][3];
+    GLfloat tex[3][4][2];
+
+    GLint vertLoc = m_yuvShader->GetVertexLoc();
+    GLint yLoc = m_yuvShader->GetYcoordLoc();
+    GLint uLoc = m_yuvShader->GetUcoordLoc();
+    GLint vLoc = m_yuvShader->GetVcoordLoc();
+
+    glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, 0, vert);
+    glVertexAttribPointer(yLoc, 2, GL_FLOAT, 0, 0, tex[0]);
+    glVertexAttribPointer(uLoc, 2, GL_FLOAT, 0, 0, tex[1]);
+    glVertexAttribPointer(vLoc, 2, GL_FLOAT, 0, 0, tex[2]);
+
+    glEnableVertexAttribArray(vertLoc);
+    glEnableVertexAttribArray(yLoc);
+    glEnableVertexAttribArray(uLoc);
+    glEnableVertexAttribArray(vLoc);
+
+    for (int i = 0; i < 4; i++)
+    {
+      vert[i][0] = m_rotatedDestCoords[i].x;
+      vert[i][1] = m_rotatedDestCoords[i].y;
+      vert[i][2] = 0.0f;
+    }
+
+    // Per-plane texcoords are 0..1; each EGL-imported texture covers the
+    // whole plane regardless of chroma subsampling.
+    for (int p = 0; p < 3; p++)
+    {
+      tex[p][0][0] = 0.0f;
+      tex[p][0][1] = 0.0f;
+      tex[p][1][0] = 1.0f;
+      tex[p][1][1] = 0.0f;
+      tex[p][2][0] = 1.0f;
+      tex[p][2][1] = 1.0f;
+      tex[p][3][0] = 0.0f;
+      tex[p][3][1] = 1.0f;
+    }
+
+    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
+
+    glDisableVertexAttribArray(vertLoc);
+    glDisableVertexAttribArray(yLoc);
+    glDisableVertexAttribArray(uLoc);
+    glDisableVertexAttribArray(vLoc);
+
+    m_yuvShader->Disable();
+
+    glActiveTexture(GL_TEXTURE2);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    buf.fence->DestroyFence();
+    buf.fence->CreateFence();
+    return;
+  }
+
+  // Full-range OES path (unchanged).
   if (!buf.texture.Map(buffer))
     return;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -30,13 +30,7 @@ using namespace KODI::UTILS::EGL;
 
 CRendererDRMPRIMEGLES::~CRendererDRMPRIMEGLES()
 {
-  Flush(false);
-
-  if (m_configured)
-  {
-    if (auto winSystem = CServiceBroker::GetWinSystem())
-      winSystem->SetVideoOutput(nullptr);
-  }
+  UnInit();
 }
 
 CBaseRenderer* CRendererDRMPRIMEGLES::Create(CVideoBuffer* buffer)
@@ -115,6 +109,8 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
   if (!winSystem)
     return false;
 
+  m_configured = true;
+
   if (!winSystem->SetVideoOutput(&picture))
     CLog::Log(LOGWARNING, "RendererDRMPRIMEGLES::Configure: SetVideoOutput failed");
 
@@ -135,7 +131,54 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
   }
 
   m_configured = true;
+
+  //! @todo limited-range color management is broken on the DRMPRIMEGLES path.
+  //! The OES_EGL_image_external sampler (samplerExternalOES) does YUV->RGB
+  //! conversion in mesa with hardcoded matrices that always output full-range
+  //! RGB regardless of source range. So `videoscreen.limitedrange=true` is
+  //! silently ignored for video pixels here, while GUI pixels go through the
+  //! GLES shader chain that does honor the setting -- producing a range
+  //! mismatch in the BO when both are composited. The clean fix is to migrate
+  //! from OES_EGL_image_external to EXT_YUV_target's __samplerExternal2DY2YEXT
+  //! (sampler returns raw YUV) and apply the conversion matrix in our own
+  //! shader, the way RendererVAAPIGLES does. Tracked in
+  //! project_limited_range_hdr.md.
+
+  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
+      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
+  {
+    m_passthroughHDR = winSystem->SetHDR(&picture);
+    CLog::Log(LOGDEBUG, "RendererDRMPRIMEGLES::Configure: HDR passthrough: {}",
+              m_passthroughHDR ? "on" : "off");
+  }
+
+  m_hdrFboActive = m_passthroughHDR && winSystem->SetGuiCompositing(picture.color_transfer);
+  if (m_passthroughHDR && !m_hdrFboActive)
+    CLog::Log(LOGWARNING, "RendererDRMPRIMEGLES::Configure: HDR passthrough active but GUI "
+                          "compositing not supported by windowing system");
+
   return true;
+}
+
+bool CRendererDRMPRIMEGLES::IsGuiLayer()
+{
+  return !m_hdrFboActive;
+}
+
+void CRendererDRMPRIMEGLES::UnInit()
+{
+  Flush(false);
+
+  if (m_configured)
+  {
+    m_hdrFboActive = false;
+    CServiceBroker::GetWinSystem()->SetGuiCompositing(false);
+    CServiceBroker::GetWinSystem()->SetHDR(nullptr);
+    m_passthroughHDR = false;
+    CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
+  }
+
+  m_configured = false;
 }
 
 void CRendererDRMPRIMEGLES::AddVideoPicture(const VideoPicture& picture, int index)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
@@ -37,8 +37,10 @@ public:
   // Player functions
   bool Configure(const VideoPicture& picture, float fps, unsigned int orientation) override;
   bool IsConfigured() override { return m_configured; }
+  bool IsGuiLayer() override;
+  bool HasVideoPlane() override { return false; }
   void AddVideoPicture(const VideoPicture& picture, int index) override;
-  void UnInit() override {}
+  void UnInit() override;
   bool Flush(bool saveBuffers) override;
   void ReleaseBuffer(int idx) override;
   bool NeedBuffer(int idx) override;
@@ -59,6 +61,8 @@ private:
   void Render(unsigned int flags, int index);
 
   bool m_configured = false;
+  bool m_passthroughHDR{false};
+  bool m_hdrFboActive{false};
 
   struct BUFFER
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
@@ -24,6 +24,14 @@ class CEGLFence;
 } // namespace UTILS
 } // namespace KODI
 
+namespace Shaders
+{
+namespace GLES
+{
+class BaseYUV2RGBGLSLShader;
+}
+} // namespace Shaders
+
 class CRendererDRMPRIMEGLES : public CBaseRenderer
 {
 public:
@@ -64,10 +72,18 @@ private:
   bool m_passthroughHDR{false};
   bool m_hdrFboActive{false};
 
+  // Limited-range path: per-plane EGL import + standard YUV2RGB shader.
+  // Set at Configure time when the user has limited-range output enabled
+  // AND the buffer's source fourcc can be imported by CDRMPRIMETextureYUV
+  // AND the shader compiles. If null, Render() falls through to the OES
+  // path (which always outputs full-range RGB).
+  std::unique_ptr<Shaders::GLES::BaseYUV2RGBGLSLShader> m_yuvShader;
+
   struct BUFFER
   {
     CVideoBuffer* videoBuffer = nullptr;
     std::unique_ptr<KODI::UTILS::EGL::CEGLFence> fence;
     CDRMPRIMETexture texture;
+    CDRMPRIMETextureYUV yuvTexture;
   } m_buffers[NUM_BUFFERS];
 };


### PR DESCRIPTION
## Description

Scope: single-plane EGL only (with DRMPRIME decoding). This does not impact Direct-to-Plane rendering.

Add HDR support for RendererDRMPRIMEGLES -- the single-plane EGL renderer used for DRMPRIME content on GBM platforms (RPi5, Amlogic, Rockchip in EGL mode).

Previously, RendererDRMPRIMEGLES had no HDR support: SetHDR() was never called, so the TV was never told the content was HDR. This was reported in the #27257 where a user noted "switching from Direct-To-Plane to EGL solve the problem but obviously then it doesn't work in HDR anymore."

This commit adds:
  - SetHDR() in Configure() to signal HDR metadata to the display
  - FBO-based GUI compositing via SetGuiCompositing() when HDR is active, using the sRGB-to-PQ tone mapping shader from #28012
  - IsGuiLayer()/HasVideoPlane() overrides to support the render split needed for FBO compositing
  - Proper cleanup in UnInit() and destructor

RendererDRMPRIMEGLES extends CBaseRenderer directly, not CLinuxRendererGLES, so it doesn't inherit the HDR detection and FBO compositing logic added in #28012. The SetHDR/SetGuiCompositing/IsGuiLayer code is added here independently.

Color management note: As with #28012, the GUI is rendered to an 8-bit sRGB FBO with full 8-bit alpha, then tone-mapped and composited onto the 10-bit backbuffer. The 10-bit buffer's alpha bits are not used for blending.

GUI peak luminance setting: The existing videoscreen.guipeakluminance setting (used on Android/Windows/WebOS) is not needed here and should remain disabled on GBM. Those platforms use a simple linear brightness scale because their compositor handles the actual color conversion. Our FBO shader does the full sRGB-to-PQ conversion directly, mapping sRGB white to the conventional SDR reference level of 100 nits (100/10000 in PQ). No user-adjustable brightness knob is needed.

Depends on #28012.  Use #28006 to get 10-bit HDR otherwise you get 8-bit HDR.

Motivation and context

  - Fixes "no HDR in EGL mode" for DRMPRIME content on ARM platforms
  - Enables proper GUI appearance during HDR playback on single-plane EGL path
  - Combined with #28006 (10-bit framebuffer) and #28012 (FBO compositing), this provides a complete HDR solution for ARM devices using EGL mode -- no
  Direct-to-Plane required

How has this been tested?

Tested on Intel NUC (i3-8109U, Coffee Lake) using DRMPRIME software decode with EGL rendering. HDR metadata signaling verified (TV switches to HDR mode).
FBO GUI compositing verified -- GUI overlay correctly tone-mapped during HDR playback, including letterboxed content.

No ARM hardware available for testing with DRMPRIME hardware decode -- requesting testing from RPi5/Amlogic/Rockchip users.

What is the effect on users?

ARM devices using EGL mode (the default on LibreELEC) can now play HDR content with proper HDR metadata signaling and correctly tone-mapped GUI overlays.

Previously HDR only worked with Direct-to-Plane rendering.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
