### PR TITLE
Settings Update Improvements V2

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -25,6 +25,7 @@ xbmc/playlists/test               test/playlists
 xbmc/pvr/channels/test            test/pvrchannels
 xbmc/rendering/capture/test       test/rendering_capture
 xbmc/settings/test                test/settings
+xbmc/settings/lib/test            test/lib/settings
 xbmc/test                         test
 xbmc/threads/test                 test/threads
 xbmc/utils/i18n/test              test/utils/i18n

--- a/xbmc/addons/settings/SettingUrlEncodedString.cpp
+++ b/xbmc/addons/settings/SettingUrlEncodedString.cpp
@@ -15,19 +15,20 @@ namespace ADDON
 {
 
 CSettingUrlEncodedString::CSettingUrlEncodedString(
-    const std::string& id, CSettingsManager* settingsManager /* = nullptr */)
+    std::string_view id, CSettingsManager* settingsManager /* = nullptr */)
   : CSettingString(id, settingsManager)
 { }
 
 CSettingUrlEncodedString::CSettingUrlEncodedString(
-    const std::string& id,
+    std::string_view id,
     int label,
     const std::string& value,
     CSettingsManager* settingsManager /* = nullptr */)
   : CSettingString(id, label, value, settingsManager)
 { }
 
-CSettingUrlEncodedString::CSettingUrlEncodedString(const std::string &id, const CSettingUrlEncodedString &setting)
+CSettingUrlEncodedString::CSettingUrlEncodedString(std::string_view id,
+                                                   const CSettingUrlEncodedString& setting)
   : CSettingString(id, setting)
 { }
 

--- a/xbmc/addons/settings/SettingUrlEncodedString.h
+++ b/xbmc/addons/settings/SettingUrlEncodedString.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2017-2018 Team Kodi
+ *  Copyright (C) 2017-2018, 2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -17,16 +17,19 @@ namespace ADDON
   class CSettingUrlEncodedString : public CSettingString
   {
   public:
-    explicit CSettingUrlEncodedString(const std::string& id,
+    explicit CSettingUrlEncodedString(std::string_view id,
                                       CSettingsManager* settingsManager = nullptr);
-    CSettingUrlEncodedString(const std::string& id,
+    CSettingUrlEncodedString(std::string_view id,
                              int label,
                              const std::string& value,
                              CSettingsManager* settingsManager = nullptr);
-    CSettingUrlEncodedString(const std::string &id, const CSettingUrlEncodedString &setting);
+    CSettingUrlEncodedString(std::string_view id, const CSettingUrlEncodedString& setting);
     ~CSettingUrlEncodedString() override = default;
 
-    SettingPtr Clone(const std::string &id) const override { return std::make_shared<CSettingUrlEncodedString>(id, *this); }
+    SettingPtr Clone(std::string_view id) const override
+    {
+      return std::make_shared<CSettingUrlEncodedString>(id, *this);
+    }
 
     std::string GetDecodedValue() const;
     bool SetDecodedValue(const std::string& decodedValue);

--- a/xbmc/settings/SettingAddon.cpp
+++ b/xbmc/settings/SettingAddon.cpp
@@ -18,21 +18,26 @@
 
 #include <mutex>
 
-CSettingAddon::CSettingAddon(const std::string &id, CSettingsManager *settingsManager /* = nullptr */)
+CSettingAddon::CSettingAddon(std::string_view id, CSettingsManager* settingsManager /* = nullptr */)
   : CSettingString(id, settingsManager)
-{ }
+{
+}
 
-CSettingAddon::CSettingAddon(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager /* = nullptr */)
+CSettingAddon::CSettingAddon(std::string_view id,
+                             int label,
+                             const std::string& value,
+                             CSettingsManager* settingsManager /* = nullptr */)
   : CSettingString(id, label, value, settingsManager)
-{ }
+{
+}
 
-CSettingAddon::CSettingAddon(const std::string &id, const CSettingAddon &setting)
+CSettingAddon::CSettingAddon(std::string_view id, const CSettingAddon& setting)
   : CSettingString(id, setting)
 {
   copyaddontype(setting);
 }
 
-SettingPtr CSettingAddon::Clone(const std::string &id) const
+SettingPtr CSettingAddon::Clone(std::string_view id) const
 {
   return std::make_shared<CSettingAddon>(id, *this);
 }

--- a/xbmc/settings/SettingAddon.h
+++ b/xbmc/settings/SettingAddon.h
@@ -20,12 +20,15 @@ class TiXmlNode;
 class CSettingAddon : public CSettingString
 {
 public:
-  CSettingAddon(const std::string &id, CSettingsManager *settingsManager = nullptr);
-  CSettingAddon(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager = nullptr);
-  CSettingAddon(const std::string &id, const CSettingAddon &setting);
+  CSettingAddon(std::string_view id, CSettingsManager* settingsManager = nullptr);
+  CSettingAddon(std::string_view id,
+                int label,
+                const std::string& value,
+                CSettingsManager* settingsManager = nullptr);
+  CSettingAddon(std::string_view id, const CSettingAddon& setting);
   ~CSettingAddon() override = default;
 
-  SettingPtr Clone(const std::string &id) const override;
+  SettingPtr Clone(std::string_view id) const override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
 

--- a/xbmc/settings/SettingDateTime.cpp
+++ b/xbmc/settings/SettingDateTime.cpp
@@ -24,11 +24,11 @@ CSettingDate::CSettingDate(const std::string& id,
   : CSettingString(id, label, value, settingsManager)
 { }
 
-CSettingDate::CSettingDate(const std::string &id, const CSettingDate &setting)
+CSettingDate::CSettingDate(std::string_view id, const CSettingDate& setting)
   : CSettingString(id, setting)
 { }
 
-SettingPtr CSettingDate::Clone(const std::string &id) const
+SettingPtr CSettingDate::Clone(std::string_view id) const
 {
   return std::make_shared<CSettingDate>(id, *this);
 }
@@ -53,22 +53,22 @@ bool CSettingDate::SetDate(const CDateTime& date)
   return SetValue(date.GetAsDBDate());
 }
 
-CSettingTime::CSettingTime(const std::string& id, CSettingsManager* settingsManager /* = nullptr */)
+CSettingTime::CSettingTime(std::string_view id, CSettingsManager* settingsManager /* = nullptr */)
   : CSettingString(id, settingsManager)
 { }
 
-CSettingTime::CSettingTime(const std::string& id,
+CSettingTime::CSettingTime(std::string_view id,
                            int label,
                            const std::string& value,
                            CSettingsManager* settingsManager /* = nullptr */)
   : CSettingString(id, label, value, settingsManager)
 { }
 
-CSettingTime::CSettingTime(const std::string &id, const CSettingTime &setting)
+CSettingTime::CSettingTime(std::string_view id, const CSettingTime& setting)
   : CSettingString(id, setting)
 { }
 
-SettingPtr CSettingTime::Clone(const std::string &id) const
+SettingPtr CSettingTime::Clone(std::string_view id) const
 {
   return std::make_shared<CSettingTime>(id, *this);
 }

--- a/xbmc/settings/SettingDateTime.h
+++ b/xbmc/settings/SettingDateTime.h
@@ -20,10 +20,10 @@ public:
                int label,
                const std::string& value,
                CSettingsManager* settingsManager = nullptr);
-  CSettingDate(const std::string &id, const CSettingDate &setting);
+  CSettingDate(std::string_view id, const CSettingDate& setting);
   ~CSettingDate() override = default;
 
-  SettingPtr Clone(const std::string &id) const override;
+  SettingPtr Clone(std::string_view id) const override;
 
   bool CheckValidity(const std::string &value) const override;
 
@@ -34,15 +34,15 @@ public:
 class CSettingTime : public CSettingString
 {
 public:
-  CSettingTime(const std::string& id, CSettingsManager* settingsManager = nullptr);
-  CSettingTime(const std::string& id,
+  CSettingTime(std::string_view id, CSettingsManager* settingsManager = nullptr);
+  CSettingTime(std::string_view id,
                int label,
                const std::string& value,
                CSettingsManager* settingsManager = nullptr);
-  CSettingTime(const std::string &id, const CSettingTime &setting);
+  CSettingTime(std::string_view id, const CSettingTime& setting);
   ~CSettingTime() override = default;
 
-  SettingPtr Clone(const std::string &id) const override;
+  SettingPtr Clone(std::string_view id) const override;
 
   bool CheckValidity(const std::string &value) const override;
 

--- a/xbmc/settings/SettingPath.cpp
+++ b/xbmc/settings/SettingPath.cpp
@@ -22,21 +22,26 @@ namespace
 constexpr const char* XML_ELM_CONSTRAINTS = "constraints";
 } // unnamed namespace
 
-CSettingPath::CSettingPath(const std::string &id, CSettingsManager *settingsManager /* = nullptr */)
+CSettingPath::CSettingPath(std::string_view id, CSettingsManager* settingsManager /* = nullptr */)
   : CSettingString(id, settingsManager)
-{ }
+{
+}
 
-CSettingPath::CSettingPath(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager /* = nullptr */)
+CSettingPath::CSettingPath(std::string_view id,
+                           int label,
+                           const std::string& value,
+                           CSettingsManager* settingsManager /* = nullptr */)
   : CSettingString(id, label, value, settingsManager)
-{ }
+{
+}
 
-CSettingPath::CSettingPath(const std::string &id, const CSettingPath &setting)
+CSettingPath::CSettingPath(std::string_view id, const CSettingPath& setting)
   : CSettingString(id, setting)
 {
   copy(setting);
 }
 
-SettingPtr CSettingPath::Clone(const std::string &id) const
+SettingPtr CSettingPath::Clone(std::string_view id) const
 {
   return std::make_shared<CSettingPath>(id, *this);
 }

--- a/xbmc/settings/SettingPath.h
+++ b/xbmc/settings/SettingPath.h
@@ -19,12 +19,15 @@ class TiXmlNode;
 class CSettingPath : public CSettingString
 {
 public:
-  CSettingPath(const std::string &id, CSettingsManager *settingsManager = nullptr);
-  CSettingPath(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager = nullptr);
-  CSettingPath(const std::string &id, const CSettingPath &setting);
+  CSettingPath(std::string_view id, CSettingsManager* settingsManager = nullptr);
+  CSettingPath(std::string_view id,
+               int label,
+               const std::string& value,
+               CSettingsManager* settingsManager = nullptr);
+  CSettingPath(std::string_view id, const CSettingPath& setting);
   ~CSettingPath() override = default;
 
-  SettingPtr Clone(const std::string &id) const override;
+  SettingPtr Clone(std::string_view id) const override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
   bool SetValue(const std::string &value) override;

--- a/xbmc/settings/SettingsValueXmlSerializer.cpp
+++ b/xbmc/settings/SettingsValueXmlSerializer.cpp
@@ -73,15 +73,15 @@ void CSettingsValueXmlSerializer::SerializeGroup(TiXmlNode* parent,
     SerializeSetting(parent, setting);
 }
 
-void CSettingsValueXmlSerializer::SerializeSetting(TiXmlNode* parent,
-                                                   const std::shared_ptr<CSetting>& setting) const
+bool CSettingsValueXmlSerializer::SerializeSetting(TiXmlNode* parent,
+                                                   const std::shared_ptr<CSetting>& setting)
 {
   if (!setting)
-    return;
+    return true;
 
   // ignore references and action settings (which don't have a value)
   if (setting->IsReference() || setting->GetType() == SettingType::Action)
-    return;
+    return true;
 
   TiXmlElement settingElement(SETTING_XML_ELM_SETTING);
   settingElement.SetAttribute(SETTING_XML_ATTR_ID, setting->GetId());
@@ -92,11 +92,13 @@ void CSettingsValueXmlSerializer::SerializeSetting(TiXmlNode* parent,
 
   // add the value
   TiXmlText value(setting->ToString());
-  settingElement.InsertEndChild(value);
 
-  if (!parent->InsertEndChild(settingElement))
+  if (settingElement.InsertEndChild(value) == nullptr ||
+      parent->InsertEndChild(settingElement) == nullptr)
   {
     CLog::Log(LOGWARNING, "CSettingsValueXmlSerializer: unable to write <{} id=\"{}\"> tag",
               SETTING_XML_ELM_SETTING, setting->GetId());
+    return false;
   }
+  return true;
 }

--- a/xbmc/settings/SettingsValueXmlSerializer.h
+++ b/xbmc/settings/SettingsValueXmlSerializer.h
@@ -26,11 +26,11 @@ public:
 
   // implementation of ISettingsValueSerializer
   std::string SerializeValues(const CSettingsManager* settingsManager) const override;
+  static bool SerializeSetting(TiXmlNode* parent, const std::shared_ptr<CSetting>& setting);
 
 private:
   void SerializeSection(TiXmlNode* parent, const std::shared_ptr<CSettingSection>& section) const;
   void SerializeCategory(TiXmlNode* parent,
                          const std::shared_ptr<CSettingCategory>& category) const;
   void SerializeGroup(TiXmlNode* parent, const std::shared_ptr<CSettingGroup>& group) const;
-  void SerializeSetting(TiXmlNode* parent, const std::shared_ptr<CSetting>& setting) const;
 };

--- a/xbmc/settings/lib/CMakeLists.txt
+++ b/xbmc/settings/lib/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES ISetting.cpp
             SettingRequirement.cpp
             SettingSection.cpp
             SettingsManager.cpp
+            SettingsMigration.cpp
             SettingUpdate.cpp)
 
 set(HEADERS ISetting.h
@@ -15,6 +16,7 @@ set(HEADERS ISetting.h
             ISettingControlCreator.h
             ISettingCreator.h
             ISettingsHandler.h
+            ISettingsMigrationStep.h
             ISettingsValueSerializer.h
             Setting.h
             SettingCategoryAccess.h
@@ -25,6 +27,7 @@ set(HEADERS ISetting.h
             SettingRequirement.h
             SettingSection.h
             SettingsManager.h
+            SettingsMigration.h
             SettingType.h
             SettingUpdate.h)
 

--- a/xbmc/settings/lib/ISetting.cpp
+++ b/xbmc/settings/lib/ISetting.cpp
@@ -14,11 +14,12 @@
 
 #include <string>
 
-ISetting::ISetting(const std::string &id, CSettingsManager *settingsManager /* = nullptr */)
-  : m_id(id)
-  , m_settingsManager(settingsManager)
-  , m_requirementCondition(settingsManager)
-{ }
+ISetting::ISetting(std::string_view id, CSettingsManager* settingsManager /* = nullptr */)
+  : m_id(id),
+    m_settingsManager(settingsManager),
+    m_requirementCondition(settingsManager)
+{
+}
 
 bool ISetting::Deserialize(const TiXmlNode *node, bool update /* = false */)
 {

--- a/xbmc/settings/lib/ISetting.h
+++ b/xbmc/settings/lib/ISetting.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2013-2018 Team Kodi
+ *  Copyright (C) 2013-2018, 2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -11,6 +11,7 @@
 #include "SettingRequirement.h"
 
 #include <string>
+#include <string_view>
 
 class CSettingsManager;
 class TiXmlNode;
@@ -28,7 +29,7 @@ public:
    \param id Identifier of the setting object
    \param settingsManager Reference to the settings manager
    */
-  ISetting(const std::string &id, CSettingsManager *settingsManager = nullptr);
+  ISetting(std::string_view id, CSettingsManager* settingsManager = nullptr);
   virtual ~ISetting() = default;
 
   /*!

--- a/xbmc/settings/lib/ISettingsMigrationStep.h
+++ b/xbmc/settings/lib/ISettingsMigrationStep.h
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/XBMCTinyXML.h"
+
+class ISettingsMigrationStep
+{
+public:
+  virtual ~ISettingsMigrationStep() = default;
+  virtual int TargetVersion() const = 0;
+  virtual bool Apply(TiXmlElement* root) = 0;
+};

--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -63,14 +63,14 @@ bool DeserializeOptionsSort(const TiXmlElement* optionsElement, SettingOptionsSo
 
 Logger CSetting::s_logger;
 
-CSetting::CSetting(const std::string& id, CSettingsManager* settingsManager /* = nullptr */)
+CSetting::CSetting(std::string_view id, CSettingsManager* settingsManager /* = nullptr */)
   : ISetting(id, settingsManager)
 {
   if (!s_logger)
     s_logger = CServiceBroker::GetLogging().GetLogger("CSetting");
 }
 
-CSetting::CSetting(const std::string& id, const CSetting& setting)
+CSetting::CSetting(std::string_view id, const CSetting& setting)
   : CSetting(id, setting.m_settingsManager)
 {
   Copy(setting);
@@ -335,16 +335,17 @@ void CSetting::Copy(const CSetting &setting)
 
 Logger CSettingList::s_logger;
 
-CSettingList::CSettingList(const std::string& id,
+CSettingList::CSettingList(std::string_view id,
                            std::shared_ptr<CSetting> settingDefinition,
                            CSettingsManager* settingsManager /* = nullptr */)
-  : CSetting(id, settingsManager), m_definition(std::move(settingDefinition))
+  : CSetting(id, settingsManager),
+    m_definition(std::move(settingDefinition))
 {
   if (!s_logger)
     s_logger = CServiceBroker::GetLogging().GetLogger("CSettingList");
 }
 
-CSettingList::CSettingList(const std::string& id,
+CSettingList::CSettingList(std::string_view id,
                            std::shared_ptr<CSetting> settingDefinition,
                            int label,
                            CSettingsManager* settingsManager /* = nullptr */)
@@ -353,13 +354,12 @@ CSettingList::CSettingList(const std::string& id,
   SetLabel(label);
 }
 
-CSettingList::CSettingList(const std::string &id, const CSettingList &setting)
-  : CSetting(id, setting)
+CSettingList::CSettingList(std::string_view id, const CSettingList& setting) : CSetting(id, setting)
 {
   copy(setting);
 }
 
-SettingPtr CSettingList::Clone(const std::string &id) const
+SettingPtr CSettingList::Clone(std::string_view id) const
 {
   if (!m_definition)
     return nullptr;
@@ -655,22 +655,24 @@ std::string CSettingList::toString(const SettingList &values) const
 
 Logger CSettingBool::s_logger;
 
-CSettingBool::CSettingBool(const std::string& id, CSettingsManager* settingsManager /* = nullptr */)
+CSettingBool::CSettingBool(std::string_view id, CSettingsManager* settingsManager /* = nullptr */)
   : CSettingBool(id, DefaultLabel, DefaultValue, settingsManager)
 {
 }
 
-CSettingBool::CSettingBool(const std::string& id, const CSettingBool& setting)
+CSettingBool::CSettingBool(std::string_view id, const CSettingBool& setting)
   : CSettingBool(id, setting.m_settingsManager)
 {
   copy(setting);
 }
 
-CSettingBool::CSettingBool(const std::string& id,
+CSettingBool::CSettingBool(std::string_view id,
                            int label,
                            bool value,
                            CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager), m_value(value), m_default(value)
+  : CTraitedSetting(id, settingsManager),
+    m_value(value),
+    m_default(value)
 {
   SetLabel(label);
 
@@ -678,7 +680,7 @@ CSettingBool::CSettingBool(const std::string& id,
     s_logger = CServiceBroker::GetLogging().GetLogger("CSettingBool");
 }
 
-SettingPtr CSettingBool::Clone(const std::string &id) const
+SettingPtr CSettingBool::Clone(std::string_view id) const
 {
   return std::make_shared<CSettingBool>(id, *this);
 }
@@ -803,17 +805,18 @@ bool CSettingBool::fromString(const std::string &strValue, bool &value) const
 
 Logger CSettingInt::s_logger;
 
-CSettingInt::CSettingInt(const std::string& id, CSettingsManager* settingsManager /* = nullptr */)
+CSettingInt::CSettingInt(std::string_view id, CSettingsManager* settingsManager /* = nullptr */)
   : CSettingInt(id, DefaultLabel, DefaultValue, settingsManager)
-{ }
+{
+}
 
-CSettingInt::CSettingInt(const std::string& id, const CSettingInt& setting)
+CSettingInt::CSettingInt(std::string_view id, const CSettingInt& setting)
   : CSettingInt(id, setting.m_settingsManager)
 {
   copy(setting);
 }
 
-CSettingInt::CSettingInt(const std::string& id,
+CSettingInt::CSettingInt(std::string_view id,
                          int label,
                          int value,
                          CSettingsManager* settingsManager /* = nullptr */)
@@ -822,7 +825,7 @@ CSettingInt::CSettingInt(const std::string& id,
   SetLabel(label);
 }
 
-CSettingInt::CSettingInt(const std::string& id,
+CSettingInt::CSettingInt(std::string_view id,
                          int label,
                          int value,
                          int minimum,
@@ -842,7 +845,7 @@ CSettingInt::CSettingInt(const std::string& id,
     s_logger = CServiceBroker::GetLogging().GetLogger("CSettingInt");
 }
 
-CSettingInt::CSettingInt(const std::string& id,
+CSettingInt::CSettingInt(std::string_view id,
                          int label,
                          int value,
                          const TranslatableIntegerSettingOptions& options,
@@ -852,7 +855,7 @@ CSettingInt::CSettingInt(const std::string& id,
   SetTranslatableOptions(options);
 }
 
-SettingPtr CSettingInt::Clone(const std::string &id) const
+SettingPtr CSettingInt::Clone(std::string_view id) const
 {
   return std::make_shared<CSettingInt>(id, *this);
 }
@@ -1152,18 +1155,19 @@ bool CSettingInt::fromString(const std::string &strValue, int &value)
 
 Logger CSettingNumber::s_logger;
 
-CSettingNumber::CSettingNumber(const std::string& id,
+CSettingNumber::CSettingNumber(std::string_view id,
                                CSettingsManager* settingsManager /* = nullptr */)
   : CSettingNumber(id, DefaultLabel, DefaultValue, settingsManager)
-{ }
+{
+}
 
-CSettingNumber::CSettingNumber(const std::string& id, const CSettingNumber& setting)
+CSettingNumber::CSettingNumber(std::string_view id, const CSettingNumber& setting)
   : CSettingNumber(id, setting.m_settingsManager)
 {
   copy(setting);
 }
 
-CSettingNumber::CSettingNumber(const std::string& id,
+CSettingNumber::CSettingNumber(std::string_view id,
                                int label,
                                float value,
                                CSettingsManager* settingsManager /* = nullptr */)
@@ -1171,7 +1175,7 @@ CSettingNumber::CSettingNumber(const std::string& id,
 {
 }
 
-CSettingNumber::CSettingNumber(const std::string& id,
+CSettingNumber::CSettingNumber(std::string_view id,
                                int label,
                                float value,
                                float minimum,
@@ -1191,7 +1195,7 @@ CSettingNumber::CSettingNumber(const std::string& id,
     s_logger = CServiceBroker::GetLogging().GetLogger("CSettingNumber");
 }
 
-SettingPtr CSettingNumber::Clone(const std::string &id) const
+SettingPtr CSettingNumber::Clone(std::string_view id) const
 {
   return std::make_shared<CSettingNumber>(id, *this);
 }
@@ -1355,22 +1359,25 @@ bool CSettingNumber::fromString(const std::string &strValue, double &value)
 const CSettingString::Value CSettingString::DefaultValue;
 Logger CSettingString::s_logger;
 
-CSettingString::CSettingString(const std::string& id,
+CSettingString::CSettingString(std::string_view id,
                                CSettingsManager* settingsManager /* = nullptr */)
   : CSettingString(id, DefaultLabel, DefaultValue, settingsManager)
-{ }
+{
+}
 
-CSettingString::CSettingString(const std::string& id, const CSettingString& setting)
+CSettingString::CSettingString(std::string_view id, const CSettingString& setting)
   : CSettingString(id, setting.m_settingsManager)
 {
   copy(setting);
 }
 
-CSettingString::CSettingString(const std::string& id,
+CSettingString::CSettingString(std::string_view id,
                                int label,
                                const std::string& value,
                                CSettingsManager* settingsManager /* = nullptr */)
-  : CTraitedSetting(id, settingsManager), m_value(value), m_default(value)
+  : CTraitedSetting(id, settingsManager),
+    m_value(value),
+    m_default(value)
 {
   SetLabel(label);
 
@@ -1378,7 +1385,7 @@ CSettingString::CSettingString(const std::string& id,
     s_logger = CServiceBroker::GetLogging().GetLogger("CSettingString");
 }
 
-SettingPtr CSettingString::Clone(const std::string &id) const
+SettingPtr CSettingString::Clone(std::string_view id) const
 {
   return std::make_shared<CSettingString>(id, *this);
 }
@@ -1627,12 +1634,13 @@ void CSettingString::copy(const CSettingString &setting)
 
 Logger CSettingAction::s_logger;
 
-CSettingAction::CSettingAction(const std::string& id,
+CSettingAction::CSettingAction(std::string_view id,
                                CSettingsManager* settingsManager /* = nullptr */)
   : CSettingAction(id, DefaultLabel, settingsManager)
-{ }
+{
+}
 
-CSettingAction::CSettingAction(const std::string& id,
+CSettingAction::CSettingAction(std::string_view id,
                                int label,
                                CSettingsManager* settingsManager /* = nullptr */)
   : CSetting(id, settingsManager)
@@ -1643,13 +1651,13 @@ CSettingAction::CSettingAction(const std::string& id,
     s_logger = CServiceBroker::GetLogging().GetLogger("CSettingAction");
 }
 
-CSettingAction::CSettingAction(const std::string& id, const CSettingAction& setting)
+CSettingAction::CSettingAction(std::string_view id, const CSettingAction& setting)
   : CSettingAction(id, setting.m_settingsManager)
 {
   copy(setting);
 }
 
-SettingPtr CSettingAction::Clone(const std::string &id) const
+SettingPtr CSettingAction::Clone(std::string_view id) const
 {
   return std::make_shared<CSettingAction>(id, *this);
 }

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -50,11 +50,11 @@ class CSetting : public ISetting,
                  public std::enable_shared_from_this<CSetting>
 {
 public:
-  CSetting(const std::string& id, CSettingsManager* settingsManager = nullptr);
-  CSetting(const std::string& id, const CSetting& setting);
+  CSetting(std::string_view id, CSettingsManager* settingsManager = nullptr);
+  CSetting(std::string_view id, const CSetting& setting);
   ~CSetting() override = default;
 
-  virtual std::shared_ptr<CSetting> Clone(const std::string &id) const = 0;
+  virtual std::shared_ptr<CSetting> Clone(std::string_view id) const = 0;
   void MergeBasics(const CSetting& other);
   virtual void MergeDetails(const CSetting& other) = 0;
 
@@ -156,10 +156,10 @@ public:
   static SettingType Type() { return TSettingType; }
 
 protected:
-  CTraitedSetting(const std::string& id, CSettingsManager* settingsManager = nullptr)
+  CTraitedSetting(std::string_view id, CSettingsManager* settingsManager = nullptr)
     : CSetting(id, settingsManager)
   { }
-  CTraitedSetting(const std::string& id, const CTraitedSetting& setting) : CSetting(id, setting) {}
+  CTraitedSetting(std::string_view id, const CTraitedSetting& setting) : CSetting(id, setting) {}
   ~CTraitedSetting() override = default;
 };
 
@@ -171,12 +171,17 @@ protected:
 class CSettingList : public CSetting
 {
 public:
-  CSettingList(const std::string &id, std::shared_ptr<CSetting> settingDefinition, CSettingsManager *settingsManager = nullptr);
-  CSettingList(const std::string &id, std::shared_ptr<CSetting> settingDefinition, int label, CSettingsManager *settingsManager = nullptr);
-  CSettingList(const std::string &id, const CSettingList &setting);
+  CSettingList(std::string_view id,
+               std::shared_ptr<CSetting> settingDefinition,
+               CSettingsManager* settingsManager = nullptr);
+  CSettingList(std::string_view id,
+               std::shared_ptr<CSetting> settingDefinition,
+               int label,
+               CSettingsManager* settingsManager = nullptr);
+  CSettingList(std::string_view id, const CSettingList& setting);
   ~CSettingList() override = default;
 
-  std::shared_ptr<CSetting> Clone(const std::string &id) const override;
+  std::shared_ptr<CSetting> Clone(std::string_view id) const override;
   void MergeDetails(const CSetting& other) override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
@@ -232,12 +237,15 @@ protected:
 class CSettingBool : public CTraitedSetting<bool, SettingType::Boolean>
 {
 public:
-  CSettingBool(const std::string &id, CSettingsManager *settingsManager = nullptr);
-  CSettingBool(const std::string &id, const CSettingBool &setting);
-  CSettingBool(const std::string &id, int label, bool value, CSettingsManager *settingsManager = nullptr);
+  CSettingBool(std::string_view id, CSettingsManager* settingsManager = nullptr);
+  CSettingBool(std::string_view id, const CSettingBool& setting);
+  CSettingBool(std::string_view id,
+               int label,
+               bool value,
+               CSettingsManager* settingsManager = nullptr);
   ~CSettingBool() override = default;
 
-  std::shared_ptr<CSetting> Clone(const std::string &id) const override;
+  std::shared_ptr<CSetting> Clone(std::string_view id) const override;
   void MergeDetails(const CSetting& other) override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
@@ -277,14 +285,27 @@ private:
 class CSettingInt : public CTraitedSetting<int, SettingType::Integer>
 {
 public:
-  CSettingInt(const std::string &id, CSettingsManager *settingsManager = nullptr);
-  CSettingInt(const std::string &id, const CSettingInt &setting);
-  CSettingInt(const std::string &id, int label, int value, CSettingsManager *settingsManager = nullptr);
-  CSettingInt(const std::string &id, int label, int value, int minimum, int step, int maximum, CSettingsManager *settingsManager = nullptr);
-  CSettingInt(const std::string &id, int label, int value, const TranslatableIntegerSettingOptions &options, CSettingsManager *settingsManager = nullptr);
+  CSettingInt(std::string_view id, CSettingsManager* settingsManager = nullptr);
+  CSettingInt(std::string_view id, const CSettingInt& setting);
+  CSettingInt(std::string_view id,
+              int label,
+              int value,
+              CSettingsManager* settingsManager = nullptr);
+  CSettingInt(std::string_view id,
+              int label,
+              int value,
+              int minimum,
+              int step,
+              int maximum,
+              CSettingsManager* settingsManager = nullptr);
+  CSettingInt(std::string_view id,
+              int label,
+              int value,
+              const TranslatableIntegerSettingOptions& options,
+              CSettingsManager* settingsManager = nullptr);
   ~CSettingInt() override = default;
 
-  std::shared_ptr<CSetting> Clone(const std::string &id) const override;
+  std::shared_ptr<CSetting> Clone(std::string_view id) const override;
   void MergeDetails(const CSetting& other) override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
@@ -363,13 +384,22 @@ private:
 class CSettingNumber : public CTraitedSetting<double, SettingType::Number>
 {
 public:
-  CSettingNumber(const std::string &id, CSettingsManager *settingsManager = nullptr);
-  CSettingNumber(const std::string &id, const CSettingNumber &setting);
-  CSettingNumber(const std::string &id, int label, float value, CSettingsManager *settingsManager = nullptr);
-  CSettingNumber(const std::string &id, int label, float value, float minimum, float step, float maximum, CSettingsManager *settingsManager = nullptr);
+  CSettingNumber(std::string_view id, CSettingsManager* settingsManager = nullptr);
+  CSettingNumber(std::string_view id, const CSettingNumber& setting);
+  CSettingNumber(std::string_view id,
+                 int label,
+                 float value,
+                 CSettingsManager* settingsManager = nullptr);
+  CSettingNumber(std::string_view id,
+                 int label,
+                 float value,
+                 float minimum,
+                 float step,
+                 float maximum,
+                 CSettingsManager* settingsManager = nullptr);
   ~CSettingNumber() override = default;
 
-  std::shared_ptr<CSetting> Clone(const std::string &id) const override;
+  std::shared_ptr<CSetting> Clone(std::string_view id) const override;
   void MergeDetails(const CSetting& other) override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
@@ -423,12 +453,15 @@ private:
 class CSettingString : public CTraitedSetting<std::string, SettingType::String>
 {
 public:
-  CSettingString(const std::string &id, CSettingsManager *settingsManager = nullptr);
-  CSettingString(const std::string &id, const CSettingString &setting);
-  CSettingString(const std::string &id, int label, const std::string &value, CSettingsManager *settingsManager = nullptr);
+  CSettingString(std::string_view id, CSettingsManager* settingsManager = nullptr);
+  CSettingString(std::string_view id, const CSettingString& setting);
+  CSettingString(std::string_view id,
+                 int label,
+                 const std::string& value,
+                 CSettingsManager* settingsManager = nullptr);
   ~CSettingString() override = default;
 
-  std::shared_ptr<CSetting> Clone(const std::string &id) const override;
+  std::shared_ptr<CSetting> Clone(std::string_view id) const override;
   void MergeDetails(const CSetting& other) override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;
@@ -503,12 +536,12 @@ protected:
 class CSettingAction : public CSetting
 {
 public:
-  CSettingAction(const std::string &id, CSettingsManager *settingsManager = nullptr);
-  CSettingAction(const std::string &id, int label, CSettingsManager *settingsManager = nullptr);
-  CSettingAction(const std::string &id, const CSettingAction &setting);
+  CSettingAction(std::string_view id, CSettingsManager* settingsManager = nullptr);
+  CSettingAction(std::string_view id, int label, CSettingsManager* settingsManager = nullptr);
+  CSettingAction(std::string_view id, const CSettingAction& setting);
   ~CSettingAction() override = default;
 
-  std::shared_ptr<CSetting> Clone(const std::string &id) const override;
+  std::shared_ptr<CSetting> Clone(std::string_view id) const override;
   void MergeDetails(const CSetting& other) override;
 
   bool Deserialize(const TiXmlNode *node, bool update = false) override;

--- a/xbmc/settings/lib/SettingSection.cpp
+++ b/xbmc/settings/lib/SettingSection.cpp
@@ -63,8 +63,7 @@ void addISetting(const TiXmlNode* node, const T& item, std::vector<T>& items, bo
 
 Logger CSettingGroup::s_logger;
 
-CSettingGroup::CSettingGroup(const std::string& id,
-                             CSettingsManager* settingsManager /* = nullptr */)
+CSettingGroup::CSettingGroup(std::string_view id, CSettingsManager* settingsManager /* = nullptr */)
   : ISetting(id, settingsManager)
 {
   if (!s_logger)

--- a/xbmc/settings/lib/SettingSection.h
+++ b/xbmc/settings/lib/SettingSection.h
@@ -35,7 +35,7 @@ public:
    \param id Identifier of the setting group
    \param settingsManager Reference to the settings manager
    */
-  CSettingGroup(const std::string &id, CSettingsManager *settingsManager = nullptr);
+  CSettingGroup(std::string_view id, CSettingsManager* settingsManager = nullptr);
   ~CSettingGroup() override = default;
 
   // implementation of ISetting

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -12,6 +12,7 @@
 #include "Setting.h"
 #include "SettingDefinitions.h"
 #include "SettingSection.h"
+#include "SettingsMigration.h"
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/log.h"
@@ -25,6 +26,21 @@
 
 const uint32_t CSettingsManager::Version = 2;
 const uint32_t CSettingsManager::MinimumSupportedVersion = 0;
+
+namespace
+{
+std::unique_ptr<TiXmlElement> Clone(const TiXmlElement* root)
+{
+  if (TiXmlNode* cloneNode = root->Clone(); cloneNode != nullptr)
+  {
+    if (TiXmlElement* clone = cloneNode->ToElement(); clone != nullptr)
+      return std::unique_ptr<TiXmlElement>(clone);
+
+    delete cloneNode;
+  }
+  return {};
+}
+} // namespace
 
 bool CSettingsManager::ParseSettingIdentifier(std::string_view settingId,
                                               std::string& categoryTag,
@@ -170,6 +186,41 @@ bool CSettingsManager::Load(const TiXmlElement* root,
     m_logger->error("unable to read setting values from version {} (current version: {})", version,
                     Version);
     return false;
+  }
+
+  updated = false;
+
+  // Scoped to remain alive until the end of the function
+  std::unique_ptr<TiXmlElement> writableRoot;
+
+  if (version < Version)
+  {
+    // Local deep copy to keep the rest of the settings reading code const
+    writableRoot = Clone(root);
+
+    if (writableRoot != nullptr)
+    {
+      CSettingsMigration migration{};
+      if (migration.UpdateXMLSettings(writableRoot.get(), version, Version))
+      {
+        // Continue loading with the modified xml document
+        root = writableRoot.get();
+        // Always mark settings updated to have them serialized with the new version number after load,
+        // even if no setting was modified (impacted setting not present in the file for example)
+        updated = true;
+      }
+    }
+
+    if (!updated)
+    {
+      m_logger->error(
+          "Unable to create an in-memory copy of the settings for the settings upgrade, or "
+          "unrecoverable upgrade failure. The settings that would have been upgraded will have "
+          "default values.");
+      // Must continue even with a catastrophic upgrade failure. All settings would otherwise be
+      // reset to default, much worse than missing the upgrade of a few settings.
+      //! @todo rework Kodi startup and handling of settings load problem.
+    }
   }
 
   if (!Deserialize(root, updated, loadedSettings))
@@ -794,8 +845,6 @@ bool CSettingsManager::Deserialize(const TiXmlNode* node,
                                    bool& updated,
                                    LoadedSettings* loadedSettings /* = nullptr */)
 {
-  updated = false;
-
   if (!node)
     return false;
 

--- a/xbmc/settings/lib/SettingsManager.cpp
+++ b/xbmc/settings/lib/SettingsManager.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2013-2018 Team Kodi
+ *  Copyright (C) 2013-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -26,19 +26,22 @@
 const uint32_t CSettingsManager::Version = 2;
 const uint32_t CSettingsManager::MinimumSupportedVersion = 0;
 
-bool ParseSettingIdentifier(const std::string& settingId, std::string& categoryTag, std::string& settingTag)
+bool CSettingsManager::ParseSettingIdentifier(std::string_view settingId,
+                                              std::string& categoryTag,
+                                              std::string& settingTag)
 {
-  static const std::string Separator = ".";
+  constexpr std::string_view separator = ".";
 
   if (settingId.empty())
     return false;
 
-  std::vector<std::string> parts = StringUtils::Split(settingId, Separator);
+  std::vector<std::string> parts = StringUtils::Split(settingId, separator);
   if (parts.empty() || parts.at(0).empty())
     return false;
 
   if (parts.size() == 1)
   {
+    categoryTag = "";
     settingTag = parts.at(0);
     return true;
   }
@@ -48,7 +51,7 @@ bool ParseSettingIdentifier(const std::string& settingId, std::string& categoryT
   parts.erase(parts.begin());
 
   // put together the setting tag
-  settingTag = StringUtils::Join(parts, Separator);
+  settingTag = StringUtils::Join(parts, separator);
 
   return true;
 }
@@ -1076,33 +1079,7 @@ bool CSettingsManager::LoadSetting(const TiXmlNode* node, const SettingPtr& sett
   if (setting->IsReference())
     settingId = setting->GetReferencedId();
 
-  const TiXmlElement* settingElement = nullptr;
-  // try to split the setting identifier into category and subsetting identifier (v1-)
-  std::string categoryTag;
-  std::string settingTag;
-  if (ParseSettingIdentifier(settingId, categoryTag, settingTag))
-  {
-    const TiXmlNode* categoryNode = node;
-    if (!categoryTag.empty())
-      categoryNode = node->FirstChild(categoryTag);
-
-    if (categoryNode)
-      settingElement = categoryNode->FirstChildElement(settingTag);
-  }
-
-  if (!settingElement)
-  {
-    // check if the setting is stored using its full setting identifier (v2+)
-    settingElement = node->FirstChildElement(SETTING_XML_ELM_SETTING);
-    while (settingElement)
-    {
-      const char* id = settingElement->Attribute(SETTING_XML_ATTR_ID);
-      if (id && settingId.compare(id) == 0)
-        break;
-
-      settingElement = settingElement->NextSiblingElement(SETTING_XML_ELM_SETTING);
-    }
-  }
+  const TiXmlElement* settingElement = LocateSetting(node, settingId);
 
   if (!settingElement)
     return false;
@@ -1461,4 +1438,43 @@ std::pair<CSettingsManager::SettingMap::iterator, bool> CSettingsManager::Insert
 {
   StringUtils::ToLower(settingId);
   return m_settings.try_emplace(settingId, setting);
+}
+
+const TiXmlElement* CSettingsManager::LocateSetting(const TiXmlNode* node,
+                                                    std::string_view settingId)
+{
+  if (node == nullptr || settingId.empty())
+    return nullptr;
+
+  const TiXmlElement* settingElement = nullptr;
+
+  // Attempt v2 first, more likely to be found as the switch from v1 happened in 2013
+
+  // check if the setting is stored using its full setting identifier (v2+)
+  settingElement = node->FirstChildElement(SETTING_XML_ELM_SETTING);
+  while (settingElement)
+  {
+    const char* id = settingElement->Attribute(SETTING_XML_ATTR_ID);
+    if (id && settingId.compare(id) == 0)
+      break;
+
+    settingElement = settingElement->NextSiblingElement(SETTING_XML_ELM_SETTING);
+  }
+
+  if (!settingElement)
+  {
+    // try to split the setting identifier into category and subsetting identifier (v1)
+    std::string categoryTag;
+    std::string settingTag;
+    if (ParseSettingIdentifier(settingId, categoryTag, settingTag))
+    {
+      const TiXmlNode* categoryNode = node;
+      if (!categoryTag.empty())
+        categoryNode = node->FirstChild(categoryTag);
+
+      if (categoryNode)
+        settingElement = categoryNode->FirstChildElement(settingTag);
+    }
+  }
+  return settingElement;
 }

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -21,6 +21,7 @@
 #include "utils/logtypes.h"
 
 #include <map>
+#include <memory>
 #include <set>
 #include <string_view>
 #include <unordered_set>

--- a/xbmc/settings/lib/SettingsManager.h
+++ b/xbmc/settings/lib/SettingsManager.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2013-2018 Team Kodi
+ *  Copyright (C) 2013-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -485,6 +485,37 @@ public:
    \param identifier Identifier of the dynamic condition
    */
   void RemoveDynamicCondition(const std::string &identifier);
+
+  /*!
+   * \brief Parses a dot-separated setting identifier into its category and setting tag components.
+   *        (used by the V1 settings format)
+   * 
+   * \param settingId[in] The setting identifier to parse. Must not be empty or start with a dot.
+   * \param categoryTag[out] The leading component of \p settingId or an empty string if the
+   *                         identifier contains no dot.
+   * \param settingTag[out] The remainder of \p settingId after the first dot, or the entire
+   *                        identifier if there is no dot.
+   * \return False for failure (\p settingId is empty or starts with a dot), true otherwise.
+   *         The output parameters are left unchanged on failure.
+   */
+  static bool ParseSettingIdentifier(std::string_view settingId,
+                                     std::string& categoryTag,
+                                     std::string& settingTag);
+
+  /*!
+   * \brief Locates the XML element for a setting within a settings document, supporting both
+   *        the current (v2+) and legacy (v1) storage formats. The v2 format is prioritized.
+   *
+   * \param node[in] The root XML node of the settings document to search within.
+   * \param settingId[in] The setting identifier to look up.
+   * \return A pointer to the matching \c TiXmlElement, or nullptr if not found or there is an error.
+   *         The returned pointer lifetime matches that of \p node.
+   */
+  static const TiXmlElement* LocateSetting(const TiXmlNode* node, std::string_view settingId);
+  static TiXmlElement* LocateSetting(TiXmlNode* node, std::string_view settingId)
+  {
+    return const_cast<TiXmlElement*>(LocateSetting(const_cast<const TiXmlNode*>(node), settingId));
+  }
 
 private:
   // implementation of ISettingCallback

--- a/xbmc/settings/lib/SettingsMigration.cpp
+++ b/xbmc/settings/lib/SettingsMigration.cpp
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SettingsMigration.h"
+
+#include "utils/log.h"
+
+#include <stdexcept>
+
+// Version when the migration system was added. Early exit for upgrades to that version or lower
+constexpr int VERSION_BEFORE_MIGRATION_SYSTEM = 2;
+
+CSettingsMigration::CSettingsMigration()
+{
+  /*
+   * Placeholder for the creation of migration steps. Could look something like this:
+
+  std::vector<std::shared_ptr<ISettingsMigrationStep>> migrations{
+      std::make_shared<CSettingsMigrationToV3>(),
+      std::make_shared<CSettingsMigrationToV4>(),
+      etc...
+  };
+
+  CSettingsMigration(std::move(migrations));
+  */
+}
+
+CSettingsMigration::CSettingsMigration(StepList steps)
+{
+  m_steps = std::move(steps);
+  std::ranges::sort(m_steps, {}, &ISettingsMigrationStep::TargetVersion);
+
+  if (m_steps.end() !=
+      std::ranges::adjacent_find(m_steps, {}, &ISettingsMigrationStep::TargetVersion))
+    throw std::invalid_argument("Multiple steps for the same target version are forbidden");
+}
+
+bool CSettingsMigration::UpdateXMLSettings(TiXmlElement* root,
+                                           int currentVersion,
+                                           int targetVersion)
+{
+  if (targetVersion > VERSION_BEFORE_MIGRATION_SYSTEM && currentVersion < targetVersion)
+  {
+    //! @todo would be nice to include the filename or something to identify more precisely in the log
+    CLog::LogF(LOGDEBUG, "upgrading settings from version {} to {}", currentVersion, targetVersion);
+
+    const int firstTarget = currentVersion + 1;
+    auto itFirst =
+        std::ranges::lower_bound(m_steps, firstTarget, {}, &ISettingsMigrationStep::TargetVersion);
+    auto itLast = std::ranges::upper_bound(m_steps, targetVersion, {},
+                                           &ISettingsMigrationStep::TargetVersion);
+
+    if (itFirst == itLast)
+    {
+      CLog::LogF(LOGDEBUG, "no migration steps available from version {} to {}", currentVersion,
+                 targetVersion);
+      return true;
+    }
+
+    // All steps must succeed, stop on first error
+    return std::none_of(itFirst, itLast, [root](const std::shared_ptr<ISettingsMigrationStep>& step)
+                        { return !step->Apply(root); });
+  }
+
+  return true;
+}

--- a/xbmc/settings/lib/SettingsMigration.cpp
+++ b/xbmc/settings/lib/SettingsMigration.cpp
@@ -8,9 +8,15 @@
 
 #include "SettingsMigration.h"
 
+#include "Setting.h"
+#include "SettingsManager.h"
+#include "settings/SettingsValueXmlSerializer.h"
+#include "utils/XMLUtils.h"
 #include "utils/log.h"
 
+#include <memory>
 #include <stdexcept>
+#include <string>
 
 // Version when the migration system was added. Early exit for upgrades to that version or lower
 constexpr int VERSION_BEFORE_MIGRATION_SYSTEM = 2;
@@ -68,4 +74,61 @@ bool CSettingsMigration::UpdateXMLSettings(TiXmlElement* root,
   }
 
   return true;
+}
+
+CSettingsMigration::SettingConversionResult CSettingsMigration::ConvertSettingBoolToInt(
+    TiXmlElement* root,
+    std::string_view oldSettingId,
+    std::string_view newSettingId,
+    const SettingBoolToIntMapping& mapping)
+{
+  if (TiXmlElement* elem = CSettingsManager::LocateSetting(root, oldSettingId); elem != nullptr)
+  {
+    //! maybe future @todo: strategy - read/write settings without dependency on CSetting* classes?
+    auto oldSetting = std::make_shared<CSettingBool>(oldSettingId, nullptr);
+    if (oldSetting == nullptr)
+      return SettingConversionResult::FAILURE;
+
+    const std::string oldValue = elem->FirstChild() ? elem->FirstChild()->ValueStr() : "";
+
+    if (!oldSetting->FromString(oldValue))
+    {
+      CLog::Log(LOGWARNING,
+                "Settings conversion: unable to load the value of the old "
+                "setting \"{}\": \"{}\". "
+                "The new setting \"{}\" will have its default value.",
+                oldSettingId, oldValue, newSettingId);
+      return SettingConversionResult::INVALID;
+    }
+
+    // Map to int setting values
+    const int newValue = oldSetting->GetValue() ? mapping.m_true : mapping.m_false;
+
+    // Prepare a new setting
+    auto newSetting = std::make_shared<CSettingInt>(newSettingId, nullptr);
+    if (newSetting == nullptr)
+      return SettingConversionResult::FAILURE;
+
+    newSetting->SetDefault(mapping.m_default);
+    newSetting->SetValue(newValue);
+
+    // Add the new setting and remove the old one
+    // The new setting doesn't have to be in the same place in the file as the old one.
+    if (!CSettingsValueXmlSerializer::SerializeSetting(root, newSetting) ||
+        !XMLUtils::RemoveNode(elem))
+      return SettingConversionResult::FAILURE;
+
+    CLog::LogF(LOGDEBUG,
+               "Successful conversion of old setting \"{}\" / \"{}\" to new "
+               "setting \"{}\" / \"{}\".",
+               oldSettingId, oldValue, newSettingId, newValue);
+    return SettingConversionResult::CONVERTED;
+  }
+
+  CLog::LogF(LOGDEBUG,
+             "Old setting \"{}\" not found. The new setting \"{}\" will have "
+             "its default value.",
+             oldSettingId, newSettingId);
+
+  return SettingConversionResult::NOT_PRESENT;
 }

--- a/xbmc/settings/lib/SettingsMigration.h
+++ b/xbmc/settings/lib/SettingsMigration.h
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "settings/lib/ISettingsMigrationStep.h"
+#include "utils/XBMCTinyXML.h"
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+class CSettingsMigration
+{
+public:
+  using StepList = std::vector<std::shared_ptr<ISettingsMigrationStep>>;
+
+  // The constructors throw for invalid lists of steps
+  CSettingsMigration();
+  CSettingsMigration(StepList steps);
+
+  /*!
+   * \brief Upgrade the settings contained in \p root from \p fromVersion to \p targetVersion.
+   *        Multiple steps will be executed automatically when \p fromVersion is more than one
+   *        version away from \p targetVersion.
+   * \param[in,out] root Settings XML representation.
+   * \param[in] fromVersion Version to upgrade from.
+   * \param[in] targetVersion Version to upgrade to.
+   * \return False for catastrophic failure (for example \p root left in an inconsistent state due
+   *         to out of memory. A setting that doesn't convert properly due to an invalid value is
+   *         not a catastrophic failure: the situation is logged and the setting receives its
+   *         default value). True otherwise.
+   */
+  bool UpdateXMLSettings(TiXmlElement* root, int currentVersion, int targetVersion);
+
+private:
+  StepList m_steps; // steps sorted by TargetVersion() in constructor
+};

--- a/xbmc/settings/lib/SettingsMigration.h
+++ b/xbmc/settings/lib/SettingsMigration.h
@@ -13,7 +13,10 @@
 
 #include <algorithm>
 #include <memory>
+#include <string_view>
 #include <vector>
+
+class TestConversions;
 
 class CSettingsMigration
 {
@@ -37,6 +40,26 @@ public:
    *         default value). True otherwise.
    */
   bool UpdateXMLSettings(TiXmlElement* root, int currentVersion, int targetVersion);
+
+  enum class SettingConversionResult
+  {
+    FAILURE, // failed conversion left an inconsistent irrecoverable state
+    NOT_PRESENT, // the old setting cannot be found
+    INVALID, // the old setting has an invalid value for its data type
+    CONVERTED, // successful conversion from old to new setting
+  };
+
+  struct SettingBoolToIntMapping
+  {
+    int m_default;
+    int m_false;
+    int m_true;
+  };
+
+  static SettingConversionResult ConvertSettingBoolToInt(TiXmlElement* root,
+                                                         std::string_view oldSettingId,
+                                                         std::string_view newSettingId,
+                                                         const SettingBoolToIntMapping& mapping);
 
 private:
   StepList m_steps; // steps sorted by TargetVersion() in constructor

--- a/xbmc/settings/lib/test/CMakeLists.txt
+++ b/xbmc/settings/lib/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestSettingsManager.cpp)
+
+core_add_test_library(settings_lib_test)

--- a/xbmc/settings/lib/test/CMakeLists.txt
+++ b/xbmc/settings/lib/test/CMakeLists.txt
@@ -1,3 +1,4 @@
-set(SOURCES TestSettingsManager.cpp)
+set(SOURCES TestSettingsManager.cpp
+            TestSettingsMigration.cpp)
 
 core_add_test_library(settings_lib_test)

--- a/xbmc/settings/lib/test/TestSettingsManager.cpp
+++ b/xbmc/settings/lib/test/TestSettingsManager.cpp
@@ -1,0 +1,204 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "settings/lib/SettingsManager.h"
+#include "utils/XBMCTinyXML.h"
+#include "utils/XMLUtils.h"
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+struct SettingIdentifierParseTest
+{
+  std::string_view settingId;
+  std::string_view category;
+  std::string_view setting;
+};
+
+std::ostream& operator<<(std::ostream& os, const SettingIdentifierParseTest& rhs)
+{
+  return os << rhs.settingId;
+}
+
+class TestParseSettingIdentifier : public testing::WithParamInterface<SettingIdentifierParseTest>,
+                                   public testing::Test
+{
+};
+
+SettingIdentifierParseTest SettingIdentifierParseTests[] = {
+    {"categorytag.settingtag", "categorytag", "settingtag"},
+    {"categorytag.settingtag.subsetting", "categorytag", "settingtag.subsetting"},
+    {"test", "", "test"},
+};
+
+TEST_P(TestParseSettingIdentifier, Parse)
+{
+  const auto& params = GetParam();
+
+  std::string categoryTag = "foo";
+  std::string settingTag = "bar";
+  EXPECT_TRUE(CSettingsManager::ParseSettingIdentifier(params.settingId, categoryTag, settingTag));
+  EXPECT_EQ(params.category, categoryTag);
+  EXPECT_EQ(params.setting, settingTag);
+}
+
+INSTANTIATE_TEST_SUITE_P(TestSettingsManager,
+                         TestParseSettingIdentifier,
+                         testing::ValuesIn(SettingIdentifierParseTests));
+
+TEST(TestSettingsManager, ParseInvalidSettingIdentifier)
+{
+  std::string categoryTag = "foo";
+  std::string settingTag = "bar";
+  EXPECT_FALSE(CSettingsManager::ParseSettingIdentifier("", categoryTag, settingTag));
+  EXPECT_FALSE(CSettingsManager::ParseSettingIdentifier(".test", categoryTag, settingTag));
+  EXPECT_EQ("foo", categoryTag);
+  EXPECT_EQ("bar", settingTag);
+}
+
+struct LocateSettingTest
+{
+  std::string_view m_document;
+  std::string_view m_settingId;
+  // nullopt means we expect the element to not be found
+  std::optional<std::string_view> m_expectedSerialization;
+};
+
+class TestLocateSetting : public testing::WithParamInterface<LocateSettingTest>,
+                          public testing::Test
+{
+};
+
+LocateSettingTest LocateSettingTests[] = {
+    // V1 format
+    {
+        R"(<settings><foo><bar>value</bar></foo></settings>)",
+        "foo.bar",
+        R"(<bar>value</bar>)",
+    },
+    {
+        R"(<settings><foo><bar>value</bar></foo></settings>)",
+        "foo",
+        R"(<foo><bar>value</bar></foo>)",
+    },
+    {
+        R"(<settings><foo><bar.baz>value</bar.baz></foo></settings>)",
+        "foo.bar.baz",
+        R"(<bar.baz>value</bar.baz>)",
+    },
+    {
+        R"(<settings><foo><bar></bar></foo></settings>)",
+        "foo.bar",
+        R"(<bar />)",
+    },
+    {
+        R"(<settings><foo><bar /></foo></settings>)",
+        "foo.bar",
+        R"(<bar />)",
+    },
+    {
+        R"(<settings><foo><baz>value</baz></foo></settings>)",
+        "foo.bar",
+        std::nullopt,
+    },
+    {
+        R"(<settings><foo></foo></settings>)",
+        "foo.bar",
+        std::nullopt,
+    },
+    {
+        R"(<settings><foo /></settings>)",
+        "foo.bar",
+        std::nullopt,
+    },
+
+    // V2 format
+    {
+        R"(<settings version="2"><setting id="foo.bar">value</setting></settings>)",
+        "foo.bar",
+        R"(<setting id="foo.bar">value</setting>)",
+    },
+    {
+        R"(<settings version="2"><setting id="foo.bar"></setting></settings>)",
+        "foo.bar",
+        R"(<setting id="foo.bar" />)",
+    },
+    {
+        R"(<settings version="2"><setting id="foo.bar" /></settings>)",
+        "foo.bar",
+        R"(<setting id="foo.bar" />)",
+    },
+    {
+        R"(<settings version="2"><setting id="foo.bar"></setting><setting id="foo.baz"></setting></settings>)",
+        "foo.baz",
+        R"(<setting id="foo.baz" />)",
+    },
+    {
+        R"(<settings version="2"><setting ab="foo.bar">value</setting></settings>)",
+        "foo.bar",
+        std::nullopt,
+    },
+
+    // Mixed V1+V2: V2 takes priority regardless of document order
+    {
+        R"(<settings version="2"><setting id="foo.bar">v2</setting><foo><bar>v1</bar></foo></settings>)",
+        "foo.bar",
+        R"(<setting id="foo.bar">v2</setting>)",
+    },
+    {
+        R"(<settings version="2"><foo><bar>v1</bar></foo><setting id="foo.bar">v2</setting></settings>)",
+        "foo.bar",
+        R"(<setting id="foo.bar">v2</setting>)",
+    },
+};
+
+TEST_P(TestLocateSetting, Locate)
+{
+  const auto& params = GetParam();
+
+  CXBMCTinyXML doc;
+  ASSERT_TRUE(doc.Parse(std::string{params.m_document}));
+
+  TiXmlElement* elem = CSettingsManager::LocateSetting(doc.RootElement(), params.m_settingId);
+
+  if (params.m_expectedSerialization.has_value())
+  {
+    ASSERT_NE(nullptr, elem);
+    EXPECT_EQ(params.m_expectedSerialization.value(),
+              XMLUtils::NodeStringSerialization(elem, XMLUtils::SerializationFormat::COMPACT));
+  }
+  else
+  {
+    EXPECT_EQ(nullptr, elem);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(TestSettingsManager,
+                         TestLocateSetting,
+                         testing::ValuesIn(LocateSettingTests));
+
+TEST(TestSettingsManager, LocateSettingNull)
+{
+  TiXmlElement* root = nullptr;
+  TiXmlElement* elem = CSettingsManager::LocateSetting(root, "foo.bar");
+  EXPECT_EQ(nullptr, elem);
+
+  const std::string document =
+      R"(<settings version="2">
+           <setting id="foo.bar">v2</setting>
+         </settings>)";
+
+  CXBMCTinyXML doc;
+  ASSERT_TRUE(doc.Parse(document));
+
+  elem = CSettingsManager::LocateSetting(doc.RootElement(), "");
+  EXPECT_EQ(nullptr, elem);
+}

--- a/xbmc/settings/lib/test/TestSettingsMigration.cpp
+++ b/xbmc/settings/lib/test/TestSettingsMigration.cpp
@@ -8,8 +8,11 @@
 
 #include "settings/lib/ISettingsMigrationStep.h"
 #include "settings/lib/SettingsMigration.h"
+#include "utils/XBMCTinyXML.h"
+#include "utils/XMLUtils.h"
 
 #include <stdexcept>
+#include <string_view>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -121,3 +124,192 @@ TEST(TestSettingsMigration, MultipleMigrationStepsSameTarget)
 
   EXPECT_THROW({ CSettingsMigration(std::move(steps)); }, std::invalid_argument);
 }
+
+class TestConversions : public ::testing::Test
+{
+public:
+  // All tests will attempt this conversion
+  std::string_view m_oldSettingId = "a.b";
+  std::string_view m_newSettingId = "c.d";
+};
+
+struct ConvertSettingBoolToIntTest
+{
+  std::string m_originalSettings;
+  CSettingsMigration::SettingConversionResult m_result;
+  std::string_view m_serializedOutput;
+};
+
+class TestConvertSettingBoolToInt : public TestConversions,
+                                    public testing::WithParamInterface<ConvertSettingBoolToIntTest>
+{
+};
+
+ConvertSettingBoolToIntTest ConvertSettingBoolToIntTests[] = {
+    // Successful conversions
+    // V2 format
+    // Convert a true value
+    {R"(<settings version="2"><setting id="a.b">true</setting></settings>)",
+     CSettingsMigration::SettingConversionResult::CONVERTED,
+     R"(<settings version="2"><setting id="c.d">2</setting></settings>)"},
+    // Convert a false value
+    {R"(<settings version="2"><setting id="a.b">false</setting></settings>)",
+     CSettingsMigration::SettingConversionResult::CONVERTED,
+     R"(<settings version="2"><setting id="c.d" default="true">1</setting></settings>)"},
+    // Convert one of multiple settings
+    {R"(<settings version="2">
+          <setting id="a.b">false</setting>
+          <setting id="foo.bar">test</setting>
+        </settings>)",
+     CSettingsMigration::SettingConversionResult::CONVERTED,
+     R"(<settings version="2">)"
+     R"(<setting id="foo.bar">test</setting>)"
+     R"(<setting id="c.d" default="true">1</setting>)"
+     R"(</settings>)"},
+    // V1 format
+    // Convert a true value
+    {R"(<settings><a><b>true</b></a></settings>)",
+     CSettingsMigration::SettingConversionResult::CONVERTED,
+     R"(<settings><a /><setting id="c.d">2</setting></settings>)"},
+    // Convert a false value
+    {R"(<settings><a><b>false</b></a></settings>)",
+     CSettingsMigration::SettingConversionResult::CONVERTED,
+     R"(<settings><a /><setting id="c.d" default="true">1</setting></settings>)"},
+    // Convert one of multiple settings
+    {R"(<settings version="2">
+          <a><b>false</b></a>
+          <foo><bar>test</bar></foo>
+        </settings>)",
+     CSettingsMigration::SettingConversionResult::CONVERTED,
+     R"(<settings version="2">)"
+     R"(<a />)"
+     R"(<foo><bar>test</bar></foo>)"
+     R"(<setting id="c.d" default="true">1</setting>)"
+     R"(</settings>)"},
+
+    // Invalid old setting values
+    // V2 format
+    {R"(<settings version="2"><setting id="a.b">notbool</setting></settings>)",
+     CSettingsMigration::SettingConversionResult::INVALID,
+     R"(<settings version="2"><setting id="a.b">notbool</setting></settings>)"},
+    {R"(<settings version="2"><setting id="a.b"> true</setting></settings>)",
+     CSettingsMigration::SettingConversionResult::INVALID,
+     R"(<settings version="2"><setting id="a.b"> true</setting></settings>)"},
+    {R"(<settings version="2"><setting id="a.b"></setting></settings>)",
+     CSettingsMigration::SettingConversionResult::INVALID,
+     R"(<settings version="2"><setting id="a.b" /></settings>)"},
+    {R"(<settings version="2"><setting id="a.b" /></settings>)",
+     CSettingsMigration::SettingConversionResult::INVALID,
+     R"(<settings version="2"><setting id="a.b" /></settings>)"},
+    // V1 format
+    {R"(<settings><a><b>notbool</b></a></settings>)",
+     CSettingsMigration::SettingConversionResult::INVALID,
+     R"(<settings><a><b>notbool</b></a></settings>)"},
+    {R"(<settings><a><b></b></a></settings>)", CSettingsMigration::SettingConversionResult::INVALID,
+     R"(<settings><a><b /></a></settings>)"},
+    {R"(<settings><a><b /></a></settings>)", CSettingsMigration::SettingConversionResult::INVALID,
+     R"(<settings><a><b /></a></settings>)"},
+
+    // Old setting is not present
+    // V2 format
+    {R"(<settings version="2"><setting id="foo.bar">true</setting></settings>)",
+     CSettingsMigration::SettingConversionResult::NOT_PRESENT,
+     R"(<settings version="2"><setting id="foo.bar">true</setting></settings>)"},
+    {R"(<settings version="2"></settings>)",
+     CSettingsMigration::SettingConversionResult::NOT_PRESENT, R"(<settings version="2" />)"},
+    {R"(<settings version="2" />)", CSettingsMigration::SettingConversionResult::NOT_PRESENT,
+     R"(<settings version="2" />)"},
+    // V1 format
+    {R"(<settings><foo><bar>true</bar></foo></settings>)",
+     CSettingsMigration::SettingConversionResult::NOT_PRESENT,
+     R"(<settings><foo><bar>true</bar></foo></settings>)"},
+    {R"(<settings><a><bar>true</bar></a></settings>)",
+     CSettingsMigration::SettingConversionResult::NOT_PRESENT,
+     R"(<settings><a><bar>true</bar></a></settings>)"},
+    // the other V1 format tests are identical to the V2, except for the version attribute
+    // which is not actively used by code
+};
+
+TEST_P(TestConvertSettingBoolToInt, Convert)
+{
+  const auto& params = GetParam();
+
+  CXBMCTinyXML doc;
+  ASSERT_TRUE(doc.Parse(params.m_originalSettings));
+
+  auto conversionResult =
+      CSettingsMigration::ConvertSettingBoolToInt(doc.RootElement(), m_oldSettingId, m_newSettingId,
+                                                  {.m_default = 1, .m_false = 1, .m_true = 2});
+  ASSERT_EQ(params.m_result, conversionResult);
+
+  EXPECT_EQ(
+      params.m_serializedOutput,
+      XMLUtils::NodeStringSerialization(doc.RootElement(), XMLUtils::SerializationFormat::COMPACT));
+}
+
+INSTANTIATE_TEST_SUITE_P(TestSettingsMigration,
+                         TestConvertSettingBoolToInt,
+                         testing::ValuesIn(ConvertSettingBoolToIntTests));
+
+struct ConvertSettingBoolToIntMappingTest
+{
+  std::string m_originalSettings;
+  CSettingsMigration::SettingBoolToIntMapping m_mapping;
+  std::string_view m_serializedOutput;
+};
+
+class TestConvertSettingBoolToIntMapping
+  : public TestConversions,
+    public testing::WithParamInterface<ConvertSettingBoolToIntMappingTest>
+{
+};
+
+ConvertSettingBoolToIntMappingTest ConvertSettingBoolToIntMappingTests[] = {
+    // True value
+    {R"(<settings version="2"><setting id="a.b">true</setting></settings>)",
+     {.m_default = 1, .m_false = 1, .m_true = 2},
+     R"(<settings version="2"><setting id="c.d">2</setting></settings>)"},
+    {R"(<settings version="2"><setting id="a.b">true</setting></settings>)",
+     {.m_default = 2, .m_false = 1, .m_true = 2},
+     R"(<settings version="2"><setting id="c.d" default="true">2</setting></settings>)"},
+    {R"(<settings version="2"><setting id="a.b">true</setting></settings>)",
+     {.m_default = 1, .m_false = 2, .m_true = 2},
+     R"(<settings version="2"><setting id="c.d">2</setting></settings>)"},
+    {R"(<settings version="2"><setting id="a.b">true</setting></settings>)",
+     {.m_default = 2, .m_false = 2, .m_true = 2},
+     R"(<settings version="2"><setting id="c.d" default="true">2</setting></settings>)"},
+
+    // False value
+    {R"(<settings version="2"><setting id="a.b">false</setting></settings>)",
+     {.m_default = 1, .m_false = 1, .m_true = 2},
+     R"(<settings version="2"><setting id="c.d" default="true">1</setting></settings>)"},
+    {R"(<settings version="2"><setting id="a.b">false</setting></settings>)",
+     {.m_default = 2, .m_false = 1, .m_true = 2},
+     R"(<settings version="2"><setting id="c.d">1</setting></settings>)"},
+    {R"(<settings version="2"><setting id="a.b">false</setting></settings>)",
+     {.m_default = 2, .m_false = 1, .m_true = 1},
+     R"(<settings version="2"><setting id="c.d">1</setting></settings>)"},
+    {R"(<settings version="2"><setting id="a.b">false</setting></settings>)",
+     {.m_default = 1, .m_false = 1, .m_true = 1},
+     R"(<settings version="2"><setting id="c.d" default="true">1</setting></settings>)"},
+};
+
+TEST_P(TestConvertSettingBoolToIntMapping, Convert)
+{
+  const auto& params = GetParam();
+
+  CXBMCTinyXML doc;
+  ASSERT_TRUE(doc.Parse(params.m_originalSettings));
+
+  auto conversionResult = CSettingsMigration::ConvertSettingBoolToInt(
+      doc.RootElement(), m_oldSettingId, m_newSettingId, params.m_mapping);
+  ASSERT_EQ(CSettingsMigration::SettingConversionResult::CONVERTED, conversionResult);
+
+  EXPECT_EQ(
+      params.m_serializedOutput,
+      XMLUtils::NodeStringSerialization(doc.RootElement(), XMLUtils::SerializationFormat::COMPACT));
+}
+
+INSTANTIATE_TEST_SUITE_P(TestSettingsMigration,
+                         TestConvertSettingBoolToIntMapping,
+                         testing::ValuesIn(ConvertSettingBoolToIntMappingTests));

--- a/xbmc/settings/lib/test/TestSettingsMigration.cpp
+++ b/xbmc/settings/lib/test/TestSettingsMigration.cpp
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "settings/lib/ISettingsMigrationStep.h"
+#include "settings/lib/SettingsMigration.h"
+
+#include <stdexcept>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+struct StepSpec
+{
+  int version;
+  bool returns{true};
+};
+
+struct UpdateXMLSettingsTest
+{
+  std::vector<StepSpec> steps;
+  int currentVersion;
+  int targetVersion;
+  bool expectedReturn;
+  std::vector<int> expectedCompleted;
+};
+
+const UpdateXMLSettingsTest UpdateXMLSettingsTests[]{
+    // "normal" guisettings.xml cases - contiguous steps from version 2
+    {{{3}}, 2, 3, true, {3}},
+    {{{3}, {4}}, 2, 4, true, {3, 4}},
+
+    // advancedsettings.xml typically doesn't have a version number => version 0
+    {{{3}}, 0, 3, true, {3}},
+
+    // steps below or above the range are skipped
+    {{{3}, {4}, {5}}, 3, 4, true, {4}},
+    {{{3}, {4}, {5}}, 4, 5, true, {5}},
+
+    // gaps in the steps
+    {{{3}, {5}}, 2, 5, true, {3, 5}},
+
+    // steps exist only outside of the range
+    {{{1}}, 2, 3, true, {}},
+    {{{10}}, 2, 3, true, {}},
+
+    // no steps
+    {{}, 2, 3, true, {}},
+
+    // steps provided out of order
+    {{{5}, {3}, {4}}, 2, 5, true, {3, 4, 5}},
+
+    // stop on first error
+    {{{3, false}, {4}}, 2, 4, false, {3}},
+    {{{3}, {4, false}}, 2, 4, false, {3, 4}},
+
+    // no work under the minimum version LEGACY_VERSION = 2 or already on current version
+    {{{0}, {1}, {2}}, 0, 2, true, {}},
+    {{}, 2, 2, true, {}},
+    {{{3}}, 3, 3, true, {}},
+};
+
+class TestSettingsMigrationUpdateXML : public testing::WithParamInterface<UpdateXMLSettingsTest>,
+                                       public testing::Test
+{
+};
+
+struct StubStep : ISettingsMigrationStep
+{
+  StubStep(int version, bool returnValue, std::vector<int>& completionLog)
+    : m_version(version),
+      m_returnValue(returnValue),
+      m_log(completionLog)
+  {
+  }
+  int TargetVersion() const override { return m_version; }
+  bool Apply(TiXmlElement*) override
+  {
+    m_log.push_back(m_version);
+    return m_returnValue;
+  }
+
+private:
+  int m_version;
+  bool m_returnValue{true};
+  std::vector<int>& m_log;
+};
+
+TEST_P(TestSettingsMigrationUpdateXML, UpdateXMLSettings)
+{
+  const auto& params = GetParam();
+
+  std::vector<int> completed;
+
+  CSettingsMigration::StepList steps;
+  for (const auto& step : params.steps)
+    steps.push_back(std::make_shared<StubStep>(step.version, step.returns, completed));
+
+  CSettingsMigration migration(std::move(steps));
+
+  EXPECT_EQ(params.expectedReturn,
+            migration.UpdateXMLSettings(nullptr, params.currentVersion, params.targetVersion));
+  EXPECT_EQ(params.expectedCompleted, completed);
+}
+
+INSTANTIATE_TEST_SUITE_P(TestSettingsMigration,
+                         TestSettingsMigrationUpdateXML,
+                         testing::ValuesIn(UpdateXMLSettingsTests));
+
+TEST(TestSettingsMigration, MultipleMigrationStepsSameTarget)
+{
+  std::vector<int> completed;
+
+  CSettingsMigration::StepList steps;
+  steps.push_back(std::make_shared<StubStep>(3, true, completed));
+  steps.push_back(std::make_shared<StubStep>(3, true, completed));
+
+  EXPECT_THROW({ CSettingsMigration(std::move(steps)); }, std::invalid_argument);
+}

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -724,4 +724,61 @@ void XMLUtils::SetDateTime(TiXmlNode* pRootNode, const char *strTag, const CDate
 void XMLUtils::SetDateTime(tinyxml2::XMLNode* rootNode, const char* tag, const CDateTime& dateTime)
 {
   SetString(rootNode, tag, dateTime.IsValid() ? dateTime.GetAsDBDateTime() : "");
+}
+
+std::string XMLUtils::NodeStringSerialization(const TiXmlNode* node, SerializationFormat format)
+{
+  if (!node)
+    return {};
+
+  TiXmlDocument tempdoc;
+
+  const TiXmlDocument* doc = node->GetDocument();
+  if (doc == nullptr || (doc != nullptr && node != doc->RootElement()))
+  {
+    // TinyXML nodes may be freestanding. Copy and attach to a document for serialization.
+    TiXmlNode* clone = node->Clone();
+    if (clone == nullptr)
+      return {};
+
+    tempdoc.LinkEndChild(clone);
+    doc = &tempdoc;
+  }
+
+  TiXmlPrinter printer;
+  if (format == SerializationFormat::COMPACT)
+    printer.SetStreamPrinting();
+  doc->Accept(&printer);
+
+  return printer.Str();
+}
+
+std::string XMLUtils::NodeStringSerialization(const tinyxml2::XMLNode* node,
+                                              SerializationFormat format)
+{
+  if (!node)
+    return {};
+
+  tinyxml2::XMLDocument tempdoc;
+
+  // Every node in TinyXML-2 must be owned by a document, but special measures are still needed
+  // to serialize a non-root node
+  const tinyxml2::XMLDocument* doc = node->GetDocument();
+  if (doc == nullptr)
+    return {};
+
+  if (node != doc->RootElement())
+  {
+    tinyxml2::XMLNode* clone = node->DeepClone(&tempdoc);
+    if (clone == nullptr)
+      return {};
+
+    tempdoc.LinkEndChild(clone);
+    doc = &tempdoc;
+  }
+
+  tinyxml2::XMLPrinter printer(nullptr, format == SerializationFormat::PRETTY ? false : true);
+  doc->Accept(&printer);
+
+  return printer.CStr();
 }

--- a/xbmc/utils/XMLUtils.cpp
+++ b/xbmc/utils/XMLUtils.cpp
@@ -782,3 +782,42 @@ std::string XMLUtils::NodeStringSerialization(const tinyxml2::XMLNode* node,
 
   return printer.CStr();
 }
+
+bool XMLUtils::RemoveNode(TiXmlNode* node)
+{
+  if (node == nullptr)
+    return false;
+
+  TiXmlNode* parent = node->Parent();
+
+  if (parent == nullptr)
+    return false;
+
+  // TinyXml doesn't allow removal of the root of the document and does nothing.
+  if (parent->Type() == TiXmlNode::TINYXML_DOCUMENT)
+    return false;
+
+  if (!parent->RemoveChild(node))
+    return false;
+
+  return true;
+}
+
+bool XMLUtils::RemoveNode(tinyxml2::XMLNode* node)
+{
+  if (node == nullptr)
+    return false;
+
+  tinyxml2::XMLNode* parent = node->Parent();
+
+  if (parent == nullptr)
+    return false;
+
+  // TinyXml doesn't allow removal of the root of the document and does nothing.
+  if (parent->ToDocument() != nullptr)
+    return false;
+
+  parent->DeleteChild(node);
+
+  return true;
+}

--- a/xbmc/utils/XMLUtils.h
+++ b/xbmc/utils/XMLUtils.h
@@ -172,6 +172,9 @@ public:
            NodeStringSerialization(node2, SerializationFormat::COMPACT);
   }
 
+  static bool RemoveNode(TiXmlNode* node);
+  static bool RemoveNode(tinyxml2::XMLNode* node);
+
   static const int path_version = 1;
 };
 

--- a/xbmc/utils/XMLUtils.h
+++ b/xbmc/utils/XMLUtils.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -149,6 +149,28 @@ public:
   static void SetLong(tinyxml2::XMLNode* rootNode, const char* tag, long value);
   static void SetDate(tinyxml2::XMLNode* rootNode, const char* tag, const CDateTime& date);
   static void SetDateTime(tinyxml2::XMLNode* rootNode, const char* tag, const CDateTime& dateTime);
+
+  enum class SerializationFormat
+  {
+    PRETTY,
+    COMPACT,
+  };
+
+  static std::string NodeStringSerialization(const TiXmlNode* node, SerializationFormat format);
+  static std::string NodeStringSerialization(const tinyxml2::XMLNode* node,
+                                             SerializationFormat format);
+
+  template<class T>
+  static bool AreNodesSerializationsEqual(const T* node1, const T* node2)
+  {
+    if (node1 == node2)
+      return true;
+    if (!node1 || !node2)
+      return false;
+
+    return NodeStringSerialization(node1, SerializationFormat::COMPACT) ==
+           NodeStringSerialization(node2, SerializationFormat::COMPACT);
+  }
 
   static const int path_version = 1;
 };

--- a/xbmc/utils/test/TestXMLUtils.cpp
+++ b/xbmc/utils/test/TestXMLUtils.cpp
@@ -679,3 +679,145 @@ TEST(TestXMLUtils, NodeSerializationPretty)
                                                           XMLUtils::SerializationFormat::PRETTY));
   }
 }
+
+TEST(TestXMLUtils, RemoveNodeFastFail)
+{
+  const std::string XmlDocument = "<root><node>some string</node></root>";
+  {
+    CXBMCTinyXML doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+
+    // the root element can't be deleted
+    EXPECT_FALSE(XMLUtils::RemoveNode(doc.RootElement()));
+
+    EXPECT_FALSE(XMLUtils::RemoveNode(static_cast<TiXmlElement*>(nullptr)));
+  }
+
+  {
+    CXBMCTinyXML2 doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+
+    // the root element can't be deleted
+    EXPECT_FALSE(XMLUtils::RemoveNode(doc.RootElement()));
+
+    EXPECT_FALSE(XMLUtils::RemoveNode(static_cast<tinyxml2::XMLElement*>(nullptr)));
+  }
+}
+
+TEST(TestXMLUtils, RemoveNode)
+{
+  const std::string XmlDocument = "<root><node>some string</node><other>string</other></root>";
+  {
+    CXBMCTinyXML doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    TiXmlNode* node = doc.RootElement()->FirstChildElement("node");
+
+    EXPECT_TRUE(XMLUtils::RemoveNode(node));
+    std::string expected = "<root><other>string</other></root>";
+
+    EXPECT_EQ(expected, XMLUtils::NodeStringSerialization(doc.RootElement(),
+                                                          XMLUtils::SerializationFormat::COMPACT));
+  }
+
+  {
+    CXBMCTinyXML2 doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    tinyxml2::XMLNode* root = doc.RootElement();
+    tinyxml2::XMLNode* node = root->FirstChildElement("node");
+
+    EXPECT_TRUE(XMLUtils::RemoveNode(node));
+    std::string expected = "<root><other>string</other></root>";
+
+    EXPECT_EQ(expected, XMLUtils::NodeStringSerialization(doc.RootElement(),
+                                                          XMLUtils::SerializationFormat::COMPACT));
+  }
+}
+
+TEST(TestXMLUtils, RemoveNodeWithChild)
+{
+  const std::string XmlDocument =
+      "<root><node><child>some string</child></node><other>string</other></root>";
+  {
+    CXBMCTinyXML doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    TiXmlNode* node = doc.RootElement()->FirstChildElement("node");
+
+    EXPECT_TRUE(XMLUtils::RemoveNode(node));
+    std::string expected = "<root><other>string</other></root>";
+
+    EXPECT_EQ(expected, XMLUtils::NodeStringSerialization(doc.RootElement(),
+                                                          XMLUtils::SerializationFormat::COMPACT));
+  }
+
+  {
+    CXBMCTinyXML2 doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    tinyxml2::XMLNode* root = doc.RootElement();
+    tinyxml2::XMLNode* node = root->FirstChildElement("node");
+
+    EXPECT_TRUE(XMLUtils::RemoveNode(node));
+    std::string expected = "<root><other>string</other></root>";
+
+    EXPECT_EQ(expected, XMLUtils::NodeStringSerialization(doc.RootElement(),
+                                                          XMLUtils::SerializationFormat::COMPACT));
+  }
+}
+
+TEST(TestXMLUtils, RemoveChildNode)
+{
+  const std::string XmlDocument =
+      "<root><node>node string<child>some string</child></node><other>string</other></root>";
+  {
+    CXBMCTinyXML doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    TiXmlNode* node = doc.RootElement()->FirstChildElement("node");
+    node = node->FirstChildElement("child");
+
+    EXPECT_TRUE(XMLUtils::RemoveNode(node));
+    std::string expected = "<root><node>node string</node><other>string</other></root>";
+
+    EXPECT_EQ(expected, XMLUtils::NodeStringSerialization(doc.RootElement(),
+                                                          XMLUtils::SerializationFormat::COMPACT));
+  }
+  {
+    CXBMCTinyXML2 doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    tinyxml2::XMLNode* root = doc.RootElement();
+    tinyxml2::XMLNode* node = root->FirstChildElement("node");
+    node = node->FirstChildElement("child");
+
+    EXPECT_TRUE(XMLUtils::RemoveNode(node));
+    std::string expected = "<root><node>node string</node><other>string</other></root>";
+
+    EXPECT_EQ(expected, XMLUtils::NodeStringSerialization(doc.RootElement(),
+                                                          XMLUtils::SerializationFormat::COMPACT));
+  }
+}
+
+TEST(TestXMLUtils, RemoveNodeFreestanding)
+{
+  const std::string XmlDocument = "<root><node>some string</node><other>string</other></root>";
+  {
+    CXBMCTinyXML doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    TiXmlNode* node = doc.RootElement()->FirstChildElement("node");
+
+    TiXmlNode* clone = node->Clone();
+
+    EXPECT_FALSE(XMLUtils::RemoveNode(clone));
+
+    TiXmlDocument tempdoc;
+    tempdoc.LinkEndChild(clone);
+  }
+
+  {
+    CXBMCTinyXML2 doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    tinyxml2::XMLNode* root = doc.RootElement();
+    tinyxml2::XMLNode* node = root->FirstChildElement("node");
+
+    tinyxml2::XMLNode* clone = node->DeepClone(nullptr);
+
+    EXPECT_FALSE(XMLUtils::RemoveNode(clone));
+  }
+}

--- a/xbmc/utils/test/TestXMLUtils.cpp
+++ b/xbmc/utils/test/TestXMLUtils.cpp
@@ -584,3 +584,98 @@ TEST(TestXMLUtils, SetDateTime)
   EXPECT_TRUE(XMLUtils::GetDateTime(b.RootElement(), "node", val2));
   EXPECT_TRUE(ref == val2);
 }
+
+TEST(TestXMLUtils, NodeSerializationRoot)
+{
+  const std::string XmlDocument = "<root><node>some string</node></root>";
+  const std::string expected = "<root><node>some string</node></root>";
+
+  {
+    // 1 - the node belongs to a document
+    CXBMCTinyXML doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    EXPECT_EQ(expected, XMLUtils::NodeStringSerialization(doc.RootElement(),
+                                                          XMLUtils::SerializationFormat::COMPACT));
+
+    // 2 - the node is not attached to a document
+    TiXmlNode* node = doc.RootElement()->Clone();
+    EXPECT_EQ(expected,
+              XMLUtils::NodeStringSerialization(node, XMLUtils::SerializationFormat::COMPACT));
+    // the node is still functional after serialization
+    EXPECT_NE(nullptr, node->FirstChildElement("node"));
+    // Free allocated memory
+    TiXmlDocument tempdoc;
+    tempdoc.LinkEndChild(node);
+  }
+  {
+    // TinyXML2 doesn't allow freestanding XMLNodes. They are always memory-managed by a XMLDocument.
+    CXBMCTinyXML2 doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    EXPECT_EQ(expected, XMLUtils::NodeStringSerialization(doc.RootElement(),
+                                                          XMLUtils::SerializationFormat::COMPACT));
+  }
+}
+
+TEST(TestXMLUtils, NodeSerializationChild)
+{
+  const std::string XmlDocument = "<root><node>some string</node></root>";
+  const std::string expected = "<node>some string</node>";
+
+  {
+    CXBMCTinyXML doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    TiXmlElement* elem = doc.RootElement()->FirstChildElement("node");
+    EXPECT_EQ(expected,
+              XMLUtils::NodeStringSerialization(elem, XMLUtils::SerializationFormat::COMPACT));
+  }
+  {
+    // TinyXML2 doesn't allow freestanding XMLNodes. They are always memory-managed by a XMLDocument.
+    CXBMCTinyXML2 doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    tinyxml2::XMLElement* elem = doc.RootElement()->FirstChildElement("node");
+
+    EXPECT_EQ(expected,
+              XMLUtils::NodeStringSerialization(elem, XMLUtils::SerializationFormat::COMPACT));
+  }
+}
+
+TEST(TestXMLUtils, NodeSerializationCompact)
+{
+  const std::string XmlDocument = "<root><node>some string</node></root>";
+  const std::string expected = "<root><node>some string</node></root>";
+
+  {
+    CXBMCTinyXML doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    EXPECT_EQ(expected, XMLUtils::NodeStringSerialization(doc.RootElement(),
+                                                          XMLUtils::SerializationFormat::COMPACT));
+  }
+  {
+    CXBMCTinyXML2 doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    EXPECT_EQ(expected, XMLUtils::NodeStringSerialization(doc.RootElement(),
+                                                          XMLUtils::SerializationFormat::COMPACT));
+  }
+}
+
+TEST(TestXMLUtils, NodeSerializationPretty)
+{
+  const std::string XmlDocument = "<root><node>some string</node></root>";
+  const std::string expected = R"(<root>
+    <node>some string</node>
+</root>
+)";
+
+  {
+    CXBMCTinyXML doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    EXPECT_EQ(expected, XMLUtils::NodeStringSerialization(doc.RootElement(),
+                                                          XMLUtils::SerializationFormat::PRETTY));
+  }
+  {
+    CXBMCTinyXML2 doc;
+    EXPECT_TRUE(doc.Parse(XmlDocument));
+    EXPECT_EQ(expected, XMLUtils::NodeStringSerialization(doc.RootElement(),
+                                                          XMLUtils::SerializationFormat::PRETTY));
+  }
+}

--- a/xbmc/video/test/TestVideoInfoTag.cpp
+++ b/xbmc/video/test/TestVideoInfoTag.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2025 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,6 +8,7 @@
 
 #include "test/TestUtils.h"
 #include "utils/XBMCTinyXML.h"
+#include "utils/XMLUtils.h"
 #include "video/VideoInfoTag.h"
 
 #include <map>
@@ -65,11 +66,8 @@ TEST(TestVideoInfoTag, SaveTVShowSeasons)
   CXBMCTinyXML xmlDoc;
   details.ForwardSaveTvShowSeasons(&xmlDoc);
 
-  TiXmlPrinter printer;
-  xmlDoc.Accept(&printer);
-  std::string result = printer.Str();
-
-  EXPECT_EQ(result, referenceXml);
+  EXPECT_EQ(referenceXml, XMLUtils::NodeStringSerialization(xmlDoc.RootElement(),
+                                                            XMLUtils::SerializationFormat::PRETTY));
 }
 
 TEST(TestVideoInfoTag, SetUniqueIDs)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Create a mechanism to enable changing the definition of setting names and data types in a way similar to database upgrades.

Before loading a settings file, the settings manager checks the version and runs upgrade functions that transform the XML settings file in memory, and the settings are loaded in memory with the transformations applied.
The settings file is then automatically persisted through existing mechanisms, with the updated version number and the modified settings.

A settings version bump can transform a boolean setting into an integer setting for example:
from
```
<settings version="2">
    <setting id="videolibrary.ignorevideoversions" default="true">true</setting>
</settings>
```

to
```
<settings version="3">
    <setting id="videolibrary.similarvideoaction" default="true">0</setting>
</settings>
```

Included in this PR: a boolean to integer setting converter since it's needed by two follow-up PRs, but other type-specialized or adhoc conversions could be added easily.
The update functions can transform the settings XML tree in any way they want and should be unit-tested!

### Example version upgrade, with bool to int conversion:

in SettingsManager.cpp, bump the version:
```
const uint32_t CSettingsManager::Version = 4;
```

create/add to SettingsMigrationStep.h/.cpp a handler for the new version:
```
class CSettingsMigrationToV4 : public ISettingsMigrationStep
{
public:
  int TargetVersion() const override { return 4; }
  bool Apply(TiXmlElement* root) override
  {
    constexpr std::string_view oldSettingId = "videolibrary.ignorevideoversions";
    constexpr std::string_view newSettingId = "videolibrary.similarvideoaction";

    return CSettingsMigration::SettingConversionResult::FAILURE !=
           CSettingsMigration::ConvertSettingBoolToInt(root, oldSettingId, newSettingId,
                                                       {.m_default = 0, .m_false = 1, .m_true = 0});
  }
};
```

add the handler to the list of migration steps:
```
CSettingsMigration::CSettingsMigration()
{
  std::vector<std::shared_ptr<ISettingsMigrationStep>> migrations{
      std::make_shared<CSettingsMigrationToV3>(),
      std::make_shared<CSettingsMigrationToV4>(),
  };

  CSettingsMigration(std::move(migrations));
}

```
The update framework handles settings file in V2 format (like the current guisettings.xml) and V1 format (like settings set through advancedsettings.xml). The new settings are generated in-memory in V2 format only, understood by the SettingManager regardless of context.

Optional optimization added to look for settings in the V2 settings file format first as they're more commonly used than the older V1 format.


Mostly finished, a few design points remain:
- should each settings file have its own version number and upgrade function
- ~handling of updated parameter of CSettingsManager::Load() - should it always be set to true for a version bump, even if the migration had no effect (old settings were not present).~ yes
- should the setting conversions use CSetting existing serialization/deserialization functions, or reimplement them for true decoupling in case they evolve in the future

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prerequisite for PR #28191 and #28349.

A generic mechanism is needed to address the needs of changes like #28191 and #28349 that want to transform a boolean setting into an integer setting, with mapping of true/false values to new int values.
Also makes changes like #21881 possible (change integer setting value interpretation) because the system can now remember whether the value should be interpreted as a new int or an old int

This also avoids running upgrade code every time settings are loaded (unlike the existing SettingUpdate mechanism - which cannot be removed immediately - maybe with further study).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Lots of unit tests written to verify the scenarios.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

No immediate effect, enables a smoother transition for other PRs that change a setting definition.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
