### PR TITLE
[cmake] Use WITH_* directly rather than passing it to find_program

### DIFF
--- a/cmake/modules/buildtools/FindJsonSchemaBuilder.cmake
+++ b/cmake/modules/buildtools/FindJsonSchemaBuilder.cmake
@@ -3,8 +3,9 @@
 # ---------------------
 # Finds the JsonSchemaBuilder
 #
-# If WITH_JSONSCHEMABUILDER is defined and points to a directory,
-# this path will be used to search for the JsonSchemaBuilder binary
+# If WITH_JSONSCHEMABUILDER is defined, it will be used as the location of an
+# existing JsonSchemaBuilder binary to execute during the build. Useful when
+# cross-compiling. The file must exist and be executable at configure time.
 #
 #
 # This will define the following (imported) targets::
@@ -17,11 +18,13 @@ if(NOT TARGET JsonSchemaBuilder::JsonSchemaBuilder)
 
   if(WITH_JSONSCHEMABUILDER)
     get_filename_component(_jsbpath ${WITH_JSONSCHEMABUILDER} ABSOLUTE)
-    get_filename_component(_jsbpath ${_jsbpath} DIRECTORY)
-    find_program(JSONSCHEMABUILDER_EXECUTABLE NAMES "${APP_NAME_LC}-JsonSchemaBuilder" JsonSchemaBuilder
-                                                    "${APP_NAME_LC}-JsonSchemaBuilder.exe" JsonSchemaBuilder.exe
-                                              HINTS ${_jsbpath})
-
+    if(NOT IS_DIRECTORY ${_jsbpath})
+      get_filename_component(_jsbpath ${_jsbpath} DIRECTORY)
+    endif()
+    find_program(JSONSCHEMABUILDER_EXECUTABLE
+                 NAMES "${APP_NAME_LC}-JsonSchemaBuilder" JsonSchemaBuilder
+                 HINTS ${_jsbpath}
+                 NO_DEFAULT_PATH)
     if(NOT JSONSCHEMABUILDER_EXECUTABLE)
       message(FATAL_ERROR "Could not find 'JsonSchemaBuilder' executable in ${_jsbpath} supplied by -DWITH_JSONSCHEMABUILDER")
     endif()

--- a/cmake/modules/buildtools/FindTexturePacker.cmake
+++ b/cmake/modules/buildtools/FindTexturePacker.cmake
@@ -3,8 +3,10 @@
 # -----------------
 # Finds the TexturePacker
 #
-# If WITH_TEXTUREPACKER is defined and points to a directory,
-# this path will be used to search for the Texturepacker binary
+# If WITH_TEXTUREPACKER is defined, it will be used as the location of an
+# existing TexturePacker binary to execute during the build. Useful when
+# cross-compiling. The file must exist and be executable at configure time. A
+# newly-built binary is installed alongside Kodi regardless.
 #
 #
 # This will define the following (imported) targets::
@@ -34,10 +36,13 @@ if(NOT TARGET TexturePacker::TexturePacker::Executable)
   else()
     if(WITH_TEXTUREPACKER)
       get_filename_component(_tppath ${WITH_TEXTUREPACKER} ABSOLUTE)
-      get_filename_component(_tppath ${_tppath} DIRECTORY)
-      find_program(TEXTUREPACKER_EXECUTABLE NAMES "${APP_NAME_LC}-TexturePacker" TexturePacker
-                                          HINTS ${_tppath})
-
+      if(NOT IS_DIRECTORY ${_tppath})
+        get_filename_component(_tppath ${_tppath} DIRECTORY)
+      endif()
+      find_program(TEXTUREPACKER_EXECUTABLE
+                   NAMES "${APP_NAME_LC}-TexturePacker" TexturePacker
+                   HINTS ${_tppath}
+                   NO_DEFAULT_PATH)
       # Use external TexturePacker executable if found
       if(TEXTUREPACKER_EXECUTABLE)
         add_executable(TexturePacker::TexturePacker::Executable IMPORTED GLOBAL)
@@ -45,10 +50,7 @@ if(NOT TARGET TexturePacker::TexturePacker::Executable)
                                           IMPORTED_LOCATION "${TEXTUREPACKER_EXECUTABLE}")
         message(STATUS "Found external TexturePacker: ${TEXTUREPACKER_EXECUTABLE}")
       else()
-        # Warn about external TexturePacker supplied but not fail fatally
-        # because we might have internal TexturePacker executable built
-        # and unset TEXTUREPACKER_EXECUTABLE variable
-        message(WARNING "Could not find '${APP_NAME_LC}-TexturePacker' or 'TexturePacker' executable in ${_tppath} supplied by -DWITH_TEXTUREPACKER. Make sure the executable file name matches these names!")
+        message(FATAL_ERROR "Could not find '${APP_NAME_LC}-TexturePacker' or 'TexturePacker' executable in ${_tppath} supplied by -DWITH_TEXTUREPACKER. Make sure the executable file name matches these names!")
       endif()
     endif()
 

--- a/cmake/scripts/common/ProjectMacros.cmake
+++ b/cmake/scripts/common/ProjectMacros.cmake
@@ -31,8 +31,8 @@ function(pack_xbt input output)
 
   file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/GeneratedPackSkins.cmake
 "message(STATUS \"Packing ${file} for ${skin}\")
-execute_process(COMMAND \"${CMAKE_COMMAND}\" -E make_directory ${dir})
-execute_process(COMMAND \$\{TEXTUREPACKER_EXECUTABLE\} -input ${input} -output ${output} -dupecheck ${verbose_flag})\n")
+execute_process(COMMAND \"${CMAKE_COMMAND}\" -E make_directory ${dir} COMMAND_ERROR_IS_FATAL ANY)
+execute_process(COMMAND \$\{TEXTUREPACKER_EXECUTABLE\} -input ${input} -output ${output} -dupecheck ${verbose_flag} COMMAND_ERROR_IS_FATAL ANY)\n")
 
     list(APPEND XBT_FILES ${output})
     set(XBT_FILES ${XBT_FILES} PARENT_SCOPE)


### PR DESCRIPTION
## Description
This makes the `find_program` calls for `WITH_JSONSCHEMABUILDER` and `WITH_TEXTUREPACKER` not search the default paths and handle directories properly.

It also makes TexturePacker execution failure fatal.

## Motivation and context
Firstly, `find_program` was searching default paths, causing it to choose the non-native TexturePacker binary that had previously been installed.

It was documented that `WITH_*` should point to a directory but the build then treated it as a file, looking in the parent directory and causing the find to fail.

Failing to find the given TexturePacker packer should also be fatal. If you supply `WITH_TEXTUREPACKER`, then you would expect it to be used or otherwise fail fast. Continuing anyway might work, but probably not when cross-compiling, and cross-compiling is the only reason to use this option.

P.S. You don't need to add `.exe` to `find_program` for Windows, CMake checks this suffix automatically.

## How has this been tested?
I've successfully done a native build and a cross build with and without kodi-TexturePacker already being installed.

## What is the effect on users?
Users can cross-compile reliably.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
