### PR TITLE
windowing/gbm: calculate refreshrate from EDID more precisely

### DIFF
--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -641,7 +641,7 @@ RESOLUTION_INFO CDRMUtils::GetResolutionInfo(drmModeModeInfoPtr mode)
   if (mode->htotal > 0 && mode->vtotal > 0)
     res.fRefreshRate = (mode->clock * 1000.0f) / (mode->htotal * mode->vtotal);
   else
-    res.fRefreshRate = 0.0f;
+    res.fRefreshRate = mode->vrefresh;
   res.iSubtitles = res.iHeight;
   res.fPixelRatio = 1.0f;
   res.bFullScreen = true;

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -638,10 +638,7 @@ RESOLUTION_INFO CDRMUtils::GetResolutionInfo(drmModeModeInfoPtr mode)
     }
   }
 
-  if (mode->clock % 5 != 0)
-    res.fRefreshRate = static_cast<float>(mode->vrefresh) * (1000.0f / 1001.0f);
-  else
-    res.fRefreshRate = mode->vrefresh;
+  res.fRefreshRate = (mode->clock * 1000.0f) / (mode->htotal * mode->vtotal);
   res.iSubtitles = res.iHeight;
   res.fPixelRatio = 1.0f;
   res.bFullScreen = true;

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -638,7 +638,10 @@ RESOLUTION_INFO CDRMUtils::GetResolutionInfo(drmModeModeInfoPtr mode)
     }
   }
 
-  res.fRefreshRate = (mode->clock * 1000.0f) / (mode->htotal * mode->vtotal);
+  if (mode->htotal > 0 && mode->vtotal > 0)
+    res.fRefreshRate = (mode->clock * 1000.0f) / (mode->htotal * mode->vtotal);
+  else
+    res.fRefreshRate = 0.0f;
   res.iSubtitles = res.iHeight;
   res.fPixelRatio = 1.0f;
   res.bFullScreen = true;


### PR DESCRIPTION
This allows for a more precise enumeration of refresh rates in Kodi on Linux DRM/gbm.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This change enables more precise enumeration and calculation of the refresh rates exposed through the EDID data block on Linux DRM/GBM platforms.
Currently, the logic uses the HDMI clock (in kHz) and applies a modulo operator; when there is a remainder, it calculates the uneven refresh rates from it. 
This works perfectly fine in cases where the default EDID is used, as the un-even refreshrates are also have "uneven" clocks.

See
```
                "3840x2160": 24 297000 3840 5116 5204 5500 2160 2168 2178 2250 0x40 0x5 ===> 297000 = 24p
                "3840x2160": 24 296703 3840 5116 5204 5500 2160 2168 2178 2250 0x40 0x5 ===> 296703 = 23.976p
```

However, with a custom EDID that is created by, for example, CRU. It's not possible to create clocks with such precision. In this case, the current calculation breaks and thinks every custom mode is an "even" refresh rate.

See
```
				"3840x2160": 24 237600 3840 4016 4104 4400 2160 2168 2178 2250 0x40 0x5 ===> 237600 = "24p" = 24p in Kodi
                "3840x2160": 24 237370 3840 4016 4104 4400 2160 2168 2178 2250 0x40 0x5 ===> 237370 = "23.976p" = 24p in Kodi
```
				
Both custom resolutions have an "even" clock and therefore show up as 24.000hz in Kodi, as there is no remainder in the modulo operator. Not useful at all.

With the fix/new calculation, Kodi calculates the refresh rate from the clock, htotal, and vtotal.
htotal and vtotal are already exposed in the Kodi code.

The math is simple:

The `mode->clock` is multiplied by 1000, so we have the clock in Hertz. The `mode->clock` is in kHz!
The clock in Hz is then divided by the multiple of htotal and vtotal. 

`clock*1000/htotal*vtotal`

calculation examples

```
                "3840x2160": 24 297000 3840 5116 5204 5500 2160 2168 2178 2250 0x40 0x5 ===> 297000 * 1000 / 5500 * 2250 = 24.00000
                "3840x2160": 24 296703 3840 5116 5204 5500 2160 2168 2178 2250 0x40 0x5 ===> 296703 * 1000 / 5500 * 2250 = 23.97600
				"3840x2160": 24 237600 3840 4016 4104 4400 2160 2168 2178 2250 0x40 0x5 ===> 237600 * 1000 / 4400 * 2250 = 24.00000
                "3840x2160": 24 237370 3840 4016 4104 4400 2160 2168 2178 2250 0x40 0x5 ===> 237370 * 1000 / 4400 * 2250 = 23.97677
```


