### PR TITLE
VideoPlayer: fix subtitle extradata being discarded in CDVDDemuxClient

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -525,7 +525,7 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
         streamSubtitle->m_parser->flags |= PARSER_FLAG_COMPLETE_FRAMES;
     }
 
-    if (source->extraData.GetSize() == 4)
+    if (source->extraData)
     {
       streamSubtitle->extraData = source->extraData;
     }


### PR DESCRIPTION
# VideoPlayer: fix subtitle extradata being discarded in `CDVDDemuxClient`

One line in `xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp` silently drops every subtitle stream's `extradata` unless it is exactly 4 bytes in size. ASS/SSA script headers are several kilobytes long, so they are always dropped, and any InputStream addon delivering rich subtitle tracks fails to render them. `CDVDOverlayCodecSSA::Open` calls into libass's `DecodeHeader` with a `nullptr`, libass refuses, and the log shows `OpenStream - Unable to init overlay codec`. This PR replaces the 4-byte size gate with the same non-empty check the audio and video branches already use.

## Symptom

For any media played through an InputStream addon (anything that goes through `CDVDDemuxClient::SetStreamProps`), ASS/SSA subtitle tracks fail to initialize:

```
ERROR <general>: CVideoPlayerSubtitle::OpenStream - Unable to init overlay codec
```

No `CDVDSubtitlesLibass: Creating new ASS track` line is ever printed, because libass rejects the call before reaching that log statement. Plain DVD-style image subtitles still work, since they don't need extradata. PGS/DVB subs from PVR streams also work, because their extradata is typically 4 bytes or absent (see history below).

The default VideoPlayer path (no InputStream addon) is unaffected because it does not route through `CDVDDemuxClient::RequestStream`.

## Root cause

In `CDVDDemuxClient::SetStreamProps`, the audio and video branches copy extradata whenever it is non-empty:

```cpp
// audio (line 451)
if (source->extraData)
{
  streamAudio->extraData = source->extraData;
}

// video (line 488)
if (source->extraData)
{
  streamVideo->extraData = source->extraData;
}
```

The subtitle branch gates the copy on an exact 4-byte size instead:

```cpp
// subtitle (line 528, before this PR)
if (source->extraData.GetSize() == 4)
{
  streamSubtitle->extraData = source->extraData;
}
```

Any subtitle stream whose extradata is not exactly 4 bytes ends up with `streamSubtitle->extraData` of size zero. When the player later builds a `CDVDStreamInfo hints` from this stream and hands it to `CDVDOverlayCodecSSA::Open`, the codec calls:

```cpp
return m_libass->DecodeHeader(reinterpret_cast<char*>(hints.extradata.GetData()),
                              hints.extradata.GetSize());
```

`CDVDSubtitlesLibass::DecodeHeader` returns false immediately if its `data` pointer is null:

```cpp
bool CDVDSubtitlesLibass::DecodeHeader(char* data, int size)
{
  std::unique_lock<CCriticalSection> lock(m_section);
  if (!m_library || !data)
    return false;
  CLog::Log(LOGINFO, "CDVDSubtitlesLibass: Creating new ASS track");
  ...
}
```

That false propagates back up as the "Unable to init overlay codec" error. The data was correctly extracted by the InputStream addon and delivered across the addon API boundary. Kodi then dropped it inside `CDVDDemuxClient` before libass ever saw it.

## History: how a PVR-only behavior became a universal regression

The offending check has three commits behind it. Each subsequent author saw the `== 4` test, treated it as load-bearing, and preserved it on the assumption that the original author had a good reason. The original author did. Later authors were reasoning about code that no longer existed in the same form.

### 1. `27d94da7` (2013-12-16, Joakim Plate / elupus)

> Subject: `livetv: dvb subtitle identifiers should be written big endian`

Introduced a 4-byte big-endian DVB-subtitle identifier (Composition Page ID + Ancillary Page ID, packed) in the PVR-only `DVDDemuxPVRClient.cpp`. Correct in context. This was the only kind of subtitle "extradata" that ever flowed through the PVR demuxer at the time, and the four-byte size was a property of the DVB spec, not a gate on anything else. The commit message itself notes uncertainty about the bitshifts ("not sure where that shift of 4 bits come from").

### 2. `016e5f58` (2016-01-29, Rainer Hochecker / fernetmenta)

> Subject: `VideoPlayer: refactor DemuxerClient (ex PVR)`

This refactor replaced `DVDDemuxPVRClient.cpp` (517 lines deleted) with `DVDDemuxClient.cpp` (575 lines added) as a generic demuxer for all InputStream addons. The new subtitle branch was written like this:

```cpp
if (source->ExtraSize == 4)
{
  st->ExtraData = new uint8_t[4];
  st->ExtraSize = 4;
  for (int j=0; j<4; j++)
    ...
}
```

The intent was to keep the existing PVR behavior. The semantics changed completely, though. What had been a description of a guaranteed 4-byte payload in PVR-only code became a gate on a now-generic code path. From this commit onward, every InputStream addon's subtitle extradata of any size other than 4 bytes is silently dropped.

### 3. `e5922ff2` (2023-04-22, Markus Härer)

> Subject: `FFmpeg: Handle FFmpeg extradata in dedicated class`

This refactor replaced raw `uint8_t*`/`ExtraSize` pairs with the typed `FFmpegExtraData` class for safer allocation. The diff translates the gate one-for-one:

```diff
-    if (source->ExtraSize == 4)
+    if (source->extraData.GetSize() == 4)
     {
-      streamSubtitle->ExtraData = std::make_unique<uint8_t[]>(4);
-      streamSubtitle->ExtraSize = 4;
-      for (int j=0; j<4; j++)
+      streamSubtitle->extraData = source->extraData;
     }
```

The PR was a memory-management cleanup. It carried the predicate forward without revisiting whether the predicate was still doing the right thing.

## The fix

Replace the subtitle branch's size-equality test with the same non-empty test the audio and video branches use:

```diff
-    if (source->extraData.GetSize() == 4)
+    if (source->extraData)
     {
       streamSubtitle->extraData = source->extraData;
     }
```

One-line change to `xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp`. After the change, the subtitle branch is symmetric with audio (line 451) and video (line 488). The 4-byte DVB identifier from PVR streams still passes, since it is non-empty, so legacy PVR behavior is preserved.

## Verification

Reproduced and fixed in a local build of the Omega-stable branch, where the same code path is at line 522. Same defect, same one-line fix.

Test setup:

* **Frontend**: `inputstream.ffmpegdirect` 21.3.8 (the version shipped on Arch Linux and CoreELEC 21.x for ARM)
* **Media**: a 60-second MKV with two embedded ASS subtitle tracks of ~9 KB extradata each (`[Script Info]` / `[V4+ Styles]` / `[Events]` script header). A standalone libavformat probe confirmed `extradata_size = 9099` and that the bytes parse as a valid ASS header.
* **Stock Kodi 21 Omega**: `ERROR <general>: CVideoPlayerSubtitle::OpenStream - Unable to init overlay codec`. No `CDVDSubtitlesLibass: Creating new ASS track` log line. Subtitles never rendered.
* **Patched Kodi 21 Omega** (`if (source->extraData.GetSize() == 4)` → `if (source->extraData)`): `info <general>: CDVDSubtitlesLibass: Creating new ASS track`. ASS subtitles rendered correctly with full style support.

The full call chain was traced. Hook point is `CDVDDemuxClient::SetStreamProps`. Failure point is `CDVDSubtitlesLibass::DecodeHeader` short-circuiting on a `nullptr` data argument. Everything in between (`InputStreamAddon` reading from `m_ExtraData`/`m_ExtraSize` on the addon-side struct, `DemuxStreamSubtitleFFmpeg::GetInformation` packing the extradata into `kodi::addon::InputstreamInfo`, the addon-side `SetExtraData(uint8_t*, size_t)` copying into the C-structure) is correct and not involved in the data loss.

## Scope and impact

* **Restores** ASS/SSA rendering for every InputStream addon: `inputstream.ffmpegdirect`, `inputstream.adaptive`, plugin-specific demuxers. Any consumer that delivers a Matroska-style script header via the standard extradata path now works.
* **Does not change** PVR behavior: the 4-byte DVB-subtitle identifier still satisfies `if (source->extraData)` (truthy on any size > 0), and downstream consumers of that identifier are unaffected by this change.
* **Does not change** audio or video paths.
* **No regression risk for the 4-byte case**: the only difference between the old gate and the new gate is that more extradata sizes are now allowed through. Anything that worked before still works.

## Backport

This bug is present in the Omega-stable (21.x) branch in the same form, at line 522 instead of 528. The literal `if (source->extraData.GetSize() == 4)` is identical. If this PR merges, a cherry-pick PR against `Omega` would be worthwhile, since the symptom is observable in any 21.x release with InputStream-based playback.

## Context

This bug surfaced in a Jellyfin-on-Kodi setup (Jellyfin server fronted by Authentik forward-auth, played via the Jellycon addon plus `inputstream.ffmpegdirect`). Tracing why subtitles stopped working under that combination took a tour through addon code, auth-proxy headers, and `inputstream.ffmpegdirect`'s probe path before landing on this `CDVDDemuxClient` line. The "Unable to init overlay codec" error is far removed from the actual cause, and a quick search shows it has been reported intermittently for years against many different addons. Some fraction of those reports are likely this same bug.
