### PR TITLE
Clear addon setting logspam for visibility conditions

### DIFF
--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -313,7 +313,7 @@ void CSetting::OnSettingPropertyChanged(const std::shared_ptr<const CSetting>& s
 
 void CSetting::Copy(const CSetting &setting)
 {
-  SetVisible(setting.IsVisible());
+  SetVisible(setting.GetVisible());
   SetLabel(setting.GetLabel());
   SetHelp(setting.GetHelp());
   SetRequirementsMet(setting.MeetsRequirements());

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -89,7 +89,9 @@ public:
   void MakeReference(const std::string& referencedId = "");
 
   bool GetVisible() const { return ISetting::IsVisible(); }
-  // overrides of ISetting
+  /*!
+    \brief Returns whether the setting is visible. This override also checks the setting's dependencies to determine the visibility of the setting.
+  */
   bool IsVisible() const override;
 
   // implementation of ISettingCallback


### PR DESCRIPTION
## Description
Copy the Visible value when copying settings objects rather than evaluating visibility. Evaluating visibility can involve dependencies that don't exist yet when a setting is copied, which produces the unexpected log message.

## Motivation and context

```
warning <CSettingDependencyCondition>: unable to check condition on unknown setting "enable_tag_whitelist"
warning <general>: Skipped 3 duplicate messages..
```

Reduce incorrect logspam.

This has been around for a long time, the classic workaround is for add-on devs to use an enabled/disabled condition instead if it is annoying enough.

The latest version of https://github.com/xbmc/metadata.themoviedb.org.python has an example.

## How has this been tested?
Light manual testing.

## What is the effect on users?
Cleaner logs / add-on devs can use the "visibility" condition if it makes sense.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
