### PR TITLE
Fix nested label formatting: Restore the original behavior of not app…

### DIFF
--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -397,7 +397,7 @@ void CGUITextLayout::ParseText(const std::wstring& text,
 
   int startPos = 0;
   size_t pos = text.find(L'[');
-  while (pos != std::string::npos && pos + 1 < text.size())
+  while (pos != std::wstring::npos && pos + 1 < text.size())
   {
     uint32_t newStyle = 0;
     KODI::UTILS::COLOR::Color newColor = currentColor;
@@ -417,20 +417,22 @@ void CGUITextLayout::ParseText(const std::wstring& text,
     { // bold
       pos += 2;
       if (on)
-        ++boldDepth;
+      {
+        if (text.find(L"[/B]", pos) != std::wstring::npos)
+          ++boldDepth;
+      }
       else if (boldDepth > 0)
         --boldDepth;
-      else
-	  {
-        // unmatched [/B] - ignore
-      }
       newStyle = FONT_STYLE_BOLD;
     }
     else if (text.compare(pos, 2, L"I]") == 0)
     { // italics
       pos += 2;
       if (on)
-        ++italicDepth;
+      {
+        if (text.find(L"[/I]", pos) != std::wstring::npos)
+          ++italicDepth;
+      }
       else if (italicDepth > 0)
         --italicDepth;
       newStyle = FONT_STYLE_ITALICS;
@@ -439,7 +441,10 @@ void CGUITextLayout::ParseText(const std::wstring& text,
     {
       pos += 10;
       if (on)
-        ++uppercaseDepth;
+      {
+        if (text.find(L"[/UPPERCASE]", pos) != std::wstring::npos)
+          ++uppercaseDepth;
+      }
       else if (uppercaseDepth > 0)
         --uppercaseDepth;
       newStyle = FONT_STYLE_UPPERCASE;
@@ -448,7 +453,10 @@ void CGUITextLayout::ParseText(const std::wstring& text,
     {
       pos += 10;
       if (on)
-        ++lowercaseDepth;
+      {
+        if (text.find(L"[/LOWERCASE]", pos) != std::wstring::npos)
+          ++lowercaseDepth;
+      }
       else if (lowercaseDepth > 0)
         --lowercaseDepth;
       newStyle = FONT_STYLE_LOWERCASE;
@@ -457,7 +465,10 @@ void CGUITextLayout::ParseText(const std::wstring& text,
     {
       pos += 11;
       if (on)
-        ++capitalizeDepth;
+      {
+        if (text.find(L"[/CAPITALIZE]", pos) != std::wstring::npos)
+          ++capitalizeDepth;
+      }
       else if (capitalizeDepth > 0)
         --capitalizeDepth;
       newStyle = FONT_STYLE_CAPITALIZE;
@@ -466,7 +477,10 @@ void CGUITextLayout::ParseText(const std::wstring& text,
     {
       pos += 6;
       if (on)
-        ++lightDepth;
+      {
+        if (text.find(L"[/LIGHT]", pos) != std::wstring::npos)
+          ++lightDepth;
+      }
       else if (lightDepth > 0)
         --lightDepth;
       newStyle = FONT_STYLE_LIGHT;
@@ -475,7 +489,7 @@ void CGUITextLayout::ParseText(const std::wstring& text,
     {
       pos += 5;
       const size_t end = text.find(L"[/TABS]", pos);
-      if (end != std::string::npos)
+      if (end != std::wstring::npos)
       {
         std::string t;
         g_charsetConverter.wToUTF8(text.substr(pos), t);
@@ -489,9 +503,10 @@ void CGUITextLayout::ParseText(const std::wstring& text,
       pos += 3;
     }
     else if (text.compare(pos,5, L"COLOR") == 0)
-    { // color - already stack-based, unchanged
+    { // color
       size_t finish = text.find(L']', pos + 5);
-      if (on && finish != std::string::npos && text.find(L"[/COLOR]",finish) != std::string::npos)
+      if (on && finish != std::wstring::npos &&
+          text.find(L"[/COLOR]", finish) != std::wstring::npos)
       {
         std::string t;
         g_charsetConverter.wToUTF8(text.substr(pos + 5, finish - pos - 5), t);
@@ -519,7 +534,7 @@ void CGUITextLayout::ParseText(const std::wstring& text,
         newColor = colorStack.top();
         colorTagChange = true;
       }
-      if (finish != std::string::npos)
+      if (finish != std::wstring::npos)
         pos = finish + 1;
     }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fix nested label formatting: Restore the original behavior of not applying style when a closing tag is unmatched

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix a regression introduced in #28280

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual testcase.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Text with unmatched format tags looks the same as before #28280.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [] I have added tests to cover my change
- [X] All new and existing tests passed
