### PR TITLE
[DVDCodecs][Video] Fix Dolby Vision reporting uncropped dimensions on Android (PGS subtitle squash)

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1786,6 +1786,22 @@ void CDVDVideoCodecAndroidMediaCodec::ConfigureOutputFormat(CJNIMediaFormat& med
   if (crop_bottom)
     height = crop_bottom + 1 - crop_top;
 
+  // The MediaCodec output format's crop keys are unreliable on some vendor
+  // Dolby Vision decoder components (observed: width/height report the full
+  // padded decode surface, e.g. 3840x2160, instead of the SPS-conformance-
+  // cropped picture, e.g. 3840x1608 - see Kodi forum threads 377103, 370653
+  // and related long-standing reports). m_hints.width/height were already
+  // parsed correctly by ffmpeg's demuxer from the stream's SPS before the
+  // codec was even opened, so when the codec's own crop math disagrees with
+  // what we already know to be correct, prefer the known-good value.
+  if (m_mime == "video/dolby-vision" && m_hints.width > 0 && m_hints.height > 0 &&
+      (width != m_hints.width || height != m_hints.height) && width >= m_hints.width &&
+      height >= m_hints.height)
+  {
+    width = m_hints.width;
+    height = m_hints.height;
+  }
+
   m_videobuffer.iDisplayWidth  = m_videobuffer.iWidth  = width;
   m_videobuffer.iDisplayHeight = m_videobuffer.iHeight = height;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
On Android, some vendor Dolby Vision decoder components report the full padded decode surface (e.g., 3840×2160) instead of the conformance-cropped picture (e.g., 3840×1608). This caused PGS subtitles to be vertically squashed and misplaced, because the overlay renderer received a 16:9 source rectangle and incorrectly aligned the subtitles to the video frame.

An earlier investigation considered a renderer-side workaround, but the root cause is the decoder's inaccurate dimensions. This patch corrects the values directly by using the demuxer-provided m_hints.width/height - already parsed correctly from the SPS - when the codec's own crop-derived dimensions are larger. The guard only overrides when the codec reports a superset of the real picture, so legitimate resolution changes are not affected.

No overlay renderer modifications are needed; the existing alignment logic functions correctly once the decoder supplies accurate dimensions.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Multiple reports since 2022 describe Dolby Vision files with PGS subtitles squashed inside the active video, while HDR10 files work normally. The issue is specific to the Android DV decoder path.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The build will be tested later, and the results will be posted.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Dolby Vision playback on Android with PGS subtitles now matches HDR10 behavior: subtitles are placed correctly in the black bars, without squashing or displacement. All other content types are unaffected.
Resolves #28491 

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
