### PR TITLE
[MusicDatabase] Begin transaction in music library cleaning function

### DIFF
--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -4616,6 +4616,7 @@ int CMusicDatabase::Cleanup(CGUIDialogProgress* progressDialog /*= nullptr*/)
   CLog::Log(LOGINFO, "Starting musicdatabase cleanup ...");
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnCleanStarted");
 
+  BeginTransaction();
   SetLibraryLastCleaned();
 
   // Drop triggers  song_artist and album_artist to avoid creation of entries in removed_link


### PR DESCRIPTION
## Description
Add `BeginTransaction` call at the start of `CMusicDatabase::Cleanup` function.

Fixes the general error that occurs when running "Library > Clean library" on Android.

logcat:
```
F libc    : /home/user/xbmc/xbmc/dbwrappers/sqlitedataset.cpp:612: virtual void dbiplus::SqliteDatabase::commit_transaction(): assertion "_in_transaction" failed
F libc    : Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 710 (Thread-7), pid 655 (org.xbmc.kodi)
```

Since `_in_transaction` is never set to true, the subsequent `commit_transaction` assertion fails.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
