### PR TITLE
[python] [cec] Add cec status builtin

### DIFF
--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -30,6 +30,7 @@
 #include "messaging/ApplicationMessenger.h"
 #include "network/Network.h"
 #include "network/NetworkServices.h"
+#include "peripherals/Peripherals.h"
 #include "playlists/PlayListTypes.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
@@ -417,6 +418,15 @@ namespace XBMCAddon
       return appPower->GlobalIdleTime();
     }
 
+    int getDevicePowerStatus()
+    {
+      XBMC_TRACE;
+      // libCEC may block briefly on a CEC bus request when its cache is stale,
+      // so release the GIL for the duration of the call.
+      DelayedCallGuard dg;
+      return static_cast<int>(CServiceBroker::GetPeripherals().GetDevicePowerStatus());
+    }
+
     String getCacheThumbName(const String& path)
     {
       XBMC_TRACE;
@@ -649,6 +659,32 @@ namespace XBMCAddon
     int getISO_639_1() { return CLangCodeExpander::ISO_639_1; }
     int getISO_639_2(){ return CLangCodeExpander::ISO_639_2; }
     int getENGLISH_NAME() { return CLangCodeExpander::ENGLISH_NAME; }
+
+    // Device power status (HDMI-CEC)
+    int getDEVICE_POWER_NO_ADAPTER()
+    {
+      return static_cast<int>(PERIPHERALS::CecPowerStatus::NO_ADAPTER);
+    }
+    int getDEVICE_POWER_ON()
+    {
+      return static_cast<int>(PERIPHERALS::CecPowerStatus::ON);
+    }
+    int getDEVICE_POWER_STANDBY()
+    {
+      return static_cast<int>(PERIPHERALS::CecPowerStatus::STANDBY);
+    }
+    int getDEVICE_POWER_TRANSITION_TO_ON()
+    {
+      return static_cast<int>(PERIPHERALS::CecPowerStatus::TRANSITION_TO_ON);
+    }
+    int getDEVICE_POWER_TRANSITION_TO_STANDBY()
+    {
+      return static_cast<int>(PERIPHERALS::CecPowerStatus::TRANSITION_TO_STANDBY);
+    }
+    int getDEVICE_POWER_UNKNOWN()
+    {
+      return static_cast<int>(PERIPHERALS::CecPowerStatus::UNKNOWN);
+    }
 
     const int lLOGDEBUG = LOGDEBUG;
   }

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -427,6 +427,12 @@ namespace XBMCAddon
       return static_cast<int>(CServiceBroker::GetPeripherals().GetDevicePowerStatus(adapterName));
     }
 
+    std::vector<String> getCecAdapterNames()
+    {
+      XBMC_TRACE;
+      return CServiceBroker::GetPeripherals().GetCecAdapterNames();
+    }
+
     String getCacheThumbName(const String& path)
     {
       XBMC_TRACE;

--- a/xbmc/interfaces/legacy/ModuleXbmc.cpp
+++ b/xbmc/interfaces/legacy/ModuleXbmc.cpp
@@ -418,13 +418,13 @@ namespace XBMCAddon
       return appPower->GlobalIdleTime();
     }
 
-    int getDevicePowerStatus()
+    int getDevicePowerStatus(const String& adapterName /* = emptyString */)
     {
       XBMC_TRACE;
       // libCEC may block briefly on a CEC bus request when its cache is stale,
       // so release the GIL for the duration of the call.
       DelayedCallGuard dg;
-      return static_cast<int>(CServiceBroker::GetPeripherals().GetDevicePowerStatus());
+      return static_cast<int>(CServiceBroker::GetPeripherals().GetDevicePowerStatus(adapterName));
     }
 
     String getCacheThumbName(const String& path)

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -618,9 +618,13 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
     ///
     /// \ingroup python_xbmc
-    /// @brief \python_func{ xbmc.getDevicePowerStatus() }
+    /// @brief \python_func{ xbmc.getDevicePowerStatus([adapterName]) }
     /// Get the power status of the device attached via HDMI-CEC.
     ///
+    /// @param adapterName           [opt] string - the CEC adapter to query, either its name
+    ///                              (e.g. `HDMI 1`) or, for an adapter that the driver didn't
+    ///                              name, its port. Defaults to empty, which queries the first
+    ///                              adapter that reports a status.
     /// @return int - one of the following constants:
     /// | Value                                   | Description                          |
     /// |----------------------------------------:|:-------------------------------------|
@@ -633,8 +637,10 @@ namespace XBMCAddon
     ///
     /// @note This is the result of calling libCEC's GetDevicePowerStatus.
     /// `DEVICE_POWER_UNKNOWN` means the device could not be found or queried on the CEC
-    /// bus. `DEVICE_POWER_NO_ADAPTER` means no CEC adapter is present. If more than
-    /// one CEC adapter is present, the status of the first one is returned.
+    /// bus. `DEVICE_POWER_NO_ADAPTER` means no CEC adapter is present, no adapter matches
+    /// the given name, or the matching adapter isn't running.
+    ///
+    /// @note The name is matched case insensitively.
     ///
     ///
     /// ------------------------------------------------------------------------
@@ -645,12 +651,15 @@ namespace XBMCAddon
     /// ..
     /// if xbmc.getDevicePowerStatus() == xbmc.DEVICE_POWER_ON:
     ///     xbmc.log('Device is on')
+    ///
+    /// if xbmc.getDevicePowerStatus('HDMI 2') == xbmc.DEVICE_POWER_STANDBY:
+    ///     xbmc.log('The device on HDMI 2 is in standby')
     /// ..
     /// ~~~~~~~~~~~~~
     ///
-    getDevicePowerStatus();
+    getDevicePowerStatus(...);
 #else
-    int getDevicePowerStatus();
+    int getDevicePowerStatus(const String& adapterName = emptyString);
 #endif
 
 #ifdef DOXYGEN_SHOULD_USE_THIS

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -665,6 +665,32 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
     ///
     /// \ingroup python_xbmc
+    /// @brief \python_func{ xbmc.getCecAdapterNames() }
+    /// Get the names of the HDMI-CEC adapters that are present.
+    ///
+    /// @return list - the name of each adapter, in the form that
+    /// \ref getDevicePowerStatus accepts.
+    ///
+    ///
+    /// ------------------------------------------------------------------------
+    /// @python_v22 New function added.
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ..
+    /// for adapter in xbmc.getCecAdapterNames():
+    ///     xbmc.log(f'{adapter}: {xbmc.getDevicePowerStatus(adapter)}')
+    /// ..
+    /// ~~~~~~~~~~~~~
+    ///
+    getCecAdapterNames();
+#else
+    std::vector<String> getCecAdapterNames();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+    ///
+    /// \ingroup python_xbmc
     /// @brief \python_func{ xbmc.getCacheThumbName(path) }
     /// Get thumb cache filename.
     ///

--- a/xbmc/interfaces/legacy/ModuleXbmc.h
+++ b/xbmc/interfaces/legacy/ModuleXbmc.h
@@ -618,6 +618,44 @@ namespace XBMCAddon
 #ifdef DOXYGEN_SHOULD_USE_THIS
     ///
     /// \ingroup python_xbmc
+    /// @brief \python_func{ xbmc.getDevicePowerStatus() }
+    /// Get the power status of the device attached via HDMI-CEC.
+    ///
+    /// @return int - one of the following constants:
+    /// | Value                                   | Description                          |
+    /// |----------------------------------------:|:-------------------------------------|
+    /// | xbmc.DEVICE_POWER_NO_ADAPTER            | No CEC adapter present               |
+    /// | xbmc.DEVICE_POWER_ON                    | Device is powered on                 |
+    /// | xbmc.DEVICE_POWER_STANDBY               | Device is in standby                 |
+    /// | xbmc.DEVICE_POWER_TRANSITION_TO_ON      | Device is powering on                |
+    /// | xbmc.DEVICE_POWER_TRANSITION_TO_STANDBY | Device is going to standby           |
+    /// | xbmc.DEVICE_POWER_UNKNOWN               | Power status could not be determined |
+    ///
+    /// @note This is the result of calling libCEC's GetDevicePowerStatus.
+    /// `DEVICE_POWER_UNKNOWN` means the device could not be found or queried on the CEC
+    /// bus. `DEVICE_POWER_NO_ADAPTER` means no CEC adapter is present. If more than
+    /// one CEC adapter is present, the status of the first one is returned.
+    ///
+    ///
+    /// ------------------------------------------------------------------------
+    /// @python_v22 New function added.
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ..
+    /// if xbmc.getDevicePowerStatus() == xbmc.DEVICE_POWER_ON:
+    ///     xbmc.log('Device is on')
+    /// ..
+    /// ~~~~~~~~~~~~~
+    ///
+    getDevicePowerStatus();
+#else
+    int getDevicePowerStatus();
+#endif
+
+#ifdef DOXYGEN_SHOULD_USE_THIS
+    ///
+    /// \ingroup python_xbmc
     /// @brief \python_func{ xbmc.getCacheThumbName(path) }
     /// Get thumb cache filename.
     ///
@@ -917,6 +955,13 @@ namespace XBMCAddon
     SWIG_CONSTANT_FROM_GETTER(int, ISO_639_1);
     SWIG_CONSTANT_FROM_GETTER(int, ISO_639_2);
     SWIG_CONSTANT_FROM_GETTER(int, ENGLISH_NAME);
