### PR TITLE
VideoPlayer/Bluray: derive playlist filename from dynamic path

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -209,7 +209,12 @@ bool CDVDInputStreamBluray::Open()
       URIUtils::RemoveSlashAtEnd(strPath);
     }
     root = strPath;
-    filename = URIUtils::GetFileName(m_item.GetPath());
+    // Use the resolved (dynamic) path so playlist selectors survive plugin
+    // resolution and library .strm playback. m_item.GetPath() returns the
+    // original library reference (e.g. .strm file) which has no .mpls
+    // extension, causing the MPLS title selector to be lost and playback
+    // to fall through to navigation/main-feature mode.
+    filename = URIUtils::GetFileName(m_item.GetDynPath());
   }
 
   // root should not have trailing slash


### PR DESCRIPTION
## Description

`CDVDInputStreamBluray::Open()` inspects the file name extension of the input
item to decide whether to play a specific MPLS playlist (`navmode=false`,
`GetTitleFile(filename)`) or to enter HDMV navigation mode and play the disc
default ("first play" / main feature).

The filename is taken from `m_item.GetPath()`. For File Manager and direct
file launches `GetPath()` and `GetDynPath()` are the same path
(e.g. `udf://.../iso/BDMV/PLAYLIST/00004.mpls`), so `.mpls` is detected and
the requested playlist plays.

For library `.strm` playback and plugin-resolved items the two paths diverge:

```
m_strPath    = nfs://.../Show/SxxEyy.strm   (library reference)
m_strDynPath = udf://.../iso/.../00004.mpls (resolved playback URL)
```

`GetPath()` returns the `.strm` reference, which has no `.mpls` extension, so
the MPLS title selector is silently dropped and playback falls through to
navigation/main-feature mode. The user gets the disc's main feature instead
of the requested episode. The same symptom appears when an addon resolves a
`plugin://` URL via `xbmcplugin.setResolvedUrl()` to an MPLS path.

## Fix

Derive `filename` from `m_item.GetDynPath()` so playlist selectors survive
plugin resolution and library `.strm` playback. `GetDynPath()` falls back to
`GetPath()` when DynPath is empty, so direct/file-manager behaviour is
unchanged.

## Symptom (before)

Library `.strm` containing `udf://.../iso/BDMV/PLAYLIST/00004.mpls`:

```
VideoPlayer::OpenFile: nfs://.../Aquarius.S01E01.strm
CDVDInputStreamBluray::Open - opening udf://.../iso/
CDVDInputStreamBluray::Open - Disc name : <disc name>
... (no "Title 0000X.mpls selected" line — disc default plays)
```

## Behaviour (after)

```
VideoPlayer::OpenFile: nfs://.../Aquarius.S01E01.strm
CDVDInputStreamBluray::Open - opening udf://.../iso/
CDVDInputStreamBluray::Open - Disc name : <disc name>
libbluray: Title 00004.mpls selected
BD_EVENT_PLAYLIST 4
VideoPlayer: playing a file with menus
```

## Test plan

Reproduced on Kodi 22 master (Git:20260506-27dd4ca621) on Windows 11 24H2
with NFS-hosted Bluray ISOs and `.strm` files of the form
`udf://.../iso/BDMV/PLAYLIST/0000X.mpls`:

- [x] Library `.strm` playback (4 episodes): **starts main feature on master, plays the requested MPLS with patch**
- [x] File Manager direct `.mpls` playback: works on both (no regression)
- [x] Direct ISO playback (no MPLS selector): works on both (no regression)
- [x] Plugin-resolved playback (`plugin://...?url=udf://...mpls` via `setResolvedUrl`): now plays correct MPLS without external workaround
