### PR TITLE
Screenshot rework part 1: capture service and high-bit-depth PNG output

### DIFF
--- a/cmake/treedata/common/subdirs.txt
+++ b/cmake/treedata/common/subdirs.txt
@@ -29,6 +29,7 @@ xbmc/playlists                                  playlists
 xbmc/powermanagement                            powermanagement
 xbmc/programs                                   programs
 xbmc/rendering                                  rendering
+xbmc/rendering/capture                          rendering_capture
 xbmc/resources                                  resources
 xbmc/speech                                     speech
 xbmc/storage                                    storage

--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -23,6 +23,7 @@ xbmc/network/test                 test/network
 xbmc/pictures/metadata/test       test/pictures/metadata
 xbmc/playlists/test               test/playlists
 xbmc/pvr/channels/test            test/pvrchannels
+xbmc/rendering/capture/test       test/rendering_capture
 xbmc/settings/test                test/settings
 xbmc/test                         test
 xbmc/threads/test                 test/threads

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -418,6 +418,22 @@ std::shared_ptr<CJobManager> CServiceBroker::GetJobManager()
   return g_serviceBroker.m_jobManager;
 }
 
+void CServiceBroker::RegisterCaptureService(
+    const std::shared_ptr<KODI::RENDERING::CAPTURE::CCaptureService>& captureService)
+{
+  g_serviceBroker.m_captureService = captureService;
+}
+
+void CServiceBroker::UnregisterCaptureService()
+{
+  g_serviceBroker.m_captureService.reset();
+}
+
+std::shared_ptr<KODI::RENDERING::CAPTURE::CCaptureService> CServiceBroker::GetCaptureService()
+{
+  return g_serviceBroker.m_captureService;
+}
+
 void CServiceBroker::RegisterAppMessenger(
     const std::shared_ptr<KODI::MESSAGING::CApplicationMessenger>& appMessenger)
 {

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -48,6 +48,14 @@ namespace MESSAGING
 {
 class CApplicationMessenger;
 }
+
+namespace RENDERING
+{
+namespace CAPTURE
+{
+class CCaptureService;
+}
+} // namespace RENDERING
 } // namespace KODI
 
 class CAppParams;
@@ -228,6 +236,11 @@ public:
   static void UnregisterJobManager();
   static std::shared_ptr<CJobManager> GetJobManager();
 
+  static void RegisterCaptureService(
+      const std::shared_ptr<KODI::RENDERING::CAPTURE::CCaptureService>& captureService);
+  static void UnregisterCaptureService();
+  static std::shared_ptr<KODI::RENDERING::CAPTURE::CCaptureService> GetCaptureService();
+
   static void RegisterAppMessenger(
       const std::shared_ptr<KODI::MESSAGING::CApplicationMessenger>& appMessenger);
   static void UnregisterAppMessenger();
@@ -265,6 +278,7 @@ private:
   std::shared_ptr<CCPUInfo> m_cpuInfo;
   std::shared_ptr<CTextureCache> m_textureCache;
   std::shared_ptr<CJobManager> m_jobManager;
+  std::shared_ptr<KODI::RENDERING::CAPTURE::CCaptureService> m_captureService;
   std::shared_ptr<KODI::MESSAGING::CApplicationMessenger> m_appMessenger;
   std::shared_ptr<KODI::KEYBOARD::CKeyboardLayoutManager> m_keyboardLayoutManager;
   std::shared_ptr<speech::ISpeechRecognition> m_speechRecognition;

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -850,16 +850,15 @@ void ServiceCaptureTaps()
     return;
 
   auto* winSystem = CServiceBroker::GetWinSystem();
-  auto* gui = CServiceBroker::GetGUI();
   auto surface = CScreenShot::CreateSurface();
-  if (!winSystem || !gui || !surface)
+  if (!winSystem || !surface)
   {
     for (const auto& request : requests)
       captureService->Fail(request);
     return;
   }
 
-  const ScreenshotContext ctx{*winSystem, gui->GetWindowManager()};
+  const ScreenshotContext ctx{*winSystem};
   if (!surface->Read(ctx))
   {
     for (const auto& request : requests)

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -121,6 +121,8 @@
 #include "pvr/guilib/PVRGUIActionsPlayback.h"
 #include "pvr/guilib/PVRGUIActionsPowerManagement.h"
 #include "rendering/RenderSystem.h"
+#include "rendering/capture/CaptureMetadata.h"
+#include "rendering/capture/CaptureService.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
@@ -261,6 +263,10 @@ bool CApplication::Create()
 
   // Register JobManager service
   CServiceBroker::RegisterJobManager(std::make_shared<CJobManager>());
+
+  // Screen capture service
+  CServiceBroker::RegisterCaptureService(
+      std::make_shared<KODI::RENDERING::CAPTURE::CCaptureService>());
 
   // Announcement service
   m_pAnnouncementManager = std::make_shared<ANNOUNCEMENT::CAnnouncementManager>();
@@ -827,6 +833,53 @@ bool CApplication::OnSettingsSaving() const
   return !m_bStop;
 }
 
+namespace
+{
+// capture tap: serve pending requests from the finished frame before it is
+// presented.
+void ServiceCaptureTaps()
+{
+  using namespace KODI::RENDERING::CAPTURE;
+
+  const auto captureService = CServiceBroker::GetCaptureService();
+  if (!captureService)
+    return;
+
+  const auto requests = captureService->TakeActive(CaptureContent::COMPOSITE);
+  if (requests.empty())
+    return;
+
+  auto* winSystem = CServiceBroker::GetWinSystem();
+  auto* gui = CServiceBroker::GetGUI();
+  auto surface = CScreenShot::CreateSurface();
+  if (!winSystem || !gui || !surface)
+  {
+    for (const auto& request : requests)
+      captureService->Fail(request);
+    return;
+  }
+
+  const ScreenshotContext ctx{*winSystem, gui->GetWindowManager()};
+  if (!surface->Read(ctx))
+  {
+    for (const auto& request : requests)
+      captureService->Fail(request);
+    return;
+  }
+
+  CaptureResult result;
+  result.pixels.reset(surface->TakeBuffer());
+  result.width = static_cast<unsigned int>(surface->GetWidth());
+  result.height = static_cast<unsigned int>(surface->GetHeight());
+  result.stride = static_cast<unsigned int>(surface->GetStride());
+  result.bitDepth = surface->GetBitDepth();
+  result.color = GetOutputColorMetadata(*winSystem);
+
+  for (const auto& request : requests)
+    captureService->Complete(request, result);
+}
+} // namespace
+
 void CApplication::Render()
 {
   // do not render if we are stopped or in background
@@ -886,6 +939,11 @@ void CApplication::Render()
 
   if (compositing)
     CServiceBroker::GetWinSystem()->CompositeGui();
+
+  // serve pending requests from the finished frame; only a frame that really
+  // drew counts
+  if (hasRendered)
+    ServiceCaptureTaps();
 
   CServiceBroker::GetRenderSystem()->EndRender();
 
@@ -1526,6 +1584,12 @@ void CApplication::FrameMove(bool processEvents, bool processGUI)
   {
     m_skipGuiRender = false;
 
+    // a new capture request marks the window manager dirty so a frame really
+    // renders, since an idle GUI would otherwise skip it
+    if (const auto captureService = CServiceBroker::GetCaptureService();
+        captureService && captureService->LatchFrame())
+      CServiceBroker::GetGUI()->GetWindowManager().MarkDirty();
+
     /*! @todo look into the possibility to use this for GBM
     int fps = 0;
 
@@ -1642,6 +1706,8 @@ bool CApplication::Cleanup()
     GetComponent<CApplicationSkinHandling>()->UnloadSkin();
 
     CServiceBroker::UnregisterTextureCache();
+
+    CServiceBroker::UnregisterCaptureService();
 
     // stop all remaining scripts; must be done after skin has been unloaded,
     // not before some windows still need it when deinitializing during skin

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -561,6 +561,11 @@ bool CFFmpegImage::DecodeFrame(AVFrame* frame, unsigned int width, unsigned int 
   return true;
 }
 
+void CFFmpegImage::SetColorMetadata(const ImageColorMetadata& color)
+{
+  m_color = color;
+}
+
 bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned int width,
                                              unsigned int height, unsigned int format,
                                              unsigned int pitch,
@@ -569,11 +574,13 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned 
                                              unsigned int &bufferoutSize)
 {
   // It seems XB_FMT_A8R8G8B8 mean RGBA and not ARGB
-  if (format != XB_FMT_A8R8G8B8)
+  if (format != XB_FMT_A8R8G8B8 && format != XB_FMT_RGBA16)
   {
     CLog::Log(LOGERROR, "Supplied format: {} is not supported.", format);
     return false;
   }
+
+  bool is16bit = (format == XB_FMT_RGBA16);
 
   bool jpg_output = false;
   if (m_strMimeType == "image/jpeg" || m_strMimeType == "image/jpg")
@@ -607,7 +614,9 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned 
   tdm.avOutctx->width = width;
   tdm.avOutctx->time_base.num = 1;
   tdm.avOutctx->time_base.den = 1;
-  tdm.avOutctx->pix_fmt = jpg_output ? AV_PIX_FMT_YUVJ420P : AV_PIX_FMT_RGBA;
+  tdm.avOutctx->pix_fmt = jpg_output ? AV_PIX_FMT_YUVJ420P
+                          : is16bit  ? AV_PIX_FMT_RGBA64BE
+                                     : AV_PIX_FMT_RGBA;
   tdm.avOutctx->flags = AV_CODEC_FLAG_QSCALE;
   tdm.avOutctx->mb_lmin = tdm.avOutctx->qmin * FF_QP2LAMBDA;
   tdm.avOutctx->mb_lmax = tdm.avOutctx->qmax * FF_QP2LAMBDA;
@@ -659,7 +668,11 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned 
     return false;
   }
 
-  if (av_image_fill_arrays(tdm.frame_temporary->data, tdm.frame_temporary->linesize, tdm.intermediateBuffer, jpg_output ? AV_PIX_FMT_YUV420P : AV_PIX_FMT_RGBA, width, height, 16) < 0)
+  AVPixelFormat intermediateFmt = jpg_output ? AV_PIX_FMT_YUV420P
+                                  : is16bit  ? AV_PIX_FMT_RGBA64BE
+                                             : AV_PIX_FMT_RGBA;
+  if (av_image_fill_arrays(tdm.frame_temporary->data, tdm.frame_temporary->linesize,
+                           tdm.intermediateBuffer, intermediateFmt, width, height, 16) < 0)
   {
     CLog::Log(LOGERROR, "Could not fill picture for thumbnail: {}", destFile);
     CleanupLocalOutputBuffer();
@@ -670,7 +683,11 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned 
   int srcStride[] = { (int) pitch, 0, 0, 0};
 
   //input size == output size which means only pix_fmt conversion
-  tdm.sws = sws_getContext(width, height, AV_PIX_FMT_RGB32, width, height, jpg_output ? AV_PIX_FMT_YUV420P : AV_PIX_FMT_RGBA, 0, 0, 0, 0);
+  AVPixelFormat srcFmt = is16bit ? AV_PIX_FMT_RGBA64LE : AV_PIX_FMT_RGB32;
+  AVPixelFormat dstFmt = jpg_output ? AV_PIX_FMT_YUV420P
+                         : is16bit  ? AV_PIX_FMT_RGBA64BE
+                                    : AV_PIX_FMT_RGBA;
+  tdm.sws = sws_getContext(width, height, srcFmt, width, height, dstFmt, 0, 0, 0, 0);
   if (!tdm.sws)
   {
     CLog::Log(LOGERROR, "Could not setup scaling context for thumbnail: {}", destFile);
@@ -718,7 +735,21 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned 
   tdm.frame_input->linesize[1] = tdm.frame_temporary->linesize[1];
   tdm.frame_input->linesize[2] = tdm.frame_temporary->linesize[2];
   // this is deprecated but mjpeg is not yet transitioned
-  tdm.frame_input->format = jpg_output ? AV_PIX_FMT_YUVJ420P : AV_PIX_FMT_RGBA;
+  tdm.frame_input->format = jpg_output ? AV_PIX_FMT_YUVJ420P
+                            : is16bit  ? AV_PIX_FMT_RGBA64BE
+                                       : AV_PIX_FMT_RGBA;
+
+  // CICP color signaling (PNG cICP/sRGB chunk). Only the PNG (RGB) path uses
+  // it; JPEG ignores it. A negative code leaves the field unset.
+  if (!jpg_output)
+  {
+    if (m_color.primaries >= 0)
+      tdm.frame_input->color_primaries = static_cast<AVColorPrimaries>(m_color.primaries);
+    if (m_color.transfer >= 0)
+      tdm.frame_input->color_trc = static_cast<AVColorTransferCharacteristic>(m_color.transfer);
+    if (m_color.range >= 0)
+      tdm.frame_input->color_range = static_cast<AVColorRange>(m_color.range);
+  }
 
   int got_package = 0;
   AVPacket* avpkt;

--- a/xbmc/guilib/FFmpegImage.h
+++ b/xbmc/guilib/FFmpegImage.h
@@ -70,6 +70,7 @@ public:
                                   unsigned char* &bufferout,
                                   unsigned int &bufferoutSize) override;
   void ReleaseThumbnailBuffer() override;
+  void SetColorMetadata(const ImageColorMetadata& color) override;
 
   bool Initialize(unsigned char* buffer, size_t bufSize);
 
@@ -85,6 +86,8 @@ private:
   std::string m_strMimeType;
   void CleanupLocalOutputBuffer();
 
+  // CICP color metadata for the encoded output (fields default to unset).
+  ImageColorMetadata m_color;
 
   MemBuffer m_buf;
 

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -23,6 +23,7 @@
 
 class CGUIDialog;
 class CGUIMediaWindow;
+class CScreenShot;
 
 #ifdef TARGET_WINDOWS_STORE
 #pragma pack(push, 8)
@@ -50,6 +51,8 @@ class CGUIWindowManager : public KODI::MESSAGING::IMessageTarget
 {
   friend CGUIDialog;
   friend CGUIMediaWindow;
+  friend CScreenShot;
+
 public:
   CGUIWindowManager();
   ~CGUIWindowManager() override;

--- a/xbmc/guilib/TextureFormats.h
+++ b/xbmc/guilib/TextureFormats.h
@@ -22,6 +22,7 @@ enum XB_FMT
   XB_FMT_A8          = 0x20,
   XB_FMT_RGBA8       = 0x40,
   XB_FMT_RGB8        = 0x80,
+  XB_FMT_RGBA16      = 0x100, // 16-bit per channel RGBA (for 10-bit+ screenshot capture)
   XB_FMT_MASK        = 0xFFFF,
   XB_FMT_OPAQUE      = 0x10000,
 };

--- a/xbmc/guilib/iimage.h
+++ b/xbmc/guilib/iimage.h
@@ -10,6 +10,16 @@
 
 #include <string>
 
+//! \brief CICP color metadata (H.273 code points) to embed in an encoded image,
+//! e.g. the PNG cICP / sRGB chunk. Values are AVColorPrimaries /
+//! AVColorTransferCharacteristic / AVColorRange; -1 leaves a field unset.
+struct ImageColorMetadata
+{
+  int primaries = -1;
+  int transfer = -1;
+  int range = -1;
+};
+
 class IImage
 {
 public:
@@ -54,6 +64,13 @@ public:
    \brief Frees the output buffer allocated by CreateThumbnailFromSurface
    */
   virtual void ReleaseThumbnailBuffer() {}
+
+  /*!
+   \brief Set the color metadata to embed in the encoded output (e.g. the PNG
+          cICP/sRGB chunk). Default no-op; only encoders that support color
+          signaling override this.
+   */
+  virtual void SetColorMetadata(const ImageColorMetadata& color) {}
 
   unsigned int Width() const              { return m_width; }
   unsigned int Height() const             { return m_height; }

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -56,14 +56,24 @@ bool CPicture::GetThumbnailFromSurface(const unsigned char* buffer, int width, i
   return true;
 }
 
-bool CPicture::CreateThumbnailFromSurface(const unsigned char *buffer, int width, int height, int stride, const std::string &thumbFile)
+bool CPicture::CreateThumbnailFromSurface(const unsigned char* buffer,
+                                          int width,
+                                          int height,
+                                          int stride,
+                                          const std::string& thumbFile,
+                                          unsigned int format,
+                                          const ImageColorMetadata& color)
 {
   CLog::Log(LOGDEBUG, "cached image '{}' size {}x{}", CURL::GetRedacted(thumbFile), width, height);
 
   unsigned char *thumb = NULL;
   unsigned int thumbsize=0;
   IImage* pImage = ImageFactory::CreateLoader(thumbFile);
-  if(pImage == NULL || !pImage->CreateThumbnailFromSurface(const_cast<unsigned char*>(buffer), width, height, XB_FMT_A8R8G8B8, stride, thumbFile.c_str(), thumb, thumbsize))
+  if (pImage)
+    pImage->SetColorMetadata(color);
+  if (pImage == NULL ||
+      !pImage->CreateThumbnailFromSurface(const_cast<unsigned char*>(buffer), width, height, format,
+                                          stride, thumbFile.c_str(), thumb, thumbsize))
   {
     CLog::Log(LOGERROR, "Failed to CreateThumbnailFromSurface for {}",
               CURL::GetRedacted(thumbFile));
@@ -81,13 +91,21 @@ bool CPicture::CreateThumbnailFromSurface(const unsigned char *buffer, int width
   return ret;
 }
 
-CThumbnailWriter::CThumbnailWriter(unsigned char* buffer, int width, int height, int stride, const std::string& thumbFile):
-  m_thumbFile(thumbFile)
+CThumbnailWriter::CThumbnailWriter(unsigned char* buffer,
+                                   int width,
+                                   int height,
+                                   int stride,
+                                   const std::string& thumbFile,
+                                   unsigned int format,
+                                   const ImageColorMetadata& color)
+  : m_thumbFile(thumbFile)
 {
   m_buffer    = buffer;
   m_width     = width;
   m_height    = height;
   m_stride    = stride;
+  m_format = format;
+  m_color = color;
 }
 
 CThumbnailWriter::~CThumbnailWriter()
@@ -99,7 +117,8 @@ bool CThumbnailWriter::DoWork()
 {
   bool success = true;
 
-  if (!CPicture::CreateThumbnailFromSurface(m_buffer, m_width, m_height, m_stride, m_thumbFile))
+  if (!CPicture::CreateThumbnailFromSurface(m_buffer, m_width, m_height, m_stride, m_thumbFile,
+                                            m_format, m_color))
   {
     CLog::Log(LOGERROR, "CThumbnailWriter::DoWork unable to write {}",
               CURL::GetRedacted(m_thumbFile));

--- a/xbmc/pictures/Picture.h
+++ b/xbmc/pictures/Picture.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "guilib/TextureFormats.h"
+#include "guilib/iimage.h"
 #include "jobs/Job.h"
 #include "pictures/PictureScalingAlgorithm.h"
 
@@ -28,7 +30,13 @@ class CPicture
 {
 public:
   static bool GetThumbnailFromSurface(const unsigned char* buffer, int width, int height, int stride, const std::string &thumbFile, uint8_t* &result, size_t& result_size);
-  static bool CreateThumbnailFromSurface(const unsigned char* buffer, int width, int height, int stride, const std::string &thumbFile);
+  static bool CreateThumbnailFromSurface(const unsigned char* buffer,
+                                         int width,
+                                         int height,
+                                         int stride,
+                                         const std::string& thumbFile,
+                                         unsigned int format = XB_FMT_A8R8G8B8,
+                                         const ImageColorMetadata& color = {});
 
   static std::unique_ptr<CTexture> CreateTiledThumb(const std::vector<std::string>& files);
 
@@ -117,7 +125,13 @@ class CThumbnailWriter : public CJob
 {
   public:
     //WARNING: buffer is deleted from DoWork()
-    CThumbnailWriter(unsigned char* buffer, int width, int height, int stride, const std::string& thumbFile);
+    CThumbnailWriter(unsigned char* buffer,
+                     int width,
+                     int height,
+                     int stride,
+                     const std::string& thumbFile,
+                     unsigned int format = XB_FMT_A8R8G8B8,
+                     const ImageColorMetadata& color = {});
     ~CThumbnailWriter() override;
     bool DoWork() override;
 
@@ -126,6 +140,8 @@ class CThumbnailWriter : public CJob
     int            m_width;
     int            m_height;
     int            m_stride;
+    unsigned int m_format;
+    ImageColorMetadata m_color;
     std::string    m_thumbFile;
 };
 

--- a/xbmc/rendering/capture/CMakeLists.txt
+++ b/xbmc/rendering/capture/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(SOURCES CaptureHandle.cpp
+            CaptureService.cpp)
+
+set(HEADERS CaptureHandle.h
+            CaptureRequest.h
+            CaptureService.h
+            CaptureTypes.h)
+
+core_add_library(rendering_capture)

--- a/xbmc/rendering/capture/CMakeLists.txt
+++ b/xbmc/rendering/capture/CMakeLists.txt
@@ -1,7 +1,9 @@
 set(SOURCES CaptureHandle.cpp
+            CaptureMetadata.cpp
             CaptureService.cpp)
 
 set(HEADERS CaptureHandle.h
+            CaptureMetadata.h
             CaptureRequest.h
             CaptureService.h
             CaptureTypes.h)

--- a/xbmc/rendering/capture/CaptureHandle.cpp
+++ b/xbmc/rendering/capture/CaptureHandle.cpp
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "CaptureHandle.h"
+
+#include "rendering/capture/CaptureRequest.h"
+#include "rendering/capture/CaptureService.h"
+
+namespace KODI
+{
+namespace RENDERING
+{
+namespace CAPTURE
+{
+
+CCaptureHandle::CCaptureHandle(CCaptureService& service, std::shared_ptr<CaptureRequest> request)
+  : m_service(service),
+    m_request(std::move(request))
+{
+}
+
+CCaptureHandle::~CCaptureHandle()
+{
+  m_service.Cancel(m_request);
+}
+
+bool CCaptureHandle::Wait(std::chrono::milliseconds timeout)
+{
+  if (!m_request->event.Wait(timeout))
+    return false;
+
+  return m_service.GetState(*m_request) == CaptureState::DONE;
+}
+
+const CaptureResult& CCaptureHandle::GetResult() const
+{
+  return m_request->result;
+}
+
+} // namespace CAPTURE
+} // namespace RENDERING
+} // namespace KODI

--- a/xbmc/rendering/capture/CaptureHandle.cpp
+++ b/xbmc/rendering/capture/CaptureHandle.cpp
@@ -10,6 +10,7 @@
 
 #include "rendering/capture/CaptureRequest.h"
 #include "rendering/capture/CaptureService.h"
+#include "utils/log.h"
 
 namespace KODI
 {
@@ -26,12 +27,13 @@ CCaptureHandle::CCaptureHandle(CCaptureService& service, std::shared_ptr<Capture
 
 CCaptureHandle::~CCaptureHandle()
 {
-  m_service.Cancel(m_request);
+  if (m_request)
+    m_service.Cancel(m_request);
 }
 
 bool CCaptureHandle::Wait(std::chrono::milliseconds timeout)
 {
-  if (!m_request->event.Wait(timeout))
+  if (!m_request || !m_request->event.Wait(timeout))
     return false;
 
   return m_service.GetState(*m_request) == CaptureState::DONE;
@@ -39,7 +41,18 @@ bool CCaptureHandle::Wait(std::chrono::milliseconds timeout)
 
 const CaptureResult& CCaptureHandle::GetResult() const
 {
+  if (!m_request)
+  {
+    CLog::LogF(LOGERROR, "called on a detached handle");
+    static const CaptureResult empty;
+    return empty;
+  }
   return m_request->result;
+}
+
+void CCaptureHandle::Detach()
+{
+  m_request.reset();
 }
 
 } // namespace CAPTURE

--- a/xbmc/rendering/capture/CaptureHandle.h
+++ b/xbmc/rendering/capture/CaptureHandle.h
@@ -38,6 +38,10 @@ public:
   //! Valid only after Wait() returned true.
   const CaptureResult& GetResult() const;
 
+  //! Release ownership without cancelling: the request completes or fails on
+  //! its own and its callback still runs. Wait() is unavailable afterwards.
+  void Detach();
+
 private:
   CCaptureService& m_service;
   std::shared_ptr<CaptureRequest> m_request;

--- a/xbmc/rendering/capture/CaptureHandle.h
+++ b/xbmc/rendering/capture/CaptureHandle.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <memory>
+
+namespace KODI
+{
+namespace RENDERING
+{
+namespace CAPTURE
+{
+
+class CCaptureService;
+struct CaptureRequest;
+struct CaptureResult;
+
+//! RAII owner of a submitted capture request: destruction cancels it.
+//! Handles must not outlive the service that issued them.
+class CCaptureHandle
+{
+public:
+  CCaptureHandle(CCaptureService& service, std::shared_ptr<CaptureRequest> request);
+  ~CCaptureHandle();
+  CCaptureHandle(const CCaptureHandle&) = delete;
+  CCaptureHandle& operator=(const CCaptureHandle&) = delete;
+
+  //! \return true when the capture completed; false on timeout, failure or cancel
+  bool Wait(std::chrono::milliseconds timeout);
+
+  //! Valid only after Wait() returned true.
+  const CaptureResult& GetResult() const;
+
+private:
+  CCaptureService& m_service;
+  std::shared_ptr<CaptureRequest> m_request;
+};
+
+} // namespace CAPTURE
+} // namespace RENDERING
+} // namespace KODI

--- a/xbmc/rendering/capture/CaptureMetadata.cpp
+++ b/xbmc/rendering/capture/CaptureMetadata.cpp
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "CaptureMetadata.h"
+
+#include "windowing/GraphicContext.h"
+#include "windowing/WinSystem.h"
+
+extern "C"
+{
+#include <libavutil/pixfmt.h>
+}
+
+namespace KODI
+{
+namespace RENDERING
+{
+namespace CAPTURE
+{
+
+ImageColorMetadata GetOutputColorMetadata(CWinSystemBase& winSystem)
+{
+  // Tag color as the display interpreted it. PQ/HLG from the winsystem HDR
+  // state; SDR by CTA-861 mode inference (HD/UHD = BT.709, SD = SMPTE-170M).
+  using KODI::UTILS::Colorimetry;
+  using KODI::UTILS::Eotf;
+  ImageColorMetadata color;
+  color.primaries = AVCOL_PRI_BT709;
+  const Colorimetry colorimetry = winSystem.GetColorimetry();
+  if (colorimetry == Colorimetry::BT2020_RGB || colorimetry == Colorimetry::BT2020_YCC ||
+      colorimetry == Colorimetry::BT2020_CYCC)
+    color.primaries = AVCOL_PRI_BT2020;
+  const Eotf eotf = winSystem.GetEotf();
+  if (eotf == Eotf::PQ)
+    color.transfer = AVCOL_TRC_SMPTE2084;
+  else if (eotf == Eotf::HLG)
+    color.transfer = AVCOL_TRC_ARIB_STD_B67;
+  //! @todo tag AVCOL_TRC_BT2020_12 once a >10-bit output surface exists:
+  //! 16-bit unorm AR48/AB48 (DRM_FORMAT_ARGB16161616/ABGR16161616) or
+  //! 16-bit float AR4H/AB4H (DRM_FORMAT_ARGB16161616F/ABGR16161616F)
+  else if (color.primaries == AVCOL_PRI_BT2020)
+    color.transfer = AVCOL_TRC_BT2020_10;
+  else if (winSystem.GetGfxContext().GetWidth() > 1024 ||
+           winSystem.GetGfxContext().GetHeight() >= 600)
+    color.transfer = AVCOL_TRC_BT709;
+  else
+  {
+    color.primaries = AVCOL_PRI_SMPTE170M;
+    color.transfer = AVCOL_TRC_SMPTE170M;
+  }
+
+  // Display output is limited-range whenever videoscreen.limitedrange is on.
+  color.range = winSystem.UseLimitedColor() ? AVCOL_RANGE_MPEG : AVCOL_RANGE_JPEG;
+  return color;
+}
+
+} // namespace CAPTURE
+} // namespace RENDERING
+} // namespace KODI

--- a/xbmc/rendering/capture/CaptureMetadata.h
+++ b/xbmc/rendering/capture/CaptureMetadata.h
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "guilib/iimage.h"
+
+class CWinSystemBase;
+
+namespace KODI
+{
+namespace RENDERING
+{
+namespace CAPTURE
+{
+
+//! \brief H.273 description of what the display output shows right now.
+ImageColorMetadata GetOutputColorMetadata(CWinSystemBase& winSystem);
+
+} // namespace CAPTURE
+} // namespace RENDERING
+} // namespace KODI

--- a/xbmc/rendering/capture/CaptureRequest.h
+++ b/xbmc/rendering/capture/CaptureRequest.h
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "rendering/capture/CaptureTypes.h"
+#include "threads/Event.h"
+
+#include <functional>
+
+namespace KODI
+{
+namespace RENDERING
+{
+namespace CAPTURE
+{
+
+enum class CaptureState
+{
+  PENDING, //!< submitted, not yet visible to taps
+  LATCHED, //!< picked up at a frame boundary, serviced by taps
+  DONE,
+  FAILED,
+  CANCELLED,
+};
+
+using CaptureCallback = std::function<void(const CaptureResult&)>;
+
+//! Passive data holder: every state transition happens inside
+//! CCaptureService under its registry lock.
+struct CaptureRequest
+{
+  CaptureSpec spec;
+  CaptureCallback callback;
+  CaptureState state{CaptureState::PENDING};
+  CaptureResult result;
+  CEvent event;
+};
+
+} // namespace CAPTURE
+} // namespace RENDERING
+} // namespace KODI

--- a/xbmc/rendering/capture/CaptureService.cpp
+++ b/xbmc/rendering/capture/CaptureService.cpp
@@ -9,6 +9,7 @@
 #include "CaptureService.h"
 
 #include "rendering/capture/CaptureHandle.h"
+#include "utils/log.h"
 
 #include <mutex>
 
@@ -113,11 +114,19 @@ void CCaptureService::Complete(const std::shared_ptr<CaptureRequest>& request, C
 
 void CCaptureService::Fail(const std::shared_ptr<CaptureRequest>& request)
 {
+  bool failed = false;
+
   {
     std::unique_lock lock(m_lock);
     if (request->state == CaptureState::LATCHED || request->state == CaptureState::PENDING)
+    {
       request->state = CaptureState::FAILED;
+      failed = true;
+    }
   }
+
+  if (failed)
+    CLog::LogF(LOGERROR, "capture request failed");
 
   request->event.Set();
   RemoveActive(request);

--- a/xbmc/rendering/capture/CaptureService.cpp
+++ b/xbmc/rendering/capture/CaptureService.cpp
@@ -1,0 +1,186 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "CaptureService.h"
+
+#include "rendering/capture/CaptureHandle.h"
+
+#include <mutex>
+
+namespace KODI
+{
+namespace RENDERING
+{
+namespace CAPTURE
+{
+
+CCaptureService::~CCaptureService()
+{
+  FailAll();
+}
+
+std::unique_ptr<CCaptureHandle> CCaptureService::Submit(const CaptureSpec& spec,
+                                                        CaptureCallback callback)
+{
+  auto request = std::make_shared<CaptureRequest>();
+  request->spec = spec;
+  request->callback = std::move(callback);
+
+  {
+    std::unique_lock lock(m_lock);
+    m_pending.push_back(request);
+    m_hasPending.store(true, std::memory_order_release);
+  }
+
+  return std::make_unique<CCaptureHandle>(*this, std::move(request));
+}
+
+bool CCaptureService::LatchFrame()
+{
+  if (!m_hasPending.load(std::memory_order_acquire) && m_active.empty())
+    return false;
+
+  bool needsFrame = false;
+
+  {
+    std::unique_lock lock(m_lock);
+    m_hasPending.store(false, std::memory_order_relaxed);
+
+    std::erase_if(m_active, [](const std::shared_ptr<CaptureRequest>& request)
+                  { return request->state == CaptureState::CANCELLED; });
+
+    for (auto& request : m_pending)
+    {
+      if (request->state != CaptureState::PENDING)
+        continue;
+      request->state = CaptureState::LATCHED;
+      m_active.push_back(request);
+      needsFrame = true;
+    }
+    m_pending.clear();
+  }
+
+  return needsFrame;
+}
+
+std::vector<std::shared_ptr<CaptureRequest>> CCaptureService::TakeActive(CaptureContent content)
+{
+  std::vector<std::shared_ptr<CaptureRequest>> matches;
+  for (const auto& request : m_active)
+  {
+    if (request->spec.content == content)
+      matches.push_back(request);
+  }
+  return matches;
+}
+
+void CCaptureService::Complete(const std::shared_ptr<CaptureRequest>& request, CaptureResult result)
+{
+  bool dispatch = false;
+  bool finished = false;
+
+  {
+    std::unique_lock lock(m_lock);
+    if (request->state == CaptureState::LATCHED)
+    {
+      request->result = std::move(result);
+      dispatch = true;
+      if (request->spec.cadence == CaptureCadence::ONESHOT)
+      {
+        request->state = CaptureState::DONE;
+        finished = true;
+      }
+    }
+    else
+    {
+      // cancelled while a tap was servicing it
+      finished = true;
+    }
+  }
+
+  request->event.Set();
+
+  if (finished)
+    RemoveActive(request);
+  if (dispatch && request->callback)
+    Dispatch(request);
+}
+
+void CCaptureService::Fail(const std::shared_ptr<CaptureRequest>& request)
+{
+  {
+    std::unique_lock lock(m_lock);
+    if (request->state == CaptureState::LATCHED || request->state == CaptureState::PENDING)
+      request->state = CaptureState::FAILED;
+  }
+
+  request->event.Set();
+  RemoveActive(request);
+}
+
+void CCaptureService::Cancel(const std::shared_ptr<CaptureRequest>& request)
+{
+  {
+    std::unique_lock lock(m_lock);
+    if (request->state == CaptureState::DONE || request->state == CaptureState::FAILED)
+      return;
+    request->state = CaptureState::CANCELLED;
+  }
+
+  request->event.Set();
+}
+
+CaptureState CCaptureService::GetState(const CaptureRequest& request) const
+{
+  std::unique_lock lock(m_lock);
+  return request.state;
+}
+
+void CCaptureService::FailAll()
+{
+  std::vector<std::shared_ptr<CaptureRequest>> all;
+
+  {
+    std::unique_lock lock(m_lock);
+    for (auto& request : m_pending)
+    {
+      if (request->state == CaptureState::PENDING)
+        request->state = CaptureState::FAILED;
+    }
+    all = std::move(m_pending);
+    m_pending.clear();
+
+    for (auto& request : m_active)
+    {
+      if (request->state == CaptureState::LATCHED)
+        request->state = CaptureState::FAILED;
+    }
+    all.insert(all.end(), m_active.begin(), m_active.end());
+    m_active.clear();
+  }
+
+  for (auto& request : all)
+    request->event.Set();
+
+  m_callbackQueue.CancelJobs();
+}
+
+void CCaptureService::Dispatch(const std::shared_ptr<CaptureRequest>& request)
+{
+  m_callbackQueue.Submit([request] { request->callback(request->result); });
+}
+
+void CCaptureService::RemoveActive(const std::shared_ptr<CaptureRequest>& request)
+{
+  std::unique_lock lock(m_lock);
+  std::erase(m_active, request);
+}
+
+} // namespace CAPTURE
+} // namespace RENDERING
+} // namespace KODI

--- a/xbmc/rendering/capture/CaptureService.h
+++ b/xbmc/rendering/capture/CaptureService.h
@@ -45,7 +45,8 @@ public:
   ~CCaptureService();
 
   //! Register a request; the returned handle owns its lifetime.
-  //! \param callback optional; runs on a worker thread after completion
+  //! \param callback optional; runs on a worker thread after SUCCESSFUL
+  //! completion only; failures and cancels just wake the waiter
   std::unique_ptr<CCaptureHandle> Submit(const CaptureSpec& spec, CaptureCallback callback = {});
 
   //! Render thread, frame boundary: make newly submitted requests visible

--- a/xbmc/rendering/capture/CaptureService.h
+++ b/xbmc/rendering/capture/CaptureService.h
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "jobs/JobQueue.h"
+#include "rendering/capture/CaptureRequest.h"
+#include "threads/CriticalSection.h"
+
+#include <atomic>
+#include <memory>
+#include <vector>
+
+namespace KODI
+{
+namespace RENDERING
+{
+namespace CAPTURE
+{
+
+class CCaptureHandle;
+
+/*!
+ \brief Registry of pixel-capture requests serviced by render-thread taps.
+
+ Threading contract:
+ - Submit()/Cancel(): any thread; they never touch the graphics context.
+ - LatchFrame()/TakeActive()/Complete()/Fail(): render thread only.
+ - Completion callbacks run on the service's job queue, never on the
+   render thread and never under the registry lock.
+ - One lock guards the registry and all request state; the atomic pending
+   flag is checked before locking, so the steady-state per-frame cost of
+   an empty registry is a single atomic load.
+ - FailAll() requires the render loop to have stopped servicing taps.
+ */
+class CCaptureService
+{
+public:
+  CCaptureService() = default;
+  ~CCaptureService();
+
+  //! Register a request; the returned handle owns its lifetime.
+  //! \param callback optional; runs on a worker thread after completion
+  std::unique_ptr<CCaptureHandle> Submit(const CaptureSpec& spec, CaptureCallback callback = {});
+
+  //! Render thread, frame boundary: make newly submitted requests visible
+  //! to this frame's taps and prune cancelled ones.
+  //! \return true when a newly latched request needs a forced frame; the
+  //! caller owns the GUI-side dirty marking.
+  bool LatchFrame();
+
+  //! Render thread: latched requests a tap of this content must service.
+  std::vector<std::shared_ptr<CaptureRequest>> TakeActive(CaptureContent content);
+
+  //! Render thread: deliver a serviced request. ONESHOT requests finish;
+  //! CONTINUOUS requests stay latched for the next frame.
+  void Complete(const std::shared_ptr<CaptureRequest>& request, CaptureResult result);
+
+  //! Render thread: fail a serviced request and wake its waiter.
+  void Fail(const std::shared_ptr<CaptureRequest>& request);
+
+  //! Any thread: abandon a request; no callback fires after this returns.
+  void Cancel(const std::shared_ptr<CaptureRequest>& request);
+
+  CaptureState GetState(const CaptureRequest& request) const;
+
+  //! Teardown: fail every request, wake every waiter, drop queued callbacks.
+  void FailAll();
+
+private:
+  void Dispatch(const std::shared_ptr<CaptureRequest>& request);
+  void RemoveActive(const std::shared_ptr<CaptureRequest>& request);
+
+  mutable CCriticalSection m_lock;
+  std::atomic<bool> m_hasPending{false};
+  //! guarded by m_lock
+  std::vector<std::shared_ptr<CaptureRequest>> m_pending;
+  //! owned by the render thread; taps iterate it with no lock held
+  std::vector<std::shared_ptr<CaptureRequest>> m_active;
+  //! FIFO with one job at a time: completions are delivered in order
+  CJobQueue m_callbackQueue;
+};
+
+} // namespace CAPTURE
+} // namespace RENDERING
+} // namespace KODI

--- a/xbmc/rendering/capture/CaptureTypes.h
+++ b/xbmc/rendering/capture/CaptureTypes.h
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "guilib/iimage.h"
+
+#include <cstdint>
+#include <memory>
+
+namespace KODI
+{
+namespace RENDERING
+{
+namespace CAPTURE
+{
+
+enum class CaptureContent
+{
+  COMPOSITE,
+  VIDEO,
+};
+
+enum class CaptureCadence
+{
+  ONESHOT,
+  CONTINUOUS,
+};
+
+struct CaptureSpec
+{
+  CaptureContent content{CaptureContent::COMPOSITE};
+  CaptureCadence cadence{CaptureCadence::ONESHOT};
+  //! 0x0 requests the native output size; nonzero requests a scaled capture
+  unsigned int width{0};
+  unsigned int height{0};
+};
+
+struct CaptureResult
+{
+  std::shared_ptr<uint8_t[]> pixels;
+  unsigned int width{0};
+  unsigned int height{0};
+  unsigned int stride{0};
+  int bitDepth{8};
+  ImageColorMetadata color;
+};
+
+} // namespace CAPTURE
+} // namespace RENDERING
+} // namespace KODI

--- a/xbmc/rendering/capture/test/CMakeLists.txt
+++ b/xbmc/rendering/capture/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestCaptureService.cpp)
+
+core_add_test_library(rendering_capture_test)

--- a/xbmc/rendering/capture/test/TestCaptureService.cpp
+++ b/xbmc/rendering/capture/test/TestCaptureService.cpp
@@ -130,6 +130,20 @@ TEST_F(TestCaptureService, ContinuousStaysActive)
   EXPECT_EQ(m_service.TakeActive(CaptureContent::COMPOSITE).size(), 1u);
 }
 
+TEST_F(TestCaptureService, DetachedRequestCompletes)
+{
+  std::atomic<bool> ran{false};
+  auto handle = m_service.Submit({}, [&ran](const CaptureResult&) { ran = true; });
+  handle->Detach();
+
+  m_service.LatchFrame();
+  auto active = m_service.TakeActive(CaptureContent::COMPOSITE);
+  ASSERT_EQ(active.size(), 1u);
+
+  m_service.Complete(active[0], MakeResult());
+  EXPECT_TRUE(ConditionPoll::poll(10000, [&ran] { return ran.load(); }));
+}
+
 TEST_F(TestCaptureService, CancelledRequestPrunedAtLatch)
 {
   auto keep = m_service.Submit({});

--- a/xbmc/rendering/capture/test/TestCaptureService.cpp
+++ b/xbmc/rendering/capture/test/TestCaptureService.cpp
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ServiceBroker.h"
+#include "jobs/JobManager.h"
+#include "rendering/capture/CaptureHandle.h"
+#include "rendering/capture/CaptureService.h"
+#include "test/MtTestUtils.h"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+using namespace KODI::RENDERING::CAPTURE;
+using namespace std::chrono_literals;
+
+namespace
+{
+
+CaptureResult MakeResult()
+{
+  CaptureResult result;
+  result.width = 4;
+  result.height = 2;
+  result.stride = 16;
+  result.bitDepth = 8;
+  result.pixels = std::shared_ptr<uint8_t[]>(new uint8_t[32]());
+  return result;
+}
+
+class TestCaptureService : public ::testing::Test
+{
+protected:
+  TestCaptureService() { CServiceBroker::RegisterJobManager(std::make_shared<CJobManager>()); }
+
+  ~TestCaptureService() override
+  {
+    CServiceBroker::GetJobManager()->CancelJobs();
+    CServiceBroker::GetJobManager()->Restart();
+    CServiceBroker::UnregisterJobManager();
+  }
+
+  CCaptureService m_service;
+};
+
+} // namespace
+
+TEST_F(TestCaptureService, OneShotCompleteWait)
+{
+  auto handle = m_service.Submit({});
+  EXPECT_TRUE(m_service.LatchFrame());
+
+  auto active = m_service.TakeActive(CaptureContent::COMPOSITE);
+  ASSERT_EQ(active.size(), 1u);
+
+  m_service.Complete(active[0], MakeResult());
+  EXPECT_TRUE(handle->Wait(1000ms));
+  EXPECT_EQ(handle->GetResult().width, 4u);
+
+  // a finished one-shot leaves the active list
+  EXPECT_TRUE(m_service.TakeActive(CaptureContent::COMPOSITE).empty());
+}
+
+TEST_F(TestCaptureService, HandleDestructionCancels)
+{
+  m_service.Submit({});
+
+  // the discarded handle cancelled the request before any latch
+  EXPECT_FALSE(m_service.LatchFrame());
+  EXPECT_TRUE(m_service.TakeActive(CaptureContent::COMPOSITE).empty());
+}
+
+TEST_F(TestCaptureService, ContentFilter)
+{
+  CaptureSpec spec;
+  spec.content = CaptureContent::VIDEO;
+  auto handle = m_service.Submit(spec);
+
+  EXPECT_TRUE(m_service.LatchFrame());
+  EXPECT_TRUE(m_service.TakeActive(CaptureContent::COMPOSITE).empty());
+  EXPECT_EQ(m_service.TakeActive(CaptureContent::VIDEO).size(), 1u);
+}
+
+TEST_F(TestCaptureService, FailWakesWaiter)
+{
+  auto handle = m_service.Submit({});
+  m_service.LatchFrame();
+
+  auto active = m_service.TakeActive(CaptureContent::COMPOSITE);
+  ASSERT_EQ(active.size(), 1u);
+
+  m_service.Fail(active[0]);
+  EXPECT_FALSE(handle->Wait(1000ms));
+}
+
+TEST_F(TestCaptureService, CallbackRunsOnWorker)
+{
+  std::atomic<bool> ran{false};
+  auto handle =
+      m_service.Submit({}, [&ran](const CaptureResult& result) { ran = result.width == 4; });
+
+  m_service.LatchFrame();
+  auto active = m_service.TakeActive(CaptureContent::COMPOSITE);
+  ASSERT_EQ(active.size(), 1u);
+
+  m_service.Complete(active[0], MakeResult());
+  EXPECT_TRUE(ConditionPoll::poll(10000, [&ran] { return ran.load(); }));
+}
+
+TEST_F(TestCaptureService, ContinuousStaysActive)
+{
+  CaptureSpec spec;
+  spec.cadence = CaptureCadence::CONTINUOUS;
+  auto handle = m_service.Submit(spec);
+
+  m_service.LatchFrame();
+  auto active = m_service.TakeActive(CaptureContent::COMPOSITE);
+  ASSERT_EQ(active.size(), 1u);
+
+  m_service.Complete(active[0], MakeResult());
+
+  // a continuous request stays latched for the next frame
+  EXPECT_EQ(m_service.TakeActive(CaptureContent::COMPOSITE).size(), 1u);
+}
+
+TEST_F(TestCaptureService, CancelledRequestPrunedAtLatch)
+{
+  auto keep = m_service.Submit({});
+  {
+    auto dropped = m_service.Submit({});
+  }
+
+  EXPECT_TRUE(m_service.LatchFrame());
+  EXPECT_EQ(m_service.TakeActive(CaptureContent::COMPOSITE).size(), 1u);
+}

--- a/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
+++ b/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
@@ -15,11 +15,21 @@
 #include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
+#include <cmath>
 #include <mutex>
 
 #include <wrl/client.h>
 
 using namespace Microsoft::WRL;
+
+namespace
+{
+// Project a 10-bit sample onto the 16-bit scale so full scale maps to full scale
+uint16_t Expand10To16(uint32_t v)
+{
+  return static_cast<uint16_t>(std::lround(v * 65535.0 / 1023.0));
+}
+} // namespace
 
 void CScreenshotSurfaceWindows::Register()
 {
@@ -62,35 +72,37 @@ bool CScreenshotSurfaceWindows::Capture(const ScreenshotContext& ctx)
     {
       m_width = desc.Width;
       m_height = desc.Height;
-      m_stride = res.RowPitch;
-      m_buffer = new unsigned char[m_height * m_stride];
       if (desc.Format == DXGI_FORMAT_R10G10B10A2_UNORM)
       {
-        // convert R10G10B10A2 -> B8G8R8A8
+        // 10-bit swapchain: unpack to RGBA16 instead of decimating to 8-bit
+        m_bitDepth = 10;
+        m_stride = m_width * 8; // 4 channels x 2 bytes
+        m_buffer = new unsigned char[m_height * m_stride];
         for (int y = 0; y < m_height; y++)
         {
-          uint32_t* pixels10 = reinterpret_cast<uint32_t*>(static_cast<uint8_t*>(res.pData) + y * res.RowPitch);
-          uint8_t* pixels8 = m_buffer + y * m_stride;
+          const uint32_t* pixels10 = reinterpret_cast<const uint32_t*>(
+              static_cast<const uint8_t*>(res.pData) + y * res.RowPitch);
+          uint16_t* pixels16 = reinterpret_cast<uint16_t*>(m_buffer + y * m_stride);
 
-          for (int x = 0; x < m_width; x++, pixels10++, pixels8 += 4)
+          for (int x = 0; x < m_width; x++, pixels10++, pixels16 += 4)
           {
             // actual bit per channel is A2B10G10R10
             uint32_t pixel = *pixels10;
-            // R
-            pixels8[2] = static_cast<uint8_t>((pixel & 0x3FF) * 255 / 1023);
-            // G
+            pixels16[0] = Expand10To16(pixel & 0x3FF); // R
             pixel >>= 10;
-            pixels8[1] = static_cast<uint8_t>((pixel & 0x3FF) * 255 / 1023);
-            // B
+            pixels16[1] = Expand10To16(pixel & 0x3FF); // G
             pixel >>= 10;
-            pixels8[0] = static_cast<uint8_t>((pixel & 0x3FF) * 255 / 1023);
-            // A
-            pixels8[3] = 0xFF;
+            pixels16[2] = Expand10To16(pixel & 0x3FF); // B
+            pixels16[3] = 0xFFFF; // A
           }
         }
       }
       else
+      {
+        m_stride = res.RowPitch;
+        m_buffer = new unsigned char[m_height * m_stride];
         memcpy(m_buffer, res.pData, m_height * m_stride);
+      }
       pImdContext->Unmap(pCopyTexture.Get(), 0);
     }
     else

--- a/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
+++ b/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
@@ -45,7 +45,11 @@ bool CScreenshotSurfaceWindows::Capture(const ScreenshotContext& ctx)
 {
   std::unique_lock lock(ctx.winSystem.GetGfxContext());
   ctx.windowManager.Render();
+  return Read(ctx);
+}
 
+bool CScreenshotSurfaceWindows::Read(const ScreenshotContext&)
+{
   auto deviceResources = DX::DeviceResources::Get();
   deviceResources->FinishCommandList();
 

--- a/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
+++ b/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
@@ -8,8 +8,6 @@
 
 #include "ScreenshotSurfaceWindows.h"
 
-#include "ServiceBroker.h"
-#include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "rendering/dx/DeviceResources.h"
 #include "utils/Screenshot.h"
@@ -33,18 +31,10 @@ std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceWindows::CreateSurface()
   return std::unique_ptr<CScreenshotSurfaceWindows>(new CScreenshotSurfaceWindows());
 }
 
-bool CScreenshotSurfaceWindows::Capture()
+bool CScreenshotSurfaceWindows::Capture(const ScreenshotContext& ctx)
 {
-  CWinSystemBase* winsystem = CServiceBroker::GetWinSystem();
-  if (!winsystem)
-    return false;
-
-  CGUIComponent* gui = CServiceBroker::GetGUI();
-  if (!gui)
-    return false;
-
-  std::unique_lock lock(winsystem->GetGfxContext());
-  gui->GetWindowManager().Render();
+  std::unique_lock lock(ctx.winSystem.GetGfxContext());
+  ctx.windowManager.Render();
 
   auto deviceResources = DX::DeviceResources::Get();
   deviceResources->FinishCommandList();

--- a/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
+++ b/xbmc/rendering/dx/ScreenshotSurfaceWindows.cpp
@@ -8,15 +8,11 @@
 
 #include "ScreenshotSurfaceWindows.h"
 
-#include "guilib/GUIWindowManager.h"
 #include "rendering/dx/DeviceResources.h"
 #include "utils/Screenshot.h"
 #include "utils/log.h"
-#include "windowing/GraphicContext.h"
-#include "windowing/WinSystem.h"
 
 #include <cmath>
-#include <mutex>
 
 #include <wrl/client.h>
 
@@ -39,13 +35,6 @@ void CScreenshotSurfaceWindows::Register()
 std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceWindows::CreateSurface()
 {
   return std::unique_ptr<CScreenshotSurfaceWindows>(new CScreenshotSurfaceWindows());
-}
-
-bool CScreenshotSurfaceWindows::Capture(const ScreenshotContext& ctx)
-{
-  std::unique_lock lock(ctx.winSystem.GetGfxContext());
-  ctx.windowManager.Render();
-  return Read(ctx);
 }
 
 bool CScreenshotSurfaceWindows::Read(const ScreenshotContext&)

--- a/xbmc/rendering/dx/ScreenshotSurfaceWindows.h
+++ b/xbmc/rendering/dx/ScreenshotSurfaceWindows.h
@@ -18,6 +18,5 @@ public:
   static void Register();
   static std::unique_ptr<IScreenshotSurface> CreateSurface();
 
-  bool Capture(const ScreenshotContext& ctx) override;
   bool Read(const ScreenshotContext& ctx) override;
 };

--- a/xbmc/rendering/dx/ScreenshotSurfaceWindows.h
+++ b/xbmc/rendering/dx/ScreenshotSurfaceWindows.h
@@ -19,4 +19,5 @@ public:
   static std::unique_ptr<IScreenshotSurface> CreateSurface();
 
   bool Capture(const ScreenshotContext& ctx) override;
+  bool Read(const ScreenshotContext& ctx) override;
 };

--- a/xbmc/rendering/dx/ScreenshotSurfaceWindows.h
+++ b/xbmc/rendering/dx/ScreenshotSurfaceWindows.h
@@ -18,5 +18,5 @@ public:
   static void Register();
   static std::unique_ptr<IScreenshotSurface> CreateSurface();
 
-  bool Capture() override;
+  bool Capture(const ScreenshotContext& ctx) override;
 };

--- a/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
+++ b/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
@@ -8,8 +8,6 @@
 
 #include "ScreenshotSurfaceGL.h"
 
-#include "ServiceBroker.h"
-#include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "utils/Screenshot.h"
 #include "windowing/GraphicContext.h"
@@ -31,18 +29,10 @@ std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceGL::CreateSurface()
   return std::make_unique<CScreenshotSurfaceGL>();
 }
 
-bool CScreenshotSurfaceGL::Capture()
+bool CScreenshotSurfaceGL::Capture(const ScreenshotContext& ctx)
 {
-  CWinSystemBase* winsystem = CServiceBroker::GetWinSystem();
-  if (!winsystem)
-    return false;
-
-  CGUIComponent* gui = CServiceBroker::GetGUI();
-  if (!gui)
-    return false;
-
-  std::unique_lock lock(winsystem->GetGfxContext());
-  gui->GetWindowManager().Render();
+  std::unique_lock lock(ctx.winSystem.GetGfxContext());
+  ctx.windowManager.Render();
 
   glReadBuffer(GL_BACK);
 

--- a/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
+++ b/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
@@ -8,15 +8,12 @@
 
 #include "ScreenshotSurfaceGL.h"
 
-#include "guilib/GUIWindowManager.h"
 #include "utils/Screenshot.h"
 #include "utils/log.h"
-#include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
 #include <cstring>
 #include <memory>
-#include <mutex>
 #include <vector>
 
 #include "system_gl.h"
@@ -29,13 +26,6 @@ void CScreenshotSurfaceGL::Register()
 std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceGL::CreateSurface()
 {
   return std::make_unique<CScreenshotSurfaceGL>();
-}
-
-bool CScreenshotSurfaceGL::Capture(const ScreenshotContext& ctx)
-{
-  std::unique_lock lock(ctx.winSystem.GetGfxContext());
-  ctx.windowManager.Render();
-  return Read(ctx);
 }
 
 bool CScreenshotSurfaceGL::Read(const ScreenshotContext& ctx)

--- a/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
+++ b/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
@@ -32,12 +32,12 @@ bool CScreenshotSurfaceGL::Read(const ScreenshotContext& ctx)
 {
   glReadBuffer(GL_BACK);
 
-  // get current viewport
+  // get current viewport: x, y, width, height
   GLint viewport[4];
   glGetIntegerv(GL_VIEWPORT, viewport);
 
-  m_width = viewport[2] - viewport[0];
-  m_height = viewport[3] - viewport[1];
+  m_width = viewport[2];
+  m_height = viewport[3];
 
   const int bitDepth = ctx.winSystem.GetOutputBitDepth();
   if (bitDepth > 8)

--- a/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
+++ b/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
@@ -10,9 +10,11 @@
 
 #include "guilib/GUIWindowManager.h"
 #include "utils/Screenshot.h"
+#include "utils/log.h"
 #include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -42,11 +44,46 @@ bool CScreenshotSurfaceGL::Capture(const ScreenshotContext& ctx)
 
   m_width = viewport[2] - viewport[0];
   m_height = viewport[3] - viewport[1];
+
+  const int bitDepth = ctx.winSystem.GetOutputBitDepth();
+  if (bitDepth > 8)
+  {
+    // desktop GL converts any framebuffer depth to 16-bit per channel on readback
+    m_bitDepth = bitDepth;
+    m_stride = m_width * 8; // 4 channels x 2 bytes
+    std::vector<uint16_t> raw(m_width * m_height * 4);
+    glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_RGBA, GL_UNSIGNED_SHORT,
+                 static_cast<GLvoid*>(raw.data()));
+
+    if (glGetError() != GL_NO_ERROR)
+    {
+      CLog::Log(LOGERROR, "CScreenshotSurfaceGL: glReadPixels 16-bit failed");
+      return false;
+    }
+
+    m_buffer = new unsigned char[m_stride * m_height];
+    for (int y = 0; y < m_height; y++)
+    {
+      uint16_t* dst = reinterpret_cast<uint16_t*>(m_buffer + y * m_stride);
+      std::memcpy(dst, raw.data() + (m_height - 1 - y) * m_width * 4, m_stride);
+      for (int x = 0; x < m_width; x++)
+        dst[x * 4 + 3] = 0xFFFF; // A
+    }
+
+    return m_buffer != nullptr;
+  }
+
   m_stride = m_width * 4;
   std::vector<uint8_t> surface(m_stride * m_height);
 
   // read pixels from the backbuffer
   glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_BGRA, GL_UNSIGNED_BYTE, static_cast<GLvoid*>(surface.data()));
+
+  if (glGetError() != GL_NO_ERROR)
+  {
+    CLog::Log(LOGERROR, "CScreenshotSurfaceGL: glReadPixels 8-bit failed");
+    return false;
+  }
 
   // make a new buffer and copy the read image to it with the Y axis inverted
   m_buffer = new unsigned char[m_stride * m_height];

--- a/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
+++ b/xbmc/rendering/gl/ScreenshotSurfaceGL.cpp
@@ -35,7 +35,11 @@ bool CScreenshotSurfaceGL::Capture(const ScreenshotContext& ctx)
 {
   std::unique_lock lock(ctx.winSystem.GetGfxContext());
   ctx.windowManager.Render();
+  return Read(ctx);
+}
 
+bool CScreenshotSurfaceGL::Read(const ScreenshotContext& ctx)
+{
   glReadBuffer(GL_BACK);
 
   // get current viewport

--- a/xbmc/rendering/gl/ScreenshotSurfaceGL.h
+++ b/xbmc/rendering/gl/ScreenshotSurfaceGL.h
@@ -18,6 +18,5 @@ public:
   static void Register();
   static std::unique_ptr<IScreenshotSurface> CreateSurface();
 
-  bool Capture(const ScreenshotContext& ctx) override;
   bool Read(const ScreenshotContext& ctx) override;
 };

--- a/xbmc/rendering/gl/ScreenshotSurfaceGL.h
+++ b/xbmc/rendering/gl/ScreenshotSurfaceGL.h
@@ -19,4 +19,5 @@ public:
   static std::unique_ptr<IScreenshotSurface> CreateSurface();
 
   bool Capture(const ScreenshotContext& ctx) override;
+  bool Read(const ScreenshotContext& ctx) override;
 };

--- a/xbmc/rendering/gl/ScreenshotSurfaceGL.h
+++ b/xbmc/rendering/gl/ScreenshotSurfaceGL.h
@@ -18,5 +18,5 @@ public:
   static void Register();
   static std::unique_ptr<IScreenshotSurface> CreateSurface();
 
-  bool Capture() override;
+  bool Capture(const ScreenshotContext& ctx) override;
 };

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
@@ -8,16 +8,13 @@
 
 #include "ScreenshotSurfaceGLES.h"
 
-#include "guilib/GUIWindowManager.h"
 #include "utils/Screenshot.h"
 #include "utils/log.h"
-#include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
 #include <cmath>
 #include <cstring>
 #include <memory>
-#include <mutex>
 #include <vector>
 
 #include "system_gl.h"
@@ -39,13 +36,6 @@ void CScreenshotSurfaceGLES::Register()
 std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceGLES::CreateSurface()
 {
   return std::make_unique<CScreenshotSurfaceGLES>();
-}
-
-bool CScreenshotSurfaceGLES::Capture(const ScreenshotContext& ctx)
-{
-  std::unique_lock lock(ctx.winSystem.GetGfxContext());
-  ctx.windowManager.Render();
-  return Read(ctx);
 }
 
 bool CScreenshotSurfaceGLES::Read(const ScreenshotContext& ctx)

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
@@ -53,8 +53,7 @@ bool CScreenshotSurfaceGLES::Capture(const ScreenshotContext& ctx)
   m_width = viewport[2] - viewport[0];
   m_height = viewport[3] - viewport[1];
 
-  GLint redBits = 8;
-  glGetIntegerv(GL_RED_BITS, &redBits);
+  const int redBits = ctx.winSystem.GetOutputBitDepth();
 
   // GLES only guarantees GL_RGBA/GL_UNSIGNED_BYTE for glReadPixels.
   // Any other format must be queried via GL_IMPLEMENTATION_COLOR_READ_TYPE.

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
@@ -40,12 +40,12 @@ std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceGLES::CreateSurface()
 
 bool CScreenshotSurfaceGLES::Read(const ScreenshotContext& ctx)
 {
-  //get current viewport
+  // get current viewport: x, y, width, height
   GLint viewport[4];
   glGetIntegerv(GL_VIEWPORT, viewport);
 
-  m_width = viewport[2] - viewport[0];
-  m_height = viewport[3] - viewport[1];
+  m_width = viewport[2];
+  m_height = viewport[3];
 
   const int redBits = ctx.winSystem.GetOutputBitDepth();
 

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
@@ -10,14 +10,26 @@
 
 #include "guilib/GUIWindowManager.h"
 #include "utils/Screenshot.h"
+#include "utils/log.h"
 #include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
+#include <cmath>
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <vector>
 
 #include "system_gl.h"
+
+namespace
+{
+// Project a 10-bit sample onto the 16-bit scale so full scale maps to full scale
+uint16_t Expand10To16(uint32_t v)
+{
+  return static_cast<uint16_t>(std::lround(v * 65535.0 / 1023.0));
+}
+} // namespace
 
 void CScreenshotSurfaceGLES::Register()
 {
@@ -40,24 +52,137 @@ bool CScreenshotSurfaceGLES::Capture(const ScreenshotContext& ctx)
 
   m_width = viewport[2] - viewport[0];
   m_height = viewport[3] - viewport[1];
-  m_stride = m_width * 4;
-  std::vector<uint8_t> surface(m_stride * m_height);
 
-  //read pixels from the backbuffer
-  glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_RGBA, GL_UNSIGNED_BYTE, static_cast<GLvoid*>(surface.data()));
+  GLint redBits = 8;
+  glGetIntegerv(GL_RED_BITS, &redBits);
 
-  //make a new buffer and copy the read image to it with the Y axis inverted
-  m_buffer = new unsigned char[m_stride * m_height];
-  for (int y = 0; y < m_height; y++)
+  // GLES only guarantees GL_RGBA/GL_UNSIGNED_BYTE for glReadPixels.
+  // Any other format must be queried via GL_IMPLEMENTATION_COLOR_READ_TYPE.
+  // For >8-bit surfaces, the driver may support:
+  //   GL_UNSIGNED_INT_2_10_10_10_REV -- packed 10:10:10:2 (10-bit surfaces)
+  //   GL_UNSIGNED_SHORT -- 16-bit per channel (12-bit or 16-bit surfaces)
+  enum class ReadbackMode
   {
-    // we need to save in BGRA order so XOR Swap RGBA -> BGRA
-    unsigned char* swap_pixels = surface.data() + (m_height - y - 1) * m_stride;
-    for (int x = 0; x < m_width; x++, swap_pixels += 4)
+    Uint8,
+    Packed1010102,
+    Uint16
+  };
+  ReadbackMode readbackMode = ReadbackMode::Uint8;
+
+#if HAS_GLES == 3
+  if (redBits > 8)
+  {
+    GLint readFormat = GL_RGBA;
+    GLint readType = GL_UNSIGNED_BYTE;
+    glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT, &readFormat);
+    glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_TYPE, &readType);
+    if (readFormat == GL_RGBA)
     {
-      std::swap(swap_pixels[0], swap_pixels[2]);
+      if (readType == GL_UNSIGNED_INT_2_10_10_10_REV)
+        readbackMode = ReadbackMode::Packed1010102;
+      else if (readType == GL_UNSIGNED_SHORT)
+        readbackMode = ReadbackMode::Uint16;
+    }
+  }
+#endif
+
+  m_bitDepth = (readbackMode != ReadbackMode::Uint8) ? redBits : 8;
+
+  if (readbackMode == ReadbackMode::Packed1010102)
+  {
+    // 10-bit surface: read packed 10:10:10:2 RGBA and unpack to 16-bit per channel
+    std::vector<uint32_t> packed(m_width * m_height);
+    glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_RGBA,
+                 GL_UNSIGNED_INT_2_10_10_10_REV, static_cast<GLvoid*>(packed.data()));
+
+    if (glGetError() != GL_NO_ERROR)
+    {
+      CLog::Log(LOGERROR,
+                "CScreenshotSurfaceGLES: glReadPixels 10-bit failed, falling back to 8-bit");
+      readbackMode = ReadbackMode::Uint8;
+      m_bitDepth = 8;
+    }
+    else
+    {
+      m_stride = m_width * 8; // 4 channels x 2 bytes
+      m_buffer = new unsigned char[m_stride * m_height];
+      for (int y = 0; y < m_height; y++)
+      {
+        uint16_t* dst = reinterpret_cast<uint16_t*>(m_buffer + y * m_stride);
+        uint32_t* src = packed.data() + (m_height - 1 - y) * m_width;
+        for (int x = 0; x < m_width; x++)
+        {
+          uint32_t p = src[x];
+          dst[x * 4 + 0] = Expand10To16((p >> 0) & 0x3FF); // R
+          dst[x * 4 + 1] = Expand10To16((p >> 10) & 0x3FF); // G
+          dst[x * 4 + 2] = Expand10To16((p >> 20) & 0x3FF); // B
+          dst[x * 4 + 3] = 0xFFFF; // A
+        }
+      }
+    }
+  }
+  else if (readbackMode == ReadbackMode::Uint16)
+  {
+    // 12-bit or 16-bit surface: read 16-bit per channel directly. glReadPixels
+    // normalizes to the full 16-bit scale whatever the surface depth, so there
+    // is no manual expansion here (unlike the packed 10:10:10:2 branch).
+    m_stride = m_width * 8; // 4 channels x 2 bytes
+    std::vector<uint16_t> raw(m_width * m_height * 4);
+    glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_RGBA, GL_UNSIGNED_SHORT,
+                 static_cast<GLvoid*>(raw.data()));
+
+    if (glGetError() != GL_NO_ERROR)
+    {
+      CLog::Log(LOGERROR,
+                "CScreenshotSurfaceGLES: glReadPixels 16-bit failed, falling back to 8-bit");
+      readbackMode = ReadbackMode::Uint8;
+      m_bitDepth = 8;
+    }
+    else
+    {
+      m_buffer = new unsigned char[m_stride * m_height];
+      for (int y = 0; y < m_height; y++)
+      {
+        uint16_t* dst = reinterpret_cast<uint16_t*>(m_buffer + y * m_stride);
+        uint16_t* src = raw.data() + (m_height - 1 - y) * m_width * 4;
+        std::memcpy(dst, src, m_stride); // already RGBA16, just Y-flip
+      }
+
+      // composited framebuffer alpha is not display truth; force opaque
+      uint16_t* alpha = reinterpret_cast<uint16_t*>(m_buffer) + 3;
+      for (int i = 0; i < m_width * m_height; i++, alpha += 4)
+        *alpha = 0xFFFF;
+    }
+  }
+
+  if (readbackMode == ReadbackMode::Uint8)
+  {
+    // 8-bit readback (default, or fallback from failed high-bit readback)
+    m_stride = m_width * 4;
+    std::vector<uint8_t> surface(m_stride * m_height);
+
+    glReadPixels(viewport[0], viewport[1], viewport[2], viewport[3], GL_RGBA, GL_UNSIGNED_BYTE,
+                 static_cast<GLvoid*>(surface.data()));
+
+    if (glGetError() != GL_NO_ERROR)
+    {
+      CLog::Log(LOGERROR, "CScreenshotSurfaceGLES: glReadPixels 8-bit failed");
+      return false;
     }
 
-    memcpy(m_buffer + y * m_stride, surface.data() + (m_height - y - 1) * m_stride, m_stride);
+    m_buffer = new unsigned char[m_stride * m_height];
+    for (int y = 0; y < m_height; y++)
+    {
+      // we need to save in BGRA order so XOR Swap RGBA -> BGRA
+      unsigned char* swap_pixels = surface.data() + (m_height - y - 1) * m_stride;
+      for (int x = 0; x < m_width; x++, swap_pixels += 4)
+      {
+        std::swap(swap_pixels[0], swap_pixels[2]);
+      }
+
+      std::memcpy(m_buffer + y * m_stride, surface.data() + (m_height - y - 1) * m_stride,
+                  m_stride);
+    }
   }
 
   return m_buffer != nullptr;

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
@@ -8,8 +8,6 @@
 
 #include "ScreenshotSurfaceGLES.h"
 
-#include "ServiceBroker.h"
-#include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "utils/Screenshot.h"
 #include "windowing/GraphicContext.h"
@@ -31,18 +29,10 @@ std::unique_ptr<IScreenshotSurface> CScreenshotSurfaceGLES::CreateSurface()
   return std::make_unique<CScreenshotSurfaceGLES>();
 }
 
-bool CScreenshotSurfaceGLES::Capture()
+bool CScreenshotSurfaceGLES::Capture(const ScreenshotContext& ctx)
 {
-  CWinSystemBase* winsystem = CServiceBroker::GetWinSystem();
-  if (!winsystem)
-    return false;
-
-  CGUIComponent* gui = CServiceBroker::GetGUI();
-  if (!gui)
-    return false;
-
-  std::unique_lock lock(winsystem->GetGfxContext());
-  gui->GetWindowManager().Render();
+  std::unique_lock lock(ctx.winSystem.GetGfxContext());
+  ctx.windowManager.Render();
 
   //get current viewport
   GLint viewport[4];

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.cpp
@@ -45,7 +45,11 @@ bool CScreenshotSurfaceGLES::Capture(const ScreenshotContext& ctx)
 {
   std::unique_lock lock(ctx.winSystem.GetGfxContext());
   ctx.windowManager.Render();
+  return Read(ctx);
+}
 
+bool CScreenshotSurfaceGLES::Read(const ScreenshotContext& ctx)
+{
   //get current viewport
   GLint viewport[4];
   glGetIntegerv(GL_VIEWPORT, viewport);

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.h
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.h
@@ -18,6 +18,5 @@ public:
   static void Register();
   static std::unique_ptr<IScreenshotSurface> CreateSurface();
 
-  bool Capture(const ScreenshotContext& ctx) override;
   bool Read(const ScreenshotContext& ctx) override;
 };

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.h
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.h
@@ -19,4 +19,5 @@ public:
   static std::unique_ptr<IScreenshotSurface> CreateSurface();
 
   bool Capture(const ScreenshotContext& ctx) override;
+  bool Read(const ScreenshotContext& ctx) override;
 };

--- a/xbmc/rendering/gles/ScreenshotSurfaceGLES.h
+++ b/xbmc/rendering/gles/ScreenshotSurfaceGLES.h
@@ -18,5 +18,5 @@ public:
   static void Register();
   static std::unique_ptr<IScreenshotSurface> CreateSurface();
 
-  bool Capture() override;
+  bool Capture(const ScreenshotContext& ctx) override;
 };

--- a/xbmc/utils/IScreenshotSurface.h
+++ b/xbmc/utils/IScreenshotSurface.h
@@ -13,7 +13,6 @@ class IScreenshotSurface
 public:
   virtual ~IScreenshotSurface() = default;
   virtual bool Capture() { return false; }
-  virtual void CaptureVideo(bool blendToBuffer) {}
 
   int GetWidth() const { return m_width; }
   int GetHeight() const { return m_height; }

--- a/xbmc/utils/IScreenshotSurface.h
+++ b/xbmc/utils/IScreenshotSurface.h
@@ -25,11 +25,23 @@ public:
   virtual ~IScreenshotSurface() = default;
   virtual bool Capture(const ScreenshotContext& ctx) { return false; }
 
+  //! \brief Read back the current framebuffer only; the caller guarantees a
+  //! fully rendered frame and render-thread context.
+  virtual bool Read(const ScreenshotContext& ctx) { return false; }
+
   int GetWidth() const { return m_width; }
   int GetHeight() const { return m_height; }
   int GetStride() const { return m_stride; }
   int GetBitDepth() const { return m_bitDepth; }
   unsigned char* GetBuffer() const { return m_buffer; }
+
+  //! \brief Transfer buffer ownership to the caller.
+  unsigned char* TakeBuffer()
+  {
+    unsigned char* buffer = m_buffer;
+    m_buffer = nullptr;
+    return buffer;
+  }
   void ReleaseBuffer()
   {
     if (m_buffer)

--- a/xbmc/utils/IScreenshotSurface.h
+++ b/xbmc/utils/IScreenshotSurface.h
@@ -8,22 +8,19 @@
 
 #pragma once
 
-class CGUIWindowManager;
 class CWinSystemBase;
 
-//! \brief Subsystem dependencies a screenshot surface needs at capture time,
-//! injected by CScreenShot so the surface does not reach for global state.
+//! \brief Subsystem dependencies a capture readback needs, injected so the
+//! surface does not reach for global state.
 struct ScreenshotContext
 {
   CWinSystemBase& winSystem;
-  CGUIWindowManager& windowManager;
 };
 
 class IScreenshotSurface
 {
 public:
   virtual ~IScreenshotSurface() = default;
-  virtual bool Capture(const ScreenshotContext& ctx) { return false; }
 
   //! \brief Read back the current framebuffer only; the caller guarantees a
   //! fully rendered frame and render-thread context.

--- a/xbmc/utils/IScreenshotSurface.h
+++ b/xbmc/utils/IScreenshotSurface.h
@@ -8,11 +8,22 @@
 
 #pragma once
 
+class CGUIWindowManager;
+class CWinSystemBase;
+
+//! \brief Subsystem dependencies a screenshot surface needs at capture time,
+//! injected by CScreenShot so the surface does not reach for global state.
+struct ScreenshotContext
+{
+  CWinSystemBase& winSystem;
+  CGUIWindowManager& windowManager;
+};
+
 class IScreenshotSurface
 {
 public:
   virtual ~IScreenshotSurface() = default;
-  virtual bool Capture() { return false; }
+  virtual bool Capture(const ScreenshotContext& ctx) { return false; }
 
   int GetWidth() const { return m_width; }
   int GetHeight() const { return m_height; }

--- a/xbmc/utils/IScreenshotSurface.h
+++ b/xbmc/utils/IScreenshotSurface.h
@@ -28,6 +28,7 @@ public:
   int GetWidth() const { return m_width; }
   int GetHeight() const { return m_height; }
   int GetStride() const { return m_stride; }
+  int GetBitDepth() const { return m_bitDepth; }
   unsigned char* GetBuffer() const { return m_buffer; }
   void ReleaseBuffer()
   {
@@ -42,5 +43,6 @@ protected:
   int m_width{0};
   int m_height{0};
   int m_stride{0};
+  int m_bitDepth{8};
   unsigned char* m_buffer{nullptr};
 };

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -23,6 +23,13 @@
 #include "settings/windows/GUIControlSettings.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
+#include "windowing/GraphicContext.h"
+#include "windowing/WinSystem.h"
+
+extern "C"
+{
+#include <libavutil/pixfmt.h>
+}
 
 using namespace XFILE;
 
@@ -60,6 +67,38 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
 
   const ScreenshotContext ctx{*winSystem, gui->GetWindowManager()};
 
+  // Tag color as the display interpreted it. PQ/HLG from the winsystem HDR
+  // state; SDR by CTA-861 mode inference (HD/UHD = BT.709, SD = SMPTE-170M).
+  using KODI::UTILS::Colorimetry;
+  using KODI::UTILS::Eotf;
+  ImageColorMetadata color;
+  color.primaries = AVCOL_PRI_BT709;
+  const Colorimetry colorimetry = winSystem->GetColorimetry();
+  if (colorimetry == Colorimetry::BT2020_RGB || colorimetry == Colorimetry::BT2020_YCC ||
+      colorimetry == Colorimetry::BT2020_CYCC)
+    color.primaries = AVCOL_PRI_BT2020;
+  const Eotf eotf = winSystem->GetEotf();
+  if (eotf == Eotf::PQ)
+    color.transfer = AVCOL_TRC_SMPTE2084;
+  else if (eotf == Eotf::HLG)
+    color.transfer = AVCOL_TRC_ARIB_STD_B67;
+  //! @todo tag AVCOL_TRC_BT2020_12 once a >10-bit output surface exists:
+  //! 16-bit unorm AR48/AB48 (DRM_FORMAT_ARGB16161616/ABGR16161616) or
+  //! 16-bit float AR4H/AB4H (DRM_FORMAT_ARGB16161616F/ABGR16161616F)
+  else if (color.primaries == AVCOL_PRI_BT2020)
+    color.transfer = AVCOL_TRC_BT2020_10;
+  else if (winSystem->GetGfxContext().GetWidth() > 1024 ||
+           winSystem->GetGfxContext().GetHeight() >= 600)
+    color.transfer = AVCOL_TRC_BT709;
+  else
+  {
+    color.primaries = AVCOL_PRI_SMPTE170M;
+    color.transfer = AVCOL_TRC_SMPTE170M;
+  }
+
+  // Display output is limited-range whenever videoscreen.limitedrange is on.
+  color.range = winSystem->UseLimitedColor() ? AVCOL_RANGE_MPEG : AVCOL_RANGE_JPEG;
+
   if (!surface->Capture(ctx))
   {
     CLog::Log(LOGERROR, "Screenshot {} failed", CURL::GetRedacted(filename));
@@ -90,7 +129,7 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
   {
     if (!CPicture::CreateThumbnailFromSurface(surface->GetBuffer(), surface->GetWidth(),
                                               surface->GetHeight(), surface->GetStride(), filename,
-                                              format))
+                                              format, color))
       CLog::Log(LOGERROR, "Unable to write screenshot {}", CURL::GetRedacted(filename));
 
     surface->ReleaseBuffer();
@@ -108,7 +147,7 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
     //buffer is deleted from CThumbnailWriter
     CThumbnailWriter* thumbnailwriter =
         new CThumbnailWriter(surface->GetBuffer(), surface->GetWidth(), surface->GetHeight(),
-                             surface->GetStride(), filename, format);
+                             surface->GetStride(), filename, format, color);
     CServiceBroker::GetJobManager()->AddJob(thumbnailwriter, nullptr);
   }
 }

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -13,20 +13,26 @@
 #include "Util.h"
 #include "filesystem/File.h"
 #include "guilib/GUIComponent.h"
-#include "jobs/JobManager.h"
+#include "guilib/GUIWindowManager.h"
+#include "messaging/ApplicationMessenger.h"
 #include "pictures/Picture.h"
-#include "rendering/capture/CaptureMetadata.h"
+#include "rendering/capture/CaptureHandle.h"
+#include "rendering/capture/CaptureService.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "settings/SettingPath.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/windows/GUIControlSettings.h"
+#include "threads/Event.h"
+#include "threads/SystemClock.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
-#include "windowing/WinSystem.h"
+
+#include <chrono>
 
 using namespace XFILE;
+using namespace std::chrono_literals;
 
 std::vector<std::function<std::unique_ptr<IScreenshotSurface>()>> CScreenShot::m_screenShotSurfaces;
 
@@ -42,38 +48,15 @@ std::unique_ptr<IScreenshotSurface> CScreenShot::CreateSurface()
   return m_screenShotSurfaces.back()();
 }
 
-void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
+namespace
 {
-  auto surface = CreateSurface();
-  if (!surface)
-  {
-    CLog::Log(LOGERROR, "failed to take screenshot: no screenshot surface available");
-    return;
-  }
-
-  auto* winSystem = CServiceBroker::GetWinSystem();
-  auto* gui = CServiceBroker::GetGUI();
-  if (!winSystem || !gui)
-  {
-    CLog::Log(LOGERROR, "Screenshot {} failed: subsystems unavailable",
-              CURL::GetRedacted(filename));
-    return;
-  }
-
-  const ScreenshotContext ctx{*winSystem, gui->GetWindowManager()};
-
-  const ImageColorMetadata color = KODI::RENDERING::CAPTURE::GetOutputColorMetadata(*winSystem);
-
-  if (!surface->Capture(ctx))
-  {
-    CLog::Log(LOGERROR, "Screenshot {} failed", CURL::GetRedacted(filename));
-    return;
-  }
-
-  CLog::Log(LOGDEBUG, "Saving screenshot {}", CURL::GetRedacted(filename));
-
+// Encode a delivered capture to the destination file; runs on the caller's
+// thread (sync) or the capture service's callback worker (async).
+void WriteCapture(const KODI::RENDERING::CAPTURE::CaptureResult& result,
+                  const std::string& filename)
+{
   unsigned int format = XB_FMT_A8R8G8B8;
-  if (surface->GetBitDepth() > 8)
+  if (result.bitDepth > 8)
   {
     // 10-bit capture: buffer is already RGBA16 with correct alpha, no swap needed
     format = XB_FMT_RGBA16;
@@ -81,25 +64,34 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
   else
   {
     //set alpha byte to 0xFF
-    for (int y = 0; y < surface->GetHeight(); y++)
+    for (unsigned int y = 0; y < result.height; y++)
     {
-      unsigned char* alphaptr = surface->GetBuffer() - 1 + y * surface->GetStride();
-      for (int x = 0; x < surface->GetWidth(); x++)
-        *(alphaptr += 4) = 0xFF;
+      unsigned char* alphaptr = result.pixels.get() + y * result.stride + 3;
+      for (unsigned int x = 0; x < result.width; x++, alphaptr += 4)
+        *alphaptr = 0xFF;
     }
   }
 
-  //if sync is true, the png file needs to be completely written when this function returns
-  if (sync)
-  {
-    if (!CPicture::CreateThumbnailFromSurface(surface->GetBuffer(), surface->GetWidth(),
-                                              surface->GetHeight(), surface->GetStride(), filename,
-                                              format, color))
-      CLog::Log(LOGERROR, "Unable to write screenshot {}", CURL::GetRedacted(filename));
+  if (!CPicture::CreateThumbnailFromSurface(result.pixels.get(), result.width, result.height,
+                                            result.stride, filename, format, result.color))
+    CLog::Log(LOGERROR, "Unable to write screenshot {}", CURL::GetRedacted(filename));
+}
+} // namespace
 
-    surface->ReleaseBuffer();
+void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
+{
+  using namespace KODI::RENDERING::CAPTURE;
+
+  const auto captureService = CServiceBroker::GetCaptureService();
+  if (!captureService)
+  {
+    CLog::Log(LOGERROR, "Screenshot {} failed: no capture service", CURL::GetRedacted(filename));
+    return;
   }
-  else
+
+  CLog::Log(LOGDEBUG, "Saving screenshot {}", CURL::GetRedacted(filename));
+
+  if (!sync)
   {
     //make sure the file exists to avoid concurrency issues
     XFILE::CFile file;
@@ -107,14 +99,42 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
       file.Close();
     else
       CLog::Log(LOGERROR, "Unable to create file {}", CURL::GetRedacted(filename));
-
-    //write .png file asynchronous with CThumbnailWriter, prevents stalling of the render thread
-    //buffer is deleted from CThumbnailWriter
-    CThumbnailWriter* thumbnailwriter =
-        new CThumbnailWriter(surface->GetBuffer(), surface->GetWidth(), surface->GetHeight(),
-                             surface->GetStride(), filename, format, color);
-    CServiceBroker::GetJobManager()->AddJob(thumbnailwriter, nullptr);
   }
+
+  // the capture itself is always async; shared event so a post-timeout
+  // straggler callback signals harmlessly
+  const auto written = std::make_shared<CEvent>();
+  auto handle = captureService->Submit({},
+                                       [filename, written](const CaptureResult& result)
+                                       {
+                                         WriteCapture(result, filename);
+                                         written->Set();
+                                       });
+
+  if (!sync)
+  {
+    handle->Detach();
+    return;
+  }
+
+  // sync contract: return only when the file is written. On the render
+  // thread wait by pumping real frames (the busy-dialog pattern); a plain
+  // wait there would deadlock the frame the capture needs.
+  const auto appMessenger = CServiceBroker::GetAppMessenger();
+  const bool processThread = appMessenger && appMessenger->IsProcessThread();
+  auto* gui = CServiceBroker::GetGUI();
+
+  XbmcThreads::EndTime<> timeout(2000ms);
+  bool done = false;
+  while (!done && !timeout.IsTimePast())
+  {
+    done = written->Wait(processThread ? 5ms : 50ms);
+    if (!done && processThread && gui)
+      gui->GetWindowManager().ProcessRenderLoop(false);
+  }
+
+  if (!done)
+    CLog::Log(LOGERROR, "Screenshot {} failed", CURL::GetRedacted(filename));
 }
 
 void CScreenShot::TakeScreenshot()

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -68,18 +68,29 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
 
   CLog::Log(LOGDEBUG, "Saving screenshot {}", CURL::GetRedacted(filename));
 
-  //set alpha byte to 0xFF
-  for (int y = 0; y < surface->GetHeight(); y++)
+  unsigned int format = XB_FMT_A8R8G8B8;
+  if (surface->GetBitDepth() > 8)
   {
-    unsigned char* alphaptr = surface->GetBuffer() - 1 + y * surface->GetStride();
-    for (int x = 0; x < surface->GetWidth(); x++)
-      *(alphaptr += 4) = 0xFF;
+    // 10-bit capture: buffer is already RGBA16 with correct alpha, no swap needed
+    format = XB_FMT_RGBA16;
+  }
+  else
+  {
+    //set alpha byte to 0xFF
+    for (int y = 0; y < surface->GetHeight(); y++)
+    {
+      unsigned char* alphaptr = surface->GetBuffer() - 1 + y * surface->GetStride();
+      for (int x = 0; x < surface->GetWidth(); x++)
+        *(alphaptr += 4) = 0xFF;
+    }
   }
 
   //if sync is true, the png file needs to be completely written when this function returns
   if (sync)
   {
-    if (!CPicture::CreateThumbnailFromSurface(surface->GetBuffer(), surface->GetWidth(), surface->GetHeight(), surface->GetStride(), filename))
+    if (!CPicture::CreateThumbnailFromSurface(surface->GetBuffer(), surface->GetWidth(),
+                                              surface->GetHeight(), surface->GetStride(), filename,
+                                              format))
       CLog::Log(LOGERROR, "Unable to write screenshot {}", CURL::GetRedacted(filename));
 
     surface->ReleaseBuffer();
@@ -95,7 +106,9 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
 
     //write .png file asynchronous with CThumbnailWriter, prevents stalling of the render thread
     //buffer is deleted from CThumbnailWriter
-    CThumbnailWriter* thumbnailwriter = new CThumbnailWriter(surface->GetBuffer(), surface->GetWidth(), surface->GetHeight(), surface->GetStride(), filename);
+    CThumbnailWriter* thumbnailwriter =
+        new CThumbnailWriter(surface->GetBuffer(), surface->GetWidth(), surface->GetHeight(),
+                             surface->GetStride(), filename, format);
     CServiceBroker::GetJobManager()->AddJob(thumbnailwriter, nullptr);
   }
 }

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -12,6 +12,7 @@
 #include "URL.h"
 #include "Util.h"
 #include "filesystem/File.h"
+#include "guilib/GUIComponent.h"
 #include "jobs/JobManager.h"
 #include "pictures/Picture.h"
 #include "resources/LocalizeStrings.h"
@@ -48,7 +49,18 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
     return;
   }
 
-  if (!surface->Capture())
+  auto* winSystem = CServiceBroker::GetWinSystem();
+  auto* gui = CServiceBroker::GetGUI();
+  if (!winSystem || !gui)
+  {
+    CLog::Log(LOGERROR, "Screenshot {} failed: subsystems unavailable",
+              CURL::GetRedacted(filename));
+    return;
+  }
+
+  const ScreenshotContext ctx{*winSystem, gui->GetWindowManager()};
+
+  if (!surface->Capture(ctx))
   {
     CLog::Log(LOGERROR, "Screenshot {} failed", CURL::GetRedacted(filename));
     return;

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -15,6 +15,7 @@
 #include "guilib/GUIComponent.h"
 #include "jobs/JobManager.h"
 #include "pictures/Picture.h"
+#include "rendering/capture/CaptureMetadata.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "settings/SettingPath.h"
@@ -23,13 +24,7 @@
 #include "settings/windows/GUIControlSettings.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
-#include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
-
-extern "C"
-{
-#include <libavutil/pixfmt.h>
-}
 
 using namespace XFILE;
 
@@ -40,19 +35,19 @@ void CScreenShot::Register(const std::function<std::unique_ptr<IScreenshotSurfac
   m_screenShotSurfaces.emplace_back(createFunc);
 }
 
-void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
+std::unique_ptr<IScreenshotSurface> CScreenShot::CreateSurface()
 {
   if (m_screenShotSurfaces.empty())
-  {
-    CLog::Log(LOGERROR, "no screenshot surface registered for this platform");
-    return;
-  }
+    return {};
+  return m_screenShotSurfaces.back()();
+}
 
-  auto surface = m_screenShotSurfaces.back()();
-
+void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
+{
+  auto surface = CreateSurface();
   if (!surface)
   {
-    CLog::Log(LOGERROR, "failed to create screenshot surface");
+    CLog::Log(LOGERROR, "failed to take screenshot: no screenshot surface available");
     return;
   }
 
@@ -67,37 +62,7 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
 
   const ScreenshotContext ctx{*winSystem, gui->GetWindowManager()};
 
-  // Tag color as the display interpreted it. PQ/HLG from the winsystem HDR
-  // state; SDR by CTA-861 mode inference (HD/UHD = BT.709, SD = SMPTE-170M).
-  using KODI::UTILS::Colorimetry;
-  using KODI::UTILS::Eotf;
-  ImageColorMetadata color;
-  color.primaries = AVCOL_PRI_BT709;
-  const Colorimetry colorimetry = winSystem->GetColorimetry();
-  if (colorimetry == Colorimetry::BT2020_RGB || colorimetry == Colorimetry::BT2020_YCC ||
-      colorimetry == Colorimetry::BT2020_CYCC)
-    color.primaries = AVCOL_PRI_BT2020;
-  const Eotf eotf = winSystem->GetEotf();
-  if (eotf == Eotf::PQ)
-    color.transfer = AVCOL_TRC_SMPTE2084;
-  else if (eotf == Eotf::HLG)
-    color.transfer = AVCOL_TRC_ARIB_STD_B67;
-  //! @todo tag AVCOL_TRC_BT2020_12 once a >10-bit output surface exists:
-  //! 16-bit unorm AR48/AB48 (DRM_FORMAT_ARGB16161616/ABGR16161616) or
-  //! 16-bit float AR4H/AB4H (DRM_FORMAT_ARGB16161616F/ABGR16161616F)
-  else if (color.primaries == AVCOL_PRI_BT2020)
-    color.transfer = AVCOL_TRC_BT2020_10;
-  else if (winSystem->GetGfxContext().GetWidth() > 1024 ||
-           winSystem->GetGfxContext().GetHeight() >= 600)
-    color.transfer = AVCOL_TRC_BT709;
-  else
-  {
-    color.primaries = AVCOL_PRI_SMPTE170M;
-    color.transfer = AVCOL_TRC_SMPTE170M;
-  }
-
-  // Display output is limited-range whenever videoscreen.limitedrange is on.
-  color.range = winSystem->UseLimitedColor() ? AVCOL_RANGE_MPEG : AVCOL_RANGE_JPEG;
+  const ImageColorMetadata color = KODI::RENDERING::CAPTURE::GetOutputColorMetadata(*winSystem);
 
   if (!surface->Capture(ctx))
   {

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -54,8 +54,6 @@ void CScreenShot::TakeScreenshot(const std::string& filename, bool sync)
     return;
   }
 
-  surface->CaptureVideo(true);
-
   CLog::Log(LOGDEBUG, "Saving screenshot {}", CURL::GetRedacted(filename));
 
   //set alpha byte to 0xFF

--- a/xbmc/utils/Screenshot.h
+++ b/xbmc/utils/Screenshot.h
@@ -20,6 +20,9 @@ class CScreenShot
 public:
   static void Register(const std::function<std::unique_ptr<IScreenshotSurface>()>& createFunc);
 
+  //! \brief Create the platform's capture readback surface, null when none registered.
+  static std::unique_ptr<IScreenshotSurface> CreateSurface();
+
   static void TakeScreenshot();
   static void TakeScreenshot(const std::string &filename, bool sync);
 

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -16,6 +16,7 @@
 #include "cores/VideoPlayer/VideoRenderers/DebugInfo.h"
 #include "guilib/DirtyRegion.h"
 #include "guilib/DispResource.h"
+#include "utils/DisplayInfo.h"
 #include "utils/HDRCapabilities.h"
 
 #include <memory>
@@ -243,6 +244,11 @@ public:
   virtual HDR_STATUS ToggleHDR() { return HDR_STATUS::HDR_UNSUPPORTED; }
   virtual HDR_STATUS GetOSHDRStatus() { return HDR_STATUS::HDR_UNSUPPORTED; }
   virtual CHDRCapabilities GetDisplayHDRCapabilities() const { return {}; }
+  virtual KODI::UTILS::Eotf GetEotf() const { return KODI::UTILS::Eotf::TRADITIONAL_SDR; }
+  virtual KODI::UTILS::Colorimetry GetColorimetry() const
+  {
+    return KODI::UTILS::Colorimetry::DEFAULT;
+  }
   static const char* SETTING_WINSYSTEM_IS_HDR_DISPLAY;
   virtual float GetGuiSdrPeakLuminance() const { return .0f; }
   virtual bool HasSystemSdrPeakLuminance() { return false; }

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -78,6 +78,8 @@ public:
   virtual bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) = 0;
   virtual void SetDirtyRegions(const CDirtyRegionList& dirtyRegionsList) {}
   virtual int GetBufferAge() { return 2; }
+  //! \brief Bits per color channel of the presented output.
+  virtual int GetOutputBitDepth() const { return 8; }
   virtual bool MoveWindow(int topLeft, int topRight){return false;}
   virtual void FinishModeChange(RESOLUTION res){}
   virtual void FinishWindowResize(int newWidth, int newHeight) {ResizeWindow(newWidth, newHeight, -1, -1);}

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -64,8 +64,8 @@ public:
   bool SetVideoOutput(const VideoPicture* videoPicture) override;
 
   void SetColorimetry(const VideoPicture* videoPicture) override;
-  KODI::UTILS::Colorimetry GetColorimetry() const { return m_colorimetry; }
-  KODI::UTILS::Eotf GetEotf() const { return m_eotf; }
+  KODI::UTILS::Colorimetry GetColorimetry() const override { return m_colorimetry; }
+  KODI::UTILS::Eotf GetEotf() const override { return m_eotf; }
   bool SetHDR(const VideoPicture* videoPicture) override;
   bool IsHDRDisplay() override;
   CHDRCapabilities GetDisplayHDRCapabilities() const override;

--- a/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
+++ b/xbmc/windowing/gbm/WinSystemGbmEGLContext.h
@@ -37,6 +37,7 @@ public:
     m_eglContext.SetDamagedRegions(dirtyRegions);
   }
   int GetBufferAge() override { return m_eglContext.GetBufferAge(); }
+  int GetOutputBitDepth() const override { return m_eglContext.GetConfigAttrib(EGL_RED_SIZE); }
 
   bool BindTextureUploadContext() override;
   bool UnbindTextureUploadContext() override;

--- a/xbmc/windowing/win10/WinSystemWin10DX.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10DX.cpp
@@ -199,6 +199,16 @@ bool CWinSystemWin10DX::IsHDROutput() const
   return m_deviceResources->IsHDROutput();
 }
 
+KODI::UTILS::Eotf CWinSystemWin10DX::GetEotf() const
+{
+  return IsTransferPQ() ? KODI::UTILS::Eotf::PQ : KODI::UTILS::Eotf::TRADITIONAL_SDR;
+}
+
+KODI::UTILS::Colorimetry CWinSystemWin10DX::GetColorimetry() const
+{
+  return IsTransferPQ() ? KODI::UTILS::Colorimetry::BT2020_RGB : KODI::UTILS::Colorimetry::DEFAULT;
+}
+
 bool CWinSystemWin10DX::IsTransferPQ() const
 {
   return m_deviceResources->IsTransferPQ();

--- a/xbmc/windowing/win10/WinSystemWin10DX.cpp
+++ b/xbmc/windowing/win10/WinSystemWin10DX.cpp
@@ -209,6 +209,13 @@ KODI::UTILS::Colorimetry CWinSystemWin10DX::GetColorimetry() const
   return IsTransferPQ() ? KODI::UTILS::Colorimetry::BT2020_RGB : KODI::UTILS::Colorimetry::DEFAULT;
 }
 
+int CWinSystemWin10DX::GetOutputBitDepth() const
+{
+  const bool is10bit =
+      m_deviceResources->GetBackBuffer().GetFormat() == DXGI_FORMAT_R10G10B10A2_UNORM;
+  return is10bit ? 10 : 8;
+}
+
 bool CWinSystemWin10DX::IsTransferPQ() const
 {
   return m_deviceResources->IsTransferPQ();

--- a/xbmc/windowing/win10/WinSystemWin10DX.h
+++ b/xbmc/windowing/win10/WinSystemWin10DX.h
@@ -70,6 +70,8 @@ public:
   bool IsHDRDisplay() override;
   HDR_STATUS ToggleHDR() override;
   HDR_STATUS GetOSHDRStatus() override;
+  KODI::UTILS::Eotf GetEotf() const override;
+  KODI::UTILS::Colorimetry GetColorimetry() const override;
 
   // HDR support
   bool IsHDROutput() const;

--- a/xbmc/windowing/win10/WinSystemWin10DX.h
+++ b/xbmc/windowing/win10/WinSystemWin10DX.h
@@ -72,6 +72,7 @@ public:
   HDR_STATUS GetOSHDRStatus() override;
   KODI::UTILS::Eotf GetEotf() const override;
   KODI::UTILS::Colorimetry GetColorimetry() const override;
+  int GetOutputBitDepth() const override;
 
   // HDR support
   bool IsHDROutput() const;

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -431,6 +431,13 @@ KODI::UTILS::Colorimetry CWinSystemWin32DX::GetColorimetry() const
   return IsTransferPQ() ? KODI::UTILS::Colorimetry::BT2020_RGB : KODI::UTILS::Colorimetry::DEFAULT;
 }
 
+int CWinSystemWin32DX::GetOutputBitDepth() const
+{
+  const bool is10bit =
+      m_deviceResources->GetBackBuffer().GetFormat() == DXGI_FORMAT_R10G10B10A2_UNORM;
+  return is10bit ? 10 : 8;
+}
+
 bool CWinSystemWin32DX::IsTransferPQ() const
 {
   return m_deviceResources->IsTransferPQ();

--- a/xbmc/windowing/windows/WinSystemWin32DX.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32DX.cpp
@@ -421,6 +421,16 @@ bool CWinSystemWin32DX::IsHDROutput() const
   return m_deviceResources->IsHDROutput();
 }
 
+KODI::UTILS::Eotf CWinSystemWin32DX::GetEotf() const
+{
+  return IsTransferPQ() ? KODI::UTILS::Eotf::PQ : KODI::UTILS::Eotf::TRADITIONAL_SDR;
+}
+
+KODI::UTILS::Colorimetry CWinSystemWin32DX::GetColorimetry() const
+{
+  return IsTransferPQ() ? KODI::UTILS::Colorimetry::BT2020_RGB : KODI::UTILS::Colorimetry::DEFAULT;
+}
+
 bool CWinSystemWin32DX::IsTransferPQ() const
 {
   return m_deviceResources->IsTransferPQ();

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -72,6 +72,8 @@ public:
   bool IsHDRDisplay() override;
   HDR_STATUS ToggleHDR() override;
   HDR_STATUS GetOSHDRStatus() override;
+  KODI::UTILS::Eotf GetEotf() const override;
+  KODI::UTILS::Colorimetry GetColorimetry() const override;
 
   // HDR support
   bool IsHDROutput() const;

--- a/xbmc/windowing/windows/WinSystemWin32DX.h
+++ b/xbmc/windowing/windows/WinSystemWin32DX.h
@@ -74,6 +74,7 @@ public:
   HDR_STATUS GetOSHDRStatus() override;
   KODI::UTILS::Eotf GetEotf() const override;
   KODI::UTILS::Colorimetry GetColorimetry() const override;
+  int GetOutputBitDepth() const override;
 
   // HDR support
   bool IsHDROutput() const;


### PR DESCRIPTION
## Description
Enable >8bit screencap, with proper colorimetry tagging.  Fix caps of gui during non-dirty gui rendering.

This involves a significant rewrite of screen capture, including bookmarks.. Two halves, staged so every commit builds and works on its own. Claude heavily involved. Looking for feedback on the broad shape of this, including especially the restructuring to get rid of re-rendering path and handling registered callback.

This is Part 1 of four parts (with #28660, #28664, #28804)

**Capture quality (commits 1-8):**

- 10-bit framebuffers are read back at full depth (GLES / GL/ DX) and written as 16-bit PNG.
- Every capture is tagged with cICP color metadata describing what the display was signalled: PQ/HLG + BT.2020 from the winsystem HDR state, BT.709 or SMPTE-170M by CTA-861 mode inference for SDR, BT2020_10 for SDR-BT.2020 output, range from the limited-range setting.
- New CWinSystemBase::GetOutputBitDepth reports the output surface depth from what the windowing layer already stores (the chosen EGL config on GBM, the swapchain format on Windows). So bitdepth is now carried and available cross-platform at the WinSystem level, defaults to 8.
- Windows reports display-EOTF and colorimetry (PQ + BT2020_RGB while the HDR swapchain is active), so its HDR captures tag correctly.
- Dead CaptureVideo path removed; empty-surface-registry UB fixed (macOS).

**Capture architecture (commits 9-11): the out-of-band re-render dies.**

A tap is a fixed point in the render loop where the pixels of the frame being produced are read out and handed to pending capture requests. CScreenShot now submits a request to a new capture service; the request forces exactly one real frame (full-viewport MarkDirty at the frame-boundary latch), and the tap in CApplication::Render serves it from the finished frame before it is presented.

This fixes the bug class where screenshots contain black or stale content because the legacy path re-rendered outside the loop with an empty dirty list and then read an undefined backbuffer.

Fixes #28540. Fixes #18545.

**PERFORMANCE**

Across part1+2+3+4 of this rework, a substantial load has been moved off of the render thread and onto worker threads.  For 4K HDR this is crucial, as those require quite a bit of processing and/or compression to get to storage.  Final results:

Render-thread time per capture (instrumented builds, single runs):
```
  ┌────────────┬─────────────┬──────────┬─────────────┐
  │  capture   │   content   │ mainline │ this branch │
  ├────────────┼─────────────┼──────────┼─────────────┤
  │ screenshot │ 8-bit 1080p │ 49 ms    │ 16 ms       │
  ├────────────┼─────────────┼──────────┼─────────────┤
  │ screenshot │ 4K HDR      │ 159 ms*  │ 42 ms       │
  ├────────────┼─────────────┼──────────┼─────────────┤
  │ bookmark   │ 8-bit 1080p │ 46 ms    │ 8 ms        │
  ├────────────┼─────────────┼──────────┼─────────────┤
  │ bookmark   │ 4K HDR      │ 22 ms*   │ 10 ms       │
  └────────────┴─────────────┴──────────┴─────────────┘

* mainline only saves to 8bit without color processing
```

## Motivation and context
10bit and HDR screenshots are broken. An gui screenshots are often broken.

Prior art: @lrusak solved DRMPRIME screenshot capture in draft #18741 by importing the video plane dma-buf into GL (EGLImage/OES shaders). That draft's own "alternative 1" (a call into videoplayer to copy the pixels of the currently rendered image) is essentially the architecture implemented here. #19140/#19142 were companion infrastructure.

## How has this been tested?
Intel N250, GBM+GLES.  Not testing on Windows, hoping for help here.

## What is the effect on users?
Capture works across media type, SDR and HDR, 8bit and >8bit.

## Screenshots (if appropriate):
ironically, no

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
