### PR TITLE
[osx] Fix bluray_cp env var to have ending slash

### DIFF
--- a/xbmc/platform/darwin/osx/PlatformDarwinOSX.mm
+++ b/xbmc/platform/darwin/osx/PlatformDarwinOSX.mm
@@ -40,7 +40,7 @@ bool CPlatformDarwinOSX::InitStageOne()
   std::string install_path(CUtil::GetHomePath());
   setenv("KODI_HOME", install_path.c_str(), 0);
   setenv("AACS_HOME", CSpecialProtocol::TranslatePath("special://home").c_str(), 1);
-  setenv("LIBBLURAY_CP", CDarwinUtils::GetJavaCPPath().c_str(), 1);
+  setenv("LIBBLURAY_CP", (CDarwinUtils::GetJavaCPPath() + "/").c_str(), 1);
 
   install_path += "/tools/darwin/runtime/preflight";
   system(install_path.c_str());


### PR DESCRIPTION
## Description
``LIBBLURAY_CP`` env var requires trailing slash

## Motivation and context
Fix bdj menu playback on macos

## How has this been tested?
DMG built and executed with successful bdj menu playback

## What is the effect on users?
bdj menu support for macos users

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
