### PR TITLE
[VideoPlayer] Forward/Backward Skip Improvement

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3570,125 +3570,130 @@ void CVideoPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
   if (!m_State.canseek)
     return;
 
-  std::optional<int64_t> seekTarget;
   const int64_t time = GetTime();
-  bool accurate = false;
+  const Direction direction = bPlus ? Direction::FORWARD : Direction::BACKWARD;
+  const SeekStep step = bLargeStep ? SeekStep::LARGE : SeekStep::NORMAL;
 
-  if (bLargeStep && bChapterOverride)
+  if (step == SeekStep::LARGE && bChapterOverride)
   {
-    const int chapter = GetChapter();
-    const bool hasValidChapters = GetChapterCount() > 1 && chapter > 0;
+    std::vector<SeekCandidate> candidates;
+    if (auto candidate = GetChapterSeekCandidate(time, direction); candidate.has_value())
+      candidates.push_back(std::move(*candidate));
+    if (auto candidate = GetBookmarkSeekCandidate(time, direction); candidate.has_value())
+      candidates.push_back(std::move(*candidate));
 
-    if (hasValidChapters || HasBookmarks())
+    if (!candidates.empty())
     {
-      const std::chrono::milliseconds ts{time};
-
-      // Seek to the nearest bookmark or chapter.
-      // No earlier/later bookmark or chapter? use a large step.
-      if (!bPlus)
+      auto bestCandidateIt = std::ranges::min_element(candidates, std::less<>{},
+                                                      [time](const CVideoPlayer::SeekCandidate& c)
+                                                      { return std::abs(c.targetTime - time); });
+      if (bestCandidateIt != candidates.end())
       {
-        const std::optional<std::chrono::milliseconds> tsBookmark =
-            GetBookmarkPos(GetPreviousBookmark(ts));
-
-        if (hasValidChapters)
-        {
-          const std::optional<std::chrono::milliseconds> tsChapter =
-              GetChapterPosMs(GetPreviousChapter());
-
-          if (tsChapter.has_value() &&
-              (!tsBookmark.has_value() || tsChapter.value().count() > tsBookmark.value().count()))
-          {
-            SeekChapter(GetPreviousChapter());
-            return;
-          }
-        }
-
-        if (tsBookmark.has_value())
-          seekTarget = tsBookmark.value().count();
-      }
-      else
-      {
-        const std::optional<std::chrono::milliseconds> tsBookmark =
-            GetBookmarkPos(GetNextBookmark(ts));
-
-        if (hasValidChapters)
-        {
-          const std::optional<std::chrono::milliseconds> tsChapter = GetChapterPosMs(chapter + 1);
-
-          if (tsChapter.has_value() &&
-              (!tsBookmark.has_value() || tsChapter.value().count() < tsBookmark.value().count()))
-          {
-            SeekChapter(chapter + 1);
-            return;
-          }
-        }
-
-        if (tsBookmark.has_value())
-          seekTarget = tsBookmark.value().count();
+        bestCandidateIt->action();
+        return;
       }
     }
   }
 
