### PR TITLE
[Peripherals] Fix memory leak caused by circular reference between CPeripheral and CAgentController

### DIFF
--- a/xbmc/peripherals/bus/PeripheralBus.cpp
+++ b/xbmc/peripherals/bus/PeripheralBus.cpp
@@ -106,8 +106,9 @@ void CPeripheralBus::UnregisterRemovedDevices(const PeripheralScanResults& resul
                 PeripheralTypeTranslator::TypeToString(peripheral->Type()),
                 peripheral->FileLocation(), peripheral->DeviceName(),
                 peripheral->VendorIdAsString(), peripheral->ProductIdAsString());
-      peripheral->OnDeviceRemoved();
     }
+
+    peripheral->OnDeviceRemoved();
 
     m_manager.OnDeviceDeleted(*this, *peripheral);
   }

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -100,6 +100,15 @@ CPeripheral::~CPeripheral(void)
   ClearSettings();
 }
 
+void CPeripheral::OnDeviceRemoved(void)
+{
+  if (m_controllerInput)
+  {
+    m_controllerInput->Deinitialize();
+    m_controllerInput.reset();
+  }
+}
+
 bool CPeripheral::operator==(const CPeripheral& right) const
 {
   return m_type == right.m_type && m_strLocation == right.m_strLocation &&

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -159,8 +159,12 @@ public:
 
   /*!
    * @brief Called when this device is removed, before calling the destructor.
+   *
+   * @note Overrides must call the base implementation, which releases the
+   *       agent controller to break the reference cycle that would otherwise
+   *       keep this peripheral alive after removal.
    */
-  virtual void OnDeviceRemoved(void) {}
+  virtual void OnDeviceRemoved(void);
 
   /*!
    * @brief Get all subdevices if this device is multifunctional.

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1773,8 +1773,12 @@ void CPeripheralCecAdapterUpdateThread::Process(void)
 
 void CPeripheralCecAdapter::OnDeviceRemoved(void)
 {
-  std::unique_lock lock(m_critSection);
-  m_bDeviceRemoved = true;
+  {
+    std::unique_lock lock(m_critSection);
+    m_bDeviceRemoved = true;
+  }
+
+  CPeripheral::OnDeviceRemoved();
 }
 
 namespace PERIPHERALS

--- a/xbmc/peripherals/devices/PeripheralImon.cpp
+++ b/xbmc/peripherals/devices/PeripheralImon.cpp
@@ -32,6 +32,8 @@ void CPeripheralImon::OnDeviceRemoved()
     if (--m_lCountOfImonsConflictWithDInput == 0)
       ActionOnImonConflict(false);
   }
+
+  CPeripheral::OnDeviceRemoved();
 }
 
 bool CPeripheralImon::InitialiseFeature(const PeripheralFeature feature)


### PR DESCRIPTION
This circular reference was never broken resulting in a memory leak everytime a peripheral was removed.
Added base CPeripheral implementation of OnDeviceRemoved that clears out the m_controllerInput pointer.

This PR was assisted by claude.

## Description
I discovered this memory leak when testing out the fix for another [PR](https://github.com/xbmc/xbmc/pull/28435). For every 1000 disconnect events it leaked ~26 MB.

Even though the CPeripheral destructor has code to clear agent reference, it was never called due to the circular reference held by the agent.

I added a base implementation of the OnDeviceRemoved method in CPeripheral that will clear out the agent reference, and all overrides now call out to it as well.

## Motivation and context
All memory leaks are bad, so when I found it I felt responsible to fix it. Even though peripheral connect events are extremely small during regular use it was still a memory leak.

## How has this been tested?
With a simple python script I simulated 5700 peripheral connect and disconnects events with 0 MB gained in memory usage.

## What is the effect on users?

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
