### PR TITLE
[profiles] Fix profile deletion: prompt for file deletion and correct index handling

### DIFF
--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -487,27 +487,15 @@ void CProfileManager::LogOff()
 bool CProfileManager::DeleteProfile(unsigned int index)
 {
   std::unique_lock lock(m_critical);
-  const CProfile *profile = GetProfile(index);
+  const CProfile* profile = GetProfile(index);
   if (!profile)
   {
     CLog::LogF(LOGERROR, "Profile not deleted. Invalid profile id {}", index);
     return false;
   }
 
-  // fall back to master profile if necessary
-  if (static_cast<int>(index) == m_autoLoginProfile)
-    m_autoLoginProfile = MASTER_PROFILE_ID;
-
-  // delete profile
+  // Grab the directory before we erase the profile from the vector.
   std::string strDirectory = profile->getDirectory();
-  m_profiles.erase(m_profiles.begin() + index);
-
-  // fall back to master profile if necessary
-  if (index == m_currentProfile)
-  {
-    LoadProfile(MASTER_PROFILE_ID);
-    m_settings->Save();
-  }
 
   CFileItemPtr item =
       std::make_shared<CFileItem>(URIUtils::AddFileToFolder(GetUserDataFolder(), strDirectory));
@@ -515,8 +503,43 @@ bool CProfileManager::DeleteProfile(unsigned int index)
   item->SetFolder(true);
   item->Select(true);
 
-  CGUIComponent *gui = CServiceBroker::GetGUI();
-  if (gui && gui->ConfirmDelete(item->GetPath()))
+  // Ask whether to delete the profile's files before changing any profile state.
+  // Doing it after a profile switch can prevent the confirmation dialog
+  // from ever being shown (the old profile's windows are already gone).
+  CGUIComponent* gui = CServiceBroker::GetGUI();
+  const bool deleteFiles = gui && gui->ConfirmDelete(item->GetPath());
+
+  // Keep auto-login and last-used indices consistent with the vector after
+  // the erase, regardless of which profile is being removed.
+  if (static_cast<int>(index) == m_autoLoginProfile)
+    m_autoLoginProfile = MASTER_PROFILE_ID;
+  else if (static_cast<int>(index) < m_autoLoginProfile)
+    --m_autoLoginProfile;
+
+  if (index == m_lastUsedProfile)
+    m_lastUsedProfile = MASTER_PROFILE_ID;
+  else if (index < m_lastUsedProfile)
+    --m_lastUsedProfile;
+
+  const bool deletingCurrentProfile = (index == m_currentProfile);
+
+  m_profiles.erase(m_profiles.begin() + index);
+
+  if (deletingCurrentProfile)
+  {
+    // Switch away from the deleted profile - this also releases open
+    // database and texture-cache handles so the folder can be removed.
+    LoadProfile(MASTER_PROFILE_ID);
+    m_settings->Save();
+  }
+  else if (index < m_currentProfile)
+  {
+    // A profile before the current one was removed; the current index
+    // shifted down, so keep it pointing at the same profile.
+    SetCurrentProfileId(m_currentProfile - 1);
+  }
+
+  if (deleteFiles)
     CFileUtils::DeleteItem(item);
 
   return Save();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
When deleting the currently active profile, the confirmation dialog asking whether to delete the profile's files was never shown, so the files were silently left on disk. This happened because the profile switch to master was executed before the confirmation dialog could appear, which closed the settings window and effectively auto-dismissed the prompt.

Additionally, when a profile with an index lower than the current profile (or lower than the auto-login / last-used profile) was deleted, the corresponding indices were not updated. This caused `m_currentProfile`, `m_autoLoginProfile`, and `m_lastUsedProfile` to point to the wrong entries, leading to unintended profile switches.

The fix reorders the operations in `CProfileManager::DeleteProfile()`:
- The file-deletion confirmation dialog is now shown before any profile state is changed, so it appears while the GUI is still fully functional.
- After a profile is removed from the internal vector, the indices are properly decremented so they continue to refer to the correct profiles.

**Note:** The deletion corrections here are meant to work alongside the profile- and database-switching fixes that ensure a stable profile change (PR #28472) for a fully reliable experience.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I first noticed this while working on the initial profile-switch crash fix: deleting the currently active profile never asked whether to delete its files. That didn't sit right with me, and after digging deeper I found the root cause - the confirmation dialog was being skipped because the profile switch happened first. While investigating, I also discovered that deleting a lower-index profile left several internal indices pointing to the wrong place, which could cause subtle misbehaviour later. Both issues are corrected here.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Kodi Linux build by creating multiple profiles and performing the following:
- Deleted a profile with a lower index than the current profile, and confirmed the current profile remained correctly selected.
- Deleted a profile with a lower index than the auto-login profile, and confirmed the auto-login setting still pointed to the intended profile.
- Deleted the currently active profile, verified that the file-deletion prompt now appears, that files are actually removed when confirmed, and that Kodi switches to the master profile correctly.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users will now be asked whether to delete a profile's files whenever they delete any profile - including the one they are currently using. Profile switching after a deletion is now reliable, and internal state remains consistent no matter which profile is removed.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed