### PR TITLE
[RegeExp] Fix incorrect bounds check in IsValidSubNumber() and add tests.

### DIFF
--- a/xbmc/utils/RegExp.cpp
+++ b/xbmc/utils/RegExp.cpp
@@ -575,7 +575,7 @@ void CRegExp::Cleanup()
 
 inline bool CRegExp::IsValidSubNumber(int iSub) const
 {
-  return iSub >= 0 && iSub <= m_iMatchCount && iSub <= m_MaxNumOfBackrefrences;
+  return iSub >= 0 && iSub < m_iMatchCount && iSub <= m_MaxNumOfBackrefrences;
 }
 
 

--- a/xbmc/utils/test/TestRegExp.cpp
+++ b/xbmc/utils/test/TestRegExp.cpp
@@ -6,9 +6,6 @@
  *  See LICENSES/README.md for more information.
  */
 
-/** @todo gtest/gtest.h needs to come in before utils/RegExp.h.
- * Investigate why.
- */
 #include "CompileInfo.h"
 #include "ServiceBroker.h"
 #include "filesystem/File.h"
@@ -91,13 +88,48 @@ TEST(TestRegExp, GetSubStart)
   EXPECT_EQ(5, regex.GetSubStart(2));
 }
 
-TEST(TestRegExp, GetCaptureTotal)
+TEST(TestRegExp, GetSubLength)
 {
   CRegExp regex;
 
   EXPECT_TRUE(regex.RegComp("^(Test)\\s*(.*)\\."));
   EXPECT_EQ(0, regex.RegFind("Test string."));
+  EXPECT_EQ(12, regex.GetSubLength(0));
+  EXPECT_EQ(4, regex.GetSubLength(1));
+  EXPECT_EQ(6, regex.GetSubLength(2));
+}
+
+TEST(TestRegExp, GetCaptureTotal)
+{
+  CRegExp regex;
+
+  // Zero capturing groups
+  EXPECT_TRUE(regex.RegComp("abc"));
+  EXPECT_EQ(0, regex.GetCaptureTotal());
+
+  // 1 capturing group
+  EXPECT_TRUE(regex.RegComp("(abc)"));
+  EXPECT_EQ(1, regex.GetCaptureTotal());
+
+  // 2 capturing groups
+  EXPECT_TRUE(regex.RegComp("^(Test)\\s*(.*)\\."));
   EXPECT_EQ(2, regex.GetCaptureTotal());
+
+  // Mixed: 2 capturing, 2 non-capturing
+  EXPECT_TRUE(regex.RegComp("(a)(?:b)(c)(?:d)"));
+  EXPECT_EQ(2, regex.GetCaptureTotal());
+
+  // Named groups still count as capturing
+  EXPECT_TRUE(regex.RegComp("(?<first>a)(?<second>b)"));
+  EXPECT_EQ(2, regex.GetCaptureTotal());
+
+  // Nested groups
+  EXPECT_TRUE(regex.RegComp("((a)(b))"));
+  EXPECT_EQ(3, regex.GetCaptureTotal());
+
+  // Before compilation
+  CRegExp uncompiled;
+  EXPECT_EQ(-1, uncompiled.GetCaptureTotal());
 }
 
 TEST(TestRegExp, GetMatch)
@@ -127,6 +159,104 @@ TEST(TestRegExp, operatorEqual)
   EXPECT_TRUE(regex.RegComp("^(?<first>Test)\\s*(?<second>.*)\\."));
   regexcopy = regex;
   EXPECT_EQ(0, regexcopy.RegFind("Test string."));
