### PR TITLE
[AE] Refactor PipeWire sink for TrueHD/DTS-HD MA passthrough

### DIFF
--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -481,17 +481,43 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
 
   std::vector<const spa_pod*> params;
 
-  // clang-format off
-  uint32_t buf_minsize = frames * pwChannels.size() * PWFormatToSampleSize(pwFormat);
-  params.emplace_back(static_cast<const spa_pod*>(spa_pod_builder_add_object(
-      &builder, SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
-          SPA_PARAM_BUFFERS_blocks, SPA_POD_Int(1),
-          SPA_PARAM_BUFFERS_size, SPA_POD_CHOICE_RANGE_Int(buf_minsize, buf_minsize, INT32_MAX),
-          SPA_PARAM_BUFFERS_stride, SPA_POD_Int(pwChannels.size() * PWFormatToSampleSize(pwFormat)))));
-  // clang-format on
+  // Buffer params are deferred to param_changed callback (matching mpv pattern).
+  // PipeWire negotiates the format first, then we respond with buffer requirements.
+  m_stride = pwChannels.size() * PWFormatToSampleSize(pwFormat);
+  m_bufferSize = frames * m_stride;
 
-  pw_stream_flags flags = static_cast<pw_stream_flags>(
-      PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_INACTIVE | PW_STREAM_FLAG_MAP_BUFFERS);
+  m_stream->SetParamChangedCallback(
+      [this](uint32_t id, const spa_pod* /* param */)
+      {
+        if (id != SPA_PARAM_Format)
+          return;
+
+        uint8_t buf[1024];
+        auto b = SPA_POD_BUILDER_INIT(buf, sizeof(buf));
+
+        // clang-format off
+        const spa_pod* bufferParam = static_cast<const spa_pod*>(spa_pod_builder_add_object(
+            &b, SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
+                SPA_PARAM_BUFFERS_blocks, SPA_POD_Int(1),
+                SPA_PARAM_BUFFERS_size, SPA_POD_CHOICE_RANGE_Int(m_bufferSize, m_bufferSize, INT32_MAX),
+                SPA_PARAM_BUFFERS_stride, SPA_POD_Int(m_stride)));
+        // clang-format on
+
+        if (bufferParam)
+        {
+          int ret = m_stream->UpdateParams(&bufferParam, 1);
+          if (ret < 0)
+            CLog::Log(LOGERROR, "CAESinkPipewire - failed to update buffer params: {}",
+                      spa_strerror(ret));
+          else
+            CLog::Log(LOGDEBUG, "CAESinkPipewire - buffer params set: size={} stride={}",
+                      m_bufferSize, m_stride);
+        }
+      });
+
+  pw_stream_flags flags =
+      static_cast<pw_stream_flags>(PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_INACTIVE |
+                                   PW_STREAM_FLAG_MAP_BUFFERS | PW_STREAM_FLAG_RT_PROCESS);
 
   if (!passthrough)
   {
@@ -582,6 +608,10 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
 
   m_format = format;
 
+  // Initialize ring buffer: 4x buffer size for headroom between audio engine and RT thread
+  uint32_t ringSize = m_bufferSize * 4;
+  m_stream->InitRingBuffer(ringSize, format.m_frameSize);
+
   return true;
 }
 
