### PR TITLE
Fix -Woverloaded-virtual warning in CWinSystemGbm…

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.h
@@ -30,6 +30,7 @@ public:
   ~CWinSystemGbmGLContext() override = default;
 
   static void Register();
+  using CWinSystemGbm::Register;
   static std::unique_ptr<CWinSystemBase> CreateWinSystem();
 
   // Implementation of CWinSystemBase via CWinSystemGbm

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
@@ -30,6 +30,7 @@ public:
   ~CWinSystemGbmGLESContext() override = default;
 
   static void Register();
+  using CWinSystemGbm::Register;
   static std::unique_ptr<CWinSystemBase> CreateWinSystem();
 
   // Implementation of CWinSystemBase via CWinSystemGbm


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

CWinSystemGbmGL(ES)Context declares a static Register() factory method that inadvertently hides the virtual Register(IDispResource*) inherited from CWinSystemGbm. These are two entirely different functions that happen to share the same name — one registers the windowing system with the application, the other manages display resource listeners.

GCC flags this as -Woverloaded-virtual because the parent's virtual overload becomes unreachable through the child class without an explicit cast.

Adding using CWinSystemGbm::Register restores visibility of the inherited overload alongside the static factory method, so both are reachable without ambiguity. No functional changes.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Address build warning

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build on LibreELEC 13

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
