### PR TITLE
[Python][interface] Correct xbmc module xbmc.getLanguage(format, region) return values

### DIFF
--- a/xbmc/addons/interfaces/General.cpp
+++ b/xbmc/addons/interfaces/General.cpp
@@ -38,6 +38,24 @@ using UTILITY::CDigest;
 namespace ADDON
 {
 
+/*! @brief Extract base language name from compound language strings.
+ *  Removes region identifier suffix in parentheses.
+ *  Example: "English(US)" -> "English"
+ *  @param lang Language string that may contain region (2-char, e.g. US) in parentheses
+ *  @return Base language name without region suffix
+ */
+static std::string GetBaseLanguageName(const std::string& lang)
+{
+  size_t openParen = lang.find('(');
+  if (openParen != std::string::npos)
+  {
+    std::string baseLang = lang.substr(0, openParen);
+    StringUtils::TrimRight(baseLang);
+    return baseLang;
+  }
+  return lang;
+}
+
 void Interface_General::Init(AddonGlobalInterface* addonInterface)
 {
   addonInterface->toKodi->kodi = static_cast<AddonToKodiFuncTable_kodi*>(malloc(sizeof(AddonToKodiFuncTable_kodi)));
@@ -96,7 +114,7 @@ char* Interface_General::get_language(void* kodiBase, int format, bool region)
     case LANG_FMT_ISO_639_1:
     {
       std::string langCode;
-      g_LangCodeExpander.ConvertToISO6391(string, langCode);
+      g_LangCodeExpander.ConvertToISO6391(GetBaseLanguageName(string), langCode);
       string = langCode;
       if (region)
       {
@@ -110,7 +128,7 @@ char* Interface_General::get_language(void* kodiBase, int format, bool region)
     case LANG_FMT_ISO_639_2:
     {
       std::string langCode;
-      g_LangCodeExpander.ConvertToISO6392B(string, langCode);
+      g_LangCodeExpander.ConvertToISO6392B(GetBaseLanguageName(string), langCode);
       string = langCode;
       if (region)
       {

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -60,6 +60,26 @@ namespace XBMCAddon
     /*****************************************************************
      * start of xbmc methods
      *****************************************************************/
+
+    /*! @brief Extract base language name from compound language strings.
+     *  Removes region or script identifier suffix in parentheses.
+     *  Examples: "English(US)" -> "English", "Chinese(Hant)" -> "Chinese"
+     *  @param lang Language string that may contain region (2-char, e.g. US) or
+     *              script identifier (e.g. Hant, Cyrl, Arab) in parentheses
+     *  @return Base language name without region or script suffix
+     */
+    static std::string GetBaseLanguageName(const std::string& lang)
+    {
+      size_t openParen = lang.find('(');
+      if (openParen != std::string::npos)
+      {
+        std::string baseLang = lang.substr(0, openParen);
+        StringUtils::TrimRight(baseLang);
+        return baseLang;
+      }
+      return lang;
+    }
+
     void log(const char* msg, int level)
     {
       // check for a valid loglevel
@@ -204,7 +224,7 @@ namespace XBMCAddon
       case CLangCodeExpander::ISO_639_1:
         {
           std::string langCode;
-          g_LangCodeExpander.ConvertToISO6391(lang, langCode);
+          g_LangCodeExpander.ConvertToISO6391(GetBaseLanguageName(lang), langCode);
           if (region)
           {
             std::string region = g_langInfo.GetRegionLocale();
@@ -218,7 +238,7 @@ namespace XBMCAddon
       case CLangCodeExpander::ISO_639_2:
         {
           std::string langCode;
-          g_LangCodeExpander.ConvertToISO6392B(lang, langCode);
+          g_LangCodeExpander.ConvertToISO6392B(GetBaseLanguageName(lang), langCode);
           if (region)
           {
             std::string region = g_langInfo.GetRegionLocale();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Ensure the strings returned by xbmc.getLanguage are valid for the case UI language has regional or script variants
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix for issue https://github.com/xbmc/xbmc/issues/24990
## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
github-copilot AI agent was requested to analyze the issue and suggest a fix.  The suggested fix was to parse the language string by splitting at a left-parens "(".  After verifying the logic the agent was requested to follow c++ best practices which resulted in factoring out the parsing code into a new helper function. 
## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Python addons which use xbmc.getLanguage() will run correctly without needing defensive coding for incorrect returned values.
## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

Built kodi as debug on Win 11 x64 VS2022. Not certain that the AI has correctly followed the code guidelines.  Will update as needed.

Tested by running a python test addon that exercises all valid arguments in the function call (first argument is a literal that maps to integer values 0,1,2 to specify return format.  Second is an optional bool.  Passed as positional).  In Kodi, set the UI language to various languages and ran the addon.  Logged the function return to kodi.log and inspected the log entries.