### PR TITLE
GBM/GL HDR Compositing

### DIFF
--- a/system/shaders/GL/1.5/gl_gui_composite.frag
+++ b/system/shaders/GL/1.5/gl_gui_composite.frag
@@ -43,8 +43,10 @@ void main()
   if (gui.a == 0.0)
     discard;
 
-  // sRGB -> linear (approximate)
-  vec3 linear = pow(gui.rgb, vec3(2.2));
+  // sRGB -> linear (IEC 61966-2-1 piecewise EOTF)
+  vec3 linear = mix(gui.rgb / 12.92,
+                    pow((gui.rgb + 0.055) / 1.055, vec3(2.4)),
+                    step(0.04045, gui.rgb));
 
   // BT.709 -> BT.2020 gamut mapping
   linear = bt709_to_bt2020 * linear;

--- a/system/shaders/GL/1.5/gl_gui_composite.frag
+++ b/system/shaders/GL/1.5/gl_gui_composite.frag
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#version 150
+
+in vec2 v_tex;
+out vec4 fragColor;
+uniform sampler2D u_samp;
+uniform float u_sdrPeak; // SDR peak in normalized PQ (e.g. 100/10000 = 0.01)
+
+// ST2084 (PQ) constants
+const float ST2084_m1 = 0.1593017578125;   // 2610/16384
+const float ST2084_m2 = 78.84375;           // 2523/4096 * 128
+const float ST2084_c1 = 0.8359375;          // 3424/4096
+const float ST2084_c2 = 18.8515625;         // 2413/4096 * 32
+const float ST2084_c3 = 18.6875;            // 2392/4096 * 32
+
+// BT.709 -> BT.2020 color space conversion matrix (applied in linear light)
+const mat3 bt709_to_bt2020 = mat3(
+  0.6274,  0.0691,  0.0164,
+  0.3293,  0.9195,  0.0880,
+  0.0433,  0.0114,  0.8956
+);
+
+vec3 forwardPQ(vec3 L)
+{
+  vec3 Lm1 = pow(L, vec3(ST2084_m1));
+  return pow((ST2084_c1 + ST2084_c2 * Lm1) / (1.0 + ST2084_c3 * Lm1), vec3(ST2084_m2));
+}
+
+void main()
+{
+  vec4 gui = texture(u_samp, v_tex);
+
+  // sRGB -> linear (approximate)
+  vec3 linear = pow(gui.rgb, vec3(2.2));
+
+  // BT.709 -> BT.2020 gamut mapping
+  linear = bt709_to_bt2020 * linear;
+
+  // scale to PQ luminance range: SDR content at u_sdrPeak of 10000 nits
+  linear *= u_sdrPeak;
+
+  // linear -> PQ
+  vec3 pq = forwardPQ(linear);
+
+  fragColor = vec4(pq, gui.a);
+}

--- a/system/shaders/GL/1.5/gl_gui_composite.frag
+++ b/system/shaders/GL/1.5/gl_gui_composite.frag
@@ -37,6 +37,12 @@ void main()
 {
   vec4 gui = texture(u_samp, v_tex);
 
+  // Skip pixels the GUI never wrote to. Blend unit would still preserve video
+  // bit-exactly via DST*(1-0)+garbage*0=DST, but discard makes it structural
+  // and avoids the tone-map math, BO read and BO write for those pixels.
+  if (gui.a == 0.0)
+    discard;
+
   // sRGB -> linear (approximate)
   vec3 linear = pow(gui.rgb, vec3(2.2));
 
@@ -48,6 +54,13 @@ void main()
 
   // linear -> PQ
   vec3 pq = forwardPQ(linear);
+
+  // Limited-range encoding at the BO write boundary. Canonical normalized
+  // ratios (bit-depth-agnostic in float space; BO write quantizes to the
+  // active surface bit depth).
+#ifdef KODI_LIMITED_RANGE
+  pq = pq * ((235.0 - 16.0) / 255.0) + (16.0 / 255.0);
+#endif
 
   fragColor = vec4(pq, gui.a);
 }

--- a/system/shaders/GL/1.5/gl_gui_composite.vert
+++ b/system/shaders/GL/1.5/gl_gui_composite.vert
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#version 150
+
+in vec2 a_pos;
+in vec2 a_tex;
+out vec2 v_tex;
+uniform mat4 u_proj;
+
+void main()
+{
+  gl_Position = u_proj * vec4(a_pos, 0.0, 1.0);
+  v_tex = a_tex;
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -133,3 +133,201 @@ void CDRMPRIMETexture::Unmap()
   m_primebuffer->Release();
   m_primebuffer = nullptr;
 }
