### PR TITLE
[GUI] Fix nested label formatting

### DIFF
--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -388,11 +388,11 @@ void CGUITextLayout::ParseText(const std::wstring& text,
   // With simple |= / &=~ the first [/B] would clear bold for everything that follows.
   // With reference counts the bit stays set until the last matching open tag is closed.
   // Unmatched closing tags are no-ops (count floors at 0).
-  int boldDepth       = 0;
-  int italicDepth     = 0;
-  int lightDepth      = 0;
-  int uppercaseDepth  = 0;
-  int lowercaseDepth  = 0;
+  int boldDepth = 0;
+  int italicDepth = 0;
+  int lightDepth = 0;
+  int uppercaseDepth = 0;
+  int lowercaseDepth = 0;
   int capitalizeDepth = 0;
 
   int startPos = 0;
@@ -420,7 +420,8 @@ void CGUITextLayout::ParseText(const std::wstring& text,
         ++boldDepth;
       else if (boldDepth > 0)
         --boldDepth;
-      else {
+      else
+	  {
         // unmatched [/B] - ignore
       }
       newStyle = FONT_STYLE_BOLD;
@@ -541,12 +542,18 @@ void CGUITextLayout::ParseText(const std::wstring& text,
       startPos = pos;
       currentColor = newColor;
       currentStyle = defaultStyle;
-      if (boldDepth       > 0) currentStyle |= FONT_STYLE_BOLD;
-      if (italicDepth     > 0) currentStyle |= FONT_STYLE_ITALICS;
-      if (lightDepth      > 0) currentStyle |= FONT_STYLE_LIGHT;
-      if (uppercaseDepth  > 0) currentStyle |= FONT_STYLE_UPPERCASE;
-      if (lowercaseDepth  > 0) currentStyle |= FONT_STYLE_LOWERCASE;
-      if (capitalizeDepth > 0) currentStyle |= FONT_STYLE_CAPITALIZE;
+      if (boldDepth > 0)
+        currentStyle |= FONT_STYLE_BOLD;
+      if (italicDepth > 0)
+        currentStyle |= FONT_STYLE_ITALICS;
+      if (lightDepth > 0)
+        currentStyle |= FONT_STYLE_LIGHT;
+      if (uppercaseDepth > 0)
+        currentStyle |= FONT_STYLE_UPPERCASE;
+      if (lowercaseDepth > 0)
+        currentStyle |= FONT_STYLE_LOWERCASE;
+      if (capitalizeDepth > 0)
+        currentStyle |= FONT_STYLE_CAPITALIZE;
     }
     pos = text.find(L'[', pos);
   }

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -420,8 +420,9 @@ void CGUITextLayout::ParseText(const std::wstring& text,
         ++boldDepth;
       else if (boldDepth > 0)
         --boldDepth;
-      else
-        ; // unmatched [/B] - ignore
+      else {
+        // unmatched [/B] - ignore
+      }
       newStyle = FONT_STYLE_BOLD;
     }
     else if (text.compare(pos, 2, L"I]") == 0)

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -381,9 +381,19 @@ void CGUITextLayout::ParseText(const std::wstring& text,
   std::stack<KODI::UTILS::COLOR::Color> colorStack;
   colorStack.push(0);
 
-  // these aren't independent, but that's probably not too much of an issue
-  // eg [UPPERCASE]Glah[LOWERCASE]FReD[/LOWERCASE]Georeg[/UPPERCASE] will work (lower case >> upper case)
-  // but [LOWERCASE]Glah[UPPERCASE]FReD[/UPPERCASE]Georeg[/LOWERCASE] won't
+  // Boolean style tags ([B], [I], [LIGHT], [UPPERCASE], [LOWERCASE], [CAPITALIZE])
+  // use per-tag reference counts so that nested identical tags work correctly.
+  // This fixes the case where a skin wraps a label in e.g. [B]...[/B] while the
+  // addon has already formatted the value with [B]...[/B], producing [B][B]text[/B][/B].
+  // With simple |= / &=~ the first [/B] would clear bold for everything that follows.
+  // With reference counts the bit stays set until the last matching open tag is closed.
+  // Unmatched closing tags are no-ops (count floors at 0).
+  int boldDepth       = 0;
+  int italicDepth     = 0;
+  int lightDepth      = 0;
+  int uppercaseDepth  = 0;
+  int lowercaseDepth  = 0;
+  int capitalizeDepth = 0;
 
   int startPos = 0;
   size_t pos = text.find(L'[');
@@ -404,46 +414,60 @@ void CGUITextLayout::ParseText(const std::wstring& text,
     }
     // check for each type
     if (text.compare(pos, 2, L"B]") == 0)
-    { // bold - finish the current text block and assign the bold state
+    { // bold
       pos += 2;
-      if ((on && text.find(L"[/B]",pos) != std::string::npos) ||          // check for a matching end point
-         (!on && (currentStyle & FONT_STYLE_BOLD)))       // or matching start point
-        newStyle = FONT_STYLE_BOLD;
+      if (on)
+        ++boldDepth;
+      else if (boldDepth > 0)
+        --boldDepth;
+      else
+        ; // unmatched [/B] - ignore
+      newStyle = FONT_STYLE_BOLD;
     }
     else if (text.compare(pos, 2, L"I]") == 0)
     { // italics
       pos += 2;
-      if ((on && text.find(L"[/I]", pos) != std::string::npos) ||          // check for a matching end point
-         (!on && (currentStyle & FONT_STYLE_ITALICS)))    // or matching start point
-        newStyle = FONT_STYLE_ITALICS;
+      if (on)
+        ++italicDepth;
+      else if (italicDepth > 0)
+        --italicDepth;
+      newStyle = FONT_STYLE_ITALICS;
     }
     else if (text.compare(pos, 10, L"UPPERCASE]") == 0)
     {
       pos += 10;
-      if ((on && text.find(L"[/UPPERCASE]", pos) != std::string::npos) ||  // check for a matching end point
-         (!on && (currentStyle & FONT_STYLE_UPPERCASE)))  // or matching start point
-        newStyle = FONT_STYLE_UPPERCASE;
+      if (on)
+        ++uppercaseDepth;
+      else if (uppercaseDepth > 0)
+        --uppercaseDepth;
+      newStyle = FONT_STYLE_UPPERCASE;
     }
     else if (text.compare(pos, 10, L"LOWERCASE]") == 0)
     {
       pos += 10;
-      if ((on && text.find(L"[/LOWERCASE]", pos) != std::string::npos) ||  // check for a matching end point
-         (!on && (currentStyle & FONT_STYLE_LOWERCASE)))  // or matching start point
-        newStyle = FONT_STYLE_LOWERCASE;
+      if (on)
+        ++lowercaseDepth;
+      else if (lowercaseDepth > 0)
+        --lowercaseDepth;
+      newStyle = FONT_STYLE_LOWERCASE;
     }
     else if (text.compare(pos, 11, L"CAPITALIZE]") == 0)
     {
       pos += 11;
-      if ((on && text.find(L"[/CAPITALIZE]", pos) != std::string::npos) ||  // check for a matching end point
-         (!on && (currentStyle & FONT_STYLE_CAPITALIZE)))  // or matching start point
-        newStyle = FONT_STYLE_CAPITALIZE;
+      if (on)
+        ++capitalizeDepth;
+      else if (capitalizeDepth > 0)
+        --capitalizeDepth;
+      newStyle = FONT_STYLE_CAPITALIZE;
     }
     else if (text.compare(pos, 6, L"LIGHT]") == 0)
     {
       pos += 6;
-      if ((on && text.find(L"[/LIGHT]", pos) != std::string::npos) ||
-         (!on && (currentStyle & FONT_STYLE_LIGHT)))
-        newStyle = FONT_STYLE_LIGHT;
+      if (on)
+        ++lightDepth;
+      else if (lightDepth > 0)
+        --lightDepth;
+      newStyle = FONT_STYLE_LIGHT;
     }
     else if (text.compare(pos, 5, L"TABS]") == 0 && on)
     {
@@ -463,7 +487,7 @@ void CGUITextLayout::ParseText(const std::wstring& text,
       pos += 3;
     }
     else if (text.compare(pos,5, L"COLOR") == 0)
-    { // color
+    { // color - already stack-based, unchanged
       size_t finish = text.find(L']', pos + 5);
       if (on && finish != std::string::npos && text.find(L"[/COLOR]",finish) != std::string::npos)
       {
@@ -512,13 +536,16 @@ void CGUITextLayout::ParseText(const std::wstring& text,
       for (int i = 0; i < tabs; ++i)
         parsedText.push_back(L'\t');
 
-      // and switch to the new style
+      // switch to the new style, deriving it from the current depths
       startPos = pos;
       currentColor = newColor;
-      if (on)
-        currentStyle |= newStyle;
-      else
-        currentStyle &= ~newStyle;
+      currentStyle = defaultStyle;
+      if (boldDepth       > 0) currentStyle |= FONT_STYLE_BOLD;
+      if (italicDepth     > 0) currentStyle |= FONT_STYLE_ITALICS;
+      if (lightDepth      > 0) currentStyle |= FONT_STYLE_LIGHT;
+      if (uppercaseDepth  > 0) currentStyle |= FONT_STYLE_UPPERCASE;
+      if (lowercaseDepth  > 0) currentStyle |= FONT_STYLE_LOWERCASE;
+      if (capitalizeDepth > 0) currentStyle |= FONT_STYLE_CAPITALIZE;
     }
     pos = text.find(L'[', pos);
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Replace simple bit toggling for boolean style tags ([B],[I],[LIGHT],[UPPERCASE],[LOWERCASE],[CAPITALIZE]) with per-tag depth counters so nested identical tags work correctly. Unmatched closing tags are now ignored (counts floor at 0). currentStyle is recomputed from the depth counters instead of using |= / &=~, and color handling remains stack-based and unchanged. This prevents premature clearing of a style when multiple nested opens are present (e.g. [B][B]text[/B][/B]).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Nested styles have been broken for a long time: https://github.com/xbmc/xbmc/issues/25263

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested across all styles.
Windows build: https://mirrors.kodi.tv/test-builds/windows/win64/KodiSetup-20260508-353ffd15-fix_nested_label_formatting-x64.exe
Drop this into /kodi/addons/Estuary/xml/
[Custom_1234_test.xml](https://github.com/user-attachments/files/27554095/Custom_1234_test.xml)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Before:
<img width="1920" height="1080" alt="Screenshot (99)" src="https://github.com/user-attachments/assets/38897596-4162-4a8c-9499-9824bfe52219" />

After:
<img width="1920" height="1080" alt="Screenshot (98)" src="https://github.com/user-attachments/assets/f74ee0ea-c829-4790-b2b6-284bdd8a75b6" />


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
