### PR TITLE
Game API v5.1.0: Add "autoconnect" property to controller ports

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
@@ -926,6 +926,12 @@ extern "C"
     ///
     bool force_connected;
 
+    /// @brief Flag to auto-connect this port when a game session begins
+    ///
+    /// Set to false to start this port disconnected.
+    ///
+    bool autoconnect;
+
     /// @brief The list of devices that can be connected to the port
     game_input_device* accepted_devices;
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -97,8 +97,8 @@
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_DEPENDS   "c-api/addon-instance/audioencoder.h" \
                                                       "addon-instance/AudioEncoder.h"
 
-#define ADDON_INSTANCE_VERSION_GAME                   "5.0.0"
-#define ADDON_INSTANCE_VERSION_GAME_MIN               "5.0.0"
+#define ADDON_INSTANCE_VERSION_GAME                   "5.1.0"
+#define ADDON_INSTANCE_VERSION_GAME_MIN               "5.1.0"
 #define ADDON_INSTANCE_VERSION_GAME_XML_ID            "kodi.binary.instance.game"
 #define ADDON_INSTANCE_VERSION_GAME_DEPENDS           "addon-instance/Game.h"
 

--- a/xbmc/games/addons/input/GameClientInput.cpp
+++ b/xbmc/games/addons/input/GameClientInput.cpp
@@ -253,7 +253,7 @@ void CGameClientInput::ActivateControllers(CControllerHub& hub)
     if (port.GetCompatibleControllers().empty())
       continue;
 
-    port.SetConnected(true);
+    port.SetConnected(port.IsAutoConnect());
     port.SetActiveController(0);
     for (auto& controller : port.GetCompatibleControllers())
       ActivateControllers(controller.GetHub());

--- a/xbmc/games/addons/input/GameClientPort.cpp
+++ b/xbmc/games/addons/input/GameClientPort.cpp
@@ -23,7 +23,8 @@ using namespace GAME;
 CGameClientPort::CGameClientPort(const game_input_port& port)
   : m_type(CGameClientTranslator::TranslatePortType(port.type)),
     m_portId(port.port_id ? port.port_id : ""),
