### PR TITLE
Format GUIWindowManager.cpp/h

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -75,7 +75,6 @@ struct InfoMap
 /// so we can use a link to point users when providing help
 ///
 
-
 /// \page modules__infolabels_boolean_conditions
 /// \section modules_list_infolabels_booleans List of Infolabels and Boolean conditions
 /// \subsection modules__infolabels_boolean_conditions_GlobalBools Global
@@ -10849,7 +10848,7 @@ void CGUIInfoManager::SplitInfoString(const std::string& infoString,
 
 /// \brief Translates a string as given by the skin into an int that we use for more
 /// efficient retrieval of data.
-int CGUIInfoManager::TranslateSingleString(const std::string &strCondition)
+int CGUIInfoManager::TranslateSingleString(const std::string& strCondition)
 {
   bool listItemDependent;
   return TranslateSingleString(strCondition, listItemDependent);
@@ -10883,7 +10882,7 @@ std::string TranslateListSeparator(const std::string& param)
 }
 } // unnamed namespace
 
-int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool &listItemDependent)
+int CGUIInfoManager::TranslateSingleString(const std::string& strCondition, bool& listItemDependent)
 {
   /* We need to disable caching in INFO::InfoBool::Get if either of the following are true:
    *  1. if condition is between LISTITEM_START and LISTITEM_END
@@ -10894,13 +10893,13 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
   std::string strTest = strCondition;
   StringUtils::Trim(strTest);
 
-  std::vector< Property> info;
+  std::vector<Property> info;
   SplitInfoString(strTest, info);
 
   if (info.empty())
     return 0;
 
-  const Property &cat = info[0];
+  const Property& cat = info[0];
   if (info.size() == 1)
   { // single category
     if (cat.Name() == "false" || cat.Name() == "no")
@@ -10910,12 +10909,13 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
   }
   else if (info.size() == 2)
   {
-    const Property &prop = info[1];
+    const Property& prop = info[1];
     if (cat.Name() == "string")
     {
       if (prop.Name() == "isempty")
       {
-        return AddMultiInfo(CGUIInfo(STRING_IS_EMPTY, TranslateSingleString(prop.param(), listItemDependent)));
+        return AddMultiInfo(
+            CGUIInfo(STRING_IS_EMPTY, TranslateSingleString(prop.param(), listItemDependent)));
       }
       else if (prop.num_params() == 2)
       {
@@ -11050,7 +11050,7 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
       }
       if (prop.num_params() == 1)
       {
-        const std::string &param = prop.param();
+        const std::string& param = prop.param();
         if (prop.Name() == "getbool")
         {
           std::string paramCopy = param;
@@ -11118,11 +11118,14 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         }
       }
       if (prop.Name() == "alarmlessorequal" && prop.num_params() == 2)
-        return AddMultiInfo(CGUIInfo(SYSTEM_ALARM_LESS_OR_EQUAL, prop.param(0), atoi(prop.param(1).c_str())));
+        return AddMultiInfo(
+            CGUIInfo(SYSTEM_ALARM_LESS_OR_EQUAL, prop.param(0), atoi(prop.param(1).c_str())));
       else if (prop.Name() == "date")
       {
         if (prop.num_params() == 2)
-          return AddMultiInfo(CGUIInfo(SYSTEM_DATE, StringUtils::DateStringToYYYYMMDD(prop.param(0)) % 10000, StringUtils::DateStringToYYYYMMDD(prop.param(1)) % 10000));
+          return AddMultiInfo(CGUIInfo(SYSTEM_DATE,
+                                       StringUtils::DateStringToYYYYMMDD(prop.param(0)) % 10000,
+                                       StringUtils::DateStringToYYYYMMDD(prop.param(1)) % 10000));
         else if (prop.num_params() == 1)
         {
           int dateformat = StringUtils::DateStringToYYYYMMDD(prop.param(0));
@@ -11141,11 +11144,13 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         {
           TIME_FORMAT timeFormat = TranslateTimeFormat(prop.param(0));
           if (timeFormat == TIME_FORMAT_GUESS)
-            return AddMultiInfo(CGUIInfo(SYSTEM_TIME, StringUtils::TimeStringToSeconds(prop.param(0))));
+            return AddMultiInfo(
+                CGUIInfo(SYSTEM_TIME, StringUtils::TimeStringToSeconds(prop.param(0))));
           return AddMultiInfo(CGUIInfo(SYSTEM_TIME, timeFormat));
         }
         else
-          return AddMultiInfo(CGUIInfo(SYSTEM_TIME, StringUtils::TimeStringToSeconds(prop.param(0)), StringUtils::TimeStringToSeconds(prop.param(1))));
+          return AddMultiInfo(CGUIInfo(SYSTEM_TIME, StringUtils::TimeStringToSeconds(prop.param(0)),
+                                       StringUtils::TimeStringToSeconds(prop.param(1))));
       }
     }
     else if (cat.Name() == "library")
@@ -11360,9 +11365,12 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         if (prop.Name() == "string")
         {
           if (prop.num_params() == 2)
-            return AddMultiInfo(CGUIInfo(SKIN_STRING_IS_EQUAL, CSkinSettings::GetInstance().TranslateString(prop.param(0)), prop.param(1)));
+            return AddMultiInfo(CGUIInfo(
+                SKIN_STRING_IS_EQUAL, CSkinSettings::GetInstance().TranslateString(prop.param(0)),
+                prop.param(1)));
           else
-            return AddMultiInfo(CGUIInfo(SKIN_STRING, CSkinSettings::GetInstance().TranslateString(prop.param(0))));
+            return AddMultiInfo(
+                CGUIInfo(SKIN_STRING, CSkinSettings::GetInstance().TranslateString(prop.param(0))));
         }
         else if (prop.Name() == "numeric")
         {
@@ -11370,7 +11378,8 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
               CGUIInfo(SKIN_INTEGER, CSkinSettings::GetInstance().TranslateString(prop.param(0))));
         }
         else if (prop.Name() == "hassetting")
-          return AddMultiInfo(CGUIInfo(SKIN_BOOL, CSkinSettings::GetInstance().TranslateBool(prop.param(0))));
+          return AddMultiInfo(
+              CGUIInfo(SKIN_BOOL, CSkinSettings::GetInstance().TranslateBool(prop.param(0))));
         else if (prop.Name() == "hastheme")
           return AddMultiInfo(CGUIInfo(SKIN_HAS_THEME, prop.param(0)));
         else if (prop.Name() == "timerisrunning")
@@ -11393,7 +11402,8 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
         { //! @todo The parameter for these should really be on the first not the second property
           if (prop.param().find("xml") != std::string::npos)
             return AddMultiInfo(CGUIInfo(window_bool.val, 0, prop.param()));
-          int winID = prop.param().empty() ? WINDOW_INVALID : CWindowTranslator::TranslateWindow(prop.param());
+          int winID = prop.param().empty() ? WINDOW_INVALID
+                                           : CWindowTranslator::TranslateWindow(prop.param());
           return AddMultiInfo(CGUIInfo(window_bool.val, winID, 0));
         }
       }
@@ -11415,7 +11425,8 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
     {
       int groupID = atoi(cat.param().c_str());
       if (groupID)
-        return AddMultiInfo(CGUIInfo(CONTROL_GROUP_HAS_FOCUS, groupID, atoi(prop.param(0).c_str())));
+        return AddMultiInfo(
+            CGUIInfo(CONTROL_GROUP_HAS_FOCUS, groupID, atoi(prop.param(0).c_str())));
     }
     else if (cat.Name() == "playlist")
     {
@@ -11558,14 +11569,15 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
     }
     else if (info[0].Name() == "control")
     {
-      const Property &prop = info[1];
+      const Property& prop = info[1];
       for (const auto& control_label : control_labels)
       {
         if (prop.Name() == control_label.str)
         { //! @todo The parameter for these should really be on the first not the second property
           int controlID = atoi(prop.param().c_str());
           if (controlID)
-            return AddMultiInfo(CGUIInfo(control_label.val, controlID, atoi(info[2].param(0).c_str())));
+            return AddMultiInfo(
+                CGUIInfo(control_label.val, controlID, atoi(info[2].param(0).c_str())));
           return 0;
         }
       }
@@ -11575,7 +11587,10 @@ int CGUIInfoManager::TranslateSingleString(const std::string &strCondition, bool
   return 0;
 }
 
-int CGUIInfoManager::TranslateListItem(const Property& cat, const Property& prop, int id, bool container)
+int CGUIInfoManager::TranslateListItem(const Property& cat,
+                                       const Property& prop,
+                                       int id,
+                                       bool container)
 {
   int ret = 0;
   std::string data3;
@@ -11673,7 +11688,7 @@ int CGUIInfoManager::TranslatePlayerString(std::string_view info) const
   return 0;
 }
 
-TIME_FORMAT CGUIInfoManager::TranslateTimeFormat(const std::string &format)
+TIME_FORMAT CGUIInfoManager::TranslateTimeFormat(const std::string& format)
 {
   if (format.empty())
     return TIME_FORMAT_GUESS;
@@ -11710,7 +11725,7 @@ TIME_FORMAT CGUIInfoManager::TranslateTimeFormat(const std::string &format)
   return TIME_FORMAT_GUESS;
 }
 
-std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *fallback) const
+std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string* fallback) const
 {
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
   {
@@ -11732,7 +11747,10 @@ std::string CGUIInfoManager::GetLabel(int info, int contextWindow, std::string *
   return strLabel;
 }
 
-bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUIListItem *item /* = nullptr */) const
+bool CGUIInfoManager::GetInt(int& value,
+                             int info,
+                             int contextWindow,
+                             const CGUIListItem* item /* = nullptr */) const
 {
   if (info >= MULTI_INFO_START && info <= MULTI_INFO_END)
   {
@@ -11753,7 +11771,7 @@ bool CGUIInfoManager::GetInt(int &value, int info, int contextWindow, const CGUI
   return m_infoProviders.GetInt(value, m_currentFile.get(), contextWindow, CGUIInfo(info));
 }
 
-INFO::InfoPtr CGUIInfoManager::Register(const std::string &expression, int context)
+INFO::InfoPtr CGUIInfoManager::Register(const std::string& expression, int context)
 {
   std::string condition(CGUIInfoLabel::ReplaceLocalize(expression));
   StringUtils::Trim(condition);
@@ -11791,7 +11809,7 @@ bool CGUIInfoManager::EvaluateBool(const std::string& expression,
   return false;
 }
 
-bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListItem *item)
+bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListItem* item)
 {
   bool bReturn = false;
   int condition = std::abs(condition1);
@@ -11821,7 +11839,9 @@ bool CGUIInfoManager::GetBool(int condition1, int contextWindow, const CGUIListI
   return (condition1 < 0) ? !bReturn : bReturn;
 }
 
-bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, const CGUIListItem *item)
+bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo& info,
+                                       int contextWindow,
+                                       const CGUIListItem* item)
 {
   bool bReturn = false;
   int condition = std::abs(info.GetInfo());
@@ -11831,7 +11851,8 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
     std::shared_ptr<CGUIListItem> itemPtr;
     if (!item)
     {
-      itemPtr = GUIINFO::GetCurrentListItem(contextWindow, info.GetData1(), info.GetData2(), info.GetInfoFlag());
+      itemPtr = GUIINFO::GetCurrentListItem(contextWindow, info.GetData1(), info.GetData2(),
+                                            info.GetInfoFlag());
       item = itemPtr.get();
     }
     if (item)
@@ -11970,7 +11991,10 @@ bool CGUIInfoManager::GetMultiInfoBool(const CGUIInfo &info, int contextWindow, 
   return (info.GetInfo() < 0) ? !bReturn : bReturn;
 }
 
-bool CGUIInfoManager::GetMultiInfoInt(int &value, const CGUIInfo &info, int contextWindow, const CGUIListItem *item) const
+bool CGUIInfoManager::GetMultiInfoInt(int& value,
+                                      const CGUIInfo& info,
+                                      int contextWindow,
+                                      const CGUIListItem* item) const
 {
   if (info.GetInfo() == INTEGER_VALUEOF)
   {
@@ -11982,7 +12006,8 @@ bool CGUIInfoManager::GetMultiInfoInt(int &value, const CGUIInfo &info, int cont
     std::shared_ptr<CGUIListItem> itemPtr;
     if (!item)
     {
-      itemPtr = GUIINFO::GetCurrentListItem(contextWindow, info.GetData1(), info.GetData2(), info.GetInfoFlag());
+      itemPtr = GUIINFO::GetCurrentListItem(contextWindow, info.GetData1(), info.GetData2(),
+                                            info.GetInfoFlag());
       item = itemPtr.get();
     }
     if (item)
@@ -12008,7 +12033,9 @@ bool CGUIInfoManager::GetMultiInfoInt(int &value, const CGUIInfo &info, int cont
   return m_infoProviders.GetInt(value, m_currentFile.get(), contextWindow, info);
 }
 
-std::string CGUIInfoManager::GetMultiInfoLabel(const CGUIInfo &constinfo, int contextWindow, std::string *fallback) const
+std::string CGUIInfoManager::GetMultiInfoLabel(const CGUIInfo& constinfo,
+                                               int contextWindow,
+                                               std::string* fallback) const
 {
   CGUIInfo info(constinfo);
 
@@ -12019,7 +12046,8 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const CGUIInfo &constinfo, int co
     if (item)
     {
       // Image prioritizes images over labels (in the case of music item ratings for instance)
-      return GetMultiInfoItemImage(dynamic_cast<CFileItem*>(item.get()), contextWindow, info, fallback);
+      return GetMultiInfoItemImage(dynamic_cast<CFileItem*>(item.get()), contextWindow, info,
+                                   fallback);
     }
     else
     {
@@ -12043,7 +12071,7 @@ std::string CGUIInfoManager::GetMultiInfoLabel(const CGUIInfo &constinfo, int co
 }
 
 /// \brief Obtains the filename of the image to show from whichever subsystem is needed
-std::string CGUIInfoManager::GetImage(int info, int contextWindow, std::string *fallback)
+std::string CGUIInfoManager::GetImage(int info, int contextWindow, std::string* fallback)
 {
   if (info >= CONDITIONAL_LABEL_START && info <= CONDITIONAL_LABEL_END)
   {
@@ -12053,11 +12081,8 @@ std::string CGUIInfoManager::GetImage(int info, int contextWindow, std::string *
   {
     return GetMultiInfoLabel(m_multiInfo[info - MULTI_INFO_START], contextWindow, fallback);
   }
-  else if (info == LISTITEM_THUMB ||
-           info == LISTITEM_ICON ||
-           info == LISTITEM_ACTUAL_ICON ||
-           info == LISTITEM_OVERLAY ||
-           info == LISTITEM_ART)
+  else if (info == LISTITEM_THUMB || info == LISTITEM_ICON || info == LISTITEM_ACTUAL_ICON ||
+           info == LISTITEM_OVERLAY || info == LISTITEM_ART)
   {
     const std::shared_ptr<CGUIListItem> item = GUIINFO::GetCurrentListItem(contextWindow);
     if (item && item->IsFileItem())
@@ -12073,12 +12098,12 @@ void CGUIInfoManager::ResetCurrentItem()
   m_infoProviders.InitCurrentItem(nullptr);
 }
 
-void CGUIInfoManager::UpdateCurrentItem(const CFileItem &item)
+void CGUIInfoManager::UpdateCurrentItem(const CFileItem& item)
 {
   m_currentFile->UpdateInfo(item);
 }
 
-void CGUIInfoManager::SetCurrentItem(const CFileItem &item)
+void CGUIInfoManager::SetCurrentItem(const CFileItem& item)
 {
   *m_currentFile = item;
   ART::FillInDefaultIcon(*m_currentFile);
@@ -12088,7 +12113,7 @@ void CGUIInfoManager::SetCurrentItem(const CFileItem &item)
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Info, "OnChanged");
 }
 
-void CGUIInfoManager::SetCurrentAlbumThumb(const std::string &thumbFileName)
+void CGUIInfoManager::SetCurrentAlbumThumb(const std::string& thumbFileName)
 {
   if (CFileUtils::Exists(thumbFileName))
     m_currentFile->SetArt("thumb", thumbFileName);
@@ -12113,7 +12138,7 @@ void CGUIInfoManager::Clear()
   do
   {
     swapList.clear();
-    for (auto &item : m_bools)
+    for (auto& item : m_bools)
       if (item.use_count() > 1)
         swapList.insert(item);
     m_bools.swap(swapList);
@@ -12143,7 +12168,7 @@ void CGUIInfoManager::UpdateAVInfo() const
   }
 }
 
-int CGUIInfoManager::AddMultiInfo(const CGUIInfo &info)
+int CGUIInfoManager::AddMultiInfo(const CGUIInfo& info)
 {
   // check to see if we have this info already
   for (unsigned int i = 0; i < m_multiInfo.size(); ++i)
@@ -12180,7 +12205,10 @@ bool CGUIInfoManager::IsListItemInfo(int info) const
   return (iResolvedInfo >= LISTITEM_START && iResolvedInfo <= LISTITEM_END);
 }
 
-bool CGUIInfoManager::GetItemInt(int &value, const CGUIListItem *item, int contextWindow, int info) const
+bool CGUIInfoManager::GetItemInt(int& value,
+                                 const CGUIListItem* item,
+                                 int contextWindow,
+                                 int info) const
 {
   value = 0;
 
@@ -12190,12 +12218,18 @@ bool CGUIInfoManager::GetItemInt(int &value, const CGUIListItem *item, int conte
   return m_infoProviders.GetInt(value, item, contextWindow, CGUIInfo(info));
 }
 
-std::string CGUIInfoManager::GetItemLabel(const CFileItem *item, int contextWindow, int info, std::string *fallback /* = nullptr */) const
+std::string CGUIInfoManager::GetItemLabel(const CFileItem* item,
+                                          int contextWindow,
+                                          int info,
+                                          std::string* fallback /* = nullptr */) const
 {
   return GetMultiInfoItemLabel(item, contextWindow, CGUIInfo(info), fallback);
 }
 
-std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback /* = nullptr */) const
+std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem* item,
+                                                   int contextWindow,
+                                                   const CGUIInfo& info,
+                                                   std::string* fallback /* = nullptr */) const
 {
   if (!item)
     return std::string();
@@ -12327,15 +12361,22 @@ std::string CGUIInfoManager::GetMultiInfoItemLabel(const CFileItem *item, int co
   return value;
 }
 
-std::string CGUIInfoManager::GetItemImage(const CGUIListItem *item, int contextWindow, int info, std::string *fallback /*= nullptr*/) const
+std::string CGUIInfoManager::GetItemImage(const CGUIListItem* item,
+                                          int contextWindow,
+                                          int info,
+                                          std::string* fallback /*= nullptr*/) const
 {
   if (!item || !item->IsFileItem())
     return std::string();
 
-  return GetMultiInfoItemImage(static_cast<const CFileItem*>(item), contextWindow, CGUIInfo(info), fallback);
+  return GetMultiInfoItemImage(static_cast<const CFileItem*>(item), contextWindow, CGUIInfo(info),
+                               fallback);
 }
 
-std::string CGUIInfoManager::GetMultiInfoItemImage(const CFileItem *item, int contextWindow, const CGUIInfo &info, std::string *fallback /*= nullptr*/) const
+std::string CGUIInfoManager::GetMultiInfoItemImage(const CFileItem* item,
+                                                   int contextWindow,
+                                                   const CGUIInfo& info,
+                                                   std::string* fallback /*= nullptr*/) const
 {
   if (info.GetInfo() >= CONDITIONAL_LABEL_START && info.GetInfo() <= CONDITIONAL_LABEL_END)
   {
@@ -12350,7 +12391,7 @@ std::string CGUIInfoManager::GetMultiInfoItemImage(const CFileItem *item, int co
   return GetMultiInfoItemLabel(item, contextWindow, info, fallback);
 }
 
-bool CGUIInfoManager::GetItemBool(const CGUIListItem *item, int contextWindow, int condition) const
+bool CGUIInfoManager::GetItemBool(const CGUIListItem* item, int contextWindow, int condition) const
 {
   if (!item)
     return false;
@@ -12388,7 +12429,7 @@ void CGUIInfoManager::ResetCache()
   ++m_refreshCounter;
 }
 
-void CGUIInfoManager::SetCurrentVideoTag(const CVideoInfoTag &tag)
+void CGUIInfoManager::SetCurrentVideoTag(const CVideoInfoTag& tag)
 {
   m_currentFile->SetFromVideoInfoTag(tag);
   m_currentFile->SetStartOffset(0);
@@ -12396,7 +12437,7 @@ void CGUIInfoManager::SetCurrentVideoTag(const CVideoInfoTag &tag)
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::Info, "OnChanged");
 }
 
-void CGUIInfoManager::SetCurrentSongTag(const MUSIC_INFO::CMusicInfoTag &tag)
+void CGUIInfoManager::SetCurrentSongTag(const MUSIC_INFO::CMusicInfoTag& tag)
 {
   m_currentFile->SetFromMusicInfoTag(tag);
   m_currentFile->SetStartOffset(0);
@@ -12481,51 +12522,51 @@ void CGUIInfoManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg)
 {
   switch (pMsg->dwMessage)
   {
-  case TMSG_GUI_INFOLABEL:
-  {
-    if (pMsg->lpVoid)
+    case TMSG_GUI_INFOLABEL:
     {
-      auto infoLabels = static_cast<std::vector<std::string>*>(pMsg->lpVoid);
-      for (const auto& param : pMsg->params)
-        infoLabels->emplace_back(GetLabel(TranslateString(param), DEFAULT_CONTEXT));
+      if (pMsg->lpVoid)
+      {
+        auto infoLabels = static_cast<std::vector<std::string>*>(pMsg->lpVoid);
+        for (const auto& param : pMsg->params)
+          infoLabels->emplace_back(GetLabel(TranslateString(param), DEFAULT_CONTEXT));
+      }
     }
-  }
-  break;
-
-  case TMSG_GUI_INFOBOOL:
-  {
-    if (pMsg->lpVoid)
-    {
-      auto infoLabels = static_cast<std::vector<bool>*>(pMsg->lpVoid);
-      for (const auto& param : pMsg->params)
-        infoLabels->push_back(EvaluateBool(param, DEFAULT_CONTEXT));
-    }
-  }
-  break;
-
-  case TMSG_UPDATE_CURRENT_ITEM:
-  {
-    auto* item{static_cast<CFileItem*>(pMsg->lpVoid)};
-    if (!item)
-      return;
-
-    if (pMsg->param1 == 1 && item->HasMusicInfoTag()) // only grab music tag
-      SetCurrentSongTag(*item->GetMusicInfoTag());
-    else if (pMsg->param1 == 2 && item->HasVideoInfoTag()) // only grab video tag
-      SetCurrentVideoTag(*item->GetVideoInfoTag());
-    else
-      SetCurrentItem(*item);
-
-    delete item;
-  }
-  break;
-
-  default:
     break;
+
+    case TMSG_GUI_INFOBOOL:
+    {
+      if (pMsg->lpVoid)
+      {
+        auto infoLabels = static_cast<std::vector<bool>*>(pMsg->lpVoid);
+        for (const auto& param : pMsg->params)
+          infoLabels->push_back(EvaluateBool(param, DEFAULT_CONTEXT));
+      }
+    }
+    break;
+
+    case TMSG_UPDATE_CURRENT_ITEM:
+    {
+      auto* item{static_cast<CFileItem*>(pMsg->lpVoid)};
+      if (!item)
+        return;
+
+      if (pMsg->param1 == 1 && item->HasMusicInfoTag()) // only grab music tag
+        SetCurrentSongTag(*item->GetMusicInfoTag());
+      else if (pMsg->param1 == 2 && item->HasVideoInfoTag()) // only grab video tag
+        SetCurrentVideoTag(*item->GetVideoInfoTag());
+      else
+        SetCurrentItem(*item);
+
+      delete item;
+    }
+    break;
+
+    default:
+      break;
   }
 }
 
-void CGUIInfoManager::RegisterInfoProvider(IGUIInfoProvider *provider)
+void CGUIInfoManager::RegisterInfoProvider(IGUIInfoProvider* provider)
 {
   if (!CServiceBroker::GetWinSystem())
     return;
@@ -12535,7 +12576,7 @@ void CGUIInfoManager::RegisterInfoProvider(IGUIInfoProvider *provider)
   m_infoProviders.RegisterProvider(provider, false);
 }
 
-void CGUIInfoManager::UnregisterInfoProvider(IGUIInfoProvider *provider)
+void CGUIInfoManager::UnregisterInfoProvider(IGUIInfoProvider* provider)
 {
   if (!CServiceBroker::GetWinSystem())
     return;

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -32,16 +32,16 @@ class CGameInfoTag;
 }
 namespace KODI::GUILIB::GUIINFO
 {
-  class CGUIInfo;
-  class IGUIInfoProvider;
-  } // namespace KODI::GUILIB::GUIINFO
+class CGUIInfo;
+class IGUIInfoProvider;
+} // namespace KODI::GUILIB::GUIINFO
 namespace INFO
 {
-  class InfoSingle;
+class InfoSingle;
 }
 namespace MUSIC_INFO
 {
-  class CMusicInfoTag;
+class CMusicInfoTag;
 }
 
 /*!
@@ -73,7 +73,7 @@ public:
    \param context the context window
    \return an identifier used to reference this expression
    */
-  INFO::InfoPtr Register(const std::string &expression, int context = 0);
+  INFO::InfoPtr Register(const std::string& expression, int context = 0);
 
   /*! \brief Unregister a boolean condition/expression
    * This routine allows controls or other clients of the info manager to unregister a previously registered
@@ -95,16 +95,22 @@ public:
                     int context,
                     const std::shared_ptr<CGUIListItem>& item = nullptr);
 
-  int TranslateString(const std::string &strCondition);
-  int TranslateSingleString(const std::string &strCondition, bool &listItemDependent);
+  int TranslateString(const std::string& strCondition);
+  int TranslateSingleString(const std::string& strCondition, bool& listItemDependent);
 
   std::string GetLabel(int info, int contextWindow, std::string* fallback = nullptr) const;
-  std::string GetImage(int info, int contextWindow, std::string *fallback = nullptr);
+  std::string GetImage(int info, int contextWindow, std::string* fallback = nullptr);
   bool GetInt(int& value, int info, int contextWindow, const CGUIListItem* item = nullptr) const;
   bool GetBool(int condition, int contextWindow, const CGUIListItem* item = nullptr);
 
-  std::string GetItemLabel(const CFileItem *item, int contextWindow, int info, std::string *fallback = nullptr) const;
-  std::string GetItemImage(const CGUIListItem *item, int contextWindow, int info, std::string *fallback = nullptr) const;
+  std::string GetItemLabel(const CFileItem* item,
+                           int contextWindow,
+                           int info,
+                           std::string* fallback = nullptr) const;
+  std::string GetItemImage(const CGUIListItem* item,
+                           int contextWindow,
+                           int info,
+                           std::string* fallback = nullptr) const;
   /*! \brief Get integer value of info.
    \param value int reference to pass value of given info
    \param info id of info
@@ -113,18 +119,18 @@ public:
    \return true if given info was handled
    \sa GetItemInt, GetMultiInfoInt
    */
-  bool GetItemInt(int &value, const CGUIListItem *item, int contextWindow, int info) const;
-  bool GetItemBool(const CGUIListItem *item, int contextWindow, int condition) const;
+  bool GetItemInt(int& value, const CGUIListItem* item, int contextWindow, int info) const;
+  bool GetItemBool(const CGUIListItem* item, int contextWindow, int condition) const;
 
   /*! \brief Set currently playing file item
    */
-  void SetCurrentItem(const CFileItem &item);
+  void SetCurrentItem(const CFileItem& item);
   void ResetCurrentItem();
-  void UpdateCurrentItem(const CFileItem &item);
+  void UpdateCurrentItem(const CFileItem& item);
 
   // Current song stuff
-  void SetCurrentAlbumThumb(const std::string &thumbFileName);
-  const MUSIC_INFO::CMusicInfoTag *GetCurrentSongTag() const;
+  void SetCurrentAlbumThumb(const std::string& thumbFileName);
+  const MUSIC_INFO::CMusicInfoTag* GetCurrentSongTag() const;
 
   // Current video stuff
   const CVideoInfoTag* GetCurrentMovieTag() const;
@@ -140,12 +146,12 @@ public:
   /*! \brief register a guiinfo provider
    \param the guiinfo provider to register
    */
-  void RegisterInfoProvider(KODI::GUILIB::GUIINFO::IGUIInfoProvider *provider);
+  void RegisterInfoProvider(KODI::GUILIB::GUIINFO::IGUIInfoProvider* provider);
 
   /*! \brief unregister a guiinfo provider
    \param the guiinfo provider to unregister
    */
-  void UnregisterInfoProvider(KODI::GUILIB::GUIINFO::IGUIInfoProvider *provider);
+  void UnregisterInfoProvider(KODI::GUILIB::GUIINFO::IGUIInfoProvider* provider);
 
   /*! \brief get access to the registered guiinfo providers
    \return the guiinfo providers
@@ -158,7 +164,7 @@ private:
   class Property
   {
   public:
-    Property(const std::string &property, const std::string &parameters);
+    Property(const std::string& property, const std::string& parameters);
 
     const std::string& Name() const { return m_name; }
 
@@ -182,32 +188,45 @@ private:
    */
   void SplitInfoString(const std::string& infoString, std::vector<Property>& info) const;
 
-  int TranslateSingleString(const std::string &strCondition);
+  int TranslateSingleString(const std::string& strCondition);
   int TranslateListItem(const Property& cat, const Property& prop, int id, bool container);
   int TranslateMusicPlayerString(std::string_view info) const;
   int TranslateVideoPlayerString(std::string_view info) const;
   int TranslatePlayerString(std::string_view info) const;
-  static TIME_FORMAT TranslateTimeFormat(const std::string &format);
+  static TIME_FORMAT TranslateTimeFormat(const std::string& format);
 
-  std::string GetMultiInfoLabel(const KODI::GUILIB::GUIINFO::CGUIInfo &info, int contextWindow, std::string *fallback = nullptr) const;
-  bool GetMultiInfoInt(int &value, const KODI::GUILIB::GUIINFO::CGUIInfo &info, int contextWindow, const CGUIListItem *item) const;
-  bool GetMultiInfoBool(const KODI::GUILIB::GUIINFO::CGUIInfo &info, int contextWindow, const CGUIListItem *item);
+  std::string GetMultiInfoLabel(const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                                int contextWindow,
+                                std::string* fallback = nullptr) const;
+  bool GetMultiInfoInt(int& value,
+                       const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                       int contextWindow,
+                       const CGUIListItem* item) const;
+  bool GetMultiInfoBool(const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                        int contextWindow,
+                        const CGUIListItem* item);
 
-  std::string GetMultiInfoItemLabel(const CFileItem *item, int contextWindow, const KODI::GUILIB::GUIINFO::CGUIInfo &info, std::string *fallback = nullptr) const;
-  std::string GetMultiInfoItemImage(const CFileItem *item, int contextWindow, const KODI::GUILIB::GUIINFO::CGUIInfo &info, std::string *fallback = nullptr) const;
+  std::string GetMultiInfoItemLabel(const CFileItem* item,
+                                    int contextWindow,
+                                    const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                                    std::string* fallback = nullptr) const;
+  std::string GetMultiInfoItemImage(const CFileItem* item,
+                                    int contextWindow,
+                                    const KODI::GUILIB::GUIINFO::CGUIInfo& info,
+                                    std::string* fallback = nullptr) const;
 
   std::string GetSkinVariableString(int info,
                                     int contextWindow,
                                     bool preferImage = false,
                                     const CGUIListItem* item = nullptr) const;
 
-  int AddMultiInfo(const KODI::GUILIB::GUIINFO::CGUIInfo &info);
+  int AddMultiInfo(const KODI::GUILIB::GUIINFO::CGUIInfo& info);
 
   int ResolveMultiInfo(int info) const;
   bool IsListItemInfo(int info) const;
 
-  void SetCurrentSongTag(const MUSIC_INFO::CMusicInfoTag &tag);
-  void SetCurrentVideoTag(const CVideoInfoTag &tag);
+  void SetCurrentSongTag(const MUSIC_INFO::CMusicInfoTag& tag);
+  void SetCurrentVideoTag(const CVideoInfoTag& tag);
 
   // Vector of multiple information mapped to a single integer lookup
   std::vector<KODI::GUILIB::GUIINFO::CGUIInfo> m_multiInfo;

--- a/xbmc/guilib/WindowIDs.h
+++ b/xbmc/guilib/WindowIDs.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+// No advantage to clobbering history when the formatted file is much less readable
+// clang-format off
+
 // Window ID defines to make the code a bit more readable
 #define WINDOW_INVALID                     9999 // do not change. value is used to avoid include in headers.
 #define WINDOW_HOME                       10000
@@ -206,3 +209,4 @@
 #define WINDOW_ADDON_START                14000
 #define WINDOW_ADDON_END                  14099
 
+// clang-format on


### PR DESCRIPTION
## Description

Formats GUIWindowManager.cpp/h.

## Motivation and context

The contributor behind https://github.com/xbmc/xbmc/pull/28496 got a messy diff because their tooling automatically formatted GUIWindowManager.cpp after a minor change.

## How has this been tested?

So I applied this change first, then soft-reset on top of it, and all of a sudden we had a beautiful diff with only green lines.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
