### PR TITLE
[Music] Fix issues relating to CUE sheets.

### DIFF
--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -30,6 +30,8 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <ranges>
+
 using namespace KODI;
 using namespace MUSIC_INFO;
 using namespace XFILE;
@@ -198,16 +200,7 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
         m_databaseHits++;
       }
 
-      /*
-      This only loads the item with the song from the database when it maps to a single song,
-      it can not load song data for items with cuesheets that expand to multiple songs.
-      For songs from embedded or separate cuesheets strFileName is not unique, so the song map for
-      the path will have the list of songs from that file. But items with cuesheets are expanded
-      (replacing each item with items for every track) elsewhere. When the item we are looking up
-      has a cuesheet document or is a music file with a cuesheet embedded in the tags, and it maps
-      to more than one song then we can not fill the tag data and thumb from the database.
-      */
-      auto it = m_songsMap.find(pItem->GetPath()); // Find file in song map
+      const auto it = m_songsMap.find(pItem->GetPath()); // Find file in song map
       if (it != m_songsMap.end() && it->second.size() == 1)
       {
         // Have we loaded this item from database before,
@@ -215,6 +208,31 @@ bool CMusicInfoLoader::LoadItemLookup(CFileItem* pItem)
         pItem->GetMusicInfoTag()->SetSong(it->second[0]);
         if (!it->second[0].strThumb.empty())
           pItem->SetArt("thumb", it->second[0].strThumb);
+      }
+      else if (it != m_songsMap.end() && it->second.size() > 1 &&
+               pItem->GetProperty("cueloadinformation").asBoolean(false))
+      {
+        // Find matching song
+        const auto& songs{it->second};
+        const auto it2{std::ranges::find_if(
+            songs,
+            [&pItem](const CSong& song)
+            {
+              return song.iStartOffset == static_cast<int>(pItem->GetStartOffset()) &&
+                     song.iEndOffset == static_cast<int>(pItem->GetEndOffset());
+            })};
+        if (it2 != songs.end())
+        {
+          // Populate the music info tag from the matched song
+          pItem->GetMusicInfoTag()->SetSong(*it2);
+          if (!it2->strThumb.empty())
+            pItem->SetArt("thumb", it2->strThumb);
+
+          // Build the musicdb:// path so the item references the database entry
+          pItem->SetDynPath(pItem->GetPath());
+          pItem->SetPath(StringUtils::Format("musicdb://songs/{}{}", it2->idSong,
+                                             URIUtils::GetExtension(it2->strFileName)));
+        }
       }
       else if (MUSIC::IsMusicDb(*pItem))
       { // a music db item that doesn't have tag loaded - grab details from the database

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -487,7 +487,10 @@ bool CPlayList::Expand(int position)
   {
     (*playlist)[i]->SetDynPath((*playlist)[i]->GetPath());
     (*playlist)[i]->SetPath(item->GetDynPath());
-    (*playlist)[i]->SetStartOffset(item->GetStartOffset());
+    // Only propagate parent's start offset if the loaded item doesn't already
+    // have its own (e.g. a CUE sheet offset loaded from the playlist file).
+    if (!(*playlist)[i]->HasProperty("item_start"))
+      (*playlist)[i]->SetStartOffset(item->GetStartOffset());
     if (!(*playlist)[i]->HasProperty("BasePath"))
       (*playlist)[i]->SetProperty("BasePath", playlist->m_strBasePath);
   }

--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -179,8 +179,7 @@ bool CPlayListM3U::Load(const std::string& strFileName)
           newItem->SetStartPartNumber(1);
           newItem->SetProperty("item_start", iStartOffset);
           newItem->SetEndOffset(iEndOffset);
-          // Prevent load message from file and override offset set here
-          newItem->GetMusicInfoTag()->SetLoaded();
+          newItem->SetProperty("cueloadinformation", true);
           newItem->GetMusicInfoTag()->SetTitle(strInfo);
           if (iEndOffset)
             lDuration = static_cast<int>(CUtil::ConvertMilliSecsToSecsIntRounded(iEndOffset - iStartOffset));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

In exploring this issue again I've discovered two problems.

The first is the lack of metadata being displayed (and play count being updated) when a song in a local, single multi-song file with a cue sheet is viewed/played in the library as part of a playlist. This is fixed with commit 1.

The second became apparent when investigating using Kodi as UPNP renderer (in this case using another instance of kodi on the LAN as the server) - the offset wasn't being respected there either - fixed in commit 2 (although the fix is not actually in the UPNP code itself).
Reproduced by creating a playlist using a song from a single file album on UPNP server and trying to play that song. Without the fix the first song (ie the beginning of the file) is played irrespective of which song is selected.

Whilst I accept CUE sheets are old - looking at the feedback in the bug report there are still people who use them. These fixes are low cost and unless they cause regressions I can't see why they shouldn't be included.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

(Part) Fix #24247.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
