### PR TITLE
fix plane info reporting in dynamic-planes

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -99,11 +99,18 @@ CWinSystemGbm::~CWinSystemGbm() = default;
 
 const std::string CWinSystemGbm::GetName()
 {
-  auto gui_plane = m_DRM->GetGuiPlane();
-  if (gui_plane == nullptr)
-    return "gbm";
-  return "gbm (" + DRMHELPERS::FourCCToString(gui_plane->GetFormat()) + " " +
-         DRMHELPERS::ModifierToString(gui_plane->GetModifier()) + ")";
+  const auto* gui = m_DRM->GetGuiPlane();
+  const auto* video = m_DRM->GetVideoPlane();
+
+  std::string name = "gbm (";
+  if (gui)
+    name += DRMHELPERS::FourCCToString(gui->GetFormat());
+  if (gui && video)
+    name += " / ";
+  if (video)
+    name += DRMHELPERS::FourCCToString(video->GetFormat());
+  name += ")";
+  return name;
 }
 
 bool CWinSystemGbm::InitWindowSystem()

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -188,7 +188,7 @@ void CGUIWindowSystemInfo::FrameMove()
     auto windowSystem = CServiceBroker::GetWinSystem();
     if (windowSystem)
     {
-      static std::string platform = windowSystem->GetName();
+      const std::string platform = windowSystem->GetName();
       if (platform != "platform default")
         SET_CONTROL_LABEL(
             i++,


### PR DESCRIPTION
## Description

The platform label in the System Info window (the one that reads e.g. "Windowing System: gbm") was sampled exactly once per process via a block-scope `static`, freezing it to whatever GBM plane format happened to be in place the first time the user opened the Video section.

Dynamic Planes #27402 added plane info but ironically didn't make the info screen dynamic. After #27402 the GUI and video planes can swap roles and the EGL surface format can switch at runtime (e.g. AR24 to AR30 on video start),
so this label is exactly the diagnostic surface users need - but it never updated.

Two changes:

1. `GUIWindowSystemInfo`: drop the `static` so the label is recomputed
   on every `FrameMove()` tick (only while the Video section is visible).
2. `WinSystemGbm::GetName`: report both planes when both are present, e.g.
   `gbm (XR24 / AR30)` with the GUI plane first. Single plane stays as
   `gbm (XR24)`. The modifier is dropped to keep the string short.

## Motivation and context

Makes the dynamic plane state from PR #27402 actually observable from
the Kodi UI without restarting.

## How has this been tested?

GBM on Intel N250 (i915), with 8-bit GUI / 10-bit HDR video playback
flipping the EGL surface format between AR24 and AR30.

## What is the effect on users?
Accurately see the plane format in current use.

## Screenshots (if appropriate):
n/a

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
