### PR TITLE
[Music] Matroska Music tags support

### DIFF
--- a/cmake/modules/FindTagLib.cmake
+++ b/cmake/modules/FindTagLib.cmake
@@ -24,16 +24,16 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   
     set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VERSION ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER})
   
+    set(patches "${CMAKE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/002-allow-chapters-without-uid.patch")
     if(WIN32 OR WINDOWS_STORE)
-      set(patches "${CMAKE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/001-cmake-pdb-debug.patch")
-      generate_patchcommand("${patches}")
-      unset(patches)
-
-      if(WINDOWS_STORE)
-        set(EXTRA_ARGS -DPLATFORM_WINRT=ON)
-      endif()
+      list(APPEND patches "${CMAKE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/001-cmake-pdb-debug.patch")
     endif()
-  
+    generate_patchcommand("${patches}")
+    unset(patches)
+
+    if(WINDOWS_STORE)
+      set(EXTRA_ARGS -DPLATFORM_WINRT=ON)
+    endif()
     # Debug postfix only used for windows
     if(WIN32 OR WINDOWS_STORE)
       set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_DEBUG_POSTFIX "d")

--- a/tools/depends/target/taglib/002-allow-chapters-without-uid.patch
+++ b/tools/depends/target/taglib/002-allow-chapters-without-uid.patch
@@ -1,0 +1,45 @@
+--- a/taglib/matroska/ebml/ebmlmkchapters.cpp
++++ b/taglib/matroska/ebml/ebmlmkchapters.cpp
+@@ -25,6 +25,7 @@
+ 
+ #include "ebmlmkchapters.h"
+ #include "ebmlstringelement.h"
++#include <atomic>
+ #include "ebmluintelement.h"
+ #include "matroskachapters.h"
+ #include "matroskachapteredition.h"
+@@ -33,6 +34,20 @@
+ 
+ namespace {
+ 
++// Counter for synthesising a unique ChapterUID when the source file omits
++// the MkChapterUID element (out-of-spec but produced by some muxers, e.g.
++// older FFmpeg or audiobook generators). MKVToolNix / MediaInfo / FFmpeg
++// all tolerate UID-less chapters; without this synth, the call sites in
++// MkChapters::parse() filter such chapters out via the `chapter.uid()`
++// check and they are silently lost.
++//
++// High bit set as a marker; counter starts at 1 and increments per atom
++// so each parsed UID-less chapter gets a distinct value within the
++// process lifetime. Real ChapterUIDs are random 64-bit values from
++// muxers; the (1ULL << 63) | n encoding makes collision practically
++// impossible while keeping the distinction local to TagLib.
++static std::atomic<Matroska::Chapter::UID> synthesisedChapterUidCounter{1};
++
+ Matroska::Chapter parseChapterAtom(
+   const std::unique_ptr<EBML::Element> &atomElement)
+ {
+@@ -67,6 +82,13 @@
+       }
+     }
+   }
++  // Spec-noncompliant: ChapterAtom missing ChapterUID. Synthesise a
++  // process-unique UID so the chapter survives downstream `chapter.uid()`
++  // filters. See synthesisedChapterUidCounter comment above.
++  if(chapterUid == 0)
++    chapterUid = (1ULL << 63) |
++                 synthesisedChapterUidCounter.fetch_add(1, std::memory_order_relaxed);
++
+   return Matroska::Chapter(chapterTimeStart, chapterTimeEnd, chapterDisplays,
+     chapterUid, chapterHidden);
+ }

--- a/tools/depends/target/taglib/Makefile
+++ b/tools/depends/target/taglib/Makefile
@@ -1,6 +1,7 @@
 include ../../Makefile.include TAGLIB-VERSION ../../download-files.include
 DEPS = ../../Makefile.include Makefile TAGLIB-VERSION ../../download-files.include \
-                                       001-cmake-pdb-debug.patch
+                                       001-cmake-pdb-debug.patch \
+                                       002-allow-chapters-without-uid.patch
 
 LIBDYLIB=$(PLATFORM)/build/$(LIBNAME)/$(BYPRODUCT)
 all: .installed-$(PLATFORM)
@@ -10,6 +11,7 @@ all: .installed-$(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); rm -rf build; mkdir -p build
 	cd $(PLATFORM); patch -p1 -i ../001-cmake-pdb-debug.patch
+	cd $(PLATFORM); patch -p1 -i ../002-allow-chapters-without-uid.patch
 	cd $(PLATFORM)/build; $(CMAKE) -DBUILD_SHARED_LIBS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_TESTING=OFF -DBUILD_BINDINGS=OFF -DCMAKE_BUILD_TYPE=Debug ..
 	touch $@
 

--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -1,5 +1,6 @@
 /*
- *  Copyright (C) 2014 Arne Morten Kvarving
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSES/README.md for more information.
@@ -9,33 +10,53 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
+#include "IFileTypes.h"
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
-#include "cores/FFmpeg.h"
+#include "dbwrappers/Database.h"
 #include "filesystem/File.h"
 #include "imagefiles/ImageFileURL.h"
+#include "music/MusicDatabase.h"
+#include "music/MusicEmbeddedCoverLoaderFFmpeg.h"
+#include "music/tags/MusicCodecInfoFFmpeg.h"
+#include "music/tags/MusicInfoTag.h"
+#include "music/tags/MusicInfoTagLoaderMatroska.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
-#include "utils/Mp4ChplReader.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/log.h"
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <commons/ilog.h>
+#include <libavformat/avformat.h>
+#include <libavformat/avio.h>
+#include <libavutil/dict.h>
+#include <libavutil/mem.h>
+#include <libavutil/rational.h>
 
 using namespace XFILE;
 using namespace MUSIC_INFO;
 
-static int cfile_file_read(void *h, uint8_t* buf, int size)
+static int cfile_file_read(void* h, uint8_t* buf, int size)
 {
   CFile* pFile = static_cast<CFile*>(h);
   return pFile->Read(buf, size);
 }
 
-static int64_t cfile_file_seek(void *h, int64_t pos, int whence)
+static int64_t cfile_file_seek(void* h, int64_t pos, int whence)
 {
   CFile* pFile = static_cast<CFile*>(h);
-  if(whence == AVSEEK_SIZE)
+  if (whence == AVSEEK_SIZE)
     return pFile->GetLength();
   else
     return pFile->Seek(pos, whence & ~AVSEEK_FORCE);
@@ -52,8 +73,7 @@ CAudioBookFileDirectory::~CAudioBookFileDirectory(void)
   }
 }
 
-bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
-                                           CFileItemList &items)
+bool CAudioBookFileDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 {
   if (!m_fctx && !ContainsFiles(url))
     return true;
@@ -62,8 +82,7 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
   std::string author;
   std::string album;
   std::string desc;
-  std::vector<std::string> artistsort;
-  std::vector<std::string> tagdata;
+
   std::vector<std::string> separators{" feat. ", " ft. ", " Feat. ", " Ft. ",  ";", ":",
                                       "|",       "#",     "/",       " with ", "&"};
   const std::string musicsep =
@@ -71,17 +90,14 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
   if (musicsep.find_first_of(";/,&|#") == std::string::npos)
     separators.push_back(musicsep); // add custom music separator from as.xml
 
-  const int end_time_m4b_file =
-      m_fctx->streams[0]->duration * av_q2d(m_fctx->streams[0]->time_base);
-  const int end_time_mka_file = m_fctx->duration * av_q2d(av_get_time_base_q());
   const bool isAudioBook = url.IsFileType("m4b");
   // Some tags are relevant to the whole album - these are read first
   CMusicInfoTag albumtag;
 
-  AVDictionaryEntry* tag=nullptr;
-  while ((tag = av_dict_get(m_fctx->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
+  AVDictionaryEntry* tag = nullptr;
+  if (isAudioBook)
   {
-    if (isAudioBook)
+    while ((tag = av_dict_get(m_fctx->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
     {
       if (StringUtils::CompareNoCase(tag->key, "title") == 0)
         title = tag->value;
@@ -92,110 +108,72 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
       else if (StringUtils::CompareNoCase(tag->key, "description") == 0)
         desc = tag->value;
     }
-    else
-    {
-      std::string key = StringUtils::ToUpper(tag->key);
-      // track is matroska's discnumber when at level 50 (these tags) as set by mp3tag
-      // part_number is the matroska spec key
-      if (key == "TRACK" || key == "PART_NUMBER")
-        albumtag.SetDiscNumber(std::stoi(tag->value));
-      else if (key == "SUBTITLE" || key == "SETSUBTITLE")
-        albumtag.SetDiscSubtitle(tag->value);
-      else if (key == "TITLE")
-        albumtag.SetAlbum(tag->value);
-      else if (key == "ALBUM")
-        albumtag.SetAlbum(tag->value);
-      else if (key == "ARTIST")
-        albumtag.SetArtist(tag->value);
-      else if (key == "ARTISTSORT" || key == "ARTIST SORT")
-        albumtag.SetArtistSort(
-            StringUtils::Join(StringUtils::Split(tag->value, separators), musicsep));
-      else if (key == "ALBUMARTIST" || key == "ALBUM ARTIST")
-        albumtag.SetAlbumArtist(
-            StringUtils::Join(StringUtils::Split(tag->value, separators), musicsep));
-      else if (key == "ALBUMARTSTS" || key == "ALBUM ARTISTS")
-        albumtag.SetAlbumArtist(StringUtils::Split(tag->value, separators));
-      else if (key == "ALBUMARTISTSORT" || key == "ALBUM ARTIST SORT")
-        albumtag.SetAlbumArtistSort(
-            StringUtils::Join(StringUtils::Split(tag->value, separators), musicsep));
-      else if (key == "MUSICBRAINZ_ARTISTID")
-        albumtag.SetMusicBrainzArtistID(StringUtils::Split(tag->value, separators));
-      else if (key == "MUSICBRAINZ_ALBUMARTISTID")
-        albumtag.SetMusicBrainzAlbumArtistID(StringUtils::Split(tag->value, separators));
-      else if (key == "MUSICBRAINZ_ALBUMARTIST")
-        albumtag.SetAlbumArtist(tag->value);
-      else if (key == "MUSICBRAINZ_ALBUMID")
-        albumtag.SetMusicBrainzAlbumID(tag->value);
-      else if (key == "MUSICBRAINZ_RELEASEGROUPID")
-        albumtag.SetMusicBrainzReleaseGroupID(tag->value);
-      else if (key == "MUSICBRAINZ_ALBUMSTATUS")
-        albumtag.SetAlbumReleaseStatus(tag->value);
-      else if (key == "MUSICBRAINZ_ALBUMTYPE")
-        albumtag.SetMusicBrainzReleaseType(tag->value);
-      else if (key == "PUBLISHER")
-        albumtag.SetRecordLabel(tag->value);
-      // mp3tag info shows year but the value is stored in date_recorded
-      // equates to TDRC in id3v2.4 ISO 8601 yyyy-mm-dd or part thereof
-      else if (key == "YEAR" || key == "DATE_RECORDED")
-        albumtag.SetReleaseDate(tag->value);
-      else if (key == "ORIGYEAR") // ISO 8601 as above. Equates to TDOR in id3v2.4 (set by mp3tag)
-        albumtag.SetOriginalDate(tag->value);
-      else if (key == "MOOD")
-        albumtag.SetMood(tag->value);
-      // genre could be comma delimited or not. Temporarily add the comma just in case.  true trims
-      // any whitespace around the genre(s)
-      else if (key == "GENRE")
-      {
-        separators.emplace_back(",");
-        albumtag.SetGenre(StringUtils::Split(tag->value, separators), true);
-        separators.pop_back();
-      }
-      // comma separated list of role, person
-      else if (key == "INVOLVEDPEOPLE")
-      {
-        tagdata = StringUtils::Split(tag->value, ",");
-        AddCommaDelimitedString(tagdata, separators, albumtag);
-      }
-      else if (key == "SUBTITLE" || key == "SETSUBTITLE")
-        albumtag.SetDiscSubtitle(tag->value);
-      else if (key == "REMIXED_BY")
-        albumtag.AddArtistRole("Remixer", tag->value);
-      else if (key == "COMMENT")
-        albumtag.SetComment(tag->value);
-    }
+  }
+
+  std::map<std::string, std::string> fileTags;
+  std::map<unsigned long long, std::map<std::string, std::string>> chapterTags;
+  std::vector<std::tuple<unsigned long long, std::string, double, double, unsigned long long>>
+      chapterOrder;
+
+  if (!isAudioBook)
+  {
+    CMusicInfoTagLoaderMatroska::GetMatroskaMusicTags(url.Get(), fileTags, chapterTags,
+                                                      chapterOrder);
+    if (fileTags.empty())
+      return true;
+    /*!
+     * initially just get the (file) Album level tags to be use in subsequent tracks
+     * (chapters) processed below to create Kodi music Songs
+    */
+    for (const auto& t : fileTags)
+      CMusicInfoTagLoaderMatroska::ParseTag(t.first, t.second, separators, musicsep, albumtag);
   }
 
   std::string thumb;
-  if (m_fctx->nb_chapters > 1)
-    thumb = IMAGE_FILES::URLFromFile(url.Get(), "music");
+  thumb = IMAGE_FILES::URLFromFile(url.Get(), "music");
+  /*! Look for any embedded cover art
+  * This can be dropped when taglib 2.3.1 is released with the embedded cover art performance
+  * fix for Matroska files and we can just use TagLib to read the embedded cover art for Matroska
+  * files. Until then, we need to use FFmpeg to read the embedded cover art for Matroska files.
+  */
+  CMusicEmbeddedCoverLoaderFFmpeg::GetEmbeddedCover(m_fctx, albumtag);
 
-  ChplChapterResult neroChapterResult{chplNone};
-  std::vector<ChplChapter> nero;
-
-  if (isAudioBook)
+  // now get the AudioCodec -------------------------------------
+  bool haveFFmpegInfo = false;
+  musicCodecInfo codec_info;
+  haveFFmpegInfo = CMusicCodecInfoFFmpeg::GetMusicCodecInfo(url.Get(), codec_info);
+  if (haveFFmpegInfo) // use data from FFmpeg (taglib 2.3 does not support some codecs)
   {
-    neroChapterResult = CChplChapterReader::ScanNeroChapters(url, nero);
-    if (neroChapterResult.IsError())
-    {
-      CLog::Log(LOGERROR,
-                "AudioBookFileDirectory: Error scanning for Nero style chapters in file {}. The "
-                "error returned was {}",
-                url.GetRedacted(), *neroChapterResult.errorMessage);
-    }
-    else if (neroChapterResult.IsNone())
-    { // can't get here without some form of chapter so must be QT style chapters (chap atom)
-      CLog::Log(
-          LOGDEBUG,
-          "AudioBookFileDirectory: Scanned for nero style chapters but didn't find any in {}, "
-          "using QT chapters",
-          url.GetRedacted());
-    }
+    albumtag.SetBitRate(codec_info.bitRate);
+    albumtag.SetSampleRate(codec_info.sampleRate);
+    /*!
+    * Additional Music properties (next PR - Add Album Codec Support to Music)
+    * albumtag.SetBitsPerSample(codec_info.bitsPerSample);
+    * albumtag.SetCodec(codec_info.codecName); // e.g. 'truehd_atmos', 'dts_ma', 'dts_hd', etc
+    */
+    albumtag.SetNoOfChannels(codec_info.channels);
+    albumtag.SetDuration(codec_info.duration);
   }
-  const size_t ns = nero.size();
 
-  for (size_t i=0;i<m_fctx->nb_chapters;++i)
+  float chapter_size = 0;
+  bool chapter_error = false;
+  for (unsigned int i = 0; m_fctx->chapters && i < m_fctx->nb_chapters; ++i)
   {
-    tag=nullptr;
+    if (!m_fctx->chapters[i] || m_fctx->chapters[i]->start < 0) // null or negative start time
+      continue;
+    chapter_size = (m_fctx->chapters[i]->end - m_fctx->chapters[i]->start) *
+                   av_q2d(m_fctx->chapters[i]->time_base);
+    if (chapter_size < 1) // Chapter must have positive time of more than 1 sec
+    {
+      CLog::Log(LOGWARNING,
+                "CAudioBookFileDirectory: Tiny chapter of size {}s detected when scanning {} Most "
+                "likely this file needs the chapters correcting",
+                chapter_size, url.GetRedacted());
+      chapter_error = true;
+      continue;
+    }
+
+    tag = nullptr;
     std::string chaptitle = StringUtils::Format(
         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25010), i + 1);
     std::string chapauthor;
@@ -204,15 +182,9 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
     std::shared_ptr<CFileItem> item(new CFileItem(url.Get(), false));
     *item->GetMusicInfoTag() = albumtag;
 
-    auto addRole = [&](const std::string& role, const std::string& value)
+    if (isAudioBook)
     {
-      if (!value.empty())
-        item->GetMusicInfoTag()->AddArtistRole(role, StringUtils::Split(value, separators));
-    };
-
-    while ((tag=av_dict_get(m_fctx->chapters[i]->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
-    {
-      if (isAudioBook)
+      while ((tag = av_dict_get(m_fctx->chapters[i]->metadata, "", tag, AV_DICT_IGNORE_SUFFIX)))
       {
         if (StringUtils::CompareNoCase(tag->key, "title") == 0)
           chaptitle = tag->value;
@@ -220,139 +192,110 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url,
           chapauthor = tag->value;
         else if (StringUtils::CompareNoCase(tag->key, "album") == 0)
           chapalbum = tag->value;
-        // Prefer nero titles if we have them over QT titles and they are different
-        if (neroChapterResult.IsFound() && (i < ns) && (nero[i].title != chaptitle))
-          chaptitle = nero[i].title;
       }
-      else
-      {
-        std::string key = StringUtils::ToUpper(tag->key);
-        if (key == "TITLE")
-          item->GetMusicInfoTag()->SetTitle(tag->value);
-        else if (key == "ARTIST")
-          item->GetMusicInfoTag()->SetArtist(tag->value);
-        else if (key == "MUSICBRAINZ_TRACKID")
-          item->GetMusicInfoTag()->SetMusicBrainzTrackID(tag->value);
-        else if (key == "COMPOSER")
-          addRole("Composer", tag->value);
-        else if (key == "LYRICIST")
-          addRole("Lyricist", tag->value);
-        else if (key == "CONDUCTOR")
-          addRole("Conductor", tag->value);
-        else if (key == "WRITER")
-          addRole("Writer", tag->value);
-        else if (key == "ARRANGER")
-          addRole("Arranger", tag->value);
-        else if (key == "BAND")
-          addRole("Band", tag->value);
-        else if (key == "ENGINEER")
-          addRole("Engineer", tag->value);
-        else if (key == "PRODUCER")
-          addRole("Producer", tag->value);
-        else if (key == "REMIXED_BY")
-          addRole("Remixer", tag->value);
-        else if (key == "YEAR" || key == "DATE_RECORDED")
-          item->GetMusicInfoTag()->SetReleaseDate(tag->value);
-        else if (key == "ORIGYEAR")
-          item->GetMusicInfoTag()->SetOriginalDate(tag->value);
-        else if (key == "SUBTITLE" || key == "SETSUBTITLE")
-          item->GetMusicInfoTag()->SetDiscSubtitle(tag->value);
-        else if (key == "COMMENT")
-          item->GetMusicInfoTag()->SetComment(tag->value);
-        else if (key == "MOOD")
-          item->GetMusicInfoTag()->SetMood(tag->value);
-        else if (key == "GENRE")
-        {
-          separators.emplace_back(",");
-          item->GetMusicInfoTag()->SetGenre(StringUtils::Split(tag->value, separators), true);
-          separators.pop_back();
-        }
-        // comma separated list of instrument, person
-        else if (key == "INSTRUMENTS")
-        {
-          tagdata = StringUtils::Split(tag->value, ",");
-          AddCommaDelimitedString(tagdata, separators, *item->GetMusicInfoTag());
-        }
-        // comma separated list of role, person
-        else if (key == "INVOLVEDPEOPLE")
-        {
-          tagdata = StringUtils::Split(tag->value, ",");
-          AddCommaDelimitedString(tagdata, separators, *item->GetMusicInfoTag());
-        }
-      }
-      /* The comma separated lists are outside the Matroska spec
-         (see https://www.matroska.org/technical/tagging.html) as it states to use multiple simple
-         tags for eg 2 or more composers.  However, ffmpeg returns just the last tag and drops the
-         rest (https://trac.ffmpeg.org/ticket/9641).  Therefore until (if) it gets fixed, this is
-         the best solution.
-       */
-    }
-    if (isAudioBook)
-    {
       item->GetMusicInfoTag()->SetTitle(chaptitle);
       item->GetMusicInfoTag()->SetAlbum(chapalbum.empty() ? album.empty() ? title : album
                                                           : chapalbum);
       item->GetMusicInfoTag()->SetArtist(chapauthor.empty() ? author : chapauthor);
       if (!desc.empty())
         item->GetMusicInfoTag()->SetComment(desc);
+
+      item->SetStartOffset(CUtil::ConvertSecsToMilliSecs(m_fctx->chapters[i]->start *
+                                                         av_q2d(m_fctx->chapters[i]->time_base)));
+      item->SetEndOffset(CUtil::ConvertSecsToMilliSecs(m_fctx->chapters[i]->end *
+                                                       av_q2d(m_fctx->chapters[i]->time_base)));
+      item->GetMusicInfoTag()->SetDuration(
+          CUtil::ConvertMilliSecsToSecsInt(item->GetEndOffset() - item->GetStartOffset()));
     }
-    item->GetMusicInfoTag()->SetTrackNumber(i+1);
+    else
+    {
+      // process chapter tags for this track using file-order chapter UID
+      if (i < chapterOrder.size())
+      {
+        auto it = chapterTags.find(std::get<0>(chapterOrder[i]));
+        if (it != chapterTags.end())
+        {
+          for (const auto& Tracktag : it->second)
+            CMusicInfoTagLoaderMatroska::ParseTag(Tracktag.first, Tracktag.second, separators,
+                                                  musicsep, *item->GetMusicInfoTag());
+
+          item->SetStartOffset(CUtil::ConvertSecsToMilliSecs(std::get<2>(chapterOrder[i])));
+          item->SetEndOffset(CUtil::ConvertSecsToMilliSecs(std::get<3>(chapterOrder[i])));
+          item->GetMusicInfoTag()->SetDuration(
+              CUtil::ConvertMilliSecsToSecsInt(item->GetEndOffset() - item->GetStartOffset()));
+        }
+      }
+    }
+
+    item->GetMusicInfoTag()->SetTrackNumber(i + 1);
     item->GetMusicInfoTag()->SetLoaded(true);
 
     item->SetLabel(StringUtils::Format("{0:02}. {1} - {2}", i + 1,
                                        item->GetMusicInfoTag()->GetAlbum(),
                                        item->GetMusicInfoTag()->GetTitle()));
-    item->SetStartOffset(CUtil::ConvertSecsToMilliSecs(m_fctx->chapters[i]->start *
-                                                       av_q2d(m_fctx->chapters[i]->time_base)));
-    item->SetEndOffset(CUtil::ConvertSecsToMilliSecs(m_fctx->chapters[i]->end *
-                                                     av_q2d(m_fctx->chapters[i]->time_base)));
-    if (item->GetEndOffset() < 0 ||
-        item->GetEndOffset() > CUtil::ConvertMilliSecsToSecs(m_fctx->duration))
-    {
-      if (i < m_fctx->nb_chapters - 1)
-        item->SetEndOffset(CUtil::ConvertSecsToMilliSecs(
-            m_fctx->chapters[i + 1]->start * av_q2d(m_fctx->chapters[i + 1]->time_base)));
-      else
-      {
-        item->SetEndOffset(CUtil::ConvertSecsToMilliSecs(end_time_mka_file)); // mka file
-        if (item->GetEndOffset() < 0)
-          item->SetEndOffset(CUtil::ConvertSecsToMilliSecs(end_time_m4b_file)); // m4b file
-      }
-    }
-    item->GetMusicInfoTag()->SetDuration(
-        CUtil::ConvertMilliSecsToSecsInt(item->GetEndOffset() - item->GetStartOffset()));
+
     item->SetProperty("item_start", item->GetStartOffset());
     item->SetProperty("audio_bookmark", item->GetStartOffset());
-    if (!thumb.empty())
+    if (!thumb.empty() && !chapter_error)
       item->SetArt("thumb", thumb);
     items.Add(item);
   }
-
   return true;
 }
 
-void CAudioBookFileDirectory::AddCommaDelimitedString(const std::vector<std::string>& data,
-                                                      const std::vector<std::string>& separators,
-                                                      MUSIC_INFO::CMusicInfoTag& musictag)
+/*!
+ * Next 4 methods were impelmented to help resolve slow initial play of
+ * Matroska files by PaPlayer when testing THIS code originally writtten for 21.3
+ * PaPlayer was calling Exists() and ContainsFiles() during initial playback to determine
+ * if the file is an audiobook. There will be a PR to implement these soon.
+ * CAudioBookFileDirectory is a Library scanning class and should never be used
+ * during playback, if the file has been scanned into the music database.
+ */
+int CAudioBookFileDirectory::GetSongCountFromDatabase(const CURL& url)
 {
-  if (!data.empty())
-  {
-    for (size_t i = 0; i + 1 < data.size(); i += 2)
-    {
-      std::vector<std::string> roles = StringUtils::Split(data[i], separators);
-      for (auto& role : roles)
-      {
-        StringUtils::Trim(role);
-        StringUtils::ToCapitalize(role);
-        musictag.AddArtistRole(role, StringUtils::Split(data[i + 1], ","));
-      }
-    }
-  }
+  CMusicDatabase db;
+  if (!db.Open())
+    return -1;
+
+  std::string strPath = URIUtils::GetDirectory(url.Get());
+  std::string strFileName = URIUtils::GetFileName(url.Get());
+
+  // db.PrepareSQL() uses mprintf-style %s substitution that escapes single
+  // quotes (and other SQL metacharacters) safely, so apostrophes in paths
+  // or filenames are handled and there is no SQL injection surface here.
+  std::string sql = db.PrepareSQL("SELECT COUNT(*) FROM song "
+                                  "JOIN path ON song.idPath = path.idPath "
+                                  "WHERE path.strPath = '%s' AND song.strFileName = '%s'",
+                                  strPath.c_str(), strFileName.c_str());
+
+  int count = db.GetSingleValueInt(sql);
+  db.Close();
+
+  return (count >= 0) ? count : -1;
 }
 
 bool CAudioBookFileDirectory::Exists(const CURL& url)
 {
-  return CFile::Exists(url) && ContainsFiles(url);
+  // Fast path: check the music database to avoid any file I/O.
+  // During playback this is called frequently (e.g. from IsAudioBook()),
+  // so it must be fast and must not open the actual media file.
+  int dbSongCount = GetSongCountFromDatabase(url);
+  if (dbSongCount > 1)
+    return true;
+  if (dbSongCount >= 0)
+    return false; // 0 or 1 songs - not a multi-chapter audiobook
+
+  // DB unavailable (-1). Return false to avoid blocking playback.
+  // The file will be properly detected during library scan when the DB
+  // is available. Returning true here risks triggering GetDirectory()
+  // which opens more file/DB handles and can deadlock during playback.
+  return false;
+}
+
+bool CAudioBookFileDirectory::HasChaptersInDatabase(const CURL& url)
+{
+  int dbSongCount = GetSongCountFromDatabase(url);
+  return dbSongCount > 1;
 }
 
 bool CAudioBookFileDirectory::ContainsFiles(const CURL& url)
@@ -361,12 +304,27 @@ bool CAudioBookFileDirectory::ContainsFiles(const CURL& url)
   if (!file.Open(url))
     return false;
 
-  uint8_t* buffer = (uint8_t*)av_malloc(32768);
-  m_ioctx = avio_alloc_context(buffer, 32768, 0, &file, cfile_file_read,
-                               nullptr, cfile_file_seek);
+  uint8_t* buffer = static_cast<uint8_t*>(av_malloc(32768));
+  if (!buffer)
+    return false;
+
+  m_ioctx = avio_alloc_context(buffer, 32768, 0, &file, cfile_file_read, nullptr, cfile_file_seek);
+  if (!m_ioctx)
+  {
+    av_free(buffer);
+    return false;
+  }
 
   m_fctx = avformat_alloc_context();
+  if (!m_fctx)
+  {
+    av_free(m_ioctx->buffer);
+    av_free(m_ioctx);
+    m_ioctx = nullptr;
+    return false;
+  }
   m_fctx->pb = m_ioctx;
+  m_fctx->flags |= AVFMT_FLAG_CUSTOM_IO;
 
   if (file.IoControl(IOControl::SEEK_POSSIBLE, nullptr) == 0)
     m_ioctx->seekable = 0;
@@ -377,14 +335,20 @@ bool CAudioBookFileDirectory::ContainsFiles(const CURL& url)
   av_probe_input_buffer(m_ioctx, &iformat, url.Get().c_str(), nullptr, 0, 0);
 
   bool contains = false;
+
   if (avformat_open_input(&m_fctx, url.Get().c_str(), iformat, nullptr) < 0)
   {
     if (m_fctx)
       avformat_close_input(&m_fctx);
     av_free(m_ioctx->buffer);
     av_free(m_ioctx);
+    m_ioctx = nullptr;
     return false;
   }
+  m_fctx->flags |= AVFMT_FLAG_NOPARSE;
+  int err = avformat_find_stream_info(m_fctx, NULL);
+  if (err < 0)
+    CLog::Log(LOGERROR, "Can't detect codec info in file {}", url.GetRedacted());
 
   contains = m_fctx->nb_chapters > 1;
 

--- a/xbmc/filesystem/AudioBookFileDirectory.h
+++ b/xbmc/filesystem/AudioBookFileDirectory.h
@@ -1,5 +1,6 @@
 /*
- *  Copyright (C) 2014 Arne Morten Kvarving
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSES/README.md for more information.
@@ -8,13 +9,11 @@
 #pragma once
 
 #include "IFileDirectory.h"
-#include "music/tags/MusicInfoTag.h"
-
-#include <memory>
 
 extern "C" {
 #include <libavformat/avformat.h>
 }
+
 namespace XFILE
 {
   class CAudioBookFileDirectory : public IFileDirectory
@@ -25,12 +24,20 @@ namespace XFILE
       bool Exists(const CURL& url) override;
       bool ContainsFiles(const CURL& url) override;
       bool IsAllowed(const CURL& url) const override { return true; }
+      /*!
+       * Check if a file already has multiple chapter/song records in the music DB.
+       * If the file is already scanned, the player can use the existing DB rows
+       * directly and there is no need to wrap the file as a directory or run a
+       * full FFmpeg probe of it.
+       * return true if the DB contains > 1 song for this file (i.e. already scanned).
+       */
+      static bool HasChaptersInDatabase(const CURL& url);
 
     protected:
-      void AddCommaDelimitedString(const std::vector<std::string>& data,
-                                   const std::vector<std::string>& separators,
-                                   MUSIC_INFO::CMusicInfoTag& musictag);
       AVIOContext* m_ioctx = nullptr;
       AVFormatContext* m_fctx = nullptr;
+
+    private:
+      static int GetSongCountFromDatabase(const CURL& url);
   };
 }

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -29,6 +29,7 @@
 #include "ServiceBroker.h"
 #include "SmartPlaylistDirectory.h"
 #include "URL.h"
+#include "Util.h"
 #include "XbtDirectory.h"
 #include "ZipDirectory.h"
 #include "addons/AudioDecoder.h"
@@ -37,6 +38,7 @@
 #include "addons/addoninfo/AddonInfo.h"
 #include "playlists/PlayListFactory.h"
 #include "playlists/SmartPlayList.h"
+#include "settings/MediaSourceSettings.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -45,6 +47,18 @@ using namespace KODI;
 using namespace KODI::ADDONS;
 using namespace XFILE;
 using namespace PLAYLIST;
+
+namespace
+{
+bool IsUnderMusicSource(const std::string& path)
+{
+  auto* sources = CMediaSourceSettings::GetInstance().GetSources("music");
+  if (!sources)
+    return false;
+  bool isSourceName = false;
+  return CUtil::GetMatchingSource(path, *sources, isSourceName) > -1;
+}
+} // namespace
 
 CFileDirectoryFactory::CFileDirectoryFactory(void) = default;
 
@@ -250,6 +264,12 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
 
   if (MUSIC::IsAudioBook(*pItem))
   {
+    // .mkv doubles as a video container — only treat a chaptered .mkv as an
+    // audiobook when browsed from a Music source, or a chaptered movie in a
+    // Video source would be expanded into chapter items.
+    if (strExtension == ".mkv" && !IsUnderMusicSource(url.Get()))
+      return nullptr;
+
     if (!pItem->HasMusicInfoTag() || pItem->GetEndOffset() <= 0)
     {
       auto pDir = std::make_unique<CAudioBookFileDirectory>();

--- a/xbmc/music/CMakeLists.txt
+++ b/xbmc/music/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES Album.cpp
             GUIViewStateMusic.cpp
             MusicDatabase.cpp
             MusicDbUrl.cpp
+            MusicEmbeddedCoverLoaderFFmpeg.cpp
             MusicEmbeddedImageFileLoader.cpp
             MusicFileItemClassify.cpp
             MusicInfoLoader.cpp
@@ -18,11 +19,13 @@ set(HEADERS Album.h
             GUIViewStateMusic.h
             MusicDatabase.h
             MusicDbUrl.h
+            MusicEmbeddedCoverLoaderFFmpeg.h
             MusicEmbeddedImageFileLoader.h
             MusicFileItemClassify.h
             MusicInfoLoader.h
             MusicLibraryQueue.h
             MusicThumbLoader.h
+            MusicType.h
             MusicUtils.h
             Song.h)
 

--- a/xbmc/music/MusicEmbeddedCoverLoaderFFmpeg.cpp
+++ b/xbmc/music/MusicEmbeddedCoverLoaderFFmpeg.cpp
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (C) 2005-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "MusicEmbeddedCoverLoaderFFmpeg.h"
+
+#include "cores/FFmpeg.h"
+#include "filesystem/File.h"
+#include "tags/MusicInfoTag.h"
+#include "utils/EmbeddedArt.h"
+
+#include <map>
+#include <string>
+
+using namespace MUSIC_INFO;
+using namespace XFILE;
+
+void CMusicEmbeddedCoverLoaderFFmpeg::GetEmbeddedCover(AVFormatContext* fctx,
+                                                       CMusicInfoTag& tag,
+                                                       EmbeddedArt* art /* nullptr */)
+{
+  if (!fctx || !fctx->streams)
+    return;
+  for (size_t i = 0; i < fctx->nb_streams; ++i)
+  {
+    const AVStream* fctx_pic = fctx->streams[i];
+    if (!fctx_pic || (fctx_pic->disposition & AV_DISPOSITION_ATTACHED_PIC) == 0)
+      continue;
+
+    AVCodecID pic_id = fctx_pic->codecpar->codec_id;
+    const std::map<AVCodecID, std::string> mime_map = {{AV_CODEC_ID_MJPEG, "image/jpeg"},
+                                                       {AV_CODEC_ID_PNG, "image/png"},
+                                                       {AV_CODEC_ID_BMP, "image/bmp"}};
+
+    auto it = mime_map.find(pic_id);
+    if (it != mime_map.end())
+    {
+      const auto& mimetype = it->second;
+      size_t pic_size = fctx_pic->attached_pic.size;
+      uint8_t* pic = fctx_pic->attached_pic.data;
+
+      tag.SetCoverArtInfo(pic_size, mimetype);
+      if (art)
+        art->Set(pic, pic_size, mimetype, "thumb");
+      break; // just need one cover
+    }
+  }
+}
+
+static int vfs_file_read(void* h, uint8_t* buf, int size)
+{
+  CFile* pFile = static_cast<CFile*>(h);
+  return pFile->Read(buf, size);
+}
+
+static int64_t vfs_file_seek(void* h, int64_t pos, int whence)
+{
+  CFile* pFile = static_cast<CFile*>(h);
+  if (whence == AVSEEK_SIZE)
+    return pFile->GetLength();
+  else
+    return pFile->Seek(pos, whence & ~AVSEEK_FORCE);
+}
+
+bool CMusicEmbeddedCoverLoaderFFmpeg::GetEmbeddedCover(const std::string& strFileName,
+                                                       CMusicInfoTag& tag,
+                                                       EmbeddedArt* art /* = nullptr */)
+{
+  CFile file;
+  if (!file.Open(strFileName))
+    return false;
+
+  int bufferSize = 4096;
+  int blockSize = file.GetChunkSize();
+  if (blockSize > 1)
+    bufferSize = blockSize;
+
+  uint8_t* buffer = static_cast<uint8_t*>(av_malloc(bufferSize));
+  if (!buffer)
+    return false;
+
+  AVIOContext* ioctx =
+      avio_alloc_context(buffer, bufferSize, 0, &file, vfs_file_read, nullptr, vfs_file_seek);
+  if (!ioctx)
+  {
+    av_free(buffer);
+    return false;
+  }
+
+  if (file.IoControl(IOControl::SEEK_POSSIBLE, nullptr) != 1)
+    ioctx->seekable = 0;
+
+  AVFormatContext* fctx = avformat_alloc_context();
+  if (!fctx)
+  {
+    av_free(ioctx->buffer);
+    av_free(ioctx);
+    return false;
+  }
+  fctx->pb = ioctx;
+
+  const AVInputFormat* iformat = nullptr;
+  av_probe_input_buffer(ioctx, &iformat, strFileName.c_str(), nullptr, 0, 0);
+
+  if (avformat_open_input(&fctx, strFileName.c_str(), iformat, nullptr) < 0)
+  {
+    if (fctx)
+      avformat_close_input(&fctx);
+    av_free(ioctx->buffer);
+    av_free(ioctx);
+    return false;
+  }
+
+  // We only need stream metadata (attached_pic), not full parse — keep it fast.
+  fctx->flags |= AVFMT_FLAG_NOPARSE;
+
+  bool ok = false;
+  if (avformat_find_stream_info(fctx, nullptr) >= 0)
+  {
+    GetEmbeddedCover(fctx, tag, art);
+    ok = true;
+  }
+
+  avformat_close_input(&fctx);
+  av_free(ioctx->buffer);
+  av_free(ioctx);
+  return ok;
+}

--- a/xbmc/music/MusicEmbeddedCoverLoaderFFmpeg.h
+++ b/xbmc/music/MusicEmbeddedCoverLoaderFFmpeg.h
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2005-2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+struct AVFormatContext;
+class EmbeddedArt;
+
+namespace MUSIC_INFO
+{
+class CMusicInfoTag;
+
+class CMusicEmbeddedCoverLoaderFFmpeg
+{
+public:
+  /*!
+ * \brief Searches the supplied AVFormatContext for the first stream containing a supported embedded
+ *  picture.
+ *  This function is called by CMusicInfoTagLoaderFFmpeg when browsing mka music in files view, and
+ *   by CAudioBookFileDirectory when scanning mka files into the music library.
+ *
+ *  If art is found, it is added to CMusicInfoTag and EmbeddedArt (if available).
+ *
+ *  If there is no embedded picture or it is not of type jpg/png/bmp then no art is set.
+ *
+ * \param fctx An AVFormatContext containing one or more streams, one of which may contain art
+ * \param tag MusicInfoTag holding information about the current music track to which found art is
+ *  added
+ * \param art Class containing embedded art details (if available)
+ */
+  static void GetEmbeddedCover(AVFormatContext* fctx,
+                               CMusicInfoTag& tag,
+                               EmbeddedArt* art = nullptr);
+
+  /*!
+   *  Convenience overload that opens the file via FFmpeg internally.
+   *  Use when the caller does not already have an AVFormatContext (e.g. the
+   *  Matroska TagLib loader). Returns false if the file could not be opened.
+   */
+  static bool GetEmbeddedCover(const std::string& strFileName,
+                               CMusicInfoTag& tag,
+                               EmbeddedArt* art = nullptr);
+};
+} // namespace MUSIC_INFO

--- a/xbmc/music/MusicFileItemClassify.cpp
+++ b/xbmc/music/MusicFileItemClassify.cpp
@@ -56,7 +56,7 @@ bool IsAudio(const CFileItem& item)
 
 bool IsAudioBook(const CFileItem& item)
 {
-  return item.IsType(".m4b") || item.IsType(".mka");
+  return item.IsType(".m4b") || item.IsType(".mka") || item.IsType(".mkv");
 }
 
 bool IsCDDA(const CFileItem& item)

--- a/xbmc/music/MusicType.h
+++ b/xbmc/music/MusicType.h
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+#pragma once
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+class AudioType
+{
+public:
+  enum class Content : uint8_t
+  {
+    Album = 0,
+    Single,
+    AudioBook,
+    Podcast,
+    Concert
+  };
+
+  // Implicit construction from enum - allows: AudioType x = AudioType::Content::Album;
+  constexpr AudioType(Content type = Content::Album) noexcept : m_type(type) {}
+
+  // Implicit conversion to enum - allows switch/case and comparisons
+  constexpr operator Content() const noexcept { return m_type; }
+
+  // Explicit getter if preferred over implicit conversion
+  constexpr Content GetContent() const noexcept { return m_type; }
+
+  // Instance method for converting to string
+  constexpr std::string_view ToString() const noexcept
+  {
+    auto it = std::ranges::find(releaseTypes, m_type, &ReleaseTypeInfo::type);
+    return it != releaseTypes.end() ? it->name : std::string_view{"album"};
+  }
+
+  // Static factory from string
+  static constexpr std::optional<AudioType> FromString(std::string_view str) noexcept
+  {
+    auto it = std::ranges::find(releaseTypes, str, &ReleaseTypeInfo::name);
+    return it != releaseTypes.end() ? std::optional{AudioType{it->type}} : std::nullopt;
+  }
+
+  static constexpr std::string_view ToString(Content type) noexcept
+  {
+    return AudioType(type).ToString();
+  }
+
+  // Convenience: owning std::string version for APIs requiring null-terminated strings (e.g. c_str()).
+  std::string ToStdString() const { return std::string{ToString()}; }
+  static std::string ToStdString(Content type) { return std::string{ToString(type)}; }
+
+  // Comparisons (defaulted generates all 6 operators: ==, !=, <, <=, >, >=)
+  constexpr auto operator<=>(const AudioType&) const noexcept = default;
+
+private:
+  Content m_type;
+
+  struct ReleaseTypeInfo
+  {
+    Content type;
+    std::string_view name;
+  };
+
+  static constexpr std::array releaseTypes{
+      ReleaseTypeInfo{Content::Album, "album"}, ReleaseTypeInfo{Content::Single, "single"},
+      ReleaseTypeInfo{Content::AudioBook, "audiobook"},
+      ReleaseTypeInfo{Content::Podcast, "podcast"}, ReleaseTypeInfo{Content::Concert, "concert"}};
+};

--- a/xbmc/music/tags/CMakeLists.txt
+++ b/xbmc/music/tags/CMakeLists.txt
@@ -1,22 +1,26 @@
-set(SOURCES MusicInfoTag.cpp
+set(SOURCES MusicCodecInfoFFmpeg.cpp
+            MusicInfoTag.cpp
             MusicInfoTagLoaderDatabase.cpp
             MusicInfoTagLoaderFactory.cpp
             MusicInfoTagLoaderFFmpeg.cpp
+            MusicInfoTagLoaderMatroska.cpp
             MusicInfoTagLoaderShn.cpp
             ReplayGain.cpp
             TagLibVFSStream.cpp
             TagLoaderTagLib.cpp)
 
 set(HEADERS ImusicInfoTagLoader.h
+            MusicCodecInfoFFmpeg.h
             MusicInfoTag.h
             MusicInfoTagLoaderDatabase.h
             MusicInfoTagLoaderFactory.h
             MusicInfoTagLoaderFFmpeg.h
+            MusicInfoTagLoaderMatroska.h
             MusicInfoTagLoaderShn.h
+            MatroskaTagLibStream.h
             ReplayGain.h
             TagLibVFSStream.h
             TagLoaderTagLib.h)
-
 if(ENABLE_OPTICAL)
   list(APPEND SOURCES MusicInfoTagLoaderCDDA.cpp)
   list(APPEND HEADERS MusicInfoTagLoaderCDDA.h)

--- a/xbmc/music/tags/MatroskaTagLibStream.h
+++ b/xbmc/music/tags/MatroskaTagLibStream.h
@@ -1,0 +1,272 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "filesystem/File.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <PlatformDefs.h>
+#include <taglib/taglib.h>
+#include <taglib/tbytevector.h>
+#include <taglib/tiostream.h>
+
+/*!
+ * VFS-backed TagLib IOStream adapter with read-ahead buffering.
+ * Allows TagLib to read through Kodi's virtual filesystem
+ * (supports nfs://, smb://, etc.)
+ *
+ * TagLib performs many small reads (often just a few bytes) interspersed
+ * with seeks. Over network VFS backends each of those tiny reads becomes
+ * a round-trip, which can stall Kodi noticeably.  This class keeps an
+ * internal read-ahead buffer so that sequential small reads are served
+ * from memory and the underlying CFile is only touched when the request
+ * falls outside the buffered window.
+ *
+ * For Matroska files, TagLib walks every top-level EBML element (including
+ * huge Cluster elements containing media data) by reading a short element
+ * header, then seeking past the element body. On a multi-GB file over
+ * NFS/SMB each of those tiny reads at a new offset triggers a VFS
+ * round-trip.  The virtual file position tracking here eliminates redundant
+ * VFS seeks: the real CFile seek is deferred until data is actually read,
+ * so consecutive seek-then-seek or seek-past-buffered-data chains cost
+ * nothing on the network.
+ */
+class MatroskaTagLibStream : public TagLib::IOStream
+{
+public:
+  MatroskaTagLibStream(const std::string& fileName) : m_fileName(fileName) {}
+  ~MatroskaTagLibStream() override
+  {
+    if (m_open)
+    {
+      try
+      {
+        m_file.Close();
+      }
+      catch (...)
+      {
+        // never propagate exceptions out of a destructor
+      }
+    }
+  }
+
+  TagLib::FileName name() const override { return m_fileName.c_str(); }
+
+  bool isOpen() const override { return m_open; }
+
+  bool open()
+  {
+    m_open = m_file.Open(m_fileName);
+    if (m_open)
+    {
+      m_fileLength = m_file.GetLength();
+      m_virtualPos = 0;
+    }
+    return m_open;
+  }
+
+  TagLib::ByteVector readBlock(size_t length) override
+  {
+    if (length == 0)
+      return {};
+
+    const int64_t pos = m_virtualPos;
+
+    // Try to satisfy the read entirely from the buffer
+    if (pos >= m_bufStart &&
+        pos + static_cast<int64_t>(length) <= m_bufStart + static_cast<int64_t>(m_bufFill))
+    {
+      const size_t offset = static_cast<size_t>(pos - m_bufStart);
+      TagLib::ByteVector bv(m_buf.data() + offset, static_cast<unsigned int>(length));
+      m_virtualPos = pos + static_cast<int64_t>(length);
+      return bv;
+    }
+
+    /*!
+     * For large reads that exceed the buffer size, bypass the buffer entirely.
+     * Construct the ByteVector with the size-only ctor so its storage is not
+     * zero-initialised before m_file.Read() overwrites it.
+     */
+    if (length > kBufCapacity)
+    {
+      invalidateBuffer();
+      syncFilePosition(pos);
+      TagLib::ByteVector bv(static_cast<unsigned int>(length));
+      ssize_t bytesRead = m_file.Read(bv.data(), length);
+      if (bytesRead > 0)
+      {
+        bv.resize(static_cast<unsigned int>(bytesRead));
+        m_virtualPos = pos + bytesRead;
+        m_filePos = m_virtualPos;
+      }
+      else
+        bv.clear();
+      return bv;
+    }
+
+    /*!
+     * Read straddles the end of the current buffer: reuse the cached prefix
+     * and only fetch the missing tail from the underlying file. This is the
+     * common pattern when TagLib reads an EBML header from the buffer and
+     * then the element body crosses the buffer boundary.
+     */
+    if (pos >= m_bufStart && pos < m_bufStart + static_cast<int64_t>(m_bufFill))
+    {
+      const size_t prefix =
+          static_cast<size_t>((m_bufStart + static_cast<int64_t>(m_bufFill)) - pos);
+      TagLib::ByteVector bv(static_cast<unsigned int>(length));
+      std::memcpy(bv.data(), m_buf.data() + (pos - m_bufStart), prefix);
+      const int64_t tailPos = m_bufStart + static_cast<int64_t>(m_bufFill);
+      syncFilePosition(tailPos);
+      ssize_t bytesRead = m_file.Read(bv.data() + prefix, length - prefix);
+      const size_t total = prefix + (bytesRead > 0 ? static_cast<size_t>(bytesRead) : 0);
+      bv.resize(static_cast<unsigned int>(total));
+      m_virtualPos = pos + static_cast<int64_t>(total);
+      m_filePos = tailPos + (bytesRead > 0 ? bytesRead : 0);
+      /*!
+       * The old buffer window is no longer contiguous with the data just
+       * returned. Refill the buffer at the new virtual position so the
+       * next EBML header read (very common immediately after a straddle
+       * on an element boundary) stays a cache hit instead of triggering
+       * another VFS round-trip.
+       */
+      invalidateBuffer();
+      if (m_virtualPos < m_fileLength)
+        fillBuffer(m_virtualPos);
+      return bv;
+    }
+
+    // Fill the buffer starting at the current virtual position
+    fillBuffer(pos);
+
+    const size_t avail = std::min(length, static_cast<size_t>(m_bufFill));
+    if (avail == 0)
+      return {};
+
+    TagLib::ByteVector bv(m_buf.data(), static_cast<unsigned int>(avail));
+    m_virtualPos = pos + static_cast<int64_t>(avail);
+    return bv;
+  }
+
+  void writeBlock(const TagLib::ByteVector&) override {}
+  void insert(const TagLib::ByteVector&, TagLib::offset_t, size_t) override {}
+  void removeBlock(TagLib::offset_t, size_t) override {}
+  bool readOnly() const override { return true; }
+
+  /*!
+   * The actual CFile::Seek is deferred until the next readBlock() or
+   * fillBuffer() call.  This is critical for Matroska parsing where TagLib
+   * performs thousands of seek-read-seek cycles to skip past Cluster
+   * elements. Many of those seeks are followed by another seek (when the
+   * element is skipped) or land inside the existing buffer, so deferring
+   * avoids thousands of NFS/SMB round-trips.
+   */
+  void seek(TagLib::offset_t offset, TagLib::IOStream::Position p) override
+  {
+    switch (p)
+    {
+      case TagLib::IOStream::Beginning:
+        m_virtualPos = offset;
+        break;
+      case TagLib::IOStream::Current:
+        m_virtualPos += offset;
+        break;
+      case TagLib::IOStream::End:
+        m_virtualPos = m_fileLength + offset;
+        break;
+    }
+
+    // Clamp to valid range
+    if (m_virtualPos < 0)
+      m_virtualPos = 0;
+    if (m_virtualPos > m_fileLength)
+      m_virtualPos = m_fileLength;
+  }
+
+  TagLib::offset_t tell() const override { return m_virtualPos; }
+
+  TagLib::offset_t length() override { return m_fileLength; }
+
+  void truncate(TagLib::offset_t) override {}
+  void clear() override {}
+
+  // Expose the underlying CFile for use by FFmpeg's AVIOContext
+  XFILE::CFile& file() { return m_file; }
+
+private:
+  /*!
+   * Internal read-ahead buffer size of 1 MiB is sized to cover
+   * TagLib's Matroska FAST-mode front-of-file scan limit
+   * (512 KiB in matroskafile.cpp) plus headroom for SeekHead
+   * targets and small embedded cover art near the file head,
+   * so the entire FAST-mode front scan can typically be served
+   * from a single VFS round-trip. Still small enough to be
+   * negligible even with several concurrent tag loads.
+   */
+  static constexpr size_t kBufCapacity = 1048576;
+
+  /*!
+   * Only issues a CFile::Seek if the real file position has diverged
+   * from the requested position (i.e. after virtual-only seeks).
+   */
+  void syncFilePosition(int64_t pos)
+  {
+    if (m_filePos != pos)
+    {
+      m_file.Seek(pos, SEEK_SET);
+      m_filePos = pos;
+    }
+  }
+
+  void fillBuffer(int64_t filePos)
+  {
+    syncFilePosition(filePos);
+    m_bufStart = filePos;
+    // Avoid asking the VFS backend to read past EOF: some SMB/NFS
+    // implementations issue an extra round-trip in that case.
+    const int64_t remaining = (m_fileLength > filePos) ? (m_fileLength - filePos) : 0;
+    const size_t toRead =
+        static_cast<size_t>(std::min<int64_t>(static_cast<int64_t>(kBufCapacity), remaining));
+    ssize_t bytesRead = (toRead > 0) ? m_file.Read(m_buf.data(), toRead) : 0;
+    m_bufFill = (bytesRead > 0) ? static_cast<size_t>(bytesRead) : 0;
+    m_filePos = filePos + static_cast<int64_t>(m_bufFill);
+  }
+
+  void invalidateBuffer()
+  {
+    m_bufStart = -1;
+    m_bufFill = 0;
+  }
+
+  std::string m_fileName;
+  XFILE::CFile m_file;
+  bool m_open = false;
+  int64_t m_fileLength = 0;
+
+  /*!
+   * Virtual file position - may diverge from the real CFile position
+   * between seek() and the next readBlock(). This avoids costly VFS
+   * seeks when TagLib seeks repeatedly without reading.
+   */
+  int64_t m_virtualPos = 0;
+
+  // Tracks the real CFile position so we can skip redundant Seek calls.
+  int64_t m_filePos = 0;
+
+  // Read-ahead buffer state
+  std::vector<char> m_buf = std::vector<char>(kBufCapacity);
+  int64_t m_bufStart = -1; //!< File offset where buffer contents begin
+  size_t m_bufFill = 0; //!< Number of valid bytes in the buffer
+};

--- a/xbmc/music/tags/MusicCodecInfoFFmpeg.cpp
+++ b/xbmc/music/tags/MusicCodecInfoFFmpeg.cpp
@@ -1,0 +1,175 @@
+/*
+ *  Copyright (C) 2005-2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "MusicCodecInfoFFmpeg.h"
+
+#include "cores/FFmpeg.h"
+#include "filesystem/File.h"
+
+using namespace XFILE;
+
+static int vfs_file_read(void* h, uint8_t* buf, int size)
+{
+  CFile* pFile = static_cast<CFile*>(h);
+  return pFile->Read(buf, size);
+}
+
+static int64_t vfs_file_seek(void* h, int64_t pos, int whence)
+{
+  CFile* pFile = static_cast<CFile*>(h);
+  if (whence == AVSEEK_SIZE)
+    return pFile->GetLength();
+  else
+    return pFile->Seek(pos, whence & ~AVSEEK_FORCE);
+}
+
+bool CMusicCodecInfoFFmpeg::GetMusicCodecInfo(const std::string& strFileName,
+                                              musicCodecInfo& codec_info)
+{
+  const AVCodec* decoder = nullptr;
+  CFile file;
+  bool haveInfo = false;
+  if (!file.Open(strFileName))
+    return haveInfo;
+
+  int bufferSize = 4096;
+  int blockSize = file.GetChunkSize();
+  if (blockSize > 1)
+    bufferSize = blockSize;
+  uint8_t* buffer = static_cast<uint8_t*>(av_malloc(bufferSize));
+  if (!buffer)
+    return haveInfo;
+
+  AVIOContext* ioctx =
+      avio_alloc_context(buffer, bufferSize, 0, &file, vfs_file_read, nullptr, vfs_file_seek);
+  if (!ioctx)
+  {
+    av_free(buffer);
+    return haveInfo;
+  }
+
+  AVFormatContext* fctx = avformat_alloc_context();
+  if (!fctx)
+  {
+    av_free(ioctx->buffer);
+    av_free(ioctx);
+    return haveInfo;
+  }
+  fctx->pb = ioctx;
+
+  if (file.IoControl(IOControl::SEEK_POSSIBLE, nullptr) != 1)
+    ioctx->seekable = 0;
+
+  const AVInputFormat* iformat = nullptr;
+  av_probe_input_buffer(ioctx, &iformat, strFileName.c_str(), nullptr, 0, 0);
+
+  AVStream* st = nullptr;
+  if (avformat_open_input(&fctx, strFileName.c_str(), iformat, nullptr) == 0)
+  {
+    fctx->flags |= AVFMT_FLAG_NOPARSE;
+    if (avformat_find_stream_info(fctx, nullptr) >= 0)
+    {
+      int streamIndex = -1;
+      // Look for the default audio stream first
+      for (unsigned int i = 0; i < fctx->nb_streams; ++i)
+      {
+        if (fctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+        {
+          if (fctx->streams[i]->disposition & AV_DISPOSITION_DEFAULT)
+          {
+            streamIndex = i;
+            break; // Found the default audio stream, no need to check further
+          }
+        }
+      }
+      if (streamIndex == -1)
+      {
+        for (unsigned int i = 0; i < fctx->nb_streams; ++i)
+        {
+          if (fctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
+          {
+            streamIndex = i;
+            break; // Found the first audio stream
+          }
+        }
+      }
+
+      if (streamIndex != -1)
+      {
+        st = fctx->streams[streamIndex];
+        decoder = avcodec_find_decoder(st->codecpar->codec_id);
+        if (decoder)
+        {
+          std::string codec_name = "unknown";
+
+          codec_name = avcodec_get_name(st->codecpar->codec_id);
+          int par_profile = st->codecpar->profile;
+          if (st->codecpar->codec_id == AV_CODEC_ID_DTS)
+          {
+            switch (par_profile)
+            {
+              case AV_PROFILE_DTS_HD_MA_X:
+                codec_name = "dtshd_ma_x";
+                break;
+              case AV_PROFILE_DTS_HD_MA_X_IMAX:
+                codec_name = "dtshd_ma_x_imax";
+                break;
+              case AV_PROFILE_DTS_ES:
+                codec_name = "dts_es";
+                break;
+              case AV_PROFILE_DTS_96_24:
+                codec_name = "dts_96_24";
+                break;
+              case AV_PROFILE_DTS_HD_HRA:
+                codec_name = "dtshd_hra";
+                break;
+              case AV_PROFILE_DTS_EXPRESS:
+                codec_name = "dts_express";
+                break;
+              case AV_PROFILE_DTS_HD_MA:
+                codec_name = "dtshd_ma";
+                break;
+              default:
+                codec_name = "dca";
+                break;
+            }
+          }
+          if (st->codecpar->codec_id == AV_CODEC_ID_EAC3 &&
+              par_profile == AV_PROFILE_EAC3_DDP_ATMOS)
+            codec_name = "eac3_ddp_atmos";
+
+          if (st->codecpar->codec_id == AV_CODEC_ID_TRUEHD &&
+              par_profile == AV_PROFILE_TRUEHD_ATMOS)
+            codec_name = "truehd_atmos";
+          codec_info.codecName = codec_name;
+          codec_info.bitRate = static_cast<int>(st->codecpar->bit_rate / 1000);
+          codec_info.channels = st->codecpar->ch_layout.nb_channels;
+          codec_info.bitsPerSample = (st->codecpar->bits_per_coded_sample != 0)
+                                         ? st->codecpar->bits_per_coded_sample
+                                         : st->codecpar->bits_per_raw_sample;
+          codec_info.sampleRate = st->codecpar->sample_rate;
+          // st->duration is in st->time_base units; rescale to whole seconds.
+          // Fall back to the container duration when the stream value is unset.
+          if (st->duration != AV_NOPTS_VALUE)
+            codec_info.duration =
+                static_cast<int>(av_rescale_q(st->duration, st->time_base, AVRational{1, 1}));
+          else if (fctx->duration != AV_NOPTS_VALUE)
+            codec_info.duration = static_cast<int>(fctx->duration / AV_TIME_BASE);
+          else
+            codec_info.duration = 0;
+          haveInfo = true;
+        }
+      }
+    }
+
+    avformat_close_input(&fctx);
+  }
+  av_free(ioctx->buffer);
+  av_free(ioctx);
+  return haveInfo;
+}

--- a/xbmc/music/tags/MusicCodecInfoFFmpeg.h
+++ b/xbmc/music/tags/MusicCodecInfoFFmpeg.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2005-2022 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+struct musicCodecInfo
+{
+public:
+  int bitsPerSample = 0;
+  int sampleRate = 0;
+  int bitRate = 0;
+  int channels = 0;
+  int duration = 0;
+  std::string codecName;
+};
+
+class CMusicCodecInfoFFmpeg
+{
+public:
+  static bool GetMusicCodecInfo(const std::string& strFileName, musicCodecInfo& codec_info);
+};

--- a/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderFactory.cpp
@@ -14,6 +14,7 @@
 #endif // HAS_OPTICAL_DRIVE
 #include "MusicInfoTagLoaderDatabase.h"
 #include "MusicInfoTagLoaderFFmpeg.h"
+#include "MusicInfoTagLoaderMatroska.h"
 #include "MusicInfoTagLoaderShn.h"
 #include "ServiceBroker.h"
 #include "TagLoaderTagLib.h"
@@ -87,8 +88,9 @@ IMusicInfoTagLoader* CMusicInfoTagLoaderFactory::CreateLoader(const CFileItem& i
     CMusicInfoTagLoaderSHN *pTagLoader = new CMusicInfoTagLoaderSHN();
     return pTagLoader;
   }
-  else if (strExtension == "mka" || strExtension == "dsf" ||
-           strExtension == "dff")
+  else if (strExtension == "mka" || strExtension == "mkv")
+    return new CMusicInfoTagLoaderMatroska();
+  else if (strExtension == "dsf" || strExtension == "dff")
     return new CMusicInfoTagLoaderFFmpeg();
 
   return NULL;

--- a/xbmc/music/tags/MusicInfoTagLoaderMatroska.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderMatroska.cpp
@@ -1,0 +1,743 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "MusicInfoTagLoaderMatroska.h"
+
+#include "MatroskaTagLibStream.h"
+#include "MusicCodecInfoFFmpeg.h"
+#include "MusicInfoTag.h"
+#include "ServiceBroker.h"
+#include "music/MusicEmbeddedCoverLoaderFFmpeg.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/EmbeddedArt.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <exception>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <commons/ilog.h>
+#include <taglib/audioproperties.h>
+#include <taglib/matroskachapteredition.h>
+#include <taglib/matroskachapters.h>
+#include <taglib/matroskafile.h>
+#include <taglib/matroskasimpletag.h>
+#include <taglib/matroskatag.h>
+#include <taglib/tlist.h>
+#include <taglib/tstring.h>
+
+using namespace MUSIC_INFO;
+using namespace XFILE;
+using namespace TagLib;
+
+/*!
+* Read embedded cover art from attachments using TagLib (performance issue in TagLib 2.3 
+* need to be resolved for Matroska large files with large attachments over SMB/NFS.
+* This should be done in TagLib 2.3.1 (there is a PR open to fix this). Once resolved, we
+* can drop the FFmpeg embedded cover art loading and just use TagLib for Matroska files.
+* This is a static method that can will be used once 2.3.1 is released before Piers final  
+
+static void GetMatroskaEmbeddedCover(TagLib::Matroska::File& matroskaFile,
+                                     CMusicInfoTag& tag,
+                                     EmbeddedArt* art = nullptr)
+{
+  TagLib::Matroska::Attachments* attachments = matroskaFile.attachments();
+  if (!attachments)
+    return;
+
+  const auto& attachedFiles = attachments->attachedFileList();
+  for (const auto& file : attachedFiles)
+  {
+    std::string mimeType = file.mediaType().toCString(true);
+    if (mimeType == "image/jpeg" || mimeType == "image/png" || mimeType == "image/bmp")
+    {
+      const TagLib::ByteVector& data = file.data();
+      if (data.isEmpty())
+        continue;
+
+      tag.SetCoverArtInfo(data.size(), mimeType);
+      if (art)
+        art->Set(reinterpret_cast<const uint8_t*>(data.data()), data.size(), mimeType, "thumb");
+      break; // just need one cover
+    }
+  }
+}
+*/
+
+namespace
+{
+const std::vector<std::string> SupportedArtistMultiValueSeparators = {";", "|"};
+const std::vector<std::string> SupportedMultiValueSeparators = {";", "/", "|", ","};
+} // namespace
+
+/*!
+* Translate multiple single key tags (Matrosk spec) to delimited a single for internal use.
+* Appends " / " + newValue to currentValue if newValue is not already present
+* (case-insensitive) among the existing delimited values. The set of delimiters
+* used to split currentValue depends on whether tagname refers to an artist tag.
+* Returns true if the value was appended, false otherwise.
+*/
+static bool AppendIfNotDuplicate(std::string& currentValue,
+                                 const std::string& newValue,
+                                 const std::string& tagname)
+{
+  const std::vector<std::string>& separators = (tagname.find("ARTIST") != std::string::npos)
+                                                   ? SupportedArtistMultiValueSeparators
+                                                   : SupportedMultiValueSeparators;
+
+  try
+  {
+    std::vector<std::string> existingValues = StringUtils::Split(currentValue, separators);
+
+    for (auto& existing : existingValues)
+    {
+      StringUtils::Trim(existing);
+      if (existing.empty())
+        continue; // mirrors RemoveEmptyEntries
+      if (StringUtils::EqualsNoCase(existing, newValue))
+        return false;
+    }
+  }
+  catch (const std::exception& ex)
+  {
+    CLog::Log(LOGERROR, "AppendIfNotDuplicate: {}", ex.what());
+    return false;
+  }
+
+  if (currentValue.empty())
+    currentValue = newValue;
+  else
+    currentValue += " / " + newValue;
+
+  return true;
+}
+
+/*!
+* Used by Matroska files with no chapters (most common) or with a single (one song)
+* Typically these are Matroska files split by Chapter start times with each chapter having
+* song tags but no chapter name or chapter tags.
+*/
+bool CMusicInfoTagLoaderMatroska::Load(const std::string& strFileName,
+                                       CMusicInfoTag& tag,
+                                       EmbeddedArt* art)
+{
+  tag.SetLoaded(false);
+
+  MatroskaTagLibStream matroskaStream(strFileName);
+  if (!matroskaStream.open())
+    return false;
+
+  std::vector<std::string> separators{";", " feat. ", " ft. ", " Feat. ", " Ft. ", ":",
+                                      "|", "#",       "/",     " with ",  "&"};
+  std::string musicsep =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_musicItemSeparator;
+  if (musicsep.find_first_of(";/,&|#") == std::string::npos)
+    separators.push_back(musicsep);
+
+  // Get tags, chapters, embedded cover art, and duration in one call
+  // (single file parse — avoids opening the Matroska file twice)
+  std::map<std::string, std::string> fileTags;
+  std::map<unsigned long long, std::map<std::string, std::string>> chapterTags;
+  std::vector<std::tuple<unsigned long long, std::string, double, double, unsigned long long>>
+      chapterOrder;
+  GetMatroskaMusicTags(strFileName, matroskaStream, fileTags, chapterTags, chapterOrder, &tag, art);
+
+  if (fileTags.empty())
+    return true;
+  for (const auto& t : fileTags)
+    ParseTag(t.first, t.second, separators, musicsep, tag);
+  /*!
+  * now process the Chapter (track) if the Matroska file has a chapter
+  * there is usually no chapters but there could be one, if > 1 
+  * the file is processed as a whole album by CAudioBookFileDirectory
+  */
+  if (!chapterOrder.empty())
+  {
+    auto it = chapterTags.find(std::get<0>(chapterOrder[0]));
+    if (it != chapterTags.end())
+    {
+      for (const auto& t : it->second)
+        ParseTag(t.first, t.second, separators, musicsep, tag);
+    }
+  }
+
+  // Look for any embedded cover art
+  CMusicEmbeddedCoverLoaderFFmpeg::GetEmbeddedCover(strFileName, tag, art);
+
+  // Get Codec data using FFmpeg (taglib not accurate for all codecs yet - v2.3)
+  bool haveFFmpegInfo = false;
+  musicCodecInfo codec_info;
+  haveFFmpegInfo = CMusicCodecInfoFFmpeg::GetMusicCodecInfo(strFileName, codec_info);
+  if (haveFFmpegInfo)
+  {
+    tag.SetBitRate(codec_info.bitRate);
+    tag.SetSampleRate(codec_info.sampleRate);
+    /*!
+    * Additional Music properties (next PR)
+    * albumtag.SetBitsPerSample(codec_info.bitsPerSample);
+    * albumtag.SetCodec(codec_info.codecName); // e.g. 'truehd_atmos', 'dts_ma', 'dts_hd', etc
+    */
+    tag.SetNoOfChannels(codec_info.channels);
+    tag.SetDuration(codec_info.duration);
+  }
+
+  if (!tag.GetAlbum().empty() || !tag.GetTitle().empty())
+    tag.SetLoaded(true);
+
+  return true;
+}
+
+void CMusicInfoTagLoaderMatroska::ParseTag(const std::string& key,
+                                           const std::string& value,
+                                           std::vector<std::string>& separators,
+                                           const std::string& musicsep,
+                                           CMusicInfoTag& tag)
+{
+  /*!
+  * Matroska Tag spec does not allow storing multi values in a single tag, but some tools
+  * do it anyway using a delimiter. So we need to split the value using the separator and
+  * then join it back using the music item separator from as.xml if needed.
+  */
+  if (key == "ALBUM")
+    tag.SetAlbum(value);
+  else if (key == "ARTIST")
+    // tag.SetArtist(StringUtils::Join(StringUtils::Split(value, separators), musicsep));
+    tag.SetArtist(value);
+  else if (key == "ARTISTS")
+    tag.SetMusicBrainzArtistHints(StringUtils::Split(value, separators));
+  else if (key == "ALBUMARTISTS" || key == "ALBUM_ARTISTS")
+    tag.SetAlbumArtist(value);
+  else if (key == "ALBUMARTIST" || key == "ALBUM_ARTIST")
+    tag.SetAlbumArtist(StringUtils::Join(StringUtils::Split(value, separators), musicsep));
+  else if (key == "TITLE")
+    tag.SetTitle(value);
+  else if (key == "PART_NUMBER" || key == "TRACK")
+  {
+    try
+    {
+      tag.SetTrackNumber(std::stoi(value));
+    }
+    catch (const std::exception&)
+    {
+    }
+  }
+  else if (key == "DISC" || key == "DISCNUMBER")
+  {
+    try
+    {
+      tag.SetDiscNumber(std::stoi(value));
+    }
+    catch (const std::exception&)
+    {
+    }
+  }
+  else if (key == "GENRE")
+    tag.SetGenre(StringUtils::Split(value, musicsep), true);
+  else if (key == "COMPILATION")
+    tag.SetCompilation(true);
+  else if (key == "DATE" || key == "DATE_RELEASED" || key == "YEAR")
+    tag.SetReleaseDate(value);
+  else if (key == "DATE_RECORDED" || key == "ORIGINALDATE" || key == "ORIGINALYEAR" ||
+           key == "ORIGYEAR")
+    tag.SetOriginalDate(value);
+  else if (key == "MOOD")
+    tag.SetMood(StringUtils::Join(StringUtils::Split(value, separators), musicsep));
+  // genre could be comma delimited or not. Temporarily add the comma just in case.
+  // true trims any whitespace around the genre(s)
+  else if (key == "COMMENT")
+    tag.SetComment(value);
+  else if (key == "ARTIST-SORT" || key == "ARTISTSORT")
+    tag.SetArtistSort(StringUtils::Join(StringUtils::Split(value, separators), musicsep));
+  else if (key == "ALBUMARTISTSORT" || key == "SORT_ALBUM_ARTIST")
+    tag.SetAlbumArtistSort(StringUtils::Join(StringUtils::Split(value, separators), musicsep));
+  else if (key == "COMPOSERSORT")
+    tag.SetComposerSort(StringUtils::Join(StringUtils::Split(value, separators), musicsep));
+  else if (key == "DISCSUBTITLE" || key == "SUBTITLE" || key == "SETSUBTITLE")
+    tag.SetDiscSubtitle(value);
+  else if (key == "MUSICBRAINZ_ARTISTID")
+    tag.SetMusicBrainzArtistID(StringUtils::Split(value, separators));
+  else if (key == "MUSICBRAINZ_ALBUMID")
+    tag.SetMusicBrainzAlbumID(value);
+  else if (key == "MUSICBRAINZ_RELEASEGROUPID")
+    tag.SetMusicBrainzReleaseGroupID(value);
+  else if (key == "MUSICBRAINZ_ALBUMARTISTID")
+    tag.SetMusicBrainzAlbumArtistID(StringUtils::Split(value, separators));
+  else if (key == "MUSICBRAINZ_TRACKID")
+    tag.SetMusicBrainzTrackID(value);
+  else if (key == "MUSICBRAINZ_ALBUMARTIST")
+  {
+    // tag.SetAlbumArtist(value);
+  }
+  else if (key == "MUSICBRAINZ_ALBUMTYPE")
+    tag.SetMusicBrainzReleaseType(value);
+  else if (key == "MUSICBRAINZ_ALBUMSTATUS")
+    tag.SetAlbumReleaseStatus(value);
+  else if (key == "ENCODED_BY" || key == "LANGUAGE")
+  {
+  }
+  else if (key == "LABEL" || key == "PUBLISHER")
+    tag.SetRecordLabel(value);
+  else if (key == "CATALOGNUMBER")
+  {
+  } // No database field yet
+  else if (key == "COPYRIGHT")
+  {
+  } // Copyright message
+  else if (key == "WRITER")
+    tag.AddArtistRole("Writer", StringUtils::Split(value, separators));
+  else if (key == "PERFORMER")
+  {
+    std::vector<std::string> tagdata = StringUtils::Split(value, separators);
+    AddRole(tagdata, separators, tag);
+  }
+  else if (key == "ARRANGER")
+  {
+    std::vector<std::string> tagdata = StringUtils::Split(value, separators);
+    AddRole(tagdata, separators, tag);
+  }
+  else if (key == "REMIXED_BY" || key == "REMIXEDBY")
+    tag.AddArtistRole("Remixer", StringUtils::Split(value, separators));
+  else if (key == "MIXED_BY" || key == "MIXER")
+    tag.AddArtistRole("Mixer", StringUtils::Split(value, separators));
+  else if (key == "LYRICIST")
+    tag.AddArtistRole("Lyricist", StringUtils::Split(value, separators));
+  else if (key == "COMPOSER")
+    tag.AddArtistRole("Composer", StringUtils::Split(value, separators));
+  else if (key == "CONDUCTOR")
+    tag.AddArtistRole("Conductor", StringUtils::Split(value, separators));
+  else if (key == "ENGINEER")
+    tag.AddArtistRole("Engineer", StringUtils::Split(value, separators));
+  else if (key == "PRODUCER")
+    tag.AddArtistRole("Producer", StringUtils::Split(value, separators));
+  else if (key == "BAND")
+    tag.AddArtistRole("Band", StringUtils::Split(value, separators));
+  // comma separated list of role, person
+  else if (key == "INVOLVEDPEOPLE" || key == "ACTOR")
+  {
+    std::vector<std::string> tagdata = StringUtils::Split(value, ",");
+
+    AddCommaDelimitedString(tagdata, separators, tag);
+  }
+  else if (key == "INSTRUMENTS")
+  {
+    std::vector<std::string> tagdata = StringUtils::Split(value, ",");
+
+    AddCommaDelimitedString(tagdata, separators, tag);
+  }
+}
+
+void CMusicInfoTagLoaderMatroska::AddRole(const std::vector<std::string>& data,
+                                          const std::vector<std::string>& separators,
+                                          CMusicInfoTag& musictag)
+{
+  if (!data.empty())
+  {
+    for (size_t i = 0; i + 1 < data.size(); i += 2)
+    {
+      std::vector<std::string> roles = StringUtils::Split(data[i], separators);
+      for (auto& role : roles)
+      {
+        StringUtils::Trim(role);
+        StringUtils::ToCapitalize(role);
+        musictag.AddArtistRole(role, StringUtils::Split(data[i + 1], separators));
+      }
+    }
+  }
+}
+
+void CMusicInfoTagLoaderMatroska::AddCommaDelimitedString(
+    const std::vector<std::string>& data,
+    const std::vector<std::string>& separators,
+    CMusicInfoTag& musictag)
+{
+  if (!data.empty())
+  {
+    for (size_t i = 0; i + 1 < data.size(); i += 2)
+    {
+      std::vector<std::string> roles = StringUtils::Split(data[i], separators);
+      for (auto& role : roles)
+      {
+        StringUtils::Trim(role);
+        StringUtils::ToCapitalize(role);
+        musictag.AddArtistRole(role, StringUtils::Split(data[i + 1], ","));
+      }
+    }
+  }
+}
+
+/*!
+* Used by Matroska files with multiple chapters. Each chapter is a separate song.
+* Static overload for external callers (e.g. AudioBookFileDirectory).
+* Opens its own MatroskaTagLibStream and delegates to the shared-stream overload.
+*/
+void CMusicInfoTagLoaderMatroska::GetMatroskaMusicTags(
+    const std::string& fileName,
+    std::map<std::string, std::string>& fileTags,
+    std::map<unsigned long long, std::map<std::string, std::string>>& chapterTags,
+    std::vector<std::tuple<unsigned long long, std::string, double, double, unsigned long long>>&
+        chapterOrder,
+    CMusicInfoTag* coverTag)
+{
+  MatroskaTagLibStream matroskaStream(fileName);
+  if (!matroskaStream.open())
+  {
+    fileTags.clear();
+    chapterTags.clear();
+    chapterOrder.clear();
+    return;
+  }
+  GetMatroskaMusicTags(fileName, matroskaStream, fileTags, chapterTags, chapterOrder, coverTag);
+}
+
+/*!
+*  use TagLib to read hierarchy of tags in file and populate album and chapter
+* (track) tags. this creates a map of chapterUid to track tags for each chapter.
+*/
+void CMusicInfoTagLoaderMatroska::GetMatroskaMusicTags(
+    const std::string& fileName,
+    MatroskaTagLibStream& matroskaStream,
+    std::map<std::string, std::string>& fileTags,
+    std::map<unsigned long long, std::map<std::string, std::string>>& chapterTags,
+    std::vector<std::tuple<unsigned long long, std::string, double, double, unsigned long long>>&
+        chapterOrder,
+    CMusicInfoTag* coverTag,
+    EmbeddedArt* art)
+{
+  fileTags.clear();
+  chapterTags.clear();
+  chapterOrder.clear();
+
+  std::unique_ptr<TagLib::Matroska::File> matroskaFile;
+  Matroska::Tag* matroskatag = nullptr;
+  try
+  {
+    // MatroskaTagLibStream provides a 512 KiB read-ahead buffer and deferred seeks
+    matroskaFile = std::make_unique<TagLib::Matroska::File>(&matroskaStream, true,
+                                                            TagLib::AudioProperties::Fast);
+    if (matroskaFile->isValid())
+      matroskatag = matroskaFile->tag(true);
+    if (!matroskatag)
+      return;
+
+    /* 
+    * Read embedded cover art from attachments (performance issue in Taglib 2.3 need to be resolved
+    * This should be done in TagLib 2.3.1 (there is a PR open to fix this). Once resolved, we
+    * can drop the FFmpeg embedded cover art loading and just use TagLib for Matroska files.
+    * if (coverTag)
+    *  GetMatroskaEmbeddedCover(*matroskaFile, *coverTag, art)
+    */
+
+    double fileDuration = 0.0;
+    TagLib::AudioProperties* audioProps = matroskaFile->audioProperties();
+    if (audioProps)
+      fileDuration = static_cast<double>(audioProps->lengthInSeconds());
+
+    /*!
+    * First get all chapters and get the chapter name for each chapter and store
+    * it in the chapterTags map. Then we have chapter name for each chapter
+    * (track) if Chapters are not tagged.
+    * Micro chapters (less than 1 second long) are skipped as they are not
+    * real tracks/songs — they can occur in some Matroska files as artifacts.
+    */
+    int chapterCount = 0;
+    TagLib::Matroska::Chapters* chapters = matroskaFile->chapters();
+    if (chapters)
+    {
+      const TagLib::Matroska::Chapters::ChapterEditionList& editions =
+          chapters->chapterEditionList();
+      for (const auto& edition : editions)
+      {
+        unsigned long long editionUid = edition.uid();
+        for (const auto& chapter : edition.chapterList())
+        {
+          unsigned long long chapUid = chapter.uid();
+
+          // Skip micro chapters less than 1 second long
+          long long durationNs = std::abs(static_cast<long long>(chapter.timeEnd()) -
+                                          static_cast<long long>(chapter.timeStart()));
+          if (durationNs < 1000000000LL)
+            continue;
+
+          std::string chapterName;
+          if (chapUid > 0 && !chapter.displayList().isEmpty())
+          {
+            // Match VB behavior: keep the last display name
+            for (const auto& display : chapter.displayList())
+              chapterName = display.string().toCString(true);
+          }
+
+          std::map<std::string, std::string> chapterTagList = {{"CHAPTERNAME", chapterName}};
+          chapterTags[chapUid] = chapterTagList;
+
+          double startTimeSecs = static_cast<double>(chapter.timeStart()) / 1000000000.0;
+          double endTimeSecs = static_cast<double>(chapter.timeEnd()) / 1000000000.0;
+          chapterOrder.push_back(
+              std::make_tuple(chapUid, chapterName, startTimeSecs, endTimeSecs, editionUid));
+          chapterCount++;
+        }
+      }
+    }
+
+    /*!
+    * Parsing Matroska tags create a dummy chapter if no chapters are present
+    * to hold song tags for later processing for Kodi internal tags.
+    * Some taggers like MP3tag save song tags as chapter tags with
+    * TargetTypeValue 30 but no ChapterUid, so need to save these somewhere.
+    *
+    * If chapters exist, fix any that have no end time set (endTime <= 0):
+    *  (out of spec but some taggers do this, Kodi neds to deal with this internally)
+    *  - use the next chapter's start time, or
+    *  - use the file duration for the last chapter.
+    */
+    constexpr unsigned long long DummyChapterUid = 999000999000999;
+    if (chapterCount == 0)
+    {
+      chapterOrder.push_back(
+          std::make_tuple(DummyChapterUid, std::string("SongTags"), 0.0, 0.0, 0ULL));
+      std::map<std::string, std::string> chapterTagList = {{"CHAPTERNAME", "SongTags"}};
+      chapterTags[DummyChapterUid] = chapterTagList;
+    }
+    else
+    {
+      for (size_t i = 0; i < chapterOrder.size(); ++i)
+      {
+        double endTime = std::get<3>(chapterOrder[i]);
+        if (endTime <= 0.0)
+        {
+          double newEndTime;
+          if (i + 1 < chapterOrder.size())
+          {
+            // use next chapter's start time
+            newEndTime = std::get<2>(chapterOrder[i + 1]);
+          }
+          else
+          {
+            // last chapter — use the file duration
+            newEndTime = fileDuration;
+          }
+          chapterOrder[i] = std::make_tuple(std::get<0>(chapterOrder[i]), // uid
+                                            std::get<1>(chapterOrder[i]), // name
+                                            std::get<2>(chapterOrder[i]), // startTime
+                                            newEndTime, // fixed endTime
+                                            std::get<4>(chapterOrder[i])); // editionUid
+        }
+      }
+    }
+
+    /*!
+    * Define tags that support multiple values and need to be concatenated into a
+    * single internal Kodi tag with a separator if more than one value is
+    * present. This is needed to support multiple same key tags (Matroska spec)
+    */
+    static constexpr std::array<const char*, 21> MULTIPLE_VALUE_TAGS = {"ALBUMARTISTS",
+                                                                        "ALBUMARTISTSORT",
+                                                                        "ARTIST",
+                                                                        "ARTISTS",
+                                                                        "ARTISTSORT",
+                                                                        "ARRANGER",
+                                                                        "BAND",
+                                                                        "COMPOSER",
+                                                                        "COMPOSERSORT",
+                                                                        "CONDUCTOR",
+                                                                        "ENGINEER",
+                                                                        "GENRE",
+                                                                        "LYRICIST",
+                                                                        "MIXER",
+                                                                        "MOOD",
+                                                                        "MUSICBRAINZ_ALBUMARTISTID",
+                                                                        "MUSICBRAINZ_ARTISTID",
+                                                                        "PERFORMER",
+                                                                        "PRODUCER",
+                                                                        "REMIXED",
+                                                                        "WRITER"};
+
+    /*!
+    * Read all simple tags and group them by file (album or song files with no
+    * chapters) or by chapter/track (if target type value is 30).
+    * Delimiter separated lists are outside the Matroska spec
+    * (see https://www.matroska.org/technical/tagging.html) it states to use
+    * multiple simple tags for eg 2 or more composers. To ensure Kodi can use
+    * multiple same name tags need create a single tag with multiple values in
+    * a delimited string (Kodi handles multiple values with
+    * delimited strings).
+    *
+    * Two pass approach:
+    * Pass 1: Process album-level tags (targetTypeValue == 50) first so album
+    *         metadata is established before track-level tags are processed.
+    *         Special handling for TITLE tag which maps to ALBUM in Kodi.
+    * Pass 2: Process file-level (targetTypeValue == 0) and chapter/song
+    *         (targetTypeValue == 30) tags.
+    */
+    std::string TagName;
+    std::string TagValue;
+    const TagLib::Matroska::SimpleTagsList& list = matroskatag->simpleTagsList();
+    // Pass 1: Process album-level tags (targetTypeValue == 50)
+    for (const TagLib::Matroska::SimpleTag& tag : list)
+    {
+      if (tag.targetTypeValue() == 50 || tag.targetTypeValue() == 60)
+      {
+        TagName = StringUtils::ToUpper(tag.name().to8Bit(true));
+        TagValue = tag.toString().to8Bit(true);
+        /*!
+        * TITLE with targetTypeValue 50 is the Album title in Matroska spec
+        * ALBUM was used in Kodi 21.3 for ffmpeg tag reding compatibility
+        * targetTypeValue 60 used by MP3Tag for concerts, maps to ALBUM in Kodi music
+        */
+        if (TagName == "TITLE")
+        {
+          if (fileTags.find("ALBUM") == fileTags.end())
+            fileTags["ALBUM"] = TagValue;
+          if (fileTags.find("TITLE") == fileTags.end())
+            fileTags["TITLE"] = TagValue;
+        }
+        else if (fileTags.find(TagName) == fileTags.end())
+        {
+          fileTags[TagName] = TagValue;
+        }
+        else
+        {
+          if (std::find(std::begin(MULTIPLE_VALUE_TAGS), std::end(MULTIPLE_VALUE_TAGS), TagName) !=
+              std::end(MULTIPLE_VALUE_TAGS))
+          {
+            std::string currentValue = fileTags[TagName];
+            if (AppendIfNotDuplicate(currentValue, TagValue, TagName))
+              fileTags[TagName] = currentValue;
+          }
+        }
+      }
+    }
+
+    // Pass 2: Process remaining tags (file-level and chapter/song tags)
+    for (const TagLib::Matroska::SimpleTag& tag : list)
+    {
+      unsigned long long chapterUid = tag.chapterUid();
+      std::string TagName = StringUtils::ToUpper(tag.name().to8Bit(true));
+      unsigned long long targetTypeValue = tag.targetTypeValue();
+
+      if (targetTypeValue == 50 || targetTypeValue == 60)
+        continue; // already processed in Pass 1
+
+      TagName = StringUtils::ToUpper(tag.name().to8Bit(true));
+      TagValue = tag.toString().to8Bit(true);
+
+      /*!
+      * No targetTypeValue should be considered as an 'Album' level tag to avoid losing metadata
+      * for files that don't follow the Matroska spec and don't set targetTypeValue.
+      */
+      if (targetTypeValue == 0)
+      {
+        if (TagName == "TITLE")
+        {
+          if (fileTags.find("ALBUM") == fileTags.end())
+            fileTags["ALBUM"] = TagValue;
+          if (fileTags.find("TITLE") == fileTags.end())
+            fileTags["TITLE"] = TagValue;
+        }
+        else
+        {
+          if (fileTags.find(TagName) == fileTags.end())
+          {
+            fileTags[TagName] = TagValue;
+          }
+          else
+          {
+            if (std::find(std::begin(MULTIPLE_VALUE_TAGS), std::end(MULTIPLE_VALUE_TAGS),
+                          TagName) != std::end(MULTIPLE_VALUE_TAGS))
+            {
+              std::string currentValue = fileTags[TagName];
+              if (AppendIfNotDuplicate(currentValue, TagValue, TagName))
+                fileTags[TagName] = currentValue;
+            }
+          }
+        }
+      }
+      else if (targetTypeValue == 30)
+      {
+        if (chapterCount == 1)
+        {
+          // Single chapter: route to the only chapter with duplicate check
+          unsigned long long firstChapterUid = std::get<0>(chapterOrder[0]);
+          auto firstIt = chapterTags.find(firstChapterUid);
+          if (firstIt != chapterTags.end())
+          {
+            auto& chapterTagList = firstIt->second;
+            auto it = chapterTagList.find(TagName);
+            if (it == chapterTagList.end())
+            {
+              chapterTagList.emplace(TagName, TagValue);
+            }
+            else
+            {
+              if (std::find(std::begin(MULTIPLE_VALUE_TAGS), std::end(MULTIPLE_VALUE_TAGS),
+                            TagName) != std::end(MULTIPLE_VALUE_TAGS))
+              {
+                AppendIfNotDuplicate(it->second, TagValue, TagName);
+              }
+            }
+          }
+        }
+        else if (chapterUid > 1)
+        {
+          // Multiple chapters: route to the chapter with matching UID
+          auto chapterIt = chapterTags.find(chapterUid);
+          if (chapterIt != chapterTags.end())
+          {
+            auto& chapterTagList = chapterIt->second;
+            auto it = chapterTagList.find(TagName);
+            if (it == chapterTagList.end())
+            {
+              chapterTagList.emplace(TagName, TagValue);
+            }
+            else
+            {
+              if (std::find(std::begin(MULTIPLE_VALUE_TAGS), std::end(MULTIPLE_VALUE_TAGS),
+                            TagName) != std::end(MULTIPLE_VALUE_TAGS))
+              {
+                AppendIfNotDuplicate(it->second, TagValue, TagName);
+              }
+            }
+          }
+          else
+          {
+            // so this chapter was not in the Chapters element. Fall back to fileTags.
+            if (fileTags.find(TagName) == fileTags.end())
+            {
+              fileTags[TagName] = TagValue;
+            }
+            else
+            {
+              if (std::find(std::begin(MULTIPLE_VALUE_TAGS), std::end(MULTIPLE_VALUE_TAGS),
+                            TagName) != std::end(MULTIPLE_VALUE_TAGS))
+              {
+                std::string currentValue = fileTags[TagName];
+                if (AppendIfNotDuplicate(currentValue, TagValue, TagName))
+                  fileTags[TagName] = currentValue;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // bufferedStream and matroskaFile are destroyed when scope exits.
+  }
+  catch (const std::exception& e)
+  {
+    CLog::Log(LOGERROR, "GetMatroskaMusicTags: Exception while reading Matroska tags: {} {}",
+              fileName, e.what());
+  }
+}

--- a/xbmc/music/tags/MusicInfoTagLoaderMatroska.h
+++ b/xbmc/music/tags/MusicInfoTagLoaderMatroska.h
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "ImusicInfoTagLoader.h"
+#include "MatroskaTagLibStream.h"
+#include "MusicInfoTag.h"
+#include "utils/EmbeddedArt.h"
+
+#include <map>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace MUSIC_INFO
+{
+class CMusicInfoTagLoaderMatroska : public IMusicInfoTagLoader
+{
+public:
+  CMusicInfoTagLoaderMatroska() = default;
+  ~CMusicInfoTagLoaderMatroska() override = default;
+
+  bool Load(const std::string& strFileName,
+            CMusicInfoTag& tag,
+            EmbeddedArt* art = nullptr) override;
+
+  static void ParseTag(const std::string& key,
+                       const std::string& value,
+                       std::vector<std::string>& separators,
+                       const std::string& musicsep,
+                       CMusicInfoTag& tag);
+
+  // Static overload for external callers (e.g. AudioBookFileDirectory) —
+  // opens its own MatroskaTagLibStream internally.
+  // If coverTag is non-null, embedded cover art info is set on it.
+  static void GetMatroskaMusicTags(
+      const std::string& fileName,
+      std::map<std::string, std::string>& fileTags,
+      std::map<unsigned long long, std::map<std::string, std::string>>& chapterTags,
+      std::vector<std::tuple<unsigned long long, std::string, double, double, unsigned long long>>&
+          chapterOrder,
+      CMusicInfoTag* coverTag = nullptr);
+
+private:
+  // Internal overload used by Load() — reuses an already-open stream
+  static void GetMatroskaMusicTags(
+      const std::string& fileName,
+      MatroskaTagLibStream& matroskaStream,
+      std::map<std::string, std::string>& fileTags,
+      std::map<unsigned long long, std::map<std::string, std::string>>& chapterTags,
+      std::vector<std::tuple<unsigned long long, std::string, double, double, unsigned long long>>&
+          chapterOrder,
+      CMusicInfoTag* coverTag = nullptr,
+      EmbeddedArt* art = nullptr);
+
+  static void AddRole(const std::vector<std::string>& data,
+                      const std::vector<std::string>& separators,
+                      CMusicInfoTag& musictag);
+  static void AddCommaDelimitedString(const std::vector<std::string>& data,
+                                      const std::vector<std::string>& separators,
+                                      CMusicInfoTag& musictag);
+};
+} // namespace MUSIC_INFO


### PR DESCRIPTION
## Description
Adds full Matroska Tag specification reading to Kodi using TagLib 2.3.

## Motivation and context
In Kodi 21.2/3 and previous Piers alphas Matroska tags were read with FFmpeg. FFmpeg does not read all Matroska spec tags, leading to issues with scanning into the music library, failure in some files. Notable critical tags being Album Title.

Additionally, other tags were not read as they were not defined in Kodi's tag parser. This PR includes support for more tags.

## How has this been tested?
Multiple beta testers:
- LibreElec x64
- LibreElec RPi 5
- Windows x64

## What is the effect on users?
Users can now reliably tag and scan Matroska MKA and MKV files, with and without chapters into Piers music library. Many additional tags are now supported vs. 21.3 FFmpeg tag reading.

## What is the effect on users?
Users can now reliably tag and scan Matroska MKA and MKV files, with and without chapters into Piers music library. Many additional tags are now supported vs. 21.3 FFmpeg tag reading.

## Design notes: `.mkv` handling
This PR adds `.mkv` to `MUSIC::IsAudioBook()` alongside `.m4b` and `.mka` so chaptered music MKVs can be expanded into per-chapter items in Files view and scanned into the music library as chapter rows. `.mkv` is dual-use (also the standard video container), so `CFileDirectoryFactory::Create` now guards the audiobook routing with a music-source check (`CMediaSourceSettings::GetSources("music")` via `CUtil::GetMatchingSource`):

- A `.mkv` is routed through `CAudioBookFileDirectory` **only** when the path is under a configured Music source.
- Video-source MKVs and out-of-library MKVs fall through unchanged — clicking plays the file via VideoPlayer as usual.
- `.m4b` and `.mka` are unambiguous music containers and remain unrestricted.

The guard affects only browse-time folder/file classification; player selection (`CPlayerCoreFactory`) is independent of `IsAudioBook`.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] ---->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] ---->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! ---->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [x] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

I nowt have access to wiki to document the supported Matroska tag keys. 

The TagLib 2.3 bump (#28294) has merged, so the prior "do not merge before" gate no longer applies.
