### PR TITLE
gbm: decouple Atomic DRM pass/fail separate from the connector setup

### DIFF
--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -16,8 +16,10 @@
 #include "settings/Settings.h"
 #include "utils/log.h"
 
+#include <chrono>
 #include <errno.h>
 #include <string.h>
+#include <thread>
 
 #include <drm_fourcc.h>
 #include <drm_mode.h>
@@ -204,27 +206,74 @@ void CDRMAtomic::FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, boo
   DrmAtomicCommit(!drm_fb ? 0 : drm_fb->fb_id, flags, rendered, videoLayer);
 }
 
-bool CDRMAtomic::InitDrm()
+bool CDRMAtomic::ValidateDevice(int fd)
 {
-  if (!CDRMUtils::OpenDrm(true))
-    return false;
-
-  auto ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_ATOMIC, 1);
+  // Tie the atomic-capability verdict to the same card OpenDrm() is inspecting,
+  // so a headless secondary GPU (common on PRIME laptops) can never decide the
+  // fate of the card the monitor is actually attached to. The atomic client cap
+  // must be set before universal planes are requested in CDRMUtils::InitDrm();
+  // doing it here, during the device scan, keeps that required ordering.
+  auto ret = drmSetClientCap(fd, DRM_CLIENT_CAP_ATOMIC, 1);
   if (ret)
   {
-    CLog::LogF(LOGERROR, "no atomic modesetting support: {}", strerror(errno));
+    CLog::LogF(LOGDEBUG, "no atomic modesetting support: {}", strerror(errno));
+    if (m_atomicSupport == AtomicSupport::UNKNOWN)
+      m_atomicSupport = AtomicSupport::UNSUPPORTED;
     return false;
   }
 
-  m_atomicRequestQueue.emplace_back(std::make_unique<CDRMAtomicRequest>());
-  m_req = m_atomicRequestQueue.back().get();
-
-  if (!CDRMUtils::InitDrm())
-    return false;
-
-  CLog::LogF(LOGDEBUG, "initialized atomic DRM");
-
+  m_atomicSupport = AtomicSupport::SUPPORTED;
   return true;
+}
+
+bool CDRMAtomic::InitDrm()
+{
+  // A connector's status can be transiently unknown/disconnected at cold boot
+  // (the HPD/EDID probe may not have completed yet, notably on amdgpu), which
+  // makes the connector search fail even though atomic-capable hardware is
+  // present. Re-scan every card a few times with a delay before giving up, so a
+  // not-yet-ready display does not demote Kodi to legacy DRM. The retry only
+  // runs while at least one scanned card is atomic-capable, so genuinely
+  // legacy-only systems fall through immediately. A permanently headless
+  // atomic card (or an atomic card whose display only ever lives on a separate
+  // non-atomic GPU) cannot be told apart from a display that is about to
+  // appear, so those rarer cases pay the bounded retry delay before correctly
+  // settling on legacy.
+  constexpr int maxPasses = 3;
+  constexpr auto retryDelay = std::chrono::milliseconds(500);
+
+  for (int pass = 0; pass < maxPasses; ++pass)
+  {
+    m_atomicSupport = AtomicSupport::UNKNOWN;
+
+    if (CDRMUtils::OpenDrm(true))
+    {
+      if (m_atomicRequestQueue.empty())
+      {
+        m_atomicRequestQueue.emplace_back(std::make_unique<CDRMAtomicRequest>());
+        m_req = m_atomicRequestQueue.back().get();
+      }
+
+      if (!CDRMUtils::InitDrm())
+        return false;
+
+      CLog::LogF(LOGDEBUG, "initialized atomic DRM");
+      return true;
+    }
+
+    if (m_atomicSupport != AtomicSupport::SUPPORTED)
+      break;
+
+    if (pass + 1 < maxPasses)
+    {
+      CLog::LogF(LOGWARNING,
+                 "atomic-capable device present but no connector ready, re-scanning ({}/{})",
+                 pass + 1, maxPasses);
+      std::this_thread::sleep_for(retryDelay);
+    }
+  }
+
+  return false;
 }
 
 void CDRMAtomic::DestroyDrm()