+
+namespace
+{
+
+// Maps a source DRM fourcc to the per-plane import descriptors used by
+// CDRMPRIMETextureYUV. planeWidthShift / planeHeightShift describe
+// chroma subsampling relative to the full Y-plane resolution.
+struct PlaneLayout
+{
+  int numPlanes;
+  uint32_t planeFourcc[CDRMPRIMETextureYUV::MAX_PLANES];
+  int planeWidthShift[CDRMPRIMETextureYUV::MAX_PLANES];
+  int planeHeightShift[CDRMPRIMETextureYUV::MAX_PLANES];
+};
+
+bool GetPlaneLayout(uint32_t sourceFormat, PlaneLayout& layout)
+{
+  switch (sourceFormat)
+  {
+    case DRM_FORMAT_NV12:
+      layout = {2, {DRM_FORMAT_R8, DRM_FORMAT_GR88, 0}, {0, 1, 0}, {0, 1, 0}};
+      return true;
+    case DRM_FORMAT_P010:
+    case DRM_FORMAT_P012:
+    case DRM_FORMAT_P016:
+      layout = {2, {DRM_FORMAT_R16, DRM_FORMAT_GR1616, 0}, {0, 1, 0}, {0, 1, 0}};
+      return true;
+    case DRM_FORMAT_YUV420:
+      layout = {3, {DRM_FORMAT_R8, DRM_FORMAT_R8, DRM_FORMAT_R8}, {0, 1, 1}, {0, 1, 1}};
+      return true;
+#if defined(DRM_FORMAT_S010)
+    case DRM_FORMAT_S010:
+#endif
+#if defined(DRM_FORMAT_S012)
+    case DRM_FORMAT_S012:
+#endif
+#if defined(DRM_FORMAT_S016)
+    case DRM_FORMAT_S016:
+#endif
+#if defined(DRM_FORMAT_S010) || defined(DRM_FORMAT_S012) || defined(DRM_FORMAT_S016)
+      layout = {3, {DRM_FORMAT_R16, DRM_FORMAT_R16, DRM_FORMAT_R16}, {0, 1, 1}, {0, 1, 1}};
+      return true;
+#endif
+    default:
+      return false;
+  }
+}
+
+} // namespace
+
+bool CDRMPRIMETextureYUV::SupportsFormat(uint32_t fourcc)
+{
+  PlaneLayout dummy;
+  return GetPlaneLayout(fourcc, dummy);
+}
+
+// Cleanup pattern taken from CDRMPRIMETexture::~CDRMPRIMETexture (above),
+// extended to the per-plane texture array.
+CDRMPRIMETextureYUV::~CDRMPRIMETextureYUV()
+{
+  // Release any active mapping (EGL images, descriptor, buffer ref).
+  Unmap();
+  // Delete the GL texture objects that Map() may have generated.
+  for (int i = 0; i < MAX_PLANES; i++)
+  {
+    if (m_textures[i])
+      glDeleteTextures(1, &m_textures[i]);
+  }
+}
+
+void CDRMPRIMETextureYUV::Init(EGLDisplay eglDisplay)
+{
+  m_eglDisplay = eglDisplay;
+}
+
+// Descriptor acquire/release lifecycle and the per-plane
+// glIsTexture/glGenTextures + glBindTexture + glTexParameteri x4 +
+// UploadImage + unbind sequence are taken from CDRMPRIMETexture::Map
+// (above) and CVaapi2Texture::Map (VaapiEGL.cpp:438-560). What is new
+// here is the per-plane DRM fourcc derivation (single-layer N-plane
+// descriptor split into N separate EGL images) and the multi-plane
+// loop. Single-layer-N-plane is the shape ffmpeg HW decoders and the
+// SW-decode -> DMA path produce.
+bool CDRMPRIMETextureYUV::Map(CVideoBufferDRMPRIME* buffer)
+{
+  if (m_primebuffer)
+    return true;
+
+  if (!buffer->AcquireDescriptor())
+  {
+    CLog::Log(LOGERROR, "CDRMPRIMETextureYUV::{} - failed to acquire descriptor", __FUNCTION__);
+    return false;
+  }
+
+  AVDRMFrameDescriptor* descriptor = buffer->GetDescriptor();
+  if (!descriptor || descriptor->nb_layers < 1)
+  {
+    buffer->ReleaseDescriptor();
+    return false;
+  }
+
+  // Only the single-layer-multi-plane descriptor shape is supported.
+  // ffmpeg HW decoders and the SW decode -> DMA path both produce this shape.
+  if (descriptor->nb_layers != 1)
+  {
+    CLog::Log(LOGWARNING,
+              "CDRMPRIMETextureYUV::{} - {} layers, only single-layer descriptors supported",
+              __FUNCTION__, descriptor->nb_layers);
+    buffer->ReleaseDescriptor();
+    return false;
+  }
+
+  AVDRMLayerDescriptor* layer = &descriptor->layers[0];
+
+  PlaneLayout planeLayout;
+  if (!GetPlaneLayout(layer->format, planeLayout))
+  {
+    CLog::Log(LOGWARNING, "CDRMPRIMETextureYUV::{} - unsupported source fourcc {:#x}", __FUNCTION__,
+              layer->format);
+    buffer->ReleaseDescriptor();
+    return false;
+  }
+
+  if (layer->nb_planes != planeLayout.numPlanes)
+  {
+    CLog::Log(LOGERROR,
+              "CDRMPRIMETextureYUV::{} - layer has {} planes, expected {} for fourcc {:#x}",
+              __FUNCTION__, layer->nb_planes, planeLayout.numPlanes, layer->format);
+    buffer->ReleaseDescriptor();
+    return false;
+  }
+
+  m_texWidth = buffer->GetWidth();
+  m_texHeight = buffer->GetHeight();
+  m_sourceFormat = layer->format;
+  m_numPlanes = planeLayout.numPlanes;
+
+  for (int i = 0; i < m_numPlanes; i++)
+  {
+    AVDRMPlaneDescriptor& plane = layer->planes[i];
+    AVDRMObjectDescriptor& object = descriptor->objects[plane.object_index];
+
+    CEGLImage::EglAttrs attribs{};
+    attribs.width = m_texWidth >> planeLayout.planeWidthShift[i];
+    attribs.height = m_texHeight >> planeLayout.planeHeightShift[i];
+    attribs.format = planeLayout.planeFourcc[i];
+    attribs.planes[0].fd = object.fd;
+    attribs.planes[0].modifier = object.format_modifier;
+    attribs.planes[0].offset = static_cast<int>(plane.offset);
+    attribs.planes[0].pitch = static_cast<int>(plane.pitch);
+
+    if (!m_eglImages[i])
+      m_eglImages[i] = std::make_unique<CEGLImage>(m_eglDisplay);
+
+    if (!m_eglImages[i]->CreateImage(attribs))
+    {
+      // Roll back any planes we already imported in this Map() call.
+      for (int j = 0; j < i; j++)
+        m_eglImages[j]->DestroyImage();
+      m_numPlanes = 0;
+      buffer->ReleaseDescriptor();
+      return false;
+    }
+
+    if (!glIsTexture(m_textures[i]))
+      glGenTextures(1, &m_textures[i]);
+    glBindTexture(GL_TEXTURE_2D, m_textures[i]);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    m_eglImages[i]->UploadImage(GL_TEXTURE_2D);
+    glBindTexture(GL_TEXTURE_2D, 0);
+  }
+
+  m_primebuffer = buffer;
+  m_primebuffer->Acquire();
+  return true;
+}
+
+// DestroyImage + ReleaseDescriptor + buffer Release + null sequence is
+// taken from CDRMPRIMETexture::Unmap (above), looped over planes.
+void CDRMPRIMETextureYUV::Unmap()
+{
+  if (!m_primebuffer)
+    return;
+
+  for (int i = 0; i < m_numPlanes; i++)
+  {
+    if (m_eglImages[i])
+      m_eglImages[i]->DestroyImage();
+  }
+  m_numPlanes = 0;
+
+  m_primebuffer->ReleaseDescriptor();
+  m_primebuffer->Release();
+  m_primebuffer = nullptr;
+}

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
@@ -12,6 +12,8 @@
 #include "utils/EGLImage.h"
 #include "utils/Geometry.h"
 
+#include <array>
+
 #include "system_gl.h"
 
 class CDRMPRIMETexture
@@ -35,4 +37,50 @@ protected:
   GLuint m_texture{0};
   int m_texWidth{0};
   int m_texHeight{0};
