### PR TITLE
[cmake] ModuleHelpers dont set cache for _FOUND variables

### DIFF
--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -535,7 +535,7 @@ macro(BUILD_DEP_TARGET)
   set(${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_FOUND 1)
 
   string(TOUPPER "${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}" _search_upper)
-  set(${_search_upper}_FOUND ON CACHE BOOL "${_search_upper}_FOUND" FORCE)
+  set(${_search_upper}_FOUND 1)
   unset(_search_upper)
 endmacro()
 


### PR DESCRIPTION
## Description
Fix issue that may occur when cmake reconfigures after the internal ffmpeg build path is followed, but prior to an ffmpeg artifact being built.

I believe this is generally safe, as find modules (eg openssl, zlib) who require the ``<UPPERCASE>_FOUND`` variables are now explicitly set. No optional/required deps rely on the ``_FOUND``, as they have been migrated to targets. Buildtools still use the ``_FOUND``, but i dont believe are affected by these helpers currently.

## Motivation and context
FindFFMPEG utilises FFMPEG_FOUND to avoid specific paths. When this cache var is set from initial configure when building internal ffmpeg, if a subsequent reconfigure occurs prior to the ffmpeg libs being actually built, the cache var causes it to follow a path that only exists when actual libs can be found.

The errors caused report as the following on any subsequent reconfigure

```
CMake Error at cmake/modules/FindFFMPEG.cmake:471 (set_target_properties):
  set_target_properties Can not find target to add properties to:
  ffmpeg::libavutil
Call Stack (most recent call first):
  cmake/modules/FindFFMPEG.cmake:478 (ffmpeg_create_target)
  cmake/scripts/common/Macros.cmake:383 (find_package)
  cmake/scripts/common/Macros.cmake:395 (find_package_with_ver)
  CMakeLists.txt:299 (core_require_dep)
```

## How has this been tested?
Configure, change inconsequential line, forces reconfigure, now passes.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
