### PR TITLE
[cmake] FindBrotli add encoder target

### DIFF
--- a/cmake/modules/FindBrotli.cmake
+++ b/cmake/modules/FindBrotli.cmake
@@ -6,6 +6,9 @@
 # This will define the following target ALIAS:
 #
 #   LIBRARY::Brotli   - The Brotli library
+#   LIBRARY::brotlidec   - The Brotli decoder library
+#   LIBRARY::brotlienc   - The Brotli encoder library
+#   LIBRARY::brotlicommon   - The Brotli common library
 #
 
 if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
@@ -29,10 +32,11 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
     endif()
 
     set(BROTLICOMMON_LIBRARY_RELEASE "${DEP_LOCATION}/lib/${_PREFIX}brotlicommon.${_LIBEXT}")
+    set(BROTLIENC_LIBRARY_RELEASE "${DEP_LOCATION}/lib/${_PREFIX}brotlienc.${_LIBEXT}")
 
-    # Brotli creates two byproducts of relevance. set BUILD_BYPRODUCTS to be both
-    # brotlicommon and brotlidec. This has to occur before BUILD_DEP_TARGET
+    # Brotli byproducts
     set(BUILD_BYPRODUCTS ${BROTLICOMMON_LIBRARY_RELEASE}
+                         ${BROTLIENC_LIBRARY_RELEASE}
                          ${DEP_LOCATION}/lib/${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BYPRODUCT})
 
     BUILD_DEP_TARGET()
@@ -66,6 +70,7 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
       if(TARGET PkgConfig::brotlicommon)
         set(brotli_VERSION ${brotlicommon_VERSION})
         pkg_check_modules(brotlidec libbrotlidec${PC_${CMAKE_FIND_PACKAGE_NAME}_FIND_SPEC} ${SEARCH_QUIET} IMPORTED_TARGET)
+        pkg_check_modules(brotlienc libbrotlienc${PC_${CMAKE_FIND_PACKAGE_NAME}_FIND_SPEC} ${SEARCH_QUIET} IMPORTED_TARGET)
 
         if(TARGET PkgConfig::brotlidec)
           set(${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_FOUND 1)
@@ -89,8 +94,13 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
   if(${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_FOUND)
     if((TARGET brotli::brotlicommon AND TARGET brotli::brotlidec) AND NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
       add_library(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ALIAS brotli::brotlidec)
+      add_library(LIBRARY::brotlienc ALIAS brotli::brotlienc)
     elseif((TARGET PkgConfig::brotlicommon AND TARGET PkgConfig::brotlidec) AND NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
       add_library(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ALIAS PkgConfig::brotlidec)
+
+      if(TARGET PkgConfig::brotlienc)
+        add_library(LIBRARY::brotlienc ALIAS PkgConfig::brotlienc)
+      endif()
     else()
       add_library(LIBRARY::brotlicommon UNKNOWN IMPORTED)
       set_target_properties(LIBRARY::brotlicommon PROPERTIES
@@ -100,6 +110,12 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
       add_library(LIBRARY::brotlidec UNKNOWN IMPORTED)
       set_target_properties(LIBRARY::brotlidec PROPERTIES
                                                IMPORTED_LOCATION "${BROTLIDEC_LIBRARY_RELEASE}"
+                                               INTERFACE_LINK_LIBRARIES LIBRARY::brotlicommon
+                                               INTERFACE_INCLUDE_DIRECTORIES "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR}")
+
+      add_library(LIBRARY::brotlienc UNKNOWN IMPORTED)
+      set_target_properties(LIBRARY::brotlienc PROPERTIES
+                                               IMPORTED_LOCATION "${BROTLIENC_LIBRARY_RELEASE}"
                                                INTERFACE_LINK_LIBRARIES LIBRARY::brotlicommon
                                                INTERFACE_INCLUDE_DIRECTORIES "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR}")
   


### PR DESCRIPTION
## Description
Brotli lib is always made up of 3 targets/libs. Flesh out the one we didnt use for completeness

## Motivation and context
Part of https://github.com/xbmc/xbmc/pull/28014, but also just completes the library

## How has this been tested?
https://github.com/xbmc/xbmc/pull/28014

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
