### PR TITLE
[VideoInfoScanner] Continue scan on INFO_ERROR instead of aborting

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -691,14 +691,17 @@ CVideoInfoScanner::~CVideoInfoScanner()
         FoundSomeInfo = false;
         break;
       }
-      if (ret == InfoRet::CANCELLED || ret == InfoRet::INFO_ERROR)
+      if (ret == InfoRet::CANCELLED)
+      {
+        break;
+      }
+      if (ret == InfoRet::INFO_ERROR)
       {
         CLog::Log(LOGWARNING,
                   "VideoInfoScanner: Error {} occurred while retrieving"
                   "information for {}.",
                   static_cast<int>(ret), CURL::GetRedacted(pItem->GetPath()));
-        FoundSomeInfo = false;
-        break;
+        continue;
       }
       if (ret == InfoRet::ADDED || ret == InfoRet::HAVE_ALREADY)
         FoundSomeInfo = true;


### PR DESCRIPTION
## Summary

When `RetrieveInfoForTvShow`/`Movie`/`MusicVideo` returns `InfoRet::INFO_ERROR` (a per-item DB write failure), the scan loop was hitting the same `break` used for `InfoRet::CANCELLED`. This silently aborts scanning of **all subsequent library items** whenever any single item fails.

The two cases should be handled differently:
- `CANCELLED` — user explicitly stopped the scan → `break` (unchanged)
- `INFO_ERROR` — transient failure for one item → `continue` to the next item

## Root cause / reproduction

With a MySQL/MariaDB backend: if one episode NFO contains a 4-byte Unicode character (e.g. `𠮟` U+20B9F, CJK Extension B) and the MySQL session charset is `utf8mb3`, the `UPDATE episode SET ...` query fails with Error 1366. `SetDetailsForEpisode` returns false → `RetrieveInfoForEpisodes` → `RetrieveInfoForTvShow` returns `InfoRet::INFO_ERROR` → scan loop `break`s.

Because Kodi processes library items in directory sort order, every item sorting after the failing one is never scanned. In a library with Japanese titles this can silently block hundreds of shows (all hiragana `お`+, katakana, kanji) from ever being added.

## Relationship to utf8mb4 fix

PR #27952 addresses the root MySQL charset cause for new Kodi builds. This change is a separate, independent fix that makes the scanner resilient to *any* per-item `INFO_ERROR` regardless of its cause (bad NFO data, permissions, DB timeout, etc.).

## Test plan

- [ ] Confirm a TV show with a failing episode (e.g. DB write error) no longer aborts scanning of subsequent shows
- [ ] Confirm `CANCELLED` (user stops scan mid-way) still stops the loop immediately
- [ ] Confirm scan completes and `FoundSomeInfo` reflects items that *did* succeed