### PR TITLE
[Windows] Fix rebuild failures in Debug related to Lzo2

### DIFF
--- a/cmake/modules/FindLzo2.cmake
+++ b/cmake/modules/FindLzo2.cmake
@@ -15,7 +15,8 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     set(patches "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/001-all-enable_tests.patch"
                 "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/002-all-enable_docs.patch"
                 "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/003-all-install_pkgconfig.patch"
-                "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/004-all-win_set_debug_postfix.patch")
+                "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/004-all-win_set_debug_postfix.patch"
+                "${CORE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/005-all-win_set_compile_mp.patch")
 
     if(WIN32 OR WINDOWS_STORE)
       # Debug postfix only used for windows

--- a/tools/depends/target/liblzo2/003-all-install_pkgconfig.patch
+++ b/tools/depends/target/liblzo2/003-all-install_pkgconfig.patch
@@ -1,17 +1,11 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -296,12 +296,12 @@
+@@ -296,7 +296,7 @@
  endif()
  endif()
  
 -if(PKG_CONFIG_FOUND)
-+#if(PKG_CONFIG_FOUND)
++if(NOT MSVC)
      configure_file(lzo2.pc.cmakein lzo2.pc @ONLY)
      #if(EXISTS "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/lzo2.pc" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
-     #endif()
--endif()
-+#endif()
- 
- endif() # CMAKE_INSTALL_FULL_LIBDIR
- 

--- a/tools/depends/target/liblzo2/005-all-win_set_compile_mp.patch
+++ b/tools/depends/target/liblzo2/005-all-win_set_compile_mp.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 98c0a1a..4ffa60d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -249,6 +249,9 @@ foreach(t ${lzo_COMPILE_TARGETS})
+     if(CMAKE_C_COMPILER_ID MATCHES "^(Clang|GNU)$")
+         target_compile_options(${t} PRIVATE -Wall -W -Wcast-qual)
+     endif()
++    if(MSVC)
++        target_compile_options(${t} PRIVATE /MP)
++    endif()
+ endforeach()
+ 
+ # /***********************************************************************


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix rebuild failures in Debug related to Lzo2
- Not install pkgconfig due cause Debug/Release conflicts
- Faster build with enabled /MP compiler option

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes link error in Debug mode:

```
43>libkodi.vcxproj -> V:\kodi-build\Debug\libkodi.lib
44>------ Build started: Project: kodi, Configuration: Debug x64 ------
44>Building Custom Rule V:/kodi/CMakeLists.txt
44>Scanning sources for module dependencies...
44>WinMain.cpp
44>Compiling...
44>WinMain.cpp
44>LINK : fatal error LNK1104: cannot open file 'lzo2.lib'
44>Done building project "kodi.vcxproj" -- FAILED.
========== Build: 43 succeeded, 1 failed, 1 up-to-date, 0 skipped ==========
========== Build completed at 9:50 and took 02:05,872 minutes ==========
```

pkgconfig is optional in Lzo2 and currently has a patch to force use it. Modified the same patch to disable in Windows continue forced enabled for other platforms.

A new patch has been included to enable the /MP compiler option. Since Lzo2 has multiple code files, it greatly benefits from parallel compilation.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested build Windows x64 in Debug, then change something in `CMakeLists.txt` to force CMake reconfigure.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
- Fixes link errors in Debug mode after the first build (trying link to `lzo2.lib` instead of `lzo2d.lib`).
- Faster liblzo2 build.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
