### PR TITLE
[Video][Bluray] Enable playing bluray playlists at chapter level.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -798,6 +798,7 @@ msgstr ""
 #: xbmc/dialogs/GUIDialogMediaFilter.cpp
 #: xbmc/playlists/SmartPlaylist.cpp
 #: xbmc/pvr/windows/GUIViewStatePVR.cpp
+#: xbmc/dialogs/GUIDialogSimpleMenu.cpp
 #: addons/skin.estuary/xml/Variables.xml
 #: addons/skin.estuary/xml/View_51_Poster.xml
 #: addons/skin.estuary/xml/DialogPVRInfo.xml
@@ -1624,6 +1625,7 @@ msgctxt "#334"
 msgid "Clean library..."
 msgstr ""
 
+#: xbmc/dialogs/GUIDialogSimpleMenu.cpp
 msgctxt "#335"
 msgid "Start"
 msgstr ""
@@ -2657,7 +2659,7 @@ msgstr ""
 #: xbmc/playlists/SmartPlaylist.cpp
 #: xbmc/PlayListPlayer.cpp
 #: xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
-#: xbmc/video/dialogs/GUIDialogSimpleMenu.cpp
+#: xbmc/dialogs/GUIDialogSimpleMenu.cpp
 msgctxt "#559"
 msgid "Playlist"
 msgstr ""
@@ -14751,6 +14753,7 @@ msgstr ""
 
 #: addons/skin.estuary/xml/DialogSeekBar.xml
 #: addons/skin.estuary/xml/DialogFullScreenInfo.xml
+#: xbmc/dialogs/GUIDialogSimpleMenu.cpp
 msgctxt "#21396"
 msgid "Chapter"
 msgstr ""
@@ -15218,7 +15221,12 @@ msgctxt "#21485"
 msgid "Supported file extensions and media types"
 msgstr ""
 
-#empty strings from id 21486 to 21601
+#: xbmc/dialogs/GUIDialogSimpleMenu.cpp
+msgctxt "#21486"
+msgid "Chapters"
+msgstr ""
+
+#empty strings from id 21487 to 21601
 
 #: xbmc/Util.cpp
 msgctxt "#21602"
@@ -16979,6 +16987,7 @@ msgid "Title: {0:d}"
 msgstr ""
 
 #: xbmc/video/windows/GUIWindowVideoBase.cpp
+#: xbmc/dialogs/GUIDialogSimpleMenu.cpp
 msgctxt "#25006"
 msgid "Select playback item"
 msgstr ""
@@ -17025,19 +17034,19 @@ msgid "Manual"
 msgstr ""
 
 #. Used to ask user if they want to use a playlist already assigned to an episode
-#: xbmc/video/dialogs/GUIDialogSimpleMenu.cpp
+#: xbmc/dialogs/GUIDialogSimpleMenu.cpp
 msgctxt "#25015"
 msgid "Selected playlist is already in use. Associate with this episode instead?"
 msgstr ""
 
 #. Inform user that no valid movie playlist has been found on disc
-#: xbmc/video/dialogs/GUIDialogSimpleMenu.cpp
+#: xbmc/dialogs/GUIDialogSimpleMenu.cpp
 msgctxt "#25016"
 msgid "No valid movie playlist has been found."
 msgstr ""
 
 #. Inform user that no valid episode playlist has been found on disc
-#: xbmc/video/dialogs/GUIDialogSimpleMenu.cpp
+#: xbmc/dialogs/GUIDialogSimpleMenu.cpp
 msgctxt "#25017"
 msgid "No valid episode playlist has been found."
 msgstr ""

--- a/xbmc/cores/VideoPlayer/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES AudioSinkAE.cpp
             Edl.cpp
             Edl/EdlParserFactory.cpp
             Edl/EdlParsers/BeyondTVParser.cpp
+            Edl/EdlParsers/ChapterEdlParser.cpp
             Edl/EdlParsers/ComskipParser.cpp
             Edl/EdlParsers/EdlFileParser.cpp
             Edl/EdlParsers/MultipleEpisodeEdlParser.cpp