@@ -609,61 +639,30 @@ unsigned int CAESinkPipewire::AddPackets(uint8_t** data,
   if (m_stream->HasStreamError())
     return 0;
 
-  unsigned int frames = frames_in;
-
-  auto& loop = pipewire->GetThreadLoop();
-
-  PIPEWIRE::CLoopLockGuard lock(loop);
-
   if (m_stream->GetState() == PW_STREAM_STATE_PAUSED)
+  {
+    auto& loop = pipewire->GetThreadLoop();
+    PIPEWIRE::CLoopLockGuard lock(loop);
     m_stream->SetActive(true);
+  }
   else if (m_stream->GetState() != PW_STREAM_STATE_STREAMING)
     return 0;
 
-  while (frames)
+  unsigned int remaining = frames_in;
+  unsigned int written_total = 0;
+  const uint8_t* src = data[0] + offset * m_format.m_frameSize;
+
+  while (remaining > 0)
   {
-    // Block until data is needed. Process() will wake us up.
-    while (!m_stream->NeedsData())
+    unsigned int w = m_stream->Write(src + written_total * m_format.m_frameSize, remaining);
+    written_total += w;
+    remaining -= w;
+
+    if (remaining > 0)
     {
-      int ret = loop.Wait(1s);
-      if (ret < 0)
-        return 0;
-    }
-
-    // Fill in exactly the requested number of frames. If we don't have enough,
-    // don't queue the buffer yet. Important for passthrough, and also for pcm
-    // since we didn't request extra buffers when creating stream.
-    pw_buffer* buffer = m_stream->GetBuffer();
-    if (!buffer)
-      return 0;
-
-    spa_buffer* spaBuffer = buffer->buffer;
-    spa_data* spaData = &spaBuffer->datas[0];
-    unsigned int max_frames = spaData->maxsize / m_format.m_frameSize;
-    unsigned int requested = buffer->requested ? buffer->requested : frames;
-    unsigned int target = std::min(requested, max_frames);
-
-    if (buffer->size < target)
-    {
-      unsigned int consume = std::min(frames, static_cast<unsigned int>(target - buffer->size));
-      size_t length = consume * m_format.m_frameSize;
-      void* dst = static_cast<uint8_t*>(spaData->data) + buffer->size * m_format.m_frameSize;
-      void* src = data[0] + offset * m_format.m_frameSize;
-
-      std::memcpy(dst, src, length);
-
-      buffer->size += consume;
-      frames -= consume;
-      offset += consume;
-    }
-
-    if (buffer->size >= target)
-    {
-      spaData->chunk->offset = 0;
-      spaData->chunk->stride = m_format.m_frameSize;
-      spaData->chunk->size = buffer->size * m_format.m_frameSize;
-
-      m_stream->QueueBuffer();
+      // Ring buffer full — wait for on_process to consume data
+      if (!m_stream->WaitForSpace(1000ms))
+        return written_total;
     }
   }
 
@@ -677,15 +676,14 @@ void CAESinkPipewire::GetDelay(AEDelayStatus& status)
   PIPEWIRE::CLoopLockGuard lock(loop);
 
   pw_stream_state state = m_stream->GetState();
-
-  pw_time time = m_stream->GetTime();
-
   if (state != PW_STREAM_STATE_STREAMING)
     return;
 
-  pw_buffer* buffer = m_stream->PeekBuffer();
-  if (buffer)
-    time.queued += buffer->size;
+  pw_time time = m_stream->GetTime();
+
+  // Add ring buffer contents to queued count
+  unsigned int bufferedFrames = m_stream->GetRingBufferReadSize() / m_format.m_frameSize;
+  time.queued += bufferedFrames;
 
   const std::chrono::duration<double, std::ratio<1>> delay =
       PWTimeToAEDelay(time, m_format.m_sampleRate);

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -23,9 +23,11 @@
 #include <algorithm>
 
 #include <pipewire/keys.h>
+#include <pipewire/pipewire.h>
 #include <spa/param/audio/format-utils.h>
 #include <spa/param/audio/raw.h>
 #include <spa/pod/builder.h>
+#include <spa/utils/result.h>
 
 using namespace std::chrono_literals;
 
@@ -77,6 +79,31 @@ constexpr uint8_t PWFormatToSampleSize(spa_audio_format format)
       return 4;
     default:
       return 0;
+  }
+}
+
+constexpr std::string_view IEC958CodecToString(spa_audio_iec958_codec codec)
+{
+  switch (codec)
+  {
+    case SPA_AUDIO_IEC958_CODEC_PCM:
+      return "PCM";
+    case SPA_AUDIO_IEC958_CODEC_DTS:
+      return "DTS";
+    case SPA_AUDIO_IEC958_CODEC_AC3:
+      return "AC3";
+    case SPA_AUDIO_IEC958_CODEC_MPEG:
+      return "MPEG";
+    case SPA_AUDIO_IEC958_CODEC_MPEG2_AAC:
+      return "MPEG2-AAC";
+    case SPA_AUDIO_IEC958_CODEC_EAC3:
+      return "EAC3";
+    case SPA_AUDIO_IEC958_CODEC_TRUEHD:
+      return "TrueHD";
+    case SPA_AUDIO_IEC958_CODEC_DTSHD:
+      return "DTS-HD";
+    default:
+      return "Unknown";
   }
 }
 
