### PR TITLE
[Android][Video] Use the text directly to obtain the crop coordinates

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1735,17 +1735,17 @@ void CDVDVideoCodecAndroidMediaCodec::ConfigureOutputFormat(CJNIMediaFormat& med
   if (mediaformat.containsKey(CJNIMediaFormat::KEY_SLICE_HEIGHT))
     slice_height = mediaformat.getInteger(CJNIMediaFormat::KEY_SLICE_HEIGHT);
 
-  if (CJNIBase::GetSDKVersion() >= 33)
-  {
-    if (mediaformat.containsKey(CJNIMediaFormat::KEY_CROP_LEFT))
-      crop_left = mediaformat.getInteger(CJNIMediaFormat::KEY_CROP_LEFT);
-    if (mediaformat.containsKey(CJNIMediaFormat::KEY_CROP_TOP))
-      crop_top = mediaformat.getInteger(CJNIMediaFormat::KEY_CROP_TOP);
-    if (mediaformat.containsKey(CJNIMediaFormat::KEY_CROP_RIGHT))
-      crop_right = mediaformat.getInteger(CJNIMediaFormat::KEY_CROP_RIGHT);
-    if (mediaformat.containsKey(CJNIMediaFormat::KEY_CROP_BOTTOM))
-      crop_bottom = mediaformat.getInteger(CJNIMediaFormat::KEY_CROP_BOTTOM);
-  }
+  // Use the crop keys directly instead of the constants defined in the MediaFormat class.
+  // These constants were formally introduced in API 33, but they had already been used
+  // directly in previous versions.
+  if (mediaformat.containsKey("crop-left"))
+    crop_left = mediaformat.getInteger("crop-left");
+  if (mediaformat.containsKey("crop-top"))
+    crop_top = mediaformat.getInteger("crop-top");
+  if (mediaformat.containsKey("crop-right"))
+    crop_right = mediaformat.getInteger("crop-right");
+  if (mediaformat.containsKey("crop-bottom"))
+    crop_bottom = mediaformat.getInteger("crop-bottom");
 
   // Note: These properties are not documented in the Android SDK but
   // are available in the MediaFormat object.


### PR DESCRIPTION
## Description
Although the public constants of the MediaFormat class ([KEY_CROP_LEFT](https://developer.android.com/reference/android/media/MediaFormat#KEY_CROP_LEFT), [KEY_CROP_TOP](https://developer.android.com/reference/android/media/MediaFormat#KEY_CROP_TOP), [KEY_CROP_RIGHT](https://developer.android.com/reference/android/media/MediaFormat#KEY_CROP_RIGHT), and [KEY_CROP_BOTTOM](https://developer.android.com/reference/android/media/MediaFormat#KEY_CROP_BOTTOM)) were formally introduced in API 33, Android's internal engine had already been using these crop keys internally for many versions to define a video's crop rectangle

## Motivation and context
Found while reviewing #28513

## How has this been tested?
Tested on a device running Android 14

## What is the effect on users?
Get crop coordinates correctly on devices running Android versions below 13

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
