### PR TITLE
RetroPlayer: Add game metadata infolabels

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4337,14 +4337,99 @@ constexpr std::array<InfoMap, 83> videoplayer = {{
 ///     @skinning_v22 **[New Boolean Condition]** \link RetroPlayer_EmptyTray `RetroPlayer.EmptyTray`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`RetroPlayer.Title`</b>,
+///                  \anchor RetroPlayer_Title
+///                  _string_,
+///     @return The title of the currently-playing game.
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_Title `RetroPlayer.Title`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`RetroPlayer.Platform`</b>,
+///                  \anchor RetroPlayer_Platform
+///                  _string_,
+///     @return The platform of the currently-playing game\, or an empty string
+///     if the platform is unknown.
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_Platform `RetroPlayer.Platform`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`RetroPlayer.Genres`</b>,
+///                  \anchor RetroPlayer_Genres
+///                  _string_,
+///     @return The genres of the currently-playing game\, joined by "\, ".
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_Genres `RetroPlayer.Genres`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`RetroPlayer.Publisher`</b>,
+///                  \anchor RetroPlayer_Publisher
+///                  _string_,
+///     @return The publisher of the currently-playing game (e.g. "Nintendo").
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_Publisher `RetroPlayer.Publisher`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`RetroPlayer.Developer`</b>,
+///                  \anchor RetroPlayer_Developer
+///                  _string_,
+///     @return The developer of the currently-playing game (e.g. "Square").
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_Developer `RetroPlayer.Developer`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`RetroPlayer.Overview`</b>,
+///                  \anchor RetroPlayer_Overview
+///                  _string_,
+///     @return The overview/summary of the currently-playing game.
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_Overview `RetroPlayer.Overview`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`RetroPlayer.GameClient`</b>,
+///                  \anchor RetroPlayer_GameClient
+///                  _string_,
+///     @return The add-on ID of the game client (a.k.a. emulator) used to play the
+///     currently-playing game (e.g. `game.libretro.beetle-psx`).
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_GameClient `RetroPlayer.GameClient`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`RetroPlayer.GameClientName`</b>,
+///                  \anchor RetroPlayer_GameClientName
+///                  _string_,
+///     @return The emulator/core name parsed from the game client's add-on name
+///     (e.g. `bsnes-mercury Performance`).
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_GameClientName `RetroPlayer.GameClientName`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`RetroPlayer.GameClientPlatforms`</b>,
+///                  \anchor RetroPlayer_GameClientPlatforms
+///                  _string_,
+///     @return The platform or platform group supported by the game client
+///     (e.g. an emulator might report "Nintendo - SNES / SFC / Game Boy / Color").
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_GameClientPlatforms `RetroPlayer.GameClientPlatforms`\endlink
+///     <p>
+///   }
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
 // clang-format off
-constexpr std::array<InfoMap, 7> retroplayer = {{
+constexpr std::array<InfoMap, 16> retroplayer = {{
     {"videofilter",   RETROPLAYER_VIDEO_FILTER},
     {"stretchmode",   RETROPLAYER_STRETCH_MODE},
     {"videorotation", RETROPLAYER_VIDEO_ROTATION},
+    {"title", RETROPLAYER_TITLE},
+    {"platform", RETROPLAYER_PLATFORM},
+    {"genres", RETROPLAYER_GENRES},
+    {"publisher", RETROPLAYER_PUBLISHER},
+    {"developer", RETROPLAYER_DEVELOPER},
+    {"overview", RETROPLAYER_OVERVIEW},
+    {"gameclient", RETROPLAYER_GAME_CLIENT},
+    {"gameclientname", RETROPLAYER_GAME_CLIENT_NAME},
+    {"gameclientplatforms", RETROPLAYER_GAME_CLIENT_PLATFORMS},
     {"supportseject", RETROPLAYER_SUPPORTS_EJECT},
     {"discejected", RETROPLAYER_DISC_EJECTED},
     {"disclabel", RETROPLAYER_DISC_LABEL},

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -305,6 +305,11 @@ CGUIComponent* CServiceBroker::GetGUI()
   return g_serviceBroker.m_pGUI;
 }
 
+const CGUIComponent* CServiceBroker::GetGUIConst()
+{
+  return g_serviceBroker.m_pGUI;
+}
+
 void CServiceBroker::RegisterGUI(CGUIComponent* gui)
 {
   g_serviceBroker.m_pGUI = gui;

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -188,6 +188,7 @@ public:
   static KODI::UTILS::I18N::CSubTagRegistryManager& GetSubTagRegistry();
 
   static CGUIComponent* GetGUI();
+  static const CGUIComponent* GetGUIConst();
   static void RegisterGUI(CGUIComponent* gui);
   static void UnregisterGUI();
 

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -218,7 +218,8 @@ bool CServiceManager::InitStageThree(const std::shared_ptr<CProfileManager>& pro
 
   m_gameServices = std::make_unique<GAME::CGameServices>(
       *m_gameControllerManager, *m_gameRenderManager, *m_peripherals, *profileManager,
-      *m_inputManager, *m_addonMgr);
+      *m_inputManager, *m_addonMgr, *m_fileExtensionProvider);
+  m_gameServices->Initialize();
 
   m_contextMenuManager->Init();
 
@@ -248,6 +249,7 @@ void CServiceManager::DeinitStageThree()
   m_playerCoreFactory.reset();
   m_PVRManager->Deinit();
   m_contextMenuManager->Deinit();
+  m_gameServices->Deinitialize();
   m_gameServices.reset();
   m_peripherals->Clear();
 

--- a/xbmc/games/GameServices.cpp
+++ b/xbmc/games/GameServices.cpp
@@ -15,6 +15,7 @@
 #include "games/GameUtils.h"
 #include "games/agents/input/AgentInput.h"
 #include "profiles/ProfileManager.h"
+#include "utils/FileExtensionProvider.h"
 
 using namespace KODI;
 using namespace GAME;
@@ -24,10 +25,12 @@ CGameServices::CGameServices(CControllerManager& controllerManager,
                              PERIPHERALS::CPeripherals& peripheralManager,
                              const CProfileManager& profileManager,
                              CInputManager& inputManager,
-                             ADDON::CAddonMgr& addons)
+                             ADDON::CAddonMgr& addons,
+                             CFileExtensionProvider& fileExtensionProvider)
   : m_controllerManager(controllerManager),
     m_gameRenderManager(renderManager),
     m_profileManager(profileManager),
+    m_fileExtensionProvider(fileExtensionProvider),
     m_gameSettings(new CGameSettings()),
     m_agentInput(std::make_unique<CAgentInput>(peripheralManager, inputManager)),
     m_videoShaders(std::make_unique<SHADER::CShaderPresetFactory>(addons))
@@ -38,6 +41,16 @@ CGameServices::CGameServices(CControllerManager& controllerManager,
 }
 
 CGameServices::~CGameServices() = default;
+
+void CGameServices::Initialize()
+{
+  // Update game extensions
+  m_fileExtensionProvider.RegisterGameExtensions(CGameUtils::GetGameExtensions());
+}
+
+void CGameServices::Deinitialize()
+{
+}
 
 ControllerPtr CGameServices::GetController(const std::string& controllerId)
 {
@@ -78,4 +91,7 @@ std::string CGameServices::GetSavestatesFolder() const
 void CGameServices::OnAddonRepoInstalled()
 {
   CGameUtils::UpdateInstallableAddons();
+
+  // Update game extensions
+  m_fileExtensionProvider.RegisterGameExtensions(CGameUtils::GetGameExtensions());
 }

--- a/xbmc/games/GameServices.h
+++ b/xbmc/games/GameServices.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <string>
 
+class CFileExtensionProvider;
 class CInputManager;
 class CProfileManager;
 
@@ -56,8 +57,13 @@ public:
                 PERIPHERALS::CPeripherals& peripheralManager,
                 const CProfileManager& profileManager,
                 CInputManager& inputManager,
-                ADDON::CAddonMgr& addons);
+                ADDON::CAddonMgr& addons,
+                CFileExtensionProvider& fileExtensionProvider);
   ~CGameServices();
+
+  // Lifecycle functions
+  void Initialize();
+  void Deinitialize();
 
   ControllerPtr GetController(const std::string& controllerId);
   ControllerPtr GetDefaultController();
@@ -99,6 +105,7 @@ private:
   CControllerManager& m_controllerManager;
   RETRO::CGUIGameRenderManager& m_gameRenderManager;
   const CProfileManager& m_profileManager;
+  CFileExtensionProvider& m_fileExtensionProvider;
 
   // Game services
   std::unique_ptr<CGameSettings> m_gameSettings;

--- a/xbmc/games/GameUtils.cpp
+++ b/xbmc/games/GameUtils.cpp
@@ -266,6 +266,12 @@ std::set<std::string> CGameUtils::GetGameExtensions()
     }
   }
 
+  // Remove special libretro extensions
+  extensions.erase("*");
+  extensions.erase(".");
+  extensions.erase("./");
+  extensions.erase("/");
+
   return extensions;
 }
 

--- a/xbmc/guilib/GUIComponent.cpp
+++ b/xbmc/guilib/GUIComponent.cpp
@@ -95,6 +95,11 @@ CGUIInfoManager &CGUIComponent::GetInfoManager()
   return *m_guiInfoManager;
 }
 