@@ -489,9 +516,23 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
 
     params.emplace_back(spa_format_audio_iec958_build(&builder, SPA_PARAM_EnumFormat, &info));
 
-    flags = static_cast<pw_stream_flags>(PW_STREAM_FLAG_EXCLUSIVE | static_cast<int>(flags));
-
     format.m_dataFormat = AE_FMT_S16NE;
+
+    CLog::Log(LOGINFO, "CAESinkPipewire::{} - passthrough: codec={} rate={} channels={}",
+              __FUNCTION__, IEC958CodecToString(info.codec), info.rate, pwChannels.size());
+
+    // PipeWire passthrough was broken from 0.8.3 to 1.0.5 (server-side).
+    // Warn users on old versions so they don't spend hours debugging a known issue.
+    const char* pwVersion = pw_get_library_version();
+    int major = 0, minor = 0, micro = 0;
+    if (pwVersion && sscanf(pwVersion, "%d.%d.%d", &major, &minor, &micro) == 3)
+    {
+      if (major < 1 || (major == 1 && minor == 0 && micro < 6))
+        CLog::Log(LOGWARNING,
+                  "CAESinkPipewire::{} - PipeWire {} may not support passthrough correctly. "
+                  "Version 1.0.6 or later is recommended.",
+                  __FUNCTION__, pwVersion);
+    }
   }
 
   if (!m_stream->Connect(id, PW_DIRECTION_OUTPUT, params, flags))

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -499,16 +499,25 @@ bool CAESinkPipewire::Initialize(AEAudioFormat& format, std::string& device)
   pw_stream_state state;
   do
   {
-    state = m_stream->GetState();
+    const char* error = nullptr;
+    state = m_stream->GetState(&error);
     if (state == PW_STREAM_STATE_PAUSED)
       break;
 
-    CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - waiting", __FUNCTION__);
+    if (state == PW_STREAM_STATE_ERROR)
+    {
+      CLog::Log(LOGWARNING, "CAESinkPipewire::{} - stream entered error state during init: {}",
+                __FUNCTION__, error ? error : "unknown");
+      return false;
+    }
+
+    CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - waiting (state: {})", __FUNCTION__,
+              pw_stream_state_as_string(state));
 
     int ret = loop.Wait(5s);
     if (ret == -ETIMEDOUT)
     {
-      CLog::Log(LOGDEBUG, "CAESinkPipewire::{} - timed out waiting for stream to be paused",
+      CLog::Log(LOGWARNING, "CAESinkPipewire::{} - timed out waiting for stream to be paused",
                 __FUNCTION__);
       return false;
     }
@@ -544,6 +553,10 @@ unsigned int CAESinkPipewire::AddPackets(uint8_t** data,
                                          unsigned int frames_in,
                                          unsigned int offset)
 {
+  // Stream error/disconnect: return 0 immediately to trigger ActiveAESink recovery
+  if (m_stream->HasStreamError())
+    return 0;
+
   unsigned int frames = frames_in;
 
   auto& loop = pipewire->GetThreadLoop();

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.cpp
@@ -324,17 +324,28 @@ void CAESinkPipewire::EnumerateDevicesEx(AEDeviceInfoList& list, bool force)
                   [&device](const auto& rate) { device.m_sampleRates.emplace_back(rate); });
 
     auto& channels = node->GetChannels();
-    if (channels.empty())
+    auto& iec958Codecs = node->GetIEC958Codecs();
+
+    // Skip nodes that have neither channel info nor IEC958 codec support
+    if (channels.empty() && iec958Codecs.empty())
       continue;
 
-    for (const auto& channel : channels)
+    if (!channels.empty())
     {
-      const auto ch = channelMap.find(channel);
-      if (ch != channelMap.cend())
-        device.m_channels += ch->second;
+      for (const auto& channel : channels)
+      {
+        const auto ch = channelMap.find(channel);
+        if (ch != channelMap.cend())
+          device.m_channels += ch->second;
+      }
+    }
+    else
+    {
+      // IEC958-only node: set default channel layout so the device is visible
+      device.m_channels = CAEChannelInfo(AE_CH_LAYOUT_2_0);
     }
 
-    for (const auto& iec958Codec : node->GetIEC958Codecs())
+    for (const auto& iec958Codec : iec958Codecs)
     {
       auto streamTypes = PWIEC958CodecToAEStreamInfoDataTypeList(iec958Codec);
       device.m_streamTypes.insert(device.m_streamTypes.end(), streamTypes.begin(),

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/AESinkPipewire.h
@@ -52,6 +52,8 @@ public:
 private:
   AEAudioFormat m_format;
   std::chrono::duration<double, std::ratio<1>> m_latency;
+  uint32_t m_bufferSize{0};
+  uint32_t m_stride{0};
 
   std::unique_ptr<KODI::PIPEWIRE::CPipewireStream> m_stream;
 };

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -13,8 +13,10 @@
 #include "PipewireThreadLoop.h"
 #include "utils/log.h"
 
+#include <cstring>
 #include <stdexcept>
 
+#include <spa/param/param.h>
 #include <spa/utils/result.h>
 
 using namespace KODI;
@@ -22,10 +24,7 @@ using namespace PIPEWIRE;
 
 CPipewireStream::CPipewireStream(CPipewireCore& core)
   : m_core(core),
-    m_streamEvents(CreateStreamEvents()),
-    m_buffer(nullptr),
-    m_waiting(false),
-    m_running(false)
+    m_streamEvents(CreateStreamEvents())
 {
   m_stream.reset(pw_stream_new(core.Get(), nullptr, pw_properties_new(nullptr, nullptr)));
   if (!m_stream)
@@ -39,19 +38,8 @@ CPipewireStream::CPipewireStream(CPipewireCore& core)
 
 void CPipewireStream::Stop()
 {
-  using namespace std::chrono_literals;
-  auto& loop = GetCore().GetContext().GetThreadLoop();
-
-  // Stop blocking in Process(), nothing produces samples any more
   m_running = false;
-
-  // If Process() is blocking, wake it up
-  if (m_waiting)
-  {
-    loop.Accept();
-    while (m_waiting)
-      loop.Wait(1s);
-  }
+  m_dataConsumed.notify_all();
 }
 
 CPipewireStream::~CPipewireStream()
@@ -87,48 +75,22 @@ pw_stream_state CPipewireStream::GetState(const char** error)
 
 void CPipewireStream::SetActive(bool active)
 {
-  if (!active)
+  if (active)
+  {
+    // Reset ring buffer under lock (as documented in AERingBuffer.h)
+    {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      if (m_ringBuffer)
+        m_ringBuffer->Reset();
+    }
+    m_streamError = false;
+    m_running = true;
+  }
+  else
+  {
     Stop();
+  }
   pw_stream_set_active(m_stream.get(), active);
-  m_running = active;
-}
-
-pw_buffer* CPipewireStream::PeekBuffer()
-{
-  return m_buffer;
-}
-
-pw_buffer* CPipewireStream::GetBuffer()
-{
-  if (!m_buffer)
-  {
-    m_buffer = pw_stream_dequeue_buffer(m_stream.get());
-    if (m_buffer)
-      m_buffer->size = 0;
-  }
-  return m_buffer;
-}
-
-void CPipewireStream::QueueBuffer()
-{
-  auto& loop = GetCore().GetContext().GetThreadLoop();
-
-  if (!m_buffer)
-    return;
-
-  pw_stream_queue_buffer(m_stream.get(), m_buffer);
-  m_buffer = nullptr;
-
-  if (m_waiting)
-  {
-    m_waiting = false;
-    loop.Accept();
-  }
-}
-
-bool CPipewireStream::NeedsData() const
-{
-  return m_waiting;
 }
 
 void CPipewireStream::Flush(bool drain)
@@ -155,6 +117,53 @@ pw_time CPipewireStream::GetTime() const
   return time;
 }
 
+// Ring buffer methods
+
+void CPipewireStream::InitRingBuffer(uint32_t size, uint32_t frameSize)
+{
+  m_frameSize = frameSize;
+  m_ringBuffer = std::make_unique<AERingBuffer>(size);
+}
+
+unsigned int CPipewireStream::Write(const uint8_t* data, unsigned int frames)
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (!m_ringBuffer)
+    return 0;
+
+  uint32_t bytesToWrite = frames * m_frameSize;
+  uint32_t space = m_ringBuffer->GetWriteSize();
+  uint32_t toWrite = std::min(bytesToWrite, space);
+  uint32_t writtenFrames = toWrite / m_frameSize;
+  toWrite = writtenFrames * m_frameSize; // align to frame boundary
+
+  if (writtenFrames > 0)
+    m_ringBuffer->Write(const_cast<unsigned char*>(data), toWrite);
+
+  return writtenFrames;
+}
+
+bool CPipewireStream::WaitForSpace(std::chrono::milliseconds timeout)
+{
+  std::unique_lock<std::mutex> lock(m_mutex);
+  return m_dataConsumed.wait_for(lock, timeout,
+                                 [this]
+                                 {
+                                   return !m_ringBuffer ||
+                                          m_ringBuffer->GetWriteSize() >= m_frameSize ||
+                                          !m_running || m_streamError;
+                                 });
+}
+
+unsigned int CPipewireStream::GetRingBufferReadSize() const
+{
+  if (!m_ringBuffer)
+    return 0;
+  return m_ringBuffer->GetReadSize();
+}
+
+// PipeWire callbacks
+
 void CPipewireStream::StateChanged(void* userdata,
                                    enum pw_stream_state old,
                                    enum pw_stream_state state,
@@ -175,37 +184,92 @@ void CPipewireStream::StateChanged(void* userdata,
     stream.m_streamError = true;
     CLog::Log(LOGWARNING, "CPipewireStream::{} - stream error: {}", __FUNCTION__,
               error ? error : "unknown");
+    // Unblock WaitForSpace so AddPackets returns immediately
+    stream.m_dataConsumed.notify_all();
   }
 
   if (state == PW_STREAM_STATE_UNCONNECTED && old != PW_STREAM_STATE_UNCONNECTED)
   {
     stream.m_streamError = true;
     CLog::Log(LOGWARNING, "CPipewireStream::{} - stream disconnected", __FUNCTION__);
+    stream.m_dataConsumed.notify_all();
   }
 
   loop.Signal(false);
 }
 
-void CPipewireStream::Process(void* userdata)
+void CPipewireStream::ParamChanged(void* userdata, uint32_t id, const struct spa_pod* param)
 {
   auto& stream = *reinterpret_cast<CPipewireStream*>(userdata);
   auto& loop = stream.GetCore().GetContext().GetThreadLoop();
 
-  // Block thread loop until there is enough data.
-  // This is allowed since we are running without PW_STREAM_FLAG_RT_PROCESS.
-  stream.m_waiting = stream.m_running;
-  while (stream.m_waiting)
+  if (id == SPA_PARAM_Format && param != nullptr)
   {
-    if (!stream.m_running)
-    {
-      stream.m_waiting = false;
-      loop.Signal(false);
-      return;
-    }
+    CLog::Log(LOGDEBUG, "CPipewireStream::{} - format negotiated", __FUNCTION__);
 
-    // Wake up AddPackets() and wait for notify from QueueBuffer()
-    loop.Signal(true);
+    if (stream.m_paramChangedCallback)
+      stream.m_paramChangedCallback(id, param);
+
+    stream.m_formatNegotiated = true;
   }
+
+  // Latency param indicates the stream node is linked (mpv pattern)
+  if (id == SPA_PARAM_Latency)
+    loop.Signal(false);
+}
+
+void CPipewireStream::Process(void* userdata)
+{
+  auto& stream = *reinterpret_cast<CPipewireStream*>(userdata);
+
+  pw_buffer* b = pw_stream_dequeue_buffer(stream.m_stream.get());
+  if (!b)
+    return;
+
+  spa_buffer* buf = b->buffer;
+  spa_data* d = &buf->datas[0];
+
+  if (stream.m_frameSize == 0 || !d->data)
+  {
+    pw_stream_queue_buffer(stream.m_stream.get(), b);
+    return;
+  }
+
+  uint32_t maxFrames = d->maxsize / stream.m_frameSize;
+  uint32_t requested = b->requested ? b->requested : maxFrames;
+  uint32_t target = std::min(requested, maxFrames);
+
+  uint32_t toRead = 0;
+  {
+    std::lock_guard<std::mutex> lock(stream.m_mutex);
+    if (stream.m_ringBuffer)
+    {
+      uint32_t available = stream.m_ringBuffer->GetReadSize() / stream.m_frameSize;
+      toRead = std::min(target, available);
+
+      if (toRead > 0)
+        stream.m_ringBuffer->Read(static_cast<unsigned char*>(d->data),
+                                  toRead * stream.m_frameSize);
+    }
+  }
+
+  // Fill remainder with silence to prevent graph stall
+  if (toRead < target)
+  {
+    std::memset(static_cast<uint8_t*>(d->data) + toRead * stream.m_frameSize, 0,
+                (target - toRead) * stream.m_frameSize);
+    toRead = target;
+  }
+
+  d->chunk->offset = 0;
+  d->chunk->stride = stream.m_frameSize;
+  d->chunk->size = toRead * stream.m_frameSize;
+  b->size = toRead;
+
+  pw_stream_queue_buffer(stream.m_stream.get(), b);
+
+  // Signal AddPackets that space is available in the ring buffer
+  stream.m_dataConsumed.notify_one();
 }
 
 void CPipewireStream::Drained(void* userdata)
@@ -220,11 +284,22 @@ void CPipewireStream::Drained(void* userdata)
   loop.Signal(false);
 }
 
