### PR TITLE
ActiveAE: verify sink supports EAC3 before selecting it for transcode

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1735,10 +1735,11 @@ void CActiveAE::ApplySettingsToFormat(AEAudioFormat& format,
     format.m_dataFormat = AE_FMT_RAW;
     format.m_sampleRate = 48000;
     format.m_channelLayout = AE_CH_LAYOUT_2_0;
-    format.m_streamInfo.m_type =
-        settings.eac3passthrough ? CAEStreamInfo::STREAM_TYPE_EAC3 : CAEStreamInfo::STREAM_TYPE_AC3;
     format.m_streamInfo.m_channels = 2;
     format.m_streamInfo.m_sampleRate = 48000;
+    format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_EAC3;
+    if (!settings.eac3passthrough || !m_sink.SupportsFormat(settings.passthroughdevice, format))
+      format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_AC3;
     if (mode)
       *mode = MODE_TRANSCODE;
   }


### PR DESCRIPTION
## Description
Fixes #28001

When ac3transcode is enabled and eac3passthrough is set, the transcode path selects EAC3 without checking whether the sink actually supports the required 192kHz IEC61937 transport rate. On devices where EAC3 passthrough is not possible (e.g. SPDIF-only receivers, AVRs without 192kHz PCM support), this causes audio sync errors because ALSA rejects the 192kHz open request.

The passthrough path already checks sink capability via SupportsRaw() which calls m_sink.SupportsFormat(). The transcode path was missing this check. Add a SupportsFormat() call before committing to EAC3 transcode, falling back to AC3 if the sink cannot handle it.

This also handles hot-plug scenarios where the user swaps audio equipment without restarting Kodi, since SupportsFormat() queries the current sink capabilities at stream setup time.

## Motivation and context
Fix #28001

## How has this been tested?
Intel CFL system with HDMI output

## What is the effect on users?
enable AC3 fallback even when EAC3 transcode is configured.

## Screenshots (if appropriate):
n/a

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
