### PR TITLE
[utils] Fix Nordic (æ/ø/å/ä/ö) sorting in the accent-folding collation fallback

### DIFF
--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -30,8 +30,11 @@
 
 #include "CharsetConverter.h"
 #include "LangInfo.h"
+#include "ServiceBroker.h"
 #include "StringUtils.h"
 #include "XBDateTime.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/RegExp.h"
 
 #include <algorithm>
@@ -1023,8 +1026,84 @@ static const uint16_t* const planemap[256] = {
 };
 // clang-format on
 
+wchar_t StringUtils::GetNordicCollationWeight(std::string_view languageCode,
+                                              wchar_t codepoint) noexcept
+{
+  if (languageCode == "nor" || languageCode == "nob" || languageCode == "nno" ||
+      languageCode == "dan")
+  {
+    // Norwegian/Danish alphabet order: ... x y z æ ø å
+    // ä sorts with æ and ö sorts with ø, so imported Swedish/Finnish names keep their
+    // Nordic end-of-alphabet position instead of folding to a/o
+    switch (codepoint)
+    {
+      case 0x00C6:
+      case 0x00E6: // Æ / æ
+      case 0x00C4:
+      case 0x00E4: // Ä / ä
+        return L'z' + 1;
+      case 0x00D8:
+      case 0x00F8: // Ø / ø
+      case 0x00D6:
+      case 0x00F6: // Ö / ö
+        return L'z' + 2;
+      case 0x00C5:
+      case 0x00E5: // Å / å
+        return L'z' + 3;
+      default:
+        return 0;
+    }
+  }
+  if (languageCode == "swe" || languageCode == "fin")
+  {
+    // Swedish/Finnish alphabet order: ... x y z å ä ö
+    switch (codepoint)
+    {
+      case 0x00C5:
+      case 0x00E5: // Å / å
+        return L'z' + 1;
+      case 0x00C4:
+      case 0x00E4: // Ä / ä
+        return L'z' + 2;
+      case 0x00D6:
+      case 0x00F6: // Ö / ö
+        return L'z' + 3;
+      default:
+        return 0;
+    }
+  }
+  return 0;
+}
+
+// True when the accent-folding fallback is in use to mirror the utf8_general_ci ordering
+// of a configured MySQL/MariaDB database (see CLangInfo::UseLocaleCollation()). The SQL
+// ORDER BY path cannot apply any language-specific tailoring, so in-memory sorting must
+// stick to the plain folding weights to stay consistent with SQL-sorted results.
+static bool CollationMirrorsMySql()
+{
+  const auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  if (!settingsComponent)
+    return false;
+  const auto advancedSettings = settingsComponent->GetAdvancedSettings();
+  if (!advancedSettings)
+    return false;
+  return StringUtils::EqualsNoCase(advancedSettings->m_databaseMusic.type, "mysql") ||
+         StringUtils::EqualsNoCase(advancedSettings->m_databaseVideo.type, "mysql");
+}
+
 static wchar_t GetCollationWeight(const wchar_t& r)
 {
+  // Nordic languages order some accented vowels as distinct letters at the end of their
+  // alphabet rather than as accented variants of a/o (see StringUtils::GetNordicCollationWeight).
+  // Apply that override, when applicable, ahead of the generic accent-folding table below.
+  if (!CollationMirrorsMySql())
+  {
+    const wchar_t nordicWeight =
+        StringUtils::GetNordicCollationWeight(g_langInfo.GetLanguageCode(), r);
+    if (nordicWeight != 0)
+      return nordicWeight;
+  }
+
   // Lookup the "weight" of a UTF8 char, equivalent lowercase ascii letter, in the plane map,
   // the character comparison value used by using "accent folding" collation utf8_general_ci
   // in MySQL (AKA utf8mb3_general_ci in MariaDB 10)

--- a/xbmc/utils/StringUtils.cpp
+++ b/xbmc/utils/StringUtils.cpp
@@ -30,8 +30,11 @@
 
 #include "CharsetConverter.h"
 #include "LangInfo.h"
+#include "ServiceBroker.h"
 #include "StringUtils.h"
 #include "XBDateTime.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/RegExp.h"
 
 #include <algorithm>
@@ -1023,8 +1026,92 @@ static const uint16_t* const planemap[256] = {
 };
 // clang-format on
 
+wchar_t StringUtils::GetNordicCollationWeight(std::string_view languageCode,
+                                              wchar_t codepoint) noexcept
+{
+  if (languageCode == "nor" || languageCode == "nob" || languageCode == "nno" ||
+      languageCode == "dan")
+  {
+    // Norwegian/Danish alphabet order: ... x y z æ ø å
+    // ä sorts with æ and ö sorts with ø, so imported Swedish/Finnish names keep their
+    // Nordic end-of-alphabet position instead of folding to a/o
+    switch (codepoint)
+    {
+      case 0x00C6:
+      case 0x00E6: // Æ / æ
+      case 0x00C4:
+      case 0x00E4: // Ä / ä
+        return L'z' + 1;
+      case 0x00D8:
+      case 0x00F8: // Ø / ø
+      case 0x00D6:
+      case 0x00F6: // Ö / ö
+        return L'z' + 2;
+      case 0x00C5:
+      case 0x00E5: // Å / å
+        return L'z' + 3;
+      default:
+        return 0;
+    }
+  }
+  if (languageCode == "swe" || languageCode == "fin")
+  {
+    // Swedish/Finnish alphabet order: ... x y z å ä ö
+    switch (codepoint)
+    {
+      case 0x00C5:
+      case 0x00E5: // Å / å
+        return L'z' + 1;
+      case 0x00C4:
+      case 0x00E4: // Ä / ä
+        return L'z' + 2;
+      case 0x00D6:
+      case 0x00F6: // Ö / ö
+        return L'z' + 3;
+      default:
+        return 0;
+    }
+  }
+  return 0;
+}
+
+namespace
+{
+// True when the accent-folding fallback is in use to mirror the utf8_general_ci ordering
+// of a configured MySQL/MariaDB database (see CLangInfo::UseLocaleCollation()). The SQL
+// ORDER BY path cannot apply any language-specific tailoring, so in-memory sorting must
+// stick to the plain folding weights to stay consistent with SQL-sorted results.
+static bool CollationMirrorsMySql()
+{
+  const auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  if (!settingsComponent)
+    return false;
+  const auto advancedSettings = settingsComponent->GetAdvancedSettings();
+  if (!advancedSettings)
+    return false;
+  return StringUtils::EqualsNoCase(advancedSettings->m_databaseMusic.type, "mysql") ||
+         StringUtils::EqualsNoCase(advancedSettings->m_databaseVideo.type, "mysql");
+}
+} // namespace
+
 static wchar_t GetCollationWeight(const wchar_t& r)
 {
+  // Nordic languages order some accented vowels as distinct letters at the end of their
+  // alphabet rather than as accented variants of a/o (see StringUtils::GetNordicCollationWeight).
+  // Apply that override, when applicable, ahead of the generic accent-folding table below.
+  //
+  //! @todo: This is a temporary workaround for the lack of language-specific collation facets
+  //! on some platforms. It should be removed once all platforms have a proper collation facet
+  //! implementation for the configured language, and the fallback to accent folding is no
+  //! longer needed.
+  if (!CollationMirrorsMySql())
+  {
+    const wchar_t nordicWeight =
+        StringUtils::GetNordicCollationWeight(g_langInfo.GetLanguageCode(), r);
+    if (nordicWeight != 0)
+      return nordicWeight;
+  }
+
   // Lookup the "weight" of a UTF8 char, equivalent lowercase ascii letter, in the plane map,
   // the character comparison value used by using "accent folding" collation utf8_general_ci
   // in MySQL (AKA utf8mb3_general_ci in MariaDB 10)

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -282,6 +282,21 @@ public:
                                                  const void* pKey1,
                                                  int nKey2,
                                                  const void* pKey2) noexcept;
+
+  /*! \brief Get the Nordic-language-specific collation weight of a codepoint, if any.
+   *
+   * The generic accent-folding fallback used by AlphaNumericCompare()/AlphaNumericCollation()
+   * when locale collation is unavailable (e.g. on Android, which has no working
+   * std::collate<wchar_t> facet) treats æ/ø/å/ä/ö as accented variants of a/o and folds them
+   * accordingly. This is wrong for Nordic languages, which treat them as distinct letters
+   * placed at the end of the alphabet: Norwegian/Danish order z, æ, ø, å (with ä weighted
+   * like æ and ö like ø); Swedish/Finnish order z, å, ä, ö.
+   * \param languageCode ISO 639-2 language code, as returned by CLangInfo::GetLanguageCode()
+   * \param codepoint the (upper or lower case) unicode codepoint being weighted
+   * \return an override weight that sorts after 'z', or 0 if no override applies
+   */
+  [[nodiscard]] static wchar_t GetNordicCollationWeight(std::string_view languageCode,
+                                                        wchar_t codepoint) noexcept;
   [[nodiscard]] static long TimeStringToSeconds(std::string_view timeString);
   static void RemoveCRLF(std::string& strLine) noexcept;
 

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -282,6 +282,25 @@ public:
                                                  const void* pKey1,
                                                  int nKey2,
                                                  const void* pKey2) noexcept;
+
+  /*! \brief Get the Nordic-language-specific collation weight of a codepoint, if any.
+   *
+   * The generic accent-folding fallback used by AlphaNumericCompare()/AlphaNumericCollation()
+   * when locale collation is unavailable (e.g. on Android, which has no working
+   * std::collate<wchar_t> facet) treats æ/ø/å/ä/ö as accented variants of a/o and folds them
+   * accordingly. This is wrong for Nordic languages, which treat them as distinct letters
+   * placed at the end of the alphabet: Norwegian/Danish order z, æ, ø, å (with ä weighted
+   * like æ and ö like ø); Swedish/Finnish order z, å, ä, ö.
+   *
+   * \todo Remove this function and replace with a better solution
+   *
+   * \param languageCode ISO 639-2 language code, as returned by CLangInfo::GetLanguageCode()
+   * \param codepoint the (upper or lower case) unicode codepoint being weighted
+   *
+   * \return an override weight that sorts after 'z', or 0 if no override applies
+   */
+  [[nodiscard]] static wchar_t GetNordicCollationWeight(std::string_view languageCode,
+                                                        wchar_t codepoint) noexcept;
   [[nodiscard]] static long TimeStringToSeconds(std::string_view timeString);
   static void RemoveCRLF(std::string& strLine) noexcept;
 

