### PR TITLE
Fix/movie set artwork remote clients

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2299,18 +2299,15 @@ int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
       idSet = AddSet(details.m_set.GetTitle(), details.m_set.GetOverview(),
                      details.m_set.GetOriginalTitle(), details.GetUpdateSetOverview());
       details.m_set.SetID(idSet);
-      // add art if not available
-      if (!HasArtForItem(idSet, MediaTypeVideoCollection))
+      for (const auto& [type, url] : artwork)
       {
-        for (const auto& [type, url] : artwork)
+        if (!StringUtils::StartsWith(type, "set."))
+          continue;
+        if (!SetArtForItem(idSet, MediaTypeVideoCollection, type.substr(4), url))
         {
-          if (StringUtils::StartsWith(type, "set.") &&
-              !SetArtForItem(idSet, MediaTypeVideoCollection, type.substr(4), url))
-          {
-            if (!inTransaction)
-              RollbackTransaction();
-            return -1;
-          }
+          if (!inTransaction)
+            RollbackTransaction();
+          return -1;
         }
       }
     }


### PR DESCRIPTION
### Description

Fixes #28367

When a Kodi master instance scrapes movies belonging to a movie set whose
artwork (poster.jpg, fanart.jpg, ...) resides in the Movie Set Information
Folder on a network share, the local artwork was only assigned to the movie
item (under `set.*` keys). The transfer into the set's `art` table row was
performed later by `CVideoDatabase::SetDetailsForMovie`, but only when the
set did not yet have any art (`if (!HasArtForItem(idSet, ...))`). On re-scraping
of an existing set, this branch was skipped, leaving the set's art table empty
in the central database.

The master Kodi instance still displayed the set artwork because it served
the textures from its local texture cache. Remote clients reading the shared
art table found no entries and showed no artwork.

### Fix

Write the discovered local set artwork directly to the set entity's `art`
table during `CVideoInfoScanner::GetArtwork`, regardless of whether the set
already has art entries. This keeps the central database authoritative for
all clients.