### PR TITLE
Android: release GLES resources before Activity surface teardown

### DIFF
--- a/xbmc/application/ApplicationMessageHandling.cpp
+++ b/xbmc/application/ApplicationMessageHandling.cpp
@@ -53,10 +53,12 @@
 #include "pvr/PVRManager.h"
 #include "pvr/guilib/PVRGUIActionsPowerManagement.h"
 #include "pvr/guilib/PVRGUIActionsRecordings.h"
+#include "rendering/RenderSystem.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "settings/lib/Setting.h"
 #include "utils/ContentUtils.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/URIUtils.h"
@@ -64,6 +66,8 @@
 #include "windowing/WinSystem.h"
 
 #ifdef TARGET_ANDROID
+#include "windowing/android/WinSystemAndroid.h"
+
 #include "platform/android/activity/XBMCApp.h"
 #endif
 #ifdef TARGET_DARWIN_EMBEDDED
@@ -178,16 +182,68 @@ void CApplicationMessageHandling::OnApplicationMessage(MESSAGING::ThreadMessage*
 
 #ifdef TARGET_ANDROID
     case TMSG_DISPLAY_SETUP:
+    {
       // We might come from a refresh rate switch destroying the native window; use the context resolution
-      *static_cast<bool*>(pMsg->lpVoid) =
+      bool displaySetup =
           m_app.InitWindow(CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution());
-      m_app.GetComponent<CApplicationPowerHandling>()->SetRenderGUI(true);
+
+      if (displaySetup && m_androidSkinUnloadedForDisplayDestroy)
+      {
+        const auto skinHandling = m_app.GetComponent<CApplicationSkinHandling>();
+        const std::shared_ptr<CSettings> settings =
+            CServiceBroker::GetSettingsComponent()->GetSettings();
+
+        std::string skinId = settings->GetString(CSettings::SETTING_LOOKANDFEEL_SKIN);
+        if (!skinHandling->LoadSkin(skinId))
+        {
+          CLog::Log(LOGERROR, "Failed to reload skin '{}' after Android display setup", skinId);
+
+          auto setting = settings->GetSetting(CSettings::SETTING_LOOKANDFEEL_SKIN);
+          if (setting)
+          {
+            std::string defaultSkin =
+                std::static_pointer_cast<const CSettingString>(setting)->GetDefault();
+            displaySetup = skinHandling->LoadSkin(defaultSkin);
+          }
+          else
+          {
+            CLog::Log(LOGFATAL, "Failed to load setting for: {}",
+                      CSettings::SETTING_LOOKANDFEEL_SKIN);
+            displaySetup = false;
+          }
+        }
+
+        if (displaySetup)
+        {
+          m_androidSkinUnloadedForDisplayDestroy = false;
+          if (CGUIComponent* gui = CServiceBroker::GetGUI(); gui)
+            gui->GetWindowManager().MarkDirty();
+        }
+      }
+
+      *static_cast<bool*>(pMsg->lpVoid) = displaySetup;
+      if (displaySetup)
+        m_app.GetComponent<CApplicationPowerHandling>()->SetRenderGUI(true);
       break;
+    }
 
     case TMSG_DISPLAY_DESTROY:
-      *static_cast<bool*>(pMsg->lpVoid) = CServiceBroker::GetWinSystem()->DestroyWindow();
+    {
       m_app.GetComponent<CApplicationPowerHandling>()->SetRenderGUI(false);
+      m_app.GetComponent<CApplicationPlayer>()->ClosePlayer();
+
+      if (CGUIComponent* gui = CServiceBroker::GetGUI(); gui && gui->GetSkinInfo())
+        m_androidSkinUnloadedForDisplayDestroy = true;
+
+      m_app.GetComponent<CApplicationSkinHandling>()->UnloadSkin();
+
+      if (CRenderSystemBase* renderSystem = CServiceBroker::GetRenderSystem())
+        renderSystem->DestroyRenderSystem();
+
+      auto winSystem = dynamic_cast<CWinSystemAndroid*>(CServiceBroker::GetWinSystem());
+      *static_cast<bool*>(pMsg->lpVoid) = winSystem && winSystem->DestroySurface();
       break;
+    }
 
     case TMSG_RESUMEAPP:
     {

--- a/xbmc/application/ApplicationMessageHandling.h
+++ b/xbmc/application/ApplicationMessageHandling.h
@@ -27,4 +27,8 @@ public:
 
 private:
   CApplication& m_app;
+
+#ifdef TARGET_ANDROID
+  bool m_androidSkinUnloadedForDisplayDestroy{false};
+#endif
 };

--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -230,7 +230,15 @@ void CApplicationSkinHandling::UnloadSkin()
     return;
 
   std::shared_ptr<ADDON::CSkinInfo> skin = gui->GetSkinInfo();
-  if (skin && m_saveSkinOnUnloading)
+  if (!skin)
+  {
+    if (!m_saveSkinOnUnloading)
+      m_saveSkinOnUnloading = true;
+
+    return;
+  }
+
+  if (m_saveSkinOnUnloading)
     skin->SaveSettings();
   else if (!m_saveSkinOnUnloading)
     m_saveSkinOnUnloading = true;

--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -1742,10 +1742,8 @@ void CXBMCApp::surfaceCreated(CJNISurfaceHolder holder)
 void CXBMCApp::surfaceDestroyed(CJNISurfaceHolder holder)
 {
   android_printf("CXBMCApp::%s", __FUNCTION__);
+
   // If we have exited XBMC, it no longer exists.
-  auto& components = CServiceBroker::GetAppComponents();
-  const auto appPower = components.GetComponent<CApplicationPowerHandling>();
-  appPower->SetRenderGUI(false);
   if (!m_exiting)
     XBMC_DestroyDisplay();
 

--- a/xbmc/rendering/gles/RenderSystemGLES.cpp
+++ b/xbmc/rendering/gles/RenderSystemGLES.cpp
@@ -156,6 +156,9 @@ bool CRenderSystemGLES::ResetRenderSystem(int width, int height)
 
 bool CRenderSystemGLES::DestroyRenderSystem()
 {
+  if (!m_bRenderCreated)
+    return true;
+
   ResetScissors();
   CDirtyRegionList dirtyRegions;
   CDirtyRegion dirtyWindow(CServiceBroker::GetWinSystem()->GetGfxContext().GetViewWindow());

--- a/xbmc/windowing/android/WinSystemAndroid.cpp
+++ b/xbmc/windowing/android/WinSystemAndroid.cpp
@@ -149,6 +149,11 @@ bool CWinSystemAndroid::DestroyWindow()
   return true;
 }
 
+bool CWinSystemAndroid::DestroySurface()
+{
+  return true;
+}
+
 void CWinSystemAndroid::UpdateResolutions()
 {
   UpdateResolutions(true);

--- a/xbmc/windowing/android/WinSystemAndroid.h
+++ b/xbmc/windowing/android/WinSystemAndroid.h
@@ -36,6 +36,7 @@ public:
                        RESOLUTION_INFO& res) override;
 
   bool DestroyWindow() override;
+  virtual bool DestroySurface();
   void UpdateResolutions() override;
 
   void InitiateModeChange();

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -105,6 +105,20 @@ bool CWinSystemAndroidGLESContext::CreateNewWindow(const std::string& name,
   return true;
 }
 
+bool CWinSystemAndroidGLESContext::DestroyWindow()
+{
+  if (m_pGLContext.GetEGLSurface() != EGL_NO_SURFACE)
+    DestroySurface();
+
+  return CWinSystemAndroid::DestroyWindow();
+}
+
+bool CWinSystemAndroidGLESContext::DestroySurface()
+{
+  m_pGLContext.DestroySurface();
+  return true;
+}
+
 bool CWinSystemAndroidGLESContext::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
 {
   CRenderSystemGLES::ResetRenderSystem(newWidth, newHeight);
@@ -126,7 +140,7 @@ void CWinSystemAndroidGLESContext::SetVSyncImpl(bool enable)
 
 void CWinSystemAndroidGLESContext::PresentRenderImpl(bool rendered)
 {
-  if (!m_nativeWindow)
+  if (!m_nativeWindow || m_pGLContext.GetEGLSurface() == EGL_NO_SURFACE)
   {
     usleep(10000);
     return;

--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.h
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.h
@@ -31,6 +31,8 @@ public:
   bool CreateNewWindow(const std::string& name,
                        bool fullScreen,
                        RESOLUTION_INFO& res) override;
+  bool DestroyWindow() override;
+  bool DestroySurface() override;
 
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;


### PR DESCRIPTION
## Description

This PR addresses one Android teardown-ordering problem observed while
investigating #28481:

https://github.com/xbmc/xbmc/issues/28481

The issue is not fully solved by this PR. The broader Android process-lifetime
problem still exists. This change is intentionally narrower: it makes Kodi stop
GL/surface users on the Kodi application thread before releasing the Android EGL
surface, and restores the GUI resources again if the same surface loss happens
during a normal Home/background transition.

The crash path being investigated happens when exiting Kodi from the power menu
and relaunching quickly, especially on NVIDIA Shield. Android can begin Activity
surface teardown while Kodi is still unwinding playback/rendering resources. If
MediaCodec, GUI rendering, skin textures, or the GLES render system still touch
GL-backed state during that window, the process can crash during exit or quick
relaunch.

The Android display-destroy ordering is:

1. disable GUI rendering
2. close the active player
3. unload skin GL resources
4. destroy the GLES render system
5. release the Android EGL surface

The EGL surface release path is idempotent, so the later full application
cleanup can still run safely.

Because Android surface loss is not limited to Exit, this PR also handles the
normal Home/background case. If display destruction unloaded the skin, the next
Android display setup reloads the configured skin after the EGL/window setup
succeeds, then re-enables GUI rendering. This avoids leaving Kodi alive with a
new surface but no loaded GUI skin resources.

## Why this approach

The important part is ownership and thread ordering. Playback/rendering and
GLES resources are created and normally used from Kodi's application thread, so
the teardown is routed through the existing Kodi message path instead of doing
substantial cleanup directly from Android lifecycle callbacks.

This keeps `surfaceDestroyed` / display-destroy handling focused on resources
that are unsafe to use after the Android surface starts going away. It does not
try to redesign Kodi's whole Android process lifetime in this PR.

## Known limitation

Android's current `android_main()` still ends with `exit(0)`. That is not ideal
for Android, but it is existing behaviour and intentionally left unchanged here.

Removing `exit(0)` is a larger follow-up because Kodi currently tears down many
process/global services during Activity shutdown. Without a broader lifecycle
split, a quick relaunch can reuse `libkodi.so` in the same Linux process after
those globals have already been partially destroyed.

So this PR should be read as a targeted GL/surface teardown ordering fix for
#28481, not as the complete fix for Android Exit/relaunch lifecycle handling.

## Testing

Tested with a debug APK on Android emulator and NVIDIA Shield TV Pro:

- launch Kodi
- press Home
- relaunch Kodi from launcher
- repeat Home/relaunch several times
- Exit from Kodi power menu
- relaunch Kodi quickly

Expected ordering was verified in logcat:

- player/render users stop before EGL surface release
- skin unload runs on display destroy
- configured skin reloads after Android display setup on Home/resume
- later full cleanup does not double-unload the skin
- no GLES presentation after the EGL surface is gone

The existing HWUI/FORTIFY abort associated with Android `exit(0)` remains a
known pre-existing limitation and is not addressed by this PR.