-  if (seekTarget.has_value())
+  if (auto candidate = GetTimeOrPercentSeekCandidate(time, direction, step); candidate.has_value())
+    candidate->action();
+}
+
+void CVideoPlayer::ExecuteTimeSeek(int64_t target, Direction direction, bool accurate)
+{
+  const int64_t time = GetTime();
+  CDVDMsgPlayerSeek::CMode mode;
+  mode.time = target;
+  mode.backward = direction == Direction::BACKWARD;
+  mode.accurate = accurate;
+  mode.restore = true;
+  mode.trickplay = false;
+  mode.sync = true;
+  m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
+  SynchronizeDemuxer();
+  if (target < 0)
+    target = 0;
+  m_callback.OnPlayBackSeek(target, target - time);
+}
+
+std::optional<CVideoPlayer::SeekCandidate> CVideoPlayer::GetTimeOrPercentSeekCandidate(
+    int64_t time, Direction direction, SeekStep step)
+{
+  int64_t target = 0;
+  const std::shared_ptr<CAdvancedSettings> advancedSettings =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+
+  if (advancedSettings->m_videoUseTimeSeeking &&
+      m_processInfo->GetMaxTime() > 2000 * advancedSettings->m_videoTimeSeekForwardBig)
   {
-    accurate = true;
+    if (step == SeekStep::LARGE)
+      target = direction == Direction::FORWARD ? advancedSettings->m_videoTimeSeekForwardBig
+                                               : advancedSettings->m_videoTimeSeekBackwardBig;
+    else
+      target = direction == Direction::FORWARD ? advancedSettings->m_videoTimeSeekForward
+                                               : advancedSettings->m_videoTimeSeekBackward;
+    target = time + target * 1000;
   }
   else
   {
-    const std::shared_ptr<CAdvancedSettings> advancedSettings =
-        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
-    if (advancedSettings->m_videoUseTimeSeeking &&
-        m_processInfo->GetMaxTime() > 2000 * advancedSettings->m_videoTimeSeekForwardBig)
-    {
-      if (bLargeStep)
-        seekTarget = bPlus ? advancedSettings->m_videoTimeSeekForwardBig
-                           : advancedSettings->m_videoTimeSeekBackwardBig;
-      else
-        seekTarget = bPlus ? advancedSettings->m_videoTimeSeekForward
-                           : advancedSettings->m_videoTimeSeekBackward;
-      seekTarget.value() *= 1000;
-      seekTarget.value() += GetTime();
-    }
+    int percent;
+    if (step == SeekStep::LARGE)
+      percent = direction == Direction::FORWARD ? advancedSettings->m_videoPercentSeekForwardBig
+                                                : advancedSettings->m_videoPercentSeekBackwardBig;
     else
-    {
-      int percent;
-      if (bLargeStep)
-        percent = bPlus ? advancedSettings->m_videoPercentSeekForwardBig
-                        : advancedSettings->m_videoPercentSeekBackwardBig;
-      else
-        percent = bPlus ? advancedSettings->m_videoPercentSeekForward
-                        : advancedSettings->m_videoPercentSeekBackward;
-      seekTarget =
-          static_cast<int64_t>(m_processInfo->GetMaxTime() * (GetPercentage() + percent) / 100);
-    }
-
-    if (g_application.CurrentFileItem().IsStack() &&
-        (seekTarget > m_processInfo->GetMaxTime() || seekTarget < 0))
-    {
-      g_application.SeekTime((seekTarget.value() - time) * 0.001 + g_application.GetTime());
-      // warning, don't access any VideoPlayer variables here as
-      // the VideoPlayer object may have been destroyed
-      return;
-    }
+      percent = direction == Direction::FORWARD ? advancedSettings->m_videoPercentSeekForward
+                                                : advancedSettings->m_videoPercentSeekBackward;
+    target = time + m_processInfo->GetMaxTime() * percent / 100;
   }
 
-  if (seekTarget.has_value())
-  {
-    int64_t target = seekTarget.value();
-    CDVDMsgPlayerSeek::CMode mode;
-    mode.time = target;
-    mode.backward = !bPlus;
-    mode.accurate = accurate;
-    mode.restore = true;
-    mode.trickplay = false;
-    mode.sync = true;
+  return SeekCandidate{target, [this, target, time, direction]()
+                       {
+                         if (g_application.CurrentFileItem().IsStack() &&
+                             (target > m_processInfo->GetMaxTime() || target < 0))
+                         {
+                           g_application.SeekTime((target - time) * 0.001 +
+                                                  g_application.GetTime());
+                           return;
+                         }
+                         ExecuteTimeSeek(target, direction, false);
+                       }};
+}
 
-    m_messenger.Put(std::make_shared<CDVDMsgPlayerSeek>(mode));
-    SynchronizeDemuxer();
-    if (target < 0)
-      target = 0;
-    m_callback.OnPlayBackSeek(target, target - time);
-  }
+std::optional<CVideoPlayer::SeekCandidate> CVideoPlayer::GetChapterSeekCandidate(
+    int64_t time, Direction direction)
+{
+  const int chapter = GetChapter();
+
+  const bool hasValidChapters = GetChapterCount() > 1 && chapter > 0;
+  if (!hasValidChapters)
+    return std::nullopt;
+
+  const int targetChapter = direction == Direction::BACKWARD ? GetPreviousChapter() : chapter + 1;
+  const std::optional<std::chrono::milliseconds> tsChapter = GetChapterPosMs(targetChapter);
+
+  if (!tsChapter.has_value())
+    return std::nullopt;
+
+  const int64_t chapterTime = tsChapter.value().count();
+  return SeekCandidate{chapterTime, [this, targetChapter]() { SeekChapter(targetChapter); }};
+}
+
+std::optional<CVideoPlayer::SeekCandidate> CVideoPlayer::GetBookmarkSeekCandidate(
+    int64_t time, Direction direction)
+{
+  if (!HasBookmarks())
+    return std::nullopt;
+
+  const std::chrono::milliseconds ts{time};
+  const std::optional<std::chrono::milliseconds> tsBookmark =
+      direction == Direction::BACKWARD ? GetBookmarkPos(GetPreviousBookmark(ts))
+                                       : GetBookmarkPos(GetNextBookmark(ts));
+  if (!tsBookmark.has_value())
+    return std::nullopt;
+
+  const int64_t bookmarkTime = tsBookmark.value().count();
+  return SeekCandidate{bookmarkTime, [this, bookmarkTime, direction]()
+                       { ExecuteTimeSeek(bookmarkTime, direction, true); }};
 }
 
 bool CVideoPlayer::SeekScene(Direction seekDirection)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3616,35 +3616,72 @@ void CVideoPlayer::ExecuteTimeSeek(int64_t target, Direction direction, bool acc
   m_callback.OnPlayBackSeek(target, target - time);
 }
 
-std::optional<CVideoPlayer::SeekCandidate> CVideoPlayer::GetTimeOrPercentSeekCandidate(
-    int64_t time, Direction direction, SeekStep step)
+int64_t CVideoPlayer::CalcTimeOrPercentSeekTarget(int64_t time,
+                                                  int64_t maxTime,
+                                                  Direction direction,
+                                                  SeekStep step)
 {
-  int64_t target = 0;
   const std::shared_ptr<CAdvancedSettings> advancedSettings =
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
 
-  if (advancedSettings->m_videoUseTimeSeeking &&
-      m_processInfo->GetMaxTime() > 2000 * advancedSettings->m_videoTimeSeekForwardBig)
+  if (advancedSettings == nullptr)
+    return time;
+
+  // Calculate a time based jump
+  auto fnTimeDelta = [&advancedSettings, step, direction]()
   {
+    int64_t delta = 0;
     if (step == SeekStep::LARGE)
-      target = direction == Direction::FORWARD ? advancedSettings->m_videoTimeSeekForwardBig
-                                               : advancedSettings->m_videoTimeSeekBackwardBig;
+      delta = direction == Direction::FORWARD ? advancedSettings->m_videoTimeSeekForwardBig
+                                              : advancedSettings->m_videoTimeSeekBackwardBig;
     else
-      target = direction == Direction::FORWARD ? advancedSettings->m_videoTimeSeekForward
-                                               : advancedSettings->m_videoTimeSeekBackward;
-    target = time + target * 1000;
-  }
-  else
+      delta = direction == Direction::FORWARD ? advancedSettings->m_videoTimeSeekForward
+                                              : advancedSettings->m_videoTimeSeekBackward;
+    return delta * 1000;
+  };
+
+  // Calculate a percentage based jump
+  auto fnPercentDelta = [&advancedSettings, step, direction, maxTime]()
   {
-    int percent;
+    int percent = 0;
     if (step == SeekStep::LARGE)
       percent = direction == Direction::FORWARD ? advancedSettings->m_videoPercentSeekForwardBig
                                                 : advancedSettings->m_videoPercentSeekBackwardBig;
     else
       percent = direction == Direction::FORWARD ? advancedSettings->m_videoPercentSeekForward
                                                 : advancedSettings->m_videoPercentSeekBackward;
-    target = time + m_processInfo->GetMaxTime() * percent / 100;
+    return maxTime * percent / 100;
+  };
+
+  int64_t delta = 0;
+
+  if (!advancedSettings->m_videoSmoothPercentToTimeSeeking &&
+      advancedSettings->m_videoUseTimeSeeking &&
+      maxTime > 2000 * advancedSettings->m_videoTimeSeekForwardBig)
+  {
+    delta = fnTimeDelta();
   }
