### PR TITLE
[Cmake] refresh android apk generation

### DIFF
--- a/cmake/modules/FindLibDvd.cmake
+++ b/cmake/modules/FindLibDvd.cmake
@@ -9,6 +9,9 @@
 if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   find_package(LibDvdNav MODULE REQUIRED)
 
+  add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} INTERFACE IMPORTED)
+  add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} ${APP_NAME_LC}::LibDvdNav)
+
   if(CORE_SYSTEM_NAME MATCHES windows)
     set(LIBDVD_TARGET_DIR .)
     copy_file_to_buildtree(${DEPENDS_PATH}/bin/libdvdnav.dll DIRECTORY ${LIBDVD_TARGET_DIR})
@@ -22,8 +25,9 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     # link a shared dvdnav library that includes the whole archives of dvdread and dvdcss as well
     # the quotes around _dvdlibs are on purpose, since we want to pass a list to the function that will be unpacked automatically
     core_link_library(${APP_NAME_LC}::LibDvdNav system/players/VideoPlayer/libdvdnav archives "${_dvdlibs}")
-  endif()
 
-  add_library(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} INTERFACE IMPORTED)
-  add_dependencies(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} ${APP_NAME_LC}::LibDvdNav)
+    set_target_properties(${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+                                                                     IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/system/players/VideoPlayer/libdvdnav-${ARCH}${CMAKE_SHARED_MODULE_SUFFIX}")
+
+  endif()
 endif()

--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -1,5 +1,22 @@
 # Android packaging
 
+# Configure variables used in replacement configure_file calls
+if(CPU MATCHES i686)
+  set(CPU x86)
+endif()
+
+string(REPLACE "." ";" APP_VERSION_CODE_LIST ${APP_VERSION_CODE})
+list(GET APP_VERSION_CODE_LIST 0 major)
+list(GET APP_VERSION_CODE_LIST 1 minor)
+list(GET APP_VERSION_CODE_LIST 2 patch)
+unset(APP_VERSION_CODE_LIST)
+math(EXPR APP_VERSION_CODE_ANDROID "(${major} * 100 + ${minor}) * 1000 + ${patch}")
+unset(major)
+unset(minor)
+unset(patch)
+
+string(REPLACE "." "/" dot_APP_PACKAGE ${APP_PACKAGE})
+
 # Configure files into packaging environment.
 configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/Makefile.in
                ${CMAKE_BINARY_DIR}/tools/android/packaging/Makefile @ONLY)
@@ -17,162 +34,213 @@ configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/gradle/wrapper/gradle
                ${CMAKE_BINARY_DIR}/tools/android/packaging/gradle/wrapper/gradle-wrapper.properties COPYONLY)
 configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/xbmc/jni/Android.mk
                ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/jni/Android.mk COPYONLY)
-file(WRITE ${CMAKE_BINARY_DIR}/tools/depends/Makefile.include
-     "$(PREFIX)/lib/${APP_NAME_LC}/lib${APP_NAME_LC}.so: ;\n")
+configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/xbmc/strings.xml.in
+               ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/res/values/strings.xml @ONLY)
+configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/xbmc/colors.xml.in
+               ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/res/values/colors.xml @ONLY)
+configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/xbmc/searchable.xml.in
+               ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/res/xml/searchable.xml @ONLY)
+configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/xbmc/AndroidManifest.xml.in
+               ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/AndroidManifest.xml @ONLY)
+configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/xbmc/build.gradle.in
+               ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/build.gradle @ONLY)
 
