### PR TITLE
GBM/DRM: fix FindVideoAndGuiPlane failure log

### DIFF
--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -300,9 +300,7 @@ bool CDRMUtils::FindVideoAndGuiPlane(uint32_t format,
       continue;
     if (output_format.alpha < 8)
     {
-      CLog::LogF(LOGWARNING,
-                 "GUI plane format {} can not do alpha blending, "
-                 "falling back to single-plane EGL import (GUI composited over video)",
+      CLog::LogF(LOGWARNING, "GUI plane format {} cannot do alpha blending",
                  DRMHELPERS::FourCCToString(m_gui_plane->GetFormat()));
       m_video_plane = nullptr;
       return false;
@@ -360,11 +358,10 @@ bool CDRMUtils::FindVideoAndGuiPlane(uint32_t format,
   }
 
   CLog::LogF(LOGWARNING,
-             "Rendering will be done through EGL. "
-             "Can not find a Video Plane [{}x{}] format:{}, modifier:{} "
+             "Cannot find a Video Plane [{}x{}] format:{}, modifier:{} "
              "together with a Gui Plane [{}x{}] format:{}, modifier:{}.",
-             res.iWidth, res.iHeight, DRMHELPERS::FourCCToString(format),
-             DRMHELPERS::ModifierToString(modifier), width, height,
+             width, height, DRMHELPERS::FourCCToString(format),
+             DRMHELPERS::ModifierToString(modifier), res.iWidth, res.iHeight,
              DRMHELPERS::FourCCToString(m_gui_plane->GetFormat()),
              DRMHELPERS::ModifierToString(m_gui_plane->GetModifier()));
   return false;


### PR DESCRIPTION
## Description

Drop the "Rendering will be done through EGL." sentence: DRMUtils does not own renderer selection and the EGL DMA-buf fallback path is gated on useprimerenderer=1, so the prediction can be wrong.

Also swap the width/height argument positions so they bind to the correct plane in the format string (matching the success log above).

This was a latent problem in #27402.

## Motivation and context
Fix misleading log.  DRMPRIMEGLES is not a fallback from DRMPRIME.  We could make it so that there is work to make DRMRPIME fallbacks work generally.,

## How has this been tested?
Intel N250.

## What is the effect on users?
Only see this during logdebug

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
