### PR TITLE
GBM: enable YUV422 support for GL and GLES renderers

### DIFF
--- a/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag
+++ b/system/shaders/GLES/2.0/gles_yuv2rgb_basic.frag
@@ -64,6 +64,35 @@ void main()
              texture2D(m_sampV, m_cordV).g,
              1.0);
 
+#elif defined(XBMC_YUY2) || defined(XBMC_UYVY)
+
+  vec2 stepxy = m_step;
+  vec2 pos    = m_cordY;
+  pos         = vec2(pos.x - stepxy.x * 0.25, pos.y);
+  vec2 f      = fract(pos / stepxy);
+
+  //y axis will be correctly interpolated by opengl
+  //x axis will not, so we grab two pixels at the center of two columns and interpolate ourselves
+  vec4 c1 = texture2D(m_sampY, vec2(pos.x + (0.5 - f.x) * stepxy.x, pos.y));
+  vec4 c2 = texture2D(m_sampY, vec2(pos.x + (1.5 - f.x) * stepxy.x, pos.y));
+
+  /* each pixel has two Y subpixels and one UV subpixel
+     YUV  Y  YUV
+     check if we're left or right of the middle Y subpixel and interpolate accordingly*/
+#ifdef XBMC_YUY2 //BGRA = YUYV
+  float leftY   = mix(c1.b, c1.r, f.x * 2.0);
+  float rightY  = mix(c1.r, c2.b, f.x * 2.0 - 1.0);
+  vec2  outUV   = mix(c1.ga, c2.ga, f.x);
+#else //BGRA = UYVY
+  float leftY   = mix(c1.g, c1.a, f.x * 2.0);
+  float rightY  = mix(c1.a, c2.g, f.x * 2.0 - 1.0);
+  vec2  outUV   = mix(c1.br, c2.br, f.x);
+#endif //XBMC_YUY2
+
+  float outY = mix(leftY, rightY, step(0.5, f.x));
+
+  yuv = vec4(outY, outUV, 1.0);
+
 #endif
 
   rgb = m_yuvmat * yuv;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -1046,24 +1046,11 @@ bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)
   pVideoPicture->m_originalColorPrimaries = pVideoPicture->color_primaries;
   pVideoPicture->color_transfer = m_pCodecContext->color_trc == AVCOL_TRC_UNSPECIFIED ? m_hints.colorTransferCharacteristic : m_pCodecContext->color_trc;
   pVideoPicture->color_space = m_pCodecContext->colorspace == AVCOL_SPC_UNSPECIFIED ? m_hints.colorSpace : m_pCodecContext->colorspace;
-  pVideoPicture->colorBits = 8;
-
-  // determine how number of bits of encoded video
-  if (m_pCodecContext->pix_fmt == AV_PIX_FMT_YUV420P12)
-    pVideoPicture->colorBits = 12;
-  else if (m_pCodecContext->pix_fmt == AV_PIX_FMT_YUV420P10)
-    pVideoPicture->colorBits = 10;
-  else if (m_pCodecContext->codec_id == AV_CODEC_ID_HEVC &&
-           m_pCodecContext->profile == AV_PROFILE_HEVC_MAIN_10)
-    pVideoPicture->colorBits = 10;
-  else if (m_pCodecContext->codec_id == AV_CODEC_ID_H264 &&
-           (m_pCodecContext->profile == AV_PROFILE_H264_HIGH_10 ||
-            m_pCodecContext->profile == AV_PROFILE_H264_HIGH_10_INTRA))
-    pVideoPicture->colorBits = 10;
-  else if ((m_pCodecContext->codec_id == AV_CODEC_ID_VP9 ||
-            m_pCodecContext->codec_id == AV_CODEC_ID_AV1) &&
-           m_pCodecContext->sw_pix_fmt == AV_PIX_FMT_YUV420P10)
-    pVideoPicture->colorBits = 10;
+  // sw_pix_fmt always describes the actual pixel layout (pix_fmt is opaque
+  // for hwaccel paths like AV_PIX_FMT_VAAPI). libavutil api covers every
+  // codec, chroma layout, and bit depth without per-profile enumeration.
+  const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(m_pCodecContext->sw_pix_fmt);
+  pVideoPicture->colorBits = desc ? desc->comp[0].depth : 8;
 
   if (m_pCodecContext->color_range == AVCOL_RANGE_JPEG ||
     m_pCodecContext->pix_fmt == AV_PIX_FMT_YUVJ420P)

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
@@ -76,6 +76,16 @@ std::vector<AVPixelFormat> CProcessInfoGBM::GetRenderFormats()
     formats.push_back(AV_PIX_FMT_YUV420P12);
     formats.push_back(AV_PIX_FMT_YUV420P14);
     formats.push_back(AV_PIX_FMT_YUV420P16);
+    formats.push_back(AV_PIX_FMT_YUV422P9);
+    formats.push_back(AV_PIX_FMT_YUV422P10);
+    formats.push_back(AV_PIX_FMT_YUV422P12);
+    formats.push_back(AV_PIX_FMT_YUV422P14);
+    formats.push_back(AV_PIX_FMT_YUV422P16);
+    formats.push_back(AV_PIX_FMT_YUV444P9);
+    formats.push_back(AV_PIX_FMT_YUV444P10);
+    formats.push_back(AV_PIX_FMT_YUV444P12);
+    formats.push_back(AV_PIX_FMT_YUV444P14);
+    formats.push_back(AV_PIX_FMT_YUV444P16);
   }
 
   return formats;

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
@@ -49,9 +49,9 @@ std::vector<AVPixelFormat> CProcessInfoGBM::GetRenderFormats()
   std::vector<AVPixelFormat> formats = {
       AV_PIX_FMT_NV12,
       AV_PIX_FMT_YUV420P,
-      // TODO: verify YUV422 on existing GL renderer, add support to GLES renderer
-      // AV_PIX_FMT_YUYV422,
-      // AV_PIX_FMT_UYVY422,
+      AV_PIX_FMT_YUV422P,
+      AV_PIX_FMT_YUYV422,
+      AV_PIX_FMT_UYVY422,
   };
   // clang-format on
 

--- a/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
+++ b/xbmc/cores/VideoPlayer/Process/gbm/ProcessInfoGBM.cpp
@@ -52,6 +52,7 @@ std::vector<AVPixelFormat> CProcessInfoGBM::GetRenderFormats()
       AV_PIX_FMT_YUV422P,
       AV_PIX_FMT_YUYV422,
       AV_PIX_FMT_UYVY422,
+      AV_PIX_FMT_YUV444P,
   };
   // clang-format on
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -358,7 +358,8 @@ EShaderFormat CBaseRenderer::GetShaderFormat()
 {
   EShaderFormat ret = SHADER_NONE;
 
-  if (m_format == AV_PIX_FMT_YUV420P || m_format == AV_PIX_FMT_YUV422P)
+  if (m_format == AV_PIX_FMT_YUV420P || m_format == AV_PIX_FMT_YUV422P ||
+      m_format == AV_PIX_FMT_YUV444P)
     ret = SHADER_YV12;
   else if (m_format == AV_PIX_FMT_YUV420P9)
     ret = SHADER_YV12_9;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -358,7 +358,7 @@ EShaderFormat CBaseRenderer::GetShaderFormat()
 {
   EShaderFormat ret = SHADER_NONE;
 
-  if (m_format == AV_PIX_FMT_YUV420P)
+  if (m_format == AV_PIX_FMT_YUV420P || m_format == AV_PIX_FMT_YUV422P)
     ret = SHADER_YV12;
   else if (m_format == AV_PIX_FMT_YUV420P9)
     ret = SHADER_YV12_9;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -358,18 +358,30 @@ EShaderFormat CBaseRenderer::GetShaderFormat()
 {
   EShaderFormat ret = SHADER_NONE;
 
-  if (m_format == AV_PIX_FMT_YUV420P || m_format == AV_PIX_FMT_YUV422P ||
+  // clang-format off
+  if (m_format == AV_PIX_FMT_YUV420P ||
+      m_format == AV_PIX_FMT_YUV422P ||
       m_format == AV_PIX_FMT_YUV444P)
     ret = SHADER_YV12;
-  else if (m_format == AV_PIX_FMT_YUV420P9)
+  else if (m_format == AV_PIX_FMT_YUV420P9 ||
+           m_format == AV_PIX_FMT_YUV422P9 ||
+           m_format == AV_PIX_FMT_YUV444P9)
     ret = SHADER_YV12_9;
-  else if (m_format == AV_PIX_FMT_YUV420P10)
+  else if (m_format == AV_PIX_FMT_YUV420P10 ||
+           m_format == AV_PIX_FMT_YUV422P10 ||
+           m_format == AV_PIX_FMT_YUV444P10)
     ret = SHADER_YV12_10;
-  else if (m_format == AV_PIX_FMT_YUV420P12)
+  else if (m_format == AV_PIX_FMT_YUV420P12 ||
+           m_format == AV_PIX_FMT_YUV422P12 ||
+           m_format == AV_PIX_FMT_YUV444P12)
     ret = SHADER_YV12_12;
-  else if (m_format == AV_PIX_FMT_YUV420P14)
+  else if (m_format == AV_PIX_FMT_YUV420P14 ||
+           m_format == AV_PIX_FMT_YUV422P14 ||
+           m_format == AV_PIX_FMT_YUV444P14)
     ret = SHADER_YV12_14;
-  else if (m_format == AV_PIX_FMT_YUV420P16)
+  else if (m_format == AV_PIX_FMT_YUV420P16 ||
+           m_format == AV_PIX_FMT_YUV422P16 ||
+           m_format == AV_PIX_FMT_YUV444P16)
     ret = SHADER_YV12_16;
   else if (m_format == AV_PIX_FMT_NV12)
     ret = SHADER_NV12;
@@ -377,6 +389,7 @@ EShaderFormat CBaseRenderer::GetShaderFormat()
     ret = SHADER_YUY2;
   else if (m_format == AV_PIX_FMT_UYVY422)
     ret = SHADER_UYVY;
+  // clang-format on
   else
     CLog::Log(LOGERROR, "CBaseRenderer::GetShaderFormat - unsupported format {}", m_format);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -1933,8 +1933,8 @@ bool CLinuxRendererGL::CreateYV12Texture(int index)
 
   im.height = m_sourceHeight;
   im.width = m_sourceWidth;
-  im.cshift_x = 1;
-  im.cshift_y = (m_format == AV_PIX_FMT_YUV422P) ? 0 : 1;
+  im.cshift_x = (m_format == AV_PIX_FMT_YUV444P) ? 0 : 1;
+  im.cshift_y = (m_format == AV_PIX_FMT_YUV422P || m_format == AV_PIX_FMT_YUV444P) ? 0 : 1;
 
   switch (m_format)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -180,7 +180,7 @@ bool CLinuxRendererGL::ValidateRenderer()
   if (ValidateRenderTarget())
     return false;
 
-  int index = m_iYV12RenderBuffer;
+  int index = m_iYUVRenderBuffer;
   const CPictureBuffer& buf = m_buffers[index];
 
   if (!buf.fields[FIELD_FULL][0].id)
@@ -215,7 +215,7 @@ bool CLinuxRendererGL::ValidateRenderTarget()
     else
       CLog::Log(LOGINFO, "Using GL_TEXTURE_2D");
 
-    for (int i = 0 ; i < m_NumYV12Buffers ; i++)
+    for (int i = 0; i < m_NumYUVBuffers; i++)
       CreateTexture(i);
 
     m_bValidated = true;
@@ -470,7 +470,7 @@ bool CLinuxRendererGL::Flush(bool saveBuffers)
   bool safe = saveBuffers && CanSaveBuffers();
   glFinish();
 
-  for (int i = 0 ; i < m_NumYV12Buffers ; i++)
+  for (int i = 0; i < m_NumYUVBuffers; i++)
   {
     if (!safe)
       ReleaseBuffer(i);
@@ -485,7 +485,7 @@ bool CLinuxRendererGL::Flush(bool saveBuffers)
   glFinish();
   m_bValidated = false;
   m_fbo.fbo.Cleanup();
-  m_iYV12RenderBuffer = 0;
+  m_iYUVRenderBuffer = 0;
 
   return safe;
 }
@@ -502,9 +502,9 @@ void CLinuxRendererGL::Update()
 void CLinuxRendererGL::RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha)
 {
   if (index2 >= 0)
-    m_iYV12RenderBuffer = index2;
+    m_iYUVRenderBuffer = index2;
   else
-    m_iYV12RenderBuffer = index;
+    m_iYUVRenderBuffer = index;
 
   if (!ValidateRenderer())
   {
@@ -540,12 +540,12 @@ void CLinuxRendererGL::RenderUpdate(int index, int index2, bool clear, unsigned 
   if (m_pVideoFilterShader)
     m_pVideoFilterShader->SetAlpha(alpha/255);
 
-  if (!Render(flags, m_iYV12RenderBuffer) && clear)
+  if (!Render(flags, m_iYUVRenderBuffer) && clear)
     ClearBackBuffer();
 
   if (index2 >= 0)
   {
-    m_iYV12RenderBuffer = index;
+    m_iYUVRenderBuffer = index;
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
@@ -554,7 +554,7 @@ void CLinuxRendererGL::RenderUpdate(int index, int index2, bool clear, unsigned 
     if (m_pVideoFilterShader)
       m_pVideoFilterShader->SetAlpha(alpha/255/2);
 
-    Render(flags, m_iYV12RenderBuffer);
+    Render(flags, m_iYUVRenderBuffer);
   }
 
   VerifyGLState();
@@ -1068,7 +1068,7 @@ void CLinuxRendererGL::UnInit()
 
   glFinish();
 
-  // YV12 textures
+  // YUV textures
   for (int i = 0; i < NUM_BUFFERS; ++i)
   {
     ReleaseBuffer(i);
@@ -1851,9 +1851,9 @@ bool CLinuxRendererGL::CreateTexture(int index)
     return CreateNV12Texture(index);
   else if (m_format == AV_PIX_FMT_YUYV422 ||
            m_format == AV_PIX_FMT_UYVY422)
-    return CreateYUV422PackedTexture(index);
+    return CreatePackedYUVTexture(index);
   else
-    return CreateYV12Texture(index);
+    return CreatePlanarYUVTexture(index);
 }
 
 void CLinuxRendererGL::DeleteTexture(int index)
@@ -1865,9 +1865,9 @@ void CLinuxRendererGL::DeleteTexture(int index)
     DeleteNV12Texture(index);
   else if (m_format == AV_PIX_FMT_YUYV422 ||
            m_format == AV_PIX_FMT_UYVY422)
-    DeleteYUV422PackedTexture(index);
+    DeletePackedYUVTexture(index);
   else
-    DeleteYV12Texture(index);
+    DeletePlanarYUVTexture(index);
 }
 
 bool CLinuxRendererGL::UploadTexture(int index)
@@ -1897,13 +1897,13 @@ bool CLinuxRendererGL::UploadTexture(int index)
     {
       CVideoBuffer::CopyYUV422PackedPicture(&dst, &src);
       BindPbo(m_buffers[index]);
-      ret = UploadYUV422PackedTexture(index);
+      ret = UploadPackedYUVTexture(index);
     }
     else
     {
       CVideoBuffer::CopyPicture(&dst, &src);
       BindPbo(m_buffers[index]);
-      ret = UploadYV12Texture(index);
+      ret = UploadPlanarYUVTexture(index);
     }
 
     if (ret)
@@ -1917,10 +1917,10 @@ bool CLinuxRendererGL::UploadTexture(int index)
 }
 
 //********************************************************************************************************
-// YV12 Texture creation, deletion, copying + clearing
+// YUV texture creation, deletion, copying + clearing
 //********************************************************************************************************
 
-bool CLinuxRendererGL::CreateYV12Texture(int index)
+bool CLinuxRendererGL::CreatePlanarYUVTexture(int index)
 {
   /* since we also want the field textures, pitch must be texture aligned */
   unsigned p;
@@ -1929,7 +1929,7 @@ bool CLinuxRendererGL::CreateYV12Texture(int index)
   YuvImage &im = m_buffers[index].image;
   GLuint *pbo = m_buffers[index].pbo;
 
-  DeleteYV12Texture(index);
+  DeletePlanarYUVTexture(index);
 
   im.height = m_sourceHeight;
   im.width = m_sourceWidth;
@@ -2070,7 +2070,7 @@ bool CLinuxRendererGL::CreateYV12Texture(int index)
   return true;
 }
 
-bool CLinuxRendererGL::UploadYV12Texture(int source)
+bool CLinuxRendererGL::UploadPlanarYUVTexture(int source)
 {
   CPictureBuffer& buf = m_buffers[source];
   YuvImage* im = &buf.image;
@@ -2138,7 +2138,7 @@ bool CLinuxRendererGL::UploadYV12Texture(int source)
   return true;
 }
 
-void CLinuxRendererGL::DeleteYV12Texture(int index)
+void CLinuxRendererGL::DeletePlanarYUVTexture(int index)
 {
   YuvImage &im = m_buffers[index].image;
   GLuint *pbo = m_buffers[index].pbo;
@@ -2427,7 +2427,7 @@ void CLinuxRendererGL::DeleteNV12Texture(int index)
   }
 }
 
-bool CLinuxRendererGL::UploadYUV422PackedTexture(int source)
+bool CLinuxRendererGL::UploadPackedYUVTexture(int source)
 {
   CPictureBuffer& buf = m_buffers[source];
   YuvImage* im = &buf.image;
@@ -2466,7 +2466,7 @@ bool CLinuxRendererGL::UploadYUV422PackedTexture(int source)
   return true;
 }
 
-void CLinuxRendererGL::DeleteYUV422PackedTexture(int index)
+void CLinuxRendererGL::DeletePackedYUVTexture(int index)
 {
   CPictureBuffer& buf = m_buffers[index];
   YuvImage &im = buf.image;
@@ -2512,7 +2512,7 @@ void CLinuxRendererGL::DeleteYUV422PackedTexture(int index)
   }
 }
 
-bool CLinuxRendererGL::CreateYUV422PackedTexture(int index)
+bool CLinuxRendererGL::CreatePackedYUVTexture(int index)
 {
   // since we also want the field textures, pitch must be texture aligned
   CPictureBuffer& buf = m_buffers[index];
@@ -2520,7 +2520,7 @@ bool CLinuxRendererGL::CreateYUV422PackedTexture(int index)
   GLuint *pbo = buf.pbo;
 
   // Delete any old texture
-  DeleteYUV422PackedTexture(index);
+  DeletePackedYUVTexture(index);
 
   im.height = m_sourceHeight;
   im.width  = m_sourceWidth;
@@ -2630,7 +2630,7 @@ bool CLinuxRendererGL::CreateYUV422PackedTexture(int index)
 
 void CLinuxRendererGL::SetTextureFilter(GLenum method)
 {
-  for (int i = 0 ; i<m_NumYV12Buffers ; i++)
+  for (int i = 0; i < m_NumYUVBuffers; i++)
   {
     CPictureBuffer& buf = m_buffers[i];
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -1934,7 +1934,7 @@ bool CLinuxRendererGL::CreateYV12Texture(int index)
   im.height = m_sourceHeight;
   im.width = m_sourceWidth;
   im.cshift_x = 1;
-  im.cshift_y = 1;
+  im.cshift_y = (m_format == AV_PIX_FMT_YUV422P) ? 0 : 1;
 
   switch (m_format)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -1933,33 +1933,14 @@ bool CLinuxRendererGL::CreatePlanarYUVTexture(int index)
 
   im.height = m_sourceHeight;
   im.width = m_sourceWidth;
-  im.cshift_x = (m_format == AV_PIX_FMT_YUV444P) ? 0 : 1;
-  im.cshift_y = (m_format == AV_PIX_FMT_YUV422P || m_format == AV_PIX_FMT_YUV444P) ? 0 : 1;
-
-  switch (m_format)
-  {
-    case AV_PIX_FMT_YUV420P16:
-      buf.m_srcTextureBits = 16;
-      break;
-    case AV_PIX_FMT_YUV420P14:
-      buf.m_srcTextureBits = 14;
-      break;
-    case AV_PIX_FMT_YUV420P12:
-      buf.m_srcTextureBits = 12;
-      break;
-    case AV_PIX_FMT_YUV420P10:
-      buf.m_srcTextureBits = 10;
-      break;
-    case AV_PIX_FMT_YUV420P9:
-      buf.m_srcTextureBits = 9;
-      break;
-    default:
-      break;
-  }
-  if (buf.m_srcTextureBits > 8)
-    im.bpp = 2;
-  else
-    im.bpp = 1;
+  // Chroma subsampling and bit depth derived from libavutil's pixdesc API,
+  // avoiding a parallel per-pix_fmt switch. Works for any planar YUV pix_fmt
+  // (4:2:0 / 4:2:2 / 4:4:4 at any supported bit depth).
+  const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(m_format);
+  im.cshift_x = desc ? desc->log2_chroma_w : 1;
+  im.cshift_y = desc ? desc->log2_chroma_h : 1;
+  buf.m_srcTextureBits = desc ? desc->comp[0].depth : 8;
+  im.bpp = (buf.m_srcTextureBits > 8) ? 2 : 1;
 
   im.stride[0] = im.bpp * im.width;
   im.stride[1] = im.bpp * (im.width >> im.cshift_x);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -21,6 +21,7 @@
 
 extern "C" {
 #include <libavutil/mastering_display_metadata.h>
+#include <libavutil/pixdesc.h>
 }
 
 class CRenderCapture;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -68,7 +68,7 @@ public:
   void AddVideoPicture(const VideoPicture &picture, int index) override;
   void UnInit() override;
   bool Flush(bool saveBuffers) override;
-  void SetBufferSize(int numBuffers) override { m_NumYV12Buffers = numBuffers; }
+  void SetBufferSize(int numBuffers) override { m_NumYUVBuffers = numBuffers; }
   void ReleaseBuffer(int idx) override;
   void RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha) override;
   void Update() override;
@@ -105,17 +105,17 @@ protected:
   virtual void DeleteTexture(int index);
   virtual bool CreateTexture(int index);
 
-  bool UploadYV12Texture(int index);
-  void DeleteYV12Texture(int index);
-  bool CreateYV12Texture(int index);
+  bool UploadPlanarYUVTexture(int index);
+  void DeletePlanarYUVTexture(int index);
+  bool CreatePlanarYUVTexture(int index);
 
   bool UploadNV12Texture(int index);
   void DeleteNV12Texture(int index);
   bool CreateNV12Texture(int index);
 
-  bool UploadYUV422PackedTexture(int index);
-  void DeleteYUV422PackedTexture(int index);
-  bool CreateYUV422PackedTexture(int index);
+  bool UploadPackedYUVTexture(int index);
+  void DeletePackedYUVTexture(int index);
+  bool CreatePackedYUVTexture(int index);
 
   void CalculateTextureSourceRects(int source, int num_planes);
 
@@ -153,8 +153,8 @@ protected:
   GLint m_intermediateType{GL_UNSIGNED_BYTE};
   bool m_intermediateGammaCorrection{false};
 
-  int m_iYV12RenderBuffer = 0;
-  int m_NumYV12Buffers = 0;
+  int m_iYUVRenderBuffer = 0;
+  int m_NumYUVBuffers = 0;
 
   bool m_bConfigured = false;
   bool m_bValidated = false;
@@ -207,7 +207,7 @@ protected:
     AVContentLightMetadata lightMetadata;
   };
 
-  // YV12 decoder textures
+  // YUV decoder textures
   // field index 0 is full image, 1 is odd scanlines, 2 is even scanlines
   CPictureBuffer m_buffers[NUM_BUFFERS];
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -152,7 +152,7 @@ bool CLinuxRendererGLES::ValidateRenderTarget()
       return false;
     }
 
-    for (int i = 0 ; i < m_NumYV12Buffers ; i++)
+    for (int i = 0; i < m_NumYUVBuffers; i++)
     {
       CreateTexture(i);
     }
@@ -225,9 +225,9 @@ bool CLinuxRendererGLES::ConfigChanged(const VideoPicture &picture)
   return false;
 }
 
-int CLinuxRendererGLES::NextYV12Texture()
+int CLinuxRendererGLES::NextYUVTexture()
 {
-  return (m_iYV12RenderBuffer + 1) % m_NumYV12Buffers;
+  return (m_iYUVRenderBuffer + 1) % m_NumYUVBuffers;
 }
 
 void CLinuxRendererGLES::AddVideoPicture(const VideoPicture &picture, int index)
@@ -404,7 +404,7 @@ bool CLinuxRendererGLES::Flush(bool saveBuffers)
 {
   glFinish();
 
-  for (int i = 0 ; i < m_NumYV12Buffers ; i++)
+  for (int i = 0; i < m_NumYUVBuffers; i++)
   {
     DeleteTexture(i);
   }
@@ -412,7 +412,7 @@ bool CLinuxRendererGLES::Flush(bool saveBuffers)
   glFinish();
   m_bValidated = false;
   m_fbo.fbo.Cleanup();
-  m_iYV12RenderBuffer = 0;
+  m_iYUVRenderBuffer = 0;
 
   return false;
 }
@@ -551,7 +551,7 @@ void CLinuxRendererGLES::DrawBlackBars()
 
 void CLinuxRendererGLES::RenderUpdate(int index, int index2, bool clear, unsigned int flags, unsigned int alpha)
 {
-  m_iYV12RenderBuffer = index;
+  m_iYUVRenderBuffer = index;
 
   if (!m_bConfigured)
   {
@@ -635,7 +635,7 @@ void CLinuxRendererGLES::RenderUpdateVideo(bool clear, unsigned int flags, unsig
   if (IsGuiLayer())
     return;
 
-  int index = m_iYV12RenderBuffer;
+  int index = m_iYUVRenderBuffer;
   CPictureBuffer& buf = m_buffers[index];
 
   if (!buf.fields[FIELD_FULL][0].id)
@@ -1037,7 +1037,7 @@ void CLinuxRendererGLES::UnInit()
 
   glFinish();
 
-  // YV12 textures
+  // YUV textures
   for (int i = 0; i < NUM_BUFFERS; ++i)
   {
     DeleteTexture(i);
@@ -1064,9 +1064,9 @@ bool CLinuxRendererGLES::CreateTexture(int index)
   if (m_format == AV_PIX_FMT_NV12)
     return CreateNV12Texture(index);
   else if (m_format == AV_PIX_FMT_YUYV422 || m_format == AV_PIX_FMT_UYVY422)
-    return CreateYUV422PackedTexture(index);
+    return CreatePackedYUVTexture(index);
   else
-    return CreateYV12Texture(index);
+    return CreatePlanarYUVTexture(index);
 }
 
 void CLinuxRendererGLES::DeleteTexture(int index)
@@ -1076,9 +1076,9 @@ void CLinuxRendererGLES::DeleteTexture(int index)
   if (m_format == AV_PIX_FMT_NV12)
     DeleteNV12Texture(index);
   else if (m_format == AV_PIX_FMT_YUYV422 || m_format == AV_PIX_FMT_UYVY422)
-    DeleteYUV422PackedTexture(index);
+    DeletePackedYUVTexture(index);
   else
-    DeleteYV12Texture(index);
+    DeletePlanarYUVTexture(index);
 }
 
 bool CLinuxRendererGLES::UploadTexture(int index)
@@ -1105,12 +1105,12 @@ bool CLinuxRendererGLES::UploadTexture(int index)
   }
   else if (m_format == AV_PIX_FMT_YUYV422 || m_format == AV_PIX_FMT_UYVY422)
   {
-    ret = UploadYUV422PackedTexture(index);
+    ret = UploadPackedYUVTexture(index);
   }
   else
   {
-    // default to YV12 texture handlers
-    ret = UploadYV12Texture(index);
+    // default to planar YUV texture handlers
+    ret = UploadPlanarYUVTexture(index);
   }
 
   if (ret)
@@ -1594,9 +1594,9 @@ bool CLinuxRendererGLES::RenderCapture(int index, CRenderCapture* capture)
 }
 
 //********************************************************************************************************/
-// YV12 Texture creation, deletion, copying + clearing
+// YUV texture creation, deletion, copying + clearing
 //********************************************************************************************************/
-bool CLinuxRendererGLES::UploadYV12Texture(int source)
+bool CLinuxRendererGLES::UploadPlanarYUVTexture(int source)
 {
   CPictureBuffer& buf = m_buffers[source];
   YuvImage* im = &buf.image;
@@ -1637,7 +1637,7 @@ bool CLinuxRendererGLES::UploadYV12Texture(int source)
   return true;
 }
 
-void CLinuxRendererGLES::DeleteYV12Texture(int index)
+void CLinuxRendererGLES::DeletePlanarYUVTexture(int index)
 {
   YuvImage &im = m_buffers[index].image;
 
@@ -1669,14 +1669,14 @@ void CLinuxRendererGLES::DeleteYV12Texture(int index)
   }
 }
 
-bool CLinuxRendererGLES::CreateYV12Texture(int index)
+bool CLinuxRendererGLES::CreatePlanarYUVTexture(int index)
 {
   // since we also want the field textures, pitch must be texture aligned
   unsigned p;
   CPictureBuffer& buf = m_buffers[index];
   YuvImage& im = buf.image;
 
-  DeleteYV12Texture(index);
+  DeletePlanarYUVTexture(index);
 
   im.height = m_sourceHeight;
   im.width = m_sourceWidth;
@@ -1977,7 +1977,7 @@ void CLinuxRendererGLES::DeleteNV12Texture(int index)
 //********************************************************************************************************
 // YUV422 packed Texture creation, deletion, copying + clearing
 //********************************************************************************************************
-bool CLinuxRendererGLES::UploadYUV422PackedTexture(int source)
+bool CLinuxRendererGLES::UploadPackedYUVTexture(int source)
 {
   CPictureBuffer& buf = m_buffers[source];
   YuvImage* im = &buf.image;
@@ -1997,7 +1997,7 @@ bool CLinuxRendererGLES::UploadYUV422PackedTexture(int source)
   return true;
 }
 
-void CLinuxRendererGLES::DeleteYUV422PackedTexture(int index)
+void CLinuxRendererGLES::DeletePackedYUVTexture(int index)
 {
   CPictureBuffer& buf = m_buffers[index];
   YuvImage& im = buf.image;
@@ -2023,11 +2023,11 @@ void CLinuxRendererGLES::DeleteYUV422PackedTexture(int index)
   im.plane[0] = nullptr;
 }
 
-bool CLinuxRendererGLES::CreateYUV422PackedTexture(int index)
+bool CLinuxRendererGLES::CreatePackedYUVTexture(int index)
 {
   if (!CServiceBroker::GetRenderSystem()->IsExtSupported("GL_EXT_texture_format_BGRA8888"))
   {
-    CLog::Log(LOGERROR, "CLinuxRendererGLES::CreateYUV422PackedTexture - "
+    CLog::Log(LOGERROR, "CLinuxRendererGLES::CreatePackedYUVTexture - "
                         "GL_EXT_texture_format_BGRA8888 not supported");
     return false;
   }
@@ -2037,7 +2037,7 @@ bool CLinuxRendererGLES::CreateYUV422PackedTexture(int index)
   YuvImage& im = buf.image;
 
   // Delete any old texture
-  DeleteYUV422PackedTexture(index);
+  DeletePackedYUVTexture(index);
 
   im.height = m_sourceHeight;
   im.width = m_sourceWidth;
@@ -2111,7 +2111,7 @@ bool CLinuxRendererGLES::CreateYUV422PackedTexture(int index)
 //********************************************************************************************************
 void CLinuxRendererGLES::SetTextureFilter(GLenum method)
 {
-  for (int i = 0 ; i < m_NumYV12Buffers; i++)
+  for (int i = 0; i < m_NumYUVBuffers; i++)
   {
     CPictureBuffer& buf = m_buffers[i];
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -1680,11 +1680,13 @@ bool CLinuxRendererGLES::CreatePlanarYUVTexture(int index)
 
   im.height = m_sourceHeight;
   im.width = m_sourceWidth;
-  im.cshift_x = (m_format == AV_PIX_FMT_YUV444P) ? 0 : 1;
-  im.cshift_y = (m_format == AV_PIX_FMT_YUV422P || m_format == AV_PIX_FMT_YUV444P) ? 0 : 1;
 
-  // Bit depth comes from libavutil's public pixdesc API, avoiding a parallel switch.
+  // Chroma subsampling derived from libavutil's pixdesc API. Works for any
+  // planar YUV pix_fmt (4:2:0 / 4:2:2 / 4:4:4) without per-format checks.
   const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(m_format);
+  im.cshift_x = desc ? desc->log2_chroma_w : 1;
+  im.cshift_y = desc ? desc->log2_chroma_h : 1;
+
   buf.m_srcTextureBits = desc ? desc->comp[0].depth : 8;
   im.bpp = (buf.m_srcTextureBits > 8) ? 2 : 1;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -1062,13 +1062,11 @@ void CLinuxRendererGLES::UnInit()
 bool CLinuxRendererGLES::CreateTexture(int index)
 {
   if (m_format == AV_PIX_FMT_NV12)
-  {
     return CreateNV12Texture(index);
-  }
+  else if (m_format == AV_PIX_FMT_YUYV422 || m_format == AV_PIX_FMT_UYVY422)
+    return CreateYUV422PackedTexture(index);
   else
-  {
     return CreateYV12Texture(index);
-  }
 }
 
 void CLinuxRendererGLES::DeleteTexture(int index)
@@ -1076,13 +1074,11 @@ void CLinuxRendererGLES::DeleteTexture(int index)
   ReleaseBuffer(index);
 
   if (m_format == AV_PIX_FMT_NV12)
-  {
     DeleteNV12Texture(index);
-  }
+  else if (m_format == AV_PIX_FMT_YUYV422 || m_format == AV_PIX_FMT_UYVY422)
+    DeleteYUV422PackedTexture(index);
   else
-  {
     DeleteYV12Texture(index);
-  }
 }
 
 bool CLinuxRendererGLES::UploadTexture(int index)
@@ -1106,6 +1102,10 @@ bool CLinuxRendererGLES::UploadTexture(int index)
   if (m_format == AV_PIX_FMT_NV12)
   {
     ret = UploadNV12Texture(index);
+  }
+  else if (m_format == AV_PIX_FMT_YUYV422 || m_format == AV_PIX_FMT_UYVY422)
+  {
+    ret = UploadYUV422PackedTexture(index);
   }
   else
   {
@@ -1681,7 +1681,7 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
   im.height = m_sourceHeight;
   im.width = m_sourceWidth;
   im.cshift_x = 1;
-  im.cshift_y = 1;
+  im.cshift_y = (m_format == AV_PIX_FMT_YUV422P) ? 0 : 1;
 
   // Bit depth comes from libavutil's public pixdesc API, avoiding a parallel switch.
   const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(m_format);
@@ -1975,6 +1975,131 @@ void CLinuxRendererGLES::DeleteNV12Texture(int index)
 }
 
 //********************************************************************************************************
+// YUV422 packed Texture creation, deletion, copying + clearing
+//********************************************************************************************************
+bool CLinuxRendererGLES::UploadYUV422PackedTexture(int source)
+{
+  CPictureBuffer& buf = m_buffers[source];
+  YuvImage* im = &buf.image;
+
+  VerifyGLState();
+
+  glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+  // Load YUYV plane
+  LoadPlane(buf.fields[FIELD_FULL][0], GL_BGRA_EXT, im->width / 2, im->height, im->stride[0],
+            im->bpp, im->plane[0]);
+
+  VerifyGLState();
+
+  CalculateTextureSourceRects(source, 3);
+
+  return true;
+}
+
+void CLinuxRendererGLES::DeleteYUV422PackedTexture(int index)
+{
+  CPictureBuffer& buf = m_buffers[index];
+  YuvImage& im = buf.image;
+
+  if (buf.fields[FIELD_FULL][0].id == 0)
+    return;
+
+  // finish up all textures, and delete them
+  for (int f = 0; f < MAX_FIELDS; f++)
+  {
+    if (buf.fields[f][0].id)
+    {
+      if (glIsTexture(buf.fields[f][0].id))
+      {
+        glDeleteTextures(1, &buf.fields[f][0].id);
+      }
+      buf.fields[f][0].id = 0;
+    }
+    buf.fields[f][1].id = 0;
+    buf.fields[f][2].id = 0;
+  }
+
+  im.plane[0] = nullptr;
+}
+
+bool CLinuxRendererGLES::CreateYUV422PackedTexture(int index)
+{
+  // since we also want the field textures, pitch must be texture aligned
+  CPictureBuffer& buf = m_buffers[index];
+  YuvImage& im = buf.image;
+
+  // Delete any old texture
+  DeleteYUV422PackedTexture(index);
+
+  im.height = m_sourceHeight;
+  im.width = m_sourceWidth;
+  im.cshift_x = 0;
+  im.cshift_y = 0;
+  im.bpp = 1;
+
+  im.stride[0] = im.width * 2;
+  im.stride[1] = 0;
+  im.stride[2] = 0;
+
+  im.planesize[0] = im.stride[0] * im.height;
+  im.planesize[1] = 0;
+  im.planesize[2] = 0;
+
+  im.plane[0] = nullptr; // will be set in UploadTexture()
+  im.plane[1] = nullptr;
+  im.plane[2] = nullptr;
+
+  for (int f = 0; f < MAX_FIELDS; f++)
+  {
+    if (!glIsTexture(buf.fields[f][0].id))
+    {
+      glGenTextures(1, &buf.fields[f][0].id);
+      VerifyGLState();
+    }
+    buf.fields[f][1].id = buf.fields[f][0].id;
+    buf.fields[f][2].id = buf.fields[f][1].id;
+  }
+
+  // YUV
+  for (int f = FIELD_FULL; f <= FIELD_BOT; f++)
+  {
+    int fieldshift = (f == FIELD_FULL) ? 0 : 1;
+    CYuvPlane(&planes)[YuvImage::MAX_PLANES] = buf.fields[f];
+
+    planes[0].texwidth = im.width / 2;
+    planes[0].texheight = im.height >> fieldshift;
+    planes[1].texwidth = planes[0].texwidth;
+    planes[1].texheight = planes[0].texheight;
+    planes[2].texwidth = planes[1].texwidth;
+    planes[2].texheight = planes[1].texheight;
+
+    for (int p = 0; p < 3; p++)
+    {
+      planes[p].pixpertex_x = 2;
+      planes[p].pixpertex_y = 1;
+    }
+
+    CYuvPlane& plane = planes[0];
+    if (plane.texwidth * plane.texheight == 0)
+      continue;
+
+    glBindTexture(m_textureTarget, plane.id);
+
+    glTexImage2D(m_textureTarget, 0, GL_RGBA, plane.texwidth, plane.texheight, 0, GL_BGRA_EXT,
+                 GL_UNSIGNED_BYTE, NULL);
+
+    glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    VerifyGLState();
+  }
+
+  return true;
+}
+
+//********************************************************************************************************
 // SurfaceTexture creation, deletion, copying + clearing
 //********************************************************************************************************
 void CLinuxRendererGLES::SetTextureFilter(GLenum method)
@@ -2048,8 +2173,14 @@ float CLinuxRendererGLES::ScalingAboveThreshold() const
 
 bool CLinuxRendererGLES::Supports(ESCALINGMETHOD method) const
 {
-  if (method == VS_SCALINGMETHOD_NEAREST || method == VS_SCALINGMETHOD_LINEAR ||
-      method == VS_SCALINGMETHOD_AUTO)
+  // nearest neighbor doesn't work on YUY2 and UYVY
+  if (method == VS_SCALINGMETHOD_NEAREST && m_format != AV_PIX_FMT_YUYV422 &&
+      m_format != AV_PIX_FMT_UYVY422)
+  {
+    return true;
+  }
+
+  if (method == VS_SCALINGMETHOD_LINEAR || method == VS_SCALINGMETHOD_AUTO)
   {
     return true;
   }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -1680,8 +1680,8 @@ bool CLinuxRendererGLES::CreateYV12Texture(int index)
 
   im.height = m_sourceHeight;
   im.width = m_sourceWidth;
-  im.cshift_x = 1;
-  im.cshift_y = (m_format == AV_PIX_FMT_YUV422P) ? 0 : 1;
+  im.cshift_x = (m_format == AV_PIX_FMT_YUV444P) ? 0 : 1;
+  im.cshift_y = (m_format == AV_PIX_FMT_YUV422P || m_format == AV_PIX_FMT_YUV444P) ? 0 : 1;
 
   // Bit depth comes from libavutil's public pixdesc API, avoiding a parallel switch.
   const AVPixFmtDescriptor* desc = av_pix_fmt_desc_get(m_format);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -2025,6 +2025,13 @@ void CLinuxRendererGLES::DeleteYUV422PackedTexture(int index)
 
 bool CLinuxRendererGLES::CreateYUV422PackedTexture(int index)
 {
+  if (!CServiceBroker::GetRenderSystem()->IsExtSupported("GL_EXT_texture_format_BGRA8888"))
+  {
+    CLog::Log(LOGERROR, "CLinuxRendererGLES::CreateYUV422PackedTexture - "
+                        "GL_EXT_texture_format_BGRA8888 not supported");
+    return false;
+  }
+
   // since we also want the field textures, pitch must be texture aligned
   CPictureBuffer& buf = m_buffers[index];
   YuvImage& im = buf.image;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -175,6 +175,14 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
             inferred ? " (inferred)" : "", picture.colorBits,
             picture.color_range == 1 ? "full" : "limited");
   m_format = picture.videoBuffer->GetFormat();
+
+  // CPU-upload renderer: HWACCEL pix_fmts (e.g. AV_PIX_FMT_DRM_PRIME) have no host planes.
+  if (GetShaderFormat() == SHADER_NONE)
+  {
+    CLog::Log(LOGDEBUG, "LinuxRendererGLES::Configure: refusing unsupported pix_fmt {}", m_format);
+    return false;
+  }
+
   m_sourceWidth = picture.iWidth;
   m_sourceHeight = picture.iHeight;
   m_renderOrientation = orientation;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -122,6 +122,10 @@ protected:
   void DeleteNV12Texture(int index);
   bool CreateNV12Texture(int index);
 
+  bool UploadYUV422PackedTexture(int index);
+  void DeleteYUV422PackedTexture(int index);
+  bool CreateYUV422PackedTexture(int index);
+
   void CalculateTextureSourceRects(int source, int num_planes);
 
   // renderers

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -71,7 +71,7 @@ public:
   void AddVideoPicture(const VideoPicture& picture, int index) override;
   void UnInit() override;
   bool Flush(bool saveBuffers) override;
-  void SetBufferSize(int numBuffers) override { m_NumYV12Buffers = numBuffers; }
+  void SetBufferSize(int numBuffers) override { m_NumYUVBuffers = numBuffers; }
   bool IsGuiLayer() override;
   bool HasVideoPlane() override { return false; }
   void ReleaseBuffer(int idx) override;
@@ -99,7 +99,7 @@ protected:
   virtual bool Render(unsigned int flags, int index);
   virtual void RenderUpdateVideo(bool clear, unsigned int flags = 0, unsigned int alpha = 255);
 
-  int NextYV12Texture();
+  int NextYUVTexture();
   virtual bool ValidateRenderTarget();
   virtual void LoadShaders(int field=FIELD_FULL);
   virtual void ReleaseShaders();
@@ -113,18 +113,18 @@ protected:
   virtual void DeleteTexture(int index);
   virtual bool CreateTexture(int index);
 
-  bool UploadYV12Texture(int index);
-  void DeleteYV12Texture(int index);
-  bool CreateYV12Texture(int index);
-  virtual bool SkipUploadYV12(int index) { return false; }
+  bool UploadPlanarYUVTexture(int index);
+  void DeletePlanarYUVTexture(int index);
+  bool CreatePlanarYUVTexture(int index);
+  virtual bool SkipUploadYUV(int index) { return false; }
 
   bool UploadNV12Texture(int index);
   void DeleteNV12Texture(int index);
   bool CreateNV12Texture(int index);
 
-  bool UploadYUV422PackedTexture(int index);
-  void DeleteYUV422PackedTexture(int index);
-  bool CreateYUV422PackedTexture(int index);
+  bool UploadPackedYUVTexture(int index);
+  void DeletePackedYUVTexture(int index);
+  bool CreatePackedYUVTexture(int index);
 
   void CalculateTextureSourceRects(int source, int num_planes);
 
@@ -145,8 +145,8 @@ protected:
     float height{0.0};
   } m_fbo;
 
-  int m_iYV12RenderBuffer{0};
-  int m_NumYV12Buffers{0};
+  int m_iYUVRenderBuffer{0};
+  int m_NumYUVBuffers{0};
 
   bool m_bConfigured{false};
   bool m_bValidated{false};
@@ -205,7 +205,7 @@ protected:
     AVContentLightMetadata lightMetadata;
   };
 
-  // YV12 decoder textures
+  // YUV decoder textures
   // field index 0 is full image, 1 is odd scanlines, 2 is even scanlines
   CPictureBuffer m_buffers[NUM_BUFFERS];
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -52,6 +52,10 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format,
     m_defines += "#define XBMC_NV12\n";
   else if (m_format == SHADER_NV12_RRG)
     m_defines += "#define XBMC_NV12_RRG\n";
+  else if (m_format == SHADER_YUY2)
+    m_defines += "#define XBMC_YUY2\n";
+  else if (m_format == SHADER_UYVY)
+    m_defines += "#define XBMC_UYVY\n";
   else
     CLog::Log(LOGERROR, "GLES: BaseYUV2RGBGLSLShader - unsupported format {}", m_format);
 

--- a/xbmc/utils/GLUtils.cpp
+++ b/xbmc/utils/GLUtils.cpp
@@ -275,6 +275,10 @@ int KODI::UTILS::GL::glFormatElementByteCount(GLenum format)
   case GL_LUMINANCE:
   case GL_ALPHA:
     return 1;
+#ifdef HAS_GLES
+  case GL_BGRA_EXT:
+    return 4;
+#endif
   default:
     CLog::Log(LOGERROR, "glFormatElementByteCount - Unknown format {}", format);
     return 1;

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -13,6 +13,7 @@
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
+#include "cores/VideoPlayer/Process/gbm/ProcessInfoGBM.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "rendering/gl/GuiCompositeShaderGL.h"
@@ -54,6 +55,7 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
   VIDEOPLAYER::CRendererFactory::ClearRenderer();
   CDVDFactoryCodec::ClearHWAccels();
   CLinuxRendererGL::Register();
+  VIDEOPLAYER::CProcessInfoGBM::Register();
   RETRO::CRPProcessInfoGbm::Register();
   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryDMAOpenGL);
   RETRO::CRPProcessInfoGbm::RegisterRendererFactory(new RETRO::CRendererFactoryOpenGL);


### PR DESCRIPTION
## Description

YUV 4:2:2 content is common from HDMI capture cards, webcams, broadcast tuners (DVB/ATSC), and ProRes files from video editors. Today on GBM platforms, all 4:2:2 content is silently downsampled to 4:2:0 by ffmpeg before rendering, losing half the vertical chroma resolution. This is because ProcessInfoGBM did not override GetRenderFormats, so the base class default (YUV420P only) was used for format negotiation with ffmpeg.

Additionally, CProcessInfoGBM was only registered for the GLES context, not the GL context. This meant GL+GBM was missing the DMA buffer pool and had broken format negotiation.

Changes:
  - ProcessInfoGBM: override GetRenderFormats to advertise YUV420P, NV12, YUV422P, YUYV422, UYVY422
  - WinSystemGbmGLContext: register CProcessInfoGBM (matches GLES context), fixing missing DMA buffer pool and format negotiation for GL+GBM
  - BaseRenderer: map AV_PIX_FMT_YUV422P to SHADER_YV12 in GetShaderFormat
  - LinuxRendererGL/GLES: derive cshift_y from pixel format in CreateYV12Texture instead of hardcoding
  - LinuxRendererGLES: add CreatePackedYUVTexture, DeletePackedYUVTexture, UploadPackedYUVTexture for packed 422 via GL_BGRA_EXT
  - YUV2RGBShaderGLES: add SHADER_YUY2/UYVY defines
  - gles_yuv2rgb_basic.frag: add XBMC_YUY2/XBMC_UYVY shader block for packed 422 subpixel interpolation (matches existing GL shader)
  - GLUtils: add GL_BGRA_EXT to glFormatElementByteCount for GLES
  - rename "YV12" functions to "YUV" since they all support more than just 4:2:0 now
 
Note: 10-bit 422 formats (YUV422P10, P210) are not included and will be added after the 10-bit surface work (dynamic planes) lands. ~~444 formats are also not included and are a separate future item.~~ UPDATE: added 444 support, as it's a trivial expansion and sets up for fixing #27745 

## Motivation and context

HDMI capture cards and webcams are increasingly common Kodi use cases (game streaming, camera preview, PVR with capture input). These devices typically output YUYV422 or UYVY422. Without native 422 support, users get degraded chroma quality with no indication that downsampling is happening.

The missing CProcessInfoGBM registration for GL+GBM was a pre-existing bug that caused missing DMA buffer pool and broken postprocessing on GL+GBM configurations.

## How has this been tested?

- Played ProRes 422 .mov files on GLES+GBM (Intel i3-8109U) -- OSD shows YUV422P pixel format, no chroma downsampling
- Played YUYV422 raw capture content on GLES+GBM
- Verified YUV420P and NV12 content still renders correctly (no regression)
- Verified HQ scalers work with 422 content
- Verified NEAREST scaling is correctly excluded for packed YUYV/UYVY formats

## What is the effect on users?

4:2:2 content from capture cards, webcams, and professional codecs now renders at full chroma resolution on GBM platforms instead of being silently downsampled to 4:2:0.

## Screenshots (if appropriate):
n/a

## Types of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Clean up (non-breaking change which removes redundant code or assets)
- [x] Improvement (non-breaking change which improves an existing feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the [Code Guidelines](https://kodi.wiki/view/Official:Code_guidelines_and_formatting_conventions) of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md) document
- [x] I have added tests to cover my changes
- [ ] All new and existing tests passed
