### PR TITLE
[network] Fix data race / use-after-free on the network interface list

### DIFF
--- a/xbmc/network/Network.cpp
+++ b/xbmc/network/Network.cpp
@@ -25,6 +25,8 @@
 #include "utils/StringUtils.h"
 #include "utils/XTimeUtils.h"
 
+#include <mutex>
+
 /* slightly modified in_ether taken from the etherboot project (http://sourceforge.net/projects/etherboot) */
 bool in_ether (const char *bufp, unsigned char *addr)
 {
@@ -143,6 +145,7 @@ bool CNetworkBase::IsLocalHost(const std::string& hostname)
       && StringUtils::EqualsNoCase(hostname, myhostname))
     return true;
 
+  std::unique_lock lock(m_lockInterfaceList);
   std::vector<CNetworkInterface*>& ifaces = GetInterfaceList();
   std::vector<CNetworkInterface*>::const_iterator iter = ifaces.begin();
   while (iter != ifaces.end())
@@ -159,6 +162,7 @@ bool CNetworkBase::IsLocalHost(const std::string& hostname)
 
 CNetworkInterface* CNetworkBase::GetFirstConnectedInterface()
 {
+  std::unique_lock lock(m_lockInterfaceList);
   CNetworkInterface* fallbackInterface = nullptr;
   for (CNetworkInterface* iface : GetInterfaceList())
   {
@@ -178,6 +182,7 @@ bool CNetworkBase::HasInterfaceForIP(unsigned long address)
 {
    unsigned long subnet;
    unsigned long local;
+   std::unique_lock lock(m_lockInterfaceList);
    std::vector<CNetworkInterface*>& ifaces = GetInterfaceList();
    std::vector<CNetworkInterface*>::const_iterator iter = ifaces.begin();
    while (iter != ifaces.end())
@@ -198,6 +203,7 @@ bool CNetworkBase::HasInterfaceForIP(unsigned long address)
 
 bool CNetworkBase::IsAvailable(void)
 {
+  std::unique_lock lock(m_lockInterfaceList);
   const std::vector<CNetworkInterface*>& ifaces = GetInterfaceList();
   return (!ifaces.empty());
 }

--- a/xbmc/network/Network.h
+++ b/xbmc/network/Network.h
@@ -8,10 +8,11 @@
 
 #pragma once
 
+#include "settings/lib/ISettingCallback.h"
+#include "threads/CriticalSection.h"
+
 #include <string>
 #include <vector>
-
-#include "settings/lib/ISettingCallback.h"
 
 #include "PlatformDefs.h"
 
@@ -115,6 +116,13 @@ public:
   static std::string GetMaskByPrefixLength(uint8_t prefixLength);
 
   std::unique_ptr<CNetworkServices> m_services;
+
+protected:
+  // Serializes access to the platform interface list (GetInterfaceList()/m_interfaces).
+  // The list is iterated by IsLocalHost()/HasInterfaceForIP()/IsAvailable() etc. from many
+  // threads while platform code rebuilds it, so all access must be guarded. Recursive so a
+  // locked accessor may call another (e.g. iOS GetFirstConnectedInterface -> queryInterfaceList).
+  CCriticalSection m_lockInterfaceList;
 };
 
 //creates, binds and listens tcp sockets on the desired port. Set bindLocal to

--- a/xbmc/platform/darwin/ios-common/network/NetworkIOS.mm
+++ b/xbmc/platform/darwin/ios-common/network/NetworkIOS.mm
@@ -14,6 +14,7 @@
 #import "platform/darwin/ios-common/network/route.h"
 
 #import <array>
+#include <mutex>
 #include <utility>
 
 #import <arpa/inet.h>
@@ -296,6 +297,10 @@ std::vector<CNetworkInterface*>& CNetworkIOS::GetInterfaceList()
 
 CNetworkInterface* CNetworkIOS::GetFirstConnectedInterface()
 {
+  // Guard the rebuild and iteration of m_interfaces against concurrent access from other
+  // threads (e.g. IsLocalHost()/HasInterfaceForIP() resolving URLs). Recursive lock: the
+  // queryInterfaceList() call below re-acquires it.
+  std::unique_lock lock(m_lockInterfaceList);
   // Renew m_interfaces to be able to handle hard interface changes (adapters removed/added)
   // This allows interfaces to be discovered if none are available at start eg. (Airplane mode on)
   queryInterfaceList();
@@ -349,6 +354,9 @@ CNetworkInterface* CNetworkIOS::GetFirstConnectedInterface()
 
 void CNetworkIOS::queryInterfaceList()
 {
+  // Serialize rebuild against readers iterating GetInterfaceList()/m_interfaces on other
+  // threads. Recursive lock so callers already holding it (GetFirstConnectedInterface) are ok.
+  std::unique_lock lock(m_lockInterfaceList);
   m_interfaces.clear();
 
   struct ifaddrs* list;


### PR DESCRIPTION
## Description

CNetworkBase::IsLocalHost(), HasInterfaceForIP() and IsAvailable() iterate the platform interface vector returned by GetInterfaceList() (m_interfaces) without any synchronisation, while platform code rebuilds that same vector concurrently. On iOS/tvOS, CNetworkIOS::queryInterfaceList() does m_interfaces.clear() followed by push_back(new ...) on every call, and it is invoked from CNetworkIOS::GetFirstConnectedInterface(), which in turn is called from many threads (URIUtils::IsHostOnLAN(), the periodic CSysInfoJob system-info refresh, AirPlay/AirTunes, UPnP, SystemInfo, ...).

When a rebuild lands while another thread is mid-iteration, the reader walks a reallocated/cleared buffer and dereferences a garbage CNetworkInterface*, e.g. at Network.cpp:151 `iface->GetCurrentIPAddress()`. This is a textbook use-after-free: EXC_BAD_ACCESS on varying threads/signals, with fault addresses that are ASCII text (observed "LogEvent", "OS=darwi") because the "pointer" is really reused heap bytes.

Fix: add a recursive CCriticalSection (m_lockInterfaceList) to CNetworkBase and hold it around every iteration of the interface list in the base-class accessors, and around the rebuild + iteration in the iOS/tvOS writer (queryInterfaceList / GetFirstConnectedInterface). The lock is recursive because GetFirstConnectedInterface() -> queryInterfaceList() re-acquires it; the interface accessors called while holding it (GetCurrentIPAddress() etc.) only do ioctl()/getifaddrs() and take no other Kodi lock, so there is no lock-ordering hazard. The pre-existing leak in queryInterfaceList() (clear() without delete) is intentionally left as-is: it is what keeps CNetworkInterface* pointers returned by GetFirstConnectedInterface() valid after the lock is released, so "fixing" it would introduce a different use-after-free.

Reproduced on an Apple TV 4K (tvOS 26.5) by browsing/scrolling an HTTP video
folder over JSON-RPC: crashed in ~65s in CVideoThumbLoader::LoadItemLookup ->
CDVDFileInfo::CanExtract -> URIUtils::IsRemote -> CURL::IsLocal -> CNetworkBase::IsLocalHost (Network.cpp:151). With this change the same load ran 6 min / 1000+ IsLocalHost calls with no crash.

Platform impact
---------------
The unsafe pattern is not iOS-specific: NetworkPosix, NetworkLinux, NetworkFreebsd, NetworkAndroid, NetworkWin32 and NetworkWin10 all return a reference to their own m_interfaces from GetInterfaceList() and rebuild it without locking. The base-class accessors patched here are shared by every platform, so they now lock on all of them. However only the iOS/tvOS *writer* (queryInterfaceList) is locked in this commit, so full protection is only guaranteed on iOS/tvOS; the other platforms' rebuild paths should take the same m_lockInterfaceList for complete coverage (left for a follow-up so this change stays reviewable and testable on the platform where it was diagnosed). The base lock is harmless on the other platforms (uncontended reader-only locking) and introduces no behaviour change.

Why some protocols hit it far more often
----------------------------------------
The bug is protocol-agnostic, but the trigger rate is not. curl-backed protocols (http/https/ftp/sftp/dav/davs) route every operation through CCurlFile::ParseAndCorrectUrl(), which calls IsLocalHost() on each open/stat/ mimetype request - hundreds to thousands of calls during normal browsing (1014 in the 6-minute repro). That keeps a reader in the racy loop almost continuously, so the collision with the background rebuild is very likely.

SMB/NFS and similar go through libsmbclient/libnfs rather than CCurlFile and therefore do not hit ParseAndCorrectUrl, so IsLocalHost() is called far less frequently per operation. They still reach the same racy code via the generic path URIUtils::IsRemote() -> CURL::IsLocal() -> IsLocalHost() (used by the thumbnail loader's CDVDFileInfo::CanExtract and by external-subtitle scanning), and SMB addressed by IP additionally hits GetFirstConnectedInterface()/ HasInterfaceForIP() in IsHostOnLAN(). So SMB users are exposed to the same latent crash, just at a lower probability (SMB by NetBIOS name short-circuits IsHostOnLAN() before those two calls, but IsRemote()->IsLocalHost() still iterates the list). The writer side (periodic system-info refresh, AirPlay, UPnP) churns the list regardless of which protocol is in use.

Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

## Motivation and context

It's a crash bug that was hitting me all quite often on tvOS

## How has this been tested?

Wrote some code that tried to repo. It repo-ed. Applied the fix. It didn't seem to repo. That's not a guarantee because it's race issue but the diagnosis appears correct.

## What is the effect on users?

They'll stop crashing

## Screenshots (if appropriate):

N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

* I didn't add tests as it's a race condition
* The existing tests pass on MacOS. Testing does not appear to be supported on iOS/tVOS

