### PR TITLE
[Video][Database][Art] Add expert setting option to load all art during scrape.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24936,7 +24936,31 @@ msgctxt "#40224"
 msgid "Make the most recently scanned version of a movie the movie's default version.[CR]Helps identify new movie versions as recently added and locate them when the \"Unwatched\" filter of the library is turned on."
 msgstr ""
 
-#empty strings from id 40225 to 40399
+#. Setting to determine when art is retrieved - during or after scrape
+#: system/settings/settings.xml
+msgctxt "#40225"
+msgid "Retrieve art"
+msgstr ""
+
+#. Help for retrieve art during/after scrape setting
+#: system/settings/settings.xml
+msgctxt "#40226"
+msgid "Determines whether art is retrieved synchronously during scrape or in the background afterwards.[CR][During scrape] Art is retrieved synchronously during scrape. This significantly extends time taken to scrape.[CR][After scrape][Default] Art is retrieved in the background after scrape. Actor thumbnails may take a while to appear."
+msgstr ""
+
+#. Option for the retrieve art during/after scrape setting
+#: system/settings/settings.xml
+msgctxt "#40227"
+msgid "During scrape"
+msgstr ""
+
+#. Option for the retrieve art during/after scrape setting
+#: system/settings/settings.xml
+msgctxt "#40228"
+msgid "After scrape"
+msgstr ""
+
+#empty strings from id 40229 to 40399
 
 # Video versions
 

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1423,6 +1423,17 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+	    <setting id="videolibrary.artretrievaltiming" type="integer" label="40225" help="40226">
+		  <level>3</level>
+		  <default>1</default>
+		  <constraints>
+		    <options>
+		      <option label="40227">0</option> <!-- during scrape -->
+			  <option label="40228">1</option> <!-- after scrape -->
+			</options>
+		  </constraints>
+		  <control type="list" format="string" />
+	    </setting>
       </group>
     </category>
     <category id="music" label="14216" help="38108">

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -100,6 +100,7 @@ public:
   static constexpr auto SETTING_VIDEOLIBRARY_NEWVERSIONSAREDEFAULT =
       "videolibrary.newversionsaredefault";
   static constexpr auto SETTING_VIDEOLIBRARY_IGNOREVIDEOEXTRAS = "videolibrary.ignorevideoextras";
+  static constexpr auto SETTING_VIDEOLIBRARY_ARTRETRIEVALTIMING = "videolibrary.artretrievaltiming";
   static constexpr auto SETTING_LOCALE_AUDIOLANGUAGE = "locale.audiolanguage";
   static constexpr auto SETTING_VIDEOPLAYER_PREFERDEFAULTFLAG = "videoplayer.preferdefaultflag";
   static constexpr auto SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM = "videoplayer.autoplaynextitem";

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -166,6 +166,37 @@ void OnDirectoryScanned(const std::string& strDirectory)
   msg.SetStringParam(strDirectory);
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
 }
+
+void CacheArtwork(const std::string& url, bool retrieveArtDuringScrape)
+{
+  if (url.empty())
+    return;
+
+  const auto& textureCache = CServiceBroker::GetTextureCache();
+  if (!retrieveArtDuringScrape)
+  {
+    textureCache->BackgroundCacheImage(url);
+    return;
+  }
+
+  bool needsRecaching{false};
+  if (!textureCache->CheckCachedImage(url, needsRecaching).empty() && !needsRecaching)
+    return; // already cached
+
+  // Fetch art or recache as needed
+  // This will be slow, but that is the point of the setting - to get the art during scraping
+  constexpr int MAX_SYNC_CACHE_ATTEMPTS = 3;
+  for (int attempt = 1; attempt <= MAX_SYNC_CACHE_ATTEMPTS; ++attempt)
+  {
+    if (!textureCache->CacheImage(url).empty())
+      return; // succeeded
+  }
+
+  // Synchronous fetch failed after several attempts (network timeout, etc.)
+  // Fall back to the resilient background path.
+  textureCache->BackgroundCacheImage(url);
+  CLog::LogF(LOGDEBUG, "Synchronous art caching for {} failed", url);
+}
 } // namespace
 
 namespace KODI::VIDEO
@@ -182,6 +213,8 @@ CVideoInfoScanner::CVideoInfoScanner()
   m_similarVideoAction = static_cast<SimilarVideoScanAction>(
       settings->GetInt(CSettings::SETTING_VIDEOLIBRARY_SIMILARVIDEOACTION));
   m_ignoreVideoExtras = settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_IGNOREVIDEOEXTRAS);
