### PR TITLE
Smooth Fast Forward Playback

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -7966,7 +7966,19 @@ msgctxt "#13557"
 msgid "Skip delay"
 msgstr ""
 
-#empty strings from id 13558 to 13600
+#. Name of a setting to configure the maximum fast-forward speed with smooth/continuous playback
+#: system/settings/settings.xml
+msgctxt "#13558"
+msgid "Maximum smooth fast-forward speed"
+msgstr ""
+
+#. Playback speed unit used to format speeds for display ex. 2x, 4x, ...
+#: xbmc/settings/PlayerSettings.cpp
+msgctxt "#13559"
+msgid "{0:d}x"
+msgstr ""
+
+#empty strings id 13600
 
 #: system/settings/darwin_tvos.xml
 msgctxt "#13601"
@@ -22937,7 +22949,13 @@ msgctxt "#37116"
 msgid "Adaptive"
 msgstr ""
 
-#empty strings from id 37117 to 37119
+#. Description of setting #13558 Maximum smooth fast-forward speed
+#: system/settings/settings.xml
+msgctxt "#37117"
+msgid "Cutoff of the analog fast-forward mode that shows every picture. Some hardware may not be able to keep up with the higher demand of the higher speeds."
+msgstr ""
+
+#empty strings from id 37118 to 37119
 
 #. Value of setting - Byte
 #: xbmc/settings/SevicesSettings.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -101,6 +101,14 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
+        <setting id="videoplayer.maxsmoothff" type="integer" label="13558" help="37117">
+          <level>2</level>
+          <default>4</default>
+          <constraints>
+            <options>playerfastforwardspeeds</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
       </group>
       <group id="3" label="14231">
         <setting id="videoplayer.rendermethod" type="integer" label="13415" help="36153">

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -705,8 +705,13 @@ void CDVDDemuxFFmpeg::SetSpeed(int iSpeed)
     av_read_play(m_pFormatContext);
   m_speed = iSpeed;
 
+  int maxSmoothFF = 4;
+  if (auto comp = CServiceBroker::GetSettingsComponent(); comp != nullptr)
+    if (auto settings = comp->GetSettings(); settings != nullptr)
+      maxSmoothFF = settings->GetInt(CSettings::SETTING_VIDEOPLAYER_MAX_SMOOTH_FF_SPEED);
+
   AVDiscard discard = AVDISCARD_NONE;
-  if (m_speed > 4 * DVD_PLAYSPEED_NORMAL)
+  if (m_speed > maxSmoothFF * DVD_PLAYSPEED_NORMAL)
     discard = AVDISCARD_NONKEY;
   else if (m_speed > 2 * DVD_PLAYSPEED_NORMAL)
     discard = AVDISCARD_BIDIR;

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -940,8 +940,19 @@ CVideoPlayerVideo::EOutputState CVideoPlayerVideo::OutputPicture(const VideoPict
   int buffer = m_renderManager.WaitForBuffer(m_bAbortOutput, maxWaitTime);
   if (buffer < 0)
   {
+    // The render buffer pool can fill up in trick-play FF, with more new pictures decoded than
+    // are taken out at the display rate.
+    // Drop the picture to let the renderer naturally drain the pool and make room for next iteration.
+    // It will receive the most current new picture instead of whatever was decoded first (likely stale)
+    if (m_speed > DVD_PLAYSPEED_NORMAL)
+    {
+      m_droppingStats.AddOutputDropGain(pPicture->pts, 1);
+      return OUTPUT_DROPPED;
+    }
+
     if (m_speed != DVD_PLAYSPEED_PAUSE)
       CLog::Log(LOGWARNING, "{} - timeout waiting for buffer", __FUNCTION__);
+
     return OUTPUT_AGAIN;
   }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerVideo.cpp
@@ -551,8 +551,11 @@ void CVideoPlayerVideo::Process()
 
       bRequestDrop = false;
       iDropDirective = CalcDropRequirement(pts);
-      if ((iDropDirective & DROP_VERYLATE) &&
-           m_bAllowDrop &&
+
+      // Framerate calibration exists to avoid dropping frames during normal playback before we're
+      // confident what the real framerate is. That doesn't apply during trick-play and
+      // DROP_VERYlATE must not be silently disabled.
+      if ((iDropDirective & DROP_VERYLATE) && (m_bAllowDrop || m_speed > DVD_PLAYSPEED_NORMAL) &&
           !bPacketDrop)
       {
         bRequestDrop = true;

--- a/xbmc/settings/PlayerSettings.cpp
+++ b/xbmc/settings/PlayerSettings.cpp
@@ -47,3 +47,16 @@ void CPlayerSettings::SettingOptionsQueueDataSizesFiller(const SettingConstPtr& 
   list.emplace_back(StringUtils::Format(mb, 512), 512);
   list.emplace_back(StringUtils::Format(gb, 1), 1024);
 }
+
+void CPlayerSettings::SettingOptionsFastForwardSpeeds(const SettingConstPtr& setting,
+                                                      std::vector<IntegerSettingOption>& list,
+                                                      int& current)
+{
+  const std::string& x = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13559);
+
+  list.emplace_back(StringUtils::Format(x, 2), 2);
+  list.emplace_back(StringUtils::Format(x, 4), 4);
+  list.emplace_back(StringUtils::Format(x, 8), 8);
+  list.emplace_back(StringUtils::Format(x, 16), 16);
+  list.emplace_back(StringUtils::Format(x, 32), 32);
+}

--- a/xbmc/settings/PlayerSettings.h
+++ b/xbmc/settings/PlayerSettings.h
@@ -22,4 +22,7 @@ public:
   static void SettingOptionsQueueDataSizesFiller(const SettingConstPtr& setting,
                                                  std::vector<IntegerSettingOption>& list,
                                                  int& current);
+  static void SettingOptionsFastForwardSpeeds(const SettingConstPtr& setting,
+                                              std::vector<IntegerSettingOption>& list,
+                                              int& current);
 };

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -448,6 +448,8 @@ void CSettings::InitializeOptionFillers()
       "playerqueuetimesizes", CPlayerSettings::SettingOptionsQueueTimeSizesFiller);
   GetSettingsManager()->RegisterSettingOptionsFiller(
       "playerqueuedatasizes", CPlayerSettings::SettingOptionsQueueDataSizesFiller);
+  GetSettingsManager()->RegisterSettingOptionsFiller(
+      "playerfastforwardspeeds", CPlayerSettings::SettingOptionsFastForwardSpeeds);
 }
 
 void CSettings::UninitializeOptionFillers()
@@ -502,6 +504,7 @@ void CSettings::UninitializeOptionFillers()
   GetSettingsManager()->UnregisterSettingOptionsFiller("filecachechunksizes");
   GetSettingsManager()->UnregisterSettingOptionsFiller("playerqueuetimesizes");
   GetSettingsManager()->UnregisterSettingOptionsFiller("playerqueuedatasizes");
+  GetSettingsManager()->UnregisterSettingOptionsFiller("playerfastforwardspeeds");
 }
 
 void CSettings::InitializeConditions()

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -103,6 +103,7 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_AUTOPLAYNEXTITEM = "videoplayer.autoplaynextitem";
   static constexpr auto SETTING_VIDEOPLAYER_SEEKSTEPS = "videoplayer.seeksteps";
   static constexpr auto SETTING_VIDEOPLAYER_SEEKDELAY = "videoplayer.seekdelay";
+  static constexpr auto SETTING_VIDEOPLAYER_MAX_SMOOTH_FF_SPEED = "videoplayer.maxsmoothff";
   static constexpr auto SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE = "videoplayer.adjustrefreshrate";
   static constexpr auto SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK = "videoplayer.usedisplayasclock";
   static constexpr auto SETTING_VIDEOPLAYER_ERRORINASPECT = "videoplayer.errorinaspect";


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Modify videoplayer to fast-forward and show as many frames as possible up to 32x speed (the "Benny Hill" effect :-)) and add a setting for user preferences / acknowledge hardware limits, since it's obviously more taxing than showing only key frames.
Default value is 4x (same as the previous behavior) but could be raised according to feedback.

<img width="1296" height="169" alt="image" src="https://github.com/user-attachments/assets/eeb1903e-9be7-4756-ac70-355fa3557a96" />

There were two main obstacles:
- the renderer has a pool of 4 buffers, draining at the presentation speed (ex. 24Hz, 29Hz, 59Hz), but the decoded pictures arrive at a much higher rate in fast forward, and stalled both decoder and renderer. The effect is worse for low display refresh rates as they drain slower. Decoded pictures are now dropped when no buffer is available. The timestamps of the remaining displayed pictures are not evenly spaced but that's not perceptible on screen.
- the clock/presentation drift watchdog in CVideoPlayer::HandlePlaySpeed was triggered because CVideoPlayerVideo seems architecturally limited to 12x speed when playing every frame (not sure why), and it was not allowed to drop more pictures before they even reached the renderer (m_bAllowDrop was not allowing the flag DVD_CODEC_CTRL_DROP_ANY to be set before CalcFrameRate() had locked on a frame rate). Keeping all frames is good to measure the frame rate at the start of playback or after a seek, but not when fast-forwarding.

16x is reliable for all tested samples with hw or sw decoding.
32x is perfect for some videos, hiccups from time to time on others, this may be hitting another architecture limit. I haven't figured it out after days spent on the PR already so gave up.
It would be possible to remove 32x from the setting options. The "key frames only" slideshow looks half-decent at 32x speed for my worst videos.

Alternative 1 could be an "auto-degrade" mode that engages the previous "keep key frames only" mode of the demuxer when the PC can't keep up. It requires many changes to pass the information between layers but that could be an improvement later on.
Alternative 2 could let the hardware run as fast as it can without resetting when lower than the expected speed (ex. 30x instead of a true 32x).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Key frames are widely spaced on some of my content and I got frustrated with the 8x and 16x fast forward slow motion slideshow.
I suppose it was built that way to accommodate less-capable hardware, but hardware decoding is widely available now and desktops have no trouble with sw decoding either. Created a setting to preserve the previous behavior for users who need it.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All sample videos on hand, with hardware and software decoding.
Tested on Windows with AMD Intel NVidia.

Low cpu Android won't be able to sw decode but hw accelerated should work unless that path has platform-specific bottlenecks.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Setting to have an analog "Benny Hill" fast forward instead of a slideshow of key frames.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
