### PR TITLE
Fix VAAPI on GL

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -25,6 +25,7 @@
 
 #include <array>
 #include <mutex>
+#include <optional>
 
 #include <drm_fourcc.h>
 #include <va/va_drm.h>
@@ -638,111 +639,75 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
       chroma = 444;
   }
 
-  VAProfile profile;
+  auto declineUnsupported = [&]
+  {
+    CLog::Log(LOGINFO, "VAAPI - no usable profile/format for this stream (chroma {}, {}-bit)",
+              chroma, m_vaapiConfig.bitDepth);
+    return false;
+  };
+
+  std::optional<VAProfile> profile;
   switch (avctx->codec_id)
   {
     case AV_CODEC_ID_MPEG2VIDEO:
       profile = VAProfileMPEG2Main;
-      if (!m_vaapiConfig.context->SupportsProfile(profile))
-        return false;
       break;
     case AV_CODEC_ID_MPEG4:
     case AV_CODEC_ID_H263:
       profile = VAProfileMPEG4AdvancedSimple;
-      if (!m_vaapiConfig.context->SupportsProfile(profile))
-        return false;
       break;
     case AV_CODEC_ID_H264:
     {
       if (avctx->profile == AV_PROFILE_H264_CONSTRAINED_BASELINE)
-      {
         profile = VAProfileH264ConstrainedBaseline;
-        if (!m_vaapiConfig.context->SupportsProfile(profile))
-          return false;
-      }
 #if VA_CHECK_VERSION(1, 18, 0)
       else if (avctx->profile == AV_PROFILE_H264_HIGH_10 && m_vaapiConfig.bitDepth == 10 &&
                m_capFormats.Supports(AV_PIX_FMT_P010))
-      {
         profile = VAProfileH264High10;
-        if (!m_vaapiConfig.context->SupportsProfile(profile))
-          return false;
-      }
 #endif
+      // Prefer Main when the driver has it, otherwise High (a superset of Main).
+      else if (avctx->profile == AV_PROFILE_H264_MAIN &&
+               m_vaapiConfig.context->SupportsProfile(VAProfileH264Main))
+        profile = VAProfileH264Main;
       else
-      {
-        if (avctx->profile == AV_PROFILE_H264_MAIN)
-        {
-          profile = VAProfileH264Main;
-          if (m_vaapiConfig.context->SupportsProfile(profile))
-            break;
-        }
         profile = VAProfileH264High;
-        if (!m_vaapiConfig.context->SupportsProfile(profile))
-          return false;
-      }
       break;
     }
     case AV_CODEC_ID_HEVC:
     {
       // VAAPI HEVC profile naming: VAProfileHEVCMain<N> is N-bit 4:2:0,
       // VAProfileHEVCMain422_<N> is N-bit 4:2:2.
-      if (avctx->profile == AV_PROFILE_HEVC_MAIN_10)
-      {
-        if (!m_capFormats.Supports(AV_PIX_FMT_P010))
-          return false;
-
+      if (avctx->profile == AV_PROFILE_HEVC_MAIN_10 && m_capFormats.Supports(AV_PIX_FMT_P010))
         profile = VAProfileHEVCMain10;
-      }
       else if (avctx->profile == AV_PROFILE_HEVC_MAIN)
         profile = VAProfileHEVCMain;
       else if (avctx->profile == AV_PROFILE_HEVC_REXT && m_vaapiConfig.bitDepth == 12 &&
                chroma == 420 &&
                (m_capFormats.Supports(AV_PIX_FMT_P012) || m_capFormats.Supports(AV_PIX_FMT_P016)))
-      {
         profile = VAProfileHEVCMain12;
-      }
       else if (avctx->profile == AV_PROFILE_HEVC_REXT && m_vaapiConfig.bitDepth == 10 &&
                chroma == 422 && m_capFormats.Supports(AV_PIX_FMT_Y210))
-      {
         profile = VAProfileHEVCMain422_10;
-      }
       else if (avctx->profile == AV_PROFILE_HEVC_REXT && m_vaapiConfig.bitDepth == 12 &&
                chroma == 422 &&
                (m_capFormats.Supports(AV_PIX_FMT_Y212) || m_capFormats.Supports(AV_PIX_FMT_Y216)))
-      {
         profile = VAProfileHEVCMain422_12;
-      }
       else if (avctx->profile == AV_PROFILE_HEVC_REXT && m_vaapiConfig.bitDepth == 8 &&
                chroma == 444 &&
                (m_capFormats.Supports(AV_PIX_FMT_VUYA) || m_capFormats.Supports(AV_PIX_FMT_VUYX)))
-      {
         profile = VAProfileHEVCMain444;
-      }
       else if (avctx->profile == AV_PROFILE_HEVC_REXT && m_vaapiConfig.bitDepth == 10 &&
                chroma == 444 && m_capFormats.Supports(AV_PIX_FMT_XV30))
-      {
         profile = VAProfileHEVCMain444_10;
-      }
       else if (avctx->profile == AV_PROFILE_HEVC_REXT && m_vaapiConfig.bitDepth == 12 &&
                chroma == 444 &&
                (m_capFormats.Supports(AV_PIX_FMT_XV36) || m_capFormats.Supports(AV_PIX_FMT_XV48)))
-      {
         profile = VAProfileHEVCMain444_12;
-      }
-      else
-        profile = VAProfileNone;
-      if (!m_vaapiConfig.context->SupportsProfile(profile))
-        return false;
       break;
     }
     case AV_CODEC_ID_VP8:
-    {
       profile = VAProfileVP8Version0_3;
-      if (!m_vaapiConfig.context->SupportsProfile(profile))
-        return false;
       break;
-    }
     case AV_CODEC_ID_VP9:
     {
       // VP9 profiles vary chroma subsampling and bit depth orthogonally:
@@ -760,31 +725,19 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
         profile = VAProfileVP9Profile2;
       else if (avctx->profile == AV_PROFILE_VP9_1 && chroma == 444 &&
                (m_capFormats.Supports(AV_PIX_FMT_VUYA) || m_capFormats.Supports(AV_PIX_FMT_VUYX)))
-      {
         profile = VAProfileVP9Profile1;
-      }
       else if (avctx->profile == AV_PROFILE_VP9_3 && chroma == 444 &&
                ((m_vaapiConfig.bitDepth == 10 && m_capFormats.Supports(AV_PIX_FMT_XV30)) ||
                 (m_vaapiConfig.bitDepth == 12 && (m_capFormats.Supports(AV_PIX_FMT_XV36) ||
                                                   m_capFormats.Supports(AV_PIX_FMT_XV48)))))
-      {
         profile = VAProfileVP9Profile3;
-      }
-      else
-        profile = VAProfileNone;
-      if (!m_vaapiConfig.context->SupportsProfile(profile))
-        return false;
       break;
     }
     case AV_CODEC_ID_WMV3:
       profile = VAProfileVC1Main;
-      if (!m_vaapiConfig.context->SupportsProfile(profile))
-        return false;
       break;
     case AV_CODEC_ID_VC1:
       profile = VAProfileVC1Advanced;
-      if (!m_vaapiConfig.context->SupportsProfile(profile))
-        return false;
       break;
     case AV_CODEC_ID_AV1:
     {
@@ -798,18 +751,17 @@ bool CDecoder::Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum A
       else if (avctx->profile == AV_PROFILE_AV1_HIGH && m_vaapiConfig.bitDepth == 10 &&
                m_capFormats.Supports(AV_PIX_FMT_XV30))
         profile = VAProfileAV1Profile1;
-      else
-        profile = VAProfileNone;
-      if (!m_vaapiConfig.context->SupportsProfile(profile))
-        return false;
       break;
     }
     default:
       return false;
   }
 
