### PR TITLE
Add DTS Missing Profiles

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6660,6 +6660,9 @@ constexpr std::array<InfoMap, 3> container_str = {{
 ///       - <b>ac3</b>
 ///       - <b>cook</b>
 ///       - <b>dts</b>
+///       - <b>dts_96_24</b>
+///       - <b>dts_es</b>
+///       - <b>dts_express</b>
 ///       - <b>dtshd_hra</b>
 ///       - <b>dtshd_ma</b>
 ///       - <b>dtshd_ma_x</b>
@@ -6677,6 +6680,12 @@ constexpr std::array<InfoMap, 3> container_str = {{
 ///       - <b>vorbis</b>
 ///       - <b>wmapro</b>
 ///       - <b>wmav2</b>
+///
+///     The names are based on ffmpeg codec names with exceptions for specific codec profiles.
+///     <p><hr>
+///     @skinning_v22 **[Infolabel Updated]** \link ListItem_AudioCodec `ListItem.AudioCodec`\endlink
+///     added aac_lc\, he_aac\, he_aac_v2\, aac_ssr\, aac_ltp\, dts_96_24\, dts_es\, dts_express\,
+///     dtshd_ma_x\, dtshd_ma_x_imax\, eac3_ddp_atmos\, truehd_atmos
 ///     <p>
 ///   }
 ///   \table_row3{   <b>`ListItem.AudioChannels(format)`</b>,

--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -65,6 +65,12 @@ std::string StreamUtils::GetCodecName(int codecId, int profile)
       codecName = "dtshd_ma_x_imax";
     else if (profile == AV_PROFILE_DTS_HD_HRA)
       codecName = "dtshd_hra";
+    else if (profile == AV_PROFILE_DTS_ES)
+      codecName = "dts_es";
+    else if (profile == AV_PROFILE_DTS_96_24)
+      codecName = "dts_96_24";
+    else if (profile == AV_PROFILE_DTS_EXPRESS)
+      codecName = "dts_express";
     else
       codecName = "dts";
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Create a few dts profiles missing Kodi codec codes so that skins can make the distinction in the media info display.

dts_es, dts_96_24 and dts_express

They were previously displayed as "dts".

No action needed for the library. The new codes will be imported/exported to nfo.

The skin changes are not included in the PR.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Consistency of core and skins.
Core formats those profiles in CDemuxStreamAudio::GetStreamType() but skins didn't have the necessary details to do the same.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I didn't have sample files for the 96/24 and the express profiles and faked them for testing.
Had a DVD with DTS-ES track to test that profile.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Skin can report audio stream codec more accurately.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
