### PR TITLE
DisplaySettings: repair stale overscan calibrations, stop saving defaults

### DIFF
--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -80,6 +80,15 @@ std::string ModeFlagsToString(unsigned int flags, bool identifier)
     res += "std";
   return res;
 }
+
+// True when this mode is uncalibrated. Only works for live modes; dead or stale modes are
+// considered non-default always.
+bool IsDefaultCalibration(const RESOLUTION_INFO& info)
+{
+  return info.Overscan.left == 0 && info.Overscan.top == 0 && info.Overscan.right == info.iWidth &&
+         info.Overscan.bottom == info.iHeight && info.iSubtitles == info.iHeight &&
+         info.fPixelRatio == 1.0f;
+}
 } // unnamed namespace
 
 CDisplaySettings::CDisplaySettings()
@@ -533,6 +542,18 @@ void CDisplaySettings::ApplyCalibrations()
     {
       if (StringUtils::EqualsNoCase(itCal->strMode, m_resolutions[res].strMode))
       {
+        // HACK for #28406: limitguisize inadvertently got enabled for single-plane rendering and
+        // saved the resulting resolution as the calibrated resolution. Undo that here. This check
+        // theoretically could catch a user-calibrated resolution but it would be an extreme
+        // overscan that we are now disallowing.
+        //! @todo remove once guisettings.xml files written before #28321 are gone from the wild
+        if (m_resolutions[res].iScreenWidth > 1920 && m_resolutions[res].iScreenHeight > 1080 &&
+            itCal->Overscan.left == 0 && itCal->Overscan.top == 0 &&
+            itCal->iSubtitles == itCal->Overscan.bottom && itCal->fPixelRatio == 1.0f &&
+            ((itCal->Overscan.right == 1280 && itCal->Overscan.bottom == 720) ||
+             (itCal->Overscan.right == 1920 && itCal->Overscan.bottom == 1080)))
+          break;
+
         // overscan
         m_resolutions[res].Overscan.left = itCal->Overscan.left;
         if (m_resolutions[res].Overscan.left < -m_resolutions[res].iWidth/4)
@@ -589,16 +610,23 @@ void CDisplaySettings::UpdateCalibrations()
         m_calibrations.cend())
       m_calibrations.emplace_back(*res);
 
-  for (auto &cal : m_calibrations)
+  for (auto it = m_calibrations.begin(); it != m_calibrations.end();)
   {
-    ResolutionInfos::const_iterator res(std::find_if(m_resolutions.cbegin() + RES_DESKTOP, m_resolutions.cend(),
-    [&](const RESOLUTION_INFO& info) { return StringUtils::EqualsNoCase(cal.strMode, info.strMode); }));
+    const ResolutionInfos::const_iterator res(std::find_if(
+        m_resolutions.cbegin() + RES_DESKTOP, m_resolutions.cend(), [&](const RESOLUTION_INFO& info)
+        { return StringUtils::EqualsNoCase(it->strMode, info.strMode); }));
 
     if (res != m_resolutions.cend())
     {
-      //! @todo erase calibrations with default values
-      cal = *res;
+      // A calibration whose mode is live and still at its defaults holds no user adjustment.
+      if (IsDefaultCalibration(*res))
+      {
+        it = m_calibrations.erase(it);
+        continue;
+      }
+      *it = *res;
     }
+    ++it;
   }
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -243,6 +243,9 @@ void CWinSystemGbm::UpdateResolutions()
   }
 
   CDisplaySettings::GetInstance().ApplyCalibrations();
+
+  // Ensure that scrubbed calibrations are always saved, otherwise would depend on calibration GUI
+  CDisplaySettings::GetInstance().UpdateCalibrations();
 }
 
 bool CWinSystemGbm::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)


### PR DESCRIPTION
## Description
Fixes #28406, followup to #28321 


<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
#28406

## How has this been tested?
Intel N250, GBM+GLES build

## What is the effect on users?
fixes #28406

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
