### PR TITLE
[Music] PaPlayer Performance/Fixes

### DIFF
--- a/xbmc/cores/paplayer/AudioDecoder.cpp
+++ b/xbmc/cores/paplayer/AudioDecoder.cpp
@@ -34,6 +34,7 @@ CAudioDecoder::CAudioDecoder()
 
   m_status = STATUS_NO_FILE;
   m_canPlay = false;
+  m_startThresholdBytes = 0;
 
   // output buffer (for transferring data from the Pcm Buffer to the rest of the audio chain)
   memset(&m_outputBuffer, 0, OUTPUT_SAMPLES * sizeof(float));
@@ -130,6 +131,17 @@ bool CAudioDecoder::Create(const CFileItem &file, int64_t seekOffset)
 
   if (seekOffset)
     m_codec->Seek(seekOffset);
+
+  // Pre-compute the startup-buffer threshold once. Format is immutable for the
+  // lifetime of m_codec, so the per-packet recomputation in ReadSamples is
+  // wasted work. 64-bit intermediate prevents wrap for extreme hi-res
+  // multichannel (see ReadSamples for the original sizing rationale).
+  constexpr unsigned int STARTUP_BUFFER_MS = 200;
+  m_startThresholdBytes = (static_cast<uint64_t>(STARTUP_BUFFER_MS) *
+                           static_cast<uint64_t>(m_codec->m_bitsPerSample >> 3) *
+                           static_cast<uint64_t>(m_codec->m_format.m_channelLayout.Count()) *
+                           static_cast<uint64_t>(m_codec->m_format.m_sampleRate)) /
+                          1000;
 
   m_status = STATUS_QUEUING;
 
@@ -274,8 +286,18 @@ int CAudioDecoder::ReadSamples(int numsamples)
         // move it into our buffer
         m_pcmBuffer.WriteData((char *)m_pcmInputBuffer, readSize);
 
-        // update status
-        if (m_status == STATUS_QUEUING && m_pcmBuffer.getMaxReadSize() > m_pcmBuffer.getSize() * 0.9)
+        // Declare queued once we have a fixed amount of decoded PCM ready.
+        // Time-based (not a percentage of the 2-s buffer) so startup latency is
+        // decoupled from buffer-capacity choices: enlarging the buffer for
+        // playback resilience does not silently increase the play-start delay.
+        // The original threshold required 90% of the 2-s buffer (~1.8 s of PCM)
+        // which on multichannel hi-res content (Atmos/TrueHD) over NFS at a
+        // chapter offset took ~4 s to fill. VideoPlayer has no equivalent
+        // threshold and starts on the first decoded frame; this brings PaPlayer
+        // closer to that feel without sacrificing the resilience the remaining
+        // buffer-fill provides during playback. Threshold is computed once in
+        // Create() since the contributing format values are immutable.
+        if (m_status == STATUS_QUEUING && m_pcmBuffer.getMaxReadSize() > m_startThresholdBytes)
         {
           CLog::Log(LOGINFO, "AudioDecoder: File is queued");
           m_status = STATUS_QUEUED;

--- a/xbmc/cores/paplayer/AudioDecoder.h
+++ b/xbmc/cores/paplayer/AudioDecoder.h
@@ -11,6 +11,8 @@
 #include "threads/CriticalSection.h"
 #include "utils/RingBuffer.h"
 
+#include <cstdint>
+
 struct AEAudioFormat;
 class CFileItem;
 class ICodec;
@@ -83,6 +85,11 @@ private:
   bool m_eof;
   int m_status;
   bool m_canPlay;
+
+  // Cached startup-buffer threshold in bytes, computed once per codec in
+  // Create() from the immutable format (bits/ch/rate). Avoids recomputing a
+  // 64-bit multiply/divide in the ReadSamples hot loop while STATUS_QUEUING.
+  uint64_t m_startThresholdBytes;
 
   // the codec we're using
   ICodec* m_codec;

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -237,9 +237,27 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
   if (NeedConvert(m_srcFormat.m_dataFormat))
   {
     m_needConvert = true;
-    // if we don't know the framesize yet, we will fail when converting
+    // Some codecs (notably TrueHD over slow sources like NFS) do not populate
+    // m_frameSize within the 10-packet sanity loop above even when channels
+    // and sample rate are already known. For PCM-decoded data the frame size
+    // is determined by bits-per-sample and channel count - both already known
+    // at this point - so compute it as a fallback instead of failing silently.
     if (m_srcFormat.m_frameSize == 0)
-      return false;
+    {
+      // The fallback only handles interleaved formats: the downstream divisor
+      // in ReadPCM (m_frameSize / m_channels) assumes interleaved layout, and
+      // for planar the per-plane sample width is too small to safely divide by
+      // m_channels (e.g. 8-bit planar stereo would integer-divide to 0).
+      // Bail out for planar - preserves pre-existing behavior for that path.
+      if (AE_IS_PLANAR(m_srcFormat.m_dataFormat))
+        return false;
+      const unsigned int bytesPerSample = CAEUtil::DataFormatToBits(m_srcFormat.m_dataFormat) >> 3;
+      // Also bail if bits-per-sample is <8: a zero frame size would propagate
+      // to ReadPCM and divide-by-zero on m_frameSize.
+      if (bytesPerSample == 0)
+        return false;
+      m_srcFormat.m_frameSize = bytesPerSample * m_channels;
+    }
 
     m_pResampler = ActiveAE::CAEResampleFactory::Create();
 

--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -17,7 +17,6 @@
 #include "dbwrappers/Database.h"
 #include "filesystem/File.h"
 #include "imagefiles/ImageFileURL.h"
-#include "music/MusicDatabase.h"
 #include "music/MusicEmbeddedCoverLoaderFFmpeg.h"
 #include "music/tags/MusicCodecInfoFFmpeg.h"
 #include "music/tags/MusicInfoTag.h"
@@ -243,59 +242,9 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url, CFileItemList& items
   return true;
 }
 
-/*!
- * Next 4 methods were impelmented to help resolve slow initial play of
- * Matroska files by PaPlayer when testing THIS code originally writtten for 21.3
- * PaPlayer was calling Exists() and ContainsFiles() during initial playback to determine
- * if the file is an audiobook. There will be a PR to implement these soon.
- * CAudioBookFileDirectory is a Library scanning class and should never be used
- * during playback, if the file has been scanned into the music database.
- */
-int CAudioBookFileDirectory::GetSongCountFromDatabase(const CURL& url)
-{
-  CMusicDatabase db;
-  if (!db.Open())
-    return -1;
-
-  std::string strPath = URIUtils::GetDirectory(url.Get());
-  std::string strFileName = URIUtils::GetFileName(url.Get());
-
-  // db.PrepareSQL() uses mprintf-style %s substitution that escapes single
-  // quotes (and other SQL metacharacters) safely, so apostrophes in paths
-  // or filenames are handled and there is no SQL injection surface here.
-  std::string sql = db.PrepareSQL("SELECT COUNT(*) FROM song "
-                                  "JOIN path ON song.idPath = path.idPath "
-                                  "WHERE path.strPath = '%s' AND song.strFileName = '%s'",
-                                  strPath.c_str(), strFileName.c_str());
-
-  int count = db.GetSingleValueInt(sql);
-  db.Close();
-
-  return (count >= 0) ? count : -1;
-}
-
 bool CAudioBookFileDirectory::Exists(const CURL& url)
 {
-  // Fast path: check the music database to avoid any file I/O.
-  // During playback this is called frequently (e.g. from IsAudioBook()),
-  // so it must be fast and must not open the actual media file.
-  int dbSongCount = GetSongCountFromDatabase(url);
-  if (dbSongCount > 1)
-    return true;
-  if (dbSongCount >= 0)
-    return false; // 0 or 1 songs - not a multi-chapter audiobook
-
-  // DB unavailable (-1). Return false to avoid blocking playback.
-  // The file will be properly detected during library scan when the DB
-  // is available. Returning true here risks triggering GetDirectory()
-  // which opens more file/DB handles and can deadlock during playback.
-  return false;
-}
-
-bool CAudioBookFileDirectory::HasChaptersInDatabase(const CURL& url)
-{
-  int dbSongCount = GetSongCountFromDatabase(url);
-  return dbSongCount > 1;
+  return CFile::Exists(url);
 }
 
 bool CAudioBookFileDirectory::ContainsFiles(const CURL& url)

--- a/xbmc/filesystem/AudioBookFileDirectory.h
+++ b/xbmc/filesystem/AudioBookFileDirectory.h
@@ -24,20 +24,9 @@ namespace XFILE
       bool Exists(const CURL& url) override;
       bool ContainsFiles(const CURL& url) override;
       bool IsAllowed(const CURL& url) const override { return true; }
-      /*!
-       * Check if a file already has multiple chapter/song records in the music DB.
-       * If the file is already scanned, the player can use the existing DB rows
-       * directly and there is no need to wrap the file as a directory or run a
-       * full FFmpeg probe of it.
-       * return true if the DB contains > 1 song for this file (i.e. already scanned).
-       */
-      static bool HasChaptersInDatabase(const CURL& url);
 
     protected:
       AVIOContext* m_ioctx = nullptr;
       AVFormatContext* m_fctx = nullptr;
-
-    private:
-      static int GetSongCountFromDatabase(const CURL& url);
   };
 }

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -30,6 +30,7 @@
 #include "addons/ExtsMimeSupportList.h"
 #include "addons/VFSEntry.h"
 #include "addons/addoninfo/AddonInfo.h"
