### PR TITLE
[python][profiles][addons] Fix database stability and add‑on enable/disable after profile switch

### DIFF
--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -69,7 +69,11 @@ bool CDatabaseManager::InitializeInternal()
   const std::shared_ptr<CAdvancedSettings> advancedSettings =
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
 
-  // NOTE: CAddonDatabase initialized in the constructor
+  // Ensure the addon database is ready for the current profile by running
+  // its update procedure, just like the other databases.
+  if (ADDON::CAddonDatabase db; !UpdateDatabase(db))
+    return false;
+
   // NOTE: Order here is important. In particular, CTextureDatabase has to be updated
   //       before CVideoDatabase.
   if (CViewDatabase db; !UpdateDatabase(db))

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -138,7 +138,14 @@ bool CAddonMgr::Init()
   }
 
   if (!m_database->Open())
+  {
     CLog::Log(LOGFATAL, "ADDONS: Failed to open database");
+    m_installedAddons.clear();
+    m_disabled.clear();
+    m_updateableAddons.clear();
+    m_updateRules = std::make_unique<CAddonUpdateRules>();
+    return false;
+  }
 
   FindAddons();
 

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -850,8 +850,8 @@ bool CGUIDialogAddonInfo::SetItem(const CFileItemPtr& item)
 
   m_item = std::make_shared<CFileItem>(*item);
   m_localAddon.reset();
-  if (CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), m_localAddon,
-                                             OnlyEnabled::CHOICE_NO))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), m_localAddon,
+                                              OnlyEnabled::CHOICE_NO))
   {
     CLog::LogF(LOGDEBUG, "Addon with id {} not found locally.", item->GetAddonInfo()->ID());
   }

--- a/xbmc/interfaces/python/PythonInvoker.cpp
+++ b/xbmc/interfaces/python/PythonInvoker.cpp
@@ -577,37 +577,41 @@ void CPythonInvoker::onExecutionDone()
 
     onDeinitialization();
 
-    // Force a full garbage collection to clean up unreferenced Python objects
-    // before we start tearing down the interpreter. This prevents objects with
-    // dangling C++ backing pointers from being destroyed during Py_EndInterpreter.
+    // Clear any lingering Python error state early, so it cannot affect
+    // the garbage collection or module dictionary clearing below.
+    PyErr_Clear();
+
+    // Force a full GC cycle unconditionally before teardown.
     PyGC_Collect();
 
-    // Unregister all Addon classes now, while the interpreter is still alive.
-    // This ensures C++ destructors can safely release Python references.
-    m_languageHook->UnregisterMe();
+    // Pre-clear all module dictionaries before calling Py_EndInterpreter.
+    // This ensures SWIG destructors fire cleanly while the interpreter
+    // is still fully initialised, preventing a SIGSEGV inside
+    // _PyModule_ClearDict when Py_EndInterpreter tears down the interpreter.
+    PyObject* modules = PyImport_GetModuleDict();
+    if (modules)
+      PyDict_Clear(modules);
 
-    // If any classes still remain, log them - but we'll still try to clear
-    // the interpreter forcefully.
+    // Collect any objects that became unreachable after dict clearing.
+    PyGC_Collect();
+
+    // Clear any Python error that may have been set by finalizers or
+    // the previous GC, to avoid debug asserts inside Py_EndInterpreter.
+    PyErr_Clear();
+
+    Py_EndInterpreter(m_threadState);
+
+    // If objects remain, log them. The language hook is still registered,
+    // so destructor callbacks during cleanup unregister from this hook,
+    // avoiding false positives.
     if (m_languageHook->HasRegisteredAddonClasses())
       CLog::Log(LOGWARNING,
                 "CPythonInvoker({}, {}): the python script \"{}\" has left several "
                 "classes in memory that we couldn't clean up. The classes include: {}",
                 GetId(), m_sourceFile, m_sourceFile, getListOfAddonClassesAsString(m_languageHook));
 
-    // Force-clear all module dictionaries in this sub-interpreter.
-    // This breaks circular references and allows the C++ bound objects
-    // to be destroyed cleanly, preventing the segfault inside _PyModule_ClearDict.
-    PyObject* modules = PyImport_GetModuleDict();
-    if (modules)
-      PyDict_Clear(modules);
-
-    // Run GC again to clean up any garbage created by the dict clearing.
-    PyGC_Collect();
-
-    // Clear any remaining Python error state to avoid asserts in debug builds.
-    PyErr_Clear();
-
-    Py_EndInterpreter(m_threadState);
+    // Unregister the language hook
+    m_languageHook->UnregisterMe();
 
     PyThreadState_Swap(m_mainThreadState);
     PyThreadState_Clear(m_mainThreadState);

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -314,6 +314,12 @@ bool CProfileManager::LoadProfile(unsigned int index)
   // Stop all texture cache jobs and close the old profile's texture database
   CServiceBroker::GetTextureCache()->Deinitialize();
 
