### PR TITLE
[android] Fix crash-on-boot on Android caused by OS cache trimming of unpacked assets

### DIFF
--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -205,7 +205,7 @@ public class Splash extends Activity
             {
               sendEmptyMessage(InError);
             }
-            if (cachedAssetsPresent() && fXbmcHome.lastModified() >= fPackagePath.lastModified())
+            if (fXbmcHome.exists() && fXbmcHome.lastModified() >= fPackagePath.lastModified())
             {
               mState = CachingDone;
               mCachingDone = true;
@@ -425,34 +425,6 @@ public class Splash extends Activity
             .setMovementMethod(LinkMovementMethod.getInstance());
   }
 
-  // Android may delete individual files from getCacheDir() at any time to
-  // reclaim storage (see Context.getCacheDir()). When that happens the cache
-  // directory still exists with an up-to-date timestamp, so the exists()+mtime
-  // check below wrongly concludes the payload is already unpacked and skips
-  // extraction. Kodi then hard-crashes in native code when it cannot open an
-  // evicted asset such as special://xbmc/system/settings/settings.xml.
-  // Treat the cache as valid only if the essential extracted assets are still
-  // present; otherwise fall through and re-extract.
-  private boolean cachedAssetsPresent()
-  {
-    if (fXbmcHome == null || !fXbmcHome.exists())
-      return false;
-
-    String[] essential = {
-      "assets/system/settings/settings.xml",
-      "assets/system/addon-manifest.xml",
-    };
-    for (String rel : essential)
-    {
-      if (!new File(fXbmcHome, rel).exists())
-      {
-        Log.w(TAG, "Cached asset missing (" + rel + "); forcing re-extraction");
-        return false;
-      }
-    }
-    return true;
-  }
-
   private void SetupEnvironment()
   {
     sXbmcHome = XBMCProperties.getStringProperty("xbmc.home", "");
@@ -482,8 +454,16 @@ public class Splash extends Activity
     File fCacheDir = getCacheDir();
     if (sXbmcHome.isEmpty())
     {
-      sXbmcHome = fCacheDir.getAbsolutePath() + "/apk";
+      // Unpack into no_backup storage rather than the cache dir. Android may
+      // delete files from getCacheDir() at any time to reclaim space, which
+      // corrupts the unpacked payload and later crashes the native side when
+      // it cannot open an evicted asset (e.g. system/settings/settings.xml ->
+      // "Unable to load settings definitions"). getNoBackupFilesDir() is never
+      // auto-purged. Publish it through the xbmc.home property so the native
+      // side (KODI_HOME / KODI_BIN_HOME / PYTHONHOME) uses the same location.
+      sXbmcHome = getNoBackupFilesDir().getAbsolutePath() + "/apk";
       fXbmcHome = new File(sXbmcHome);
+      System.setProperty("xbmc.home", sXbmcHome);
     }
     File fLibCache = new File(fCacheDir.getAbsolutePath() + "/lib");
     fLibCache.mkdirs();
@@ -696,7 +676,7 @@ public class Splash extends Activity
 
         SetupEnvironment();
 
-        if (mState != InError && cachedAssetsPresent() && fXbmcHome.lastModified() >= fPackagePath.lastModified())
+        if (mState != InError && fXbmcHome.exists() && fXbmcHome.lastModified() >= fPackagePath.lastModified())
         {
           mState = CachingDone;
           mCachingDone = true;

--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -205,7 +205,7 @@ public class Splash extends Activity
             {
               sendEmptyMessage(InError);
             }
-            if (fXbmcHome.exists() && fXbmcHome.lastModified() >= fPackagePath.lastModified())
+            if (cachedAssetsPresent() && fXbmcHome.lastModified() >= fPackagePath.lastModified())
             {
               mState = CachingDone;
               mCachingDone = true;
@@ -423,6 +423,34 @@ public class Splash extends Activity
     // Make links actually clickable
     ((TextView) myAlertDialog.findViewById(android.R.id.message))
             .setMovementMethod(LinkMovementMethod.getInstance());
+  }
+
+  // Android may delete individual files from getCacheDir() at any time to
+  // reclaim storage (see Context.getCacheDir()). When that happens the cache
+  // directory still exists with an up-to-date timestamp, so the exists()+mtime
+  // check below wrongly concludes the payload is already unpacked and skips
+  // extraction. Kodi then hard-crashes in native code when it cannot open an
+  // evicted asset such as special://xbmc/system/settings/settings.xml.
+  // Treat the cache as valid only if the essential extracted assets are still
+  // present; otherwise fall through and re-extract.
+  private boolean cachedAssetsPresent()
+  {
+    if (fXbmcHome == null || !fXbmcHome.exists())
+      return false;
+
+    String[] essential = {
+      "assets/system/settings/settings.xml",
+      "assets/system/addon-manifest.xml",
+    };
+    for (String rel : essential)
+    {
+      if (!new File(fXbmcHome, rel).exists())
+      {
+        Log.w(TAG, "Cached asset missing (" + rel + "); forcing re-extraction");
+        return false;
+      }
+    }
+    return true;
   }
 
   private void SetupEnvironment()
@@ -668,7 +696,7 @@ public class Splash extends Activity
 
         SetupEnvironment();
 
-        if (mState != InError && fXbmcHome.exists() && fXbmcHome.lastModified() >= fPackagePath.lastModified())
+        if (mState != InError && cachedAssetsPresent() && fXbmcHome.lastModified() >= fPackagePath.lastModified())
         {
           mState = CachingDone;
           mCachingDone = true;

--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -459,11 +459,11 @@ public class Splash extends Activity
       // corrupts the unpacked payload and later crashes the native side when
       // it cannot open an evicted asset (e.g. system/settings/settings.xml ->
       // "Unable to load settings definitions"). getNoBackupFilesDir() is never
-      // auto-purged. Publish it through the xbmc.home property so the native
-      // side (KODI_HOME / KODI_BIN_HOME / PYTHONHOME) uses the same location.
+      // auto-purged. The native side derives the same no_backup location on its
+      // own (see XBMCApp::SetupEnv), so this does not depend on a property that
+      // would be unset if the OS relaunches Main without going through Splash.
       sXbmcHome = getNoBackupFilesDir().getAbsolutePath() + "/apk";
       fXbmcHome = new File(sXbmcHome);
-      System.setProperty("xbmc.home", sXbmcHome);
     }
     File fLibCache = new File(fCacheDir.getAbsolutePath() + "/lib");
     fLibCache.mkdirs();

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1665,16 +1665,13 @@ void CXBMCApp::SetupEnv()
   }
 
   std::string xbmcHome = CJNISystem::getProperty("xbmc.home", "");
-  if (xbmcHome.empty())
-  {
-    setenv("KODI_BIN_HOME", (cacheDir + "/apk/assets").c_str(), 0);
-    setenv("KODI_HOME", (cacheDir + "/apk/assets").c_str(), 0);
-  }
-  else
-  {
-    setenv("KODI_BIN_HOME", (xbmcHome + "/assets").c_str(), 0);
-    setenv("KODI_HOME", (xbmcHome + "/assets").c_str(), 0);
-  }
+  // When xbmc.home is set (e.g. the bootstrap unpacks into no_backup storage to
+  // avoid the OS evicting cached assets) every asset path must follow it,
+  // including PYTHONHOME below - otherwise the interpreter is looked up in the
+  // empty cache dir and add-ons fail to load.
+  std::string assetsHome = xbmcHome.empty() ? (cacheDir + "/apk/assets") : (xbmcHome + "/assets");
+  setenv("KODI_BIN_HOME", assetsHome.c_str(), 0);
+  setenv("KODI_HOME", assetsHome.c_str(), 0);
   setenv("KODI_BINADDON_PATH", (cacheDir + "/lib").c_str(), 0);
 
   std::string externalDir = CJNISystem::getProperty("xbmc.data", "");
@@ -1693,7 +1690,7 @@ void CXBMCApp::SetupEnv()
   else
     setenv("HOME", getenv("KODI_TEMP"), 0);
 
-  std::string pythonPath = cacheDir + "/apk/assets/python" + CCompileInfo::GetPythonVersion();
+  std::string pythonPath = assetsHome + "/python" + CCompileInfo::GetPythonVersion();
   setenv("PYTHONHOME", pythonPath.c_str(), 1);
   setenv("PYTHONPATH", "", 1);
   setenv("PYTHONOPTIMIZE","", 1);

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1664,12 +1664,24 @@ void CXBMCApp::SetupEnv()
     setenv("KODI_TEMP", xbmcTemp.c_str(), 0);
   }
 
+  // Resolve the unpacked-asset location WITHOUT relying on the Java Splash
+  // activity having set xbmc.home. Android can relaunch the Main activity
+  // directly after killing the idle process (Main has its own MAIN intent
+  // filter), skipping Splash; and the OS evicts files from getCacheDir() under
+  // storage pressure. Both together caused a crash-on-boot when the native side
+  // fell back to the (evicted) cache. Derive no_backup - a sibling of cache
+  // that the OS never auto-purges - directly from the cache path, so every asset
+  // path is correct regardless of how the process was started. (libandroidjni
+  // in this branch only binds getCacheDir(), hence the string derivation.)
+  std::string assetsBase = cacheDir;
+  const std::string cacheSuffix = "/cache";
+  if (assetsBase.size() >= cacheSuffix.size() &&
+      assetsBase.compare(assetsBase.size() - cacheSuffix.size(), cacheSuffix.size(), cacheSuffix) == 0)
+    assetsBase.resize(assetsBase.size() - cacheSuffix.size());
+
   std::string xbmcHome = CJNISystem::getProperty("xbmc.home", "");
-  // When xbmc.home is set (e.g. the bootstrap unpacks into no_backup storage to
-  // avoid the OS evicting cached assets) every asset path must follow it,
-  // including PYTHONHOME below - otherwise the interpreter is looked up in the
-  // empty cache dir and add-ons fail to load.
-  std::string assetsHome = xbmcHome.empty() ? (cacheDir + "/apk/assets") : (xbmcHome + "/assets");
+  std::string assetsHome =
+      xbmcHome.empty() ? (assetsBase + "/no_backup/apk/assets") : (xbmcHome + "/assets");
   setenv("KODI_BIN_HOME", assetsHome.c_str(), 0);
   setenv("KODI_HOME", assetsHome.c_str(), 0);
   setenv("KODI_BINADDON_PATH", (cacheDir + "/lib").c_str(), 0);


