### PR TITLE
[VideoPlayer] Integration of bookmarks in forwards/backwards skip

### DIFF
--- a/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
+++ b/addons/skin.estuary/xml/Custom_1109_TopBarOverlay.xml
@@ -163,6 +163,15 @@
 				<righttexture>colors/white.png</righttexture>
 				<info>Player.Chapters</info>
 			</control>
+			<control type="ranges">
+				<left>0</left>
+				<top>61</top>
+				<width>100%</width>
+				<height>4</height>
+				<texturebg border="3" colordiffuse="00FFFFFF">colors/white50.png</texturebg>
+				<righttexture>colors/white.png</righttexture>
+				<info>Player.Bookmarks</info>
+			</control>
 		</control>
 		<control type="group">
 			<animation effect="slide" end="0,-200" time="300" tween="sine" easing="inout" condition="$EXP[infodialog_active]">conditional</animation>

--- a/addons/skin.estuary/xml/DialogSeekBar.xml
+++ b/addons/skin.estuary/xml/DialogSeekBar.xml
@@ -186,6 +186,15 @@
 				<righttexture>colors/white.png</righttexture>
 				<info>Player.Chapters</info>
 			</control>
+			<control type="ranges">
+				<left>0</left>
+				<top>76</top>
+				<width>100%</width>
+				<height>4</height>
+				<texturebg border="3" colordiffuse="00FFFFFF">colors/white50.png</texturebg>
+				<righttexture>colors/white.png</righttexture>
+				<info>Player.Bookmarks</info>
+			</control>
 		</control>
 		<control type="group">
 			<visible>!Window.IsVisible(playerprocessinfo)</visible>

--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -1,6 +1,7 @@
 xbmc/addons/gui/skin/test         test/skin
 xbmc/addons/test                  test/addons
 xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