+};
+
+/*
+ * CDRMPRIMETextureYUV: import a DRMPRIME dma-buf as separate per-plane
+ * GL_TEXTURE_2D textures, the same way VAAPIGLES handles VA-API surfaces
+ * (see CVaapi2Texture::Map). Used by the limited-range render path on
+ * CRendererDRMPRIMEGLES so the YUV->RGB matrix can be applied in a
+ * standard BaseYUV2RGBGLSLShader instead of being baked in by the OES
+ * external sampler's full-range-only Mesa matrix.
+ *
+ * Supports a fixed set of source DRM fourccs (NV12 / P010 / P012 / P016 /
+ * YUV420). For other formats, SupportsFormat returns false and the
+ * caller is expected to fall back to the OES path.
+ */
+class CDRMPRIMETextureYUV
+{
+public:
+  static constexpr int MAX_PLANES = 3;
+
+  CDRMPRIMETextureYUV() = default;
+  ~CDRMPRIMETextureYUV();
+
+  CDRMPRIMETextureYUV(const CDRMPRIMETextureYUV&) = delete;
+  CDRMPRIMETextureYUV& operator=(const CDRMPRIMETextureYUV&) = delete;
+
+  void Init(EGLDisplay eglDisplay);
+  bool Map(CVideoBufferDRMPRIME* buffer);
+  void Unmap();
+
+  GLuint GetTexture(int plane) const { return m_textures[plane]; }
+  int GetNumPlanes() const { return m_numPlanes; }
+  CSizeInt GetTextureSize() const { return {m_texWidth, m_texHeight}; }
+  uint32_t GetSourceFormat() const { return m_sourceFormat; }
+
+  // Returns true if the given DRM fourcc can be imported by this class.
+  static bool SupportsFormat(uint32_t fourcc);
+
+protected:
+  CVideoBufferDRMPRIME* m_primebuffer{nullptr};
+  EGLDisplay m_eglDisplay{nullptr};
+  std::array<std::unique_ptr<CEGLImage>, MAX_PLANES> m_eglImages;
+  std::array<GLuint, MAX_PLANES> m_textures{{0, 0, 0}};
+  int m_numPlanes{0};
+  int m_texWidth{0};
+  int m_texHeight{0};
+  uint32_t m_sourceFormat{0};
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -13,6 +13,8 @@
 #include "cores/VideoPlayer/VideoRenderers/RenderCapture.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFlags.h"
+#include "cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.h"
+#include "rendering/MatrixGL.h"
 #include "rendering/gles/RenderSystemGLES.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -126,23 +128,107 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
     if (!buf.fence)
     {
       buf.texture.Init(eglDisplay);
+      buf.yuvTexture.Init(eglDisplay);
       buf.fence = std::make_unique<CEGLFence>(eglDisplay);
     }
   }
 
   m_configured = true;
 
-  //! @todo limited-range color management is broken on the DRMPRIMEGLES path.
-  //! The OES_EGL_image_external sampler (samplerExternalOES) does YUV->RGB
-  //! conversion in mesa with hardcoded matrices that always output full-range
-  //! RGB regardless of source range. So `videoscreen.limitedrange=true` is
-  //! silently ignored for video pixels here, while GUI pixels go through the
-  //! GLES shader chain that does honor the setting -- producing a range
-  //! mismatch in the BO when both are composited. The clean fix is to migrate
-  //! from OES_EGL_image_external to EXT_YUV_target's __samplerExternal2DY2YEXT
-  //! (sampler returns raw YUV) and apply the conversion matrix in our own
-  //! shader, the way RendererVAAPIGLES does. Tracked in
-  //! project_limited_range_hdr.md.
+  // Two render paths, selected per-frame in Render():
+  //  - Full-range: OES samplerExternalOES (always available).
+  //  - Limited-range: per-plane sampler2D + BaseYUV2RGBGLSLShader, built
+  //    here when the source fourcc is one we can per-plane import.
+  m_yuvShader.reset();
+
+  uint32_t sourceFourcc = 0;
+  auto* drmBuf = dynamic_cast<CVideoBufferDRMPRIME*>(picture.videoBuffer);
+  if (drmBuf && drmBuf->AcquireDescriptor())
+  {
+    auto* desc = drmBuf->GetDescriptor();
+    if (desc && desc->nb_layers == 1)
+      sourceFourcc = desc->layers[0].format;
+    drmBuf->ReleaseDescriptor();
+  }
+
+  if (CDRMPRIMETextureYUV::SupportsFormat(sourceFourcc))
+  {
+    using namespace Shaders::GLES;
+    // Both src and dst primaries equal disables the in-shader primary-matrix
+    // path (`if (dstPrimaries != srcPrimaries)`); we want pass-through, same
+    // as the OES path does. No tone mapping either.
+    //! @todo SHADER_YV12_10 is the WRONG token here for 8-bit YUV420 content.
+    //! The EShaderFormat enum conflates two things: the shader sampling
+    //! pattern (.r/.g/.a legacy CPU-upload vs .r/.r/.r per-plane R8/R16) and
+    //! the source bit depth. Per-plane EGL import always wants the
+    //! single-channel sampling pattern (XBMC_YV12_HI define) regardless of
+    //! bit depth, but the only way to get that today is to pick one of
+    //! SHADER_YV12_9 / _10 / _12 / _14 / _16. Picking _10 here just routes
+    //! through the right shader define; the actual bit depth is handled by
+    //! SetColParams below. Clean up by either (a) adding a
+    //! SHADER_YV12_PLANAR enum value that activates XBMC_YV12_HI without
+    //! implying a bit depth, or (b) dropping 3-plane YUV420 from this path
+    //! entirely (NV12/P010/P012/P016 via SHADER_NV12_RRG cover the realistic
+    //! DRMPRIME cases).
+    //! @todo SHADER_YV12_10 is the WRONG token here for 8-bit YUV420 content.
+    //! The EShaderFormat enum conflates two things: the shader sampling
+    //! pattern (.r/.g/.a legacy CPU-upload vs .r/.r/.r per-plane R8/R16) and
+    //! the source bit depth. Per-plane EGL import always wants the
+    //! single-channel sampling pattern (XBMC_YV12_HI define) regardless of
+    //! bit depth, but the only way to get that today is to pick one of
+    //! SHADER_YV12_9 / _10 / _12 / _14 / _16. Picking _10 here just routes
+    //! through the right shader define; the actual bit depth is handled by
+    //! SetColParams below. Clean up by either (a) adding a
+    //! SHADER_YV12_PLANAR enum value that activates XBMC_YV12_HI without
+    //! implying a bit depth, or (b) dropping 3-plane YUV420 from this path
+    //! entirely (NV12/P010/P012/P016 via SHADER_NV12_RRG cover the realistic
+    //! DRMPRIME cases).
+    const bool planar3 = (sourceFourcc == DRM_FORMAT_YUV420
+#if defined(DRM_FORMAT_S010)
+                          || sourceFourcc == DRM_FORMAT_S010
+#endif
+#if defined(DRM_FORMAT_S012)
+                          || sourceFourcc == DRM_FORMAT_S012
+#endif
+#if defined(DRM_FORMAT_S016)
+                          || sourceFourcc == DRM_FORMAT_S016
+#endif
+    );
+    EShaderFormat fmt = planar3 ? SHADER_YV12_10 : SHADER_NV12_RRG;
+    auto shader = std::make_unique<YUV2RGBProgressiveShader>(
+        fmt, picture.color_primaries, picture.color_primaries,
+        /*toneMap*/ false, VS_TONEMAPMETHOD_OFF);
+    if (shader->CompileAndLink())
+    {
+      // P010/P012/P016 are MSB-aligned -> textureBits=8 (no rescale).
+      // S010/S012/S016 are LSB-aligned -> textureBits=colorBits (matrix rescales).
+      const bool lsbAligned =
+#if defined(DRM_FORMAT_S010)
+          sourceFourcc == DRM_FORMAT_S010 ||
+#endif
+#if defined(DRM_FORMAT_S012)
+          sourceFourcc == DRM_FORMAT_S012 ||
+#endif
+#if defined(DRM_FORMAT_S016)
+          sourceFourcc == DRM_FORMAT_S016 ||
+#endif
+          false;
+      const int textureBits = lsbAligned ? picture.colorBits : 8;
+      shader->SetColParams(picture.color_space, picture.colorBits, picture.color_range != 1,
+                           textureBits);
+      m_yuvShader = std::move(shader);
+      CLog::Log(LOGINFO,
+                "RendererDRMPRIMEGLES::Configure: limited-range YUV path "
+                "available (src bits {}, src {} range, fourcc {:#x})",
+                picture.colorBits, picture.color_range ? "full" : "limited", sourceFourcc);
+    }
+    else
+    {
+      CLog::Log(LOGWARNING, "RendererDRMPRIMEGLES::Configure: limited-range "
+                            "YUV shader compile/link failed; OES path will "
+                            "be used regardless of user setting");
+    }
+  }
 
   if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
       picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
