### PR TITLE
Fix SWIG Warning 302 redefinition of Dialog input constants

### DIFF
--- a/xbmc/interfaces/legacy/Dialog.h
+++ b/xbmc/interfaces/legacy/Dialog.h
@@ -24,6 +24,9 @@ namespace XBMCAddon
 {
 namespace xbmcgui
 {
+#ifndef SWIG
+// These constants are exposed to Python via SWIG_CONSTANT in ModuleXbmcgui.h.
+// Excluded from SWIG processing here to avoid Warning 302 redefinition.
 constexpr int INPUT_ALPHANUM{0};
 constexpr int INPUT_NUMERIC{1};
 constexpr int INPUT_DATE{2};
@@ -33,6 +36,7 @@ constexpr int INPUT_PASSWORD{5};
 
 constexpr int PASSWORD_VERIFY{1};
 constexpr int ALPHANUM_HIDE_INPUT{2};
+#endif
 
     ///
     /// \defgroup python_Dialog Dialog


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The constants INPUT_ALPHANUM, INPUT_NUMERIC, INPUT_DATE, INPUT_TIME,
INPUT_IPADDRESS, INPUT_PASSWORD, PASSWORD_VERIFY, and ALPHANUM_HIDE_INPUT
are defined as constexpr int in Dialog.h for C++ use and also exposed to
Python via SWIG_CONSTANT in ModuleXbmcgui.h. SWIG processes both files and
warns about the duplicate definitions with Warning 302.

Wrap the constexpr definitions in Dialog.h with #ifndef SWIG so SWIG
skips them entirely, relying solely on the SWIG_CONSTANT entries in
ModuleXbmcgui.h for the Python xbmcgui module. C++ compilation is
unaffected as the constexpr definitions remain visible to the compiler.


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix build warnings

```c++
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/kodi-c35e1ca4bb72fb8abd19bdc84156864e1b4b7433/xbmc/interfaces/legacy/ModuleXbmcgui.h:137: Warning 302: previous definition of 'INPUT_TIME' as XBMCAddon::xbmcgui::INPUT_TIME.
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/kodi-c35e1ca4bb72fb8abd19bdc84156864e1b4b7433/xbmc/interfaces/legacy/Dialog.h:31: Warning 302: Redefinition of identifier 'INPUT_IPADDRESS' as XBMCAddon::xbmcgui::INPUT_IPADDRESS ignored,
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/kodi-c35e1ca4bb72fb8abd19bdc84156864e1b4b7433/xbmc/interfaces/legacy/ModuleXbmcgui.h:138: Warning 302: previous definition of 'INPUT_IPADDRESS' as XBMCAddon::xbmcgui::INPUT_IPADDRESS.
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/kodi-c35e1ca4bb72fb8abd19bdc84156864e1b4b7433/xbmc/interfaces/legacy/Dialog.h:32: Warning 302: Redefinition of identifier 'INPUT_PASSWORD' as XBMCAddon::xbmcgui::INPUT_PASSWORD ignored,
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/kodi-c35e1ca4bb72fb8abd19bdc84156864e1b4b7433/xbmc/interfaces/legacy/ModuleXbmcgui.h:139: Warning 302: previous definition of 'INPUT_PASSWORD' as XBMCAddon::xbmcgui::INPUT_PASSWORD.
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/kodi-c35e1ca4bb72fb8abd19bdc84156864e1b4b7433/xbmc/interfaces/legacy/Dialog.h:34: Warning 302: Redefinition of identifier 'PASSWORD_VERIFY' as XBMCAddon::xbmcgui::PASSWORD_VERIFY ignored,
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/kodi-c35e1ca4bb72fb8abd19bdc84156864e1b4b7433/xbmc/interfaces/legacy/ModuleXbmcgui.h:144: Warning 302: previous definition of 'PASSWORD_VERIFY' as XBMCAddon::xbmcgui::PASSWORD_VERIFY.
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/kodi-c35e1ca4bb72fb8abd19bdc84156864e1b4b7433/xbmc/interfaces/legacy/Dialog.h:35: Warning 302: Redefinition of identifier 'ALPHANUM_HIDE_INPUT' as XBMCAddon::xbmcgui::ALPHANUM_HIDE_INPUT ignored,
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/kodi-c35e1ca4bb72fb8abd19bdc84156864e1b4b7433/xbmc/interfaces/legacy/ModuleXbmcgui.h:145: Warning 302: previous definition of 'ALPHANUM_HIDE_INPUT' as XBMCAddon::xbmcgui::ALPHANUM_HIDE_INPUT.
``` 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built on LibreELEC 13

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