@@ -37,6 +38,7 @@ set(HEADERS AudioSinkAE.h
             Edl/EdlParser.h
             Edl/EdlParserFactory.h
             Edl/EdlParsers/BeyondTVParser.h
+            Edl/EdlParsers/ChapterEdlParser.h
             Edl/EdlParsers/ComskipParser.h
             Edl/EdlParsers/EdlFileParser.h
             Edl/EdlParsers/MultipleEpisodeEdlParser.h

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -278,6 +278,9 @@ public:
 
   static void UpdateStackItem(CFileItem& item, std::chrono::milliseconds length);
 
+  virtual std::vector<ChapterInfo> GetChapters() { return {}; }
+  virtual std::chrono::milliseconds GetDuration() { return std::chrono::milliseconds::zero(); }
+
 protected:
   DVDStreamType m_streamType;
   BitstreamStats m_stats;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -28,7 +28,6 @@
 #include "video/VideoInfoTag.h"
 
 #include <chrono>
-#include <functional>
 #include <limits>
 #include <memory>
 #include <string>
@@ -1361,4 +1360,27 @@ void CDVDInputStreamBluray::UpdateStack(CFileItem& item)
 {
   return UpdateStackItem(item,
                          m_titleInfo ? std::chrono::milliseconds(m_titleInfo->duration / 90) : 0ms);
+}
+
+std::vector<ChapterInfo> CDVDInputStreamBluray::GetChapters()
+{
+  std::vector<ChapterInfo> chapters;
+  if (!m_titleInfo || !m_titleInfo->chapters)
+    return chapters;
+
+  for (unsigned int i = 0; i < m_titleInfo->chapter_count; ++i)
+  {
+    const BLURAY_TITLE_CHAPTER& chapter{m_titleInfo->chapters[i]};
+    std::chrono::milliseconds start{chapter.start / 90};
+    std::chrono::milliseconds duration{chapter.duration / 90};
+    chapters.push_back({i + 1, start, duration});
+  }
+  return chapters;
+}
+
+std::chrono::milliseconds CDVDInputStreamBluray::GetDuration()
+{
+  if (!m_titleInfo)
+    return 0ms;
+  return std::chrono::milliseconds(m_titleInfo->duration / 90);
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -144,6 +144,9 @@ public:
   UpdateState UpdateItemFromSavedStates(CFileItem& item, double time, bool& closed) override;
   void UpdateStack(CFileItem& item) override;
 
+  std::vector<ChapterInfo> GetChapters() override;
+  std::chrono::milliseconds GetDuration() override;
+
 protected:
   struct SPlane;
 

--- a/xbmc/cores/VideoPlayer/Edl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl.cpp
@@ -9,7 +9,6 @@
 #include "Edl.h"
 
 #include "Edl/EdlParserFactory.h"
-#include "Edl/EdlParsers/MultipleEpisodeEdlParser.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
@@ -17,7 +16,6 @@
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
-#include "utils/URIUtils.h"
 #include "utils/log.h"
 
 #include <algorithm>
@@ -64,12 +62,18 @@ bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem,
   CLog::LogF(LOGDEBUG, "Checking for edit decision lists (EDL) for: {}",
              CURL::GetRedacted(fileItem.GetDynPath()));
 
-  // Run the multi-episode parser independently so episode start/end can be
-  // applied to any edits found by the file-based parsers
-  CEdlParserResult multiEpisodeResult;
-  CMultipleEpisodeEdlParser multiEpParser;
-  if (URIUtils::IsLocalOrLAN(fileItem.GetDynPath()) && multiEpParser.CanParse(fileItem))
-    multiEpisodeResult = multiEpParser.Parse(fileItem, fps, duration);
+  // Run the multi-episode and chapter parsers independently so episode/chapter
+  // start/end can be applied to any edits found by the file-based parsers
+  CEdlParserResult partFileResult;
+  for (const auto& parser : CEdlParserFactory::GetPartFileEdlParsersForItem(fileItem))
+  {
+    if (parser->CanParse(fileItem))
+    {
+      partFileResult = parser->Parse(fileItem, fps, duration);
+      if (!partFileResult.IsEmpty())
+        break;
+    }
+  }
 
   for (const auto& parser : CEdlParserFactory::GetEdlParsersForItem(fileItem))
   {
@@ -78,12 +82,12 @@ bool CEdl::ReadEditDecisionLists(const CFileItem& fileItem,
 
     CEdlParserResult result = parser->Parse(fileItem, fps, duration);
     if (!result.IsEmpty())
-      return ProcessParserResult(result, multiEpisodeResult, duration);
+      return ProcessParserResult(result, partFileResult, duration);
   }
 
   // No file-based EDL found; still apply multi-episode cuts alone if present
-  if (!multiEpisodeResult.IsEmpty())
-    return ProcessParserResult(multiEpisodeResult);
+  if (!partFileResult.IsEmpty())
+    return ProcessParserResult(partFileResult);
 
   return false;
 }

--- a/xbmc/cores/VideoPlayer/Edl/EdlParserFactory.cpp
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParserFactory.cpp
@@ -9,8 +9,10 @@
 #include "EdlParserFactory.h"
 
 #include "EdlParsers/BeyondTVParser.h"
+#include "EdlParsers/ChapterEdlParser.h"
 #include "EdlParsers/ComskipParser.h"
 #include "EdlParsers/EdlFileParser.h"
+#include "EdlParsers/MultipleEpisodeEdlParser.h"
 #include "EdlParsers/PvrEdlParser.h"
 #include "EdlParsers/VideoReDoParser.h"
 #include "FileItem.h"
@@ -35,6 +37,18 @@ std::vector<std::unique_ptr<IEdlParser>> CEdlParserFactory::GetEdlParsersForItem
     // Metadata-based parsers for other items (PVR, streams, etc.)
     parsers.emplace_back(std::make_unique<CPvrEdlParser>());
   }
+
+  return parsers;
+}
+
+std::vector<std::unique_ptr<IEdlParser>> CEdlParserFactory::GetPartFileEdlParsersForItem(
+    const CFileItem& item)
+{
+  std::vector<std::unique_ptr<IEdlParser>> parsers;
+
+  parsers.emplace_back(std::make_unique<CChapterEdlParser>());
+  if (URIUtils::IsLocalOrLAN(item.GetDynPath()))
+    parsers.emplace_back(std::make_unique<CMultipleEpisodeEdlParser>());
 
   return parsers;
 }

--- a/xbmc/cores/VideoPlayer/Edl/EdlParserFactory.h
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParserFactory.h
@@ -29,7 +29,7 @@ class CEdlParserFactory
 {
 public:
   /*!
-   * @brief Get all EDL parsers applicable for the given file item
+   * @brief Get all EDL file/metadata parsers applicable for the given file item
    *
    * Returns file-based parsers for local/LAN items, or metadata-based
    * parsers (like PVR) for other items. The factory handles all context
@@ -39,6 +39,17 @@ public:
    * @return Vector of applicable parser instances
    */
   static std::vector<std::unique_ptr<IEdlParser>> GetEdlParsersForItem(const CFileItem& item);
+
+  /*!
+   * @brief Get all EDL parsers that play file segments of the given file item
+   *
+   * Returns the part file parsers.
+   *
+   * @param item The file item to get parsers for
+   * @return Vector of applicable parser instances
+   */
+  static std::vector<std::unique_ptr<IEdlParser>> GetPartFileEdlParsersForItem(
+      const CFileItem& item);
 };
 
 } // namespace EDL

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/ChapterEdlParser.cpp
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/ChapterEdlParser.cpp
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ChapterEdlParser.h"
+
+#include "FileItem.h"
+#include "utils/RegExp.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+#include "video/VideoInfoTag.h"
+
+#include <chrono>
+#include <tuple>
+
+using namespace EDL;
+using namespace std::chrono_literals;
+
+namespace
+{
+std::tuple<bool, std::chrono::milliseconds, std::chrono::milliseconds> ParseChapters(
+    const CFileItem& item)
+{
+  if (!item.HasVideoInfoTag())
+    return std::make_tuple(false, 0ms, 0ms);
+
+  const CVideoInfoTag* tag{item.GetVideoInfoTag()};
+  const auto& chapters{tag->GetChapters()};
+  if (chapters.empty())
+    return std::make_tuple(false, 0ms, 0ms);
+
+  const CURL url{item.GetDynPath()};
+  const std::string chaptersOption{url.GetOption("chapters")};
+  if (chaptersOption.empty())
+    return std::make_tuple(false, 0ms, 0ms);
+
+  CRegExp c{true, CRegExp::autoUtf8, R"((\d{1,3})(?:-)(\d{1,3})$)"};
+  if (c.RegFind(chaptersOption) == -1)
+    return std::make_tuple(false, 0ms, 0ms);
+
+  int startChapter{std::stoi(c.GetMatch(1))};
+  int endChapter{std::stoi(c.GetMatch(2))};
+  if (startChapter < 1 || endChapter > static_cast<int>(chapters.size()) ||
+      startChapter > endChapter)
+    return std::make_tuple(false, 0ms, 0ms);
+
+  // Chapter numbers are 1 based
+  return std::make_tuple(true, chapters[startChapter - 1].start,
+                         chapters[endChapter - 1].start + chapters[endChapter - 1].duration);
+}
+} // namespace
+
+bool CChapterEdlParser::CanParse(const CFileItem& item) const
+{
+  [[maybe_unused]] const auto& [success, start, end] = ParseChapters(item);
+  return success;
+}
+
+CEdlParserResult CChapterEdlParser::Parse(const CFileItem& item,
+                                          float fps,
+                                          std::chrono::milliseconds duration)
+{
+  CEdlParserResult result;
+
+  const auto& [success, start, end] = ParseChapters(item);
+  if (!success)
+    return result;
+
+  // Check EDL actually needed
+  if (start == 0ms && end == duration)
+    return result;
+
+  // Check times are valid
+  if (start < 0ms || start > duration || end < 0ms || end > duration || start >= end)
+  {
+    CLog::LogF(LOGERROR, "Invalid chapter times for item: {}. Start: {}, End: {}.",
+               CURL::GetRedacted(item.GetDynPath()), StringUtils::MillisecondsToTimeString(start),
+               StringUtils::MillisecondsToTimeString(end));
+    return result;
+  }
+
+  Edit edit;
+  edit.action = Action::CUT;
+  if (start > 0ms)
+  {
+    edit.start = 0ms;
+    edit.end = start;
+    result.AddEdit(edit);
+    CLog::LogF(LOGDEBUG, "Adding start EDL cut [{} - {}] for chapters in item: {}.",
+               StringUtils::MillisecondsToTimeString(0ms),
+               StringUtils::MillisecondsToTimeString(start), CURL::GetRedacted(item.GetDynPath()));
+  }
+  if (end > 0ms && end < duration)
+  {
+    edit.start = end;
+    edit.end = duration;
+    result.AddEdit(edit);
+    CLog::LogF(LOGDEBUG, "Adding end EDL cut [{} - {}] for chapters in item: {}.",
+               StringUtils::MillisecondsToTimeString(end),
+               StringUtils::MillisecondsToTimeString(duration),
+               CURL::GetRedacted(item.GetDynPath()));
+  }
+
+  return result;
+}

--- a/xbmc/cores/VideoPlayer/Edl/EdlParsers/ChapterEdlParser.h
+++ b/xbmc/cores/VideoPlayer/Edl/EdlParsers/ChapterEdlParser.h
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "cores/VideoPlayer/Edl/EdlParser.h"
+
+#include <chrono>
+
+namespace EDL
+{
+
+/*!
+ * @brief Parser for media with chapters.
+ *
+ * Uses chapters from the url to create EDL cuts for the episode being played.
+ * This parser implements IEdlParser directly (not CEdlFileParserBase)
+ * as it doesn't read from files.
+ */
+class CChapterEdlParser : public IEdlParser
+{
+public:
+  bool CanParse(const CFileItem& item) const override;
+  CEdlParserResult Parse(const CFileItem& item,
+                         float fps,
+                         std::chrono::milliseconds duration) override;
+};
+
+} // namespace EDL

--- a/xbmc/cores/VideoPlayer/Edl/test/TestEdl.cpp
+++ b/xbmc/cores/VideoPlayer/Edl/test/TestEdl.cpp
@@ -6,6 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "Edl/EdlParsers/ChapterEdlParser.h"
 #include "Edl/EdlParsers/MultipleEpisodeEdlParser.h"
 #include "FileItem.h"
 #include "ServiceBroker.h"
@@ -944,4 +945,197 @@ TEST_F(TestParseEditsForEpisode, EditStraddlingBothBoundariesIsClamped)
     }
   }
   EXPECT_TRUE(clampedFound) << "Expected wide commbreak clamped to episode window [500s - 600s]";
