### PR TITLE
[Video][Bluray] Improve episode playlist identification algorithm.

### DIFF
--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -74,6 +74,7 @@ CDiscDirectoryHelper::CDiscDirectoryHelper()
   m_groups.clear();
   m_candidatePlaylists.clear();
   m_candidateSpecials.clear();
+  m_nthLongestPlaylists.clear();
 
   m_minEpisodeDuration = std::chrono::milliseconds(CServiceBroker::GetSettingsComponent()
                                                        ->GetAdvancedSettings()
@@ -260,9 +261,10 @@ bool ProcessPlaylistClips(const ClipMap& clips,
 }
 
 bool CheckDurationsWithinTolerance(std::chrono::milliseconds episodeDuration,
-                                   std::chrono::milliseconds playlistDuration)
+                                   std::chrono::milliseconds playlistDuration,
+                                   int durationTolerancePercent = DURATION_TOLERANCE_PERCENT)
 {
-  const auto tolerance{(episodeDuration * DURATION_TOLERANCE_PERCENT) / 100};
+  const auto tolerance{(episodeDuration * durationTolerancePercent) / 100};
   return episodeDuration > 0ms && std::chrono::abs(playlistDuration - episodeDuration) <= tolerance;
 }
 
@@ -415,6 +417,47 @@ void CDiscDirectoryHelper::FindGroups(const PlaylistMap& playlists, const Episod
                              });
       m_groups.emplace_back(std::move(group));
     }
+  }
+
+  // Make a group of the numEpisodes longest playlists (sorted by playlist)
+  // This assumes the episodes occur in ascending playlist order
+  // Exclude any playlists that might be play all playlists
+  // Also exclude duplicate durations (added back later if needed)
+  // Don't add to m_groups yet as it is only to be used if no other groups are found
+  if (playlists.size() >= m_numEpisodes)
+  {
+    std::set<int64_t> seenDurations;
+    std::vector<CandidatePlaylistInformation> candidates;
+    candidates.reserve(playlists.size());
+    std::ranges::copy_if(std::views::values(playlists) |
+                             std::views::transform(
+                                 [](const PlaylistInformation& p)
+                                 {
+                                   return CandidatePlaylistInformation{.playlist = p.playlist,
+                                                                       .duration = p.duration,
+                                                                       .clips = p.clips,
+                                                                       .languages = p.languages};
+                                 }) |
+                             std::views::filter([this](const CandidatePlaylistInformation& cpi)
+                                                { return !m_playAllPlaylists.contains(cpi); }),
+                         std::back_inserter(candidates),
+                         [&seenDurations](const CandidatePlaylistInformation& c) noexcept
+                         { return seenDurations.insert(c.duration.count()).second; });
+
+    m_nthLongestPlaylists.clear();
+    m_nthLongestPlaylists.resize(m_numEpisodes);
+    const auto sortResult = std::ranges::partial_sort_copy(
+        candidates, m_nthLongestPlaylists,
+        [](const CandidatePlaylistInformation& a, const CandidatePlaylistInformation& b)
+        { return a.duration > b.duration; });
+
+    // Fewer than m_numEpisodes playlists remain after excluding play-all/duplicate playlists
+    if (sortResult.out != m_nthLongestPlaylists.end())
+      m_nthLongestPlaylists.clear();
+    else
+      std::ranges::sort(m_nthLongestPlaylists, [&](const CandidatePlaylistInformation& a,
+                                                   const CandidatePlaylistInformation& b)
+                        { return a.playlist < b.playlist; });
   }
 
   if (m_groups.empty())
@@ -589,7 +632,75 @@ void CDiscDirectoryHelper::GetPlaylistsFromGroup(
   }
 }
 
