### PR TITLE
[Video][Bluray] Improve bluray episode (and multi-episode) display and selection in Videos -> Files

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -15218,7 +15218,37 @@ msgctxt "#21485"
 msgid "Supported file extensions and media types"
 msgstr ""
 
-#empty strings from id 21486 to 21601
+#. Used to show Episodes in Video->Files (eg. Episode n)
+#: xbmc/FileItem.cpp
+msgctxt "#21486"
+msgid "Episode {0:d}"
+msgstr ""
+
+#. Used to show Episodes in Video->Files (eg. Episodes m-n)
+#: xbmc/FileItem.cpp
+msgctxt "#21487"
+msgid "Episodes {0:d}-{1:d}"
+msgstr ""
+
+#. Used to show Episodes in Video->Files (eg. Season x Episode n)
+#: xbmc/FileItem.cpp
+msgctxt "#21488"
+msgid "Season {0:d} Episode {1:d}"
+msgstr ""
+
+#. Used to show Episodes in Video->Files (eg. Season x Episodes m-n)
+#: xbmc/FileItem.cpp
+msgctxt "#21489"
+msgid "Season {0:d} Episodes {1:d}-{2:d}"
+msgstr ""
+
+#. Used to show Specials in Video->Files (when there are no episodes) (eg. Specials)
+#: xbmc/FileItem.cpp
+msgctxt "#21490"
+msgid "Specials"
+msgstr ""
+
+#empty strings from id 21491 to 21601
 
 #: xbmc/Util.cpp
 msgctxt "#21602"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24453,7 +24453,58 @@ msgctxt "#39210"
 msgid "If enabled, Dolby Vision files will have level 5 (active area) metadata overridden to zero offsets. Enable if your display has issues with incorrectly cropped image in Dolby Vision playback."
 msgstr ""
 
-#empty strings from id 39211 to 39999
+#empty strings from id 39211 to 39899
+
+#. List formatting: pattern used to join a list of exactly two items, e.g. "A and B"
+#. STR_LIST_AND_TWO
+#: xbmc/utils/i18n/ListFormatter.h
+msgctxt "#39900"
+msgid "{0} and {1}"
+msgstr ""
+
+#. List formatting: pattern used to join the first item to the rest of a list of three or more items, e.g. "A" + "B, and C" -> "A, B, and C"
+#. Note the "B, and C" is used here as an example - the actual formatting of the last two item(s) of a list of three of more is determined by STR_LIST_AND_END
+#. STR_LIST_AND_START
+#: xbmc/utils/i18n/ListFormatter.h
+msgctxt "#39901"
+msgid "{0}, {1}"
+msgstr ""
+
+#. List formatting: pattern used to join an already-combined partial list to the next item, for the interior items of a list of four or more, e.g. "A, B" + "C" -> "A, B, C"
+#. STR_LIST_AND_MIDDLE
+#: xbmc/utils/i18n/ListFormatter.h
+msgctxt "#39902"
+msgid "{0}, {1}"
+msgstr ""
+
+#. List formatting: pattern used to join the already-combined partial list to the final item in a list of three or more items, e.g. "A, B" + "C" -> "A, B, and C"
+#. STR_LIST_AND_END
+#: xbmc/utils/i18n/ListFormatter.h
+msgctxt "#39903"
+msgid "{0}, and {1}"
+msgstr ""
+
+# 39904 to 39909 are reserved for language formatting
+
+#. List formatting: pattern used to join a list of exactly two items, e.g. "A or B"
+#. STR_LIST_OR_TWO
+#: xbmc/utils/i18n/ListFormatter.h
+msgctxt "#39910"
+msgid "{0} or {1}"
+msgstr ""
+
+#. List formatting: pattern used to join the already-combined partial list to the final item in a list of three or more items, e.g. "A, B" + "C" -> "A, B, or C"
+#. Note: the "or"-type list uses only TWO and END patterns; the START and MIDDLE joins for lists of three or more still use the AND-type comma pattern 
+#. (STR_LIST_AND_START / STR_LIST_AND_MIDDLE), with only the very last join switching to "or"
+#. STR_LIST_OR_END
+#: xbmc/utils/i18n/ListFormatter.h
+msgctxt "#39911"
+msgid "{0}, or {1}"
+msgstr ""
+
+# 39912 to 39949 are reserved for language formatting
+
+#empty strings from id 39950 to 39999
 
 # 40000 to 40800 are reserved for Video Versions feature
 

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -24,7 +24,6 @@
 #include "filesystem/VideoDatabaseDirectory/QueryParams.h"
 #include "games/GameUtils.h"
 #include "games/tags/GameInfoTag.h"
-#include "media/MediaLockState.h"
 #include "music/Album.h"
 #include "music/Artist.h"
 #include "music/MusicDatabase.h"
@@ -56,6 +55,7 @@
 #include "settings/lib/Setting.h"
 #include "utils/Archive.h"
 #include "utils/ArtUtils.h"
+#include "utils/EpisodeUtils.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/Mime.h"
 #include "utils/RegExp.h"
@@ -69,8 +69,12 @@
 #include "video/VideoInfoTag.h"
 #include "video/VideoUtils.h"
 
+#include <cstdint>
 #include <cstdlib>
+#include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 using namespace KODI;
 using namespace XFILE;
@@ -1308,7 +1312,9 @@ bool CFileItem::IsAlbum() const
   return m_bIsAlbum;
 }
 
-void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
+void CFileItem::UpdateInfo(const CFileItem& item,
+                           bool replaceLabels /* = true */,
+                           MultipleEpisodes replaceEpisodes /* = DONT_GROUP_MULTIPLE_EPISODES */)
 {
   if (item.HasVideoInfoTag())
   { // copy info across
@@ -1376,8 +1382,26 @@ void CFileItem::UpdateInfo(const CFileItem &item, bool replaceLabels /*=true*/)
     SetInvalid();
   }
   SetDynPath(item.GetDynPath());
-  if (replaceLabels && !item.GetLabel().empty())
-    SetLabel(item.GetLabel());
+
+  // Alter label to episode number(s) if requested
+  std::string label;
+  if (replaceLabels)
+  {
+    if (replaceEpisodes == MultipleEpisodes::GROUP_MULTIPLE_EPISODES &&
+        item.HasProperty("episodes") && item.GetVideoContentType() == VideoDbContentType::EPISODES)
+    {
+      label = CEpisodeUtils::GetEpisodesLabel(item);
+
+      // Multiple episodes so use show plot rather than episode plot
+      if (HasVideoInfoTag() && item.HasProperty("episodes_show_plot"))
+        GetVideoInfoTag()->m_strPlot = item.GetProperty("episodes_show_plot").asString();
+    }
+    else if (!item.GetLabel().empty())
+      label = item.GetLabel();
+  }
+  if (!label.empty())
+    SetLabel(label);
+
   if (replaceLabels && !item.GetLabel2().empty())
     SetLabel2(item.GetLabel2());
   if (!item.GetArt().empty())

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -81,6 +81,12 @@ enum class FileFolderType
   MASK_ONBROWSE = ALWAYS | ONCLICK | ONBROWSE,
 };
 
+enum class MultipleEpisodes
+{
+  DONT_GROUP_MULTIPLE_EPISODES = 0,
+  GROUP_MULTIPLE_EPISODES
+};
+
 /* special startoffset used to indicate that we wish to resume */
 constexpr int STARTOFFSET_RESUME = -1;
 
@@ -481,8 +487,12 @@ public:
    in the given item.
    \param item the item used to supplement information
    \param replaceLabels whether to replace labels (defaults to true)
+   \param replaceEpisodes whether to list all episodes on multi-episode disc (defaults to not)
    */
-  void UpdateInfo(const CFileItem &item, bool replaceLabels = true);
+  void UpdateInfo(
+      const CFileItem& item,
+      bool replaceLabels = true,
+      MultipleEpisodes replaceEpisodes = MultipleEpisodes::DONT_GROUP_MULTIPLE_EPISODES);
 
   /*! \brief Merge an item with information from another item
   We take metadata/art information from the given item and supplement the current

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -156,7 +156,7 @@ void CURL::Parse(std::string strURL1)
   if (IsProtocol("rss") || IsProtocol("rsss") || IsProtocol("rar") || IsProtocol("apk") ||
       IsProtocol("xbt") || IsProtocol("zip") || IsProtocol("addons") || IsProtocol("image") ||
       IsProtocol("videodb") || IsProtocol("musicdb") || IsProtocol("androidapp") ||
-      IsProtocol("pvr") || IsProtocol("bluray"))
+      IsProtocol("pvr") || IsProtocol("bluray") || IsProtocol("episodes"))
     sep = "?";
   else if (IsProtocolEqual(strProtocol2, "http") || IsProtocolEqual(strProtocol2, "https") ||
            IsProtocolEqual(strProtocol2, "plugin") || IsProtocolEqual(strProtocol2, "addons") ||
@@ -848,7 +848,8 @@ bool CURL::HasParentInHostname() const
 
 bool CURL::HasEncodedHostname() const
 {
-  return HasParentInHostname() || IsProtocol("musicsearch") || IsProtocol("image");
+  return HasParentInHostname() || IsProtocol("musicsearch") || IsProtocol("image") ||
+         IsProtocol("episodes");
 }
 
 bool CURL::HasEncodedFilename() const

--- a/xbmc/filesystem/CMakeLists.txt
+++ b/xbmc/filesystem/CMakeLists.txt
@@ -11,7 +11,8 @@ set(SOURCES AddonsDirectory.cpp
             DirectoryFactory.cpp
             DirectoryHistory.cpp
             DllLibCurl.cpp
-	    DiscDirectoryHelper.cpp
+            DiscDirectoryHelper.cpp
+            EpisodesDirectory.cpp
             EventsDirectory.cpp
             FavouritesDirectory.cpp
             FileCache.cpp
@@ -75,6 +76,7 @@ set(HEADERS AddonsDirectory.h
             DirectoryHistory.h
             DllLibCurl.h
 	    DiscDirectoryHelper.h
+            EpisodesDirectory.h
             EventsDirectory.h
             FTPDirectory.h
             FTPParse.h

--- a/xbmc/filesystem/EpisodesDirectory.cpp
+++ b/xbmc/filesystem/EpisodesDirectory.cpp
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "EpisodesDirectory.h"
+
+#include "FileItem.h"
+#include "FileItemList.h"
+#include "URL.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+#include "video/VideoDatabase.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace XFILE;
+
+bool CEpisodesDirectory::Resolve(CFileItem& item) const
+{
+  const CURL url{item.GetDynPath()};
+  if (url.GetProtocol() != "episodes")
+    return false;
+  return true;
+}
+
+bool CEpisodesDirectory::GetDirectory(const CURL& url, CFileItemList& items)
+{
+  CLog::LogF(LOGDEBUG, "Retrieving all episodes for URL: {}", url.Get());
+
+  CVideoDatabase database;
+  if (!database.Open())
+  {
+    CLog::LogF(LOGERROR, "Failed to open video database");
+    return false;
+  }
+
+  const std::string& path{url.GetHostName()};
+  const std::string show{url.GetOption("show")};
+  int idShow{-1};
+  if (!show.empty())
+    idShow = static_cast<int>(StringUtils::ToUint32(show));
+  std::vector<CVideoInfoTag> episodes;
+  database.GetEpisodesByBasePath(path, episodes, idShow);
+  database.Close();
+  if (episodes.empty())
+  {
+    CLog::LogF(LOGERROR, "No episodes found for path: {}", path);
+    return false;
+  }
+
+  for (const auto& episode : episodes)
+  {
+    auto item{std::make_shared<CFileItem>(episode)};
+    items.Add(item);
+  }
+  return !items.IsEmpty();
+}

--- a/xbmc/filesystem/EpisodesDirectory.h
+++ b/xbmc/filesystem/EpisodesDirectory.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "IFileDirectory.h"
+
+namespace XFILE
+{
+
+/*!
+ \brief Abstracts a virtual directory (episodes://) which points to one or more episodes
+ */
+class CEpisodesDirectory : public IFileDirectory
+{
+public:
+  CEpisodesDirectory() = default;
+  ~CEpisodesDirectory() override = default;
+  bool GetDirectory(const CURL& url, CFileItemList& items) override;
+  bool ContainsFiles(const CURL& url) override { return false; }
+  bool Resolve(CFileItem& item) const override;
+};
+} // namespace XFILE

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -8,26 +8,20 @@
 
 #include "FileDirectoryFactory.h"
 
-#include "music/MusicFileItemClassify.h"
-
+#include "AudioBookFileDirectory.h"
+#include "Directory.h"
+#include "EpisodesDirectory.h"
+#include "FileItem.h"
 #if defined(HAS_ISO9660PP)
 #include "ISO9660Directory.h"
 #endif
+#include "PlaylistFileDirectory.h"
+#include "RSSDirectory.h"
+#include "ServiceBroker.h"
+#include "SmartPlaylistDirectory.h"
 #if defined(HAS_UDFREAD)
 #include "UDFDirectory.h"
 #endif
-#include "RSSDirectory.h"
-#include "UDFDirectory.h"
-#include "utils/URIUtils.h"
-#if defined(TARGET_ANDROID)
-#include "platform/android/filesystem/APKDirectory.h"
-#endif
-#include "AudioBookFileDirectory.h"
-#include "Directory.h"
-#include "FileItem.h"
-#include "PlaylistFileDirectory.h"
-#include "ServiceBroker.h"
-#include "SmartPlaylistDirectory.h"
 #include "URL.h"
 #include "XbtDirectory.h"
 #include "ZipDirectory.h"
@@ -35,9 +29,14 @@
 #include "addons/ExtsMimeSupportList.h"
 #include "addons/VFSEntry.h"
 #include "addons/addoninfo/AddonInfo.h"
+#include "music/MusicFileItemClassify.h"
+#if defined(TARGET_ANDROID)
+#include "platform/android/filesystem/APKDirectory.h"
+#endif
 #include "playlists/PlayListFactory.h"
 #include "playlists/SmartPlayList.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/log.h"
 
 using namespace ADDON;
@@ -153,6 +152,8 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
   if (pItem->IsRSS())
     return new CRSSDirectory();
 
+  if (url.IsProtocol("episodes"))
+    return new CEpisodesDirectory();
 
   if (pItem->IsDiscImage())
   {

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -7,12 +7,17 @@
  */
 
 #include "FileItem.h"
+#include "LangInfo.h"
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "media/MediaType.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/SettingsManager.h"
+#include "video/VideoInfoTag.h"
 
 #include <gtest/gtest.h>
 
@@ -1015,3 +1020,83 @@ TEST(TestFileItem, MimeType)
   EXPECT_EQ("http://testdomain.com/api/movies", item.GetURL().Get());
   EXPECT_EQ("http://testdomain.com/api/movies", item.GetDynURL().Get());
 }
+
+namespace
+{
+// U+2068 FSI / U+2069 PDI: bidi isolation markers emitted by CListFormatter
+constexpr std::string_view FSI = "\xE2\x81\xA8";
+constexpr std::string_view PDI = "\xE2\x81\xA9";
+
+std::string StripIsolates(std::string s)
+{
+  for (std::string_view marker : {FSI, PDI})
+  {
+    size_t pos = 0;
+    while ((pos = s.find(marker, pos)) != std::string::npos)
+      s.erase(pos, marker.size());
+  }
+  return s;
+}
+
+struct EpisodeLabelTestCase
+{
+  const char* testName; //!< GTest parameter name (must be [a-zA-Z0-9_]+)
+  const char* episodes; //!< value for "episodes" property
+  int episodesSpecials; //!< > 0 → set "episodes_specials"; 0 = omit property
+  const char* expectedLabel; //!< expected label after stripping isolates
+};
+
+CFileItem MakeEpisodeItem()
+{
+  const auto tag = std::make_unique<CVideoInfoTag>();
+  tag->m_type = MediaTypeEpisode;
+  return CFileItem(*tag);
+}
+
+// clang-format off
+const EpisodeLabelTestCase EpisodeLabelCases[] = {
+  // testName                             episodes              specials  expectedLabel
+  {"SingleEpisode",                       "S01E01",             0, "Episode 1"},
+  {"ContiguousSingleSeasonRange",         "S01E01S01E02S01E03", 0, "Episodes 1-3"},
+  {"NonContiguousSingleSeason",           "S01E01S01E03S01E05", 0, "Episode 1, Episode 3, and Episode 5"},
+  {"MultipleSeasons_SingleEpisodeEach",   "S01E05S02E01",       0, "Season 1 Episode 5 and Season 2 Episode 1"},
+  {"MultipleSeasons_RangeInFirstSeason",  "S01E05S01E06S02E01", 0, "Season 1 Episodes 5-6 and Season 2 Episode 1"},
+  {"SpecialsOnly",                        "",                   3, "Specials"},
+  {"MixedEpisodesAndSpecials",            "S01E01S01E02",       2, "Episodes 1-2 and Specials"},
+  {"ThreeSegmentList",                    "S01E01S02E01S03E01", 0, "Season 1 Episode 1, Season 2 Episode 1, and Season 3 Episode 1"},
+};
+// clang-format on
+
+class TestFileItemEpisodeLabel : public Test, public WithParamInterface<EpisodeLabelTestCase>
+{
+protected:
+  void SetUp() override
+  {
+    ASSERT_TRUE(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Load(
+        g_langInfo.GetLanguagePath(), "resource.language.en_gb"));
+  }
+
+  void TearDown() override { CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Clear(); }
+};
+} // namespace
+
+TEST_P(TestFileItemEpisodeLabel, FormatsCorrectly)
+{
+  const EpisodeLabelTestCase& tc = GetParam();
+
+  CFileItem source = MakeEpisodeItem();
+  source.SetProperty("episodes", tc.episodes);
+  if (tc.episodesSpecials > 0)
+    source.SetProperty("episodes_specials", tc.episodesSpecials);
+
+  CFileItem target = MakeEpisodeItem();
+  target.UpdateInfo(source, /*replaceLabels=*/true, MultipleEpisodes::GROUP_MULTIPLE_EPISODES);
+
+  EXPECT_EQ(tc.expectedLabel, StripIsolates(target.GetLabel()));
+}
+
+INSTANTIATE_TEST_SUITE_P(EpisodeLabel,
+                         TestFileItemEpisodeLabel,
+                         ValuesIn(EpisodeLabelCases),
+                         [](const testing::TestParamInfo<EpisodeLabelTestCase>& info)
+                         { return info.param.testName; });

--- a/xbmc/utils/EpisodeUtils.cpp
+++ b/xbmc/utils/EpisodeUtils.cpp
@@ -12,14 +12,22 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
+#include "i18n/ListFormatter.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
 #include <cctype>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <set>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <vector>
 
 using namespace KODI;
@@ -368,4 +376,109 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item,
     return true;
   }
   return false;
+}
+
+namespace
+{
+std::vector<std::tuple<int, int, int>> ParseEpisodes(const std::string& input)
+{
+  std::map<int, std::set<int>> allEpisodes;
+
+  CRegExp pattern;
+  if (!pattern.RegComp(R"(S(\d{1,3})E(\d{1,3}))"))
+  {
+    CLog::LogF(LOGERROR, "Failed to compile episode regex pattern");
+    return {};
+  }
+
+  // Parse string
+  int pos = 0;
+  while ((pos = pattern.RegFind(input, pos)) >= 0)
+  {
+    int season = static_cast<int>(std::strtol(pattern.GetMatch(1).c_str(), nullptr, 10));
+    int episode = static_cast<int>(std::strtol(pattern.GetMatch(2).c_str(), nullptr, 10));
+    allEpisodes[season].insert(episode);
+    pos += pattern.GetFindLen();
+  }
+
+  // Now find ranges
+  std::vector<std::tuple<int, int, int>> result;
+  for (const auto& [season, episodes] : allEpisodes)
+  {
+    if (episodes.empty())
+      continue;
+
+    int rangeStart{*episodes.begin()};
+    int rangeEnd{rangeStart};
+    for (auto it = std::next(episodes.begin()); it != episodes.end(); ++it)
+    {
+      if (*it == rangeEnd + 1)
+        rangeEnd = *it;
+      else
+      {
+        result.emplace_back(season, rangeStart, rangeEnd);
+        rangeStart = rangeEnd = *it;
+      }
+    }
+    result.emplace_back(season, rangeStart, rangeEnd);
+  }
+
+  return result;
+}
+} // namespace
+
+std::string CEpisodeUtils::GetEpisodesLabel(const CFileItem& item)
+{
+  const std::string episodeString{item.GetProperty("episodes").asString("")};
+  const int numSpecials{item.GetProperty("episodes_specials").asInteger32(0)};
+  const auto episodes{ParseEpisodes(episodeString)};
+  const bool hasSpecials{numSpecials > 0};
+  bool singleSeason{!episodes.empty() &&
+                    std::get<0>(episodes.front()) == std::get<0>(episodes.back())};
+
+  constexpr int BASE{21486};
+  constexpr int RANGE{1};
+  constexpr int SEASON{2};
+  constexpr int SPECIALS{21490};
+
+  std::vector<std::string> labels;
+  if (!episodes.empty())
+  {
+    for (const auto& [season, startEpisode, endEpisode] : episodes)
+    {
+      if (singleSeason)
+      {
+        if (endEpisode == startEpisode)
+          labels.push_back(StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(BASE),
+              startEpisode));
+        else
+          labels.push_back(StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(BASE + RANGE),
+              startEpisode, endEpisode));
+      }
+      else
+      {
+        if (endEpisode == startEpisode)
+          labels.push_back(StringUtils::Format(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(BASE + SEASON),
+              season, startEpisode));
+        else
+          labels.push_back(
+              StringUtils::Format(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                                      BASE + SEASON + RANGE),
+                                  season, startEpisode, endEpisode));
+      }
+    }
+  }
+  if (hasSpecials)
+    labels.push_back(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(SPECIALS));
+
+  // Generate label
+  using namespace KODI::UTILS::I18N;
+  const auto fmt =
+      CListFormatter::CreateInstance(CServiceBroker::GetResourcesComponent().GetLocalizeStrings());
+  const std::string label{fmt.Format(labels)};
+
+  return label;
 }

--- a/xbmc/utils/EpisodeUtils.h
+++ b/xbmc/utils/EpisodeUtils.h
@@ -19,4 +19,6 @@ public:
   static bool EnumerateEpisodeItem(const CFileItem* item,
                                    KODI::VIDEO::EPISODELIST& episodeList,
                                    KODI::REGEXP::RegExpCache* cache = nullptr);
+
+  static std::string GetEpisodesLabel(const CFileItem& item);
 };

--- a/xbmc/utils/i18n/CMakeLists.txt
+++ b/xbmc/utils/i18n/CMakeLists.txt
@@ -4,7 +4,8 @@ set(SOURCES Bcp47.cpp
             Iso3166_1.cpp
             Iso639.cpp
             Iso639_1.cpp
-            Iso639_2.cpp)
+            Iso639_2.cpp
+            ListFormatter.cpp)
 
 set(HEADERS Bcp47.h
             Bcp47Common.h
@@ -18,6 +19,7 @@ set(HEADERS Bcp47.h
             Iso639_1_Table.h
             Iso639_2.h
             Iso639_2_Table.h
+            ListFormatter.h
             TableLanguageCodes.h)
 
 core_add_library(utils_i18n)

--- a/xbmc/utils/i18n/ListFormatter.cpp
+++ b/xbmc/utils/i18n/ListFormatter.cpp
@@ -1,0 +1,125 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/i18n/ListFormatter.h"
+
+#include "utils/ILocalizer.h"
+
+#include <utility>
+
+using namespace KODI::UTILS::I18N;
+
+namespace
+{
+// English fallbacks if the localized string is missing.
+CListFormatter::Patterns FallbackPatterns(ListFormatType type)
+{
+  switch (type)
+  {
+    case ListFormatType::OR:
+      return {"{0} or {1}", "{0}, {1}", "{0}, {1}", "{0}, or {1}"};
+    case ListFormatType::UNITS:
+      return {"{0}, {1}", "{0}, {1}", "{0}, {1}", "{0}, {1}"};
+    case ListFormatType::AND:
+    default:
+      return {"{0} and {1}", "{0}, {1}", "{0}, {1}", "{0}, and {1}"};
+  }
+}
+
+std::string Localize(const ILocalizer& localizer, uint32_t id, std::string_view fallback)
+{
+  std::string s = localizer.Localize(id);
+  return s.empty() ? std::string(fallback) : s;
+}
+} // unnamed namespace
+
+CListFormatter CListFormatter::CreateInstance(const ILocalizer& localizer,
+                                              ListFormatType type,
+                                              ListFormatWidth width,
+                                              bool isolateItems)
+{
+  // NOTE: width (WIDE/SHORT/NARROW) is accepted for API parity with ICU
+  (void)width;
+
+  const Patterns fb = FallbackPatterns(type);
+  if (type == ListFormatType::UNITS)
+  {
+    const std::string sepStart = Localize(localizer, STR_LIST_AND_START, fb.start);
+    const std::string sepMiddle = Localize(localizer, STR_LIST_AND_MIDDLE, fb.middle);
+    return CListFormatter(Patterns{sepStart, sepStart, sepMiddle, sepMiddle}, isolateItems);
+  }
+
+  const bool isOr = type == ListFormatType::OR;
+  Patterns p;
+  p.two = Localize(localizer, isOr ? STR_LIST_OR_TWO : STR_LIST_AND_TWO, fb.two);
+  p.start = Localize(localizer, STR_LIST_AND_START, fb.start);
+  p.middle = Localize(localizer, STR_LIST_AND_MIDDLE, fb.middle);
+  p.end = Localize(localizer, isOr ? STR_LIST_OR_END : STR_LIST_AND_END, fb.end);
+  return CListFormatter(std::move(p), isolateItems);
+}
+
+std::string CListFormatter::Apply(std::string_view pattern, std::string_view a, std::string_view b)
+{
+  std::string out;
+  out.reserve(pattern.size() + a.size() + b.size());
+  for (size_t i = 0; i < pattern.size();)
+  {
+    if (pattern[i] == '{' && i + 2 < pattern.size() && pattern[i + 2] == '}')
+    {
+      if (pattern[i + 1] == '0')
+      {
+        out.append(a);
+        i += 3;
+        continue;
+      }
+      if (pattern[i + 1] == '1')
+      {
+        out.append(b);
+        i += 3;
+        continue;
+      }
+    }
+    out.push_back(pattern[i++]);
+  }
+  return out;
+}
+
+namespace
+{
+// Explicit UTF-8 bytes to avoid execution-charset ambiguity (MSVC without /utf-8).
+constexpr std::string_view FSI = "\xE2\x81\xA8"; // U+2068 First Strong Isolate
+constexpr std::string_view PDI = "\xE2\x81\xA9"; // U+2069 Pop Directional Isolate
+} // unnamed namespace
+
+std::string CListFormatter::Format(const std::vector<std::string>& items) const
+{
+  const size_t n = items.size();
+  if (n == 0)
+    return {};
+
+  // Wrap only the *raw* items, never the accumulator (it already carries isolates).
+  const auto iso = [this](std::string_view item)
+  {
+    if (!m_isolateItems)
+      return std::string(item);
+    std::string s;
+    s.reserve(item.size() + FSI.size() + PDI.size());
+    s.append(FSI).append(item).append(PDI);
+    return s;
+  };
+
+  if (n == 1)
+    return iso(items[0]);
+  if (n == 2)
+    return Apply(m_patterns.two, iso(items[0]), iso(items[1]));
+
+  std::string result = Apply(m_patterns.start, iso(items[0]), iso(items[1]));
+  for (size_t i = 2; i < n - 1; ++i)
+    result = Apply(m_patterns.middle, result, iso(items[i]));
+  return Apply(m_patterns.end, result, iso(items[n - 1]));
+}

--- a/xbmc/utils/i18n/ListFormatter.h
+++ b/xbmc/utils/i18n/ListFormatter.h
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+class ILocalizer;
+
+namespace KODI::UTILS::I18N
+{
+/*! \brief List conjunction type, mirroring ICU UListFormatterType. */
+enum class ListFormatType
+{
+  AND, //!< "A, B and C"
+  OR, //!< "A, B or C"
+  UNITS //!< "A, B, C" (no conjunction)
+};
+
+/*! \brief List width, mirroring ICU UListFormatterWidth. */
+enum class ListFormatWidth
+{
+  WIDE,
+  SHORT,
+  NARROW
+};
+
+inline constexpr uint32_t STR_LIST_AND_TWO = 39900; // "{0} and {1}"
+inline constexpr uint32_t STR_LIST_AND_START = 39901; // "{0}, {1}"
+inline constexpr uint32_t STR_LIST_AND_MIDDLE = 39902; // "{0}, {1}"
+inline constexpr uint32_t STR_LIST_AND_END = 39903; // "{0}, and {1}"
+inline constexpr uint32_t STR_LIST_OR_TWO = 39910; // "{0} or {1}"
+inline constexpr uint32_t STR_LIST_OR_END = 39911; // "{0}, or {1}"
+
+/*!
+ * \brief Immutable list formatter.
+ *        Joins items using locale-aware list patterns. Depending on the
+ *        ListFormatType, the final item may use a conjunction or only a
+ *        separator.
+ */
+class CListFormatter
+{
+public:
+  /*! \brief The four CLDR list patterns. Each uses {0} and {1} placeholders. */
+  struct Patterns
+  {
+    std::string two; //!< exactly two items
+    std::string start; //!< first pair of 3+ items
+    std::string middle; //!< inner items of 3+ items
+    std::string end; //!< last pair of 3+ items
+  };
+
+  explicit CListFormatter(Patterns patterns, bool isolateItems = true)
+    : m_patterns(std::move(patterns)),
+      m_isolateItems(isolateItems)
+  {
+  }
+
+  /*!
+   * \brief Create a formatter for the active locale (equivalent to
+   *        ListFormatter::createInstance).
+   * \param localizer source of translated patterns (e.g. g_localizeStrings)
+   * \param type list conjunction type (AND, OR, UNITS)
+   * \param width list width (WIDE, SHORT, NARROW)
+   * \param isolateItems whether to isolate items with Unicode isolation characters
+   */
+  static CListFormatter CreateInstance(const ILocalizer& localizer,
+                                       ListFormatType type = ListFormatType::AND,
+                                       ListFormatWidth width = ListFormatWidth::WIDE,
+                                       bool isolateItems = true);
+
+  /*! \brief Format a list of strings (equivalent to ListFormatter::format). */
+  std::string Format(const std::vector<std::string>& items) const;
+
+private:
+  static std::string Apply(std::string_view pattern, std::string_view a, std::string_view b);
+
+  Patterns m_patterns;
+  bool m_isolateItems{true};
+};
+} // namespace KODI::UTILS::I18N

--- a/xbmc/utils/i18n/test/CMakeLists.txt
+++ b/xbmc/utils/i18n/test/CMakeLists.txt
@@ -4,7 +4,8 @@ set(SOURCES TestBcp47.cpp
             TestIso3166_1.cpp
             TestIso639_1.cpp
             TestIso639_2.cpp
-            TestI18nUtils.cpp)
+            TestI18nUtils.cpp
+            TestListFormatter.cpp)
 
 set(HEADERS TestI18nUtils.h)
 

--- a/xbmc/utils/i18n/test/TestListFormatter.cpp
+++ b/xbmc/utils/i18n/test/TestListFormatter.cpp
@@ -1,0 +1,391 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/ILocalizer.h"
+#include "utils/i18n/ListFormatter.h"
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace KODI::UTILS::I18N;
+
+namespace
+{
+// Bidi isolate markers (UAX #9). Explicit UTF-8 bytes avoid execution-charset issues.
+constexpr std::string_view FSI = "\xE2\x81\xA8"; // U+2068 First Strong Isolate
+constexpr std::string_view PDI = "\xE2\x81\xA9"; // U+2069 Pop Directional Isolate
+
+// Arabic (RTL)
+constexpr std::string_view AR_AND = "\xD9\x88"; // و   U+0648 (waw, "and")
+constexpr std::string_view AR_COMMA = "\xD8\x8C"; // ،   U+060C (Arabic comma)
+constexpr std::string_view AR_A = "\xD8\xA7\xD8\xA8"; // اب
+constexpr std::string_view AR_B = "\xD8\xA8\xD8\xAA"; // بت
+constexpr std::string_view AR_C = "\xD8\xAA\xD8\xA7"; // تا
+
+//! \brief Wrap text in First-Strong/Pop directional isolates.
+std::string Iso(std::string_view s)
+{
+  std::string out;
+  out.reserve(FSI.size() + s.size() + PDI.size());
+  out.append(FSI).append(s).append(PDI);
+  return out;
+}
+
+std::string Sv(std::string_view s)
+{
+  return std::string(s);
+}
+
+size_t CountSubstr(const std::string& haystack, std::string_view needle)
+{
+  size_t count = 0;
+  for (size_t pos = haystack.find(needle); pos != std::string::npos;
+       pos = haystack.find(needle, pos + needle.size()))
+    ++count;
+  return count;
+}
+
+// Arabic "and" list patterns: two="{0} و{1}", sep="{0}، {1}", end="{0}، و{1}".
+CListFormatter::Patterns ArabicAndPatterns()
+{
+  return {
+      Sv("{0} ").append(AR_AND).append("{1}"), // two
+      Sv("{0}").append(AR_COMMA).append(" {1}"), // start
+      Sv("{0}").append(AR_COMMA).append(" {1}"), // middle
+      Sv("{0}").append(AR_COMMA).append(" ").append(AR_AND).append("{1}"), // end
+  };
+}
+
+// English "and" list patterns (modern CLDR, Oxford comma): "a, b, and c".
+CListFormatter::Patterns EnglishAndPatterns()
+{
+  return {"{0} and {1}", "{0}, {1}", "{0}, {1}", "{0}, and {1}"};
+}
+
+//! \brief Returns a fixed string for any string id (proves the factory reads the localizer).
+class CAlwaysLocalizer : public ILocalizer
+{
+public:
+  explicit CAlwaysLocalizer(std::string value) : m_value(std::move(value)) {}
+  std::string Localize(std::uint32_t /*code*/) const override { return m_value; }
+
+private:
+  std::string m_value;
+};
+
+//! \brief Returns empty for every id, forcing CListFormatter's English fallbacks.
+class CEmptyLocalizer : public ILocalizer
+{
+public:
+  std::string Localize(std::uint32_t /*code*/) const override { return {}; }
+};
+} // unnamed namespace
+
+// --------------------------------------------------------------------------
+// Structural / item-count cases
+// --------------------------------------------------------------------------
+
+TEST(ListFormatter, Empty_ReturnsEmpty)
+{
+  const CListFormatter fmt(ArabicAndPatterns());
+  EXPECT_EQ(fmt.Format({}), "");
+}
+
+TEST(ListFormatter, SingleItem_IsIsolated)
+{
+  // A lone item must still be isolated so it is self-contained when embedded
+  // inside surrounding UI text of the opposite direction.
+  const CListFormatter fmt(ArabicAndPatterns());
+  EXPECT_EQ(fmt.Format({Sv(AR_A)}), Iso(AR_A));
+}
+
+// --------------------------------------------------------------------------
+// Pure RTL content - logical order is preserved (NOT visually reversed)
+// --------------------------------------------------------------------------
+
+TEST(ListFormatter, Arabic_And_TwoItems)
+{
+  const CListFormatter fmt(ArabicAndPatterns());
+  const std::string expected = Iso(AR_A) + " " + Sv(AR_AND) + Iso(AR_B);
+  EXPECT_EQ(fmt.Format({Sv(AR_A), Sv(AR_B)}), expected);
+}
+
+TEST(ListFormatter, Arabic_And_ThreeItems_LogicalOrderWithIsolates)
+{
+  const CListFormatter fmt(ArabicAndPatterns());
+  const std::string expected =
+      Iso(AR_A) + Sv(AR_COMMA) + " " + Iso(AR_B) + Sv(AR_COMMA) + " " + Sv(AR_AND) + Iso(AR_C);
+  EXPECT_EQ(fmt.Format({Sv(AR_A), Sv(AR_B), Sv(AR_C)}), expected);
+}
+
+// --------------------------------------------------------------------------
+// Mixed-direction lists
+// --------------------------------------------------------------------------
+
+TEST(ListFormatter, MixedDirection_EachItemIsolated)
+{
+  // Arabic ("and") list containing one LTR/Latin item. Every item - including
+  // the Latin one - must be wrapped so the UBA cannot leak across the
+  // item/separator boundary.
+  const CListFormatter fmt(ArabicAndPatterns());
+  const std::string result = fmt.Format({Sv(AR_A), "Bob", Sv(AR_C)});
+
+  const std::string expected =
+      Iso(AR_A) + Sv(AR_COMMA) + " " + Iso("Bob") + Sv(AR_COMMA) + " " + Sv(AR_AND) + Iso(AR_C);
+  EXPECT_EQ(result, expected);
+
+  // The Latin item is bracketed by FSI...PDI.
+  EXPECT_NE(result.find(Iso("Bob")), std::string::npos);
+}
+
+TEST(ListFormatter, IsolationDisabled_NoMarkers)
+{
+  // With isolation off the mixed list contains no isolates
+  // and is therefore vulnerable to UBA reordering at render time.
+  const CListFormatter fmt(ArabicAndPatterns(), /*isolateItems*/ false);
+  const std::string result = fmt.Format({Sv(AR_A), "Bob", Sv(AR_C)});
+
+  EXPECT_EQ(CountSubstr(result, FSI), 0u);
+  EXPECT_EQ(CountSubstr(result, PDI), 0u);
+  EXPECT_EQ(result, Sv(AR_A) + Sv(AR_COMMA) + " Bob" + Sv(AR_COMMA) + " " + Sv(AR_AND) + Sv(AR_C));
+}
+
+// --------------------------------------------------------------------------
+// Isolation invariants
+// --------------------------------------------------------------------------
+
+TEST(ListFormatter, IsolationCountMatchesItemCount)
+{
+  const CListFormatter fmt(ArabicAndPatterns());
+
+  EXPECT_EQ(CountSubstr(fmt.Format({}), FSI), 0u);
+  EXPECT_EQ(CountSubstr(fmt.Format({Sv(AR_A)}), FSI), 1u);
+  EXPECT_EQ(CountSubstr(fmt.Format({Sv(AR_A), Sv(AR_B)}), FSI), 2u);
+
+  const std::string three = fmt.Format({Sv(AR_A), Sv(AR_B), Sv(AR_C)});
+  EXPECT_EQ(CountSubstr(three, FSI), 3u); // one open per item
+  EXPECT_EQ(CountSubstr(three, PDI), 3u); // one close per item
+}
+
+TEST(ListFormatter, ConjunctionIsNotIsolated)
+{
+  // Pattern literals (separators / conjunction) must sit OUTSIDE the isolates.
+  const CListFormatter fmt(ArabicAndPatterns());
+  const std::string result = fmt.Format({Sv(AR_A), Sv(AR_B), Sv(AR_C)});
+
+  // "and" should never appear wrapped as FSI و PDI.
+  EXPECT_EQ(CountSubstr(result, Iso(AR_AND)), 0u);
+  // The conjunction is immediately followed by the next item's opening isolate.
+  EXPECT_NE(result.find(Sv(AR_AND) + Sv(FSI)), std::string::npos);
+}
+
+TEST(ListFormatter, ItemContainingPlaceholderIsNotReExpanded)
+{
+  // Single-pass substitution: an item that itself contains "{1}" is treated as
+  // data, not as a pattern placeholder.
+  const CListFormatter::Patterns en{"{0} and {1}", "{0}, {1}", "{0}, {1}", "{0}, and {1}"};
+  const CListFormatter fmt(en, /*isolateItems*/ false);
+  EXPECT_EQ(fmt.Format({"{1}", "x"}), "{1} and x");
+}
+
+TEST(ListFormatter, Units_NoConjunction_StillIsolates)
+{
+  // UNITS-style: separators only, no conjunction, but items remain isolated.
+  const CListFormatter::Patterns units{"{0}, {1}", "{0}, {1}", "{0}, {1}", "{0}, {1}"};
+  const CListFormatter fmt(units);
+  EXPECT_EQ(fmt.Format({Sv(AR_A), Sv(AR_B), Sv(AR_C)}),
+            Iso(AR_A) + ", " + Iso(AR_B) + ", " + Iso(AR_C));
+}
+
+// --------------------------------------------------------------------------
+// CreateInstance: localization wiring + English fallback
+// --------------------------------------------------------------------------
+
+//! \brief Returns a configurable string per string id; falls back to empty.
+namespace
+{
+class CMapLocalizer : public ILocalizer
+{
+public:
+  explicit CMapLocalizer(std::map<std::uint32_t, std::string> strings)
+    : m_strings(std::move(strings))
+  {
+  }
+  std::string Localize(std::uint32_t code) const override
+  {
+    const auto it = m_strings.find(code);
+    return it != m_strings.end() ? it->second : std::string{};
+  }
+
+private:
+  std::map<std::uint32_t, std::string> m_strings;
+};
+} // unnamed namespace
+
+TEST(ListFormatter, CreateInstance_FallbackEnglish_And)
+{
+  const CEmptyLocalizer localizer;
+  const CListFormatter fmt = CListFormatter::CreateInstance(localizer, ListFormatType::AND);
+  EXPECT_EQ(fmt.Format({"a", "b", "c"}), Iso("a") + ", " + Iso("b") + ", and " + Iso("c"));
+}
+
+TEST(ListFormatter, CreateInstance_FallbackEnglish_Or)
+{
+  const CEmptyLocalizer localizer;
+  const CListFormatter fmt = CListFormatter::CreateInstance(localizer, ListFormatType::OR);
+  EXPECT_EQ(fmt.Format({"a", "b"}), Iso("a") + " or " + Iso("b"));
+}
+
+TEST(ListFormatter, CreateInstance_Units_FallbackEnglish)
+{
+  // With no localized strings UNITS falls back to English ", " separator for
+  // all slots. Output is identical to the old hard-coded path but now goes
+  // through Localize() so locale overrides are honoured.
+  const CEmptyLocalizer localizer;
+  const CListFormatter fmt = CListFormatter::CreateInstance(localizer, ListFormatType::UNITS);
+  EXPECT_EQ(fmt.Format({"a", "b", "c"}), Iso("a") + ", " + Iso("b") + ", " + Iso("c"));
+}
+
+TEST(ListFormatter, CreateInstance_Units_UsesLocalizedSeparator)
+{
+  // Prove CreateInstance reads the localizer for UNITS (previously bypassed).
+  // CAlwaysLocalizer returns the Arabic comma separator for every string id.
+  const CAlwaysLocalizer localizer(Sv("{0}").append(AR_COMMA).append(" {1}"));
+  const CListFormatter fmt = CListFormatter::CreateInstance(localizer, ListFormatType::UNITS);
+  EXPECT_EQ(fmt.Format({Sv(AR_A), Sv(AR_B), Sv(AR_C)}),
+            Iso(AR_A) + Sv(AR_COMMA) + " " + Iso(AR_B) + Sv(AR_COMMA) + " " + Iso(AR_C));
+}
+
+TEST(ListFormatter, CreateInstance_Units_StartAndMiddleCanDiffer)
+{
+  // UNITS builds: two=start=STR_LIST_AND_START, middle=end=STR_LIST_AND_MIDDLE.
+  // Use distinct patterns per ID so we can verify the slot assignment.
+  const CMapLocalizer localizer({
+      {STR_LIST_AND_START, "{0}~SEP_START~{1}"},
+      {STR_LIST_AND_MIDDLE, "{0}~SEP_MIDDLE~{1}"},
+  });
+  const CListFormatter fmt =
+      CListFormatter::CreateInstance(localizer, ListFormatType::UNITS, ListFormatWidth::WIDE,
+                                     /*isolateItems=*/false);
+
+  // Two items → two slot (= start pattern)
+  EXPECT_EQ(fmt.Format({"a", "b"}), "a~SEP_START~b");
+  // Three items → start then middle (= middle pattern for end, no conjunction)
+  EXPECT_EQ(fmt.Format({"a", "b", "c"}), "a~SEP_START~b~SEP_MIDDLE~c");
+  // Four items → start, middle (inner), middle (end)
+  EXPECT_EQ(fmt.Format({"a", "b", "c", "d"}), "a~SEP_START~b~SEP_MIDDLE~c~SEP_MIDDLE~d");
+}
+
+TEST(ListFormatter, CreateInstance_ReadsLocalizedRtlPattern)
+{
+  // Proves the factory pulls patterns from the localizer (RTL "two" pattern),
+  // rather than always using the English fallback.
+  const CAlwaysLocalizer localizer(Sv("{0} ").append(AR_AND).append("{1}"));
+  const CListFormatter fmt = CListFormatter::CreateInstance(localizer, ListFormatType::AND);
+  EXPECT_EQ(fmt.Format({Sv(AR_A), Sv(AR_B)}), Iso(AR_A) + " " + Sv(AR_AND) + Iso(AR_B));
+}
+
+// --------------------------------------------------------------------------
+// English / LTR content
+// --------------------------------------------------------------------------
+
+TEST(ListFormatter, English_SingleItem_IsIsolated)
+{
+  // Isolation is direction-agnostic: a lone LTR item is wrapped too.
+  const CListFormatter fmt(EnglishAndPatterns());
+  EXPECT_EQ(fmt.Format({"Alice"}), Iso("Alice"));
+}
+
+TEST(ListFormatter, English_And_TwoItems)
+{
+  const CListFormatter fmt(EnglishAndPatterns());
+  EXPECT_EQ(fmt.Format({"Alice", "Bob"}), Iso("Alice") + " and " + Iso("Bob"));
+}
+
+TEST(ListFormatter, English_And_ThreeItems)
+{
+  const CListFormatter fmt(EnglishAndPatterns());
+  EXPECT_EQ(fmt.Format({"a", "b", "c"}), Iso("a") + ", " + Iso("b") + ", and " + Iso("c"));
+}
+
+TEST(ListFormatter, English_And_FourItems_DocExample)
+{
+  // The icu::ListFormatter doc example. Four items is the smallest list that
+  // exercises the `middle` pattern (items between first pair and last).
+  const CListFormatter fmt(EnglishAndPatterns());
+  const std::string expected =
+      Iso("Alice") + ", " + Iso("Bob") + ", " + Iso("Charlie") + ", and " + Iso("Delta");
+  EXPECT_EQ(fmt.Format({"Alice", "Bob", "Charlie", "Delta"}), expected);
+}
+
+TEST(ListFormatter, English_And_FourItems_DocExample_NoIsolation)
+{
+  // Human-readable canonical output (Oxford comma per modern CLDR).
+  const CListFormatter fmt(EnglishAndPatterns(), /*isolateItems*/ false);
+  EXPECT_EQ(fmt.Format({"Alice", "Bob", "Charlie", "Delta"}), "Alice, Bob, Charlie, and Delta");
+}
+
+TEST(ListFormatter, English_Or_ThreeItems)
+{
+  const CListFormatter::Patterns en{"{0} or {1}", "{0}, {1}", "{0}, {1}", "{0}, or {1}"};
+  const CListFormatter fmt(en);
+  EXPECT_EQ(fmt.Format({"a", "b", "c"}), Iso("a") + ", " + Iso("b") + ", or " + Iso("c"));
+}
+
+TEST(ListFormatter, French_And_LocalizedConjunction)
+{
+  // Non-English LTR: French uses "et" and no comma before the conjunction.
+  const CListFormatter::Patterns fr{"{0} et {1}", "{0}, {1}", "{0}, {1}", "{0} et {1}"};
+  const CListFormatter fmt(fr);
+  EXPECT_EQ(fmt.Format({"a", "b", "c"}), Iso("a") + ", " + Iso("b") + " et " + Iso("c"));
+}
+
+TEST(ListFormatter, Ltr_WithEmbeddedRtlItem_EachItemIsolated)
+{
+  // Mirror of the Arabic mixed-direction case: an English (LTR) list that
+  // contains an Arabic (RTL) item. The RTL item must be isolated so it cannot
+  // disturb the surrounding LTR separators.
+  const CListFormatter fmt(EnglishAndPatterns());
+  const std::string result = fmt.Format({"Alice", Sv(AR_A), "Bob"});
+
+  EXPECT_EQ(result, Iso("Alice") + ", " + Iso(AR_A) + ", and " + Iso("Bob"));
+  EXPECT_NE(result.find(Iso(AR_A)), std::string::npos);
+}
+
+TEST(ListFormatter, StartMiddleEnd_AppliedAtCorrectPositions)
+{
+  // Distinct markers per slot prove each pattern is applied at the right
+  // position: `two` only for exactly two items; otherwise start(front),
+  // middle(inner, possibly repeated), end(back).
+  const CListFormatter::Patterns p{"{0}~TWO~{1}", "{0}~START~{1}", "{0}~MIDDLE~{1}", "{0}~END~{1}"};
+  const CListFormatter fmt(p, /*isolateItems*/ false);
+
+  EXPECT_EQ(fmt.Format({"a", "b"}), "a~TWO~b");
+  EXPECT_EQ(fmt.Format({"a", "b", "c"}), "a~START~b~END~c"); // no middle yet
+  EXPECT_EQ(fmt.Format({"a", "b", "c", "d", "e"}), "a~START~b~MIDDLE~c~MIDDLE~d~END~e");
+}
+
+// --------------------------------------------------------------------------
+// Marker sanity
+// --------------------------------------------------------------------------
+
+TEST(ListFormatter, IsolateMarkers_AreCorrectCodepoints)
+{
+  ASSERT_EQ(FSI.size(), 3u);
+  ASSERT_EQ(PDI.size(), 3u);
+  EXPECT_EQ(static_cast<unsigned char>(FSI[0]), 0xE2); // U+2068
+  EXPECT_EQ(static_cast<unsigned char>(FSI[1]), 0x81);
+  EXPECT_EQ(static_cast<unsigned char>(FSI[2]), 0xA8);
+  EXPECT_EQ(static_cast<unsigned char>(PDI[2]), 0xA9); // U+2069
+}

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3426,6 +3426,60 @@ void CVideoDatabase::GetEpisodesByBlurayPath(const std::string& path,
   }
 }
 
+void CVideoDatabase::GetEpisodesByBasePath(const std::string& path,
+                                           std::vector<CVideoInfoTag>& episodes,
+                                           int idShow /* = -1 */)
+{
+  try
+  {
+    if (idShow == -1)
+      // Will only find first idShow for a given base path
+      // Note the wiki says all TV shows should be in their own folder
+      idShow = GetSingleValueInt(PrepareSQL("SELECT idShow FROM episode WHERE c%02d='%s'",
+                                            VIDEODB_ID_EPISODE_BASEPATH, path.c_str()),
+                                 *m_pDS);
+
+    // Generate map of episodes in each file (finding base file for bluray://) of show
+    EpisodeFileMap fileMap;
+    if (!GetEpisodeMap(idShow, fileMap, *m_pDS))
+    {
+      m_pDS->close();
+      return;
+    }
+
+    // Get episode details
+    auto filteredEpisodes{fileMap |
+                          std::views::filter(
+                              [&path](const EpisodeFileMapEntry& episode)
+                              {
+                                // Base path is either the file (ISO/MKV) or path containing the BDMV/VIDEO_TS folder
+                                const std::string basePath{
+                                    URIUtils::IsBDFile(episode.first) ||
+                                            URIUtils::IsDVDFile(episode.first)
+                                        ? URIUtils::GetDiscBase(episode.first)
+                                        : episode.first};
+                                return basePath == path;
+                              }) |
+                          std::views::values};
+    for (const auto& episode : filteredEpisodes)
+    {
+      m_pDS->goto_rec(episode.index);
+      CVideoInfoTag tag{GetDetailsForEpisode(*m_pDS)};
+      tag.m_duration = episode.duration;
+      episodes.push_back(std::move(tag));
+    }
+    m_pDS->close();
+  }
+  catch (const std::exception& e)
+  {
+    CLog::LogF(LOGERROR, "Failed for base path {} - error {}", path, e.what());
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "Failed for base path {}", path);
+  }
+}
+
 void CVideoDatabase::GetEpisodesByFile(const std::string& strFilenameAndPath,
                                        std::vector<CVideoInfoTag>& episodes)
 {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8698,7 +8698,6 @@ std::string CVideoDatabase::GetContentForPath(const std::string& strPath)
       // So see if there are any matches using the parentpathid.
       sql = PrepareSQL("SELECT DISTINCT e.strPath FROM episode_view e "
                        "JOIN path p ON e.c%02d = p.idPath "
-                       "JOIN files f ON e.idFile = f.idFile "
                        "WHERE p.strPath = '%s' ",
                        VIDEODB_ID_EPISODE_PARENTPATHID, strPath.c_str());
       m_pDS->query(sql);
@@ -8707,7 +8706,7 @@ std::string CVideoDatabase::GetContentForPath(const std::string& strPath)
         while (!m_pDS->eof())
         {
           const CURL url(m_pDS->fv(0).get_asString());
-          if (url.GetFileName().empty() && URIUtils::IsArchive(url))
+          if ((url.GetFileName().empty() && URIUtils::IsArchive(url)) || url.IsBlurayPath())
             return "episodes"; // Episodes in root of archive
           m_pDS->next();
         }
@@ -9519,6 +9518,34 @@ void CVideoDatabase::GetMusicVideosByName(const std::string& strSearch, CFileIte
   {
     CLog::LogF(LOGERROR, "({}) failed", strSQL);
   }
+}
+
+std::string CVideoDatabase::GetPlotByShowId(int idShow)
+{
+  std::string strSQL;
+
+  try
+  {
+    if (nullptr == m_pDB)
+      return "";
+    if (nullptr == m_pDS)
+      return "";
+
+    strSQL = PrepareSQL("SELECT c%02d FROM tvshow WHERE idShow = %i", VIDEODB_ID_TV_PLOT, idShow);
+    m_pDS->query(strSQL);
+
+    std::string plot{};
+    if (!m_pDS->eof())
+      plot = m_pDS->fv(0).get_asString();
+
+    m_pDS->close();
+    return plot;
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
+  }
+  return {};
 }
 
 void CVideoDatabase::GetEpisodesByPlot(const std::string& strSearch, CFileItemList& items)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -309,6 +309,9 @@ public:
   int GetSeasonId(int idShow, int season) const;
 
   void GetEpisodesByBlurayPath(const std::string& path, std::vector<CVideoInfoTag>& episodes);
+  void GetEpisodesByBasePath(const std::string& path,
+                             std::vector<CVideoInfoTag>& episodes,
+                             int idShow = -1);
   void GetEpisodesByFile(const std::string& strFilenameAndPath, std::vector<CVideoInfoTag>& episodes);
   void GetEpisodesByFileId(int idFile, std::vector<CVideoInfoTag>& episodes);
   bool GetEpisodeMap(int idShow, EpisodeFileMap& fileMap, int idFile = -1) const;

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -642,6 +642,7 @@ public:
   void GetEpisodesByName(const std::string& strSearch, CFileItemList& items);
   void GetMusicVideosByName(const std::string& strSearch, CFileItemList& items);
 
+  std::string GetPlotByShowId(int idShow);
   void GetEpisodesByPlot(const std::string& strSearch, CFileItemList& items);
   void GetMoviesByPlot(const std::string& strSearch, CFileItemList& items);
 

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -58,7 +58,6 @@
 #include "utils/Variant.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
-#include "video/VideoDbUrl.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoScanner.h"
 #include "video/VideoLibraryQueue.h"
@@ -70,7 +69,12 @@
 #include "video/guilib/VideoSelectActionProcessor.h"
 #include "view/GUIViewState.h"
 
+#include <map>
 #include <memory>
+#include <ranges>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 using namespace XFILE;
 using namespace VIDEODATABASEDIRECTORY;
@@ -720,13 +724,61 @@ void CGUIWindowVideoBase::LoadVideoInfo(CFileItemList& items,
   if (!content.empty())
   {
     database.GetItemsForPath(content, items.GetPath(), dbItems);
+
+    // Determine episode ranges for multi-episode items sharing the same basePath (same file).
+    if (content == "episodes" && !dbItems.IsEmpty())
+    {
+      std::map<std::string, std::vector<int>> episodesByPath;
+      for (int i = 0; i < dbItems.Size(); i++)
+      {
+        const auto& dbItem = dbItems.Get(i);
+        if (dbItem->HasVideoInfoTag())
+          episodesByPath[dbItem->GetPath()].emplace_back(i);
+      }
+
+      std::unordered_map<int, std::string> showPlotCache;
+      for (const auto& episodes : episodesByPath | std::views::values)
+      {
+        if (episodes.size() < 2)
+          continue;
+
+        const auto& firstItem{dbItems.Get(episodes[0])};
+        int numSpecials{0};
+        std::string episodeString;
+        for (int e : episodes)
+        {
+          const auto* tag{dbItems.Get(e)->GetVideoInfoTag()};
+          if (!tag)
+            continue;
+          if (tag->m_iSeason == 0)
+            numSpecials++;
+          else
+            episodeString += fmt::format("S{:02d}E{:02d};", tag->m_iSeason, tag->m_iEpisode);
+        }
+
+        // Store on the first item (saved by SetFastLookup)
+        firstItem->SetProperty("episodes", episodeString);
+        firstItem->SetProperty("episodes_specials", numSpecials);
+
+        // Pre-fetch show plot for multi-episode range labels (as the individual episode plot is not relevant)
+        if (firstItem->HasVideoInfoTag())
+        {
+          const int idShow{firstItem->GetVideoInfoTag()->m_iIdShow};
+          auto [it, inserted] = showPlotCache.emplace(idShow, std::string{});
+          if (inserted)
+            it->second = database.GetPlotByShowId(idShow);
+          firstItem->SetProperty("episodes_show_plot", it->second);
+        }
+      }
+    }
+
     dbItems.SetFastLookup(true);
   }
 
   for (int i = 0; i < items.Size(); i++)
   {
-    CFileItemPtr pItem = items[i];
-    CFileItemPtr match;
+    const auto& pItem{items[i]};
+    std::shared_ptr<CFileItem> match;
 
     if (pItem->IsFolder() && !pItem->IsParentFolder())
     {
@@ -745,9 +797,18 @@ void CGUIWindowVideoBase::LoadVideoInfo(CFileItemList& items,
     }
     if (match)
     {
-      pItem->UpdateInfo(*match, replaceLabels);
+      pItem->UpdateInfo(*match, replaceLabels, MultipleEpisodes::GROUP_MULTIPLE_EPISODES);
 
-      if (stackItems)
+      if (match->HasProperty("episodes") && !pItem->GetPath().empty())
+      {
+        CURL url("episodes://");
+        url.SetHostName(pItem->GetPath());
+        if (pItem->HasVideoInfoTag())
+          url.SetOptions("?show=" + std::to_string(pItem->GetVideoInfoTag()->m_iIdShow));
+        pItem->SetPath(url.Get());
+        pItem->SetFolder(true);
+      }
+      else if (stackItems)
       {
         if (match->IsFolder())
           pItem->SetPath(match->GetVideoInfoTag()->m_strPath);
@@ -1159,6 +1220,10 @@ bool CGUIWindowVideoBase::GetDirectory(const std::string &strDirectory, CFileIte
   // No "normal" episodes should stack, and multi-parts should be supported)
   ADDON::ScraperPtr info = m_database.GetScraperForPath(strDirectory);
   if (info && info->Content() == ContentType::TVSHOWS)
+    m_stackingAvailable = false;
+
+  // Do not stack episodes that are in a multi-episode file
+  if (strDirectory.starts_with("episodes://"))
     m_stackingAvailable = false;
 
   if (m_stackingAvailable && !items.IsStack() && CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_MYVIDEOS_STACKVIDEOS))

--- a/xbmc/view/GUIViewState.cpp
+++ b/xbmc/view/GUIViewState.cpp
@@ -27,7 +27,6 @@
 #include "games/windows/GUIViewStateWindowGames.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "guilib/TextureManager.h"
 #include "music/GUIViewStateMusic.h"
 #include "pictures/GUIViewStatePictures.h"
 #include "playlists/PlayListFileItemClassify.h"
@@ -95,6 +94,9 @@ CGUIViewState* CGUIViewState::GetViewState(int windowId, const CFileItemList& it
 
   if (url.IsProtocol("library"))
     return new CGUIViewStateLibrary(items);
+
+  if (url.IsProtocol("episodes"))
+    return new CGUIViewStateVideoEpisodes(items);
 
   if (PLAYLIST::IsPlayList(items))
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Properly recognise bluray episodes when browsing through Video->Files and allow selection of any episode on the disc. 

I've also had a crack at a lightweight ListFormatter to cover RTL languages.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Browsing Video->Files does not show already scanned bluray episodes.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Before:
<img width="3200" height="2000" alt="image" src="https://github.com/user-attachments/assets/71eb020e-7aee-4560-bea7-55aa5c5f2c11" />

After:
<img width="3200" height="2000" alt="image" src="https://github.com/user-attachments/assets/4a4b44fb-1ef8-4bd8-8e50-ff0ddd9350e7" />

<img width="3200" height="2000" alt="image" src="https://github.com/user-attachments/assets/b838fa24-e717-4a47-be50-897f809e5bfd" />

**RTL Language Test**

Now testing with Arabic.

Using the current Arabic language strings.po and adding:
```
#. Used to show Episodes in Video->Files (eg. Episode n)
#: xbmc/FileItem.cpp
msgctxt "#21486"
msgid "Episode {0:d}"
msgstr "الحلقة {0:d}"
```
and
```
#. List formatting - STR_LIST_AND_START
#: xbmc/utils/i18n/ListFormatting.h
msgctxt "#39901"
msgid "{0}, {1}"
msgstr "{0}، {1}"

#. List formatting - STR_LIST_AND_MIDDLE
#: xbmc/utils/i18n/ListFormatting.h
msgctxt "#39902"
msgid "{0}, {1}"
msgstr "{0}، {1}"

#. List formatting - STR_LIST_AND_END
#: xbmc/utils/i18n/ListFormatting.h
msgctxt "#39903"
msgid "{0}, and {1}"
msgstr "{0}، و{1}"
```

English
<img width="2045" height="1216" alt="image" src="https://github.com/user-attachments/assets/033de15e-401e-4f69-b746-aaa37b767a32" />

Arabic
<img width="1781" height="1116" alt="image" src="https://github.com/user-attachments/assets/9125a89f-f5c0-4544-81ac-7650aac29a3b" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
