### PR TITLE
[Android] Unused member variable definitions in MediaCodec

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.h
@@ -37,17 +37,7 @@ class CDVDMediaCodecOnFrameAvailable;
 class CJNIByteBuffer;
 class CBitstreamConverter;
 
-struct DemuxCryptoInfo;
 struct mpeg2_sequence;
-
-
-typedef struct amc_demux
-{
-  uint8_t* pData;
-  int iSize;
-  double dts;
-  double pts;
-} amc_demux;
 
 class CMediaCodecVideoBufferPool;
 
@@ -164,8 +154,6 @@ protected:
   CJNIMediaCrypto* m_crypto = nullptr;
   std::shared_ptr<CJNISurfaceTexture> m_surfaceTexture;
   std::shared_ptr<CDVDMediaCodecOnFrameAvailable> m_frameAvailable;
-
-  amc_demux m_demux_pkt;
   std::shared_ptr<CMediaCodecVideoBufferPool> m_videoBufferPool;
 
   uint32_t m_OutputDuration = 0, m_fpsDuration = 0;
@@ -181,8 +169,6 @@ protected:
   int m_indexInputBuffer;
   bool m_render_surface;
   mpeg2_sequence* m_mpeg2_sequence = nullptr;
-  int m_src_offset[4];
-  int m_src_stride[4];
   bool m_useDTSforPTS = false;
 
   // CJNISurfaceHolderCallback interface


### PR DESCRIPTION
## Description
These variables are not currently used in the code.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
