### PR TITLE
LinuxRendererGL/GLES: fix multipass scalers after renderer flush

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9579,7 +9579,7 @@ msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 msgctxt "#16315"
-msgid "Lanczos3 - Optimised"
+msgid "Lanczos3 - Fast"
 msgstr ""
 
 #. value for setting 'Create versions for similar videos'
@@ -9622,7 +9622,7 @@ msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
 msgctxt "#16323"
-msgid "Spline36 - Optimised"
+msgid "Spline36 - Fast"
 msgstr ""
 
 #: xbmc/video/dialogs/GUIDialogVideoSettings.cpp

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGL.cpp
@@ -202,9 +202,9 @@ bool CLinuxRendererGL::ValidateRenderTarget()
     }
 
     // trigger update of video filters
-    m_scalingMethodGui = (ESCALINGMETHOD)-1;
+    m_scalingMethodGui = VS_SCALINGMETHOD_MAX;
 
-     // create the yuv textures
+    // create the yuv textures
     UpdateVideoFilter();
     LoadShaders();
     if (m_renderMethod < 0)
@@ -244,7 +244,7 @@ bool CLinuxRendererGL::Configure(const VideoPicture &picture, float fps, unsigne
   ManageRenderArea();
 
   m_bConfigured = true;
-  m_scalingMethodGui = (ESCALINGMETHOD)-1;
+  m_scalingMethodGui = VS_SCALINGMETHOD_MAX;
   m_scalingMethod = m_videoSettings.m_ScalingMethod;
 
   // Ensure that textures are recreated and rendering starts only after the 1st
@@ -1313,15 +1313,24 @@ void CLinuxRendererGL::RenderToFBO(int index, int field, bool weave /*= false*/)
     LoadShaders(m_currentField);
   }
 
+  //! @todo Believed dead: every FBO invalidation clears m_bValidated, and
+  //! ValidateRenderTarget resets the filter cache so UpdateVideoFilter
+  //! recreates the FBO before any multipass render. Kept as a failsafe
+  //! against unenumerated invalidation paths.
   if (!m_fbo.fbo.IsValid())
   {
+    CLog::Log(LOGWARNING, "GL: multipass FBO invalid at render time, recreating");
+
     if (!m_fbo.fbo.Initialize())
     {
       CLog::Log(LOGERROR, "GL: Error initializing FBO");
       return;
     }
 
-    if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight, GL_RGBA, GL_SHORT))
+    // Recreate with the format/type UpdateVideoFilter settled on, so the
+    // intermediate FBO keeps the bit depth configured by hqscalerprecision.
+    if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight,
+                                          m_intermediateFormat, m_intermediateType, GL_NEAREST))
     {
       CLog::Log(LOGERROR, "GL: Error creating texture and binding to FBO");
       return;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -771,9 +771,10 @@ void CLinuxRendererGLES::UpdateVideoFilter()
     // (YUV2RGBFilterShader with textureGather). On lower versions, fall through to
     // multi-pass FBO path. Matches GL 4.0+ single-pass / GL <4.0 multi-pass pattern.
     // On GLES, VAAPI maps to SHADER_NV12_RRG (GL maps it to SHADER_NV12).
+    // Only patterns the filter shader implements may pass: >8-bit planar
+    // (XBMC_YV12_HI) has no sampling block there and takes the multipass path.
     EShaderFormat fmt = GetShaderFormat();
-    if (fmt == SHADER_NV12 || fmt == SHADER_NV12_RRG ||
-        (fmt >= SHADER_YV12 && fmt <= SHADER_YV12_16))
+    if (fmt == SHADER_NV12 || fmt == SHADER_NV12_RRG || fmt == SHADER_YV12)
     {
       uint32_t major, minor;
       m_renderSystem->GetRenderVersion(major, minor);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -143,7 +143,10 @@ bool CLinuxRendererGLES::ValidateRenderTarget()
       DeleteTexture(i);
     }
 
-     // create the yuv textures
+    // trigger update of video filters
+    m_scalingMethodGui = VS_SCALINGMETHOD_MAX;
+
+    // create the yuv textures
     UpdateVideoFilter();
     LoadShaders();
 
@@ -199,7 +202,7 @@ bool CLinuxRendererGLES::Configure(const VideoPicture &picture, float fps, unsig
   ManageRenderArea();
 
   m_bConfigured = true;
-  m_scalingMethodGui = (ESCALINGMETHOD)-1;
+  m_scalingMethodGui = VS_SCALINGMETHOD_MAX;
   m_scalingMethod = m_videoSettings.m_ScalingMethod;
 
   // Ensure that textures are recreated and rendering starts only after the 1st
@@ -767,8 +770,10 @@ void CLinuxRendererGLES::UpdateVideoFilter()
     // On GLES 3.1+, FAST scalers use a single-pass combined YUV+convolution shader
     // (YUV2RGBFilterShader with textureGather). On lower versions, fall through to
     // multi-pass FBO path. Matches GL 4.0+ single-pass / GL <4.0 multi-pass pattern.
+    // On GLES, VAAPI maps to SHADER_NV12_RRG (GL maps it to SHADER_NV12).
     EShaderFormat fmt = GetShaderFormat();
-    if (fmt == SHADER_NV12 || (fmt >= SHADER_YV12 && fmt <= SHADER_YV12_16))
+    if (fmt == SHADER_NV12 || fmt == SHADER_NV12_RRG ||
+        (fmt >= SHADER_YV12 && fmt <= SHADER_YV12_16))
     {
       uint32_t major, minor;
       m_renderSystem->GetRenderVersion(major, minor);
@@ -1311,16 +1316,24 @@ void CLinuxRendererGLES::RenderToFBO(int index, int field)
     LoadShaders(m_currentField);
   }
 
+  //! @todo Believed dead: every FBO invalidation clears m_bValidated, and
+  //! ValidateRenderTarget resets the filter cache so UpdateVideoFilter
+  //! recreates the FBO before any multipass render. Kept as a failsafe
+  //! against unenumerated invalidation paths.
   if (!m_fbo.fbo.IsValid())
   {
+    CLog::Log(LOGWARNING, "GLES: multipass FBO invalid at render time, recreating");
+
     if (!m_fbo.fbo.Initialize())
     {
       CLog::Log(LOGERROR, "GLES: Error initializing FBO");
       return;
     }
 
-    if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight, GL_RGBA,
-                                          GL_SHORT))
+    // Recreate with the format/type UpdateVideoFilter settled on, so the
+    // intermediate FBO keeps the bit depth configured by hqscalerprecision.
+    if (!m_fbo.fbo.CreateAndBindToTexture(GL_TEXTURE_2D, m_sourceWidth, m_sourceHeight,
+                                          m_intermediateFormat, m_intermediateType, GL_NEAREST))
     {
       CLog::Log(LOGERROR, "GLES: Error creating texture and binding to FBO");
       return;


### PR DESCRIPTION
## Description

Fixes #28518.

There was a latent bug in GLES renderer due to a flush&reset that was added to GL that was not added to GLES.  

Also, cleanup use of scaler sentinels and fix some stale comments.

Also, fix an edge case of high-bit-depth software decode (eg Hi10P) hitting the singlepass scaler shader  path.

## Motivation and context
Fixed #28518 

## How has this been tested?
(waiting on @chewitt and @smp79 )

## What is the effect on users?
Changing scalers dynamically or changing streams (eg via inputstream addon) should now properly reset the GLES shader.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
