### PR TITLE
cmake: conditionally generate meson pkg-config properties

### DIFF
--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -879,7 +879,9 @@ endfunction()
 # sets meson_properties_string to PARENT_SCOPE
 function(create_mesonproperties)
 
-  string(APPEND output_string "pkg_config_libdir = '${DEPENDS_PATH}/lib/pkgconfig'\n")
+  if(CMAKE_CROSSCOMPILING)
+    string(APPEND output_string "pkg_config_libdir = '${DEPENDS_PATH}/lib/pkgconfig'\n")
+  endif()
   if(CMAKE_TOOLCHAIN_FILE)
     string(APPEND output_string "cmake_toolchain_file = '${CMAKE_TOOLCHAIN_FILE}'\n")
   endif()
@@ -937,6 +939,10 @@ function(create_mesonbuiltin)
   string(APPEND output_string "libdir = 'lib'\n")
   string(APPEND output_string "bindir = 'bin'\n")
   string(APPEND output_string "includedir = 'include'\n")
+
+  if(NOT CMAKE_CROSSCOMPILING)
+    string(APPEND output_string "pkg_config_path = '${DEPENDS_PATH}/lib/pkgconfig'\n")
+  endif()
 
   # Easiest to just prepend header at the end of the full string creation
   string(PREPEND output_string "[built-in options]\n")


### PR DESCRIPTION
## Description
When doing a native build with ENABLE_INTERNAL_<LIB>=ON (e.g., ENABLE_INTERNAL_BLURAY), the hardcoded `pkg_config_libdir` property in the generated Meson cross-file acts as a strict sandbox kill-switch. This prevents pkg-config from falling back to host system libraries like libxml2 or freetype2, causing the build to fail or miss downstream libraries.

For now this impacts FindUdfread, FindBluray, FindDav1d, FindLCMS2

This patch wraps the Meson property generation in CMAKE_CROSSCOMPILING checks:
- Retains `pkg_config_libdir` for true cross-builds to maintain strict host isolation.
- Injects `pkg_config_path` instead for native internal builds, allowing them to successfully resolve host system dependencies.

## Motivation and context
allow ENABLE_INTERNAL_BLURAY and ENABLE_INTERNAL_UDFREAD on native builds.

## How has this been tested?
Intel N250 / Linux / GBM

## What is the effect on users?
Native builds of Kodi can statically link meson-configured libriaries like libudfread and libbluray

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
