### PR TITLE
[MySQL] Avoid crash when the server is temporarily unavailable

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -232,24 +232,21 @@ int MysqlDatabase::connect(bool create_new)
   {
     disconnect();
 
-    conn = mysql_init(nullptr);
-    if (conn == nullptr)
-      return DB_CONNECTION_NONE;
-
-    if (!key.empty() || !cert.empty() || !ca.empty() || !capath.empty() || !ciphers.empty())
+    if (!conn)
     {
-      mysql_ssl_set(conn, key.empty() ? nullptr : key.c_str(),
-                    cert.empty() ? nullptr : cert.c_str(), ca.empty() ? nullptr : ca.c_str(),
-                    capath.empty() ? nullptr : capath.c_str(),
-                    ciphers.empty() ? nullptr : ciphers.c_str());
+      conn = mysql_init(conn);
+      if (!key.empty() || !cert.empty() || !ca.empty() || !capath.empty() || !ciphers.empty())
+      {
+        mysql_ssl_set(conn, key.empty() ? nullptr : key.c_str(),
+                      cert.empty() ? nullptr : cert.c_str(), ca.empty() ? nullptr : ca.c_str(),
+                      capath.empty() ? nullptr : capath.c_str(),
+                      ciphers.empty() ? nullptr : ciphers.c_str());
+      }
+      mysql_options(conn, MYSQL_OPT_CONNECT_TIMEOUT, &connect_timeout);
     }
-    mysql_options(conn, MYSQL_OPT_CONNECT_TIMEOUT, &connect_timeout);
 
     if (!CWakeOnAccess::GetInstance().WakeUpHost(host, "MySQL : " + db))
-    {
-      disconnect();
       return DB_CONNECTION_NONE;
-    }
 
     // establish connection with just user credentials
     if (mysql_real_connect(conn, host.c_str(), login.c_str(), passwd.c_str(), nullptr,
@@ -340,13 +337,13 @@ int MysqlDatabase::connect(bool create_new)
 
     CLog::Log(LOGERROR, "Unable to open database: {} [{}]({})", db, mysql_errno(conn),
               mysql_error(conn));
+
+    return DB_CONNECTION_NONE;
   }
   catch (...)
   {
     CLog::Log(LOGERROR, "Unable to open database: {} ({})", db, GetLastError());
   }
-
-  disconnect();
   return DB_CONNECTION_NONE;
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

While technically correct, 4e40267eb769b9cc9e15c47d3318f193b9253ab7 caused a crash when the server is temporarily  unavailable because of inadequate error handling in the rest of the code.

The `PrepareSQL` function for MySQL databases uses the `mysql_real_escape_string()` function of the mariadb client lib, which requires a valid MYSQL* pointer. The optimization made the pointer null earlier, causing a crash when PrepareSQL was used with an unavailable server.
PrepareSQL shouldn't even be called when the server is not available.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Kodi crashes when the network or MySQL/MariaDB server is not available some time after the initial startup checks.
That was not happening with 21.3 or 22 alpha 2.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Start Kodi with network and db available, unplug the network, navigate in Kodi > no crash

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Restore alpha2 behavior, no crash when the db server is temporarily unavailable.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
