### PR TITLE
[MusicInfoScanner] Prevent possible infinite recursion.

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -2363,21 +2363,31 @@ void CMusicInfoScanner::Run()
 }
 
 // Recurse through all folders we scan and count files
-int CMusicInfoScanner::CountFilesRecursively(const std::string& strPath)
+int CMusicInfoScanner::CountFilesRecursively(const std::string& strPath, int depth)
 {
+  static constexpr int MAX_COUNT_DEPTH{256};
+  if (depth >= MAX_COUNT_DEPTH)
+  {
+    CLog::LogF(LOGWARNING, "Maximum directory depth ({}) reached for: {}", MAX_COUNT_DEPTH,
+               CURL::GetRedacted(strPath));
+    return 0;
+  }
+
   // load subfolder
   CFileItemList items;
-  CDirectory::GetDirectory(strPath, items, CServiceBroker::GetFileExtensionProvider().GetMusicExtensions(), DIR_FLAG_NO_FILE_DIRS);
+  CDirectory::GetDirectory(strPath, items,
+                           CServiceBroker::GetFileExtensionProvider().GetMusicExtensions(),
+                           DIR_FLAG_NO_FILE_DIRS);
 
   if (m_bStop)
     return 0;
 
   // true for recursive counting
-  int count = CountFiles(items, true);
+  int count = CountFiles(items, true, depth);
   return count;
 }
 
-int CMusicInfoScanner::CountFiles(const CFileItemList& items, bool recursive)
+int CMusicInfoScanner::CountFiles(const CFileItemList& items, bool recursive, int depth)
 {
   int count = 0;
   for (int i = 0; i < items.Size(); ++i)
@@ -2385,7 +2395,7 @@ int CMusicInfoScanner::CountFiles(const CFileItemList& items, bool recursive)
     const CFileItemPtr pItem = items[i];
 
     if (recursive && pItem->IsFolder())
-      count += CountFilesRecursively(pItem->GetPath());
+      count += CountFilesRecursively(pItem->GetPath(), depth + 1);
     else if (MUSIC::IsAudio(*pItem) && !PLAYLIST::IsPlayList(*pItem) && !pItem->IsNFO())
       ++count;
   }

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -262,8 +262,8 @@ protected:
   int GetPathHash(const CFileItemList &items, std::string &hash);
 
   void Run() override;
-  int CountFiles(const CFileItemList& items, bool recursive);
-  int CountFilesRecursively(const std::string& strPath);
+  int CountFiles(const CFileItemList& items, bool recursive, int depth = 0);
+  int CountFilesRecursively(const std::string& strPath, int depth = 0);
 
   /*! \brief Resolve a MusicBrainzID to a URL
    If we have a MusicBrainz ID for an artist or album,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add a depth check to `CMusicInfoScanner::CountFiles()`

EDIT: The definitive fix is #28187 for the UPNP issue but I still think this has value in it's own right.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #28137 

This may not be a complete fix - I don't know much about UPNP and whether once this error is thrown it should stop:
```
2026-04-06 10:22:29.474 T:16572   debug <CUPnPDirectory::GetResource>: resource protocol info 'http-get:*:image/png:DLNA.ORG_PN=PNG_LRG;DLNA.ORG_FLAGS=00900000000000000000000000000000'
2026-04-06 10:22:29.475 T:16572   debug <general>: File::Stat - redirecting implementation for upnp://7313092d-7a3c-4b67-be6f-f0472ff57c0d/50/
2026-04-06 10:22:29.475 T:16572   error <general>: XFILE::CFile::Stat - Error statting upnp://7313092d-7a3c-4b67-be6f-f0472ff57c0d/50/
```

But in principle, all recursive functions should probably have a depth check.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally. New log confirms fix.
https://paste.kodi.tv/ihuxufubik.kodi
```
2026-04-06 10:32:12.032 T:32568 warning <general>: MUSIC_INFO::CMusicInfoScanner::CountFilesRecursively: Maximum directory depth (64) reached for: upnp://7313092d-7a3c-4b67-be6f-f0472ff57c0d/50/
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Prevent crash.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
