### PR TITLE
DRMPRIME/GBM: null m_video_plane after D2P playback

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -29,14 +29,24 @@ using namespace KODI::WINDOWING::GBM;
 CRendererDRMPRIME::~CRendererDRMPRIME()
 {
   Flush(false);
+
+  auto* winSystem = static_cast<CWinSystemGbm*>(CServiceBroker::GetWinSystem());
+
   // Clear the scanout colorspace and HDR metadata set during Configure so
   // the GUI after playback falls back to Default / SDR.
-  if (auto* winSystem = CServiceBroker::GetWinSystem())
-  {
-    winSystem->SetGuiCompositing(false);
-    winSystem->SetHDR(nullptr);
-    winSystem->SetColorimetry(nullptr);
-  }
+  winSystem->SetGuiCompositing(false);
+  winSystem->SetHDR(nullptr);
+  winSystem->SetColorimetry(nullptr);
+
+  //! @todo Restore single-plane state after D2P playback: null m_video_plane
+  //! via direct FindGuiPlane, mirroring Create's direct FindVideoAndGuiPlane.
+  //! D2P cannot share single-plane's teardown via winSystem->SetVideoOutput
+  //! (nullptr) because the renderer factory hands Create a CVideoBuffer*
+  //! (not a VideoPicture*) and start has no buffer-shaped winsystem entry.
+  //! Future: unified plane API for D2P and single-plane to share teardown.
+  auto drm = winSystem->GetDrm();
+  auto* gui = drm->GetGuiPlane();
+  drm->FindGuiPlane(gui->GetFormat(), gui->GetModifier());
 }
 
 CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -179,6 +179,7 @@ bool CDRMUtils::FindGuiPlane(uint32_t format, uint64_t modifier)
                DRMHELPERS::ModifierToString(modifier), m_crtc->GetId());
     m_gui_plane->SetFormat(format);
     m_gui_plane->SetModifier(modifier);
+    m_video_plane = nullptr;
     return true;
   }
 


### PR DESCRIPTION
## Description
After Direct-to-Plane (D2P) playback ends, `m_video_plane` was left assigned even though no video plane was active. This closes the contract that `m_video_plane` is non-null only while a video plane is in use.

Two pieces:

1. `CDRMUtils::FindGuiPlane`'s "Using existing gui plane" branch was
   missing the `m_video_plane = nullptr` that its other two branches
   already perform. Adding it makes every successful return from
   `FindGuiPlane` leave `m_video_plane` null.

2. `CRendererDRMPRIME::~CRendererDRMPRIME` now calls `FindGuiPlane`
   directly, mirroring `Create`'s direct `FindVideoAndGuiPlane`, so
   the contract is exercised on D2P stop.

todo: in the dtor notes that D2P and single-plane teardown
could be unified under a future winsystem plane API.

## Motivation and context
`CWinSystemGbm::GetName()` reported stale `gbm (AR24 / P030)` in System Info after D2P playback ended, even though only the GUI plane was active.

D2P bypasses the `winSystem->SetVideoOutput()` abstraction that single-plane renderers use for teardown, so nothing nulled `FindGuiPlane` first-branch bug surfaced once dynamic-plane support broke the single-plane flip-flop invariant (`m_gui_plane` set implied `m_video_plane` null), which that branch had been relying on.

## How has this been tested?
DRMPRIME config on Intel N250 GBM+GLES.

## What is the effect on users?
Mostly invsibile except for the System Information screen.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
