### PR TITLE
[Peripheral] Fix race on m_peripherals

### DIFF
--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -210,36 +210,38 @@ bool CPeripheralAddon::Register(unsigned int peripheralIndex, const PeripheralPt
 void CPeripheralAddon::UnregisterRemovedDevices(const PeripheralScanResults& results,
                                                 PeripheralVector& removedPeripherals)
 {
-  std::vector<unsigned int> removedIndexes;
+  PeripheralVector removed;
 
   {
     std::unique_lock lock(m_critSection);
-    for (auto& it : m_peripherals)
+    for (auto it = m_peripherals.begin(); it != m_peripherals.end();)
     {
-      const PeripheralPtr& peripheral = it.second;
+      const PeripheralPtr& peripheral = it->second;
       PeripheralScanResult updatedDevice(PERIPHERAL_BUS_ADDON);
       if (!results.GetDeviceOnLocation(peripheral->Location(), &updatedDevice) ||
           *peripheral != updatedDevice)
       {
-        // Device removed
-        removedIndexes.push_back(it.first);
+        removed.emplace_back(peripheral);
+        it = m_peripherals.erase(it);
+      }
+      else
+      {
+        ++it;
       }
     }
   }
 
-  for (auto index : removedIndexes)
+  for (const auto& peripheral : removed)
   {
-    auto it = m_peripherals.find(index);
-    const PeripheralPtr& peripheral = it->second;
     CLog::Log(LOGINFO, "{} - {} device removed from {}: {} ({}:{})", __FUNCTION__,
               PeripheralTypeTranslator::TypeToString(peripheral->Type()),
               peripheral->FileLocation(), peripheral->DeviceName(), peripheral->VendorIdAsString(),
               peripheral->ProductIdAsString());
     UnregisterButtonMap(peripheral.get());
     peripheral->OnDeviceRemoved();
-    removedPeripherals.push_back(peripheral);
-    m_peripherals.erase(it);
   }
+
+  removedPeripherals.insert(removedPeripherals.end(), removed.begin(), removed.end());
 }
 
 bool CPeripheralAddon::HasFeature(const PeripheralFeature feature) const
@@ -471,11 +473,19 @@ bool CPeripheralAddon::ProcessEvents(void)
       }
     }
 
-    for (const auto& it : m_peripherals)
+    std::vector<std::shared_ptr<CPeripheralJoystick>> joysticks;
     {
-      if (it.second->Type() == PERIPHERAL_JOYSTICK)
-        std::static_pointer_cast<CPeripheralJoystick>(it.second)->OnInputFrame();
+      std::unique_lock lock(m_critSection);
+      joysticks.reserve(m_peripherals.size());
+      for (const auto& it : m_peripherals)
+      {
+        if (it.second->Type() == PERIPHERAL_JOYSTICK)
+          joysticks.emplace_back(std::static_pointer_cast<CPeripheralJoystick>(it.second));
+      }
     }
+
+    for (const auto& joystick : joysticks)
+      joystick->OnInputFrame();
 
     m_ifc.peripheral->toAddon->free_events(m_ifc.peripheral, eventCount, pEvents);
 


### PR DESCRIPTION
The ProcessEvents function and UnregisterRemovedDevices both read or modified m_peripherals without locking, and with some rapid connect and disconnect events you could cause the system to crash.

This PR is assisted by claude.

## Description
I was testing a hotplug addition to linux joystick support, [PR](https://github.com/xbmc/peripheral.joystick/pull/341), by rapidly connecting and disconnecting controllers. Doing so resulted in a crash. After replicating it and reviewing the crash logs, it came down to these two locations stomping on each others toes.

UnregisterRemovedDevices would erase items from m_peripherals at the same time ProcessEvents was iterating over the map. Solving this for ProcessEvents required taking a snapshot of m_peripherals under lock and then iterating over the clone afterwards, and for UnregisterRemovedDevices I moved the erase call into the existing lock scope.

## Motivation and context
This race condition is really hard to hit, even with rapid connect events. It would take a couple minutes of spam to trigger the crash, which is why it likely hasn't been reported. Even though it's hard to hit it, it is still a potential crash point and should be patched.

## How has this been tested?
I had multiple real controllers connected, and I ran a python script that simulates connecting and disconnecting a joystick device a few times a second. Without this fix I could regularly crash the app in about 2 minutes. With this fix I ran the script for over 20 minutes and with over 4000 connect events without it crashing or seizing up. I plan on letting it run longer and will update this if anything does or doesn't happen.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [] All new and existing tests passed
