### PR TITLE
Enable 10-bit GUI framebuffer support on top of DRM dynamic plane selection (#27402)

### DIFF
--- a/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag
+++ b/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag
@@ -50,6 +50,13 @@ void main()
              texture2D(m_sampV, m_cordV).a,
              1.0);
 
+#elif defined(XBMC_YV12_HI)
+
+  yuv = vec4(texture2D(m_sampY, m_cordY).r,
+             texture2D(m_sampU, m_cordU).r,
+             texture2D(m_sampV, m_cordV).r,
+             1.0);
+
 #elif defined(XBMC_NV12_RRG)
 
   yuv = vec4(texture2D(m_sampY, m_cordY).r,

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
@@ -10,8 +10,10 @@
 
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/Buffers/VideoBufferPoolDMA.h"
+#include "rendering/RenderSystem.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/log.h"
 
 using namespace VIDEOPLAYER;
 
@@ -44,17 +46,36 @@ EINTERLACEMETHOD CProcessInfoGBM::GetFallbackDeintMethod()
 std::vector<AVPixelFormat> CProcessInfoGBM::GetRenderFormats()
 {
   // clang-format off
-  return {
+  std::vector<AVPixelFormat> formats = {
       AV_PIX_FMT_NV12,
       AV_PIX_FMT_YUV420P,
-      AV_PIX_FMT_YUV420P9,
-      AV_PIX_FMT_YUV420P10,
-      AV_PIX_FMT_YUV420P12,
-      AV_PIX_FMT_YUV420P14,
-      AV_PIX_FMT_YUV420P16,
       // TODO: verify YUV422 on existing GL renderer, add support to GLES renderer
       // AV_PIX_FMT_YUYV422,
       // AV_PIX_FMT_UYVY422,
   };
   // clang-format on
+
+  // For software decode, the ffmpeg codec queries GetRenderFormats before any
+  // renderer is created. Since GLES 2.0 vs 3.0+ is a runtime (not compile-time)
+  // issue, this method gates >8-bit formats on behalf of the eventual renderer.
+  // >8-bit requires GL_EXT_texture_norm16; without it, ffmpeg downconverts to
+  // 8-bit, preserving existing behavior.
+#if defined(HAS_GLES)
+  auto renderSystem = CServiceBroker::GetRenderSystem();
+  if (!renderSystem)
+  {
+    CLog::Log(LOGERROR, "CProcessInfoGBM::GetRenderFormats: render system not initialized");
+    return formats;
+  }
+  if (renderSystem->IsExtSupported("GL_EXT_texture_norm16"))
+#endif
+  {
+    formats.push_back(AV_PIX_FMT_YUV420P9);
+    formats.push_back(AV_PIX_FMT_YUV420P10);
+    formats.push_back(AV_PIX_FMT_YUV420P12);
+    formats.push_back(AV_PIX_FMT_YUV420P14);
+    formats.push_back(AV_PIX_FMT_YUV420P16);
+  }
+
+  return formats;
 }

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
@@ -40,3 +40,21 @@ EINTERLACEMETHOD CProcessInfoGBM::GetFallbackDeintMethod()
   return CProcessInfo::GetFallbackDeintMethod();
 #endif
 }
+
+std::vector<AVPixelFormat> CProcessInfoGBM::GetRenderFormats()
+{
+  // clang-format off
+  return {
+      AV_PIX_FMT_NV12,
+      AV_PIX_FMT_YUV420P,
+      AV_PIX_FMT_YUV420P9,
+      AV_PIX_FMT_YUV420P10,
+      AV_PIX_FMT_YUV420P12,
+      AV_PIX_FMT_YUV420P14,
+      AV_PIX_FMT_YUV420P16,
+      // TODO: verify YUV422 on existing GL renderer, add support to GLES renderer
+      // AV_PIX_FMT_YUYV422,
+      // AV_PIX_FMT_UYVY422,
+  };
+  // clang-format on
+}

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h
@@ -22,6 +22,7 @@ public:
 
   CProcessInfoGBM();
   EINTERLACEMETHOD GetFallbackDeintMethod() override;
+  std::vector<AVPixelFormat> GetRenderFormats() override;
 };
 
 } // namespace VIDEOPLAYER

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -66,6 +66,9 @@ CLinuxRendererGLES::CLinuxRendererGLES()
     m_pixelStoreKey = GL_UNPACK_ROW_LENGTH_EXT;
   }
 #endif
+
+  if (m_renderSystem && m_renderSystem->IsExtSupported("GL_EXT_texture_norm16"))
+    m_hasTextureNorm16 = true;
 }
 
 CLinuxRendererGLES::~CLinuxRendererGLES()
@@ -328,7 +331,8 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
       pixelData = m_planeBuffer;
     }
   }
-  glTexSubImage2D(m_textureTarget, 0, 0, 0, width, height, type, GL_UNSIGNED_BYTE, pixelData);
+  GLenum datatype = (bpp == 2) ? GL_UNSIGNED_SHORT : GL_UNSIGNED_BYTE;
+  glTexSubImage2D(m_textureTarget, 0, 0, 0, width, height, type, datatype, pixelData);
 
   if (m_pixelStoreKey > 0 && pixelStoreChanged)
     glPixelStorei(m_pixelStoreKey, 0);
@@ -336,17 +340,13 @@ void CLinuxRendererGLES::LoadPlane(CYuvPlane& plane, int type,
   // check if we need to load any border pixels
   if (height < plane.texheight)
   {
-    glTexSubImage2D(m_textureTarget, 0,
-                    0, height, width, 1,
-                    type, GL_UNSIGNED_BYTE,
+    glTexSubImage2D(m_textureTarget, 0, 0, height, width, 1, type, datatype,
                     static_cast<const unsigned char*>(pixelData) + stride * (height - 1));
   }
 
   if (width  < plane.texwidth)
   {
-    glTexSubImage2D(m_textureTarget, 0,
-                    width, 0, 1, height,
-                    type, GL_UNSIGNED_BYTE,
+    glTexSubImage2D(m_textureTarget, 0, width, 0, 1, height, type, datatype,
                     static_cast<const unsigned char*>(pixelData) + bps * (width - 1));
   }
 
@@ -1456,22 +1456,32 @@ bool CLinuxRendererGLES::UploadYV12Texture(int source)
 
   VerifyGLState();
 
-  glPixelStorei(GL_UNPACK_ALIGNMENT,1);
+  glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
-  // load Y plane
-  LoadPlane(buf.fields[FIELD_FULL][0], GL_LUMINANCE,
-            im->width, im->height,
-            im->stride[0], im->bpp, im->plane[0]);
+  if (im->bpp == 2)
+  {
+    // >8-bit: three separate GL_R16_EXT planes
+    LoadPlane(buf.fields[FIELD_FULL][0], GL_RED, im->width, im->height, im->stride[0], im->bpp,
+              im->plane[0]);
 
-  // load U plane
-  LoadPlane(buf.fields[FIELD_FULL][1], GL_LUMINANCE,
-            im->width >> im->cshift_x, im->height >> im->cshift_y,
-            im->stride[1], im->bpp, im->plane[1]);
+    LoadPlane(buf.fields[FIELD_FULL][1], GL_RED, im->width >> im->cshift_x,
+              im->height >> im->cshift_y, im->stride[1], im->bpp, im->plane[1]);
 
-  // load V plane
-  LoadPlane(buf.fields[FIELD_FULL][2], GL_ALPHA,
-            im->width >> im->cshift_x, im->height >> im->cshift_y,
-            im->stride[2], im->bpp, im->plane[2]);
+    LoadPlane(buf.fields[FIELD_FULL][2], GL_RED, im->width >> im->cshift_x,
+              im->height >> im->cshift_y, im->stride[2], im->bpp, im->plane[2]);
+  }
+  else
+  {
+    // 8-bit: GL_LUMINANCE for Y/U, GL_ALPHA for V
+    LoadPlane(buf.fields[FIELD_FULL][0], GL_LUMINANCE, im->width, im->height, im->stride[0],
+              im->bpp, im->plane[0]);
+
+    LoadPlane(buf.fields[FIELD_FULL][1], GL_LUMINANCE, im->width >> im->cshift_x,
+              im->height >> im->cshift_y, im->stride[1], im->bpp, im->plane[1]);
+
+    LoadPlane(buf.fields[FIELD_FULL][2], GL_ALPHA, im->width >> im->cshift_x,
+              im->height >> im->cshift_y, im->stride[2], im->bpp, im->plane[2]);
+  }
 
   VerifyGLState();
 
@@ -1516,7 +1526,8 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
 {
   // since we also want the field textures, pitch must be texture aligned
   unsigned p;
-  YuvImage &im = m_buffers[index].image;
+  CPictureBuffer& buf = m_buffers[index];
+  YuvImage& im = buf.image;
 
   DeleteYV12Texture(index);
 
@@ -1524,7 +1535,11 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
   im.width = m_sourceWidth;
   im.cshift_x = 1;
   im.cshift_y = 1;
-  im.bpp = 1;
+
+  // Bit depth comes from libavutil's public pixdesc API, avoiding a parallel switch.
+  const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(m_format);
+  buf.m_srcTextureBits = desc ? desc->comp[0].depth : 8;
+  im.bpp = (m_hasTextureNorm16 && buf.m_srcTextureBits > 8) ? 2 : 1;
 
   im.stride[0] = im.bpp * im.width;
   im.stride[1] = im.bpp * (im.width >> im.cshift_x);
@@ -1581,17 +1596,23 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
 
       glBindTexture(m_textureTarget, plane.id);
 
-      GLint format;
-      if (p == 2) // V plane needs an alpha texture
+      if (im.bpp == 2)
       {
-        format = GL_ALPHA;
+        glTexImage2D(m_textureTarget, 0, GL_R16_EXT, plane.texwidth, plane.texheight, 0, GL_RED,
+                     GL_UNSIGNED_SHORT, nullptr);
       }
       else
       {
-        format = GL_LUMINANCE;
+        GLint format;
+        if (p == 2) // V plane needs an alpha texture
+          format = GL_ALPHA;
+        else
+          format = GL_LUMINANCE;
+
+        glTexImage2D(m_textureTarget, 0, format, plane.texwidth, plane.texheight, 0, format,
+                     GL_UNSIGNED_BYTE, nullptr);
       }
 
-      glTexImage2D(m_textureTarget, 0, format, plane.texwidth, plane.texheight, 0, format, GL_UNSIGNED_BYTE, nullptr);
       glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
       glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
       glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -66,9 +66,6 @@ CLinuxRendererGLES::CLinuxRendererGLES()
     m_pixelStoreKey = GL_UNPACK_ROW_LENGTH_EXT;
   }
 #endif
-
-  if (m_renderSystem && m_renderSystem->IsExtSupported("GL_EXT_texture_norm16"))
-    m_hasTextureNorm16 = true;
 }
 
 CLinuxRendererGLES::~CLinuxRendererGLES()
@@ -1539,7 +1536,7 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
   // Bit depth comes from libavutil's public pixdesc API, avoiding a parallel switch.
   const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(m_format);
   buf.m_srcTextureBits = desc ? desc->comp[0].depth : 8;
-  im.bpp = (m_hasTextureNorm16 && buf.m_srcTextureBits > 8) ? 2 : 1;
+  im.bpp = (buf.m_srcTextureBits > 8) ? 2 : 1;
 
   im.stride[0] = im.bpp * im.width;
   im.stride[1] = im.bpp * (im.width >> im.cshift_x);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -1595,8 +1595,13 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
 
       if (im.bpp == 2)
       {
+#if defined(GL_R16_EXT)
         glTexImage2D(m_textureTarget, 0, GL_R16_EXT, plane.texwidth, plane.texheight, 0, GL_RED,
                      GL_UNSIGNED_SHORT, nullptr);
+#else
+        CLog::Log(LOGERROR, "GLES: GL_R16_EXT undefined; cannot render >8-bit YUV");
+        return false;
+#endif
       }
       else
       {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -23,6 +23,7 @@
 
 extern "C" {
 #include <libavutil/mastering_display_metadata.h>
+#include <libavutil/pixdesc.h>
 }
 
 class CRenderCapture;
@@ -150,6 +151,7 @@ protected:
   bool m_reloadShaders{false};
   CRenderSystemGLES *m_renderSystem{nullptr};
   GLenum m_pixelStoreKey{0};
+  bool m_hasTextureNorm16{false};
 
   struct CYuvPlane
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -151,7 +151,6 @@ protected:
   bool m_reloadShaders{false};
   CRenderSystemGLES *m_renderSystem{nullptr};
   GLenum m_pixelStoreKey{0};
-  bool m_hasTextureNorm16{false};
 
   struct CYuvPlane
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -43,6 +43,9 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format,
 
   if (m_format == SHADER_YV12)
     m_defines += "#define XBMC_YV12\n";
+  else if (m_format == SHADER_YV12_9 || m_format == SHADER_YV12_10 || m_format == SHADER_YV12_12 ||
+           m_format == SHADER_YV12_14 || m_format == SHADER_YV12_16)
+    m_defines += "#define XBMC_YV12_HI\n";
   else if (m_format == SHADER_NV12)
     m_defines += "#define XBMC_NV12\n";
   else if (m_format == SHADER_NV12_RRG)

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -257,15 +257,15 @@ int KODI::UTILS::GL::glFormatElementByteCount(GLenum format)
 #ifdef HAS_GL
   case GL_BGRA:
     return 4;
-  case GL_RED:
-    return 1;
   case GL_GREEN:
     return 1;
-  case GL_RG:
-    return 2;
   case GL_BGR:
     return 3;
 #endif
+  case GL_RED:
+    return 1;
+  case GL_RG:
+    return 2;
   case GL_RGBA:
     return 4;
   case GL_RGB:

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -361,11 +361,16 @@ std::vector<std::string> CWinSystemGbm::GetConnectedOutputs()
 
 bool CWinSystemGbm::SetVideoOutput(const VideoPicture* videoPicture)
 {
-  // Scaffolding: in this commit just flips m_gui_plane / m_video_plane role
-  // identity. Format and modifier are read from the current surface and pass
-  // through tautologically -- the current plane already supports them. A
-  // follow-on (#28030) will recreate the GBM surface at a different
-  // bit depth and pick a matching plane for real.
+  // Base: flip the gui/video plane role for the single shared output
+  // plane on GBM. videoPicture set means a video is starting and the
+  // output plane should be tracked as the video plane; nullptr means
+  // playback ended and the plane reverts to the gui role.
+  //
+  // Format and modifier come from whichever plane is currently active.
+  // EGL backends override this and rebuild the GBM/EGL output surface
+  // at the target bit depth before chaining here, so by the time we
+  // run the active plane's cached format reflects the post-rebuild
+  // surface (e.g. AR30 for 10-bit content).
   CDRMPlane* current = m_DRM->GetGuiPlane() ? m_DRM->GetGuiPlane() : m_DRM->GetVideoPlane();
   if (!current)
     return false;

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -19,7 +19,7 @@ using namespace KODI::WINDOWING::LINUX;
 
 bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint apiType)
 {
-  if (!CWinSystemGbm::InitWindowSystem())
+  if (!m_DRM && !CWinSystemGbm::InitWindowSystem())
   {
     return false;
   }
@@ -31,6 +31,7 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
 
   if (!m_eglContext.InitializeDisplay(apiType))
   {
+    m_eglContext.Destroy();
     return false;
   }
 
@@ -38,11 +39,13 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
 
   if (!ChooseEGLConfig(renderableType))
   {
+    m_eglContext.Destroy();
     return false;
   }
 
   if (!CreateContext())
   {
+    m_eglContext.Destroy();
     return false;
   }
 

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -255,6 +255,13 @@ bool CWinSystemGbmEGLContext::SetVideoOutput(const VideoPicture* videoPicture)
 
     CLog::LogF(LOGINFO, "Output surface recreated at {}-bit", bitDepth);
 
+    // amdgpu disables the CRTC when RMFB removes a still-bound FB during
+    // surface destroy (primary-plane invariant). Force a full modeset on
+    // the next commit to re-enable the CRTC. No-op on drivers without the
+    // quirk (Intel, RPi, etc.) so they keep the fast-flip path.
+    if (m_DRM->HasQuirk(KODI::WINDOWING::GBM::QUIRK_NEEDSPRIMARY))
+      m_DRM->SetActive(true);
+
     // The chained base reads the active plane's cached format and
     // modifier to decide which DRM plane satisfies the new role.
     // After a surface rebuild that cache is stale, so refresh it

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -10,6 +10,7 @@
 
 #include "OptionalsReg.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "utils/log.h"
 
@@ -33,16 +34,9 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
     return false;
   }
 
-  // InitWindowSystemEGL runs only at boot for GUI init, so the output
-  // surface is always the gui surface here.
-  auto guiformats = m_DRM->GetOutputFormats();
-  if (!std::ranges::any_of(guiformats,
-                           [&](struct outputformat format)
-                           {
-                             return format.active &&
-                                    m_eglContext.ChooseConfig(renderableType, format.drm, false,
-                                                              format.alpha);
-                           }))
+  m_renderableType = renderableType;
+
+  if (!ChooseEGLConfig(renderableType))
   {
     return false;
   }
@@ -72,6 +66,35 @@ bool CWinSystemGbmEGLContext::InitWindowSystemEGL(EGLint renderableType, EGLint 
   }
 
   return true;
+}
+
+bool CWinSystemGbmEGLContext::ChooseEGLConfig(EGLint renderableType, int bitDepth)
+{
+  // Pick the highest active output format whose bpp is in range for the
+  // requested bit depth. Policy: when bitDepth > 8, accept only entries
+  // with bpp >= 10 and bpp <= bitDepth (do not silently fall back to 8).
+  // When bitDepth <= 8, accept entries with bpp <= 8.
+  auto outputformats = m_DRM->GetOutputFormats();
+
+  std::vector<outputformat> candidates;
+  std::ranges::copy_if(outputformats, std::back_inserter(candidates),
+                       [bitDepth](const outputformat& format)
+                       {
+                         if (!format.active)
+                           return false;
+                         if (bitDepth > 8)
+                           return format.bpp >= 10 && format.bpp <= bitDepth;
+                         return format.bpp <= 8;
+                       });
+  std::ranges::sort(candidates, std::greater<>{}, &outputformat::bpp);
+
+  for (const auto& format : candidates)
+  {
+    if (m_eglContext.ChooseConfig(renderableType, format.drm, false, format.alpha))
+      return true;
+  }
+
+  return false;
 }
 
 bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
@@ -163,6 +186,93 @@ bool CWinSystemGbmEGLContext::DestroyWindow()
 
   CLog::Log(LOGDEBUG, "CWinSystemGbmEGLContext::{} - deinitialized GBM", __FUNCTION__);
   return true;
+}
+
+bool CWinSystemGbmEGLContext::SetVideoOutput(const VideoPicture* videoPicture)
+{
+  // Override: the base only flips the gui/video plane role. On EGL
+  // backends we additionally rebuild the GBM and EGL output surface
+  // to a wider format (e.g. AR24 -> AR30) when the video needs more
+  // than 8-bit through the single output plane, then chain to the
+  // base so plane-role tracking sees the new format. The EGL context
+  // survives across the rebuild -- no shader recompile, no modeset.
+  const int bitDepth = videoPicture ? videoPicture->colorBits : 8;
+
+  // Pick an EGL config matching the target bit depth, then rebuild
+  // the surface only if that pick changed the native visual ID.
+  uint32_t currentFormat = m_eglContext.GetConfigAttrib(EGL_NATIVE_VISUAL_ID);
+
+  if (!ChooseEGLConfig(m_renderableType, bitDepth))
+  {
+    CLog::LogF(LOGERROR, "failed to choose EGL config for {}-bit", bitDepth);
+    return false;
+  }
+
+  uint32_t format = m_eglContext.GetConfigAttrib(EGL_NATIVE_VISUAL_ID);
+
+  if (format != currentFormat)
+  {
+    m_eglContext.DestroySurface();
+
+    std::vector<uint64_t> fallbackModifiers = {DRM_FORMAT_MOD_LINEAR};
+    std::vector<uint64_t>* modifiers = &fallbackModifiers;
+
+    for (auto& fmt : m_DRM->GetOutputFormats())
+    {
+      if (fmt.drm == format && fmt.active)
+      {
+        modifiers = &fmt.modifiers;
+        break;
+      }
+    }
+
+    if (!m_GBM->GetDevice().CreateSurface(m_nWidth, m_nHeight, format, modifiers->data(),
+                                          modifiers->size()))
+    {
+      CLog::LogF(LOGERROR, "failed to create GBM surface");
+      return false;
+    }
+
+    if (!m_eglContext.CreatePlatformSurface(
+            m_GBM->GetDevice().GetSurface().Get(),
+            reinterpret_cast<khronos_uintptr_t>(m_GBM->GetDevice().GetSurface().Get())))
+    {
+      return false;
+    }
+
+    if (!m_eglContext.BindContext())
+    {
+      return false;
+    }
+
+    if (!m_eglContext.TrySwapBuffers())
+    {
+      return false;
+    }
+
+    CLog::LogF(LOGINFO, "Output surface recreated at {}-bit", bitDepth);
+
+    // The chained base reads the active plane's cached format and
+    // modifier to decide which DRM plane satisfies the new role.
+    // After a surface rebuild that cache is stale, so refresh it
+    // from the just-locked GBM front buffer before chaining.
+    if (auto* plane = m_DRM->GetGuiPlane() ? m_DRM->GetGuiPlane() : m_DRM->GetVideoPlane())
+    {
+      if (struct gbm_bo* bo = m_GBM->GetDevice().GetSurface().LockFrontBuffer().Get())
+      {
+        plane->SetFormat(gbm_bo_get_format(bo));
+#if defined(HAS_GBM_MODIFIERS)
+        plane->SetModifier(gbm_bo_get_modifier(bo));
+#else
+        plane->SetModifier(DRM_FORMAT_MOD_LINEAR);
+#endif
+      }
+    }
+  }
+
+  // Dispatch to FindVideoPlane (videoPicture set) or FindGuiPlane
+  // using the now-current plane format.
+  return CWinSystemGbm::SetVideoOutput(videoPicture);
 }
 
 bool CWinSystemGbmEGLContext::DestroyWindowSystem()

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
@@ -42,6 +42,8 @@ public:
   bool UnbindTextureUploadContext() override;
   bool HasContext() override;
 
+  bool SetVideoOutput(const VideoPicture* videoPicture) override;
+
 protected:
   CWinSystemGbmEGLContext(EGLenum platform, std::string const& platformExtension)
     : CWinSystemEGL{platform, platformExtension}
@@ -53,7 +55,10 @@ protected:
    * and call this function there with appropriate parameters
    */
   bool InitWindowSystemEGL(EGLint renderableType, EGLint apiType);
+  bool ChooseEGLConfig(EGLint renderableType, int bitDepth = 8);
   virtual bool CreateContext() = 0;
+
+  EGLint m_renderableType{0};
 
   std::unique_ptr<KODI::UTILS::EGL::CEGLFence> m_eglFence;
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -61,9 +61,14 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryDMAOpenGLES);
   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGLES);
 
