### PR TITLE
Fix peak luminance in HDR PQ mode with preserve chroma

### DIFF
--- a/system/shaders/GLES/2.0/gles_shader_default.frag
+++ b/system/shaders/GLES/2.0/gles_shader_default.frag
@@ -24,6 +24,8 @@ precision mediump float;
 uniform lowp vec4 m_unicol;
 uniform float m_sdrPeak;
 
+const vec3 kLuma = vec3(0.2126, 0.7152, 0.0722);
+
 void main ()
 {
   vec4 rgb;
@@ -36,7 +38,9 @@ void main ()
 #endif
 
 #if defined(KODI_TRANSFER_PQ)
-  rgb.rgb *= m_sdrPeak;
+  float luma = dot(rgb.rgb, kLuma);
+  vec3 chroma = rgb.rgb - luma;
+  rgb.rgb = (luma * m_sdrPeak) + chroma;
 #endif
 
   gl_FragColor = rgb;

--- a/system/shaders/GLES/2.0/gles_shader_fonts.frag
+++ b/system/shaders/GLES/2.0/gles_shader_fonts.frag
@@ -26,6 +26,8 @@ varying vec4 m_cord0;
 varying lowp vec4 m_colour;
 uniform float m_sdrPeak;
 
+const vec3 kLuma = vec3(0.2126, 0.7152, 0.0722);
+
 void main ()
 {
   vec4 rgb;
@@ -39,7 +41,9 @@ void main ()
 #endif
 
 #if defined(KODI_TRANSFER_PQ)
-  rgb.rgb *= m_sdrPeak;
+  float luma = dot(rgb.rgb, kLuma);
+  vec3 chroma = rgb.rgb - luma;
+  rgb.rgb = (luma * m_sdrPeak) + chroma;
 #endif
 
   gl_FragColor = rgb;

--- a/system/shaders/GLES/2.0/gles_shader_multi.frag
+++ b/system/shaders/GLES/2.0/gles_shader_multi.frag
@@ -27,6 +27,8 @@ varying vec4 m_cord0;
 varying vec4 m_cord1;
 uniform float m_sdrPeak;
 
+const vec3 kLuma = vec3(0.2126, 0.7152, 0.0722);
+
 void main ()
 {
   vec4 rgb;
@@ -39,7 +41,9 @@ void main ()
 #endif
 
 #if defined(KODI_TRANSFER_PQ)
-  rgb.rgb *= m_sdrPeak;
+  float luma = dot(rgb.rgb, kLuma);
+  vec3 chroma = rgb.rgb - luma;
+  rgb.rgb = (luma * m_sdrPeak) + chroma;
 #endif
 
   gl_FragColor = rgb;

--- a/system/shaders/GLES/2.0/gles_shader_multi_111r_111r_blendcolor.frag
+++ b/system/shaders/GLES/2.0/gles_shader_multi_111r_111r_blendcolor.frag
@@ -16,6 +16,8 @@ varying vec4 m_cord1;
 uniform lowp vec4 m_unicol;
 uniform float m_sdrPeak;
 
+const vec3 kLuma = vec3(0.2126, 0.7152, 0.0722);
+
 void main()
 {
   gl_FragColor = m_unicol;
@@ -28,6 +30,9 @@ void main()
 #endif
 
 #if defined(KODI_TRANSFER_PQ)
-  gl_FragColor.rgb *= m_sdrPeak;
+  float luma = dot(gl_FragColor.rgb, kLuma);
+  vec3 chroma = gl_FragColor.rgb - luma;
+  gl_FragColor.rgb = (luma * m_sdrPeak) + chroma;
 #endif
+
 }

--- a/system/shaders/GLES/2.0/gles_shader_multi_blendcolor.frag
+++ b/system/shaders/GLES/2.0/gles_shader_multi_blendcolor.frag
@@ -28,6 +28,8 @@ varying vec4 m_cord1;
 uniform lowp vec4 m_unicol;
 uniform float m_sdrPeak;
 
+const vec3 kLuma = vec3(0.2126, 0.7152, 0.0722);
+
 void main ()
 {
   vec4 rgb;
@@ -40,7 +42,9 @@ void main ()
 #endif
 
 #if defined(KODI_TRANSFER_PQ)
-  rgb.rgb *= m_sdrPeak;
+  float luma = dot(rgb.rgb, kLuma);
+  vec3 chroma = rgb.rgb - luma;
+  rgb.rgb = (luma * m_sdrPeak) + chroma;
 #endif
 
   gl_FragColor = rgb;

--- a/system/shaders/GLES/2.0/gles_shader_multi_rgba_111r.frag
+++ b/system/shaders/GLES/2.0/gles_shader_multi_rgba_111r.frag
@@ -15,6 +15,8 @@ varying vec4 m_cord0;
 varying vec4 m_cord1;
 uniform float m_sdrPeak;
 
+const vec3 kLuma = vec3(0.2126, 0.7152, 0.0722);
+
 void main()
 {
   gl_FragColor = texture2D(m_samp0, m_cord0.xy);
@@ -26,6 +28,9 @@ void main()
 #endif
 
 #if defined(KODI_TRANSFER_PQ)
-  gl_FragColor.rgb *= m_sdrPeak;
+  float luma = dot(gl_FragColor.rgb, kLuma);
+  vec3 chroma = gl_FragColor.rgb - luma;
+  gl_FragColor.rgb = (luma * m_sdrPeak) + chroma;
 #endif
+
 }

--- a/system/shaders/GLES/2.0/gles_shader_multi_rgba_111r_blendcolor.frag
+++ b/system/shaders/GLES/2.0/gles_shader_multi_rgba_111r_blendcolor.frag
@@ -16,6 +16,8 @@ varying vec4 m_cord1;
 uniform lowp vec4 m_unicol;
 uniform float m_sdrPeak;
 
+const vec3 kLuma = vec3(0.2126, 0.7152, 0.0722);
+
 void main()
 {
   gl_FragColor = m_unicol;
@@ -28,6 +30,8 @@ void main()
 #endif
 
 #if defined(KODI_TRANSFER_PQ)
-  gl_FragColor.rgb *= m_sdrPeak;
+  float luma = dot(gl_FragColor.rgb, kLuma);
+  vec3 chroma = gl_FragColor.rgb - luma;
+  gl_FragColor.rgb = (luma * m_sdrPeak) + chroma;
 #endif
 }

--- a/system/shaders/GLES/2.0/gles_shader_texture.frag
+++ b/system/shaders/GLES/2.0/gles_shader_texture.frag
@@ -26,6 +26,8 @@ uniform lowp vec4 m_unicol;
 varying vec4 m_cord0;
 uniform float m_sdrPeak;
 
+const vec3 kLuma = vec3(0.2126, 0.7152, 0.0722);
+
 void main ()
 {
   vec4 rgb;
@@ -38,7 +40,9 @@ void main ()
 #endif
 
 #if defined(KODI_TRANSFER_PQ)
-  rgb.rgb *= m_sdrPeak;
+  float luma = dot(rgb.rgb, kLuma);
+  vec3 chroma = rgb.rgb - luma;
+  rgb.rgb = (luma * m_sdrPeak) + chroma;
 #endif
 
   gl_FragColor = rgb;

--- a/system/shaders/GLES/2.0/gles_shader_texture_111r.frag
+++ b/system/shaders/GLES/2.0/gles_shader_texture_111r.frag
@@ -14,6 +14,8 @@ uniform lowp vec4 m_unicol;
 varying vec4 m_cord0;
 uniform float m_sdrPeak;
 
+const vec3 kLuma = vec3(0.2126, 0.7152, 0.0722);
+
 void main()
 {
   gl_FragColor = m_unicol;
@@ -25,6 +27,9 @@ void main()
 #endif
 
 #if defined(KODI_TRANSFER_PQ)
-  gl_FragColor.rgb *= m_sdrPeak;
+  float luma = dot(gl_FragColor.rgb, kLuma);
+  vec3 chroma = gl_FragColor.rgb - luma;
+  gl_FragColor.rgb = (luma * m_sdrPeak) + chroma;
 #endif
+
 }

--- a/system/shaders/GLES/2.0/gles_shader_texture_noalpha.frag
+++ b/system/shaders/GLES/2.0/gles_shader_texture_noalpha.frag
@@ -13,6 +13,8 @@ uniform sampler2D m_samp0;
 varying vec4 m_cord0;
 uniform float m_sdrPeak;
 
+const vec3 kLuma = vec3(0.2126, 0.7152, 0.0722);
+
 void main ()
 {
   vec3 rgb = texture2D(m_samp0, m_cord0.xy).rgb;
@@ -23,7 +25,9 @@ void main ()
 #endif
 
 #if defined(KODI_TRANSFER_PQ)
-  rgb.rgb *= m_sdrPeak;
+  float luma = dot(rgb.rgb, kLuma);
+  vec3 chroma = rgb.rgb - luma;
+  rgb.rgb = (luma * m_sdrPeak) + chroma;
 #endif
 
   gl_FragColor = vec4(rgb, 1.0);

--- a/system/shaders/GLES/2.0/gles_shader_texture_noblend.frag
+++ b/system/shaders/GLES/2.0/gles_shader_texture_noblend.frag
@@ -25,6 +25,8 @@ uniform sampler2D m_samp0;
 varying vec4 m_cord0;
 uniform float m_sdrPeak;
 
+const vec3 kLuma = vec3(0.2126, 0.7152, 0.0722);
+
 void main ()
 {
   vec4 rgb;
@@ -37,7 +39,9 @@ void main ()
 #endif
 
 #if defined(KODI_TRANSFER_PQ)
-  rgb.rgb *= m_sdrPeak;
+  float luma = dot(rgb.rgb, kLuma);
+  vec3 chroma = rgb.rgb - luma;
+  rgb.rgb = (luma * m_sdrPeak) + chroma;
 #endif
 
   gl_FragColor = rgb;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Fix peak luminance in HDR PQ mode with preserve chroma
Add PQ‑based tone-dependent saturation boost to improve quality.
Defaut is now a saturation boost of 1.25, can be changed by windowing system by override.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Current implementation apply peak brightness to whole RGB value what is not correct.
It should only be applied to Y.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On HDR screen with HDR10/DV/HLG media.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
GUI quality

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