-  m_vaapiConfig.profile = profile;
-  m_vaapiConfig.attrib = m_vaapiConfig.context->GetAttrib(profile);
+  if (!profile || !m_vaapiConfig.context->SupportsProfile(*profile))
+    return declineUnsupported();
+
+  m_vaapiConfig.profile = *profile;
+  m_vaapiConfig.attrib = m_vaapiConfig.context->GetAttrib(*profile);
 
   if (avctx->codec_id == AV_CODEC_ID_H264)
   {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -461,6 +461,9 @@ struct VaFormatEntry
 inline constexpr VaFormatEntry kVaFormatTable[] = {
     {VA_FOURCC_NV12, VA_RT_FORMAT_YUV420, AV_PIX_FMT_NV12},
     {VA_FOURCC_P010, VA_RT_FORMAT_YUV420_10BPP, AV_PIX_FMT_P010},
+#if defined(HAS_GLES)
+    // The GL renderer samples every surface as NV12 and has no shader for the
+    // 12-bit 4:2:0 / packed 4:2:2 / packed 4:4:4 layouts, so those are GLES-only.
     {VA_FOURCC_P012, VA_RT_FORMAT_YUV420_12, AV_PIX_FMT_P012},
     {VA_FOURCC_P016, VA_RT_FORMAT_YUV420_12, AV_PIX_FMT_P016},
     {VA_FOURCC_Y210, VA_RT_FORMAT_YUV422_10, AV_PIX_FMT_Y210},
@@ -471,6 +474,7 @@ inline constexpr VaFormatEntry kVaFormatTable[] = {
     {VA_FOURCC_Y410, VA_RT_FORMAT_YUV444_10, AV_PIX_FMT_XV30},
     {VA_FOURCC_Y412, VA_RT_FORMAT_YUV444_12, AV_PIX_FMT_XV36},
     {VA_FOURCC_Y416, VA_RT_FORMAT_YUV444_12, AV_PIX_FMT_XV48},
+#endif
 };
 
 /*!

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -43,9 +43,16 @@ void CRendererVAAPIGL::Register(IVaapiWinSystem* winSystem,
     return;
   }
 
-  CVaapi2Texture::TestInterop(vaDpy, eglDisplay, general, deepColor);
-  CLog::Log(LOGDEBUG, "VAAPI EGL interop test results: general {}, deepColor {}",
-            general ? "yes" : "no", deepColor ? "yes" : "no");
+  // Probe importable surface formats via vaExportSurfaceHandle.
+  CCapabilities& caps = CDecoder::GetCaps();
+  CVaapi2Texture::TestInteropFormats(vaDpy, eglDisplay, caps);
+
+  CLog::Log(LOGDEBUG, "VAAPI EGL interop: {}", caps.ToString());
+
+  // Bool out-params are views over caps for the OptionalsReg / WinSystem
+  // boundary that still expresses capability as the general/deepColor pair.
+  general = caps.Supports(AV_PIX_FMT_NV12);
+  deepColor = caps.Supports(AV_PIX_FMT_P010);
 
   vaTerminate(vaDpy);
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -55,17 +55,10 @@ bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
     return failMap();
   }
 
-  // Remember fds to close them later
-  if (surface.num_objects > m_drmFDs.size())
-  {
-    failMap();
-    throw std::logic_error("Too many fds returned by vaExportSurfaceHandle");
-  }
-
-  for (uint32_t object = 0; object < surface.num_objects; object++)
-  {
+  // Take ownership of the exported fds (RAII closes them on Unmap). num_objects
+  // is bounded by the libva descriptor's fixed objects[] array == m_drmFDs.size().
+  for (uint32_t object = 0; object < surface.num_objects && object < m_drmFDs.size(); object++)
     m_drmFDs[object].attach(surface.objects[object].fd);
-  }
 
   status = vaSyncSurface(pic->vadsp, pic->procPic.videoSurface);
   if (status != VA_STATUS_SUCCESS)
@@ -267,30 +260,34 @@ bool CVaapi2Texture::TestEsh(VADisplay vaDpy, EGLDisplay eglDisplay, std::uint32
   if (status == VA_STATUS_SUCCESS)
   {
     auto const& layer = drmPrimeSurface.layers[0];
-    if (layer.object_index[0] >= drmPrimeSurface.num_objects)
+    if (layer.object_index[0] < drmPrimeSurface.num_objects)
     {
+      auto const& object = drmPrimeSurface.objects[layer.object_index[0]];
+      EGLint attribs[] = {EGL_LINUX_DRM_FOURCC_EXT,
+                          static_cast<EGLint>(drmPrimeSurface.layers[0].drm_format),
+                          EGL_WIDTH,
+                          width,
+                          EGL_HEIGHT,
+                          height,
+                          EGL_DMA_BUF_PLANE0_FD_EXT,
+                          static_cast<EGLint>(object.fd),
+                          EGL_DMA_BUF_PLANE0_OFFSET_EXT,
+                          static_cast<EGLint>(layer.offset[0]),
+                          EGL_DMA_BUF_PLANE0_PITCH_EXT,
+                          static_cast<EGLint>(layer.pitch[0]),
+                          EGL_NONE};
+
+      EGLImageKHR eglImage =
+          eglCreateImageKHR(eglDisplay, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, attribs);
+      if (eglImage)
+      {
+        eglDestroyImageKHR(eglDisplay, eglImage);
+        result = true;
+      }
+    }
+    else
       CLog::Log(LOGERROR, "CVaapi2Texture::TestEsh: object_index {} >= num_objects {}",
                 layer.object_index[0], drmPrimeSurface.num_objects);
-      return false;
-    }
-    auto const& object = drmPrimeSurface.objects[layer.object_index[0]];
-    EGLint attribs[] = {
-      EGL_LINUX_DRM_FOURCC_EXT, static_cast<EGLint>(drmPrimeSurface.layers[0].drm_format),
-      EGL_WIDTH, width,
-      EGL_HEIGHT, height,
-      EGL_DMA_BUF_PLANE0_FD_EXT, static_cast<EGLint>(object.fd),
-      EGL_DMA_BUF_PLANE0_OFFSET_EXT, static_cast<EGLint>(layer.offset[0]),
-      EGL_DMA_BUF_PLANE0_PITCH_EXT, static_cast<EGLint>(layer.pitch[0]),
-      EGL_NONE};
-
-    EGLImageKHR eglImage = eglCreateImageKHR(eglDisplay,
-      EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr,
-      attribs);
-    if (eglImage)
-    {
-      eglDestroyImageKHR(eglDisplay, eglImage);
-      result = true;
-    }
 
     for (uint32_t object = 0; object < drmPrimeSurface.num_objects; object++)
     {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -303,23 +303,6 @@ bool CVaapi2Texture::TestEsh(VADisplay vaDpy, EGLDisplay eglDisplay, std::uint32
   return result;
 }
 
-void CVaapi2Texture::TestInterop(VADisplay vaDpy, EGLDisplay eglDisplay, bool& general, bool& deepColor)
-{
-  general = false;
-  deepColor = false;
-
-  general = TestInteropGeneral(vaDpy, eglDisplay);
-  if (general)
-  {
-    deepColor = TestEsh(vaDpy, eglDisplay, VA_RT_FORMAT_YUV420_10BPP, VA_FOURCC_P010);
-  }
-}
-
-bool CVaapi2Texture::TestInteropGeneral(VADisplay vaDpy, EGLDisplay eglDisplay)
-{
-  return TestEsh(vaDpy, eglDisplay, VA_RT_FORMAT_YUV420, VA_FOURCC_NV12);
-}
-
 void CVaapi2Texture::TestInteropFormats(VADisplay vaDpy, EGLDisplay eglDisplay, CCapabilities& caps)
 {
   // NV12 is the importability gate. If EGL cannot import the baseline 8-bit

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
@@ -63,9 +63,6 @@ public:
   GLuint GetTextureVU() override;
   CSizeInt GetTextureSize() override;
 
-  static void TestInterop(VADisplay vaDpy, EGLDisplay eglDisplay, bool &general, bool &deepColor);
-  static bool TestInteropGeneral(VADisplay vaDpy, EGLDisplay eglDisplay);
-
   // Probe every importable VA fourcc the renderer cares about and Add()
   // each successful one to caps.
   static void TestInteropFormats(VADisplay vaDpy, EGLDisplay eglDisplay, CCapabilities& caps);


### PR DESCRIPTION
## Description
#28276 broke VAAPI + GL.

Fixes #28410 

## Motivation and context
as above

## How has this been tested?
Intel N250, GL+GBM build.

## What is the effect on users?
GL+VAAPI works as it did prior to #28276.  NOTE: this does NOT enable 4:2:2 or 4:4:4 for GL.  That is limited to GLES.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