+}
+
+// ============================================================================
+// TestChapterEdlParser
+// ============================================================================
+
+class TestChapterEdlParser : public ::testing::Test
+{
+protected:
+  // Build `count` evenly-spaced ChapterInfo entries, each `chapterDuration` long.
+  static std::vector<ChapterInfo> MakeChapters(int count, std::chrono::milliseconds chapterDuration)
+  {
+    std::vector<ChapterInfo> chapters;
+    for (int i = 0; i < count; ++i)
+    {
+      ChapterInfo ch;
+      ch.chapter = static_cast<unsigned int>(i + 1);
+      ch.start = chapterDuration * i;
+      ch.duration = chapterDuration;
+      chapters.push_back(ch);
+    }
+    return chapters;
+  }
+
+  // Build a CFileItem with a VideoInfoTag carrying the given chapters.
+  // The path contains ?chapters=<chaptersRange> when chaptersRange is non-empty.
+  static CFileItem MakeChapterItem(const std::vector<ChapterInfo>& chapters,
+                                   const std::string& chaptersRange)
+  {
+    CFileItem item;
+    const std::string path = chaptersRange.empty()
+                                 ? "bluray://localhost/movie.iso"
+                                 : "bluray://localhost/movie.iso?chapters=" + chaptersRange;
+    item.SetPath(path);
+    item.GetVideoInfoTag()->SetChapters(chapters);
+    return item;
+  }
+};
+
+// ---- CanParse ----------------------------------------------------------
+
+TEST_F(TestChapterEdlParser, CanParse_ReturnsFalse_WhenNoVideoInfoTag)
+{
+  // ParseChapters early-exits when HasVideoInfoTag() is false
+  CChapterEdlParser parser;
+  CFileItem item;
+  item.SetPath("bluray://localhost/movie.iso?chapters=1-3");
+  // Do NOT call GetVideoInfoTag() so HasVideoInfoTag() stays false
+  EXPECT_FALSE(parser.CanParse(item));
+}
+
+TEST_F(TestChapterEdlParser, CanParse_ReturnsFalse_WhenChaptersAreEmpty)
+{
+  // Item has a VideoInfoTag but its chapter list is empty
+  CChapterEdlParser parser;
+  const auto item = MakeChapterItem({}, "1-1");
+  EXPECT_FALSE(parser.CanParse(item));
+}
+
+TEST_F(TestChapterEdlParser, CanParse_ReturnsFalse_WhenNoChaptersUrlOption)
+{
+  // Item has chapters but the path carries no ?chapters= option
+  CChapterEdlParser parser;
+  const auto item = MakeChapterItem(MakeChapters(3, 10s), "");
+  EXPECT_FALSE(parser.CanParse(item));
+}
+
+TEST_F(TestChapterEdlParser, CanParse_ReturnsFalse_WhenChaptersOptionFormatIsInvalid)
+{
+  // The ?chapters= value does not match the required \d{1,3}-\d{1,3} pattern
+  CChapterEdlParser parser;
+  CFileItem item;
+  item.SetPath("bluray://localhost/movie.iso?chapters=invalid");
+  item.GetVideoInfoTag()->SetChapters(MakeChapters(3, 10s));
+  EXPECT_FALSE(parser.CanParse(item));
+}
+
+TEST_F(TestChapterEdlParser, CanParse_ReturnsFalse_WhenStartChapterIsZero)
+{
+  // startChapter of 0 is invalid (chapters are 1-based)
+  CChapterEdlParser parser;
+  const auto item = MakeChapterItem(MakeChapters(3, 10s), "0-2");
+  EXPECT_FALSE(parser.CanParse(item));
+}
+
+TEST_F(TestChapterEdlParser, CanParse_ReturnsFalse_WhenEndChapterExceedsChapterCount)
+{
+  // endChapter (5) exceeds the actual number of chapters (3)
+  CChapterEdlParser parser;
+  const auto item = MakeChapterItem(MakeChapters(3, 10s), "1-5");
+  EXPECT_FALSE(parser.CanParse(item));
+}
+
+TEST_F(TestChapterEdlParser, CanParse_ReturnsFalse_WhenStartChapterExceedsEnd)
+{
+  // startChapter > endChapter is an invalid range
+  CChapterEdlParser parser;
+  const auto item = MakeChapterItem(MakeChapters(3, 10s), "3-1");
+  EXPECT_FALSE(parser.CanParse(item));
+}
+
+TEST_F(TestChapterEdlParser, CanParse_ReturnsTrue_WhenChaptersOptionAndChaptersAreValid)
+{
+  // All conditions met: chapters present, valid range within chapter count
+  CChapterEdlParser parser;
+  const auto item = MakeChapterItem(MakeChapters(3, 10s), "1-3");
+  EXPECT_TRUE(parser.CanParse(item));
+}
+
+// ---- Parse -------------------------------------------------------------
+
+TEST_F(TestChapterEdlParser, Parse_ReturnsEmptyResult_WhenCannotParse)
+{
+  // Parse returns an empty result when ParseChapters fails (no VideoInfoTag)
+  CChapterEdlParser parser;
+  CFileItem item;
+  item.SetPath("bluray://localhost/movie.iso?chapters=1-3");
+  const auto result = parser.Parse(item, 0, 30s);
+  EXPECT_TRUE(result.IsEmpty());
+}
+
+TEST_F(TestChapterEdlParser, Parse_ReturnsEmptyResult_WhenChapterSpansEntireFile)
+{
+  // Range "1-3" over a 3×10s file with duration=30s → start=0ms, end=30s=duration
+  // No EDL cuts are needed so the result must be empty
+  CChapterEdlParser parser;
+  const auto item = MakeChapterItem(MakeChapters(3, 10s), "1-3");
+  const auto result = parser.Parse(item, 0, 30s);
+  EXPECT_TRUE(result.IsEmpty());
+}
+
+TEST_F(TestChapterEdlParser, Parse_ReturnsEmptyResult_WhenChapterEndExceedsFileDuration)
+{
+  // Single chapter: start=20s, duration=20s → end=40s which exceeds duration=30s → invalid
+  CChapterEdlParser parser;
+  std::vector<ChapterInfo> chapters;
+  ChapterInfo ch;
+  ch.chapter = 1;
+  ch.start = 20s;
+  ch.duration = 20s;
+  chapters.push_back(ch);
+  CFileItem item;
+  item.SetPath("bluray://localhost/movie.iso?chapters=1-1");
+  item.GetVideoInfoTag()->SetChapters(chapters);
+  const auto result = parser.Parse(item, 0, 30s);
+  EXPECT_TRUE(result.IsEmpty());
+}
+
+TEST_F(TestChapterEdlParser, Parse_ReturnsOnlyStartCut_WhenChapterRangeStartsAfterZero)
+{
+  // Range "2-3" over a 3×10s file: start=10s, end=30s=duration → only a start cut
+  CChapterEdlParser parser;
+  const auto item = MakeChapterItem(MakeChapters(3, 10s), "2-3");
+  const auto result = parser.Parse(item, 0, 30s);
+  EXPECT_EQ(result.GetEdits().size(), 1);
+  EXPECT_TRUE(result.GetSceneMarkers().empty());
+  EXPECT_EQ(result.GetEdits().at(0).edit.start, 0ms);
+  EXPECT_EQ(result.GetEdits().at(0).edit.end, 10s);
+  for (const auto& entry : result.GetEdits())
+    EXPECT_EQ(entry.edit.action, Action::CUT);
+  EXPECT_TRUE(result.GetSceneMarkers().empty());
+}
+
+TEST_F(TestChapterEdlParser, Parse_ReturnsOnlyEndCut_WhenChapterRangeEndsBeforeFileDuration)
+{
+  // Range "1-2" over a 3×10s file: start=0ms, end=20s < 30s → only an end cut
+  CChapterEdlParser parser;
+  const auto item = MakeChapterItem(MakeChapters(3, 10s), "1-2");
+  const auto result = parser.Parse(item, 0, 30s);
+  EXPECT_EQ(result.GetEdits().size(), 1);
+  EXPECT_TRUE(result.GetSceneMarkers().empty());
+  EXPECT_EQ(result.GetEdits().at(0).edit.start, 20s);
+  EXPECT_EQ(result.GetEdits().at(0).edit.end, 30s);
+  for (const auto& entry : result.GetEdits())
+    EXPECT_EQ(entry.edit.action, Action::CUT);
+  EXPECT_TRUE(result.GetSceneMarkers().empty());
+}
+
+TEST_F(TestChapterEdlParser, Parse_ReturnsBothCuts_WhenChapterRangeIsMiddleOfFile)
+{
+  // Range "2-2" over a 3×10s file: start=10s, end=20s → start cut + end cut
+  CChapterEdlParser parser;
+  const auto item = MakeChapterItem(MakeChapters(3, 10s), "2-2");
+  const auto result = parser.Parse(item, 0, 30s);
+  EXPECT_EQ(result.GetEdits().size(), 2);
+  EXPECT_TRUE(result.GetSceneMarkers().empty());
+  EXPECT_EQ(result.GetEdits().at(0).edit.start, 0ms);
+  EXPECT_EQ(result.GetEdits().at(0).edit.end, 10s);
+  EXPECT_EQ(result.GetEdits().at(1).edit.start, 20s);
+  EXPECT_EQ(result.GetEdits().at(1).edit.end, 30s);
+  for (const auto& entry : result.GetEdits())
+    EXPECT_EQ(entry.edit.action, Action::CUT);
+  EXPECT_TRUE(result.GetSceneMarkers().empty());
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4236,9 +4236,18 @@ bool CVideoPlayer::OpenVideoStream(CDVDStreamInfo& hint, bool reset)
     float fFramesPerSecond = 0.0f;
     if (m_CurrentVideo.hint.fpsscale > 0.0f)
       fFramesPerSecond = static_cast<float>(m_CurrentVideo.hint.fpsrate) / static_cast<float>(m_CurrentVideo.hint.fpsscale);
-    const std::chrono::milliseconds duration =
-        m_pDemuxer ? std::chrono::milliseconds(m_pDemuxer->GetStreamLength()) : 0ms;
-    m_Edl.ReadEditDecisionLists(m_item, fFramesPerSecond, duration);
+    std::chrono::milliseconds duration{0ms};
+    if (m_pDemuxer)
+      duration = std::chrono::milliseconds(m_pDemuxer->GetStreamLength());
+    if (duration == 0ms && m_pInputStream)
+      duration = m_pInputStream->GetDuration();
+
+    // Get chapters (for bluray)
+    CFileItem item(m_item);
+    if (item.HasVideoInfoTag() && m_pInputStream)
+      item.GetVideoInfoTag()->SetChapters(m_pInputStream->GetChapters());
+
+    m_Edl.ReadEditDecisionLists(item, fFramesPerSecond, duration);
     CServiceBroker::GetDataCacheCore().SetEditList(m_Edl.GetEditList());
     CServiceBroker::GetDataCacheCore().SetCuts(m_Edl.GetCutMarkers());
     CServiceBroker::GetDataCacheCore().SetSceneMarkers(m_Edl.GetSceneMarkers());

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -16,6 +16,7 @@
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "utils/StringUtils.h"
+#include "video/VideoInfoTag.h"
 
 #include <memory>
 
@@ -37,11 +38,37 @@ CGUIDialogSelect::CGUIDialogSelect(int windowId)
     m_bButtonPressed(false),
     m_bButton2Pressed(false),
     m_useDetails(false),
-    m_multiSelection(false)
+    m_multiSelection(false),
+    m_enforceContiguousSelection(false),
+    m_useExtraAsOK(false),
+    m_selectChapters(false)
 {
   m_bConfirmed = false;
   m_loadType = KEEP_IN_MEMORY;
 }
+
+namespace
+{
+bool AreSelectedItemsContiguous(const CFileItemList& items)
+{
+  // Find the first selected item
+  const auto firstSelected{std::find_if(items.begin(), items.end(),
+                                        [](const std::shared_ptr<CFileItem>& item)
+                                        { return item->IsSelected(); })};
+  if (firstSelected == items.end())
+    return false; // No selected items
+
+  // Find the last selected item
+  const auto lastSelected{std::find_if(items.rbegin(), items.rend(),
+                                       [](const std::shared_ptr<CFileItem>& item)
+                                       { return item->IsSelected(); })
+                              .base()};
+
+  // Check that no unselected items exist between first and last
+  return std::all_of(firstSelected, lastSelected,
+                     [](const std::shared_ptr<CFileItem>& item) { return item->IsSelected(); });
+}
+} // namespace
 
 CGUIDialogSelect::~CGUIDialogSelect(void) = default;
 
@@ -49,7 +76,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
 {
   switch (message.GetMessage())
   {
-  case GUI_MSG_WINDOW_DEINIT:
+    case GUI_MSG_WINDOW_DEINIT:
     {
       CGUIDialogBoxBase::OnMessage(message);
 
@@ -58,12 +85,16 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
       m_useDetails = false;
       m_multiSelection = false;
 
+      m_enforceContiguousSelection = false;
+      m_useExtraAsOK = false;
+      m_selectChapters = false;
+
       // construct selected items list
       m_selectedItems.clear();
       m_selectedItem = nullptr;
-      for (int i = 0 ; i < m_vecList->Size() ; i++)
+      for (int i = 0; i < m_vecList->Size(); i++)
       {
-        CFileItemPtr item = m_vecList->Get(i);
+        std::shared_ptr<CFileItem> item = m_vecList->Get(i);
         if (item->IsSelected())
         {
           m_selectedItems.push_back(i);
@@ -76,7 +107,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
     }
     break;
 
-  case GUI_MSG_WINDOW_INIT:
+    case GUI_MSG_WINDOW_INIT:
     {
       m_bButtonPressed = false;
       m_bButton2Pressed = false;
@@ -86,8 +117,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
     }
     break;
 
-
-  case GUI_MSG_CLICKED:
+    case GUI_MSG_CLICKED:
     {
       int iControl = message.GetSenderId();
       if (m_viewControl.HasControl(CONTROL_SIMPLE_LIST))
@@ -98,16 +128,30 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
           int iSelected = m_viewControl.GetSelectedItem();
           if (iSelected >= 0 && iSelected < m_vecList->Size())
           {
-            CFileItemPtr item(m_vecList->Get(iSelected));
+            std::shared_ptr<CFileItem> item(m_vecList->Get(iSelected));
             if (m_multiSelection)
               item->Select(!item->IsSelected());
             else
             {
-              for (int i = 0 ; i < m_vecList->Size() ; i++)
+              for (int i = 0; i < m_vecList->Size(); i++)
                 m_vecList->Get(i)->Select(false);
               item->Select(true);
               OnSelect(iSelected);
             }
+
+            if (m_enforceContiguousSelection)
+            {
+              if (AreSelectedItemsContiguous(*m_vecList))
+                CONTROL_ENABLE(CONTROL_EXTRA_BUTTON);
+              else
+                CONTROL_DISABLE(CONTROL_EXTRA_BUTTON);
+            }
+
+            if (m_selectChapters && item->HasVideoInfoTag() &&
+                item->GetVideoInfoTag()->HasChapters() && !item->HasProperty("chapter"))
+              CONTROL_ENABLE(CONTROL_EXTRA_BUTTON2);
+            else
+              CONTROL_DISABLE(CONTROL_EXTRA_BUTTON2);
           }
         }
       }
@@ -136,7 +180,8 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
       }
     }
     break;
-  case GUI_MSG_SETFOCUS:
+
+    case GUI_MSG_SETFOCUS:
     {
       if (m_viewControl.HasControl(message.GetControlId()))
       {
@@ -156,6 +201,9 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
       }
     }
     break;
+
+    default:
+      break;
   }
 
   return CGUIDialogBoxBase::OnMessage(message);
@@ -164,7 +212,8 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
 void CGUIDialogSelect::OnSelect(int idx)
 {
   m_bConfirmed = true;
-  Close();
+  if (!m_useExtraAsOK)
+    Close();
 }
 
 bool CGUIDialogSelect::OnBack(int actionID)
@@ -183,6 +232,10 @@ void CGUIDialogSelect::Reset()
   m_bButton2Enabled = false;
   m_bButton2Pressed = false;
 
+  m_enforceContiguousSelection = false;
+  m_useExtraAsOK = false;
+  m_selectChapters = false;
+
   m_useDetails = false;
   m_multiSelection = false;
   m_focusToButton = false;
@@ -193,7 +246,7 @@ void CGUIDialogSelect::Reset()
 
 int CGUIDialogSelect::Add(const std::string& strLabel)
 {
-  CFileItemPtr pItem(new CFileItem(strLabel));
+  std::shared_ptr<CFileItem> pItem(std::make_shared<CFileItem>(strLabel));
   m_vecList->Add(pItem);
   return m_vecList->Size() - 1;
 }
@@ -217,7 +270,7 @@ int CGUIDialogSelect::GetSelectedItem() const
   return !m_selectedItems.empty() ? m_selectedItems[0] : -1;
 }
 
-const CFileItemPtr CGUIDialogSelect::GetSelectedFileItem() const
+const std::shared_ptr<CFileItem> CGUIDialogSelect::GetSelectedFileItem() const
 {
   if (m_selectedItem)
     return m_selectedItem;
@@ -253,12 +306,12 @@ void CGUIDialogSelect::EnableButton2(bool enable, const std::string& label)
   m_button2Label = label;
 }
 
-bool CGUIDialogSelect::IsButtonPressed()
+bool CGUIDialogSelect::IsButtonPressed() const
 {
   return m_bButtonPressed;
 }
 
-bool CGUIDialogSelect::IsButton2Pressed()
+bool CGUIDialogSelect::IsButton2Pressed() const
 {
   return m_bButton2Pressed;
 }
@@ -317,11 +370,34 @@ void CGUIDialogSelect::SetUseDetails(bool useDetails)
 void CGUIDialogSelect::SetMultiSelection(bool multiSelection)
 {
   m_multiSelection = multiSelection;
+  if (multiSelection)
+    SetUseExtraAsOK(true);
+  else
+    SetUseExtraAsOK(false);
 }
 
 void CGUIDialogSelect::SetButtonFocus(bool buttonFocus)
 {
   m_focusToButton = buttonFocus;
+}
+
+void CGUIDialogSelect::SetEnforceContiguousSelection(bool enforceContiguousSelection)
+{
+  m_enforceContiguousSelection = enforceContiguousSelection;
+}
+
+void CGUIDialogSelect::SetUseExtraAsOK(bool useExtraAsOK)
+{
+  m_useExtraAsOK = useExtraAsOK;
+  if (useExtraAsOK)
+    EnableButton(true, 186); // OK
+  else
+    EnableButton(false, 186);
+}
+
+void CGUIDialogSelect::SetSelectChapters(bool selectChapters)
+{
+  m_selectChapters = selectChapters;
 }
 
 CGUIControl *CGUIDialogSelect::GetFirstFocusableControl(int id)
@@ -361,9 +437,6 @@ void CGUIDialogSelect::OnInitWindow()
       StringUtils::Format("{} {}", m_vecList->Size(),
                           CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(127)));
 
-  if (m_multiSelection)
-    EnableButton(true, 186);
-
   if (m_bButtonEnabled)
   {
     SET_CONTROL_LABEL(CONTROL_EXTRA_BUTTON, m_buttonLabel);
@@ -376,12 +449,21 @@ void CGUIDialogSelect::OnInitWindow()
   {
     SET_CONTROL_LABEL(CONTROL_EXTRA_BUTTON2, m_button2Label);
     SET_CONTROL_VISIBLE(CONTROL_EXTRA_BUTTON2);
+    if (m_selectChapters)
+      CONTROL_DISABLE(
+          CONTROL_EXTRA_BUTTON2); // Disable button until an item with chapters is selected
   }
   else
     SET_CONTROL_HIDDEN(CONTROL_EXTRA_BUTTON2);
 
   SET_CONTROL_LABEL(CONTROL_CANCEL_BUTTON,
                     CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(222));
+
+  // If contiguous items are required this implies at least one must be selected
+  // Also it means the UseExtraAsOK button is in effect
+  // So disable the OK (extra) button initially
+  if (m_enforceContiguousSelection)
+    CONTROL_DISABLE(CONTROL_EXTRA_BUTTON);
 
   CGUIDialogBoxBase::OnInitWindow();
 

--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -37,8 +37,8 @@ public:
   void EnableButton(bool enable, const std::string& label);
   void EnableButton2(bool enable, int label);
   void EnableButton2(bool enable, const std::string& label);
-  bool IsButtonPressed();
-  bool IsButton2Pressed();
+  bool IsButtonPressed() const;
+  bool IsButton2Pressed() const;
   void Sort(bool bSortOrder = true);
   void SetSelected(int iSelected);
   void SetSelected(const std::string &strSelectedLabel);
@@ -47,9 +47,12 @@ public:
   void SetUseDetails(bool useDetails);
   void SetMultiSelection(bool multiSelection);
   void SetButtonFocus(bool buttonFocus);
+  void SetEnforceContiguousSelection(bool enforceContiguousSelection);
+  void SetUseExtraAsOK(bool useExtraAsOK);
+  void SetSelectChapters(bool selectChapters);
+  CGUIControl* GetFirstFocusableControl(int id) override;
 
 protected:
-  CGUIControl *GetFirstFocusableControl(int id) override;
   void OnWindowLoaded() override;
   void OnInitWindow() override;
   void OnDeinitWindow(int nextWindowID) override;
@@ -71,6 +74,9 @@ private:
   bool m_useDetails;
   bool m_multiSelection;
   bool m_focusToButton{};
+  bool m_enforceContiguousSelection;
+  bool m_useExtraAsOK;
+  bool m_selectChapters;
 
   std::vector<int> m_selectedItems;
 };

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -9,11 +9,16 @@
 #include "GUIDialogSimpleMenu.h"
 
 #include "FileItem.h"
+#include "FileItemList.h"
 #include "GUIDialogSelect.h"
 #include "GUIDialogYesNo.h"
 #include "ServiceBroker.h"
+#include "URL.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
+#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
@@ -28,69 +33,147 @@ using namespace KODI;
 bool CGUIDialogSimpleMenu::ShowPlaylistSelection(
     const CFileItem& item,
     CFileItem& selectedItem,
-    const CFileItemList& items,
+    const CFileItemList& playlistItems,
     const std::vector<CVideoDatabase::PlaylistInfo>& usedPlaylists)
 {
   CGUIDialogSelect* dialog{CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
       WINDOW_DIALOG_SELECT)};
 
-  dialog->Reset();
-  dialog->SetHeading(CVariant{25006}); // Select playback item
-  dialog->SetItems(items);
-  dialog->SetUseDetails(true);
-  dialog->Open();
-
-  if (dialog->GetSelectedItem() < 0)
+  if (!dialog)
   {
-    CLog::LogF(LOGDEBUG, "User aborted playlist selection");
+    CLog::LogF(LOGERROR, "Unable to get WINDOW_DIALOG_SELECT instance");
     return false;
   }
 
-  // If item is not folder (ie. all titles)
-  selectedItem = *dialog->GetSelectedFileItem();
-  if (!selectedItem.IsFolder())
+  CFileItemList items;
+  items.Copy(playlistItems);
+
+  bool chapters{false};
+  while (true)
   {
-    // See if already selected
-    if (!usedPlaylists.empty())
+    dialog->Reset();
+    dialog->SetHeading(CVariant{25006}); // Select playback item
+    dialog->SetItems(items);
+    dialog->SetUseDetails(true);
+    if (chapters)
     {
-      // See if playlist already used
-      const int newPlaylist{selectedItem.GetProperty("bluray_playlist").asInteger32(0)};
-      auto matchingPlaylists{usedPlaylists |
-                             std::views::filter([newPlaylist](const CVideoDatabase::PlaylistInfo& p)
-                                                { return p.playlist == newPlaylist; })};
-
-      if (std::ranges::distance(matchingPlaylists) > 0)
-      {
-        // Warn that this playlist is already associated with an episode
-        if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{559}, CVariant{25015}))
-          return false;
-
-        std::string base{item.GetDynPath()};
-        if (URIUtils::IsBlurayPath(base))
-          base = URIUtils::GetDiscFile(base);
-
-        CVideoDatabase db;
-        if (!db.Open())
-        {
-          CLog::LogF(LOGERROR, "Failed to open video database");
-          return false;
-        }
-
-        for (const auto& it : matchingPlaylists)
-        {
-          // Revert file to base file (BDMV/ISO)
-          db.BeginTransaction();
-          if (db.SetFileForMedia(base, it.mediaType, it.idMedia,
-                                 CVideoDatabase::FileRecord{
-                                     .m_idFile = it.idFile,
-                                     .m_dateAdded = item.GetVideoInfoTag()->m_dateAdded}) > 0)
-            db.CommitTransaction();
-          else
-            db.RollbackTransaction();
-        }
-        db.Close();
-      }
+      dialog->SetMultiSelection(true);
+      dialog->SetEnforceContiguousSelection(true);
     }
+    else
+    {
+      dialog->EnableButton2(true, 21486); // Chapters
+      dialog->SetSelectChapters(true);
+      dialog->SetUseExtraAsOK(true);
+    }
+    dialog->Open();
+
+    if (dialog->GetSelectedItem() < 0)
+    {
+      CLog::LogF(LOGDEBUG, "User aborted playlist selection");
+      return false;
+    }
+
+    selectedItem = *dialog->GetSelectedFileItem();
+    if (selectedItem.IsFolder())
+      return true; // If item is a folder (ie. all titles)
+
+    if (chapters)
+    {
+      // Generate bluray:// path from selected chapters
+      std::vector<int> selectedItems{dialog->GetSelectedItems()};
+      int startChapter{items[selectedItems.front()]->GetProperty("chapter").asInteger32()};
+      int endChapter{items[selectedItems.back()]->GetProperty("chapter").asInteger32()};
+
+      CURL url{selectedItem.GetPath()};
+      std::string file{url.GetFileName()};
+      file = file.substr(0, file.find("/chapter/"));
+      url.SetFileName(file);
+      url.SetOptions("?chapters=" + std::to_string(startChapter) + "-" +
+                     std::to_string(endChapter));
+      selectedItem.SetPath(url.Get());
+      return true;
+    }
+
+    if (dialog->IsButton2Pressed()) // Chapter
+    {
+      // Generate chapter list
+      items.Clear();
+      for (const auto& chapter : selectedItem.GetVideoInfoTag()->GetChapters())
+      {
+        const auto chapterItem{std::make_shared<CFileItem>(
+            URIUtils::AddFileToFolder(selectedItem.GetDynPath(), "chapter",
+                                      std::to_string(chapter.chapter)),
+            false)};
+        chapterItem->SetLabel(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(21396) /* Chapter */ +
+            " " + std::to_string(chapter.chapter));
+        chapterItem->SetLabel2(
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(335) /* Start */ +
+            " " +
+            StringUtils::SecondsToTimeString(static_cast<int>(chapter.start.count() / 1000),
+                                             TIME_FORMAT_HH_MM_SS) +
+            " - " +
+            CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(180) /* Duration */ +
+            " " +
+            StringUtils::SecondsToTimeString(static_cast<int>(chapter.duration.count() / 1000),
+                                             TIME_FORMAT_HH_MM_SS));
+        chapterItem->GetVideoInfoTag()->m_streamDetails =
+            selectedItem.GetVideoInfoTag()->m_streamDetails;
+        chapterItem->GetVideoInfoTag()->SetChapters(selectedItem.GetVideoInfoTag()->GetChapters());
+        chapterItem->SetArt("icon", "DefaultStudios.png");
+        chapterItem->SetProperty("chapter", chapter.chapter);
+        items.Add(chapterItem);
+      }
+      chapters = true;
+      continue;
+    }
+
+    // See if menu selected
+    if (URIUtils::GetFileName(selectedItem.GetPath()) == "menu")
+      return true;
+
+    if (usedPlaylists.empty())
+      return true; // No used playlists
+
+    // See if playlist already used
+    const int newPlaylist{selectedItem.GetProperty("bluray_playlist").asInteger32(0)};
+    auto matchingPlaylists{usedPlaylists |
+                           std::views::filter([newPlaylist](const CVideoDatabase::PlaylistInfo& p)
+                                              { return p.playlist == newPlaylist; })};
+
+    if (std::ranges::distance(matchingPlaylists) > 0)
+    {
+      // Warn that this playlist is already associated with an episode
+      if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{559}, CVariant{25015}))
+        return false;
+
+      std::string base{item.GetDynPath()};
+      if (URIUtils::IsBlurayPath(base))
+        base = URIUtils::GetDiscFile(base);
+
+      CVideoDatabase db;
+      if (!db.Open())
+      {
+        CLog::LogF(LOGERROR, "Failed to open video database");
+        return false;
+      }
+
+      for (const auto& it : matchingPlaylists)
+      {
+        // Revert file to base file (BDMV/ISO)
+        db.BeginTransaction();
+        if (db.SetFileForMedia(
+                base, it.mediaType, it.idMedia,
+                CVideoDatabase::FileRecord{.m_idFile = it.idFile,
+                                           .m_dateAdded = item.GetVideoInfoTag()->m_dateAdded}) > 0)
+          db.CommitTransaction();
+        else
+          db.RollbackTransaction();
+      }
+      db.Close();
+    }
+
+    return true;
   }
