### PR TITLE
Add ParseText tests and fix unmatched TABS handling

### DIFF
--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -485,16 +485,19 @@ void CGUITextLayout::ParseText(const std::wstring& text,
         --lightDepth;
       newStyle = FONT_STYLE_LIGHT;
     }
-    else if (text.compare(pos, 5, L"TABS]") == 0 && on)
+    else if (text.compare(pos, 5, L"TABS]") == 0)
     {
       pos += 5;
-      const size_t end = text.find(L"[/TABS]", pos);
-      if (end != std::wstring::npos)
+      if (on)
       {
-        std::string t;
-        g_charsetConverter.wToUTF8(text.substr(pos), t);
-        tabs = atoi(t.c_str());
-        pos = end + 7;
+        const size_t end = text.find(L"[/TABS]", pos);
+        if (end != std::wstring::npos)
+        {
+          std::string t;
+          g_charsetConverter.wToUTF8(text.substr(pos, end - pos), t);
+          tabs = atoi(t.c_str());
+          pos = end + 7;
+        }
       }
     }
     else if (text.compare(pos, 3, L"CR]") == 0 && on)

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -499,6 +499,9 @@ void CGUITextLayout::ParseText(const std::wstring& text,
           pos = end + 7;
         }
       }
+      // Equivalent of newStyle for other formatting tags to have the tag text discarded.
+      if (!tabs)
+        tabs = -1;
     }
     else if (text.compare(pos, 3, L"CR]") == 0 && on)
     {

--- a/xbmc/guilib/test/CMakeLists.txt
+++ b/xbmc/guilib/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES TestGUIControlFactory.cpp
-            TestGamesGUIInfo.cpp)
+            TestGamesGUIInfo.cpp
+            TestGUITextLayout.cpp)
 
 core_add_test_library(guilib_test)