+  else if (!advancedSettings->m_videoSmoothPercentToTimeSeeking)
+  {
+    delta = fnPercentDelta();
+  }
+  else
+  {
+    const int64_t percentDelta = fnPercentDelta();
+    const int64_t timeDelta = fnTimeDelta();
+
+    delta = direction == Direction::FORWARD ? std::min(percentDelta, timeDelta)
+                                            : std::max(percentDelta, timeDelta);
+  }
+
+  return time + delta;
+}
+
+std::optional<CVideoPlayer::SeekCandidate> CVideoPlayer::GetTimeOrPercentSeekCandidate(
+    int64_t time, Direction direction, SeekStep step)
+{
+  const int64_t target =
+      CalcTimeOrPercentSeekTarget(time, m_processInfo->GetMaxTime(), direction, step);
 
   return SeekCandidate{target, [this, target, time, direction]()
                        {

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3921,7 +3921,7 @@ bool CVideoPlayer::SeekTimeRelative(int64_t iTime)
 }
 
 // return the time in milliseconds
-int64_t CVideoPlayer::GetTime()
+int64_t CVideoPlayer::GetTime() const
 {
   std::unique_lock lock(m_StateSection);
   return llrint(m_State.time);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -504,7 +504,7 @@ protected:
   void UpdatePlayState(double timeout);
   void GetGeneralInfo(std::string& strVideoInfo);
   int64_t GetUpdatedTime();
-  int64_t GetTime();
+  int64_t GetTime() const;
   float GetPercentage();
 
   virtual bool CanTempo();

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -532,6 +532,10 @@ protected:
     LARGE,
   };
 
+  static int64_t CalcTimeOrPercentSeekTarget(int64_t time,
+                                             int64_t maxTime,
+                                             Direction direction,
+                                             SeekStep step);
   std::optional<SeekCandidate> GetTimeOrPercentSeekCandidate(int64_t time,
                                                              Direction direction,
                                                              SeekStep step);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -27,6 +27,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -518,6 +519,25 @@ protected:
   int GetPreviousBookmark(std::chrono::milliseconds ts);
   int GetNextBookmark(std::chrono::milliseconds ts);
   std::optional<std::chrono::milliseconds> GetBookmarkPos(int idx);
+
+  struct SeekCandidate
+  {
+    int64_t targetTime;
+    std::function<void()> action;
+  };
+
+  enum class SeekStep
+  {
+    NORMAL,
+    LARGE,
+  };
+
+  std::optional<SeekCandidate> GetTimeOrPercentSeekCandidate(int64_t time,
+                                                             Direction direction,
+                                                             SeekStep step);
+  std::optional<SeekCandidate> GetChapterSeekCandidate(int64_t time, Direction direction);
+  std::optional<SeekCandidate> GetBookmarkSeekCandidate(int64_t time, Direction direction);
+  void ExecuteTimeSeek(int64_t target, Direction direction, bool accurate);
 
   bool m_players_created;
 

--- a/xbmc/cores/VideoPlayer/test/TestVideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/test/TestVideoPlayer.cpp
@@ -10,6 +10,10 @@
 #include "cores/IPlayerCallback.h"
 #include "cores/VideoPlayer/VideoPlayer.h"
 #include "jobs/JobManager.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+
+#include <stdexcept>
 
 #include <gtest/gtest.h>
 
@@ -25,6 +29,12 @@ public:
   void OnPlayBackStopped() override {}
   void OnPlayBackError() override {}
   void OnQueueNextItem() override {}
+};
+
+enum class TestSeekStep
+{
+  NORMAL,
+  LARGE,
 };
 
 class CTestVideoPlayer : public CVideoPlayer
@@ -47,6 +57,23 @@ public:
   bool GetHasVideo() const { return m_HasVideo; }
   bool GetHasAudio() const { return m_HasAudio; }
   void InvokeUpdateHasVideoAudio() { UpdateHasVideoAudio(); }
+
+  constexpr static SeekStep ConvertTestSeekStep(TestSeekStep step)
+  {
+    if (step == TestSeekStep::NORMAL)
+      return SeekStep::NORMAL;
+    else if (step == TestSeekStep::LARGE)
+      return SeekStep::LARGE;
+    throw std::out_of_range("missing mapping");
+  }
+
+  static int64_t InvokeCalcTimeOrPercentSeekTarget(int64_t time,
+                                                   int64_t maxTime,
+                                                   Direction direction,
+                                                   TestSeekStep step)
+  {
+    return CalcTimeOrPercentSeekTarget(time, maxTime, direction, ConvertTestSeekStep(step));
+  }
 };
 
 class TestVideoPlayer : public testing::Test
@@ -182,4 +209,159 @@ TEST_F(TestVideoPlayer, UpdateHasVideoAudioKeepsFlagsWhenStreamsOpen)
 
   EXPECT_TRUE(player.GetHasVideo());
   EXPECT_TRUE(player.GetHasAudio());
+}
+
+TEST_F(TestVideoPlayer, CalcTimeOrPercentSeekTargetCompat)
+{
+  const std::shared_ptr<CAdvancedSettings> advancedSettings =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+  ASSERT_TRUE(advancedSettings != nullptr);
+
+  // Back compatibility mode
+  // time based jumps allowed
+  advancedSettings->m_videoSmoothPercentToTimeSeeking = false;
+  advancedSettings->m_videoUseTimeSeeking = true;
+
+  // ensure video long enough to engage time jumps
+  int64_t maxTime = 2000 * advancedSettings->m_videoTimeSeekForwardBig + 1000;
+
+  EXPECT_EQ(advancedSettings->m_videoTimeSeekForwardBig * 1000,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::FORWARD,
+                                                                TestSeekStep::LARGE));
+
+  EXPECT_EQ(advancedSettings->m_videoTimeSeekForward * 1000,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::FORWARD,
+                                                                TestSeekStep::NORMAL));
+
+  EXPECT_EQ(advancedSettings->m_videoTimeSeekBackwardBig * 1000,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::BACKWARD,
+                                                                TestSeekStep::LARGE));
+
+  EXPECT_EQ(advancedSettings->m_videoTimeSeekBackward * 1000,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::BACKWARD,
+                                                                TestSeekStep::NORMAL));
+
+  // video not long enough => percent based jumps
+  maxTime = 2000 * advancedSettings->m_videoTimeSeekForwardBig - 1000;
+
+  EXPECT_EQ(maxTime * advancedSettings->m_videoPercentSeekForwardBig / 100,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::FORWARD,
+                                                                TestSeekStep::LARGE));
+
+  EXPECT_EQ(maxTime * advancedSettings->m_videoPercentSeekForward / 100,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::FORWARD,
+                                                                TestSeekStep::NORMAL));
+
+  EXPECT_EQ(maxTime * advancedSettings->m_videoPercentSeekBackwardBig / 100,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::BACKWARD,
+                                                                TestSeekStep::LARGE));
+
+  EXPECT_EQ(maxTime * advancedSettings->m_videoPercentSeekBackward / 100,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::BACKWARD,
+                                                                TestSeekStep::NORMAL));
+}
+
+TEST_F(TestVideoPlayer, CalcTimeOrPercentSeekTargetPercent)
+{
+  const std::shared_ptr<CAdvancedSettings> advancedSettings =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+  ASSERT_TRUE(advancedSettings != nullptr);
+
+  // Percent based only
+  advancedSettings->m_videoSmoothPercentToTimeSeeking = false;
+  advancedSettings->m_videoUseTimeSeeking = false;
+
+  // duration that would have engaged time based jumps otherwise
+  int64_t maxTime = 2000 * advancedSettings->m_videoTimeSeekForwardBig + 1000;
+
+  EXPECT_EQ(maxTime * advancedSettings->m_videoPercentSeekForwardBig / 100,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::FORWARD,
+                                                                TestSeekStep::LARGE));
+
+  EXPECT_EQ(maxTime * advancedSettings->m_videoPercentSeekForward / 100,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::FORWARD,
+                                                                TestSeekStep::NORMAL));
+
+  EXPECT_EQ(maxTime * advancedSettings->m_videoPercentSeekBackwardBig / 100,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::BACKWARD,
+                                                                TestSeekStep::LARGE));
+
+  EXPECT_EQ(maxTime * advancedSettings->m_videoPercentSeekBackward / 100,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::BACKWARD,
+                                                                TestSeekStep::NORMAL));
+}
+
+TEST_F(TestVideoPlayer, CalcTimeOrPercentSeekTargetSmooth)
+{
+  const std::shared_ptr<CAdvancedSettings> advancedSettings =
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+  ASSERT_TRUE(advancedSettings != nullptr);
+
+  // Smooth percent to time based jumps
+  advancedSettings->m_videoSmoothPercentToTimeSeeking = true;
+
+  // Tests pattern: find the threshold between percent-based and time-based using
+  // the advanced settings, then try a maxTime under and over the threshold
+
+  int64_t threshold = advancedSettings->m_videoTimeSeekForwardBig * 1000 * 100 /
+                      advancedSettings->m_videoPercentSeekForwardBig;
+
+  // percent based for small durations
+  int64_t maxTime = threshold / 2;
+
+  EXPECT_EQ(maxTime * advancedSettings->m_videoPercentSeekForwardBig / 100,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::FORWARD,
+                                                                TestSeekStep::LARGE));
+  // time based for large durations
+  maxTime = threshold * 2;
+
+  EXPECT_EQ(advancedSettings->m_videoTimeSeekForwardBig * 1000,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::FORWARD,
+                                                                TestSeekStep::LARGE));
+
+  // Repeat for the other types of jumps
+  threshold = advancedSettings->m_videoTimeSeekForward * 1000 * 100 /
+              advancedSettings->m_videoPercentSeekForward;
+
+  maxTime = threshold / 2;
+
+  EXPECT_EQ(maxTime * advancedSettings->m_videoPercentSeekForward / 100,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::FORWARD,
+                                                                TestSeekStep::NORMAL));
+
+  maxTime = threshold * 2;
+
+  EXPECT_EQ(advancedSettings->m_videoTimeSeekForward * 1000,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::FORWARD,
+                                                                TestSeekStep::NORMAL));
+
+  threshold = advancedSettings->m_videoTimeSeekBackwardBig * 1000 * 100 /
+              advancedSettings->m_videoPercentSeekBackwardBig;
+
+  maxTime = threshold / 2;
+
+  EXPECT_EQ(maxTime * advancedSettings->m_videoPercentSeekBackwardBig / 100,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::BACKWARD,
+                                                                TestSeekStep::LARGE));
+
+  maxTime = threshold * 2;
+
+  EXPECT_EQ(advancedSettings->m_videoTimeSeekBackwardBig * 1000,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::BACKWARD,
+                                                                TestSeekStep::LARGE));
+
+  threshold = advancedSettings->m_videoTimeSeekBackward * 1000 * 100 /
+              advancedSettings->m_videoPercentSeekBackward;
+
+  maxTime = threshold / 2;
+
+  EXPECT_EQ(maxTime * advancedSettings->m_videoPercentSeekBackward / 100,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::BACKWARD,
+                                                                TestSeekStep::NORMAL));
+
+  maxTime = threshold * 2;
+
+  EXPECT_EQ(advancedSettings->m_videoTimeSeekBackward * 1000,
+            CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::BACKWARD,
+                                                                TestSeekStep::NORMAL));
 }

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -202,6 +202,7 @@ void CAdvancedSettings::Initialize()
   m_videoAudioDelayRange = 10;
   m_videoAudioDelayStep = 0.025f;
   m_videoUseTimeSeeking = true;
