### PR TITLE
Fix GLES subtitle overlay crash on WebOS 33.x

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
@@ -95,7 +95,7 @@ static void LoadTexture(GLenum target,
     }
 
     pixelData = pixelVector;
-    stride = bytesPerLine;
+    stride = bytesPerPixel * width;
   }
   /** OpenGL ES does not support strided texture input. Make a copy without stride **/
   else if (stride != bytesPerLine)
@@ -119,19 +119,10 @@ static void LoadTexture(GLenum target,
 
   glTexImage2D(target, 0, internalFormat, width2, height2, 0, externalFormat, GL_UNSIGNED_BYTE,
                NULL);
-
-  GLenum glErr = glGetError();
-  if (glErr != GL_NO_ERROR)
-    CLog::Log(LOGERROR,
-              "OverlayGLES: glTexImage2D failed with 0x{:04x} ({}x{} fmt=0x{:04x}/0x{:04x})", glErr,
-              width2, height2, internalFormat, externalFormat);
+  VerifyGLState();
 
   glTexSubImage2D(target, 0, 0, 0, width, height, externalFormat, GL_UNSIGNED_BYTE, pixelData);
-
-  glErr = glGetError();
-  if (glErr != GL_NO_ERROR)
-    CLog::Log(LOGERROR, "OverlayGLES: glTexSubImage2D failed with 0x{:04x} ({}x{} stride={})",
-              glErr, width, height, stride);
+  VerifyGLState();
 
   if (height < height2)
     glTexSubImage2D(target, 0, 0, height, width, 1, externalFormat, GL_UNSIGNED_BYTE,
@@ -329,16 +320,40 @@ COverlayGlyphGLES::COverlayGlyphGLES(ASS_Image* images, float width, float heigh
   }
 
   glBindTexture(GL_TEXTURE_2D, 0);
+
+  // Expand quads to triangles and upload to VBO once
+  std::vector<VERTEX> vecVertices(6 * m_vertex.size() / 4);
+  VERTEX* vertices = vecVertices.data();
+
+  for (size_t i = 0; i < m_vertex.size(); i += 4)
+  {
+    *vertices++ = m_vertex[i];
+    *vertices++ = m_vertex[i + 1];
+    *vertices++ = m_vertex[i + 2];
+
+    *vertices++ = m_vertex[i + 1];
+    *vertices++ = m_vertex[i + 3];
+    *vertices++ = m_vertex[i + 2];
+  }
+
+  glGenBuffers(1, &m_vertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, m_vertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(VERTEX) * vecVertices.size(), vecVertices.data(),
+               GL_STATIC_DRAW);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+  m_vertexCount = vecVertices.size();
 }
 
 COverlayGlyphGLES::~COverlayGlyphGLES()
 {
   glDeleteTextures(1, &m_texture);
+  glDeleteBuffers(1, &m_vertexVBO);
 }
 
 void COverlayGlyphGLES::Render(SRenderState& state)
 {
-  if ((m_texture == 0) || (m_vertex.empty()))
+  if ((m_texture == 0) || (m_vertexVBO == 0))
     return;
 
   glEnable(GL_BLEND);
@@ -369,25 +384,7 @@ void COverlayGlyphGLES::Render(SRenderState& state)
   matrix.MultMatrixf(glMatrixModview.Get());
   glUniformMatrix4fv(matrixUniformLoc, 1, GL_FALSE, matrix);
 
-  std::vector<VERTEX> vecVertices(6 * m_vertex.size() / 4);
-  VERTEX* vertices = vecVertices.data();
-
-  for (size_t i = 0; i < m_vertex.size(); i += 4)
-  {
-    *vertices++ = m_vertex[i];
-    *vertices++ = m_vertex[i + 1];
-    *vertices++ = m_vertex[i + 2];
-
-    *vertices++ = m_vertex[i + 1];
-    *vertices++ = m_vertex[i + 3];
-    *vertices++ = m_vertex[i + 2];
-  }
-
-  GLuint vertexVBO;
-  glGenBuffers(1, &vertexVBO);
-  glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(VERTEX) * vecVertices.size(), vecVertices.data(),
-               GL_STATIC_DRAW);
+  glBindBuffer(GL_ARRAY_BUFFER, m_vertexVBO);
 
   glVertexAttribPointer(posLoc, 3, GL_FLOAT, GL_FALSE, sizeof(VERTEX),
                         reinterpret_cast<const GLvoid*>(offsetof(VERTEX, x)));
@@ -402,14 +399,13 @@ void COverlayGlyphGLES::Render(SRenderState& state)
 
   glUniform1f(depthLoc, -1.0f);
 
-  glDrawArrays(GL_TRIANGLES, 0, vecVertices.size());
+  glDrawArrays(GL_TRIANGLES, 0, m_vertexCount);
 
   glDisableVertexAttribArray(posLoc);
   glDisableVertexAttribArray(colLoc);
   glDisableVertexAttribArray(tex0Loc);
 
   glBindBuffer(GL_ARRAY_BUFFER, 0);
-  glDeleteBuffers(1, &vertexVBO);
 
   renderSystem->DisableGUIShader();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
@@ -123,16 +123,15 @@ static void LoadTexture(GLenum target,
   GLenum glErr = glGetError();
   if (glErr != GL_NO_ERROR)
     CLog::Log(LOGERROR,
-              "OverlayGLES: glTexImage2D failed with 0x{:04x} ({}x{} fmt=0x{:04x}/0x{:04x})",
-              glErr, width2, height2, internalFormat, externalFormat);
+              "OverlayGLES: glTexImage2D failed with 0x{:04x} ({}x{} fmt=0x{:04x}/0x{:04x})", glErr,
+              width2, height2, internalFormat, externalFormat);
 
   glTexSubImage2D(target, 0, 0, 0, width, height, externalFormat, GL_UNSIGNED_BYTE, pixelData);
 
   glErr = glGetError();
   if (glErr != GL_NO_ERROR)
-    CLog::Log(LOGERROR,
-              "OverlayGLES: glTexSubImage2D failed with 0x{:04x} ({}x{} stride={})", glErr,
-              width, height, stride);
+    CLog::Log(LOGERROR, "OverlayGLES: glTexSubImage2D failed with 0x{:04x} ({}x{} stride={})",
+              glErr, width, height, stride);
 
   if (height < height2)
     glTexSubImage2D(target, 0, 0, height, width, 1, externalFormat, GL_UNSIGNED_BYTE,

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
@@ -95,7 +95,7 @@ static void LoadTexture(GLenum target,
     }
 
     pixelData = pixelVector;
-    stride = width;
+    stride = bytesPerLine;
   }
   /** OpenGL ES does not support strided texture input. Make a copy without stride **/
   else if (stride != bytesPerLine)
@@ -120,7 +120,19 @@ static void LoadTexture(GLenum target,
   glTexImage2D(target, 0, internalFormat, width2, height2, 0, externalFormat, GL_UNSIGNED_BYTE,
                NULL);
 
+  GLenum glErr = glGetError();
+  if (glErr != GL_NO_ERROR)
+    CLog::Log(LOGERROR,
+              "OverlayGLES: glTexImage2D failed with 0x{:04x} ({}x{} fmt=0x{:04x}/0x{:04x})",
+              glErr, width2, height2, internalFormat, externalFormat);
+
   glTexSubImage2D(target, 0, 0, 0, width, height, externalFormat, GL_UNSIGNED_BYTE, pixelData);
+
+  glErr = glGetError();
+  if (glErr != GL_NO_ERROR)
+    CLog::Log(LOGERROR,
+              "OverlayGLES: glTexSubImage2D failed with 0x{:04x} ({}x{} stride={})", glErr,
+              width, height, stride);
 
   if (height < height2)
     glTexSubImage2D(target, 0, 0, height, width, 1, externalFormat, GL_UNSIGNED_BYTE,
@@ -358,7 +370,6 @@ void COverlayGlyphGLES::Render(SRenderState& state)
   matrix.MultMatrixf(glMatrixModview.Get());
   glUniformMatrix4fv(matrixUniformLoc, 1, GL_FALSE, matrix);
 
-  // stack object until VBOs will be used
   std::vector<VERTEX> vecVertices(6 * m_vertex.size() / 4);
   VERTEX* vertices = vecVertices.data();
 
@@ -373,14 +384,18 @@ void COverlayGlyphGLES::Render(SRenderState& state)
     *vertices++ = m_vertex[i + 2];
   }
 
-  vertices = vecVertices.data();
+  GLuint vertexVBO;
+  glGenBuffers(1, &vertexVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, vertexVBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(VERTEX) * vecVertices.size(), vecVertices.data(),
+               GL_STATIC_DRAW);
 
   glVertexAttribPointer(posLoc, 3, GL_FLOAT, GL_FALSE, sizeof(VERTEX),
-                        (char*)vertices + offsetof(VERTEX, x));
+                        reinterpret_cast<const GLvoid*>(offsetof(VERTEX, x)));
   glVertexAttribPointer(colLoc, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(VERTEX),
-                        (char*)vertices + offsetof(VERTEX, r));
+                        reinterpret_cast<const GLvoid*>(offsetof(VERTEX, r)));
   glVertexAttribPointer(tex0Loc, 2, GL_FLOAT, GL_FALSE, sizeof(VERTEX),
-                        (char*)vertices + offsetof(VERTEX, u));
+                        reinterpret_cast<const GLvoid*>(offsetof(VERTEX, u)));
 
   glEnableVertexAttribArray(posLoc);
   glEnableVertexAttribArray(colLoc);
@@ -393,6 +408,9 @@ void COverlayGlyphGLES::Render(SRenderState& state)
   glDisableVertexAttribArray(posLoc);
   glDisableVertexAttribArray(colLoc);
   glDisableVertexAttribArray(tex0Loc);
+
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glDeleteBuffers(1, &vertexVBO);
 
   renderSystem->DisableGUIShader();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
@@ -95,7 +95,7 @@ static void LoadTexture(GLenum target,
     }
 
     pixelData = pixelVector;
-    stride = width;
+    stride = 4 * width;
   }
   /** OpenGL ES does not support strided texture input. Make a copy without stride **/
   else if (stride != bytesPerLine)
@@ -119,8 +119,10 @@ static void LoadTexture(GLenum target,
 
   glTexImage2D(target, 0, internalFormat, width2, height2, 0, externalFormat, GL_UNSIGNED_BYTE,
                NULL);
+  VerifyGLState();
 
   glTexSubImage2D(target, 0, 0, 0, width, height, externalFormat, GL_UNSIGNED_BYTE, pixelData);
+  VerifyGLState();
 
   if (height < height2)
     glTexSubImage2D(target, 0, 0, height, width, 1, externalFormat, GL_UNSIGNED_BYTE,
@@ -318,16 +320,40 @@ COverlayGlyphGLES::COverlayGlyphGLES(ASS_Image* images, float width, float heigh
   }
 
   glBindTexture(GL_TEXTURE_2D, 0);
+
+  // Expand quads to triangles and upload to VBO once
+  std::vector<VERTEX> vecVertices(6 * m_vertex.size() / 4);
+  VERTEX* vertices = vecVertices.data();
+
+  for (size_t i = 0; i < m_vertex.size(); i += 4)
+  {
+    *vertices++ = m_vertex[i];
+    *vertices++ = m_vertex[i + 1];
+    *vertices++ = m_vertex[i + 2];
+
+    *vertices++ = m_vertex[i + 1];
+    *vertices++ = m_vertex[i + 3];
+    *vertices++ = m_vertex[i + 2];
+  }
+
+  glGenBuffers(1, &m_VBO);
+  glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(VERTEX) * vecVertices.size(), vecVertices.data(),
+               GL_STATIC_DRAW);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+  m_vertexCount = vecVertices.size();
 }
 
 COverlayGlyphGLES::~COverlayGlyphGLES()
 {
   glDeleteTextures(1, &m_texture);
+  glDeleteBuffers(1, &m_VBO);
 }
 
 void COverlayGlyphGLES::Render(SRenderState& state)
 {
-  if ((m_texture == 0) || (m_vertex.empty()))
+  if (m_texture == 0 || m_vertexCount == 0)
     return;
 
   glEnable(GL_BLEND);
@@ -358,29 +384,14 @@ void COverlayGlyphGLES::Render(SRenderState& state)
   matrix.MultMatrixf(glMatrixModview.Get());
   glUniformMatrix4fv(matrixUniformLoc, 1, GL_FALSE, matrix);
 
-  // stack object until VBOs will be used
-  std::vector<VERTEX> vecVertices(6 * m_vertex.size() / 4);
-  VERTEX* vertices = vecVertices.data();
-
-  for (size_t i = 0; i < m_vertex.size(); i += 4)
-  {
-    *vertices++ = m_vertex[i];
-    *vertices++ = m_vertex[i + 1];
-    *vertices++ = m_vertex[i + 2];
-
-    *vertices++ = m_vertex[i + 1];
-    *vertices++ = m_vertex[i + 3];
-    *vertices++ = m_vertex[i + 2];
-  }
-
-  vertices = vecVertices.data();
+  glBindBuffer(GL_ARRAY_BUFFER, m_VBO);
 
   glVertexAttribPointer(posLoc, 3, GL_FLOAT, GL_FALSE, sizeof(VERTEX),
-                        (char*)vertices + offsetof(VERTEX, x));
+                        reinterpret_cast<const GLvoid*>(offsetof(VERTEX, x)));
   glVertexAttribPointer(colLoc, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(VERTEX),
-                        (char*)vertices + offsetof(VERTEX, r));
+                        reinterpret_cast<const GLvoid*>(offsetof(VERTEX, r)));
   glVertexAttribPointer(tex0Loc, 2, GL_FLOAT, GL_FALSE, sizeof(VERTEX),
-                        (char*)vertices + offsetof(VERTEX, u));
+                        reinterpret_cast<const GLvoid*>(offsetof(VERTEX, u)));
 
   glEnableVertexAttribArray(posLoc);
   glEnableVertexAttribArray(colLoc);
