### PR TITLE
[Estuary] Tweak element heights and vertical offsets

### DIFF
--- a/addons/skin.estuary/xml/Custom_1102_TextViewer.xml
+++ b/addons/skin.estuary/xml/Custom_1102_TextViewer.xml
@@ -17,7 +17,7 @@
 				<left>1%</left>
 				<top>85</top>
 				<width>82%</width>
-				<height>675</height>
+				<height>662</height>
 				<shadowcolor>black</shadowcolor>
 				<pagecontrol>3000</pagecontrol>
 				<font>font37</font>

--- a/addons/skin.estuary/xml/DialogVideoInfo.xml
+++ b/addons/skin.estuary/xml/DialogVideoInfo.xml
@@ -153,7 +153,7 @@
 						<left>40</left>
 						<top>25</top>
 						<width>670</width>
-						<height>363</height>
+						<height>368</height>
 						<label fallback="19055">$VAR[VideoInfoPlotVar]</label>
 						<autoscroll delay="10000" time="5000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
 						<visible>Integer.IsGreater(Container(4000).NumItems,0)</visible>
@@ -162,7 +162,7 @@
 						<left>40</left>
 						<top>25</top>
 						<width>1165</width>
-						<height>363</height>
+						<height>368</height>
 						<label fallback="19055">$VAR[VideoInfoPlotVar]</label>
 						<autoscroll delay="10000" time="5000" repeat="10000">Skin.HasSetting(AutoScroll)</autoscroll>
 						<visible>!Integer.IsGreater(Container(4000).NumItems,0)</visible>
@@ -782,7 +782,7 @@
 			<control type="group">
 				<visible>Control.HasFocus(50) + !String.IsEqual(ListItem.DBType,set)</visible>
 				<animation effect="fade" time="200">VisibleChange</animation>
-				<top>10</top>
+				<top>-10</top>
 				<left>0</left>
 				<control type="image">
 					<left>21</left>
@@ -802,7 +802,7 @@
 			<control type="group">
 				<visible>Control.HasFocus(138)</visible>
 				<animation effect="fade" time="200">VisibleChange</animation>
-				<top>10</top>
+				<top>-10</top>
 				<left>0</left>
 				<control type="image">
 					<top>4</top>


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Adjust layout values in Estuary skin XML to improve spacing and alignment:

- addons/skin.estuary/xml/Custom_1102_TextViewer.xml: reduce text viewer height from 675 to 662 to correct vertical sizing.
- addons/skin.estuary/xml/DialogVideoInfo.xml: increase plot/label heights from 363 to 368 in two places; change two group top offsets from 10 to -10 to nudge controls upward and fix visual alignment.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

These changes address clipping/spacing issues in the UI and refine element positioning.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally at 720p, 1080p, and 4k.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Before:
<img width="1920" height="1080" alt="Screenshot (81)" src="https://github.com/user-attachments/assets/d20d0046-a60c-4003-9807-8672e3d28fe7" />

After:
<img width="1920" height="1080" alt="Screenshot (77)" src="https://github.com/user-attachments/assets/01d7f51b-ffbe-4e6c-878c-be6c53274158" />

Before:
<img width="1920" height="1080" alt="Screenshot (82)" src="https://github.com/user-attachments/assets/9f68c654-32ed-4873-a0cc-a34d68832620" />

After:
<img width="1920" height="1080" alt="Screenshot (78)" src="https://github.com/user-attachments/assets/1c81fc4f-ae60-487e-835a-7b9cf771558e" />

Before:
<img width="1920" height="1080" alt="Screenshot (83)" src="https://github.com/user-attachments/assets/58ddc385-b2fb-422e-9beb-63dac0291fee" />

After:
<img width="1920" height="1080" alt="Screenshot (79)" src="https://github.com/user-attachments/assets/ee53aeb8-68e6-4aed-b8e8-4cd13d88c2b2" />

Before:
<img width="1920" height="1080" alt="Screenshot (84)" src="https://github.com/user-attachments/assets/6ac0b9ba-1816-4f37-a352-071fa8d73ebe" />

After:
<img width="1920" height="1080" alt="Screenshot (80)" src="https://github.com/user-attachments/assets/e22d6953-a8a9-4921-a5ff-220cd8225034" />


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
