### PR TITLE
StereoscopicsManager: Trigger 3D modeswitch immediately after UI settings change

### DIFF
--- a/xbmc/guilib/StereoscopicsManager.cpp
+++ b/xbmc/guilib/StereoscopicsManager.cpp
@@ -508,6 +508,20 @@ void CStereoscopicsManager::ApplyStereoMode(const RenderStereoMode mode, bool no
     CServiceBroker::GetWinSystem()->GetGfxContext().SetStereoMode(mode);
     CLog::Log(LOGDEBUG, "StereoscopicsManager: stereo mode changed to {}",
               ConvertGuiStereoModeToString(mode));
+    {
+      const auto& components = CServiceBroker::GetAppComponents();
+      const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+      if (appPlayer && !appPlayer->IsPlaying())
+      {
+        const RESOLUTION_INFO curInfo =
+            CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
+        const bool is3D = (mode != RenderStereoMode::OFF && mode != RenderStereoMode::MONO);
+        RESOLUTION res = CResolutionUtils::ChooseBestResolution(
+            curInfo.fRefreshRate, curInfo.iScreenWidth, curInfo.iScreenHeight, is3D);
+        CServiceBroker::GetWinSystem()->GetGfxContext().SetVideoResolution(res, true);
+      }
+    }
+
     if (notify)
       CGUIDialogKaiToast::QueueNotification(
           CGUIDialogKaiToast::Info,


### PR DESCRIPTION
## Description
This PR fixes the behavior when changing the current 3D output mode in the UI settings. So far the mode changed only after the next movie playback stopped although the new mode was notified on the osd immediately. Now the behavior is more in line with e.g. changing the output resolution. The 3D output mode switches immediately after the setting is changed.


## Motivation and context
The previous behaviour of the current 3D output mode settings wasn't in line with other settings which can be changed via the osd. E.g. changing the display resolution leads to immediate modeswitch to the new resolution.
Claude helped me to analzye the problem and provided the code.

## How has this been tested?
Tested with current Kodi Piers master on an Nvidia Shield (only SBS/TAB) and the latest CoreELEC22/Kodi (also Framepacked 3D). Changing the current 3D output mode leads to an immediate switch to the target mode, no side effects observed. 

## What is the effect on users?
For the few remaining 3D users the UI experience improves a little, for everyone else it changes nothing.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