@@ -388,12 +399,14 @@ void COverlayGlyphGLES::Render(SRenderState& state)
 
   glUniform1f(depthLoc, -1.0f);
 
-  glDrawArrays(GL_TRIANGLES, 0, vecVertices.size());
+  glDrawArrays(GL_TRIANGLES, 0, m_vertexCount);
   CRenderSystemBase::m_GUIElementCount++;
 
   glDisableVertexAttribArray(posLoc);
   glDisableVertexAttribArray(colLoc);
   glDisableVertexAttribArray(tex0Loc);
+
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
 
   renderSystem->DisableGUIShader();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.h
@@ -59,6 +59,8 @@ public:
   std::vector<VERTEX> m_vertex;
 
   GLuint m_texture = 0;
+  GLuint m_vertexVBO = 0;
+  GLsizei m_vertexCount = 0;
   float m_u;
   float m_v;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.h
@@ -59,6 +59,8 @@ public:
   std::vector<VERTEX> m_vertex;
 
   GLuint m_texture = 0;
+  GLuint m_VBO = 0;
+  GLsizei m_vertexCount = 0;
   float m_u;
   float m_v;
 };


### PR DESCRIPTION
Fixes #27630

## Summary

Two bugs in `OverlayRendererGLES.cpp` cause a system-level crash on LG WebOS 33.22.75+ when subtitles are displayed. The crash takes down the entire WebOS graphics stack, requiring a power cycle.

