### PR TITLE
[cmake] FindBluray setup env for install command step

### DIFF
--- a/cmake/modules/FindBluray.cmake
+++ b/cmake/modules/FindBluray.cmake
@@ -130,7 +130,9 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     set(BUILD_COMMAND ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_dev_env}
                       ${build_env_mod}
                       ${NINJA_EXECUTABLE} -C ./build)
-    set(INSTALL_COMMAND ${NINJA_EXECUTABLE} -C ./build install)
+    set(INSTALL_COMMAND ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_dev_env}
+                        ${build_env_mod}
+                        ${NINJA_EXECUTABLE} -C ./build install)
     set(BUILD_IN_SOURCE 1)
 
     BUILD_DEP_TARGET()


### PR DESCRIPTION
## Description
Windows requires java env to be populated through to install step, as meson is running a jar fixup step as part of the install.

## Motivation and context
Reported build failures on windows

```
  BUILD SUCCESSFUL

  Total time: 2 seconds

  [1/2] Installing files
  Traceback (most recent call last):
    File "mesonbuild\mesonmain.py", line 193, in run
    File "mesonbuild\minstall.py", line 888, in run
    File "mesonbuild\minstall.py", line 563, in do_install
    File "mesonbuild\minstall.py", line 788, in install_targets
    File "mesonbuild\minstall.py", line 348, in fix_rpath
    File "mesonbuild\scripts\depfixer.py", line 467, in fix_rpath
      fix_jar(fname)
    File "mesonbuild\scripts\depfixer.py", line 443, in fix_jar
      subprocess.check_call(['jar', 'xf', fname, 'META-INF/MANIFEST.MF'])
    File "subprocess.py", line 408, in check_call
    File "subprocess.py", line 389, in call
    File "subprocess.py", line 1026, in __init__
    File "subprocess.py", line 1538, in _execute_child
  FileNotFoundError: [WinError 2] The system cannot find the file specified
  Installing src\bluray.dll to C:/source/repos/xbmc/project/BuildDependencies/x64\bin
  Installing src/bluray.lib to C:/source/repos/xbmc/project/BuildDependencies/x64\lib
  Installing src/libbluray/bdj\libbluray-j2se-1.4.1.jar to C:/source/repos/xbmc/project/BuildDependencies/x
  64\share/java

CUSTOMBUILD : error : Unhandled python OSError. This is probably not a Meson bug, but an issue with your build environm
ent. [C:\source\repos\xbmc\build\build-libbluray.vcxproj]
  FAILED: meson-internal__install
  "C:\source\repos\xbmc\project\BuildDependencies\tools\bin\Meson\meson.exe" "install" "--no-rebuild"
  ninja: build stopped: subcommand failed.
C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(254,5): e
rror MSB8066: Custom build for 'C:\source\repos\xbmc\build\CMakeFiles\68a8bedce630f4023d3484be1bac1740\buil
d-libbluray-download.rule;C:\source\repos\xbmc\build\CMakeFiles\68a8bedce630f4023d3484be1bac1740\build-libb
luray-update.rule;C:\source\repos\xbmc\build\CMakeFiles\68a8bedce630f4023d3484be1bac1740\build-libbluray-pa
tch.rule;C:\source\repos\xbmc\build\CMakeFiles\68a8bedce630f4023d3484be1bac1740\build-libbluray-configure.r
ule;C:\source\repos\xbmc\build\CMakeFiles\68a8bedce630f4023d3484be1bac1740\build-libbluray-build.rule;C:\source\repos\xbmc\build\CMakeFiles\68a8bedce630f4023d3484be1bac1740\build-libbluray-install.rule;C:\source\repos\xbmc\build\CMakeFiles\55ebbba2f92bb6110206c9ef57b4f32f\build-libbluray-complete.rule;C:\sou
rce\repos\xbmc\build\CMakeFiles\183368610c3a92a2b0b90f7e1aaea745\build-libbluray.rule;C:\source\repos\xbmc\
CMakeLists.txt' exited with code 1. [C:\source\repos\xbmc\build\build-libbluray.vcxproj]
```

## How has this been tested?
Windows build x64 with JDK 21, no env changes prior

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
