### PR TITLE
[cmake] FindBluray use macos wrapper tool to detect java paths

### DIFF
--- a/cmake/modules/FindBluray.cmake
+++ b/cmake/modules/FindBluray.cmake
@@ -38,7 +38,20 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
 
         if(Java_Development_FOUND)
           get_filename_component(java_binpath ${Java_JAVAC_EXECUTABLE} DIRECTORY)
-          get_filename_component(java_homepath ${java_binpath} DIRECTORY)
+
+          # Apple hosts have a complicated potential combination of binary and include paths
+          # If on an apple host, fall back to using the /usr/libexec/java_home binary to search
+          # for path based on the found version in the find_package(Java) call.
+          # This avoids the issue when the java binary is found in /usr/bin, as apple has
+          # potential helpers that dont necessarily stem from JAVA_HOME env vars
+          if(CMAKE_HOST_APPLE)
+            execute_process(COMMAND /usr/libexec/java_home -v ${Java_VERSION}
+                            ERROR_QUIET
+                            OUTPUT_VARIABLE java_homepath
+                            OUTPUT_STRIP_TRAILING_WHITESPACE)
+          else()
+            get_filename_component(java_homepath ${java_binpath} DIRECTORY)
+          endif()
 
           get_target_property(ANT_PATH ANT::ANT ANT_PATH)
           get_target_property(ANT_HOME ANT::ANT ANT_HOME)


### PR DESCRIPTION
## Description
For macos hosts, use ``native`` tools to provide include paths for java installation found.

## Motivation and context
If java path found is ``/usr/bin/``, these are actually wrappers to other locations on a macos host.There are no include paths that would be found by get_filename_component()

On macos hosts, use ``/usr/libexec/java_home`` with the found version to get correct paths

The failure shows as

```
Host machine cpu family: aarch64
Host machine cpu: 
Target machine cpu family: aarch64
Target machine cpu: 
Run-time dependency appleframeworks found: YES (CoreFoundation, DiskArbitration)

meson.build:110:26: ERROR: Include dir /usr/include does not exist.
```

## How has this been tested?
Clean depends dir with java executables found in /usr/bin

```
build % which javac
/usr/bin/javac

```

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
