### PR TITLE
[Video][tvOS] Fix realtime non-interlaced streams in PVR not using VTB decoder on tvOS

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
@@ -132,7 +132,7 @@ IHardwareDecoder* CDecoder::Create(CDVDStreamInfo &hint, CProcessInfo &processIn
 #if defined(TARGET_DARWIN_EMBEDDED)
   // force disable HW acceleration for live streams
   // to avoid absent image issue on interlaced videos
-  if (processInfo.IsRealtimeStream())
+  if (processInfo.IsRealtimeStream() && hint.interlaced)
     return nullptr;
 #endif
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
On iOS/tvOS, PVR streams with "realtime" enabled will fallback to software decoder.  The initial intent and comment for this behavior indicates it's to prevent issues with interlaced streams, however it affects all streams interlaced or not.  This fix simply restricts the behavior to interlaced streams.
Fixes #27783

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For users of PVR on iOS/tvOS (I may be one of the only ones idk...), all IPTV streams with timeshift enabled (flagging the stream as realtime) fallback to software only.  Ideally we want to use hardware decoders where most appropriate, to keep cpu/power consumption/heat to a minimum.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on tvOS device with realtime h264 PVR stream.  Before fix, only software encoder would work.  After fix, VTB encoder properly picks up non-interlaced streams.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users using pvr.iptvsimple with timeshift enabled will now properly get hardware decoding on non-interlaced realtime streams.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
