### PR TITLE
[Video][Bluray] Automatically identify playlists for movies and episodes when added to library.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16990,7 +16990,14 @@ msgctxt "#25017"
 msgid "No valid episode playlist has been found."
 msgstr ""
 
-#empty strings from id 25018 to 29800
+#. Automatic menu
+#. Simple menu is shown only if playlist not identified automatically
+#: system/settings/settings.xml
+msgctxt "#25018"
+msgid "Automatic menu selection"
+msgstr ""
+
+#empty strings from id 25019 to 29800
 
 #: unused
 msgctxt "#29801"

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -461,9 +461,10 @@
           <default>0</default> <!-- default -->
           <constraints>
             <options>
-              <option label="14104">0</option> <!-- show simplified menu -->
-              <option label="25003">1</option> <!-- show disc menu -->
-              <option label="14103">2</option> <!-- play main movie -->
+              <option label="25018">0</option> <!-- automatic menu selection -->
+              <option label="14104">1</option> <!-- show simplified menu -->
+              <option label="25003">2</option> <!-- show disc menu -->
+              <option label="14103">3</option> <!-- play main movie -->
             </options>
           </constraints>
           <control type="list" format="string" />

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -160,18 +160,10 @@ void CURL::Parse(std::string strURL1)
 
   //! @todo fix all Addon paths
   std::string strProtocol2 = GetTranslatedProtocol();
-  if(IsProtocol("rss") ||
-     IsProtocol("rsss") ||
-     IsProtocol("rar") ||
-     IsProtocol("apk") ||
-     IsProtocol("xbt") ||
-     IsProtocol("zip") ||
-     IsProtocol("addons") ||
-     IsProtocol("image") ||
-     IsProtocol("videodb") ||
-     IsProtocol("musicdb") ||
-     IsProtocol("androidapp") ||
-     IsProtocol("pvr"))
+  if (IsProtocol("rss") || IsProtocol("rsss") || IsProtocol("rar") || IsProtocol("apk") ||
+      IsProtocol("xbt") || IsProtocol("zip") || IsProtocol("addons") || IsProtocol("image") ||
+      IsProtocol("videodb") || IsProtocol("musicdb") || IsProtocol("androidapp") ||
+      IsProtocol("pvr") || IsProtocol("bluray"))
     sep = "?";
   else
   if(  IsProtocolEqual(strProtocol2, "http")

--- a/xbmc/application/ApplicationPlay.cpp
+++ b/xbmc/application/ApplicationPlay.cpp
@@ -15,8 +15,8 @@
 #include "Util.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "cores/playercorefactory/PlayerCoreFactory.h"
-#include "dialogs/GUIDialogSimpleMenu.h"
 #include "filesystem/DirectoryFactory.h"
+#include "filesystem/DiscDirectoryHelper.h"
 #include "music/MusicFileItemClassify.h"
 #include "playlists/PlayList.h"
 #include "playlists/PlayListFileItemClassify.h"
@@ -202,7 +202,7 @@ bool CApplicationPlay::GetPlaylistIfDisc()
        forceBlurayPlaylistSelection) &&
       IsSimpleMenuAllowed(m_item, m_player, forceSelection))
   {
-    if (!CGUIDialogSimpleMenu::ShowPlaylistSelection(m_item))
+    if (!CDiscDirectoryHelper::GetOrShowPlaylistSelection(m_item))
       return false;
 
     // Reset any resume state as new playlist chosen

--- a/xbmc/application/ApplicationPlay.cpp
+++ b/xbmc/application/ApplicationPlay.cpp
@@ -156,6 +156,12 @@ void CApplicationPlay::GetOptionsAndUpdateItem()
         else if (m_options.starttime == 0.0 && m_item.HasVideoInfoTag())
           GetEpisodeBookmark(m_item, m_options, db);
       }
+
+      // No resume data found from any source — clear the stale resume request
+      // so downstream code (e.g. DVDInputStreamBluray::Open) doesn't attempt
+      // to resume from a non-existent state.
+      if (m_options.starttime == 0.0)
+        m_item.SetStartOffset(0);
     }
     else if (m_item.HasVideoInfoTag())
       GetEpisodeBookmark(m_item, m_options, db);
@@ -166,10 +172,11 @@ void CApplicationPlay::GetOptionsAndUpdateItem()
 
 namespace
 {
-bool IsSimpleMenuAllowed(const CFileItem& item,
-                         const std::string& player,
-                         const bool forceSelection)
+MenuDecision GetMenuDecisions(const CFileItem& item,
+                              const std::string& player,
+                              const CPlayerOptions& options)
 {
+  using enum MenuDecision;
   const CPlayerCoreFactory& playerCoreFactory{CServiceBroker::GetPlayerCoreFactory()};
   const std::string defaultPlayer{player.empty() ? playerCoreFactory.GetDefaultPlayer(item)
                                                  : player};
@@ -177,40 +184,81 @@ bool IsSimpleMenuAllowed(const CFileItem& item,
   // No video selection when using external or remote players (they handle it if supported)
   const bool isExternalPlayer{playerCoreFactory.IsExternalPlayer(defaultPlayer)};
   const bool isRemotePlayer{playerCoreFactory.IsRemotePlayer(defaultPlayer)};
+  if (isExternalPlayer || isRemotePlayer)
+    return NO_ACTION;
 
-  // Check if simple menu is enabled or if we are forced to select a playlist
-  const bool isSimpleMenu{forceSelection ||
-                          CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-                              CSettings::SETTING_DISC_PLAYBACK) == BD_PLAYBACK_SIMPLE_MENU};
+  // See if disc image is a Blu-ray (as an image could be a DVD as well) or if the path is a BDMV folder
+  const bool isBluray{::UTILS::DISCS::IsBlurayDiscImage(item) ||
+                      URIUtils::IsBDFile(item.GetDynPath())};
 
-  return !isExternalPlayer && !isRemotePlayer && isSimpleMenu;
+  // If already a bluray:// path then playlist selection may not be needed
+  // Unless overridden by context menu 'Choose Playlist' or 'Simple Menu' in settings
+  const bool isBlurayPath{URIUtils::IsBlurayPath(item.GetDynPath())};
+
+  const int playbackSetting{CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_DISC_PLAYBACK)};
+  const bool atStart{options.startpercent == 0.0 && options.starttime == 0.0};
+
+  // Show Disc menu
+  // This takes priority over the simple menu
+  const bool useDiscMenuSetting{playbackSetting == BD_PLAYBACK_DISC_MENU};
+  if ((isBluray || isBlurayPath) && atStart && useDiscMenuSetting)
+    return SHOW_DISC_MENU;
+
+  // Select main title
+  const bool useMainTitleSetting{playbackSetting == BD_PLAYBACK_MAIN_TITLE};
+  if ((isBluray || isBlurayPath) && atStart && useMainTitleSetting)
+    return GET_MAIN_TITLE;
+
+  // See if choose (new) playlist has been selected from context menu of if simple menu should always be used
+  const bool forceSelectionAlways{item.GetProperty("force_playlist_selection").asBoolean(false)};
+  const bool forceSelectionAtStart{playbackSetting == BD_PLAYBACK_SIMPLE_MENU};
+  const bool mainTitle{playbackSetting == BD_PLAYBACK_MAIN_TITLE};
+
+  // Show simple menu:
+  // If we don't have a playlist (ie. ISO or BDMV) and we're at the start
+  if (isBluray && atStart && !mainTitle)
+    return SHOW_SIMPLE_MENU;
+
+  // If we already have a playlist but Choose Playlist has been selected on the context menu
+  if (forceSelectionAlways && isBlurayPath)
+    return SHOW_SIMPLE_MENU;
+  // If we already have a playlist but we're at the start and simple menu is enabled in settings
+  if (forceSelectionAtStart && isBlurayPath && atStart)
+    return SHOW_SIMPLE_MENU;
+
+  return NO_ACTION;
 }
 } // namespace
 
 bool CApplicationPlay::GetPlaylistIfDisc()
 {
-  // See if disc image is a Blu-ray (as an image could be a DVD as well) or if the path is a BDMV folder
-  const bool isBluray{::UTILS::DISCS::IsBlurayDiscImage(m_item) ||
-                      URIUtils::IsBDFile(m_item.GetDynPath())};
-
-  // See if choose (new) playlist has been selected from context menu
-  const bool forceSelection{m_item.GetProperty("force_playlist_selection").asBoolean(false)};
-  const bool forceBlurayPlaylistSelection{forceSelection &&
-                                          URIUtils::IsBlurayPath(m_item.GetDynPath())};
-
-  if (((isBluray && !(m_options.startpercent > 0.0 || m_options.starttime > 0.0)) ||
-       forceBlurayPlaylistSelection) &&
-      IsSimpleMenuAllowed(m_item, m_player, forceSelection))
+  using enum MenuDecision;
+  switch (MenuDecision menuDecision{GetMenuDecisions(m_item, m_player, m_options)}; menuDecision)
   {
-    if (!CDiscDirectoryHelper::GetOrShowPlaylistSelection(m_item))
-      return false;
+    case SHOW_DISC_MENU:
+    {
+      // Generate a bluray:// menu path
+      m_item.SetDynPath(URIUtils::GetBlurayMenuPath(m_item.GetDynPath()));
+      break;
+    }
+    case SHOW_SIMPLE_MENU:
+    case GET_MAIN_TITLE:
+    case SILENT:
+    {
+      // Select playlist, showing simple menu if needed
+      if (!CDiscDirectoryHelper::GetOrShowPlaylistSelection(m_item, menuDecision))
+        return false; // User cancelled
 
-    // Reset any resume state as new playlist chosen
-    m_options.starttime = m_options.startpercent = 0.0;
-    m_options.state = {};
-    m_item.ClearProperty("force_playlist_selection");
+      // Reset any resume state as new playlist chosen
+      m_options.starttime = m_options.startpercent = 0.0;
+      m_options.state = {};
+      m_item.ClearProperty("force_playlist_selection");
+      break;
+    }
+    case NO_ACTION:
+      break;
   }
-
   return true;
 }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -16,7 +16,6 @@
 #include "URL.h"
 #include "filesystem/BlurayCallback.h"
 #include "filesystem/SpecialProtocol.h"
-#include "settings/DiscSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Geometry.h"
@@ -325,17 +324,10 @@ bool CDVDInputStreamBluray::Open()
     return false;
   }
 
-  int mode = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_DISC_PLAYBACK);
-
   if (URIUtils::HasExtension(filename, ".mpls"))
   {
     m_navmode = false;
     m_titleInfo = GetTitleFile(filename);
-  }
-  else if (mode == BD_PLAYBACK_MAIN_TITLE)
-  {
-    m_navmode = false;
-    m_titleInfo = GetTitleLongest();
   }
   else if (resumable && m_item.GetStartOffset() == STARTOFFSET_RESUME && m_item.IsResumable())
   {

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -9,18 +9,11 @@
 #include "GUIDialogSimpleMenu.h"
 
 #include "FileItem.h"
-#include "FileItemList.h"
-#include "GUIDialogOK.h"
 #include "GUIDialogSelect.h"
 #include "GUIDialogYesNo.h"
 #include "ServiceBroker.h"
-#include "dialogs/GUIDialogBusy.h"
-#include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "threads/IRunnable.h"
-#include "utils/RegExp.h"
-#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -32,182 +25,72 @@
 
 using namespace KODI;
 
-namespace
+bool CGUIDialogSimpleMenu::ShowPlaylistSelection(
+    const CFileItem& item,
+    CFileItem& selectedItem,
+    const CFileItemList& items,
+    const std::vector<CVideoDatabase::PlaylistInfo>& usedPlaylists)
 {
-class CGetDirectoryItems : public IRunnable
-{
-public:
-  CGetDirectoryItems(const std::string& path,
-                     CFileItemList& items,
-                     const XFILE::CDirectory::CHints& hints)
-    : m_path(path), m_items(items), m_hints(hints)
-  {
-  }
-  void Run() override
-  {
-    m_result = XFILE::CDirectory::GetDirectory(m_path, m_items, m_hints);
-  }
-  bool m_result;
-protected:
-  std::string m_path;
-  CFileItemList &m_items;
-  XFILE::CDirectory::CHints m_hints;
-};
-}
-
-bool CGUIDialogSimpleMenu::ShowPlaylistSelection(CFileItem& item)
-{
-  const std::string originalDynPath{
-      item.GetDynPath()}; // Overwritten by dialog selection. Needed for screen refresh.
-
-  const std::string directory{
-      [&item, &originalDynPath]
-      {
-        if (item.GetVideoContentType() == VideoDbContentType::EPISODES)
-        {
-          const CVideoInfoTag* tag{item.GetVideoInfoTag()};
-          return URIUtils::GetBlurayEpisodePath(originalDynPath, tag->m_iSeason, tag->m_iEpisode);
-        }
-        return URIUtils::GetBlurayRootPath(originalDynPath);
-      }()};
-
-  const bool forcePlaylistSelection{item.GetProperty("force_playlist_selection").asBoolean(false)};
-
-  // Get playlists that are already used (for warning after selection to avoid duplicates in file table)
-  std::vector<CVideoDatabase::PlaylistInfo> usedPlaylists{};
-  CVideoDatabase database;
-  if (!database.Open())
-  {
-    CLog::LogF(LOGERROR, "Failed to open video database");
-    return false;
-  }
-  usedPlaylists = database.GetPlaylistsByPath(URIUtils::GetBlurayPlaylistPath(originalDynPath));
-
-  // If replacing existing playlist (FORCE_PLAYLIST_SELECTION), remove it from exclude list
-  // as user could choose the same playlist again
-  if (forcePlaylistSelection)
-  {
-    CRegExp regex{true, CRegExp::autoUtf8, R"(\/(\d{5}).mpls$)"};
-    if (regex.RegFind(originalDynPath) != -1)
-    {
-      const int playlist{std::stoi(regex.GetMatch(1))};
-      std::erase_if(usedPlaylists, [&playlist](const CVideoDatabase::PlaylistInfo& p)
-                    { return p.playlist == playlist; });
-    }
-  }
-
-  // Get items
-  CFileItemList items;
-  if (!GetItems(item, items, directory))
-  {
-    // No main movie or episode playlist found
-    CGUIDialogOK::ShowAndGetInput(
-        CVariant{257},
-        CVariant{item.GetVideoContentType() == VideoDbContentType::EPISODES ? 25017 : 25016});
-    return false;
-  }
-
   CGUIDialogSelect* dialog{CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
       WINDOW_DIALOG_SELECT)};
-  while (true)
+
+  dialog->Reset();
+  dialog->SetHeading(CVariant{25006}); // Select playback item
+  dialog->SetItems(items);
+  dialog->SetUseDetails(true);
+  dialog->Open();
+
+  if (dialog->GetSelectedItem() < 0)
   {
-    dialog->Reset();
-    dialog->SetHeading(CVariant{25006}); // Select playback item
-    dialog->SetItems(items);
-    dialog->SetUseDetails(true);
-    dialog->Open();
+    CLog::LogF(LOGDEBUG, "User aborted playlist selection");
+    return false;
+  }
 
-    const std::shared_ptr<CFileItem> item_new{dialog->GetSelectedFileItem()};
-    if (!item_new || dialog->GetSelectedItem() < 0)
+  // If item is not folder (ie. all titles)
+  selectedItem = *dialog->GetSelectedFileItem();
+  if (!selectedItem.IsFolder())
+  {
+    // See if already selected
+    if (!usedPlaylists.empty())
     {
-      CLog::LogF(LOGDEBUG, "User aborted {}", directory);
-      break;
-    }
+      // See if playlist already used
+      const int newPlaylist{selectedItem.GetProperty("bluray_playlist").asInteger32(0)};
+      auto matchingPlaylists{usedPlaylists |
+                             std::views::filter([newPlaylist](const CVideoDatabase::PlaylistInfo& p)
+                                                { return p.playlist == newPlaylist; })};
 
-    // If item is not folder (ie. all titles)
-    if (!item_new->IsFolder())
-    {
-      if (!usedPlaylists.empty())
+      if (std::ranges::distance(matchingPlaylists) > 0)
       {
-        // See if playlist already used
-        const int newPlaylist{item_new->GetProperty("bluray_playlist").asInteger32(0)};
-        auto matchingPlaylists{
-            usedPlaylists | std::views::filter([newPlaylist](const CVideoDatabase::PlaylistInfo& p)
-                                               { return p.playlist == newPlaylist; })};
+        // Warn that this playlist is already associated with an episode
+        if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{559}, CVariant{25015}))
+          return false;
 
-        if (std::ranges::distance(matchingPlaylists) > 0)
+        std::string base{item.GetDynPath()};
+        if (URIUtils::IsBlurayPath(base))
+          base = URIUtils::GetDiscFile(base);
+
+        CVideoDatabase db;
+        if (!db.Open())
         {
-          // Warn that this playlist is already associated with an episode
-          if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{559}, CVariant{25015}))
-            return false;
-
-          std::string base{originalDynPath};
-          if (URIUtils::IsBlurayPath(base))
-            base = URIUtils::GetDiscFile(base);
-
-          for (const auto& it : matchingPlaylists)
-          {
-            // Revert file to base file (BDMV/ISO)
-            database.BeginTransaction();
-            if (database.SetFileForMedia(base, it.mediaType, it.idMedia,
-                                         CVideoDatabase::FileRecord{
-                                             .m_idFile = it.idFile,
-                                             .m_dateAdded = item.GetVideoInfoTag()->m_dateAdded}) >
-                0)
-              database.CommitTransaction();
-            else
-              database.RollbackTransaction();
-          }
+          CLog::LogF(LOGERROR, "Failed to open video database");
+          return false;
         }