+  // Reset database manager state while the texture cache is quiet.
+  // The manager holds no persistent connections; this call just clears
+  // m_dbStatus so the next Initialize() re-runs schema checks and
+  // migrations for the new profile.
+  CServiceBroker::GetDatabaseManager().Deinitialize();
+
   SetCurrentProfileId(index);
   m_previousProfileLoadedForLogin = false;
 
@@ -328,13 +334,16 @@ bool CProfileManager::LoadProfile(unsigned int index)
 
   CreateProfileFolders();
 
-  // Re-open the texture database for the new profile
+  // Update/migrate databases for the new profile first, then re-start the
+  // texture cache. The cache opens its own connection, but the Textures DB
+  // schema must be current before that happens - the order matters.
+  if (!CServiceBroker::GetDatabaseManager().Initialize())
+  {
+    CLog::Log(LOGFATAL, "CProfileManager: unable to initialize databases for profile \"{}\"",
+              m_profiles.at(index).getName());
+    return false;
+  }
   CServiceBroker::GetTextureCache()->Initialize();
-
-  // Reset the database manager so all databases are re-initialized for the
-  // new profile, which forces a schema version check and migration.
-  CServiceBroker::GetDatabaseManager().Deinitialize();
-  CServiceBroker::GetDatabaseManager().Initialize();
   CServiceBroker::GetInputManager().LoadKeymaps();
 
   CServiceBroker::GetInputManager().SetMouseEnabled(settings->GetBool(CSettings::SETTING_INPUT_ENABLEMOUSE));
@@ -468,6 +477,8 @@ void CProfileManager::LogOff()
   // re-initialized cleanly when the login screen is shown again.
   CServiceBroker::GetDatabaseManager().Deinitialize();
 
+  // LoadMasterProfileForLogin calls LoadProfile, which closes and re-opens
+  // all databases at the correct point in the switch sequence.
   LoadMasterProfileForLogin();
 
   g_passwordManager.bMasterUser = false;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
The previous crash fix reordered cleanup to call `UnregisterMe()` before `Py_EndInterpreter()`. This prevented the segfault but caused the "left several classes" warning to fire on every shutdown, even for objects that Python would later clean up.
Thanks to @MoojMidge for pointing this out in #28390.

**Update (further testing and fixes)**
Testing with more add-ons revealed two remaining issues:
- The unconditional `PyGC_Collect()` alone still led to a crash because SWIG-wrapped objects in module dicts weren't freed before `Py_EndInterpreter`. Adding `PyDict_Clear(modules)` before interpreter teardown resolves this, while keeping the original `UnregisterMe()` / warning order so that only genuine leaks are reported.
- The profile switch also triggered SQLITE_MISUSE on the texture database. These were introduced by a previous database-migration fix #28446 that called `DatabaseManager::Deinitialize()` after `TextureCache::Initialize()`, creating a race where the texture DB was closed while background caching jobs were already running. The order is now corrected: both deinitialization calls happen before `SetCurrentProfileId`, and `DatabaseManager::Initialize()` runs before `TextureCache::Initialize()`.

**Update (add-on database fixes)**
After switching to a profile that was not active at startup, add-on enable/disable had no visible effect - the GUI stayed unchanged and the setting was not persisted.
The root cause was that `CAddonDatabase` was only initialised once in the `CDatabaseManager` constructor, so a profile activated later never got a working addons db.
Second commit commit adds the missing `CAddonDatabase` update to `InitializeInternal()`, so it runs on every profile switch just like the other databases.
Additionally, `CAddonMgr::Init()` now returns false when the database cannot be opened (instead of silently continuing), and an inverted log condition in `GUIDialogAddonInfo::SetItem` is corrected.

Everything is now stable - no crashes, no false warnings, no database misuse, and add-on enable/disable works reliably after a profile switch - even with many add-ons installed.
## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The warning spam after the initial fix was noisy and misleading. Database misuse was discovered while fixing a regression that reintroduced crashes after the initial push.
The add-on database issue was reported after the original commit.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Kodi Linux build with multiple profiles (new, copy-default, existing) and several installed add-ons from various categories.
Profile switches and application exit all succeed without crashes, warnings, or database errors.
After switching to a profile, enabling/disabling an add-on in the Add-on Info dialog correctly updates the GUI and persists the setting.
Switching back to the master profile and returning to the other profile confirms the add-on state is retained.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
No more false leftover-class warnings in the log.
No database errors when switching profiles.

Resolves #28550:
Profile and exit behaviour is now fully stable, even with many add-ons.
Add-on enable/disable actions now work immediately after a profile switch, without requiring a full Kodi restart.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
