### PR TITLE
[music] Force tag rescan to re-read disk tags on already-loaded items

### DIFF
--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -600,7 +600,13 @@ CInfoScanner::InfoRet CMusicInfoScanner::ScanTags(const CFileItemList& items,
     m_currentItem++;
 
     CMusicInfoTag& tag = *pItem->GetMusicInfoTag();
-    if (!tag.Loaded())
+    // Forced rescan must re-read tags from disk even if the item arrives with
+    // tag.Loaded() already true (e.g. DB-enriched directory listings). The
+    // folder-level SCAN_RESCAN check above (line 521) bypasses the path-hash
+    // skip, but without this check ScanTags would still reuse cached tag
+    // state on a per-file basis, defeating "Do full tag scan even when
+    // unchanged".
+    if (!tag.Loaded() || (m_flags & SCAN_RESCAN))
     {
       std::unique_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(*pItem));
       if (nullptr != pLoader)


### PR DESCRIPTION
When the user invokes "Scan item into library" with "Do full tag scan even when music files are unchanged" enabled, Kodi does not read the file tags.

## Description
The SCAN_RESCAN flag was honoured at the folder-level path-hash check (CMusicInfoScanner:: RetrieveMusicInfo path-hash branch) but not at the per-file ScanTags loop. Fix: Honour SCAN_RESCAN at the per-file gate so the disk read always fires when the user explicitly forces a rescan.

EDIT: @garbear  This is a Huge user pain point: Example I have been supporting Kodi users on a music forum for several year. I get newbies using Kodi music for first time, I have seen several users that cant update the music tags due to this bug that have  dumped Kodi because it "just doesn't work". On user even started bagging Kodi across multiple threads with "Kodi is a piece of s**t. Don't use it!" THIS BUG NEEDS MERGING!! Don't wait for @DaveTBlake to approve. Get it into Beta 1 please.

## Motivation and context
UI option: "Do full tag scan even when music files are unchanged" has not actually re-read tags from disk in the common case for a long time. Anyone editing tags externally (Picard, Mp3tag, foobar2000…) and then asking Kodi to pick up the changes has been hitting cached state instead of disk truth, with no log indication that the force flag was dropped. The fix is a one-line addition to the existing gate plus a comment explaining why.

## How has this been tested?
LibreElec x64

### Regression introduced by
Commit `3ec411a9a7`

The bug has therefore been dormant since 2012 roughly fourteen years. It was uncovered while validating Piers music scanner behaviour for tag-edit workflows.

## What is the effect on users?
Kodi actually does what it says it will!! Read the tags!! Users need to refresh existing tags

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
