### PR TITLE
[Video][Bluray] DVD/Bluray state (play count etc..) not saved on subsequent plays.

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1003,6 +1003,8 @@ bool CVideoPlayer::OpenDemuxStream()
     if (item.HasVideoInfoTag())
       m_pInputStream->SaveCurrentState(item.GetVideoInfoTag()->m_streamDetails);
   }
+  else
+    m_pInputStream->SaveCurrentState({});
 
   return true;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Ensure SaveCurrentState is called with empty stream details at the beginning of play in VideoPlayer.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Somewhere along the line I've introduced a logic error. SaveCurrentState() - which saves the current playlist, position etc.. along with streamdetails is gated by m_updateStreamDetails in VideoPlayer. This means that when play has finished the playlist vector is empty, and NOT_PLAYED is returned by CDVDInputStream::UpdateItemFromPlaylistDetails() - which is shared for DVDs and Blurays - and the state is then cleared in OnExit()

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
