### PR TITLE
[VideoPlayer] Add detection of Dolby Vision EL type (FEL/MEL) at playback time

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1066,6 +1066,16 @@ bool CDVDVideoCodecAndroidMediaCodec::AddData(const DemuxPacket &packet)
 
         iSize = m_bitstream->GetConvertSize();
         pData = m_bitstream->GetConvertBuffer();
+
+        if (m_hints.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION && m_hints.dovi.dv_profile == 7)
+        {
+          const bool isFEL = m_bitstream->GetDoviIsFEL();
+          if (m_doviIsFEL != isFEL)
+          {
+            m_processInfo.SetDoviIsFEL(isFEL);
+            m_doviIsFEL = isFEL;
+          }
+        }
       }
 
       if (m_state == MEDIACODEC_STATE_FLUSHED)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -184,6 +184,7 @@ protected:
   int m_src_offset[4];
   int m_src_stride[4];
   bool m_useDTSforPTS = false;
+  bool m_doviIsFEL{false};
 
   // CJNISurfaceHolderCallback interface
 public:

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -1136,7 +1136,8 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
     pVideoPicture->hasLightMetadata = true;
   }
 
-  if (pVideoPicture->hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION)
+  if (!m_doviELTested && pVideoPicture->hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION &&
+      m_hints.dovi.dv_profile == 7)
   {
     sd = av_frame_get_side_data(m_pFrame, AV_FRAME_DATA_DOVI_METADATA);
     if (sd)
@@ -1148,7 +1149,7 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
       if (hdr != nullptr && hdr->el_spatial_resampling_filter_flag == 1 &&
           hdr->disable_residual_flag == 0)
       {
-        pVideoPicture->strDVELType = "MEL";
+        bool isFEL = false;
         for (int i = 0; i < 3; i++)
         {
           if (mapping != nullptr &&
@@ -1156,10 +1157,13 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
                mapping->nlq[i].linear_deadzone_slope != 0 ||
                mapping->nlq[i].linear_deadzone_threshold != 0))
           {
-            pVideoPicture->strDVELType = "FEL";
+            isFEL = true;
             break;
           }
         }
+        pVideoPicture->strDVELType = isFEL ? "FEL" : "MEL";
+        m_processInfo.SetDoviIsFEL(isFEL);
+        m_doviELTested = true;
       }
     }
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -98,6 +98,7 @@ protected:
   int m_codecControlFlags = 0;
   bool m_interlaced = false;
   double m_DAR = 1.0;
+  bool m_doviELTested = false;
   CDVDStreamInfo m_hints;
   CDVDCodecOptions m_options;
 

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -1145,6 +1145,17 @@ void CMediaPipelineWebOS::FeedVideoData(const std::shared_ptr<CDVDMsg>& msg)
 
     size = m_bitstream->GetConvertSize();
     data = m_bitstream->GetConvertBuffer();
+
+    if (m_videoHint.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION &&
+        m_videoHint.dovi.dv_profile == 7)
+    {
+      const bool isFEL = m_bitstream->GetDoviIsFEL();
+      if (m_doviIsFEL != isFEL)
+      {
+        m_processInfo.SetDoviIsFEL(isFEL);
+        m_doviIsFEL = isFEL;
+      }
+    }
   }
 
   if (m_flushed)

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
@@ -438,6 +438,7 @@ private:
   CDVDClock& m_clock;
   CDVDOverlayContainer& m_overlayContainer;
   bool m_hasAudio{true};
+  bool m_doviIsFEL{false};
 
   std::atomic<bool> m_videoClosed{true};
   std::atomic<bool> m_audioClosed{true};

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -75,6 +75,7 @@ void CProcessInfo::ResetVideoCodecInfo()
   m_videoFPS = 0.0;
   m_videoDAR = 0.0;
   m_videoIsInterlaced = false;
+  m_doviIsFEL = false;
   m_deintMethods.clear();
   m_deintMethods.push_back(EINTERLACEMETHOD::VS_INTERLACEMETHOD_NONE);
   m_deintMethodDefault = EINTERLACEMETHOD::VS_INTERLACEMETHOD_NONE;
@@ -237,6 +238,20 @@ bool CProcessInfo::GetVideoInterlaced()
   std::unique_lock lock(m_videoCodecSection);
 
   return m_videoIsInterlaced;
+}
+
+void CProcessInfo::SetDoviIsFEL(bool isFEL)
+{
+  std::unique_lock lock(m_videoCodecSection);
+
+  m_doviIsFEL = isFEL;
+}
+
+bool CProcessInfo::GetDoviIsFEL()
+{
+  std::unique_lock lock(m_videoCodecSection);
+
+  return m_doviIsFEL;
 }
 
 EINTERLACEMETHOD CProcessInfo::GetFallbackDeintMethod()

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -50,6 +50,8 @@ public:
   float GetVideoDAR();
   void SetVideoInterlaced(bool interlaced);
   bool GetVideoInterlaced();
