### PR TITLE
Bluray iso cache v2

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayIsoCache.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayIsoCache.cpp
@@ -1,0 +1,364 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "BlurayIsoCache.h"
+
+#include "utils/log.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+
+namespace
+{
+constexpr const char* LOG_TAG = "CBlurayIsoCache";
+}
+
+CBlurayIsoCache::CBlurayIsoCache(int64_t sourceLength, ReadCallback readCallback, Config config)
+  : m_config(std::move(config)),
+    m_readCallback(std::move(readCallback)),
+    m_sourceLength(sourceLength)
+{
+  if (m_config.pageSize < BLOCK_SIZE)
+    m_config.pageSize = BLOCK_SIZE;
+
+  const size_t remainder = m_config.pageSize % BLOCK_SIZE;
+  if (remainder != 0)
+    m_config.pageSize += BLOCK_SIZE - remainder;
+
+  if (m_config.maxBytes < m_config.pageSize)
+    m_config.maxBytes = m_config.pageSize;
+
+  m_maxPages = std::max<size_t>(1, m_config.maxBytes / m_config.pageSize);
+}
+
+CBlurayIsoCache::~CBlurayIsoCache()
+{
+  Stop();
+}
+
+void CBlurayIsoCache::Start()
+{
+  Stop();
+
+  if (m_sourceLength <= 0 || !m_readCallback)
+  {
+    CLog::Log(LOGDEBUG, "{}::{} - disable cache, invalid source length {}", LOG_TAG, __FUNCTION__,
+              m_sourceLength);
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(m_queueMutex);
+    m_stopWorker = false;
+    m_prefetchEnabled = true;
+  }
+
+  m_worker = std::thread(&CBlurayIsoCache::Worker, this);
+  m_started = true;
+
+  CLog::Log(LOGDEBUG, "{}::{} - cache config pageSize={} maxBytes={} maxPages={} forwardPages={}",
+            LOG_TAG, __FUNCTION__, m_config.pageSize, m_config.maxBytes, m_maxPages,
+            m_config.forwardPrefetchPages);
+
+  CLog::Log(LOGINFO, "{}::{} - Bluray ISO cache started for {} bytes source", LOG_TAG, __FUNCTION__,
+            m_sourceLength);
+}
+
+void CBlurayIsoCache::Stop()
+{
+  if (m_started)
+    LogStats("stop");
+
+  {
+    std::lock_guard<std::mutex> lock(m_queueMutex);
+    m_stopWorker = true;
+    m_prefetchEnabled = false;
+    m_prefetchQueue.clear();
+    m_prefetchQueuedPages.clear();
+  }
+  m_queueChanged.notify_all();
+
+  if (m_worker.joinable())
+    m_worker.join();
+
+  {
+    std::lock_guard<std::mutex> cacheLock(m_cacheMutex);
+    m_pages.clear();
+    m_lruOrder.clear();
+  }
+
+  ResetAccessPattern();
+  m_started = false;
+}
+
+void CBlurayIsoCache::ResetAccessPattern()
+{
+  std::lock_guard<std::mutex> lock(m_accessMutex);
+  m_lastReadEndPage = -1;
+}
+
+int CBlurayIsoCache::ReadBlocks(uint8_t* buffer, int lba, int numBlocks)
+{
+  if (!buffer || lba < 0 || numBlocks <= 0)
+    return -1;
+
+  ++m_readRequests;
+  m_requestedBlocks += static_cast<uint64_t>(numBlocks);
+
+  const int64_t offset = static_cast<int64_t>(lba) * BLOCK_SIZE;
+  const int64_t requestedBytes = static_cast<int64_t>(numBlocks) * BLOCK_SIZE;
+  if (offset < 0 || requestedBytes <= 0 || offset >= m_sourceLength)
+    return -1;
+
+  const int64_t availableBytes = std::min<int64_t>(requestedBytes, m_sourceLength - offset);
+  const int64_t firstPage = offset / static_cast<int64_t>(m_config.pageSize);
+  const int64_t lastPage = (offset + availableBytes - 1) / static_cast<int64_t>(m_config.pageSize);
+
+  int64_t copied = 0;
+  for (int64_t pageIndex = firstPage; pageIndex <= lastPage; ++pageIndex)
+  {
+    PagePtr page = GetPage(pageIndex);
+    if (!page)
+    {
+      ++m_pageMisses;
+      page = LoadPage(pageIndex, false);
+    }
+    else
+      ++m_pageHits;
+
+    if (!page)
+      return copied > 0 ? static_cast<int>(copied / BLOCK_SIZE) : -1;
+
+    const int64_t pageStart = pageIndex * static_cast<int64_t>(m_config.pageSize);
+    const int64_t copyStart = std::max<int64_t>(offset, pageStart);
+    const int64_t copyEnd = std::min<int64_t>(offset + availableBytes,
+                                              pageStart + static_cast<int64_t>(page->validBytes));
+    if (copyEnd <= copyStart)
+      break;
+
+    const size_t pageOffset = static_cast<size_t>(copyStart - pageStart);
+    const size_t chunk = static_cast<size_t>(copyEnd - copyStart);
+    std::memcpy(buffer + copied, page->data.data() + pageOffset, chunk);
+    copied += static_cast<int64_t>(chunk);
+  }
+
+  if (copied <= 0)
+    return -1;
+
+  QueueForwardPrefetch(firstPage, lastPage);
+  {
+    std::lock_guard<std::mutex> lock(m_accessMutex);
+    m_lastReadEndPage = lastPage;
+  }
+
+  return static_cast<int>(copied / BLOCK_SIZE);
+}
+
+CBlurayIsoCache::PagePtr CBlurayIsoCache::GetPage(int64_t pageIndex)
+{
+  std::lock_guard<std::mutex> lock(m_cacheMutex);
+  auto it = m_pages.find(pageIndex);
+  if (it == m_pages.end())
+    return nullptr;
+
+  TouchPageUnlocked(it);
+  return it->second.page;
+}
+
+CBlurayIsoCache::PagePtr CBlurayIsoCache::LoadPage(int64_t pageIndex, bool prefetch)
+{
+  if (!IsValidPageIndex(pageIndex) || !m_readCallback)
+    return nullptr;
+
+  auto page = std::make_shared<Page>();
+  page->data.resize(m_config.pageSize);
+
+  const int64_t offset = pageIndex * static_cast<int64_t>(m_config.pageSize);
+  const size_t bytesToRead = static_cast<size_t>(
+      std::min<int64_t>(static_cast<int64_t>(m_config.pageSize), m_sourceLength - offset));
+  const int64_t bytesRead = m_readCallback(offset, page->data.data(), bytesToRead);
+  if (bytesRead <= 0)
+    return nullptr;
+
+  if (static_cast<size_t>(bytesRead) > bytesToRead ||
+      static_cast<size_t>(bytesRead) > page->data.size())
+  {
+    CLog::Log(LOGERROR, "{}::{} - callback returned {} bytes, expected {} to at most {}", LOG_TAG,
+              __FUNCTION__, bytesRead, bytesToRead, page->data.size());
+    return nullptr;
+  }
+
+  page->validBytes = static_cast<size_t>(bytesRead);
+  InsertPage(pageIndex, page);
+
+  if (prefetch)
+    ++m_prefetchPageLoads;
+  else
+    ++m_syncPageLoads;
+
+  return page;
+}
+
+void CBlurayIsoCache::InsertPage(int64_t pageIndex, PagePtr page)
+{
+  if (!page)
+    return;
+
+  std::lock_guard<std::mutex> lock(m_cacheMutex);
+  auto it = m_pages.find(pageIndex);
+  if (it != m_pages.end())
+  {
+    it->second.page = std::move(page);
+    TouchPageUnlocked(it);
+    return;
+  }
+
+  m_lruOrder.push_front(pageIndex);
+  m_pages.emplace(pageIndex, CacheSlot{m_lruOrder.begin(), std::move(page)});
+  TrimUnlocked();
+}
+
+void CBlurayIsoCache::TouchPageUnlocked(std::unordered_map<int64_t, CacheSlot>::iterator it)
+{
+  if (it->second.lruIt != m_lruOrder.begin())
+    m_lruOrder.splice(m_lruOrder.begin(), m_lruOrder, it->second.lruIt);
+  it->second.lruIt = m_lruOrder.begin();
+}
+
+void CBlurayIsoCache::TrimUnlocked()
+{
+  while (m_pages.size() > m_maxPages && !m_lruOrder.empty())
+  {
+    const int64_t pageIndex = m_lruOrder.back();
+    m_lruOrder.pop_back();
+    m_pages.erase(pageIndex);
+    ++m_evictions;
+  }
+}
+
+void CBlurayIsoCache::LogStats(const char* reason)
+{
+  size_t cachedPages = 0;
+  {
+    std::lock_guard<std::mutex> lock(m_cacheMutex);
+    cachedPages = m_pages.size();
+  }
+
+  CLog::Log(LOGDEBUG,
+            "{}::{} - {} detail: reads={} reqBlocks={} pageHits={} misses={} syncLoads={} "
+            "pfLoads={} pfFails={} evicts={} fwdPfs={} pages={}",
+            LOG_TAG, __FUNCTION__, reason, m_readRequests.load(), m_requestedBlocks.load(),
+            m_pageHits.load(), m_pageMisses.load(), m_syncPageLoads.load(),
+            m_prefetchPageLoads.load(), m_prefetchFailures.load(), m_evictions.load(),
+            m_forwardPrefetchRequests.load(), cachedPages);
+
+  CLog::Log(LOGINFO,
+            "{}::{} - {}: {} reads, {} pageHits / {} pageMisses, {} pfLoads ({} failed), {} evicts",
+            LOG_TAG, __FUNCTION__, reason, m_readRequests.load(), m_pageHits.load(),
+            m_pageMisses.load(), m_prefetchPageLoads.load(), m_prefetchFailures.load(),
+            m_evictions.load());
+}
+
+void CBlurayIsoCache::QueueForwardPrefetch(int64_t firstPage, int64_t lastPage)
+{
+  if (m_config.forwardPrefetchPages == 0)
+    return;
+
+  bool sequential = false;
+  {
+    std::lock_guard<std::mutex> lock(m_accessMutex);
+    sequential = (m_lastReadEndPage < 0 ||
+                  (firstPage >= m_lastReadEndPage && firstPage <= (m_lastReadEndPage + 1)));
+  }
+
+  if (!sequential)
+    return;
+
+  ++m_forwardPrefetchRequests;
+  QueuePrefetchWindow(lastPage + 1, m_config.forwardPrefetchPages, true);
+}
+
+void CBlurayIsoCache::QueuePrefetchWindow(int64_t firstPage, size_t pageCount, bool highPriority)
+{
+  if (pageCount == 0)
+    return;
+
+  for (size_t i = 0; i < pageCount; ++i)
+  {
+    const int64_t pageIndex = firstPage + static_cast<int64_t>(i);
+    QueuePage(pageIndex, highPriority);
+  }
+}
+
+void CBlurayIsoCache::QueuePage(int64_t pageIndex, bool highPriority)
+{
+  if (!IsValidPageIndex(pageIndex))
+    return;
+
+  {
+    std::lock_guard<std::mutex> cacheLock(m_cacheMutex);
+    if (m_pages.find(pageIndex) != m_pages.end())
+      return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(m_queueMutex);
+    if (!m_prefetchEnabled || m_stopWorker)
+      return;
+    if (!m_prefetchQueuedPages.insert(pageIndex).second)
+      return;
+    if (highPriority)
+      m_prefetchQueue.push_front(pageIndex);
+    else
+      m_prefetchQueue.push_back(pageIndex);
+  }
+  m_queueChanged.notify_one();
+}
+
+void CBlurayIsoCache::Worker()
+{
+  while (true)
+  {
+    int64_t pageIndex = -1;
+    {
+      std::unique_lock<std::mutex> lock(m_queueMutex);
+      m_queueChanged.wait(lock, [this] { return m_stopWorker || !m_prefetchQueue.empty(); });
+      if (m_stopWorker && m_prefetchQueue.empty())
+        break;
+
+      pageIndex = m_prefetchQueue.front();
+      m_prefetchQueue.pop_front();
+      m_prefetchQueuedPages.erase(pageIndex);
+    }
+
+    {
+      std::lock_guard<std::mutex> cacheLock(m_cacheMutex);
+      if (m_pages.find(pageIndex) != m_pages.end())
+        continue;
+    }
+
+    if (!LoadPage(pageIndex, true))
+    {
+      ++m_prefetchFailures;
+      CLog::Log(LOGDEBUG, "{}::{} - failed prefetch page {}", LOG_TAG, __FUNCTION__, pageIndex);
+    }
+  }
+}
+
+bool CBlurayIsoCache::IsValidPageIndex(int64_t pageIndex) const
+{
+  return pageIndex >= 0 && pageIndex <= GetMaxPageIndex();
+}
+
+int64_t CBlurayIsoCache::GetMaxPageIndex() const
+{
+  if (m_sourceLength <= 0)
+    return -1;
+  return (m_sourceLength - 1) / static_cast<int64_t>(m_config.pageSize);
+}

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayIsoCache.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/BlurayIsoCache.h
@@ -1,0 +1,108 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+class CBlurayIsoCache
+{
+public:
+  static constexpr size_t BLOCK_SIZE = 2048;
+
+  struct Config
+  {
+    size_t pageSize{256 * 1024};
+    size_t maxBytes{64 * 1024 * 1024};
+    size_t forwardPrefetchPages{1};
+  };
+
+  using ReadCallback = std::function<int64_t(int64_t offset, uint8_t* buffer, size_t size)>;
+
+  CBlurayIsoCache(int64_t sourceLength, ReadCallback readCallback, Config config);
+  ~CBlurayIsoCache();
+
+  void Start();
+  void Stop();
+  void ResetAccessPattern();
+  int ReadBlocks(uint8_t* buffer, int lba, int numBlocks);
+
+private:
+  struct Page
+  {
+    std::vector<uint8_t> data;
+    size_t validBytes{0};
+  };
+
+  using PagePtr = std::shared_ptr<Page>;
+
+  struct CacheSlot
+  {
+    std::list<int64_t>::iterator lruIt;
+    PagePtr page;
+  };
+
+  PagePtr GetPage(int64_t pageIndex);
+  PagePtr LoadPage(int64_t pageIndex, bool prefetch);
+  void InsertPage(int64_t pageIndex, PagePtr page);
+  void TouchPageUnlocked(std::unordered_map<int64_t, CacheSlot>::iterator it);
+  void TrimUnlocked();
+  void LogStats(const char* reason);
+
+  void QueueForwardPrefetch(int64_t firstPage, int64_t lastPage);
+  void QueuePrefetchWindow(int64_t firstPage, size_t pageCount, bool highPriority);
+  void QueuePage(int64_t pageIndex, bool highPriority);
+  void Worker();
+
+  bool IsValidPageIndex(int64_t pageIndex) const;
+  int64_t GetMaxPageIndex() const;
+
+  Config m_config;
+  ReadCallback m_readCallback;
+  int64_t m_sourceLength{0};
+  size_t m_maxPages{1};
+
+  std::mutex m_cacheMutex;
+  std::list<int64_t> m_lruOrder;
+  std::unordered_map<int64_t, CacheSlot> m_pages;
+
+  std::mutex m_queueMutex;
+  std::condition_variable m_queueChanged;
+  std::deque<int64_t> m_prefetchQueue;
+  std::unordered_set<int64_t> m_prefetchQueuedPages;
+  std::thread m_worker;
+  bool m_stopWorker{false};
+  bool m_prefetchEnabled{false};
+  bool m_started{false};
+
+  std::mutex m_accessMutex;
+  int64_t m_lastReadEndPage{-1};
+
+  std::atomic<uint64_t> m_readRequests{0};
+  std::atomic<uint64_t> m_requestedBlocks{0};
+  std::atomic<uint64_t> m_pageHits{0};
+  std::atomic<uint64_t> m_pageMisses{0};
+  std::atomic<uint64_t> m_syncPageLoads{0};
+  std::atomic<uint64_t> m_prefetchPageLoads{0};
+  std::atomic<uint64_t> m_prefetchFailures{0};
+  std::atomic<uint64_t> m_evictions{0};
+  std::atomic<uint64_t> m_forwardPrefetchRequests{0};
+};

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/CMakeLists.txt
@@ -29,8 +29,10 @@ set(HEADERS BlurayStateSerializer.h
             InputStreamPVRRecording.h)
 
 if(TARGET ${APP_NAME_LC}::Bluray)
-  list(APPEND SOURCES DVDInputStreamBluray.cpp)
-  list(APPEND HEADERS DVDInputStreamBluray.h)
+  list(APPEND SOURCES BlurayIsoCache.cpp
+                      DVDInputStreamBluray.cpp)
+  list(APPEND HEADERS BlurayIsoCache.h
+                      DVDInputStreamBluray.h)
 endif()
 
 core_add_library(dvdinputstreams)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -8,6 +8,7 @@
 
 #include "DVDInputStreamBluray.h"
 
+#include "BlurayIsoCache.h"
 #include "DVDCodecs/Overlay/DVDOverlay.h"
 #include "DVDCodecs/Overlay/DVDOverlayImage.h"
 #include "IVideoPlayer.h"
@@ -16,6 +17,9 @@
 #include "URL.h"
 #include "filesystem/BlurayCallback.h"
 #include "filesystem/SpecialProtocol.h"
+#include "guilib/LocalizeStrings.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/DiscSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/Geometry.h"
@@ -399,6 +403,22 @@ void CDVDInputStreamBluray::Close()
 {
   FreeTitleInfo();
 
+  if (m_isoCacheFallbacks > 0)
+  {
+    CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::{} - ISO cache fallbacks {}", __FUNCTION__,
+              m_isoCacheFallbacks.load());
+  }
+
+  {
+    std::shared_ptr<CBlurayIsoCache> cache;
+    {
+      std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+      cache = std::move(m_isoCache);
+    }
+    if (cache)
+      cache->Stop();
+  }
+
   if(m_bd)
   {
     bd_register_overlay_proc(m_bd, nullptr, nullptr);
@@ -465,6 +485,11 @@ void CDVDInputStreamBluray::ProcessEvent() {
 
   case BD_EVENT_SEEK:
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_SEEK");
+    {
+      std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+      if (m_isoCache)
+        m_isoCache->ResetAccessPattern();
+    }
     //m_player->OnDVDNavResult(nullptr, 1);
     //bd_read_skip_still(m_bd);
     //m_hold = HOLD_HELD;
@@ -514,6 +539,11 @@ void CDVDInputStreamBluray::ProcessEvent() {
   case BD_EVENT_TITLE:
   {
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_TITLE {}", m_event.param);
+    {
+      std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+      if (m_isoCache)
+        m_isoCache->ResetAccessPattern();
+    }
     const BLURAY_DISC_INFO* disc_info = bd_get_disc_info(m_bd);
 
     m_menu = false;
@@ -536,6 +566,11 @@ void CDVDInputStreamBluray::ProcessEvent() {
   }
   case BD_EVENT_PLAYLIST:
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_PLAYLIST {}", m_event.param);
+    {
+      std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+      if (m_isoCache)
+        m_isoCache->ResetAccessPattern();
+    }
     m_playlist = m_event.param;
     FreeTitleInfo();
     m_titleInfo = bd_get_playlist_info(m_bd, m_playlist, m_angle);
@@ -543,6 +578,11 @@ void CDVDInputStreamBluray::ProcessEvent() {
 
   case BD_EVENT_PLAYITEM:
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_PLAYITEM {}", m_event.param);
+    {
+      std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+      if (m_isoCache)
+        m_isoCache->ResetAccessPattern();
+    }
     if (m_titleInfo && m_event.param < m_titleInfo->clip_count)
       m_clip = &m_titleInfo->clips[m_event.param];
     break;
@@ -697,19 +737,28 @@ int CDVDInputStreamBluray::Read(uint8_t* buf, int buf_size)
 
 int CDVDInputStreamBluray::ReadBlocks(uint8_t* buf, int lba, int num_blocks)
 {
-  CDVDInputStreamFile* lpstream = m_pstream.get();
-  if (!lpstream)
-    return -1;
-  int result = -1;
-  int64_t offset = static_cast<int64_t>(lba) * 2048;
-  std::unique_lock lock(m_readBlocksLock);
-  if (lpstream->Seek(offset, SEEK_SET) >= 0)
+  std::shared_ptr<CBlurayIsoCache> cache;
   {
-    int64_t size = static_cast<int64_t>(num_blocks) * 2048;
-    if (size <= std::numeric_limits<int>::max())
-      result = lpstream->Read(buf, static_cast<int>(size)) / 2048;
+    std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+    cache = m_isoCache;
   }
-  return result;
+  if (cache)
+  {
+    const int result = cache->ReadBlocks(buf, lba, num_blocks);
+    if (result >= 0)
+      return result;
+
+    ++m_isoCacheFallbacks;
+    if (m_isoCacheFallbacks <= 3 || (m_isoCacheFallbacks & (m_isoCacheFallbacks - 1)) == 0)
+    {
+      CLog::Log(
+          LOGDEBUG,
+          "CDVDInputStreamBluray::{} - cached read failed at lba {} blocks {}, falling back ({})",
+          __FUNCTION__, lba, num_blocks, m_isoCacheFallbacks.load());
+    }
+  }
+
+  return ReadBlocksDirect(buf, lba, num_blocks);
 }
 
 static uint8_t  clamp(double v)
@@ -1260,8 +1309,23 @@ void CDVDInputStreamBluray::SetupPlayerSettings()
 
 bool CDVDInputStreamBluray::OpenStream(CFileItem &item)
 {
-  m_pstream = std::make_unique<CDVDInputStreamFile>(
-      item, XFILE::READ_TRUNCATED | XFILE::READ_BITRATE | XFILE::READ_NO_CACHE);
+  CLog::Log(LOGINFO, "CDVDInputStreamBluray::{} - opening ISO stream for {}", __FUNCTION__,
+            CURL::GetRedacted(item.GetPath()));
+
+  {
+    std::shared_ptr<CBlurayIsoCache> cache;
+    {
+      std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+      cache = std::move(m_isoCache);
+    }
+    if (cache)
+      cache->Stop();
+  }
+
+  m_isoCacheFallbacks = 0;
+
+  m_pstream = std::make_unique<CDVDInputStreamFile>(item, READ_TRUNCATED | READ_BITRATE |
+                                                              READ_CHUNKED | READ_NO_CACHE);
 
   if (!m_pstream->Open())
   {
@@ -1270,7 +1334,88 @@ bool CDVDInputStreamBluray::OpenStream(CFileItem &item)
     return false;
   }
 
+  const int64_t sourceLength = m_pstream->GetLength();
+  if (sourceLength > 0)
+  {
+    const auto adv = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+    CBlurayIsoCache::Config cacheConfig{};
+    cacheConfig.pageSize = adv->m_blurayIsoCachePageSize;
+    cacheConfig.maxBytes = adv->m_blurayIsoCacheMaxBytes;
+    cacheConfig.forwardPrefetchPages = adv->m_blurayIsoCacheForwardPrefetchPages;
+
+    CLog::Log(LOGINFO, "CDVDInputStreamBluray::{} - enable Bluray ISO cache for {} ({} bytes)",
+              __FUNCTION__, CURL::GetRedacted(item.GetPath()), sourceLength);
+    m_isoCache = std::make_shared<CBlurayIsoCache>(
+        sourceLength, [this](int64_t offset, uint8_t* buffer, size_t size)
+        { return ReadRaw(offset, buffer, size); }, cacheConfig);
+    m_isoCache->Start();
+  }
+  else
+  {
+    CLog::Log(LOGINFO, "CDVDInputStreamBluray::{} - skip ISO cache, source length {}", __FUNCTION__,
+              sourceLength);
+  }
+
   return true;
+}
+
+int CDVDInputStreamBluray::ReadBlocksDirect(uint8_t* buf, int lba, int num_blocks)
+{
+  CDVDInputStreamFile* lpstream = m_pstream.get();
+  if (!lpstream)
+    return -1;
+
+  int result = -1;
+  int64_t offset = static_cast<int64_t>(lba) * 2048;
+
+  std::lock_guard lock(m_readBlocksLock);
+
+  if (lpstream->Seek(offset, SEEK_SET) >= 0)
+  {
+    int64_t size = static_cast<int64_t>(num_blocks) * 2048;
+    if (size <= std::numeric_limits<int>::max())
+    {
+      const int bytesRead = lpstream->Read(buf, static_cast<int>(size));
+      if (bytesRead < 0)
+      {
+        result = -1;
+      }
+      else
+      {
+        result = bytesRead / 2048;
+      }
+    }
+  }
+
+  return result;
+}
+
+int64_t CDVDInputStreamBluray::ReadRaw(int64_t offset, uint8_t* buffer, size_t size)
+{
+  CDVDInputStreamFile* lpstream = m_pstream.get();
+  if (!lpstream || !buffer || size == 0)
+    return -1;
+
+  if (size > static_cast<size_t>(std::numeric_limits<int>::max()))
+    return -1;
+
+  std::lock_guard lock(m_readBlocksLock);
+
+  if (lpstream->Seek(offset, SEEK_SET) < 0)
+    return -1;
+
+  size_t totalRead = 0;
+  while (totalRead < size)
+  {
+    int chunk = lpstream->Read(buffer + totalRead, static_cast<int>(size - totalRead));
+    if (chunk < 0)
+      return -1;
+    if (chunk == 0)
+      break;
+    totalRead += static_cast<size_t>(chunk);
+  }
+
+  return static_cast<int64_t>(totalRead > 0 ? totalRead : -1);
 }
 
 bool CDVDInputStreamBluray::GetState(std::string& xmlstate)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -8,6 +8,7 @@
 
 #include "DVDInputStreamBluray.h"
 
+#include "BlurayIsoCache.h"
 #include "DVDCodecs/Overlay/DVDOverlay.h"
 #include "DVDCodecs/Overlay/DVDOverlayImage.h"
 #include "IVideoPlayer.h"
@@ -415,6 +416,22 @@ void CDVDInputStreamBluray::Close()
 {
   FreeTitleInfo();
 
+  if (m_isoCacheFallbacks > 0)
+  {
+    CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::{} - ISO cache fallbacks {}", __FUNCTION__,
+              m_isoCacheFallbacks.load());
+  }
+
+  {
+    std::shared_ptr<CBlurayIsoCache> cache;
+    {
+      std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+      cache = std::move(m_isoCache);
+    }
+    if (cache)
+      cache->Stop();
+  }
+
   if(m_bd)
   {
     bd_register_overlay_proc(m_bd, nullptr, nullptr);
@@ -510,6 +527,11 @@ void CDVDInputStreamBluray::ProcessEvent() {
 
   case BD_EVENT_SEEK:
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_SEEK");
+    {
+      std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+      if (m_isoCache)
+        m_isoCache->ResetAccessPattern();
+    }
     //m_player->OnDVDNavResult(nullptr, 1);
     //bd_read_skip_still(m_bd);
     //m_hold = HOLD_HELD;
@@ -559,6 +581,11 @@ void CDVDInputStreamBluray::ProcessEvent() {
   case BD_EVENT_TITLE:
   {
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_TITLE {}", m_event.param);
+    {
+      std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+      if (m_isoCache)
+        m_isoCache->ResetAccessPattern();
+    }
     const BLURAY_DISC_INFO* disc_info = bd_get_disc_info(m_bd);
 
     m_menu = false;
@@ -581,6 +608,11 @@ void CDVDInputStreamBluray::ProcessEvent() {
   }
   case BD_EVENT_PLAYLIST:
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_PLAYLIST {}", m_event.param);
+    {
+      std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+      if (m_isoCache)
+        m_isoCache->ResetAccessPattern();
+    }
     m_playlist = m_event.param;
     FreeTitleInfo();
     m_titleInfo = bd_get_playlist_info(m_bd, m_playlist, m_angle);
@@ -588,6 +620,11 @@ void CDVDInputStreamBluray::ProcessEvent() {
 
   case BD_EVENT_PLAYITEM:
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_PLAYITEM {}", m_event.param);
+    {
+      std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+      if (m_isoCache)
+        m_isoCache->ResetAccessPattern();
+    }
     if (m_titleInfo && m_event.param < m_titleInfo->clip_count)
     {
       m_clip = &m_titleInfo->clips[m_event.param];
@@ -745,19 +782,28 @@ int CDVDInputStreamBluray::Read(uint8_t* buf, int buf_size)
 
 int CDVDInputStreamBluray::ReadBlocks(uint8_t* buf, int lba, int num_blocks)
 {
-  CDVDInputStreamFile* lpstream = m_pstream.get();
-  if (!lpstream)
-    return -1;
-  int result = -1;
-  int64_t offset = static_cast<int64_t>(lba) * 2048;
-  std::unique_lock lock(m_readBlocksLock);
-  if (lpstream->Seek(offset, SEEK_SET) >= 0)
+  std::shared_ptr<CBlurayIsoCache> cache;
   {
-    int64_t size = static_cast<int64_t>(num_blocks) * 2048;
-    if (size <= std::numeric_limits<int>::max())
-      result = lpstream->Read(buf, static_cast<int>(size)) / 2048;
+    std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+    cache = m_isoCache;
   }
-  return result;
+  if (cache)
+  {
+    const int result = cache->ReadBlocks(buf, lba, num_blocks);
+    if (result >= 0)
+      return result;
+
+    ++m_isoCacheFallbacks;
+    if (m_isoCacheFallbacks <= 3 || (m_isoCacheFallbacks & (m_isoCacheFallbacks - 1)) == 0)
+    {
+      CLog::Log(
+          LOGDEBUG,
+          "CDVDInputStreamBluray::{} - cached read failed at lba {} blocks {}, falling back ({})",
+          __FUNCTION__, lba, num_blocks, m_isoCacheFallbacks.load());
+    }
+  }
+
+  return ReadBlocksDirect(buf, lba, num_blocks);
 }
 
 static uint8_t  clamp(double v)
@@ -1344,7 +1390,7 @@ MenuType CDVDInputStreamBluray::GetSupportedMenuType()
   return MenuType::NONE;
 }
 
-void CDVDInputStreamBluray::SetupPlayerSettings()
+void CDVDInputStreamBluray::SetupPlayerSettings() const
 {
   int region = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_BLURAY_PLAYERREGION);
   if ( region != BLURAY_REGION_A
@@ -1388,8 +1434,24 @@ void CDVDInputStreamBluray::SetupPlayerSettings()
 
 bool CDVDInputStreamBluray::OpenStream(CFileItem &item)
 {
-  m_pstream = std::make_unique<CDVDInputStreamFile>(
-      item, XFILE::READ_TRUNCATED | XFILE::READ_BITRATE | XFILE::READ_NO_CACHE);
+  CLog::Log(LOGINFO, "CDVDInputStreamBluray::{} - opening ISO stream for {}", __FUNCTION__,
+            CURL::GetRedacted(item.GetPath()));
+
+  {
+    std::shared_ptr<CBlurayIsoCache> cache;
+    {
+      std::lock_guard<std::mutex> lock(m_isoCacheMutex);
+      cache = std::move(m_isoCache);
+    }
+    if (cache)
+      cache->Stop();
+  }
+
+  m_isoCacheFallbacks = 0;
+
+  m_pstream = std::make_unique<CDVDInputStreamFile>(item, XFILE::READ_TRUNCATED |
+                                                              XFILE::READ_BITRATE |
+                                                              XFILE::READ_NO_CACHE);
 
   if (!m_pstream->Open())
   {
@@ -1398,7 +1460,88 @@ bool CDVDInputStreamBluray::OpenStream(CFileItem &item)
     return false;
   }
 
+  const int64_t sourceLength = m_pstream->GetLength();
+  if (sourceLength > 0)
+  {
+    const auto adv = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+    CBlurayIsoCache::Config cacheConfig{};
+    cacheConfig.pageSize = adv->m_blurayIsoCachePageSize;
+    cacheConfig.maxBytes = adv->m_blurayIsoCacheMaxBytes;
+    cacheConfig.forwardPrefetchPages = adv->m_blurayIsoCacheForwardPrefetchPages;
+
+    CLog::Log(LOGINFO, "CDVDInputStreamBluray::{} - enable Bluray ISO cache for {} ({} bytes)",
+              __FUNCTION__, CURL::GetRedacted(item.GetPath()), sourceLength);
+    m_isoCache = std::make_shared<CBlurayIsoCache>(
+        sourceLength, [this](int64_t offset, uint8_t* buffer, size_t size)
+        { return ReadRaw(offset, buffer, size); }, cacheConfig);
+    m_isoCache->Start();
+  }
+  else
+  {
+    CLog::Log(LOGINFO, "CDVDInputStreamBluray::{} - skip ISO cache, source length {}", __FUNCTION__,
+              sourceLength);
+  }
+
   return true;
+}
+
+int CDVDInputStreamBluray::ReadBlocksDirect(uint8_t* buf, int lba, int num_blocks)
+{
+  CDVDInputStreamFile* lpstream = m_pstream.get();
+  if (!lpstream)
+    return -1;
+
+  int result = -1;
+  int64_t offset = static_cast<int64_t>(lba) * 2048;
+
+  std::lock_guard lock(m_readBlocksLock);
+
+  if (lpstream->Seek(offset, SEEK_SET) >= 0)
+  {
+    int64_t size = static_cast<int64_t>(num_blocks) * 2048;
+    if (size <= std::numeric_limits<int>::max())
+    {
+      const int bytesRead = lpstream->Read(buf, static_cast<int>(size));
+      if (bytesRead < 0)
+      {
+        result = -1;
+      }
+      else
+      {
+        result = bytesRead / 2048;
+      }
+    }
+  }
+
+  return result;
+}
+
+int64_t CDVDInputStreamBluray::ReadRaw(int64_t offset, uint8_t* buffer, size_t size)
+{
+  CDVDInputStreamFile* lpstream = m_pstream.get();
+  if (!lpstream || !buffer || size == 0)
+    return -1;
+
+  if (size > static_cast<size_t>(std::numeric_limits<int>::max()))
+    return -1;
+
+  std::lock_guard lock(m_readBlocksLock);
+
+  if (lpstream->Seek(offset, SEEK_SET) < 0)
+    return -1;
+
+  size_t totalRead = 0;
+  while (totalRead < size)
+  {
+    int chunk = lpstream->Read(buffer + totalRead, static_cast<int>(size - totalRead));
+    if (chunk < 0)
+      return -1;
+    if (chunk == 0)
+      break;
+    totalRead += static_cast<size_t>(chunk);
+  }
+
+  return static_cast<int64_t>(totalRead > 0 ? totalRead : -1);
 }
 
 bool CDVDInputStreamBluray::GetState(std::string& xmlstate)

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -12,9 +12,11 @@
 #include "DVDInputStream.h"
 #include "threads/CriticalSection.h"
 
+#include <atomic>
 #include <chrono>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <string>
 
 extern "C"
@@ -44,6 +46,7 @@ extern "C"
 #define HDMV_PID_IG_LAST          0x141f
 
 class CDVDOverlayImage;
+class CBlurayIsoCache;
 class IVideoPlayer;
 
 class CDVDInputStreamBluray
@@ -191,8 +194,13 @@ protected:
 
   private:
     bool OpenStream(CFileItem &item);
-    void SetupPlayerSettings();
+    int ReadBlocksDirect(uint8_t* buf, int lba, int num_blocks);
+    int64_t ReadRaw(int64_t offset, uint8_t* buffer, size_t size);
+    void SetupPlayerSettings() const;
     void FreeTitleInfo();
+    std::atomic<unsigned int> m_isoCacheFallbacks{0};
+    std::mutex m_isoCacheMutex;
+    std::shared_ptr<CBlurayIsoCache> m_isoCache;
     std::unique_ptr<CDVDInputStreamFile> m_pstream;
     std::string m_rootPath;
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -15,9 +15,11 @@
 #include "filesystem/UDFContext.h"
 #endif
 
+#include <atomic>
 #include <chrono>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 
@@ -48,6 +50,7 @@ extern "C"
 #define HDMV_PID_IG_LAST          0x141f
 
 class CDVDOverlayImage;
+class CBlurayIsoCache;
 class IVideoPlayer;
 
 class CDVDInputStreamBluray
@@ -207,7 +210,9 @@ protected:
 
   private:
     bool OpenStream(CFileItem &item);
-    void SetupPlayerSettings();
+    int ReadBlocksDirect(uint8_t* buf, int lba, int num_blocks);
+    int64_t ReadRaw(int64_t offset, uint8_t* buffer, size_t size);
+    void SetupPlayerSettings() const;
     void FreeTitleInfo();
     void FreeClipInfo();
 
@@ -232,6 +237,9 @@ protected:
      * \return True if the clip carries the stream, false otherwise
      */
     bool GetClipStreamLanguage(int pid, std::string& language) const;
+    std::atomic<unsigned int> m_isoCacheFallbacks{0};
+    std::mutex m_isoCacheMutex;
+    std::shared_ptr<CBlurayIsoCache> m_isoCache;
     std::unique_ptr<CDVDInputStreamFile> m_pstream;
     std::string m_rootPath;
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -231,6 +231,10 @@ void CAdvancedSettings::Initialize()
   m_videoDefaultLatency = 0.0;
   m_videoDefaultHdrExtraLatency = 0.0;
 
+  m_blurayIsoCachePageSize = 256 * 1024;
+  m_blurayIsoCacheMaxBytes = 64 * 1024 * 1024;
+  m_blurayIsoCacheForwardPrefetchPages = 1;
+
   m_musicUseTimeSeeking = true;
   m_musicTimeSeekForward = 10;
   m_musicTimeSeekBackward = -10;
@@ -867,6 +871,16 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
       XMLUtils::GetFloat(pVideoLatency, "hdrextradelay", m_videoDefaultHdrExtraLatency, -600.0f,
                          600.0f);
     }
+  }
+
+  pElement = pRootElement->FirstChildElement("blurayisocache");
+  if (pElement)
+  {
+    XMLUtils::GetUInt(pElement, "pagesize", m_blurayIsoCachePageSize, 2048, 1024 * 1024);
+    XMLUtils::GetUInt(pElement, "maxbytes", m_blurayIsoCacheMaxBytes, 256 * 1024,
+                      1024 * 1024 * 1024);
+    XMLUtils::GetUInt(pElement, "forwardprefetchpages", m_blurayIsoCacheForwardPrefetchPages, 0,
+                      16);
   }
 
   pElement = pRootElement->FirstChildElement("musiclibrary");

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -233,6 +233,10 @@ void CAdvancedSettings::Initialize()
   m_videoDefaultLatency = 0.0;
   m_videoDefaultHdrExtraLatency = 0.0;
 
+  m_blurayIsoCachePageSize = 256 * 1024;
+  m_blurayIsoCacheMaxBytes = 64 * 1024 * 1024;
+  m_blurayIsoCacheForwardPrefetchPages = 1;
+
   m_musicUseTimeSeeking = true;
   m_musicTimeSeekForward = 10;
   m_musicTimeSeekBackward = -10;
@@ -872,6 +876,16 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
       XMLUtils::GetFloat(pVideoLatency, "hdrextradelay", m_videoDefaultHdrExtraLatency, -600.0f,
                          600.0f);
     }
+  }
+
+  pElement = pRootElement->FirstChildElement("blurayisocache");
+  if (pElement)
+  {
+    XMLUtils::GetUInt(pElement, "pagesize", m_blurayIsoCachePageSize, 2048, 1024 * 1024);
+    XMLUtils::GetUInt(pElement, "maxbytes", m_blurayIsoCacheMaxBytes, 256 * 1024,
+                      1024 * 1024 * 1024);
+    XMLUtils::GetUInt(pElement, "forwardprefetchpages", m_blurayIsoCacheForwardPrefetchPages, 0,
+                      16);
   }
 
   pElement = pRootElement->FirstChildElement("musiclibrary");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -419,6 +419,11 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     uint32_t m_nfsTimeout;
     int m_nfsRetries;
 
+    // Bluray ISO cache settings
+    unsigned int m_blurayIsoCachePageSize;
+    unsigned int m_blurayIsoCacheMaxBytes;
+    unsigned int m_blurayIsoCacheForwardPrefetchPages;
+
   private:
     void Initialize();
     void Clear();

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -422,6 +422,11 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     uint32_t m_nfsTimeout;
     int m_nfsRetries;
 
+    // Bluray ISO cache settings
+    unsigned int m_blurayIsoCachePageSize;
+    unsigned int m_blurayIsoCacheMaxBytes;
+    unsigned int m_blurayIsoCacheForwardPrefetchPages;
+
   private:
     void Initialize();
     void Clear();


### PR DESCRIPTION
feat(bluray): add page-level LRU cache for Bluray ISO playback
Add CBlurayIsoCache as a dedicated 256KB-page / 64MB LRU cache
layer for Bluray ISO (stream mode), intercepting ReadBlocks()
in CDVDInputStreamBluray. The cache uses sync miss-read with
forward prefetch (1 page) on sequential detection. Falls back
to original direct read on error.

Key changes:

New files: BlurayIsoCache.h/cpp (page LRU + worker + stats)
DVDInputStreamBluray: Open() retains upstream original logic
(zero-overhead IsDiscImage() check); ReadBlocks() routes
through cache with fallback to ReadBlocksDirect(); ReadRaw()
handles partial reads from HTTP-based protocols
CMakeLists.txt: register new source files under BLURAY_FOUND
AdvancedSettings: XML-configurable pageSize/maxBytes/prefetch
Verified on CoreELEC Amlogic-ng (arm, Linux 4.9): SMB/NFS/dav/
Emby-videodb all achieve 99%+ hit rate with zero fallbacks.
Testing playback of Elio.2025.iso: loads 10–20 seconds faster.