### PR TITLE
GLES dithering

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7760,7 +7760,49 @@ msgctxt "#13476"
 msgid "16 bit per channel"
 msgstr ""
 
-#empty strings from id 13477 to 13504
+#. Value of setting with label #36100 "Dither depth"
+#: system/settings/settings.xml
+msgctxt "#13477"
+msgid "2 bit"
+msgstr ""
+
+#. Value of setting with label #36100 "Dither depth"
+#: system/settings/settings.xml
+msgctxt "#13478"
+msgid "3 bit"
+msgstr ""
+
+#. Value of setting with label #36100 "Dither depth"
+#: system/settings/settings.xml
+msgctxt "#13479"
+msgid "4 bit"
+msgstr ""
+
+#. Value of setting with label #36100 "Dither depth"
+#: system/settings/settings.xml
+msgctxt "#13480"
+msgid "5 bit"
+msgstr ""
+
+#. Value of setting with label #36100 "Dither depth"
+#: system/settings/settings.xml
+msgctxt "#13481"
+msgid "6 bit"
+msgstr ""
+
+#. Value of setting with label #36100 "Dither depth"
+#: system/settings/settings.xml
+msgctxt "#13482"
+msgid "7 bit"
+msgstr ""
+
+#. Value of setting with label #36100 "Dither depth"
+#: system/settings/settings.xml
+msgctxt "#13483"
+msgid "8 bit"
+msgstr ""
+
+#empty strings from id 13484 to 13504
 
 #: system/settings/settings.xml
 msgctxt "#13505"
@@ -22116,7 +22158,7 @@ msgstr ""
 #. Description of setting with label #36100 "Dither depth"
 #: system/settings/settings.xml
 msgctxt "#36599"
-msgid "Video dithering output precision in bits. Use the highest setting that doesn't show banding. The default of 8 is recommended for most systems. If your GPU is set to scale the output RGB levels or you use a laptop screen, a 7 or 6 bit setting may eliminate more banding. Lower settings are available for testing purposes only to make it easy to see whether dithering is applied and that the dither noise pixel size matches the display resolution."
+msgid "Video dithering output precision in bits. Auto enables dithering only when beneficial (limited- / full-range mismatch, bit depth reduction, downscaling, or HDR tone mapping) and uses 8- or 10-bit depth based on what the display supports. Lower settings are available for testing purposes only."
 msgstr ""
 
 #reserved strings 365XX

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2885,6 +2885,7 @@
           <requirement>
             <or>
               <condition>HAS_GL</condition>
+              <condition>HAS_GLES</condition>
               <condition>HAS_DX</condition>
             </or>
           </requirement>
@@ -2896,20 +2897,28 @@
           <requirement>
             <or>
               <condition>HAS_GL</condition>
+              <condition>HAS_GLES</condition>
               <condition>HAS_DX</condition>
             </or>
           </requirement>
           <level>3</level>
-          <default>8</default>
+          <default>0</default>
           <constraints>
-            <minimum>2</minimum>
-            <step>1</step>
-            <maximum>8</maximum>
+            <options>
+              <option label="16316">0</option>
+              <option label="13477">2</option>
+              <option label="13478">3</option>
+              <option label="13479">4</option>
+              <option label="13480">5</option>
+              <option label="13481">6</option>
+              <option label="13482">7</option>
+              <option label="13483">8</option>
+            </options>
           </constraints>
           <dependencies>
             <dependency type="visible" setting="videoscreen.dither" operator="is">true</dependency>
           </dependencies>
-          <control type="spinner" format="integer" />
+          <control type="spinner" format="string" />
         </setting>
         <setting id="videoscreen.cmsenabled" type="boolean" label="36560" help="36561">
           <requirement>

--- a/system/shaders/GLES/2.0/gles_dither_body.frag
+++ b/system/shaders/GLES/2.0/gles_dither_body.frag
@@ -1,0 +1,8 @@
+#if defined(XBMC_DITHER)
+  if (m_ditherEnabled > 0.0)
+  {
+    vec2 ditherpos = gl_FragCoord.xy / m_dithersize;
+    float ditherval = texture2D(m_dither, ditherpos).r * 16.0;
+    rgb = floor(rgb * m_ditherquant + ditherval) / m_ditherquant;
+  }
+#endif

--- a/system/shaders/GLES/2.0/gles_dither_uniforms.frag
+++ b/system/shaders/GLES/2.0/gles_dither_uniforms.frag
@@ -1,0 +1,6 @@
+#if defined(XBMC_DITHER)
+uniform float m_ditherEnabled;
+uniform sampler2D m_dither;
+uniform float m_ditherquant;
+uniform vec2 m_dithersize;
+#endif

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -118,6 +118,9 @@ CLinuxRendererGL::CLinuxRendererGL()
   m_format = AV_PIX_FMT_NONE;
 
   std::tie(m_useDithering, m_ditherDepth) = CServiceBroker::GetWinSystem()->GetDitherSettings();
