### PR TITLE
Webinterface: Sanitize URL parameters in videoPlayer.html

### DIFF
--- a/addons/webinterface.default/videoPlayer.html
+++ b/addons/webinterface.default/videoPlayer.html
@@ -17,7 +17,12 @@
             name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
             var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
                     results = regex.exec(location.search);
-            return results == null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+            var res = results == null ? "" : results[1].replace(/\+/g, " ");
+            try { res = decodeURIComponent(res); } catch (e) { return ""; }
+            res = res.replace(/[\u0000-\u001F\u007F]/g, "").trim();
+            // Reject any absolute/protocol-relative URL or URL with a scheme (prevents javascript:, data:, http:, etc.)
+            if (/^(?:[a-zA-Z][a-zA-Z0-9+.-]*:|\/\/)/.test(res)) return "";
+            return res.replace(/[<>\"]/g, "");
         }
         function getBaseURL() {
             var parts = window.location.href.split('videoPlayer.html');
@@ -115,7 +120,7 @@
 
             });
         }
-        else if (yt != '') {
+        else if (yt != '' && /^[a-zA-Z0-9_-]+$/.test(yt)) {
             // If playing a youtube video.
             $player = $('<iframe>', {
                 width: width,


### PR DESCRIPTION
## Description
Sanitized URL parameters in `videoPlayer.html` to prevent potential XSS and open redirects.

## Motivation and context
Parameter handling currently allows unvalidated input to reach sensitive sinks. This change improves the robustness of the Chorus2 web interface.

## How has this been tested?
Verified locally that video playback and player switching still work correctly.

## Types of change
[✓] Fix (non-breaking change which fixes an issue)
[✓] My code follows the Code Guidelines of this project
[✓] I have read the Contributing document
[✓] All new and existing tests passed