### PR TITLE
Change DTS codec name from dca to dts

### DIFF
--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -814,7 +814,6 @@
 		<value condition="String.IsEqual(ListItem.AudioCodec,ape) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,ape)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Codec,ape)]">APE</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,avc) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,avc)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Codec,avc)]">AVC</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,cdda) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,cdda)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Codec,cdda)]">CDDA</value>
-		<value condition="String.IsEqual(ListItem.AudioCodec,dca) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dca)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Codec,dca)]">DTS</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,dolbydigital) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dolbydigital)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Codec,dolbydigital)]">Dolby Digital</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,dts) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dts)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Codec,dts)]">DTS</value>
 		<value condition="String.IsEqual(ListItem.AudioCodec,dtshd_hra) | [Window.IsActive(fullscreenvideo) + String.IsEqual(VideoPlayer.AudioCodec,dtshd_hra)] | [Window.IsActive(visualisation) + String.IsEqual(MusicPlayer.Codec,dtshd_hra)]">DTS-HD HRA</value>
@@ -918,7 +917,6 @@
 		<value condition="Window.IsVisible(dialogselectaudio) + String.IsEqual(ListItem.Property(stream.codec),dtshd_ma_x_imax)">DTS-HD MA / DTS:X IMAX</value>
 		<value condition="Window.IsVisible(dialogselectaudio) + String.IsEqual(ListItem.Property(stream.codec),dtshd_ma_x)">DTS-HD MA / DTS:X</value>
 		<value condition="Window.IsVisible(dialogselectaudio) + String.IsEqual(ListItem.Property(stream.codec),dtshd_ma)">DTS-HD MA</value>
-		<value condition="Window.IsVisible(dialogselectaudio) + String.IsEqual(ListItem.Property(stream.codec),dca)">DTS</value>
 		<value condition="Window.IsVisible(dialogselectaudio) + String.IsEqual(ListItem.Property(stream.codec),dts)">DTS</value>
 		<value condition="Window.IsVisible(dialogselectaudio) + String.IsEqual(ListItem.Property(stream.codec),eac3_ddp_atmos)">Dolby Digital+ Atmos</value>
 		<value condition="Window.IsVisible(dialogselectaudio) + String.IsEqual(ListItem.Property(stream.codec),eac3)">Dolby Digital+</value>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6384,7 +6384,7 @@ constexpr std::array<InfoMap, 3> container_str = {{
 ///       - <b>aac_ltp</b>
 ///       - <b>ac3</b>
 ///       - <b>cook</b>
-///       - <b>dca</b>
+///       - <b>dts</b>
 ///       - <b>dtshd_hra</b>
 ///       - <b>dtshd_ma</b>
 ///       - <b>dtshd_ma_x</b>

--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -44,7 +44,7 @@ int StreamUtils::GetCodecPriority(const std::string &codec)
     return 4;
   if (codec == "eac3") // Dolby Digital Plus
     return 3;
-  if (codec == "dca") // DTS
+  if (codec == "dts") // DTS
     return 2;
   if (codec == "ac3") // Dolby Digital
     return 1;
@@ -66,7 +66,7 @@ std::string StreamUtils::GetCodecName(int codecId, int profile)
     else if (profile == AV_PROFILE_DTS_HD_HRA)
       codecName = "dtshd_hra";
     else
-      codecName = "dca";
+      codecName = "dts";
 
     return codecName;
   }

--- a/xbmc/utils/test/TestStreamUtils.cpp
+++ b/xbmc/utils/test/TestStreamUtils.cpp
@@ -14,7 +14,7 @@ TEST(TestStreamUtils, General)
 {
   EXPECT_EQ(0, StreamUtils::GetCodecPriority(""));
   EXPECT_EQ(1, StreamUtils::GetCodecPriority("ac3"));
-  EXPECT_EQ(2, StreamUtils::GetCodecPriority("dca"));
+  EXPECT_EQ(2, StreamUtils::GetCodecPriority("dts"));
   EXPECT_EQ(3, StreamUtils::GetCodecPriority("eac3"));
   EXPECT_EQ(4, StreamUtils::GetCodecPriority("eac3_ddp_atmos"));
   EXPECT_EQ(5, StreamUtils::GetCodecPriority("dtshd_hra"));

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -1149,10 +1149,17 @@ void CVideoDatabase::UpdateTables(int iVersion)
   }
 
   if (iVersion < 144)
+  {
     m_pDS->exec("ALTER TABLE streamdetails ADD strHdrDetail text");
+  }
+
+  if (iVersion < 145)
+  {
+    m_pDS->exec("UPDATE streamdetails set strAudioCodec = 'dts' where strAudioCodec = 'dca'");
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 144;
+  return 145;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The codec name of DTS tracks was accidentally changed from dts to dca in 235d3d6317ab66f5017368de67d63092f10c4fd8.
dca is the name of the decoder (and still is).

Every other codec uses the codec name (with the exception of the few Kodi-specific names made up for audio object technologies - see StreamUtils::GetCodecName), not the decoder name.

No change needed in InputStream, INPUTSTREAM_INFO::m_codecName is expected to be a ffmpeg decoder name (passed to avcodec_find_decoder_by_name())

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Consistency. And dca is an unexpected name for dts audio.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

library browsing, full screen info, library scan, existing movies in the library

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

decoder name is still dca (player info):
<img width="1671" height="428" alt="image" src="https://github.com/user-attachments/assets/44a419d0-6227-4353-88fd-fec67dd0b9cd" />

codec name recognized as dts in player info:
<img width="1667" height="419" alt="image" src="https://github.com/user-attachments/assets/c9f182db-813a-4e73-ad90-6d20d13e8c19" />

codec name displayed as expected in fullscreen info:
<img width="959" height="166" alt="image" src="https://github.com/user-attachments/assets/5c9769ad-0807-4d74-ae1c-43fd621a57d5" />


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
