### PR TITLE
[GUI] Block clicks on disabled buttons

### DIFF
--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -13,6 +13,7 @@
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "input/mouse/MouseEvent.h"
+#include "utils/log.h"
 #include "windowing/WinSystem.h"
 
 using namespace KODI;
@@ -402,9 +403,18 @@ void CGUIButtonControl::PythonSetDisabledColor(KODI::UTILS::COLOR::Color disable
 void CGUIButtonControl::OnClick()
 {
   // Save values, as the click message may deactivate the window
-  int controlID = GetID();
-  int parentID = GetParentID();
-  CGUIAction clickActions = m_clickActions;
+  const int controlID = GetID();
+  const int parentID = GetParentID();
+  const CGUIAction clickActions = m_clickActions;
+
+  if (IsDisabled())
+  {
+    CLog::Log(LOGWARNING,
+              "Button control: Blocked an attempt to click a disabled button "
+              "(control {} window {})",
+              controlID, parentID);
+    return;
+  }
 
   // button selected, send a message
   CGUIMessage msg(GUI_MSG_CLICKED, controlID, parentID, 0);

--- a/xbmc/guilib/GUIControl.cpp
+++ b/xbmc/guilib/GUIControl.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -37,6 +37,7 @@ CGUIControl::CGUIControl()
   m_visibleFromSkinCondition = true;
   m_forceHidden = false;
   m_enabled = true;
+  m_enabledFromSkinCondition = true;
   m_posX = 0;
   m_posY = 0;
   m_width = 0;
@@ -68,6 +69,7 @@ CGUIControl::CGUIControl(int parentID, int controlID, float posX, float posY, fl
   m_visibleFromSkinCondition = true;
   m_forceHidden = false;
   m_enabled = true;
+  m_enabledFromSkinCondition = true;
   ControlType = GUICONTROL_UNKNOWN;
   m_bInvalidated = true;
   m_bAllocated=false;
@@ -395,7 +397,6 @@ bool CGUIControl::OnMessage(CGUIMessage& message)
       SetVisible(false);
       return true;
 
-      // Note that the skin <enable> tag will override these messages
     case GUI_MSG_ENABLED:
       SetEnabled(true);
       return true;
@@ -429,24 +430,27 @@ bool CGUIControl::IsVisible() const
 
 bool CGUIControl::IsDisabled() const
 {
-  return !m_enabled;
+  return !m_enabled || !m_enabledFromSkinCondition;
 }
 
 void CGUIControl::SetEnabled(bool bEnable)
 {
+  const bool wasDisabled = IsDisabled();
+
   if (bEnable != m_enabled)
   {
     m_enabled = bEnable;
-    SetInvalid();
+    if (IsDisabled() != wasDisabled)
+      SetInvalid();
   }
 }
 
 void CGUIControl::SetEnableCondition(const std::string &expression)
 {
   if (expression == "true")
-    m_enabled = true;
+    m_enabledFromSkinCondition = true;
   else if (expression == "false")
-    m_enabled = false;
+    m_enabledFromSkinCondition = false;
   else
     m_enableCondition = CServiceBroker::GetGUI()->GetInfoManager().Register(expression, GetParentID());
 }
@@ -641,13 +645,12 @@ void CGUIControl::UpdateVisibility(const CGUIListItem *item)
     if (anim.GetType() == ANIM_TYPE_CONDITIONAL)
       anim.UpdateCondition(item);
   }
-  // and check for conditional enabling - note this overrides SetEnabled() from the code currently
-  // this may need to be reviewed at a later date
-  bool enabled = m_enabled;
+  // and check for conditional enabling, combined with status set with SetEnabled()
+  const bool disabled = IsDisabled();
   if (m_enableCondition)
-    m_enabled = m_enableCondition->Get(INFO::DEFAULT_CONTEXT, item);
+    m_enabledFromSkinCondition = m_enableCondition->Get(INFO::DEFAULT_CONTEXT, item);
 
-  if (m_enabled != enabled)
+  if (IsDisabled() != disabled)
     MarkDirtyRegion();
 
   m_allowHiddenFocus.Update(INFO::DEFAULT_CONTEXT, item);
@@ -680,10 +683,9 @@ void CGUIControl::SetInitialVisibility()
     if (anim.GetType() == ANIM_TYPE_CONDITIONAL)
       anim.SetInitialCondition();
   }
-  // and check for conditional enabling - note this overrides SetEnabled() from the code currently
-  // this may need to be reviewed at a later date
+  // and check for conditional enabling
   if (m_enableCondition)
-    m_enabled = m_enableCondition->Get(INFO::DEFAULT_CONTEXT);
+    m_enabledFromSkinCondition = m_enableCondition->Get(INFO::DEFAULT_CONTEXT);
   m_allowHiddenFocus.Update(INFO::DEFAULT_CONTEXT);
   UpdateColors(nullptr);
 

--- a/xbmc/guilib/GUIControl.h
+++ b/xbmc/guilib/GUIControl.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -377,6 +377,7 @@ protected:
   // enable/disable state
   INFO::InfoPtr m_enableCondition;
   bool m_enabled;
+  bool m_enabledFromSkinCondition;
 
   bool m_pushedUpdates;
 

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -163,6 +163,29 @@
 using namespace KODI;
 using namespace PVR;
 using namespace PERIPHERALS;
+
+namespace
+{
+bool PreValidateMessage(CGUIMessage& message, CGUIWindow& window)
+{
+  // Click message: check that the underlying control hasn't been disabled by core code.
+  // note: the "regular" enabled status is modified by skin conditions > use a different function.
+  if (message.GetMessage() == GUI_MSG_CLICKED && window.HasID(message.GetControlId()))
+  {
+    // @todo: if this is not enough to locate the control, maybe borrow more from SendControlMessage
+    if (CGUIControl * ctrl{window.GetControl(message.GetSenderId(), nullptr)};
+        ctrl != nullptr && ctrl->IsDisabled())
+    {
+      CLog::Log(LOGWARNING,
+                "Window manager: Blocked an attempt to click a disabled control "
+                "(control {} window {})",
+                message.GetSenderId(), message.GetControlId());
+      return false;
+    }
+  }
+  return true;
+}
+} // namespace
 
 CGUIWindowManager::CGUIWindowManager()
 {
@@ -556,6 +579,10 @@ bool CGUIWindowManager::SendMessage(CGUIMessage& message)
   while (topWindow)
   {
     auto dialog = m_activeDialogs[--topWindow];
+
+    if (!PreValidateMessage(message, *dialog))
+      continue;
+
     if (!modalAcceptedMessage && dialog->IsModalDialog())
     { // modal window
       hasModalDialog = true;
@@ -576,7 +603,7 @@ bool CGUIWindowManager::SendMessage(CGUIMessage& message)
 
   // now send to the underlying window
   CGUIWindow* window = GetWindow(GetActiveWindow());
-  if (window)
+  if (window && PreValidateMessage(message, *window))
   {
     if (hasModalDialog)
     {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The PR adds a protection against unexpected clicks on buttons that were explicitly disabled by core code. It's a generalization of #28247, which tracked and checked button status only for the video info dialog.

Core enables or disables some controls with macros such as `CONTROL_DISABLE`, `CONTROL_ENABLE`, `CONTROL_ENABLE_ON_CONDITION`, but skins used to be able to override the disabled status with `<enable>` conditions and have the controls accept/generate click actions.

Implementation:

Track separately the enabled status set by core and skin enable condition results. The effective enabled status is a combination of both: if core or the skin want the disabled status, then the effective status is disabled. It's enabled otherwise.

Clicks come through 2 paths:

- Click on the button control: taken care of by the new effective enabled status calculation. The button cannot be selected anymore and can't generate clicks.

- The `SendClick()` builtin sends a GUI_MSG_CLICKED message to any control number and the message may be broadcast to multiple windows. Solution: Intercept the message in the window manager before the broadcast, attempt to locate the control and check its enabled status.

I didn't find a way for skins or addons to generate GUI_MSG_DISABLED or GUI_MSG_ENABLED messages and override the status set by core so the solution should be reliable.

A warning message is logged when a clicked button is in disabled status.

Additional thoughts:
- There is a risk of side effects: some window/dialog code and skin code may rely on disabled buttons; other button click code paths may have been missed
- There are probably more existing controls to protect using this new mechanism and per-window or per-dialog follow-up PRs could take care of that.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Create a mechanism to protect against crash / db corruption / unexpected behaviors (see #27693) when the conditions in button skin code doesn't align perfectly with core code.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Video Info Dialog with Aeon Nox and Estuary, which use the two techniques listed in the description to click buttons.
Core conditionally enables or disables the art chooser/user ratings/refresh buttons.
Aeon Nox has visible and enabled conditions that don't align with core expectations > the buttons appear disabled now and can't be clicked.
Modified Estuary's visibility condition of the buttons to create discrepancies with core expectations and checked that the PR blocks the clicks.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Reduce unexpected behaviors/crash/corruption when skins are not perfectly aligned with core code expectations.

## Screenshots (if appropriate):

The visibility of buttons doesn't change, no action happens on click and the log contains lines such as:
```
2026-05-02 14:55:19.038 T:29684 warning <general>: Button control: Blocked an attempt to click a disabled button (control 6 window 12003)
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