### PR DESCRIPTION
Please note: This entire PR, code and all, was generated by Claude Code from a couple of prompts.  I literally just asked it to debug the live version of the app running on my Chromecast and it did it without any human intervention.

I've manually checked the code myself.  From my perspective as a C++ developer, after the second prompt to revise the approach (see commit 2), it looks clean and the logic makes sense (new folder is immune to Android cache trimming).

I also manually checked which API version introduced the no_backup folder and it's been there since 5.0, so no issues on that part either.

I've attached the full log here if anyone else wants to read through it, but honestly I'm in genuine awe.
[2026-06-06-141445-whenever-i-launch-kodi-on-my-chromecast-4k-it-cr.txt](https://github.com/user-attachments/files/28659304/2026-06-06-141445-whenever-i-launch-kodi-on-my-chromecast-4k-it-cr.txt)

Going to do a little bit more testing before publishing the PR, but as of now the kids are watching Paw Patrol and it's working perfectly.

Anyway, below is Claude's (slightly hand-edited) ~AI slop~ clean solution to a years-old problem.

## Problem

On Android, Kodi unpacks its bundled `assets/` (skins, the Python runtime, and the core `system/` files including `system/settings/settings.xml`) into the app's `getCacheDir()` on first run, and the native side reads them back from there (`KODI_HOME`, `KODI_BIN_HOME`, `PYTHONHOME`).

`getCacheDir()` is, by Android's own contract, storage the system may delete from at any time to reclaim space — and it deletes **individual files**, leaving the unpack directory present with an up-to-date timestamp. The bootstrap's `exists() + mtime` check then concludes the payload is already unpacked and skips re-extraction, after which the native side hard-crashes trying to open an evicted asset:

```
CSettings: error loading settings definition from special://xbmc/system/settings/settings.xml
Failed to open file
critical <general>: Unable to load settings definitions
F libc   : Fatal signal 11 (SIGSEGV) ... in CSettingsManager::GetSetting
```

To users this looks like "Kodi crashes on launch", typically on storage-constrained devices (e.g. Chromecast with Google TV). Clearing the app cache "fixes" it (a full clear removes the directory, forcing a clean re-extract) until the OS trims the cache again.

## Fix
[2026-06-06-141445-whenever-i-launch-kodi-on-my-chromecast-4k-it-cr.txt](https://github.com/user-attachments/files/28659274/2026-06-06-141445-whenever-i-launch-kodi-on-my-chromecast-4k-it-cr.txt)

Unpack into `getNoBackupFilesDir()` instead of `getCacheDir()`. The OS does not auto-purge no_backup storage, so the payload stays intact and the crash (and the repeated re-extraction it triggers) cannot happen. `no_backup` rather than `files` so ~100 MB of regenerable assets aren't pushed into cloud backup.

Both sides must agree on the location:
- `Splash.java.in`: unpack into `getNoBackupFilesDir()/apk` and publish it via the existing `xbmc.home` system property.
- `XBMCApp.cpp`: derive every asset path (`KODI_HOME`, `KODI_BIN_HOME`, and the one previously hard-coded to the cache, `PYTHONHOME`) from a single `assetsHome` that honours `xbmc.home`.

## Testing

Built from this branch for `armeabi-v7a` and run on a Chromecast with Google TV 4K (Android 14) that was previously crash-looping:

- `special://xbmc/` now maps to `…/no_backup/apk/assets`.
- Boots fully into the skin; Python add-ons load (PYTHONHOME resolves correctly); no more "Unable to load settings definitions" crash and no recurring first-run extraction screen.

A ready-to-sideload test build (armeabi-v7a, **self-signed — not an official build**) is attached for others to reproduce/test:
👉 https://github.com/EspoTek/xbmc/releases/download/android-nobackup-test-21.2/kodi-21.2-nobackup-fix.apk

> Note for reviewers: standalone executables shipped by add-ons (e.g. Elementum's torrent daemon) can no longer be `execve`'d from no_backup the way they could from cache on some devices; Elementum transparently falls back to its in-process shared-library mode. Flagging in case binary-addon exec paths warrant keeping a cache-based, exec-capable location for that specific case.

---

### Addendum — initial approach (superseded, kept in history)

The first attempt (commit `a884cd9`) took a more conservative, recover-from-failure tack instead of preventing the eviction: keep unpacking into the cache, but before trusting it, verify a couple of essential extracted assets (`system/settings/settings.xml`, `system/addon-manifest.xml`) still exist — and if the OS has evicted them, fall through to a full re-extract rather than crash. It is dex/bootstrap-only (no native change) and leaves Kodi's storage layout and binary-exec behaviour exactly as today.

It works, but only *recovers* from eviction: each time the OS trims the cache, the user still sees the "Preparing for first run" extraction screen. The no_backup approach in the final commit prevents the eviction entirely, so it was chosen instead. The initial commit is retained in this branch's history so both options are visible.