+const CGUIInfoManager& CGUIComponent::GetInfoManager() const
+{
+  return *m_guiInfoManager;
+}
+
 CGUIColorManager &CGUIComponent::GetColorManager()
 {
   return *m_guiColorManager;

--- a/xbmc/guilib/GUIComponent.h
+++ b/xbmc/guilib/GUIComponent.h
@@ -41,6 +41,7 @@ public:
   CGUITextureCallbackManager& GetTextureCallbackManager();
   CStereoscopicsManager &GetStereoscopicsManager();
   CGUIInfoManager &GetInfoManager();
+  const CGUIInfoManager& GetInfoManager() const;
   CGUIColorManager &GetColorManager();
   CGUIAudioManager &GetAudioManager();
 

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -337,9 +337,19 @@ constexpr uint32_t VIDEOPLAYER_CHANNEL_NUMBER        = 327;
 constexpr uint32_t VIDEOPLAYER_HAS_EPG               = 328;
 constexpr uint32_t VIDEOPLAYER_CAN_RESUME_LIVE_TV    = 329;
 
+// RetroPlayer infolabels
 constexpr uint32_t RETROPLAYER_VIDEO_FILTER          = 330;
 constexpr uint32_t RETROPLAYER_STRETCH_MODE          = 331;
 constexpr uint32_t RETROPLAYER_VIDEO_ROTATION        = 332;
+constexpr uint32_t RETROPLAYER_TITLE                 = 1704;
+constexpr uint32_t RETROPLAYER_PLATFORM              = 1705;
+constexpr uint32_t RETROPLAYER_GENRES                = 1706;
+constexpr uint32_t RETROPLAYER_PUBLISHER             = 1707;
+constexpr uint32_t RETROPLAYER_DEVELOPER             = 1708;
+constexpr uint32_t RETROPLAYER_OVERVIEW              = 1709;
+constexpr uint32_t RETROPLAYER_GAME_CLIENT           = 1710;
+constexpr uint32_t RETROPLAYER_GAME_CLIENT_NAME      = 1711;
+constexpr uint32_t RETROPLAYER_GAME_CLIENT_PLATFORMS = 1712;
 constexpr uint32_t RETROPLAYER_SUPPORTS_EJECT        = 1700;
 constexpr uint32_t RETROPLAYER_DISC_EJECTED          = 1701;
 constexpr uint32_t RETROPLAYER_DISC_LABEL            = 1702;

--- a/xbmc/guilib/guiinfo/GamesGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/GamesGUIInfo.cpp
@@ -9,22 +9,58 @@
 #include "guilib/guiinfo/GamesGUIInfo.h"
 
 #include "FileItem.h"
+#include "GUIInfoManager.h"
 #include "ServiceBroker.h"
 #include "Util.h"
+#include "addons/AddonManager.h"
+#include "addons/IAddon.h"
+#include "addons/addoninfo/AddonType.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
 #include "cores/RetroPlayer/RetroPlayerUtils.h"
+#include "games/addons/GameClient.h"
 #include "games/tags/GameInfoTag.h"
+#include "guilib/GUIComponent.h"
 #include "guilib/guiinfo/GUIInfo.h"
 #include "guilib/guiinfo/GUIInfoLabels.h"
 #include "settings/MediaSettings.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 
 using namespace KODI::GUILIB::GUIINFO;
 using namespace KODI::GAME;
 using namespace KODI::RETRO;
+
+namespace
+{
+/*!
+ * \brief Helper to get the currently-playing game tag
+ *
+ * This bypasses the global application player by using GUIInfoManager instead.
+ *
+ * The currently-playing item flow:
+ *
+ *   - Arrives via play command
+ *   - Sent to the application player, which copies the item for itself
+ *   - Sent to the GUIInfoManager via GUI_MSG_PLAYBACK_STARTED from the player
+ *     calling CApplicationPlayerCallback::OnPlayBackStarted(). Also copies any
+ *     updates back to the player.
+ *   - The item can be updated at runtime via TMSG_UPDATE_PLAYER_ITEM, which
+ *     updates the application's item silently and GUIInfoManager directly
+ */
+const CGameInfoTag* GetGUIGameTag()
+{
+  // Use const access because infotags can accidentally be created
+  // when querying a tag that isn't set, which can completely break
+  // all downstream is-video/audio/game checks
+  if (const auto* gui = CServiceBroker::GetGUIConst(); gui != nullptr)
+    return gui->GetInfoManager().GetCurrentGameTag();
+
+  return nullptr;
+}
+} // namespace
 
 //! @todo Savestates were removed from v18
 //#define FILEITEM_PROPERTY_SAVESTATE_DURATION  "duration"
@@ -41,11 +77,15 @@ bool CGamesGUIInfo::InitCurrentItem(CFileItem* item)
 
     if (tag->GetTitle().empty())
     {
-      // No title in tag, show filename only
-      tag->SetTitle(CUtil::GetTitleFromPath(item->GetPath()));
+      // No title in tag, derive one from the item path
+      std::string title = CUtil::GetTitleFromPath(item->GetPath(), item->IsFolder());
+      if (!title.empty())
+        tag->SetTitle(title);
     }
+
     return true;
   }
