### PR TITLE
Apple Silicon native arch detection and fstrcmp libtool init

### DIFF
--- a/tools/depends/m4/xbmc_arch.m4
+++ b/tools/depends/m4/xbmc_arch.m4
@@ -14,7 +14,7 @@ case $build in
   amd64-*-freebsd*)
      AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_FREEBSD")
      ;;
-  arm-apple-darwin*)
+  arm-apple-darwin*|aarch64-apple-darwin*)
      AC_SUBST(NATIVE_ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_DARWIN -DTARGET_DARWIN_OSX")
      ;;
   x86_64-apple-darwin*)

--- a/tools/depends/target/fstrcmp/01-use-lt-init.patch
+++ b/tools/depends/target/fstrcmp/01-use-lt-init.patch
@@ -1,0 +1,60 @@
+--- a/configure.ac
++++ b/configure.ac
+@@ -22,8 +22,7 @@
+ AC_CANONICAL_HOST
+ AC_GNU_SOURCE
+ AC_PROG_INSTALL
+-AC_PROG_RANLIB
+-AC_CHECK_PROGS(AR, ar)
++LT_INIT
+ 
+ AC_USE_SYSTEM_EXTENSIONS
+ AC_C_CONST
+@@ -53,37 +52,7 @@
+ dnl! AC_ADD_CFLAGS(-Werror)
+ dnl! AC_ADD_CFLAGS([-Wl,--as-needed])
+ 
+-AC_CHECK_PROGS(LIBTOOL, libtool)
+ 
+-if test -z "$LIBTOOL"
+-then
+-  AC_MSG_RESULT([
+-        You must have GNU Libtool installed to build fstrcmp.
+-        Homepage: http://www.gnu.org/software/libtool/])
+-  OK=no
+-  if apt-get --version > /dev/null 2> /dev/null; then
+-    AC_MSG_RESULT([
+-        The following command may be used to install it:
+-        sudo apt-get install libtool
+-    ])
+-    OK=yes
+-  fi
+-  if yum --version > /dev/null 2> /dev/null; then
+-    AC_MSG_RESULT([
+-        The following command may be used to install it:
+-        sudo yum install libtool
+-    ])
+-    OK=yes
+-  fi
+-  if test "$OK" != "yes"; then
+-    AC_MSG_RESULT([
+-        If you are using a package based install, you will need the
+-        libtool package.
+-    ])
+-  fi
+-  exit 1
+-fi
+-
+ AC_CHECK_PROGS(GROFF, groff roff)
+ AC_CHECK_PROGS(SOELIM, gsoelim soelim)
+ AC_CHECK_PROGS(REFER, refer grefer)
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -34,6 +34,7 @@
+ #
+ # directory containing the source
+ #
++top_builddir = .
+ srcdir = @srcdir@
+ VPATH = @srcdir@
+ 

--- a/tools/depends/target/fstrcmp/Makefile
+++ b/tools/depends/target/fstrcmp/Makefile
@@ -1,5 +1,6 @@
 include ../../Makefile.include FSTRCMP-VERSION ../../download-files.include
-DEPS = ../../Makefile.include Makefile FSTRCMP-VERSION ../../download-files.include
+DEPS = ../../Makefile.include Makefile FSTRCMP-VERSION ../../download-files.include \
+                                 01-use-lt-init.patch
 
 # configuration settings
 CONFIGURE=./configure --prefix=$(PREFIX)
@@ -11,6 +12,7 @@ all: .installed-$(PLATFORM)
 $(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../01-use-lt-init.patch
 	cd $(PLATFORM); autoreconf -vif; $(CONFIGURE)
 
 $(LIBDYLIB): $(PLATFORM)


### PR DESCRIPTION
## Description

Two build system fixes for `tools/depends`:

1. **Add missing `aarch64-apple-darwin` triplet**: The `xbmc_arch.m4` native arch case only matched `arm-apple-darwin*`, missing Apple Silicon Macs that report as `aarch64-apple-darwin`.

2. **fstrcmp: use `LT_INIT` instead of manual libtool detection**: Upstream fstrcmp uses `AC_CHECK_PROGS(LIBTOOL, libtool)` which fails in cross-compilation environments. Replace it with the standard `LT_INIT` macro and add the missing `top_builddir` in `Makefile.in`.

## Motivation and context

- `tools/depends/configure` fails on Apple Silicon Macs with "unsupported build target".
- fstrcmp fails to build in cross-compilation setups because it searches for a host `libtool` binary instead of using the standard Autotools libtool integration.

## How has this been tested?

- Ran `tools/depends` configure on an Apple Silicon Mac.
- Built fstrcmp target dependency with the patch applied in a cross-compilation setup.

## What is the effect on users?

Fixes build failures on Apple Silicon Macs and when cross-compiling fstrcmp.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed