### PR TITLE
[Windows] Fix missing UWP patch for build libmariadb

### DIFF
--- a/tools/depends/target/mariadb/03-win-uwp.patch
+++ b/tools/depends/target/mariadb/03-win-uwp.patch
@@ -53,6 +53,19 @@
  ELSE()
  # in cmake 3.12+ we can use
  #INSTALL(TARGETS libmariadb LIBRARY DESTINATION ${INSTALL_LIBDIR}
+diff --git a/include/ma_context.h b/include/ma_context.h
+index d9ba1ffc..c8437561 100644
+--- a/include/ma_context.h
++++ b/include/ma_context.h
+@@ -47,7 +47,7 @@
+ #  endif
+ #endif
+ 
+-#ifdef _WIN32
++#if defined(_WIN32) && !defined(MS_APP)
+ #define MY_CONTEXT_USE_WIN32_FIBERS 1
+ #elif defined(ASAN_PREFER_NON_ASM) && defined(HAVE_BOOST_CONTEXT_H)
+ #define MY_CONTEXT_USE_BOOST_CONTEXT
 --- a/libmariadb/ma_client_plugin.c.in
 +++ b/libmariadb/ma_client_plugin.c.in
 @@ -46,6 +46,8 @@


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix missing UWP patch for build libmariadb.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Noticed while looking at UWP-64 build log for other reason:

```
2>V:\kodi-build-UWP\build\build-mariadb\src\build-mariadb\libmariadb\ma_context.c(1024,17): warning C4013: 'CreateFiber' undefined; assuming extern returning int [V:\kodi-build-UWP\build\build-mariadb\src\build-mariadb-build\libmariadb\mariadb_obj.vcxproj]
2>  old_password.c
2>V:\kodi-build-UWP\build\build-mariadb\src\build-mariadb\libmariadb\ma_context.c(1024,15): warning C4047: '=': 'void *' differs in levels of indirection from 'int' [V:\kodi-build-UWP\build\build-mariadb\src\build-mariadb-build\libmariadb\mariadb_obj.vcxproj]
2>V:\kodi-build-UWP\build\build-mariadb\src\build-mariadb\libmariadb\ma_context.c(1051,64): warning C4013: 'ConvertThreadToFiber' undefined; assuming extern returning int [V:\kodi-build-UWP\build\build-mariadb\src\build-mariadb-build\libmariadb\mariadb_obj.vcxproj]
2>V:\kodi-build-UWP\build\build-mariadb\src\build-mariadb\libmariadb\ma_context.c(1051,62): warning C4047: ':': 'PVOID' differs in levels of indirection from 'int' [V:\kodi-build-UWP\build\build-mariadb\src\build-mariadb-build\libmariadb\mariadb_obj.vcxproj]
```

Build not fails because only is generated a warning but not should be ignored because mariadb try to use a not available system calls in UWP: `CreateFiber` and `ConvertThreadToFiber` and may result in undefined or bad behavior.

This patch was present before in the pre-built Windows dependency:
https://github.com/thexai/mariadb-connector-c/commit/e5dc7e86a0fc2dfd3f36efd5522570db245df57e#diff-f4e3b4d511091c8b05e2987c702b30113e6b5d44a2db22c00fea42fd2e4c2c33

So it seems clear that it was lost by accident.

Fixed also no last end line in patch file (fails to apply outside of Kodi build with "git apply").

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build UWP-64, these warnings no longer present.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
