### PR TITLE
[Video] Fix bookmark not cleared when playback finished.

### DIFF
--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -23,7 +23,6 @@
 #include "guilib/GUIMessage.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/StereoscopicsManager.h"
-#include "interfaces/AnnouncementManager.h"
 #include "interfaces/python/XBPython.h"
 #include "jobs/JobManager.h"
 #include "music/MusicFileItemClassify.h"
@@ -273,6 +272,13 @@ bool UpdateDiscStackBookmark(CBookmark& bookmark,
   return true;
 }
 
+bool IsFinished(double timeInSeconds, double totalTimeInSeconds)
+{
+  // If the total time is unknown then we can't determine if finished
+  constexpr double FINISH_THRESHOLD{1.0}; // 1 second from end is considered finished
+  return totalTimeInSeconds > 0.0 && (totalTimeInSeconds - timeInSeconds) <= FINISH_THRESHOLD;
+}
+
 void UpdateStackAndItem(const CFileItem& file,
                         CFileItem& fileItem,
                         CBookmark& bookmark,
@@ -317,10 +323,8 @@ void UpdateStackAndItem(const CFileItem& file,
   }
   else
   {
-    constexpr double FINISH_THRESHOLD{1.0}; // 1 second from end is considered finished
-    const bool currentPartFinished{bookmark.timeInSeconds + FINISH_THRESHOLD >
-                                   bookmark.totalTimeInSeconds};
-    stackHelper->SetCurrentPartFinished(currentPartFinished);
+    stackHelper->SetCurrentPartFinished(
+        IsFinished(bookmark.timeInSeconds, bookmark.totalTimeInSeconds));
 
     ConvertRelativeStackTimesToAbsolute(bookmark, file, stackHelper);
   }
@@ -377,7 +381,8 @@ void CApplicationPlayerCallback::OnPlayerCloseFile(const CFileItem& file,
     if (stackHelper->GetStack(file) != nullptr)
       UpdateStackAndItem(file, fileItem, bookmark, stackHelper);
 
-    if (WithinPercentOfEnd(bookmark, advancedSettings->m_videoIgnorePercentAtEnd))
+    if (WithinPercentOfEnd(bookmark, advancedSettings->m_videoIgnorePercentAtEnd) ||
+        IsFinished(bookmark.timeInSeconds, bookmark.totalTimeInSeconds))
     {
       bookmark.timeInSeconds = -1.0; // Finished (bookmark cleared)
     }
@@ -388,9 +393,8 @@ void CApplicationPlayerCallback::OnPlayerCloseFile(const CFileItem& file,
   }
   else if (MUSIC::IsAudio(fileItem))
   {
-    if (bookmark.timeInSeconds >= bookmark.totalTimeInSeconds - 1)
+    if (IsFinished(bookmark.timeInSeconds, bookmark.totalTimeInSeconds))
     {
-      // If within 1 second of the end
       bookmark.timeInSeconds = -1.0; // Finished (bookmark cleared)
     }
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

When `<ignorepercentatend>0</ignorepercentatend>` is set the end of playback is not properly recognised and a bookmark is set regardless.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #28493

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Confirmed working by bug reporter.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
