### PR TITLE
[Video] Various small movie set fixes.

### DIFF
--- a/xbmc/video/SetInfoTag.cpp
+++ b/xbmc/video/SetInfoTag.cpp
@@ -87,7 +87,10 @@ void CSetInfoTag::Merge(const CSetInfoTag& other)
   if (other.HasOriginalTitle())
     m_originalTitle = other.GetOriginalTitle();
   if (other.HasOverview())
+  {
     m_overview = other.GetOverview();
+    m_updateSetOverview = other.m_updateSetOverview;
+  }
   if (!other.m_art.empty())
     m_art = other.m_art;
 }
@@ -98,6 +101,7 @@ void CSetInfoTag::Copy(const CSetInfoTag& other)
   m_title = other.GetTitle();
   m_originalTitle = other.GetOriginalTitle();
   m_overview = other.GetOverview();
+  m_updateSetOverview = other.m_updateSetOverview;
   m_art = other.m_art;
 }
 

--- a/xbmc/video/SetInfoTag.h
+++ b/xbmc/video/SetInfoTag.h
@@ -62,13 +62,15 @@ public:
   void Archive(CArchive& ar) override;
   void Serialize(CVariant& value) const override;
 
+private:
+  friend struct CSetInfoTagOffsets;
+
   std::string m_title; // Title of the movie set
   std::string m_originalTitle; // Original title of movie set (from scraper)
   std::string m_overview; // Overview/description of the movie set
   KODI::ART::Artwork m_art; // Art information
   int m_id{-1}; // ID of movie set in database
 
-private:
   bool m_updateSetOverview{false}; // If overview has been set
 
   /* \brief Parse our native XML format for video info.

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -2297,7 +2297,7 @@ int CVideoDatabase::SetDetailsForMovie(CVideoInfoTag& details,
     if (details.m_set.HasTitle())
     {
       idSet = AddSet(details.m_set.GetTitle(), details.m_set.GetOverview(),
-                     details.m_set.GetOriginalTitle(), details.GetUpdateSetOverview());
+                     details.m_set.GetOriginalTitle(), details.m_set.GetUpdateSetOverview());
       details.m_set.SetID(idSet);
       for (const auto& [type, url] : artwork)
       {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4428,8 +4428,7 @@ void CVideoDatabase::GetDetailsFromDB(const dbiplus::sql_record* const record,
     switch (offsets[i].type)
     {
       case VIDEODB_TYPE_STRING:
-        *reinterpret_cast<std::string*>((reinterpret_cast<char*>(&details)) + offsets[i].offset) =
-            record->at(i + idxOffset).get_asString();
+        details.*(offsets[i].member) = record->at(i + idxOffset).get_asString();
         break;
       case VIDEODB_TYPE_UNUSED: // Skip the unused field to avoid populating unused data
         continue;
@@ -4742,7 +4741,7 @@ CSetInfoTag CVideoDatabase::GetDetailsForSet(const dbiplus::sql_record* const re
 
   GetDetailsFromDB(record, VIDEODB_ID_SET_MIN, VIDEODB_ID_SET_MAX, DbSetOffsets, details, 1);
 
-  details.m_id = idSet;
+  details.SetID(idSet);
 
   return details;
 }
@@ -10680,7 +10679,7 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           // get set information and generate .nfo
           CSetInfoTag set{GetDetailsForSet(*m_pDS)};
           KODI::ART::Artwork artwork;
-          if (GetArtForItem(set.m_id, MediaTypeVideoCollection, artwork) && !artwork.empty())
+          if (GetArtForItem(set.GetID(), MediaTypeVideoCollection, artwork) && !artwork.empty())
           {
             // Remove local urls as files saved in the set folder
             std::erase_if(artwork, [](const auto& art) { return !URIUtils::IsRemote(art.second); });

--- a/xbmc/video/VideoDatabaseColumns.h
+++ b/xbmc/video/VideoDatabaseColumns.h
@@ -225,10 +225,23 @@ enum VIDEODB_SET_IDS // this enum MUST match the offset struct further down!! an
 
 constexpr int DB_SET_OFFSETS_SIZE = 3;
 
-const std::array<SDbTableOffsets, DB_SET_OFFSETS_SIZE> DbSetOffsets = {{
-    {VIDEODB_TYPE_STRING, my_offsetof(CSetInfoTag, m_title)},
-    {VIDEODB_TYPE_STRING, my_offsetof(CSetInfoTag, m_overview)},
-    {VIDEODB_TYPE_STRING, my_offsetof(CSetInfoTag, m_originalTitle)},
+struct CSetInfoTagOffsets
+{
+  static constexpr std::string CSetInfoTag::*Title = &CSetInfoTag::m_title;
+  static constexpr std::string CSetInfoTag::*Overview = &CSetInfoTag::m_overview;
+  static constexpr std::string CSetInfoTag::*OriginalTitle = &CSetInfoTag::m_originalTitle;
+};
+
+struct SDbSetTableOffsets
+{
+  int type{VIDEODB_TYPE_UNUSED};
+  std::string CSetInfoTag::*member{nullptr};
+};
+
+constexpr std::array<SDbSetTableOffsets, DB_SET_OFFSETS_SIZE> DbSetOffsets = {{
+    {VIDEODB_TYPE_STRING, CSetInfoTagOffsets::Title},
+    {VIDEODB_TYPE_STRING, CSetInfoTagOffsets::Overview},
+    {VIDEODB_TYPE_STRING, CSetInfoTagOffsets::OriginalTitle},
 }};
 
 enum VIDEODB_TV_IDS // this enum MUST match the offset struct further down!! and make sure to keep min and max at -1 and sizeof(offsets)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -621,10 +621,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
           if (!setTag.GetTitle().empty())
             tag.m_set.SetTitle(setTag.GetTitle());
           if (!setTag.GetOverview().empty())
-          {
             tag.m_set.SetOverview(setTag.GetOverview());
-            tag.SetUpdateSetOverview(true);
-          }
           if (setTag.HasArt())
             tag.m_set.SetArt(setTag.GetArt());
           setUpdated = true;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1027,7 +1027,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
           return InfoRet::INFO_ERROR;
 
         // Deal with set
-        if (UpdateSetInTag(*pItem->GetVideoInfoTag()) && !AddSet(pItem->GetVideoInfoTag()->m_set))
+        if (UpdateSetInTag(*item.GetVideoInfoTag()) && !AddSet(item.GetVideoInfoTag()->m_set))
           return InfoRet::INFO_ERROR;
       }
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -649,7 +649,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
           movieSetArt.try_emplace(url.m_aspect.substr(4), url.m_url);
     }
     if (!movieSetArt.empty())
+    {
       tag.m_set.SetArt(movieSetArt);
+      setUpdated = true;
+    }
 
     return setUpdated;
   }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1676,11 +1676,22 @@ CVideoInfoScanner::~CVideoInfoScanner()
       // Remove remote set art (if need)
       if (useRemoteArt == UseRemoteArtWithLocalScraper::NO)
         std::erase_if(art,
-                      [](const std::pair<std::string, std::string>& artItem)
+                      [](const auto& artItem)
                       {
                         const auto& [type, url] = artItem;
                         return StringUtils::StartsWith(type, "set.") && URIUtils::IsRemote(url);
                       });
+
+      // Art in SetInfoTag trumps set.* art in VideoInfoTag
+      std::erase_if(art,
+                    [&pItem](const auto& artItem)
+                    {
+                      const auto& [type, url] = artItem;
+                      if (StringUtils::StartsWith(type, "set."))
+                        // Remove set art from VideoInfoTag if same type art in SetInfoTag
+                        return pItem->GetVideoInfoTag()->m_set.GetArt().contains(type.substr(4));
+                      return false;
+                    });
 
       // Deal with 'Disc n' subdirectories
       // Unless dealing with a full nfo in which case details are taken from there already

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -100,7 +100,6 @@ void CVideoInfoTag::Reset()
   m_relevance = -1;
   m_parsedDetails = 0;
   m_coverArt.clear();
-  m_updateSetOverview = true;
 }
 
 bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathInfo, const TiXmlElement *additionalNode)
@@ -1430,7 +1429,6 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
 
   // Pre-Jarvis NFO file:
   // <set>A set</set>
-  m_updateSetOverview = false;
   if (XMLUtils::GetString(movie, "set", value))
     SetSet(value);
   // Jarvis+:
@@ -1443,10 +1441,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
     {
       SetSet(value);
       if (XMLUtils::GetString(node, "overview", value))
-      {
         SetSetOverview(value);
-        m_updateSetOverview = true;
-      }
     }
   }
 

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -228,7 +228,10 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
   if (m_set.HasTitle())
   {
     TiXmlElement set("set");
-    XMLUtils::SetString(&set, "name", m_set.GetOriginalTitle());
+    // Original title used here (in the movie nfo), as the user defined title will be derived from the MSIF set.nfo
+    // This is to ensure that if the movie nfo is used independently then the set name still matches the one from the scraper source
+    XMLUtils::SetString(&set, "name",
+                        m_set.HasOriginalTitle() ? m_set.GetOriginalTitle() : m_set.GetTitle());
     if (m_set.HasOverview())
       XMLUtils::SetString(&set, "overview", m_set.GetOverview());
     movie->InsertEndChild(set);

--- a/xbmc/video/VideoInfoTag.h
+++ b/xbmc/video/VideoInfoTag.h
@@ -363,14 +363,6 @@ public:
   void SetIsDefaultVideoVersion(bool isDefaultVideoVersion);
 
   /*!
-  * @brief Get whether the Set Overview should be updated. If an NFO contains a <name> but no <overview> then
-  * this allows the current Overview to be kept. Otherwise it is overwritten. Default is true - so if updated
-  * by a scraper the Overview will be overwritten.
-  */
-  bool GetUpdateSetOverview() const { return m_updateSetOverview; }
-  void SetUpdateSetOverview(const bool value) { m_updateSetOverview = value; }
-
-  /*!
    * @brief Set this videos's resume point.
    * @param timeInSeconds the time of the resume point
    * @param totalTimeInSeconds the total time of the video
@@ -477,6 +469,5 @@ private:
   bool m_hasVideoExtras{false};
   bool m_isDefaultVideoVersion{false};
 
-  bool m_updateSetOverview{true};
   bool m_override{false};
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

See the individual fixes.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Looking at the set code (in #26295) again for an unrelated bug, I noticed a few comments from @CrystalP I hadn't addressed.
In looking at those I found a few small bugs in the code, mainly around artwork.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally using 2 movies in a set. TMDB scraper.

With no set MSIF - State 1
<img width="940" height="588" alt="image" src="https://github.com/user-attachments/assets/56b7fe0c-e151-46c1-98d3-31188c4763da" />

With set MSIF - State 2
<img width="940" height="588" alt="image" src="https://github.com/user-attachments/assets/d62b69d4-6997-4f7a-905a-2837c1626523" />

**Testing (Movie/Set)**

Scrape movie with no folder in MSIF -> State 1
Add MSIF folder and refresh SET through info dialog -> State 2
Remove MSIF folder and refresh SET through info dialog -> State 1
Add MSIF folder and refresh MOVIE (in set) through info dialog -> State 2
Remove MSIF folder and refresh MOVIE (in set) through info dialog -> State 1

**Import/Export Testing (Seperate Files)**

Scrape movie with MSIF folder -> State 2
Export to seperate files, delete database, reimport with local scraper -> State 2

Scrape movie with MSIF folder -> State 2
Export to seperate files, REMOVE the MSIF folder, delete database, reimport with local scraper
<img width="3200" height="2000" alt="image" src="https://github.com/user-attachments/assets/653c3a14-15fa-4ff8-b8ca-092331b36e5c" />
Note that the new set name and art are missing - this is expected - only the original set name, overview and scraper art are stored in the movie.nfo.
This is to ensure that if the movie nfo is used independently then the set name still matches the one from the scraper source.

**Import/Export (Single File)**

Scrape movie with MSIF folder -> State 2
Export to single file, delete database, import -> State 2

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
