### PR TITLE
[ActiveAE] Fix audio sync errors during seeks on high tempo like 1.6x

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -80,10 +80,11 @@ void CEngineStats::GetDelay(AEDelayStatus& status)
   std::unique_lock lock(m_lock);
   status = m_sinkDelay;
   if (m_pcmOutput)
-    status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
+    status.delay += static_cast<double>(m_bufferedSamples) / m_sinkSampleRate;
   else
-    status.delay +=
-        static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
+    status.delay += static_cast<double>(static_cast<int64_t>(m_bufferedSamples) *
+                                        m_sinkFormat.m_streamInfo.GetDuration()) /
+                    1000.0;
 }
 
 void CEngineStats::AddStream(unsigned int streamid)
@@ -152,10 +153,11 @@ void CEngineStats::GetDelay(AEDelayStatus& status, CActiveAEStream *stream)
   status = m_sinkDelay;
   status.delay += static_cast<double>(m_sinkLatency);
   if (m_pcmOutput)
-    status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
+    status.delay += static_cast<double>(m_bufferedSamples) / m_sinkSampleRate;
   else
-    status.delay +=
-        static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
+    status.delay += static_cast<double>(static_cast<int64_t>(m_bufferedSamples) *
+                                        m_sinkFormat.m_streamInfo.GetDuration()) /
+                    1000.0;
 
   for (auto &str : m_streamStats)
   {
@@ -176,10 +178,11 @@ void CEngineStats::GetSyncInfo(CAESyncInfo& info, CActiveAEStream *stream)
   AEDelayStatus status;
   status = m_sinkDelay;
   if (m_pcmOutput)
-    status.delay += (double)m_bufferedSamples / m_sinkSampleRate;
+    status.delay += static_cast<double>(m_bufferedSamples) / m_sinkSampleRate;
   else
-    status.delay +=
-        static_cast<double>(m_bufferedSamples) * m_sinkFormat.m_streamInfo.GetDuration() / 1000;
+    status.delay += static_cast<double>(static_cast<int64_t>(m_bufferedSamples) *
+                                        m_sinkFormat.m_streamInfo.GetDuration()) /
+                    1000.0;
 
   status.delay += static_cast<double>(m_sinkLatency);
 
@@ -234,7 +237,9 @@ float CEngineStats::GetWaterLevel()
   if (m_pcmOutput)
     return static_cast<float>(m_bufferedSamples) / m_sinkSampleRate;
   else
-    return static_cast<float>(m_bufferedSamples * m_sinkFormat.m_streamInfo.GetDuration()) / 1000;
+    return static_cast<float>(static_cast<int64_t>(m_bufferedSamples) *
+                              m_sinkFormat.m_streamInfo.GetDuration()) /
+           1000.0f;
 }
 
 void CEngineStats::SetSuspended(bool state)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -500,6 +500,23 @@ bool CActiveAEBufferPoolAtempo::ProcessBuffers()
     {
       in = m_inputSamples.front();
       m_inputSamples.pop_front();
+
+      // 1. If the video file provides a new time (like a seek), use it. Otherwise, calculate the next time
+      if (in->timestamp)
+      {
+        m_lastSamplePts = in->timestamp;
+      }
+      else
+      {
+        in->pkt_start_offset = 0;
+        // 2. Give the audio its correct time if it was missing
+        in->timestamp = m_lastSamplePts;
+      }
+
+      // 3. Tick the internal clock forward for the next piece of audio
+      m_lastSamplePts += static_cast<int64_t>(in->pkt->nb_samples - in->pkt_start_offset) * 1000 /
+                         m_format.m_sampleRate;
+
       m_outputSamples.push_back(in);
       busy = true;
     }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -297,14 +297,15 @@ bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
         }
 
         // pts of last sample we added to the buffer
-        m_lastSamplePts +=
-            (in->pkt->nb_samples - in->pkt_start_offset) * 1000 / in->pkt->config.sample_rate;
+        m_lastSamplePts += static_cast<int64_t>(in->pkt->nb_samples - in->pkt_start_offset) * 1000 /
+                           in->pkt->config.sample_rate;
       }
 
       // calculate pts for last sample in m_procSample
       int bufferedSamples = m_resampler->GetBufferedSamples();
       m_procSample->pkt_start_offset = m_procSample->pkt->nb_samples;
-      m_procSample->timestamp = m_lastSamplePts - bufferedSamples * 1000 / m_format.m_sampleRate;
+      m_procSample->timestamp =
+          m_lastSamplePts - static_cast<int64_t>(bufferedSamples) * 1000 / m_format.m_sampleRate;
 
       if ((m_drain || m_changeResampler) && m_empty)
       {
@@ -563,13 +564,15 @@ bool CActiveAEBufferPoolAtempo::ProcessBuffers()
           in->pkt_start_offset = 0;
 
         // pts of last sample we added to the buffer
-        m_lastSamplePts += (in->pkt->nb_samples-in->pkt_start_offset) * 1000 / m_format.m_sampleRate;
+        m_lastSamplePts += static_cast<int64_t>(in->pkt->nb_samples - in->pkt_start_offset) * 1000 /
+                           m_format.m_sampleRate;
       }
 
       // calculate pts for last sample in m_procSample
       int bufferedSamples = m_pTempoFilter->GetBufferedSamples();
       m_procSample->pkt_start_offset = m_procSample->pkt->nb_samples;
-      m_procSample->timestamp = m_lastSamplePts - bufferedSamples * 1000 / m_format.m_sampleRate;
+      m_procSample->timestamp =
+          m_lastSamplePts - static_cast<int64_t>(bufferedSamples) * 1000 / m_format.m_sampleRate;
 
       if ((m_drain || m_changeFilter) && m_empty)
       {

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -51,7 +51,7 @@ public:
   void Return();
   std::unique_ptr<CSoundPacket> pkt;
   CActiveAEBufferPool *pool = nullptr;
-  int64_t timestamp;
+  int64_t timestamp = 0;
   int pkt_start_offset = 0;
   int refCount = 0;
   double centerMixLevel;
@@ -145,7 +145,7 @@ protected:
   bool m_drain;
   bool m_changeFilter;
   float m_tempo;
-  int64_t m_lastSamplePts;
+  int64_t m_lastSamplePts = 0;
   bool m_fillPackets;
 };
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -13,6 +13,7 @@
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <mutex>
 
 using namespace ActiveAE;
@@ -178,7 +179,13 @@ double CActiveAEStream::CalcResampleRatio(double error)
   if (fabs(error) > 1000)
     m_resampleIntegral = 0;
   else if (fabs(error) > 5)
-    m_resampleIntegral += error / 1000 / 50;
+  {
+    // Limit the correction sum to +/-0.04 to prevent over-correction during large fixes
+    // This stops the system from swinging too far the other way after a big sync gap.
+    constexpr double MAX_RESAMPLE_INTEGRAL = 0.04;
+    m_resampleIntegral = std::clamp(m_resampleIntegral + error / 1000 / 50, -MAX_RESAMPLE_INTEGRAL,
+                                    MAX_RESAMPLE_INTEGRAL);
+  }
 
   double proportional = 0.0;
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -204,8 +204,15 @@ std::chrono::milliseconds CActiveAEStream::GetErrorInterval()
 {
   std::chrono::milliseconds ret = m_errorInterval;
   double rr = m_processingBuffers->GetRR();
-  if (rr > 1.02 || rr < 0.98)
+
+  const bool isAtempo = m_processingBuffers->IsAtempoActive();
+
+  // If atempo is active, we don't want to slow down the sync checks.
+  // The normal 3x wait is meant to keep standard resampling smooth,
+  // but for Atempo it just makes sync recovery take too long.
+  if (!isAtempo && (rr > 1.02 || rr < 0.98))
     ret *= 3;
+
   return ret;
 }
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -118,6 +118,9 @@ public:
   std::unique_ptr<CActiveAEBufferPool> GetResampleBuffers();
   std::unique_ptr<CActiveAEBufferPool> GetAtempoBuffers();
 
+  // helper to check if Atempo is actively engaged with a non-1.0 tempo
+  bool IsAtempoActive() const { return m_atempoBuffers && m_atempoBuffers->GetTempo() != 1.0f; }
+
   AEAudioFormat m_inputFormat;
   std::deque<CSampleBuffer*> m_outputSamples;
   std::deque<CSampleBuffer*> m_inputSamples;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This PR fixes issues where audio could jump out of sync after a seek on tempo 1.6x. 

