### PR TITLE
[MediaManager] Improve autoplay actions.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6461,7 +6461,10 @@ msgctxt "#13018"
 msgid "Allow idle shutdown"
 msgstr ""
 
-#empty string with id 13019
+#: xbmc/storage/MediaManager.cpp
+msgctxt "#13019"
+msgid "Mounted optical disc"
+msgstr ""
 
 #: unknown
 msgctxt "#13020"
@@ -8297,7 +8300,7 @@ msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14088"
-msgid "Play DVDs automatically"
+msgid "Video disc insert action"
 msgstr ""
 
 #. Subtitle font selection setting
@@ -20123,10 +20126,10 @@ msgctxt "#36193"
 msgid "This category contains the settings for how DVD's, Blu-ray, & CD's are handled."
 msgstr ""
 
-#. Description of setting with label #14088 "Play DVDs automatically"
+#. Description of setting with label #14088 "Video disc insert action"
 #: system/settings/settings.xml
 msgctxt "#36194"
-msgid "Autorun DVD video when inserted in drive."
+msgid "Action to take when a video disc is inserted."
 msgstr ""
 
 #. Description of setting with label #21372 "Forced DVD player region"
@@ -20604,7 +20607,7 @@ msgstr ""
 #. Description of setting with label #14097 "Audio CD Insert Action"
 #: system/settings/settings.xml
 msgctxt "#36283"
-msgid "Autorun CDs when inserted in drive."
+msgid "Action to take when an audio CD is inserted."
 msgstr ""
 
 #. Description of setting with label #227 "Load audio CD information from online service"
@@ -21554,7 +21557,25 @@ msgctxt "#36461"
 msgid "Notification event describe regular processes and actions performed by the system or the user."
 msgstr ""
 
-#empty strings from id 36462 to 36499
+#. Action on DVD/Bluray physical disc insertion - take no action
+#: system/settings/settings.xml
+msgctxt "#36462"
+msgid "None"
+msgstr ""
+
+#. Action on DVD/Bluray physical disc insertion - play the disc automatically
+#: system/settings/settings.xml
+msgctxt "#36463"
+msgid "Play"
+msgstr ""
+
+#. Action on DVD/Bluray physical disc insertion - show a browse dialog
+#: system/settings/settings.xml
+msgctxt "#36464"
+msgid "Browse"
+msgstr ""
+
+#empty strings from id 36465 to 36499
 #end reservation
 
 #. label of a setting for the stereoscopic 3D mode of the GUI that is/should be applied

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4200,8 +4200,11 @@ msgctxt "#1023"
 msgid "Browse for new share"
 msgstr ""
 
-#: addons/skin.estuary/xml/DialogNetworkSetup.xml
+#. Displays a dialog to select movie title(s) for text matching in a smart rule
 #: addons/skin.estuary/xml/SmartPlaylistRule.xml
+#.
+#. Action on DVD/Bluray physical disc insertion - show a browse dialog
+#: system/settings/settings.xml
 msgctxt "#1024"
 msgid "Browse"
 msgstr ""
@@ -6469,7 +6472,10 @@ msgctxt "#13018"
 msgid "Allow idle shutdown"
 msgstr ""
 
-#empty string with id 13019
+#: xbmc/storage/MediaManager.cpp
+msgctxt "#13019"
+msgid "Mounted optical disc"
+msgstr ""
 
 #: unknown
 msgctxt "#13020"
@@ -8350,7 +8356,10 @@ msgctxt "#14084"
 msgid "Queue songs on selection"
 msgstr ""
 
-#empty string with id 14085
+#: system/settings/settings.xml
+msgctxt "#14085"
+msgid "Video disc insert action"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#14086"
@@ -8363,10 +8372,7 @@ msgctxt "#14087"
 msgid "Discs"
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#14088"
-msgid "Play DVDs automatically"
-msgstr ""
+#empty string with id 14088
 
 #. Subtitle font selection setting
 #: system/settings/settings.xml
@@ -8412,10 +8418,7 @@ msgctxt "#14097"
 msgid "Audio CD insert action"
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#14098"
-msgid "Play"
-msgstr ""
+#empty string with id 14098
 
 #: system/settings/settings.xml
 msgctxt "#14099"
@@ -9300,7 +9303,6 @@ msgctxt "#16017"
 msgid "Enter search string"
 msgstr ""
 
-#: system/settings/settings.xml
 #: xbmc/playlists/SmartPlaylist.cpp
 msgctxt "#16018"
 msgid "None"
@@ -20312,11 +20314,7 @@ msgctxt "#36193"
 msgid "This category contains the settings for how DVD's, Blu-ray, & CD's are handled."
 msgstr ""
 
-#. Description of setting with label #14088 "Play DVDs automatically"
-#: system/settings/settings.xml
-msgctxt "#36194"
-msgid "Autorun DVD video when inserted in drive."
-msgstr ""
+#empty strings from id 36194
 
 #. Description of setting with label #21372 "Forced DVD player region"
 #: system/settings/settings.xml
@@ -20790,11 +20788,7 @@ msgctxt "#36282"
 msgid "This category contains the settings for how CDs are handled."
 msgstr ""
 
-#. Description of setting with label #14097 "Audio CD Insert Action"
-#: system/settings/settings.xml
-msgctxt "#36283"
-msgid "Autorun CDs when inserted in drive."
-msgstr ""
+#empty strings from id 36283
 
 #. Description of setting with label #227 "Load audio CD information from online service"
 #: system/settings/settings.xml
@@ -21709,7 +21703,17 @@ msgctxt "#36439"
 msgid "Enable automatic playback of the next programme when playing past programmes (catchup) or for Video On Demand (VOD) channels. Please note that catchup and VOD only work if supported by the channel provider."
 msgstr ""
 
-#empty strings from id 36440 to 36441
+#. Description of setting with label #14085 "Video disc insert action"
+#: system/settings/settings.xml
+msgctxt "#36440"
+msgid "Action to take when a video disc is inserted."
+msgstr ""
+
+#. Description of setting with label #14097 "Audio CD Insert Action"
+#: system/settings/settings.xml
+msgctxt "#36441"
+msgid "Action to take when an audio CD is inserted."
+msgstr ""
 
 #. Description of setting "System -> Audio output -> Volume control steps" with label #1302
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -420,11 +420,17 @@
     </category>
     <category id="discs" label="14087" help="36193">
       <group id="1" label="446">
-        <setting id="dvds.autorun" type="boolean" label="14088" help="36194">
+        <setting id="dvds.autorun" type="integer" label="14088" help="36194">
           <requirement>HAS_OPTICAL_DRIVE</requirement>
           <level>0</level>
-          <default>false</default>
-          <control type="toggle" />
+          <default>0</default> <!-- None -->
+          <constraints>
+            <options>videodiscactions</options>
+          </constraints>
+          <updates>
+            <update type="change" />
+          </updates>
+          <control type="list" format="string" />
         </setting>
         <setting id="dvds.playerregion" type="integer" label="21372" help="36195">
           <level>1</level>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -433,11 +433,17 @@
     </category>
     <category id="discs" label="14087" help="36193">
       <group id="1" label="446">
-        <setting id="dvds.autorun" type="boolean" label="14088" help="36194">
+        <setting id="dvds.autoaction" type="integer" label="14085" help="36440">
           <requirement>HAS_OPTICAL_DRIVE</requirement>
           <level>0</level>
-          <default>false</default>
-          <control type="toggle" />
+          <default>0</default> <!-- None -->
+          <constraints>
+            <options>videodiscactions</options>
+          </constraints>
+          <updates>
+            <update type="change" />
+          </updates>
+          <control type="list" format="string" />
         </setting>
         <setting id="dvds.playerregion" type="integer" label="21372" help="36195">
           <level>1</level>
@@ -484,7 +490,7 @@
         </setting>
       </group>
       <group id="3" label="620">
-        <setting id="audiocds.autoaction" type="integer" label="14097" help="36283">
+        <setting id="audiocds.autoaction" type="integer" label="14097" help="36441">
           <requirement>HAS_OPTICAL_DRIVE</requirement>
           <level>1</level>
           <default>0</default> <!-- AUTOCD_NONE -->

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -107,10 +107,11 @@ bool CAutorun::ExecuteAutorun(const std::string& path)
 bool CAutorun::PlayDisc(const std::string& path, const PlayDiscOptions& options)
 {
   const auto& settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  const AutoCDAction action =
+  const auto cdAction =
       static_cast<AutoCDAction>(settings->GetInt(CSettings::SETTING_AUDIOCDS_AUTOACTION));
-  if (!options.bypassSettings && action != AutoCDAction::PLAY &&
-      !settings->GetBool(CSettings::SETTING_DVDS_AUTORUN))
+  const auto dvdAction =
+      static_cast<AutoDVDAction>(settings->GetInt(CSettings::SETTING_DVDS_AUTOACTION));
+  if (!options.bypassSettings && cdAction != AutoCDAction::PLAY && dvdAction != AutoDVDAction::PLAY)
     return false;
 
   int nSize = CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST::Id::TYPE_MUSIC).size();
@@ -202,7 +203,9 @@ bool CAutorun::RunDisc(IDirectory* pDir,
   {
     std::string hddvdname = "";
     CFileItemPtr phddvdItem;
-    bool bAutorunDVDs = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_DVDS_AUTORUN);
+    bool bAutorunDVDs =
+        CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+            CSettings::SETTING_DVDS_AUTOACTION) == static_cast<int>(AutoDVDAction::PLAY);
 
     // check root folders next, for normal structured dvd's
     for (const auto& pItem : vecItems)
@@ -430,8 +433,9 @@ bool CAutorun::RunDisc(IDirectory* pDir,
 
   // check video first
   if (!nAddedToPlaylist && !bPlaying &&
-      (options.bypassSettings || CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-                                     CSettings::SETTING_DVDS_AUTORUN)))
+      (options.bypassSettings ||
+       CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+           CSettings::SETTING_DVDS_AUTOACTION) == static_cast<int>(AutoDVDAction::PLAY)))
   {
     // stack video files
     CFileItemList tempItems;
@@ -604,4 +608,16 @@ void CAutorun::SettingOptionAudioCdActionsFiller(const SettingConstPtr& setting,
   list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14096),
                     static_cast<int>(AutoCDAction::RIP));
 #endif
+}
+
+void CAutorun::SettingOptionVideoDiscActionsFiller(const SettingConstPtr& setting,
+                                                   std::vector<IntegerSettingOption>& list,
+                                                   int& current)
+{
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36462),
+                    static_cast<int>(AutoDVDAction::NONE));
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36463),
+                    static_cast<int>(AutoDVDAction::PLAY));
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(36464),
+                    static_cast<int>(AutoDVDAction::BROWSE));
 }

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -107,10 +107,11 @@ bool CAutorun::ExecuteAutorun(const std::string& path)
 bool CAutorun::PlayDisc(const std::string& path, const PlayDiscOptions& options)
 {
   const auto& settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  const AutoCDAction action =
+  const auto cdAction =
       static_cast<AutoCDAction>(settings->GetInt(CSettings::SETTING_AUDIOCDS_AUTOACTION));
-  if (!options.bypassSettings && action != AutoCDAction::PLAY &&
-      !settings->GetBool(CSettings::SETTING_DVDS_AUTORUN))
+  const auto dvdAction =
+      static_cast<AutoDVDAction>(settings->GetInt(CSettings::SETTING_DVDS_AUTOACTION));
+  if (!options.bypassSettings && cdAction != AutoCDAction::PLAY && dvdAction != AutoDVDAction::PLAY)
     return false;
 
   int nSize = CServiceBroker::GetPlaylistPlayer().GetPlaylist(PLAYLIST::Id::TYPE_MUSIC).size();
@@ -202,7 +203,9 @@ bool CAutorun::RunDisc(IDirectory* pDir,
   {
     std::string hddvdname = "";
     CFileItemPtr phddvdItem;
-    bool bAutorunDVDs = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_DVDS_AUTORUN);
+    bool bAutorunDVDs =
+        CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+            CSettings::SETTING_DVDS_AUTOACTION) == static_cast<int>(AutoDVDAction::PLAY);
 
     // check root folders next, for normal structured dvd's
     for (const auto& pItem : vecItems)
@@ -430,8 +433,9 @@ bool CAutorun::RunDisc(IDirectory* pDir,
 
   // check video first
   if (!nAddedToPlaylist && !bPlaying &&
-      (options.bypassSettings || CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-                                     CSettings::SETTING_DVDS_AUTORUN)))
+      (options.bypassSettings ||
+       CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+           CSettings::SETTING_DVDS_AUTOACTION) == static_cast<int>(AutoDVDAction::PLAY)))
   {
     // stack video files
     CFileItemList tempItems;
@@ -596,12 +600,25 @@ void CAutorun::SettingOptionAudioCdActionsFiller(const SettingConstPtr& setting,
                                                  std::vector<IntegerSettingOption>& list,
                                                  int& current)
 {
-  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16018),
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231), // None
                     static_cast<int>(AutoCDAction::NONE));
-  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14098),
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(208), // Play
                     static_cast<int>(AutoCDAction::PLAY));
 #ifdef HAS_CDDA_RIPPER
-  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14096),
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(14096), // Rip
                     static_cast<int>(AutoCDAction::RIP));
 #endif
+}
+
+void CAutorun::SettingOptionVideoDiscActionsFiller(const SettingConstPtr& setting,
+                                                   std::vector<IntegerSettingOption>& list,
+                                                   int& current)
+{
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(231), // None
+                    static_cast<int>(AutoDVDAction::NONE));
+  list.emplace_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(208), // Play
+                    static_cast<int>(AutoDVDAction::PLAY));
+  list.emplace_back(
+      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1024), // Browse
+      static_cast<int>(AutoDVDAction::BROWSE));
 }

--- a/xbmc/Autorun.h
+++ b/xbmc/Autorun.h
@@ -18,6 +18,7 @@
 
 #ifdef HAS_OPTICAL_DRIVE
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
@@ -32,11 +33,18 @@ namespace XFILE
 
 class CSetting;
 
-enum class AutoCDAction
+enum class AutoCDAction : uint8_t
 {
   NONE = 0,
   PLAY,
   RIP
+};
+
+enum class AutoDVDAction : uint8_t
+{
+  NONE = 0,
+  PLAY,
+  BROWSE
 };
 
 namespace MEDIA_DETECT
@@ -71,6 +79,9 @@ public:
   static void SettingOptionAudioCdActionsFiller(const std::shared_ptr<const CSetting>& setting,
                                                 std::vector<IntegerSettingOption>& list,
                                                 int& current);
+  static void SettingOptionVideoDiscActionsFiller(const std::shared_ptr<const CSetting>& setting,
+                                                  std::vector<IntegerSettingOption>& list,
+                                                  int& current);
 
 protected:
   static bool RunDisc(XFILE::IDirectory* pDir,

--- a/xbmc/application/ApplicationSettingsHandling.cpp
+++ b/xbmc/application/ApplicationSettingsHandling.cpp
@@ -8,6 +8,7 @@
 
 #include "ApplicationSettingsHandling.h"
 
+#include "Autorun.h"
 #include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "addons/addoninfo/AddonType.h"
@@ -24,6 +25,7 @@
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"
+#include "utils/XBMCTinyXML.h"
 #include "windowing/WinSystem.h"
 
 #if defined(TARGET_DARWIN_OSX)
@@ -74,7 +76,8 @@ void CApplicationSettingsHandling::RegisterSettings()
                                        CSettings::SETTING_SOURCE_VIDEOS,
                                        CSettings::SETTING_SOURCE_MUSIC,
                                        CSettings::SETTING_SOURCE_PICTURES,
-                                       CSettings::SETTING_VIDEOSCREEN_FAKEFULLSCREEN});
+                                       CSettings::SETTING_VIDEOSCREEN_FAKEFULLSCREEN,
+                                       CSettings::SETTING_DVDS_AUTOACTION});
 
   auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
@@ -183,6 +186,27 @@ bool CApplicationSettingsHandling::OnSettingUpdate(const std::shared_ptr<CSettin
 {
   if (!setting)
     return false;
+
+#ifdef HAS_OPTICAL_DRIVE
+  if (setting->GetId() == CSettings::SETTING_DVDS_AUTOACTION && oldSettingNode)
+  {
+    const auto intSetting{std::static_pointer_cast<CSettingInt>(setting)};
+    if (oldSettingNode->FirstChild())
+    {
+      const std::string oldValue = oldSettingNode->FirstChild()->ValueStr();
+      if (oldValue == "true")
+        return intSetting->SetValue(static_cast<int>(AutoDVDAction::PLAY));
+      else if (oldValue == "false")
+        return intSetting->SetValue(static_cast<int>(AutoDVDAction::NONE));
+      else
+      {
+        CLog::LogF(LOGWARNING, "Unexpected old value '{}' for dvds.autorun setting, using default",
+                   oldValue);
+        return intSetting->SetValue(static_cast<int>(AutoDVDAction::NONE));
+      }
+    }
+  }
+#endif
 
 #if defined(TARGET_DARWIN_OSX)
   if (setting->GetId() == CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE)

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -9,7 +9,6 @@
 
 #include "ServiceBroker.h"
 #include "filesystem/SpecialProtocol.h"
-#include "jobs/JobManager.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "storage/MediaManager.h"
@@ -17,6 +16,8 @@
 #include "utils/log.h"
 
 #include "platform/win32/CharsetConverter.h"
+
+#include <mutex>
 
 #include <SetupAPI.h>
 #include <ShlObj.h>
@@ -34,18 +35,22 @@ void CWin32StorageProvider::Initialize()
   // check for a DVD drive
   std::vector<CMediaSource> vShare;
   GetDrivesByType(vShare, DVD_DRIVES);
-  if(!vShare.empty())
+  if (!vShare.empty())
     CServiceBroker::GetMediaManager().SetHasOpticalDrive(true);
   else
     CLog::LogF(LOGDEBUG, "No optical drive found.");
 
 #ifdef HAS_OPTICAL_DRIVE
-  // Can be removed once the StorageHandler supports optical media
+  // A disc already present in a drive at startup is added as a source but does
+  // NOT autorun, matching Linux
   for (const auto& it : vShare)
+  {
     if (CServiceBroker::GetMediaManager().GetDriveStatus(it.strPath) ==
         DriveState::CLOSED_MEDIA_PRESENT)
-      CServiceBroker::GetJobManager()->AddJob(new CDetectDisc(it.strPath, false), nullptr);
-      // remove end
+    {
+      CServiceBroker::GetMediaManager().AddOpticalSource(it.strPath);
+    }
+  }
 #endif
 }
 
@@ -168,13 +173,6 @@ std::vector<std::string > CWin32StorageProvider::GetDiskUsage()
     }while( wcslen( pcBuffer.get() + iPos ) > 0 );
   }
   return result;
-}
-
-bool CWin32StorageProvider::PumpDriveChangeEvents(IStorageEventsCallback *callback)
-{
-  bool b = xbevent;
-  xbevent = false;
-  return b;
 }
 
 void CWin32StorageProvider::GetDrivesByType(std::vector<CMediaSource>& localDrives,
@@ -378,27 +376,71 @@ DEVINST CWin32StorageProvider::GetDrivesDevInstByDiskNumber(long DiskNumber)
   return 0;
 }
 
-CDetectDisc::CDetectDisc(const std::string &strPath, const bool bautorun)
-  : m_strPath(strPath), m_bautorun(bautorun)
+MEDIA_DETECT::STORAGE::StorageDevice CWin32StorageProvider::GetStorageDevice(
+    const std::string& drive)
 {
+  using KODI::PLATFORM::WINDOWS::FromW;
+  using KODI::PLATFORM::WINDOWS::ToW;
+
+  MEDIA_DETECT::STORAGE::StorageDevice device;
+  device.path = drive; // e.g. "D:"
+  device.label = drive;
+
+  const std::wstring root = ToW(drive + "\\");
+  if (GetDriveTypeW(root.c_str()) == DRIVE_CDROM)
+    device.type = MEDIA_DETECT::STORAGE::Type::OPTICAL;
+
+  wchar_t volumeName[MAX_PATH + 1] = {};
+  if (GetVolumeInformationW(root.c_str(), volumeName, MAX_PATH, nullptr, nullptr, nullptr, nullptr,
+                            0) &&
+      volumeName[0] != L'\0')
+  {
+    device.label = FromW(volumeName);
+  }
+  return device;
 }
 