+xbmc/cores/VideoPlayer/test       test/videoplayer
 xbmc/cores/VideoPlayer/DVDDemuxers/test test/dvddemuxers
 xbmc/cores/VideoPlayer/Edl/test   test/edl
 xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test test/videoshaders

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -777,7 +777,7 @@ constexpr std::array<InfoMap, 7> integer_bools = {{
 ///                  \anchor Player_Editlist
 ///                  _string_,
 ///     @return The editlist of the currently playing item as csv in the format start1\,end1\,start2\,end2\,...
-///     Tokens must have values in the range from 0.0 to 100.0. end token must be less or equal than start token.
+///     Tokens have values in the range from 0.0 to 100.0. end token is greater or equal to the  start token.
 ///     @note This infolabel does not contain EDL cuts. Edits start and end times are adjusted according to cuts
 ///     defined for the media item.
 ///     <p><hr>
@@ -788,7 +788,7 @@ constexpr std::array<InfoMap, 7> integer_bools = {{
 ///                  \anchor Player_Cuts
 ///                  _string_,
 ///     @return The EDL cut markers of the currently playing item as csv in the format start1\,end1\,start2\,end2\,...
-///     Tokens must have values in the range from 0.0 to 100.0. end token must be less or equal than start token.
+///     Tokens have values in the range from 0.0 to 100.0. end token is greater or equal to the  start token.
 ///     <p><hr>
 ///     @skinning_v20 **[New Infolabel]** \link Player_Cuts `Player.Cuts`\endlink
 ///     <p>
@@ -797,7 +797,7 @@ constexpr std::array<InfoMap, 7> integer_bools = {{
 ///                  \anchor Player_SceneMarkers
 ///                  _string_,
 ///     @return The EDL scene markers of the currently playing item as csv in the format start1\,end1\,start2\,end2\,...
-///     Tokens must have values in the range from 0.0 to 100.0. end token must be less or equal than start token.
+///     Tokens have values in the range from 0.0 to 100.0. end token is greater or equal to the  start token.
 ///     <p><hr>
 ///     @skinning_v20 **[New Infolabel]** \link Player_SceneMarkers `Player.SceneMarkers`\endlink
 ///     <p>
@@ -814,7 +814,7 @@ constexpr std::array<InfoMap, 7> integer_bools = {{
 ///                  \anchor Player_Chapters
 ///                  _string_,
 ///     @return The chapters of the currently playing item as csv in the format start1\,end1\,start2\,end2\,...
-///     Tokens must have values in the range from 0.0 to 100.0. end token must be less or equal than start token.
+///     Tokens have values in the range from 0.0 to 100.0. end token is greater or equal to the  start token.
 ///     <p><hr>
 ///     @skinning_v19 **[New Infolabel]** \link Player_Chapters `Player.Chapters`\endlink
 ///     <p>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -819,6 +819,23 @@ constexpr std::array<InfoMap, 7> integer_bools = {{
 ///     @skinning_v19 **[New Infolabel]** \link Player_Chapters `Player.Chapters`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Player.Bookmarks`</b>,
+///                  \anchor Player_Bookmarks
+///                  _string_,
+///     @return The bookmarks of the currently playing item as csv in the format start1\,end1\,start2\,end2\,...
+///     Tokens have values in the range from 0.0 to 100.0. end token is greater or equal to the  start token.
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link Player_Bookmarks `Player.Bookmarks`\endlink
+///     <p>
+///   }
+///   \table_row3{   <b>`Player.HasBookmarks`</b>,
+///                  \anchor Player_HasBookmarks
+///                  _boolean_,
+///     @return **True** if the item being played has bookmarks\, **False** otherwise
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link Player_HasBookmarks `Player.HasBookmarks`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`Player.IsExternal`</b>,
 ///                  \anchor Player_IsExternal
 ///                  _boolean_,
@@ -844,7 +861,7 @@ constexpr std::array<InfoMap, 7> integer_bools = {{
 ///     <p>
 ///   }
 // clang-format off
-constexpr std::array<InfoMap, 58> player_labels = {{
+constexpr std::array<InfoMap, 60> player_labels = {{
     {"hasmedia",              PLAYER_HAS_MEDIA},
     {"hasaudio",              PLAYER_HAS_AUDIO},
     {"hasvideo",              PLAYER_HAS_VIDEO},
@@ -903,6 +920,8 @@ constexpr std::array<InfoMap, 58> player_labels = {{
     {"scenemarkers",          PLAYER_SCENE_MARKERS},
     {"hasscenemarkers",       PLAYER_HAS_SCENE_MARKERS},
     {"chapters",              PLAYER_CHAPTERS},
+    {"bookmarks",             PLAYER_BOOKMARKS},
+    {"hasbookmarks",          PLAYER_HAS_BOOKMARKS},
 }};
 // clang-format on
 

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -79,6 +79,7 @@ bool CServiceManager::InitForTesting()
     CLog::Log(LOGFATAL, "CServiceManager::{}: Unable to start CAddonMgr", __FUNCTION__);
     return false;
   }
+  m_dataCacheCore = std::make_unique<CDataCacheCore>();
 
   m_extsMimeSupportList = std::make_unique<ADDONS::CExtsMimeSupportList>(*m_addonMgr);
   m_fileExtensionProvider = std::make_unique<CFileExtensionProvider>(*m_addonMgr);
@@ -96,6 +97,7 @@ void CServiceManager::DeinitTesting()
   m_subTagRegistryManager.reset();
   m_fileExtensionProvider.reset();
   m_extsMimeSupportList.reset();
+  m_dataCacheCore.reset();
   m_binaryAddonManager.reset();
   m_addonMgr.reset();
   m_databaseManager.reset();

--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -205,6 +205,21 @@ int64_t CApplicationPlayer::GetChapterPos(int chapterIdx) const
     return player->GetChapterPos(chapterIdx);
 
   return -1;
+}
+
+std::vector<std::chrono::milliseconds> CApplicationPlayer::GetBookmarks() const
+{
+  const std::shared_ptr<const IPlayer> player = GetInternal();
+  if (player)
+    return player->GetBookmarks();
+  return {};
+}
+
+void CApplicationPlayer::SetBookmarks(const std::vector<std::chrono::milliseconds>& bookmarks)
+{
+  const std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->SetBookmarks(bookmarks);
 }
 
 bool CApplicationPlayer::HasAudio() const

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -16,6 +16,7 @@
 #include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -87,6 +88,7 @@ public:
   int GetAudioStream();
   int GetAudioStreamCount() const;
   void GetAudioStreamInfo(int index, AudioStreamInfo& info) const;
+  std::vector<std::chrono::milliseconds> GetBookmarks() const;
   int GetCacheLevel() const;
   float GetCachePercentage() const;
   int GetChapterCount() const;
@@ -150,6 +152,7 @@ public:
   void SeekTimeRelative(int64_t iTime = 0);
   void SetAudioStream(int iStream);
   void SetAVDelay(float fValue = 0.0f);
+  void SetBookmarks(const std::vector<std::chrono::milliseconds>& bookmarks);
   void SetDynamicRangeCompression(long drc);
   void SetMute(bool bOnOff);
   bool SetPlayerState(const std::string& state);

--- a/xbmc/cores/DataCacheCore.cpp
+++ b/xbmc/cores/DataCacheCore.cpp
@@ -327,6 +327,18 @@ const std::vector<std::pair<std::string, int64_t>>& CDataCacheCore::GetChapters(
   return m_contentInfo.GetChapters();
 }
 
+void CDataCacheCore::SetBookmarks(const std::vector<std::chrono::milliseconds>& bookmarks)
+{
+  std::unique_lock lock(m_contentSection);
+  m_contentInfo.SetBookmarks(bookmarks);
+}
+
+const std::vector<std::chrono::milliseconds>& CDataCacheCore::GetBookmarks() const
+{
+  std::unique_lock lock(m_contentSection);
+  return m_contentInfo.GetBookmarks();
+}
+
 void CDataCacheCore::SetRenderClockSync(bool enable)
 {
   std::unique_lock lock(m_renderSection);

--- a/xbmc/cores/DataCacheCore.h
+++ b/xbmc/cores/DataCacheCore.h
@@ -119,6 +119,18 @@ public:
    */
   const std::vector<std::pair<std::string, int64_t>>& GetChapters() const;
 
+  /*!
+   * \brief Set the list of bookmarks in cache.
+   * \return The list of bookmarks or an empty list if no bookmarks exist
+   */
+  void SetBookmarks(const std::vector<std::chrono::milliseconds>& bookmarks);
+
+  /*!
+   * \brief Get the list of bookmarks from cache.
+   * \return The list of bookmarks or an empty vector if no scene exist.
+   */
+  const std::vector<std::chrono::milliseconds>& GetBookmarks() const;
+
   // render info
   void SetRenderClockSync(bool enabled);
   bool IsRenderClockSync();
@@ -292,6 +304,21 @@ protected:
     const std::vector<std::pair<std::string, int64_t>>& GetChapters() const { return m_chapters; }
 
     /*!
+      * @brief Save the list of bookmarks in cache.
+      * @param sceneMarkers the list of bookmarks to store in cache
+      */
+    void SetBookmarks(const std::vector<std::chrono::milliseconds>& bookmarks)
+    {
+      m_bookmarks = bookmarks;
+    }
+
+    /*!
+      * \brief Get the list of bookmarks in cache.
+      * \return the list of bookmarks in cache
+      */
+    const std::vector<std::chrono::milliseconds>& GetBookmarks() const { return m_bookmarks; }
+
+    /*!
       * @brief Reset the content cache to the original values (all empty)
       */
     void Reset()
@@ -300,6 +327,7 @@ protected:
       m_chapters.clear();
       m_cuts.clear();
       m_sceneMarkers.clear();
+      m_bookmarks.clear();
     }
 
   private:
@@ -311,6 +339,8 @@ protected:
     std::vector<std::chrono::milliseconds> m_cuts;
     /*!< position for EDL scene markers */
     std::vector<std::chrono::milliseconds> m_sceneMarkers;
+    /*!< position for bookmarks */
+    std::vector<std::chrono::milliseconds> m_bookmarks;
   } m_contentInfo;
 
   CCriticalSection m_renderSection;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -14,6 +14,7 @@
 #include "MenuType.h"
 #include "VideoSettings.h"
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -165,6 +166,8 @@ public:
   virtual int64_t GetChapterPos(int chapterIdx = -1) const { return 0; }
   virtual int  SeekChapter(int iChapter)                       { return -1; }
 //  virtual bool GetChapterInfo(int chapter, SChapterInfo &info) { return false; }
+  virtual std::vector<std::chrono::milliseconds> GetBookmarks() const { return {}; }
+  virtual void SetBookmarks(const std::vector<std::chrono::milliseconds>& bookmarks) {}
 
   virtual void SeekTime(int64_t iTime = 0) {}
   /*

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -626,7 +626,8 @@ float CProcessInfo::MaxTempoPlatform()
 bool CProcessInfo::IsTempoAllowed(float tempo)
 {
   if (tempo > MinTempoPlatform() &&
-      (tempo < MaxTempoPlatform() || tempo < CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_maxTempo))
+      (tempo < MaxTempoPlatform() ||
+       tempo < CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_maxTempo + 0.05f))
     return true;
 
   return false;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -106,8 +106,6 @@ public:
   void SetNewTempo(float tempo);
   float GetNewTempo();
   bool IsTempoAllowed(float tempo);
-  virtual float MinTempoPlatform();
-  virtual float MaxTempoPlatform();
   void SetLevelVQ(int level);
   int GetLevelVQ();
   void SetGuiRender(bool gui);
@@ -126,6 +124,10 @@ public:
 
 protected:
   CProcessInfo();
+
+  virtual float MinTempoPlatform();
+  virtual float MaxTempoPlatform();
+
   static std::map<std::string, CreateProcessControl> m_processControls;
   CDataCacheCore *m_dataCache = nullptr;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -776,12 +776,14 @@ CVideoPlayer::CVideoPlayer(IPlayerCallback& callback)
   m_displayLost = false;
   m_error = false;
   m_bCloseRequest = false;
-  CServiceBroker::GetWinSystem()->Register(this);
+  if (auto system = CServiceBroker::GetWinSystem(); system != nullptr)
+    system->Register(this);
 }
 
 CVideoPlayer::~CVideoPlayer()
 {
-  CServiceBroker::GetWinSystem()->Unregister(this);
+  if (auto system = CServiceBroker::GetWinSystem(); system != nullptr)
+    system->Unregister(this);
 
   CloseFile();
   DestroyPlayers();
@@ -849,8 +851,13 @@ bool CVideoPlayer::CloseFile(bool reopen)
   // wait for the main thread to finish up
   // since this main thread cleans up all other resources and threads
   // we are done after the StopThread call
+  if (auto system = CServiceBroker::GetWinSystem(); system != nullptr)
   {
-    CSingleExit exitlock(CServiceBroker::GetWinSystem()->GetGfxContext());
+    CSingleExit exitlock(system->GetGfxContext());
+    StopThread();
+  }
+  else
+  {
     StopThread();
   }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4162,6 +4162,13 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
     CServiceBroker::GetDataCacheCore().SetCuts(m_Edl.GetCutMarkers());
     CServiceBroker::GetDataCacheCore().SetSceneMarkers(m_Edl.GetSceneMarkers());
 
+    VECBOOKMARKS bm;
+    if (CBookmark::GetBookmarksForFile(m_item.GetDynPath(), bm, {CBookmark::STANDARD}))
+    {
+      std::vector<std::chrono::milliseconds> pos = CBookmark::BookmarksToPositions(bm);
+      SetBookmarks(pos);
+    }
+
     static_cast<IDVDStreamPlayerVideo*>(player)->SetSpeed(m_streamPlayerSpeed);
     m_CurrentVideo.syncState = IDVDStreamPlayer::SYNC_STARTING;
     m_CurrentVideo.packets = 0;
@@ -5038,6 +5045,16 @@ int CVideoPlayer::GetPreviousChapter()
     return chapter - 1;
   else
     return chapter;
+}
+
+std::vector<std::chrono::milliseconds> CVideoPlayer::GetBookmarks() const
+{
+  return CServiceBroker::GetDataCacheCore().GetBookmarks();
+}
+
+void CVideoPlayer::SetBookmarks(const std::vector<std::chrono::milliseconds>& bookmarks)
+{
+  CServiceBroker::GetDataCacheCore().SetBookmarks(bookmarks);
 }
 
 void CVideoPlayer::AddSubtitle(const std::string& strSubPath)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5047,14 +5047,66 @@ int CVideoPlayer::GetPreviousChapter()
     return chapter;
 }
 
+bool CVideoPlayer::HasBookmarks() const
+{
+  std::unique_lock lock(m_StateSection);
+  return !m_State.m_bookmarks.empty();
+}
+
 std::vector<std::chrono::milliseconds> CVideoPlayer::GetBookmarks() const
 {
-  return CServiceBroker::GetDataCacheCore().GetBookmarks();
+  std::unique_lock lock(m_StateSection);
+  return m_State.m_bookmarks;
 }
 
 void CVideoPlayer::SetBookmarks(const std::vector<std::chrono::milliseconds>& bookmarks)
 {
+  std::unique_lock lock(m_StateSection);
+  m_State.m_bookmarks = bookmarks;
   CServiceBroker::GetDataCacheCore().SetBookmarks(bookmarks);
+}
+
+int CVideoPlayer::GetPreviousBookmark(std::chrono::milliseconds ts)
+{
+  std::unique_lock lock(m_StateSection);
+  std::vector<std::chrono::milliseconds> bookmarks = m_State.m_bookmarks;
+
+  if (bookmarks.empty())
+    return -1;
+
+  // Add grace period of 5 seconds to make it easier to skip backwards through bookmarks
+  //! @todo reduce to 2 seconds if seek accuracy can be improved
+  const std::chrono::milliseconds adjusted_ts = ts - 5s;
+
+  size_t idx{0};
+  while (idx < bookmarks.size() && bookmarks[idx] < adjusted_ts)
+    ++idx;
+
+  return idx > 0 ? static_cast<int>(idx) - 1 : -1;
+}
+
+int CVideoPlayer::GetNextBookmark(std::chrono::milliseconds ts)
+{
+  std::unique_lock lock(m_StateSection);
+  std::vector<std::chrono::milliseconds> bookmarks = m_State.m_bookmarks;
+
+  if (bookmarks.empty())
+    return -1;
+
+  size_t idx{0};
+  while (idx < bookmarks.size() && bookmarks[idx] <= ts)
+    ++idx;
+
+  return idx < bookmarks.size() ? idx : -1;
+}
+
+std::optional<std::chrono::milliseconds> CVideoPlayer::GetBookmarkPos(int idx)
+{
+  std::unique_lock lock(m_StateSection);
+  if (idx >= 0 && static_cast<size_t>(idx) < m_State.m_bookmarks.size())
+    return m_State.m_bookmarks[idx];
+  else
+    return std::nullopt;
 }
 
 void CVideoPlayer::AddSubtitle(const std::string& strSubPath)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3528,68 +3528,125 @@ void CVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   if (!m_State.canseek)
     return;
 
-  if (bLargeStep && bChapterOverride && GetChapter() > 0 && GetChapterCount() > 1)
+  std::optional<int64_t> seekTarget;
+  const int64_t time = GetTime();
+  bool accurate = false;
+
+  if (bLargeStep && bChapterOverride)
   {
-    if (!bPlus)
+    const int chapter = GetChapter();
+    const bool hasValidChapters = GetChapterCount() > 1 && chapter > 0;
+
+    if (hasValidChapters || HasBookmarks())
     {
-      SeekChapter(GetPreviousChapter());
-      return;
-    }
-    else if (GetChapter() < GetChapterCount())
-    {
-      SeekChapter(GetChapter() + 1);
-      return;
+      const std::chrono::milliseconds ts{time};
+
+      // Seek to the nearest bookmark or chapter.
+      // No earlier/later bookmark or chapter? use a large step.
+      if (!bPlus)
+      {
+        const std::optional<std::chrono::milliseconds> tsBookmark =
+            GetBookmarkPos(GetPreviousBookmark(ts));
+
+        if (hasValidChapters)
+        {
+          const std::optional<std::chrono::milliseconds> tsChapter =
+              GetChapterPosMs(GetPreviousChapter());
+
+          if (tsChapter.has_value() &&
+              (!tsBookmark.has_value() || tsChapter.value().count() > tsBookmark.value().count()))
+          {
+            SeekChapter(GetPreviousChapter());
+            return;
+          }
+        }
+
+        if (tsBookmark.has_value())
+          seekTarget = tsBookmark.value().count();
+      }
+      else
+      {
+        const std::optional<std::chrono::milliseconds> tsBookmark =
+            GetBookmarkPos(GetNextBookmark(ts));
+
+        if (hasValidChapters)
+        {
+          const std::optional<std::chrono::milliseconds> tsChapter = GetChapterPosMs(chapter + 1);
+
+          if (tsChapter.has_value() &&
+              (!tsBookmark.has_value() || tsChapter.value().count() < tsBookmark.value().count()))
+          {
+            SeekChapter(chapter + 1);
+            return;
+          }
+        }
+
+        if (tsBookmark.has_value())
+          seekTarget = tsBookmark.value().count();
+      }
     }
   }
 
-  int64_t seekTarget;
-  const std::shared_ptr<CAdvancedSettings> advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
-  if (advancedSettings->m_videoUseTimeSeeking && m_processInfo->GetMaxTime() > 2000 * advancedSettings->m_videoTimeSeekForwardBig)
+  if (seekTarget.has_value())
   {
-    if (bLargeStep)
-      seekTarget = bPlus ? advancedSettings->m_videoTimeSeekForwardBig :
-                           advancedSettings->m_videoTimeSeekBackwardBig;
-    else
-      seekTarget = bPlus ? advancedSettings->m_videoTimeSeekForward :
-                           advancedSettings->m_videoTimeSeekBackward;
-    seekTarget *= 1000;
-    seekTarget += GetTime();
+    accurate = true;
   }
   else
   {
-    int percent;
-    if (bLargeStep)
-      percent = bPlus ? advancedSettings->m_videoPercentSeekForwardBig : advancedSettings->m_videoPercentSeekBackwardBig;
+    const std::shared_ptr<CAdvancedSettings> advancedSettings =
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+    if (advancedSettings->m_videoUseTimeSeeking &&
+        m_processInfo->GetMaxTime() > 2000 * advancedSettings->m_videoTimeSeekForwardBig)
+    {
+      if (bLargeStep)
+        seekTarget = bPlus ? advancedSettings->m_videoTimeSeekForwardBig
+                           : advancedSettings->m_videoTimeSeekBackwardBig;
+      else
+        seekTarget = bPlus ? advancedSettings->m_videoTimeSeekForward
+                           : advancedSettings->m_videoTimeSeekBackward;
+      seekTarget.value() *= 1000;
+      seekTarget.value() += GetTime();
+    }
     else
-      percent = bPlus ? advancedSettings->m_videoPercentSeekForward : advancedSettings->m_videoPercentSeekBackward;
-    seekTarget = static_cast<int64_t>(m_processInfo->GetMaxTime() * (GetPercentage() + percent) / 100);
+    {
+      int percent;
+      if (bLargeStep)
+        percent = bPlus ? advancedSettings->m_videoPercentSeekForwardBig
+                        : advancedSettings->m_videoPercentSeekBackwardBig;
+      else
+        percent = bPlus ? advancedSettings->m_videoPercentSeekForward
+                        : advancedSettings->m_videoPercentSeekBackward;
+      seekTarget =
+          static_cast<int64_t>(m_processInfo->GetMaxTime() * (GetPercentage() + percent) / 100);
+    }
+
+    if (g_application.CurrentFileItem().IsStack() &&
+        (seekTarget > m_processInfo->GetMaxTime() || seekTarget < 0))
+    {
+      g_application.SeekTime((seekTarget.value() - time) * 0.001 + g_application.GetTime());
+      // warning, don't access any VideoPlayer variables here as
+      // the VideoPlayer object may have been destroyed
+      return;
+    }
   }
 
-  bool restore = true;
-
-  int64_t time = GetTime();
-  if(g_application.CurrentFileItem().IsStack() &&
-     (seekTarget > m_processInfo->GetMaxTime() || seekTarget < 0))
+  if (seekTarget.has_value())
   {
-    g_application.SeekTime((seekTarget - time) * 0.001 + g_application.GetTime());
-    // warning, don't access any VideoPlayer variables here as
-    // the VideoPlayer object may have been destroyed
-    return;
+    int64_t target = seekTarget.value();
+    CDVDMsgPlayerSeek::CMode mode;
+    mode.time = target;
+    mode.backward = !bPlus;
+    mode.accurate = accurate;
+    mode.restore = true;
+    mode.trickplay = false;
+    mode.sync = true;
+
+    m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
+    SynchronizeDemuxer();
+    if (target < 0)
+      target = 0;
+    m_callback.OnPlayBackSeek(target, target - time);
   }
-
-  CDVDMsgPlayerSeek::CMode mode;
-  mode.time = (int)seekTarget;
-  mode.backward = !bPlus;
-  mode.accurate = false;
-  mode.restore = restore;
-  mode.trickplay = false;
-  mode.sync = true;
-
-  m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
-  SynchronizeDemuxer();
-  if (seekTarget < 0)
-    seekTarget = 0;
-  m_callback.OnPlayBackSeek(seekTarget, seekTarget - time);
 }
 
 bool CVideoPlayer::SeekScene(Direction seekDirection)
@@ -5040,6 +5097,15 @@ int64_t CVideoPlayer::GetChapterPos(int chapterIdx) const
         .count();
 
   return -1;
+}
+
+std::optional<std::chrono::milliseconds> CVideoPlayer::GetChapterPosMs(int chapterIdx) const
+{
+  std::unique_lock lock(m_StateSection);
+  if (chapterIdx > 0 && chapterIdx <= static_cast<int>(m_State.chapters.size()))
+    return m_State.chapters[chapterIdx - 1].second;
+
+  return std::nullopt;
 }
 
 int CVideoPlayer::GetPreviousChapter()

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -337,7 +337,7 @@ public:
   int GetChapterCount() const override;
   int GetChapter() const override;
   void GetChapterName(std::string& strChapterName, int chapterIdx = -1) const override;
-  int64_t GetChapterPos(int chapterIdx = -1) const override;
+  int64_t GetChapterPos(int chapterIdx = -1) const override; // chapter start ts in seconds
   int  SeekChapter(int iChapter) override;
   std::vector<std::chrono::milliseconds> GetBookmarks() const override;
   bool HasBookmarks() const;
@@ -511,6 +511,7 @@ protected:
 
   void UpdateFileItemStreamDetails(CFileItem& item, UpdateStreamDetails update);
   int GetPreviousChapter();
+  std::optional<std::chrono::milliseconds> GetChapterPosMs(int chapterIdx = -1) const;
   int GetPreviousBookmark(std::chrono::milliseconds ts);
   int GetNextBookmark(std::chrono::milliseconds ts);
   std::optional<std::chrono::milliseconds> GetBookmarkPos(int idx);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -28,6 +28,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -49,6 +50,7 @@ struct SPlayerState
     menuType = MenuType::NONE;
     chapter = 0;
     chapters.clear();
+    m_bookmarks.clear();
     canpause = false;
     canseek = false;
     cantempo = false;
@@ -79,6 +81,8 @@ struct SPlayerState
   int chapter; // 1-based current chapter. <=0 means no chapter / unknown
   // name and start timestamp of chapters.
   std::vector<std::pair<std::string, std::chrono::milliseconds>> chapters;
+  // position of the bookmarks
+  std::vector<std::chrono::milliseconds> m_bookmarks;
 
   bool canpause;            // pvr: can pause the current playing item
   bool canseek;             // pvr: can seek in the current playing item
@@ -336,6 +340,7 @@ public:
   int64_t GetChapterPos(int chapterIdx = -1) const override;
   int  SeekChapter(int iChapter) override;
   std::vector<std::chrono::milliseconds> GetBookmarks() const override;
+  bool HasBookmarks() const;
   void SetBookmarks(const std::vector<std::chrono::milliseconds>& bookmarks) override;
 
   void SeekTime(int64_t iTime) override;
@@ -506,6 +511,9 @@ protected:
 
   void UpdateFileItemStreamDetails(CFileItem& item, UpdateStreamDetails update);
   int GetPreviousChapter();
+  int GetPreviousBookmark(std::chrono::milliseconds ts);
+  int GetNextBookmark(std::chrono::milliseconds ts);
+  std::optional<std::chrono::milliseconds> GetBookmarkPos(int idx);
 
   bool m_players_created;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -335,6 +335,8 @@ public:
   void GetChapterName(std::string& strChapterName, int chapterIdx = -1) const override;
   int64_t GetChapterPos(int chapterIdx = -1) const override;
   int  SeekChapter(int iChapter) override;
+  std::vector<std::chrono::milliseconds> GetBookmarks() const override;
+  void SetBookmarks(const std::vector<std::chrono::milliseconds>& bookmarks) override;
 
   void SeekTime(int64_t iTime) override;
   bool SeekTimeRelative(int64_t iTime) override;

--- a/xbmc/cores/VideoPlayer/test/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestVideoPlayer.cpp)
+
+core_add_test_library(videoplayer_test)

--- a/xbmc/cores/VideoPlayer/test/TestVideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/test/TestVideoPlayer.cpp
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ServiceBroker.h"
+#include "cores/IPlayerCallback.h"
+#include "cores/VideoPlayer/VideoPlayer.h"
+#include "jobs/JobManager.h"
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+class CFileItem;
+
+class CTestPlayerCallback : public IPlayerCallback
+{
+public:
+  void OnPlayBackEnded() override {}
+  void OnPlayBackStarted(const CFileItem& file) override {}
+  void OnPlayBackStopped() override {}
+  void OnPlayBackError() override {}
+  void OnQueueNextItem() override {}
+};
+
+class CTestVideoPlayer : public CVideoPlayer
+{
+public:
+  explicit CTestVideoPlayer(IPlayerCallback& c) : CVideoPlayer(c) {}
+  virtual ~CTestVideoPlayer() {}
+
+  int InvokeGetPreviousBookmark(std::chrono::milliseconds ts) { return GetPreviousBookmark(ts); }
+  int InvokeGetNextBookmark(std::chrono::milliseconds ts) { return GetNextBookmark(ts); }
+  std::optional<std::chrono::milliseconds> InvokeGetBookmarkPos(int idx)
+  {
+    return GetBookmarkPos(idx);
+  }
+};
+
+class TestVideoPlayer : public testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    CServiceBroker::RegisterJobManager(std::make_shared<CJobManager>());
+  }
+  static void TearDownTestSuite() { CServiceBroker::UnregisterJobManager(); }
+};
+
+TEST_F(TestVideoPlayer, GetPreviousBookmark)
+{
+  CTestPlayerCallback playercallback;
+  CTestVideoPlayer player(playercallback);
+
+  std::vector<std::chrono::milliseconds> bookmarks{100s, 200s};
+  player.SetBookmarks(bookmarks);
+
+  std::chrono::milliseconds ts{0s};
+  int idx = player.InvokeGetPreviousBookmark(ts);
+  EXPECT_EQ(-1, idx);
+  ts = 100s;
+  idx = player.InvokeGetPreviousBookmark(ts);
+  EXPECT_EQ(-1, idx);
+  // 5-second grade delay
+  ts = 105s;
+  idx = player.InvokeGetPreviousBookmark(ts);
+  EXPECT_EQ(-1, idx);
+  ts = 106s;
+  idx = player.InvokeGetPreviousBookmark(ts);
+  EXPECT_EQ(0, idx);
+  ts = 200s;
+  idx = player.InvokeGetPreviousBookmark(ts);
+  EXPECT_EQ(0, idx);
+  // 5-second grade delay
+  ts = 205s;
+  idx = player.InvokeGetPreviousBookmark(ts);
+  EXPECT_EQ(0, idx);
+  ts = 206s;
+  idx = player.InvokeGetPreviousBookmark(ts);
+  EXPECT_EQ(1, idx);
+}
+
+TEST_F(TestVideoPlayer, GetNextBookmark)
+{
+  CTestPlayerCallback playercallback;
+  CTestVideoPlayer player(playercallback);
+
+  std::vector<std::chrono::milliseconds> bookmarks{100s, 200s};
+  player.SetBookmarks(bookmarks);
+
+  std::chrono::milliseconds ts{0s};
+  int idx = player.InvokeGetNextBookmark(ts);
+  EXPECT_EQ(0, idx);
+  ts = 100s;
+  idx = player.InvokeGetNextBookmark(ts);
+  EXPECT_EQ(1, idx);
+  ts = 101s;
+  idx = player.InvokeGetNextBookmark(ts);
+  EXPECT_EQ(1, idx);
+  ts = 200s;
+  idx = player.InvokeGetNextBookmark(ts);
+  EXPECT_EQ(-1, idx);
+  ts = 201s;
+  idx = player.InvokeGetNextBookmark(ts);
+  EXPECT_EQ(-1, idx);
+}
+
+TEST_F(TestVideoPlayer, GetBookmarkPos)
+{
+  CTestPlayerCallback playercallback;
+  CTestVideoPlayer player(playercallback);
+
+  std::vector<std::chrono::milliseconds> bookmarks{100s, 200s};
+  player.SetBookmarks(bookmarks);
+
+  std::optional<std::chrono::milliseconds> pos = player.InvokeGetBookmarkPos(-1);
+
+  EXPECT_FALSE(pos.has_value());
+
+  pos = player.InvokeGetBookmarkPos(0);
+  EXPECT_TRUE(pos.has_value());
+  if (pos.has_value())
+  {
+    // braces to quiet clang warning
+    EXPECT_EQ(100s, pos.value());
+  }
+
+  pos = player.InvokeGetBookmarkPos(1);
+  EXPECT_TRUE(pos.has_value());
+  if (pos.has_value())
+  {
+    // braces to quiet clang warning
+    EXPECT_EQ(200s, pos.value());
+  }
+
+  pos = player.InvokeGetBookmarkPos(2);
+  EXPECT_FALSE(pos.has_value());
+}

--- a/xbmc/guilib/GUIRangesControl.dox
+++ b/xbmc/guilib/GUIRangesControl.dox
@@ -39,7 +39,7 @@ important, as xml tags are case-sensitive.
 | lefttexture   | The texture used in the left hand side of the range
 | midtexture    | The texture used for the mid section of the range
 | righttexture  | The texture used in the right hand side of the range
-| info          | Specifies the information the range control holds. It expects an infolabel that returns a string in CSV format: e.g. `"start1,end1,start2,end2,..."`. Tokens must have values in the range from 0.0 to 100.0. end token must be less or equal than start token. Examples of currently supported infolabels are \link Player_Editlist `Player.Editlist`\endlink, \link Player_Cutlist `Player.Cutlist`\endlink, \link Player_Cuts `Player.Cuts`\endlink, \link Player_SceneMarkers `Player.Cutlist`\endlink and \link Player_Chapters `Player.Chapters`\endlink. \n @deprecated \link Player_Cutlist `Player.Cutlist`\endlink is deprecated use \link Player_Cuts `Player.Cuts`\endlink instead.
+| info          | Specifies the information the range control holds. It expects an infolabel that returns a string in CSV format: e.g. `"start1,end1,start2,end2,..."`. Tokens must have values in the range from 0.0 to 100.0. end token must be less or equal than start token. Examples of currently supported infolabels are \link Player_Editlist `Player.Editlist`\endlink, \link Player_Cutlist `Player.Cutlist`\endlink, \link Player_Cuts `Player.Cuts`\endlink, \link Player_SceneMarkers `Player.Cutlist`\endlink, \link Player_Chapters `Player.Chapters`\endlink and \link Player_Bookmarks `Player.Bookmarks`\endlink. \n @deprecated \link Player_Cutlist `Player.Cutlist`\endlink is deprecated use \link Player_Cuts `Player.Cuts`\endlink instead.
 
 \section Ranges_Control_sect3 Revision History
 

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -81,7 +81,9 @@ constexpr uint32_t PLAYER_EDITLIST                   = 69;
 constexpr uint32_t PLAYER_CUTS                       = 70;
 constexpr uint32_t PLAYER_SCENE_MARKERS              = 71;
 constexpr uint32_t PLAYER_HAS_SCENE_MARKERS          = 72;
-// unused id 73 to 80
+constexpr uint32_t PLAYER_BOOKMARKS                  = 73;
+constexpr uint32_t PLAYER_HAS_BOOKMARKS              = 74;
+// unused id 75 to 80
 
 // Keep player infolabels that work with offset and position together
 constexpr uint32_t PLAYER_PATH                       = 81;

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -304,6 +304,7 @@ bool CPlayerGUIInfo::GetLabel(std::string& value,
     case PLAYER_CUTS:
     case PLAYER_SCENE_MARKERS:
     case PLAYER_CHAPTERS:
+    case PLAYER_BOOKMARKS:
       value = GetContentRanges(info.GetInfo());
       return true;
 
@@ -564,6 +565,9 @@ bool CPlayerGUIInfo::GetBool(bool& value,
     case PLAYER_HAS_SCENE_MARKERS:
       value = !CServiceBroker::GetDataCacheCore().GetSceneMarkers().empty();
       return true;
+    case PLAYER_HAS_BOOKMARKS:
+      value = !CServiceBroker::GetDataCacheCore().GetBookmarks().empty();
+      return true;
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // PLAYLIST_*
@@ -682,6 +686,9 @@ std::string CPlayerGUIInfo::GetContentRanges(int iInfo) const
       case PLAYER_CHAPTERS:
         ranges = GetChapters(data, duration);
         break;
+      case PLAYER_BOOKMARKS:
+        ranges = GetBookmarks(data, duration);
+        break;
       default:
         CLog::Log(LOGERROR, "CPlayerGUIInfo::GetContentRanges({}) - unhandled guiinfo", iInfo);
         break;
@@ -767,6 +774,24 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetChapters(const CDataCach
     const float marker =
         static_cast<float>(chapterEnd * 1000) * 100.0f / static_cast<float>(duration);
     if (marker != 0.0f)
+      ranges.emplace_back(lastMarker, marker);
+
+    lastMarker = marker;
+  }
+  return ranges;
+}
+
+std::vector<std::pair<float, float>> CPlayerGUIInfo::GetBookmarks(const CDataCacheCore& data,
+                                                                  std::time_t duration) const
+{
+  std::vector<std::pair<float, float>> ranges;
+
+  const std::vector<std::chrono::milliseconds>& bookmarks = data.GetBookmarks();
+  float lastMarker = 0.0f;
+  for (const auto& scene : bookmarks)
+  {
+    float marker = scene.count() * 100.0f / duration;
+    if (marker != 0)
       ranges.emplace_back(lastMarker, marker);
 
     lastMarker = marker;

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -710,6 +710,9 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetEditList(const CDataCach
 {
   std::vector<std::pair<float, float>> ranges;
 
+  if (duration == 0)
+    return ranges;
+
   const std::vector<EDL::Edit>& edits = data.GetEditList();
   for (const auto& edit : edits)
   {
@@ -724,6 +727,9 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetCuts(const CDataCacheCor
                                                              std::time_t duration) const
 {
   std::vector<std::pair<float, float>> ranges;
+
+  if (duration == 0)
+    return ranges;
 
   const std::vector<std::chrono::milliseconds>& cuts = data.GetCuts();
   float lastMarker = 0.0f;
@@ -749,6 +755,9 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetSceneMarkers(const CData
 {
   std::vector<std::pair<float, float>> ranges;
 
+  if (duration == 0)
+    return ranges;
+
   const std::vector<std::chrono::milliseconds>& scenes = data.GetSceneMarkers();
   float lastMarker = 0.0f;
   for (const auto& scene : scenes)
@@ -766,6 +775,9 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetChapters(const CDataCach
                                                                  std::time_t duration) const
 {
   std::vector<std::pair<float, float>> ranges;
+
+  if (duration == 0)
+    return ranges;
 
   const std::vector<std::pair<std::string, int64_t>>& chapters = data.GetChapters();
   float lastMarker = 0.0f;
@@ -785,6 +797,9 @@ std::vector<std::pair<float, float>> CPlayerGUIInfo::GetBookmarks(const CDataCac
                                                                   std::time_t duration) const
 {
   std::vector<std::pair<float, float>> ranges;
+
+  if (duration == 0)
+    return ranges;
 
   const std::vector<std::chrono::milliseconds>& bookmarks = data.GetBookmarks();
   float lastMarker = 0.0f;

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.h
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2018 Team Kodi
+ *  Copyright (C) 2012-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -85,6 +85,8 @@ private:
                                                        std::time_t duration) const;
   std::vector<std::pair<float, float>> GetChapters(const CDataCacheCore& data,
                                                    std::time_t duration) const;
+  std::vector<std::pair<float, float>> GetBookmarks(const CDataCacheCore& data,
+                                                    std::time_t duration) const;
 
   std::unique_ptr<CFileItem> m_currentItem;
   std::atomic_bool m_playerShowTime{false};

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -823,7 +823,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
 
     //0 = disable fps detect, 1 = only detect on timestamps with uniform spacing, 2 detect on all timestamps
     XMLUtils::GetInt(pElement, "fpsdetect", m_videoFpsDetect, 0, 2);
-    XMLUtils::GetFloat(pElement, "maxtempo", m_maxTempo, 1.5, 2.1);
+    XMLUtils::GetFloat(pElement, "maxtempo", m_maxTempo, 1.5, 2.0);
     XMLUtils::GetBoolean(pElement, "preferstereostream", m_videoPreferStereoStream);
 
     // Store global display latency settings

--- a/xbmc/video/Bookmark.cpp
+++ b/xbmc/video/Bookmark.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -7,6 +7,8 @@
  */
 
 #include "Bookmark.h"
+
+#include "video/VideoDatabase.h"
 
 CBookmark::CBookmark()
 {
@@ -36,4 +38,49 @@ bool CBookmark::IsPartWay() const
 bool CBookmark::HasSavedPlayerState() const
 {
   return !playerState.empty();
+}
+
+bool CBookmark::GetBookmarksForFile(const std::string& filePath,
+                                    VECBOOKMARKS& bookmarks,
+                                    std::vector<EType> types)
+{
+  bookmarks.clear();
+
+  CVideoDatabase videoDatabase;
+  if (!videoDatabase.Open())
+    return false;
+
+  for (CBookmark::EType type : types)
+    videoDatabase.GetBookMarksForFile(filePath, bookmarks, type, true);
+
+  videoDatabase.Close();
+  return true;
+}
+
+std::vector<std::chrono::milliseconds> CBookmark::BookmarksToPositions(
+    const VECBOOKMARKS& bookmarks)
+{
+  std::vector<std::chrono::milliseconds> result;
+  for (const CBookmark& b : bookmarks)
+  {
+    if (b.type == CBookmark::STANDARD)
+    {
+      std::chrono::duration<double> sec(b.timeInSeconds);
+      result.push_back(std::chrono::duration_cast<std::chrono::milliseconds>(sec));
+    }
+  }
+  std::ranges::sort(result);
+
+  return result;
+}
+
+void CBookmark::AddToPositions(const CBookmark& bookmark,
+                               std::vector<std::chrono::milliseconds>& positions)
+{
+  if (bookmark.type == CBookmark::STANDARD)
+  {
+    std::chrono::duration<double> sec(bookmark.timeInSeconds);
+    positions.push_back(std::chrono::duration_cast<std::chrono::milliseconds>(sec));
+    std::ranges::sort(positions); //! @todo use a std::set instead?
+  }
 }

--- a/xbmc/video/Bookmark.h
+++ b/xbmc/video/Bookmark.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,12 +8,23 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
 #include <vector>
+
+class CBookmark;
+typedef std::vector<CBookmark> VECBOOKMARKS;
 
 class CBookmark
 {
 public:
+  enum EType
+  {
+    STANDARD = 0,
+    RESUME = 1,
+    EPISODE = 2
+  } type;
+
   CBookmark();
   void Reset();
 
@@ -32,6 +43,31 @@ public:
    */
   bool HasSavedPlayerState() const;
 
+  /*!
+   * \brief Retrieve bookmarks for the file
+   * \param[in] filePath file
+   * \param[in,out] bookmarks list of bookmarks
+   * \param[in] types types of bookmark to retrieve
+   * \return true for success, false otherwise
+   */
+  static bool GetBookmarksForFile(const std::string& filePath,
+                                  VECBOOKMARKS& bookmarks,
+                                  std::vector<EType> types);
+
+  /*!
+   * \brief Create a list of the start timestamps of the standard bookmarks from the provided list
+   * \param[in] bookmarks list of bookmarks
+   * \return list of bookmarks' start timestamp
+   */
+  static std::vector<std::chrono::milliseconds> BookmarksToPositions(const VECBOOKMARKS& bookmarks);
+  /*!
+   * \brief Add a bookmark to the provided list
+   * \param[in] bookmark the bookmark
+   * \param[in] positions list of bookmark start timestamps
+   */
+  static void AddToPositions(const CBookmark& bookmark,
+                             std::vector<std::chrono::milliseconds>& positions);
+
   double timeInSeconds;
   double totalTimeInSeconds;
   long partNumber;
@@ -40,14 +76,4 @@ public:
   std::string player;
   long seasonNumber;
   long episodeNumber;
-
-  enum EType
-  {
-    STANDARD = 0,
-    RESUME = 1,
-    EPISODE = 2
-  } type;
 };
-
-typedef std::vector<CBookmark> VECBOOKMARKS;
-

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -228,19 +228,24 @@ void CGUIDialogVideoBookmarks::Delete(const CBookmark& bm)
 
 void CGUIDialogVideoBookmarks::OnRefreshList()
 {
-  m_bookmarks.clear();
-  std::vector<CFileItemPtr> items;
-
   // open the d/b and retrieve the bookmarks for the current movie
   m_filePath = g_application.CurrentFileItem().GetDynPath();
 
-  CVideoDatabase videoDatabase;
-  if (!videoDatabase.Open())
+  if (!CBookmark::GetBookmarksForFile(m_filePath, m_bookmarks,
+                                      {CBookmark::STANDARD, CBookmark::EPISODE}))
     return;
 
-  videoDatabase.GetBookMarksForFile(m_filePath, m_bookmarks);
-  videoDatabase.GetBookMarksForFile(m_filePath, m_bookmarks, CBookmark::EPISODE, true);
-  videoDatabase.Close();
+  {
+    auto& components = CServiceBroker::GetAppComponents();
+    const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+    if (appPlayer != nullptr)
+    {
+      std::vector<std::chrono::milliseconds> pos = CBookmark::BookmarksToPositions(m_bookmarks);
+      appPlayer->SetBookmarks(pos);
+    }
+  }
+
+  std::vector<CFileItemPtr> items;
 
   std::unique_lock lock(m_refreshSection);
   m_vecItems->Clear();
@@ -506,6 +511,10 @@ bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
   {
     const std::string path{g_application.CurrentFileItem().GetDynPath()};
     videoDatabase.AddBookMarkToFile(path, bookmark, CBookmark::STANDARD);
+
+    std::vector<std::chrono::milliseconds> positions = appPlayer->GetBookmarks();
+    CBookmark::AddToPositions(bookmark, positions);
+    appPlayer->SetBookmarks(positions);
   }
   videoDatabase.Close();
   return true;

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES TestStacks.cpp
+set(SOURCES TestBookmark.cpp
+            TestStacks.cpp
             TestVideoDbUrl.cpp
             TestVideoFileItemClassify.cpp
             TestVideoInfoTag.cpp

--- a/xbmc/video/test/TestBookmark.cpp
+++ b/xbmc/video/test/TestBookmark.cpp
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "video/Bookmark.h"
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+CBookmark BuildBookmark(CBookmark::EType type, double timeInSeconds)
+{
+  CBookmark b;
+  b.type = type;
+  b.timeInSeconds = timeInSeconds;
+  return b;
+}
+} // namespace
+
+TEST(TestBookmark, BookmarksToPositions)
+{
+  // Sort by timestamps, only standard bookmarks.
+  VECBOOKMARKS bookmarks{
+      BuildBookmark(CBookmark::STANDARD, 200),
+      BuildBookmark(CBookmark::STANDARD, 100),
+      BuildBookmark(CBookmark::EPISODE, 300),
+      BuildBookmark(CBookmark::RESUME, 400),
+  };
+
+  auto positions = CBookmark::BookmarksToPositions(bookmarks);
+
+  ASSERT_EQ(2, positions.size());
+  ASSERT_EQ(positions[0], 100s);
+  ASSERT_EQ(positions[1], 200s);
+}
+
+TEST(TestBookmark, AddToPositions)
+{
+  // Standard bookmark, time converted from seconds.
+  CBookmark b = BuildBookmark(CBookmark::STANDARD, 123);
+
+  std::vector<std::chrono::milliseconds> positions{100s, 200s};
+
+  CBookmark::AddToPositions(b, positions);
+
+  ASSERT_EQ(3, positions.size());
+  ASSERT_EQ(positions[0], 100s);
+  ASSERT_EQ(positions[1], 123s);
+  ASSERT_EQ(positions[2], 200s);
+
+  // Episode bookmark ignored
+  b = BuildBookmark(CBookmark::EPISODE, 234);
+
+  CBookmark::AddToPositions(b, positions);
+
+  ASSERT_EQ(3, positions.size());
+  ASSERT_EQ(positions[0], 100s);
+  ASSERT_EQ(positions[1], 123s);
+  ASSERT_EQ(positions[2], 200s);
+}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Added the timestamps of the user bookmarks to VideoPlayer, AppPlayer and DataCacheCore. The resume point and episode bookmarks stored in the same database table are ignored.

Added new infolabels:
- info bool Player.HasBookmarks, true the playing item has bookmarks
- info label Player.Bookmarks contains the list of start/end timestamps of the bookmarks, in the format expected by "ranges" controls

The Estuary commit is only there as a functional proof of concept; @jjd-uk or @Hitcher will certainly have better ideas (a miniature bookmark sign? different color? ...)

<img width="1789" height="76" alt="image" src="https://github.com/user-attachments/assets/60c39ace-426b-4d82-b6cd-d2b2f368f322" />


The last commit (more work and testing needed) alters the actions ACTION_CHAPTER_OR_BIG_STEP_FORWARD and ACTION_CHAPTER_OR_BIG_STEP_BACK.
The play position jumps to the next or previous chapter or bookmark, whichever one is closest to the current position.
Known issues:
- ~skipping back repeatedly to bookmarks may be difficult (have to skip back twice quickly as workaround for now)~
- ~playback may not stop after skipping forward after the last bookmark (skips to the end of the file but doesn't always stop)~
- ~add unit tests~ done, though it's not easy to unit test videoplayer but there is no other way to unit test with the current architecture.

The architecture is not great - managing navigation doesn't seem like a player task to me (we'd want it shared if a videoplayer2 appeared for example), a future PR should extract navigation into an intermediate component between the player and the application.

Open questions:
- Integrate bookmarks in other jump actions, like the PlayerControl(Previous)/(Next) actions and their visual indicators in the OSD? 
<img width="471" height="85" alt="image" src="https://github.com/user-attachments/assets/ddfdda06-35c0-428c-ae3d-f5e8a748195f" />

- in case of widely spaced chapters and bookmarks, jump to the nearest big step (default 10 minutes) if it's closer than the nearest chapter or bookmark?

Bookmark accuracy is still 1 second - improving to millisecond will be another PR.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It's a pain to open the chapters dialog from the OSD to skip to the next or previous bookmark.
Can't see in the timelines if the video has bookmarks.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Keeping track of bookmarks / info labels: solid
Navigation testing: unit test for the bookmarks functions, more manual tests to do, there are known issues at this time

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

More intuitive behavior when skipping forward or back and skip to bookmarks as well, not only chapters.

## Screenshots (if appropriate):

2 bookmarks before the second chapter:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/28f4e7d4-ec61-4466-ad13-4718662eb2f8" />

The black chapter thumbs are normal, the video is black on those chapter changes.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
