### PR TITLE
GLES: fix font shader state

### DIFF
--- a/xbmc/guilib/GUIFontTTFGLES.cpp
+++ b/xbmc/guilib/GUIFontTTFGLES.cpp
@@ -158,6 +158,9 @@ void CGUIFontTTFGLES::LastEnd()
   CRenderSystemGLES* renderSystem =
       dynamic_cast<CRenderSystemGLES*>(CServiceBroker::GetRenderSystem());
 
+  renderSystem->EnableGUIShader(m_scissorClip ? ShaderMethodGLES::SM_FONTS
+                                              : ShaderMethodGLES::SM_FONTS_SHADER_CLIP);
+
   GLint posLoc = renderSystem->GUIShaderGetPos();
   GLint colLoc = renderSystem->GUIShaderGetCol();
   GLint tex0Loc = renderSystem->GUIShaderGetCoord0();
@@ -165,6 +168,19 @@ void CGUIFontTTFGLES::LastEnd()
   GLint coordStepUniformLoc = renderSystem->GUIShaderGetCoordStep();
   GLint matrixUniformLoc = renderSystem->GUIShaderGetMatrix();
   GLint depthLoc = renderSystem->GUIShaderGetDepth();
+
+  if (posLoc < 0 || colLoc < 0 || tex0Loc < 0)
+  {
+    static bool loggedInvalidFontAttributes = false;
+    if (!loggedInvalidFontAttributes)
+    {
+      CLog::Log(LOGERROR, "GUIFontTTFGLES: invalid font shader attributes: pos={} col={} tex0={}",
+                posLoc, colLoc, tex0Loc);
+      loggedInvalidFontAttributes = true;
+    }
+    renderSystem->DisableGUIShader();
+    return;
+  }
 
   CreateStaticVertexBuffers();
 


### PR DESCRIPTION
Rebind the GLES font shader before drawing queued glyphs so we do not reuse a shader without font attributes.

## Description
Crash when I enable the debug log feature on WASM

## Motivation and context
font rendering assumes the active GLES shader is still the font shader when LastEnd() runs

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
