### PR TITLE
Fix jerky vertical text scrolling of long texts

### DIFF
--- a/xbmc/guilib/GUIFont.cpp
+++ b/xbmc/guilib/GUIFont.cpp
@@ -87,13 +87,14 @@ std::string& CGUIFont::GetFontName()
   return m_strFontName;
 }
 
-void CGUIFont::DrawText(float x,
-                        float y,
-                        std::span<const KODI::UTILS::COLOR::Color> colors,
-                        KODI::UTILS::COLOR::Color shadowColor,
-                        std::span<const character_t> text,
-                        uint32_t alignment,
-                        float maxPixelWidth)
+void CGUIFont::DrawTextInternal(float x,
+                                float y,
+                                std::span<const KODI::UTILS::COLOR::Color> colors,
+                                KODI::UTILS::COLOR::Color shadowColor,
+                                std::span<const character_t> text,
+                                uint32_t alignment,
+                                float maxPixelWidth,
+                                bool isVScrolling)
 {
   CWinSystemBase* const winSystem = CServiceBroker::GetWinSystem();
   if (!m_font || !winSystem)
@@ -120,9 +121,10 @@ void CGUIFont::DrawText(float x,
     for (const auto& renderColor : renderColors)
       shadowColors.emplace_back((renderColor & 0xff000000) != 0 ? shadowColor : 0);
     m_font->DrawTextInternal(context, x + 1, y + 1, shadowColors, text, alignment, maxPixelWidth,
-                             false);
+                             false, isVScrolling);
   }
-  m_font->DrawTextInternal(context, x, y, renderColors, text, alignment, maxPixelWidth, false);
+  m_font->DrawTextInternal(context, x, y, renderColors, text, alignment, maxPixelWidth, false,
+                           isVScrolling);
 
   if (clip)
     context.RestoreClipRegion();
@@ -235,17 +237,17 @@ void CGUIFont::DrawScrollingText(float x,
     for (float dx = -offset; dx < maxWidth; dx += scrollInfo.m_totalWidth)
     {
       m_font->DrawTextInternal(context, x + 1, y + 1, shadowColors, text, alignment, textPixelWidth,
-                               scroll, dx);
+                               scroll, false, dx);
       m_font->DrawTextInternal(context, x + scrollInfo.m_textWidth + 1, y + 1, shadowColors,
-                               scrollInfo.m_suffix, alignment, suffixPixelWidth, scroll, dx);
+                               scrollInfo.m_suffix, alignment, suffixPixelWidth, scroll, false, dx);
     }
   }
   for (float dx = -offset; dx < maxWidth; dx += scrollInfo.m_totalWidth)
   {
     m_font->DrawTextInternal(context, x, y, renderColors, text, alignment, textPixelWidth, scroll,
-                             dx);
+                             false, dx);
     m_font->DrawTextInternal(context, x + scrollInfo.m_textWidth, y, renderColors,
-                             scrollInfo.m_suffix, alignment, suffixPixelWidth, scroll, dx);
+                             scrollInfo.m_suffix, alignment, suffixPixelWidth, scroll, false, dx);
   }
 
   context.RestoreClipRegion();

--- a/xbmc/guilib/GUIFont.h
+++ b/xbmc/guilib/GUIFont.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2003-2018 Team Kodi
+ *  Copyright (C) 2003-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -139,7 +139,10 @@ public:
                 KODI::UTILS::COLOR::Color shadowColor,
                 std::span<const character_t> text,
                 uint32_t alignment,
-                float maxPixelWidth);
+                float maxPixelWidth)
+  {
+    DrawTextInternal(x, y, colors, shadowColor, text, alignment, maxPixelWidth, false);
+  }
 
   void DrawScrollingText(float x,
                          float y,
@@ -149,6 +152,18 @@ public:
                          uint32_t alignment,
                          float maxPixelWidth,
                          const CScrollInfo& scrollInfo);
+
+  void DrawVScrollingText(float x,
+                          float y,
+                          std::span<const KODI::UTILS::COLOR::Color> colors,
+                          KODI::UTILS::COLOR::Color shadowColor,
+                          std::span<const character_t> text,
+                          uint32_t alignment,
+                          float maxPixelWidth,
+                          bool isScrolling)
+  {
+    DrawTextInternal(x, y, colors, shadowColor, text, alignment, maxPixelWidth, isScrolling);
+  }
 
   bool UpdateScrollInfo(std::span<const character_t> text, CScrollInfo& scrollInfo);
 
@@ -182,4 +197,13 @@ protected:
 private:
   bool ClippedRegionIsEmpty(
       CGraphicContext& context, float x, float y, float width, uint32_t alignment) const;
+
+  void DrawTextInternal(float x,
+                        float y,
+                        std::span<const KODI::UTILS::COLOR::Color> colors,
+                        KODI::UTILS::COLOR::Color shadowColor,
+                        std::span<const character_t> text,
+                        uint32_t alignment,
+                        float maxPixelWidth,
+                        bool isVScrolling);
 };

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -385,7 +385,6 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
   // round coordinates to the pixel grid. otherwise, we might sample at the wrong positions.
   if (!scrolling)
     x = std::round(x);
-  y = std::round(y);
 
   // GL, GLES and DX can scissor and shader clip
   const bool hardwareClipping = true;

--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -369,7 +369,8 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
                                    std::span<const character_t> text,
                                    uint32_t alignment,
                                    float maxPixelWidth,
