### PR TITLE
Video: Preserve tag order from local NFOs

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4987,7 +4987,10 @@ void CVideoDatabase::GetTags(int media_id, const std::string &media_type, std::v
     if (!m_pDS2)
       return;
 
-    std::string sql = PrepareSQL("SELECT tag.name FROM tag INNER JOIN tag_link ON tag_link.tag_id = tag.tag_id WHERE tag_link.media_id = %i AND tag_link.media_type = '%s' ORDER BY tag.tag_id", media_id, media_type.c_str());
+    std::string sql = PrepareSQL(
+        "SELECT tag.name FROM tag INNER JOIN tag_link ON tag_link.tag_id = tag.tag_id WHERE "
+        "tag_link.media_id = %i AND tag_link.media_type = '%s' ORDER BY tag_link.rowid",
+        media_id, media_type.c_str());
     m_pDS2->query(sql);
     while (!m_pDS2->eof())
     {

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -28,6 +28,26 @@
 #include <string>
 #include <vector>
 
+namespace
+{
+std::vector<std::string> PreserveOrderUniqueTags(std::vector<std::string>&& tags)
+{
+  std::vector<std::string> uniqueTags;
+  uniqueTags.reserve(tags.size());
+
+  for (auto& tag : tags)
+  {
+    tag = StringUtils::Trim(tag);
+    if (tag.empty() || std::ranges::find(uniqueTags, tag) != uniqueTags.end())
+      continue;
+
+    uniqueTags.emplace_back(std::move(tag));
+  }
+
+  return uniqueTags;
+}
+} // namespace
+
 void CVideoInfoTag::Reset()
 {
   m_director.clear();
@@ -1830,7 +1850,7 @@ void CVideoInfoTag::SetSetOverview(std::string_view setOverview)
 
 void CVideoInfoTag::SetTags(std::vector<std::string> tags)
 {
-  m_tags = Trim(std::move(tags));
+  m_tags = PreserveOrderUniqueTags(std::move(tags));
 }
 
 void CVideoInfoTag::SetFile(std::string file)

--- a/xbmc/video/test/TestVideoInfoTag.cpp
+++ b/xbmc/video/test/TestVideoInfoTag.cpp
@@ -12,8 +12,31 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
+
+namespace
+{
+std::vector<std::string> GetSavedTags(const CXBMCTinyXML& doc)
+{
+  std::vector<std::string> tags;
+
+  const TiXmlElement* movie = doc.RootElement();
+  if (!movie)
+    return tags;
+
+  const TiXmlElement* tag = movie->FirstChildElement("tag");
+  while (tag)
+  {
+    if (tag->FirstChild())
+      tags.emplace_back(tag->FirstChild()->ValueStr());
+    tag = tag->NextSiblingElement("tag");
+  }
+
+  return tags;
+}
+} // namespace
 
 TEST(TestVideoInfoTag, ReadTVShowSeasons)
 {
@@ -39,6 +62,71 @@ TEST(TestVideoInfoTag, ReadTVShowSeasons)
       {1, {"season 1", ""}}, {3, {"", "plot 3"}}, {4, {"season 4", "plot 4"}}};
 
   EXPECT_EQ(details.m_seasons, reference);
+}
+
+TEST(TestVideoInfoTag, LoadNativePreservesTagOrder)
+{
+  const std::string document =
+      R"(<movie>
+           <tag>secret agent</tag>
+           <tag>undercover</tag>
+           <tag>killing</tag>
+           <tag>british secret service</tag>
+           <tag>mi6</tag>
+         </movie>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  CVideoInfoTag details;
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+
+  const std::vector<std::string> reference = {"secret agent", "undercover", "killing",
+                                              "british secret service", "mi6"};
+  EXPECT_EQ(details.m_tags, reference);
+}
+
+TEST(TestVideoInfoTag, SaveAfterLoadNativePreservesTagOrder)
+{
+  const std::string document =
+      R"(<movie>
+           <tag>secret agent</tag>
+           <tag>undercover</tag>
+           <tag>killing</tag>
+           <tag>british secret service</tag>
+           <tag>mi6</tag>
+         </movie>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  CVideoInfoTag details;
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+
+  CXBMCTinyXML savedDoc;
+  EXPECT_TRUE(details.Save(&savedDoc, "movie"));
+
+  const std::vector<std::string> reference = {"secret agent", "undercover", "killing",
+                                              "british secret service", "mi6"};
+  EXPECT_EQ(GetSavedTags(savedDoc), reference);
+}
+
+TEST(TestVideoInfoTag, SetTagsDeduplicatesWithoutReordering)
+{
+  CVideoInfoTag details;
+  details.SetTags({"secret agent", "undercover", "secret agent", "mi6"});
+
+  const std::vector<std::string> reference = {"secret agent", "undercover", "mi6"};
+  EXPECT_EQ(details.m_tags, reference);
+}
+
+TEST(TestVideoInfoTag, SetTagsKeepsAssignedOrder)
+{
+  CVideoInfoTag details;
+  details.SetTags({"mi6", "secret agent", "undercover"});
+
+  const std::vector<std::string> reference = {"mi6", "secret agent", "undercover"};
+  EXPECT_EQ(details.m_tags, reference);
 }
 
 // Trick to make protected methods accessible for testing


### PR DESCRIPTION
## Description

This PR keeps video tags in insertion order when loading local NFO metadata and deduplicates tags without reordering the first occurrence.

Tags are read from the video database in tag-link insertion order so scanning a local NFO and exporting it again does not create tag-only diffs.

## Motivation and context

I tracked my nfo files in git, and got a lot of changelog spew from re-ordering tags unnecessarily:

```patch
@@ -70,10 +70,10 @@
     <uniqueid type="tmdb" default="true">5176</uniqueid>
     <genre>Western</genre>
     <country>United States of America</country>
+    <tag>family</tag>
     <tag>rivalry</tag>
     <tag>parent child relationship</tag>
     <tag>hero</tag>
-    <tag>family</tag>
     <tag>saloon</tag>
     <tag>arizona</tag>
     <tag>liberation of prisoners</tag>
```

## How has this been tested?

Tested by exporting my existing library, overwriting files.

Before:

Produced git changelog spew like above.

After:

Tag order is stable, no re-ordering occurs.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
