### PR TITLE
Use movie filename edition attribute as version name

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -449,40 +449,40 @@ std::string CUtil::GetPartNumberFromPath(std::string path)
 
 bool CUtil::GetFilenameIdentifier(const std::string& fileName,
                                   std::string& identifierType,
-                                  std::string& identifier)
+                                  std::string& identifier,
+                                  KODI::REGEXP::RegExpCache* cache)
 {
   std::string match;
-  return GetFilenameIdentifier(fileName, identifierType, identifier, match);
+  return GetFilenameIdentifier(fileName, identifierType, identifier, match, cache);
 }
 
 bool CUtil::GetFilenameIdentifier(const std::string& fileName,
                                   std::string& identifierType,
                                   std::string& identifier,
-                                  std::string& match)
+                                  std::string& match,
+                                  KODI::REGEXP::RegExpCache* cache)
 {
-  CRegExp reIdentifier(true, CRegExp::autoUtf8);
+  std::shared_ptr<CRegExp> reIdentifier;
 
   const std::shared_ptr<CAdvancedSettings> advancedSettings =
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
-  if (!reIdentifier.RegComp(advancedSettings->m_videoFilenameIdentifierRegExp))
+
+  if (reIdentifier = KODI::REGEXP::GetRegExp(advancedSettings->m_videoFilenameIdentifierRegExp,
+                                             cache, true, CRegExp::autoUtf8);
+      reIdentifier == nullptr)
   {
     CLog::LogF(LOGERROR, "Invalid filename identifier RegExp:'{}'",
                advancedSettings->m_videoFilenameIdentifierRegExp);
     return false;
   }
-  else
+
+  if (reIdentifier->RegFind(fileName) >= 0)
   {
-    if (reIdentifier.RegComp(advancedSettings->m_videoFilenameIdentifierRegExp))
-    {
-      if (reIdentifier.RegFind(fileName) >= 0)
-      {
-        match = reIdentifier.GetMatch(0);
-        identifierType = reIdentifier.GetMatch(1);
-        identifier = reIdentifier.GetMatch(2);
-        StringUtils::ToLower(identifierType);
-        return true;
-      }
-    }
+    match = reIdentifier->GetMatch(0);
+    identifierType = reIdentifier->GetMatch(1);
+    identifier = reIdentifier->GetMatch(2);
+    StringUtils::ToLower(identifierType);
+    return true;
   }
   return false;
 }
@@ -491,7 +491,7 @@ bool CUtil::HasFilenameIdentifier(const std::string& fileName)
 {
   std::string identifierType;
   std::string identifier;
-  return GetFilenameIdentifier(fileName, identifierType, identifier);
+  return GetFilenameIdentifier(fileName, identifierType, identifier, nullptr);
 }
 
 void CUtil::CleanString(const std::string& strFileName,
@@ -509,7 +509,7 @@ void CUtil::CleanString(const std::string& strFileName,
   std::string identifier;
   std::string identifierType;
   std::string identifierMatch;
-  if (GetFilenameIdentifier(strFileName, identifierType, identifier, identifierMatch))
+  if (GetFilenameIdentifier(strFileName, identifierType, identifier, identifierMatch, nullptr))
     StringUtils::Replace(strTitleAndYear, identifierMatch, "");
 
   const std::shared_ptr<CAdvancedSettings> advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -102,6 +102,7 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
+#include <functional>
 #include <iomanip>
 #include <memory>
 #include <random>
@@ -445,6 +446,102 @@ std::string CUtil::RemoveTrailingPartNumberSegmentFromPath(std::string path,
 std::string CUtil::GetPartNumberFromPath(std::string path)
 {
   return GetPartAndRemoveDiscFromPath(path, PreserveFileName::REMOVE);
+}
+
+namespace
+{
+/*!
+ * \brief Returns a compiled regular expression to retrieve filename attributes
+ * \param[in] cache Optional regular expression cache
+ * \return Valid pointer if the regular expression was compiled successfully, nullptr otherwise.
+ */
+std::shared_ptr<CRegExp> InitFilenameAttributesRegExp(KODI::REGEXP::RegExpCache* cache)
+{
+  std::shared_ptr<CRegExp> re;
+
+  const std::shared_ptr<CAdvancedSettings> advancedSettings =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+
+  if (advancedSettings == nullptr)
+    return re;
+
+  re = KODI::REGEXP::GetRegExp(advancedSettings->m_videoFilenameAttributePairsRegExp, cache, true,
+                               CRegExp::autoUtf8);
+  if (re == nullptr)
+  {
+    CLog::LogF(LOGERROR, "Invalid filename attribute pairs RegExp:'{}'",
+               advancedSettings->m_videoFilenameAttributePairsRegExp);
+  }
+  return re;
+}
+
+/*!
+ * \brief Iterates over all filename attributes key=value pairs in @p fileName, invoking @p callback
+ *        for each one.
+ * @p fileName must not be modified by @p callback.
+ * \param fileName [in] The filename to search for attribute pairs.
+ * \param cache[in] Optional regular expression cache
+ * \param callback[in] Invoked for each match with the absolute position, the match length, the value
+ *                     of the key and value of the match.
+ */
+void ForEachFilenameAttribute(
+    const std::string& fileName,
+    KODI::REGEXP::RegExpCache* cache,
+    std::function<void(int pos, int len, const std::string& key, const std::string& value)>
+        callback)
+{
+  if (std::shared_ptr<CRegExp> re = InitFilenameAttributesRegExp(cache); re != nullptr)
+  {
+    unsigned int offset = 0;
+    while (true)
+    {
+      int pos = re->RegFind(fileName, offset);
+      if (pos < 0)
+        break;
+
+      const int matchLength = re->GetFindLen();
+      callback(pos, matchLength, re->GetMatch("key"), re->GetMatch("value"));
+      offset = pos + matchLength;
+    }
+  }
+}
+} // namespace
+
+CUtil::FilenameAttributeMap CUtil::GetFilenameAttributePairs(const std::string& fileName,
+                                                             KODI::REGEXP::RegExpCache* cache)
+{
+  FilenameAttributeMap result;
+
+  ForEachFilenameAttribute(fileName, cache,
+                           [&result](int, int, std::string key, std::string value)
+                           {
+                             StringUtils::Trim(key);
+                             StringUtils::ToLower(key);
+                             StringUtils::Trim(value);
+                             if (!key.empty() && !value.empty())
+                               result.insert_or_assign(key, value);
+                           });
+  return result;
+}
+
+void CUtil::CleanFilenameAttributePairs(std::string& fileName, KODI::REGEXP::RegExpCache* cache)
+{
+  std::string result;
+  result.reserve(fileName.size());
+  int last = 0;
+
+  // Copy the gaps between matches into the new result string - less allocations/shifting than
+  // deleting from the existing string, and doesn't modify the string being iterated.
+  ForEachFilenameAttribute(
+      fileName, cache,
+      [&result, &fileName, &last](int pos, int len, const std::string&, const std::string&)
+      {
+        result.append(fileName, last, pos - last);
+        last = pos + len;
+      });
+  result.append(fileName, last, std::string::npos);
+
+  fileName = std::move(result);
 }
 
 bool CUtil::GetFilenameIdentifier(const std::string& fileName,

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -89,6 +89,7 @@
 #include "utils/LangCodeExpander.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
+#include "video/FilenameAttributes.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoFileItemClassify.h"
 #include "windowing/GraphicContext.h"
@@ -103,16 +104,13 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
-#include <functional>
 #include <iomanip>
 #include <memory>
 #include <random>
 #include <ranges>
 #include <sstream>
 #include <string>
-#include <string_view>
 #include <unordered_set>
-#include <utility>
 #include <vector>
 
 #include <fstrcmp.h>
@@ -128,8 +126,6 @@ using namespace KODI;
 #if !defined(TARGET_WINDOWS)
 unsigned int CUtil::s_randomSeed = time(NULL);
 #endif
-
-constexpr std::string_view FILENAME_EDITION = "edition";
 
 namespace
 {
@@ -453,182 +449,6 @@ std::string CUtil::GetPartNumberFromPath(std::string path)
   return GetPartAndRemoveDiscFromPath(path, PreserveFileName::REMOVE);
 }
 
-namespace
-{
-/*!
- * \brief Returns a compiled regular expression to retrieve filename attributes
- * \param[in] cache Optional regular expression cache
- * \return Valid pointer if the regular expression was compiled successfully, nullptr otherwise.
- */
-std::shared_ptr<CRegExp> InitFilenameAttributesRegExp(KODI::REGEXP::RegExpCache* cache)
-{
-  std::shared_ptr<CRegExp> re;
-
-  const std::shared_ptr<CAdvancedSettings> advancedSettings =
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
-
-  if (advancedSettings == nullptr)
-    return re;
-
-  re = KODI::REGEXP::GetRegExp(advancedSettings->m_videoFilenameAttributePairsRegExp, cache, true,
-                               CRegExp::autoUtf8);
-  if (re == nullptr)
-  {
-    CLog::LogF(LOGERROR, "Invalid filename attribute pairs RegExp:'{}'",
-               advancedSettings->m_videoFilenameAttributePairsRegExp);
-  }
-  return re;
-}
-
-/*!
- * \brief Iterates over all filename attributes key=value pairs in @p fileName, invoking @p callback
- *        for each one.
- * @p fileName must not be modified by @p callback.
- * \param fileName [in] The filename to search for attribute pairs.
- * \param cache[in] Optional regular expression cache
- * \param callback[in] Invoked for each match with the absolute position, the match length, the value
- *                     of the key and value of the match.
- */
-void ForEachFilenameAttribute(
-    const std::string& fileName,
-    KODI::REGEXP::RegExpCache* cache,
-    std::function<void(int pos, int len, const std::string& key, const std::string& value)>
-        callback)
-{
-  if (std::shared_ptr<CRegExp> re = InitFilenameAttributesRegExp(cache); re != nullptr)
-  {
-    unsigned int offset = 0;
-    while (true)
-    {
-      int pos = re->RegFind(fileName, offset);
-      if (pos < 0)
-        break;
-
-      const int matchLength = re->GetFindLen();
-      callback(pos, matchLength, re->GetMatch("key"), re->GetMatch("value"));
-      offset = pos + matchLength;
-    }
-  }
-}
-} // namespace
-
-CUtil::FilenameAttributeMap CUtil::GetFilenameAttributePairs(const std::string& fileName,
-                                                             KODI::REGEXP::RegExpCache* cache)
-{
-  FilenameAttributeMap result;
-
-  ForEachFilenameAttribute(fileName, cache,
-                           [&result](int, int, std::string key, std::string value)
-                           {
-                             StringUtils::Trim(key);
-                             StringUtils::ToLower(key);
-                             StringUtils::Trim(value);
-                             if (!key.empty() && !value.empty())
-                               result.insert_or_assign(key, value);
-                           });
-  return result;
-}
-
-void CUtil::CleanFilenameAttributePairs(std::string& fileName, KODI::REGEXP::RegExpCache* cache)
-{
-  std::string result;
-  result.reserve(fileName.size());
-  int last = 0;
-
-  // Collect the gaps between attribute tokens into the new result string. Reduces allocations
-  // and in place erasure without modification of the string being iterated.
-  ForEachFilenameAttribute(
-      fileName, cache,
-      [&result, &fileName, &last](int pos, int len, const std::string&, const std::string&)
-      {
-        result.append(fileName, last, pos - last);
-        last = pos + len;
-      });
-  result.append(fileName, last, std::string::npos);
-
-  fileName = std::move(result);
-}
-
-bool CUtil::GetFilenameIdentifier(const std::string& fileName,
-                                  std::string& identifierType,
-                                  std::string& identifier,
-                                  KODI::REGEXP::RegExpCache* cache)
-{
-  return GetFilenameIdentifier(GetFilenameAttributePairs(fileName, cache), identifierType,
-                               identifier);
-}
-
-bool CUtil::GetFilenameIdentifier(const CUtil::FilenameAttributeMap& attributes,
-                                  std::string& identifierType,
-                                  std::string& identifier)
-{
-  if (const std::shared_ptr<CAdvancedSettings> advancedSettings =
-          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
-      advancedSettings != nullptr)
-  {
-    const std::unordered_set<std::string>& identifiers =
-        advancedSettings->m_videoScannerMetadataSources;
-
-    if (identifiers.empty())
-      return false;
-
-    // The attribute key must be a known identifier with an optional id suffix and the value
-    // must be purely alphanumeric.
-
-    // Projection to strip the "id" suffix
-    auto proj = [](const std::pair<std::string, std::string>& attr)
-    {
-      constexpr std::string_view suffix = "id";
-      if (!StringUtils::EndsWithNoCase(attr.first, suffix))
-        return attr;
-      return std::pair{attr.first.substr(0, attr.first.size() - suffix.size()), attr.second};
-    };
-
-    auto it = std::ranges::find_if(
-        attributes,
-        [&identifiers](const auto& attr)
-        {
-          if (identifiers.contains(attr.first) && !attr.second.empty() &&
-              std::ranges::all_of(attr.second,
-                                  [](char c) { return StringUtils::isasciialphanum(c); }))
-            return true;
-
-          return false;
-        },
-        proj);
-
-    if (it != attributes.end())
-    {
-      auto stripped = proj(*it);
-      identifierType = stripped.first;
-      identifier = stripped.second;
-      return true;
-    }
-  }
-  return false;
-}
-
-bool CUtil::HasFilenameIdentifier(const std::string& fileName)
-{
-  std::string identifierType;
-  std::string identifier;
-  return GetFilenameIdentifier(fileName, identifierType, identifier, nullptr);
-}
-
-std::string CUtil::GetFilenameEdition(const std::string& fileName, KODI::REGEXP::RegExpCache* cache)
-{
-  return GetFilenameEdition(GetFilenameAttributePairs(fileName, cache));
-}
-
-std::string CUtil::GetFilenameEdition(const FilenameAttributeMap& attributes)
-{
-  auto it = attributes.find(FILENAME_EDITION);
-  if (it != attributes.end())
-    return it->second;
-
-  return "";
-}
-
 void CUtil::CleanString(const std::string& strFileName,
                         std::string& strTitle,
                         std::string& strTitleAndYear,
@@ -641,7 +461,7 @@ void CUtil::CleanString(const std::string& strFileName,
   if (strFileName == "..")
    return;
 
-  CleanFilenameAttributePairs(strTitleAndYear, nullptr);
+  KODI::VIDEO::CFilenameAttributes::CleanFilenameAttributePairs(strTitleAndYear, nullptr);
 
   const std::shared_ptr<CAdvancedSettings> advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
   const std::vector<std::string> &regexps = advancedSettings->m_videoCleanStringRegExps;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -109,6 +109,7 @@
 #include <ranges>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <vector>
 
@@ -125,6 +126,8 @@ using namespace KODI;
 #if !defined(TARGET_WINDOWS)
 unsigned int CUtil::s_randomSeed = time(NULL);
 #endif
+
+constexpr std::string_view FILENAME_EDITION = "edition";
 
 namespace
 {
@@ -589,6 +592,20 @@ bool CUtil::HasFilenameIdentifier(const std::string& fileName)
   std::string identifierType;
   std::string identifier;
   return GetFilenameIdentifier(fileName, identifierType, identifier, nullptr);
+}
+
+std::string CUtil::GetFilenameEdition(const std::string& fileName, KODI::REGEXP::RegExpCache* cache)
+{
+  return GetFilenameEdition(GetFilenameAttributePairs(fileName, cache));
+}
+
+std::string CUtil::GetFilenameEdition(const FilenameAttributeMap& attributes)
+{
+  auto it = attributes.find(FILENAME_EDITION);
+  if (it != attributes.end())
+    return it->second;
+
+  return "";
 }
 
 void CUtil::CleanString(const std::string& strFileName,

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -552,16 +552,6 @@ bool CUtil::GetFilenameIdentifier(const std::string& fileName,
                                   std::string& identifier,
                                   KODI::REGEXP::RegExpCache* cache)
 {
-  std::string match;
-  return GetFilenameIdentifier(fileName, identifierType, identifier, match, cache);
-}
-
-bool CUtil::GetFilenameIdentifier(const std::string& fileName,
-                                  std::string& identifierType,
-                                  std::string& identifier,
-                                  std::string& match,
-                                  KODI::REGEXP::RegExpCache* cache)
-{
   std::shared_ptr<CRegExp> reIdentifier;
 
   const std::shared_ptr<CAdvancedSettings> advancedSettings =
@@ -578,7 +568,6 @@ bool CUtil::GetFilenameIdentifier(const std::string& fileName,
 
   if (reIdentifier->RegFind(fileName) >= 0)
   {
-    match = reIdentifier->GetMatch(0);
     identifierType = reIdentifier->GetMatch(1);
     identifier = reIdentifier->GetMatch(2);
     StringUtils::ToLower(identifierType);
@@ -620,11 +609,7 @@ void CUtil::CleanString(const std::string& strFileName,
   if (strFileName == "..")
    return;
 
-  std::string identifier;
-  std::string identifierType;
-  std::string identifierMatch;
-  if (GetFilenameIdentifier(strFileName, identifierType, identifier, identifierMatch, nullptr))
-    StringUtils::Replace(strTitleAndYear, identifierMatch, "");
+  CleanFilenameAttributes(strTitleAndYear, nullptr);
 
   const std::shared_ptr<CAdvancedSettings> advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
   const std::vector<std::string> &regexps = advancedSettings->m_videoCleanStringRegExps;

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -88,6 +88,7 @@
 #include "utils/FileExtensionProvider.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/RegExp.h"
+#include "utils/StringUtils.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoFileItemClassify.h"
 #include "windowing/GraphicContext.h"
@@ -111,6 +112,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include <fstrcmp.h>
@@ -533,8 +535,8 @@ void CUtil::CleanFilenameAttributePairs(std::string& fileName, KODI::REGEXP::Reg
   result.reserve(fileName.size());
   int last = 0;
 
-  // Copy the gaps between matches into the new result string - less allocations/shifting than
-  // deleting from the existing string, and doesn't modify the string being iterated.
+  // Collect the gaps between attribute tokens into the new result string. Reduces allocations
+  // and in place erasure without modification of the string being iterated.
   ForEachFilenameAttribute(
       fileName, cache,
       [&result, &fileName, &last](int pos, int len, const std::string&, const std::string&)
@@ -552,26 +554,56 @@ bool CUtil::GetFilenameIdentifier(const std::string& fileName,
                                   std::string& identifier,
                                   KODI::REGEXP::RegExpCache* cache)
 {
-  std::shared_ptr<CRegExp> reIdentifier;
+  return GetFilenameIdentifier(GetFilenameAttributePairs(fileName, cache), identifierType,
+                               identifier);
+}
 
-  const std::shared_ptr<CAdvancedSettings> advancedSettings =
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
-
-  if (reIdentifier = KODI::REGEXP::GetRegExp(advancedSettings->m_videoFilenameIdentifierRegExp,
-                                             cache, true, CRegExp::autoUtf8);
-      reIdentifier == nullptr)
+bool CUtil::GetFilenameIdentifier(const CUtil::FilenameAttributeMap& attributes,
+                                  std::string& identifierType,
+                                  std::string& identifier)
+{
+  if (const std::shared_ptr<CAdvancedSettings> advancedSettings =
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+      advancedSettings != nullptr)
   {
-    CLog::LogF(LOGERROR, "Invalid filename identifier RegExp:'{}'",
-               advancedSettings->m_videoFilenameIdentifierRegExp);
-    return false;
-  }
+    const std::unordered_set<std::string>& identifiers =
+        advancedSettings->m_videoScannerMetadataSources;
 
-  if (reIdentifier->RegFind(fileName) >= 0)
-  {
-    identifierType = reIdentifier->GetMatch(1);
-    identifier = reIdentifier->GetMatch(2);
-    StringUtils::ToLower(identifierType);
-    return true;
+    if (identifiers.empty())
+      return false;
+
+    // The attribute key must be a known identifier with an optional id suffix and the value
+    // must be purely alphanumeric.
+
+    // Projection to strip the "id" suffix
+    auto proj = [](const std::pair<std::string, std::string>& attr)
+    {
+      constexpr std::string_view suffix = "id";
+      if (!StringUtils::EndsWithNoCase(attr.first, suffix))
+        return attr;
+      return std::pair{attr.first.substr(0, attr.first.size() - suffix.size()), attr.second};
+    };
+
+    auto it = std::ranges::find_if(
+        attributes,
+        [&identifiers](const auto& attr)
+        {
+          if (identifiers.contains(attr.first) && !attr.second.empty() &&
+              std::ranges::all_of(attr.second,
+                                  [](char c) { return StringUtils::isasciialphanum(c); }))
+            return true;
+
+          return false;
+        },
+        proj);
+
+    if (it != attributes.end())
+    {
+      auto stripped = proj(*it);
+      identifierType = stripped.first;
+      identifier = stripped.second;
+      return true;
+    }
   }
   return false;
 }
@@ -609,7 +641,7 @@ void CUtil::CleanString(const std::string& strFileName,
   if (strFileName == "..")
    return;
 
-  CleanFilenameAttributes(strTitleAndYear, nullptr);
+  CleanFilenameAttributePairs(strTitleAndYear, nullptr);
 
   const std::shared_ptr<CAdvancedSettings> advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
   const std::vector<std::string> &regexps = advancedSettings->m_videoCleanStringRegExps;

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -15,6 +15,7 @@
 #include <cstdint>
 #include <span>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 //! \brief Enumeration of filesystem types for LegalPath/FileName
@@ -43,13 +44,47 @@ struct ExternalStreamInfo
 class CUtil
 {
   CUtil() = delete;
+
 public:
+  /*!
+   * \brief Transparent string hasher for std::unordered_map heterogeneous lookup
+   */
+  struct StringHash
+  {
+    using is_transparent = void; // Enables heterogeneous operations.
+    std::size_t operator()(std::string_view sv) const { return std::hash<std::string_view>{}(sv); }
+  };
+
+  using FilenameAttributeMap =
+      std::unordered_map<std::string, std::string, StringHash, std::equal_to<>>;
+
   static void CleanString(const std::string& strFileName,
                           std::string& strTitle,
                           std::string& strTitleAndYear,
                           std::string& strYear,
                           bool bRemoveExtension = false,
                           bool bCleanChars = true);
+  /*!
+   * \brief Extracts all key/value attribute pairs encoded in @p fileName (ex. [key=value])
+   *        Matches are found using a regular expression from advanced settings, which
+   *        must contain named capture groups @c key and @c value. 
+   *        The key is trimmed and lowercased before insertion. If the same key appears more than
+   *        once, the last value wins.
+   * \param fileName[in] The filename to extract attributes from.
+   * \param cache[in,out] Optional regular expression cache.
+   * \return A map of attribute keys and their values, or an empty map if the
+   *         regular expression is invalid or no matches are found.
+   */
+  static FilenameAttributeMap GetFilenameAttributePairs(const std::string& fileName,
+                                                        KODI::REGEXP::RegExpCache* cache);
+
+  /*!
+   * \brief Removes all filename attribute pairs from @p fileName
+   * \param[in,out] fileName The filename to strip attributes from.
+   * \param[in,out] cache Optional regular expression cache
+   */
+  static void CleanFilenameAttributePairs(std::string& fileName, KODI::REGEXP::RegExpCache* cache);
+
   static bool GetFilenameIdentifier(const std::string& fileName,
                                     std::string& identifierType,
                                     std::string& identifier,

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -15,7 +15,6 @@
 #include <cstdint>
 #include <span>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 //! \brief Enumeration of filesystem types for LegalPath/FileName
@@ -46,58 +45,12 @@ class CUtil
   CUtil() = delete;
 
 public:
-  /*!
-   * \brief Transparent string hasher for std::unordered_map heterogeneous lookup
-   */
-  struct StringHash
-  {
-    using is_transparent = void; // Enables heterogeneous operations.
-    std::size_t operator()(std::string_view sv) const { return std::hash<std::string_view>{}(sv); }
-  };
-
-  using FilenameAttributeMap =
-      std::unordered_map<std::string, std::string, StringHash, std::equal_to<>>;
-
   static void CleanString(const std::string& strFileName,
                           std::string& strTitle,
                           std::string& strTitleAndYear,
                           std::string& strYear,
                           bool bRemoveExtension = false,
                           bool bCleanChars = true);
-  /*!
-   * \brief Extracts all key/value attribute pairs encoded in @p fileName (ex. [key=value])
-   *        Matches are found using a regular expression from advanced settings, which
-   *        must contain named capture groups @c key and @c value. 
-   *        The key is trimmed and lowercased before insertion. If the same key appears more than
-   *        once, the last value wins.
-   * \param fileName[in] The filename to extract attributes from.
-   * \param cache[in,out] Optional regular expression cache.
-   * \return A map of attribute keys and their values, or an empty map if the
-   *         regular expression is invalid or no matches are found.
-   */
-  static FilenameAttributeMap GetFilenameAttributePairs(const std::string& fileName,
-                                                        KODI::REGEXP::RegExpCache* cache);
-
-  /*!
-   * \brief Removes all filename attribute pairs from @p fileName
-   * \param[in,out] fileName The filename to strip attributes from.
-   * \param[in,out] cache Optional regular expression cache
-   */
-  static void CleanFilenameAttributePairs(std::string& fileName, KODI::REGEXP::RegExpCache* cache);
-
-  static bool GetFilenameIdentifier(const std::string& fileName,
-                                    std::string& identifierType,
-                                    std::string& identifier,
-                                    KODI::REGEXP::RegExpCache* cache);
-  static bool GetFilenameIdentifier(const CUtil::FilenameAttributeMap& attributes,
-                                    std::string& identifierType,
-                                    std::string& identifier);
-
-  static bool HasFilenameIdentifier(const std::string& fileName);
-
-  static std::string GetFilenameEdition(const std::string& fileName,
-                                        KODI::REGEXP::RegExpCache* cache);
-  static std::string GetFilenameEdition(const FilenameAttributeMap& attributes);
 
   static std::string GetTitleFromPath(const CURL& url, bool bIsFolder = false);
   static std::string GetTitleFromPath(const std::string& strFileNameAndPath, bool bIsFolder = false);

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -89,6 +89,10 @@ public:
                                     std::string& identifierType,
                                     std::string& identifier,
                                     KODI::REGEXP::RegExpCache* cache);
+  static bool GetFilenameIdentifier(const CUtil::FilenameAttributeMap& attributes,
+                                    std::string& identifierType,
+                                    std::string& identifier);
+
   static bool HasFilenameIdentifier(const std::string& fileName);
 
   static std::string GetFilenameEdition(const std::string& fileName,

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -89,11 +89,6 @@ public:
                                     std::string& identifierType,
                                     std::string& identifier,
                                     KODI::REGEXP::RegExpCache* cache);
-  static bool GetFilenameIdentifier(const std::string& fileName,
-                                    std::string& identifierType,
-                                    std::string& identifier,
-                                    std::string& match,
-                                    KODI::REGEXP::RegExpCache* cache);
   static bool HasFilenameIdentifier(const std::string& fileName);
 
   static std::string GetFilenameEdition(const std::string& fileName,

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -52,11 +52,13 @@ public:
                           bool bCleanChars = true);
   static bool GetFilenameIdentifier(const std::string& fileName,
                                     std::string& identifierType,
-                                    std::string& identifier);
+                                    std::string& identifier,
+                                    KODI::REGEXP::RegExpCache* cache);
   static bool GetFilenameIdentifier(const std::string& fileName,
                                     std::string& identifierType,
                                     std::string& identifier,
-                                    std::string& match);
+                                    std::string& match,
+                                    KODI::REGEXP::RegExpCache* cache);
   static bool HasFilenameIdentifier(const std::string& fileName);
   static std::string GetTitleFromPath(const CURL& url, bool bIsFolder = false);
   static std::string GetTitleFromPath(const std::string& strFileNameAndPath, bool bIsFolder = false);

--- a/xbmc/Util.h
+++ b/xbmc/Util.h
@@ -95,6 +95,11 @@ public:
                                     std::string& match,
                                     KODI::REGEXP::RegExpCache* cache);
   static bool HasFilenameIdentifier(const std::string& fileName);
+
+  static std::string GetFilenameEdition(const std::string& fileName,
+                                        KODI::REGEXP::RegExpCache* cache);
+  static std::string GetFilenameEdition(const FilenameAttributeMap& attributes);
+
   static std::string GetTitleFromPath(const CURL& url, bool bIsFolder = false);
   static std::string GetTitleFromPath(const std::string& strFileNameAndPath, bool bIsFolder = false);
 

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -255,7 +255,6 @@ void CAdvancedSettings::Initialize()
   m_fullScreenOnMovieStart = true;
   m_cachePath = "special://temp/";
 
-  m_videoFilenameIdentifierRegExp = R"([{\[](tmdb|imdb|tvdb)(?:id)?[-=](\w+)[}\]])";
   m_videoFilenameAttributePairsRegExp = R"([\[{]\s*(?<key>\w+)\s*[=\-](?<value>[^\]}]+)[\]}])";
   m_videoCleanDateTimeRegExp = "(.*[^ _\\,\\.\\(\\)\\[\\]\\-])[ _\\.\\(\\)\\[\\]\\-]+(19[0-9][0-9]|20[0-9][0-9])([ _\\,\\.\\(\\)\\[\\]\\-]|[^0-9]$)?";
 
@@ -401,6 +400,7 @@ void CAdvancedSettings::Initialize()
   m_bVideoLibraryCleanOnUpdate = false;
   m_bVideoLibraryUseFastHash = true;
   m_bVideoScannerIgnoreErrors = false;
+  m_metadataSourcesPriv = "tmdb|imdb|tvdb|anidb|";
   m_iVideoLibraryDateAdded = 1; // prefer mtime over ctime and current time
   m_minimumEpisodePlaylistDuration = 5 * 60; // 5 minutes
   m_disableEpisodeRanges = false;
@@ -718,7 +718,6 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     if (pVideoExcludes)
       GetCustomRegexps(pVideoExcludes, m_videoCleanStringRegExps);
 
-    XMLUtils::GetString(pElement, "filenameidentifier", m_videoFilenameIdentifierRegExp);
     XMLUtils::GetString(pElement, "filenameattributepairs", m_videoFilenameAttributePairsRegExp);
     XMLUtils::GetString(pElement,"cleandatetime", m_videoCleanDateTimeRegExp);
     XMLUtils::GetString(pElement,"ppffmpegpostprocessing",m_videoPPFFmpegPostProc);
@@ -920,6 +919,15 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
   if (pElement)
   {
     XMLUtils::GetBoolean(pElement, "ignoreerrors", m_bVideoScannerIgnoreErrors);
+
+    // Adjust the builtin list with the advanced setting then prepare for use.
+    if (const TiXmlElement* elem = pElement->FirstChildElement("metadatasources"); elem != nullptr)
+      GetCustomExtensions(elem, m_metadataSourcesPriv);
+
+    StringUtils::ToLower(m_metadataSourcesPriv);
+    const std::vector<std::string> split = StringUtils::Split(m_metadataSourcesPriv, '|');
+    m_videoScannerMetadataSources = std::unordered_set<std::string>(
+        std::make_move_iterator(split.begin()), std::make_move_iterator(split.end()));
   }
 
   // Backward-compatibility of ExternalPlayer config

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -255,7 +255,7 @@ void CAdvancedSettings::Initialize()
   m_fullScreenOnMovieStart = true;
   m_cachePath = "special://temp/";
 
-  m_videoFilenameIdentifierRegExp = R"([\{\[](\w+?)(?:id)?[-=](\w+)[\}|\]])";
+  m_videoFilenameIdentifierRegExp = R"([{\[](tmdb|imdb|tvdb)(?:id)?[-=](\w+)[}\]])";
   m_videoCleanDateTimeRegExp = "(.*[^ _\\,\\.\\(\\)\\[\\]\\-])[ _\\.\\(\\)\\[\\]\\-]+(19[0-9][0-9]|20[0-9][0-9])([ _\\,\\.\\(\\)\\[\\]\\-]|[^0-9]$)?";
 
   m_videoCleanStringRegExps.clear();

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -256,6 +256,7 @@ void CAdvancedSettings::Initialize()
   m_cachePath = "special://temp/";
 
   m_videoFilenameIdentifierRegExp = R"([{\[](tmdb|imdb|tvdb)(?:id)?[-=](\w+)[}\]])";
+  m_videoFilenameAttributePairsRegExp = R"([\[{]\s*(?<key>\w+)\s*[=\-](?<value>[^\]}]+)[\]}])";
   m_videoCleanDateTimeRegExp = "(.*[^ _\\,\\.\\(\\)\\[\\]\\-])[ _\\.\\(\\)\\[\\]\\-]+(19[0-9][0-9]|20[0-9][0-9])([ _\\,\\.\\(\\)\\[\\]\\-]|[^0-9]$)?";
 
   m_videoCleanStringRegExps.clear();
@@ -718,6 +719,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
       GetCustomRegexps(pVideoExcludes, m_videoCleanStringRegExps);
 
     XMLUtils::GetString(pElement, "filenameidentifier", m_videoFilenameIdentifierRegExp);
+    XMLUtils::GetString(pElement, "filenameattributepairs", m_videoFilenameAttributePairsRegExp);
     XMLUtils::GetString(pElement,"cleandatetime", m_videoCleanDateTimeRegExp);
     XMLUtils::GetString(pElement,"ppffmpegpostprocessing",m_videoPPFFmpegPostProc);
     XMLUtils::GetInt(pElement,"vdpauscaling",m_videoVDPAUScaling);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -20,6 +20,7 @@
 #include <functional>
 #include <map>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -230,7 +231,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     bool m_fullScreenOnMovieStart;
     std::string m_cachePath;
     std::string m_videoCleanDateTimeRegExp;
-    std::string m_videoFilenameIdentifierRegExp;
     std::string m_videoFilenameAttributePairsRegExp;
     std::vector<std::string> m_videoCleanStringRegExps;
     std::vector<std::string> m_videoExcludeFromListingRegExps;
@@ -295,6 +295,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     bool m_bVideoScannerIgnoreErrors;
     int m_iVideoLibraryDateAdded;
+    std::unordered_set<std::string> m_videoScannerMetadataSources;
 
     bool m_caseSensitiveLocalArtMatch{true};
     int m_minimumEpisodePlaylistDuration; // seconds
@@ -430,4 +431,5 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     mutable CCriticalSection m_listCritSection;
     std::map<int, AdvancedSettingsCallback> m_settingsLoadedCallbacks;
+    std::string m_metadataSourcesPriv;
 };

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -231,6 +231,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::string m_cachePath;
     std::string m_videoCleanDateTimeRegExp;
     std::string m_videoFilenameIdentifierRegExp;
+    std::string m_videoFilenameAttributePairsRegExp;
     std::vector<std::string> m_videoCleanStringRegExps;
     std::vector<std::string> m_videoExcludeFromListingRegExps;
     std::vector<std::string> m_allExcludeFromScanRegExps;

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -10,6 +10,7 @@
 #include "Util.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "video/FilenameAttributes.h"
 
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
@@ -17,6 +18,8 @@
 using ::testing::Test;
 using ::testing::ValuesIn;
 using ::testing::WithParamInterface;
+
+using namespace KODI::VIDEO;
 
 TEST(TestUtil, GetQualifiedFilename)
 {
@@ -129,7 +132,7 @@ TEST_P(TestUtilCleanString, GetFilenameIdentifier)
 {
   std::string identifierType;
   std::string identifier;
-  CUtil::GetFilenameIdentifier(GetParam().input, identifierType, identifier, nullptr);
+  CFilenameAttributes(GetParam().input, nullptr).GetIdentifier(identifierType, identifier);
   EXPECT_EQ(identifierType, GetParam().expIdentifierType);
   EXPECT_EQ(identifier, GetParam().expIdentifier);
 }
@@ -165,149 +168,6 @@ const TestUtilCleanStringData values[] = {
     {"Some (Director Cut).BDRemux.mkv", true, "Some (Director Cut)", "Some (Director Cut)", ""}};
 
 INSTANTIATE_TEST_SUITE_P(URL, TestUtilCleanString, ValuesIn(values));
-
-struct TestUtilFilenameAttributesData
-{
-  std::string input;
-  CUtil::FilenameAttributeMap expected;
-};
-
-std::ostream& operator<<(std::ostream& os, const TestUtilFilenameAttributesData& rhs)
-{
-  return os << rhs.input;
-}
-
-class TestUtilFilenameAttributePairs : public Test,
-                                       public WithParamInterface<TestUtilFilenameAttributesData>
-{
-};
-
-TEST_P(TestUtilFilenameAttributePairs, RetrieveAttributes)
-{
-  auto& params = GetParam();
-  EXPECT_EQ(params.expected, CUtil::GetFilenameAttributePairs(params.input, nullptr));
-}
-
-const TestUtilFilenameAttributesData filenameAttributePairsTests[] = {
-    {"Some.MovieName.mkv", {}},
-    // separators and braces
-    {"Some.MovieName[key=value].mkv", {{"key", "value"}}},
-    {"Some.MovieName[key-value].mkv", {{"key", "value"}}},
-    {"Some.MovieName{key=value}.mkv", {{"key", "value"}}},
-    {"Some.MovieName{key-value}.mkv", {{"key", "value"}}},
-    // trim
-    {"Some.MovieName[ key  =   value  ].mkv", {{"key", "value"}}},
-    // multiple matches
-    {"Some.MovieName [key1=value1]{key2 = value2}.mkv", {{"key1", "value1"}, {"key2", "value2"}}},
-    {"Some.MovieName [key1=value1] foobar {key2 = value2}.mkv",
-     {{"key1", "value1"}, {"key2", "value2"}}},
-    // case
-    {"Some.MovieName[KeY=vAlUe].mkv", {{"key", "vAlUe"}}},
-    // repeated key
-    {"Some.MovieName[key=value1][key=value2].mkv", {{"key", "value2"}}},
-    // no match
-    {"Some.MovieName.key=value.mkv", {}},
-    {"Some.MovieName[key=].mkv", {}},
-    {"Some.MovieName[=value].mkv", {}},
-    {"", {}},
-};
-
-INSTANTIATE_TEST_SUITE_P(TestUtil,
-                         TestUtilFilenameAttributePairs,
-                         ValuesIn(filenameAttributePairsTests));
-
-TEST(TestUtil, GetFilenameEditionMap)
-{
-  CUtil::FilenameAttributeMap attrs = {{"edition", "Director's Cut"}, {"foo", "bar"}};
-  EXPECT_EQ("Director's Cut", CUtil::GetFilenameEdition(attrs));
-
-  attrs = {{"foo", "bar"}, {"edition", "Director's Cut"}};
-  EXPECT_EQ("Director's Cut", CUtil::GetFilenameEdition(attrs));
-
-  CUtil::FilenameAttributeMap emptyAttrs;
-  EXPECT_EQ("", CUtil::GetFilenameEdition(emptyAttrs));
-}
-
-TEST(TestUtil, GetFilenameEditionString)
-{
-  EXPECT_EQ("Director's Cut",
-            CUtil::GetFilenameEdition("Some.MovieName[edition=Director's Cut].mkv", nullptr));
-  EXPECT_EQ("", CUtil::GetFilenameEdition("Some.MovieName[foo=bar].mkv", nullptr));
-  EXPECT_EQ("", CUtil::GetFilenameEdition("Some.MovieName.mkv", nullptr));
-}
-
-TEST(TestUtil, GetFilenameIdentifierMap)
-{
-  std::string identifierType;
-  std::string identifier;
-
-  // Inject list of known metadata sources for reliable results
-  const std::shared_ptr<CAdvancedSettings> advancedSettings =
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
-  ASSERT_TRUE(advancedSettings != nullptr);
-
-  advancedSettings->m_videoScannerMetadataSources = {"tmdb"};
-
-  CUtil::FilenameAttributeMap emptyAttrs;
-  EXPECT_FALSE(CUtil::GetFilenameIdentifier(emptyAttrs, identifierType, identifier));
-
-  CUtil::FilenameAttributeMap attrs = {{"edition", "test"}};
-  EXPECT_FALSE(CUtil::GetFilenameIdentifier(attrs, identifierType, identifier));
-
-  attrs = {{"foo", "bar"}};
-  EXPECT_FALSE(CUtil::GetFilenameIdentifier(attrs, identifierType, identifier));
-
-  // the suffix "id" is removed from the key
-  attrs = CUtil::FilenameAttributeMap{{"tmdb", "123"}};
-  EXPECT_TRUE(CUtil::GetFilenameIdentifier(attrs, identifierType, identifier));
-  EXPECT_EQ("tmdb", identifierType);
-  EXPECT_EQ("123", identifier);
-
-  attrs = CUtil::FilenameAttributeMap{{"tmdbid", "123"}};
-  EXPECT_TRUE(CUtil::GetFilenameIdentifier(attrs, identifierType, identifier));
-  EXPECT_EQ("tmdb", identifierType);
-  EXPECT_EQ("123", identifier);
-
-  // The value must be alphanum.
-  attrs = {{"tmdb", "test-12 3"}};
-  EXPECT_FALSE(CUtil::GetFilenameIdentifier(attrs, identifierType, identifier));
-}
-
-struct TestUtilCleanFilenameAttributesData
-{
-  std::string input;
-  std::string expected;
-};
-
-std::ostream& operator<<(std::ostream& os, const TestUtilCleanFilenameAttributesData& rhs)
-{
-  return os << rhs.input;
-}
-
-class TestUtilCleanFilenameAttributePairs
-  : public Test,
-    public WithParamInterface<TestUtilCleanFilenameAttributesData>
-{
-};
-
-TEST_P(TestUtilCleanFilenameAttributePairs, Clean)
-{
-  auto& params = GetParam();
-  std::string file = params.input;
-  CUtil::CleanFilenameAttributePairs(file, nullptr);
-  EXPECT_EQ(params.expected, file);
-}
-
-const TestUtilCleanFilenameAttributesData cleanFilenameAttributePairsTests[] = {
-    {"Some.MovieName[key=value].mkv", "Some.MovieName.mkv"},
-    {"Some.MovieName [key1=value1]{key2 = value2}.mkv", "Some.MovieName .mkv"},
-    {"Some.MovieName [key1=value1] foobar {key2 = value2}.mkv", "Some.MovieName  foobar .mkv"},
-    {"Some.MovieName.mkv", "Some.MovieName.mkv"},
-};
-
-INSTANTIATE_TEST_SUITE_P(TestUtil,
-                         TestUtilCleanFilenameAttributePairs,
-                         ValuesIn(cleanFilenameAttributePairsTests));
 
 struct TestUtilSplitParamsData
 {

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -204,6 +204,26 @@ INSTANTIATE_TEST_SUITE_P(TestUtil,
                          TestUtilFilenameAttributePairs,
                          ValuesIn(filenameAttributePairsTests));
 
+TEST(TestUtil, GetFilenameEditionMap)
+{
+  CUtil::FilenameAttributeMap attrs = {{"edition", "Director's Cut"}, {"foo", "bar"}};
+  EXPECT_EQ("Director's Cut", CUtil::GetFilenameEdition(attrs));
+
+  attrs = {{"foo", "bar"}, {"edition", "Director's Cut"}};
+  EXPECT_EQ("Director's Cut", CUtil::GetFilenameEdition(attrs));
+
+  CUtil::FilenameAttributeMap emptyAttrs;
+  EXPECT_EQ("", CUtil::GetFilenameEdition(emptyAttrs));
+}
+
+TEST(TestUtil, GetFilenameEditionString)
+{
+  EXPECT_EQ("Director's Cut",
+            CUtil::GetFilenameEdition("Some.MovieName[edition=Director's Cut].mkv", nullptr));
+  EXPECT_EQ("", CUtil::GetFilenameEdition("Some.MovieName[foo=bar].mkv", nullptr));
+  EXPECT_EQ("", CUtil::GetFilenameEdition("Some.MovieName.mkv", nullptr));
+}
+
 struct TestUtilCleanFilenameAttributesData
 {
   std::string input;

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -154,6 +154,92 @@ const TestUtilCleanStringData values[] = {
 
 INSTANTIATE_TEST_SUITE_P(URL, TestUtilCleanString, ValuesIn(values));
 
+struct TestUtilFilenameAttributesData
+{
+  std::string input;
+  CUtil::FilenameAttributeMap expected;
+};
+
+std::ostream& operator<<(std::ostream& os, const TestUtilFilenameAttributesData& rhs)
+{
+  return os << rhs.input;
+}
+
+class TestUtilFilenameAttributePairs : public Test,
+                                       public WithParamInterface<TestUtilFilenameAttributesData>
+{
+};
+
+TEST_P(TestUtilFilenameAttributePairs, RetrieveAttributes)
+{
+  auto& params = GetParam();
+  EXPECT_EQ(params.expected, CUtil::GetFilenameAttributePairs(params.input, nullptr));
+}
+
+const TestUtilFilenameAttributesData filenameAttributePairsTests[] = {
+    {"Some.MovieName.mkv", {}},
+    // separators and braces
+    {"Some.MovieName[key=value].mkv", {{"key", "value"}}},
+    {"Some.MovieName[key-value].mkv", {{"key", "value"}}},
+    {"Some.MovieName{key=value}.mkv", {{"key", "value"}}},
+    {"Some.MovieName{key-value}.mkv", {{"key", "value"}}},
+    // trim
+    {"Some.MovieName[ key  =   value  ].mkv", {{"key", "value"}}},
+    // multiple matches
+    {"Some.MovieName [key1=value1]{key2 = value2}.mkv", {{"key1", "value1"}, {"key2", "value2"}}},
+    {"Some.MovieName [key1=value1] foobar {key2 = value2}.mkv",
+     {{"key1", "value1"}, {"key2", "value2"}}},
+    // case
+    {"Some.MovieName[KeY=vAlUe].mkv", {{"key", "vAlUe"}}},
+    // repeated key
+    {"Some.MovieName[key=value1][key=value2].mkv", {{"key", "value2"}}},
+    // no match
+    {"Some.MovieName.key=value.mkv", {}},
+    {"Some.MovieName[key=].mkv", {}},
+    {"Some.MovieName[=value].mkv", {}},
+    {"", {}},
+};
+
+INSTANTIATE_TEST_SUITE_P(TestUtil,
+                         TestUtilFilenameAttributePairs,
+                         ValuesIn(filenameAttributePairsTests));
+
+struct TestUtilCleanFilenameAttributesData
+{
+  std::string input;
+  std::string expected;
+};
+
+std::ostream& operator<<(std::ostream& os, const TestUtilCleanFilenameAttributesData& rhs)
+{
+  return os << rhs.input;
+}
+
+class TestUtilCleanFilenameAttributePairs
+  : public Test,
+    public WithParamInterface<TestUtilCleanFilenameAttributesData>
+{
+};
+
+TEST_P(TestUtilCleanFilenameAttributePairs, Clean)
+{
+  auto& params = GetParam();
+  std::string file = params.input;
+  CUtil::CleanFilenameAttributePairs(file, nullptr);
+  EXPECT_EQ(params.expected, file);
+}
+
+const TestUtilCleanFilenameAttributesData cleanFilenameAttributePairsTests[] = {
+    {"Some.MovieName[key=value].mkv", "Some.MovieName.mkv"},
+    {"Some.MovieName [key1=value1]{key2 = value2}.mkv", "Some.MovieName .mkv"},
+    {"Some.MovieName [key1=value1] foobar {key2 = value2}.mkv", "Some.MovieName  foobar .mkv"},
+    {"Some.MovieName.mkv", "Some.MovieName.mkv"},
+};
+
+INSTANTIATE_TEST_SUITE_P(TestUtil,
+                         TestUtilCleanFilenameAttributePairs,
+                         ValuesIn(cleanFilenameAttributePairsTests));
+
 struct TestUtilSplitParamsData
 {
   std::string input;

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -117,7 +117,7 @@ TEST_P(TestUtilCleanString, GetFilenameIdentifier)
 {
   std::string identifierType;
   std::string identifier;
-  CUtil::GetFilenameIdentifier(GetParam().input, identifierType, identifier);
+  CUtil::GetFilenameIdentifier(GetParam().input, identifierType, identifier, nullptr);
   EXPECT_EQ(identifierType, GetParam().expIdentifierType);
   EXPECT_EQ(identifier, GetParam().expIdentifier);
 }

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -6,7 +6,10 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "ServiceBroker.h"
 #include "Util.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
@@ -111,6 +114,15 @@ std::ostream& operator<<(std::ostream& os, const TestUtilCleanStringData& rhs)
 
 class TestUtilCleanString : public Test, public WithParamInterface<TestUtilCleanStringData>
 {
+public:
+  static void SetUpTestSuite()
+  {
+    // Inject list of known metadata sources for reliable results
+    const std::shared_ptr<CAdvancedSettings> advancedSettings =
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+    ASSERT_TRUE(advancedSettings != nullptr);
+    advancedSettings->m_videoScannerMetadataSources = {"tmdb", "imdb"};
+  }
 };
 
 TEST_P(TestUtilCleanString, GetFilenameIdentifier)
@@ -222,6 +234,43 @@ TEST(TestUtil, GetFilenameEditionString)
             CUtil::GetFilenameEdition("Some.MovieName[edition=Director's Cut].mkv", nullptr));
   EXPECT_EQ("", CUtil::GetFilenameEdition("Some.MovieName[foo=bar].mkv", nullptr));
   EXPECT_EQ("", CUtil::GetFilenameEdition("Some.MovieName.mkv", nullptr));
+}
+
+TEST(TestUtil, GetFilenameIdentifierMap)
+{
+  std::string identifierType;
+  std::string identifier;
+
+  // Inject list of known metadata sources for reliable results
+  const std::shared_ptr<CAdvancedSettings> advancedSettings =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+  ASSERT_TRUE(advancedSettings != nullptr);
+
+  advancedSettings->m_videoScannerMetadataSources = {"tmdb"};
+
+  CUtil::FilenameAttributeMap emptyAttrs;
+  EXPECT_FALSE(CUtil::GetFilenameIdentifier(emptyAttrs, identifierType, identifier));
+
+  CUtil::FilenameAttributeMap attrs = {{"edition", "test"}};
+  EXPECT_FALSE(CUtil::GetFilenameIdentifier(attrs, identifierType, identifier));
+
+  attrs = {{"foo", "bar"}};
+  EXPECT_FALSE(CUtil::GetFilenameIdentifier(attrs, identifierType, identifier));
+
+  // the suffix "id" is removed from the key
+  attrs = CUtil::FilenameAttributeMap{{"tmdb", "123"}};
+  EXPECT_TRUE(CUtil::GetFilenameIdentifier(attrs, identifierType, identifier));
+  EXPECT_EQ("tmdb", identifierType);
+  EXPECT_EQ("123", identifier);
+
+  attrs = CUtil::FilenameAttributeMap{{"tmdbid", "123"}};
+  EXPECT_TRUE(CUtil::GetFilenameIdentifier(attrs, identifierType, identifier));
+  EXPECT_EQ("tmdb", identifierType);
+  EXPECT_EQ("123", identifier);
+
+  // The value must be alphanum.
+  attrs = {{"tmdb", "test-12 3"}};
+  EXPECT_FALSE(CUtil::GetFilenameIdentifier(attrs, identifierType, identifier));
 }
 
 struct TestUtilCleanFilenameAttributesData

--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES Bookmark.cpp
             ContextMenus.cpp
+            FilenameAttributes.cpp
             GUIViewStateVideo.cpp
             PlayerController.cpp
             SetInfoTag.cpp
@@ -23,6 +24,7 @@ set(SOURCES Bookmark.cpp
 set(HEADERS Bookmark.h
             ContextMenus.h
             Episode.h
+            FilenameAttributes.h
             GUIViewStateVideo.h
             PlayerController.h
             SetInfoTag.h

--- a/xbmc/video/FilenameAttributes.cpp
+++ b/xbmc/video/FilenameAttributes.cpp
@@ -1,0 +1,206 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "video/FilenameAttributes.h"
+
+#include "ServiceBroker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+
+#include <algorithm>
+#include <functional>
+#include <utility>
+
+constexpr std::string_view FILENAME_EDITION = "edition";
+
+namespace
+{
+/*!
+ * \brief Returns a compiled regular expression to retrieve filename attributes
+ * \param[in] cache Optional regular expression cache
+ * \return Valid pointer if the regular expression was compiled successfully, nullptr otherwise.
+ */
+std::shared_ptr<CRegExp> InitFilenameAttributesRegExp(KODI::REGEXP::RegExpCache* cache)
+{
+  std::shared_ptr<CRegExp> re;
+
+  const std::shared_ptr<CAdvancedSettings> advancedSettings =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+
+  if (advancedSettings == nullptr)
+    return re;
+
+  re = KODI::REGEXP::GetRegExp(advancedSettings->m_videoFilenameAttributePairsRegExp, cache, true,
+                               CRegExp::autoUtf8);
+  if (re == nullptr)
+  {
+    CLog::LogF(LOGERROR, "Invalid filename attribute pairs RegExp:'{}'",
+               advancedSettings->m_videoFilenameAttributePairsRegExp);
+  }
+  return re;
+}
+
+/*!
+ * \brief Iterates over all filename attributes key=value pairs in @p fileName, invoking @p callback
+ *        for each one.
+ * @p fileName must not be modified by @p callback.
+ * \param fileName [in] The filename to search for attribute pairs.
+ * \param cache[in] Optional regular expression cache
+ * \param callback[in] Invoked for each match with the absolute position, the match length, the value
+ *                     of the key and value of the match.
+ */
+void ForEachFilenameAttribute(
+    const std::string& fileName,
+    KODI::REGEXP::RegExpCache* cache,
+    std::function<void(int pos, int len, const std::string& key, const std::string& value)>
+        callback)
+{
+  if (std::shared_ptr<CRegExp> re = InitFilenameAttributesRegExp(cache); re != nullptr)
+  {
+    unsigned int offset = 0;
+    while (true)
+    {
+      int pos = re->RegFind(fileName, offset);
+      if (pos < 0)
+        break;
+
+      const int matchLength = re->GetFindLen();
+      callback(pos, matchLength, re->GetMatch("key"), re->GetMatch("value"));
+      offset = pos + matchLength;
+    }
+  }
+}
+} // namespace
+
+namespace KODI::VIDEO
+{
+CFilenameAttributes::CFilenameAttributes(const std::string& filename,
+                                         KODI::REGEXP::RegExpCache* cache)
+{
+  m_attributes = GetFilenameAttributePairs(filename, cache);
+}
+
+AttributeMap CFilenameAttributes::GetFilenameAttributePairs(const std::string& fileName,
+                                                            KODI::REGEXP::RegExpCache* cache)
+{
+  AttributeMap result;
+
+  ForEachFilenameAttribute(fileName, cache,
+                           [&result](int, int, std::string key, std::string value)
+                           {
+                             StringUtils::Trim(key);
+                             StringUtils::ToLower(key);
+                             StringUtils::Trim(value);
+                             if (!key.empty() && !value.empty())
+                               result.insert_or_assign(key, value);
+                           });
+  return result;
+}
+
+void CFilenameAttributes::CleanFilenameAttributePairs(std::string& fileName,
+                                                      KODI::REGEXP::RegExpCache* cache)
+{
+  std::string result;
+  result.reserve(fileName.size());
+  int last = 0;
+
+  // Collect the gaps between attribute tokens into the new result string. Reduces allocations
+  // and in place erasure without modification of the string being iterated.
+  ForEachFilenameAttribute(
+      fileName, cache,
+      [&result, &fileName, &last](int pos, int len, const std::string&, const std::string&)
+      {
+        result.append(fileName, last, pos - last);
+        last = pos + len;
+      });
+  result.append(fileName, last, std::string::npos);
+
+  fileName = std::move(result);
+}
+
+bool CFilenameAttributes::GetIdentifier(std::string& identifierType, std::string& identifier) const
+{
+  if (!m_hasIdentifier.has_value())
+    m_hasIdentifier = GetIdentifierInternal(m_identifierType, m_identifier);
+
+  if (m_hasIdentifier.value())
+  {
+    identifierType = m_identifierType;
+    identifier = m_identifier;
+  }
+  return m_hasIdentifier.value();
+}
+
+bool CFilenameAttributes::GetIdentifierInternal(std::string& identifierType,
+                                                std::string& identifier) const
+{
+  if (const std::shared_ptr<CAdvancedSettings> advancedSettings =
+          CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+      advancedSettings != nullptr)
+  {
+    const std::unordered_set<std::string>& identifiers =
+        advancedSettings->m_videoScannerMetadataSources;
+
+    if (identifiers.empty())
+      return false;
+
+    // The attribute key must be a known identifier with an optional id suffix and the value
+    // must be purely alphanumeric.
+
+    // Projection to strip the "id" suffix
+    auto proj = [](const std::pair<std::string, std::string>& attr)
+    {
+      constexpr std::string_view suffix = "id";
+      if (!StringUtils::EndsWithNoCase(attr.first, suffix))
+        return attr;
+      return std::pair{attr.first.substr(0, attr.first.size() - suffix.size()), attr.second};
+    };
+
+    auto it = std::ranges::find_if(
+        m_attributes,
+        [&identifiers](const auto& attr)
+        {
+          if (identifiers.contains(attr.first) && !attr.second.empty() &&
+              std::ranges::all_of(attr.second,
+                                  [](char c) { return StringUtils::isasciialphanum(c); }))
+            return true;
+
+          return false;
+        },
+        proj);
+
+    if (it != m_attributes.end())
+    {
+      auto stripped = proj(*it);
+      identifierType = stripped.first;
+      identifier = stripped.second;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool CFilenameAttributes::HasIdentifier() const
+{
+  if (!m_hasIdentifier.has_value())
+    m_hasIdentifier = GetIdentifierInternal(m_identifierType, m_identifier);
+
+  return m_hasIdentifier.value();
+}
+
+std::string CFilenameAttributes::GetEdition() const
+{
+  auto it = m_attributes.find(FILENAME_EDITION);
+  if (it != m_attributes.end())
+    return it->second;
+
+  return "";
+}
+} // namespace KODI::VIDEO

--- a/xbmc/video/FilenameAttributes.h
+++ b/xbmc/video/FilenameAttributes.h
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "utils/RegExp.h"
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+class TestFilenameAttributes;
+
+namespace KODI::VIDEO
+{
+/*!
+ * \brief Transparent string hasher for std::unordered_map heterogeneous lookup
+ */
+struct StringHash
+{
+  using is_transparent = void; // Enables heterogeneous operations.
+  std::size_t operator()(std::string_view sv) const { return std::hash<std::string_view>{}(sv); }
+};
+
+using AttributeMap = std::unordered_map<std::string, std::string, StringHash, std::equal_to<>>;
+
+class CFilenameAttributes
+{
+public:
+  CFilenameAttributes(const std::string& filename, KODI::REGEXP::RegExpCache* cache);
+
+  /*!
+   * \brief Retrieve unique identifier information from the attributes.
+   *        in case multiple identifier exist, an undetermined identifier is returned.
+   * \param[out] identifierType Type of unique identifier (ex. tmdb)
+   * \param[out] identifier Unique identifier
+   * \return true if a unique identifier attribute exists, false otherwise
+   */
+  bool GetIdentifier(std::string& identifierType, std::string& identifier) const;
+
+  /*!
+   * \brief Existence of a unique identifier attribute
+   * \return true if a unique identifier attribute exists, false otherwise
+   */
+  bool HasIdentifier() const;
+
+  /*!
+   * \brief Retrieve the edition from the attributes.
+   * \return Value of the edition attribute when present, empty otherwise.
+   */
+  std::string GetEdition() const;
+
+  /*!
+   * \brief Removes all filename attribute pairs from @p fileName
+   * \param[in,out] fileName The filename to strip attributes from.
+   * \param[in,out] cache Optional regular expression cache
+   */
+  static void CleanFilenameAttributePairs(std::string& fileName, KODI::REGEXP::RegExpCache* cache);
+
+private:
+  friend class ::TestFilenameAttributes;
+
+  /*!
+   * \brief Extracts all key/value attribute pairs encoded in @p fileName (ex. [key=value])
+   *        Matches are found using a regular expression from advanced settings, which
+   *        must contain named capture groups @c key and @c value. 
+   *        The key is trimmed and lowercased before insertion. If the same key appears more than
+   *        once, the last value wins.
+   * \param fileName[in] The filename to extract attributes from.
+   * \param cache[in,out] Optional regular expression cache.
+   * \return A map of attribute keys and their values, or an empty map if the
+   *         regular expression is invalid or no matches are found.
+   */
+  static AttributeMap GetFilenameAttributePairs(const std::string& fileName,
+                                                KODI::REGEXP::RegExpCache* cache);
+
+  /*!
+   * \brief Retrieve and cache unique identifier information from the attributes.
+   *        The attributes are compared against a list of known metadata providers and the first
+   *        match wins. The list may be modified by users with advanced settings.
+   * \param[out] identifierType Type of unique identifier (ex. tmdb)
+   * \param[out] identifier Unique identifier
+   * \return true if a unique identifier attribute exists, false otherwise
+   */
+  bool GetIdentifierInternal(std::string& identifierType, std::string& identifier) const;
+
+  AttributeMap m_attributes;
+  mutable std::string m_identifierType;
+  mutable std::string m_identifier;
+  mutable std::optional<bool> m_hasIdentifier;
+};
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -927,6 +927,23 @@ CVideoInfoScanner::~CVideoInfoScanner()
     if (m_handle)
       m_handle->SetText(pItem->GetMovieName(bDirNames));
 
+    //! @todo: do something about edition values slightly different from db version types due to
+    //! available filesystem characters. ex. "directors cut" in file name vs "Director's Cut"
+    const std::string editionFromFilename{
+        CUtil::GetFilenameEdition(URIUtils::GetFileName(pItem->GetPath()), &m_regexpCache)};
+
+    // An edition extracted from the filename is applied only when an asset title hasn't been set yet (NFO wins).
+    const auto applyEdition = [&editionFromFilename](CFileItem* item)
+    {
+      if (editionFromFilename.empty())
+        return;
+
+      // Creation of a tag if one doesn't exist yet is on purpose
+      CVideoInfoTag* tag{item->GetVideoInfoTag()};
+      if (tag && tag->GetAssetInfo().GetTitle().empty())
+        tag->GetAssetInfo().SetTitle(editionFromFilename);
+    };
+
     InfoType result = InfoType::NONE;
     CScraperUrl scrUrl;
 
@@ -967,6 +984,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
       // Existing movie cannot be found or is not version - add it
       if (movieId < 0)
       {
+        applyEdition(&item);
+
         movieId = static_cast<int>(AddVideo(&item, info2, bDirNames, true));
         if (movieId < 0)
           return InfoRet::INFO_ERROR;
@@ -1056,6 +1075,9 @@ CVideoInfoScanner::~CVideoInfoScanner()
       {
         if (UpdateSetInTag(*pItem->GetVideoInfoTag()) && !AddSet(pItem->GetVideoInfoTag()->m_set))
           return InfoRet::INFO_ERROR;
+
+        applyEdition(pItem);
+
         const int dbId{static_cast<int>(AddVideo(pItem, info2, bDirNames, useLocal))};
         if (dbId < 0)
           return InfoRet::INFO_ERROR;
@@ -1080,6 +1102,9 @@ CVideoInfoScanner::~CVideoInfoScanner()
     {
       if (UpdateSetInTag(*pItem->GetVideoInfoTag()) && !AddSet(pItem->GetVideoInfoTag()->m_set))
         return InfoRet::INFO_ERROR;
+
+      applyEdition(pItem);
+
       const int dbId{static_cast<int>(AddVideo(pItem, info2, bDirNames, useLocal))};
       if (dbId < 0)
         return InfoRet::INFO_ERROR;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -927,10 +927,12 @@ CVideoInfoScanner::~CVideoInfoScanner()
     if (m_handle)
       m_handle->SetText(pItem->GetMovieName(bDirNames));
 
-    //! @todo: do something about edition values slightly different from db version types due to
+    const auto filenameAttributes =
+        CUtil::GetFilenameAttributePairs(URIUtils::GetFileName(pItem->GetPath()), &m_regexpCache);
+
+    //! @todo: do something about edition values slightly different from db due to
     //! available filesystem characters. ex. "directors cut" in file name vs "Director's Cut"
-    const std::string editionFromFilename{
-        CUtil::GetFilenameEdition(URIUtils::GetFileName(pItem->GetPath()), &m_regexpCache)};
+    const std::string editionFromFilename{CUtil::GetFilenameEdition(filenameAttributes)};
 
     // An edition extracted from the filename is applied only when an asset title hasn't been set yet (NFO wins).
     const auto applyEdition = [&editionFromFilename](CFileItem* item)
@@ -1065,7 +1067,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     std::string identifierType;
     std::string identifier;
     if (info2->IsPython() &&
-        CUtil::GetFilenameIdentifier(movieTitle, identifierType, identifier, &m_regexpCache))
+        CUtil::GetFilenameIdentifier(filenameAttributes, identifierType, identifier))
     {
       const ADDON::CScraper::UniqueIDs uniqueIDs{{identifierType, identifier}};
       if (GetDetails(pItem, uniqueIDs, url, info2,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -858,7 +858,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
     std::string identifierType;
     std::string identifier;
     long lResult = -1;
-    if (info2->IsPython() && CUtil::GetFilenameIdentifier(movieTitle, identifierType, identifier))
+    if (info2->IsPython() &&
+        CUtil::GetFilenameIdentifier(movieTitle, identifierType, identifier, &m_regexpCache))
     {
       const ADDON::CScraper::UniqueIDs uniqueIDs{{identifierType, identifier}};
       if (GetDetails(pItem, uniqueIDs, url, info2,
@@ -1045,7 +1046,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
     std::string identifierType;
     std::string identifier;
-    if (info2->IsPython() && CUtil::GetFilenameIdentifier(movieTitle, identifierType, identifier))
+    if (info2->IsPython() &&
+        CUtil::GetFilenameIdentifier(movieTitle, identifierType, identifier, &m_regexpCache))
     {
       const ADDON::CScraper::UniqueIDs uniqueIDs{{identifierType, identifier}};
       if (GetDetails(pItem, uniqueIDs, url, info2,
@@ -1143,7 +1145,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
     std::string identifierType;
     std::string identifier;
-    if (info2->IsPython() && CUtil::GetFilenameIdentifier(movieTitle, identifierType, identifier))
+    if (info2->IsPython() &&
+        CUtil::GetFilenameIdentifier(movieTitle, identifierType, identifier, &m_regexpCache))
     {
       const ADDON::CScraper::UniqueIDs uniqueIDs{{identifierType, identifier}};
       if (GetDetails(pItem, uniqueIDs, url, info2,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -52,6 +52,7 @@
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
+#include "video/FilenameAttributes.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 #include "video/VideoManagerTypes.h"
@@ -859,7 +860,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     std::string identifier;
     long lResult = -1;
     if (info2->IsPython() &&
-        CUtil::GetFilenameIdentifier(movieTitle, identifierType, identifier, &m_regexpCache))
+        CFilenameAttributes(movieTitle, &m_regexpCache).GetIdentifier(identifierType, identifier))
     {
       const ADDON::CScraper::UniqueIDs uniqueIDs{{identifierType, identifier}};
       if (GetDetails(pItem, uniqueIDs, url, info2,
@@ -927,12 +928,12 @@ CVideoInfoScanner::~CVideoInfoScanner()
     if (m_handle)
       m_handle->SetText(pItem->GetMovieName(bDirNames));
 
-    const auto filenameAttributes =
-        CUtil::GetFilenameAttributePairs(URIUtils::GetFileName(pItem->GetPath()), &m_regexpCache);
+    const CFilenameAttributes filenameAttributes(URIUtils::GetFileName(pItem->GetPath()),
+                                                 &m_regexpCache);
 
     //! @todo: do something about edition values slightly different from db due to
     //! available filesystem characters. ex. "directors cut" in file name vs "Director's Cut"
-    const std::string editionFromFilename{CUtil::GetFilenameEdition(filenameAttributes)};
+    const std::string editionFromFilename{filenameAttributes.GetEdition()};
 
     // An edition extracted from the filename is applied only when an asset title hasn't been set yet (NFO wins).
     const auto applyEdition = [&editionFromFilename](CFileItem* item)
@@ -1066,8 +1067,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
     std::string identifierType;
     std::string identifier;
-    if (info2->IsPython() &&
-        CUtil::GetFilenameIdentifier(filenameAttributes, identifierType, identifier))
+    if (info2->IsPython() && filenameAttributes.GetIdentifier(identifierType, identifier))
     {
       const ADDON::CScraper::UniqueIDs uniqueIDs{{identifierType, identifier}};
       if (GetDetails(pItem, uniqueIDs, url, info2,
@@ -1172,7 +1172,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     std::string identifierType;
     std::string identifier;
     if (info2->IsPython() &&
-        CUtil::GetFilenameIdentifier(movieTitle, identifierType, identifier, &m_regexpCache))
+        CFilenameAttributes(movieTitle, &m_regexpCache).GetIdentifier(identifierType, identifier))
     {
       const ADDON::CScraper::UniqueIDs uniqueIDs{{identifierType, identifier}};
       if (GetDetails(pItem, uniqueIDs, url, info2,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -972,9 +972,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
           return InfoRet::INFO_ERROR;
 
         // Deal with set
-        if (UpdateSetInTag(*pItem->GetVideoInfoTag()))
-          if (!AddSet(pItem->GetVideoInfoTag()->m_set))
-            return InfoRet::INFO_ERROR;
+        if (UpdateSetInTag(*pItem->GetVideoInfoTag()) && !AddSet(pItem->GetVideoInfoTag()->m_set))
+          return InfoRet::INFO_ERROR;
       }
 
       // Look for default version
@@ -1679,15 +1678,14 @@ CVideoInfoScanner::~CVideoInfoScanner()
         if (idMovie != -1)
         {
           pItem->SetArt(art); // May have been filtered above
-          CVideoInfoTag* vtag{pItem->GetVideoInfoTag()};
 
           // Need to look up asset title in current table as, if importing, it may have a different id (primary key)
-          const std::string assetTitle{vtag->GetAssetInfo().GetTitle()};
+          const std::string assetTitle{tag->GetAssetInfo().GetTitle()};
           const int assetId{m_database.AddOrValidateVideoVersionType(assetTitle)};
 
           lResult = m_database.AddVideoAsset(VideoDbContentType::MOVIES, idMovie, assetId,
                                              VideoAssetType::VERSION, *pItem)
-                        ? vtag->m_iFileId
+                        ? tag->m_iFileId
                         : -1;
         }
       }

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -32,6 +32,7 @@
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
+#include "video/FilenameAttributes.h"
 #include "video/VideoDatabase.h"
 #include "video/VideoInfoDownloader.h"
 #include "video/VideoInfoScanner.h"
@@ -292,7 +293,7 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
       CVideoInfoDownloader infoDownloader(scraper);
 
       // try adding by filename identifier
-      if (scraper->IsPython() && CUtil::HasFilenameIdentifier(itemTitle))
+      if (scraper->IsPython() && CFilenameAttributes(itemTitle, nullptr).HasIdentifier())
       {
         CFileItemList items;
         items.Add(m_item);

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES TestBookmark.cpp
+            TestFilenameAttributes.cpp
             TestStacks.cpp
             TestVideoDbUrl.cpp
             TestVideoFileItemClassify.cpp

--- a/xbmc/video/test/TestFilenameAttributes.cpp
+++ b/xbmc/video/test/TestFilenameAttributes.cpp
@@ -1,0 +1,218 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ServiceBroker.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+#include "video/FilenameAttributes.h"
+
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+
+using ::testing::Test;
+using ::testing::ValuesIn;
+using ::testing::WithParamInterface;
+
+using namespace KODI::VIDEO;
+
+class TestFilenameAttributes : public Test
+{
+public:
+  static void SetUpTestSuite()
+  {
+    // Inject list of known metadata sources for reliable results
+    const std::shared_ptr<CAdvancedSettings> advancedSettings =
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+    ASSERT_TRUE(advancedSettings != nullptr);
+    advancedSettings->m_videoScannerMetadataSources = {"tmdb", "imdb"};
+  }
+
+  static AttributeMap CallGetFilenameAttributePairs(const std::string& fileName,
+                                                    KODI::REGEXP::RegExpCache* cache)
+  {
+    return CFilenameAttributes::GetFilenameAttributePairs(fileName, cache);
+  }
+};
+
+struct TestUtilFilenameAttributesData
+{
+  std::string input;
+  AttributeMap expected;
+};
+
+std::ostream& operator<<(std::ostream& os, const TestUtilFilenameAttributesData& rhs)
+{
+  return os << rhs.input;
+}
+
+class TestUtilFilenameAttributePairs : public TestFilenameAttributes,
+                                       public WithParamInterface<TestUtilFilenameAttributesData>
+{
+};
+
+TEST_P(TestUtilFilenameAttributePairs, RetrieveAttributes)
+{
+  const auto& params = GetParam();
+  EXPECT_EQ(params.expected, CallGetFilenameAttributePairs(params.input, nullptr));
+}
+
+const TestUtilFilenameAttributesData filenameAttributePairsTests[] = {
+    {"Some.MovieName.mkv", {}},
+    // separators and braces
+    {"Some.MovieName[key=value].mkv", {{"key", "value"}}},
+    {"Some.MovieName[key-value].mkv", {{"key", "value"}}},
+    {"Some.MovieName{key=value}.mkv", {{"key", "value"}}},
+    {"Some.MovieName{key-value}.mkv", {{"key", "value"}}},
+    // trim
+    {"Some.MovieName[ key  =   value  ].mkv", {{"key", "value"}}},
+    // multiple matches
+    {"Some.MovieName [key1=value1]{key2 = value2}.mkv", {{"key1", "value1"}, {"key2", "value2"}}},
+    {"Some.MovieName [key1=value1] foobar {key2 = value2}.mkv",
+     {{"key1", "value1"}, {"key2", "value2"}}},
+    // case
+    {"Some.MovieName[KeY=vAlUe].mkv", {{"key", "vAlUe"}}},
+    // repeated key
+    {"Some.MovieName[key=value1][key=value2].mkv", {{"key", "value2"}}},
+    {"Some.MovieName[key=value1][KEY=value2].mkv", {{"key", "value2"}}},
+    // unicode
+    {"Some.MovieName[key=r\u00E9alisateur].mkv", {{"key", "r\u00E9alisateur"}}},
+    // no match
+    {"Some.MovieName.key=value.mkv", {}},
+    {"Some.MovieName[key=].mkv", {}},
+    {"Some.MovieName[key=   ].mkv", {}},
+    {"Some.MovieName[=value].mkv", {}},
+    {"", {}},
+};
+
+INSTANTIATE_TEST_SUITE_P(TestFilenameAttributes,
+                         TestUtilFilenameAttributePairs,
+                         ValuesIn(filenameAttributePairsTests));
+
+struct TestUtilCleanFilenameAttributesData
+{
+  std::string input;
+  std::string expected;
+};
+
+std::ostream& operator<<(std::ostream& os, const TestUtilCleanFilenameAttributesData& rhs)
+{
+  return os << rhs.input;
+}
+
+class TestUtilCleanFilenameAttributePairs
+  : public Test,
+    public WithParamInterface<TestUtilCleanFilenameAttributesData>
+{
+};
+
+TEST_P(TestUtilCleanFilenameAttributePairs, Clean)
+{
+  const auto& params = GetParam();
+  std::string file = params.input;
+  CFilenameAttributes::CleanFilenameAttributePairs(file, nullptr);
+  EXPECT_EQ(params.expected, file);
+}
+
+const TestUtilCleanFilenameAttributesData cleanFilenameAttributePairsTests[] = {
+    {"Some.MovieName[key=value].mkv", "Some.MovieName.mkv"},
+    {"Some.MovieName [key1=value1]{key2 = value2}.mkv", "Some.MovieName .mkv"},
+    {"Some.MovieName [key1=value1] foobar {key2 = value2}.mkv", "Some.MovieName  foobar .mkv"},
+    {"Some.MovieName.mkv", "Some.MovieName.mkv"},
+    {"[key=value]Some.MovieName.mkv", "Some.MovieName.mkv"},
+};
+
+INSTANTIATE_TEST_SUITE_P(TestFilenameAttributes,
+                         TestUtilCleanFilenameAttributePairs,
+                         ValuesIn(cleanFilenameAttributePairsTests));
+TEST(TestFilenameAttributes, GetEdition)
+{
+  auto fa = CFilenameAttributes("Some.MovieName[edition=Director's Cut].mkv", nullptr);
+  EXPECT_EQ("Director's Cut", fa.GetEdition());
+  fa = CFilenameAttributes("Some.MovieName[foo=bar].mkv", nullptr);
+  EXPECT_EQ("", fa.GetEdition());
+  fa = CFilenameAttributes("Some.MovieName.mkv", nullptr);
+  EXPECT_EQ("", fa.GetEdition());
+  fa = CFilenameAttributes("", nullptr);
+  EXPECT_EQ("", fa.GetEdition());
+}
+
+struct TestFilenameIdentifierData
+{
+  std::string input;
+  bool rc;
+  std::string identifierType{};
+  std::string identifier{};
+};
+
+std::ostream& operator<<(std::ostream& os, const TestFilenameIdentifierData& rhs)
+{
+  return os << rhs.input;
+}
+
+class TestFilenameIdentifier : public TestFilenameAttributes,
+                               public WithParamInterface<TestFilenameIdentifierData>
+{
+};
+
+TEST_P(TestFilenameIdentifier, GetIdentifier)
+{
+  const auto& params = GetParam();
+  CFilenameAttributes fa(params.input, nullptr);
+  std::string identifierType;
+  std::string identifier;
+  EXPECT_EQ(params.rc, fa.GetIdentifier(identifierType, identifier));
+  EXPECT_EQ(params.identifierType, identifierType);
+  EXPECT_EQ(params.identifier, identifier);
+}
+
+TEST_P(TestFilenameIdentifier, HasIdentifier)
+{
+  const auto& params = GetParam();
+  CFilenameAttributes fa(params.input, nullptr);
+  EXPECT_EQ(params.rc, fa.HasIdentifier());
+}
+
+const TestFilenameIdentifierData FilenameIdentifierTests[] = {
+    {"", false},
+    {"Some.MovieName[edition=test].mkv", false},
+    // known identifiers
+    {"Some.MovieName[tmdb=123].mkv", true, "tmdb", "123"},
+    {"Some.MovieName[imdb=tt0012345].mkv", true, "imdb", "tt0012345"},
+    // the suffix "id" is removed from the key
+    {"Some.MovieName[tmdbid=123].mkv", true, "tmdb", "123"},
+    {"Some.MovieName[TMDBID=123].mkv", true, "tmdb", "123"},
+    {"Some.MovieName[fooid=bar].mkv", false},
+    // the value must be alphanum.
+    {"Some.MovieName[tmdb=test-12 3].mkv", false},
+};
+
+INSTANTIATE_TEST_SUITE_P(TestFilenameAttributes,
+                         TestFilenameIdentifier,
+                         ValuesIn(FilenameIdentifierTests));
+
+TEST(TestFilenameAttributes, EmptyKnownIdentifiers)
+{
+  const std::shared_ptr<CAdvancedSettings> advancedSettings =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+  ASSERT_TRUE(advancedSettings != nullptr);
+  advancedSettings->m_videoScannerMetadataSources = {};
+
+  auto fa = CFilenameAttributes("Some.MovieName[tmdb=123].mkv", nullptr);
+  EXPECT_FALSE(fa.HasIdentifier());
+  std::string identifierType;
+  std::string identifier;
+  EXPECT_FALSE(fa.GetIdentifier(identifierType, identifier));
+  EXPECT_TRUE(identifierType.empty());
+  EXPECT_TRUE(identifier.empty());
+
+  fa = CFilenameAttributes("", nullptr);
+  EXPECT_FALSE(fa.HasIdentifier());
+  EXPECT_FALSE(fa.GetIdentifier(identifierType, identifier));
+  EXPECT_TRUE(identifierType.empty());
+  EXPECT_TRUE(identifier.empty());
+}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add movies to the library with a version type extracted from the filename instead of the default "Standard Edition" type,
Note that the version specified in the <videoassettitle> nfo tag, when present, takes precedence.

Recognized pattern:
```
Movie name.2026.remastered.2160p.UHD.Bluray.remux.H265.TrueHD.Atmos[edition=Director's Cut].mkv
```
`{}` braces work as well and `-` is also recognized as separator.

The edition text may appear anywhere in the movie filename, though it could interfere with movie name and year extraction if it appears before them.
May be used in conjunction with a metadata provider id (ex. [imdb-tt123456])

The format can be customized with a regexp in advanced settings:
```
<advancedsettings>
  <video>
    <filenameattributepairs>[\[{]\s*(?<key>\w+)\s*[=\-](?P<value>[^\]}]+)[\]}]</filenameattributepairs>
  </video>
</advancedsettings>
```
The regexp receives the complete file name.

The existing metadata provider id extraction had a similar extraction pattern `[brace]key[- or =]value[brace]` and matched on edition=xxx as well, which was a problem.
The conflict was resolved with a list of known providers, user-customizable through a regexp.

Default know providers: tmdb, imdb, tvdb, anidb
Customization through advancedsettings: similar to extensions
```
<advancedsettings>
  <videoscanner>
    <metadatasources>
      <add>foo|bar</add>
and/or
      <remove>baz</remove>
    </metadatasources>
  </videoscanner>
</advancedsettings>
```

The filenameidentifier regexp was removed.

Future possible improvements:
- ~encapsulate the filename parsing and metadata provider/edition extraction in a dedicated class.~ done
- cover other patterns that don't require the word "edition" present.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Automation of movie version creation and compatibility with other media center applications.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added unit tests, tested movie with version in filename, movie with version in filename and nfo, movie with nfo and without version in filename.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Movies are created in the library with the version name specified in the filename,

## Screenshots (if appropriate):

Movie with edition in filename:
<img width="702" height="104" alt="image" src="https://github.com/user-attachments/assets/8a0927c8-cd1c-4094-a3a4-9f65be9a20e3" />

After library scan:
<img width="1889" height="698" alt="image" src="https://github.com/user-attachments/assets/ec2a2802-3344-4fd1-a391-58b76f2568c2" />


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
