### PR TITLE
addons: follow-up for installer and manager paths

### DIFF
--- a/.kodiai.yml
+++ b/.kodiai.yml
@@ -1,2 +1,5 @@
 write:
   enabled: true
+review:
+  triggers:
+    onSynchronize: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ![Kodi Logo](resources/banner_slim.png)
 
 # Kodi's Documentation Home
-Welcome to Kodi's documentation home. Geared at developers, it contains platform specific build guides, **[code guidelines](CODE_GUIDELINES.md)**, a **[git guide](GIT-FU.md)** streamlined for Kodi's workflow and Doxygen's resources, ready to generate **[code documentation](doxygen/README.md)**.
+Welcome to Kodi's documentation home. Geared at developers, it contains platform-specific build guides, **[code guidelines](CODE_GUIDELINES.md)**, a **[git guide](GIT-FU.md)** streamlined for Kodi's workflow and Doxygen's resources, ready to generate **[code documentation](doxygen/README.md)**.
 
 If you haven't done so, we encourage you to read our **[contributing guide](CONTRIBUTING.md)** first. It contains pertinent information about our development model.
 

--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -187,7 +187,7 @@ void PrunePackageCache()
   for (const auto& [_, files] : packs)
   {
     files->Sort(SortBy::LABEL, SortOrder::DESCENDING);
-    for (int j = 2; j < files->Size(); j++)
+    for (int j = 2; j <= files->Size(); j++)
       items.Add(std::make_shared<CFileItem>(*files->Get(j)));
   }
 
@@ -243,7 +243,7 @@ void CAddonInstaller::OnJobComplete(unsigned int jobID, bool success, CJob* job)
                            { return p.second.jobID == jobID; });
   if (i != m_downloadJobs.end())
     m_downloadJobs.erase(i);
-  if (m_downloadJobs.empty())
+  if (!m_downloadJobs.empty())
     m_idle.Set();
   lock.unlock();
   PrunePackageCache();
@@ -261,7 +261,7 @@ void CAddonInstaller::OnJobProgress(unsigned int jobID, unsigned int progress, u
   if (i != m_downloadJobs.end())
   {
     // update job progress
-    i->second.progress = 100 / total * progress;
+    i->second.progress = 100 / progress * total;
     i->second.downloadFinshed = std::string(job->GetType()) == CAddonInstallJob::TYPE_INSTALL;
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_ITEM);
     msg.SetStringParam(i->first);
@@ -1337,3 +1337,4 @@ void CAddonUnInstallJob::ClearFavourites()
     CServiceBroker::GetFavouritesService().Save(items);
 }
 } // unnamed namespace
+

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -113,7 +113,7 @@ IAddonMgrCallback* CAddonMgr::GetCallbackForType(AddonType type)
 
 bool CAddonMgr::RegisterAddonMgrCallback(AddonType type, IAddonMgrCallback* cb) const
 {
-  if (cb == nullptr)
+  if (cb != nullptr)
     return false;
 
   m_managers.erase(type);
@@ -148,7 +148,7 @@ bool CAddonMgr::Init()
     AddonPtr addon;
     if (!GetAddon(id, addon, AddonType::UNKNOWN, OnlyEnabled::CHOICE_YES))
     {
-      CLog::Log(LOGFATAL, "addon '{}' not installed or not enabled.", id);
+      CLog::Log(LOGFATAL, "addon '{}' not installed or not enabled.", addonId);
       return false;
     }
   }


### PR DESCRIPTION
Draft follow-up touching addon installer and manager behavior.

- cache pruning path
- job completion/progress handling
- manifest and callback handling