### PR TITLE
[Video][Database] Fix issues with .rar archives (2/2) - Database fix

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1936,10 +1936,14 @@ std::string URIUtils::SanitiseUrlEncoding(std::string_view path)
   // Some providers (eg. vfs rar) return paths with %2F instead of %2f,
   // which causes problems when comparing paths.
   // This only applies to the hostname element of the url
-  auto protocolEnd{path.find("://")};
+  constexpr std::string_view PROTOCOL_SEP = "://";
+  auto protocolEnd{path.find(PROTOCOL_SEP)};
   if (protocolEnd == std::string::npos)
     return std::string(path);
-  protocolEnd += 3;
+
+  protocolEnd += PROTOCOL_SEP.size();
+  if (protocolEnd >= path.size())
+    return std::string(path);
 
   auto hostEnd{path.find('/', protocolEnd)};
   if (hostEnd == std::string::npos)
@@ -1947,9 +1951,6 @@ std::string URIUtils::SanitiseUrlEncoding(std::string_view path)
 
   constexpr auto is_hex = [](char c) noexcept
   { return ('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F'); };
-
-  if (protocolEnd >= path.size() || hostEnd > path.size())
-    return std::string(path);
 
   std::string out{path.substr(0, protocolEnd)};
   for (auto it = path.begin() + static_cast<long long>(protocolEnd);

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -31,9 +31,12 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <ranges>
 #include <sstream>
 #include <stdlib.h>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 using namespace dbiplus;
@@ -97,6 +100,68 @@ static std::string LowerCaseEncodingV143(std::string_view in)
     else
       out += *it;
   }
+
+  return out;
+}
+
+static std::string SanitiseUrlEncodingV147(const std::string& path)
+{
+  // Firstly look at encoded character capitalization.
+  // Some providers (eg. vfs rar) return paths with %2F instead of %2f,
+  // which causes problems when comparing paths.
+  // This only applies to the hostname element of the url
+  constexpr std::string_view PROTOCOL_SEP = "://";
+  auto protocolEnd{path.find(PROTOCOL_SEP)};
+  if (protocolEnd == std::string::npos)
+    return path;
+
+  protocolEnd += PROTOCOL_SEP.size();
+  if (protocolEnd >= path.size())
+    return path;
+
+  auto hostEnd{path.find('/', protocolEnd)};
+  if (hostEnd == std::string::npos)
+    hostEnd = path.size();
+
+  constexpr auto is_hex = [](char c) noexcept
+  { return ('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F'); };
+
+  std::string out{path.substr(0, protocolEnd)};
+  for (auto it = path.begin() + static_cast<long long>(protocolEnd);
+       it != path.begin() + static_cast<long long>(hostEnd); ++it)
+  {
+    if (*it == '%' && std::ranges::distance(it, path.end()) > 2)
+    {
+      if (is_hex(it[1]) && is_hex(it[2]))
+      {
+        out += '%';
+        out += StringUtils::ToLowerAscii(it[1]);
+        out += StringUtils::ToLowerAscii(it[2]);
+        std::ranges::advance(it, 2);
+      }
+      else
+      {
+        CLog::LogF(LOGDEBUG, "Invalid encoding in path {}", CURL::GetRedacted(std::string(path)));
+        out += *it;
+      }
+    }
+    else
+      out += *it;
+  }
+
+  // In case addon (eg. vfs rar) returns malformed DOS paths (eg. c:/ and not c:\)
+  // m_basePath is used to populate the VIDEODB_ID_BASEPATH column which in turn is used
+  // by GetItemsByPath() to find items when browsing Video -> Files
+  // Pattern for DOS drive letter path: "D:/" encoded as "D%3a%2f"
+  constexpr std::string_view DOS_DRIVE_PATTERN = "%3a%2f";
+  constexpr size_t DOS_DRIVE_PATTERN_LENGTH =
+      DOS_DRIVE_PATTERN.length() + 1; // +1 for the drive letter
+  if (out.size() >= DOS_DRIVE_PATTERN_LENGTH &&
+      std::isalpha(static_cast<unsigned char>(out[protocolEnd])) &&
+      out.compare(protocolEnd + 1, DOS_DRIVE_PATTERN.length(), DOS_DRIVE_PATTERN) == 0)
+    StringUtils::Replace(out, "%2f", "%5c");
+
+  out += path.substr(hostEnd);
 
   return out;
 }
@@ -1209,9 +1274,157 @@ void CVideoDatabase::UpdateTables(int iVersion)
     m_pDS->dropIndex("episode", "id_episode_file_2");
     m_pDS->dropIndex("streamdetails", "ix_streamdetails");
   }
+
+  if (iVersion < 147)
+  {
+    constexpr int LOCAL_VIDEODB_ID_BASEPATH = 22;
+    constexpr int LOCAL_VIDEODB_ID_PARENTPATHID = 23;
+    constexpr int LOCAL_VIDEODB_ID_EPISODE_BASEPATH = 18;
+    constexpr int LOCAL_VIDEODB_ID_EPISODE_PARENTPATHID = 19;
+
+    std::unordered_set<int> idPathSet;
+    std::unordered_map<int, int> pathMap;
+
+    auto FixParentPath{
+        [&](const std::string& table, const std::string& mediaColumnName, int parentPathIdColumn,
+            int idMedia, int idParentPath, const std::string& parentPath)
+        {
+          if (parentPath.empty() || !URIUtils::IsDOSPath(parentPath))
+            return;
+
+          std::string newPath{parentPath};
+          StringUtils::Replace(newPath, '/', '\\');
+          if (newPath == parentPath)
+            return;
+
+          int newIdParentPath{idParentPath};
+          if (pathMap.contains(idParentPath))
+          {
+            newIdParentPath = pathMap[idParentPath];
+          }
+          else
+          {
+            m_pDS2->query(
+                PrepareSQL("SELECT idPath FROM path WHERE strPath = '%s'", newPath.c_str()));
+            if (!m_pDS2->eof())
+            {
+              newIdParentPath = m_pDS2->fv(0).get_asInt();
+              pathMap[idParentPath] = newIdParentPath;
+            }
+            else if (!idPathSet.contains(idParentPath))
+            {
+              m_pDS2->exec(PrepareSQL("UPDATE path SET strPath = '%s' WHERE idPath = %i",
+                                      newPath.c_str(), idParentPath));
+              idPathSet.insert(idParentPath);
+            }
+            m_pDS2->close();
+          }
+
+          if (newIdParentPath != idParentPath)
+            m_pDS2->exec(PrepareSQL("UPDATE %s SET c%02d = %i WHERE %s = %i", table.c_str(),
+                                    parentPathIdColumn, newIdParentPath, mediaColumnName.c_str(),
+                                    idMedia));
+        }};
+
+    // Movies
+    std::string sql{
+        PrepareSQL("SELECT m.idMovie, m.c%02d, p.idPath, p.strPath, pp.idPath, pp.strPath "
+                   "FROM movie AS m "
+                   "JOIN files AS f ON m.idFile = f.idFile "
+                   "JOIN path AS p ON f.idPath = p.idPath "
+                   "LEFT JOIN path AS pp ON m.c%02d = pp.idPath "
+                   "WHERE p.strPath LIKE 'rar://%%'",
+                   LOCAL_VIDEODB_ID_BASEPATH, LOCAL_VIDEODB_ID_PARENTPATHID)};
+    m_pDS->query(sql);
+
+    while (!m_pDS->eof())
+    {
+      const int idMovie{m_pDS->fv(0).get_asInt()};
+      const std::string basePath{m_pDS->fv(1).get_asString()};
+      const int idPath{m_pDS->fv(2).get_asInt()};
+      const std::string path{m_pDS->fv(3).get_asString()};
+      const int idParentPath{m_pDS->fv(4).get_asInt()};
+      const std::string parentPath{m_pDS->fv(5).get_asString()};
+
+      std::string newPath{KODI::DATABASE::MIGRATION::SanitiseUrlEncodingV147(path)};
+      if (newPath != path && !idPathSet.contains(idPath))
+      {
+        // Update rar:// path (in path)
+        sql =
+            PrepareSQL("UPDATE path SET strPath = '%s' WHERE idPath = %i", newPath.c_str(), idPath);
+        m_pDS2->exec(sql);
+        idPathSet.insert(idPath);
+      }
+
+      if (URIUtils::IsDOSPath(basePath))
+      {
+        newPath = basePath;
+        StringUtils::Replace(newPath, '/', '\\');
+        if (newPath != basePath)
+        {
+          // Update DOS basepath (in movie)
+          sql = PrepareSQL("UPDATE movie SET c%02d = '%s' WHERE idMovie = %i",
+                           LOCAL_VIDEODB_ID_BASEPATH, newPath.c_str(), idMovie);
+          m_pDS2->exec(sql);
+        }
+      }
+
+      FixParentPath("movie", "idMovie", LOCAL_VIDEODB_ID_PARENTPATHID, idMovie, idParentPath,
+                    parentPath);
+
+      m_pDS->next();
+    }
+    m_pDS->close();
+
+    // Episodes
+    sql = PrepareSQL("SELECT e.idEpisode, e.c%02d, p.idPath, p.strPath, pp.idPath, pp.strPath "
+                     "FROM episode AS e "
+                     "JOIN files AS f ON e.idFile = f.idFile "
+                     "JOIN path AS p ON f.idPath = p.idPath "
+                     "LEFT JOIN path AS pp ON e.c%02d = pp.idPath "
+                     "WHERE e.c%02d LIKE 'rar://%%'",
+                     LOCAL_VIDEODB_ID_EPISODE_BASEPATH, LOCAL_VIDEODB_ID_EPISODE_PARENTPATHID,
+                     LOCAL_VIDEODB_ID_EPISODE_BASEPATH);
+    m_pDS->query(sql);
+
+    while (!m_pDS->eof())
+    {
+      const int idEpisode{m_pDS->fv(0).get_asInt()};
+      const std::string basePath{m_pDS->fv(1).get_asString()};
+      const int idPath{m_pDS->fv(2).get_asInt()};
+      const std::string path{m_pDS->fv(3).get_asString()};
+      const int idParentPath{m_pDS->fv(4).get_asInt()};
+      const std::string parentPath{m_pDS->fv(5).get_asString()};
+
+      std::string newPath{KODI::DATABASE::MIGRATION::SanitiseUrlEncodingV147(path)};
+      if (newPath != path && !idPathSet.contains(idPath))
+      {
+        // Update rar:// path (in path)
+        sql =
+            PrepareSQL("UPDATE path SET strPath = '%s' WHERE idPath = %i", newPath.c_str(), idPath);
+        m_pDS2->exec(sql);
+        idPathSet.insert(idPath);
+      }
+
+      newPath = KODI::DATABASE::MIGRATION::SanitiseUrlEncodingV147(basePath);
+      if (newPath != basePath)
+      {
+        // Update rar:// base path (in episode)
+        sql = PrepareSQL("UPDATE episode SET c%02d = '%s' WHERE idEpisode = %i",
+                         LOCAL_VIDEODB_ID_EPISODE_BASEPATH, newPath.c_str(), idEpisode);
+        m_pDS2->exec(sql);
+      }
+
+      FixParentPath("episode", "idEpisode", LOCAL_VIDEODB_ID_EPISODE_PARENTPATHID, idEpisode,
+                    idParentPath, parentPath);
+
+      m_pDS->next();
+    }
+    m_pDS->close();
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 146;
+  return 147;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Part 1/2 #28142 fixes things prospectively - ie. all rar archives added after applying that PR can be viewed correctly.
This part 2/2 applies database fixes to make the fixes retrospective - ie. all rar archives already added.

This corrects the necessary entries in the database, replacing '/' with '\' for DOS paths related to rar archives (this includes forward slashes encoded as %2f are changed to %5c backslashes and encoding is lower cased).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #28148 

As reported by @snyft in the forum - https://forum.kodi.tv/showthread.php?tid=384424&pid=3267730#pid3267730

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally
Confirmed fixed in thread - https://forum.kodi.tv/showthread.php?tid=384424&pid=3279139#pid3279139 by two users.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Before:
<img width="940" height="588" alt="image" src="https://github.com/user-attachments/assets/7169a3aa-12c2-48f4-a868-b3fc97ba8c96" />
<img width="940" height="588" alt="image" src="https://github.com/user-attachments/assets/e163f6b1-f51e-47b2-aef2-b8b45ba5f611" />

After:
<img width="940" height="588" alt="image" src="https://github.com/user-attachments/assets/22e47371-d1fa-4a83-a8cb-d80c7aab60b3" />

Database

Before
path table
<img width="940" height="429" alt="image" src="https://github.com/user-attachments/assets/443fdf85-2b74-4a1c-8966-f074f398ddc5" />
 
Note how the rar paths have %2f encoded – this is a ‘/’ forward slash and not a ‘\’ backslash – which kodi uses internally when generating DOS paths – this leads to unintentional path mismatches.
Note also the duplicate paths that result (one each with forward and backslash) – one added generated by Kodi and one from the path returned by the vfs rar addon.

<img width="940" height="462" alt="image" src="https://github.com/user-attachments/assets/5296bbe8-265f-450f-afd4-3d39197b291f" />
 
Also note that idPath 5, a rar:// path, has a hash – it should be on physical path.

movie table
<img width="609" height="171" alt="image" src="https://github.com/user-attachments/assets/ca06873a-8309-414b-978a-7c351f1409ed" />
 
Note the forward slashes

episode table
<img width="940" height="621" alt="image" src="https://github.com/user-attachments/assets/2e2f89a5-c55a-43bf-b081-f271b581d79d" />
 
Note the %2f encoded forward slashes
Note the parentpathid field (c19) points to the physical paths with the forward slashes.

After
path table
<img width="940" height="418" alt="image" src="https://github.com/user-attachments/assets/033bc966-ca2a-4d70-a55e-8c0dfdf1210d" />
 
Note the rar:// paths how have %5c
The physical path has been added at 23 (with a hash)

movie table
<img width="617" height="203" alt="image" src="https://github.com/user-attachments/assets/f5f8f039-b55f-4257-9c60-787026dc51fa" />
 
Note corrected backslashes

episode table
<img width="940" height="639" alt="image" src="https://github.com/user-attachments/assets/d7fb9553-d163-4f15-8216-7d238347fd22" />
 
Note the %5f encoded backslashes
Note the parentpathid field (c19) now points to the physical paths with the backslashes

Fresh scan with this PR
<img width="2303" height="962" alt="image" src="https://github.com/user-attachments/assets/45b3256a-6030-4528-9ba7-e25531e36e5d" />

Note the unneeded duplicate path entries with foward slashes are never created.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