-  if (!CWinSystemGbmEGLContext::InitWindowSystemEGL(EGL_OPENGL_ES2_BIT, EGL_OPENGL_ES_API))
+  // GLES 3.0 required for 10-bit texture format support (GL_RGB10_A2, GL_R16UI, etc.)
+  // Fall back to GLES 2.0 for devices that don't support GLES 3.0 (e.g. lima driver)
+  if (!CWinSystemGbmEGLContext::InitWindowSystemEGL(EGL_OPENGL_ES3_BIT, EGL_OPENGL_ES_API))
   {
-    return false;
+    if (!CWinSystemGbmEGLContext::InitWindowSystemEGL(EGL_OPENGL_ES2_BIT, EGL_OPENGL_ES_API))
+    {
+      return false;
+    }
   }
 
   bool general, deepColor;

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -188,8 +188,10 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
 
 bool CWinSystemGbmGLESContext::CreateContext()
 {
+  const EGLint version = (m_renderableType == EGL_OPENGL_ES3_BIT) ? 3 : 2;
+
   CEGLAttributesVec contextAttribs;
-  contextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, 2}});
+  contextAttribs.Add({{EGL_CONTEXT_CLIENT_VERSION, version}});
 
   if (!m_eglContext.CreateContext(contextAttribs))
   {

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -297,7 +297,7 @@ bool CDRMUtils::FindVideoAndGuiPlane(uint32_t format,
   {
     if (output_format.drm != m_gui_plane->GetFormat())
       continue;
-    if (!output_format.alpha)
+    if (output_format.alpha < 8)
     {
       CLog::LogF(LOGWARNING,
                  "GUI plane format {} can not do alpha blending, "

--- a/xbmc/windowing/gbm/drm/DRMUtils.h
+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
@@ -125,8 +125,12 @@ private:
   std::vector<std::unique_ptr<CDRMConnector>> m_connectors;
   std::vector<std::unique_ptr<CDRMEncoder>> m_encoders;
   std::vector<std::unique_ptr<CDRMCrtc>> m_crtcs;
+  // 8-bit formats first: Direct-to-Plane needs full 8-bit alpha for GUI overlay.
+  // 10-bit formats are available for single-plane HDR rendering when requested.
   std::vector<outputformat> m_output_formats = {{DRM_FORMAT_ARGB8888, 8, 8, false, {}},
-                                                {DRM_FORMAT_XRGB8888, 8, 0, false, {}}};
+                                                {DRM_FORMAT_XRGB8888, 8, 0, false, {}},
+                                                {DRM_FORMAT_ARGB2101010, 10, 2, false, {}},
+                                                {DRM_FORMAT_XRGB2101010, 10, 0, false, {}}};
 };
 
 } // namespace GBM


### PR DESCRIPTION
## Description

Enable 10-bit GUI framebuffer support on top of #27402 (dynamic plane selection for DRM). This is functionally the same PR as #28006 which depends on master where DRM plane setup is done at Kodi startup.

Add ARGB2101010 and XRGB2101010 entries to m_output_formats so InitWindowSystemEGL selects a 10-bit EGL config when the hardware supports it. 10-bit entries are tried first; the existing 8-bit entries provide automatic fallback. Request EGL_OPENGL_ES3_BIT for 10-bit texture support, with fallback to ES2 for  drivers without GLES 3.0 (e.g. lima).

Fix the alpha check in FindVideoAndGuiPlane(): the existing !gui_format.alpha test is incorrect for ARGB2101010 which has alpha=2. Since 2 is truthy, it passes the check and allows Direct-to-Plane compositing with only 2-bit alpha, causing severe GUI banding on the overlay. Changed to gui_format.alpha < 8 to require full 8-bit alpha for hardware compositing.

This is the #27402-native alternative to #28006, which achieves the same result on the current master branch. The dynamic plane architecture in #27402 eliminates the need for settings checks at init time -- FindVideoAndGuiPlane() handles plane re-selection at playback time when Direct-to-Plane activates.

This enables true 10bit video for EGL single-plane rendering and should be combined with #28012 and #28029 for proper HDR support.

**10-bit Software Decode Support**: Added `GetRenderFormats` override to `CProcessInfoGBM`, fixing a longstanding gap where GBM was the only platform that never advertised >8-bit pixel format support. Previously, ffmpeg silently downconverted all 10-bit software decoded content to 8-bit before reaching the renderer. Now advertises YUV420P 9/10/12/14/16-bit and NV12 formats, matching X11/Wayland/Windows/macOS. For GLES, adds GL_R16_EXT texture support (via GL_EXT_texture_norm16 runtime check) with a new XBMC_YV12_HI shader path for >8-bit three-plane sampling. 

## Motivation and context

  - Enables true 10-bit EGL output for single-plane GBM renderers (VAAPI+GLES, DRMPRIMEGLES)
  - Prerequisite for FBO-based HDR GUI compositing (#28012)
  - Fixes a latent bug in #27402 where 2-bit alpha formats could be used for Direct-to-Plane GUI compositing
  - Depends on #27402

## How has this been tested?

Tested on Intel NUC (i3-8109U, Coffee Lake GT3e) with GBM+GLES output over HDMI 2.0 (LSPCON DP-to-HDMI). Verified:
  - 10-bit EGL config selected (XR30, INTEL_Y_TILED) on DRM primary plane
  - System Info screen shows "XR30 INTEL_Y_TILED"
  - FindGuiPlane correctly matches format and modifier after surface creation
  - GLES3 init succeeds; GLES2 fallback path confirmed by testing with modified code
  - 8-bit fallback works when 10-bit entries are removed from m_gui_formats

No RPi5 or Amlogic hardware available for Direct-to-Plane testing of the alpha check fix.

## What is the effect on users?

On hardware with 10-bit plane support, the GUI framebuffer is upgraded from 8-bit to 10-bit, reducing banding in gradients and enabling full-depth output for HDR passthrough. No user-visible change on hardware without 10-bit support (automatic fallback). No new settings.

Risks

  - Lima (Mali 400/450) devices fall back to GLES2, which has been the default until now -- no regression
  - The alpha check change only affects formats with alpha < 8, which only exist in the newly added 10-bit entries -- no change for existing 8-bit formats

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
