### PR TITLE
[Android] Reduce calls to the display mode change API

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -718,16 +718,20 @@ void CXBMCApp::SetDisplayModeCallback(void* modeVariant)
 void CXBMCApp::SetDisplayMode(int mode, float rate)
 {
   if (mode < 1.0)
+  {
+    CLog::LogF(LOGDEBUG, "Invalid mode: {}", mode);
     return;
-
+  }
   CJNIWindow window = getWindow();
   if (window)
   {
     CJNIWindowManagerLayoutParams params = window.getAttributes();
     if (params.getpreferredDisplayModeId() == mode)
+    {
+      CLog::LogF(LOGDEBUG, "Requested mode and preferred mode match");
       return;
+    }
   }
-
   m_displayChangeEvent.Reset();
 
   if (m_hdmiSource)

--- a/xbmc/windowing/android/AndroidUtils.cpp
+++ b/xbmc/windowing/android/AndroidUtils.cpp
@@ -181,7 +181,14 @@ bool CAndroidUtils::SetNativeResolution(const RESOLUTION_INFO& res)
   CLog::Log(LOGINFO, "CAndroidUtils: SetNativeResolution: {}: {}x{} {}x{}@{:f}", res.strId,
             res.iWidth, res.iHeight, res.iScreenWidth, res.iScreenHeight, res.fRefreshRate);
 
-  CXBMCApp::Get().SetDisplayMode(std::atoi(res.strId.c_str()), res.fRefreshRate);
+  // Avoid calling the mode-switch API unless the resolution and/or refresh rate changes
+  if (s_res_cur_displayMode.iScreenWidth != res.iScreenWidth ||
+      s_res_cur_displayMode.iScreenHeight != res.iScreenHeight ||
+      std::fabs(s_res_cur_displayMode.fRefreshRate - res.fRefreshRate) > FLT_EPSILON)
+  {
+    CLog::LogF(LOGDEBUG, "request mode: {}", res.strId);
+    CXBMCApp::Get().SetDisplayMode(std::atoi(res.strId.c_str()), res.fRefreshRate);
+  }
   s_res_cur_displayMode = res;
   CXBMCApp::Get().SetBuffersGeometry(res.iWidth, res.iHeight, 0);
 


### PR DESCRIPTION
## Description
Avoid calling the display mode change API when the resolution and refresh rate match the current settings.

## How has this been tested?
Tested on Android TV: When playing videos, the resolution change API is only called when the video resolution or frame rate differs from the current window's settings.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