+
   return false;
 }
 
@@ -78,6 +118,99 @@ bool CGamesGUIInfo::GetLabel(std::string& value,
           CMediaSettings::GetInstance().GetCurrentGameSettings().RotationDegCCW();
       value = std::to_string(rotationDegCCW);
       return true;
+    }
+    case RETROPLAYER_TITLE:
+    {
+      if (const auto* tag = GetGUIGameTag(); tag != nullptr)
+      {
+        value = tag->GetTitle();
+        return true;
+      }
+      break;
+    }
+    case RETROPLAYER_PLATFORM:
+    {
+      if (const auto* tag = GetGUIGameTag(); tag != nullptr)
+      {
+        value = tag->GetPlatform();
+        return true;
+      }
+      break;
+    }
+    case RETROPLAYER_GENRES:
+    {
+      if (const auto* tag = GetGUIGameTag(); tag != nullptr)
+      {
+        value = StringUtils::Join(tag->GetGenres(), ", ");
+        return true;
+      }
+      break;
+    }
+    case RETROPLAYER_PUBLISHER:
+    {
+      if (const auto* tag = GetGUIGameTag(); tag != nullptr)
+      {
+        value = tag->GetPublisher();
+        return true;
+      }
+      break;
+    }
+    case RETROPLAYER_DEVELOPER:
+    {
+      if (const auto* tag = GetGUIGameTag(); tag != nullptr)
+      {
+        value = tag->GetDeveloper();
+        return true;
+      }
+      break;
+    }
+    case RETROPLAYER_OVERVIEW:
+    {
+      if (const auto* tag = GetGUIGameTag(); tag != nullptr)
+      {
+        value = tag->GetOverview();
+        return true;
+      }
+      break;
+    }
+    case RETROPLAYER_GAME_CLIENT:
+    {
+      if (const auto* tag = GetGUIGameTag(); tag != nullptr)
+      {
+        value = tag->GetGameClient();
+        return true;
+      }
+      break;
+    }
+    case RETROPLAYER_GAME_CLIENT_NAME:
+    {
+      if (const auto* tag = GetGUIGameTag(); tag != nullptr)
+      {
+        ADDON::AddonPtr addon;
+        if (CServiceBroker::GetAddonMgr().GetAddon(tag->GetGameClient(), addon,
+                                                   ADDON::AddonType::GAMEDLL,
+                                                   ADDON::OnlyEnabled::CHOICE_YES))
+        {
+          value = std::static_pointer_cast<CGameClient>(addon)->GetEmulatorName();
+          return true;
+        }
+      }
+      break;
+    }
+    case RETROPLAYER_GAME_CLIENT_PLATFORMS:
+    {
+      if (const auto* tag = GetGUIGameTag(); tag != nullptr)
+      {
+        ADDON::AddonPtr addon;
+        if (CServiceBroker::GetAddonMgr().GetAddon(tag->GetGameClient(), addon,
+                                                   ADDON::AddonType::GAMEDLL,
+                                                   ADDON::OnlyEnabled::CHOICE_YES))
+        {
+          value = std::static_pointer_cast<CGameClient>(addon)->GetPlatforms();
+          return true;
+        }
+      }
+      break;
     }
     case RETROPLAYER_DISC_LABEL:
     {

--- a/xbmc/guilib/test/CMakeLists.txt
+++ b/xbmc/guilib/test/CMakeLists.txt
@@ -1,3 +1,4 @@
-set(SOURCES TestGUIControlFactory.cpp)
+set(SOURCES TestGUIControlFactory.cpp
+            TestGamesGUIInfo.cpp)
 
 core_add_test_library(guilib_test)

--- a/xbmc/guilib/test/TestGamesGUIInfo.cpp
+++ b/xbmc/guilib/test/TestGamesGUIInfo.cpp
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileItem.h"
+#include "GUIInfoManager.h"
+#include "ServiceBroker.h"
+#include "games/tags/GameInfoTag.h"
+#include "guilib/guiinfo/GUIInfo.h"
+#include "guilib/guiinfo/GUIInfoLabels.h"
+#include "guilib/guiinfo/GamesGUIInfo.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/FileExtensionProvider.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI::GAME;
+using namespace KODI::GUILIB::GUIINFO;
+
+class TestGamesGUIInfo : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+    m_showExtensionsOriginal = settings->GetBool(CSettings::SETTING_FILELISTS_SHOWEXTENSIONS);
+    settings->SetBool(CSettings::SETTING_FILELISTS_SHOWEXTENSIONS, false);
+
+    CServiceBroker::GetFileExtensionProvider().RegisterGameExtensions({".rom"});
+  }
+
+  void TearDown() override
+  {
+    CServiceBroker::GetFileExtensionProvider().UnregisterGameExtensions({".rom"});
+
+    CServiceBroker::GetSettingsComponent()->GetSettings()->SetBool(
+        CSettings::SETTING_FILELISTS_SHOWEXTENSIONS, m_showExtensionsOriginal);
+  }
+
+  bool m_showExtensionsOriginal{false};
+};
+
+TEST_F(TestGamesGUIInfo, TranslatesRetroPlayerLabels)
+{
+  CGUIInfoManager infoManager;
+
+  EXPECT_EQ(infoManager.TranslateString("RetroPlayer.Title"), RETROPLAYER_TITLE);
+  EXPECT_EQ(infoManager.TranslateString("RetroPlayer.Platform"), RETROPLAYER_PLATFORM);
+  EXPECT_EQ(infoManager.TranslateString("RetroPlayer.Genres"), RETROPLAYER_GENRES);
+  EXPECT_EQ(infoManager.TranslateString("RetroPlayer.Publisher"), RETROPLAYER_PUBLISHER);
+  EXPECT_EQ(infoManager.TranslateString("RetroPlayer.Developer"), RETROPLAYER_DEVELOPER);
+  EXPECT_EQ(infoManager.TranslateString("RetroPlayer.Overview"), RETROPLAYER_OVERVIEW);
+  EXPECT_EQ(infoManager.TranslateString("RetroPlayer.GameClient"), RETROPLAYER_GAME_CLIENT);
+  EXPECT_EQ(infoManager.TranslateString("RetroPlayer.GameClientName"),
+            RETROPLAYER_GAME_CLIENT_NAME);
+  EXPECT_EQ(infoManager.TranslateString("RetroPlayer.GameClientPlatforms"),
+            RETROPLAYER_GAME_CLIENT_PLATFORMS);
+}
+
+TEST_F(TestGamesGUIInfo, GetLabelRequiresCurrentGameInGUIInfoManager)
+{
+  CFileItem item{"/roms/test.rom", false};
+  item.GetGameInfoTag()->SetTitle("Chrono Trigger");
+
+  CGamesGUIInfo gamesGUIInfo;
+  std::string value;
+
+  EXPECT_FALSE(gamesGUIInfo.GetLabel(value, &item, 0, CGUIInfo(RETROPLAYER_TITLE), nullptr));
+  EXPECT_TRUE(value.empty());
+}
+
+TEST_F(TestGamesGUIInfo, InitCurrentItemSetsTitleFromFilesystemPath)
+{
+  CFileItem item{"/roms/test.rom", false};
+  item.GetGameInfoTag();
+
+  CGamesGUIInfo gamesGUIInfo;
+
+  EXPECT_TRUE(gamesGUIInfo.InitCurrentItem(&item));
+
+  const CGameInfoTag* tag = item.GetGameInfoTag();
+  ASSERT_NE(tag, nullptr);
+  EXPECT_EQ(tag->GetTitle(), "test");
+}
+
+TEST_F(TestGamesGUIInfo, InitCurrentItemSetsTitleFromVfsHostnamePath)
+{
+  CFileItem item{"zip://test.rom/", false};
+  item.GetGameInfoTag();
+
+  CGamesGUIInfo gamesGUIInfo;
+
+  EXPECT_TRUE(gamesGUIInfo.InitCurrentItem(&item));
+
+  const CGameInfoTag* tag = item.GetGameInfoTag();
+  ASSERT_NE(tag, nullptr);
+  EXPECT_EQ(tag->GetTitle(), "test");
+}

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -374,6 +374,24 @@ void CFileExtensionProvider::SetAddonExtensions(AddonType type)
   m_addonFileFolderExtensions[type] = StringUtils::Join(fileFolderExtensions, "|");
 }
 
