### PR TITLE
[Video][Database] Fix issues with .rar archives (1/2) - Prospective fix.

### DIFF
--- a/xbmc/InfoScanner.h
+++ b/xbmc/InfoScanner.h
@@ -10,6 +10,7 @@
 
 #include <set>
 #include <string>
+#include <utility>
 
 class CGUIDialogProgressBarHandle;
 
@@ -47,8 +48,6 @@ public:
   //! \brief Empty destructor.
   virtual ~CInfoScanner() = default;
 
-  virtual bool DoScan(const std::string& strDirectory) = 0;
-
   /*! \brief Check if the folder is excluded from scanning process
    \param strDirectory Directory to scan
    \return true if there is a .nomedia file
@@ -64,6 +63,20 @@ public:
 protected:
   //! \brief Protected constructor to only allow subclass instances.
   CInfoScanner() = default;
+
+  enum class ScanComplete : bool
+  {
+    Stopped,
+    Completed
+  };
+
+  enum class ContentFound : bool
+  {
+    None,
+    NewContentFound
+  };
+
+  virtual std::pair<ScanComplete, ContentFound> DoScan(const std::string& strDirectory) = 0;
 
   std::set<std::string, std::less<>> m_pathsToScan; //!< Set of paths to scan
   bool m_showDialog = false; //!< Whether or not to show progress bar dialog

--- a/xbmc/addons/VFSEntry.cpp
+++ b/xbmc/addons/VFSEntry.cpp
@@ -16,6 +16,7 @@
 #include "addons/interfaces/Filesystem.h"
 #include "network/ZeroconfBrowser.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/log.h"
 
 #include <mutex>
@@ -499,7 +500,7 @@ void VFSDirEntriesToCFileItemList(int num_entries, const VFSDirEntry* entries, C
   {
     auto item = std::make_shared<CFileItem>();
     item->SetLabel(entries[i].label);
-    item->SetPath(entries[i].path);
+    item->SetPath(URIUtils::SanitiseUrlEncoding(entries[i].path));
     item->SetSize(entries[i].size);
     item->SetDateTime(entries[i].date_time);
     item->SetFolder(entries[i].folder);
@@ -566,7 +567,7 @@ bool CVFSEntry::ContainsFiles(const CURL& url, CFileItemList& items) const
   VFSDirEntriesToCFileItemList(num_entries, entries, items);
   m_ifc.vfs->toAddon->free_directory(m_ifc.vfs, entries, num_entries);
   if (strlen(rootpath))
-    items.SetPath(rootpath);
+    items.SetPath(URIUtils::SanitiseUrlEncoding(rootpath));
 
   return true;
 }

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -150,8 +150,8 @@ void CMusicInfoScanner::Process()
 
         // Clear list of albums added by this scan
         m_albumsAdded.clear();
-        bool scancomplete = DoScan(it);
-        if (scancomplete)
+        if ([[maybe_unused]] const auto [scanComplete, foundContent] = DoScan(it);
+            scanComplete == ScanComplete::Completed)
         {
           if (!m_albumsAdded.empty())
           {
@@ -479,7 +479,8 @@ static std::string Prettify(const std::string& strDirectory)
   return CURL::Decode(url.GetWithoutUserDetails());
 }
 
-bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
+std::pair<CInfoScanner::ScanComplete, CInfoScanner::ContentFound> CMusicInfoScanner::DoScan(
+    const std::string& strDirectory)
 {
   if (m_handle)
   {
@@ -490,7 +491,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
 
   std::set<std::string>::const_iterator it = m_seenPaths.find(strDirectory);
   if (it != m_seenPaths.end())
-    return true;
+    return std::make_pair(ScanComplete::Completed, ContentFound::None);
 
   m_seenPaths.insert(strDirectory);
 
@@ -498,10 +499,10 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
   const std::vector<std::string> &regexps = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_audioExcludeFromScanRegExps;
 
   if (CUtil::ExcludeFileOrFolder(strDirectory, regexps, &m_regexpCache))
-    return true;
+    return std::make_pair(ScanComplete::Completed, ContentFound::None);
 
   if (HasNoMedia(strDirectory))
-    return true;
+    return std::make_pair(ScanComplete::Completed, ContentFound::None);
 
   // load subfolder
   CFileItemList items;
@@ -515,6 +516,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
   GetPathHash(items, hash);
 
   // check whether we need to rescan or not
+  ContentFound foundContent{ContentFound::None};
   std::string dbHash;
   if ((m_flags & SCAN_RESCAN) || !m_musicDatabase.GetPathHash(strDirectory, dbHash) || !StringUtils::EqualsNoCase(dbHash, hash))
   { // path has changed - rescan
@@ -538,6 +540,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
     {
       if (m_handle)
         OnDirectoryScanned(strDirectory);
+      foundContent = ContentFound::NewContentFound;
     }
 
     // save information about this folder
@@ -568,14 +571,14 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
     // if we have a directory item (non-playlist) we then recurse into that folder
     if (pItem->IsFolder() && !pItem->IsParentFolder() && !PLAYLIST::IsPlayList(*pItem))
     {
-      std::string strPath=pItem->GetPath();
-      if (!DoScan(strPath))
-      {
+      const auto [scanComplete, foundContentOnRecursion] = DoScan(pItem->GetPath());
+      if (scanComplete == ScanComplete::Stopped)
         m_bStop = true;
-      }
+      if (foundContentOnRecursion == ContentFound::NewContentFound)
+        foundContent = ContentFound::NewContentFound;
     }
   }
-  return !m_bStop;
+  return std::make_pair(m_bStop ? ScanComplete::Stopped : ScanComplete::Completed, foundContent);
 }
 
 CInfoScanner::InfoRet CMusicInfoScanner::ScanTags(const CFileItemList& items,

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -92,8 +92,7 @@ public:
 
 protected:
   virtual void Process();
-  bool DoScan(const std::string& strDirectory) override;
-
+  std::pair<ScanComplete, ContentFound> DoScan(const std::string& strDirectory) override;
 
   /*! \brief Find art for albums
    Based on the albums in the folder, finds whether we have unique album art

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -28,12 +28,12 @@
 #include "pvr/channels/PVRChannelsPath.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/FileExtensionProvider.h"
-#if defined(TARGET_WINDOWS_STORE)
 #include "utils/log.h"
-#endif
+
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cctype>
 #include <charconv>
 #include <cstdint>
 #include <optional>
@@ -1928,4 +1928,68 @@ CURL URIUtils::AddCredentials(CURL url)
   if (CPasswordManager::GetInstance().IsURLSupported(url) && url.GetUserName().empty())
     CPasswordManager::GetInstance().AuthenticateURL(url);
   return url;
+}
+
+std::string URIUtils::SanitiseUrlEncoding(std::string_view path)
+{
+  std::string out;
+  out.reserve(path.size());
+
+  // Firstly look at encoded character capitalization.
+  // Some providers (eg. vfs rar) return paths with %2F instead of %2f,
+  // which causes problems when comparing paths.
+  // This only applies to the hostname element of the url
+  auto protocolEnd{path.find("://")};
+  if (protocolEnd == std::string::npos)
+    return std::string(path);
+  protocolEnd += 3;
+
+  auto hostEnd{path.find('/', protocolEnd)};
+  if (hostEnd == std::string::npos)
+    hostEnd = path.size();
+
+  constexpr auto is_hex = [](char c) noexcept
+  { return ('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F'); };
+
+  if (protocolEnd >= path.size() || hostEnd > path.size())
+    return std::string(path);
+
+  for (auto it = path.begin() + static_cast<long long>(protocolEnd);
+       it != path.begin() + static_cast<long long>(hostEnd); ++it)
+  {
+    if (*it == '%' && std::ranges::distance(it, path.end()) > 2)
+    {
+      if (is_hex(it[1]) && is_hex(it[2]))
+      {
+        out += '%';
+        out += StringUtils::ToLowerAscii(it[1]);
+        out += StringUtils::ToLowerAscii(it[2]);
+        std::ranges::advance(it, 2);
+      }
+      else
+      {
+        CLog::LogF(LOGDEBUG, "Invalid encoding in path {}", CURL::GetRedacted(std::string(path)));
+        out += *it;
+      }
+    }
+    else
+      out += *it;
+  }
+
+  // In case addon (eg. vfs rar) returns malformed DOS paths (eg. c:/ and not c:\)
+  // m_basePath is used to populate the VIDEODB_ID_BASEPATH column which in turn is used
+  // by GetItemsByPath() to find items when browsing Video -> Files
+  // Pattern for DOS drive letter path: "D:/" encoded as "D%3a%2f"
+  constexpr std::string_view DOS_DRIVE_PATTERN = "%3a%2f";
+  if (out.size() >= 7 && std::isalpha(static_cast<unsigned char>(out[0])) &&
+      out.compare(1, DOS_DRIVE_PATTERN.length(), DOS_DRIVE_PATTERN) == 0)
+    StringUtils::Replace(out, "%2f", "%5c");
+
+  std::string result;
+  result.reserve(protocolEnd + out.size() + (path.size() - hostEnd));
+  result.append(path.substr(0, protocolEnd));
+  result.append(out);
+  result.append(path.substr(hostEnd));
+
+  return result;
 }

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 class CURL;
@@ -384,6 +385,19 @@ public:
   static bool UpdateUrlEncoding(std::string &strFilename);
 
   static CURL AddCredentials(CURL url);
+
+  /*!
+   \brief Updates the URL encoding (if needed) of the hostname element of the given url path 
+   and returns the updated path.
+
+   Ensures that the hex encoded characters are lower case
+   Ensures that DOS paths use '\' as path separator and not '/'
+   as this can cause unintentional path mismatches
+
+   \param path Path to update
+   \return Updated path
+   */
+  static std::string SanitiseUrlEncoding(std::string_view path);
 
 private:
   static std::string resolvePath(const std::string &path);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -1375,6 +1375,67 @@ TEST_F(TestURIUtils, UpdateUrlEncoding)
   EXPECT_STRCASEEQ(newUrl.c_str(), oldUrl.c_str());
 }
 
+struct SanitiseUrlEncodingTestData
+{
+  std::string_view dirty;
+  std::string_view clean;
+};
+
+constexpr SanitiseUrlEncodingTestData SanitiseUrlEncodingData[] = {
+    // lower case encoding and '\' in encoded path
+    {"rar://D%3A%2FMovies%2Fmovie.rar/movie.mkv", "rar://D%3a%5cMovies%5cmovie.rar/movie.mkv"},
+    // lower case encoding and '\' in encoded path
+    {"archive://D%3A%2FMovies%2Fmovie.rar/movie.mkv",
+     "archive://D%3a%5cMovies%5cmovie.rar/movie.mkv"},
+    // lower case encoding
+    {"rar://D%3A%5CMovies%5Cmovie.rar/movie.mkv", "rar://D%3a%5cMovies%5cmovie.rar/movie.mkv"},
+    // '\' in encoded path
+    {"rar://D%3a%2fMovies%2fmovie.rar/movie.mkv", "rar://D%3a%5cMovies%5cmovie.rar/movie.mkv"},
+    // lower case encoding
+    {"rar://%2FMovies%2Fmovie.rar/movie.mkv", "rar://%2fMovies%2fmovie.rar/movie.mkv"},
+    // unchanged
+    {"bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/root/episode/3/4",
+     "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/root/episode/3/4"},
+    // only sanitise hostname
+    {"rar://D%3A%2FMovies%2Fmovie.rar/movie%DD/movie.mkv",
+     "rar://D%3a%5cMovies%5cmovie.rar/movie%DD/movie.mkv"},
+    // Malformed encoding: lone % at end of hostname - passed through unchanged
+    {"rar://D%3a%5cMovies%5cmovie%.rar/movie.mkv", "rar://D%3a%5cMovies%5cmovie%.rar/movie.mkv"},
+    // Malformed encoding: % followed by single hex digit then end of hostname
+    {"rar://D%3a%5cMovies%5cmovie%2.rar/movie.mkv", "rar://D%3a%5cMovies%5cmovie%2.rar/movie.mkv"},
+    // Malformed encoding: % followed by one valid then one invalid hex digit
+    {"rar://D%3a%5cMovies%5cmovie%2Z.rar/movie.mkv",
+     "rar://D%3a%5cMovies%5cmovie%2Z.rar/movie.mkv"},
+    // Malformed encoding: % followed by two invalid hex digits
+    {"rar://D%3a%5cMovies%5cmovie%ZZ.rar/movie.mkv",
+     "rar://D%3a%5cMovies%5cmovie%ZZ.rar/movie.mkv"},
+    // Malformed encoding followed by valid encoding: invalid sequence unchanged, valid sequences lowercased
+    {"rar://D%3A%5CMovies%5C%2Zmovie.rar/movie.mkv",
+     "rar://D%3a%5cMovies%5c%2Zmovie.rar/movie.mkv"},
+    // Malformed protocol with no hostname or path at all - empty hostname
+    {"rar://", "rar://"},
+    // Malformed protocol marker at very end of string - not a valid protocol, returned as-is
+    {"rar:/", "rar:/"},
+    // Malformed with no :// at all - no protocol, returned as-is
+    {"D%3A%5CMovies%5Cmovie.rar", "D%3A%5CMovies%5Cmovie.rar"},
+    // Malformed hostname only, no trailing slash or path
+    {"rar://D%3A%5Cmovie.rar", "rar://D%3a%5cmovie.rar"},
+};
+
+class TestSanitiseUrlEncoding : public testing::Test,
+                                public testing::WithParamInterface<SanitiseUrlEncodingTestData>
+{
+};
+
+TEST_P(TestSanitiseUrlEncoding, SanitiseUrlEncoding)
+{
+  EXPECT_EQ(GetParam().clean, URIUtils::SanitiseUrlEncoding(std::string{GetParam().dirty}));
+}
+
+INSTANTIATE_TEST_SUITE_P(SanitiseUrlEncoding,
+                         TestSanitiseUrlEncoding,
+                         ValuesIn(SanitiseUrlEncodingData));
+
 struct URLEncodings
 {
   std::string_view input;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8612,21 +8612,56 @@ std::string CVideoDatabase::GetContentForPath(const std::string& strPath)
   {
     if (scraper->Content() == ContentType::TVSHOWS)
     {
-      // check for episodes or seasons.  Assumptions are:
-      // 1. if episodes are in the path then we're in episodes.
-      // 2. if no episodes are found, and content was set directly on this path, then we're in shows.
-      // 3. if no episodes are found, and content was not set directly on this path, we're in seasons (assumes tvshows/seasons/episodes)
-      std::string sql = "SELECT COUNT(*) FROM episode_view ";
+      // For TV shows scraped with 'Single TV show in folder OFF' - pointing to folder /TV Shows/
+      // For TV shows scraped with 'Single TV show in folder ON' - pointing to folder /Show (2002)/
+      //
+      // Contents of:                                                   Return
+      // ------------                                                   ------
+      // /TV Shows/                                                     tvshows (NB first case only)
+      // /TV Shows/Show (2002)/                                         seasons - if folder does NOT contain any episodes (eg. Season subfolders only)
+      // /TV Shows/Show (2002)/                                         episodes - if folder DOES contain episode(s)
+      // /TV Shows/Show (2002)/Season 1/                                episodes - if folder DOES contain episode(s)
+      // /TV Shows/Show (2002)/Season 1/                                seasons - if folder does NOT contain episode(s)
+      //                                                                @todo - this currently returns episodes if there is a single archive containing multiple episodes
+      //                                                                @todo - (although of no functional consequence)
+      // /TV Shows/Show (2002)/Season 1/episode.rar                     episodes - if the archive(s) contains an episode (the .rar is expanded by the vfs automatically)
+      // /TV Shows/Show (2002)/Season 1/episodes.rar                    seasons - if the archive does NOT contain any episodes (ie. they are in a subfolder of the archive)
+      // /TV Shows/Show (2002)/episodes.rar/Season 1                    episodes - if the archive contains episode(s) (expanded by the vfs)
+      // /TV Shows/Show (2002)/Seasons 1 and 2/episodes.rar/Season 1    episodes - if the archive contains episode(s) (expanded by the vfs)
 
-      if (foundDirectly)
-        sql += PrepareSQL("WHERE strPath = '%s'", strPath.c_str());
-      else
-        sql += PrepareSQL("WHERE strPath LIKE '%s%%'", strPath.c_str());
+      std::string sql = PrepareSQL("SELECT 1 FROM episode_view "
+                                   "WHERE strPath = '%s' "
+                                   "LIMIT 1",
+                                   strPath.c_str());
 
-      m_pDS->query( sql );
-      if (m_pDS->num_rows() && m_pDS->fv(0).get_asInt() > 0)
+      m_pDS->query(sql);
+      if (m_pDS->num_rows())
         return "episodes";
-      return foundDirectly ? "tvshows" : "seasons";
+
+      // If the episodes are in individual archives
+      // then strPath may point to the directory containing the archive
+      // rather than the archive itself (eg. rar://).
+      // So see if there are any matches using the parentpathid.
+      sql = PrepareSQL("SELECT DISTINCT e.strPath FROM episode_view e "
+                       "JOIN path p ON e.c%02d = p.idPath "
+                       "JOIN files f ON e.idFile = f.idFile "
+                       "WHERE p.strPath = '%s' ",
+                       VIDEODB_ID_EPISODE_PARENTPATHID, strPath.c_str());
+      m_pDS->query(sql);
+      if (m_pDS->num_rows())
+      {
+        while (!m_pDS->eof())
+        {
+          const CURL url(m_pDS->fv(0).get_asString());
+          if (url.GetFileName().empty() && URIUtils::IsArchive(url))
+            return "episodes"; // Episodes in root of archive
+          m_pDS->next();
+        }
+      }
+
+      // If the scraper was set directly on this path, it is a tvshows root
+      // unless the scraper is set for a single tv show in this folder
+      return foundDirectly && !settings.parent_name ? "tvshows" : "seasons";
     }
     return TranslateContent(scraper->Content());
   }
@@ -11523,6 +11558,14 @@ bool CVideoDatabase::GetItemsForPath(const std::string &content, const std::stri
       GetItemsForPath(content, p, items);
 
     return !items.IsEmpty();
+  }
+
+  if (URIUtils::IsArchive(CURL(path)))
+  {
+    std::string parent = URIUtils::GetParentPath(path);
+    if (!parent.empty() && parent != path)
+      return GetItemsForPath(content, parent, items);
+    return false;
   }
 
   int pathID = GetPathId(path);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -264,7 +264,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
                     CURL::GetRedacted(directory), m_bClean ? " and clean" : "");
           m_pathsToScan.erase(m_pathsToScan.begin());
         }
