### PR TITLE
[cmake] fix internal libxslt build finding LibXml2

### DIFF
--- a/cmake/modules/FindXSLT.cmake
+++ b/cmake/modules/FindXSLT.cmake
@@ -37,6 +37,10 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
       list(APPEND CMAKE_ARGS -DBUILD_SHARED_LIBS=OFF)
     endif()
 
+    set(patches "${CMAKE_SOURCE_DIR}/tools/depends/target/libxslt/01-cmake-libxml2-module-mode.patch")
+    generate_patchcommand("${patches}")
+    unset(patches)
+
     BUILD_DEP_TARGET()
 
     set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LINK_LIBRARIES LibXml2::LibXml2)

--- a/tools/depends/target/libxslt/01-cmake-libxml2-module-mode.patch
+++ b/tools/depends/target/libxslt/01-cmake-libxml2-module-mode.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -34,7 +34,7 @@ include(GNUInstallDirs)
+
+ if(NOT TARGET LibXml2)
+-	find_package(LibXml2 CONFIG REQUIRED)
++	find_package(LibXml2 REQUIRED)
+ endif()
+
+ option(BUILD_SHARED_LIBS "Build shared libraries" ON)


### PR DESCRIPTION
## Description
Internal libxslt (`ENABLE_INTERNAL_XSLT`) fails to configure: libxslt's CMakeLists uses `find_package(LibXml2 CONFIG REQUIRED)`, but Kodi provides LibXml2 via module/pkg-config (`LibXml2::LibXml2`), not a CMake CONFIG package. A patch switches libxslt to module-mode `find_package(LibXml2 REQUIRED)`.

## Motivation and context
`ENABLE_INTERNAL_XSLT=ON` is currently broken on builds that supply LibXml2 through pkg-config rather than a CONFIG package.

## How has this been tested?
Configured and built with `-DENABLE_INTERNAL_XSLT=ON -DENABLE_XSLT=ON` on Linux; libxslt now configures and links against Kodi's LibXml2.

## What is the effect on users?
Hopefully none.  Easier to use internal XSLT now.  libxml2 is very common as a baseline system library so internal xslt + system xml is now possible.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
