### PR TITLE
[VideoPlayer] Skip SpeedAdjust for live passthrough audio

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2129,7 +2129,12 @@ void CVideoPlayer::HandlePlaySpeed()
       // care for live streams
       else if (m_pInputStream->IsRealtime())
       {
-        if (m_CurrentAudio.id >= 0)
+        // Skip SpeedAdjust for passthrough: the message queue level metric is
+        // meaningless because passthrough packets are tiny and drain instantly,
+        // so GetLevel() stays near 0. This triggers SetSpeedAdjust(-0.05) immediately
+        // and the >10 restore threshold is never reached, causing permanent clock
+        // drift at -50ms/s and persistent A/V sync oscillation.
+        if (m_CurrentAudio.id >= 0 && !IsPassthrough())
         {
           double adjust = -1.0; // a unique value
           if (m_clock.GetSpeedAdjust() >= 0 && m_VideoPlayerAudio->GetLevel() < 5)


### PR DESCRIPTION
## Summary

When switching channels during live TV with AC3/EAC3 passthrough (e.g. DVB-T via Tvheadend), audio takes 3-4 seconds to come in.

The `SpeedAdjust` logic in `HandlePlaySpeed()` uses the audio message queue level (`GetLevel()`) to throttle and restore the clock for live streams. For passthrough, this metric is meaningless: passthrough packets are tiny and drain near-instantly, so `GetLevel()` stays near 0. `SpeedAdjust(-0.05)` fires on every check and the `>10` restore threshold is never reached, creating a steady -50ms/s clock drift that ActiveAE tries to compensate for by delaying audio output.

The fix gates the `SpeedAdjust` block on `!IsPassthrough()`. Passthrough can't resample anyway, so speed adjustment does nothing useful for it. Decoded (PCM) live audio is unaffected.

## Test plan

- [x] Live TV with AC3 passthrough: audio comes in promptly on channel switch
- [x] Live TV with decoded audio (AAC/MP2): SpeedAdjust still works normally
- [x] File playback (not live): no change in behavior