### PR TITLE
[Video] Let mkv video tag loader pass the correct url to the scraper

### DIFF
--- a/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
+++ b/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
@@ -212,8 +212,13 @@ CInfoScanner::InfoType CVideoTagLoaderFFmpeg::LoadMKV(CVideoInfoTag& tag,
     {
       CNfoFile nfo;
       nfo.Create(avtag->value, m_info);
-      m_url = nfo.ScraperUrl();
-      return CInfoScanner::InfoType::URL;
+      CScraperUrl m_url_new = nfo.ScraperUrl();
+      // Try other tags if the scraper wont use the url:
+      if (m_url_new.HasUrls())
+      {
+        m_url = m_url_new;
+        return CInfoScanner::InfoType::URL;
+      }
     }
     else if (StringUtils::CompareNoCase(avtag->key, "title") == 0)
       tag.SetTitle(avtag->value);

--- a/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
+++ b/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
@@ -53,8 +53,8 @@ std::string filenameToType(std::string_view filename)
 CVideoTagLoaderFFmpeg::CVideoTagLoaderFFmpeg(const CFileItem& item,
                                              const ADDON::ScraperPtr& info,
                                              bool lookInFolder)
-  : IVideoInfoTagLoader(item, info, lookInFolder)
-  , m_info(info)
+  : IVideoInfoTagLoader(item, info, lookInFolder),
+    m_info(info)
 {
   std::string filename =
       item.IsStack() ? CStackDirectory::GetFirstStackedFile(item.GetPath()) : item.GetPath();
@@ -71,9 +71,8 @@ CVideoTagLoaderFFmpeg::CVideoTagLoaderFFmpeg(const CFileItem& item,
   int blockSize = m_file->GetChunkSize();
   int bufferSize = blockSize > 1 ? blockSize : 4096;
   uint8_t* buffer = (uint8_t*)av_malloc(bufferSize);
-  m_ioctx = avio_alloc_context(buffer, bufferSize, 0,
-                               m_file, vfs_file_read, nullptr,
-                               vfs_file_seek);
+  m_ioctx =
+      avio_alloc_context(buffer, bufferSize, 0, m_file, vfs_file_read, nullptr, vfs_file_seek);
 
   m_fctx = avformat_alloc_context();
   m_fctx->pb = m_ioctx;
@@ -111,12 +110,12 @@ bool CVideoTagLoaderFFmpeg::HasInfo() const
   {
     const AVDictionaryEntry* avtag =
         av_dict_get(m_fctx->streams[i]->metadata, "filename", nullptr, AV_DICT_IGNORE_SUFFIX);
-    if (avtag && strcmp(avtag->value,"kodi-metadata") == 0)
+    if (avtag && strcmp(avtag->value, "kodi-metadata") == 0)
     {
       m_metadata_stream = i;
       return true;
     }
-    else if (avtag && strcmp(avtag->value,"kodi-override-metadata") == 0)
+    else if (avtag && strcmp(avtag->value, "kodi-override-metadata") == 0)
     {
       m_metadata_stream = i;
       m_override_data = true;
@@ -129,7 +128,8 @@ bool CVideoTagLoaderFFmpeg::HasInfo() const
     return av_dict_get(m_fctx->metadata, "IMDBURL", nullptr, AV_DICT_IGNORE_SUFFIX) ||
            av_dict_get(m_fctx->metadata, "TMDBURL", nullptr, AV_DICT_IGNORE_SUFFIX) ||
            av_dict_get(m_fctx->metadata, "TITLE", nullptr, AV_DICT_IGNORE_SUFFIX);
-  } else if (m_item.IsType(".mp4") || m_item.IsType(".avi"))
+  }
+  else if (m_item.IsType(".mp4") || m_item.IsType(".avi"))
     return av_dict_get(m_fctx->metadata, "title", nullptr, AV_DICT_IGNORE_SUFFIX);
   else
     return false;
@@ -245,7 +245,7 @@ CInfoScanner::InfoType CVideoTagLoaderFFmpeg::LoadMP4(CVideoInfoTag& tag,
       tag.SetWritingCredits(StringUtils::Split(avtag->value, " / "));
     else if (strcmp(avtag->key, "genre") == 0)
       tag.SetGenre(StringUtils::Split(avtag->value, " / "));
-    else if (strcmp(avtag->key,"date") == 0)
+    else if (strcmp(avtag->key, "date") == 0)
       tag.SetYear(atoi(avtag->value));
     else if (strcmp(avtag->key, "description") == 0)
     {
@@ -290,7 +290,7 @@ CInfoScanner::InfoType CVideoTagLoaderFFmpeg::LoadAVI(CVideoInfoTag& tag,
   {
     if (strcmp(avtag->key, "title") == 0)
       tag.SetTitle(avtag->value);
-    else if (strcmp(avtag->key,"date") == 0)
+    else if (strcmp(avtag->key, "date") == 0)
       tag.SetYear(atoi(avtag->value));
   }
 

--- a/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
+++ b/xbmc/video/tags/VideoTagLoaderFFmpeg.cpp
@@ -204,7 +204,7 @@ CInfoScanner::InfoType CVideoTagLoaderFFmpeg::LoadMKV(CVideoInfoTag& tag,
   }
 
   AVDictionaryEntry* avtag = nullptr;
-  bool hastag = false;
+  bool hasTitle = false;
   while ((avtag = av_dict_get(m_fctx->metadata, "", avtag, AV_DICT_IGNORE_SUFFIX)))
   {
     if (StringUtils::CompareNoCase(avtag->key, "imdburl") == 0 ||
@@ -212,22 +212,25 @@ CInfoScanner::InfoType CVideoTagLoaderFFmpeg::LoadMKV(CVideoInfoTag& tag,
     {
       CNfoFile nfo;
       nfo.Create(avtag->value, m_info);
-      m_url = nfo.ScraperUrl();
-      return CInfoScanner::InfoType::URL;
+      // Try other tags if the scraper wont use the url:
+      if (nfo.ScraperUrl().HasUrls())
+      {
+        m_url = nfo.ScraperUrl();
+        return CInfoScanner::InfoType::URL;
+      }
     }
     else if (StringUtils::CompareNoCase(avtag->key, "title") == 0)
-      tag.SetTitle(avtag->value);
-    else if (StringUtils::CompareNoCase(avtag->key, "director") == 0)
     {
-      std::vector<std::string> dirs = StringUtils::Split(avtag->value, " / ");
-      tag.SetDirector(dirs);
+      tag.SetTitle(avtag->value);
+      hasTitle = true;
     }
+    else if (StringUtils::CompareNoCase(avtag->key, "director") == 0)
+      tag.SetDirector(StringUtils::Split(avtag->value, " / "));
     else if (StringUtils::CompareNoCase(avtag->key, "date_released") == 0)
       tag.SetYear(atoi(avtag->value));
-    hastag = true;
   }
 
-  return hastag ? CInfoScanner::InfoType::TITLE : CInfoScanner::InfoType::NONE;
+  return hasTitle ? CInfoScanner::InfoType::TITLE : CInfoScanner::InfoType::NONE;
 }
 
 // https://wiki.multimedia.cx/index.php/FFmpeg_Metadata


### PR DESCRIPTION
## Description
This change will improve the interplay between the scraper and the mkv video tag loader.

`VideoTagLoaderFFmpeg::LoadMKV` should now pass the correct scraper url to the scraper if
more than one url is available.

## Motivation and context

In a situation where a mkv has both `IMDBURL` and `TMDBURL` tags and the scraper is e.g.
`metadata.themoviedb.org.python`, `LoadMKV`  will only consider the first of both tags it
finds. If it is `IMDBURL`, the scraper will not use it and fall back to title lookup,
even though `TMDBURL` would be available.
With this change, `LoadMKV` will continue if the scraper cannot use `IMDBURL` / `TMDBURL`.


## How has this been tested?
* set `<setting id="myvideos.usetags">true</setting>` in `~/.kodi/userdata/guisettings.xml`
* Search for new content in a directory containing a mkv tagged with both `IMDBURL` and `TMDBURL` using `metadata.themoviedb.org.python`
* Environment: kodi 21.3 on gentoo, built using the gentoo ebuild

## What is the effect on users?
Users with a video library containing mkv s with url tags will get a better library scanning experience.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
