### PR TITLE
[GUI] Add alternate CPU usage GUI label

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1967,6 +1967,7 @@ constexpr std::array<InfoMap, 76> system_labels = {{
     {"dpmsactive",              SYSTEM_DPMS_ACTIVE},
     {"cputemperature",          SYSTEM_CPU_TEMPERATURE}, // labels from here
     {"cpuusage",                SYSTEM_CPU_USAGE},
+    {"cpualtusage",             SYSTEM_CPU_ALT_USAGE},
     {"gputemperature",          SYSTEM_GPU_TEMPERATURE},
     {"fanspeed",                SYSTEM_FAN_SPEED},
     {"freespace",               SYSTEM_FREE_SPACE},

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -468,11 +468,12 @@ constexpr uint32_t SYSTEM_ADDON_UPDATE_COUNT         = 642;
 constexpr uint32_t SYSTEM_PRIVACY_POLICY             = 643;
 constexpr uint32_t SYSTEM_TOTAL_MEMORY               = 644;
 constexpr uint32_t SYSTEM_CPU_USAGE                  = 645;
-constexpr uint32_t SYSTEM_USED_MEMORY_PERCENT        = 646;
-constexpr uint32_t SYSTEM_USED_MEMORY                = 647;
-constexpr uint32_t SYSTEM_FREE_MEMORY                = 648;
-constexpr uint32_t SYSTEM_FREE_MEMORY_PERCENT        = 649;
-// unused id 650 to 653
+constexpr uint32_t SYSTEM_CPU_ALT_USAGE              = 646;
+constexpr uint32_t SYSTEM_USED_MEMORY_PERCENT        = 647;
+constexpr uint32_t SYSTEM_USED_MEMORY                = 648;
+constexpr uint32_t SYSTEM_FREE_MEMORY                = 649;
+constexpr uint32_t SYSTEM_FREE_MEMORY_PERCENT        = 650;
+// unused id 651 to 653
 constexpr uint32_t SYSTEM_UPTIME                     = 654;
 constexpr uint32_t SYSTEM_TOTALUPTIME                = 655;
 constexpr uint32_t SYSTEM_CPUFREQUENCY               = 656;

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -468,11 +468,11 @@ constexpr uint32_t SYSTEM_ADDON_UPDATE_COUNT         = 642;
 constexpr uint32_t SYSTEM_PRIVACY_POLICY             = 643;
 constexpr uint32_t SYSTEM_TOTAL_MEMORY               = 644;
 constexpr uint32_t SYSTEM_CPU_USAGE                  = 645;
-constexpr uint32_t SYSTEM_CPU_ALT_USAGE              = 646;
-constexpr uint32_t SYSTEM_USED_MEMORY_PERCENT        = 647;
-constexpr uint32_t SYSTEM_USED_MEMORY                = 648;
-constexpr uint32_t SYSTEM_FREE_MEMORY                = 649;
-constexpr uint32_t SYSTEM_FREE_MEMORY_PERCENT        = 650;
+constexpr uint32_t SYSTEM_USED_MEMORY_PERCENT        = 646;
+constexpr uint32_t SYSTEM_USED_MEMORY                = 647;
+constexpr uint32_t SYSTEM_FREE_MEMORY                = 648;
+constexpr uint32_t SYSTEM_FREE_MEMORY_PERCENT        = 649;
+constexpr uint32_t SYSTEM_CPU_ALT_USAGE              = 650;
 // unused id 651 to 653
 constexpr uint32_t SYSTEM_UPTIME                     = 654;
 constexpr uint32_t SYSTEM_TOTALUPTIME                = 655;

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -92,6 +92,12 @@ std::string CSystemGUIInfo::GetSystemHeatInfo(int info) const
         text = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
             10005); // Not available
       break;
+    case SYSTEM_CPU_ALT_USAGE:
+      if (CServiceBroker::GetCPUInfo()->SupportsCPUUsage())
+        return CServiceBroker::GetCPUInfo()->GetCoresUsageAltString();
+      else
+        return g_localizeStrings.Get(10005); // Not available
+      break;
     default:
       break;
   }
@@ -150,6 +156,7 @@ bool CSystemGUIInfo::GetLabel(std::string& value,
     case SYSTEM_GPU_TEMPERATURE:
     case SYSTEM_FAN_SPEED:
     case SYSTEM_CPU_USAGE:
+    case SYSTEM_CPU_ALT_USAGE:
       value = GetSystemHeatInfo(info.GetInfo());
       return true;
     case SYSTEM_VIDEO_ENCODER_INFO:

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -94,9 +94,10 @@ std::string CSystemGUIInfo::GetSystemHeatInfo(int info) const
       break;
     case SYSTEM_CPU_ALT_USAGE:
       if (CServiceBroker::GetCPUInfo()->SupportsCPUUsage())
-        return CServiceBroker::GetCPUInfo()->GetCoresUsageAltString();
+        text = CServiceBroker::GetCPUInfo()->GetCoresUsageAltString();
       else
-        return g_localizeStrings.Get(10005); // Not available
+        text = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+            10005); // Not available
       break;
     default:
       break;

--- a/xbmc/utils/CPUInfo.cpp
+++ b/xbmc/utils/CPUInfo.cpp
@@ -62,3 +62,36 @@ std::string CCPUInfo::GetCoresUsageString()
 
   return strCores;
 }
+
+std::string CCPUInfo::GetCoresUsageAltString()
+{
+  std::string strCores;
+
+  if (SupportsCPUUsage())
+  {
+    GetUsedPercentage(); // must call it to recalculate pct values
+
+    if (!m_cores.empty())
+    {
+      bool isFirst = true;
+      for (const auto& core : m_cores)
+      {
+        if (!isFirst) strCores += " | "; 
+        else isFirst = false;
+
+        unsigned int cpu_percent = static_cast<unsigned int>(std::min(99.99, core.m_usagePercent));
+
+        if (cpu_percent < 100) 
+          strCores += StringUtils::Format("{:02d}", cpu_percent);
+        else 
+          strCores += "**";
+      }
+    }
+    else
+    {
+      strCores += StringUtils::Format("{:02d}", static_cast<int>(m_lastUsedPercentage));
+    }
+  }
+
+  return strCores;
+}

--- a/xbmc/utils/CPUInfo.h
+++ b/xbmc/utils/CPUInfo.h
@@ -85,6 +85,7 @@ public:
   bool HasCoreId(int coreId) const;
   const CoreInfo GetCoreInfo(int coreId);
   std::string GetCoresUsageString();
+  std::string GetCoresUsageAltString();
 
   unsigned int GetCPUFeatures() const { return m_cpuFeatures; }
   int GetCPUCount() const { return m_cpuCount; }


### PR DESCRIPTION
## Description
This adds an alternative display for CPU usage

## Screenshots (if appropriate):
<img width="508" height="31" alt="591849544-9c0a7dfc-a3f3-477f-ab0c-fa6902ff1a4d" src="https://github.com/user-attachments/assets/4b906899-9417-4c54-b5e6-55db237468ce" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
