### PR TITLE
Fix/ffmpeg idempotent patches

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -182,6 +182,9 @@ macro(buildFFMPEG)
                       ${CMAKE_SOURCE_DIR}/tools/depends/target/ffmpeg/CMakeLists.txt
                       <SOURCE_DIR>
                       COMMAND ${CMAKE_COMMAND} -E copy
+                      ${CMAKE_SOURCE_DIR}/tools/depends/apply-patches.sh
+                      <SOURCE_DIR>
+                      COMMAND ${CMAKE_COMMAND} -E copy
                       ${CMAKE_SOURCE_DIR}/tools/depends/target/ffmpeg/002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch
                       <SOURCE_DIR>
     )

--- a/cmake/modules/PatchHelpers.cmake
+++ b/cmake/modules/PatchHelpers.cmake
@@ -1,0 +1,76 @@
+# Helper functions for applying patches in ExternalProject patch steps.
+
+get_filename_component(_patchhelpers_apply_patches_script
+                       ${CMAKE_CURRENT_LIST_DIR}/../../tools/depends/apply-patches.sh
+                       ABSOLUTE)
+
+# Macro to test format of line endings of a patch.
+# Windows specific.
+macro(PATCH_LF_CHECK patch)
+  if(CMAKE_HOST_WIN32)
+    # On Windows "patch.exe" can only handle CR-LF line-endings.
+    # Our patches have LF-only line endings - except when they
+    # have been checked out as part of a dependency hosted on Git
+    # and core.autocrlf=true.
+    file(READ ${ARGV0} patch_content_hex HEX)
+    # Force handle LF-only line endings
+    if(NOT patch_content_hex MATCHES "0d0a")
+      if (NOT "--binary" IN_LIST PATCH_EXECUTABLE)
+        list(APPEND PATCH_EXECUTABLE --binary)
+      endif()
+    else()
+      if ("--binary" IN_LIST PATCH_EXECUTABLE)
+        list(REMOVE_ITEM PATCH_EXECUTABLE --binary)
+      endif()
+    endif()
+  endif()
+  unset(patch_content_hex)
+endmacro()
+
+# Function to loop through list of patch files (full path).
+# Sets the generated command in the parent scope.
+function(generate_patchcommand _patchlist)
+  set(oneValueArgs OUTPUT_VARIABLE)
+  cmake_parse_arguments(arg "" "${oneValueArgs}" "" ${ARGN})
+  if(NOT arg_OUTPUT_VARIABLE)
+    set(arg_OUTPUT_VARIABLE PATCH_COMMAND)
+  endif()
+
+  # find the path to the patch executable
+  find_package(Patch MODULE REQUIRED ${SEARCH_QUIET})
+
+  if(WIN32 OR WINDOWS_STORE)
+    # Loop through patches and add to PATCH_COMMAND.
+    # For Windows, check CRLF/LF state.
+    set(_count 0)
+    foreach(patch ${_patchlist})
+      PATCH_LF_CHECK(${patch})
+      if(${_count} EQUAL "0")
+        set(_patch_command ${PATCH_EXECUTABLE} -p1 -i ${patch})
+      else()
+        list(APPEND _patch_command COMMAND ${PATCH_EXECUTABLE} -p1 -i ${patch})
+      endif()
+
+      math(EXPR _count "${_count}+1")
+    endforeach()
+    unset(_count)
+  else()
+    if(EXISTS "${_patchhelpers_apply_patches_script}")
+      set(_apply_patches_script ${_patchhelpers_apply_patches_script})
+    elseif(EXISTS "${CMAKE_SOURCE_DIR}/apply-patches.sh")
+      set(_apply_patches_script ${CMAKE_SOURCE_DIR}/apply-patches.sh)
+    else()
+      message(FATAL_ERROR "Could not find apply-patches.sh")
+    endif()
+
+    set(_patch_command /bin/sh
+                       ${_apply_patches_script}
+                       ${PATCH_EXECUTABLE}
+                       <SOURCE_DIR>
+                       ${_patchlist})
+    unset(_apply_patches_script)
+  endif()
+
+  set(${arg_OUTPUT_VARIABLE} ${_patch_command} PARENT_SCOPE)
+  unset(_patch_command)
+endfunction()

--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -101,33 +101,7 @@ function(get_libversion_data module libtype)
   set(LIB_${MOD_UPPER}_VER ${${MOD_UPPER}_VER} PARENT_SCOPE)
 endfunction()
 
