### PR TITLE
[Video] Fix TV show details can be lost after a refresh.

### DIFF
--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -825,13 +825,22 @@ CVideoInfoScanner::~CVideoInfoScanner()
         idSeason = m_database.GetSeasonId(idTvShow, pItem->GetVideoInfoTag()->m_iSeason);
     }
 
+    // If we only want to refresh show details (and not the episodes), the
+    // episode-folder hash comparison below is irrelevant: it exists purely to decide
+    // whether episodes need to be re-scanned.
+    const bool refreshShowInfoOnly =
+        idTvShow > -1 && pItem->IsFolder() && !isSeason && !fetchEpisodes;
+
     // Enumerate episodes here as this compares hashes of folders containing episodes from this show
     //  and we want to do this before processing nfo files
     EPISODELIST files;
-    if (!EnumerateSeriesFolder(pItem, files))
-      return InfoRet::HAVE_ALREADY;
-    if (files.empty()) // no update or no files
-      return InfoRet::NOT_NEEDED;
+    if (!refreshShowInfoOnly)
+    {
+      if (!EnumerateSeriesFolder(pItem, files))
+        return InfoRet::HAVE_ALREADY;
+      if (files.empty()) // no update or no files
+        return InfoRet::NOT_NEEDED;
+    }
 
     if (ProgressCancelled(pDlgProgress, pItem->IsFolder() ? 20353 : 20361,
                           pItem->IsFolder() ? pItem->GetVideoInfoTag()->m_strShowTitle
@@ -848,7 +857,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     if (useLocal)
       std::tie(result, loader) = ReadInfoTag(*pItem, info2, bDirNames, true);
 
-    if (result == InfoType::FULL && idTvShow < 0)
+    if (result == InfoType::FULL && (idTvShow < 0 || refreshShowInfoOnly))
     {
 
       long lResult = AddVideo(pItem, info2, bDirNames, useLocal);

--- a/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryRefreshingJob.cpp
@@ -469,8 +469,6 @@ bool CVideoLibraryRefreshingJob::Work(CVideoDatabase &db)
           db.DeleteSeason(origDbId);
         else if (m_refreshAll)
           db.DeleteTvShow(origDbId);
-        else
-          db.DeleteDetailsForTvShow(origDbId);
       }
     }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fix both issues highlighted below by:
- removing the unnecessary `DeleteDetailsForTvShow()`
- adjusting the conditions gating the hash checks and `AddVideo()` so the tv show details are updated

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #28545.

Scenario
- a TV show is added via a source that uses the local scraper (nfo files).
- you then refresh through the information dialog saying no to refresh all episodes dialog.
- the TV show details are lost (fields c00-c23 in the entry in the tvshow database are reset).

There are two related issues.

In `GUIDialogVideoInfo.cpp:144-159` - When the user answers the "refresh all episodes?" prompt:
Yes → m_bRefreshAll = true and the folder's path hash is cleared via db.SetPathHash(path, "")
No → m_bRefreshAll = false, and the has is not changed.

Then in `CVideoLibraryRefreshingJob::Work()` `db.DeleteDetailsForTvShow(origDbId);`  was called when the user says no to updaing episodes. However, given the hash had not changed updated tvshow details were never read.

This delete was unneccesary as there is another in `UpdateDetailsForTvShow()`

Secondly, the tv show update was being skipped (so if the nfo contents had changed the show was not being updated) as in `RetrieveInfoForTvShow()` details derived from an nfo were only being added for a new show.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
