### PR TITLE
GLES: remove redundant limited-range compression in CGUITextureGLES

### DIFF
--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -59,13 +59,6 @@ void CGUITextureGLES::Begin(KODI::UTILS::COLOR::Color color)
   m_col[2] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::B, color);
   m_col[3] = KODI::UTILS::GL::GetChannelFromARGB(KODI::UTILS::GL::ColorChannel::A, color);
 
-  if (CServiceBroker::GetWinSystem()->UseLimitedColor())
-  {
-    m_col[0] = (235 - 16) * m_col[0] / 255 + 16;
-    m_col[1] = (235 - 16) * m_col[1] / 255 + 16;
-    m_col[2] = (235 - 16) * m_col[2] / 255 + 16;
-  }
-
   bool hasAlpha = m_texture.m_textures[m_currentFrame]->HasAlpha() || m_col[3] < 255;
   const bool hasBlendColor =
       m_col[0] != 255 || m_col[1] != 255 || m_col[2] != 255 || m_col[3] != 255;


### PR DESCRIPTION
## Description

When the "Use limited color range" option is enabled, every textured GUI element on the GLES render path is compressed to limited range twice:

1. `CGUITextureGLES::Begin()` rescales `m_col` from `[0, 255]` to  `[16, 235]` in C++.
2. The fragment shader then applies the same `KODI_LIMITED_RANGE` transformation again on the final fragment output.

Result: white draws at 218/255 instead of 235/255 (about 7% dim); `colordiffuse`-tinted dark elements render with raised blacks (e.g. `colordiffuse="FF000000"` reads at 30/255 instead of 16/255 in the scanout buffer). As a side effect, the C++ comp also turns the default no-tint value `0xFFFFFFFF` into `(235, 235, 235, 255)`, which fails the `hasBlendColor` check at `GUITextureGLES.cpp:71` and unconditionally routes every untinted draw through `SM_TEXTURE` instead of the `SM_TEXTURE_NOBLEND` optimization.

`CGUIFontTTFGLES` has never had this C++ block; it relies solely on the shader's `KODI_LIMITED_RANGE` define and renders correct values. This PR removes the redundant C++ compression in `CGUITextureGLES::Begin()` to align the textured path with the font path.

## Motivation and Context

Bug exists since `6b2a8954d9` (2018) when the GLES limited-range support was first added. Empirically verified on Linux GBM/GLES with SDR scanout BO captures: full-range (setting off) and limited-range (setting on). Comparison of three render paths (untinted texture, colordiffuse texture, font) at seven gray levels each confirms the font path matches the limited-range encoding spec exactly while both texture paths drift; with the setting off, all three paths produce identity.

Measured values on a 1920x1080 SDR scanout (limited range enabled):

```
src    untinted    colordiffuse    fonts (correct)
0x00      16          30                16
0x10      29          41                30
0x40      67          76                71
0x80     117         123               126
0xC0     168         171               181
0xEB     202         202               218
0xFF     218         218               235
```

After the fix:
- `colordiffuse="FF000000"` correctly produces `m_col = (0, 0, 0, ...)` -> `hasBlendColor = false` -> `SM_TEXTURE_NOBLEND` (when no actual tint is needed) or shader's single-pass `KODI_LIMITED_RANGE` compression (when a real tint is applied).
- White untinted images correctly render at `235/255`.
- `colordiffuse`-tinted blacks correctly render at the limited-range black floor (`16/255`).

## How Has This Been Tested?

- Linux GBM/GLES, Intel N250 (ADL-N), HDMI 2.0
- 7-step gray test ramp rendered three ways in the PlayerProcessInfo dialog: untinted baked PNG (`SM_TEXTURE`), `colordiffuse` on `white.png` (`SM_TEXTURE`), and a U+2588 filled-block character at varying `textcolor` (`SM_FONTS`)
- The scanout BO is captured by debug code and sampled numerically from the AR24 raw frame
- Verified that with `Use limited color range` disabled, all three paths produce identity output (untouched), confirming the change has no effect when the setting is off

## Screenshots (if appropriate):

N/A - bug is most visible on calibrated displays as a 7% peak luminance loss and raised blacks on tinted dark elements.

## Types of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CODE_OF_CONDUCT.md** document.