### PR TITLE
Retry transient curl errors in Exists and Stat

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -158,6 +158,38 @@ static inline void* realloc_simple(void *ptr, size_t size)
 static constexpr int CURL_OFF = 0L;
 static constexpr int CURL_ON = 1L;
 
+static bool IsTransientCurlError(CURLcode result)
+{
+  return result == CURLE_OPERATION_TIMEDOUT || result == CURLE_PARTIAL_FILE ||
+         result == CURLE_COULDNT_CONNECT || result == CURLE_HTTP2_STREAM ||
+         result == CURLE_RECV_ERROR;
+}
+
+static CURLcode PerformWithTransientRetries(CURL_HANDLE* easyHandle,
+                                            const CURL& url,
+                                            const char* functionName)
+{
+  const int maxRetries =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_curlretries;
+
+  CURLcode result = CURLE_OK;
+  for (int attempt = 0; attempt <= maxRetries; ++attempt)
+  {
+    result = g_curlInterface.easy_perform(easyHandle);
+    if (!IsTransientCurlError(result) || attempt == maxRetries)
+      break;
+
+    // Force the next probe off the failed/reused connection.
+    CLog::Log(LOGWARNING, "CCurlFile::{} - <{}> Transient error {}({}), reconnect and retry {}",
+              functionName, url.GetRedacted(), g_curlInterface.easy_strerror(result), result,
+              attempt + 1);
+    g_curlInterface.easy_setopt(easyHandle, CURLOPT_FRESH_CONNECT, CURL_ON);
+  }
+
+  g_curlInterface.easy_setopt(easyHandle, CURLOPT_FRESH_CONNECT, CURL_OFF); // restore pool reuse
+  return result;
+}
+
 size_t CCurlFile::CReadState::HeaderCallback(void *ptr, size_t size, size_t nmemb)
 {
   std::string inString;
@@ -1373,7 +1405,7 @@ bool CCurlFile::Exists(const CURL& url)
       g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_NOCWD);
   }
 
-  CURLcode result = g_curlInterface.easy_perform(m_state->m_easyHandle);
+  CURLcode result = PerformWithTransientRetries(m_state->m_easyHandle, url, __FUNCTION__);
 
   if (result == CURLE_WRITE_ERROR || result == CURLE_OK)
   {
@@ -1399,7 +1431,7 @@ bool CCurlFile::Exists(const CURL& url)
         list = g_curlInterface.slist_append(list, "Range: bytes=0-1"); /* try to only request 1 byte */
         g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_HTTPHEADER, list);
 
-        CURLcode result = g_curlInterface.easy_perform(m_state->m_easyHandle);
+        result = PerformWithTransientRetries(m_state->m_easyHandle, url, __FUNCTION__);
         g_curlInterface.slist_free_all(list);
 
         if (result == CURLE_WRITE_ERROR || result == CURLE_OK)
@@ -1580,7 +1612,7 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
       g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_NOCWD);
   }
 
-  CURLcode result = g_curlInterface.easy_perform(m_state->m_easyHandle);
+  CURLcode result = PerformWithTransientRetries(m_state->m_easyHandle, url, __FUNCTION__);
 
   if(result == CURLE_HTTP_RETURNED_ERROR)
   {
@@ -1611,8 +1643,7 @@ int CCurlFile::Stat(const CURL& url, struct __stat64* buffer)
 #endif
     g_curlInterface.easy_setopt(m_state->m_easyHandle, CURLOPT_NOPROGRESS, 0);
 
-    result = g_curlInterface.easy_perform(m_state->m_easyHandle);
-
+    result = PerformWithTransientRetries(m_state->m_easyHandle, url, __FUNCTION__);
   }
 
   if( result != CURLE_ABORTED_BY_CALLBACK && result != CURLE_OK )
@@ -1787,12 +1818,7 @@ int8_t CCurlFile::CReadState::FillBuffer(unsigned int want)
                         msg->data.result);
             }
 
-            if ( (msg->data.result == CURLE_OPERATION_TIMEDOUT ||
-                  msg->data.result == CURLE_PARTIAL_FILE       ||
-                  msg->data.result == CURLE_COULDNT_CONNECT    ||
-                  msg->data.result == CURLE_HTTP2_STREAM       ||
-                  msg->data.result == CURLE_RECV_ERROR)        &&
-                  !m_bFirstLoop)
+            if (IsTransientCurlError(msg->data.result) && !m_bFirstLoop)
             {
               bRetryNow = false; // Leave it to caller whether the operation is retried
               bError = true;


### PR DESCRIPTION
 ## Description

  Retry transient curl transport errors in `CCurlFile::Exists()` and `CCurlFile::Stat()` before reporting the probe as failed.

  This adds a shared retry helper for the existing curl `easy_perform()` calls used by these probe paths. When curl returns a     transient transport error, the helper logs the retry, requests a fresh connection, waits briefly, and retries according to the existing `m_curlretries` setting.

  ## Motivation and context
fixes https://github.com/xbmc/xbmc/issues/28382

  `CCurlFile::FillBuffer()` already has retry handling for transient curl errors during reads, but `Exists()` and `Stat()` currently fail after a single `easy_perform()` failure.

  For remote filesystems such as WebDAV, this can make playback startup fail if the initial metadata probe hits a temporary transport problem, even though a retry would recover. One observed case was a WebDAV movie file where `Stat()` failed during playback startup after a
  transient curl error, causing Kodi to treat the file as unavailable.

  This change makes the metadata probe paths behave more like the read path for transient curl failures.

  ## How has this been tested?

  Tested with a LibreELEC/Kodi build containing this patch.

  Manual WebDAV playback test:
  - Started playback of a WebDAV-hosted movie file.
  - Temporarily made the WebDAV nginx server unavailable during the pre-playback `CCurlFile::Stat()` request.
  - Restored nginx before Kodi exhausted the retry loop.
  - Verified Kodi logged the new retry warning from `CCurlFile::Stat()`:
    - `Transient error Could not connect to server(7), reconnect and retry 1`
    - `Transient error Could not connect to server(7), reconnect and retry 2`
    - `Transient error Could not connect to server(7), reconnect and retry 3`
  - Verified the same startup probe then recovered:
    - WebDAV `HEAD` returned `401 Unauthorized`
    - curl retried with authentication
    - WebDAV `HEAD` returned `200 OK`
  - Verified playback continued successfully:
    - WebDAV `GET` returned `206 Partial Content`
    - ffmpeg opened the Matroska input
    - Kodi reached `OnAVStarted`

  Also tested the longer unavailable-server case and verified the retry loop is exhausted cleanly before Kodi reports the failure.

  ## What is the effect on users?

  Kodi is more tolerant of short transient network or server-side interruptions during remote file startup checks. Playback from remote sources such as WebDAV can recover from brief connection failures during `Exists()` / `Stat()` instead of failing immediately.

  ## Screenshots (if appropriate):

  N/A

  ## Types of change

  - [X] **Bug fix** (non-breaking change which fixes an issue)
  - [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
  - [X] **Improvement** (non-breaking change which improves existing functionality)
  - [ ] **New feature** (non-breaking change which adds functionality)
  - [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
  - [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
  - [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
  - [ ] **None of the above** (please explain below)

  ## Checklist:

  - [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
  - [ ] My change requires a change to the documentation, either Doxygen or wiki
  - [ ] I have updated the documentation accordingly
  - [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
  - [ ] I have added tests to cover my change
  - [ ] All new and existing tests passed