### PR TITLE
[Android] Fix crash when starting Zeroconf browser

### DIFF
--- a/xbmc/platform/android/activity/JNIXBMCNsdManagerDiscoveryListener.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCNsdManagerDiscoveryListener.cpp
@@ -23,7 +23,7 @@ static std::string s_className = std::string(CCompileInfo::GetClass()) + "/inter
 CJNIXBMCNsdManagerDiscoveryListener::CJNIXBMCNsdManagerDiscoveryListener()
   : CJNIBase(s_className)
 {
-  m_object = new_object(CJNIContext::getClassLoader().loadClass(GetClassNameAsPath()));
+  m_object = new_object(CJNIContext::getClassLoader().loadClass(ClassPathToName(s_className)));
   m_object.setGlobal();
 
   add_instance(m_object, this);


### PR DESCRIPTION
## Description
The app crashes when using Zeroconf browser within the File manager:
```
JNI DETECTED ERROR IN APPLICATION: JNI GetMethodID called with pending exception java.lang.NullPointerException
```
Related to https://github.com/xbmc/xbmc/pull/27944

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
