### PR TITLE
[cmake] FindFFMPEG fix header property being applied with a valid target

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -457,14 +457,14 @@ else()
                                                    IMPORTED_LOCATION "${FFMPEG_${libname_UPPER}}"
                                                    INTERFACE_LINK_LIBRARIES "${${libname}_LDFLAGS}")
         endif()
-      endif()
 
-      if(FFMPEG_${libname_UPPER}_INCLUDE_DIRS)
-        set_target_properties(ffmpeg::${libname} PROPERTIES
-                                                 INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_${libname_UPPER}_INCLUDE_DIRS}")
-      else()
-        set_target_properties(ffmpeg::${libname} PROPERTIES
-                                                 INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIRS}")
+        if(FFMPEG_${libname_UPPER}_INCLUDE_DIRS)
+          set_target_properties(ffmpeg::${libname} PROPERTIES
+                                                   INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_${libname_UPPER}_INCLUDE_DIRS}")
+        else()
+          set_target_properties(ffmpeg::${libname} PROPERTIES
+                                                   INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIRS}")
+        endif()
       endif()
     endmacro()
 


### PR DESCRIPTION
## Description
The header property application needs to be inside the ``if(FFMPEG_${libname_UPPER})`` check as source plugins may be in the ``FFMPEG_PKGS`` list, but not actually found/used

## Motivation and context
Fixes #28200

A diff was supplied to an external contributor with https://github.com/xbmc/xbmc/pull/28127#pullrequestreview-4098327958 but applied incorrectly to the final commit. The final commit has the target property being changed outside of the scope of whether ``FFMPEG_${libname_UPPER}`` had data, and therefore created a target. We need it gated, as the initial target creation checks may be run with source plugins (ie postproc) existing in the ``FFMPEG_PKGS`` list

## How has this been tested?
Locally with/without postproc pkgconfig data

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
