### PR TITLE
GLES: enable HQ scalers (8/10/16-bit) for feature parity with GL renderer

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -124,7 +124,12 @@
           </control>
         </setting>
         <setting id="videoplayer.hqscalerprecision" type="integer" label="13472" help="13473">
-          <requirement>HAS_GL</requirement>
+          <requirement>
+            <or>
+              <condition>HAS_GL</condition>
+              <condition>HAS_GLES</condition>
+            </or>
+          </requirement>
           <level>2</level>
           <default>10</default>
           <constraints>

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -147,6 +147,8 @@ CLinuxRendererGL::CLinuxRendererGL()
     m_intermediateType = GL_UNSIGNED_INT_2_10_10_10_REV;
     m_intermediateGammaCorrection = true;
   }
+  CLog::Log(LOGDEBUG, "GL: HQ scaler precision={}, intermediate format={:#x}",
+            intermediatePrecision, static_cast<unsigned>(m_intermediateFormat));
 }
 
 CLinuxRendererGL::~CLinuxRendererGL()
@@ -240,6 +242,7 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
 
   m_bConfigured = true;
   m_scalingMethodGui = (ESCALINGMETHOD)-1;
+  m_scalingMethod = m_videoSettings.m_ScalingMethod;
 
   // Ensure that textures are recreated and rendering starts only after the 1st
   // frame is loaded after every call to Configure().
@@ -484,9 +487,8 @@ void CLinuxRendererGL::Update()
 {
   if (!m_bConfigured)
     return;
-  ManageRenderArea();
-  m_scalingMethodGui = (ESCALINGMETHOD)-1;
 
+  ManageRenderArea();
   ValidateRenderTarget();
 }
 
@@ -754,7 +756,7 @@ void CLinuxRendererGL::UpdateVideoFilter()
   {
     m_nonLinStretchGui = CDisplaySettings::GetInstance().IsNonLinearStretched();
     m_pixelRatio = CDisplaySettings::GetInstance().GetPixelRatio();
-    m_reloadShaders = 1;
+    m_reloadShaders = true;
     nonLinStretchChanged = true;
 
     if (m_nonLinStretchGui && (m_pixelRatio < 0.999f || m_pixelRatio > 1.001f) && Supports(RENDERFEATURE_NONLINSTRETCH))
@@ -772,18 +774,26 @@ void CLinuxRendererGL::UpdateVideoFilter()
   CRect srcRect, dstRect, viewRect;
   GetVideoRect(srcRect, dstRect, viewRect);
 
+  // TODO: UpdateVideoFilter may be called with a 0x0 viewport before the
+  // display resolution is established (the WHITELIST/resolution ADJUST happens
+  // ~500ms after the first RenderUpdate). The root-cause fix is in PR #28161
+  // (viewport-0x0-fix). Remove this bail-out once #28161 lands on master.
+  if (viewRect.Height() == 0 || viewRect.Width() == 0)
+    return;
+
   if (m_scalingMethodGui == m_videoSettings.m_ScalingMethod &&
       viewRect.Height() == m_viewRect.Height() &&
       viewRect.Width() == m_viewRect.Width() &&
       !nonLinStretchChanged && !cmsChanged)
     return;
-  else
-    m_reloadShaders = 1;
 
-  // recompile YUV shader when non-linear stretch is turned on/off
-  // or when it's on and the scaling method changed
-  if (m_nonLinStretch || nonLinStretchChanged)
-    m_reloadShaders = 1;
+  // Reload shader when the scaling method, non-linear stretch state, or CMS
+  // configuration changes. Also reload when non-linear stretch is currently
+  // active, because its shader bakes in viewport-dependent stretch parameters
+  // and we may be here due to a viewport change.
+  if (m_scalingMethod != m_videoSettings.m_ScalingMethod || nonLinStretchChanged || cmsChanged ||
+      m_nonLinStretch)
+    m_reloadShaders = true;
 
   if (cmsChanged)
   {
@@ -897,6 +907,8 @@ void CLinuxRendererGL::UpdateVideoFilter()
         break;
       }
 
+      // TODO: consider falling back to GL_RGBA8 if requested format fails,
+      // as GLES does for GL_RGB10_A2 / GL_RGBA16F on GLES 2.0 contexts.
       if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight,
                                             m_intermediateFormat, m_intermediateType, GL_NEAREST))
       {
@@ -920,6 +932,9 @@ void CLinuxRendererGL::UpdateVideoFilter()
       break;
     }
 
