### PR TITLE
[VideoPlayer][Estuary] Display the subtitle codec of the playing video

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -989,3 +989,15 @@ msgstr ""
 msgctxt "#31613"
 msgid "Subtitle decoder"
 msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the subtitle codec name
+msgctxt "#31614"
+msgid "Subtitle codec"
+msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the subtitle language
+msgctxt "#31615"
+msgid "Subtitle language"
+msgstr ""

--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -983,3 +983,9 @@ msgstr ""
 msgctxt "#31612"
 msgid "channels"
 msgstr ""
+
+#: /xml/DialogPlayerProcessInfo.xml
+#. Label to show the subtitle decoder name
+msgctxt "#31613"
+msgid "Subtitle decoder"
+msgstr ""

--- a/addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
+++ b/addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
@@ -219,6 +219,29 @@
 				</control>
 			</control>
 			<control type="grouplist">
+				<left>985</left>
+				<top>-4</top>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5552)</visible>
+				<control type="label">
+					<width>885</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.SubtitleCodec,[COLOR button_focus]$LOCALIZE[31614]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + !String.IsEmpty(VideoPlayer.SubtitleCodec)</visible>
+				</control>
+				<control type="label">
+					<width>885</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[VideoPlayer.SubtitlesLanguage,[COLOR button_focus]$LOCALIZE[31615]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + !String.IsEmpty(VideoPlayer.SubtitlesLanguage)</visible>
+				</control>
+			</control>
+			<control type="grouplist">
 				<left>50</left>
 				<top>-204</top>
 				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5553)</visible>

--- a/addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
+++ b/addons/skin.estuary/xml/DialogPlayerProcessInfo.xml
@@ -300,6 +300,20 @@
 				</control>
 			</control>
 			<control type="grouplist">
+				<left>985</left>
+				<top>-4</top>
+				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5553)</visible>
+				<control type="label">
+					<width>885</width>
+					<height>50</height>
+					<aligny>bottom</aligny>
+					<label>$INFO[Player.Process(subtitledecoder),[COLOR button_focus]$LOCALIZE[31613]:[/COLOR] ]</label>
+					<font>font14</font>
+					<shadowcolor>black</shadowcolor>
+					<visible>VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + !String.IsEmpty(Player.Process(subtitledecoder))</visible>
+				</control>
+			</control>
+			<control type="grouplist">
 				<left>50</left>
 				<top>-204</top>
 				<visible>String.IsEqual(Window(Home).Property(PlayerInfoDialogFocus),5554)</visible>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -427,8 +427,8 @@
 					<param name="flag_label" value="$VAR[AudioPropertyFlagVar]" />
 				</include>
 				<include content="MediaFlag">
-					<param name="flag_visible" value="VideoPlayer.HasSubTitles + VideoPlayer.SubTitlesEnabled + !String.IsEmpty(VideoPlayer.SubtitleCodec)" />
-					<param name="flag_label" value="$VAR[SubtitleCodecVar]" />
+					<param name="flag_visible" value="VideoPlayer.SubtitlesEnabled + [!String.IsEmpty(VideoPlayer.SubtitleCodec) | !String.IsEmpty(VideoPlayer.SubtitlesLanguage)]" />
+					<param name="flag_label" value="$VAR[ActiveVideoPlayerSubtitleLanguage]" />
 				</include>
 			</control>
 			<control type="grouplist">

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -426,6 +426,10 @@
 					<param name="flag_visible" value="!String.IsEmpty(VideoPlayer.AudioChannels)" />
 					<param name="flag_label" value="$VAR[AudioPropertyFlagVar]" />
 				</include>
+				<include content="MediaFlag">
+					<param name="flag_visible" value="VideoPlayer.HasSubTitles + VideoPlayer.SubTitlesEnabled + !String.IsEmpty(VideoPlayer.SubtitleCodec)" />
+					<param name="flag_label" value="$VAR[SubtitleCodecVar]" />
+				</include>
 			</control>
 			<control type="grouplist">
 				<visible>!String.IsEqual(ListItem.DbType,musicvideo) + [Container.Content(albums) | Window.IsActive(music)]</visible>

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -658,7 +658,7 @@
 						<height>20</height>
 						<font>font10</font>
 						<aligny>center</aligny>
-						<label>$VAR[StreamCodecVar]$INFO[ListItem.Property(stream.description), | ]</label>
+						<label>$VAR[SubtitleStreamDescriptionVar]</label>
 						<textcolor>grey</textcolor>
 					</control>
 					<control type="image">
@@ -707,7 +707,7 @@
 						<font>font10</font>
 						<aligny>center</aligny>
 						<scroll>true</scroll>