+
+    SWIG_CONSTANT_FROM_GETTER(int, DEVICE_POWER_NO_ADAPTER);
+    SWIG_CONSTANT_FROM_GETTER(int, DEVICE_POWER_ON);
+    SWIG_CONSTANT_FROM_GETTER(int, DEVICE_POWER_STANDBY);
+    SWIG_CONSTANT_FROM_GETTER(int, DEVICE_POWER_TRANSITION_TO_ON);
+    SWIG_CONSTANT_FROM_GETTER(int, DEVICE_POWER_TRANSITION_TO_STANDBY);
+    SWIG_CONSTANT_FROM_GETTER(int, DEVICE_POWER_UNKNOWN);
 #if 0
     void registerMonitor(Monitor* monitor);
     void unregisterMonitor(Monitor* monitor);

--- a/xbmc/peripherals/PeripheralTypes.h
+++ b/xbmc/peripherals/PeripheralTypes.h
@@ -81,6 +81,22 @@ enum PeripheralType
   PERIPHERAL_MOUSE,
 };
 
+/*!
+ * \brief Power status of the device attached via HDMI-CEC.
+ *
+ * This is the result of calling libCEC's GetDevicePowerStatus. UNKNOWN means the device could not
+ * be found or queried on the CEC bus. NO_ADAPTER means no CEC adapter is present.
+ */
+enum class CecPowerStatus
+{
+  NO_ADAPTER = -1, //!< no CEC adapter present, or libCEC not built
+  ON = 0,
+  STANDBY = 1,
+  TRANSITION_TO_ON = 2,
+  TRANSITION_TO_STANDBY = 3,
+  UNKNOWN = 4,
+};
+
 class CPeripheral;
 using PeripheralPtr = std::shared_ptr<CPeripheral>;
 using PeripheralVector = std::vector<PeripheralPtr>;

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -886,6 +886,23 @@ CecPowerStatus CPeripherals::GetDevicePowerStatus(const std::string& adapterName
   return CecPowerStatus::NO_ADAPTER;
 }
 
+std::vector<std::string> CPeripherals::GetCecAdapterNames() const
+{
+  std::vector<std::string> names;
+
+  if (SupportsCEC())
+  {
+    PeripheralVector peripherals;
+    GetPeripheralsWithFeature(peripherals, FEATURE_CEC);
+
+    for (const auto& peripheral : peripherals)
+      names.emplace_back(peripheral->DeviceName().empty() ? peripheral->Location()
+                                                          : peripheral->DeviceName());
+  }
+
+  return names;
+}
+
 EventPollHandlePtr CPeripherals::RegisterEventPoller()
 {
   return m_eventScanner->RegisterPollHandle();

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -859,17 +859,27 @@ bool CPeripherals::ToggleDeviceState(CecStateChange mode /*= STATE_SWITCH_TOGGLE
   return ret;
 }
 
-CecPowerStatus CPeripherals::GetDevicePowerStatus()
+CecPowerStatus CPeripherals::GetDevicePowerStatus(const std::string& adapterName /* = "" */)
 {
   PeripheralVector peripherals;
 
   if (SupportsCEC() && GetPeripheralsWithFeature(peripherals, FEATURE_CEC))
   {
-    for (auto& peripheral : peripherals)
+    for (const auto& peripheral : peripherals)
     {
+      /* an empty name matches every adapter, so the first one that has a status is returned */
+      if (!adapterName.empty() &&
+          !StringUtils::EqualsNoCase(peripheral->DeviceName(), adapterName) &&
+          !StringUtils::EqualsNoCase(peripheral->Location(), adapterName))
+        continue;
+
       std::shared_ptr<CPeripheralCecAdapter> cecDevice =
           std::static_pointer_cast<CPeripheralCecAdapter>(peripheral);
-      return cecDevice->GetDevicePowerStatus();
+
+      /* adapters that aren't running report NO_ADAPTER, so keep looking */
+      const CecPowerStatus status = cecDevice->GetDevicePowerStatus();
+      if (status != CecPowerStatus::NO_ADAPTER)
+        return status;
     }
   }
 

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -859,6 +859,23 @@ bool CPeripherals::ToggleDeviceState(CecStateChange mode /*= STATE_SWITCH_TOGGLE
   return ret;
 }
 
+CecPowerStatus CPeripherals::GetDevicePowerStatus()
+{
+  PeripheralVector peripherals;
+
+  if (SupportsCEC() && GetPeripheralsWithFeature(peripherals, FEATURE_CEC))
+  {
+    for (auto& peripheral : peripherals)
+    {
+      std::shared_ptr<CPeripheralCecAdapter> cecDevice =
+          std::static_pointer_cast<CPeripheralCecAdapter>(peripheral);
+      return cecDevice->GetDevicePowerStatus();
+    }
+  }
+
+  return CecPowerStatus::NO_ADAPTER;
+}
+
 EventPollHandlePtr CPeripherals::RegisterEventPoller()
 {
   return m_eventScanner->RegisterPollHandle();

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -236,6 +236,13 @@ public:
   CecPowerStatus GetDevicePowerStatus(const std::string& adapterName = "");
 
   /*!
+   * @brief Get the names of the CEC adapters that are present.
+   * @return The name of each adapter, or its location when the bus didn't name it. These are the
+   * names that GetDevicePowerStatus() matches against.
+   */
+  std::vector<std::string> GetCecAdapterNames() const;
+
+  /*!
    * @brief Try to mute the audio via a peripheral.
    * @return True when this change was handled by a peripheral (and should not be handled by
    * anything else), false otherwise.

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -227,11 +227,13 @@ public:
 
   /*!
    * @brief Query the power status of the device attached via HDMI-CEC.
-   * @return The reported power status, or CecPowerStatus::NO_ADAPTER when no CEC
-   * adapter is present. If more than one CEC adapter is present, the status of
-   * the first one is returned.
+   * @param adapterName The name of the CEC adapter to query, matched case insensitively against
+   * the adapter's device name and against its location, so unnamed adapters can be addressed by
+   * port. When empty, the first adapter that reports a status is queried.
+   * @return The reported power status, or CecPowerStatus::NO_ADAPTER when no CEC adapter is
+   * present, when no adapter matches the name, or when the matching adapter isn't running.
    */
-  CecPowerStatus GetDevicePowerStatus();
+  CecPowerStatus GetDevicePowerStatus(const std::string& adapterName = "");
 
   /*!
    * @brief Try to mute the audio via a peripheral.

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -226,6 +226,14 @@ public:
   bool ToggleDeviceState(const CecStateChange mode = STATE_SWITCH_TOGGLE);
 
   /*!
+   * @brief Query the power status of the device attached via HDMI-CEC.
+   * @return The reported power status, or CecPowerStatus::NO_ADAPTER when no CEC
+   * adapter is present. If more than one CEC adapter is present, the status of
+   * the first one is returned.
+   */
+  CecPowerStatus GetDevicePowerStatus();
+
+  /*!
    * @brief Try to mute the audio via a peripheral.
    * @return True when this change was handled by a peripheral (and should not be handled by
    * anything else), false otherwise.

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1904,3 +1904,25 @@ bool CPeripheralCecAdapter::ToggleDeviceState(CecStateChange mode /*= STATE_SWIT
 
   return false;
 }
+
+CecPowerStatus CPeripheralCecAdapter::GetDevicePowerStatus(void)
+{
+  if (!IsRunning())
+    return CecPowerStatus::NO_ADAPTER;
+
+  // libCEC caches the power status internally and only re-requests it from the device when
+  // needed. So this call is cheap.
+  switch (m_cecAdapter->GetDevicePowerStatus(CECDEVICE_TV))
+  {
+    case CEC_POWER_STATUS_ON:
+      return CecPowerStatus::ON;
+    case CEC_POWER_STATUS_STANDBY:
+      return CecPowerStatus::STANDBY;
+    case CEC_POWER_STATUS_IN_TRANSITION_STANDBY_TO_ON:
+      return CecPowerStatus::TRANSITION_TO_ON;
+    case CEC_POWER_STATUS_IN_TRANSITION_ON_TO_STANDBY:
+      return CecPowerStatus::TRANSITION_TO_STANDBY;
+    default:
+      return CecPowerStatus::UNKNOWN;
+  }
+}

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -31,6 +31,7 @@ public:
   {
     return false;
   }
+  CecPowerStatus GetDevicePowerStatus(void) { return CecPowerStatus::NO_ADAPTER; }
 
   int GetButton(void) { return 0; }
   unsigned int GetHoldTime(void) { return 0; }
@@ -130,6 +131,7 @@ public:
   void ActivateSource(void);
   void StandbyDevices(void);
   bool ToggleDeviceState(CecStateChange mode = STATE_SWITCH_TOGGLE, bool forceType = false);
+  CecPowerStatus GetDevicePowerStatus(void);
 
 private:
   bool InitialiseFeature(const PeripheralFeature feature) override;


### PR DESCRIPTION
## Description
This creates a new function `getDevicePowerStatus` (that can be called from python) to check the status of a CEC device. It basically just proxies the result of `libCEC`'s existing `GetDevicePowerStatus` back to the caller.

## Motivation and context
This is useful for things like screensavers that might not want to trigger if the TV is already off. (In particular I have the issue that [aerial](https://kodi.wiki/view/Add-on:Aerial) triggers with my TV off and turns it back on.)

I tried to search the forums, but "cec" is too common so couldn't narrow down and find any requests for this, but it does feel generally useful to me.

## How has this been tested?
Created a script and called the new function in different states, ensuring it works.

## What is the effect on users?
No effect

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
