### PR TITLE
AdvancedSettings: add tests and convert to tinyxml2

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -604,25 +604,24 @@ bool CLangInfo::UseLocaleCollation()
   return m_collationtype == 2;
 }
 
-void CLangInfo::LoadTokens(const TiXmlNode* pTokens, Tokens& vecTokens)
+void CLangInfo::LoadTokens(const tinyxml2::XMLElement* pTokens, Tokens& vecTokens)
 {
   if (pTokens && !pTokens->NoChildren())
   {
-    const TiXmlElement *pToken = pTokens->FirstChildElement("token");
+    const auto* pToken = pTokens->FirstChildElement("token");
     while (pToken)
     {
-      std::string strSep= " ._";
-      if (pToken->Attribute("separators"))
-        strSep = pToken->Attribute("separators");
+      const char* attr = pToken->Attribute("separators");
+      const std::string_view strSep = attr ? attr : " ._";
       if (pToken->FirstChild() && pToken->FirstChild()->Value())
       {
         if (strSep.empty())
-          vecTokens.insert(pToken->FirstChild()->ValueStr());
+          vecTokens.insert(pToken->FirstChild()->Value());
         else
-          for (unsigned int i=0;i<strSep.size();++i)
-            vecTokens.insert(pToken->FirstChild()->ValueStr() + strSep[i]);
+          for (const char sep : strSep)
+            vecTokens.insert(std::string(pToken->FirstChild()->Value()) + sep);
       }
-      pToken = pToken->NextSiblingElement();
+      pToken = pToken->NextSiblingElement("token");
     }
   }
 }

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -32,12 +32,15 @@
 #endif // GetTimeFormat
 #endif // TARGET_WINDOWS
 
-class TiXmlNode;
 struct StringSettingOption;
 
 namespace ADDON
 {
   class CLanguageResource;
+}
+namespace tinyxml2
+{
+class XMLElement;
 }
 typedef std::shared_ptr<ADDON::CLanguageResource> LanguageResourcePtr;
 
@@ -199,7 +202,7 @@ public:
   static std::string GetLanguageInfoPath(const std::string &language);
   bool UseLocaleCollation();
 
-  static void LoadTokens(const TiXmlNode* pTokens, Tokens& vecTokens);
+  static void LoadTokens(const tinyxml2::XMLElement* pTokens, Tokens& vecTokens);
 
   static void SettingOptionsLanguageNamesFiller(const std::shared_ptr<const CSetting>& setting,
                                                 std::vector<StringSettingOption>& list,

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -588,7 +588,28 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
   //Make a copy of the AS.xml and hide advancedsettings passwords
   CXBMCTinyXML advancedXMLCopy(advancedXML);
-  TiXmlNode *pRootElementCopy = advancedXMLCopy.RootElement();
+  Redact(advancedXMLCopy);
+
+  // Dump contents of copied AS.xml to debug log
+  TiXmlPrinter printer;
+  printer.SetLineBreak("\n");
+  printer.SetIndent("  ");
+  advancedXMLCopy.Accept(&printer);
+  // redact User/pass in URLs
+  std::regex redactRe("(\\w+://)\\S+:\\S+@");
+  CLog::Log(LOGINFO, "Contents of {} are...\n{}", file,
+            std::regex_replace(printer.CStr(), redactRe, "$1USERNAME:PASSWORD@"));
+
+  ParseSettingsXML(advancedXML.RootElement());
+
+  // load in the settings overrides
+  CServiceBroker::GetSettingsComponent()->GetSettings()->LoadHidden(advancedXML.RootElement());
+}
+
+void CAdvancedSettings::Redact(CXBMCTinyXML& input) const
+{
+  //Make a copy of the AS.xml and hide advancedsettings passwords
+  TiXmlNode* pRootElementCopy = input.RootElement();
   for (const auto& dbname : { "videodatabase", "musicdatabase", "tvdatabase", "epgdatabase" })
   {
     TiXmlNode *db = pRootElementCopy->FirstChild(dbname);
@@ -606,6 +627,8 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
       }
     }
   }
+
+  // Note: This is a regular setting override, not an advancedsetting.
   TiXmlNode *network = pRootElementCopy->FirstChild("network");
   if (network)
   {
@@ -620,21 +643,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
       }
     }
   }
-
-  // Dump contents of copied AS.xml to debug log
-  TiXmlPrinter printer;
-  printer.SetLineBreak("\n");
-  printer.SetIndent("  ");
-  advancedXMLCopy.Accept(&printer);
-  // redact User/pass in URLs
-  std::regex redactRe("(\\w+://)\\S+:\\S+@");
-  CLog::Log(LOGINFO, "Contents of {} are...\n{}", file,
-            std::regex_replace(printer.CStr(), redactRe, "$1USERNAME:PASSWORD@"));
-
-  ParseSettingsXML(advancedXML.RootElement());
-
-  // load in the settings overrides
-  CServiceBroker::GetSettingsComponent()->GetSettings()->LoadHidden(advancedXML.RootElement());
 }
 
 void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -631,6 +631,14 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   CLog::Log(LOGINFO, "Contents of {} are...\n{}", file,
             std::regex_replace(printer.CStr(), redactRe, "$1USERNAME:PASSWORD@"));
 
+  ParseSettingsXML(advancedXML.RootElement());
+
+  // load in the settings overrides
+  CServiceBroker::GetSettingsComponent()->GetSettings()->LoadHidden(advancedXML.RootElement());
+}
+
+void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
+{
   const TiXmlElement* pElement = pRootElement->FirstChildElement("audio");
   if (pElement)
   {
@@ -1306,9 +1314,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   }
 
   XMLUtils::GetBoolean(pRootElement, "opengldebugging", m_openGlDebugging);
-
-  // load in the settings overrides
-  CServiceBroker::GetSettingsComponent()->GetSettings()->LoadHidden(pRootElement);
 }
 
 void CAdvancedSettings::Clear()

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -603,7 +603,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   ParseSettingsXML(advancedXML.RootElement());
 
   // load in the settings overrides
-  CServiceBroker::GetSettingsComponent()->GetSettings()->LoadHidden(advancedXML.RootElement());
+  CServiceBroker::GetSettingsComponent()->GetSettings()->LoadHidden(file);
 }
 
 void CAdvancedSettings::Redact(CXBMCTinyXML& input) const

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -27,6 +27,7 @@
 #include "utils/StringUtils.h"
 #include "utils/SystemInfo.h"
 #include "utils/URIUtils.h"
+#include "utils/XBMCTinyXML2.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
@@ -50,9 +51,9 @@ bool ValidateVideoStackRegex(const CRegExp& regex)
     return false;
   }
   return true;
-};
+}
 
-void ParseDatabaseSettings(const TiXmlElement* element, DatabaseSettings& settings)
+void ParseDatabaseSettings(const tinyxml2::XMLElement* element, DatabaseSettings& settings)
 {
   XMLUtils::GetString(element, "type", settings.type);
   XMLUtils::GetString(element, "host", settings.host);
@@ -562,7 +563,7 @@ bool CAdvancedSettings::Load(const CProfileManager &profileManager)
 
 void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 {
-  CXBMCTinyXML advancedXML;
+  CXBMCTinyXML2 advancedXML;
   if (!CFileUtils::Exists(file))
   {
     CLog::Log(LOGINFO, "No settings file to load ({})", file);
@@ -571,12 +572,12 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
   if (!advancedXML.LoadFile(file))
   {
-    CLog::Log(LOGERROR, "Error loading {}, Line {}\n{}", file, advancedXML.ErrorRow(),
-              advancedXML.ErrorDesc());
+    CLog::Log(LOGERROR, "Error loading {}, Line {}\n{}", file, advancedXML.ErrorLineNum(),
+              advancedXML.ErrorStr());
     return;
   }
 
-  const TiXmlElement* pRootElement = advancedXML.RootElement();
+  const auto* pRootElement = advancedXML.RootElement();
   if (!pRootElement || StringUtils::CompareNoCase(pRootElement->Value(), "advancedsettings") != 0)
   {
     CLog::Log(LOGERROR, "Error loading {}, no <advancedsettings> node", file);
@@ -586,14 +587,13 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   // succeeded - tell the user it worked
   CLog::Log(LOGINFO, "Loaded settings file from {}", file);
 
-  //Make a copy of the AS.xml and hide advancedsettings passwords
-  CXBMCTinyXML advancedXMLCopy(advancedXML);
+  // Make a copy of the AS.xml and hide advancedsettings passwords
+  tinyxml2::XMLDocument advancedXMLCopy;
+  advancedXML.DeepCopy(&advancedXMLCopy);
   Redact(advancedXMLCopy);
 
   // Dump contents of copied AS.xml to debug log
-  TiXmlPrinter printer;
-  printer.SetLineBreak("\n");
-  printer.SetIndent("  ");
+  tinyxml2::XMLPrinter printer;
   advancedXMLCopy.Accept(&printer);
   // redact User/pass in URLs
   std::regex redactRe("(\\w+://)\\S+:\\S+@");
@@ -606,48 +606,50 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   CServiceBroker::GetSettingsComponent()->GetSettings()->LoadHidden(file);
 }
 
-void CAdvancedSettings::Redact(CXBMCTinyXML& input) const
+void CAdvancedSettings::Redact(tinyxml2::XMLDocument& input) const
 {
-  //Make a copy of the AS.xml and hide advancedsettings passwords
-  TiXmlNode* pRootElementCopy = input.RootElement();
+  // Make a copy of the AS.xml and hide advancedsettings passwords
+  auto* rootElementCopy = input.RootElement();
   for (const auto& dbname : { "videodatabase", "musicdatabase", "tvdatabase", "epgdatabase" })
   {
-    TiXmlNode *db = pRootElementCopy->FirstChild(dbname);
+    auto* db = rootElementCopy->FirstChildElement(dbname);
     if (db)
     {
-      TiXmlNode *passTag = db->FirstChild("pass");
+      auto* passTag = db->FirstChildElement("pass");
       if (passTag)
       {
-        TiXmlNode *pass = passTag->FirstChild();
+        auto* pass = passTag->FirstChild();
         if (pass)
         {
-          passTag->RemoveChild(pass);
-          passTag->LinkEndChild(new TiXmlText("*****"));
+          passTag->DeleteChild(pass);
+          auto* elem = input.NewText("*****");
+          passTag->InsertEndChild(elem);
         }
       }
     }
   }
 
   // Note: This is a regular setting override, not an advancedsetting.
-  TiXmlNode *network = pRootElementCopy->FirstChild("network");
+  auto* network = rootElementCopy->FirstChildElement("network");
   if (network)
   {
-    TiXmlNode *passTag = network->FirstChild("httpproxypassword");
+    auto* passTag = network->FirstChildElement("httpproxypassword");
     if (passTag)
     {
-      TiXmlNode *pass = passTag->FirstChild();
+      auto* pass = passTag->FirstChild();
       if (pass)
       {
-        passTag->RemoveChild(pass);
-        passTag->LinkEndChild(new TiXmlText("*****"));
+        passTag->DeleteChild(pass);
+        auto* elem = input.NewText("*****");
+        passTag->InsertEndChild(elem);
       }
     }
   }
 }
 
-void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
+void CAdvancedSettings::ParseSettingsXML(const tinyxml2::XMLElement* pRootElement)
 {
-  const TiXmlElement* pElement = pRootElement->FirstChildElement("audio");
+  const auto* pElement = pRootElement->FirstChildElement("audio");
   if (pElement)
   {
     XMLUtils::GetString(pElement, "defaultplayer", m_audioDefaultPlayer);
@@ -665,7 +667,7 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
     XMLUtils::GetInt(pElement, "percentseekforwardbig", m_musicPercentSeekForwardBig, 0, 100);
     XMLUtils::GetInt(pElement, "percentseekbackwardbig", m_musicPercentSeekBackwardBig, -100, 0);
 
-    const TiXmlElement* pAudioExcludes = pElement->FirstChildElement("excludefromlisting");
+    const auto* pAudioExcludes = pElement->FirstChildElement("excludefromlisting");
     if (pAudioExcludes)
       GetCustomRegexps(pAudioExcludes, m_audioExcludeFromListingRegExps);
 
@@ -717,7 +719,7 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
     XMLUtils::GetInt(pElement, "percentseekforwardbig", m_videoPercentSeekForwardBig, 0, 100);
     XMLUtils::GetInt(pElement, "percentseekbackwardbig", m_videoPercentSeekBackwardBig, -100, 0);
 
-    const TiXmlElement* pVideoExcludes = pElement->FirstChildElement("excludefromlisting");
+    const auto* pVideoExcludes = pElement->FirstChildElement("excludefromlisting");
     if (pVideoExcludes)
       GetCustomRegexps(pVideoExcludes, m_videoExcludeFromListingRegExps);
 
@@ -744,10 +746,10 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
     XMLUtils::GetBoolean(pElement,"vdpauHDdeintSkipChroma",m_videoVDPAUdeintSkipChromaHD);
     XMLUtils::GetBoolean(pElement, "bypasscodecprofile", m_videoBypassCodecProfile);
 
-    const TiXmlElement* pAdjustRefreshrate = pElement->FirstChildElement("adjustrefreshrate");
+    const auto* pAdjustRefreshrate = pElement->FirstChildElement("adjustrefreshrate");
     if (pAdjustRefreshrate)
     {
-      const TiXmlElement* pRefreshOverride = pAdjustRefreshrate->FirstChildElement("override");
+      const auto* pRefreshOverride = pAdjustRefreshrate->FirstChildElement("override");
       while (pRefreshOverride)
       {
         RefreshOverride refreshOverride = {};
@@ -801,7 +803,7 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
         pRefreshOverride = pRefreshOverride->NextSiblingElement("override");
       }
 
-      const TiXmlElement* pRefreshFallback = pAdjustRefreshrate->FirstChildElement("fallback");
+      const auto* pRefreshFallback = pAdjustRefreshrate->FirstChildElement("fallback");
       while (pRefreshFallback)
       {
         RefreshOverride fallback = {};
@@ -843,11 +845,11 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
     XMLUtils::GetBoolean(pElement, "preferstereostream", m_videoPreferStereoStream);
 
     // Store global display latency settings
-    const TiXmlElement* pVideoLatency = pElement->FirstChildElement("latency");
+    const auto* pVideoLatency = pElement->FirstChildElement("latency");
     if (pVideoLatency)
     {
       float refresh, refreshmin, refreshmax;
-      const TiXmlElement* pRefreshVideoLatency = pVideoLatency->FirstChildElement("refresh");
+      const auto* pRefreshVideoLatency = pVideoLatency->FirstChildElement("refresh");
 
       while (pRefreshVideoLatency)
       {
@@ -899,16 +901,16 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
     XMLUtils::GetBoolean(pElement, "useisodates", m_bMusicLibraryUseISODates);
     XMLUtils::GetBoolean(pElement, "artistnavigatestosongs", m_bMusicLibraryArtistNavigatesToSongs);
     // Music artist name separators
-    const TiXmlElement* separators = pElement->FirstChildElement("artistseparators");
+    const auto* separators = pElement->FirstChildElement("artistseparators");
     if (separators)
     {
       m_musicArtistSeparators.clear();
-      const TiXmlNode* separator = separators->FirstChild("separator");
+      const auto* separator = separators->FirstChildElement("separator");
       while (separator)
       {
-        if (separator->FirstChild())
-          m_musicArtistSeparators.push_back(separator->FirstChild()->ValueStr());
-        separator = separator->NextSibling("separator");
+        if (separator->FirstChild() && separator->FirstChild()->Value())
+          m_musicArtistSeparators.emplace_back(separator->FirstChild()->Value());
+        separator = separator->NextSiblingElement("separator");
       }
     }
   }
@@ -1064,12 +1066,12 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
   }
 
   // picture exclude regexps
-  const TiXmlElement* pPictureExcludes = pRootElement->FirstChildElement("pictureexcludes");
+  const auto* pPictureExcludes = pRootElement->FirstChildElement("pictureexcludes");
   if (pPictureExcludes)
     GetCustomRegexps(pPictureExcludes, m_pictureExcludeFromListingRegExps);
 
   // picture extensions
-  const TiXmlElement* pExts = pRootElement->FirstChildElement("pictureextensions");
+  const auto* pExts = pRootElement->FirstChildElement("pictureextensions");
   if (pExts)
     GetCustomExtensions(pExts, m_pictureExtensions);
 
@@ -1089,7 +1091,7 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
     GetCustomExtensions(pExts, m_discStubExtensions);
 
   m_vecTokens.clear();
-  CLangInfo::LoadTokens(pRootElement->FirstChild("sorttokens"), m_vecTokens);
+  CLangInfo::LoadTokens(pRootElement->FirstChildElement("sorttokens"), m_vecTokens);
 
   //! @todo Should cache path be given in terms of our predefined paths??
   //! Are we even going to have predefined paths??
@@ -1101,7 +1103,7 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
   g_LangCodeExpander.LoadUserCodes(pRootElement->FirstChildElement("languagecodes"));
 
   // trailer matching regexps
-  const TiXmlElement* pTrailerMatching = pRootElement->FirstChildElement("trailermatching");
+  const auto* pTrailerMatching = pRootElement->FirstChildElement("trailermatching");
   if (pTrailerMatching)
     GetCustomRegexps(pTrailerMatching, m_trailerMatchRegExps);
 
@@ -1111,7 +1113,7 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
                                         m_trailerMatchRegExps.end());
 
   // video stacking regexps
-  const TiXmlElement* videoStacking = pRootElement->FirstChildElement("moviestacking");
+  const auto* videoStacking = pRootElement->FirstChildElement("moviestacking");
   if (videoStacking)
   {
     GetCustomRegexps(videoStacking, m_videoStackStrings);
@@ -1120,7 +1122,7 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
   }
 
   // folder stacking regexps
-  const TiXmlElement* folderStacking = pRootElement->FirstChildElement("folderstacking");
+  const auto* folderStacking = pRootElement->FirstChildElement("folderstacking");
   if (folderStacking)
   {
     GetCustomRegexps(folderStacking, m_folderStackStrings);
@@ -1128,7 +1130,7 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
   }
 
   //tv stacking regexps
-  const TiXmlElement* pTVStacking = pRootElement->FirstChildElement("tvshowmatching");
+  const auto* pTVStacking = pRootElement->FirstChildElement("tvshowmatching");
   if (pTVStacking)
     GetCustomTVRegexps(pTVStacking, m_tvshowEnumRegExps);
 
@@ -1136,19 +1138,19 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
   XMLUtils::GetString(pRootElement, "tvmultipartmatching", m_tvshowMultiPartEnumRegExp);
 
   // path substitutions
-  const TiXmlElement* pPathSubstitution = pRootElement->FirstChildElement("pathsubstitution");
+  const auto* pPathSubstitution = pRootElement->FirstChildElement("pathsubstitution");
   if (pPathSubstitution)
   {
     m_pathSubstitutions.clear();
     CLog::Log(LOGDEBUG,"Configuring path substitutions");
-    const TiXmlNode* pSubstitute = pPathSubstitution->FirstChildElement("substitute");
+    const auto* pSubstitute = pPathSubstitution->FirstChildElement("substitute");
     while (pSubstitute)
     {
       std::string strFrom, strTo;
-      const TiXmlNode* pFrom = pSubstitute->FirstChild("from");
+      const auto* pFrom = pSubstitute->FirstChildElement("from");
       if (pFrom && !pFrom->NoChildren())
-        strFrom = CSpecialProtocol::TranslatePath(pFrom->FirstChild()->Value()).c_str();
-      const TiXmlNode* pTo = pSubstitute->FirstChild("to");
+        strFrom = CSpecialProtocol::TranslatePath(pFrom->FirstChild()->Value());
+      const auto* pTo = pSubstitute->FirstChildElement("to");
       if (pTo && !pTo->NoChildren())
         strTo = pTo->FirstChild()->Value();
 
@@ -1186,35 +1188,35 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
   XMLUtils::GetBoolean(pRootElement, "detectasudf", m_detectAsUdf);
 
   // music thumbs
-  const TiXmlElement* pThumbs = pRootElement->FirstChildElement("musicthumbs");
+  const auto* pThumbs = pRootElement->FirstChildElement("musicthumbs");
   if (pThumbs)
     GetCustomExtensions(pThumbs,m_musicThumbs);
 
   // show art for shoutcast v2 streams (set to false for devices with limited storage)
   XMLUtils::GetBoolean(pRootElement, "shoutcastart", m_bShoutcastArt);
   // music filename->tag filters
-  const TiXmlElement* filters = pRootElement->FirstChildElement("musicfilenamefilters");
+  const auto* filters = pRootElement->FirstChildElement("musicfilenamefilters");
   if (filters)
   {
-    const TiXmlNode* filter = filters->FirstChild("filter");
+    const auto* filter = filters->FirstChildElement("filter");
     while (filter)
     {
-      if (filter->FirstChild())
-        m_musicTagsFromFileFilters.push_back(filter->FirstChild()->ValueStr());
-      filter = filter->NextSibling("filter");
+      if (filter->FirstChild() && filter->FirstChild()->Value())
+        m_musicTagsFromFileFilters.emplace_back(filter->FirstChild()->Value());
+      filter = filter->NextSiblingElement("filter");
     }
   }
 
-  const TiXmlElement* pHostEntries = pRootElement->FirstChildElement("hosts");
+  const auto* pHostEntries = pRootElement->FirstChildElement("hosts");
   if (pHostEntries)
   {
-    const TiXmlElement* element = pHostEntries->FirstChildElement("entry");
+    const auto* element = pHostEntries->FirstChildElement("entry");
     while(element)
     {
-      if(!element->NoChildren())
+      if (!element->NoChildren())
       {
         std::string name  = XMLUtils::GetAttribute(element, "name");
-        std::string value = element->FirstChild()->ValueStr();
+        std::string value = element->FirstChild()->Value();
         if (!name.empty())
           CServiceBroker::GetDNSNameCache()->AddPermanent(name, value);
       }
@@ -1225,7 +1227,7 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
   XMLUtils::GetString(pRootElement, "cputempcommand", m_cpuTempCmd);
   XMLUtils::GetString(pRootElement, "gputempcommand", m_gpuTempCmd);
 
-  const TiXmlElement* pPowerManagement = pRootElement->FirstChildElement("powermanagement");
+  const auto* pPowerManagement = pRootElement->FirstChildElement("powermanagement");
   if (pPowerManagement)
   {
     XMLUtils::GetString(pPowerManagement, "powerdown", m_powerdownCommand);
@@ -1236,7 +1238,7 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
 
   XMLUtils::GetBoolean(pRootElement, "alwaysontop", m_alwaysOnTop);
 
-  const TiXmlElement* pPVR = pRootElement->FirstChildElement("pvr");
+  const auto* pPVR = pRootElement->FirstChildElement("pvr");
   if (pPVR)
   {
     XMLUtils::GetInt(pPVR, "timecorrection", m_iPVRTimeCorrection, 0, 1440);
@@ -1247,7 +1249,7 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
                       60000);
     XMLUtils::GetInt(pPVR, "timeshiftthreshold", m_iPVRTimeshiftThreshold, 0, 60);
     XMLUtils::GetBoolean(pPVR, "timeshiftsimpleosd", m_bPVRTimeshiftSimpleOSD);
-    const TiXmlElement* pSortDecription = pPVR->FirstChildElement("pvrrecordings");
+    const auto* pSortDecription = pPVR->FirstChildElement("pvrrecordings");
     if (pSortDecription)
     {
       static constexpr CSet validSortMethods{SortBy::LABEL,          SortBy::DATE,
@@ -1268,23 +1270,21 @@ void CAdvancedSettings::ParseSettingsXML(const TiXmlElement* pRootElement)
     }
   }
 
-  if (const TiXmlElement* dbElement = pRootElement->FirstChildElement("videodatabase");
+  if (const auto* dbElement = pRootElement->FirstChildElement("videodatabase");
       dbElement != nullptr)
   {
     CLog::Log(LOGWARNING, "VIDEO database configuration is experimental.");
     ParseDatabaseSettings(dbElement, m_databaseVideo);
   }
 
-  if (const TiXmlElement* dbElement = pRootElement->FirstChildElement("musicdatabase");
+  if (const auto* dbElement = pRootElement->FirstChildElement("musicdatabase");
       dbElement != nullptr)
     ParseDatabaseSettings(dbElement, m_databaseMusic);
 
-  if (const TiXmlElement* dbElement = pRootElement->FirstChildElement("tvdatabase");
-      dbElement != nullptr)
+  if (const auto* dbElement = pRootElement->FirstChildElement("tvdatabase"); dbElement != nullptr)
     ParseDatabaseSettings(dbElement, m_databaseTV);
 
-  if (const TiXmlElement* dbElement = pRootElement->FirstChildElement("epgdatabase");
-      dbElement != nullptr)
+  if (const auto* dbElement = pRootElement->FirstChildElement("epgdatabase"); dbElement != nullptr)
     ParseDatabaseSettings(dbElement, m_databaseEpg);
 
   XMLUtils::GetBoolean(pRootElement, "enablemultimediakeys", m_enableMultimediaKeys);
@@ -1345,10 +1345,10 @@ void CAdvancedSettings::Clear()
   m_userAgent.clear();
 }
 
-void CAdvancedSettings::GetCustomTVRegexps(const TiXmlElement* pRootElement,
+void CAdvancedSettings::GetCustomTVRegexps(const tinyxml2::XMLElement* pRootElement,
                                            SETTINGS_TVSHOWLIST& settings)
 {
-  const TiXmlElement* pElement = pRootElement;
+  const auto* pElement = pRootElement;
   while (pElement)
   {
     int iAction = 0; // overwrite
@@ -1368,7 +1368,7 @@ void CAdvancedSettings::GetCustomTVRegexps(const TiXmlElement* pRootElement,
     }
     if (iAction == 0)
       settings.clear();
-    const TiXmlNode* pRegExp = pElement->FirstChild("regexp");
+    const auto* pRegExp = pElement->FirstChildElement("regexp");
     int i = 0;
     while (pRegExp)
     {
@@ -1387,9 +1387,17 @@ void CAdvancedSettings::GetCustomTVRegexps(const TiXmlElement* pRootElement,
           std::string byTitleAttr = XMLUtils::GetAttribute(pRegExp->ToElement(), "bytitle");
           byTitle = (byTitleAttr == "true");
           std::string defaultSeason = XMLUtils::GetAttribute(pRegExp->ToElement(), "defaultseason");
-          if(!defaultSeason.empty())
+          if (!defaultSeason.empty())
           {
-            iDefaultSeason = atoi(defaultSeason.c_str());
+            try
+            {
+              iDefaultSeason = std::stoi(defaultSeason.c_str());
+            }
+            catch (...)
+            {
+              CLog::LogF(LOGERROR,
+                         "Failed to convert default season to integer, using default value 1");
+            }
           }
         }
         std::string regExp = pRegExp->FirstChild()->Value();
@@ -1404,17 +1412,17 @@ void CAdvancedSettings::GetCustomTVRegexps(const TiXmlElement* pRootElement,
           settings.emplace_back(bByDate, regExp, iDefaultSeason, byTitle);
         }
       }
-      pRegExp = pRegExp->NextSibling("regexp");
+      pRegExp = pRegExp->NextSiblingElement("regexp");
     }
 
     pElement = pElement->NextSiblingElement(pRootElement->Value());
   }
 }
 
-void CAdvancedSettings::GetCustomRegexps(const TiXmlElement* pRootElement,
+void CAdvancedSettings::GetCustomRegexps(const tinyxml2::XMLElement* pRootElement,
                                          std::vector<std::string>& settings)
 {
-  const TiXmlElement* pElement = pRootElement;
+  const auto* pElement = pRootElement;
   while (pElement)
   {
     int iAction = 0; // overwrite
@@ -1434,7 +1442,7 @@ void CAdvancedSettings::GetCustomRegexps(const TiXmlElement* pRootElement,
     }
     if (iAction == 0)
       settings.clear();
-    const TiXmlNode* pRegExp = pElement->FirstChild("regexp");
+    const auto* pRegExp = pElement->FirstChildElement("regexp");
     int i = 0;
     while (pRegExp)
     {
@@ -1449,14 +1457,14 @@ void CAdvancedSettings::GetCustomRegexps(const TiXmlElement* pRootElement,
         else
           settings.push_back(regExp);
       }
-      pRegExp = pRegExp->NextSibling("regexp");
+      pRegExp = pRegExp->NextSiblingElement("regexp");
     }
 
     pElement = pElement->NextSiblingElement(pRootElement->Value());
   }
 }
 
-void CAdvancedSettings::GetCustomExtensions(const TiXmlElement* pRootElement,
+void CAdvancedSettings::GetCustomExtensions(const tinyxml2::XMLElement* pRootElement,
                                             std::string& extensions)
 {
   std::string extraExtensions;
@@ -1519,17 +1527,17 @@ void CAdvancedSettings::SetDebugMode(bool debug)
   }
 }
 
-void CAdvancedSettings::SetExtraArtwork(const TiXmlElement* arttypes,
+void CAdvancedSettings::SetExtraArtwork(const tinyxml2::XMLElement* arttypes,
                                         std::vector<std::string>& artworkMap) const
 {
   if (!arttypes)
     return;
   artworkMap.clear();
-  const TiXmlNode* arttype = arttypes->FirstChild("arttype");
+  const auto* arttype = arttypes->FirstChildElement("arttype");
   while (arttype)
   {
     if (arttype->FirstChild())
-      artworkMap.push_back(arttype->FirstChild()->ValueStr());
-    arttype = arttype->NextSibling("arttype");
+      artworkMap.push_back(arttype->FirstChild()->Value());
+    arttype = arttype->NextSiblingElement("arttype");
   }
 }

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -420,8 +420,10 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     uint32_t m_nfsTimeout;
     int m_nfsRetries;
 
-  private:
+  protected:
     void Initialize();
+
+  private:
     void Clear();
     void SetExtraArtwork(const TiXmlElement* arttypes, std::vector<std::string>& artworkMap) const;
 

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -29,7 +29,12 @@ class CXBMCTinyXML;
 class CVariant;
 struct IntegerSettingOption;
 
-class TiXmlElement;
+namespace tinyxml2
+{
+class XMLDocument;
+class XMLElement;
+} // namespace tinyxml2
+
 namespace ADDON
 {
   class IAddon;
@@ -140,10 +145,12 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
      */
     void UnregisterSettingsLoadedCallback(int handle);
 
-    static void GetCustomTVRegexps(const TiXmlElement* pRootElement, SETTINGS_TVSHOWLIST& settings);
-    static void GetCustomRegexps(const TiXmlElement* pRootElement,
+    static void GetCustomTVRegexps(const tinyxml2::XMLElement* pRootElement,
+                                   SETTINGS_TVSHOWLIST& settings);
+    static void GetCustomRegexps(const tinyxml2::XMLElement* pRootElement,
                                  std::vector<std::string>& settings);
-    static void GetCustomExtensions(const TiXmlElement* pRootElement, std::string& extensions);
+    static void GetCustomExtensions(const tinyxml2::XMLElement* pRootElement,
+                                    std::string& extensions);
 
     std::string m_audioDefaultPlayer;
     float m_audioPlayCountMinimumPercent;
@@ -389,7 +396,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_enableMultimediaKeys;
     std::vector<std::string> m_settingsFiles;
     void ParseSettingsFile(const std::string &file);
-    void ParseSettingsXML(const TiXmlElement* pRootElement);
+    void ParseSettingsXML(const tinyxml2::XMLElement* pRootElement);
 
     float GetLatencyTweak(float refreshrate, bool isHDREnabled) const;
     bool m_initialized{false};
@@ -422,12 +429,13 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_nfsRetries;
 
   protected:
-    void Redact(CXBMCTinyXML& input) const;
+    void Redact(tinyxml2::XMLDocument& input) const;
     void Initialize();
 
   private:
     void Clear();
-    void SetExtraArtwork(const TiXmlElement* arttypes, std::vector<std::string>& artworkMap) const;
+    void SetExtraArtwork(const tinyxml2::XMLElement* arttypes,
+                         std::vector<std::string>& artworkMap) const;
 
     std::vector<std::string> m_videoStackStrings;
     std::vector<std::string> m_folderStackStrings;

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -388,6 +388,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_enableMultimediaKeys;
     std::vector<std::string> m_settingsFiles;
     void ParseSettingsFile(const std::string &file);
+    void ParseSettingsXML(const TiXmlElement* pRootElement);
 
     float GetLatencyTweak(float refreshrate, bool isHDREnabled) const;
     bool m_initialized{false};

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -40,7 +40,6 @@ class DatabaseSettings
 public:
   static constexpr unsigned int DEFAULT_CONNECT_TIMEOUT = 5; // secs
 
-  DatabaseSettings() { Reset(); }
   void Reset()
   {
     type.clear();
@@ -56,20 +55,21 @@ public:
     ciphers.clear();
     connecttimeout = DEFAULT_CONNECT_TIMEOUT;
     compression = false;
-  };
-  std::string type;
-  std::string host;
-  std::string port;
-  std::string user;
-  std::string pass;
-  std::string name;
-  std::string key;
-  std::string cert;
-  std::string ca;
-  std::string capath;
-  std::string ciphers;
+  }
+
+  std::string type{};
+  std::string host{};
+  std::string port{};
+  std::string user{};
+  std::string pass{};
+  std::string name{};
+  std::string key{};
+  std::string cert{};
+  std::string ca{};
+  std::string capath{};
+  std::string ciphers{};
   unsigned int connecttimeout{DEFAULT_CONNECT_TIMEOUT};
-  bool compression;
+  bool compression{false};
 };
 
 struct TVShowRegexp

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -25,6 +25,7 @@
 
 class CProfileManager;
 class CSettingsManager;
+class CXBMCTinyXML;
 class CVariant;
 struct IntegerSettingOption;
 
@@ -421,6 +422,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_nfsRetries;
 
   protected:
+    void Redact(CXBMCTinyXML& input) const;
     void Initialize();
 
   private:

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -142,6 +142,18 @@ bool CSettings::Load(const TiXmlElement* root)
   return Load(root, updated);
 }
 
+bool CSettings::LoadHidden(const std::string& file)
+{
+  CXBMCTinyXML xmlDoc;
+  if (!XFILE::CFile::Exists(file) || !xmlDoc.LoadFile(file))
+  {
+    CLog::Log(LOGERROR, "CSettings: unable to load hidden settings from {}", file);
+    return false;
+  }
+
+  return this->LoadHidden(xmlDoc.RootElement());
+}
+
 bool CSettings::Save()
 {
   const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -553,14 +553,22 @@ public:
   \return True if the setting values were successfully loaded, false otherwise
   */
   bool Load(const TiXmlElement* root);
+
   /*!
    \brief Loads setting values from the given XML element.
 
    \param root XML element containing setting values
-   \param hide Whether to hide the loaded settings or not
    \return True if the setting values were successfully loaded, false otherwise
    */
   bool LoadHidden(const TiXmlElement *root) { return CSettingsBase::LoadHiddenValuesFromXml(root); }
+
+  /*!
+   \brief Loads setting values from the givenn (XML) file.
+
+   \param file File name of XML file containing setting values
+   \return True if the setting values were successfully loaded, false otherwise
+   */
+  bool LoadHidden(const std::string& file);
 
   /*!
    \brief Saves the setting values to the given (XML) file.

--- a/xbmc/settings/test/CMakeLists.txt
+++ b/xbmc/settings/test/CMakeLists.txt
@@ -1,3 +1,4 @@
-set(SOURCES TestMediaSourceSettings.cpp)
+set(SOURCES TestAdvancedSettings.cpp
+            TestMediaSourceSettings.cpp)
 
 core_add_test_library(settings_test)

--- a/xbmc/settings/test/TestAdvancedSettings.cpp
+++ b/xbmc/settings/test/TestAdvancedSettings.cpp
@@ -10,7 +10,7 @@
 #include "network/DNSNameCache.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/StringUtils.h"
-#include "utils/XBMCTinyXML.h"
+#include "utils/XBMCTinyXML2.h"
 
 #include <array>
 #include <string>
@@ -25,7 +25,7 @@ class CAdvancedSettingsInit : public CAdvancedSettings
 public:
   CAdvancedSettingsInit() { Initialize(); }
 
-  void DoRedact(CXBMCTinyXML& doc) { Redact(doc); }
+  void DoRedact(tinyxml2::XMLDocument& doc) { Redact(doc); }
 };
 
 struct RegExpT
@@ -87,7 +87,7 @@ std::string GenREXML(std::string_view suite, std::string_view tag, RegExpT::Acti
 template<RegExpT::Action action>
 void RunRETest(const RegExpT& param)
 {
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(GenREXML(param.suite, param.tag, action));
   CAdvancedSettingsInit settings;
   const auto orig_size = std::invoke(param.member, settings).size();
@@ -197,7 +197,7 @@ TEST(TestAdvancedSettings, Audio)
            </audio>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -229,7 +229,7 @@ TEST(TestAdvancedSettings, X11)
            </x11>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -278,7 +278,7 @@ TEST(TestAdvancedSettings, Video)
            </video>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -342,7 +342,7 @@ TEST(TestAdvancedSettings, MusicLibrary)
            </musiclibrary>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -381,7 +381,7 @@ TEST(TestAdvancedSettings, VideoLibrary)
            </videolibrary>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -408,7 +408,7 @@ TEST(TestAdvancedSettings, VideoScanner)
            </videoscanner>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -426,7 +426,7 @@ TEST(TestAdvancedSettings, Slideshow)
            </slideshow>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -452,7 +452,7 @@ TEST(TestAdvancedSettings, Network)
            </network>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -477,7 +477,7 @@ TEST(TestAdvancedSettings, JsonRPC)
            </jsonrpc>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -496,7 +496,7 @@ TEST(TestAdvancedSettings, Samba)
            </samba>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -514,7 +514,7 @@ TEST(TestAdvancedSettings, HTTPDirectory)
            </httpdirectory>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -530,7 +530,7 @@ TEST(TestAdvancedSettings, FTP)
            </ftp>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -579,7 +579,7 @@ TEST(TestAdvancedSettings, TopLevel)
            <opengldebugging>true</opengldebugging>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -642,7 +642,7 @@ TEST(TestAdvancedSettings, EPG)
            </epg>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -671,7 +671,7 @@ TEST(TestAdvancedSettings, EDL)
            </edl>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -696,7 +696,7 @@ TEST(TestAdvancedSettings, SortTokens)
            </sorttokens>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   const auto orig_size = settings.m_vecTokens.size();
@@ -725,7 +725,7 @@ TEST(TestAdvancedSettings, PathSubstitution)
            </pathsubstitution>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -747,7 +747,7 @@ TEST(TestAdvancedSettings, MusicFileNameFilters)
            </musicfilenamefilters>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -771,7 +771,7 @@ TEST(TestAdvancedSettings, Hosts)
 
   auto cache = std::make_shared<CDNSNameCache>();
   CServiceBroker::RegisterDNSNameCache(cache);
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -795,7 +795,7 @@ TEST(TestAdvancedSettings, PowerManagement)
            </powermanagement>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -824,7 +824,7 @@ TEST(TestAdvancedSettings, PVR)
            </pvr>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -855,7 +855,7 @@ TEST(TestAdvancedSettings, GUI)
            </gui>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -906,7 +906,7 @@ TEST(TestAdvancedSettings, VideoAdjustRefreshRate)
            </video>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -961,7 +961,7 @@ TEST(TestAdvancedSettings, VideoLatency)
            </video>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CAdvancedSettingsInit settings;
   settings.ParseSettingsXML(doc.RootElement());
@@ -997,7 +997,7 @@ TEST_P(ExtensionTest, AddAndRemove)
   EXPECT_TRUE(std::ranges::all_of(remove_array, is_in_orig));
   EXPECT_TRUE(std::ranges::none_of(add_array, is_in_orig));
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(GenExtXML(GetParam()));
   settings.ParseSettingsXML(doc.RootElement());
 
@@ -1031,7 +1031,7 @@ TEST_P(RegExpTest, Prepend)
 
 TEST_P(DatabaseTest, Parse)
 {
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   const DatabaseSettings ref{
       .type = "1",
       .host = "2",
@@ -1068,7 +1068,7 @@ TEST_P(DatabaseTest, Parse)
 
 TEST_P(DatabaseTest, Redact)
 {
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   const DatabaseSettings ref{
       .type = "1",
       .host = "2",

--- a/xbmc/settings/test/TestAdvancedSettings.cpp
+++ b/xbmc/settings/test/TestAdvancedSettings.cpp
@@ -1,0 +1,1142 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ServiceBroker.h"
+#include "network/DNSNameCache.h"
+#include "settings/AdvancedSettings.h"
+#include "utils/StringUtils.h"
+#include "utils/XBMCTinyXML.h"
+
+#include <array>
+#include <string>
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+class CAdvancedSettingsInit : public CAdvancedSettings
+{
+public:
+  CAdvancedSettingsInit() { Initialize(); }
+
+  void DoRedact(CXBMCTinyXML& doc) { Redact(doc); }
+};
+
+struct RegExpT
+{
+  enum class Action
+  {
+    APPEND,
+    APPEND_OLD,
+    OVERWRITE,
+    PREPEND,
+  };
+  std::string_view suite;
+  std::string_view tag;
+  std::vector<std::string> CAdvancedSettings::*member;
+};
+
+class RegExpTest : public testing::WithParamInterface<RegExpT>, public testing::Test
+{
+};
+
+std::string GenREXML(std::string_view suite, std::string_view tag, RegExpT::Action action)
+{
+  auto getAction = [action]() -> std::string_view
+  {
+    switch (action)
+    {
+      case RegExpT::Action::APPEND:
+        return R"(action="append")";
+      case RegExpT::Action::APPEND_OLD:
+        return R"(append="yes")";
+      case RegExpT::Action::OVERWRITE:
+        return "";
+      case RegExpT::Action::PREPEND:
+        return R"(action="prepend")";
+    }
+    std::exit(1);
+  };
+
+  if (suite.empty())
+    return StringUtils::Format(R"(<advancedsettings>
+                                  <{0} {1}>
+                                    <regexp>1</regexp>
+                                    <regexp>2</regexp>
+                                  </{0}>
+                                </advancedsettings>)",
+                               tag, getAction());
+  else
+    return StringUtils::Format(R"(<advancedsettings>
+                                  <{0}>
+                                    <{1} {2}>
+                                      <regexp>1</regexp>
+                                      <regexp>2</regexp>
+                                    </{1}>
+                                  </{0}>
+                                </advancedsettings>)",
+                               suite, tag, getAction());
+}
+
+template<RegExpT::Action action>
+void RunRETest(const RegExpT& param)
+{
+  CXBMCTinyXML doc;
+  doc.Parse(GenREXML(param.suite, param.tag, action));
+  CAdvancedSettingsInit settings;
+  const auto orig_size = std::invoke(param.member, settings).size();
+  settings.ParseSettingsXML(doc.RootElement());
+  const auto& array = std::invoke(param.member, settings);
+  if constexpr (action == RegExpT::Action::OVERWRITE)
+  {
+    EXPECT_EQ(array.size(), 2);
+    EXPECT_EQ(array[0], "1");
+    EXPECT_EQ(array[1], "2");
+  }
+  else if constexpr (action == RegExpT::Action::APPEND || action == RegExpT::Action::APPEND_OLD)
+  {
+    EXPECT_EQ(array.size(), orig_size + 2);
+    EXPECT_EQ(array[orig_size], "1");
+    EXPECT_EQ(array[orig_size + 1], "2");
+  }
+  else if constexpr (action == RegExpT::Action::PREPEND)
+  {
+    EXPECT_EQ(array.size(), orig_size + 2);
+    EXPECT_EQ(array[0], "1");
+    EXPECT_EQ(array[1], "2");
+  }
+}
+
+struct ExtT
+{
+  std::string_view tag;
+  std::string_view add;
+  std::string_view remove;
+  std::string CAdvancedSettings::*member;
+};
+
+class ExtensionTest : public testing::WithParamInterface<ExtT>, public testing::Test
+{
+};
+
+std::string GenExtXML(const ExtT& param)
+{
+  return StringUtils::Format(R"(<advancedsettings>
+                                <{0}>
+                                  <add>{1}</add>
+                                  <remove>{2}</remove>
+                                </{0}>
+                              </advancedsettings>)",
+                             param.tag, param.add, param.remove);
+}
+
+struct DbTestT
+{
+  std::string_view tag;
+  DatabaseSettings CAdvancedSettings::*member;
+};
+
+class DatabaseTest : public testing::WithParamInterface<DbTestT>, public testing::Test
+{
+};
+
+std::string GenDbXML(std::string_view tag, const DatabaseSettings& param)
+{
+  return StringUtils::Format(R"(<advancedsettings>
+                                <{0}>
+                                 <type>{1}</type>
+                                 <host>{2}</host>
+                                 <port>{3}</port>
+                                 <user>{4}</user>
+                                 <pass>{5}</pass>
+                                 <name>{6}</name>
+                                 <key>{7}</key>
+                                 <cert>{8}</cert>
+                                 <ca>{9}</ca>
+                                 <capath>{10}</capath>
+                                 <ciphers>{11}</ciphers>
+                                 <connecttimeout>{12}</connecttimeout>
+                                 <compression>{13}</compression>
+                                </{0}>
+                              </advancedsettings>)",
+                             tag, param.type, param.host, param.port, param.user, param.pass,
+                             param.name, param.key, param.cert, param.ca, param.capath,
+                             param.ciphers, param.connecttimeout, param.compression);
+}
+
+} // namespace
+
+TEST(TestAdvancedSettings, Audio)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <audio>
+             <defaultplayer>1</defaultplayer>
+             <playcountminimumpercent>101</playcountminimumpercent>
+             <usetimeseeking>false</usetimeseeking>
+             <timeseekforward>20</timeseekforward>
+             <timeseekforwardbig>200</timeseekforwardbig>
+             <timeseekbackward>-30</timeseekbackward>
+             <timeseekbackwardbig>-300</timeseekbackwardbig>
+             <percentseekforward>5</percentseekforward>
+             <percentseekforwardbig>50</percentseekforwardbig>
+             <percentseekbackward>-3</percentseekbackward>
+             <percentseekbackwardbig>-7</percentseekbackwardbig>
+             <applydrc>7.3</applydrc>
+             <limiterhold>2.5</limiterhold>
+             <limiterrelease>8.5</limiterrelease>
+             <maxpassthroughoffsyncduration>40</maxpassthroughoffsyncduration>
+             <allowmultichannelfloat>true</allowmultichannelfloat>
+             <superviseaudiodelay>true</superviseaudiodelay>
+           </audio>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_EQ(settings.m_audioDefaultPlayer, "1");
+  EXPECT_FLOAT_EQ(settings.m_audioPlayCountMinimumPercent, 101.f);
+  EXPECT_FALSE(settings.m_musicUseTimeSeeking);
+  EXPECT_EQ(settings.m_musicTimeSeekForward, 20);
+  EXPECT_EQ(settings.m_musicTimeSeekForwardBig, 200);
+  EXPECT_EQ(settings.m_musicTimeSeekBackward, -30);
+  EXPECT_EQ(settings.m_musicTimeSeekBackwardBig, -300);
+  EXPECT_EQ(settings.m_musicPercentSeekForward, 5);
+  EXPECT_EQ(settings.m_musicPercentSeekForwardBig, 50);
+  EXPECT_EQ(settings.m_musicPercentSeekBackward, -3);
+  EXPECT_EQ(settings.m_musicPercentSeekBackwardBig, -7);
+  EXPECT_FLOAT_EQ(settings.m_audioApplyDrc, 7.3f);
+  EXPECT_FLOAT_EQ(settings.m_limiterHold, 2.5f);
+  EXPECT_FLOAT_EQ(settings.m_limiterRelease, 8.5f);
+  EXPECT_EQ(settings.m_maxPassthroughOffSyncDuration, 40);
+  EXPECT_TRUE(settings.m_AllowMultiChannelFloat);
+  EXPECT_TRUE(settings.m_superviseAudioDelay);
+}
+
+TEST(TestAdvancedSettings, X11)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <x11>
+             <omlsync>false</omlsync>
+           </x11>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_FALSE(settings.m_omlSync);
+}
+
+TEST(TestAdvancedSettings, Video)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <video>
+             <stereoscopicregex3d>1</stereoscopicregex3d>
+             <stereoscopicregexsbs>2</stereoscopicregexsbs>
+             <stereoscopicregextab>3</stereoscopicregextab>
+             <subsdelayrange>20</subsdelayrange>
+             <subsdelaystep>0.5</subsdelaystep>
+             <audiodelayrange>30</audiodelayrange>
+             <audiodelaystep>0.4</audiodelaystep>
+             <defaultplayer>4</defaultplayer>
+             <fullscreenonmoviestart>false</fullscreenonmoviestart>
+             <playcountminimumpercent>101</playcountminimumpercent>
+             <ignoresecondsatstart>123</ignoresecondsatstart>
+             <usetimeseeking>false</usetimeseeking>
+             <timeseekforward>10</timeseekforward>
+             <timeseekforwardbig>100</timeseekforwardbig>
+             <timeseekbackward>-20</timeseekbackward>
+             <timeseekbackwardbig>-200</timeseekbackwardbig>
+             <percentseekforward>7</percentseekforward>
+             <percentseekforwardbig>70</percentseekforwardbig>
+             <percentseekbackward>-4</percentseekbackward>
+             <percentseekbackwardbig>-6</percentseekbackwardbig>
+             <filenameidentifier>5</filenameidentifier>
+             <cleandatetime>6</cleandatetime>
+             <ppffmpegpostprocessing>7</ppffmpegpostprocessing>
+             <vdpauscaling>1</vdpauscaling>
+             <nonlinearstretchratio>0.2</nonlinearstretchratio>
+             <autoscalemaxfps>50</autoscalemaxfps>
+             <useocclusionquery>1</useocclusionquery>
+             <vdpauInvTelecine>true</vdpauInvTelecine>
+             <vdpauHDdeintSkipChroma>true</vdpauHDdeintSkipChroma>
+             <bypasscodecprofile>true</bypasscodecprofile>
+             <checkdxvacompatibility>true</checkdxvacompatibility>
+             <fpsdetect>2</fpsdetect>
+             <maxtempo>2.0</maxtempo>
+             <preferstereostream>true</preferstereostream>
+           </video>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_EQ(settings.m_stereoscopicregex_3d, "1");
+  EXPECT_EQ(settings.m_stereoscopicregex_sbs, "2");
+  EXPECT_EQ(settings.m_stereoscopicregex_tab, "3");
+  EXPECT_EQ(settings.m_videoSubsDelayRange, 20.f);
+  EXPECT_EQ(settings.m_videoSubsDelayStep, 0.5f);
+  EXPECT_EQ(settings.m_videoAudioDelayRange, 30.f);
+  EXPECT_EQ(settings.m_videoAudioDelayStep, 0.4f);
+  EXPECT_EQ(settings.m_videoDefaultPlayer, "4");
+  EXPECT_FALSE(settings.m_fullScreenOnMovieStart);
+  EXPECT_EQ(settings.m_videoPlayCountMinimumPercent, 101.f);
+  EXPECT_EQ(settings.m_videoIgnoreSecondsAtStart, 123);
+  EXPECT_FALSE(settings.m_videoUseTimeSeeking);
+  EXPECT_EQ(settings.m_videoTimeSeekForward, 10);
+  EXPECT_EQ(settings.m_videoTimeSeekForwardBig, 100);
+  EXPECT_EQ(settings.m_videoTimeSeekBackward, -20);
+  EXPECT_EQ(settings.m_videoTimeSeekBackwardBig, -200);
+  EXPECT_EQ(settings.m_videoPercentSeekForward, 7);
+  EXPECT_EQ(settings.m_videoPercentSeekForwardBig, 70);
+  EXPECT_EQ(settings.m_videoPercentSeekBackward, -4);
+  EXPECT_EQ(settings.m_videoPercentSeekBackwardBig, -6);
+  EXPECT_EQ(settings.m_videoFilenameIdentifierRegExp, "5");
+  EXPECT_EQ(settings.m_videoCleanDateTimeRegExp, "6");
+  EXPECT_EQ(settings.m_videoPPFFmpegPostProc, "7");
+  EXPECT_EQ(settings.m_videoVDPAUScaling, 1);
+  EXPECT_EQ(settings.m_videoNonLinStretchRatio, 0.2f);
+  EXPECT_EQ(settings.m_videoAutoScaleMaxFps, 50.f);
+  EXPECT_EQ(settings.m_videoCaptureUseOcclusionQuery, 1);
+  EXPECT_TRUE(settings.m_videoVDPAUtelecine);
+  EXPECT_TRUE(settings.m_videoVDPAUdeintSkipChromaHD);
+  EXPECT_TRUE(settings.m_videoBypassCodecProfile);
+  EXPECT_TRUE(settings.m_DXVACheckCompatibility);
+  EXPECT_EQ(settings.m_videoFpsDetect, 2);
+  EXPECT_EQ(settings.m_maxTempo, 2.f);
+  EXPECT_TRUE(settings.m_videoPreferStereoStream);
+
+  // TODO: Refresh stuff
+}
+
+TEST(TestAdvancedSettings, MusicLibrary)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <musiclibrary>
+             <recentlyaddeditems>1</recentlyaddeditems>
+             <prioritiseapetags>true</prioritiseapetags>
+             <allitemsonbottom>true</allitemsonbottom>
+             <cleanonupdate>true</cleanonupdate>
+             <artistsortonupdate>true</artistsortonupdate>
+             <albumformat>1</albumformat>
+             <itemseparator>2</itemseparator>
+             <dateadded>0</dateadded>
+             <useisodates>true</useisodates>
+             <artistnavigatestosongs>true</artistnavigatestosongs>
+             <artistseparators>
+              <separator>3</separator>
+              <separator>4</separator>
+             </artistseparators>
+           </musiclibrary>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_EQ(settings.m_iMusicLibraryRecentlyAddedItems, 1);
+  EXPECT_TRUE(settings.m_prioritiseAPEv2tags);
+  EXPECT_TRUE(settings.m_bMusicLibraryAllItemsOnBottom);
+  EXPECT_TRUE(settings.m_bMusicLibraryCleanOnUpdate);
+  EXPECT_TRUE(settings.m_bMusicLibraryArtistSortOnUpdate);
+  EXPECT_EQ(settings.m_strMusicLibraryAlbumFormat, "1");
+  EXPECT_EQ(settings.m_musicItemSeparator, "2");
+  EXPECT_EQ(settings.m_iMusicLibraryDateAdded, 0);
+  EXPECT_TRUE(settings.m_bMusicLibraryUseISODates);
+  EXPECT_TRUE(settings.m_bMusicLibraryArtistNavigatesToSongs);
+  EXPECT_EQ(settings.m_musicArtistSeparators.size(), 2U);
+  EXPECT_EQ(settings.m_musicArtistSeparators[0], "3");
+  EXPECT_EQ(settings.m_musicArtistSeparators[1], "4");
+}
+
+TEST(TestAdvancedSettings, VideoLibrary)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <videolibrary>
+             <allitemsonbottom>true</allitemsonbottom>
+             <recentlyaddeditems>2</recentlyaddeditems>
+             <cleanonupdate>true</cleanonupdate>
+             <usefasthash>false</usefasthash>
+             <itemseparator>1</itemseparator>
+             <importwatchedstate>false</importwatchedstate>
+             <importresumepoint>false</importresumepoint>
+             <dateadded>2</dateadded>
+             <casesensitivelocalartmatch>false</casesensitivelocalartmatch>
+             <minimumepisodeplaylistduration>3</minimumepisodeplaylistduration>
+             <disableepisoderanges>true</disableepisoderanges>
+             <noremoteartwithlocalscraper>true</noremoteartwithlocalscraper>
+           </videolibrary>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_TRUE(settings.m_bVideoLibraryAllItemsOnBottom);
+  EXPECT_EQ(settings.m_iVideoLibraryRecentlyAddedItems, 2);
+  EXPECT_TRUE(settings.m_bVideoLibraryCleanOnUpdate);
+  EXPECT_FALSE(settings.m_bVideoLibraryUseFastHash);
+  EXPECT_EQ(settings.m_videoItemSeparator, "1");
+  EXPECT_FALSE(settings.m_bVideoLibraryImportWatchedState);
+  EXPECT_FALSE(settings.m_bVideoLibraryImportResumePoint);
+  EXPECT_EQ(settings.m_iVideoLibraryDateAdded, 2);
+  EXPECT_FALSE(settings.m_caseSensitiveLocalArtMatch);
+  EXPECT_EQ(settings.m_minimumEpisodePlaylistDuration, 3);
+  EXPECT_TRUE(settings.m_disableEpisodeRanges);
+  EXPECT_TRUE(settings.m_bNoRemoteArtWithLocalScraper);
+}
+
+TEST(TestAdvancedSettings, VideoScanner)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <videoscanner>
+             <ignoreerrors>true</ignoreerrors>
+           </videoscanner>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_TRUE(settings.m_bVideoScannerIgnoreErrors);
+}
+
+TEST(TestAdvancedSettings, Slideshow)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <slideshow>
+             <panamount>1.0</panamount>
+             <zoomamount>2.0</zoomamount>
+             <blackbarcompensation>3.0</blackbarcompensation>
+           </slideshow>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_EQ(settings.m_slideshowPanAmount, 1.0);
+  EXPECT_EQ(settings.m_slideshowZoomAmount, 2.0);
+  EXPECT_EQ(settings.m_slideshowBlackBarCompensation, 3.0);
+}
+
+TEST(TestAdvancedSettings, Network)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <network>
+             <curlclienttimeout>1</curlclienttimeout>
+             <curllowspeedtime>2</curllowspeedtime>
+             <curlretries>3</curlretries>
+             <curlkeepaliveinterval>4</curlkeepaliveinterval>
+             <disableipv6>true</disableipv6>
+             <disablehttp2>true</disablehttp2>
+             <catrustfile>1</catrustfile>
+             <nfstimeout>5</nfstimeout>
+             <nfsretries>6</nfsretries>
+           </network>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_EQ(settings.m_curlconnecttimeout, 1);
+  EXPECT_EQ(settings.m_curllowspeedtime, 2);
+  EXPECT_EQ(settings.m_curlretries, 3);
+  EXPECT_EQ(settings.m_curlKeepAliveInterval, 4);
+  EXPECT_TRUE(settings.m_curlDisableIPV6);
+  EXPECT_TRUE(settings.m_curlDisableHTTP2);
+  EXPECT_EQ(settings.m_caTrustFile, "1");
+  EXPECT_EQ(settings.m_nfsTimeout, 5);
+  EXPECT_EQ(settings.m_nfsRetries, 6);
+}
+
+TEST(TestAdvancedSettings, JsonRPC)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <jsonrpc>
+             <compactoutput>false</compactoutput>
+             <tcpport>1</tcpport>
+           </jsonrpc>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_FALSE(settings.m_jsonOutputCompact);
+  EXPECT_EQ(settings.m_jsonTcpPort, 1);
+}
+
+TEST(TestAdvancedSettings, Samba)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <samba>
+             <doscodepage>1</doscodepage>
+             <clienttimeout>5</clienttimeout>
+             <statfiles>false</statfiles>
+           </samba>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_EQ(settings.m_sambadoscodepage, "1");
+  EXPECT_EQ(settings.m_sambaclienttimeout, 5);
+  EXPECT_FALSE(settings.m_sambastatfiles);
+}
+
+TEST(TestAdvancedSettings, HTTPDirectory)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <httpdirectory>
+             <statfilesize>true</statfilesize>
+           </httpdirectory>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_TRUE(settings.m_bHTTPDirectoryStatFilesize);
+}
+
+TEST(TestAdvancedSettings, FTP)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <ftp>
+             <remotethumbs>true</remotethumbs>
+           </ftp>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_TRUE(settings.m_bFTPThumbs);
+}
+
+TEST(TestAdvancedSettings, TopLevel)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <cddbaddress>1</cddbaddress>
+           <addsourceontop>true</addsourceontop>
+           <airtunesport>2</airtunesport>
+           <airplayport>3</airplayport>
+           <handlemounting>false</handlemounting>
+           <automountopticalmedia>false</automountopticalmedia>
+           <minimizetotray>true</minimizetotray>
+           <fullscreen>true</fullscreen>
+           <splash>false</splash>
+           <showexitbutton>false</showexitbutton>
+           <canwindowed>false</canwindowed>
+           <songinfoduration>4</songinfoduration>
+           <playlistretries>5</playlistretries>
+           <playlisttimeout>6</playlisttimeout>
+           <glrectanglehack>true</glrectanglehack>
+           <skiploopfilter>7</skiploopfilter>
+           <virtualshares>false</virtualshares>
+           <packagefoldersize>8</packagefoldersize>
+           <cachepath>https://some.where/foo</cachepath>
+           <tvmultipartmatching>9</tvmultipartmatching>
+           <remotedelay>10</remotedelay>
+           <scanirserver>false</scanirserver>
+           <fanartres>11</fanartres>
+           <imageres>12</imageres>
+           <imagescalingalgorithm>bicubic</imagescalingalgorithm>
+           <imagequalityjpeg>13</imagequalityjpeg>
+           <playlistasfolders>false</playlistasfolders>
+           <uselocalecollation>false</uselocalecollation>
+           <detectasudf>true</detectasudf>
+           <shoutcastart>false</shoutcastart>
+           <cputempcommand>14</cputempcommand>
+           <gputempcommand>15</gputempcommand>
+           <alwaysontop>true</alwaysontop>
+           <enablemultimediakeys>true</enablemultimediakeys>
+           <seeksteps>16,17</seeksteps>
+           <opengldebugging>true</opengldebugging>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_EQ(settings.m_cddbAddress, "1");
+  EXPECT_TRUE(settings.m_addSourceOnTop);
+  EXPECT_EQ(settings.m_airTunesPort, 2);
+  EXPECT_EQ(settings.m_airPlayPort, 3);
+  EXPECT_FALSE(settings.m_handleMounting);
+  EXPECT_FALSE(settings.m_autoMountOpticalMedia);
+#if defined(TARGET_WINDOWS_DESKTOP)
+  EXPECT_TRUE(settings.m_minimizeToTray);
+#endif
+#if defined(TARGET_DARWIN_OSX) || defined(TARGET_WINDOWS)
+  EXPECT_TRUE(settings.m_startFullScreen);
+#endif
+  EXPECT_FALSE(settings.m_splashImage);
+  EXPECT_FALSE(settings.m_showExitButton);
+  EXPECT_FALSE(settings.m_canWindowed);
+  EXPECT_EQ(settings.m_songInfoDuration, 4);
+  EXPECT_EQ(settings.m_playlistRetries, 5);
+  EXPECT_EQ(settings.m_playlistTimeout, 6);
+  EXPECT_TRUE(settings.m_GLRectangleHack);
+  EXPECT_EQ(settings.m_iSkipLoopFilter, 7);
+  EXPECT_FALSE(settings.m_bVirtualShares);
+  EXPECT_EQ(settings.m_addonPackageFolderSize, 8);
+  EXPECT_EQ(settings.m_cachePath, "https://some.where/foo/");
+  EXPECT_EQ(settings.m_tvshowMultiPartEnumRegExp, "9");
+  EXPECT_EQ(settings.m_remoteDelay, 10);
+  EXPECT_FALSE(settings.m_bScanIRServer);
+  EXPECT_EQ(settings.m_fanartRes, 11);
+  EXPECT_EQ(settings.m_imageRes, 12);
+  EXPECT_EQ(settings.m_imageScalingAlgorithm, CPictureScalingAlgorithm::Bicubic);
+  EXPECT_EQ(settings.m_imageQualityJpeg, 13);
+  EXPECT_FALSE(settings.m_playlistAsFolders);
+  EXPECT_FALSE(settings.m_useLocaleCollation);
+  EXPECT_TRUE(settings.m_detectAsUdf);
+  EXPECT_FALSE(settings.m_bShoutcastArt);
+  EXPECT_EQ(settings.m_cpuTempCmd, "14");
+  EXPECT_EQ(settings.m_gpuTempCmd, "15");
+  EXPECT_TRUE(settings.m_alwaysOnTop);
+  EXPECT_TRUE(settings.m_enableMultimediaKeys);
+  EXPECT_EQ(settings.m_seekSteps.size(), 2);
+  EXPECT_EQ(settings.m_seekSteps[0], 16);
+  EXPECT_EQ(settings.m_seekSteps[1], 17);
+  EXPECT_TRUE(settings.m_openGlDebugging);
+}
+
+TEST(TestAdvancedSettings, EPG)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <epg>
+             <updatecheckinterval>1</updatecheckinterval>
+             <cleanupinterval>2</cleanupinterval>
+             <activetagcheckinterval>3</activetagcheckinterval>
+             <retryinterruptedupdateinterval>4</retryinterruptedupdateinterval>
+             <updateemptytagsinterval>5</updateemptytagsinterval>
+             <displayupdatepopup>false</displayupdatepopup>
+             <displayincrementalupdatepopup>true</displayincrementalupdatepopup>
+           </epg>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_EQ(settings.m_iEpgUpdateCheckInterval, 1);
+  EXPECT_EQ(settings.m_iEpgCleanupInterval, 2);
+  EXPECT_EQ(settings.m_iEpgActiveTagCheckInterval, 3);
+  EXPECT_EQ(settings.m_iEpgRetryInterruptedUpdateInterval, 4);
+  EXPECT_EQ(settings.m_iEpgUpdateEmptyTagsInterval, 5);
+  EXPECT_FALSE(settings.m_bEpgDisplayUpdatePopup);
+  EXPECT_TRUE(settings.m_bEpgDisplayIncrementalUpdatePopup);
+}
+
+TEST(TestAdvancedSettings, EDL)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <edl>
+             <mergeshortcommbreaks>true</mergeshortcommbreaks>
+             <displaycommbreaknotifications>false</displaycommbreaknotifications>
+             <maxcommbreaklength>1</maxcommbreaklength>
+             <mincommbreaklength>2</mincommbreaklength>
+             <maxcommbreakgap>3</maxcommbreakgap>
+             <maxstartgap>4</maxstartgap>
+             <commbreakautowait>5</commbreakautowait>
+             <commbreakautowind>6</commbreakautowind>
+           </edl>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_TRUE(settings.m_bEdlMergeShortCommBreaks);
+  EXPECT_FALSE(settings.m_EdlDisplayCommbreakNotifications);
+  EXPECT_EQ(settings.m_iEdlMaxCommBreakLength, 1);
+  EXPECT_EQ(settings.m_iEdlMinCommBreakLength, 2);
+  EXPECT_EQ(settings.m_iEdlMaxCommBreakGap, 3);
+  EXPECT_EQ(settings.m_iEdlMaxStartGap, 4);
+  EXPECT_EQ(settings.m_iEdlCommBreakAutowait, 5);
+  EXPECT_EQ(settings.m_iEdlCommBreakAutowind, 6);
+}
+
+TEST(TestAdvancedSettings, SortTokens)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <sorttokens>
+             <token>foo</token>
+             <token separators=".">bar</token>
+             <token separators="">foobar</token>
+           </sorttokens>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  const auto orig_size = settings.m_vecTokens.size();
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_EQ(settings.m_vecTokens.size(), orig_size + 5);
+  EXPECT_TRUE(settings.m_vecTokens.find("foo ") != settings.m_vecTokens.end());
+  EXPECT_TRUE(settings.m_vecTokens.find("foo.") != settings.m_vecTokens.end());
+  EXPECT_TRUE(settings.m_vecTokens.find("foo_") != settings.m_vecTokens.end());
+  EXPECT_TRUE(settings.m_vecTokens.find("bar.") != settings.m_vecTokens.end());
+  EXPECT_TRUE(settings.m_vecTokens.find("foobar") != settings.m_vecTokens.end());
+}
+
+TEST(TestAdvancedSettings, PathSubstitution)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <pathsubstitution>
+             <substitute>
+               <from>/foo</from>
+                <to>/bar</to>
+              </substitute>
+             <substitute>
+               <from>/foobar</from>
+                <to>/mama</to>
+              </substitute>
+           </pathsubstitution>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  using namespace std::string_literals;
+  const auto ref = std::vector{
+      std::pair{"/foo"s, "/bar"s},
+      std::pair{"/foobar"s, "/mama"s},
+  };
+  EXPECT_EQ(settings.m_pathSubstitutions, ref);
+}
+
+TEST(TestAdvancedSettings, MusicFileNameFilters)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <musicfilenamefilters>
+             <filter>foo</filter>
+             <filter>bar</filter>
+           </musicfilenamefilters>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  using namespace std::string_literals;
+  const auto ref = std::vector{
+      "foo"s,
+      "bar"s,
+  };
+  EXPECT_EQ(settings.m_musicTagsFromFileFilters, ref);
+}
+
+TEST(TestAdvancedSettings, Hosts)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <hosts>
+             <entry name="foo">1.2.3.4</entry>
+             <entry name="bar">5.6.7.8</entry>
+           </hosts>
+         </advancedsettings>)";
+
+  auto cache = std::make_shared<CDNSNameCache>();
+  CServiceBroker::RegisterDNSNameCache(cache);
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  std::string ip;
+  EXPECT_TRUE(CServiceBroker::GetDNSNameCache()->GetCached("foo", ip));
+  EXPECT_EQ(ip, "1.2.3.4");
+  EXPECT_TRUE(CServiceBroker::GetDNSNameCache()->GetCached("bar", ip));
+  EXPECT_EQ(ip, "5.6.7.8");
+  CServiceBroker::UnregisterDNSNameCache();
+}
+
+TEST(TestAdvancedSettings, PowerManagement)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <powermanagement>
+             <powerdown>1</powerdown>
+             <reboot>2</reboot>
+             <suspend>3</suspend>
+             <hibernate>4</hibernate>
+           </powermanagement>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_EQ(settings.m_powerdownCommand, "1");
+  EXPECT_EQ(settings.m_rebootCommand, "2");
+  EXPECT_EQ(settings.m_suspendCommand, "3");
+  EXPECT_EQ(settings.m_hibernateCommand, "4");
+}
+
+TEST(TestAdvancedSettings, PVR)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <pvr>
+             <timecorrection>1</timecorrection>
+             <infotoggleinterval>2</infotoggleinterval>
+             <channeliconsautoscan>false</channeliconsautoscan>
+             <autoscaniconsuserset>true</autoscaniconsuserset>
+             <numericchannelswitchtimeout>53</numericchannelswitchtimeout>
+             <timeshiftthreshold>4</timeshiftthreshold>
+             <timeshiftsimpleosd>false</timeshiftsimpleosd>
+             <pvrrecordings>
+              <sortmethod>episode</sortmethod>
+              <sortorder>ascending</sortorder>
+             </pvrrecordings>
+           </pvr>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_EQ(settings.m_iPVRTimeCorrection, 1);
+  EXPECT_EQ(settings.m_iPVRInfoToggleInterval, 2);
+  EXPECT_FALSE(settings.m_bPVRChannelIconsAutoScan);
+  EXPECT_TRUE(settings.m_bPVRAutoScanIconsUserSet);
+  EXPECT_EQ(settings.m_iPVRNumericChannelSwitchTimeout, 53);
+  EXPECT_EQ(settings.m_iPVRTimeshiftThreshold, 4);
+  EXPECT_FALSE(settings.m_bPVRTimeshiftSimpleOSD);
+  EXPECT_EQ(settings.m_PVRDefaultSortOrder.sortBy, SortBy::EPISODE_NUMBER);
+  EXPECT_EQ(settings.m_PVRDefaultSortOrder.sortOrder, SortOrder::ASCENDING);
+}
+
+TEST(TestAdvancedSettings, GUI)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <gui>
+             <visualizedirtyregions>true</visualizedirtyregions>
+             <algorithmdirtyregions>1</algorithmdirtyregions>
+             <smartredraw>true</smartredraw>
+             <anisotropicfiltering>2</anisotropicfiltering>
+             <fronttobackrendering>true</fronttobackrendering>
+             <geometryclear>false</geometryclear>
+             <asynctextureupload>true</asynctextureupload>
+             <transparentvideolayout>true</transparentvideolayout>
+           </gui>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  EXPECT_TRUE(settings.m_guiVisualizeDirtyRegions);
+  EXPECT_EQ(settings.m_guiAlgorithmDirtyRegions, 1);
+  EXPECT_TRUE(settings.m_guiSmartRedraw);
+  EXPECT_EQ(settings.m_guiAnisotropicFiltering, 2);
+  EXPECT_TRUE(settings.m_guiFrontToBackRendering);
+  EXPECT_FALSE(settings.m_guiGeometryClear);
+  EXPECT_TRUE(settings.m_guiAsyncTextureUpload);
+  EXPECT_TRUE(settings.m_guiVideoLayoutTransparent);
+}
+
+TEST(TestAdvancedSettings, VideoAdjustRefreshRate)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <video>
+             <adjustrefreshrate>
+               <override>
+                 <fps>25.0</fps>
+                 <refresh>25.0</refresh>
+               </override>
+               <override>
+                 <fpsmin>25.8</fpsmin>
+                 <fpsmax>26.2</fpsmax>
+                 <refresh>47.0</refresh>
+               </override>
+               <override>
+                 <fps>27.0</fps>
+                 <refreshmin>46.8</refreshmin>
+                 <refreshmax>47.2</refreshmax>
+               </override>
+               <override>
+                 <fpsmin>25.8</fpsmin>
+                 <fpsmax>26.2</fpsmax>
+                 <refreshmin>46.8</refreshmin>
+                 <refreshmax>47.2</refreshmax>
+               </override>
+               <fallback>
+                 <refresh>25.0</refresh>
+               </fallback>
+               <fallback>
+                 <refreshmin>24.8</refreshmin>
+                 <refreshmax>25.8</refreshmax>
+               </fallback>
+             </adjustrefreshrate>
+           </video>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  const auto ref = std::vector{
+      RefreshOverride{24.99f, 25.01f, 24.99f, 25.01f, false},
+      RefreshOverride{25.8f, 26.2f, 46.99f, 47.01f, false},
+      RefreshOverride{26.99f, 27.01f, 46.8f, 47.2f, false},
+      RefreshOverride{25.8f, 26.2f, 46.8f, 47.2f, false},
+      RefreshOverride{0.f, 0.f, 24.99f, 25.01f, true},
+      RefreshOverride{0.f, 0.f, 24.8f, 25.8f, true},
+  };
+
+  ASSERT_EQ(settings.m_videoAdjustRefreshOverrides.size(), ref.size());
+  for (size_t i = 0; i < ref.size(); ++i)
+  {
+    const auto& r = ref[i];
+    const auto& p = settings.m_videoAdjustRefreshOverrides[i];
+    EXPECT_FLOAT_EQ(p.refreshmax, r.refreshmax);
+    EXPECT_FLOAT_EQ(p.refreshmin, r.refreshmin);
+    EXPECT_FLOAT_EQ(p.fpsmax, r.fpsmax);
+    EXPECT_FLOAT_EQ(p.fpsmin, r.fpsmin);
+    EXPECT_EQ(p.fallback, r.fallback);
+  }
+}
+
+TEST(TestAdvancedSettings, VideoLatency)
+{
+  const std::string xml =
+      R"(<advancedsettings>
+           <video>
+             <latency>
+               <refresh>
+                 <rate>25.0</rate>
+                 <delay>100</delay>
+                 <hdrextradelay>200</hdrextradelay>
+               </refresh>
+               <refresh>
+                 <rate>25.0</rate>
+                 <delay>100</delay>
+               </refresh>
+               <refresh>
+                 <rate>25.0</rate>
+                 <hdrextradelay>200</hdrextradelay>
+               </refresh>
+               <refresh>
+                 <min>24.8</min>
+                 <max>25.2</max>
+                 <delay>100</delay>
+                 <hdrextradelay>200</hdrextradelay>
+               </refresh>
+             </latency>
+           </video>
+         </advancedsettings>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(xml);
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+  const auto ref = std::vector{
+      RefreshVideoLatency{24.99f, 25.01f, 100.f, 200.f},
+      RefreshVideoLatency{24.99f, 25.01f, 100.f, 0.f},
+      RefreshVideoLatency{24.99f, 25.01f, 0.f, 200.f},
+      RefreshVideoLatency{24.8f, 25.2f, 100.f, 200.f},
+  };
+
+  ASSERT_EQ(settings.m_videoRefreshLatency.size(), ref.size());
+  for (size_t i = 0; i < ref.size(); ++i)
+  {
+    const auto& r = ref[i];
+    const auto& p = settings.m_videoRefreshLatency[i];
+    EXPECT_FLOAT_EQ(p.refreshmax, r.refreshmax);
+    EXPECT_FLOAT_EQ(p.refreshmin, r.refreshmin);
+    EXPECT_FLOAT_EQ(p.delay, r.delay);
+    EXPECT_FLOAT_EQ(p.hdrextradelay, r.hdrextradelay);
+  }
+}
+
+TEST_P(ExtensionTest, AddAndRemove)
+{
+  CAdvancedSettingsInit settings;
+  const auto orig_array = StringUtils::Split(std::invoke(GetParam().member, settings), "|");
+  const auto add_array = StringUtils::Split(GetParam().add, "|");
+  const auto remove_array = StringUtils::Split(GetParam().remove, "|");
+
+  auto is_in_orig = [&orig_array](const auto& r)
+  { return std::ranges::find(orig_array, r) != orig_array.end(); };
+
+  EXPECT_TRUE(std::ranges::all_of(remove_array, is_in_orig));
+  EXPECT_TRUE(std::ranges::none_of(add_array, is_in_orig));
+
+  CXBMCTinyXML doc;
+  doc.Parse(GenExtXML(GetParam()));
+  settings.ParseSettingsXML(doc.RootElement());
+
+  const auto new_array = StringUtils::Split(std::invoke(GetParam().member, settings), "|");
+  auto is_in_new = [&new_array](const auto& r)
+  { return std::ranges::find(new_array, r) != new_array.end(); };
+
+  EXPECT_TRUE(std::ranges::none_of(remove_array, is_in_new));
+  EXPECT_TRUE(std::ranges::all_of(add_array, is_in_new));
+}
+
+TEST_P(RegExpTest, Append)
+{
+  RunRETest<RegExpT::Action::APPEND>(GetParam());
+}
+
+TEST_P(RegExpTest, AppendOld)
+{
+  RunRETest<RegExpT::Action::APPEND_OLD>(GetParam());
+}
+
+TEST_P(RegExpTest, Overwrite)
+{
+  RunRETest<RegExpT::Action::OVERWRITE>(GetParam());
+}
+
+TEST_P(RegExpTest, Prepend)
+{
+  RunRETest<RegExpT::Action::PREPEND>(GetParam());
+}
+
+TEST_P(DatabaseTest, Parse)
+{
+  CXBMCTinyXML doc;
+  const DatabaseSettings ref{
+      .type = "1",
+      .host = "2",
+      .port = "3",
+      .user = "4",
+      .pass = "5",
+      .key = "6",
+      .cert = "7",
+      .ca = "8",
+      .capath = "9",
+      .ciphers = "10",
+      .connecttimeout = 11,
+      .compression = true,
+  };
+  doc.Parse(GenDbXML(GetParam().tag, ref));
+  CAdvancedSettingsInit settings;
+  settings.ParseSettingsXML(doc.RootElement());
+
+  const auto& p = std::invoke(GetParam().member, settings);
+  EXPECT_EQ(p.type, ref.type);
+  EXPECT_EQ(p.host, ref.host);
+  EXPECT_EQ(p.port, ref.port);
+  EXPECT_EQ(p.user, ref.user);
+  EXPECT_EQ(p.pass, ref.pass);
+  EXPECT_EQ(p.name, ref.name);
+  EXPECT_EQ(p.key, ref.key);
+  EXPECT_EQ(p.cert, ref.cert);
+  EXPECT_EQ(p.ca, ref.ca);
+  EXPECT_EQ(p.capath, ref.capath);
+  EXPECT_EQ(p.ciphers, ref.ciphers);
+  EXPECT_EQ(p.connecttimeout, ref.connecttimeout);
+  EXPECT_EQ(p.compression, ref.compression);
+}
+
+TEST_P(DatabaseTest, Redact)
+{
+  CXBMCTinyXML doc;
+  const DatabaseSettings ref{
+      .type = "1",
+      .host = "2",
+      .port = "3",
+      .user = "4",
+      .pass = "5",
+      .key = "6",
+      .cert = "7",
+      .ca = "8",
+      .capath = "9",
+      .ciphers = "10",
+      .connecttimeout = 11,
+      .compression = true,
+  };
+  doc.Parse(GenDbXML(GetParam().tag, ref));
+  CAdvancedSettingsInit settings;
+  settings.DoRedact(doc);
+  settings.ParseSettingsXML(doc.RootElement());
+
+  const auto& p = std::invoke(GetParam().member, settings);
+  EXPECT_EQ(p.type, ref.type);
+  EXPECT_EQ(p.host, ref.host);
+  EXPECT_EQ(p.port, ref.port);
+  EXPECT_EQ(p.user, ref.user);
+  EXPECT_EQ(p.pass, "*****");
+  EXPECT_EQ(p.name, ref.name);
+  EXPECT_EQ(p.key, ref.key);
+  EXPECT_EQ(p.cert, ref.cert);
+  EXPECT_EQ(p.ca, ref.ca);
+  EXPECT_EQ(p.capath, ref.capath);
+  EXPECT_EQ(p.ciphers, ref.ciphers);
+  EXPECT_EQ(p.connecttimeout, ref.connecttimeout);
+  EXPECT_EQ(p.compression, ref.compression);
+}
+
+namespace
+{
+
+// clang-format off
+const auto regexp_tests = std::array{
+  RegExpT{"audio", "excludefromlisting", &CAdvancedSettings::m_audioExcludeFromListingRegExps},
+  RegExpT{"audio", "excludefromscan", &CAdvancedSettings::m_audioExcludeFromScanRegExps},
+  RegExpT{"video", "excludefromlisting", &CAdvancedSettings::m_videoExcludeFromListingRegExps},
+  RegExpT{"video", "excludefromscan", &CAdvancedSettings::m_moviesExcludeFromScanRegExps},
+  RegExpT{"video", "excludetvshowsfromscan", &CAdvancedSettings::m_tvshowExcludeFromScanRegExps},
+  RegExpT{"video", "cleanstrings", &CAdvancedSettings::m_videoCleanStringRegExps},
+  RegExpT{"", "pictureexcludes", &CAdvancedSettings::m_pictureExcludeFromListingRegExps},
+  RegExpT{"", "trailermatching", &CAdvancedSettings::m_trailerMatchRegExps},
+};
+
+const auto extension_tests = std::array{
+  ExtT{"pictureextensions",  ".foo|.bar",       ".gif|.jpg", &CAdvancedSettings::m_pictureExtensions},
+  ExtT{"musicextensions",    ".foo|.bar",       ".mp3|.m4a", &CAdvancedSettings::m_musicExtensions},
+  ExtT{"videoextensions",    ".foo|.bar",       ".mov|.mkv", &CAdvancedSettings::m_videoExtensions},
+  ExtT{"discstubextensions", ".foo|.bar",       ".disc",     &CAdvancedSettings::m_discStubExtensions},
+  ExtT{"musicthumbs",        "foo.jpg|bar.png", "folder.jpg|Cover.jpg", &CAdvancedSettings::m_musicThumbs},
+};
+
+const auto db_tests = std::array{
+  DbTestT{"videodatabase", &CAdvancedSettings::m_databaseVideo},
+  DbTestT{"musicdatabase", &CAdvancedSettings::m_databaseMusic},
+  DbTestT{"tvdatabase",    &CAdvancedSettings::m_databaseTV},
+  DbTestT{"epgdatabase",   &CAdvancedSettings::m_databaseEpg},
+};
+// clang-format on
+
+} // namespace
+
+INSTANTIATE_TEST_SUITE_P(TestAdvancedSettings, RegExpTest, testing::ValuesIn(regexp_tests));
+INSTANTIATE_TEST_SUITE_P(TestAdvancedSettings, ExtensionTest, testing::ValuesIn(extension_tests));
+INSTANTIATE_TEST_SUITE_P(TestAdvancedSettings, DatabaseTest, testing::ValuesIn(db_tests));

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -11,7 +11,7 @@
 #include "LangInfo.h"
 #include "ServiceBroker.h"
 #include "utils/StringUtils.h"
-#include "utils/XBMCTinyXML.h"
+#include "utils/XMLUtils.h"
 #include "utils/i18n/Bcp47.h"
 #include "utils/i18n/Bcp47Registry/SubTagRegistryManager.h"
 #include "utils/i18n/Iso3166_1.h"
@@ -22,6 +22,8 @@
 
 #include <algorithm>
 #include <cassert>
+
+#include <tinyxml2.h>
 
 using namespace KODI::UTILS::I18N;
 
@@ -36,7 +38,7 @@ void CLangCodeExpander::Clear()
   m_mapUser.clear();
 }
 
-void CLangCodeExpander::LoadUserCodes(const TiXmlElement* pRootElement)
+void CLangCodeExpander::LoadUserCodes(const tinyxml2::XMLElement* pRootElement)
 {
   if (pRootElement != nullptr)
   {
@@ -44,22 +46,17 @@ void CLangCodeExpander::LoadUserCodes(const TiXmlElement* pRootElement)
 
     std::string sShort, sLong;
 
-    const TiXmlNode* pLangCode = pRootElement->FirstChild("code");
+    const auto* pLangCode = pRootElement->FirstChildElement("code");
     while (pLangCode != nullptr)
     {
-      const TiXmlNode* pShort = pLangCode->FirstChildElement("short");
-      const TiXmlNode* pLong = pLangCode->FirstChildElement("long");
-      if (pShort != nullptr && pShort->FirstChild() != nullptr && pLong != nullptr &&
-          pLong->FirstChild() != nullptr)
+      if (XMLUtils::GetString(pLangCode, "short", sShort) &&
+          XMLUtils::GetString(pLangCode, "long", sLong))
       {
-        sShort = pShort->FirstChild()->Value();
-        sLong = pLong->FirstChild()->Value();
         StringUtils::ToLower(sShort);
-
-        m_mapUser[sShort] = sLong;
+        m_mapUser.emplace(sShort, sLong);
       }
 
-      pLangCode = pLangCode->NextSibling();
+      pLangCode = pLangCode->NextSiblingElement();
     }
   }
 }

--- a/xbmc/utils/LangCodeExpander.h
+++ b/xbmc/utils/LangCodeExpander.h
@@ -12,7 +12,10 @@
 #include <string>
 #include <vector>
 
-class TiXmlElement;
+namespace tinyxml2
+{
+class XMLElement;
+}
 
 class CLangCodeExpander
 {
@@ -41,7 +44,7 @@ public:
     INCLUDE_ADDONS_USERDEFINED,
   };
 
-  void LoadUserCodes(const TiXmlElement* pRootElement);
+  void LoadUserCodes(const tinyxml2::XMLElement* pRootElement);
   void Clear();
 
   bool Lookup(const std::string& code, std::string& desc);

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "utils/LangCodeExpander.h"
-#include "utils/XBMCTinyXML.h"
+#include "utils/XBMCTinyXML2.h"
 
 #include <gtest/gtest.h>
 
@@ -41,7 +41,7 @@ TEST(TestLangCodeExpander, ParseUserCodes)
            </languagecodes>
          </advancedsettings>)";
 
-  CXBMCTinyXML doc;
+  CXBMCTinyXML2 doc;
   doc.Parse(xml);
   CLangCodeExpanderTest exp;
   ASSERT_TRUE(doc.RootElement() != nullptr);


### PR DESCRIPTION
## Description
Some refactoring to enable testing, add tests, and then move AdvancedSettings to tinyxml2

## Motivation and context
Move more code to tinyxml2

## How has this been tested?
Tests added, basic runtime testing

## What is the effect on users?
Hopefully none

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
