### PR TITLE
VideoPlayer: fix 0x0 viewport at renderer Configure, avoid shader recompiles

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2249,7 +2249,11 @@ void CVideoPlayer::HandlePlaySpeed()
 
       if (!m_State.streamsReady)
       {
-        if (m_playerOptions.fullscreen)
+        // For video, the fullscreen switch is handled synchronously in OpenStream
+        // so the renderer can configure with a valid viewport. This async fallback
+        // covers audio-only playback (visualisation window).
+        if (m_playerOptions.fullscreen &&
+            !CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenVideo())
         {
           CServiceBroker::GetAppMessenger()->PostMsg(TMSG_SWITCHTOFULLSCREEN);
         }
@@ -3871,6 +3875,17 @@ bool CVideoPlayer::OpenStream(CCurrentStream& current, int64_t demuxerId, int iS
       break;
     case StreamType::VIDEO:
       res = OpenVideoStream(hint, reset);
+      // Activate fullscreen video window synchronously so the renderer
+      // configures with a valid viewport. Without this, GetViewWindow()
+      // returns 0x0 because m_bFullScreenVideo is not set until the async
+      // window activation in the streamsReady block below. m_HasVideo is
+      // set inside OpenVideoStream so SwitchToFullScreen's
+      // IsPlayingVideo() check will pass.
+      if (res && m_playerOptions.fullscreen &&
+          !CServiceBroker::GetWinSystem()->GetGfxContext().IsFullScreenVideo())
+      {
+        CServiceBroker::GetAppMessenger()->SendMsg(TMSG_SWITCHTOFULLSCREEN);
+      }
       break;
     case StreamType::SUBTITLE:
       res = OpenSubtitleStream(hint);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -782,8 +782,7 @@ void CLinuxRendererGL::UpdateVideoFilter()
     return;
 
   if (m_scalingMethodGui == m_videoSettings.m_ScalingMethod &&
-      viewRect.Height() == m_viewRect.Height() &&
-      viewRect.Width() == m_viewRect.Width() &&
+      viewRect.Height() == m_lastViewRect.Height() && viewRect.Width() == m_lastViewRect.Width() &&
       !nonLinStretchChanged && !cmsChanged)
     return;
 
@@ -814,7 +813,7 @@ void CLinuxRendererGL::UpdateVideoFilter()
 
   m_scalingMethodGui = m_videoSettings.m_ScalingMethod;
   m_scalingMethod = m_scalingMethodGui;
-  m_viewRect = viewRect;
+  m_lastViewRect = viewRect;
 
   if (!Supports(m_scalingMethod))
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -226,7 +226,7 @@ protected:
   bool m_nonLinStretch = false;
   bool m_nonLinStretchGui = false;
   float m_pixelRatio = 0.0f;
-  CRect m_viewRect;
+  CRect m_lastViewRect;
 
   // color management
   std::unique_ptr<CColorManager> m_ColorManager;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -607,8 +607,7 @@ void CLinuxRendererGLES::UpdateVideoFilter()
   // TODO: GL also checks nonLinStretchChanged and cmsChanged in the early exit
   // and the reload check below. Add when non-linear stretch and CMS are ported to GLES.
   if (m_scalingMethodGui == m_videoSettings.m_ScalingMethod &&
-      viewRect.Height() == m_viewRect.Height() &&
-      viewRect.Width() == m_viewRect.Width())
+      viewRect.Height() == m_lastViewRect.Height() && viewRect.Width() == m_lastViewRect.Width())
   {
     return;
   }
@@ -619,7 +618,7 @@ void CLinuxRendererGLES::UpdateVideoFilter()
 
   m_scalingMethodGui = m_videoSettings.m_ScalingMethod;
   m_scalingMethod = m_scalingMethodGui;
-  m_viewRect = viewRect;
+  m_lastViewRect = viewRect;
 
   if(!Supports(m_scalingMethod))
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -215,7 +215,7 @@ protected:
 
   // clear colour for "black" bars
   float m_clearColour{0.0f};
-  CRect m_viewRect;
+  CRect m_lastViewRect;
 
 private:
   void ClearBackBuffer();


### PR DESCRIPTION
## Description

This has driven me crazy for months and took forever to hunt down. If you check log you see a bunch of double-initiations of shaders that shouldn't be happening.  This should finally solve that cleanly.

Fix a 0x0 viewport bug that causes every video playback to compile shaders twice. The renderer configures before the fullscreen video window is active, so `GetViewWindow()` returns an empty rect. Shader setup (scaling method selection, dithering decisions) runs with invalid dimensions, then gets discarded and recompiled when the viewport becomes valid on the next frame.

Also fix a member-variable shadowing bug in the GL and GLES renderers where a derived-class `m_viewRect` shadowed the base-class member, causing `UpdateVideoFilter` to run unconditionally every frame instead of early-exiting when the viewport hasn't changed. This looks like a very long-lived bug.

## Motivation and context

The double shader compile has been latent since the fullscreen video window activation was made asynchronous via PostMsg. Every video start on every platform pays the cost of compiling shaders with wrong state, then immediately recompiling with correct state. This is particularly visible on lower-end GLES devices where shader compilation is expensive.

The shadowing bug independently causes UpdateVideoFilter to skip its early-exit optimization, running the full filter evaluation every frame until the shadow variable is populated.

## How has this been tested?

- GBM/GLES (Intel N250): played SDR 8-bit, SDR 10-bit, HDR 10-bit content at 1080p and 4K with various whitelist configurations. Confirmed fullScreenVideo=true and valid viewRect/destRect at Configure time in all cases. No viewport 0x0 in logs. Single shader compile per video start.
- GBM/GLES (integration-test branch with HQ scalers + dithering): confirmed scaling method accepted on first pass, dithering decisions correct on first pass, no wasted recompile.
- Verified the PostMsg fallback still fires for non-video playback paths.

## What is the effect on users?

Faster video start on all platforms -- eliminates a redundant shader compile on every playback. Reduces GPU stall at video start, potentially noticeable on embedded/mobile GLES devices.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