-  return true;
 }

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -900,6 +900,24 @@ void CDiscDirectoryHelper::FindSpecials(const PlaylistMap& playlists)
 
 namespace
 {
+std::vector<ChapterInfo> GetChapterInfo(const PlaylistInformation& playlistInformation)
+{
+  if (playlistInformation.chapters.empty())
+    return {};
+
+  std::vector<ChapterInfo> chapterInfo;
+  for (unsigned int i = 0; i < playlistInformation.chapters.size() - 1; ++i)
+  {
+    const std::chrono::milliseconds start = playlistInformation.chapters[i];
+    const std::chrono::milliseconds duration = playlistInformation.chapters[i + 1] - start;
+    chapterInfo.push_back({i + 1, start, duration});
+  }
+  chapterInfo.push_back({static_cast<unsigned int>(playlistInformation.chapters.size()),
+                         playlistInformation.chapters.back(),
+                         playlistInformation.duration - playlistInformation.chapters.back()});
+  return chapterInfo;
+}
+
 void GenerateItem(const CURL& url,
                   const std::shared_ptr<CFileItem>& item,
                   unsigned int playlist,
@@ -926,8 +944,10 @@ void GenerateItem(const CURL& url,
   item->SetPath(path.Get());
 
   CVideoInfoTag* itemTag{item->GetVideoInfoTag()};
-  itemTag->SetDuration(static_cast<int>(duration.count()));
+  itemTag->SetDuration(static_cast<int>(duration.count() / 1000));
   item->SetProperty("bluray_playlist", playlist);
+
+  itemTag->SetChapters(GetChapterInfo(it->second));
 
   // Get episode title
   const std::string& title{episode.strTitle};

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -22,7 +22,6 @@
 class CFileItem;
 class CFileItemList;
 class CURL;
-class CVideoInfoTag;
 
 namespace XFILE
 {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3412,10 +3412,11 @@ void CVideoDatabase::GetEpisodesByBlurayPath(const std::string& path,
     CURL url{path};
     url.SetFileName("");
     const std::string blurayPath{URIUtils::AddFileToFolder(url.Get(), "BDMV", "PLAYLIST", "")};
-    const std::string sql{
-        PrepareSQL("select idFile from episode_view "
-                   "where (strPath = '%s' and strFileName = '%s') or strPath = '%s'",
-                   basePath.c_str(), baseFile.c_str(), blurayPath.c_str())};
+    const std::string sql{PrepareSQL("SELECT idFile FROM episode_view "
+                                     "WHERE (strPath = '%s' AND strFileName = '%s') "
+                                     "OR SUBSTR(strPath, 1, %i) = '%s'",
+                                     basePath.c_str(), baseFile.c_str(),
+                                     static_cast<int>(blurayPath.size()), blurayPath.c_str())};
     m_pDS->query(sql);
     if (!m_pDS->eof())
       return GetEpisodesByFileId(m_pDS->fv("idFile").get_asInt(), episodes);

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -101,6 +101,7 @@ void CVideoInfoTag::Reset()
   m_parsedDetails = 0;
   m_coverArt.clear();
   m_updateSetOverview = true;
+  m_chapters.clear();
 }
 
 bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathInfo, const TiXmlElement *additionalNode)
@@ -518,6 +519,9 @@ void CVideoInfoTag::Merge(CVideoInfoTag& other)
   m_hasVideoVersions = other.m_hasVideoVersions;
   m_hasVideoExtras = other.m_hasVideoExtras;
   m_isDefaultVideoVersion = other.m_isDefaultVideoVersion;
+
+  if (!other.m_chapters.empty())
+    m_chapters = other.m_chapters;
 }
 
 void CVideoInfoTag::Archive(CArchive& ar)
@@ -2109,4 +2113,24 @@ void CVideoInfoTag::SetHasVideoExtras(bool hasExtras)
 void CVideoInfoTag::SetIsDefaultVideoVersion(bool isDefaultVideoVersion)
 {
   m_isDefaultVideoVersion = isDefaultVideoVersion;
+}
+
+bool CVideoInfoTag::HasChapters() const
+{
+  return !m_chapters.empty();
+}
+
+std::vector<ChapterInfo>& CVideoInfoTag::GetChapters()
+{
+  return m_chapters;
+}
+
+const std::vector<ChapterInfo>& CVideoInfoTag::GetChapters() const
+{
+  return m_chapters;
+}
+
+void CVideoInfoTag::SetChapters(const std::vector<ChapterInfo>& chapters)
+{
+  m_chapters = chapters;
 }

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -17,6 +17,7 @@
 #include "utils/StreamDetails.h"
 #include "video/Bookmark.h"
 
+#include <chrono>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -39,6 +40,13 @@ struct SActorInfo
   CScraperUrl thumbUrl;
   std::string thumb;
   int order{-1};
+};
+
+struct ChapterInfo
+{
+  unsigned int chapter{0}; // 1 based chapter number
+  std::chrono::milliseconds start{0};
+  std::chrono::milliseconds duration{0};
 };
 
 class CRating
@@ -379,6 +387,25 @@ public:
    */
   virtual bool SetResumePoint(double timeInSeconds, double totalTimeInSeconds, const std::string &playerState);
 
+  /*!
+   * @brief Set the video (bluray playlist) chapter information.
+   * @param chapters Vector of ChapterInfo containing information about the chapter timing.
+   */
+  void SetChapters(const std::vector<ChapterInfo>& chapters);
+
+  /*!
+   * @brief Get the chapter information (currently only set for bluray playlists).
+   * @return Vector of ChapterInfo containing information about the chapter timing.
+   */
+  std::vector<ChapterInfo>& GetChapters();
+  const std::vector<ChapterInfo>& GetChapters() const;
+
+  /*!
+   * @brief Indicate if the video (bluray playlist) has chapters.
+   * @return true if the bluray playlist has chapters, false otherwise.
+   */
+  bool HasChapters() const;
+
   const std::string& GetOriginalLanguage() const { return m_originalLanguage; }
 
   std::string m_basePath; // the base path of the video, for folder-based lookups
@@ -439,6 +466,7 @@ public:
   int m_relevance; // Used for actors' number of appearances
   int m_parsedDetails;
   std::vector<EmbeddedArtInfo> m_coverArt; ///< art information
+  std::vector<ChapterInfo> m_chapters;
 
   // TODO: cannot be private, because of 'struct SDbTableOffsets'
   unsigned int m_duration; ///< duration in seconds


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Extends the bluray vfs to allow playback at chapter level. Utilises EDLs to play just the selected chapter(s).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Some TV show blurays have a single playlist with each chapter am episode (eg. anime).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
