### PR TITLE
Revert glblend (alpha) from #28012

### DIFF
--- a/xbmc/guilib/GUIFontTTFGLES.cpp
+++ b/xbmc/guilib/GUIFontTTFGLES.cpp
@@ -126,19 +126,7 @@ bool CGUIFontTTFGLES::FirstBegin()
     m_textureStatus = TEXTURE_READY;
   }
 
-  // Alpha blending assumes linear light. SDR (direct-to-backbuffer or
-  // direct-to-plane) blends in sRGB -- "wrong but consistent", the aesthetic
-  // skins are designed against. HDR FBO compositing draws GUI into an sRGB
-  // FBO that is color-transformed to PQ/HLG before compositing with video
-  // in that non-linear space -- two stages of non-linear blending. The
-  // compensated factors below trade accumulator coverage for a squared-
-  // alpha blend that approximately matches SDR perceived translucency. It
-  // is a "close enough" compromise; a mathematically correct fix would
-  // require linear-light compositing (too expensive on typical ARM GPUs).
-  if (CServiceBroker::GetWinSystem()->IsHdrComposite())
-    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-  else
-    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
+  glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
   glEnable(GL_BLEND);
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, m_nTexture);

--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -121,15 +121,7 @@ void CGUITextureGLES::Begin(KODI::UTILS::COLOR::Color color)
 
   if (hasAlpha)
   {
-    // See CGUIFontTTFGLES::FirstBegin for rationale. SDR uses accumulator
-    // coverage alpha; HDR FBO composite uses a compensated squared-alpha
-    // blend because the FBO is color-transformed to PQ/HLG before composite,
-    // and alpha blending in non-linear space is mathematically wrong.
-    if (CServiceBroker::GetWinSystem()->IsHdrComposite())
-      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_SRC_ALPHA,
-                          GL_ONE_MINUS_SRC_ALPHA);
-    else
-      glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
+    glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE_MINUS_DST_ALPHA, GL_ONE);
     glEnable( GL_BLEND );
   }
   else


### PR DESCRIPTION
## Description

Alpha blending of the FBO GUI for HDR is too transparent for during fullscreen overlay GUI.  For now, revert the hand-tuned glBlendFund; subtitles, PlayerProcessInfo etc will be more accurate while fullscreen GUI alpha is debugged.

HOWEVER, for VAAPI and DRMPRIME-EGL, this means that fullscreen GUI will be opaque. Given that is rare relative to partial onscreen gui, this is a reasonable trade.  This is a TEMPORARY solution while we work through EGL FBO rendering issues.  DRMPRIME Direct-to-Plane is unaffected, and with #28332 now has proper HDR GUI compositing.

## Motivation and context
Lots of reports of poor alpha blending on different platforms (GL and GLES both) especially fullscreen GUI during video playback.

## How has this been tested?
Intel N250, including Direct-to-Plane.

## What is the effect on users?
Users on VAAPI and DRMPRIME-EGL will have improved onscreen GUI during video playback including improved subtitle visual fidelity.

## Screenshots (if appropriate):
n/a

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