+
+        for (const auto& it : matchingPlaylists)
+        {
+          // Revert file to base file (BDMV/ISO)
+          db.BeginTransaction();
+          if (db.SetFileForMedia(base, it.mediaType, it.idMedia,
+                                 CVideoDatabase::FileRecord{
+                                     .m_idFile = it.idFile,
+                                     .m_dateAdded = item.GetVideoInfoTag()->m_dateAdded}) > 0)
+            db.CommitTransaction();
+          else
+            db.RollbackTransaction();
+        }
+        db.Close();
       }
-
-      item.SetDynPath(item_new->GetDynPath());
-      item.SetProperty("original_listitem_url", originalDynPath);
-
-      // If streamdetails are already present they are from an nfo and should not be overwritten
-      //  unless forced playlist selection (ie. choose playlist selected from the context menu) - given we
-      //  don't know the source of the original streamdetails (nfo or previous playlist) we always overwrite
-      // @todo - update when streamdetails source tracking is added
-      if (!item.GetVideoInfoTag()->HasStreamDetails() || forcePlaylistSelection)
-        item.GetVideoInfoTag()->m_streamDetails = item_new->GetVideoInfoTag()->m_streamDetails;
-
-      return true;
     }
-
-    if (!GetItems(item, items, item_new->GetDynPath())) // Get selected (usually all) titles
-      return true;
   }
-
-  return false;
-}
-
-bool CGUIDialogSimpleMenu::GetItems(const CFileItem& item,
-                                    CFileItemList& items,
-                                    const std::string& directory)
-{
-  items.Clear();
-  if (!GetDirectoryItems(directory, items, XFILE::CDirectory::CHints()))
-  {
-    CLog::LogF(LOGERROR, "Failed to get play directory for {}", directory);
-    return false;
-  }
-
-  if (items.IsEmpty())
-  {
-    CLog::LogF(LOGERROR, "Failed to get any items in {}", directory);
-    return false;
-  }
-
   return true;
-}
-
-bool CGUIDialogSimpleMenu::GetDirectoryItems(const std::string &path, CFileItemList &items,
-                                             const XFILE::CDirectory::CHints &hints)
-{
-  CGetDirectoryItems getItems(path, items, hints);
-  if (!CGUIDialogBusy::Wait(&getItems, 100, true))
-  {
-    return false;
-  }
-  return getItems.m_result;
 }

--- a/xbmc/dialogs/GUIDialogSimpleMenu.h
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include "filesystem/Directory.h"
+#include "video/VideoDatabase.h"
 
-#include <string>
+#include <vector>
 
 class CFileItem;
 class CFileItemList;
@@ -18,15 +18,9 @@ class CFileItemList;
 class CGUIDialogSimpleMenu
 {
 public:
-
   /*! \brief Show dialog allowing selection of wanted playback item */
-  static bool ShowPlaylistSelection(CFileItem& item);
-
-protected:
-  static bool GetDirectoryItems(const std::string& path,
-                                CFileItemList& items,
-                                const XFILE::CDirectory::CHints& hints);
-
-private:
-  static bool GetItems(const CFileItem& item, CFileItemList& items, const std::string& directory);
+  static bool ShowPlaylistSelection(const CFileItem& item,
+                                    CFileItem& selectedItem,
+                                    const CFileItemList& items,
+                                    const std::vector<CVideoDatabase::PlaylistInfo>& usedPlaylists);
 };

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -201,6 +201,31 @@ void RemoveShortPlaylists(std::vector<PlaylistInformation>& playlists)
   }
 }
 
+void GetMainPlaylist(std::vector<PlaylistInformation>& playlists, GetTitle job)
+{
+  // If any playlists have more than one chapter, discard those without
+  if (std::ranges::any_of(playlists,
+                          [](const PlaylistInformation& p) { return p.chapters.size() > 1; }))
+  {
+    std::erase_if(playlists, [](const PlaylistInformation& p) { return p.chapters.size() <= 1; });
+  }
+
+  const auto it{std::ranges::max_element(playlists, {}, &PlaylistInformation::duration)};
+  if (it == playlists.end())
+    return;
+
+  if (job == GetTitle::GET_TITLES_SINGLE)
+  {
+    playlists = {*it}; // Single longest title
+    return;
+  }
+
+  // All titles with duration of at least 70% of the longest title (to allow multiple editions on same disc)
+  const auto minimumDuration{it->duration * MAIN_TITLE_LENGTH_PERCENT / 100};
+  std::erase_if(playlists, [minimumDuration](const PlaylistInformation& playlist)
+                { return playlist.duration < minimumDuration; });
+}
+
 void SortPlaylists(std::vector<PlaylistInformation>& playlists, SortTitles sort, int mainPlaylist)
 {
   std::ranges::sort(playlists,
@@ -231,8 +256,8 @@ bool IncludePlaylist(GetTitle job,
   using enum GetTitle;
   return job == GET_TITLES_ALL || job == GET_TITLES_EPISODES ||
          (job == GET_TITLES_MAIN && title.duration >= minDuration) ||
-         (job == GET_TITLES_ONE && (title.playlist == static_cast<unsigned int>(mainPlaylist) ||
-                                    (mainPlaylist == -1 && title.playlist == maxPlaylist)));
+         (job == GET_TITLES_SINGLE && (title.playlist == static_cast<unsigned int>(mainPlaylist) ||
+                                       (mainPlaylist == -1 && title.playlist == maxPlaylist)));
 }
 
 void SetStreamDetails(const CURL& url,
@@ -352,6 +377,10 @@ bool FilterPlaylists(std::vector<PlaylistInformation>& playlists,
   // No playlists found
   if (playlists.empty())
     return false;
+
+  // For the main or single title select the longest playlist(s) that has >1 chapter
+  if (job == GetTitle::GET_TITLES_MAIN || job == GetTitle::GET_TITLES_SINGLE)
+    GetMainPlaylist(playlists, job);
 
   // Sort
   // Movies - placing main title - if present - first, then by duration
@@ -711,6 +740,7 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     return false;
 
   // /root                              - get main (length >70% longest) playlists
+  // /root/main	                        - get the single (most likely) main title playlist only
   // /root/titles                       - get all playlists
   // /root/episode/<season>/<episode>   - get playlists that correspond with S<season>E<episode>
   //                                      if none found then return all playlists
@@ -726,6 +756,10 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   if (file == "root/titles")
     return GetPlaylists(url, m_realPath, m_flags, GetTitle::GET_TITLES_ALL, items,
                         SortTitles::SORT_TITLES_MOVIE, m_clipCache);
+
+  if (file == "root/main")
+    return GetPlaylists(url, m_realPath, m_flags, GetTitle::GET_TITLES_SINGLE, items,
+                        SortTitles::SORT_TITLES_NONE, m_clipCache);
 
   if (StringUtils::StartsWith(file, "root/episode"))
   {

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -550,6 +550,7 @@ void ProcessPlaylist(PlaylistMap& playlists, PlaylistInformation& titleInfo, Cli
 bool GetPlaylistsInformation(const CURL& url,
                              const std::string& realPath,
                              int flags,
+                             CFileItemList& allTitles,
                              ClipMap& clips,
                              PlaylistMap& playlists,
                              std::map<unsigned int, ClipInformation>& clipCache)
@@ -558,7 +559,7 @@ bool GetPlaylistsInformation(const CURL& url,
   {
     // Check cache
     const std::string& path{url.GetHostName()};
-    if (CServiceBroker::GetBlurayDiscCache()->GetMaps(path, playlists, clips))
+    if (CServiceBroker::GetBlurayDiscCache()->GetMaps(path, playlists, clips, allTitles))
     {
       CLog::LogF(LOGDEBUG, "Playlist information for {} retrieved from cache", path);
       return false;
@@ -566,7 +567,6 @@ bool GetPlaylistsInformation(const CURL& url,
 
     // Get all titles on disc
     // Sort by playlist for grouping later
-    CFileItemList allTitles;
     GetPlaylists(url, realPath, flags, GetTitle::GET_TITLES_EPISODES, allTitles,
                  SortTitles::SORT_TITLES_EPISODE, clipCache);
 
@@ -604,7 +604,7 @@ bool GetPlaylistsInformation(const CURL& url,
     CLog::LogF(LOGDEBUG, "*** Playlist information End ***");
 
     // Cache
-    CServiceBroker::GetBlurayDiscCache()->SetMaps(path, playlists, clips);
+    CServiceBroker::GetBlurayDiscCache()->SetMaps(path, playlists, clips, allTitles);
     CLog::LogF(LOGDEBUG, "Playlist information for {} cached", path);
 
     return true;
@@ -828,11 +828,13 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     // Get playlist, clip and language information
     ClipMap clips;
     PlaylistMap playlists;
-    GetPlaylistsInformation(m_url, m_realPath, m_flags, clips, playlists, m_clipCache);
+    CFileItemList allTitles;
+    GetPlaylistsInformation(m_url, m_realPath, m_flags, allTitles, clips, playlists, m_clipCache);
 
     // Get episode playlists
     CDiscDirectoryHelper helper;
-    helper.GetEpisodePlaylists(m_url, items, episodeIndex, episodesOnDisc, clips, playlists);
+    helper.GetEpisodePlaylists(m_url, items, allTitles, episodeIndex, episodesOnDisc, clips,
+                               playlists);
 
     // Heuristics failed so return all playlists
     if (items.IsEmpty())

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -26,6 +26,7 @@
 #include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/EpisodeUtils.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
@@ -731,6 +732,15 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 {
   Dispose();
   m_url = url;
+
+  // Deal with options
+  unsigned int duration{0};
+  if (m_url.HasOption("duration"))
+  {
+    duration = StringUtils::ToUint32(m_url.GetOption("duration"), 0);
+    m_url.RemoveOption("duration");
+  }
+
   std::string root{m_url.GetHostName()};
   std::string file{m_url.GetFileName()};
   URIUtils::RemoveSlashAtEnd(file);
@@ -747,24 +757,49 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   // /root/episode/all                  - get all episodes
   if (file == "root")
   {
-    GetPlaylists(url, m_realPath, m_flags, GetTitle::GET_TITLES_MAIN, items,
+    GetPlaylists(m_url, m_realPath, m_flags, GetTitle::GET_TITLES_MAIN, items,
                  SortTitles::SORT_TITLES_MOVIE, m_clipCache);
     AddOptionsAndSort(m_url, items, m_blurayMenuSupport);
     return (items.Size() > 2);
   }
 
   if (file == "root/titles")
-    return GetPlaylists(url, m_realPath, m_flags, GetTitle::GET_TITLES_ALL, items,
+    return GetPlaylists(m_url, m_realPath, m_flags, GetTitle::GET_TITLES_ALL, items,
                         SortTitles::SORT_TITLES_MOVIE, m_clipCache);
 
   if (file == "root/main")
-    return GetPlaylists(url, m_realPath, m_flags, GetTitle::GET_TITLES_SINGLE, items,
+    return GetPlaylists(m_url, m_realPath, m_flags, GetTitle::GET_TITLES_SINGLE, items,
                         SortTitles::SORT_TITLES_NONE, m_clipCache);
 
   if (StringUtils::StartsWith(file, "root/episode"))
   {
-    // Get episodes on disc
-    const std::vector<CVideoInfoTag> episodesOnDisc{CDiscDirectoryHelper::GetEpisodesOnDisc(url)};
+    // Get episodes on disc by parsing file/path
+    // Done first as if called from VideoInfoScanner during library scan
+    //  not all episodes may be in database yet
+    std::string path = URIUtils::GetDiscBase(m_url.Get());
+    URIUtils::RemoveSlashAtEnd(path);
+    CFileItem item(path, false);
+    KODI::VIDEO::EPISODELIST episodesOnDisc;
+    CEpisodeUtils::EnumerateEpisodeItem(&item, episodesOnDisc);
+
+    // Now get any available information from database
+    const std::vector<CVideoInfoTag> episodesInDatabase{
+        CDiscDirectoryHelper::GetEpisodesOnDisc(m_url)};
+    if (!episodesInDatabase.empty())
+    {
+      // Update data with database information (where available)
+      for (auto& episode : episodesOnDisc)
+      {
+        const auto& it{std::ranges::find_if(
+            episodesInDatabase, [&episode](const CVideoInfoTag& e)
+            { return e.m_iSeason == episode.iSeason && e.m_iEpisode == episode.iEpisode; })};
+        if (it != episodesInDatabase.end())
+        {
+          episode.duration = it->GetDuration();
+          episode.strTitle = it->GetTitle();
+        }
+      }
+    }
 
     int season{-1};
     int episode{-1};
@@ -780,17 +815,20 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 
       // Check desired episode is on disc
       const auto& it{
-          std::ranges::find_if(episodesOnDisc, [&season, &episode](const CVideoInfoTag& e)
-                               { return e.m_iSeason == season && e.m_iEpisode == episode; })};
+          std::ranges::find_if(episodesOnDisc, [&season, &episode](const KODI::VIDEO::EPISODE& e)
+                               { return e.iSeason == season && e.iEpisode == episode; })};
       if (it == episodesOnDisc.end())
         return false; // Episode not on disc
       episodeIndex = static_cast<int>(std::distance(episodesOnDisc.begin(), it));
+
+      // Add duration from scraper
+      it->duration = duration;
     }
 
     // Get playlist, clip and language information
     ClipMap clips;
     PlaylistMap playlists;
-    GetPlaylistsInformation(url, m_realPath, m_flags, clips, playlists, m_clipCache);
+    GetPlaylistsInformation(m_url, m_realPath, m_flags, clips, playlists, m_clipCache);
 
     // Get episode playlists
     CDiscDirectoryHelper helper;
@@ -798,7 +836,7 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 
     // Heuristics failed so return all playlists
     if (items.IsEmpty())
-      GetPlaylists(url, m_realPath, m_flags, GetTitle::GET_TITLES_EPISODES, items,
+      GetPlaylists(m_url, m_realPath, m_flags, GetTitle::GET_TITLES_EPISODES, items,
                    SortTitles::SORT_TITLES_EPISODE, m_clipCache);
 
     // Add all titles and menu options
@@ -807,10 +845,10 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     return (items.Size() > 2);
   }
 
-  if (URIUtils::IsBlurayPath(url.Get()))
+  if (URIUtils::IsBlurayPath(m_url.Get()))
   {
-    if (int playlist{URIUtils::GetBlurayPlaylistFromPath(url.Get())}; playlist >= 0)
-      return GetPlaylists(url, m_realPath, m_flags, static_cast<GetTitle>(playlist), items,
+    if (int playlist{URIUtils::GetBlurayPlaylistFromPath(m_url.Get())}; playlist >= 0)
+      return GetPlaylists(m_url, m_realPath, m_flags, static_cast<GetTitle>(playlist), items,
                           SortTitles::SORT_TITLES_NONE, m_clipCache);
     return false;
   }

--- a/xbmc/filesystem/BlurayDiscCache.cpp
+++ b/xbmc/filesystem/BlurayDiscCache.cpp
@@ -46,7 +46,8 @@ void CBlurayDiscCache::SetPlaylistInfo(const std::string& path,
 
 void CBlurayDiscCache::SetMaps(const std::string& path,
                                const PlaylistMap& playlistmap,
-                               const ClipMap& clipmap)
+                               const ClipMap& clipmap,
+                               const CFileItemList& itemmap)
 {
   std::unique_lock lock(m_cs);
 
@@ -60,6 +61,7 @@ void CBlurayDiscCache::SetMaps(const std::string& path,
   auto& [_, disc] = *i;
   disc.playlistMap = playlistmap;
   disc.clipMap = clipmap;
+  disc.itemMap.Copy(itemmap);
   disc.mapsSet = true;
 }
 
@@ -106,7 +108,8 @@ bool CBlurayDiscCache::GetPlaylistInfo(const std::string& path,
 
 bool CBlurayDiscCache::GetMaps(const std::string& path,
                                PlaylistMap& playlistmap,
-                               ClipMap& clipmap) const
+                               ClipMap& clipmap,
+                               CFileItemList& itemmap) const
 {
   std::unique_lock lock(m_cs);
 
@@ -121,6 +124,7 @@ bool CBlurayDiscCache::GetMaps(const std::string& path,
     {
       clipmap = disc.clipMap;
       playlistmap = disc.playlistMap;
+      itemmap.Copy(disc.itemMap);
       return true;
     }
   }

--- a/xbmc/filesystem/BlurayDiscCache.h
+++ b/xbmc/filesystem/BlurayDiscCache.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "DiscDirectoryHelper.h"
+#include "FileItemList.h"
 #include "bluray/M2TSParser.h"
 #include "bluray/PlaylistStructure.h"
 #include "threads/CriticalSection.h"
@@ -23,6 +24,7 @@ struct Disc
   bool mapsSet{false};
   XFILE::PlaylistMap playlistMap;
   XFILE::ClipMap clipMap;
+  CFileItemList itemMap;
 
   std::map<unsigned int, XFILE::StreamMap, std::less<>> streamMap;
 };
@@ -46,7 +48,10 @@ public:
   void SetPlaylistInfo(const std::string& path,
                        unsigned int playlist,
                        const BlurayPlaylistInformation& playlistInfo);
-  void SetMaps(const std::string& path, const PlaylistMap& playlistmap, const ClipMap& clipmap);
+  void SetMaps(const std::string& path,
+               const PlaylistMap& playlistmap,
+               const ClipMap& clipmap,
+               const CFileItemList& itemmap);
   void SetPlaylistStreamInfo(const std::string& path,
                              unsigned int playlist,
                              const StreamMap& streams);
@@ -54,7 +59,10 @@ public:
   bool GetPlaylistInfo(const std::string& path,
                        unsigned int playlist,
                        BlurayPlaylistInformation& playlistInfo) const;
-  bool GetMaps(const std::string& path, PlaylistMap& playlistmap, ClipMap& clipmap) const;
+  bool GetMaps(const std::string& path,
+               PlaylistMap& playlistmap,
+               ClipMap& clipmap,
+               CFileItemList& itemmap) const;
   bool GetPlaylistStreamInfo(const std::string& path,
                              unsigned int playlist,
                              StreamMap& streams) const;

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -11,8 +11,14 @@
 #include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "dialogs/GUIDialogBusy.h"
+#include "dialogs/GUIDialogOK.h"
+#include "dialogs/GUIDialogSimpleMenu.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
+#include "settings/DiscSettings.h"
+#include "threads/IRunnable.h"
+#include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -33,6 +39,24 @@ using namespace std::chrono_literals;
 using PlaylistMapEntry = std::pair<unsigned int, PlaylistInformation>;
 using PlaylistVector = std::vector<std::pair<unsigned int, PlaylistInformation>>;
 using PlaylistVectorEntry = std::pair<unsigned int, PlaylistInformation>;
+
+class CGetDirectoryItems : public IRunnable
+{
+public:
+  CGetDirectoryItems(std::string path, CFileItemList& items, CDirectory::CHints hints)
+    : m_path(std::move(path)),
+      m_items(&items),
+      m_hints(std::move(hints))
+  {
+  }
+  void Run() override { m_result = CDirectory::GetDirectory(m_path, *m_items, m_hints); }
+  bool m_result{false};
+
+private:
+  std::string m_path;
+  CFileItemList* m_items;
+  CDirectory::CHints m_hints;
+};
 
 CDiscDirectoryHelper::CDiscDirectoryHelper()
 {
@@ -988,4 +1012,121 @@ std::vector<CVideoInfoTag> CDiscDirectoryHelper::GetEpisodesOnDisc(const CURL& u
                       return i.m_iSeason < j.m_iSeason;
                     });
   return episodesOnDisc;
+}
+
+bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, int playback)
+{
+  const std::string originalDynPath{
+      item.GetDynPath()}; // Overwritten by dialog selection. Needed for screen refresh.
+
+  const std::string directory{
+      [&item, &originalDynPath, playback]
+      {
+        // Single episode
+        if (item.GetVideoContentType() == VideoDbContentType::EPISODES)
+        {
+          const CVideoInfoTag* tag{item.GetVideoInfoTag()};
+          return URIUtils::GetBlurayEpisodePath(originalDynPath, tag->m_iSeason, tag->m_iEpisode);
+        }
+
+        // Playlists > 70% longest
+        if (playback == BD_PLAYBACK_SIMPLE_MENU)
+          return URIUtils::GetBlurayRootPath(originalDynPath);
+
+        // Single main title
+        return URIUtils::GetBlurayMainTitlePath(originalDynPath);
+      }()};
+
+  // Get playlists that are already used (to avoid duplicates in file table)
+  std::vector<CVideoDatabase::PlaylistInfo> usedPlaylists{};
+  CVideoDatabase database;
+  if (!database.Open())
+  {
+    CLog::LogF(LOGERROR, "Failed to open video database");
+    return false;
+  }
+  usedPlaylists = database.GetPlaylistsByPath(URIUtils::GetBlurayPlaylistPath(originalDynPath));
+
+  // If replacing existing playlist (FORCE_PLAYLIST_SELECTION), remove it from exclude list
+  // as user could choose the same playlist again
+  if (item.GetProperty("force_playlist_selection").asBoolean(false))
+  {
+    CRegExp regex{true, CRegExp::autoUtf8, R"(\/(\d{5}).mpls$)"};
+    if (regex.RegFind(originalDynPath) != -1)
+    {
+      const int playlist{std::stoi(regex.GetMatch(1))};
+      std::erase_if(usedPlaylists, [&playlist](const CVideoDatabase::PlaylistInfo& p)
+                    { return p.playlist == playlist; });
+    }
+  }
+
+  // Get items
+  CFileItemList items;
+  if (!GetItems(items, directory))
+  {
+    // No main movie or episode playlist found
+    CGUIDialogOK::ShowAndGetInput(
+        CVariant{257},
+        CVariant{item.GetVideoContentType() == VideoDbContentType::EPISODES ? 25017 : 25016});
+    return false;
+  }
+
+  // Select item
+  CFileItem selectedItem;
+  if (playback == BD_PLAYBACK_SIMPLE_MENU)
+  {
+    // Use simple menu dialog to select playlist
+    while (true)
+    {
+      if (!CGUIDialogSimpleMenu::ShowPlaylistSelection(item, selectedItem, items, usedPlaylists))
+        return false;
+
+      // If a non-folder item is selected, we're done
+      if (!selectedItem.IsFolder())
+        break;
+
+      // Folder selected - retrieve all titles within it
+      if (!GetItems(items, selectedItem.GetDynPath()))
+        return false;
+    }
+  }
+
+  if (selectedItem.GetPath().empty())
+    selectedItem = *items[0]; // Main item
+
+  item.SetDynPath(selectedItem.GetDynPath());
+  item.GetVideoInfoTag()->m_streamDetails = selectedItem.GetVideoInfoTag()->m_streamDetails;
+  item.SetProperty("original_listitem_url", originalDynPath);
+
+  return true;
+}
+
+bool CDiscDirectoryHelper::GetItems(CFileItemList& items, const std::string& directory)
+{
+  items.Clear();
+  if (!GetDirectoryItems(directory, items, CDirectory::CHints()))
+  {
+    CLog::LogF(LOGERROR, "Failed to get play directory for {}", directory);
+    return false;
+  }
+
+  if (items.IsEmpty())
+  {
+    CLog::LogF(LOGERROR, "Failed to get any items in {}", directory);
+    return false;
+  }
+
+  return true;
+}
+
+bool CDiscDirectoryHelper::GetDirectoryItems(const std::string& path,
+                                             CFileItemList& items,
+                                             const CDirectory::CHints& hints)
+{
+  CGetDirectoryItems getItems(path, items, hints);
+  if (!CGUIDialogBusy::Wait(&getItems, 100, true))
+  {
+    return false;
+  }
+  return getItems.m_result;
 }

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -898,6 +898,7 @@ void CDiscDirectoryHelper::EndPlaylistSearch() const
 void CDiscDirectoryHelper::PopulateFileItems(
     const CURL& url,
     CFileItemList& items,
+    const CFileItemList& allTitles,
     int episodeIndex,
     const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc,
     const PlaylistMap& playlists) const
@@ -936,6 +937,14 @@ void CDiscDirectoryHelper::PopulateFileItems(
       const auto newItem{std::make_shared<CFileItem>("", false)};
       GenerateItem(url, newItem, playlist.playlist, playlists, episodesOnDisc[playlist.index],
                    IsSpecial::EPISODE);
+
+      if (const auto detailsItem{allTitles.Get(newItem->GetPath())}; detailsItem)
+        newItem->GetVideoInfoTag()->m_streamDetails =
+            detailsItem->GetVideoInfoTag()->m_streamDetails;
+      else
+        CLog::LogFC(LOGDEBUG, LOGBLURAY, "Failed to find streamdetails for playlist {}",
+                    playlist.playlist);
+
       items.Add(newItem);
     }
   }
@@ -949,6 +958,13 @@ void CDiscDirectoryHelper::PopulateFileItems(
       if (m_isSpecial == IsSpecial::SPECIAL && m_candidateSpecials.size() == 1)
         episode = episodesOnDisc[episodeIndex];
       GenerateItem(url, newItem, playlist, playlists, episode, IsSpecial::SPECIAL);
+
+      if (const auto detailsItem{allTitles.Get(newItem->GetPath())}; detailsItem)
+        newItem->GetVideoInfoTag()->m_streamDetails =
+            detailsItem->GetVideoInfoTag()->m_streamDetails;
+      else
+        CLog::LogFC(LOGDEBUG, LOGBLURAY, "Failed to find streamdetails for playlist {}", playlist);
+
       items.Add(newItem);
     }
   }
@@ -957,6 +973,7 @@ void CDiscDirectoryHelper::PopulateFileItems(
 bool CDiscDirectoryHelper::GetEpisodePlaylists(
     const CURL& url,
     CFileItemList& items,
+    const CFileItemList& allTitles,
     int episodeIndex,
     const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc,
     const ClipMap& clips,
@@ -968,7 +985,7 @@ bool CDiscDirectoryHelper::GetEpisodePlaylists(
   FindCandidatePlaylists(episodesOnDisc, episodeIndex, playlists);
   FindSpecials(playlists);
   EndPlaylistSearch();
-  PopulateFileItems(url, items, episodeIndex, episodesOnDisc, playlists);
+  PopulateFileItems(url, items, allTitles, episodeIndex, episodesOnDisc, playlists);
 
   return !items.IsEmpty();
 }
@@ -1114,7 +1131,7 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item,
   else
   {
     // Silent - used during scraping
-    // Items may 2-3 items (the latter two being 'All Titles' and 'Menu' - if menus supported) then select the first item (main title/episode)
+    // There may 2-3 items (the latter two being 'All Titles' and 'Menu' - if menus supported) then select the first item (main title/episode)
     // Otherwise return false as we don't know which item to select and don't want to guess (as could be multiple movie versions on the disc etc..)
     const auto playlists{
         std::ranges::count_if(items, [](const std::shared_ptr<CFileItem>& item)

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -16,7 +16,6 @@
 #include "dialogs/GUIDialogSimpleMenu.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
-#include "settings/DiscSettings.h"
 #include "threads/IRunnable.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
@@ -1036,10 +1035,9 @@ std::vector<CVideoInfoTag> CDiscDirectoryHelper::GetEpisodesOnDisc(const CURL& u
   return episodesOnDisc;
 }
 
-bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item,
-                                                      int playback,
-                                                      bool silent /* = false */)
+bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, MenuDecision playback)
 {
+  const bool silent{playback == MenuDecision::SILENT};
   const std::string originalDynPath{
       item.GetDynPath()}; // Overwritten by dialog selection. Needed for screen refresh.
 
@@ -1054,7 +1052,8 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item,
         }
 
         // Playlists > 70% longest
-        if (playback == BD_PLAYBACK_SIMPLE_MENU)
+        using enum MenuDecision;
+        if (playback == SHOW_SIMPLE_MENU || playback == SILENT)
           return URIUtils::GetBlurayRootPath(originalDynPath);
 
         // Single main title
@@ -1068,20 +1067,6 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item,
   {
     CLog::LogF(LOGERROR, "Failed to open video database");
     return false;
-  }
-  usedPlaylists = database.GetPlaylistsByPath(URIUtils::GetBlurayPlaylistPath(originalDynPath));
-
-  // If replacing existing playlist (FORCE_PLAYLIST_SELECTION), remove it from exclude list
-  // as user could choose the same playlist again
-  if (item.GetProperty("force_playlist_selection").asBoolean(false))
-  {
-    CRegExp regex{true, CRegExp::autoUtf8, R"(\/(\d{5}).mpls$)"};
-    if (regex.RegFind(originalDynPath) != -1)
-    {
-      const int playlist{std::stoi(regex.GetMatch(1))};
-      std::erase_if(usedPlaylists, [&playlist](const CVideoDatabase::PlaylistInfo& p)
-                    { return p.playlist == playlist; });
-    }
   }
 
   // Add duration to bluray:// url as needed for episode determination in CBlurayDirectory
@@ -1110,8 +1095,23 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item,
   CFileItem selectedItem;
   if (!silent)
   {
-    if (playback == BD_PLAYBACK_SIMPLE_MENU)
+    if (playback == MenuDecision::SHOW_SIMPLE_MENU)
     {
+      usedPlaylists = database.GetPlaylistsByPath(URIUtils::GetBlurayPlaylistPath(originalDynPath));
+
+      // If replacing existing playlist (FORCE_PLAYLIST_SELECTION), remove it from exclude list
+      // as user could choose the same playlist again
+      if (item.GetProperty("force_playlist_selection").asBoolean(false))
+      {
+        CRegExp regex{true, CRegExp::autoUtf8, R"(\/(\d{5}).mpls$)"};
+        if (regex.RegFind(originalDynPath) != -1)
+        {
+          const int playlist{std::stoi(regex.GetMatch(1))};
+          std::erase_if(usedPlaylists, [&playlist](const CVideoDatabase::PlaylistInfo& p)
+                        { return p.playlist == playlist; });
+        }
+      }
+
       // Use simple menu dialog to select playlist
       while (true)
       {

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -299,16 +299,17 @@ void CDiscDirectoryHelper::FindGroups(const PlaylistMap& playlists)
                   { return group.size() < m_numEpisodes; });
     if (m_groups.empty() && m_numSpecials == 0 && longPlaylists.size() == m_numEpisodes)
     {
-      std::ranges::transform(
-          longPlaylists, std::back_inserter(m_groups),
-          [](const auto& PlaylistInformation) -> std::vector<CandidatePlaylistInformation>
-          {
-            const auto& [playlist, playlistInformation] = PlaylistInformation;
-            return {{.playlist = playlist,
-                     .duration = playlistInformation.duration,
-                     .clips = {},
-                     .languages = {}}};
-          });
+      std::vector<CandidatePlaylistInformation> group;
+      std::ranges::transform(longPlaylists, std::back_inserter(group),
+                             [](const auto& PlaylistInformation) -> CandidatePlaylistInformation
+                             {
+                               const auto& [playlist, playlistInformation] = PlaylistInformation;
+                               return {.playlist = playlist,
+                                       .duration = playlistInformation.duration,
+                                       .clips = {},
+                                       .languages = {}};
+                             });
+      m_groups.emplace_back(std::move(group));
     }
 
     if (m_groups.empty())

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -68,16 +68,16 @@ CDiscDirectoryHelper::CDiscDirectoryHelper()
 }
 
 void CDiscDirectoryHelper::InitialisePlaylistSearch(
-    int episodeIndex, const std::vector<CVideoInfoTag>& episodesOnDisc)
+    int episodeIndex, const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc)
 {
   // Need to differentiate between specials and episodes
   m_allEpisodes = episodeIndex == -1 ? AllEpisodes::ALL : AllEpisodes::SINGLE;
-  m_isSpecial = m_allEpisodes == AllEpisodes::SINGLE && episodesOnDisc[episodeIndex].m_iSeason == 0
+  m_isSpecial = m_allEpisodes == AllEpisodes::SINGLE && episodesOnDisc[episodeIndex].iSeason == 0
                     ? IsSpecial::SPECIAL
                     : IsSpecial::EPISODE;
 
   m_numEpisodes = static_cast<unsigned int>(std::ranges::count_if(
-      episodesOnDisc, [](const CVideoInfoTag& e) { return e.m_iSeason > 0; }));
+      episodesOnDisc, [](const KODI::VIDEO::EPISODE& e) { return e.iSeason > 0; }));
   m_numSpecials = static_cast<unsigned int>(episodesOnDisc.size()) - m_numEpisodes;
 
   // If we are looking for a special then we want to find all episodes - to exclude them
@@ -89,8 +89,8 @@ void CDiscDirectoryHelper::InitialisePlaylistSearch(
   if (m_allEpisodes == AllEpisodes::SINGLE)
   {
     CLog::LogFC(LOGDEBUG, LOGBLURAY, "Looking for season {} episode {} duration {}",
-                episodesOnDisc[episodeIndex].m_iSeason, episodesOnDisc[episodeIndex].m_iEpisode,
-                episodesOnDisc[episodeIndex].GetDuration());
+                episodesOnDisc[episodeIndex].iSeason, episodesOnDisc[episodeIndex].iEpisode,
+                episodesOnDisc[episodeIndex].duration);
   }
   else
     CLog::LogFC(LOGDEBUG, LOGBLURAY, "Looking for all episodes on disc");
@@ -99,7 +99,7 @@ void CDiscDirectoryHelper::InitialisePlaylistSearch(
   for (const auto& e : episodesOnDisc)
   {
     CLog::LogFC(LOGDEBUG, LOGBLURAY, "Expected on disc - season {} episode {} duration {}",
-                e.m_iSeason, e.m_iEpisode, e.GetDuration());
+                e.iSeason, e.iEpisode, e.duration);
   }
 }
 
@@ -491,7 +491,7 @@ bool CheckDurationsWithinTolerance(std::chrono::milliseconds episodeDuration,
 } // namespace
 
 void CDiscDirectoryHelper::UseGroupMethod(unsigned int episodeIndex,
-                                          const std::vector<CVideoInfoTag>& episodesOnDisc)
+                                          const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc)
 {
   // Method 2ai - More than one episode on disc
 
@@ -514,8 +514,7 @@ void CDiscDirectoryHelper::UseGroupMethod(unsigned int episodeIndex,
     // Now look for groups that contain same/more than numEpisodes playlists (with duplicates)
     // Check that the first numEpisodes playlists have a duration within 20% of the desired episode
     CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using group method - relaxed number of playlists");
-    const std::chrono::milliseconds episodeDuration{episodesOnDisc[episodeIndex].GetDuration() *
-                                                    1000ms};
+    const std::chrono::milliseconds episodeDuration{episodesOnDisc[episodeIndex].duration * 1000ms};
     for (const auto& group : m_groups)
     {
       if (group.size() < m_numEpisodes)
@@ -539,7 +538,7 @@ void CDiscDirectoryHelper::UseGroupMethod(unsigned int episodeIndex,
 }
 
 void CDiscDirectoryHelper::UseTotalMethod(unsigned int episodeIndex,
-                                          const std::vector<CVideoInfoTag>& episodesOnDisc,
+                                          const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc,
                                           const PlaylistMap& playlists)
 {
   // Method 2aii - More than one episode on disc
@@ -555,7 +554,7 @@ void CDiscDirectoryHelper::UseTotalMethod(unsigned int episodeIndex,
       std::views::iota(0u, m_numEpisodes),
       [&](unsigned int i)
       {
-        const std::chrono::milliseconds episodeDuration{episodesOnDisc[i].GetDuration() * 1000ms};
+        const std::chrono::milliseconds episodeDuration{episodesOnDisc[i].duration * 1000ms};
         const auto playlistDuration{std::next(playlists.begin(), i)->second.duration};
         return CheckDurationsWithinTolerance(episodeDuration, playlistDuration);
       })};
@@ -589,7 +588,7 @@ int CDiscDirectoryHelper::CalculateMultiple(std::chrono::milliseconds duration,
 }
 
 void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(
-    unsigned int episodeIndex, const std::vector<CVideoInfoTag>& episodesOnDisc)
+    unsigned int episodeIndex, const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc)
 {
   // No groups of numEpisodes length so see if there could be double episode playlists
   // Assume more than one playlist
@@ -640,7 +639,7 @@ void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(
           playlistInformation.index = index;
           m_candidatePlaylists.try_emplace(playlist.playlist, playlistInformation);
           CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {} for episode {}",
-                      playlist.playlist, episodesOnDisc[index].m_iEpisode);
+                      playlist.playlist, episodesOnDisc[index].iEpisode);
         }
         ++index;
       }
@@ -653,7 +652,7 @@ void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(
 }
 
 void CDiscDirectoryHelper::ChooseSingleBestPlaylist(
-    const std::vector<CVideoInfoTag>& episodesOnDisc)
+    const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc)
 {
   // Rebuild candidatePlaylists
   auto oldCandidatePlaylists{std::move(m_candidatePlaylists)};
@@ -668,7 +667,7 @@ void CDiscDirectoryHelper::ChooseSingleBestPlaylist(
   // Loop through each index (episode) and find the playlist with the closest duration
   for (unsigned int currentEpisodeIndex : indexes)
   {
-    std::chrono::milliseconds duration{episodesOnDisc[currentEpisodeIndex].GetDuration() * 1000};
+    std::chrono::milliseconds duration{episodesOnDisc[currentEpisodeIndex].duration * 1000};
 
     // If episode length not known, ensure the longest playlist selected
     if (duration == 0ms)
@@ -724,9 +723,10 @@ void CDiscDirectoryHelper::AddIdenticalPlaylists(const PlaylistMap& playlists)
   }
 }
 
-void CDiscDirectoryHelper::FindCandidatePlaylists(const std::vector<CVideoInfoTag>& episodesOnDisc,
-                                                  unsigned int episodeIndex,
-                                                  const PlaylistMap& playlists)
+void CDiscDirectoryHelper::FindCandidatePlaylists(
+    const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc,
+    unsigned int episodeIndex,
+    const PlaylistMap& playlists)
 {
   // At this stage we have a number of ways of trying to determine the correct playlist for an episode
   //
@@ -832,7 +832,7 @@ void CDiscDirectoryHelper::GenerateItem(const CURL& url,
                                         const std::shared_ptr<CFileItem>& item,
                                         unsigned int playlist,
                                         const PlaylistMap& playlists,
-                                        const CVideoInfoTag& tag,
+                                        const KODI::VIDEO::EPISODE& episode,
                                         IsSpecial isSpecial)
 {
   if (!playlists.contains(playlist))
@@ -858,7 +858,7 @@ void CDiscDirectoryHelper::GenerateItem(const CURL& url,
   item->SetProperty("bluray_playlist", playlist);
 
   // Get episode title
-  const std::string& title{tag.GetTitle()};
+  const std::string& title{episode.strTitle};
   if (isSpecial == IsSpecial::SPECIAL)
   {
     if (title.empty())
@@ -866,14 +866,14 @@ void CDiscDirectoryHelper::GenerateItem(const CURL& url,
     else
       /* Special xx - title */
       buf = StringUtils::Format(
-          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21348), tag.m_iEpisode,
-          tag.GetTitle());
+          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21348), episode.iEpisode,
+          episode.strTitle);
   }
   else
     /* Episode xx - title */
     buf =
         StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21349),
-                            tag.m_iEpisode, tag.GetTitle());
+                            episode.iEpisode, episode.strTitle);
   item->SetTitle(buf);
   item->SetLabel(buf);
 
@@ -894,11 +894,12 @@ void CDiscDirectoryHelper::EndPlaylistSearch() const
   CLog::LogFC(LOGDEBUG, LOGBLURAY, "*** Episode Search End ***");
 }
 
-void CDiscDirectoryHelper::PopulateFileItems(const CURL& url,
-                                             CFileItemList& items,
-                                             int episodeIndex,
-                                             const std::vector<CVideoInfoTag>& episodesOnDisc,
-                                             const PlaylistMap& playlists) const
+void CDiscDirectoryHelper::PopulateFileItems(
+    const CURL& url,
+    CFileItemList& items,
+    int episodeIndex,
+    const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc,
+    const PlaylistMap& playlists) const
 {
   // Now populate CFileItemList to return
   //
@@ -943,21 +944,22 @@ void CDiscDirectoryHelper::PopulateFileItems(const CURL& url,
     for (const auto& playlist : m_candidateSpecials)
     {
       const auto newItem{std::make_shared<CFileItem>("", false)};
-      CVideoInfoTag tag;
+      KODI::VIDEO::EPISODE episode;
       if (m_isSpecial == IsSpecial::SPECIAL && m_candidateSpecials.size() == 1)
-        tag = episodesOnDisc[episodeIndex];
-      GenerateItem(url, newItem, playlist, playlists, tag, IsSpecial::SPECIAL);
+        episode = episodesOnDisc[episodeIndex];
+      GenerateItem(url, newItem, playlist, playlists, episode, IsSpecial::SPECIAL);
       items.Add(newItem);
     }
   }
 }
 
-bool CDiscDirectoryHelper::GetEpisodePlaylists(const CURL& url,
-                                               CFileItemList& items,
-                                               int episodeIndex,
-                                               const std::vector<CVideoInfoTag>& episodesOnDisc,
-                                               const ClipMap& clips,
-                                               const PlaylistMap& playlists)
+bool CDiscDirectoryHelper::GetEpisodePlaylists(
+    const CURL& url,
+    CFileItemList& items,
+    int episodeIndex,
+    const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc,
+    const ClipMap& clips,
+    const PlaylistMap& playlists)
 {
   InitialisePlaylistSearch(episodeIndex, episodesOnDisc);
   FindPlayAllPlaylists(clips, playlists);
@@ -981,6 +983,7 @@ void CDiscDirectoryHelper::AddRootOptions(const CURL& url,
   item->SetLabel(
       CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25002) /* All titles */);
   item->SetArt("icon", "DefaultVideoPlaylists.png");
+  item->SetProperty("special", true);
   items.Add(item);
 
   if (addMenuOption == AddMenuOption::ADD_MENU)
@@ -990,6 +993,7 @@ void CDiscDirectoryHelper::AddRootOptions(const CURL& url,
     item->SetLabel(
         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25003) /* Menu */);
     item->SetArt("icon", "DefaultProgram.png");
+    item->SetProperty("special", true);
     items.Add(item);
   }
 }
@@ -1014,7 +1018,9 @@ std::vector<CVideoInfoTag> CDiscDirectoryHelper::GetEpisodesOnDisc(const CURL& u
   return episodesOnDisc;
 }
 
-bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, int playback)
+bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item,
+                                                      int playback,
+                                                      bool silent /* = false */)
 {
   const std::string originalDynPath{
       item.GetDynPath()}; // Overwritten by dialog selection. Needed for screen refresh.
@@ -1060,34 +1066,62 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, int playb
     }
   }
 
+  // Add duration to bluray:// url as needed for episode determination in CBlurayDirectory
+  std::string directoryDuration{directory};
+  if (item.HasVideoInfoTag() && item.GetVideoInfoTag()->GetDuration() > 0 &&
+      item.GetVideoContentType() == VideoDbContentType::EPISODES)
+  {
+    CURL dirUrl(directory);
+    dirUrl.SetOption("duration", std::to_string(item.GetVideoInfoTag()->GetDuration()));
+    directoryDuration = dirUrl.Get();
+  }
+
   // Get items
   CFileItemList items;
-  if (!GetItems(items, directory))
+  if (!GetItems(items, directoryDuration, silent))
   {
     // No main movie or episode playlist found
-    CGUIDialogOK::ShowAndGetInput(
-        CVariant{257},
-        CVariant{item.GetVideoContentType() == VideoDbContentType::EPISODES ? 25017 : 25016});
+    if (!silent)
+      CGUIDialogOK::ShowAndGetInput(
+          CVariant{257},
+          CVariant{item.GetVideoContentType() == VideoDbContentType::EPISODES ? 25017 : 25016});
     return false;
   }
 
   // Select item
   CFileItem selectedItem;
-  if (playback == BD_PLAYBACK_SIMPLE_MENU)
+  if (!silent)
   {
-    // Use simple menu dialog to select playlist
-    while (true)
+    if (playback == BD_PLAYBACK_SIMPLE_MENU)
     {
-      if (!CGUIDialogSimpleMenu::ShowPlaylistSelection(item, selectedItem, items, usedPlaylists))
-        return false;
+      // Use simple menu dialog to select playlist
+      while (true)
+      {
+        if (!CGUIDialogSimpleMenu::ShowPlaylistSelection(item, selectedItem, items, usedPlaylists))
+          return false;
 
-      // If a non-folder item is selected, we're done
-      if (!selectedItem.IsFolder())
-        break;
+        // If a non-folder item is selected, we're done
+        if (!selectedItem.IsFolder())
+          break;
 
-      // Folder selected - retrieve all titles within it
-      if (!GetItems(items, selectedItem.GetDynPath()))
-        return false;
+        // Folder selected - retrieve all titles within it
+        if (!GetItems(items, selectedItem.GetDynPath(), silent))
+          return false;
+      }
+    }
+  }
+  else
+  {
+    // Silent - used during scraping
+    // Items may 2-3 items (the latter two being 'All Titles' and 'Menu' - if menus supported) then select the first item (main title/episode)
+    // Otherwise return false as we don't know which item to select and don't want to guess (as could be multiple movie versions on the disc etc..)
+    const auto playlists{
+        std::ranges::count_if(items, [](const std::shared_ptr<CFileItem>& item)
+                              { return !item->GetProperty("special").asBoolean(false); })};
+    if (playlists > 1)
+    {
+      CLog::LogF(LOGERROR, "Unable to automatically determine main playlist for {}", directory);
+      return false;
     }
   }
 
@@ -1101,10 +1135,10 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, int playb
   return true;
 }
 
-bool CDiscDirectoryHelper::GetItems(CFileItemList& items, const std::string& directory)
+bool CDiscDirectoryHelper::GetItems(CFileItemList& items, const std::string& directory, bool silent)
 {
   items.Clear();
-  if (!GetDirectoryItems(directory, items, CDirectory::CHints()))
+  if (!GetDirectoryItems(directory, items, CDirectory::CHints(), silent))
   {
     CLog::LogF(LOGERROR, "Failed to get play directory for {}", directory);
     return false;
@@ -1121,8 +1155,15 @@ bool CDiscDirectoryHelper::GetItems(CFileItemList& items, const std::string& dir
 
 bool CDiscDirectoryHelper::GetDirectoryItems(const std::string& path,
                                              CFileItemList& items,
-                                             const CDirectory::CHints& hints)
+                                             const CDirectory::CHints& hints,
+                                             bool silent)
 {
+  if (silent)
+  {
+    // Non-interactive path so skip the busy dialog
+    return CDirectory::GetDirectory(path, items, hints);
+  }
+
   CGetDirectoryItems getItems(path, items, hints);
   if (!CGUIDialogBusy::Wait(&getItems, 100, true))
   {

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "Directory.h"
+#include "settings/DiscSettings.h"
 #include "video/VideoInfoTag.h"
 
 #include <chrono>
@@ -29,7 +31,7 @@ using namespace std::chrono_literals;
 
 enum class GetTitle : int
 {
-  GET_TITLES_ONE = -1,
+  GET_TITLES_SINGLE = -1,
   GET_TITLES_MAIN = -2,
   GET_TITLES_EPISODES = -3,
   GET_TITLES_ALL = -4
@@ -189,6 +191,19 @@ public:
    */
   static void AddRootOptions(const CURL& url, CFileItemList& items, AddMenuOption addMenuOption);
 
+  /*!
+   * \brief Either shows simple menu to select playlist, chooses main feature (movie/episode) playlists or returns if disc menu will be used later.
+   * \param item FileItem containing details of desired movie/episode. This is updated with the selected playlist.
+   * \param playback Setting SETTING_DISC_PLAYBACK - determines if the dialog should be shown or the main title selected (if possible).
+   * \return true if a playlist was selected or if the disc menu will be used later, false if the user cancelled.
+   */
+  static bool GetOrShowPlaylistSelection(CFileItem& item, int playback = BD_PLAYBACK_SIMPLE_MENU);
+
+protected:
+  static bool GetDirectoryItems(const std::string& path,
+                                CFileItemList& items,
+                                const CDirectory::CHints& hints);
+
 private:
   void InitialisePlaylistSearch(int episodeIndex, const std::vector<CVideoInfoTag>& episodesOnDisc);
   bool IsPotentialPlayAllPlaylist(const PlaylistInformation& playlistInformation) const;
@@ -262,5 +277,7 @@ private:
   std::vector<std::vector<CandidatePlaylistInformation>> m_allGroups;
   std::map<unsigned int, CandidatePlaylistInformation> m_candidatePlaylists;
   std::set<unsigned int> m_candidateSpecials;
+
+  static bool GetItems(CFileItemList& items, const std::string& directory);
 };
 } // namespace XFILE

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "Directory.h"
-#include "settings/DiscSettings.h"
 #include "video/Episode.h"
 #include "video/VideoInfoTag.h"
 
@@ -49,6 +48,15 @@ enum class AddMenuOption : bool
 {
   NO_MENU,
   ADD_MENU
+};
+
+enum class MenuDecision : uint8_t
+{
+  NO_ACTION,
+  SILENT,
+  SHOW_SIMPLE_MENU,
+  SHOW_DISC_MENU,
+  GET_MAIN_TITLE
 };
 
 enum class ENCODING_TYPE : uint8_t
@@ -197,13 +205,10 @@ public:
   /*!
    * \brief Either shows simple menu to select playlist, chooses main feature (movie/episode) playlists or returns if disc menu will be used later.
    * \param item FileItem containing details of desired movie/episode. This is updated with the selected playlist.
-   * \param playback Setting SETTING_DISC_PLAYBACK - determines if the dialog should be shown or the main title selected (if possible).
-   * \param silent If true, the dialog will not be shown and the method will return false if a playlist cannot be automatically selected.
+   * \param playback Determines if the simple dialog should be shown or the main title selected (if possible).
    * \return true if a playlist was selected or if the disc menu will be used later, false if the user cancelled.
    */
-  static bool GetOrShowPlaylistSelection(CFileItem& item,
-                                         int playback = BD_PLAYBACK_SIMPLE_MENU,
-                                         bool silent = false);
+  static bool GetOrShowPlaylistSelection(CFileItem& item, MenuDecision playback);
 
 protected:
   static bool GetDirectoryItems(const std::string& path,

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -164,6 +164,7 @@ public:
    * \brief Populates a CFileItemList with the playlist(s) corresponding to the given episode.
    * \param url bluray:// episode url
    * \param items CFileItemList to populate
+   * \param allTitles CFileItemList of all titles on the disc (populated by CBlurayDirectory). Used for streamdetails.
    * \param episodeIndex index into episodesOnDisc
    * \param episodesOnDisc vector array of CVideoInfoTags - one for each episode on the disc (populated by GetEpisodesOnDisc)
    * \param clips map of clips on disc (populated in CBlurayDirectory)
@@ -172,6 +173,7 @@ public:
    */
   bool GetEpisodePlaylists(const CURL& url,
                            CFileItemList& items,
+                           const CFileItemList& allTitles,
                            int episodeIndex,
                            const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc,
                            const ClipMap& clips,
@@ -269,6 +271,7 @@ private:
   void EndPlaylistSearch() const;
   void PopulateFileItems(const CURL& url,
                          CFileItemList& items,
+                         const CFileItemList& allTitles,
                          int episodeIndex,
                          const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc,
                          const PlaylistMap& playlists) const;

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -10,6 +10,7 @@
 
 #include "Directory.h"
 #include "settings/DiscSettings.h"
+#include "video/Episode.h"
 #include "video/VideoInfoTag.h"
 
 #include <chrono>
@@ -172,7 +173,7 @@ public:
   bool GetEpisodePlaylists(const CURL& url,
                            CFileItemList& items,
                            int episodeIndex,
-                           const std::vector<CVideoInfoTag>& episodesOnDisc,
+                           const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc,
                            const ClipMap& clips,
                            const PlaylistMap& playlists);
 
@@ -195,17 +196,22 @@ public:
    * \brief Either shows simple menu to select playlist, chooses main feature (movie/episode) playlists or returns if disc menu will be used later.
    * \param item FileItem containing details of desired movie/episode. This is updated with the selected playlist.
    * \param playback Setting SETTING_DISC_PLAYBACK - determines if the dialog should be shown or the main title selected (if possible).
+   * \param silent If true, the dialog will not be shown and the method will return false if a playlist cannot be automatically selected.
    * \return true if a playlist was selected or if the disc menu will be used later, false if the user cancelled.
    */
-  static bool GetOrShowPlaylistSelection(CFileItem& item, int playback = BD_PLAYBACK_SIMPLE_MENU);
+  static bool GetOrShowPlaylistSelection(CFileItem& item,
+                                         int playback = BD_PLAYBACK_SIMPLE_MENU,
+                                         bool silent = false);
 
 protected:
   static bool GetDirectoryItems(const std::string& path,
                                 CFileItemList& items,
-                                const CDirectory::CHints& hints);
+                                const CDirectory::CHints& hints,
+                                bool silent = false);
 
 private:
-  void InitialisePlaylistSearch(int episodeIndex, const std::vector<CVideoInfoTag>& episodesOnDisc);
+  void InitialisePlaylistSearch(int episodeIndex,
+                                const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc);
   bool IsPotentialPlayAllPlaylist(const PlaylistInformation& playlistInformation) const;
   static bool ClipQualifies(const ClipInfo& clipInformation,
                             unsigned int clip,
@@ -238,18 +244,19 @@ private:
       const std::vector<std::vector<CandidatePlaylistInformation>>& groups);
   void GetPlaylistsFromGroup(unsigned int episodeIndex,
                              const std::vector<CandidatePlaylistInformation>& group);
-  void UseGroupMethod(unsigned int episodeIndex, const std::vector<CVideoInfoTag>& episodesOnDisc);
+  void UseGroupMethod(unsigned int episodeIndex,
+                      const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc);
   void UseTotalMethod(unsigned int episodeIndex,
-                      const std::vector<CVideoInfoTag>& episodesOnDisc,
+                      const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc,
                       const PlaylistMap& playlists);
   static int CalculateMultiple(std::chrono::milliseconds duration,
                                std::chrono::milliseconds averageShortest,
                                double multiplePercent);
   void UseGroupsWithMultiplesMethod(unsigned int episodeIndex,
-                                    const std::vector<CVideoInfoTag>& episodesOnDisc);
-  void ChooseSingleBestPlaylist(const std::vector<CVideoInfoTag>& episodesOnDisc);
+                                    const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc);
+  void ChooseSingleBestPlaylist(const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc);
   void AddIdenticalPlaylists(const PlaylistMap& playlists);
-  void FindCandidatePlaylists(const std::vector<CVideoInfoTag>& episodesOnDisc,
+  void FindCandidatePlaylists(const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc,
                               unsigned int episodeIndex,
                               const PlaylistMap& playlists);
   void FindSpecials(const PlaylistMap& playlists);
@@ -257,13 +264,13 @@ private:
                            const std::shared_ptr<CFileItem>& item,
                            unsigned int playlist,
                            const PlaylistMap& playlists,
-                           const CVideoInfoTag& tag,
+                           const KODI::VIDEO::EPISODE& episode,
                            IsSpecial isSpecial);
   void EndPlaylistSearch() const;
   void PopulateFileItems(const CURL& url,
                          CFileItemList& items,
                          int episodeIndex,
-                         const std::vector<CVideoInfoTag>& episodesOnDisc,
+                         const std::vector<KODI::VIDEO::EPISODE>& episodesOnDisc,
                          const PlaylistMap& playlists) const;
 
   AllEpisodes m_allEpisodes{AllEpisodes::SINGLE};
@@ -278,6 +285,6 @@ private:
   std::map<unsigned int, CandidatePlaylistInformation> m_candidatePlaylists;
   std::set<unsigned int> m_candidateSpecials;
 
-  static bool GetItems(CFileItemList& items, const std::string& directory);
+  static bool GetItems(CFileItemList& items, const std::string& directory, bool silent = false);
 };
 } // namespace XFILE

--- a/xbmc/settings/DiscSettings.h
+++ b/xbmc/settings/DiscSettings.h
@@ -15,7 +15,8 @@
 */
 enum BDPlaybackMode
 {
-  BD_PLAYBACK_SIMPLE_MENU = 0,
+  BD_PLAYBACK_AUTO = 0, // Only use simple menu if playlist not known
+  BD_PLAYBACK_SIMPLE_MENU,
   BD_PLAYBACK_DISC_MENU,
   BD_PLAYBACK_MAIN_TITLE,
 };

--- a/xbmc/test/CMakeLists.txt
+++ b/xbmc/test/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES TestAutoSwitch.cpp
             TestCueDocument.cpp
             TestDateTime.cpp
             TestDateTimeSpan.cpp
+            TestEpisodeUtils.cpp
             TestFileItem.cpp
             TestLangInfo.cpp
             TestMediaSource.cpp

--- a/xbmc/test/TestEpisodeUtils.cpp
+++ b/xbmc/test/TestEpisodeUtils.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -10,20 +10,20 @@
 #include "ServiceBroker.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
-#include "video/VideoInfoScanner.h"
+#include "utils/EpisodeUtils.h"
 
+#include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
 
-using namespace KODI;
 using ::testing::Test;
-using ::testing::WithParamInterface;
 using ::testing::ValuesIn;
+using ::testing::WithParamInterface;
 
 struct TestEntry
 {
   const char* path;
-  std::vector<VIDEO::EPISODE> ranges;
-  std::vector<VIDEO::EPISODE> noranges;
+  std::vector<KODI::VIDEO::EPISODE> ranges;
+  std::vector<KODI::VIDEO::EPISODE> noranges;
 };
 
 static const TestEntry TestData[] = {
@@ -103,39 +103,38 @@ static const TestEntry TestData[] = {
     {"foo.S02E03-extended.mkv", {{2, 3}}, {{2, 3}}}, // comment (starting with e)
 };
 
-class TestVideoInfoScanner : public Test,
-                             public WithParamInterface<TestEntry>
+class TestEnumerateEpisodes : public Test, public WithParamInterface<TestEntry>
 {
 };
 
-TEST_P(TestVideoInfoScanner, EnumerateEpisodeItem)
+TEST_P(TestEnumerateEpisodes, EnumerateEpisodeItem)
 {
   const std::shared_ptr<CAdvancedSettings> advancedSettings =
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
   const TestEntry& entry = GetParam();
 
   CFileItem item(entry.path, false);
-  VIDEO::CVideoInfoScanner scanner;
-  VIDEO::EPISODELIST result;
+  KODI::VIDEO::EPISODELIST result;
 
+  const bool saveState{advancedSettings->m_disableEpisodeRanges};
   advancedSettings->m_disableEpisodeRanges = false;
-  ASSERT_TRUE(scanner.EnumerateEpisodeItem(&item, result));
+  ASSERT_TRUE(CEpisodeUtils::EnumerateEpisodeItem(&item, result));
   EXPECT_EQ(entry.ranges, result);
 
   advancedSettings->m_disableEpisodeRanges = true;
   result.clear();
-  ASSERT_TRUE(scanner.EnumerateEpisodeItem(&item, result));
+  ASSERT_TRUE(CEpisodeUtils::EnumerateEpisodeItem(&item, result));
   EXPECT_EQ(entry.noranges, result);
+  advancedSettings->m_disableEpisodeRanges = saveState;
 }
 
-INSTANTIATE_TEST_SUITE_P(VideoInfoScanner, TestVideoInfoScanner, ValuesIn(TestData));
+INSTANTIATE_TEST_SUITE_P(EnumerateEpisodeItem, TestEnumerateEpisodes, ValuesIn(TestData));
 
-TEST(TestVideoInfoScanner, EnumerateEpisodeItemByTitle)
+TEST(TestEnumerateEpisodes, EnumerateEpisodeItemByTitle)
 {
-  VIDEO::CVideoInfoScanner scanner;
   CFileItem item("/foo.special.mp4", false);
-  VIDEO::EPISODELIST result;
-  ASSERT_TRUE(scanner.EnumerateEpisodeItem(&item, result));
+  KODI::VIDEO::EPISODELIST result;
+  ASSERT_TRUE(CEpisodeUtils::EnumerateEpisodeItem(&item, result));
   ASSERT_EQ(result.size(), 1);
   ASSERT_EQ(result[0].strTitle, "foo");
 }

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -21,6 +21,7 @@ set(SOURCES ActorProtocol.cpp
             DiscsUtils.cpp
             EndianSwap.cpp
             EmbeddedArt.cpp
+            EpisodeUtils.cpp
             ExecString.cpp
             FileExtensionProvider.cpp
             Fanart.cpp
@@ -103,6 +104,7 @@ set(HEADERS ActorProtocol.h
             Digest.h
             DiscsUtils.h
             EndianSwap.h
+            EpisodeUtils.h
             EventStream.h
             EventStreamDetail.h
             ExecString.h

--- a/xbmc/utils/EpisodeUtils.cpp
+++ b/xbmc/utils/EpisodeUtils.cpp
@@ -1,0 +1,362 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "EpisodeUtils.h"
+
+#include "FileItem.h"
+#include "ServiceBroker.h"
+#include "URL.h"
+#include "Util.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+
+#include <cctype>
+#include <string>
+#include <vector>
+
+using namespace KODI;
+
+namespace
+{
+bool GetEpisodeAndSeasonFromRegExp(CRegExp& reg, VIDEO::EPISODE& episodeInfo, int defaultSeason)
+{
+  std::string season(reg.GetMatch(1));
+  std::string episode(reg.GetMatch(2));
+
+  if (!season.empty() || !episode.empty())
+  {
+    char* endptr = NULL;
+    if (season.empty() && !episode.empty())
+    { // no season specified -> assume defaultSeason
+      episodeInfo.iSeason = defaultSeason;
+      if ((episodeInfo.iEpisode = CUtil::TranslateRomanNumeral(episode.c_str())) == -1)
+        episodeInfo.iEpisode = strtol(episode.c_str(), &endptr, 10);
+    }
+    else if (!season.empty() && episode.empty())
+    { // no episode specification -> assume defaultSeason
+      episodeInfo.iSeason = defaultSeason;
+      if ((episodeInfo.iEpisode = CUtil::TranslateRomanNumeral(season.c_str())) == -1)
+        episodeInfo.iEpisode = atoi(season.c_str());
+    }
+    else
+    { // season and episode specified
+      episodeInfo.iSeason = atoi(season.c_str());
+      episodeInfo.iEpisode = strtol(episode.c_str(), &endptr, 10);
+    }
+    if (endptr)
+    {
+      if (isalpha(*endptr))
+        episodeInfo.iSubepisode = *endptr - (islower(*endptr) ? 'a' : 'A') + 1;
+      else if (*endptr == '.')
+        episodeInfo.iSubepisode = atoi(endptr + 1);
+    }
+    return true;
+  }
+  return false;
+}
+
+bool GetAirDateFromRegExp(CRegExp& reg, VIDEO::EPISODE& episodeInfo)
+{
+  std::string param1(reg.GetMatch(1));
+  std::string param2(reg.GetMatch(2));
+  std::string param3(reg.GetMatch(3));
+
+  if (!param1.empty() && !param2.empty() && !param3.empty())
+  {
+    // regular expression by date
+    int len1 = param1.size();
+    int len2 = param2.size();
+    int len3 = param3.size();
+
+    if (len1 == 4 && len2 == 2 && len3 == 2)
+    {
+      // yyyy mm dd format
+      episodeInfo.cDate.SetDate(atoi(param1.c_str()), atoi(param2.c_str()), atoi(param3.c_str()));
+    }
+    else if (len1 == 2 && len2 == 2 && len3 == 4)
+    {
+      // mm dd yyyy format
+      episodeInfo.cDate.SetDate(atoi(param3.c_str()), atoi(param1.c_str()), atoi(param2.c_str()));
+    }
+  }
+  return episodeInfo.cDate.IsValid();
+}
+
+bool GetEpisodeTitleFromRegExp(CRegExp& reg, VIDEO::EPISODE& episodeInfo)
+{
+  std::string param1(reg.GetMatch(1));
+
+  if (!param1.empty())
+  {
+    episodeInfo.strTitle = param1;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * \brief Maximum allowed number of episodes in a single episode range.
+ *
+ * The value 50 was chosen as a safety limit to prevent accidental processing of
+ * extremely large episode ranges, which could be caused by malformed filenames or
+ * incorrect regular expression matches. Note this is a per-file number and not the
+ * total number of episodes in a season.
+ */
+constexpr int MAX_EPISODE_RANGE = 50;
+
+// Character following season/episode range must be one of these for range to be valid.
+constexpr std::string_view allowed{"-_.esx "};
+
+/*! \brief Perform checks, then add episodes in a given range to the episode list
+ \param first first episode in the range to add.
+ \param last last episode in the range.
+ \param episode the first episode in the range (already added to the list).
+ \param episodeList the list (vector) of episodes to add to.
+ \param regex the regex used to match the episode range.
+ \param remainder the remainder of the filename after the episode range.
+*/
+void ProcessEpisodeRange(int first,
+                         int last,
+                         VIDEO::EPISODE& episode,
+                         VIDEO::EPISODELIST& episodeList,
+                         const std::string& regex,
+                         const std::string& remainder)
+{
+  if (first > last && !episodeList.empty())
+  {
+    // SxxEaa-SxxEbb or Eaa-Ebb is backwards - bb<aa
+    CLog::LogF(LOGDEBUG,
+               "VideoInfoScanner: Removing season {}, episode {} as range {}-{} is backwards",
+               episode.iSeason, episode.iEpisode, episodeList.back().iEpisode, last);
+    episodeList.pop_back();
+    return;
+  }
+  if ((last - first + 1) > MAX_EPISODE_RANGE && !episodeList.empty())
+  {
+    CLog::LogF(LOGDEBUG,
+               "VideoInfoScanner: Removing season {}, episode {} as range is too large {} (maximum "
+               "allowed {})",
+               episode.iSeason, episode.iEpisode, last - first + 1, MAX_EPISODE_RANGE);
+    episodeList.pop_back();
+    return;
+  }
+  if (!remainder.empty() && allowed.find(static_cast<char>(std::tolower(static_cast<unsigned char>(
+                                remainder.front())))) == std::string_view::npos)
+  {
+    CLog::LogF(LOGDEBUG,
+               "VideoInfoScanner:Last episode in range {} is not part of an episode string ({}) "
+               "- ignoring",
+               last, remainder);
+    return;
+  }
+  for (int e = first; e <= last; ++e)
+  {
+    episode.iEpisode = e;
+    CLog::LogF(LOGDEBUG, "VideoInfoScanner: Adding multipart episode {} [{}]", episode.iEpisode,
+               regex);
+    episodeList.push_back(episode);
+  }
+}
+} // namespace
+
+bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELIST& episodeList)
+{
+  const auto advancedSettings{CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()};
+  const auto& tvShowRegExps{advancedSettings->m_tvshowEnumRegExps};
+
+  // Remove path to main file if it's a bd or dvd folder to regex the right (folder) name
+  std::string label;
+  if (item->IsOpticalMediaFile())
+  {
+    label = item->GetLocalMetadataPath();
+    URIUtils::RemoveSlashAtEnd(label);
+  }
+  else
+    label = item->GetPath();
+
+  // URLDecode in case an episode is on a http/https/dav/davs:// source and URL-encoded like foo%201x01%20bar.avi
+  label = CURL::Decode(CURL::GetRedacted(label));
+
+  // Pre-compile multi-part regex
+  CRegExp reg2(true, CRegExp::autoUtf8);
+  const bool multiPartRegexValid{reg2.RegComp(advancedSettings->m_tvshowMultiPartEnumRegExp)};
+  if (!multiPartRegexValid)
+    CLog::LogF(LOGWARNING, "Invalid multipart RegExp '{}', multipart episode detection disabled",
+               advancedSettings->m_tvshowMultiPartEnumRegExp);
+  const bool disableEpisodeRanges{advancedSettings->m_disableEpisodeRanges};
+
+  for (const auto& tvShowRegExp : tvShowRegExps)
+  {
+    CRegExp reg(true, CRegExp::autoUtf8);
+    if (!reg.RegComp(tvShowRegExp.regexp))
+      continue; // Failed to compile
+
+    int regPosition;
+    if ((regPosition = reg.RegFind(label.c_str())) < 0)
+      continue;
+
+    VIDEO::EPISODE episode;
+    episode.strPath = item->GetPath();
+    episode.iSeason = -1;
+    episode.iEpisode = -1;
+    episode.cDate.SetValid(false);
+    episode.isFolder = false;
+
+    const bool byDate{tvShowRegExp.byDate};
+    const bool byTitle{tvShowRegExp.byTitle};
+    const int defaultSeason{tvShowRegExp.defaultSeason};
+
+    if (byDate)
+    {
+      if (!GetAirDateFromRegExp(reg, episode))
+        continue;
+
+      CLog::LogF(LOGDEBUG, "Found date based match {} ({}) [{}]",
+                 CURL::GetRedacted(episode.strPath), episode.cDate.GetAsLocalizedDate(),
+                 tvShowRegExp.regexp);
+    }
+    else if (byTitle)
+    {
+      if (!GetEpisodeTitleFromRegExp(reg, episode))
+        continue;
+
+      CLog::LogF(LOGDEBUG, "Found title based match {} ({}) [{}]",
+                 CURL::GetRedacted(episode.strPath), episode.strTitle, tvShowRegExp.regexp);
+    }
+    else
+    {
+      if (!GetEpisodeAndSeasonFromRegExp(reg, episode, defaultSeason))
+        continue;
+
+      CLog::LogF(LOGDEBUG, "Found episode match {} (s{}e{}) [{}]",
+                 CURL::GetRedacted(episode.strPath), episode.iSeason, episode.iEpisode,
+                 tvShowRegExp.regexp);
+    }
+
+    // Grab the remainder from first regexp run
+    // as second run might modify or empty it.
+    std::string remainder(reg.GetMatch(3));
+
+    // Check if the files base path is a dedicated folder that contains
+    // only this single episode. If season and episode match with the
+    // actual media file, we set episode.isFolder to true.
+    std::string basePath{item->GetBaseMoviePath(true)};
+    URIUtils::RemoveSlashAtEnd(basePath);
+    basePath = URIUtils::GetFileName(basePath);
+
+    if (reg.RegFind(basePath.c_str()) > -1)
+    {
+      VIDEO::EPISODE parent;
+      if (byDate)
+      {
+        GetAirDateFromRegExp(reg, parent);
+        if (episode.cDate == parent.cDate)
+          episode.isFolder = true;
+      }
+      else
+      {
+        GetEpisodeAndSeasonFromRegExp(reg, parent, defaultSeason);
+        if (episode.iSeason == parent.iSeason && episode.iEpisode == parent.iEpisode)
+          episode.isFolder = true;
+      }
+    }
+
+    // add what we found by now
+    episodeList.push_back(episode);
+
+    // check the remainder of the string for any further episodes.
+    // Multi-part only applies to season/episode matches, not date or title based
+    if (!byDate && !byTitle && multiPartRegexValid)
+    {
+      size_t offset{0};
+      int reg2Position;
+      int currentSeason{episode.iSeason};
+      int currentEpisode{episode.iEpisode};
+
+      // we want "long circuit" OR below so that both offsets are evaluated
+      while (static_cast<int>((reg2Position = reg2.RegFind(remainder.c_str() + offset)) > -1) |
+             static_cast<int>((regPosition = reg.RegFind(remainder.c_str() + offset)) > -1))
+      {
+        if ((regPosition <= reg2Position && regPosition != -1) || // season (or 'ep') match
+            (regPosition >= 0 && reg2Position == -1))
+        {
+          GetEpisodeAndSeasonFromRegExp(reg, episode, defaultSeason);
+          if (currentSeason == episode.iSeason)
+          {
+            // Already added SxxEyy now loop (if needed) to SxxEzz
+            const int last{episode.iEpisode};
+            const int next{
+                disableEpisodeRanges || !remainder.starts_with("-") ? last : currentEpisode + 1};
+
+            ProcessEpisodeRange(next, last, episode, episodeList,
+                                advancedSettings->m_tvshowMultiPartEnumRegExp, remainder);
+
+            currentEpisode = episode.iEpisode;
+            remainder = reg.GetMatch(3);
+          }
+          else
+          {
+            // Two possible scenarios here:
+            if (remainder.substr(offset, 1) != "-" || disableEpisodeRanges)
+            {
+              // (Sxx)Eyy has already been added and we now in a new range (eg. S00E01S01E01....)
+              // Add first episode here
+              currentSeason = episode.iSeason;
+              currentEpisode = episode.iEpisode;
+              episodeList.push_back(episode);
+              remainder = reg.GetMatch(3);
+            }
+            else
+            {
+              // (Sxx)Eyy has already been added as start of range and we now have SaaEbb (eg. S01E01-S02E05)
+              //   this is not allowed as scanner cannot determine how many episodes in a season
+              if (offset == 0)
+              {
+                // Already added first episode of invalid range so remove it
+                episodeList.pop_back();
+                remainder = reg.GetMatch(3);
+                CLog::LogF(
+                    LOGDEBUG,
+                    "VideoInfoScanner: Removing season {}, episode {} as part of invalid range",
+                    episode.iSeason, episode.iEpisode);
+              }
+              else
+              {
+                remainder = remainder.substr(offset);
+              }
+            }
+          }
+          offset = 0;
+        }
+        else if ((reg2Position < regPosition && reg2Position != -1) || // episode match
+                 (reg2Position >= 0 && regPosition == -1))
+        {
+          const std::string result{reg2.GetMatch(2)};
+          const int last{std::stoi(result)};
+          const std::string prefix{
+              offset < remainder.length()
+                  ? StringUtils::ToLower(std::string_view(remainder).substr(offset, 2))
+                  : std::string{}};
+          const int next{(prefix == "-e" || prefix == "-s") && !disableEpisodeRanges
+                             ? currentEpisode + 1
+                             : last};
+
+          ProcessEpisodeRange(next, last, episode, episodeList,
+                              advancedSettings->m_tvshowMultiPartEnumRegExp, reg2.GetMatch(3));
+
+          currentEpisode = episode.iEpisode;
+          offset += reg2Position + reg2.GetMatch(1).length() + result.length();
+        }
+      }
+    }
+    return true;
+  }
+  return false;
+}

--- a/xbmc/utils/EpisodeUtils.h
+++ b/xbmc/utils/EpisodeUtils.h
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "video/Episode.h"
+
+class CFileItem;
+
+class CEpisodeUtils
+{
+public:
+  static bool EnumerateEpisodeItem(const CFileItem* item, KODI::VIDEO::EPISODELIST& episodeList);
+};

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -701,6 +701,11 @@ std::string URIUtils::GetBlurayTitlesPath(const std::string& path)
   return AddFileToFolder(GetBlurayPath(path), "root", "titles");
 }
 
+std::string URIUtils::GetBlurayMainTitlePath(const std::string& path)
+{
+  return AddFileToFolder(GetBlurayPath(path), "root", "main");
+}
+
 std::string URIUtils::GetBlurayEpisodePath(const std::string& path, int season, int episode)
 {
   return AddFileToFolder(GetBlurayPath(path), "root", "episode", std::to_string(season),

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -691,6 +691,11 @@ std::string URIUtils::GetDiscUnderlyingFile(const CURL& url)
   return AddFileToFolder(host, filename);
 }
 
+std::string URIUtils::GetBlurayMenuPath(const std::string& path)
+{
+  return AddFileToFolder(GetBlurayPath(path), "menu");
+}
+
 std::string URIUtils::GetBlurayRootPath(const std::string& path)
 {
   return AddFileToFolder(GetBlurayPath(path), "root");

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -129,6 +129,12 @@ public:
    */
   static std::string GetDiscUnderlyingFile(const CURL& url);
 
+  /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path to menu.
+   \param path the ISO/index.BDMV path.
+   \return the bluray:// menu path.
+   */
+  static std::string GetBlurayMenuPath(const std::string& path);
+
   /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path to root.
    \param path the ISO/index.BDMV path.
    \return the bluray:// root path.

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -141,6 +141,12 @@ public:
    */
   static std::string GetBlurayTitlesPath(const std::string& path);
 
+  /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path to main title.
+   \param path the ISO/index.BDMV path.
+   \return the bluray:// root/main path.
+   */
+  static std::string GetBlurayMainTitlePath(const std::string& path);
+
   /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path to a given episode.
    \param path the ISO/index.BDMV path.
    \return the bluray:// root/episode/<season number>/<episode number> path.

--- a/xbmc/video/Episode.h
+++ b/xbmc/video/Episode.h
@@ -20,32 +20,30 @@ class CFileItem;
 // single episode information
 namespace KODI::VIDEO
 {
-  struct EPISODE
+struct EPISODE
+{
+  bool isFolder;
+  int iSeason;
+  int iEpisode;
+  int iSubepisode;
+  unsigned int duration{0};
+  std::string strPath;
+  std::string strTitle;
+  CDateTime cDate;
+  CScraperUrl cScraperUrl;
+  std::shared_ptr<CFileItem> item;
+  EPISODE(int Season = -1, int Episode = -1, int Subepisode = 0, bool Folder = false)
   {
-    bool        isFolder;
-    int         iSeason;
-    int         iEpisode;
-    int         iSubepisode;
-    std::string strPath;
-    std::string strTitle;
-    CDateTime   cDate;
-    CScraperUrl cScraperUrl;
-    std::shared_ptr<CFileItem> item;
-    EPISODE(int Season = -1, int Episode = -1, int Subepisode = 0, bool Folder = false)
-    {
-      iSeason     = Season;
-      iEpisode    = Episode;
-      iSubepisode = Subepisode;
-      isFolder    = Folder;
-    }
-    bool operator==(const struct EPISODE& rhs) const
-    {
-      return (iSeason     == rhs.iSeason  &&
-              iEpisode    == rhs.iEpisode &&
-              iSubepisode == rhs.iSubepisode);
-    }
-  };
+    iSeason = Season;
+    iEpisode = Episode;
+    iSubepisode = Subepisode;
+    isFolder = Folder;
+  }
+  bool operator==(const struct EPISODE& rhs) const
+  {
+    return (iSeason == rhs.iSeason && iEpisode == rhs.iEpisode && iSubepisode == rhs.iSubepisode);
+  }
+};
 
   typedef std::vector<EPISODE> EPISODELIST;
-}
-
+  } // namespace KODI::VIDEO

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1571,7 +1571,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     // Also populates streamdetails
     if (::UTILS::DISCS::IsBlurayDiscImage(path) || URIUtils::IsBDFile(path))
     {
-      if (CDiscDirectoryHelper::GetOrShowPlaylistSelection(*pItem, BD_PLAYBACK_SIMPLE_MENU, true))
+      if (CDiscDirectoryHelper::GetOrShowPlaylistSelection(*pItem, MenuDecision::SILENT))
         pItem->GetVideoInfoTag()->SetFileNameAndPath(pItem->GetDynPath());
     }
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -24,6 +24,7 @@
 #include "events/EventLog.h"
 #include "events/MediaLibraryEvent.h"
 #include "filesystem/Directory.h"
+#include "filesystem/DiscDirectoryHelper.h"
 #include "filesystem/File.h"
 #include "filesystem/MultiPathDirectory.h"
 #include "filesystem/PluginDirectory.h"
@@ -43,6 +44,8 @@
 #include "tags/VideoInfoTagLoaderFactory.h"
 #include "utils/ArtUtils.h"
 #include "utils/Digest.h"
+#include "utils/DiscsUtils.h"
+#include "utils/EpisodeUtils.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
@@ -75,71 +78,6 @@ using KODI::UTILITY::CDigest;
 
 namespace
 {
-
-/**
- * \brief Maximum allowed number of episodes in a single episode range.
- *
- * The value 50 was chosen as a safety limit to prevent accidental processing of
- * extremely large episode ranges, which could be caused by malformed filenames or
- * incorrect regular expression matches. Note this is a per-file number and not the
- * total number of episodes in a season.
- */
-constexpr int MAX_EPISODE_RANGE = 50;
-
-// Character following season/episode range must be one of these for range to be valid.
-constexpr std::string_view allowed{"-_.esx "};
-
-/*! \brief Perform checks, then add episodes in a given range to the episode list
- \param first first episode in the range to add.
- \param last last episode in the range.
- \param episode the first episode in the range (already added to the list).
- \param episodeList the list (vector) of episodes to add to.
- \param regex the regex used to match the episode range.
- \param remainder the remainder of the filename after the episode range.
-*/
-void ProcessEpisodeRange(int first,
-                         int last,
-                         VIDEO::EPISODE& episode,
-                         VIDEO::EPISODELIST& episodeList,
-                         const std::string& regex,
-                         const std::string& remainder)
-{
-  if (first > last && !episodeList.empty())
-  {
-    // SxxEaa-SxxEbb or Eaa-Ebb is backwards - bb<aa
-    CLog::LogF(LOGDEBUG,
-               "VideoInfoScanner: Removing season {}, episode {} as range {}-{} is backwards",
-               episode.iSeason, episode.iEpisode, episodeList.back().iEpisode, last);
-    episodeList.pop_back();
-    return;
-  }
-  if ((last - first + 1) > MAX_EPISODE_RANGE && !episodeList.empty())
-  {
-    CLog::LogF(LOGDEBUG,
-               "VideoInfoScanner: Removing season {}, episode {} as range is too large {} (maximum "
-               "allowed {})",
-               episode.iSeason, episode.iEpisode, last - first + 1, MAX_EPISODE_RANGE);
-    episodeList.pop_back();
-    return;
-  }
-  if (!remainder.empty() && allowed.find(static_cast<char>(std::tolower(static_cast<unsigned char>(
-                                remainder.front())))) == std::string_view::npos)
-  {
-    CLog::LogF(LOGDEBUG,
-               "VideoInfoScanner:Last episode in range {} is not part of an episode string ({}) "
-               "- ignoring",
-               last, remainder);
-    return;
-  }
-  for (int e = first; e <= last; ++e)
-  {
-    episode.iEpisode = e;
-    CLog::LogF(LOGDEBUG, "VideoInfoScanner: Adding multipart episode {} [{}]", episode.iEpisode,
-               regex);
-    episodeList.push_back(episode);
-  }
-}
-
 /*! \brief Retrieve the art type for an image from the given size.
  \param width the width of the image.
  \param height the height of the image.
@@ -1448,7 +1386,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (ProcessItemByVideoInfoTag(items[i].get(), episodeList))
         continue;
 
-      if (!EnumerateEpisodeItem(items[i].get(), episodeList))
+      if (!CEpisodeUtils::EnumerateEpisodeItem(items[i].get(), episodeList))
         CLog::Log(LOGDEBUG, "VideoInfoScanner: Could not enumerate file {}", CURL::GetRedacted(items[i]->GetPath()));
     }
     return true;
@@ -1553,273 +1491,6 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return false;
   }
 
-  bool CVideoInfoScanner::EnumerateEpisodeItem(const CFileItem *item, EPISODELIST& episodeList)
-  {
-    SETTINGS_TVSHOWLIST expression = m_advancedSettings->m_tvshowEnumRegExps;
-
-    std::string strLabel;
-
-    // remove path to main file if it's a bd or dvd folder to regex the right (folder) name
-    if (item->IsOpticalMediaFile())
-    {
-      strLabel = item->GetLocalMetadataPath();
-      URIUtils::RemoveSlashAtEnd(strLabel);
-    }
-    else
-      strLabel = item->GetPath();
-
-    // URLDecode in case an episode is on a http/https/dav/davs:// source and URL-encoded like foo%201x01%20bar.avi
-    strLabel = CURL::Decode(CURL::GetRedacted(strLabel));
-
-    for (unsigned int i=0;i<expression.size();++i)
-    {
-      CRegExp reg(true, CRegExp::autoUtf8);
-      if (!reg.RegComp(expression[i].regexp))
-        continue;
-
-      int regexppos, regexp2pos;
-      //CLog::Log(LOGDEBUG,"running expression {} on {}",expression[i].regexp,strLabel);
-      if ((regexppos = reg.RegFind(strLabel.c_str())) < 0)
-        continue;
-
-      EPISODE episode;
-      episode.strPath = item->GetPath();
-      episode.iSeason = -1;
-      episode.iEpisode = -1;
-      episode.cDate.SetValid(false);
-      episode.isFolder = false;
-
-      bool byDate = expression[i].byDate ? true : false;
-      bool byTitle = expression[i].byTitle;
-      int defaultSeason = expression[i].defaultSeason;
-
-      if (byDate)
-      {
-        if (!GetAirDateFromRegExp(reg, episode))
-          continue;
-
-        CLog::Log(LOGDEBUG, "VideoInfoScanner: Found date based match {} ({}) [{}]",
-                  CURL::GetRedacted(episode.strPath), episode.cDate.GetAsLocalizedDate(),
-                  expression[i].regexp);
-      }
-      else if (byTitle)
-      {
-        if (!GetEpisodeTitleFromRegExp(reg, episode))
-          continue;
-
-        CLog::Log(LOGDEBUG, "VideoInfoScanner: Found title based match {} ({}) [{}]",
-                  CURL::GetRedacted(episode.strPath), episode.strTitle, expression[i].regexp);
-      }
-      else
-      {
-        if (!GetEpisodeAndSeasonFromRegExp(reg, episode, defaultSeason))
-          continue;
-
-        CLog::Log(LOGDEBUG, "VideoInfoScanner: Found episode match {} (s{}e{}) [{}]",
-                  CURL::GetRedacted(episode.strPath), episode.iSeason, episode.iEpisode,
-                  expression[i].regexp);
-      }
-
-      // Grab the remainder from first regexp run
-      // as second run might modify or empty it.
-      std::string remainder(reg.GetMatch(3));
-
-      /*
-       * Check if the files base path is a dedicated folder that contains
-       * only this single episode. If season and episode match with the
-       * actual media file, we set episode.isFolder to true.
-       */
-      std::string strBasePath = item->GetBaseMoviePath(true);
-      URIUtils::RemoveSlashAtEnd(strBasePath);
-      strBasePath = URIUtils::GetFileName(strBasePath);
-
-      if (reg.RegFind(strBasePath.c_str()) > -1)
-      {
-        EPISODE parent;
-        if (byDate)
-        {
-          GetAirDateFromRegExp(reg, parent);
-          if (episode.cDate == parent.cDate)
-            episode.isFolder = true;
-        }
-        else
-        {
-          GetEpisodeAndSeasonFromRegExp(reg, parent, defaultSeason);
-          if (episode.iSeason == parent.iSeason && episode.iEpisode == parent.iEpisode)
-            episode.isFolder = true;
-        }
-      }
-
-      // add what we found by now
-      episodeList.push_back(episode);
-
-      const bool disableEpisodeRanges{m_advancedSettings->m_disableEpisodeRanges};
-
-      CRegExp reg2(true, CRegExp::autoUtf8);
-      // check the remainder of the string for any further episodes.
-      if (!byDate && reg2.RegComp(m_advancedSettings->m_tvshowMultiPartEnumRegExp))
-      {
-        size_t offset{0};
-        int currentSeason{episode.iSeason};
-        int currentEpisode{episode.iEpisode};
-
-        // we want "long circuit" OR below so that both offsets are evaluated
-        while (static_cast<int>((regexp2pos = reg2.RegFind(remainder.c_str() + offset)) > -1) |
-               static_cast<int>((regexppos = reg.RegFind(remainder.c_str() + offset)) > -1))
-        {
-          if ((regexppos <= regexp2pos && regexppos != -1) || // season (or 'ep') match
-              (regexppos >= 0 && regexp2pos == -1))
-          {
-            GetEpisodeAndSeasonFromRegExp(reg, episode, defaultSeason);
-            if (currentSeason == episode.iSeason)
-            {
-              // Already added SxxEyy now loop (if needed) to SxxEzz
-              const int last{episode.iEpisode};
-              const int next{
-                  disableEpisodeRanges || !remainder.starts_with("-") ? last : currentEpisode + 1};
-
-              ProcessEpisodeRange(next, last, episode, episodeList,
-                                  m_advancedSettings->m_tvshowMultiPartEnumRegExp, remainder);
-
-              currentEpisode = episode.iEpisode;
-              remainder = reg.GetMatch(3);
-            }
-            else
-            {
-              // Two possible scenarios here:
-              if (remainder.substr(offset, 1) != "-" || disableEpisodeRanges)
-              {
-                // (Sxx)Eyy has already been added and we now in a new range (eg. S00E01S01E01....)
-                // Add first episode here
-                currentSeason = episode.iSeason;
-                currentEpisode = episode.iEpisode;
-                episodeList.push_back(episode);
-                remainder = reg.GetMatch(3);
-              }
-              else
-              {
-                // (Sxx)Eyy has already been added as start of range and we now have SaaEbb (eg. S01E01-S02E05)
-                //   this is not allowed as scanner cannot determine how many episodes in a season
-                if (offset == 0)
-                {
-                  // Already added first episode of invalid range so remove it
-                  episodeList.pop_back();
-                  remainder = reg.GetMatch(3);
-                  CLog::LogF(
-                      LOGDEBUG,
-                      "VideoInfoScanner: Removing season {}, episode {} as part of invalid range",
-                      episode.iSeason, episode.iEpisode);
-                }
-                else
-                {
-                  remainder = remainder.substr(offset);
-                }
-              }
-            }
-            offset = 0;
-          }
-          else if ((regexp2pos < regexppos && regexp2pos != -1) || // episode match
-                   (regexp2pos >= 0 && regexppos == -1))
-          {
-            const std::string result{reg2.GetMatch(2)};
-            const int last{std::stoi(result)};
-            const std::string prefix{
-                offset < remainder.length()
-                    ? StringUtils::ToLower(std::string_view(remainder).substr(offset, 2))
-                    : std::string{}};
-            const int next{(prefix == "-e" || prefix == "-s") && !disableEpisodeRanges
-                               ? currentEpisode + 1
-                               : last};
-
-            ProcessEpisodeRange(next, last, episode, episodeList,
-                                m_advancedSettings->m_tvshowMultiPartEnumRegExp, reg2.GetMatch(3));
-
-            currentEpisode = episode.iEpisode;
-            offset += regexp2pos + reg2.GetMatch(1).length() + result.length();
-          }
-        }
-      }
-      return true;
-    }
-    return false;
-  }
-
-  bool CVideoInfoScanner::GetEpisodeAndSeasonFromRegExp(CRegExp &reg, EPISODE &episodeInfo, int defaultSeason)
-  {
-    std::string season(reg.GetMatch(1));
-    std::string episode(reg.GetMatch(2));
-
-    if (!season.empty() || !episode.empty())
-    {
-      char* endptr = NULL;
-      if (season.empty() && !episode.empty())
-      { // no season specified -> assume defaultSeason
-        episodeInfo.iSeason = defaultSeason;
-        if ((episodeInfo.iEpisode = CUtil::TranslateRomanNumeral(episode.c_str())) == -1)
-          episodeInfo.iEpisode = strtol(episode.c_str(), &endptr, 10);
-      }
-      else if (!season.empty() && episode.empty())
-      { // no episode specification -> assume defaultSeason
-        episodeInfo.iSeason = defaultSeason;
-        if ((episodeInfo.iEpisode = CUtil::TranslateRomanNumeral(season.c_str())) == -1)
-          episodeInfo.iEpisode = atoi(season.c_str());
-      }
-      else
-      { // season and episode specified
-        episodeInfo.iSeason = atoi(season.c_str());
-        episodeInfo.iEpisode = strtol(episode.c_str(), &endptr, 10);
-      }
-      if (endptr)
-      {
-        if (isalpha(*endptr))
-          episodeInfo.iSubepisode = *endptr - (islower(*endptr) ? 'a' : 'A') + 1;
-        else if (*endptr == '.')
-          episodeInfo.iSubepisode = atoi(endptr+1);
-      }
-      return true;
-    }
-    return false;
-  }
-
-  bool CVideoInfoScanner::GetAirDateFromRegExp(CRegExp &reg, EPISODE &episodeInfo)
-  {
-    std::string param1(reg.GetMatch(1));
-    std::string param2(reg.GetMatch(2));
-    std::string param3(reg.GetMatch(3));
-
-    if (!param1.empty() && !param2.empty() && !param3.empty())
-    {
-      // regular expression by date
-      int len1 = param1.size();
-      int len2 = param2.size();
-      int len3 = param3.size();
-
-      if (len1==4 && len2==2 && len3==2)
-      {
-        // yyyy mm dd format
-        episodeInfo.cDate.SetDate(atoi(param1.c_str()), atoi(param2.c_str()), atoi(param3.c_str()));
-      }
-      else if (len1==2 && len2==2 && len3==4)
-      {
-        // mm dd yyyy format
-        episodeInfo.cDate.SetDate(atoi(param3.c_str()), atoi(param1.c_str()), atoi(param2.c_str()));
-      }
-    }
-    return episodeInfo.cDate.IsValid();
-  }
-
-  bool CVideoInfoScanner::GetEpisodeTitleFromRegExp(CRegExp& reg, EPISODE& episodeInfo)
-  {
-    std::string param1(reg.GetMatch(1));
-
-    if (!param1.empty())
-    {
-      episodeInfo.strTitle = param1;
-      return true;
-    }
-    return false;
-  }
-
   bool CVideoInfoScanner::AddSet(const CSetInfoTag& set)
   {
     // ensure our database is open (this can get called via other classes)
@@ -1894,6 +1565,14 @@ CVideoInfoScanner::~CVideoInfoScanner()
     {
       strTitle = StringUtils::Format("{} - {}x{} - {}", showInfo->m_strTitle,
                                      movieDetails.m_iSeason, movieDetails.m_iEpisode, strTitle);
+    }
+
+    // Determine bluray playlist (if possible)
+    // Also populates streamdetails
+    if (::UTILS::DISCS::IsBlurayDiscImage(path) || URIUtils::IsBDFile(path))
+    {
+      if (CDiscDirectoryHelper::GetOrShowPlaylistSelection(*pItem, BD_PLAYBACK_SIMPLE_MENU, true))
+        pItem->GetVideoInfoTag()->SetFileNameAndPath(pItem->GetDynPath());
     }
 
     /* As HasStreamDetails() returns true for TV shows (because the scraper calls SetVideoInfoTag()

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -149,8 +149,6 @@ namespace KODI::VIDEO
         UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES);
     static std::string GetImage(const CScraperUrl::SUrlEntry &image, const std::string& itemPath);
 
-    bool EnumerateEpisodeItem(const CFileItem *item, EPISODELIST& episodeList);
-
     static std::string GetMovieSetInfoFolder(const std::string& setTitle);
 
   protected:

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -18,8 +18,8 @@
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogOK.h"
 #include "dialogs/GUIDialogSelect.h"
-#include "dialogs/GUIDialogSimpleMenu.h"
 #include "dialogs/GUIDialogYesNo.h"
+#include "filesystem/DiscDirectoryHelper.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "resources/LocalizeStrings.h"
@@ -367,7 +367,8 @@ bool CGUIDialogVideoManagerVersions::ChoosePlaylist(const std::shared_ptr<CFileI
   item->SetProperty("force_playlist_selection", true);
   const int idMovie{m_database.GetMovieId(oldPath)};
 
-  if (CGUIDialogSimpleMenu::ShowPlaylistSelection(*item) && oldPath != item->GetDynPath())
+  if (XFILE::CDiscDirectoryHelper::GetOrShowPlaylistSelection(*item) &&
+      oldPath != item->GetDynPath())
   {
     // Add playlist file as bluray://
     int idFile;

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -367,7 +367,8 @@ bool CGUIDialogVideoManagerVersions::ChoosePlaylist(const std::shared_ptr<CFileI
   item->SetProperty("force_playlist_selection", true);
   const int idMovie{m_database.GetMovieId(oldPath)};
 
-  if (XFILE::CDiscDirectoryHelper::GetOrShowPlaylistSelection(*item) &&
+  if (XFILE::CDiscDirectoryHelper::GetOrShowPlaylistSelection(
+          *item, XFILE::MenuDecision::SHOW_SIMPLE_MENU) &&
       oldPath != item->GetDynPath())
   {
     // Add playlist file as bluray://

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(SOURCES TestStacks.cpp
             TestVideoDbUrl.cpp
             TestVideoFileItemClassify.cpp
-            TestVideoInfoScanner.cpp
             TestVideoInfoTag.cpp
             TestVideoUtils.cpp)
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

One of the final pieces in the Bluray puzzle!

This PR identifies movies with a single playlist and episodes where the heuristic algorithm identifies a single episode playlist to have that playlist identified and used automatically (ie. without user input) when the movie/show is added to the library.

The streamdetails are identifeid and added at scan time as well.

To all intents and purposes the movie/episode now behaves like a video file (ie. mkv/mp4) episode would behave - there is no need for the GUI simple menu.

The GUI simple menu is only needed if the episode can't be identified or if there are multiple versions of the movie on the same disc. In the former case the episode will be selected using the simple menu in the normal way, similarly the movie version playlist can be selected (or pre-selected using bluray movie version support added a little while back).

The playlist can always be changed with the exisitng Choose Playlist context menu option.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

More seamless bluray support.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
