### PR TITLE
[cmake] disable zstd in internal libcurl build

### DIFF
--- a/cmake/modules/FindCurl.cmake
+++ b/cmake/modules/FindCurl.cmake
@@ -46,6 +46,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                    -DCURL_USE_OPENSSL=ON
                    -DOPENSSL_ROOT_DIR=${DEPENDS_PATH}
                    -DCURL_BROTLI=ON
+                   -DCURL_ZSTD=OFF
                    -DUSE_NGHTTP2=ON
                    -DUSE_LIBIDN2=OFF
                    -DCURL_USE_LIBSSH2=OFF


### PR DESCRIPTION
### Description
The internal libcurl is built static (`BUILD_STATIC_LIBS=ON`) with `CURL_ZSTD=AUTO`, so curl auto-detects a host `libzstd` and links `ZSTD_createDStream` into `libcurl.a`. The curl link interface does not propagate zstd, so on hosts that have `libzstd` (its a requirement for building Linux kernel now) the final link fails. This PR sets `-DCURL_ZSTD=OFF` for the internal build.  Trying to make CURL_ZSTD=AUTO work is fussier and requires more extensive cmake changes than is worth the trouble.

### Motivation and context
`ENABLE_INTERNAL_CURL=ON` fails to link on any host with libzstd dev files installed. Disabling zstd makes the internal build deterministic regardless of host packages.  Losing zstd in all cases is suboptimal but better than failed build.

### How has this been tested?
Built with `-DENABLE_INTERNAL_CURL=ON` on Linux with libzstd installed; the internal libcurl now links and kodi builds.

## What is the effect on users?
Hopefully none.  Internal-curl is a rare build.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
