### PR TITLE
Automated version creation on library scan

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -4050,6 +4050,7 @@ msgid "No"
 msgstr ""
 
 #. Value for setting 'Delete after watching'. Confirm delete.
+#. Value for setting 'Create versions for similar videos'
 #: system/settings/settings.xml
 msgctxt "#863"
 msgid "Ask"
@@ -7930,6 +7931,9 @@ msgctxt "#13550"
 msgid "Delay after change of refresh rate"
 msgstr ""
 
+#. value for setting 'Create versions for similar videos'
+#: system/settings/settings.xml
+#: xbmc/settings/DisplaySettings.cpp
 msgctxt "#13551"
 msgid "Off"
 msgstr ""
@@ -9578,8 +9582,10 @@ msgctxt "#16315"
 msgid "Lanczos3 - Optimised"
 msgstr ""
 
+#. value for setting 'Create versions for similar videos'
 #: xbmc/games/dialogs/osd/DialogGameVideoFilter.cpp
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+#: system/settings/settings.xml
 msgctxt "#16316"
 msgid "Auto"
 msgstr ""
@@ -24709,7 +24715,7 @@ msgstr ""
 #. Help for Ignore different video versions settting
 #: system/settings/settings.xml
 msgctxt "#40203"
-msgid "Select scanner action for different video versions.[CR][Enabled] Add different video versions to library seperately without confirmation.[CR][Disabled] Prompt for converting different video versions into additional versions of the original."
+msgid "Select the scanner action for different versions of a video.[CR][Off] Add versions of a video to the library as separate entries.[CR][Ask] Prompt if different versions should be added separately or grouped with the original.[CR][Auto] Automatically create and group the additional versions with the original."
 msgstr ""
 
 #. Ignore video extras settting
@@ -24724,7 +24730,7 @@ msgctxt "#40205"
 msgid "Select scanner action for video extras in \"extras\" folder.[CR][Enabled] Scan video extras like regular videos.[CR][Disabled] Add video extras to library for associated video."
 msgstr ""
 
-#empty strings from id 40206 to 40208
+#empty strings from id 40206 to 40208 freed in v22
 
 #. Button label for video assets
 #: xbmc/filesystem/VideoDatabaseDirectory.cpp
@@ -24761,7 +24767,7 @@ msgctxt "#40213"
 msgid "If selected the remote player volume level will be synchronized with the volume of this application.[CR]Warning: Global system volume level may be different than the application volume level - they are controlled independently.[CR]This may lead the remote player to be set to 100% volume level if the application has 100% volume level but the overall system volume level is smaller."
 msgstr ""
 
-#empty string id 40214
+#empty string id 40214 freed in v22
 
 #. Title of the dialog for version rename action from Versions Manager
 #: xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -24799,7 +24805,15 @@ msgctxt "#40220"
 msgid "New extra name"
 msgstr ""
 
-#empty strings from id 40221 to 40399
+#empty string id 40221 freed in v22
+
+#. "Create separate versions of the same movie" setting
+#: system/settings/settings.xml
+msgctxt "#40222"
+msgid "Group the different versions of videos"
+msgstr ""
+
+#empty strings from id 40223 to 40399
 
 # Video versions
 

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -985,10 +985,17 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
-        <setting id="videolibrary.ignorevideoversions" type="boolean" label="40202" help="40203">
+        <setting id="videolibrary.similarvideoaction" type="integer" label="40222" help="40203">
           <level>1</level>
-          <default>true</default>
-          <control type="toggle" />
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="13551">0</option> <!-- off -->
+              <option label="863">1</option> <!-- ask -->
+              <option label="16316">2</option> <!-- auto -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
         </setting>
         <setting id="videolibrary.ignorevideoextras" type="boolean" label="40204" help="40205">
           <level>1</level>

