### PR TITLE
FixedList control: configurable vertical alignment and top movement

### DIFF
--- a/addons/skin.estuary/xml/Includes_DialogSelect.xml
+++ b/addons/skin.estuary/xml/Includes_DialogSelect.xml
@@ -256,7 +256,7 @@
 					<param name="list_id" value="3" />
 				</include>
 			</control>
-			<control type="list" id="6">
+			<control type="fixedlist" id="6">
 				<left>20</left>
 				<top>100</top>
 				<width>930</width>
@@ -266,6 +266,10 @@
 				<onleft>9001</onleft>
 				<onright>61</onright>
 				<pagecontrol>61</pagecontrol>
+				<focusposition>4</focusposition>
+				<startmovement>4</startmovement>
+				<endmovement>5</endmovement>
+				<aligny>top</aligny>
 				<scrolltime>200</scrolltime>
 				<itemlayout height="75" width="930">
 					<control type="image">
@@ -439,7 +443,7 @@
 					<param name="list_id" value="3" />
 				</include>
 			</control>
-			<control type="list" id="6">
+			<control type="fixedlist" id="6">
 				<left>20</left>
 				<top>100</top>
 				<width>930</width>
@@ -449,6 +453,10 @@
 				<onleft>9001</onleft>
 				<onright>61</onright>
 				<pagecontrol>61</pagecontrol>
+				<focusposition>4</focusposition>
+				<startmovement>4</startmovement>
+				<endmovement>5</endmovement>
+				<aligny>top</aligny>
 				<scrolltime>200</scrolltime>
 				<itemlayout height="75" width="930">
 					<control type="image">
@@ -621,7 +629,7 @@
 					<param name="list_id" value="3" />
 				</include>
 			</control>
-			<control type="list" id="6">
+			<control type="fixedlist" id="6">
 				<left>20</left>
 				<top>100</top>
 				<width>880</width>
@@ -631,6 +639,10 @@
 				<onleft>9001</onleft>
 				<onright>61</onright>
 				<pagecontrol>61</pagecontrol>
+				<focusposition>4</focusposition>
+				<startmovement>4</startmovement>
+				<endmovement>5</endmovement>
+				<aligny>top</aligny>
 				<scrolltime>200</scrolltime>
 				<itemlayout height="75" width="880">
 					<control type="image">

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -888,6 +888,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
   float buttonGap = 5;
   int startMovement = 0;
   int endMovement = 0;
+  FixedListAlignY fixedListAlignY = FixedListAlignY::CENTER;
   CAspectRatio aspect;
   std::string allowHiddenFocus;
   std::string enableCondition;
@@ -1027,6 +1028,10 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
   uint32_t alignY = 0;
   if (GetLabelAlignmentY(pControlNode, "aligny", alignY))
     labelInfo.align |= alignY;
+  // No attribute = center vertical alignment
+  GetAlignmentY(pControlNode, "aligny", fixedListAlignY,
+                {FixedListAlignY::CENTER, FixedListAlignY::TOP, FixedListAlignY::CENTER,
+                 FixedListAlignY::BOTTOM});
   if (XMLUtils::GetFloat(pControlNode, "textwidth", labelInfo.width))
     labelInfo.align |= XBFONT_TRUNCATED;
 
@@ -1617,9 +1622,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       CScroller scroller;
       GetScroller(pControlNode, "scrolltime", scroller);
 
-      control =
-          new CGUIFixedListContainer(parentID, id, posX, posY, width, height, orientation, scroller,
-                                     preloadItems, focusPosition, startMovement, endMovement);
+      control = new CGUIFixedListContainer(parentID, id, posX, posY, width, height, orientation,
+                                           scroller, preloadItems, focusPosition, startMovement,
+                                           endMovement, fixedListAlignY);
       CGUIFixedListContainer* fcontrol = static_cast<CGUIFixedListContainer*>(control);
       fcontrol->LoadLayout(pControlNode);
       fcontrol->LoadListProvider(pControlNode, defaultControl, defaultAlways);

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -864,7 +864,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
   std::string strRSSTags = "";
 
   float buttonGap = 5;
-  int iMovementRange = 0;
+  int startMovement = 0;
+  int endMovement = 0;
   CAspectRatio aspect;
   std::string allowHiddenFocus;
   std::string enableCondition;
@@ -1130,7 +1131,14 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       orientation = HORIZONTAL;
   }
   XMLUtils::GetFloat(pControlNode, "itemgap", buttonGap);