-    m_forceConnected(port.force_connected)
+    m_forceConnected(port.force_connected),
+    m_autoConnect(port.autoconnect)
 {
   if (port.accepted_devices != nullptr)
   {
@@ -49,7 +50,8 @@ CGameClientPort::CGameClientPort(const game_input_port& logicalPort,
                                  const CPhysicalPort& physicalPort)
   : m_type(PORT_TYPE::CONTROLLER),
     m_portId(physicalPort.ID()),
-    m_forceConnected(logicalPort.force_connected)
+    m_forceConnected(logicalPort.force_connected),
+    m_autoConnect(logicalPort.autoconnect)
 {
   if (logicalPort.accepted_devices != nullptr)
   {

--- a/xbmc/games/addons/input/GameClientPort.h
+++ b/xbmc/games/addons/input/GameClientPort.h
@@ -90,6 +90,11 @@ public:
   bool ForceConnected() const { return m_forceConnected; }
 
   /*!
+   * \brief True if a controller should be connected automatically on startup
+   */
+  bool AutoConnect() const { return m_autoConnect; }
+
+  /*!
    * \brief Get the list of devices accepted by this port
    */
   const GameClientDeviceVec& Devices() const { return m_acceptedDevices; }
@@ -98,6 +103,7 @@ private:
   PORT_TYPE m_type;
   std::string m_portId;
   bool m_forceConnected{false};
+  bool m_autoConnect{true};
   GameClientDeviceVec m_acceptedDevices;
 };
 } // namespace GAME

--- a/xbmc/games/addons/input/GameClientTopology.cpp
+++ b/xbmc/games/addons/input/GameClientTopology.cpp
@@ -79,6 +79,7 @@ CPortNode CGameClientTopology::GetPortNode(const GameClientPortPtr& port,
   portNode.SetPortID(port->ID());
   portNode.SetAddress(portAddress);
   portNode.SetForceConnected(port->ForceConnected());
+  portNode.SetAutoConnect(port->AutoConnect());
 
   ControllerNodeVec nodes;
   for (const GameClientDevicePtr& device : port->Devices())

--- a/xbmc/games/addons/input/test/TestGameClientTopology.cpp
+++ b/xbmc/games/addons/input/test/TestGameClientTopology.cpp
@@ -182,3 +182,31 @@ TEST(TestGameClientTopology, TestMouse)
   EXPECT_EQ(mouseController.first, MOUSE_PORT_ADDRESS);
   EXPECT_EQ(mouseController.second, DEFAULT_MOUSE_ID);
 }
+
+TEST(TestGameClientTopology, GameApiAutoConnect)
+{
+  game_input_port port{};
+  port.type = GAME_PORT_CONTROLLER;
+  port.port_id = DEFAULT_PORT_ID;
+  port.force_connected = false;
+  port.autoconnect = false;
+  port.accepted_devices = nullptr;
+  port.device_count = 0;
+
+  CGameClientPort gameClientPort{port};
+  EXPECT_FALSE(gameClientPort.AutoConnect());
+  EXPECT_FALSE(gameClientPort.ForceConnected());
+
+  // force_connected controls disconnectability, not startup auto-connect
+  port.force_connected = true;
+  CGameClientPort forcedPort{port};
+  EXPECT_TRUE(forcedPort.ForceConnected());
+  EXPECT_FALSE(forcedPort.AutoConnect());
+
+  // autoconnect controls startup connection state
+  port.force_connected = false;
+  port.autoconnect = true;
+  CGameClientPort autoconnectPort{port};
+  EXPECT_FALSE(autoconnectPort.ForceConnected());
+  EXPECT_TRUE(autoconnectPort.AutoConnect());
+}

--- a/xbmc/games/controllers/test/TestControllerDigest.cpp
+++ b/xbmc/games/controllers/test/TestControllerDigest.cpp
@@ -85,6 +85,7 @@ TEST(TestControllerDigest, SimpleTree)
   UTILITY::CDigest manualPort{type};
   manualPort.Update(CControllerTranslator::TranslatePortType(PORT_TYPE::CONTROLLER));
   manualPort.Update("1");
+  manualPort.Update("true");
   manualPort.Update(expectedNodeDigest);
   const std::string expectedPortDigest = manualPort.FinalizeRaw();
   EXPECT_EQ(portDigest, expectedPortDigest);
@@ -156,6 +157,7 @@ TEST(TestControllerDigest, MultiControllerPort)
   UTILITY::CDigest manualPort{type};
   manualPort.Update(CControllerTranslator::TranslatePortType(PORT_TYPE::CONTROLLER));
   manualPort.Update("1");
+  manualPort.Update("true");
   manualPort.Update(expectedNodeDigest1);
   manualPort.Update(expectedNodeDigest2);
   const std::string expectedPortDigest = manualPort.FinalizeRaw();
@@ -235,6 +237,7 @@ TEST(TestControllerDigest, NestedHub)
   UTILITY::CDigest manualPortChild{type};
   manualPortChild.Update(CControllerTranslator::TranslatePortType(PORT_TYPE::CONTROLLER));
   manualPortChild.Update("2");
+  manualPortChild.Update("true");
   manualPortChild.Update(expectedNodeChild);
   const std::string expectedPortChild = manualPortChild.FinalizeRaw();
   EXPECT_EQ(portDigestChild, expectedPortChild);
@@ -253,6 +256,7 @@ TEST(TestControllerDigest, NestedHub)
   UTILITY::CDigest manualPortParent{type};
   manualPortParent.Update(CControllerTranslator::TranslatePortType(PORT_TYPE::CONTROLLER));
   manualPortParent.Update("1");
+  manualPortParent.Update("true");
   manualPortParent.Update(expectedNodeParent);
   const std::string expectedPortParent = manualPortParent.FinalizeRaw();
   EXPECT_EQ(portDigestParent, expectedPortParent);
@@ -261,4 +265,32 @@ TEST(TestControllerDigest, NestedHub)
   manualHubRoot.Update(expectedPortParent);
   const std::string expectedHubRoot = manualHubRoot.FinalizeRaw();
   EXPECT_EQ(hubDigestRoot, expectedHubRoot);
+}
+
+/*!
+ * Verify auto-connect contributes to port digest
+ */
+TEST(TestControllerDigest, PortAutoConnectAffectsDigest)
+{
+  const UTILITY::CDigest::Type type = UTILITY::CDigest::Type::MD5;
+
+  auto addonInfo = std::make_shared<ADDON::CAddonInfo>("game.controller.test",
+                                                       ADDON::AddonType::GAME_CONTROLLER);
+  auto controller = std::make_shared<CController>(addonInfo);
+
+  CControllerNode node;
+  node.SetController(controller);
+
+  CPortNode autoConnectPort;
+  autoConnectPort.SetPortType(PORT_TYPE::CONTROLLER);
+  autoConnectPort.SetPortID("1");
+  autoConnectPort.SetCompatibleControllers({node});
+
+  CPortNode manualConnectPort;
+  manualConnectPort.SetPortType(PORT_TYPE::CONTROLLER);
+  manualConnectPort.SetPortID("1");
+  manualConnectPort.SetAutoConnect(false);
+  manualConnectPort.SetCompatibleControllers({node});
+
+  EXPECT_NE(autoConnectPort.GetDigest(type), manualConnectPort.GetDigest(type));
 }

--- a/xbmc/games/controllers/test/TestControllerTreeXML.cpp
+++ b/xbmc/games/controllers/test/TestControllerTreeXML.cpp
@@ -90,6 +90,48 @@ TEST(TestControllerTreeXML, SerializeSimpleTree)
 }
 
 /*!
+ * Serialize a controller tree port with auto-connect disabled
+ */
+TEST(TestControllerTreeXML, SerializePortAutoConnectFalse)
+{
+  // Load the default controller add-on
+  const ADDON::CAddonMgr& addonManager = CServiceBroker::GetAddonMgr();
+  ADDON::AddonPtr addon;
+  ASSERT_TRUE(addonManager.GetAddon(DEFAULT_CONTROLLER_ID, addon, ADDON::AddonType::GAME_CONTROLLER,
+                                    ADDON::OnlyEnabled::CHOICE_YES));
+  ControllerPtr controller = std::static_pointer_cast<CController>(addon);
+  ASSERT_NE(controller.get(), nullptr);
+
+  // Build the controller node
+  CControllerNode node;
+  node.SetController(controller);
+
+  // Build the port node with auto-connect disabled
+  CPortNode port;
+  port.SetPortType(PORT_TYPE::CONTROLLER);
+  port.SetPortID("1");
+  port.SetAutoConnect(false);
+  port.SetCompatibleControllers({node});
+
+  // Build the hub containing the port
+  CControllerHub hub;
+  hub.SetPorts({port});
+
+  // Serialize to XML
+  CXBMCTinyXML2 doc;
+  auto* root = doc.NewElement("controller");
+  ASSERT_TRUE(hub.Serialize(*root));
+  doc.InsertFirstChild(root);
+
+  tinyxml2::XMLPrinter printer;
+  doc.Print(&printer);
+  std::string xml = printer.CStr();
+
+  // Verify auto-connect is explicitly disabled in output
+  EXPECT_NE(xml.find("autoconnect=\"false\""), std::string::npos);
+}
+
+/*!
  * Deserialize a simple controller tree from XML
  *
  * The XML contains one controller port accepting the default controller.
@@ -117,10 +159,36 @@ TEST(TestControllerTreeXML, DeserializeSimpleTree)
   const CPortNode& port = hub.GetPorts().front();
   EXPECT_EQ(port.GetPortType(), PORT_TYPE::CONTROLLER);
   EXPECT_EQ(port.GetPortID(), "1");
+  EXPECT_TRUE(port.IsAutoConnect());
   ASSERT_EQ(port.GetCompatibleControllers().size(), 1u);
   const CControllerNode& node = port.GetCompatibleControllers().front();
   ASSERT_NE(node.GetController(), nullptr);
   EXPECT_EQ(node.GetController()->ID(), std::string(DEFAULT_CONTROLLER_ID));
+}
+
+/*!
+ * Deserialize a controller tree port with auto-connect disabled
+ */
+TEST(TestControllerTreeXML, DeserializePortAutoConnectFalse)
+{
+  // Build an XML document with autoconnect disabled on a controller port
+  const char* xml = R"(<controller>
+                         <port type="controller" id="1" autoconnect="false">
+                           <accepts controller="game.controller.default"/>
+                         </port>
+                       </controller>)";
+  std::string xmlStr{xml};
+  CXBMCTinyXML2 doc;
+  ASSERT_TRUE(doc.Parse(xmlStr));
+  const tinyxml2::XMLElement* root = doc.RootElement();
+  ASSERT_NE(root, nullptr);
+
+  CControllerHub hub;
+  ASSERT_TRUE(hub.Deserialize(*root));
+
+  ASSERT_EQ(hub.GetPorts().size(), 1u);
+  const CPortNode& port = hub.GetPorts().front();
+  EXPECT_FALSE(port.IsAutoConnect());
 }
 
 /*!

--- a/xbmc/games/ports/types/PortNode.cpp
+++ b/xbmc/games/ports/types/PortNode.cpp
@@ -28,6 +28,7 @@ namespace
 constexpr auto XML_ELM_ACCEPTS = "accepts";
 constexpr auto XML_ATTR_PORT_TYPE = "type";
 constexpr auto XML_ATTR_PORT_ID = "id";
+constexpr auto XML_ATTR_PORT_AUTOCONNECT = "autoconnect";
 } // namespace
 
 CPortNode::~CPortNode() = default;
@@ -42,6 +43,7 @@ CPortNode& CPortNode::operator=(const CPortNode& rhs)
     m_portId = rhs.m_portId;
     m_address = rhs.m_address;
     m_forceConnected = rhs.m_forceConnected;
+    m_autoConnect = rhs.m_autoConnect;
     m_controllers = rhs.m_controllers;
   }
 
@@ -58,6 +60,7 @@ CPortNode& CPortNode::operator=(CPortNode&& rhs) noexcept
     m_portId = std::move(rhs.m_portId);
     m_address = std::move(rhs.m_address);
     m_forceConnected = rhs.m_forceConnected;
+    m_autoConnect = rhs.m_autoConnect;
     m_controllers = std::move(rhs.m_controllers);
   }
 
@@ -232,6 +235,10 @@ bool CPortNode::Serialize(tinyxml2::XMLElement& portElement) const
   // Set the port ID
   portElement.SetAttribute(XML_ATTR_PORT_ID, m_portId.c_str());
 
+  // Set auto-connect state when explicitly disabled
+  if (!m_autoConnect)
+    portElement.SetAttribute(XML_ATTR_PORT_AUTOCONNECT, false);
+
   // Iterate and serialize each controller accepted by this port
   for (const auto& controllerNode : m_controllers)
   {
@@ -291,6 +298,12 @@ bool CPortNode::Deserialize(const tinyxml2::XMLElement& portElement)
     return false;
   }
 
+  // Ports auto-connect by default unless topology opts out
+  bool autoConnect = true;
+  if (portElement.QueryBoolAttribute(XML_ATTR_PORT_AUTOCONNECT, &autoConnect) ==
+      tinyxml2::XML_SUCCESS)
+    m_autoConnect = autoConnect;
+
   // Get first "accepts" element
   const tinyxml2::XMLElement* controllerElement = portElement.FirstChildElement(XML_ELM_ACCEPTS);
   if (controllerElement == nullptr)
@@ -322,6 +335,7 @@ std::string CPortNode::GetDigest(UTILITY::CDigest::Type digestType) const
 
   digest.Update(CControllerTranslator::TranslatePortType(m_portType));
   digest.Update(m_portId);
+  digest.Update(m_autoConnect ? "true" : "false");
 
   for (const CControllerNode& controller : m_controllers)
     digest.Update(controller.GetDigest(digestType));

--- a/xbmc/games/ports/types/PortNode.h
+++ b/xbmc/games/ports/types/PortNode.h
@@ -92,6 +92,12 @@ public:
   void SetForceConnected(bool forceConnected) { m_forceConnected = forceConnected; }
 
   /*!
+   * \brief If true, this port starts connected when a game session begins
+   */
+  bool IsAutoConnect() const { return m_autoConnect; }
+  void SetAutoConnect(bool autoConnect) { m_autoConnect = autoConnect; }
+
+  /*!
    * \brief Return the controller profiles that are compatible with this port
    *
    * \return The controller profiles, or empty if this port doesn't support
@@ -157,6 +163,7 @@ private:
   std::string m_portId;
   std::string m_address;
   bool m_forceConnected{true};
+  bool m_autoConnect{true};
   ControllerNodeVec m_controllers;
 };
 


### PR DESCRIPTION
## Description

@kodiai generate the entire PR for me

Eh, it got this far: Adds `autoconnect` property to Game API v5.1.0 controller ports to control whether ports are connected automatically at game session start.

game.libretro companion: https://github.com/kodi-game/game.libretro/pull/156

## Motivation and context

Required by https://github.com/kodi-game/game.libretro.uae/pull/10, which goes from 4 controller ports to 6, with the last two only accepting a keyboard.

We don't want the keyboard connected by default, we also don't have keyboard input on controller ports, but give the user a way to send the underlying libretro command by swithing to the keyboard.

## Related PRs

PRs for full Amiga input support:

* https://github.com/kodi-game/controller-topology-project/pull/428
* https://github.com/kodi-game/game.libretro/pull/155
* https://github.com/xbmc/xbmc/pull/28046
* https://github.com/kodi-game/game.libretro/pull/156
* https://github.com/kodi-game/game.libretro.uae/pull/10
* https://github.com/xbmc/peripheral.joystick/pull/339

## How has this been tested?

Included in latest test builds: https://github.com/garbear/xbmc/releases/tag/retroplayer-22alpha3-20260317