```
diff --git a/xbmc/windowing/gbm/drm/DRMUtils.cpp b/xbmc/windowing/gbm/drm/DRMUtils.cpp
index df2f397b2a..df4f285edd 100644
--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -638,10 +638,7 @@ RESOLUTION_INFO CDRMUtils::GetResolutionInfo(drmModeModeInfoPtr mode)
     }
   }
 
-  if (mode->clock % 5 != 0)
-    res.fRefreshRate = static_cast<float>(mode->vrefresh) * (1000.0f / 1001.0f);
-  else
-    res.fRefreshRate = mode->vrefresh;
+  res.fRefreshRate = (mode->clock * 1000.0f) / (mode->htotal * mode->vtotal);
   res.iSubtitles = res.iHeight;
   res.fPixelRatio = 1.0f;
   res.bFullScreen = true;

```



## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The motivation of this fix is to use custom EDID modes more easily. With the A310, I have a problem of frame drops caused by bad 23.976p modes. This leads to an "av correction" every 20 minutes or so (things I only used to know from nvidia... well) - to fix this, custom EDID modes are necessary.
With this fix, they now show up and can be/are selected by Kodi on playback start. 


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been successfully tested with LibreElec nightly on an Intel Arc A310 GPU.

Here is a snippet from the Kodi log.
```
2026-03-27 13:14:12.218 T:812      info <general>: CDRMUtils: Using encoder: 532
2026-03-27 13:14:12.218 T:812      info <general>: CDRMUtils: using crtc: 148
2026-03-27 13:14:12.218 T:812   warning <general>: [display-info] EDID parser warnings:
2026-03-27 13:14:12.218 T:812   warning <general>: [display-info] ----------------------------------------------
2026-03-27 13:14:12.218 T:812   warning <general>: [display-info] Block 1, CTA-861 Extension Block:
2026-03-27 13:14:12.218 T:812   warning <general>: [display-info]   Speaker Allocation Data Block: Deprecated bit F16 must be 0.
2026-03-27 13:14:12.218 T:812   warning <general>: [display-info]
2026-03-27 13:14:12.218 T:812   warning <general>: [display-info] ----------------------------------------------
2026-03-27 13:14:12.218 T:812      info <general>: [display-info] make: 'MARANTZ JAPAN, INC.' model: 'marantz-AVR'
2026-03-27 13:14:12.218 T:812      info <general>: [display-info] supports hdr static metadata type1: true
2026-03-27 13:14:12.218 T:812      info <general>: [display-info] supported eotf:
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   traditional sdr: true
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   traditional hdr: false
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   pq:              true
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   hlg:             true
2026-03-27 13:14:12.218 T:812      info <general>: [display-info] luma min: '0' avg: '0' max: '0'
2026-03-27 13:14:12.218 T:812      info <general>: [display-info] supported colorimetry:
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   xvycc_601:   false
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   xvycc_709:   false
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   sycc_601:    false
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   opycc_601:   false
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   oprgb:       false
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   bt2020_cycc: false
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   bt2020_ycc:  true
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   bt2020_rgb:  true
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   st2113_rgb:  false
2026-03-27 13:14:12.218 T:812      info <general>: [display-info]   ictcp:       false
2026-03-27 13:14:12.279 T:812      info <general>: Found resolution 3840x2160 with 3840x2160 @ 60.000000 Hz
2026-03-27 13:14:12.279 T:812      info <general>: Found resolution 4096x2160 with 4096x2160 @ 60.000000 Hz
2026-03-27 13:14:12.279 T:812      info <general>: Found resolution 4096x2160 with 4096x2160 @ 59.940098 Hz
2026-03-27 13:14:12.279 T:812      info <general>: Found resolution 4096x2160 with 4096x2160 @ 50.000000 Hz
2026-03-27 13:14:12.279 T:812      info <general>: Found resolution 4096x2160 with 4096x2160 @ 30.000000 Hz
2026-03-27 13:14:12.279 T:812      info <general>: Found resolution 4096x2160 with 4096x2160 @ 29.970001 Hz
2026-03-27 13:14:12.279 T:812      info <general>: Found resolution 4096x2160 with 4096x2160 @ 25.000000 Hz
2026-03-27 13:14:12.279 T:812      info <general>: Found resolution 4096x2160 with 4096x2160 @ 24.000000 Hz
2026-03-27 13:14:12.279 T:812      info <general>: Found resolution 4096x2160 with 4096x2160 @ 23.976000 Hz
2026-03-27 13:14:12.279 T:812      info <general>: Found resolution 3840x2160 with 3840x2160 @ 59.940098 Hz
2026-03-27 13:14:12.279 T:812      info <general>: Found resolution 3840x2160 with 3840x2160 @ 50.000000 Hz
2026-03-27 13:14:12.279 T:812      info <general>: Found resolution 3840x2160 with 3840x2160 @ 30.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 3840x2160 with 3840x2160 @ 29.970001 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 3840x2160 with 3840x2160 @ 25.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 3840x2160 with 3840x2160 @ 24.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 3840x2160 with 3840x2160 @ 23.976768 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1920x1080 with 1920x1080 @ 120.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1920x1080 with 1920x1080 @ 119.880005 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1920x1080 with 1920x1080 @ 100.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1920x1080 with 1920x1080 @ 60.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1920x1080 with 1920x1080 @ 59.940201 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1920x1080 with 1920x1080 @ 50.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1920x1080 with 1920x1080 @ 30.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1920x1080 with 1920x1080 @ 29.970100 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1920x1080 with 1920x1080 @ 25.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1920x1080 with 1920x1080 @ 24.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1920x1080 with 1920x1080 @ 23.976080 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1280x1024 with 1280x1024 @ 60.019741 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1152x864 with 1152x864 @ 59.966923 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1280x720 with 1280x720 @ 60.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1280x720 with 1280x720 @ 59.940201 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1280x720 with 1280x720 @ 50.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 1024x768 with 1024x768 @ 60.003841 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 800x600 with 800x600 @ 60.316540 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 720x576 with 720x576 @ 50.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 720x480 with 720x480 @ 60.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 720x480 with 720x480 @ 59.940060 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 640x480 with 640x480 @ 60.000000 Hz
2026-03-27 13:14:12.280 T:812      info <general>: Found resolution 640x480 with 640x480 @ 59.940475 Hz
2026-03-27 13:14:12.282 T:812      info <general>: EGL_VERSION = 1.5
2026-03-27 13:14:12.282 T:812      info <general>: EGL_VENDOR = Mesa Project
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
In cases where the EDID is not altered, there is basically no difference. 
Due to the different calculation, the modes may show up slightly differently, e.g., 60.0000 Hz is now 60.0001 Hz
This may require the user to reselect the allowed resolutions.



## Different approach.

However, not tested - so no idea if it really works - I also thought about this approach.
Here the clock is divided by 10, to have an uneven clock from an even clock.
With even refreshes it does not make a difference, with uneven it works.
The downside is the inclusion of a new header and the more complex modulo operator (fmod), and the refresh rates are not calculated precisely

Calculation Example from above - for better visualization, I use %, even though its not really correct, as % does not work with floats
```
                "3840x2160": 24 297000 3840 5116 5204 5500 2160 2168 2178 2250 0x40 0x5 ===> 297000 / 10 % 5 => no remainder => 24.00000
                "3840x2160": 24 296703 3840 5116 5204 5500 2160 2168 2178 2250 0x40 0x5 ===> 296703 / 10 % 5 => remainder of 0.3 => 23.976
				"3840x2160": 24 237600 3840 4016 4104 4400 2160 2168 2178 2250 0x40 0x5 ===> 237600 / 10 % 5 => no remainder = 24.00000
                "3840x2160": 24 237370 3840 4016 4104 4400 2160 2168 2178 2250 0x40 0x5 ===> 237370 / 10 % 5 => remainder of 2 => 23.976

```

```
diff --git a/xbmc/windowing/gbm/drm/DRMUtils.cpp b/xbmc/windowing/gbm/drm/DRMUtils.cpp
index df2f397b2a..7bac7f1a16 100644
--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -6,6 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include <math.h>
 #include "DRMUtils.h"
 
 #include "ServiceBroker.h"
@@ -638,7 +639,7 @@ RESOLUTION_INFO CDRMUtils::GetResolutionInfo(drmModeModeInfoPtr mode)
     }
   }
 
-  if (mode->clock % 5 != 0)
+  if (fmod((mode->clock / 10.0f), 5.0f) != 0.0f)
     res.fRefreshRate = static_cast<float>(mode->vrefresh) * (1000.0f / 1001.0f);
   else
     res.fRefreshRate = mode->vrefresh;
```




## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
