### PR TITLE
Fix bad interaction of MySQL client lib with MariaDB 10.x remote databases

### DIFF
--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -41,27 +41,28 @@ bool CDatabaseManager::Initialize()
 {
   std::unique_lock lock(m_section);
 
+  if (m_initialized)
+    return false;
+
   const bool rc = InitializeInternal();
 
   m_bIsUpgrading = false;
   m_connecting = false;
+  m_initialized = true;
 
   return rc;
 }
 
 bool CDatabaseManager::InitializeInternal()
 {
-  m_dbStatus.clear();
-
   CLog::LogF(LOGDEBUG, "updating databases...");
 
   const std::shared_ptr<CAdvancedSettings> advancedSettings =
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
 
+  // NOTE: CAddonDatabase initialized in the constructor
   // NOTE: Order here is important. In particular, CTextureDatabase has to be updated
   //       before CVideoDatabase.
-  if (ADDON::CAddonDatabase db; !UpdateDatabase(db))
-    return false;
   if (CViewDatabase db; !UpdateDatabase(db))
     return false;
   if (CTextureDatabase db; !UpdateDatabase(db))

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <mutex>
+#include <stdexcept>
 
 using namespace PVR;
 
@@ -30,7 +31,8 @@ CDatabaseManager::CDatabaseManager() :
 {
   // Initialize the addon database (must be before the addon manager is init'd)
   ADDON::CAddonDatabase db;
-  UpdateDatabase(db);
+  if (!UpdateDatabase(db))
+    throw std::runtime_error("unable to initialize the Add-On database");
 }
 
 CDatabaseManager::~CDatabaseManager() = default;
@@ -39,32 +41,42 @@ bool CDatabaseManager::Initialize()
 {
   std::unique_lock lock(m_section);
 
-  m_dbStatus.clear();
-
-  CLog::Log(LOGDEBUG, "{}, updating databases...", __FUNCTION__);
-
-  const std::shared_ptr<CAdvancedSettings> advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
-
-  // NOTE: Order here is important. In particular, CTextureDatabase has to be updated
-  //       before CVideoDatabase.
-  {
-    ADDON::CAddonDatabase db;
-    UpdateDatabase(db);
-  }
-  { CViewDatabase db; UpdateDatabase(db); }
-  { CTextureDatabase db; UpdateDatabase(db); }
-  { CMusicDatabase db; UpdateDatabase(db, &advancedSettings->m_databaseMusic); }
-  { CVideoDatabase db; UpdateDatabase(db, &advancedSettings->m_databaseVideo); }
-  { CPVRDatabase db; UpdateDatabase(db, &advancedSettings->m_databaseTV); }
-  { CPVREpgDatabase db; UpdateDatabase(db, &advancedSettings->m_databaseEpg); }
-
-  CLog::Log(LOGDEBUG, "{}, updating databases... DONE", __FUNCTION__);
+  const bool rc = InitializeInternal();
 
   m_bIsUpgrading = false;
   m_connecting = false;
 
-  return std::ranges::all_of(m_dbStatus,
-                             [](const auto& db) { return db.second == DBStatus::READY; });
+  return rc;
+}
+
+bool CDatabaseManager::InitializeInternal()
+{
+  m_dbStatus.clear();
+
+  CLog::LogF(LOGDEBUG, "updating databases...");
+
+  const std::shared_ptr<CAdvancedSettings> advancedSettings =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+
+  // NOTE: Order here is important. In particular, CTextureDatabase has to be updated
+  //       before CVideoDatabase.
+  if (ADDON::CAddonDatabase db; !UpdateDatabase(db))
+    return false;
+  if (CViewDatabase db; !UpdateDatabase(db))
+    return false;
+  if (CTextureDatabase db; !UpdateDatabase(db))
+    return false;
+  if (CMusicDatabase db; !UpdateDatabase(db, &advancedSettings->m_databaseMusic))
+    return false;
+  if (CVideoDatabase db; !UpdateDatabase(db, &advancedSettings->m_databaseVideo))
+    return false;
+  if (CPVRDatabase db; !UpdateDatabase(db, &advancedSettings->m_databaseTV))
+    return false;
+  if (CPVREpgDatabase db; !UpdateDatabase(db, &advancedSettings->m_databaseEpg))
+    return false;
+
+  CLog::LogF(LOGDEBUG, "updating databases... DONE");
+  return true;
 }
 
 bool CDatabaseManager::CanOpen(const std::string &name)
@@ -76,14 +88,16 @@ bool CDatabaseManager::CanOpen(const std::string &name)
   return false; // db isn't even attempted to update yet
 }
 
-void CDatabaseManager::UpdateDatabase(CDatabase &db, DatabaseSettings *settings)
+bool CDatabaseManager::UpdateDatabase(CDatabase& db, DatabaseSettings* settings)
 {
-  std::string name = db.GetBaseDBName();
+  const std::string name = db.GetBaseDBName();
   UpdateStatus(name, DBStatus::UPDATING);
-  if (Update(db, settings ? *settings : DatabaseSettings()))
+  const bool rc = Update(db, settings ? *settings : DatabaseSettings());
+  if (rc)
     UpdateStatus(name, DBStatus::READY);
   else
     UpdateStatus(name, DBStatus::FAILED);
+  return rc;
 }
 
 bool CDatabaseManager::Update(CDatabase &db, const DatabaseSettings &settings)

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -65,6 +65,7 @@ public:
 private:
   std::atomic<bool> m_bIsUpgrading;
   std::atomic<bool> m_connecting{false};
+  bool m_initialized{false};
 
   enum class DBStatus
   {

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -74,9 +74,10 @@ private:
     FAILED
   };
   void UpdateStatus(const std::string& name, DBStatus status);
-  void UpdateDatabase(CDatabase &db, DatabaseSettings *settings = NULL);
+  bool UpdateDatabase(CDatabase& db, DatabaseSettings* settings = nullptr);
   bool Update(CDatabase &db, const DatabaseSettings &settings);
   bool UpdateVersion(CDatabase &db, const std::string &dbName);
+  bool InitializeInternal();
 
   CCriticalSection            m_section;     ///< Critical section protecting m_dbStatus.
   std::map<std::string, DBStatus> m_dbStatus; ///< Our database status map.

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -126,7 +126,15 @@ bool CServiceManager::InitStageOne()
 bool CServiceManager::InitStageTwo(const std::string& profilesUserDataFolder)
 {
   // Initialize the addon database (must be before the addon manager is init'd)
-  m_databaseManager = std::make_unique<CDatabaseManager>();
+  try
+  {
+    m_databaseManager = std::make_unique<CDatabaseManager>();
+  }
+  catch (...)
+  {
+    CLog::Log(LOGFATAL, "CServiceManager::{}: Unable to start CDatabaseManager", __FUNCTION__);
+    return false;
+  }
 
   m_binaryAddonManager = std::make_unique<
       ADDON::

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <charconv>
 #include <chrono>
 #include <cstdlib>
 #include <string>
@@ -44,11 +45,42 @@ constexpr int ER_BAD_DB_ERROR = 1049;
 constexpr std::string_view SQL_CHARSET_COLLATION =
     "CHARACTER SET " DEF_CHARSET " COLLATE " DEF_COLLATION;
 
+// MariaDB 10.x version number prefix hack to trick MySQL 5.5 replication slaves into working
+// see https://jira.mariadb.org/browse/MDEV-4088
+constexpr std::string_view MARIADB_10_HACK_PREFIX = "5.5.5-";
+
 // Minimum MySQL and MariaDB versions required for the default large index size needed by utf8mb4
-constexpr unsigned long MIN_MYSQL = 50709;
 constexpr std::string_view MIN_MYSQL_STR = "5.7.9";
-constexpr unsigned long MIN_MARIADB = 100205;
 constexpr std::string_view MIN_MARIADB_STR = "10.2.5";
+
+struct MySQLDbVersion
+{
+  auto operator<=>(const MySQLDbVersion& other) const = default;
+
+  // the field order is important for the compiler-generated comparison operators
+  unsigned int m_major{0};
+  unsigned int m_minor{0};
+  unsigned int m_patch{0};
+};
+
+MySQLDbVersion VersionNumber(std::string_view str)
+{
+  // Expected format: xx.yy.zz
+  MySQLDbVersion version;
+  const char* end{str.data() + str.size()};
+
+  auto res = std::from_chars(str.data(), end, version.m_major);
+  if (res.ec != std::errc{} || res.ptr == end)
+    return version;
+
+  res = std::from_chars(res.ptr + 1, end, version.m_minor);
+  if (res.ec != std::errc{} || res.ptr == end)
+    return version;
+
+  res = std::from_chars(res.ptr + 1, end, version.m_patch);
+
+  return version;
+}
 
 /*!
  * \brief Validation of unquoted identifiers
@@ -227,22 +259,33 @@ int MysqlDatabase::connect(bool create_new)
       static bool showed_ver_info = false;
       if (!showed_ver_info)
       {
-        const std::string version_string = mysql_get_server_info(conn);
-        CLog::Log(LOGINFO, "MYSQL: Connected to version {}", version_string);
+        CLog::Log(LOGINFO, "MYSQL: client library {}", mysql_get_client_info());
+
+        std::string versionString = mysql_get_server_info(conn);
+        CLog::Log(LOGINFO, "MYSQL: Connected to version {}", versionString);
         showed_ver_info = true;
 
-        const unsigned long version = mysql_get_server_version(conn);
-        const unsigned long minVersion =
-            version_string.find("MariaDB") != std::string::npos ? MIN_MARIADB : MIN_MYSQL;
+        // Undo MariaDB 10.x version string hack - remove the prefix
+        if (versionString.starts_with(MARIADB_10_HACK_PREFIX))
+          versionString = versionString.substr(MARIADB_10_HACK_PREFIX.size());
+
+        const MySQLDbVersion version = VersionNumber(versionString);
+
+        CLog::LogF(LOGDEBUG, "server version interpreted as {}.{}.{}", version.m_major,
+                   version.m_minor, version.m_patch);
+
+        const std::string_view minVersionString =
+            versionString.find("MariaDB") != std::string::npos ? MIN_MARIADB_STR : MIN_MYSQL_STR;
+        const MySQLDbVersion minVersion = VersionNumber(minVersionString);
 
         if (version < minVersion)
         {
           CLog::Log(LOGERROR,
                     "MYSQL: Your database server version {} is very old. Kodi requires at least "
                     "MySQL {} or MariaDB {}.",
-                    version_string, MIN_MYSQL_STR, MIN_MARIADB_STR);
+                    versionString, MIN_MYSQL_STR, MIN_MARIADB_STR);
 
-          throw DbErrors("database server version %s too old", version_string.c_str());
+          throw DbErrors("database server version %s is too old", versionString.c_str());
         }
       }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

- First issue:

MariaDB 10.x servers sends version number strings similar to this as part of the connection handshake:
5.5.5-10.11.16-MariaDB-ubu2204

The MySQL client library doesn't have the logic to interpret those strings and mysql_get_server_version() reports version 5.5.5 -- too old for Kodi

Solution: strip off the 5.5.5- prefix and parse in Kodi to avoid mysql client library issues.

I think it's OK to remove the fixed prefix instead a more complicated solution involving parsing, because the official MariaDB client library does the same (see mariadb_lib.c)

Alternatively we could say that the MariaDB client library has to be used when connecting to a MariaDB server, but that wouldn't be very user-friendly.

- Second issue:

Kodi only checks the version of the first remote db server connection > this is wrong. Ideally should check each remote db server once (different name and/or port), but it's complicated with the current code. 99% of users have all their remote databases on the same db server and it would be expensive and unnecessary to check db server version for every connection > no fix here, leaving as is.

Kodi continued database initialization (and migrations) regardless of prior errors when starting up.
Since the server version is checked only once, the first db fails, but the check is skipped for the second db > migrated, though it shouldn't be (features missing in the old db version may be used)
Solution: better propagation of the failures in DatabaseManager and stop the initialization process after the first error.

- Bonus: CAddonDatabase was initialized twice, residue from earlier times when CDatabaseManager had Initialize and DeInitialize methods. Nowadays the AddonDB is initialized in the constructor before the other databases and there is no DeInitialize(), so no need to ever re-initialize.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fix #28027

Two-part issue:
- MariaDB 10.x servers add the prefix 5.5.5- to the reported version number, which is not interpreted correctly on systems using the mysql client library instead of mariadb client library.

- Databases initialization / migration continues after a failure due to old version detection, eventually Kodi exits in error

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No ability to test with the mysql client library on Windows, so tested by hardcoding some raw version strings.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

MariaDB 10.x works even with MySQL client library.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
