### PR TITLE
Filesystem fixes

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -54,7 +54,10 @@
 
 using namespace KODI;
 
-CServiceManager::CServiceManager() = default;
+CServiceManager::CServiceManager()
+  : m_fileExtensionProvider(std::make_unique<CFileExtensionProvider>())
+{
+}
 
 CServiceManager::~CServiceManager()
 {
@@ -82,7 +85,7 @@ bool CServiceManager::InitForTesting()
   m_dataCacheCore = std::make_unique<CDataCacheCore>();
 
   m_extsMimeSupportList = std::make_unique<ADDONS::CExtsMimeSupportList>(*m_addonMgr);
-  m_fileExtensionProvider = std::make_unique<CFileExtensionProvider>(*m_addonMgr);
+  m_fileExtensionProvider->Initialize(*m_addonMgr);
 
   m_subTagRegistryManager = std::make_unique<KODI::UTILS::I18N::CSubTagRegistryManager>();
   m_subTagRegistryManager->Initialize();
@@ -95,7 +98,7 @@ void CServiceManager::DeinitTesting()
 {
   init_level = 0;
   m_subTagRegistryManager.reset();
-  m_fileExtensionProvider.reset();
+  m_fileExtensionProvider->Deinitialize();
   m_extsMimeSupportList.reset();
   m_dataCacheCore.reset();
   m_binaryAddonManager.reset();
@@ -177,7 +180,7 @@ bool CServiceManager::InitStageTwo(const std::string& profilesUserDataFolder)
 
   m_gameRenderManager = std::make_unique<RETRO::CGUIGameRenderManager>();
 
-  m_fileExtensionProvider = std::make_unique<CFileExtensionProvider>(*m_addonMgr);
+  m_fileExtensionProvider->Initialize(*m_addonMgr);
 
   m_powerManager = std::make_unique<CPowerManager>();
   m_powerManager->Initialize();
@@ -273,7 +276,7 @@ void CServiceManager::DeinitStageTwo()
 
   m_weatherManager.reset();
   m_powerManager.reset();
-  m_fileExtensionProvider.reset();
+  m_fileExtensionProvider->Deinitialize();
   m_gameRenderManager.reset();
   m_peripherals.reset();
   m_inputManager.reset();

--- a/xbmc/filesystem/OverrideDirectory.cpp
+++ b/xbmc/filesystem/OverrideDirectory.cpp
@@ -26,6 +26,13 @@ bool COverrideDirectory::Create(const CURL& url)
   return CDirectory::Create(translatedPath.c_str());
 }
 
+bool COverrideDirectory::Exists(const CURL& url)
+{
+  std::string translatedPath = TranslatePath(url);
+
+  return CDirectory::Exists(translatedPath.c_str());
+}
+
 bool COverrideDirectory::Remove(const CURL& url)
 {
   std::string translatedPath = TranslatePath(url);
@@ -33,9 +40,9 @@ bool COverrideDirectory::Remove(const CURL& url)
   return CDirectory::Remove(translatedPath.c_str());
 }
 
-bool COverrideDirectory::Exists(const CURL& url)
+bool COverrideDirectory::RemoveRecursive(const CURL& url)
 {
   std::string translatedPath = TranslatePath(url);
 
-  return CDirectory::Exists(translatedPath.c_str());
+  return CDirectory::RemoveRecursive(translatedPath.c_str());
 }

--- a/xbmc/filesystem/OverrideDirectory.h
+++ b/xbmc/filesystem/OverrideDirectory.h
@@ -21,6 +21,7 @@ public:
   bool Create(const CURL& url) override;
   bool Exists(const CURL& url) override;
   bool Remove(const CURL& url) override;
+  bool RemoveRecursive(const CURL& url) override;
 
 protected:
   virtual std::string TranslatePath(const CURL &url) = 0;

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -33,46 +33,57 @@ using namespace KODI::ADDONS;
 
 constexpr std::array ADDON_TYPES{AddonType::VFS, AddonType::IMAGEDECODER, AddonType::AUDIODECODER};
 
-CFileExtensionProvider::CFileExtensionProvider(ADDON::CAddonMgr& addonManager)
-  : m_advancedSettings(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()),
-    m_addonManager(addonManager)
+void CFileExtensionProvider::Initialize(ADDON::CAddonMgr& addonManager)
 {
+  m_addonManager = &addonManager;
+
+  m_advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+  if (!m_advancedSettings)
+    m_advancedSettings = std::make_shared<CAdvancedSettings>();
+
   SetAddonExtensions();
 
-  m_addonManager.Events().Subscribe(this,
-                                    [this](const AddonEvent& event)
-                                    {
-                                      if (typeid(event) == typeid(AddonEvents::Enabled) ||
-                                          typeid(event) == typeid(AddonEvents::Disabled) ||
-                                          typeid(event) == typeid(AddonEvents::ReInstalled))
-                                      {
-                                        for (auto& type : ADDON_TYPES)
-                                        {
-                                          if (m_addonManager.HasType(event.addonId, type))
-                                          {
-                                            std::lock_guard lock{m_critSection};
-                                            SetAddonExtensions(type);
-                                            break;
-                                          }
-                                        }
-                                      }
-                                      else if (typeid(event) == typeid(AddonEvents::UnInstalled))
-                                      {
-                                        std::lock_guard lock{m_critSection};
-                                        SetAddonExtensions();
-                                      }
-                                    });
+  m_addonManager->Events().Subscribe(this,
+                                     [this](const AddonEvent& event)
+                                     {
+                                       if (typeid(event) == typeid(AddonEvents::Enabled) ||
+                                           typeid(event) == typeid(AddonEvents::Disabled) ||
+                                           typeid(event) == typeid(AddonEvents::ReInstalled))
+                                       {
+                                         for (auto& type : ADDON_TYPES)
+                                         {
+                                           if (m_addonManager->HasType(event.addonId, type))
+                                           {
+                                             std::lock_guard lock{m_critSection};
+                                             SetAddonExtensions(type);
+                                             break;
+                                           }
+                                         }
+                                       }
+                                       else if (typeid(event) == typeid(AddonEvents::UnInstalled))
+                                       {
+                                         std::lock_guard lock{m_critSection};
+                                         SetAddonExtensions();
+                                       }
+                                     });
 
   m_callbackId =
       m_advancedSettings->RegisterSettingsLoadedCallback([this]() { OnAdvancedSettingsLoaded(); });
 }
 
-CFileExtensionProvider::~CFileExtensionProvider()
+void CFileExtensionProvider::Deinitialize()
 {
   if (m_callbackId.has_value())
+  {
     m_advancedSettings->UnregisterSettingsLoadedCallback(m_callbackId.value());
+    m_callbackId.reset();
+  }
 
-  m_addonManager.Events().Unsubscribe(this);
+  if (m_addonManager != nullptr)
+  {
+    m_addonManager->Events().Unsubscribe(this);
+    m_addonManager = nullptr;
+  }
 
   m_advancedSettings.reset();
   m_addonExtensions.clear();
@@ -341,7 +352,10 @@ void CFileExtensionProvider::SetAddonExtensions(AddonType type)
   else if (type == AddonType::VFS)
   {
     std::vector<AddonInfoPtr> addonInfos;
-    m_addonManager.GetAddonInfos(addonInfos, true, type);
+
+    if (m_addonManager != nullptr)
+      m_addonManager->GetAddonInfos(addonInfos, true, type);
+
     for (const auto& addonInfo : addonInfos)
     {
       std::string ext = addonInfo->Type(type)->GetValue("@extensions").asString();

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -28,8 +28,11 @@ class CAdvancedSettings;
 class CFileExtensionProvider
 {
 public:
-  CFileExtensionProvider(ADDON::CAddonMgr& addonManager);
-  ~CFileExtensionProvider();
+  CFileExtensionProvider() = default;
+  ~CFileExtensionProvider() = default;
+
+  void Initialize(ADDON::CAddonMgr& addonManager);
+  void Deinitialize();
 
   /*!
    * @brief Returns a list of picture extensions
@@ -108,7 +111,7 @@ private:
 
   // Construction properties
   std::shared_ptr<CAdvancedSettings> m_advancedSettings;
-  ADDON::CAddonMgr &m_addonManager;
+  ADDON::CAddonMgr* m_addonManager{nullptr};
   std::optional<int> m_callbackId;
 
   mutable CCriticalSection m_critSection;


### PR DESCRIPTION
## Description

When adding a new feature, I hit a couple test case failures due to the introduction of a transient ServiceBroker service introduced in https://github.com/xbmc/xbmc/pull/27580:

```c++
  auto exts{StringUtils::Split(
      !extensions.empty()
          ? extensions
          : CServiceBroker::GetFileExtensionProvider().GetCompoundArchiveExtensions(),
      '|')};

```

Extension checks happen often, and checks made during early init or after environment teardown would crash.

Fixed by extending the lifetime of the object and adding explicit Initialize() / Deinitialize() functions.

Also, I noticed that RemoveRecursive() failed for `special://` paths. Fixed by adding the missing override.

## Motivation and context

Noticed when writing test cases for my experimental IPFS branch.

## How has this been tested?

Before:

Crashes on some platforms, and this error:

```
2026-06-18 00:11:51.659 T:416290   error <general>: RemoveRecursive - Error removing special://temp/kodi_ipfs_test
```

After:

No more crashes, and error is gone.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