--- a/xbmc/settings/CMakeLists.txt
+++ b/xbmc/settings/CMakeLists.txt
@@ -45,7 +45,8 @@ set(HEADERS AdvancedSettings.h
             SettingUtils.h
             SkinSettings.h
             SettingsComponent.h
-            SubtitlesSettings.h)
+            SubtitlesSettings.h
+            VideoVersionsSettings.h)
 
 if(TARGET ${APP_NAME_LC}::Bluray)
   list(APPEND SOURCES DiscSettings.cpp)

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -96,8 +96,7 @@ public:
       "videolibrary.musicvideoartwhitelist";
   static constexpr auto SETTING_VIDEOLIBRARY_SHOWPERFORMERS =
       "videolibrary.musicvideosallperformers";
-  static constexpr auto SETTING_VIDEOLIBRARY_IGNOREVIDEOVERSIONS =
-      "videolibrary.ignorevideoversions";
+  static constexpr auto SETTING_VIDEOLIBRARY_SIMILARVIDEOACTION = "videolibrary.similarvideoaction";
   static constexpr auto SETTING_VIDEOLIBRARY_IGNOREVIDEOEXTRAS = "videolibrary.ignorevideoextras";
   static constexpr auto SETTING_LOCALE_AUDIOLANGUAGE = "locale.audiolanguage";
   static constexpr auto SETTING_VIDEOPLAYER_PREFERDEFAULTFLAG = "videoplayer.preferdefaultflag";