-# Function to loop through list of patch files (full path)
-# Sets to a PATCH_COMMAND variable and set to parent scope (caller)
-# Used to test windows line endings and set appropriate patch commands
-function(generate_patchcommand _patchlist)
-  # find the path to the patch executable
-  find_package(Patch MODULE REQUIRED ${SEARCH_QUIET})
-
-  # Loop through patches and add to PATCH_COMMAND
-  # for windows, check CRLF/LF state
-
-  set(_count 0)
-  foreach(patch ${_patchlist})
-    if(WIN32 OR WINDOWS_STORE)
-      PATCH_LF_CHECK(${patch})
-    endif()
-    if(${_count} EQUAL "0")
-      set(_patch_command ${PATCH_EXECUTABLE} -p1 -i ${patch})
-    else()
-      list(APPEND _patch_command COMMAND ${PATCH_EXECUTABLE} -p1 -i ${patch})
-    endif()
-
-    math(EXPR _count "${_count}+1")
-  endforeach()
-  set(PATCH_COMMAND ${_patch_command} PARENT_SCOPE)
-  unset(_count)
-  unset(_patch_command)
-endfunction()
+include(PatchHelpers)
 
 # Macro to factor out the repetitive URL setup
 macro(SETUP_BUILD_VARS)
@@ -537,29 +511,6 @@ macro(BUILD_DEP_TARGET)
   string(TOUPPER "${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}" _search_upper)
   set(${_search_upper}_FOUND ON CACHE BOOL "${_search_upper}_FOUND" FORCE)
   unset(_search_upper)
-endmacro()
-
-# Macro to test format of line endings of a patch
-# Windows Specific
-macro(PATCH_LF_CHECK patch)
-  if(CMAKE_HOST_WIN32)
-    # On Windows "patch.exe" can only handle CR-LF line-endings.
-    # Our patches have LF-only line endings - except when they
-    # have been checked out as part of a dependency hosted on Git
-    # and core.autocrlf=true.
-    file(READ ${ARGV0} patch_content_hex HEX)
-    # Force handle LF-only line endings
-    if(NOT patch_content_hex MATCHES "0d0a")
-      if (NOT "--binary" IN_LIST PATCH_EXECUTABLE)
-        list(APPEND PATCH_EXECUTABLE --binary)
-      endif()
-    else()
-      if ("--binary" IN_LIST PATCH_EXECUTABLE)
-        list(REMOVE_ITEM PATCH_EXECUTABLE --binary)
-      endif()
-    endif()
-  endif()
-  unset(patch_content_hex)
 endmacro()
 
 # Function to check a list of libraries to force the calling library to be

