### PR TITLE
VideoPlayer: guard SetEnableStream() against stale stream IDs

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -470,6 +470,19 @@ bool CSelectionStreams::Get(StreamType type, StreamFlags flag, SelectionStream& 
   return false;
 }
 
+bool CSelectionStreams::Contains(StreamType type, int source, int64_t demuxerId, int id) const
+{
+  if (id < 0)
+    return false;
+
+  return std::any_of(m_Streams.cbegin(), m_Streams.cend(),
+                     [type, source, demuxerId, id](const SelectionStream& stream)
+                     {
+                       return stream.type == type && stream.source == source &&
+                              stream.demuxerId == demuxerId && stream.id == id;
+                     });
+}
+
 int CSelectionStreams::TypeIndexOf(StreamType type, int source, int64_t demuxerId, int id) const
 {
   if (id < 0)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3812,8 +3812,16 @@ void CVideoPlayer::SetSubtitleVisible(bool bVisible)
 
 void CVideoPlayer::SetEnableStream(CCurrentStream& current, bool isEnabled)
 {
-  if (m_pDemuxer && STREAM_SOURCE_MASK(current.source) == STREAM_SOURCE_DEMUX)
+  // Guard against stale stream IDs reaching the demuxer after a stream
+  // change. CloseStream() calls this method with stream identification coming
+  // from m_Current* members that may belong to a previous demuxer session.
+  // m_SelectionStreams mirrors the current demuxer's state, so a stale stream
+  // from a prior session won't be found and EnableStream() won't be called.
+  if (m_pDemuxer && STREAM_SOURCE_MASK(current.source) == STREAM_SOURCE_DEMUX &&
+      m_SelectionStreams.Contains(current.type, current.source, current.demuxerId, current.id))
+  {
     m_pDemuxer->EnableStream(current.demuxerId, current.id, isEnabled);
+  }
 }
 
 void CVideoPlayer::SetSubtitleVisibleInternal(bool bVisible)
@@ -4394,6 +4402,10 @@ bool CVideoPlayer::CloseStream(CCurrentStream& current, bool bWaitForBuffers)
   if(bWaitForBuffers)
     SetCaching(CACHESTATE_DONE);
 
+  //! @todo: CloseStream() primarily closes a stream player. SetEnableStream()
+  //! call below should be moved away from this method to the places where
+  //! stream enable/disable is actually intended, avoiding stale stream
+  //! identification from reaching the demuxer.
   SetEnableStream(current, false);
 
   IDVDStreamPlayer* player = GetStreamPlayer(current.player);

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -222,6 +222,7 @@ public:
   SelectionStream& Get(StreamType type, int index);
   const SelectionStream& Get(StreamType type, int index) const;
   bool Get(StreamType type, StreamFlags flag, SelectionStream& out);
+  bool Contains(StreamType type, int source, int64_t demuxerId, int id) const;
   void Clear(StreamType type, StreamSource source);
   int Source(StreamSource source, const std::string& filename);
   void Update(SelectionStream& s);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When switching from one stream to another using inputstream.adaptive while playback is ongoing, the CVideoPlayer receives a PLAYER_OPENFILE message in HandleMessages() which Prepare() to reinitialize.

CVideoPlayer::Prepare() clears only the stream hints but preserves the stream identification fields (id, demuxerId, source) from the previous stream. When CVideoPlayer::OpenDefaultStreams() runs and finds no subtitle stream in the new session, it calls CloseStream(m_CurrentSubtitle, false) with the stale subtitle ID. This reaches the input stream addon's EnableStream() callback with an ID that now maps to a different stream type in the new session (e.g. video or audio).

The callstack is as following:
  * CVideoPlayer::HandleMessages()
  * CVideoPlayer::Prepare()
  * CVideoPlayer::OpenDefaultStreams(true)
  * CVideoPlayer::CloseStream(m_CurrentSubtitle, false) // stale id used
  * CDVDDemux::SetEnableStream(current, false)
  * CDVDDemuxClient::EnableStream(demuxerId, staleId, false)
  * CInputStreamAddon::EnableStream(staleId, false)

In inputstream.adaptive, this triggers CSession::EnableStream() on the wrong stream instance, causing CStream::Disable() to run and potentially disabling a video or audio stream that should remain active.

In the specific reproducing case, switching from a stream A to stream B:

  Stream type | Stream A | Stream B
  ------------|----------|----------
  Video       | ID 1005  | ID 1007
  Audio       | ID 1006  | ID 1008
  Subtitle    | ID 1007  | none

Since stream B has no subtitle streams, the subtitle for-loop at https://github.com/xbmc/xbmc/blob/f0232910490189b97717bc5d309aec2e5751d6d3/xbmc/cores/VideoPlayer/VideoPlayer.cpp#L1085 is empty, m_CurrentSubtitle.id stays at 1007 from the stream A, and the CloseStream at line https://github.com/xbmc/xbmc/blob/f0232910490189b97717bc5d309aec2e5751d6d3/xbmc/cores/VideoPlayer/VideoPlayer.cpp#L1113 fires with it.

Fix this by adding a guard in SetEnableStream() that checks whether the stream still exists in m_SelectionStreams. A stale stream from a previous demuxer session will not be found, so EnableStream() won't be called.

Huge thanks to @FernetMenta for help in solving and diagnosing this issue!

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix a bug where sometimes after switching streams using inputstream.adaptive, video was not played.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- install ISASamples test addon: https://github.com/xbmc/inputstream.adaptive/wiki/Test-samples-python-addon
- Optional: Set ISA setting "stream selection type" to Manual OSD (to list more stream ids)
- On ISASamples, play stream: ->Dash->VOD->Akamaized IT1 [subtitles]
- Ensure subtitles are enabled, then _while in playback_, return to the menu, and play following stream
- On ISASamples, play stream: ->Dash->VOD->Akamaized bbb_30fps_4k
- From debug log, on the last video played you can see
`2026-06-28 12:59:09.338 T:17024   debug <inputstream.adaptive>: EnableStream(1003: false)`
so Kodi core try to disable a stream of previous video, on the new opened video

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
It should fix a bug when sometimes audio/video was not played when switching streams that use inputstream.adaptive.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
