### PR TITLE
[Video] Refactor TV show folder content determination code to allow tests.

### DIFF
--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES Bookmark.cpp
             PlayerController.cpp
             SetInfoTag.cpp
             Teletext.cpp
+            VideoContentUtils.cpp
             VideoDatabase.cpp
             VideoDatabaseDDL.cpp
             VideoDatabaseMigration.cpp
@@ -30,6 +31,7 @@ set(HEADERS Bookmark.h
             SetInfoTag.h
             Teletext.h
             TeletextDefines.h
+            VideoContentUtils.h
             VideoDatabase.h
             VideoDatabaseColumns.h
             VideoDatabaseDDL.h

--- a/xbmc/video/VideoContentUtils.cpp
+++ b/xbmc/video/VideoContentUtils.cpp
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VideoContentUtils.h"
+
+#include "URL.h"
+#include "utils/URIUtils.h"
+
+namespace KODI::VIDEO
+{
+
+// For TV shows scraped with 'Single TV show in folder OFF' - pointing to folder /TV Shows/ or subfolder
+// For TV shows scraped with 'Single TV show in folder ON' - pointing to folder /Show (2002)/ or subfolder
+
+std::string DetermineContentForTVShows(bool scraperSetOnThisPath,
+                                       bool isShowNameFolder,
+                                       const TVShowEpisodePathResult& result)
+{
+  if (result.episodesInThisPath)
+    return "episodes";
+
+  // If episodes in archives the strPath in episode_view points inside
+  // the archive (e.g. rar://host/archive.rar/episode.mkv).
+  // When episodes exist in the root of the archive we treat the folder
+  // containing the archive as containing episodes (this is handled in GetDirectory())
+  for (const auto& path : result.candidatePaths)
+  {
+    const CURL url(path);
+    if ((url.GetFileName().empty() && URIUtils::IsArchive(url)) || url.IsBlurayPath())
+      return "episodes"; // episode in root of archive
+  }
+
+  // The scraper was attached directly to this path and single-show mode is not active
+  // then the folder is the TV Show source root
+  return scraperSetOnThisPath && !isShowNameFolder ? "tvshows" : "seasons";
+}
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoContentUtils.h
+++ b/xbmc/video/VideoContentUtils.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace KODI::VIDEO
+{
+
+/*!
+ * \brief Raw data collected from the DB for a given path during TV show content resolution.
+ */
+struct TVShowEpisodePathResult
+{
+  //! True when episode_view contains a row whose strPath exactly matches the queried path.
+  bool episodesInThisPath{false};
+
+  //! Distinct strPath values from episode_view whose parent path idPath matches the queried path.
+  std::vector<std::string> candidatePaths{};
+};
+
+/*!
+ * \brief Determine the content label for a TV show path from pre-fetched DB results.
+ *
+ * \param scraperSetOnThisPath  True if the scraper was configured directly on \p strPath
+ *                              (not inherited from a parent path).
+ * \param isShowNameFolder      True if \p strPath is the base folder for a show
+ *                              ie. /TV Shows/Show Name (2002)/ and not /TV Shows/Show Name (2002)/Season 1/
+ *                              (derived from SScanSettings::parent_name for the scraper)
+ * \param result                Pre-fetched query results for the path.
+ * \return One of "episodes", "seasons", or "tvshows".
+ */
+std::string DetermineContentForTVShows(bool scraperSetOnThisPath,
+                                       bool isShowNameFolder,
+                                       const TVShowEpisodePathResult& result);
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -8654,68 +8654,52 @@ bool CVideoDatabase::GetUseAllExternalAudioForVideo(const std::string& videoPath
   return false;
 }
 
+TVShowEpisodePathResult CVideoDatabase::GetEpisodesInPaths(const std::string& strPath) const
+{
+  TVShowEpisodePathResult result;
+
+  std::string sql = PrepareSQL("SELECT 1 FROM episode_view "
+                               "WHERE strPath = '%s' "
+                               "LIMIT 1",
+                               strPath.c_str());
+  m_pDS->query(sql);
+  if (m_pDS->num_rows())
+  {
+    result.episodesInThisPath = true;
+    return result;
+  }
+
+  // If the episodes are in individual archives
+  // then strPath may point to the directory containing the archive
+  // rather than the archive itself (eg. rar://).
+  // So see if there are any matches using the parentpathid.
+  sql = PrepareSQL("SELECT DISTINCT e.strPath FROM episode_view e "
+                   "JOIN path p ON e.c%02d = p.idPath "
+                   "WHERE p.strPath = '%s' ",
+                   VIDEODB_ID_EPISODE_PARENTPATHID, strPath.c_str());
+  m_pDS->query(sql);
+  while (!m_pDS->eof())
+  {
+    result.candidatePaths.emplace_back(m_pDS->fv(0).get_asString());
+    m_pDS->next();
+  }
+
+  return result;
+}
+
 std::string CVideoDatabase::GetContentForPath(const std::string& strPath)
 {
   SScanSettings settings;
-  bool foundDirectly = false;
-  ScraperPtr scraper = GetScraperForPath(strPath, settings, foundDirectly);
-  if (scraper)
-  {
-    if (scraper->Content() == ContentType::TVSHOWS)
-    {
-      // For TV shows scraped with 'Single TV show in folder OFF' - pointing to folder /TV Shows/
-      // For TV shows scraped with 'Single TV show in folder ON' - pointing to folder /Show (2002)/
-      //
-      // Contents of:                                                   Return
-      // ------------                                                   ------
-      // /TV Shows/                                                     tvshows (NB first case only)
-      // /TV Shows/Show (2002)/                                         seasons - if folder does NOT contain any episodes (eg. Season subfolders only)
-      // /TV Shows/Show (2002)/                                         episodes - if folder DOES contain episode(s)
-      // /TV Shows/Show (2002)/Season 1/                                episodes - if folder DOES contain episode(s)
-      // /TV Shows/Show (2002)/Season 1/                                seasons - if folder does NOT contain episode(s)
-      //                                                                @todo - this currently returns episodes if there is a single archive containing multiple episodes
-      //                                                                @todo - (although of no functional consequence)
-      // /TV Shows/Show (2002)/Season 1/episode.rar                     episodes - if the archive(s) contains an episode (the .rar is expanded by the vfs automatically)
-      // /TV Shows/Show (2002)/Season 1/episodes.rar                    seasons - if the archive does NOT contain any episodes (ie. they are in a subfolder of the archive)
-      // /TV Shows/Show (2002)/episodes.rar/Season 1                    episodes - if the archive contains episode(s) (expanded by the vfs)
-      // /TV Shows/Show (2002)/Seasons 1 and 2/episodes.rar/Season 1    episodes - if the archive contains episode(s) (expanded by the vfs)
+  bool scraperSetOnThisPath = false;
+  ScraperPtr scraper = GetScraperForPath(strPath, settings, scraperSetOnThisPath);
+  if (!scraper)
+    return "";
 
-      std::string sql = PrepareSQL("SELECT 1 FROM episode_view "
-                                   "WHERE strPath = '%s' "
-                                   "LIMIT 1",
-                                   strPath.c_str());
-
-      m_pDS->query(sql);
-      if (m_pDS->num_rows())
-        return "episodes";
-
-      // If the episodes are in individual archives
-      // then strPath may point to the directory containing the archive
-      // rather than the archive itself (eg. rar://).
-      // So see if there are any matches using the parentpathid.
-      sql = PrepareSQL("SELECT DISTINCT e.strPath FROM episode_view e "
-                       "JOIN path p ON e.c%02d = p.idPath "
-                       "WHERE p.strPath = '%s' ",
-                       VIDEODB_ID_EPISODE_PARENTPATHID, strPath.c_str());
-      m_pDS->query(sql);
-      if (m_pDS->num_rows())
-      {
-        while (!m_pDS->eof())
-        {
-          const CURL url(m_pDS->fv(0).get_asString());
-          if ((url.GetFileName().empty() && URIUtils::IsArchive(url)) || url.IsBlurayPath())
-            return "episodes"; // Episodes in root of archive
-          m_pDS->next();
-        }
-      }
-
-      // If the scraper was set directly on this path, it is a tvshows root
-      // unless the scraper is set for a single tv show in this folder
-      return foundDirectly && !settings.parent_name ? "tvshows" : "seasons";
-    }
+  if (scraper->Content() != ContentType::TVSHOWS)
     return TranslateContent(scraper->Content());
-  }
-  return "";
+
+  return DetermineContentForTVShows(scraperSetOnThisPath, settings.parent_name,
+                                    GetEpisodesInPaths(strPath));
 }
 
 void CVideoDatabase::GetMovieGenresByName(const std::string& strSearch, CFileItemList& items)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "Bookmark.h"
+#include "VideoContentUtils.h"
 #include "VideoInfoTag.h"
 #include "addons/Scraper.h"
 #include "dbwrappers/Database.h"
@@ -570,6 +571,11 @@ public:
    \return A content type string for the current path.
    */
   std::string GetContentForPath(const std::string& strPath);
+
+  /*!
+   * \brief Finds any episodes directly in a given path or archives that contain episodes in the path. 
+   */
+  KODI::VIDEO::TVShowEpisodePathResult GetEpisodesInPaths(const std::string& strPath) const;
 
   /*! \brief Get videos of the given content type from the given path
    \param content the content type to fetch.

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES TestBookmark.cpp
             TestFilenameAttributes.cpp
             TestStacks.cpp
             TestVideoDbUrl.cpp
+            TestVideoContentUtils.cpp
             TestVideoFileItemClassify.cpp
             TestVideoInfoTag.cpp
             TestVideoUtils.cpp)

--- a/xbmc/video/test/TestVideoContentUtils.cpp
+++ b/xbmc/video/test/TestVideoContentUtils.cpp
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "video/VideoContentUtils.h"
+
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+using ::testing::ValuesIn;
+using ::testing::WithParamInterface;
+using KODI::VIDEO::DetermineContentForTVShows;
+using KODI::VIDEO::TVShowEpisodePathResult;
+
+namespace
+{
+struct TVShowContentTestData
+{
+  bool scraperSetOnThisPath;
+  bool isShowNameFolder;
+  TVShowEpisodePathResult queryResult;
+  std::string_view expected;
+};
+
+class TestDetermineContentForTVShows : public testing::Test,
+                                       public WithParamInterface<TVShowContentTestData>
+{
+};
+} // namespace
+
+// clang-format off
+const TVShowContentTestData TVShowContentData[] = {
+  // --- Direct episodes in path ----------------------------------
+  // scraperSetOnThisPath / isShowNameFolder don't matter if episodesInThisPath is true
+  {false, false, {.episodesInThisPath = true},  "episodes"},
+  {true,  false, {.episodesInThisPath = true},  "episodes"},
+  {false, true,  {.episodesInThisPath = true},  "episodes"},
+  {true,  true,  {.episodesInThisPath = true},  "episodes"},
+
+  // --- No direct episodes, no archive candidates ------------------------------
+  // Scraper set directly on path, single-show mode OFF → source root (ie tvshows)
+  {true,  false, {}, "tvshows"},
+  // Scraper inherited from parent path → intermediate folder with no episodes (directly or via parent path) → seasons
+  // Note this includes episode files not in the root of an archive (eg. /TV Shows/Show (2002)/Season 1 and 2/episodes.rar/Season 1/episode.mkv)
+  {false, false, {}, "seasons"},
+  // Scraper set directly, single-show mode ON and folder has no episodes (directly or via parent path) → seasons
+  {true,  true,  {}, "seasons"},
+
+  // --- Archive candidates: episode in root of archive ----------
+  // rar:// URL with no filename component → episode is at root → episodes
+  {false, false, {.candidatePaths = {"rar://D%3a%5cShow%5cshow.rar/"}},        "episodes"},
+  {false, false, {.candidatePaths = {"zip://D%3a%5cShow%5cshow.zip/"}},        "episodes"},
+  {false, false, {.candidatePaths = {"archive://D%3a%5cShow%5cshow.tar.gz/"}}, "episodes"},
+
+  // --- Bluray candidates ----------
+  // bluray:// URL → episodes
+  {false, false, {.candidatePaths = {"bluray://udf%3a%2f%2fD%253a%255cShows%255cShow%255cDisc%2520S01E01-E05.iso%2f/BDMV/PLAYLIST/"}},"episodes"},
+};
+// clang-format on
+
+TEST_P(TestDetermineContentForTVShows, ReturnsExpectedContent)
+{
+  const auto& [scraperSetOnThisPath, singleShowFolder, queryResult, expected] = GetParam();
+  EXPECT_EQ(expected,
+            DetermineContentForTVShows(scraperSetOnThisPath, singleShowFolder, queryResult));
+}
+
+INSTANTIATE_TEST_SUITE_P(VideoContentUtils,
+                         TestDetermineContentForTVShows,
+                         ValuesIn(TVShowContentData));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Refactor. No functional changes. Tests added.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As discsussed in #28142 with @CrystalP.

This makes future changes to the content determination routine for TV show folders more straightforward to test.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally. With tests.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
