### PR TITLE
Video: Expose codec profile in Media Details dialog

### DIFF
--- a/addons/skin.estuary/xml/Includes_InfoViewer.xml
+++ b/addons/skin.estuary/xml/Includes_InfoViewer.xml
@@ -128,8 +128,8 @@
 				</control>
 				<include content="InfoViewerButton">
 					<param name="control_id" value="102"/>
-					<param name="label" value="[COLOR button_focus]$LOCALIZE[31600]: [/COLOR]$VAR[VideoCodecVar]"/>
-					<param name="altlabel" value="$LOCALIZE[31600]: $VAR[VideoCodecVar]"/>
+					<param name="label" value="[COLOR button_focus]$LOCALIZE[31600]: [/COLOR]$VAR[VideoCodecVar]$INFO[ListItem.VideoProfile, (,)]"/>
+					<param name="altlabel" value="$LOCALIZE[31600]: $VAR[VideoCodecVar]$INFO[ListItem.VideoProfile, (,)]"/>
 					<param name="visible" value="!String.IsEmpty(ListItem.VideoCodec)"/>
 				</include>
 				<include content="InfoViewerButton">

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -6608,6 +6608,16 @@ constexpr std::array<InfoMap, 3> container_str = {{
 ///      - etc
 ///     <p>
 ///   }
+///   \table_row3{   <b>`ListItem.VideoProfile`</b>,
+///                  \anchor ListItem_VideoProfile
+///                  _string_,
+///     @return The video codec profile of the currently selected video, if available.
+///      Example values:
+///      - <b>Main</b>
+///      - <b>Main 10</b>
+///      - etc
+///     <p>
+///   }
 ///   \table_row3{   <b>`ListItem.VideoResolution`</b>,
 ///                  \anchor ListItem_VideoResolution
 ///                  _string_,
@@ -7709,7 +7719,7 @@ constexpr std::array<InfoMap, 3> container_str = {{
 ///
 /// -----------------------------------------------------------------------------
 // clang-format off
-constexpr std::array<InfoMap, 228> listitem_labels = {{
+constexpr std::array<InfoMap, 229> listitem_labels = {{
     {"thumb",                         LISTITEM_THUMB},
     {"icon",                          LISTITEM_ICON},
     {"actualicon",                    LISTITEM_ACTUAL_ICON},
@@ -7823,6 +7833,7 @@ constexpr std::array<InfoMap, 228> listitem_labels = {{
     {"set",                           LISTITEM_SET},
     {"setid",                         LISTITEM_SETID},
     {"videocodec",                    LISTITEM_VIDEO_CODEC},
+    {"videoprofile",                  LISTITEM_VIDEO_PROFILE},
     {"videoresolution",               LISTITEM_VIDEO_RESOLUTION},
     {"videowidth",                    LISTITEM_VIDEO_WIDTH},
     {"videoheight",                   LISTITEM_VIDEO_HEIGHT},

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -554,6 +554,13 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
       if (p->m_fAspect == 0.0f && p->m_iHeight > 0)
         p->m_fAspect = (float)p->m_iWidth / p->m_iHeight;
       p->m_strCodec = pDemux->GetStreamCodecName(stream->demuxerId, stream->uniqueId);
+      p->m_bProfileScanned = true;
+      if (stream->profile != AV_PROFILE_UNKNOWN)
+      {
+        const char* profile = avcodec_profile_name(stream->codec, stream->profile);
+        if (profile != nullptr)
+          p->m_strProfile = profile;
+      }
       p->m_iDuration = pDemux->GetStreamLength();
       p->m_strStereoMode = vstream->stereo_mode;
       p->m_strLanguage = vstream->language;
@@ -721,4 +728,3 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const std::string &path, CStream
 
   return true;
 }
-

--- a/xbmc/cores/VideoPlayer/Interface/StreamInfo.h
+++ b/xbmc/cores/VideoPlayer/Interface/StreamInfo.h
@@ -80,6 +80,7 @@ struct VideoStreamInfo : StreamInfo
   CRect DestRect;
   CRect VideoRect;
   std::string stereoMode;
+  std::string profileName;
   int angles = 0;
   StreamHdrType hdrType = StreamHdrType::HDR_TYPE_NONE;
   StreamHdrType hdrTypeAlt = StreamHdrType::HDR_TYPE_NONE;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -73,6 +73,11 @@
 #include <mutex>
 #include <utility>
 
+extern "C"
+{
+#include <libavcodec/avcodec.h>
+}
+
 using namespace KODI;
 using namespace std::chrono_literals;
 
@@ -5941,6 +5946,12 @@ void CVideoPlayer::GetVideoStreamInfo(int streamId, VideoStreamInfo& info) const
   info.width = s.width;
   info.height = s.height;
   info.codecName = s.codec;
+  if (s.profile != AV_PROFILE_UNKNOWN)
+  {
+    const char* profile = avcodec_profile_name(s.codecId, s.profile);
+    if (profile != nullptr)
+      info.profileName = profile;
+  }
   info.videoAspectRatio = s.aspect_ratio;
   info.stereoMode = s.stereo_mode;
   info.flags = s.flags;

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -1063,6 +1063,7 @@ constexpr uint32_t LISTITEM_MEDIAPROVIDERS           = LISTITEM_START + 224;
 constexpr uint32_t LISTITEM_TITLE_EXTRAINFO          = LISTITEM_START + 225;
 constexpr uint32_t LISTITEM_DECODED_FILENAME_AND_PATH  = LISTITEM_START + 226;
 constexpr uint32_t LISTITEM_VIDEO_HDR_DETAIL         = LISTITEM_START + 227;
+constexpr uint32_t LISTITEM_VIDEO_PROFILE            = LISTITEM_START + 228;
 
 constexpr int      LISTITEM_END                      = LISTITEM_START + 2500;
 

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -475,6 +475,9 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
       case LISTITEM_VIDEO_CODEC:
         value = tag->m_streamDetails.GetVideoCodec();
         return true;
+      case LISTITEM_VIDEO_PROFILE:
+        value = tag->m_streamDetails.GetVideoProfile();
+        return true;
       case LISTITEM_VIDEO_RESOLUTION:
         value = CStreamDetails::VideoDimsToResolutionDescription(
             tag->m_streamDetails.GetVideoWidth(), tag->m_streamDetails.GetVideoHeight());

--- a/xbmc/guilib/test/CMakeLists.txt
+++ b/xbmc/guilib/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES TestGUIControlFactory.cpp
             TestGamesGUIInfo.cpp
             TestGUITextLayout.cpp
             TestSkinMapManager.cpp
+            TestVideoGUIInfo.cpp
 )
 
 core_add_test_library(guilib_test)

--- a/xbmc/guilib/test/TestVideoGUIInfo.cpp
+++ b/xbmc/guilib/test/TestVideoGUIInfo.cpp
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileItem.h"
+#include "guilib/guiinfo/GUIInfo.h"
+#include "guilib/guiinfo/GUIInfoLabels.h"
+#include "guilib/guiinfo/VideoGUIInfo.h"
+#include "video/VideoInfoTag.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI::GUILIB::GUIINFO;
+
+TEST(TestVideoGUIInfo, ListItemVideoProfileReturnsProfile)
+{
+  CFileItem item{"/videos/test.mkv", false};
+  auto* video = new CStreamDetailVideo();
+  video->m_strProfile = "Main 10";
+  item.GetVideoInfoTag()->m_streamDetails.AddStream(video);
+  item.GetVideoInfoTag()->m_streamDetails.DetermineBestStreams();
+
+  CVideoGUIInfo videoGUIInfo;
+  std::string value;
+
+  EXPECT_TRUE(videoGUIInfo.GetLabel(value, &item, 0, CGUIInfo(LISTITEM_VIDEO_PROFILE), nullptr));
+  EXPECT_EQ(value, "Main 10");
+}
+
+TEST(TestVideoGUIInfo, ListItemVideoProfileReturnsEmptyWhenUnavailable)
+{
+  CFileItem item{"/videos/test.mkv", false};
+  auto* video = new CStreamDetailVideo();
+  video->m_strCodec = "hevc";
+  item.GetVideoInfoTag()->m_streamDetails.AddStream(video);
+  item.GetVideoInfoTag()->m_streamDetails.DetermineBestStreams();
+
+  CVideoGUIInfo videoGUIInfo;
+  std::string value;
+
+  EXPECT_TRUE(videoGUIInfo.GetLabel(value, &item, 0, CGUIInfo(LISTITEM_VIDEO_PROFILE), nullptr));
+  EXPECT_TRUE(value.empty());
+}

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -13,10 +13,16 @@
 #include "utils/Archive.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/Variant.h"
+#include "utils/log.h"
 
 #include <math.h>
 
 const float VIDEOASPECT_EPSILON = 0.025f;
+
+namespace
+{
+constexpr int STREAM_DETAILS_ARCHIVE_VERSION = 1;
+}
 
 CStreamDetailVideo::CStreamDetailVideo() :
   CStreamDetail(CStreamDetail::VIDEO)
@@ -30,6 +36,8 @@ CStreamDetailVideo::CStreamDetailVideo(const VideoStreamInfo& info, int duration
     m_fAspect(info.videoAspectRatio),
     m_iDuration(duration),
     m_strCodec(info.codecName),
+    m_strProfile(info.profileName),
+    m_bProfileScanned(true),
     m_strStereoMode(info.stereoMode),
     m_strLanguage(info.language),
     m_strHdrType(CStreamDetails::HdrTypeToString(info.hdrType)),
@@ -38,6 +46,11 @@ CStreamDetailVideo::CStreamDetailVideo(const VideoStreamInfo& info, int duration
 }
 
 void CStreamDetailVideo::Archive(CArchive& ar)
+{
+  Archive(ar, 0);
+}
+
+void CStreamDetailVideo::Archive(CArchive& ar, int archiveVersion)
 {
   if (ar.IsStoring())
   {
@@ -50,6 +63,11 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     ar << m_strLanguage;
     ar << m_strHdrType;
     ar << m_strHdrDetail;
+    if (archiveVersion >= 1)
+    {
+      ar << m_strProfile;
+      ar << m_bProfileScanned;
+    }
   }
   else
   {
@@ -62,11 +80,17 @@ void CStreamDetailVideo::Archive(CArchive& ar)
     ar >> m_strLanguage;
     ar >> m_strHdrType;
     ar >> m_strHdrDetail;
+    if (archiveVersion >= 1)
+    {
+      ar >> m_strProfile;
+      ar >> m_bProfileScanned;
+    }
   }
 }
 void CStreamDetailVideo::Serialize(CVariant& value) const
 {
   value["codec"] = m_strCodec;
+  value["profile"] = m_strProfile;
   value["aspect"] = m_fAspect;
   value["height"] = m_iHeight;
   value["width"] = m_iWidth;
@@ -189,6 +213,8 @@ CStreamDetailVideo& CStreamDetailVideo::operator=(const CStreamDetailVideo& that
     this->m_iHeight = that.m_iHeight;
     this->m_fAspect = that.m_fAspect;
     this->m_strCodec = that.m_strCodec;
+    this->m_strProfile = that.m_strProfile;
+    this->m_bProfileScanned = that.m_bProfileScanned;
     this->m_iDuration = that.m_iDuration;
     this->m_strStereoMode = that.m_strStereoMode;
     this->m_strLanguage = that.m_strLanguage;
@@ -247,9 +273,11 @@ bool CStreamDetails::operator ==(const CStreamDetails &right) const
 
   for (int iStream=1; iStream<=GetVideoStreamCount(); iStream++)
   {
-    if (GetVideoCodec(iStream)    != right.GetVideoCodec(iStream)    ||
-        GetVideoWidth(iStream)    != right.GetVideoWidth(iStream)    ||
-        GetVideoHeight(iStream)   != right.GetVideoHeight(iStream)   ||
+    if (GetVideoCodec(iStream) != right.GetVideoCodec(iStream) ||
+        GetVideoProfile(iStream) != right.GetVideoProfile(iStream) ||
+        HasVideoProfileScanned(iStream) != right.HasVideoProfileScanned(iStream) ||
+        GetVideoWidth(iStream) != right.GetVideoWidth(iStream) ||
+        GetVideoHeight(iStream) != right.GetVideoHeight(iStream) ||
         GetVideoDuration(iStream) != right.GetVideoDuration(iStream) ||
         fabs(GetVideoAspect(iStream) - right.GetVideoAspect(iStream)) > VIDEOASPECT_EPSILON)
       return false;
@@ -400,6 +428,37 @@ std::string CStreamDetails::GetVideoCodec(int idx) const
     return "";
 }
 
+std::string CStreamDetails::GetVideoProfile(int idx) const
+{
+  const CStreamDetailVideo* item =
+      dynamic_cast<const CStreamDetailVideo*>(GetNthStream(CStreamDetail::VIDEO, idx));
+  if (item)
+    return item->m_strProfile;
+  else
+    return "";
+}
+
+bool CStreamDetails::HasVideoProfileScanned(int idx) const
+{
+  const CStreamDetailVideo* item =
+      dynamic_cast<const CStreamDetailVideo*>(GetNthStream(CStreamDetail::VIDEO, idx));
+  if (item)
+    return item->m_bProfileScanned;
+  else
+    return false;
+}
+
+bool CStreamDetails::HasUnscannedVideoProfile() const
+{
+  for (const auto& iter : m_vecItems)
+  {
+    if (iter->m_eType == CStreamDetail::VIDEO &&
+        !static_cast<const CStreamDetailVideo*>(iter.get())->m_bProfileScanned)
+      return true;
+  }
+  return false;
+}
+
 float CStreamDetails::GetVideoAspect(int idx) const
 {
   const CStreamDetailVideo* item =
@@ -527,6 +586,7 @@ void CStreamDetails::Archive(CArchive& ar)
 {
   if (ar.IsStoring())
   {
+    ar << -STREAM_DETAILS_ARCHIVE_VERSION;
     ar << (int)m_vecItems.size();
 
     for (auto &iter : m_vecItems)
@@ -534,13 +594,32 @@ void CStreamDetails::Archive(CArchive& ar)
       // the type goes before the actual item.  When loading we need
       // to know the type before we can construct an instance to serialize
       ar << (int)iter->m_eType;
-      ar << (*iter);
+      if (iter->m_eType == CStreamDetail::VIDEO)
+        static_cast<CStreamDetailVideo*>(iter.get())->Archive(ar, STREAM_DETAILS_ARCHIVE_VERSION);
+      else
+        ar << (*iter);
     }
   }
   else
   {
-    int count;
+    int count = 0;
     ar >> count;
+
+    int archiveVersion = 0;
+    if (count < 0)
+    {
+      archiveVersion = -count;
+      ar >> count;
+    }
+    if (archiveVersion > STREAM_DETAILS_ARCHIVE_VERSION)
+    {
+      CLog::Log(
+          LOGWARNING,
+          "CStreamDetails: unsupported stream details archive version {}, ignoring stream details",
+          archiveVersion);
+      Reset();
+      return;
+    }
 
     Reset();
     for (int i=0; i<count; i++)
@@ -550,7 +629,9 @@ void CStreamDetails::Archive(CArchive& ar)
 
       ar >> type;
       p = NewStream(CStreamDetail::StreamType(type));
-      if (p)
+      if (p && p->m_eType == CStreamDetail::VIDEO)
+        static_cast<CStreamDetailVideo*>(p)->Archive(ar, archiveVersion);
+      else if (p)
         ar >> (*p);
     }
 
@@ -614,6 +695,34 @@ void CStreamDetails::DetermineBestStreams(void)
     if ((*champion == NULL) || (*champion)->IsWorseThan(*iter))
       *champion = iter.get();
   }  /* for each */
+}
+
+bool CStreamDetails::UpdateMissingVideoProfilesFrom(const CStreamDetails& source)
+{
+  bool changed = false;
+  int videoIndex = 0;
+
+  for (const auto& iter : m_vecItems)
+  {
+    if (iter->m_eType != CStreamDetail::VIDEO)
+      continue;
+
+    ++videoIndex;
+    auto* video = static_cast<CStreamDetailVideo*>(iter.get());
+    if (video->m_bProfileScanned)
+      continue;
+
+    const auto* sourceVideo = static_cast<const CStreamDetailVideo*>(
+        source.GetNthStream(CStreamDetail::VIDEO, videoIndex));
+    if (!sourceVideo || !sourceVideo->m_bProfileScanned)
+      continue;
+
+    video->m_bProfileScanned = true;
+    video->m_strProfile = sourceVideo->m_strProfile;
+    changed = true;
+  }
+
+  return changed;
 }
 
 std::string CStreamDetails::VideoDimsToResolutionDescription(int iWidth, int iHeight)

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -50,6 +50,7 @@ public:
   CStreamDetailVideo(const CStreamDetailVideo&) = default;
   CStreamDetailVideo& operator=(const CStreamDetailVideo& that);
   void Archive(CArchive& ar) override;
+  void Archive(CArchive& ar, int archiveVersion);
   void Serialize(CVariant& value) const override;
   bool IsWorseThan(const CStreamDetail &that) const override;
 
@@ -58,6 +59,8 @@ public:
   float m_fAspect = 0.0;
   int m_iDuration = 0;
   std::string m_strCodec;
+  std::string m_strProfile;
+  bool m_bProfileScanned = false;
   std::string m_strStereoMode;
   std::string m_strLanguage;
   std::string m_strHdrType;
@@ -114,6 +117,9 @@ public:
   const CStreamDetail* GetNthStream(CStreamDetail::StreamType type, int idx) const;
 
   std::string GetVideoCodec(int idx = 0) const;
+  std::string GetVideoProfile(int idx = 0) const;
+  bool HasVideoProfileScanned(int idx = 0) const;
+  bool HasUnscannedVideoProfile() const;
   float GetVideoAspect(int idx = 0) const;
   int GetVideoWidth(int idx = 0) const;
   int GetVideoHeight(int idx = 0) const;
@@ -133,6 +139,7 @@ public:
   void AddStream(CStreamDetail *item);
   void Reset(void);
   void DetermineBestStreams(void);
+  bool UpdateMissingVideoProfilesFrom(const CStreamDetails& source);
 
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;

--- a/xbmc/utils/test/TestStreamDetails.cpp
+++ b/xbmc/utils/test/TestStreamDetails.cpp
@@ -6,9 +6,62 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "cores/VideoPlayer/Interface/StreamInfo.h"
+#include "filesystem/File.h"
+#include "test/TestUtils.h"
+#include "utils/Archive.h"
 #include "utils/StreamDetails.h"
+#include "utils/Variant.h"
 
 #include <gtest/gtest.h>
+
+namespace
+{
+void ArchiveRoundTrip(CStreamDetails& source, CStreamDetails& loaded)
+{
+  XFILE::CFile* file = XBMC_CREATETEMPFILE(".ar");
+  ASSERT_NE(file, nullptr);
+
+  CArchive arstore(file, CArchive::store);
+  arstore << source;
+  arstore.Close();
+
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
+  CArchive arload(file, CArchive::load);
+  arload >> loaded;
+  arload.Close();
+
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(file));
+}
+
+void AddArchiveTestStreams(CStreamDetails& details, const std::string& profile, bool profileScanned)
+{
+  auto* video = new CStreamDetailVideo();
+  video->m_strCodec = "hevc";
+  video->m_strProfile = profile;
+  video->m_bProfileScanned = profileScanned;
+  video->m_fAspect = 1.78f;
+  video->m_iHeight = 1080;
+  video->m_iWidth = 1920;
+  video->m_iDuration = 30;
+  video->m_strStereoMode = "left_right";
+  video->m_strLanguage = "eng";
+  video->m_strHdrType = "hdr10";
+  video->m_strHdrDetail = "maxcll";
+  details.AddStream(video);
+
+  auto* audio = new CStreamDetailAudio();
+  audio->m_strCodec = "aac";
+  audio->m_strLanguage = "eng";
+  audio->m_iChannels = 6;
+  details.AddStream(audio);
+
+  auto* subtitle = new CStreamDetailSubtitle();
+  subtitle->m_strLanguage = "spa";
+  details.AddStream(subtitle);
+  details.DetermineBestStreams();
+}
+} // namespace
 
 TEST(TestStreamDetails, General)
 {
@@ -22,6 +75,7 @@ TEST(TestStreamDetails, General)
   video->m_fAspect = 2.39f;
   video->m_iDuration = 30;
   video->m_strCodec = "h264";
+  video->m_strProfile = "High";
   video->m_strStereoMode = "left_right";
   video->m_strLanguage = "eng";
 
@@ -39,6 +93,7 @@ TEST(TestStreamDetails, General)
   EXPECT_EQ(1, a.GetStreamCount(CStreamDetail::VIDEO));
   EXPECT_EQ(1, a.GetVideoStreamCount());
   EXPECT_STREQ("", a.GetVideoCodec().c_str());
+  EXPECT_STREQ("", a.GetVideoProfile().c_str());
   EXPECT_EQ(0.0f, a.GetVideoAspect());
   EXPECT_EQ(0, a.GetVideoWidth());
   EXPECT_EQ(0, a.GetVideoHeight());
@@ -57,11 +112,241 @@ TEST(TestStreamDetails, General)
 
   a.DetermineBestStreams();
   EXPECT_STREQ("h264", a.GetVideoCodec().c_str());
+  EXPECT_STREQ("High", a.GetVideoProfile().c_str());
   EXPECT_EQ(2.39f, a.GetVideoAspect());
   EXPECT_EQ(1920, a.GetVideoWidth());
   EXPECT_EQ(1080, a.GetVideoHeight());
   EXPECT_EQ(30, a.GetVideoDuration());
   EXPECT_STREQ("left_right", a.GetStereoMode().c_str());
+}
+
+TEST(TestStreamDetails, EmptyVideoProfile)
+{
+  CStreamDetails details;
+  details.AddStream(new CStreamDetailVideo());
+  details.DetermineBestStreams();
+
+  EXPECT_EQ(details.GetVideoProfile(), "");
+  EXPECT_FALSE(details.HasVideoProfileScanned());
+  EXPECT_TRUE(details.HasUnscannedVideoProfile());
+}
+
+TEST(TestStreamDetails, SerializeVideoProfile)
+{
+  CStreamDetailVideo video;
+  video.m_strProfile = "Main 10";
+
+  CVariant value;
+  video.Serialize(value);
+
+  EXPECT_EQ(value["profile"].asString(), "Main 10");
+}
+
+TEST(TestStreamDetails, ScannedEmptyVideoProfile)
+{
+  CStreamDetails details;
+  auto* video = new CStreamDetailVideo();
+  video->m_bProfileScanned = true;
+  details.AddStream(video);
+  details.DetermineBestStreams();
+
+  EXPECT_EQ(details.GetVideoProfile(), "");
+  EXPECT_TRUE(details.HasVideoProfileScanned());
+  EXPECT_FALSE(details.HasUnscannedVideoProfile());
+}
+
+TEST(TestStreamDetails, ScannedNonEmptyVideoProfile)
+{
+  CStreamDetails details;
+  auto* video = new CStreamDetailVideo();
+  video->m_strProfile = "Main 10";
+  video->m_bProfileScanned = true;
+  details.AddStream(video);
+  details.DetermineBestStreams();
+
+  EXPECT_EQ(details.GetVideoProfile(), "Main 10");
+  EXPECT_TRUE(details.HasVideoProfileScanned());
+  EXPECT_FALSE(details.HasUnscannedVideoProfile());
+}
+
+TEST(TestStreamDetails, VideoStreamInfoPreservesProfile)
+{
+  VideoStreamInfo info;
+  info.profileName = "Main 10";
+
+  CStreamDetailVideo video(info);
+
+  EXPECT_EQ(video.m_strProfile, "Main 10");
+  EXPECT_TRUE(video.m_bProfileScanned);
+}
+
+TEST(TestStreamDetails, UpdateMissingVideoProfilesFromExtractedDetails)
+{
+  CStreamDetails nfo;
+  auto* nfoVideo = new CStreamDetailVideo();
+  nfoVideo->m_strCodec = "hevc";
+  nfoVideo->m_iWidth = 1280;
+  nfoVideo->m_iHeight = 720;
+  nfoVideo->m_strProfile.clear();
+  nfoVideo->m_bProfileScanned = false;
+  nfo.AddStream(nfoVideo);
+  nfo.DetermineBestStreams();
+
+  CStreamDetails extracted;
+  auto* extractedVideo = new CStreamDetailVideo();
+  extractedVideo->m_strCodec = "h264";
+  extractedVideo->m_iWidth = 3840;
+  extractedVideo->m_iHeight = 2160;
+  extractedVideo->m_strProfile = "Main 10";
+  extractedVideo->m_bProfileScanned = true;
+  extracted.AddStream(extractedVideo);
+  extracted.DetermineBestStreams();
+
+  EXPECT_TRUE(nfo.UpdateMissingVideoProfilesFrom(extracted));
+  EXPECT_EQ(nfo.GetVideoCodec(), "hevc");
+  EXPECT_EQ(nfo.GetVideoWidth(), 1280);
+  EXPECT_EQ(nfo.GetVideoHeight(), 720);
+  EXPECT_EQ(nfo.GetVideoProfile(), "Main 10");
+  EXPECT_TRUE(nfo.HasVideoProfileScanned());
+}
+
+TEST(TestStreamDetails, UpdateMissingVideoProfilesDoesNotOverwriteScannedProfile)
+{
+  CStreamDetails nfo;
+  auto* nfoVideo = new CStreamDetailVideo();
+  nfoVideo->m_strProfile = "";
+  nfoVideo->m_bProfileScanned = true;
+  nfo.AddStream(nfoVideo);
+  nfo.DetermineBestStreams();
+
+  CStreamDetails extracted;
+  auto* extractedVideo = new CStreamDetailVideo();
+  extractedVideo->m_strProfile = "Main 10";
+  extractedVideo->m_bProfileScanned = true;
+  extracted.AddStream(extractedVideo);
+  extracted.DetermineBestStreams();
+
+  EXPECT_FALSE(nfo.UpdateMissingVideoProfilesFrom(extracted));
+  EXPECT_EQ(nfo.GetVideoProfile(), "");
+  EXPECT_TRUE(nfo.HasVideoProfileScanned());
+}
+
+TEST(TestStreamDetails, ArchiveRoundTripPreservesExistingFields)
+{
+  CStreamDetails source;
+  AddArchiveTestStreams(source, "Main 10", true);
+
+  CStreamDetails loaded;
+  ArchiveRoundTrip(source, loaded);
+
+  EXPECT_EQ(loaded.GetVideoCodec(), "hevc");
+  EXPECT_EQ(loaded.GetVideoProfile(), "Main 10");
+  EXPECT_TRUE(loaded.HasVideoProfileScanned());
+  EXPECT_FLOAT_EQ(loaded.GetVideoAspect(), 1.78f);
+  EXPECT_EQ(loaded.GetVideoHeight(), 1080);
+  EXPECT_EQ(loaded.GetVideoWidth(), 1920);
+  EXPECT_EQ(loaded.GetVideoDuration(), 30);
+  EXPECT_EQ(loaded.GetStereoMode(), "left_right");
+  EXPECT_EQ(loaded.GetVideoLanguage(), "eng");
+  EXPECT_EQ(loaded.GetVideoHdrType(), "hdr10");
+  EXPECT_EQ(loaded.GetVideoHdrDetail(), "maxcll");
+  EXPECT_EQ(loaded.GetAudioCodec(), "aac");
+  EXPECT_EQ(loaded.GetAudioLanguage(), "eng");
+  EXPECT_EQ(loaded.GetAudioChannels(), 6);
+  EXPECT_EQ(loaded.GetSubtitleLanguage(), "spa");
+}
+
+TEST(TestStreamDetails, ArchiveRoundTripPreservesScannedEmptyVideoProfile)
+{
+  CStreamDetails source;
+  AddArchiveTestStreams(source, "", true);
+
+  CStreamDetails loaded;
+  ArchiveRoundTrip(source, loaded);
+
+  EXPECT_EQ(loaded.GetVideoProfile(), "");
+  EXPECT_TRUE(loaded.HasVideoProfileScanned());
+  EXPECT_FALSE(loaded.HasUnscannedVideoProfile());
+}
+
+TEST(TestStreamDetails, ArchiveRoundTripPreservesUnknownVideoProfile)
+{
+  CStreamDetails source;
+  AddArchiveTestStreams(source, "", false);
+
+  CStreamDetails loaded;
+  ArchiveRoundTrip(source, loaded);
+
+  EXPECT_EQ(loaded.GetVideoProfile(), "");
+  EXPECT_FALSE(loaded.HasVideoProfileScanned());
+  EXPECT_TRUE(loaded.HasUnscannedVideoProfile());
+}
+
+TEST(TestStreamDetails, LegacyArchiveLoadsExistingFieldsWithUnknownVideoProfile)
+{
+  XFILE::CFile* file = XBMC_CREATETEMPFILE(".ar");
+  ASSERT_NE(file, nullptr);
+
+  CArchive arstore(file, CArchive::store);
+  arstore << 3;
+  arstore << static_cast<int>(CStreamDetail::VIDEO);
+  arstore << std::string("hevc");
+  arstore << 1.78f;
+  arstore << 1080;
+  arstore << 1920;
+  arstore << 30;
+  arstore << std::string("left_right");
+  arstore << std::string("eng");
+  arstore << std::string("hdr10");
+  arstore << std::string("maxcll");
+  arstore << static_cast<int>(CStreamDetail::AUDIO);
+  arstore << std::string("aac");
+  arstore << std::string("eng");
+  arstore << 6;
+  arstore << static_cast<int>(CStreamDetail::SUBTITLE);
+  arstore << std::string("spa");
+  arstore.Close();
+
+  ASSERT_EQ(0, file->Seek(0, SEEK_SET));
+  CStreamDetails loaded;
+  CArchive arload(file, CArchive::load);
+  arload >> loaded;
+  arload.Close();
+
+  EXPECT_EQ(loaded.GetVideoCodec(), "hevc");
+  EXPECT_EQ(loaded.GetVideoProfile(), "");
+  EXPECT_FALSE(loaded.HasVideoProfileScanned());
+  EXPECT_TRUE(loaded.HasUnscannedVideoProfile());
+  EXPECT_FLOAT_EQ(loaded.GetVideoAspect(), 1.78f);
+  EXPECT_EQ(loaded.GetVideoHeight(), 1080);
+  EXPECT_EQ(loaded.GetVideoWidth(), 1920);
+  EXPECT_EQ(loaded.GetVideoDuration(), 30);
+  EXPECT_EQ(loaded.GetStereoMode(), "left_right");
+  EXPECT_EQ(loaded.GetVideoLanguage(), "eng");
+  EXPECT_EQ(loaded.GetVideoHdrType(), "hdr10");
+  EXPECT_EQ(loaded.GetVideoHdrDetail(), "maxcll");
+  EXPECT_EQ(loaded.GetAudioCodec(), "aac");
+  EXPECT_EQ(loaded.GetAudioLanguage(), "eng");
+  EXPECT_EQ(loaded.GetAudioChannels(), 6);
+  EXPECT_EQ(loaded.GetSubtitleLanguage(), "spa");
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(file));
+}
+
+TEST(TestStreamDetails, EqualityDetectsVideoProfileDifference)
+{
+  CStreamDetails left;
+  auto* leftVideo = new CStreamDetailVideo();
+  leftVideo->m_strCodec = "hevc";
+  leftVideo->m_strProfile = "Main";
+  left.AddStream(leftVideo);
+
+  CStreamDetails right;
+  auto* rightVideo = new CStreamDetailVideo();
+  rightVideo->m_strCodec = "hevc";
+  rightVideo->m_strProfile = "Main 10";
+  right.AddStream(rightVideo);
+
+  EXPECT_NE(left, right);
 }
 
 TEST(TestStreamDetails, VideoDimsToResolutionDescription)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3163,16 +3163,35 @@ bool CVideoDatabase::SetStreamDetailsForFileId(const CStreamDetails& details, in
 
     for (int i=1; i<=details.GetVideoStreamCount(); i++)
     {
-      m_pDS->exec(PrepareSQL(
-          "INSERT INTO streamdetails "
-          "(idFile, iStreamType, strVideoCodec, fVideoAspect, iVideoWidth, iVideoHeight, "
-          "iVideoDuration, strStereoMode, strVideoLanguage, strHdrType, strHdrDetail) "
-          "VALUES (%i,%i,'%s',%f,%i,%i,%i,'%s','%s','%s','%s')",
-          idFile, static_cast<int>(CStreamDetail::VIDEO), details.GetVideoCodec(i).c_str(),
-          static_cast<double>(details.GetVideoAspect(i)), details.GetVideoWidth(i),
-          details.GetVideoHeight(i), details.GetVideoDuration(i), details.GetStereoMode(i).c_str(),
-          details.GetVideoLanguage(i).c_str(), details.GetVideoHdrType(i).c_str(),
-          details.GetVideoHdrDetail(i).c_str()));
+      if (details.HasVideoProfileScanned(i))
+      {
+        m_pDS->exec(PrepareSQL(
+            "INSERT INTO streamdetails "
+            "(idFile, iStreamType, strVideoCodec, fVideoAspect, iVideoWidth, iVideoHeight, "
+            "strVideoProfile, iVideoDuration, strStereoMode, strVideoLanguage, strHdrType, "
+            "strHdrDetail) "
+            "VALUES (%i,%i,'%s',%f,%i,%i,'%s',%i,'%s','%s','%s','%s')",
+            idFile, static_cast<int>(CStreamDetail::VIDEO), details.GetVideoCodec(i).c_str(),
+            static_cast<double>(details.GetVideoAspect(i)), details.GetVideoWidth(i),
+            details.GetVideoHeight(i), details.GetVideoProfile(i).c_str(),
+            details.GetVideoDuration(i), details.GetStereoMode(i).c_str(),
+            details.GetVideoLanguage(i).c_str(), details.GetVideoHdrType(i).c_str(),
+            details.GetVideoHdrDetail(i).c_str()));
+      }
+      else
+      {
+        m_pDS->exec(PrepareSQL(
+            "INSERT INTO streamdetails "
+            "(idFile, iStreamType, strVideoCodec, fVideoAspect, iVideoWidth, iVideoHeight, "
+            "strVideoProfile, iVideoDuration, strStereoMode, strVideoLanguage, strHdrType, "
+            "strHdrDetail) "
+            "VALUES (%i,%i,'%s',%f,%i,%i,NULL,%i,'%s','%s','%s','%s')",
+            idFile, static_cast<int>(CStreamDetail::VIDEO), details.GetVideoCodec(i).c_str(),
+            static_cast<double>(details.GetVideoAspect(i)), details.GetVideoWidth(i),
+            details.GetVideoHeight(i), details.GetVideoDuration(i),
+            details.GetStereoMode(i).c_str(), details.GetVideoLanguage(i).c_str(),
+            details.GetVideoHdrType(i).c_str(), details.GetVideoHdrDetail(i).c_str()));
+      }
     }
     for (int i=1; i<=details.GetAudioStreamCount(); i++)
     {
@@ -4539,7 +4558,12 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
   std::unique_ptr<Dataset> pDS(m_pDB->CreateDataset());
   try
   {
-    std::string strSQL = PrepareSQL("SELECT * FROM streamdetails WHERE idFile = %i", fileId);
+    std::string strSQL = PrepareSQL(
+        "SELECT idFile, iStreamType, strVideoCodec, fVideoAspect, iVideoWidth, iVideoHeight, "
+        "strAudioCodec, iAudioChannels, strAudioLanguage, strSubtitleLanguage, iVideoDuration, "
+        "strStereoMode, strVideoLanguage, strHdrType, strHdrDetail, strVideoProfile "
+        "FROM streamdetails WHERE idFile = %i",
+        fileId);
     pDS->query(strSQL);
 
     while (!pDS->eof())
@@ -4554,6 +4578,8 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
           p->m_fAspect = pDS->fv(3).get_asFloat();
           p->m_iWidth = pDS->fv(4).get_asInt();
           p->m_iHeight = pDS->fv(5).get_asInt();
+          p->m_strProfile = pDS->fv(15).get_asString();
+          p->m_bProfileScanned = !pDS->fv(15).get_isNull();
           p->m_iDuration = pDS->fv(10).get_asInt();
           p->m_strStereoMode = pDS->fv(11).get_asString();
           p->m_strLanguage = pDS->fv(12).get_asString();

--- a/xbmc/video/VideoDatabaseDDL.cpp
+++ b/xbmc/video/VideoDatabaseDDL.cpp
@@ -154,6 +154,7 @@ void CVideoDatabaseDDL::CreateTables(CDatabase& db)
   db.ExecuteQuery(
       "CREATE TABLE streamdetails (idFile integer, iStreamType integer, "
       "strVideoCodec text, fVideoAspect float, iVideoWidth integer, iVideoHeight integer, "
+      "strVideoProfile text, "
       "strAudioCodec text, iAudioChannels integer, strAudioLanguage text, "
       "strSubtitleLanguage text, iVideoDuration integer, strStereoMode text, "
       "strVideoLanguage text, strHdrType text, strHdrDetail text)");

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -1422,9 +1422,14 @@ void CVideoDatabase::UpdateTables(int iVersion)
     }
     m_pDS->close();
   }
+
+  if (iVersion < 148)
+  {
+    m_pDS->exec("ALTER TABLE streamdetails ADD strVideoProfile text");
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 147;
+  return 148;
 }

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -262,6 +262,8 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
     {
       TiXmlElement stream("video");
       XMLUtils::SetString(&stream, "codec", m_streamDetails.GetVideoCodec(iStream));
+      if (m_streamDetails.HasVideoProfileScanned(iStream))
+        XMLUtils::SetString(&stream, "profile", m_streamDetails.GetVideoProfile(iStream));
       XMLUtils::SetFloat(&stream, "aspect", m_streamDetails.GetVideoAspect(iStream));
       XMLUtils::SetInt(&stream, "width", m_streamDetails.GetVideoWidth(iStream));
       XMLUtils::SetInt(&stream, "height", m_streamDetails.GetVideoHeight(iStream));
@@ -1511,6 +1513,11 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
         auto* p = new CStreamDetailVideo();
         if (XMLUtils::GetString(nodeDetail, "codec", value))
           p->m_strCodec = StringUtils::Trim(value);
+        if (XMLUtils::GetString(nodeDetail, "profile", value))
+        {
+          p->m_strProfile = StringUtils::Trim(value);
+          p->m_bProfileScanned = true;
+        }
 
         XMLUtils::GetFloat(nodeDetail, "aspect", p->m_fAspect);
         XMLUtils::GetInt(nodeDetail, "width", p->m_iWidth);

--- a/xbmc/video/test/TestVideoInfoTag.cpp
+++ b/xbmc/video/test/TestVideoInfoTag.cpp
@@ -41,6 +41,98 @@ TEST(TestVideoInfoTag, ReadTVShowSeasons)
   EXPECT_EQ(details.m_seasons, reference);
 }
 
+TEST(TestVideoInfoTag, SaveNativeStreamDetailsWritesVideoProfile)
+{
+  CVideoInfoTag details;
+  auto* video = new CStreamDetailVideo();
+  video->m_strCodec = "hevc";
+  video->m_strProfile = "Main 10";
+  video->m_bProfileScanned = true;
+  details.m_streamDetails.AddStream(video);
+
+  CXBMCTinyXML xmlDoc;
+  EXPECT_TRUE(details.Save(&xmlDoc, "movie"));
+
+  TiXmlPrinter printer;
+  xmlDoc.Accept(&printer);
+  EXPECT_NE(std::string(printer.Str()).find("<profile>Main 10</profile>"), std::string::npos);
+}
+
+TEST(TestVideoInfoTag, SaveNativeStreamDetailsOmitsUnknownVideoProfile)
+{
+  CVideoInfoTag details;
+  auto* video = new CStreamDetailVideo();
+  video->m_strCodec = "hevc";
+  video->m_bProfileScanned = false;
+  details.m_streamDetails.AddStream(video);
+
+  CXBMCTinyXML xmlDoc;
+  EXPECT_TRUE(details.Save(&xmlDoc, "movie"));
+
+  TiXmlPrinter printer;
+  xmlDoc.Accept(&printer);
+  EXPECT_EQ(std::string(printer.Str()).find("<profile"), std::string::npos);
+}
+
+TEST(TestVideoInfoTag, SaveNativeStreamDetailsWritesEmptyScannedVideoProfile)
+{
+  CVideoInfoTag details;
+  auto* video = new CStreamDetailVideo();
+  video->m_strCodec = "hevc";
+  video->m_strProfile.clear();
+  video->m_bProfileScanned = true;
+  details.m_streamDetails.AddStream(video);
+
+  CXBMCTinyXML xmlDoc;
+  EXPECT_TRUE(details.Save(&xmlDoc, "movie"));
+
+  TiXmlPrinter printer;
+  xmlDoc.Accept(&printer);
+  EXPECT_NE(std::string(printer.Str()).find("<profile"), std::string::npos);
+}
+
+TEST(TestVideoInfoTag, LoadNativeStreamDetailsReadsVideoProfile)
+{
+  const std::string document =
+      R"(<movie><fileinfo><streamdetails><video><codec>hevc</codec><profile>Main 10</profile></video></streamdetails></fileinfo></movie>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  CVideoInfoTag details;
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+  EXPECT_EQ(details.m_streamDetails.GetVideoProfile(), "Main 10");
+  EXPECT_TRUE(details.m_streamDetails.HasVideoProfileScanned());
+}
+
+TEST(TestVideoInfoTag, LoadNativeStreamDetailsReadsEmptyVideoProfile)
+{
+  const std::string document =
+      R"(<movie><fileinfo><streamdetails><video><codec>hevc</codec><profile></profile></video></streamdetails></fileinfo></movie>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  CVideoInfoTag details;
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+  EXPECT_EQ(details.m_streamDetails.GetVideoProfile(), "");
+  EXPECT_TRUE(details.m_streamDetails.HasVideoProfileScanned());
+}
+
+TEST(TestVideoInfoTag, LoadNativeStreamDetailsWithoutVideoProfile)
+{
+  const std::string document =
+      R"(<movie><fileinfo><streamdetails><video><codec>hevc</codec></video></streamdetails></fileinfo></movie>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  CVideoInfoTag details;
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+  EXPECT_EQ(details.m_streamDetails.GetVideoProfile(), "");
+  EXPECT_FALSE(details.m_streamDetails.HasVideoProfileScanned());
+}
+
 // Trick to make protected methods accessible for testing
 class CVideoInfoTagTest : public CVideoInfoTag
 {


### PR DESCRIPTION
## Description

This PR shows the codec profile alongside the codec name in the new Media Details dialog.

Note: This is the raw change to show the video codec profile, there's probably other stuff that can be improved like loading the profile on-demand when unknown (e.g. after Kodi update).

## Motivation and context

Seems like a simple extension. We show codec, so why not profile.

## How has this been tested?

Tested on macOS ARM with H265 content. Rescanning the items shows "Main 10" (see screenshot).

## What is the effect on users?

* Improved Media Details dialog

## Screenshots (if appropriate):

<img width="1312" height="710" alt="Screenshot 2026-06-23 at 8 16 13 AM" src="https://github.com/user-attachments/assets/df8a02de-5682-4f7d-85b2-a6440a1d5e8b" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
