### PR TITLE
[cmake] FindBrotli add Brotli_FOUND cache variable for external searches

### DIFF
--- a/cmake/modules/FindBrotli.cmake
+++ b/cmake/modules/FindBrotli.cmake
@@ -130,6 +130,10 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
     endif()
 
     ADD_MULTICONFIG_BUILDMACRO()
+
+    # Required for external searches. Not used internally
+    set(Brotli_FOUND ON CACHE BOOL "Brotli found")
+    mark_as_advanced(Brotli_FOUND)
   else()
     if(Brotli_FIND_REQUIRED)
       message(FATAL_ERROR "Brotli libraries were not found.")


### PR DESCRIPTION
## Description
set Brotli_FOUND cache variable on FindBrotli.cmake

## Motivation and context
Exiv2 cmake config relies on ``Brotli_FOUND`` to confirm availability for static lib use.
It will use our FindBrotli as its located on ``CMAKE_MODULE_PATH``, but the exiv config then relies on the variable Brotli_FOUND to confirm the found package of Brotli.

Fixes current master failure - https://jenkins.kodi.tv/job/BuildMulti-All/3259/

## How has this been tested?
Locally with existing deps of brotli/exiv2 that trigger the exiv2 config search.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
