### PR TITLE
[Video][Database] Track source of streamdetails.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -442,6 +442,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
   {
     CStreamDetailSubtitle* sub = new CStreamDetailSubtitle();
     sub->m_strLanguage = subs[i].m_strLanguage;
+    sub->SetSource(CStreamDetail::MEDIA);
     details.AddStream(sub);
     result = true;
   }
@@ -581,6 +582,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
         if (!GetDetailsFromFrame(vstream, pDemux, *p))
           CLog::LogF(LOGERROR, "Failed to get HDR details from frame");
       }
+      p->SetSource(CStreamDetail::MEDIA);
 
       // stack handling
       if (URIUtils::IsStack(path))
@@ -627,6 +629,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
       p->m_iChannels = static_cast<CDemuxStreamAudio*>(stream)->iChannels;
       p->m_strLanguage = stream->language;
       p->m_strCodec = pDemux->GetStreamCodecName(stream->demuxerId, stream->uniqueId);
+      p->SetSource(CStreamDetail::MEDIA);
       details.AddStream(p);
       retVal = true;
     }
@@ -635,6 +638,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
     {
       CStreamDetailSubtitle *p = new CStreamDetailSubtitle();
       p->m_strLanguage = stream->language;
+      p->SetSource(CStreamDetail::MEDIA);
       details.AddStream(p);
       retVal = true;
     }
@@ -703,6 +707,7 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const std::string &path, CStream
       CStreamDetailSubtitle *dsub = new CStreamDetailSubtitle();
       std::string lang = stream->language;
       dsub->m_strLanguage = g_LangCodeExpander.ConvertToISO6392B(lang);
+      dsub->SetSource(CStreamDetail::MEDIA);
       details.AddStream(dsub);
     }
     return true;
@@ -717,6 +722,7 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const std::string &path, CStream
   CStreamDetailSubtitle *dsub = new CStreamDetailSubtitle();
   ExternalStreamInfo info = CUtil::GetExternalStreamDetailsFromFilename(path, filename);
   dsub->m_strLanguage = g_LangCodeExpander.ConvertToISO6392B(info.language);
+  dsub->SetSource(CStreamDetail::MEDIA);
   details.AddStream(dsub);
 
   return true;

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -453,6 +453,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
   {
     CStreamDetailSubtitle* sub = new CStreamDetailSubtitle();
     sub->m_strLanguage = subs[i].m_strLanguage;
+    sub->SetSource(CStreamDetail::MEDIA);
     details.AddStream(sub);
     result = true;
   }
@@ -592,6 +593,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
         if (!GetDetailsFromFrame(vstream, pDemux, *p))
           CLog::LogF(LOGERROR, "Failed to get HDR details from frame");
       }
+      p->SetSource(CStreamDetail::MEDIA);
 
       // stack handling
       if (URIUtils::IsStack(path))
@@ -638,6 +640,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
       p->m_iChannels = static_cast<CDemuxStreamAudio*>(stream)->iChannels;
       p->m_strLanguage = stream->language;
       p->m_strCodec = pDemux->GetStreamCodecName(stream->demuxerId, stream->uniqueId);
+      p->SetSource(CStreamDetail::MEDIA);
       details.AddStream(p);
       retVal = true;
     }
@@ -646,6 +649,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
     {
       CStreamDetailSubtitle *p = new CStreamDetailSubtitle();
       p->m_strLanguage = stream->language;
+      p->SetSource(CStreamDetail::MEDIA);
       details.AddStream(p);
       retVal = true;
     }
@@ -714,6 +718,7 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const std::string &path, CStream
       CStreamDetailSubtitle *dsub = new CStreamDetailSubtitle();
       std::string lang = stream->language;
       dsub->m_strLanguage = g_LangCodeExpander.ConvertToISO6392B(lang);
+      dsub->SetSource(CStreamDetail::MEDIA);
       details.AddStream(dsub);
     }
     return true;
@@ -728,6 +733,7 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const std::string &path, CStream
   CStreamDetailSubtitle *dsub = new CStreamDetailSubtitle();
   ExternalStreamInfo info = CUtil::GetExternalStreamDetailsFromFilename(path, filename);
   dsub->m_strLanguage = g_LangCodeExpander.ConvertToISO6392B(info.language);
+  dsub->SetSource(CStreamDetail::MEDIA);
   details.AddStream(dsub);
 
   return true;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5836,20 +5836,20 @@ void CVideoPlayer::UpdateFileItemStreamDetails(CFileItem& item, UpdateStreamDeta
   CVideoInfoTag* info = item.GetVideoInfoTag();
   GetVideoStreamInfo(CURRENT_STREAM, videoInfo);
   info->m_streamDetails.SetStreams(videoInfo, m_processInfo->GetMaxTime() / 1000, audioInfo,
-                                   subtitleInfo);
+                                   subtitleInfo, CStreamDetail::MEDIA);
 
   //grab all the audio and subtitle info and save it
 
   for (int i = 0; i < GetAudioStreamCount(); i++)
   {
     GetAudioStreamInfo(i, audioInfo);
-    info->m_streamDetails.AddStream(new CStreamDetailAudio(audioInfo));
+    info->m_streamDetails.AddStream(new CStreamDetailAudio(audioInfo, CStreamDetail::MEDIA));
   }
 
   for (int i = 0; i < GetSubtitleCount(); i++)
   {
     GetSubtitleStreamInfo(i, subtitleInfo);
-    info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitleInfo));
+    info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitleInfo, CStreamDetail::MEDIA));
   }
 }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5968,20 +5968,20 @@ void CVideoPlayer::UpdateFileItemStreamDetails(CFileItem& item, UpdateStreamDeta
   CVideoInfoTag* info = item.GetVideoInfoTag();
   GetVideoStreamInfo(CURRENT_STREAM, videoInfo);
   info->m_streamDetails.SetStreams(videoInfo, m_processInfo->GetMaxTime() / 1000, audioInfo,
-                                   subtitleInfo);
+                                   subtitleInfo, CStreamDetail::MEDIA);
 
   //grab all the audio and subtitle info and save it
 
   for (int i = 0; i < GetAudioStreamCount(); i++)
   {
     GetAudioStreamInfo(i, audioInfo);
-    info->m_streamDetails.AddStream(new CStreamDetailAudio(audioInfo));
+    info->m_streamDetails.AddStream(new CStreamDetailAudio(audioInfo, CStreamDetail::MEDIA));
   }
 
   for (int i = 0; i < GetSubtitleCount(); i++)
   {
     GetSubtitleStreamInfo(i, subtitleInfo);
-    info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitleInfo));
+    info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitleInfo, CStreamDetail::MEDIA));
   }
 }
 

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -198,17 +198,18 @@ void SetStreamDetails(const CURL& url,
   if (!title.videoStreams.empty())
     info->m_streamDetails.SetStreams(title.videoStreams[0],
                                      static_cast<int>(title.duration.count() / 1000),
-                                     AudioStreamInfo{}, SubtitleStreamInfo{});
+                                     AudioStreamInfo{}, SubtitleStreamInfo{}, CStreamDetail::MEDIA);
   else
-    info->m_streamDetails.SetStreams(VideoStreamInfo{}, 0, AudioStreamInfo{}, SubtitleStreamInfo{});
+    info->m_streamDetails.SetStreams(VideoStreamInfo{}, 0, AudioStreamInfo{}, SubtitleStreamInfo{},
+                                     CStreamDetail::MEDIA);
 
   // Audio streams
   for (const auto& audio : title.audioStreams)
-    info->m_streamDetails.AddStream(new CStreamDetailAudio(audio));
+    info->m_streamDetails.AddStream(new CStreamDetailAudio(audio, CStreamDetail::MEDIA));
 
   // Subtitles
   for (const auto& subtitle : title.pgStreams)
-    info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitle));
+    info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitle, CStreamDetail::MEDIA));
 
   info->m_streamDetails.DetermineBestStreams();
 }

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -225,17 +225,18 @@ bool SetStreamDetails(const CURL& url,
   if (!title.videoStreams.empty())
     info->m_streamDetails.SetStreams(title.videoStreams[0],
                                      static_cast<int>(title.duration.count() / 1000),
-                                     AudioStreamInfo{}, SubtitleStreamInfo{});
+                                     AudioStreamInfo{}, SubtitleStreamInfo{}, CStreamDetail::MEDIA);
   else
-    info->m_streamDetails.SetStreams(VideoStreamInfo{}, 0, AudioStreamInfo{}, SubtitleStreamInfo{});
+    info->m_streamDetails.SetStreams(VideoStreamInfo{}, 0, AudioStreamInfo{}, SubtitleStreamInfo{},
+                                     CStreamDetail::MEDIA);
 
   // Audio streams
   for (const auto& audio : title.audioStreams)
-    info->m_streamDetails.AddStream(new CStreamDetailAudio(audio));
+    info->m_streamDetails.AddStream(new CStreamDetailAudio(audio, CStreamDetail::MEDIA));
 
   // Subtitles
   for (const auto& subtitle : title.pgStreams)
-    info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitle));
+    info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitle, CStreamDetail::MEDIA));
 
   info->m_streamDetails.DetermineBestStreams();
   return true;

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -1786,8 +1786,11 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, MenuDecis
     selectedItem = *items[0]; // Main item
 
   item.SetDynPath(selectedItem.GetDynPath());
-  item.GetVideoInfoTag()->m_streamDetails = selectedItem.GetVideoInfoTag()->m_streamDetails;
   item.SetProperty("original_listitem_url", originalDynPath);
+
+  // If streamdetails are already present and they are from an nfo and should not be overwritten
+  if (!item.GetVideoInfoTag()->HasNFOStreamDetails())
+    item.GetVideoInfoTag()->m_streamDetails = selectedItem.GetVideoInfoTag()->m_streamDetails;
 
   return true;
 }

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -2697,7 +2697,8 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(const CFileItem& item,
         tag->SetFileNameAndPath(selectedItem.GetDynPath());
         if (selectedItem.HasVideoInfoTag())
         {
-          if (selectedItem.GetVideoInfoTag()->HasStreamDetails())
+          // Don't overwrite streamdetails that came from an nfo
+          if (selectedItem.GetVideoInfoTag()->HasStreamDetails() && !tag->HasNFOStreamDetails())
             tag->m_streamDetails = selectedItem.GetVideoInfoTag()->m_streamDetails;
 
           // Episode bookmarks

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -2024,8 +2024,8 @@ TEST_F(TestDiscDirectoryHelper,
         VideoStreamInfo video;
         video.valid = true;
         const auto duration{static_cast<int>(playlists.at(playlist).duration.count() / 1000)};
-        item.GetVideoInfoTag()->m_streamDetails.SetStreams(video, duration, AudioStreamInfo{},
-                                                           SubtitleStreamInfo{});
+        item.GetVideoInfoTag()->m_streamDetails.SetStreams(
+            video, duration, AudioStreamInfo{}, SubtitleStreamInfo{}, CStreamDetail::MEDIA);
       }};
 
   // Episode 17 has playlist 601 to itself, so runs for all of it. Episodes 18-21 share 602 and each

--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -1085,6 +1085,7 @@ namespace XBMCAddon
 
     void InfoTagVideo::addStreamRaw(CVideoInfoTag* infoTag, CStreamDetail* stream)
     {
+      stream->SetSource(CStreamDetail::EXTERNAL);
       infoTag->m_streamDetails.AddStream(stream);
     }
 

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1154,6 +1154,7 @@ int PopulateTagFromObject(CVideoInfoTag& tag,
       detail->m_iChannels = resource->m_NbAudioChannels;
       tag.m_streamDetails.AddStream(detail);
     }
+    tag.m_streamDetails.SetSources(CStreamDetail::EXTERNAL);
   }
   return NPT_SUCCESS;
 }

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -11,7 +11,6 @@
 #include "FileItem.h"
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
-#include "StringUtils.h"
 #include "URIUtils.h"
 #include "URL.h"
 #include "Util.h"
@@ -24,17 +23,13 @@
 #include "music/MusicFileItemClassify.h"
 #include "music/tags/MusicInfoTag.h"
 #include "network/upnp/UPnP.h"
-#include "utils/ComponentContainer.h"
 #include "utils/Variant.h"
 #include "video/Bookmark.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoFileItemClassify.h"
 
-#include <chrono>
-
 using namespace KODI;
 using namespace KODI::VIDEO;
-using namespace std::chrono_literals;
 
 void CSaveFileState::DoWork(CFileItem& item,
                             CBookmark& bookmark,
@@ -203,7 +198,10 @@ void CSaveFileState::DoWork(CFileItem& item,
 
           // Check whether the item's db streamdetails need updating
           if (!videodatabase.GetStreamDetails(dbItem) ||
-              dbItem.GetVideoInfoTag()->m_streamDetails != item.GetVideoInfoTag()->m_streamDetails)
+              (dbItem.GetVideoInfoTag()->m_streamDetails !=
+                   item.GetVideoInfoTag()->m_streamDetails &&
+               dbItem.GetVideoInfoTag()->m_streamDetails.ShouldUpdateWithNewDetails(
+                   item.GetVideoInfoTag()->m_streamDetails)))
           {
             videodatabase.BeginTransaction();
 

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -14,16 +14,28 @@
 #include "utils/LangCodeExpander.h"
 #include "utils/Variant.h"
 
-#include <math.h>
+#include <algorithm>
+#include <cmath>
+#include <ranges>
 
 const float VIDEOASPECT_EPSILON = 0.025f;
+
+CStreamDetail::Source CStreamDetail::GetSource() const
+{
+  return m_source;
+}
+
+void CStreamDetail::SetSource(Source source)
+{
+  m_source = source;
+}
 
 CStreamDetailVideo::CStreamDetailVideo() :
   CStreamDetail(CStreamDetail::VIDEO)
 {
 }
 
-CStreamDetailVideo::CStreamDetailVideo(const VideoStreamInfo& info, int duration)
+CStreamDetailVideo::CStreamDetailVideo(const VideoStreamInfo& info, int duration, Source source)
   : CStreamDetail(CStreamDetail::VIDEO),
     m_iWidth(info.width),
     m_iHeight(info.height),
@@ -35,6 +47,7 @@ CStreamDetailVideo::CStreamDetailVideo(const VideoStreamInfo& info, int duration
     m_strHdrType(CStreamDetails::HdrTypeToString(info.hdrType)),
     m_strHdrDetail(info.hdrDetail)
 {
+  m_source = source;
 }
 
 void CStreamDetailVideo::Archive(CArchive& ar)
@@ -50,6 +63,7 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     ar << m_strLanguage;
     ar << m_strHdrType;
     ar << m_strHdrDetail;
+    ar << m_source;
   }
   else
   {
@@ -62,6 +76,9 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     ar >> m_strLanguage;
     ar >> m_strHdrType;
     ar >> m_strHdrDetail;
+    int s;
+    ar >> s;
+    m_source = static_cast<Source>(s);
   }
 }
 void CStreamDetailVideo::Serialize(CVariant& value) const
@@ -75,6 +92,7 @@ void CStreamDetailVideo::Serialize(CVariant& value) const
   value["language"] = m_strLanguage;
   value["hdrtype"] = m_strHdrType;
   value["hdrdetail"] = m_strHdrDetail;
+  value["source"] = m_source;
 }
 
 bool CStreamDetailVideo::IsWorseThan(const CStreamDetail &that) const
@@ -92,12 +110,13 @@ CStreamDetailAudio::CStreamDetailAudio() :
 {
 }
 
-CStreamDetailAudio::CStreamDetailAudio(const AudioStreamInfo &info) :
-  CStreamDetail(CStreamDetail::AUDIO),
-  m_iChannels(info.channels),
-  m_strCodec(info.codecName),
-  m_strLanguage(info.language)
+CStreamDetailAudio::CStreamDetailAudio(const AudioStreamInfo& info, Source source)
+  : CStreamDetail(CStreamDetail::AUDIO),
+    m_iChannels(info.channels),
+    m_strCodec(info.codecName),
+    m_strLanguage(info.language)
 {
+  m_source = source;
 }
 
 void CStreamDetailAudio::Archive(CArchive& ar)
@@ -107,12 +126,16 @@ void CStreamDetailAudio::Archive(CArchive& ar)
     ar << m_strCodec;
     ar << m_strLanguage;
     ar << m_iChannels;
+    ar << m_source;
   }
   else
   {
     ar >> m_strCodec;
     ar >> m_strLanguage;
     ar >> m_iChannels;
+    int s;
+    ar >> s;
+    m_source = static_cast<Source>(s);
   }
 }
 void CStreamDetailAudio::Serialize(CVariant& value) const
@@ -120,6 +143,7 @@ void CStreamDetailAudio::Serialize(CVariant& value) const
   value["codec"] = m_strCodec;
   value["language"] = m_strLanguage;
   value["channels"] = m_iChannels;
+  value["source"] = m_source;
 }
 
 bool CStreamDetailAudio::IsWorseThan(const CStreamDetail &that) const
@@ -143,10 +167,11 @@ CStreamDetailSubtitle::CStreamDetailSubtitle() :
 {
 }
 
-CStreamDetailSubtitle::CStreamDetailSubtitle(const SubtitleStreamInfo &info) :
-  CStreamDetail(CStreamDetail::SUBTITLE),
-  m_strLanguage(info.language)
+CStreamDetailSubtitle::CStreamDetailSubtitle(const SubtitleStreamInfo& info, Source source)
+  : CStreamDetail(CStreamDetail::SUBTITLE),
+    m_strLanguage(info.language)
 {
+  m_source = source;
 }
 
 void CStreamDetailSubtitle::Archive(CArchive& ar)
@@ -154,15 +179,20 @@ void CStreamDetailSubtitle::Archive(CArchive& ar)
   if (ar.IsStoring())
   {
     ar << m_strLanguage;
+    ar << m_source;
   }
   else
   {
     ar >> m_strLanguage;
+    int s;
+    ar >> s;
+    m_source = static_cast<Source>(s);
   }
 }
 void CStreamDetailSubtitle::Serialize(CVariant& value) const
 {
   value["language"] = m_strLanguage;
+  value["source"] = m_source;
 }
 
 bool CStreamDetailSubtitle::IsWorseThan(const CStreamDetail &that) const
@@ -195,6 +225,7 @@ CStreamDetailVideo& CStreamDetailVideo::operator=(const CStreamDetailVideo& that
     this->m_strHdrType = that.m_strHdrType;
     this->m_strHdrTypeAlt = that.m_strHdrTypeAlt;
     this->m_strHdrDetail = that.m_strHdrDetail;
+    this->m_source = that.m_source;
   }
   return *this;
 }
@@ -205,6 +236,7 @@ CStreamDetailSubtitle& CStreamDetailSubtitle::operator=(const CStreamDetailSubti
   {
     this->m_pParent = that.m_pParent;
     this->m_strLanguage = that.m_strLanguage;
+    this->m_source = that.m_source;
   }
   return *this;
 }
@@ -247,25 +279,29 @@ bool CStreamDetails::operator ==(const CStreamDetails &right) const
 
   for (int iStream=1; iStream<=GetVideoStreamCount(); iStream++)
   {
-    if (GetVideoCodec(iStream)    != right.GetVideoCodec(iStream)    ||
-        GetVideoWidth(iStream)    != right.GetVideoWidth(iStream)    ||
-        GetVideoHeight(iStream)   != right.GetVideoHeight(iStream)   ||
+    if (GetVideoCodec(iStream) != right.GetVideoCodec(iStream) ||
+        GetVideoWidth(iStream) != right.GetVideoWidth(iStream) ||
+        GetVideoHeight(iStream) != right.GetVideoHeight(iStream) ||
         GetVideoDuration(iStream) != right.GetVideoDuration(iStream) ||
-        fabs(GetVideoAspect(iStream) - right.GetVideoAspect(iStream)) > VIDEOASPECT_EPSILON)
+        fabsf(GetVideoAspect(iStream) - right.GetVideoAspect(iStream)) > VIDEOASPECT_EPSILON ||
+        GetSource(CStreamDetail::VIDEO, iStream) != right.GetSource(CStreamDetail::VIDEO, iStream))
       return false;
   }
 
   for (int iStream=1; iStream<=GetAudioStreamCount(); iStream++)
   {
-    if (GetAudioCodec(iStream)    != right.GetAudioCodec(iStream)    ||
+    if (GetAudioCodec(iStream) != right.GetAudioCodec(iStream) ||
         GetAudioLanguage(iStream) != right.GetAudioLanguage(iStream) ||
-        GetAudioChannels(iStream) != right.GetAudioChannels(iStream) )
+        GetAudioChannels(iStream) != right.GetAudioChannels(iStream) ||
+        GetSource(CStreamDetail::AUDIO, iStream) != right.GetSource(CStreamDetail::AUDIO, iStream))
       return false;
   }
 
   for (int iStream=1; iStream<=GetSubtitleStreamCount(); iStream++)
   {
-    if (GetSubtitleLanguage(iStream) != right.GetSubtitleLanguage(iStream) )
+    if (GetSubtitleLanguage(iStream) != right.GetSubtitleLanguage(iStream) ||
+        GetSource(CStreamDetail::SUBTITLE, iStream) !=
+            right.GetSource(CStreamDetail::SUBTITLE, iStream))
       return false;
   }
 
@@ -682,17 +718,21 @@ std::string CStreamDetails::VideoAspectToAspectDescription(float fAspect)
   return "2.76";
 }
 
-bool CStreamDetails::SetStreams(const VideoStreamInfo& videoInfo, int videoDuration, const AudioStreamInfo& audioInfo, const SubtitleStreamInfo& subtitleInfo)
+bool CStreamDetails::SetStreams(const VideoStreamInfo& videoInfo,
+                                int videoDuration,
+                                const AudioStreamInfo& audioInfo,
+                                const SubtitleStreamInfo& subtitleInfo,
+                                CStreamDetail::Source source)
 {
   if (!videoInfo.valid && !audioInfo.valid && !subtitleInfo.valid)
     return false;
   Reset();
   if (videoInfo.valid)
-    AddStream(new CStreamDetailVideo(videoInfo, videoDuration));
+    AddStream(new CStreamDetailVideo(videoInfo, videoDuration, source));
   if (audioInfo.valid)
-    AddStream(new CStreamDetailAudio(audioInfo));
+    AddStream(new CStreamDetailAudio(audioInfo, source));
   if (subtitleInfo.valid)
-    AddStream(new CStreamDetailSubtitle(subtitleInfo));
+    AddStream(new CStreamDetailSubtitle(subtitleInfo, source));
   DetermineBestStreams();
   return true;
 }
@@ -713,4 +753,29 @@ std::string CStreamDetails::HdrTypeToString(StreamHdrType hdrType)
     default:
       return "";
   }
+}
+
+CStreamDetail::Source CStreamDetails::GetSource(CStreamDetail::StreamType type, int idx) const
+{
+  const CStreamDetail* item = GetNthStream(type, idx);
+  return item ? item->GetSource() : CStreamDetail::UNDEFINED;
+}
+
+CStreamDetail::Source CStreamDetails::GetSources() const
+{
+  if (!HasItems())
+    return CStreamDetail::UNDEFINED;
+  return std::ranges::max(m_vecItems |
+                          std::views::transform([](const auto& s) { return s->GetSource(); }));
+}
+
+void CStreamDetails::SetSources(CStreamDetail::Source source)
+{
+  for (const auto& s : m_vecItems)
+    s->SetSource(source);
+}
+
+bool CStreamDetails::ShouldUpdateWithNewDetails(const CStreamDetails& newInfo) const
+{
+  return (GetSources() <= newInfo.GetSources());
 }

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -64,6 +64,7 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     ar << m_strHdrType;
     ar << m_strHdrDetail;
     ar << static_cast<int>(m_source);
+    ar << m_version;
   }
   else
   {
@@ -79,6 +80,7 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     int s;
     ar >> s;
     m_source = static_cast<Source>(s);
+    ar >> m_version;
   }
 }
 void CStreamDetailVideo::Serialize(CVariant& value) const
@@ -93,6 +95,7 @@ void CStreamDetailVideo::Serialize(CVariant& value) const
   value["hdrtype"] = m_strHdrType;
   value["hdrdetail"] = m_strHdrDetail;
   value["source"] = static_cast<int>(m_source);
+  value["version"] = m_version;
 }
 
 bool CStreamDetailVideo::IsWorseThan(const CStreamDetail &that) const
@@ -127,6 +130,7 @@ void CStreamDetailAudio::Archive(CArchive& ar)
     ar << m_strLanguage;
     ar << m_iChannels;
     ar << static_cast<int>(m_source);
+    ar << m_version;
   }
   else
   {
@@ -136,6 +140,7 @@ void CStreamDetailAudio::Archive(CArchive& ar)
     int s;
     ar >> s;
     m_source = static_cast<Source>(s);
+    ar >> m_version;
   }
 }
 void CStreamDetailAudio::Serialize(CVariant& value) const
@@ -144,6 +149,7 @@ void CStreamDetailAudio::Serialize(CVariant& value) const
   value["language"] = m_strLanguage;
   value["channels"] = m_iChannels;
   value["source"] = static_cast<int>(m_source);
+  value["version"] = m_version;
 }
 
 bool CStreamDetailAudio::IsWorseThan(const CStreamDetail &that) const
