### PR TITLE
[GUI] Add Control.ResetGrouplist(ID) feature for resetting grouplist focus item

### DIFF
--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -20,6 +20,8 @@
 #include "utils/StringUtils.h"
 #include "windowing/WinSystem.h"
 
+#include <algorithm>
+
 using namespace KODI;
 
 CGUIControlGroupList::CGUIControlGroupList(int parentID, int controlID, float posX, float posY, float width, float height, float itemGap, int pageControl, ORIENTATION orientation, bool useControlPositions, uint32_t alignment, const CScroller& scroller)
@@ -188,6 +190,19 @@ bool CGUIControlGroupList::OnAction(const CAction& action)
       return true;
   }
   return CGUIControlGroup::OnAction(action);
+}
+
+bool CGUIControlGroupList::ResetFocusToFirstItem()
+{
+  CGUIControl* firstControl = GetFirstVisibleFocusableControl();
+  if (firstControl == nullptr)
+    return false;
+
+  if (!SetFocusedControl(firstControl))
+    return false;
+
+  ScrollTo(0.f);
+  return true;
 }
 
 bool CGUIControlGroupList::OnMessage(CGUIMessage& message)
@@ -733,39 +748,45 @@ void CGUIControlGroupList::ScrollPages(float pages)
   ScrollTo(newOffset);
 }
 
-void CGUIControlGroupList::MoveTo(CGUIControl* control, float offset)
+bool CGUIControlGroupList::SetFocusedControl(CGUIControl* control)
 {
-  CGUIControl* focusedControl = GetFocusedControl();
+  if (control == nullptr)
+    return false;
 
-  if (focusedControl && control)
+  CGUIControl* focusedControl = GetFocusedControl();
+  if (focusedControl != nullptr && focusedControl != control)
   {
     CGUIMessage message(GUI_MSG_LOSTFOCUS, GetID(), focusedControl->GetID(), control->GetID());
     focusedControl->OnMessage(message);
-
-    CGUIMessage message2(GUI_MSG_SETFOCUS, GetID(), control->GetID());
-    control->OnMessage(message2);
   }
+
+  CGUIMessage message(GUI_MSG_SETFOCUS, GetID(), control->GetID());
+  return control->OnMessage(message);
+}
+
+void CGUIControlGroupList::MoveTo(CGUIControl* control, float offset)
+{
+  SetFocusedControl(control);
   ScrollTo(offset);
 }
 
 CGUIControl* CGUIControlGroupList::GetFirstFocusableControl() const
 {
-  for (ciControls it = m_children.begin(); it != m_children.end(); ++it)
-  {
-    CGUIControl* child = *it;
-    if (child->CanFocus())
-      return child;
-  }
-  return nullptr;
+  const auto it =
+      std::ranges::find_if(m_children, [](const auto* child) { return child->CanFocus(); });
+  return it != m_children.end() ? *it : nullptr;
+}
+
+CGUIControl* CGUIControlGroupList::GetFirstVisibleFocusableControl() const
+{
+  const auto it = std::ranges::find_if(m_children, [](const auto* child)
+                                       { return child->IsVisible() && child->CanFocus(); });
+  return it != m_children.end() ? *it : nullptr;
 }
 
 CGUIControl* CGUIControlGroupList::GetLastFocusableControl() const
 {
-  for (crControls it = m_children.rbegin(); it != m_children.rend(); ++it)
-  {
-    CGUIControl* child = *it;
-    if (child->CanFocus())
-      return child;
-  }
-  return nullptr;
+  const auto it = std::ranges::find_if(m_children.rbegin(), m_children.rend(),
+                                       [](const auto* child) { return child->CanFocus(); });
+  return it != m_children.rend() ? *it : nullptr;
 }

--- a/xbmc/guilib/GUIControlGroupList.h
+++ b/xbmc/guilib/GUIControlGroupList.h
@@ -43,6 +43,7 @@ public:
   void Process(unsigned int currentTime, CDirtyRegionList &dirtyregions) override;
   void Render() override;
   bool OnAction(const CAction& action) override;
+  bool ResetFocusToFirstItem();
   bool OnMessage(CGUIMessage& message) override;
 
   EVENT_RESULT SendMouseEvent(const CPoint& point, const KODI::MOUSE::CMouseEvent& event) override;
@@ -98,17 +99,27 @@ protected:
    */
   void ScrollPages(float pages);
   /*!
+   * \brief Change the focused child control using the normal GUI focus message flow.
+   * \param control New focused control
+   * \return True if the control accepted focus, false otherwise.
+   */
+  bool SetFocusedControl(CGUIControl* control);
+  /*!
    * \brief Change the selected control and scroll to the specified position.
    * \param control New selected control
    * \param offset Offset of the top of the visible view
    */
   void MoveTo(CGUIControl* control, float offset);
   /*!
-   * Return the first visible and focusable child control.
+   * Return the first focusable child control.
    */
   CGUIControl* GetFirstFocusableControl() const;
   /*!
-   * Return the last visible and focusable child control.
+   * Return the first visible and focusable child control.
+   */
+  CGUIControl* GetFirstVisibleFocusableControl() const;
+  /*!
+   * Return the last focusable child control.
    */
   CGUIControl* GetLastFocusableControl() const;
 
@@ -130,4 +141,3 @@ protected:
   // for autosizing
   float m_minSize;
 };
-

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -16,6 +16,7 @@
 #include "dialogs/GUIDialogNumeric.h"
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
+#include "guilib/GUIControlGroupList.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/StereoscopicsManager.h"
 #include "input/WindowTranslator.h"
@@ -35,10 +36,70 @@
 #include "utils/log.h"
 #include "windows/GUIMediaWindow.h"
 
+#include <charconv>
+
 using namespace KODI;
 
 namespace
 {
+/*! \brief Reset a grouplist control's focus to its first item.
+ *  \param params The parameters.
+ *  \details params[0] = The control ID of the grouplist to reset.
+ *  \return 1 if focus was reset, 0 otherwise.
+ */
+static int ResetGroupList(const std::vector<std::string>& params)
+{
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (gui == nullptr)
+  {
+    CLog::Log(LOGWARNING, "ResetGroupList: No GUI present");
+    return 0;
+  }
+
+  CGUIWindow* window =
+      gui->GetWindowManager().GetWindow(gui->GetWindowManager().GetActiveWindowOrDialog());
+  if (window == nullptr)
+  {
+    CLog::Log(LOGWARNING, "ResetGroupList: No active window or dialog found");
+    return 0;
+  }
+
+  int controlId = 0;
+  const auto& param = params[0];
+  const auto end = param.data() + param.size();
+  const auto [ptr, ec] = std::from_chars(param.data(), end, controlId);
+  if (ec != std::errc{} || ptr != end)
+  {
+    CLog::Log(LOGWARNING, "ResetGroupList: control ID '{}' is not numeric.", params[0]);
+    return 0;
+  }
+
+  CGUIControl* control = window->GetControl(controlId);
+  if (control == nullptr)
+  {
+    CLog::Log(LOGWARNING, "ResetGroupList: Control {} not found", params[0]);
+    return 0;
+  }
+
+  auto groupList = dynamic_cast<CGUIControlGroupList*>(control);
+  if (control->GetControlType() != CGUIControl::GUICONTROL_GROUPLIST || groupList == nullptr)
+  {
+    CLog::Log(LOGWARNING, "ResetGroupList: Control {} is not a grouplist", params[0]);
+    return 0;
+  }
+
+  if (!groupList->ResetFocusToFirstItem())
+  {
+    CLog::Log(
+        LOGWARNING,
+        "ResetGroupList: Unable to reset grouplist {} - no visible and focusable controls found",
+        params[0]);
+    return 0;
+  }
+
+  return 1;
+}
+
 /*! \brief Execute a GUI action.
  *  \param params The parameters.
  *  \details params[0] = Action to execute.
@@ -581,9 +642,17 @@ static int ToggleDirty(const std::vector<std::string>&)
 ///     ,
 ///     makes dirty regions visible for debugging proposes.
 ///   }
+///   \table_row2_l{
+///     <b>`Control.ResetGroupList(id)`</b>
+///     ,
+///     Resets a grouplist control's focus to its first item and scrolls back to the top.
+///     @param[in] id                    The control ID of the grouplist to reset.
+///     \skinning_v22
+///   }
 ///  \table_end
 ///
 
+// clang-format off
 CBuiltins::CommandMap CGUIBuiltins::GetOperations() const
 {
   return {
@@ -602,6 +671,8 @@ CBuiltins::CommandMap CGUIBuiltins::GetOperations() const
            {"setproperty",                    {"Sets a window property for the current focused window/dialog (key,value)", 2, SetProperty}},
            {"setstereomode",                  {"Changes the stereo mode of the GUI. Params can be: toggle, next, previous, select, tomono or any of the supported stereomodes (off, split_vertical, split_horizontal, row_interleaved, hardware_based, anaglyph_cyan_red, anaglyph_green_magenta, anaglyph_yellow_blue, monoscopic)", 1, SetStereoMode}},
            {"takescreenshot",                 {"Takes a Screenshot", 0, Screenshot}},
-           {"toggledirtyregionvisualization", {"Enables/disables dirty-region visualization", 0, ToggleDirty}}
+           {"toggledirtyregionvisualization", {"Enables/disables dirty-region visualization", 0, ToggleDirty}},
+           {"control.resetgrouplist",         {"Resets a grouplist control's focus to its first item", 1, ResetGroupList}},
          };
 }
+// clang-format on

--- a/xbmc/interfaces/builtins/GUIBuiltins.cpp
+++ b/xbmc/interfaces/builtins/GUIBuiltins.cpp
@@ -16,6 +16,7 @@
 #include "dialogs/GUIDialogNumeric.h"
 #include "filesystem/Directory.h"
 #include "guilib/GUIComponent.h"
+#include "guilib/GUIControlGroupList.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/StereoscopicsManager.h"
 #include "input/WindowTranslator.h"
@@ -35,10 +36,69 @@
 #include "utils/log.h"
 #include "windows/GUIMediaWindow.h"
 
+#include <charconv>
+
 using namespace KODI;
 
 namespace
 {
+/*! \brief Reset a grouplist control's focus to its first item.
+ *  \param params The parameters.
+ *  \details params[0] = The control ID of the grouplist to reset.
+ */
+static int ResetGroupList(const std::vector<std::string>& params)
+{
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  if (gui == nullptr)
+  {
+    CLog::Log(LOGWARNING, "ResetGroupList: No GUI present");
+    return 0;
+  }
+
+  CGUIWindow* window =
+      gui->GetWindowManager().GetWindow(gui->GetWindowManager().GetActiveWindowOrDialog());
+  if (window == nullptr)
+  {
+    CLog::Log(LOGWARNING, "ResetGroupList: No active window or dialog found");
+    return 0;
+  }
+
+  int controlId = 0;
+  const auto& param = params[0];
+  const auto result = std::from_chars(param.data(), param.data() + param.size(), controlId);
+  if (result.ec != std::errc{})
+  {
+    CLog::Log(LOGWARNING, "ResetGroupList: Invalid control ID '{}'", params[0]);
+    return 0;
+  }
+
+  CGUIControl* control = window->GetControl(controlId);
+  if (control == nullptr)
+  {
+    CLog::Log(LOGWARNING, "ResetGroupList: Control {} not found", params[0]);
+    return 0;
+  }
+
+  if (control->GetControlType() != CGUIControl::GUICONTROL_GROUPLIST)
+  {
+    CLog::Log(LOGWARNING, "ResetGroupList: Control {} is not a grouplist", params[0]);
+    return 0;
+  }
+
+  if (!static_cast<CGUIControlGroupList*>(control)->ResetFocusToFirstItem())
+  {
+    CLog::Log(
+        LOGWARNING,
+        "ResetGroupList: Unable to reset grouplist {} - no visible and focusable controls found",
+        params[0]);
+    return 0;
+  }
+
+  CLog::Log(LOGDEBUG, "ResetGroupList: Reset grouplist {} to first item", params[0]);
+
+  return 1;
+}
+
 /*! \brief Execute a GUI action.
  *  \param params The parameters.
  *  \details params[0] = Action to execute.
@@ -581,9 +641,17 @@ static int ToggleDirty(const std::vector<std::string>&)
 ///     ,
 ///     makes dirty regions visible for debugging proposes.
 ///   }
+///   \table_row2_l{
+///     <b>`Control.ResetGroupList(id)`</b>
+///     ,
+///     Resets a grouplist control's focus to its first item and scrolls back to the top.
+///     @param[in] id                    The control ID of the grouplist to reset.
+///     \skinning_v22
+///   }
 ///  \table_end
 ///
 
+// clang-format off
 CBuiltins::CommandMap CGUIBuiltins::GetOperations() const
 {
   return {
@@ -602,6 +670,8 @@ CBuiltins::CommandMap CGUIBuiltins::GetOperations() const
            {"setproperty",                    {"Sets a window property for the current focused window/dialog (key,value)", 2, SetProperty}},
            {"setstereomode",                  {"Changes the stereo mode of the GUI. Params can be: toggle, next, previous, select, tomono or any of the supported stereomodes (off, split_vertical, split_horizontal, row_interleaved, hardware_based, anaglyph_cyan_red, anaglyph_green_magenta, anaglyph_yellow_blue, monoscopic)", 1, SetStereoMode}},
            {"takescreenshot",                 {"Takes a Screenshot", 0, Screenshot}},
-           {"toggledirtyregionvisualization", {"Enables/disables dirty-region visualization", 0, ToggleDirty}}
+           {"toggledirtyregionvisualization", {"Enables/disables dirty-region visualization", 0, ToggleDirty}},
+           {"control.resetgrouplist",         {"Resets a grouplist control's focus to its first item", 1, ResetGroupList}}
          };
 }
+// clang-format on


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add a ResetFocusToFirstItem method to CGUIControlGroupList (declared in GUIControlGroupList.h and implemented in GUIControlGroupList.cpp) which moves focus to the first focusable control. Expose this as a new builtin command Control.ResetGrouplist(ID) in GUIBuiltins.cpp (with a small doc comment), plus the necessary include, so skins and scripts can reset a grouplist's focus position by using its ID.
Replaces #28259

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Allows skinners to reset the last focused item in a grouplist.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally on Windows 11 (test build [here](https://mirrors.kodi.tv/test-builds/windows/win64/KodiSetup-20260621-b7f37f3a-reset_grouplist_focus_position_clean-x64.exe))

To test add `<onleft>Control.ResetGroupList(9000)</onleft>` just after `<pagecontrol>$PARAM[list_id]600</pagecontrol>` in `skin.estuary\xml\View_50_List.xml`.
Navigate to Movies, Select Viewtype - List, navigate left to the media menu, move to any control, navigate away from the media menu and then return. The first item is selected.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [ ] All new and existing tests passed