--- a/xbmc/guilib/test/TestGUITextLayout.cpp
+++ b/xbmc/guilib/test/TestGUITextLayout.cpp
@@ -1,0 +1,159 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "guilib/GUITextLayout.h"
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+// CGUITextLayout::Filter strips recognised format tags and returns the
+// remaining plain UTF-8 text. It is used here as the test entry point for
+// ParseText tag-parsing logic introduced in PRs #28280 and #28356.
+//
+// [COLOR] tags are not tested here because they call into CServiceBroker
+// and require a full service-broker setup.
+
+namespace
+{
+
+std::string Filter(const std::string& input)
+{
+  std::string text = input;
+  CGUITextLayout::Filter(text);
+  return text;
+}
+
+} // namespace
+
+struct TagTestParam
+{
+  std::string input;
+  std::string expected;
+};
+
+class TestGUITextLayoutFilterTags : public testing::TestWithParam<TagTestParam>
+{
+};
+
+TEST_P(TestGUITextLayoutFilterTags, ReturnsExpectedText)
+{
+  EXPECT_EQ(GetParam().expected, Filter(GetParam().input));
+}
+
+static const std::vector<TagTestParam> filterTestCases{
+    // Plain text
+    {"", ""},
+    {"Hello world", "Hello world"},
+
+    // Matched style tags
+    {"[B]bold[/B]", "bold"},
+    {"[I]italic[/I]", "italic"},
+    {"[LIGHT]text[/LIGHT]", "text"},
+    {"prefix [B]bold[/B] suffix", "prefix bold suffix"},
+
+    // Case-transform tags also apply the transform
+    {"[UPPERCASE]hello[/UPPERCASE]", "HELLO"},
+    {"[LOWERCASE]HELLO[/LOWERCASE]", "hello"},
+    {"[CAPITALIZE]hello world[/CAPITALIZE]", "Hello World"},
+
+    // CR tag becomes newline
+    {"a[CR]b", "a\nb"},
+
+    // TABS tag inserts the specified number of tab characters
+    {"[TABS]1[/TABS]label", "\tlabel"},
+    {"[TABS]2[/TABS]label", "\t\tlabel"},
+    {"[TABS]3[/TABS]label", "\t\t\tlabel"},
+
+    // Unmatched [TABS] without [/TABS]: the tag token is consumed but no
+    // tabs are emitted; content after the tag passes through unchanged.
+    {"[TABS]1 label", "1 label"},
+    {"label[/TABS]", "label"},
+
+    // Nested identical tags (PR #28280)
+    {"[B][B]text[/B][/B]", "text"},
+    {"[B][B][B]text[/B][/B][/B]", "text"},
+    {"[I][I]text[/I][/I]", "text"},
+    {"[LIGHT][LIGHT]text[/LIGHT][/LIGHT]", "text"},
+    {"[UPPERCASE][UPPERCASE]hello[/UPPERCASE][/UPPERCASE]", "HELLO"},
+    {"[LOWERCASE][LOWERCASE]HELLO[/LOWERCASE][/LOWERCASE]", "hello"},
+    {"[CAPITALIZE][CAPITALIZE]hello world[/CAPITALIZE][/CAPITALIZE]", "Hello World"},
+
+    // Unmatched opening tags (PR #28356 lookahead)
+    {"[B]no close", "no close"},
+    {"[I]no close", "no close"},
+    {"[LIGHT]no close", "no close"},
+    {"[UPPERCASE]no close", "no close"},
+    {"[LOWERCASE]no close", "no close"},
+    {"[CAPITALIZE]no close", "no close"},
+    {"text[B]", "text"},
+
+    // Unmatched closing tags
+    {"[/B]text", "text"},
+    {"text [/B] more", "text  more"},
+    {"text [/I] more", "text  more"},
+    {"text [/LIGHT] more", "text  more"},
+    {"text [/UPPERCASE] more", "text  more"},
+    {"text [/LOWERCASE] more", "text  more"},
+    {"text [/CAPITALIZE] more", "text  more"},
+    {"[B]text[/B][/B]", "text"},
+    {"[B][B]text[/B][/B][/B]", "text"},
+    {"[/B][/B][/B][B]valid[/B]", "valid"},
+    {"[B]first[/B] [/B] [B]second[/B]", "first  second"},
+
+    // Mixed / edge cases
+    {"[B]first[/B] mid [B]second[/B]", "first mid second"},
+    {"[B][I]bold+italic[/I][/B]", "bold+italic"},
+    {"[B][I][LIGHT]content[/LIGHT][/I][/B]", "content"},
+    {"[B][I]text[/B][/I]", "text"},
+    {"[B][B]styled[/B][/B] plain", "styled plain"},
+    {"[B][/B]", ""},
+    {"[B][B][/B][/B]", ""},
+    {"[b]text[/b]", "[b]text[/b]"},
+};
+
+INSTANTIATE_TEST_SUITE_P(TestGUITextLayoutFilter,
+                         TestGUITextLayoutFilterTags,
+                         testing::ValuesIn(filterTestCases));
+
+TEST(TestGUITextLayoutFilter, VeryLongPlainText)
+{
+  const std::string text(10000, 'A');
+  EXPECT_EQ(text, Filter(text));
+}
+
+TEST(TestGUITextLayoutFilter, VeryLongNestedBold)
+{
+  const std::string inner(5000, 'X');
+  EXPECT_EQ(inner, Filter("[B]" + inner + "[/B]"));
+}
+
+TEST(TestGUITextLayoutFilter, DeeplyNested100Levels)
+{
+  std::string open, close;
+  for (int i = 0; i < 100; ++i)
+  {
+    open += "[B]";
+    close = "[/B]" + close;
+  }
+  EXPECT_EQ("deep", Filter(open + "deep" + close));
+}
+
+TEST(TestGUITextLayoutFilter, DeeplyNested100Levels_OneMissingClose)
+{
+  // 100 opens, 99 closes - outermost [B] has no matching close so is ignored.
+  // Parser must not crash; content must be extracted.
+  std::string open, close;
+  for (int i = 0; i < 100; ++i)
+    open += "[B]";
+  for (int i = 0; i < 99; ++i)
+    close += "[/B]";
+  const std::string result = Filter(open + "deep" + close);
+  EXPECT_NE(result.find("deep"), std::string::npos);
+}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Add unit test coverage for `CGUITextLayout::ParseText()` and fix unmatched `[TABS]` handling.

The new test suite exercises matched formatting tags, nested tags, unmatched opening/closing tags, malformed nesting, CR/TABS handling, case transforms, deep nesting, and edge-case inputs.

The tests cover parser behaviour related to PR #28280 and PR #28356. While adding coverage, an inconsistency was identified in `[TABS]` handling. This PR updates the parser so malformed `[TABS]` tags are consumed consistently with the other supported formatting tags.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Built and executed the `TestGUITextLayoutFilter` test suite.

- `TestGUITextLayoutFilter` tests pass
- All Jenkins builders pass

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built and executed the `TestGUITextLayoutParseText` test suite.

- 52 `TestGUITextLayoutParseText` tests pass
- All Jenkins builders pass

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Improves parser robustness and consistency when processing malformed label formatting tags.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
