### PR TITLE
Add forward and reverse frame stepping while paused

### DIFF
--- a/xbmc/SeekHandler.cpp
+++ b/xbmc/SeekHandler.cpp
@@ -286,11 +286,31 @@ bool CSeekHandler::OnAction(const CAction &action)
     case ACTION_SMALL_STEP_BACK:
     case ACTION_STEP_BACK:
     {
+      if (appPlayer->IsPausedPlayback() && appPlayer->HasVideo())
+      {
+        const float fps{CServiceBroker::GetDataCacheCore().GetVideoFps()};
+        if (fps > 1.0f)
+        {
+          const int64_t frameTimeMs{static_cast<int64_t>(std::lround(1000.0f / fps))};
+          const int64_t targetTimeMs{std::max(
+              appPlayer->GetMinTime(), appPlayer->GetTime() - std::max<int64_t>(1, frameTimeMs))};
+          appPlayer->SeekTime(targetTimeMs);
+          return true;
+        }
+        // Fall through to normal seek behavior if fps is invalid
+      }
+
       Seek(false, action.GetAmount(), action.GetRepeat(), false, type);
       return true;
     }
     case ACTION_STEP_FORWARD:
     {
+      if (appPlayer->IsPausedPlayback() && appPlayer->HasVideo())
+      {
+        appPlayer->FrameAdvance(1);
+        return true;
+      }
+
       Seek(true, action.GetAmount(), action.GetRepeat(), false, type);
       return true;
     }

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/input/action_ids.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/input/action_ids.h
@@ -80,10 +80,12 @@ enum ADDON_ACTION
   /// @brief <b>`19 `</b>: Toggle quick-access zoom modes. Can b used in videoFullScreen.zml window id=2005
   ADDON_ACTION_ASPECT_RATIO = 19,
 
-  /// @brief <b>`20 `</b>: Seek +1% in the movie. Can b used in videoFullScreen.xml window id=2005
+  /// @brief <b>`20 `</b>: Seek forward during video playback. While paused,
+  /// advance one frame. Can be used in videoFullScreen.xml window id=2005
   ADDON_ACTION_STEP_FORWARD = 20,
 
-  /// @brief <b>`21 `</b>: Seek -1% in the movie. Can b used in videoFullScreen.xml window id=2005
+  /// @brief <b>`21 `</b>: Seek backward during video playback. While paused,
+  /// step backward one frame. Can be used in videoFullScreen.xml window id=2005
   ADDON_ACTION_STEP_BACK = 21,
 
   /// @brief <b>`22 `</b>: Seek +10% in the movie. Can b used in videoFullScreen.xml window id=2005
@@ -243,7 +245,8 @@ enum ADDON_ACTION
   /// @brief <b>`71 `</b>: Resolution select.
   ADDON_ACTION_PLAYER_RESOLUTION_SELECT = 71,
 
-  /// @brief <b>`76 `</b>: Jumps a few seconds back during playback of movie. Can b used in videoFullScreen.xml window id=2005
+  /// @brief <b>`76 `</b>: Jumps a few seconds back during video playback. While
+  /// paused, steps backward one frame. Can be used in videoFullScreen.xml window id=2005
   ADDON_ACTION_SMALL_STEP_BACK = 76,
 
   /// @brief <b>`77 `</b>: FF in current file played. global action, can be used anywhere

--- a/xbmc/input/actions/ActionIDs.h
+++ b/xbmc/input/actions/ActionIDs.h
@@ -48,10 +48,12 @@ constexpr const int ACTION_SHOW_GUI = 18;
 //! Toggle quick-access zoom modes. Can be used in videoFullScreen.zml window id=2005
 constexpr const int ACTION_ASPECT_RATIO = 19;
 
-//! Seek +1% in the movie. Can be used in videoFullScreen.xml window id=2005
+//! Seek forward during video playback. While paused, advance one frame.
+//! Can be used in videoFullScreen.xml window id=2005
 constexpr const int ACTION_STEP_FORWARD = 20;
 
-//! Seek -1% in the movie. Can be used in videoFullScreen.xml window id=2005
+//! Seek backward during video playback. While paused, step backward one frame.
+//! Can be used in videoFullScreen.xml window id=2005
 constexpr const int ACTION_STEP_BACK = 21;
 
 //! Seek +10% in the movie. Can be used in videoFullScreen.xml window id=2005
@@ -217,8 +219,8 @@ constexpr const int ACTION_PLAYER_PROGRAM_SELECT = 70;
 
 constexpr const int ACTION_PLAYER_RESOLUTION_SELECT = 71;
 
-//! Jumps a few seconds back during playback of movie. Can be used in videoFullScreen.xml
-//! window id=2005
+//! Jumps a few seconds back during video playback. While paused, steps backward one frame.
+//! Can be used in videoFullScreen.xml window id=2005
 constexpr const int ACTION_SMALL_STEP_BACK = 76;
 
 //! FF in current file played. global action, can be used anywhere


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. --> While video playback is paused the ACTION_STEP_FORWARD and ACTION_STEP_BACK actions are repurposed for frame stepping forwards and backwards.  Each press will move forward/backward a single frame.  Normal stepping behaviour is restored once you resume normal playback.


## Motivation and context
<!--- Why is this change required? What problem does it solve? --> Mainly adds reverse frame stepping capability, though repurposing the skip ahead/back actions while paused seems logical to me.
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. --> Played back several videos, tried skipping ahead/back, paused and tried frame stepping ahead/back, resumed playback and tried skipping ahead/back again to ensure normal behaviour had returned.
<!--- Include details of your testing environment, and the tests you ran to --> Windows 11
<!--- see how your change affects other areas of the code, etc. --> I don't think it should have any effect other than skipping ahead/back behaviour is changed while paused.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. --> Will allow stepping through frame by frame in both forward and reverse.
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
