### PR TITLE
[Experimental] Implement InputStream addon audio codec interface

### DIFF
--- a/addons/kodi.binary.instance.audiocodec/addon.xml.in
+++ b/addons/kodi.binary.instance.audiocodec/addon.xml.in
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon id="kodi.binary.instance.audiocodec" version="@ADDON_INSTANCE_VERSION_AUDIOCODEC@" provider-name="Team Kodi">
+  <backwards-compatibility abi="@ADDON_INSTANCE_VERSION_AUDIOCODEC_MIN@"/>
+  <requires>
+    <import addon="xbmc.core" version="0.1.0"/>
+  </requires>
+</addon>

--- a/system/addon-manifest.xml
+++ b/system/addon-manifest.xml
@@ -12,6 +12,7 @@
   <addon>kodi.binary.global.main</addon>
   <addon>kodi.binary.global.network</addon>
   <addon>kodi.binary.global.tools</addon>
+  <addon>kodi.binary.instance.audiocodec</addon>
   <addon>kodi.binary.instance.audiodecoder</addon>
   <addon>kodi.binary.instance.audioencoder</addon>
   <addon>kodi.binary.instance.game</addon>

--- a/xbmc/addons/AddonProvider.h
+++ b/xbmc/addons/AddonProvider.h
@@ -29,7 +29,8 @@ public:
   enum class InstanceType
   {
     INPUTSTREAM,
-    VIDEOCODEC
+    VIDEOCODEC,
+    AUDIOCODEC
   };
   virtual void GetAddonInstance(InstanceType instance_type,
                                 ADDON::AddonInfoPtr& addonInfo,

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/AudioCodec.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/AudioCodec.h
@@ -1,0 +1,400 @@
+/*
+ *  Copyright (C) 2017-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "../AddonBase.h"
+#include "../c-api/addon-instance/audio_codec.h"
+#include "inputstream/DemuxPacket.h"
+#include "inputstream/StreamCodec.h"
+#include "inputstream/StreamCrypto.h"
+
+#ifdef __cplusplus
+
+namespace kodi
+{
+namespace addon
+{
+
+class CInstanceAudioCodec;
+
+//==============================================================================
+/// @defgroup cpp_kodi_addon_audiocodec_Defs_AudioCodecInitdata class AudioCodecInitdata
+/// @ingroup cpp_kodi_addon_audiocodec_Defs
+/// @brief Initialization data to open an audio codec stream.
+///
+/// ----------------------------------------------------------------------------
+///
+/// @copydetails cpp_kodi_addon_audiocodec_Defs_AudioCodecInitdata_Help
+///
+///@{
+class ATTR_DLL_LOCAL AudioCodecInitdata : public CStructHdl<AudioCodecInitdata, AUDIOCODEC_INITDATA>
+{
+  /*! \cond PRIVATE */
+  friend class CInstanceAudioCodec;
+  /*! \endcond */
+
+public:
+  /// @defgroup cpp_kodi_addon_audiocodec_Defs_AudioCodecInitdata_Help Value Help
+  /// @ingroup cpp_kodi_addon_audiocodec_Defs_AudioCodecInitdata
+  ///
+  /// <b>The following table contains values that can be set with @ref cpp_kodi_addon_audiocodec_Defs_AudioCodecInitdata :</b>
+  /// | Name | Type | Get call
+  /// |------|------|----------
+  /// | **Codec type** | `AUDIOCODEC_TYPE` | @ref AudioCodecInitdata::GetCodecType "GetCodecType"
+  /// | **Codec profile** | `STREAMCODEC_PROFILE` | @ref AudioCodecInitdata::GetCodecProfile "GetCodecProfile"
+  /// | **Audio formats** | `std::vector<AUDIOCODEC_FORMAT>` | @ref AudioCodecInitdata::GetAudioFormats "GetAudioFormats"
+  /// | **Extra data** | `const uint8_t*` | @ref AudioCodecInitdata::GetExtraData "GetExtraData"
+  /// | **Extra data size** | `unsigned int` | @ref AudioCodecInitdata::GetExtraDataSize "GetExtraDataSize"
+  /// | **Crypto session** | `kodi::addon::StreamCryptoSession` | @ref AudioCodecInitdata::GetCryptoSession "GetCryptoSession"
+  ///
+
+  /// @addtogroup cpp_kodi_addon_audiocodec_Defs_AudioCodecInitdata
+  ///@{
+
+  /// @brief The codec type required by Kodi to process the stream.
+  ///
+  /// See @ref AUDIOCODEC_TYPE for possible values.
+  AUDIOCODEC_TYPE GetCodecType() const { return m_cStructure->codec; }
+
+  /// @brief Used profile
+  STREAMCODEC_PROFILE GetCodecProfile() const { return m_cStructure->codecProfile; }
+
+  /// @brief Depending on the required decoding, additional data given by the stream.
+  const uint8_t* GetExtraData() const { return m_cStructure->extraData; }
+
+  /// @brief Size of the data given with @ref extraData.
+  unsigned int GetExtraDataSize() const { return m_cStructure->extraDataSize; }
+
+  /// @brief **Data to manage stream cryptography**\n
+  /// To get class structure manages any encryption values required in order to have
+  /// them available in their stream processing.
+  ///
+  /// ----------------------------------------------------------------------------
+  ///
+  /// @copydetails cpp_kodi_addon_inputstream_Defs_Info_StreamCryptoSession_Help
+  ///
+  kodi::addon::StreamCryptoSession GetCryptoSession() const { return &m_cStructure->cryptoSession; }
+
+  ///@}
+
+private:
+  AudioCodecInitdata() = delete;
+  AudioCodecInitdata(const AudioCodecInitdata& session) : CStructHdl(session) {}
+  AudioCodecInitdata(const AUDIOCODEC_INITDATA* session) : CStructHdl(session) {}
+  AudioCodecInitdata(AUDIOCODEC_INITDATA* session) : CStructHdl(session) {}
+};
+///@}
+//------------------------------------------------------------------------------
+
+//##############################################################################
+/// @defgroup cpp_kodi_addon_audiocodec_Defs Definitions, structures and enumerators
+/// @ingroup cpp_kodi_addon_audiocodec
+/// @brief **Audio codec add-on general variables**
+///
+/// Used to exchange the available options between Kodi and addon.
+///
+///
+
+//============================================================================
+///
+/// @addtogroup cpp_kodi_addon_audiocodec
+/// @brief \cpp_class{ kodi::addon::CInstanceAudioCodec }
+/// **Audio codec add-on instance**
+///
+/// This is an addon instance class to add an additional audio decoder to Kodi
+/// using addon.
+///
+/// This means that either a new type of decoding can be introduced to an input
+/// stream add-on that requires special types of decoding.
+///
+/// When using the inputstream addon, @ref cpp_kodi_addon_inputstream_Defs_Interface_InputstreamInfo
+/// to @ref cpp_kodi_addon_inputstream_Defs_Info is used to declare that the
+/// decoder stored in the addon is used.
+///
+/// @note At the moment this can only be used together with input stream addons,
+/// independent use as a codec addon is not yet possible.
+///
+/// Include the header @ref AudioCodec.h "#include <kodi/addon-instance/AudioCodec.h>"
+/// to use this class.
+///
+/// --------------------------------------------------------------------------
+///
+/// **Example:**
+/// This as an example when used together with @ref cpp_kodi_addon_inputstream "kodi::addon::CInstanceInputStream".
+///
+/// ~~~~~~~~~~~~~{.cpp}
+/// #include <kodi/addon-instance/Inputstream.h>
+/// #include <kodi/addon-instance/AudioCodec.h>
+///
+/// class CMyAudioCodec : public kodi::addon::CInstanceAudioCodec
+/// {
+/// public:
+///   CMyAudioCodec(const kodi::addon::IInstanceInfo& instance,
+///                 CMyInputstream* inputstream);
+///   ...
+///
+/// private:
+///   CMyInputstream* m_inputstream;
+/// };
+///
+/// CMyAudioCodec::CMyAudioCodec(const kodi::addon::IInstanceInfo& instance,
+///                              CMyInputstream* inputstream)
+///   : kodi::addon::CInstanceAudioCodec(instance),
+///     m_inputstream(inputstream)
+/// {
+///   ...
+/// }
+/// ...
+///
+/// //----------------------------------------------------------------------
+///
+/// class CMyInputstream : public kodi::addon::CInstanceInputStream
+/// {
+/// public:
+///   CMyInputstream(KODI_HANDLE instance, const std::string& kodiVersion);
+///
+///   ADDON_STATUS CreateInstance(const kodi::addon::IInstanceInfo& instance,
+///                               KODI_ADDON_INSTANCE_HDL& hdl) override;
+///   ...
+/// };
+///
+/// CMyInputstream::CMyInputstream(KODI_HANDLE instance, const std::string& kodiVersion)
+///   : kodi::addon::CInstanceInputStream(instance, kodiVersion)
+/// {
+///   ...
+/// }
+///
+/// ADDON_STATUS CMyInputstream::CreateInstance(const kodi::addon::IInstanceInfo& instance,
+///                                             KODI_ADDON_INSTANCE_HDL& hdl)
+/// {
+/// {
+///   if (instance.IsType(ADDON_INSTANCE_AUDIOCODEC))
+///   {
+///     addonInstance = new CMyAudioCodec(instance, this);
+///     return ADDON_STATUS_OK;
+///   }
+///   return ADDON_STATUS_NOT_IMPLEMENTED;
+/// }
+///
+/// ...
+///
+/// //----------------------------------------------------------------------
+///
+/// class CMyAddon : public kodi::addon::CAddonBase
+/// {
+/// public:
+///   CMyAddon() = default;
+///   ADDON_STATUS CreateInstance(const kodi::addon::IInstanceInfo& instance,
+///                               KODI_ADDON_INSTANCE_HDL& hdl) override;
+/// };
+///
+/// // If you use only one instance in your add-on, can be instanceType and
+/// // instanceID ignored
+/// ADDON_STATUS CMyAddon::CreateInstance(const kodi::addon::IInstanceInfo& instance,
+///                                       KODI_ADDON_INSTANCE_HDL& hdl)
+/// {
+///   if (instance.IsType(ADDON_INSTANCE_INPUTSTREAM))
+///   {
+///     kodi::Log(ADDON_LOG_NOTICE, "Creating my Inputstream");
+///     hdl = new CMyInputstream(instance);
+///     return ADDON_STATUS_OK;
+///   }
+///   else if (...)
+///   {
+///     ...
+///   }
+///   return ADDON_STATUS_UNKNOWN;
+/// }
+///
+/// ADDONCREATOR(CMyAddon)
+/// ~~~~~~~~~~~~~
+///
+/// The destruction of the example class `CMyInputstream` is called from
+/// Kodi's header. Manually deleting the add-on instance is not required.
+///
+///
+///
+class ATTR_DLL_LOCAL CInstanceAudioCodec : public IAddonInstance
+{
+public:
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_audiocodec
+  /// @brief Audio codec class constructor used to support multiple instance
+  /// types
+  ///
+  /// @param[in] instance The instance value given to <b>`kodi::addon::CAddonBase::CreateInstance(...)`</b>,
+  ///                     or by a inputstream instance if them declared as parent.
+  /// @param[in] kodiVersion [opt] Version used in Kodi for this instance, to
+  ///                        allow compatibility to older Kodi versions.
+  ///
+  explicit CInstanceAudioCodec(const IInstanceInfo& instance) : IAddonInstance(instance)
+  {
+    if (CPrivateBase::m_interface->globalSingleInstance != nullptr)
+      throw std::logic_error("kodi::addon::CInstanceAudioCodec: Creation of multiple together with "
+                             "single instance way is not allowed!");
+
+    SetAddonStruct(instance);
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_audiocodec
+  /// @brief Destructor
+  ///
+  ~CInstanceAudioCodec() override = default;
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_audiocodec
+  /// @brief Open the decoder, returns true on success
+  ///
+  /// Decoders not capable of running multiple instances should return false in case
+  /// there is already a instance open.
+  ///
+  /// @param[in] initData Audio codec init data
+  /// @return true if successfully done
+  ///
+  ///
+  /// ----------------------------------------------------------------------------
+  ///
+  /// @copydetails cpp_kodi_addon_audiocodec_Defs_AudioCodecInitdata_Help
+  ///
+  virtual bool Open(const kodi::addon::AudioCodecInitdata& initData) { return false; }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_audiocodec
+  /// @brief add data, decoder has to consume the entire packet
+  ///
+  /// @param[in] packet Data to process for decode
+  /// @return true if the packet was consumed or if resubmitting it is useless
+  ///
+  virtual bool AddData(const DEMUX_PACKET& packet) { return false; }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_audiocodec
+  /// @brief GetFrame controls decoding.
+  ///
+  /// Player calls it on every cycle it can signal a frame, request a buffer,
+  /// or return none, if nothing applies the data is valid until the next
+  /// GetFramee return @ref VC_FRAME
+  ///
+  /// @param[in,out] Structure which contains the necessary data
+  /// @return The with @ref AUDIOCODEC_RETVAL return values
+  ///
+  virtual AUDIOCODEC_RETVAL GetFrame(AUDIOCODEC_FRAME& frame) { return AC_ERROR; }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_audiocodec
+  /// @brief should return codecs name
+  ///
+  /// @return Codec name
+  ///
+  virtual const char* GetName() { return nullptr; }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_audiocodec
+  /// @brief Reset the decoder
+  ///
+  virtual void Reset() {}
+  //----------------------------------------------------------------------------
+
+  /*!
+   * @brief AddonToKodi interface
+   */
+
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_audiocodec
+  /// @brief All frame members can be expected to be set correctly except
+  /// decodedData and pts.
+  ///
+  /// GetFrameBuffer has to set decodedData to a valid memory address and return true.
+  ///
+  /// @param[out] frame The buffer, or unmodified if false is returned
+  /// @return In case buffer allocation fails, it return false.
+  ///
+  /// @note If this returns true, buffer must be freed using @ref ReleaseFrameBuffer().
+  ///
+  /// @remarks Only called from addon itself
+  ///
+  bool GetFrameBuffer(AUDIOCODEC_FRAME& frame)
+  {
+    return m_instanceData->toKodi->get_frame_buffer(m_instanceData->toKodi->kodiInstance, &frame);
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  ///
+  /// @ingroup cpp_kodi_addon_audiocodec
+  /// @brief Release the with @ref GetFrameBuffer() given framebuffer.
+  ///
+  /// @param[in] handle the on @ref AUDIOCODEC_FRAME.audioBufferHandle defined buffer handle
+  ///
+  /// @remarks Only called from addon itself
+  ///
+  void ReleaseFrameBuffer(void* buffer)
+  {
+    return m_instanceData->toKodi->release_frame_buffer(m_instanceData->toKodi->kodiInstance,
+                                                        buffer);
+  }
+  //----------------------------------------------------------------------------
+
+private:
+  void SetAddonStruct(KODI_ADDON_INSTANCE_STRUCT* instance)
+  {
+    instance->hdl = this;
+    instance->audiocodec->toAddon->open = ADDON_Open;
+    instance->audiocodec->toAddon->add_data = ADDON_AddData;
+    instance->audiocodec->toAddon->get_frame = ADDON_GetFrame;
+    instance->audiocodec->toAddon->get_name = ADDON_GetName;
+    instance->audiocodec->toAddon->reset = ADDON_Reset;
+
+    m_instanceData = instance->audiocodec;
+    m_instanceData->toAddon->addonInstance = this;
+  }
+
+  inline static bool ADDON_Open(const AddonInstance_AudioCodec* instance,
+                                AUDIOCODEC_INITDATA* initData)
+  {
+    return static_cast<CInstanceAudioCodec*>(instance->toAddon->addonInstance)->Open(initData);
+  }
+
+  inline static bool ADDON_AddData(const AddonInstance_AudioCodec* instance,
+                                   const DEMUX_PACKET* packet)
+  {
+    return static_cast<CInstanceAudioCodec*>(instance->toAddon->addonInstance)->AddData(*packet);
+  }
+
+  inline static AUDIOCODEC_RETVAL ADDON_GetFrame(const AddonInstance_AudioCodec* instance,
+                                                   AUDIOCODEC_FRAME* frame)
+  {
+    return static_cast<CInstanceAudioCodec*>(instance->toAddon->addonInstance)
+        ->GetFrame(*frame);
+  }
+
+  inline static const char* ADDON_GetName(const AddonInstance_AudioCodec* instance)
+  {
+    return static_cast<CInstanceAudioCodec*>(instance->toAddon->addonInstance)->GetName();
+  }
+
+  inline static void ADDON_Reset(const AddonInstance_AudioCodec* instance)
+  {
+    return static_cast<CInstanceAudioCodec*>(instance->toAddon->addonInstance)->Reset();
+  }
+
+  AddonInstance_AudioCodec* m_instanceData;
+};
+
+} // namespace addon
+} // namespace kodi
+
+#endif /* __cplusplus */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/CMakeLists.txt
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See xbmc/addons/kodi-dev-kit/tools/code-generator.py.
 
 set(HEADERS
+  AudioCodec.h
   AudioDecoder.h
   AudioEncoder.h
   Game.h

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/inputstream/StreamCrypto.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/inputstream/StreamCrypto.h
@@ -21,6 +21,7 @@ namespace addon
 class CInstanceInputStream;
 class InputstreamInfo;
 class VideoCodecInitdata;
+class AudioCodecInitdata;
 
 //==============================================================================
 /// @defgroup cpp_kodi_addon_inputstream_Defs_StreamEncryption_StreamCryptoSession class StreamCryptoSession
@@ -45,6 +46,7 @@ class ATTR_DLL_LOCAL StreamCryptoSession
   friend class CInstanceInputStream;
   friend class InputstreamInfo;
   friend class VideoCodecInitdata;
+  friend class AudioCodecInitdata;
   /*! \endcond */
 
 public:

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/CMakeLists.txt
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See xbmc/addons/kodi-dev-kit/tools/code-generator.py.
 
 set(HEADERS
+  audio_codec.h
   audiodecoder.h
   audioencoder.h
   game.h

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/audio_codec.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/audio_codec.h
@@ -1,0 +1,235 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#ifndef C_API_ADDONINSTANCE_AUDIOCODEC_H
+#define C_API_ADDONINSTANCE_AUDIOCODEC_H
+
+#include "../addon_base.h"
+#include "inputstream/demux_packet.h"
+#include "inputstream/stream_codec.h"
+#include "inputstream/stream_crypto.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_audio_codec_Defs
+  /// @brief Return values used by audio decoder interface
+  enum AUDIOCODEC_RETVAL
+  {
+    /// @brief Noop
+    AC_NONE = 0,
+
+    /// @brief An error occurred, no other messages will be returned
+    AC_ERROR,
+
+    /// @brief The decoder needs more data
+    AC_BUFFER,
+
+    /// @brief The decoder got a frame
+    AC_FRAME,
+
+    /// @brief The decoder signals EOF
+    AC_EOF,
+  };
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_audiocodec_Defs_AudioCodecInitdata
+  /// @brief Audio codec types that can be requested from Kodi
+  ///
+  enum AUDIOCODEC_TYPE
+  {
+    /// @brief Unknown or other type requested
+    AUDIOCODEC_UNKNOWN = 0,
+    AUDIOCODEC_MP1,
+    AUDIOCODEC_MP2,
+    AUDIOCODEC_MP3, /// @brief preferred ID for decoding MPEG audio layer 1, 2 or 3
+    AUDIOCODEC_AAC,
+    AUDIOCODEC_AAC_LATM,
+    AUDIOCODEC_AC3,
+    AUDIOCODEC_EAC3,
+    AUDIOCODEC_DTS,
+    AUDIOCODEC_TRUEHD,
+    AUDIOCODEC_VORBIS,
+    AUDIOCODEC_OPUS,
+    AUDIOCODEC_AC4,
+  };
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_audiocodec_Defs
+  /// @brief Audio formats that can be requested from Kodi
+  ///
+  /// Minimal set, addon and Kodi can extend this later if needed.
+  enum AUDIOCODEC_FORMAT
+  {
+    AUDIOCODEC_FMT_UNKNOWN = 0,
+
+    AUDIOCODEC_FMT_U8,
+
+    AUDIOCODEC_FMT_S16BE,
+    AUDIOCODEC_FMT_S16LE,
+    AUDIOCODEC_FMT_S16NE,
+
+    AUDIOCODEC_FMT_S32BE,
+    AUDIOCODEC_FMT_S32LE,
+    AUDIOCODEC_FMT_S32NE,
+
+    AUDIOCODEC_FMT_S24BE4,
+    AUDIOCODEC_FMT_S24LE4,
+    AUDIOCODEC_FMT_S24NE4, // 24 bits in lower 3 bytes
+    AUDIOCODEC_FMT_S24NE4MSB, // S32 with bits_per_sample < 32
+
+    AUDIOCODEC_FMT_S24BE3,
+    AUDIOCODEC_FMT_S24LE3,
+    AUDIOCODEC_FMT_S24NE3, // S24 in 3 bytes
+
+    AUDIOCODEC_FMT_DOUBLE,
+    AUDIOCODEC_FMT_FLOAT,
+
+    // Bitstream
+    AUDIOCODEC_FMT_RAW,
+
+    // Planar formats
+    AUDIOCODEC_FMT_U8P,
+    AUDIOCODEC_FMT_S16NEP,
+    AUDIOCODEC_FMT_S32NEP,
+    AUDIOCODEC_FMT_S24NE4P,
+    AUDIOCODEC_FMT_S24NE4MSBP,
+    AUDIOCODEC_FMT_S24NE3P,
+    AUDIOCODEC_FMT_DOUBLEP,
+    AUDIOCODEC_FMT_FLOATP,
+
+    AUDIOCODEC_FMT_MAX
+  };
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @ingroup cpp_kodi_addon_audiocodec_Defs_AUDIOCODEC_FRAME
+  /// @brief Audio coded process flags, used to perform special operations in
+  /// stream calls.
+  ///
+  /// These are used to access stored data in @ref AUDIOCODEC_FRAME::flags.
+  ///
+  /// @note These variables are bit flags which are created using "|" can be used together.
+  ///
+  enum AUDIOCODEC_FRAME_FLAGS
+  {
+    /// @brief Empty and nothing defined
+    AUDIOCODEC_FRAME_FLAG_NONE = 0,
+
+    /// @brief Drop in decoder
+    AUDIOCODEC_FRAME_FLAG_DROP = (1 << 0),
+
+    /// @brief Squeeze out framed without feeding new packets
+    AUDIOCODEC_FRAME_FLAG_DRAIN = (1 << 1),
+  };
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  /// @defgroup cpp_kodi_addon_audiocodec_Defs_AUDIOCODEC_FRAME struct AUDIOCODEC_FRAME
+  /// @ingroup cpp_kodi_addon_audiocodec_Defs
+  /// @brief Data structure which is given to the addon when a decoding call is made.
+  ///
+  ///@{
+  struct AUDIOCODEC_FRAME
+  {
+    /// @brief The audio format declared with @ref AUDIOCODEC_FORMAT and to be
+    /// used on the addon.
+    enum AUDIOCODEC_FORMAT audioFormat;
+
+    /// @brief Audio coded process flags, used to perform special operations in
+    /// stream calls.
+    ///
+    /// Possible flags are declared here @ref AUDIOCODEC_FRAME_FLAGS.
+    uint32_t flags;
+
+    /// @brief Data to be decoded in the addon.
+    uint8_t* decodedData;
+
+    /// @brief Size of the data given with @ref decodedData
+    size_t decodedDataSize;
+
+    /// @brief Picture presentation time stamp (PTS).
+    int64_t pts;
+
+    /// @brief This is used to save the related handle from Kodi.
+    ///
+    /// To handle the input stream buffer, this is given by Kodi using
+    /// @ref kodi::addon::CInstanceAudioCodec::GetFrameBuffer and must be
+    /// released again using @ref kodi::addon::CInstanceAudioCodec::ReleaseFrameBuffer.
+    KODI_HANDLE audioBufferHandle;
+  };
+  ///@}
+  //----------------------------------------------------------------------------
+
+  struct AUDIOCODEC_INITDATA
+  {
+    enum AUDIOCODEC_TYPE codec;
+    enum STREAMCODEC_PROFILE codecProfile;
+    const uint8_t* extraData;
+    unsigned int extraDataSize;
+    struct STREAM_CRYPTO_SESSION cryptoSession;
+    int32_t sampleRate;
+    int32_t channels;
+    int32_t bitsPerSample;
+  };
+
+  // this are properties given to the addon on create
+  // at this time we have no parameters for the addon
+  typedef struct AddonProps_AudioCodec
+  {
+    int dummy;
+  } AddonProps_AudioCodec;
+
+  struct AddonInstance_AudioCodec;
+  typedef struct KodiToAddonFuncTable_AudioCodec
+  {
+    KODI_HANDLE addonInstance;
+
+    //! @brief Opens a codec
+    bool(__cdecl* open)(const struct AddonInstance_AudioCodec* instance,
+                        struct AUDIOCODEC_INITDATA* initData);
+
+    //! @brief Feed codec if requested from GetFrame() (return VC_BUFFER)
+    bool(__cdecl* add_data)(const struct AddonInstance_AudioCodec* instance,
+                            const struct DEMUX_PACKET* packet);
+
+    //! @brief Get a decoded frame / request new data
+    enum AUDIOCODEC_RETVAL(__cdecl* get_frame)(const struct AddonInstance_AudioCodec* instance,
+                                               struct AUDIOCODEC_FRAME* frame);
+
+    //! @brief Get the name of this audio decoder
+    const char*(__cdecl* get_name)(const struct AddonInstance_AudioCodec* instance);
+
+    //! @brief Reset the codec
+    void(__cdecl* reset)(const struct AddonInstance_AudioCodec* instance);
+  } KodiToAddonFuncTable_AudioCodec;
+
+  typedef struct AddonToKodiFuncTable_AudioCodec
+  {
+    KODI_HANDLE kodiInstance;
+    bool (*get_frame_buffer)(void* kodiInstance, struct AUDIOCODEC_FRAME* frame);
+    void (*release_frame_buffer)(void* kodiInstance, void* buffer);
+  } AddonToKodiFuncTable_AudioCodec;
+
+  typedef struct AddonInstance_AudioCodec
+  {
+    struct AddonProps_AudioCodec* props;
+    struct AddonToKodiFuncTable_AudioCodec* toKodi;
+    struct KodiToAddonFuncTable_AudioCodec* toAddon;
+  } AddonInstance_AudioCodec;
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* !C_API_ADDONINSTANCE_AUDIOCODEC_H */

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/inputstream.h
@@ -202,7 +202,7 @@ extern "C"
     /// @brief **0000 0000 0000 0000 :** Empty to set if nothing is used
     INPUTSTREAM_FEATURE_NONE = 0,
 
-    /// @brief **0000 0000 0000 0001 :** To set addon decode should used with @ref cpp_kodi_addon_videocodec.
+    /// @brief **0000 0000 0000 0001 :** To set addon decode should used with @ref cpp_kodi_addon_videocodec or @ref cpp_kodi_addon_audiocodec.
     INPUTSTREAM_FEATURE_DECODE = (1 << 0)
   };
   ///@}

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon_base.h
@@ -285,6 +285,7 @@ extern "C"
       struct AddonInstance_ShaderPreset* shaderpreset;
       struct AddonInstance_VFSEntry* vfs;
       struct AddonInstance_VideoCodec* videocodec;
+      struct AddonInstance_AudioCodec* audiocodec;
       struct AddonInstance_Visualization* visualization;
     };
   } KODI_ADDON_INSTANCE_STRUCT;

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -37,8 +37,8 @@
 // because cmake uses this area in this form to perform its addon dependency
 // check.
 // clang-format off
-#define ADDON_GLOBAL_VERSION_MAIN                     "2.0.3"
-#define ADDON_GLOBAL_VERSION_MAIN_MIN                 "2.0.3"
+#define ADDON_GLOBAL_VERSION_MAIN                     "2.1.0"
+#define ADDON_GLOBAL_VERSION_MAIN_MIN                 "2.1.0"
 #define ADDON_GLOBAL_VERSION_MAIN_XML_ID              "kodi.binary.global.main"
 #define ADDON_GLOBAL_VERSION_MAIN_DEPENDS             "AddonBase.h" \
                                                       "addon-instance/" \
@@ -108,8 +108,8 @@
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "c-api/addon-instance/imagedecoder.h" \
                                                       "addon-instance/ImageDecoder.h"
 
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.4.0"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "3.4.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "3.5.0"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM_MIN        "3.5.0"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_XML_ID     "kodi.binary.instance.inputstream"
 #define ADDON_INSTANCE_VERSION_INPUTSTREAM_DEPENDS    "c-api/addon-instance/inputstream.h" \
                                                       "c-api/addon-instance/inputstream/demux_packet.h" \
@@ -180,8 +180,8 @@
 #define ADDON_INSTANCE_VERSION_VISUALIZATION_DEPENDS  "addon-instance/Visualization.h" \
                                                       "c-api/addon-instance/visualization.h"
 
-#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "2.1.0"
-#define ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN         "2.1.0"
+#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "2.1.1"
+#define ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN         "2.1.1"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_XML_ID      "kodi.binary.instance.videocodec"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_DEPENDS     "c-api/addon-instance/video_codec.h" \
                                                       "c-api/addon-instance/inputstream/stream_codec.h" \
@@ -189,6 +189,17 @@
                                                       "addon-instance/VideoCodec.h" \
                                                       "addon-instance/inputstream/StreamCodec.h" \
                                                       "addon-instance/inputstream/StreamCrypto.h"
+
+#define ADDON_INSTANCE_VERSION_AUDIOCODEC             "1.0.0"
+#define ADDON_INSTANCE_VERSION_AUDIOCODEC_MIN         "1.0.0"
+#define ADDON_INSTANCE_VERSION_AUDIOCODEC_XML_ID      "kodi.binary.instance.audiocodec"
+#define ADDON_INSTANCE_VERSION_AUDIOCODEC_DEPENDS     "c-api/addon-instance/audio_codec.h" \
+                                                      "c-api/addon-instance/inputstream/stream_codec.h" \
+                                                      "c-api/addon-instance/inputstream/stream_crypto.h" \
+                                                      "addon-instance/AudioCodec.h" \
+                                                      "addon-instance/inputstream/StreamCodec.h" \
+                                                      "addon-instance/inputstream/StreamCrypto.h"
+
 // clang-format on
 
 //==============================================================================
@@ -255,6 +266,9 @@ typedef enum ADDON_TYPE
 
   /// Shader preset instance, see @ref cpp_kodi_addon_shaderpreset "kodi::addon::CInstanceShaderPreset"
   ADDON_INSTANCE_SHADERPRESET = 113,
+
+  /// Audio codec instance, see @ref cpp_kodi_addon_audiocodec "kodi::addon::CInstanceAudioCodec"
+  ADDON_INSTANCE_AUDIOCODEC = 114,
 } ADDON_TYPE;
 ///@}
 //------------------------------------------------------------------------------
@@ -360,6 +374,10 @@ extern "C"
       case ADDON_INSTANCE_VIDEOCODEC:
         return ADDON_INSTANCE_VERSION_VIDEOCODEC;
 #endif
+#if !defined(BUILD_KODI_ADDON) || defined(ADDON_INSTANCE_VERSION_AUDIOCODEC_USED)
+      case ADDON_INSTANCE_AUDIOCODEC:
+        return ADDON_INSTANCE_VERSION_AUDIOCODEC;
+#endif
     }
     return "0.0.0";
   }
@@ -417,6 +435,8 @@ extern "C"
         return ADDON_INSTANCE_VERSION_VISUALIZATION_MIN;
       case ADDON_INSTANCE_VIDEOCODEC:
         return ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN;
+      case ADDON_INSTANCE_AUDIOCODEC:
+        return ADDON_INSTANCE_VERSION_AUDIOCODEC_MIN;
     }
     return "0.0.0";
   }
@@ -471,6 +491,8 @@ extern "C"
         return "Visualization";
       case ADDON_INSTANCE_VIDEOCODEC:
         return "VideoCodec";
+      case ADDON_INSTANCE_AUDIOCODEC:
+        return "AudioCodec";
     }
     return "unknown";
   }
@@ -526,6 +548,8 @@ extern "C"
         return ADDON_INSTANCE_VISUALIZATION;
       else if (strcmp(name, "videocodec") == 0)
         return ADDON_INSTANCE_VIDEOCODEC;
+      else if (strcmp(name, "audiocodec") == 0)
+        return ADDON_INSTANCE_AUDIOCODEC;
     }
     return -1;
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/AddonAudioCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/AddonAudioCodec.cpp
@@ -1,0 +1,396 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "AddonAudioCodec.h"
+
+#include "addons/addoninfo/AddonInfo.h"
+#include "cores/AudioEngine/Utils/AEUtil.h"
+#include "cores/VideoPlayer/DVDCodecs/DVDCodecs.h"
+#include "cores/VideoPlayer/DVDStreamInfo.h"
+#include "cores/VideoPlayer/Interface/DemuxCrypto.h"
+#include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "utils/StreamUtils.h"
+#include "utils/log.h"
+
+#include <cstdlib>
+
+extern "C"
+{
+#include <libavcodec/defs.h>
+}
+
+namespace
+{
+AEDataFormat ConvAudioCodecFormat(AUDIOCODEC_FORMAT acFormat)
+{
+  switch (acFormat)
+  {
+    case AUDIOCODEC_FMT_U8:
+      return AE_FMT_U8;
+    case AUDIOCODEC_FMT_S16BE:
+      return AE_FMT_S16BE;
+    case AUDIOCODEC_FMT_S16LE:
+      return AE_FMT_S16LE;
+    case AUDIOCODEC_FMT_S16NE:
+      return AE_FMT_S16NE;
+    case AUDIOCODEC_FMT_S32BE:
+      return AE_FMT_S32BE;
+    case AUDIOCODEC_FMT_S32LE:
+      return AE_FMT_S32LE;
+    case AUDIOCODEC_FMT_S32NE:
+      return AE_FMT_S32NE;
+    case AUDIOCODEC_FMT_S24BE4:
+      return AE_FMT_S24BE4;
+    case AUDIOCODEC_FMT_S24LE4:
+      return AE_FMT_S24LE4;
+    case AUDIOCODEC_FMT_S24NE4:
+      return AE_FMT_S24NE4;
+    case AUDIOCODEC_FMT_S24NE4MSB:
+      return AE_FMT_S24NE4MSB;
+    case AUDIOCODEC_FMT_S24BE3:
+      return AE_FMT_S24BE3;
+    case AUDIOCODEC_FMT_S24LE3:
+      return AE_FMT_S24LE3;
+    case AUDIOCODEC_FMT_S24NE3:
+      return AE_FMT_S24NE3;
+    case AUDIOCODEC_FMT_DOUBLE:
+      return AE_FMT_DOUBLE;
+    case AUDIOCODEC_FMT_FLOAT:
+      return AE_FMT_FLOAT;
+    case AUDIOCODEC_FMT_RAW:
+      return AE_FMT_RAW;
+    case AUDIOCODEC_FMT_U8P:
+      return AE_FMT_U8P;
+    case AUDIOCODEC_FMT_S16NEP:
+      return AE_FMT_S16NEP;
+    case AUDIOCODEC_FMT_S32NEP:
+      return AE_FMT_S32NEP;
+    case AUDIOCODEC_FMT_S24NE4P:
+      return AE_FMT_S24NE4P;
+    case AUDIOCODEC_FMT_S24NE4MSBP:
+      return AE_FMT_S24NE4MSBP;
+    case AUDIOCODEC_FMT_S24NE3P:
+      return AE_FMT_S24NE3P;
+    case AUDIOCODEC_FMT_DOUBLEP:
+      return AE_FMT_DOUBLEP;
+    case AUDIOCODEC_FMT_FLOATP:
+      return AE_FMT_FLOATP;
+    default:
+      CLog::LogF(LOGWARNING, "Audio format '{}' not valid", acFormat);
+      return AE_FMT_INVALID;
+  };
+}
+} // unnamed namespace
+
+AEAudioFormat CAddonAudioCodec::GetFormat()
+{
+  return m_format;
+}
+
+CAddonAudioCodec::CAddonAudioCodec(CProcessInfo& processInfo,
+                                   ADDON::AddonInfoPtr& addonInfo,
+                                   KODI_HANDLE parentInstance)
+  : CDVDAudioCodec(processInfo),
+    IAddonInstanceHandler(
+        ADDON_INSTANCE_AUDIOCODEC, addonInfo, ADDON::ADDON_INSTANCE_ID_UNUSED, parentInstance)
+{
+  m_ifc.audiocodec = new AddonInstance_AudioCodec;
+  m_ifc.audiocodec->props = new AddonProps_AudioCodec();
+  m_ifc.audiocodec->toAddon = new KodiToAddonFuncTable_AudioCodec();
+  m_ifc.audiocodec->toKodi = new AddonToKodiFuncTable_AudioCodec();
+
+  m_ifc.audiocodec->toKodi->kodiInstance = this;
+  m_ifc.audiocodec->toKodi->get_frame_buffer = get_frame_buffer;
+  m_ifc.audiocodec->toKodi->release_frame_buffer = release_frame_buffer;
+  if (CreateInstance() != ADDON_STATUS_OK || !m_ifc.audiocodec->toAddon->open)
+  {
+    CLog::Log(LOGERROR, "CInputStreamAddon: Failed to create add-on instance for '{}'",
+              addonInfo->ID());
+    return;
+  }
+}
+
+CAddonAudioCodec::~CAddonAudioCodec()
+{
+  //free remaining buffers
+  Reset();
+
+  DestroyInstance();
+
+  // Delete "C" interface structures
+  delete m_ifc.audiocodec->toAddon;
+  delete m_ifc.audiocodec->toKodi;
+  delete m_ifc.audiocodec->props;
+  delete m_ifc.audiocodec;
+}
+
+bool CAddonAudioCodec::CopyToInitData(AUDIOCODEC_INITDATA& initData, CDVDStreamInfo& hints)
+{
+  initData.codecProfile = STREAMCODEC_PROFILE::CodecProfileNotNeeded;
+
+  switch (hints.codec)
+  {
+    case AV_CODEC_ID_MP1:
+      initData.codec = AUDIOCODEC_MP1;
+      break;
+    case AV_CODEC_ID_MP2:
+      initData.codec = AUDIOCODEC_MP2;
+      break;
+    case AV_CODEC_ID_MP3:
+      initData.codec = AUDIOCODEC_MP3;
+      break;
+    case AV_CODEC_ID_AAC:
+      initData.codec = AUDIOCODEC_AAC;
+      break;
+    case AV_CODEC_ID_AAC_LATM:
+      initData.codec = AUDIOCODEC_AAC_LATM;
+      break;
+    case AV_CODEC_ID_AC3:
+      initData.codec = AUDIOCODEC_AC3;
+      break;
+    case AV_CODEC_ID_EAC3:
+      initData.codec = AUDIOCODEC_EAC3;
+      break;
+    case AV_CODEC_ID_DTS:
+      initData.codec = AUDIOCODEC_DTS;
+      break;
+    case AV_CODEC_ID_TRUEHD:
+      initData.codec = AUDIOCODEC_TRUEHD;
+      break;
+    case AV_CODEC_ID_VORBIS:
+      initData.codec = AUDIOCODEC_VORBIS;
+      break;
+    case AV_CODEC_ID_OPUS:
+      initData.codec = AUDIOCODEC_OPUS;
+      break;
+    case AV_CODEC_ID_AC4:
+      initData.codec = AUDIOCODEC_AC4;
+      break;
+    default:
+      initData.codec = AUDIOCODEC_UNKNOWN;
+      break;
+  }
+
+  if (hints.cryptoSession)
+  {
+    switch (hints.cryptoSession->keySystem)
+    {
+      case CRYPTO_SESSION_SYSTEM_NONE:
+        initData.cryptoSession.keySystem = STREAM_CRYPTO_KEY_SYSTEM_NONE;
+        break;
+      case CRYPTO_SESSION_SYSTEM_WIDEVINE:
+        initData.cryptoSession.keySystem = STREAM_CRYPTO_KEY_SYSTEM_WIDEVINE;
+        break;
+      case CRYPTO_SESSION_SYSTEM_PLAYREADY:
+        initData.cryptoSession.keySystem = STREAM_CRYPTO_KEY_SYSTEM_PLAYREADY;
+        break;
+      case CRYPTO_SESSION_SYSTEM_WISEPLAY:
+        initData.cryptoSession.keySystem = STREAM_CRYPTO_KEY_SYSTEM_WISEPLAY;
+        break;
+      case CRYPTO_SESSION_SYSTEM_CLEARKEY:
+        initData.cryptoSession.keySystem = STREAM_CRYPTO_KEY_SYSTEM_CLEARKEY;
+        break;
+      default:
+        return false;
+    }
+
+    strncpy(initData.cryptoSession.sessionId, hints.cryptoSession->sessionId.c_str(),
+            sizeof(initData.cryptoSession.sessionId) - 1);
+  }
+
+  initData.extraData = hints.extradata.GetData();
+  initData.extraDataSize = hints.extradata.GetSize();
+
+  initData.sampleRate = hints.samplerate;
+  m_format.m_sampleRate = hints.samplerate;
+  initData.channels = hints.channels;
+  m_audioChannels = hints.channels;
+  initData.bitsPerSample = hints.bitspersample;
+
+  // set data format from bits per sample as fallback
+  switch (hints.bitspersample)
+  {
+    case 8:
+      m_format.m_dataFormat = AE_FMT_U8;
+      break;
+    case 16:
+      m_format.m_dataFormat = AE_FMT_S16NE;
+      break;
+    case 24:
+      m_format.m_dataFormat = AE_FMT_S24NE3;
+      break;
+    case 32:
+      m_format.m_dataFormat = AE_FMT_S32NE;
+      break;
+    default:
+      m_format.m_dataFormat = AE_FMT_INVALID;
+      break;
+  }
+
+  return true;
+}
+
+bool CAddonAudioCodec::Open(CDVDStreamInfo& hints, CDVDCodecOptions& options)
+{
+  if (!m_ifc.audiocodec->toAddon->open)
+    return false;
+
+  AUDIOCODEC_INITDATA initData;
+  if (!CopyToInitData(initData, hints))
+    return false;
+
+  bool ret = m_ifc.audiocodec->toAddon->open(m_ifc.audiocodec, &initData);
+
+  m_processInfo.SetAudioDecoderName(GetName());
+
+  return ret;
+}
+
+bool CAddonAudioCodec::AddData(const DemuxPacket& packet)
+{
+  if (!m_ifc.audiocodec->toAddon->add_data)
+    return false;
+
+  return m_ifc.audiocodec->toAddon->add_data(m_ifc.audiocodec, &packet);
+}
+
+void CAddonAudioCodec::GetData(DVDAudioFrame& frame)
+{
+  if (!m_ifc.audiocodec->toAddon->get_frame)
+    return;
+
+  AUDIOCODEC_FRAME acFrame;
+
+  switch (m_ifc.audiocodec->toAddon->get_frame(m_ifc.audiocodec, &acFrame))
+  {
+    case AUDIOCODEC_RETVAL::AC_NONE:
+      return;
+    case AUDIOCODEC_RETVAL::AC_ERROR:
+      return;
+    case AUDIOCODEC_RETVAL::AC_BUFFER:
+      return;
+    case AUDIOCODEC_RETVAL::AC_FRAME:
+    {
+      // Map addon frame to internal DVDAudioFrame. Many fields are filled by
+      // the addon; here we perform basic mapping. Addons should provide
+      // decodedData and decodedDataSize via GetFrameBuffer and set pts.
+      frame.pts = static_cast<double>(acFrame.pts);
+      frame.hasTimestamp = (acFrame.pts != DVD_NOPTS_VALUE);
+
+      frame.format = m_format;
+
+      const AEDataFormat format = ConvAudioCodecFormat(acFrame.audioFormat);
+      if (format != AE_FMT_INVALID)
+        frame.format.m_dataFormat = format;
+
+      // compute framesize and nb_frames
+      frame.framesize =
+          (CAEUtil::DataFormatToBits(frame.format.m_dataFormat) >> 3) * m_audioChannels;
+      if (frame.framesize > 0 && acFrame.decodedDataSize > 0)
+        frame.nb_frames = static_cast<unsigned int>(acFrame.decodedDataSize / frame.framesize);
+      else
+        frame.nb_frames = 0;
+
+      frame.framesOut = 0;
+      frame.passthrough = false;
+      frame.planes = AE_IS_PLANAR(frame.format.m_dataFormat) ? m_audioChannels : 1;
+      frame.data[0] = acFrame.decodedData; //! @todo: support planar formats with more planes
+
+      // compute duration
+      if (frame.format.m_sampleRate)
+        frame.duration =
+            static_cast<double>(frame.nb_frames) * DVD_TIME_BASE / frame.format.m_sampleRate;
+      else
+        frame.duration = 0.0;
+
+      frame.bits_per_sample = CAEUtil::DataFormatToBits(frame.format.m_dataFormat);
+      frame.hasDownmix = false;
+      frame.centerMixLevel = 0.0;
+      frame.profile = 0;
+      frame.matrix_encoding = AV_MATRIX_ENCODING_NONE;
+
+      return;
+    }
+    case AUDIOCODEC_RETVAL::AC_EOF:
+    {
+      CLog::Log(LOGINFO, "CAddonAudioCodec: GetData: EOF");
+      return;
+    }
+    default:
+      return;
+  }
+}
+
+std::string CAddonAudioCodec::GetName()
+{
+  if (m_ifc.audiocodec->toAddon->get_name)
+    return m_ifc.audiocodec->toAddon->get_name(m_ifc.audiocodec);
+  return "";
+}
+
+void CAddonAudioCodec::Reset()
+{
+  CLog::Log(LOGDEBUG, "CAddonAudioCodec: Reset");
+
+  // Get the remaining frames out of the external decoder
+  AUDIOCODEC_FRAME frame;
+  frame.flags = AUDIOCODEC_FRAME_FLAG_DRAIN;
+
+  AUDIOCODEC_RETVAL ret;
+  while ((ret = m_ifc.audiocodec->toAddon->get_frame(m_ifc.audiocodec, &frame)) !=
+         AUDIOCODEC_RETVAL::AC_EOF)
+  {
+    if (ret == AUDIOCODEC_RETVAL::AC_FRAME)
+    {
+      if (frame.audioBufferHandle)
+        ReleaseFrameBuffer(frame.audioBufferHandle);
+    }
+  }
+  if (m_ifc.audiocodec->toAddon->reset)
+    m_ifc.audiocodec->toAddon->reset(m_ifc.audiocodec);
+}
+
+bool CAddonAudioCodec::GetFrameBuffer(AUDIOCODEC_FRAME& frame)
+{
+  CLog::Log(LOGDEBUG, "CAddonAudioCodec: GetFrameBuffer allocating {} bytes",
+            frame.decodedDataSize);
+  frame.decodedData = static_cast<uint8_t*>(malloc(frame.decodedDataSize));
+  if (!frame.decodedData)
+  {
+    CLog::Log(LOGERROR, "CAddonAudioCodec::GetFrameBuffer Failed to allocate buffer");
+    frame.audioBufferHandle = nullptr;
+    return false;
+  }
+  frame.audioBufferHandle = frame.decodedData;
+
+  return true;
+}
+
+void CAddonAudioCodec::ReleaseFrameBuffer(KODI_HANDLE audioBufferHandle)
+{
+  if (audioBufferHandle)
+    free(audioBufferHandle);
+}
+
+/*********************     ADDON-TO-KODI    **********************/
+
+bool CAddonAudioCodec::get_frame_buffer(void* kodiInstance, AUDIOCODEC_FRAME* frame)
+{
+  if (!kodiInstance)
+    return false;
+
+  return static_cast<CAddonAudioCodec*>(kodiInstance)->GetFrameBuffer(*frame);
+}
+
+void CAddonAudioCodec::release_frame_buffer(void* kodiInstance, KODI_HANDLE audioBufferHandle)
+{
+  if (!kodiInstance)
+    return;
+
+  static_cast<CAddonAudioCodec*>(kodiInstance)->ReleaseFrameBuffer(audioBufferHandle);
+}

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/AddonAudioCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/AddonAudioCodec.h
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "DVDAudioCodec.h"
+#include "addons/AddonProvider.h"
+#include "addons/binary-addons/AddonInstanceHandler.h"
+#include "addons/kodi-dev-kit/include/kodi/addon-instance/AudioCodec.h"
+
+class BufferPool;
+
+class CAddonAudioCodec : public CDVDAudioCodec, public ADDON::IAddonInstanceHandler
+{
+public:
+  CAddonAudioCodec(CProcessInfo& processInfo,
+                   ADDON::AddonInfoPtr& addonInfo,
+                   KODI_HANDLE parentInstance);
+  ~CAddonAudioCodec() override;
+
+  bool Open(CDVDStreamInfo& hints, CDVDCodecOptions& options) override;
+  bool AddData(const DemuxPacket& packet) override;
+  void GetData(DVDAudioFrame& frame) override;
+  void Reset() override;
+
+  AEAudioFormat GetFormat() override;
+  std::string GetName() override;
+
+  void Dispose() override {}
+
+private:
+  bool CopyToInitData(AUDIOCODEC_INITDATA& initData, CDVDStreamInfo& hints);
+
+  /*!
+   * @brief All frame members can be expected to be set correctly except decodedData and pts.
+   * GetFrameBuffer has to set decodedData to a valid memory address and return true.
+   * In case buffer allocation fails, return false.
+   */
+  bool GetFrameBuffer(AUDIOCODEC_FRAME& frame);
+  void ReleaseFrameBuffer(KODI_HANDLE audioBufferHandle);
+
+  static bool get_frame_buffer(void* kodiInstance, AUDIOCODEC_FRAME* frame);
+  static void release_frame_buffer(void* kodiInstance, KODI_HANDLE audioBufferHandle);
+
+  AEAudioFormat m_format{};
+  int32_t m_audioChannels = 0;
+};

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/CMakeLists.txt
@@ -1,7 +1,9 @@
-set(SOURCES DVDAudioCodecFFmpeg.cpp
+set(SOURCES AddonAudioCodec.cpp
+            DVDAudioCodecFFmpeg.cpp
             DVDAudioCodecPassthrough.cpp)
 
-set(HEADERS DVDAudioCodec.h
+set(HEADERS AddonAudioCodec.h
+            DVDAudioCodec.h
             DVDAudioCodecFFmpeg.h
             DVDAudioCodecPassthrough.h)
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -8,6 +8,7 @@
 
 #include "DVDFactoryCodec.h"
 
+#include "Audio/AddonAudioCodec.h"
 #include "Audio/DVDAudioCodec.h"
 #include "Audio/DVDAudioCodecFFmpeg.h"
 #include "Audio/DVDAudioCodecPassthrough.h"
@@ -183,6 +184,25 @@ std::unique_ptr<CDVDAudioCodec> CDVDFactoryCodec::CreateAudioCodec(
 
   if (!allowdtshddecode)
     options.m_keys.emplace_back("allowdtshddecode", "0");
+
+  // addon handler for this stream ?
+
+  if (hint.externalInterfaces)
+  {
+    ADDON::AddonInfoPtr addonInfo;
+    KODI_HANDLE parentInstance;
+    hint.externalInterfaces->GetAddonInstance(ADDON::IAddonProvider::InstanceType::AUDIOCODEC,
+                                              addonInfo, parentInstance);
+    if (addonInfo && parentInstance)
+    {
+      pCodec = std::make_unique<CAddonAudioCodec>(processInfo, addonInfo, parentInstance);
+      if (pCodec->Open(hint, options))
+      {
+        return pCodec;
+      }
+    }
+    return nullptr;
+  }
 
   // platform specific audio decoders
   for (auto &codec : m_hwAudioCodecs)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -41,7 +41,8 @@ void CInputStreamProvider::GetAddonInstance(InstanceType instance_type,
                                             ADDON::AddonInfoPtr& addonInfo,
                                             KODI_HANDLE& parentInstance)
 {
-  if (instance_type == ADDON::IAddonProvider::InstanceType::VIDEOCODEC)
+  if (instance_type == ADDON::IAddonProvider::InstanceType::VIDEOCODEC ||
+      instance_type == ADDON::IAddonProvider::InstanceType::AUDIOCODEC)
   {
     addonInfo = m_addonInfo;
     parentInstance = m_parentInstance;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Implement InputStream addon audio codec interface
to allow addons to decrypt audio streams that require DRM secure decoder

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The InputStream Adaptive add-on make use of `CInstanceVideoCodec`
to allow the video stream to be decrypted and decoded with the DRM secure decoder
https://github.com/xbmc/inputstream.adaptive/blob/097a80fa07f04efa9b3687887b4fdf008a076f14/src/main.h#L72

Although this works well, the audio equivalent is missing, it has not yet been implemented in either Kodi nor InputStream Adaptive, and this lead that DRM audio streams cant be played, as opened for reference issue https://github.com/xbmc/inputstream.adaptive/issues/2013
so this is an attempt to implement this missing interface

on ISAdaptive addon side it should use the DRM decoder with
https://github.com/xbmc/inputstream.adaptive/blob/097a80fa07f04efa9b3687887b4fdf008a076f14/lib/cdm/cdm/media/cdm/cdm_adapter.h#L150-L151
https://github.com/xbmc/inputstream.adaptive/blob/097a80fa07f04efa9b3687887b4fdf008a076f14/lib/cdm/cdm/media/cdm/cdm_adapter.h#L163-L164
(~not done yet~ WIP https://github.com/xbmc/inputstream.adaptive/pull/2021)

I don't fully understand the InputStream interface and its many interrelated components,
i'm not so sure if i will be able to complete this task without help
so im posting this PR here to get feedback and corrections

If one day i manage to get this working, the plan is to implement it on Kodi v23

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
WIP

At today i can say that by testing this on ISAdaptive addon the `CInstanceAudioCodec` instance is created and it try to open the decoder as it should

to test it i made a draft ISA PR: https://github.com/xbmc/inputstream.adaptive/pull/2021

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
To be able to play DRM audio streams that require the secure decoder

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
