### PR TITLE
[addons] allow Win build with cygwin/MSYS (support for test purposes)

### DIFF
--- a/cmake/scripts/common/AddonHelpers.cmake
+++ b/cmake/scripts/common/AddonHelpers.cmake
@@ -14,6 +14,13 @@ else()
                     COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target package)
 endif()
 
+if(MINGW)
+  message(WARNING
+          "MSYS/MINGW generated add-ons are not supported for use in Kodi!\n"
+          "For compiler test purposes only!"
+         )
+endif()
+
 macro(add_cpack_workaround target version ext)
   if(NOT PACKAGE_DIR)
     set(PACKAGE_DIR "${CMAKE_INSTALL_PREFIX}/zips")
@@ -312,9 +319,11 @@ macro (build_addon target prefix libs)
                 COMPONENT ${target}-${${prefix}_VERSION}-${PLATFORM_TAG})
 
         # for debug builds also install the PDB file
-        install(FILES $<TARGET_PDB_FILE:${target}> DESTINATION ${target}
-                CONFIGURATIONS Debug RelWithDebInfo
-                COMPONENT ${target}-${${prefix}_VERSION}-${PLATFORM_TAG})
+        if(NOT MINGW)
+          install(FILES $<TARGET_PDB_FILE:${target}> DESTINATION ${target}
+                  CONFIGURATIONS Debug RelWithDebInfo
+                  COMPONENT ${target}-${${prefix}_VERSION}-${PLATFORM_TAG})
+        endif()
       endif()
       if(${prefix}_CUSTOM_BINARY)
         install(FILES ${LIBRARY_LOCATION} DESTINATION ${target} RENAME ${LIBRARY_FILENAME}


### PR DESCRIPTION
## Description

This adds the possibility to create a binary add-on on Windows with cygwin or with MSYS/MSYS2. As the required change is very small comes with this the support in.

To use it as this, **makes only sense for compiler test purposes**, as the created add-on depends to the libraries from there.

For this reason generate CMake then this warning about:
```
CMake Warning at build/build/depends/lib/kodi/AddonHelpers.cmake:18 (message):
  MSYS/MINGW generated add-ons are not supported for use in Kodi!

  For compiler test purposes only!
Call Stack (most recent call first):
  build/build/depends/lib/kodi/KodiConfig.cmake:33 (include)
  CMakeLists.txt:6 (find_package)
```

**The request can also be rejected; I just thought it would be nice to have.**

Here what `ldd` bring about (to see why only for tests and not usable):
```
$ ldd C:/Dev/KODI/kodi/build/Debug/addons/screensaver.matrixtrails/screensaver.matrixtrails.dll
        ntdll.dll => /c/Windows/SYSTEM32/ntdll.dll (0x7ffe252d0000)
        KERNEL32.DLL => /c/Windows/System32/KERNEL32.DLL (0x7ffe24690000)
        KERNELBASE.dll => /c/Windows/System32/KERNELBASE.dll (0x7ffe22640000)
        msvcrt.dll => /c/Windows/System32/msvcrt.dll (0x7ffe23040000)
        GDI32.dll => /c/Windows/System32/GDI32.dll (0x7ffe24090000)
        win32u.dll => /c/Windows/System32/win32u.dll (0x7ffe22a20000)
        dxgi.dll => /c/Windows/SYSTEM32/dxgi.dll (0x7ffe1fc00000)
        gdi32full.dll => /c/Windows/System32/gdi32full.dll (0x7ffe223e0000)
        d3d9.dll => /c/Windows/SYSTEM32/d3d9.dll (0x7ffdb6190000)
        msvcp_win.dll => /c/Windows/System32/msvcp_win.dll (0x7ffe22ce0000)
        msvcp_win.dll => /c/Windows/System32/msvcp_win.dll (0x1860000)
        sechost.dll => /c/Windows/System32/sechost.dll (0x7ffe24c20000)
        libgcc_s_seh-1.dll => /mingw64/bin/libgcc_s_seh-1.dll (0x7ffe0a600000)
        ucrtbase.dll => /c/Windows/System32/ucrtbase.dll (0x7ffe22bc0000)
        ucrtbase.dll => /c/Windows/System32/ucrtbase.dll (0x1860000)
        bcrypt.dll => /c/Windows/System32/bcrypt.dll (0x7ffe22d80000)
        USER32.dll => /c/Windows/System32/USER32.dll (0x7ffe244d0000)
        combase.dll => /c/Windows/System32/combase.dll (0x7ffe240c0000)
        RPCRT4.dll => /c/Windows/System32/RPCRT4.dll (0x7ffe231d0000)
        libwinpthread-1.dll => /mingw64/bin/libwinpthread-1.dll (0x7ffe0a5a0000)
        dwmapi.dll => /c/Windows/SYSTEM32/dwmapi.dll (0x7ffe1fd10000)
        libstdc++-6.dll => /mingw64/bin/libstdc++-6.dll (0x7ffd36cd0000)
        dxcore.dll => /c/Windows/SYSTEM32/dxcore.dll (0x7ffe1fa70000)
        IMM32.DLL => /c/Windows/System32/IMM32.DLL (0x7ffe22ff0000)
        CRYPTBASE.DLL => /c/Windows/SYSTEM32/CRYPTBASE.DLL (0x7ffe21c60000)
        bcryptPrimitives.dll => /c/Windows/System32/bcryptPrimitives.dll (0x7ffe225c0000)
```

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
To allow by code writes on Windows a quick test on POSIX based compilers.
On end can be then the correct builds and tests on related platforms performed. And maybe then more less changes and compile fixes needed.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
With add-ons build and with Kodi build

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