@@ -180,6 +186,7 @@ void CStreamDetailSubtitle::Archive(CArchive& ar)
   {
     ar << m_strLanguage;
     ar << static_cast<int>(m_source);
+    ar << m_version;
   }
   else
   {
@@ -187,12 +194,14 @@ void CStreamDetailSubtitle::Archive(CArchive& ar)
     int s;
     ar >> s;
     m_source = static_cast<Source>(s);
+    ar >> m_version;
   }
 }
 void CStreamDetailSubtitle::Serialize(CVariant& value) const
 {
   value["language"] = m_strLanguage;
   value["source"] = static_cast<int>(m_source);
+  value["version"] = m_version;
 }
 
 bool CStreamDetailSubtitle::IsWorseThan(const CStreamDetail &that) const
@@ -226,6 +235,7 @@ CStreamDetailVideo& CStreamDetailVideo::operator=(const CStreamDetailVideo& that
     this->m_strHdrTypeAlt = that.m_strHdrTypeAlt;
     this->m_strHdrDetail = that.m_strHdrDetail;
     this->m_source = that.m_source;
+    this->m_version = that.m_version;
   }
   return *this;
 }
@@ -237,6 +247,7 @@ CStreamDetailSubtitle& CStreamDetailSubtitle::operator=(const CStreamDetailSubti
     this->m_pParent = that.m_pParent;
     this->m_strLanguage = that.m_strLanguage;
     this->m_source = that.m_source;
+    this->m_version = that.m_version;
   }
   return *this;
 }
@@ -732,6 +743,12 @@ CStreamDetail::Source CStreamDetails::GetSource(CStreamDetail::StreamType type, 
 {
   const CStreamDetail* item = GetNthStream(type, idx);
   return item ? item->GetSource() : CStreamDetail::UNDEFINED;
+}
+
+int CStreamDetails::GetVersion(CStreamDetail::StreamType type, int idx) const
+{
+  const CStreamDetail* item = GetNthStream(type, idx);
+  return item ? item->GetVersion() : 0;
 }
 
 CStreamDetail::Source CStreamDetails::GetSources() const

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -14,16 +14,28 @@
 #include "utils/LangCodeExpander.h"
 #include "utils/Variant.h"
 
-#include <math.h>
+#include <algorithm>
+#include <cmath>
+#include <ranges>
 
 const float VIDEOASPECT_EPSILON = 0.025f;
+
+CStreamDetail::Source CStreamDetail::GetSource() const
+{
+  return m_source;
+}
+
+void CStreamDetail::SetSource(Source source)
+{
+  m_source = source;
+}
 
 CStreamDetailVideo::CStreamDetailVideo() :
   CStreamDetail(CStreamDetail::VIDEO)
 {
 }
 
-CStreamDetailVideo::CStreamDetailVideo(const VideoStreamInfo& info, int duration)
+CStreamDetailVideo::CStreamDetailVideo(const VideoStreamInfo& info, int duration, Source source)
   : CStreamDetail(CStreamDetail::VIDEO),
     m_iWidth(info.width),
     m_iHeight(info.height),
@@ -35,6 +47,7 @@ CStreamDetailVideo::CStreamDetailVideo(const VideoStreamInfo& info, int duration
     m_strHdrType(CStreamDetails::HdrTypeToString(info.hdrType)),
     m_strHdrDetail(info.hdrDetail)
 {
+  m_source = source;
 }
 
 void CStreamDetailVideo::Archive(CArchive& ar)
@@ -50,6 +63,7 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     ar << m_strLanguage;
     ar << m_strHdrType;
     ar << m_strHdrDetail;
+    ar << static_cast<int>(m_source);
   }
   else
   {
@@ -62,6 +76,9 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     ar >> m_strLanguage;
     ar >> m_strHdrType;
     ar >> m_strHdrDetail;
+    int s;
+    ar >> s;
+    m_source = static_cast<Source>(s);
   }
 }
 void CStreamDetailVideo::Serialize(CVariant& value) const
@@ -75,6 +92,7 @@ void CStreamDetailVideo::Serialize(CVariant& value) const
   value["language"] = m_strLanguage;
   value["hdrtype"] = m_strHdrType;
   value["hdrdetail"] = m_strHdrDetail;
+  value["source"] = static_cast<int>(m_source);
 }
 
 bool CStreamDetailVideo::IsWorseThan(const CStreamDetail &that) const
@@ -92,12 +110,13 @@ CStreamDetailAudio::CStreamDetailAudio() :
 {
 }
 
-CStreamDetailAudio::CStreamDetailAudio(const AudioStreamInfo &info) :
-  CStreamDetail(CStreamDetail::AUDIO),
-  m_iChannels(info.channels),
-  m_strCodec(info.codecName),
-  m_strLanguage(info.language)
+CStreamDetailAudio::CStreamDetailAudio(const AudioStreamInfo& info, Source source)
+  : CStreamDetail(CStreamDetail::AUDIO),
+    m_iChannels(info.channels),
+    m_strCodec(info.codecName),
+    m_strLanguage(info.language)
 {
+  m_source = source;
 }
 
 void CStreamDetailAudio::Archive(CArchive& ar)
@@ -107,12 +126,16 @@ void CStreamDetailAudio::Archive(CArchive& ar)
     ar << m_strCodec;
     ar << m_strLanguage;
     ar << m_iChannels;
+    ar << static_cast<int>(m_source);
   }
   else
   {
     ar >> m_strCodec;
     ar >> m_strLanguage;
     ar >> m_iChannels;
+    int s;
+    ar >> s;
+    m_source = static_cast<Source>(s);
   }
 }
 void CStreamDetailAudio::Serialize(CVariant& value) const
@@ -120,6 +143,7 @@ void CStreamDetailAudio::Serialize(CVariant& value) const
   value["codec"] = m_strCodec;
   value["language"] = m_strLanguage;
   value["channels"] = m_iChannels;
+  value["source"] = static_cast<int>(m_source);
 }
 
 bool CStreamDetailAudio::IsWorseThan(const CStreamDetail &that) const
@@ -143,10 +167,11 @@ CStreamDetailSubtitle::CStreamDetailSubtitle() :
 {
 }
 
-CStreamDetailSubtitle::CStreamDetailSubtitle(const SubtitleStreamInfo &info) :
-  CStreamDetail(CStreamDetail::SUBTITLE),
-  m_strLanguage(info.language)
+CStreamDetailSubtitle::CStreamDetailSubtitle(const SubtitleStreamInfo& info, Source source)
+  : CStreamDetail(CStreamDetail::SUBTITLE),
+    m_strLanguage(info.language)
 {
+  m_source = source;
 }
 
 void CStreamDetailSubtitle::Archive(CArchive& ar)
@@ -154,15 +179,20 @@ void CStreamDetailSubtitle::Archive(CArchive& ar)
   if (ar.IsStoring())
   {
     ar << m_strLanguage;
+    ar << static_cast<int>(m_source);
   }
   else
   {
     ar >> m_strLanguage;
+    int s;
+    ar >> s;
+    m_source = static_cast<Source>(s);
   }
 }
 void CStreamDetailSubtitle::Serialize(CVariant& value) const
 {
   value["language"] = m_strLanguage;
+  value["source"] = static_cast<int>(m_source);
 }
 
 bool CStreamDetailSubtitle::IsWorseThan(const CStreamDetail &that) const
@@ -195,6 +225,7 @@ CStreamDetailVideo& CStreamDetailVideo::operator=(const CStreamDetailVideo& that
     this->m_strHdrType = that.m_strHdrType;
     this->m_strHdrTypeAlt = that.m_strHdrTypeAlt;
     this->m_strHdrDetail = that.m_strHdrDetail;
+    this->m_source = that.m_source;
   }
   return *this;
 }
@@ -205,6 +236,7 @@ CStreamDetailSubtitle& CStreamDetailSubtitle::operator=(const CStreamDetailSubti
   {
     this->m_pParent = that.m_pParent;
     this->m_strLanguage = that.m_strLanguage;
+    this->m_source = that.m_source;
   }
   return *this;
 }
@@ -247,25 +279,29 @@ bool CStreamDetails::operator ==(const CStreamDetails &right) const
 
   for (int iStream=1; iStream<=GetVideoStreamCount(); iStream++)
   {
-    if (GetVideoCodec(iStream)    != right.GetVideoCodec(iStream)    ||
-        GetVideoWidth(iStream)    != right.GetVideoWidth(iStream)    ||
-        GetVideoHeight(iStream)   != right.GetVideoHeight(iStream)   ||
+    if (GetVideoCodec(iStream) != right.GetVideoCodec(iStream) ||
+        GetVideoWidth(iStream) != right.GetVideoWidth(iStream) ||
+        GetVideoHeight(iStream) != right.GetVideoHeight(iStream) ||
         GetVideoDuration(iStream) != right.GetVideoDuration(iStream) ||
-        fabs(GetVideoAspect(iStream) - right.GetVideoAspect(iStream)) > VIDEOASPECT_EPSILON)
+        std::fabs(GetVideoAspect(iStream) - right.GetVideoAspect(iStream)) > VIDEOASPECT_EPSILON ||
+        GetSource(CStreamDetail::VIDEO, iStream) != right.GetSource(CStreamDetail::VIDEO, iStream))
       return false;
   }
 
   for (int iStream=1; iStream<=GetAudioStreamCount(); iStream++)
   {
-    if (GetAudioCodec(iStream)    != right.GetAudioCodec(iStream)    ||
+    if (GetAudioCodec(iStream) != right.GetAudioCodec(iStream) ||
         GetAudioLanguage(iStream) != right.GetAudioLanguage(iStream) ||
-        GetAudioChannels(iStream) != right.GetAudioChannels(iStream) )
+        GetAudioChannels(iStream) != right.GetAudioChannels(iStream) ||
+        GetSource(CStreamDetail::AUDIO, iStream) != right.GetSource(CStreamDetail::AUDIO, iStream))
       return false;
   }
 
   for (int iStream=1; iStream<=GetSubtitleStreamCount(); iStream++)
   {
-    if (GetSubtitleLanguage(iStream) != right.GetSubtitleLanguage(iStream) )
+    if (GetSubtitleLanguage(iStream) != right.GetSubtitleLanguage(iStream) ||
+        GetSource(CStreamDetail::SUBTITLE, iStream) !=
+            right.GetSource(CStreamDetail::SUBTITLE, iStream))
       return false;
   }
 
@@ -655,17 +691,21 @@ std::string CStreamDetails::VideoAspectToAspectDescription(float fAspect)
   return std::string(COMMON_ASPECT_RATIOS.back().label);
 }
 
-bool CStreamDetails::SetStreams(const VideoStreamInfo& videoInfo, int videoDuration, const AudioStreamInfo& audioInfo, const SubtitleStreamInfo& subtitleInfo)
+bool CStreamDetails::SetStreams(const VideoStreamInfo& videoInfo,
+                                int videoDuration,
+                                const AudioStreamInfo& audioInfo,
+                                const SubtitleStreamInfo& subtitleInfo,
+                                CStreamDetail::Source source)
 {
   if (!videoInfo.valid && !audioInfo.valid && !subtitleInfo.valid)
     return false;
   Reset();
   if (videoInfo.valid)
-    AddStream(new CStreamDetailVideo(videoInfo, videoDuration));
+    AddStream(new CStreamDetailVideo(videoInfo, videoDuration, source));
   if (audioInfo.valid)
-    AddStream(new CStreamDetailAudio(audioInfo));
+    AddStream(new CStreamDetailAudio(audioInfo, source));
   if (subtitleInfo.valid)
-    AddStream(new CStreamDetailSubtitle(subtitleInfo));
+    AddStream(new CStreamDetailSubtitle(subtitleInfo, source));
   DetermineBestStreams();
   return true;
 }
@@ -686,4 +726,29 @@ std::string CStreamDetails::HdrTypeToString(StreamHdrType hdrType)
     default:
       return "";
   }
+}
+
+CStreamDetail::Source CStreamDetails::GetSource(CStreamDetail::StreamType type, int idx) const
+{
+  const CStreamDetail* item = GetNthStream(type, idx);
+  return item ? item->GetSource() : CStreamDetail::UNDEFINED;
+}
+
+CStreamDetail::Source CStreamDetails::GetSources() const
+{
+  if (!HasItems())
+    return CStreamDetail::UNDEFINED;
+  return std::ranges::max(m_vecItems |
+                          std::views::transform([](const auto& s) { return s->GetSource(); }));
+}
+
+void CStreamDetails::SetSources(CStreamDetail::Source source)
+{
+  for (const auto& s : m_vecItems)
+    s->SetSource(source);
+}
+
+bool CStreamDetails::ShouldUpdateWithNewDetails(const CStreamDetails& newInfo) const
+{
+  return (GetSources() <= newInfo.GetSources());
 }

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -64,6 +64,7 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     ar << m_strHdrType;
     ar << m_strHdrDetail;
     ar << m_source;