It includes the following fixes:
- Fixes the Atempo filter's timing logic so missing timestamps don't cause massive sync gaps.
- Fixes math sign flips and potential overflow errors in delay and timestamp calculations.
- Adds limits to the sync error correction to prevent the audio from over-correcting and "swinging" from too slow to too fast after a big seek.
- Skips the extra 3-second wait for sync checks when Atempo is active, allowing for much faster sync recovery during tempo playback.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When playing video at higher speeds (like 1.3x) and seeking, the audio engine would sometimes fail to recover. It would log massive errors (like -88837ms) or swing wildly out of sync. This PR prevents sign flips and keeps the synchronization accurate.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested the PR diff on LibreELEC running on a Raspberry Pi 4. tested seeking forward and backward while playing media at 1.0x and 1.6x tempo to ensure the large audio sync errors no longer occur and audio stays in sync.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users seeking on tempo playback will no longer experience wildly out-of-sync audio.

## log section
log when seeking during tempo=1.6x
audio log before fix
```
2026-03-23 09:29:30.075 T:4076    debug <general>: demuxer seek to: 1401000.000000, success
2026-03-23 09:29:30.095 T:4083    debug <general>: CDVDAudio::Flush - flush audio stream
2026-03-23 09:29:30.095 T:4083    debug <general>: CDVDAudio::Pause - pausing audio stream
2026-03-23 09:29:30.095 T:4083    debug <general>: CVideoPlayerAudio - CDVDMsg::GENERAL_SYNCHRONIZE
2026-03-23 09:29:30.320 T:4076    debug <general>: VideoPlayer::Sync - Audio - pts: 1401301000.000000, cache: 320000.022650, totalcache: 957604.169846
2026-03-23 09:29:30.320 T:4083    debug <general>: CVideoPlayerAudio - CDVDMsg::GENERAL_RESYNC(1400796000.000000), level: 45, cache: 792103.208650
2026-03-23 09:29:30.321 T:4083    debug <general>: CDVDAudio::Resume - resume audio stream
2026-03-23 09:29:30.326 T:1153    debug <general>: ActiveAE - start sync of audio stream
2026-03-23 09:29:31.976 T:1153  warning <general>: ActiveAE - large audio sync error: -1042.993145
2026-03-23 09:29:32.080 T:1153  warning <general>: ActiveAE - large audio sync error: -1056.659458
2026-03-23 09:29:32.080 T:1153  warning <general>: ActiveAE - large audio sync error: -1005.850793
2026-03-23 09:29:32.185 T:1153  warning <general>: ActiveAE - large audio sync error: -1018.368383
2026-03-23 09:29:37.168 T:1153  warning <general>: ActiveAE - large audio sync error: 1008.017785
2026-03-23 09:29:37.271 T:1153  warning <general>: ActiveAE - large audio sync error: 1043.725526
2026-03-23 09:29:37.375 T:1153  warning <general>: ActiveAE - large audio sync error: 1030.668305
2026-03-23 09:29:37.378 T:1153  warning <general>: ActiveAE - large audio sync error: 1077.767151
2026-03-23 09:29:37.479 T:1153  warning <general>: ActiveAE - large audio sync error: 1065.098340
2026-03-23 09:29:37.481 T:1153  warning <general>: ActiveAE - large audio sync error: 1112.977281
2026-03-23 09:29:37.584 T:1153  warning <general>: ActiveAE - large audio sync error: 1100.259602
2026-03-23 09:29:37.586 T:1153  warning <general>: ActiveAE - large audio sync error: 1147.189359
2026-03-23 09:29:37.672 T:1153  warning <general>: ActiveAE - large audio sync error: 1145.437718
2026-03-23 09:29:37.673 T:1153  warning <general>: ActiveAE - large audio sync error: 1194.679773
2026-03-23 09:29:37.775 T:1153  warning <general>: ActiveAE - large audio sync error: 1161.421468
2026-03-23 09:29:37.880 T:1153  warning <general>: ActiveAE - large audio sync error: 1128.462721
2026-03-23 09:29:37.883 T:1153  warning <general>: ActiveAE - large audio sync error: 1156.227615
2026-03-23 09:29:37.985 T:1153  warning <general>: ActiveAE - large audio sync error: 1125.245831
2026-03-23 09:29:38.089 T:1153  warning <general>: ActiveAE - large audio sync error: 1090.823900
2026-03-23 09:29:38.091 T:1153  warning <general>: ActiveAE - large audio sync error: 1118.889970
2026-03-23 09:29:38.193 T:1153  warning <general>: ActiveAE - large audio sync error: 1087.578882
2026-03-23 09:29:38.299 T:1153  warning <general>: ActiveAE - large audio sync error: 1052.216032
2026-03-23 09:29:38.301 T:1153  warning <general>: ActiveAE - large audio sync error: 1081.136241
2026-03-23 09:29:38.385 T:1153  warning <general>: ActiveAE - large audio sync error: 1060.219837
2026-03-23 09:29:38.489 T:1153  warning <general>: ActiveAE - large audio sync error: 1026.581895
2026-03-23 09:29:38.596 T:1153  warning <general>: ActiveAE - large audio sync error: 1021.026301
2026-03-23 09:29:40.892 T:1153  warning <general>: ActiveAE - large audio sync error: -88837.369750
```

