### PR TITLE
FFmpeg Chapters Improvements

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -1,6 +1,7 @@
 xbmc/addons/gui/skin/test         test/skin
 xbmc/addons/test                  test/addons
 xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
+xbmc/cores/VideoPlayer/DVDDemuxers/test test/dvddemuxers
 xbmc/cores/VideoPlayer/Edl/test   test/edl
 xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test test/videoshaders
 xbmc/dbwrappers/test              test/dbwrappers

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -455,6 +455,12 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
   // Avoid detecting framerate if advancedsettings.xml says so
   if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_videoFpsDetect == 0)
       m_pFormatContext->fps_probe_size = 0;
+
+  if (m_pFormatContext->nb_chapters && m_pFormatContext->chapters != nullptr)
+  {
+    m_chapters = CDVDDemuxUtils::LoadChapters(
+        std::span<AVChapter*>{m_pFormatContext->chapters, m_pFormatContext->nb_chapters});
+  }
 
   // analyse very short to speed up mjpeg playback start
   if (iformat && (strcmp(iformat->name, "mjpeg") == 0) && m_ioContext->seekable == 0)
@@ -2015,10 +2021,7 @@ int CDVDDemuxFFmpeg::GetChapterCount()
   if (ich)
     return ich->GetChapterCount();
 
-  if (m_pFormatContext == NULL)
-    return 0;
-
-  return m_pFormatContext->nb_chapters;
+  return m_chapters.size();
 }
 
 int CDVDDemuxFFmpeg::GetChapter()
@@ -2027,25 +2030,22 @@ int CDVDDemuxFFmpeg::GetChapter()
   if (ich)
     return ich->GetChapter();
 
-  if (m_pFormatContext == NULL || m_currentPts == DVD_NOPTS_VALUE)
+  if (m_chapters.empty() || m_currentPts == DVD_NOPTS_VALUE)
     return 0;
 
-  for (unsigned i = 0; i < m_pFormatContext->nb_chapters; i++)
+  const auto chapterCount = static_cast<unsigned int>(m_chapters.size());
+  for (unsigned i = 0; i < chapterCount; i++)
   {
-    const AVChapter* chapter = m_pFormatContext->chapters[i];
-    const double startPts =
-        ConvertTimestamp(chapter->start, chapter->time_base.den, chapter->time_base.num);
+    const double startPts = m_chapters[i].m_startPts;
 
-    if (i == m_pFormatContext->nb_chapters - 1)
+    if (i == chapterCount - 1)
     {
       if (m_currentPts >= startPts)
         return i + 1;
     }
     else
     {
-      const AVChapter* nextChapter = m_pFormatContext->chapters[i + 1];
-      const double nextStartPts = ConvertTimestamp(nextChapter->start, nextChapter->time_base.den,
-                                                   nextChapter->time_base.num);
+      const double nextStartPts = m_chapters[i + 1].m_startPts;
 
       if (m_currentPts >= startPts && m_currentPts < nextStartPts)
         return i + 1;
@@ -2067,10 +2067,7 @@ void CDVDDemuxFFmpeg::GetChapterName(std::string& strChapterName, int chapterIdx
     if (chapterIdx <= 0)
       return;
 
-    AVDictionaryEntry* titleTag = av_dict_get(m_pFormatContext->chapters[chapterIdx - 1]->metadata,
-                                                          "title", NULL, 0);
-    if (titleTag)
-      strChapterName = titleTag->value;
+    strChapterName = m_chapters[chapterIdx - 1].m_name;
   }
 }
 
@@ -2087,8 +2084,7 @@ std::chrono::milliseconds CDVDDemuxFFmpeg::GetChapterPos(int chapterIdx)
   if (ich)
     return ich->GetChapterPos(chapterIdx);
 
-  std::chrono::duration<float> fsec(m_pFormatContext->chapters[chapterIdx - 1]->start *
-                                    av_q2d(m_pFormatContext->chapters[chapterIdx - 1]->time_base));
+  std::chrono::duration<float> fsec(m_chapters[chapterIdx - 1].m_startPts);
   return std::chrono::duration_cast<std::chrono::milliseconds>(fsec);
 }
 