+void CFileExtensionProvider::RegisterGameExtensions(const std::set<std::string>& extensions)
+{
+  std::lock_guard lock{m_critSection};
+  m_gameExtensions.insert(extensions.begin(), extensions.end());
+}
+
+void CFileExtensionProvider::UnregisterGameExtensions(const std::set<std::string>& extensions)
+{
+  std::lock_guard lock{m_critSection};
+  for (const auto& ext : extensions)
+    m_gameExtensions.erase(ext);
+}
+
+std::string CFileExtensionProvider::GetGameExtensions() const
+{
+  return StringUtils::Join(m_gameExtensions, "|");
+}
+
 bool CFileExtensionProvider::EncodedHostName(const std::string& protocol) const
 {
   std::lock_guard lock{m_critSection};

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -82,6 +83,21 @@ public:
    */
   static bool CanOperateExtension(const std::string& path);
 
+  /*!
+   * @brief Register game extensions
+   */
+  void RegisterGameExtensions(const std::set<std::string>& extensions);
+
+  /*!
+   * @brief Unregister game extensions
+   */
+  void UnregisterGameExtensions(const std::set<std::string>& extensions);
+
+  /*!
+   * @brief Returns a pipe-separated list of game extensions
+   */
+  std::string GetGameExtensions() const;
+
 private:
   std::string GetAddonExtensions(ADDON::AddonType type) const;
   std::string GetAddonFileFolderExtensions(ADDON::AddonType type) const;
@@ -100,6 +116,9 @@ private:
   // File extension properties
   std::map<ADDON::AddonType, std::string> m_addonExtensions;
   std::map<ADDON::AddonType, std::string> m_addonFileFolderExtensions;
+
+  // Game extension registry
+  std::set<std::string> m_gameExtensions;
 
   // Protocols from add-ons with encoded host names
   std::vector<std::string> m_encoded;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -291,16 +291,19 @@ void URIUtils::RemoveExtension(std::string& path)
 
   // Extensions to remove
   const std::string extensions{
+      // clang-format off
       CServiceBroker::GetFileExtensionProvider().GetPictureExtensions() +
       CServiceBroker::GetFileExtensionProvider().GetMusicExtensions() +
       CServiceBroker::GetFileExtensionProvider().GetVideoExtensions() +
       CServiceBroker::GetFileExtensionProvider().GetSubtitleExtensions() +
       CServiceBroker::GetFileExtensionProvider().GetCompoundArchiveExtensions() +
       CServiceBroker::GetFileExtensionProvider().GetArchiveExtensions() +
+      CServiceBroker::GetFileExtensionProvider().GetGameExtensions() +
       "|.py|.xml|.milk|.xbt|.cdg"
 #ifdef TARGET_DARWIN
       + "|.app|.applescript|.workflow"
 #endif
+      // clang-format on
   };
 
   if (const int extension{FindExtension(path, extensions, FindExtensions::ONLY_IN_LIST,


### PR DESCRIPTION
## Description

This PR adds the following infolabels, as well as their documentation:

* RetroPlayer.Title
* RetroPlayer.Platform
* RetroPlayer.Genres
* RetroPlayer.Publisher
* RetroPlayer.Developer
* RetroPlayer.Overview
* RetroPlayer.GameClient
* RetroPlayer.GameClientName
* RetroPlayer.GameClientPlatforms

## Motivation and context

Requested here for the skin "Confluence Zeitgeist": https://forum.kodi.tv/showthread.php?tid=384832&pid=3271975#pid3271975

## How has this been tested?

Tested by adding a temporary label `$INFO[RetroPlayer.GameClientPlatforms]` in the new Disc Manager:

<img width="1360" height="760" alt="Screenshot 2026-03-18 at 12 02 49 PM" src="https://github.com/user-attachments/assets/3261fbba-6e9e-4fcd-bd77-cb16d18121bf" />

## What is the effect on users?

* Added new RetroPlayer.* infolabels for skins

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