+void CPipewireStream::SetParamChangedCallback(ParamChangedCallback callback)
+{
+  m_paramChangedCallback = std::move(callback);
+}
+
+int CPipewireStream::UpdateParams(const spa_pod** params, uint32_t n_params)
+{
+  return pw_stream_update_params(m_stream.get(), params, n_params);
+}
+
 pw_stream_events CPipewireStream::CreateStreamEvents()
 {
   pw_stream_events streamEvents = {};
   streamEvents.version = PW_VERSION_STREAM_EVENTS;
   streamEvents.state_changed = StateChanged;
+  streamEvents.param_changed = ParamChanged;
   streamEvents.process = Process;
   streamEvents.drained = Drained;
 

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.cpp
@@ -80,6 +80,11 @@ pw_stream_state CPipewireStream::GetState()
   return pw_stream_get_state(m_stream.get(), nullptr);
 }
 
+pw_stream_state CPipewireStream::GetState(const char** error)
+{
+  return pw_stream_get_state(m_stream.get(), error);
+}
+
 void CPipewireStream::SetActive(bool active)
 {
   if (!active)
@@ -165,8 +170,18 @@ void CPipewireStream::StateChanged(void* userdata,
     CLog::Log(LOGDEBUG, "CPipewireStream::{} - stream node {}", __FUNCTION__, stream.GetNodeId());
 
   if (state == PW_STREAM_STATE_ERROR)
-    CLog::Log(LOGDEBUG, "CPipewireStream::{} - stream node {} error: {}", __FUNCTION__,
-              stream.GetNodeId(), error);
+  {
+    stream.m_initError = true;
+    stream.m_streamError = true;
+    CLog::Log(LOGWARNING, "CPipewireStream::{} - stream error: {}", __FUNCTION__,
+              error ? error : "unknown");
+  }
+
+  if (state == PW_STREAM_STATE_UNCONNECTED && old != PW_STREAM_STATE_UNCONNECTED)
+  {
+    stream.m_streamError = true;
+    CLog::Log(LOGWARNING, "CPipewireStream::{} - stream disconnected", __FUNCTION__);
+  }
 
   loop.Signal(false);
 }

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <vector>
 
@@ -38,6 +39,9 @@ public:
                const pw_stream_flags& flags);
 
   pw_stream_state GetState();
