### PR TITLE
GBM: gate limitguisize on Direct-to-Plane configuration

### DIFF
--- a/system/settings/linux.xml
+++ b/system/settings/linux.xml
@@ -215,7 +215,7 @@
           <visible>false</visible>
         </setting>
         <setting id="videoscreen.limitguisize" type="integer" label="37021" help="36548">
-          <visible>false</visible>
+          <visible>true</visible>
           <level>3</level>
           <default>0</default>
           <constraints>
@@ -227,6 +227,14 @@
               <option label="13467">4</option> <!-- Unlimited / 1080 (>30Hz) -->
             </options>
           </constraints>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition setting="videoplayer.useprimedecoder" operator="is">true</condition>
+                <condition setting="videoplayer.useprimerenderer" operator="is">0</condition>
+              </and>
+            </dependency>
+          </dependencies>
           <control type="list" format="string" />
         </setting>
         <setting id="videoscreen.limitedrange" type="boolean" label="36042" help="36359">

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -170,10 +170,6 @@ bool CWinSystemGbm::InitWindowSystem()
   if (setting)
     setting->SetVisible(true);
 
-  setting = settings->GetSetting("videoscreen.limitguisize");
-  if (setting)
-    setting->SetVisible(true);
-
   SetHDR(nullptr);
 
   CLog::Log(LOGDEBUG, "CWinSystemGbm::{} - initialized DRM", __FUNCTION__);

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -770,8 +770,14 @@ RESOLUTION_INFO CDRMUtils::GetResolutionInfo(drmModeModeInfoPtr mode)
   res.iWidth = res.iScreenWidth;
   res.iHeight = res.iScreenHeight;
 
-  int limit = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-      SETTING_VIDEOSCREEN_LIMITGUISIZE);
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+
+  // limitguisize should only apply if Direct-to-Plane is configured.
+  //! @todo we are forced to check settings to detect D2P status, but this is brittle.
+  const int limit = settings->GetBool(CSettings::SETTING_VIDEOPLAYER_USEPRIMEDECODER) &&
+                            settings->GetInt(CSettings::SETTING_VIDEOPLAYER_USEPRIMERENDERER) == 0
+                        ? settings->GetInt(SETTING_VIDEOSCREEN_LIMITGUISIZE)
+                        : 0;
   if (limit > 0 && res.iScreenWidth > 1920 && res.iScreenHeight > 1080)
   {
     switch (limit)


### PR DESCRIPTION
## Description

Gate videoscreen.limitguisize on Direct-to-Plane (dual-plane) configuration.

Fixes #28139 

limitguisize caps the GUI render resolution to save memory. In DRMPRIME direct-to-plane mode the GUI and video are independent DRM planes, so capping the GUI plane is harmless - the video plane scans out at full resolution regardless. But in every other GBM rendering mode (DRMPRIMEGLES, VAAPI, any single-plane EGL path) the GUI surface is the video surface, so the cap wrongly downscales video too: a 4K video with the GUI limited to 1080p gets rendered at 1080p and then upscaled back by the scanout hardware.

This change:
- linux.xml: makes limitguisize visible with a type="visible" dependency on useprimedecoder=true AND useprimerenderer=0, so the setting only appears when D2P is actually configured.
- WinSystemGbm: drops the unconditional SetVisible call; visibility is now driven by the dependency.
- DRMUtils::GetResolutionInfo: gates the limitguisize cap on the same D2P condition, so a previously-stored setting value doesn't keep constraining video after the user switches away from D2P.

## Motivation and context
Fixes #28139. The setting's help text (36548) claims "Does not affect video playback" - which is only true in D2P dual-plane mode.  On the entire VAAPI / single-plane EGL world the setting silently downscales video. The original limitguisize patch (#16063) was intended for the dual-plane DRMPRIME scenario; this restricts it to that scenario.

## How has this been tested?
Linux+GBM+VAAPI and Linux+DRMPRIME

## What is the effect on users?
Users on VAAPI or DRMPRIMEGLES who had limitguisize inadvertently set will get full-resolution video instead of GUI-resolution-capped video. The setting no longer appears for them (it's only relevant to D2P). D2P users see no change.

## Screenshots (if appropriate):
n/a

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
