### PR TITLE
[Video][Bluray] Do not look for playlists at scan time if source is an NFO or library import.

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -937,6 +937,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
     {
       // Add the movie entry
       int movieId{-1};
+      item.SetProperty("from_nfo", true);
+
       CVideoInfoTag* tag{item.GetVideoInfoTag()};
       if (tag->HasVideoVersions())
       {
@@ -972,8 +974,6 @@ CVideoInfoScanner::~CVideoInfoScanner()
           if (!AddSet(pItem->GetVideoInfoTag()->m_set))
             return InfoRet::INFO_ERROR;
       }
-
-      item.SetProperty("from_nfo", true);
 
       // Look for default version
       int defaultVersionFileId{-1};
@@ -1108,6 +1108,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       std::tie(result, loader) = ReadInfoTag(*pItem, info2, bDirNames, true);
     if (result == InfoType::FULL)
     {
+      pItem->SetProperty("from_nfo", true);
       if (AddVideo(pItem, info2, bDirNames, true) < 0)
         return InfoRet::INFO_ERROR;
       return InfoRet::ADDED;
@@ -1569,10 +1570,14 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
     // Determine bluray playlist (if possible)
     // Also populates streamdetails
-    if (::UTILS::DISCS::IsBlurayDiscImage(path) || URIUtils::IsBDFile(path))
+    if (!libraryImport && !pItem->GetProperty("from_nfo").asBoolean(false) &&
+        (::UTILS::DISCS::IsBlurayDiscImage(path) || URIUtils::IsBDFile(path)))
     {
       if (CDiscDirectoryHelper::GetOrShowPlaylistSelection(*pItem, MenuDecision::SILENT))
-        pItem->GetVideoInfoTag()->SetFileNameAndPath(pItem->GetDynPath());
+      {
+        path = pItem->GetDynPath();
+        pItem->GetVideoInfoTag()->SetFileNameAndPath(path);
+      }
     }
 
     /* As HasStreamDetails() returns true for TV shows (because the scraper calls SetVideoInfoTag()
@@ -2071,6 +2076,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
         std::tie(result, loader) = ReadInfoTag(item, info, false, false);
       if (result == InfoType::FULL)
       {
+        item.SetProperty("from_nfo", true);
+
         // override with episode and season number from file if available
         if (file->iEpisode > -1)
         {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Do not scan for playlist when adding via nfo or library import.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Bluray title searching at library scan time was happening for nfos and library import.
In both of these cases the playlist should be determined by the <playlist> tag only.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By user reporting issue in https://forum.kodi.tv/showthread.php?tid=385912&pid=3281305#pid3281305

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
