### PR TITLE
[VideoPlayer] Fix VideoPlayer state update / Broken OSD for DVD

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5083,13 +5083,20 @@ void CVideoPlayer::UpdatePlayState(double timeout)
   else if (m_CurrentAudio.startpts != DVD_NOPTS_VALUE)
     state.dts = m_CurrentAudio.startpts;
 
+  state.startTime = 0;
+  state.timeMin = 0;
+
   std::shared_ptr<CDVDInputStream::IMenus> pMenu = std::dynamic_pointer_cast<CDVDInputStream::IMenus>(m_pInputStream);
 
   bool chapterNbEnabled{false};
 
   if (m_pDemuxer)
   {
-    if (!(IsInMenuInternal() && pMenu && !pMenu->CanSeek()))
+    if (IsInMenuInternal() && pMenu && !pMenu->CanSeek())
+    {
+      state.chapter = 0;
+    }
+    else
     {
       state.chapter = m_pDemuxer->GetChapter();
       chapterNbEnabled = true;
@@ -5109,12 +5116,22 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     state.timeMax = m_pDemuxer->GetStreamLength();
   }
 
+  state.canpause = false;
+  state.canseek = false;
+  state.cantempo = false;
+  state.isInMenu = false;
+  state.menuType = MenuType::NONE;
+
   if (m_pInputStream)
   {
     CDVDInputStream::IChapter* pChapter = m_pInputStream->GetIChapter();
     if (pChapter)
     {
-      if (!(IsInMenuInternal() && pMenu && !pMenu->CanSeek()))
+      if (IsInMenuInternal() && pMenu && !pMenu->CanSeek())
+      {
+        state.chapter = 0;
+      }
+      else
       {
         state.chapter = pChapter->GetChapter();
         chapterNbEnabled = true;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5103,9 +5103,9 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     }
 
     state.chapters.clear();
-    if (m_pDemuxer->GetChapterCount() > 0)
+    if (const int chapterCount = m_pDemuxer->GetChapterCount(); chapterCount > 0)
     {
-      for (int i = 0, ie = m_pDemuxer->GetChapterCount(); i < ie; ++i)
+      for (int i = 0, ie = chapterCount; i < ie; ++i)
       {
         auto& p = state.chapters.emplace_back(
             std::string{}, m_Edl.GetTimeWithoutCuts(m_pDemuxer->GetChapterPos(i + 1)));
@@ -5138,9 +5138,9 @@ void CVideoPlayer::UpdatePlayState(double timeout)
       }
 
       state.chapters.clear();
-      if (pChapter->GetChapterCount() > 0)
+      if (const int chapterCount = pChapter->GetChapterCount(); chapterCount > 0)
       {
-        for (int i = 0, ie = pChapter->GetChapterCount(); i < ie; ++i)
+        for (int i = 0, ie = chapterCount; i < ie; ++i)
         {
           auto& p = state.chapters.emplace_back(std::string{}, pChapter->GetChapterPos(i + 1));
           pChapter->GetChapterName(p.first, i + 1);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -76,8 +76,8 @@ struct SPlayerState
   MenuType menuType;
   bool streamsReady;
 
-  int chapter;              // current chapter
-  // name and position for chapters
+  int chapter; // 1-based current chapter. <=0 means no chapter / unknown
+  // name and start timestamp of chapters.
   std::vector<std::pair<std::string, std::chrono::milliseconds>> chapters;
 
   bool canpause;            // pvr: can pause the current playing item


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Revert commit 5413fcc of #27969

The state object is copy-initialized from m_State and doesn't have default values so resetting some members is needed.
Improved a couple comments and avoided a few variable copies while in the neighborhood.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #28020 - OSD doesn't work after starting playback from DVD menu.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Confirmed fixed with DVD. Unable to confirm with Bluray, starting the menu seems broken in v22a3.
edit: 22a3 build requirements list is incomplete (addressed in other PR), adding a JDK for build fixed the issue.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Fix previous breakage, OSD works again when playing a DVD.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
