### PR TITLE
Revert "[application] Fix video info not available when playing strm files."

### DIFF
--- a/xbmc/application/ApplicationPlay.cpp
+++ b/xbmc/application/ApplicationPlay.cpp
@@ -114,17 +114,14 @@ void CApplicationPlay::GetOptionsAndUpdateItem()
       return;
 
     // Get path
-    std::string path{m_item.GetDynPath()};
+    std::string path{m_item.GetPath()};
     if (m_item.HasVideoInfoTag())
     {
       const std::string videoInfoTagPath{m_item.GetVideoInfoTag()->m_strFileNameAndPath};
-      if (!videoInfoTagPath.empty())
-      {
-        // removable:// may be embedded in bluray:// path
-        if (VIDEO::IsVideoDb(m_item) ||
-            CURL::Decode(videoInfoTagPath).find("removable://") != std::string::npos)
-          path = videoInfoTagPath;
-      }
+      // removable:// may be embedded in bluray:// path
+      if (CURL::Decode(videoInfoTagPath).find("removable://") != std::string::npos ||
+          VIDEO::IsVideoDb(m_item))
+        path = videoInfoTagPath;
     }
     else if (m_item.HasProperty("original_listitem_url") &&
              URIUtils::IsPlugin(m_item.GetProperty("original_listitem_url").asString()))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This reverts commit 62dc66296c1c1811e79995df6c7b762023561b4b.

The fix introduced with #27980 has unwanted side effects, at least for (some?) plugins resume points do not work anymore. 

The revert introduces the old bug that should be fixed with #27980. Due to lack of time and plugin resume points considered more important, a fix for the strm files will be postponed.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Make plugin resume points work again.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Provided a test build for @Lunatixz and he confirmed the plugin resume points working again.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Plugin-provided resume points work a again.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
