### PR TITLE
[Video][Bluray] Fix bluray streamdetails determination.

### DIFF
--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -14,7 +14,6 @@
 #include "LangInfo.h"
 #include "ServiceBroker.h"
 #include "Util.h"
-#include "bluray/BitReader.h"
 #include "bluray/M2TSParser.h"
 #include "bluray/MPLSParser.h"
 #include "bluray/PlaylistStructure.h"
@@ -37,11 +36,10 @@
 #include <algorithm>
 #include <cassert>
 #include <chrono>
-#include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <ranges>
-#include <span>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -285,6 +283,8 @@ void SetStreamDetails(const CURL& url,
   // Subtitles
   for (const auto& subtitle : title.pgStreams)
     info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitle));
+
+  info->m_streamDetails.DetermineBestStreams();
 }
 
 std::shared_ptr<CFileItem> GetFileItem(const CURL& url,

--- a/xbmc/filesystem/bluray/M2TSParser.cpp
+++ b/xbmc/filesystem/bluray/M2TSParser.cpp
@@ -44,7 +44,7 @@ constexpr unsigned int SYNC_BYTE = 0x47;
 constexpr unsigned int TS_HEADER_SIZE = 4;
 constexpr unsigned int ADAPTATION_FIELD_MASK = 0x02;
 constexpr unsigned int PACKETS_TO_PARSE =
-    2000; // Based on testing this is enough to analyse all streams
+    8000; // Based on testing this is enough to analyse all streams
 constexpr unsigned int BUFFER_SIZE{BDAV_PACKET_SIZE * PACKETS_TO_PARSE};
 constexpr int TIMESTAMP_SIZE = 4;
 

--- a/xbmc/filesystem/bluray/StreamParser.cpp
+++ b/xbmc/filesystem/bluray/StreamParser.cpp
@@ -175,7 +175,7 @@ AudioStreamInfo PopulateAudioStreamInfo(const StreamInformation& stream,
         if (bsai->isXLL)
           asi.codecName = "dtshd_hra";
         else
-          asi.codecName = "dca";
+          asi.codecName = "dts";
         break;
       }
       case AUDIO_DTSHD_MASTER:


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Increase packets parsed to 8000.
Note - there is an early exit if all details are found. Also note each frame is only 192 bytes so the data read is not large.

Also DCA needs to be replaced with DTS (see #28140)
This code does not use CStreamDetails to determine the text string for a stream as the stream encoding is numerically different to that returned by FFMPEG.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

At scrape, ffmpeg cannot determine the streamdetails of bluray discs (without playing the content) so the M2TS files are parsed directly.

Arbitrarily 2000 TS packets were parsed. I've found a couple of discs (Avatar Fire and Ash UHD and Aliens UHD) where the first audio frames are beyond that.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Before:
<img width="967" height="617" alt="image" src="https://github.com/user-attachments/assets/d8910a05-54b2-4e39-8b13-b662b38a1557" />

After:
<img width="1548" height="631" alt="image" src="https://github.com/user-attachments/assets/bebc23ff-bb46-4679-b186-713ed46c2cb5" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