--- a/xbmc/settings/VideoVersionsSettings.h
+++ b/xbmc/settings/VideoVersionsSettings.h
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+enum class SimilarVideoScanAction
+{
+  NONE = 0, //!< no action
+  ASK = 1, //!< ask the user if a new version of an existing video should be created
+  AUTO, //!< automatically create a new version
+};

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4234,15 +4234,18 @@ void CVideoDatabase::GetSameVideoItems(const CFileItem& item,
 
         if (const int idPath{GetPathId(path)}; idPath > 0)
         {
-          sql = PrepareSQL("SELECT idMovie FROM movie "
-                           "JOIN files ON files.idFile = movie.idFile "
-                           "WHERE files.idPath = %i",
-                           idPath);
+          sql = PrepareSQL("SELECT DISTINCT vv.idMedia "
+                           "FROM videoversion vv "
+                           "  JOIN files ON files.idFile = vv.idFile "
+                           "WHERE files.idPath = %i "
+                           "AND vv.media_type = '%s' "
+                           "AND vv.itemType = %i ",
+                           idPath, mediaType.c_str(), VideoAssetType::VERSION);
 
           m_pDS->query(sql);
           while (!m_pDS->eof())
           {
-            itemIds.insert(m_pDS->fv("idMovie").get_asInt());
+            itemIds.insert(m_pDS->fv("idMedia").get_asInt());
             m_pDS->next();
           }
           m_pDS->close();
@@ -4254,12 +4257,14 @@ void CVideoDatabase::GetSameVideoItems(const CFileItem& item,
       if (matchingMask & Title)
       {
         if (item.GetVideoInfoTag()->HasYear())
-          sql = PrepareSQL("SELECT idMovie FROM movie WHERE c%02d = '%s' AND premiered LIKE '%i%%'",
-                           VIDEODB_ID_TITLE, item.GetVideoInfoTag()->GetTitle().c_str(),
-                           item.GetVideoInfoTag()->GetYear());
+          sql = PrepareSQL(
+              "SELECT DISTINCT idMovie FROM movie WHERE c%02d = '%s' AND premiered LIKE '%i%%'",
+              VIDEODB_ID_TITLE, item.GetVideoInfoTag()->GetTitle().c_str(),
+              item.GetVideoInfoTag()->GetYear());
         else
-          sql = PrepareSQL("SELECT idMovie FROM movie WHERE c%02d = '%s' AND LENGTH(premiered) < 4",
-                           VIDEODB_ID_TITLE, item.GetVideoInfoTag()->GetTitle().c_str());
+          sql = PrepareSQL(
+              "SELECT DISTINCT idMovie FROM movie WHERE c%02d = '%s' AND LENGTH(premiered) < 4",
+              VIDEODB_ID_TITLE, item.GetVideoInfoTag()->GetTitle().c_str());
 
         m_pDS->query(sql);
         while (!m_pDS->eof())

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12299,9 +12299,13 @@ bool CVideoDatabase::ConvertVideoToVersion(VideoDbContentType itemType,
       DeleteMovie(dbIdSource, cascadeAction, DeleteMovieHashAction::HASH_PRESERVE);
   }
 
-  // Rename the default version
-  ExecuteQuery(PrepareSQL("UPDATE videoversion SET idType = %i, itemType = %i WHERE idFile = %i",
-                          idVideoVersion, assetType, idFile));
+  // Rename the default version when provided
+  if (idVideoVersion < 0)
+    ExecuteQuery(
+        PrepareSQL("UPDATE videoversion SET itemType = %i WHERE idFile = %i", assetType, idFile));
+  else
+    ExecuteQuery(PrepareSQL("UPDATE videoversion SET idType = %i, itemType = %i WHERE idFile = %i",
+                            idVideoVersion, assetType, idFile));
 
   CommitTransaction();
 
@@ -12696,6 +12700,30 @@ bool CVideoDatabase::GetVideoVersionTypes(VideoDbContentType idContent,
     CLog::LogF(LOGERROR, "failed");
   }
   return false;
+}
+
+bool CVideoDatabase::IsValidVideoAssetType(int typeId,
+                                           VideoDbContentType idContent,
+                                           VideoAssetType assetType)
+{
+  if (!m_pDB)
+    return false;
+
+  MediaType mediaType;
+
+  if (idContent == VideoDbContentType::MOVIES)
+    mediaType = MediaTypeMovie;
+  else
+    return false;
+
+  const std::string query =
+      PrepareSQL("SELECT 1 FROM videoversiontype "
+                 "WHERE id = %i "
+                 "AND name != '' "
+                 "AND itemType = %i "
+                 "AND owner IN (%i, %i)",
+                 typeId, assetType, VideoAssetTypeOwner::SYSTEM, VideoAssetTypeOwner::USER);
+  return GetSingleValueInt(query) == 1;
 }
 
 std::string CVideoDatabase::GetVideoVersionById(int id)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -939,12 +939,13 @@ public:
   /*!
    * \brief Remove a video from the library and transfer all of its assets to another video of the
    * same type.
-   * \param itemType Type of the video being converted
-   * \param dbIdSource id of the video being converted
-   * \param dbIdTarget id that the video will be attached to
-   * \param idVideoVersion new versiontype of the default version of the video
-   * \param assetType new asset type of the default version of the video
-   * \param cascadeAction action to take on the assets of the video being converted
+   * \param itemType[in] Type of the video being converted
+   * \param dbIdSource[in] id of the video being converted
+   * \param dbIdTarget[in] id that the video will be attached to
+   * \param idVideoVersion[in] new versiontype of the default version of the video
+   *                           special value -1: keep the current versiontype of the video.
+   * \param assetType[in] new asset type of the default version of the video.
+   * \param cascadeAction[in] action to take on the assets of the video being converted
    *        (used to preserve streamdetails for bluray playlists)
    * \return true for success, false otherwise
    */
@@ -993,8 +994,17 @@ public:
   bool DeleteVideoAsset(int idFile);
   bool IsDefaultVideoVersion(int idFile);
   bool GetVideoVersionTypes(VideoDbContentType idContent,
-                            VideoAssetType asset,
+                            VideoAssetType assetType,
                             CFileItemList& items);
+
+  /*!
+   * \brief Check the validity of the video asset type id.
+   * \param[in] typeId Id of the video asset type
+   * \param[in] idContent db item type
+   * \param[in] asset type of the video asset type
+   * \return true when the id exists and matches the provided content and asset type, false otherwise.
+   */
+  bool IsValidVideoAssetType(int typeId, VideoDbContentType idContent, VideoAssetType asset);
   bool SetVideoVersionDefaultArt(int dbId, int idFrom, const MediaType& mediaType);
   void UpdateVideoVersionTypeTable();
   bool GetVideoVersionsNav(const std::string& strBaseDir,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1059,7 +1059,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
         const int dbId{static_cast<int>(AddVideo(pItem, info2, bDirNames, useLocal))};
         if (dbId < 0)
           return InfoRet::INFO_ERROR;
-        if (m_similarVideoAction == SimilarVideoScanAction::ASK &&
+        if ((m_similarVideoAction == SimilarVideoScanAction::ASK ||
+             m_similarVideoAction == SimilarVideoScanAction::AUTO) &&
             ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
           return InfoRet::HAVE_ALREADY;
         return InfoRet::ADDED;
@@ -1084,7 +1085,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
       const int dbId{static_cast<int>(AddVideo(pItem, info2, bDirNames, useLocal))};
       if (dbId < 0)
         return InfoRet::INFO_ERROR;
-      if (m_similarVideoAction == SimilarVideoScanAction::ASK &&
+      if ((m_similarVideoAction == SimilarVideoScanAction::ASK ||
+           m_similarVideoAction == SimilarVideoScanAction::AUTO) &&
           ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
         return InfoRet::HAVE_ALREADY;
       return InfoRet::ADDED;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -179,7 +179,8 @@ CVideoInfoScanner::CVideoInfoScanner()
 
   const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
-  m_ignoreVideoVersions = settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_IGNOREVIDEOVERSIONS);
+  m_similarVideoAction = static_cast<SimilarVideoScanAction>(
+      settings->GetInt(CSettings::SETTING_VIDEOLIBRARY_SIMILARVIDEOACTION));
   m_ignoreVideoExtras = settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_IGNOREVIDEOEXTRAS);
 }
 
@@ -1058,7 +1059,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
         const int dbId{static_cast<int>(AddVideo(pItem, info2, bDirNames, useLocal))};
         if (dbId < 0)
           return InfoRet::INFO_ERROR;
-        if (!m_ignoreVideoVersions && ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
+        if (m_similarVideoAction == SimilarVideoScanAction::ASK &&
+            ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
           return InfoRet::HAVE_ALREADY;
         return InfoRet::ADDED;
       }
@@ -1082,7 +1084,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
       const int dbId{static_cast<int>(AddVideo(pItem, info2, bDirNames, useLocal))};
       if (dbId < 0)
         return InfoRet::INFO_ERROR;
-      if (!m_ignoreVideoVersions && ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
+      if (m_similarVideoAction == SimilarVideoScanAction::ASK &&
+          ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
         return InfoRet::HAVE_ALREADY;
       return InfoRet::ADDED;
     }

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -12,6 +12,7 @@
 #include "VideoDatabase.h"
 #include "addons/Scraper.h"
 #include "guilib/GUIListItem.h"
+#include "settings/VideoVersionsSettings.h"
 #include "utils/Artwork.h"
 #include "utils/RegExp.h"
 
@@ -325,7 +326,8 @@ namespace KODI::VIDEO
 
     bool m_bStop;
     bool m_scanAll;
-    bool m_ignoreVideoVersions{false};
+
+    SimilarVideoScanAction m_similarVideoAction{SimilarVideoScanAction::NONE};
     bool m_ignoreVideoExtras{false};
     CVideoDatabase m_database;
     std::set<int> m_pathsToClean;

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -500,21 +500,6 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
   if (!selectedItem)
     return false;
 
-  CFileItemList list;
-  videoDb.GetVideoVersions(itemType, selectedItem->GetVideoInfoTag()->m_iDbId, list,
-                           VideoAssetType::VERSION);
-
-  // ask confirmation for the addition of a movie with multiple versions to another movie
-  if (list.Size() > 1 && !CGUIDialogYesNo::ShowAndGetInput(CVariant{40014}, CVariant{40037}))
-  {
-    return false;
-  }
-
-  // choose a video version for the video
-  const int idVideoVersion{ChooseVideoAsset(selectedItem, VideoAssetType::VERSION, "")};
-  if (idVideoVersion < 0)
-    return false;
-
   int sourceDbId, targetDbId;
   switch (role)
   {
@@ -529,6 +514,20 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
     default:
       return false;
   }
+
+  CFileItemList list;
+  videoDb.GetVideoVersions(itemType, sourceDbId, list, VideoAssetType::VERSION);
+
+  // ask confirmation for the addition of a movie with multiple versions to another movie
+  if (list.Size() > 1 && !CGUIDialogYesNo::ShowAndGetInput(CVariant{40014}, CVariant{40037}))
+  {
+    return false;
+  }
+
+  // choose a video version for the video
+  const int idVideoVersion{ChooseVideoAsset(selectedItem, VideoAssetType::VERSION, "")};
+  if (idVideoVersion < 0)
+    return false;
 
   return videoDb.ConvertVideoToVersion(itemType, sourceDbId, targetDbId, idVideoVersion,
                                        VideoAssetType::VERSION,

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -27,6 +27,7 @@
 #include "settings/MediaSourceSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "settings/VideoVersionsSettings.h"
 #include "storage/MediaManager.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/RegExp.h"
@@ -266,7 +267,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersion()
 
         return ChooseVideoAndConvertToVideoVersion(items, m_videoAsset->GetVideoContentType(),
                                                    tag->m_type, tag->m_iDbId, videoDb,
-                                                   MediaRole::Parent);
+                                                   MediaRole::Parent, Mode::INTERACTIVE);
       }
 
       case CGUIDialogYesNo::DIALOG_RESULT_YES:
@@ -322,7 +323,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersion()
 
     return ChooseVideoAndConvertToVideoVersion(items, m_videoAsset->GetVideoContentType(),
                                                tag->m_type, tag->m_iDbId, videoDb,
-                                               MediaRole::Parent);
+                                               MediaRole::Parent, Mode::INTERACTIVE);
   }
   return false;
 }
@@ -457,18 +458,14 @@ bool CGUIDialogVideoManagerVersions::ManageVideoVersions(const std::shared_ptr<C
   return dialog->HasUpdatedItems();
 }
 
-bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
-    CFileItemList& items,
-    VideoDbContentType itemType,
-    const std::string& mediaType,
-    int dbId,
-    CVideoDatabase& videoDb,
-    MediaRole role)
+namespace
+{
+std::shared_ptr<CFileItem> ChooseVideo(CFileItemList& items, MediaRole role)
 {
   if (items.Size() == 0)
   {
     CGUIDialogOK::ShowAndGetInput(role == MediaRole::NewVersion ? 40002 : 40030, 40031);
-    return false;
+    return nullptr;
   }
 
   // choose a video
@@ -477,7 +474,7 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
   if (!dialog)
   {
     CLog::LogF(LOGERROR, "Unable to get WINDOW_DIALOG_SELECT instance!");
-    return false;
+    return nullptr;
   }
 
   // Load thumbs async
@@ -494,11 +491,35 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
     loader.StopThread();
 
   if (!dialog->IsConfirmed())
-    return false;
+    return nullptr;
 
-  const std::shared_ptr<CFileItem> selectedItem{dialog->GetSelectedFileItem()};
+  return dialog->GetSelectedFileItem();
+}
+} // namespace
+
+bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
+    CFileItemList& items,
+    VideoDbContentType itemType,
+    const std::string& mediaType,
+    int dbId,
+    CVideoDatabase& videoDb,
+    MediaRole role,
+    Mode mode)
+{
+  std::shared_ptr<CFileItem> selectedItem;
+
+  if (mode == Mode::INTERACTIVE)
+    selectedItem = ChooseVideo(items, role);
+  else if (items.Size() == 1)
+    selectedItem = items[0];
+
   if (!selectedItem)
+  {
+    if (mode == Mode::NON_INTERACTIVE)
+      CLog::Log(LOGINFO,
+                "Automated video version creation stopped by multiple existing similar videos");
     return false;
+  }
 
   int sourceDbId, targetDbId;
   switch (role)
@@ -518,18 +539,31 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
   CFileItemList list;
   videoDb.GetVideoVersions(itemType, sourceDbId, list, VideoAssetType::VERSION);
 
-  // ask confirmation for the addition of a movie with multiple versions to another movie
-  if (list.Size() > 1 && !CGUIDialogYesNo::ShowAndGetInput(CVariant{40014}, CVariant{40037}))
+  // A movie with multiple versions would be added to another movie
+  // Ask for confirmation if allowed, automatic failure otherwise.
+  if (list.Size() > 1 && (mode == Mode::NON_INTERACTIVE ||
+                          !CGUIDialogYesNo::ShowAndGetInput(CVariant{40014}, CVariant{40037})))
   {
+    if (mode == Mode::NON_INTERACTIVE)
+      CLog::Log(LOGINFO,
+                "Automated video version creation stopped by multiple versions of the source video "
+                "dbid {} path '{}'",
+                sourceDbId, CURL::GetRedacted(selectedItem->GetDynPath()));
+
     return false;
   }
 
-  // choose a video version for the video
-  const int idVideoVersion{ChooseVideoAsset(selectedItem, VideoAssetType::VERSION, "")};
-  if (idVideoVersion < 0)
-    return false;
+  // Selection of the version type. Leave unchanged by default.
+  int versionTypeId = -1;
 
-  return videoDb.ConvertVideoToVersion(itemType, sourceDbId, targetDbId, idVideoVersion,
+  if (mode == Mode::INTERACTIVE)
+  {
+    versionTypeId = ChooseVideoAsset(selectedItem, VideoAssetType::VERSION, "");
+    if (versionTypeId < 0)
+      return false;
+  }
+
+  return videoDb.ConvertVideoToVersion(itemType, sourceDbId, targetDbId, versionTypeId,
                                        VideoAssetType::VERSION,
                                        DeleteMovieCascadeAction::ALL_ASSETS);
 }
@@ -589,25 +623,44 @@ bool CGUIDialogVideoManagerVersions::ProcessVideoVersion(VideoDbContentType item
   if (list.Size() < 2)
     return false;
 
-  const MediaType mediaType{item.GetVideoInfoTag()->m_type};
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  const auto action = static_cast<SimilarVideoScanAction>(
+      settings->GetInt(CSettings::SETTING_VIDEOLIBRARY_SIMILARVIDEOACTION));
 
-  std::string path;
-  videodb.GetFilePathById(dbId, path, itemType);
-
-  if (!CGUIDialogYesNo::ShowAndGetInput(
-          CVariant{40008},
-          StringUtils::Format(
-              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40009),
-              item.GetVideoInfoTag()->GetTitle(), path)))
+  switch (action)
   {
-    return false;
+    case SimilarVideoScanAction::ASK:
+    {
+      std::string path;
+      videodb.GetFilePathById(dbId, path, itemType);
+
+      if (!CGUIDialogYesNo::ShowAndGetInput(
+              CVariant{40008},
+              StringUtils::Format(
+                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40009),
+                  item.GetVideoInfoTag()->GetTitle(), path)))
+      {
+        return false;
+      }
+      break;
+    }
+    case SimilarVideoScanAction::AUTO:
+      // permission granted through the settings
+      break;
+    case SimilarVideoScanAction::NONE:
+    default:
+      // no action or unknown value: abort
+      return false;
   }
 
   if (!PostProcessList(list, dbId))
     return false;
 
-  return ChooseVideoAndConvertToVideoVersion(list, itemType, mediaType, dbId, videodb,
-                                             MediaRole::NewVersion);
+  const MediaType mediaType{item.GetVideoInfoTag()->m_type};
+
+  return ChooseVideoAndConvertToVideoVersion(
+      list, itemType, mediaType, dbId, videodb, MediaRole::NewVersion,
+      action == SimilarVideoScanAction::ASK ? Mode::INTERACTIVE : Mode::NON_INTERACTIVE);
 }
 
 bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -63,6 +63,12 @@ private:
   void SetDefault();
   void UpdateDefaultVideoVersionSelection();
 