+    ar << m_version;
   }
   else
   {
@@ -79,6 +80,7 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     int s;
     ar >> s;
     m_source = static_cast<Source>(s);
+    ar >> m_version;
   }
 }
 void CStreamDetailVideo::Serialize(CVariant& value) const
@@ -93,6 +95,7 @@ void CStreamDetailVideo::Serialize(CVariant& value) const
   value["hdrtype"] = m_strHdrType;
   value["hdrdetail"] = m_strHdrDetail;
   value["source"] = m_source;
+  value["version"] = m_version;
 }
 
 bool CStreamDetailVideo::IsWorseThan(const CStreamDetail &that) const
@@ -127,6 +130,7 @@ void CStreamDetailAudio::Archive(CArchive& ar)
     ar << m_strLanguage;
     ar << m_iChannels;
     ar << m_source;
+    ar << m_version;
   }
   else
   {
@@ -136,6 +140,7 @@ void CStreamDetailAudio::Archive(CArchive& ar)
     int s;
     ar >> s;
     m_source = static_cast<Source>(s);
+    ar >> m_version;
   }
 }
 void CStreamDetailAudio::Serialize(CVariant& value) const
@@ -144,6 +149,7 @@ void CStreamDetailAudio::Serialize(CVariant& value) const
   value["language"] = m_strLanguage;
   value["channels"] = m_iChannels;
   value["source"] = m_source;
+  value["version"] = m_version;
 }
 
 bool CStreamDetailAudio::IsWorseThan(const CStreamDetail &that) const
@@ -180,6 +186,7 @@ void CStreamDetailSubtitle::Archive(CArchive& ar)
   {
     ar << m_strLanguage;
     ar << m_source;
+    ar << m_version;
   }
   else
   {
@@ -187,12 +194,14 @@ void CStreamDetailSubtitle::Archive(CArchive& ar)
     int s;
     ar >> s;
     m_source = static_cast<Source>(s);
+    ar >> m_version;
   }
 }
 void CStreamDetailSubtitle::Serialize(CVariant& value) const
 {
   value["language"] = m_strLanguage;
   value["source"] = m_source;
+  value["version"] = m_version;
 }
 
 bool CStreamDetailSubtitle::IsWorseThan(const CStreamDetail &that) const
@@ -226,6 +235,7 @@ CStreamDetailVideo& CStreamDetailVideo::operator=(const CStreamDetailVideo& that
     this->m_strHdrTypeAlt = that.m_strHdrTypeAlt;
     this->m_strHdrDetail = that.m_strHdrDetail;
     this->m_source = that.m_source;
+    this->m_version = that.m_version;
   }
   return *this;
 }
@@ -237,6 +247,7 @@ CStreamDetailSubtitle& CStreamDetailSubtitle::operator=(const CStreamDetailSubti
     this->m_pParent = that.m_pParent;
     this->m_strLanguage = that.m_strLanguage;
     this->m_source = that.m_source;
+    this->m_version = that.m_version;
   }
   return *this;
 }

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -31,11 +31,28 @@ public:
     SUBTITLE
   };
 
-  explicit CStreamDetail(StreamType type) : m_eType(type), m_pParent(NULL) {}
-  virtual ~CStreamDetail() = default;
+  // Source of the stream information
+  // Order is important - higher values (towards end of list) take precedence over lower values
+  // when updating stream details
+  enum Source : uint8_t
+  {
+    UNDEFINED = 0,
+    EXTERNAL = 10,
+    MEDIA = 20,
+    NFO = 30,
+    LEGACY = 40
+  };
+
+  explicit CStreamDetail(StreamType type) : m_eType(type), m_pParent(nullptr) {}
+  ~CStreamDetail() override = default;
+  CStreamDetail(const CStreamDetail&) = default;
+  CStreamDetail& operator=(const CStreamDetail&) = delete;
   virtual bool IsWorseThan(const CStreamDetail &that) const = 0;
+  Source GetSource() const;
+  void SetSource(Source source);
 
   const StreamType m_eType;
+  Source m_source{UNDEFINED};
 
 protected:
   CStreamDetails *m_pParent;
@@ -46,7 +63,7 @@ class CStreamDetailVideo final : public CStreamDetail
 {
 public:
   CStreamDetailVideo();
-  CStreamDetailVideo(const VideoStreamInfo &info, int duration = 0);
+  CStreamDetailVideo(const VideoStreamInfo& info, int duration, Source source);
   CStreamDetailVideo(const CStreamDetailVideo&) = default;
   CStreamDetailVideo& operator=(const CStreamDetailVideo& that);
   void Archive(CArchive& ar) override;
@@ -69,7 +86,8 @@ class CStreamDetailAudio final : public CStreamDetail
 {
 public:
   CStreamDetailAudio();
-  CStreamDetailAudio(const AudioStreamInfo &info);
+  CStreamDetailAudio(const AudioStreamInfo& info, Source source);
+  CStreamDetailAudio(const CStreamDetailAudio&) = default;
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
   bool IsWorseThan(const CStreamDetail &that) const override;
@@ -83,7 +101,7 @@ class CStreamDetailSubtitle final : public CStreamDetail
 {
 public:
   CStreamDetailSubtitle();
-  CStreamDetailSubtitle(const SubtitleStreamInfo &info);
+  CStreamDetailSubtitle(const SubtitleStreamInfo& info, Source source);
   CStreamDetailSubtitle(const CStreamDetailSubtitle&) = default;
   CStreamDetailSubtitle& operator=(const CStreamDetailSubtitle &that);
   void Archive(CArchive& ar) override;
@@ -137,7 +155,17 @@ public:
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
 
-  bool SetStreams(const VideoStreamInfo& videoInfo, int videoDuration, const AudioStreamInfo& audioInfo, const SubtitleStreamInfo& subtitleInfo);
+  bool SetStreams(const VideoStreamInfo& videoInfo,
+                  int videoDuration,
+                  const AudioStreamInfo& audioInfo,
+                  const SubtitleStreamInfo& subtitleInfo,
+                  CStreamDetail::Source source);
+
+  CStreamDetail::Source GetSource(CStreamDetail::StreamType type, int idx) const;
+  CStreamDetail::Source GetSources() const;
+  void SetSources(CStreamDetail::Source source);
+  bool ShouldUpdateWithNewDetails(const CStreamDetails& newInfo) const;
+
 private:
   CStreamDetail *NewStream(CStreamDetail::StreamType type);
   std::vector<std::unique_ptr<CStreamDetail>> m_vecItems;

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -25,6 +25,8 @@ struct SubtitleStreamInfo;
 class CStreamDetail : public IArchivable, public ISerializable
 {
 public:
+  static constexpr int STREAM_DETAILS_VERSION = 2;
+
   enum StreamType {
     VIDEO,
     AUDIO,
@@ -50,6 +52,7 @@ public:
   virtual bool IsWorseThan(const CStreamDetail &that) const = 0;
   Source GetSource() const;
   void SetSource(Source source);
+  int GetVersion() const { return m_version; }
 
   const StreamType m_eType;
   Source m_source{UNDEFINED};
@@ -57,6 +60,13 @@ public:
 protected:
   CStreamDetails *m_pParent;
   friend class CStreamDetails;
+
+private:
+  int m_version{STREAM_DETAILS_VERSION};
+  friend class CVideoDatabase;
+  friend class CStreamDetailVideo;
+  friend class CStreamDetailAudio;
+  friend class CStreamDetailSubtitle;
 };
 
 class CStreamDetailVideo final : public CStreamDetail

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -33,22 +33,40 @@ public:
     SUBTITLE
   };
 
-  explicit CStreamDetail(StreamType type) : m_eType(type), m_pParent(NULL) {}
-  virtual ~CStreamDetail() = default;
+  // Source of the stream information
+  // Order is important - higher values (towards end of list) take precedence over lower values
+  // when updating stream details
+  enum Source : uint8_t
+  {
+    UNDEFINED = 0,
+    EXTERNAL = 10,
+    MEDIA = 20,
+    NFO = 30,
+    LEGACY = 40
+  };
+
+  explicit CStreamDetail(StreamType type) : m_eType(type), m_pParent(nullptr) {}
+  ~CStreamDetail() override = default;
+  CStreamDetail(const CStreamDetail&) = default;
+  CStreamDetail& operator=(const CStreamDetail&) = delete;
   virtual bool IsWorseThan(const CStreamDetail &that) const = 0;
+  Source GetSource() const;
+  void SetSource(Source source);
 
   const StreamType m_eType;
 
 protected:
   CStreamDetails *m_pParent;
+  Source m_source{UNDEFINED};
   friend class CStreamDetails;
+  friend class CVideoDatabase;
 };
 
 class CStreamDetailVideo final : public CStreamDetail
 {
 public:
   CStreamDetailVideo();
-  CStreamDetailVideo(const VideoStreamInfo &info, int duration = 0);
+  CStreamDetailVideo(const VideoStreamInfo& info, int duration, Source source);
   CStreamDetailVideo(const CStreamDetailVideo&) = default;
   CStreamDetailVideo& operator=(const CStreamDetailVideo& that);
   void Archive(CArchive& ar) override;
@@ -71,7 +89,8 @@ class CStreamDetailAudio final : public CStreamDetail
 {
 public:
   CStreamDetailAudio();
-  CStreamDetailAudio(const AudioStreamInfo &info);
+  CStreamDetailAudio(const AudioStreamInfo& info, Source source);
+  CStreamDetailAudio(const CStreamDetailAudio&) = default;
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
   bool IsWorseThan(const CStreamDetail &that) const override;
@@ -85,7 +104,7 @@ class CStreamDetailSubtitle final : public CStreamDetail
 {
 public:
   CStreamDetailSubtitle();
-  CStreamDetailSubtitle(const SubtitleStreamInfo &info);
+  CStreamDetailSubtitle(const SubtitleStreamInfo& info, Source source);
   CStreamDetailSubtitle(const CStreamDetailSubtitle&) = default;
   CStreamDetailSubtitle& operator=(const CStreamDetailSubtitle &that);
   void Archive(CArchive& ar) override;
@@ -211,7 +230,17 @@ public:
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
 
-  bool SetStreams(const VideoStreamInfo& videoInfo, int videoDuration, const AudioStreamInfo& audioInfo, const SubtitleStreamInfo& subtitleInfo);
+  bool SetStreams(const VideoStreamInfo& videoInfo,
+                  int videoDuration,
+                  const AudioStreamInfo& audioInfo,
+                  const SubtitleStreamInfo& subtitleInfo,
+                  CStreamDetail::Source source);
+
+  CStreamDetail::Source GetSource(CStreamDetail::StreamType type, int idx) const;
+  CStreamDetail::Source GetSources() const;
+  void SetSources(CStreamDetail::Source source);
+  bool ShouldUpdateWithNewDetails(const CStreamDetails& newInfo) const;
+
 private:
   CStreamDetail *NewStream(CStreamDetail::StreamType type);
   std::vector<std::unique_ptr<CStreamDetail>> m_vecItems;

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -27,6 +27,8 @@ struct SubtitleStreamInfo;
 class CStreamDetail : public IArchivable, public ISerializable
 {
 public:
+  static constexpr int STREAM_DETAILS_VERSION = 2;
+
   enum StreamType {
     VIDEO,
     AUDIO,
@@ -52,12 +54,14 @@ public:
   virtual bool IsWorseThan(const CStreamDetail &that) const = 0;
   Source GetSource() const;
   void SetSource(Source source);
+  int GetVersion() const { return m_version; }
 
   const StreamType m_eType;
 
 protected:
   CStreamDetails *m_pParent;
   Source m_source{UNDEFINED};
+  int m_version{STREAM_DETAILS_VERSION};
   friend class CStreamDetails;
   friend class CVideoDatabase;
 };
@@ -240,6 +244,8 @@ public:
   CStreamDetail::Source GetSources() const;
   void SetSources(CStreamDetail::Source source);
   bool ShouldUpdateWithNewDetails(const CStreamDetails& newInfo) const;
+
+  int GetVersion(CStreamDetail::StreamType type, int idx) const;
 
 private:
   CStreamDetail *NewStream(CStreamDetail::StreamType type);

--- a/xbmc/utils/test/TestStreamDetails.cpp
+++ b/xbmc/utils/test/TestStreamDetails.cpp
@@ -24,12 +24,15 @@ TEST(TestStreamDetails, General)
   video->m_strCodec = "h264";
   video->m_strStereoMode = "left_right";
   video->m_strLanguage = "eng";
+  video->SetSource(CStreamDetail::MEDIA);
 
   audio->m_iChannels = 2;
   audio->m_strCodec = "aac";
   audio->m_strLanguage = "eng";
+  audio->SetSource(CStreamDetail::MEDIA);
 
   subtitle->m_strLanguage = "eng";
+  subtitle->SetSource(CStreamDetail::MEDIA);
 
   a.AddStream(video);
   a.AddStream(audio);
@@ -44,6 +47,7 @@ TEST(TestStreamDetails, General)
   EXPECT_EQ(0, a.GetVideoHeight());
   EXPECT_EQ(0, a.GetVideoDuration());
   EXPECT_STREQ("", a.GetStereoMode().c_str());
+  EXPECT_EQ(CStreamDetail::MEDIA, a.GetSources());
 
   EXPECT_EQ(1, a.GetStreamCount(CStreamDetail::AUDIO));
   EXPECT_EQ(1, a.GetAudioStreamCount());
@@ -73,4 +77,167 @@ TEST(TestStreamDetails, VideoDimsToResolutionDescription)
 TEST(TestStreamDetails, VideoAspectToAspectDescription)
 {
   EXPECT_STREQ("2.40", CStreamDetails::VideoAspectToAspectDescription(2.39f).c_str());
+}
+
+namespace
+{
+// Builds a CStreamDetails with one video stream (h264, 1920x1080, 1.78, 5400s),
+// one audio stream (aac, eng, 6 ch) and one subtitle stream (eng).
+// Each stream type receives its own source value so individual source
+// differences can be isolated per test.
+CStreamDetails MakeTypicalStreamDetails(CStreamDetail::Source videoSrc,
+                                        CStreamDetail::Source audioSrc,
+                                        CStreamDetail::Source subtitleSrc)
+{
+  CStreamDetails details;
+
+  auto* video = new CStreamDetailVideo();
+  video->m_strCodec = "h264";
+  video->m_iWidth = 1920;
+  video->m_iHeight = 1080;
+  video->m_fAspect = 1.78f;
+  video->m_iDuration = 5400;
+  video->m_strStereoMode = "left_right";
+  video->m_strLanguage = "eng";
+  video->SetSource(videoSrc);
+  details.AddStream(video);
+
+  auto* audio = new CStreamDetailAudio();
+  audio->m_strCodec = "aac";
+  audio->m_strLanguage = "eng";
+  audio->m_iChannels = 6;
+  audio->SetSource(audioSrc);
+  details.AddStream(audio);
+
+  auto* subtitle = new CStreamDetailSubtitle();
+  subtitle->m_strLanguage = "eng";
+  subtitle->SetSource(subtitleSrc);
+  details.AddStream(subtitle);
+
+  details.DetermineBestStreams();
+  return details;
+}
+
+// Convenience overload: all streams get the same source
+CStreamDetails MakeTypicalStreamDetails(CStreamDetail::Source source)
+{
+  return MakeTypicalStreamDetails(source, source, source);
+}
+} // namespace
+
+TEST(TestStreamDetails, Equality_BothEmpty)
+{
+  // Two default-constructed objects carry no streams, so there is nothing
+  // for the source comparison to trip on; they must be equal.
+  const CStreamDetails a;
+  const CStreamDetails b;
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+}
+
+TEST(TestStreamDetails, Equality_SelfComparison)
+{
+  // operator== has a `this == &right` identity fast-path - verify it fires
+  // and that operator!= is its consistent negation.
+  const CStreamDetails a = MakeTypicalStreamDetails(CStreamDetail::MEDIA);
+  EXPECT_TRUE(a == a);
+  EXPECT_FALSE(a != a);
+}
+
+TEST(TestStreamDetails, Equality_IdenticalContentAndSource)
+{
+  // Baseline: two independently built objects with the same content and the
+  // same source must compare equal.
+  const CStreamDetails a = MakeTypicalStreamDetails(CStreamDetail::MEDIA);
+  const CStreamDetails b = MakeTypicalStreamDetails(CStreamDetail::MEDIA);
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+}
+
+TEST(TestStreamDetails, Equality_SameContentDifferentVideoSource_MediaVsNfo)
+{
+  // Content-identical objects whose VIDEO stream carries different sources
+  // (MEDIA vs NFO) must NOT be equal.
+
+  const CStreamDetails media =
+      MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::MEDIA, CStreamDetail::MEDIA);
+  const CStreamDetails nfo =
+      MakeTypicalStreamDetails(CStreamDetail::NFO, CStreamDetail::MEDIA, CStreamDetail::MEDIA);
+
+  EXPECT_FALSE(media == nfo);
+  EXPECT_TRUE(media != nfo);
+}
+
+TEST(TestStreamDetails, Equality_SameContentDifferentAudioSource_MediaVsNfo)
+{
+  // As above, but only the AUDIO stream's source differs; the video and
+  // subtitle sources match. Verifies the audio loop in operator== is reached.
+  const CStreamDetails media =
+      MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::MEDIA, CStreamDetail::MEDIA);
+  const CStreamDetails nfo =
+      MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::NFO, CStreamDetail::MEDIA);
+
+  EXPECT_FALSE(media == nfo);
+  EXPECT_TRUE(media != nfo);
+}
+
+TEST(TestStreamDetails, Equality_SameContentDifferentSubtitleSource_MediaVsNfo)
+{
+  // As above, but only the SUBTITLE stream's source differs. Verifies the
+  // subtitle loop in operator== is reached even when video and audio match.
+  const CStreamDetails media =
+      MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::MEDIA, CStreamDetail::MEDIA);
+  const CStreamDetails nfo =
+      MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::MEDIA, CStreamDetail::NFO);
+
+  EXPECT_FALSE(media == nfo);
+  EXPECT_TRUE(media != nfo);
+}
+
+TEST(TestStreamDetails, Equality_BothNfoSource_SameContent)
+{
+  // When both sides have source=NFO and identical content they must still
+  // compare equal.
+  const CStreamDetails a = MakeTypicalStreamDetails(CStreamDetail::NFO);
+  const CStreamDetails b = MakeTypicalStreamDetails(CStreamDetail::NFO);
+
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+}
+
+TEST(TestStreamDetails, Equality_DifferentContentSameSource)
+{
+  // Content differs while source is identical - must NOT be equal.
+  const CStreamDetails a =
+      MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::MEDIA, CStreamDetail::MEDIA);
+
+  CStreamDetails b;
+
+  auto* video = new CStreamDetailVideo();
+  video->m_strCodec = "hevc";
+  video->m_iWidth = 1920;
+  video->m_iHeight = 1080;
+  video->m_fAspect = 1.78f;
+  video->m_iDuration = 5400;
+  video->m_strStereoMode = "left_right";
+  video->m_strLanguage = "eng";
+  video->SetSource(CStreamDetail::MEDIA);
+  b.AddStream(video);
+
+  auto* audio = new CStreamDetailAudio();
+  audio->m_strCodec = "aac";
+  audio->m_strLanguage = "eng";
+  audio->m_iChannels = 6;
+  audio->SetSource(CStreamDetail::MEDIA);
+  b.AddStream(audio);
+
+  auto* subtitle = new CStreamDetailSubtitle();
+  subtitle->m_strLanguage = "eng";
+  subtitle->SetSource(CStreamDetail::MEDIA);
+  b.AddStream(subtitle);
+
+  b.DetermineBestStreams();
+
+  EXPECT_FALSE(a == b);
+  EXPECT_TRUE(a != b);
 }

