### PR TITLE
depends: install bzip2.pc for pkg-config consumers

### DIFF
--- a/tools/depends/target/bzip2/Makefile
+++ b/tools/depends/target/bzip2/Makefile
@@ -1,5 +1,5 @@
 include ../../Makefile.include
-DEPS = ../../Makefile.include Makefile Makefile.patch ../../download-files.include
+DEPS = ../../Makefile.include Makefile Makefile.patch bzip2.pc.in ../../download-files.include
 
 # lib name, version
 LIBNAME=bzip2
@@ -25,6 +25,8 @@ all: .installed-$(PLATFORM)
 	$(MAKE) -C $(PLATFORM) PREFIX=$(PREFIX) CC="$(CC)" CFLAGS="$(CFLAGS)" LDFLAGS="$(LDFLAGS)" AR="$(AR)"
 	$(MAKE) -C $(PLATFORM) install PREFIX=$(PREFIX)
 	rm $(PREFIX)/bin/bzip2
+	mkdir -p $(PREFIX)/lib/pkgconfig
+	sed -e 's|@PREFIX@|$(PREFIX)|' -e 's|@VERSION@|$(VERSION)|' bzip2.pc.in > $(PREFIX)/lib/pkgconfig/bzip2.pc
 	touch $@
 
 clean:

--- a/tools/depends/target/bzip2/bzip2.pc.in
+++ b/tools/depends/target/bzip2/bzip2.pc.in
@@ -1,0 +1,10 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: A patent-free, high-quality data compression library.
+Version: @VERSION@
+Libs: -L${libdir} -lbz2
+Cflags: -I${includedir}


### PR DESCRIPTION
The legacy bzip2 Makefile build installs libbz2 but no pkg-config file, which breaks freetype2 resolution for libass and other autotools deps.

For context: I'm trying to build WASM from a fresh new Mac (only very few tools installed on it)