+  enum class Mode
+  {
+    INTERACTIVE,
+    NON_INTERACTIVE,
+  };
+
   /*!
    * \brief Ask the user to choose an item from the list of items, the version type of the item,
    * and perform the version conversion according to the role parameter.
@@ -73,7 +79,10 @@ private:
    * to if role is Parent
    * \param[in] videoDb Database connection
    * \param[in] role NewVersion: dbId will be converted to a version of the movie chosen by
-   * the user from the whole library.
+   *                 the user from the whole library.
+   * \param[in] interaction INTERACTIVE: ask the user to choose and confirm as needed.
+   *                        NON_INTERACTIVE false: no user interaction allowed, use heuristics in
+   *                        place of user input
    * Parent: dbId will have another movie chosen by the user from the whole library as a new version.
    *
    * \return True: success, a version was created and attached, false otherwise.
@@ -83,7 +92,8 @@ private:
                                                   const std::string& mediaType,
                                                   int dbId,
                                                   CVideoDatabase& videoDb,
-                                                  MediaRole role);
+                                                  MediaRole role,
+                                                  Mode mode);
   /*!
    * \brief Use a file picker to select a file to add as a new version of a movie.
    * \return True when a version was added, false otherwise


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Automatically creates new versions during the library scan when conditions are met.

New setting `Group the different versions of videos`, a replacement and extension of the setting `Ignore different video versions on scan`:

<img width="1226" height="120" alt="image" src="https://github.com/user-attachments/assets/ecbe3357-87cd-4727-ba91-1f969b177dde" />

Setting values:
- Off and Ask are identical to the current setting Enabled and Disabled values respectively
- Auto: create a new version without user intervention
Auto uses the same existing video-matching algorithms as Ask (search by unique id then title and year) and when there is a single match, creates a new version with the type of the new setting `Default version type`. The default type is "Standard Edition", with a selection from all the defined types in the system.
The default value is "Off", same as the current setting.

Problems in the automatic process are logged.

notes;
- the existing setting value could not be migrated because of the type change. SettingsManager doesn't allow it. Used the opportunity to change the name of the setting to `videolibrary.similarvideoaction`
~- possible future PR to retrieve the version type from the filename or .nfo tags~ done, PR 28429
- possible future PR to add more conditions / allow the user to choose the match quality required (ex. must match unique id, reject matches on title)
- commit 1 is a small bugfix. when scanning a new movie the check looked at multiple versions of the chosen parent movie, instead of multiple versions of the scanned movie. Made automatic imports fail for movies that already have multiple versions.
- commit 2 looks at existing versions and not only the default version when attempting a match by path.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

user request + numerous users turn off versions creation on scan because of the popups.

interim solution to help automate the creation of versions until a naming nomenclature is adopted.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

scan additional movie copy of movies that exist/don't exist in the library 
scan additional movie copy of movies that have multiple entries in the library
scan additional movie copy of movie that already has versions

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
New settings:
<img width="1226" height="120" alt="image" src="https://github.com/user-attachments/assets/ecbe3357-87cd-4727-ba91-1f969b177dde" />

List of values for "Group the different versions of videos":
<img width="1095" height="682" alt="image" src="https://github.com/user-attachments/assets/fb697fc9-6807-4702-96d9-e88dce766e0c" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