--- a/xbmc/utils/test/TestStreamDetails.cpp
+++ b/xbmc/utils/test/TestStreamDetails.cpp
@@ -498,3 +498,50 @@ TEST(TestStreamDetails, ShouldUpdateWithNewDetails_MixedSourcesUseHighest)
   EXPECT_FALSE(partialNfo.ShouldUpdateWithNewDetails(allMedia));
   EXPECT_TRUE(allMedia.ShouldUpdateWithNewDetails(partialNfo));
 }
+
+TEST(TestStreamDetails, Version_DefaultsToCurrentAndSurvivesCopy)
+{
+  // Every newly created stream carries the current version, and copying an item
+  // (as happens whenever a CVideoInfoTag is copied) must preserve it.
+  const CStreamDetails details = MakeTypicalStreamDetails(CStreamDetail::MEDIA);
+
+  EXPECT_EQ(CStreamDetail::STREAM_DETAILS_VERSION, details.GetVersion(CStreamDetail::VIDEO, 1));
+  EXPECT_EQ(CStreamDetail::STREAM_DETAILS_VERSION, details.GetVersion(CStreamDetail::AUDIO, 1));
+  EXPECT_EQ(CStreamDetail::STREAM_DETAILS_VERSION, details.GetVersion(CStreamDetail::SUBTITLE, 1));
+
+  const CStreamDetails copy{details};
+  EXPECT_EQ(CStreamDetail::STREAM_DETAILS_VERSION, copy.GetVersion(CStreamDetail::VIDEO, 1));
+  EXPECT_EQ(CStreamDetail::MEDIA, copy.GetSource(CStreamDetail::VIDEO, 1));
+}
+
+TEST(TestStreamDetails, Version_AbsentStreamReportsZero)
+{
+  // A stream that isn't there has no version, which must not be confused with
+  // version 1 (the marker for details that predate source tracking).
+  const CStreamDetails empty;
+  EXPECT_EQ(0, empty.GetVersion(CStreamDetail::VIDEO, 1));
+  EXPECT_EQ(0, MakeTypicalStreamDetails(CStreamDetail::MEDIA).GetVersion(CStreamDetail::VIDEO, 2));
+}
+
+TEST(TestStreamDetails, Source_SurvivesCopyAssignment)
+{
+  // CStreamDetailVideo and CStreamDetailSubtitle define their own operator=, which
+  // must carry the source and version across along with the stream data.
+  CStreamDetailVideo video;
+  video.m_strCodec = "h264";
+  video.SetSource(CStreamDetail::NFO);
+
+  CStreamDetailVideo videoCopy;
+  videoCopy = video;
+  EXPECT_EQ(CStreamDetail::NFO, videoCopy.GetSource());
+  EXPECT_EQ(CStreamDetail::STREAM_DETAILS_VERSION, videoCopy.GetVersion());
+
+  CStreamDetailSubtitle subtitle;
+  subtitle.m_strLanguage = "eng";
+  subtitle.SetSource(CStreamDetail::EXTERNAL);
+
+  CStreamDetailSubtitle subtitleCopy;
+  subtitleCopy = subtitle;
+  EXPECT_EQ(CStreamDetail::EXTERNAL, subtitleCopy.GetSource());
+  EXPECT_EQ(CStreamDetail::STREAM_DETAILS_VERSION, subtitleCopy.GetVersion());
+}

--- a/xbmc/utils/test/TestStreamDetails.cpp
+++ b/xbmc/utils/test/TestStreamDetails.cpp
@@ -24,12 +24,15 @@ TEST(TestStreamDetails, General)
   video->m_strCodec = "h264";
   video->m_strStereoMode = "left_right";
   video->m_strLanguage = "eng";
+  video->SetSource(CStreamDetail::MEDIA);
 
   audio->m_iChannels = 2;
   audio->m_strCodec = "aac";
   audio->m_strLanguage = "eng";
+  audio->SetSource(CStreamDetail::MEDIA);
 
   subtitle->m_strLanguage = "eng";
+  subtitle->SetSource(CStreamDetail::MEDIA);
 
   a.AddStream(video);
   a.AddStream(audio);
@@ -44,6 +47,7 @@ TEST(TestStreamDetails, General)
   EXPECT_EQ(0, a.GetVideoHeight());
   EXPECT_EQ(0, a.GetVideoDuration());
   EXPECT_STREQ("", a.GetStereoMode().c_str());
+  EXPECT_EQ(CStreamDetail::MEDIA, a.GetSources());
 
   EXPECT_EQ(1, a.GetStreamCount(CStreamDetail::AUDIO));
   EXPECT_EQ(1, a.GetAudioStreamCount());
@@ -219,4 +223,278 @@ TEST(TestStreamDetails, VideoAspectToAspectDescriptionRelabelledRanges)
   EXPECT_STREQ("1.50", CStreamDetails::VideoAspectToAspectDescription(1.48f).c_str()); // was 1.37
   EXPECT_STREQ("1.50", CStreamDetails::VideoAspectToAspectDescription(1.55f).c_str()); // was 1.66
   EXPECT_STREQ("1.90", CStreamDetails::VideoAspectToAspectDescription(1.90f).c_str()); // was 1.85
+}
+
+namespace
+{
+// Builds a CStreamDetails with one video stream (h264, 1920x1080, 1.78, 5400s),
+// one audio stream (aac, eng, 6 ch) and one subtitle stream (eng).
+// Each stream type receives its own source value so individual source
+// differences can be isolated per test.
+CStreamDetails MakeTypicalStreamDetails(CStreamDetail::Source videoSrc,
+                                        CStreamDetail::Source audioSrc,
+                                        CStreamDetail::Source subtitleSrc)
+{
+  CStreamDetails details;
+
+  auto* video = new CStreamDetailVideo();
+  video->m_strCodec = "h264";
+  video->m_iWidth = 1920;
+  video->m_iHeight = 1080;
+  video->m_fAspect = 1.78f;
+  video->m_iDuration = 5400;
+  video->m_strStereoMode = "left_right";
+  video->m_strLanguage = "eng";
+  video->SetSource(videoSrc);
+  details.AddStream(video);
+
+  auto* audio = new CStreamDetailAudio();
+  audio->m_strCodec = "aac";
+  audio->m_strLanguage = "eng";
+  audio->m_iChannels = 6;
+  audio->SetSource(audioSrc);
+  details.AddStream(audio);
+
+  auto* subtitle = new CStreamDetailSubtitle();
+  subtitle->m_strLanguage = "eng";
+  subtitle->SetSource(subtitleSrc);
+  details.AddStream(subtitle);
+
+  details.DetermineBestStreams();
+  return details;
+}
+
+// Convenience overload: all streams get the same source
+CStreamDetails MakeTypicalStreamDetails(CStreamDetail::Source source)
+{
+  return MakeTypicalStreamDetails(source, source, source);
+}
+} // namespace
+
+TEST(TestStreamDetails, Equality_BothEmpty)
+{
+  // Two default-constructed objects carry no streams, so there is nothing
+  // for the source comparison to trip on; they must be equal.
+  const CStreamDetails a;
+  const CStreamDetails b;
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+}
+
+TEST(TestStreamDetails, Equality_SelfComparison)
+{
+  // operator== has a `this == &right` identity fast-path - verify it fires
+  // and that operator!= is its consistent negation.
+  const CStreamDetails a = MakeTypicalStreamDetails(CStreamDetail::MEDIA);
+  EXPECT_TRUE(a == a);
+  EXPECT_FALSE(a != a);
+}
+
+TEST(TestStreamDetails, Equality_IdenticalContentAndSource)
+{
+  // Baseline: two independently built objects with the same content and the
+  // same source must compare equal.
+  const CStreamDetails a = MakeTypicalStreamDetails(CStreamDetail::MEDIA);
+  const CStreamDetails b = MakeTypicalStreamDetails(CStreamDetail::MEDIA);
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+}
+
+TEST(TestStreamDetails, Equality_SameContentDifferentVideoSource_MediaVsNfo)
+{
+  // Content-identical objects whose VIDEO stream carries different sources
+  // (MEDIA vs NFO) must NOT be equal.
+
+  const CStreamDetails media =
+      MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::MEDIA, CStreamDetail::MEDIA);
+  const CStreamDetails nfo =
+      MakeTypicalStreamDetails(CStreamDetail::NFO, CStreamDetail::MEDIA, CStreamDetail::MEDIA);
+
+  EXPECT_FALSE(media == nfo);
+  EXPECT_TRUE(media != nfo);
+}
+
+TEST(TestStreamDetails, Equality_SameContentDifferentAudioSource_MediaVsNfo)
+{
+  // As above, but only the AUDIO stream's source differs; the video and
+  // subtitle sources match. Verifies the audio loop in operator== is reached.
+  const CStreamDetails media =
+      MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::MEDIA, CStreamDetail::MEDIA);
+  const CStreamDetails nfo =
+      MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::NFO, CStreamDetail::MEDIA);
+
+  EXPECT_FALSE(media == nfo);
+  EXPECT_TRUE(media != nfo);
+}
+
+TEST(TestStreamDetails, Equality_SameContentDifferentSubtitleSource_MediaVsNfo)
+{
+  // As above, but only the SUBTITLE stream's source differs. Verifies the
+  // subtitle loop in operator== is reached even when video and audio match.
+  const CStreamDetails media =
+      MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::MEDIA, CStreamDetail::MEDIA);
+  const CStreamDetails nfo =
+      MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::MEDIA, CStreamDetail::NFO);
+
+  EXPECT_FALSE(media == nfo);
+  EXPECT_TRUE(media != nfo);
+}
+
+TEST(TestStreamDetails, Equality_BothNfoSource_SameContent)
+{
+  // When both sides have source=NFO and identical content they must still
+  // compare equal.
+  const CStreamDetails a = MakeTypicalStreamDetails(CStreamDetail::NFO);
+  const CStreamDetails b = MakeTypicalStreamDetails(CStreamDetail::NFO);
+
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+}
+
+TEST(TestStreamDetails, Equality_DifferentContentSameSource)
+{
+  // Content differs while source is identical - must NOT be equal.
+  const CStreamDetails a =
+      MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::MEDIA, CStreamDetail::MEDIA);
+
+  CStreamDetails b;
+
+  auto* video = new CStreamDetailVideo();
+  video->m_strCodec = "hevc";
+  video->m_iWidth = 1920;
+  video->m_iHeight = 1080;
+  video->m_fAspect = 1.78f;
+  video->m_iDuration = 5400;
+  video->m_strStereoMode = "left_right";
+  video->m_strLanguage = "eng";
+  video->SetSource(CStreamDetail::MEDIA);
+  b.AddStream(video);
+
+  auto* audio = new CStreamDetailAudio();
+  audio->m_strCodec = "aac";
+  audio->m_strLanguage = "eng";
+  audio->m_iChannels = 6;
+  audio->SetSource(CStreamDetail::MEDIA);
+  b.AddStream(audio);
+
+  auto* subtitle = new CStreamDetailSubtitle();
+  subtitle->m_strLanguage = "eng";
+  subtitle->SetSource(CStreamDetail::MEDIA);
+  b.AddStream(subtitle);
+
+  b.DetermineBestStreams();
+
+  EXPECT_FALSE(a == b);
+  EXPECT_TRUE(a != b);
+}
+
+TEST(TestStreamDetails, GetSource_PerStreamAndOutOfRange)
+{
+  // GetSource() addresses an individual stream; index 1 is the first stream of
+  // that type. An index with no matching stream must report UNDEFINED rather
+  // than the item's overall source.
+  const CStreamDetails details =
+      MakeTypicalStreamDetails(CStreamDetail::NFO, CStreamDetail::MEDIA, CStreamDetail::EXTERNAL);
+
+  EXPECT_EQ(CStreamDetail::NFO, details.GetSource(CStreamDetail::VIDEO, 1));
+  EXPECT_EQ(CStreamDetail::MEDIA, details.GetSource(CStreamDetail::AUDIO, 1));
+  EXPECT_EQ(CStreamDetail::EXTERNAL, details.GetSource(CStreamDetail::SUBTITLE, 1));
+
+  EXPECT_EQ(CStreamDetail::UNDEFINED, details.GetSource(CStreamDetail::VIDEO, 2));
+  EXPECT_EQ(CStreamDetail::UNDEFINED, details.GetSource(CStreamDetail::AUDIO, 99));
+}
+
+TEST(TestStreamDetails, GetSources_Empty)
+{
+  // With no streams at all there is no source to report.
+  const CStreamDetails details;
+  EXPECT_EQ(CStreamDetail::UNDEFINED, details.GetSources());
+}
+
+TEST(TestStreamDetails, GetSources_ReturnsHighestOfMixedSources)
+{
+  // GetSources() collapses the per-stream sources to the single highest-ranked
+  // one, so an item is only as overwritable as its most authoritative stream.
+  EXPECT_EQ(CStreamDetail::NFO, MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::NFO,
+                                                         CStreamDetail::EXTERNAL)
+                                    .GetSources());
+
+  EXPECT_EQ(CStreamDetail::MEDIA,
+            MakeTypicalStreamDetails(CStreamDetail::UNDEFINED, CStreamDetail::EXTERNAL,
+                                     CStreamDetail::MEDIA)
+                .GetSources());
+
+  EXPECT_EQ(
+      CStreamDetail::LEGACY,
+      MakeTypicalStreamDetails(CStreamDetail::LEGACY, CStreamDetail::MEDIA, CStreamDetail::MEDIA)
+          .GetSources());
+}
+
+TEST(TestStreamDetails, SetSources_AppliesToEveryStream)
+{
+  // SetSources() overwrites the source of every stream, whatever it was before.
+  CStreamDetails details =
+      MakeTypicalStreamDetails(CStreamDetail::MEDIA, CStreamDetail::EXTERNAL, CStreamDetail::MEDIA);
+  details.SetSources(CStreamDetail::NFO);
+
+  EXPECT_EQ(CStreamDetail::NFO, details.GetSource(CStreamDetail::VIDEO, 1));
+  EXPECT_EQ(CStreamDetail::NFO, details.GetSource(CStreamDetail::AUDIO, 1));
+  EXPECT_EQ(CStreamDetail::NFO, details.GetSource(CStreamDetail::SUBTITLE, 1));
+  EXPECT_EQ(CStreamDetail::NFO, details.GetSources());
+}
+
+TEST(TestStreamDetails, ShouldUpdateWithNewDetails_HigherOrEqualSourceWins)
+{
+  // New details replace existing ones when their source ranks at least as high.
+  const CStreamDetails media = MakeTypicalStreamDetails(CStreamDetail::MEDIA);
+  const CStreamDetails nfo = MakeTypicalStreamDetails(CStreamDetail::NFO);
+  const CStreamDetails external = MakeTypicalStreamDetails(CStreamDetail::EXTERNAL);
+
+  // Equal source - an update of like with like is allowed
+  EXPECT_TRUE(media.ShouldUpdateWithNewDetails(media));
+
+  // Higher-ranked new source - allowed
+  EXPECT_TRUE(media.ShouldUpdateWithNewDetails(nfo));
+  EXPECT_TRUE(external.ShouldUpdateWithNewDetails(media));
+
+  // Lower-ranked new source - refused
+  EXPECT_FALSE(nfo.ShouldUpdateWithNewDetails(media));
+  EXPECT_FALSE(media.ShouldUpdateWithNewDetails(external));
+}
+
+TEST(TestStreamDetails, ShouldUpdateWithNewDetails_LegacyIsNeverOverwritten)
+{
+  // Details migrated from a pre-source-tracking library are ranked LEGACY, above
+  // every other source, because they may themselves have come from an nfo. Nothing
+  // silently replaces them; only an explicit rescan (which writes directly) can.
+  const CStreamDetails legacy = MakeTypicalStreamDetails(CStreamDetail::LEGACY);
+
+  EXPECT_FALSE(legacy.ShouldUpdateWithNewDetails(MakeTypicalStreamDetails(CStreamDetail::MEDIA)));
+  EXPECT_FALSE(legacy.ShouldUpdateWithNewDetails(MakeTypicalStreamDetails(CStreamDetail::NFO)));
+  EXPECT_FALSE(
+      legacy.ShouldUpdateWithNewDetails(MakeTypicalStreamDetails(CStreamDetail::EXTERNAL)));
+  EXPECT_TRUE(legacy.ShouldUpdateWithNewDetails(legacy));
+}
+
+TEST(TestStreamDetails, ShouldUpdateWithNewDetails_EmptyDetails)
+{
+  // An item with no details yet accepts anything, and nothing is ever replaced by
+  // an empty set (UNDEFINED ranks below every real source).
+  const CStreamDetails empty;
+  const CStreamDetails media = MakeTypicalStreamDetails(CStreamDetail::MEDIA);
+
+  EXPECT_TRUE(empty.ShouldUpdateWithNewDetails(media));
+  EXPECT_FALSE(media.ShouldUpdateWithNewDetails(empty));
+}
+
+TEST(TestStreamDetails, ShouldUpdateWithNewDetails_MixedSourcesUseHighest)
+{
+  // Only the highest-ranked stream of each side is considered, so a single NFO
+  // stream protects the whole item.
+  const CStreamDetails partialNfo =
+      MakeTypicalStreamDetails(CStreamDetail::NFO, CStreamDetail::MEDIA, CStreamDetail::MEDIA);
+  const CStreamDetails allMedia = MakeTypicalStreamDetails(CStreamDetail::MEDIA);
+
+  EXPECT_FALSE(partialNfo.ShouldUpdateWithNewDetails(allMedia));
+  EXPECT_TRUE(allMedia.ShouldUpdateWithNewDetails(partialNfo));
 }

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3143,35 +3143,38 @@ bool CVideoDatabase::SetStreamDetailsForFileId(const CStreamDetails& details, in
   {
     m_pDS->exec(PrepareSQL("DELETE FROM streamdetails WHERE idFile = %i", idFile));
 
-    for (int i=1; i<=details.GetVideoStreamCount(); i++)
+    for (int i = 1; i <= details.GetVideoStreamCount(); i++)
     {
       m_pDS->exec(PrepareSQL(
           "INSERT INTO streamdetails "
           "(idFile, iStreamType, strVideoCodec, fVideoAspect, iVideoWidth, iVideoHeight, "
-          "iVideoDuration, strStereoMode, strVideoLanguage, strHdrType, strHdrDetail) "
-          "VALUES (%i,%i,'%s',%f,%i,%i,%i,'%s','%s','%s','%s')",
+          "iVideoDuration, strStereoMode, strVideoLanguage, strHdrType, strHdrDetail, iSource) "
+          "VALUES (%i,%i,'%s',%f,%i,%i,%i,'%s','%s','%s','%s',%i)",
           idFile, static_cast<int>(CStreamDetail::VIDEO), details.GetVideoCodec(i).c_str(),
           static_cast<double>(details.GetVideoAspect(i)), details.GetVideoWidth(i),
           details.GetVideoHeight(i), details.GetVideoDuration(i), details.GetStereoMode(i).c_str(),
           details.GetVideoLanguage(i).c_str(), details.GetVideoHdrType(i).c_str(),
-          details.GetVideoHdrDetail(i).c_str()));
+          details.GetVideoHdrDetail(i).c_str(),
+          static_cast<int>(details.GetSource(CStreamDetail::VIDEO, i))));
     }
