### PR TITLE
[Wayland] Use wl_output.name for display names instead of deprecated make/model

### DIFF
--- a/xbmc/windowing/wayland/Output.cpp
+++ b/xbmc/windowing/wayland/Output.cpp
@@ -67,6 +67,22 @@ COutput::COutput(std::uint32_t globalName,
     m_scale = scale;
   };
 
+  // wl_output.name and description were added in version 4
+  // wl_output.name is the plain output name, e.g. HDMI-A-1
+  // wl_output.description is a human-readable display name e.g. Samsung
+  // Electric Company QBQ90S 0x01000E00
+  m_output.on_name() = [this](std::string const& name)
+  {
+    std::unique_lock lock(m_geometryCriticalSection);
+    m_name = name;
+  };
+
+  m_output.on_description() = [this](std::string const& description)
+  {
+    std::unique_lock lock(m_geometryCriticalSection);
+    m_description = description;
+  };
+
   m_output.on_done() = [this]()
   {
 #ifndef TARGET_WEBOS

--- a/xbmc/windowing/wayland/Output.h
+++ b/xbmc/windowing/wayland/Output.h
@@ -72,6 +72,16 @@ public:
     std::unique_lock lock(m_geometryCriticalSection);
     return m_model;
   }
+  std::string const& GetName() const
+  {
+    std::unique_lock lock(m_geometryCriticalSection);
+    return m_name;
+  }
+  std::string const& GetDescription() const
+  {
+    std::unique_lock lock(m_geometryCriticalSection);
+    return m_description;
+  }
   std::int32_t GetScale() const
   {
     return m_scale;
@@ -136,7 +146,7 @@ private:
 
   CPointInt m_position;
   CSizeInt m_physicalSize;
-  std::string m_make, m_model;
+  std::string m_make, m_model, m_name, m_description;
   std::atomic<std::int32_t> m_scale{1}; // default scale of 1 if no wl_output::scale is sent
 
   std::set<Mode> m_modes;

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -171,7 +171,8 @@ bool CWinSystemWayland::InitWindowSystem()
   m_registry->RequestSingleton(m_presentation, 1, 1, false);
   // version 2 adds done() -> required
   // version 3 adds destructor -> optional
-  m_registry->Request<wayland::output_t>(2, 3, std::bind(&CWinSystemWayland::OnOutputAdded, this, _1, _2), std::bind(&CWinSystemWayland::OnOutputRemoved, this, _1));
+  // version 4 adds name() and description() -> optional, used for connector names (HDMI-A-1 etc.)
+  m_registry->Request<wayland::output_t>(2, 4, std::bind(&CWinSystemWayland::OnOutputAdded, this, _1, _2), std::bind(&CWinSystemWayland::OnOutputRemoved, this, _1));
 
   m_registry->Bind();
 
@@ -1100,14 +1101,30 @@ CWinSystemWayland::SizeUpdateInformation CWinSystemWayland::UpdateSizeVariables(
 std::string CWinSystemWayland::UserFriendlyOutputName(std::shared_ptr<COutput> const& output)
 {
   std::vector<std::string> parts;
-  if (!output->GetMake().empty())
+
+  // Prefer wl_output.description (v4, e.g. "Samsung Electric Company QBQ90S
+  // 0x01000E00") over wl_output.name (v4, e.g. "HDMI-A-1") over legacy
+  // make/model from wl_output.geometry.
+  if (!output->GetDescription().empty())
   {
-    parts.emplace_back(output->GetMake());
+    parts.emplace_back(output->GetDescription());
   }
-  if (!output->GetModel().empty())
+  else if (!output->GetName().empty())
   {
-    parts.emplace_back(output->GetModel());
+    parts.emplace_back(output->GetName());
   }
+  else
+  {
+    if (!output->GetMake().empty())
+    {
+      parts.emplace_back(output->GetMake());
+    }
+    if (!output->GetModel().empty())
+    {
+      parts.emplace_back(output->GetModel());
+    }
+  }
+
   if (parts.empty())
   {
     // Fallback to "unknown" if no name received from compositor


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Changes:
- Bump the requested wl_output protocol version from 3 to 4 in WinSystemWayland.cpp
- Subscribe to the on_name() event in Output.cpp to capture the connector name (e.g. HDMI-A-1, DP-1)
- Expose it via GetName() in Output.h
- Update UserFriendlyOutputName() to prefer the connector name from wl_output.name over EDID make/model; the old EDID path remains as a fallback for compositors that don't support wl_output v4

Version 4 is backward-compatible - if the compositor only supports up to v3, on_name() is never called and the existing make/model fallback behaviour is unchanged.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

wlroots 0.21 (pulled into Sway on 2026-03-20) intentionally stopped populating the make/model fields of wl_output.geometry, hardcoding "Unknown" instead. This caused Kodi to display all monitors as "Unknown Unknown" under Sway and any other compositor based on wlroots 0.21+. The wlroots commit message ([c2327248](https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/c2327248f8a22b3e66e00a6e8bccb3771834cad9)) explicitly states these are legacy fields and clients should migrate to wl_output.name and wl_output.description (added in wl_output version 4).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Launch Kodi on Wayland (Sway git)
- Enter Settings -> System -> Display
- Change the monitor from `Default` to any other value

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

- Correct monitor name displayed in settings.
- Correct placement of Kodi on the configured monitor.

## Screenshots (if appropriate):

After: 
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/aec38f3c-9709-42f3-8324-b94267bfebf4" />

Before (different res, because Kodi opened on the wrong display):

<img width="3440" height="1440" alt="image" src="https://github.com/user-attachments/assets/c33f0a07-4634-4462-898c-2adce4c7f41a" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
