### PR TITLE
[webOS] Improve queueing logic

### DIFF
--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -220,42 +220,6 @@ int CMediaPipelineWebOS::GetVideoBitrate() const
   return static_cast<int>(m_videoStats.GetBitrate());
 }
 
-void CMediaPipelineWebOS::UpdateAudioInfo()
-{
-  const unsigned int level = GetQueueLevel(StreamType::AUDIO);
-  const double kb = m_messageQueueAudio.GetDataSize() / 1024.0;
-  const double ts = m_messageQueueAudio.GetTimeSize();
-  const double kbps = m_audioStats.GetBitrate() / 1024.0;
-
-  std::scoped_lock lock(m_audioInfoMutex);
-
-  std::string transcodedInfo;
-  if (m_audioEncoder)
-  {
-    transcodedInfo = fmt::format(
-        ", transcoded {}", (m_audioEncoder->GetCodecID() == AV_CODEC_ID_EAC3) ? "eac3" : "ac3");
-  }
-
-  m_audioInfo =
-      fmt::format("aq:{:02}% {:.3f}s {:.3f}Kb, Kb/s:{:.2f}{}", level, ts, kb, kbps, transcodedInfo);
-}
-
-void CMediaPipelineWebOS::UpdateVideoInfo()
-{
-  const int level = m_processInfo.GetLevelVQ();
-  const double ts = m_messageQueueVideo.GetTimeSize();
-  const double mb = m_messageQueueVideo.GetDataSize() / 1024.0 / 1024.0;
-  const double mbps = static_cast<double>(GetVideoBitrate()) / (1024.0 * 1024.0);
-  double fps = 0.0;
-
-  if (m_videoHint.fpsrate && m_videoHint.fpsscale)
-    fps = static_cast<double>(m_videoHint.fpsrate) / static_cast<double>(m_videoHint.fpsscale);
-
-  std::scoped_lock lock(m_videoInfoMutex);
-  m_videoInfo = fmt::format("vq:{:02}% {:.3f}s, {:.3f}Mb, Mb/s:{:.2f}, fr:{:.3f}, drop:{}", level,
-                            ts, mb, mbps, fps, m_droppedFrames.load());
-}
-
 void CMediaPipelineWebOS::UpdateGUISounds(const bool playing)
 {
   IAE* activeAE = CServiceBroker::GetActiveAE();
@@ -271,16 +235,37 @@ void CMediaPipelineWebOS::UpdateGUISounds(const bool playing)
     activeAE->SetVolume(1.0);
 }
 
-std::string CMediaPipelineWebOS::GetAudioInfo()
+std::string CMediaPipelineWebOS::GetAudioInfo() const
 {
-  std::scoped_lock lock(m_audioInfoMutex);
-  return m_audioInfo;
+  const unsigned int level = GetQueueLevel(StreamType::AUDIO);
+  const double kb = m_messageQueueAudio.GetDataSize() / 1024.0;
+  const double ts = m_messageQueueAudio.GetTimeSize();
+  const double kbps = m_audioStats.GetBitrate() / 1024.0;
+
+  std::string transcodedInfo;
+  if (m_audioEncoder)
+  {
+    transcodedInfo = fmt::format(
+        ", transcoded {}", (m_audioEncoder->GetCodecID() == AV_CODEC_ID_EAC3) ? "eac3" : "ac3");
+  }
+
+  return fmt::format("aq:{:02}% {:.3f}s {:.3f}Kb, Kb/s:{:.2f}{}", level, ts, kb, kbps,
+                     transcodedInfo);
 }
 
-std::string CMediaPipelineWebOS::GetVideoInfo()
+std::string CMediaPipelineWebOS::GetVideoInfo() const
 {
-  std::scoped_lock lock(m_videoInfoMutex);
-  return m_videoInfo;
+  const int level = m_processInfo.GetLevelVQ();
+  const double ts = m_messageQueueVideo.GetTimeSize();
+  const double mb = m_messageQueueVideo.GetDataSize() / 1024.0 / 1024.0;
+  const double mbps = static_cast<double>(GetVideoBitrate()) / (1024.0 * 1024.0);
+  double fps = 0.0;
+
+  if (m_videoHint.fpsrate && m_videoHint.fpsscale)
+    fps = static_cast<double>(m_videoHint.fpsrate) / static_cast<double>(m_videoHint.fpsscale);
+
+  return fmt::format("vq:{:02}% {:.3f}s, {:.3f}Mb, Mb/s:{:.2f}, fr:{:.3f}, drop:{}", level, ts, mb,
+                     mbps, fps, m_droppedFrames);
 }
 
 bool CMediaPipelineWebOS::Supports(const AVCodecID codec, const int profile)
