### PR TITLE
Refactor Video Info Dialog Buttons Activation

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -275,13 +275,10 @@ void CGUIDialogVideoInfo::OnInitWindow()
 
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
 
-  const std::string uniqueId = m_movieItem->GetProperty("xxuniqueid").asString();
-  if (uniqueId.empty() || !StringUtils::StartsWithNoCase(uniqueId, "xx"))
-    CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH,
-        (profileManager->GetCurrentProfile().canWriteDatabases() ||
-        g_passwordManager.bMasterUser));
-  else
-    CONTROL_DISABLE(CONTROL_BTN_REFRESH);
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH,
+                              m_refreshEnabled &&
+                                  (profileManager->GetCurrentProfile().canWriteDatabases() ||
+                                   g_passwordManager.bMasterUser));
 
   // @todo add support to edit video asset art. Until then edit art through Versions Manager.
   if (!VIDEO::IsVideoAssetFile(*m_movieItem))

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -273,33 +273,31 @@ void CGUIDialogVideoInfo::OnInitWindow()
   m_hasUpdatedUserrating = false;
   m_bViewReview = true;
 
-  const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
+  const std::shared_ptr<CProfileManager> profileManager =
+      CServiceBroker::GetSettingsComponent()->GetProfileManager();
+  const bool userCanWrite =
+      profileManager->GetCurrentProfile().canWriteDatabases() || g_passwordManager.bMasterUser;
 
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH,
-                              m_refreshEnabled &&
-                                  (profileManager->GetCurrentProfile().canWriteDatabases() ||
-                                   g_passwordManager.bMasterUser));
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_REFRESH, m_refreshEnabled && userCanWrite);
 
   // @todo add support to edit video asset art. Until then edit art through Versions Manager.
-  if (!VIDEO::IsVideoAssetFile(*m_movieItem))
-    CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_THUMB,
-                                (profileManager->GetCurrentProfile().canWriteDatabases() ||
-                                 g_passwordManager.bMasterUser) &&
-                                    !StringUtils::StartsWithNoCase(
-                                        m_movieItem->GetVideoInfoTag()->GetUniqueID(), "plugin"));
+  if (!VIDEO::IsVideoAssetFile(*m_movieItem) && userCanWrite)
+    CONTROL_ENABLE_ON_CONDITION(
+        CONTROL_BTN_GET_THUMB,
+        !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID(), "plugin"));
   else
     CONTROL_DISABLE(CONTROL_BTN_GET_THUMB);
 
   // Disable video user rating button for plugins and sets as they don't have tables to save this
-  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_USERRATING, !m_movieItem->IsPlugin() && m_movieItem->GetVideoInfoTag()->m_type != MediaTypeVideoCollection);
+  CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_USERRATING,
+                              !m_movieItem->IsPlugin() && m_movieItem->GetVideoInfoTag()->m_type !=
+                                                              MediaTypeVideoCollection);
 
   VideoDbContentType type = m_movieItem->GetVideoContentType();
-  if (type == VideoDbContentType::TVSHOWS || type == VideoDbContentType::MOVIES)
-    CONTROL_ENABLE_ON_CONDITION(CONTROL_BTN_GET_FANART,
-                                (profileManager->GetCurrentProfile().canWriteDatabases() ||
-                                 g_passwordManager.bMasterUser) &&
-                                    !StringUtils::StartsWithNoCase(
-                                        m_movieItem->GetVideoInfoTag()->GetUniqueID(), "plugin"));
+  if ((type == VideoDbContentType::TVSHOWS || type == VideoDbContentType::MOVIES) && userCanWrite)
+    CONTROL_ENABLE_ON_CONDITION(
+        CONTROL_BTN_GET_FANART,
+        !StringUtils::StartsWithNoCase(m_movieItem->GetVideoInfoTag()->GetUniqueID(), "plugin"));
   else
     CONTROL_DISABLE(CONTROL_BTN_GET_FANART);
 

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.h
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -38,6 +38,13 @@ public:
   std::shared_ptr<CFileItem> GetCurrentListItem(int offset = 0) override { return m_movieItem; }
   const CFileItemList& CurrentDirectory() const { return *m_castList; }
   bool HasListItems() const override { return true; }
+
+  /*!
+   * \brief May the user request a refresh of the item displayed by the dialog
+            note: call before displaying the dialog
+   * \param[in] enable true to allow or false to block the action
+   */
+  void EnableItemRefresh(bool enable) { m_refreshEnabled = enable; }
 
   static void AddItemPathToFileBrowserSources(std::vector<CMediaSource>& sources,
                                               const CFileItem& item);
@@ -113,6 +120,7 @@ protected:
   bool m_hasUpdatedUserrating = false;
   int m_startUserrating = -1;
   bool m_hasUpdatedItems{false};
+  bool m_refreshEnabled{false}; //!< May the item be refreshed
 
 private:
   static bool ManageVideoItemArtwork(const std::shared_ptr<CFileItem>& item,

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -434,13 +434,14 @@ CGUIWindowVideoBase::ShowInfoResult CGUIWindowVideoBase::ShowInfo(
     movieDetails = *item->GetVideoInfoTag();
   }
 
+  // @todo add support to refresh movie version information
+  pDlgInfo->EnableItemRefresh((info != nullptr && info->Content() != ContentType::NONE &&
+                               !VIDEO::IsVideoAssetFile(*item)) ||
+                              item->GetVideoContentType() == VideoDbContentType::MOVIE_SETS);
+
   bool needsRefresh = false;
   if (bHasInfo)
   {
-    // @todo add support to refresh movie version information
-    if ((!info || info->Content() == ContentType::NONE || VIDEO::IsVideoAssetFile(*item)) &&
-        item->GetVideoContentType() != VideoDbContentType::MOVIE_SETS)
-      item->SetProperty("xxuniqueid", "xx" + movieDetails.GetUniqueID()); // disable refresh button
     item->SetProperty("CheckAutoPlayNextItem", IsActive());
     *item->GetVideoInfoTag() = movieDetails;
     pDlgInfo->SetMovie(item.get());


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

(The PR initially had commits to record the dialog buttons enabled status to dismiss click messages - that part was removed in favor of the generic approach of PR #28256, which covers all windows and dialogs)

Refactored the way WindowVideoBase indicates to the video info dialog that an item supports the "refresh" operation, using a new member of the dialog instead of an item property.

Removed some code duplication in `OnInitWindow()`.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Code improvement.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No change in behavior observed with Aeon family of skins or Estuary.).

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Avoid accidental video db breakage or art modified by user profiles that should be able to, for some skins.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