-  XMLUtils::GetInt(pControlNode, "movement", iMovementRange);
+
+  int movement = 0;
+  XMLUtils::GetInt(pControlNode, "movement", movement);
+  if (!XMLUtils::GetInt(pControlNode, "startmovement", startMovement))
+    startMovement = movement;
+  if (!XMLUtils::GetInt(pControlNode, "endmovement", endMovement))
+    endMovement = movement;
+
   GetAspectRatio(pControlNode, "aspectratio", aspect);
 
   bool alwaysScroll;
@@ -1587,8 +1595,9 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
       CScroller scroller;
       GetScroller(pControlNode, "scrolltime", scroller);
 
-      control = new CGUIFixedListContainer(parentID, id, posX, posY, width, height, orientation,
-                                           scroller, preloadItems, focusPosition, iMovementRange);
+      control =
+          new CGUIFixedListContainer(parentID, id, posX, posY, width, height, orientation, scroller,
+                                     preloadItems, focusPosition, startMovement, endMovement);
       CGUIFixedListContainer* fcontrol = static_cast<CGUIFixedListContainer*>(control);
       fcontrol->LoadLayout(pControlNode);
       fcontrol->LoadListProvider(pControlNode, defaultControl, defaultAlways);

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -60,6 +60,8 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <array>
+
 using namespace KODI;
 using namespace KODI::GUILIB;
 using namespace PVR;
@@ -108,6 +110,40 @@ static const ControlMapping controls[] = {
     {"visualisation", CGUIControl::GUICONTROL_VISUALISATION},
     {"wraplist", CGUIControl::GUICONTAINER_WRAPLIST},
 };
+
+namespace
+{
+/*!
+ * \brief Retrieve vertical alignment tag value
+ * \param[in] rootNode root XML node
+ * \param[in] tag tag name
+ * \param[out] alignment vertical alignment - one of the values provided in values
+ * \param[in] values values for unknown, top, center and bottom vertical alignment (in that order)
+ * \return true when the tag is found, false otherwise
+ */
+template<typename T>
+bool GetAlignmentY(const TiXmlNode* rootNode,
+                   const char* tag,
+                   T& alignment,
+                   std::array<T, 4> values)
+{
+  const TiXmlNode* pNode = rootNode->FirstChild(tag);
+  if (!pNode || !pNode->FirstChild())
+    return false;
+
+  const std::string strAlign = pNode->FirstChild()->Value();
+
+  alignment = values[0];
+  if (strAlign == "top")
+    alignment = values[1];
+  else if (strAlign == "center")
+    alignment = values[2];
+  else if (strAlign == "bottom")
+    alignment = values[3];
+
+  return true;
+}
+} // namespace
 
 CGUIControl::GUICONTROLTYPES CGUIControlFactory::TranslateControlType(const std::string& type)
 {
@@ -455,25 +491,11 @@ bool CGUIControlFactory::GetAlignment(const TiXmlNode* pRootNode,
   return true;
 }
 
-bool CGUIControlFactory::GetAlignmentY(const TiXmlNode* pRootNode,
-                                       const char* strTag,
-                                       uint32_t& alignment)
+bool CGUIControlFactory::GetLabelAlignmentY(const TiXmlNode* pRootNode,
+                                            const char* strTag,
+                                            uint32_t& alignment)
 {
-  const TiXmlNode* pNode = pRootNode->FirstChild(strTag);
-  if (!pNode || !pNode->FirstChild())
-  {
-    return false;
-  }
-
-  std::string strAlign = pNode->FirstChild()->Value();
-
-  alignment = 0;
-  if (strAlign == "center")
-  {
-    alignment = XBFONT_CENTER_Y;
-  }
-
-  return true;
+  return GetAlignmentY(pRootNode, strTag, alignment, {0, 0, XBFONT_CENTER_Y, 0});
 }
 
 bool CGUIControlFactory::GetConditionalVisibility(const TiXmlNode* control,
@@ -1003,7 +1025,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
     labelInfo.font = g_fontManager.GetFont(strFont);
   XMLUtils::GetString(pControlNode, "monofont", strMonoFont);
   uint32_t alignY = 0;
-  if (GetAlignmentY(pControlNode, "aligny", alignY))
+  if (GetLabelAlignmentY(pControlNode, "aligny", alignY))
     labelInfo.align |= alignY;
   if (XMLUtils::GetFloat(pControlNode, "textwidth", labelInfo.width))
     labelInfo.align |= XBFONT_TRUNCATED;

--- a/xbmc/guilib/GUIControlFactory.h
+++ b/xbmc/guilib/GUIControlFactory.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -73,7 +73,9 @@ public:
                              int parentID);
   static bool GetTexture(const TiXmlNode* pRootNode, const char* strTag, CTextureInfo& image);
   static bool GetAlignment(const TiXmlNode* pRootNode, const char* strTag, uint32_t& dwAlignment);
-  static bool GetAlignmentY(const TiXmlNode* pRootNode, const char* strTag, uint32_t& dwAlignment);
+  static bool GetLabelAlignmentY(const TiXmlNode* pRootNode,
+                                 const char* strTag,
+                                 uint32_t& dwAlignment);
   static bool GetAnimations(TiXmlNode* control,
                             const CRect& rect,
                             int context,

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -12,13 +12,26 @@
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 
-CGUIFixedListContainer::CGUIFixedListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems, int fixedPosition, int cursorRange)
-    : CGUIBaseContainer(parentID, controlID, posX, posY, width, height, orientation, scroller, preloadItems)
+CGUIFixedListContainer::CGUIFixedListContainer(int parentID,
+                                               int controlID,
+                                               float posX,
+                                               float posY,
+                                               float width,
+                                               float height,
+                                               ORIENTATION orientation,
+                                               const CScroller& scroller,
+                                               int preloadItems,
+                                               int fixedPosition,
+                                               int startCursorRange,
+                                               int endCursorRange)
+  : CGUIBaseContainer(
+        parentID, controlID, posX, posY, width, height, orientation, scroller, preloadItems)
 {
   ControlType = GUICONTAINER_FIXEDLIST;
   m_type = VIEW_TYPE_LIST;
   m_fixedCursor = fixedPosition;
-  m_cursorRange = std::max(0, cursorRange);
+  m_startCursorRange = startCursorRange;
+  m_endCursorRange = endCursorRange;
   SetCursor(m_fixedCursor);
 }
 
@@ -288,8 +301,8 @@ int CGUIFixedListContainer::GetCurrentPage() const
 
 void CGUIFixedListContainer::GetCursorRange(int &minCursor, int &maxCursor) const
 {
-  minCursor = std::max(m_fixedCursor - m_cursorRange, 0);
-  maxCursor = std::min(m_fixedCursor + m_cursorRange, m_itemsPerPage);
+  minCursor = std::max(m_fixedCursor - m_startCursorRange, 0);
+  maxCursor = std::min(m_fixedCursor + m_endCursorRange, m_itemsPerPage);
 
   if (m_items.empty())
   {
@@ -298,7 +311,8 @@ void CGUIFixedListContainer::GetCursorRange(int &minCursor, int &maxCursor) cons
     return;
   }
 
-  while (maxCursor - minCursor > (int)m_items.size() - 1)
+  const int itemsCount = static_cast<int>(m_items.size());
+  while (maxCursor - minCursor > itemsCount - 1)
   {
     if (maxCursor - m_fixedCursor > m_fixedCursor - minCursor)
       maxCursor--;
@@ -306,4 +320,3 @@ void CGUIFixedListContainer::GetCursorRange(int &minCursor, int &maxCursor) cons
       minCursor++;
   }
 }
-

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -12,6 +12,8 @@
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 
+#include <functional>
+
 CGUIFixedListContainer::CGUIFixedListContainer(int parentID,
                                                int controlID,
                                                float posX,
@@ -23,7 +25,8 @@ CGUIFixedListContainer::CGUIFixedListContainer(int parentID,
                                                int preloadItems,
                                                int fixedPosition,
                                                int startCursorRange,
-                                               int endCursorRange)
+                                               int endCursorRange,
+                                               FixedListAlignY alignY)
   : CGUIBaseContainer(
         parentID, controlID, posX, posY, width, height, orientation, scroller, preloadItems)
 {
@@ -32,6 +35,7 @@ CGUIFixedListContainer::CGUIFixedListContainer(int parentID,
   m_fixedCursor = fixedPosition;
   m_startCursorRange = startCursorRange;
   m_endCursorRange = endCursorRange;
+  m_alignY = alignY;
   SetCursor(m_fixedCursor);
 }
 
@@ -311,12 +315,30 @@ void CGUIFixedListContainer::GetCursorRange(int &minCursor, int &maxCursor) cons
     return;
   }
 
-  const int itemsCount = static_cast<int>(m_items.size());
-  while (maxCursor - minCursor > itemsCount - 1)
+  std::function<void(int& minCursor, int& maxCursor, int fixedCursor)> fn;
+
+  switch (m_alignY)
   {
-    if (maxCursor - m_fixedCursor > m_fixedCursor - minCursor)
-      maxCursor--;
-    else
-      minCursor++;
+    case FixedListAlignY::CENTER:
+      fn = [](int& minCursor, int& maxCursor, int fixedCursor)
+      {
+        if (maxCursor - fixedCursor > fixedCursor - minCursor)
+          maxCursor--;
+        else
+          minCursor++;
+      };
+      break;
+    case FixedListAlignY::TOP:
+      fn = [](int& minCursor, int& maxCursor, int fixedCursor) { maxCursor--; };
+      break;
+    case FixedListAlignY::BOTTOM:
+      fn = [](int& minCursor, int& maxCursor, int fixedCursor) { minCursor++; };
+      break;
+    default:
+      // unknown value: nothing can be done, exit to avoid an infinite loop.
+      return;
   }
+
+  while (maxCursor - minCursor > static_cast<int>(m_items.size()) - 1)
+    fn(minCursor, maxCursor, m_fixedCursor);
 }

--- a/xbmc/guilib/GUIFixedListContainer.dox
+++ b/xbmc/guilib/GUIFixedListContainer.dox
@@ -32,6 +32,7 @@ control is very flexible.
           <autoscroll>true</autoscroll>
           <focusposition>4</focusposition>
           <movement>6</movement>
+		  <aligny>top</aligny>
           <itemlayout width="250" height="29">
                     <control type="image">
                             <posx>5</posx>
@@ -130,6 +131,7 @@ important, as xml tags are case-sensitive.
 | content       | Used to set the item content that this list will contain. Allows the skinner to setup a list anywhere they want with a static set of content, as a useful alternative to the grouplist control. [See here for more information](http://kodi.wiki/view/Static_List_Content).
 | preloaditems  | Used in association with the background image loader. [See here for more information](http://kodi.wiki/view/Background_Image_Loader).
 | autoscroll    | Used to make the container scroll automatically
+| aligny        | Can be top, center, or bottom. Aligns the list items within the available list area. Has no effect when items fill the list area. Defaults to center.
 
 
 --------------------------------------------------------------------------------

--- a/xbmc/guilib/GUIFixedListContainer.dox
+++ b/xbmc/guilib/GUIFixedListContainer.dox
@@ -1,7 +1,7 @@
 /*!
 
 \page Fixed_List_Container Fixed List Container
-\brief <b>Used for a list of items with a fixed focus. Same as the
+\brief <b>Used for a list of items with a fixed focus. Similar to the
 \ref Wrap_List_Container "Wrap List Container" except it doesn't wrap.</b>
 
 \tableofcontents
@@ -122,7 +122,9 @@ important, as xml tags are case-sensitive.
 | pagecontrol   | Used to set the <b>`<id>`</b> of the page control used to control this list.
 | scrolltime    | The time (in ms) to scroll from one item to another. By default, this is 200ms. The list will scroll smoothly from one item to another as needed. Set it to zero to disable the smooth scrolling. The scroll movement can be further adjusted by selecting one of the available [tween](http://kodi.wiki/view/Tweeners) methods.
 | focusposition | Specifies the focus position (from 0 -> number of displayable items - 1). The focused position doesn't change - instead, the items move up or down (or left and right) as focus changes.
-| movement      | This will make the focused position scroll again at the end of the list. (ie. <b>`<movement>6</movement>`</b> if there are only 6 items below the focus, the focus moves down to the bottom)
+| startmovement | This will make the focused position scroll again at the beginning of the list. (ie. <b>`<startmovement>6</startmovement>`</b> if there are only 6 items below the focus, the focus moves up to the top) [Added in v22]
+| endmovement   | This will make the focused position scroll again at the end of the list. (ie. <b>`<endmovement>6</endmovement>`</b> if there are only 6 items below the focus, the focus moves down to the bottom) [Added in v22]
+| movement      | This will make the focused position scroll again at the beginning and end of the list and is used as default value for <b>`<startmovement>`</b> and <b>`<endmovement>`</b> when they are not specified (ie. <b>`<movement>6</movement>`</b> if there are only 6 items below the focus, the focus moves down to the bottom)
 | itemlayout    | Specifies the layout of items in the list. Requires the height attribute set in a vertical list, and the width attribute set for a horizontal list. The <b>`<itemlayout>`</b> then contains as many label and image controls as required. [See here for more information](http://kodi.wiki/view/Container_Item_Layout).
 | focusedlayout | Specifies the layout of items in the list that have focus. Requires the height attribute set in a vertical list, and the width attribute set for a horizontal list. The <b>`<focusedlayout>`</b> then contains as many label and image controls as required. [See here for more information](http://kodi.wiki/view/Container_Item_Layout).
 | content       | Used to set the item content that this list will contain. Allows the skinner to setup a list anywhere they want with a static set of content, as a useful alternative to the grouplist control. [See here for more information](http://kodi.wiki/view/Static_List_Content).

--- a/xbmc/guilib/GUIFixedListContainer.h
+++ b/xbmc/guilib/GUIFixedListContainer.h
@@ -15,6 +15,13 @@
 
 #include "GUIBaseContainer.h"
 
+enum class FixedListAlignY
+{
+  CENTER = 0,
+  TOP,
+  BOTTOM,
+};
+
 /*!
  \ingroup controls
  \brief
@@ -33,7 +40,8 @@ public:
                          int preloadItems,
                          int fixedPosition,
                          int startCursorRange,
-                         int endCursorRange);
+                         int endCursorRange,
+                         FixedListAlignY alignY);
   ~CGUIFixedListContainer(void) override;
   CGUIFixedListContainer* Clone() const override { return new CGUIFixedListContainer(*this); }
 
@@ -68,5 +76,6 @@ private:
   int m_fixedCursor; ///< default position the skinner wishes to use for the focused item
   int m_startCursorRange; ///< range that the focused item can vary when at the beginning end of the list
   int m_endCursorRange; ///< range that the focused item can vary when at the end of the list
+  FixedListAlignY m_alignY; //!< Vertical alignment of the items
 };
 

--- a/xbmc/guilib/GUIFixedListContainer.h
+++ b/xbmc/guilib/GUIFixedListContainer.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -22,7 +22,18 @@
 class CGUIFixedListContainer : public CGUIBaseContainer
 {
 public:
-  CGUIFixedListContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems, int fixedPosition, int cursorRange);
+  CGUIFixedListContainer(int parentID,
+                         int controlID,
+                         float posX,
+                         float posY,
+                         float width,
+                         float height,
+                         ORIENTATION orientation,
+                         const CScroller& scroller,
+                         int preloadItems,
+                         int fixedPosition,
+                         int startCursorRange,
+                         int endCursorRange);
   ~CGUIFixedListContainer(void) override;
   CGUIFixedListContainer* Clone() const override { return new CGUIFixedListContainer(*this); }
 
@@ -54,7 +65,8 @@ private:
    */
   void GetCursorRange(int &minCursor, int &maxCursor) const;
 
-  int m_fixedCursor;    ///< default position the skinner wishes to use for the focused item
-  int m_cursorRange;    ///< range that the focused item can vary when at the ends of the list
+  int m_fixedCursor; ///< default position the skinner wishes to use for the focused item
+  int m_startCursorRange; ///< range that the focused item can vary when at the beginning end of the list
+  int m_endCursorRange; ///< range that the focused item can vary when at the end of the list
 };
 

--- a/xbmc/guilib/test/TestGUIControlFactory.cpp
+++ b/xbmc/guilib/test/TestGUIControlFactory.cpp
@@ -179,11 +179,13 @@ const auto AlignmentTests = std::array{
     AlignmentTest{R"(<root/>)"s, 0, false},
 };
 
-class TestGetAlignmentY : public testing::WithParamInterface<AlignmentTest>, public testing::Test
+class TestGetLabelAlignmentY : public testing::WithParamInterface<AlignmentTest>,
+                               public testing::Test
 {
 };
 
-const auto AlignmentYTests = std::array{
+const auto LabelAlignmentYTests = std::array{
+    AlignmentTest{R"(<root><test>top</test></root>)"s, 0},
     AlignmentTest{R"(<root><test>center</test></root>)"s, XBFONT_CENTER_Y},
     AlignmentTest{R"(<root><test>bottom</test></root>)"s, 0},
     AlignmentTest{R"(<root><test/></root>)"s, std::numeric_limits<uint32_t>::max(), false},
@@ -695,18 +697,18 @@ INSTANTIATE_TEST_SUITE_P(TestGUIControlFactory,
                          TestGetAlignment,
                          testing::ValuesIn(AlignmentTests));
 
-TEST_P(TestGetAlignmentY, GetAlignmentY)
+TEST_P(TestGetLabelAlignmentY, GetAlignmentY)
 {
   CXBMCTinyXML doc;
   doc.Parse(GetParam().def);
   uint32_t align = std::numeric_limits<uint32_t>::max();
-  EXPECT_EQ(CGFTestable::GetAlignmentY(doc.RootElement(), "test", align), GetParam().result);
+  EXPECT_EQ(CGFTestable::GetLabelAlignmentY(doc.RootElement(), "test", align), GetParam().result);
   EXPECT_EQ(align, GetParam().align);
 }
 
 INSTANTIATE_TEST_SUITE_P(TestGUIControlFactory,
-                         TestGetAlignmentY,
-                         testing::ValuesIn(AlignmentYTests));
+                         TestGetLabelAlignmentY,
+                         testing::ValuesIn(LabelAlignmentYTests));
 
 TEST_P(TestAspectRatio, GetAspectRatio)
 {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

CGUIFixedListContainer aka"fixedlist" control  changes:
- added new tag `<AlignY>`, values top/center/bottom (default=center) to control the vertical alignment when there are not enough items to fill the list.
- added new tags `<StartMovement>` and `<EndMovement>`, which allow the independent configuration of the amount of movement allowed at the top and the bottom of the list, with fallback on the value of `<Movement>`, for backward compatibility (and 0 when movement is not present either).

The changes were minimal thanks to the good structure and algorithm of the existing code.

There may be other Estuary dialogs where the changes could be helpful. The new stream selection dialog is used as proof of concept and the PR is not meant to update the entire skin.

wiki to be edited: https://kodi.wiki/view/Fixed_List_Container
doxygen updated by the PR

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

More user-friendly audio/subtitle stream selection, see screenshots

When a video has many streams, the current selection is displayed at the bottom of the list, even if it's not the last stream. That's how the list control behaves.

The fixedlist control, used in media lists for example, centers the list around the current item, but even with configuration, has an odd appearance in a dialog when there are fewer items than the capacity of the list.
The appearance is fine in the media lists as is as far as I am concernced, no change needed.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Estuary's existing fixed lists are unaffected (ex. categories on the home page, media lists)

With the stream selection dialog and many items: no difference versus the list control, with fewer items, they appear at the top of the list, per the vertical alignment attribute.

Tested but no committed example: specify StartMovement and/or EndMovement and the empty rows at the top and bottom of fixed lists that have many items vary.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

More user-friendly stream selection, opens more possibiltiies for skins.

## Screenshots (if appropriate):
Before, with a list control, the selected item appears at the bottom:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/8a25d7f3-378d-4438-a71d-a515c4556e5c" />


With the modified fixedlist control, the selected item appears in the middle of the screen and the surrounding items are visible (other subs in same language for example):
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/78327e4c-d229-4307-a783-ed58eddec66e" />

No visual difference with the list when the new fixed list is configured appropriately and there are fewer items than the list size:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/5e7358da-56df-4460-8d25-c759f8c1a6a4" />


Playing with the new parameters, less items than the list size:
```
<focusposition>4</focusposition>
<startmovement>3</startmovement>
<endmovement>3</endmovement>
<aligny>top</aligny>
```
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/b9f42487-1286-407f-bed7-3e25f79a9555" />

```
<focusposition>4</focusposition>
<startmovement>3</startmovement>
<endmovement>3</endmovement>
<aligny>center</aligny>
```
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/16237015-daf8-48ca-bcc2-b2c6b9914053" />

```
<focusposition>4</focusposition>
<startmovement>3</startmovement>
<endmovement>3</endmovement>
<aligny>bottom</aligny>
```
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/6d61772b-3d88-473a-b07c-3d9399a57b21" />


Playing with the new parameters, more items than the list size (aligny has no effect when there are more items that the list size):
```
<focusposition>4</focusposition>
<startmovement>3</startmovement>
<endmovement>3</endmovement>
```

top of the list:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/fdda362a-637a-4700-8dc7-b65f152973df" />

bottom of the list:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/c35337cf-98a0-4dd9-bce4-c3e511b84c5f" />


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
