### PR TITLE
[Android] Handle potential NsdManager exception

### DIFF
--- a/xbmc/platform/android/network/ZeroconfAndroid.cpp
+++ b/xbmc/platform/android/network/ZeroconfAndroid.cpp
@@ -24,7 +24,11 @@ CZeroconfAndroid::~CZeroconfAndroid()
   doStop();
 }
 
-bool CZeroconfAndroid::doPublishService(const std::string& fcr_identifier, const std::string& fcr_type, const std::string& fcr_name, unsigned int f_port, const std::vector<std::pair<std::string, std::string> >& txt)
+bool CZeroconfAndroid::doPublishService(const std::string& fcr_identifier,
+                                        const std::string& fcr_type,
+                                        const std::string& fcr_name,
+                                        unsigned int f_port,
+                                        const std::vector<std::pair<std::string, std::string>>& txt)
 {
   CLog::Log(LOGDEBUG, "ZeroconfAndroid: identifier: {} type: {} name:{} port:{}", fcr_identifier,
             fcr_type, fcr_name, f_port);
@@ -42,7 +46,15 @@ bool CZeroconfAndroid::doPublishService(const std::string& fcr_identifier, const
     newService.serviceInfo.setAttribute(it.first, it.second);
   }
 
-  m_manager.registerService(newService.serviceInfo, 1 /* PROTOCOL_DNS_SD */, newService.registrationListener);
+  m_manager.registerService(newService.serviceInfo, 1 /* PROTOCOL_DNS_SD */,
+                            newService.registrationListener);
+  if (xbmc_jnienv()->ExceptionCheck())
+  {
+    std::string ex = CJNIBase::ExceptionToString();
+    CLog::Log(LOGERROR, "ZeroconfAndroid: {}", ex);
+    xbmc_jnienv()->ExceptionClear();
+    return false;
+  }
 
   std::unique_lock lock(m_data_guard);
   newService.updateNumber = 0;
@@ -69,7 +81,14 @@ bool CZeroconfAndroid::doForceReAnnounceService(const std::string& fcr_identifie
 
     m_manager.unregisterService(it->second.registrationListener);
     it->second.registrationListener = jni::CJNIXBMCNsdManagerRegistrationListener();
-    m_manager.registerService(it->second.serviceInfo, 1 /* PROTOCOL_DNS_SD */, it->second.registrationListener);
+    m_manager.registerService(it->second.serviceInfo, 1 /* PROTOCOL_DNS_SD */,
+                              it->second.registrationListener);
+    if (xbmc_jnienv()->ExceptionCheck())
+    {
+      std::string ex = CJNIBase::ExceptionToString();
+      CLog::Log(LOGERROR, "ZeroconfAndroid: {}", ex);
+      xbmc_jnienv()->ExceptionClear();
+    }
   }
   return ret;
 }


### PR DESCRIPTION
## Description

Catch any exception that occurs when calling the `registerService()` method of the `NsdManager` class.

Prevent general app failure:

```
Abort message: 'JNI DETECTED ERROR IN APPLICATION: JNI NewGlobalRef called with pending exception java.lang.SecurityException: Missing local network permission
```

## Motivation and context
Crash found while testing the app on an Android 17.0 Pre-Release Image.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
