### PR TITLE
[AE] Fix ALSA error recovery and add BitstreamPacker unit tests

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -1,6 +1,7 @@
 xbmc/addons/gui/skin/test         test/skin
 xbmc/addons/test                  test/addons
 xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
+xbmc/cores/AudioEngine/Utils/test test/audioengine_utils
 xbmc/cores/VideoPlayer/Edl/test   test/edl
 xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test test/videoshaders
 xbmc/dbwrappers/test              test/dbwrappers

--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -1,6 +1,7 @@
 xbmc/addons/gui/skin/test         test/skin
 xbmc/addons/test                  test/addons
 xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
+xbmc/cores/AudioEngine/Utils/test test/audioengine_utils
 xbmc/cores/VideoPlayer/Buffers/test test/videoplayer_buffers
 xbmc/cores/VideoPlayer/test       test/videoplayer
 xbmc/cores/VideoPlayer/DVDDemuxers/test test/dvddemuxers

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -979,6 +979,9 @@ void CAESinkALSA::HandleError(const char* name, int err)
     default:
       CLog::Log(LOGERROR, "CAESinkALSA::HandleError({}) - snd_pcm_writei returned {} ({})", name,
                 err, snd_strerror(err));
+      if ((err = snd_pcm_prepare(m_pcm)) < 0)
+        CLog::Log(LOGERROR, "CAESinkALSA::HandleError({}) - snd_pcm_prepare returned {} ({})", name,
+                  err, snd_strerror(err));
       break;
   }
 }

--- a/xbmc/cores/AudioEngine/Utils/test/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/Utils/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestAEBitstreamPacker.cpp)
+
+core_add_test_library(audioengine_utils_test)

--- a/xbmc/cores/AudioEngine/Utils/test/TestAEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/test/TestAEBitstreamPacker.cpp
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/AudioEngine/Utils/AEBitstreamPacker.h"
+#include "cores/AudioEngine/Utils/AEStreamInfo.h"
+
+#include <gtest/gtest.h>
+
+TEST(TestAEBitstreamPacker, TrueHDOutputRate192kAt48k)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_TRUEHD;
+  info.m_sampleRate = 48000;
+  EXPECT_EQ(CAEBitstreamPacker::GetOutputRate(info), 192000u);
+}
+
+TEST(TestAEBitstreamPacker, TrueHDOutputRate192kAt96k)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_TRUEHD;
+  info.m_sampleRate = 96000;
+  EXPECT_EQ(CAEBitstreamPacker::GetOutputRate(info), 192000u);
+}
+
+TEST(TestAEBitstreamPacker, TrueHDOutputRate176kAt44k)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_TRUEHD;
+  info.m_sampleRate = 44100;
+  EXPECT_EQ(CAEBitstreamPacker::GetOutputRate(info), 176400u);
+}
+
+TEST(TestAEBitstreamPacker, TrueHDOutputChannels8)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_TRUEHD;
+  info.m_sampleRate = 0;
+  CAEChannelInfo channels = CAEBitstreamPacker::GetOutputChannelMap(info);
+  EXPECT_EQ(channels.Count(), 8u);
+}
+
+TEST(TestAEBitstreamPacker, DTSHDMAOutputRate192k)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD_MA;
+  info.m_sampleRate = 48000;
+  EXPECT_EQ(CAEBitstreamPacker::GetOutputRate(info), 192000u);
+}
+
+TEST(TestAEBitstreamPacker, DTSHDMAOutputChannels8)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD_MA;
+  info.m_sampleRate = 0;
+  CAEChannelInfo channels = CAEBitstreamPacker::GetOutputChannelMap(info);
+  EXPECT_EQ(channels.Count(), 8u);
+}
+
+TEST(TestAEBitstreamPacker, AC3OutputChannels2)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_AC3;
+  info.m_sampleRate = 0;
+  CAEChannelInfo channels = CAEBitstreamPacker::GetOutputChannelMap(info);
+  EXPECT_EQ(channels.Count(), 2u);
+}
+
+TEST(TestAEBitstreamPacker, EAC3OutputRate4x)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_EAC3;
+  info.m_sampleRate = 48000;
+  EXPECT_EQ(CAEBitstreamPacker::GetOutputRate(info), 192000u);
+}
+
+TEST(TestAEBitstreamPacker, DTS512OutputChannels2)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_DTS_512;
+  info.m_sampleRate = 0;
+  CAEChannelInfo channels = CAEBitstreamPacker::GetOutputChannelMap(info);
+  EXPECT_EQ(channels.Count(), 2u);
+}


### PR DESCRIPTION
## Description

Add `snd_pcm_prepare()` recovery to `HandleError` default case so unhandled errors (not `-EPIPE` or `-ESTRPIPE`) don't leave the PCM stream broken during extended passthrough playback. Follows the same pattern as the existing EPIPE case.

Add unit tests for `BitstreamPacker::GetOutputRate()` and `GetOutputChannelMap()` covering TrueHD, DTS-HD MA, AC3, EAC3, and DTS.

## Motivation and context

Related to https://github.com/xbmc/xbmc/issues/21135 — TrueHD and DTS-HD MA passthrough not working on Linux.

**Companion PR:** #28116 (PipeWire sink refactor). That PR is independent of this one but together they address #21135.

## How has this been tested?

Full Kodi build on Debian 13 (Trixie), g++ 14.2.0, ALSA 1.2.14. Zero warnings under `-Wall -Wextra -Werror=sign-compare -Werror=missing-field-initializers -Werror=double-promotion`. 9/9 unit tests pass.

## What is the effect on users?

Improved ALSA error recovery during extended passthrough playback. Previously, unhandled errors in the default `HandleError` case left the PCM stream broken with no recovery attempt.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed