### PR TITLE
VideoPlayer: Fix time and chapter after chapter jump

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5526,7 +5526,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
   // The current chapter provided by the demuxer/inputstream is ahead by a cache duration most of the time.
   if (chapterNbEnabled)
   {
-    const std::chrono::milliseconds currentTime{llrint(m_State.time)};
+    const std::chrono::milliseconds currentTime{llrint(state.time)};
     const int playPosChapter = CalculateCurrentChapter(currentTime, state.chapters);
 
     // Successfully calculated a current chapter from the play position?

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5415,7 +5415,12 @@ void CVideoPlayer::UpdatePlayState(double timeout)
         m_pDemuxer->GetChapterName(p.first, i + 1);
       }
     }
-    state.time = m_clock.GetClock(false) * 1000 / DVD_TIME_BASE;
+    state.time = DVD_TIME_TO_MSEC(m_clock.GetClock(false));
+    // Let the clock catch up after seek
+    if (m_CurrentVideo.startpts != DVD_NOPTS_VALUE &&
+        state.time < DVD_TIME_TO_MSEC(m_CurrentVideo.startpts))
+      state.time = DVD_TIME_TO_MSEC(m_CurrentVideo.startpts);
+
     state.timeMax = m_pDemuxer->GetStreamLength();
   }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5415,7 +5415,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
         m_pDemuxer->GetChapterName(p.first, i + 1);
       }
     }
-    state.time = DVD_TIME_TO_MSEC(m_clock.GetClock(false));
+    state.time = DVD_TIME_TO_MSEC(m_clock.GetClock());
     // Let the clock catch up after seek
     if (m_CurrentVideo.startpts != DVD_NOPTS_VALUE &&
         state.time < DVD_TIME_TO_MSEC(m_CurrentVideo.startpts))
@@ -5463,7 +5463,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     if (pTimes && pTimes->GetTimes(times))
     {
       state.startTime = times.startTime;
-      state.time = (m_clock.GetClock(false) - times.ptsStart) * 1000 / DVD_TIME_BASE;
+      state.time = (m_clock.GetClock() - times.ptsStart) * 1000 / DVD_TIME_BASE;
       state.timeMax = (times.ptsEnd - times.ptsStart) * 1000 / DVD_TIME_BASE;
       state.timeMin = (times.ptsBegin - times.ptsStart) * 1000 / DVD_TIME_BASE;
       state.time_offset = -times.ptsStart;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The are a couple factors in Videoplayer that affect the time and chapter displayed after jumping to the next or previous chapter.

- the current chapter, recalculated every cycle in `CVideoPlayer::UpdatePlayState`, used the cycle-old time instead of the fresh time.

- the chapter jump causes two Discontinuity() calls, first in `FlushBuffer()` with the target pts (perfect), and then another in `HandlePlaySpeed()` on A/V sync, with clock about 100ms earlier than the target time > main cause for the visual glitch.
The offset comes from the cachetime/cachetotal values for audio (actual calculations) and video (const values with a TODO note). I applied a clamp to the clock value to get over the discontinuity but don't really know if it would be more appropriate to find a way to ignore the streams cache values after seek (are they even valid)

The time after chapter jump is stable with the clock clamping.

- with the main cause above taken care of, the displayed time is OK (and rounded for display anyway...) but the current chapter still hiccups due to a residual pts difference of a few milliseconds after the jump. This comes from calling single param `Discontinuity()` in `FlushBuffers()` and `HandlePlaySpeed()`, which uses interpolated clock time, but reading raw clock in `UpdatePlayState()`. The clocks difference account for the residual difference.
The clock read and write need to be either both interpolated or both raw. I wasn't sure of the rationale for the way things are today and opted to change `UpdatePlayState()` to use interpolated clock with `GetClock()` instead of `GetClock(false)`.
There seem to be less possible downstream repercussions from consumers of the time and play state produced by `UpdatePlayState()`. The alternative (raw clock for both `Discontinuity()` and `UpdatePlayState`) appears to work as well.

The residual difference disappeared with the same clock written and read, and the chapter number is stable after chapter jump.
A float epsilon comparison is not even needed because the microsecond timestamp is rounded to nearest millisecond before current chapter calculation.

@FernetMenta if you have the time I'd really appreciate your input about the second discontinuity handling and the use of interpolated vs raw clock.

- included a minor related fix for chapters timestamps not adjusted for EDL cuts in videos with inputstream interface active (actual input stream, dvd, bluray) since I was reviewing nearby code

out of scope: time flicker when using the incremental time jump (ex. press right key for a 10 second jump, twice for a 30 second jump)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

After jumping to the next or previous chapter, the time and current chapter visible in the OSD flicker briefly. They initially show the new target time and chapter, briefly roll back and finally revert to the new time and chapter.

This doesn't happen when playback is paused or when jumping to a bookmark.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Multiple files with chapters.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Stable time and chapter displayed after jumping to next or previous chapter.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