log when seeking during tempo=1.6x
audio log after fix
```
2026-03-27 22:12:35.307 T:8872    debug <general>: demuxer seek to: 546436.000000, success
2026-03-27 22:12:35.320 T:8883    debug <general>: CDVDAudio::Flush - flush audio stream
2026-03-27 22:12:35.320 T:8883    debug <general>: CDVDAudio::Pause - pausing audio stream
2026-03-27 22:12:35.320 T:8883    debug <general>: CVideoPlayerAudio - CDVDMsg::GENERAL_SYNCHRONIZE
2026-03-27 22:12:35.426 T:8872    debug <general>: VideoPlayer::Sync - Audio - pts: 545831473.000000, cache: 301859.408617, totalcache: 957596.421242
2026-03-27 22:12:35.426 T:8883    debug <general>: CVideoPlayerAudio - CDVDMsg::GENERAL_RESYNC(545445000.000000), level: 82, cache: 301859.408617
2026-03-27 22:12:35.426 T:8883    debug <general>: CDVDAudio::Resume - resume audio stream
2026-03-27 22:12:35.435 T:1152    debug <general>: ActiveAE - start sync of audio stream
2026-03-27 22:12:36.764 T:1152  warning <general>: ActiveAE - large audio sync error: -1009.219825
2026-03-27 22:12:36.868 T:1152  warning <general>: ActiveAE - large audio sync error: -1070.557890
2026-03-27 22:12:36.974 T:1152  warning <general>: ActiveAE - large audio sync error: -1133.939318
2026-03-27 22:12:37.077 T:1152  warning <general>: ActiveAE - large audio sync error: -1247.128485
2026-03-27 22:12:37.181 T:1152  warning <general>: ActiveAE - large audio sync error: -1259.921398
2026-03-27 22:12:37.182 T:1152  warning <general>: ActiveAE - large audio sync error: -1210.068754
2026-03-27 22:12:37.288 T:1152  warning <general>: ActiveAE - large audio sync error: -1223.797894
2026-03-27 22:12:37.295 T:1152  warning <general>: ActiveAE - large audio sync error: -1178.177569
2026-03-27 22:12:37.391 T:1152  warning <general>: ActiveAE - large audio sync error: -1185.386129
2026-03-27 22:12:37.392 T:1152  warning <general>: ActiveAE - large audio sync error: -1136.090143
2026-03-27 22:12:37.478 T:1152  warning <general>: ActiveAE - large audio sync error: -1137.689769
2026-03-27 22:12:37.479 T:1152  warning <general>: ActiveAE - large audio sync error: -1088.444823
2026-03-27 22:12:37.584 T:1152  warning <general>: ActiveAE - large audio sync error: -1101.959767
2026-03-27 22:12:37.585 T:1152  warning <general>: ActiveAE - large audio sync error: -1052.764397
2026-03-27 22:12:37.687 T:1152  warning <general>: ActiveAE - large audio sync error: -1064.641811
2026-03-27 22:12:37.688 T:1152  warning <general>: ActiveAE - large audio sync error: -1014.447623
2026-03-27 22:12:37.791 T:1152  warning <general>: ActiveAE - large audio sync error: -1027.328496
```


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
