### PR TITLE
[VideoPlayer] Fix VideoPlayer HDR labels using stale item metadata

### DIFF
--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -586,7 +586,6 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
         }
 
         return true;
-      case VIDEOPLAYER_HDR_TYPE:
       case LISTITEM_VIDEO_HDR_TYPE:
         if (tag->m_streamDetails.GetStreamCount(CStreamDetail::VIDEO) > 1 &&
             tag->m_streamDetails.GetVideoHdrType(2) == "dolbyvision")
@@ -594,7 +593,6 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
         else
           value = tag->m_streamDetails.GetVideoHdrType();
         return true;
-      case VIDEOPLAYER_HDR_DETAIL:
       case LISTITEM_VIDEO_HDR_DETAIL:
         if (tag->m_streamDetails.GetStreamCount(CStreamDetail::VIDEO) > 1 &&
             tag->m_streamDetails.GetVideoHdrType(2) == "dolbyvision")


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
VideoPlayer.HDRType and VideoPlayer.HDRDetail were handled together with ListItem video HDR labels, causing them to read stream details from the current item tag before falling back to live playback info.

If stream details were missing or stale when playback started, the VideoPlayer labels could show SDR until the item was rescanned or played again. Keep ListItem labels tag-based, but let VideoPlayer labels use the live player stream info.

This restores the intended split:
- VideoPlayer.* uses live player stream info
- ListItem.* uses item/DB stream details

Regression introduced by #27914

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #28475

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS 11

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
