### PR TITLE
RetroPlayer: Rename "1:1 PAR" item to "square pixels"

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19085,10 +19085,10 @@ msgctxt "#35236"
 msgid "In this release, only controllers can be used to play games."
 msgstr ""
 
-#. Label of thumbnail in the in-game menu for normal size with 1:1 pixel aspect ratio (PAR)
+#. Label of thumbnail in the in-game menu for normal size with square pixels
 #: xbmc/games/dialogs/osd/DialogGameStretchMode.cpp
 msgctxt "#35237"
-msgid "Normal (1:1 PAR)"
+msgid "Square pixels"
 msgstr ""
 
 #. Label of thumbnail in the in-game menu for integer underscaling
@@ -19097,10 +19097,10 @@ msgctxt "#35238"
 msgid "Integer"
 msgstr ""
 
-#. Label of thumbnail in the in-game menu for integer underscaling with 1:1 pixel aspect ratio (PAR)
+#. Label of thumbnail in the in-game menu for integer underscaling with square pixels
 #: xbmc/games/dialogs/osd/DialogGameStretchMode.cpp
 msgctxt "#35239"
-msgid "Integer (1:1 PAR)"
+msgid "Integer (square pixels)"
 msgstr ""
 
 #empty strings from id 35240 to 35248


### PR DESCRIPTION
## Description

The abbreviation "PAR" isn't clear to the user, and "1:1 pixel aspect ratio" is a videophile term. Much simpler to just say "square pixels", as that's what 1:1 entails.

## Motivation and context

Make UI more accessible.

## What is the effect on users?

* Shaders are new in v22, haven't been released yet

## Screenshots (if appropriate):

Before:

<img width="1729" height="978" alt="Screenshot 2026-05-06 at 7 26 50 PM" src="https://github.com/user-attachments/assets/de43bfd4-e4a5-402b-8292-38fffa2e3c80" />

<img width="1727" height="985" alt="Screenshot 2026-05-06 at 7 27 02 PM" src="https://github.com/user-attachments/assets/0b245893-6505-474e-838d-150144f9f67d" />

After:

<img width="1726" height="980" alt="Screenshot 2026-05-06 at 7 20 22 PM" src="https://github.com/user-attachments/assets/bf6b34f9-de6c-40da-8f9f-c1dfba016d0b" />

<img width="1732" height="981" alt="Screenshot 2026-05-06 at 7 20 34 PM" src="https://github.com/user-attachments/assets/8f043ff9-7e3b-42e9-95ee-4ef0aeb59fc9" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
