### PR TITLE
[PVR] Guide window: Fix 'smart select'

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRGuide.cpp
@@ -497,24 +497,24 @@ bool CGUIWindowPVRGuideBase::OnMessage(CGUIMessage& message)
                   const std::shared_ptr<const CPVREpgInfoTag> tag(pItem->GetEPGInfoTag());
                   if (tag)
                   {
-                    if (tag->IsPlayable())
+                    const CDateTime start{tag->StartAsUTC()};
+                    const CDateTime end{tag->EndAsUTC()};
+                    const CDateTime now{CDateTime::GetUTCDateTime()};
+
+                    if (start <= now && now <= end)
+                    {
+                      // Current event
+                      CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
+                          *pItem);
+                    }
+                    else if (tag->IsPlayable())
                     {
                       // VOD event
                       CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().PlayEpgTag(*pItem);
                     }
                     else
                     {
-                      const CDateTime start{tag->StartAsUTC()};
-                      const CDateTime end{tag->EndAsUTC()};
-                      const CDateTime now{CDateTime::GetUTCDateTime()};
-
-                      if (start <= now && now <= end)
-                      {
-                        // Current event
-                        CServiceBroker::GetPVRManager().Get<PVR::GUI::Playback>().SwitchToChannel(
-                            *pItem);
-                      }
-                      else if (now < start)
+                      if (now < start)
                       {
                         // Future event
                         if (CServiceBroker::GetPVRManager().Timers()->GetTimerForEpgTag(tag))


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Guide window: Fix 'smart select' for EPG events to switch to channel when current event is selected instead start playback of the tag from beginning.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix issue #28430

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not yet. I hope @rbuehlma can?

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Smart select again works as expected.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
