### PR TITLE
[Input] Move CEC input handling off main thread

### DIFF
--- a/cmake/treedata/common/input.txt
+++ b/cmake/treedata/common/input.txt
@@ -1,6 +1,7 @@
 xbmc/input                                      input
 xbmc/input/actions                              input/actions
 xbmc/input/actions/interfaces                   input/actions/interfaces
+xbmc/input/cec                                  input/cec
 xbmc/input/hardware                             input/hardware
 xbmc/input/joysticks                            input/joysticks
 xbmc/input/joysticks/dialogs                    input/joysticks/dialogs

--- a/xbmc/input/InputManager.cpp
+++ b/xbmc/input/InputManager.cpp
@@ -20,6 +20,7 @@
 #include "guilib/GUIWindowManager.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "input/cec/ICecInputProvider.h"
 #include "input/keyboard/Key.h"
 #include "input/keyboard/KeyboardEasterEgg.h"
 #include "input/keyboard/XBMC_vkeys.h"
@@ -109,14 +110,6 @@ void CInputManager::InitializeInputs()
 
 void CInputManager::Deinitialize()
 {
-}
-
-bool CInputManager::ProcessPeripherals(float frameTime)
-{
-  CKey key;
-  if (CServiceBroker::GetPeripherals().GetNextKeypress(frameTime, key))
-    return OnKey(key);
-  return false;
 }
 
 bool CInputManager::ProcessMouse(int windowId)
@@ -302,8 +295,21 @@ bool CInputManager::ProcessEventServer(int windowId, float frameTime)
   return false;
 }
 
+void CInputManager::ProcessCec()
+{
+  std::unique_lock lock(m_cecHandlingMutex);
+
+  for (auto* handler : m_cecInputProviders)
+  {
+    std::optional<CKey> key = handler->GetCecKey();
+    if (key)
+      QueueCecKey(*key);
+  }
+}
+
 void CInputManager::ProcessQueuedActions()
 {
+  // Process actions
   std::vector<CAction> queuedActions;
   {
     std::unique_lock lock(m_actionMutex);
@@ -312,6 +318,16 @@ void CInputManager::ProcessQueuedActions()
 
   for (const CAction& action : queuedActions)
     g_application.OnAction(action);
+
+  // Process CEC keys
+  std::vector<CKey> queuedCecKeys;
+  {
+    std::unique_lock lock(m_cecKeyMutex);
+    queuedCecKeys.swap(m_queuedCecKeys);
+  }
+
+  for (const CKey& key : queuedCecKeys)
+    OnKey(key);
 }
 
 void CInputManager::QueueAction(const CAction& action)
@@ -330,11 +346,16 @@ void CInputManager::QueueAction(const CAction& action)
   m_queuedActions.push_back(action);
 }
 
+void CInputManager::QueueCecKey(const CKey& key)
+{
+  std::unique_lock lock(m_cecKeyMutex);
+  m_queuedCecKeys.emplace_back(key);
+}
+
 bool CInputManager::Process(int windowId, float frameTime)
 {
   // process input actions
   ProcessEventServer(windowId, frameTime);
-  ProcessPeripherals(frameTime);
   ProcessQueuedActions();
 
   // Inform the environment of the new active window ID
@@ -957,4 +978,19 @@ void CInputManager::UnregisterMouseDriverHandler(MOUSE::IMouseDriverHandler* han
 {
   m_mouseHandlers.erase(std::remove(m_mouseHandlers.begin(), m_mouseHandlers.end(), handler),
                         m_mouseHandlers.end());
+}
+
+void CInputManager::RegisterCecInputProvider(CEC::ICecInputProvider* handler)
+{
+  std::unique_lock lock(m_cecHandlingMutex);
+
+  if (std::ranges::find(m_cecInputProviders, handler) == m_cecInputProviders.end())
+    m_cecInputProviders.emplace_back(handler);
+}
+
+void CInputManager::UnregisterCecInputProvider(CEC::ICecInputProvider* handler)
+{
+  std::unique_lock lock(m_cecHandlingMutex);
+
+  std::erase(m_cecInputProviders, handler);
 }

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -29,6 +29,10 @@ class CProfileManager;
 
 namespace KODI
 {
+namespace CEC
+{
+class ICecInputProvider;
+}
 
 namespace KEYBOARD
 {
@@ -90,13 +94,6 @@ public:
    * \return true if event is handled, false otherwise
    */
   bool ProcessEventServer(int windowId, float frameTime);
-
-  /*! \brief decode an event from peripherals.
-   *
-   * \param frameTime Time in seconds since last call
-   * \return true if event is handled, false otherwise
-   */
-  bool ProcessPeripherals(float frameTime);
 
   /*! \brief Process all inputs
    *
@@ -228,6 +225,11 @@ public:
    */
   void QueueAction(const CAction& action);
 
+  /*!
+   * \brief Process CEC input
+   */
+  void ProcessCec();
+
   // implementation of ISettingCallback
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
 
@@ -239,6 +241,9 @@ public:
 
   virtual void RegisterMouseDriverHandler(KODI::MOUSE::IMouseDriverHandler* handler);
   virtual void UnregisterMouseDriverHandler(KODI::MOUSE::IMouseDriverHandler* handler);
+
+  void RegisterCecInputProvider(KODI::CEC::ICecInputProvider* handler);
+  void UnregisterCecInputProvider(KODI::CEC::ICecInputProvider* handler);
 
 private:
   /*! \brief Process keyboard event and translate into an action
@@ -262,6 +267,11 @@ private:
    * \return true on successfully handled event
    */
   bool HandleKey(const CKey& key);
+
+  /*!
+   * \brief Queue CEC key to be processed on the next call to Process()
+   */
+  void QueueCecKey(const CKey& key);
 
   /*! \brief Determine if an action should be processed or just
    *   cancel the screensaver
@@ -295,6 +305,10 @@ private:
   std::vector<CAction> m_queuedActions;
   CCriticalSection m_actionMutex;
 
+  std::vector<CKey> m_queuedCecKeys;
+  CCriticalSection m_cecKeyMutex;
+  CCriticalSection m_cecHandlingMutex;
+
   // Button translation
   std::unique_ptr<KODI::KEYMAP::IKeymapEnvironment> m_keymapEnvironment;
   std::unique_ptr<KODI::KEYMAP::CButtonTranslator> m_buttonTranslator;
@@ -304,6 +318,7 @@ private:
 
   std::vector<KODI::KEYBOARD::IKeyboardDriverHandler*> m_keyboardHandlers;
   std::vector<KODI::MOUSE::IMouseDriverHandler*> m_mouseHandlers;
+  std::vector<KODI::CEC::ICecInputProvider*> m_cecInputProviders;
 
   std::unique_ptr<KODI::KEYBOARD::IKeyboardDriverHandler> m_keyboardEasterEgg;
 

--- a/xbmc/input/cec/CMakeLists.txt
+++ b/xbmc/input/cec/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(SOURCES
+)
+
+set(HEADERS ICecInputProvider.h
+)
+
+if(NOT ENABLE_STATIC_LIBS)
+  core_add_library(input_cec)
+endif()

--- a/xbmc/input/cec/ICecInputProvider.h
+++ b/xbmc/input/cec/ICecInputProvider.h
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <optional>
+
+class CKey;
+
+namespace KODI::CEC
+{
+class ICecInputProvider
+{
+public:
+  virtual ~ICecInputProvider() = default;
+
+  /*!
+   * \brief Try to get a keypress from a CEC peripheral
+   */
+  virtual std::optional<CKey> GetCecKey() = 0;
+};
+} // namespace KODI::CEC

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -828,28 +828,6 @@ bool CPeripherals::ToggleDeviceState(CecStateChange mode /*= STATE_SWITCH_TOGGLE
   return ret;
 }
 
-bool CPeripherals::GetNextKeypress(float frameTime, CKey& key)
-{
-  PeripheralVector peripherals;
-  if (SupportsCEC() && GetPeripheralsWithFeature(peripherals, FEATURE_CEC))
-  {
-    for (auto& peripheral : peripherals)
-    {
-      std::shared_ptr<CPeripheralCecAdapter> cecDevice =
-          std::static_pointer_cast<CPeripheralCecAdapter>(peripheral);
-      if (cecDevice->GetButton())
-      {
-        CKey newKey(cecDevice->GetButton(), cecDevice->GetHoldTime());
-        cecDevice->ResetButton();
-        key = newKey;
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
 EventPollHandlePtr CPeripherals::RegisterEventPoller()
 {
   return m_eventScanner->RegisterPollHandle();

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -237,14 +237,6 @@ public:
   } //! @todo CEC only supports toggling the mute status at this time
 
   /*!
-   * @brief Try to get a keypress from a peripheral.
-   * @param frameTime The current frametime.
-   * @param key The fetched key.
-   * @return True when a keypress was fetched, false otherwise.
-   */
-  bool GetNextKeypress(float frameTime, CKey& key);
-
-  /*!
    * @brief Register with the event scanner to control scan timing
    * @return A handle that unregisters itself when expired
    */

--- a/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
@@ -8,6 +8,9 @@
 
 #include "PeripheralBusCEC.h"
 
+#include "input/InputManager.h"
+#include "peripherals/Peripherals.h"
+
 #include <libcec/cec.h>
 
 using namespace PERIPHERALS;
@@ -23,6 +26,11 @@ CPeripheralBusCEC::~CPeripheralBusCEC(void)
 {
   if (m_cecAdapter)
     CECDestroy(m_cecAdapter);
+}
+
+void CPeripheralBusCEC::ProcessEvents()
+{
+  m_manager.GetInputManager().ProcessCec();
 }
 
 bool CPeripheralBusCEC::PerformDeviceScan(PeripheralScanResults& results)

--- a/xbmc/peripherals/bus/virtual/PeripheralBusCEC.h
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusCEC.h
@@ -34,9 +34,8 @@ public:
   explicit CPeripheralBusCEC(CPeripherals& manager);
   ~CPeripheralBusCEC(void) override;
 
-  /*!
-   * @see PeripheralBus::PerformDeviceScan()
-   */
+  // Implementation of CPeripheralBus
+  void ProcessEvents() override;
   bool PerformDeviceScan(PeripheralScanResults& results) override;
 
 private:

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -17,12 +17,15 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "input/InputManager.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "input/keyboard/Key.h"
 #include "input/keymaps/remote/IRRemoteIDs.h"
 #include "interfaces/AnnouncementManager.h"
 #include "jobs/JobManager.h"
 #include "messaging/ApplicationMessenger.h"
+#include "peripherals/Peripherals.h"
 #include "pictures/GUIWindowSlideShow.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
@@ -78,6 +81,8 @@ CPeripheralCecAdapter::CPeripheralCecAdapter(CPeripherals& manager,
 
 CPeripheralCecAdapter::~CPeripheralCecAdapter(void)
 {
+  m_manager.GetInputManager().UnregisterCecInputProvider(this);
+
   {
     std::unique_lock lock(m_critSection);
     CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
@@ -285,9 +290,25 @@ bool CPeripheralCecAdapter::InitialiseFeature(const PeripheralFeature feature)
 
     m_bStarted = true;
     Create();
+
+    m_manager.GetInputManager().RegisterCecInputProvider(this);
   }
 
   return CPeripheral::InitialiseFeature(feature);
+}
+
+std::optional<CKey> CPeripheralCecAdapter::GetCecKey()
+{
+  const int buttonCode = GetButton();
+  const unsigned int holdTime = GetHoldTime();
+
+  if (buttonCode <= 0)
+    return {};
+
+  std::optional<CKey> key = CKey{static_cast<uint32_t>(buttonCode), holdTime};
+
+  ResetButton();
+  return key;
 }
 
 void CPeripheralCecAdapter::SetVersionInfo(const libcec_configuration& configuration)

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -42,6 +42,7 @@ public:
 
 #include "PeripheralHID.h"
 #include "XBDateTime.h"
+#include "input/cec/ICecInputProvider.h"
 #include "interfaces/AnnouncementManager.h"
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
@@ -63,6 +64,11 @@ namespace CEC
 class ICECAdapter;
 };
 
+namespace KODI::CEC
+{
+class ICecKeyHandler;
+} // namespace KODI::CEC
+
 namespace PERIPHERALS
 {
 class CPeripheralCecAdapterUpdateThread;
@@ -83,6 +89,7 @@ typedef enum
 } CecVolumeChange;
 
 class CPeripheralCecAdapter : public CPeripheralHID,
+                              public KODI::CEC::ICecInputProvider,
                               public ANNOUNCEMENT::IAnnouncer,
                               private CThread
 {
@@ -115,6 +122,9 @@ public:
   int GetButton(void);
   unsigned int GetHoldTime(void);
   void ResetButton(void);
+
+  // Implementation of ICecInputProvider
+  std::optional<CKey> GetCecKey() override;
 
   // public CEC methods
   void ActivateSource(void);


### PR DESCRIPTION
## Description

This PR moves CEC input handling off the main thread.

Specifically, it's currently handled in `CApplication::FrameMove()`, which calls into ServiceBroker, which calls into InputManager, which calls:

* ProcessEventServer()
* ProcessPeripherals()
* ProcessQueuedActions() (controller input queued from peripherals thread)

This PR removes `ProcessPeripherals()` from the list (which only processes CEC).

Now, CEC input is queried in the peripherals thread (at 60fps), and queued for processing in the main thread, identical to how controller input is handled.

## Motivation and context

Done in order to get https://github.com/xbmc/xbmc/pull/16740 further along.

## How has this been tested?

To be tested with CEC adapter on a 2025 model LG TV

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
