### PR TITLE
[URL] Fix CURL::Parse to handle nfs URL options correctly.

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -160,7 +160,7 @@ void CURL::Parse(std::string strURL1)
     sep = "?";
   else if (IsProtocolEqual(strProtocol2, "http") || IsProtocolEqual(strProtocol2, "https") ||
            IsProtocolEqual(strProtocol2, "plugin") || IsProtocolEqual(strProtocol2, "addons") ||
-           IsProtocolEqual(strProtocol2, "rtsp"))
+           IsProtocolEqual(strProtocol2, "rtsp") || IsProtocolEqual(strProtocol2, "nfs"))
     sep = "?;#|";
   else if (IsProtocolEqual(strProtocol2, "ftp") || IsProtocolEqual(strProtocol2, "ftps"))
     sep = "?;|";

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -122,16 +122,8 @@ void CURL::Parse(std::string strURL1)
   // ones that come to mind are iso9660, cdda, musicdb, etc.
   // they are all local protocols and have no server part, port number, special options, etc.
   // this removes the need for special handling below.
-  // clang-format off
-  if (
-    IsProtocol("stack") ||
-    IsProtocol("virtualpath") ||
-    IsProtocol("multipath") ||
-    IsProtocol("special") ||
-    IsProtocol("resource") ||
-    IsProtocol("file")
-    )
-  // clang-format on
+  if (IsProtocol("stack") || IsProtocol("virtualpath") || IsProtocol("multipath") ||
+      IsProtocol("special") || IsProtocol("resource") || IsProtocol("file"))
   {
     SetFileName(std::move(strURL).substr(iPos));
     return;
@@ -151,7 +143,8 @@ void CURL::Parse(std::string strURL1)
   }
 
   // check for username/password - should occur before first /
-  if (iPos == std::string::npos) iPos = 0;
+  if (iPos == std::string::npos)
+    iPos = 0;
 
   // for protocols supporting options, chop that part off here
   // maybe we should invert this list instead?
@@ -165,18 +158,14 @@ void CURL::Parse(std::string strURL1)
       IsProtocol("videodb") || IsProtocol("musicdb") || IsProtocol("androidapp") ||
       IsProtocol("pvr") || IsProtocol("bluray"))
     sep = "?";
-  else
-  if(  IsProtocolEqual(strProtocol2, "http")
-    || IsProtocolEqual(strProtocol2, "https")
-    || IsProtocolEqual(strProtocol2, "plugin")
-    || IsProtocolEqual(strProtocol2, "addons")
-    || IsProtocolEqual(strProtocol2, "rtsp"))
+  else if (IsProtocolEqual(strProtocol2, "http") || IsProtocolEqual(strProtocol2, "https") ||
+           IsProtocolEqual(strProtocol2, "plugin") || IsProtocolEqual(strProtocol2, "addons") ||
+           IsProtocolEqual(strProtocol2, "rtsp"))
     sep = "?;#|";
-  else if(IsProtocolEqual(strProtocol2, "ftp")
-       || IsProtocolEqual(strProtocol2, "ftps"))
+  else if (IsProtocolEqual(strProtocol2, "ftp") || IsProtocolEqual(strProtocol2, "ftps"))
     sep = "?;|";
 
-  if(sep)
+  if (sep)
   {
     size_t iOptions = strURL.find_first_of(sep, iPos);
     if (iOptions != std::string::npos)
@@ -185,8 +174,8 @@ void CURL::Parse(std::string strURL1)
       size_t iProto = strURL.find_first_of('|', iOptions);
       if (iProto != std::string::npos)
       {
-        SetProtocolOptions(strURL.substr(iProto+1));
-        SetOptions(strURL.substr(iOptions,iProto-iOptions));
+        SetProtocolOptions(strURL.substr(iProto + 1));
+        SetOptions(strURL.substr(iOptions, iProto - iOptions));
       }
       else
         SetOptions(strURL.substr(iOptions));
@@ -195,15 +184,15 @@ void CURL::Parse(std::string strURL1)
   }
 
   size_t iSlash = strURL.find('/', iPos);
