### PR TITLE
VAAPI: fix 10-bit surface format for HEVC/VP9/AV1 via inputstream addons

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -31,12 +31,13 @@
 #include <va/va_drmcommon.h>
 
 extern "C" {
+#include <libavfilter/buffersink.h>
+#include <libavfilter/buffersrc.h>
 #include <libavutil/avutil.h>
 #include <libavutil/hwcontext.h>
 #include <libavutil/hwcontext_vaapi.h>
 #include <libavutil/opt.h>
-#include <libavfilter/buffersink.h>
-#include <libavfilter/buffersrc.h>
+#include <libavutil/pixdesc.h>
 }
 
 #include "system_egl.h"
@@ -589,6 +590,16 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
   m_vaapiConfig.surfaceHeight = avctx->coded_height;
   m_vaapiConfig.aspect = avctx->sample_aspect_ratio;
   m_vaapiConfig.bitDepth = avctx->bits_per_raw_sample;
+  // ffmpeg's HEVC, VP9, and AV1 decoders do not set bits_per_raw_sample,
+  // but they do set pix_fmt correctly (e.g. yuv420p10le for 10-bit).
+  // Derive bit depth from the pixel format when bits_per_raw_sample is 0,
+  // otherwise ConfigVAAPI creates NV12 surfaces for 10-bit content.
+  if (m_vaapiConfig.bitDepth == 0)
+  {
+    const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(avctx->pix_fmt);
+    if (desc)
+      m_vaapiConfig.bitDepth = desc->comp[0].depth;
+  }
   m_DisplayState = VAAPI_OPEN;
   m_vaapiConfigured = false;
   m_presentPicture = nullptr;


### PR DESCRIPTION
## Description

Fixes #25383 

VAAPI creates NV12 (8-bit) surfaces instead of P010 (10-bit) for HEVC Main10 content played via inputstream addons, because ffmpeg's HEVC, VP9, and AV1 decoders do not set `avctx->bits_per_raw_sample`. Derive bit depth from `avctx->pix_fmt` as a fallback.

NOTE: The current inputstream API does not allow setting bitDepth.  

NOTE: it would be nice it ffmpeg set `bits_per_raw_sample` for all codecs, but it only does so for H.264.  But this PR solves the problem today for the other major codecs that are supported by VAAPI.


## Motivation and context

Fixes #25383 -- HEVC 10-bit content (e.g. Disney+ via inputstream.adaptive) fails with `vaEndPicture error 18 (invalid parameter)` on every frame. File-based playback is unaffected because `CDVDDemuxFFmpeg` sets `bitDepth` independently.

## How has this been tested?

  - Disney+ HEVC Main10 720p via inputstream.adaptive on Intel Gen12 (iHD driver)
  - Verified P010 surfaces created instead of NV12
  - Verified playback succeeds with VAAPI where it previously failed on every frame
  - Software decode confirmed working before and after the change

## What is the effect on users?
fixes #25383

## Screenshots (if appropriate):
n/a

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
