### PR TITLE
[python][profiles][dbwrappers] Fix hard crash when switching to a newly created profile

### DIFF
--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -546,6 +546,11 @@ DbErrors::DbErrors(const char* msg, ...)
   va_list vl;
   va_start(vl, msg);
   char buf[DB_BUFF_MAX] = "";
+
+  // Prevent a NULL format string from crashing vsnprintf
+  if (!msg)
+    msg = "unknown database error (NULL format)";
+
 #ifndef TARGET_POSIX
   _vsnprintf(buf, DB_BUFF_MAX - 1, msg, vl);
 #else

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -409,6 +409,7 @@ void SqliteDatabase::disconnect()
     return;
   sqlite3_close(conn);
   active = false;
+  conn = nullptr; // Reset handle to avoid stale pointer usage after database is closed
 }
 
 int SqliteDatabase::postconnect()
@@ -897,7 +898,7 @@ int SqliteDataset::exec(const std::string& sql)
 
   const auto start = std::chrono::steady_clock::now();
 
-  char* errmsg;
+  char* errmsg = nullptr; // Must be initialized to nullptr; sqlite3_exec may not always set it
   const int res =
       db->setErr(sqlite3_exec(handle(), qry.c_str(), &callback, &exec_res, &errmsg), qry.c_str());
 
@@ -914,13 +915,20 @@ int SqliteDataset::exec(const std::string& sql)
   {
     if (errmsg)
     {
-      DbErrors err("%s (%s)", db->getErrorMsg(), errmsg);
+      // Guard against possible NULL strings from getErrorMsg
+      const char* dbErr = db->getErrorMsg();
+      if (!dbErr)
+        dbErr = "unknown database error";
+      DbErrors err("%s (%s)", dbErr, errmsg);
       sqlite3_free(errmsg);
       throw err;
     }
     else
     {
-      throw DbErrors("%s", db->getErrorMsg());
+      const char* dbErr = db->getErrorMsg();
+      if (!dbErr)
+        dbErr = "unknown database error";
+      throw DbErrors("%s", dbErr);
     }
   }
 }

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -56,10 +56,6 @@ extern "C" FILE* fopen_utf8(const char* _Filename, const char* _Mode);
 #define fopen_utf8 fopen
 #endif
 
-#define GC_SCRIPT \
-  "import gc\n" \
-  "gc.collect(2)\n"
-
 #define PY_PATH_SEP DELIM
 
 // Time before ill-behaved scripts are terminated
@@ -88,7 +84,8 @@ static const std::string getListOfAddonClassesAsString(
 }
 
 CPythonInvoker::CPythonInvoker(ILanguageInvocationHandler* invocationHandler)
-  : ILanguageInvoker(invocationHandler), m_threadState(NULL)
+  : ILanguageInvoker(invocationHandler),
+    m_threadState(NULL)
 {
 }
 
@@ -347,7 +344,6 @@ bool CPythonInvoker::execute(const std::string& script, std::vector<std::wstring
     }
   }
 
