### PR TITLE
RetroPlayer: Improve code consistency and style

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.h
@@ -36,13 +36,11 @@ public:
   CRenderBufferDMA(CRenderContext& context, int fourcc);
   ~CRenderBufferDMA() override;
 
-  // implementation of IRenderBuffer via CRenderBufferSysMem
+  // Implementation of IRenderBuffer via CBaseRenderBuffer
   bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height) override;
   size_t GetFrameSize() const override;
   uint8_t* GetMemory() override;
   void ReleaseMemory() override;
-
-  // implementation of IRenderBuffer
   bool UploadTexture() override;
 
   GLuint TextureID() const { return m_textureId; }

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGL.cpp
@@ -13,13 +13,13 @@
 using namespace KODI;
 using namespace RETRO;
 
-CRenderBufferOpenGL::CRenderBufferOpenGL(GLuint pixeltype,
-                                         GLuint internalformat,
-                                         GLuint pixelformat,
+CRenderBufferOpenGL::CRenderBufferOpenGL(GLuint pixelType,
+                                         GLuint internalFormat,
+                                         GLuint pixelFormat,
                                          GLuint bpp)
-  : m_pixeltype(pixeltype),
-    m_internalformat(internalformat),
-    m_pixelformat(pixelformat),
+  : m_pixelType(pixelType),
+    m_internalFormat(internalFormat),
+    m_pixelFormat(pixelFormat),
     m_bpp(bpp)
 {
 }
@@ -35,8 +35,8 @@ void CRenderBufferOpenGL::CreateTexture()
 
   glBindTexture(m_textureTarget, m_textureId);
 
-  glTexImage2D(m_textureTarget, 0, m_internalformat, m_width, m_height, 0, m_pixelformat,
-               m_pixeltype, NULL);
+  glTexImage2D(m_textureTarget, 0, m_internalFormat, m_width, m_height, 0, m_pixelFormat,
+               m_pixelType, NULL);
 
   glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -63,10 +63,10 @@ bool CRenderBufferOpenGL::UploadTexture()
   //! We want to use PBO's instead of glTexSubImage2D!
   //! This code has been borrowed from OpenGL ES in order
   //! to remove GL dependencies on GLES.
-  glTexSubImage2D(m_textureTarget, 0, 0, 0, m_width, m_height, m_pixelformat, m_pixeltype,
+  glTexSubImage2D(m_textureTarget, 0, 0, 0, m_width, m_height, m_pixelFormat, m_pixelType,
                   m_data.data());
-  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
   return true;
 }
 

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGL.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGL.h
@@ -21,17 +21,19 @@ class CRenderContext;
 class CRenderBufferOpenGL : public CRenderBufferSysMem
 {
 public:
-  CRenderBufferOpenGL(GLuint pixeltype, GLuint internalformat, GLuint pixelformat, GLuint bpp);
+  CRenderBufferOpenGL(GLuint pixelType, GLuint internalFormat, GLuint pixelFormat, GLuint bpp);
   ~CRenderBufferOpenGL() override;
 
+  // Implementation of IRenderBuffer via CRenderBufferSysMem
   bool UploadTexture() override;
+
   GLuint TextureID() const { return m_textureId; }
 
 private:
   // Construction parameters
-  const GLuint m_pixeltype;
-  const GLuint m_internalformat;
-  const GLuint m_pixelformat;
+  const GLuint m_pixelType;
+  const GLuint m_internalFormat;
+  const GLuint m_pixelFormat;
   const GLuint m_bpp;
 
   const GLenum m_textureTarget = GL_TEXTURE_2D; //! @todo

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGLES.cpp
@@ -14,14 +14,14 @@ using namespace KODI;
 using namespace RETRO;
 
 CRenderBufferOpenGLES::CRenderBufferOpenGLES(CRenderContext& context,
-                                             GLuint pixeltype,
-                                             GLuint internalformat,
-                                             GLuint pixelformat,
+                                             GLuint pixelType,
+                                             GLuint internalFormat,
+                                             GLuint pixelFormat,
                                              GLuint bpp)
   : m_context(context),
-    m_pixeltype(pixeltype),
-    m_internalformat(internalformat),
-    m_pixelformat(pixelformat),
+    m_pixelType(pixelType),
+    m_internalFormat(internalFormat),
+    m_pixelFormat(pixelFormat),
     m_bpp(bpp)
 {
 }
@@ -37,8 +37,8 @@ void CRenderBufferOpenGLES::CreateTexture()
 
   glBindTexture(m_textureTarget, m_textureId);
 
-  glTexImage2D(m_textureTarget, 0, m_internalformat, m_width, m_height, 0, m_pixelformat,
-               m_pixeltype, NULL);
+  glTexImage2D(m_textureTarget, 0, m_internalFormat, m_width, m_height, 0, m_pixelFormat,
+               m_pixelType, NULL);
 
   glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -59,7 +59,7 @@ bool CRenderBufferOpenGLES::UploadTexture()
 
   glPixelStorei(GL_UNPACK_ALIGNMENT, m_bpp);
 
-  if (m_bpp == 4 && m_pixelformat == GL_RGBA)
+  if (m_bpp == 4 && m_pixelFormat == GL_RGBA)
   {
     // XOR Swap RGBA -> BGRA
     // GLES 2.0 doesn't support strided textures (unless GL_UNPACK_ROW_LENGTH_EXT is supported)
@@ -68,14 +68,14 @@ bool CRenderBufferOpenGLES::UploadTexture()
     {
       for (int x = 0; x < stride; x += 4)
         std::swap(pixels[x], pixels[x + 2]);
-      glTexSubImage2D(m_textureTarget, 0, 0, y, m_width, 1, m_pixelformat, m_pixeltype, pixels);
+      glTexSubImage2D(m_textureTarget, 0, 0, y, m_width, 1, m_pixelFormat, m_pixelType, pixels);
     }
   }
   else if (m_context.IsExtSupported("GL_EXT_unpack_subimage"))
   {
 #ifdef GL_UNPACK_ROW_LENGTH_EXT
     glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride / m_bpp);
-    glTexSubImage2D(m_textureTarget, 0, 0, 0, m_width, m_height, m_pixelformat, m_pixeltype,
+    glTexSubImage2D(m_textureTarget, 0, 0, 0, m_width, m_height, m_pixelFormat, m_pixelType,
                     m_data.data());
     glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, 0);
 #endif
@@ -84,7 +84,7 @@ bool CRenderBufferOpenGLES::UploadTexture()
   {
     uint8_t* pixels = const_cast<uint8_t*>(m_data.data());
     for (unsigned int y = 0; y < m_height; ++y, pixels += stride)
-      glTexSubImage2D(m_textureTarget, 0, 0, y, m_width, 1, m_pixelformat, m_pixeltype, pixels);
+      glTexSubImage2D(m_textureTarget, 0, 0, y, m_width, 1, m_pixelFormat, m_pixelType, pixels);
   }
 
   glBindTexture(m_textureTarget, 0);

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferOpenGLES.h
@@ -22,13 +22,13 @@ class CRenderBufferOpenGLES : public CRenderBufferSysMem
 {
 public:
   CRenderBufferOpenGLES(CRenderContext& context,
-                        GLuint pixeltype,
-                        GLuint internalformat,
-                        GLuint pixelformat,
+                        GLuint pixelType,
+                        GLuint internalFormat,
+                        GLuint pixelFormat,
                         GLuint bpp);
   ~CRenderBufferOpenGLES() override;
 
-  // implementation of IRenderBuffer via CRenderBufferSysMem
+  // Implementation of IRenderBuffer via CRenderBufferSysMem
   bool UploadTexture() override;
 
   GLuint TextureID() const { return m_textureId; }
@@ -36,9 +36,9 @@ public:
 private:
   // Construction parameters
   CRenderContext& m_context;
-  const GLuint m_pixeltype;
-  const GLuint m_internalformat;
-  const GLuint m_pixelformat;
+  const GLuint m_pixelType;
+  const GLuint m_internalFormat;
+  const GLuint m_pixelFormat;
   const GLuint m_bpp;
 
   const GLenum m_textureTarget = GL_TEXTURE_2D; //! @todo

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMA.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMA.h
@@ -27,14 +27,15 @@ public:
   CRenderBufferPoolDMA(CRenderContext& context);
   ~CRenderBufferPoolDMA() override = default;
 
-  // implementation of IRenderBufferPool via CBaseRenderBufferPool
+  // Implementation of IRenderBufferPool via CBaseRenderBufferPool
   bool IsCompatible(const CRenderVideoSettings& renderSettings) const override;
 
 protected:
-  // implementation of CBaseRenderBufferPool
+  // Implementation of CBaseRenderBufferPool
   IRenderBuffer* CreateRenderBuffer(void* header = nullptr) override;
   bool ConfigureInternal() override;
 
+private:
   // Construction parameters
   CRenderContext& m_context;
 

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGL.cpp
@@ -24,35 +24,35 @@ bool CRenderBufferPoolOpenGL::IsCompatible(const CRenderVideoSettings& renderSet
 
 IRenderBuffer* CRenderBufferPoolOpenGL::CreateRenderBuffer(void* header /* = nullptr */)
 {
-  return new CRenderBufferOpenGL(m_pixeltype, m_internalformat, m_pixelformat, m_bpp);
+  return new CRenderBufferOpenGL(m_pixelType, m_internalFormat, m_pixelFormat, m_bpp);
 }
 
 bool CRenderBufferPoolOpenGL::ConfigureInternal()
 {
-  // Configure CRenderBufferPoolOpenGLES
+  // Configure CRenderBufferPoolOpenGL
   switch (m_format)
   {
     case AV_PIX_FMT_0RGB32:
     {
-      m_pixeltype = GL_UNSIGNED_BYTE;
-      m_internalformat = GL_RGBA;
-      m_pixelformat = GL_BGRA;
+      m_pixelType = GL_UNSIGNED_BYTE;
+      m_internalFormat = GL_RGBA8;
+      m_pixelFormat = GL_BGRA;
       m_bpp = sizeof(uint32_t);
       return true;
     }
     case AV_PIX_FMT_RGB555:
     {
-      m_pixeltype = GL_UNSIGNED_SHORT_5_5_5_1;
-      m_internalformat = GL_RGB;
-      m_pixelformat = GL_RGB;
+      m_pixelType = GL_UNSIGNED_SHORT_5_5_5_1;
+      m_internalFormat = GL_RGB;
+      m_pixelFormat = GL_RGB;
       m_bpp = sizeof(uint16_t);
       return true;
     }
     case AV_PIX_FMT_RGB565:
     {
-      m_pixeltype = GL_UNSIGNED_SHORT_5_6_5;
-      m_internalformat = GL_RGB;
-      m_pixelformat = GL_RGB;
+      m_pixelType = GL_UNSIGNED_SHORT_5_6_5;
+      m_internalFormat = GL_RGB565;
+      m_pixelFormat = GL_RGB;
       m_bpp = sizeof(uint16_t);
       return true;
     }

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGL.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGL.h
@@ -26,19 +26,19 @@ public:
   CRenderBufferPoolOpenGL() = default;
   ~CRenderBufferPoolOpenGL() override = default;
 
-  // implementation of IRenderBufferPool via CBaseRenderBufferPool
+  // Implementation of IRenderBufferPool via CBaseRenderBufferPool
   bool IsCompatible(const CRenderVideoSettings& renderSettings) const override;
 
 protected:
-  // implementation of CBaseRenderBufferPool
+  // Implementation of CBaseRenderBufferPool
   IRenderBuffer* CreateRenderBuffer(void* header = nullptr) override;
   bool ConfigureInternal() override;
 
 private:
   // Configuration parameters
-  GLuint m_pixeltype = 0;
-  GLuint m_internalformat = 0;
-  GLuint m_pixelformat = 0;
+  GLuint m_pixelType = 0;
+  GLuint m_internalFormat = 0;
+  GLuint m_pixelFormat = 0;
   GLuint m_bpp = 0;
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.cpp
@@ -28,33 +28,34 @@ bool CRenderBufferPoolOpenGLES::IsCompatible(const CRenderVideoSettings& renderS
 
 IRenderBuffer* CRenderBufferPoolOpenGLES::CreateRenderBuffer(void* header /* = nullptr */)
 {
-  return new CRenderBufferOpenGLES(m_context, m_pixeltype, m_internalformat, m_pixelformat, m_bpp);
+  return new CRenderBufferOpenGLES(m_context, m_pixelType, m_internalFormat, m_pixelFormat, m_bpp);
 }
 
 bool CRenderBufferPoolOpenGLES::ConfigureInternal()
 {
+  // Configure CRenderBufferPoolOpenGLES
   switch (m_format)
   {
     case AV_PIX_FMT_0RGB32:
     {
-      m_pixeltype = GL_UNSIGNED_BYTE;
+      m_pixelType = GL_UNSIGNED_BYTE;
       if (m_context.IsExtSupported("GL_EXT_texture_format_BGRA8888") ||
           m_context.IsExtSupported("GL_IMG_texture_format_BGRA8888"))
       {
-        m_internalformat = GL_BGRA_EXT;
-        m_pixelformat = GL_BGRA_EXT;
+        m_internalFormat = GL_BGRA_EXT;
+        m_pixelFormat = GL_BGRA_EXT;
       }
       else if (m_context.IsExtSupported("GL_APPLE_texture_format_BGRA8888"))
       {
         // Apple's implementation does not conform to spec. Instead, they require
         // differing format/internalformat, more like GL.
-        m_internalformat = GL_RGBA;
-        m_pixelformat = GL_BGRA_EXT;
+        m_internalFormat = GL_RGBA;
+        m_pixelFormat = GL_BGRA_EXT;
       }
       else
       {
-        m_internalformat = GL_RGBA;
-        m_pixelformat = GL_RGBA;
+        m_internalFormat = GL_RGBA;
+        m_pixelFormat = GL_RGBA;
       }
       m_bpp = sizeof(uint32_t);
       return true;
@@ -62,9 +63,9 @@ bool CRenderBufferPoolOpenGLES::ConfigureInternal()
     case AV_PIX_FMT_RGB555:
     case AV_PIX_FMT_RGB565:
     {
-      m_pixeltype = GL_UNSIGNED_SHORT_5_6_5;
-      m_internalformat = GL_RGB;
-      m_pixelformat = GL_RGB;
+      m_pixelType = GL_UNSIGNED_SHORT_5_6_5;
+      m_internalFormat = GL_RGB;
+      m_pixelFormat = GL_RGB;
       m_bpp = sizeof(uint16_t);
       return true;
     }

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolOpenGLES.h
@@ -26,21 +26,22 @@ public:
   CRenderBufferPoolOpenGLES(CRenderContext& context);
   ~CRenderBufferPoolOpenGLES() override = default;
 
-  // implementation of IRenderBufferPool via CBaseRenderBufferPool
+  // Implementation of IRenderBufferPool via CBaseRenderBufferPool
   bool IsCompatible(const CRenderVideoSettings& renderSettings) const override;
 
-private:
-  // implementation of CBaseRenderBufferPool
+protected:
+  // Implementation of CBaseRenderBufferPool
   IRenderBuffer* CreateRenderBuffer(void* header = nullptr) override;
   bool ConfigureInternal() override;
 
+private:
   // Construction parameters
   CRenderContext& m_context;
 
   // Configuration parameters
-  GLuint m_pixeltype = 0;
-  GLuint m_internalformat = 0;
-  GLuint m_pixelformat = 0;
+  GLuint m_pixelType = 0;
+  GLuint m_internalFormat = 0;
+  GLuint m_pixelFormat = 0;
   GLuint m_bpp = 0;
 };
 } // namespace RETRO

--- a/xbmc/cores/RetroPlayer/buffers/video/RenderBufferGuiTexture.h
+++ b/xbmc/cores/RetroPlayer/buffers/video/RenderBufferGuiTexture.h
@@ -25,7 +25,7 @@ public:
   CRenderBufferGuiTexture(SCALINGMETHOD scalingMethod);
   ~CRenderBufferGuiTexture() override = default;
 
-  // implementation of IRenderBuffer via CBaseRenderBuffer
+  // Implementation of IRenderBuffer via CBaseRenderBuffer
   bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height) override;
   size_t GetFrameSize() const override;
   uint8_t* GetMemory() override;

--- a/xbmc/cores/RetroPlayer/buffers/video/RenderBufferSysMem.h
+++ b/xbmc/cores/RetroPlayer/buffers/video/RenderBufferSysMem.h
@@ -28,7 +28,7 @@ public:
   CRenderBufferSysMem() = default;
   ~CRenderBufferSysMem() override = default;
 
-  // implementation of IRenderBuffer
+  // Implementation of IRenderBuffer via CBaseRenderBuffer
   bool Allocate(AVPixelFormat format, unsigned int width, unsigned int height) override;
   size_t GetFrameSize() const override;
   uint8_t* GetMemory() override;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
@@ -21,6 +21,8 @@
 using namespace KODI;
 using namespace RETRO;
 
+// --- CRendererFactoryDMAOpenGL --------------------------------------------------
+
 std::string CRendererFactoryDMAOpenGL::RenderSystemName() const
 {
   return "DMAOpenGL";

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
@@ -78,8 +78,8 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
     m_RBTexturesMap.emplace(renderBuffer, rbTextures);
   }
 
-  std::shared_ptr<SHADER::CShaderTextureGLRef> source = rbTextures->source;
-  std::shared_ptr<SHADER::CShaderTextureGLRef> target = rbTextures->target;
+  std::shared_ptr<SHADER::CShaderTextureGLRef> sourceTexture = rbTextures->sourceTexture;
+  std::shared_ptr<SHADER::CShaderTextureGLRef> targetTexture = rbTextures->targetTexture;
 
   Updateshaders();
 
@@ -90,14 +90,14 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
     if (m_shaderPreset->GetPasses()[0].filterType == SHADER::FilterType::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, source->GetTextureID());
+    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     if (!m_shaderPreset->RenderUpdate(m_rotatedDestCoords, {m_fullDestWidth, m_fullDestHeight},
-                                      *source, *target))
+                                      *sourceTexture, *targetTexture))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
@@ -110,7 +110,7 @@ void CRPRendererDMAOpenGL::Render(uint8_t alpha)
     if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, source->GetTextureID());
+    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.h
@@ -23,7 +23,7 @@ class CRendererFactoryDMAOpenGL : public IRendererFactory
 public:
   ~CRendererFactoryDMAOpenGL() override = default;
 
-  // implementation of IRendererFactory
+  // Implementation of IRendererFactory
   std::string RenderSystemName() const override;
   CRPBaseRenderer* CreateRenderer(const CRenderSettings& settings,
                                   CRenderContext& context,

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -78,8 +78,8 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
     m_RBTexturesMap.emplace(renderBuffer, rbTextures);
   }
 
-  std::shared_ptr<SHADER::CShaderTextureGLESRef> source = rbTextures->source;
-  std::shared_ptr<SHADER::CShaderTextureGLESRef> target = rbTextures->target;
+  std::shared_ptr<SHADER::CShaderTextureGLESRef> sourceTexture = rbTextures->sourceTexture;
+  std::shared_ptr<SHADER::CShaderTextureGLESRef> targetTexture = rbTextures->targetTexture;
 
   Updateshaders();
 
@@ -90,14 +90,14 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
     if (m_shaderPreset->GetPasses()[0].filterType == SHADER::FilterType::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, source->GetTextureID());
+    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     if (!m_shaderPreset->RenderUpdate(m_rotatedDestCoords, {m_fullDestWidth, m_fullDestHeight},
-                                      *source, *target))
+                                      *sourceTexture, *targetTexture))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
@@ -110,7 +110,7 @@ void CRPRendererDMAOpenGLES::Render(uint8_t alpha)
     if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, source->GetTextureID());
+    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -21,6 +21,8 @@
 using namespace KODI;
 using namespace RETRO;
 
+// --- CRendererFactoryDMAOpenGLES ------------------------------------------------
+
 std::string CRendererFactoryDMAOpenGLES::RenderSystemName() const
 {
   return "DMAOpenGLES";

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.h
@@ -23,7 +23,7 @@ class CRendererFactoryDMAOpenGLES : public IRendererFactory
 public:
   ~CRendererFactoryDMAOpenGLES() override = default;
 
-  // implementation of IRendererFactory
+  // Implementation of IRendererFactory
   std::string RenderSystemName() const override;
   CRPBaseRenderer* CreateRenderer(const CRenderSettings& settings,
                                   CRenderContext& context,

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.cpp
@@ -307,8 +307,8 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
     m_RBTexturesMap.emplace(renderBuffer, rbTextures);
   }
 
-  std::shared_ptr<SHADER::CShaderTextureGLRef> source = rbTextures->source;
-  std::shared_ptr<SHADER::CShaderTextureGLRef> target = rbTextures->target;
+  std::shared_ptr<SHADER::CShaderTextureGLRef> sourceTexture = rbTextures->sourceTexture;
+  std::shared_ptr<SHADER::CShaderTextureGLRef> targetTexture = rbTextures->targetTexture;
 
   Updateshaders();
 
@@ -319,14 +319,14 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
     if (m_shaderPreset->GetPasses()[0].filterType == SHADER::FilterType::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, source->GetTextureID());
+    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     if (!m_shaderPreset->RenderUpdate(m_rotatedDestCoords, {m_fullDestWidth, m_fullDestHeight},
-                                      *source, *target))
+                                      *sourceTexture, *targetTexture))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
@@ -339,7 +339,7 @@ void CRPRendererOpenGL::Render(uint8_t alpha)
     if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, source->GetTextureID());
+    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -33,7 +33,7 @@ class CRendererFactoryOpenGL : public IRendererFactory
 public:
   ~CRendererFactoryOpenGL() override = default;
 
-  // implementation of IRendererFactory
+  // Implementation of IRendererFactory
   std::string RenderSystemName() const override;
   CRPBaseRenderer* CreateRenderer(const CRenderSettings& settings,
                                   CRenderContext& context,
@@ -49,7 +49,7 @@ public:
                     std::shared_ptr<IRenderBufferPool> bufferPool);
   ~CRPRendererOpenGL() override;
 
-  // implementation of CRPBaseRenderer
+  // Implementation of CRPBaseRenderer
   bool Supports(RENDERFEATURE feature) const override;
   SCALINGMETHOD GetDefaultScalingMethod() const override { return SCALINGMETHOD::NEAREST; }
 
@@ -75,7 +75,7 @@ protected:
     std::shared_ptr<SHADER::CShaderTextureGLRef> target;
   };
 
-  // implementation of CRPBaseRenderer
+  // Implementation of CRPBaseRenderer
   void RenderInternal(bool clear, uint8_t alpha) override;
   void FlushInternal() override;
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGL.h
@@ -71,8 +71,8 @@ protected:
 
   struct RenderBufferTextures
   {
-    std::shared_ptr<SHADER::CShaderTextureGLRef> source;
-    std::shared_ptr<SHADER::CShaderTextureGLRef> target;
+    std::shared_ptr<SHADER::CShaderTextureGLRef> sourceTexture;
+    std::shared_ptr<SHADER::CShaderTextureGLRef> targetTexture;
   };
 
   // Implementation of CRPBaseRenderer

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.cpp
@@ -275,8 +275,8 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
     m_RBTexturesMap.emplace(renderBuffer, rbTextures);
   }
 
-  std::shared_ptr<SHADER::CShaderTextureGLESRef> source = rbTextures->source;
-  std::shared_ptr<SHADER::CShaderTextureGLESRef> target = rbTextures->target;
+  std::shared_ptr<SHADER::CShaderTextureGLESRef> sourceTexture = rbTextures->sourceTexture;
+  std::shared_ptr<SHADER::CShaderTextureGLESRef> targetTexture = rbTextures->targetTexture;
 
   Updateshaders();
 
@@ -287,14 +287,14 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
     if (m_shaderPreset->GetPasses()[0].filterType == SHADER::FilterType::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, source->GetTextureID());
+    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     if (!m_shaderPreset->RenderUpdate(m_rotatedDestCoords, {m_fullDestWidth, m_fullDestHeight},
-                                      *source, *target))
+                                      *sourceTexture, *targetTexture))
     {
       m_bShadersNeedUpdate = false;
       m_bUseShaderPreset = false;
@@ -307,7 +307,7 @@ void CRPRendererOpenGLES::Render(uint8_t alpha)
     if (GetRenderSettings().VideoSettings().GetScalingMethod() == SCALINGMETHOD::LINEAR)
       filter = GL_LINEAR;
 
-    glBindTexture(m_textureTarget, source->GetTextureID());
+    glBindTexture(m_textureTarget, sourceTexture->GetTextureID());
     glTexParameteri(m_textureTarget, GL_TEXTURE_MAG_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_MIN_FILTER, filter);
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -33,7 +33,7 @@ class CRendererFactoryOpenGLES : public IRendererFactory
 public:
   ~CRendererFactoryOpenGLES() override = default;
 
-  // implementation of IRendererFactory
+  // Implementation of IRendererFactory
   std::string RenderSystemName() const override;
   CRPBaseRenderer* CreateRenderer(const CRenderSettings& settings,
                                   CRenderContext& context,
@@ -49,7 +49,7 @@ public:
                       std::shared_ptr<IRenderBufferPool> bufferPool);
   ~CRPRendererOpenGLES() override;
 
-  // implementation of CRPBaseRenderer
+  // Implementation of CRPBaseRenderer
   bool Supports(RENDERFEATURE feature) const override;
   SCALINGMETHOD GetDefaultScalingMethod() const override { return SCALINGMETHOD::NEAREST; }
 
@@ -75,7 +75,7 @@ protected:
     std::shared_ptr<SHADER::CShaderTextureGLESRef> target;
   };
 
-  // implementation of CRPBaseRenderer
+  // Implementation of CRPBaseRenderer
   void RenderInternal(bool clear, uint8_t alpha) override;
   void FlushInternal() override;
 

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererOpenGLES.h
@@ -71,8 +71,8 @@ protected:
 
   struct RenderBufferTextures
   {
-    std::shared_ptr<SHADER::CShaderTextureGLESRef> source;
-    std::shared_ptr<SHADER::CShaderTextureGLESRef> target;
+    std::shared_ptr<SHADER::CShaderTextureGLESRef> sourceTexture;
+    std::shared_ptr<SHADER::CShaderTextureGLESRef> targetTexture;
   };
 
   // Implementation of CRPBaseRenderer

--- a/xbmc/cores/RetroPlayer/shaders/IShader.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShader.h
@@ -53,7 +53,7 @@ public:
    * \param source Source texture to pass to the shader as input
    * \param target Target texture to render the shader to
    */
-  virtual void Render(IShaderTexture& source, IShaderTexture& target) = 0;
+  virtual void Render(IShaderTexture& sourceTexture, IShaderTexture& targetTexture) = 0;
 
   /*!
    * \brief Sets the input and output sizes in pixels

--- a/xbmc/cores/RetroPlayer/shaders/IShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/IShaderPreset.h
@@ -47,8 +47,8 @@ public:
    */
   virtual bool RenderUpdate(const RETRO::ViewportCoordinates& dest,
                             const float2 fullDestSize,
-                            IShaderTexture& source,
-                            IShaderTexture& target) = 0;
+                            IShaderTexture& sourceTexture,
+                            IShaderTexture& targetTexture) = 0;
 
   /*!
    * \brief Informs about the speed of playback

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
@@ -41,8 +41,8 @@ bool CShaderPreset::ReadPresetFile(const std::string& presetPath)
 
 bool CShaderPreset::RenderUpdate(const RETRO::ViewportCoordinates& dest,
                                  const float2 fullDestSize,
-                                 IShaderTexture& source,
-                                 IShaderTexture& target)
+                                 IShaderTexture& sourceTexture,
+                                 IShaderTexture& targetTexture)
 {
   // Save the viewport
   CRect viewPort;
@@ -55,17 +55,17 @@ bool CShaderPreset::RenderUpdate(const RETRO::ViewportCoordinates& dest,
   if (!Update())
     return false;
 
-  PrepareParameters(dest, source);
+  PrepareParameters(dest, sourceTexture);
 
   // Apply all passes except the last one (which needs to be applied to the backbuffer)
-  IShaderTexture* sourceTexture = &source;
+  IShaderTexture* currentTexture = &sourceTexture;
   const auto numPasses = static_cast<unsigned int>(m_pShaders.size());
   for (unsigned shaderIdx = 0; shaderIdx + 1 < numPasses; ++shaderIdx)
   {
     IShader& shader = *m_pShaders[shaderIdx];
-    IShaderTexture& texture = *m_pShaderTextures[shaderIdx];
-    RenderShader(shader, *sourceTexture, texture);
-    sourceTexture = &texture;
+    IShaderTexture& nextTexture = *m_pShaderTextures[shaderIdx];
+    RenderShader(shader, *currentTexture, nextTexture);
+    currentTexture = &nextTexture;
   }
 
   // Restore our viewport
@@ -74,7 +74,7 @@ bool CShaderPreset::RenderUpdate(const RETRO::ViewportCoordinates& dest,
 
   // Apply the last pass and write to target (backbuffer) instead of the last texture
   IShader* lastShader = m_pShaders.back().get();
-  lastShader->Render(*sourceTexture, target);
+  lastShader->Render(*currentTexture, targetTexture);
 
   m_frameCount += static_cast<float>(m_speed);
   return true;
@@ -182,15 +182,15 @@ void CShaderPreset::UpdateMVPs()
 }
 
 void CShaderPreset::PrepareParameters(const RETRO::ViewportCoordinates& dest,
-                                      IShaderTexture& source)
+                                      IShaderTexture& sourceTexture)
 {
   // Prepare parameters for all shader passes
   const auto numPasses = static_cast<unsigned int>(m_pShaders.size());
   for (unsigned int shaderIdx = 0; shaderIdx < numPasses; ++shaderIdx)
   {
     std::unique_ptr<IShader>& videoShader = m_pShaders[shaderIdx];
-    videoShader->PrepareParameters(dest, m_fullDestSize, source, m_pShaderTextures, m_pShaders,
-                                   static_cast<uint64_t>(m_frameCount));
+    videoShader->PrepareParameters(dest, m_fullDestSize, sourceTexture, m_pShaderTextures,
+                                   m_pShaders, static_cast<uint64_t>(m_frameCount));
   }
 }
 

--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.h
@@ -42,8 +42,8 @@ public:
   bool ReadPresetFile(const std::string& presetPath) override;
   bool RenderUpdate(const RETRO::ViewportCoordinates& dest,
                     const float2 fullDestSize,
-                    IShaderTexture& source,
-                    IShaderTexture& target) override;
+                    IShaderTexture& sourceTexture,
+                    IShaderTexture& targetTexture) override;
   void SetSpeed(double speed) override { m_speed = speed; }
   void SetVideoSize(unsigned int videoWidth, unsigned int videoHeight) override;
   bool SetShaderPreset(const std::string& shaderPresetPath) override;
@@ -57,13 +57,15 @@ protected:
   virtual bool CreateBuffers() = 0;
   virtual bool CreateShaderTextures() = 0;
   virtual bool CreateSamplers() = 0;
-  virtual void RenderShader(IShader& shader, IShaderTexture& source, IShaderTexture& target) = 0;
+  virtual void RenderShader(IShader& shader,
+                            IShaderTexture& sourceTexture,
+                            IShaderTexture& targetTexture) = 0;
 
   // Helper functions
   bool Update();
   void UpdateViewPort(CRect viewPort, const float2 fullDestSize);
   void UpdateMVPs();
-  void PrepareParameters(const RETRO::ViewportCoordinates& dest, IShaderTexture& source);
+  void PrepareParameters(const RETRO::ViewportCoordinates& dest, IShaderTexture& sourceTexture);
   void CalculateScaledSize(const KODI::SHADER::ShaderPass& pass,
                            const float2& prevSize,
                            float2& scaledSize);

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -158,9 +158,9 @@ bool CShaderGL::Create(unsigned int passIdx,
   return true;
 }
 
-void CShaderGL::Render(IShaderTexture& source, IShaderTexture& target)
+void CShaderGL::Render(IShaderTexture& sourceTexture, IShaderTexture& targetTexture)
 {
-  auto& sourceGL = static_cast<CShaderTextureGL&>(source);
+  auto& sourceGL = static_cast<CShaderTextureGL&>(sourceTexture);
 
   glUseProgram(m_shaderProgram);
 

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -118,12 +118,14 @@ private:
   unsigned int m_frameCountMod{0};
 
   GLuint m_shaderProgram{0};
+
   std::array<std::array<float, 3>, 4> m_VertexCoords;
   std::array<std::array<float, 3>, 4> m_colors;
   std::array<std::array<float, 2>, 4> m_TexCoords;
 
   UniformInputs m_uniformInputs;
   UniformFrameInputs m_uniformFrameInputs;
+
   std::vector<UniformFrameInputs> m_passesUniformFrameInputs;
 
   GLint m_FrameDirectionLoc{-1};

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.h
@@ -38,7 +38,7 @@ public:
               ShaderParameterMap shaderParameters,
               std::vector<std::shared_ptr<IShaderLut>> luts,
               unsigned int frameCountMod = 0) override;
-  void Render(IShaderTexture& source, IShaderTexture& target) override;
+  void Render(IShaderTexture& sourceTexture, IShaderTexture& targetTexture) override;
   void SetSizes(const float2& prevSize,
                 const float2& prevTextureSize,
                 const float2& nextSize) override;

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
@@ -189,16 +189,18 @@ bool CShaderPresetGL::CreateShaderTextures()
   return true;
 }
 
-void CShaderPresetGL::RenderShader(IShader& shader, IShaderTexture& source, IShaderTexture& target)
+void CShaderPresetGL::RenderShader(IShader& shader,
+                                   IShaderTexture& sourceTexture,
+                                   IShaderTexture& targetTexture)
 {
-  if (static_cast<CShaderTextureGL&>(target).BindFBO())
+  if (static_cast<CShaderTextureGL&>(targetTexture).BindFBO())
   {
-    const CRect newViewPort(0.f, 0.f, target.GetWidth(), target.GetHeight());
+    const CRect newViewPort(0.f, 0.f, targetTexture.GetWidth(), targetTexture.GetHeight());
     glViewport((GLsizei)newViewPort.x1, (GLsizei)newViewPort.y1, (GLsizei)newViewPort.x2,
                (GLsizei)newViewPort.y2);
     glScissor((GLsizei)newViewPort.x1, (GLsizei)newViewPort.y1, (GLsizei)newViewPort.x2,
               (GLsizei)newViewPort.y2);
-    shader.Render(source, target);
-    static_cast<CShaderTextureGL&>(target).UnbindFBO();
+    shader.Render(sourceTexture, targetTexture);
+    static_cast<CShaderTextureGL&>(targetTexture).UnbindFBO();
   }
 }

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.h
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.h
@@ -36,7 +36,9 @@ protected:
   bool CreateBuffers() override { return true; }
   bool CreateShaderTextures() override;
   bool CreateSamplers() override { return true; }
-  void RenderShader(IShader& shader, IShaderTexture& source, IShaderTexture& target) override;
+  void RenderShader(IShader& shader,
+                    IShaderTexture& sourceTexture,
+                    IShaderTexture& targetTexture) override;
 };
 } // namespace SHADER
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
@@ -330,6 +330,7 @@ CShaderGLES::UniformInputs CShaderGLES::GetInputData(uint64_t frameCount) const
       // Time always flows forward
       1 // frame_direction
   };
+
   return input;
 }
 
@@ -341,6 +342,7 @@ CShaderGLES::UniformFrameInputs CShaderGLES::GetFrameInputData(GLuint texture) c
       texture, // texture
       m_passAlias // alias
   };
+
   return frameInput;
 }
 
@@ -397,7 +399,6 @@ void CShaderGLES::SetShaderParameters(CShaderTextureGLES& sourceTexture)
   for (unsigned int i = 0; i < m_passIdx + 1; ++i)
   {
     GLint paramLoc;
-
     std::string paramPass = i ? "Pass" + std::to_string(i) : "Orig";
     paramLoc = glGetUniformLocation(m_shaderProgram, (paramPass + "InputSize").c_str());
     glUniform2f(paramLoc, m_passesUniformFrameInputs[i].input_size.x,

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
@@ -140,9 +140,9 @@ bool CShaderGLES::Create(unsigned int passIdx,
   return true;
 }
 
-void CShaderGLES::Render(IShaderTexture& source, IShaderTexture& target)
+void CShaderGLES::Render(IShaderTexture& sourceTexture, IShaderTexture& targetTexture)
 {
-  auto& sourceGL = static_cast<CShaderTextureGLES&>(source);
+  auto& sourceGL = static_cast<CShaderTextureGLES&>(sourceTexture);
 
   glUseProgram(m_shaderProgram);
 

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
@@ -118,12 +118,14 @@ private:
   unsigned int m_frameCountMod{0};
 
   GLuint m_shaderProgram{0};
+
   std::array<std::array<float, 3>, 4> m_VertexCoords;
   std::array<std::array<float, 3>, 4> m_colors;
   std::array<std::array<float, 2>, 4> m_TexCoords;
 
   UniformInputs m_uniformInputs;
   UniformFrameInputs m_uniformFrameInputs;
+
   std::vector<UniformFrameInputs> m_passesUniformFrameInputs;
 
   GLint m_FrameDirectionLoc{-1};

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.h
@@ -38,7 +38,7 @@ public:
               ShaderParameterMap shaderParameters,
               std::vector<std::shared_ptr<IShaderLut>> luts,
               unsigned int frameCountMod = 0) override;
-  void Render(IShaderTexture& source, IShaderTexture& target) override;
+  void Render(IShaderTexture& sourceTexture, IShaderTexture& targetTexture) override;
   void SetSizes(const float2& prevSize,
                 const float2& prevTextureSize,
                 const float2& nextSize) override;

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
@@ -186,17 +186,17 @@ bool CShaderPresetGLES::CreateShaderTextures()
 }
 
 void CShaderPresetGLES::RenderShader(IShader& shader,
-                                     IShaderTexture& source,
-                                     IShaderTexture& target)
+                                     IShaderTexture& sourceTexture,
+                                     IShaderTexture& targetTexture)
 {
-  if (static_cast<CShaderTextureGLES&>(target).BindFBO())
+  if (static_cast<CShaderTextureGLES&>(targetTexture).BindFBO())
   {
-    const CRect newViewPort(0.f, 0.f, target.GetWidth(), target.GetHeight());
+    const CRect newViewPort(0.f, 0.f, targetTexture.GetWidth(), targetTexture.GetHeight());
     glViewport((GLsizei)newViewPort.x1, (GLsizei)newViewPort.y1, (GLsizei)newViewPort.x2,
                (GLsizei)newViewPort.y2);
     glScissor((GLsizei)newViewPort.x1, (GLsizei)newViewPort.y1, (GLsizei)newViewPort.x2,
               (GLsizei)newViewPort.y2);
-    shader.Render(source, target);
-    static_cast<CShaderTextureGLES&>(target).UnbindFBO();
+    shader.Render(sourceTexture, targetTexture);
+    static_cast<CShaderTextureGLES&>(targetTexture).UnbindFBO();
   }
 }

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.h
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.h
@@ -36,7 +36,9 @@ protected:
   bool CreateBuffers() override { return true; }
   bool CreateShaderTextures() override;
   bool CreateSamplers() override { return true; }
-  void RenderShader(IShader& shader, IShaderTexture& source, IShaderTexture& target) override;
+  void RenderShader(IShader& shader,
+                    IShaderTexture& sourceTexture,
+                    IShaderTexture& targetTexture) override;
 };
 } // namespace SHADER
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
@@ -77,23 +77,23 @@ bool CShaderDX::Create(unsigned int passIdx,
   return true;
 }
 
-void CShaderDX::Render(IShaderTexture& source, IShaderTexture& target)
+void CShaderDX::Render(IShaderTexture& sourceTexture, IShaderTexture& targetTexture)
 {
-  auto& sourceDX = static_cast<CShaderTextureDX&>(source);
+  auto& sourceDX = static_cast<CShaderTextureDX&>(sourceTexture);
 
   // Get source texture object
-  const CD3DTexture& sourceTexture = sourceDX.GetTexture();
+  const CD3DTexture& sourceD3dTexture = sourceDX.GetTexture();
 
   //! @todo Handle ref textures better
-  auto* targetDX = dynamic_cast<CShaderTextureDX*>(&target);
-  auto* targetDXRef = dynamic_cast<CShaderTextureDXRef*>(&target);
+  auto* targetDX = dynamic_cast<CShaderTextureDX*>(&targetTexture);
+  auto* targetDXRef = dynamic_cast<CShaderTextureDXRef*>(&targetTexture);
 
-  CD3DTexture& targetTexture =
+  CD3DTexture& targetD3dTexture =
       targetDX != nullptr ? targetDX->GetTexture() : targetDXRef->GetTexture();
 
   //! @todo Check for nullptr
-  SetShaderParameters(sourceTexture);
-  Execute({&targetTexture}, 4);
+  SetShaderParameters(sourceD3dTexture);
+  Execute({&targetD3dTexture}, 4);
 }
 
 void CShaderDX::SetSizes(const float2& prevSize,

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
@@ -79,7 +79,7 @@ bool CShaderDX::Create(unsigned int passIdx,
 
 void CShaderDX::Render(IShaderTexture& source, IShaderTexture& target)
 {
-  CShaderTextureDX& sourceDX = static_cast<CShaderTextureDX&>(source);
+  auto& sourceDX = static_cast<CShaderTextureDX&>(source);
 
   // Get source texture object
   const CD3DTexture& sourceTexture = sourceDX.GetTexture();

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.h
@@ -37,7 +37,7 @@ public:
               ShaderParameterMap shaderParameters,
               std::vector<std::shared_ptr<IShaderLut>> luts,
               unsigned int frameCountMod = 0) override;
-  void Render(IShaderTexture& source, IShaderTexture& target) override;
+  void Render(IShaderTexture& sourceTexture, IShaderTexture& targetTexture) override;
   void SetSizes(const float2& prevSize,
                 const float2& prevTextureSize,
                 const float2& nextSize) override;

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
@@ -227,10 +227,12 @@ bool CShaderPresetDX::CreateSamplers()
   return true;
 }
 
-void CShaderPresetDX::RenderShader(IShader& shader, IShaderTexture& source, IShaderTexture& target)
+void CShaderPresetDX::RenderShader(IShader& shader,
+                                   IShaderTexture& sourceTexture,
+                                   IShaderTexture& targetTexture)
 {
-  const CRect newViewPort(0.f, 0.f, target.GetWidth(), target.GetHeight());
+  const CRect newViewPort(0.f, 0.f, targetTexture.GetWidth(), targetTexture.GetHeight());
   m_context.SetViewPort(newViewPort);
   m_context.SetScissors(newViewPort);
-  shader.Render(source, target);
+  shader.Render(sourceTexture, targetTexture);
 }

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.h
@@ -40,7 +40,9 @@ protected:
   bool CreateBuffers() override;
   bool CreateShaderTextures() override;
   bool CreateSamplers() override;
-  void RenderShader(IShader& shader, IShaderTexture& source, IShaderTexture& target) override;
+  void RenderShader(IShader& shader,
+                    IShaderTexture& sourceTexture,
+                    IShaderTexture& targetTexture) override;
 
 private:
   // Point/nearest neighbor sampler


### PR DESCRIPTION
## Description

This PR improves code consistency across RetroPlayer's platform code. The code became unfortunately duplicated in a past architecture improvement, so occasionally discovered inconsistencies need to be fixed. The PR also applies some modern stylistic improvements.

As a result, the size of https://github.com/xbmc/xbmc/pull/27912 is 10% less.

## Motivation and context

Reduces size of diff of https://github.com/xbmc/xbmc/pull/27912 by 10%.

We could have simply cherry-picked this into https://github.com/xbmc/xbmc/pull/27912, but I wanted to demonstrate that independent PRs (more than one) can improve reviewability when critical features approach 1K lines of code.

## How has this been tested?

Only compile tested, but on Windows/Linux/macOS.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
