### PR TITLE
[Android] Replace friend class declaration in CNativeWindow

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.h
+++ b/xbmc/platform/android/activity/XBMCApp.h
@@ -59,8 +59,6 @@ struct androidPackage
 
 class CNativeWindow
 {
-  friend class CWinSystemAndroidGLESContext; // meh
-
 public:
   static std::shared_ptr<CNativeWindow> CreateFromSurface(CJNISurfaceHolder holder);
   ~CNativeWindow();
@@ -68,6 +66,8 @@ public:
   bool SetBuffersGeometry(int width, int height, int format);
   int32_t GetWidth() const;
   int32_t GetHeight() const;
+
+  ANativeWindow* GetWindow() const { return m_window; }
 
 private:
   explicit CNativeWindow(ANativeWindow* window);

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -177,7 +177,7 @@ std::unique_ptr<CVideoSync> CWinSystemAndroidGLESContext::GetVideoSync(CVideoRef
 
 bool CWinSystemAndroidGLESContext::CreateSurface()
 {
-  if (!m_pGLContext.CreateSurface(static_cast<EGLNativeWindowType>(m_nativeWindow->m_window),
+  if (!m_pGLContext.CreateSurface(static_cast<EGLNativeWindowType>(m_nativeWindow->GetWindow()),
                                   m_HDRColorSpace))
   {
     if (m_HDRColorSpace != EGL_NONE)
@@ -185,7 +185,8 @@ bool CWinSystemAndroidGLESContext::CreateSurface()
       m_HDRColorSpace = EGL_NONE;
       m_displayMetadata = nullptr;
       m_lightMetadata = nullptr;
-      if (!m_pGLContext.CreateSurface(static_cast<EGLNativeWindowType>(m_nativeWindow->m_window)))
+      if (!m_pGLContext.CreateSurface(
+              static_cast<EGLNativeWindowType>(m_nativeWindow->GetWindow())))
         return false;
     }
     else


### PR DESCRIPTION
## Description
Changes to replace the declaration of `CWinSystemAndroidGLESContext` as a friend class of `CNativeWindow`

## How has this been tested?
Works correctly on Android TV

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
