### PR TITLE
[Android] Fix crash when using voice recognition

### DIFF
--- a/xbmc/platform/android/activity/JNIXBMCSpeechRecognitionListener.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCSpeechRecognitionListener.cpp
@@ -38,7 +38,8 @@ void CJNIXBMCSpeechRecognitionListener::RegisterNatives(JNIEnv* env)
 
 CJNIXBMCSpeechRecognitionListener::CJNIXBMCSpeechRecognitionListener() : CJNIBase(s_className)
 {
-  m_object = new_object(CJNIContext::getClassLoader().loadClass(GetClassNameAsPath()));
+  m_object = new_object(CJNIContext::getClassLoader().loadClass(
+      ClassPathToName(s_className))); // TODO: replace param with GetClassNameAsPath
   m_object.setGlobal();
 
   add_instance(m_object, this);


### PR DESCRIPTION
## Description
The crash occurs when loading the class because the member variables it uses are not initialized.

Related to https://github.com/xbmc/xbmc/pull/27944

## How has this been tested?
Voice recognition is working again on Android

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
