### PR TITLE
[Video][Bluray] Fix NFO file not found when refreshing a bluray:// through the information dialog.

### DIFF
--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -136,6 +136,19 @@ std::string CVideoTagLoaderNFO::FindNFO(const CFileItem& item,
       return nfoFile;
     }
 
+    // For bluray:// paths, use the real file name (either <movie>.iso or index.bdmv)
+    if (URIUtils::IsBlurayPath(item.GetPath()))
+    {
+      CFileItem item2(item);
+      const std::string path{URIUtils::GetDiscFile(item.GetPath())};
+      if (!path.empty())
+      {
+        item2.SetPath(path);
+        nfoFile = FindNFO(item2, movieFolder);
+        return nfoFile;
+      }
+    }
+
     // grab the folder path
     std::string strPath{URIUtils::GetDirectory(item.GetPath())};
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Properly resolve bluray:// paths in `FindNFO()`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Refresh led to NFO not being found and either wrong path association or recurrent request for the movie name.

Issue reported in https://forum.kodi.tv/showthread.php?tid=385912&pid=3282406.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally. Confirmed by bug reporter in https://forum.kodi.tv/showthread.php?tid=385912&pid=3282406#pid3282406.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed