### PR TITLE
Settings Update Improvements

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -425,11 +425,19 @@
     </category>
     <category id="discs" label="14087" help="36193">
       <group id="1" label="446">
-        <setting id="dvds.autorun" type="boolean" label="14088" help="36194">
+        <setting id="dvds.autorun" type="integer" label="14088" help="36194">
           <requirement>HAS_OPTICAL_DRIVE</requirement>
           <level>0</level>
-          <default>false</default>
-          <control type="toggle" />
+          <default>0</default>
+		  <constraints>
+            <minimum>0</minimum>
+            <step>1</step>
+            <maximum>2</maximum>
+          </constraints>
+          <control type="spinner" format="string"/>
+		  <updates>
+			<update type="change"/>
+		  </updates>
         </setting>
         <setting id="dvds.playerregion" type="integer" label="21372" help="36195">
           <level>1</level>
@@ -989,6 +997,21 @@
           <level>1</level>
           <default>true</default>
           <control type="toggle" />
+        </setting>
+        <setting id="videolibrary.similarvideoaction" type="integer" label="40202" help="40203">
+          <level>1</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="13551">0</option> <!-- off -->
+              <option label="863">1</option> <!-- ask -->
+              <option label="16316">2</option> <!-- auto -->
+            </options>
+          </constraints>
+          <control type="list" format="string" />
+ 		  <updates>
+		    <update type="change">videolibrary.ignorevideoversions</update>
+		  </updates>
         </setting>
         <setting id="videolibrary.ignorevideoextras" type="boolean" label="40204" help="40205">
           <level>1</level>

--- a/xbmc/application/ApplicationSettingsHandling.cpp
+++ b/xbmc/application/ApplicationSettingsHandling.cpp
@@ -24,6 +24,8 @@
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"
+#include "utils/StringUtils.h"
+#include "utils/XBMCTinyXML.h"
 #include "windowing/WinSystem.h"
 
 #if defined(TARGET_DARWIN_OSX)
@@ -39,6 +41,50 @@ bool IsPlaying(const std::string& condition,
   auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
   return appPlayer ? appPlayer->IsPlaying() : false;
+}
+
+/*!
+ * \brief Set the value of an integer setting from a bool setting, using the provided mappings.
+ * \tparam T Class of the values the bool setting is mapped to
+ * \param setting The Integer setting
+ * \param oldSettingId Name of the bool setting
+ * \param oldSettingNode XML node of the bool setting
+ * \param mappingFalse Mapping of the bool false value
+ * \param mappingTrue Mapping of the bool true value
+ * \return 
+ */
+template<typename T>
+bool ConvertSettingBoolToInt(const std::shared_ptr<CSetting>& setting,
+                             std::string_view oldSettingId,
+                             const TiXmlElement* oldSettingNode,
+                             const T& mappingFalse,
+                             const T& mappingTrue)
+{
+  // Leave the new setting at default value if the old setting had the default value.
+  const char* isDefaultAttribute = oldSettingNode->Attribute(SETTING_XML_ELM_DEFAULT);
+  if (const bool isDefault =
+          isDefaultAttribute && StringUtils::EqualsNoCase(isDefaultAttribute, "true");
+      isDefault)
+    return false;
+
+  const auto intSetting{std::static_pointer_cast<CSettingInt>(setting)};
+  if (oldSettingNode->FirstChild())
+  {
+    const std::string oldValue = oldSettingNode->FirstChild()->ValueStr();
+    if (oldValue == "false")
+      return intSetting->SetValue(static_cast<int>(mappingFalse));
+    else if (oldValue == "true")
+      return intSetting->SetValue(static_cast<int>(mappingTrue));
+    else if (setting->GetId() != oldSettingId ||
+             (setting->GetId() == oldSettingId &&
+              (!oldValue.empty() && !isdigit(oldValue.front()))))
+    {
+      // change without rename: the setting may already be in int format and it's not an error
+      CLog::LogF(LOGWARNING, "Unexpected old value '{}' for setting {}, using default", oldValue,
+                 oldSettingId);
+    }
+  }
+  return false;
 }
 } // namespace
 

--- a/xbmc/application/ApplicationSettingsHandling.cpp
+++ b/xbmc/application/ApplicationSettingsHandling.cpp
@@ -178,8 +178,8 @@ void CApplicationSettingsHandling::OnSettingAction(const std::shared_ptr<const C
 }
 
 bool CApplicationSettingsHandling::OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
-                                                   const char* oldSettingId,
-                                                   const TiXmlNode* oldSettingNode)
+                                                   std::string_view oldSettingId,
+                                                   const TiXmlElement* oldSettingNode)
 {
   if (!setting)
     return false;

--- a/xbmc/application/ApplicationSettingsHandling.cpp
+++ b/xbmc/application/ApplicationSettingsHandling.cpp
@@ -32,6 +32,20 @@
 #include "utils/StringUtils.h"
 #endif
 
+enum class SimilarVideoScanAction : int
+{
+  ACTION_NONE = 0, //!< no action
+  ACTION_ASK = 1, //!< ask the user if a new version of an existing video should be created
+  ACTION_AUTO, //!< automatically create a new version
+};
+
+enum class AutoDVDAction : uint8_t
+{
+  NONE = 0,
+  PLAY,
+  BROWSE
+};
+
 namespace
 {
 bool IsPlaying(const std::string& condition,
@@ -120,7 +134,9 @@ void CApplicationSettingsHandling::RegisterSettings()
                                        CSettings::SETTING_SOURCE_VIDEOS,
                                        CSettings::SETTING_SOURCE_MUSIC,
                                        CSettings::SETTING_SOURCE_PICTURES,
-                                       CSettings::SETTING_VIDEOSCREEN_FAKEFULLSCREEN});
+                                       CSettings::SETTING_VIDEOSCREEN_FAKEFULLSCREEN,
+                                       CSettings::SETTING_VIDEOLIBRARY_SIMILARVIDEOACTION,
+                                       CSettings::SETTING_DVDS_AUTORUN});
 
   auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
@@ -245,6 +261,21 @@ bool CApplicationSettingsHandling::OnSettingUpdate(const std::shared_ptr<CSettin
     }
   }
 #endif
+
+  if (setting->GetId() == CSettings::SETTING_VIDEOLIBRARY_SIMILARVIDEOACTION &&
+      oldSettingId == "videolibrary.ignorevideoversions" && oldSettingNode)
+  {
+    return ConvertSettingBoolToInt<SimilarVideoScanAction>(setting, oldSettingId, oldSettingNode,
+                                                           SimilarVideoScanAction::ACTION_ASK,
+                                                           SimilarVideoScanAction::ACTION_NONE);
+  }
+
+  if (setting->GetId() == CSettings::SETTING_DVDS_AUTORUN && oldSettingId == "dvds.autorun" &&
+      oldSettingNode)
+  {
+    return ConvertSettingBoolToInt<AutoDVDAction>(setting, oldSettingId, oldSettingNode,
+                                                  AutoDVDAction::NONE, AutoDVDAction::PLAY);
+  }
 
   return false;
 }

--- a/xbmc/application/ApplicationSettingsHandling.h
+++ b/xbmc/application/ApplicationSettingsHandling.h
@@ -31,6 +31,6 @@ protected:
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
   void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;
   bool OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
-                       const char* oldSettingId,
-                       const TiXmlNode* oldSettingNode) override;
+                       std::string_view oldSettingId,
+                       const TiXmlElement* oldSettingNode) override;
 };

--- a/xbmc/guilib/GUIAudioManager.cpp
+++ b/xbmc/guilib/GUIAudioManager.cpp
@@ -57,8 +57,8 @@ void CGUIAudioManager::OnSettingChanged(const std::shared_ptr<const CSetting>& s
 }
 
 bool CGUIAudioManager::OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