-						<label>$VAR[StreamCodecVar]$INFO[ListItem.Property(stream.description), | ]</label>
+						<label>$VAR[SubtitleStreamDescriptionVar]</label>
 						<scroll>true</scroll>
 					</control>
 					<control type="image">

--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -658,7 +658,7 @@
 						<height>20</height>
 						<font>font10</font>
 						<aligny>center</aligny>
-						<label>$INFO[ListItem.Property(stream.description)]</label>
+						<label>$VAR[StreamCodecVar]$INFO[ListItem.Property(stream.description), | ]</label>
 						<textcolor>grey</textcolor>
 					</control>
 					<control type="image">
@@ -707,7 +707,7 @@
 						<font>font10</font>
 						<aligny>center</aligny>
 						<scroll>true</scroll>
-						<label>$INFO[ListItem.Property(stream.description)]</label>
+						<label>$VAR[StreamCodecVar]$INFO[ListItem.Property(stream.description), | ]</label>
 						<scroll>true</scroll>
 					</control>
 					<control type="image">

--- a/addons/skin.estuary/xml/Includes_SettingsDialog.xml
+++ b/addons/skin.estuary/xml/Includes_SettingsDialog.xml
@@ -52,7 +52,7 @@
 				<param name="width" value="1000" />
 			</include>
 			<label>$LOCALIZE[31115]</label>
-			<label2>[B]$VAR[ActiveVideoPlayerSubtitleLanguage]$VAR[SubtitleCodecVar, | ][/B]</label2>
+			<label2>[B]$VAR[ActiveVideoPlayerSubtitleLanguage][/B]</label2>
 			<onclick>DialogSelectSubtitle</onclick>
 			<enable>VideoPlayer.HasSubtitles</enable>
 		</control>

--- a/addons/skin.estuary/xml/Includes_SettingsDialog.xml
+++ b/addons/skin.estuary/xml/Includes_SettingsDialog.xml
@@ -52,7 +52,7 @@
 				<param name="width" value="1000" />
 			</include>
 			<label>$LOCALIZE[31115]</label>
-			<label2>[B]$VAR[ActiveVideoPlayerSubtitleLanguage][/B]</label2>
+			<label2>[B]$VAR[ActiveVideoPlayerSubtitleLanguage]$VAR[SubtitleCodecVar, | ][/B]</label2>
 			<onclick>DialogSelectSubtitle</onclick>
 			<enable>VideoPlayer.HasSubtitles</enable>
 		</control>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -737,10 +737,12 @@
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>
 	<variable name="ActiveVideoPlayerSubtitleLanguage">
-		<value condition="!VideoPlayer.HasSubtitles">$LOCALIZE[36623]</value>
-		<value condition="VideoPlayer.HasSubtitles + !VideoPlayer.SubtitlesEnabled">$LOCALIZE[1223]</value>
-		<value condition="VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + !String.IsEmpty(VideoPlayer.SubtitlesLanguage)">$INFO[VideoPlayer.SubtitlesLanguage]</value>
-		<value condition="VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + [String.IsEmpty(VideoPlayer.SubtitlesLanguage) | String.IsEqual(ListItem.AudioLanguage,und)]">$LOCALIZE[13205]</value>
+		<value condition="Window.IsActive(Custom_1101_SettingsDialog.xml) + !VideoPlayer.HasSubtitles">$LOCALIZE[36623]</value>
+		<value condition="Window.IsActive(Custom_1101_SettingsDialog.xml) + VideoPlayer.HasSubtitles + !VideoPlayer.SubtitlesEnabled">$LOCALIZE[1223]</value>
+        <value condition="Window.IsActive(Custom_1101_SettingsDialog.xml) + VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + [String.IsEmpty(VideoPlayer.SubtitlesLanguage) | String.IsEqual(VideoPlayer.SubtitlesLanguage,und)]">$LOCALIZE[13205]$VAR[SubtitleCodecVar, | ]</value>
+		<value condition="Window.IsActive(Custom_1101_SettingsDialog.xml) + VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + !String.IsEmpty(VideoPlayer.SubtitlesLanguage)">$INFO[VideoPlayer.SubtitlesLanguage]$VAR[SubtitleCodecVar, | ]</value>
+        <value condition="Window.IsActive(fullscreenvideo) + [String.IsEmpty(VideoPlayer.SubtitlesLanguage) | String.IsEqual(VideoPlayer.SubtitlesLanguage,und)] + !String.IsEmpty(VideoPlayer.SubtitleCodec)">$VAR[SubtitleCodecVar]</value>
+		<value condition="Window.IsActive(fullscreenvideo) + !String.IsEmpty(VideoPlayer.SubtitlesLanguage)">$INFO[VideoPlayer.SubtitlesLanguage]$VAR[SubtitleCodecVar, &#8226; ]</value>
 	</variable>
 	<variable name="ActiveVideoPlayerAudioLanguage">
 		<value condition="!String.IsEmpty(VideoPlayer.AudioLanguage)">$INFO[VideoPlayer.AudioLanguage]</value>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -1053,6 +1053,11 @@
 	<variable name="StreamBitrateVar">
 		<value condition="!String.IsEqual(ListItem.Property(stream.bitrate),0)">$INFO[ListItem.Property(stream.bitrate)]</value>
 	</variable>
+	<variable name="SubtitleStreamDescriptionVar">
+		<value condition="!String.IsEmpty(ListItem.Property(stream.codecdesc))">$INFO[ListItem.Property(stream.codecdesc)]$INFO[ListItem.Property(stream.description), | ]</value>
+		<value condition="!String.IsEmpty(ListItem.Property(stream.codec))">$INFO[ListItem.Property(stream.codec)]$INFO[ListItem.Property(stream.description), | ]</value>
+		<value>$INFO[ListItem.Property(stream.description)]</value>
+	</variable>
 	<variable name="MediaInfoListLabelVar">
 		<value>$INFO[ListItem.Label]</value>
 	</variable>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -950,6 +950,7 @@
 		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, ttml)">TTML</value>
 		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, vplayer)">VPlayer</value>
 		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, webvtt)">WebVTT</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, xsub)">XSUB</value>
 		<value condition="Window.IsActive(fullscreenvideo)">$INFO[VideoPlayer.SubtitleCodec]</value>
 	</variable>
 	<variable name="StreamCodecVar">
