### PR TITLE
[Android] Fix future risk of crash on startup when getting User Agent

### DIFF
--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -54,8 +54,6 @@ using namespace winrt::Windows::System::Profile;
 #include "utils/XMLUtils.h"
 #if defined(TARGET_ANDROID)
 #include <androidjni/Build.h>
-#include <androidjni/Context.h>
-#include <androidjni/PackageManager.h>
 #endif
 
 /* Platform identification */
@@ -691,7 +689,9 @@ std::string CSysInfo::GetOsName(bool emptyIfUnknown /* = false*/)
 #elif defined(TARGET_DARWIN_OSX)
     osName = "macOS";
 #elif defined(TARGET_ANDROID)
-    if (CJNIContext::GetPackageManager().hasSystemFeature(CJNIPackageManager::FEATURE_LEANBACK))
+    char characteristics[PROP_VALUE_MAX] = {};
+    const int propLen = __system_property_get("ro.build.characteristics", characteristics);
+    if (propLen > 0 && std::string(characteristics, propLen).find("tv") != std::string::npos)
       osName = "Android TV";
     else
       osName = "Android";


### PR DESCRIPTION
## Description

This PR avoids PackageManager for getting the OS name.

CSysInfo::GetUserAgent() can run during libkodi.so static initialization. On Android, GetOsName() queried PackageManager through CJNIContext, which can be unavailable before the app context is ready and crash during startup.

Use Android system properties instead to preserve Android TV detection without requiring JNI context.

## Motivation and context

Fixed crash I immediately got on startup when testing my RetroPlayer build.

## How has this been tested?

Before:

```
05-31 11:39:06.780 F libc  : Fatal signal 11 (SIGSEGV), code 1
05-31 11:39:06.900 F DEBUG : signal 11 (SIGSEGV), code 1 (SEGV_MAPERR)
05-31 11:39:06.900 F DEBUG : fault addr 0x0
05-31 11:39:06.900 F DEBUG : Cause: null pointer dereference
05-31 11:39:07.723 F DEBUG : backtrace:
05-31 11:39:07.723 F DEBUG : #00 jni::call_method(...)
05-31 11:39:07.723 F DEBUG : #01 CJNIContext::GetPackageManager()
05-31 11:39:07.723 F DEBUG : #02 CSysInfo::GetOsName(bool)
05-31 11:39:07.724 F DEBUG : #03 CSysInfo::GetUserAgent()
05-31 11:39:07.724 F DEBUG : #04 libkodi.so
```

After:

Kodi successfully starts.

## What is the effect on users?

* Fixed Kodi starting on the Shield TV

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
