### PR TITLE
[EDL] Fix CEdl::AddSceneMarker to insert the new marker sorted, …

### DIFF
--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -245,7 +245,17 @@ bool CEdl::AddSceneMarker(std::chrono::milliseconds iSceneMarker)
 
   CLog::LogF(LOGDEBUG, "Inserting new scene marker: {}",
              StringUtils::MillisecondsToTimeString(iSceneMarker));
-  m_vecSceneMarkers.push_back(iSceneMarker); // Unsorted
+
+  // Insert scene marker in sorted ascending order
+  if (m_vecSceneMarkers.empty() || iSceneMarker > m_vecSceneMarkers.back())
+  {
+    m_vecSceneMarkers.emplace_back(iSceneMarker);
+  }
+  else
+  {
+    const auto it{std::ranges::lower_bound(m_vecSceneMarkers, iSceneMarker)};
+    m_vecSceneMarkers.insert(it, iSceneMarker);
+  }
 
   return true;
 }

--- a/xbmc/cores/VideoPlayer/Edl/test/TestEdl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl/test/TestEdl.cpp
@@ -82,7 +82,7 @@ TEST_F(TestEdl, TestParsingMplayerTimeBasedEDL)
   EXPECT_EQ(edl.GetSceneMarkers().at(0),
             edl.GetTimeWithoutCuts(duration_cast<std::chrono::milliseconds>(255.3s)));
   // one of them only has start defined, at 720.1 secs
-  EXPECT_EQ(edl.GetSceneMarkers().at(1),
+  EXPECT_EQ(edl.GetSceneMarkers().at(2),
             edl.GetTimeWithoutCuts(duration_cast<std::chrono::milliseconds>(720.1s)));
 
   // commbreaks


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fix CEdl::AddSceneMarker to insert the new marker sorted, similar to CEdl::AddEdit. (ALL algorithms assume scene markers and edits are in ascending order).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix warnings in the log that annoyed me for a long time:

```log
2026-05-18 16:50:06.525 T:733499   error <general>: CGUIRangesControl::UpdateInfo - malformed ranges csv string (end element must be larger or equal than start element)
```
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual, by checking the log after applying the patch and starting playback of a PVR recording which always caused the warning.
 
## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Correct scene markers displayed in Estuary OSD, for example.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