@@ -2114,15 +2110,10 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
     return true;
   }
 
-  if (m_pFormatContext == NULL)
+  if (chapter < 1 || m_chapters.empty() || chapter > static_cast<int>(m_chapters.size()))
     return false;
 
-  if (chapter < 1 || chapter > (int)m_pFormatContext->nb_chapters)
-    return false;
-
-  const AVChapter* ch = m_pFormatContext->chapters[chapter - 1];
-  const double pts = ch->start * av_q2d(ch->time_base);
-  return SeekTime(pts * 1000, true, startpts);
+  return SeekTime(m_chapters[chapter - 1].m_startPts * 1000, true, startpts);
 }
 
 std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -2034,20 +2034,22 @@ int CDVDDemuxFFmpeg::GetChapter()
     return 0;
 
   const auto chapterCount = static_cast<unsigned int>(m_chapters.size());
+  const auto currentPts = std::chrono::milliseconds(DVD_TIME_TO_MSEC(m_currentPts));
+
   for (unsigned i = 0; i < chapterCount; i++)
   {
-    const double startPts = m_chapters[i].m_startPts;
+    const std::chrono::milliseconds startPts = m_chapters[i].m_startPts;
 
     if (i == chapterCount - 1)
     {
-      if (m_currentPts >= startPts)
+      if (currentPts >= startPts)
         return i + 1;
     }
     else
     {
-      const double nextStartPts = m_chapters[i + 1].m_startPts;
+      const std::chrono::milliseconds nextStartPts = m_chapters[i + 1].m_startPts;
 
-      if (m_currentPts >= startPts && m_currentPts < nextStartPts)
+      if (currentPts >= startPts && currentPts < nextStartPts)
         return i + 1;
     }
   }
@@ -2084,8 +2086,7 @@ std::chrono::milliseconds CDVDDemuxFFmpeg::GetChapterPos(int chapterIdx)
   if (ich)
     return ich->GetChapterPos(chapterIdx);
 
-  std::chrono::duration<float> fsec(m_chapters[chapterIdx - 1].m_startPts);
-  return std::chrono::duration_cast<std::chrono::milliseconds>(fsec);
+  return m_chapters[chapterIdx - 1].m_startPts;
 }
 
 bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
@@ -2113,7 +2114,10 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
   if (chapter < 1 || m_chapters.empty() || chapter > static_cast<int>(m_chapters.size()))
     return false;
 
-  return SeekTime(m_chapters[chapter - 1].m_startPts * 1000, true, startpts);
+  return SeekTime(
+      std::chrono::duration_cast<std::chrono::milliseconds>(m_chapters[chapter - 1].m_startPts)
+          .count(),
+      true, startpts);
 }
 
 std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -2120,9 +2120,9 @@ bool CDVDDemuxFFmpeg::SeekChapter(int chapter, double* startpts)
   if (chapter < 1 || chapter > (int)m_pFormatContext->nb_chapters)
     return false;
 
-  AVChapter* ch = m_pFormatContext->chapters[chapter - 1];
-  double dts = ConvertTimestamp(ch->start, ch->time_base.den, ch->time_base.num);
-  return SeekTime(DVD_TIME_TO_MSEC(dts), true, startpts);
+  const AVChapter* ch = m_pFormatContext->chapters[chapter - 1];
+  const double pts = ch->start * av_q2d(ch->time_base);
+  return SeekTime(pts * 1000, true, startpts);
 }
 
 std::string CDVDDemuxFFmpeg::GetStreamCodecName(int iStreamId)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -2033,26 +2033,16 @@ int CDVDDemuxFFmpeg::GetChapter()
   if (m_chapters.empty() || m_currentPts == DVD_NOPTS_VALUE)
     return 0;
 
-  const auto chapterCount = static_cast<unsigned int>(m_chapters.size());
   const auto currentPts = std::chrono::milliseconds(DVD_TIME_TO_MSEC(m_currentPts));
+  const std::size_t end = m_chapters.size() - 1;
 