+  m_videoSmoothPercentToTimeSeeking = true;
   m_videoTimeSeekForward = 30;
   m_videoTimeSeekBackward = -30;
   m_videoTimeSeekForwardBig = 600;
@@ -692,6 +693,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetFloat(pElement, "ignorepercentatend", m_videoIgnorePercentAtEnd, 0, 100.0f);
 
     XMLUtils::GetBoolean(pElement, "usetimeseeking", m_videoUseTimeSeeking);
+    XMLUtils::GetBoolean(pElement, "smoothpercenttotimeseeking", m_videoSmoothPercentToTimeSeeking);
     XMLUtils::GetInt(pElement, "timeseekforward", m_videoTimeSeekForward, 0, 6000);
     XMLUtils::GetInt(pElement, "timeseekbackward", m_videoTimeSeekBackward, -6000, 0);
     XMLUtils::GetInt(pElement, "timeseekforwardbig", m_videoTimeSeekForwardBig, 0, 6000);

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -157,6 +157,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     float m_videoAudioDelayRange;
     float m_videoAudioDelayStep;
     bool m_videoUseTimeSeeking;
+    bool m_videoSmoothPercentToTimeSeeking;
     int m_videoTimeSeekForward;
     int m_videoTimeSeekBackward;
     int m_videoTimeSeekForwardBig;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

With default settings, for a 19 minutes long video, a forward skip will jump a bit less than 2 minutes (10% of the duration).
For a 21 minutes long video, a forward skip jumps 10 minutes (the large step size) and it's very easy to accidentally jump past the end and close the video in 3 skips.
The drastic difference is not user-friendly or convenient. Most anime episodes are a bit over 20 minutes for example.

The PR adds a jump method with a percent-based jump size that grows up to the step size.
For example:

10 minutes long video > jump = 1 minute (10%)
20 minutes long video > jump = 2 minutes (10%)
40 minutes long video > jump = 4 minutes (10%)
100 minutes long video > jump = 10 minutes (10% and also the large step size)
120 minutes long video > jump = 10 minutes (large step size)

The pure percent based jump mode remains available (set existing as.xml usetimeseeking=false) and the current jump with abrupt transition between percent and time also remains available (set new as.xml smoothpercenttotimeseeking=false)

The PR starts with a refactor of the jump code that should allow future consolidation of other types of seeks and jumps and a cleanup of VideoPlayer.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added unit tests.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

No jump behavior change for videos under 20 minutes and barely above.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
