### PR TITLE
[Windows] Fix Pixel Shaders and Software render method recovery from lost D3D11 device

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAEnumeratorHD.h
@@ -196,7 +196,7 @@ public:
   void OnCreateDevice() override
   {
     std::unique_lock lock(m_section);
-    if (m_width > 0 && m_height > 0)
+    if (m_width > 0 && m_height > 0 && m_input_dxgi_format != DXGI_FORMAT_UNKNOWN)
       OpenEnumerator();
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DXVAHD.cpp
@@ -74,6 +74,7 @@ void CProcessorHD::UnInit()
 {
   std::unique_lock lock(m_section);
   m_enumerator = nullptr;
+  m_procCaps.m_valid = false;
   Close();
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -30,6 +30,25 @@ using namespace Microsoft::WRL;
 
 //===================================================================
 
+CWinShader::~CWinShader()
+{
+  Unregister();
+}
+
+void CWinShader::OnDestroyDevice(bool fatal)
+{
+  // Nothing to save: the layout element descriptions cannot be retrieved from an existing input
+  // layout and were saved during the creation.
+  if (m_inputLayout != nullptr)
+    m_inputLayout.Reset();
+}
+
+void CWinShader::OnCreateDevice()
+{
+  if (!m_inputLayoutElementDesc.empty())
+    CreateInputLayoutResources(m_inputLayoutElementDesc);
+}
+
 bool CWinShader::CreateVertexBuffer(unsigned int count, unsigned int size)
 {
   if (!m_vb.Create(D3D11_BIND_VERTEX_BUFFER, count, size, DXGI_FORMAT_UNKNOWN, D3D11_USAGE_DYNAMIC))
@@ -45,7 +64,7 @@ bool CWinShader::CreateVertexBuffer(unsigned int count, unsigned int size)
   return true;
 }
 
-bool CWinShader::CreateInputLayout(D3D11_INPUT_ELEMENT_DESC *layout, unsigned numElements)
+bool CWinShader::CreateInputLayoutResources(std::span<const D3D11_INPUT_ELEMENT_DESC> elementDesc)
 {
   D3DX11_PASS_DESC desc = {};
   if (FAILED(m_effect.Get()->GetTechniqueByIndex(0)->GetPassByIndex(0)->GetDesc(&desc)))
@@ -55,7 +74,20 @@ bool CWinShader::CreateInputLayout(D3D11_INPUT_ELEMENT_DESC *layout, unsigned nu
   }
 
   ComPtr<ID3D11Device> pDevice = DX::DeviceResources::Get()->GetD3DDevice();
-  return SUCCEEDED(pDevice->CreateInputLayout(layout, numElements, desc.pIAInputSignature, desc.IAInputSignatureSize, &m_inputLayout));
+  return pDevice && SUCCEEDED(pDevice->CreateInputLayout(
+                        elementDesc.data(), elementDesc.size(), desc.pIAInputSignature,
+                        desc.IAInputSignatureSize, m_inputLayout.ReleaseAndGetAddressOf()));
+}
+
+bool CWinShader::CreateInputLayout(std::span<const D3D11_INPUT_ELEMENT_DESC> elementDesc)
+{
+  if (CreateInputLayoutResources(elementDesc))
+  {
+    m_inputLayoutElementDesc = elementDesc;
+    Register();
+    return true;
+  }
+  return false;
 }
 
 void CWinShader::SetTarget(CD3DTexture* target, ID3D11DepthStencilView* dsv)
@@ -299,12 +331,11 @@ bool COutputShader::Create(bool useLUT,
   }
 
   // Create input layout
-  D3D11_INPUT_ELEMENT_DESC layout[] =
-  {
-    { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-    { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+  static constexpr D3D11_INPUT_ELEMENT_DESC layout[] = {
+      {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0},
   };
-  return CWinShader::CreateInputLayout(layout, ARRAYSIZE(layout));
+  return CWinShader::CreateInputLayout(layout);
 }
 
 void COutputShader::Render(CD3DTexture& sourceTexture, CRect sourceRect, const CPoint points[4]
@@ -593,14 +624,13 @@ bool CYUV2RGBShader::Create(AVPixelFormat fmt, AVColorPrimaries dstPrimaries,
 
   CWinShader::CreateVertexBuffer(4, sizeof(Vertex));
   // Create input layout
-  D3D11_INPUT_ELEMENT_DESC layout[] =
-  {
-    { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0,  0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-    { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT,    0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-    { "TEXCOORD", 1, DXGI_FORMAT_R32G32_FLOAT,    0, 20, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+  static constexpr D3D11_INPUT_ELEMENT_DESC layout[] = {
+      {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 1, DXGI_FORMAT_R32G32_FLOAT, 0, 20, D3D11_INPUT_PER_VERTEX_DATA, 0},
   };
 
-  if (!CWinShader::CreateInputLayout(layout, ARRAYSIZE(layout)))
+  if (!CWinShader::CreateInputLayout(layout))
   {
     CLog::LogF(LOGERROR, "Failed to create input layout for Input Assembler.");
     return false;
@@ -843,12 +873,11 @@ bool CConvolutionShader1Pass::Create(ESCALINGMETHOD method, const std::shared_pt
     return false;
 
   // Create input layout
-  D3D11_INPUT_ELEMENT_DESC layout[] =
-  {
-    { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-    { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+  static constexpr D3D11_INPUT_ELEMENT_DESC layout[] = {
+      {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0},
   };
-  return CWinShader::CreateInputLayout(layout, ARRAYSIZE(layout));
+  return CWinShader::CreateInputLayout(layout);
 }
 
 void CConvolutionShader1Pass::Render(CD3DTexture& sourceTexture, CD3DTexture& target,
@@ -983,12 +1012,11 @@ bool CConvolutionShaderSeparable::Create(ESCALINGMETHOD method, const std::share
     return false;
 
   // Create input layout
-  D3D11_INPUT_ELEMENT_DESC layout[] =
-  {
-    { "POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0 },
-    { "TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0 },
+  static constexpr D3D11_INPUT_ELEMENT_DESC layout[] = {
+      {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0},
   };
-  return CWinShader::CreateInputLayout(layout, ARRAYSIZE(layout));
+  return CWinShader::CreateInputLayout(layout);
 }
 
 void CConvolutionShaderSeparable::Render(CD3DTexture& sourceTexture, CD3DTexture& target,

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -14,6 +14,7 @@
 #include "utils/Geometry.h"
 
 #include <array>
+#include <span>
 #include <vector>
 
 #include <DirectXMath.h>
@@ -27,7 +28,7 @@ class CRenderBuffer;
 
 using namespace DirectX;
 
-class CWinShader
+class CWinShader : ID3DResource
 {
 public:
   /*!
@@ -36,9 +37,12 @@ public:
    */
   void SetFinalShader(bool final) { m_isFinalShader = final; }
 
+  void OnDestroyDevice(bool fatal) override;
+  void OnCreateDevice() override;
+
 protected:
   CWinShader() = default;
-  virtual ~CWinShader() = default;
+  virtual ~CWinShader();
 
   virtual bool CreateVertexBuffer(unsigned int vertCount, unsigned int vertSize);
   virtual bool LockVertexBuffer(void **data);
@@ -46,19 +50,28 @@ protected:
   virtual bool LoadEffect(const std::string& filename, DefinesMap* defines);
   virtual bool Execute(const std::vector<CD3DTexture*>& targets, unsigned int vertexIndexStep);
   virtual void SetStepParams(unsigned stepIndex) { }
-  virtual bool CreateInputLayout(D3D11_INPUT_ELEMENT_DESC *layout, unsigned numElements);
+
+  /*!
+   * \brief Create the input layout of the shader.
+   * \param[in] elementDesc Descriptions of the input layout element. They are expected to live at
+   *                        least as long as this object.
+   * \return true for success, false otherwise.
+   */
+  virtual bool CreateInputLayout(std::span<const D3D11_INPUT_ELEMENT_DESC> elementDesc);
 
   CD3DEffect m_effect;
   CD3DTexture* m_target = nullptr;
 
 private:
   void SetTarget(CD3DTexture* target, ID3D11DepthStencilView* dsv);
+  bool CreateInputLayoutResources(std::span<const D3D11_INPUT_ELEMENT_DESC> elementDesc);
 
   CD3DBuffer m_vb;
   CD3DBuffer m_ib;
   unsigned int m_vbsize = 0;
   unsigned int m_vertsize = 0;
-  Microsoft::WRL::ComPtr<ID3D11InputLayout> m_inputLayout = nullptr;
+  Microsoft::WRL::ComPtr<ID3D11InputLayout> m_inputLayout;
+  std::span<const D3D11_INPUT_ELEMENT_DESC> m_inputLayoutElementDesc;
   bool m_isFinalShader{false};
 };
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Recreate vertex shader input layout D3D11 resources of the video renderer shaders when the D3D11 device is recreated, as expected by D3D.
The shaders are used at varying degrees by all render methods.

Slight correctness improvement for DXVA renderer, but it's not enough to fix video playback while moving the window between multiple screens. It still results in a black screen.
At least m_enumerator = nullptr; needs to be commented out in CProcessorHD::UnInit() but that causes a memory exception in the driver in the inputview creation and it's not clear to me why that happens so I'm leaving things as they are for now. A black screen is better than a crash.

Out of scope: hw accelerated decoding causes crashes for other reasons

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed while playing videos for other issue and moving the window across multiple screens connected to different GPUs.
Was not happening when moving between screens connected to the same GPU, the driver tolerated the issue.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Force-killed the graphics driver, moved Kodi fullscreen or window from screen to screen connected to different GPUs.
Software decoding only since hw-accelerated causes other crashes.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Partially fix crashes when moving Kodi to a different screen while playing video (Software decoding + Pixel Shaders or Software render methods)

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
