### PR TITLE
VideoPlayer: fix aspect ratio for matroska containers for stereo modes

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1455,9 +1455,12 @@ double CDVDDemuxFFmpeg::SelectAspect(AVStream* st, bool& forced)
     if (entry)
     {
       if (strcmp(entry->value, "left_right") == 0 || strcmp(entry->value, "right_left") == 0)
-        dar /= 2;
+        dar /= ((st->codecpar->width <= 1920.0 ? (st->codecpar->width * 2) : st->codecpar->width) /
+                1920.0);
       else if (strcmp(entry->value, "top_bottom") == 0 || strcmp(entry->value, "bottom_top") == 0)
-        dar *= 2;
+        dar *=
+            ((st->codecpar->height <= 1080.0 ? (st->codecpar->height * 2) : st->codecpar->height) /
+             1080.0);
     }
     return dar;
   }


### PR DESCRIPTION
Use the codec's width and height parameters for correct factor computation.

Improvement of https://github.com/xbmc/xbmc/commit/643b552e7dccc8c629fe0a0fffa08fcbfe4fb8ef

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Use codec parameter values to compute the correct factor.
For full/half SBS and TAB stereo mode the factor need to be arround 2.
But it is not always exact 2.0 like a real FTAB example with 1920x2072 where the factor is 1.918518519.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It fix the factor if it is not exact 2.0.
It also works for FSBS and FTAB.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Multiple samples FSBS/HSBS and FTAB/HTAB.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Correct aspect ratio when the media include correct `stereo_mode` meta info.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
