### PR TITLE
[Windows] Improve FFmpeg build conditions

### DIFF
--- a/tools/buildsteps/windows/buildhelpers.sh
+++ b/tools/buildsteps/windows/buildhelpers.sh
@@ -184,8 +184,8 @@ PATH_CHANGE_REV_FILENAME=".last_success_revision"
 #params paths to be hashed
 function getBuildHash ()
 {
-  local ver_dav1d="$(extractVersion $3)"
-  local ver_ffmpeg="$(extractVersion $4)"
+  local ver_dav1d="$(extractVersion $4)"
+  local ver_ffmpeg="$(extractVersion $5)"
   local hashStr
   hashStr="$(git rev-list HEAD --max-count=1  -- $@)"
   hashStr="$hashStr $@ $ver_ffmpeg $ver_dav1d"

--- a/tools/buildsteps/windows/make-mingwlibs.sh
+++ b/tools/buildsteps/windows/make-mingwlibs.sh
@@ -77,7 +77,7 @@ checkfiles() {
 
 buildProcess() {
 export PREFIX=/xbmc/project/BuildDependencies/mingwlibs/$TRIPLET
-if [ "$(pathChanged $PREFIX /xbmc/tools/buildsteps/windows /xbmc/tools/depends/target/dav1d/DAV1D-VERSION /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION)" == "0" ]; then
+if [ "$(pathChanged $PREFIX /xbmc/tools/depends/target/ffmpeg /xbmc/tools/buildsteps/windows /xbmc/tools/depends/target/dav1d/DAV1D-VERSION /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION)" == "0" ]; then
   return
 fi
 
@@ -110,7 +110,7 @@ echo "--------------------------------------------------------------------------
 echo " compile mingw libs $TRIPLET done..."
 echo "-------------------------------------------------------------------------------"
 
-tagSuccessFulBuild $PREFIX /xbmc/tools/buildsteps/windows /xbmc/tools/depends/target/dav1d/DAV1D-VERSION /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION
+tagSuccessFulBuild $PREFIX /xbmc/tools/depends/target/ffmpeg /xbmc/tools/buildsteps/windows /xbmc/tools/depends/target/dav1d/DAV1D-VERSION /xbmc/tools/depends/target/ffmpeg/FFMPEG-VERSION
 }
 
 run_builds() {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Improve FFmpeg build conditions in Windows.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Observed that FFmpeg is not rebuild when only changed `win_ffmpeg_options.txt`. This has happened e.g. in https://github.com/xbmc/xbmc/pull/28001. 

The decision of rebuild FFmpeg depends on changes on some tracking paths (git hash). Since `win_ffmpeg_options.txt` was moved recently from `xbmc/tools/buildsteps/windows` to `/xbmc/tools/depends/target/ffmpeg`, now is not supervised.

This PR adds the path `/xbmc/tools/depends/target/ffmpeg` to be part tracked paths. Then any change in FFmpeg Windows patches, CMakeLists.txt, Makefile or win_ffmpeg_options.txt will trigger also FFmpeg re-build.

The other conditions remain the same: FFmpeg version and dav1d version (even for not merged changes).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally Windows x64 doing manual changes in these paths.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Prevents obsolete or inconsistent FFmpeg build due not always is rebuild.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
