### PR TITLE
[GUI] Add `Control.ResetGrouplist(ID)` feature for resetting grouplist focus item

### DIFF
--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -190,6 +190,17 @@ bool CGUIControlGroupList::OnAction(const CAction& action)
   return CGUIControlGroup::OnAction(action);
 }
 
+bool CGUIControlGroupList::ResetFocusToFirstItem()
+{
+  CGUIControl* firstControl = GetFirstFocusableControl();
+  if (!firstControl)
+    return false;
+
+  m_focusedControl = firstControl->GetID();
+  m_scroller.SetValue(0.0f);
+  return true;
+}
+
 bool CGUIControlGroupList::OnMessage(CGUIMessage& message)
 {
   switch (message.GetMessage() )

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -193,18 +193,17 @@ bool CGUIControlGroupList::OnAction(const CAction& action)
 bool CGUIControlGroupList::ResetFocusToFirstItem()
 {
   CGUIControl* firstControl = GetFirstFocusableControl();
-  if (!firstControl)
+  if (!firstControl || !firstControl->IsVisible())
     return false;
 
   CGUIControl* focusedControl = GetFocusedControl();
-  
+
   // If there's a currently focused control and it's different from the first control,
   // send proper focus messages to maintain consistent state
   if (focusedControl && focusedControl != firstControl)
   {
     CGUIMessage message(GUI_MSG_LOSTFOCUS, GetID(), focusedControl->GetID(), firstControl->GetID());
     focusedControl->OnMessage(message);
-
     CGUIMessage message2(GUI_MSG_SETFOCUS, GetID(), firstControl->GetID());
     firstControl->OnMessage(message2);
   }

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -196,6 +196,19 @@ bool CGUIControlGroupList::ResetFocusToFirstItem()
   if (!firstControl)
     return false;
 
+  CGUIControl* focusedControl = GetFocusedControl();
+  
+  // If there's a currently focused control and it's different from the first control,
+  // send proper focus messages to maintain consistent state
+  if (focusedControl && focusedControl != firstControl)
+  {
+    CGUIMessage message(GUI_MSG_LOSTFOCUS, GetID(), focusedControl->GetID(), firstControl->GetID());
+    focusedControl->OnMessage(message);
+
+    CGUIMessage message2(GUI_MSG_SETFOCUS, GetID(), firstControl->GetID());
+    firstControl->OnMessage(message2);
+  }
+
   m_focusedControl = firstControl->GetID();
   m_scroller.SetValue(0.0f);
   return true;

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -209,7 +209,7 @@ bool CGUIControlGroupList::ResetFocusToFirstItem()
   }
 
   m_focusedControl = firstControl->GetID();
-  m_focusedControl = firstControl->GetID();
+  m_scroller.SetValue(0.0f);
   m_scroller.SetValue(0.0f);
   SetInvalid();
   MarkDirtyRegion();

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -190,6 +190,31 @@ bool CGUIControlGroupList::OnAction(const CAction& action)
   return CGUIControlGroup::OnAction(action);
 }
 
+bool CGUIControlGroupList::ResetFocusToFirstItem()
+{
+  CGUIControl* firstControl = GetFirstFocusableControl();
+  if (!firstControl || !firstControl->IsVisible())
+    return false;
+
+  CGUIControl* focusedControl = GetFocusedControl();
+
+  // If there's a currently focused control and it's different from the first control,
+  // send proper focus messages to maintain consistent state
+  if (focusedControl && focusedControl != firstControl)
+  {
+    CGUIMessage message(GUI_MSG_LOSTFOCUS, GetID(), focusedControl->GetID(), firstControl->GetID());
+    focusedControl->OnMessage(message);
+    CGUIMessage message2(GUI_MSG_SETFOCUS, GetID(), firstControl->GetID());
+    firstControl->OnMessage(message2);
+  }
+
+  m_focusedControl = firstControl->GetID();
+  m_scroller.SetValue(0.0f);
+  SetInvalid();
+  MarkDirtyRegion();
+  return true;
+}
+
 bool CGUIControlGroupList::OnMessage(CGUIMessage& message)
 {
   switch (message.GetMessage() )

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -209,7 +209,11 @@ bool CGUIControlGroupList::ResetFocusToFirstItem()
   }
 
   m_focusedControl = firstControl->GetID();
+  m_focusedControl = firstControl->GetID();
   m_scroller.SetValue(0.0f);
+  SetInvalid();
+  MarkDirtyRegion();
+  return true;
   return true;
 }
 

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -210,11 +210,9 @@ bool CGUIControlGroupList::ResetFocusToFirstItem()
 
   m_focusedControl = firstControl->GetID();
   m_scroller.SetValue(0.0f);
-  m_scroller.SetValue(0.0f);
   SetInvalid();
   MarkDirtyRegion();
   return true;
-}
 }
 
 bool CGUIControlGroupList::OnMessage(CGUIMessage& message)

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -214,7 +214,7 @@ bool CGUIControlGroupList::ResetFocusToFirstItem()
   SetInvalid();
   MarkDirtyRegion();
   return true;
-  return true;
+}
 }
 
 bool CGUIControlGroupList::OnMessage(CGUIMessage& message)

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -43,6 +43,7 @@ public:
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
   bool OnAction(const CAction& action) override;
+  bool ResetFocusToFirstItem();
   bool OnMessage(CGUIMessage& message) override;
 
   EVENT_RESULT SendMouseEvent(const CPoint& point, const KODI::MOUSE::CMouseEvent& event) override;

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -612,22 +612,39 @@ static int ToggleDirty(const std::vector<std::string>&)
 CBuiltins::CommandMap CGUIBuiltins::GetOperations() const
 {
   return {
-           {"action",                         {"Executes an action for the active window (same as in keymap)", 1, Action}},
-           {"cancelalarm",                    {"Cancels an alarm", 1, CancelAlarm}},
-           {"alarmclock",                     {"Prompt for a length of time and start an alarm clock", 2, AlarmClock}},
-           {"activatewindow",                 {"Activate the specified window", 1, ActivateWindow<false>}},
-           {"activatewindowandfocus",         {"Activate the specified window and sets focus to the specified id", 1, ActivateAndFocus<false>}},
-           {"clearproperty",                  {"Clears a window property for the current focused window/dialog (key,value)", 1, ClearProperty}},
-           {"dialog.close",                   {"Close a dialog", 1, CloseDialog}},
-           {"notification",                   {"Shows a notification on screen, specify header, then message, and optionally time in milliseconds and a icon.", 2, Notification}},
-           {"refreshrss",                     {"Reload RSS feeds from RSSFeeds.xml", 0, RefreshRSS}},
-           {"replacewindow",                  {"Replaces the current window with the new one", 1, ActivateWindow<true>}},
-           {"replacewindowandfocus",          {"Replaces the current window with the new one and sets focus to the specified id", 1, ActivateAndFocus<true>}},
-           {"setguilanguage",                 {"Set GUI Language", 1, SetLanguage}},
-           {"setproperty",                    {"Sets a window property for the current focused window/dialog (key,value)", 2, SetProperty}},
-           {"setstereomode",                  {"Changes the stereo mode of the GUI. Params can be: toggle, next, previous, select, tomono or any of the supported stereomodes (off, split_vertical, split_horizontal, row_interleaved, hardware_based, anaglyph_cyan_red, anaglyph_green_magenta, anaglyph_yellow_blue, monoscopic)", 1, SetStereoMode}},
-           {"takescreenshot",                 {"Takes a Screenshot", 0, Screenshot}},
-           {"toggledirtyregionvisualization", {"Enables/disables dirty-region visualization", 0, ToggleDirty}},
-           {"control.resetgrouplist",         {"Resets a grouplist control's focus to its first item", 1, ResetGroupList}}
-         };
+      {"action", {"Executes an action for the active window (same as in keymap)", 1, Action}},
+      {"cancelalarm", {"Cancels an alarm", 1, CancelAlarm}},
+      {"alarmclock", {"Prompt for a length of time and start an alarm clock", 2, AlarmClock}},
+      {"activatewindow", {"Activate the specified window", 1, ActivateWindow<false>}},
+      {"activatewindowandfocus",
+       {"Activate the specified window and sets focus to the specified id", 1,
+        ActivateAndFocus<false>}},
+      {"clearproperty",
+       {"Clears a window property for the current focused window/dialog (key,value)", 1,
+        ClearProperty}},
+      {"dialog.close", {"Close a dialog", 1, CloseDialog}},
+      {"notification",
+       {"Shows a notification on screen, specify header, then message, and optionally time in "
+        "milliseconds and a icon.",
+        2, Notification}},
+      {"refreshrss", {"Reload RSS feeds from RSSFeeds.xml", 0, RefreshRSS}},
+      {"replacewindow", {"Replaces the current window with the new one", 1, ActivateWindow<true>}},
+      {"replacewindowandfocus",
+       {"Replaces the current window with the new one and sets focus to the specified id", 1,
+        ActivateAndFocus<true>}},
+      {"setguilanguage", {"Set GUI Language", 1, SetLanguage}},
+      {"setproperty",
+       {"Sets a window property for the current focused window/dialog (key,value)", 2,
+        SetProperty}},
+      {"setstereomode",
+       {"Changes the stereo mode of the GUI. Params can be: toggle, next, previous, select, tomono "
+        "or any of the supported stereomodes (off, split_vertical, split_horizontal, "
+        "row_interleaved, hardware_based, anaglyph_cyan_red, anaglyph_green_magenta, "
+        "anaglyph_yellow_blue, monoscopic)",
+        1, SetStereoMode}},
+      {"takescreenshot", {"Takes a Screenshot", 0, Screenshot}},
+      {"toggledirtyregionvisualization",
+       {"Enables/disables dirty-region visualization", 0, ToggleDirty}},
+      {"control.resetgrouplist",
+       {"Resets a grouplist control's focus to its first item", 1, ResetGroupList}}};
 }

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -52,7 +52,10 @@ static int ResetGroupList(const std::vector<std::string>& params)
   {
     CGUIControl* control = window->GetControl(atoi(params[0].c_str()));
     if (control && control->GetControlType() == CGUIControl::GUICONTROL_GROUPLIST)
-      static_cast<CGUIControlGroupList*>(control)->ResetFocusToFirstItem();
+      if (static_cast<CGUIControlGroupList*>(control)->ResetFocusToFirstItem())
+        CLog::Log(LOGDEBUG, "ResetGroupList: Reset grouplist {} to first item", params[0]);
+      else
+        CLog::Log(LOGWARNING, "ResetGroupList: No focusable controls found in grouplist {}", params[0]);
   }
 
   return 0;

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -16,6 +16,7 @@
 #include "dialogs/GUIDialogNumeric.h"
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
+#include "guilib/GUIControlGroupList.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/StereoscopicsManager.h"
 #include "input/WindowTranslator.h"
@@ -39,6 +40,24 @@ using namespace KODI;
 
 namespace
 {
+/*! \brief Reset a grouplist control's focus to its first item.
+ *  \param params The parameters.
+ *  \details params[0] = The control ID of the grouplist to reset.
+ */
+static int ResetGroupList(const std::vector<std::string>& params)
+{
+  CGUIWindow* window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow(
+      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindowOrDialog());
+  if (window)
+  {
+    CGUIControl* control = window->GetControl(atoi(params[0].c_str()));
+    if (control && control->GetControlType() == CGUIControl::GUICONTROL_GROUPLIST)
+      static_cast<CGUIControlGroupList*>(control)->ResetFocusToFirstItem();
+  }
+
+  return 0;
+}
+
 /*! \brief Execute a GUI action.
  *  \param params The parameters.
  *  \details params[0] = Action to execute.
@@ -581,6 +600,12 @@ static int ToggleDirty(const std::vector<std::string>&)
 ///     ,
 ///     makes dirty regions visible for debugging proposes.
 ///   }
+///   \table_row2_l{
+///     <b>`Control.ResetGroupList(id)`</b>
+///     ,
+///     Resets a grouplist control's focus to its first item and scrolls back to the top.
+///     @param[in] id                    The control ID of the grouplist to reset.
+///   }
 ///  \table_end
 ///
 
@@ -602,6 +627,7 @@ CBuiltins::CommandMap CGUIBuiltins::GetOperations() const
            {"setproperty",                    {"Sets a window property for the current focused window/dialog (key,value)", 2, SetProperty}},
            {"setstereomode",                  {"Changes the stereo mode of the GUI. Params can be: toggle, next, previous, select, tomono or any of the supported stereomodes (off, split_vertical, split_horizontal, row_interleaved, hardware_based, anaglyph_cyan_red, anaglyph_green_magenta, anaglyph_yellow_blue, monoscopic)", 1, SetStereoMode}},
            {"takescreenshot",                 {"Takes a Screenshot", 0, Screenshot}},
-           {"toggledirtyregionvisualization", {"Enables/disables dirty-region visualization", 0, ToggleDirty}}
+           {"toggledirtyregionvisualization", {"Enables/disables dirty-region visualization", 0, ToggleDirty}},
+           {"control.resetgrouplist",         {"Resets a grouplist control's focus to its first item", 1, ResetGroupList}}
          };
 }

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -50,7 +50,14 @@ static int ResetGroupList(const std::vector<std::string>& params)
       CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindowOrDialog());
   if (window)
   {
-    CGUIControl* control = window->GetControl(atoi(params[0].c_str()));
+    int controlId = 0;
+    try {
+      controlId = std::stoi(params[0]);
+    } catch (const std::exception&) {
+      CLog::Log(LOGWARNING, "ResetGroupList: Invalid control ID '{}'", params[0]);
+      return 0;
+    }
+    CGUIControl* control = window->GetControl(controlId);
     if (control && control->GetControlType() == CGUIControl::GUICONTROL_GROUPLIST)
       if (static_cast<CGUIControlGroupList*>(control)->ResetFocusToFirstItem())
         CLog::Log(LOGDEBUG, "ResetGroupList: Reset grouplist {} to first item", params[0]);

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -48,7 +48,11 @@ static int ResetGroupList(const std::vector<std::string>& params)
 {
   CGUIWindow* window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow(
       CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindowOrDialog());
-  if (window)
+  if (!window)
+  {
+    CLog::Log(LOGWARNING, "ResetGroupList: No active window or dialog found");
+    return 0;
+  }
   {
     int controlId = 0;
     try {

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -55,7 +55,8 @@ static int ResetGroupList(const std::vector<std::string>& params)
       if (static_cast<CGUIControlGroupList*>(control)->ResetFocusToFirstItem())
         CLog::Log(LOGDEBUG, "ResetGroupList: Reset grouplist {} to first item", params[0]);
       else
-        CLog::Log(LOGWARNING, "ResetGroupList: No focusable controls found in grouplist {}", params[0]);
+        CLog::Log(LOGWARNING, "ResetGroupList: No focusable controls found in grouplist {}",
+                  params[0]);
   }
 
   return 0;

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -55,7 +55,8 @@ static int ResetGroupList(const std::vector<std::string>& params)
   }
   {
     int controlId = 0;
-    try {
+    try
+    {
       controlId = std::stoi(params[0]);
     } catch (const std::exception&) {
       CLog::Log(LOGWARNING, "ResetGroupList: Invalid control ID '{}'", params[0]);

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -58,7 +58,9 @@ static int ResetGroupList(const std::vector<std::string>& params)
     try
     {
       controlId = std::stoi(params[0]);
-    } catch (const std::exception&) {
+    }
+    catch (const std::exception&)
+    {
       CLog::Log(LOGWARNING, "ResetGroupList: Invalid control ID '{}'", params[0]);
       return 0;
     }

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -62,12 +62,21 @@ static int ResetGroupList(const std::vector<std::string>& params)
       return 0;
     }
     CGUIControl* control = window->GetControl(controlId);
-    if (control && control->GetControlType() == CGUIControl::GUICONTROL_GROUPLIST)
-      if (static_cast<CGUIControlGroupList*>(control)->ResetFocusToFirstItem())
-        CLog::Log(LOGDEBUG, "ResetGroupList: Reset grouplist {} to first item", params[0]);
-      else
-        CLog::Log(LOGWARNING, "ResetGroupList: No focusable controls found in grouplist {}",
-                  params[0]);
+    if (!control)
+    {
+      CLog::Log(LOGWARNING, "ResetGroupList: Control {} not found", params[0]);
+      return 0;
+    }
+    if (control->GetControlType() != CGUIControl::GUICONTROL_GROUPLIST)
+    {
+      CLog::Log(LOGWARNING, "ResetGroupList: Control {} is not a grouplist", params[0]);
+      return 0;
+    }
+    if (static_cast<CGUIControlGroupList*>(control)->ResetFocusToFirstItem())
+      CLog::Log(LOGDEBUG, "ResetGroupList: Reset grouplist {} to first item", params[0]);
+    else
+      CLog::Log(LOGWARNING, "ResetGroupList: No focusable controls found in grouplist {}",
+                params[0]);
   }
 
   return 0;

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -16,6 +16,7 @@
 #include "dialogs/GUIDialogNumeric.h"
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
+#include "guilib/GUIControlGroupList.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/StereoscopicsManager.h"
 #include "input/WindowTranslator.h"
@@ -39,6 +40,51 @@ using namespace KODI;
 
 namespace
 {
+/*! \brief Reset a grouplist control's focus to its first item.
+ *  \param params The parameters.
+ *  \details params[0] = The control ID of the grouplist to reset.
+ */
+static int ResetGroupList(const std::vector<std::string>& params)
+{
+  CGUIWindow* window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow(
+      CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindowOrDialog());
+  if (!window)
+  {
+    CLog::Log(LOGWARNING, "ResetGroupList: No active window or dialog found");
+    return 0;
+  }
+  {
+    int controlId = 0;
+    try
+    {
+      controlId = std::stoi(params[0]);
+    }
+    catch (const std::exception&)
+    {
+      CLog::Log(LOGWARNING, "ResetGroupList: Invalid control ID '{}'", params[0]);
+      return 0;
+    }
+    CGUIControl* control = window->GetControl(controlId);
+    if (!control)
+    {
+      CLog::Log(LOGWARNING, "ResetGroupList: Control {} not found", params[0]);
+      return 0;
+    }
+    if (control->GetControlType() != CGUIControl::GUICONTROL_GROUPLIST)
+    {
+      CLog::Log(LOGWARNING, "ResetGroupList: Control {} is not a grouplist", params[0]);
+      return 0;
+    }
+    if (static_cast<CGUIControlGroupList*>(control)->ResetFocusToFirstItem())
+      CLog::Log(LOGDEBUG, "ResetGroupList: Reset grouplist {} to first item", params[0]);
+    else
+      CLog::Log(LOGWARNING, "ResetGroupList: No focusable controls found in grouplist {}",
+                params[0]);
+  }
+
+  return 0;
+}
+
 /*! \brief Execute a GUI action.
  *  \param params The parameters.
  *  \details params[0] = Action to execute.
@@ -581,27 +627,51 @@ static int ToggleDirty(const std::vector<std::string>&)
 ///     ,
 ///     makes dirty regions visible for debugging proposes.
 ///   }
+///   \table_row2_l{
+///     <b>`Control.ResetGroupList(id)`</b>
+///     ,
+///     Resets a grouplist control's focus to its first item and scrolls back to the top.
+///     @param[in] id                    The control ID of the grouplist to reset.
+///   }
 ///  \table_end
 ///
 
 CBuiltins::CommandMap CGUIBuiltins::GetOperations() const
 {
   return {
-           {"action",                         {"Executes an action for the active window (same as in keymap)", 1, Action}},
-           {"cancelalarm",                    {"Cancels an alarm", 1, CancelAlarm}},
-           {"alarmclock",                     {"Prompt for a length of time and start an alarm clock", 2, AlarmClock}},
-           {"activatewindow",                 {"Activate the specified window", 1, ActivateWindow<false>}},
-           {"activatewindowandfocus",         {"Activate the specified window and sets focus to the specified id", 1, ActivateAndFocus<false>}},
-           {"clearproperty",                  {"Clears a window property for the current focused window/dialog (key,value)", 1, ClearProperty}},
-           {"dialog.close",                   {"Close a dialog", 1, CloseDialog}},
-           {"notification",                   {"Shows a notification on screen, specify header, then message, and optionally time in milliseconds and a icon.", 2, Notification}},
-           {"refreshrss",                     {"Reload RSS feeds from RSSFeeds.xml", 0, RefreshRSS}},
-           {"replacewindow",                  {"Replaces the current window with the new one", 1, ActivateWindow<true>}},
-           {"replacewindowandfocus",          {"Replaces the current window with the new one and sets focus to the specified id", 1, ActivateAndFocus<true>}},
-           {"setguilanguage",                 {"Set GUI Language", 1, SetLanguage}},
-           {"setproperty",                    {"Sets a window property for the current focused window/dialog (key,value)", 2, SetProperty}},
-           {"setstereomode",                  {"Changes the stereo mode of the GUI. Params can be: toggle, next, previous, select, tomono or any of the supported stereomodes (off, split_vertical, split_horizontal, row_interleaved, hardware_based, anaglyph_cyan_red, anaglyph_green_magenta, anaglyph_yellow_blue, monoscopic)", 1, SetStereoMode}},
-           {"takescreenshot",                 {"Takes a Screenshot", 0, Screenshot}},
-           {"toggledirtyregionvisualization", {"Enables/disables dirty-region visualization", 0, ToggleDirty}}
-         };
+      {"action", {"Executes an action for the active window (same as in keymap)", 1, Action}},
+      {"cancelalarm", {"Cancels an alarm", 1, CancelAlarm}},
+      {"alarmclock", {"Prompt for a length of time and start an alarm clock", 2, AlarmClock}},
+      {"activatewindow", {"Activate the specified window", 1, ActivateWindow<false>}},
+      {"activatewindowandfocus",
+       {"Activate the specified window and sets focus to the specified id", 1,
+        ActivateAndFocus<false>}},
+      {"clearproperty",
+       {"Clears a window property for the current focused window/dialog (key,value)", 1,
+        ClearProperty}},
+      {"dialog.close", {"Close a dialog", 1, CloseDialog}},
+      {"notification",
+       {"Shows a notification on screen, specify header, then message, and optionally time in "
+        "milliseconds and a icon.",
+        2, Notification}},
+      {"refreshrss", {"Reload RSS feeds from RSSFeeds.xml", 0, RefreshRSS}},
+      {"replacewindow", {"Replaces the current window with the new one", 1, ActivateWindow<true>}},
+      {"replacewindowandfocus",
+       {"Replaces the current window with the new one and sets focus to the specified id", 1,
+        ActivateAndFocus<true>}},
+      {"setguilanguage", {"Set GUI Language", 1, SetLanguage}},
+      {"setproperty",
+       {"Sets a window property for the current focused window/dialog (key,value)", 2,
+        SetProperty}},
+      {"setstereomode",
+       {"Changes the stereo mode of the GUI. Params can be: toggle, next, previous, select, tomono "
+        "or any of the supported stereomodes (off, split_vertical, split_horizontal, "
+        "row_interleaved, hardware_based, anaglyph_cyan_red, anaglyph_green_magenta, "
+        "anaglyph_yellow_blue, monoscopic)",
+        1, SetStereoMode}},
+      {"takescreenshot", {"Takes a Screenshot", 0, Screenshot}},
+      {"toggledirtyregionvisualization",
+       {"Enables/disables dirty-region visualization", 0, ToggleDirty}},
+      {"control.resetgrouplist",
+       {"Resets a grouplist control's focus to its first item", 1, ResetGroupList}}};
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add a ResetFocusToFirstItem method to CGUIControlGroupList (declared in GUIControlGroupList.h and implemented in GUIControlGroupList.cpp) which moves focus to the first focusable control. Expose this as a new builtin command Control.ResetGrouplist(ID) in GUIBuiltins.cpp (with a small doc comment), plus the necessary include, so skins and scripts can reset a grouplist's focus position by using its ID.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Allows skinners to reset the last focused item in a grouplist.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally on Windows 11 (test build [here](https://mirrors.kodi.tv/test-builds/windows/win64/KodiSetup-20260506-d1eddd8e-reset_grouplist_focus_position-x64.exe))

To test add `<onleft>Control.ResetGroupList(9000)</onleft>` just after `<pagecontrol>$PARAM[list_id]600</pagecontrol>` in `skin.estuary\xml\View_50_List.xml`.
Navigate to Movies, Select Viewtype - List, navigate left to the media menu, move to any control, navigate away from the media menu and then return. The first item is selected.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
