### PR TITLE
Fix 28022 & update legacy doxygen info

### DIFF
--- a/xbmc/interfaces/builtins/WeatherBuiltins.cpp
+++ b/xbmc/interfaces/builtins/WeatherBuiltins.cpp
@@ -71,8 +71,8 @@ static int SwitchLocation(const std::vector<std::string>& params)
 ///   \table_row2_l{
 ///     <b>`Weather.LocationSet`</b>
 ///     ,
-///     Switch to given weather location (parameter can be 1-3).
-///     @param[in] parameter             1-3
+///     Switch to given weather location (parameter can be 1-N where N is the number of configured locations).
+///     @param[in] parameter             1-N
 ///   }
 /// \table_end
 ///
@@ -80,9 +80,11 @@ static int SwitchLocation(const std::vector<std::string>& params)
 CBuiltins::CommandMap CWeatherBuiltins::GetOperations() const
 {
   return {
-           {"weather.refresh",          {"Force weather data refresh", 0, SwitchLocation<0>}},
-           {"weather.locationnext",     {"Switch to next weather location", 0, SwitchLocation<1>}},
-           {"weather.locationprevious", {"Switch to previous weather location", 0, SwitchLocation<-1>}},
-           {"weather.locationset",      {"Switch to given weather location (parameter can be 1-3)", 1, SetLocation}}
-         };
+      {"weather.refresh", {"Force weather data refresh", 0, SwitchLocation<0>}},
+      {"weather.locationnext", {"Switch to next weather location", 0, SwitchLocation<1>}},
+      {"weather.locationprevious", {"Switch to previous weather location", 0, SwitchLocation<-1>}},
+      {"weather.locationset",
+       {"Switch to given weather location (parameter can be 1-N where N is the number of "
+        "configured locations)",
+        1, SetLocation}}};
 }

--- a/xbmc/weather/GUIWindowWeather.cpp
+++ b/xbmc/weather/GUIWindowWeather.cpp
@@ -104,11 +104,11 @@ bool CGUIWindowWeather::OnMessage(CGUIMessage& message)
     {
       if (message.GetSenderId() == 0 && m_maxLocation > 0) //handle only message from builtin
       {
-        // Clamp location between 1 and m_maxLocation
+        // Clamp location between 1 and m_maxLocation & cast maxLoc to avoid signed modulo with unsigned type
+        // maxLoc is added before the modulo operation to ensure non-negative operands, for correct wrapping behavior
         const CWeatherManager& wmgr{CServiceBroker::GetWeatherManager()};
-        int v = (wmgr.GetLocation() + message.GetParam1() - 1) % m_maxLocation + 1;
-        if (v < 1)
-          v += m_maxLocation;
+        const int maxLoc{static_cast<int>(m_maxLocation)};
+        int v = (wmgr.GetLocation() + message.GetParam1() - 1 + maxLoc) % maxLoc + 1;
         SetLocation(v);
         return true;
       }


### PR DESCRIPTION
## Description
Fixes #28022 issue with Weather `LocationPrevious` and >3 locations & updates the incorrect legacy doxygen info

## Motivation and context
As above

## How has this been tested?
Compiled & tested on Ubuntu 24.04 with my addon (with pending updates from: https://github.com/xbmc/repo-scripts/pull/2807)

## What is the effect on users?
Fixes UI Bug, accurate documentation

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
