### PR TITLE
[URL] Fix NFS library scan crash caused by # or ; in directory names

### DIFF
--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -20,14 +20,11 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #ifndef TARGET_POSIX
-#include <sys\stat.h>
+#include <sys/stat.h>
 #endif
 
 #include <array>
-#include <iterator>
-#include <ranges>
 #include <string>
-#include <system_error>
 #include <vector>
 
 #include <fmt/xchar.h>
@@ -111,11 +108,8 @@ void CURL::Parse(std::string strURL1)
     SetFileName(std::move(strURL));
     return;
   }
-  else
-  {
-    SetProtocol(strURL.substr(0, iPos));
-    iPos += 3;
-  }
+  SetProtocol(strURL.substr(0, iPos));
+  iPos += 3;
 
   // virtual protocols
   // why not handle all format 2 (protocol://file) style urls here?
@@ -142,10 +136,6 @@ void CURL::Parse(std::string strURL1)
     }
   }
 
-  // check for username/password - should occur before first /
-  if (iPos == std::string::npos)
-    iPos = 0;
-
   // for protocols supporting options, chop that part off here
   // maybe we should invert this list instead?
   size_t iEnd = strURL.length();
@@ -159,8 +149,7 @@ void CURL::Parse(std::string strURL1)
       IsProtocol("pvr") || IsProtocol("bluray") || IsProtocol("episodes"))
     sep = "?";
   else if (IsProtocolEqual(strProtocol2, "http") || IsProtocolEqual(strProtocol2, "https") ||
-           IsProtocolEqual(strProtocol2, "plugin") || IsProtocolEqual(strProtocol2, "addons") ||
-           IsProtocolEqual(strProtocol2, "rtsp"))
+           IsProtocolEqual(strProtocol2, "plugin") || IsProtocolEqual(strProtocol2, "rtsp"))
     sep = "?;#|";
   else if (IsProtocolEqual(strProtocol2, "ftp") || IsProtocolEqual(strProtocol2, "ftps") ||
            IsProtocolEqual(strProtocol2, "nfs"))

--- a/xbmc/URL.cpp
+++ b/xbmc/URL.cpp
@@ -160,10 +160,11 @@ void CURL::Parse(std::string strURL1)
     sep = "?";
   else if (IsProtocolEqual(strProtocol2, "http") || IsProtocolEqual(strProtocol2, "https") ||
            IsProtocolEqual(strProtocol2, "plugin") || IsProtocolEqual(strProtocol2, "addons") ||
-           IsProtocolEqual(strProtocol2, "rtsp") || IsProtocolEqual(strProtocol2, "nfs"))
+           IsProtocolEqual(strProtocol2, "rtsp"))
     sep = "?;#|";
-  else if (IsProtocolEqual(strProtocol2, "ftp") || IsProtocolEqual(strProtocol2, "ftps"))
-    sep = "?;|";
+  else if (IsProtocolEqual(strProtocol2, "ftp") || IsProtocolEqual(strProtocol2, "ftps") ||
+           IsProtocolEqual(strProtocol2, "nfs"))
+    sep = "?|";
 
   if (sep)
   {
@@ -359,7 +360,7 @@ std::string CURL::GetTranslatedProtocol() const
   if (IsProtocol("shout") || IsProtocol("dav") || IsProtocol("rss"))
     return "http";
 
-  if (IsProtocol("davs") || IsProtocol("rsss"))
+  if (IsProtocol("shouts") || IsProtocol("davs") || IsProtocol("rsss"))
     return "https";
 
   return GetProtocol();

--- a/xbmc/test/TestURL.cpp
+++ b/xbmc/test/TestURL.cpp
@@ -460,6 +460,12 @@ const TestNFSURLParsingData nfsParsingData[] = {
     // NFS URL with encoded spaces in path
     {"nfs://192.168.1.100/Public/My%20Videos/Movie%202020.mkv?type=video", "nfs", "192.168.1.100",
      "Public/My%20Videos/Movie%202020.mkv", "?type=video", "mkv"},
+    // '#' in directory name - must remain part of the file name
+    {"nfs://192.168.178.23/share/#recently-added/movie.mkv", "nfs", "192.168.178.23",
+     "share/#recently-added/movie.mkv", "", "mkv"},
+    // ';' in directory name - must remain part of the file name
+    {"nfs://192.168.178.23/share/Comedy;Drama/movie.mkv", "nfs", "192.168.178.23",
+     "share/Comedy;Drama/movie.mkv", "", "mkv"},
 };
 
 INSTANTIATE_TEST_SUITE_P(NFSParsing, TestNFSURLParsing, ValuesIn(nfsParsingData));

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -2358,6 +2358,26 @@ TEST_F(TestURIUtils, CheckConsistencyBetweenFileNameUtilities)
     EXPECT_EQ("movie.avi", URIUtils_Split("nfs://127.0.0.1/srv/share/movie.avi|option=true"));
   }
   {
+    EXPECT_EQ("srv/share/#recently-added/movie.avi",
+              CURL("nfs://127.0.0.1/srv/share/#recently-added/movie.avi").GetFileName());
+
+    EXPECT_EQ("movie.avi",
+              URIUtils::GetFileName("nfs://127.0.0.1/srv/share/#recently-added/movie.avi"));
+    EXPECT_EQ("movie.avi",
+              CURL_FileName_URIUtils_Split("nfs://127.0.0.1/srv/share/#recently-added/movie.avi"));
+    EXPECT_EQ("movie.avi", URIUtils_Split("nfs://127.0.0.1/srv/share/#recently-added/movie.avi"));
+  }
+  {
+    EXPECT_EQ("srv/share/Comedy;Drama/movie.avi",
+              CURL("nfs://127.0.0.1/srv/share/Comedy;Drama/movie.avi").GetFileName());
+
+    EXPECT_EQ("movie.avi",
+              URIUtils::GetFileName("nfs://127.0.0.1/srv/share/Comedy;Drama/movie.avi"));
+    EXPECT_EQ("movie.avi",
+              CURL_FileName_URIUtils_Split("nfs://127.0.0.1/srv/share/Comedy;Drama/movie.avi"));
+    EXPECT_EQ("movie.avi", URIUtils_Split("nfs://127.0.0.1/srv/share/Comedy;Drama/movie.avi"));
+  }
+  {
     EXPECT_EQ("a:b", URIUtils::GetFileName("/hello/there/a:b"));
     EXPECT_EQ("a:b", CURL_FileName_URIUtils_Split("/hello/there/a:b"));
     EXPECT_EQ("a:b", URIUtils_Split("/hello/there/a:b"));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
PR #28249 included NFS in the set of protocols that treat `?`, `#`, `;`, and `|` as URL option separators.
Since `#` and `;` are legal characters in NFS file/directory names, the URL parser would truncate the path at the first such character, storing the remainder as "options". This corrupted the internal URL and caused the video library scanner to loop infinitely or crash when encountering directories like "#recently-added" or "Comedy;Drama".
This PR restores safe parsing for NFS by giving it its own separator list: `"?|"`.
Appropriate unit tests for `#` and `;` in NFS paths have been added to _TestURL.cpp_ and _TestURIUtils.cpp_.

Additionally:
- The option separators for FTP and FTPS have been changed from `?;|` to `?|` to prevent the same kind of path corruption on semicolons (FTP directories are scanned like NFS)
- The missing `shouts` protocol has been added to the URL translator so it maps to "https" and gets proper option stripping, making it consistent with the existing shout/http, dav/davs, and rss/rsss pairs.

**Additional cleanups in _URL.cpp_** (unrelated, layered on top):
- Removed a dead `if (iPos == npos)` check that could never be reached.
- Removed a duplicate `"addons"` protocol check in the option-separator selection that was always skipped.
- Removed three unused includes and fixed a non‑portable backslash in a system header.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Users storing media on NFS shares with folder names containing `#` (e.g. "#recently-added") or `;` (e.g. "Comedy;Drama") experienced infinite library scan loops and application crashes after builds that included PR #28249.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The affected user tested a build with this fix and confirmed that the library scan now completes successfully without crashes.
All existing NFS and general URL tests pass.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Kodi's NFS library scanner no longer crashes or loops when media is stored in directories whose names contain `#` or `;`. Scanning of NFS shares is stable and reliable again, matching the behaviour from before the regression.
Resolves #28502

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [ ] All new and existing tests passed