@@ -1019,6 +1020,24 @@
 		<value condition="Window.IsVisible(dialogselectaudio) + String.IsEqual(ListItem.Property(stream.codec),ac3)">Dolby Digital</value>
 		<value condition="Window.IsVisible(dialogselectaudio) + String.IsEqual(ListItem.Property(stream.codec),truehd_atmos)">Dolby TrueHD / Atmos</value>
 		<value condition="Window.IsVisible(dialogselectaudio) + String.IsEqual(ListItem.Property(stream.codec),truehd)">Dolby TrueHD</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),ass)">ASS</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),dvb_subtitle)">DVB-SUB</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),dvb_teletext)">DVB-Text</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),dvd_subtitle)">VobSub</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),hdmv_pgs_subtitle)">PGS</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),microdvd)">MicroDVD</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),mov_text)">Timed Text</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),mpl2)">MPL2</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),realtext)">RealText</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),sami)">SAMI</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),srt)">SubRip</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),ssa)">SSA</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),subrip)">Subrip</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),text)">Text</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),ttml)">TTML</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),vplayer)">VPlayer</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),webvtt)">WebVTT</value>
+		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),xsub)">XSUB</value>
 		<value>$INFO[ListItem.Property(stream.codec)]</value>
 	</variable>
 	<variable name="StreamChannelsVar">

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -932,6 +932,26 @@
 		<value condition="Container.Content(albums) | Window.IsActive(10502)">$INFO[ListItem.MusicChannels(DefaultLayout)]</value>
 		<value>$INFO[ListItem.AudioChannels(DefaultLayout)]</value>
 	</variable>
