### PR TITLE
[posix][filesystem] Restore filtering of hidden Windows SMB shares (names ending with $)

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -85,7 +85,7 @@ CSMBDirectory::~CSMBDirectory(void)
   smb.AddIdleConnection();
 }
 
-bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
+bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 {
   // We accept smb://[[[domain;]user[:password@]]server[/share[/path[/file]]]]
 
@@ -176,6 +176,13 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       if (dirent->smbc_type != SMBC_FILE_SHARE && dirent->smbc_type != SMBC_SERVER)
         continue;
 
+      // Skip hidden and Windows administrative shares (names ending with '$').
+      // These shares (C$, ADMIN$, IPC$, etc.) are not intended for browsing
+      // and are usually inaccessible.  Filtering them here keeps the listing clean.
+      const std::string shareName = dirent->name;
+      if (dirent->smbc_type == SMBC_FILE_SHARE && !shareName.empty() && shareName.back() == '$')
+        continue;
+
       std::string path(strRoot);
 
       // needed for network / workgroup browsing
@@ -208,7 +215,7 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   return true;
 }
 
-int CSMBDirectory::Open(const CURL &url)
+int CSMBDirectory::Open(const CURL& url)
 {
   smb.Init();
   std::string strAuth;
@@ -243,8 +250,7 @@ int CSMBDirectory::OpenDir(const CURL& url, std::string& strAuth)
   // don't do this for smb:// !!
   std::string s = strAuth;
   int len = s.length();
-  if (len > 1 && s.at(len - 2) != '/' &&
-      (s.at(len - 1) == '/' || s.at(len - 1) == '\\'))
+  if (len > 1 && s.at(len - 2) != '/' && (s.at(len - 1) == '/' || s.at(len - 1) == '\\'))
   {
     s.erase(len - 1, 1);
   }
@@ -309,7 +315,7 @@ bool CSMBDirectory::Create(const CURL& url2)
 
   int result = smbc_mkdir(strFileName.c_str(), 0);
   bool success = (result == 0 || EEXIST == errno);
-  if(!success)
+  if (!success)
     CLog::LogF(LOGERROR, "Error( {} )", strerror(errno));
 
   return success;
@@ -326,7 +332,7 @@ bool CSMBDirectory::Remove(const CURL& url2)
 
   int result = smbc_rmdir(strFileName.c_str());
 
-  if(result != 0 && errno != ENOENT)
+  if (result != 0 && errno != ENOENT)
   {
     CLog::LogF(LOGERROR, "Error( {} )", strerror(errno));
     return false;
@@ -350,4 +356,3 @@ bool CSMBDirectory::Exists(const CURL& url2)
 
   return S_ISDIR(info.st_mode);
 }
-


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The previous CSMBDirectory::GetDirectory skipped share names ending with $ (e.g. C$, ADMIN$, IPC$, and custom hidden shares). This filter was not carried over when the directory‑listing code was rewritten for performance in #27068 . This PR adds it back in the legacy fallback path used for share browsing.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Shares whose names end with $ are hidden by design in Windows – they are not meant to appear when browsing a server. After the rewrite, they began showing up in the Kodi share list, cluttering the interface. Restoring the filter returns the list to what users expect, matching the behavior of earlier Kodi versions.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Linux with a Windows 10 SMB server. With the filter active, only user‑visible shares are shown; hidden shares ($‑shares) are not listed. Browsing and playback inside normal shares remain unaffected.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users will see a clean list of SMB shares without hidden administrative or custom hidden shares. Those shares can still be accessed directly by typing their full path. No functional impact on browsing, playback, or library scanning.

## Screenshots (if appropriate):
<img width="720" height="512" alt="admin_shares" src="https://github.com/user-attachments/assets/ae61e44b-1c1b-4457-8bc5-6a918ad38ec4" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed