### PR TITLE
[cmake] FindBluray add option to disable building libbluray Jar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ include(cmake/scripts/common/DependencyOptions.cmake)
 # general
 option(VERBOSE            "Enable verbose output?" OFF)
 option(VERBOSE_FIND       "Enable verbose output of library searches only?" OFF)
+option(ENABLE_BLURAY_JAR "Enable building libbluray jar libraries (requires ENABLE_INTERNAL_BLURAY=ON)?" ON)
 option(ENABLE_CLANGTIDY   "Enable clang-tidy support?" OFF)
 option(ENABLE_CPPCHECK    "Enable cppcheck support?" OFF)
 option(ENABLE_DVDCSS      "Enable libdvdcss support?" ON)

--- a/cmake/modules/FindBluray.cmake
+++ b/cmake/modules/FindBluray.cmake
@@ -16,9 +16,6 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     find_package(Meson REQUIRED)
     find_package(Ninja REQUIRED)
 
-    # Required for building libbluray bd jars, however is optional for libbluray
-    find_package(ANT)
-
     find_package(Udfread 1.2.0 REQUIRED ${SEARCH_QUIET})
     find_package(FreeType REQUIRED ${SEARCH_QUIET})
     find_package(LibXml2 REQUIRED ${SEARCH_QUIET})
@@ -29,26 +26,41 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
       list(APPEND additional_env_mod --modify FONTCONFIG_ROOT=set:${DEPENDS_PATH})
     endif()
 
-    if(TARGET ANT::ANT)
-      find_package(Java COMPONENTS Development)
+    set(temp_extras_arg -Dbdj_jar=disabled)
+    set(temp_env_mod --unset=JAVA_HOME)
 
-      if(Java_Development_FOUND)
-        get_filename_component(java_binpath ${Java_JAVAC_EXECUTABLE} DIRECTORY)
-        get_filename_component(java_homepath ${java_binpath} DIRECTORY)
+    if(ENABLE_BLURAY_JAR)
+      # Required for building libbluray bd jars, however is optional for libbluray
+      find_package(ANT)
 
-        get_target_property(ANT_PATH ANT::ANT ANT_PATH)
-        get_target_property(ANT_HOME ANT::ANT ANT_HOME)
+      if(TARGET ANT::ANT)
+        find_package(Java COMPONENTS Development)
 
-        if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.26)
-          list(APPEND additional_env_mod --modify PATH=path_list_prepend:${NATIVEPREFIX}/bin
-                                         --modify PATH=path_list_prepend:${java_binpath}
-                                         --modify PATH=path_list_prepend:${ANT_PATH}
-                                         --modify ANT_HOME=set:${ANT_HOME}
-                                         --modify JAVA_HOME=set:${java_homepath})
+        if(Java_Development_FOUND)
+          get_filename_component(java_binpath ${Java_JAVAC_EXECUTABLE} DIRECTORY)
+          get_filename_component(java_homepath ${java_binpath} DIRECTORY)
 
-          set(build_env_mod ${CMAKE_COMMAND} -E env ${additional_env_mod})
+          get_target_property(ANT_PATH ANT::ANT ANT_PATH)
+          get_target_property(ANT_HOME ANT::ANT ANT_HOME)
+
+          if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.26)
+            list(APPEND additional_env_mod --modify PATH=path_list_prepend:${NATIVEPREFIX}/bin
+                                           --modify PATH=path_list_prepend:${java_binpath}
+                                           --modify PATH=path_list_prepend:${ANT_PATH}
+                                           --modify ANT_HOME=set:${ANT_HOME}
+                                           --modify JAVA_HOME=set:${java_homepath})
+
+            set(build_env_mod ${CMAKE_COMMAND} -E env ${additional_env_mod})
+          endif()
+          set(temp_extras_arg -Djdk_home=${java_homepath} -Dbdj_jar=enabled)
+          unset(temp_env_mod)
         endif()
       endif()
+    endif()
+
+    list(APPEND ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_EXTRAS ${temp_extras_arg})
+    if(temp_env_mod)
+      list(APPEND additional_env_mod ${temp_env_mod})
     endif()
 
     if(APPLE)
@@ -112,6 +124,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                           -Ddefault_library=${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_libType}
                           -Denable_tools=false
                           -Dembed_udfread=false
+                          ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_EXTRAS}
                           ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}_CROSS_FILE})
 
     set(BUILD_COMMAND ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_dev_env}


### PR DESCRIPTION
## Description
Add an option (ENABLUE_BLURAY_JAR) that is dependent on using and building ENABLE_INTERNAL_BLURAY. This enables to opt out of building libbluray's jar files.

## Motivation and context
@ksooo had some issues with environment issues that caused libbluray bdjar builds. Technically it would be a best practice to allow to disable such an optional feature

## How has this been tested?
locally, ksooo's machine

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
