### PR TITLE
[Doxygen] Update doxygen for new retroplayer infolabels/bools

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4299,22 +4299,25 @@ constexpr std::array<InfoMap, 83> videoplayer = {{
 ///     <p><hr>
 ///     @skinning_v18 **[New Infolabel]** \link RetroPlayer_VideoRotation `RetroPlayer.VideoRotation`\endlink
 ///     <p>
+///   }
 ///   \table_row3{   <b>`RetroPlayer.SupportsEject`</b>,
 ///                  \anchor RetroPlayer_SupportsEject
 ///                  _boolean_,
 ///     @return **True** if the game's disc can be ejected\, **False** if the
 ///     game isn't disc-based or doesn't support ejecting the disc.
 ///     <p><hr>
-///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_SupportsEject `RetroPlayer.SupportsEject`\endlink
+///     @skinning_v22 **[New Boolean Condition]** \link RetroPlayer_SupportsEject `RetroPlayer.SupportsEject`\endlink
 ///     <p>
+///   }
 ///   \table_row3{   <b>`RetroPlayer.DiscEjected`</b>,
 ///                  \anchor RetroPlayer_DiscEjected
 ///                  _boolean_,
 ///     @return **True** if the game's disc is ejected (tray is open)\, **False**
 ///     if the game isn't disc-based or the tray is closed.
 ///     <p><hr>
-///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_DiscEjected `RetroPlayer.DiscEjected`\endlink
+///     @skinning_v22 **[New Boolean Condition]** \link RetroPlayer_DiscEjected `RetroPlayer.DiscEjected`\endlink
 ///     <p>
+///   }
 ///   \table_row3{   <b>`RetroPlayer.DiscLabel`</b>,
 ///                  \anchor RetroPlayer_DiscLabel
 ///                  _string_,
@@ -4324,13 +4327,14 @@ constexpr std::array<InfoMap, 83> videoplayer = {{
 ///     <p><hr>
 ///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_DiscLabel `RetroPlayer.DiscLabel`\endlink
 ///     <p>
+///   }
 ///   \table_row3{   <b>`RetroPlayer.EmptyTray`</b>,
 ///                  \anchor RetroPlayer_EmptyTray
 ///                  _boolean_,
 ///     @return **True** if the selected disc state is "No disc"\, **False** if a
 ///     disc is selected or the game isn't disc-based.
 ///     <p><hr>
-///     @skinning_v22 **[New Infolabel]** \link RetroPlayer_EmptyTray `RetroPlayer.EmptyTray`\endlink
+///     @skinning_v22 **[New Boolean Condition]** \link RetroPlayer_EmptyTray `RetroPlayer.EmptyTray`\endlink
 ///     <p>
 ///   }
 /// \table_end


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Correct some syntax in GUIInfoManager doxy documentation after recent addition of retroplayer info items

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/xbmc/xbmc/issues/28251

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build Kodi doxygen documentation locally and observed the infolabel and boolean conditions are available in the documentation tree and the new labels/bools are listed.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Doxygen documentation is a key resource for skinning Kodi

## Screenshots (if appropriate):

<img width="800" height="414" alt="doxygen" src="https://github.com/user-attachments/assets/86072903-0553-43c3-b4bf-6f1c130c3afb" />

Note:  there seems to be some additional layout issues in that new items are improperly indented after an occurrence of one of the @skinning_ aliases which inserts an \xrefitem but that is outside the scope of this PR.
## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
