### PR TITLE
Fix -Wmaybe-uninitialized warnings in MusicDatabaseDirectory and Mp4ChplReader

### DIFF
--- a/xbmc/filesystem/MusicDatabaseDirectory.cpp
+++ b/xbmc/filesystem/MusicDatabaseDirectory.cpp
@@ -40,7 +40,7 @@ bool CMusicDatabaseDirectory::GetDirectory(const CURL& url, CFileItemList &items
   // Adjust path to control navigation from albums to discs or directly to songs
   CQueryParams params;
   NodeType type;
-  NodeType childtype;
+  NodeType childtype{};
   GetDirectoryNodeInfo(path, type, childtype, params);
   if (childtype == NodeType::DISC)
   {

--- a/xbmc/utils/Mp4ChplReader.cpp
+++ b/xbmc/utils/Mp4ChplReader.cpp
@@ -89,7 +89,7 @@ ChplChapterResult ParseChpl(CFile& file, const int64_t chplSize, std::vector<Chp
       (uint32_t(flagBuf[0]) << 16) | (uint32_t(flagBuf[1]) << 8) | uint32_t(flagBuf[2]);
 
   uint32_t count = 0;
-  std::chrono::nanoseconds timeBase;
+  std::chrono::nanoseconds timeBase{};
 
   if (version == 0)
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Value-initialize two variables that GCC flags as potentially uninitialized:

childtype in CMusicDatabaseDirectory::GetDirectory — GetDirectoryNodeInfo
may not set it in all code paths before use.
timeBase in ParseChpl — only assigned in the version == 1 branch but
potentially reachable via timeBase * ts from other paths. The version == 0
path never uses it and version == 1 always overwrites it before use.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix build warnings

```c++
../../kodi-66a63a8378e2808e4dac24096275fc9f1eae4724/.x86_64-libreelec-linux-gnu/../xbmc/filesystem/MusicDatabaseDirectory.cpp: In member function 'GetDirectory':
../../kodi-66a63a8378e2808e4dac24096275fc9f1eae4724/.x86_64-libreelec-linux-gnu/../xbmc/filesystem/MusicDatabaseDirectory.cpp:45:3: warning: 'childtype' may be used uninitialized [-Wmaybe-uninitialized]
../../kodi-66a63a8378e2808e4dac24096275fc9f1eae4724/.x86_64-libreelec-linux-gnu/../xbmc/filesystem/MusicDatabaseDirectory.cpp:43:12: note: 'childtype' was declared here
In function '__cast',
    inlined from 'duration_cast' at /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/16.0.1/bits/chrono.h:293:23,
    inlined from '__ct ' at /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/16.0.1/bits/chrono.h:586:33,
    inlined from 'operator*' at /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/16.0.1/bits/chrono.h:749:14,
    inlined from 'ParseChpl' at ../../kodi-364219ea7cb01c1ee627c56c88c0178d310505a1/.x86_64-libreelec-linux-gnu/../xbmc/utils/Mp4ChplReader.cpp:150:27,
    inlined from 'ProcessAtom' at ../../kodi-364219ea7cb01c1ee627c56c88c0178d310505a1/.x86_64-libreelec-linux-gnu/../xbmc/utils/Mp4ChplReader.cpp:241:53:
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/16.0.1/bits/chrono.h:205:27: warning: 'MEM[(const struct duration *)&timeBase].__r' may be used uninitialized [-Wmaybe-uninitialized]
  205 |             return _ToDur(static_cast<__to_rep>(__d.count()));
      |                           ^
../../kodi-364219ea7cb01c1ee627c56c88c0178d310505a1/.x86_64-libreelec-linux-gnu/../xbmc/utils/Mp4ChplReader.cpp: In function 'ProcessAtom':
../../kodi-364219ea7cb01c1ee627c56c88c0178d310505a1/.x86_64-libreelec-linux-gnu/../xbmc/utils/Mp4ChplReader.cpp:92:28: note: 'MEM[(const struct duration *)&timeBase].__r' was declared here


``` 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
LibreELEC 13

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
