### PR TITLE
[VideoPlayer] DVDDemuxFFmpeg: keep the stream changes counter across CreateStreams

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -36,6 +36,7 @@
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
+#include <map>
 #include <memory>
 #include <mutex>
 #include <sstream>
@@ -1483,6 +1484,22 @@ double CDVDDemuxFFmpeg::SelectAspect(AVStream* st, bool& forced)
 
 void CDVDDemuxFFmpeg::CreateStreams(unsigned int program)
 {
+  // changes must keep increasing across rebuilds; consumers detect a rebuild by comparing values
+  std::map<int, int> prevChanges;
+  for (const auto& [streamIdx, stream] : m_streams)
+    prevChanges[streamIdx] = stream->changes;
+
+  // only carries on the rebuild path; on Open() m_streams is empty and there is nothing to carry
+  const auto addStreamKeepingChanges = [this, &prevChanges](int streamIdx)
+  {
+    CDemuxStream* stream = AddStream(streamIdx);
+    if (!stream)
+      return;
+
+    if (const auto it = prevChanges.find(streamIdx); it != prevChanges.end())
+      stream->changes = it->second + 1;
+  };
+
   DisposeStreams();
 
   // add the ffmpeg streams to our own stream map
@@ -1518,7 +1535,7 @@ void CDVDDemuxFFmpeg::CreateStreams(unsigned int program)
       {
         int streamIdx = m_pFormatContext->programs[m_program]->stream_index[i];
         m_pFormatContext->streams[streamIdx]->discard = AVDISCARD_NONE;
-        AddStream(streamIdx);
+        addStreamKeepingChanges(streamIdx);
       }
 
       // discard all unneeded streams
@@ -1537,7 +1554,7 @@ void CDVDDemuxFFmpeg::CreateStreams(unsigned int program)
   if (m_program == UINT_MAX)
   {
     for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
-      AddStream(i);
+      addStreamKeepingChanges(static_cast<int>(i));
   }
 }
 
@@ -2000,6 +2017,8 @@ void CDVDDemuxFFmpeg::AddStream(int streamIdx, CDemuxStream* stream)
   }
   else
   {
+    // changes must keep increasing across replacements; consumers detect them by comparing values
+    stream->changes = res.first->second->changes + 1;
     delete res.first->second;
     res.first->second = stream;
   }


### PR DESCRIPTION
### Description

Fixes #28537.

New approach, replacing the first one. The old patch re-issued a `DMX_SPECIALID_STREAMCHANGE` packet after the `SeekTime()` wait loop had swallowed it, and as @fritsch pointed out that makes the player re-fetch all streams on every seek, on every platform. Wooden hammer, agreed.

This is @reardonia's suggestion instead: `CreateStreams()` disposes the `CDemuxStream` objects and builds new ones, so their `changes` counter restarts at zero and `CVideoPlayer::CheckStreamChanges()` has no signal to work with. Carrying the previous value forward (incremented), the way `CDVDDemuxClient` already does, gives it that signal, and the re-open only happens when the hints really are different. Nothing conditional on Android, mpegts or a failed codec open.

The bug it fixes: for mpegts with H.264 the codec parameters (extradata, dimensions) are only completed while demuxing, after the streams have been opened. Opening such a file at a resume position leaves the video stream running with the incomplete hints for the whole session. On Android that means mediacodec was rejected at open time (`null size, cannot handle`) and playback stays on the software decoder, which judders on hardware that can't software decode the stream in real time (1080p50 on a Fire TV Stick 4K here). Starting the same file from the beginning ends up on mediacodec.

Logs of both cases (works from 0, broken on resume) are in #28537.

One thing I could not confirm: `CheckStreamChanges()` also triggers on the stream pointer changing, and the pointers do change when the streams are rebuilt, so on paper it should already fire today. It doesn't, so something else in that path isn't behaving as expected. That is the main reason I'd rather have this tested on a device before it goes anywhere.

### Motivation and context

DVR/PVR recordings stored as raw mpegts with H.264 (Tvheadend in pass-through profile, for example) are common. Resuming one silently loses hardware decoding for the rest of the session, with nothing in the UI explaining why.

### How Has This Been Tested?

Not yet. I still have no Android toolchain here, so I can't build it myself. The previous approach was confirmed working on a Fire TV Stick 4K with the build @fritsch kindly posted (jenkins android-arm-docker 16677): resume used mediacodec and resume time was short. If someone can spare another build for this branch I'll test it the same way and report back.

### Types of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (no existing unit-test coverage for this path)
- [ ] All new and existing tests passed. (not build-tested locally, see above)
