### PR TITLE
[keyboard] Fix keyboard layout sorting

### DIFF
--- a/xbmc/input/keyboard/KeyboardLayoutManager.cpp
+++ b/xbmc/input/keyboard/KeyboardLayoutManager.cpp
@@ -133,7 +133,7 @@ namespace
 {
 inline bool LayoutSort(const StringSettingOption& i, const StringSettingOption& j)
 {
-  return (i.value < j.value);
+  return (i.label < j.label);
 }
 } // namespace
 

--- a/xbmc/platform/linux/input/LibInputSettings.cpp
+++ b/xbmc/platform/linux/input/LibInputSettings.cpp
@@ -27,7 +27,7 @@ namespace
 {
   inline bool LayoutSort(const StringSettingOption& i, const StringSettingOption& j)
   {
-    return (i.value < j.value);
+    return (i.label < j.label);
   }
 } // unnamed namespace
 


### PR DESCRIPTION
## Description
The keyboard layouts have to be sorted by label/description, not by value.

While it does not make a difference in KeyboardLayoutManager, as label and value are set to the same string, it leads to rather weird sorting in libinput:

value is set to the xkb layout, eg "gb" for English (UK) and "us" for English (US) which results in both entries being very far apart.

The issue was introduced in commit 0028699753f97 "[settings] Add possibility to supply properties (name-value-pairs) with setting options." which switched the std::pair to StringSettingOption and introduced the LayoutSort helper function.

When comparing two pairs the < operator compares the first elements (i.e. the label) first and only looks at the second elements if the first ones are equal.

LayoutSort however compared the value which didn't match the old behaviour.

Fix this both in KeyboardLayoutManager and LibInputSettings so that LayoutSort is identical in both files.

Fixes: #28527

## Motivation and context
Fixing #28527 to make it easier to change the hardware keyboard layout on Linux/GBM

## How has this been tested?
Tested on LibreELEC RPi5 (gbm) and verified that the hardware keyboard layout list is sorted as expected.
Also verified that the virtual/onscreen keyboard layout list is still sorted as before.

## What is the effect on users?
Allow Linux GBM users to change the keyboard layout without having to scroll through the whole (rather unexpectedly sorted) list to locate the desired layout.

## Screenshots (if appropriate):
Before:
<img width="1920" height="1200" alt="screenshot00010" src="https://github.com/user-attachments/assets/12dad858-0cb6-467a-9bb2-640d29150053" />

After:
<img width="1920" height="1200" alt="screenshot00011" src="https://github.com/user-attachments/assets/08eba525-239a-4d38-b261-e1e92c90b1c6" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