-void CDiscDirectoryHelper::UseGroupMethod(int episodeIndex, const Episodes& episodesOnDisc)
+bool CDiscDirectoryHelper::CheckGroupDurations(
+    const std::vector<CandidatePlaylistInformation>& group,
+    const Episodes& episodesOnDisc,
+    int durationTolerancePercent) const
+{
+  return std::ranges::all_of(std::views::iota(0u, m_numEpisodes),
+                             [&](const unsigned i)
+                             {
+                               const auto& episode = episodesOnDisc[i + m_numSpecials];
+                               return CheckDurationsWithinTolerance(episode.duration * 1000ms,
+                                                                    group[i].duration,
+                                                                    durationTolerancePercent);
+                             });
+}
+
+bool CDiscDirectoryHelper::CheckGroupDurations(
+    const std::vector<CandidatePlaylistInformation>& groupA,
+    const std::vector<CandidatePlaylistInformation>& groupB,
+    int durationTolerancePercent) const
+{
+  return std::ranges::all_of(std::views::iota(0u, m_numEpisodes),
+                             [&](const unsigned i)
+                             {
+                               return CheckDurationsWithinTolerance(groupA[i].duration,
+                                                                    groupB[i].duration,
+                                                                    durationTolerancePercent);
+                             });
+}
+
+// Decide if the group identified is likely to contain the episodes
+// We might be in a position where we have a group of shorter playlists but the actual episode (longer)
+// playlists are not in a group
+bool CDiscDirectoryHelper::CheckGroup(const std::vector<CandidatePlaylistInformation>& group,
+                                      const Episodes& episodesOnDisc) const
+{
+  // If we have episode durations in episodesOnDisc
+  if (std::ranges::all_of(episodesOnDisc | std::views::drop(m_numSpecials),
+                          [](const Episode& e) { return e.duration > 0; }))
+  {
+    // First check they are within tolerance of the durations in the group
+    // This makes it likely the group represents the episodes
+    if (CheckGroupDurations(group, episodesOnDisc))
+      return true;
+
+    // Now see if the durations of the longest playlists are within tolerance of the expected episodes on disc
+    // If so, this probably isn't a valid group
+    if (!m_nthLongestPlaylists.empty() &&
+        CheckGroupDurations(m_nthLongestPlaylists, episodesOnDisc))
+      return false;
+  }
+  else
+  {
+    // If we don't have all durations (often the case as they are loaded sequentially by the scraper)
+    if (!m_nthLongestPlaylists.empty())
+    {
+      // Compare the longest playlist group to this group
+      // Use a more relaxed tolerance (arbitrarily chosen)
+      constexpr int RELAXED_DURATION_TOLERANCE_PERCENT = 40;
+      if (!CheckGroupDurations(m_nthLongestPlaylists, group, RELAXED_DURATION_TOLERANCE_PERCENT))
+        return false; // This probably isn't a valid group
+    }
+  }
+
+  return true;
+}
+
+void CDiscDirectoryHelper::UseGroupMethod(int episodeIndex,
+                                          const Episodes& episodesOnDisc,
+                                          const PlaylistMap& playlists)
 {
   // Method 2ai - More than one episode on disc
 
@@ -598,10 +709,14 @@ void CDiscDirectoryHelper::UseGroupMethod(int episodeIndex, const Episodes& epis
   // Firstly look just at groups that contain exactly numEpisodes playlists
   // Having removed duplicates
   CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using group method - exact number of playlists");
+
   const std::vector groups{GetGroupsWithoutDuplicates(m_groups)};
   for (const auto& group : groups)
   {
     if (group.size() != m_numEpisodes)
+      continue;
+
+    if (!CheckGroup(group, episodesOnDisc))
       continue;
 
     GetPlaylistsFromGroup(episodeIndex, group);
@@ -636,6 +751,49 @@ void CDiscDirectoryHelper::UseGroupMethod(int episodeIndex, const Episodes& epis
 
         GetPlaylistsFromGroup(episodeIndex, group);
       }
+    }
+  }
+
+  if (m_candidatePlaylists.empty() && !m_nthLongestPlaylists.empty())
+  {
+    // Now use the longest playlists
+    // These should not be sequential (as they would have been handled above)
+    if (std::ranges::adjacent_find(
+            m_nthLongestPlaylists,
+            [](const CandidatePlaylistInformation& a, const CandidatePlaylistInformation& b)
+            { return b.playlist != a.playlist + 1; }) != m_nthLongestPlaylists.end())
+    {
+      // Now ensure there are no other playlists of similar length to the longest
+      // Get the next longest playlist
+      std::vector<PlaylistInformation> tmp;
+      tmp.reserve(playlists.size());
+      std::ranges::copy(
+          playlists | std::views::values |
+              std::views::filter([this](const PlaylistInformation& p)
+                                 { return !m_playAllPlaylists.contains(p.playlist); }),
+          std::back_inserter(tmp));
+
+      // If there is no playlist beyond the m_nthLongestPlaylists ones, there is nothing
+      // to compare against, so there cannot be a next playlist of similar length
+      bool nextPlaylistIsClose{false};
+      if (tmp.size() > m_nthLongestPlaylists.size())
+      {
+        std::ranges::nth_element(tmp, tmp.begin() + (m_nthLongestPlaylists.size()),
+                                 [](const PlaylistInformation& a, const PlaylistInformation& b)
+                                 { return a.duration > b.duration; });
+
+        const auto lengthNext{tmp[m_nthLongestPlaylists.size()].duration};
+        const auto length{std::ranges::min_element(m_nthLongestPlaylists, {},
+                                                   &CandidatePlaylistInformation::duration)
+                              ->duration};
+        nextPlaylistIsClose = CheckDurationsWithinTolerance(length, lengthNext);
+      }
+
+      // If the next longest playlist is close to those in nthLongestPlaylists then
+      // we cannot be certain the nthLongestPlaylists are the episodes
+      if (!nextPlaylistIsClose)
+        if (CheckGroup(m_nthLongestPlaylists, episodesOnDisc))
+          GetPlaylistsFromGroup(episodeIndex, m_nthLongestPlaylists);
     }
   }
 
@@ -854,7 +1012,7 @@ void CDiscDirectoryHelper::FindCandidatePlaylists(const Episodes& episodesOnDisc
   else if (m_numEpisodes == 1)
     UseLongOrCommonMethodForSingleEpisode(episodeIndex, playlists);
   else if (!m_groups.empty())
-    UseGroupMethod(episodeIndex, episodesOnDisc);
+    UseGroupMethod(episodeIndex, episodesOnDisc, playlists);
 
   if (m_candidatePlaylists.empty() && !m_allGroups.empty() && m_numEpisodes > 1)
     UseGroupsWithMultiplesMethod(episodeIndex, episodesOnDisc);

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -287,7 +287,17 @@ private:
       const std::vector<std::vector<CandidatePlaylistInformation>>& groups);
   void GetPlaylistsFromGroup(int episodeIndex,
                              const std::vector<CandidatePlaylistInformation>& group);
-  void UseGroupMethod(int episodeIndex, const Episodes& episodesOnDisc);
+  void UseGroupMethod(int episodeIndex,
+                      const Episodes& episodesOnDisc,
+                      const PlaylistMap& playlists);
+  bool CheckGroupDurations(const std::vector<CandidatePlaylistInformation>& group,
+                           const Episodes& episodesOnDisc,
+                           int durationTolerancePercent = DURATION_TOLERANCE_PERCENT) const;
+  bool CheckGroupDurations(const std::vector<CandidatePlaylistInformation>& groupA,
+                           const std::vector<CandidatePlaylistInformation>& groupB,
+                           int durationTolerancePercent = DURATION_TOLERANCE_PERCENT) const;
+  bool CheckGroup(const std::vector<CandidatePlaylistInformation>& group,
+                  const Episodes& episodesOnDisc) const;
   static std::chrono::milliseconds CalculateAverageOfShortEpisodes(
       const std::vector<CandidatePlaylistInformation>& group);
   void UseGroupsWithMultiplesMethod(int episodeIndex, const Episodes& episodesOnDisc);
@@ -338,6 +348,7 @@ private:
   std::vector<std::vector<CandidatePlaylistInformation>> m_allGroups;
   std::map<unsigned int, CandidatePlaylistInformation> m_candidatePlaylists;
   std::set<unsigned int> m_candidateSpecials;
+  std::vector<CandidatePlaylistInformation> m_nthLongestPlaylists;
 
   static bool GetItems(CFileItemList& items, const std::string& directory, bool silent = false);
 };

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -1650,6 +1650,125 @@ TEST_F(TestDiscDirectoryHelper,
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 }
 
+// There is no play-all playlist, nor any consecutive groups of playlists (of the correct number)
+// There are n long playlists but there is a valid group of shorter playlists that is the same length as the number of episodes
+// (Example It Welcome to Derry S1D1 UK UHD)
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_LongNumberOfPlaylists)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeEpisode(1, 1, 2700), // 45 min
+                    MakeEpisode(1, 2, 2700), MakeEpisode(1, 3, 2700)};
+
+  PlaylistMap playlists{
+      {800u, MakePlaylist(800u, 42min, {1u}, {42min})},
+      {811u, MakePlaylist(811u, 2min, {7u}, {2min})},
+      {812u, MakePlaylist(812u, 3min, {8u}, {3min})},
+      {817u, MakePlaylist(817u, 47min, {2u}, {47min})},
+      {818u, MakePlaylist(818u, 48min, {3u}, {48min})},
+      {820u, MakePlaylist(820u, 12min, {4u}, {12min})},
+      {821u, MakePlaylist(821u, 13min, {5u}, {13min})},
+      {822u, MakePlaylist(822u, 14min, {6u}, {14min})},
+  };
+  ClipMap clips{
+      {1u, MakeClip(42min, {800u})}, {2u, MakeClip(47min, {817u})}, {3u, MakeClip(48min, {818u})},
+      {4u, MakeClip(12min, {820u})}, {5u, MakeClip(13min, {821u})}, {6u, MakeClip(14min, {822u})},
+      {7u, MakeClip(2min, {811u})},  {8u, MakeClip(3min, {812u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 800u);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 817u);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 2, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 818u);
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
+                                          playlists)); // Invalid episode index
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 3); // All episodes
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{800u, 817u, 818u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 6);
+  returned = GetPlaylists(items);
+  expected = {800u, 817u, 818u, 820u, 821u, 822u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 8);
+  returned = GetPlaylists(items);
+  expected = {800u, 811u, 812u, 817u, 818u, 820u, 821u, 822u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// There is no play-all playlist, nor any consecutive groups of playlists (of the correct number)
+// There are n long playlists but there is a valid group of shorter playlists that is the same length as the number of episodes
+// In this case the next longest playlist (after the longest 3) is too close in length to the longest playlists, so could be an episode as well
+TEST_F(TestDiscDirectoryHelper,
+       GetEpisodePlaylists_ThreeEpisodes_GroupMethod_LongNumberOfPlaylists_Fail)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeEpisode(1, 1, 2700), // 45 min
+                    MakeEpisode(1, 2, 2700), MakeEpisode(1, 3, 2700)};
+
+  PlaylistMap playlists{
+      {800u, MakePlaylist(800u, 42min, {1u}, {42min})},
+      {811u, MakePlaylist(811u, 2min, {7u}, {2min})},
+      {812u, MakePlaylist(812u, 3min, {8u}, {3min})},
+      {817u, MakePlaylist(817u, 47min, {2u}, {47min})},
+      {818u, MakePlaylist(818u, 48min, {3u}, {48min})},
+      {820u, MakePlaylist(820u, 12min, {4u}, {12min})},
+      {821u, MakePlaylist(821u, 13min, {5u}, {13min})},
+      {822u, MakePlaylist(822u, 44min, {6u}, {44min})},
+  };
+  ClipMap clips{
+      {1u, MakeClip(42min, {800u})}, {2u, MakeClip(47min, {817u})}, {3u, MakeClip(48min, {818u})},
+      {4u, MakeClip(12min, {820u})}, {5u, MakeClip(13min, {821u})}, {6u, MakeClip(44min, {822u})},
+      {7u, MakeClip(2min, {811u})},  {8u, MakeClip(3min, {812u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_FALSE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 6);
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected = {800u, 817u, 818u, 820u, 821u, 822u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 8);
+  returned = GetPlaylists(items);
+  expected = {800u, 811u, 812u, 817u, 818u, 820u, 821u, 822u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
 // Consecutive playlists → group method assigns the nth playlist to episode n
 // Playlist 800 = episode 1; 801 = episode 2; 802 = episodes 3 and 4
 // (Example The Expanse S1D2 R1 Bluray - episodes 9 and 10 are combined into a single playlist)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Guard against identifying consecutive short playlists as episodes when there are longer non-consecutive playlists on the disc.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I've come across as disc where a false positive episode playlist identification is made - It Welcome to Derry S1D1 UHD UK.
There are 3 consecutive short playlists which are falsely identified as the episodes.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.
Added tests.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
