### PR TITLE
NFS: refuse to open directories as files (fixes folder DVDs on NFS)

### DIFF
--- a/xbmc/filesystem/NFSFile.cpp
+++ b/xbmc/filesystem/NFSFile.cpp
@@ -30,6 +30,9 @@
 #ifdef TARGET_WINDOWS
 #include <fcntl.h>
 #include <sys\stat.h>
+#ifndef S_ISDIR
+#define S_ISDIR(m) (((m) & _S_IFDIR) != 0)
+#endif
 #endif
 
 #if defined(TARGET_WINDOWS)
@@ -670,7 +673,12 @@ bool CNFSFile::Open(const CURL& url)
 
   struct __stat64 tmpBuffer;
 
-  if( Stat(&tmpBuffer) )
+  // nfs_open succeeds on directories, which lets libdvdread / libbluray
+  // mis-classify a folder structure (DVD VIDEO_TS, Bluray BDMV) as a disc image
+  // and run UDF/BDMV parsing on it, which then fails. Reject directories here
+  // so callers fall back to file-by-file mode, the correct behaviour for folder
+  // structures on remote VFS shares.
+  if (Stat(&tmpBuffer) != 0 || S_ISDIR(tmpBuffer.st_mode))
   {
     m_url.Reset();
     Close();


### PR DESCRIPTION
## Description

`CNFSFile::Open` trusts `nfs_open()` to give a sensible answer for the
input path. libnfs happily returns a valid file handle when the path
resolves to a directory, so callers that only check the return value
end up with a "file" handle that points at a directory.

This trips up `libdvdread`: when opening a folder-structured DVD over
NFS (e.g. `nfs://.../Movie/VIDEO_TS/VIDEO_TS.IFO`), `dvd_open()` probes
the parent folder with `open()`. The open succeeds via Kodi's NFS
handler (because the path is a directory), `libdvdread` classifies the
parent as a disc image, and then fails when the UDF reader cannot parse
a folder as a UDF filesystem.

Same shape applies to `libbluray` for BDMV folder structures on NFS
(not tested here because I only had Bluray ISOs to hand, but the open
path is identical).

## Symptom (before)

```
CNFSFile::Open - opened volume1/.../Movie
Libdvd: DVDOpenFileUDF:UDFFindFile /VIDEO_TS/VIDEO_TS.IFO failed
Libdvd: vm: vm: failed to read VIDEO_TS.IFO
Error on dvdnav_open
CVideoPlayer::OpenInputStream - error opening [...]
```

## Behaviour (after)

```
CNFSFile::Open - refusing directory open '...Movie'
Libdvd: Could not open ...Movie with libdvdcss.
CNFSFile::Open - opened ...Movie/VIDEO_TS/VIDEO_TS.IFO
Libdvd: Unable to open device file ...Movie.   (no longer fatal)
VideoPlayer: playing a file with menus
CNFSFile::Open - opened ...Movie/VIDEO_TS/VTS_01_0.IFO
CNFSFile::Open - opened ...Movie/VIDEO_TS/VTS_01_1.VOB
```

## Notes

The bug appeared intermittent: it failed reliably on the first playback
after Kodi start, but worked after warming the NFS context via any
prior browse to the share. That is because `libdvdcss` probed first in
the warm path, errored quickly, and pushed `libdvdread` to its
file-by-file branch. On a cold NFS context the `libdvdcss` probe
behaved differently and `libdvdread` went straight to the broken image
branch.

## Test plan

Reproduced on Kodi 22 master (Git:20260506-27dd4ca621) on Windows 11
24H2 with a Synology NAS NFSv3 share holding folder-structured DVDs
(`/Movie/VIDEO_TS/*.IFO|*.VOB`):

- [x] Cold-start playback from library: **fails on master, works with patch**
- [x] Warm-state playback from File Manager: works on both (no regression)
- [x] Cold-start playback of NFS-hosted Bluray ISO: works on both (no regression — ISOs do not hit this path)
- [x] DVD playback with menu navigation, chapter changes, and VTS title switches: all work after patch