-    for (int i=1; i<=details.GetAudioStreamCount(); i++)
+    for (int i = 1; i <= details.GetAudioStreamCount(); i++)
     {
       m_pDS->exec(PrepareSQL(
           "INSERT INTO streamdetails "
-          "(idFile, iStreamType, strAudioCodec, iAudioChannels, strAudioLanguage) "
-          "VALUES (%i,%i,'%s',%i,'%s')",
+          "(idFile, iStreamType, strAudioCodec, iAudioChannels, strAudioLanguage, iSource) "
+          "VALUES (%i,%i,'%s',%i,'%s',%i)",
           idFile, static_cast<int>(CStreamDetail::AUDIO), details.GetAudioCodec(i).c_str(),
-          details.GetAudioChannels(i), details.GetAudioLanguage(i).c_str()));
+          details.GetAudioChannels(i), details.GetAudioLanguage(i).c_str(),
+          static_cast<int>(details.GetSource(CStreamDetail::AUDIO, i))));
     }
-    for (int i=1; i<=details.GetSubtitleStreamCount(); i++)
+    for (int i = 1; i <= details.GetSubtitleStreamCount(); i++)
     {
       m_pDS->exec(PrepareSQL("INSERT INTO streamdetails "
-                             "(idFile, iStreamType, strSubtitleLanguage) "
-                             "VALUES (%i,%i,'%s')",
+                             "(idFile, iStreamType, strSubtitleLanguage, iSource) "
+                             "VALUES (%i,%i,'%s',%i)",
                              idFile, static_cast<int>(CStreamDetail::SUBTITLE),
-                             details.GetSubtitleLanguage(i).c_str()));
+                             details.GetSubtitleLanguage(i).c_str(),
+                             static_cast<int>(details.GetSource(CStreamDetail::SUBTITLE, i))));
     }
 
     // update the runtime information, if empty
@@ -4541,6 +4544,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
           p->m_strLanguage = pDS->fv(12).get_asString();
           p->m_strHdrType = pDS->fv(13).get_asString();
           p->m_strHdrDetail = pDS->fv(14).get_asString();
+          p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
           details.AddStream(p);
           retVal = true;
           break;
@@ -4554,6 +4558,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
           else
             p->m_iChannels = pDS->fv(7).get_asInt();
           p->m_strLanguage = pDS->fv(8).get_asString();
+          p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
           details.AddStream(p);
           retVal = true;
           break;
@@ -4562,6 +4567,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
         {
           auto* p = new CStreamDetailSubtitle();
           p->m_strLanguage = pDS->fv(9).get_asString();
+          p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
           details.AddStream(p);
           retVal = true;
           break;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3148,33 +3148,38 @@ bool CVideoDatabase::SetStreamDetailsForFileId(const CStreamDetails& details, in
       m_pDS->exec(PrepareSQL(
           "INSERT INTO streamdetails "
           "(idFile, iStreamType, strVideoCodec, fVideoAspect, iVideoWidth, iVideoHeight, "
-          "iVideoDuration, strStereoMode, strVideoLanguage, strHdrType, strHdrDetail, iSource) "
-          "VALUES (%i,%i,'%s',%f,%i,%i,%i,'%s','%s','%s','%s',%i)",
+          "iVideoDuration, strStereoMode, strVideoLanguage, strHdrType, strHdrDetail, iSource, "
+          "iVersion) "
+          "VALUES (%i,%i,'%s',%f,%i,%i,%i,'%s','%s','%s','%s',%i,%i)",
           idFile, static_cast<int>(CStreamDetail::VIDEO), details.GetVideoCodec(i).c_str(),
           static_cast<double>(details.GetVideoAspect(i)), details.GetVideoWidth(i),
           details.GetVideoHeight(i), details.GetVideoDuration(i), details.GetStereoMode(i).c_str(),
           details.GetVideoLanguage(i).c_str(), details.GetVideoHdrType(i).c_str(),
           details.GetVideoHdrDetail(i).c_str(),
-          static_cast<int>(details.GetSource(CStreamDetail::VIDEO, i))));
+          static_cast<int>(details.GetSource(CStreamDetail::VIDEO, i)),
+          CStreamDetail::STREAM_DETAILS_VERSION));
     }
     for (int i = 1; i <= details.GetAudioStreamCount(); i++)
     {
-      m_pDS->exec(PrepareSQL(
-          "INSERT INTO streamdetails "
-          "(idFile, iStreamType, strAudioCodec, iAudioChannels, strAudioLanguage, iSource) "
-          "VALUES (%i,%i,'%s',%i,'%s',%i)",
-          idFile, static_cast<int>(CStreamDetail::AUDIO), details.GetAudioCodec(i).c_str(),
-          details.GetAudioChannels(i), details.GetAudioLanguage(i).c_str(),
-          static_cast<int>(details.GetSource(CStreamDetail::AUDIO, i))));
+      m_pDS->exec(PrepareSQL("INSERT INTO streamdetails "
+                             "(idFile, iStreamType, strAudioCodec, iAudioChannels, "
+                             "strAudioLanguage, iSource, iVersion) "
+                             "VALUES (%i,%i,'%s',%i,'%s',%i, %i)",
+                             idFile, static_cast<int>(CStreamDetail::AUDIO),
+                             details.GetAudioCodec(i).c_str(), details.GetAudioChannels(i),
+                             details.GetAudioLanguage(i).c_str(),
+                             static_cast<int>(details.GetSource(CStreamDetail::AUDIO, i)),
+                             CStreamDetail::STREAM_DETAILS_VERSION));
     }
     for (int i = 1; i <= details.GetSubtitleStreamCount(); i++)
     {
       m_pDS->exec(PrepareSQL("INSERT INTO streamdetails "
-                             "(idFile, iStreamType, strSubtitleLanguage, iSource) "
-                             "VALUES (%i,%i,'%s',%i)",
+                             "(idFile, iStreamType, strSubtitleLanguage, iSource, iVersion) "
+                             "VALUES (%i,%i,'%s',%i, %i)",
                              idFile, static_cast<int>(CStreamDetail::SUBTITLE),
                              details.GetSubtitleLanguage(i).c_str(),
-                             static_cast<int>(details.GetSource(CStreamDetail::SUBTITLE, i))));
+                             static_cast<int>(details.GetSource(CStreamDetail::SUBTITLE, i)),
+                             CStreamDetail::STREAM_DETAILS_VERSION));
     }
 
     // update the runtime information, if empty
@@ -4545,6 +4550,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
           p->m_strHdrType = pDS->fv(13).get_asString();
           p->m_strHdrDetail = pDS->fv(14).get_asString();
           p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
+          p->m_version = pDS->fv(16).get_asInt();
           details.AddStream(p);
           retVal = true;
           break;
@@ -4559,6 +4565,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
             p->m_iChannels = pDS->fv(7).get_asInt();
           p->m_strLanguage = pDS->fv(8).get_asString();
           p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
+          p->m_version = pDS->fv(16).get_asInt();
           details.AddStream(p);
           retVal = true;
           break;
@@ -4568,6 +4575,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
           auto* p = new CStreamDetailSubtitle();
           p->m_strLanguage = pDS->fv(9).get_asString();
           p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
+          p->m_version = pDS->fv(16).get_asInt();
           details.AddStream(p);
           retVal = true;
           break;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3181,35 +3181,38 @@ bool CVideoDatabase::SetStreamDetailsForFileId(const CStreamDetails& details, in
   {
     m_pDS->exec(PrepareSQL("DELETE FROM streamdetails WHERE idFile = %i", idFile));
 
-    for (int i=1; i<=details.GetVideoStreamCount(); i++)
+    for (int i = 1; i <= details.GetVideoStreamCount(); i++)
     {
       m_pDS->exec(PrepareSQL(
           "INSERT INTO streamdetails "
           "(idFile, iStreamType, strVideoCodec, fVideoAspect, iVideoWidth, iVideoHeight, "
-          "iVideoDuration, strStereoMode, strVideoLanguage, strHdrType, strHdrDetail) "
-          "VALUES (%i,%i,'%s',%f,%i,%i,%i,'%s','%s','%s','%s')",
+          "iVideoDuration, strStereoMode, strVideoLanguage, strHdrType, strHdrDetail, iSource) "
+          "VALUES (%i,%i,'%s',%f,%i,%i,%i,'%s','%s','%s','%s',%i)",
           idFile, static_cast<int>(CStreamDetail::VIDEO), details.GetVideoCodec(i).c_str(),
           static_cast<double>(details.GetVideoAspect(i)), details.GetVideoWidth(i),
           details.GetVideoHeight(i), details.GetVideoDuration(i), details.GetStereoMode(i).c_str(),
           details.GetVideoLanguage(i).c_str(), details.GetVideoHdrType(i).c_str(),
-          details.GetVideoHdrDetail(i).c_str()));
+          details.GetVideoHdrDetail(i).c_str(),
+          static_cast<int>(details.GetSource(CStreamDetail::VIDEO, i))));
     }
-    for (int i=1; i<=details.GetAudioStreamCount(); i++)
+    for (int i = 1; i <= details.GetAudioStreamCount(); i++)
     {
       m_pDS->exec(PrepareSQL(
           "INSERT INTO streamdetails "
-          "(idFile, iStreamType, strAudioCodec, iAudioChannels, strAudioLanguage) "
-          "VALUES (%i,%i,'%s',%i,'%s')",
+          "(idFile, iStreamType, strAudioCodec, iAudioChannels, strAudioLanguage, iSource) "
+          "VALUES (%i,%i,'%s',%i,'%s',%i)",
           idFile, static_cast<int>(CStreamDetail::AUDIO), details.GetAudioCodec(i).c_str(),
-          details.GetAudioChannels(i), details.GetAudioLanguage(i).c_str()));
+          details.GetAudioChannels(i), details.GetAudioLanguage(i).c_str(),
+          static_cast<int>(details.GetSource(CStreamDetail::AUDIO, i))));
     }
-    for (int i=1; i<=details.GetSubtitleStreamCount(); i++)
+    for (int i = 1; i <= details.GetSubtitleStreamCount(); i++)
     {
       m_pDS->exec(PrepareSQL("INSERT INTO streamdetails "
-                             "(idFile, iStreamType, strSubtitleLanguage) "
-                             "VALUES (%i,%i,'%s')",
+                             "(idFile, iStreamType, strSubtitleLanguage, iSource) "
+                             "VALUES (%i,%i,'%s',%i)",
                              idFile, static_cast<int>(CStreamDetail::SUBTITLE),
-                             details.GetSubtitleLanguage(i).c_str()));
+                             details.GetSubtitleLanguage(i).c_str(),
+                             static_cast<int>(details.GetSource(CStreamDetail::SUBTITLE, i))));
     }
 
     // update the runtime information, if empty
@@ -4579,6 +4582,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
           p->m_strLanguage = pDS->fv(12).get_asString();
           p->m_strHdrType = pDS->fv(13).get_asString();
           p->m_strHdrDetail = pDS->fv(14).get_asString();
+          p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
           details.AddStream(p);
           retVal = true;
           break;
@@ -4592,6 +4596,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
           else
             p->m_iChannels = pDS->fv(7).get_asInt();
           p->m_strLanguage = pDS->fv(8).get_asString();
+          p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
           details.AddStream(p);
           retVal = true;
           break;
