### PR TITLE
WinSystemGbm: SetHDR cleanup (transfer check, state cache, blob RAII)

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -230,13 +230,9 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
     }
   }
 
-  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
-      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
-  {
-    m_passthroughHDR = winSystem->SetHDR(&picture);
-    CLog::Log(LOGDEBUG, "RendererDRMPRIMEGLES::Configure: HDR passthrough: {}",
-              m_passthroughHDR ? "on" : "off");
-  }
+  m_passthroughHDR = winSystem->SetHDR(&picture);
+  CLog::Log(LOGDEBUG, "RendererDRMPRIMEGLES::Configure: HDR passthrough: {}",
+            m_passthroughHDR ? "on" : "off");
 
   m_hdrFboActive = m_passthroughHDR && winSystem->SetGuiCompositing(picture.color_transfer);
   if (m_passthroughHDR && !m_hdrFboActive)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -170,14 +170,8 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
 
   const VideoPicture& picture = buffer->GetPicture();
 
-  // Gate HDR passthrough on transfer function, matching the pattern in
-  // LinuxRendererGLES and RendererDRMPRIMEGLES (see smp79's 850dfb04d4).
-  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
-      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
-  {
-    if (winSystem->SetHDR(&picture))
-      winSystem->SetGuiCompositing(picture.color_transfer);
-  }
+  if (winSystem->SetHDR(&picture))
+    winSystem->SetGuiCompositing(picture.color_transfer);
 
   std::optional<uint64_t> colorEncoding =
       plane->GetPropertyEnumValue("COLOR_ENCODING", GetColorEncoding(picture));

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -260,13 +260,9 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
   if (!CServiceBroker::GetWinSystem()->SetVideoOutput(&picture))
     CLog::Log(LOGWARNING, "LinuxRendererGL::Configure: SetVideoOutput failed");
 
-  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
-      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
-  {
-    m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
-    CLog::Log(LOGDEBUG, "LinuxRendererGL::Configure: HDR passthrough: {}",
-              m_passthroughHDR ? "on" : "off");
-  }
+  m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
+  CLog::Log(LOGDEBUG, "LinuxRendererGL::Configure: HDR passthrough: {}",
+            m_passthroughHDR ? "on" : "off");
 
   m_hdrFboActive =
       m_passthroughHDR && CServiceBroker::GetWinSystem()->SetGuiCompositing(picture.color_transfer);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -193,13 +193,9 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
   if (!CServiceBroker::GetWinSystem()->SetVideoOutput(&picture))
     CLog::Log(LOGWARNING, "LinuxRendererGLES::Configure: SetVideoOutput failed");
 
-  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
-      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
-  {
-    m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
-    CLog::Log(LOGDEBUG, "LinuxRendererGLES::Configure: HDR passthrough: {}",
-              m_passthroughHDR ? "on" : "off");
-  }
+  m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
+  CLog::Log(LOGDEBUG, "LinuxRendererGLES::Configure: HDR passthrough: {}",
+            m_passthroughHDR ? "on" : "off");
 
   m_hdrFboActive =
       m_passthroughHDR && CServiceBroker::GetWinSystem()->SetGuiCompositing(picture.color_transfer);

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -421,9 +421,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
       drm->AddProperty(connector, "HDR_OUTPUT_METADATA", 0);
       drm->SetActive(true);
 
-      if (m_hdr_blob_id)
-        drmModeDestroyPropertyBlob(drm->GetFileDescriptor(), m_hdr_blob_id);
-      m_hdr_blob_id = 0;
+      m_hdrBlob.Reset();
     }
 
     m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
@@ -466,9 +464,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
     hdr_metadata.hdmi_metadata_type1.eotf = static_cast<uint8_t>(eotf);
     hdr_metadata.hdmi_metadata_type1.metadata_type = DRMPRIME::HDMI_STATIC_METADATA_TYPE1;
 
-    if (m_hdr_blob_id)
-      drmModeDestroyPropertyBlob(drm->GetFileDescriptor(), m_hdr_blob_id);
-    m_hdr_blob_id = 0;
+    m_hdrBlob.Reset();
 
     if (hdr_metadata.hdmi_metadata_type1.eotf)
     {
@@ -529,15 +525,14 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
                   hdr_metadata.hdmi_metadata_type1.max_fall);
       }
 
-      drmModeCreatePropertyBlob(drm->GetFileDescriptor(), &hdr_metadata, sizeof(hdr_metadata),
-                                &m_hdr_blob_id);
+      m_hdrBlob = CDRMPropertyBlob(drm->GetFileDescriptor(), &hdr_metadata, sizeof(hdr_metadata));
     }
 
-    drm->AddProperty(connector, "HDR_OUTPUT_METADATA", m_hdr_blob_id);
+    drm->AddProperty(connector, "HDR_OUTPUT_METADATA", m_hdrBlob.Get());
     drm->SetActive(true);
   }
 
-  return m_hdr_blob_id != 0;
+  return m_hdrBlob.IsValid();
 }
 
 bool CWinSystemGbm::IsHDRDisplay()

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -429,6 +429,14 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
     return false;
   }
 
+  // Only enable HDR for PQ (HDR10/HDR10+/DV) or HLG transfer functions
+  if (videoPicture->color_transfer != AVCOL_TRC_SMPTE2084 &&
+      videoPicture->color_transfer != AVCOL_TRC_ARIB_STD_B67)
+  {
+    m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
+    return false;
+  }
+
   KODI::UTILS::Colorimetry colorimetry = DRMPRIME::GetColorimetry(*videoPicture);
 
   if (connector->SupportsProperty("Colorspace") && m_info &&

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -426,6 +426,8 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
       m_hdr_blob_id = 0;
     }
 
+    m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
+    m_colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
     return false;
   }
 
@@ -438,6 +440,9 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
   }
 
   KODI::UTILS::Colorimetry colorimetry = DRMPRIME::GetColorimetry(*videoPicture);
+  KODI::UTILS::Eotf eotf = DRMPRIME::GetEOTF(*videoPicture);
+  m_colorimetry = colorimetry;
+  m_eotf = eotf;
 
   if (connector->SupportsProperty("Colorspace") && m_info &&
       m_info->SupportsColorimetry(colorimetry))
@@ -451,8 +456,6 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
       drm->SetActive(true);
     }
   }
-
-  KODI::UTILS::Eotf eotf = DRMPRIME::GetEOTF(*videoPicture);
 
   if (connector->SupportsProperty("HDR_OUTPUT_METADATA") && m_info &&
       m_info->SupportsHDRStaticMetadataType1() && m_info->SupportsEOTF(eotf))

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "VideoLayerBridge.h"
+#include "drm/DRMObject.h"
 #include "drm/DRMUtils.h"
 #include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
@@ -96,7 +97,7 @@ protected:
   std::unique_ptr<CLibInputHandler> m_libinput;
 
 private:
-  uint32_t m_hdr_blob_id = 0;
+  CDRMPropertyBlob m_hdrBlob;
   KODI::UTILS::Eotf m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
   KODI::UTILS::Colorimetry m_colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
 

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -12,6 +12,7 @@
 #include "drm/DRMUtils.h"
 #include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
+#include "utils/DisplayInfo.h"
 #include "windowing/WinSystem.h"
 
 #include "platform/linux/input/LibInputHandler.h"
@@ -61,6 +62,8 @@ public:
 
   bool SetVideoOutput(const VideoPicture* videoPicture) override;
 
+  KODI::UTILS::Colorimetry GetColorimetry() const { return m_colorimetry; }
+  KODI::UTILS::Eotf GetEotf() const { return m_eotf; }
   bool SetHDR(const VideoPicture* videoPicture) override;
   bool IsHDRDisplay() override;
   CHDRCapabilities GetDisplayHDRCapabilities() const override;
@@ -94,6 +97,8 @@ protected:
 
 private:
   uint32_t m_hdr_blob_id = 0;
+  KODI::UTILS::Eotf m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
+  KODI::UTILS::Colorimetry m_colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
 
   std::unique_ptr<UTILS::CDisplayInfo> m_info;
 };


### PR DESCRIPTION
## Description
Three cleanups to `CWinSystemGbm::SetHDR` that consolidate scattered HDR logic into the windowing system and remove a small blob leak.

Required for followon Colorimetry fixes in #28338 

1. **`WinSystemGbm: move HDR transfer function check into SetHDR`** -- The PQ/HLG `color_transfer` check used to live in each renderer that called `SetHDR`. Some renderers checked it, others (notably the DRMPRIME bridge) called `SetHDR` unconditionally. Move the check into `SetHDR` itself so it returns `false` early for non-HDR content. Callers now use the return value directly and no longer need to duplicate the transfer-function gate.

2. **`WinSystemGbm: cache EOTF and colorimetry in SetHDR`** -- Store the currently-active EOTF and colorimetry as members of `CWinSystemGbm` when `SetHDR` is called. Lets other components (e.g. screenshot capture, info-label reporting) query the active HDR state without reading back DRM connector properties.

3. **`GBM: use CDRMPropertyBlob for HDR_OUTPUT_METADATA`** -- Replace the hand-rolled `drmModeCreate` / `DestroyPropertyBlob` pair around `m_hdr_blob_id` with `CDRMPropertyBlob m_hdrBlob`. Collapses the destroy-old / create-new dance into a single move-assignment in `SetHDR`, removes two copies of error-check boilerplate, and fixes a pre-existing blob leak on winsystem shutdown (the hand-rolled member was never destroyed in `CWinSystemGbm` destructor). Same lifetime semantics as before.


## Motivation and context
`CWinSystemGbm::SetHDR` accumulated complexity over time: callers had to remember to gate on `color_transfer`, the active HDR state was only readable by querying DRM, and the property-blob lifetime was managed
by hand with no RAII. This PR doesn't change runtime behavior (other than fixing the shutdown leak) -- it makes the function easier to read and harder to misuse.

## How has this been tested?
Tested on Intel N250 (ADL-N) GBM/DRM with native HDMI 2.0 and
DP-1.4a-to-HDMI dongle paths. HDR PQ and HLG content via
inputstream.testpattern and ffmpeg HEVC HDR files; SDR content for
the non-HDR early-return path.

- HDR start: same DRM HDR_OUTPUT_METADATA blob set as before
- HDR stop: blob cleared, GUI returns to SDR
- Repeated start/stop cycles: no leaks (verified with kernel-side
  blob ID accounting)
- SDR content: SetHDR returns false, no DRM properties touched
- Kodi shutdown during HDR playback: blob now properly destroyed
  (previously leaked)

## What is the effect on users?
No user-visible behavior change. Internal cleanup; fixes a minor blob leak on Kodi shutdown during HDR playback that had no observable impact in practice.

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
