### PR TITLE
depends/target: update nettle to 4.0

### DIFF
--- a/tools/depends/target/nettle/01-disable_testsuite.patch
+++ b/tools/depends/target/nettle/01-disable_testsuite.patch
@@ -1,11 +1,13 @@
+diff --git a/Makefile.in b/Makefile.in
+index 93999850..484b5761 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -19,7 +19,7 @@
+@@ -20,7 +20,7 @@ OPT_NETTLE_SOURCES = @OPT_NETTLE_SOURCES@
+ FAT_OVERRIDE_LIST = @FAT_OVERRIDE_LIST@
+ FAT_EMULATE_LIST = @FAT_EMULATE_LIST@
  
- FAT_TEST_LIST = @FAT_TEST_LIST@
- 
--SUBDIRS = tools testsuite examples
-+SUBDIRS = tools examples
+-SUBDIRS = testsuite tools examples
++SUBDIRS = tools
  
  include config.make
  

--- a/tools/depends/target/nettle/Makefile
+++ b/tools/depends/target/nettle/Makefile
@@ -3,10 +3,10 @@ DEPS = ../../Makefile.include Makefile 01-disable_testsuite.patch ../../download
 
 # lib name, version
 LIBNAME=nettle
-VERSION=3.7.3
+VERSION=4.0
 SOURCE=$(LIBNAME)-$(VERSION)
 ARCHIVE=$(SOURCE).tar.gz
-SHA512=9901eba305421adff6d551ac7f478dff3f68a339d444c776724ab0b977fe6be792b1d2950c8705acbe76bd924fd6d898a65eded546777884be3b436d0e052437
+SHA512=833303d94f5a67094011ad4dd931fffdb9adf679b4df241a544a08194a66e6e449398b704ba5b29d52c1c3b5ada6f6dc18b24d1adb3382a68470a11645bf13cd
 include ../../download-files.include
 
 ifeq ($(OS),osx)


### PR DESCRIPTION
## Description
This updates nettle dependency. This is only required as a newer version is required by gnutls which fails to build under GCC 15.

Patch also updated to disable testsuite and examples.

## Motivation and context
Compiling under GCC 15 is currently broken

## How has this been tested?
On webOS 11, kodi opens and plays a video file.

## What is the effect on users?
None

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
