### PR TITLE
[application] Fix building without libbluray

### DIFF
--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -16,7 +16,9 @@
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
 #include "application/ApplicationStackHelper.h"
+#ifdef HAVE_LIBBLURAY
 #include "filesystem/BlurayDirectory.h"
+#endif
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
@@ -116,6 +118,7 @@ void CApplicationPlayerCallback::OnPlayBackStarted(const CFileItem& file)
 
 namespace
 {
+#ifdef HAVE_LIBBLURAY
 void UpdateRemovableBlurayPath(CFileItem& fileItem, bool updateStreamDetails)
 {
   if (fileItem.HasVideoInfoTag())
@@ -169,6 +172,7 @@ void UpdateRemovableBlurayPath(CFileItem& fileItem, bool updateStreamDetails)
     }
   }
 }
+#endif
 
 bool WithinPercentOfEnd(const CBookmark& bookmark, float ignorePercentAtEnd)
 {


### PR DESCRIPTION
## Description
This adds `#ifdef HAVE_LIBBLURAY` where necessary to build without libbluray. The call to `UpdateRemovableBlurayPath` is already gated like this.

## Motivation and context
It's supposed to be possible to build without libbluray. This currently fails, presumably since 623de78a287a7479be19309e03863a0d3621c81b.

## How has this been tested?
I've built Kodi without libbluray and had a quick click around. I'm not sure exactly when this code would be triggered.

## What is the effect on users?
None beyond not needing libbluray.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