-        else if (!DoScan(directory))
+        else if ([[maybe_unused]] const auto [scanComplete, foundContent] = DoScan(directory);
+                 scanComplete == ScanComplete::Stopped)
           bCancelled = true;
       }
 
@@ -348,7 +349,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
     m_bStop = true;
   }
 
-  bool CVideoInfoScanner::DoScan(const std::string& strDirectory)
+  std::pair<CInfoScanner::ScanComplete, CInfoScanner::ContentFound> CVideoInfoScanner::DoScan(
+      const std::string& strDirectory)
   {
     if (m_handle)
     {
@@ -380,14 +382,14 @@ CVideoInfoScanner::~CVideoInfoScanner()
                                         : m_advancedSettings->m_moviesExcludeFromScanRegExps;
 
     if (CUtil::ExcludeFileOrFolder(strDirectory, regexps, &m_regexpCache))
-      return true;
+      return std::make_pair(ScanComplete::Completed, ContentFound::None);
 
     if (HasNoMedia(strDirectory))
-      return true;
+      return std::make_pair(ScanComplete::Completed, ContentFound::None);
 
     bool ignoreFolder = !m_scanAll && settings.noupdate;
     if (content == ContentType::NONE || ignoreFolder)
-      return true;
+      return std::make_pair(ScanComplete::Completed, ContentFound::None);
 
     if (URIUtils::IsPlugin(strDirectory) && !CPluginDirectory::IsMediaLibraryScanningAllowed(TranslateContent(content), strDirectory))
     {
@@ -395,7 +397,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
           LOGINFO,
           "VideoInfoScanner: Plugin '{}' does not support media library scanning for '{}' content",
           CURL::GetRedacted(strDirectory), content);
-      return true;
+      return std::make_pair(ScanComplete::Completed, ContentFound::None);
     }
 
     std::string hash, dbHash;
@@ -504,7 +506,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
       {
         if (!m_bStop && (content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS))
         {
-          m_database.SetPathHash(strDirectory, hash);
+          if (!URIUtils::IsArchive(CURL(strDirectory)))
+            m_database.SetPathHash(strDirectory, hash);
           if (m_bClean)
             m_pathsToClean.insert(m_database.GetPathId(strDirectory));
           CLog::Log(LOGDEBUG, "VideoInfoScanner: Finished adding information from dir {}",
@@ -521,13 +524,16 @@ CVideoInfoScanner::~CVideoInfoScanner()
     }
     else if (!StringUtils::EqualsNoCase(hash, dbHash) &&
              (content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS))
-    { // update the hash either way - we may have changed the hash to a fast version
-      m_database.SetPathHash(strDirectory, hash);
+    {
+      // update the hash either way - we may have changed the hash to a fast version
+      if (!URIUtils::IsArchive(CURL(strDirectory)))
+        m_database.SetPathHash(strDirectory, hash);
     }
 
     if (m_handle)
       OnDirectoryScanned(strDirectory);
 
+    bool foundSomethingInArchive = false;
     for (int i = 0; i < items.Size(); ++i)
     {
       CFileItemPtr pItem = items[i];
@@ -554,13 +560,39 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (content != ContentType::TVSHOWS && settings.recurse > 0 && pItem->IsFolder() &&
           !pItem->IsParentFolder() && !PLAYLIST::IsPlayList(*pItem))
       {
-        if (!DoScan(pItem->GetPath()))
+        if (const auto [scanComplete, foundContentOnRecursion] = DoScan(pItem->GetPath());
+            scanComplete == ScanComplete::Stopped)
         {
           m_bStop = true;
         }
+        // If this subdirectory is an archive and content was found inside it,
+        // store the hash for the physical parent directory instead of the archive (eg. rar://) path.
+        // This ensures change detection works correctly on the real filesystem path.
+        else if (!foundSomething && !m_bStop &&
+                 foundContentOnRecursion == ContentFound::NewContentFound &&
+                 (content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS) &&
+                 URIUtils::IsArchive(CURL(pItem->GetPath())))
+        {
+          foundSomethingInArchive = true;
+        }
       }
     }
-    return !m_bStop;
+
+    // If the direct scan found nothing but an archive subfolder scan did,
+    // store the hash for the physical directory so it is used for change detection
+    // rather than the archive (eg. rar://) virtual path.
+    if (!bSkip && !m_bStop && foundSomethingInArchive && !URIUtils::IsArchive(CURL(strDirectory)))
+    {
+      m_database.SetPathHash(strDirectory, hash);
+      CLog::LogF(LOGDEBUG,
+                 "Stored hash for physical dir '{}' after finding content in "
+                 "archive subfolder",
+                 CURL::GetRedacted(strDirectory));
+    }
+
+    return std::make_pair(m_bStop ? ScanComplete::Stopped : ScanComplete::Completed,
+                          foundSomething || foundSomethingInArchive ? ContentFound::NewContentFound
+                                                                    : ContentFound::None);
   }
 
   bool CVideoInfoScanner::UpdateSetInTag(CVideoInfoTag& tag)
@@ -2390,7 +2422,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
     for (int i = 0; i < items.Size(); ++i)
     {
-      if (items[i]->IsFolder() &&
+      // For the purposes of fast hashing archives are not considered folders
+      if (items[i]->IsFolder() && !URIUtils::IsArchive(CURL(items[i]->GetPath())) &&
           !CUtil::ExcludeFileOrFolder(items[i]->GetPath(), excludes, &m_regexpCache))
         return false;
     }

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -11,7 +11,6 @@
 #include "InfoScanner.h"
 #include "VideoDatabase.h"
 #include "addons/Scraper.h"
-#include "guilib/GUIListItem.h"
 #include "settings/VideoVersionsSettings.h"
 #include "utils/Artwork.h"
 #include "utils/RegExp.h"
@@ -156,7 +155,7 @@ namespace KODI::VIDEO
 
   protected:
     virtual void Process();
-    bool DoScan(const std::string& strDirectory) override;
+    std::pair<ScanComplete, ContentFound> DoScan(const std::string& strDirectory) override;
 
     InfoRet RetrieveInfoForTvShow(CFileItem* pItem,
                                   bool bDirNames,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This is part 1/2 - the prospective fix - ie. all rar archives added after applying this PR can be viewed correctly in Video -> Files.
Prat 2/2 #28383 applies database fixes to make the fixes retrospective - ie. all rar archives already added.

The archive path (eg. zip://) is passed to `CVideoDatabase::GetItemsForPath()` whereas the `VIDEODB_ID_EPISODE_PARENTPATHID` column (c19) is populated with the parent path (the physical path on disc) - so no matches are returned. First commit addresses that.

Further issues identified:
- The vfs rar addon returns DOS paths (with / instead of \) that means string matching of paths fails. Patch is added to ensure all vfs addons return Kodi compatible DOS/encoded paths.
- Sometimes the rar:// path was hashed rather than the containing physical path (occured if there were other files in the physical folder - eg. external subtitles)
~~- Added caching of the contents of archives to speed up subtitile file scans (which can be within the archive as well as outside)~~

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #28148 

As reported by @snyft in the forum - https://forum.kodi.tv/showthread.php?tid=384424&pid=3267730#pid3267730

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally
Confirmed fixed in thread - https://forum.kodi.tv/showthread.php?tid=384424&pid=3279139#pid3279139 by two users.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Before:
<img width="940" height="588" alt="image" src="https://github.com/user-attachments/assets/7169a3aa-12c2-48f4-a868-b3fc97ba8c96" />
<img width="940" height="588" alt="image" src="https://github.com/user-attachments/assets/e163f6b1-f51e-47b2-aef2-b8b45ba5f611" />

After:
<img width="940" height="588" alt="image" src="https://github.com/user-attachments/assets/22e47371-d1fa-4a83-a8cb-d80c7aab60b3" />

Fresh scan with this PR
<img width="2303" height="962" alt="image" src="https://github.com/user-attachments/assets/45b3256a-6030-4528-9ba7-e25531e36e5d" />

Note the unneeded duplicate path entries with foward slashes are never created.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
