### PR TITLE
[NFS] replace nfs_create with nfs_open2

### DIFF
--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -942,18 +942,12 @@ bool CNFSFile::OpenForWrite(const CURL& url, bool bOverWrite)
   {
     CLog::Log(LOGWARNING, "FileNFS::OpenForWrite() called with overwriting enabled! - {}",
               filename);
-    //create file with proper permissions
-    ret = nfs_create(m_pNfsContext, filename.c_str(), O_RDWR | O_EXCL,
-                     S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH, &m_pFileHandle);
-    //if file was created the file handle isn't valid ... so close it and open later
-    if(ret == 0)
-    {
-      nfs_close(m_pNfsContext,m_pFileHandle);
-      m_pFileHandle = NULL;
-    }
   }
 
-  ret = nfs_open(m_pNfsContext, filename.c_str(), O_RDWR, &m_pFileHandle);
+  // nfs_open2 handles both creation and open atomically;
+  const int flags = bOverWrite ? O_CREAT | O_RDWR | O_EXCL : O_RDWR;
+  const int mode = bOverWrite ? S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH : 0;
+  ret = nfs_open2(m_pNfsContext, filename.c_str(), flags, mode, &m_pFileHandle);
 
   if (ret || m_pFileHandle == NULL)
   {


### PR DESCRIPTION
## Description
A change introduced in https://github.com/xbmc/xbmc/pull/28152 broke builds against libnfs 6.x since the nfs_create function was removed in libnfs v6. I've changed the fix to use nfs_open2 instead which builds against libnfs 5.x and 6.x.

Since creation and opening happen atomically, a minor optimisation was made to prevent an unnecessary close and reopen of the file.

## Motivation and context
Fixes #28164 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Successfully built a armeabi-v7a Android build against libnfs 5.0.2. And successfully copied a file across to an NFSv4 share.

Build against libnfs 6.0.2 and a test against an NFSv3 share is untested.

## What is the effect on users?
There should be no functional changes visible from a users perspective.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
