### PR TITLE
Use .strm path as subtitle anchor

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2010,7 +2010,7 @@ std::string CFileItem::GetLocalMetadataPath() const
 
 std::string CFileItem::GetSubtitleAnchorPath() const
 {
-  if (IsType(".strm"))
+  if (GetURL().HasExtension(".strm"))
     return m_strPath;
 
   return GetDynPath();

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -933,6 +933,11 @@ bool CFileItem::IsLibraryFolder() const
   return GetURL().IsLibraryFolder();
 }
 
+bool CFileItem::IsStrm() const
+{
+  return GetURL().HasExtension(".strm");
+}
+
 bool CFileItem::IsPythonScript() const
 {
   return GetURL().HasExtension(".py");
@@ -2010,7 +2015,7 @@ std::string CFileItem::GetLocalMetadataPath() const
 
 std::string CFileItem::GetSubtitleAnchorPath() const
 {
-  if (GetURL().HasExtension(".strm"))
+  if (IsStrm())
     return m_strPath;
 
   return GetDynPath();

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -2008,6 +2008,14 @@ std::string CFileItem::GetLocalMetadataPath() const
   return URIUtils::GetParentPath(m_strPath);
 }
 
+std::string CFileItem::GetSubtitleAnchorPath() const
+{
+  if (IsType(".strm"))
+    return m_strPath;
+
+  return GetDynPath();
+}
+
 bool CFileItem::LoadMusicTag()
 {
   // not audio

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1315,6 +1315,22 @@ bool CFileItem::IsAlbum() const
 
 void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
 {
+  // Keep the library-facing label for .strm items even when the playback item has already
+  // been resolved to a remote URL and carries a transport-derived label.
+  const bool keepStrmLabel = IsStrm() && item.IsStrm() && NETWORK::IsInternetStream(item) &&
+                             item.GetDynPath() != item.GetPath();
+
+  if (IsStrm() || item.IsStrm())
+  {
+    CLog::Log(LOGDEBUG,
+              "STRM-SUBS UpdateInfo this(path='{}', dyn='{}', label='{}', isstrm={}) "
+              "item(path='{}', dyn='{}', label='{}', isstrm={}, isinternet={}) "
+              "replaceLabels={} keepStrmLabel={}",
+              GetPath(), GetDynPath(), GetLabel(), IsStrm(), item.GetPath(), item.GetDynPath(),
+              item.GetLabel(), item.IsStrm(), NETWORK::IsInternetStream(item), replaceLabels,
+              keepStrmLabel);
+  }
+
   if (item.HasVideoInfoTag())
   { // copy info across
     //! @todo premiered info is normally stored in m_dateTime by the db
@@ -1381,7 +1397,7 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
     SetInvalid();
   }
   SetDynPath(item.GetDynPath());
-  if (replaceLabels && !item.GetLabel().empty())
+  if (replaceLabels && !keepStrmLabel && !item.GetLabel().empty())
     SetLabel(item.GetLabel());
   if (replaceLabels && !item.GetLabel2().empty())
     SetLabel2(item.GetLabel2());
@@ -1396,6 +1412,21 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
 
 void CFileItem::MergeInfo(const CFileItem& item)
 {
+  // Keep the library-facing label for .strm items even when the playback item has already
+  // been resolved to a remote URL and carries a transport-derived label.
+  const bool keepStrmLabel = IsStrm() && item.IsStrm() && NETWORK::IsInternetStream(item) &&
+                             item.GetDynPath() != item.GetPath();
+
+  if (IsStrm() || item.IsStrm())
+  {
+    CLog::Log(LOGDEBUG,
+              "STRM-SUBS MergeInfo this(path='{}', dyn='{}', label='{}', isstrm={}) "
+              "item(path='{}', dyn='{}', label='{}', isstrm={}, isinternet={}) "
+              "keepStrmLabel={}",
+              GetPath(), GetDynPath(), GetLabel(), IsStrm(), item.GetPath(), item.GetDynPath(),
+              item.GetLabel(), item.IsStrm(), NETWORK::IsInternetStream(item), keepStrmLabel);
+  }
+
   // TODO: Currently merge the metadata/art info is implemented for video case only
   if (item.HasVideoInfoTag())
   {
@@ -1454,7 +1485,7 @@ void CFileItem::MergeInfo(const CFileItem& item)
     SetInvalid();
   }
   SetDynPath(item.GetDynPath());
-  if (!item.GetLabel().empty())
+  if (!keepStrmLabel && !item.GetLabel().empty())
     SetLabel(item.GetLabel());
   if (!item.GetLabel2().empty())
     SetLabel2(item.GetLabel2());

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -936,6 +936,11 @@ bool CFileItem::IsLibraryFolder() const
   return GetURL().IsLibraryFolder();
 }
 
+bool CFileItem::IsStrm() const
+{
+  return GetURL().HasExtension(".strm");
+}
+
 bool CFileItem::IsPythonScript() const
 {
   return GetURL().HasExtension(".py");
@@ -2054,6 +2059,14 @@ std::string CFileItem::GetLocalMetadataPath() const
     return URIUtils::GetDiscBasePath(GetDynPath());
 
   return URIUtils::GetParentPath(m_strPath);
+}
+
+std::string CFileItem::GetSubtitleAnchorPath() const
+{
+  if (IsStrm() && !IsPlugin())
+    return m_strPath;
+
+  return GetDynPath();
 }
 
 bool CFileItem::LoadMusicTag()

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -429,6 +429,12 @@ public:
    */
   std::string GetLocalMetadataPath() const;
 
+  /*! \brief Get the path that should be used as the anchor for associated subtitles.
+   This is usually the resolved playback path, except for .strm items where subtitles
+   should be associated with the local .strm file rather than its resolved target URL.
+   */
+  std::string GetSubtitleAnchorPath() const;
+
   bool LoadMusicTag();
   bool LoadGameTag();
 

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -156,6 +156,7 @@ public:
 
   bool IsGame() const;
   bool IsLibraryFolder() const;
+  bool IsStrm() const;
   bool IsPythonScript() const;
   bool IsPlugin() const;
   bool IsScript() const;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -164,6 +164,7 @@ public:
 
   bool IsGame() const;
   bool IsLibraryFolder() const;
+  bool IsStrm() const;
   bool IsPythonScript() const;
   bool IsPlugin() const;
   bool IsScript() const;
@@ -436,6 +437,12 @@ public:
      \sa URIUtils::GetParentPath
    */
   std::string GetLocalMetadataPath() const;
+
+  /*! \brief Get the path that should be used as the anchor for associated subtitles.
+   This is usually the resolved playback path, except for .strm items where subtitles
+   should be associated with the local .strm file rather than its resolved target URL.
+   */
+  std::string GetSubtitleAnchorPath() const;
 
   bool LoadMusicTag();
   bool LoadGameTag();

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -1009,7 +1009,7 @@ void CFileItemList::Swap(unsigned int item1, unsigned int item2)
     std::swap(m_items[item1], m_items[item2]);
 }
 
-bool CFileItemList::UpdateItem(const CFileItem* item)
+bool CFileItemList::UpdateItem(const CFileItem* item, bool replaceLabels /* = true */)
 {
   if (!item)
     return false;
@@ -1018,7 +1018,7 @@ bool CFileItemList::UpdateItem(const CFileItem* item)
   const auto it =
       std::ranges::find_if(m_items, [&item](const auto& pItem) { return pItem->IsSamePath(item); });
   if (it != m_items.end())
-    (*it)->UpdateInfo(*item);
+    (*it)->UpdateInfo(*item, replaceLabels);
 
   return it != m_items.end();
 }

--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -170,9 +170,10 @@ public:
 
   /*! \brief Update an item in the item list
    \param item the new item, which we match based on path to an existing item in the list
+   \param replaceLabels whether to replace labels (defaults to true)
    \return true if the item exists in the list (and was thus updated), false otherwise.
    */
-  bool UpdateItem(const CFileItem* item);
+  bool UpdateItem(const CFileItem* item, bool replaceLabels = true);
 
   void AddSortMethod(SortBy sortBy,
                      int buttonLabel,

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -12245,9 +12245,9 @@ void CGUIInfoManager::ResetCurrentItem()
   m_infoProviders.InitCurrentItem(nullptr);
 }
 
-void CGUIInfoManager::UpdateCurrentItem(const CFileItem& item)
+void CGUIInfoManager::UpdateCurrentItem(const CFileItem& item, bool replaceLabels /* = true */)
 {
-  m_currentFile->UpdateInfo(item);
+  m_currentFile->UpdateInfo(item, replaceLabels);
 }
 
 void CGUIInfoManager::SetCurrentItem(const CFileItem& item)

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -126,7 +126,7 @@ public:
    */
   void SetCurrentItem(const CFileItem& item);
   void ResetCurrentItem();
-  void UpdateCurrentItem(const CFileItem& item);
+  void UpdateCurrentItem(const CFileItem& item, bool replaceLabels = true);
 
   // Current song stuff
   void SetCurrentAlbumThumb(const std::string& thumbFileName);

--- a/xbmc/GUIUserMessages.h
+++ b/xbmc/GUIUserMessages.h
@@ -109,6 +109,7 @@ constexpr const int GUI_MSG_UPDATE_ITEM             = GUI_MSG_USER + 29;
 // Flags for GUI_MSG_UPDATE_ITEM message
 constexpr int GUI_MSG_FLAG_UPDATE_LIST  = 0x00000001;
 constexpr int GUI_MSG_FLAG_FORCE_UPDATE = 0x00000002;
+constexpr int GUI_MSG_FLAG_KEEP_CURRENT_LABELS = 0x00000004;
 
 // Message sent to tell the GUI to change view mode
 constexpr const int GUI_MSG_CHANGE_VIEW_MODE        = GUI_MSG_USER + 30;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2111,8 +2111,20 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
   auto start = std::chrono::steady_clock::now();
 
   CFileItem item(strMovie, false);
-  if ((NETWORK::IsInternetStream(item) && !URIUtils::IsOnLAN(item.GetDynPath())) ||
-      PLAYLIST::IsPlayList(item) || item.IsPVR() || !VIDEO::IsVideo(item))
+  // A local .strm is the anchor we want to scan around, not the playlist/stream we want to reject.
+  const bool isStrmAnchor = item.IsStrm();
+  const bool isInternetStream = NETWORK::IsInternetStream(item);
+  const bool isOnLAN = URIUtils::IsOnLAN(item.GetDynPath());
+  const bool isPlayList = PLAYLIST::IsPlayList(item);
+  const bool isVideo = VIDEO::IsVideo(item);
+  const bool isPvr = item.IsPVR();
+  CLog::Log(LOGDEBUG,
+            "STRM-SUBS scan anchor path='{}' dyn='{}' isStrm={} isPlaylist={} isVideo={} "
+            "isInternetStream={} isOnLAN={} isPvr={}",
+            item.GetPath(), item.GetDynPath(), isStrmAnchor, isPlayList, isVideo, isInternetStream,
+            isOnLAN, isPvr);
+  if ((isInternetStream && !isOnLAN) || (!isStrmAnchor && isPlayList) || isPvr ||
+      (!isStrmAnchor && !isVideo))
     return;
 
   CLog::Log(LOGDEBUG, "{}: Searching for subtitles...", __FUNCTION__);

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2070,8 +2070,20 @@ void CUtil::ScanForExternalSubtitles(const std::string& strMovie, std::vector<st
   auto start = std::chrono::steady_clock::now();
 
   CFileItem item(strMovie, false);
-  if ((NETWORK::IsInternetStream(item) && !URIUtils::IsOnLAN(item.GetDynPath())) ||
-      PLAYLIST::IsPlayList(item) || item.IsPVR() || !VIDEO::IsVideo(item))
+  // A local .strm is the anchor we want to scan around, not the playlist/stream we want to reject.
+  const bool isStrmAnchor = item.IsStrm() && !item.IsPlugin();
+  const bool isInternetStream = NETWORK::IsInternetStream(item);
+  const bool isOnLAN = URIUtils::IsOnLAN(item.GetDynPath());
+  const bool isPlayList = PLAYLIST::IsPlayList(item);
+  const bool isVideo = VIDEO::IsVideo(item);
+  const bool isPvr = item.IsPVR();
+  CLog::Log(LOGDEBUG,
+            "STRM-SUBS scan anchor path='{}' dyn='{}' isStrm={} isPlaylist={} isVideo={} "
+            "isInternetStream={} isOnLAN={} isPvr={}",
+            CURL::GetRedacted(item.GetPath()), CURL::GetRedacted(item.GetDynPath()), isStrmAnchor,
+            isPlayList, isVideo, isInternetStream, isOnLAN, isPvr);
+  if ((isInternetStream && !isOnLAN) || (!isStrmAnchor && isPlayList) || isPvr ||
+      (!isStrmAnchor && !isVideo))
     return;
 
   CLog::Log(LOGDEBUG, "{}: Searching for subtitles...", __FUNCTION__);

--- a/xbmc/application/ApplicationMessageHandling.cpp
+++ b/xbmc/application/ApplicationMessageHandling.cpp
@@ -481,8 +481,9 @@ bool CApplicationMessageHandling::OnMessage(const CGUIMessage& message)
         CFileItemPtr item = std::static_pointer_cast<CFileItem>(message.GetItem());
         if (m_app.CurrentFileItem().IsSamePath(item.get()))
         {
-          m_app.CurrentFileItem().UpdateInfo(*item);
-          CServiceBroker::GetGUI()->GetInfoManager().UpdateCurrentItem(*item);
+          const bool replaceLabels = !(message.GetParam2() & GUI_MSG_FLAG_KEEP_CURRENT_LABELS);
+          m_app.CurrentFileItem().UpdateInfo(*item, replaceLabels);
+          CServiceBroker::GetGUI()->GetInfoManager().UpdateCurrentItem(*item, replaceLabels);
         }
       }
     }

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -561,7 +561,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
 void CDVDFileInfo::ProcessExternalSubtitles(CFileItem* item)
 {
   std::vector<std::string> externalSubtitles;
-  const std::string videoPath = item->GetDynPath();
+  const std::string videoPath = item->GetSubtitleAnchorPath();
 
   CUtil::ScanForExternalSubtitles(videoPath, externalSubtitles);
 

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -675,7 +675,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
 void CDVDFileInfo::ProcessExternalSubtitles(CFileItem* item)
 {
   std::vector<std::string> externalSubtitles;
-  const std::string videoPath = item->GetDynPath();
+  const std::string videoPath = item->GetSubtitleAnchorPath();
 
   CUtil::ScanForExternalSubtitles(videoPath, externalSubtitles);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -907,7 +907,7 @@ bool CVideoPlayer::OpenInputStream()
 
     if (!URIUtils::IsUPnP(m_item.GetPath()) &&
         !m_item.GetProperty("no-ext-subs-scan").asBoolean(false))
-      CUtil::ScanForExternalSubtitles(m_item.GetDynPath(), filenames);
+      CUtil::ScanForExternalSubtitles(m_item.GetSubtitleAnchorPath(), filenames);
 
     // load any subtitles from file item
     std::string key("subtitle:1");

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -950,7 +950,7 @@ bool CVideoPlayer::OpenInputStream()
 
     if (!URIUtils::IsUPnP(m_item.GetPath()) &&
         !m_item.GetProperty("no-ext-subs-scan").asBoolean(false))
-      CUtil::ScanForExternalSubtitles(m_item.GetDynPath(), filenames);
+      CUtil::ScanForExternalSubtitles(m_item.GetSubtitleAnchorPath(), filenames);
 
     // load any subtitles from file item
     std::string key("subtitle:1");

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -962,6 +962,24 @@ TEST(TestFileItem, TestSimplePathSet)
   EXPECT_EQ("/local/path/dynamic/file.txt", item.GetDynURL().Get());
 }
 
+TEST(TestFileItem, GetSubtitleAnchorPathUsesDynPathForRegularFiles)
+{
+  CFileItem item;
+  item.SetPath("/local/path/video.mkv");
+  item.SetDynPath("smb://server/share/video.mkv");
+
+  EXPECT_EQ("smb://server/share/video.mkv", item.GetSubtitleAnchorPath());
+}
+
+TEST(TestFileItem, GetSubtitleAnchorPathUsesPathForStrmFiles)
+{
+  CFileItem item;
+  item.SetPath("/local/path/video.strm");
+  item.SetDynPath("https://example.com/video.m3u8");
+
+  EXPECT_EQ("/local/path/video.strm", item.GetSubtitleAnchorPath());
+}
+
 TEST(TestFileItem, TestLabel)
 {
   CFileItem item("My Item Label");

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -1045,6 +1045,24 @@ TEST(TestFileItem, UpdateInfoKeepsAResolvedDynPath)
   EXPECT_EQ("/resolved/real-stream.mkv", target.GetDynPath());
 }
 
+TEST(TestFileItem, UpdateInfoUpdatesLabelForResolvedStrm)
+{
+  CFileItem target;
+  target.SetPath("/library/movie.strm");
+  target.SetDynPath("https://example.com/movie.mp4");
+  target.SetLabel("Library title");
+
+  CFileItem source;
+  source.SetPath("/library/movie.strm");
+  source.SetDynPath("https://example.com/movie.mp4");
+  source.SetLabel("Updated title");
+
+  target.UpdateInfo(source);
+
+  EXPECT_EQ("Updated title", target.GetLabel());
+  EXPECT_EQ("https://example.com/movie.mp4", target.GetDynPath());
+}
+
 TEST(TestFileItem, UpdateInfoTakesADynPathTheSourceActuallyHas)
 {
   CFileItem target = MakeResolvedPluginItem();
@@ -1064,6 +1082,33 @@ TEST(TestFileItem, MergeInfoKeepsAResolvedDynPath)
   target.MergeInfo(MakeAddonUpdateItem());
 
   EXPECT_EQ("/resolved/real-stream.mkv", target.GetDynPath());
+}
+
+TEST(TestFileItem, GetSubtitleAnchorPathUsesDynPathForRegularFiles)
+{
+  CFileItem item;
+  item.SetPath("/local/path/video.mkv");
+  item.SetDynPath("smb://server/share/video.mkv");
+
+  EXPECT_EQ("smb://server/share/video.mkv", item.GetSubtitleAnchorPath());
+}
+
+TEST(TestFileItem, GetSubtitleAnchorPathUsesPathForStrmFiles)
+{
+  CFileItem item;
+  item.SetPath("/local/path/video.strm");
+  item.SetDynPath("https://example.com/video.m3u8");
+
+  EXPECT_EQ("/local/path/video.strm", item.GetSubtitleAnchorPath());
+}
+
+TEST(TestFileItem, GetSubtitleAnchorPathUsesDynPathForPluginStrmRoutes)
+{
+  CFileItem item;
+  item.SetPath("plugin://plugin.video.example/play/video.strm");
+  item.SetDynPath("https://example.com/video.m3u8");
+
+  EXPECT_EQ("https://example.com/video.m3u8", item.GetSubtitleAnchorPath());
 }
 
 TEST(TestFileItem, TestLabel)

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -263,6 +263,20 @@ void CSaveFileState::DoWork(CFileItem& item,
         {
           CUtil::DeleteVideoDatabaseDirectoryCache();
           CFileItemPtr msgItem(new CFileItem(item));
+          // Preserve the library title before broadcasting the post-playback update for .strm
+          // items. The playback item keeps the local .strm path, but its label can already have
+          // been replaced with the remote resource name.
+          if (msgItem->IsStrm() && msgItem->HasVideoInfoTag() &&
+              !msgItem->GetVideoInfoTag()->m_strTitle.empty())
+          {
+            CLog::Log(LOGDEBUG,
+                      "STRM-SUBS save-state relabel path='{}' dyn='{}' old='{}' new='{}' "
+                      "isstrm={} isvideo={} updatePlayCount={}",
+                      msgItem->GetPath(), msgItem->GetDynPath(), msgItem->GetLabel(),
+                      msgItem->GetVideoInfoTag()->m_strTitle, msgItem->IsStrm(),
+                      VIDEO::IsVideo(*msgItem), updatePlayCount);
+            msgItem->SetLabel(msgItem->GetVideoInfoTag()->m_strTitle);
+          }
           if (item.HasProperty("original_listitem_url"))
             msgItem->SetPath(item.GetProperty("original_listitem_url").asString());
 

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -266,7 +266,15 @@ void CSaveFileState::DoWork(CFileItem& item,
           if (item.HasProperty("original_listitem_url"))
             msgItem->SetPath(item.GetProperty("original_listitem_url").asString());
 
-          CGUIMessage message(GUI_MSG_NOTIFY_ALL, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, GUI_MSG_UPDATE_ITEM, 0, msgItem);
+          int64_t updateFlags = 0;
+          if (item.IsStrm() && !item.IsPlugin() && item.GetDynPath() != item.GetPath())
+          {
+            // Prevent replacing the library title with the remote resource name.
+            updateFlags |= GUI_MSG_FLAG_KEEP_CURRENT_LABELS;
+          }
+          CGUIMessage message(GUI_MSG_NOTIFY_ALL,
+                              CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0,
+                              GUI_MSG_UPDATE_ITEM, updateFlags, msgItem);
           CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
         }
 

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -132,7 +132,7 @@ std::string CGUIDialogSubtitleSettings::BrowseForSubtitle()
   std::string strPath{currentItem.GetProperty("BasePath").asString("")};
   if (strPath.empty())
   {
-    const std::string dynPath{currentItem.GetDynPath()};
+    const std::string dynPath{currentItem.GetSubtitleAnchorPath()};
     if (URIUtils::IsInRAR(dynPath) || URIUtils::IsInZIP(dynPath))
     {
       strPath = CURL(dynPath).GetHostName();

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -550,7 +550,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
   SUBTITLE_STORAGEMODE storageMode = (SUBTITLE_STORAGEMODE) CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_SUBTITLES_STORAGEMODE);
 
   // Get (unstacked) path
-  std::string strCurrentFile = g_application.CurrentUnstackedItem().GetDynPath();
+  std::string strCurrentFile = g_application.CurrentUnstackedItem().GetSubtitleAnchorPath();
 
   std::string strDownloadPath = "special://temp";
   std::string strDestPath;

--- a/xbmc/video/dialogs/GUIDialogSubtitles.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitles.cpp
@@ -551,7 +551,7 @@ void CGUIDialogSubtitles::OnDownloadComplete(const CFileItemList *items, const s
   SUBTITLE_STORAGEMODE storageMode = (SUBTITLE_STORAGEMODE) CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_SUBTITLES_STORAGEMODE);
 
   // Get (unstacked) path
-  std::string strCurrentFile = g_application.CurrentUnstackedItem().GetDynPath();
+  std::string strCurrentFile = g_application.CurrentUnstackedItem().GetSubtitleAnchorPath();
 
   std::string strDownloadPath = "special://temp";
   std::string strDestPath;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -386,7 +386,8 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
 
         if (IsActive() || (flag & GUI_MSG_FLAG_FORCE_UPDATE))
         {
-          m_vecItems->UpdateItem(newItem.get());
+          const bool replaceLabels = !(flag & GUI_MSG_FLAG_KEEP_CURRENT_LABELS);
+          m_vecItems->UpdateItem(newItem.get(), replaceLabels);
 
           if (flag & GUI_MSG_FLAG_UPDATE_LIST)
           { // need the list updated as well


### PR DESCRIPTION
Add CFileItem::GetSubtitleAnchorPath() to distinguish the playback path from the path that should be used to associate external subtitles.

For regular items the anchor remains the resolved dynamic path, but for `.strm` files it now uses the local `.strm` path instead of the resolved target URL.

Use the new anchor path when scanning for external subtitles, saving downloaded subtitles, and browsing for subtitle files. This makes subtitle association consistent for `.strm` playback and adds tests that cover both regular files and `.strm` items.

## Description

Kodi currently uses `CFileItem::GetDynPath()` in subtitle-related flows to determine where to look for associated subtitles and where to save downloaded subtitles.

For `.strm` items this is not the appropriate path, because `GetDynPath()` points to the resolved target URL instead of the local `.strm` file itself. This change introduces `CFileItem::GetSubtitleAnchorPath()` to represent the path that should be used as the subtitle association anchor.

For regular items, the new method returns the resolved dynamic path. For `.strm` items, it returns the local `.strm` path instead. The new method is then used in the relevant subtitle flows:

- scanning for external subtitles during playback
- saving downloaded subtitles
- browsing for subtitle files manually

Unit tests were also added to cover both regular files and `.strm` items.

## Motivation and context

This change is required to make subtitle handling for `.strm` files consistent with the behavior of normal media files.

At the moment, downloaded subtitles and external subtitle discovery can be based on the resolved remote URL instead of the local `.strm` file location. That means Kodi may ignore the directory that actually contains the `.strm` file, even though that is the location users would expect to be used for associated subtitles.

Using the local `.strm` path as the subtitle anchor fixes that inconsistency.

## How has this been tested?

- Added unit tests for `CFileItem::GetSubtitleAnchorPath()`
- Reviewed the affected subtitle code paths to ensure they now use the subtitle anchor path consistently
- Not runtime-tested locally
- Not build-tested locally

## What is the effect on users?

Users playing media through `.strm` files should get more consistent subtitle behavior.

Kodi will now use the local `.strm` file as the reference for associated subtitles, which affects:

- where downloaded subtitles are stored
- where external subtitles are searched for
- the starting location when browsing for subtitle files manually

This makes `.strm` subtitle handling behave more like other local media items.

## Screenshots (if appropriate):

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [ ] All new and existing tests passed