+  void SetDoviIsFEL(bool isFEL);
+  bool GetDoviIsFEL();
   virtual EINTERLACEMETHOD GetFallbackDeintMethod();
   virtual void SetSwDeinterlacingMethods();
   void UpdateDeinterlacingMethods(std::list<EINTERLACEMETHOD> &methods);
@@ -135,6 +137,7 @@ protected:
   float m_videoFPS;
   float m_videoDAR;
   bool m_videoIsInterlaced;
+  bool m_doviIsFEL;
   std::list<EINTERLACEMETHOD> m_deintMethods;
   EINTERLACEMETHOD m_deintMethodDefault;
   mutable CCriticalSection m_videoCodecSection;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5620,19 +5620,33 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, VideoStreamInfo& info) const
   info.videoAspectRatio = s.aspect_ratio;
   info.stereoMode = s.stereo_mode;
   info.flags = s.flags;
-  info.hdrType = s.hdrType;
+  info.fpsRate = s.fpsRate;
+  info.fpsScale = s.fpsScale;
+
+  // Determine if stream is Dolby Vision P7 DTDL (double track, double layer)
+  const bool isDTDL = GetVideoStreamCount() == 2 && s.hdrType == StreamHdrType::HDR_TYPE_HDR10 &&
+                      m_content.m_selectionStreams.Get(StreamType::VIDEO, 1).hdrType ==
+                          StreamHdrType::HDR_TYPE_DOLBYVISION;
+
+  // For DTDL streams pick HDR info from EL (secondary stream)
+  const SelectionStream& sHDR = isDTDL ? m_content.m_selectionStreams.Get(StreamType::VIDEO, 1) : s;
+
+  info.hdrType = sHDR.hdrType;
   if (info.hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION)
   {
-    if (info.hdrDetail.length() == 0)
-      info.hdrDetail =
-          s.dovi.dv_profile == 0 ? "" : std::to_string(static_cast<int>(s.dovi.dv_profile));
+    info.hdrDetail =
+        sHDR.dovi.dv_profile == 0 ? "" : std::to_string(static_cast<int>(sHDR.dovi.dv_profile));
     // distinguish HDR10 from HLG base
-    if (s.dovi.dv_profile == 8)
+    if (sHDR.dovi.dv_profile == 8)
     {
       info.hdrDetail += ".";
-      info.hdrDetail += std::to_string(static_cast<int>(s.dovi.dv_bl_signal_compatibility_id));
-      if (s.dovi.dv_bl_signal_compatibility_id == 4)
+      info.hdrDetail += std::to_string(static_cast<int>(sHDR.dovi.dv_bl_signal_compatibility_id));
+      if (sHDR.dovi.dv_bl_signal_compatibility_id == 4)
         info.hdrTypeAlt = StreamHdrType::HDR_TYPE_HLG;
+    }
+    else if (sHDR.dovi.dv_profile == 7)
+    {
+      info.hdrDetail += m_processInfo->GetDoviIsFEL() ? "FEL" : "MEL";
     }
   }
   else
@@ -5640,8 +5654,6 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, VideoStreamInfo& info) const
     info.hdrDetail = "";
     info.hdrTypeAlt = StreamHdrType::HDR_TYPE_NONE;
   }
-  info.fpsRate = s.fpsRate;
-  info.fpsScale = s.fpsScale;
 }
 
 int CVideoPlayer::GetVideoStreamCount() const

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -667,7 +667,7 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
           CStreamDetails::VideoDimsToResolutionDescription(m_videoInfo.width, m_videoInfo.height);
       return true;
     case VIDEOPLAYER_HDR_TYPE:
-      value = CStreamDetails::HdrTypeToString(m_videoInfo.hdrType);
+      value = CStreamDetails::HdrTypeToString(m_videoInfo.hdrType) + " " + m_videoInfo.hdrDetail;
       return true;
     case VIDEOPLAYER_HDR_DETAIL:
       value = m_videoInfo.hdrDetail;

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -585,7 +585,6 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
         }
 
         return true;
-      case VIDEOPLAYER_HDR_TYPE:
       case LISTITEM_VIDEO_HDR_TYPE:
         if (tag->m_streamDetails.GetStreamCount(CStreamDetail::VIDEO) > 1 &&
             tag->m_streamDetails.GetVideoHdrType(2) == "dolbyvision")
@@ -593,7 +592,6 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
         else
           value = tag->m_streamDetails.GetVideoHdrType();
         return true;