+  pw_stream_state GetState(const char** error);
+  bool HasInitError() const { return m_initError; }
+  bool HasStreamError() const { return m_streamError; }
   void SetActive(bool active);
 
   pw_buffer* GetBuffer();
@@ -75,6 +79,8 @@ private:
 
   bool m_waiting;
   bool m_running;
+  bool m_initError{false};
+  std::atomic<bool> m_streamError{false};
 
   struct PipewireStreamDeleter
   {

--- a/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
+++ b/xbmc/cores/AudioEngine/Sinks/pipewire/PipewireStream.h
@@ -8,12 +8,19 @@
 
 #pragma once
 
+#include "cores/AudioEngine/Utils/AERingBuffer.h"
+
 #include <atomic>
+#include <condition_variable>
+#include <functional>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include <pipewire/core.h>
 #include <pipewire/stream.h>
+
+struct spa_pod;
 
 namespace KODI
 {
@@ -44,10 +51,6 @@ public:
   bool HasStreamError() const { return m_streamError; }
   void SetActive(bool active);
 
-  pw_buffer* GetBuffer();
-  pw_buffer* PeekBuffer();
-  void QueueBuffer();
-
   void Flush(bool drain);
 
   uint32_t GetNodeId();
@@ -56,13 +59,23 @@ public:
 
   pw_time GetTime() const;
 
-  bool NeedsData() const;
+  using ParamChangedCallback = std::function<void(uint32_t id, const spa_pod* param)>;
+  void SetParamChangedCallback(ParamChangedCallback callback);
+  bool IsFormatNegotiated() const { return m_formatNegotiated; }
+  int UpdateParams(const spa_pod** params, uint32_t n_params);
+
+  // Ring buffer interface for RT_PROCESS data delivery
+  void InitRingBuffer(uint32_t size, uint32_t frameSize);
+  unsigned int Write(const uint8_t* data, unsigned int frames);
+  bool WaitForSpace(std::chrono::milliseconds timeout);
+  unsigned int GetRingBufferReadSize() const;
 
 private:
   static void StateChanged(void* userdata,
                            enum pw_stream_state old,
                            enum pw_stream_state state,
                            const char* error);
+  static void ParamChanged(void* userdata, uint32_t id, const struct spa_pod* param);
   static void Process(void* userdata);
   static void Drained(void* userdata);
   void Stop();
@@ -75,12 +88,17 @@ private:
 
   spa_hook m_streamListener;
 
-  pw_buffer* m_buffer;
-
-  bool m_waiting;
-  bool m_running;
   bool m_initError{false};
+  bool m_formatNegotiated{false};
   std::atomic<bool> m_streamError{false};
+  ParamChangedCallback m_paramChangedCallback;
+
+  // Ring buffer for decoupling audio engine thread from PipeWire RT thread
+  std::unique_ptr<AERingBuffer> m_ringBuffer;
+  std::mutex m_mutex;
+  std::condition_variable m_dataConsumed; // signaled when on_process drains data
+  std::atomic<bool> m_running{false};
+  uint32_t m_frameSize{0};
 
   struct PipewireStreamDeleter
   {


### PR DESCRIPTION
## Description

Refactor the PipeWire audio sink to fix TrueHD and DTS-HD Master Audio passthrough over HDMI on Linux. Four commits, each independently reviewable:

1. **Error detection** — Detect `PW_STREAM_STATE_ERROR` in `Initialize()` loop (previously silent 5s timeout). Handle runtime `ERROR` and `UNCONNECTED` in `StateChanged`, unblocking `AddPackets` immediately for ~500ms recovery instead of ~5s.

2. **Node enumeration** — HDMI nodes advertising only IEC958 codecs (no PCM channel info) were skipped by `channels.empty()`, hiding passthrough devices from settings. Now enumerated with a default 2.0 channel layout.

3. **Remove EXCLUSIVE, add logging** — Remove unconditional `PW_STREAM_FLAG_EXCLUSIVE` for passthrough. PipeWire enters passthrough mode based on the IEC958 format pod, not the EXCLUSIVE flag (`stream.h` lines 477-478). Add passthrough-specific `LOGINFO` with codec type, rate, and channel count. Add `pw_get_library_version()` warning for PipeWire < 1.0.6.

4. **Defer buffer params + RT_PROCESS + ring buffer** — Defer buffer params to `param_changed` callback per PipeWire API spec (`stream.h` lines 83-97). Enable `PW_STREAM_FLAG_RT_PROCESS` with `AERingBuffer` pull model, replacing the old blocking `Process()` that violated RT-safety (`stream.h` lines 473-475).

**Companion PR:** #28115 (ALSA AES3 fix). That PR is independent of this one but together they provide the complete fix for #21135.

## Motivation and context

Related to https://github.com/xbmc/xbmc/issues/21135 — TrueHD and DTS-HD MA passthrough not working on Linux.

## How has this been tested?

Full Kodi build on Debian 13 (Trixie), g++ 14.2.0, PipeWire 1.4.2. Zero warnings under `-Wall -Wextra -Werror=sign-compare -Werror=missing-field-initializers -Werror=double-promotion`.

> **Note:** Hardware testing on HDMI + AVR is needed before merging. If anyone with an AMD or Intel GPU connected via HDMI to a TrueHD/DTS-HD MA capable receiver could test a build from this branch (ideally together with the companion ALSA PR), that would be very helpful.

**Hardware test matrix (community help welcome):**
- [ ] PCM stereo/5.1/7.1 — no regressions
- [ ] AC3 passthrough — AVR shows "Dolby Digital"
- [ ] TrueHD passthrough — AVR shows "Dolby TrueHD"
- [ ] DTS-HD MA passthrough — AVR shows "DTS-HD MA"
- [ ] Extended playback 30+ min — no audio drops
- [ ] `pw-top` — zero xruns during passthrough

**PipeWire pre-flight checks:**
- Requires PipeWire >= 1.0.6 (`pw-cli --version`)
- Verify IEC958 codec support (`pw-dump | grep -i iec958`)
- Verify 8-channel ALSA support (`aplay -l | grep HDMI`)

## What is the effect on users?

Users with HDMI audio setups on Linux should be able to use TrueHD and DTS-HD Master Audio passthrough through PipeWire. Previously, passthrough settings were hidden when PipeWire was enabled, format negotiation failures caused silent 5s timeouts, and stream disconnects took ~5s to recover from.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
