### PR TITLE
[Q*] RetroPlayer: Compress savestates with ZSTD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ dependent_option(ENABLE_INTERNAL_MARIADBCLIENT "Enable internal mariadb-c-connec
 dependent_option(ENABLE_INTERNAL_NLOHMANNJSON "Enable internal nlohmannjson?")
 dependent_option(ENABLE_INTERNAL_UDFREAD "Enable internal libudfread?")
 dependent_option(ENABLE_INTERNAL_XSLT "Enable internal libxslt?")
+dependent_option(ENABLE_INTERNAL_ZSTD "Enable internal Zstandard?")
 
 # If ENABLE_INTERNAL_FMT is ON, we force ENABLE_INTERNAL_SPDLOG ON as it has a hard
 # dependency on fmt

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -18927,7 +18927,25 @@ msgctxt "#35173"
 msgid "No controllers connected"
 msgstr ""
 
-#empty strings from id 35174 to 35199
+#. Group heading for saved game settings
+#: system/settings/settings.xml
+msgctxt "#35174"
+msgid "Saved Games"
+msgstr ""
+
+#. Setting name for compressing saved games
+#: system/settings/settings.xml
+msgctxt "#35175"
+msgid "Compress saved games"
+msgstr ""
+
+#. Description for the setting with label #35175 "Compress saved games"
+#: system/settings/settings.xml
+msgctxt "#35176"
+msgid "Compress saved games to reduce storage use. Compressed saved games cannot be opened in previous versions of Kodi."
+msgstr ""
+
+#empty strings from id 35177 to 35199
 
 #. This string is an early meme from the late 1990's that made fun of the poor translation in the 16-bit game Zero Wing from the late 1980's. DO NOT TRANSLATE!
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19425,13 +19425,7 @@ msgstr ""
 
 #empty strings from id 35281 to 35297
 
-#. Error message shown when trying to load a compressed savestate in an unsupported version of Kodi
-#: xbmc/games/dialogs/osd/DialogInGameSaves.cpp
-msgctxt "#35298"
-msgid "This savestate is compressed and can't be loaded by this version of Kodi."
-msgstr ""
-
-#empty strings from id 35299 to 35504
+#empty strings from id 35298 to 35504
 
 #. connection state "host unreachable"
 #: xbmc/pvr/addons/PVRClients.cpp

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -18990,7 +18990,25 @@ msgctxt "#35173"
 msgid "No controllers connected"
 msgstr ""
 
-#empty strings from id 35174 to 35199
+#. Group heading for saved game settings
+#: system/settings/settings.xml
+msgctxt "#35174"
+msgid "Saved Games"
+msgstr ""
+
+#. Setting name for compressing saved games
+#: system/settings/settings.xml
+msgctxt "#35175"
+msgid "Compress saved games"
+msgstr ""
+
+#. Description for the setting with label #35175 "Compress saved games"
+#: system/settings/settings.xml
+msgctxt "#35176"
+msgid "Compress saved games to reduce storage use. Compressed saved games cannot be opened in previous versions of Kodi."
+msgstr ""
+
+#empty strings from id 35177 to 35199
 
 #. This string is an early meme from the late 1990's that made fun of the poor translation in the 16-bit game Zero Wing from the late 1980's. DO NOT TRANSLATE!
 #: system/settings/settings.xml

--- a/cmake/modules/FindCurl.cmake
+++ b/cmake/modules/FindCurl.cmake
@@ -14,6 +14,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     find_package(Brotli REQUIRED ${SEARCH_QUIET})
     find_package(NGHttp2 REQUIRED ${SEARCH_QUIET})
     find_package(OpenSSL REQUIRED ${SEARCH_QUIET})
+    find_package(ZSTD REQUIRED ${SEARCH_QUIET})
 
     # Darwin platforms link against toolchain provided zlib regardless
     # They will fail when searching for static. All other platforms, prefer static
@@ -46,7 +47,7 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                    -DCURL_USE_OPENSSL=ON
                    -DOPENSSL_ROOT_DIR=${DEPENDS_PATH}
                    -DCURL_BROTLI=ON
-                   -DCURL_ZSTD=OFF
+                   -DCURL_ZSTD=ON
                    -DUSE_NGHTTP2=ON
                    -DUSE_LIBIDN2=OFF
                    -DCURL_USE_LIBSSH2=OFF
@@ -55,21 +56,37 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                    -DCURL_CA_FALLBACK=ON
                    ${OPTIONAL_ARGS})
 
+    # Curl runs its own FindZstd.cmake in the nested configure step, so pass the
+    # ZSTD include/library paths explicitly
+    get_target_property(ZSTD_INCLUDE_DIR LIBRARY::ZSTD ZSTD_INCLUDE_DIR)
+    get_target_property(ZSTD_LIBRARY LIBRARY::ZSTD ZSTD_LIBRARY)
+    if (ZSTD_INCLUDE_DIR)
+      list(APPEND CMAKE_ARGS -DZSTD_INCLUDE_DIR=${ZSTD_INCLUDE_DIR})
+    endif()
+    if (ZSTD_LIBRARY)
+      list(APPEND CMAKE_ARGS -DZSTD_LIBRARY=${ZSTD_LIBRARY})
+    endif()
+
     BUILD_DEP_TARGET()
+
+    unset(ZSTD_INCLUDE_DIR)
+    unset(ZSTD_LIBRARY)
 
     # Link libraries for target interface
     list(APPEND ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LINK_LIBRARIES LIBRARY::Brotli
                                                                     LIBRARY::NGHttp2
                                                                     OpenSSL::Crypto
                                                                     OpenSSL::SSL
-                                                                    LIBRARY::ZLIB)
+                                                                    LIBRARY::ZLIB
+                                                                    LIBRARY::ZSTD)
 
     # Add dependencies to build target
     add_dependencies(${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME} LIBRARY::Brotli
                                                                         LIBRARY::NGHttp2
                                                                         OpenSSL::SSL
                                                                         OpenSSL::Crypto
-                                                                        LIBRARY::ZLIB)
+                                                                        LIBRARY::ZLIB
+                                                                        LIBRARY::ZSTD)
   endmacro()
 
   # If there is a potential this library can be built internally
@@ -80,7 +97,8 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
     set(${CMAKE_FIND_PACKAGE_NAME}_DEPLIST Brotli
                                            NGHttp2
                                            OpenSSL
-                                           ZLIB)
+                                           ZLIB
+                                           ZSTD)
 
     check_dependency_build(${CMAKE_FIND_PACKAGE_NAME} "${${CMAKE_FIND_PACKAGE_NAME}_DEPLIST}")
   endif()

--- a/cmake/modules/FindMariaDBClient.cmake
+++ b/cmake/modules/FindMariaDBClient.cmake
@@ -73,7 +73,8 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                                -DCLIENT_PLUGIN_CACHING_SHA2_PASSWORD=STATIC
                                -DCLIENT_PLUGIN_MYSQL_CLEAR_PASSWORD=STATIC
                                -DCLIENT_PLUGIN_MYSQL_OLD_PASSWORD=STATIC
-                               -DCLIENT_PLUGIN_CLIENT_ED25519=STATIC)
+                               -DCLIENT_PLUGIN_CLIENT_ED25519=STATIC
+                               -DCLIENT_PLUGIN_ZSTD=OFF)
 
     # Disable GSSAPI authentication plugin (not widely used by Kodi users)
     list(APPEND CLIENT_PLUGINS -DCLIENT_PLUGIN_AUTH_GSSAPI_CLIENT=OFF)

--- a/cmake/modules/FindZSTD.cmake
+++ b/cmake/modules/FindZSTD.cmake
@@ -1,0 +1,79 @@
+#.rst:
+# FindZSTD
+# ----------
+# Finds the ZSTD library
+#
+# This will define the following target:
+#
+#   LIBRARY::ZSTD   - The App specific library dependency target
+#
+
+if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
+
+  macro(buildmacroZSTD)
+
+    if(CORE_SYSTEM_NAME STREQUAL android)
+      set(EXTRA_ARGS -DANDROID_PLATFORM_LEVEL=${TARGET_MINSDK})
+    endif()
+
+    set(CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+                   -DZSTD_BUILD_STATIC=ON
+                   -DZSTD_BUILD_SHARED=OFF
+                   -DZSTD_LEGACY_SUPPORT=OFF
+                   -DZSTD_BUILD_PROGRAMS=OFF
+                   -DZSTD_BUILD_TESTS=OFF
+                   ${EXTRA_ARGS})
+
+    # This can be removed when a release newer than 1.5.7 is bumped
+    set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_SOURCE_SUBDIR build/cmake)
+
+    BUILD_DEP_TARGET()
+  endmacro()
+
+  include(cmake/scripts/common/ModuleHelpers.cmake)
+
+  set(${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC zstd)
+
+  SETUP_BUILD_VARS()
+
+  SETUP_FIND_SPECS()
+
+  SEARCH_EXISTING_PACKAGES()
+
+  if(("${${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_VERSION}" VERSION_LESS ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER} AND ENABLE_INTERNAL_ZSTD) OR
+     (DEFINED ${CMAKE_FIND_PACKAGE_NAME}_FORCE_BUILD))
+    message(STATUS "Building ${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}: \(version \"${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER}\"\)")
+    cmake_language(EVAL CODE "
+      buildmacro${CMAKE_FIND_PACKAGE_NAME}()
+    ")
+  endif()
+
+  if(${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_FOUND)
+    if(TARGET zstd::libzstd AND NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      add_library(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ALIAS zstd::libzstd)
+    elseif(TARGET PkgConfig::${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME} AND NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      add_library(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ALIAS PkgConfig::${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME})
+    else()
+      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_TYPE LIBRARY)
+      SETUP_BUILD_TARGET()
+
+      add_dependencies(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+
+      # Set LIB_BUILD property to allow calling modules to know we will be building
+      set_target_properties(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES LIB_BUILD ON)
+
+      # Allow calling modules to use the include dir and library when building
+      # their own targets
+      set_target_properties(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+        ZSTD_INCLUDE_DIR "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR}"
+        ZSTD_LIBRARY "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY}"
+      )
+    endif()
+
+    ADD_MULTICONFIG_BUILDMACRO()
+  else()
+    if(ZSTD_FIND_REQUIRED)
+      message(FATAL_ERROR "ZSTD libraries were not found. Try -DENABLE_INTERNAL_ZSTD=ON")
+    endif()
+  endif()
+endif()

--- a/cmake/modules/FindZSTD.cmake
+++ b/cmake/modules/FindZSTD.cmake
@@ -1,0 +1,83 @@
+#.rst:
+# FindZSTD
+# ----------
+# Finds the ZSTD library
+#
+# This will define the following target:
+#
+#   LIBRARY::ZSTD   - The App specific library dependency target
+#
+
+if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
+
+  macro(buildmacroZSTD)
+
+    if(CORE_SYSTEM_NAME STREQUAL android)
+      set(EXTRA_ARGS -DANDROID_PLATFORM_LEVEL=${TARGET_MINSDK})
+    endif()
+
+    set(CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+                   -DZSTD_BUILD_STATIC=ON
+                   -DZSTD_BUILD_SHARED=OFF
+                   -DZSTD_LEGACY_SUPPORT=OFF
+                   -DZSTD_BUILD_PROGRAMS=OFF
+                   -DZSTD_BUILD_TESTS=OFF
+                   ${EXTRA_ARGS})
+
+    # This can be removed when a release newer than 1.5.7 is bumped
+    set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_SOURCE_SUBDIR build/cmake)
+
+    BUILD_DEP_TARGET()
+  endmacro()
+
+  include(cmake/scripts/common/ModuleHelpers.cmake)
+
+  set(${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC zstd)
+
+  SETUP_BUILD_VARS()
+
+  SETUP_FIND_SPECS()
+
+  SEARCH_EXISTING_PACKAGES()
+
+  if(("${${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_VERSION}" VERSION_LESS ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER} AND ENABLE_INTERNAL_ZSTD) OR
+     (DEFINED ${CMAKE_FIND_PACKAGE_NAME}_FORCE_BUILD))
+    message(STATUS "Building ${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}: \(version \"${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_VER}\"\)")
+    cmake_language(EVAL CODE "
+      buildmacro${CMAKE_FIND_PACKAGE_NAME}()
+    ")
+  endif()
+
+  if(${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME}_FOUND)
+    if(TARGET zstd::libzstd AND NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      add_library(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ALIAS zstd::libzstd)
+    elseif(TARGET zstd::libzstd_shared AND NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      add_library(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ALIAS zstd::libzstd_shared)
+    elseif(TARGET zstd::libzstd_static AND NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      add_library(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ALIAS zstd::libzstd_static)
+    elseif(TARGET PkgConfig::${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME} AND NOT TARGET ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+      add_library(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ALIAS PkgConfig::${${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME})
+    else()
+      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_TYPE LIBRARY)
+      SETUP_BUILD_TARGET()
+
+      add_dependencies(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_BUILD_NAME})
+
+      # Set LIB_BUILD property to allow calling modules to know we will be building
+      set_target_properties(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES LIB_BUILD ON)
+
+      # Allow calling modules to use the include dir and library when building
+      # their own targets
+      set_target_properties(LIBRARY::${CMAKE_FIND_PACKAGE_NAME} PROPERTIES
+        ZSTD_INCLUDE_DIR "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_INCLUDE_DIR}"
+        ZSTD_LIBRARY "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY}"
+      )
+    endif()
+
+    ADD_MULTICONFIG_BUILDMACRO()
+  else()
+    if(ZSTD_FIND_REQUIRED)
+      message(FATAL_ERROR "ZSTD libraries were not found. Try -DENABLE_INTERNAL_ZSTD=ON")
+    endif()
+  endif()
+endif()

--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -193,6 +193,7 @@ macro(CLEAR_BUILD_VARS)
   unset(CMAKE_ARGS)
   unset(PATCH_COMMAND)
   unset(CONFIGURE_COMMAND)
+  unset(SOURCE_SUBDIR)
   unset(BUILD_COMMAND)
   unset(INSTALL_COMMAND)
   unset(BUILD_IN_SOURCE)
@@ -366,6 +367,11 @@ macro(BUILD_DEP_TARGET)
     else()
       set(CONFIGURE_COMMAND CONFIGURE_COMMAND ${CONFIGURE_COMMAND})
     endif()
+  else()
+    # SOURCE_SUBDIR is only available when no CONFIGURE_COMMAND is provided
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_SOURCE_SUBDIR)
+      set(SOURCE_SUBDIR SOURCE_SUBDIR ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_SOURCE_SUBDIR})
+    endif()
   endif()
 
   if(BUILD_COMMAND)
@@ -521,6 +527,7 @@ macro(BUILD_DEP_TARGET)
                       ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_GENERATOR_PLATFORM}
                       ${PATCH_COMMAND}
                       ${CONFIGURE_COMMAND}
+                      ${SOURCE_SUBDIR}
                       ${BUILD_COMMAND}
                       ${INSTALL_COMMAND}
                       ${BUILD_BYPRODUCTS}

--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -193,6 +193,7 @@ macro(CLEAR_BUILD_VARS)
   unset(CMAKE_ARGS)
   unset(PATCH_COMMAND)
   unset(CONFIGURE_COMMAND)
+  unset(SOURCE_SUBDIR)
   unset(BUILD_COMMAND)
   unset(INSTALL_COMMAND)
   unset(BUILD_IN_SOURCE)
@@ -367,6 +368,11 @@ macro(BUILD_DEP_TARGET)
     else()
       set(CONFIGURE_COMMAND CONFIGURE_COMMAND ${CONFIGURE_COMMAND})
     endif()
+  else()
+    # SOURCE_SUBDIR is only available when no CONFIGURE_COMMAND is provided
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_SOURCE_SUBDIR)
+      set(SOURCE_SUBDIR SOURCE_SUBDIR ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_SOURCE_SUBDIR})
+    endif()
   endif()
 
   if(BUILD_COMMAND)
@@ -532,6 +538,7 @@ macro(BUILD_DEP_TARGET)
                       ${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_GENERATOR_PLATFORM}
                       ${PATCH_COMMAND}
                       ${CONFIGURE_COMMAND}
+                      ${SOURCE_SUBDIR}
                       ${BUILD_COMMAND}
                       ${INSTALL_COMMAND}
                       ${BUILD_BYPRODUCTS}

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2746,6 +2746,13 @@
           </control>
         </setting>
       </group>
+      <group id="2" label="35174">
+        <setting id="games.compresssavedgames" type="boolean" label="35175" help="35176">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
     </category>
     <category id="gamesachievements" label="15312">
       <group id="1" label="15313">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2784,6 +2784,13 @@
           </control>
         </setting>
       </group>
+      <group id="2" label="35174">
+        <setting id="games.compresssavedgames" type="boolean" label="35175" help="35176">
+          <level>0</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
+      </group>
     </category>
     <category id="gamesachievements" label="15312">
       <group id="1" label="15313">

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -153,7 +153,7 @@ download: $(DOWNLOAD_TARGETS)
 
 cec: p8-platform
 crossguid: $(LIBUUID)
-curl: brotli openssl nghttp2 $(ZLIB)
+curl: brotli openssl nghttp2 $(ZLIB) zstd
 dbus: expat
 exiv2: $(ICONV) $(ZLIB) expat
 ffmpeg: $(ICONV) $(ZLIB) bzip2 gnutls dav1d $(LIBVA)

--- a/tools/depends/target/Makefile
+++ b/tools/depends/target/Makefile
@@ -151,7 +151,7 @@ $(DOWNLOAD_TARGETS):
 download: $(DOWNLOAD_TARGETS)
 
 crossguid: $(LIBUUID)
-curl: brotli openssl nghttp2 $(ZLIB)
+curl: brotli openssl nghttp2 $(ZLIB) zstd
 dbus: expat
 exiv2: $(ICONV) $(ZLIB) expat
 ffmpeg: $(ICONV) $(ZLIB) bzip2 gnutls dav1d $(LIBVA)

--- a/tools/depends/target/curl/Makefile
+++ b/tools/depends/target/curl/Makefile
@@ -15,6 +15,7 @@ CMAKE_OPTIONS=-DCMAKE_INSTALL_PREFIX=$(PREFIX) \
               -DCURL_USE_OPENSSL=ON \
               -DOPENSSL_ROOT_DIR=$(PREFIX) \
               -DCURL_BROTLI=ON \
+              -DCURL_ZSTD=ON \
               -DUSE_NGHTTP2=ON \
               -DUSE_LIBIDN2=OFF \
               -DCURL_USE_LIBSSH2=OFF \

--- a/tools/depends/target/zstd/Makefile
+++ b/tools/depends/target/zstd/Makefile
@@ -1,0 +1,37 @@
+include ../../Makefile.include ZSTD-VERSION ../../download-files.include
+DEPS = ../../Makefile.include Makefile ZSTD-VERSION ../../download-files.include
+
+CMAKE_OPTIONS = -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_INSTALL_PREFIX=$(PREFIX) \
+                -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                -DZSTD_BUILD_STATIC=ON \
+                -DZSTD_BUILD_SHARED=OFF \
+                -DZSTD_LEGACY_SUPPORT=OFF \
+                -DZSTD_BUILD_PROGRAMS=OFF \
+                -DZSTD_BUILD_TESTS=OFF
+
+ifeq ($(OS),android)
+  CMAKE_OPTIONS+= -DANDROID_PLATFORM_LEVEL=$(NDK_LEVEL)
+endif
+
+LIBDYLIB=$(PLATFORM)/build/lib/$(BYPRODUCT)
+
+all: .installed-$(PLATFORM)
+
+$(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
+	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)/build-dir
+	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM)/build-dir; $(CMAKE) ${CMAKE_OPTIONS} -B . -S ../build/cmake
+
+$(LIBDYLIB): $(PLATFORM)
+	$(MAKE) -C $(PLATFORM)/build-dir
+
+.installed-$(PLATFORM): $(LIBDYLIB)
+	$(MAKE) -C $(PLATFORM)/build-dir install
+	touch $@
+
+clean:
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)
+
+distclean::
+	rm -rf $(PLATFORM) .installed-$(PLATFORM)

--- a/tools/depends/target/zstd/ZSTD-VERSION
+++ b/tools/depends/target/zstd/ZSTD-VERSION
@@ -1,0 +1,8 @@
+LIBNAME=zstd
+VERSION=1.5.7
+ARCHIVE=$(LIBNAME)-$(VERSION).tar.gz
+SHA512=b4de208f179b68d4c6454139ca60d66ed3ef3893a560d6159a056640f83d3ee67cdf6ffb88971cdba35449dba4b597eaa8b4ae908127ef7fd58c89f40bf9a705
+BYPRODUCT=libzstd.a
+BYPRODUCT_WIN=zstd_static.lib
+
+FULL_URL=https://github.com/facebook/zstd/releases/download/v$(VERSION)/zstd-$(VERSION).tar.gz

--- a/xbmc/cores/RetroPlayer/messages/savestate.fbs
+++ b/xbmc/cores/RetroPlayer/messages/savestate.fbs
@@ -11,7 +11,7 @@ include "video.fbs";
 namespace KODI.RETRO.SAVESTATE;
 
 // Savestate schema
-// Version 4
+// Version 5
 
 file_identifier "SAV_";
 
@@ -19,6 +19,11 @@ enum SaveType : uint8 {
   Unknown,
   Auto,
   Manual
+}
+
+enum CompressionType : uint8 {
+  None,
+  Zstd
 }
 
 table Savestate {
@@ -58,9 +63,15 @@ table Savestate {
   video_height:uint16 (id: 20);
   display_aspect_ratio:float (id: 23);
   rotation_ccw:VideoRotation (id: 21);
+  video_data_compressed:[uint8] (id: 27);
+  video_data_compression:CompressionType = None (id: 28);
+  video_data_uncompressed_size:uint64 = 0 (id: 29);
 
   // Memory properties
   memory_data:[uint8] (id: 10);
+  memory_data_compressed:[uint8] (id: 24);
+  memory_data_compression:CompressionType = None (id: 25);
+  memory_data_uncompressed_size:uint64 = 0 (id: 26);
 }
 
 root_type Savestate;

--- a/xbmc/cores/RetroPlayer/messages/savestate.fbs
+++ b/xbmc/cores/RetroPlayer/messages/savestate.fbs
@@ -23,6 +23,7 @@ enum SaveType : uint8 {
 
 enum CompressionType : uint8 {
   None,
+  Zstd,
 }
 
 table Savestate {

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -16,6 +16,9 @@
 #include "cores/RetroPlayer/rendering/RPRenderManager.h"
 #include "cores/RetroPlayer/savestates/ISavestate.h"
 #include "cores/RetroPlayer/savestates/SavestateDatabase.h"
+#include "cores/RetroPlayer/savestates/SavestateThumbnail.h"
+#include "cores/RetroPlayer/savestates/SavestateWriteQueue.h"
+#include "cores/RetroPlayer/savestates/SavestateWriteRequest.h"
 #include "cores/RetroPlayer/streams/memory/DeltaPairMemoryStream.h"
 #include "filesystem/File.h"
 #include "games/GameServices.h"
@@ -26,6 +29,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <cstring>
 #include <memory>
 #include <mutex>
 
@@ -45,7 +49,8 @@ CReversiblePlayback::CReversiblePlayback(GAME::CGameClient* gameClient,
     m_cheevos(cheevos),
     m_guiMessenger(guiMessenger),
     m_gameLoop(this, fps),
-    m_savestateDatabase(new CSavestateDatabase)
+    m_savestateDatabase(new CSavestateDatabase),
+    m_savestateWriteQueue(std::make_unique<CSavestateWriteQueue>(m_guiMessenger))
 {
   UpdateMemoryStream();
 
@@ -68,10 +73,8 @@ void CReversiblePlayback::Initialize()
 
 void CReversiblePlayback::Deinitialize()
 {
-  // Wait for autosave tasks
-  for (std::future<void>& task : m_savestateThreads)
-    task.wait();
-  m_savestateThreads.clear();
+  if (m_savestateWriteQueue)
+    m_savestateWriteQueue->Wait();
 
   m_gameLoop.Stop();
 }
@@ -167,53 +170,32 @@ std::string CReversiblePlayback::CreateSavestate(bool autosave,
   // Capture the current video frame
   m_renderManager.CacheVideoFrame(savePath);
 
-  {
-    std::unique_lock lock(m_savestateMutex);
+  std::optional<SavestateWriteRequest> request =
+      CaptureSavestateWriteRequest(autosave, savePath, nowUTC, timestampFrames);
+  if (!request)
+    return "";
 
-    // Prune any finished autosave threads
-    m_savestateThreads.erase(std::remove_if(m_savestateThreads.begin(), m_savestateThreads.end(),
-                                            [](std::future<void>& task) {
-                                              return task.wait_for(std::chrono::seconds(0)) ==
-                                                     std::future_status::ready;
-                                            }),
-                             m_savestateThreads.end());
-
-    // Save async to not block game loop
-    std::future<void> task =
-        std::async(std::launch::async, [this, autosave, savePath, nowUTC, timestampFrames]()
-                   { CommitSavestate(autosave, savePath, nowUTC, timestampFrames); });
-
-    m_savestateThreads.emplace_back(std::move(task));
-  }
+  m_savestateWriteQueue->QueueSavestateWrite(std::move(*request));
 
   return savePath;
 }
 
-void CReversiblePlayback::CommitSavestate(bool autosave,
-                                          const std::string& savePath,
-                                          const CDateTime& nowUTC,
-                                          uint64_t timestampFrames)
+std::optional<SavestateWriteRequest> CReversiblePlayback::CaptureSavestateWriteRequest(
+    bool autosave, const std::string& savePath, const CDateTime& nowUTC, uint64_t timestampFrames)
 {
   std::unique_ptr<ISavestate> savestate = CSavestateDatabase::AllocateSavestate();
   std::unique_ptr<ISavestate> loadedSavestate;
 
   const size_t memorySize = m_gameClient->SerializeSize();
-  uint8_t* const memoryData = savestate->GetMemoryBuffer(memorySize);
+  if (memorySize == 0)
+    return std::nullopt;
 
-  // Copy the savestate memory
-  {
-    std::unique_lock lock(m_mutex);
-    if (m_memoryStream && m_memoryStream->CurrentFrame() != nullptr)
-    {
-      std::memcpy(memoryData, m_memoryStream->CurrentFrame(), memorySize);
-    }
-    else
-    {
-      lock.unlock();
-      if (!m_gameClient->Serialize(memoryData, memorySize))
-        return;
-    }
-  }
+  uint8_t* const memoryData = savestate->GetMemoryBuffer(memorySize);
+  if (memoryData == nullptr)
+    return std::nullopt;
+
+  if (!m_gameClient->Serialize(memoryData, memorySize))
+    return std::nullopt;
 
   // Attempt to get existing properties
   {
@@ -246,22 +228,18 @@ void CReversiblePlayback::CommitSavestate(bool autosave,
 
   m_renderManager.SaveVideoFrame(savePath, *savestate);
 
-  savestate->Finalize();
+  const std::string thumbnailPath = CSavestateDatabase::MakeThumbnailPath(savePath);
+  std::optional<SavestateThumbnailPayload> thumbnail =
+      CreateSavestateThumbnailPayload(thumbnailPath, *savestate);
+  if (!thumbnail)
+    CLog::Log(LOGDEBUG, "RetroPlayer[SAVE]: No thumbnail captured for savestate {}", savePath);
 
-  bool success;
-  {
-    std::unique_lock lock(m_savestateMutex);
-    success = m_savestateDatabase->AddSavestate(savePath, m_gameClient->GetGamePath(), *savestate);
-  }
-
-  if (success)
-  {
-    std::string thumbnailPath = CSavestateDatabase::MakeThumbnailPath(savePath);
-    m_renderManager.SaveThumbnail(thumbnailPath);
-  }
-
-  // Notify the GUI that the metadata for this savestate should be refreshed
-  m_guiMessenger.RefreshSavestates(savePath, savestate.get());
+  return SavestateWriteRequest{
+      savePath,
+      m_gameClient->GetGamePath(),
+      std::move(savestate),
+      std::move(thumbnail),
+  };
 }
 
 bool CReversiblePlayback::LoadSavestate(const std::string& savestatePath)

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -277,10 +277,14 @@ bool CReversiblePlayback::LoadSavestate(const std::string& savestatePath)
   std::unique_ptr<ISavestate> savestate = CSavestateDatabase::AllocateSavestate();
   if (m_savestateDatabase->GetSavestate(savestatePath, *savestate))
   {
-    if (savestate->GetMemorySize() != memorySize)
+    if (!savestate->PrepareMemoryData(memorySize))
     {
-      CLog::Log(LOGERROR, "Invalid memory size, got {}, expected {}", memorySize,
-                savestate->GetMemorySize());
+      CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Failed to prepare memory data");
+    }
+    else if (savestate->GetMemorySize() != memorySize)
+    {
+      CLog::Log(LOGERROR, "Invalid memory size, got {}, expected {}", savestate->GetMemorySize(),
+                memorySize);
     }
     else
     {

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -24,6 +24,8 @@
 #include "games/GameServices.h"
 #include "games/GameSettings.h"
 #include "games/addons/GameClient.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/MathUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -234,11 +236,15 @@ std::optional<SavestateWriteRequest> CReversiblePlayback::CaptureSavestateWriteR
   if (!thumbnail)
     CLog::Log(LOGDEBUG, "RetroPlayer[SAVE]: No thumbnail captured for savestate {}", savePath);
 
+  const bool compressSavedGame = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+      CSettings::SETTING_GAMES_COMPRESSSAVEDGAMES);
+
   return SavestateWriteRequest{
       savePath,
       m_gameClient->GetGamePath(),
       std::move(savestate),
       std::move(thumbnail),
+      compressSavedGame,
   };
 }
 

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.h
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.h
@@ -13,8 +13,8 @@
 #include "threads/CriticalSection.h"
 #include "utils/Observer.h"
 
-#include <future>
 #include <memory>
+#include <optional>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -33,7 +33,9 @@ class CCheevos;
 class CGUIGameMessenger;
 class CRPRenderManager;
 class CSavestateDatabase;
+class CSavestateWriteQueue;
 class IMemoryStream;
+struct SavestateWriteRequest;
 
 class CReversiblePlayback : public IPlayback, public IGameLoopCallback, public Observer
 {
@@ -76,10 +78,10 @@ private:
   void AdvanceFrames(uint64_t frames);
   void UpdatePlaybackStats();
   void UpdateMemoryStream();
-  void CommitSavestate(bool autosave,
-                       const std::string& savePath,
-                       const CDateTime& nowUTC,
-                       uint64_t timestampFrames);
+  std::optional<SavestateWriteRequest> CaptureSavestateWriteRequest(bool autosave,
+                                                                    const std::string& savePath,
+                                                                    const CDateTime& nowUTC,
+                                                                    uint64_t timestampFrames);
 
   // Construction parameter
   GAME::CGameClient* const m_gameClient;
@@ -94,8 +96,8 @@ private:
 
   // Savestate functionality
   std::unique_ptr<CSavestateDatabase> m_savestateDatabase;
+  std::unique_ptr<CSavestateWriteQueue> m_savestateWriteQueue;
   std::string m_autosavePath{};
-  std::vector<std::future<void>> m_savestateThreads;
   CCriticalSection m_savestateMutex;
 
   // Playback stats

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -23,9 +23,9 @@
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPBaseRenderer.h"
 #include "cores/RetroPlayer/savestates/ISavestate.h"
 #include "cores/RetroPlayer/savestates/SavestateDatabase.h"
+#include "cores/RetroPlayer/savestates/SavestateThumbnail.h"
 #include "cores/RetroPlayer/streams/RetroPlayerVideo.h"
 #include "filesystem/File.h"
-#include "pictures/Picture.h"
 #include "threads/SingleLock.h"
 #include "utils/ColorUtils.h"
 #include "utils/TransformMatrix.h"
@@ -869,34 +869,15 @@ void CRPRenderManager::SaveThumbnail(const std::string& thumbnailPath)
     return;
   }
 
-  std::vector<uint8_t> copiedData(sourceData, sourceData + sourceSize);
+  SavestateThumbnailPayload payload;
+  payload.thumbnailPath = thumbnailPath;
+  payload.pixels.assign(sourceData, sourceData + sourceSize);
+  payload.width = width;
+  payload.height = height;
+  payload.rotationCCW = rotationCCW;
+  payload.pixelFormat = sourceFormat;
 
-  const int stride = CRenderTranslator::TranslateWidthToBytes(width, sourceFormat);
-
-  unsigned int scaleWidth = 400;
-  unsigned int scaleHeight = 220;
-  CPicture::GetScale(width, height, scaleWidth, scaleHeight);
-
-  const int bytesPerPixel = 4;
-  std::vector<uint8_t> scaledImage(scaleWidth * scaleHeight * bytesPerPixel);
-
-  const AVPixelFormat outFormat = AV_PIX_FMT_BGR0;
-  const int scaleStride = CRenderTranslator::TranslateWidthToBytes(scaleWidth, outFormat);
-
-  if (CPicture::ScaleImage(copiedData.data(), width, height, stride, sourceFormat,
-                           scaledImage.data(), scaleWidth, scaleHeight, scaleStride, outFormat))
-  {
-    //! @todo Rotate image by rotationCCW
-    (void)rotationCCW;
-
-    CPicture::CreateThumbnailFromSurface(scaledImage.data(), scaleWidth, scaleHeight, scaleStride,
-                                         thumbnailPath);
-  }
-  else
-  {
-    CLog::Log(LOGERROR, "Failed to scale image from size {}x{} to size {}x{}", width, height,
-              scaleWidth, scaleHeight);
-  }
+  WriteSavestateThumbnailPayload(payload);
 
   FreeVideoFrame(renderBuffer, std::move(cachedFrame));
 }

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -1070,6 +1070,12 @@ void CRPRenderManager::LoadVideoFrameSync(const std::string& savestatePath)
   if (!db.GetSavestate(savestatePath, *savestate))
     return;
 
+  if (!savestate->PrepareVideoData())
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Failed to prepare video data");
+    return;
+  }
+
   // Load video data
   const AVPixelFormat format = savestate->GetPixelFormat();
   const uint8_t* data = savestate->GetVideoData();

--- a/xbmc/cores/RetroPlayer/savestates/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/savestates/CMakeLists.txt
@@ -2,6 +2,8 @@ set(SOURCES SavestateDatabase.cpp
             SavestateBlob.cpp
             SavestateCompression.cpp
             SavestateFlatBuffer.cpp
+            SavestateThumbnail.cpp
+            SavestateWriteQueue.cpp
 )
 
 set(HEADERS ISavestate.h
@@ -9,7 +11,10 @@ set(HEADERS ISavestate.h
             SavestateCompression.h
             SavestateDatabase.h
             SavestateFlatBuffer.h
+            SavestateThumbnail.h
             SavestateTypes.h
+            SavestateWriteQueue.h
+            SavestateWriteRequest.h
 )
 
 core_add_library(retroplayer_savestates)

--- a/xbmc/cores/RetroPlayer/savestates/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/savestates/CMakeLists.txt
@@ -1,14 +1,19 @@
 set(SOURCES SavestateDatabase.cpp
+            SavestateBlob.cpp
+            SavestateCompression.cpp
             SavestateFlatBuffer.cpp
 )
 
 set(HEADERS ISavestate.h
+            SavestateBlob.h
+            SavestateCompression.h
             SavestateDatabase.h
             SavestateFlatBuffer.h
             SavestateTypes.h
 )
 
 core_add_library(retroplayer_savestates)
+target_link_libraries(${CORE_LIBRARY} PRIVATE LIBRARY::ZSTD)
 
 set(DEPENDS retroplayer_messages)
 

--- a/xbmc/cores/RetroPlayer/savestates/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/savestates/CMakeLists.txt
@@ -1,16 +1,19 @@
 set(SOURCES SavestateDatabase.cpp
             SavestateBlob.cpp
+            SavestateCompression.cpp
             SavestateFlatBuffer.cpp
 )
 
 set(HEADERS ISavestate.h
             SavestateBlob.h
+            SavestateCompression.h
             SavestateDatabase.h
             SavestateFlatBuffer.h
             SavestateTypes.h
 )
 
 core_add_library(retroplayer_savestates)
+target_link_libraries(${CORE_LIBRARY} PRIVATE LIBRARY::ZSTD)
 
 set(DEPENDS retroplayer_messages)
 

--- a/xbmc/cores/RetroPlayer/savestates/ISavestate.h
+++ b/xbmc/cores/RetroPlayer/savestates/ISavestate.h
@@ -227,7 +227,7 @@ public:
   virtual void SetDisplayAspectRatio(float displayAspectRatio) = 0;
   virtual void SetRotationDegCCW(unsigned int rotationCCW) = 0;
   virtual uint8_t* GetMemoryBuffer(size_t size) = 0;
-  virtual void Finalize() = 0;
+  virtual void Finalize(bool compress) = 0;
   ///}
 
   /*!

--- a/xbmc/cores/RetroPlayer/savestates/ISavestate.h
+++ b/xbmc/cores/RetroPlayer/savestates/ISavestate.h
@@ -148,6 +148,11 @@ public:
   virtual const uint8_t* GetVideoData() const = 0;
 
   /*!
+   * \brief Validate and prepare the frame's video data for reading
+   */
+  virtual bool PrepareVideoData() = 0;
+
+  /*!
    * \brief The size of the frame's video data, in bytes
    */
   virtual size_t GetVideoSize() const = 0;
@@ -183,9 +188,19 @@ public:
   virtual const uint8_t* GetMemoryData() const = 0;
 
   /*!
+   * \brief Validate and prepare the memory data for reading
+   */
+  virtual bool PrepareMemoryData(size_t expectedSize) = 0;
+
+  /*!
    * \brief The size of the memory region returned by GetMemoryData()
    */
   virtual size_t GetMemorySize() const = 0;
+
+  /*!
+   * \brief Copy the memory data to another savestate without requiring decompression
+   */
+  virtual bool CopyMemoryDataTo(ISavestate& target) const = 0;
   ///}
 
   /// @name Builders for setting individual fields

--- a/xbmc/cores/RetroPlayer/savestates/ISavestate.h
+++ b/xbmc/cores/RetroPlayer/savestates/ISavestate.h
@@ -232,7 +232,7 @@ public:
   virtual void SetDisplayAspectRatio(float displayAspectRatio) = 0;
   virtual void SetRotationDegCCW(unsigned int rotationCCW) = 0;
   virtual uint8_t* GetMemoryBuffer(size_t size) = 0;
-  virtual void Finalize() = 0;
+  virtual void Finalize(bool compress) = 0;
   ///}
 
   /*!

--- a/xbmc/cores/RetroPlayer/savestates/SavestateBlob.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateBlob.cpp
@@ -97,11 +97,12 @@ bool PendingSavestateBlob::HasCompressedData() const
 
 SavestateBlobOffsets CSavestateBlob::CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
                                                         const std::vector<uint8_t>& rawData,
-                                                        const char* fieldName)
+                                                        const char* fieldName,
+                                                        bool compress)
 {
   SavestateBlobOffsets offsets;
 
-  if (!rawData.empty())
+  if (compress && !rawData.empty())
   {
     std::vector<uint8_t> compressedData;
     if (CSavestateCompression::CompressZstdIfSmaller(rawData.data(), rawData.size(),
@@ -121,21 +122,38 @@ SavestateBlobOffsets CSavestateBlob::CreateWriteOffsets(flatbuffers::FlatBufferB
   }
 
   offsets.raw = builder.CreateVector(rawData);
+  offsets.compressionType = SAVESTATE::CompressionType_None;
+  offsets.uncompressedSize = 0;
   return offsets;
 }
 
 SavestateBlobOffsets CSavestateBlob::CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
                                                         const PendingSavestateBlob& pending,
-                                                        const char* fieldName)
+                                                        const char* fieldName,
+                                                        bool compress)
 {
+  if (!compress)
+  {
+    if (pending.raw.empty() && pending.HasCompressedData())
+    {
+      CLog::Log(LOGDEBUG,
+                "RetroPlayer[SAVE]: Preserving compressed {} because raw data is unavailable",
+                fieldName ? fieldName : "blob");
+    }
+    else
+    {
+      return CreateWriteOffsets(builder, pending.raw, fieldName, false);
+    }
+  }
+
   if (!pending.HasCompressedData())
-    return CreateWriteOffsets(builder, pending.raw, fieldName);
+    return CreateWriteOffsets(builder, pending.raw, fieldName, true);
 
   if (pending.uncompressedSize == 0 || pending.compressed.size() > pending.uncompressedSize)
   {
     CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed {} pending blob",
               fieldName ? fieldName : "blob");
-    return CreateWriteOffsets(builder, pending.raw, fieldName);
+    return CreateWriteOffsets(builder, pending.raw, fieldName, true);
   }
 
   SavestateBlobOffsets offsets;

--- a/xbmc/cores/RetroPlayer/savestates/SavestateBlob.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateBlob.cpp
@@ -1,0 +1,274 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SavestateBlob.h"
+
+#include "SavestateCompression.h"
+#include "utils/log.h"
+
+#include <limits>
+
+using namespace KODI;
+using namespace RETRO;
+
+namespace
+{
+constexpr size_t MAX_SAVESTATE_MEMORY_SIZE = 512 * 1024 * 1024;
+constexpr size_t MAX_SAVESTATE_VIDEO_SIZE = 128 * 1024 * 1024;
+
+bool GetVideoBytesPerPixel(SAVESTATE::PixelFormat pixelFormat, size_t& bytesPerPixel)
+{
+  switch (pixelFormat)
+  {
+    case SAVESTATE::PixelFormat_RGBA_8888:
+    case SAVESTATE::PixelFormat_XRGB_8888:
+    case SAVESTATE::PixelFormat_BGRX_8888:
+      bytesPerPixel = 4;
+      return true;
+
+    case SAVESTATE::PixelFormat_RGB_565_BE:
+    case SAVESTATE::PixelFormat_RGB_565_LE:
+    case SAVESTATE::PixelFormat_RGB_555_BE:
+    case SAVESTATE::PixelFormat_RGB_555_LE:
+      bytesPerPixel = 2;
+      return true;
+
+    default:
+      break;
+  }
+
+  return false;
+}
+
+bool GetPackedMinimumVideoSize(const SAVESTATE::Savestate& savestate, size_t& packedMinimumSize)
+{
+  const unsigned int width = savestate.video_width();
+  const unsigned int height = savestate.video_height();
+  size_t bytesPerPixel = 0;
+
+  if (width == 0 || height == 0 || !GetVideoBytesPerPixel(savestate.pixel_format(), bytesPerPixel))
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid video metadata in savestate");
+    return false;
+  }
+
+  if (width > std::numeric_limits<size_t>::max() / height)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Video dimensions overflow size calculation");
+    return false;
+  }
+
+  const size_t pixels = static_cast<size_t>(width) * height;
+  if (pixels > std::numeric_limits<size_t>::max() / bytesPerPixel)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Video size overflows size calculation");
+    return false;
+  }
+
+  packedMinimumSize = pixels * bytesPerPixel;
+  if (packedMinimumSize == 0 || packedMinimumSize > MAX_SAVESTATE_VIDEO_SIZE)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Video minimum size {} exceeds limit {}",
+              packedMinimumSize, MAX_SAVESTATE_VIDEO_SIZE);
+    return false;
+  }
+
+  return true;
+}
+} // namespace
+
+void PendingSavestateBlob::Clear()
+{
+  raw.clear();
+  compressed.clear();
+  uncompressedSize = 0;
+  compression = SAVESTATE::CompressionType_None;
+}
+
+bool PendingSavestateBlob::HasCompressedData() const
+{
+  return compression == SAVESTATE::CompressionType_Zstd && !compressed.empty();
+}
+
+SavestateBlobOffsets CSavestateBlob::CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
+                                                        const std::vector<uint8_t>& rawData,
+                                                        const char* fieldName)
+{
+  SavestateBlobOffsets offsets;
+
+  if (!rawData.empty())
+  {
+    std::vector<uint8_t> compressedData;
+    if (CSavestateCompression::CompressZstdIfSmaller(rawData.data(), rawData.size(),
+                                                     compressedData))
+    {
+      const std::vector<uint8_t> emptyData;
+      offsets.raw = builder.CreateVector(emptyData);
+      offsets.compressed = builder.CreateVector(compressedData);
+      offsets.compressionType = SAVESTATE::CompressionType_Zstd;
+      offsets.uncompressedSize = rawData.size();
+
+      CLog::Log(LOGDEBUG, "RetroPlayer[SAVE]: Compressed {} from {} to {} bytes using zstd",
+                fieldName ? fieldName : "blob", rawData.size(), compressedData.size());
+
+      return offsets;
+    }
+  }
+
+  offsets.raw = builder.CreateVector(rawData);
+  return offsets;
+}
+
+SavestateBlobOffsets CSavestateBlob::CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
+                                                        const PendingSavestateBlob& pending,
+                                                        const char* fieldName)
+{
+  if (!pending.HasCompressedData())
+    return CreateWriteOffsets(builder, pending.raw, fieldName);
+
+  if (pending.uncompressedSize == 0 || pending.compressed.size() > pending.uncompressedSize)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed {} pending blob",
+              fieldName ? fieldName : "blob");
+    return CreateWriteOffsets(builder, pending.raw, fieldName);
+  }
+
+  SavestateBlobOffsets offsets;
+  const std::vector<uint8_t> emptyData;
+  offsets.raw = builder.CreateVector(emptyData);
+  offsets.compressed = builder.CreateVector(pending.compressed);
+  offsets.compressionType = pending.compression;
+  offsets.uncompressedSize = pending.uncompressedSize;
+  return offsets;
+}
+
+bool CSavestateBlob::PrepareMemoryData(const SAVESTATE::Savestate& savestate,
+                                       size_t expectedSize,
+                                       std::vector<uint8_t>& decompressedMemoryData)
+{
+  decompressedMemoryData.clear();
+
+  if (!IsSupportedMemorySize(expectedSize))
+    return false;
+
+  if (savestate.memory_data_uncompressed_size() != expectedSize)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed memory size {}, expected {}",
+              savestate.memory_data_uncompressed_size(), expectedSize);
+    return false;
+  }
+
+  const auto* compressed = savestate.memory_data_compressed();
+  if (compressed == nullptr || compressed->size() == 0 || compressed->size() > expectedSize ||
+      compressed->size() > MAX_SAVESTATE_MEMORY_SIZE)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed memory data size");
+    return false;
+  }
+
+  decompressedMemoryData.resize(expectedSize);
+  if (!CSavestateCompression::DecompressZstd(compressed->data(), compressed->size(),
+                                             decompressedMemoryData.data(), expectedSize, "memory"))
+  {
+    decompressedMemoryData.clear();
+    return false;
+  }
+
+  return true;
+}
+
+bool CSavestateBlob::PrepareVideoData(const SAVESTATE::Savestate& savestate,
+                                      std::vector<uint8_t>& decompressedVideoData)
+{
+  decompressedVideoData.clear();
+
+  size_t packedMinimumSize = 0;
+  if (!GetPackedMinimumVideoSize(savestate, packedMinimumSize))
+    return false;
+
+  const uint64_t uncompressedSize = savestate.video_data_uncompressed_size();
+  if (uncompressedSize == 0 || uncompressedSize > MAX_SAVESTATE_VIDEO_SIZE ||
+      uncompressedSize < packedMinimumSize)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed video size {}", uncompressedSize);
+    return false;
+  }
+
+  const size_t expectedSize = static_cast<size_t>(uncompressedSize);
+  const auto* compressed = savestate.video_data_compressed();
+  if (compressed == nullptr || compressed->size() == 0 || compressed->size() > expectedSize ||
+      compressed->size() > MAX_SAVESTATE_VIDEO_SIZE)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed video data size");
+    return false;
+  }
+
+  decompressedVideoData.resize(expectedSize);
+  if (!CSavestateCompression::DecompressZstd(compressed->data(), compressed->size(),
+                                             decompressedVideoData.data(), expectedSize, "video"))
+  {
+    decompressedVideoData.clear();
+    return false;
+  }
+
+  return true;
+}
+
+bool CSavestateBlob::IsValidRawMemoryData(const SAVESTATE::Savestate& savestate,
+                                          size_t expectedSize)
+{
+  if (!IsSupportedMemorySize(expectedSize))
+    return false;
+
+  const auto* memoryData = savestate.memory_data();
+  return memoryData != nullptr && memoryData->size() == expectedSize;
+}
+
+bool CSavestateBlob::HasRawVideoData(const SAVESTATE::Savestate& savestate)
+{
+  return savestate.video_data() != nullptr && savestate.video_data()->size() > 0;
+}
+
+bool CSavestateBlob::IsValidCopiedCompressedMemoryData(const SAVESTATE::Savestate& savestate)
+{
+  const auto* compressed = savestate.memory_data_compressed();
+  const uint64_t uncompressedSize = savestate.memory_data_uncompressed_size();
+
+  if (compressed == nullptr || compressed->size() == 0 ||
+      compressed->size() > MAX_SAVESTATE_MEMORY_SIZE || uncompressedSize == 0 ||
+      uncompressedSize > MAX_SAVESTATE_MEMORY_SIZE || compressed->size() > uncompressedSize)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed memory data size");
+    return false;
+  }
+
+  return true;
+}
+
+bool CSavestateBlob::IsValidMemoryDataSize(size_t size)
+{
+  if (size > MAX_SAVESTATE_MEMORY_SIZE)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid memory data size");
+    return false;
+  }
+
+  return true;
+}
+
+bool CSavestateBlob::IsSupportedMemorySize(size_t expectedSize)
+{
+  if (expectedSize == 0 || expectedSize > MAX_SAVESTATE_MEMORY_SIZE)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid memory size {}, limit {}", expectedSize,
+              MAX_SAVESTATE_MEMORY_SIZE);
+    return false;
+  }
+
+  return true;
+}

--- a/xbmc/cores/RetroPlayer/savestates/SavestateBlob.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateBlob.cpp
@@ -126,11 +126,12 @@ bool PendingSavestateBlob::HasCompressedData() const
 
 SavestateBlobOffsets CSavestateBlob::CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
                                                         const std::vector<uint8_t>& rawData,
-                                                        const char* /* fieldName */)
+                                                        const char* fieldName,
+                                                        bool compress)
 {
   SavestateBlobOffsets offsets;
 
-  if (!rawData.empty())
+  if (compress && !rawData.empty())
   {
     std::vector<uint8_t> compressedData;
     if (CSavestateCompression::CompressZstdIfSmaller(rawData.data(), rawData.size(),
@@ -150,21 +151,38 @@ SavestateBlobOffsets CSavestateBlob::CreateWriteOffsets(flatbuffers::FlatBufferB
   }
 
   offsets.raw = builder.CreateVector(rawData);
+  offsets.compressionType = SAVESTATE::CompressionType_None;
+  offsets.uncompressedSize = 0;
   return offsets;
 }
 
 SavestateBlobOffsets CSavestateBlob::CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
                                                         const PendingSavestateBlob& pending,
-                                                        const char* fieldName)
+                                                        const char* fieldName,
+                                                        bool compress)
 {
+  if (!compress)
+  {
+    if (pending.raw.empty() && pending.HasCompressedData())
+    {
+      CLog::Log(LOGDEBUG,
+                "RetroPlayer[SAVE]: Preserving compressed {} because raw data is unavailable",
+                fieldName ? fieldName : "blob");
+    }
+    else
+    {
+      return CreateWriteOffsets(builder, pending.raw, fieldName, false);
+    }
+  }
+
   if (!pending.HasCompressedData())
-    return CreateWriteOffsets(builder, pending.raw, fieldName);
+    return CreateWriteOffsets(builder, pending.raw, fieldName, true);
 
   if (pending.uncompressedSize == 0 || pending.compressed.size() > pending.uncompressedSize)
   {
     CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed {} pending blob",
               fieldName ? fieldName : "blob");
-    return CreateWriteOffsets(builder, pending.raw, fieldName);
+    return CreateWriteOffsets(builder, pending.raw, fieldName, true);
   }
 
   SavestateBlobOffsets offsets;

--- a/xbmc/cores/RetroPlayer/savestates/SavestateBlob.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateBlob.cpp
@@ -8,6 +8,7 @@
 
 #include "SavestateBlob.h"
 
+#include "SavestateCompression.h"
 #include "utils/log.h"
 
 #include <limits>
@@ -110,11 +111,12 @@ void PendingSavestateBlob::Clear()
 
 bool PendingSavestateBlob::HasCompressedData() const
 {
-  //! @todo Add support for new compression types
   switch (compression)
   {
     case SAVESTATE::CompressionType_None:
       return false;
+    case SAVESTATE::CompressionType_Zstd:
+      return !compressed.empty();
     default:
       break;
   }
@@ -128,7 +130,24 @@ SavestateBlobOffsets CSavestateBlob::CreateWriteOffsets(flatbuffers::FlatBufferB
 {
   SavestateBlobOffsets offsets;
 
-  //! @todo Compress rawData with zstd if a smaller representation is available
+  if (!rawData.empty())
+  {
+    std::vector<uint8_t> compressedData;
+    if (CSavestateCompression::CompressZstdIfSmaller(rawData.data(), rawData.size(),
+                                                     compressedData))
+    {
+      const std::vector<uint8_t> emptyData;
+      offsets.raw = builder.CreateVector(emptyData);
+      offsets.compressed = builder.CreateVector(compressedData);
+      offsets.compressionType = SAVESTATE::CompressionType_Zstd;
+      offsets.uncompressedSize = rawData.size();
+
+      CLog::Log(LOGDEBUG, "RetroPlayer[SAVE]: Compressed {} from {} to {} bytes using zstd",
+                fieldName ? fieldName : "blob", rawData.size(), compressedData.size());
+
+      return offsets;
+    }
+  }
 
   offsets.raw = builder.CreateVector(rawData);
   return offsets;
@@ -186,10 +205,15 @@ bool CSavestateBlob::PrepareMemoryData(const SAVESTATE::Savestate& savestate,
     return false;
   }
 
-  //! @todo Decompress the memory data into decompressedMemoryData
-  CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Compressed memory data is not supported by this version");
+  decompressedMemoryData.resize(expectedSize);
+  if (!CSavestateCompression::DecompressZstd(compressed->data(), compressed->size(),
+                                             decompressedMemoryData.data(), expectedSize, "memory"))
+  {
+    decompressedMemoryData.clear();
+    return false;
+  }
 
-  return false;
+  return true;
 }
 
 bool CSavestateBlob::PrepareVideoData(const SAVESTATE::Savestate& savestate,
@@ -218,10 +242,15 @@ bool CSavestateBlob::PrepareVideoData(const SAVESTATE::Savestate& savestate,
     return false;
   }
 
-  //! @todo Decompress the video data into decompressedVideoData
+  decompressedVideoData.resize(expectedSize);
+  if (!CSavestateCompression::DecompressZstd(compressed->data(), compressed->size(),
+                                             decompressedVideoData.data(), expectedSize, "video"))
+  {
+    decompressedVideoData.clear();
+    return false;
+  }
 
-  CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Compressed video data is not supported by this version");
-  return false;
+  return true;
 }
 
 bool CSavestateBlob::IsValidRawMemoryData(const SAVESTATE::Savestate& savestate,

--- a/xbmc/cores/RetroPlayer/savestates/SavestateBlob.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateBlob.h
@@ -44,11 +44,13 @@ class CSavestateBlob
 public:
   static SavestateBlobOffsets CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
                                                  const std::vector<uint8_t>& rawData,
-                                                 const char* fieldName);
+                                                 const char* fieldName,
+                                                 bool compress);
 
   static SavestateBlobOffsets CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
                                                  const PendingSavestateBlob& pending,
-                                                 const char* fieldName);
+                                                 const char* fieldName,
+                                                 bool compress);
 
   static bool PrepareMemoryData(const SAVESTATE::Savestate& savestate,
                                 size_t expectedSize,

--- a/xbmc/cores/RetroPlayer/savestates/SavestateBlob.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateBlob.h
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "savestate_generated.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <flatbuffers/flatbuffers.h>
+
+namespace KODI
+{
+namespace RETRO
+{
+struct SavestateBlobOffsets
+{
+  flatbuffers::Offset<flatbuffers::Vector<uint8_t>> raw;
+  flatbuffers::Offset<flatbuffers::Vector<uint8_t>> compressed;
+  SAVESTATE::CompressionType compressionType{SAVESTATE::CompressionType_None};
+  uint64_t uncompressedSize{0};
+};
+
+struct PendingSavestateBlob
+{
+  std::vector<uint8_t> raw;
+  std::vector<uint8_t> compressed;
+  uint64_t uncompressedSize{0};
+  SAVESTATE::CompressionType compression{SAVESTATE::CompressionType_None};
+
+  void Clear();
+  bool HasCompressedData() const;
+};
+
+class CSavestateBlob
+{
+public:
+  static SavestateBlobOffsets CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
+                                                 const std::vector<uint8_t>& rawData,
+                                                 const char* fieldName);
+
+  static SavestateBlobOffsets CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
+                                                 const PendingSavestateBlob& pending,
+                                                 const char* fieldName);
+
+  static bool PrepareMemoryData(const SAVESTATE::Savestate& savestate,
+                                size_t expectedSize,
+                                std::vector<uint8_t>& decompressedMemoryData);
+
+  static bool PrepareVideoData(const SAVESTATE::Savestate& savestate,
+                               std::vector<uint8_t>& decompressedVideoData);
+
+  static bool IsValidRawMemoryData(const SAVESTATE::Savestate& savestate, size_t expectedSize);
+  static bool HasRawVideoData(const SAVESTATE::Savestate& savestate);
+  static bool IsValidCopiedCompressedMemoryData(const SAVESTATE::Savestate& savestate);
+  static bool IsValidMemoryDataSize(size_t size);
+  static bool IsSupportedMemorySize(size_t expectedSize);
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/cores/RetroPlayer/savestates/SavestateBlob.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateBlob.h
@@ -91,7 +91,8 @@ public:
    */
   static SavestateBlobOffsets CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
                                                  const std::vector<uint8_t>& rawData,
-                                                 const char* fieldName);
+                                                 const char* fieldName,
+                                                 bool compress);
 
   /*!
    * \brief Create FlatBuffer offsets for pending raw or compressed blob data
@@ -107,7 +108,8 @@ public:
    */
   static SavestateBlobOffsets CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
                                                  const PendingSavestateBlob& pending,
-                                                 const char* fieldName);
+                                                 const char* fieldName,
+                                                 bool compress);
 
   /*!
    * \brief Validate and prepare compressed memory data for reading

--- a/xbmc/cores/RetroPlayer/savestates/SavestateCompression.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateCompression.cpp
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SavestateCompression.h"
+
+#include "utils/log.h"
+
+#include <utility>
+
+#include <zstd.h>
+
+using namespace KODI;
+using namespace RETRO;
+
+bool CSavestateCompression::CompressZstdIfSmaller(const uint8_t* data,
+                                                  size_t size,
+                                                  std::vector<uint8_t>& compressed)
+{
+  compressed.clear();
+
+  if (data == nullptr || size == 0)
+    return false;
+
+  const size_t bound = ZSTD_compressBound(size);
+  std::vector<uint8_t> candidate(bound);
+
+  const size_t result =
+      ZSTD_compress(candidate.data(), candidate.size(), data, size, ZSTD_CLEVEL_DEFAULT);
+
+  if (ZSTD_isError(result))
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Zstd compression failed: {}",
+              ZSTD_getErrorName(result));
+    return false;
+  }
+
+  if (result == 0 || result >= size)
+    return false;
+
+  candidate.resize(result);
+  compressed = std::move(candidate);
+  return true;
+}
+
+bool CSavestateCompression::DecompressZstd(const uint8_t* compressedData,
+                                           size_t compressedSize,
+                                           uint8_t* outputData,
+                                           size_t expectedOutputSize,
+                                           const char* logContext)
+{
+  if (compressedData == nullptr || compressedSize == 0 || outputData == nullptr ||
+      expectedOutputSize == 0)
+  {
+    return false;
+  }
+
+  const char* context = logContext != nullptr ? logContext : "blob";
+  const size_t result =
+      ZSTD_decompress(outputData, expectedOutputSize, compressedData, compressedSize);
+
+  if (ZSTD_isError(result))
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Zstd {} decompression failed: {}", context,
+              ZSTD_getErrorName(result));
+    return false;
+  }
+
+  if (result != expectedOutputSize)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Zstd {} decompressed to {} bytes, expected {}", context,
+              result, expectedOutputSize);
+    return false;
+  }
+
+  return true;
+}

--- a/xbmc/cores/RetroPlayer/savestates/SavestateCompression.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateCompression.cpp
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SavestateCompression.h"
+
+#include "utils/log.h"
+
+#include <utility>
+
+#include <zstd.h>
+
+using namespace KODI;
+using namespace RETRO;
+
+bool CSavestateCompression::CompressZstdIfSmaller(const uint8_t* data,
+                                                  size_t size,
+                                                  std::vector<uint8_t>& compressed)
+{
+  compressed.clear();
+
+  if (data == nullptr || size == 0)
+    return false;
+
+  const size_t bound = ZSTD_compressBound(size);
+  std::vector<uint8_t> candidate(bound);
+
+  if (candidate.empty())
+    return false;
+
+  const size_t result =
+      ZSTD_compress(candidate.data(), candidate.size(), data, size, ZSTD_CLEVEL_DEFAULT);
+
+  if (ZSTD_isError(result))
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Zstd compression failed: {}",
+              ZSTD_getErrorName(result));
+    return false;
+  }
+
+  if (result == 0 || result >= size)
+    return false;
+
+  candidate.resize(result);
+  compressed = std::move(candidate);
+  return true;
+}
+
+bool CSavestateCompression::DecompressZstd(const uint8_t* compressedData,
+                                           size_t compressedSize,
+                                           uint8_t* outputData,
+                                           size_t expectedOutputSize,
+                                           const char* logContext)
+{
+  if (compressedData == nullptr || compressedSize == 0 || outputData == nullptr ||
+      expectedOutputSize == 0)
+  {
+    return false;
+  }
+
+  const char* context = logContext != nullptr ? logContext : "blob";
+  const size_t result =
+      ZSTD_decompress(outputData, expectedOutputSize, compressedData, compressedSize);
+
+  if (ZSTD_isError(result))
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Zstd {} decompression failed: {}", context,
+              ZSTD_getErrorName(result));
+    return false;
+  }
+
+  if (result != expectedOutputSize)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Zstd {} decompressed to {} bytes, expected {}", context,
+              result, expectedOutputSize);
+    return false;
+  }
+
+  return true;
+}

--- a/xbmc/cores/RetroPlayer/savestates/SavestateCompression.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateCompression.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace KODI
+{
+namespace RETRO
+{
+class CSavestateCompression
+{
+public:
+  static bool CompressZstdIfSmaller(const uint8_t* data,
+                                    size_t size,
+                                    std::vector<uint8_t>& compressed);
+
+  static bool DecompressZstd(const uint8_t* compressedData,
+                             size_t compressedSize,
+                             uint8_t* outputData,
+                             size_t expectedOutputSize,
+                             const char* logContext);
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -206,8 +206,8 @@ std::unique_ptr<ISavestate> CSavestateDatabase::RenameSavestate(const std::strin
   newSavestate->SetGameClientID(savestate->GameClientID());
   newSavestate->SetGameClientVersion(savestate->GameClientVersion());
 
-  size_t memorySize = savestate->GetMemorySize();
-  std::memcpy(newSavestate->GetMemoryBuffer(memorySize), savestate->GetMemoryData(), memorySize);
+  if (!savestate->CopyMemoryDataTo(*newSavestate))
+    return {};
 
   newSavestate->Finalize();
 

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -209,7 +209,10 @@ std::unique_ptr<ISavestate> CSavestateDatabase::RenameSavestate(const std::strin
   if (!savestate->CopyMemoryDataTo(*newSavestate))
     return {};
 
-  newSavestate->Finalize();
+  // Metadata-only saved-game rewrites may copy existing compressed payloads
+  // without raw data available. Keep compression enabled here so existing
+  // payloads are preserved.
+  newSavestate->Finalize(true);
 
   if (!AddSavestate(savestatePath, "", *newSavestate))
     return {};

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
@@ -659,15 +659,15 @@ uint8_t* CSavestateFlatBuffer::GetMemoryBuffer(size_t size)
   return m_memoryData.raw.empty() ? nullptr : m_memoryData.raw.data();
 }
 
-void CSavestateFlatBuffer::Finalize()
+void CSavestateFlatBuffer::Finalize(bool compress)
 {
   if (m_builder == nullptr)
     return;
 
   const SavestateBlobOffsets videoBlob =
-      CSavestateBlob::CreateWriteOffsets(*m_builder, m_videoData, "video_data");
+      CSavestateBlob::CreateWriteOffsets(*m_builder, m_videoData, "video_data", compress);
   const SavestateBlobOffsets memoryBlob =
-      CSavestateBlob::CreateWriteOffsets(*m_builder, m_memoryData, "memory_data");
+      CSavestateBlob::CreateWriteOffsets(*m_builder, m_memoryData, "memory_data", compress);
 
   // Helper class to build the nested Savestate table
   SAVESTATE::SavestateBuilder savestateBuilder(*m_builder);

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
@@ -389,7 +389,7 @@ AVPixelFormat CSavestateFlatBuffer::GetPixelFormat() const
   if (m_savestate != nullptr)
     return TranslatePixelFormat(m_savestate->pixel_format());
 
-  return AV_PIX_FMT_NONE;
+  return m_pixelFormat;
 }
 
 void CSavestateFlatBuffer::SetPixelFormat(AVPixelFormat pixelFormat)
@@ -470,6 +470,9 @@ const uint8_t* CSavestateFlatBuffer::GetVideoData() const
   if (m_savestate != nullptr && m_savestate->video_data())
     return m_savestate->video_data()->data();
 
+  if (!m_videoData.empty())
+    return m_videoData.data();
+
   return nullptr;
 }
 
@@ -501,6 +504,9 @@ size_t CSavestateFlatBuffer::GetVideoSize() const
   if (m_savestate != nullptr && m_savestate->video_data())
     return m_savestate->video_data()->size();
 
+  if (!m_videoData.empty())
+    return m_videoData.size();
+
   return 0;
 }
 
@@ -516,7 +522,7 @@ unsigned int CSavestateFlatBuffer::GetVideoWidth() const
   if (m_savestate != nullptr)
     return m_savestate->video_width();
 
-  return 0;
+  return m_videoWidth;
 }
 
 void CSavestateFlatBuffer::SetVideoWidth(unsigned int videoWidth)
@@ -529,7 +535,7 @@ unsigned int CSavestateFlatBuffer::GetVideoHeight() const
   if (m_savestate != nullptr)
     return m_savestate->video_height();
 
-  return 0;
+  return m_videoHeight;
 }
 
 void CSavestateFlatBuffer::SetVideoHeight(unsigned int videoHeight)
@@ -555,7 +561,7 @@ unsigned int CSavestateFlatBuffer::GetRotationDegCCW() const
   if (m_savestate != nullptr)
     return TranslateRotation(m_savestate->rotation_ccw());
 
-  return 0;
+  return m_rotationCCW;
 }
 
 void CSavestateFlatBuffer::SetRotationDegCCW(unsigned int rotationCCW)

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
@@ -8,6 +8,7 @@
 
 #include "SavestateFlatBuffer.h"
 
+#include "SavestateBlob.h"
 #include "XBDateTime.h"
 #include "savestate_generated.h"
 #include "utils/log.h"
@@ -20,7 +21,7 @@ using namespace RETRO;
 
 namespace
 {
-const uint8_t SCHEMA_VERSION = 3;
+const uint8_t SCHEMA_VERSION = 5;
 const uint8_t SCHEMA_MIN_VERSION = 1;
 
 /*!
@@ -183,6 +184,7 @@ unsigned int TranslateRotation(SAVESTATE::VideoRotation rotationCCW)
 
   return 0;
 }
+
 } // namespace
 
 CSavestateFlatBuffer::CSavestateFlatBuffer()
@@ -197,6 +199,31 @@ void CSavestateFlatBuffer::Reset()
   m_builder = std::make_unique<flatbuffers::FlatBufferBuilder>(INITIAL_FLATBUFFER_SIZE);
   m_data.clear();
   m_savestate = nullptr;
+
+  m_type = SAVE_TYPE::UNKNOWN;
+  m_slot = 0;
+  m_labelOffset.reset();
+  m_captionOffset.reset();
+  m_createdOffset.reset();
+  m_gameFileNameOffset.reset();
+  m_timestampFrames = 0;
+  m_timestampWallClock = 0.0;
+  m_emulatorAddonIdOffset.reset();
+  m_emulatorVersionOffset.reset();
+  m_pixelFormat = AV_PIX_FMT_NONE;
+  m_nominalWidth = 0;
+  m_nominalHeight = 0;
+  m_nominalDisplayAspectRatio = 0.0f;
+  m_maxWidth = 0;
+  m_maxHeight = 0;
+  m_videoData.clear();
+  m_videoDataDecompressed.clear();
+  m_videoWidth = 0;
+  m_videoHeight = 0;
+  m_displayAspectRatio = 0.0f;
+  m_rotationCCW = 0;
+  m_memoryData.Clear();
+  m_memoryDataDecompressed.clear();
 }
 
 bool CSavestateFlatBuffer::Serialize(const uint8_t*& data, size_t& size) const
@@ -437,14 +464,40 @@ void CSavestateFlatBuffer::SetMaxHeight(unsigned int maxHeight)
 
 const uint8_t* CSavestateFlatBuffer::GetVideoData() const
 {
+  if (!m_videoDataDecompressed.empty())
+    return m_videoDataDecompressed.data();
+
   if (m_savestate != nullptr && m_savestate->video_data())
     return m_savestate->video_data()->data();
 
   return nullptr;
 }
 
+bool CSavestateFlatBuffer::PrepareVideoData()
+{
+  m_videoDataDecompressed.clear();
+
+  if (m_savestate == nullptr)
+    return false;
+
+  if (m_savestate->video_data_compression() == SAVESTATE::CompressionType_Zstd)
+    return CSavestateBlob::PrepareVideoData(*m_savestate, m_videoDataDecompressed);
+
+  if (m_savestate->video_data_compression() != SAVESTATE::CompressionType_None)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Unsupported video compression type {}",
+              static_cast<unsigned int>(m_savestate->video_data_compression()));
+    return false;
+  }
+
+  return CSavestateBlob::HasRawVideoData(*m_savestate);
+}
+
 size_t CSavestateFlatBuffer::GetVideoSize() const
 {
+  if (!m_videoDataDecompressed.empty())
+    return m_videoDataDecompressed.size();
+
   if (m_savestate != nullptr && m_savestate->video_data())
     return m_savestate->video_data()->size();
 
@@ -453,12 +506,9 @@ size_t CSavestateFlatBuffer::GetVideoSize() const
 
 uint8_t* CSavestateFlatBuffer::GetVideoBuffer(size_t size)
 {
-  uint8_t* videoBuffer = nullptr;
+  m_videoData.assign(size, 0);
 
-  m_videoDataOffset =
-      std::make_unique<VectorOffset>(m_builder->CreateUninitializedVector(size, &videoBuffer));
-
-  return videoBuffer;
+  return m_videoData.empty() ? nullptr : m_videoData.data();
 }
 
 unsigned int CSavestateFlatBuffer::GetVideoWidth() const
@@ -515,32 +565,104 @@ void CSavestateFlatBuffer::SetRotationDegCCW(unsigned int rotationCCW)
 
 const uint8_t* CSavestateFlatBuffer::GetMemoryData() const
 {
+  if (!m_memoryDataDecompressed.empty())
+    return m_memoryDataDecompressed.data();
+
   if (m_savestate != nullptr && m_savestate->memory_data())
     return m_savestate->memory_data()->data();
 
   return nullptr;
 }
 
+bool CSavestateFlatBuffer::PrepareMemoryData(size_t expectedSize)
+{
+  m_memoryDataDecompressed.clear();
+
+  if (m_savestate == nullptr)
+    return false;
+
+  if (m_savestate->memory_data_compression() == SAVESTATE::CompressionType_Zstd)
+    return CSavestateBlob::PrepareMemoryData(*m_savestate, expectedSize, m_memoryDataDecompressed);
+
+  if (m_savestate->memory_data_compression() != SAVESTATE::CompressionType_None)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Unsupported memory compression type {}",
+              static_cast<unsigned int>(m_savestate->memory_data_compression()));
+    return false;
+  }
+
+  return CSavestateBlob::IsValidRawMemoryData(*m_savestate, expectedSize);
+}
+
 size_t CSavestateFlatBuffer::GetMemorySize() const
 {
+  if (!m_memoryDataDecompressed.empty())
+    return m_memoryDataDecompressed.size();
+
   if (m_savestate != nullptr && m_savestate->memory_data())
     return m_savestate->memory_data()->size();
 
   return 0;
 }
 
+bool CSavestateFlatBuffer::CopyMemoryDataTo(ISavestate& target) const
+{
+  auto* targetFlatBuffer = dynamic_cast<CSavestateFlatBuffer*>(&target);
+  if (targetFlatBuffer == nullptr || m_savestate == nullptr)
+    return false;
+
+  targetFlatBuffer->m_memoryData.Clear();
+  targetFlatBuffer->m_memoryDataDecompressed.clear();
+
+  if (m_savestate->memory_data_compression() == SAVESTATE::CompressionType_Zstd)
+  {
+    if (!CSavestateBlob::IsValidCopiedCompressedMemoryData(*m_savestate))
+      return false;
+
+    const auto* compressed = m_savestate->memory_data_compressed();
+    targetFlatBuffer->m_memoryData.compressed.assign(compressed->data(),
+                                                     compressed->data() + compressed->size());
+    targetFlatBuffer->m_memoryData.compression = SAVESTATE::CompressionType_Zstd;
+    targetFlatBuffer->m_memoryData.uncompressedSize = m_savestate->memory_data_uncompressed_size();
+    return true;
+  }
+
+  if (m_savestate->memory_data_compression() != SAVESTATE::CompressionType_None)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Unsupported memory compression type {}",
+              static_cast<unsigned int>(m_savestate->memory_data_compression()));
+    return false;
+  }
+
+  const auto* memoryData = m_savestate->memory_data();
+  if (memoryData == nullptr || !CSavestateBlob::IsValidMemoryDataSize(memoryData->size()))
+    return false;
+
+  if (memoryData->size() > 0)
+    targetFlatBuffer->m_memoryData.raw.assign(memoryData->data(),
+                                              memoryData->data() + memoryData->size());
+
+  return true;
+}
+
 uint8_t* CSavestateFlatBuffer::GetMemoryBuffer(size_t size)
 {
-  uint8_t* memoryBuffer = nullptr;
+  m_memoryData.Clear();
+  m_memoryData.raw.assign(size, 0);
 
-  m_memoryDataOffset =
-      std::make_unique<VectorOffset>(m_builder->CreateUninitializedVector(size, &memoryBuffer));
-
-  return memoryBuffer;
+  return m_memoryData.raw.empty() ? nullptr : m_memoryData.raw.data();
 }
 
 void CSavestateFlatBuffer::Finalize()
 {
+  if (m_builder == nullptr)
+    return;
+
+  const SavestateBlobOffsets videoBlob =
+      CSavestateBlob::CreateWriteOffsets(*m_builder, m_videoData, "video_data");
+  const SavestateBlobOffsets memoryBlob =
+      CSavestateBlob::CreateWriteOffsets(*m_builder, m_memoryData, "memory_data");
+
   // Helper class to build the nested Savestate table
   SAVESTATE::SavestateBuilder savestateBuilder(*m_builder);
 
@@ -604,11 +726,11 @@ void CSavestateFlatBuffer::Finalize()
 
   savestateBuilder.add_max_height(m_maxHeight);
 
-  if (m_videoDataOffset)
-  {
-    savestateBuilder.add_video_data(*m_videoDataOffset);
-    m_videoDataOffset.reset();
-  }
+  savestateBuilder.add_video_data(videoBlob.raw);
+  if (videoBlob.compressed.o != 0)
+    savestateBuilder.add_video_data_compressed(videoBlob.compressed);
+  savestateBuilder.add_video_data_compression(videoBlob.compressionType);
+  savestateBuilder.add_video_data_uncompressed_size(videoBlob.uncompressedSize);
 
   savestateBuilder.add_video_width(m_videoWidth);
 
@@ -618,11 +740,11 @@ void CSavestateFlatBuffer::Finalize()
 
   savestateBuilder.add_rotation_ccw(TranslateRotation(m_rotationCCW));
 
-  if (m_memoryDataOffset)
-  {
-    savestateBuilder.add_memory_data(*m_memoryDataOffset);
-    m_memoryDataOffset.reset();
-  }
+  savestateBuilder.add_memory_data(memoryBlob.raw);
+  if (memoryBlob.compressed.o != 0)
+    savestateBuilder.add_memory_data_compressed(memoryBlob.compressed);
+  savestateBuilder.add_memory_data_compression(memoryBlob.compressionType);
+  savestateBuilder.add_memory_data_uncompressed_size(memoryBlob.uncompressedSize);
 
   auto savestate = savestateBuilder.Finish();
   FinishSavestateBuffer(*m_builder, savestate);

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
@@ -749,15 +749,15 @@ uint8_t* CSavestateFlatBuffer::GetMemoryBuffer(size_t size)
   return m_memoryData.raw.empty() ? nullptr : m_memoryData.raw.data();
 }
 
-void CSavestateFlatBuffer::Finalize()
+void CSavestateFlatBuffer::Finalize(bool compress)
 {
   if (m_builder == nullptr)
     return;
 
   const SavestateBlobOffsets videoBlob =
-      CSavestateBlob::CreateWriteOffsets(*m_builder, m_videoData, SCHEMA_VIDEO_DATA_FIELD_NAME);
+      CSavestateBlob::CreateWriteOffsets(*m_builder, m_videoData, SCHEMA_VIDEO_DATA_FIELD_NAME, compress);
   const SavestateBlobOffsets memoryBlob =
-      CSavestateBlob::CreateWriteOffsets(*m_builder, m_memoryData, SCHEMA_MEMORY_DATA_FIELD_NAME);
+      CSavestateBlob::CreateWriteOffsets(*m_builder, m_memoryData, SCHEMA_MEMORY_DATA_FIELD_NAME, compress);
 
   // Helper class to build the nested Savestate table
   SAVESTATE::SavestateBuilder savestateBuilder(*m_builder);

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
@@ -415,7 +415,7 @@ AVPixelFormat CSavestateFlatBuffer::GetPixelFormat() const
   if (m_savestate != nullptr)
     return TranslatePixelFormat(m_savestate->pixel_format());
 
-  return AV_PIX_FMT_NONE;
+  return m_pixelFormat;
 }
 
 void CSavestateFlatBuffer::SetPixelFormat(AVPixelFormat pixelFormat)
@@ -496,6 +496,9 @@ const uint8_t* CSavestateFlatBuffer::GetVideoData() const
   if (m_savestate != nullptr && m_savestate->video_data())
     return m_savestate->video_data()->data();
 
+  if (!m_videoData.empty())
+    return m_videoData.data();
+
   return nullptr;
 }
 
@@ -545,6 +548,9 @@ size_t CSavestateFlatBuffer::GetVideoSize() const
   if (m_savestate != nullptr && m_savestate->video_data())
     return m_savestate->video_data()->size();
 
+  if (!m_videoData.empty())
+    return m_videoData.size();
+
   return 0;
 }
 
@@ -560,7 +566,7 @@ unsigned int CSavestateFlatBuffer::GetVideoWidth() const
   if (m_savestate != nullptr)
     return m_savestate->video_width();
 
-  return 0;
+  return m_videoWidth;
 }
 
 void CSavestateFlatBuffer::SetVideoWidth(unsigned int videoWidth)
@@ -573,7 +579,7 @@ unsigned int CSavestateFlatBuffer::GetVideoHeight() const
   if (m_savestate != nullptr)
     return m_savestate->video_height();
 
-  return 0;
+  return m_videoHeight;
 }
 
 void CSavestateFlatBuffer::SetVideoHeight(unsigned int videoHeight)
@@ -599,7 +605,7 @@ unsigned int CSavestateFlatBuffer::GetRotationDegCCW() const
   if (m_savestate != nullptr)
     return TranslateRotation(m_savestate->rotation_ccw());
 
-  return 0;
+  return m_rotationCCW;
 }
 
 void CSavestateFlatBuffer::SetRotationDegCCW(unsigned int rotationCCW)

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
@@ -506,7 +506,6 @@ bool CSavestateFlatBuffer::PrepareVideoData()
   if (m_savestate == nullptr)
     return false;
 
-  //! @todo Add support for new compression types
   switch (m_savestate->video_data_compression())
   {
     case SAVESTATE::CompressionType_None:
@@ -517,6 +516,14 @@ bool CSavestateFlatBuffer::PrepareVideoData()
         CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid video data");
         return false;
       }
+
+      break;
+    }
+    case SAVESTATE::CompressionType_Zstd:
+    {
+      if (!CSavestateBlob::PrepareVideoData(*m_savestate, m_videoDataDecompressed))
+        return false;
+
       break;
     }
     default:
@@ -632,7 +639,6 @@ bool CSavestateFlatBuffer::PrepareMemoryData(size_t expectedSize)
   if (m_savestate == nullptr)
     return false;
 
-  //! @todo Add support for new compression types
   switch (m_savestate->memory_data_compression())
   {
     case SAVESTATE::CompressionType_None:
@@ -642,6 +648,13 @@ bool CSavestateFlatBuffer::PrepareMemoryData(size_t expectedSize)
         CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid memory size {}", expectedSize);
         return false;
       }
+      break;
+    }
+    case SAVESTATE::CompressionType_Zstd:
+    {
+      if (!CSavestateBlob::PrepareMemoryData(*m_savestate, expectedSize, m_memoryDataDecompressed))
+        return false;
+
       break;
     }
     default:
@@ -675,7 +688,6 @@ bool CSavestateFlatBuffer::CopyMemoryDataTo(ISavestate& target) const
   targetFlatBuffer->m_memoryData.Clear();
   targetFlatBuffer->m_memoryDataDecompressed.clear();
 
-  //! @todo Add support for new compression types
   switch (m_savestate->memory_data_compression())
   {
     case SAVESTATE::CompressionType_None:
@@ -695,6 +707,20 @@ bool CSavestateFlatBuffer::CopyMemoryDataTo(ISavestate& target) const
         targetFlatBuffer->m_memoryData.raw.assign(memoryData->data(),
                                                   memoryData->data() + memoryData->size());
       }
+
+      break;
+    }
+    case SAVESTATE::CompressionType_Zstd:
+    {
+      if (!CSavestateBlob::IsValidCopiedCompressedMemoryData(*m_savestate))
+        return false;
+
+      const auto* compressed = m_savestate->memory_data_compressed();
+
+      targetFlatBuffer->m_memoryData.compressed.assign(compressed->data(),
+                                                       compressed->data() + compressed->size());
+      targetFlatBuffer->m_memoryData.compression = SAVESTATE::CompressionType_Zstd;
+      targetFlatBuffer->m_memoryData.uncompressedSize = m_savestate->memory_data_uncompressed_size();
 
       break;
     }

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.h
@@ -82,7 +82,7 @@ public:
   void SetDisplayAspectRatio(float displayAspectRatio) override;
   void SetRotationDegCCW(unsigned int rotationCCW) override;
   uint8_t* GetMemoryBuffer(size_t size) override;
-  void Finalize() override;
+  void Finalize(bool compress) override;
   bool Deserialize(std::vector<uint8_t> data) override;
 
 private:

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "ISavestate.h"
+#include "SavestateBlob.h"
 
 #include <memory>
 
@@ -49,13 +50,16 @@ public:
   unsigned int GetMaxWidth() const override;
   unsigned int GetMaxHeight() const override;
   const uint8_t* GetVideoData() const override;
+  bool PrepareVideoData() override;
   size_t GetVideoSize() const override;
   unsigned int GetVideoWidth() const override;
   unsigned int GetVideoHeight() const override;
   float GetDisplayAspectRatio() const override;
   unsigned int GetRotationDegCCW() const override;
   const uint8_t* GetMemoryData() const override;
+  bool PrepareMemoryData(size_t expectedSize) override;
   size_t GetMemorySize() const override;
+  bool CopyMemoryDataTo(ISavestate& target) const override;
   void SetType(SAVE_TYPE type) override;
   void SetSlot(uint8_t slot) override;
   void SetLabel(const std::string& label) override;
@@ -102,7 +106,6 @@ private:
   const SAVESTATE::Savestate* m_savestate = nullptr;
 
   using StringOffset = flatbuffers::Offset<flatbuffers::String>;
-  using VectorOffset = flatbuffers::Offset<flatbuffers::Vector<uint8_t>>;
 
   // Temporary deserialization variables
   SAVE_TYPE m_type = SAVE_TYPE::UNKNOWN;
@@ -121,12 +124,14 @@ private:
   float m_nominalDisplayAspectRatio{0.0f};
   unsigned int m_maxWidth{0};
   unsigned int m_maxHeight{0};
-  std::unique_ptr<VectorOffset> m_videoDataOffset;
+  std::vector<uint8_t> m_videoData;
+  std::vector<uint8_t> m_videoDataDecompressed;
   unsigned int m_videoWidth{0};
   unsigned int m_videoHeight{0};
   float m_displayAspectRatio{0.0f};
   unsigned int m_rotationCCW{0};
-  std::unique_ptr<VectorOffset> m_memoryDataOffset;
+  PendingSavestateBlob m_memoryData;
+  std::vector<uint8_t> m_memoryDataDecompressed;
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.h
@@ -83,7 +83,7 @@ public:
   void SetDisplayAspectRatio(float displayAspectRatio) override;
   void SetRotationDegCCW(unsigned int rotationCCW) override;
   uint8_t* GetMemoryBuffer(size_t size) override;
-  void Finalize() override;
+  void Finalize(bool compress) override;
   bool Deserialize(std::vector<uint8_t> data) override;
 
 private:

--- a/xbmc/cores/RetroPlayer/savestates/SavestateThumbnail.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateThumbnail.cpp
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SavestateThumbnail.h"
+
+#include "ISavestate.h"
+#include "pictures/Picture.h"
+#include "utils/log.h"
+
+extern "C"
+{
+#include <libavutil/imgutils.h>
+}
+
+using namespace KODI;
+using namespace RETRO;
+
+std::optional<SavestateThumbnailPayload> KODI::RETRO::CreateSavestateThumbnailPayload(
+    const std::string& thumbnailPath, const ISavestate& savestate)
+{
+  const uint8_t* const videoData = savestate.GetVideoData();
+  const size_t videoSize = savestate.GetVideoSize();
+  const unsigned int width = savestate.GetVideoWidth();
+  const unsigned int height = savestate.GetVideoHeight();
+  const AVPixelFormat pixelFormat = savestate.GetPixelFormat();
+
+  if (thumbnailPath.empty() || videoData == nullptr || videoSize == 0 || width == 0 ||
+      height == 0 || pixelFormat == AV_PIX_FMT_NONE)
+  {
+    return std::nullopt;
+  }
+
+  SavestateThumbnailPayload payload;
+  payload.thumbnailPath = thumbnailPath;
+  payload.pixels.assign(videoData, videoData + videoSize);
+  payload.width = width;
+  payload.height = height;
+  payload.rotationCCW = savestate.GetRotationDegCCW();
+  payload.pixelFormat = pixelFormat;
+
+  return payload;
+}
+
+bool KODI::RETRO::WriteSavestateThumbnailPayload(const SavestateThumbnailPayload& payload)
+{
+  if (payload.thumbnailPath.empty() || payload.pixels.empty() || payload.width == 0 ||
+      payload.height == 0 || payload.pixelFormat == AV_PIX_FMT_NONE)
+  {
+    return false;
+  }
+
+  const int stride = av_image_get_linesize(payload.pixelFormat, static_cast<int>(payload.width), 0);
+  if (stride <= 0)
+    return false;
+
+  unsigned int scaleWidth = 400;
+  unsigned int scaleHeight = 220;
+  CPicture::GetScale(payload.width, payload.height, scaleWidth, scaleHeight);
+
+  const int bytesPerPixel = 4;
+  std::vector<uint8_t> scaledImage(scaleWidth * scaleHeight * bytesPerPixel);
+
+  const AVPixelFormat outFormat = AV_PIX_FMT_BGR0;
+  const int scaleStride = av_image_get_linesize(outFormat, static_cast<int>(scaleWidth), 0);
+  if (scaleStride <= 0)
+    return false;
+
+  if (!CPicture::ScaleImage(const_cast<uint8_t*>(payload.pixels.data()), payload.width,
+                            payload.height, stride, payload.pixelFormat, scaledImage.data(),
+                            scaleWidth, scaleHeight, scaleStride, outFormat))
+  {
+    CLog::Log(LOGERROR, "Failed to scale image from size {}x{} to size {}x{}", payload.width,
+              payload.height, scaleWidth, scaleHeight);
+    return false;
+  }
+
+  //! @todo Rotate image by rotationCCW
+  (void)payload.rotationCCW;
+
+  return CPicture::CreateThumbnailFromSurface(scaledImage.data(), scaleWidth, scaleHeight,
+                                              scaleStride, payload.thumbnailPath);
+}

--- a/xbmc/cores/RetroPlayer/savestates/SavestateThumbnail.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateThumbnail.h
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+extern "C"
+{
+#include <libavutil/pixfmt.h>
+}
+
+namespace KODI
+{
+namespace RETRO
+{
+class ISavestate;
+
+/*!
+ * \brief Self-contained data needed to create a savestate thumbnail
+ *
+ * This payload owns a copy of the savestate video frame so thumbnail encoding can be performed
+ * after the savestate object has been moved, finalized, or destroyed.
+ */
+struct SavestateThumbnailPayload
+{
+  //! Destination path for the generated thumbnail image
+  std::string thumbnailPath;
+
+  //! Raw video frame pixels copied from the savestate
+  std::vector<uint8_t> pixels;
+
+  //! Width of the source video frame, in pixels
+  unsigned int width{0};
+
+  //! Height of the source video frame, in pixels
+  unsigned int height{0};
+
+  //! Source video frame rotation, in degrees counter-clockwise
+  unsigned int rotationCCW{0};
+
+  //! FFmpeg pixel format for the source video frame
+  AVPixelFormat pixelFormat{AV_PIX_FMT_NONE};
+};
+
+/*!
+ * \brief Create a thumbnail payload from a savestate video frame
+ *
+ * \param thumbnailPath Destination path for the thumbnail image
+ * \param savestate Savestate containing prepared video frame data
+ *
+ * \return A populated payload, or std::nullopt if the thumbnail path or required video metadata is
+ * invalid
+ */
+std::optional<SavestateThumbnailPayload> CreateSavestateThumbnailPayload(
+    const std::string& thumbnailPath, const ISavestate& savestate);
+
+/*!
+ * \brief Scale and write a savestate thumbnail payload to disk
+ *
+ * \param payload Thumbnail payload created by CreateSavestateThumbnailPayload()
+ *
+ * \return True when the thumbnail was written successfully, false otherwise
+ */
+bool WriteSavestateThumbnailPayload(const SavestateThumbnailPayload& payload);
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/cores/RetroPlayer/savestates/SavestateWriteQueue.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateWriteQueue.cpp
@@ -55,6 +55,7 @@ struct SavestateFileWriteRequest
   std::string savePath;
   std::string gamePath;
   std::unique_ptr<ISavestate> savestate;
+  bool compressSavedGame{true};
 };
 
 class CWriteCompletionGuard
@@ -145,7 +146,7 @@ public:
     if (m_request.savePath.empty() || m_request.gamePath.empty() || !m_request.savestate)
       return false;
 
-    m_request.savestate->Finalize();
+    m_request.savestate->Finalize(m_request.compressSavedGame);
 
     CSavestateDatabase database;
     const bool success =
@@ -201,7 +202,7 @@ void CSavestateWriteQueue::QueueSavestateWrite(SavestateWriteRequest request)
   std::optional<SavestateThumbnailPayload> thumbnail = std::move(request.thumbnail);
 
   if (!QueueSavestateFileWrite(std::move(request.savePath), std::move(request.gamePath),
-                               std::move(request.savestate)))
+                               std::move(request.savestate), request.compressSavedGame))
     return;
 
   if (thumbnail)
@@ -237,7 +238,8 @@ bool CSavestateWriteQueue::ArmWrite()
 
 bool CSavestateWriteQueue::QueueSavestateFileWrite(std::string savePath,
                                                    std::string gamePath,
-                                                   std::unique_ptr<ISavestate> savestate)
+                                                   std::unique_ptr<ISavestate> savestate,
+                                                   bool compressSavedGame)
 {
   if (!ArmWrite())
     return false;
@@ -246,6 +248,7 @@ bool CSavestateWriteQueue::QueueSavestateFileWrite(std::string savePath,
       std::move(savePath),
       std::move(gamePath),
       std::move(savestate),
+      compressSavedGame,
   };
 
   auto* job = new CSavestateWriteJob(std::move(request), m_refreshState, m_tracker);

--- a/xbmc/cores/RetroPlayer/savestates/SavestateWriteQueue.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateWriteQueue.cpp
@@ -1,0 +1,276 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SavestateWriteQueue.h"
+
+#include "ISavestate.h"
+#include "SavestateDatabase.h"
+#include "SavestateWriteRequest.h"
+#include "ServiceBroker.h"
+#include "cores/RetroPlayer/guibridge/GUIGameMessenger.h"
+#include "jobs/Job.h"
+#include "jobs/JobQueue.h"
+#include "messaging/ApplicationMessenger.h"
+#include "messaging/ThreadMessage.h"
+#include "utils/log.h"
+
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <utility>
+
+using namespace KODI;
+using namespace RETRO;
+
+namespace KODI::RETRO
+{
+struct WriteTracker
+{
+  std::mutex mutex;
+  std::condition_variable condition;
+  unsigned int pendingWrites{0};
+  bool acceptingWrites{true};
+};
+
+// Refresh callbacks are posted asynchronously. Wait() disables the shared
+// refresh state before draining workers so callbacks posted before shutdown
+// either run safely on the app thread or no-op after shutdown begins.
+struct RefreshState
+{
+  std::mutex mutex;
+  CGUIGameMessenger* guiMessenger{nullptr};
+  bool acceptingRefreshes{true};
+};
+} // namespace KODI::RETRO
+
+namespace
+{
+struct SavestateFileWriteRequest
+{
+  std::string savePath;
+  std::string gamePath;
+  std::unique_ptr<ISavestate> savestate;
+};
+
+class CWriteCompletionGuard
+{
+public:
+  explicit CWriteCompletionGuard(std::shared_ptr<WriteTracker> tracker)
+    : m_tracker(std::move(tracker))
+  {
+  }
+
+  CWriteCompletionGuard(const CWriteCompletionGuard&) = delete;
+  CWriteCompletionGuard& operator=(const CWriteCompletionGuard&) = delete;
+
+  ~CWriteCompletionGuard()
+  {
+    if (!m_tracker)
+      return;
+
+    std::unique_lock lock(m_tracker->mutex);
+    if (m_tracker->pendingWrites > 0)
+      --m_tracker->pendingWrites;
+    lock.unlock();
+    m_tracker->condition.notify_all();
+  }
+
+private:
+  std::shared_ptr<WriteTracker> m_tracker;
+};
+
+void RefreshSavestatesOnApplicationThread(void* userptr);
+
+struct RefreshSavestatesCallback : KODI::MESSAGING::ThreadMessageCallback
+{
+  std::shared_ptr<RefreshState> refreshState;
+  std::string savePath;
+};
+
+void RefreshSavestatesOnApplicationThread(void* userptr)
+{
+  std::unique_ptr<RefreshSavestatesCallback> callback(
+      static_cast<RefreshSavestatesCallback*>(userptr));
+
+  CGUIGameMessenger* guiMessenger = nullptr;
+  {
+    std::unique_lock lock(callback->refreshState->mutex);
+    if (!callback->refreshState->acceptingRefreshes)
+      return;
+
+    guiMessenger = callback->refreshState->guiMessenger;
+    if (guiMessenger == nullptr)
+      return;
+  }
+
+  guiMessenger->RefreshSavestates(callback->savePath);
+}
+
+void PostSavestateRefresh(std::shared_ptr<RefreshState> refreshState, const std::string& savePath)
+{
+  {
+    std::unique_lock lock(refreshState->mutex);
+    if (!refreshState->acceptingRefreshes || refreshState->guiMessenger == nullptr)
+      return;
+  }
+
+  auto* callback = new RefreshSavestatesCallback;
+  callback->callback = RefreshSavestatesOnApplicationThread;
+  callback->userptr = callback;
+  callback->refreshState = std::move(refreshState);
+  callback->savePath = savePath;
+
+  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_CALLBACK, -1, -1, callback);
+}
+
+class CSavestateWriteJob : public CJob
+{
+public:
+  CSavestateWriteJob(SavestateFileWriteRequest request,
+                     std::shared_ptr<RefreshState> refreshState,
+                     std::shared_ptr<WriteTracker> tracker)
+    : m_request(std::move(request)),
+      m_refreshState(std::move(refreshState)),
+      m_completionGuard(std::move(tracker))
+  {
+  }
+
+  bool DoWork() override
+  {
+    if (m_request.savePath.empty() || m_request.gamePath.empty() || !m_request.savestate)
+      return false;
+
+    m_request.savestate->Finalize();
+
+    CSavestateDatabase database;
+    const bool success =
+        database.AddSavestate(m_request.savePath, m_request.gamePath, *m_request.savestate);
+
+    if (success)
+      PostSavestateRefresh(m_refreshState, m_request.savePath);
+
+    return success;
+  }
+
+private:
+  SavestateFileWriteRequest m_request;
+  std::shared_ptr<RefreshState> m_refreshState;
+  CWriteCompletionGuard m_completionGuard;
+};
+
+class CSavestateThumbnailWriteJob : public CJob
+{
+public:
+  CSavestateThumbnailWriteJob(SavestateThumbnailPayload payload,
+                              std::shared_ptr<WriteTracker> tracker)
+    : m_payload(std::move(payload)),
+      m_completionGuard(std::move(tracker))
+  {
+  }
+
+  bool DoWork() override { return WriteSavestateThumbnailPayload(m_payload); }
+
+private:
+  SavestateThumbnailPayload m_payload;
+  CWriteCompletionGuard m_completionGuard;
+};
+} // namespace
+
+CSavestateWriteQueue::CSavestateWriteQueue(CGUIGameMessenger& guiMessenger)
+  : m_guiMessenger(guiMessenger),
+    m_fileWriteQueue(false, 1, CJob::PRIORITY_LOW),
+    m_thumbnailWriteQueue(false, 1, CJob::PRIORITY_LOW),
+    m_refreshState(std::make_shared<RefreshState>()),
+    m_tracker(std::make_shared<WriteTracker>())
+{
+  m_refreshState->guiMessenger = &m_guiMessenger;
+}
+
+CSavestateWriteQueue::~CSavestateWriteQueue()
+{
+  Wait();
+}
+
+void CSavestateWriteQueue::QueueSavestateWrite(SavestateWriteRequest request)
+{
+  std::optional<SavestateThumbnailPayload> thumbnail = std::move(request.thumbnail);
+
+  if (!QueueSavestateFileWrite(std::move(request.savePath), std::move(request.gamePath),
+                               std::move(request.savestate)))
+    return;
+
+  if (thumbnail)
+  {
+    // Thumbnail writes are best-effort. If queueing or writing the thumbnail
+    // fails, keep the savestate file.
+    (void)QueueThumbnailWrite(std::move(*thumbnail));
+  }
+}
+
+void CSavestateWriteQueue::Wait()
+{
+  {
+    std::unique_lock refreshLock(m_refreshState->mutex);
+    m_refreshState->acceptingRefreshes = false;
+    m_refreshState->guiMessenger = nullptr;
+  }
+
+  std::unique_lock lock(m_tracker->mutex);
+  m_tracker->acceptingWrites = false;
+  m_tracker->condition.wait(lock, [this] { return m_tracker->pendingWrites == 0; });
+}
+
+bool CSavestateWriteQueue::ArmWrite()
+{
+  std::unique_lock lock(m_tracker->mutex);
+  if (!m_tracker->acceptingWrites)
+    return false;
+
+  ++m_tracker->pendingWrites;
+  return true;
+}
+
+bool CSavestateWriteQueue::QueueSavestateFileWrite(std::string savePath,
+                                                   std::string gamePath,
+                                                   std::unique_ptr<ISavestate> savestate)
+{
+  if (!ArmWrite())
+    return false;
+
+  SavestateFileWriteRequest request{
+      std::move(savePath),
+      std::move(gamePath),
+      std::move(savestate),
+  };
+
+  auto* job = new CSavestateWriteJob(std::move(request), m_refreshState, m_tracker);
+
+  if (!m_fileWriteQueue.AddJob(job))
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Failed to queue savestate write job");
+    return false;
+  }
+
+  return true;
+}
+
+bool CSavestateWriteQueue::QueueThumbnailWrite(SavestateThumbnailPayload payload)
+{
+  if (!ArmWrite())
+    return false;
+
+  auto* job = new CSavestateThumbnailWriteJob(std::move(payload), m_tracker);
+
+  if (!m_thumbnailWriteQueue.AddJob(job))
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Failed to queue savestate thumbnail write job");
+    return false;
+  }
+
+  return true;
+}

--- a/xbmc/cores/RetroPlayer/savestates/SavestateWriteQueue.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateWriteQueue.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "jobs/JobQueue.h"
+
+#include <memory>
+#include <string>
+
+namespace KODI
+{
+namespace RETRO
+{
+class CGUIGameMessenger;
+class ISavestate;
+struct SavestateThumbnailPayload;
+struct SavestateWriteRequest;
+struct RefreshState;
+struct WriteTracker;
+
+class CSavestateWriteQueue
+{
+public:
+  explicit CSavestateWriteQueue(CGUIGameMessenger& guiMessenger);
+  ~CSavestateWriteQueue();
+
+  void QueueSavestateWrite(SavestateWriteRequest request);
+  void Wait();
+
+private:
+  bool ArmWrite();
+  bool QueueSavestateFileWrite(std::string savePath,
+                               std::string gamePath,
+                               std::unique_ptr<ISavestate> savestate);
+  bool QueueThumbnailWrite(SavestateThumbnailPayload payload);
+
+  CGUIGameMessenger& m_guiMessenger;
+  CJobQueue m_fileWriteQueue;
+  CJobQueue m_thumbnailWriteQueue;
+  std::shared_ptr<RefreshState> m_refreshState;
+  std::shared_ptr<WriteTracker> m_tracker;
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/cores/RetroPlayer/savestates/SavestateWriteQueue.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateWriteQueue.h
@@ -37,7 +37,8 @@ private:
   bool ArmWrite();
   bool QueueSavestateFileWrite(std::string savePath,
                                std::string gamePath,
-                               std::unique_ptr<ISavestate> savestate);
+                               std::unique_ptr<ISavestate> savestate,
+                               bool compressSavedGame);
   bool QueueThumbnailWrite(SavestateThumbnailPayload payload);
 
   CGUIGameMessenger& m_guiMessenger;

--- a/xbmc/cores/RetroPlayer/savestates/SavestateWriteRequest.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateWriteRequest.h
@@ -40,6 +40,9 @@ struct SavestateWriteRequest
 
   //! Optional pre-copied thumbnail payload for the savestate
   std::optional<SavestateThumbnailPayload> thumbnail;
+
+  //! Whether to compress savestate payloads while finalizing for disk
+  bool compressSavedGame{true};
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/savestates/SavestateWriteRequest.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateWriteRequest.h
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "SavestateThumbnail.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace KODI
+{
+namespace RETRO
+{
+class ISavestate;
+
+/*!
+ * \brief Move-only request for writing a captured savestate off-thread
+ *
+ * The request owns the finalized savestate data that will be written to disk.
+ * Thumbnail data is optional because thumbnail capture is best-effort and can
+ * fail independently of the savestate file write.
+ */
+struct SavestateWriteRequest
+{
+  //! Destination path for the savestate file
+  std::string savePath;
+
+  //! Path to the game file associated with the savestate
+  std::string gamePath;
+
+  //! Captured savestate object to finalize and write
+  std::unique_ptr<ISavestate> savestate;
+
+  //! Optional pre-copied thumbnail payload for the savestate
+  std::optional<SavestateThumbnailPayload> thumbnail;
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/games/GameUtils.cpp
+++ b/xbmc/games/GameUtils.cpp
@@ -60,16 +60,6 @@ bool CGameUtils::FillInGameClient(CFileItem& item, std::string& savestatePath)
         RETRO::CSavestateDatabase db;
         std::unique_ptr<RETRO::ISavestate> save = RETRO::CSavestateDatabase::AllocateSavestate();
         db.GetSavestate(savestatePath, *save);
-
-        //! @todo Remove this when we can load compressed savestates
-        if (save->IsCompressed())
-        {
-          // "Error"
-          // "This savestate is compressed and can't be loaded by this version of Kodi."
-          CGUIDialogOK::ShowAndGetInput(257, 35298);
-          return false;
-        }
-
         item.GetGameInfoTag()->SetGameClient(save->GameClientID());
       }
       else

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -280,7 +280,7 @@ void CDialogInGameSaves::OnNewSave()
   savestate->SetType(SAVE_TYPE::MANUAL);
   savestate->SetCreated(CDateTime::GetUTCDateTime());
 
-  savestate->Finalize();
+  savestate->Finalize(true);
 
   CFileItemPtr item = std::make_shared<CFileItem>();
   CSavestateDatabase::GetSavestateItem(*savestate, savestatePath, *item);
@@ -329,7 +329,7 @@ void CDialogInGameSaves::OnOverwrite(CFileItem& focusedItem)
     savestate->SetCaption(focusedItem.GetProperty(SAVESTATE_CAPTION).asString());
     savestate->SetCreated(CDateTime::GetUTCDateTime());
 
-    savestate->Finalize();
+    savestate->Finalize(true);
 
     CSavestateDatabase::GetSavestateItem(*savestate, savestatePath, focusedItem);
 

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -302,17 +302,6 @@ void CDialogInGameSaves::OnLoad(CFileItem& focusedItem)
   }
   else
   {
-    //! @todo Remove this when support for savestate compression is added
-    RETRO::CSavestateDatabase db;
-    std::unique_ptr<RETRO::ISavestate> savestate = RETRO::CSavestateDatabase::AllocateSavestate();
-    if (db.GetSavestate(focusedItem.GetPath(), *savestate) && savestate->IsCompressed())
-    {
-      // "Error"
-      // "This savestate is compressed and can't be loaded by this version of Kodi."
-      CGUIDialogOK::ShowAndGetInput(257, 35298);
-      return;
-    }
-
     // "Error"
     // "An unknown error has occurred."
     CGUIDialogOK::ShowAndGetInput(257, 24071);

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -191,6 +191,7 @@ public:
   static constexpr auto SETTING_SCRAPERS_MOVIESDEFAULT = "scrapers.moviesdefault";
   static constexpr auto SETTING_SCRAPERS_TVSHOWSDEFAULT = "scrapers.tvshowsdefault";
   static constexpr auto SETTING_SCRAPERS_MUSICVIDEOSDEFAULT = "scrapers.musicvideosdefault";
+  static constexpr auto SETTING_GAMES_COMPRESSSAVEDGAMES = "games.compresssavedgames";
   static constexpr auto SETTING_PVRMANAGER_PRESELECTPLAYINGCHANNEL =
       "pvrmanager.preselectplayingchannel";
   static constexpr auto SETTING_PVRMANAGER_BACKENDCHANNELGROUPSORDER =

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -196,6 +196,7 @@ public:
   static constexpr auto SETTING_SCRAPERS_MOVIESDEFAULT = "scrapers.moviesdefault";
   static constexpr auto SETTING_SCRAPERS_TVSHOWSDEFAULT = "scrapers.tvshowsdefault";
   static constexpr auto SETTING_SCRAPERS_MUSICVIDEOSDEFAULT = "scrapers.musicvideosdefault";
+  static constexpr auto SETTING_GAMES_COMPRESSSAVEDGAMES = "games.compresssavedgames";
   static constexpr auto SETTING_PVRMANAGER_PRESELECTPLAYINGCHANNEL =
       "pvrmanager.preselectplayingchannel";
   static constexpr auto SETTING_PVRMANAGER_BACKENDCHANNELGROUPSORDER =


### PR DESCRIPTION
## Description

This PR enables savestate compression, both for serialized state and pixel data.

Another improvement is writing savestates off-thread, which can cause stuttering during gameplay. I may PR this for v22.

Compressed saves aren't backwards compatible. Loading them in v22 will just start at the beginning of the game. I'll probably add simple error checking for v22.

Requires https://github.com/xbmc/xbmc/pull/28476.

## Motivation and context

Now that ZSTD is added in https://github.com/xbmc/xbmc/pull/28476, we can use it to compress savestates.

## How has this been tested?

Included in latest RetroPlayer test builds.

## What is the effect on users?

* Added saved game compression

## Screenshots (if appropriate):

<img width="1790" height="931" alt="Screenshot 2026-06-28 at 2 52 23 PM" src="https://github.com/user-attachments/assets/c84d6474-bb73-4f40-9edc-7c445cad4707" />

## Types of change

<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
