### PR TITLE
GBM HDR and Colorimetry cleanup

### DIFF
--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
@@ -20,19 +20,6 @@ extern "C"
 namespace DRMPRIME
 {
 
-KODI::UTILS::Colorimetry GetColorimetry(const VideoPicture& picture)
-{
-  switch (picture.color_space)
-  {
-    case AVCOL_SPC_BT2020_CL:
-      return KODI::UTILS::Colorimetry::BT2020_CYCC;
-    case AVCOL_SPC_BT2020_NCL:
-      return KODI::UTILS::Colorimetry::BT2020_YCC;
-    default:
-      return KODI::UTILS::Colorimetry::DEFAULT;
-  }
-}
-
 std::string GetColorEncoding(const VideoPicture& picture)
 {
   switch (picture.color_space)
@@ -61,30 +48,6 @@ std::string GetColorRange(const VideoPicture& picture)
   if (picture.color_range)
     return "YCbCr full range";
   return "YCbCr limited range";
-}
-
-KODI::UTILS::Eotf GetEOTF(const VideoPicture& picture)
-{
-  switch (picture.color_transfer)
-  {
-    case AVCOL_TRC_SMPTE2084:
-      return KODI::UTILS::Eotf::PQ;
-    case AVCOL_TRC_ARIB_STD_B67:
-    case AVCOL_TRC_BT2020_10:
-      return KODI::UTILS::Eotf::HLG;
-    default:
-      return KODI::UTILS::Eotf::TRADITIONAL_SDR;
-  }
-}
-
-const AVMasteringDisplayMetadata* GetMasteringDisplayMetadata(const VideoPicture& picture)
-{
-  return picture.hasDisplayMetadata ? &picture.displayMetadata : nullptr;
-}
-
-const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& picture)
-{
-  return picture.hasLightMetadata ? &picture.lightMetadata : nullptr;
 }
 
 } // namespace DRMPRIME

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
@@ -10,37 +10,18 @@
 
 #include "cores/VideoPlayer/Buffers/VideoBuffer.h"
 #include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
-#include "utils/DisplayInfo.h"
 
 extern "C"
 {
 #include <libavutil/frame.h>
 #include <libavutil/hwcontext_drm.h>
-#include <libavutil/mastering_display_metadata.h>
 }
 
 namespace DRMPRIME
 {
 
-// HDR enums is copied from linux include/linux/hdmi.h (strangely not part of uapi)
-enum hdmi_metadata_type
-{
-  HDMI_STATIC_METADATA_TYPE1 = 0,
-};
-enum hdmi_eotf
-{
-  HDMI_EOTF_TRADITIONAL_GAMMA_SDR,
-  HDMI_EOTF_TRADITIONAL_GAMMA_HDR,
-  HDMI_EOTF_SMPTE_ST2084,
-  HDMI_EOTF_BT_2100_HLG,
-};
-
-KODI::UTILS::Colorimetry GetColorimetry(const VideoPicture& picture);
 std::string GetColorEncoding(const VideoPicture& picture);
 std::string GetColorRange(const VideoPicture& picture);
-KODI::UTILS::Eotf GetEOTF(const VideoPicture& picture);
-const AVMasteringDisplayMetadata* GetMasteringDisplayMetadata(const VideoPicture& picture);
-const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& picture);
 
 } // namespace DRMPRIME
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -33,6 +33,7 @@ CRendererDRMPRIME::~CRendererDRMPRIME()
   // the GUI after playback falls back to Default / SDR.
   if (auto* winSystem = CServiceBroker::GetWinSystem())
   {
+    winSystem->SetGuiCompositing(false);
     winSystem->SetHDR(nullptr);
     winSystem->SetColorimetry(nullptr);
   }
@@ -121,7 +122,16 @@ bool CRendererDRMPRIME::Configure(const VideoPicture& picture, float fps, unsign
   if (auto* winSystem = CServiceBroker::GetWinSystem())
   {
     winSystem->SetColorimetry(&picture);
-    winSystem->SetHDR(&picture);
+
+    const bool passthroughHDR = winSystem->SetHDR(&picture);
+    CLog::Log(LOGDEBUG, "CRendererDRMPRIME::Configure: HDR passthrough: {}",
+              passthroughHDR ? "on" : "off");
+
+    const bool hdrFboActive =
+        passthroughHDR && winSystem->SetGuiCompositing(picture.color_transfer);
+    if (passthroughHDR && !hdrFboActive)
+      CLog::Log(LOGWARNING, "CRendererDRMPRIME::Configure: HDR passthrough active but "
+                            "GUI compositing not supported by windowing system");
   }
 
   // Calculate the input frame aspect ratio.

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -29,6 +29,13 @@ using namespace KODI::WINDOWING::GBM;
 CRendererDRMPRIME::~CRendererDRMPRIME()
 {
   Flush(false);
+  // Clear the scanout colorspace and HDR metadata set during Configure so
+  // the GUI after playback falls back to Default / SDR.
+  if (auto* winSystem = CServiceBroker::GetWinSystem())
+  {
+    winSystem->SetHDR(nullptr);
+    winSystem->SetColorimetry(nullptr);
+  }
 }
 
 CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)
@@ -107,6 +114,15 @@ bool CRendererDRMPRIME::Configure(const VideoPicture& picture, float fps, unsign
              GetFlagsColorMatrix(picture.color_space, picture.iWidth, picture.iHeight) |
              GetFlagsColorPrimaries(picture.color_primaries) |
              GetFlagsStereoMode(picture.stereoMode);
+
+  // Signal source colorimetry and HDR metadata on the scanout via the DRM
+  // Colorspace and HDR_OUTPUT_METADATA connector properties. The direct-to-
+  // plane scanout path bypasses GL video rendering entirely.
+  if (auto* winSystem = CServiceBroker::GetWinSystem())
+  {
+    winSystem->SetColorimetry(&picture);
+    winSystem->SetHDR(&picture);
+  }
 
   // Calculate the input frame aspect ratio.
   CalculateFrameAspectRatio(picture.iDisplayWidth, picture.iDisplayHeight);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -230,6 +230,7 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
     }
   }
 
+  winSystem->SetColorimetry(&picture);
   m_passthroughHDR = winSystem->SetHDR(&picture);
   CLog::Log(LOGDEBUG, "RendererDRMPRIMEGLES::Configure: HDR passthrough: {}",
             m_passthroughHDR ? "on" : "off");
@@ -257,6 +258,7 @@ void CRendererDRMPRIMEGLES::UnInit()
     CServiceBroker::GetWinSystem()->SetGuiCompositing(false);
     CServiceBroker::GetWinSystem()->SetHDR(nullptr);
     m_passthroughHDR = false;
+    CServiceBroker::GetWinSystem()->SetColorimetry(nullptr);
     CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -230,13 +230,9 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
     }
   }
 
-  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
-      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
-  {
-    m_passthroughHDR = winSystem->SetHDR(&picture);
-    CLog::Log(LOGDEBUG, "RendererDRMPRIMEGLES::Configure: HDR passthrough: {}",
-              m_passthroughHDR ? "on" : "off");
-  }
+  m_passthroughHDR = winSystem->SetHDR(&picture);
+  CLog::Log(LOGDEBUG, "RendererDRMPRIMEGLES::Configure: HDR passthrough: {}",
+            m_passthroughHDR ? "on" : "off");
 
   m_hdrFboActive = m_passthroughHDR && winSystem->SetGuiCompositing(picture.color_transfer);
   if (m_passthroughHDR && !m_hdrFboActive)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -170,14 +170,8 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
 
   const VideoPicture& picture = buffer->GetPicture();
 
-  // Gate HDR passthrough on transfer function, matching the pattern in
-  // LinuxRendererGLES and RendererDRMPRIMEGLES (see smp79's 850dfb04d4).
-  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
-      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
-  {
-    if (winSystem->SetHDR(&picture))
-      winSystem->SetGuiCompositing(picture.color_transfer);
-  }
+  if (winSystem->SetHDR(&picture))
+    winSystem->SetGuiCompositing(picture.color_transfer);
 
   std::optional<uint64_t> colorEncoding =
       plane->GetPropertyEnumValue("COLOR_ENCODING", GetColorEncoding(picture));

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -39,14 +39,6 @@ void CVideoLayerBridgeDRMPRIME::Disable()
   // disable video plane
   m_DRM->AddProperty(plane, "FB_ID", 0);
   m_DRM->AddProperty(plane, "CRTC_ID", 0);
-
-  auto winSystem = CServiceBroker::GetWinSystem();
-  if (!winSystem)
-    return;
-
-  // disable HDR metadata and GUI compositing
-  winSystem->SetHDR(nullptr);
-  winSystem->SetGuiCompositing(false);
 }
 
 void CVideoLayerBridgeDRMPRIME::Acquire(CVideoBufferDRMPRIME* buffer)
@@ -164,14 +156,7 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
   if (!plane)
     return;
 
-  auto winSystem = CServiceBroker::GetWinSystem();
-  if (!winSystem)
-    return;
-
   const VideoPicture& picture = buffer->GetPicture();
-
-  if (winSystem->SetHDR(&picture))
-    winSystem->SetGuiCompositing(picture.color_transfer);
 
   std::optional<uint64_t> colorEncoding =
       plane->GetPropertyEnumValue("COLOR_ENCODING", GetColorEncoding(picture));

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -260,6 +260,8 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
   if (!CServiceBroker::GetWinSystem()->SetVideoOutput(&picture))
     CLog::Log(LOGWARNING, "LinuxRendererGL::Configure: SetVideoOutput failed");
 
+  CServiceBroker::GetWinSystem()->SetColorimetry(&picture);
+
   m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
   CLog::Log(LOGDEBUG, "LinuxRendererGL::Configure: HDR passthrough: {}",
             m_passthroughHDR ? "on" : "off");
@@ -1081,6 +1083,7 @@ void CLinuxRendererGL::UnInit()
     CServiceBroker::GetWinSystem()->SetGuiCompositing(false);
     CServiceBroker::GetWinSystem()->SetHDR(nullptr);
     m_passthroughHDR = false;
+    CServiceBroker::GetWinSystem()->SetColorimetry(nullptr);
     CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -260,13 +260,9 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
   if (!CServiceBroker::GetWinSystem()->SetVideoOutput(&picture))
     CLog::Log(LOGWARNING, "LinuxRendererGL::Configure: SetVideoOutput failed");
 
-  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
-      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
-  {
-    m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
-    CLog::Log(LOGDEBUG, "LinuxRendererGL::Configure: HDR passthrough: {}",
-              m_passthroughHDR ? "on" : "off");
-  }
+  m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
+  CLog::Log(LOGDEBUG, "LinuxRendererGL::Configure: HDR passthrough: {}",
+            m_passthroughHDR ? "on" : "off");
 
   m_hdrFboActive =
       m_passthroughHDR && CServiceBroker::GetWinSystem()->SetGuiCompositing(picture.color_transfer);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -193,6 +193,8 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
   if (!CServiceBroker::GetWinSystem()->SetVideoOutput(&picture))
     CLog::Log(LOGWARNING, "LinuxRendererGLES::Configure: SetVideoOutput failed");
 
+  CServiceBroker::GetWinSystem()->SetColorimetry(&picture);
+
   m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
   CLog::Log(LOGDEBUG, "LinuxRendererGLES::Configure: HDR passthrough: {}",
             m_passthroughHDR ? "on" : "off");
@@ -1040,6 +1042,7 @@ void CLinuxRendererGLES::UnInit()
     CServiceBroker::GetWinSystem()->SetGuiCompositing(false);
     CServiceBroker::GetWinSystem()->SetHDR(nullptr);
     m_passthroughHDR = false;
+    CServiceBroker::GetWinSystem()->SetColorimetry(nullptr);
     CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -27,6 +27,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/GLUtils.h"
+#include "utils/HDRUtils.h"
 #include "utils/MathUtils.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
@@ -166,7 +167,13 @@ bool CLinuxRendererGLES::ValidateRenderTarget()
 
 bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsigned int orientation)
 {
-  CLog::Log(LOGDEBUG, "LinuxRendererGLES::Configure: fps: {:0.3f}", fps);
+  auto colorimetry = KODI::UTILS::GetColorimetry(picture);
+  bool inferred = (picture.color_space == AVCOL_SPC_UNSPECIFIED);
+  CLog::Log(LOGDEBUG,
+            "LinuxRendererGLES::Configure: fps: {:0.3f}, {}x{}, colorimetry: {}{}, {}bit, {} range",
+            fps, picture.iWidth, picture.iHeight, KODI::UTILS::ColorimetryToString(colorimetry),
+            inferred ? " (inferred)" : "", picture.colorBits,
+            picture.color_range == 1 ? "full" : "limited");
   m_format = picture.videoBuffer->GetFormat();
   m_sourceWidth = picture.iWidth;
   m_sourceHeight = picture.iHeight;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -193,13 +193,9 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
   if (!CServiceBroker::GetWinSystem()->SetVideoOutput(&picture))
     CLog::Log(LOGWARNING, "LinuxRendererGLES::Configure: SetVideoOutput failed");
 
-  if (picture.color_transfer == AVCOL_TRC_SMPTE2084 ||
-      picture.color_transfer == AVCOL_TRC_ARIB_STD_B67)
-  {
-    m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
-    CLog::Log(LOGDEBUG, "LinuxRendererGLES::Configure: HDR passthrough: {}",
-              m_passthroughHDR ? "on" : "off");
-  }
+  m_passthroughHDR = CServiceBroker::GetWinSystem()->SetHDR(&picture);
+  CLog::Log(LOGDEBUG, "LinuxRendererGLES::Configure: HDR passthrough: {}",
+            m_passthroughHDR ? "on" : "off");
 
   m_hdrFboActive =
       m_passthroughHDR && CServiceBroker::GetWinSystem()->SetGuiCompositing(picture.color_transfer);

--- a/xbmc/utils/CMakeLists.txt
+++ b/xbmc/utils/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SOURCES ActorProtocol.cpp
             FontUtils.cpp
             GpuInfo.cpp
             GroupUtils.cpp
+            HDRUtils.cpp
             HevcSei.cpp
             HTMLUtil.cpp
             HttpHeader.cpp
@@ -118,6 +119,7 @@ set(HEADERS ActorProtocol.h
             GpuInfo.h
             GroupUtils.h
             HDRCapabilities.h
+            HDRUtils.h
             HevcSei.h
             HTMLUtil.h
             HttpHeader.h

--- a/xbmc/utils/DisplayInfo.cpp
+++ b/xbmc/utils/DisplayInfo.cpp
@@ -202,6 +202,9 @@ bool CDisplayInfo::SupportsColorimetry(Colorimetry colorimetry) const
 
   switch (colorimetry)
   {
+    case Colorimetry::SMPTE_170M_YCC:
+    case Colorimetry::BT709_YCC:
+      return true; // baseline HDMI, all sinks support these
     case Colorimetry::XVYCC_601:
       return m_colorimetry->xvycc_601;
     case Colorimetry::XVYCC_709:

--- a/xbmc/utils/DisplayInfo.h
+++ b/xbmc/utils/DisplayInfo.h
@@ -32,15 +32,24 @@ enum class Eotf
 
 enum class Colorimetry
 {
+  // DRM order (DRM_MODE_COLORIMETRY_*)
   DEFAULT,
+  SMPTE_170M_YCC,
+  BT709_YCC,
   XVYCC_601,
   XVYCC_709,
   SYCC_601,
   OPYCC_601,
   OPRGB,
   BT2020_CYCC,
-  BT2020_YCC,
   BT2020_RGB,
+  BT2020_YCC,
+  DCI_P3_RGB_D65,
+  DCI_P3_RGB_THEATER,
+  RGB_WIDE_FIXED,
+  RGB_WIDE_FLOAT,
+  BT601_YCC,
+  // CTA-861 only (not in DRM)
   ST2113_RGB,
   ICTCP,
 };

--- a/xbmc/utils/HDRUtils.cpp
+++ b/xbmc/utils/HDRUtils.cpp
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (C) 2017-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "HDRUtils.h"
+
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+}
+
+namespace KODI
+{
+namespace UTILS
+{
+
+Colorimetry GetColorimetry(const VideoPicture& picture)
+{
+  switch (picture.color_space)
+  {
+    case AVCOL_SPC_BT2020_CL:
+      return Colorimetry::BT2020_CYCC;
+    case AVCOL_SPC_BT2020_NCL:
+      return Colorimetry::BT2020_YCC;
+    case AVCOL_SPC_BT709:
+      return Colorimetry::BT709_YCC;
+    case AVCOL_SPC_SMPTE170M:
+    case AVCOL_SPC_BT470BG:
+      return Colorimetry::SMPTE_170M_YCC;
+    default:
+      return Colorimetry::DEFAULT;
+  }
+}
+
+Eotf GetEOTF(const VideoPicture& picture)
+{
+  switch (picture.color_transfer)
+  {
+    case AVCOL_TRC_SMPTE2084:
+      return Eotf::PQ;
+    case AVCOL_TRC_ARIB_STD_B67:
+    case AVCOL_TRC_BT2020_10:
+      return Eotf::HLG;
+    default:
+      return Eotf::TRADITIONAL_SDR;
+  }
+}
+
+const AVMasteringDisplayMetadata* GetMasteringDisplayMetadata(const VideoPicture& picture)
+{
+  return picture.hasDisplayMetadata ? &picture.displayMetadata : nullptr;
+}
+
+const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& picture)
+{
+  return picture.hasLightMetadata ? &picture.lightMetadata : nullptr;
+}
+
+} // namespace UTILS
+} // namespace KODI

--- a/xbmc/utils/HDRUtils.cpp
+++ b/xbmc/utils/HDRUtils.cpp
@@ -32,7 +32,56 @@ Colorimetry GetColorimetry(const VideoPicture& picture)
     case AVCOL_SPC_BT470BG:
       return Colorimetry::SMPTE_170M_YCC;
     default:
-      return Colorimetry::DEFAULT;
+      if (picture.iWidth > 1024 || picture.iHeight >= 600)
+        return Colorimetry::BT709_YCC;
+      else
+        return Colorimetry::SMPTE_170M_YCC;
+  }
+}
+
+const char* ColorimetryToString(Colorimetry colorimetry)
+{
+  // DRM connector "Colorspace" property strings from drm_connector.c
+  switch (colorimetry)
+  {
+    case Colorimetry::DEFAULT:
+      return "Default";
+    case Colorimetry::SMPTE_170M_YCC:
+      return "SMPTE_170M_YCC";
+    case Colorimetry::BT709_YCC:
+      return "BT709_YCC";
+    case Colorimetry::XVYCC_601:
+      return "XVYCC_601";
+    case Colorimetry::XVYCC_709:
+      return "XVYCC_709";
+    case Colorimetry::SYCC_601:
+      return "SYCC_601";
+    case Colorimetry::OPYCC_601:
+      return "opYCC_601";
+    case Colorimetry::OPRGB:
+      return "opRGB";
+    case Colorimetry::BT2020_CYCC:
+      return "BT2020_CYCC";
+    case Colorimetry::BT2020_RGB:
+      return "BT2020_RGB";
+    case Colorimetry::BT2020_YCC:
+      return "BT2020_YCC";
+    case Colorimetry::DCI_P3_RGB_D65:
+      return "DCI-P3_RGB_D65";
+    case Colorimetry::DCI_P3_RGB_THEATER:
+      return "DCI-P3_RGB_Theater";
+    case Colorimetry::RGB_WIDE_FIXED:
+      return "RGB_WIDE_FIXED";
+    case Colorimetry::RGB_WIDE_FLOAT:
+      return "RGB_WIDE_FLOAT";
+    case Colorimetry::BT601_YCC:
+      return "BT601_YCC";
+    case Colorimetry::ST2113_RGB:
+      return "ST2113_RGB";
+    case Colorimetry::ICTCP:
+      return "ICtCp";
+    default:
+      return "Default";
   }
 }
 