@@ -1383,7 +1368,6 @@ void CMediaPipelineWebOS::Process()
     std::shared_ptr<CDVDMsg> msg = nullptr;
     int priority = 0;
     m_messageQueueVideo.Get(msg, 10ms, priority);
-    UpdateVideoInfo();
 
     if (msg)
     {
@@ -1438,7 +1422,7 @@ void CMediaPipelineWebOS::ProcessAudio()
     std::shared_ptr<CDVDMsg> msg = nullptr;
     int priority = 0;
     m_messageQueueAudio.Get(msg, 10ms, priority);
-    UpdateAudioInfo();
+
     if (msg)
     {
       if (msg->IsType(CDVDMsg::DEMUXER_PACKET))

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -1325,13 +1325,13 @@ unsigned int CMediaPipelineWebOS::GetQueuedBytes(const StreamType type) const
 
 unsigned int CMediaPipelineWebOS::GetQueueLevel(const StreamType type) const
 {
-  if (type == StreamType::AUDIO && m_audioHint.codec == AV_CODEC_ID_NONE)
-    return 0;
+  if (type == StreamType::VIDEO)
+    return std::min(99, m_messageQueueVideo.GetLevel());
 
-  const unsigned int bytes = GetQueuedBytes(type);
-  const unsigned int capacity = GetQueueCapacity(type);
+  if (type == StreamType::AUDIO && m_audioHint.codec != AV_CODEC_ID_NONE)
+    return std::min(99, m_messageQueueAudio.GetLevel());
 
-  return std::min(99L, std::lround(100.0 * bytes / capacity));
+  return 0;
 }
 
 void CMediaPipelineWebOS::SetDynamicRangeCompression(const long drc)

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -320,7 +320,7 @@ bool CMediaPipelineWebOS::OpenAudioStream(CDVDStreamInfo& audioHint)
 
     if (m_webOSVersion >= 6)
     {
-      std::scoped_lock lock(m_audioCriticalSection);
+      CWorkerGate::Lock audioLock(m_audioGate);
       CVariant optInfo = CVariant::VariantTypeObject;
       const std::string codecName = SetupAudio(audioHint, optInfo);
 
@@ -376,7 +376,7 @@ bool CMediaPipelineWebOS::OpenVideoStream(CDVDStreamInfo hint)
     m_videoClosed = false;
     if (m_videoHint.codec == hint.codec && m_videoHint.hdrType == hint.hdrType)
     {
-      std::scoped_lock lock(m_videoCriticalSection);
+      CWorkerGate::Lock videoLock(m_videoGate);
       SetupBitstreamConverter(hint);
       m_videoHint = hint;
 
@@ -437,8 +437,8 @@ void CMediaPipelineWebOS::CloseVideoStream(const bool waitForBuffers)
 
 void CMediaPipelineWebOS::Flush(bool sync)
 {
-  std::scoped_lock videoLock(m_videoCriticalSection);
-  std::scoped_lock audioLock(m_audioCriticalSection);
+  CWorkerGate::Lock videoLock(m_videoGate);
+  CWorkerGate::Lock audioLock(m_audioGate);
 
   if (!m_mediaAPIs->flush())
     CLog::LogF(LOGDEBUG, "Failed to flush media APIs");
@@ -572,8 +572,8 @@ void CMediaPipelineWebOS::SetSubtitleDelay(const double delay)
 
 bool CMediaPipelineWebOS::Load(CDVDStreamInfo videoHint, CDVDStreamInfo audioHint)
 {
-  std::scoped_lock videoLock(m_videoCriticalSection);
-  std::scoped_lock audioLock(m_audioCriticalSection);
+  CWorkerGate::Lock videoLock(m_videoGate);
+  CWorkerGate::Lock audioLock(m_audioGate);
 
   CVariant p;
 
@@ -1375,9 +1375,11 @@ void CMediaPipelineWebOS::SetDynamicRangeCompression(const long drc)
 
 void CMediaPipelineWebOS::Process()
 {
+  m_videoGate.SetRunning(true);
   while (!m_bStop)
   {
-    std::unique_lock videoLock(m_videoCriticalSection);
+    m_videoGate.Checkpoint();
+
     std::shared_ptr<CDVDMsg> msg = nullptr;
     int priority = 0;
     m_messageQueueVideo.Get(msg, 10ms, priority);
@@ -1419,18 +1421,19 @@ void CMediaPipelineWebOS::Process()
         CLog::LogF(LOGDEBUG, "Received video message: {}", msg->GetMessageType());
       }
     }
-    msg = nullptr;
-    videoLock.unlock();
-    std::this_thread::yield();
   }
+
+  m_videoGate.SetRunning(false);
+  m_videoGate.OnExit();
 }
 
 void CMediaPipelineWebOS::ProcessAudio()
 {
+  m_audioGate.SetRunning(true);
   m_audioStats.Start();
   while (!m_bStop)
   {
-    std::unique_lock lock(m_audioCriticalSection);
+    m_audioGate.Checkpoint();
 
     std::shared_ptr<CDVDMsg> msg = nullptr;
     int priority = 0;
@@ -1606,11 +1609,10 @@ void CMediaPipelineWebOS::ProcessAudio()
         CLog::LogF(LOGDEBUG, "Received audio message: {}", msg->GetMessageType());
       }
     }
-
-    msg = nullptr;
-    lock.unlock();
-    std::this_thread::yield();
   }
+
+  m_audioGate.SetRunning(false);
+  m_audioGate.OnExit();
 }
 
 void CMediaPipelineWebOS::GetVideoResolution(unsigned int& width, unsigned int& height) const

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -81,6 +81,7 @@ constexpr unsigned int MIN_SRC_BUFFER_LEVEL_AUDIO = 1 * 1024 * 1024; // 1 MB
 constexpr unsigned int MIN_SRC_BUFFER_LEVEL_VIDEO = 1 * 1024 * 1024; // 1 MB
 constexpr unsigned int MAX_SRC_BUFFER_LEVEL_AUDIO = 2 * 1024 * 1024; // 2 MB
 constexpr unsigned int MAX_SRC_BUFFER_LEVEL_VIDEO = 8 * 1024 * 1024; // 8 MB
+constexpr std::chrono::nanoseconds MAX_FEED_AHEAD_TIME = 1600ms;
 
 constexpr unsigned int SVP_VERSION_30 = 30;
 constexpr unsigned int SVP_VERSION_40 = 40;
@@ -312,6 +313,9 @@ bool CMediaPipelineWebOS::OpenAudioStream(CDVDStreamInfo& audioHint)
 
   if (m_loaded)
   {
+    m_fedAudioPts = NO_PTS;
+    m_started = false;
+
     if (m_webOSVersion >= 6)
     {
       std::scoped_lock lock(m_audioCriticalSection);
@@ -365,6 +369,8 @@ bool CMediaPipelineWebOS::OpenVideoStream(CDVDStreamInfo hint)
 
   if (m_loaded)
   {
+    m_fedVideoPts = NO_PTS;
+    m_started = false;
     m_videoClosed = false;
     if (m_videoHint.codec == hint.codec && m_videoHint.hdrType == hint.hdrType)
     {
@@ -404,6 +410,7 @@ bool CMediaPipelineWebOS::OpenVideoStream(CDVDStreamInfo hint)
 void CMediaPipelineWebOS::CloseAudioStream(const bool waitForBuffers)
 {
   m_audioClosed = true;
+  m_fedAudioPts = NO_PTS;
   if (m_videoClosed && m_audioClosed)
   {
     Unload(waitForBuffers);
@@ -416,6 +423,7 @@ void CMediaPipelineWebOS::CloseAudioStream(const bool waitForBuffers)
 void CMediaPipelineWebOS::CloseVideoStream(const bool waitForBuffers)
 {
   m_videoClosed = true;
+  m_fedVideoPts = NO_PTS;
   if (m_videoClosed && m_audioClosed)
   {
     Unload(waitForBuffers);
@@ -427,13 +435,18 @@ void CMediaPipelineWebOS::CloseVideoStream(const bool waitForBuffers)
 
 void CMediaPipelineWebOS::Flush(bool sync)
 {
+  std::scoped_lock videoLock(m_videoCriticalSection);
+  std::scoped_lock audioLock(m_audioCriticalSection);
+
   if (!m_mediaAPIs->flush())
     CLog::LogF(LOGDEBUG, "Failed to flush media APIs");
   FlushAudioMessages();
   FlushVideoMessages();
-  std::scoped_lock lock(m_videoCriticalSection);
   if (m_bitstream)
     m_bitstream->ResetStartDecode();
+  m_fedAudioPts = NO_PTS;
+  m_fedVideoPts = NO_PTS;
+  m_started = false;
   m_flushed = true;
 }
 
@@ -812,6 +825,10 @@ bool CMediaPipelineWebOS::Load(CDVDStreamInfo videoHint, CDVDStreamInfo audioHin
     }
   }
 
+  m_fedAudioPts = NO_PTS;
+  m_fedVideoPts = NO_PTS;
+  m_started = false;
+
   m_videoClosed = false;
   if (m_hasAudio)
     m_audioClosed = false;
@@ -827,6 +844,10 @@ void CMediaPipelineWebOS::Unload(const bool sync)
 
   if (!m_mediaAPIs->Unload())
     CLog::LogF(LOGERROR, "Unload failed");
+
+  m_fedAudioPts = NO_PTS;
+  m_fedVideoPts = NO_PTS;
+  m_started = false;
 
   if (sync)
   {
@@ -1079,7 +1100,7 @@ void CMediaPipelineWebOS::SetHDR(const CDVDStreamInfo& hint) const
     CLog::LogF(LOGERROR, "setHdrInfo failed");
 }
 
-void CMediaPipelineWebOS::FeedAudioData(const std::shared_ptr<CDVDMsg>& msg)
+bool CMediaPipelineWebOS::FeedAudioData(const std::shared_ptr<CDVDMsg>& msg)
 {
   DemuxPacket* packet = std::static_pointer_cast<CDVDMsgDemuxerPacket>(msg)->GetPacket();
 
@@ -1087,7 +1108,11 @@ void CMediaPipelineWebOS::FeedAudioData(const std::shared_ptr<CDVDMsg>& msg)
       std::chrono::duration<double, std::ratio<1, DVD_TIME_BASE>>(packet->pts));
 
   if (pts < 0ns)
-    return;
+    return true;
+
+  const std::chrono::nanoseconds fedAudioPts = m_fedAudioPts.load();
+  if (m_started && fedAudioPts != NO_PTS && fedAudioPts - m_pts.load() > MAX_FEED_AHEAD_TIME)
+    return false;
 
   CVariant payload;
   payload["bufferAddr"] = fmt::format("{:#x}", reinterpret_cast<std::uintptr_t>(packet->pData));
@@ -1103,22 +1128,19 @@ void CMediaPipelineWebOS::FeedAudioData(const std::shared_ptr<CDVDMsg>& msg)
 
   if (result.find("Ok") != std::string::npos)
   {
+    m_fedAudioPts = pts;
     m_audioStats.AddSampleBytes(packet->iSize);
-    UpdateAudioInfo();
-    return;
+    return true;
   }
 
   if (result.find("BufferFull") != std::string::npos)
-  {
-    m_messageQueueAudio.PutBack(msg);
-    std::this_thread::sleep_for(100ms);
-    return;
-  }
+    return false;
 
   CLog::LogF(LOGWARNING, "Buffer submit returned error: {}", result);
+  return true;
 }
 
-void CMediaPipelineWebOS::FeedVideoData(const std::shared_ptr<CDVDMsg>& msg)
+bool CMediaPipelineWebOS::FeedVideoData(const std::shared_ptr<CDVDMsg>& msg)
 {
   DemuxPacket* packet = std::static_pointer_cast<CDVDMsgDemuxerPacket>(msg)->GetPacket();
 
@@ -1134,7 +1156,7 @@ void CMediaPipelineWebOS::FeedVideoData(const std::shared_ptr<CDVDMsg>& msg)
     pts = dts;
 
   if (pts < 0ns)
-    return;
+    return true;
 
   uint8_t* data = packet->pData;
   size_t size = packet->iSize;
@@ -1147,7 +1169,7 @@ void CMediaPipelineWebOS::FeedVideoData(const std::shared_ptr<CDVDMsg>& msg)
     if (!m_bitstream->CanStartDecode())
     {
       CLog::LogF(LOGDEBUG, "Waiting for keyframe (bitstream)");
-      return;
+      return true;
     }
 
     size = m_bitstream->GetConvertSize();
@@ -1178,6 +1200,9 @@ void CMediaPipelineWebOS::FeedVideoData(const std::shared_ptr<CDVDMsg>& msg)
     pipeline->sendSegmentEvent();
 
     m_pts = pts;
+    m_fedVideoPts = NO_PTS;
+    m_fedAudioPts = NO_PTS;
+    m_started = false;
 
     SStartMsg startMsg{.timestamp = GetCurrentPts(),
                        .player = VideoPlayer_VIDEO,
@@ -1191,12 +1216,17 @@ void CMediaPipelineWebOS::FeedVideoData(const std::shared_ptr<CDVDMsg>& msg)
     m_flushed = false;
   }
 
+  const std::chrono::nanoseconds fedVideoPts = m_fedVideoPts.load();
+  if (m_started && fedVideoPts != NO_PTS && fedVideoPts - m_pts.load() > MAX_FEED_AHEAD_TIME)
+    return false;
+
   if (data && size)
   {
+    const auto feedPts = pts - std::chrono::milliseconds(m_renderManager.GetDelay());
     CVariant payload;
     payload["bufferAddr"] = fmt::format("{:#x}", reinterpret_cast<std::uintptr_t>(data));
     payload["bufferSize"] = size;
-    payload["pts"] = (pts - std::chrono::milliseconds(m_renderManager.GetDelay())).count();
+    payload["pts"] = feedPts.count();
     payload["esData"] = 1;
 
     std::string json;
@@ -1207,22 +1237,19 @@ void CMediaPipelineWebOS::FeedVideoData(const std::shared_ptr<CDVDMsg>& msg)
 
     if (result.find("Ok") != std::string::npos)
     {
+      m_fedVideoPts = feedPts;
       m_videoStats.AddSampleBytes(packet->iSize);
-      UpdateVideoInfo();
       const unsigned int level = GetQueueLevel(StreamType::VIDEO);
       m_processInfo.SetLevelVQ(static_cast<int>(level));
-      return;
+      return true;
     }
 
     if (result.find("BufferFull") != std::string::npos)
-    {
-      m_messageQueueVideo.PutBack(msg);
-      std::this_thread::sleep_for(100ms);
-      return;
-    }
+      return false;
 
     CLog::LogF(LOGWARNING, "Buffer submit returned error: {}", result);
   }
+  return true;
 }
 
 void CMediaPipelineWebOS::ProcessOverlays(const double pts) const
@@ -1343,17 +1370,21 @@ void CMediaPipelineWebOS::Process()
 {
   while (!m_bStop)
   {
+    std::unique_lock videoLock(m_videoCriticalSection);
     std::shared_ptr<CDVDMsg> msg = nullptr;
     int priority = 0;
     m_messageQueueVideo.Get(msg, 10ms, priority);
+    UpdateVideoInfo();
 
     if (msg)
     {
-      std::scoped_lock videoLock(m_videoCriticalSection);
-
       if (msg->IsType(CDVDMsg::DEMUXER_PACKET))
       {
-        FeedVideoData(msg);
+        if (!FeedVideoData(msg))
+        {
+          m_messageQueueVideo.PutBack(msg);
+          std::this_thread::sleep_for(10ms);
+        }
       }
       else if (msg->IsType(CDVDMsg::PLAYER_REQUEST_STATE))
       {
@@ -1373,6 +1404,9 @@ void CMediaPipelineWebOS::Process()
         CLog::LogF(LOGDEBUG, "Received video message: {}", msg->GetMessageType());
       }
     }
+    msg = nullptr;
+    videoLock.unlock();
+    std::this_thread::yield();
   }
 }
 
@@ -1381,13 +1415,14 @@ void CMediaPipelineWebOS::ProcessAudio()
   m_audioStats.Start();
   while (!m_bStop)
   {
+    std::unique_lock lock(m_audioCriticalSection);
+
     std::shared_ptr<CDVDMsg> msg = nullptr;
     int priority = 0;
     m_messageQueueAudio.Get(msg, 10ms, priority);
+    UpdateAudioInfo();
     if (msg)
     {
-      std::scoped_lock lock(m_audioCriticalSection);
-
       if (msg->IsType(CDVDMsg::DEMUXER_PACKET))
       {
         const DemuxPacket* packet =
@@ -1509,14 +1544,24 @@ void CMediaPipelineWebOS::ProcessAudio()
                     m_audioEncoder->Encode(buf->pkt->data[0], buf->pkt->planes * buf->pkt->linesize,
                                            p->m_packet->pData, p->m_packet->iSize);
                 buf->Return();
-                FeedAudioData(p);
+                if (!FeedAudioData(p))
+                {
+                  m_messageQueueAudio.PutBack(p);
+                  std::this_thread::sleep_for(10ms);
+                }
               }
               m_audioResample->m_outputSamples.clear();
             }
           }
         }
         else
-          FeedAudioData(msg);
+        {
+          if (!FeedAudioData(msg))
+          {
+            m_messageQueueAudio.PutBack(msg);
+            std::this_thread::sleep_for(10ms);
+          }
+        }
       }
       else if (msg->IsType(CDVDMsg::PLAYER_REQUEST_STATE))
       {
@@ -1532,6 +1577,10 @@ void CMediaPipelineWebOS::ProcessAudio()
         CLog::LogF(LOGDEBUG, "Received audio message: {}", msg->GetMessageType());
       }
     }
+
+    msg = nullptr;
+    lock.unlock();
+    std::this_thread::yield();
   }
 }
 
@@ -1582,13 +1631,12 @@ void CMediaPipelineWebOS::PlayerCallback(int32_t type, const int64_t numValue, c
       m_pts = std::chrono::nanoseconds(numValue);
       const double pts = GetCurrentPts();
       ProcessOverlays(pts);
+      m_started = true;
       m_picture.dts = pts;
       m_picture.pts = pts;
       std::atomic<bool> stop(false);
       m_renderManager.AddVideoPicture(m_picture, stop, VS_INTERLACEMETHOD_AUTO, false);
       m_clock.Discontinuity(pts);
-      UpdateVideoInfo();
-      UpdateAudioInfo();
       break;
     }
     case PF_EVENT_TYPE_STR_AUDIO_INFO:

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -1400,6 +1400,14 @@ void CMediaPipelineWebOS::Process()
         if (!m_mediaAPIs->pushEOS())
           CLog::LogF(LOGERROR, "Failed to push EOS message");
       }
+      else if (msg->IsType(CDVDMsg::GENERAL_SYNCHRONIZE))
+      {
+        if (std::static_pointer_cast<CDVDMsgGeneralSynchronize>(msg)->Wait(100ms, SYNCSOURCE_VIDEO))
+          CLog::Log(LOGDEBUG, "CDVDMsg::GENERAL_SYNCHRONIZE");
+        else
+          // push back as prio message, to process other prio messages
+          m_messageQueueVideo.Put(msg, 1);
+      }
       else
       {
         CLog::LogF(LOGDEBUG, "Received video message: {}", msg->GetMessageType());
@@ -1578,6 +1586,14 @@ void CMediaPipelineWebOS::ProcessAudio()
         };
         m_messageQueueParent.Put(
             std::make_shared<CDVDMsgType<SStateMsg>>(CDVDMsg::PLAYER_REPORT_STATE, stateMsg));
+      }
+      else if (msg->IsType(CDVDMsg::GENERAL_SYNCHRONIZE))
+      {
+        if (std::static_pointer_cast<CDVDMsgGeneralSynchronize>(msg)->Wait(100ms, SYNCSOURCE_AUDIO))
+          CLog::Log(LOGDEBUG, "CDVDMsg::GENERAL_SYNCHRONIZE");
+        else
+          // push back as prio message, to process other prio messages
+          m_messageQueueAudio.Put(msg, 1);
       }
       else
       {

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -72,6 +72,7 @@ namespace
 constexpr unsigned int AC3_MAX_SYNC_FRAME_SIZE = 3840;
 constexpr unsigned int EAC3_MAX_SYNC_FRAME_SIZE = 6144;
 constexpr int RESAMPLED_STREAM_ID = -1000;
+constexpr int CONVERTED_STREAM_ID = -2000;
 constexpr unsigned int MIN_AUDIO_RESAMPLE_BUFFER_SIZE = 4096;
 
 constexpr unsigned int PRE_BUFFER_BYTES = 0;
@@ -1165,7 +1166,12 @@ bool CMediaPipelineWebOS::FeedVideoData(const std::shared_ptr<CDVDMsg>& msg)
   // we have an input buffer, fill it.
   if (data && m_bitstream)
   {
-    m_bitstream->Convert(data, static_cast<int>(size));
+    if (packet->iStreamId != CONVERTED_STREAM_ID)
+    {
+      m_bitstream->Convert(data, static_cast<int>(size));
+      // change the stream id here so we do not convert again if the packet is put back
+      packet->iStreamId = CONVERTED_STREAM_ID;
+    }
 
     if (!m_bitstream->CanStartDecode())
     {

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -1166,10 +1166,13 @@ void CMediaPipelineWebOS::FeedVideoData(const std::shared_ptr<CDVDMsg>& msg)
     if (!m_mediaAPIs->setTimeToDecode(payload.c_str()))
     {
       CLog::LogF(LOGERROR, "setTimeToDecode failed");
-      MEDIA_CUSTOM_CONTENT_INFO_T contentInfo;
-      pipeline->loadSpi_getInfo(&contentInfo);
-      contentInfo.ptsToDecode = pts.count();
-      pipeline->setContentInfo(MEDIA_CUSTOM_SRC_TYPE_ES, &contentInfo);
+      if (m_webOSVersion < 11)
+      {
+        MEDIA_CUSTOM_CONTENT_INFO_T contentInfo;
+        pipeline->loadSpi_getInfo(&contentInfo);
+        contentInfo.ptsToDecode = pts.count();
+        pipeline->setContentInfo(MEDIA_CUSTOM_SRC_TYPE_ES, &contentInfo);
+      }
     }
 
     pipeline->sendSegmentEvent();

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -47,6 +47,7 @@
 #include <cstdint>
 #include <exception>
 #include <map>
+#include <ranges>
 #include <ratio>
 #include <string_view>
 #include <utility>
@@ -1505,6 +1506,8 @@ void CMediaPipelineWebOS::ProcessAudio()
 
             m_audioResample->m_inputSamples.emplace_back(buffer);
 
+            std::vector<std::shared_ptr<CDVDMsgDemuxerPacket>> unconsumedPackets;
+            bool canConsume = true;
             while (m_audioResample->ResampleBuffers())
             {
               for (const auto& buf : m_audioResample->m_outputSamples)
@@ -1544,14 +1547,18 @@ void CMediaPipelineWebOS::ProcessAudio()
                     m_audioEncoder->Encode(buf->pkt->data[0], buf->pkt->planes * buf->pkt->linesize,
                                            p->m_packet->pData, p->m_packet->iSize);
                 buf->Return();
-                if (!FeedAudioData(p))
+                if (!canConsume || !FeedAudioData(p))
                 {
-                  m_messageQueueAudio.PutBack(p);
-                  std::this_thread::sleep_for(10ms);
+                  canConsume = false;
+                  unconsumedPackets.emplace_back(std::move(p));
                 }
               }
               m_audioResample->m_outputSamples.clear();
             }
+
+            // not consumed packets need to be pushed back in reverse to keep ordering
+            std::ranges::for_each(unconsumedPackets | std::views::reverse,
+                                  [this](const auto& p) { m_messageQueueAudio.PutBack(p); });
           }
         }
         else
@@ -1631,7 +1638,8 @@ void CMediaPipelineWebOS::PlayerCallback(int32_t type, const int64_t numValue, c
       m_pts = std::chrono::nanoseconds(numValue);
       const double pts = GetCurrentPts();
       ProcessOverlays(pts);
-      m_started = true;
+      if (!m_flushed)
+        m_started = true;
       m_picture.dts = pts;
       m_picture.pts = pts;
       std::atomic<bool> stop(false);

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -184,10 +184,17 @@ CMediaPipelineWebOS::CMediaPipelineWebOS(CProcessInfo& processInfo,
 {
   m_messageQueueAudio.Init();
   m_messageQueueVideo.Init();
-  m_messageQueueAudio.SetMaxTimeSize(1.0);
-  m_messageQueueVideo.SetMaxTimeSize(1.0);
-  m_messageQueueAudio.SetMaxDataSize(MAX_SRC_BUFFER_LEVEL_AUDIO);
-  m_messageQueueVideo.SetMaxDataSize(MAX_SRC_BUFFER_LEVEL_VIDEO);
+  const int tenthsSeconds = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_VIDEOPLAYER_QUEUETIMESIZE);
+  m_messageQueueAudio.SetMaxTimeSize(tenthsSeconds / 10.0);
+  m_messageQueueVideo.SetMaxTimeSize(tenthsSeconds / 10.0);
+
+  // allows max bitrate of 18 Mbit/s (TrueHD max peak) during m_messageQueueTimeSize seconds
+  // matches the value in CVideoPlayerAudio
+  const int sizeMB = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_VIDEOPLAYER_QUEUEDATASIZE);
+  m_messageQueueAudio.SetMaxDataSize(18 * (tenthsSeconds / 10.0) / 8 * 1024 * 1024);
+  m_messageQueueVideo.SetMaxDataSize(sizeMB * 1024 * 1024);
 
   m_picture.Reset();
   m_picture.videoBuffer = new CStarfishVideoBuffer();

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
@@ -280,8 +280,9 @@ private:
   /**
    * @brief Feed a video packet to the media API.
    * @param msg Demux packet wrapped in a CDVDMsg.
+   * @return true if the packet was consumed, false if not.
    */
-  void FeedVideoData(const std::shared_ptr<CDVDMsg>& msg);
+  bool FeedVideoData(const std::shared_ptr<CDVDMsg>& msg);
 
   /**
    * @brief Render subtitle and overlay graphics at given timestamp.
@@ -292,8 +293,9 @@ private:
   /**
    * @brief Feed an audio packet to the media API.
    * @param msg Demux packet wrapped in a CDVDMsg.
+   * @return true if the packet was consumed, false if not.
    */
-  void FeedAudioData(const std::shared_ptr<CDVDMsg>& msg);
+  bool FeedAudioData(const std::shared_ptr<CDVDMsg>& msg);
 
   /**
    * @brief Configure and load media streams into the pipeline.
@@ -402,6 +404,8 @@ private:
                              int& height,
                              int& framerate) const;
 
+  static constexpr std::chrono::nanoseconds NO_PTS{-1};
+
   std::condition_variable m_eventCondition;
   std::mutex m_eventMutex;
 
@@ -441,6 +445,10 @@ private:
 
   std::atomic<bool> m_videoClosed{true};
   std::atomic<bool> m_audioClosed{true};
+
+  std::atomic<std::chrono::nanoseconds> m_fedAudioPts{NO_PTS};
+  std::atomic<std::chrono::nanoseconds> m_fedVideoPts{NO_PTS};
+  std::atomic<bool> m_started{false};
 
   std::mutex m_audioInfoMutex;
   std::string m_audioInfo;

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
@@ -45,6 +45,89 @@ class CDVDAudioCodec;
 class StarfishMediaAPIs;
 
 /**
+ * \brief Lock-free cooperative gate for pausing a worker thread.
+ *
+ * The worker calls \ref Checkpoint() each loop iteration. If a pause has been
+ * requested it blocks (via std::atomic::wait) until the requester releases.
+ *
+ * Other threads obtain a \ref Lock RAII guard which requests the pause, waits
+ * for the worker to reach its checkpoint, and resumes the worker on
+ * destruction.
+ */
+class CWorkerGate
+{
+public:
+  /**
+   * \brief RAII guard – pauses the worker on construction, resumes on destruction.
+   */
+  class Lock
+  {
+  public:
+    explicit Lock(CWorkerGate& gate) : m_gate(gate) { m_gate.Pause(); }
+    ~Lock() { m_gate.Resume(); }
+    Lock(const Lock&) = delete;
+    Lock& operator=(const Lock&) = delete;
+
+  private:
+    CWorkerGate& m_gate;
+  };
+
+  /**
+   * \brief Called by the worker thread at the top of every loop iteration.
+   *
+   * If a pause has been requested the call blocks until the requester
+   * calls Resume() (typically via Lock destruction).
+   */
+  void Checkpoint()
+  {
+    if (m_pauseRequested.load(std::memory_order_acquire))
+    {
+      m_paused.store(true, std::memory_order_release);
+      m_paused.notify_all();
+      m_pauseRequested.wait(true, std::memory_order_acquire);
+      m_paused.store(false, std::memory_order_release);
+    }
+  }
+
+  /**
+   * \brief Called by the worker thread just before it exits its loop.
+   *
+   * Ensures any thread blocked in Pause() is woken up.
+   */
+  void OnExit()
+  {
+    m_paused.store(true, std::memory_order_release);
+    m_paused.notify_all();
+  }
+
+  /**
+   * \brief Indicate whether the associated worker thread is running.
+   *
+   * Must be set to \c true before the worker loop and \c false after.
+   */
+  void SetRunning(const bool running) { m_running.store(running, std::memory_order_release); }
+
+private:
+  void Pause()
+  {
+    m_pauseRequested.store(true, std::memory_order_release);
+    if (m_running.load(std::memory_order_acquire))
+      m_paused.wait(false, std::memory_order_acquire);
+  }
+
+  void Resume()
+  {
+    m_pauseRequested.store(false, std::memory_order_release);
+    m_pauseRequested.notify_all();
+    m_paused.store(false, std::memory_order_release);
+  }
+
+  std::atomic<bool> m_pauseRequested{false};
+  std::atomic<bool> m_paused{false};
+  std::atomic<bool> m_running{false};
+};
+
+/**
  * @class CMediaPipelineWebOS
  * @brief WebOS media pipeline for audio/video playback.
  */
@@ -431,8 +514,8 @@ private:
   std::atomic<unsigned long> m_droppedFrames{0};
   std::chrono::duration<double, std::ratio<1, DVD_TIME_BASE>> m_audioClock{0.0};
 
-  std::mutex m_audioCriticalSection;
-  std::mutex m_videoCriticalSection;
+  CWorkerGate m_videoGate;
+  CWorkerGate m_audioGate;
 
   CDVDMessageQueue m_messageQueueAudio;
   CDVDMessageQueue m_messageQueueVideo;

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
@@ -323,13 +323,13 @@ public:
   /**
    * @return Audio stream debug info
    */
-  std::string GetAudioInfo();
+  std::string GetAudioInfo() const;
 
   /**
    *
    * @return Video stream debug info
    */
-  std::string GetVideoInfo();
+  std::string GetVideoInfo() const;
 
   /**
    * @brief Get the resolution of the video stream
@@ -407,16 +407,6 @@ private:
    * @param hint Video stream hint.
    */
   void SetupBitstreamConverter(CDVDStreamInfo& hint);
-
-  /**
-   * @brief Updates the player video debug info.
-   */
-  void UpdateVideoInfo();
-
-  /**
-   * @brief Updates the player video debug info.
-   */
-  void UpdateAudioInfo();
 
   /**
    * @brief Updates ActiveAE volume setting based on current audio state.
@@ -533,10 +523,6 @@ private:
   std::atomic<std::chrono::nanoseconds> m_fedVideoPts{NO_PTS};
   std::atomic<bool> m_started{false};
 
-  std::mutex m_audioInfoMutex;
-  std::string m_audioInfo;
-  std::mutex m_videoInfoMutex;
-  std::string m_videoInfo;
   BitstreamStats m_audioStats{};
   BitstreamStats m_videoStats{};
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudioWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudioWebOS.cpp
@@ -36,7 +36,8 @@ void CVideoPlayerAudioWebOS::SetSpeed(const int speed)
 
 void CVideoPlayerAudioWebOS::Flush(const bool sync)
 {
-  m_mediaPipeline.Flush(sync);
+  // VideoPlayer calls this right before calling flush on the video player
+  // We can skip this call because it would essential flush the pipeline twice
 }
 
 bool CVideoPlayerAudioWebOS::AcceptsData() const


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Limit maximum feed ahead time into the pipeline. Previously, we just fed data into the pipeline until the buffers were exhausted. This PR changes this behavior to avoid feeding too much data into the pipeline decreasing latency. The pipeline buffers can grow very large (> 10 seconds) causing a lot of buffering after a flush. This should help reduce memory consumption together with the queue size changes (making this adjustable, as with the other platforms).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS 11 / 26

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
