### PR TITLE
utils/log: avoid deprecated fstring to string_view conversion

### DIFF
--- a/xbmc/utils/log.h
+++ b/xbmc/utils/log.h
@@ -118,7 +118,12 @@ public:
     if (!GetInstance().CanLogComponent(component))
       return;
 
+#if FMT_VERSION >= 120200
+    GetInstance().FormatAndLogInternal(level, component, format.str,
+                                       fmt::make_format_args(args...));
+#else
     GetInstance().FormatAndLogInternal(level, component, format, fmt::make_format_args(args...));
+#endif
   }
 
   template<typename... Args>
@@ -127,8 +132,13 @@ public:
                   fmt::format_string<Args...> format,
                   Args&&... args)
   {
+#if FMT_VERSION >= 120200
+    GetInstance().FormatAndLogInternal(loggerName, MapLogLevel(level), format.str,
+                                       fmt::make_format_args(args...));
+#else
     GetInstance().FormatAndLogInternal(loggerName, MapLogLevel(level), format,
                                        fmt::make_format_args(args...));
+#endif
   }
 
 #ifdef TARGET_WINDOWS


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

fstring's implicit operator const string_view&() was deprecated in libfmt 12.2.0 (FMT_VERSION >= 120200). Access the public str member directly for libfmt 12.2.0 and later to avoid -Wdeprecated-declarations.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Support build with updated libfmt
- https://github.com/fmtlib/fmt/releases/tag/12.2.0

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Compiled on LibreELEC-13.0

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
