### PR TITLE
VideoPlayer: guard SetEnableStream() against stale stream IDs

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -486,6 +486,11 @@ int CSelectionStreams::TypeIndexOf(StreamType type, int source, int64_t demuxerI
     return -1;
 }
 
+bool CSelectionStreams::Contains(StreamType type, int source, int64_t demuxerId, int id) const
+{
+  return TypeIndexOf(type, source, demuxerId, id) >= 0;
+}
+
 int CSelectionStreams::Source(StreamSource source, const std::string& filename)
 {
   int index = source - 1;
@@ -3799,7 +3804,14 @@ void CVideoPlayer::SetSubtitleVisible(bool bVisible)
 
 void CVideoPlayer::SetEnableStream(CCurrentStream& current, bool isEnabled)
 {
-  if (m_pDemuxer && STREAM_SOURCE_MASK(current.source) == STREAM_SOURCE_DEMUX)
+  // Guard against stale stream IDs reaching the demuxer after a stream
+  // change. CloseStream() calls this method with stream identification coming
+  // from m_Current* members that may belong to a previous demuxer session.
+  // m_SelectionStreams mirrors the current demuxer's state, so a stale stream
+  // from a prior session won't be found and EnableStream() won't be called.
+
+  if (m_pDemuxer && STREAM_SOURCE_MASK(current.source) == STREAM_SOURCE_DEMUX &&
+      m_SelectionStreams.Contains(current.type, current.source, current.demuxerId, current.id))
     m_pDemuxer->EnableStream(current.demuxerId, current.id, isEnabled);
 }
 
@@ -4380,6 +4392,11 @@ bool CVideoPlayer::CloseStream(CCurrentStream& current, bool bWaitForBuffers)
 
   if(bWaitForBuffers)
     SetCaching(CACHESTATE_DONE);
+
+  // CloseStream() primarily closes a stream player. SetEnableStream()
+  // call below should be moved away from this method to the places where
+  // stream enable/disable is actually intended, avoiding stale stream
+  // identification from reaching the demuxer.
 
   SetEnableStream(current, false);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -217,6 +217,7 @@ public:
   CSelectionStreams() = default;
 
   int TypeIndexOf(StreamType type, int source, int64_t demuxerId, int id) const;
+  bool Contains(StreamType type, int source, int64_t demuxerId, int id) const;
   int CountTypeOfSource(StreamType type, StreamSource source) const;
   int CountType(StreamType type) const;
   SelectionStream& Get(StreamType type, int index);


### PR DESCRIPTION
## Description
When switching from one stream to another using inputstream.adaptive while playback is ongoing, the CVideoPlayer receives a PLAYER_OPENFILE message in HandleMessages() which Prepare() to reinitialize.

CVideoPlayer::Prepare() clears only the stream hints but preserves the stream identification fields (id, demuxerId, source) from the previous stream. When CVideoPlayer::OpenDefaultStreams() runs and finds no subtitle stream in the new session, it calls CloseStream(m_CurrentSubtitle, false) with the stale subtitle ID. This reaches the input stream addon's EnableStream() callback with an ID that now maps to a different stream type in the new session (e.g. video or audio).

The callstack is as following:
  * CVideoPlayer::HandleMessages()
  * CVideoPlayer::Prepare()
  * CVideoPlayer::OpenDefaultStreams(true)
  * CVideoPlayer::CloseStream(m_CurrentSubtitle, false) // stale id used
  * CDVDDemux::SetEnableStream(current, false)
  * CDVDDemuxClient::EnableStream(demuxerId, staleId, false)
  * CInputStreamAddon::EnableStream(staleId, false)

In inputstream.adaptive, this triggers CSession::EnableStream() on the wrong stream instance, causing CStream::Disable() to run and potentially disabling a video or audio stream that should remain active.

In the specific reproducing case, switching from a stream A to stream B:

  Stream type | Stream A | Stream B
  ------------|----------|----------
  Video       | ID 1005  | ID 1007
  Audio       | ID 1006  | ID 1008
  Subtitle    | ID 1007  | none

Since stream B has no subtitle streams, the subtitle for-loop at VideoPlayer.cpp:1071 is empty, m_CurrentSubtitle.id stays at 1007 from the stream A, and the CloseStream at line VideoPlayer.cpp:1098 fires with it. Line numbers are grabbed from the source code of this PR.

Fix this by adding a guard in SetEnableStream() that checks whether the stream still exists in m_SelectionStreams. A stale stream from a previous demuxer session will not be found, so EnableStream() won't be called.

Huge thanks to @FernetMenta for help in solving and diagnosing this issue!

## Motivation and context
Fix a bug where sometimes after switching streams using inputstream.adaptive, video was not played.

## How has this been tested?
I've found two streams which are reproducing the bug every time. After testing it with code in this PR, bug is no longer reproducible.

## What is the effect on users?
It should fix a bug when sometimes audio/video was not played when switching streams that use inputstream.adaptive.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