+#include "music/MusicDatabase.h"
 #include "music/MusicFileItemClassify.h"
 #if defined(TARGET_ANDROID)
 #include "platform/android/filesystem/APKDirectory.h"
@@ -56,6 +57,34 @@ bool IsUnderMusicSource(const std::string& path)
     return false;
   bool isSourceName = false;
   return CUtil::GetMatchingSource(path, *sources, isSourceName) > -1;
+}
+
+/*!
+ * Return true if the file already has multiple chapter/song rows in the music DB
+ * (i.e. has been scanned by CAudioBookFileDirectory previously). Used to skip the
+ * FFmpeg probe in ContainsFiles() that otherwise stalls Play() for several seconds,
+ * especially over SMB/NFS.
+ */
+bool HasChaptersInMusicDb(const CURL& url)
+{
+  CMusicDatabase db;
+  if (!db.Open())
+    return false;
+
+  const std::string strPath = URIUtils::GetDirectory(url.Get());
+  const std::string strFileName = URIUtils::GetFileName(url.Get());
+
+  // PrepareSQL uses mprintf-style %s substitution that escapes single quotes
+  // (and other SQL metacharacters) safely, so apostrophes in paths or filenames
+  // are handled and there is no SQL injection surface here.
+  const std::string sql = db.PrepareSQL("SELECT COUNT(*) FROM song "
+                                        "JOIN path ON song.idPath = path.idPath "
+                                        "WHERE path.strPath = '%s' AND song.strFileName = '%s'",
+                                        strPath.c_str(), strFileName.c_str());
+
+  const int count = db.GetSingleValueInt(sql);
+  db.Close();
+  return count > 1;
 }
 } // namespace
 
@@ -271,13 +300,19 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
     if (strExtension == ".mkv" && !IsUnderMusicSource(url.Get()))
       return nullptr;
 
+    // Already-expanded chapter rows (have a music tag and a positive end offset)
+    // are going to return nullptr regardless, so skip the music-DB open for them
+    // and only consult the DB on the not-yet-expanded path where it gates the
+    // expensive FFmpeg ContainsFiles() probe.
     if (!pItem->HasMusicInfoTag() || pItem->GetEndOffset() <= 0)
     {
+      if (HasChaptersInMusicDb(url))
+        return nullptr;
       auto pDir = std::make_unique<CAudioBookFileDirectory>();
       if (pDir->ContainsFiles(url))
         return pDir.release();
     }
-    return NULL;
+    return nullptr;
   }
   return NULL;
 }

--- a/xbmc/music/MusicInfoLoader.cpp
+++ b/xbmc/music/MusicInfoLoader.cpp
@@ -123,6 +123,15 @@ bool CMusicInfoLoader::LoadAdditionalTagInfo(CFileItem* pItem)
       CMusicDatabase::SetPropertiesFromAlbum(*pItem, album);
 
     path = pItem->GetMusicInfoTag()->GetURL();
+
+    // The artist and album lookups above have populated the item from the DB.
+    // The remaining work below opens the source file with TagLib just to
+    // fetch lyrics, which is not worth the cost - particularly for files on
+    // network shares, or large Matroska/chaptered containers where TagLib
+    // seeks to EOF hunting for ID3-style tags that aren't there. Bail out for
+    // anything already in the music DB.
+    pItem->SetProperty("hasfullmusictag", "true");
+    return true;
   }
 
   CLog::Log(LOGDEBUG, "Loading additional tag info for file {}", path);


### PR DESCRIPTION
# PaPlayer Performance Improvements/Fixes

## Description
A set of related performance and correctness improvements to PaPlayer's startup and audiobook/Matroska handling paths. Empirically these reduce click-to-first-audio latency on multichannel hi-res content (Atmos TrueHD MKA over NFS) from ~4.5 s to ~680 ms (≈6.6×), and fix an upstream bug that caused Atmos M4A albums to auto-skip through tracks when starting playback from any non-first track.

**Depends on #28314 (MatroskaTags2 — Matroska Music Tags support). Must merge after that PR.** Until #28314 merges, the diff in this PR shows MT2 content alongside the perf commits — please review the last 2 commits in isolation.

## Motivation and Context
Two concrete user-visible problems motivated this work:

1. **Slow play start on multi-channel hi-res music over network shares.** Playing an Atmos TrueHD `.mka` chapter from a music-library album took ~4.5 s from clicking play to hearing audio. VideoPlayer plays similarly-structured MKV files instantly; PaPlayer's startup path had structural reasons for the gap that this PR addresses.

2. **Atmos M4A album auto-skip bug (pre-existing upstream).** Playing any non-first track of a multichannel M4A album would silently auto-skip through several tracks until the codec/cache state warmed up enough for one to succeed. `CAudioDecoder::Create` logs "Unable to Init Codec" but the underlying cause is a silent `return false` deep in `VideoPlayerCodec::Init` when the 10-packet sanity loop exits before the codec reports its frame size.

## Commits
**Commit 1 — `[Music] PaPlayer/audiobook start-up performance improvements`** *(squashed perf work)*

Four related improvements bundled into one commit:
- **CFileDirectoryFactory** — short-circuit before constructing `CAudioBookFileDirectory` when the music DB already has multiple chapter/song rows for the file. Eliminates a ~3 s FFmpeg probe stall on browse-from-files-view and library-scan paths. DB-presence policy moves into an anonymous-namespace helper inside the factory (where it belongs); `CAudioBookFileDirectory` becomes a pure scanner and loses its `HasChaptersInDatabase` / `GetSongCountFromDatabase` methods. `Exists()` reverts to a simple `CFile::Exists` because the factory now guards against instantiation during playback.

- **CMusicInfoLoader::LoadAdditionalTagInfo** — bail out for in-DB songs after the existing artist/album DB enrichment. Previously continued to a TagLib file open purely to refresh lyrics — small cost locally but over NFS on multi-GB chaptered files TagLib seeks to EOF hunting for ID3-style tags that aren't there. Behavioural change: `CGUIDialogSongInfo` no longer refreshes lyrics from file for in-DB songs — consistent with the existing `hasfullmusictag` short-circuit in the same function.

