### PR TITLE
Video/Music Scanner Regexp Cache and Speed Up

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -647,21 +647,24 @@ std::string CUtil::GetSplashPath()
   return CSpecialProtocol::TranslatePathConvertCase(*it);
 }
 
-bool CUtil::ExcludeFileOrFolder(const std::string& strFileOrFolder, const std::vector<std::string>& regexps)
+bool CUtil::ExcludeFileOrFolder(const std::string& strFileOrFolder,
+                                const std::vector<std::string>& regexps,
+                                KODI::REGEXP::RegExpCache* cache)
 {
   if (strFileOrFolder.empty())
     return false;
 
-  CRegExp regExExcludes(true, CRegExp::autoUtf8);  // case insensitive regex
+  std::shared_ptr<CRegExp> regExExcludes;
 
   for (const auto &regexp : regexps)
   {
-    if (!regExExcludes.RegComp(regexp.c_str()))
+    if (regExExcludes = KODI::REGEXP::GetRegExp(regexp, cache, true, CRegExp::autoUtf8);
+        regExExcludes == nullptr)
     { // invalid regexp - complain in logs
       CLog::Log(LOGERROR, "{}: Invalid exclude RegExp:'{}'", __FUNCTION__, regexp);
       continue;
     }
-    if (regExExcludes.RegFind(strFileOrFolder) > -1)
+    if (regExExcludes->RegFind(strFileOrFolder) > -1)
     {
       CLog::LogF(LOGDEBUG, "File '{}' excluded. (Matches exclude rule RegExp: '{}')", CURL::GetRedacted(strFileOrFolder), regexp);
       return true;

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -10,6 +10,7 @@
 
 #include "MediaSource.h" // Definition of std::vector<CMediaSource>
 #include "utils/Digest.h"
+#include "utils/RegExp.h"
 
 #include <cstdint>
 #include <span>
@@ -84,7 +85,9 @@ public:
   static void RunShortcut(const char* szPath);
   static std::string GetHomePath(
       const std::string& strTarget = "KODI_HOME"); // default target is "KODI_HOME"
-  static bool ExcludeFileOrFolder(const std::string& strFileOrFolder, const std::vector<std::string>& regexps);
+  static bool ExcludeFileOrFolder(const std::string& strFileOrFolder,
+                                  const std::vector<std::string>& regexps,
+                                  KODI::REGEXP::RegExpCache* cache);
   static void GetFileAndProtocol(const std::string& strURL, std::string& strDir);
   static int GetDVDIfoTitle(const std::string& strPathFile);
 

--- a/xbmc/interfaces/json-rpc/FileOperations.cpp
+++ b/xbmc/interfaces/json-rpc/FileOperations.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2020 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -32,6 +32,7 @@
 #include <memory>
 
 using namespace KODI;
+using namespace KODI::REGEXP;
 using namespace JSONRPC;
 using namespace XFILE;
 
@@ -114,9 +115,10 @@ JSONRPC_STATUS CFileOperations::GetDirectory(const std::string &method, ITranspo
     }
 
     CFileItemList filteredFiles;
+    RegExpCache cache;
     for (unsigned int i = 0; i < (unsigned int)items.Size(); i++)
     {
-      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps))
+      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps, &cache))
         continue;
 
       if (items[i]->IsSmb())
@@ -386,9 +388,10 @@ bool CFileOperations::FillFileItemList(const CVariant &parameterObject, CFileIte
           items.Sort(SortBy::FILE, SortOrder::ASCENDING);
 
         CFileItemList filteredDirectories;
+        RegExpCache cache;
         for (unsigned int i = 0; i < (unsigned int)items.Size(); i++)
         {
-          if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps))
+          if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps, &cache))
             continue;
 
           if (items[i]->IsFolder())

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -497,7 +497,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
   // Discard all excluded files defined by m_musicExcludeRegExps
   const std::vector<std::string> &regexps = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_audioExcludeFromScanRegExps;
 
-  if (CUtil::ExcludeFileOrFolder(strDirectory, regexps, nullptr))
+  if (CUtil::ExcludeFileOrFolder(strDirectory, regexps, &m_regexpCache))
     return true;
 
   if (HasNoMedia(strDirectory))
@@ -591,7 +591,7 @@ CInfoScanner::InfoRet CMusicInfoScanner::ScanTags(const CFileItemList& items,
 
     CFileItemPtr pItem = items[i];
 
-    if (CUtil::ExcludeFileOrFolder(pItem->GetPath(), regexps, nullptr))
+    if (CUtil::ExcludeFileOrFolder(pItem->GetPath(), regexps, &m_regexpCache))
       continue;
 
     if (pItem->IsFolder() || PLAYLIST::IsPlayList(*pItem) || pItem->IsPicture() ||

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -497,7 +497,7 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
   // Discard all excluded files defined by m_musicExcludeRegExps
   const std::vector<std::string> &regexps = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_audioExcludeFromScanRegExps;
 
-  if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
+  if (CUtil::ExcludeFileOrFolder(strDirectory, regexps, nullptr))
     return true;
 
   if (HasNoMedia(strDirectory))
@@ -581,7 +581,8 @@ bool CMusicInfoScanner::DoScan(const std::string& strDirectory)
 CInfoScanner::InfoRet CMusicInfoScanner::ScanTags(const CFileItemList& items,
                                                   CFileItemList& scannedItems)
 {
-  std::vector<std::string> regexps = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_audioExcludeFromScanRegExps;
+  std::vector<std::string> regexps =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_audioExcludeFromScanRegExps;
 
   for (int i = 0; i < items.Size(); ++i)
   {
@@ -590,7 +591,7 @@ CInfoScanner::InfoRet CMusicInfoScanner::ScanTags(const CFileItemList& items,
 
     CFileItemPtr pItem = items[i];
 
-    if (CUtil::ExcludeFileOrFolder(pItem->GetPath(), regexps))
+    if (CUtil::ExcludeFileOrFolder(pItem->GetPath(), regexps, nullptr))
       continue;
 
     if (pItem->IsFolder() || PLAYLIST::IsPlayList(*pItem) || pItem->IsPicture() ||

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -12,6 +12,7 @@
 #include "music/MusicDatabase.h"
 #include "threads/IRunnable.h"
 #include "threads/Thread.h"
+#include "utils/RegExp.h"
 
 #include <string>
 
@@ -289,5 +290,6 @@ protected:
   std::set<std::string> m_seenPaths;
   int m_flags;
   CThread m_fileCountReader;
+  mutable KODI::REGEXP::RegExpCache m_regexpCache;
 };
 }

--- a/xbmc/utils/EpisodeUtils.cpp
+++ b/xbmc/utils/EpisodeUtils.cpp
@@ -167,7 +167,9 @@ void ProcessEpisodeRange(int first,
 }
 } // namespace
 
-bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELIST& episodeList)
+bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item,
+                                         VIDEO::EPISODELIST& episodeList,
+                                         KODI::REGEXP::RegExpCache* cache /* = nullptr */)
 {
   const auto advancedSettings{CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()};
   const auto& tvShowRegExps{advancedSettings->m_tvshowEnumRegExps};
@@ -186,21 +188,22 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELI
   label = CURL::Decode(CURL::GetRedacted(label));
 
   // Pre-compile multi-part regex
-  CRegExp reg2(true, CRegExp::autoUtf8);
-  const bool multiPartRegexValid{reg2.RegComp(advancedSettings->m_tvshowMultiPartEnumRegExp)};
-  if (!multiPartRegexValid)
+  std::shared_ptr<CRegExp> multiPartRegex = KODI::REGEXP::GetRegExp(
+      advancedSettings->m_tvshowMultiPartEnumRegExp, cache, true, CRegExp::autoUtf8);
+  if (multiPartRegex == nullptr)
     CLog::LogF(LOGWARNING, "Invalid multipart RegExp '{}', multipart episode detection disabled",
                advancedSettings->m_tvshowMultiPartEnumRegExp);
   const bool disableEpisodeRanges{advancedSettings->m_disableEpisodeRanges};
 
   for (const auto& tvShowRegExp : tvShowRegExps)
   {
-    CRegExp reg(true, CRegExp::autoUtf8);
-    if (!reg.RegComp(tvShowRegExp.regexp))
+    std::shared_ptr<CRegExp> reg =
+        KODI::REGEXP::GetRegExp(tvShowRegExp.regexp, cache, true, CRegExp::autoUtf8);
+    if (reg == nullptr)
       continue; // Failed to compile
 
     int regPosition;
-    if ((regPosition = reg.RegFind(label.c_str())) < 0)
+    if ((regPosition = reg->RegFind(label.c_str())) < 0)
       continue;
 
     VIDEO::EPISODE episode;
@@ -216,7 +219,7 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELI
 
     if (byDate)
     {
-      if (!GetAirDateFromRegExp(reg, episode))
+      if (!GetAirDateFromRegExp(*reg, episode))
         continue;
 
       CLog::LogF(LOGDEBUG, "Found date based match {} ({}) [{}]",
@@ -225,7 +228,7 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELI
     }
     else if (byTitle)
     {
-      if (!GetEpisodeTitleFromRegExp(reg, episode))
+      if (!GetEpisodeTitleFromRegExp(*reg, episode))
         continue;
 
       CLog::LogF(LOGDEBUG, "Found title based match {} ({}) [{}]",
@@ -233,7 +236,7 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELI
     }
     else
     {
-      if (!GetEpisodeAndSeasonFromRegExp(reg, episode, defaultSeason))
+      if (!GetEpisodeAndSeasonFromRegExp(*reg, episode, defaultSeason))
         continue;
 
       CLog::LogF(LOGDEBUG, "Found episode match {} (s{}e{}) [{}]",
@@ -243,7 +246,7 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELI
 
     // Grab the remainder from first regexp run
     // as second run might modify or empty it.
-    std::string remainder(reg.GetMatch(3));
+    std::string remainder(reg->GetMatch(3));
 
     // Check if the files base path is a dedicated folder that contains
     // only this single episode. If season and episode match with the
@@ -252,18 +255,18 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELI
     URIUtils::RemoveSlashAtEnd(basePath);
     basePath = URIUtils::GetFileName(basePath);
 
-    if (reg.RegFind(basePath.c_str()) > -1)
+    if (reg->RegFind(basePath.c_str()) > -1)
     {
       VIDEO::EPISODE parent;
       if (byDate)
       {
-        GetAirDateFromRegExp(reg, parent);
+        GetAirDateFromRegExp(*reg, parent);
         if (episode.cDate == parent.cDate)
           episode.isFolder = true;
       }
       else
       {
-        GetEpisodeAndSeasonFromRegExp(reg, parent, defaultSeason);
+        GetEpisodeAndSeasonFromRegExp(*reg, parent, defaultSeason);
         if (episode.iSeason == parent.iSeason && episode.iEpisode == parent.iEpisode)
           episode.isFolder = true;
       }
@@ -274,7 +277,7 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELI
 
     // check the remainder of the string for any further episodes.
     // Multi-part only applies to season/episode matches, not date or title based
-    if (!byDate && !byTitle && multiPartRegexValid)
+    if (!byDate && !byTitle && multiPartRegex != nullptr)
     {
       size_t offset{0};
       int reg2Position;
@@ -282,13 +285,14 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELI
       int currentEpisode{episode.iEpisode};
 
       // we want "long circuit" OR below so that both offsets are evaluated
-      while (static_cast<int>((reg2Position = reg2.RegFind(remainder.c_str() + offset)) > -1) |
-             static_cast<int>((regPosition = reg.RegFind(remainder.c_str() + offset)) > -1))
+      while (static_cast<int>((reg2Position = multiPartRegex->RegFind(remainder.c_str() + offset)) >
+                              -1) |
+             static_cast<int>((regPosition = reg->RegFind(remainder.c_str() + offset)) > -1))
       {
         if ((regPosition <= reg2Position && regPosition != -1) || // season (or 'ep') match
             (regPosition >= 0 && reg2Position == -1))
         {
-          GetEpisodeAndSeasonFromRegExp(reg, episode, defaultSeason);
+          GetEpisodeAndSeasonFromRegExp(*reg, episode, defaultSeason);
           if (currentSeason == episode.iSeason)
           {
             // Already added SxxEyy now loop (if needed) to SxxEzz
@@ -302,7 +306,7 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELI
                                 advancedSettings->m_tvshowMultiPartEnumRegExp, remainder);
 
             currentEpisode = episode.iEpisode;
-            remainder = reg.GetMatch(3);
+            remainder = reg->GetMatch(3);
           }
           else
           {
@@ -315,7 +319,7 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELI
               currentSeason = episode.iSeason;
               currentEpisode = episode.iEpisode;
               episodeList.push_back(episode);
-              remainder = reg.GetMatch(3);
+              remainder = reg->GetMatch(3);
             }
             else
             {
@@ -325,7 +329,7 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELI
               {
                 // Already added first episode of invalid range so remove it
                 episodeList.pop_back();
-                remainder = reg.GetMatch(3);
+                remainder = reg->GetMatch(3);
                 CLog::LogF(
                     LOGDEBUG,
                     "VideoInfoScanner: Removing season {}, episode {} as part of invalid range",
@@ -342,7 +346,7 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELI
         else if ((reg2Position < regPosition && reg2Position != -1) || // episode match
                  (reg2Position >= 0 && regPosition == -1))
         {
-          const std::string result{reg2.GetMatch(2)};
+          const std::string result{multiPartRegex->GetMatch(2)};
           const int last{std::stoi(result)};
           const std::string prefix{
               offset < remainder.length()
@@ -353,10 +357,11 @@ bool CEpisodeUtils::EnumerateEpisodeItem(const CFileItem* item, VIDEO::EPISODELI
                              : last};
 
           ProcessEpisodeRange(next, last, episode, episodeList,
-                              advancedSettings->m_tvshowMultiPartEnumRegExp, reg2.GetMatch(3));
+                              advancedSettings->m_tvshowMultiPartEnumRegExp,
+                              multiPartRegex->GetMatch(3));
 
           currentEpisode = episode.iEpisode;
-          offset += reg2Position + reg2.GetMatch(1).length() + result.length();
+          offset += reg2Position + multiPartRegex->GetMatch(1).length() + result.length();
         }
       }
     }

--- a/xbmc/utils/EpisodeUtils.h
+++ b/xbmc/utils/EpisodeUtils.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/RegExp.h"
 #include "video/Episode.h"
 
 class CFileItem;
@@ -15,5 +16,7 @@ class CFileItem;
 class CEpisodeUtils
 {
 public:
-  static bool EnumerateEpisodeItem(const CFileItem* item, KODI::VIDEO::EPISODELIST& episodeList);
+  static bool EnumerateEpisodeItem(const CFileItem* item,
+                                   KODI::VIDEO::EPISODELIST& episodeList,
+                                   KODI::REGEXP::RegExpCache* cache = nullptr);
 };

--- a/xbmc/utils/RegExp.h
+++ b/xbmc/utils/RegExp.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -10,7 +10,10 @@
 
 //! @todo - move to std::regex (after switching to gcc 4.9 or higher) and get rid of CRegExp
 
+#include <memory>
 #include <string>
+#include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #define PCRE2_CODE_UNIT_WIDTH 8
@@ -151,3 +154,53 @@ private:
 };
 
 std::vector<CRegExp> CompileRegexes(const std::vector<std::string>& regExpPatterns);
+
+namespace KODI::REGEXP
+{
+struct StringHash
+{
+  using is_transparent = void; // Enables heterogeneous operations.
+  std::size_t operator()(std::string_view sv) const
+  {
+    std::hash<std::string_view> hasher;
+    return hasher(sv);
+  }
+};
+
+// RegExpCache doesn't support concurrent access or execution of the cached regexp.
+// Synchronization must be provided by the caller for such scenarios.
+using RegExpCache =
+    std::unordered_map<std::string, std::shared_ptr<CRegExp>, StringHash, std::equal_to<>>;
+
+/*!
+ * \brief Provide the caller with a compiled CRegExp for the provided pattern. The CRegExp will be
+ *        retrieved from the optional cache first or created when it doesn't exist in the cache.
+ *        note: the cache key is the pattern. The same CRegExp will be returned for the same pattern
+ *        and different constructor arguments.
+ * \tparam ...Args 
+ * \param[in] pattern Regular expression pattern
+ * \param[in] cache Optional cache of regexp
+ * \param[in] ...ctorArgs Arguments to forward to the constructor of CRegExp
+ * \return A compiled regexp of the provided pattern.
+ */
+template<typename... Args>
+std::shared_ptr<CRegExp> GetRegExp(const std::string& pattern,
+                                   RegExpCache* cache,
+                                   Args&&... ctorArgs)
+{
+  if (cache)
+  {
+    if (auto iter = cache->find(pattern); iter != cache->end())
+      return iter->second;
+  }
+  auto regexp = std::make_shared<CRegExp>(std::forward<Args>(ctorArgs)...);
+  if (!regexp->RegComp(pattern))
+    regexp.reset();
+
+  // Unconditionnally add to the cache to avoid recompiling failing patterns.
+  if (cache)
+    cache->emplace(pattern, regexp);
+
+  return regexp;
+}
+} // namespace KODI::REGEXP

--- a/xbmc/utils/test/TestRegExp.cpp
+++ b/xbmc/utils/test/TestRegExp.cpp
@@ -302,3 +302,126 @@ TEST_F(TestRegExpLog, DumpOvector)
 
   EXPECT_TRUE(XFILE::CFile::Delete(logfile));
 }
+
+namespace
+{
+void RegExpCacheTest(KODI::REGEXP::RegExpCache* cache)
+{
+  std::shared_ptr<CRegExp> regexp;
+
+  // Invalid pattern
+  regexp = KODI::REGEXP::GetRegExp("(abc", cache);
+
+  EXPECT_EQ(nullptr, regexp);
+  if (cache != nullptr)
+  {
+    // braces to keep clang-format happy
+    EXPECT_EQ(1, cache->size());
+  }
+
+  // The cache doesn't grow for known patterns
+  regexp = KODI::REGEXP::GetRegExp("(abc", cache);
+
+  EXPECT_EQ(nullptr, regexp);
+  if (cache != nullptr)
+  {
+    // braces to keep clang-format happy
+    EXPECT_EQ(1, cache->size());
+  }
+
+  regexp = KODI::REGEXP::GetRegExp("^(Test)", cache);
+
+  if (cache != nullptr)
+  {
+    // braces to keep clang-format happy
+    EXPECT_EQ(2, cache->size());
+  }
+  EXPECT_NE(nullptr, regexp);
+  if (regexp != nullptr)
+  {
+    EXPECT_TRUE(regexp->IsCompiled());
+    EXPECT_EQ(0, regexp->RegFind("Test"));
+  }
+
+  // The cache doesn't grow for known patterns
+  KODI::REGEXP::GetRegExp("^(Test)", cache);
+
+  if (cache != nullptr)
+  {
+    // braces to keep clang-format happy
+    EXPECT_EQ(2, cache->size());
+  }
+
+  // Return a cached regexp
+  std::shared_ptr<CRegExp> regexp2;
+  regexp2 = KODI::REGEXP::GetRegExp("^(Test)", cache);
+
+  if (cache != nullptr)
+  {
+    // braces to keep clang-format happy
+    EXPECT_TRUE(regexp.get() == regexp2.get());
+  }
+  else
+  {
+    EXPECT_TRUE(regexp.get() != regexp2.get());
+  }
+}
+} // namespace
+
+TEST(TestRegExpCache, WithCache)
+{
+  KODI::REGEXP::RegExpCache cache;
+  EXPECT_TRUE(cache.empty());
+
+  RegExpCacheTest(&cache);
+}
+
+TEST(TestRegExpCache, WithoutCache)
+{
+  RegExpCacheTest(nullptr);
+}
+
+TEST(TestRegExpCache, CtorArgs)
+{
+  std::shared_ptr<CRegExp> regexp;
+
+  // Default constructor: case sensitive
+  regexp = KODI::REGEXP::GetRegExp("^(Test)", nullptr);
+
+  EXPECT_NE(nullptr, regexp);
+  if (regexp != nullptr)
+  {
+    EXPECT_TRUE(regexp->IsCompiled());
+    EXPECT_EQ(-1, regexp->RegFind("TeST"));
+  }
+
+  // ctor argument for case sensitive match
+  regexp = KODI::REGEXP::GetRegExp("^(Test)", nullptr, true, CRegExp::forceUtf8);
+
+  EXPECT_NE(nullptr, regexp);
+  if (regexp != nullptr)
+  {
+    EXPECT_TRUE(regexp->IsCompiled());
+    // Successful match with a different case
+    EXPECT_EQ(0, regexp->RegFind("TeST"));
+  }
+
+  // Default constructor: ascii mode
+  regexp = KODI::REGEXP::GetRegExp("\\x{00E0}", nullptr);
+  EXPECT_NE(nullptr, regexp);
+  if (regexp != nullptr)
+  {
+    EXPECT_TRUE(regexp->IsCompiled());
+    EXPECT_EQ(-1, regexp->RegFind("\u00E0")); // letter à
+  }
+
+  // Constructor argument for unicode mode
+  regexp = KODI::REGEXP::GetRegExp("\\x{00E0}", nullptr, false, CRegExp::forceUtf8);
+
+  EXPECT_NE(nullptr, regexp);
+  if (regexp != nullptr)
+  {
+    EXPECT_TRUE(regexp->IsCompiled());
+    EXPECT_EQ(0, regexp->RegFind("\u00E0"));
+  }
+}

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11144,6 +11144,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
     movie = root->FirstChildElement();
     std::string lastTitle;
     int lastMovieId{-1};
+    KODI::REGEXP::RegExpCache regexpCache;
     while (movie)
     {
       std::string currentTitle{};
@@ -11244,8 +11245,9 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         // season artwork
         KODI::ART::SeasonsArtwork seasonArt;
         artItem.GetVideoInfoTag()->m_strPath = artPath;
-        CVideoInfoScanner::GetSeasonThumbs(*artItem.GetVideoInfoTag(), seasonArt,
-                                           CVideoThumbLoader::GetArtTypes(MediaTypeSeason), true);
+        CVideoInfoScanner::GetSeasonThumbs(
+            *artItem.GetVideoInfoTag(), seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason),
+            true, CVideoInfoScanner::UseRemoteArtWithLocalScraper::YES, &regexpCache);
         for (const auto& [seasonNumber, art] : seasonArt)
         {
           const int seasonID = AddSeason(showID, seasonNumber);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1398,8 +1398,9 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (ProcessItemByVideoInfoTag(items[i].get(), episodeList))
         continue;
 
-      if (!CEpisodeUtils::EnumerateEpisodeItem(items[i].get(), episodeList))
-        CLog::Log(LOGDEBUG, "VideoInfoScanner: Could not enumerate file {}", CURL::GetRedacted(items[i]->GetPath()));
+      if (!CEpisodeUtils::EnumerateEpisodeItem(items[i].get(), episodeList, &m_regexpCache))
+        CLog::Log(LOGDEBUG, "VideoInfoScanner: Could not enumerate file {}",
+                  CURL::GetRedacted(items[i]->GetPath()));
     }
     return true;
   }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -377,7 +377,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         content == ContentType::TVSHOWS ? m_advancedSettings->m_tvshowExcludeFromScanRegExps
                                         : m_advancedSettings->m_moviesExcludeFromScanRegExps;
 
-    if (CUtil::ExcludeFileOrFolder(strDirectory, regexps))
+    if (CUtil::ExcludeFileOrFolder(strDirectory, regexps, &m_regexpCache))
       return true;
 
     if (HasNoMedia(strDirectory))
@@ -667,7 +667,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (CUtil::ExcludeFileOrFolder(pItem->GetPath(),
                                      (content == ContentType::TVSHOWS)
                                          ? m_advancedSettings->m_tvshowExcludeFromScanRegExps
-                                         : m_advancedSettings->m_moviesExcludeFromScanRegExps))
+                                         : m_advancedSettings->m_moviesExcludeFromScanRegExps,
+                                     &m_regexpCache))
         continue;
 
       if (info2->Content() == ContentType::MOVIES || info2->Content() == ContentType::MUSICVIDEOS)
@@ -1214,7 +1215,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
                 ? UseRemoteArtWithLocalScraper::NO
                 : UseRemoteArtWithLocalScraper::YES};
         GetSeasonThumbs(showInfo, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason),
-                        useLocal && !item->IsPlugin(), useRemoteArt);
+                        useLocal && !item->IsPlugin(), useRemoteArt, &m_regexpCache);
         for (const auto& [season, art] : seasonArt)
         {
           const int seasonID{m_database.AddSeason(static_cast<int>(showID), season)};
@@ -1386,7 +1387,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         continue;
 
       // Discard all exclude files defined by regExExcludes
-      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps))
+      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps, &m_regexpCache))
         continue;
 
       /*
@@ -1614,7 +1615,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     if (content == ContentType::MOVIES)
     {
       // find local trailer first
-      std::string strTrailer = UTILS::FindTrailer(*pItem);
+      std::string strTrailer = UTILS::FindTrailer(*pItem, &m_regexpCache);
       if (!strTrailer.empty())
         movieDetails.m_strTrailer = strTrailer;
 
@@ -1713,7 +1714,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
         if (!libraryImport)
           GetSeasonThumbs(movieDetails, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason),
-                          useLocal && !pItem->IsPlugin(), useRemoteArt);
+                          useLocal && !pItem->IsPlugin(), useRemoteArt, &m_regexpCache);
 
         lResult = m_database.SetDetailsForTvShow(multipath, movieDetails, art, seasonArt);
         movieDetails.m_iDbId = lResult;
@@ -2365,7 +2366,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
     for (int i = 0; i < items.Size(); ++i)
     {
-      if (items[i]->IsFolder() && !CUtil::ExcludeFileOrFolder(items[i]->GetPath(), excludes))
+      if (items[i]->IsFolder() &&
+          !CUtil::ExcludeFileOrFolder(items[i]->GetPath(), excludes, &m_regexpCache))
         return false;
     }
     return true;
@@ -2435,7 +2437,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
                                           KODI::ART::SeasonsArtwork& seasonArt,
                                           const std::vector<std::string>& artTypes,
                                           bool useLocal /* = true */,
-                                          UseRemoteArtWithLocalScraper useRemoteArt /* = yes */)
+                                          UseRemoteArtWithLocalScraper useRemoteArt /* = yes */,
+                                          KODI::REGEXP::RegExpCache* cache /* = nullptr*/)
   {
     int artLevel = CServiceBroker::GetSettingsComponent()->GetSettings()->
       GetInt(CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL);
@@ -2454,15 +2457,16 @@ CVideoInfoScanner::~CVideoInfoScanner()
                                      DIR_FLAG_NO_FILE_INFO);
       }
       extensions.erase(std::remove(extensions.begin(), extensions.end(), '.'), extensions.end());
-      CRegExp reg;
-      if (items.Size() && reg.RegComp("season([0-9]+)(-[a-z0-9]+)?\\.(" + extensions + ")"))
+      std::shared_ptr<CRegExp> reg;
+      const std::string pattern = "season([0-9]+)(-[a-z0-9]+)?\\.(" + extensions + ")";
+      if (!items.IsEmpty() && (reg = KODI::REGEXP::GetRegExp(pattern, cache)) != nullptr)
       {
         for (const auto& item : items)
         {
           std::string name = URIUtils::GetFileName(item->GetPath());
-          if (reg.RegFind(name) > -1)
+          if (reg->RegFind(name) > -1)
           {
-            int season = atoi(reg.GetMatch(1).c_str());
+            int season = atoi(reg->GetMatch(1).c_str());
             if (season > maxSeasons)
               maxSeasons = season;
           }

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -13,6 +13,7 @@
 #include "addons/Scraper.h"
 #include "guilib/GUIListItem.h"
 #include "utils/Artwork.h"
+#include "utils/RegExp.h"
 
 #include <set>
 #include <string>
@@ -49,14 +50,13 @@ namespace KODI::VIDEO
 
   class CVideoInfoScanner : public CInfoScanner
   {
-
+  public:
     enum class UseRemoteArtWithLocalScraper : bool
     {
       NO,
       YES
     };
 
-  public:
     CVideoInfoScanner();
     ~CVideoInfoScanner() override;
 
@@ -136,17 +136,19 @@ namespace KODI::VIDEO
 
     /*! \brief Get season thumbs for a tvshow.
      All seasons (regardless of whether the user has episodes) are added to the art map.
-     \param show     tvshow info tag
-     \param art      artwork map to which season thumbs are added.
-     \param useLocal whether to use local thumbs, defaults to true
-     \param useRemoteArt use remote art if also using local scraper. Defaults to yes.
+     \param[in] show     tvshow info tag
+     \param[in] art      artwork map to which season thumbs are added.
+     \param[in] useLocal whether to use local thumbs, defaults to true
+     \param[in] useRemoteArt use remote art if also using local scraper. Defaults to yes.
+     \param[in] cache regexp cache to avoid repeated compilations
      */
     static void GetSeasonThumbs(
         const CVideoInfoTag& show,
         KODI::ART::SeasonsArtwork& art,
         const std::vector<std::string>& artTypes,
         bool useLocal = true,
-        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES);
+        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES,
+        KODI::REGEXP::RegExpCache* cache = nullptr);
     static std::string GetImage(const CScraperUrl::SUrlEntry &image, const std::string& itemPath);
 
     static std::string GetMovieSetInfoFolder(const std::string& setTitle);
@@ -329,5 +331,6 @@ namespace KODI::VIDEO
     std::set<int> m_pathsToClean;
     std::shared_ptr<CAdvancedSettings> m_advancedSettings;
     CVideoDatabase::ScraperCache m_scraperCache;
+    mutable KODI::REGEXP::RegExpCache m_regexpCache;
   };
   } // namespace KODI::VIDEO

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022 Team Kodi
+ *  Copyright (C) 2022-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -42,7 +42,7 @@
 namespace KODI::VIDEO::UTILS
 {
 
-std::string FindTrailer(const CFileItem& item)
+std::string FindTrailer(const CFileItem& item, KODI::REGEXP::RegExpCache* cache /* = nullptr */)
 {
   std::string strFile2;
   std::string strFile = item.GetPath();
@@ -81,15 +81,16 @@ std::string FindTrailer(const CFileItem& item)
   std::string strFile3 = URIUtils::AddFileToFolder(strDir, "movie-trailer");
 
   // Precompile our REs
-  std::vector<CRegExp> matchRegExps;
-  CRegExp tmpRegExp(true, CRegExp::autoUtf8);
+  std::vector<std::shared_ptr<CRegExp>> matchRegExps;
   const std::vector<std::string>& strMatchRegExps =
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_trailerMatchRegExps;
 
   for (const auto& strRegExp : strMatchRegExps)
   {
-    if (tmpRegExp.RegComp(strRegExp))
-      matchRegExps.push_back(tmpRegExp);
+    if (std::shared_ptr<CRegExp> r =
+            KODI::REGEXP::GetRegExp(strRegExp, cache, true, CRegExp::autoUtf8);
+        r != nullptr)
+      matchRegExps.push_back(r);
   }
 
   std::string strTrailer;
@@ -108,7 +109,7 @@ std::string FindTrailer(const CFileItem& item)
     {
       for (auto& expr : matchRegExps)
       {
-        if (expr.RegFind(strCandidate) != -1)
+        if (expr->RegFind(strCandidate) != -1)
         {
           strTrailer = items[i]->GetPath();
           i = items.Size();

--- a/xbmc/video/VideoUtils.h
+++ b/xbmc/video/VideoUtils.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2022 Team Kodi
+ *  Copyright (C) 2022-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/RegExp.h"
 #include "video/Bookmark.h"
 
 #include <cstdint>
@@ -23,9 +24,11 @@ namespace KODI::VIDEO::UTILS
 
 /*! \brief
  *  Find a local trailer file for a given file item
+ *  \param[in] item the file item
+ *  \param[in] optional Regexp cache to avoid recompilation
  *  \return non-empty string with path of trailer if found
  */
-std::string FindTrailer(const CFileItem& item);
+std::string FindTrailer(const CFileItem& item, KODI::REGEXP::RegExpCache* cache = nullptr);
 
 /*!
  \brief Check whether an item is an optical media folder or its parent.

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -310,10 +310,11 @@ bool CGUIWindowVideoBase::OnItemInfo(const CFileItem& fileItem)
       const std::vector<std::string>& excludeFromScan = CServiceBroker::GetSettingsComponent()
                                                             ->GetAdvancedSettings()
                                                             ->m_moviesExcludeFromScanRegExps;
+      KODI::REGEXP::RegExpCache cache;
       for (const auto& i : items)
       {
         if (VIDEO::IsVideo(*i) && !PLAYLIST::IsPlayList(*i) &&
-            !CUtil::ExcludeFileOrFolder(i->GetPath(), excludeFromScan))
+            !CUtil::ExcludeFileOrFolder(i->GetPath(), excludeFromScan, &cache))
         {
           item.SetPath(i->GetPath());
           item.SetFolder(false);

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -789,9 +789,10 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
 
   if (!regexps.empty())
   {
+    KODI::REGEXP::RegExpCache cache;
     for (int i=0; i < items.Size();)
     {
-      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps, nullptr))
+      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps, &cache))
         items.Remove(i);
       else
         i++;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -791,7 +791,7 @@ bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemLis
   {
     for (int i=0; i < items.Size();)
     {
-      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps))
+      if (CUtil::ExcludeFileOrFolder(items[i]->GetPath(), regexps, nullptr))
         items.Remove(i);
       else
         i++;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The PR avoids some unnecessary regexp compilation during library scans. The regexp are compiled once, stored in caches and reused.

The caches have the lifetime of the library scan or Media Window GetDirectory() call. They don't deal with concurrent access.

A 10-15% speedup was measured on a Windows desktop for a video library scan. I don't have a significant music library to benchmark.

Note: the constructor arguments are forwarded but are not part of the cache key, as explained in code comments. It's not needed for this implementation of local caches but would be for a global cache (for example different case sensitivity or utf8 mode)

Out of scope: there are a few other regexp uses that could benefit from caching, in particular the xml/nfo file reading. There is no single "owner" of the regexp to manage the life cycle and the caches would have to be passed as parameters in many places...
I think those would be best handled with a global cache in a future PR, with eviction of the least used regexp and concurrency handling (the CRegExp class is not thread safe, another refactor needed), 


## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed the many regexp unnecessary compilations in the scanners.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Scan with movie/episode addition or without change, with excludefromscan/excludetvshowsfromscan advanced settings.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Faster library scan.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