+}
+
+TEST(TestRegExp, BoundsChecks)
+{
+  CRegExp regex;
+
+  EXPECT_TRUE(regex.RegComp("^(Test)\\s*(.*)\\."));
+  EXPECT_EQ(0, regex.RegFind("Test string."));
+
+  // One past last capturing group (the off-by-one slot)
+  EXPECT_TRUE(regex.GetMatch(3).empty());
+  EXPECT_EQ(-1, regex.GetSubStart(3));
+  EXPECT_EQ(-1, regex.GetSubLength(3));
+
+  // Further beyond
+  EXPECT_TRUE(regex.GetMatch(4).empty());
+  EXPECT_EQ(-1, regex.GetSubStart(4));
+  EXPECT_EQ(-1, regex.GetSubLength(4));
+
+  // At and beyond m_MaxNumOfBackrefrences (20)
+  EXPECT_TRUE(regex.GetMatch(CRegExp::m_MaxNumOfBackrefrences).empty());
+  EXPECT_EQ(-1, regex.GetSubStart(CRegExp::m_MaxNumOfBackrefrences));
+  EXPECT_EQ(-1, regex.GetSubLength(CRegExp::m_MaxNumOfBackrefrences));
+  EXPECT_TRUE(regex.GetMatch(CRegExp::m_MaxNumOfBackrefrences + 1).empty());
+  EXPECT_EQ(-1, regex.GetSubStart(CRegExp::m_MaxNumOfBackrefrences + 1));
+  EXPECT_EQ(-1, regex.GetSubLength(CRegExp::m_MaxNumOfBackrefrences + 1));
+
+  // Negative index
+  EXPECT_TRUE(regex.GetMatch(-1).empty());
+  EXPECT_EQ(-1, regex.GetSubStart(-1));
+  EXPECT_EQ(-1, regex.GetSubLength(-1));
+}
+
+// Non-capturing groups (?:...) must not inflate GetCaptureTotal
+TEST(TestRegExp, NonCapturingGroupsNotCounted)
+{
+  CRegExp regex;
+
+  // (?:...) is invisible to capture numbering
+  EXPECT_TRUE(regex.RegComp("S(\\d+)E(\\d+)(?:[^\\\\/]*)$"));
+  EXPECT_EQ(2, regex.GetCaptureTotal());
+
+  EXPECT_GE(regex.RegFind("S01E02_remainder"), 0);
+  EXPECT_STREQ("01", regex.GetMatch(1).c_str());
+  EXPECT_STREQ("02", regex.GetMatch(2).c_str());
+
+  // Group 3 doesn't exist — non-capturing group is not numbered
+  EXPECT_TRUE(regex.GetMatch(3).empty());
+  EXPECT_EQ(-1, regex.GetSubStart(3));
+}
+
+// Optional groups within pattern: unmatched groups should return empty/−1,
+// not stale data from a previous match
+TEST(TestRegExp, OptionalGroupUnmatched)
+{
+  CRegExp regex;
+
+  EXPECT_TRUE(regex.RegComp("(a)(b)?(c)?"));
+  EXPECT_EQ(3, regex.GetCaptureTotal());
+
+  // First match: all 3 groups participate
+  EXPECT_GE(regex.RegFind("abc"), 0);
+  EXPECT_STREQ("a", regex.GetMatch(1).c_str());
+  EXPECT_STREQ("b", regex.GetMatch(2).c_str());
+  EXPECT_STREQ("c", regex.GetMatch(3).c_str());
+
+  // Second match (same compiled pattern, reuses m_matchData): only group 1
+  EXPECT_GE(regex.RegFind("a"), 0);
+  EXPECT_STREQ("a", regex.GetMatch(1).c_str());
+
+  // Groups 2 and 3 did not participate — must NOT return stale "b"/"c"
+  EXPECT_TRUE(regex.GetMatch(2).empty());
+  EXPECT_TRUE(regex.GetMatch(3).empty());
+
+  // Beyond pattern — off-by-one slot
+  EXPECT_TRUE(regex.GetMatch(4).empty());
+  EXPECT_EQ(-1, regex.GetSubStart(4));
+  EXPECT_EQ(-1, regex.GetSubLength(4));
+}
+
+// Verify behavior before any match and after a failed match
+TEST(TestRegExp, GetMatchNoMatch)
+{
+  CRegExp regex;
+
+  EXPECT_TRUE(regex.RegComp("(a)(b)(c)"));
+
+  // Before any RegFind: m_bMatched is false, m_iMatchCount is 0
+  EXPECT_TRUE(regex.GetMatch(0).empty());
+  EXPECT_TRUE(regex.GetMatch(1).empty());
+  EXPECT_EQ(-1, regex.GetSubStart(0));
+
+  // After failed RegFind
+  EXPECT_EQ(-1, regex.RegFind("xyz"));
+  EXPECT_TRUE(regex.GetMatch(0).empty());
+  EXPECT_TRUE(regex.GetMatch(1).empty());
+  EXPECT_EQ(-1, regex.GetSubStart(0));
+  EXPECT_EQ(-1, regex.GetSubLength(0));
 }
 
 class TestRegExpLog : public testing::Test


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Looking at the pcre2 specs - https://www.pcre.org/current/doc/html/pcre2_match.html
`The return from pcre2_match() is one more than the highest numbered capturing pair that has been set`
This value is used to set `m_iMatchCount`

So the comparison should be `<` not `<=`

Interestinly GetSubCount() is correct:
` int GetSubCount() const { return m_iMatchCount - 1; } // PCRE returns the number of sub-patterns + 1`

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Discovered whilst investigating a crash in the forums - https://forum.kodi.tv/showthread.php?tid=384424&pid=3278941#pid3278941

The custom TV show regexs in advancedsettings only had 1 capture group, whereas the code in EnumerateEpisodes() expects 3.
There is a safety check in CRegExp - `IsValidSubNumber()` - but it wasn't catching it (due to the error above).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