+  // TODO: GL does not support Auto dithering yet; treat as 8-bit (previous default)
+  if (m_ditherDepth == 0)
+    m_ditherDepth = 8;
 
   m_fullRange = !CServiceBroker::GetWinSystem()->UseLimitedColor();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -55,6 +55,7 @@ CLinuxRendererGLES::CLinuxRendererGLES()
     }
     else
     {
+#if defined(GL_R16_EXT)
       glGenTextures(1, &m_ditherTex);
       glActiveTexture(GL_TEXTURE3);
       glBindTexture(GL_TEXTURE_2D, m_ditherTex);
@@ -70,6 +71,12 @@ CLinuxRendererGLES::CLinuxRendererGLES()
         CLog::Log(LOGDEBUG, "GLES: dithering auto");
       else
         CLog::Log(LOGDEBUG, "GLES: dithering enabled, depth={}", m_ditherDepth);
+#else
+      // GL_EXT_texture_norm16 not exposed by this GL header (e.g. iOS):
+      // no 16-bit single-channel format available for the dither texture.
+      CLog::Log(LOGWARNING, "GLES: GL_R16_EXT undefined at build time; dithering disabled");
+      m_useDithering = false;
+#endif
     }
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -14,6 +14,7 @@
 #include "ServiceBroker.h"
 #include "VideoShaders/VideoFilterShaderGLES.h"
 #include "VideoShaders/YUV2RGBShaderGLES.h"
+#include "VideoShaders/dither.h"
 #include "application/Application.h"
 #include "cores/IPlayer.h"
 #include "guilib/Texture.h"
@@ -42,6 +43,35 @@ CLinuxRendererGLES::CLinuxRendererGLES()
   m_fullRange = !CServiceBroker::GetWinSystem()->UseLimitedColor();
 
   m_renderSystem = dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
+
+  std::tie(m_useDithering, m_ditherDepth) = CServiceBroker::GetWinSystem()->GetDitherSettings();
+  if (m_useDithering)
+  {
+    if (m_renderSystem && !m_renderSystem->IsExtSupported("GL_EXT_texture_norm16"))
+    {
+      CLog::Log(LOGWARNING,
+                "GLES: dithering requested but GL_EXT_texture_norm16 not supported, disabling");
+      m_useDithering = false;
+    }
+    else
+    {
+      glGenTextures(1, &m_ditherTex);
+      glActiveTexture(GL_TEXTURE3);
+      glBindTexture(GL_TEXTURE_2D, m_ditherTex);
+      glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+      glTexImage2D(GL_TEXTURE_2D, 0, GL_R16_EXT, dither_size, dither_size, 0, GL_RED,
+                   GL_UNSIGNED_SHORT, dither_matrix);
+      glActiveTexture(GL_TEXTURE0);
+      if (m_ditherDepth == 0)
+        CLog::Log(LOGDEBUG, "GLES: dithering auto");
+      else
+        CLog::Log(LOGDEBUG, "GLES: dithering enabled, depth={}", m_ditherDepth);
+    }
+  }
 
 #if defined(GL_ES_VERSION_3_0)
   int32_t intermediatePrecision = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
@@ -73,6 +103,9 @@ CLinuxRendererGLES::~CLinuxRendererGLES()
   UnInit();
 
   ReleaseShaders();
+
+  if (m_ditherTex)
+    glDeleteTextures(1, &m_ditherTex);
 
   free(m_planeBuffer);
   m_planeBuffer = nullptr;
@@ -133,6 +166,8 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
   m_renderOrientation = orientation;
 
   m_srcPrimaries = picture.color_primaries;
+  m_srcColorBits = picture.colorBits;
+  m_srcFullRange = picture.color_range == 1;
   m_toneMap = false;
 
   // Calculate the input frame aspect ratio.
@@ -773,13 +808,37 @@ void CLinuxRendererGLES::UpdateVideoFilter()
       }
     }
 
-    // TODO: GL passes additional params: m_nonLinStretch, m_intermediateGammaCorrection,
-    // GLSLOutput* (for dithering and color management). Add when ported to GLES.
-    m_pVideoFilterShader = new ConvolutionFilterShader(m_scalingMethod);
+    // TODO: GL also passes m_nonLinStretch, m_intermediateGammaCorrection.
+    // Add when non-linear stretch and gamma correction are ported to GLES.
+    m_pVideoFilterShader = new ConvolutionFilterShader(m_scalingMethod, m_useDithering);
     if (!m_pVideoFilterShader->CompileAndLink())
     {
       CLog::Log(LOGERROR, "GLES: Error compiling and linking video filter shader");
       break;
+    }
+
+    if (m_useDithering && m_ditherTex)
+    {
+      bool ditherActive = true;
+      unsigned int effectiveDitherDepth = m_ditherDepth;
+      if (m_ditherDepth == 0)
+      {
+        GLint redBits = 0;
+        glGetIntegerv(GL_RED_BITS, &redBits);
+        // Use framebuffer depth on HDR displays; assume 8-bit on SDR displays
+        // since the CRTC or display will truncate to 8-bit regardless of BO depth.
+        if (CServiceBroker::GetWinSystem()->IsHDRDisplay())
+          effectiveDitherDepth = (redBits > 0) ? redBits : 8;
+        else
+          effectiveDitherDepth = 8;
+
+        float scaleFactor = ScalingAboveThreshold();
+        bool downscaling = scaleFactor > 0.0f && scaleFactor < 1.0f;
+        ditherActive = (m_srcFullRange != m_fullRange) || m_srcColorBits > effectiveDitherDepth ||
+                       m_toneMap || downscaling;
+      }
+      static_cast<ConvolutionFilterShader*>(m_pVideoFilterShader)
+          ->SetDitherUniforms(ditherActive, m_ditherTex, effectiveDitherDepth, dither_size);
     }
 
     CLog::Log(LOGINFO, "GLES: FBO intermediate format {:#x}",
@@ -840,6 +899,33 @@ void CLinuxRendererGLES::LoadShaders(int field)
         // Try GLSL shaders if supported and user requested auto or GLSL.
         if (glCreateProgram())
         {
+          // Auto dithering (depth=0): decide per-video whether dithering is beneficial.
+          // Shaders are always compiled with XBMC_DITHER when the setting is on.
+          // The m_ditherEnabled uniform controls whether the shader applies dithering.
+          bool ditherActive = true;
+          unsigned int effectiveDitherDepth = m_ditherDepth;
+
+          if (m_ditherDepth == 0 && m_ditherTex)
+          {
+            GLint redBits = 0;
+            glGetIntegerv(GL_RED_BITS, &redBits);
+            if (CServiceBroker::GetWinSystem()->IsHDRDisplay())
+              effectiveDitherDepth = (redBits > 0) ? redBits : 8;
+            else
+              effectiveDitherDepth = 8;
+
+            float scaleFactor = ScalingAboveThreshold();
+            bool downscaling = scaleFactor > 0.0f && scaleFactor < 1.0f;
+            ditherActive = (m_srcFullRange != m_fullRange) ||
+                           m_srcColorBits > effectiveDitherDepth || m_toneMap || downscaling;
+
+            CLog::Log(LOGDEBUG,
+                      "GLES: auto dither {} (depth={}, source={}bit, "
+                      "rangeMismatch={}, toneMap={}, downscaling={})",
+                      ditherActive ? "on" : "off", effectiveDitherDepth, m_srcColorBits,
+                      m_srcFullRange != m_fullRange, m_toneMap, downscaling);
+          }
+
           EShaderFormat shaderFormat = GetShaderFormat();
           m_toneMapMethod = m_videoSettings.m_ToneMapMethod;
 
@@ -850,7 +936,7 @@ void CLinuxRendererGLES::LoadShaders(int field)
           {
             m_pYUVProgShader = new YUV2RGBFilterShader(
                 shaderFormat, m_passthroughHDR ? m_srcPrimaries : AVColorPrimaries::AVCOL_PRI_BT709,
-                m_srcPrimaries, m_toneMap, m_toneMapMethod, m_scalingMethod);
+                m_srcPrimaries, m_toneMap, m_toneMapMethod, m_scalingMethod, m_useDithering);
             // TODO: GL gates this on !m_cmsOn. Add when CMS is ported to GLES.
             m_pYUVProgShader->SetConvertFullColorRange(m_fullRange);
 
@@ -858,6 +944,9 @@ void CLinuxRendererGLES::LoadShaders(int field)
 
             if (m_pYUVProgShader->CompileAndLink())
             {
+              if (m_useDithering && m_ditherTex)
+                m_pYUVProgShader->SetDitherUniforms(ditherActive, m_ditherTex, effectiveDitherDepth,
+                                                    dither_size);
               m_renderMethod = RENDER_GLSL;
               UpdateVideoFilter();
               break;
@@ -873,19 +962,26 @@ void CLinuxRendererGLES::LoadShaders(int field)
           // Fall back to regular progressive shader
           m_pYUVProgShader = new YUV2RGBProgressiveShader(
               shaderFormat, m_passthroughHDR ? m_srcPrimaries : AVColorPrimaries::AVCOL_PRI_BT709,
-              m_srcPrimaries, m_toneMap, m_toneMapMethod);
+              m_srcPrimaries, m_toneMap, m_toneMapMethod, m_useDithering);
           m_pYUVProgShader->SetConvertFullColorRange(m_fullRange);
 
           CLog::Log(LOGINFO, "GLES: Selecting YUV 2 RGB shader");
 
           m_pYUVBobShader = new YUV2RGBBobShader(
               shaderFormat, m_passthroughHDR ? m_srcPrimaries : AVColorPrimaries::AVCOL_PRI_BT709,
-              m_srcPrimaries, m_toneMap, m_toneMapMethod);
+              m_srcPrimaries, m_toneMap, m_toneMapMethod, m_useDithering);
           m_pYUVBobShader->SetConvertFullColorRange(m_fullRange);
 
           if ((m_pYUVProgShader && m_pYUVProgShader->CompileAndLink())
               && (m_pYUVBobShader && m_pYUVBobShader->CompileAndLink()))
           {
+            if (m_useDithering && m_ditherTex)
+            {
+              m_pYUVProgShader->SetDitherUniforms(ditherActive, m_ditherTex, effectiveDitherDepth,
+                                                  dither_size);
+              m_pYUVBobShader->SetDitherUniforms(ditherActive, m_ditherTex, effectiveDitherDepth,
+                                                 dither_size);
+            }
             m_renderMethod = RENDER_GLSL;
             UpdateVideoFilter();
             break;
@@ -1924,6 +2020,22 @@ bool CLinuxRendererGLES::SupportsMultiPassRendering()
   return true;
 }
 
+float CLinuxRendererGLES::ScalingAboveThreshold() const
+{
+  float scaleX = m_destRect.Width() / static_cast<float>(m_sourceWidth);
+  float scaleY = m_destRect.Height() / static_cast<float>(m_sourceHeight);
+  float scaleFactor = (scaleX + scaleY) / 2.0f;
+  float scalePercent = fabs(1.0f - scaleFactor) * 100;
+  int minScale = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_VIDEOPLAYER_HQSCALERS);
+
+  if (scalePercent < minScale)
+    return 0.0f;
+
+  // < 1.0 = downscale, > 1.0 = upscale
+  return scaleFactor;
+}
+
 bool CLinuxRendererGLES::Supports(ESCALINGMETHOD method) const
 {
   if (method == VS_SCALINGMETHOD_NEAREST || method == VS_SCALINGMETHOD_LINEAR ||
@@ -1944,13 +2056,8 @@ bool CLinuxRendererGLES::Supports(ESCALINGMETHOD method) const
       method == VS_SCALINGMETHOD_LANCZOS3)
   {
     // if scaling is below level, avoid hq scaling
-    float scaleX = fabs((static_cast<float>(m_sourceWidth) - m_destRect.Width()) / m_sourceWidth) * 100;
-    float scaleY = fabs((static_cast<float>(m_sourceHeight) - m_destRect.Height()) / m_sourceHeight) * 100;
-    int minScale = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_HQSCALERS);
-    if (scaleX < minScale && scaleY < minScale)
-    {
+    if (ScalingAboveThreshold() == 0.0f)
       return false;
-    }
 
     if (m_renderMethod & RENDER_GLSL)
     {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -89,6 +89,9 @@ public:
   CRenderCapture* GetRenderCapture() override;
 
 protected:
+  // Returns 0 if scaling is below hqscalers threshold.
+  // Otherwise returns the scale factor: < 1.0 = downscale, > 1.0 = upscale.
+  float ScalingAboveThreshold() const;
   static const int FIELD_FULL{0};
   static const int FIELD_TOP{1};
   static const int FIELD_BOT{2};
@@ -146,6 +149,13 @@ protected:
   GLenum m_textureTarget = GL_TEXTURE_2D;
   int m_renderMethod{RENDER_GLSL};
   RenderQuality m_renderQuality{RQ_SINGLEPASS};
+
+  // Dithering
+  bool m_useDithering{false};
+  unsigned int m_ditherDepth{0};
+  unsigned int m_srcColorBits{8};
+  bool m_srcFullRange{false};
+  GLuint m_ditherTex{0};
 
   // Raw data used by renderer
   int m_currentField{FIELD_FULL};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
@@ -57,9 +57,10 @@ bool BaseVideoFilterShader::OnEnabled()
   return true;
 }
 
-ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method)
+ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method, bool dither)
 {
   m_method = method;
+  m_dither = dither;
 
   std::string shadername;
   std::string defines;
@@ -100,10 +101,15 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method)
     m_internalformat = GL_RGBA;
   }
 
+  if (m_dither)
+    defines += "#define XBMC_DITHER\n";
+
   CLog::Log(LOGDEBUG, "GLES: using scaling method: {}", m_method);
   CLog::Log(LOGDEBUG, "GLES: using shader: {}", shadername);
 
   PixelShader()->LoadSource(shadername, defines);
+  PixelShader()->InsertSource("gles_dither_uniforms.frag", "void main()");
+  PixelShader()->InsertSource("gles_dither_body.frag", "gl_FragColor");
 }
 
 ConvolutionFilterShader::~ConvolutionFilterShader()
@@ -119,6 +125,14 @@ void ConvolutionFilterShader::OnCompiledAndLinked()
   m_hSourceTex = glGetUniformLocation(ProgramHandle(), "img");
   m_hStepXY    = glGetUniformLocation(ProgramHandle(), "stepxy");
   m_hKernTex   = glGetUniformLocation(ProgramHandle(), "kernelTex");
+
+  if (m_dither)
+  {
+    m_hDitherEnabled = glGetUniformLocation(ProgramHandle(), "m_ditherEnabled");
+    m_hDither = glGetUniformLocation(ProgramHandle(), "m_dither");
+    m_hDitherQuant = glGetUniformLocation(ProgramHandle(), "m_ditherquant");
+    m_hDitherSize = glGetUniformLocation(ProgramHandle(), "m_dithersize");
+  }
 
   CConvolutionKernel kernel(m_method, 256);
 
@@ -167,6 +181,17 @@ void ConvolutionFilterShader::OnCompiledAndLinked()
   VerifyGLState();
 }
 
+void ConvolutionFilterShader::SetDitherUniforms(bool enabled,
+                                                GLuint ditherTex,
+                                                unsigned int ditherDepth,
+                                                int ditherSize)
+{
+  m_ditherEnabled = enabled;
+  m_ditherTex = ditherTex;
+  m_ditherDepth = ditherDepth;
+  m_ditherSize = ditherSize;
+}
+
 bool ConvolutionFilterShader::OnEnabled()
 {
   BaseVideoFilterShader::OnEnabled();
@@ -181,11 +206,29 @@ bool ConvolutionFilterShader::OnEnabled()
   glUniform2f(m_hStepXY, m_stepX, m_stepY);
   VerifyGLState();
 
+  if (m_dither && m_ditherTex)
+  {
+    glUniform1f(m_hDitherEnabled, m_ditherEnabled ? 1.0f : 0.0f);
+    glUniform1i(m_hDither, 3);
+    glActiveTexture(GL_TEXTURE3);
+    glBindTexture(GL_TEXTURE_2D, m_ditherTex);
+    glActiveTexture(GL_TEXTURE0);
+    glUniform1f(m_hDitherQuant, (1 << m_ditherDepth) - 1.0f);
+    glUniform2f(m_hDitherSize, static_cast<float>(m_ditherSize), static_cast<float>(m_ditherSize));
+    VerifyGLState();
+  }
+
   return true;
 }
 
 void ConvolutionFilterShader::OnDisabled()
 {
+  if (m_dither && m_ditherTex)
+  {
+    glActiveTexture(GL_TEXTURE3);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glActiveTexture(GL_TEXTURE0);
+  }
 }
 
 void ConvolutionFilterShader::Free()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.h
@@ -69,7 +69,7 @@ protected:
   class ConvolutionFilterShader : public BaseVideoFilterShader
   {
   public:
-    ConvolutionFilterShader(ESCALINGMETHOD method);
+    ConvolutionFilterShader(ESCALINGMETHOD method, bool dither = false);
     ~ConvolutionFilterShader() override;
     void OnCompiledAndLinked() override;
     bool OnEnabled() override;
@@ -77,6 +77,11 @@ protected:
     void Free();
 
     bool GetTextureFilter(GLint& filter) override { filter = GL_NEAREST; return true; }
+
+    void SetDitherUniforms(bool enabled,
+                           GLuint ditherTex,
+                           unsigned int ditherDepth,
+                           int ditherSize);
 
   protected:
     // kernel textures
@@ -88,6 +93,17 @@ protected:
     ESCALINGMETHOD m_method;
     bool m_floattex; //if float textures are supported
     GLint m_internalformat;
+
+    // dithering
+    bool m_dither = false;
+    bool m_ditherEnabled = false;
+    GLint m_hDitherEnabled = -1;
+    GLint m_hDither = -1;
+    GLint m_hDitherQuant = -1;
+    GLint m_hDitherSize = -1;
+    GLuint m_ditherTex = 0;
+    unsigned int m_ditherDepth = 0;
+    int m_ditherSize = 0;
   };
 
   class DefaultFilterShader : public BaseVideoFilterShader

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -29,12 +29,14 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format,
                                              AVColorPrimaries dstPrimaries,
                                              AVColorPrimaries srcPrimaries,
                                              bool toneMap,
-                                             ETONEMAPMETHOD toneMapMethod)
+                                             ETONEMAPMETHOD toneMapMethod,
+                                             bool dither)
 {
   m_width = 1;
   m_height = 1;
   m_field = 0;
   m_format = format;
+  m_dither = dither;
 
   m_black = 0.0f;
   m_contrast = 1.0f;
@@ -71,6 +73,9 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format,
       m_defines += "#define KODI_TONE_MAPPING_HABLE\n";
   }
 
+  if (m_dither)
+    m_defines += "#define XBMC_DITHER\n";
+
   VertexShader()->LoadSource("gles_yuv2rgb.vert", m_defines);
 
   CLog::Log(LOGDEBUG, "GLES: using shader format: {}", m_format);
@@ -104,6 +109,15 @@ void BaseYUV2RGBGLSLShader::OnCompiledAndLinked()
   m_hCoefsDst = glGetUniformLocation(ProgramHandle(), "m_coefsDst");
   m_hToneP1 = glGetUniformLocation(ProgramHandle(), "m_toneP1");
   m_hLuminance = glGetUniformLocation(ProgramHandle(), "m_luminance");
+
+  if (m_dither)
+  {
+    m_hDitherEnabled = glGetUniformLocation(ProgramHandle(), "m_ditherEnabled");
+    m_hDither = glGetUniformLocation(ProgramHandle(), "m_dither");
+    m_hDitherQuant = glGetUniformLocation(ProgramHandle(), "m_ditherquant");
+    m_hDitherSize = glGetUniformLocation(ProgramHandle(), "m_dithersize");
+  }
+
   VerifyGLState();
 }
 
@@ -178,13 +192,41 @@ bool BaseYUV2RGBGLSLShader::OnEnabled()
     }
   }
 
+  if (m_dither && m_ditherTex)
+  {
+    glUniform1f(m_hDitherEnabled, m_ditherEnabled ? 1.0f : 0.0f);
+    glUniform1i(m_hDither, 4);
+    glActiveTexture(GL_TEXTURE4);
+    glBindTexture(GL_TEXTURE_2D, m_ditherTex);
+    glActiveTexture(GL_TEXTURE0);
+    glUniform1f(m_hDitherQuant, (1 << m_ditherDepth) - 1.0f);
+    glUniform2f(m_hDitherSize, static_cast<float>(m_ditherSize), static_cast<float>(m_ditherSize));
+  }
+
   VerifyGLState();
 
   return true;
 }
 
+void BaseYUV2RGBGLSLShader::SetDitherUniforms(bool enabled,
+                                              GLuint ditherTex,
+                                              unsigned int ditherDepth,
+                                              int ditherSize)
+{
+  m_ditherEnabled = enabled;
+  m_ditherTex = ditherTex;
+  m_ditherDepth = ditherDepth;
+  m_ditherSize = ditherSize;
+}
+
 void BaseYUV2RGBGLSLShader::OnDisabled()
 {
+  if (m_dither && m_ditherTex)
+  {
+    glActiveTexture(GL_TEXTURE4);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glActiveTexture(GL_TEXTURE0);
+  }
 }
 
 void BaseYUV2RGBGLSLShader::Free()
@@ -228,11 +270,14 @@ YUV2RGBProgressiveShader::YUV2RGBProgressiveShader(EShaderFormat format,
                                                    AVColorPrimaries dstPrimaries,
                                                    AVColorPrimaries srcPrimaries,
                                                    bool toneMap,
-                                                   ETONEMAPMETHOD toneMapMethod)
-  : BaseYUV2RGBGLSLShader(format, dstPrimaries, srcPrimaries, toneMap, toneMapMethod)
+                                                   ETONEMAPMETHOD toneMapMethod,
+                                                   bool dither)
+  : BaseYUV2RGBGLSLShader(format, dstPrimaries, srcPrimaries, toneMap, toneMapMethod, dither)
 {
   PixelShader()->LoadSource("gles_yuv2rgb_basic.frag", m_defines);
   PixelShader()->InsertSource("gles_tonemap.frag", "void main()");
+  PixelShader()->InsertSource("gles_dither_uniforms.frag", "void main()");
+  PixelShader()->InsertSource("gles_dither_body.frag", "gl_FragColor");
 }
 
 
@@ -244,11 +289,14 @@ YUV2RGBBobShader::YUV2RGBBobShader(EShaderFormat format,
                                    AVColorPrimaries dstPrimaries,
                                    AVColorPrimaries srcPrimaries,
                                    bool toneMap,
-                                   ETONEMAPMETHOD toneMapMethod)
-  : BaseYUV2RGBGLSLShader(format, dstPrimaries, srcPrimaries, toneMap, toneMapMethod)
+                                   ETONEMAPMETHOD toneMapMethod,
+                                   bool dither)
+  : BaseYUV2RGBGLSLShader(format, dstPrimaries, srcPrimaries, toneMap, toneMapMethod, dither)
 {
   PixelShader()->LoadSource("gles_yuv2rgb_bob.frag", m_defines);
   PixelShader()->InsertSource("gles_tonemap.frag", "void main()");
+  PixelShader()->InsertSource("gles_dither_uniforms.frag", "void main()");
+  PixelShader()->InsertSource("gles_dither_body.frag", "gl_FragColor");
 }
 
 void YUV2RGBBobShader::OnCompiledAndLinked()
