### PR TITLE
GBM HDR FBO idle skip + dirty-driven GUI render skip

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -851,9 +851,10 @@ void CApplication::Render()
     return;
 
   // render gui layer
-  bool compositing = CServiceBroker::GetWinSystem()->BeginGuiComposite();
+  const bool guiWillRender = appPower->GetRenderGUI() && !m_skipGuiRender;
+  bool compositing = CServiceBroker::GetWinSystem()->BeginGuiComposite(guiWillRender);
 
-  if (appPower->GetRenderGUI() && !m_skipGuiRender)
+  if (guiWillRender)
   {
     if (CServiceBroker::GetWinSystem()->GetGfxContext().GetStereoMode() != RenderStereoMode::OFF)
     {
@@ -1547,10 +1548,14 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
     }
 
     if (!m_bStop)
-    {
-      if (!m_skipGuiRender)
-        CServiceBroker::GetGUI()->GetWindowManager().Process(CTimeUtils::GetFrameTime());
-    }
+      CServiceBroker::GetGUI()->GetWindowManager().Process(CTimeUtils::GetFrameTime());
+
+    // Dirty-driven skip: on paths with a persistent framebuffer (D2P plane or
+    // HDR GUI compositing FBO), skip Render when no controls dirtied themselves
+    // this frame. The persistence keeps the previous OSD on screen for free.
+    if (!m_skipGuiRender && appPlayer->IsRenderingVideoLayer() &&
+        !CServiceBroker::GetGUI()->GetWindowManager().HasDirtyRegions())
+      m_skipGuiRender = true;
     CServiceBroker::GetGUI()->GetWindowManager().FrameMove();
   }
 

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -905,6 +905,42 @@ void CApplication::Render()
                                                        appPlayer->IsRenderingVideoLayer());
 
   CTimeUtils::UpdateFrameTime(hasRendered);
+
+  // [debug hack] count gui-on-screen frames vs total played and skipped
+  {
+    static unsigned int s_video = 0;
+    static unsigned int s_ctrls = 0;
+    static unsigned int s_subs = 0;
+    static unsigned int s_skipGui = 0;
+    static unsigned int s_skipAny = 0;
+    if (!appPlayer->IsPlayingVideo())
+    {
+      s_video = 0;
+      s_ctrls = 0;
+      s_subs = 0;
+      s_skipGui = 0;
+      s_skipAny = 0;
+    }
+    else
+    {
+      ++s_video;
+      const bool ctrlsOn = CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls();
+      const bool subsOn = appPlayer->HasVisibleOverlay();
+      if (ctrlsOn)
+        ++s_ctrls;
+      if (subsOn)
+        ++s_subs;
+      if (m_skipGuiRender)
+      {
+        ++s_skipAny;
+        if (ctrlsOn || subsOn)
+          ++s_skipGui;
+      }
+      if (s_video % 240 == 0)
+        CLog::Log(LOGDEBUG, "TEMP: [framecount] video={} ctrls={} subs={} skip-gui={} skip-any={}",
+                  s_video, s_ctrls, s_subs, s_skipGui, s_skipAny);
+    }
+  }
 }
 
 bool CApplication::OnAction(const CAction &action)

--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -946,6 +946,15 @@ bool CApplicationPlayer::IsRenderingVideoLayer() const
     return false;
 }
 
+bool CApplicationPlayer::HasVisibleOverlay() const
+{
+  const std::shared_ptr<const IPlayer> player = GetInternal();
+  if (player)
+    return player->HasVisibleOverlay();
+  else
+    return false;
+}
+
 bool CApplicationPlayer::Supports(EINTERLACEMETHOD method) const
 {
   const std::shared_ptr<const IPlayer> player = GetInternal();

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -62,6 +62,7 @@ public:
   bool IsRenderingVideo() const;
   bool IsRenderingGuiLayer() const;
   bool IsRenderingVideoLayer() const;
+  bool HasVisibleOverlay() const;
   bool Supports(EINTERLACEMETHOD method) const;
   EINTERLACEMETHOD GetDeinterlacingMethodDefault() const;
   bool Supports(ESCALINGMETHOD method) const;

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -241,6 +241,12 @@ public:
   virtual float GetRenderAspectRatio() const { return 1.0; }
   virtual void TriggerUpdateResolution() {}
   virtual bool IsRenderingVideo() const { return false; }
+  /*!
+   * \brief True if any subtitle/overlay is actually visible on the current
+   *  presented frame. Per-frame accurate. Default false for players that
+   *  do not render overlays (e.g. retro, paplayer, external).
+   */
+  virtual bool HasVisibleOverlay() const { return false; }
   virtual bool IsLiveStream() const { return false; }
   virtual void GetRects(CRect& source, CRect& dest, CRect& view) const
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h
@@ -22,7 +22,12 @@ public:
   {
   }
 
-  CDVDOverlayLibass(const CDVDOverlayLibass& src) : CDVDOverlay(src), m_libass(src.m_libass) {}
+  CDVDOverlayLibass(const CDVDOverlayLibass& src)
+    : CDVDOverlay(src),
+      m_pendingChange(src.m_pendingChange),
+      m_libass(src.m_libass)
+  {
+  }
 
   ~CDVDOverlayLibass() override = default;
 
@@ -31,6 +36,13 @@ public:
   \return The Libass handler.
   */
   std::shared_ptr<CDVDSubtitlesLibass> GetLibassHandler() const { return m_libass; }
+
+  // libass change-since-last-walk-consumed flag. Set non-zero by
+  // OVERLAY::CRenderer::PrepareOverlays when libass detect_change reports
+  // non-zero; consumed and cleared by ConvertLibass when a fresh COverlay
+  // is created. Lives on the persistent overlay so it survives the
+  // per-frame SElement recycling driven by RenderManager AddOverlay/Release.
+  int m_pendingChange{0};
 
 private:
   std::shared_ptr<CDVDSubtitlesLibass> m_libass;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5656,6 +5656,11 @@ bool CVideoPlayer::IsRenderingVideo() const
   return m_renderManager.IsConfigured();
 }
 
+bool CVideoPlayer::HasVisibleOverlay() const
+{
+  return m_renderManager.HasVisibleOverlay();
+}
+
 bool CVideoPlayer::IsLiveStream() const
 {
   if (!m_processInfo)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -365,6 +365,7 @@ public:
   unsigned int GetOrientation() const override;
   void TriggerUpdateResolution() override;
   bool IsRenderingVideo() const override;
+  bool HasVisibleOverlay() const override;
   bool IsLiveStream() const override;
   bool Supports(EINTERLACEMETHOD method) const override;
   EINTERLACEMETHOD GetDeinterlacingMethodDefault() const override;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -102,6 +102,13 @@ void CDebugRenderer::Render(CRect& src, CRect& dst, CRect& view)
 
   m_overlayRenderer.SetVideoRect(src, dst, view);
   m_overlayRenderer.Render(0);
+
+  // Sustain the dirty-driven Render skip while the debug OSD is enabled.
+  // Unlike video subtitles (which call AddOverlay per video frame and so
+  // mark dirty per frame), the debug OSD only calls AddOverlay once at
+  // Initialize, so without a per-frame nudge here the GUI walk would not
+  // re-fire after the first frame and the debug OSD would freeze.
+  MarkDirty();
 }
 
 void CDebugRenderer::Flush()

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -8,11 +8,13 @@
 
 #include "DebugRenderer.h"
 
+#include "ServiceBroker.h"
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h"
 #include "cores/VideoPlayer/Interface/TimingConstants.h"
 #include "settings/SubtitlesSettings.h"
 #include "utils/log.h"
 #include "windowing/GraphicContext.h"
+#include "windowing/WinSystem.h"
 
 using namespace OVERLAY;
 
@@ -44,6 +46,11 @@ void CDebugRenderer::Initialize()
   // We create only a single overlay with a fixed PTS for each rendered frame
   m_overlay = m_adapter->CreateOverlay();
   m_overlayRenderer.AddOverlay(m_overlay, 1000000., 0);
+
+  // Kick the dirty-driven walk skip so the toggle takes effect this frame;
+  // without this the walk stays idle and the debug overlay never starts
+  // rendering until something else dirties the GUI.
+  OVERLAY::MarkDirty();
 }
 
 void CDebugRenderer::Dispose()
@@ -51,6 +58,7 @@ void CDebugRenderer::Dispose()
   m_isInitialized = false;
   m_overlayRenderer.Flush();
   m_overlay.reset();
+  OVERLAY::MarkDirty();
   if (m_adapter)
   {
     delete m_adapter;
@@ -138,8 +146,117 @@ void CDebugRenderer::CRenderer::Render(int idx, float depth)
       if (updateStyle)
         CreateSubtitlesStyle();
 
-      std::shared_ptr<COverlay> o =
-          ConvertLibass(*ovAss, it->pts, updateStyle, m_debugOverlayStyle);
+      // Debug OSD is a standalone path: text content changes every frame
+      // and DebugRenderer::Render MarkDirty's per frame anyway, so it does
+      // not participate in the PrepareOverlays / SElement caching scheme.
+      // The rOpts setup below mirrors what master's CRenderer::ConvertLibass
+      // did inline.
+      KODI::SUBTITLES::STYLE::renderOpts rOpts;
+      rOpts.sourceWidth = m_rs.Width();
+      rOpts.sourceHeight = m_rs.Height();
+      rOpts.videoWidth = m_rd.Width();
+      rOpts.videoHeight = m_rd.Height();
+      rOpts.frameWidth = m_rv.Width();
+      rOpts.frameHeight = m_rv.Height();
+
+      // Render subtitle of half-sbs and half-ou video in full screen, not in half screen
+      if (m_stereomode == "left_right" || m_stereomode == "right_left")
+      {
+        // only half-sbs video, sbs video don't need to change source size
+        if (rOpts.sourceWidth / rOpts.sourceHeight < 1.2f)
+          rOpts.sourceWidth = m_rs.Width() * 2;
+      }
+      else if (m_stereomode == "top_bottom" || m_stereomode == "bottom_top")
+      {
+        // only half-ou video, ou video don't need to change source size
+        if (rOpts.sourceWidth / rOpts.sourceHeight > 2.5f)
+          rOpts.sourceHeight = m_rs.Height() * 2;
+      }
+
+      // Set position of subtitles based on video calibration settings
+      RESOLUTION_INFO resInfo = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
+      // Keep track of subtitle position value change,
+      // can be changed by GUI Calibration or by window mode/resolution change or
+      // by user manual change (e.g. keyboard shortcut)
+      if (m_subtitlePosResInfo != resInfo.iSubtitles)
+      {
+        if (m_subtitlePosResInfo == POSRESINFO_SAVE_CHANGES)
+        {
+          // m_subtitlePosition has been changed
+          // and has been requested to save the value to resInfo
+          resInfo.iSubtitles = m_subtitlePosition + m_subtitleVerticalMargin;
+          CServiceBroker::GetWinSystem()->GetGfxContext().SetResInfo(
+              CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution(), resInfo);
+          m_subtitlePosResInfo = m_subtitlePosition + m_subtitleVerticalMargin;
+        }
+        else
+          ResetSubtitlePosition();
+      }
+
+      rOpts.m_par = resInfo.fPixelRatio;
+
+      // rOpts.position and margins (set to style) can invalidate the text
+      // positions to subtitles type that make use of margins to position text on
+      // the screen (e.g. ASS/WebVTT) then we allow to set them when position
+      // override setting is enabled only
+      if (ovAss->IsForcedMargins())
+      {
+        rOpts.marginsMode = KODI::SUBTITLES::STYLE::MarginsMode::DISABLED;
+      }
+      else if (m_subtitleAlign == KODI::SUBTITLES::Align::MANUAL)
+      {
+        // When vertical margins are used Libass apply a displacement in percentage
+        // of the height available to line position, this displacement causes
+        // problems with subtitle calibration bar on Video Calibration window,
+        // so when you moving the subtitle bar of the GUI the text will no longer
+        // match the bar, this calculation compensates for the displacement.
+        // Note also that the displacement compensation will cause a different
+        // default position of the text, different from the other alignment positions
+        double posPx = static_cast<double>(m_subtitlePosition - resInfo.Overscan.top);
+
+        int assPlayResY = ovAss->GetLibassHandler()->GetPlayResY();
+        double assVertMargin = static_cast<double>(m_debugOverlayStyle->marginVertical) *
+                               (static_cast<double>(assPlayResY) / 720);
+        double vertMarginScaled =
+            assVertMargin / assPlayResY * static_cast<double>(rOpts.frameHeight);
+
+        double pos = posPx / (static_cast<double>(rOpts.frameHeight) - vertMarginScaled);
+        rOpts.position = 100 - pos * 100;
+      }
+      else if (m_subtitleAlign == KODI::SUBTITLES::Align::BOTTOM_OUTSIDE)
+      {
+        // To keep consistent the position of text as other alignment positions
+        // we avoid apply the displacement compensation
+        double posPx = static_cast<double>(m_subtitlePosition + m_subtitleVerticalMargin -
+                                           resInfo.Overscan.top);
+        rOpts.position = 100 - posPx / static_cast<double>(rOpts.frameHeight) * 100;
+      }
+      else if (m_subtitleAlign == KODI::SUBTITLES::Align::BOTTOM_INSIDE ||
+               m_subtitleAlign == KODI::SUBTITLES::Align::TOP_INSIDE)
+      {
+        rOpts.marginsMode = KODI::SUBTITLES::STYLE::MarginsMode::INSIDE_VIDEO;
+      }
+
+      // Set the horizontal text alignment (currently used to improve readability on CC subtitles only)
+      // This setting influence style->alignment property
+      if (ovAss->IsTextAlignEnabled())
+      {
+        if (m_subtitleHorizontalAlign == KODI::SUBTITLES::HorizontalAlign::LEFT)
+          rOpts.horizontalAlignment = KODI::SUBTITLES::STYLE::HorizontalAlign::LEFT;
+        else if (m_subtitleHorizontalAlign == KODI::SUBTITLES::HorizontalAlign::RIGHT)
+          rOpts.horizontalAlignment = KODI::SUBTITLES::STYLE::HorizontalAlign::RIGHT;
+        else
+          rOpts.horizontalAlignment = KODI::SUBTITLES::STYLE::HorizontalAlign::CENTER;
+      }
+
+      int changes = 0;
+      ASS_Image* images = ovAss->GetLibassHandler()->RenderImage(it->pts, rOpts, updateStyle,
+                                                                 m_debugOverlayStyle, &changes);
+
+      if (!images)
+        continue;
+
+      std::shared_ptr<COverlay> o = COverlay::Create(images, rOpts.frameWidth, rOpts.frameHeight);
 
       if (o)
         OVERLAY::CRenderer::Render(o.get());

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -55,6 +55,9 @@ void CDebugRenderer::Initialize()
 
 void CDebugRenderer::Dispose()
 {
+  if (!m_isInitialized)
+    return;
+
   m_isInitialized = false;
   m_overlayRenderer.Flush();
   m_overlay.reset();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/DebugRenderer.cpp
@@ -146,11 +146,11 @@ void CDebugRenderer::CRenderer::Render(int idx, float depth)
       if (updateStyle)
         CreateSubtitlesStyle();
 
-      // Debug OSD is a standalone path: text content changes every frame
-      // and DebugRenderer::Render MarkDirty's per frame anyway, so it does
-      // not participate in the PrepareOverlays / SElement caching scheme.
-      // The rOpts setup below mirrors what master's CRenderer::ConvertLibass
-      // did inline.
+      // Copied from OVERLAY::CRenderer::ConvertLibass. PR #28373 changed
+      // that function to read its libass output from a per-frame SElement
+      // populated by AddOverlay/Release. The debug overlay is added once
+      // at Initialize and never produces an SElement, so it cannot share
+      // the implementation.
       KODI::SUBTITLES::STYLE::renderOpts rOpts;
       rOpts.sourceWidth = m_rs.Width();
       rOpts.sourceHeight = m_rs.Height();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -17,6 +17,8 @@
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayImage.h"
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayLibass.h"
 #include "cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlaySpu.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
 #include "settings/DisplaySettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
@@ -43,6 +45,11 @@ COverlay::COverlay()
 
 COverlay::~COverlay() = default;
 
+void OVERLAY::MarkDirty()
+{
+  CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
+}
+
 unsigned int CRenderer::m_textureid = 1;
 
 CRenderer::CRenderer()
@@ -64,6 +71,16 @@ void CRenderer::AddOverlay(std::shared_ptr<CDVDOverlay> o, double pts, int index
   e.pts = pts;
   e.overlay_dvd = std::move(o);
   m_buffers[index].push_back(e);
+
+  // Wake the dirty-driven skip so the new overlay actually paints on its
+  // first frame. Without this hook the GUI walk would stay skipped and the
+  // overlay would never reach its draw site. For video subtitles this also
+  // fires per video frame (ProcessOverlays calls AddOverlay for every
+  // active overlay), sustaining the walk while the subtitle is visible.
+  //! @todo Smart subtitle dirty: query libass ass_step_sub to mark dirty
+  //! only on actual subtitle transitions, not every video frame, so the
+  //! dirty-driven skip can take effect between transitions.
+  MarkDirty();
 }
 
 void CRenderer::Release(std::vector<SElement>& list)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -266,15 +266,16 @@ bool CRenderer::HasVisibleOverlay(int idx) const
       continue;
 
     const CDVDOverlay& o = *e.overlay_dvd;
-    // Image-based (PGS/DVB) and DVD SPU: ProcessOverlays PTS-filters before
-    // AddOverlay, so presence is the per-frame visibility test.
+    // PGS/DVB and DVD SPU: ProcessOverlays inserts these into m_buffers
+    // only at PTS values where the bitmap is on screen, so finding one
+    // here means it is visible.
     if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE) || o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
       return true;
 
-    // libass (TEXT/SSA): the container survives the whole session via
-    // iPTSStopTime=DVD_NOPTS_VALUE, so presence alone is meaningless. The
-    // accurate per-frame signal is whether ass_render_frame returned any
-    // images for the current PTS, cached by PrepareOverlays.
+    // libass (TEXT/SSA): the container stays in m_buffers for the whole
+    // video (iPTSStopTime=DVD_NOPTS_VALUE). Visibility means
+    // ass_render_frame returned images for the current PTS, cached by
+    // PrepareOverlays in e.renderedImages.
     if (o.IsOverlayType(DVDOVERLAY_TYPE_TEXT) || o.IsOverlayType(DVDOVERLAY_TYPE_SSA))
     {
       if (e.renderedImages != nullptr)
@@ -427,7 +428,7 @@ void CRenderer::PrepareOverlays(int idx)
   if (idx < 0 || idx >= NUM_BUFFERS)
     return;
 
-  bool hasChanges = false;
+  bool doMarkDirty = false;
   bool hasImageSpu = false;
   for (auto& e : m_buffers[idx])
   {
@@ -441,18 +442,16 @@ void CRenderer::PrepareOverlays(int idx)
 
     CDVDOverlay& o = *e.overlay_dvd;
 
-    // Image-based subtitles (PGS, DVB) and DVD SPU: presence of the entry
-    // in the present buffer slot is the visibility test. ProcessOverlays
-    // PTS-filters before AddOverlay, so any entry here covers "now".
-    // For change detection: m_textureid == 0 means the overlay has never
-    // been rendered (new arrival). Catches new bitmaps for PGS/DVB and
-    // every-frame-different animated PGS. The presence-flip check after
-    // the loop catches the disappearance case.
+    // PGS/DVB and DVD SPU: only added to m_buffers at their visible PTS,
+    // so finding one means it is on screen now. m_textureid == 0 is the
+    // "new arrival" signal (also true every frame for animated PGS where
+    // each frame is a fresh CDVDOverlay). Disappearance is caught after
+    // the loop by the hasImageSpu vs m_prevHadImageSpu check.
     if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE) || o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
     {
       hasImageSpu = true;
       if (o.m_textureid == 0)
-        hasChanges = true;
+        doMarkDirty = true;
       continue;
     }
 
@@ -471,11 +470,12 @@ void CRenderer::PrepareOverlays(int idx)
       CreateSubtitlesStyle();
     }
 
+    // rOpts setup moved from CRenderer::ConvertLibass; duplicated in CDebugRenderer::CRenderer::Render.
     SUBTITLES::STYLE::renderOpts rOpts;
 
-    // libass render in a target area which named as frame. the frame size may bigger than video size,
-    // and including margins between video to frame edge. libass allow to render subtitles into the margins.
-    // this has been used to show subtitles in the top or bottom "black bar" between video to frame border.
+    // Three rects: source (subtitle canvas), video (playing size), frame
+    // (render target; may exceed video to include letterbox bars so libass
+    // can place subtitles in them).
     rOpts.sourceWidth = m_rs.Width();
     rOpts.sourceHeight = m_rs.Height();
     rOpts.videoWidth = m_rd.Width();
@@ -581,30 +581,22 @@ void CRenderer::PrepareOverlays(int idx)
     int currentChange = 0;
     e.renderedImages = ovAss.GetLibassHandler()->RenderImage(e.pts, rOpts, updateStyle,
                                                              m_overlayStyle, &currentChange);
-    // OR-accumulate libass's per-call change onto the persistent overlay,
-    // not onto SElement: m_buffers[idx] is rebuilt per frame by AddOverlay/
-    // Release on the render queue, so SElement state cannot survive the
-    // transition-to-walk gap. The CDVDOverlayLibass shared_ptr survives.
     if (currentChange > 0)
+    {
+      // Persist on the overlay so a skipped GUI render does not drop the change.
       ovAss.m_pendingChange = currentChange;
-
-    // MarkDirty only on this-frame change (not the accumulated value).
-    if (currentChange > 0)
-      hasChanges = true;
+      doMarkDirty = true;
+    }
   }
 
-  // Image/SPU disappearance: image-based subtitles (PGS/DVB/SPU) have no
-  // libass-style per-frame change signal. The m_textureid==0 check inside
-  // the loop catches arrival of a new bitmap. This catches the symmetric
-  // case: the buffer slot just went empty (last frame had image/SPU, this
-  // frame does not). Without this, when a PGS subtitle ends the walk does
-  // not fire, the cached bitmap stays on the GUI plane, and the screen
-  // never blanks between consecutive PGS subtitles.
+  // PGS/DVB/SPU disappearance: arrival is caught by m_textureid==0 in
+  // the loop above. Without this, a PGS subtitle ending leaves its
+  // cached bitmap on the GUI plane until something else dirties.
   if (hasImageSpu != m_prevHadImageSpu)
-    hasChanges = true;
+    doMarkDirty = true;
   m_prevHadImageSpu = hasImageSpu;
 
-  if (hasChanges)
+  if (doMarkDirty)
     MarkDirty();
 }
 
@@ -651,8 +643,8 @@ std::shared_ptr<COverlay> CRenderer::Convert(SElement& e)
     if (!ovAss.GetLibassHandler())
       return nullptr;
 
-    // ASS_Image* and detect_change were populated this frame by
-    // PrepareOverlays. ConvertLibass does not re-enter libass.
+    // Build the COverlay from libass output PrepareOverlays cached on e
+    // earlier this frame; avoids re-entering libass during render.
     r = ConvertLibass(e);
 
     if (!r)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -71,16 +71,6 @@ void CRenderer::AddOverlay(std::shared_ptr<CDVDOverlay> o, double pts, int index
   e.pts = pts;
   e.overlay_dvd = std::move(o);
   m_buffers[index].push_back(e);
-
-  // Wake the dirty-driven skip so the new overlay actually paints on its
-  // first frame. Without this hook the GUI walk would stay skipped and the
-  // overlay would never reach its draw site. For video subtitles this also
-  // fires per video frame (ProcessOverlays calls AddOverlay for every
-  // active overlay), sustaining the walk while the subtitle is visible.
-  //! @todo Smart subtitle dirty: query libass ass_step_sub to mark dirty
-  //! only on actual subtitle transitions, not every video frame, so the
-  //! dirty-driven skip can take effect between transitions.
-  MarkDirty();
 }
 
 void CRenderer::Release(std::vector<SElement>& list)
@@ -165,7 +155,7 @@ void CRenderer::Render(int idx, float depth)
   {
     if (it->overlay_dvd)
     {
-      std::shared_ptr<COverlay> o = Convert(*(it->overlay_dvd), it->pts);
+      std::shared_ptr<COverlay> o = Convert(*it);
 
       if (o)
         Render(o.get());
@@ -264,22 +254,34 @@ void CRenderer::Render(COverlay* o)
   o->Render(state);
 }
 
-bool CRenderer::HasOverlay(int idx)
+bool CRenderer::HasVisibleOverlay(int idx) const
 {
-  bool hasOverlay = false;
-
   std::unique_lock lock(m_section);
+  if (idx < 0 || idx >= NUM_BUFFERS)
+    return false;
 
-  std::vector<SElement>& list = m_buffers[idx];
-  for(std::vector<SElement>::iterator it = list.begin(); it != list.end(); ++it)
+  for (const auto& e : m_buffers[idx])
   {
-    if (it->overlay_dvd)
+    if (!e.overlay_dvd)
+      continue;
+
+    const CDVDOverlay& o = *e.overlay_dvd;
+    // Image-based (PGS/DVB) and DVD SPU: ProcessOverlays PTS-filters before
+    // AddOverlay, so presence is the per-frame visibility test.
+    if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE) || o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
+      return true;
+
+    // libass (TEXT/SSA): the container survives the whole session via
+    // iPTSStopTime=DVD_NOPTS_VALUE, so presence alone is meaningless. The
+    // accurate per-frame signal is whether ass_render_frame returned any
+    // images for the current PTS, cached by PrepareOverlays.
+    if (o.IsOverlayType(DVDOVERLAY_TYPE_TEXT) || o.IsOverlayType(DVDOVERLAY_TYPE_SSA))
     {
-      hasOverlay = true;
-      break;
+      if (e.renderedImages != nullptr)
+        return true;
     }
   }
-  return hasOverlay;
+  return false;
 }
 
 void CRenderer::SetVideoRect(CRect &source, CRect &dest, CRect &view)
@@ -419,150 +421,48 @@ void CRenderer::CreateSubtitlesStyle()
   m_overlayStyle->lineSpacing = settings->GetLineSpacing();
 }
 
