### PR TITLE
GBM: restore headless boot path and harden DRM init failure handling

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -169,6 +169,7 @@ bool CWinSystemGbm::InitWindowSystem()
   if (!m_GBM->CreateDevice(m_DRM->GetFileDescriptor()))
   {
     m_GBM.reset();
+    m_DRM.reset();
     return false;
   }
 

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.cpp
@@ -171,7 +171,10 @@ bool CWinSystemGbmEGLContext::CreateNewWindow(const std::string& name,
 #else
   uint64_t modifier = DRM_FORMAT_MOD_LINEAR;
 #endif
-  if (!m_DRM->FindGuiPlane(gbm_bo_get_format(bo), modifier))
+  // Offscreen has no CRTC and no scanout planes; FindGuiPlane has nothing to
+  // assign, so skip the call rather than violate its post-condition that
+  // m_gui_plane is set on success.
+  if (m_DRM->GetCrtc() && !m_DRM->FindGuiPlane(gbm_bo_get_format(bo), modifier))
   {
     return false;
   }

--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
@@ -39,7 +39,7 @@ public:
 private:
   void DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer);
 
-  bool m_need_modeset;
+  bool m_need_modeset{true};
   bool m_active = true;
 
   class CDRMAtomicRequest

--- a/xbmc/windowing/gbm/drm/DRMUtils.h
+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
@@ -91,7 +91,7 @@ protected:
   bool OpenDrm(bool needConnector);
   drm_fb* DrmFbGetFromBo(struct gbm_bo* bo);
 
-  int m_fd;
+  int m_fd{-1};
   CDRMConnector* m_connector{nullptr};
   CDRMEncoder* m_encoder{nullptr};
   CDRMCrtc* m_crtc{nullptr};
@@ -118,7 +118,7 @@ private:
   RESOLUTION_INFO GetResolutionInfo(drmModeModeInfoPtr mode);
   void PrintDrmDeviceInfo(drmDevicePtr device);
 
-  int m_renderFd;
+  int m_renderFd{-1};
   const char* m_renderDevicePath{nullptr};
 
   int m_drm_quirks{0};

--- a/xbmc/windowing/gbm/drm/OffScreenModeSetting.cpp
+++ b/xbmc/windowing/gbm/drm/OffScreenModeSetting.cpp
@@ -10,6 +10,8 @@
 
 #include "utils/log.h"
 
+#include <algorithm>
+
 using namespace KODI::WINDOWING::GBM;
 
 namespace
@@ -23,6 +25,15 @@ bool COffScreenModeSetting::InitDrm()
 {
   if (!CDRMUtils::OpenDrm(false))
     return false;
+
+  // No real KMS planes exist offscreen, so the plane-scanning loop in
+  // CDRMUtils::InitDrm that flags each outputformat as active never runs.
+  // Activate AR24 here so CWinSystemGbmEGLContext::ChooseEGLConfig has a
+  // candidate and EGL context creation can proceed.
+  auto& formats = GetOutputFormats();
+  auto it = std::ranges::find(formats, DRM_FORMAT_ARGB8888, &outputformat::drm);
+  if (it != formats.end())
+    it->active = true;
 
   CLog::LogF(LOGDEBUG, "initialized offscreen DRM");
   return true;


### PR DESCRIPTION
## Description

This restores the GBM headless boot path introduced in #14125 (@a1rwulf, 2018) that regressed during the dynamic-planes refactor (#27402 /#28246) and hardens three latent defects in the DRM init failure path.

Two commits:

**1. GBM: restore headless boot path** -- `CWinSystemGbmEGLContext::ChooseEGLConfig` filters `m_output_formats` by `format.active`; `COffScreenModeSetting::InitDrm` skips the plane scan that flags formats active, so every candidate is rejected and EGL context creation fails. Mark AR24 active explicitly in offscreen init, and skip `FindGuiPlane` in `CreateNewWindow` when there is no CRTC (nothing to bind a scanout plane to).

**2. GBM/DRM: harden init failure paths** -- when mesa lacks a GBM backend for the DRM device, Kodi SIGSEGV'd in the ES2 fallback path because `WinSystemGbm::InitWindowSystem` reset `m_GBM` but left `m_DRM` set; the retry skipped re-init and dereferenced the freed `m_GBM`. Reset both. Default-initialize `m_fd` / `m_renderFd` to `-1` and `m_need_modeset` to `true` to avoid `close(garbage)` and UB on failure paths.

## Motivation and context

Restores behavior originally added in #14125 for "boot without a display, control via JSON-RPC, play audio." Regressed when `ChooseEGLConfig` was factored out of `InitWindowSystemEGL`. The init-hardening half turns a SIGSEGV on no-GBM-driver hardware into a clean "unable to init windowing system" exit.

## How has this been tested?

Tested on AMD Ryzen 3 5300U (Renoir) with HDMI cable disconnected: Kodi boots to GUI at 1280x720 offscreen, JSON-RPC + webserver reachable, ALSA opens HDMI + analog out, VAAPI initializes. With monitor reconnected (after restart): normal connected-display boot still works. Forced no-GBM-driver scenario: clean exit with `unable to init windowing system (CRITICAL)` instead of SIGSEGV.

## What is the effect on users?

Users running Kodi GBM on a box with no monitor attached (e.g. music-only setup, JSON-RPC remote control) can now boot. Users on hardware where mesa lacks a GBM driver get a diagnostic message instead of a crash.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