-string(REPLACE "." ";" APP_VERSION_CODE_LIST ${APP_VERSION_CODE})
-list(GET APP_VERSION_CODE_LIST 0 major)
-list(GET APP_VERSION_CODE_LIST 1 minor)
-list(GET APP_VERSION_CODE_LIST 2 patch)
-unset(APP_VERSION_CODE_LIST)
-math(EXPR APP_VERSION_CODE_ANDROID "(${major} * 100 + ${minor}) * 1000 + ${patch}")
-unset(major)
-unset(minor)
-unset(patch)
-
-set(package_files strings.xml
-                  colors.xml
-                  searchable.xml
-                  AndroidManifest.xml
-                  build.gradle
-                  src/Splash.java
-                  src/Main.java
-                  src/XBMCBroadcastReceiver.java
-                  src/XBMCInputDeviceListener.java
-                  src/XBMCJsonRPC.java
-                  src/XBMCMainView.java
-                  src/XBMCMediaSession.java
-                  src/XBMCRecommendationBuilder.java
-                  src/XBMCSearchableActivity.java
-                  src/XBMCSettingsContentObserver.java
-                  src/XBMCProperties.java
-                  src/XBMCVideoView.java
-                  src/XBMCFile.java
-                  src/XBMCTextureCache.java
-                  src/XBMCURIUtils.java
-                  src/channels/SyncChannelJobService.java
-                  src/channels/SyncProgramsJobService.java
-                  src/channels/model/XBMCDatabase.java
-                  src/channels/model/Subscription.java
-                  src/channels/util/SharedPreferencesHelper.java
-                  src/channels/util/TvUtil.java
-                  src/interfaces/XBMCAudioManagerOnAudioFocusChangeListener.java
-                  src/interfaces/XBMCSurfaceTextureOnFrameAvailableListener.java
-                  src/interfaces/XBMCNsdManagerResolveListener.java
-                  src/interfaces/XBMCNsdManagerRegistrationListener.java
-                  src/interfaces/XBMCNsdManagerDiscoveryListener.java
-                  src/interfaces/XBMCMediaDrmOnEventListener.java
-                  src/interfaces/XBMCMediaDrmOnKeyStatusChangeListener.java
-                  src/interfaces/XBMCDisplayManagerDisplayListener.java
-                  src/interfaces/XBMCSpeechRecognitionListener.java
-                  src/interfaces/XBMCConnectivityManagerNetworkCallback.java
-                  src/model/TVEpisode.java
-                  src/model/Movie.java
-                  src/model/TVShow.java
-                  src/model/File.java
-                  src/model/Album.java
-                  src/model/Song.java
-                  src/model/MusicVideo.java
-                  src/model/Media.java
-                  src/content/XBMCFileContentProvider.java
-                  src/content/XBMCFileProvider.java
-                  src/content/XBMCMediaContentProvider.java
-                  src/content/XBMCContentProvider.java
-                  src/util/Storage.java
+set(src_java_files Splash.java
+                   Main.java
+                   XBMCBroadcastReceiver.java
+                   XBMCInputDeviceListener.java
+                   XBMCJsonRPC.java
+                   XBMCMainView.java
+                   XBMCMediaSession.java
+                   XBMCRecommendationBuilder.java
+                   XBMCSearchableActivity.java
+                   XBMCSettingsContentObserver.java
+                   XBMCProperties.java
+                   XBMCVideoView.java
+                   XBMCFile.java
+                   XBMCTextureCache.java
+                   XBMCURIUtils.java
+                   channels/SyncChannelJobService.java
+                   channels/SyncProgramsJobService.java
+                   channels/model/XBMCDatabase.java
+                   channels/model/Subscription.java
+                   channels/util/SharedPreferencesHelper.java
+                   channels/util/TvUtil.java
+                   interfaces/XBMCAudioManagerOnAudioFocusChangeListener.java
+                   interfaces/XBMCSurfaceTextureOnFrameAvailableListener.java
+                   interfaces/XBMCNsdManagerResolveListener.java
+                   interfaces/XBMCNsdManagerRegistrationListener.java
+                   interfaces/XBMCNsdManagerDiscoveryListener.java
+                   interfaces/XBMCMediaDrmOnEventListener.java
+                   interfaces/XBMCMediaDrmOnKeyStatusChangeListener.java
+                   interfaces/XBMCDisplayManagerDisplayListener.java
+                   interfaces/XBMCSpeechRecognitionListener.java
+                   interfaces/XBMCConnectivityManagerNetworkCallback.java
+                   model/TVEpisode.java
+                   model/Movie.java
+                   model/TVShow.java
+                   model/File.java
+                   model/Album.java
+                   model/Song.java
+                   model/MusicVideo.java
+                   model/Media.java
+                   content/XBMCFileContentProvider.java
+                   content/XBMCFileProvider.java
+                   content/XBMCMediaContentProvider.java
+                   content/XBMCContentProvider.java
+                   util/Storage.java
                   )
-foreach(file IN LISTS package_files)
-  configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/xbmc/${file}.in
-                 ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/${file} @ONLY)
+
+foreach(file IN LISTS src_java_files)
+  configure_file(${CMAKE_SOURCE_DIR}/tools/android/packaging/xbmc/src/${file}.in
+                 ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/java/${dot_APP_PACKAGE}/${file} @ONLY)
 endforeach()
 
-# Copy files to the location expected by the Android packaging scripts.
-add_custom_target(bundle
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/tools/android/packaging/media
-                                               ${CMAKE_BINARY_DIR}/tools/android/packaging/media
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/tools/android/packaging/xbmc/res
-                                               ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/res
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${DEPENDS_PATH}/lib/python${PYTHON_VERSION} ${libdir}/python${PYTHON_VERSION}
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${DEPENDS_PATH}/share/${APP_NAME_LC} ${datadir}/${APP_NAME_LC}
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${APP_NAME_LC}>
-                                     ${libdir}/${APP_NAME_LC}/$<TARGET_FILE_NAME:${APP_NAME_LC}>)
-add_dependencies(bundle ${APP_NAME_LC})
+# Copies dir to destination, excluding any shared libs
+function(add_bundle_dir dir dir_dest)
+  file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake
+              "file(COPY \"${dir}/\"\n"
+              "     DESTINATION \"${dir_dest}/\"\n"
+              "     REGEX \".*\\\\.so$\" EXCLUDE)\n")
+endfunction()
 
-# This function is used to prepare a prefix expected by the Android packaging
-# scripts. It creates a bundle_files command that is added to the bundle target.
-function(add_bundle_file file destination relative)
-  if(NOT TARGET bundle_files)
-    file(REMOVE ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake)
-    add_custom_target(bundle_files COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake)
-    add_dependencies(bundle bundle_files)
-    add_dependencies(bundle_files ${APP_NAME_LC})
-  endif()
+# Copies library to destination, renaming to android required lib prefix if needed
+function(add_bundle_lib input destination)
+  if(TARGET ${input})
+    # TARGET is required to have IMPORTED_LOCATION
+    get_target_property(imploc_file ${input} IMPORTED_LOCATION)
 
-  if(TARGET ${file})
-    # Add support for IMPORTED lib targets
-    # If we need specific properties from other target types later, we can add them
-    # here with some validity checks
-    get_target_property(imploc_file ${file} IMPORTED_LOCATION)
     if(imploc_file)
       set(file ${imploc_file})
     else()
       return()
     endif()
+  else()
+    set(file ${input})
   endif()
 
-  string(REPLACE "${relative}/" "" outfile ${file})
-  get_filename_component(file ${file} REALPATH)
-  get_filename_component(outdir ${outfile} DIRECTORY)
-  file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake
-       "file(COPY \"${file}\" DESTINATION \"${destination}/${outdir}\")\n")
-  if(file MATCHES "\\.so\\..+$")
-    get_filename_component(srcfile "${file}" NAME)
-    string(REGEX REPLACE "\\.so\\..+$" "\.so" destfile ${srcfile})
-    file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake
-         "file(RENAME \"${destination}/${outdir}/${srcfile}\" \"${destination}/${outdir}/${destfile}\")\n")
+  cmake_path(GET file FILENAME out_file)
+
+  # Check if we need to add lib prefix
+  string(FIND ${out_file} "lib" lib_prefix)
+  if(${lib_prefix} EQUAL "-1")
+    set(_prefix lib)
   endif()
+
+  file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake
+       "configure_file(\"${file}\" \"${destination}/${_prefix}${out_file}\" COPYONLY)\n")
 endfunction()
 
-# Copy files into prefix
-foreach(file IN LISTS XBT_FILES install_data)
-  string(REPLACE "${CMAKE_BINARY_DIR}/" "" file ${file})
-  add_bundle_file(${CMAKE_BINARY_DIR}/${file} ${datarootdir}/${APP_NAME_LC} ${CMAKE_BINARY_DIR})
-endforeach()
+# Copy app shared lib to destination packaging
+add_custom_target(bundle
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${APP_NAME_LC}>
+                                     ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/lib/${CPU}
+    COMMAND ${CMAKE_STRIP} --strip-unneeded ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/lib/${CPU}/*.so)
 
-# libdvdnav is currently the only LIBRARY_FILES item remaining for android
-foreach(library IN LISTS LIBRARY_FILES)
-  add_bundle_file(${library} ${libdir}/${APP_NAME_LC} ${CMAKE_BINARY_DIR})
-endforeach()
+add_dependencies(bundle ${APP_NAME_LC})
 
-if(TARGET ${APP_NAME_LC}::Shairplay)
-  add_bundle_file(${APP_NAME_LC}::Shairplay ${libdir} "")
+if(NOT TARGET bundle_files)
+  file(REMOVE ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake)
+  add_custom_target(bundle_files COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake)
+  add_dependencies(bundle bundle_files)
+  add_dependencies(bundle_files ${APP_NAME_LC})
 endif()
 
-# Main targets from Makefile.in
-if(CPU MATCHES i686)
-  set(CPU x86)
+add_bundle_dir("${CMAKE_SOURCE_DIR}/tools/android/packaging/xbmc/res" "${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/res")
+
+# This copies extracted pil to addons folder prior to bundle step for addons
+# This runs at configure time, if python modules are ever built at build time, this will need
+# to be revisited
+file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake
+            "file(COPY \"${DEPENDS_PATH}/share/${APP_NAME_LC}/addons/\"\n"
+            "     DESTINATION \"${CMAKE_BINARY_DIR}/addons\"\n"
+            "     REGEX \".*\\\\.so$\" EXCLUDE)\n")
+
+# Copy addon shared lib files to package lib folder
+file(GLOB_RECURSE _addon_libs CONFIGURE_DEPENDS ${DEPENDS_PATH}/share/${APP_NAME_LC}/addons/*.so)
+
+foreach(file IN LISTS _addon_libs)
+  add_bundle_lib(${file} "${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/lib/${CPU}")
+endforeach()
+
+# libc++
+add_bundle_lib("${TOOLCHAIN}/sysroot/usr/lib/${HOST}/libc++_shared.so" "${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/lib/${CPU}/")
+
+configure_file("${CMAKE_SOURCE_DIR}/privacy-policy.txt" "${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/assets/privacy-policy.txt" COPYONLY)
+
+# Copy res data to package folder
+configure_file(${CMAKE_SOURCE_DIR}/media/applaunch_screen.png
+               ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/res/drawable-xxxhdpi/applaunch_screen.png COPYONLY)
+configure_file(${CMAKE_SOURCE_DIR}/media/applaunch_screen.png
+               ${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/res/drawable/applaunch_screen.png COPYONLY)
+
+file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake
+            "file(COPY \"${CMAKE_SOURCE_DIR}/tools/android/packaging/media/\"\n"
+            "     DESTINATION \"${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/res\"\n"
+            "     PATTERN \"mipmap-*\"\n"
+            "     PATTERN playstore.png EXCLUDE)\n")
+
+# Copy files into package assets folder
+add_bundle_dir("${CMAKE_BINARY_DIR}/addons" "${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/assets/addons")
+add_bundle_dir("${CMAKE_BINARY_DIR}/media" "${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/assets/media")
+add_bundle_dir("${CMAKE_BINARY_DIR}/system" "${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/assets/system")
+add_bundle_dir("${CMAKE_BINARY_DIR}/userdata" "${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/assets/userdata")
+
+# Copy python folder structure, excluding any shared archives
+# PYTHONHOME use requires the structure <PYTHONHOME>/lib/python${PYTHON_VERSION}
+file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake
+            "file(COPY ${DEPENDS_PATH}/lib/python${PYTHON_VERSION}/\n"
+            "     DESTINATION \"${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/assets/python${PYTHON_VERSION}/lib/python${PYTHON_VERSION}/\"\n"
+            "     PATTERN \"lib-dynload\" EXCLUDE\n"
+            "     PATTERN \"config-${PYTHON_VERSION}\" EXCLUDE\n"
+            "     REGEX \".*\\\\.so$\" EXCLUDE)\n")
+
+# Copy python shared lib files to package lib folder
+file(GLOB_RECURSE _py_libs CONFIGURE_DEPENDS ${DEPENDS_PATH}/lib/python${PYTHON_VERSION}/*.so)
+
+file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake
+            "file(COPY ${_py_libs}\n"
+            "     DESTINATION \"${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/lib/${CPU}/\"\n"
+            "     FILES_MATCHING PATTERN \"*.so\"\n"
+            "     REGEX \".*[Cc]ryptodome+.*\" EXCLUDE)\n")
+
+# Cryptodome is special and requires further renaming due to runtime patches
+list(FILTER _py_libs INCLUDE REGEX ".*[Cc]ryptodome+.*")
+
+foreach(file IN LISTS _py_libs)
+  block()
+    string(REGEX REPLACE "\.abi[0-9]" "" str_abistrip ${file})
+
+    string(REGEX MATCH "[Cc]ryptodome.+\.so" str_pathname ${str_abistrip})
+    string(REPLACE "/" "_" out_file ${str_pathname})
+
+    # Check if we need to add lib prefix
+    string(FIND ${out_file} "lib" lib_prefix)
+    if(${lib_prefix} EQUAL "-1")
+      set(_prefix lib)
+    endif()
+
+    file(APPEND ${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/BundleFiles.cmake
+                "configure_file(\"${file}\" \"${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/lib/${CPU}/${_prefix}${out_file}\" COPYONLY)\n")
+  endblock()
+endforeach()
+
+if(TARGET ${APP_NAME_LC}::LibDvd)
+  add_bundle_lib(${APP_NAME_LC}::LibDvd "${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/lib/${CPU}")
+endif()
+
+if(TARGET ${APP_NAME_LC}::Shairplay)
+  add_bundle_lib(${APP_NAME_LC}::Shairplay "${CMAKE_BINARY_DIR}/tools/android/packaging/xbmc/lib/${CPU}")
 endif()
 
 find_program(MAKE_EXECUTABLE make REQUIRED)
 
-foreach(target apk apk-clean)
-  add_custom_target(${target}
-      COMMAND env PATH=${NATIVEPREFIX}/bin:$ENV{PATH} ${MAKE_EXECUTABLE} -j1
-              -C ${CMAKE_BINARY_DIR}/tools/android/packaging
-              CMAKE_SOURCE_DIR=${CMAKE_SOURCE_DIR}
-              CC=${CMAKE_C_COMPILER}
-              CPU=${CPU}
-              HOST=${HOST}
-              TOOLCHAIN=${TOOLCHAIN}
-              PREFIX=${prefix}
-              DEPENDS_PATH=${DEPENDS_PATH}
-              NDKROOT=${NDKROOT}
-              SDKROOT=${SDKROOT}
-              STRIP=${CMAKE_STRIP}
-              ${target}
-      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tools/android/packaging
-      VERBATIM
-  )
-  if(NOT target STREQUAL apk-clean)
-    add_dependencies(${target} bundle)
-  endif()
-endforeach()
+add_custom_target(apk
+    COMMAND env PATH=${NATIVEPREFIX}/bin:$ENV{PATH} ${MAKE_EXECUTABLE} -j1
+            -C ${CMAKE_BINARY_DIR}/tools/android/packaging
+            apk
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tools/android/packaging
+    VERBATIM
+)
+
+add_dependencies(apk bundle)

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -1,14 +1,4 @@
-include ../../depends/Makefile.include
-
-BUILD_TYPE:=@CMAKE_BUILD_TYPE@
-BUILD_TYPE_LC:=$(shell echo $(BUILD_TYPE) | tr A-Z a-z)
-
-OBJS = libshairplay.so
-
-EXCLUDED_ADDONS =
-
-CMAKE_SOURCE_DIR = $(shell cd $(CURDIR)/../../..; pwd)
-APP_PACKAGE_DIR = $(subst .,/,@APP_PACKAGE@)
+BUILD_TYPE_LC:=$(shell echo @CMAKE_BUILD_TYPE@ | tr A-Z a-z)
 
 ifeq ($(KODI_ANDROID_STORE_FILE),)
 export KODI_ANDROID_STORE_FILE:=$(HOME)/.android/debug.keystore
@@ -26,87 +16,11 @@ ifeq ($(KODI_ANDROID_KEY_PASSWORD),)
 export KODI_ANDROID_KEY_PASSWORD:=android
 endif
 
-# libc++
-STLLIB=$(TOOLCHAIN)/sysroot/usr/lib/$(HOST)/libc++_shared.so
-
-SRCLIBS = $(addprefix $(PREFIX)/lib/,$(OBJS))
-
 all: apk
 
-apk: apk-clean sharedapk package
-
-xbmc/assets:
-	mkdir -p xbmc/assets
-
-shared:
-	mkdir -p assets
-	cp -rfp $(PREFIX)/share/@APP_NAME_LC@/* ./assets
-	cp -rfp $(DEPENDS_PATH)/share/kodi/* ./assets || true
-	find `pwd`/assets/ -depth -name ".git" -exec rm -rf {} \;
-	find `pwd`/assets/ -name "*.so" -exec rm {} \;
-	find `pwd`/assets/addons/skin.*/media/* -depth -not -iname "*.xbt" -exec rm -rf {} \;
-	cd `pwd`/assets/addons; rm -rf $(EXCLUDED_ADDONS)
-	cp $(CMAKE_SOURCE_DIR)/privacy-policy.txt assets
-
-sharedapk: shared | xbmc/assets
-	cp -rfp assets/* ./xbmc/assets
-
-python: | xbmc/assets
-	mkdir -p xbmc/assets/python@PYTHON_VERSION@/lib/
-	cp -rfp $(PREFIX)/lib/python@PYTHON_VERSION@ xbmc/assets/python@PYTHON_VERSION@/lib/
-	cd xbmc/assets/python@PYTHON_VERSION@/lib/python@PYTHON_VERSION@/; rm -rf test config config-@PYTHON_VERSION@ lib-dynload ; find . -name "*.so" -exec rm -f {} \;
-
-res:
-	mkdir -p xbmc/res xbmc/res/values xbmc/res/xml
-	cp -rfp media/mipmap-* xbmc/res/
-	cp -fp $(CMAKE_SOURCE_DIR)/media/applaunch_screen.png xbmc/res/drawable/
-	cp -fp $(CMAKE_SOURCE_DIR)/media/applaunch_screen.png xbmc/res/drawable-xxxhdpi/
-	cp xbmc/strings.xml xbmc/res/values/
-	cp xbmc/colors.xml xbmc/res/values/
-	cp xbmc/searchable.xml xbmc/res/xml/
-
-libs: $(PREFIX)/lib/@APP_NAME_LC@/lib@APP_NAME_LC@.so
-	rm -rf xbmc/lib/$(CPU) xbmc/obj/local/$(CPU)
-	mkdir -p xbmc/lib/$(CPU) xbmc/assets/python@PYTHON_VERSION@/lib/ xbmc/obj/local/$(CPU)
-	cp -fpL $(SRCLIBS) xbmc/obj/local/$(CPU)/
-	cp -fp $(PREFIX)/lib/@APP_NAME_LC@/lib@APP_NAME_LC@.so xbmc/obj/local/$(CPU)/
-	(test -d $(PREFIX)/lib/@APP_NAME_LC@/addons && \
-	  find $(PREFIX)/lib/@APP_NAME_LC@/addons -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \;) || true
-	find $(PREFIX)/share/@APP_NAME_LC@/addons -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \; || true
-	find $(DEPENDS_PATH)/share/kodi/addons -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \; || true
-	(test -d $(DEPENDS_PATH)/lib/kodi/addons && \
-	  find $(DEPENDS_PATH)/lib/kodi/addons -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \;) || true
-	find $(PREFIX)/lib/@APP_NAME_LC@/system -name "*.so" -exec cp -fp {} xbmc/obj/local/$(CPU)/ \;
-	DIR=${CURDIR}; cd $(PREFIX)/lib/python@PYTHON_VERSION@/site-packages; for i in `find Cryptodome -name \*.so` ; do FN=`echo $$i | cut -c1- | tr "/" "_" | sed -e 's/\.abi[0-9]\\././'` ;cp $$i $$DIR/xbmc/obj/local/$(CPU)/$$FN ; done
-	cd xbmc/obj/local/$(CPU)/; find . -name "*.so" -not -name "lib*.so" | sed "s/\.\///" | xargs -I@ mv @ lib@
-	cp -fp xbmc/obj/local/$(CPU)/*.so xbmc/lib/$(CPU)/
-	$(STRIP) --strip-unneeded xbmc/lib/$(CPU)/*.so
-	(test -s $(STLLIB) && install -p $(STLLIB) ./xbmc/lib/$(CPU)/) || true
-
-java: res
-	mkdir -p xbmc/java/$(APP_PACKAGE_DIR) xbmc/obj
-	@cp -R xbmc/src/* xbmc/java/$(APP_PACKAGE_DIR)/
-
-package: libs python java
+apk:
 	@echo "Gradle build and sign..."
-	ANDROID_HOME=$(SDKROOT) ./gradlew assemble$(BUILD_TYPE)
-	@cp xbmc/build/outputs/apk/$(BUILD_TYPE_LC)/xbmc-$(BUILD_TYPE_LC).apk $(CMAKE_SOURCE_DIR)/@APP_NAME_LC@app-$(CPU)-$(BUILD_TYPE_LC).apk
+	ANDROID_HOME=@SDKROOT@ ./gradlew assemble$(@CMAKE_BUILD_TYPE@)
+	@cp xbmc/build/outputs/apk/$(BUILD_TYPE_LC)/xbmc-$(BUILD_TYPE_LC).apk @CMAKE_SOURCE_DIR@/@APP_NAME_LC@app-@CPU@-$(BUILD_TYPE_LC).apk
 
-$(PREFIX)/lib/xbmc/lib@APP_NAME_LC@.so: $(SRCLIBS)
-	$(MAKE) -C ../../depends/target/xbmc
-
-$(SRCLIBS):
-
-apk-clean:
-	rm -rf xbmc/java
-	rm -rf xbmc/lib
-	rm -rf xbmc/assets
-	rm -rf xbmc/obj
-	rm -rf xbmc/res/values
-	rm -rf xbmc/res/mipmap-*
-	rm -f xbmc/res/drawable/applaunch_screen.png
-	rm -f xbmc/res/drawable-xxxhdpi/applaunch_screen.png
-	rm -rf assets
-
-.PHONY: force libs assets python sharedapk res package
-
+.PHONY: force


### PR DESCRIPTION
## Description
Bring app folder preparation for apk generation into cmake from external Makefile
Reduce folder copy operations
Prepare all folder preparation to execute at build time to allow correct point of time operations for final package prep
relocate python data from nested location

## Motivation and context
Starting to prepare a PR to package bluray bdj files for android and noticed that theres 3 different locations of package data being copied around.

## How has this been tested?
creating apk for aarch64 android and comparing extracted apk folder structure to current master
runtime testing to be carried out still

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
