### PR TITLE
DatabaseManager: reset state on profile change to re-run migrations

### DIFF
--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -53,6 +53,15 @@ bool CDatabaseManager::Initialize()
   return rc;
 }
 
+void CDatabaseManager::Deinitialize()
+{
+  std::unique_lock lock(m_section);
+  m_initialized = false;
+  m_bIsUpgrading = false;
+  m_connecting = false;
+  m_dbStatus.clear();
+}
+
 bool CDatabaseManager::InitializeInternal()
 {
   CLog::LogF(LOGDEBUG, "updating databases...");

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -39,6 +39,13 @@ public:
    */
   bool Initialize();
 
+  /*! \brief Reset the database manager state.
+   Must be called on profile changes (LoadProfile / LogOff) so that the
+   next call to Initialize() re-runs the schema version check and migration
+   for all databases under the new profile's database folder.
+   */
+  void Deinitialize();
+
   /*! \brief Check whether we can open a database.
 
    Checks whether the database has been updated correctly, if so returns true.

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -331,6 +331,9 @@ bool CProfileManager::LoadProfile(unsigned int index)
   // Re-open the texture database for the new profile
   CServiceBroker::GetTextureCache()->Initialize();
 
+  // Reset the database manager so all databases are re-initialized for the
+  // new profile, which forces a schema version check and migration.
+  CServiceBroker::GetDatabaseManager().Deinitialize();
   CServiceBroker::GetDatabaseManager().Initialize();
   CServiceBroker::GetInputManager().LoadKeymaps();
 
@@ -460,6 +463,10 @@ void CProfileManager::LogOff()
   CServiceBroker::GetPVRManager().Stop();
 
   networkManager.NetworkMessage(CNetworkBase::SERVICES_DOWN, 1);
+
+  // Reset the database manager so the master profile's databases are
+  // re-initialized cleanly when the login screen is shown again.
+  CServiceBroker::GetDatabaseManager().Deinitialize();
 
   LoadMasterProfileForLogin();
 


### PR DESCRIPTION
## Description

When the login screen (`<useloginscreen>true</useloginscreen>`) is used, or when a user logs off from the master profile and selects another profile, the new profile's video database is not migrated to the current schema version (e.g. from v145 to v146). Other databases (MyMusic, Textures, View, PVR, EPG) are affected the same way.

`CDatabaseManager::Initialize()` runs the schema version check and migration for all databases exactly once per process lifetime, guarded by `m_initialized`. After a profile change, `LoadProfile()` calls `DatabaseManager.Initialize()`, but the guard short-circuits it. The cached `m_dbStatus["MyVideos"] = READY` (set during the initial init for the master profile) is then returned by `CanOpen()`, so `CDatabase::Open()` opens the new profile's DB at its old schema version. `CDatabase::Open()` never calls `UpdateTables()` itself - that lives in `CDatabaseManager::Update()`.

This adds `CDatabaseManager::Deinitialize()` which clears `m_initialized`, `m_dbStatus`, `m_bIsUpgrading` and `m_connecting`, and calls it from `CProfileManager::LoadProfile()` and `CProfileManager::LogOff()` right before the next `Initialize()`. This mirrors the existing `CTextureCache::Deinitialize()`/`Initialize()` pattern already used in `LoadProfile()`.

## Motivation and context

Reproducer:
1. Enable `<useloginscreen>true</useloginscreen>` in `profiles/profiles.xml`
2. Start Kodi - MyVideos is migrated for the master profile
3. Pick a second profile whose `Database/MyVideos*.db` is on an older schema version (e.g. from a previous Kodi install)
4. Expected: the new profile's `MyVideos` is migrated to the current `GetSchemaVersion()`
5. Actual: the DB is opened at the old version; no migration runs; the user sees stale or missing library data

The same symptom occurs when the user logs off from a non-master profile back to the login screen and then picks a different profile.

## How has this been tested?

- Static code review and dry-run path simulation of the login-screen start -> profile load -> `CVideoDatabase::Open()` flow before and after the change.
- Verified `m_section` (`CCriticalSection`) is held by both `Initialize()` and the new `Deinitialize()`, so they are mutually exclusive and cannot race against each other.
- Verified no other call sites of `DatabaseManager.Initialize()` exist outside `Application::Initialize()` and `CProfileManager::LoadProfile()` (`xbmc/profiles/ProfileManager.cpp:337`), so the change has no unexpected side effects.
- Verified the existing early-return for `index == MASTER_PROFILE_ID && IsMasterProfile()` in `LoadProfile()` (around `ProfileManager.cpp:290`) is unchanged: the `Deinitialize()` in `LogOff()` runs before `LoadMasterProfileForLogin()` enters that fast path, and the next non-master `LoadProfile()` will run a fresh `Initialize()` for the chosen profile.
- A full build / `ctest` run was not possible in this environment (no build directory configured), so the patch has not yet been compiled or runtime-tested. Behavioural confirmation on real profile switches still needs to be done by a tester with both an old-schema and a new-schema profile available.

## What is the effect on users?

Users who use the login screen (or frequently switch profiles) will once again get their video and music libraries migrated automatically when picking a profile that hasn't been opened under the current Kodi version. Today those users silently end up with a stale database, which surfaces as missing/incorrect movies, episodes, songs, and PVR data, and can require manual workarounds (deleting `MyVideos*.db`, running a full library rescan). After this fix, the first open of a profile with an older schema version triggers the normal migration path.

For users who never use the login screen and never log off, behaviour is unchanged: `Initialize()` still runs exactly once at startup.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed