### PR TITLE
Gate DRMPRIME renderers and DMA buffer pool on useprimedecoder setting

### DIFF
--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
@@ -8,7 +8,10 @@
 
 #include "ProcessInfoGBM.h"
 
+#include "ServiceBroker.h"
 #include "cores/VideoPlayer/Buffers/VideoBufferPoolDMA.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 
 using namespace VIDEOPLAYER;
 
@@ -24,7 +27,9 @@ void CProcessInfoGBM::Register()
 
 CProcessInfoGBM::CProcessInfoGBM()
 {
-  m_videoBufferManager.RegisterPool(std::make_shared<CVideoBufferPoolDMA>());
+  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_VIDEOPLAYER_USEPRIMEDECODER))
+    m_videoBufferManager.RegisterPool(std::make_shared<CVideoBufferPoolDMA>());
 }
 
 EINTERLACEMETHOD CProcessInfoGBM::GetFallbackDeintMethod()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -26,8 +26,6 @@
 
 using namespace KODI::WINDOWING::GBM;
 
-const std::string SETTING_VIDEOPLAYER_USEPRIMERENDERER = "videoplayer.useprimerenderer";
-
 CRendererDRMPRIME::~CRendererDRMPRIME()
 {
   Flush(false);
@@ -35,8 +33,11 @@ CRendererDRMPRIME::~CRendererDRMPRIME()
 
 CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
 {
-  if (buffer && CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-                    SETTING_VIDEOPLAYER_USEPRIMERENDERER) == 0)
+  auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  if (!settings->GetBool(CSettings::SETTING_VIDEOPLAYER_USEPRIMEDECODER))
+    return nullptr;
+
+  if (buffer && settings->GetInt(CSettings::SETTING_VIDEOPLAYER_USEPRIMERENDERER) == 0)
   {
     auto buf = dynamic_cast<CVideoBufferDRMPRIME*>(buffer);
     if (!buf)
@@ -94,7 +95,7 @@ void CRendererDRMPRIME::Register()
   {
     CServiceBroker::GetSettingsComponent()
         ->GetSettings()
-        ->GetSetting(SETTING_VIDEOPLAYER_USEPRIMERENDERER)
+        ->GetSetting(CSettings::SETTING_VIDEOPLAYER_USEPRIMERENDERER)
         ->SetVisible(true);
     VIDEOPLAYER::CRendererFactory::RegisterRenderer("drm_prime", CRendererDRMPRIME::Create);
     return;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -14,6 +14,8 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
 #include "rendering/gles/RenderSystemGLES.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/EGLFence.h"
 #include "utils/EGLImage.h"
 #include "utils/GLUtils.h"
@@ -34,6 +36,13 @@ CRendererDRMPRIMEGLES::~CRendererDRMPRIMEGLES()
 CBaseRenderer* CRendererDRMPRIMEGLES::Create(CVideoBuffer* buffer)
 {
   if (!buffer)
+    return nullptr;
+
+  auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  if (!settings->GetBool(CSettings::SETTING_VIDEOPLAYER_USEPRIMEDECODER))
+    return nullptr;
+
+  if (settings->GetInt(CSettings::SETTING_VIDEOPLAYER_USEPRIMERENDERER) != 1)
     return nullptr;
 
   auto buf = dynamic_cast<CVideoBufferDRMPRIME*>(buffer);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -131,6 +131,7 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_USEDXVA2 = "videoplayer.usedxva2";
   static constexpr auto SETTING_VIDEOPLAYER_USEVTB = "videoplayer.usevtb";
   static constexpr auto SETTING_VIDEOPLAYER_USEPRIMEDECODER = "videoplayer.useprimedecoder";
+  static constexpr auto SETTING_VIDEOPLAYER_USEPRIMERENDERER = "videoplayer.useprimerenderer";
   static constexpr auto SETTING_VIDEOPLAYER_USESTARFISHDECODER = "videoplayer.usestarfishdecoder";
   static constexpr auto SETTING_VIDEOPLAYER_USESTAGEFRIGHT = "videoplayer.usestagefright";
   static constexpr auto SETTING_VIDEOPLAYER_LIMITGUIUPDATE = "videoplayer.limitguiupdate";


### PR DESCRIPTION
## Description

When useprimedecoder is disabled, the DRMPRIME rendering path remains partially active:

  1. CProcessInfoGBM unconditionally registers CVideoBufferPoolDMA, which takes priority over CVideoBufferPoolSysMem in VideoBufferManager::Get().  Any codec that requests a buffer through the video buffer manager receives a CVideoBufferDMA instead of a CVideoBufferSysMem, even though the user has explicitly disabled DRMPRIME.
  2. CVideoBufferDMA inherits from CVideoBufferDRMPRIME, so RendererDRMPRIMEGLES::Create() and RendererDRMPRIME::Create() claim the buffer via dynamic_cast<CVideoBufferDRMPRIME*>, bypassing LinuxRendererGLES ("default"). The user ends up on the DRMPRIME rendering path with no way to  avoid it, regardless of settings.

This affects two code paths that use VideoBufferManager::Get():

  - All inputstream addon codecs (CAddonVideoCodec::GetFrameBuffer): addon-decoded frames are unnecessarily routed through DRMPRIME renderers.
  - CDVDVideoPPFFmpeg (ffmpeg post-processing): when the user enables post-processing, the filter allocates its output buffer via VideoBufferManager::Get(). Since post-processing runs on every frame including the first, the renderer is selected based on a CVideoBufferDMA buffer and RendererDRMPRIMEGLES claims the rendering path. This means enabling post-processing on any software-decoded video (including VAAPI fallback to software for formats like mpeg2) silently switches to the DRMPRIME renderer.

  Note: the Kodi settings UI allows both VAAPI and DRMPRIME to be enabled simultaneously. TODO: should these be made mutually exclusive in settings?

  Changes

  - RendererDRMPRIME::Create(): return nullptr if useprimedecoder is disabled, check useprimerenderer via CSettings constant
  - RendererDRMPRIMEGLES::Create(): return nullptr if useprimedecoder is disabled or useprimerenderer != 1 (EGL mode)
  - CProcessInfoGBM: only register CVideoBufferPoolDMA when useprimedecoder is enabled; when disabled, VideoBufferManager::Get() falls through to CVideoBufferPoolSysMem
  - Settings.h: promote SETTING_VIDEOPLAYER_USEPRIMERENDERER from local constant in RendererDRMPRIME.cpp to CSettings member

## Motivation and context
Discovered while developing an inputstream addon video codec. The addon's buffers were claimed by RendererDRMPRIMEGLES even with useprimedecoder=false, causing rendering issues. Investigation revealed that the DMA buffer pool registration and renderer selection are not gated on the DRMPRIME settings, leaving the DRMPRIME path partially active when it should be fully disabled.

## How has this been tested?
  - useprimedecoder=false: verified video plays through LinuxRendererGLES (log shows LinuxRendererGLES::Configure, no CEGLImage::CreateImage)
  - useprimedecoder=true, useprimerenderer=0: verified D2P renderer claims buffer (NV12 scanout confirmed via i915_display_info)
  - useprimedecoder=true, useprimerenderer=1: verified DRMPRIMEGLES renderer claims buffer (CEGLImage::CreateImage in log)
  - VAAPI playback unaffected in all configurations (VAAPI uses own VASurface path, not VideoBufferManager)
  - Tested on Intel i3-8109U (CFL) and N250 (ADL-N) with GBM/GLES, VAAPI on/off.

## What is the effect on users?
Rendering artifacts from inputstream addons should be eliminated.  Kodi now respects DRMPRIME settings.

## Screenshots (if appropriate):
n/a

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