-bool CDetectDisc::DoWork()
+void CWin32StorageProvider::QueueStorageEvent(StorageEventType type,
+                                              const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
-#ifdef HAS_OPTICAL_DRIVE
-  CLog::LogF(LOGDEBUG, "Optical media found in drive {}", m_strPath);
-  CMediaSource share;
-  share.strPath = m_strPath;
-  share.strStatus = CServiceBroker::GetMediaManager().GetDiskLabel(share.strPath);
-  share.strDiskUniqueId = CServiceBroker::GetMediaManager().GetDiskUniqueId(share.strPath);
-  if (CServiceBroker::GetMediaManager().IsAudio(share.strPath))
-    share.strStatus = "Audio-CD";
-  else if(share.strStatus == "")
-    share.strStatus = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(446);
-  share.strName = share.strPath;
-  share.m_ignore = true;
-  share.m_iDriveType = SourceType::OPTICAL_DISC;
-  CServiceBroker::GetMediaManager().AddAutoSource(share, m_bautorun);
-#endif
-  return true;
+  std::unique_lock lock(m_eventsSection);
+  m_events.emplace_back(StorageEvent{type, device});
+}
+
+bool CWin32StorageProvider::PumpDriveChangeEvents(IStorageEventsCallback* callback)
+{
+  std::vector<StorageEvent> events;
+  {
+    std::unique_lock lock(m_eventsSection);
+    events.swap(m_events);
+  }
+
+  if (callback)
+  {
+    for (const auto& ev : events)
+    {
+      switch (ev.type)
+      {
+        case StorageEventType::ADDED:
+          callback->OnStorageAdded(ev.device);
+          break;
+        case StorageEventType::SAFELY_REMOVED:
+          callback->OnStorageSafelyRemoved(ev.device);
+          break;
+        case StorageEventType::UNSAFELY_REMOVED:
+          callback->OnStorageUnsafelyRemoved(ev.device);
+          break;
+      }
+    }
+  }
+
+  bool changed = !events.empty();
+
+  // legacy flag still used by the shell-notification (SD card) path
+  if (xbevent)
+  {
+    xbevent = false;
+    changed = true;
+  }
+  return changed;
 }

--- a/xbmc/platform/win32/storage/Win32StorageProvider.h
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include "jobs/Job.h"
 #include "storage/IStorageProvider.h"
+#include "threads/CriticalSection.h"
 
 #include <vector>
 
@@ -39,7 +39,22 @@ public:
 
   virtual std::vector<std::string> GetDiskUsage();
 
-  virtual bool PumpDriveChangeEvents(IStorageEventsCallback *callback);
+  virtual bool PumpDriveChangeEvents(IStorageEventsCallback* callback);
+
+  // Translated from Windows messages
+  enum class StorageEventType
+  {
+    ADDED,
+    SAFELY_REMOVED,
+    UNSAFELY_REMOVED,
+  };
+
+  // Build a StorageDevice descriptor from a drive root (eg. "D:")
+  static MEDIA_DETECT::STORAGE::StorageDevice GetStorageDevice(const std::string& drive);
+
+  // Called from the windowing thread to queue a change for the next pump
+  static void QueueStorageEvent(StorageEventType type,
+                                const MEDIA_DETECT::STORAGE::StorageDevice& device);
 
   static void SetEvent() { xbevent = true; }
   static bool xbevent;
@@ -49,16 +64,13 @@ private:
                               Drive_Types eDriveType = ALL_DRIVES,
                               bool bonlywithmedia = false);
   static DEVINST GetDrivesDevInstByDiskNumber(long DiskNumber);
+
+  struct StorageEvent
+  {
+    StorageEventType type;
+    MEDIA_DETECT::STORAGE::StorageDevice device;
+  };
+
+  inline static std::vector<StorageEvent> m_events;
+  inline static CCriticalSection m_eventsSection;
 };