-std::shared_ptr<COverlay> CRenderer::ConvertLibass(
-    CDVDOverlayLibass& o,
-    double pts,
-    bool updateStyle,
-    const std::shared_ptr<struct SUBTITLES::STYLE::style>& overlayStyle)
+void CRenderer::PrepareOverlays(int idx)
 {
-  SUBTITLES::STYLE::renderOpts rOpts;
+  std::unique_lock lock(m_section);
+  if (idx < 0 || idx >= NUM_BUFFERS)
+    return;
 
-  // libass render in a target area which named as frame. the frame size may bigger than video size,
-  // and including margins between video to frame edge. libass allow to render subtitles into the margins.
-  // this has been used to show subtitles in the top or bottom "black bar" between video to frame border.
-  rOpts.sourceWidth = m_rs.Width();
-  rOpts.sourceHeight = m_rs.Height();
-  rOpts.videoWidth = m_rd.Width();
-  rOpts.videoHeight = m_rd.Height();
-  rOpts.frameWidth = m_rv.Width();
-  rOpts.frameHeight = m_rv.Height();
+  bool hasChanges = false;
+  bool hasImageSpu = false;
+  for (auto& e : m_buffers[idx])
+  {
+    // Clear last frame's cached output; libass may have invalidated the
+    // pointer on its next ass_render_frame call.
+    // (assDetectChange is consumed by ConvertLibass, not here.)
+    e.renderedImages = nullptr;
 
-  // Render subtitle of half-sbs and half-ou video in full screen, not in half screen
-  if (m_stereomode == "left_right" || m_stereomode == "right_left")
-  {
-    // only half-sbs video, sbs video don't need to change source size
-    if (rOpts.sourceWidth / rOpts.sourceHeight < 1.2f)
-      rOpts.sourceWidth = m_rs.Width() * 2;
-  }
-  else if (m_stereomode == "top_bottom" || m_stereomode == "bottom_top")
-  {
-    // only half-ou video, ou video don't need to change source size
-    if (rOpts.sourceWidth / rOpts.sourceHeight > 2.5f)
-      rOpts.sourceHeight = m_rs.Height() * 2;
-  }
+    if (!e.overlay_dvd)
+      continue;
 
-  // Set position of subtitles based on video calibration settings
-  RESOLUTION_INFO resInfo = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
-  // Keep track of subtitle position value change,
-  // can be changed by GUI Calibration or by window mode/resolution change or
-  // by user manual change (e.g. keyboard shortcut)
-  if (m_subtitlePosResInfo != resInfo.iSubtitles)
-  {
-    if (m_subtitlePosResInfo == POSRESINFO_SAVE_CHANGES)
+    CDVDOverlay& o = *e.overlay_dvd;
+
+    // Image-based subtitles (PGS, DVB) and DVD SPU: presence of the entry
+    // in the present buffer slot is the visibility test. ProcessOverlays
+    // PTS-filters before AddOverlay, so any entry here covers "now".
+    // For change detection: m_textureid == 0 means the overlay has never
+    // been rendered (new arrival). Catches new bitmaps for PGS/DVB and
+    // every-frame-different animated PGS. The presence-flip check after
+    // the loop catches the disappearance case.
+    if (o.IsOverlayType(DVDOVERLAY_TYPE_IMAGE) || o.IsOverlayType(DVDOVERLAY_TYPE_SPU))
     {
-      // m_subtitlePosition has been changed
-      // and has been requested to save the value to resInfo
-      resInfo.iSubtitles = m_subtitlePosition + m_subtitleVerticalMargin;
-      CServiceBroker::GetWinSystem()->GetGfxContext().SetResInfo(
-          CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution(), resInfo);
-      m_subtitlePosResInfo = m_subtitlePosition + m_subtitleVerticalMargin;
+      hasImageSpu = true;
+      if (o.m_textureid == 0)
+        hasChanges = true;
+      continue;
     }
-    else
-      ResetSubtitlePosition();
-  }
 
-  rOpts.m_par = resInfo.fPixelRatio;
+    if (!o.IsOverlayType(DVDOVERLAY_TYPE_TEXT) && !o.IsOverlayType(DVDOVERLAY_TYPE_SSA))
+      continue;
 
-  // rOpts.position and margins (set to style) can invalidate the text
-  // positions to subtitles type that make use of margins to position text on
-  // the screen (e.g. ASS/WebVTT) then we allow to set them when position
-  // override setting is enabled only
-  if (o.IsForcedMargins())
-  {
-    rOpts.marginsMode = SUBTITLES::STYLE::MarginsMode::DISABLED;
-  }
-  else if (m_subtitleAlign == SUBTITLES::Align::MANUAL)
-  {
-    // When vertical margins are used Libass apply a displacement in percentage
-    // of the height available to line position, this displacement causes
-    // problems with subtitle calibration bar on Video Calibration window,
-    // so when you moving the subtitle bar of the GUI the text will no longer
-    // match the bar, this calculation compensates for the displacement.
-    // Note also that the displacement compensation will cause a different
-    // default position of the text, different from the other alignment positions
-    double posPx = static_cast<double>(m_subtitlePosition - resInfo.Overscan.top);
-
-    int assPlayResY = o.GetLibassHandler()->GetPlayResY();
-    double assVertMargin = static_cast<double>(overlayStyle->marginVertical) *
-                           (static_cast<double>(assPlayResY) / 720);
-    double vertMarginScaled = assVertMargin / assPlayResY * static_cast<double>(rOpts.frameHeight);
-
-    double pos = posPx / (static_cast<double>(rOpts.frameHeight) - vertMarginScaled);
-    rOpts.position = 100 - pos * 100;
-  }
-  else if (m_subtitleAlign == SUBTITLES::Align::BOTTOM_OUTSIDE)
-  {
-    // To keep consistent the position of text as other alignment positions
-    // we avoid apply the displacement compensation
-    double posPx =
-        static_cast<double>(m_subtitlePosition + m_subtitleVerticalMargin - resInfo.Overscan.top);
-    rOpts.position = 100 - posPx / static_cast<double>(rOpts.frameHeight) * 100;
-  }
-  else if (m_subtitleAlign == SUBTITLES::Align::BOTTOM_INSIDE ||
-           m_subtitleAlign == SUBTITLES::Align::TOP_INSIDE)
-  {
-    rOpts.marginsMode = SUBTITLES::STYLE::MarginsMode::INSIDE_VIDEO;
-  }
-
-  // Set the horizontal text alignment (currently used to improve readability on CC subtitles only)
-  // This setting influence style->alignment property
-  if (o.IsTextAlignEnabled())
-  {
-    if (m_subtitleHorizontalAlign == SUBTITLES::HorizontalAlign::LEFT)
-      rOpts.horizontalAlignment = SUBTITLES::STYLE::HorizontalAlign::LEFT;
-    else if (m_subtitleHorizontalAlign == SUBTITLES::HorizontalAlign::RIGHT)
-      rOpts.horizontalAlignment = SUBTITLES::STYLE::HorizontalAlign::RIGHT;
-    else
-      rOpts.horizontalAlignment = SUBTITLES::STYLE::HorizontalAlign::CENTER;
-  }
-
-  // changes: Detect changes from previously rendered images, if > 0 they are changed
-  int changes = 0;
-  ASS_Image* images =
-      o.GetLibassHandler()->RenderImage(pts, rOpts, updateStyle, overlayStyle, &changes);
-
-  // If no images not execute the renderer
-  if (!images)
-    return nullptr;
-
-  if (o.m_textureid)
-  {
-    if (changes == 0)
-    {
-      std::map<unsigned int, std::shared_ptr<COverlay>>::iterator it =
-          m_textureCache.find(o.m_textureid);
-      if (it != m_textureCache.end())
-        return it->second;
-    }
-  }
-
-  std::shared_ptr<COverlay> overlay = COverlay::Create(images, rOpts.frameWidth, rOpts.frameHeight);
-
-  m_textureCache[m_textureid] = overlay;
-  o.m_textureid = m_textureid;
-  m_textureid++;
-  return overlay;
-}
-
-std::shared_ptr<COverlay> CRenderer::Convert(CDVDOverlay& o, double pts)
-{
-  std::shared_ptr<COverlay> r = NULL;
-
-  if (o.IsOverlayType(DVDOVERLAY_TYPE_TEXT) || o.IsOverlayType(DVDOVERLAY_TYPE_SSA))
-  {
     CDVDOverlayLibass& ovAss = static_cast<CDVDOverlayLibass&>(o);
     if (!ovAss.GetLibassHandler())
-      return nullptr;
+      continue;
+
     bool updateStyle = !m_overlayStyle || m_isSettingsChanged;
     if (updateStyle)
     {
@@ -571,7 +471,189 @@ std::shared_ptr<COverlay> CRenderer::Convert(CDVDOverlay& o, double pts)
       CreateSubtitlesStyle();
     }
 
-    r = ConvertLibass(ovAss, pts, updateStyle, m_overlayStyle);
+    SUBTITLES::STYLE::renderOpts rOpts;
+
+    // libass render in a target area which named as frame. the frame size may bigger than video size,
+    // and including margins between video to frame edge. libass allow to render subtitles into the margins.
+    // this has been used to show subtitles in the top or bottom "black bar" between video to frame border.
+    rOpts.sourceWidth = m_rs.Width();
+    rOpts.sourceHeight = m_rs.Height();
+    rOpts.videoWidth = m_rd.Width();
+    rOpts.videoHeight = m_rd.Height();
+    rOpts.frameWidth = m_rv.Width();
+    rOpts.frameHeight = m_rv.Height();
+
+    // Render subtitle of half-sbs and half-ou video in full screen, not in half screen
+    if (m_stereomode == "left_right" || m_stereomode == "right_left")
+    {
+      // only half-sbs video, sbs video don't need to change source size
+      if (rOpts.sourceWidth / rOpts.sourceHeight < 1.2f)
+        rOpts.sourceWidth = m_rs.Width() * 2;
+    }
+    else if (m_stereomode == "top_bottom" || m_stereomode == "bottom_top")
+    {
+      // only half-ou video, ou video don't need to change source size
+      if (rOpts.sourceWidth / rOpts.sourceHeight > 2.5f)
+        rOpts.sourceHeight = m_rs.Height() * 2;
+    }
+
+    // Set position of subtitles based on video calibration settings
+    RESOLUTION_INFO resInfo = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
+    // Keep track of subtitle position value change,
+    // can be changed by GUI Calibration or by window mode/resolution change or
+    // by user manual change (e.g. keyboard shortcut)
+    if (m_subtitlePosResInfo != resInfo.iSubtitles)
+    {
+      if (m_subtitlePosResInfo == POSRESINFO_SAVE_CHANGES)
+      {
+        // m_subtitlePosition has been changed
+        // and has been requested to save the value to resInfo
+        resInfo.iSubtitles = m_subtitlePosition + m_subtitleVerticalMargin;
+        CServiceBroker::GetWinSystem()->GetGfxContext().SetResInfo(
+            CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution(), resInfo);
+        m_subtitlePosResInfo = m_subtitlePosition + m_subtitleVerticalMargin;
+      }
+      else
+        ResetSubtitlePosition();
+    }
+
+    rOpts.m_par = resInfo.fPixelRatio;
+
+    // rOpts.position and margins (set to style) can invalidate the text
+    // positions to subtitles type that make use of margins to position text on
+    // the screen (e.g. ASS/WebVTT) then we allow to set them when position
+    // override setting is enabled only
+    if (ovAss.IsForcedMargins())
+    {
+      rOpts.marginsMode = SUBTITLES::STYLE::MarginsMode::DISABLED;
+    }
+    else if (m_subtitleAlign == SUBTITLES::Align::MANUAL)
+    {
+      // When vertical margins are used Libass apply a displacement in percentage
+      // of the height available to line position, this displacement causes
+      // problems with subtitle calibration bar on Video Calibration window,
+      // so when you moving the subtitle bar of the GUI the text will no longer
+      // match the bar, this calculation compensates for the displacement.
+      // Note also that the displacement compensation will cause a different
+      // default position of the text, different from the other alignment positions
+      double posPx = static_cast<double>(m_subtitlePosition - resInfo.Overscan.top);
+
+      int assPlayResY = ovAss.GetLibassHandler()->GetPlayResY();
+      double assVertMargin = static_cast<double>(m_overlayStyle->marginVertical) *
+                             (static_cast<double>(assPlayResY) / 720);
+      double vertMarginScaled =
+          assVertMargin / assPlayResY * static_cast<double>(rOpts.frameHeight);
+
+      double pos = posPx / (static_cast<double>(rOpts.frameHeight) - vertMarginScaled);
+      rOpts.position = 100 - pos * 100;
+    }
+    else if (m_subtitleAlign == SUBTITLES::Align::BOTTOM_OUTSIDE)
+    {
+      // To keep consistent the position of text as other alignment positions
+      // we avoid apply the displacement compensation
+      double posPx =
+          static_cast<double>(m_subtitlePosition + m_subtitleVerticalMargin - resInfo.Overscan.top);
+      rOpts.position = 100 - posPx / static_cast<double>(rOpts.frameHeight) * 100;
+    }
+    else if (m_subtitleAlign == SUBTITLES::Align::BOTTOM_INSIDE ||
+             m_subtitleAlign == SUBTITLES::Align::TOP_INSIDE)
+    {
+      rOpts.marginsMode = SUBTITLES::STYLE::MarginsMode::INSIDE_VIDEO;
+    }
+
+    // Set the horizontal text alignment (currently used to improve readability on CC subtitles only)
+    // This setting influence style->alignment property
+    if (ovAss.IsTextAlignEnabled())
+    {
+      if (m_subtitleHorizontalAlign == SUBTITLES::HorizontalAlign::LEFT)
+        rOpts.horizontalAlignment = SUBTITLES::STYLE::HorizontalAlign::LEFT;
+      else if (m_subtitleHorizontalAlign == SUBTITLES::HorizontalAlign::RIGHT)
+        rOpts.horizontalAlignment = SUBTITLES::STYLE::HorizontalAlign::RIGHT;
+      else
+        rOpts.horizontalAlignment = SUBTITLES::STYLE::HorizontalAlign::CENTER;
+    }
+
+    e.renderedFrameWidth = rOpts.frameWidth;
+    e.renderedFrameHeight = rOpts.frameHeight;
+
+    // Pull the libass output for this PTS. Cached on the SElement until
+    // ConvertLibass consumes it later in this frame's GUI walk.
+    int currentChange = 0;
+    e.renderedImages = ovAss.GetLibassHandler()->RenderImage(e.pts, rOpts, updateStyle,
+                                                             m_overlayStyle, &currentChange);
+    // OR-accumulate libass's per-call change onto the persistent overlay,
+    // not onto SElement: m_buffers[idx] is rebuilt per frame by AddOverlay/
+    // Release on the render queue, so SElement state cannot survive the
+    // transition-to-walk gap. The CDVDOverlayLibass shared_ptr survives.
+    if (currentChange > 0)
+      ovAss.m_pendingChange = currentChange;
+
+    // MarkDirty only on this-frame change (not the accumulated value).
+    if (currentChange > 0)
+      hasChanges = true;
+  }
+
+  // Image/SPU disappearance: image-based subtitles (PGS/DVB/SPU) have no
+  // libass-style per-frame change signal. The m_textureid==0 check inside
+  // the loop catches arrival of a new bitmap. This catches the symmetric
+  // case: the buffer slot just went empty (last frame had image/SPU, this
+  // frame does not). Without this, when a PGS subtitle ends the walk does
+  // not fire, the cached bitmap stays on the GUI plane, and the screen
+  // never blanks between consecutive PGS subtitles.
+  if (hasImageSpu != m_prevHadImageSpu)
+    hasChanges = true;
+  m_prevHadImageSpu = hasImageSpu;
+
+  if (hasChanges)
+    MarkDirty();
+}
+
+std::shared_ptr<COverlay> CRenderer::ConvertLibass(SElement& e)
+{
+  // If no images not execute the renderer
+  if (!e.renderedImages)
+    return nullptr;
+
+  CDVDOverlayLibass& o = static_cast<CDVDOverlayLibass&>(*e.overlay_dvd);
+
+  if (o.m_textureid)
+  {
+    if (o.m_pendingChange == 0)
+    {
+      std::map<unsigned int, std::shared_ptr<COverlay>>::iterator it =
+          m_textureCache.find(o.m_textureid);
+      if (it != m_textureCache.end())
+        return it->second;
+    }
+  }
+
+  std::shared_ptr<COverlay> overlay =
+      COverlay::Create(e.renderedImages, e.renderedFrameWidth, e.renderedFrameHeight);
+
+  m_textureCache[m_textureid] = overlay;
+  o.m_textureid = m_textureid;
+  m_textureid++;
+  o.m_pendingChange = 0; // consume
+  return overlay;
+}
+
+std::shared_ptr<COverlay> CRenderer::Convert(SElement& e)
+{
+  if (!e.overlay_dvd)
+    return nullptr;
+
+  CDVDOverlay& o = *e.overlay_dvd;
+  std::shared_ptr<COverlay> r = NULL;
+
+  if (o.IsOverlayType(DVDOVERLAY_TYPE_TEXT) || o.IsOverlayType(DVDOVERLAY_TYPE_SSA))
+  {
+    CDVDOverlayLibass& ovAss = static_cast<CDVDOverlayLibass&>(o);
+    if (!ovAss.GetLibassHandler())
+      return nullptr;
+
+    // ASS_Image* and detect_change were populated this frame by
+    // PrepareOverlays. ConvertLibass does not re-enter libass.
+    r = ConvertLibass(e);
 
     if (!r)
       return nullptr;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -40,6 +40,14 @@ namespace OVERLAY {
     float height;
   };
 
+  /*!
+   * \brief Mark the GUI dirty so the GUI walk fires next frame.
+   *  Used by overlay-related code paths (subtitles, debug OSD) to keep
+   *  the GUI walk running while overlays are visible; overlays are not
+   *  CGUIControls and do not participate in the dirty system automatically.
+   */
+  void MarkDirty();
+
   class COverlay
   {
   public:

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -41,10 +41,11 @@ namespace OVERLAY {
   };
 
   /*!
-   * \brief Mark the GUI dirty so the GUI walk fires next frame.
-   *  Used by overlay-related code paths (subtitles, debug OSD) to keep
-   *  the GUI walk running while overlays are visible; overlays are not
-   *  CGUIControls and do not participate in the dirty system automatically.
+   * \brief Mark the entire GUI dirty so the next render pass runs
+   *  (not skipped). Overlays (subtitles, debug OSD) are not CGUIControls
+   *  and do not set m_controlDirtyState automatically; callers invoke
+   *  this at overlay state transitions and on per-frame updates where
+   *  needed (debug OSD).
    */
   void MarkDirty();
 
@@ -134,20 +135,15 @@ namespace OVERLAY {
     void Release(int idx);
 
     /*!
-     * \brief True if any overlay in buffer slot \a idx is actually visible
-     *  on this frame.
+     * \brief True if any overlay in m_buffers[idx] is visible this frame.
      *
-     *  For libass overlays (TEXT/SSA), the persistent CDVDOverlayText /
-     *  CDVDOverlaySSA container has iPTSStopTime = DVD_NOPTS_VALUE and so
-     *  survives ProcessOverlays' PTS filter for the entire playback session
-     *  even between events. Presence in m_buffers[idx] is therefore not a
-     *  visibility test for libass. Visibility is read from the per-frame
-     *  e.renderedImages cache populated by PrepareOverlays via
-     *  ass_render_frame (non-null when an event covers the current PTS).
+     *  PGS/DVB and DVD SPU: ProcessOverlays only inserts at the visible PTS,
+     *  so any entry in m_buffers means visible.
      *
-     *  For image (PGS/DVB/IMAGE) and SPU overlays, ProcessOverlays already
-     *  PTS-filters before AddOverlay, so presence in m_buffers[idx] is the
-     *  per-frame visibility test.
+     *  libass (TEXT/SSA): the container is added once with no stop PTS and
+     *  stays in m_buffers for the whole video. Visibility means
+     *  ass_render_frame returned images for the current PTS, cached on
+     *  e.renderedImages by PrepareOverlays.
      *
      *  Must be called after PrepareOverlays has run this frame; before that
      *  e.renderedImages reflects the previous frame's state.
@@ -180,9 +176,9 @@ namespace OVERLAY {
       SElement() : overlay_dvd(NULL) { pts = 0.0; }
       double pts;
       std::shared_ptr<CDVDOverlay> overlay_dvd;
-      // Output of libass cached by PrepareOverlays and consumed by
-      // ConvertLibass when the GUI walk runs. libass owns renderedImages;
-      // the pointer is valid only until the next ass_render_frame call.
+      // libass output cached by PrepareOverlays; read by ConvertLibass during
+      // render. libass owns the pointer; valid only until the next
+      // ass_render_frame call.
       ASS_Image* renderedImages{nullptr};
       float renderedFrameWidth{0.0f};
       float renderedFrameHeight{0.0f};
@@ -232,10 +228,9 @@ namespace OVERLAY {
 
     std::shared_ptr<struct KODI::SUBTITLES::STYLE::style> m_overlayStyle;
     std::atomic<bool> m_isSettingsChanged{false};
-    // Track whether last frame had any image/SPU overlay, for transition
-    // detection in PrepareOverlays. Image/SPU overlays have no per-frame
-    // change signal like libass' assDetectChange, so we compare per-frame
-    // presence to drive MarkDirty on arrival and disappearance.
+    // Whether last frame had any image/SPU overlay. Used by PrepareOverlays
+    // to detect arrival/disappearance transitions (image/SPU have no
+    // per-frame change signal of their own, unlike libass detect_change).
     bool m_prevHadImageSpu{false};
   };
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -110,6 +110,16 @@ namespace OVERLAY {
     virtual void Render(int idx, float depth = 0.0f);
 
     /*!
+     * \brief Pre-walk hook: render libass output for the present slot.
+     *  Called once per frame on the GUI/main thread before the GUI walk-skip
+     *  decision. Caches the ASS_Image* and detect_change flag on each
+     *  SElement so ConvertLibass can consume them during the walk without
+     *  re-entering libass. Calls MarkDirty internally when libass reports
+     *  a visible or changed subtitle.
+     */
+    void PrepareOverlays(int idx);
+
+    /*!
      * \brief Release resources
      */
     void UnInit();
@@ -122,7 +132,27 @@ namespace OVERLAY {
     void Reset();
 
     void Release(int idx);
-    bool HasOverlay(int idx);
+
+    /*!
+     * \brief True if any overlay in buffer slot \a idx is actually visible
+     *  on this frame.
+     *
+     *  For libass overlays (TEXT/SSA), the persistent CDVDOverlayText /
+     *  CDVDOverlaySSA container has iPTSStopTime = DVD_NOPTS_VALUE and so
+     *  survives ProcessOverlays' PTS filter for the entire playback session
+     *  even between events. Presence in m_buffers[idx] is therefore not a
+     *  visibility test for libass. Visibility is read from the per-frame
+     *  e.renderedImages cache populated by PrepareOverlays via
+     *  ass_render_frame (non-null when an event covers the current PTS).
+     *
+     *  For image (PGS/DVB/IMAGE) and SPU overlays, ProcessOverlays already
+     *  PTS-filters before AddOverlay, so presence in m_buffers[idx] is the
+     *  per-frame visibility test.
+     *
+     *  Must be called after PrepareOverlays has run this frame; before that
+     *  e.renderedImages reflects the previous frame's state.
+     */
+    bool HasVisibleOverlay(int idx) const;
     void SetVideoRect(CRect &source, CRect &dest, CRect &view);
     void SetStereoMode(const std::string &stereomode);
 
@@ -150,22 +180,19 @@ namespace OVERLAY {
       SElement() : overlay_dvd(NULL) { pts = 0.0; }
       double pts;
       std::shared_ptr<CDVDOverlay> overlay_dvd;
+      // Output of libass cached by PrepareOverlays and consumed by
+      // ConvertLibass when the GUI walk runs. libass owns renderedImages;
+      // the pointer is valid only until the next ass_render_frame call.
+      ASS_Image* renderedImages{nullptr};
+      float renderedFrameWidth{0.0f};
+      float renderedFrameHeight{0.0f};
     };
 
     void Render(COverlay* o);
-    std::shared_ptr<COverlay> Convert(CDVDOverlay& o, double pts);
-    /*!
-    * \brief Convert the overlay to a overlay renderer
-    * \param o The overlay to convert
-    * \param pts The current PTS time
-    * \param subStyle The style to be used, MUST BE SET ONLY at the first call or when user change settings
-    * \return True if success, false if error
-    */
-    std::shared_ptr<COverlay> ConvertLibass(
-        CDVDOverlayLibass& o,
-        double pts,
-        bool updateStyle,
-        const std::shared_ptr<struct KODI::SUBTITLES::STYLE::style>& overlayStyle);
+    std::shared_ptr<COverlay> Convert(SElement& e);
+    // Build a COverlay (cached or freshly created) from the libass output
+    // already produced by PrepareOverlays. Does not call ass_render_frame.
+    std::shared_ptr<COverlay> ConvertLibass(SElement& e);
 
     void CreateSubtitlesStyle();
 
@@ -184,7 +211,7 @@ namespace OVERLAY {
       POSRESINFO_SAVE_CHANGES = -2,
     };
 
-    CCriticalSection m_section;
+    mutable CCriticalSection m_section;
     std::vector<SElement> m_buffers[NUM_BUFFERS];
     std::map<unsigned int, std::shared_ptr<COverlay>> m_textureCache;
     static unsigned int m_textureid;
@@ -205,5 +232,10 @@ namespace OVERLAY {
 
     std::shared_ptr<struct KODI::SUBTITLES::STYLE::style> m_overlayStyle;
     std::atomic<bool> m_isSettingsChanged{false};
+    // Track whether last frame had any image/SPU overlay, for transition
+    // detection in PrepareOverlays. Image/SPU overlays have no per-frame
+    // change signal like libass' assDetectChange, so we compare per-frame
+    // presence to drive MarkDirty on arrival and disappearance.
+    bool m_prevHadImageSpu{false};
   };
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGL.cpp
@@ -334,6 +334,7 @@ void COverlayGlyphGL::Render(SRenderState& state)
   glUniform1f(depthLoc, -1.0f);
 
   glDrawArrays(GL_TRIANGLES, 0, vecVertices.size());
+  CRenderSystemBase::m_GUIElementCount++;
 
   glDisableVertexAttribArray(posLoc);
   glDisableVertexAttribArray(colLoc);
@@ -463,6 +464,7 @@ void COverlayTextureGL::Render(SRenderState& state)
   glUniform1f(depthLoc, -1.0f);
 
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
+  CRenderSystemBase::m_GUIElementCount++;
 
   glDisableVertexAttribArray(posLoc);
   glDisableVertexAttribArray(tex0Loc);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
@@ -389,6 +389,7 @@ void COverlayGlyphGLES::Render(SRenderState& state)
   glUniform1f(depthLoc, -1.0f);
 
   glDrawArrays(GL_TRIANGLES, 0, vecVertices.size());
+  CRenderSystemBase::m_GUIElementCount++;
 
   glDisableVertexAttribArray(posLoc);
   glDisableVertexAttribArray(colLoc);
@@ -482,6 +483,7 @@ void COverlayTextureGLES::Render(SRenderState& state)
   tex[2][1] = tex[3][1] = m_v;
 
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
+  CRenderSystemBase::m_GUIElementCount++;
 
   glDisableVertexAttribArray(posLoc);
   glDisableVertexAttribArray(tex0Loc);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -352,11 +352,9 @@ void CRenderManager::FrameMove()
 
   m_playerPort->UpdateGuiRender(IsGuiLayer() || !m_pRenderer->HasVideoPlane() || firstFrame);
 
-  // Pre-walk libass probe: render the libass output for the present slot
-  // once on the render thread, before the GUI walk-skip check runs next
-  // frame. PrepareOverlays MarkDirty's internally when libass reports
-  // something visible or changed. Replaces the cross-thread MarkDirty
-  // formerly issued from CRenderer::AddOverlay on the video thread.
+  // Run libass for the current PTS and cache the output for ConvertLibass
+  // to use during the render pass. PrepareOverlays MarkDirty's on libass
+  // changes and on PGS/DVB/SPU arrival/disappearance.
   m_overlays.PrepareOverlays(m_presentsource);
 
   ManageCaptures();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -231,7 +231,7 @@ bool CRenderManager::Configure()
     m_presentpts = DVD_NOPTS_VALUE;
     m_lateframes = -1;
     m_presentevent.notifyAll();
-    m_renderedOverlay = false;
+    m_renderedDebugOverlay = false;
     m_renderDebug = false;
     m_clockSync.Reset();
     m_dvdClock.SetVsyncAdjust(0);
@@ -351,6 +351,13 @@ void CRenderManager::FrameMove()
   }
 
   m_playerPort->UpdateGuiRender(IsGuiLayer() || !m_pRenderer->HasVideoPlane() || firstFrame);
+
+  // Pre-walk libass probe: render the libass output for the present slot
+  // once on the render thread, before the GUI walk-skip check runs next
+  // frame. PrepareOverlays MarkDirty's internally when libass reports
+  // something visible or changed. Replaces the cross-thread MarkDirty
+  // formerly issued from CRenderer::AddOverlay on the video thread.
+  m_overlays.PrepareOverlays(m_presentsource);
 
   ManageCaptures();
 }
@@ -736,7 +743,6 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
     if (!m_pRenderer->IsGuiLayer())
       m_pRenderer->Update();
 
-    m_renderedOverlay = m_overlays.HasOverlay(m_presentsource);
     CRect src, dst, view;
     m_pRenderer->GetVideoRect(src, dst, view);
     m_overlays.SetVideoRect(src, dst, view);
@@ -774,7 +780,7 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
       m_debugRenderer.Render(src, dst, view);
 
       m_debugTimer.Set(1000ms);
-      m_renderedOverlay = true;
+      m_renderedDebugOverlay = true;
     }
   }
 
@@ -811,8 +817,8 @@ bool CRenderManager::IsGuiLayer()
     if (!m_pRenderer)
       return false;
 
-    if ((m_pRenderer->IsGuiLayer() && IsPresenting()) ||
-        m_renderedOverlay || m_overlays.HasOverlay(m_presentsource))
+    if ((m_pRenderer->IsGuiLayer() && IsPresenting()) || m_renderedDebugOverlay ||
+        m_overlays.HasVisibleOverlay(m_presentsource))
       return true;
 
     if (m_renderDebug && m_debugTimer.IsTimePast())

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -101,6 +101,18 @@ public:
   void AddOverlay(std::shared_ptr<CDVDOverlay> o, double pts);
   void ShowVideo(bool enable);
 
+  /*!
+   * \brief True if any subtitle/overlay is actually visible on the current
+   *  presented frame. Per-frame accurate, unlike the coarse HasOverlay path
+   *  which returns true for the whole playback session whenever a libass
+   *  track is loaded (due to the persistent NOPTS container). See
+   *  OVERLAY::CRenderer::HasVisibleOverlay for the full rationale.
+   *
+   *  Must be called after CRenderManager::FrameMove has run this frame
+   *  (which calls PrepareOverlays). Reads cached state; cheap.
+   */
+  bool HasVisibleOverlay() const { return m_overlays.HasVisibleOverlay(m_presentsource); }
+
   /**
    * If player uses buffering it has to wait for a buffer before it calls
    * AddVideoPicture and AddOverlay. It waits for max 50 ms before it returns -1
@@ -152,7 +164,7 @@ protected:
   CCriticalSection m_datalock;
   bool m_bTriggerUpdateResolution = false;
   bool m_bRenderGUI = true;
-  bool m_renderedOverlay = false;
+  bool m_renderedDebugOverlay = false;
   bool m_renderDebug = false;
   bool m_renderDebugVideo = false;
   XbmcThreads::EndTime<> m_debugTimer;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.h
@@ -102,11 +102,9 @@ public:
   void ShowVideo(bool enable);
 
   /*!
-   * \brief True if any subtitle/overlay is actually visible on the current
-   *  presented frame. Per-frame accurate, unlike the coarse HasOverlay path
-   *  which returns true for the whole playback session whenever a libass
-   *  track is loaded (due to the persistent NOPTS container). See
-   *  OVERLAY::CRenderer::HasVisibleOverlay for the full rationale.
+   * \brief True if any subtitle/overlay is visible on the current presented
+   *  frame. Per-frame accurate. See OVERLAY::CRenderer::HasVisibleOverlay
+   *  for the libass vs PGS/DVB/SPU details.
    *
    *  Must be called after CRenderManager::FrameMove has run this frame
    *  (which calls PrepareOverlays). Reads cached state; cheap.

--- a/xbmc/guilib/GUIFontTTFGL.cpp
+++ b/xbmc/guilib/GUIFontTTFGL.cpp
@@ -286,6 +286,7 @@ void CGUIFontTTFGL::LastEnd()
             reinterpret_cast<GLvoid*>(character * sizeof(SVertex) * 4 + offsetof(SVertex, u)));
 
         glDrawElements(GL_TRIANGLES, 6 * count, GL_UNSIGNED_SHORT, 0);
+        CRenderSystemBase::m_GUIElementCount++;
       }
     }
 

--- a/xbmc/guilib/GUIFontTTFGLES.cpp
+++ b/xbmc/guilib/GUIFontTTFGLES.cpp
@@ -281,6 +281,7 @@ void CGUIFontTTFGLES::LastEnd()
             reinterpret_cast<GLvoid*>(character * sizeof(SVertex) * 4 + offsetof(SVertex, u)));
 
         glDrawElements(GL_TRIANGLES, 6 * count, GL_UNSIGNED_SHORT, 0);
+        CRenderSystemBase::m_GUIElementCount++;
       }
 
       glMatrixModview.Pop();

--- a/xbmc/guilib/GUITextureGL.cpp
+++ b/xbmc/guilib/GUITextureGL.cpp
@@ -153,6 +153,7 @@ void CGUITextureGL::End()
     glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(ushort)*m_idx.size(), m_idx.data(), GL_STATIC_DRAW);
 
     glDrawElements(GL_TRIANGLES, m_packedVertices.size()*6 / 4, GL_UNSIGNED_SHORT, 0);
+    CRenderSystemBase::m_GUIElementCount++;
 
     if (m_diffuse.size())
       glDisableVertexAttribArray(tex1Loc);
@@ -371,6 +372,7 @@ void CGUITextureGL::DrawQuad(const CRect& rect,
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(GLubyte)*4, idx, GL_STATIC_DRAW);
 
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, nullptr);
+  CRenderSystemBase::m_GUIElementCount++;
 
   glDisableVertexAttribArray(posLoc);
   if (texture)

--- a/xbmc/guilib/GUITextureGLES.cpp
+++ b/xbmc/guilib/GUITextureGLES.cpp
@@ -173,6 +173,7 @@ void CGUITextureGLES::End()
     glEnableVertexAttribArray(tex0Loc);
 
     glDrawElements(GL_TRIANGLES, m_packedVertices.size()*6 / 4, GL_UNSIGNED_SHORT, m_idx.data());
+    CRenderSystemBase::m_GUIElementCount++;
 
     if (m_diffuse.size())
       glDisableVertexAttribArray(tex1Loc);
@@ -355,6 +356,7 @@ void CGUITextureGLES::DrawQuad(const CRect& rect,
   }
 
   glDrawElements(GL_TRIANGLE_STRIP, 4, GL_UNSIGNED_BYTE, idx);
+  CRenderSystemBase::m_GUIElementCount++;
 
   glDisableVertexAttribArray(posLoc);
   if (texture)

--- a/xbmc/guilib/GUIVideoControl.cpp
+++ b/xbmc/guilib/GUIVideoControl.cpp
@@ -36,7 +36,9 @@ void CGUIVideoControl::Process(unsigned int currentTime, CDirtyRegionList &dirty
   //! @todo Proper processing which marks when its actually changed. Just mark always for now.
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-  if (appPlayer->IsRenderingGuiLayer())
+  // Only fire for single-plane renderers where video draws via the GUI walk.
+  // See CGUIWindowFullScreen::Process for full rationale.
+  if (!appPlayer->IsRenderingVideoLayer())
     MarkDirtyRegion();
 
   CGUIControl::Process(currentTime, dirtyregions);

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -99,6 +99,13 @@ public:
    */
   void MarkDirty(const CRect& rect);
 
+  /*! \brief True if Process() collected any dirty regions this frame.
+   Callable after Process() to decide whether Render() needs to run; used by
+   the dirty-driven skip on paths with a persistent framebuffer (DRM plane,
+   GUI compositing FBO).
+   */
+  bool HasDirtyRegions() const { return !m_dirtyregions.empty(); }
+
   /*! \brief Rendering of the current window and any dialogs
    Render is called every frame to draw the current window and any dialogs.
    It should only be called from the application thread.

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -100,9 +100,9 @@ public:
   void MarkDirty(const CRect& rect);
 
   /*! \brief True if Process() collected any dirty regions this frame.
-   Callable after Process() to decide whether Render() needs to run; used by
-   the dirty-driven skip on paths with a persistent framebuffer (DRM plane,
-   GUI compositing FBO).
+   *   Callable after Process() to decide whether the render pass needs
+   *   to run; used by the dirty-driven skip in CApplication::FrameMove
+   *   (currently gated to D2P plane and HDR GUI compositing FBO contexts).
    */
   bool HasDirtyRegions() const { return !m_dirtyregions.empty(); }
 

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -695,9 +695,10 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
     CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPicturesInfoProvider().SetCurrentSlide(m_slides.at(m_iCurrentSlide).get());
 
   RenderPause();
-  // Force MarkDirty when video is drawn through the GUI walk (single-plane
-  // path: the walk drives video frame display). On D2P the video plane self-
-  // updates independently of the walk, so no per-frame MarkDirty is needed.
+  // Single-plane mode (video drawn into the GUI back buffer during the
+  // render pass): MarkDirty every frame to keep the render pass running.
+  // D2P (video has its own hardware plane): video updates independently
+  // of the render pass.
   if (IsVideo(*m_slides.at(m_iCurrentSlide)) && appPlayer && !appPlayer->IsRenderingVideoLayer())
   {
     MarkDirtyRegion();

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -695,7 +695,10 @@ void CGUIWindowSlideShow::Process(unsigned int currentTime, CDirtyRegionList &re
     CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetPicturesInfoProvider().SetCurrentSlide(m_slides.at(m_iCurrentSlide).get());
 
   RenderPause();
-  if (IsVideo(*m_slides.at(m_iCurrentSlide)) && appPlayer && appPlayer->IsRenderingGuiLayer())
+  // Force MarkDirty when video is drawn through the GUI walk (single-plane
+  // path: the walk drives video frame display). On D2P the video plane self-
+  // updates independently of the walk, so no per-frame MarkDirty is needed.
+  if (IsVideo(*m_slides.at(m_iCurrentSlide)) && appPlayer && !appPlayer->IsRenderingVideoLayer())
   {
     MarkDirtyRegion();
   }

--- a/xbmc/rendering/RenderSystem.cpp
+++ b/xbmc/rendering/RenderSystem.cpp
@@ -19,6 +19,8 @@
 
 #include <memory>
 
+unsigned int CRenderSystemBase::m_GUIElementCount = 0;
+
 CRenderSystemBase::CRenderSystemBase()
 {
   OnAdvancedSettingsLoaded();

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -45,6 +45,10 @@ public:
   CRenderSystemBase();
   virtual ~CRenderSystemBase();
 
+  // Number of GUI elements (textures, text, overlays) drawn this frame; reset
+  // in BeginRender, bumped at each GUI draw primitive. Render-thread only.
+  static unsigned int m_GUIElementCount;
+
   virtual bool InitRenderSystem() = 0;
   virtual bool DestroyRenderSystem() = 0;
   virtual bool ResetRenderSystem(int width, int height) = 0;

--- a/xbmc/rendering/RenderSystem.h
+++ b/xbmc/rendering/RenderSystem.h
@@ -49,6 +49,8 @@ public:
   // in BeginRender, bumped at each GUI draw primitive. Render-thread only.
   static unsigned int m_GUIElementCount;
 
+  unsigned int GetGUIElementCount() const { return m_GUIElementCount; }
+
   virtual bool InitRenderSystem() = 0;
   virtual bool DestroyRenderSystem() = 0;
   virtual bool ResetRenderSystem(int width, int height) = 0;

--- a/xbmc/rendering/gl/RenderSystemGL.cpp
+++ b/xbmc/rendering/gl/RenderSystemGL.cpp
@@ -262,6 +262,8 @@ bool CRenderSystemGL::BeginRender()
   if (!m_bRenderCreated)
     return false;
 
+  m_GUIElementCount = 0;
+
   bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor() &&
                     !CServiceBroker::GetWinSystem()->IsHdrComposite();
 

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -176,6 +176,8 @@ bool CRenderSystemGLES::BeginRender()
   if (!m_bRenderCreated)
     return false;
 
+  m_GUIElementCount = 0;
+
   const bool useLimited = CServiceBroker::GetWinSystem()->UseLimitedColor() &&
                           !CServiceBroker::GetWinSystem()->IsHdrComposite();
   const bool usePQ = CServiceBroker::GetWinSystem()->GetGfxContext().IsTransferPQ();

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -376,7 +376,11 @@ void CGUIWindowFullScreen::Process(unsigned int currentTime, CDirtyRegionList &d
 {
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-  if (appPlayer->IsRenderingGuiLayer())
+  // Only fire for single-plane renderers where video draws via the GUI walk
+  // (VAAPI, LinuxRendererGLES, DRMPRIMEGLES). For D2P, video lives on its
+  // own hardware plane; subtitle dirty is handled by OVERLAY::PrepareOverlays
+  // on actual change.
+  if (!appPlayer->IsRenderingVideoLayer())
     MarkDirtyRegion();
 
   m_controlStats->Reset();

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -376,10 +376,11 @@ void CGUIWindowFullScreen::Process(unsigned int currentTime, CDirtyRegionList &d
 {
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-  // Only fire for single-plane renderers where video draws via the GUI walk
-  // (VAAPI, LinuxRendererGLES, DRMPRIMEGLES). For D2P, video lives on its
-  // own hardware plane; subtitle dirty is handled by OVERLAY::PrepareOverlays
-  // on actual change.
+  // IsRenderingVideoLayer: true on D2P (video has its own DRM plane);
+  // false in single-plane mode (video drawn through the render pass).
+  // Single-plane: MarkDirtyRegion every frame so the render pass keeps
+  // running and draws the next video frame. D2P video plane updates
+  // independently.
   if (!appPlayer->IsRenderingVideoLayer())
     MarkDirtyRegion();
 

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -257,7 +257,10 @@ public:
   // GUI compositing for HDR: render GUI to FBO, composite with tone mapping
   // colorTransfer: AVCOL_TRC_SMPTE2084 (PQ) or AVCOL_TRC_ARIB_STD_B67 (HLG), 0 to disable
   virtual bool SetGuiCompositing(int colorTransfer) { return false; }
-  virtual bool BeginGuiComposite() { return false; }
+  // guiWillRender: hint that GUI rendering is about to fire this frame.
+  // When false, implementations should skip FBO bind/clear since no GUI
+  // draws will land in the FBO this frame.
+  virtual bool BeginGuiComposite(bool guiWillRender) { return false; }
   virtual void EndGuiComposite() {}
   virtual void CompositeGui() {}
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -242,10 +242,12 @@ bool CWinSystemGbmGLContext::SetGuiCompositing(int colorTransfer)
   return m_guiCompositing;
 }
 
-bool CWinSystemGbmGLContext::BeginGuiComposite()
+bool CWinSystemGbmGLContext::BeginGuiComposite(bool guiWillRender)
 {
   if (!m_guiCompositing)
     return false;
+
+  m_guiWillRender = guiWillRender;
 
   int width = m_nWidth;
   int height = m_nHeight;
@@ -282,6 +284,11 @@ bool CWinSystemGbmGLContext::BeginGuiComposite()
     CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext: created GUI FBO {}x{}", width, height);
   }
 
+  // When GUI render is being skipped, leave the FBO bind/clear out: nothing
+  // will draw into it this frame.
+  if (!guiWillRender)
+    return true;
+
   if (!m_guiFbo.BeginRender())
     return false;
 
@@ -298,7 +305,8 @@ bool CWinSystemGbmGLContext::BeginGuiComposite()
 
 void CWinSystemGbmGLContext::EndGuiComposite()
 {
-  m_guiFbo.EndRender();
+  if (m_guiWillRender)
+    m_guiFbo.EndRender();
 
   glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
   glClear(GL_COLOR_BUFFER_BIT);

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -285,7 +285,14 @@ bool CWinSystemGbmGLContext::BeginGuiComposite(bool guiWillRender)
   }
 
   // When GUI render is being skipped, leave the FBO bind/clear out: nothing
-  // will draw into it this frame.
+  // will draw into it this frame. The FBO's prior sRGB GUI content is
+  // implicitly preserved across the skipped frame as a side effect.
+  //! @todo The preserved sRGB FBO is currently not leveraged: D2P reuses the
+  //! post-PQ GUI plane back buffer directly via display HW, and single-plane
+  //! never reaches !guiWillRender (the dirty-driven skip is gated on
+  //! IsRenderingVideoLayer). Future single-plane "gate, don't move" work
+  //! lets the GUI walk skip while CompositeGui still runs each video frame,
+  //! re-using this cached sRGB FBO as the composite source.
   if (!guiWillRender)
     return true;
 
@@ -308,6 +315,14 @@ void CWinSystemGbmGLContext::EndGuiComposite()
   if (m_guiWillRender)
     m_guiFbo.EndRender();
 
+  // When the GUI render is skipped this frame, Flip(hasRendered=false, ...)
+  // will skip eglSwapBuffers and the back-buffer contents never reach the
+  // screen. Clearing it is pure waste. Single-plane never reaches
+  // !m_guiWillRender, so the D2P gate is the only path that triggers.
+  const bool isD2P = m_DRM && m_DRM->GetVideoPlane() != nullptr && m_DRM->GetGuiPlane() != nullptr;
+  if (isD2P && !m_guiWillRender)
+    return;
+
   glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
   glClear(GL_COLOR_BUFFER_BIT);
 }
@@ -320,12 +335,26 @@ void CWinSystemGbmGLContext::CompositeGui()
   if (!m_guiFbo.IsValid() || !m_guiFbo.IsBound() || !m_compositeShader)
     return;
 
-  // CRenderSystemBase counts the GUI elements drawn this frame. Zero means the
-  // GUI layer put nothing in the FBO: it is still clean (skip next clear) and
-  // there is nothing to composite.
-  const bool guiEmpty = (CRenderSystemBase::m_GUIElementCount == 0);
-  m_guiFboClean = guiEmpty;
-  if (guiEmpty)
+  // Only update m_guiFboClean when GUI render fired this frame; otherwise the
+  // FBO is in the same state as the previous frame and the flag stays as-is.
+  if (m_guiWillRender)
+  {
+    const bool guiEmpty = (CRenderSystemBase::m_GUIElementCount == 0);
+    m_guiFboClean = guiEmpty;
+    if (guiEmpty)
+      return;
+  }
+  else if (m_guiFboClean)
+  {
+    return;
+  }
+
+  // D2P with no new render: the cached PQ frame is already in the GUI plane
+  // back buffer from the prior composite. Skip the shader pass entirely; Flip
+  // will skip eglSwapBuffers too (hasRendered==false), and the display HW keeps
+  // scanning out the cached frame while the video plane updates independently.
+  if (!m_guiWillRender && m_DRM && m_DRM->GetVideoPlane() != nullptr &&
+      m_DRM->GetGuiPlane() != nullptr)
     return;
 
   glActiveTexture(GL_TEXTURE0);

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -339,7 +339,7 @@ void CWinSystemGbmGLContext::CompositeGui()
   // FBO is in the same state as the previous frame and the flag stays as-is.
   if (m_guiWillRender)
   {
-    const bool guiEmpty = (CRenderSystemBase::m_GUIElementCount == 0);
+    const bool guiEmpty = (GetGUIElementCount() == 0);
     m_guiFboClean = guiEmpty;
     if (guiEmpty)
       return;

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -268,16 +268,30 @@ bool CWinSystemGbmGLContext::BeginGuiComposite()
       return false;
     }
 
+    if (GetEnabledFrontToBackRendering() && !m_guiFbo.AttachDepthBuffer(width, height))
+    {
+      CLog::Log(LOGERROR, "CWinSystemGbmGLContext: failed to attach depth buffer to GUI FBO {}x{}",
+                width, height);
+      m_guiFbo.Cleanup();
+      return false;
+    }
+
     m_guiFboWidth = width;
     m_guiFboHeight = height;
+    m_guiFboClean = false; // fresh FBO is undefined, force a clear
     CLog::Log(LOGDEBUG, "CWinSystemGbmGLContext: created GUI FBO {}x{}", width, height);
   }
 
   if (!m_guiFbo.BeginRender())
     return false;
 
-  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-  glClear(GL_COLOR_BUFFER_BIT);
+  // Clear only when the FBO holds stale content; idle frames are already clean.
+  if (!m_guiFboClean)
+  {
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    m_guiFboClean = true;
+  }
 
   return true;
 }
@@ -296,6 +310,14 @@ void CWinSystemGbmGLContext::EndGuiComposite()
 void CWinSystemGbmGLContext::CompositeGui()
 {
   if (!m_guiFbo.IsValid() || !m_guiFbo.IsBound() || !m_compositeShader)
+    return;
+
+  // CRenderSystemBase counts the GUI elements drawn this frame. Zero means the
+  // GUI layer put nothing in the FBO: it is still clean (skip next clear) and
+  // there is nothing to composite.
+  const bool guiEmpty = (CRenderSystemBase::m_GUIElementCount == 0);
+  m_guiFboClean = guiEmpty;
+  if (guiEmpty)
     return;
 
   glActiveTexture(GL_TEXTURE0);

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.h
@@ -58,6 +58,7 @@ private:
   CFrameBufferObject m_guiFbo;
   int m_guiFboWidth{0};
   int m_guiFboHeight{0};
+  bool m_guiFboClean{false};
   std::unique_ptr<CGuiCompositeShaderGL> m_compositeShader;
 };
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.h
@@ -43,7 +43,7 @@ public:
 
   // GUI compositing for HDR (FBO + sRGB->PQ shader)
   bool SetGuiCompositing(int colorTransfer) override;
-  bool BeginGuiComposite() override;
+  bool BeginGuiComposite(bool guiWillRender) override;
   void EndGuiComposite() override;
   void CompositeGui() override;
   bool IsHdrComposite() const override { return m_guiCompositing; }
@@ -59,6 +59,8 @@ private:
   int m_guiFboWidth{0};
   int m_guiFboHeight{0};
   bool m_guiFboClean{false};
+  // Hint from BeginGuiComposite about whether the GUI render is going to fire.
+  bool m_guiWillRender{true};
   std::unique_ptr<CGuiCompositeShaderGL> m_compositeShader;
 };
 

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.h
@@ -58,8 +58,9 @@ private:
   CFrameBufferObject m_guiFbo;
   int m_guiFboWidth{0};
   int m_guiFboHeight{0};
+  // True when the GUI FBO is empty (no draws this frame); CompositeGui skips composite when true.
   bool m_guiFboClean{false};
-  // Hint from BeginGuiComposite about whether the GUI render is going to fire.
+  // Whether the GUI render pass will run this frame; set by BeginGuiComposite.
   bool m_guiWillRender{true};
   std::unique_ptr<CGuiCompositeShaderGL> m_compositeShader;
 };

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -277,7 +277,14 @@ bool CWinSystemGbmGLESContext::BeginGuiComposite(bool guiWillRender)
   }
 
   // When GUI render is being skipped, leave the FBO bind/clear out: nothing
-  // will draw into it this frame.
+  // will draw into it this frame. The FBO's prior sRGB GUI content is
+  // implicitly preserved across the skipped frame as a side effect.
+  //! @todo The preserved sRGB FBO is currently not leveraged: D2P reuses the
+  //! post-PQ GUI plane back buffer directly via display HW, and single-plane
+  //! never reaches !guiWillRender (the dirty-driven skip is gated on
+  //! IsRenderingVideoLayer). Future single-plane "gate, don't move" work
+  //! lets the GUI walk skip while CompositeGui still runs each video frame,
+  //! re-using this cached sRGB FBO as the composite source.
   if (!guiWillRender)
     return true;
 
@@ -300,6 +307,15 @@ void CWinSystemGbmGLESContext::EndGuiComposite()
   if (m_guiWillRender)
     m_guiFbo.EndRender();
 
+  // When the GUI render is skipped this frame, Flip(hasRendered=false, ...)
+  // will skip eglSwapBuffers and the back-buffer contents never reach the
+  // screen. Clearing it is pure waste. Gate on D2P because single-plane
+  // never reaches !m_guiWillRender (the dirty-driven skip is gated on
+  // IsRenderingVideoLayer()), so this is the only path that triggers.
+  const bool isD2P = m_DRM && m_DRM->GetVideoPlane() != nullptr && m_DRM->GetGuiPlane() != nullptr;
+  if (isD2P && !m_guiWillRender)
+    return;
+
   // Clear the backbuffer before video renders. In the FBO compositing path,
   // video renders in the RenderEx pass with clear=false, so DrawBlackBars is
   // never called. Without this clear, letterbox areas retain stale content
@@ -317,12 +333,30 @@ void CWinSystemGbmGLESContext::CompositeGui()
   if (!m_guiFbo.IsValid() || !m_guiFbo.IsBound() || !m_compositeShader)
     return;
 
-  // CRenderSystemBase counts the GUI elements drawn this frame. Zero means the
-  // GUI layer put nothing in the FBO: it is still clean (skip next clear) and
-  // there is nothing to composite.
-  const bool guiEmpty = (CRenderSystemBase::m_GUIElementCount == 0);
-  m_guiFboClean = guiEmpty;
-  if (guiEmpty)
+  // Only update m_guiFboClean when GUI render fired this frame; otherwise the
+  // FBO is in the same state as the previous frame and the flag stays as-is.
+  // m_guiFboClean meaning depends on context:
+  //   single-plane: "FBO is empty/clean" (no composite work needed)
+  //   D2P:          "FBO is empty/clean AND back buffer cache is invalid"
+  if (m_guiWillRender)
+  {
+    const bool guiEmpty = (CRenderSystemBase::m_GUIElementCount == 0);
+    m_guiFboClean = guiEmpty;
+    if (guiEmpty)
+      return;
+  }
+  else if (m_guiFboClean)
+  {
+    return;
+  }
+
+  // D2P with no new render: the cached PQ frame is already in the GUI plane
+  // back buffer from the prior composite. Skip the shader pass entirely; Flip
+  // will skip eglSwapBuffers too (hasRendered==false because Render was not
+  // called), and the display HW keeps scanning out the cached frame while the
+  // video plane updates independently via atomic commit.
+  if (!m_guiWillRender && m_DRM && m_DRM->GetVideoPlane() != nullptr &&
+      m_DRM->GetGuiPlane() != nullptr)
     return;
 
   glActiveTexture(GL_TEXTURE0);

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -232,10 +232,12 @@ bool CWinSystemGbmGLESContext::SetGuiCompositing(int colorTransfer)
   return m_guiCompositing;
 }
 
-bool CWinSystemGbmGLESContext::BeginGuiComposite()
+bool CWinSystemGbmGLESContext::BeginGuiComposite(bool guiWillRender)
 {
   if (!m_guiCompositing)
     return false;
+
+  m_guiWillRender = guiWillRender;
 
   int width = m_nWidth;
   int height = m_nHeight;
@@ -274,6 +276,11 @@ bool CWinSystemGbmGLESContext::BeginGuiComposite()
     CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext: created GUI FBO {}x{}", width, height);
   }
 
+  // When GUI render is being skipped, leave the FBO bind/clear out: nothing
+  // will draw into it this frame.
+  if (!guiWillRender)
+    return true;
+
   if (!m_guiFbo.BeginRender())
     return false;
 
@@ -290,7 +297,8 @@ bool CWinSystemGbmGLESContext::BeginGuiComposite()
 
 void CWinSystemGbmGLESContext::EndGuiComposite()
 {
-  m_guiFbo.EndRender();
+  if (m_guiWillRender)
+    m_guiFbo.EndRender();
 
   // Clear the backbuffer before video renders. In the FBO compositing path,
   // video renders in the RenderEx pass with clear=false, so DrawBlackBars is

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -270,15 +270,20 @@ bool CWinSystemGbmGLESContext::BeginGuiComposite()
 
     m_guiFboWidth = width;
     m_guiFboHeight = height;
+    m_guiFboClean = false; // fresh FBO is undefined, force a clear
     CLog::Log(LOGDEBUG, "CWinSystemGbmGLESContext: created GUI FBO {}x{}", width, height);
   }
 
   if (!m_guiFbo.BeginRender())
     return false;
 
-  // clear FBO to transparent black
-  glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
-  glClear(GL_COLOR_BUFFER_BIT);
+  // Clear only when the FBO holds stale content; idle frames are already clean.
+  if (!m_guiFboClean)
+  {
+    glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+    glClear(GL_COLOR_BUFFER_BIT);
+    m_guiFboClean = true;
+  }
 
   return true;
 }
@@ -302,6 +307,14 @@ void CWinSystemGbmGLESContext::EndGuiComposite()
 void CWinSystemGbmGLESContext::CompositeGui()
 {
   if (!m_guiFbo.IsValid() || !m_guiFbo.IsBound() || !m_compositeShader)
+    return;
+
+  // CRenderSystemBase counts the GUI elements drawn this frame. Zero means the
+  // GUI layer put nothing in the FBO: it is still clean (skip next clear) and
+  // there is nothing to composite.
+  const bool guiEmpty = (CRenderSystemBase::m_GUIElementCount == 0);
+  m_guiFboClean = guiEmpty;
+  if (guiEmpty)
     return;
 
   glActiveTexture(GL_TEXTURE0);

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -340,7 +340,7 @@ void CWinSystemGbmGLESContext::CompositeGui()
   //   D2P:          "FBO is empty/clean AND back buffer cache is invalid"
   if (m_guiWillRender)
   {
-    const bool guiEmpty = (CRenderSystemBase::m_GUIElementCount == 0);
+    const bool guiEmpty = (GetGUIElementCount() == 0);
     m_guiFboClean = guiEmpty;
     if (guiEmpty)
       return;

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
@@ -44,7 +44,7 @@ public:
 
   // GUI compositing for HDR
   bool SetGuiCompositing(int colorTransfer) override;
-  bool BeginGuiComposite() override;
+  bool BeginGuiComposite(bool guiWillRender) override;
   void EndGuiComposite() override;
   void CompositeGui() override;
   bool IsHdrComposite() const override { return m_guiCompositing; }
@@ -60,6 +60,8 @@ private:
   int m_guiFboWidth{0};
   int m_guiFboHeight{0};
   bool m_guiFboClean{false};
+  // Hint from BeginGuiComposite about whether the GUI render is going to fire.
+  bool m_guiWillRender{true};
 
   std::unique_ptr<CGuiCompositeShaderGLES> m_compositeShader;
 };

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
@@ -59,6 +59,7 @@ private:
   CFrameBufferObject m_guiFbo;
   int m_guiFboWidth{0};
   int m_guiFboHeight{0};
+  bool m_guiFboClean{false};
 
   std::unique_ptr<CGuiCompositeShaderGLES> m_compositeShader;
 };

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.h
@@ -59,8 +59,9 @@ private:
   CFrameBufferObject m_guiFbo;
   int m_guiFboWidth{0};
   int m_guiFboHeight{0};
