### PR TITLE
Fix static compile patch python3 dependencies

### DIFF
--- a/tools/depends/target/python3/static-compile.patch
+++ b/tools/depends/target/python3/static-compile.patch
@@ -1,15 +1,15 @@
 --- a/Makefile.pre.in
 +++ b/Makefile.pre.in
-@@ -3396,3 +3396,12 @@
- # Local Variables:
- # mode: makefile
- # End:
-+
+@@ -701,6 +701,12 @@ LIBHACL_HMAC_OBJS= \
+ LIBHACL_HMAC_LIB_STATIC=Modules/_hacl/libHacl_HMAC.a
+ LIBHACL_HMAC_LIB_SHARED=$(LIBHACL_HMAC_OBJS)
+ 
 +LIBHACL_BLAKE2_LIB_SHARED=
 +LIBHACL_SHA1_LIB_SHARED=
 +LIBHACL_SHA3_LIB_SHARED=
 +LIBHACL_MD5_LIB_SHARED=
++LIBRARY_OBJS_OMIT_FROZEN += $(LIBHACL_HMAC_OBJS)
 +
-+$(LIBRARY): $(LIBRARY_OBJS)
-+		-rm -f $@
-+		$(AR) $(ARFLAGS) $@ $(LIBRARY_OBJS) $(LIBHACL_HMAC_OBJS)
+ LIBHACL_HEADERS= \
+ 		Modules/_hacl/include/krml/FStar_UInt128_Verified.h \
+ 		Modules/_hacl/include/krml/FStar_UInt_8_16_32_64.h \


### PR DESCRIPTION
Missing dependencies in the patch