@@ -178,6 +264,7 @@ void CRendererDRMPRIMEGLES::UnInit()
     CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
   }
 
+  m_yuvShader.reset();
   m_configured = false;
 }
 
@@ -190,6 +277,7 @@ void CRendererDRMPRIMEGLES::AddVideoPicture(const VideoPicture& picture, int ind
     if (buf.fence)
       buf.fence->DestroyFence();
     buf.texture.Unmap();
+    buf.yuvTexture.Unmap();
     buf.videoBuffer->Release();
   }
   buf.videoBuffer = picture.videoBuffer;
@@ -213,6 +301,7 @@ void CRendererDRMPRIMEGLES::ReleaseBuffer(int index)
     buf.fence->DestroyFence();
 
   buf.texture.Unmap();
+  buf.yuvTexture.Unmap();
 
   if (buf.videoBuffer)
   {
@@ -370,6 +459,105 @@ void CRendererDRMPRIMEGLES::Render(unsigned int flags, int index)
   if (!renderSystem)
     return;
 
+  // Per-frame path selection. m_yuvShader is only alive if the source
+  // fourcc was importable; UseLimitedColor() is checked every frame so
+  // the user can toggle the setting at runtime and the next frame picks
+  // up the new path without any rebuild.
+  auto* winSystem = CServiceBroker::GetWinSystem();
+  const bool useYUVPath =
+      m_yuvShader && winSystem && winSystem->UseLimitedColor() && buf.yuvTexture.Map(buffer);
+
+  if (useYUVPath)
+  {
+    // Limited-range YUV path: per-plane sampler2D + BaseYUV2RGBGLSLShader.
+    // Vertex/cord array setup is taken from CLinuxRendererGLES::RenderSinglePass
+    // (LinuxRendererGLES.cpp:1100-1183). The texture-unit binding pattern is
+    // taken from CRendererVAAPIGLES::UploadTexture (RendererVAAPIGLES.cpp:270-282)
+    // -- specifically, the SHADER_NV12_RRG case binds the UV texture to BOTH
+    // U and V samplers so .r returns U and .g returns V via the GR88 / GR1616
+    // import.
+    const int numPlanes = buf.yuvTexture.GetNumPlanes();
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, buf.yuvTexture.GetTexture(0));
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, buf.yuvTexture.GetTexture(1));
+    glActiveTexture(GL_TEXTURE2);
+    // 3-plane (YV12_HI): plane 2 is V. 2-plane (NV12_RRG): rebind plane 1
+    // (UV) so sampV samples the same texture as sampU.
+    glBindTexture(GL_TEXTURE_2D, buf.yuvTexture.GetTexture(numPlanes == 3 ? 2 : 1));
+    glActiveTexture(GL_TEXTURE0);
+
+    const CSizeInt texSize = buf.yuvTexture.GetTextureSize();
+    m_yuvShader->SetWidth(texSize.Width());
+    m_yuvShader->SetHeight(texSize.Height());
+    m_yuvShader->SetAlpha(1.0f);
+    m_yuvShader->SetMatrices(glMatrixProject.Get(), glMatrixModview.Get());
+    // SetConvertFullColorRange(false) was set at Configure time -> matrix
+    // produces limited-range RGB. No per-frame setter needed.
+    m_yuvShader->Enable();
+
+    GLubyte idx[4] = {0, 1, 3, 2};
+    GLfloat vert[4][3];
+    GLfloat tex[3][4][2];
+
+    GLint vertLoc = m_yuvShader->GetVertexLoc();
+    GLint yLoc = m_yuvShader->GetYcoordLoc();
+    GLint uLoc = m_yuvShader->GetUcoordLoc();
+    GLint vLoc = m_yuvShader->GetVcoordLoc();
+
+    glVertexAttribPointer(vertLoc, 3, GL_FLOAT, 0, 0, vert);
+    glVertexAttribPointer(yLoc, 2, GL_FLOAT, 0, 0, tex[0]);
+    glVertexAttribPointer(uLoc, 2, GL_FLOAT, 0, 0, tex[1]);
+    glVertexAttribPointer(vLoc, 2, GL_FLOAT, 0, 0, tex[2]);
+
+    glEnableVertexAttribArray(vertLoc);
+    glEnableVertexAttribArray(yLoc);
+    glEnableVertexAttribArray(uLoc);
+    glEnableVertexAttribArray(vLoc);
+
+    for (int i = 0; i < 4; i++)
+    {
+      vert[i][0] = m_rotatedDestCoords[i].x;
+      vert[i][1] = m_rotatedDestCoords[i].y;
+      vert[i][2] = 0.0f;
+    }
+
+    // Per-plane texcoords are 0..1; each EGL-imported texture covers the
+    // whole plane regardless of chroma subsampling.
+    for (int p = 0; p < 3; p++)
+    {
+      tex[p][0][0] = 0.0f;
+      tex[p][0][1] = 0.0f;
+      tex[p][1][0] = 1.0f;
+      tex[p][1][1] = 0.0f;
+      tex[p][2][0] = 1.0f;
+      tex[p][2][1] = 1.0f;
+      tex[p][3][0] = 0.0f;
+      tex[p][3][1] = 1.0f;
+    }
+
+    glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
+
+    glDisableVertexAttribArray(vertLoc);
+    glDisableVertexAttribArray(yLoc);
+    glDisableVertexAttribArray(uLoc);
+    glDisableVertexAttribArray(vLoc);
+
+    m_yuvShader->Disable();
+
+    glActiveTexture(GL_TEXTURE2);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glActiveTexture(GL_TEXTURE1);
+    glBindTexture(GL_TEXTURE_2D, 0);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    buf.fence->DestroyFence();
+    buf.fence->CreateFence();
+    return;
+  }
+
+  // Full-range OES path (unchanged).
   if (!buf.texture.Map(buffer))
     return;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -30,13 +30,7 @@ using namespace KODI::UTILS::EGL;
 
 CRendererDRMPRIMEGLES::~CRendererDRMPRIMEGLES()
 {
-  Flush(false);
-
-  if (m_configured)
-  {
-    if (auto winSystem = CServiceBroker::GetWinSystem())
-      winSystem->SetVideoOutput(nullptr);
-  }
+  UnInit();
 }
 
 CBaseRenderer* CRendererDRMPRIMEGLES::Create(CVideoBuffer* buffer)
@@ -115,6 +109,8 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
   if (!winSystem)
     return false;
 
+  m_configured = true;
+
   if (!winSystem->SetVideoOutput(&picture))
     CLog::Log(LOGWARNING, "RendererDRMPRIMEGLES::Configure: SetVideoOutput failed");
 
@@ -135,7 +131,54 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
   }
 
   m_configured = true;
+
+  //! @todo limited-range color management is broken on the DRMPRIMEGLES path.
+  //! The OES_EGL_image_external sampler (samplerExternalOES) does YUV->RGB
+  //! conversion in mesa with hardcoded matrices that always output full-range
+  //! RGB regardless of source range. So `videoscreen.limitedrange=true` is
+  //! silently ignored for video pixels here, while GUI pixels go through the
+  //! GLES shader chain that does honor the setting -- producing a range
+  //! mismatch in the BO when both are composited. The clean fix is to migrate
+  //! from OES_EGL_image_external to EXT_YUV_target's __samplerExternal2DY2YEXT
+  //! (sampler returns raw YUV) and apply the conversion matrix in our own
+  //! shader, the way RendererVAAPIGLES does. Tracked in
+  //! project_limited_range_hdr.md.
+
+  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
+      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
+  {
+    m_passthroughHDR = winSystem->SetHDR(&picture);
+    CLog::Log(LOGDEBUG, "RendererDRMPRIMEGLES::Configure: HDR passthrough: {}",
+              m_passthroughHDR ? "on" : "off");
+  }
+
+  m_hdrFboActive = m_passthroughHDR && winSystem->SetGuiCompositing(picture.color_transfer);
+  if (m_passthroughHDR && !m_hdrFboActive)
+    CLog::Log(LOGWARNING, "RendererDRMPRIMEGLES::Configure: HDR passthrough active but GUI "
+                          "compositing not supported by windowing system");
+
   return true;
+}
+
+bool CRendererDRMPRIMEGLES::IsGuiLayer()
+{
+  return !m_hdrFboActive;
+}
+
+void CRendererDRMPRIMEGLES::UnInit()
+{
+  Flush(false);
+
+  if (m_configured)
+  {
+    m_hdrFboActive = false;
+    CServiceBroker::GetWinSystem()->SetGuiCompositing(false);
+    CServiceBroker::GetWinSystem()->SetHDR(nullptr);
+    m_passthroughHDR = false;
+    CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
+  }
+
+  m_configured = false;
 }
 
 void CRendererDRMPRIMEGLES::AddVideoPicture(const VideoPicture& picture, int index)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
@@ -37,8 +37,10 @@ public:
   // Player functions
   bool Configure(const VideoPicture& picture, float fps, unsigned int orientation) override;
   bool IsConfigured() override { return m_configured; }
+  bool IsGuiLayer() override;
+  bool HasVideoPlane() override { return false; }
   void AddVideoPicture(const VideoPicture& picture, int index) override;
-  void UnInit() override {}
+  void UnInit() override;
   bool Flush(bool saveBuffers) override;
   void ReleaseBuffer(int idx) override;
   bool NeedBuffer(int idx) override;
@@ -59,6 +61,8 @@ private:
   void Render(unsigned int flags, int index);
 
   bool m_configured = false;
+  bool m_passthroughHDR{false};
+  bool m_hdrFboActive{false};
 
   struct BUFFER
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
@@ -24,6 +24,14 @@ class CEGLFence;
 } // namespace UTILS
 } // namespace KODI
 
+namespace Shaders
+{
+namespace GLES
+{
+class BaseYUV2RGBGLSLShader;
+}
+} // namespace Shaders
+
 class CRendererDRMPRIMEGLES : public CBaseRenderer
 {
 public:
@@ -64,10 +72,18 @@ private:
   bool m_passthroughHDR{false};
   bool m_hdrFboActive{false};
 
+  // Limited-range path: per-plane EGL import + standard YUV2RGB shader.
+  // Set at Configure time when the user has limited-range output enabled
+  // AND the buffer's source fourcc can be imported by CDRMPRIMETextureYUV
+  // AND the shader compiles. If null, Render() falls through to the OES
+  // path (which always outputs full-range RGB).
+  std::unique_ptr<Shaders::GLES::BaseYUV2RGBGLSLShader> m_yuvShader;
+
   struct BUFFER
   {
     CVideoBuffer* videoBuffer = nullptr;
     std::unique_ptr<KODI::UTILS::EGL::CEGLFence> fence;
     CDRMPRIMETexture texture;
+    CDRMPRIMETextureYUV yuvTexture;
   } m_buffers[NUM_BUFFERS];
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -44,8 +44,9 @@ void CVideoLayerBridgeDRMPRIME::Disable()
   if (!winSystem)
     return;
 
-  // disable HDR metadata
+  // disable HDR metadata and GUI compositing
   winSystem->SetHDR(nullptr);
+  winSystem->SetGuiCompositing(false);
 }
 
 void CVideoLayerBridgeDRMPRIME::Acquire(CVideoBufferDRMPRIME* buffer)
