### PR TITLE
[Video] Use EDLs to play single episode in a multi-episode file.

### DIFF
--- a/xbmc/application/ApplicationPlay.cpp
+++ b/xbmc/application/ApplicationPlay.cpp
@@ -80,8 +80,12 @@ bool GetEpisodeBookmark(const CFileItem& item, CPlayerOptions& options, CVideoDa
     {
       CBookmark bookmark;
       db.GetBookMarkForEpisode(*tag, bookmark);
-      options.starttime = bookmark.timeInSeconds;
       options.state = bookmark.playerState;
+
+      // Only apply starttime for non-local/LAN items where EDL parser won't run
+      if (!URIUtils::IsLocalOrLAN(item.GetDynPath()))
+        options.starttime = bookmark.timeInSeconds;
+
       return true;
     }
   }
@@ -153,7 +157,7 @@ void CApplicationPlay::GetOptionsAndUpdateItem()
           m_options.starttime = bookmark.timeInSeconds;
           m_options.state = bookmark.playerState;
         }
-        else if (m_options.starttime == 0.0 && m_item.HasVideoInfoTag())
+        else if (m_options.starttime == 0.0)
           GetEpisodeBookmark(m_item, m_options, db);
       }
 
@@ -163,7 +167,7 @@ void CApplicationPlay::GetOptionsAndUpdateItem()
       if (m_options.starttime == 0.0)
         m_item.SetStartOffset(0);
     }
-    else if (m_item.HasVideoInfoTag())
+    else
       GetEpisodeBookmark(m_item, m_options, db);
 
     db.Close();

--- a/xbmc/cores/VideoPlayer/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES AudioSinkAE.cpp
             Edl/EdlParsers/BeyondTVParser.cpp
             Edl/EdlParsers/ComskipParser.cpp
             Edl/EdlParsers/EdlFileParser.cpp
+            Edl/EdlParsers/MultipleEpisodeEdlParser.cpp
             Edl/EdlParsers/PvrEdlParser.cpp
             Edl/EdlParsers/VideoReDoParser.cpp
             PTSTracker.cpp
@@ -38,6 +39,7 @@ set(HEADERS AudioSinkAE.h
             Edl/EdlParsers/BeyondTVParser.h
             Edl/EdlParsers/ComskipParser.h
             Edl/EdlParsers/EdlFileParser.h
+            Edl/EdlParsers/MultipleEpisodeEdlParser.h
             Edl/EdlParsers/PvrEdlParser.h
             Edl/EdlParsers/VideoReDoParser.h
             IVideoPlayer.h

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -9,6 +9,7 @@
 #include "Edl.h"
 
 #include "Edl/EdlParserFactory.h"
+#include "Edl/EdlParsers/MultipleEpisodeEdlParser.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
@@ -16,10 +17,15 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <ranges>
+#include <string>
+#include <vector>
 
 using namespace std::chrono_literals;
 using namespace EDL;
@@ -58,6 +64,13 @@ bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem,
   CLog::LogF(LOGDEBUG, "Checking for edit decision lists (EDL) for: {}",
              CURL::GetRedacted(fileItem.GetDynPath()));
 
+  // Run the multi-episode parser independently so episode start/end can be
+  // applied to any edits found by the file-based parsers
+  CEdlParserResult multiEpisodeResult;
+  CMultipleEpisodeEdlParser multiEpParser;
+  if (URIUtils::IsLocalOrLAN(fileItem.GetDynPath()) && multiEpParser.CanParse(fileItem))
+    multiEpisodeResult = multiEpParser.Parse(fileItem, fps, duration);
+
   for (const auto& parser : CEdlParserFactory::GetEdlParsersForItem(fileItem))
   {
     if (!parser->CanParse(fileItem))
@@ -65,13 +78,19 @@ bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem,
 
     CEdlParserResult result = parser->Parse(fileItem, fps, duration);
     if (!result.IsEmpty())
-      return ProcessParserResult(result);
+      return ProcessParserResult(result, multiEpisodeResult, duration);
   }
+
+  // No file-based EDL found; still apply multi-episode cuts alone if present
+  if (!multiEpisodeResult.IsEmpty())
+    return ProcessParserResult(multiEpisodeResult);
 
   return false;
 }
 
-bool CEdl::ProcessParserResult(const CEdlParserResult& result)
+bool CEdl::ProcessParserResult(const CEdlParserResult& result,
+                               const CEdlParserResult& multiEpisodeResult,
+                               std::chrono::milliseconds duration)
 {
   for (const auto& entry : result.GetSceneMarkers())
   {
@@ -102,6 +121,7 @@ bool CEdl::ProcessParserResult(const CEdlParserResult& result)
     }
   }
 
+  ParseEditsForEpisode(multiEpisodeResult, duration);
   MergeShortCommBreaks();
   AddSceneMarkersAtStartAndEndOfEdits();
   return true;
@@ -545,4 +565,119 @@ void CEdl::AddSceneMarkersAtStartAndEndOfEdits()
       AddSceneMarker(edit.end);
     }
   }
+}
+
+void CEdl::ParseEditsForEpisode(const CEdlParserResult& multiEpisodeResult,
+                                std::chrono::milliseconds duration)
+{
+  if (multiEpisodeResult.GetEdits().empty())
+    return;
+
+  const auto& multiEdits{multiEpisodeResult.GetEdits()};
+
+  // Derive the absolute episode window from the multi-episode cuts
+  const std::chrono::milliseconds episodeStart{
+      (!multiEdits.empty() && multiEdits.front().edit.start == 0ms) ? multiEdits.front().edit.end
+                                                                    : 0ms};
+  const std::chrono::milliseconds episodeEnd{
+      (!multiEdits.empty() && multiEdits.back().edit.start > 0ms)
+          ? multiEdits.back().edit.start
+          : (duration > 0ms ? duration : std::chrono::milliseconds::max())};
+
+  if (episodeStart >= episodeEnd)
+  {
+    CLog::LogF(LOGERROR,
+               "Invalid episode window derived from multi-episode cuts. Start: {}, End: {}",
+               StringUtils::MillisecondsToTimeString(episodeStart),
+               StringUtils::MillisecondsToTimeString(episodeEnd));
+    return;
+  }
+
+  // Erase file-based edits that fall entirely outside the episode window
+  std::erase_if(m_vecEdits,
+                [episodeStart, episodeEnd](const auto& edit)
+                {
+                  if (edit.end <= episodeStart || edit.start >= episodeEnd)
+                  {
+                    CLog::LogF(LOGDEBUG,
+                               "Removed EDL edit [{} - {} action {}] as it falls outside episode "
+                               "window [{} - {}]",
+                               StringUtils::MillisecondsToTimeString(edit.start),
+                               StringUtils::MillisecondsToTimeString(edit.end),
+                               ActionToString(edit.action),
+                               StringUtils::MillisecondsToTimeString(episodeStart),
+                               StringUtils::MillisecondsToTimeString(episodeEnd));
+                    return true;
+                  }
+                  return false;
+                });
+
+  // Clamp any edits that straddle an episode start/end
+  for (auto& edit : m_vecEdits)
+  {
+    const auto clampedStart{std::max(edit.start, episodeStart)};
+    const auto clampedEnd{std::min(edit.end, episodeEnd)};
+    if (clampedStart != edit.start || clampedEnd != edit.end)
+    {
+      CLog::LogF(LOGDEBUG, "Clamped EDL edit [{} - {} action {}] to episode window [{} - {}]",
+                 StringUtils::MillisecondsToTimeString(edit.start),
+                 StringUtils::MillisecondsToTimeString(edit.end), ActionToString(edit.action),
+                 StringUtils::MillisecondsToTimeString(episodeStart),
+                 StringUtils::MillisecondsToTimeString(episodeEnd));
+      edit.start = clampedStart;
+      edit.end = clampedEnd;
+    }
+  }
+
+  // Remove any edits that became invalid after clamping (start >= end)
+  std::erase_if(m_vecEdits, [](const auto& edit) { return edit.start >= edit.end; });
+
+  // m_totalCutTime is stale after erase_if removed CUT edits that were already
+  // accumulated by AddEdit()
+  m_totalCutTime = 0ms;
+  for (const auto& edit : m_vecEdits)
+  {
+    if (edit.action == Action::CUT)
+      m_totalCutTime += edit.end - edit.start;
+  }
+
+  // Add episode cuts
+  if (multiEdits.front().edit.start == 0ms)
+  {
+    if (!AddEdit(multiEdits.front().edit))
+    {
+      CLog::LogF(
+          LOGERROR,
+          "Failed to add multi-episode start cut [{} - {}]. Edit may overlap with existing edits.",
+          StringUtils::MillisecondsToTimeString(multiEdits.front().edit.start),
+          StringUtils::MillisecondsToTimeString(multiEdits.front().edit.end));
+    }
+    else
+    {
+      CLog::LogF(LOGDEBUG, "Added multi-episode start cut [{} - {}].",
+                 StringUtils::MillisecondsToTimeString(multiEdits.front().edit.start),
+                 StringUtils::MillisecondsToTimeString(multiEdits.front().edit.end));
+    }
+  }
+  if (multiEdits.back().edit.start > 0ms)
+  {
+    if (!AddEdit(multiEdits.back().edit))
+    {
+      CLog::LogF(
+          LOGERROR,
+          "Failed to add multi-episode end cut [{} - {}]. Edit may overlap with existing edits.",
+          StringUtils::MillisecondsToTimeString(multiEdits.back().edit.start),
+          StringUtils::MillisecondsToTimeString(multiEdits.back().edit.end));
+    }
+    else
+    {
+      CLog::LogF(LOGDEBUG, "Added multi-episode end cut [{} - {}].",
+                 StringUtils::MillisecondsToTimeString(multiEdits.back().edit.start),
+                 StringUtils::MillisecondsToTimeString(multiEdits.back().edit.end));
+    }
+  }
+
+  // Remove scene markers that fall outside the episode window
+  std::erase_if(m_vecSceneMarkers, [episodeStart, episodeEnd](const auto& marker)
+                { return marker <= episodeStart || marker >= episodeEnd; });
 }

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -681,3 +681,33 @@ void CEdl::ParseEditsForEpisode(const CEdlParserResult& multiEpisodeResult,
   std::erase_if(m_vecSceneMarkers, [episodeStart, episodeEnd](const auto& marker)
                 { return marker <= episodeStart || marker >= episodeEnd; });
 }
+
+std::chrono::milliseconds CEdl::GetNextPlayableTime(std::chrono::milliseconds seekTime) const
+{
+  for (const EDL::Edit& edit : m_vecEdits)
+  {
+    // Edits are sorted - once seekTime is before this edit's start, no further edits apply
+    if (seekTime < edit.start)
+      break;
+
+    if (edit.action == Action::CUT && seekTime >= edit.start && seekTime < edit.end)
+      seekTime = edit.end;
+  }
+  return seekTime;
+}
+
+std::chrono::milliseconds CEdl::GetPrevPlayableTime(std::chrono::milliseconds seekTime) const
+{
+  for (int i = static_cast<int>(m_vecEdits.size()) - 1; i >= 0; --i)
+  {
+    const EDL::Edit& edit = m_vecEdits[i];
+
+    // Edits are sorted ascending - once seekTime is past this edit's end, all earlier ones are also behind
+    if (seekTime >= edit.end)
+      break;
+
+    if (edit.action == Action::CUT && seekTime >= edit.start && seekTime < edit.end)
+      seekTime = edit.start;
+  }
+  return seekTime;
+}

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -156,7 +156,7 @@ bool CEdl::AddEdit(const Edit& newEdit)
     return false;
   }
 
-  if (InEdit(edit.start) || InEdit(edit.end))
+  if (InEdit(edit.start) || InEdit(edit.end - 1ms))
   {
     CLog::LogF(LOGERROR, "Start or end is in an existing edit! [{} - {}], {}",
                StringUtils::MillisecondsToTimeString(edit.start),
@@ -332,7 +332,7 @@ std::chrono::milliseconds CEdl::GetTimeWithoutCuts(std::chrono::milliseconds see
       continue;
 
     // inside cut
-    if (seek >= edit.start && seek <= edit.end)
+    if (seek >= edit.start && seek < edit.end)
     {
       // decrease cut length by 1 ms to jump over the end boundary.
       cutTime += seek - edit.start - 1ms;
@@ -375,7 +375,7 @@ std::optional<std::unique_ptr<EDL::Edit>> CEdl::InEdit(std::chrono::milliseconds
     if (seekTime < m_vecEdits[i].start) // Early exit if not even up to the edit start time.
       return std::nullopt;
 
-    if (seekTime >= m_vecEdits[i].start && seekTime <= m_vecEdits[i].end) // Inside edit.
+    if (seekTime >= m_vecEdits[i].start && seekTime < m_vecEdits[i].end) // Inside edit.
       return std::make_unique<EDL::Edit>(m_vecEdits[i]);
   }
 

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -18,6 +18,9 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include <chrono>
+#include <cstdint>
+
 using namespace std::chrono_literals;
 using namespace EDL;
 
@@ -46,7 +49,9 @@ void CEdl::Clear()
   m_lastEditTime = std::nullopt;
 }
 
-bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, float fps)
+bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem,
+                                 float fps,
+                                 std::chrono::milliseconds duration)
 {
   Clear();
 
@@ -58,7 +63,7 @@ bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem, float fps)
     if (!parser->CanParse(fileItem))
       continue;
 
-    CEdlParserResult result = parser->Parse(fileItem, fps);
+    CEdlParserResult result = parser->Parse(fileItem, fps, duration);
     if (!result.IsEmpty())
       return ProcessParserResult(result);
   }

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -156,6 +156,25 @@ public:
   std::optional<std::chrono::milliseconds> GetNextSceneMarker(Direction direction,
                                                               std::chrono::milliseconds clockTime);
 
+  /*!
+   * @brief Resolve the next playable time on the original media timeline.
+   * If the provided time lands inside an edit, or exactly on the start of an
+   * adjacent edit, advance to the end of that edit and keep walking until a
+   * playable point is reached.
+   * @param seekTime The candidate seek time on the original timeline
+   * @return The next playable time on the original timeline
+   */
+  std::chrono::milliseconds GetNextPlayableTime(std::chrono::milliseconds seekTime) const;
+
+  /*!
+   * @brief Resolve the previous playable time on the original media timeline.
+   * If the provided time lands inside an edit, retreat to the start of that edit
+   * and keep walking backward until a playable point is reached.
+   * @param seekTime The candidate seek time on the original timeline
+   * @return The previous playable time on the original timeline
+   */
+  std::chrono::milliseconds GetPrevPlayableTime(std::chrono::milliseconds seekTime) const;
+
 private:
   friend class TestParseEditsForEpisode;
 

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -15,10 +15,10 @@
 #include <chrono>
 #include <memory>
 #include <optional>
-#include <string>
 #include <vector>
 
 class CFileItem;
+class TestParseEditsForEpisode;
 
 class CEdl
 {
@@ -157,6 +157,8 @@ public:
                                                               std::chrono::milliseconds clockTime);
 
 private:
+  friend class TestParseEditsForEpisode;
+
   // total cut time (edl cuts) in ms
   std::chrono::milliseconds m_totalCutTime;
   std::vector<EDL::Edit> m_vecEdits;
@@ -175,9 +177,13 @@ private:
   /*!
    * @brief Process the result from an EDL parser
    * @param result The parser result containing edits and scene markers
+   * @param multiEpisodeResult Optional multi-episode parser result.
+   * @param duration (Optional) The duration of the media item in ms (used for multi-episode parsing)
    * @return true if the result was processed successfully
    */
-  bool ProcessParserResult(const EDL::CEdlParserResult& result);
+  bool ProcessParserResult(const EDL::CEdlParserResult& result,
+                           const EDL::CEdlParserResult& multiEpisodeResult = {},
+                           std::chrono::milliseconds duration = std::chrono::milliseconds(0));
 
   /*!
    * @brief Adds an edit to the list of EDL edits
@@ -195,4 +201,12 @@ private:
    * (currently only for commercial breaks)
   */
   void AddSceneMarkersAtStartAndEndOfEdits();
+
+  /*!
+   * @brief Parse edits if this is a multi-episode file
+   * @param multiEpisodeResult The result from the multi-episode EDL parser, containing episode start/end edits
+   * @param duration The duration of the media item in ms (used for multi-episode parsing)
+  */
+  void ParseEditsForEpisode(const EDL::CEdlParserResult& multiEpisodeResult,
+                            std::chrono::milliseconds duration);
 };

--- a/xbmc/cores/VideoPlayer/Edl.h
+++ b/xbmc/cores/VideoPlayer/Edl.h
@@ -12,7 +12,7 @@
 #include "cores/Direction.h"
 #include "cores/EdlEdit.h"
 
-#include <cstdint>
+#include <chrono>
 #include <memory>
 #include <optional>
 #include <string>
@@ -25,7 +25,9 @@ class CEdl
 public:
   CEdl();
 
-  bool ReadEditDecisionLists(const CFileItem& fileItem, float fps);
+  bool ReadEditDecisionLists(const CFileItem& fileItem,
+                             float fps,
+                             std::chrono::milliseconds duration);
   void Clear();
 
   /*!

--- a/xbmc/cores/VideoPlayer/Edl/EdlParser.h
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParser.h
@@ -10,7 +10,6 @@
 
 #include "cores/EdlEdit.h"
 #include "filesystem/File.h"
-#include "utils/URIUtils.h"
 
 #include <chrono>
 #include <optional>
@@ -118,9 +117,12 @@ public:
    * @brief Parse EDL data from a file item
    * @param item The file item (provides path for file-based, or PVR tags for PVR)
    * @param fps Frames per second (needed for frame-based formats, 0 if unavailable)
+   * @param duration Duration of the media item in milliseconds (0 if unavailable)
    * @return CEdlParserResult containing edits and scene markers, or empty if parsing failed
    */