-  if(iSlash >= iEnd)
+  if (iSlash >= iEnd)
     iSlash = std::string::npos; // was an invalid slash as it was contained in options
 
   // also skip parsing username:password@ for udp/rtp as it not valid
   // and conflicts with the following example: rtp://sourceip@multicastip
   size_t iAlphaSign = strURL.find('@', iPos);
   if (iAlphaSign != std::string::npos && iAlphaSign < iEnd &&
-      (iAlphaSign < iSlash || iSlash == std::string::npos) &&
-      !IsProtocol("udp") && !IsProtocol("rtp"))
+      (iAlphaSign < iSlash || iSlash == std::string::npos) && !IsProtocol("udp") &&
+      !IsProtocol("rtp"))
   {
     // username/password found
     std::string strUserNamePassword = strURL.substr(iPos, iAlphaSign - iPos);
@@ -240,15 +229,16 @@ void CURL::Parse(std::string strURL1)
       iSlash = std::string::npos;
   }
 
-  std::string strHostNameAndPort = strURL.substr(iPos, (iSlash == std::string::npos) ? iEnd - iPos : iSlash - iPos);
+  std::string strHostNameAndPort =
+      strURL.substr(iPos, (iSlash == std::string::npos) ? iEnd - iPos : iSlash - iPos);
   // check for IPv6 numerical representation inside [].
   // if [] found, let's store string inside as hostname
   // and remove that parsed part from strHostNameAndPort
   size_t iBrk = strHostNameAndPort.rfind(']');
   if (iBrk != std::string::npos && strHostNameAndPort.starts_with('['))
   {
-    m_strHostName = strHostNameAndPort.substr(1, iBrk-1);
-    strHostNameAndPort.erase(0, iBrk+1);
+    m_strHostName = strHostNameAndPort.substr(1, iBrk - 1);
+    strHostNameAndPort.erase(0, iBrk + 1);
   }
 
   // detect hostname:port/ or just :port/ if previous step found [IPv6] format
