### PR TITLE
cmake: clean stale copied files from build tree on source removal

### DIFF
--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -324,8 +324,24 @@ function(copy_files_from_filelist_to_buildtree pattern)
           # Don't recursively add all files with the given name.
           set(files ${src})
         else()
-          # Static path contents, so we can just glob at generation time
-          file(GLOB_RECURSE files RELATIVE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/${src})
+          # CONFIGURE_DEPENDS re-runs this glob at build time and triggers a
+          # reconfigure when files are added or removed in the source tree.
+          file(GLOB_RECURSE files CONFIGURE_DEPENDS RELATIVE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/${src})
+
+          # Remove stale files from build tree that no longer exist in source.
+          # CONFIGURE_DEPENDS updates the file list, but previously-copied files
+          # persist in the build tree and would be installed or deployed.
+          string(REPLACE "*" "" _clean_dir ${src})
+          string(REGEX REPLACE "/+$" "" _clean_dir ${_clean_dir})
+          if(IS_DIRECTORY ${CMAKE_BINARY_DIR}/${_clean_dir})
+            file(GLOB_RECURSE _build_files RELATIVE ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/${src})
+            foreach(_bf ${_build_files})
+              if(NOT ${_bf} IN_LIST files)
+                file(REMOVE ${CMAKE_BINARY_DIR}/${_bf})
+                message(STATUS "Removed stale file from build tree: ${_bf}")
+              endif()
+            endforeach()
+          endif()
         endif()
 
         foreach(file ${files})


### PR DESCRIPTION
## Description

I'm sure other developers have hit this many times: stale files in build tree that are simple copies from the source tree but have since been removed from the source tree. This patch effectively does an rsync to make sure they stay identical.

copy_files_from_filelist_to_buildtree uses GLOB_RECURSE to mirror source files into the build tree for installation. When a source file is deleted or renamed, the stale copy in the build tree persists indefinitely. This causes deleted files to be installed and can lead to hard-to-diagnose issues (e.g. an old shader version overriding a new one at runtime).

This PR adds CONFIGURE_DEPENDS so cmake re-runs the glob at build time when files are added or removed, and actively removes build tree files whose source counterparts no longer exist.

## Motivation and context

Encountered during GLES shader development: a shader file was moved from `system/shaders/GLES/3.1/` to `system/shaders/GLES/2.0/` but the old 3.1 copy persisted in the build tree. `GetShaderPath()` prefers higher versioned directories, so the stale file was loaded instead of the new one, causing a shader compile failure at runtime. Running cmake or even a full rebuild did not remove the orphaned file -- only manually deleting it or wiping the build tree resolved it.

## How has this been tested?

- GBM/GLES build on Linux (aarch64, Intel N250)
- Verified stale shader files are automatically removed from build tree after source deletion
- Verified new files are picked up without manual cmake re-run
- Confirmed message(STATUS ...) output logs each removal for build-time visibility

## What is the effect on users?

No user-visible change. Developers and packagers benefit from build trees that stay in sync with source after file
renames or deletions, without requiring a clean rebuild.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
