### PR TITLE
Fix advanced filter & related MySQL crash + MySQL improvements

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -1821,7 +1821,7 @@ void MysqlDataset::make_query(StringList& _sql)
       Dataset::parse_sql(query);
       if ((static_cast<MysqlDatabase*>(db)->query_with_reconnect(query.c_str())) != MYSQL_OK)
       {
-        throw DbErrors(db->getErrorMsg());
+        throw DbErrors("%s", db->getErrorMsg());
       }
     } // end of for
 
@@ -1948,7 +1948,7 @@ int MysqlDataset::exec(const std::string& sql)
 
   if (res != MYSQL_OK)
   {
-    throw DbErrors(db->getErrorMsg());
+    throw DbErrors("%s", db->getErrorMsg());
   }
   else
   {
@@ -1989,7 +1989,7 @@ bool MysqlDataset::query(const std::string& query)
   if (static_cast<MysqlDatabase*>(db)->setErr(
           static_cast<MysqlDatabase*>(db)->query_with_reconnect(qry.c_str()), qry.c_str()) !=
       MYSQL_OK)
-    throw DbErrors(db->getErrorMsg());
+    throw DbErrors("%s", db->getErrorMsg());
 
   MYSQL* conn = handle();
   stmt = mysql_store_result(conn);

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -211,15 +211,27 @@ int MysqlDatabase::connect(bool create_new)
   if (host.empty() || db.empty())
     return DB_CONNECTION_NONE;
 
-  std::string resolvedHost;
-  if (!StringUtils::EqualsNoCase(host, "localhost") &&
-      CServiceBroker::GetDNSNameCache()->Lookup(host, resolvedHost))
+  if (!StringUtils::EqualsNoCase(host, "localhost"))
   {
-    if (host != resolvedHost)
-      CLog::LogF(LOGDEBUG, "Replacing configured host {} with resolved host {}", host,
-                 resolvedHost);
+    std::string resolvedHost;
 
-    host = resolvedHost;
+    if (!CServiceBroker::GetDNSNameCache()->Lookup(host, resolvedHost))
+      return DB_CONNECTION_NONE;
+
+    if (host != resolvedHost)
+    {
+      static std::string lastHost;
+      static std::string lastResolvedHost;
+
+      if (host != lastHost || resolvedHost != lastResolvedHost)
+      {
+        CLog::LogF(LOGDEBUG, "Replacing configured host {} with resolved host {}", host,
+                   resolvedHost);
+        lastHost = host;
+        lastResolvedHost = resolvedHost;
+      }
+      host = resolvedHost;
+    }
   }
 
   try

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -133,29 +133,23 @@ int MysqlDatabase::status()
 
 int MysqlDatabase::setErr(int err_code, const char* qry)
 {
-  switch (err_code)
+  if (err_code == MYSQL_OK)
   {
-    case MYSQL_OK:
-      error = "Successful result";
-      break;
-    case CR_COMMANDS_OUT_OF_SYNC:
-      error = "Commands were executed in an improper order";
-      break;
-    case CR_SERVER_GONE_ERROR:
-      error = "The MySQL server has gone away";
-      break;
-    case CR_SERVER_LOST:
-      error = "The connection to the server was lost during this query";
-      break;
-    case CR_UNKNOWN_ERROR:
-      error = "An unknown error occurred";
-      break;
-    case 1146: /* ER_NO_SUCH_TABLE */
-      error = "The table does not exist";
-      break;
-    default:
-      error = StringUtils::Format("Undefined MySQL error: Code ({})", err_code);
-      break;
+    error = "Success";
+  }
+  else
+  {
+    const unsigned int err = mysql_errno(conn);
+    if (err != static_cast<unsigned int>(err_code))
+      CLog::LogF(LOGERROR,
+                 "setErr was not called immediately after the error happened (function return code "
+                 "{}, mysql_errno {})",
+                 err_code, err);
+
+    const char* errMsg = mysql_error(conn);
+
+    error = StringUtils::Format("MySQL error {} ({}): {}", err_code, mysql_sqlstate(conn),
+                                *errMsg != 0 ? errMsg : "unknown error");
   }
   error = "[" + db + "] " + error;
   error += "\nQuery: ";

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -32,6 +32,8 @@
 #include "video/VideoDatabase.h"
 #include "video/VideoDbUrl.h"
 
+#include <algorithm>
+
 using namespace KODI;
 
 #define CONTROL_HEADING             2
@@ -660,13 +662,13 @@ int CGUIDialogMediaFilter::GetItems(const Filter &filter, std::vector<std::strin
 {
   CFileItemList selectItems;
 
-  // add all rules except for the field of the filter we want to retrieve items for
-  PLAYLIST::CSmartPlaylist tmpFilter;
-  for (const auto& rule : m_filter->m_ruleCombination.GetRules())
-  {
-    if (rule->m_field != static_cast<int>(filter.field))
-      tmpFilter.m_ruleCombination.AddRule(rule);
-  }
+  // remove the rule for the field of the filter we want to retrieve items for
+  PLAYLIST::CSmartPlaylist tmpFilter = *m_filter;
+
+  auto it = std::ranges::find_if(tmpFilter.m_ruleCombination.GetRules(), [&filter](const auto& rule)
+                                 { return static_cast<int>(filter.field) == rule->m_field; });
+  if (it != tmpFilter.m_ruleCombination.GetRules().cend())
+    tmpFilter.m_ruleCombination.RemoveRule(*it);
 
   if (m_mediaType == "movies" || m_mediaType == "tvshows" || m_mediaType == "episodes" || m_mediaType == "musicvideos")
   {
@@ -721,7 +723,7 @@ int CGUIDialogMediaFilter::GetItems(const Filter &filter, std::vector<std::strin
       musicdb.GetAlbumTypesNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
     else if (filter.field == Field::MUSIC_LABEL)
       musicdb.GetMusicLabelsNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
-    if (filter.field == Field::SOURCE)
+    else if (filter.field == Field::SOURCE)
       musicdb.GetSourcesNav(m_dbUrl->ToString(), selectItems, dbfilter, countOnly);
   }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

A commit per change:

1/ MySQL query execution error messages include the faulty query and are expanded using `sprintf`. This caused a crash for error messages that contained % format specifiers as no additional parameters are provided.
solution: use %s as the format and the error message as the sole parameter so it is not interpreted. SQLite already did that.

2/ Use `mysql_error()` to retrieve complete error messages instead of harcoding messages for a handful of error codes
new format: error number, server state, error message (see Screenshots)

3/ Suppress repetitive messages "Replacing configured host {} with resolved host {}". Show only when the host or resolved IP change.

4/ The advanced filter internal smartplaylist was missing media type (and other members..) when evaluated for each field of the dialog, and the wrong table name/field was used in the generated SQL WHERE clause.
solution: partial revert of edd7d0ab57173ccf8e1b81985db77b521c808d2a with slightly modernized code.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The advanced filter dialog (filter button from libraries) failed to update as the filters were modified (the ranges or counts on the dialog not refreshed after each change)
There was also an application crash when typing in the title field for external database setups (MySQL, MariaDB).

With local db (SQLite), while the dialog was not updated for each change, after pressing "OK" the correct filtered list of items was still displayed, which probably explains why the crash had not been reported since June.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Entry in various fields of the advanced filter for movies, tv shows, episodes. music videos, artists, albums, songs
(other contents don't have advanced filtering)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

No crash and advanced filter dialog that responds to every data entry

## Screenshots (if appropriate):

original log with incorrect generated SQL query:
```
SQL: [MyVideos_Next144] Undefined MySQL error: Code (1054)
Query: SELECT COUNT(DISTINCT genre.genre_id) FROM genre JOIN genre_link ON genre.genre_id = genre_link.genre_id...
```

improved log with the same incorrect query:
```
SQL: [MyVideos_Next144] MySQL error 1054 (42S22): Unknown column 'songview.strTitle' in 'WHERE'
Query: SELECT COUNT(DISTINCT genre.genre_id) FROM genre JOIN genre_link ON genre.genre_id = genre_link.genre_id...
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