@@ -169,7 +170,14 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
 
   const VideoPicture& picture = buffer->GetPicture();
 
-  winSystem->SetHDR(&picture);
+  // Gate HDR passthrough on transfer function, matching the pattern in
+  // LinuxRendererGLES and RendererDRMPRIMEGLES (see smp79's 850dfb04d4).
+  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
+      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
+  {
+    if (winSystem->SetHDR(&picture))
+      winSystem->SetGuiCompositing(picture.color_transfer);
+  }
 
   std::optional<uint64_t> colorEncoding =
       plane->GetPropertyEnumValue("COLOR_ENCODING", GetColorEncoding(picture));

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -268,6 +268,12 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
               m_passthroughHDR ? "on" : "off");
   }
 
+  m_hdrFboActive =
+      m_passthroughHDR && CServiceBroker::GetWinSystem()->SetGuiCompositing(picture.color_transfer);
+  if (m_passthroughHDR && !m_hdrFboActive)
+    CLog::Log(LOGWARNING, "LinuxRendererGL::Configure: HDR passthrough active but GUI "
+                          "compositing not supported by windowing system");
+
   // load 3DLUT
   if (m_ColorManager->IsEnabled())
   {
@@ -1075,6 +1081,8 @@ void CLinuxRendererGL::UnInit()
 
   if (m_bConfigured)
   {
+    m_hdrFboActive = false;
+    CServiceBroker::GetWinSystem()->SetGuiCompositing(false);
     CServiceBroker::GetWinSystem()->SetHDR(nullptr);
     m_passthroughHDR = false;
     CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
@@ -1084,6 +1092,11 @@ void CLinuxRendererGL::UnInit()
   m_fbo.fbo.Cleanup();
   m_bValidated = false;
   m_bConfigured = false;
+}
+
+bool CLinuxRendererGL::IsGuiLayer()
+{
+  return !m_hdrFboActive;
 }
 
 bool CLinuxRendererGL::Render(unsigned int flags, int renderBuffer)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h
@@ -82,6 +82,8 @@ public:
   bool Supports(ESCALINGMETHOD method) const override;
 
   CRenderCapture* GetRenderCapture() override;
+  bool IsGuiLayer() override;
+  bool HasVideoPlane() override { return false; }
 
 protected:
 
@@ -220,6 +222,7 @@ protected:
   bool m_toneMap = false;
   ETONEMAPMETHOD m_toneMapMethod = VS_TONEMAPMETHOD_OFF;
   bool m_passthroughHDR = false;
+  bool m_hdrFboActive{false};
   bool m_pboSupported = true;
   bool m_pboUsed = false;
   bool m_nonLinStretch = false;

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -131,8 +131,19 @@ bool CGUIFontTTFGL::FirstBegin()
     m_textureStatus = TEXTURE_READY;
   }
 
-  // Turn Blending On
-  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
+  // Alpha blending assumes linear light. SDR (direct-to-backbuffer or
+  // direct-to-plane) blends in sRGB -- "wrong but consistent", the aesthetic
+  // skins are designed against. HDR FBO compositing draws GUI into an sRGB
+  // FBO that is color-transformed to PQ before compositing with video in
+  // that non-linear space -- two stages of non-linear blending. The
+  // compensated factors below trade accumulator coverage for a squared-
+  // alpha blend that approximately matches SDR perceived translucency. It
+  // is a "close enough" compromise; a mathematically correct fix would
+  // require linear-light compositing (too expensive on typical ARM GPUs).
+  if (CServiceBroker::GetWinSystem()->IsHdrComposite())
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+  else
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
   glEnable(GL_BLEND);
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, m_nTexture);

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -89,7 +89,15 @@ void CGUITextureGL::Begin(KODI::UTILS::COLOR::Color color)
 
   if (hasAlpha)
   {
-    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
+    // See CGUIFontTTFGL::FirstBegin for rationale. SDR uses accumulator
+    // coverage alpha; HDR FBO composite uses a compensated squared-alpha
+    // blend because the FBO is color-transformed to PQ before composite,
+    // and alpha blending in non-linear space is mathematically wrong.
+    if (CServiceBroker::GetWinSystem()->IsHdrComposite())
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA,
+                          GL_ONE_MINUS_SRC_ALPHA);
+    else
+      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
     glEnable(GL_BLEND);
   }
   else

--- a/xbmc/rendering/gl/CMakeLists.txt
+++ b/xbmc/rendering/gl/CMakeLists.txt
@@ -1,11 +1,13 @@
 if(TARGET ${APP_NAME_LC}::OpenGl)
   set(SOURCES RenderSystemGL.cpp
               ScreenshotSurfaceGL.cpp
-              GLShader.cpp)
+              GLShader.cpp
+              GuiCompositeShaderGL.cpp)
 
   set(HEADERS RenderSystemGL.h
               ScreenshotSurfaceGL.h
-              GLShader.h)
+              GLShader.h
+              GuiCompositeShaderGL.h)
 
   core_add_library(rendering_gl)
 endif()

--- a/xbmc/rendering/gl/GuiCompositeShaderGL.cpp
+++ b/xbmc/rendering/gl/GuiCompositeShaderGL.cpp
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GuiCompositeShaderGL.h"
+
+#include "utils/log.h"
+
+CGuiCompositeShaderGL::CGuiCompositeShaderGL()
+{
+  VertexShader()->LoadSource("gl_gui_composite.vert");
+  PixelShader()->LoadSource("gl_gui_composite.frag");
+}
+
+void CGuiCompositeShaderGL::OnCompiledAndLinked()
+{
+  m_hPos = glGetAttribLocation(ProgramHandle(), "a_pos");
+  m_hTex = glGetAttribLocation(ProgramHandle(), "a_tex");
+  m_hSamp = glGetUniformLocation(ProgramHandle(), "u_samp");
+  m_hProj = glGetUniformLocation(ProgramHandle(), "u_proj");
+  m_hSdrPeak = glGetUniformLocation(ProgramHandle(), "u_sdrPeak");
+
+  glUseProgram(ProgramHandle());
+  glUniform1i(m_hSamp, 0);
+  glUseProgram(0);
+}
+
+bool CGuiCompositeShaderGL::OnEnabled()
+{
+  if (m_proj)
+    glUniformMatrix4fv(m_hProj, 1, GL_FALSE, m_proj);
+
+  glUniform1f(m_hSdrPeak, m_sdrPeak);
+  return true;
+}