@@ -281,13 +329,16 @@ YUV2RGBFilterShader::YUV2RGBFilterShader(EShaderFormat format,
                                          AVColorPrimaries srcPrimaries,
                                          bool toneMap,
                                          ETONEMAPMETHOD toneMapMethod,
-                                         ESCALINGMETHOD method)
-  : BaseYUV2RGBGLSLShader(format, dstPrimaries, srcPrimaries, toneMap, toneMapMethod)
+                                         ESCALINGMETHOD method,
+                                         bool dither)
+  : BaseYUV2RGBGLSLShader(format, dstPrimaries, srcPrimaries, toneMap, toneMapMethod, dither)
 {
   m_scaling = method;
   PixelShader()->LoadSource("gles310_yuv2rgb_filter.frag", m_defines);
   VertexShader()->LoadSource("gles310_yuv2rgb.vert");
   PixelShader()->InsertSource("gles_tonemap.frag", "void main()");
+  PixelShader()->InsertSource("gles_dither_uniforms.frag", "void main()");
+  PixelShader()->InsertSource("gles_dither_body.frag", "fragColor");
 }
 
 YUV2RGBFilterShader::~YUV2RGBFilterShader()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -338,7 +338,7 @@ YUV2RGBFilterShader::YUV2RGBFilterShader(EShaderFormat format,
   VertexShader()->LoadSource("gles310_yuv2rgb.vert");
   PixelShader()->InsertSource("gles_tonemap.frag", "void main()");
   PixelShader()->InsertSource("gles_dither_uniforms.frag", "void main()");
-  PixelShader()->InsertSource("gles_dither_body.frag", "fragColor");
+  PixelShader()->InsertSource("gles_dither_body.frag", "fragColor = rgb");
 }
 
 YUV2RGBFilterShader::~YUV2RGBFilterShader()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h
@@ -30,7 +30,8 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
                           AVColorPrimaries dst,
                           AVColorPrimaries src,
                           bool toneMap,
-                          ETONEMAPMETHOD toneMapMethod);
+                          ETONEMAPMETHOD toneMapMethod,
+                          bool dither = false);
     ~BaseYUV2RGBGLSLShader() override;
     void SetField(int field) { m_field = field; }
     void SetWidth(int w) { m_width = w; }
@@ -40,6 +41,10 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
     void SetBlack(float black) { m_black = black; }
     void SetContrast(float contrast) { m_contrast = contrast; }
     void SetConvertFullColorRange(bool convertFullRange) { m_convertFullRange = convertFullRange; }
+    void SetDitherUniforms(bool enabled,
+                           GLuint ditherTex,
+                           unsigned int ditherDepth,
+                           int ditherSize);
     void SetDisplayMetadata(bool hasDisplayMetadata,
                             const AVMasteringDisplayMetadata& displayMetadata,
                             bool hasLightMetadata,
@@ -107,6 +112,17 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
     GLfloat m_alpha{1.0f};
 
     bool m_convertFullRange;
+
+    // dithering
+    bool m_dither{false};
+    bool m_ditherEnabled{false};
+    GLint m_hDitherEnabled{-1};
+    GLint m_hDither{-1};
+    GLint m_hDitherQuant{-1};
+    GLint m_hDitherSize{-1};
+    GLuint m_ditherTex{0};
+    unsigned int m_ditherDepth{0};
+    int m_ditherSize{0};
   };
 
   class YUV2RGBProgressiveShader : public BaseYUV2RGBGLSLShader
@@ -116,7 +132,8 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
                              AVColorPrimaries dstPrimaries,
                              AVColorPrimaries srcPrimaries,
                              bool toneMap,
-                             ETONEMAPMETHOD toneMapMethod);
+                             ETONEMAPMETHOD toneMapMethod,
+                             bool dither = false);
   };
 
   class YUV2RGBBobShader : public BaseYUV2RGBGLSLShader
@@ -126,7 +143,8 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
                      AVColorPrimaries dstPrimaries,
                      AVColorPrimaries srcPrimaries,
                      bool toneMap,
-                     ETONEMAPMETHOD toneMapMethod);
+                     ETONEMAPMETHOD toneMapMethod,
+                     bool dither = false);
     void OnCompiledAndLinked() override;
     bool OnEnabled() override;
 
@@ -143,7 +161,8 @@ class BaseYUV2RGBGLSLShader : public CGLSLShaderProgram
                         AVColorPrimaries srcPrimaries,
                         bool toneMap,
                         ETONEMAPMETHOD toneMapMethod,
-                        ESCALINGMETHOD method);
+                        ESCALINGMETHOD method,
+                        bool dither = false);
     ~YUV2RGBFilterShader() override;
 
   protected:

--- a/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp
@@ -189,6 +189,9 @@ bool CRendererBase::Configure(const VideoPicture& picture, float fps, unsigned o
   m_renderOrientation = orientation;
 
   std::tie(m_useDithering, m_ditherDepth) = DX::Windowing()->GetDitherSettings();
+  // TODO: DX does not support Auto dithering yet; treat as 8-bit (previous default)
+  if (m_ditherDepth == 0)
+    m_ditherDepth = 8;
 
   m_lastHdr10 = {};
   m_HdrType = HDR_TYPE::HDR_INVALID;


### PR DESCRIPTION
## Description

Add ordered Bayer matrix dithering to the GLES renderer, matching the existing GL dithering capability. This introduces an Auto dithering mode that intelligently enables dithering only when the video processing pipeline would benefit from it. Add 10-bit dithering where it makes sense (see below).

Depends on #28070 (GLES HQ scalers).

_Auto Dithering_

The new default dither depth setting is "Auto", which evaluates four conditions per-video to decide whether dithering is needed:

1. Range mismatch -- source limited/full range differs from display output range
2. Bit depth reduction -- source bit depth exceeds the display output depth (e.g. 10-bit content on an 8-bit display)
3. HDR tone mapping -- tone mapping is active, which introduces quantization
4. Downscaling -- video is being downscaled beyond the hqscalers threshold (uses the same `ScalingAboveThreshold()` check as HQ scaler gating)

When Auto is selected, the dither depth is determined by the display: 8-bit on SDR displays (using `IsHDRDisplay()` as a proxy, since non-HDR displays are effectively 8-bit regardless of the framebuffer format) and the actual framebuffer depth (GL_RED_BITS) on HDR displays. This has the effect of introducing 10-bit dithering. Decided against making 10-bit a separate setting and instead foldered into the Auto setting.

Shaders are always compiled with `XBMC_DITHER` support when dithering is enabled. A `m_ditherEnabled` uniform controls whether dithering is applied at runtime, avoiding shader recompilation when the Auto decision changes.

GL and DX compatibility

The Auto setting (value 0) is visible on all platforms. On GL and DX, which do not yet implement Auto dithering logic, selecting Auto silently falls back to 8-bit dithering (the previous default). This is a safe no-op change for those renderers until Auto support is added there.

Design differences from GL

The GL renderer's dithering uses `GLSLOutput`, a shared output stage class that bundles dithering with color management (ICC/3D LUT). Rather than porting `GLSLOutput` to GLES -- which would pull in color management infrastructure that GLES doesn't yet support -- this implementation adds dithering directly to the existing GLES shader pipeline via InsertSource shader fragments. This keeps the change minimal and avoids coupling dithering to a future CMS port.

The Auto mode is entirely new and has no GL equivalent. GL's dithering always runs at a fixed bit depth. Auto was designed for GLES-first because embedded devices have more varied display capabilities (8-bit TVs, 10-bit panels, mixed SDR/HDR) and benefit most from adaptive dithering.

Implementation

- Dither texture: 16x16 ordered Bayer matrix stored as GL_R16_EXT on texture unit 3, with a runtime `GL_EXT_texture_norm16` capability check
- Settings: `videoscreen.ditherdepth` changed from spinner (2-8) to options list (Auto, 2-8 bit)
- New shader fragments: `gles_dither_uniforms.frag` and `gles_dither_body.frag`, inserted into both the YUV2RGB and convolution filter shaders via InsertSource
- `ScalingAboveThreshold()` extracted from `Supports()` for reuse by both HQ scaler gating and dither Auto logic; returns the scale factor (< 1.0 = downscale, > 1.0 = upscale, 0 = below threshold)

## Motivation and context

The GL renderer has had dithering for years but GLES never got it. On embedded GLES devices (RPi, x86 LE?, Amlogic, etc.) color banding is visible in gradients, especially with limited-range content, tone-mapped HDR, or when downscaling 4K to 1080p. This brings GLES to feature parity with GL for dithering.

The Auto mode is new and unique to GLES -- previously the only option was a fixed bit depth (default 8). Auto avoids unnecessary dithering overhead when the pipeline would not benefit from it, and automatically adapts the dither depth to the display capability.

## How has this been tested?

Tested on Intel NUC (N250 ADL-N, GBM/GLES and GBM/GL)

- SDR 8-bit on HDR display (4K): Auto dither off -- no triggers active. Correct.
- SDR 8-bit on HDR display (upscaled 1080p to 4K): Auto dither off -- upscaling, no downscale trigger. Correct.
- HDR 10-bit on SDR display (4K, forced SDR): Auto dither on -- bit depth reduction (10 > 8) + tone mapping. depth=8. Correct.
- HDR 10-bit downscaled to 1080p on SDR display: Auto dither on -- downscaling + bit depth reduction + tone mapping. depth=8. Correct.
- SDR 8-bit limited-range on full-range output: Auto dither on -- range mismatch. depth=8. Correct.
- HDR 10-bit on HDR display (4K, passthrough): Auto dither off -- no triggers (10-bit source, 10-bit display, no tone map, no scaling). Correct.
- GL build: verified Auto (0) silently becomes 8-bit, no crash, video plays correctly.

What is the effect on users?

GLES users gain access to video dithering to reduce color banding. The new Auto default intelligently enables dithering only when needed, with no user configuration required. Existing GL and DX users see the new Auto option in settings but behavior is unchanged (Auto falls back to 8-bit, the previous default).

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