+	<variable name="SubtitleCodecVar">
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, ass)">ASS</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, dvb_subtitle)">DVB-SUB</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, dvb_teletext)">DVB-Text</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, dvd_subtitle)">VobSub</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, hdmv_pgs_subtitle)">PGS</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, microdvd)">MicroDVD</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, mov_text)">Timed Text</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, mpl2)">MPL2</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, realtext)">RealText</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, sami)">SAMI</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, srt)">SubRip</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, ssa)">SSA</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, subrip)">Subrip</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, text)">Text</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, ttml)">TTML</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, vplayer)">VPlayer</value>
+		<value condition="Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.SubtitleCodec, webvtt)">WebVTT</value>
+		<value condition="Window.IsActive(fullscreenvideo)">$INFO[VideoPlayer.SubtitleCodec]</value>
+	</variable>
 	<variable name="StreamCodecVar">
 		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),av1)">AV1</value>
 		<value condition="Window.IsVisible(dialogselectvideo) + String.IsEqual(ListItem.Property(stream.codec),avc1)">AVC-1</value>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -3935,6 +3935,35 @@ constexpr std::array<InfoMap, 46> musicplayer = {{
 ///     @skinning_v13 **[New Infolabel]** \link VideoPlayer_SubtitlesLanguage `VideoPlayer.SubtitlesLanguage`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`VideoPlayer.SubtitleCodec`</b>,
+///                  \anchor VideoPlayer_SubtitleCodec
+///                  _string_,
+///     @return The codec of the current subtitles of the currently playing video. Possible values include:
+///       - <b>ass</b>
+///       - <b>dvb_subtitle</b>
+///       - <b>dvb_teletext</b>
+///       - <b>dvd_subtitle</b>
+///       - <b>hdmv_pgs_subtitle</b>
+///       - <b>microdvd</b>
+///       - <b>mov_text</b>
+///       - <b>mpl2</b>
+///       - <b>realtext</b>
+///       - <b>sami</b>
+///       - <b>srt</b>
+///       - <b>ssa</b>
+///       - <b>subrip</b>
+///       - <b>text</b>
+///       - <b>ttml</b>
+///       - <b>vplayer</b>
+///       - <b>webvtt</b>
+///       - <b>xsub</b>
+///
+///     @note `VideoPlayer.SubtitleCodec` holds the codec of the next available subtitles stream
+///     if subtitles are disabled in the player.
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link VideoPlayer_SubtitleCodec `VideoPlayer.SubtitleCodec`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`VideoPlayer.StereoscopicMode`</b>,
 ///                  \anchor VideoPlayer_StereoscopicMode
 ///                  _string_,
@@ -4181,7 +4210,7 @@ constexpr std::array<InfoMap, 46> musicplayer = {{
 ///
 /// -----------------------------------------------------------------------------
 // clang-format off
-constexpr std::array<InfoMap, 83> videoplayer = {{
+constexpr std::array<InfoMap, 84> videoplayer = {{
     {"title",                 VIDEOPLAYER_TITLE},
     {"genre",                 VIDEOPLAYER_GENRE},
     {"country",               VIDEOPLAYER_COUNTRY},
@@ -4229,6 +4258,7 @@ constexpr std::array<InfoMap, 83> videoplayer = {{
     {"hassubtitles",          VIDEOPLAYER_HASSUBTITLES},
     {"subtitlesenabled",      VIDEOPLAYER_SUBTITLESENABLED},
     {"subtitleslanguage",     VIDEOPLAYER_SUBTITLES_LANG},
+    {"subtitlecodec",         VIDEOPLAYER_SUBTITLE_CODEC},
     {"starttime",             VIDEOPLAYER_STARTTIME},
     {"endtime",               VIDEOPLAYER_ENDTIME},
     {"nexttitle",             VIDEOPLAYER_NEXT_TITLE},

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -1120,7 +1120,7 @@ constexpr std::array<InfoMap, 10> player_times = {{
 ///   \table_row3{   <b>`Player.Process(audiochannels)`</b>,
 ///                  \anchor Player_Process_audiochannels
 ///                  _string_,
-///     @return The audiodecoder name of the currently playing item.
+///     @return The audiochannels string of the currently playing item.
 ///     <p><hr>
 ///     @skinning_v17 **[New Infolabel]** \link Player_Process_audiochannels `Player.Process(audiochannels)`\endlink
 ///     <p>
@@ -1141,11 +1141,20 @@ constexpr std::array<InfoMap, 10> player_times = {{
 ///     @skinning_v17 **[New Infolabel]** \link Player_Process_audiobitspersample `Player.Process(audiobitspersample)`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Player.Process(subtitledecoder)`</b>,
+///                  \anchor Player_Process_subtitledecoder
+///                  _string_,
+///     @return The name of the active subtitle decoder for the currently playing item\, for example
+///             ff-pgssub or SSA Subtitle Decoder.
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link Player_Process_subtitledecoder `Player.Process(subtitledecoder)`\endlink
+///     <p>
+///   }
 /// \table_end
 ///
 /// -----------------------------------------------------------------------------
 // clang-format off
-constexpr std::array<InfoMap, 13> player_process = {{
+constexpr std::array<InfoMap, 14> player_process = {{
     {"videodecoder",        PLAYER_PROCESS_VIDEODECODER},
     {"deintmethod",         PLAYER_PROCESS_DEINTMETHOD},
     {"pixformat",           PLAYER_PROCESS_PIXELFORMAT},
@@ -1159,6 +1168,7 @@ constexpr std::array<InfoMap, 13> player_process = {{
     {"audiosamplerate",     PLAYER_PROCESS_AUDIOSAMPLERATE},
     {"audiobitspersample",  PLAYER_PROCESS_AUDIOBITSPERSAMPLE},
     {"videoscantype",       PLAYER_PROCESS_VIDEOSCANTYPE},
+    {"subtitledecoder",     PLAYER_PROCESS_SUBTITLEDECODER},
 }};
 // clang-format on
 

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -262,6 +262,21 @@ int CDataCacheCore::GetAudioBitsPerSample()
   std::unique_lock lock(m_audioPlayerSection);
 
   return m_playerAudioInfo.bitsPerSample;
+}
+
+// player subtitle info
+void CDataCacheCore::SetSubtitleDecoderName(std::string name)
+{
+  std::unique_lock lock(m_subtitlePlayerSection);
+
+  m_playerSubtitleInfo.m_decoderName = std::move(name);
+}
+
+std::string CDataCacheCore::GetSubtitleDecoderName()
+{
+  std::unique_lock lock(m_subtitlePlayerSection);
+
+  return m_playerSubtitleInfo.m_decoderName;
 }
 
 void CDataCacheCore::SetEditList(const std::vector<EDL::Edit>& editList)

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -68,6 +68,10 @@ public:
   int GetAudioSampleRate();
   void SetAudioBitsPerSample(int bitsPerSample);
   int GetAudioBitsPerSample();
+
+  // player subtitle info
+  void SetSubtitleDecoderName(std::string name);
+  std::string GetSubtitleDecoderName();
 
   // content info
 
@@ -222,6 +226,12 @@ protected:
     int sampleRate;
     int bitsPerSample;
   } m_playerAudioInfo;
+
+  CCriticalSection m_subtitlePlayerSection;
+  struct SPlayerSubtitleInfo
+  {
+    std::string m_decoderName;
+  } m_playerSubtitleInfo;
 
   mutable CCriticalSection m_contentSection;
   struct SContentInfo

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodec.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -77,6 +77,12 @@ public:
    * return codecs name
    */
   const std::string& GetName() const { return m_codecName; }
+
+  /*!
+   * \brief Set the codec name
+   * \param[in] name name
+   */
+  void SetName(const std::string& name) { m_codecName = name; }
 
 protected:
   /*

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -113,6 +113,9 @@ bool CDVDOverlayCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &optio
     avcodec_free_context(&m_pCodecContext);
     return false;
   }
+
+  if (pCodec->name != nullptr)
+    SetName("ff-" + std::string(pCodec->name));
 
   return true;
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -11,8 +11,11 @@
 #include "ServiceBroker.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
+#include "utils/Map.h"
 #include "utils/StreamUtils.h"
 #include "utils/StringUtils.h"
+
+#include <string_view>
 
 std::string CDemuxStreamAudio::GetStreamType() const
 {
@@ -141,6 +144,37 @@ std::string CDemuxStreamAudio::GetStreamType() const
 
   strInfo.append(" ");
   strInfo.append(StreamUtils::GetLayout(iChannels));
+
+  return strInfo;
+}
+
+constexpr auto subtitleTypes = make_map<int, std::string_view>({
+    {AV_CODEC_ID_DVD_SUBTITLE, "VobSub"},
+    {AV_CODEC_ID_DVB_SUBTITLE, "DVB-SUB"},
+    {AV_CODEC_ID_SSA, "SSA"},
+    {AV_CODEC_ID_MOV_TEXT, "TTXT"}, // mov-text, timed text
+    {AV_CODEC_ID_TEXT, "Text"},
+    {AV_CODEC_ID_XSUB, "XSUB"},
+    {AV_CODEC_ID_HDMV_PGS_SUBTITLE, "PGS"},
+    {AV_CODEC_ID_DVB_TELETEXT, "DVB-TXT"},
+    {AV_CODEC_ID_SRT, "SubRip"},
+    {AV_CODEC_ID_MICRODVD, "MicroDVD"},
+    {AV_CODEC_ID_SAMI, "SAMI"},
+    {AV_CODEC_ID_REALTEXT, "RealText"},
+    {AV_CODEC_ID_SUBRIP, "SubRip"},
+    {AV_CODEC_ID_WEBVTT, "WebVTT"},
+    {AV_CODEC_ID_MPL2, "MPL2"},
+    {AV_CODEC_ID_VPLAYER, "VPlayer"},
+    {AV_CODEC_ID_ASS, "ASS"},
+    {AV_CODEC_ID_TTML, "TTML"},
+});
+
+std::string CDemuxStreamSubtitle::GetStreamType() const
+{
+  std::string strInfo;
+
+  if (auto it = subtitleTypes.find(codec); it != subtitleTypes.cend())
+    strInfo = it->second;
 
   return strInfo;
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -202,6 +202,8 @@ class CDemuxStreamSubtitle : public CDemuxStream
 {
 public:
   CDemuxStreamSubtitle() : CDemuxStream(StreamType::SUBTITLE) {}
+
+  std::string GetStreamType() const;
 };
 
 class CDemuxStreamTeletext : public CDemuxStream

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -975,6 +975,7 @@ void CDVDInputStreamNavigator::SetSubtitleStreamName(SubtitleStreamInfo &info, c
         break;
     }
     info.codecName = "dvd_subtitle";
+    info.codecDesc = "VobSub";
   }
 }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamNavigator.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2022 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -974,6 +974,7 @@ void CDVDInputStreamNavigator::SetSubtitleStreamName(SubtitleStreamInfo &info, c
       default:
         break;
     }
+    info.codecName = "dvd_subtitle";
   }
 }
 

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -411,6 +411,39 @@ int CProcessInfo::GetAudioBitsPerSample()
 bool CProcessInfo::AllowDTSHDDecode()
 {
   return true;
+}
+
+//******************************************************************************
+// player subtitle info
+//******************************************************************************
+
+void CProcessInfo::ResetSubtitleCodecInfo()
+{
+  std::unique_lock lock(m_subtitleCodecSection);
+
+  m_subtitleDecoderName.clear();
+
+  if (m_dataCache)
+  {
+    m_dataCache->SetSubtitleDecoderName(m_subtitleDecoderName);
+  }
+}
+
+void CProcessInfo::SetSubtitleDecoderName(const std::string& name)
+{
+  std::unique_lock lock(m_subtitleCodecSection);
+
+  m_subtitleDecoderName = name;
+
+  if (m_dataCache)
+    m_dataCache->SetSubtitleDecoderName(m_subtitleDecoderName);
+}
+
+std::string CProcessInfo::GetSubtitleDecoderName()
+{
+  std::unique_lock lock(m_subtitleCodecSection);
+
+  return m_subtitleDecoderName;
 }
 
 void CProcessInfo::SetRenderClockSync(bool enabled)

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -72,6 +72,11 @@ public:
   int GetAudioBitsPerSample();
   virtual bool AllowDTSHDDecode();
   virtual bool WantsRawPassthrough() { return false; }
+
+  // subtitle info
+  void ResetSubtitleCodecInfo();
+  void SetSubtitleDecoderName(const std::string& name);
+  std::string GetSubtitleDecoderName();
 
   // render info
   void SetRenderClockSync(bool enabled);
@@ -147,6 +152,10 @@ protected:
   int m_audioSampleRate;
   int m_audioBitsPerSample;
   CCriticalSection m_audioCodecSection;
+
+  // player subtitle info
+  std::string m_subtitleDecoderName;
+  CCriticalSection m_subtitleCodecSection;
 
   // render info
   CCriticalSection m_renderSection;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -584,6 +584,7 @@ void CSelectionStreams::Update(const std::shared_ptr<CDVDInputStream>& input,
       SubtitleStreamInfo info = nav->GetSubtitleStreamInfo(i);
       s.name     = info.name;
       s.codec = info.codecName;
+      s.codecDesc = info.codecDesc;
       s.flags = info.flags;
       s.language = g_LangCodeExpander.ConvertToISO6392B(info.language);
       Update(s);
@@ -659,6 +660,10 @@ void CSelectionStreams::Update(const std::shared_ptr<CDVDInputStream>& input,
         s.codecDesc = static_cast<CDemuxStreamAudio*>(stream)->GetStreamType();
         s.channels = static_cast<CDemuxStreamAudio*>(stream)->iChannels;
         s.bitrate = static_cast<CDemuxStreamAudio*>(stream)->iBitRate;
+      }
+      if (stream->type == StreamType::SUBTITLE)
+      {
+        s.codecDesc = static_cast<CDemuxStreamSubtitle*>(stream)->GetStreamType();
       }
       Update(s);
     }
@@ -5767,6 +5772,7 @@ void CVideoPlayer::GetSubtitleStreamInfo(int index, SubtitleStreamInfo& info) co
   info.valid = true;
   info.language = s.language;
   info.codecName = s.codec;
+  info.codecDesc = s.codecDesc;
   info.flags = s.flags;
   info.isExternal = STREAM_SOURCE_MASK(s.source) == STREAM_SOURCE_DEMUX_SUB ||
                     STREAM_SOURCE_MASK(s.source) == STREAM_SOURCE_TEXT;
@@ -5838,6 +5844,7 @@ void CVideoPlayer::NotifySubtitleUpdate(int flags)
       // Only add stream info if valid
       CVariant contentEntry(CVariant::VariantTypeObject);
       contentEntry["index"] = stream;
+      contentEntry["codec"] = info.codecDesc;
       contentEntry["isdefault"] = (info.flags & StreamFlags::FLAG_DEFAULT) != 0;
       contentEntry["isforced"] = (info.flags & StreamFlags::FLAG_FORCED) != 0;
       contentEntry["isimpaired"] = (info.flags & StreamFlags::FLAG_VISUAL_IMPAIRED) != 0;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -1094,8 +1094,11 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
     }
   }
 
-  if(!valid)
+  if (!valid)
+  {
     CloseStream(m_CurrentSubtitle, false);
+    m_processInfo->ResetSubtitleCodecInfo();
+  }
 
   // only set subtitle visibility if state not stored by dvd navigator, because navigator will restore it (if visible)
   if (!std::dynamic_pointer_cast<CDVDInputStreamNavigator>(m_pInputStream) ||

--- a/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerSubtitle.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -141,6 +141,7 @@ bool CVideoPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, std::string &filena
 {
   std::unique_lock lock(m_section);
 
+  m_processInfo.ResetSubtitleCodecInfo();
   CloseStream(false);
   m_streaminfo = hints;
 
@@ -174,7 +175,9 @@ bool CVideoPlayerSubtitle::OpenStream(CDVDStreamInfo &hints, std::string &filena
   m_pOverlayCodec = CDVDFactoryCodec::CreateOverlayCodec(hints);
   if (m_pOverlayCodec)
   {
-    CLog::Log(LOGDEBUG, "Created subtitles overlay codec: {}", m_pOverlayCodec->GetName());
+    const std::string& name = m_pOverlayCodec->GetName();
+    CLog::Log(LOGDEBUG, "Created subtitles overlay codec: {}", name);
+    m_processInfo.SetSubtitleDecoderName(name);
     return true;
   }
 

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -290,7 +290,7 @@ constexpr uint32_t VIDEOPLAYER_AUDIO_CODEC           = 285;
 constexpr uint32_t VIDEOPLAYER_AUDIO_CHANNELS        = 286;
 constexpr uint32_t VIDEOPLAYER_VIDEO_ASPECT          = 287;
 constexpr uint32_t VIDEOPLAYER_SUBTITLES_LANG        = 288;
-// unused id 289
+constexpr uint32_t VIDEOPLAYER_SUBTITLE_CODEC        = 289;
 constexpr uint32_t VIDEOPLAYER_AUDIO_LANG            = 290;
 constexpr uint32_t VIDEOPLAYER_STEREOSCOPIC_MODE     = 291;
 constexpr uint32_t VIDEOPLAYER_CAST                  = 292;

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -792,6 +792,7 @@ constexpr uint32_t PLAYER_PROCESS_AUDIOCHANNELS      = PLAYER_PROCESS_START + 9;
 constexpr uint32_t PLAYER_PROCESS_AUDIOSAMPLERATE    = PLAYER_PROCESS_START + 10;
 constexpr uint32_t PLAYER_PROCESS_AUDIOBITSPERSAMPLE = PLAYER_PROCESS_START + 11;
 constexpr uint32_t PLAYER_PROCESS_VIDEOSCANTYPE      = PLAYER_PROCESS_START + 12;
+constexpr uint32_t PLAYER_PROCESS_SUBTITLEDECODER    = PLAYER_PROCESS_START + 13;
 
 constexpr uint32_t ADDON_INFOS_START                 = 1600;
 constexpr uint32_t ADDON_SETTING_STRING              = ADDON_INFOS_START;

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2018 Team Kodi
+ *  Copyright (C) 2012-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -345,6 +345,9 @@ bool CPlayerGUIInfo::GetLabel(std::string& value,
       return true;
     case PLAYER_PROCESS_AUDIOBITSPERSAMPLE:
       value = StringUtils::FormatNumber(CServiceBroker::GetDataCacheCore().GetAudioBitsPerSample());
+      return true;
+    case PLAYER_PROCESS_SUBTITLEDECODER:
+      value = CServiceBroker::GetDataCacheCore().GetSubtitleDecoderName();
       return true;
 
     ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2018 Team Kodi
+ *  Copyright (C) 2012-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -635,7 +635,9 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
     case VIDEOPLAYER_SUBTITLES_LANG:
       value = m_subtitleInfo.language;
       return true;
-      break;
+    case VIDEOPLAYER_SUBTITLE_CODEC:
+      value = m_subtitleInfo.codecName;
+      return true;
     case VIDEOPLAYER_COVER:
       if (m_appPlayer->IsPlayingVideo())
       {

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -93,9 +93,15 @@ bool CPlayerController::OnAction(const CAction &action)
             sub = lang;
           else
             sub = StringUtils::Format("{} - {}", lang, info.name);
+
+          if (!info.codecDesc.empty())
+            sub.append(StringUtils::Format(" ({})", info.codecDesc));
+          else if (!info.codecName.empty())
+            sub.append(StringUtils::Format(" ({})", info.codecName));
         }
         else
           sub = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1223);
+
         CGUIDialogKaiToast::QueueNotification(
             CGUIDialogKaiToast::Info,
             CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(287), sub, DisplTime,
@@ -150,9 +156,15 @@ bool CPlayerController::OnAction(const CAction &action)
             sub = lang;
           else
             sub = StringUtils::Format("{} - {}", lang, info.name);
+
+          if (!info.codecDesc.empty())
+            sub.append(StringUtils::Format(" ({})", info.codecDesc));
+          else if (!info.codecName.empty())
+            sub.append(StringUtils::Format(" ({})", info.codecName));
         }
         else
           sub = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1223);
+
         CGUIDialogKaiToast::QueueNotification(
             CGUIDialogKaiToast::Info,
             CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(287), sub, DisplTime,

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -358,6 +358,23 @@ void CGUIDialogSubtitleSettings::AddSubtitleStreams(const std::shared_ptr<CSetti
   m_subtitleStreamSetting = AddList(group, settingId, 462, SettingLevel::Basic, m_subtitleStream, SubtitleStreamsOptionFiller, 462);
 }
 
+namespace
+{
+std::string FormatCodec(const SubtitleStreamInfo& info)
+{
+  std::string codec = " (";
+  if (!info.codecDesc.empty())
+    codec += info.codecDesc;
+  else if (!info.codecName.empty())
+    codec += info.codecName;
+  else
+    codec += CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // unknown
+  codec += ")";
+
+  return codec;
+}
+} // namespace
+
 void CGUIDialogSubtitleSettings::SubtitleStreamsOptionFiller(
     const SettingConstPtr& setting, std::vector<IntegerSettingOption>& list, int& current)
 {
@@ -384,6 +401,7 @@ void CGUIDialogSubtitleSettings::SubtitleStreamsOptionFiller(
     else
       strItem = StringUtils::Format("{} - {}", strLanguage, info.name);
 
+    strItem += FormatCodec(info);
     strItem += FormatFlags(info.flags);
     strItem += StringUtils::Format(" ({}/{})", i + 1, subtitleStreamCount);
 

--- a/xbmc/video/guilib/VideoStreamSelectHelper.cpp
+++ b/xbmc/video/guilib/VideoStreamSelectHelper.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2024 Team Kodi
+ *  Copyright (C) 2024-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -482,6 +482,7 @@ void KODI::VIDEO::GUILIB::OpenDialogSelectSubtitleStream()
     fileItem->SetProperty("stream.id", info.streamId);
     fileItem->SetProperty("stream.description", info.name);
     fileItem->SetProperty("stream.codec", info.codecName);
+    fileItem->SetProperty("stream.codecdesc", info.codecDesc);
 
     fileItem->SetProperty("stream.isdefault", info.isDefault);
     fileItem->SetProperty("stream.isforced", info.isForced);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Show the codec of the current subtitles of the playing video.
Changes split in multiple stages and commits. The changes are basic plumbing for the most part and a few Estuary changes to show the information.

New info labels:
`Videoplayer.SubtitleCodec`: ffmpeg codec name (ex. dvd_subtitle)

`Player.Process(subtitledecoder)`: decoder name. For ffmpeg decoders, concatenation of 'ff-' with the name of the decoder

Estuary changes: The player process tabs could probably be reorganized with 3 columns instead of 2 but that's beyond the PR scope, I'll leave it to a skinner to fine tune the appearance.
I added the subtitles language to player process info at the same time since the info label existed.

I mimicked the process info update trigger points of video and audio, but subtitles are not handled the same way (not an independent thread, subtitles can be decoded even when disabled, forced subs make consistent information difficult to provide). The solution has reasonable results, but I'm not 100% sure.

External subs not handled (yet), they look like a significant amount of work better suited for a follow-up PR.
Inputstream: works, but tricky - subs in ttml format for example are transcoded to subrip because ffmpeg/Kodi doesn't have a proper ttml codec. They appear as subrip in the GUI as well.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Visibility of the subtitle codec of the playing video in the info screen, stream selection mechanisms and player process info.

partial replacement of #25023

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
videos with srt, ass, vobsub, pgs, no subtitles
subtitles enabled and disabled
video with forced subtitles
inputstream

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

subtitle codec and language of the playing video visible in the GUI and the stream selections.

## Screenshots (if appropriate):

Fullscreen Info:
<img width="1674" height="684" alt="image" src="https://github.com/user-attachments/assets/68ee671a-4b33-4a2d-9279-34775e5f3690" />

Stream selection:
<img width="912" height="311" alt="image" src="https://github.com/user-attachments/assets/e5dc6be8-6cac-4fca-82a4-eb5793d75dca" />

Subtitles selection:
<img width="1093" height="319" alt="image" src="https://github.com/user-attachments/assets/92b77fad-d546-4c9f-aa40-e8653aa398ca" />

OSD subtitles settings:
<img width="1387" height="355" alt="image" src="https://github.com/user-attachments/assets/cc860d01-a045-48cf-8f45-298fa1c37b09" />

Player info / player:
<img width="1672" height="406" alt="image" src="https://github.com/user-attachments/assets/a7dae408-6357-491e-a2bd-71d89a954500" />

Player info / media:
<img width="1674" height="378" alt="image" src="https://github.com/user-attachments/assets/847df5ce-e604-4254-aa7c-8f2ab073a72f" />

Kai toast notification on subtitle toggle / next sub:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/52c88adb-b212-49a2-a106-829abc694e01" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
