### PR TITLE
[BackgroundInfoLoader][windows] Prevent crash when exiting while a directory is still loading

### DIFF
--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -11,6 +11,7 @@
 #include "FileItem.h"
 #include "FileItemList.h"
 #include "URL.h"
+#include "application/Application.h"
 #include "threads/Thread.h"
 #include "utils/log.h"
 
@@ -92,6 +93,10 @@ void CBackgroundInfoLoader::Run()
 
 void CBackgroundInfoLoader::Load(CFileItemList& items)
 {
+  // Never start a background load while the application is shutting down.
+  if (g_application.IsStopping())
+    return;
+
   StopThread();
 
   if (items.IsEmpty())

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -363,6 +363,9 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
           CLog::Log(LOGWARNING, "CGUIMediaWindow::OnMessage - updating in progress");
           return true;
         }
+        if (g_application.IsStopping())
+          return true;
+
         CUpdateGuard ug(m_vecItemsUpdating);
         if (message.GetNumStringParams())
         {
@@ -546,6 +549,12 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
         SetInitialVisibility();
         return true;
       }
+
+      // Prevent the default CGUIWindow::OnMessage handler from running
+      // (which would call OnInitWindow -> Update -> GetDirectory) when the
+      // application is already shutting down.
+      if (g_application.IsStopping())
+        return true;
     }
     break;
   }
@@ -709,6 +718,10 @@ void CGUIMediaWindow::FormatAndSort(CFileItemList &items)
  */
 bool CGUIMediaWindow::GetDirectory(const std::string &strDirectory, CFileItemList &items)
 {
+  // Never allow a directory load once the application is shutting down.
+  if (g_application.IsStopping())
+    return false;
+
   CURL pathToUrl(strDirectory);
 
   std::string strParentPath = m_history.GetParentPath(strDirectory);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When Kodi exits while a media window is still loading a directory, or while a video is playing and the player closes, queued GUI messages can be processed after the shutdown sequence has begun. This causes a new GetDirectory call that accesses already‑destroyed subsystems, resulting in a segfault.

The fix adds g_application.IsStopping() guards in three places:
- CGUIMediaWindow::GetDirectory() – returns false immediately if the application is shutting down, preventing any directory load.
- CGUIMediaWindow::OnMessage() – the handlers for GUI_MSG_UPDATE and GUI_MSG_WINDOW_INIT now bail out early when IsStopping() is true, so they don’t trigger a refresh or window initialisation that would call GetDirectory.
- CBackgroundInfoLoader::Load() – refuses to start a new background loader thread after shutdown has begun, avoiding a new thread that would touch the job manager and texture database.

Since all media‑window GetDirectory methods (Videos, Music, Pictures, etc.) call the base CGUIMediaWindow::GetDirectory, this single guard protects every folder view from the same crash. The message‑handler guards in OnMessage cover all media windows as well.

The issue was reproduced in two ways: (1) exiting while browsing an inaccessible SMB share, and (2) exiting while a video from a network share was still playing. The underlying race can happen with any pending directory load or window activation during shutdown, so the fix is protocol‑independent.

The crash is timing‑dependent; it was consistently reproducible on one slow machine, but a faster error response (e.g., permission denied) can mask it. The guard is a safe, general protection against any late directory access.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Exiting Kodi while a directory was still being loaded, or after stopping a video, could produce a crash after Application stopped appeared. The crash occurred because GUI messages still queued at that moment triggered a late directory listing or window re‑initialisation, accessing objects that were already destroyed. The added guards block this late access and make the shutdown sequence safe.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In a Linux Kodi build (using a slow VM) - (1) exiting while browsing an inaccessible SMB share, and (2) exiting while a video file from an SMB share was playing. In both cases the exit had previously crashed; after applying the guards the exit completes cleanly and no crash occurs. Multiple repetitions showed consistent behaviour. Normal directory browsing and normal shutdown (without pending loads) are unaffected.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Exiting Kodi while a directory is loading or while a video is playing will no longer cause a crash. The shutdown is safe regardless of the type of source (local, SMB, NFS, etc.) or whether the exit is triggered during browsing or during playback. 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
