### PR TITLE
VideoToolbox: Accept full-range VTB GL surfaces

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVTBGL.cpp
@@ -21,6 +21,28 @@
 #include <CoreVideo/CoreVideo.h>
 #include <OpenGL/CGLIOSurface.h>
 
+namespace
+{
+bool IsSupportedVTBGLSurface(CVPixelBufferRef pixelBuffer, IOSurfaceRef& surface)
+{
+  if (!pixelBuffer)
+    return false;
+
+  surface = CVPixelBufferGetIOSurface(pixelBuffer);
+  if (!surface)
+    return false;
+
+  const OSType formatType = IOSurfaceGetPixelFormat(surface);
+  if (formatType != kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange &&
+      formatType != kCVPixelFormatType_420YpCbCr8BiPlanarFullRange)
+  {
+    return false;
+  }
+
+  return IOSurfaceGetPlaneCount(surface) == 2;
+}
+} // namespace
+
 CBaseRenderer* CRendererVTB::Create(CVideoBuffer *buffer)
 {
   VTB::CVideoBufferVTB *vb = dynamic_cast<VTB::CVideoBufferVTB*>(buffer);
@@ -151,17 +173,8 @@ bool CRendererVTB::UploadTexture(int index)
   // with an IOSurface as there is no CPU -> GPU upload.
   CWinSystemOSX* winSystem = dynamic_cast<CWinSystemOSX*>(CServiceBroker::GetWinSystem());
   CGLContextObj cgl_ctx  = (CGLContextObj)winSystem->GetCGLContextObj();
-  IOSurfaceRef surface  = CVPixelBufferGetIOSurface(cvBufferRef);
-  OSType format_type = IOSurfaceGetPixelFormat(surface);
-
-  if (format_type != kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange)
-  {
-    return false;
-  }
-
-  GLsizei surfplanes = IOSurfaceGetPlaneCount(surface);
-
-  if (surfplanes != 2)
+  IOSurfaceRef surface = nullptr;
+  if (!IsSupportedVTBGLSurface(cvBufferRef, surface))
   {
     return false;
   }


### PR DESCRIPTION
## Description

HDR10 HEVC Main 10 content caused VideoToolbox on my Mac to hand Kodi a full-range 420f two-plane IOSurface, while Kodi's VTB GL upload path only allowed video-range 420v two-plane IOSurfaces.

To fix this, we accept full-range VideoToolbox GL surfaces in RendererVTBGL.

RendererVTBGL already supports two-plane NV12-style CoreVideo surfaces, but texture upload only accepted the video-range `420v` format. This also allows the full-range `420f` variant while continuing to reject unsupported layouts.

## Motivation and context

With VideoToolbox enabled, the 4K sample I used to reproduce the problem produced full-range `420f` CVPixelBuffer/IOSurface frames:

- HEVC Main 10
- 3840x2160, 16:9
- 24 fps
- limited range
- BT.2020 primaries
- PQ transfer
- BT.2020 non-constant luminance matrix

The VTB renderer was selected, but `RendererVTBGL::UploadTexture()` only accepted `kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange` (`420v`). The sample produced `kCVPixelFormatType_420YpCbCr8BiPlanarFullRange` (`420f`), so texture upload failed and playback continued with black video.

This change accepts both `420v` and `420f` two-plane CoreVideo surfaces in `RendererVTBGL`.

## How has this been tested?

Tested on macOS ARM64 with VideoToolbox enabled using the 4K HDR10 HEVC sample described above.

Before this change, playback advanced and audio played, but video remained black because `UploadTexture()` rejected the `420f` IOSurface.

After this change, `RendererVTBGL` accepts the `420f` two-plane surface and the sample displays video.

## What is the effect on users?

* Fixes black video on macOS when playing some HDR videos with VideoToolbox enabled

## Types of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)