-
-class CDetectDisc : public CJob
-{
-public:
-  CDetectDisc(const std::string &strPath, const bool bautorun);
-  bool DoWork();
-
-private:
-  std::string  m_strPath;
-  bool        m_bautorun;
-};
-

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -372,7 +372,10 @@ void CSettings::InitializeOptionFillers()
 {
   // register setting option fillers
 #ifdef HAS_OPTICAL_DRIVE
-  GetSettingsManager()->RegisterSettingOptionsFiller("audiocdactions", MEDIA_DETECT::CAutorun::SettingOptionAudioCdActionsFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "audiocdactions", MEDIA_DETECT::CAutorun::SettingOptionAudioCdActionsFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "videodiscactions", MEDIA_DETECT::CAutorun::SettingOptionVideoDiscActionsFiller);
 #endif
   GetSettingsManager()->RegisterSettingOptionsFiller("charsets", CCharsetConverter::SettingOptionsCharsetsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("fonts", GUIFontManager::SettingOptionsFontsFiller);
@@ -453,6 +456,7 @@ void CSettings::InitializeOptionFillers()
 void CSettings::UninitializeOptionFillers()
 {
   GetSettingsManager()->UnregisterSettingOptionsFiller("audiocdactions");
+  GetSettingsManager()->UnregisterSettingOptionsFiller("videodiscactions");
   GetSettingsManager()->UnregisterSettingOptionsFiller("audiocdencoders");
   GetSettingsManager()->UnregisterSettingOptionsFiller("charsets");
   GetSettingsManager()->UnregisterSettingOptionsFiller("fontheights");

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -372,7 +372,10 @@ void CSettings::InitializeOptionFillers()
 {
   // register setting option fillers
 #ifdef HAS_OPTICAL_DRIVE
-  GetSettingsManager()->RegisterSettingOptionsFiller("audiocdactions", MEDIA_DETECT::CAutorun::SettingOptionAudioCdActionsFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "audiocdactions", MEDIA_DETECT::CAutorun::SettingOptionAudioCdActionsFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "videodiscactions", MEDIA_DETECT::CAutorun::SettingOptionVideoDiscActionsFiller);
 #endif
   GetSettingsManager()->RegisterSettingOptionsFiller("charsets", CCharsetConverter::SettingOptionsCharsetsFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller("fonts", GUIFontManager::SettingOptionsFontsFiller);
@@ -455,6 +458,7 @@ void CSettings::InitializeOptionFillers()
 void CSettings::UninitializeOptionFillers()
 {
   GetSettingsManager()->UnregisterSettingOptionsFiller("audiocdactions");
+  GetSettingsManager()->UnregisterSettingOptionsFiller("videodiscactions");
   GetSettingsManager()->UnregisterSettingOptionsFiller("audiocdencoders");
   GetSettingsManager()->UnregisterSettingOptionsFiller("charsets");
   GetSettingsManager()->UnregisterSettingOptionsFiller("fontheights");

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -181,7 +181,7 @@ public:
   static constexpr auto SETTING_SUBTITLES_DOWNLOADFIRST = "subtitles.downloadfirst";
   static constexpr auto SETTING_SUBTITLES_TV = "subtitles.tv";
   static constexpr auto SETTING_SUBTITLES_MOVIE = "subtitles.movie";
-  static constexpr auto SETTING_DVDS_AUTORUN = "dvds.autorun";
+  static constexpr auto SETTING_DVDS_AUTOACTION = "dvds.autorun";
   static constexpr auto SETTING_DVDS_PLAYERREGION = "dvds.playerregion";
   static constexpr auto SETTING_DVDS_AUTOMENU = "dvds.automenu";
   static constexpr auto SETTING_DISC_PLAYBACK = "disc.playback";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -184,7 +184,7 @@ public:
   static constexpr auto SETTING_SUBTITLES_DOWNLOADFIRST = "subtitles.downloadfirst";
   static constexpr auto SETTING_SUBTITLES_TV = "subtitles.tv";
   static constexpr auto SETTING_SUBTITLES_MOVIE = "subtitles.movie";
-  static constexpr auto SETTING_DVDS_AUTORUN = "dvds.autorun";
+  static constexpr auto SETTING_DVDS_AUTOACTION = "dvds.autoaction";
   static constexpr auto SETTING_DVDS_PLAYERREGION = "dvds.playerregion";
   static constexpr auto SETTING_DVDS_AUTOMENU = "dvds.automenu";
   static constexpr auto SETTING_DISC_PLAYBACK = "disc.playback";

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -1111,16 +1111,19 @@ bool CSettingsManager::LoadSetting(const TiXmlNode* node, const SettingPtr& sett
   const char* isDefaultAttribute = settingElement->Attribute(SETTING_XML_ELM_DEFAULT);
   const bool isDefault =
       isDefaultAttribute && StringUtils::EqualsNoCase(isDefaultAttribute, "true");
+  const std::set<CSettingUpdate>& updates = setting->GetUpdates();
 
-  if (!setting->FromString(settingElement->FirstChild() ? settingElement->FirstChild()->ValueStr()
-                                                        : StringUtils::Empty))
+  const bool failedRead{!setting->FromString(settingElement->FirstChild()
+                                                 ? settingElement->FirstChild()->ValueStr()
+                                                 : StringUtils::Empty)};
+  if (failedRead)
   {
     m_logger->warn("unable to read value of setting \"{}\"", settingId);
-    return false;
+    if (updates.empty())
+      return false; // No updates to process
   }
 
   // check if we need to perform any update logic for the setting
-  const std::set<CSettingUpdate>& updates = setting->GetUpdates();
   for (const auto& update : updates)
     updated |= UpdateSetting(node, setting, update);
 
@@ -1129,7 +1132,7 @@ bool CSettingsManager::LoadSetting(const TiXmlNode* node, const SettingPtr& sett
   if (!updated && isDefault)
     setting->Reset();
 
-  return true;
+  return !failedRead || updated;
 }
 
 bool CSettingsManager::UpdateSetting(const TiXmlNode* node,
@@ -1140,37 +1143,68 @@ bool CSettingsManager::UpdateSetting(const TiXmlNode* node,
     return false;
 
   bool updated = false;
-  const char *oldSetting = nullptr;
-  const TiXmlNode *oldSettingNode = nullptr;
+  const char* oldSetting = nullptr;
+  const TiXmlNode* oldSettingNode = nullptr;
+
+  // For rename updates, look up the old setting node
+  // For change updates, look up the current one
+  std::string lookupId;
   if (update.GetType() == SettingUpdateType::Rename)
   {
     if (update.GetValue().empty())
       return false;
-
+    lookupId = update.GetValue();
     oldSetting = update.GetValue().c_str();
+  }
+  else if (update.GetType() == SettingUpdateType::Change)
+  {
+    lookupId = setting->GetId();
+  }
+
+  if (!lookupId.empty())
+  {
     std::string categoryTag;
     std::string settingTag;
-    if (!ParseSettingIdentifier(oldSetting, categoryTag, settingTag))
+    if (!ParseSettingIdentifier(lookupId, categoryTag, settingTag))
       return false;
 
+    // Try v1 format: <category><settingtag>value</settingtag></category>
     const TiXmlNode* categoryNode = node;
     if (!categoryTag.empty())
-    {
       categoryNode = node->FirstChild(categoryTag);
-      if (!categoryNode)
-        return false;
+
+    if (categoryNode)
+      oldSettingNode = categoryNode->FirstChild(settingTag);
+
+    // Try v2+ format: <setting id="lookupId">value</setting>
+    if (!oldSettingNode)
+    {
+      const TiXmlElement* settingElement = node->FirstChildElement(SETTING_XML_ELM_SETTING);
+      while (settingElement)
+      {
+        const char* id = settingElement->Attribute(SETTING_XML_ATTR_ID);
+        if (id && lookupId == id)
+        {
+          oldSettingNode = settingElement;
+          break;
+        }
+        settingElement = settingElement->NextSiblingElement(SETTING_XML_ELM_SETTING);
+      }
     }
 
-    oldSettingNode = categoryNode->FirstChild(settingTag);
     if (!oldSettingNode)
       return false;
 
-    if (setting->FromString(oldSettingNode->FirstChild() ? oldSettingNode->FirstChild()->ValueStr()
-                                                         : StringUtils::Empty))
-      updated = true;
-    else
-      m_logger->warn("unable to update \"{}\" through automatically renaming from \"{}\"",
-                     setting->GetId(), oldSetting);
+    if (update.GetType() == SettingUpdateType::Rename)
+    {
+      if (setting->FromString(oldSettingNode->FirstChild()
+                                  ? oldSettingNode->FirstChild()->ValueStr()
+                                  : StringUtils::Empty))
+        updated = true;
+      else
+        m_logger->warn("unable to update \"{}\" through automatically renaming from \"{}\"",
+                       setting->GetId(), oldSetting);
+    }
   }
 
   updated |= OnSettingUpdate(setting, oldSetting, oldSettingNode);

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -24,7 +24,7 @@
 #include <unordered_set>
 #include <utility>
 
-const uint32_t CSettingsManager::Version = 2;
+const uint32_t CSettingsManager::Version = 3;
 const uint32_t CSettingsManager::MinimumSupportedVersion = 0;
 
 namespace

--- a/xbmc/settings/lib/SettingsMigration.cpp
+++ b/xbmc/settings/lib/SettingsMigration.cpp
@@ -21,19 +21,33 @@
 // Version when the migration system was added. Early exit for upgrades to that version or lower
 constexpr int VERSION_BEFORE_MIGRATION_SYSTEM = 2;
 
-CSettingsMigration::CSettingsMigration()
+namespace
 {
-  /*
-   * Placeholder for the creation of migration steps. Could look something like this:
+class CSettingsMigrationToV3 : public ISettingsMigrationStep
+{
+public:
+  int TargetVersion() const override { return 3; }
+  bool Apply(TiXmlElement* root) override
+  {
+    constexpr std::string_view oldSettingId = "dvds.autorun";
+    constexpr std::string_view newSettingId = "dvds.autoaction";
 
-  std::vector<std::shared_ptr<ISettingsMigrationStep>> migrations{
+    return CSettingsMigration::SettingConversionResult::FAILURE !=
+           CSettingsMigration::ConvertSettingBoolToInt(root, oldSettingId, newSettingId,
+                                                       {.m_default = 0, .m_false = 0, .m_true = 1});
+  }
+};
+
+CSettingsMigration::StepList BuildMigrationSteps()
+{
+  return {
       std::make_shared<CSettingsMigrationToV3>(),
-      std::make_shared<CSettingsMigrationToV4>(),
-      etc...
   };
+}
+} // namespace
 
-  CSettingsMigration(std::move(migrations));
-  */
+CSettingsMigration::CSettingsMigration() : CSettingsMigration(BuildMigrationSteps())
+{
 }
 
 CSettingsMigration::CSettingsMigration(StepList steps)

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -8,31 +8,12 @@
 
 #include "MediaManager.h"
 
-#include "FileItem.h"
-#include "ServiceBroker.h"
-#include "URL.h"
-#include "guilib/GUIComponent.h"
-#include "resources/LocalizeStrings.h"
-#include "resources/ResourcesComponent.h"
-#include "utils/URIUtils.h"
-
-#include <mutex>
-#ifdef TARGET_WINDOWS
-#include "platform/win32/WIN32Util.h"
-#include "utils/CharsetConverter.h"
-#endif
-#include "guilib/GUIWindowManager.h"
-#ifdef HAS_OPTICAL_DRIVE
-#ifndef TARGET_WINDOWS
-//! @todo switch all ports to use auto sources
-#include <map>
-#include <utility>
-#include "DetectDVDType.h"
-#endif
-#endif
 #include "Autorun.h"
 #include "AutorunMediaJob.h"
+#include "FileItem.h"
 #include "GUIUserMessages.h"
+#include "ServiceBroker.h"
+#include "URL.h"
 #include "addons/VFSEntry.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogPlayEject.h"
@@ -40,19 +21,40 @@
 #include "filesystem/BlurayDiscCache.h"
 #endif
 #include "filesystem/File.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
 #include "jobs/JobManager.h"
 #include "messaging/helpers/DialogOKHelper.h"
+#ifdef TARGET_WINDOWS
+#include "utils/CharsetConverter.h"
+
+#include "platform/win32/WIN32Util.h"
+#endif
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/XBMCTinyXML2.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
 
+#ifdef HAS_OPTICAL_DRIVE
+#ifndef TARGET_WINDOWS
+//! @todo switch all ports to use auto sources
+#include "DetectDVDType.h"
+
+#include <map>
+#include <utility>
+#endif
+#endif
+
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -778,40 +780,83 @@ std::vector<std::string> CMediaManager::GetDiskUsage()
 void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
 #ifdef HAS_OPTICAL_DRIVE
-  const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  if (settings->GetInt(CSettings::SETTING_AUDIOCDS_AUTOACTION) !=
-          static_cast<int>(AutoCDAction::NONE) ||
-      settings->GetBool(CSettings::SETTING_DVDS_AUTORUN))
+  if (device.type == MEDIA_DETECT::STORAGE::Type::OPTICAL)
   {
-    if (settings->GetInt(CSettings::SETTING_AUDIOCDS_AUTOACTION) ==
-        static_cast<int>(AutoCDAction::RIP))
+    const std::shared_ptr<CSettings> settings{
+        CServiceBroker::GetSettingsComponent()->GetSettings()};
+
+    CCdInfo* pInfo{GetCdInfo(device.path)};
+    const bool isAudioDisc{pInfo && // If it returns null, it is likely to be a protected video disc
+                           pInfo->IsAudio(1)};
+
+    if (isAudioDisc)
     {
-      CServiceBroker::GetJobManager()->AddJob(new CAutorunMediaJob(device.label, device.path), this,
-                                              CJob::PRIORITY_LOW);
+      const auto cdAutoAction{
+          static_cast<AutoCDAction>(settings->GetInt(CSettings::SETTING_AUDIOCDS_AUTOACTION))};
+      CLog::LogF(LOGDEBUG, "Audio CD detected with path {}, auto action is {}", device.path,
+                 static_cast<int>(cdAutoAction));
+
+      bool processed{true};
+      using enum AutoCDAction;
+      if (cdAutoAction == RIP || cdAutoAction == PLAY)
+      {
+        // Will fallback to play if HAS_CDDA_RIPPER not defined
+        if (!MEDIA_DETECT::CAutorun::ExecuteAutorun(device.path))
+        {
+          CLog::LogF(LOGDEBUG, "Could not execute autorun (rip/play) for audio CD with path {}",
+                     device.path);
+          processed = false;
+        }
+      }
+      if (cdAutoAction == NONE || !processed)
+      {
+        CGUIDialogKaiToast::QueueNotification(
+            CGUIDialogKaiToast::Info,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13019), device.label,
+            TOAST_DISPLAY_TIME, false);
+      }
     }
     else
     {
-      if (device.type == MEDIA_DETECT::STORAGE::Type::OPTICAL)
+      const auto dvdAutoAction{
+          static_cast<AutoDVDAction>(settings->GetInt(CSettings::SETTING_DVDS_AUTOACTION))};
+      CLog::LogF(LOGDEBUG, "Video disc detected with path {}, auto action is {}", device.path,
+                 static_cast<int>(dvdAutoAction));
+
+      bool processed{true};
+      using enum AutoDVDAction;
+      if (dvdAutoAction == BROWSE)
       {
-        if (MEDIA_DETECT::CAutorun::ExecuteAutorun(device.path))
-        {
-          return;
-        }
-        CLog::Log(LOGDEBUG, "{}: Could not execute autorun for optical disc with path {}",
-                  __FUNCTION__, device.path);
+        CServiceBroker::GetJobManager()->AddJob(new CAutorunMediaJob(device.label, device.path),
+                                                this, CJob::PRIORITY_HIGH);
       }
-      CServiceBroker::GetJobManager()->AddJob(new CAutorunMediaJob(device.label, device.path), this,
-                                              CJob::PRIORITY_HIGH);
+      else if (dvdAutoAction == PLAY)
+      {
+        if (!MEDIA_DETECT::CAutorun::ExecuteAutorun(device.path))
+        {
+          CLog::LogF(LOGDEBUG, "Could not execute autorun for video disc with path {}",
+                     device.path);
+          processed = false;
+        }
+      }
+      if (dvdAutoAction == NONE || !processed)
+      {
+        CGUIDialogKaiToast::QueueNotification(
+            CGUIDialogKaiToast::Info,
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13019), device.label,
+            TOAST_DISPLAY_TIME, false);
+      }
     }
   }
   else
+#endif
   {
+    // Non-optical (or no optical support) - eg. USB stick
     CGUIDialogKaiToast::QueueNotification(
         CGUIDialogKaiToast::Info,
         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13021), device.label,
         TOAST_DISPLAY_TIME, false);
   }
-#endif
 }
 
 void CMediaManager::OnStorageSafelyRemoved(const MEDIA_DETECT::STORAGE::StorageDevice& device)

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -11,6 +11,7 @@
 #include "Autorun.h"
 #include "AutorunMediaJob.h"
 #include "FileItem.h"
+#include "GUIInfoManager.h"
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "URL.h"
@@ -27,8 +28,6 @@
 #include "messaging/helpers/DialogOKHelper.h"
 #ifdef TARGET_WINDOWS
 #include "utils/CharsetConverter.h"
-
-#include "platform/win32/WIN32Util.h"
 #endif
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
@@ -54,7 +53,6 @@
 #endif
 #endif
 
-#include <mutex>
 #include <string>
 #include <vector>
 
@@ -66,7 +64,7 @@ const char MEDIA_SOURCES_XML[] = { "special://profile/mediasources.xml" };
 
 CMediaManager::CMediaManager()
 {
-  m_bhasoptical = false;
+  m_bOpticalDrivePresent = false;
 }
 
 void CMediaManager::Stop()
@@ -382,7 +380,9 @@ void CMediaManager::RemoveAutoSource(const CMediaSource &share)
   CMediaSourceSettings::GetInstance().DeleteSource("music", share.strName, share.strPath, true);
   CMediaSourceSettings::GetInstance().DeleteSource("programs", share.strName, share.strPath, true);
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_SOURCES);
-  CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage( msg );
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (gui)
+    gui->GetWindowManager().SendThreadMessage(msg);
 
 #ifdef HAS_OPTICAL_DRIVE
   // delete cached CdInfo if any
@@ -406,7 +406,7 @@ std::string CMediaManager::TranslateDevicePath(const std::string& devicePath, bo
 #endif
 
 #ifdef TARGET_WINDOWS
-  if(!m_bhasoptical)
+  if (!m_bOpticalDrivePresent)
     return "";
 
   if(bReturnAsDevice == false)
@@ -423,17 +423,20 @@ bool CMediaManager::IsDiscInDrive(const std::string& devicePath)
 {
 #ifdef HAS_OPTICAL_DRIVE
 #ifdef TARGET_WINDOWS
-  if(!m_bhasoptical)
+  if (!m_bOpticalDrivePresent)
     return false;
 
   std::string strDevice = TranslateDevicePath(devicePath, false);
-  std::map<std::string,CCdInfo*>::iterator it;
-  std::unique_lock waitLock(m_muAutoSource);
-  it = m_mapCdInfo.find(strDevice);
-  if(it != m_mapCdInfo.end())
-    return true;
-  else
-    return false;
+
+  // m_mapCdInfo is only populated for audio CDs
+  {
+    std::unique_lock waitLock(m_muAutoSource);
+    if (m_mapCdInfo.contains(strDevice))
+      return true;
+  }
+
+  // Check physical drive state (for video discs)
+  return GetDriveStatus(devicePath) == DriveState::CLOSED_MEDIA_PRESENT;
 #else
   if(URIUtils::IsDVD(devicePath) || devicePath.empty())
     return MEDIA_DETECT::CDetectDVDMedia::IsDiscInDrive();   //! @todo switch all ports to use auto sources
@@ -449,7 +452,7 @@ bool CMediaManager::IsAudio(const std::string& devicePath)
 {
 #ifdef HAS_OPTICAL_DRIVE
 #ifdef TARGET_WINDOWS
-  if(!m_bhasoptical)
+  if (!m_bOpticalDrivePresent)
     return false;
 
   CCdInfo* pCdInfo = GetCdInfo(devicePath);
@@ -480,7 +483,7 @@ DriveState CMediaManager::GetDriveStatus(const std::string& devicePath)
 {
 #ifdef HAS_OPTICAL_DRIVE
 #ifdef TARGET_WINDOWS
-  if (!m_bhasoptical || !m_platformDiscDriveHander)
+  if (!m_bOpticalDrivePresent || !m_platformDiscDriveHander)
     return DriveState::NOT_READY;
 
   std::string translatedDevicePath = TranslateDevicePath(devicePath, true);
@@ -497,7 +500,7 @@ DriveState CMediaManager::GetDriveStatus(const std::string& devicePath)
 CCdInfo* CMediaManager::GetCdInfo(const std::string& devicePath)
 {
 #ifdef TARGET_WINDOWS
-  if(!m_bhasoptical)
+  if (!m_bOpticalDrivePresent)
     return NULL;
 
   std::string strDevice = TranslateDevicePath(devicePath, false);
@@ -526,7 +529,7 @@ CCdInfo* CMediaManager::GetCdInfo(const std::string& devicePath)
 
 bool CMediaManager::RemoveCdInfo(const std::string& devicePath)
 {
-  if(!m_bhasoptical)
+  if (!m_bOpticalDrivePresent)
     return false;
 
   std::string strDevice = TranslateDevicePath(devicePath, false);
@@ -550,7 +553,7 @@ std::string CMediaManager::GetDiskLabel(const std::string& devicePath)
 #ifdef TARGET_WINDOWS_STORE
   return ""; // GetVolumeInformationW nut support in UWP app
 #elif defined(TARGET_WINDOWS)
-  if(!m_bhasoptical)
+  if (!m_bOpticalDrivePresent)
     return "";
 
   std::string mediaPath = CServiceBroker::GetMediaManager().TranslateDevicePath(devicePath);
@@ -701,7 +704,7 @@ std::shared_ptr<IDiscDriveHandler> CMediaManager::GetDiscDriveHandler()
 void CMediaManager::SetHasOpticalDrive(bool bstatus)
 {
   std::unique_lock waitLock(m_muAutoSource);
-  m_bhasoptical = bstatus;
+  m_bOpticalDrivePresent = bstatus;
 }
 
 bool CMediaManager::Eject(const std::string& mountpath)
@@ -757,13 +760,21 @@ void CMediaManager::ProcessEvents()
   std::unique_lock lock(m_CritSecStorageProvider);
   if (m_platformStorage->PumpDriveChangeEvents(this))
   {
-#if defined(HAS_OPTICAL_DRIVE) && defined(TARGET_DARWIN_OSX)
+#if defined(HAS_OPTICAL_DRIVE)
+#if defined(TARGET_DARWIN_OSX)
     // darwins GetFirstOpticalDeviceFileName only gives us something
     // when a disc is inserted
     // so we have to refresh m_strFirstAvailDrive when this happens after Initialize
     // was called (e.x. the disc was inserted after the start of xbmc)
     // else TranslateDevicePath wouldn't give the correct device
     m_strFirstAvailDrive = m_platformStorage->GetFirstOpticalDeviceFileName();
+#elif defined(TARGET_WINDOWS)
+    // On Windows, virtual drives can appear or disappear at any time.
+    // Re-scan to get the current state of optical drives and update
+    // m_bhasoptical and m_strFirstAvailDrive accordingly.
+    m_strFirstAvailDrive = m_platformStorage->GetFirstOpticalDeviceFileName();
+    SetHasOpticalDrive(!m_strFirstAvailDrive.empty());
+#endif
 #endif
 
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_UPDATE_SOURCES);
@@ -777,11 +788,40 @@ std::vector<std::string> CMediaManager::GetDiskUsage()
   return m_platformStorage->GetDiskUsage();
 }
 
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+void CMediaManager::AddOpticalSource(const std::string& devicePath)
+{
+  CMediaSource share;
+  share.strPath = devicePath;
+  share.strName = devicePath;
+
+  RemoveAutoSource(share);
+
+  share.strStatus = GetDiskLabel(share.strPath);
+  share.strDiskUniqueId = GetDiskUniqueId(share.strPath);
+  if (IsAudio(share.strPath))
+    share.strStatus = "Audio-CD";
+  else if (share.strStatus.empty())
+    share.strStatus = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(446);
+
+  share.m_ignore = true;
+  share.m_iDriveType = SourceType::OPTICAL_DISC;
+  AddAutoSource(share, false);
+}
+#endif
+
 void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
 #ifdef HAS_OPTICAL_DRIVE
   if (device.type == MEDIA_DETECT::STORAGE::Type::OPTICAL)
   {
+#ifdef TARGET_WINDOWS
+    SetHasOpticalDrive(true); // In case drive appeared after startup (eg. virtual drive)
+    if (m_strFirstAvailDrive.empty())
+      m_strFirstAvailDrive = device.path;
+    AddOpticalSource(device.path);
+#endif
+
     const std::shared_ptr<CSettings> settings{
         CServiceBroker::GetSettingsComponent()->GetSettings()};
 
@@ -861,6 +901,15 @@ void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& d
 
 void CMediaManager::OnStorageSafelyRemoved(const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
+#ifdef TARGET_WINDOWS
+  if (device.type == MEDIA_DETECT::STORAGE::Type::OPTICAL)
+  {
+    CMediaSource share;
+    share.strPath = device.path;
+    share.strName = device.path;
+    RemoveAutoSource(share);
+  }
+#endif
   CGUIDialogKaiToast::QueueNotification(
       CGUIDialogKaiToast::Info,
       CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13023), device.label,
@@ -869,6 +918,15 @@ void CMediaManager::OnStorageSafelyRemoved(const MEDIA_DETECT::STORAGE::StorageD
 
 void CMediaManager::OnStorageUnsafelyRemoved(const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
+#ifdef TARGET_WINDOWS
+  if (device.type == MEDIA_DETECT::STORAGE::Type::OPTICAL)
+  {
+    CMediaSource share;
+    share.strPath = device.path;
+    share.strName = device.path;
+    RemoveAutoSource(share);
+  }
+#endif
   CGUIDialogKaiToast::QueueNotification(
       CGUIDialogKaiToast::Warning,
       CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13022), device.label);

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -19,8 +19,6 @@
 #include <memory>
 #include <vector>
 
-#include "PlatformDefs.h"
-
 class CFileItem;
 
 class CNetworkLocation
@@ -60,6 +58,15 @@ public:
 
   void AddAutoSource(const CMediaSource &share, bool bAutorun=false);
   void RemoveAutoSource(const CMediaSource &share);
+
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+  /*! \brief Build and register an optical-disc auto source for the given device path.
+   * Adds the source WITHOUT triggering autorun.
+   * \param devicePath The optical drive path (e.g. "D:")
+   */
+  void AddOpticalSource(const std::string& devicePath);
+#endif
+
   bool IsDiscInDrive(const std::string& devicePath="");
   bool IsAudio(const std::string& devicePath="");
   bool HasOpticalDrive();
@@ -129,7 +136,7 @@ protected:
 #ifdef HAS_OPTICAL_DRIVE
   std::map<std::string,MEDIA_DETECT::CCdInfo*> m_mapCdInfo;
 #endif
-  bool m_bhasoptical;
+  bool m_bOpticalDrivePresent;
   std::string m_strFirstAvailDrive;
 
 private:

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -790,32 +790,36 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
             {
               CServiceBroker::GetPeripherals().TriggerDeviceScan(PERIPHERALS::PERIPHERAL_BUS_USB);
             }
-            // check if an usb or optical media was inserted or removed
-            if (((_DEV_BROADCAST_HEADER*) lParam)->dbcd_devicetype == DBT_DEVTYP_VOLUME)
+            // check if a usb volume or optical media was inserted or removed
+            if (((_DEV_BROADCAST_HEADER*)lParam)->dbcd_devicetype == DBT_DEVTYP_VOLUME)
             {
-              PDEV_BROADCAST_VOLUME lpdbv = (PDEV_BROADCAST_VOLUME)((_DEV_BROADCAST_HEADER*) lParam);
-              // optical medium
-              if (lpdbv -> dbcv_flags & DBTF_MEDIA)
+              PDEV_BROADCAST_VOLUME lpdbv = (PDEV_BROADCAST_VOLUME)((_DEV_BROADCAST_HEADER*)lParam);
+
+              std::string strdrive =
+                  StringUtils::Format("{}:", CWIN32Util::FirstDriveFromMask(lpdbv->dbcv_unitmask));
+
+              MEDIA_DETECT::STORAGE::StorageDevice device =
+                  CWin32StorageProvider::GetStorageDevice(strdrive);
+
+              // DBTF_MEDIA set => optical disc (media) change rather than a USB volume
+              if (lpdbv->dbcv_flags & DBTF_MEDIA)
+                device.type = MEDIA_DETECT::STORAGE::Type::OPTICAL;
+
+              if (wParam == DBT_DEVICEARRIVAL)
               {
-                std::string strdrive = StringUtils::Format(
-                    "{}:", CWIN32Util::FirstDriveFromMask(lpdbv->dbcv_unitmask));
-                if(wParam == DBT_DEVICEARRIVAL)
-                {
-                  CLog::LogF(LOGDEBUG, "Drive {} Media has arrived.", strdrive);
-                  CServiceBroker::GetJobManager()->AddJob(new CDetectDisc(strdrive, true), nullptr);
-                }
-                else
-                {
-                  CLog::LogF(LOGDEBUG, "Drive {} Media was removed.", strdrive);
-                  CMediaSource share;
-                  share.strPath = strdrive;
-                  share.strName = share.strPath;
-                  CServiceBroker::GetMediaManager().RemoveAutoSource(share);
-                }
+                CLog::LogF(LOGDEBUG, "Drive {} Media has arrived.", strdrive);
+                CWin32StorageProvider::QueueStorageEvent(
+                    CWin32StorageProvider::StorageEventType::ADDED, device);
               }
               else
-                CWin32StorageProvider::SetEvent();
+              {
+                CLog::LogF(LOGDEBUG, "Drive {} Media was removed.", strdrive);
+                CWin32StorageProvider::QueueStorageEvent(
+                    CWin32StorageProvider::StorageEventType::SAFELY_REMOVED, device);
+              }
             }
+            else
+              CWin32StorageProvider::SetEvent();
             break;
           default:;
         }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Properly separate actions in MediaManager.
Add Win32 support.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #27943.

The wiki is not clear about what happens when autoplay is not set:
<img width="1330" height="174" alt="image" src="https://github.com/user-attachments/assets/56d981a6-3171-4a52-b559-726c8c171a4d" />

Also fix failure of win32 to detect disc/removable storage insertions.
Note they are recognised if present when Kodi starts.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Options:

None
<img width="892" height="351" alt="image" src="https://github.com/user-attachments/assets/9b308944-4bec-4f2c-b6db-ea2fcd3dc9f5" />
Just shows the transient popup notification.

Play
<img width="940" height="555" alt="image" src="https://github.com/user-attachments/assets/c06466ec-02cf-4c3a-92d8-93668dff1bd0" />
For blurays (shows the simple menu - if selected)
For DVDs it just plays the disc

Browse
<img width="940" height="560" alt="image" src="https://github.com/user-attachments/assets/81df0585-7ba4-403c-bce6-4a7d42161a38" />
Shows the browse dialog

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