### 1. Stride calculation error (line 98)

After the BGRA→RGBA software conversion in `LoadTexture()`, `stride` is set to `width` (pixel count) instead of `bytesPerLine` (byte count = `4 * width` for RGBA). The border-padding code then reads from incorrect offsets. The desktop GL path (`OverlayRendererGL.cpp`) doesn't have this bug because it uses `GL_UNPACK_ROW_LENGTH`.

### 2. Client-side vertex arrays instead of VBOs (line 376+)

`COverlayGlyphGLES::Render()` passes raw CPU pointers to `glVertexAttribPointer()` — the code even had a TODO comment: `"stack object until VBOs will be used"`. The desktop GL path (`OverlayRendererGL.cpp:316-343`) already uses proper VBOs. Some GLES 3.0 drivers on embedded platforms crash when client-side arrays interact with the driver's memory management. This is the likely primary cause of the system-level crash.

### Why GUI fonts work but subtitles crash

Both GUI fonts (`GUIFontTTFGLES.cpp`) and subtitle overlays use `GL_ALPHA` textures with the `SM_FONTS` shader. The difference is that GUI fonts use a pre-allocated texture atlas, while subtitle overlays create/destroy textures every frame via `LoadTexture()` (with the stride bug) and render with client-side vertex arrays.

Also adds `glGetError()` diagnostics after `glTexImage2D`/`glTexSubImage2D` for future debugging.

## Test plan

- [x] Tested on LG OLED65B29LA (WebOS 33.22.75+) — subtitles now work without crash
- [x] No regressions observed in normal playback or GUI
- [ ] Needs testing on other GLES platforms (Android, Raspberry Pi, other WebOS models)