-                                   bool scrolling,
+                                   bool hScrolling,
+                                   bool vScrolling,
                                    float dx,
                                    float dy)
 {
@@ -383,8 +384,10 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
   bool dirtyCache(false);
 
   // round coordinates to the pixel grid. otherwise, we might sample at the wrong positions.
-  if (!scrolling)
+  if (!hScrolling)
     x = std::round(x);
+  if (!vScrolling)
+    y = std::round(y);
 
   // GL, GLES and DX can scissor and shader clip
   const bool hardwareClipping = true;
@@ -400,13 +403,13 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
   CVertexBuffer& vertexBuffer =
       hardwareClipping
           ? m_dynamicCache.Lookup(context, dynamicPos, colors, text, alignment, maxPixelWidth,
-                                  scrolling, std::chrono::steady_clock::now(), dirtyCache)
+                                  hScrolling, std::chrono::steady_clock::now(), dirtyCache)
           : unusedVertexBuffer;
   std::shared_ptr<std::vector<SVertex>> tempVertices = std::make_shared<std::vector<SVertex>>();
   std::shared_ptr<std::vector<SVertex>>& vertices =
       hardwareClipping ? tempVertices
                        : static_cast<std::shared_ptr<std::vector<SVertex>>&>(m_staticCache.Lookup(
-                             context, staticPos, colors, text, alignment, maxPixelWidth, scrolling,
+                             context, staticPos, colors, text, alignment, maxPixelWidth, hScrolling,
                              std::chrono::steady_clock::now(), dirtyCache));
 
   // reserves vertex vector capacity, only the ones that are going to be used
@@ -638,7 +641,7 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
 
           for (int i = 0; i < 3; i++)
           {
-            RenderCharacter(context, startX + cursorX, startY, period, color, !scrolling,
+            RenderCharacter(context, startX + cursorX, startY, period, color, !hScrolling,
                             *tempVertices);
             cursorX += period->m_advance;
           }
@@ -654,7 +657,7 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
 
         for (int i = 0; i < 3; i++)
         {
-          RenderCharacter(context, startX + cursorX, startY, period, color, !scrolling,
+          RenderCharacter(context, startX + cursorX, startY, period, color, !hScrolling,
                           *tempVertices);
           cursorX += period->m_advance;
         }
@@ -666,7 +669,7 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
           MathUtils::round_int(static_cast<double>(itGlyph->m_glyphPosition.x_offset) / 64));
       offsetY = static_cast<float>(
           MathUtils::round_int(static_cast<double>(itGlyph->m_glyphPosition.y_offset) / 64));
-      RenderCharacter(context, startX + cursorX + offsetX, startY - offsetY, ch, color, !scrolling,
+      RenderCharacter(context, startX + cursorX + offsetX, startY - offsetY, ch, color, !hScrolling,
                       *tempVertices);
       if (alignment & XBFONT_JUSTIFIED)
       {
@@ -683,15 +686,15 @@ void CGUIFontTTF::DrawTextInternal(CGraphicContext& context,
     {
       CVertexBuffer& vertexBuffer =
           m_dynamicCache.Lookup(context, dynamicPos, colors, text, rawAlignment, maxPixelWidth,
-                                scrolling, std::chrono::steady_clock::now(), dirtyCache);
+                                hScrolling, std::chrono::steady_clock::now(), dirtyCache);
       CVertexBuffer newVertexBuffer = CreateVertexBuffer(*tempVertices);
       vertexBuffer = newVertexBuffer;
       m_vertexTrans.emplace_back(x, y, 0.0f, &vertexBuffer, context.GetClipRegion(), dx, dy);
     }
     else
     {
-      m_staticCache.Lookup(context, staticPos, colors, text, rawAlignment, maxPixelWidth, scrolling,
-                           std::chrono::steady_clock::now(), dirtyCache) =
+      m_staticCache.Lookup(context, staticPos, colors, text, rawAlignment, maxPixelWidth,
+                           hScrolling, std::chrono::steady_clock::now(), dirtyCache) =
           *static_cast<CGUIFontCacheStaticValue*>(&tempVertices);
       /* Append the new vertices to the set collected since the first Begin() call */
       m_vertex.insert(m_vertex.end(), tempVertices->begin(), tempVertices->end());

--- a/xbmc/guilib/GUIFontTTF.h
+++ b/xbmc/guilib/GUIFontTTF.h
@@ -164,7 +164,8 @@ protected:
                         std::span<const character_t> text,
                         uint32_t alignment,
                         float maxPixelWidth,
-                        bool scrolling,
+                        bool hScrolling,
+                        bool vScrolling,
                         float dx = 0.0f,
                         float dy = 0.0f);
 

--- a/xbmc/guilib/GUITextBox.cpp
+++ b/xbmc/guilib/GUITextBox.cpp
@@ -251,8 +251,8 @@ void CGUITextBox::Render()
         if (!lineString.m_text.empty() && lineString.m_carriageReturn)
           align &= ~XBFONT_JUSTIFIED; // last line of a paragraph shouldn't be justified
 
-        m_font->DrawText(posX, posY, m_colors, m_label.shadowColor, lineString.m_text, align,
-                         m_width);
+        m_font->DrawVScrollingText(posX, posY, m_colors, m_label.shadowColor, lineString.m_text,
+                                   align, m_width, m_scrollSpeed != 0.0f);
         posY += m_itemHeight;
         current++;
       }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Vertical scrolling text snaps to integer coordinates, resulting in jerky movement especially at lower resolutions < 1080p.
Will also impact D3D once #28483 is merged, in addition to already affected GL/GLES.

The PR removes the Y coordinate rounding.

There probably is a way to make y scrolling behave like x scrolling but I don't understand the mechanism well enough.
I hope @sarbes can take a look and offer advice.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Was initially discovered and tested in Windows / #28483 and received a few confirmations that it helps Android.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Smooth vertical scrolling movement of long text (ex. movie plot in the left side bar or in the info dialog).

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