-  virtual CEdlParserResult Parse(const CFileItem& item, float fps) = 0;
+  virtual CEdlParserResult Parse(const CFileItem& item,
+                                 float fps,
+                                 std::chrono::milliseconds duration) = 0;
 };
 
 /*!

--- a/xbmc/cores/VideoPlayer/Edl/EdlParserFactory.cpp
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParserFactory.cpp
@@ -22,15 +22,7 @@ std::vector<std::unique_ptr<IEdlParser>> CEdlParserFactory::GetEdlParsersForItem
     const CFileItem& item)
 {
   std::vector<std::unique_ptr<IEdlParser>> parsers;
-
-  const std::string& mediaFilePath = item.GetDynPath();
-
-  // Check if item is on local drive or network share
-  const bool isLocalOrLan = (URIUtils::IsHD(mediaFilePath) ||
-                             URIUtils::IsOnLAN(mediaFilePath, LanCheckMode::ANY_PRIVATE_SUBNET)) &&
-                            !URIUtils::IsInternetStream(mediaFilePath);
-
-  if (isLocalOrLan)
+  if (URIUtils::IsLocalOrLAN(item.GetDynPath()))
   {
     // File-based parsers for local/LAN items
     parsers.emplace_back(std::make_unique<CVideoReDoParser>());

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/BeyondTVParser.cpp
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/BeyondTVParser.cpp
@@ -13,6 +13,8 @@
 #include "utils/XBMCTinyXML2.h"
 #include "utils/log.h"
 
+#include <chrono>
+
 using namespace EDL;
 
 std::string CBeyondTVParser::GetEdlFilePath(const CFileItem& item) const
@@ -22,7 +24,9 @@ std::string CBeyondTVParser::GetEdlFilePath(const CFileItem& item) const
                                     URIUtils::GetExtension(mediaFilePath) + ".chapters.xml");
 }
 
-CEdlParserResult CBeyondTVParser::Parse(const CFileItem& item, float fps)
+CEdlParserResult CBeyondTVParser::Parse(const CFileItem& item,
+                                        float fps,
+                                        std::chrono::milliseconds duration)
 {
   CEdlParserResult result;
 

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/BeyondTVParser.h
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/BeyondTVParser.h
@@ -10,6 +10,8 @@
 
 #include "cores/VideoPlayer/Edl/EdlParser.h"
 
+#include <chrono>
+
 namespace EDL
 {
 
@@ -32,7 +34,9 @@ namespace EDL
 class CBeyondTVParser : public CEdlFileParserBase
 {
 public:
-  CEdlParserResult Parse(const CFileItem& item, float fps) override;
+  CEdlParserResult Parse(const CFileItem& item,
+                         float fps,
+                         std::chrono::milliseconds duration) override;
 
 protected:
   std::string GetEdlFilePath(const CFileItem& item) const override;

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/ComskipParser.cpp
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/ComskipParser.cpp
@@ -13,6 +13,8 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <chrono>
+
 namespace
 {
 constexpr const char* COMSKIP_HEADER = "FILE PROCESSING COMPLETE";
@@ -26,7 +28,9 @@ std::string CComskipParser::GetEdlFilePath(const CFileItem& item) const
   return URIUtils::ReplaceExtension(item.GetDynPath(), ".txt");
 }
 
-CEdlParserResult CComskipParser::Parse(const CFileItem& item, float fps)
+CEdlParserResult CComskipParser::Parse(const CFileItem& item,
+                                       float fps,
+                                       std::chrono::milliseconds duration)
 {
   CEdlParserResult result;
 

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/ComskipParser.h
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/ComskipParser.h
@@ -10,6 +10,8 @@
 
 #include "cores/VideoPlayer/Edl/EdlParser.h"
 
+#include <chrono>
+
 namespace EDL
 {
 
@@ -25,7 +27,9 @@ namespace EDL
 class CComskipParser : public CEdlFileParserBase
 {
 public:
-  CEdlParserResult Parse(const CFileItem& item, float fps) override;
+  CEdlParserResult Parse(const CFileItem& item,
+                         float fps,
+                         std::chrono::milliseconds duration) override;
 
 protected:
   std::string GetEdlFilePath(const CFileItem& item) const override;

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/EdlFileParser.cpp
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/EdlFileParser.cpp
@@ -15,6 +15,7 @@
 #include "utils/log.h"
 
 #include <charconv>
+#include <chrono>
 
 using namespace EDL;
 using namespace XFILE;
@@ -24,7 +25,9 @@ std::string CEdlFileParser::GetEdlFilePath(const CFileItem& item) const
   return URIUtils::ReplaceExtension(item.GetDynPath(), ".edl");
 }
 
-CEdlParserResult CEdlFileParser::Parse(const CFileItem& item, float fps)
+CEdlParserResult CEdlFileParser::Parse(const CFileItem& item,
+                                       float fps,
+                                       std::chrono::milliseconds duration)
 {
   CEdlParserResult result;
 

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/EdlFileParser.h
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/EdlFileParser.h
@@ -10,6 +10,8 @@
 
 #include "cores/VideoPlayer/Edl/EdlParser.h"
 
+#include <chrono>
+
 namespace EDL
 {
 
@@ -23,7 +25,9 @@ namespace EDL
 class CEdlFileParser : public CEdlFileParserBase
 {
 public:
-  CEdlParserResult Parse(const CFileItem& item, float fps) override;
+  CEdlParserResult Parse(const CFileItem& item,
+                         float fps,
+                         std::chrono::milliseconds duration) override;
 
 protected:
   std::string GetEdlFilePath(const CFileItem& item) const override;

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/MultipleEpisodeEdlParser.cpp
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/MultipleEpisodeEdlParser.cpp
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "MultipleEpisodeEdlParser.h"
+
+#include "FileItem.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+#include "video/VideoDatabase.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <ranges>
+
+using namespace EDL;
+using namespace std::chrono_literals;
+
+bool CMultipleEpisodeEdlParser::CanParse(const CFileItem& item) const
+{
+  if (!item.HasVideoInfoTag())
+    return false;
+
+  const CVideoInfoTag* tag{item.GetVideoInfoTag()};
+  if (tag->m_type != MediaTypeEpisode)
+    return false;
+  if (tag->m_iIdShow <= 0 || tag->m_iFileId <= 0)
+    return false;
+
+  return true;
+}
+
+CEdlParserResult CMultipleEpisodeEdlParser::Parse(const CFileItem& item,
+                                                  float fps,
+                                                  std::chrono::milliseconds duration)
+{
+  CEdlParserResult result;
+  const CVideoInfoTag* tag{item.GetVideoInfoTag()};
+
+  EpisodeFileMap fileMap;
+  bool success;
+  {
+    CVideoDatabase db;
+    if (!db.Open())
+    {
+      CLog::LogF(LOGERROR, "Failed to open video database");
+      return result;
+    }
+    success = db.GetEpisodeMap(tag->m_iIdShow, fileMap, tag->m_iFileId);
+    db.Close();
+  } // Destroy database if GetEpisodeMap() fails
+
+  if (!success)
+    return result;
+
+  result = Process(item, fps, duration, fileMap);
+  return result;
+}
+
+CEdlParserResult CMultipleEpisodeEdlParser::Process(const CFileItem& item,
+                                                    float fps,
+                                                    std::chrono::milliseconds duration,
+                                                    const EpisodeFileMap& fileMap)
+{
+  CEdlParserResult result;
+
+  // Find this episode in the map
+  const CVideoInfoTag* tag{item.GetVideoInfoTag()};
+  const auto it{std::ranges::find_if(
+      fileMap, [tag](const auto& i)
+      { return i.second.season == tag->m_iSeason && i.second.episode == tag->m_iEpisode; })};
+  if (it == fileMap.end())
+    return result;
+
+  const auto episodeInfo{it->second};
+  if (fileMap.size() == 1 && episodeInfo.bookmark.timeInSeconds == 0.0 &&
+      episodeInfo.bookmark.totalTimeInSeconds == 0.0)
+    return result; // No bookmark for single episode
+
+  // If no episode bookmark then timeInSeconds will be 0ms
+  const auto start{
+      std::chrono::milliseconds(static_cast<int64_t>(episodeInfo.bookmark.timeInSeconds * 1000))};
+  const auto length{duration};
+  auto end{length};
+
+  // Now see if the next episode is also in the file (to determine the end of this episode)
+  // Note the FileMap only includes episodes in this file
+  // Otherwise default to the end of the file
+  const auto it2{std::ranges::find_if(
+      fileMap, [tag](const auto& i)
+      { return i.second.season == tag->m_iSeason && i.second.episode == tag->m_iEpisode + 1; })};
+  if (it2 != fileMap.end())
+  {
+    if (const auto time{it2->second.bookmark.timeInSeconds}; time > 0)
+      end = std::chrono::milliseconds(static_cast<int64_t>(time * 1000));
+  }
+
+  // Check EDL actually needed
+  if (start == 0ms && end == length)
+    return result;
+
+  // Check times are valid
+  if (start < 0ms || start > length || end < 0ms || end > length || start >= end)
+  {
+    CLog::LogF(LOGERROR,
+               "Invalid episode bookmark times for multi-episode item: {}. Start: {}, End: {}, "
+               "Length: {}.",
+               CURL::GetRedacted(item.GetDynPath()), StringUtils::MillisecondsToTimeString(start),
+               StringUtils::MillisecondsToTimeString(end),
+               StringUtils::MillisecondsToTimeString(length));
+    return result;
+  }
+
+  Edit edit;
+  edit.action = Action::CUT;
+  if (start > 0ms)
+  {
+    edit.start = 0ms;
+    edit.end = start;
+    result.AddEdit(edit);
+    CLog::LogF(LOGDEBUG, "Adding start EDL cut [{} - {}] for multi-episode item: {}.",
+               StringUtils::MillisecondsToTimeString(0ms),
+               StringUtils::MillisecondsToTimeString(start), CURL::GetRedacted(item.GetDynPath()));
+  }
+  if (end > 0ms && end < length)
+  {
+    edit.start = end;
+    edit.end = length;
+    result.AddEdit(edit);
+    CLog::LogF(LOGDEBUG, "Adding end EDL cut [{} - {}] for multi-episode item: {}.",
+               StringUtils::MillisecondsToTimeString(end),
+               StringUtils::MillisecondsToTimeString(length), CURL::GetRedacted(item.GetDynPath()));
+  }
+
+  return result;
+}

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/MultipleEpisodeEdlParser.h
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/MultipleEpisodeEdlParser.h
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "cores/VideoPlayer/Edl/EdlParser.h"
+
+#include <chrono>
+#include <map>
+
+struct EpisodeInformation;
+using EpisodeFileMap = std::multimap<std::string, EpisodeInformation, std::less<>>;
+
+namespace EDL
+{
+
+/*!
+ * @brief Parser for multi-episode files.
+ *
+ * Uses episode bookmarks from the video database to create EDL cuts for the episode being played.
+ * This parser implements IEdlParser directly (not CEdlFileParserBase)
+ * as it doesn't read from files.
+ */
+class CMultipleEpisodeEdlParser : public IEdlParser
+{
+public:
+  bool CanParse(const CFileItem& item) const override;
+  CEdlParserResult Parse(const CFileItem& item,
+                         float fps,
+                         std::chrono::milliseconds duration) override;
+  static CEdlParserResult Process(const CFileItem& item,
+                                  float fps,
+                                  std::chrono::milliseconds duration,
+                                  const EpisodeFileMap& fileMap);
+};
+
+} // namespace EDL

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/PvrEdlParser.cpp
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/PvrEdlParser.cpp
@@ -13,6 +13,8 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include <chrono>
+
 using namespace EDL;
 
 bool CPvrEdlParser::CanParse(const CFileItem& item) const
@@ -20,7 +22,9 @@ bool CPvrEdlParser::CanParse(const CFileItem& item) const
   return item.HasPVRRecordingInfoTag() || item.HasEPGInfoTag();
 }
 
