### PR TITLE
TCPServer: fix race in Announce iterating m_connections without server lock

### DIFF
--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -115,18 +115,26 @@ void CTCPServer::Process()
     struct timeval  to     = {1, 0};
     FD_ZERO(&rfds);
 
-    for (auto& it : m_servers)
     {
-      FD_SET(it, &rfds);
-      if ((intptr_t)it > (intptr_t)max_fd)
-        max_fd = it;
-    }
+      // Build the fd_set under lock so a concurrent Announce or modification
+      // of m_connections doesn't tear out from under us. Drop the lock for
+      // the select() call below since it sleeps up to 1s and would otherwise
+      // starve Announce.
+      std::unique_lock lock(m_connectionsCritSection);
 
-    for (unsigned int i = 0; i < m_connections.size(); i++)
-    {
-      FD_SET(m_connections[i]->m_socket, &rfds);
-      if ((intptr_t)m_connections[i]->m_socket > (intptr_t)max_fd)
-        max_fd = m_connections[i]->m_socket;
+      for (auto& it : m_servers)
+      {
+        FD_SET(it, &rfds);
+        if ((intptr_t)it > (intptr_t)max_fd)
+          max_fd = it;
+      }
+
+      for (unsigned int i = 0; i < m_connections.size(); i++)
+      {
+        FD_SET(m_connections[i]->m_socket, &rfds);
+        if ((intptr_t)m_connections[i]->m_socket > (intptr_t)max_fd)
+          max_fd = m_connections[i]->m_socket;
+      }
     }
 
     int res = select((intptr_t)max_fd+1, &rfds, NULL, NULL, &to);
@@ -138,6 +146,9 @@ void CTCPServer::Process()
     }
     else if (res > 0)
     {
+      // Re-acquire for the I/O and accept passes; both modify m_connections.
+      std::unique_lock lock(m_connectionsCritSection);
+
       for (int i = m_connections.size() - 1; i >= 0; i--)
       {
         int socket = m_connections[i]->m_socket;
@@ -237,6 +248,12 @@ void CTCPServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                           const std::string& message,
                           const CVariant& data)
 {
+  // Hold m_connectionsCritSection across the whole iteration so the Process
+  // thread cannot erase a connection out from under us while we Send to it.
+  // Without this lock, a client that disconnects right after receiving its
+  // response (e.g. `nc -q1`) crashes Announce on use-after-free.
+  std::unique_lock lock(m_connectionsCritSection);
+
   if (m_connections.empty())
     return;
 
@@ -245,7 +262,7 @@ void CTCPServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
   for (unsigned int i = 0; i < m_connections.size(); i++)
   {
     {
-      std::unique_lock lock(m_connections[i]->m_critSection);
+      std::unique_lock connLock(m_connections[i]->m_critSection);
       if ((m_connections[i]->GetAnnouncementFlags() & flag) == 0)
         continue;
     }
@@ -479,6 +496,8 @@ bool CTCPServer::InitializeTCP()
 
 void CTCPServer::Deinitialize()
 {
+  std::unique_lock lock(m_connectionsCritSection);
+
   for (unsigned int i = 0; i < m_connections.size(); i++)
   {
     m_connections[i]->Disconnect();

--- a/xbmc/network/TCPServer.h
+++ b/xbmc/network/TCPServer.h
@@ -109,6 +109,7 @@ namespace JSONRPC
 
     std::vector<CTCPClient*> m_connections;
     std::vector<SOCKET> m_servers;
+    CCriticalSection m_connectionsCritSection;
     int m_port;
     bool m_nonlocal;
     void* m_sdpd;


### PR DESCRIPTION
## Description

Fixes a use-after-free crash in `CTCPServer::Announce` when a JSON-RPC TCP client disconnects just after sending a request that triggers an announcement broadcast.

`CTCPServer::Announce` iterates `m_connections` while holding only a per-connection lock; the `Process` thread can `erase()` entries from the vector concurrently when it detects a client disconnect. The result is a dereference of a freed `CTCPClient` on the Announce thread.

The fix adds a server-level `CCriticalSection` covering all `m_connections` accesses:

- `Process()` locks around fd_set build and around the I/O + accept block, drops the lock during `select()` so Announce is not starved
- `Announce()` locks across the full iteration
- `Deinitialize()` locks the cleanup loop

Lock order is server-level -> per-connection in both readers and writers, so there is no deadlock with the existing `CTCPClient::m_critSection`.

## Motivation and context
Reproduces reliably with `nc -q1` (which disconnects ~1 s after stdin EOF) sending any JSON-RPC method that emits an announcement, e.g.:

`echo '{"jsonrpc":"2.0","id":1,"method":"Player.SetSubtitle","params":{"playerid":1,"subtitle":"off"}}' | nc -q1 localhost 9090`

The server returns `OK`, nc closes its socket, `Process` removes the closed connection, and `Announce` (broadcasting `OnPropertyChanged`) crashes mid-iteration.

Backtrace from gdb on the failing thread:

```
Thread "Announce" received signal SIGSEGV
#0  JSONRPC::CTCPServer::Announce(...)
#1  ANNOUNCEMENT::CAnnouncementManager::DoAnnounce(...)
#2  ANNOUNCEMENT::CAnnouncementManager::Process()
```

## How has this been tested?

Tested on Linux GBM (Intel ADL-N), Kodi master plus this fix.

- Before: subtitle on/off via JSON-RPC over `nc -q1` crashes Kodi within a handful of toggles (often the first one).
- After: same command sequence runs cleanly, no crashes across hundreds of toggles.
- Tested concurrent connection churn: opening and closing many short-lived nc clients while announcements fire (subtitle toggle, playback start/stop) -- no crashes, no regressions, no perceptible latency added to GUI/playback.

## What is the effect on users?

Users of any third-party tool that connects to Kodi's JSON-RPC TCP server (port 9090) and disconnects shortly after each request --  common behavior of CLI tools, scripted controllers, and custom remotes -- no longer crash Kodi when the server emits an announcement after the client has disconnected. No user-visible behavior change otherwise.

## Screenshots (if appropriate):
n/a

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