--- a/xbmc/rendering/gl/GuiCompositeShaderGL.cpp
+++ b/xbmc/rendering/gl/GuiCompositeShaderGL.cpp
@@ -10,10 +10,10 @@
 
 #include "utils/log.h"
 
-CGuiCompositeShaderGL::CGuiCompositeShaderGL()
+CGuiCompositeShaderGL::CGuiCompositeShaderGL(const std::string& prefix)
 {
-  VertexShader()->LoadSource("gl_gui_composite.vert");
-  PixelShader()->LoadSource("gl_gui_composite.frag");
+  VertexShader()->LoadSource("gl_gui_composite.vert", prefix);
+  PixelShader()->LoadSource("gl_gui_composite.frag", prefix);
 }
 
 void CGuiCompositeShaderGL::OnCompiledAndLinked()

--- a/xbmc/rendering/gl/GuiCompositeShaderGL.h
+++ b/xbmc/rendering/gl/GuiCompositeShaderGL.h
@@ -29,7 +29,7 @@ protected:
 
 private:
   const GLfloat* m_proj{nullptr};
-  float m_sdrPeak{100.0f / 10000.0f};
+  float m_sdrPeak{203.0f / 10000.0f};
 
   GLint m_hPos{-1};
   GLint m_hTex{-1};

--- a/xbmc/rendering/gl/GuiCompositeShaderGL.h
+++ b/xbmc/rendering/gl/GuiCompositeShaderGL.h
@@ -10,10 +10,12 @@
 
 #include "guilib/Shader.h"
 
+#include <string>
+
 class CGuiCompositeShaderGL : public Shaders::CGLSLShaderProgram
 {
 public:
-  CGuiCompositeShaderGL();
+  explicit CGuiCompositeShaderGL(const std::string& prefix);
 
   void SetProjection(const GLfloat* proj) { m_proj = proj; }
   void SetSdrPeak(float peak) { m_sdrPeak = peak; }

--- a/xbmc/rendering/gl/GuiCompositeShaderGL.h
+++ b/xbmc/rendering/gl/GuiCompositeShaderGL.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "guilib/Shader.h"
+
+class CGuiCompositeShaderGL : public Shaders::CGLSLShaderProgram
+{
+public:
+  CGuiCompositeShaderGL();
+
+  void SetProjection(const GLfloat* proj) { m_proj = proj; }
+  void SetSdrPeak(float peak) { m_sdrPeak = peak; }
+
+  GLint GetPosLoc() { return m_hPos; }
+  GLint GetTexLoc() { return m_hTex; }
+
+protected:
+  void OnCompiledAndLinked() override;
+  bool OnEnabled() override;
+
+private:
+  const GLfloat* m_proj{nullptr};
+  float m_sdrPeak{100.0f / 10000.0f};
+
+  GLint m_hPos{-1};
+  GLint m_hTex{-1};
+  GLint m_hSamp{-1};
+  GLint m_hProj{-1};
+  GLint m_hSdrPeak{-1};
+};

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -262,7 +262,8 @@ bool CRenderSystemGL::BeginRender()
   if (!m_bRenderCreated)
     return false;
 
-  bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor();
+  bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor() &&
+                    !CServiceBroker::GetWinSystem()->IsHdrComposite();
 
   if (m_limitedColorRange != useLimited)
   {
@@ -710,7 +711,8 @@ bool CRenderSystemGL::SupportsStereo(RenderStereoMode mode) const
 void CRenderSystemGL::InitialiseShaders()
 {
   std::string defines;
-  m_limitedColorRange = CServiceBroker::GetWinSystem()->UseLimitedColor();
+  m_limitedColorRange = CServiceBroker::GetWinSystem()->UseLimitedColor() &&
+                        !CServiceBroker::GetWinSystem()->IsHdrComposite();
   if (m_limitedColorRange)
   {
     defines += "#define KODI_LIMITED_RANGE 1\n";

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -15,6 +15,7 @@
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "cores/VideoPlayer/VideoRenderers/LinuxRendererGL.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderFactory.h"
+#include "rendering/gl/GuiCompositeShaderGL.h"
 #include "rendering/gl/ScreenshotSurfaceGL.h"
 #include "utils/BufferObjectFactory.h"
 #include "utils/DMAHeapBufferObject.h"
@@ -203,4 +204,141 @@ bool CWinSystemGbmGLContext::CreateContext()
   }
 
   return true;
+}
+
+bool CWinSystemGbmGLContext::SetGuiCompositing(int colorTransfer)
+{
+  // TODO: add CreateLUTs(colorTransfer) support to GL composite shader to match
+  // GLES (WinSystemGbmGLESContext). Currently GL only handles PQ via pow shader;
+  // HLG and LUT-based PQ are not yet implemented.
+  m_guiCompositing = (colorTransfer != 0);
+
+  if (m_guiCompositing)
+  {
+    if (!m_compositeShader)
+    {
+      m_compositeShader = std::make_unique<CGuiCompositeShaderGL>();
+      if (!m_compositeShader->CompileAndLink())
+      {
+        CLog::Log(LOGERROR, "CWinSystemGbmGLContext: failed to compile GUI composite shader");
+        m_compositeShader.reset();
+        m_guiCompositing = false;
+      }
+    }
+  }
+  else
+  {
+    m_guiFbo.Cleanup();
+    m_guiFboWidth = 0;
+    m_guiFboHeight = 0;
+    m_compositeShader.reset();
+  }
+
+  return m_guiCompositing;
+}
+
+bool CWinSystemGbmGLContext::BeginGuiComposite()
+{
+  if (!m_guiCompositing)
+    return false;
+
+  int width = m_nWidth;
+  int height = m_nHeight;
+
+  if (!m_guiFbo.IsValid() || m_guiFboWidth != width || m_guiFboHeight != height)
+  {
+    m_guiFbo.Cleanup();
+
+    if (!m_guiFbo.Initialize())
+    {
+      CLog::Log(LOGERROR, "CWinSystemGbmGLContext: failed to initialize GUI FBO");
+      return false;
+    }
+
+    if (!m_guiFbo.CreateAndBindToTexture(GL_TEXTURE_2D, width, height, GL_RGBA))
+    {
+      CLog::Log(LOGERROR, "CWinSystemGbmGLContext: failed to create GUI FBO texture {}x{}", width,
+                height);
+      m_guiFbo.Cleanup();
+      return false;
+    }
+
+    m_guiFboWidth = width;
+    m_guiFboHeight = height;
+    CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext: created GUI FBO {}x{}", width, height);
+  }
+
+  if (!m_guiFbo.BeginRender())
+    return false;
+
+  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
+
+  return true;
+}
+
+void CWinSystemGbmGLContext::EndGuiComposite()
+{
+  m_guiFbo.EndRender();
+
+  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+  glClear(GL_COLOR_BUFFER_BIT);
+}
+
+// CompositeGui is the last GL operation in the frame (called just before EndRender).
+// GL state (blend mode, active texture, vertex arrays) is not restored afterward;
+// the next frame's rendering sets its own state.
+void CWinSystemGbmGLContext::CompositeGui()
+{
+  if (!m_guiFbo.IsValid() || !m_guiFbo.IsBound() || !m_compositeShader)
+    return;
+
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D, m_guiFbo.Texture());
+
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+  // set up orthographic projection (screen coords, Y-down)
+  float w = static_cast<float>(m_guiFboWidth);
+  float h = static_cast<float>(m_guiFboHeight);
+
+  GLfloat proj[16] = {2.0f / w, 0, 0, 0, 0, -2.0f / h, 0, 0, 0, 0, -1, 0, -1.0f, 1.0f, 0, 1};
+
+  m_compositeShader->SetProjection(proj);
+  m_compositeShader->SetSdrPeak(100.0f / 10000.0f);
+  m_compositeShader->Enable();
+
+  GLint posLoc = m_compositeShader->GetPosLoc();
+  GLint texLoc = m_compositeShader->GetTexLoc();
+
+  GLfloat vert[4][2] = {{0, 0}, {w, 0}, {w, h}, {0, h}};
+  GLfloat tex[4][2] = {{0, 1}, {1, 1}, {1, 0}, {0, 0}};
+  GLubyte idx[4] = {0, 1, 3, 2};
+
+  GLuint vbo[3];
+  glGenBuffers(3, vbo);
+
+  glBindBuffer(GL_ARRAY_BUFFER, vbo[0]);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(vert), vert, GL_STREAM_DRAW);
+  glVertexAttribPointer(posLoc, 2, GL_FLOAT, GL_FALSE, 0, 0);
+  glEnableVertexAttribArray(posLoc);
+
+  glBindBuffer(GL_ARRAY_BUFFER, vbo[1]);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(tex), tex, GL_STREAM_DRAW);
+  glVertexAttribPointer(texLoc, 2, GL_FLOAT, GL_FALSE, 0, 0);
+  glEnableVertexAttribArray(texLoc);
+
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, vbo[2]);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(idx), idx, GL_STREAM_DRAW);
+
+  glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, 0);
+
+  glDisableVertexAttribArray(posLoc);
+  glDisableVertexAttribArray(texLoc);
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+  glDeleteBuffers(3, vbo);
+
+  m_compositeShader->Disable();
 }

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -309,7 +309,7 @@ void CWinSystemGbmGLContext::CompositeGui()
   GLfloat proj[16] = {2.0f / w, 0, 0, 0, 0, -2.0f / h, 0, 0, 0, 0, -1, 0, -1.0f, 1.0f, 0, 1};
 
   m_compositeShader->SetProjection(proj);