-CEdlParserResult CPvrEdlParser::Parse(const CFileItem& item, float fps)
+CEdlParserResult CPvrEdlParser::Parse(const CFileItem& item,
+                                      float fps,
+                                      std::chrono::milliseconds duration)
 {
   CEdlParserResult result;
 

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/PvrEdlParser.h
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/PvrEdlParser.h
@@ -10,6 +10,8 @@
 
 #include "cores/VideoPlayer/Edl/EdlParser.h"
 
+#include <chrono>
+
 namespace EDL
 {
 
@@ -24,7 +26,9 @@ class CPvrEdlParser : public IEdlParser
 {
 public:
   bool CanParse(const CFileItem& item) const override;
-  CEdlParserResult Parse(const CFileItem& item, float fps) override;
+  CEdlParserResult Parse(const CFileItem& item,
+                         float fps,
+                         std::chrono::milliseconds duration) override;
 };
 
 } // namespace EDL

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/VideoReDoParser.cpp
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/VideoReDoParser.cpp
@@ -13,6 +13,8 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <chrono>
+
 namespace
 {
 constexpr const char* VIDEOREDO_HEADER = "<Version>2";
@@ -28,7 +30,9 @@ std::string CVideoReDoParser::GetEdlFilePath(const CFileItem& item) const
   return URIUtils::ReplaceExtension(item.GetDynPath(), ".Vprj");
 }
 
-CEdlParserResult CVideoReDoParser::Parse(const CFileItem& item, float fps)
+CEdlParserResult CVideoReDoParser::Parse(const CFileItem& item,
+                                         float fps,
+                                         std::chrono::milliseconds duration)
 {
   /*
    * VideoReDo file is strange. Tags are XML like, but it isn't an XML file.

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/VideoReDoParser.h
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/VideoReDoParser.h
@@ -10,6 +10,8 @@
 
 #include "cores/VideoPlayer/Edl/EdlParser.h"
 
+#include <chrono>
+
 namespace EDL
 {
 
@@ -26,7 +28,9 @@ namespace EDL
 class CVideoReDoParser : public CEdlFileParserBase
 {
 public:
-  CEdlParserResult Parse(const CFileItem& item, float fps) override;
+  CEdlParserResult Parse(const CFileItem& item,
+                         float fps,
+                         std::chrono::milliseconds duration) override;
 
 protected:
   std::string GetEdlFilePath(const CFileItem& item) const override;

--- a/xbmc/cores/VideoPlayer/Edl/test/TestEdl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl/test/TestEdl.cpp
@@ -6,12 +6,15 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "Edl/EdlParsers/MultipleEpisodeEdlParser.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/Edl.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "test/TestUtils.h"
+#include "video/VideoDatabase.h"
+#include "video/VideoInfoTag.h"
 
 #include <chrono>
 #include <cmath>
@@ -478,4 +481,467 @@ TEST_F(TestEdl, TestMergeSmallCommbreaksAdvanced)
   EXPECT_EQ(edl.GetEditList().at(0).end - edl.GetEditList().at(0).start, 32s - 10s);
   // 4th, 5th and 6th commbreaks joined
   EXPECT_EQ(edl.GetEditList().at(1).end - edl.GetEditList().at(1).start, 65100ms - 37s);
+}
+
+TEST_F(TestEdl, TestMultipleEpisodeEdlProcess)
+{
+  // Helper: build an EpisodeFileMap entry with a bookmark at the given time (seconds)
+  auto testEntry = [](int episode, double bookmarkTimeSec) -> EpisodeFileMapEntry
+  {
+    EpisodeInformation info;
+    info.season = 1;
+    info.episode = episode;
+    info.bookmark.timeInSeconds = bookmarkTimeSec;
+    info.bookmark.totalTimeInSeconds = 3600.0;
+    info.bookmark.type = CBookmark::EPISODE;
+    return {"video.mkv", info};
+  };
+
+  // Helper: build a CFileItem tagged as the given episode
+  auto testItem = [](int episode) -> CFileItem
+  {
+    CFileItem item;
+    item.SetPath("/path/to/video.mkv");
+    CVideoInfoTag* tag = item.GetVideoInfoTag();
+    tag->m_type = MediaTypeEpisode;
+    tag->m_iIdShow = 1;
+    tag->m_iFileId = 1;
+    tag->m_iSeason = 1;
+    tag->m_iEpisode = episode;
+    return item;
+  };
+
+  constexpr std::chrono::milliseconds fileDurationMs = 3600s; // 60 minutes
+
+  // Scenario 1: 3-episode file, playing the middle episode (ep 2).
+  // Ep1=0s, Ep2=1200s (20min), Ep3=2400s (40min). File=60min.
+  // Expect CUT [0 - 20min] and CUT [40min - 60min].
+  {
+    EpisodeFileMap fileMap;
+    fileMap.insert(testEntry(1, 0.0));
+    fileMap.insert(testEntry(2, 1200.0));
+    fileMap.insert(testEntry(3, 2400.0));
+
+    const auto item = testItem(2);
+    const auto result = CMultipleEpisodeEdlParser::Process(item, 0, fileDurationMs, fileMap);
+
+    EXPECT_EQ(result.GetEdits().size(), 2);
+    EXPECT_EQ(result.GetEdits().at(0).edit.action, Action::CUT);
+    EXPECT_EQ(result.GetEdits().at(0).edit.start, 0ms);
+    EXPECT_EQ(result.GetEdits().at(0).edit.end, 1200000ms);
+    EXPECT_EQ(result.GetEdits().at(1).edit.action, Action::CUT);
+    EXPECT_EQ(result.GetEdits().at(1).edit.start, 2400000ms);
+    EXPECT_EQ(result.GetEdits().at(1).edit.end, std::chrono::milliseconds(fileDurationMs));
+  }
+
+  // Scenario 2: 2-episode file, playing the first episode.
+  // Ep1=0s, Ep2=1800s (30min). File=60min.
+  // start=0 → no leading CUT; end=30min → CUT [30min - 60min].
+  {
+    EpisodeFileMap fileMap;
+    fileMap.insert(testEntry(1, 0.0));
+    fileMap.insert(testEntry(2, 1800.0));
+
+    const auto item = testItem(1);
+    const auto result = CMultipleEpisodeEdlParser::Process(item, 0, fileDurationMs, fileMap);
+
+    EXPECT_EQ(result.GetEdits().size(), 1);
+    EXPECT_EQ(result.GetEdits().at(0).edit.start, 1800000ms);
+    EXPECT_EQ(result.GetEdits().at(0).edit.end, std::chrono::milliseconds(fileDurationMs));
+  }
+
+  // Scenario 3: 2-episode file, playing the last episode.
+  // Ep1=0s, Ep2=1500s (25min). File=60min.
+  // start=25min → CUT [0 - 25min]; no next ep → end=length, no trailing CUT.
+  {
+    EpisodeFileMap fileMap;
+    fileMap.insert(testEntry(1, 0.0));
+    fileMap.insert(testEntry(2, 1500.0));
+
+    const auto item = testItem(2);
+    const auto result = CMultipleEpisodeEdlParser::Process(item, 0, fileDurationMs, fileMap);
+
+    EXPECT_EQ(result.GetEdits().size(), 1);
+    EXPECT_EQ(result.GetEdits().at(0).edit.start, 0ms);
+    EXPECT_EQ(result.GetEdits().at(0).edit.end, 1500000ms);
+  }
+
+  // Scenario 4: Single episode, no bookmarks → empty result (no EDL needed).
+  {
+    EpisodeFileMap fileMap;
+    EpisodeInformation info;
+    info.season = 1;
+    info.episode = 1;
+    info.bookmark.timeInSeconds = 0.0;
+    info.bookmark.totalTimeInSeconds = 0.0;
+    fileMap.insert({"video.mkv", info});
+
+    const auto item = testItem(1);
+    const auto result = CMultipleEpisodeEdlParser::Process(item, 0, fileDurationMs, fileMap);
+
+    EXPECT_EQ(result.IsEmpty(), true);
+  }
+
+  // Scenario 5: Episode not in file map → empty result.
+  {
+    EpisodeFileMap fileMap;
+    fileMap.insert(testEntry(1, 0.0));
+    fileMap.insert(testEntry(2, 1200.0));
+
+    const auto item = testItem(5);
+    const auto result = CMultipleEpisodeEdlParser::Process(item, 0, fileDurationMs, fileMap);
+
+    EXPECT_EQ(result.IsEmpty(), true);
+  }
+
+  // Scenario 6: 4-episode file with unequal splits, playing episode 3.
+  // Ep1=0s, Ep2=600s, Ep3=900s (15min), Ep4=2700s (45min). File=60min.
+  // Expect CUT [0 - 15min] and CUT [45min - 60min]. Playable = 30min.
+  {
+    EpisodeFileMap fileMap;
+    fileMap.insert(testEntry(1, 0.0));
+    fileMap.insert(testEntry(2, 600.0));
+    fileMap.insert(testEntry(3, 900.0));
+    fileMap.insert(testEntry(4, 2700.0));
+
+    const auto item = testItem(3);
+    const auto result = CMultipleEpisodeEdlParser::Process(item, 0, fileDurationMs, fileMap);
+
+    EXPECT_EQ(result.GetEdits().size(), 2);
+    EXPECT_EQ(result.GetEdits().at(0).edit.start, 0ms);
+    EXPECT_EQ(result.GetEdits().at(0).edit.end, 900000ms);
+    EXPECT_EQ(result.GetEdits().at(1).edit.start, 2700000ms);
+    EXPECT_EQ(result.GetEdits().at(1).edit.end, std::chrono::milliseconds(fileDurationMs));
+    // playable duration = 60min - 15min - 15min = 30min
+    const auto totalCut = (result.GetEdits().at(0).edit.end - result.GetEdits().at(0).edit.start) +
+                          (result.GetEdits().at(1).edit.end - result.GetEdits().at(1).edit.start);
+    EXPECT_EQ(std::chrono::milliseconds(fileDurationMs) - totalCut, 1800000ms);
+  }
+
+  // Scenario 7: Next episode's bookmark is 0 (unset) → end defaults to file length.
+  // Ep1=0s, Ep2=1200s, Ep3 bookmark=0. File=60min. Playing Ep2.
+  // Expect only CUT [0 - 20min].
+  {
+    EpisodeFileMap fileMap;
+    fileMap.insert(testEntry(1, 0.0));
+    fileMap.insert(testEntry(2, 1200.0));
+    fileMap.insert(testEntry(3, 0.0));
+
+    const auto item = testItem(2);
+    const auto result = CMultipleEpisodeEdlParser::Process(item, 0, fileDurationMs, fileMap);
+
+    EXPECT_EQ(result.GetEdits().size(), 1);
+    EXPECT_EQ(result.GetEdits().at(0).edit.start, 0ms);
+    EXPECT_EQ(result.GetEdits().at(0).edit.end, 1200000ms);
+  }
+}
+
+class TestParseEditsForEpisode : public ::testing::Test
+{
+protected:
+  // Build a CEdlParserResult with a start cut [0 - startEnd] and/or
+  // an end cut [endStart - fileDuration].
+  static EDL::CEdlParserResult MakeMultiEpResult(std::chrono::milliseconds startCutEnd,
+                                                 std::chrono::milliseconds endCutStart,
+                                                 std::chrono::milliseconds fileDuration)
+  {
+    EDL::CEdlParserResult r;
+    EDL::Edit edit;
+    edit.action = EDL::Action::CUT;
+    if (startCutEnd > 0ms)
+    {
+      edit.start = 0ms;
+      edit.end = startCutEnd;
+      r.AddEdit(edit);
+    }
+    if (endCutStart > 0ms && endCutStart < fileDuration)
+    {
+      edit.start = endCutStart;
+      edit.end = fileDuration;
+      r.AddEdit(edit);
+    }
+    return r;
+  }
+
+  static void CallParseEditsForEpisode(CEdl& edl,
+                                       const EDL::CEdlParserResult& multiEpisodeResult,
+                                       std::chrono::milliseconds duration)
+  {
+    edl.ParseEditsForEpisode(multiEpisodeResult, duration);
+  }
+
+  static bool AddEdit(CEdl& edl, const EDL::Edit& edit) { return edl.AddEdit(edit); }
+};
+
+TEST_F(TestParseEditsForEpisode, EmptyMultiEpisodeResultIsNoOp)
+{
+  // ParseEditsForEpisode with an empty result should not modify the existing edits
+  CEdl edl;
+  CFileItem mediaItem;
+  mediaItem.SetPath(
+      XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebased.mkv"));
+  edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
+  const size_t editsBefore = edl.GetRawEditList().size();
+  const size_t markersBefore = edl.GetSceneMarkers().size();
+
+  EDL::CEdlParserResult empty;
+  CallParseEditsForEpisode(edl, empty, 0ms);
+
+  EXPECT_EQ(edl.GetRawEditList().size(), editsBefore);
+  EXPECT_EQ(edl.GetSceneMarkers().size(), markersBefore);
+}
+
+TEST_F(TestParseEditsForEpisode, EditsOutsideEpisodeWindowAreRemoved)
+{
+  // The mplayertimebased.edl has a cut at 5.3s-7.1s and other edits.
+  // Apply a multi-episode window starting at 10s - meaning the cut is before the window.
+  // The cut [5.3s - 7.1s] should be removed.
+  CEdl edl;
+  CFileItem mediaItem;
+  mediaItem.SetPath(
+      XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebased.mkv"));
+  edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
+
+  // Sanity check: cut exists before ParseEditsForEpisode
+  EXPECT_TRUE(edl.HasCuts() && edl.GetCutMarkers().size() == 1);
+
+  // Episode window: 10s to 1000s (file duration 1000s)
+  // Start cut [0 - 10s] will remove the 5.3s-7.1s cut which is inside [0-10s]
+  const std::chrono::milliseconds fileDuration = 1000s;
+  auto multiEpResult = MakeMultiEpResult(10s, 0ms, fileDuration);
+  CallParseEditsForEpisode(edl, multiEpResult, fileDuration);
+
+  // There should still be one cut (the start cut)
+  EXPECT_TRUE(edl.HasCuts() && edl.GetCutMarkers().size() == 1);
+}
+
+TEST_F(TestParseEditsForEpisode, EpisodeStartCutIsAddedToEditList)
+{
+  // After ParseEditsForEpisode with a start cut, that cut should be present in the raw edit list
+  CEdl edl;
+  CFileItem mediaItem;
+  mediaItem.SetPath(
+      XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebased.mkv"));
+  edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
+
+  const std::chrono::milliseconds fileDuration = 1000s;
+  auto multiEpResult = MakeMultiEpResult(30s, 0ms, fileDuration);
+  CallParseEditsForEpisode(edl, multiEpResult, fileDuration);
+
+  // The start cut [0 - 30s] should now appear at the start of the raw edit list
+  EXPECT_TRUE(edl.HasCuts());
+  if (edl.HasCuts())
+  {
+    const auto& edit{edl.GetRawEditList()[0]};
+    EXPECT_TRUE(edit.action == EDL::Action::CUT && edit.start == 0ms && edit.end == 30s)
+        << "Expected start cut [0 - 30s] at the start of the raw edit list";
+  }
+}
+
+TEST_F(TestParseEditsForEpisode, EpisodeEndCutIsAddedToEditList)
+{
+  // After ParseEditsForEpisode with an end cut, that cut should be present in the raw edit list
+  CEdl edl;
+  CFileItem mediaItem;
+  mediaItem.SetPath(
+      XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebased.mkv"));
+  edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
+
+  const std::chrono::milliseconds fileDuration = 1000s;
+  auto multiEpResult = MakeMultiEpResult(0ms, 500s, fileDuration);
+  CallParseEditsForEpisode(edl, multiEpResult, fileDuration);
+
+  // The end cut [500s - 1000s] should now appear at the end of the raw edit list
+  EXPECT_TRUE(edl.HasCuts());
+  if (edl.HasCuts())
+  {
+    const auto& edit{edl.GetRawEditList().back()};
+    EXPECT_TRUE(edit.action == EDL::Action::CUT && edit.start == 500s && edit.end == fileDuration)
+        << "Expected end cut [500s - 1000s] at the end of the raw edit list";
+  }
+}
+
+TEST_F(TestParseEditsForEpisode, TotalCutTimeIsRecalculatedAfterEpisodeWindow)
+{
+  // Verify m_totalCutTime is correct after episode window filtering removes cuts
+  // mplayertimebased has cut [5.3s - 7.1s] = 1800ms
+  CEdl edl;
+  CFileItem mediaItem;
+  mediaItem.SetPath(
+      XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebased.mkv"));
+  edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
+  EXPECT_EQ(edl.GetTotalCutTime(), 1800ms);
+
+  // Apply episode window that removes the cut (window starts at 10s)
+  const std::chrono::milliseconds fileDuration = 1000s;
+  auto multiEpResult = MakeMultiEpResult(10s, 0ms, fileDuration);
+  CallParseEditsForEpisode(edl, multiEpResult, fileDuration);
+
+  // The original 1800ms cut is gone; only the episode start cut [0-10s] remains
+  EXPECT_EQ(edl.GetTotalCutTime(), 10s);
+}
+
+TEST_F(TestParseEditsForEpisode, SceneMarkersOutsideEpisodeWindowAreRemoved)
+{
+  // Scene markers outside the episode window should be removed by ParseEditsForEpisode
+  CEdl edl;
+  CFileItem mediaItem;
+  mediaItem.SetPath(
+      XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebased.mkv"));
+  edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
+
+  // There should be 4 scene markers initially
+  // Two explicitly set and two from the commbreak [420s-822s]
+  EXPECT_TRUE(edl.HasSceneMarker() && edl.GetSceneMarkers().size() == 4)
+      << "Expected 4 scene markers initially";
+
+  // The file has scene markers. Apply an episode window [200s - 400s]
+  // Scene markers outside this window should be stripped.
+  const std::chrono::milliseconds fileDuration = 1000s;
+  const std::chrono::milliseconds episodeStart = 200s;
+  auto multiEpResult = MakeMultiEpResult(episodeStart, 400s, fileDuration);
+  CallParseEditsForEpisode(edl, multiEpResult, fileDuration);
+
+  // There should be 1 scene marker remaining
+  EXPECT_TRUE(edl.HasSceneMarker() && edl.GetSceneMarkers().size() == 1)
+      << "Expected only 1 scene marker within the episode window";
+
+  if (edl.HasSceneMarker())
+  {
+    const auto marker{edl.GetSceneMarkers()[0]};
+    EXPECT_EQ(marker, 255300ms - episodeStart);
+  }
+}
+
+TEST_F(TestParseEditsForEpisode, BothStartAndEndCutsApplied)
+{
+  // Apply both a start and end cut, verify both appear in edit list
+  CEdl edl;
+  CFileItem mediaItem;
+  mediaItem.SetPath(
+      XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebased.mkv"));
+  edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
+
+  const std::chrono::milliseconds fileDuration = 1000s;
+  auto multiEpResult = MakeMultiEpResult(20s, 500s, fileDuration);
+  CallParseEditsForEpisode(edl, multiEpResult, fileDuration);
+
+  EXPECT_TRUE(edl.HasCuts() && edl.GetRawEditList().size() >= 2)
+      << "Expected at least 2 cuts - episode start and end";
+
+  // The start cut [0 - 20s] should now appear at the start of the raw edit list
+  if (edl.HasCuts() && edl.GetRawEditList().size() >= 2)
+  {
+    const auto& edit{edl.GetRawEditList()[0]};
+    EXPECT_TRUE(edit.action == EDL::Action::CUT && edit.start == 0ms && edit.end == 20s)
+        << "Expected start cut [0 - 20s] at the start of the raw edit list";
+    // The end cut [500s - 1000s] should now appear at the end of the raw edit list
+    const auto& editEnd{edl.GetRawEditList().back()};
+    EXPECT_TRUE(editEnd.action == EDL::Action::CUT && editEnd.start == 500s &&
+                editEnd.end == fileDuration)
+        << "Expected end cut [500s - 1000s] at the end of the raw edit list";
+  }
+}
+
+TEST_F(TestParseEditsForEpisode, EditsWithinEpisodeWindowAreRetained)
+{
+  // Edits that fall entirely within the episode window must be kept
+  // mplayertimebased has: cut [5.3s-7.1s], mute [15s-16.7s], commbreak [420s-822s]
+  // Apply window [4s - 900s] → cut, mute and commbreak within should survive
+  CEdl edl;
+  CFileItem mediaItem;
+  mediaItem.SetPath(
+      XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebased.mkv"));
+  edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
+
+  const size_t editsBeforeEpisodeWindow = edl.GetRawEditList().size();
+
+  const std::chrono::milliseconds fileDuration = 1000s;
+  auto multiEpResult = MakeMultiEpResult(4s, 900s, fileDuration);
+  CallParseEditsForEpisode(edl, multiEpResult, fileDuration);
+
+  bool cutRetained = false;
+  bool muteRetained = false;
+  bool commbreakRetained = false;
+  for (const auto& edit : edl.GetRawEditList())
+  {
+    if (edit.action == EDL::Action::CUT && edit.start == 5300ms && edit.end == 7100ms)
+      cutRetained = true;
+
+    if (edit.action == EDL::Action::MUTE && edit.start == 15000ms && edit.end == 16700ms)
+      muteRetained = true;
+    if (edit.action == EDL::Action::COMM_BREAK && edit.start == 420000ms && edit.end == 822000ms)
+      commbreakRetained = true;
+  }
+  EXPECT_TRUE(cutRetained) << "Cut [5.3s-7.1s] is within the episode window and should be kept";
+  EXPECT_TRUE(muteRetained) << "Mute [15s-16.7s] is within the episode window and should be kept";
+  EXPECT_TRUE(commbreakRetained)
+      << "CommBreak [420s-822s] is within the episode window and should be kept";
+
+  // Plus episode start and end cuts were added, so total edits = original + 2
+  EXPECT_EQ(edl.GetRawEditList().size(), editsBeforeEpisodeWindow + 2);
+}
+
+TEST_F(TestParseEditsForEpisode, EditStraddlingEpisodeStartIsClamped)
+{
+  // An edit that starts before the episode window but ends inside it should have
+  // its start clamped to the episode start, not be removed entirely.
+  // mplayertimebased has a cut at [5.3s - 7.1s].
+  // Apply an episode window starting at 6s (i.e. start cut [0 - 6s]).
+  // The cut straddles the episode start: starts at 5.3s (outside), ends at 7.1s (inside).
+  // Expected: cut is clamped to [6s - 7.1s], not removed.
+  CEdl edl;
+  CFileItem mediaItem;
+  mediaItem.SetPath(
+      XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebased.mkv"));
+  edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
+  EXPECT_TRUE(edl.HasCuts());
+
+  const std::chrono::milliseconds fileDuration = 1000s;
+  const std::chrono::milliseconds episodeStart = 6s;
+  auto multiEpResult = MakeMultiEpResult(episodeStart, 0ms, fileDuration);
+  CallParseEditsForEpisode(edl, multiEpResult, fileDuration);
+
+  // The cut should have been clamped, not removed
+  bool clampedCutFound = false;
+  bool originalCutFound = false;
+  for (const auto& edit : edl.GetRawEditList())
+  {
+    if (edit.action == EDL::Action::CUT && edit.start == episodeStart && edit.end == 7100ms)
+      clampedCutFound = true;
+    if (edit.action == EDL::Action::CUT && edit.start == 5300ms)
+      originalCutFound = true;
+  }
+  EXPECT_TRUE(clampedCutFound) << "Expected cut clamped to [6s - 7.1s]";
+  EXPECT_FALSE(originalCutFound) << "Original unclamped cut start (5.3s) should not exist";
+}
+
+TEST_F(TestParseEditsForEpisode, EditStraddlingBothBoundariesIsClamped)
+{
+  // An edit that starts before the episode window but ends after the episode window should have
+  // its start and end clamped to the episode window.
+  // mplayertimebased has a commbreak at [420s - 822s].
+  // Apply an episode window starting at 500s and ending at 600s.
+  // The commbreak straddles the episode window: starts at 420s (outside), ends at 822s (outside).
+  // Expected: commbreak is clamped to [500s - 600s], not removed.
+  CEdl edl;
+  CFileItem mediaItem;
+  mediaItem.SetPath(
+      XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebased.mkv"));
+  edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
+
+  const std::chrono::milliseconds fileDuration = 1000s;
+  auto multiEpResult = MakeMultiEpResult(500s, 600s, fileDuration);
+  CallParseEditsForEpisode(edl, multiEpResult, fileDuration);
+
+  bool clampedFound = false;
+  for (const auto& edit : edl.GetRawEditList())
+  {
+    if (edit.action == EDL::Action::COMM_BREAK && edit.start == 500s && edit.end == 600s)
+    {
+      clampedFound = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(clampedFound) << "Expected wide commbreak clamped to episode window [500s - 600s]";
 }

--- a/xbmc/cores/VideoPlayer/Edl/test/TestEdl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl/test/TestEdl.cpp
@@ -35,7 +35,7 @@ TEST_F(TestEdl, TestParsingMplayerTimeBasedEDL)
   CFileItem mediaItem;
   mediaItem.SetPath(
       XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebased.mkv"));
-  const bool found = edl.ReadEditDecisionLists(mediaItem, 0);
+  const bool found = edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
   // expect kodi to be able to parse the file correctly
   EXPECT_EQ(found, true);
   // the file has 5 interest points: 2 scenemarkers, 1 mute, 1 cut and 1 commbreak
@@ -123,7 +123,7 @@ TEST_F(TestEdl, TestParsingMplayerTimeBasedInterleavedCutsEDL)
   CFileItem mediaItem;
   mediaItem.SetPath(XBMC_REF_FILE_PATH(
       "xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebasedinterleavedcuts.mkv"));
-  const bool found = edl.ReadEditDecisionLists(mediaItem, 0);
+  const bool found = edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
   // expect kodi to be able to parse the file correctly
   EXPECT_EQ(found, true);
   EXPECT_EQ(edl.GetEditList().size(), 2);
@@ -153,7 +153,7 @@ TEST_F(TestEdl, TestParsingMplayerFrameBasedEDL)
   CFileItem mediaItem;
   mediaItem.SetPath(
       XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/mplayerframebased.mkv"));
-  const bool found = edl.ReadEditDecisionLists(mediaItem, fps);
+  const bool found = edl.ReadEditDecisionLists(mediaItem, fps, 0ms);
   // expect kodi to be able to parse the file correctly
   EXPECT_EQ(found, true);
   EXPECT_EQ(edl.HasEdits(), true);
@@ -180,7 +180,7 @@ TEST_F(TestEdl, TestParsingMplayerTimeBasedMixedEDL)
   CFileItem mediaItem;
   mediaItem.SetPath(
       XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebasedmixed.mkv"));
-  bool found = edl.ReadEditDecisionLists(mediaItem, 0);
+  bool found = edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
   // expect kodi to be able to parse the file correctly
   EXPECT_EQ(found, true);
   EXPECT_EQ(edl.HasEdits(), true);
@@ -210,7 +210,7 @@ TEST_F(TestEdl, TestParsingVideoRedoEDL)
   // this is an edl file in VideoReDo format
   CFileItem mediaItem;
   mediaItem.SetPath(XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/videoredo.mkv"));
-  bool found = edl.ReadEditDecisionLists(mediaItem, 0);
+  bool found = edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
   EXPECT_EQ(found, true);
   EXPECT_EQ(edl.HasEdits(), true);
   // videoredo only supports cuts or scenemarkers, hence the editlist should be empty. Raw editlist should contain the cuts.
@@ -233,7 +233,7 @@ TEST_F(TestEdl, TestSnapStreamEDL)
   // this is an edl file in SnapStream BeyondTV format
   CFileItem mediaItem;
   mediaItem.SetPath(XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/snapstream.mkv"));
-  const bool found = edl.ReadEditDecisionLists(mediaItem, 0);
+  const bool found = edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
   EXPECT_EQ(found, true);
   // this format only supports commbreak types
   EXPECT_EQ(edl.HasEdits(), true);
@@ -255,12 +255,12 @@ TEST_F(TestEdl, TestComSkipVersion1EDL)
   CFileItem mediaItem;
   mediaItem.SetPath(
       XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/comskipversion1.mkv"));
-  bool found = edl.ReadEditDecisionLists(mediaItem, 0);
+  bool found = edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
   // fps was not supplied, kodi will not be able to process the file
   EXPECT_EQ(found, false);
   // parse the file again this time supplying 60 fps
   const float fps = 60;
-  found = edl.ReadEditDecisionLists(mediaItem, fps);
+  found = edl.ReadEditDecisionLists(mediaItem, fps, 0ms);
   EXPECT_EQ(found, true);
   EXPECT_EQ(edl.HasEdits(), true);
   EXPECT_EQ(edl.GetCutMarkers().empty(), true);
@@ -283,7 +283,7 @@ TEST_F(TestEdl, TestComSkipVersion2EDL)
   CFileItem mediaItem;
   mediaItem.SetPath(
       XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/comskipversion2.mkv"));
-  const bool found = edl.ReadEditDecisionLists(mediaItem, 0);
+  const bool found = edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
   EXPECT_EQ(found, true);
   // fps is obtained from the file as it always takes precedence (note we supplied 0 above),
   // the EDL file has the value of 2500 for fps. kodi converts this to 25 fps by dividing by a factor of 100
@@ -338,7 +338,7 @@ TEST_F(TestEdl, TestCommBreakAdvancedSettings)
   CFileItem mediaItem;
   mediaItem.SetPath(
       XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/edlautowindautowait.mkv"));
-  bool found = edl.ReadEditDecisionLists(mediaItem, 0);
+  bool found = edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
   EXPECT_EQ(found, true);
   // confirm the start and end times of all the commbreaks match
   EXPECT_EQ(edl.GetEditList().size(), 5);
@@ -358,7 +358,7 @@ TEST_F(TestEdl, TestCommBreakAdvancedSettings)
   advancedSettings->m_iEdlCommBreakAutowind = 3; // secs
   EXPECT_EQ(advancedSettings->m_iEdlCommBreakAutowait, 3);
   EXPECT_EQ(advancedSettings->m_iEdlCommBreakAutowind, 3);
-  found = edl.ReadEditDecisionLists(mediaItem, 0);
+  found = edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
   EXPECT_EQ(edl.GetEditList().size(), 5);
   // the second edit has a duration smaller than the autowait
   // this moves the start time to the end of the edit
@@ -408,7 +408,7 @@ TEST_F(TestEdl, TestCommBreakAdvancedSettingsRemoveSmallCommbreaks)
   CFileItem mediaItem;
   mediaItem.SetPath(
       XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/edlautowindautowait.mkv"));
-  const bool found = edl.ReadEditDecisionLists(mediaItem, 0);
+  const bool found = edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
   EXPECT_EQ(found, true);
   EXPECT_EQ(edl.GetEditList().size(), 3);
 }
@@ -437,7 +437,7 @@ TEST_F(TestEdl, TestMergeSmallCommbreaks)
   CFileItem mediaItem;
   mediaItem.SetPath(
       XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/edlautowindautowait.mkv"));
-  const bool found = edl.ReadEditDecisionLists(mediaItem, 0);
+  const bool found = edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
   EXPECT_EQ(found, true);
   // kodi should merge all commbreaks into a single one starting at the first point (0)
   // and ending at the last edit time
@@ -470,7 +470,7 @@ TEST_F(TestEdl, TestMergeSmallCommbreaksAdvanced)
   CFileItem mediaItem;
   mediaItem.SetPath(
       XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/Edl/test/testdata/edlautowindautowait.mkv"));
-  const bool found = edl.ReadEditDecisionLists(mediaItem, 0);
+  const bool found = edl.ReadEditDecisionLists(mediaItem, 0, 0ms);
   EXPECT_EQ(found, true);
   // kodi should merge all commbreaks into two
   EXPECT_EQ(edl.GetEditList().size(), 2);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1455,6 +1455,24 @@ void CVideoPlayer::Prepare()
         starttime = edit->end;
         CLog::Log(LOGDEBUG, "{} - Start position set to end of first cut: {}", __FUNCTION__,
                   starttime.count());
+
+        // If the cut end lands at the start of a commercial break and auto-skip
+        // is enabled, advance past it now
+        if (m_SkipCommercials)
+        {
+          const auto commEdit = m_Edl.InEdit(starttime);
+          if (commEdit && commEdit.value()->action == EDL::Action::COMM_BREAK)
+          {
+            CLog::Log(LOGDEBUG,
+                      "{} - Start position advanced past commercial break [{} - {}] to: {}",
+                      __FUNCTION__, StringUtils::MillisecondsToTimeString(commEdit.value()->start),
+                      StringUtils::MillisecondsToTimeString(commEdit.value()->end),
+                      commEdit.value()->end.count());
+            m_Edl.SetLastEditTime(commEdit.value()->end);
+            m_Edl.SetLastEditActionType(EDL::Action::COMM_BREAK);
+            starttime = commEdit.value()->end;
+          }
+        }
       }
       else if (edit->action == EDL::Action::COMM_BREAK)
       {
@@ -2548,6 +2566,43 @@ bool CVideoPlayer::CheckSceneSkip(const CCurrentStream& current)
   return hasEdit && hasEdit.value()->action == EDL::Action::CUT;
 }
 
+void CVideoPlayer::QueueAutoSceneSkip(std::chrono::milliseconds seekTime)
+{
+  if (m_pDemuxer)
+  {
+    const auto streamLength{
+        std::chrono::milliseconds(static_cast<int64_t>(m_pDemuxer->GetStreamLength()))};
+
+    // Use the same 50ms tolerance as the chapter-seek EOF guard (see HandleMessages PLAYER_SEEK_CHAPTER):
+    // cut/skip time arithmetic can produce a result fractionally past the true stream end due to
+    // millisecond rounding, which would cause the demuxer to stall rather than ending cleanly.
+    if (streamLength > 0ms && seekTime + 50ms >= streamLength)
+    {
+      CLog::Log(LOGDEBUG,
+                "{} - Resolved EDL skip target [{}] is at/near EOF [{}]. Ending playback.",
+                __FUNCTION__, StringUtils::MillisecondsToTimeString(seekTime),
+                StringUtils::MillisecondsToTimeString(streamLength));
+
+      SetCaching(CACHESTATE_DONE);
+
+      // Abort the processing loop immediately, but keep the playback result as "ended".
+      // The caller sets LastEditTime and suppresses any re-trigger (the player is terminating)
+      m_bCloseRequest = false;
+      m_error = false;
+      m_bAbortRequest = true;
+    }
+  }
+
+  CDVDMsgPlayerSeek::CMode mode;
+  mode.time = seekTime.count();
+  mode.backward = true;
+  mode.accurate = true;
+  mode.restore = false;
+  mode.trickplay = false;
+  mode.sync = true;
+  m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
+}
+
 void CVideoPlayer::CheckAutoSceneSkip()
 {
   if (!m_Edl.HasEdits())
@@ -2591,18 +2646,44 @@ void CVideoPlayer::CheckAutoSceneSkip()
                 StringUtils::MillisecondsToTimeString(clock));
 
       // Seeking either goes to the start or the end of the cut depending on the play direction.
-      std::chrono::milliseconds seek = m_playSpeed >= 0 ? edit->end : edit->start;
+      std::chrono::milliseconds seek = m_playSpeed >= 0 ? m_Edl.GetNextPlayableTime(edit->end)
+                                                        : m_Edl.GetPrevPlayableTime(edit->start);
+
+      // If the resolved seek target lands at the start of a commercial break and
+      // auto-skip is enabled, absorb it into this seek so no frames are rendered
+      // before the second CheckAutoSceneSkip cycle would otherwise fire.
+      // The COMM_BREAK edit is preserved so the user can still seek back into it.
+      if (m_playSpeed >= 0 && m_SkipCommercials)
+      {
+        const auto commEdit = m_Edl.InEdit(seek);
+        if (commEdit && commEdit.value()->action == EDL::Action::COMM_BREAK)
+        {
+          CLog::Log(LOGDEBUG,
+                    "{} - CUT seek target [{}] lands in commercial break [{} - {}]; "
+                    "advancing past it in single seek.",
+                    __FUNCTION__, StringUtils::MillisecondsToTimeString(seek),
+                    StringUtils::MillisecondsToTimeString(commEdit.value()->start),
+                    StringUtils::MillisecondsToTimeString(commEdit.value()->end));
+          seek = m_Edl.GetNextPlayableTime(commEdit.value()->end);
+        }
+      }
+
+      if (m_playSpeed >= 0 && seek != edit->end)
+      {
+        CLog::Log(LOGDEBUG, "{} - Resolved cut end [{}] to next playable point [{}].", __FUNCTION__,
+                  StringUtils::MillisecondsToTimeString(edit->end),
+                  StringUtils::MillisecondsToTimeString(seek));
+      }
+      else if (m_playSpeed < 0 && seek != edit->start)
+      {
+        CLog::Log(LOGDEBUG, "{} - Resolved cut start [{}] to prev playable point [{}].",
+                  __FUNCTION__, StringUtils::MillisecondsToTimeString(edit->start),
+                  StringUtils::MillisecondsToTimeString(seek));
+      }
+
       if (m_Edl.GetLastEditTime() != seek)
       {
-        CDVDMsgPlayerSeek::CMode mode;
-        mode.time = seek.count();
-        mode.backward = true;
-        mode.accurate = true;
-        mode.restore = false;
-        mode.trickplay = false;
-        mode.sync = true;
-        m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
-
+        QueueAutoSceneSkip(seek);
         m_Edl.SetLastEditTime(seek);
         m_Edl.SetLastEditActionType(edit->action);
       }
@@ -2611,7 +2692,9 @@ void CVideoPlayer::CheckAutoSceneSkip()
   else if (edit->action == EDL::Action::COMM_BREAK)
   {
     // marker for commbreak may be inaccurate. allow user to skip into break from the back
-    if (m_playSpeed >= 0 && m_Edl.GetLastEditTime() != edit->start && clock < edit->end - 1s)
+    const std::chrono::milliseconds seek = m_Edl.GetNextPlayableTime(edit->end);
+
+    if (m_playSpeed >= 0 && m_Edl.GetLastEditTime() != seek && clock < edit->end - 1s)
     {
       CVariant announcement{StringUtils::SecondsToTimeString(
           std::chrono::duration_cast<std::chrono::seconds>(edit->end - edit->start).count(),
@@ -2619,31 +2702,26 @@ void CVideoPlayer::CheckAutoSceneSkip()
       CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Player, "OnCommercial",
                                                          announcement);
 
-      m_Edl.SetLastEditTime(edit->start);
+      // use resolved seek target, not edit->start, to also suppress
+      // adjacent commercial breaks encountered while seeking
+      m_Edl.SetLastEditTime(seek);
       m_Edl.SetLastEditActionType(edit->action);
 
       if (m_SkipCommercials)
       {
         CLog::Log(LOGDEBUG,
-                  "{} - Clock in commercial break [{} - {}]: {}. Automatically skipping to end of "
-                  "commercial break",
+                  "{} - Clock in commercial break [{} - {}]: {}. Automatically skipping to next "
+                  "playable point [{}].",
                   __FUNCTION__, StringUtils::MillisecondsToTimeString(edit->start),
                   StringUtils::MillisecondsToTimeString(edit->end),
-                  StringUtils::MillisecondsToTimeString(clock));
+                  StringUtils::MillisecondsToTimeString(clock),
+                  StringUtils::MillisecondsToTimeString(seek));
 
-        CDVDMsgPlayerSeek::CMode mode;
-        mode.time = edit->end.count();
-        mode.backward = true;
-        mode.accurate = true;
-        mode.restore = false;
-        mode.trickplay = false;
-        mode.sync = true;
-        m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
+        QueueAutoSceneSkip(seek);
       }
     }
   }
 }
-
 
 void CVideoPlayer::SynchronizeDemuxer()
 {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4058,7 +4058,9 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
     float fFramesPerSecond = 0.0f;
     if (m_CurrentVideo.hint.fpsscale > 0.0f)
       fFramesPerSecond = static_cast<float>(m_CurrentVideo.hint.fpsrate) / static_cast<float>(m_CurrentVideo.hint.fpsscale);
-    m_Edl.ReadEditDecisionLists(m_item, fFramesPerSecond);
+    const std::chrono::milliseconds duration =
+        m_pDemuxer ? std::chrono::milliseconds(m_pDemuxer->GetStreamLength()) : 0ms;
+    m_Edl.ReadEditDecisionLists(m_item, fFramesPerSecond, duration);
     CServiceBroker::GetDataCacheCore().SetEditList(m_Edl.GetEditList());
     CServiceBroker::GetDataCacheCore().SetCuts(m_Edl.GetCutMarkers());
     CServiceBroker::GetDataCacheCore().SetSceneMarkers(m_Edl.GetSceneMarkers());

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -470,6 +470,7 @@ protected:
   void HandlePlaySpeed();
   bool IsInMenuInternal() const;
   void SynchronizeDemuxer();
+  void QueueAutoSceneSkip(std::chrono::milliseconds seekTime);
   void CheckAutoSceneSkip();
   bool CheckContinuity(CCurrentStream& current, DemuxPacket* pPacket);
   bool CheckSceneSkip(const CCurrentStream& current);

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -712,8 +712,14 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetCuts(const CDataCacheCor
   float lastMarker = 0.0f;
   for (const auto& cut : cuts)
   {
-    float marker = cut.count() * 100.0f / duration;
-    if (marker != 0)
+    float marker = static_cast<float>(cut.count()) * 100.0f / static_cast<float>(duration);
+
+    if (marker >= 100.0f)
+      // Cut at or beyond end, no mark needed
+      // Break as cuts stored in time order
+      break;
+
+    if (marker != 0.0f)
       ranges.emplace_back(lastMarker, marker);
 
     lastMarker = marker;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1065,6 +1065,12 @@ bool URIUtils::IsHostOnLAN(const std::string& host, LanCheckMode lanCheckMode)
   return false;
 }
 
+bool URIUtils::IsLocalOrLAN(const std::string& path)
+{
+  // Check if item is on local drive or network share
+  return (IsHD(path) || IsOnLAN(path, LanCheckMode::ANY_PRIVATE_SUBNET)) && !IsInternetStream(path);
+}
+
 bool URIUtils::IsMultiPath(const std::string& strPath)
 {
   return IsProtocol(strPath, "multipath");

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -271,6 +271,7 @@ public:
                       LanCheckMode lanCheckMode = LanCheckMode::ONLY_LOCAL_SUBNET);
   static bool IsHostOnLAN(const std::string& hostName,
                           LanCheckMode lanCheckMode = LanCheckMode::ONLY_LOCAL_SUBNET);
+  static bool IsLocalOrLAN(const std::string& path);
   static bool IsPlugin(const std::string& strFile);
   static bool IsScript(const std::string& strFile);
   static bool IsRAR(const std::string& strFile);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -2082,3 +2082,57 @@ TEST_P(GetFileOrFolderNameTester, TestValue)
 INSTANTIATE_TEST_SUITE_P(TestURIUtils,
                          GetFileOrFolderNameTester,
                          testing::ValuesIn(GetFileOrFolderNameTests));
+
+TEST_F(TestURIUtils, IsLocalOrLAN)
+{
+  // --- Local paths ---
+  // Bare path with no protocol = local HD
+  EXPECT_TRUE(URIUtils::IsLocalOrLAN("/home/user/video.mkv"));
+  EXPECT_TRUE(URIUtils::IsLocalOrLAN("C:\\Videos\\movie.mp4"));
+
+  // Explicit file:// protocol = local HD
+  EXPECT_TRUE(URIUtils::IsLocalOrLAN("file:///home/user/video.mkv"));
+  EXPECT_TRUE(URIUtils::IsLocalOrLAN("file://localhost/C:/Videos/movie.mp4"));
+
+  // resource:// is treated as local by IsHD
+  EXPECT_TRUE(URIUtils::IsLocalOrLAN("resource://plugin.name/video.mkv"));
+
+  // stack:// of local files resolves to local
+  EXPECT_TRUE(URIUtils::IsLocalOrLAN(
+      "stack:///home/user/video_part1.mkv , /home/user/video_part2.mkv"));
+
+  // --- LAN paths ---
+  // SMB shares on private subnet addresses are LAN
+  EXPECT_TRUE(URIUtils::IsLocalOrLAN("smb://192.168.1.10/share/video.mkv"));
+  EXPECT_TRUE(URIUtils::IsLocalOrLAN("smb://10.0.0.5/share/video.mkv"));
+  EXPECT_TRUE(URIUtils::IsLocalOrLAN("smb://172.16.0.1/share/video.mkv"));
+
+  // UPnP is considered LAN by IsOnLAN
+  EXPECT_TRUE(URIUtils::IsLocalOrLAN("upnp://uuid/item"));
+
+  // --- Internet streams: always false regardless of IP ---
+  // HTTP/HTTPS - IsInternetStream takes priority even for private IPs
+  EXPECT_FALSE(URIUtils::IsLocalOrLAN("http://192.168.1.10/video.mkv"));
+  EXPECT_FALSE(URIUtils::IsLocalOrLAN("https://192.168.1.10/video.mkv"));
+
+  // Streaming protocols
+  EXPECT_FALSE(URIUtils::IsLocalOrLAN("rtmp://stream.example.com/live/video"));
+  EXPECT_FALSE(URIUtils::IsLocalOrLAN("rtsp://stream.example.com/video"));
+  EXPECT_FALSE(URIUtils::IsLocalOrLAN("mms://stream.example.com/video"));
+  EXPECT_FALSE(URIUtils::IsLocalOrLAN("rtp://239.0.0.1/video"));
+
+  // stack:// of internet streams is treated as an internet stream
+  EXPECT_FALSE(URIUtils::IsLocalOrLAN(
+      "stack://http://stream.example.com/part1.mkv , http://stream.example.com/part2.mkv"));
+
+  // --- Remote/public internet paths ---
+  // Public internet SMB/NFS hosts are not LAN
+  EXPECT_FALSE(URIUtils::IsLocalOrLAN("smb://203.0.113.5/share/video.mkv"));
+  EXPECT_FALSE(URIUtils::IsLocalOrLAN("nfs://203.0.113.5/export/video.mkv"));
+
+  // Plugins are explicitly excluded by IsOnLAN
+  EXPECT_FALSE(URIUtils::IsLocalOrLAN("plugin://plugin.video.example/play/123"));
+
+  // videodb:// is a virtual path - not HD, not LAN, not an internet stream
+  EXPECT_FALSE(URIUtils::IsLocalOrLAN("videodb://tvshows/titles/1/1/42"));
+}

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3463,6 +3463,50 @@ void CVideoDatabase::GetEpisodesByFileId(int idFile, std::vector<CVideoInfoTag>&
   }
 }
 
+bool CVideoDatabase::GetEpisodeMap(int idShow, EpisodeFileMap& fileMap, int idFile /* = -1 */) const
+{
+  if (!m_pDB)
+    return false;
+
+  std::unique_ptr<dbiplus::Dataset> ds{m_pDB->CreateDataset()};
+  if (!ds)
+    return false;
+
+  return GetEpisodeMap(idShow, fileMap, *ds, idFile);
+}
+
+namespace
+{
+struct BookmarkFieldNames
+{
+  const char* timeInSeconds;
+  const char* totalTimeInSeconds;
+  const char* thumbNailImage;
+  const char* player;
+  const char* playerState;
+  const char* type;
+};
+
+constexpr BookmarkFieldNames bookmarkFields{"timeInSeconds", "totalTimeInSeconds", "thumbNailImage",
+                                            "player",        "playerState",        "type"};
+
+constexpr BookmarkFieldNames episodeBookmarkFields{"epBookmarkTime",  "epBookmarkTotalTime",
+                                                   "epBookmarkThumb", "epBookmarkPlayer",
+                                                   "epBookmarkState", "epBookmarkType"};
+
+void ParseBookmarkFields(dbiplus::Dataset& ds,
+                         CBookmark& bookmark,
+                         const BookmarkFieldNames& fields)
+{
+  bookmark.timeInSeconds = ds.fv(fields.timeInSeconds).get_asDouble();
+  bookmark.totalTimeInSeconds = ds.fv(fields.totalTimeInSeconds).get_asDouble();
+  bookmark.thumbNailImage = ds.fv(fields.thumbNailImage).get_asString();
+  bookmark.player = ds.fv(fields.player).get_asString();
+  bookmark.playerState = ds.fv(fields.playerState).get_asString();
+  bookmark.type = static_cast<CBookmark::EType>(ds.fv(fields.type).get_asInt());
+}
+} // namespace
+
 bool CVideoDatabase::GetEpisodeMap(int idShow,
                                    EpisodeFileMap& fileMap,
                                    dbiplus::Dataset& pDS,
@@ -3471,12 +3515,21 @@ bool CVideoDatabase::GetEpisodeMap(int idShow,
   try
   {
     const std::string sql{PrepareSQL(
-        "select episode_view.*, streamdetails.iVideoDuration as duration from "
-        "episode_view left join streamdetails on episode_view.idFile = streamdetails.idFile "
+        "select episode_view.*, streamdetails.iVideoDuration as duration, "
+        "epBookmark.timeInSeconds as epBookmarkTime, "
+        "epBookmark.totalTimeInSeconds as epBookmarkTotalTime, "
+        "epBookmark.thumbNailImage as epBookmarkThumb, "
+        "epBookmark.player as epBookmarkPlayer, "
+        "epBookmark.playerState as epBookmarkState, "
+        "epBookmark.type as epBookmarkType "
+        "from episode_view "
+        "left join streamdetails on episode_view.idFile = streamdetails.idFile "
         "and streamdetails.iStreamType = %i "
+        "left join bookmark as epBookmark on epBookmark.idBookmark = episode_view.c%02d "
         "where episode_view.idShow = %i "
         "order by cast(episode_view.c%02d as integer), cast(episode_view.c%02d as integer)",
-        CStreamDetail::VIDEO, idShow, VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_EPISODE_EPISODE)};
+        CStreamDetail::VIDEO, VIDEODB_ID_EPISODE_BOOKMARK, idShow, VIDEODB_ID_EPISODE_SEASON,
+        VIDEODB_ID_EPISODE_EPISODE)};
     pDS.query(sql);
 
     // Generate map of episodes in each file (finding base file for bluray://) of show
@@ -3489,12 +3542,25 @@ bool CVideoDatabase::GetEpisodeMap(int idShow,
                                                        pDS.fv("strFileName").get_asString())};
       const std::string baseFile{URIUtils::IsBlurayPath(file) ? URIUtils::GetDiscFile(file) : file};
       // Different scrapers put duration in different places
+      // @todo: this has been fixed in latest tmdb scraper and this (+SQL) can be simplified after PR #27769 is merged
       const unsigned int streamDetailsDuration{pDS.fv("duration").get_asUInt()};
       const unsigned int episodeViewDuration{
           pDS.fv(StringUtils::Format("c{:02}", VIDEODB_ID_EPISODE_RUNTIME).c_str()).get_asUInt()};
       episodeInformation.duration =
           episodeViewDuration > 0 ? episodeViewDuration : streamDetailsDuration;
       episodeInformation.index = index;
+      episodeInformation.season =
+          pDS.fv(StringUtils::Format("c{:02}", VIDEODB_ID_EPISODE_SEASON).c_str()).get_asInt();
+      episodeInformation.episode =
+          pDS.fv(StringUtils::Format("c{:02}", VIDEODB_ID_EPISODE_EPISODE).c_str()).get_asInt();
+
+      // See if there is an episode bookmark for this episode
+      if (!pDS.fv("epBookmarkTime").get_isNull())
+      {
+        CBookmark bookmark;
+        ParseBookmarkFields(pDS, bookmark, episodeBookmarkFields);
+        episodeInformation.bookmark = bookmark;
+      }
 
       fileMap.insert({baseFile, episodeInformation});
       if (idFile > 0 && episodeFile.empty() && pDS.fv("idFile").get_asInt() == idFile)
@@ -3664,21 +3730,22 @@ bool CVideoDatabase::ClearBookMarksOfFile(int idFile,
   return true;
 }
 
+bool CVideoDatabase::GetBookMarkForEpisode(const CVideoInfoTag& tag, CBookmark& bookmark) const
+{
+  return GetBookMarkForEpisode(tag.m_iDbId, bookmark);
+}
 
-bool CVideoDatabase::GetBookMarkForEpisode(const CVideoInfoTag& tag, CBookmark& bookmark)
+bool CVideoDatabase::GetBookMarkForEpisode(int dbId, CBookmark& bookmark) const
 {
   try
   {
-    std::string strSQL = PrepareSQL("select bookmark.* from bookmark join episode on episode.c%02d=bookmark.idBookmark where episode.idEpisode=%i", VIDEODB_ID_EPISODE_BOOKMARK, tag.m_iDbId);
+    std::string strSQL = PrepareSQL("select bookmark.* from bookmark join episode on "
+                                    "episode.c%02d=bookmark.idBookmark where episode.idEpisode=%i",
+                                    VIDEODB_ID_EPISODE_BOOKMARK, dbId);
     m_pDS2->query( strSQL );
     if (!m_pDS2->eof())
     {
-      bookmark.timeInSeconds = m_pDS2->fv("timeInSeconds").get_asDouble();
-      bookmark.totalTimeInSeconds = m_pDS2->fv("totalTimeInSeconds").get_asDouble();
-      bookmark.thumbNailImage = m_pDS2->fv("thumbNailImage").get_asString();
-      bookmark.playerState = m_pDS2->fv("playerState").get_asString();
-      bookmark.player = m_pDS2->fv("player").get_asString();
-      bookmark.type = (CBookmark::EType)m_pDS2->fv("type").get_asInt();
+      ParseBookmarkFields(*m_pDS2, bookmark, bookmarkFields);
     }
     else
     {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -139,11 +139,14 @@ enum class DeleteMovieHashAction
 struct EpisodeInformation
 {
   int index{0};
+  int season{-1};
+  int episode{-1};
   unsigned int duration{0};
+  CBookmark bookmark{};
 };
 
 using EpisodeFileMap = std::multimap<std::string, EpisodeInformation, std::less<>>;
-using EpisodeFileMapEntry = std::pair<std::string, EpisodeInformation>;
+using EpisodeFileMapEntry = EpisodeFileMap::value_type;
 
 static constexpr const char* MULTIPLE_EPISODES{"multiple_episodes"};
 
@@ -308,6 +311,7 @@ public:
   void GetEpisodesByBlurayPath(const std::string& path, std::vector<CVideoInfoTag>& episodes);
   void GetEpisodesByFile(const std::string& strFilenameAndPath, std::vector<CVideoInfoTag>& episodes);
   void GetEpisodesByFileId(int idFile, std::vector<CVideoInfoTag>& episodes);
+  bool GetEpisodeMap(int idShow, EpisodeFileMap& fileMap, int idFile = -1) const;
   bool GetEpisodeMap(int idShow,
                      EpisodeFileMap& fileMap,
                      dbiplus::Dataset& pDS,
@@ -509,7 +513,8 @@ public:
   bool ClearBookMarksOfFile(const std::string& strFilenameAndPath,
                             CBookmark::EType type = CBookmark::STANDARD);
   bool ClearBookMarksOfFile(int idFile, CBookmark::EType type = CBookmark::STANDARD);
-  bool GetBookMarkForEpisode(const CVideoInfoTag& tag, CBookmark& bookmark);
+  bool GetBookMarkForEpisode(int dbId, CBookmark& bookmark) const;
+  bool GetBookMarkForEpisode(const CVideoInfoTag& tag, CBookmark& bookmark) const;
   void AddBookMarkForEpisode(const CVideoInfoTag& tag, const CBookmark& bookmark);
   void DeleteBookMarkForEpisode(const CVideoInfoTag& tag);
   bool GetResumePoint(CVideoInfoTag& tag);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Lets say you have a multi-episode file - `Show S01E01E02.mp4` - and you play the first episode with automatically play next enabled, then the entire file (both episodes) plays through twice - as the entire file is associated with both episodes.

If you set up an episode bookmark for the episodes (either 1 and 2, or just 2) then then entire file still plays for episode 1 (ie. it doesn't stop where episode 1 ends and episode 2 begins) and then plays from the episode bookmark (for episode 2) to the end of the file - for episode 2.

This patch dynamically generates an EDL to only play the segment of the file that relates to the single episode - using episode bookmarks to determine the start and end.

**EDL end point - inclusive or exclusive**

I've also done some investigating as to whether the end of an EDL edit should be treated as inclusive or exclusive. I can't find any definitive documentation. The code is inconsistent.

In `Edl.cpp` the `InEdit()` function uses the comparator `seekTime <= edit.end` - which would suggest inclusivity but in `VideoPlayer.cpp` for both CUTS and COMM_BREAKS a seek is done to `edit->end` which would suggest exclusivity.

Further in `Edl.cpp` there are other inconsistencies - in `GetTimeAfterRestoringCuts()` - being in a cut is defined as `(seek >= edit.start && seek <= edit.end)` but then durations are calculated as `cutTime += edit.end - edit.start;` when technically incusivity would need a `+1ms`

A practical test as follows:
```
50.0 150.0 0
150.0 170.0 1
```
In this case the first cut is applied but the second mute is not - because of the overlap determined by `InDepth()`. But this seems illogical.

I've taken the liberty of making the end exclusive. Firstly it makes the practical test (which seems reasonable to me) work, and secondly the worst case scenario would be 1ms of video between adjacent EDL edits gets played whereas the worst case scenario with inclusivity is a whole edit gets dropped.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #27902.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
