### PR TITLE
[VideoPlayer] Fix stale HasVideo/HasAudio on playlist item transition

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -1032,6 +1032,17 @@ void CVideoPlayer::CloseDemuxer()
   CServiceBroker::GetDataCacheCore().SignalSubtitleInfoChange();
 }
 
+void CVideoPlayer::UpdateHasVideoAudio()
+{
+  // a playlist item transition (e.g. music video to audio-only track) reuses this
+  // running player instance without a CloseFile(), so a stale true from the previous
+  // item must be cleared here if no stream was opened for the current item
+  if (m_CurrentVideo.id < 0)
+    m_HasVideo = false;
+  if (m_CurrentAudio.id < 0)
+    m_HasAudio = false;
+}
+
 void CVideoPlayer::OpenDefaultStreams(bool reset)
 {
   // if input stream dictate, we will open later
@@ -1081,6 +1092,8 @@ void CVideoPlayer::OpenDefaultStreams(bool reset)
     CloseStream(m_CurrentAudio, true);
     m_processInfo->ResetAudioCodecInfo();
   }
+
+  UpdateHasVideoAudio();
 
   // enable or disable subtitles
   bool visible = m_processInfo->GetVideoSettings().m_SubtitleOn;
@@ -1244,11 +1257,10 @@ bool CVideoPlayer::ReadPacket(DemuxPacket*& packet, CDemuxStream*& stream)
       UpdateContent();
       OpenDefaultStreams(false);
 
-      // reevaluate HasVideo/Audio, we may have switched from/to a radio channel
-      if(m_CurrentVideo.id < 0)
-        m_HasVideo = false;
-      if(m_CurrentAudio.id < 0)
-        m_HasAudio = false;
+      // OpenDefaultStreams() returns early while DVD/BD navigation controls stream
+      // selection, so reevaluate here as well (we may have switched from/to a radio
+      // channel)
+      UpdateHasVideoAudio();
 
       return true;
     }

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -499,6 +499,7 @@ protected:
   bool OpenDemuxStream();
   void CloseDemuxer();
   void OpenDefaultStreams(bool reset = true);
+  void UpdateHasVideoAudio();
 
   void UpdatePlayState(double timeout);
   void GetGeneralInfo(std::string& strVideoInfo);

--- a/xbmc/cores/VideoPlayer/test/TestVideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/test/TestVideoPlayer.cpp
@@ -39,6 +39,14 @@ public:
   {
     return GetBookmarkPos(idx);
   }
+
+  void SetCurrentVideoId(int id) { m_CurrentVideo.id = id; }
+  void SetCurrentAudioId(int id) { m_CurrentAudio.id = id; }
+  void SetHasVideo(bool hasVideo) { m_HasVideo = hasVideo; }
+  void SetHasAudio(bool hasAudio) { m_HasAudio = hasAudio; }
+  bool GetHasVideo() const { return m_HasVideo; }
+  bool GetHasAudio() const { return m_HasAudio; }
+  void InvokeUpdateHasVideoAudio() { UpdateHasVideoAudio(); }
 };
 
 class TestVideoPlayer : public testing::Test
@@ -139,4 +147,39 @@ TEST_F(TestVideoPlayer, GetBookmarkPos)
 
   pos = player.InvokeGetBookmarkPos(2);
   EXPECT_FALSE(pos.has_value());
+}
+
+TEST_F(TestVideoPlayer, UpdateHasVideoAudioClearsStaleVideoFlag)
+{
+  // simulates a mixed playlist transition from a music video to an audio-only
+  // track: the previous item left m_HasVideo true, but the new item has no
+  // video stream (m_CurrentVideo.id < 0), so the stale flag must be cleared
+  CTestPlayerCallback playercallback;
+  CTestVideoPlayer player(playercallback);
+
+  player.SetHasVideo(true);
+  player.SetHasAudio(true);
+  player.SetCurrentVideoId(-1);
+  player.SetCurrentAudioId(0);
+
+  player.InvokeUpdateHasVideoAudio();
+
+  EXPECT_FALSE(player.GetHasVideo());
+  EXPECT_TRUE(player.GetHasAudio());
+}
+
+TEST_F(TestVideoPlayer, UpdateHasVideoAudioKeepsFlagsWhenStreamsOpen)
+{
+  CTestPlayerCallback playercallback;
+  CTestVideoPlayer player(playercallback);
+
+  player.SetHasVideo(true);
+  player.SetHasAudio(true);
+  player.SetCurrentVideoId(0);
+  player.SetCurrentAudioId(0);
+
+  player.InvokeUpdateHasVideoAudio();
+
+  EXPECT_TRUE(player.GetHasVideo());
+  EXPECT_TRUE(player.GetHasAudio());
 }


### PR DESCRIPTION
## Description
Extracts the `m_HasVideo`/`m_HasAudio` reevaluation into `CVideoPlayer::UpdateHasVideoAudio()`, called from `OpenDefaultStreams()` and - since `OpenDefaultStreams()` returns early while DVD/BD navigation controls stream selection - still from the `DMX_SPECIALID_STREAMCHANGE` branch of `ReadPacket()`.

## Motivation and context
A playlist transition from a video item to an audio-only item reuses the running `CVideoPlayer` without `CloseFile()`, leaving `m_HasVideo` stuck true. This is visible to skins through the `Player.HasVideo` info bool and to remote clients through JSON-RPC.

Fixes the stale-flag side of #28422 (stale HasVideo kept the FULLSCREEN action from opening visualisation in mixed playback).

## How has this been tested?
New `TestVideoPlayer` gtest cases: stale flags are cleared when the corresponding stream is closed (`m_Current*.id < 0`) and kept when streams are open. Full suite run via CI.

## What is the effect on users?
Skins and JSON-RPC clients see correct `Player.HasVideo`/`Player.HasAudio` state after a playlist switches between video and audio-only items (e.g. no more video OSD/overlays on audio-only tracks).

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed