### PR TITLE
[VideoDatabase] Fix episode duration stored in streamdetails and not the episode table.

### DIFF
--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -1369,39 +1369,46 @@ bool CScraper::GetVideoDetails(XFILE::CCurlFile& fcurl,
 
   video.Reset();
 
+  bool fRet(false);
   if (m_isPython)
-    return PythonDetails(ID(), "url", scurl.GetFirstThumbUrl(),
+  {
+    fRet = PythonDetails(ID(), "url", scurl.GetFirstThumbUrl(),
                          fMovie ? "getdetails" : "getepisodedetails", GetPathSettingsAsJSON(),
                          uniqueIDs, video);
-
-  std::string sFunc = fMovie ? "GetDetails" : "GetEpisodeDetails";
-  std::vector<std::string> vcsIn;
-  vcsIn.push_back(scurl.GetId());
-  vcsIn.push_back(scurl.GetFirstThumbUrl());
-  std::vector<std::string> vcsOut = RunNoThrow(sFunc, scurl, fcurl, &vcsIn);
-
-  // parse XML output
-  bool fRet(false);
-  for (const auto& i : vcsOut)
-  {
-    CXBMCTinyXML doc;
-    doc.Parse(i, TIXML_ENCODING_UTF8);
-    if (!doc.RootElement())
-    {
-      CLog::LogF(LOGERROR, "Unable to parse XML");
-      continue;
-    }
-
-    TiXmlHandle xhDoc(&doc);
-    const TiXmlElement* pxeDetails = xhDoc.FirstChild("details").Element();
-    if (!pxeDetails)
-    {
-      CLog::LogF(LOGERROR, "Invalid XML file (want <details>)");
-      continue;
-    }
-    video.Load(pxeDetails, true /*fChain*/);
-    fRet = true; // but don't exit in case of chaining
   }
+  else
+  {
+    std::string sFunc = fMovie ? "GetDetails" : "GetEpisodeDetails";
+    std::vector<std::string> vcsIn;
+    vcsIn.push_back(scurl.GetId());
+    vcsIn.push_back(scurl.GetFirstThumbUrl());
+    std::vector<std::string> vcsOut = RunNoThrow(sFunc, scurl, fcurl, &vcsIn);
+
+    // parse XML output
+    for (const auto& i : vcsOut)
+    {
+      CXBMCTinyXML doc;
+      doc.Parse(i, TIXML_ENCODING_UTF8);
+      if (!doc.RootElement())
+      {
+        CLog::LogF(LOGERROR, "Unable to parse XML");
+        continue;
+      }
+
+      TiXmlHandle xhDoc(&doc);
+      const TiXmlElement* pxeDetails = xhDoc.FirstChild("details").Element();
+      if (!pxeDetails)
+      {
+        CLog::LogF(LOGERROR, "Invalid XML file (want <details>)");
+        continue;
+      }
+      video.Load(pxeDetails, true /*fChain*/);
+      fRet = true; // but don't exit in case of chaining
+    }
+  }
+
+  video.m_streamDetails.Reset(); // Scrapers should not return streamdetails
+
   return fRet;
 }
 

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -1157,9 +1157,61 @@ void CVideoDatabase::UpdateTables(int iVersion)
   {
     m_pDS->exec("UPDATE streamdetails set strAudioCodec = 'dts' where strAudioCodec = 'dca'");
   }
+
+  if (iVersion < 146)
+  {
+    constexpr int LOCAL_VIDEODB_ID_EPISODE_RUNTIME = 9;
+
+    // Create indices to speed up the queries below (CVideoDatabaseDDL::CreateIndices() has not been called yet)
+    m_pDS->exec("CREATE UNIQUE INDEX ix_episode_file_1 ON episode (idEpisode, idFile)");
+    m_pDS->exec("CREATE UNIQUE INDEX id_episode_file_2 ON episode (idFile, idEpisode)");
+    m_pDS->exec("CREATE INDEX ix_streamdetails ON streamdetails (idFile)");
+
+    // Create temporary table
+    // Avoids MySQL/MariaDB/Sqlite incompatible differences in the later UPDATE and DELETE queries
+    m_pDS->exec("CREATE TABLE single_video_streams "
+                "(idEpisode INTEGER PRIMARY KEY, idFile INTEGER, iVideoDuration INTEGER, "
+                "iTotalStreams INTEGER)");
+
+    // Populate temporary table
+    // Find any episode where the duration (c09) is 0 but there is a video stream with a positive duration in streamdetails
+    // We don't look for height/width = 0 here as the file may have been played and proper streamdetails derived
+    m_pDS->exec(PrepareSQL(
+        "INSERT INTO single_video_streams (idEpisode, idFile, iVideoDuration, iTotalStreams) "
+        "SELECT e.idEpisode, e.idFile, "
+        "  MAX(s.iVideoDuration), "
+        "  (SELECT COUNT(*) FROM streamdetails s2 WHERE s2.idFile = e.idFile) "
+        "FROM episode e "
+        "JOIN streamdetails s ON e.idFile = s.idFile "
+        "WHERE (e.c%02d = '0' OR e.c%02d IS NULL) "
+        "  AND s.iStreamType = 0 AND s.iVideoDuration > 0 "
+        "GROUP BY e.idEpisode, e.idFile",
+        LOCAL_VIDEODB_ID_EPISODE_RUNTIME));
+
+    // Update the episodes' duration with the value from streamdetails
+    m_pDS->exec(PrepareSQL("UPDATE episode "
+                           "SET c%02d = (SELECT iVideoDuration FROM single_video_streams AS s "
+                           "            WHERE s.idEpisode = episode.idEpisode) "
+                           "WHERE idEpisode IN (SELECT idEpisode FROM single_video_streams)",
+                           LOCAL_VIDEODB_ID_EPISODE_RUNTIME));
+
+    // Delete any streamdetails where the video height/width are 0 (dummy entry created by scraper)
+    m_pDS->exec(PrepareSQL("DELETE FROM streamdetails "
+                           "WHERE iVideoHeight = 0 AND iVideoWidth = 0 AND iStreamType = 0 "
+                           "  AND idFile IN (SELECT idFile FROM single_video_streams "
+                           "                   WHERE iTotalStreams = 1)"));
+
+    // Remove temporary table
+    m_pDS->exec("DROP TABLE IF EXISTS single_video_streams");
+
+    // Remove indices
+    m_pDS->dropIndex("episode", "ix_episode_file_1");
+    m_pDS->dropIndex("episode", "id_episode_file_2");
+    m_pDS->dropIndex("streamdetails", "ix_streamdetails");
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 145;
+  return 146;
 }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1590,23 +1590,13 @@ CVideoInfoScanner::~CVideoInfoScanner()
       }
     }
 
