### PR TITLE
Fix playback loginfo with proper info strings

### DIFF
--- a/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
@@ -45,8 +45,9 @@ CAudioSinkAE::~CAudioSinkAE()
 
 bool CAudioSinkAE::Create(const DVDAudioFrame &audioframe, AVCodecID codec, bool needresampler)
 {
-  CLog::Log(LOGINFO, "Creating audio stream (codec id: {}, channels: {}, sample rate: {}, {})",
-            codec, audioframe.format.m_channelLayout.Count(), audioframe.format.m_sampleRate,
+  CLog::Log(LOGINFO, "Creating audio stream (codec: {}, channels: {}, sample rate: {}, {})",
+            avcodec_get_name(codec), audioframe.format.m_channelLayout.Count(),
+            audioframe.format.m_sampleRate,
             audioframe.passthrough ? "pass-through" : "no pass-through");
 
   // if passthrough isset do something else

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -2720,6 +2720,8 @@ bool CVppPostproc::UpdateDeintMethod(EINTERLACEMETHOD method)
   m_forwardRefs = pplCaps.num_forward_references;
   m_backwardRefs = pplCaps.num_backward_references;
 
+  CLog::Log(LOGINFO, "VAAPI::CVppPostproc - deinterlacer active: {}",
+            fmt::formatter<EINTERLACEMETHOD>::ToString(method));
   return true;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -127,7 +127,7 @@ bool CVideoPlayerVideo::OpenStream(CDVDStreamInfo hint)
     // clang-format on
   }
 
-  CLog::Log(LOGINFO, "Creating video codec with codec id: {}", hint.codec);
+  CLog::Log(LOGINFO, "Creating video codec: {}", avcodec_get_name(hint.codec));
 
   if (m_messageQueue.IsInited())
   {
@@ -167,7 +167,8 @@ bool CVideoPlayerVideo::OpenStream(CDVDStreamInfo hint)
 
 void CVideoPlayerVideo::OpenStream(CDVDStreamInfo& hint, std::unique_ptr<CDVDVideoCodec> codec)
 {
-  CLog::Log(LOGDEBUG, "CVideoPlayerVideo::OpenStream - open stream with codec id: {}", hint.codec);
+  CLog::Log(LOGDEBUG, "CVideoPlayerVideo::OpenStream - open stream with codec: {}",
+            avcodec_get_name(hint.codec));
 
   m_processInfo.GetVideoBufferManager().ReleasePools();
 
@@ -218,7 +219,7 @@ void CVideoPlayerVideo::OpenStream(CDVDStreamInfo& hint, std::unique_ptr<CDVDVid
 
   if (!codec)
   {
-    CLog::Log(LOGINFO, "Creating video codec with codec id: {}", hint.codec);
+    CLog::Log(LOGINFO, "Creating video codec: {}", avcodec_get_name(hint.codec));
     hint.codecOptions |= CODEC_ALLOW_FALLBACK;
     codec = CDVDFactoryCodec::CreateVideoCodec(hint, m_processInfo);
     if (!codec)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
@@ -391,7 +391,8 @@ EShaderFormat CBaseRenderer::GetShaderFormat()
     ret = SHADER_UYVY;
   // clang-format on
   else
-    CLog::Log(LOGERROR, "CBaseRenderer::GetShaderFormat - unsupported format {}", m_format);
+    CLog::Log(LOGERROR, "CBaseRenderer::GetShaderFormat - unsupported format {}",
+              m_format == AV_PIX_FMT_NONE ? "none" : av_get_pix_fmt_name(m_format));
 
   return ret;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -179,7 +179,8 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
   // CPU-upload renderer: HWACCEL pix_fmts (e.g. AV_PIX_FMT_DRM_PRIME) have no host planes.
   if (GetShaderFormat() == SHADER_NONE)
   {
-    CLog::Log(LOGDEBUG, "LinuxRendererGLES::Configure: refusing unsupported pix_fmt {}", m_format);
+    CLog::Log(LOGDEBUG, "LinuxRendererGLES::Configure: refusing unsupported pix_fmt {}",
+              m_format == AV_PIX_FMT_NONE ? "none" : av_get_pix_fmt_name(m_format));
     return false;
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderInfo.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderInfo.h
@@ -13,6 +13,7 @@
 #include "cores/IPlayer.h"
 
 extern "C" {
+#include <libavutil/pixdesc.h>
 #include <libavutil/pixfmt.h>
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ShaderFormats.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ShaderFormats.h
@@ -45,6 +45,12 @@ struct fmt::formatter<EShaderFormat> : fmt::formatter<std::string_view>
     return fmt::formatter<string_view>::format(it->second, ctx);
   }
 
+  static constexpr std::string_view ToString(EShaderFormat f) noexcept
+  {
+    const auto it = shaderFormatMap.find(f);
+    return it != shaderFormatMap.cend() ? it->second : "unknown";
+  }
+
 private:
   static constexpr auto shaderFormatMap = make_map<EShaderFormat, std::string_view>({
       {SHADER_NONE, "none"},

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGL.cpp
@@ -106,7 +106,8 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method,
     defines += m_glslOutput->GetDefines();
   }
 
-  CLog::Log(LOGDEBUG, "GL: using scaling method: {}", m_method);
+  CLog::Log(LOGDEBUG, "GL: using scaling method: {}",
+            fmt::formatter<ESCALINGMETHOD>::ToString(m_method));
   CLog::Log(LOGDEBUG, "GL: using shader: {}", shadername);
 
   PixelShader()->LoadSource(shadername, defines);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/VideoFilterShaderGLES.cpp
@@ -104,7 +104,8 @@ ConvolutionFilterShader::ConvolutionFilterShader(ESCALINGMETHOD method, bool dit
   if (m_dither)
     defines += "#define XBMC_DITHER\n";
 
-  CLog::Log(LOGDEBUG, "GLES: using scaling method: {}", m_method);
+  CLog::Log(LOGDEBUG, "GLES: using scaling method: {}",
+            fmt::formatter<ESCALINGMETHOD>::ToString(m_method));
   CLog::Log(LOGDEBUG, "GLES: using shader: {}", shadername);
 
   PixelShader()->LoadSource(shadername, defines);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGL.cpp
@@ -82,7 +82,8 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(bool rect,
   else if (m_format == SHADER_UYVY)
     m_defines += "#define XBMC_UYVY\n";
   else
-    CLog::Log(LOGERROR, "GL: BaseYUV2RGBGLSLShader - unsupported format {}", m_format);
+    CLog::Log(LOGERROR, "GL: BaseYUV2RGBGLSLShader - unsupported format {}",
+              fmt::formatter<EShaderFormat>::ToString(m_format));
 
   if (dstPrimaries != srcPrimaries)
   {
@@ -105,8 +106,10 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(bool rect,
 
   VertexShader()->LoadSource("gl_yuv2rgb_vertex.glsl", m_defines);
 
-  CLog::Log(LOGDEBUG, "GL: using shader format: {}", m_format);
-  CLog::Log(LOGDEBUG, "GL: using tonemap method: {}", toneMapMethod);
+  CLog::Log(LOGDEBUG, "GL: using shader format: {}",
+            fmt::formatter<EShaderFormat>::ToString(m_format));
+  CLog::Log(LOGDEBUG, "GL: using tonemap method: {}",
+            fmt::formatter<ETONEMAPMETHOD>::ToString(toneMapMethod));
 
   m_convMatrix.SetDestinationColorPrimaries(dstPrimaries).SetSourceColorPrimaries(srcPrimaries);
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/YUV2RGBShaderGLES.cpp
@@ -65,7 +65,8 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format,
   else if (m_format == SHADER_Y412)
     m_defines += "#define XBMC_Y412\n";
   else
-    CLog::Log(LOGERROR, "GLES: BaseYUV2RGBGLSLShader - unsupported format {}", m_format);
+    CLog::Log(LOGERROR, "GLES: BaseYUV2RGBGLSLShader - unsupported format {}",
+              fmt::formatter<EShaderFormat>::ToString(m_format));
 
   if (dstPrimaries != srcPrimaries)
   {
@@ -90,8 +91,10 @@ BaseYUV2RGBGLSLShader::BaseYUV2RGBGLSLShader(EShaderFormat format,
 
   VertexShader()->LoadSource("gles_yuv2rgb.vert", m_defines);
 
-  CLog::Log(LOGDEBUG, "GLES: using shader format: {}", m_format);
-  CLog::Log(LOGDEBUG, "GLES: using tonemap method: {}", m_toneMappingMethod);
+  CLog::Log(LOGDEBUG, "GLES: using shader format: {}",
+            fmt::formatter<EShaderFormat>::ToString(m_format));
+  CLog::Log(LOGDEBUG, "GLES: using tonemap method: {}",
+            fmt::formatter<ETONEMAPMETHOD>::ToString(m_toneMappingMethod));
 
   m_convMatrix.SetSourceColorPrimaries(srcPrimaries).SetDestinationColorPrimaries(dstPrimaries);
 }

--- a/xbmc/cores/VideoSettings.h
+++ b/xbmc/cores/VideoSettings.h
@@ -54,6 +54,12 @@ struct fmt::formatter<EINTERLACEMETHOD> : fmt::formatter<std::string_view>
     return fmt::formatter<string_view>::format(it->second, ctx);
   }
 
+  static constexpr std::string_view ToString(EINTERLACEMETHOD m) noexcept
+  {
+    const auto it = interlaceMethodMap.find(m);
+    return it != interlaceMethodMap.cend() ? it->second : "unknown";
+  }
+
 private:
   static constexpr auto interlaceMethodMap = make_map<EINTERLACEMETHOD, std::string_view>({
       {VS_INTERLACEMETHOD_NONE, "none"},
@@ -114,6 +120,12 @@ public:
     return fmt::formatter<string_view>::format(it->second, ctx);
   }
 
+  static constexpr std::string_view ToString(ESCALINGMETHOD m) noexcept
+  {
+    const auto it = scalingMethodMap.find(m);
+    return it != scalingMethodMap.cend() ? it->second : "unknown";
+  }
+
 private:
   static constexpr auto scalingMethodMap = make_map<ESCALINGMETHOD, std::string_view>({
       {VS_SCALINGMETHOD_NEAREST, "nearest neighbour"},
@@ -133,8 +145,8 @@ private:
       {VS_SCALINGMETHOD_VDPAU_HARDWARE, "vdpau"},
       {VS_SCALINGMETHOD_DXVA_HARDWARE, "dxva"},
       {VS_SCALINGMETHOD_AUTO, "auto"},
-      {VS_SCALINGMETHOD_SPLINE36_FAST, "spline32 fast"},
-      {VS_SCALINGMETHOD_SPLINE36, "spline32"},
+      {VS_SCALINGMETHOD_SPLINE36_FAST, "spline36 fast"},
+      {VS_SCALINGMETHOD_SPLINE36, "spline36"},
   });
 
   static_assert(VS_SCALINGMETHOD_MAX == scalingMethodMap.size(),
@@ -163,6 +175,12 @@ public:
       throw std::range_error("no tonemap method string found");
 
     return fmt::formatter<string_view>::format(it->second, ctx);
+  }
+
+  static constexpr std::string_view ToString(ETONEMAPMETHOD m) noexcept
+  {
+    const auto it = tonemapMethodMap.find(m);
+    return it != tonemapMethodMap.cend() ? it->second : "unknown";
   }
 
 private:


### PR DESCRIPTION
## Description

Three small commits to make kodi.log readable.  This is mostly bringing back the functionality of PR #21957 which was lost along the way. I'm keep this short--we would ideally revert #23453 and do the template refactor but it's not worth it for Kodi v22

1. Expose the existing enum-to-string maps from #21957 via a static ToString helper inside each fmt::formatter, and call it from the shader/scaling/tonemap log sites. Also fixes a pre-existing "spline32" -> "spline36" typo.
2. Add a LOGINFO when the VAAPI VPP deinterlacer activates.
3. Wrap AVCodecID / AVPixelFormat args at common log sites with avcodec_get_name / av_get_pix_fmt_name.

## Motivation and context

PR #21957 added fmt::formatter specializations whose private string maps were the only mapping from these enums to readable names. PR #23453 added `using fmt::enums::format_as;` to log.h as a fmt 10 compat shim and silently bypassed every formatter from #21957, so the strings have not reached the log since 2023. This change exposes the maps without disturbing the shim, so existing CLog sites elsewhere continue to compile unchanged.

## How has this been tested?

Intel N250 (Twin Lake) on GBM/GLES. HEVC 4:2:2 10-bit and H.264 playback. Verified log output matches enum names.

## What is the effect on users?

Log lines that printed bare integers now print names:
- "using shader format: 11" -> "Y210 packed 4:2:2"
- "using scaling method: 18" -> "spline36"
- "Creating video codec with codec id: 27" -> "Creating video codec: h264"
- VAAPI deint method now visible in the log instead of only in the codec-info dialog

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