--- a/tools/depends/apply-patches.sh
+++ b/tools/depends/apply-patches.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Apply patches to a source tree idempotently using marker files.
+#
+# CMake ExternalProject patch steps can rerun on an already-patched source
+# tree (for example, when the patch command changes between configures but
+# the source tree is not re-extracted). Plain `patch` then prompts
+# interactively with "Reversed (or previously applied) patch detected!" and
+# hangs the build.
+#
+# This wrapper records each successfully applied patch as a marker file in
+# <source_dir>/.kodi-applied-patches/. The marker name embeds a checksum of
+# the patch file, so the same patch is skipped on later reruns while edited
+# patch files get a new marker and are applied again.
+#
+# Usage: apply-patches.sh <patch_program> <source_dir> <patch_file> [<patch_file> ...]
+
+set -eu
+
+if [ $# -lt 3 ]; then
+    echo "Usage: $0 <patch_program> <source_dir> <patch_file> [<patch_file> ...]" >&2
+    exit 2
+fi
+
+patch_program="$1"
+source_dir="$2"
+shift 2
+
+if ! command -v "$patch_program" >/dev/null 2>&1; then
+    echo "apply-patches.sh: patch program does not exist: $patch_program" >&2
+    exit 1
+fi
+
+if [ ! -d "$source_dir" ]; then
+    echo "apply-patches.sh: source directory does not exist: $source_dir" >&2
+    exit 1
+fi
+
+marker_dir="$source_dir/.kodi-applied-patches"
+mkdir -p "$marker_dir"
+
+for patch_file in "$@"; do
+    if [ ! -f "$patch_file" ]; then
+        echo "apply-patches.sh: patch file does not exist: $patch_file" >&2
+        exit 1
+    fi
+
+    patch_name=$(basename "$patch_file")
+    patch_hash=$(cksum "$patch_file" | awk '{print $1"-"$2}')
+    marker="$marker_dir/${patch_name}.${patch_hash}"
+
+    if [ -f "$marker" ]; then
+        echo "apply-patches.sh: skipping (already applied): $patch_name"
+        continue
+    fi
+
+    echo "apply-patches.sh: applying $patch_name"
+    # -N (--forward): skip already-applied / reversed patches without
+    # silently rolling them back. --batch: never prompt interactively.
+    if ! "$patch_program" -d "$source_dir" -p1 -N --batch -i "$patch_file"; then
+        echo "apply-patches.sh: failed to apply $patch_name" >&2
+        echo "apply-patches.sh: hint: source tree may be stale, re-extract with 'make distclean'." >&2
+        exit 1
+    fi
+
+    : > "$marker"
+done

--- a/tools/depends/apply-patches.sh
+++ b/tools/depends/apply-patches.sh
@@ -58,7 +58,7 @@ for patch_file in "$@"; do
     # silently rolling them back. --batch: never prompt interactively.
     if ! "$patch_program" -d "$source_dir" -p1 -N --batch -i "$patch_file"; then
         echo "apply-patches.sh: failed to apply $patch_name" >&2
-        echo "apply-patches.sh: hint: source tree may be stale, re-extract with 'make distclean'." >&2
+        echo "apply-patches.sh: hint: source tree may be stale, re-extract it and try again." >&2
         exit 1
     fi
 

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -151,20 +151,18 @@ if(CMAKE_GENERATOR STREQUAL Ninja)
   endif()
 endif()
 
-find_package(Patch MODULE REQUIRED)
+include(PatchHelpers)
 
 set(ffmpeg_patches <SOURCE_DIR>/002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch)
 if(NOT DISABLE_FFMPEG_SOURCE_PLUGINS)
   list(PREPEND ffmpeg_patches <SOURCE_DIR>/001-ffmpeg-all-libpostproc-plugin.patch)
 endif()
+generate_patchcommand("${ffmpeg_patches}" OUTPUT_VARIABLE sourceplugin_patch)
 
 include(ExternalProject)
 externalproject_add(ffmpeg
                     SOURCE_DIR ${CMAKE_SOURCE_DIR}
-                    PATCH_COMMAND /bin/sh <SOURCE_DIR>/apply-patches.sh
-                      ${PATCH_EXECUTABLE}
-                      <SOURCE_DIR>
-                      ${ffmpeg_patches}
+                    PATCH_COMMAND ${sourceplugin_patch}
                     CONFIGURE_COMMAND ${pkgconf} ${pkgconf_path} <SOURCE_DIR>/configure
                       --prefix=${CMAKE_INSTALL_PREFIX}
                       --extra-version="kodi-${FFMPEG_VER}"

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -151,16 +151,20 @@ if(CMAKE_GENERATOR STREQUAL Ninja)
   endif()
 endif()
 
+find_package(Patch MODULE REQUIRED)
+
+set(ffmpeg_patches <SOURCE_DIR>/002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch)
 if(NOT DISABLE_FFMPEG_SOURCE_PLUGINS)
-  set(sourceplugin_patch PATCH_COMMAND /bin/sh -c "patch -p1 -i <SOURCE_DIR>/001-ffmpeg-all-libpostproc-plugin.patch && patch -p1 -i <SOURCE_DIR>/002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch")
-else()
-  set(sourceplugin_patch PATCH_COMMAND patch -p1 -i <SOURCE_DIR>/002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch)
+  list(PREPEND ffmpeg_patches <SOURCE_DIR>/001-ffmpeg-all-libpostproc-plugin.patch)
 endif()
 
 include(ExternalProject)
 externalproject_add(ffmpeg
                     SOURCE_DIR ${CMAKE_SOURCE_DIR}
-                    ${sourceplugin_patch}
+                    PATCH_COMMAND /bin/sh <SOURCE_DIR>/apply-patches.sh
+                      ${PATCH_EXECUTABLE}
+                      <SOURCE_DIR>
+                      ${ffmpeg_patches}
                     CONFIGURE_COMMAND ${pkgconf} ${pkgconf_path} <SOURCE_DIR>/configure
                       --prefix=${CMAKE_INSTALL_PREFIX}
                       --extra-version="kodi-${FFMPEG_VER}"

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -2,6 +2,7 @@
 include FFMPEG-VERSION
 DEPS = FFMPEG-VERSION Makefile ../../download-files.include \
                       CMakeLists.txt \
+                      ../../apply-patches.sh \
                       001-ffmpeg-all-libpostproc-plugin.patch \
                       002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch
 
@@ -46,6 +47,7 @@ all: .installed-$(PLATFORM)
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)/build
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); cp ../CMakeLists.txt ./
+	cd $(PLATFORM); cp ../../apply-patches.sh ./
 	cd $(PLATFORM); cp ../001-ffmpeg-all-libpostproc-plugin.patch ../002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch ./
 	cd $(PLATFORM)/build; $(CMAKE) $(CMAKE_ARGS) ..
 	touch $@


### PR DESCRIPTION
## Description
Make the ffmpeg patch step idempotent by using a shared tools/depends/apply-patches.sh helper with marker files.

## Motivation and context
The ffmpeg ExternalProject patch step could rerun on an already-patched source tree and block on an interactive patch prompt. This avoids the prompt and skips patches that were already applied by the helper.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
