### PR TITLE
Fix PAPlayer seeking with inputstream addons (CDVDDemuxClient::GetStreamLength)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -704,6 +704,21 @@ bool CDVDDemuxClient::SeekTime(double timems, bool backwards, double *startpts)
   return false;
 }
 
+int CDVDDemuxClient::GetStreamLength()
+{
+  if (m_pInput)
+  {
+    CDVDInputStream::IDisplayTime* pDisplayTime = m_pInput->GetIDisplayTime();
+    if (pDisplayTime)
+    {
+      int total = pDisplayTime->GetTotalTime();
+      if (total > 0)
+        return total;
+    }
+  }
+  return 0;
+}
+
 void CDVDDemuxClient::SetSpeed (int speed)
 {
   if (m_IDemux)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -43,6 +43,7 @@ public:
   void EnableStream(int id, bool enable) override;
   void OpenStream(int id) override;
   void SetVideoResolution(unsigned int width, unsigned int height) override;
+  int GetStreamLength() override;
 
 protected:
   void RequestStreams();


### PR DESCRIPTION
## Description

Override `CDVDDemuxClient::GetStreamLength()` to query the inputstream addon's `IDisplayTime::GetTotalTime()` instead of returning the base class default of 0.

## Motivation and context

PAPlayer doesn't support tempo (playback speed adjustment). 

For the purpose of creating an AudioBookShelf [add-on](https://github.com/kontell/KoShelf), I added tempo adjustment to an inputstream.ffmpegdirect [fork](https://github.com/kontell/inputstream.tempo). 

This gives PAPlayer tempo adjustment, but seeking is broken.

When PAPlayer uses an inputstream addon that provides its own demuxer (`INPUTSTREAM_SUPPORTS_IDEMUX`), seeking always goes to position 0.

`CDVDDemuxClient` does not override `GetStreamLength()`, inheriting `return 0` from `CDVDDemux`. During `VideoPlayerCodec::Init()`, `m_TotalTime` is set from this:

```cpp
m_TotalTime = m_pDemuxer->GetStreamLength();  // always 0
```

Then `CAudioDecoder::Seek(time)` clamps every seek target to `m_TotalTime`:

```cpp
if (time > m_codec->m_TotalTime) time = m_codec->m_TotalTime;  // clamps to 0
```

VideoPlayer is unaffected because it calls `DemuxSeekTime()` directly without this clamping.

The fix queries the inputstream via `m_pInput->GetIDisplayTime()->GetTotalTime()` — the same `IDisplayTime` interface already used by `CDVDDemuxClient` for display time updates (line 357).

Input stream addons need to declare INPUTSTREAM_SUPPORTS_IDISPLAYTIME in their capabilities for GetStreamLength() to return a non-zero value.

## How has this been tested?

Tested with a custom inputstream addon (based on inputstream.ffmpegdirect) used through PAPlayer for audiobook playback. Before the fix, all seeks via the OSD and `player.seekTime()` went to position 0. 

With the fix seeking works as expected.

## What is the effect on users?

Seeking now works correctly for audio content played through PAPlayer when an inputstream addon provides the demuxer. Previously all seeks silently went to position 0.

This facilitates an essential feature for audio book & podcast playback through PAPlayer.

No effect on VideoPlayer (it doesn't use `GetStreamLength()` for seek clamping) or PAPlayer without inputstream addons.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

Milestone & label needs to be added.