@@ -281,7 +271,7 @@ void CURL::Parse(std::string strURL1)
     }
     else
     {
-      if (!m_strHostName.empty() && strURL[iEnd-1]=='/')
+      if (!m_strHostName.empty() && strURL[iEnd - 1] == '/')
         m_strFileName = m_strHostName + "/";
       else
         m_strFileName = m_strHostName;
@@ -312,13 +302,13 @@ void CURL::SetFileName(std::string strFileName)
 
   size_t slash = m_strFileName.find_last_of(GetDirectorySeparator());
   size_t period = m_strFileName.find_last_of('.');
-  if(period != std::string::npos && (slash == std::string::npos || period > slash))
-    m_strFileType = m_strFileName.substr(period+1);
+  if (period != std::string::npos && (slash == std::string::npos || period > slash))
+    m_strFileType = m_strFileName.substr(period + 1);
   else
     m_strFileType = "";
 
   slash = m_strFileName.find_first_of(GetDirectorySeparator());
-  if(slash == std::string::npos)
+  if (slash == std::string::npos)
     m_strShareName = m_strFileName;
   else
     m_strShareName = m_strFileName.substr(0, slash);
@@ -339,10 +329,8 @@ void CURL::SetOptions(std::string strOptions)
   m_options.Clear();
   if (!strOptions.empty())
   {
-    if(strOptions[0] == '?' ||
-       strOptions[0] == '#' ||
-       strOptions[0] == ';' ||
-       strOptions.find("xml") != std::string::npos)
+    if (strOptions[0] == '?' || strOptions[0] == '#' || strOptions[0] == ';' ||
+        strOptions.find("xml") != std::string::npos)
     {
       m_strOptions = std::move(strOptions);
       m_options.AddOptions(m_strOptions);
@@ -368,13 +356,10 @@ void CURL::SetProtocolOptions(std::string strOptions)
 
 std::string CURL::GetTranslatedProtocol() const
 {
-  if (IsProtocol("shout")
-   || IsProtocol("dav")
-   || IsProtocol("rss"))
+  if (IsProtocol("shout") || IsProtocol("dav") || IsProtocol("rss"))
     return "http";
 
-  if (IsProtocol("davs")
-   || IsProtocol("rsss"))
+  if (IsProtocol("davs") || IsProtocol("rsss"))
     return "https";
 
   return GetProtocol();
@@ -383,11 +368,8 @@ std::string CURL::GetTranslatedProtocol() const
 std::string CURL::GetFileNameWithoutPath() const
 {
   // *.zip and *.rar store the actual zip/rar path in the hostname of the url
-  if ((IsProtocol("rar")  ||
-       IsProtocol("zip")  ||
-       IsProtocol("xbt")  ||
-       IsProtocol("apk")) &&
-       m_strFileName.empty())
+  if ((IsProtocol("rar") || IsProtocol("zip") || IsProtocol("xbt") || IsProtocol("apk")) &&
+      m_strFileName.empty())
     return URIUtils::GetFileName(m_strHostName);
 
   // otherwise, we've already got the filepath, so just grab the filename portion
@@ -396,8 +378,7 @@ std::string CURL::GetFileNameWithoutPath() const
   return URIUtils::GetFileName(file);
 }
 
-inline
-void protectIPv6(std::string &hn)
+inline void protectIPv6(std::string& hn)
 {
   if (!hn.empty() && hn.find(':') != hn.rfind(':') && hn.find(':') != std::string::npos)
   {
@@ -428,11 +409,11 @@ std::string CURL::Get() const
 
   std::string strURL = GetWithoutOptions();
 
-  if( !m_strOptions.empty() )
+  if (!m_strOptions.empty())
     strURL += m_strOptions;
 
   if (!m_strProtocolOptions.empty())
-    strURL += "|"+m_strProtocolOptions;
+    strURL += "|" + m_strProtocolOptions;
 
   return strURL;
 }
@@ -462,9 +443,9 @@ std::string CURL::GetWithoutUserDetails(bool redact) const
   {
     CFileItemList items;
     XFILE::CStackDirectory dir;
-    dir.GetDirectory(*this,items);
+    dir.GetDirectory(*this, items);
     std::vector<std::string> newItems;
-    for (int i=0;i<items.Size();++i)
+    for (int i = 0; i < items.Size(); ++i)
     {
       CURL url(items[i]->GetPath());
       items[i]->SetPath(url.GetWithoutUserDetails(redact));
@@ -474,12 +455,8 @@ std::string CURL::GetWithoutUserDetails(bool redact) const
     return strURL;
   }
 
-  unsigned int sizeneed = m_strProtocol.length()
-                        + m_strHostName.length()
-                        + m_strFileName.length()
-                        + m_strOptions.length()
-                        + m_strProtocolOptions.length()
-                        + 10;
+  unsigned int sizeneed = m_strProtocol.length() + m_strHostName.length() + m_strFileName.length() +
+                          m_strOptions.length() + m_strProtocolOptions.length() + 10;
 
   if (redact && !m_strUserName.empty())
   {
@@ -520,7 +497,7 @@ std::string CURL::GetWithoutUserDetails(bool redact) const
     if (HasEncodedHostname())
       strHostName = Encode(strHostName);
 
-    if ( HasPort() )
+    if (HasPort())
     {
       protectIPv6(strHostName);
       strURL += strHostName + StringUtils::Format(":{}", m_iPort);
@@ -535,7 +512,7 @@ std::string CURL::GetWithoutUserDetails(bool redact) const
   if (!m_strOptions.empty())
     strURL += m_strOptions;
   if (!m_strProtocolOptions.empty())
-    strURL += "|"+m_strProtocolOptions;
+    strURL += "|" + m_strProtocolOptions;
 
   return strURL;
 }
@@ -545,12 +522,8 @@ std::string CURL::GetWithoutFilename() const
   if (m_strProtocol.empty())
     return "";
 
-  unsigned int sizeneed = m_strProtocol.length()
-                        + m_strDomain.length()
-                        + m_strUserName.length()
-                        + m_strPassword.length()
-                        + m_strHostName.length()
-                        + 10;
+  unsigned int sizeneed = m_strProtocol.length() + m_strDomain.length() + m_strUserName.length() +
+                          m_strPassword.length() + m_strHostName.length() + 10;
 
   std::string strURL;
   strURL.reserve(sizeneed);
@@ -617,18 +590,21 @@ bool CURL::IsLocalHost() const
   return CServiceBroker::GetNetwork().IsLocalHost(m_strHostName);
 }
 
-bool CURL::IsFileOnly(const std::string &url)
+bool CURL::IsFileOnly(const std::string& url)
 {
   return url.find_first_of("/\\") == std::string::npos;
 }
 
-bool CURL::IsFullPath(const std::string &url)
+bool CURL::IsFullPath(const std::string& url)
 {
-  if (!url.empty() && url[0] == '/')
-    return true; //   /foo/bar.ext
-  if (url.find("://") != std::string::npos) return true;                 //   foo://bar.ext
-  if (url.size() > 1 && url[1] == ':') return true; //   c:\\foo\\bar\\bar.ext
-  if (StringUtils::StartsWith(url, "\\\\")) return true;    //   \\UNC\path\to\file
+  if (!url.empty() && url[0] == '/') // /foo/bar.ext
+    return true;
+  if (url.find("://") != std::string::npos) // foo://bar.ext
+    return true;
+  if (url.size() > 1 && url[1] == ':') // c:\\foo\\bar\\bar.ext
+    return true;
+  if (StringUtils::StartsWith(url, "\\\\")) // \\UNC\path\to\file
+    return true;
   return false;
 }
 
@@ -653,7 +629,7 @@ bool CURL::IsProtocolEqual(const std::string& protocol, std::string_view type)
   return protocol == type;
 }
 
-void CURL::GetOptions(std::map<std::string, std::string> &options) const
+void CURL::GetOptions(std::map<std::string, std::string>& options) const
 {
   CUrlOptions::UrlOptions optionsMap = m_options.GetOptions();
   for (CUrlOptions::UrlOptions::const_iterator option = optionsMap.begin();
@@ -661,12 +637,12 @@ void CURL::GetOptions(std::map<std::string, std::string> &options) const
     options[option->first] = option->second.asString();
 }
 
-bool CURL::HasOption(const std::string &key) const
+bool CURL::HasOption(const std::string& key) const
 {
   return m_options.HasOption(key);
 }
 
-bool CURL::GetOption(const std::string &key, std::string &value) const
+bool CURL::GetOption(const std::string& key, std::string& value) const
 {
   CVariant valueObj;
   if (!m_options.GetOption(key, valueObj))
@@ -676,7 +652,7 @@ bool CURL::GetOption(const std::string &key, std::string &value) const
   return true;
 }
 
-std::string CURL::GetOption(const std::string &key) const
+std::string CURL::GetOption(const std::string& key) const
 {
   std::string value;
   if (!GetOption(key, value))
@@ -685,19 +661,19 @@ std::string CURL::GetOption(const std::string &key) const
   return value;
 }
 
-void CURL::SetOption(const std::string &key, const std::string &value)
+void CURL::SetOption(const std::string& key, const std::string& value)
 {
   m_options.AddOption(key, value);
   SetOptions(m_options.GetOptionsString(true));
 }
 
-void CURL::RemoveOption(const std::string &key)
+void CURL::RemoveOption(const std::string& key)
 {
   m_options.RemoveOption(key);
   SetOptions(m_options.GetOptionsString(true));
 }
 
-void CURL::GetProtocolOptions(std::map<std::string, std::string> &options) const
+void CURL::GetProtocolOptions(std::map<std::string, std::string>& options) const
 {
   CUrlOptions::UrlOptions optionsMap = m_protocolOptions.GetOptions();
   for (CUrlOptions::UrlOptions::const_iterator option = optionsMap.begin();
@@ -705,12 +681,12 @@ void CURL::GetProtocolOptions(std::map<std::string, std::string> &options) const
     options[option->first] = option->second.asString();
 }
 
-bool CURL::HasProtocolOption(const std::string &key) const
+bool CURL::HasProtocolOption(const std::string& key) const
 {
   return m_protocolOptions.HasOption(key);
 }
 
-bool CURL::GetProtocolOption(const std::string &key, std::string &value) const
+bool CURL::GetProtocolOption(const std::string& key, std::string& value) const
 {
   CVariant valueObj;
   if (!m_protocolOptions.GetOption(key, valueObj))
@@ -720,7 +696,7 @@ bool CURL::GetProtocolOption(const std::string &key, std::string &value) const
   return true;
 }
 
-std::string CURL::GetProtocolOption(const std::string &key) const
+std::string CURL::GetProtocolOption(const std::string& key) const
 {
   std::string value;
   if (!GetProtocolOption(key, value))
@@ -729,13 +705,13 @@ std::string CURL::GetProtocolOption(const std::string &key) const
   return value;
 }
 
-void CURL::SetProtocolOption(const std::string &key, const std::string &value)
+void CURL::SetProtocolOption(const std::string& key, const std::string& value)
 {
   m_protocolOptions.AddOption(key, value);
   m_strProtocolOptions = m_protocolOptions.GetOptionsString(false);
 }
 
-void CURL::RemoveProtocolOption(const std::string &key)
+void CURL::RemoveProtocolOption(const std::string& key)
 {
   m_protocolOptions.RemoveOption(key);
   m_strProtocolOptions = m_protocolOptions.GetOptionsString(false);

--- a/xbmc/URL.h
+++ b/xbmc/URL.h
@@ -42,72 +42,33 @@ public:
   void SetProtocol(std::string strProtocol);
   void SetOptions(std::string strOptions);
   void SetProtocolOptions(std::string strOptions);
-  void SetPort(int port)
-  {
-    m_iPort = port;
-  }
+  void SetPort(int port) { m_iPort = port; }
 
-  bool HasPort() const
-  {
-    return (m_iPort != 0);
-  }
+  bool HasPort() const { return (m_iPort != 0); }
 
-  int GetPort() const
-  {
-    return m_iPort;
-  }
+  int GetPort() const { return m_iPort; }
 
-  const std::string& GetHostName() const
-  {
-    return m_strHostName;
-  }
+  const std::string& GetHostName() const { return m_strHostName; }
 
-  const std::string& GetDomain() const
-  {
-    return m_strDomain;
-  }
+  const std::string& GetDomain() const { return m_strDomain; }
 
-  const std::string& GetUserName() const
-  {
-    return m_strUserName;
-  }
+  const std::string& GetUserName() const { return m_strUserName; }
 
-  const std::string& GetPassWord() const
-  {
-    return m_strPassword;
-  }
+  const std::string& GetPassWord() const { return m_strPassword; }
 
-  const std::string& GetFileName() const
-  {
-    return m_strFileName;
-  }
+  const std::string& GetFileName() const { return m_strFileName; }
 
-  const std::string& GetProtocol() const
-  {
-    return m_strProtocol;
-  }
+  const std::string& GetProtocol() const { return m_strProtocol; }
 
   std::string GetTranslatedProtocol() const;
 
-  const std::string& GetFileType() const
-  {
-    return m_strFileType;
-  }
+  const std::string& GetFileType() const { return m_strFileType; }
 
-  const std::string& GetShareName() const
-  {
-      return m_strShareName;
-  }
+  const std::string& GetShareName() const { return m_strShareName; }
 
-  const std::string& GetOptions() const
-  {
-    return m_strOptions;
-  }
+  const std::string& GetOptions() const { return m_strOptions; }
 
-  const std::string& GetProtocolOptions() const
-  {
-    return m_strProtocolOptions;
-  }
+  const std::string& GetProtocolOptions() const { return m_strProtocolOptions; }
 
   std::string GetFileNameWithoutPath() const; /* return the filename excluding path */
 
@@ -121,8 +82,9 @@ public:
   static std::string GetRedacted(std::string path);
   bool IsLocal() const;
   bool IsLocalHost() const;
-  static bool IsFileOnly(const std::string &url); ///< return true if there are no directories in the url.
-  static bool IsFullPath(const std::string &url); ///< return true if the url includes the full path
+  static bool IsFileOnly(
+      const std::string& url); ///< return true if there are no directories in the url.
+  static bool IsFullPath(const std::string& url); ///< return true if the url includes the full path
   static std::string Decode(std::string_view strURLData);
   static std::string Encode(std::string_view strURLData);
 
@@ -150,19 +112,19 @@ public:
    */
   bool IsFileType(std::string_view type) const { return m_strFileType == type; }
 
-  void GetOptions(std::map<std::string, std::string> &options) const;
-  bool HasOption(const std::string &key) const;
-  bool GetOption(const std::string &key, std::string &value) const;
-  std::string GetOption(const std::string &key) const;
-  void SetOption(const std::string &key, const std::string &value);
-  void RemoveOption(const std::string &key);
+  void GetOptions(std::map<std::string, std::string>& options) const;
+  bool HasOption(const std::string& key) const;
+  bool GetOption(const std::string& key, std::string& value) const;
+  std::string GetOption(const std::string& key) const;
+  void SetOption(const std::string& key, const std::string& value);
+  void RemoveOption(const std::string& key);
 
-  void GetProtocolOptions(std::map<std::string, std::string> &options) const;
-  bool HasProtocolOption(const std::string &key) const;
-  bool GetProtocolOption(const std::string &key, std::string &value) const;
-  std::string GetProtocolOption(const std::string &key) const;
-  void SetProtocolOption(const std::string &key, const std::string &value);
-  void RemoveProtocolOption(const std::string &key);
+  void GetProtocolOptions(std::map<std::string, std::string>& options) const;
+  bool HasProtocolOption(const std::string& key) const;
+  bool GetProtocolOption(const std::string& key, std::string& value) const;
+  std::string GetProtocolOption(const std::string& key) const;
+  void SetProtocolOption(const std::string& key, const std::string& value);
+  void RemoveProtocolOption(const std::string& key);
 
   bool HasExtension(std::string_view extensions) const;
   std::string GetExtension() const;

--- a/xbmc/test/TestURL.cpp
+++ b/xbmc/test/TestURL.cpp
@@ -287,3 +287,179 @@ TEST_F(TestCURL, TestExtensions)
   EXPECT_EQ(".gz", url.GetExtension());
   EXPECT_FALSE(url.HasExtension(extensions));
 }
+
+// Tests for NFS URL options parsing (PR #28249)
+TEST_F(TestCURL, TestNFSURLWithOptions)
+{
+  // Test NFS URL with mimetype option
+  std::string nfsUrl = "nfs://192.168.178.23/mnt/HD/Videos/movie.mkv?mimetype=video%2fx-matroska";
+  CURL url(nfsUrl);
+
+  EXPECT_EQ(url.GetProtocol(), "nfs");
+  EXPECT_EQ(url.GetHostName(), "192.168.178.23");
+  EXPECT_EQ(url.GetFileName(), "mnt/HD/Videos/movie.mkv");
+  EXPECT_EQ(url.GetFileType(), "mkv");
+  EXPECT_EQ(url.GetOptions(), "?mimetype=video%2fx-matroska");
+  // Verify options are properly separated from filename
+  EXPECT_FALSE(url.GetFileName().find("?") != std::string::npos);
+}
+
+TEST_F(TestCURL, TestNFSURLWithoutOptions)
+{
+  // Test NFS URL without options - should work normally
+  std::string nfsUrl = "nfs://192.168.178.23/mnt/HD/Videos/movie.mkv";
+  CURL url(nfsUrl);
+
+  EXPECT_EQ(url.GetProtocol(), "nfs");
+  EXPECT_EQ(url.GetHostName(), "192.168.178.23");
+  EXPECT_EQ(url.GetFileName(), "mnt/HD/Videos/movie.mkv");
+  EXPECT_EQ(url.GetFileType(), "mkv");
+  EXPECT_EQ(url.GetOptions(), "");
+}
+
+TEST_F(TestCURL, TestNFSURLWithPort)
+{
+  // Test NFS URL with port number
+  std::string nfsUrl = "nfs://192.168.178.23:2049/mnt/HD/Videos/movie.mkv";
+  CURL url(nfsUrl);
+
+  EXPECT_EQ(url.GetProtocol(), "nfs");
+  EXPECT_EQ(url.GetHostName(), "192.168.178.23");
+  EXPECT_EQ(url.GetPort(), 2049);
+  EXPECT_EQ(url.GetFileName(), "mnt/HD/Videos/movie.mkv");
+}
+
+TEST_F(TestCURL, TestNFSURLWithPortAndOptions)
+{
+  // Test NFS URL with both port and options
+  std::string nfsUrl = "nfs://192.168.178.23:2049/mnt/HD/Videos/movie.mp4?mimetype=video%2fmp4";
+  CURL url(nfsUrl);
+
+  EXPECT_EQ(url.GetProtocol(), "nfs");
+  EXPECT_EQ(url.GetHostName(), "192.168.178.23");
+  EXPECT_EQ(url.GetPort(), 2049);
+  EXPECT_EQ(url.GetFileName(), "mnt/HD/Videos/movie.mp4");
+  EXPECT_EQ(url.GetOptions(), "?mimetype=video%2fmp4");
+  EXPECT_FALSE(url.GetFileName().find("?") != std::string::npos);
+}
+
+TEST_F(TestCURL, TestNFSURLMultipleOptions)
+{
+  // Test NFS URL with multiple options
+  std::string nfsUrl = "nfs://192.168.178.23/share/file.mp4?mimetype=video%2fmp4&timeout=30";
+  CURL url(nfsUrl);
+
+  EXPECT_EQ(url.GetProtocol(), "nfs");
+  EXPECT_EQ(url.GetHostName(), "192.168.178.23");
+  EXPECT_EQ(url.GetFileName(), "share/file.mp4");
+  EXPECT_EQ(url.GetOptions(), "?mimetype=video%2fmp4&timeout=30");
+  // Filename should not contain options
+  EXPECT_FALSE(url.GetFileName().find("?") != std::string::npos);
+  EXPECT_FALSE(url.GetFileName().find("&") != std::string::npos);
+}
+
+TEST_F(TestCURL, TestNFSURLWithSpecialCharacters)
+{
+  // Test NFS URL with spaces and special characters in path
+  std::string nfsUrl = "nfs://192.168.178.23/mnt/Public/Shared%20Videos/"
+                       "Movie%20(2020).mkv?mimetype=video%2fx-matroska";
+  CURL url(nfsUrl);
+
+  EXPECT_EQ(url.GetProtocol(), "nfs");
+  EXPECT_EQ(url.GetHostName(), "192.168.178.23");
+  // Filename should contain the path with encoded spaces but NOT the query
+  EXPECT_EQ(url.GetFileName(), "mnt/Public/Shared%20Videos/Movie%20(2020).mkv");
+  EXPECT_EQ(url.GetOptions(), "?mimetype=video%2fx-matroska");
+  EXPECT_EQ(url.GetFileType(), "mkv");
+}
+
+TEST_F(TestCURL, TestNFSURLReconstructed)
+{
+  // Test that reconstructing NFS URL preserves options
+  std::string originalUrl = "nfs://192.168.178.23/mnt/HD/Videos/movie.mkv?mimetype=video%2fmp4";
+  CURL url(originalUrl);
+  std::string reconstructedUrl = url.Get();
+
+  EXPECT_EQ(reconstructedUrl, originalUrl);
+}
+
+TEST_F(TestCURL, TestNFSURLWithIPv6)
+{
+  // Test NFS URL with IPv6 address
+  std::string nfsUrl = "nfs://[2001:db8::1]/mnt/HD/Videos/movie.mp4?mimetype=video%2fmp4";
+  CURL url(nfsUrl);
+
+  EXPECT_EQ(url.GetProtocol(), "nfs");
+  EXPECT_EQ(url.GetHostName(), "2001:db8::1");
+  EXPECT_EQ(url.GetFileName(), "mnt/HD/Videos/movie.mp4");
+  EXPECT_EQ(url.GetOptions(), "?mimetype=video%2fmp4");
+}
+
+TEST_F(TestCURL, TestNFSURLGetWithoutUserDetails)
+{
+  // Test GetWithoutUserDetails for NFS URL with options
+  std::string nfsUrl = "nfs://user:pass@192.168.178.23/share/movie.mp4?mimetype=video%2fmp4";
+  CURL url(nfsUrl);
+
+  std::string result = url.GetWithoutUserDetails(false);
+  EXPECT_EQ(result, "nfs://192.168.178.23/share/movie.mp4?mimetype=video%2fmp4");
+}
+
+TEST_F(TestCURL, TestNFSURLGetWithoutOptions)
+{
+  // Test GetWithoutOptions for NFS URL
+  std::string nfsUrl = "nfs://192.168.178.23/share/movie.mp4?mimetype=video%2fmp4";
+  CURL url(nfsUrl);
+
+  std::string resultWithoutOptions = url.GetWithoutOptions();
+  EXPECT_EQ(resultWithoutOptions, "nfs://192.168.178.23/share/movie.mp4");
+}
+
+struct TestNFSURLParsingData
+{
+  std::string input;
+  std::string expectedProtocol;
+  std::string expectedHostName;
+  std::string expectedFileName;
+  std::string expectedOptions;
+  std::string expectedFileType;
+};
+
+std::ostream& operator<<(std::ostream& os, const TestNFSURLParsingData& rhs)
+{
+  return os << "(Input: " << rhs.input << ")";
+}
+
+class TestNFSURLParsing : public Test, public WithParamInterface<TestNFSURLParsingData>
+{
+};
+
+TEST_P(TestNFSURLParsing, ParseNFSURL)
+{
+  CURL url(GetParam().input);
+  EXPECT_EQ(url.GetProtocol(), GetParam().expectedProtocol);
+  EXPECT_EQ(url.GetHostName(), GetParam().expectedHostName);
+  EXPECT_EQ(url.GetFileName(), GetParam().expectedFileName);
+  EXPECT_EQ(url.GetOptions(), GetParam().expectedOptions);
+  EXPECT_EQ(url.GetFileType(), GetParam().expectedFileType);
+}
+
+const TestNFSURLParsingData nfsParsingData[] = {
+    // Basic NFS URL with options
+    {"nfs://192.168.178.23/share/file.mkv?mimetype=video%2fx-matroska", "nfs", "192.168.178.23",
+     "share/file.mkv", "?mimetype=video%2fx-matroska", "mkv"},
+    // NFS URL without options
+    {"nfs://192.168.1.1/export/path/video.mp4", "nfs", "192.168.1.1", "export/path/video.mp4", "",
+     "mp4"},
+    // NFS URL with port and options
+    {"nfs://10.0.0.5:2049/data/movie.avi?timeout=30", "nfs", "10.0.0.5", "data/movie.avi",
+     "?timeout=30", "avi"},
+    // NFS URL with multiple query parameters
+    {"nfs://server.local/nfs/files.iso?mimetype=application%2fx-iso9660-image&version=1", "nfs",
+     "server.local", "nfs/files.iso", "?mimetype=application%2fx-iso9660-image&version=1", "iso"},
+    // NFS URL with encoded spaces in path
+    {"nfs://192.168.1.100/Public/My%20Videos/Movie%202020.mkv?type=video", "nfs", "192.168.1.100",
+     "Public/My%20Videos/Movie%202020.mkv", "?type=video", "mkv"},
+};
+
+INSTANTIATE_TEST_SUITE_P(NFSParsing, TestNFSURLParsing, ValuesIn(nfsParsingData));

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -1879,22 +1879,22 @@ TEST_F(TestURIUtils, CheckConsistencyBetweenFileNameUtilities)
     EXPECT_EQ(".thing", URIUtils_Split("/hello/there/.thing"));
   }
   {
-    EXPECT_EQ("srv/share/movie.avi?option=true",
+    EXPECT_EQ("srv/share/movie.avi",
               CURL("nfs://127.0.0.1/srv/share/movie.avi?option=true").GetFileName());
 
-    EXPECT_EQ("movie.avi?option=true",
+    EXPECT_EQ("movie.avi",
               URIUtils::GetFileName("nfs://127.0.0.1/srv/share/movie.avi?option=true"));
-    EXPECT_EQ("movie.avi?option=true",
+    EXPECT_EQ("movie.avi",
               CURL_FileName_URIUtils_Split("nfs://127.0.0.1/srv/share/movie.avi?option=true"));
     EXPECT_EQ("movie.avi", URIUtils_Split("nfs://127.0.0.1/srv/share/movie.avi?option=true"));
   }
   {
-    EXPECT_EQ("srv/share/movie.avi|option=true",
+    EXPECT_EQ("srv/share/movie.avi",
               CURL("nfs://127.0.0.1/srv/share/movie.avi|option=true").GetFileName());
 
-    EXPECT_EQ("movie.avi|option=true",
+    EXPECT_EQ("movie.avi",
               URIUtils::GetFileName("nfs://127.0.0.1/srv/share/movie.avi|option=true"));
-    EXPECT_EQ("movie.avi|option=true",
+    EXPECT_EQ("movie.avi",
               CURL_FileName_URIUtils_Split("nfs://127.0.0.1/srv/share/movie.avi|option=true"));
     EXPECT_EQ("movie.avi", URIUtils_Split("nfs://127.0.0.1/srv/share/movie.avi|option=true"));
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fixes construction of `CURL` instances from a given NFS URL string containing URL options.

Example: `nfs://192.168.178.23/mnt/HD/HD_a2/Public/Shared Videos/Filme/1000 Jahre EAV Live Der Abschied 2019.mkv?mimetype=video%2fx-matroska`

Side note: It seems we're not properly escaping special chars, like blanks... but this seems not to cause issues.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Wanted to find out the reason for recently observed log errors of the form

```log
2026-04-28 20:51:55.703 T:11145   error <general>: NFS: Failed to stat(mnt/HD/HD_a2/Public/Shared Videos/Filme/1000 Jahre EAV Live Der Abschied 2019.mkv?mimetype=video%2fx-matroska) stat call failed with "NFS: Lookup of /Shared Videos/Filme/1000 Jahre EAV Live Der Abschied 2019.mkv?mimetype=video%2fx-matroska failed with NFS3ERR_NOENT(-2)"
```

... where the mkv file definitely was present at the given location.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Not sure, but it happens when starting playback of files and I guess not being able to determine existence of a file correctly could lead to all kind of misbehavior.

## Screenshots (if appropriate):

Good: This is how a `CURL` instance created for URL string `nfs://192.168.178.23/mnt/HD/HD_a2/Public/Shared Videos/Filme/1000 Jahre EAV Live Der Abschied 2019.mkv?mimetype=video%2fx-matroska` should look like:

<img width="837" height="534" alt="Screenshot 2026-05-01 at 10 57 29" src="https://github.com/user-attachments/assets/c4ade8c8-3ed2-4f1f-9cb4-d49ed4135f16" />


Bad: This is how a `CURL` instance created for URL string `nfs://192.168.178.23/mnt/HD/HD_a2/Public/Shared Videos/Filme/1000 Jahre EAV Live Der Abschied 2019.mkv?mimetype=video%2fx-matroska` looks before this PR:

<img width="835" height="529" alt="Screenshot 2026-05-01 at 10 58 53" src="https://github.com/user-attachments/assets/8c01c3b4-05a9-40cc-aab8-c0863125ef7e" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
