### PR TITLE
[guilib] Match DirectoryProvider jobs on sort/limit/browse, not URL alone

### DIFF
--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -242,7 +242,14 @@ public:
     if (strcmp(job->GetType(), GetType()) == 0)
     {
       const auto* dirJob = dynamic_cast<const CDirectoryJob*>(job);
-      if (dirJob && dirJob->m_url == m_url)
+      // Jobs must also agree on sort/limit/browse: two containers can be bound to the
+      // same content path but configured differently, and each must get its own results
+      // sorted/limited according to its own settings rather than merging into a single
+      // job and sharing whichever container's job happened to run first.
+      if (dirJob && dirJob->m_url == m_url && dirJob->m_sort.sortBy == m_sort.sortBy &&
+          dirJob->m_sort.sortOrder == m_sort.sortOrder &&
+          dirJob->m_sort.sortAttributes == m_sort.sortAttributes && dirJob->m_limit == m_limit &&
+          dirJob->m_browse == m_browse)
         return true;
     }
     return false;


### PR DESCRIPTION
## Description
`CDirectoryJob` equality (used to deduplicate queued jobs) now includes the sort method/order/attributes, the item limit and the browse setting in addition to the URL.

## Motivation and context
Two containers bound to the same content path but configured with a different sort order or limit were deduplicated into a single job, so both containers received whichever configuration's job happened to run first - one of them showed wrongly sorted/limited results. Found while investigating #28422.

## How has this been tested?
Built and existing tests run via CI.

## What is the effect on users?
Skins with multiple widgets/containers on the same content path but different sort or limit settings now render each container correctly instead of one inheriting the other's results.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed