### PR TITLE
Fix: NFSv4 file creation with atomic O_EXCL flag

### DIFF
--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -943,7 +943,8 @@ bool CNFSFile::OpenForWrite(const CURL& url, bool bOverWrite)
     CLog::Log(LOGWARNING, "FileNFS::OpenForWrite() called with overwriting enabled! - {}",
               filename);
     //create file with proper permissions
-    ret = nfs_creat(m_pNfsContext, filename.c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH, &m_pFileHandle);
+    ret = nfs_create(m_pNfsContext, filename.c_str(), O_RDWR | O_EXCL,
+                     S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH, &m_pFileHandle);
     //if file was created the file handle isn't valid ... so close it and open later
     if(ret == 0)
     {


### PR DESCRIPTION
## Description
Kodi isn't able to write to NFSv4 shares for a while now which has prevented me from storing my Kodi configuration backups remotely. I noticed PR https://github.com/xbmc/xbmc/pull/23302 had fixed the issue but due to other changes the PR was closed due to disagreements. So I've pulled out the fix for this particular issue.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes:
  - #23162
  - #24714

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I used a debug armeabi-v7a build running on Android TV and Kodi's File Manager to copy across some files to my NFSv4 share which would otherwise fail on an unfixed build resulting in a 0 byte file.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

As a user, fixing this will enable me to store my configuration backups off device to an NFSv4 share. If there are cases where Kodi needs to write to a library stored on an NFS share such as NFO files or other metadata these will succeed on an NFSv4 share.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
