### PR TITLE
doxygen: Property escape commas

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4302,7 +4302,7 @@ constexpr std::array<InfoMap, 83> videoplayer = {{
 ///   \table_row3{   <b>`RetroPlayer.SupportsEject`</b>,
 ///                  \anchor RetroPlayer_SupportsEject
 ///                  _boolean_,
-///     @return **True** if the game's disc can be ejected, **False** if the
+///     @return **True** if the game's disc can be ejected\, **False** if the
 ///     game isn't disc-based or doesn't support ejecting the disc.
 ///     <p><hr>
 ///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_SupportsEject `RetroPlayer.SupportsEject`\endlink
@@ -4310,7 +4310,7 @@ constexpr std::array<InfoMap, 83> videoplayer = {{
 ///   \table_row3{   <b>`RetroPlayer.DiscEjected`</b>,
 ///                  \anchor RetroPlayer_DiscEjected
 ///                  _boolean_,
-///     @return **True** if the game's disc is ejected (tray is open), **False**
+///     @return **True** if the game's disc is ejected (tray is open)\, **False**
 ///     if the game isn't disc-based or the tray is closed.
 ///     <p><hr>
 ///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_DiscEjected `RetroPlayer.DiscEjected`\endlink
@@ -4318,7 +4318,7 @@ constexpr std::array<InfoMap, 83> videoplayer = {{
 ///   \table_row3{   <b>`RetroPlayer.DiscLabel`</b>,
 ///                  \anchor RetroPlayer_DiscLabel
 ///                  _string_,
-///     @return The human-readable label of the currently inserted disc, or
+///     @return The human-readable label of the currently inserted disc\, or
 ///     an empty string if no disc is in the tray/floppy drive or the game
 ///     isn't disc-based.
 ///     <p><hr>
@@ -4327,7 +4327,7 @@ constexpr std::array<InfoMap, 83> videoplayer = {{
 ///   \table_row3{   <b>`RetroPlayer.EmptyTray`</b>,
 ///                  \anchor RetroPlayer_EmptyTray
 ///                  _boolean_,
-///     @return **True** if the selected disc state is "No disc", **False** if a
+///     @return **True** if the selected disc state is "No disc"\, **False** if a
 ///     disc is selected or the game isn't disc-based.
 ///     <p><hr>
 ///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_EmptyTray `RetroPlayer.EmptyTray`\endlink


### PR DESCRIPTION
## Description

As title says. It seems that https://github.com/xbmc/xbmc/pull/27984 included some non-escaped commas, which broke doxygen, causing https://github.com/xbmc/xbmc/issues/28251.

## Motivation and context

Fixes https://github.com/xbmc/xbmc/issues/28251.

## How has this been tested?

Untested.

## What is the effect on users?

* Fixes doxygen after Disc Manager PR.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