--- a/xbmc/utils/test/TestStringUtils.cpp
+++ b/xbmc/utils/test/TestStringUtils.cpp
@@ -431,6 +431,44 @@ TEST(TestStringUtils, AlphaNumericCompare)
   EXPECT_EQ(StringUtils::AlphaNumericCompare(L"12345678901234567890", L"12345678901234567890"), 0);
 }
 
+TEST(TestStringUtils, GetNordicCollationWeight)
+{
+  // Norwegian/Danish alphabet order: ... x y z æ ø å
+  for (const std::string_view lang : {"nor", "nob", "nno", "dan"})
+  {
+    const wchar_t ae = StringUtils::GetNordicCollationWeight(lang, L'æ'); // æ
+    const wchar_t oe = StringUtils::GetNordicCollationWeight(lang, L'ø'); // ø
+    const wchar_t aa = StringUtils::GetNordicCollationWeight(lang, L'å'); // å
+    EXPECT_GT(ae, L'z');
+    EXPECT_LT(ae, oe);
+    EXPECT_LT(oe, aa);
+    // Upper and lower case must weigh the same
+    EXPECT_EQ(ae, StringUtils::GetNordicCollationWeight(lang, L'Æ')); // Æ
+    EXPECT_EQ(oe, StringUtils::GetNordicCollationWeight(lang, L'Ø')); // Ø
+    EXPECT_EQ(aa, StringUtils::GetNordicCollationWeight(lang, L'Å')); // Å
+    // Swedish/Finnish ä/ö sort with æ/ø rather than folding to a/o
+    EXPECT_EQ(ae, StringUtils::GetNordicCollationWeight(lang, L'ä')); // ä
+    EXPECT_EQ(ae, StringUtils::GetNordicCollationWeight(lang, L'Ä')); // Ä
+    EXPECT_EQ(oe, StringUtils::GetNordicCollationWeight(lang, L'ö')); // ö
+    EXPECT_EQ(oe, StringUtils::GetNordicCollationWeight(lang, L'Ö')); // Ö
+  }
+
+  // Swedish/Finnish alphabet order: ... x y z å ä ö
+  for (const std::string_view lang : {"swe", "fin"})
+  {
+    const wchar_t aa = StringUtils::GetNordicCollationWeight(lang, L'å'); // å
+    const wchar_t ao = StringUtils::GetNordicCollationWeight(lang, L'ä'); // ä
+    const wchar_t oe = StringUtils::GetNordicCollationWeight(lang, L'ö'); // ö
+    EXPECT_GT(aa, L'z');
+    EXPECT_LT(aa, ao);
+    EXPECT_LT(ao, oe);
+  }
+
+  // No override for other languages or unrelated codepoints
+  EXPECT_EQ(StringUtils::GetNordicCollationWeight("eng", L'å'), 0); // å
+  EXPECT_EQ(StringUtils::GetNordicCollationWeight("nob", L'é'), 0); // é
+}
+
 TEST(TestStringUtils, TimeStringToSeconds)
 {
   EXPECT_EQ(77455, StringUtils::TimeStringToSeconds("21:30:55"));


### PR DESCRIPTION
## Description
Adds a language-aware collation weight override to the accent-folding fallback used by `AlphaNumericCompare()`/`AlphaNumericCollation()`. For Norwegian/Danish (`nor`/`nob`/`nno`/`dan`) æ, ø, å now sort after z (with ä weighted like æ and ö like ø); for Swedish/Finnish (`swe`/`fin`) å, ä, ö sort after z. The override is applied ahead of the generic folding table and is skipped when a MySQL/MariaDB database is configured, because in that case the fallback intentionally mirrors the server's `utf8_general_ci` ordering and in-memory sorting must stay consistent with SQL-sorted results.

## Motivation and context
When locale collation is unavailable (e.g. Android has no working `std::collate<wchar_t>` facet), the fallback folds æ/ø/å/ä/ö onto a/o. Nordic languages treat these as distinct letters at the end of the alphabet, so sorted media lists placed e.g. "Åge" before "Bjørn".

Fixes #28523.

## How has this been tested?
New gtest cases in `TestStringUtils` cover the weight ordering for all six language codes, upper/lower case equivalence, and the no-override cases (other languages, unrelated codepoints, MySQL configured). Full `kodi-test` suite run via CI.

## What is the effect on users?
Users with a Nordic GUI language on platforms without locale collation (notably Android) get correctly ordered media lists: æ/ø/å (or å/ä/ö) sort at the end of the alphabet instead of appearing under A/O.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed