### PR TITLE
GLES: fix limited-range wash-out on premultiplied-alpha (PMA) bitmap

### DIFF
--- a/system/shaders/GL/1.5/gl_shader_frag_texture_lim.glsl
+++ b/system/shaders/GL/1.5/gl_shader_frag_texture_lim.glsl
@@ -14,6 +14,18 @@ in vec2 m_cord0;
 out vec4 fragColor;
 
 // SM_TEXTURE shader
+//! @todo This shader assumes the texture is limited-range RGB, but the only
+//! consumer (COverlayTextureGL with paletted overlays: PGS/VOBSUB/DVD SPU/
+//! paletted BD-PG) uploads full-range RGB (FFmpeg's PGS decoder converts via
+//! YUV_TO_RGB2_CCIR with the 255/219 expansion factor, producing full-range
+//! output). The math here therefore renders with incorrect brightness in both
+//! output modes. The GLES counterpart (gles_shader_texture_noblend.frag) uses
+//! full-range-in/limited-range-out math which matches the texture data; it
+//! also accepts an m_pma uniform that scales the limited-range offset by
+//! alpha for PMA-stored overlays. The fix here is the equivalent: replace the
+//! math below with the GLES-style "rgb *= 219/255; rgb += mix(1.0, a, m_pma)
+//! * 16/255" inside an "#if defined(KODI_LIMITED_RANGE)" block, and add the
+//! m_pma uniform plumbing on the GL side. See Kodi issue #22383.
 void main()
 {
   fragColor = texture(m_samp0, m_cord0) * m_unicol;

--- a/system/shaders/GLES/2.0/gles_shader_texture_noblend.frag
+++ b/system/shaders/GLES/2.0/gles_shader_texture_noblend.frag
@@ -24,6 +24,7 @@ precision mediump float;
 uniform sampler2D m_samp0;
 varying vec4 m_cord0;
 uniform float m_sdrPeak;
+uniform float m_pma;
 
 void main ()
 {
@@ -33,7 +34,7 @@ void main ()
 
 #if defined(KODI_LIMITED_RANGE)
   rgb.rgb *= (235.0 - 16.0) / 255.0;
-  rgb.rgb += 16.0 / 255.0;
+  rgb.rgb += mix(1.0, rgb.a, m_pma) * 16.0 / 255.0;
 #endif
 
 #if defined(KODI_TRANSFER_PQ)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
@@ -450,6 +450,15 @@ void COverlayTextureGLES::Render(SRenderState& state)
   GLint tex0Loc = renderSystem->GUIShaderGetCoord0();
   GLint depthLoc = renderSystem->GUIShaderGetDepth();
 
+  // Tell the shader this texture is premultiplied so its limited-range
+  // conversion scales the +16/255 offset by alpha; without this, transparent
+  // PMA texels (alpha=0, rgb=0) would emit (0.063, 0.063, 0.063, 0) which the
+  // PMA blend would write straight into dst, leaking a constant brightening
+  // across the bitmap quad. CGLESShader::OnEnabled resets this to 0.0 every
+  // time a shader is bound, so non-PMA consumers stay on straight-alpha math.
+  if (m_pma)
+    glUniform1f(renderSystem->GUIShaderGetPma(), 1.0f);
+
   GLfloat ver[4][2];
   GLfloat tex[4][2];
   GLubyte idx[4] = {0, 1, 3, 2}; //determines order of triangle strip

--- a/xbmc/rendering/gles/GLESShader.cpp
+++ b/xbmc/rendering/gles/GLESShader.cpp
@@ -59,6 +59,7 @@ void CGLESShader::OnCompiledAndLinked()
   m_hShaderClip = glGetUniformLocation(ProgramHandle(), "m_shaderClip");
   m_hCoordStep = glGetUniformLocation(ProgramHandle(), "m_cordStep");
   m_hDepth = glGetUniformLocation(ProgramHandle(), "m_depth");
+  m_hPma = glGetUniformLocation(ProgramHandle(), "m_pma");
 
   // Vertex attributes
   m_hPos    = glGetAttribLocation(ProgramHandle(),  "m_attrpos");
@@ -172,6 +173,11 @@ bool CGLESShader::OnEnabled()
 
   glUniform1f(m_hBrightness, 0.0f);
   glUniform1f(m_hContrast, 1.0f);
+
+  // Default to straight-alpha math for all consumers; the one site that draws
+  // premultiplied-alpha textures (COverlayTextureGLES) overrides this to 1.0
+  // before drawing so the limited-range conversion offset scales by alpha.
+  glUniform1f(m_hPma, 0.0f);
 
   const float sdrPeak = CServiceBroker::GetWinSystem()->GetGuiSdrPeakLuminance();
   glUniform1f(m_sdrPeak, sdrPeak);

--- a/xbmc/rendering/gles/GLESShader.h
+++ b/xbmc/rendering/gles/GLESShader.h
@@ -26,6 +26,7 @@ public:
   GLint GetCord0Loc() { return m_hCord0; }
   GLint GetCord1Loc() { return m_hCord1; }
   GLint GetDepthLoc() { return m_hDepth; }
+  GLint GetPmaLoc() { return m_hPma; }
   GLint GetUniColLoc() { return m_hUniCol; }
   GLint GetCoord0MatrixLoc() { return m_hCoord0Matrix; }
   GLint GetFieldLoc() { return m_hField; }
@@ -61,6 +62,7 @@ protected:
   GLint m_hContrast = 0;
   GLint m_hBrightness = 0;
   GLint m_hDepth = 0;
+  GLint m_hPma = 0;
 
   const GLfloat *m_proj;
   const GLfloat *m_model;

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -752,6 +752,14 @@ GLint CRenderSystemGLES::GUIShaderGetDepth()
   return -1;
 }
 
+GLint CRenderSystemGLES::GUIShaderGetPma()
+{
+  if (m_pShader[m_method])
+    return m_pShader[m_method]->GetPmaLoc();
+
+  return -1;
+}
+
 GLint CRenderSystemGLES::GUIShaderGetUniCol()
 {
   if (m_pShader[m_method])

--- a/xbmc/rendering/gles/RenderSystemGLES.h
+++ b/xbmc/rendering/gles/RenderSystemGLES.h
@@ -143,6 +143,7 @@ public:
   GLint GUIShaderGetClip();
   GLint GUIShaderGetCoordStep();
   GLint GUIShaderGetDepth();
+  GLint GUIShaderGetPma();
 
 protected:
   virtual void SetVSyncImpl(bool enable) = 0;


### PR DESCRIPTION
## Description

Fix limited-range wash-out on premultiplied-alpha bitmap overlays in GLES.

Fixes #22383 

Reported again by @smp79 

Also a problem on GL but inverted (black clipping), adding @todo there.


## Motivation and context
`gles_shader_texture_noblend.frag`'s limited-range conversion adds `16/255` unconditionally. With `COverlayTextureGLES`'s PMA blend (`GL_ONE`), that offset lands in the framebuffer for transparent texels and brightens the underlying picture across the bitmap quad. Manifests as screen-wide wash-out for PGS / VOBSUB / DVD SPU / paletted BD-PG with limited-range output.


## How has this been tested?
Verified on GBM/GLES with a PGS-subtitle MKV at `videoscreen.limitedrange=true`. Wash-out gone. Default uniform value of `0.0` keeps every non-PMA consumer (GUI textures, fonts, libass overlays) unchanged.

## What is the effect on users?
Subtitles on GBM/GLES with limited-range output no longer brighten the underlying picture. In the worst case this led to flashing of the entire video as subtitles came on/off.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