-    /* As HasStreamDetails() returns true for TV shows (because the scraper calls SetVideoInfoTag()
-     * directly to set the duration) a better test is just to see if we have any common flag info
-     * missing.  If we have already read an nfo file then this data should be populated, otherwise
-     * get it from the video file */
-
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-            CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
+            CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS) &&
+        !movieDetails.HasStreamDetails())
     {
-      const auto& strmdetails = movieDetails.m_streamDetails;
-      if (strmdetails.GetVideoCodec(1).empty() || strmdetails.GetVideoHeight(1) == 0 ||
-          strmdetails.GetVideoWidth(1) == 0 || strmdetails.GetVideoDuration(1) == 0)
-
-      {
-        CDVDFileInfo::GetFileStreamDetails(pItem);
-        CLog::Log(LOGDEBUG, "VideoInfoScanner: Extracted filestream details from video file {}",
-                  CURL::GetRedacted(path));
-      }
+      CDVDFileInfo::GetFileStreamDetails(pItem);
+      CLog::Log(LOGDEBUG, "VideoInfoScanner: Extracted filestream details from video file {}",
+                CURL::GetRedacted(path));
     }
 
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to {}:{}", content,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This finds any episode entries with a zero c09 duration field and updates it with the duration from streamdetails, deleting and streamdetails entries where there is a single video stream with height and width = 0.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Following on from discussion in #27606 and subseqeuently #27769.

Bluray episodes scanned with TMDB TV Shows scraper (prior to 1.8.1 where @pkscout kindly fixed it) had their duration (from the scraper) stored in streamdetails where height/width = 0 and the duration field in the episode table (c09) was left at 0.

(Note scanning with the TheTVDB scraper episodes.c09 is set correctly to the duration and there is no superfluous entry in streamdetails)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
