### PR TITLE
[Android] Remove unnecessary constructors in XBMCMainView

### DIFF
--- a/tools/android/packaging/xbmc/src/XBMCMainView.java.in
+++ b/tools/android/packaging/xbmc/src/XBMCMainView.java.in
@@ -2,7 +2,6 @@ package @APP_PACKAGE@;
 
 import android.content.Context;
 import android.graphics.PixelFormat;
-import android.util.AttributeSet;
 import android.util.Log;
 import android.view.SurfaceView;
 import android.view.SurfaceHolder;
@@ -32,21 +31,6 @@ public class XBMCMainView extends SurfaceView implements SurfaceHolder.Callback
     Log.d(TAG, "XBMCMainView: Created");
 }
 
-  public XBMCMainView(Context context, AttributeSet attrs, int defStyle)
-  {
-    super(context, attrs, defStyle);
-    setZOrderOnTop(true);
-    getHolder().addCallback(this);
-    getHolder().setFormat(PixelFormat.TRANSPARENT);
-
-    Log.d(TAG, "XBMCMainView: Created");
-  }
-
-  public XBMCMainView(Context context, AttributeSet attrs)
-  {
-    this(context, attrs, 0);
-  }
-
   @Override
   public void surfaceCreated(SurfaceHolder holder)
   {
@@ -57,8 +41,7 @@ public class XBMCMainView extends SurfaceView implements SurfaceHolder.Callback
   }
 
   @Override
-  public void surfaceChanged(SurfaceHolder holder, int format, int width,
-                             int height)
+  public void surfaceChanged(SurfaceHolder holder, int format, int width, int height)
   {
     if (holder != getHolder())
       return;


### PR DESCRIPTION
## Description
Clean up unused constructors in `XBMCMainView` class.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
