### PR TITLE
use VAProfileH264High as a fallback for libva versions < 2.18 where V…

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -53,6 +53,12 @@ using namespace std::chrono_literals;
 
 #define NUM_RENDER_PICS 7
 
+#ifndef VAProfileH264High10
+    #define VAProfileH264High10_Fallback VAProfileH264High
+#else
+    #define VAProfileH264High10_Fallback VAProfileH264High10
+#endif
+
 constexpr auto SETTING_VIDEOPLAYER_USEVAAPI = "videoplayer.usevaapi";
 constexpr auto SETTING_VIDEOPLAYER_USEVAAPIAV1 = "videoplayer.usevaapiav1";
 constexpr auto SETTING_VIDEOPLAYER_USEVAAPIAVC = "videoplayer.usevaapiavc";
@@ -663,7 +669,7 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
       else if (avctx->profile == AV_PROFILE_H264_HIGH_10 && m_vaapiConfig.bitDepth == 10 &&
                m_capFormats.Supports(AV_PIX_FMT_P010))
       {
-        profile = VAProfileH264High10;
+        profile = VAProfileH264High10_Fallback;
         if (!m_vaapiConfig.context->SupportsProfile(profile))
           return false;
       }
@@ -1266,7 +1272,7 @@ bool CDecoder::ConfigVAAPI()
   if ((m_vaapiConfig.profile == VAProfileHEVCMain10 ||
        m_vaapiConfig.profile == VAProfileVP9Profile2 ||
        m_vaapiConfig.profile == VAProfileAV1Profile0 ||
-       m_vaapiConfig.profile == VAProfileH264High10) &&
+       m_vaapiConfig.profile == VAProfileH264High10_Fallback) &&
       m_vaapiConfig.bitDepth == 10)
   {
     format = VA_RT_FORMAT_YUV420_10BPP;


### PR DESCRIPTION
…AProfileH264High10

## Motivation and context
fix build on debian bookworm where libva is version 2.17 and `VAProfileH264High10` isnt introduced yet.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

thanks @fuzzard for the hint