-      case VIDEOPLAYER_HDR_DETAIL:
       case LISTITEM_VIDEO_HDR_DETAIL:
         if (tag->m_streamDetails.GetStreamCount(CStreamDetail::VIDEO) > 1 &&
             tag->m_streamDetails.GetVideoHdrType(2) == "dolbyvision")

--- a/xbmc/utils/BitstreamConverter.cpp
+++ b/xbmc/utils/BitstreamConverter.cpp
@@ -18,6 +18,7 @@
 #include "HevcSei.h"
 
 #include <algorithm>
+#include <cstring>
 
 extern "C"
 {
@@ -1318,6 +1319,7 @@ bool CBitstreamConverter::mpeg2_sequence_header(const uint8_t* data,
 
 #ifdef HAVE_LIBDOVI
 // Processes Dolby Vision RPU
+//   - Sets `m_doviIsFEL` flag to true when DV is profile 7 / FEL
 //   - Converts to profile 8.1 if `m_convert_dovi` is enabled
 //   - Sets level 5 metadata to 0 offsets if `m_setDoviZeroLevel5` is enabled
 //
@@ -1325,8 +1327,8 @@ bool CBitstreamConverter::mpeg2_sequence_header(const uint8_t* data,
 // May be NULL if no processing was done or if parsing errored
 const DoviData* CBitstreamConverter::processDoviRpu(uint8_t* buf, uint32_t nalSize)
 {
-  // early exit if no processing option is enabled
-  if (!m_convert_dovi && !m_setDoviZeroLevel5)
+  // early exit if no processing option is enabled and EL type is alredy tested
+  if (m_doviELTested && !m_convert_dovi && !m_setDoviZeroLevel5)
     return NULL;
 
   DoviRpuOpaque* rpu = dovi_parse_unspec62_nalu(buf, nalSize);
@@ -1340,6 +1342,14 @@ const DoviData* CBitstreamConverter::processDoviRpu(uint8_t* buf, uint32_t nalSi
   {
     dovi_rpu_free(rpu);
     return rpuData;
+  }
+
+  if (!m_doviELTested)
+  {
+    if (header->guessed_profile == 7 && header->el_type && 0 == std::strcmp(header->el_type, "FEL"))
+      m_doviIsFEL = true;
+
+    m_doviELTested = true;
   }
 
   if (m_convert_dovi && header->guessed_profile == 7)

--- a/xbmc/utils/BitstreamConverter.h
+++ b/xbmc/utils/BitstreamConverter.h
@@ -108,6 +108,7 @@ public:
   void SetRemoveDovi(bool value) { m_removeDovi = value; }
   void SetRemoveHdr10Plus(bool value) { m_removeHdr10Plus = value; }
   void SetDoviZeroLevel5(bool value) { m_setDoviZeroLevel5 = value; }
+  bool GetDoviIsFEL() const { return m_doviIsFEL; }
 
   static bool mpeg2_sequence_header(const uint8_t* data,
                                     const uint32_t size,
@@ -162,4 +163,6 @@ protected:
   bool m_removeDovi;
   bool m_removeHdr10Plus;
   bool m_setDoviZeroLevel5;
+  bool m_doviIsFEL{false};
+  bool m_doviELTested{false};
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
[VideoPlayer] Add detection of Dolby Vision EL type (FEL/MEL) at playback time.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
VideoPlayer infolabels info should be obtained from playback video and in current master `VideoPlayer.hdrInfo` and `VideoPlayer.hdrDetail` are obtained from database (streamdetails table). This, even works, may not be correct all the time: e.g. video file replaced and not updated in DB yet, etc.

Different platforms have important differences, and in some cases, such as Windows/Linux, this information can be obtained from the decoded video data (`CDVDVideoCodecFFmpeg::GetPictureCommon`), while in others (Android / webOS), this data is not accessible due how hardware decoding is implemented. The only way is obtain this info from the raw stream before decoding.

In both code paths, is prevented parse video/stream multiple times (each video frame) because it is not necessary and could result in a small extra CPU usage. From a "playback performance" pow, the impact of this PR is almost zero.


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Windows x64 and Android (Shield). Dolby Vision profile and EL type FEL/MEL is correctly displayed in Player Process Info / Media / HDR info.

NOTE: the default skin (Estuary) cannot yet display hdrDetail, which is why a temporary commit has been added to display hdrDetail in hdrInfo field. This commit for testing purposes only and must be removed before merge.

Can be also tested with https://github.com/xbmc/xbmc/pull/28120 (and no TEMP commit).

webOS not tested.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Nothing in current skin but it will allow hdrDetail info (Dolby Vision profile and FEL/MEL) obtained from current playback video instead of database table.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