-  for (unsigned i = 0; i < chapterCount; i++)
+  for (std::size_t i = 0; i < end; ++i)
   {
-    const std::chrono::milliseconds startPts = m_chapters[i].m_startPts;
-
-    if (i == chapterCount - 1)
-    {
-      if (currentPts >= startPts)
-        return i + 1;
-    }
-    else
-    {
-      const std::chrono::milliseconds nextStartPts = m_chapters[i + 1].m_startPts;
-
-      if (currentPts >= startPts && currentPts < nextStartPts)
-        return i + 1;
-    }
+    if (currentPts >= m_chapters[i].m_startPts && currentPts < m_chapters[i + 1].m_startPts)
+      return i + 1;
   }
+  if (currentPts >= m_chapters[end].m_startPts)
+    return static_cast<int>(end + 1);
 
   return 0;
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -22,6 +22,7 @@ extern "C" {
 class CDVDDemuxFFmpeg;
 class CDVDInputStream;
 class CURL;
+struct ChapterFFmpeg;
 
 enum class TRANSPORT_STREAM_STATE
 {
@@ -178,5 +179,5 @@ protected:
   double m_dtsAtDisplayTime;
   bool m_seekToKeyFrame = false;
   double m_startTime = 0;
+  std::vector<ChapterFFmpeg> m_chapters;
 };
-

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
@@ -123,22 +123,24 @@ std::vector<ChapterFFmpeg> CDVDDemuxUtils::LoadChapters(std::span<AVChapter*> ch
 
   result.reserve(chapters.size());
 
-  std::ranges::transform(chapters, std::back_inserter(result),
-                         [](const AVChapter* chapter)
-                         {
-                           ChapterFFmpeg newChapter{};
+  std::ranges::transform(
+      chapters, std::back_inserter(result),
+      [](const AVChapter* chapter)
+      {
+        ChapterFFmpeg newChapter{};
 
-                           newChapter.m_startPts = chapter->start * av_q2d(chapter->time_base);
-                           newChapter.m_endPts = chapter->end * av_q2d(chapter->time_base);
+        std::chrono::duration<double> dsec(chapter->start * av_q2d(chapter->time_base));
+        newChapter.m_startPts = std::chrono::duration_cast<std::chrono::milliseconds>(dsec);
+        dsec = std::chrono::duration<double>(chapter->end * av_q2d(chapter->time_base));
+        newChapter.m_endPts = std::chrono::duration_cast<std::chrono::milliseconds>(dsec);
 
-                           const AVDictionaryEntry* titleTag =
-                               av_dict_get(chapter->metadata, "title", nullptr, 0);
+        const AVDictionaryEntry* titleTag = av_dict_get(chapter->metadata, "title", nullptr, 0);
 
-                           if (titleTag)
-                             newChapter.m_name = titleTag->value;
+        if (titleTag)
+          newChapter.m_name = titleTag->value;
 
-                           return newChapter;
-                         });
+        return newChapter;
+      });
 
   std::ranges::sort(result, std::less(), &ChapterFFmpeg::m_startPts);
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
@@ -116,6 +116,8 @@ void CDVDDemuxUtils::StoreSideData(DemuxPacket *pkt, AVPacket *src)
 
 std::vector<ChapterFFmpeg> CDVDDemuxUtils::LoadChapters(std::span<AVChapter*> chapters)
 {
+  using namespace std::chrono_literals;
+
   std::vector<ChapterFFmpeg> result;
 
   if (chapters.empty() || chapters.data() == nullptr)
@@ -143,6 +145,10 @@ std::vector<ChapterFFmpeg> CDVDDemuxUtils::LoadChapters(std::span<AVChapter*> ch
       });
 
   std::ranges::sort(result, std::less(), &ChapterFFmpeg::m_startPts);
+
+  // Videoplayer expects the first chapter to start at 00:00:00 - make one up if needed.
+  if (result.front().m_startPts != 0ms)
+    result.insert(result.begin(), ChapterFFmpeg{0ms, 0ms, ""});
 
   return result;
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -12,9 +12,13 @@
 #include "utils/MemUtils.h"
 #include "utils/log.h"
 
-extern "C" {
+extern "C"
+{
 #include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
 }
+
+#include <algorithm>
 
 void CDVDDemuxUtils::FreeDemuxPacket(DemuxPacket* pPacket)
 {
@@ -108,4 +112,35 @@ void CDVDDemuxUtils::StoreSideData(DemuxPacket *pkt, AVPacket *src)
   // and storing our own AVPacket. This will require some extensive changes.
   av_buffer_unref(&avPkt->buf);
   av_free(avPkt);
+}
+
+std::vector<ChapterFFmpeg> CDVDDemuxUtils::LoadChapters(std::span<AVChapter*> chapters)
+{
+  std::vector<ChapterFFmpeg> result;
+
+  if (chapters.empty() || chapters.data() == nullptr)
+    return result;
+
+  result.reserve(chapters.size());
+
+  std::ranges::transform(chapters, std::back_inserter(result),
+                         [](const AVChapter* chapter)
+                         {
+                           ChapterFFmpeg newChapter{};
+
+                           newChapter.m_startPts = chapter->start * av_q2d(chapter->time_base);
+                           newChapter.m_endPts = chapter->end * av_q2d(chapter->time_base);
+
+                           const AVDictionaryEntry* titleTag =
+                               av_dict_get(chapter->metadata, "title", nullptr, 0);
+
+                           if (titleTag)
+                             newChapter.m_name = titleTag->value;
+
+                           return newChapter;
+                         });
+
+  std::ranges::sort(result, std::less(), &ChapterFFmpeg::m_startPts);
+
+  return result;
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h
@@ -10,6 +10,7 @@
 
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
 
+#include <chrono>
 #include <span>
 #include <string>
 #include <vector>
@@ -21,8 +22,8 @@ struct ChapterFFmpeg
 {
   bool operator==(const ChapterFFmpeg&) const = default;
 
-  double m_startPts; // movie time, in seconds
-  double m_endPts; // movie time, in seconds
+  std::chrono::milliseconds m_startPts;
+  std::chrono::milliseconds m_endPts;
   std::string m_name;
 };
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -9,16 +9,30 @@
 #pragma once
 
 #include "cores/VideoPlayer/Interface/DemuxPacket.h"
-extern "C" {
-#include <libavcodec/avcodec.h>
-}
+
+#include <span>
+#include <string>
+#include <vector>
+
+struct AVChapter;
+struct AVPacket;
+
+struct ChapterFFmpeg
+{
+  bool operator==(const ChapterFFmpeg&) const = default;
+
+  double m_startPts; // movie time, in seconds
+  double m_endPts; // movie time, in seconds
+  std::string m_name;
+};
 
 class CDVDDemuxUtils
 {
 public:
   static void FreeDemuxPacket(DemuxPacket* pPacket);
   static DemuxPacket* AllocateDemuxPacket(int iDataSize = 0);
-  static DemuxPacket* AllocateDemuxPacket(unsigned int iDataSize, unsigned int encryptedSubsampleCount);
-  static void StoreSideData(DemuxPacket *pkt, AVPacket *src);
+  static DemuxPacket* AllocateDemuxPacket(unsigned int iDataSize,
+                                          unsigned int encryptedSubsampleCount);
+  static void StoreSideData(DemuxPacket* pkt, AVPacket* src);
+  static std::vector<ChapterFFmpeg> LoadChapters(std::span<AVChapter*> chapters);
 };
-

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/test/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestDVDDemuxUtils.cpp)
+
+core_add_test_library(dvddemuxers_test)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxUtils.cpp
@@ -18,6 +18,8 @@ extern "C"
 #include <libavformat/avformat.h>
 }
 
+using namespace std::chrono_literals;
+
 struct TestAVChapter
 {
   int timebasenum;
@@ -36,21 +38,21 @@ struct TestChapter
 // clang-format off
 const TestChapter testChapters[] = {
   {{{{1, 1, 0, 1, "A"}, {1, 1, 1, 2, "B"}}},
-    {{{0.0, 1.0, "A"}, {1.0, 2.0, "B"}}}},
+    {{{0s, 1s, "A"}, {1s, 2s, "B"}}}},
   // Test timebase
   {{{{1, 1000, 0, 10000, "A"}, {20, 500, 250, 500, "B"}}},
-    {{{0.0, 10.0, "A"}, {10.0, 20.0, "B"}}}},
+    {{{0s, 10s, "A"}, {10s, 20s, "B"}}}},
   // Overlapping chapters
   {{{{1, 1, 0, 11, "A"}, {1, 1, 10, 20, "B"}}},
-    {{{0.0, 11.0, "A"}, {10.0, 20.0, "B"}}}},
+    {{{0s, 11s, "A"}, {10s, 20s, "B"}}}},
   // Chapter markers
   {{{{1, 1, 0, 0, "A"}, {1, 1, 10, 10, "B"}}},
-    {{{0.0, 0.0, "A"}, {10.0, 10.0, "B"}}}},
+    {{{0s, 0s, "A"}, {10s, 10s, "B"}}}},
   {{{{1, 1, 0, 0, "A"}, {1, 1, 10, 0, "B"}}},
-    {{{0.0, 0.0, "A"}, {10.0, 0.0, "B"}}}},
+    {{{0s, 0s, "A"}, {10s, 0s, "B"}}}},
   // Out of order chapters
   {{{{1, 1, 10, 20, "B"}, {1, 1, 0, 10, "A"}}},
-    {{{0.0, 10.0, "A"}, {10.0, 20.0, "B"}}}},
+    {{{0s, 10s, "A"}, {10s, 20s, "B"}}}},
 };
 // clang-format on
 

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxUtils.cpp
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h"
+
+#include <algorithm>
+#include <string>
+
+#include <gtest/gtest.h>
+
+extern "C"
+{
+#include <libavformat/avformat.h>
+}
+
+struct TestAVChapter
+{
+  int timebasenum;
+  int timebaseden;
+  int64_t start;
+  int64_t end;
+  std::string title;
+};
+
+struct TestChapter
+{
+  std::vector<TestAVChapter> input;
+  std::vector<ChapterFFmpeg> expected;
+};
+
+// clang-format off
+const TestChapter testChapters[] = {
+  {{{{1, 1, 0, 1, "A"}, {1, 1, 1, 2, "B"}}},
+    {{{0.0, 1.0, "A"}, {1.0, 2.0, "B"}}}},
+  // Test timebase
+  {{{{1, 1000, 0, 10000, "A"}, {20, 500, 250, 500, "B"}}},
+    {{{0.0, 10.0, "A"}, {10.0, 20.0, "B"}}}},
+  // Overlapping chapters
+  {{{{1, 1, 0, 11, "A"}, {1, 1, 10, 20, "B"}}},
+    {{{0.0, 11.0, "A"}, {10.0, 20.0, "B"}}}},
+  // Chapter markers
+  {{{{1, 1, 0, 0, "A"}, {1, 1, 10, 10, "B"}}},
+    {{{0.0, 0.0, "A"}, {10.0, 10.0, "B"}}}},
+  {{{{1, 1, 0, 0, "A"}, {1, 1, 10, 0, "B"}}},
+    {{{0.0, 0.0, "A"}, {10.0, 0.0, "B"}}}},
+  // Out of order chapters
+  {{{{1, 1, 10, 20, "B"}, {1, 1, 0, 10, "A"}}},
+    {{{0.0, 10.0, "A"}, {10.0, 20.0, "B"}}}},
+};
+// clang-format on
+
+class ChapterLoaderTester : public testing::Test, public testing::WithParamInterface<TestChapter>
+{
+};
+
+TEST_P(ChapterLoaderTester, LoadChapters)
+{
+  auto& param = GetParam();
+
+  // Build a temporary AVChapter**, as it would be found in AVFormatContext::chapters
+  std::vector<AVChapter> avChapters;
+  avChapters.reserve(param.input.size());
+
+  std::ranges::transform(param.input, std::back_inserter(avChapters),
+                         [](const TestAVChapter& c)
+                         {
+                           AVChapter avc{.id = 0,
+                                         .time_base{.num = c.timebasenum, .den = c.timebaseden},
+                                         .start = c.start,
+                                         .end = c.end,
+                                         .metadata = nullptr};
+                           av_dict_set(&avc.metadata, "title", c.title.c_str(), 0);
+                           return avc;
+                         });
+
+  std::vector<AVChapter*> ptrAvChapters;
+  ptrAvChapters.reserve(avChapters.size());
+
+  std::ranges::transform(avChapters, std::back_inserter(ptrAvChapters),
+                         [](AVChapter& c) { return &c; });
+
+  std::vector<ChapterFFmpeg> actual =
+      CDVDDemuxUtils::LoadChapters(std::span<AVChapter*>{ptrAvChapters});
+
+  EXPECT_EQ(param.expected, actual);
+
+  // Cleanup ffmpeg allocated memory
+  std::ranges::for_each(avChapters, [](AVChapter& c) { av_dict_free(&c.metadata); });
+}
+
+INSTANTIATE_TEST_SUITE_P(TestDVDDemuxUtils, ChapterLoaderTester, testing::ValuesIn(testChapters));
+
+TEST(TestDVDDemuxUtils, ReadChaptersInvalid)
+{
+  AVChapter** noChapters = nullptr;
+  std::vector<ChapterFFmpeg> output =
+      CDVDDemuxUtils::LoadChapters(std::span<AVChapter*>{noChapters, 1});
+  EXPECT_TRUE(output.empty());
+
+  AVChapter avc;
+  AVChapter* avcptr = &avc;
+  output = CDVDDemuxUtils::LoadChapters(std::span<AVChapter*>{&avcptr, 0});
+  EXPECT_TRUE(output.empty());
+}

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxUtils.cpp
@@ -53,6 +53,9 @@ const TestChapter testChapters[] = {
   // Out of order chapters
   {{{{1, 1, 10, 20, "B"}, {1, 1, 0, 10, "A"}}},
     {{{0s, 10s, "A"}, {10s, 20s, "B"}}}},
+  // 1st chapter is not at 00:00:00
+  {{{{1, 1, 1, 2, "A"}}},
+    {{{0s, 0s, ""}, {1s, 2s, "A"}}}},
 };
 // clang-format on
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Improved handling of chapters read by ffmpeg.

- Most videos have their first chapter at 00:00:00, but it's not mandatory. "chapter or big step back" could not return to the beginning of videos with the first chapter after 00:00:00, but only to the start of the first chapter. Even if technically correct, it's not the user expectation.
ex. auto-generated chapters like this:
chapter 1 00:09:00.000
chapter 2 00:18:00.000
chapter 3 00:27:00.000
...
The solution is to add a virtual chapter at 00.00.00 when needed (last commit). This has the side-effect of adding 1 to the count of chapters.

- Chapters don't have to be defined in increasing timestamp order, even if it's common practice. Odd behavior on chapter jump / current chapter display resulted for the exceptions. ffmpeg has some limitations in that area as well and perfect results cannot be achieved.
for ex:
chapter 1 00:00:00.000 Intro
chapter 2 00:23:00.000 Outro
chapter 3 00:02:00.000 Part A
chapter 4 00:12:00.000 Part B
The chapters are now sorted by increasing timestamp and chapters are read only once from the AVFormatContext for efficency (middle commits)

- `CDVDDemuxFFmpeg::SeekChapter` was using `ConvertTimestamp` before calling `SeekTime`. That converted the timestamp to the correct timebase (milliseconds) but also subtracted the video's start_time,  which shouldn't be needed since chapters are in movie time, not track time (first commit) and `SeekTime` expects movie time from what I understood.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- inability to go back to the beginning of some movies with "chapter or big step back" - analysis showed that the first chapter of those videos was not at timestamp 00.00.00

- weird current chapter / chapter jump behavior for videos that don't have chapters defined in increasing start time.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added unit tests for the fixed issues
Playing the files that had issues works fine, some other random files had no change as expected.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

More dependable chapter jumps / current chapter display

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
