### PR TITLE
ffmpeg: fix AV1 playback with keyframe-filtering=2

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -806,6 +806,14 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecFFmpeg::GetPicture(VideoPicture* pVideoPi
     m_started = true;
     m_iLastKeyframe = m_pCodecContext->has_b_frames + 2;
   }
+  // AV1 with keyframe-filtering=2 encodes hidden keyframes (show_frame=0) that
+  // are decoded but never output. The first visible frame is INTER, not KEY.
+  // The decoder only outputs frames with valid references, so trust it.
+  else if (m_pCodecContext->codec_id == AV_CODEC_ID_AV1 && !m_started)
+  {
+    m_started = true;
+    m_iLastKeyframe = m_pCodecContext->has_b_frames + 2;
+  }
   if (m_pDecodedFrame->flags & AV_FRAME_FLAG_INTERLACED)
     m_interlaced = true;
   else


### PR DESCRIPTION
AV1 encoders using libaom's keyframe-filtering=2 produce hidden reference keyframes (show_frame=0) that are decoded but never output by the decoder. The first visible frame is an INTER frame, not a KEY frame.

The m_started gate in GetPicture() waits for AV_FRAME_FLAG_KEY, which is never set on any output frame in this encoding mode, causing indefinite frame dropping (audio plays, no video). Fixes #23320.

For AV1, trust the decoder's output -- if it emits a frame, the reference chain is valid. Set m_started on the first decoded AV1 frame regardless of frame type.

## Description
Kodi cannot play AV1 with keyframe-filtering=2 (aggressive)

## Motivation and context
Fix #23320 

## How has this been tested?
CFL and ADL-N Intel using VAAPI. Have not tested with dav1d. Fix confirmed by @smp79

## What is the effect on users?
Can now play an additional subtype of AV1

## Screenshots (if appropriate):
n/a

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
