### PR TITLE
[VideoPlayer] Fix Skip Accuracy When Paused

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -112,6 +112,12 @@ void CDVDClock::Pause(bool pause)
   }
 }
 
+bool CDVDClock::IsPaused() const
+{
+  std::unique_lock lock(m_critSection);
+  return m_pauseClock != 0;
+}
+
 void CDVDClock::Advance(double time)
 {
   std::unique_lock lock(m_critSection);

--- a/xbmc/cores/VideoPlayer/DVDClock.cpp
+++ b/xbmc/cores/VideoPlayer/DVDClock.cpp
@@ -162,7 +162,7 @@ void CDVDClock::SetSpeedAdjust(double adjust)
   m_speedAdjust = adjust;
 }
 
-double CDVDClock::GetSpeedAdjust()
+double CDVDClock::GetSpeedAdjust() const
 {
   std::unique_lock lock(m_critSection);
   return m_speedAdjust;
@@ -266,12 +266,12 @@ bool CDVDClock::GetClockInfo(int& MissedVblanks, double& ClockSpeed, double& Ref
   return m_videoRefClock->GetClockInfo(MissedVblanks, ClockSpeed, RefreshRate);
 }
 
-double CDVDClock::SystemToAbsolute(int64_t system)
+double CDVDClock::SystemToAbsolute(int64_t system) const
 {
   return DVD_TIME_BASE * (double)(system - m_systemOffset) / m_systemFrequency;
 }
 
-int64_t CDVDClock::AbsoluteToSystem(double absolute)
+int64_t CDVDClock::AbsoluteToSystem(double absolute) const
 {
   return (int64_t)(absolute / DVD_TIME_BASE * m_systemFrequency) + m_systemOffset;
 }
@@ -301,7 +301,7 @@ double CDVDClock::SystemToPlaying(int64_t system)
   return DVD_TIME_BASE * (double)(current - m_startClock + m_systemAdjust) / m_systemUsed + m_iDisc;
 }
 
-double CDVDClock::GetClockSpeed()
+double CDVDClock::GetClockSpeed() const
 {
   std::unique_lock lock(m_critSection);
 

--- a/xbmc/cores/VideoPlayer/DVDClock.h
+++ b/xbmc/cores/VideoPlayer/DVDClock.h
@@ -35,9 +35,10 @@ public:
   void Reset() { m_bReset = true; }
   void SetSpeed(int iSpeed);
   void SetSpeedAdjust(double adjust);
-  double GetSpeedAdjust();
+  double GetSpeedAdjust() const;
 
-  double GetClockSpeed(); /**< get the current speed of the clock relative normal system time */
+  double GetClockSpeed()
+      const; /**< get the current speed of the clock relative normal system time */
 
   /* tells clock at what framerate video is, to  *
    * allow it to adjust speed for a better match */
@@ -56,11 +57,11 @@ public:
   void Advance(double time);
 
 protected:
-  double SystemToAbsolute(int64_t system);
-  int64_t AbsoluteToSystem(double absolute);
+  double SystemToAbsolute(int64_t system) const;
+  int64_t AbsoluteToSystem(double absolute) const;
   double SystemToPlaying(int64_t system);
 
-  CCriticalSection m_critSection;
+  mutable CCriticalSection m_critSection;
   int64_t m_systemUsed;
   int64_t m_startClock;
   int64_t m_pauseClock;

--- a/xbmc/cores/VideoPlayer/DVDClock.h
+++ b/xbmc/cores/VideoPlayer/DVDClock.h
@@ -54,6 +54,7 @@ public:
   double GetVsyncAdjust();
 
   void Pause(bool pause);
+  bool IsPaused() const;
   void Advance(double time);
 
 protected:

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1149,7 +1149,9 @@ void CRenderManager::PrepareNextRender()
       m_videoDelay -
       static_cast<double>(CServiceBroker::GetWinSystem()->GetFrameLatencyAdjustment()));
 
-  double renderPts = frameOnScreen + m_displayLatency;
+  double renderPts = frameOnScreen;
+  if (!m_dvdClock.IsPaused())
+    renderPts += m_displayLatency;
 
   double nextFramePts = m_Queue[m_queued.front()].pts;
   if (m_dvdClock.GetClockSpeed() < 0)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1149,8 +1149,9 @@ void CRenderManager::PrepareNextRender()
       m_videoDelay -
       static_cast<double>(CServiceBroker::GetWinSystem()->GetFrameLatencyAdjustment()));
 
+  const bool isPaused = m_dvdClock.IsPaused();
   double renderPts = frameOnScreen;
-  if (!m_dvdClock.IsPaused())
+  if (!isPaused)
     renderPts += m_displayLatency;
 
   double nextFramePts = m_Queue[m_queued.front()].pts;
@@ -1171,7 +1172,8 @@ void CRenderManager::PrepareNextRender()
 
       m_dvdClock.SetVsyncAdjust(-average);
     }
-    renderPts += frametime / 2 - m_clockSync.m_syncOffset;
+    if (!isPaused)
+      renderPts += frametime / 2 - m_clockSync.m_syncOffset;
   }
   else
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -1138,10 +1138,10 @@ void CRenderManager::PrepareNextRender()
   if (!m_showVideo && !m_forceNext)
     return;
 
-  double frameOnScreen = m_dvdClock.GetClock();
-  double frametime = 1.0 /
-                     static_cast<double>(CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS()) *
-                     DVD_TIME_BASE;
+  const double frameOnScreen = m_dvdClock.GetClock();
+  const double frametime =
+      1.0 / static_cast<double>(CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS()) *
+      DVD_TIME_BASE;
 
   m_displayLatency = DVD_MSEC_TO_TIME(
       m_latencyTweak +
@@ -1154,9 +1154,8 @@ void CRenderManager::PrepareNextRender()
   if (!isPaused)
     renderPts += m_displayLatency;
 
-  double nextFramePts = m_Queue[m_queued.front()].pts;
-  if (m_dvdClock.GetClockSpeed() < 0)
-    nextFramePts = renderPts;
+  const double nextFramePts =
+      m_dvdClock.GetClockSpeed() < 0 ? renderPts : m_Queue[m_queued.front()].pts;
 
   if (m_clockSync.m_enabled)
   {
@@ -1165,7 +1164,7 @@ void CRenderManager::PrepareNextRender()
     m_clockSync.m_errCount ++;
     if (m_clockSync.m_errCount > 30)
     {
-      double average = m_clockSync.m_error / m_clockSync.m_errCount;
+      const double average = m_clockSync.m_error / m_clockSync.m_errCount;
       m_clockSync.m_syncOffset = average;
       m_clockSync.m_error = 0;
       m_clockSync.m_errCount = 0;
@@ -1225,8 +1224,8 @@ void CRenderManager::PrepareNextRender()
       m_queued.pop_front();
     }
 
-    int lateframes = static_cast<int>((renderPts - m_Queue[idx].pts) *
-                                      static_cast<double>(m_fps / DVD_TIME_BASE));
+    const int lateframes = static_cast<int>((renderPts - m_Queue[idx].pts) *
+                                            static_cast<double>(m_fps / DVD_TIME_BASE));
     if (lateframes)
       m_lateframes += lateframes;
     else


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

1/ The clock is fixed at the seek target pts after seeking while paused. 
`PrepareNextRender` calculates the PTS to render (renderPts) as the current clock's frame + display latency, ahead of the seek target by ~67ms in the test video. Any decoded frame earlier than renderPts is immediately considered overdue and is presented, causing the player to advance several frames past the seek target before stopping.

The fix: do not add the display latency when the clock is paused, then only the target PTS gets presented.

2/ The clock synchro was attempting to move renderPts to the estimated middle of an interval between frame timestamps, which made the next frame overdue and presented. Happened only for display fps = video fps and multiples.

The 2 advancing mechanisms make sense while playing and were only modified for the pause state.

A `IsPaused` accessor was added to `DVDClock` to retrieve the pause status cleanly.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #28448 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Sample video. Has no effect when not paused.
The sample video is 50fps. Tested 23.98 24 29.97 30 50 59.97 60 100 120Hz display refresh rates.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Frame-accurate seeking in pause.

## Screenshots (if appropriate):
See #28448 

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
