### PR TITLE
[AudioCodecPassthrough] Dynamically allocate TrueHD buffers to prevent segfault

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Audio/DVDAudioCodecPassthrough.cpp
@@ -187,6 +187,14 @@ bool CDVDAudioCodecPassthrough::AddData(const DemuxPacket &packet)
 
   if (m_format.m_streamInfo.m_type == CAEStreamInfo::STREAM_TYPE_TRUEHD)
   {
+    if (m_trueHDBuffer.empty())
+    {
+      m_trueHDBuffer.resize(TRUEHD_BUF_SIZE);
+
+      if (!m_deviceIsRAW && !m_packerMAT)
+        m_packerMAT = std::make_unique<CPackerMAT>();
+    }
+
     if (m_deviceIsRAW) // RAW
     {
       m_dataSize = PackTrueHD();


### PR DESCRIPTION
## Description
Resolves a crash that occurs when toggling audio pass-through during DTS-HD playback. When the media resets mid-stream, data misalignment can cause the stream parser to falsely detect a TrueHD sync word within the compressed DTS-HD payload. The codec immediately tries to process this "TrueHD" frame using the TrueHD buffers that were never allocated, resulting in a segmentation fault.

This fix ensures TrueHD buffers are dynamically allocated on the fly if the stream type changes, safely absorbing the false-positive frame until the parser re-syncs to the correct stream.

## Motivation and context
When playing back DTS-HD audio, and toggling the audio passthrough setting which resets the stream, Kodi sometimes crashes with a segfault.

## How has this been tested?
Tested on WebOS version with video with DTS-HD audio track. Tested toggling audio passthrough setting multiple times.
Before change: Sometimes Kodi will crash with a segmentation fault.
After change: Kodi doesn't crash.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
