### PR TITLE
[GUI] Fix scrolling text speed scaling with display resolution

### DIFF
--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -154,9 +154,7 @@ bool CGUIFont::UpdateScrollInfo(std::span<const character_t> text, CScrollInfo& 
 
   CScrollInfo old(scrollInfo);
 
-  // move along by the appropriate scroll amount
-  float scrollAmount =
-      fabs(scrollInfo.GetPixelsPerFrame() * winSystem->GetGfxContext().GetGUIScaleX());
+  float scrollAmount = fabs(scrollInfo.GetPixelsPerFrame());
 
   if (!scrollInfo.m_widthValid)
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
CGUIFont::UpdateScrollInfo() calculated the per-frame scroll amount in screen pixels
by multiplying GetPixelsPerFrame() by GetGUIScaleX(), but m_pixelPos was then compared
and wrapped against m_totalWidth which is in skin-coordinate pixels. This mismatch caused
the visual scroll speed to vary with resolution - scrolling too fast at resolutions below
the skin's native resolution and too slow at resolutions above it.

Fix by keeping m_pixelPos in skin-coordinate space (removing the GetGUIScaleX() multiply).
DrawScrollingText already divides m_textWidth and m_totalWidth by GetGUIScaleX() when
passing to DrawTextInternal, so the correct screen-pixel conversion happens at render time.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes: https://github.com/xbmc/xbmc/issues/24935

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally at 720p, 1080p, and 4k.

Steps to reproduce the behavior:

1. Drop the Custom_1111_Scrollspeed_Test.xml into Estuary's xml folder
2. Navigate to System Settings
3. Observe the label scrolling speed at various resolutions

[Custom_1111_Scrollspeed_Test.zip](https://github.com/xbmc/xbmc/files/14827099/Custom_1111_Scrollspeed_Test.zip)

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
