### PR TITLE
[python] fix InfoTagVideo::addVideoStream

### DIFF
--- a/xbmc/interfaces/legacy/InfoTagVideo.cpp
+++ b/xbmc/interfaces/legacy/InfoTagVideo.cpp
@@ -719,6 +719,7 @@ namespace XBMCAddon
       {
         XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
         addStreamRaw(infoTag, streamDetail);
+        finalizeStreamsRaw(infoTag);
       }
     }
 
@@ -731,6 +732,7 @@ namespace XBMCAddon
       {
         XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
         addStreamRaw(infoTag, streamDetail);
+        finalizeStreamsRaw(infoTag);
       }
     }
 
@@ -743,6 +745,7 @@ namespace XBMCAddon
       {
         XBMCAddonUtils::GuiLock lock(languageHook, offscreen);
         addStreamRaw(infoTag, streamDetail);
+        finalizeStreamsRaw(infoTag);
       }
     }
 


### PR DESCRIPTION
## Description
currently the python methods addVideoStream(), addAudioStream() & addSubtileStream() are not working.
ListItems created with those methods will have no stream info available.
this PR will fix that bug.

## Motivation and context
a few years ago, the ListItem.addStreamInfo() was deprecated and devs are encouraged (trough nagging in the logfile) to move to the addVideoStream(), addAudioStream() & addSubtileStream() methods instead.

since my GlobalSearch addon was using addStreamInfo(), i decided to update the code to those new methods,
only to find out things didn't work as expected.

comparing the sourcecode for the old and new methods, i noticed addStreamInfo()  was calling addStreamRaw() and then finalizeStreamsRaw() https://github.com/xbmc/xbmc/blob/f3c54fd44eefcfae732972e4f6e449846b63a158/xbmc/interfaces/legacy/ListItem.cpp#L868-L870 while the new methods would only call addStreamRaw() https://github.com/xbmc/xbmc/blob/f3c54fd44eefcfae732972e4f6e449846b63a158/xbmc/interfaces/legacy/InfoTagVideo.cpp#L713-L723

after adding finalizeStreamsRaw() to the new addVideoStream(), addAudioStream() & addSubtileStream() methods,
things are now working ok.


## How has this been tested?
this change has been tested using the GlobalSearch addon and verifying the stream info is available on the listitems in the search result.

## What is the effect on users?
since the stream info is mostly used for displaying media flags in the gui, the affect is that those flags will now show up again.

## Screenshots (if appropriate):
before this change:

<img width="1280" height="720" alt="before" src="https://github.com/user-attachments/assets/be8c7f14-3b21-4cbc-a360-add50d6997d8" />


after this change:

<img width="1280" height="720" alt="after" src="https://github.com/user-attachments/assets/ee302533-c5c7-4e46-bc9a-e16b55c24559" />



## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
