### PR TITLE
[gbm] Fix display refresh rate calculation with interlacing

### DIFF
--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -639,7 +639,19 @@ RESOLUTION_INFO CDRMUtils::GetResolutionInfo(drmModeModeInfoPtr mode)
   }
 
   if (mode->htotal > 0 && mode->vtotal > 0)
-    res.fRefreshRate = (mode->clock * 1000.0f) / (mode->htotal * mode->vtotal);
+  {
+    double numerator = mode->clock * 1000.0;
+    double denominator = static_cast<double>(mode->vtotal) * mode->htotal;
+
+    if (mode->flags & DRM_MODE_FLAG_INTERLACE)
+      denominator /= 2;
+    if (mode->flags & DRM_MODE_FLAG_DBLSCAN)
+      denominator *= 2;
+    if (mode->vscan > 1)
+      denominator *= mode->vscan;
+
+    res.fRefreshRate = numerator / denominator;
+  }
   else
     res.fRefreshRate = mode->vrefresh;
   res.iSubtitles = res.iHeight;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fix display refresh rate calculation with interlacing. Code for this taken from https://gitlab.gnome.org/GNOME/mutter/-/blob/main/src/backends/native/meta-kms-utils.c?ref_type=heads#L25-L40 and https://gitlab.freedesktop.org/wayland/weston/-/blob/main/libweston/backend-drm/modes.c#L498-L507

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes the problem reported in https://github.com/xbmc/xbmc/pull/28080#issuecomment-4341172991

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

My display doesn't has interlaced modes according to [drm_info](https://gitlab.freedesktop.org/emersion/drm_info), so I'm unable to see the change myself. Non interlaced resolutions are unchanged.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

See linked comment.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