+    CLog::Log(LOGINFO, "GL: FBO intermediate format {:#x}",
+              static_cast<unsigned>(m_intermediateFormat));
+    CLog::Log(LOGINFO, "GL: Selecting multi pass rendering");
     m_renderQuality = RQ_MULTIPASS;
     return;
 
@@ -945,7 +960,8 @@ void CLinuxRendererGL::UpdateVideoFilter()
   m_pVideoFilterShader = new DefaultFilterShader();
   if (!m_pVideoFilterShader->CompileAndLink())
   {
-    CLog::Log(LOGERROR, "CLinuxRendererGL::UpdateVideoFilter: Error compiling and linking defauilt video filter shader");
+    CLog::Log(LOGERROR, "CLinuxRendererGL::UpdateVideoFilter: Error compiling and linking default "
+                        "video filter shader");
   }
 
   SetTextureFilter(GL_LINEAR);
@@ -954,7 +970,7 @@ void CLinuxRendererGL::UpdateVideoFilter()
 
 void CLinuxRendererGL::LoadShaders(int field)
 {
-  m_reloadShaders = 0;
+  m_reloadShaders = false;
 
   if (!LoadShadersHook())
   {
@@ -1120,7 +1136,7 @@ void CLinuxRendererGL::RenderSinglePass(int index, int field)
 
   if (m_reloadShaders)
   {
-    m_reloadShaders = 0;
+    m_reloadShaders = false;
     LoadShaders(field);
   }
 
@@ -1275,7 +1291,7 @@ void CLinuxRendererGL::RenderToFBO(int index, int field, bool weave /*= false*/)
 
   if (m_reloadShaders)
   {
-    m_reloadShaders = 0;
+    m_reloadShaders = false;
     LoadShaders(m_currentField);
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -163,7 +163,7 @@ protected:
 
   // Raw data used by renderer
   int m_currentField = FIELD_FULL;
-  int m_reloadShaders = 0;
+  bool m_reloadShaders = false;
 
   struct CYuvPlane
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -43,6 +43,23 @@ CLinuxRendererGLES::CLinuxRendererGLES()
 
   m_renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
 
+#if defined(GL_ES_VERSION_3_0)
+  int32_t intermediatePrecision = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_VIDEOPLAYER_HQSCALERPRECISION);
+  if (intermediatePrecision == 16)
+  {
+    m_intermediateFormat = GL_RGBA16F;
+    m_intermediateType = GL_FLOAT;
+  }
+  else if (intermediatePrecision == 10)
+  {
+    m_intermediateFormat = GL_RGB10_A2;
+    m_intermediateType = GL_UNSIGNED_INT_2_10_10_10_REV;
+  }
+  CLog::Log(LOGDEBUG, "GLES: HQ scaler precision={}, intermediate format={:#x}",
+            intermediatePrecision, static_cast<unsigned>(m_intermediateFormat));
+#endif
+
 #if defined (GL_UNPACK_ROW_LENGTH_EXT)
   if (CGLExtensions::IsExtensionSupported(CGLExtensions::EXT_unpack_subimage))
   {
@@ -125,6 +142,7 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
 
   m_bConfigured = true;
   m_scalingMethodGui = (ESCALINGMETHOD)-1;
+  m_scalingMethod = m_videoSettings.m_ScalingMethod;
 
   // Ensure that textures are recreated and rendering starts only after the 1st
   // frame is loaded after every call to Configure().
@@ -579,6 +597,15 @@ void CLinuxRendererGLES::UpdateVideoFilter()
   CRect viewRect;
   GetVideoRect(srcRect, dstRect, viewRect);
 
+  // TODO: ValidateRenderTarget runs before the display resolution is established
+  // (the WHITELIST/resolution ADJUST happens ~500ms after the first RenderUpdate).
+  // This causes UpdateVideoFilter to be called with a 0x0 viewport. The proper fix
+  // is in CRenderManager to defer rendering until the resolution is ready.
+  if (viewRect.Height() == 0 || viewRect.Width() == 0)
+    return;
+
+  // TODO: GL also checks nonLinStretchChanged and cmsChanged in the early exit
+  // and the reload check below. Add when non-linear stretch and CMS are ported to GLES.
   if (m_scalingMethodGui == m_videoSettings.m_ScalingMethod &&
       viewRect.Height() == m_viewRect.Height() &&
       viewRect.Width() == m_viewRect.Width())
@@ -586,9 +613,11 @@ void CLinuxRendererGLES::UpdateVideoFilter()
     return;
   }
 
-  m_scalingMethodGui = m_videoSettings.m_ScalingMethod;
-  if (m_scalingMethod != m_scalingMethodGui)
+  // Viewport-only change doesn't need shader reload -- only method changes do
+  if (m_scalingMethod != m_videoSettings.m_ScalingMethod)
     m_reloadShaders = true;
+
+  m_scalingMethodGui = m_videoSettings.m_ScalingMethod;
   m_scalingMethod = m_scalingMethodGui;
   m_viewRect = viewRect;
 
@@ -611,24 +640,55 @@ void CLinuxRendererGLES::UpdateVideoFilter()
 
   VerifyGLState();
 
+  if (m_scalingMethod == VS_SCALINGMETHOD_AUTO)
+  {
+    bool scaleSD = m_sourceHeight < 720 && m_sourceWidth < 1280;
+    bool scaleUp =
+        (int)m_sourceHeight < m_viewRect.Height() && (int)m_sourceWidth < m_viewRect.Width();
+    bool scaleFps =
+        m_fps <
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoAutoScaleMaxFps +
+            0.01f;
+
+    if (Supports(VS_SCALINGMETHOD_LANCZOS3_FAST) && scaleSD && scaleUp && scaleFps)
+      m_scalingMethod = VS_SCALINGMETHOD_LANCZOS3_FAST;
+    else
+      m_scalingMethod = VS_SCALINGMETHOD_LINEAR;
+  }
+
   switch (m_scalingMethod)
   {
   case VS_SCALINGMETHOD_NEAREST:
+  case VS_SCALINGMETHOD_LINEAR:
   {
-    CLog::Log(LOGINFO, "GLES: Selecting single pass rendering");
-    SetTextureFilter(GL_NEAREST);
+    // TODO: GL creates DefaultFilterShader here (or StretchFilterShader for
+    // non-linear stretch). Add when non-linear stretch is ported to GLES.
+    SetTextureFilter(m_scalingMethod == VS_SCALINGMETHOD_NEAREST ? GL_NEAREST : GL_LINEAR);
     m_renderQuality = RQ_SINGLEPASS;
     return;
   }
-  case VS_SCALINGMETHOD_LINEAR:
   case VS_SCALINGMETHOD_LANCZOS3_FAST:
   case VS_SCALINGMETHOD_SPLINE36_FAST:
   {
-    CLog::Log(LOGINFO, "GLES: Selecting single pass rendering");
-    SetTextureFilter(GL_LINEAR);
-    m_renderQuality = RQ_SINGLEPASS;
-    return;
+    // On GLES 3.1+, FAST scalers use a single-pass combined YUV+convolution shader
+    // (YUV2RGBFilterShader with textureGather). On lower versions, fall through to
+    // multi-pass FBO path. Matches GL 4.0+ single-pass / GL <4.0 multi-pass pattern.
+    EShaderFormat fmt = GetShaderFormat();
+    if (fmt == SHADER_NV12 || (fmt >= SHADER_YV12 && fmt <= SHADER_YV12_16))
+    {
+      uint32_t major, minor;
+      m_renderSystem->GetRenderVersion(major, minor);
+      if (major >= 3 && minor >= 1)
+      {
+        SetTextureFilter(GL_LINEAR);
+        m_renderQuality = RQ_SINGLEPASS;
+        return;
+      }
+    }
+
+    [[fallthrough]];
   }
+
   case VS_SCALINGMETHOD_LANCZOS2:
   case VS_SCALINGMETHOD_SPLINE36:
   case VS_SCALINGMETHOD_LANCZOS3:
@@ -646,13 +706,34 @@ void CLinuxRendererGLES::UpdateVideoFilter()
         break;
       }
 
-      if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight, GL_RGBA))
+      // m_intermediateFormat and m_intermediateType are set in the constructor from
+      // hqscalerprecision setting. Try requested format first, fall back to GL_RGBA
+      // if unsupported (e.g. GLES 2.0 context where GL_RGB10_A2 / GL_RGBA16F are
+      // not available).
+      if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight,
+                                            m_intermediateFormat, m_intermediateType, GL_NEAREST))
       {
-        CLog::Log(LOGERROR, "GLES: Error creating texture and binding to FBO");
-        break;
+        if (m_intermediateFormat != GL_RGBA)
+        {
+          m_intermediateFormat = GL_RGBA;
+          m_intermediateType = GL_UNSIGNED_BYTE;
+          if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight,
+                                                GL_RGBA))
+          {
+            CLog::Log(LOGERROR, "GLES: Error creating texture and binding to FBO");
+            break;
+          }
+        }
+        else
+        {
+          CLog::Log(LOGERROR, "GLES: Error creating texture and binding to FBO");
+          break;
+        }
       }
     }
 
+    // TODO: GL passes additional params: m_nonLinStretch, m_intermediateGammaCorrection,
+    // GLSLOutput* (for dithering and color management). Add when ported to GLES.
     m_pVideoFilterShader = new ConvolutionFilterShader(m_scalingMethod);
     if (!m_pVideoFilterShader->CompileAndLink())
     {
@@ -660,6 +741,8 @@ void CLinuxRendererGLES::UpdateVideoFilter()
       break;
     }
 
+    CLog::Log(LOGINFO, "GLES: FBO intermediate format {:#x}",
+              static_cast<unsigned>(m_intermediateFormat));
     CLog::Log(LOGINFO, "GLES: Selecting multi pass rendering");
     SetTextureFilter(GL_LINEAR);
     m_renderQuality = RQ_MULTIPASS;
@@ -686,13 +769,20 @@ void CLinuxRendererGLES::UpdateVideoFilter()
 
   m_fbo.fbo.Cleanup();
 
+  m_pVideoFilterShader = new DefaultFilterShader();
+  if (!m_pVideoFilterShader->CompileAndLink())
+  {
+    CLog::Log(LOGERROR, "CLinuxRendererGLES::UpdateVideoFilter: Error compiling and linking "
+                        "default video filter shader");
+  }
+
   SetTextureFilter(GL_LINEAR);
   m_renderQuality = RQ_SINGLEPASS;
 }
 
 void CLinuxRendererGLES::LoadShaders(int field)
 {
-  m_reloadShaders = 0;
+  m_reloadShaders = false;
 
   if (!LoadShadersHook())
   {
@@ -709,25 +799,44 @@ void CLinuxRendererGLES::LoadShaders(int field)
         // Try GLSL shaders if supported and user requested auto or GLSL.
         if (glCreateProgram())
         {
-          // create regular scan shader
-          CLog::Log(LOGINFO, "GLES: Selecting YUV 2 RGB shader");
-
           EShaderFormat shaderFormat = GetShaderFormat();
           m_toneMapMethod = m_videoSettings.m_ToneMapMethod;
-          if (m_scalingMethod == VS_SCALINGMETHOD_LANCZOS3_FAST ||
-              m_scalingMethod == VS_SCALINGMETHOD_SPLINE36_FAST)
+
+          // Try single-pass filter shader for FAST scalers on GLES 3.1+
+          if (m_renderQuality == RQ_SINGLEPASS &&
+              (m_scalingMethod == VS_SCALINGMETHOD_LANCZOS3_FAST ||
+               m_scalingMethod == VS_SCALINGMETHOD_SPLINE36_FAST))
           {
             m_pYUVProgShader = new YUV2RGBFilterShader(
                 shaderFormat, m_passthroughHDR ? m_srcPrimaries : AVColorPrimaries::AVCOL_PRI_BT709,
                 m_srcPrimaries, m_toneMap, m_toneMapMethod, m_scalingMethod);
+            // TODO: GL gates this on !m_cmsOn. Add when CMS is ported to GLES.
+            m_pYUVProgShader->SetConvertFullColorRange(m_fullRange);
+
+            CLog::Log(LOGINFO, "GLES: Selecting YUV 2 RGB shader with filter");
+
+            if (m_pYUVProgShader->CompileAndLink())
+            {
+              m_renderMethod = RENDER_GLSL;
+              UpdateVideoFilter();
+              break;
+            }
+            else
+            {
+              CLog::Log(LOGERROR, "GLES: Error enabling YUV2RGB GLSL shader");
+              delete m_pYUVProgShader;
+              m_pYUVProgShader = nullptr;
+            }
           }
-          else
-          {
-            m_pYUVProgShader = new YUV2RGBProgressiveShader(
-                shaderFormat, m_passthroughHDR ? m_srcPrimaries : AVColorPrimaries::AVCOL_PRI_BT709,
-                m_srcPrimaries, m_toneMap, m_toneMapMethod);
-          }
+
+          // Fall back to regular progressive shader
+          m_pYUVProgShader = new YUV2RGBProgressiveShader(
+              shaderFormat, m_passthroughHDR ? m_srcPrimaries : AVColorPrimaries::AVCOL_PRI_BT709,
+              m_srcPrimaries, m_toneMap, m_toneMapMethod);
           m_pYUVProgShader->SetConvertFullColorRange(m_fullRange);
+
+          CLog::Log(LOGINFO, "GLES: Selecting YUV 2 RGB shader");
+
           m_pYUVBobShader = new YUV2RGBBobShader(
               shaderFormat, m_passthroughHDR ? m_srcPrimaries : AVColorPrimaries::AVCOL_PRI_BT709,
               m_srcPrimaries, m_toneMap, m_toneMapMethod);
@@ -926,6 +1035,7 @@ void CLinuxRendererGLES::RenderSinglePass(int index, int field)
 
   if (m_reloadShaders)
   {
+    m_reloadShaders = false;
     LoadShaders(field);
   }
 
@@ -1035,7 +1145,7 @@ void CLinuxRendererGLES::RenderToFBO(int index, int field)
 
   if (m_reloadShaders)
   {
-    m_reloadShaders = 0;
+    m_reloadShaders = false;
     LoadShaders(m_currentField);
   }
 
@@ -1047,7 +1157,8 @@ void CLinuxRendererGLES::RenderToFBO(int index, int field)
       return;
     }
 
-    if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight, GL_RGBA))
+    if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight, GL_RGBA,
+                                          GL_SHORT))
     {
       CLog::Log(LOGERROR, "GLES: Error creating texture and binding to FBO");
       return;
@@ -1742,8 +1853,8 @@ bool CLinuxRendererGLES::SupportsMultiPassRendering()
 
 bool CLinuxRendererGLES::Supports(ESCALINGMETHOD method) const
 {
-  if(method == VS_SCALINGMETHOD_NEAREST ||
-     method == VS_SCALINGMETHOD_LINEAR)
+  if (method == VS_SCALINGMETHOD_NEAREST || method == VS_SCALINGMETHOD_LINEAR ||
+      method == VS_SCALINGMETHOD_AUTO)
   {
     return true;
   }
@@ -1759,18 +1870,6 @@ bool CLinuxRendererGLES::Supports(ESCALINGMETHOD method) const
       method == VS_SCALINGMETHOD_SPLINE36 ||
       method == VS_SCALINGMETHOD_LANCZOS3)
   {
-    if (method == VS_SCALINGMETHOD_SPLINE36_FAST || method == VS_SCALINGMETHOD_LANCZOS3_FAST)
-    {
-#if defined(GL_ES_VERSION_3_0)
-      // we need GLES 3.0 headers for GL_RGBA16f, but GLES 3.1 for the shader
-      uint32_t major, minor;
-      m_renderSystem->GetRenderVersion(major, minor);
-      if (major < 3 || minor == 0)
-        return false;
-#else
-      return false;
-#endif
-    }
     // if scaling is below level, avoid hq scaling
     float scaleX = fabs((static_cast<float>(m_sourceWidth) - m_destRect.Width()) / m_sourceWidth) * 100;
     float scaleY = fabs((static_cast<float>(m_sourceHeight) - m_destRect.Height()) / m_sourceHeight) * 100;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -147,7 +147,7 @@ protected:
 
   // Raw data used by renderer
   int m_currentField{FIELD_FULL};
-  int m_reloadShaders{0};
+  bool m_reloadShaders{false};
   CRenderSystemGLES *m_renderSystem{nullptr};
   GLenum m_pixelStoreKey{0};
 
@@ -207,6 +207,9 @@ protected:
   bool m_toneMap = false;
   ETONEMAPMETHOD m_toneMapMethod = VS_TONEMAPMETHOD_OFF;
   bool m_passthroughHDR = false;
+  GLint m_intermediateFormat{GL_RGBA};
+  GLint m_intermediateType{GL_UNSIGNED_BYTE};
+  // TODO: GL has m_intermediateGammaCorrection -- add when ported to GLES
   unsigned char* m_planeBuffer = nullptr;
   size_t m_planeBufferSize = 0;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -284,9 +284,7 @@ YUV2RGBFilterShader::YUV2RGBFilterShader(EShaderFormat format,
   m_scaling = method;
   PixelShader()->LoadSource("gles310_yuv2rgb_filter.frag", m_defines);
   VertexShader()->LoadSource("gles310_yuv2rgb.vert");
-  PixelShader()->AppendSource("gl_output.glsl");
-
-  PixelShader()->InsertSource("gl_tonemap.glsl", "void main()");
+  PixelShader()->InsertSource("gles_tonemap.frag", "void main()");
 }
 
 YUV2RGBFilterShader::~YUV2RGBFilterShader()


### PR DESCRIPTION
## Description
(UPDATED)

Add configurable FBO intermediate precision (8/10/16-bit) for GLES HQ scalers. Fix crash when FAST scalers are combined with HDR tone mapping (#25801). Fix several bugs in both GL and GLES renderers.

NOTE: GLES has had working HQ scalers (multi-pass FBO with ConvolutionFilterShader) since #12474 (2017). This PR does NOT enable HQ scalers from scratch -- it adds higher-precision FBO intermediates for parity with GL, fixes bugs, and improves "FAST" (aka "Optimized") scaler routing.

Bug fixes (critical)

- Fix #25801 -- FAST scaler + tone mapping crash: YUV2RGBFilterShader (from #24611) included GL-only shader files (gl_tonemap.glsl, gl_output.glsl) instead of GLES equivalent (gles_tonemap.frag). When tone mapping was active, the shader failed to compile (inversePQ() and hable() undefined), causing a null dereference crash.
- Fix LoadShaders double initialization: Filter shader was created regardless of RQ_SINGLEPASS. In multi-pass mode (FAST on < GLES 3.1), the wrong shader type was used for the YUV pass. Also added fallback to YUV2RGBProgressiveShader on compile failure.

Bug fixes (other)

- Configure() not initializing m_scalingMethod -- stale value persists across videos (both GL and GLES)
- GL Update() resetting m_scalingMethodGui to -1 on every call, causing needless shader/FBO recreation on window resize, pause/resume
- Viewport 0x0 guard in UpdateVideoFilter -- ValidateRenderTarget calls it before display resolution is established
- DefaultFilterShader fallback for GLES -- prevents null m_pVideoFilterShader after scaler initialization failure

Features

- Configurable FBO intermediate precision (8/10/16-bit) via hqscalerprecision setting, now exposed on GLES builds (was GL-only). GL_RGB10_A2 for 10-bit, GL_RGBA16F for 16-bit, with fallback to GL_RGBA
- AUTO scaling method on GLES (resolves to Lanczos3 Fast for SD upscaling, otherwise Linear)
- FAST scalers available on all GLES versions: single-pass with textureGather on GLES 3.1+, multi-pass FBO fallback on lower versions

Type correctness / cosmetic
- m_reloadShaders int->bool across both renderers
- Typo fix in GL error log ("defauilt" -> "default")

Changes settings.xml to allow hqscalerprecision on HAS_GLES builds.

NOTE: this applies to 4:2:0 video only.  4:2:2 will come in future PR.

NOTE: DRMPRIMEGLES support will come in future PR.

## Motivation and context
Feature parity for GLES renderers. Users on GBM/GLES platforms (RPi, RK3588, x86 with GLES) had no access to HQ scalers (8/10/16-bit) that GL users have had for years. This is part of a broader effort to reach GL/GLES feature parity.

## How has this been tested?
Tested on Intel NUC (i3-8109U) with mesa iris GLES 3.1:
- All HQ scaler methods verified working (Lanczos2/3, Spline36, cubics)
- FAST variants use single-pass on GLES 3.1+, multi-pass FBO on lower versions
- FBO precision 8/10/16-bit verified
- Fallback to GL_RGBA when higher precision not available
- No regressions on YUV420P or NV12 software decode

## What is the effect on users?
Brings high-quality scaling to GLES platforms; better scaled video.  Potentially allows Libreelec move to GLES everywhere not just ARM SoC.

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
