### PR TITLE
GBM: fix display reset blocked during idle render loop

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -154,21 +154,21 @@ void CWinSystemGbmGLContext::PresentRender(bool rendered, bool videoLayer)
     }
 
     CWinSystemGbm::FlipPage(rendered, videoLayer, async);
-
-    if (m_dispReset && m_dispResetTimer.IsTimePast())
-    {
-      CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext::{} - Sending display reset to all clients",
-                __FUNCTION__);
-      m_dispReset = false;
-      std::unique_lock lock(m_resourceSection);
-
-      for (auto resource : m_resources)
-        resource->OnResetDisplay();
-    }
   }
   else
   {
     KODI::TIME::Sleep(10ms);
+  }
+
+  if (m_dispReset && m_dispResetTimer.IsTimePast())
+  {
+    CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext::{} - Sending display reset to all clients",
+              __FUNCTION__);
+    m_dispReset = false;
+    std::unique_lock lock(m_resourceSection);
+
+    for (auto resource : m_resources)
+      resource->OnResetDisplay();
   }
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -163,21 +163,21 @@ void CWinSystemGbmGLESContext::PresentRender(bool rendered, bool videoLayer)
     }
 
     CWinSystemGbm::FlipPage(rendered, videoLayer, async);
-
-    if (m_dispReset && m_dispResetTimer.IsTimePast())
-    {
-      CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext::{} - Sending display reset to all clients",
-                __FUNCTION__);
-      m_dispReset = false;
-      std::unique_lock lock(m_resourceSection);
-
-      for (auto resource : m_resources)
-        resource->OnResetDisplay();
-    }
   }
   else
   {
     KODI::TIME::Sleep(10ms);
+  }
+
+  if (m_dispReset && m_dispResetTimer.IsTimePast())
+  {
+    CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext::{} - Sending display reset to all clients",
+              __FUNCTION__);
+    m_dispReset = false;
+    std::unique_lock lock(m_resourceSection);
+
+    for (auto resource : m_resources)
+      resource->OnResetDisplay();
   }
 }
 


### PR DESCRIPTION
## Description

The display reset timer in PresentRender was only checked inside the `if (rendered || videoLayer)` block. When neither flag is set (e.g. during video player initialization before the first frame is decoded), PresentRender enters the `else { Sleep(10ms); }` branch and never fires the pending display reset.

This causes a deadlock: the video thread is paused waiting for OnResetDisplay to signal that the display is ready, but OnResetDisplay never fires because PresentRender skips the timer check when no frame is being rendered.

The deadlock is triggered by stop+restart of video playback when a mode change occurs (e.g. GUI resolution differs from video resolution). The video thread stays paused indefinitely and playback never starts.

Fix by moving the display reset timer check after the if/else block so it runs on every PresentRender call regardless of render state.


## Motivation and context
Video playback gets stuck especially switching 1080p -> 4K and especially when restarting a video. This is a latent bug that is much more obvious when true 10-bit planes and/or dynamic planes (#27402) are enabled. since those trigger mode switches more regularly.

## How has this been tested?
on CFL and ADL-N Intel, Linux + EGL (GL or GLES doesn't matter).

## What is the effect on users?
Video always starts when it should start :)

## Screenshots (if appropriate):
n/a 

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
