### PR TITLE
[Video][Bluray] Action 'Choose Playlist' from context menu should override play disc menu option.

### DIFF
--- a/xbmc/application/ApplicationPlay.cpp
+++ b/xbmc/application/ApplicationPlay.cpp
@@ -203,6 +203,13 @@ MenuDecision GetMenuDecisions(const CFileItem& item,
       CSettings::SETTING_DISC_PLAYBACK)};
   const bool atStart{options.startpercent == 0.0 && options.starttime == 0.0};
 
+  // See if choose (new) playlist has been selected from context menu
+  const bool forceSelectionAlways{item.GetProperty("force_playlist_selection").asBoolean(false)};
+
+  // If we already have a playlist but Choose Playlist has been selected on the context menu
+  if (forceSelectionAlways && isBlurayPath)
+    return SHOW_SIMPLE_MENU;
+
   // Show Disc menu
   // This takes priority over the simple menu
   const bool useDiscMenuSetting{playbackSetting == BD_PLAYBACK_DISC_MENU};
@@ -214,8 +221,6 @@ MenuDecision GetMenuDecisions(const CFileItem& item,
   if ((isBluray || isBlurayPath) && atStart && useMainTitleSetting)
     return GET_MAIN_TITLE;
 
-  // See if choose (new) playlist has been selected from context menu of if simple menu should always be used
-  const bool forceSelectionAlways{item.GetProperty("force_playlist_selection").asBoolean(false)};
   const bool forceSelectionAtStart{playbackSetting == BD_PLAYBACK_SIMPLE_MENU};
   const bool mainTitle{playbackSetting == BD_PLAYBACK_MAIN_TITLE};
 
@@ -224,9 +229,6 @@ MenuDecision GetMenuDecisions(const CFileItem& item,
   if (isBluray && atStart && !mainTitle)
     return SHOW_SIMPLE_MENU;
 
-  // If we already have a playlist but Choose Playlist has been selected on the context menu
-  if (forceSelectionAlways && isBlurayPath)
-    return SHOW_SIMPLE_MENU;
   // If we already have a playlist but we're at the start and simple menu is enabled in settings
   if (forceSelectionAtStart && isBlurayPath && atStart)
     return SHOW_SIMPLE_MENU;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

I think that if the user has specifically selected 'Choose Playlist' then, irresepective of the playback setting, the user should be given the choice of playlist.

The converse is already true - if simple menu is selected as playback method then 'Choose Playlist' allows you to select the blu-ray menu as an option.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When Settings -> Player -> Discs -> Blu-ray playback mode is set to 'Show Blu-ray menu':
<img width="2425" height="355" alt="image" src="https://github.com/user-attachments/assets/77d53707-544b-4a88-8fce-5674a2c81035" />

Then the 'Choose Playlist' option on the context menu just plays the disc menu. 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