-  m_compositeShader->SetSdrPeak(100.0f / 10000.0f);
+  m_compositeShader->SetSdrPeak(203.0f / 10000.0f);
   m_compositeShader->Enable();
 
   GLint posLoc = m_compositeShader->GetPosLoc();

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -217,7 +217,10 @@ bool CWinSystemGbmGLContext::SetGuiCompositing(int colorTransfer)
   {
     if (!m_compositeShader)
     {
-      m_compositeShader = std::make_unique<CGuiCompositeShaderGL>();
+      std::string defines;
+      if (UseLimitedColor())
+        defines += "#define KODI_LIMITED_RANGE 1\n";
+      m_compositeShader = std::make_unique<CGuiCompositeShaderGL>(defines);
       if (!m_compositeShader->CompileAndLink())
       {
         CLog::Log(LOGERROR, "CWinSystemGbmGLContext: failed to compile GUI composite shader");

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.h
@@ -46,6 +46,7 @@ public:
   bool BeginGuiComposite() override;
   void EndGuiComposite() override;
   void CompositeGui() override;
+  bool IsHdrComposite() const override { return m_guiCompositing; }
 
 protected:
   void SetVSyncImpl(bool enable) override {}

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.h
@@ -9,11 +9,13 @@
 #pragma once
 
 #include "WinSystemGbmEGLContext.h"
+#include "cores/VideoPlayer/VideoRenderers/FrameBufferObject.h"
 #include "rendering/gl/RenderSystemGL.h"
 #include "utils/EGLUtils.h"
 
 #include <memory>
 
+class CGuiCompositeShaderGL;
 class CVaapiProxy;
 
 namespace KODI
@@ -39,10 +41,23 @@ public:
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
   void PresentRender(bool rendered, bool videoLayer) override;
 
+  // GUI compositing for HDR (FBO + sRGB->PQ shader)
+  bool SetGuiCompositing(int colorTransfer) override;
+  bool BeginGuiComposite() override;
+  void EndGuiComposite() override;
+  void CompositeGui() override;
+
 protected:
   void SetVSyncImpl(bool enable) override {}
   void PresentRenderImpl(bool rendered) override {};
   bool CreateContext() override;
+
+private:
+  bool m_guiCompositing{false};
+  CFrameBufferObject m_guiFbo;
+  int m_guiFboWidth{0};
+  int m_guiFboHeight{0};
+  std::unique_ptr<CGuiCompositeShaderGL> m_compositeShader;
 };
 
 } // namespace GBM

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -308,7 +308,16 @@ void CWinSystemGbmGLESContext::CompositeGui()
   glBindTexture(GL_TEXTURE_2D, m_guiFbo.Texture());
 
   glEnable(GL_BLEND);
-  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+  // In D2P, the GUI plane is composited against a separate video plane by
+  // the display HW. The default glBlendFunc also blends the alpha channel,
+  // leaving the GUI plane buffer with src.a^2; the hardware composite then
+  // reads that squared alpha and translucent GUI pixels render at the
+  // wrong opacity. Replace the stored alpha so the hardware sees src.a.
+  if (m_DRM->GetVideoPlane() && m_DRM->GetGuiPlane())
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ZERO);
+  else
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
   // set up orthographic projection (screen coords, Y-down)
   float w = static_cast<float>(m_guiFboWidth);


### PR DESCRIPTION
## Description
FBO compositing of the GUI during HDR playback, as in #28012 and #28029.

## Motivation and context
Proper 10bit HDR support in GBM+GL.  Note that this will not work (is not enabled) with X11 / Wayland.

## How has this been tested?
Linux GBM+GL on Intel N250.

## What is the effect on users?
On standalone (not X11) installs, GUI is properly tonemapped during HDR playback.

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