- **CAudioDecoder threshold** — *the main lever.* `ReadSamples` previously waited for the PCM buffer to be 90 % full before transitioning `STATUS_QUEUING → STATUS_QUEUED`. The buffer is sized for 2 s of decoded PCM, so this was waiting on ~1.8 s of decoded audio. For multichannel hi-res content over NFS at a chapter seek-offset, that took ~4 s to fill. Replaced with an explicit `STARTUP_BUFFER_MS = 200` time-based constant; the 2-s buffer still fills for resilience during playback, only the start condition changes. VideoPlayer has no equivalent threshold and starts on the first decoded frame.

**Commit 2 — `[Music] VideoPlayerCodec: compute m_frameSize fallback instead of silent fail`** *(bug fix)*
Fixes a pre-existing upstream bug where Atmos M4A albums would auto-skip through many tracks before playback succeeded. `VideoPlayerCodec::Init`'s 10-packet sanity loop exits when channels and sample rate are populated, but for slower codec paths (TrueHD over NFS) `m_frameSize` may still be 0 at that point. The subsequent `NeedConvert` branch then returns false with no log message — `CAudioDecoder::Create` logs "Unable to Init Codec" with no clue why. Frame size for PCM is `bytes_per_sample × channels` (or just `bytes_per_sample` for planar) — both already known at that point. Compute the fallback instead of failing.

## How has this been tested?
Windows x64
LibreElec x64

Empirical measurements my home gear:

- **Atmos TrueHD MKA over NFS** (6.6 GB chaptered file, multichannel hi-res):
  - Before: click → `OnAVStarted` ≈ 4500 ms
  - After: click → `OnAVStarted` ≈ 680 ms (6.6× speedup)
  - Measured by debug-log timestamp deltas across 3 separate runs each
- **Atmos M4A album playback** (Elton John – Diamonds, 49 tracks, multichannel):
  - Before: picking any non-first track auto-skipped through many tracks before one succeeded
  - After: any selected track plays immediately
- **MP3 / FLAC / stereo content**: no user-visible change (these formats filled the 2-s PCM buffer in tens of ms anyway; the threshold change is invisible for them)
- **Gapless playback between tracks**: unaffected — the two-decoder pre-queue mechanism uses the same `STATUS_QUEUING → STATUS_QUEUED` transition for the next decoder, but it runs during the current track's playback so threshold timing is irrelevant
- All test playback was via NFS to a Synology, DirectSound output on Windows debug builds; LibreELEC builds for full Atmos hardware chain testing are in progress

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) — commit 5 fixes the Atmos M4A album auto-skip bug
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] Code refactoring (non-breaking change) — commits 1, 2, 3, 4
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change

## Notes for reviewers
- **The `STARTUP_BUFFER_MS` value (200 ms) is conservative.** It mathematically matches the original 0.9 × 2 s threshold's behaviour to keep this PR a pure refactor at default settings. Lower values (50–100 ms) measured even faster start with no audible artefacts on home LAN; the constant is one-line tuneable for further work.
- **Behavioural change in commit 3** affects `CGUIDialogSongInfo` for in-DB songs: lyrics are no longer re-fetched from file when opening Song Info. This is consistent with the existing per-CFileItem `hasfullmusictag` short-circuit on the same function.
- The audiobook scan was specifically the use case for the factory short-circuit; once MT2 (Matroska Music Tags) merges, multi-chapter MKA scanning will be the primary beneficiary of these optimisations.

## Attribution
Diagnosis, implementation, and prose drafted in pair with Claude (Anthropic AI). Each commit's `Co-Authored-By` trailer documents the collaboration. 

## Checklist:
- [ X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

NOTE: These are all user critical changes/fixes 