### PR TITLE
Fix outdated watched/in progress status of movies/tv shows

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -394,14 +394,19 @@ bool CGUIMediaWindow::OnMessage(CGUIMessage& message)
         { // need to remove the disc cache
           CFileItemList items;
           items.SetPath(URIUtils::GetDirectory(newItem->GetPath()));
-          if (newItem->HasProperty("cachefilename"))
-          {
-            // Use stored cache file name
-            std::string crcfile = newItem->GetProperty("cachefilename").asString();
-            items.RemoveDiscCacheCRC(crcfile);
-          }
-          else
-            // No stored cache file name, attempt using truncated item path as list path
+
+          const bool hasCacheFilename = newItem->HasProperty("cachefilename");
+          const bool hasParentPath = newItem->HasProperty("ParentPath");
+
+          // Use the stored cache file name
+          if (hasCacheFilename)
+            items.RemoveDiscCacheCRC(newItem->GetProperty("cachefilename").asString());
+
+          if (hasParentPath)
+            RemoveDiscCache(newItem->GetProperty("ParentPath").asString());
+
+          // No stored cache file name or parent path, try the truncated item path as list path
+          if (!hasCacheFilename && !hasParentPath)
             items.RemoveDiscCache(GetID());
         }
       }
@@ -950,7 +955,7 @@ bool CGUIMediaWindow::Refresh(bool clearCache /* = false */)
     return false;
 
   if (clearCache)
-    m_vecItems->RemoveDiscCache(GetID());
+    RemoveDiscCache(strCurrentDirectory);
 
   bool ret = true;
 
@@ -2223,5 +2228,28 @@ bool CGUIMediaWindow::GetDirectoryItems(CURL &url, CFileItemList &items, bool us
   else
   {
     return m_rootDir.GetDirectory(url, items, useDir, false);
+  }
+}
+
+void CGUIMediaWindow::RemoveDiscCache(const std::string& directory) const
+{
+  CFileItemList items;
+  items.SetPath(directory);
+  items.RemoveDiscCache(GetID());
+
+  // Deeper clean when the window navigated the videodb directory
+  // There may be nested folders for movie sets or versions
+  if (!URIUtils::IsVideoDb(directory) || !m_history.IsInHistory(directory))
+    return;
+
+  CDirectoryHistory history = m_history;
+  for (std::string histPath = history.RemoveParentPath(); !histPath.empty();
+       histPath = history.RemoveParentPath())
+  {
+    if (histPath != directory)
+    {
+      items.SetPath(histPath);
+      items.RemoveDiscCache(GetID());
+    }
   }
 }

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -173,6 +173,12 @@ protected:
   static std::string RemoveParameterFromPath(const std::string &strDirectory, const std::string &strParameter);
 
   bool ProcessRenderLoop(bool renderOnly);
+
+  /*!
+   * \brief Helper function to remove the disc cache of <p> directory and possible dependencies
+   * \param[in] directory Directory
+   */
+  void RemoveDiscCache(const std::string& directory) const;
 
   XFILE::CVirtualDirectory m_rootDir;
   CGUIViewControl m_viewControl;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

There is a problem with the directory content cache files created for slow-loading directories (load time > 1s. Due to library size, slow device, remote db, ...).

While the cached data is removed correctly for the folder directly containing a modified item and stale data is avoided, that was not done for their "parent" folders.
That situation happens when playing/modifying items inside movie sets/versions folders or tv show episodes folders.

The PR cleans the cached data more thoroughly when items of the video db are modified.
No change for other types of items.
The navigation history of the media windows is used to determine the additional folders that need their cached data removed.

It's not ideal and does both too much and not enough, but works reasonably well and I didn't see other solutions that didn't require extensive changes.

existing out of scope bug: marking recently added/unwatched/random movies watched on the home page does not refresh media windows containing the movie refreshed. The announce mechanism doesn't provide enough information. The same action in a movie list or other media window works because the window itself has the context.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix long standing issue with libraries that need more than a second to load content lists (library size, external db, slow devices, ...)

To reproduce
1/ Go to the movies or TV Shows library
2/ Navigate into a movie set, folder of movie versions or list of episodes
3/ Play some/all movies/episodes of the folder
4/ The watched/in-progress indicator of the movie/episode changed > OK
5/ Return to the list of all movies or tv shows: the watched/in-progress indicator didn't change. 
If the unwatched display filter is on, the just-watched movies and shows did not disappear.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Movies and TV shows with a medium-size remote videodb.
Videos navigation not impacted at all.
To facilitate testing in a development environment, modified GUIMediaWindow to force the caching of all displayed directories

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Fixed movies and tv shows watched/in-progress status for libraries of a certain size or slow devices.
It was not refreshed after playing movies from a movie set or a versions directory or after playing episodes.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
