### PR TITLE
Linux Renderers: fix double divide by 255 in letterbox bars uniform

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -134,8 +134,6 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
     }
   }
 
-  m_clearColour = winSystem->UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
-
   m_configured = true;
   return true;
 }
@@ -244,7 +242,7 @@ void CRendererDRMPRIMEGLES::DrawBlackBars()
   GLint uniCol = renderSystem->GUIShaderGetUniCol();
   GLint depthLoc = renderSystem->GUIShaderGetDepth();
 
-  glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
+  glUniform4f(uniCol, 0.0f, 0.0f, 0.0f, 1.0f);
   glUniform1f(depthLoc, -1.0f);
 
   GLuint vertexVBO;
@@ -278,7 +276,8 @@ void CRendererDRMPRIMEGLES::RenderUpdate(
       DrawBlackBars();
     else
     {
-      glClearColor(m_clearColour, m_clearColour, m_clearColour, 0);
+      const float bg = CServiceBroker::GetWinSystem()->UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
+      glClearColor(bg, bg, bg, 0);
       glClear(GL_COLOR_BUFFER_BIT);
       glClearColor(0, 0, 0, 0);
     }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
@@ -59,7 +59,6 @@ private:
   void Render(unsigned int flags, int index);
 
   bool m_configured = false;
-  float m_clearColour{0.0f};
 
   struct BUFFER
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -257,9 +257,6 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
   if (!CServiceBroker::GetWinSystem()->SetVideoOutput(&picture))
     CLog::Log(LOGWARNING, "LinuxRendererGL::Configure: SetVideoOutput failed");
 
-  // setup the background colour
-  m_clearColour = CServiceBroker::GetWinSystem()->UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
-
   if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
       picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
   {
@@ -594,7 +591,7 @@ void CLinuxRendererGL::ClearBackBufferQuad()
   GLint posLoc = m_renderSystem->ShaderGetPos();
   GLint uniCol = m_renderSystem->ShaderGetUniCol();
 
-  glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
+  glUniform4f(uniCol, 0.0f, 0.0f, 0.0f, 1.0f);
 
   GLuint vertexVBO;
   glGenBuffers(1, &vertexVBO);
@@ -630,7 +627,7 @@ void CLinuxRendererGL::DrawBlackBars()
   GLint posLoc = m_renderSystem->ShaderGetPos();
   GLint uniCol = m_renderSystem->ShaderGetUniCol();
 
-  glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
+  glUniform4f(uniCol, 0.0f, 0.0f, 0.0f, 1.0f);
 
   int osWindowWidth = CServiceBroker::GetWinSystem()->GetGfxContext().GetWidth();
   int osWindowHeight = CServiceBroker::GetWinSystem()->GetGfxContext().GetHeight();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -220,7 +220,6 @@ protected:
   bool m_toneMap = false;
   ETONEMAPMETHOD m_toneMapMethod = VS_TONEMAPMETHOD_OFF;
   bool m_passthroughHDR = false;
-  float m_clearColour = 0.0f;
   bool m_pboSupported = true;
   bool m_pboUsed = false;
   bool m_nonLinStretch = false;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -151,9 +151,6 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
   if (!CServiceBroker::GetWinSystem()->SetVideoOutput(&picture))
     CLog::Log(LOGWARNING, "LinuxRendererGLES::Configure: SetVideoOutput failed");
 
-  // setup the background colour
-  m_clearColour = CServiceBroker::GetWinSystem()->UseLimitedColor() ? (16.0f / 0xff) : 0.0f;
-
   if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
       picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
   {
@@ -418,7 +415,7 @@ void CLinuxRendererGLES::ClearBackBufferQuad()
   GLint uniCol = m_renderSystem->GUIShaderGetUniCol();
   GLint depthLoc = m_renderSystem->GUIShaderGetDepth();
 
-  glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
+  glUniform4f(uniCol, 0.0f, 0.0f, 0.0f, 1.0f);
   glUniform1f(depthLoc, -1);
 
   GLuint vertexVBO;
@@ -482,7 +479,7 @@ void CLinuxRendererGLES::DrawBlackBars()
   GLint uniCol = renderSystem->GUIShaderGetUniCol();
   GLint depthLoc = m_renderSystem->GUIShaderGetDepth();
 
-  glUniform4f(uniCol, m_clearColour / 255.0f, m_clearColour / 255.0f, m_clearColour / 255.0f, 1.0f);
+  glUniform4f(uniCol, 0.0f, 0.0f, 0.0f, 1.0f);
   glUniform1f(depthLoc, -1);
 
   GLuint vertexVBO;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -213,8 +213,6 @@ protected:
   unsigned char* m_planeBuffer = nullptr;
   size_t m_planeBufferSize = 0;
 
-  // clear colour for "black" bars
-  float m_clearColour{0.0f};
   CRect m_lastViewRect;
 
 private:


### PR DESCRIPTION
## Description

Three Linux renderers (CLinuxRendererGL, CLinuxRendererGLES, CRendererDRMPRIMEGLES) had a double-normalize bug in their DrawBlackBars / ClearBackBuffer paths.

m_clearColour was set in Configure to an already-normalized [0,1] value:

    m_clearColour = UseLimitedColor() ? (16.0f / 0xff) : 0.0f;

The shader-uniform sites then divided by 255 again:

    glUniform4f(uniCol, m_clearColour / 255.0f, ...);

Limited-range (16-235) black thus arrived at the shader as 16/(255*255) ~= 0 instead of the intended 16/255. The bug was masked because SM_DEFAULT's KODI_LIMITED_RANGE block (rgb *= 219/255; rgb += 16/255) re-encoded the ~0 input back to nominal black at code 16. Final BO output was correct by accident.

Replace the shader-uniform expression with a literal 0.0f at all five sites, making the math explicit: shader receives "input black", SM_DEFAULT's range encoding produces nominal black for the active range -- 16 in limited range, 0 in full range. Code 0 in limited range is reserved for SAV/EAV timing references and forbidden as picture content per BT.709, so nominal black is the correct target.

Inline the glClearColor branch in CRendererDRMPRIMEGLES::ClearBackBuffer (which writes m_clearColour directly to the framebuffer, no shader involved -- range-aware behaviour is correct there) to read UseLimitedColor() at the call site.

m_clearColour has no users left and is removed from all three renderer headers and Configure paths.

BO output unchanged.

## Motivation and context
Bug fix.  Set's up for the introduction of `limitedrange` support in DRMPRIMEGLES, which currently ignores this setting. This is part of ongoing series of cleanups and fixes for proper limitedrange (16-235) color support, removal of double-compression bugs, etc.

## How has this been tested?
Kodi 22.alpha3, all three renderers.

## What is the effect on users?
see above

## Screenshots (if appropriate):
n/a

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
