### PR TITLE
[cmake] Find FFMPEG headers per-lib and using pkg-config INCLUDE_DIRS

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -385,11 +385,6 @@ else()
      FFMPEG_LIBSWSCALE AND
      FFMPEG_LIBSWRESAMPLE)
     set(FFMPEG_FOUND 1)
-
-    # list of sourceplugin headers for find_path
-    if(FFMPEG_LIBPOSTPROC)
-      set(source_plugin_headers libpostproc/postprocess.h)
-    endif()
   endif()
 
   if(FFMPEG_FOUND)
@@ -400,10 +395,17 @@ else()
     set(FFMPEG_VERSION ${REQUIRED_FFMPEG_VERSION})
 
     find_path(FFMPEG_INCLUDE_DIRS libavcodec/avcodec.h libavfilter/avfilter.h libavformat/avformat.h
-                                  libavutil/avutil.h libswscale/swscale.h ${source_plugin_headers}
+                                  libavutil/avutil.h libswscale/swscale.h
               PATH_SUFFIXES ffmpeg
               HINTS ${DEPENDS_PATH}/include ${MINGW_LIBS_DIR}/include
               ${${CORE_SYSTEM_NAME}_SEARCH_CONFIG})
+
+    if(FFMPEG_LIBPOSTPROC AND NOT FFMPEG_LIBPOSTPROC_INCLUDE_DIRS)
+      find_path(FFMPEG_LIBPOSTPROC_INCLUDE_DIRS libpostproc/postprocess.h
+                PATH_SUFFIXES ffmpeg
+                HINTS ${DEPENDS_PATH}/include ${MINGW_LIBS_DIR}/include
+                ${${CORE_SYSTEM_NAME}_SEARCH_CONFIG})
+    endif()
 
     # Windows is still just a straight file search. Explicitly search for Dav1d for
     # correct dependency linking
@@ -421,8 +423,7 @@ else()
         if(WIN32 OR WINDOWS_STORE)
           add_library(ffmpeg::${libname} UNKNOWN IMPORTED)
           set_target_properties(ffmpeg::${libname} PROPERTIES
-                                                   IMPORTED_LOCATION "${FFMPEG_${libname_UPPER}}"
-                                                   INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIRS}")
+                                                   IMPORTED_LOCATION "${FFMPEG_${libname_UPPER}}")
         else()
           # pkg-config LDFLAGS always seem to have -l<name> listed. We dont need that, as
           # the target gets a direct path to the physical lib
@@ -451,9 +452,16 @@ else()
           add_library(ffmpeg::${libname} STATIC IMPORTED)
           set_target_properties(ffmpeg::${libname} PROPERTIES
                                                    IMPORTED_LOCATION "${FFMPEG_${libname_UPPER}}"
-                                                   INTERFACE_LINK_LIBRARIES "${${libname}_LDFLAGS}"
-                                                   INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIRS}")
+                                                   INTERFACE_LINK_LIBRARIES "${${libname}_LDFLAGS}")
         endif()
+      endif()
+
+      if(FFMPEG_${libname_UPPER}_INCLUDE_DIRS)
+        set_target_properties(ffmpeg::${libname} PROPERTIES
+                                                 INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_${libname_UPPER}_INCLUDE_DIRS}")
+      else()
+        set_target_properties(ffmpeg::${libname} PROPERTIES
+                                                 INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIRS}")
       endif()
     endmacro()
 
@@ -477,7 +485,6 @@ if(FFMPEG_FOUND)
   if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} INTERFACE IMPORTED)
     set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
-                                                                     INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIRS}"
                                                                      INTERFACE_COMPILE_DEFINITIONS "${_ffmpeg_definitions}")
   endif()
 


### PR DESCRIPTION
## Description
Let's not assume that all the FFMPEG headers are in the same place.

Respect the include directories returned by pkg-config rather than simply searching standard locations.

There is no need to set `INTERFACE_INCLUDE_DIRECTORIES` for the overall ffmpeg target because it inherits these from its library dependencies.

## Motivation and context
Gentoo would ideally like to use the system FFMPEG, but this is missing libpostproc now that it's been dropped upstream. We have found that it is very easy to build libpostproc separately from the rest of FFMPEG, so we would like to build this just before Kodi and then point Kodi at it using `PKG_CONFIG_PATH`. I have verified that this works.

I am interested to know what your long term plans are regarding libpostproc. I imagine you don't want to keep carrying a big patch forever. There is the [source plugin](https://github.com/michaelni/libpostproc), but if I understand correctly, Kodi uses libpostproc without any FFMPEG context. Perhaps it would make sense to just turn it into a truly standalone library and maintain it within Kodi or as a separate CMake-based project. Or maybe another library can do the job? Or maybe the feature isn't that important? I must admit that I'm not sure how it's used here.

## How has this been tested?
I have tested building with and without the system FFMPEG on Linux.

## What is the effect on users?
Users can build with a separate libpostproc if pkg-config is configured appropriately.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