--- a/xbmc/utils/HDRUtils.h
+++ b/xbmc/utils/HDRUtils.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2017-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h"
+#include "utils/DisplayInfo.h"
+
+extern "C"
+{
+#include <libavutil/mastering_display_metadata.h>
+}
+
+namespace KODI
+{
+namespace UTILS
+{
+
+// HDR enums copied from linux include/linux/hdmi.h (not part of uapi)
+enum hdmi_metadata_type
+{
+  HDMI_STATIC_METADATA_TYPE1 = 0,
+};
+
+Colorimetry GetColorimetry(const VideoPicture& picture);
+Eotf GetEOTF(const VideoPicture& picture);
+const AVMasteringDisplayMetadata* GetMasteringDisplayMetadata(const VideoPicture& picture);
+const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& picture);
+
+} // namespace UTILS
+} // namespace KODI

--- a/xbmc/utils/HDRUtils.h
+++ b/xbmc/utils/HDRUtils.h
@@ -28,6 +28,7 @@ enum hdmi_metadata_type
 };
 
 Colorimetry GetColorimetry(const VideoPicture& picture);
+const char* ColorimetryToString(Colorimetry colorimetry);
 Eotf GetEOTF(const VideoPicture& picture);
 const AVMasteringDisplayMetadata* GetMasteringDisplayMetadata(const VideoPicture& picture);
 const AVContentLightMetadata* GetContentLightMetadata(const VideoPicture& picture);

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -227,6 +227,13 @@ public:
   virtual bool SetVideoOutput(const VideoPicture* videoPicture) { return false; }
 
   /*!
+   * \brief Set colorimetry (BT.709, BT.2020, etc). Passing nullptr as the
+   * parameter resets to "Default" (display then decides based on rez)
+   *
+   */
+  virtual void SetColorimetry(const VideoPicture* videoPicture) {}
+
+  /*!
    * \brief Set the HDR metadata. Passing nullptr as the parameter should
    * disable HDR.
    *

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -421,9 +421,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
       drm->AddProperty(connector, "HDR_OUTPUT_METADATA", 0);
       drm->SetActive(true);
 
-      if (m_hdr_blob_id)
-        drmModeDestroyPropertyBlob(drm->GetFileDescriptor(), m_hdr_blob_id);
-      m_hdr_blob_id = 0;
+      m_hdrBlob.Reset();
     }
 
     m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
@@ -466,9 +464,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
     hdr_metadata.hdmi_metadata_type1.eotf = static_cast<uint8_t>(eotf);
     hdr_metadata.hdmi_metadata_type1.metadata_type = DRMPRIME::HDMI_STATIC_METADATA_TYPE1;
 
-    if (m_hdr_blob_id)
-      drmModeDestroyPropertyBlob(drm->GetFileDescriptor(), m_hdr_blob_id);
-    m_hdr_blob_id = 0;
+    m_hdrBlob.Reset();
 
     if (hdr_metadata.hdmi_metadata_type1.eotf)
     {
@@ -529,15 +525,14 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
                   hdr_metadata.hdmi_metadata_type1.max_fall);
       }
 
-      drmModeCreatePropertyBlob(drm->GetFileDescriptor(), &hdr_metadata, sizeof(hdr_metadata),
-                                &m_hdr_blob_id);
+      m_hdrBlob = CDRMPropertyBlob(drm->GetFileDescriptor(), &hdr_metadata, sizeof(hdr_metadata));
     }
 
-    drm->AddProperty(connector, "HDR_OUTPUT_METADATA", m_hdr_blob_id);
+    drm->AddProperty(connector, "HDR_OUTPUT_METADATA", m_hdrBlob.Get());
     drm->SetActive(true);
   }
 
-  return m_hdr_blob_id != 0;
+  return m_hdrBlob.IsValid();
 }
 
 bool CWinSystemGbm::IsHDRDisplay()

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -73,14 +73,21 @@ namespace
 
 constexpr auto ColorimetryMap = make_map<KODI::UTILS::Colorimetry, std::string_view>({
     {KODI::UTILS::Colorimetry::DEFAULT, "Default"},
+    {KODI::UTILS::Colorimetry::SMPTE_170M_YCC, "SMPTE_170M_YCC"},
+    {KODI::UTILS::Colorimetry::BT709_YCC, "BT709_YCC"},
     {KODI::UTILS::Colorimetry::XVYCC_601, "XVYCC_601"},
     {KODI::UTILS::Colorimetry::XVYCC_709, "XVYCC_709"},
     {KODI::UTILS::Colorimetry::SYCC_601, "SYCC_601"},
     {KODI::UTILS::Colorimetry::OPYCC_601, "opYCC_601"},
     {KODI::UTILS::Colorimetry::OPRGB, "opRGB"},
     {KODI::UTILS::Colorimetry::BT2020_CYCC, "BT2020_CYCC"},
-    {KODI::UTILS::Colorimetry::BT2020_YCC, "BT2020_YCC"},
     {KODI::UTILS::Colorimetry::BT2020_RGB, "BT2020_RGB"},
+    {KODI::UTILS::Colorimetry::BT2020_YCC, "BT2020_YCC"},
+    {KODI::UTILS::Colorimetry::DCI_P3_RGB_D65, "DCI-P3_RGB_D65"},
+    {KODI::UTILS::Colorimetry::DCI_P3_RGB_THEATER, "DCI-P3_RGB_Theater"},
+    {KODI::UTILS::Colorimetry::RGB_WIDE_FIXED, "RGB_WIDE_FIXED"},
+    {KODI::UTILS::Colorimetry::RGB_WIDE_FLOAT, "RGB_WIDE_FLOAT"},
+    {KODI::UTILS::Colorimetry::BT601_YCC, "BT601_YCC"},
     {KODI::UTILS::Colorimetry::ST2113_RGB, "Default"},
     {KODI::UTILS::Colorimetry::ICTCP, "Default"},
 });
@@ -165,6 +172,9 @@ bool CWinSystemGbm::InitWindowSystem()
     return false;
   }
 
+  SetColorimetry(nullptr);
+  SetHDR(nullptr);
+
   auto settingsComponent = CServiceBroker::GetSettingsComponent();
   if (!settingsComponent)
     return false;
@@ -173,7 +183,7 @@ bool CWinSystemGbm::InitWindowSystem()
   if (!settings)
     return false;
 
-  auto setting = settings->GetSetting(CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE);
+  auto setting = settings->GetSetting("videoscreen.limitguisize");
   if (setting)
     setting->SetVisible(true);
 
@@ -382,6 +392,62 @@ bool CWinSystemGbm::SetVideoOutput(const VideoPicture* videoPicture)
                       : m_DRM->FindGuiPlane(current->GetFormat(), current->GetModifier());
 }
 
+void CWinSystemGbm::SetColorimetry(const VideoPicture* videoPicture)
+{
+  auto drm = std::dynamic_pointer_cast<CDRMAtomic>(m_DRM);
+  if (!drm)
+    return;
+
+  auto connector = drm->GetConnector();
+  if (!connector || !connector->SupportsProperty("Colorspace"))
+    return;
+
+  KODI::UTILS::Colorimetry colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
+
+  if (videoPicture)
+    colorimetry = KODI::UTILS::GetColorimetry(*videoPicture);
+
+  m_colorimetry = colorimetry;
+
+  // The DRM Colorspace connector property controls what colorimetry tag the
+  // driver transmits in the HDMI AVI InfoFrame (or DisplayPort VSC SDP). The
+  // transmitted tag must match the pixel encoding actually on the wire.
+  // Kodi scans out to an RGB primary plane (XR24/XR30/AB4H), so we must pick
+  // an RGB-variant Colorspace. Signaling YCC while sending RGB causes most
+  // DP-to-HDMI bridges (incl. LSPCON) to misinterpret the signal.
+  //
+  // The CTA-861 standard (used by both HDMI and DisplayPort for colorimetry
+  // signaling) defines explicit RGB variants only for wide-gamut spaces
+  // (BT.2020_RGB, DCI-P3_RGB). BT.709 RGB and BT.601 RGB are signaled via
+  // "Default", with the sink inferring primaries from the transmitted mode
+  // (HD resolution -> BT.709, SD resolution -> BT.601).
+  KODI::UTILS::Colorimetry scanoutColorimetry;
+  switch (colorimetry)
+  {
+    case KODI::UTILS::Colorimetry::BT2020_YCC:
+    case KODI::UTILS::Colorimetry::BT2020_CYCC:
+      scanoutColorimetry = KODI::UTILS::Colorimetry::BT2020_RGB;
+      break;
+    default:
+      // BT709_YCC, SMPTE_170M_YCC, and all other YCC variants map to Default,
+      // which signals sRGB/BT.709 RGB (HD) or BT.601 RGB (SD) based on the
+      // transmitted resolution.
+      scanoutColorimetry = KODI::UTILS::Colorimetry::DEFAULT;
+      break;
+  }
+
+  std::optional<uint64_t> colorspace =
+      connector->GetPropertyEnumValue("Colorspace", ColorimetryMap.at(scanoutColorimetry));
+  if (colorspace)
+  {
+    CLog::LogF(LOGDEBUG, "setting connector colorspace to {} (source {})",
+               KODI::UTILS::ColorimetryToString(scanoutColorimetry),
+               KODI::UTILS::ColorimetryToString(colorimetry));
+    drm->AddProperty(connector, "Colorspace", colorspace.value());
+    drm->SetActive(true);
+  }
+}
+
 bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
 {
   auto settingsComponent = CServiceBroker::GetSettingsComponent();
@@ -405,19 +471,9 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
 
   if (!videoPicture)
   {
-    if (connector->SupportsProperty("Colorspace"))
-    {
-      std::optional<uint64_t> colorspace = connector->GetPropertyEnumValue("Colorspace", "Default");
-      if (colorspace)
-      {
-        CLog::LogF(LOGDEBUG, "setting connector colorspace to Default");
-        drm->AddProperty(connector, "Colorspace", colorspace.value());
-        drm->SetActive(true);
-      }
-    }
-
     if (connector->SupportsProperty("HDR_OUTPUT_METADATA"))
     {
+      CLog::LogF(LOGDEBUG, "clearing HDR_OUTPUT_METADATA");
       drm->AddProperty(connector, "HDR_OUTPUT_METADATA", 0);
       drm->SetActive(true);
 
@@ -425,7 +481,6 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
     }
 
     m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
-    m_colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
     return false;
   }
 
@@ -437,23 +492,8 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
     return false;
   }
 
-  KODI::UTILS::Colorimetry colorimetry = KODI::UTILS::GetColorimetry(*videoPicture);
   KODI::UTILS::Eotf eotf = KODI::UTILS::GetEOTF(*videoPicture);
-  m_colorimetry = colorimetry;
   m_eotf = eotf;
-
-  if (connector->SupportsProperty("Colorspace") && m_info &&
-      m_info->SupportsColorimetry(colorimetry))
-  {
-    std::optional<uint64_t> colorspace =
-        connector->GetPropertyEnumValue("Colorspace", ColorimetryMap.at(colorimetry));
-    if (colorspace)
-    {
-      CLog::LogF(LOGDEBUG, "setting connector colorspace to {}", ColorimetryMap.at(colorimetry));
-      drm->AddProperty(connector, "Colorspace", colorspace.value());
-      drm->SetActive(true);
-    }
-  }
 
   if (connector->SupportsProperty("HDR_OUTPUT_METADATA") && m_info &&
       m_info->SupportsHDRStaticMetadataType1() && m_info->SupportsEOTF(eotf))

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -429,6 +429,14 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
     return false;
   }
 
+  // Only enable HDR for PQ (HDR10/HDR10+/DV) or HLG transfer functions
+  if (videoPicture->color_transfer != AVCOL_TRC_SMPTE2084 &&
+      videoPicture->color_transfer != AVCOL_TRC_ARIB_STD_B67)
+  {
+    m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
+    return false;
+  }
+
   KODI::UTILS::Colorimetry colorimetry = DRMPRIME::GetColorimetry(*videoPicture);
 
   if (connector->SupportsProperty("Colorspace") && m_info &&

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -426,6 +426,8 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
       m_hdr_blob_id = 0;
     }
 
+    m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
+    m_colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
     return false;
   }
 
@@ -438,6 +440,9 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
   }
 
   KODI::UTILS::Colorimetry colorimetry = DRMPRIME::GetColorimetry(*videoPicture);
+  KODI::UTILS::Eotf eotf = DRMPRIME::GetEOTF(*videoPicture);
+  m_colorimetry = colorimetry;
+  m_eotf = eotf;
 
   if (connector->SupportsProperty("Colorspace") && m_info &&
       m_info->SupportsColorimetry(colorimetry))
@@ -451,8 +456,6 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
       drm->SetActive(true);
     }
   }
-
-  KODI::UTILS::Eotf eotf = DRMPRIME::GetEOTF(*videoPicture);
 
   if (connector->SupportsProperty("HDR_OUTPUT_METADATA") && m_info &&
       m_info->SupportsHDRStaticMetadataType1() && m_info->SupportsEOTF(eotf))

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -12,7 +12,6 @@
 #include "OptionalsReg.h"
 #include "ServiceBroker.h"
 #include "VideoSyncGbm.h"
-#include "cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h"
 #include "cores/VideoPlayer/VideoReferenceClock.h"
 #include "drm/DRMAtomic.h"
 #include "drm/DRMLegacy.h"
@@ -24,6 +23,7 @@
 #include "settings/lib/Setting.h"
 #include "utils/DRMHelpers.h"
 #include "utils/DisplayInfo.h"
+#include "utils/HDRUtils.h"
 #include "utils/Map.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
@@ -437,8 +437,8 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
     return false;
   }
 
-  KODI::UTILS::Colorimetry colorimetry = DRMPRIME::GetColorimetry(*videoPicture);
-  KODI::UTILS::Eotf eotf = DRMPRIME::GetEOTF(*videoPicture);
+  KODI::UTILS::Colorimetry colorimetry = KODI::UTILS::GetColorimetry(*videoPicture);
+  KODI::UTILS::Eotf eotf = KODI::UTILS::GetEOTF(*videoPicture);
   m_colorimetry = colorimetry;
   m_eotf = eotf;
 
@@ -460,15 +460,16 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
   {
     hdr_output_metadata hdr_metadata = {};
 
-    hdr_metadata.metadata_type = DRMPRIME::HDMI_STATIC_METADATA_TYPE1;
+    hdr_metadata.metadata_type = KODI::UTILS::HDMI_STATIC_METADATA_TYPE1;
     hdr_metadata.hdmi_metadata_type1.eotf = static_cast<uint8_t>(eotf);
-    hdr_metadata.hdmi_metadata_type1.metadata_type = DRMPRIME::HDMI_STATIC_METADATA_TYPE1;
+    hdr_metadata.hdmi_metadata_type1.metadata_type = KODI::UTILS::HDMI_STATIC_METADATA_TYPE1;
 
     m_hdrBlob.Reset();
 
     if (hdr_metadata.hdmi_metadata_type1.eotf)
     {
-      const AVMasteringDisplayMetadata* mdmd = DRMPRIME::GetMasteringDisplayMetadata(*videoPicture);
+      const AVMasteringDisplayMetadata* mdmd =
+          KODI::UTILS::GetMasteringDisplayMetadata(*videoPicture);
       if (mdmd && mdmd->has_primaries)
       {
         // Convert to unsigned 16-bit values in units of 0.00002,
@@ -513,7 +514,7 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
                   __FUNCTION__, hdr_metadata.hdmi_metadata_type1.min_display_mastering_luminance);
       }
 
-      const AVContentLightMetadata* clmd = DRMPRIME::GetContentLightMetadata(*videoPicture);
+      const AVContentLightMetadata* clmd = KODI::UTILS::GetContentLightMetadata(*videoPicture);
       if (clmd)
       {
         hdr_metadata.hdmi_metadata_type1.max_cll = clmd->MaxCLL;

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "VideoLayerBridge.h"
+#include "drm/DRMObject.h"
 #include "drm/DRMUtils.h"
 #include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
@@ -96,7 +97,7 @@ protected:
   std::unique_ptr<CLibInputHandler> m_libinput;
 
 private:
-  uint32_t m_hdr_blob_id = 0;
+  CDRMPropertyBlob m_hdrBlob;
   KODI::UTILS::Eotf m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
   KODI::UTILS::Colorimetry m_colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
 

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -12,6 +12,7 @@
 #include "drm/DRMUtils.h"
 #include "threads/CriticalSection.h"
 #include "threads/SystemClock.h"
+#include "utils/DisplayInfo.h"
 #include "windowing/WinSystem.h"
 
 #include "platform/linux/input/LibInputHandler.h"
@@ -61,6 +62,8 @@ public:
 
   bool SetVideoOutput(const VideoPicture* videoPicture) override;
 
+  KODI::UTILS::Colorimetry GetColorimetry() const { return m_colorimetry; }
+  KODI::UTILS::Eotf GetEotf() const { return m_eotf; }
   bool SetHDR(const VideoPicture* videoPicture) override;
   bool IsHDRDisplay() override;
   CHDRCapabilities GetDisplayHDRCapabilities() const override;
@@ -94,6 +97,8 @@ protected:
 
 private:
   uint32_t m_hdr_blob_id = 0;
+  KODI::UTILS::Eotf m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
+  KODI::UTILS::Colorimetry m_colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
 
   std::unique_ptr<UTILS::CDisplayInfo> m_info;
 };

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -63,6 +63,7 @@ public:
 
   bool SetVideoOutput(const VideoPicture* videoPicture) override;
 
+  void SetColorimetry(const VideoPicture* videoPicture) override;
   KODI::UTILS::Colorimetry GetColorimetry() const { return m_colorimetry; }
   KODI::UTILS::Eotf GetEotf() const { return m_eotf; }
   bool SetHDR(const VideoPicture* videoPicture) override;


### PR DESCRIPTION
## Description

Builds on the SetHDR changes in #28334 to cleanup and make consistently the handling of Colorimetry info and HDR info across all GBM renderers.

Adds explicit DRM Colorspace signaling on the GBM/DRM path so DP-to-HDMI bridges, LSPCONs, and other downstream display chains receive correct colorimetry tags in the HDMI AVI InfoFrame. Previously Kodi left the
connector Colorspace property unset, which made sinks fall back to mode-inferred defaults (often wrong for BT.2020 HDR content). Plus an adjacent refactor that moves HDR / Colorimetry ownership into the renderer where lifecycle naturally belongs.

NOTE: This improves on the current situation but does not fully solve the problem of DRM drivers arbitrarily changing RGB -> YUV without informing userspace.  That requires the "color format" kernel upgrades. This will change again when DRM "color format"  UAPI, now in dev, finally hits Linux kernel. 

- **HDRUtils: factor video metadata helpers out of DRMPRIME** -- pure refactor. Moves `GetColorimetry`, `GetEOTF`, `GetMasteringDisplayMetadata`, and `GetContentLightMetadata` from the DRMPRIME namespace into `KODI::UTILS::HDRUtils` so the EGL render path can use them without depending on `VideoBufferDRMPRIME`.

- **GBM: add SetColorimetry with BT709/SMPTE170M/BT2020 signaling** --
adds `CWinSystemBase::SetColorimetry()` virtual with a GBM implementation that drives the DRM connector `Colorspace` property.  Because Kodi scans out to an RGB primary plane (XR24 / XR30 / AB4H), the GBM implementation remaps source YCC variants to their RGB counterparts: `BT2020_YCC` -> `BT2020_RGB`; `BT709_YCC` / `SMPTE_170M_YCC` -> `Default` (the CTA-861 mode-inferred RGB colorimetry). Signaling YCC while transmitting RGB causes DP-to-HDMI bridges (including LSPCON) to misinterpret the signal.

- **Colorimetry: add ColorimetryToString, consolidate inference logic** -- single source of truth for the DRM colorspace property string names; moves resolution-based colorimetry inference into `HDRUtils::GetColorimetry` so both the renderer matrix code and the windowing system see consistent values.

- **Renderers: pair SetColorimetry with SetHDR in all Linux renderers** -- `LinuxRendererGLES` already called `SetColorimetry`; `LinuxRendererGL`, `RendererDRMPRIME`, and `RendererDRMPRIMEGLES` did not. They now pair `SetColorimetry(picture)` with `SetHDR(picture)` at Configure and clear both at UnInit / destructor in reverse order.

- **DRMPRIME: handle Colorimetry & HDR in renderer not in bridge** -- moves `SetHDR` / `SetGuiCompositing` from `CVideoLayerBridgeDRMPRIME` into `CRendererDRMPRIME`. The bridge handles DRM video plane setup; the renderer is the natural owner of HDR metadata and GUI compositing state because lifecycle is tied to
`Configure` / destructor like every other renderer.

## Motivation and context
Before this PR, Kodi on GBM left the DRM connector `Colorspace` property unset for all video paths except one (`LinuxRendererGLES`). With no explicit signaling, sinks fell back to mode-inferred defaults: fine for SDR BT.709 content at HD resolution, wrong for BT.2020 HDR where the sink could end up applying BT.709 colorimetry to BT.2020 primaries (visibly desaturated, hue-shifted whites).

The wrong-signal problem is most visible on DP-to-HDMI bridges (Intel LSPCONs, active DP-to-HDMI dongles): they re-emit the AVI InfoFrame and depend on the source's explicit Colorspace value. With nothing signaled they pick a default that doesn't match what's actually on the wire.

The renderer/bridge refactor (commit 5) untangles a layering issue: HDR metadata and GUI compositing state are renderer-scope concepts (lifecycle = Configure to destructor), not video-plane-bridge concepts. Moving the responsibility makes the DRMPRIME path's HDR setup match every other renderer's pattern.

## How has this been tested?
GBM on Intel N250.  LSPCON on Intel CFL.  DP-HDMI 2.1 dongle on both.

* SDR BT.709 content (HD resolution): connector `Colorspace` property
  now reads `Default`; sink shows BT.709-inferred decoding (matches
  pre-PR visual result for SDR).
* HDR PQ BT.2020 content: connector `Colorspace` reads `BT2020_RGB`;
  TV enters HDR mode with correct gamut signaling. Previously the TV
  occasionally signaled BT.709 colorimetry over the same input,
  resulting in visibly washed-out colors that would correct themselves
  after a stream restart.
* DRMPRIME D2P and DRMPRIMEGLES paths both verified -- the
  bridge-to-renderer move (commit 5) leaves the user-visible behavior
  identical, just reorganizes ownership.
* LinuxRendererGL and LinuxRendererGLES verified by toggling between
  SDR and HDR sources mid-session and confirming `Colorspace` property
  changes accordingly via `drm_info`.

## What is the effect on users?
End-users on GBM/DRM (LibreELEC, Volumio, custom builds, etc.) playing HDR content through DP-to-HDMI bridges, LSPCONs, or any sink that honors the AVI InfoFrame Colorspace bits will see correct colorimetry
signaling, fixing intermittent washed-out / desaturated HDR rendering. SDR users see no change. X11 / Wayland / Windows / macOS paths are unaffected (`SetColorimetry` is a no-op on the base class).

## Screenshots (if appropriate):
n/a

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
