### PR TITLE
Utils: Fix removing game extensions failing when VFS add-ons are present

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -292,12 +292,12 @@ void URIUtils::RemoveExtension(std::string& path)
   // Extensions to remove
   const std::string extensions{
       // clang-format off
-      CServiceBroker::GetFileExtensionProvider().GetPictureExtensions() +
-      CServiceBroker::GetFileExtensionProvider().GetMusicExtensions() +
-      CServiceBroker::GetFileExtensionProvider().GetVideoExtensions() +
-      CServiceBroker::GetFileExtensionProvider().GetSubtitleExtensions() +
-      CServiceBroker::GetFileExtensionProvider().GetCompoundArchiveExtensions() +
-      CServiceBroker::GetFileExtensionProvider().GetArchiveExtensions() +
+      CServiceBroker::GetFileExtensionProvider().GetPictureExtensions() + "|" +
+      CServiceBroker::GetFileExtensionProvider().GetMusicExtensions() + "|" +
+      CServiceBroker::GetFileExtensionProvider().GetVideoExtensions() + "|" +
+      CServiceBroker::GetFileExtensionProvider().GetSubtitleExtensions() + "|" +
+      CServiceBroker::GetFileExtensionProvider().GetCompoundArchiveExtensions() + "|" +
+      CServiceBroker::GetFileExtensionProvider().GetArchiveExtensions() + "|" +
       CServiceBroker::GetFileExtensionProvider().GetGameExtensions() +
       "|.py|.xml|.milk|.xbt|.cdg"
 #ifdef TARGET_DARWIN


### PR DESCRIPTION
## Description

This fixes a problem I caught when testing _with_ VFS add-ons present and auto-enabled on startup. The lack of separating `|` between extension lists causes the `.rom` extension, used in Game test cases, to not be properly removed.

## Motivation and context

Fixes test cases for my RetroPlayer builds, as I ship vfs.archive and vfs.rar for compressed roms out-of-the-box.

## How has this been tested?

Built VFS add-ons, and enabled them as such:

```patch
--- a/system/addon-manifest.xml
+++ b/system/addon-manifest.xml
@@ -72,6 +72,8 @@
   <addon optional="true">script.module.six</addon>
   <addon optional="true">script.module.urllib3</addon>
   <addon optional="true">service.xbmc.versioncheck</addon>
+  <addon optional="true">vfs.libarchive</addon>
+  <addon optional="true">vfs.rar</addon>
   <addon optional="true">visualization.projectm</addon>
   <addon optional="true">weather.openmeteo</addon>
 </addons>
```

Before, on macOS:

```
[----------] Global test environment tear-down
[==========] 3188 tests from 257 test suites ran. (11202 ms total)
[  PASSED  ] 3186 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] TestGamesGUIInfo.InitCurrentItemSetsTitleFromFilesystemPath
[  FAILED  ] TestGamesGUIInfo.InitCurrentItemSetsTitleFromVfsHostnamePath

 2 FAILED TESTS
```

After:

```
[----------] Global test environment tear-down
[==========] 3188 tests from 257 test suites ran. (11100 ms total)
[  PASSED  ] 3188 tests.
```

## What is the effect on users?

* Probably nothing outside of the new Disc Manager

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