-  m_systemExitThrown = false;
   InvokerState stateToSet;
   if (!failed && !PyErr_Occurred())
   {
@@ -357,7 +353,6 @@ bool CPythonInvoker::execute(const std::string& script, std::vector<std::wstring
   }
   else if (PyErr_ExceptionMatches(PyExc_SystemExit))
   {
-    m_systemExitThrown = true;
     CLog::Log(LOGDEBUG, "CPythonInvoker({}, {}): script aborted", GetId(), m_sourceFile);
     stateToSet = InvokerStateFailed;
     onAbort();
@@ -546,7 +541,6 @@ bool CPythonInvoker::stop(bool abort)
         PyEval_RestoreThread(ts);
       }
 
-
       PyThreadState* state = PyInterpreterState_ThreadHead(m_threadState->interp);
       while (state)
       {
@@ -583,34 +577,37 @@ void CPythonInvoker::onExecutionDone()
 
     onDeinitialization();
 
-    // run the gc before finishing
-    //
-    // if the script exited by throwing a SystemExit exception then going back
-    // into the interpreter causes this python bug to get hit:
-    //    http://bugs.python.org/issue10582
-    // and that causes major failures. So we are not going to go back in
-    // to run the GC if that's the case.
-    if (!m_stop && m_languageHook->HasRegisteredAddonClasses() && !m_systemExitThrown &&
-        PyRun_SimpleString(GC_SCRIPT) == -1)
-      CLog::Log(LOGERROR,
-                "CPythonInvoker({}, {}): failed to run the gc to clean up after running prior to "
-                "shutting down the Interpreter",
-                GetId(), m_sourceFile);
+    // Force a full garbage collection to clean up unreferenced Python objects
+    // before we start tearing down the interpreter. This prevents objects with
+    // dangling C++ backing pointers from being destroyed during Py_EndInterpreter.
+    PyGC_Collect();
 
-    // PyErr_Clear() is required to prevent the debug python library to trigger an assert() at the Py_EndInterpreter() level
-    PyErr_Clear();
+    // Unregister all Addon classes now, while the interpreter is still alive.
+    // This ensures C++ destructors can safely release Python references.
+    m_languageHook->UnregisterMe();
 
-    Py_EndInterpreter(m_threadState);
-
-    // If we still have objects left around, produce an error message detailing what's been left behind
+    // If any classes still remain, log them - but we'll still try to clear
+    // the interpreter forcefully.
     if (m_languageHook->HasRegisteredAddonClasses())
       CLog::Log(LOGWARNING,
                 "CPythonInvoker({}, {}): the python script \"{}\" has left several "
                 "classes in memory that we couldn't clean up. The classes include: {}",
                 GetId(), m_sourceFile, m_sourceFile, getListOfAddonClassesAsString(m_languageHook));
 
-    // unregister the language hook
-    m_languageHook->UnregisterMe();
+    // Force-clear all module dictionaries in this sub-interpreter.
+    // This breaks circular references and allows the C++ bound objects
+    // to be destroyed cleanly, preventing the segfault inside _PyModule_ClearDict.
+    PyObject* modules = PyImport_GetModuleDict();
+    if (modules)
+      PyDict_Clear(modules);
+
+    // Run GC again to clean up any garbage created by the dict clearing.
+    PyGC_Collect();
+
+    // Clear any remaining Python error state to avoid asserts in debug builds.
+    PyErr_Clear();
+
+    Py_EndInterpreter(m_threadState);
 
     PyThreadState_Swap(m_mainThreadState);
     PyThreadState_Clear(m_mainThreadState);

--- a/xbmc/interfaces/python/PythonInvoker.h
+++ b/xbmc/interfaces/python/PythonInvoker.h
@@ -66,7 +66,6 @@ private:
   CEvent m_stoppedEvent;
 
   XBMCAddon::AddonClass::Ref<XBMCAddon::Python::PythonLanguageHook> m_languageHook;
-  bool m_systemExitThrown = false;
 
   static CCriticalSection s_critical;
 

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -16,6 +16,7 @@
 #include "PasswordManager.h"
 #include "PlayListPlayer.h" //! @todo Remove me
 #include "ServiceBroker.h"
+#include "TextureCache.h"
 #include "Util.h"
 #include "addons/AddonManager.h" //! @todo Remove me
 #include "addons/Service.h" //! @todo Remove me
@@ -310,6 +311,9 @@ bool CProfileManager::LoadProfile(unsigned int index)
   // unload any old settings
   settings->Unload();
 
+  // Stop all texture cache jobs and close the old profile's texture database
+  CServiceBroker::GetTextureCache()->Deinitialize();
+
   SetCurrentProfileId(index);
   m_previousProfileLoadedForLogin = false;
 
@@ -323,6 +327,9 @@ bool CProfileManager::LoadProfile(unsigned int index)
   settings->SetLoaded();
 
   CreateProfileFolders();
+
+  // Re-open the texture database for the new profile
+  CServiceBroker::GetTextureCache()->Initialize();
 
   CServiceBroker::GetDatabaseManager().Initialize();
   CServiceBroker::GetInputManager().LoadKeymaps();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When switching to a profile that has never been used before, Kodi crashes with a segmentation fault.
The crash occurs in two places:
- dbiplus::DbErrors receives a NULL error string from sqlite3_errmsg() and passes it directly to vsnprintf, causing an immediate segfault.
- The Python invoker crashes inside Py_EndInterpreter because add-on classes are left registered while the sub-interpreter is being torn down.
- Additionally, the texture cache database was not being properly closed and re‑opened during a profile switch, which left background jobs running with an invalid database handle and flooded the log with SQLITE_MISUSE errors.

This PR fixes all three issues:
- Hardens DbErrors::DbErrors to never pass a NULL format string to vsnprintf.
- Forces a full garbage collection and module dictionary clearing in CPythonInvoker::onExecutionDone() before destroying the sub‑interpreter.
- Adds calls to CTextureCache::Deinitialize() and Initialize() in CProfileManager::LoadProfile() so that the texture database is properly cycled during a profile switch.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The reported issue #28202 (reproduced) described a hard segfault when switching to a freshly created profile. Investigation revealed that the profile switch did not stop background texture caching jobs before the old database was closed, and two independent code paths would crash on the resulting SQLITE_MISUSE error or on Python interpreter shutdown.
The changes ensure that:
- Profile switching gracefully handles the texture cache lifecycle.
- Any database error is logged safely instead of crashing Kodi.
- Python service add‑on shutdowns no longer cause a segfault during profile switching.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a Linux Kodi build.
Steps:
- Launched Kodi with the master profile.
- Created a new profile (tried both “Copy default” and “Start fresh”).
- Selected “Load profile” for the newly created profile.
- Verified that the switch completes successfully and the new profile's home screen appears without a crash.
- Repeated the process several times and also switched back to the master profile.
- Verified that exiting Kodi no longer crashes when service add‑ons are stopped during a profile switch.

A minor observation (likely intended behavior): deleting a profile that is not currently active shows a confirmation dialog to delete its files. When deleting the currently active profile, no such prompt appears - the profile is simply removed  and the profile’s files are not deleted. This does not affect stability.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users can now create and switch to new profiles without Kodi crashing.
Profile switches are now reliable, even when the destination profile has never been used before.
The fix also prevents a potential crash on exit when Python service add-ons are stopped, improving overall stability.
Resolves #28202 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
