### PR TITLE
[cmake] FindFFMPEG enable windows BUILDMODE to allow cleaning

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -60,9 +60,13 @@ macro(buildFFMPEG)
     set(msys_env MSYS2_PATH_TYPE=inherit
                  MSYS_INSTALL_PATH=${MSYS_INSTALL_PATH})
 
-    # Todo: buildmode?
     set(PROMPTLEVEL noprompt)
-    set(BUILDMODE noclean)
+
+    if(FFMPEG_DEP_BUILD)
+      set(BUILDMODE clean)
+    else()
+      set(BUILDMODE noclean)
+    endif()
 
     set(build32 no)
     set(build64 no)


### PR DESCRIPTION
## Description
If a lib dependency check requests a rebuild for FFMPEG, enable BUILDMODE to clean the msys2 workspace and force a rebuild

## Motivation and context
If we add further third party libs to ffmpeg, our msys2 system for windows is less capable to understand when a rebuild is required. Use the BUILDMODE to force a clean of the ffmpeg build in msys

## How has this been tested?
Part of https://github.com/xbmc/xbmc/pull/28014

## What is the effect on users?
n/a

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
