### PR TITLE
[AudioEngine] Fix TrueHD MAT packer seamless-branch handling

### DIFF
--- a/xbmc/cores/AudioEngine/Utils/PackerMAT.cpp
+++ b/xbmc/cores/AudioEngine/Utils/PackerMAT.cpp
@@ -1,13 +1,19 @@
 /*
  *  Copyright (C) 2024 Team Kodi
+ *  Copyright (C) 2010-2021 Hendrik Leppkes
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSES/README.md for more information.
+ *
+ *  The TrueHD seamless-branch handling (output-timing discontinuity detection
+ *  and padding carry-forward) is derived from the TrueHD MAT packer in LAV
+ *  Filters by Hendrik Leppkes (Nevcairiel), decoder/LAVAudio/BitstreamMAT.cpp.
  */
 
 #include "PackerMAT.h"
 
+#include "utils/BitstreamReader.h"
 #include "utils/log.h"
 
 #include <array>
@@ -40,6 +46,100 @@ constexpr std::array<uint8_t, 12> mat_middle_code = {0xC3, 0xC1, 0x42, 0x49, 0x3
 constexpr std::array<uint8_t, 24> mat_end_code = {0xC3, 0xC2, 0xC0, 0xC4, 0x00, 0x00, 0x00, 0x00,
                                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x97, 0x11,
                                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+
+// Parsed fields from a TrueHD major sync frame. outputTiming lets us detect a
+// stream branch point that the plain frame-time counter cannot. Internal to
+// this translation unit.
+struct TrueHDMajorSyncInfo
+{
+  int ratebits{0};
+  uint16_t outputTiming{0};
+  bool outputTimingPresent{false};
+  bool valid{false};
+};
+
+// Parse a TrueHD major sync frame for the sample rate bits and, when a restart
+// header is present, the output timing counter used for seamless-branch
+// detection. Derived from LAV Filters (Nevcairiel).
+TrueHDMajorSyncInfo ParseTrueHDMajorSyncHeaders(const uint8_t* p, int buffsize)
+{
+  TrueHDMajorSyncInfo info;
+
+  if (buffsize < 32)
+    return {};
+
+  // parse major sync and look for a restart header
+  int majorSyncSize = 28;
+  if (p[29] & 1) // restart header exists
+  {
+    int extensionSize = p[30] >> 4; // calculate headers size
+    majorSyncSize += 2 + extensionSize * 2;
+  }
+
+  // The computed header size must fit within the provided buffer; otherwise the
+  // bitstream reads below could run past the end on malformed/corrupt input.
+  if (majorSyncSize > buffsize)
+    return {};
+
+  CBitstreamReader bs(p + 4, buffsize - 4);
+
+  bs.SkipBits(32); // format_sync
+
+  info.ratebits = bs.ReadBits(4); // ratebits
+  info.valid = true;
+
+  //  (1) 6ch_multichannel_type
+  //  (1) 8ch_multichannel_type
+  //  (2) reserved
+  //  (2) 2ch_presentation_channel_modifier
+  //  (2) 6ch_presentation_channel_modifier
+  //  (5) 6ch_presentation_channel_assignment
+  //  (2) 8ch_presentation_channel_modifier
+  // (13) 8ch_presentation_channel_assignment
+  // (16) signature
+  // (16) flags
+  // (16) reserved
+  //  (1) variable_rate
+  // (15) peak_data_rate
+  bs.SkipBits(1 + 1 + 2 + 2 + 2 + 5 + 2 + 13 + 16 + 16 + 16 + 1 + 15);
+
+  const int numSubstreams = bs.ReadBits(4);
+
+  bs.SkipBits(4 + (majorSyncSize - 17) * 8);
+
+  // substream directory
+  for (int i = 0; i < numSubstreams; i++)
+  {
+    int extraSubstreamWord = bs.ReadBits(1);
+    //  (1) restart_nonexistent
+    //  (1) crc_present
+    //  (1) reserved
+    // (12) substream_end_ptr
+    bs.SkipBits(15);
+    if (extraSubstreamWord)
+      bs.SkipBits(16); // drc_gain_update, drc_time_update, reserved
+  }
+
+  // substream segments
+  for (int i = 0; i < numSubstreams; i++)
+  {
+    if (bs.ReadBits(1))
+    { // block_header_exists
+      if (bs.ReadBits(1))
+      { // restart_header_exists
+        bs.SkipBits(14); // restart_sync_word
+        info.outputTiming = bs.ReadBits(16);
+        info.outputTimingPresent = true;
+        // XXX: restart header
+      }
+      // XXX: Block header
+    }
+    // XXX: All blocks, all substreams?
+    break;
+  }
+
+  return info;
+}
 } // namespace
 
 CPackerMAT::CPackerMAT()
@@ -61,11 +161,20 @@ bool CPackerMAT::PackTrueHD(const uint8_t* data, int size)
   if (size < 10)
     return false;
 
-  // get the ratebits from the major sync frame
-  if (AV_RB32(data + 4) == FORMAT_MAJOR_SYNC)
+  const bool isMajorSync = (AV_RB32(data + 4) == FORMAT_MAJOR_SYNC);
+
+  // Parse the major sync headers to obtain the sample rate bits and the output
+  // timing counter, which is needed to detect seamless branch points.
+  TrueHDMajorSyncInfo info;
+
+  if (isMajorSync)
   {
-    // read audio_sampling_frequency (high nibble after format major sync)
-    m_state.ratebits = data[8] >> 4;
+    info = ParseTrueHDMajorSyncHeaders(data, size);
+
+    // Fall back to master's ratebits read when the full header parse fails on a
+    // short/unusual major-sync frame, so the frame is still packed (without
+    // seamless-branch detection) instead of being dropped.
+    m_state.ratebits = info.valid ? info.ratebits : (data[8] >> 4);
   }
   else if (!m_state.prevFrametimeValid)
   {
@@ -75,6 +184,53 @@ bool CPackerMAT::PackTrueHD(const uint8_t* data, int size)
 
   const uint16_t frameTime = AV_RB16(data + 2);
   uint32_t spaceSize = 0;
+  const uint16_t frameSamples = 40 << (m_state.ratebits & 7);
+
+  // Advance the output timing counter and, if the parsed output timing does not
+  // match, treat it as a seamless branch point: carry the padding forward
+  // instead of dropping frames.
+  m_state.outputTiming += frameSamples;
+
+  if (info.outputTimingPresent)
+  {
+    if (m_state.outputTimingValid && (info.outputTiming != m_state.outputTiming))
+    {
+      CLog::Log(LOGDEBUG,
+                "CPackerMAT::PackTrueHD: detected stream discontinuity "
+                "(seamless branch), expected outputTiming={}, actual={}",
+                m_state.outputTiming, info.outputTiming);
+
+      // Reset frame timing state and use default padding.
+      // NOTE: do NOT reset prevMatFramesize - it is kept for proper padding calculation.
+      m_state.prevFrametimeValid = false;
+      // Standard padding for one MAT slot: frameSamples * (64 >> ratebits) = 2560
+      // bytes at every rate (frameSamples is 40/80/160 for 48/96/192 kHz; a bare
+      // 40 would only yield 2560 at 48 kHz and under-pad higher rates).
+      spaceSize = frameSamples * (64 >> (m_state.ratebits & 7));
+
+      // Calculate and carry forward padding based on the output time offset. The
+      // output timing is always one frame ahead for buffering reasons, so deduct
+      // one frame worth.
+      uint32_t prevOutput = static_cast<uint16_t>(info.outputTiming - frameSamples);
+      if (prevOutput < frameTime) // wrap around, output is always in front of frame time
+        prevOutput += 0x10000u; // 2^16, not UINT16_MAX (65535) - 16-bit counter wraps at 65536
+
+      // Get the offset of this frame, so we can compare to the previous frame,
+      // and determine the amount of padding that needs to be inserted.
+      int32_t currentFrameOutputOffset = static_cast<int32_t>(prevOutput - frameTime);
+
+      // The previous offset should never be smaller than the incoming offset,
+      // or we will lack the reserved space.
+      if (m_state.nOutputTimeOffset >= currentFrameOutputOffset)
+        m_state.padding +=
+            (m_state.nOutputTimeOffset - currentFrameOutputOffset) * (64 >> (m_state.ratebits & 7));
+
+      CLog::Log(LOGDEBUG, "CPackerMAT::PackTrueHD: carrying forward {} padding (offset {} - {})",
+                m_state.padding, m_state.nOutputTimeOffset, currentFrameOutputOffset);
+    }
+    m_state.outputTiming = info.outputTiming;
+    m_state.outputTimingValid = true;
+  }
 
   // compute final padded size for the previous frame, if any
   if (m_state.prevFrametimeValid)
@@ -89,8 +245,10 @@ bool CPackerMAT::PackTrueHD(const uint8_t* data, int size)
 
   m_state.padding += (spaceSize - m_state.prevMatFramesize);
 
-  // detect seeks and re-initialize internal state i.e. skip stream
-  // until the next major sync frame
+  // Seek/corruption safety net: negative padding is expected (branch-point
+  // carry-forward), but an unbounded large POSITIVE padding - e.g. a wild
+  // frameTime jump on a hard seek or corrupt stream - would spin the
+  // while(padding > 0) loop below emitting a huge number of MAT frames.
   if (m_state.padding > MAT_BUFFER_SIZE * 5)
   {
     CLog::Log(LOGINFO, "CPackerMAT::PackTrueHD: seek detected, re-initializing MAT packer state");
@@ -99,6 +257,17 @@ bool CPackerMAT::PackTrueHD(const uint8_t* data, int size)
     m_buffer.clear();
     m_bufferCount = 0;
     return false;
+  }
+
+  // Record the offset of frame time to output time, used to size the padding
+  // carry-forward on the next discontinuity.
+  if (m_state.outputTimingValid)
+  {
+    uint32_t prevOutput = static_cast<uint16_t>(m_state.outputTiming - frameSamples);
+    if (prevOutput < frameTime) // wrap around, output is always in front of frame time
+      prevOutput += 0x10000u; // 2^16, not UINT16_MAX (65535) - 16-bit counter wraps at 65536
+
+    m_state.nOutputTimeOffset = static_cast<int32_t>(prevOutput - frameTime);
   }
 
   // store frame time of the previous frame
@@ -166,13 +335,10 @@ bool CPackerMAT::PackTrueHD(const uint8_t* data, int size)
 
 std::vector<uint8_t> CPackerMAT::GetOutputFrame()
 {
-  std::vector<uint8_t> buffer;
-
   if (m_outputQueue.empty())
     return {};
 
-  buffer = std::move(m_outputQueue.front());
-
+  std::vector<uint8_t> buffer = std::move(m_outputQueue.front());
   m_outputQueue.pop_front();
 
   return buffer;
@@ -273,8 +439,10 @@ int CPackerMAT::FillDataBuffer(const uint8_t* data, int size, Type type)
       remaining -= mat_middle_code.size();
 
     // write remaining data after the MAT marker
+    // Guard nullptr: for padding, data is nullptr - pointer arithmetic on nullptr
+    // is undefined behavior, so pass it through unchanged.
     if (remaining > 0)
-      remaining = FillDataBuffer(data + nBytesBefore, remaining, type);
+      remaining = FillDataBuffer(data ? data + nBytesBefore : nullptr, remaining, type);
 
     return remaining;
   }

--- a/xbmc/cores/AudioEngine/Utils/PackerMAT.h
+++ b/xbmc/cores/AudioEngine/Utils/PackerMAT.h
@@ -1,9 +1,14 @@
 /*
  *  Copyright (C) 2024 Team Kodi
+ *  Copyright (C) 2010-2021 Hendrik Leppkes
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSES/README.md for more information.
+ *
+ *  The TrueHD seamless-branch handling (output-timing discontinuity detection
+ *  and padding carry-forward) is derived from the TrueHD MAT packer in LAV
+ *  Filters by Hendrik Leppkes (Nevcairiel), decoder/LAVAudio/BitstreamMAT.cpp.
  */
 
 #pragma once
@@ -41,6 +46,12 @@ private:
     // 10 -> 176.4 kHz
     int ratebits;
 
+    // output timing parsed from the TrueHD major sync restart header (when
+    // present) or inferred by advancing a counter. Used to detect a seamless
+    // branch point: the value jumps when the stream branches.
+    uint16_t outputTiming;
+    bool outputTimingValid;
+
     // input timing of previous audio unit used to calculate padding bytes
     uint16_t prevFrametime;
     bool prevFrametimeValid;
@@ -49,6 +60,10 @@ private:
     uint32_t prevMatFramesize; // size in bytes of previous MAT frame
 
     uint32_t padding; // padding bytes pending to write
+
+    // frame-time to output-time offset, used to size the padding carry-forward
+    // on the next branch point.
+    int32_t nOutputTimeOffset;
   };
 
   void WriteHeader();


### PR DESCRIPTION
## What this is

A focused, platform-independent fix to the TrueHD MAT packer's handling of **seamless branch points** (the clip joins in Blu-ray/UHD playlists), plus a latent **undefined-behaviour** fix in the padding path. It touches only `PackerMAT.cpp`/`.h`, adds no settings, and does not change output outside a branch point.

This PR has been **scoped down** from its original form per review feedback: the internal-clock / jitter-correction retiming layer has been removed so this stands on its own as a packer fix, judged on its own merits. (The retiming work can be proposed separately with its own cross-platform justification.)

## Problem

- At a TrueHD seamless branch point the MAT frame timing restarts. The stock packer only has a coarse *"padding overflow → wipe state → skip until next major sync"* path, which **drops audio** or shifts the MAT audio-unit boundaries that strict TrueHD decoders can lose lock on.
- `CPackerMAT::FillDataBuffer()` is called from `WritePadding()` with `data == nullptr` (padding writes no data). When the padding straddles the MAT middle marker it recurses with `data + nBytesBefore` — **pointer arithmetic on `nullptr`, which is undefined behaviour**.

## Solution

- Parse the TrueHD major sync **restart header** for the output-timing counter and use it to detect a branch point (the counter jumps when the stream branches). On a branch, reset frame timing to the default MAT slot padding and **carry the padding forward** to the following frames instead of wiping state and dropping audio.
- **Guard the `nullptr` pointer arithmetic** in `FillDataBuffer()` (pass `nullptr` through unchanged), and **bounds-check** the major-sync bit reader so a malformed/corrupt header cannot read past the end of the buffer.

Outside a branch point the packer output is unchanged, and the existing seek/corruption safety net (padding-overflow re-init) is retained.

## Credit

The seamless-branch handling (output-timing discontinuity detection and padding carry-forward) is derived from the TrueHD MAT packer in **LAV Filters by Hendrik Leppkes (Nevcairiel)** — https://github.com/Nevcairiel/LAVFilters. Full credit for that design belongs to him; this change adapts it to Kodi's MAT packer, as noted in the file headers.

## Testing

- Builds clean (`kodi-x11`, GCC, `git clang-format master` clean).
- Fixes audio dropouts at seamless-branch points on bitstreamed TrueHD (e.g. UHD titles with playlist clip joins). A deterministic sample + log capture demonstrating the stock *"seek detected, re-initializing MAT packer state"* firing during normal (no-seek) playback will follow.