+  m_artRetrievalTiming = static_cast<ArtRetrievalTiming>(
+      settings->GetInt(CSettings::SETTING_VIDEOLIBRARY_ARTRETRIEVALTIMING));
 }
 
 CVideoInfoScanner::~CVideoInfoScanner()
@@ -1329,6 +1362,9 @@ CVideoInfoScanner::~CVideoInfoScanner()
                         useLocal && !item->IsPlugin(), useRemoteArt, &m_regexpCache);
         for (const auto& [season, art] : seasonArt)
         {
+          for (const auto& url : art | std::views::values)
+            CacheArtwork(url, m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS);
+
           const int seasonID{m_database.AddSeason(static_cast<int>(showID), season)};
           m_database.SetArtForItem(seasonID, MediaTypeSeason, art);
         }
@@ -1829,8 +1865,13 @@ CVideoInfoScanner::~CVideoInfoScanner()
         KODI::ART::SeasonsArtwork seasonArt;
 
         if (!libraryImport)
+        {
           GetSeasonThumbs(movieDetails, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason),
                           useLocal && !pItem->IsPlugin(), useRemoteArt, &m_regexpCache);
+          for (const auto& seasonArtwork : seasonArt | std::views::values)
+            for (const auto& url : seasonArtwork | std::views::values)
+              CacheArtwork(url, m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS);
+        }
 
         lResult = m_database.SetDetailsForTvShow(multipath, movieDetails, art, seasonArt);
         movieDetails.m_iDbId = lResult;
@@ -2099,10 +2140,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
     }
 
     for (const auto& artType : artTypes)
-    {
       if (art.contains(artType))
-        CServiceBroker::GetTextureCache()->BackgroundCacheImage(art[artType]);
-    }
+        CacheArtwork(art.at(artType), m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS);
 
     pItem->SetArt(art);
 
@@ -2667,9 +2706,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
           if (notUsingThisRemoteArt)
             i->thumbUrl.Clear();
         }
-        if (!i->thumb.empty())
-          CServiceBroker::GetTextureCache()->BackgroundCacheImage(i->thumb);
       }
+      CacheArtwork(i->thumb, m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS);
     }
   }
 

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -15,6 +15,7 @@
 #include "utils/Artwork.h"
 #include "utils/RegExp.h"
 
+#include <cstdint>
 #include <functional>
 #include <set>
 #include <string>
@@ -339,6 +340,14 @@ namespace KODI::VIDEO
 
     SimilarVideoScanAction m_similarVideoAction{SimilarVideoScanAction::NONE};
     bool m_ignoreVideoExtras{false};
+
+    enum class ArtRetrievalTiming : uint8_t
+    {
+      SYNCHRONOUS = 0, //!< retrieve art synchronously during scrape
+      BACKGROUND = 1 //!< retrieve art in background after scrape
+    };
+
+    ArtRetrievalTiming m_artRetrievalTiming{ArtRetrievalTiming::BACKGROUND};
     CVideoDatabase m_database;
     std::set<int> m_pathsToClean;
     std::shared_ptr<CAdvancedSettings> m_advancedSettings;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

I've added the setting `Retrieve art during or after scrape` in `Settings -> Media -> Videos` - default 'After scrape' (current background behaviour as above), 'During scrape' retrieves all art synchronously at scrape time.

<img width="2429" height="924" alt="image" src="https://github.com/user-attachments/assets/f673c5e2-4bfa-42a0-bec8-48aa7ff78327" />

Obviously it makes scraping take longer (although this still all in the background) - example scanning 20 TV shows (x2):
Setting False
Scan takes 57480ms, 58284ms
Files in userdata/Thumbnails = 133

SettingTrue
Scan takes 415287ms, 410605ms
Files in userdata/Thumbnails = 1059

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Following a couple of discussions with @KarellenX about art, and exporting art for local scraping, we discussed how, often, after scraping the art (especially actor thumbs) are not yet in Thumbnails.

Art is retrieved asynchronously in a low priortiy thread:
`CServiceBroker::GetTextureCache()->BackgroundCacheImage()`
So it can take a while for all the art to be retrieved and you don't know when it's all done.
If you want to export all art then this can be frustrating.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **New feature** (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
