### PR TITLE
[GUILIB] CGUIImage: crossfade fixes

### DIFF
--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -202,6 +202,21 @@ void CGUIImage::ProcessState()
     return;
   }
 
+  // finish an interrupted fade on its more visible side so the new fade starts clean
+  if (m_isTransitioning && (m_textureNext->ReadyToRender() || m_textureNext->GetFileName().empty()))
+  {
+    // an image-less current has nothing to show, so a ready incoming always wins
+    if (m_textureNext->ReadyToRender() &&
+        (!m_textureCurrent->ReadyToRender() || m_currentFadeTime * 2 >= m_crossFadeTime))
+    {
+      std::swap(m_textureCurrent, m_textureNext);
+      std::swap(m_nameCurrent, m_nameNext);
+    }
+    m_textureCurrent->SetAlpha(0xff);
+    m_currentFadeTime = 0;
+    MarkDirtyRegion();
+  }
+
   // replace the in-flight texture, so the latest request always wins
   m_textureNext->SetFileName(fileName);
   m_nameNext = fileName;

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -202,11 +202,7 @@ void CGUIImage::ProcessState()
     return;
   }
 
-  // can't set new texture during animation.
-  if (m_isTransitioning && (m_textureNext->ReadyToRender() || m_textureNext->GetFileName().empty()))
-    return;
-
-  // finally, we can request a new image.
+  // replace the in-flight texture, so the latest request always wins
   m_textureNext->SetFileName(fileName);
   m_nameNext = fileName;
   m_isTransitioning = true;
@@ -594,6 +590,9 @@ std::string CGUIImage::GetFallback(const std::string& currentName)
 
 std::string CGUIImage::GetDescription(void) const
 {
+  // report the incoming texture as soon as it resolves so Control.GetLabel doesn't lag the fade
+  if (m_isTransitioning && (m_textureNext->ReadyToRender() || m_textureNext->GetFileName().empty()))
+    return m_textureNext->GetFileName();
   return GetFileName();
 }
 

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -324,10 +324,11 @@ void CGUIImage::Render()
   if (!IsVisible())
     return;
 
+  m_textureCurrent->Render();
+
+  // incoming above outgoing (v21), so a fading-out tail hides behind the new image
   if (m_isTransitioning)
     m_textureNext->Render();
-
-  m_textureCurrent->Render();
 
   CGUIControl::Render();
 }

--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -252,6 +252,10 @@ void CGUIImage::ProcessAllocation()
 
 void CGUIImage::ProcessNoTransition(unsigned int currentTime)
 {
+  // keep the clock current while not fading (v21 never reset it), so a fade pending
+  // across a processing gap settles on resume instead of replaying stale content
+  m_lastRenderTime = currentTime;
+
   if (m_textureCurrent->Process(currentTime))
     MarkDirtyRegion();
 }
@@ -263,6 +267,10 @@ void CGUIImage::ProcessInstantTransition(unsigned int currentTime)
 
   m_nameNext = "";
   m_textureNext->SetFileName("");
+
+  // the incoming texture carries a partial alpha when it completes an in-flight fade
+  m_textureCurrent->SetAlpha(0xff);
+  m_currentFadeTime = 0;
 
   m_textureCurrent->Process(currentTime);
 
@@ -303,7 +311,6 @@ void CGUIImage::ProcessFadingTransition(unsigned int currentTime)
     m_textureNext->SetFileName("");
 
     m_currentFadeTime = 0;
-    m_lastRenderTime = 0;
     m_isTransitioning = false;
   }
 
@@ -374,7 +381,6 @@ void CGUIImage::FreeTextures(bool immediately /* = false */)
   }
 
   m_isTransitioning = false;
-  m_lastRenderTime = 0;
   m_currentFadeTime = 0;
 }
 


### PR DESCRIPTION
## Description

Four crossfade fixes for CGUIImage, one commit each. The two-texture model unchanged.

1. Track the latest requested image across a crossfade. `Control.GetLabel` returned the old image until the fade completed. Now it returns the new image as soon as it is ready (or empty if it failed). A new image requested during a fade also had to wait for the fade to finish, so an image that was wrong for one frame stayed for a full fade. Now a new request just replaces the previous one.

2. Finish an interrupted crossfade before replacing it. Otherwise the old texture keeps its half-faded alpha while the new one loads, and the leftover fade time ends the next fade instantly. The more visible texture is set to full alpha and the fade time resets.

3. Restore the v21 render clock. The clock (`m_lastRenderTime`) only runs during a fade and is reset after. A control that is not processed for a while (a hidden control, a freed list item, another window) plays a full crossfade of the old image when it comes back with a new image pending. The previous image flashes on every change, at any scroll speed. Now the clock advances every processed frame and is never reset, so such a control gets the whole gap as frame time and the fade completes at once. Visible controls fade the full time as before, also after a texture load.

4. Render the incoming texture above the outgoing. The old texture currently draws on top, so what is left of it shows as a short ghost over the new image. Drawing the new texture last hides it, as v21 did. Once blending is corrected so the draw order has no influence on the result, this commit does nothing anymore. It is the top commit and can be dropped on its own.

## Motivation and context

Skins use `Control.GetLabel` of an image to drive visibility, variables and fallbacks. Every image change starts a crossfade, so the value is wrong for the length of the fade. Scrolling flashes the previous image. v21 has none of these issues. This fixes them inside the two-texture model.

## How has this been tested?

Built on current master and tested.

## What is the effect on users?

No more flashes of the previous image when scrolling, and `Control.GetLabel` of a crossfading image is current again.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