--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
@@ -26,6 +26,13 @@ namespace GBM
 class CDRMAtomic : public CDRMUtils
 {
 public:
+  enum class AtomicSupport
+  {
+    UNKNOWN,
+    UNSUPPORTED,
+    SUPPORTED,
+  };
+
   CDRMAtomic() = default;
   ~CDRMAtomic() override = default;
   void FlipPage(struct gbm_bo* bo, bool rendered, bool videoLayer, bool async) override;
@@ -33,14 +40,19 @@ public:
   bool SetActive(bool active) override;
   bool InitDrm() override;
   void DestroyDrm() override;
+
   bool SupportsFencing() override { return true; }
   bool AddProperty(CDRMObject* object, const char* name, uint64_t value);
+
+protected:
+  bool ValidateDevice(int fd) override;
 
 private:
   void DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer);
 
   bool m_need_modeset{true};
   bool m_active = true;
+  AtomicSupport m_atomicSupport{AtomicSupport::UNKNOWN};
 
   class CDRMAtomicRequest
   {

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -496,8 +496,9 @@ bool CDRMUtils::OpenDrm(bool needConnector)
     if (renderPath)
     {
       m_renderDevicePath = renderPath;
+      close(m_renderFd);
       m_renderFd = open(renderPath, O_RDWR | O_CLOEXEC);
-      if (m_renderFd != 0)
+      if (m_renderFd >= 0)
         CLog::LogF(LOGDEBUG, "Opened render node: {}", renderPath);
     }
 

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -457,6 +457,9 @@ bool CDRMUtils::OpenDrm(bool needConnector)
     if (m_fd < 0)
       continue;
 
+    if (!ValidateDevice(m_fd))
+      continue;
+
     if (needConnector)
     {
       auto resources = drmModeGetResources(m_fd);

--- a/xbmc/windowing/gbm/drm/DRMUtils.h
+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
@@ -89,6 +89,18 @@ public:
 
 protected:
   bool OpenDrm(bool needConnector);
+
+  /*!
+   * \brief Per-device validation hook invoked while scanning DRM devices.
+   *
+   * Called by OpenDrm() for each candidate device after its primary node has
+   * been opened. Returning false makes OpenDrm() skip the device and continue
+   * with the next one. The base implementation accepts every device; subclasses
+   * override it to require additional capabilities (e.g. atomic modesetting) so
+   * that the capability verdict stays tied to the same card as the connector.
+   */
+  virtual bool ValidateDevice(int fd) { return true; }
+
   drm_fb* DrmFbGetFromBo(struct gbm_bo* bo);
 
   int m_fd{-1};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

DRM atomic initialization could fail spuriously at cold boot: `OpenDrm(true)` requires a connector to already be present, but a connector's HPD/EDID probe can still be in progress at that point (notably on amdgpu), so the scan finds nothing, the atomic client cap is never tested, and Kodi permanently demotes itself to legacy DRM for the session. A first attempt at fixing this recorded the atomic-capability verdict from whichever card a `needConnector=false` scan happened to latch onto first - typically a headless secondary GPU on PRIME laptops - so the verdict could come from a different card than the one the monitor is attached to.

- Add a `ValidateDevice()` hook to the device scan so `CDRMAtomic` sets the atomic client cap per-card as each candidate device is opened, keeping the atomic verdict tied to the same card as the connector search instead of an unrelated GPU.
- Move the retry into `CDRMAtomic::InitDrm()`: re-scan every card up to 3 times with a 500ms delay before demoting to legacy, but only while an atomic-capable card is present, so legacy-only systems fall through immediately with no added delay.
- Fix a render-node fd leak in `OpenDrm()` (the previous descriptor was never closed before reopening) and correct the `m_renderFd != 0` sentinel, which mislabelled fd 0 as failure and a genuine `open()` error (-1) as success.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #28412 wherein this bug surfaced, but the underlying problem is the DRM/atomic initialization race and mis-scoped verdict described above, not anything specific to that video.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified atomic DRM initializes correctly and consistently across cold boots on an AMD Ryzen 7 8845HS w/ Radeon 780M Graphics, including the case that previously triggered #28412, without demoting to legacy DRM or killing the HDMI connection. Separately, with no monitor is attached, kodi goes into headless mode just fine.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Fixes a bug that causes monitor to go dead.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change (others should be able to reproduce the crash with the provided video)
- [ ] All new and existing tests passed

