### PR TITLE
[VFS][Directory] Cache files found when scanning an archive to improve intra-archive subtitle scanning speed.

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2025,7 +2025,7 @@ int CUtil::ScanArchiveForAssociatedItems(const std::string& strArchivePath,
   else
     url = URIUtils::CreateArchivePath("archive", pathToUrl, "");
 
-  if (!CDirectory::GetDirectory(url, ItemList, "", DIR_FLAG_NO_FILE_DIRS))
+  if (!CDirectory::GetDirectory(url, ItemList, "", DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_FORCE_CACHE))
   {
     CLog::LogF(LOGDEBUG, "Failed to scan archive {}", CURL::GetRedacted(strArchivePath));
     return 0;

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -17,8 +17,6 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "commons/Exception.h"
-#include "dialogs/GUIDialogBusy.h"
-#include "guilib/GUIWindowManager.h"
 #include "jobs/Job.h"
 #include "jobs/JobManager.h"
 #include "messaging/ApplicationMessenger.h"
@@ -153,9 +151,20 @@ bool CDirectory::GetDirectory(const CURL& url, CFileItemList &items, const std::
   return GetDirectory(url, items, hints);
 }
 
-bool CDirectory::GetDirectory(const CURL& url, CFileItemList &items, const CHints &hints)
+bool CDirectory::GetDirectory(const CURL& url, CFileItemList& items, const CHints& hints)
 {
-  CURL realURL = URIUtils::SubstitutePath(url);
+  const CURL realURL = URIUtils::SubstitutePath(url);
+  // FORCE_CACHE flag bypasses the IDirectory creation (which is slow for rar:// archives) and uses the cache directly
+  // BYPASS_CACHE will override this
+  if ((hints.flags & DIR_FLAG_FORCE_CACHE) == DIR_FLAG_FORCE_CACHE &&
+      !(hints.flags & DIR_FLAG_BYPASS_CACHE) && hints.mask.empty() &&
+      g_directoryCache.GetDirectory(realURL, items, true))
+  {
+    items.SetURL(url);
+    PostProcessDirectory(url, realURL, items, hints);
+    return true;
+  }
+
   std::shared_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
   return CDirectory::GetDirectory(url, pDirectory, items, hints);
 }
@@ -167,7 +176,7 @@ bool CDirectory::GetDirectory(const CURL& url,
 {
   try
   {
-    CURL realURL = URIUtils::SubstitutePath(url);
+    const CURL realURL = URIUtils::SubstitutePath(url);
     if (!pDirectory)
       return false;
 
@@ -268,37 +277,8 @@ bool CDirectory::GetDirectory(const CURL& url,
         }
       }
     }
-    // filter hidden files
-    //! @todo we shouldn't be checking the gui setting here, callers should use getHidden instead
-    if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_SHOWHIDDEN) && !(hints.flags & DIR_FLAG_GET_HIDDEN))
-    {
-      for (int i = 0; i < items.Size(); ++i)
-      {
-        if (items[i]->GetProperty("file:hidden").asBoolean())
-        {
-          items.Remove(i);
-          i--; // don't confuse loop
-        }
-      }
-    }
 
-    //  Should any of the files we read be treated as a directory?
-    //  Disable for database folders, as they already contain the extracted items
-    if (!(hints.flags & DIR_FLAG_NO_FILE_DIRS) && !MUSIC::IsMusicDb(items) &&
-        !VIDEO::IsVideoDb(items) && !PLAYLIST::IsSmartPlayList(items))
-      FilterFileDirectories(items, hints.mask);
-
-    // Correct items for path substitution
-    const std::string pathToUrl(url.Get());
-    const std::string pathToUrl2(realURL.Get());
-    if (pathToUrl != pathToUrl2)
-    {
-      for (int i = 0; i < items.Size(); ++i)
-      {
-        CFileItemPtr item = items[i];
-        item->SetPath(URIUtils::SubstitutePath(item->GetPath(), true));
-      }
-    }
+    PostProcessDirectory(url, realURL, items, hints);
 
     return true;
   }
@@ -474,6 +454,46 @@ void CDirectory::FilterFileDirectories(CFileItemList &items, const std::string &
         items.Remove(i);
         i--; // don't confuse loop
       }
+    }
+  }
+}
+
+void CDirectory::PostProcessDirectory(const CURL& url,
+                                      const CURL& realUrl,
+                                      CFileItemList& items,
+                                      const CHints& hints)
+{
+  // filter hidden files
+  //! @todo we shouldn't be checking the gui setting here, callers should use getHidden instead
+  if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_FILELISTS_SHOWHIDDEN) &&
+      !(hints.flags & DIR_FLAG_GET_HIDDEN))
+  {
+    for (int i = 0; i < items.Size(); ++i)
+    {
+      if (items[i]->GetProperty("file:hidden").asBoolean())
+      {
+        items.Remove(i);
+        i--; // don't confuse loop
+      }
+    }
+  }
+
+  //  Should any of the files we read be treated as a directory?
+  //  Disable for database folders, as they already contain the extracted items
+  if (!(hints.flags & DIR_FLAG_NO_FILE_DIRS) && !MUSIC::IsMusicDb(items) &&
+      !VIDEO::IsVideoDb(items) && !PLAYLIST::IsSmartPlayList(items))
+    FilterFileDirectories(items, hints.mask);
+
+  // Correct items for path substitution
+  const std::string pathToUrl(url.Get());
+  const std::string pathToUrl2(realUrl.Get());
+  if (pathToUrl != pathToUrl2)
+  {
+    for (int i = 0; i < items.Size(); ++i)
+    {
+      CFileItemPtr item = items[i];
+      item->SetPath(URIUtils::SubstitutePath(item->GetPath(), true));
     }
   }
 }

--- a/xbmc/filesystem/Directory.h
+++ b/xbmc/filesystem/Directory.h
@@ -102,5 +102,11 @@ public:
   */
   static void FilterFileDirectories(CFileItemList &items, const std::string &mask,
                                     bool expandImages=false);
+
+private:
+  static void PostProcessDirectory(const CURL& url,
+                                   const CURL& realUrl,
+                                   CFileItemList& items,
+                                   const CHints& hints);
 };
 }

--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -10,6 +10,7 @@
 
 #include "AudioBookFileDirectory.h"
 #include "Directory.h"
+#include "DirectoryCache.h"
 #include "EpisodesDirectory.h"
 #include "FileItem.h"
 #if defined(HAS_ISO9660PP)
@@ -117,6 +118,17 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
               CURL itemUrl{item->GetPath()};
               if (URIUtils::HasParentInHostname(itemUrl))
                 item->SetPath(itemUrl.Get());
+            }
+
+            // Cache the archive listing so subsequent CDirectory::GetDirectory calls
+            // (e.g. from ScanArchiveForAssociatedItems) get a cache hit instead of
+            // re-opening the archive via the VFS addon
+            const std::string& archivePath = wrap->GetItems().GetPath();
+            constexpr int MAX_CACHE_ITEMS = 1000; // Don't cache very large archives
+            if (!archivePath.empty() && wrap->GetItems().Size() < MAX_CACHE_ITEMS)
+            {
+              const CURL realArchiveUrl{URIUtils::SubstitutePath(CURL{archivePath})};
+              g_directoryCache.SetDirectory(realArchiveUrl, wrap->GetItems(), CacheType::ONCE);
             }
 
             if (wrap->GetItems().Size() == 1)

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -45,7 +45,10 @@ enum DIR_FLAG
   DIR_FLAG_GET_HIDDEN = (2 << 3), ///< Get hidden files
   DIR_FLAG_READ_CACHE = (2 << 4), ///< Force reading from the directory cache (if available)
   DIR_FLAG_BYPASS_CACHE =
-      (2 << 5) ///< Completely bypass the directory cache (no reading, no writing)
+      (2 << 5), ///< Completely bypass the directory cache (no reading, no writing)
+  DIR_FLAG_FORCE_CACHE =
+      (2
+       << 6), ///< Force reading from the cache bypassing IDirectory creation (if cached and no mask is used)
 };
 /*!
  \ingroup filesystem


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Cache directory contents of archives.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Scanning within archives for external subtitles is slow.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

<img width="1846" height="206" alt="image" src="https://github.com/user-attachments/assets/91b8ab74-7100-44e9-b639-522c0a15c35b" />


Scanning single archive with single external subtitle. Three runs each.

Before
```
2026-06-26 17:58:07.583 T:13744    info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 25626 ms
2026-06-26 18:00:00.200 T:17072    info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 29221 ms
2026-06-26 18:01:21.859 T:16260    info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 30234 ms
```

After
```
2026-06-26 18:06:27.487 T:14816    info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 14633 ms
2026-06-26 18:07:26.172 T:4976     info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 5943 ms
2026-06-26 18:08:30.028 T:25240    info <general>: VideoInfoScanner: Finished scan. Scanning for video info took 7966 ms
```

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