-                                       const char* oldSettingId,
-                                       const TiXmlNode* oldSettingNode)
+                                       std::string_view oldSettingId,
+                                       const TiXmlElement* oldSettingNode)
 {
   if (setting == NULL)
     return false;

--- a/xbmc/guilib/GUIAudioManager.h
+++ b/xbmc/guilib/GUIAudioManager.h
@@ -45,8 +45,8 @@ public:
 
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
   bool OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
-                       const char* oldSettingId,
-                       const TiXmlNode* oldSettingNode) override;
+                       std::string_view oldSettingId,
+                       const TiXmlElement* oldSettingNode) override;
 
   void Initialize();
   void DeInitialize();

--- a/xbmc/network/NetworkServices.cpp
+++ b/xbmc/network/NetworkServices.cpp
@@ -508,8 +508,8 @@ void CNetworkServices::OnSettingChanged(const std::shared_ptr<const CSetting>& s
 }
 
 bool CNetworkServices::OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
-                                       const char* oldSettingId,
-                                       const TiXmlNode* oldSettingNode)
+                                       std::string_view oldSettingId,
+                                       const TiXmlElement* oldSettingNode)
 {
   if (setting == NULL)
     return false;

--- a/xbmc/network/NetworkServices.h
+++ b/xbmc/network/NetworkServices.h
@@ -36,8 +36,8 @@ public:
   bool OnSettingChanging(const std::shared_ptr<const CSetting>& setting) override;
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
   bool OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
-                       const char* oldSettingId,
-                       const TiXmlNode* oldSettingNode) override;
+                       std::string_view oldSettingId,
+                       const TiXmlElement* oldSettingNode) override;
 
   void Start();
   void Stop(bool bWait);

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -358,8 +358,8 @@ bool CDisplaySettings::OnSettingChanging(const std::shared_ptr<const CSetting>& 
 }
 
 bool CDisplaySettings::OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
-                                       const char* oldSettingId,
-                                       const TiXmlNode* oldSettingNode)
+                                       std::string_view oldSettingId,
+                                       const TiXmlElement* oldSettingNode)
 {
   if (!setting)
     return false;

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -36,8 +36,8 @@ public:
   void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;
   bool OnSettingChanging(const std::shared_ptr<const CSetting>& setting) override;
   bool OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
-                       const char* oldSettingId,
-                       const TiXmlNode* oldSettingNode) override;
+                       std::string_view oldSettingId,
+                       const TiXmlElement* oldSettingNode) override;
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
 
   /*!

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -96,6 +96,7 @@ public:
       "videolibrary.musicvideoartwhitelist";
   static constexpr auto SETTING_VIDEOLIBRARY_SHOWPERFORMERS =
       "videolibrary.musicvideosallperformers";
+  static constexpr auto SETTING_VIDEOLIBRARY_SIMILARVIDEOACTION = "videolibrary.similarvideoaction";
   static constexpr auto SETTING_VIDEOLIBRARY_IGNOREVIDEOVERSIONS =
       "videolibrary.ignorevideoversions";
   static constexpr auto SETTING_VIDEOLIBRARY_IGNOREVIDEOEXTRAS = "videolibrary.ignorevideoextras";

--- a/xbmc/settings/lib/ISettingCallback.h
+++ b/xbmc/settings/lib/ISettingCallback.h
@@ -9,9 +9,10 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
 
 class CSetting;
-class TiXmlNode;
+class TiXmlElement;
 
 class ISettingCallback
 {
@@ -66,8 +67,8 @@ public:
    \return True if the setting has been successfully updated otherwise false
    */
   virtual bool OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
-                               const char* oldSettingId,
-                               const TiXmlNode* oldSettingNode)
+                               std::string_view oldSettingId,
+                               const TiXmlElement* oldSettingNode)
   {
     return false;
   }

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -293,8 +293,8 @@ bool CSetting::DeserializeIdentification(const TiXmlNode* node,
 }
 
 bool CSetting::OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
-                               const char* oldSettingId,
-                               const TiXmlNode* oldSettingNode)
+                               std::string_view oldSettingId,
+                               const TiXmlElement* oldSettingNode)
 {
   if (!m_callback)
     return false;

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -115,8 +115,8 @@ protected:
   bool OnSettingChanging(const std::shared_ptr<const CSetting>& setting) override;
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
   bool OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
-                       const char* oldSettingId,
-                       const TiXmlNode* oldSettingNode) override;
+                       std::string_view oldSettingId,
+                       const TiXmlElement* oldSettingNode) override;
   void OnSettingPropertyChanged(const std::shared_ptr<const CSetting>& setting,
                                 const char* propertyName) override;
 

--- a/xbmc/settings/lib/SettingUpdate.cpp
+++ b/xbmc/settings/lib/SettingUpdate.cpp
@@ -38,15 +38,13 @@ bool CSettingUpdate::Deserialize(const TiXmlNode *node)
     return false;
   }
 
