### PR TITLE
[tvOS] Improve Siri Remote playback controls

### DIFF
--- a/system/keymaps/customcontroller.SiriRemote.xml
+++ b/system/keymaps/customcontroller.SiriRemote.xml
@@ -72,8 +72,8 @@
       <button id="2">VolumeDown</button>
       <button id="3">StepBack</button>
       <button id="4">StepForward</button>
-      <button id="5">Pause</button>
-      <button id="6">Stop</button>
+      <button id="5">OSD</button>
+      <button id="6">Back</button>
       <button id="7">OSD</button>
       <button id="8">noop</button>
       <button id="9">noop</button>
@@ -131,7 +131,7 @@
   <VideoMenu>
     <customcontroller name="SiriRemote">
       <button id="5">Select</button>
-      <button id="6">Stop</button>
+      <button id="6">Back</button>
       <button id="7">OSD</button>
     </customcontroller>
   </VideoMenu>


### PR DESCRIPTION
## Description
This updates the tvOS Siri Remote playback keymap so the clickpad center button opens Kodi's on-screen display during fullscreen video playback, while the Back/Menu button backs out of playback overlays instead of stopping playback.

## Motivation and context
The Siri Remote already has a dedicated Play/Pause button. Mapping the clickpad center button to `OSD` makes the playback controls reachable with normal Apple TV remote navigation, and mapping Back/Menu to `Back` avoids accidentally stopping playback while closing video menus.

## How has this been tested?
Validated the edited XML with:

```sh
xmllint --noout system/keymaps/customcontroller.SiriRemote.xml
```

## What is the effect on users?
tvOS users can open Kodi's playback OSD with the Siri Remote clickpad center button during fullscreen video playback and use Back/Menu to leave playback overlays without stopping the video.

## Screenshots (if appropriate):

## Types of change
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