+  // True when the GUI FBO is empty (no draws this frame); CompositeGui skips composite when true.
   bool m_guiFboClean{false};
-  // Hint from BeginGuiComposite about whether the GUI render is going to fire.
+  // Whether the GUI render pass will run this frame; set by BeginGuiComposite.
   bool m_guiWillRender{true};
 
   std::unique_ptr<CGuiCompositeShaderGLES> m_compositeShader;

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -9,6 +9,8 @@
 #include "DRMAtomic.h"
 
 #include "ServiceBroker.h"
+#include "application/ApplicationComponents.h"
+#include "application/ApplicationPlayer.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "settings/Settings.h"
@@ -108,20 +110,19 @@ void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool video
       AddProperty(outputPlane, "IN_FENCE_FD", m_inFenceFd);
     }
   }
+  //! @todo Reaching out to the window manager and application player
+  //! singletons from inside the DRM layer is a layering violation. The
+  //! "should the GUI plane be attached this frame" decision is GUI/player
+  //! policy and should be computed at the WinSystem caller and passed in
+  //! as a parameter on FlipPage. Until that refactor lands, do the lookups
+  //! in place to match the surrounding master code pattern.
   else if (m_gui_plane && m_video_plane &&
            !CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls() &&
+           !CServiceBroker::GetAppComponents()
+                .GetComponent<CApplicationPlayer>()
+                ->HasVisibleOverlay() &&
            !HasQuirk(QUIRK_NEEDSPRIMARY))
   {
-    // Dual-plane (DRMPRIME D2P) mode with no visible GUI controls: disable
-    // the gui plane to save scanout bandwidth. The video plane is being
-    // populated by CVideoLayerBridgeDRMPRIME on the same atomic request.
-    // Skip when the crtc requires a primary plane (amdgpu QUIRK_NEEDSPRIMARY)
-    // -- in that case the gui plane is the primary and disabling it would
-    // fail the commit.
-    //
-    // Gating on (m_gui_plane && m_video_plane) precisely matches dual-plane
-    // mode and rejects single-plane flip-flop mode where m_gui_plane is null
-    // (FindVideoPlane has adopted it as the video output plane).
     AddProperty(m_gui_plane, "FB_ID", 0);
     AddProperty(m_gui_plane, "CRTC_ID", 0);
   }


### PR DESCRIPTION
## Description
GUI rendering is expensive; it's particularly expensive when combined with GL-based compositing. On D2P HDR the cost is acute: each idle frame still does an FBO bind, clear, full GUI tree draw, sRGB-to-PQ composite shader pass, and EGL swap. RPi4 can't keep up with this during 4K HDR playback and stutters.

*What this PR does*
Two things. First, the renderer now actually honors MarkDirty: when nothing on the GUI has changed, the render pass is skipped instead of redrawing identical pixels. Second, overlays (subtitles, debug OSD) are taught to MarkDirty when they change. Previously they relied on the always-running render pass and never participated in the dirty system at all.

For D2P video playback this means idle GUI frames cost nothing: no control tree walk, no FBO clear, no PQ composite shader, no EGL swap. The video plane keeps updating on its own hardware plane; the GUI plane stays cached.

The HDR FBO compositing path picks up a few additional shortcuts: skip the FBO clear when it's already clean, skip the composite shader when the GUI produced no draws, preserve the prior PQ buffer across skipped frames.

The new overlay plumbing: a PrepareOverlays pre-render hook runs libass once per frame and MarkDirty's on detect_change. Image subtitles (PGS/DVB/SPU) MarkDirty on arrival and disappearance via per-frame state tracking. Debug OSD MarkDirty's at Initialize, Dispose, and per-frame from Render. HasVisibleOverlay is added and is per-frame accurate, replacing a coarse signal that was true for an entire video any time a libass track was loaded.

Single-plane renderers (VAAPI, LinuxRendererGLES, DRMPRIMEGLES) are excluded from the skip - their video shader runs inside the render pass, so the pass must keep firing. They still get the FBO shortcuts.


*Dirty architecture* - overlays: pre-PR, overlays didn't MarkDirty because the render pass ran unconditionally. Now they must.
- A new pre-render hook OVERLAY::CRenderer::PrepareOverlays runs once per CRenderManager::FrameMove on the GUI/main thread. It calls ass_render_frame for each active libass overlay at the current PTS, caches the returned ASS_Image* on SElement.renderedImages, and calls OVERLAY::MarkDirty() when libass reports detect_change > 0. ConvertLibass is reworked to consume from this cache during the render pass instead of re-entering libass.
- A new m_pendingChange flag on CDVDOverlayLibass carries libass's change signal across the PrepareOverlays-vs-ConvertLibass timing gap: when the render pass is skipped a frame after PrepareOverlays cached new images, the flag survives on the persistent overlay so the next render pass's ConvertLibass rebuilds the COverlay correctly.
- Subtitle dirty-marking now happens on the main thread (previously the video thread's AddOverlay reached cross-thread into CGUIWindowManager to MarkDirty when a subtitle arrived)
- PGS/DVB image subtitles and DVD SPU: same PrepareOverlays hook detects arrival via m_textureid == 0 and disappearance via a m_prevHadImageSpu transition. Either fires MarkDirty.
- Debug OSD (CDebugRenderer): calls OVERLAY::MarkDirty() from Initialize, Dispose, and per-frame from Render. Without Initialize's call, toggling the OSD on an idle screen wouldn't fire the first render.

Per-frame visibility signal: OVERLAY::CRenderer::HasVisibleOverlay() is new and per-frame accurate (PGS/DVB/SPU: any entry in m_buffers; libass: e.renderedImages != nullptr). Forwarded up through IPlayer::HasVisibleOverlay (new virtual) -> CVideoPlayer -> CApplicationPlayer -> CRenderManager. The old coarse HasOverlay path returned true for the entire video any time a libass track was loaded (the container lives the whole video with iPTSStopTime = DVD_NOPTS_VALUE); it's gone.

Gate consumers of the new signal:
- DRMAtomic::FlipPage re-enables the GUI-plane detach optimization on D2P when !HasVisibleControls() && !HasVisibleOverlay(). Without the per-frame-accurate visibility check this would blank subtitles on idle frames.
- CGUIVideoControl::Process, CGUIWindowFullScreen::Process, and CGUIWindowSlideShow::Process MarkDirty every frame when !IsRenderingVideoLayer() (single-plane). In D2P these are silent because the overlay-driven MarkDirty above is sufficient.

*Terminology*

The codebase uses "process" and "render" inconsistently. This PR uses:

- Walk / Process pass = CGUIWindowManager::Process -> CGUIControl::DoProcess tree traversal. Always runs every frame in this PR. Animations advance, timers tick, controls call MarkDirtyRegion when their state changes.
- Render pass = CGUIWindowManager::Render -> CGUIControl::Render tree traversal that issues GL/GLES draws. CONDITIONALLY SKIPPED via m_skipGuiRender.
- D2P = Direct-to-Plane: video has its own DRM hardware plane (RendererDRMPRIME). GUI lives on a separate gui_plane. `IsRenderingVideoLayer()==true`.
- Single-plane = video composited with GUI on the same plane via the render pass. `IsRenderingVideoLayer()==false`.

Added member variable `CRenderSystemBase::m_GUIElementCount` that globally tracks the number of GL/GLES renderable events that have happened per frame.  This is a nice-to-have for diagnostics that has runtime function in the HDR scenario.

This PR addresses the overuse of compositing when it's not needed. Further PR's are necessary to make the remaining uses more efficient.

*Scope notes (intentionally NOT in this PR)*

The following cleanups are deferred to dedicated follow-up PRs to keep this one reviewable:

- Delete the dead IsRenderingGuiLayer polled-status chain (10 files, render manager + IPlayer + CVideoPlayer + CDataCacheCore + 3 callers). Three call sites were already converted to !IsRenderingVideoLayer() here; the rest of the chain is unused after that and will be removed in its own PR.
- Reduce global singleton use and increase class-layer separation: Parameterize CDRMAtomic::FlipPage to eliminate the CServiceBroker fan-out into GetWindowManager().HasVisibleControls() and
GetAppComponents().GetComponent<CApplicationPlayer>().HasVisibleOverlay() from inside the DRM layer (flagged with a @todo at DRMAtomic.cpp). The decision should be computed at the WinSystem caller and passed in.
- A smarter ass_step_sub-based libass MarkDirty that fires only on actual subtitle transitions (rather than the current per-detect_change heuristic) is noted as a future refinement.

**Known issue: TEMP debug-hack to be removed before merge**

CApplication::Render carries a temporary diagnostic block that counts video / controls-visible / overlay-visible / skip-gui / skip-any frames and logs every 240 frames. This was added to verify skip-rate during draft testing and must be removed before merge. It does not affect behavior, only adds a periodic log line.

## Motivation and context
Overworked GPU.  RPi4 is struggling to keep up with the load. of HDR compositing during normal playback.

## How has this been tested?
Intel N250 and "DRMPRIME" D2P mode as well as VAAPIGLES.

## What is the effect on users?
RPi4 users should experience fewer (none?) stuttering during 4K HDR playback.

## Screenshots (if appropriate):
n/a

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