@@ -4600,6 +4605,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
         {
           auto* p = new CStreamDetailSubtitle();
           p->m_strLanguage = pDS->fv(9).get_asString();
+          p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
           details.AddStream(p);
           retVal = true;
           break;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3186,33 +3186,38 @@ bool CVideoDatabase::SetStreamDetailsForFileId(const CStreamDetails& details, in
       m_pDS->exec(PrepareSQL(
           "INSERT INTO streamdetails "
           "(idFile, iStreamType, strVideoCodec, fVideoAspect, iVideoWidth, iVideoHeight, "
-          "iVideoDuration, strStereoMode, strVideoLanguage, strHdrType, strHdrDetail, iSource) "
-          "VALUES (%i,%i,'%s',%f,%i,%i,%i,'%s','%s','%s','%s',%i)",
+          "iVideoDuration, strStereoMode, strVideoLanguage, strHdrType, strHdrDetail, iSource, "
+          "iVersion) "
+          "VALUES (%i,%i,'%s',%f,%i,%i,%i,'%s','%s','%s','%s',%i,%i)",
           idFile, static_cast<int>(CStreamDetail::VIDEO), details.GetVideoCodec(i).c_str(),
           static_cast<double>(details.GetVideoAspect(i)), details.GetVideoWidth(i),
           details.GetVideoHeight(i), details.GetVideoDuration(i), details.GetStereoMode(i).c_str(),
           details.GetVideoLanguage(i).c_str(), details.GetVideoHdrType(i).c_str(),
           details.GetVideoHdrDetail(i).c_str(),
-          static_cast<int>(details.GetSource(CStreamDetail::VIDEO, i))));
+          static_cast<int>(details.GetSource(CStreamDetail::VIDEO, i)),
+          details.GetVersion(CStreamDetail::VIDEO, i)));
     }
     for (int i = 1; i <= details.GetAudioStreamCount(); i++)
     {
-      m_pDS->exec(PrepareSQL(
-          "INSERT INTO streamdetails "
-          "(idFile, iStreamType, strAudioCodec, iAudioChannels, strAudioLanguage, iSource) "
-          "VALUES (%i,%i,'%s',%i,'%s',%i)",
-          idFile, static_cast<int>(CStreamDetail::AUDIO), details.GetAudioCodec(i).c_str(),
-          details.GetAudioChannels(i), details.GetAudioLanguage(i).c_str(),
-          static_cast<int>(details.GetSource(CStreamDetail::AUDIO, i))));
+      m_pDS->exec(PrepareSQL("INSERT INTO streamdetails "
+                             "(idFile, iStreamType, strAudioCodec, iAudioChannels, "
+                             "strAudioLanguage, iSource, iVersion) "
+                             "VALUES (%i,%i,'%s',%i,'%s',%i, %i)",
+                             idFile, static_cast<int>(CStreamDetail::AUDIO),
+                             details.GetAudioCodec(i).c_str(), details.GetAudioChannels(i),
+                             details.GetAudioLanguage(i).c_str(),
+                             static_cast<int>(details.GetSource(CStreamDetail::AUDIO, i)),
+                             details.GetVersion(CStreamDetail::AUDIO, i)));
     }
     for (int i = 1; i <= details.GetSubtitleStreamCount(); i++)
     {
       m_pDS->exec(PrepareSQL("INSERT INTO streamdetails "
-                             "(idFile, iStreamType, strSubtitleLanguage, iSource) "
-                             "VALUES (%i,%i,'%s',%i)",
+                             "(idFile, iStreamType, strSubtitleLanguage, iSource, iVersion) "
+                             "VALUES (%i,%i,'%s',%i, %i)",
                              idFile, static_cast<int>(CStreamDetail::SUBTITLE),
                              details.GetSubtitleLanguage(i).c_str(),
-                             static_cast<int>(details.GetSource(CStreamDetail::SUBTITLE, i))));
+                             static_cast<int>(details.GetSource(CStreamDetail::SUBTITLE, i)),
+                             details.GetVersion(CStreamDetail::SUBTITLE, i)));
     }
 
     // update the runtime information, if empty
@@ -4583,6 +4588,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
           p->m_strHdrType = pDS->fv(13).get_asString();
           p->m_strHdrDetail = pDS->fv(14).get_asString();
           p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
+          p->m_version = pDS->fv(16).get_asInt();
           details.AddStream(p);
           retVal = true;
           break;
@@ -4597,6 +4603,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
             p->m_iChannels = pDS->fv(7).get_asInt();
           p->m_strLanguage = pDS->fv(8).get_asString();
           p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
+          p->m_version = pDS->fv(16).get_asInt();
           details.AddStream(p);
           retVal = true;
           break;
@@ -4606,6 +4613,7 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
           auto* p = new CStreamDetailSubtitle();
           p->m_strLanguage = pDS->fv(9).get_asString();
           p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
+          p->m_version = pDS->fv(16).get_asInt();
           details.AddStream(p);
           retVal = true;
           break;

--- a/xbmc/video/VideoDatabaseDDL.cpp
+++ b/xbmc/video/VideoDatabaseDDL.cpp
@@ -156,7 +156,7 @@ void CVideoDatabaseDDL::CreateTables(CDatabase& db)
       "strVideoCodec text, fVideoAspect float, iVideoWidth integer, iVideoHeight integer, "
       "strAudioCodec text, iAudioChannels integer, strAudioLanguage text, "
       "strSubtitleLanguage text, iVideoDuration integer, strStereoMode text, "
-      "strVideoLanguage text, strHdrType text, strHdrDetail text)");
+      "strVideoLanguage text, strHdrType text, strHdrDetail text, iSource integer)");
 
   CLog::Log(LOGINFO, "create sets table");
   db.ExecuteQuery("CREATE TABLE `sets` ( idSet integer primary key, strSet text, strOverview text, "

--- a/xbmc/video/VideoDatabaseDDL.cpp
+++ b/xbmc/video/VideoDatabaseDDL.cpp
@@ -9,7 +9,6 @@
 #include "video/VideoDatabaseDDL.h"
 
 #include "ServiceBroker.h"
-#include "dbwrappers/dataset.h"
 #include "media/MediaType.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
@@ -156,7 +155,8 @@ void CVideoDatabaseDDL::CreateTables(CDatabase& db)
       "strVideoCodec text, fVideoAspect float, iVideoWidth integer, iVideoHeight integer, "
       "strAudioCodec text, iAudioChannels integer, strAudioLanguage text, "
       "strSubtitleLanguage text, iVideoDuration integer, strStereoMode text, "
-      "strVideoLanguage text, strHdrType text, strHdrDetail text, iSource integer)");
+      "strVideoLanguage text, strHdrType text, strHdrDetail text, iSource integer, iVersion "
+      "integer)");
 
   CLog::Log(LOGINFO, "create sets table");
   db.ExecuteQuery("CREATE TABLE `sets` ( idSet integer primary key, strSet text, strOverview text, "

--- a/xbmc/video/VideoDatabaseDDL.h
+++ b/xbmc/video/VideoDatabaseDDL.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "dbwrappers/Database.h"
-#include "dbwrappers/dataset.h"
 
 #include <string>
 

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -1421,7 +1421,10 @@ void CVideoDatabase::UpdateTables(int iVersion)
   }
 
   if (iVersion < 148)
+  {
     m_pDS->exec("ALTER TABLE streamdetails ADD iSource INTEGER DEFAULT 40");
+    m_pDS->exec("ALTER TABLE streamdetails ADD iVersion INTEGER DEFAULT 1");
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -27,13 +27,10 @@
 #include "utils/log.h"
 
 #include <algorithm>
-#include <cctype>
-#include <functional>
 #include <map>
 #include <memory>
 #include <ranges>
 #include <sstream>
-#include <stdlib.h>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -1422,9 +1419,12 @@ void CVideoDatabase::UpdateTables(int iVersion)
     }
     m_pDS->close();
   }
+
+  if (iVersion < 148)
+    m_pDS->exec("ALTER TABLE streamdetails ADD iSource INTEGER DEFAULT 40");
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 147;
+  return 148;
 }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1663,12 +1663,16 @@ CVideoInfoScanner::~CVideoInfoScanner()
     }
 
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-            CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS) &&
-        !movieDetails.HasStreamDetails())
+            CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
     {
-      CDVDFileInfo::GetFileStreamDetails(pItem);
-      CLog::Log(LOGDEBUG, "VideoInfoScanner: Extracted filestream details from video file {}",
-                CURL::GetRedacted(path));
+      if (!movieDetails.HasNFOStreamDetails())
+      {
+        CDVDFileInfo::GetFileStreamDetails(pItem);
+        CLog::LogF(LOGDEBUG, "Extracted filestream details from video file {}",
+                   CURL::GetRedacted(path));
+      }
+      else
+        CLog::LogF(LOGDEBUG, "Filestream details from NFO file");
     }
 
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to {}:{}", content,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2012,12 +2012,27 @@ CVideoInfoScanner::~CVideoInfoScanner()
     }
 
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-            CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS) &&
-        !movieDetails.HasStreamDetails())
+            CSettings::SETTING_MYVIDEOS_EXTRACTFLAGS))
     {
-      CDVDFileInfo::GetFileStreamDetails(pItem);
-      CLog::Log(LOGDEBUG, "VideoInfoScanner: Extracted filestream details from video file {}",
-                CURL::GetRedacted(path));
+      // At this stage potential sources of stream details are:
+      // NFO - Local NFO (CVideoTagLoaderNFO)
+      // NFO - NFO embedded in MKV (CVideoTagLoaderFFmpeg::LoadMKV() → CNfoFile::GetDetails())
+      // NFO - Library import (ImportFromXML)
+      // MEDIA - Bluray (ResolveBlurayPlaylist())
+      // EXTERNAL - Plugin content (CVideoTagLoaderPlugin)
+      if (!movieDetails.HasStreamDetails())
+      {
+        if (CDVDFileInfo::GetFileStreamDetails(pItem))
+          CLog::LogF(LOGDEBUG, "Extracted filestream details from video file {}",
+                     CURL::GetRedacted(path));
+        else
+          CLog::LogF(LOGDEBUG, "No filestream details extracted from video file {}",
+                     CURL::GetRedacted(path));
+      }
+      else if (movieDetails.HasNFOStreamDetails())
+        CLog::LogF(LOGDEBUG, "Filestream details from NFO file for {}", CURL::GetRedacted(path));
+      else
+        CLog::LogF(LOGDEBUG, "Filestream details already present for {}", CURL::GetRedacted(path));
     }
 
     CLog::Log(LOGDEBUG, "VideoInfoScanner: Adding new item to {}:{}", content,

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1544,6 +1544,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
         m_streamDetails.AddStream(p);
       }
     }
+    m_streamDetails.SetSources(CStreamDetail::NFO);
     m_streamDetails.DetermineBestStreams();
   }  /* if fileinfo */
 
@@ -1608,6 +1609,14 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
 bool CVideoInfoTag::HasStreamDetails() const
 {
   return m_streamDetails.HasItems();
+}
+
+bool CVideoInfoTag::HasNFOStreamDetails() const
+{
+  if (!HasStreamDetails())
+    return false;
+
+  return m_streamDetails.GetSources() >= CStreamDetail::NFO;
 }
 
 bool CVideoInfoTag::IsEmpty() const

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1542,6 +1542,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
         m_streamDetails.AddStream(p);
       }
     }
+    m_streamDetails.SetSources(CStreamDetail::NFO);
     m_streamDetails.DetermineBestStreams();
   }  /* if fileinfo */
 
@@ -1606,6 +1607,14 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
 bool CVideoInfoTag::HasStreamDetails() const
 {
   return m_streamDetails.HasItems();
+}
+
+bool CVideoInfoTag::HasNFOStreamDetails() const
+{
+  if (!HasStreamDetails())
+    return false;
+
+  return m_streamDetails.GetSources() >= CStreamDetail::NFO;
 }
 
 bool CVideoInfoTag::IsEmpty() const

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -96,6 +96,7 @@ public:
   const CDateTime& GetFirstAired() const;
   std::string GetCast(const std::string& separator, bool bIncludeRole = false) const;
   bool HasStreamDetails() const;
+  bool HasNFOStreamDetails() const;
   bool IsEmpty() const;
 
   const std::string& GetPath() const


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Adds a column in the streamdetails table to track the source of the streamdetail.
Done on an individual detail level (although decisions are made at a per file level) - just to allow greater granularity in the future.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Following on from discussion in #27606 and previous PRs with @CrystalP - there can be a need to track the source of streamdetails - especially when they may be set later on (ie. blurays when the playlist cannot be determined at scan time). If there are partial streamdetails then it is not known if they arise from an NFO (in which case they should be kept) or from the media itself (in which case they should be updated).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
