### PR TITLE
depends: add gmp patch to fix compilation under gcc 15 due to missing function params in acinclude

### DIFF
--- a/tools/depends/target/gmp/0001-acinclude.m4-for-C23.patch
+++ b/tools/depends/target/gmp/0001-acinclude.m4-for-C23.patch
@@ -1,0 +1,51 @@
+From 9cd0c36d0110191a5f42e268d7bd21a95a2aa883 Mon Sep 17 00:00:00 2001
+From: Marc Glisse <marc.glisse@inria.fr>
+Date: Wed, 29 Jan 2025 22:38:02 +0100
+Subject: [PATCH] Complete function prototype in acinclude.m4 for C23
+ compatibility
+
+Add parameter names to function prototype
+
+Upstream: https://gmplib.org/repo/gmp/rev/d66d66d82dbb
+Upstream: https://gmplib.org/repo/gmp/rev/8e7bb4ae7a18
+Signed-off-by: Marc Glisse <marc.glisse@inria.fr>
+[Julien: git patch adapted from two upstream mercurial changesets]
+Signed-off-by: Julien Olivain <ju.o@free.fr>
+---
+ ChangeLog    | 9 +++++++++
+ acinclude.m4 | 2 +-
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/ChangeLog b/ChangeLog
+index 2902cd2..d808a8b 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,12 @@
++2025-03-15  Khem Raj <raj.khem@gmail.com>
++
++	* acinclude.m4: Add parameter names to function prototype.
++
++2025-01-29  Rudi Heitbaum <rudi@heitbaum.com>
++	    Marc Glisse <marc.glisse@inria.fr>
++
++	* acinclude.m4: Complete function prototype.
++
+ 2023-07-29  Torbjörn Granlund  <tg@gmplib.org>
+ 
+ 	* Version 6.3.0 released.
+diff --git a/acinclude.m4 b/acinclude.m4
+index 9cf9483..b79a431 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -609,7 +609,7 @@ GMP_PROG_CC_WORKS_PART([$1], [long long reliability test 1],
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int a,t1 const*b,t1 c,t2 d,t1 const*e,int f){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}
+-- 
+2.49.0
+

--- a/tools/depends/target/gmp/Makefile
+++ b/tools/depends/target/gmp/Makefile
@@ -1,5 +1,6 @@
 include ../../Makefile.include GMP-VERSION ../../download-files.include
-DEPS = ../../Makefile.include Makefile GMP-VERSION ../../download-files.include
+DEPS = ../../Makefile.include Makefile GMP-VERSION ../../download-files.include \
+                                       0001-acinclude.m4-for-C23.patch
 
 # ABI selection
 ifeq ($(OS),linux)
@@ -38,6 +39,8 @@ all: .installed-$(PLATFORM)
 $(PLATFORM)/config.status: $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../0001-acinclude.m4-for-C23.patch
+	cd $(PLATFORM); $(AUTORECONF) -vif
 	cd $(PLATFORM); $(CONFIGURE)
 
 $(LIBDYLIB): $(PLATFORM)/config.status


### PR DESCRIPTION
## Description
GMP on GCC 15 defaults to C23 but fails to compile as the definition of g{} is missing its parameters.

## Motivation and context
Fails to compile with GCC 15

## How has this been tested?
Compiling under GCC 15, webOS

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
