### PR TITLE
[VFS] Remove special:// from excluded directories.

### DIFF
--- a/xbmc/filesystem/DirectoryFactory.cpp
+++ b/xbmc/filesystem/DirectoryFactory.cpp
@@ -133,7 +133,7 @@ IDirectory* CDirectoryFactory::Create(const CURL& url)
 
   struct __stat64 st = {};
   static constexpr auto excludedProtocols =
-      make_set<std::string_view>({"upnp", "special", "addons", "favourites", "sources"});
+      make_set<std::string_view>({"upnp", "addons", "favourites", "sources"});
   const bool exclude{excludedProtocols.contains(url.GetProtocol())};
   if (!exclude && CFile::Stat(URIUtils::SubstitutePath(url), &st) == 0)
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Remove special:// from the excluded directories list.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix issue identified in https://github.com/xbmc/xbmc/pull/28187#discussion_r3145351663.

Excluding special:// in  #28187 meant directories with playlist extensions were not read.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
