### PR TITLE
VAAPI: guard VAProfileH264High10 on libva >= 2.18

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -660,6 +660,7 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
         if (!m_vaapiConfig.context->SupportsProfile(profile))
           return false;
       }
+#if VA_CHECK_VERSION(1, 18, 0)
       else if (avctx->profile == AV_PROFILE_H264_HIGH_10 && m_vaapiConfig.bitDepth == 10 &&
                m_capFormats.Supports(AV_PIX_FMT_P010))
       {
@@ -667,6 +668,7 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
         if (!m_vaapiConfig.context->SupportsProfile(profile))
           return false;
       }
+#endif
       else
       {
         if (avctx->profile == AV_PROFILE_H264_MAIN)
@@ -1265,8 +1267,10 @@ bool CDecoder::ConfigVAAPI()
 
   if ((m_vaapiConfig.profile == VAProfileHEVCMain10 ||
        m_vaapiConfig.profile == VAProfileVP9Profile2 ||
-       m_vaapiConfig.profile == VAProfileAV1Profile0 ||
-       m_vaapiConfig.profile == VAProfileH264High10) &&
+#if VA_CHECK_VERSION(1, 18, 0)
+       m_vaapiConfig.profile == VAProfileH264High10 ||
+#endif
+       m_vaapiConfig.profile == VAProfileAV1Profile0) &&
       m_vaapiConfig.bitDepth == 10)
   {
     format = VA_RT_FORMAT_YUV420_10BPP;


### PR DESCRIPTION
## Description
fix build failure on #28276 

## Motivation and context
n/a

## How has this been tested?
build test.

## What is the effect on users?
n/a

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