-  if (m_type == SettingUpdateType::Rename)
-  {
-    if (node->FirstChild() == nullptr || node->FirstChild()->Type() != TiXmlNode::TINYXML_TEXT)
-    {
-      s_logger->warn("missing or invalid setting id for rename update definition");
-      return false;
-    }
-
+  if (node->FirstChild() != nullptr && node->FirstChild()->Type() == TiXmlNode::TINYXML_TEXT)
     m_value = node->FirstChild()->ValueStr();
+
+  if (m_type == SettingUpdateType::Rename && m_value.empty())
+  {
+    s_logger->warn("missing or invalid setting id for rename update definition");
+    return false;
   }
 
   return true;

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -960,8 +960,8 @@ void CSettingsManager::OnSettingAction(const std::shared_ptr<const CSetting>& se
 }
 
 bool CSettingsManager::OnSettingUpdate(const SettingPtr& setting,
-                                       const char* oldSettingId,
-                                       const TiXmlNode* oldSettingNode)
+                                       std::string_view oldSettingId,
+                                       const TiXmlElement* oldSettingNode)
 {
   std::shared_lock lock(m_settingsCritical);
   if (!setting)
@@ -1157,14 +1157,14 @@ bool CSettingsManager::UpdateSetting(const TiXmlNode* node,
     return false;
 
   bool updated = false;
-  const char* oldSetting = nullptr;
+  std::string oldSetting;
   const TiXmlElement* oldSettingElement = nullptr;
   if (update.GetType() == SettingUpdateType::Rename)
   {
     if (update.GetValue().empty())
       return false;
 
-    oldSetting = update.GetValue().c_str();
+    oldSetting = update.GetValue();
     oldSettingElement = LocateSetting(node, oldSetting);
 
     if (!oldSettingElement)

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -1178,6 +1178,15 @@ bool CSettingsManager::UpdateSetting(const TiXmlNode* node,
       m_logger->warn("unable to update \"{}\" through automatically renaming from \"{}\"",
                      setting->GetId(), oldSetting);
   }
+  else if (update.GetType() == SettingUpdateType::Change)
+  {
+    oldSetting = update.GetValue().empty() ? setting->GetId() : update.GetValue();
+
+    oldSettingElement = LocateSetting(node, oldSetting);
+
+    if (!oldSettingElement)
+      return false;
+  }
 
   updated |= OnSettingUpdate(setting, oldSetting, oldSettingElement);
   return updated;

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -1120,20 +1120,20 @@ bool CSettingsManager::LoadSetting(const TiXmlNode* node, const SettingPtr& sett
     settingId = setting->GetReferencedId();
 
   const TiXmlElement* settingElement = LocateSetting(node, settingId);
+  bool isDefault = true;
 
-  if (!settingElement)
-    return false;
-
-  // check if the default="true" attribute is set for the value
-  const char* isDefaultAttribute = settingElement->Attribute(SETTING_XML_ELM_DEFAULT);
-  const bool isDefault =
-      isDefaultAttribute && StringUtils::EqualsNoCase(isDefaultAttribute, "true");
-
-  if (!setting->FromString(settingElement->FirstChild() ? settingElement->FirstChild()->ValueStr()
-                                                        : StringUtils::Empty))
+  if (settingElement)
   {
-    m_logger->warn("unable to read value of setting \"{}\"", settingId);
-    return false;
+    // check if the default="true" attribute is set for the value
+    const char* isDefaultAttribute = settingElement->Attribute(SETTING_XML_ELM_DEFAULT);
+    isDefault = isDefaultAttribute && StringUtils::EqualsNoCase(isDefaultAttribute, "true");
+
+    if (!setting->FromString(settingElement->FirstChild() ? settingElement->FirstChild()->ValueStr()
+                                                          : StringUtils::Empty))
+    {
+      m_logger->warn("unable to read value of setting \"{}\"", settingId);
+      return false;
+    }
   }
 
   // check if we need to perform any update logic for the setting

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -20,20 +20,25 @@
 #include <map>
 #include <mutex>
 #include <shared_mutex>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 
 const uint32_t CSettingsManager::Version = 2;
 const uint32_t CSettingsManager::MinimumSupportedVersion = 0;
 
-bool ParseSettingIdentifier(const std::string& settingId, std::string& categoryTag, std::string& settingTag)
+namespace
 {
-  static const std::string Separator = ".";
+bool ParseSettingIdentifier(std::string_view settingId,
+                            std::string& categoryTag,
+                            std::string& settingTag)
+{
+  constexpr std::string_view separator = ".";
 
   if (settingId.empty())
     return false;
 
-  std::vector<std::string> parts = StringUtils::Split(settingId, Separator);
+  std::vector<std::string> parts = StringUtils::Split(settingId, separator);
   if (parts.empty() || parts.at(0).empty())
     return false;
 
@@ -48,10 +53,48 @@ bool ParseSettingIdentifier(const std::string& settingId, std::string& categoryT
   parts.erase(parts.begin());
 
   // put together the setting tag
-  settingTag = StringUtils::Join(parts, Separator);
+  settingTag = StringUtils::Join(parts, separator);
 
   return true;
 }
+
+const TiXmlElement* LocateSetting(const TiXmlNode* node, std::string_view settingId)
+{
+  const TiXmlElement* settingElement = nullptr;
+
+  // Attempt v2 first, the switch from v1 happened in 2013
+  if (!settingElement)
+  {
+    // check if the setting is stored using its full setting identifier (v2+)
+    settingElement = node->FirstChildElement(SETTING_XML_ELM_SETTING);
+    while (settingElement)
+    {
+      const char* id = settingElement->Attribute(SETTING_XML_ATTR_ID);
+      if (id && settingId.compare(id) == 0)
+        break;
+
+      settingElement = settingElement->NextSiblingElement(SETTING_XML_ELM_SETTING);
+    }
+  }
+
+  if (!settingElement)
+  {
+    // try to split the setting identifier into category and subsetting identifier (v1-)
+    std::string categoryTag;
+    std::string settingTag;
+    if (ParseSettingIdentifier(settingId, categoryTag, settingTag))
+    {
+      const TiXmlNode* categoryNode = node;
+      if (!categoryTag.empty())
+        categoryNode = node->FirstChild(categoryTag);
+
+      if (categoryNode)
+        settingElement = categoryNode->FirstChildElement(settingTag);
+    }
+  }
+  return settingElement;
+}
+} // namespace
 
 CSettingsManager::CSettingsManager()
   : m_logger(CServiceBroker::GetLogging().GetLogger("CSettingsManager"))
@@ -1076,33 +1119,7 @@ bool CSettingsManager::LoadSetting(const TiXmlNode* node, const SettingPtr& sett
   if (setting->IsReference())
     settingId = setting->GetReferencedId();
 
-  const TiXmlElement* settingElement = nullptr;
-  // try to split the setting identifier into category and subsetting identifier (v1-)
-  std::string categoryTag;
-  std::string settingTag;
-  if (ParseSettingIdentifier(settingId, categoryTag, settingTag))
-  {
-    const TiXmlNode* categoryNode = node;
-    if (!categoryTag.empty())
-      categoryNode = node->FirstChild(categoryTag);
-
-    if (categoryNode)
-      settingElement = categoryNode->FirstChildElement(settingTag);
-  }
-
-  if (!settingElement)
-  {
-    // check if the setting is stored using its full setting identifier (v2+)
-    settingElement = node->FirstChildElement(SETTING_XML_ELM_SETTING);
-    while (settingElement)
-    {
-      const char* id = settingElement->Attribute(SETTING_XML_ATTR_ID);
-      if (id && settingId.compare(id) == 0)
-        break;
-
-      settingElement = settingElement->NextSiblingElement(SETTING_XML_ELM_SETTING);
-    }
-  }
+  const TiXmlElement* settingElement = LocateSetting(node, settingId);
 
   if (!settingElement)
     return false;

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -1157,40 +1157,29 @@ bool CSettingsManager::UpdateSetting(const TiXmlNode* node,
     return false;
 
   bool updated = false;
-  const char *oldSetting = nullptr;
-  const TiXmlNode *oldSettingNode = nullptr;
+  const char* oldSetting = nullptr;
+  const TiXmlElement* oldSettingElement = nullptr;
   if (update.GetType() == SettingUpdateType::Rename)
   {
     if (update.GetValue().empty())
       return false;
 
     oldSetting = update.GetValue().c_str();
-    std::string categoryTag;
-    std::string settingTag;
-    if (!ParseSettingIdentifier(oldSetting, categoryTag, settingTag))
+    oldSettingElement = LocateSetting(node, oldSetting);
+
+    if (!oldSettingElement)
       return false;
 
-    const TiXmlNode* categoryNode = node;
-    if (!categoryTag.empty())
-    {
-      categoryNode = node->FirstChild(categoryTag);
-      if (!categoryNode)
-        return false;
-    }
-
-    oldSettingNode = categoryNode->FirstChild(settingTag);
-    if (!oldSettingNode)
-      return false;
-
-    if (setting->FromString(oldSettingNode->FirstChild() ? oldSettingNode->FirstChild()->ValueStr()
-                                                         : StringUtils::Empty))
+    if (setting->FromString(oldSettingElement->FirstChild()
+                                ? oldSettingElement->FirstChild()->ValueStr()
+                                : StringUtils::Empty))
       updated = true;
     else
       m_logger->warn("unable to update \"{}\" through automatically renaming from \"{}\"",
                      setting->GetId(), oldSetting);
   }
 
-  updated |= OnSettingUpdate(setting, oldSetting, oldSettingNode);
+  updated |= OnSettingUpdate(setting, oldSetting, oldSettingElement);
   return updated;
 }
 

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -1119,8 +1119,10 @@ bool CSettingsManager::LoadSetting(const TiXmlNode* node, const SettingPtr& sett
   if (setting->IsReference())
     settingId = setting->GetReferencedId();
 
+  const std::set<CSettingUpdate>& updates = setting->GetUpdates();
   const TiXmlElement* settingElement = LocateSetting(node, settingId);
   bool isDefault = true;
+  bool failedRead = false;
 
   if (settingElement)
   {
@@ -1128,16 +1130,14 @@ bool CSettingsManager::LoadSetting(const TiXmlNode* node, const SettingPtr& sett
     const char* isDefaultAttribute = settingElement->Attribute(SETTING_XML_ELM_DEFAULT);
     isDefault = isDefaultAttribute && StringUtils::EqualsNoCase(isDefaultAttribute, "true");
 
-    if (!setting->FromString(settingElement->FirstChild() ? settingElement->FirstChild()->ValueStr()
-                                                          : StringUtils::Empty))
-    {
+    failedRead =
+        !setting->FromString(settingElement->FirstChild() ? settingElement->FirstChild()->ValueStr()
+                                                          : StringUtils::Empty);
+    if (failedRead)
       m_logger->warn("unable to read value of setting \"{}\"", settingId);
-      return false;
-    }
   }
 
   // check if we need to perform any update logic for the setting
-  const std::set<CSettingUpdate>& updates = setting->GetUpdates();
   for (const auto& update : updates)
     updated |= UpdateSetting(node, setting, update);
 
@@ -1146,7 +1146,7 @@ bool CSettingsManager::LoadSetting(const TiXmlNode* node, const SettingPtr& sett
   if (!updated && isDefault)
     setting->Reset();
 
-  return true;
+  return !failedRead || updated;
 }
 
 bool CSettingsManager::UpdateSetting(const TiXmlNode* node,

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -492,8 +492,8 @@ private:
   void OnSettingChanged(const std::shared_ptr<const CSetting>& setting) override;
   void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;
   bool OnSettingUpdate(const std::shared_ptr<CSetting>& setting,
-                       const char* oldSettingId,
-                       const TiXmlNode* oldSettingNode) override;
+                       std::string_view oldSettingId,
+                       const TiXmlElement* oldSettingNode) override;
   void OnSettingPropertyChanged(const std::shared_ptr<const CSetting>& setting,
                                 const char* propertyName) override;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

As mentioned in PR #28191 and #28349, which would benefit from the ability to update existing settings (change the data type from boolean to integer/enum class values, with/without setting name change)

The last commit illustrates how the improvements could be used in the mentioned PRs, and is not to be merged, since this PR should come first.

However after working on it, fixing up / extending the current code of CSettingsManager doesn't seem to be the right solution as it doesn't address some situation and is not particularly efficient.

- Changing the data type without renaming the setting causes an initial data read error that's difficult to avoid (an int settings fails to read "false" or "true") and makes the return value of LoadSetting not always truthful. Later the "update handler" in ApplicationSettingsHandling for example always needs to figure out if the conversion already happened and whether the settings file contains a bool or int. It's easy for bool to int, but would be a problem for bool to string for example, since "false" and "true" are valid strings and booleans.
- Attempted to generalize the solution a bit with a templated function to convert bool to int. It could be moved to a more central file, but invoking from the update handlers doesn't feel like the right place
- No sane way to do multiple changes or renames on the same setting - may not be possible to know which "version" of the setting a guisettings.xml value belongs to
- Cannot help with changes like PR #21881 which aims to shift the db integer value of the replaygain settings. Update handlers do not have state to determine if the shift has been applied already or not. The data type doesn't change and doesn't give a clue.
- All update handlers are called every time Kodi starts, whether old settings are present or not
- Multiple <update> tags are allowed for a setting but I don't understand how chaining updates could actually work and produce useful results.
- No way to reverse the conversions and handle downgrades - user settings are lost and reset to default (best case)

It seems to me that something like database migrations would take care of all issues.
A "data version" number would be stored in the settings files (ex. guisettings.xml). When loading the settings on boot, the data version of the file would be compared with the current data version of the program and launch migration functions as needed. The migration functions transform the in-memory XML elements from the older format to the current. Finally the settings file "data version" would be set to the current version and it would be saved to disk.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It's not really possible to change a setting's type or name to extend or finetune it. As a result, new settings are created and the old ones removed, which resets the values to defaults, losing users choices.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
