### PR TITLE
[Android] Validate paths served by XBMCFileContentProvider

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -122,6 +122,11 @@
             android:name=".content.XBMCMediaContentProvider"
             android:authorities="@APP_PACKAGE@.media"
             android:exported="true" />
+        <!-- Must stay openly exported: URIs from this provider are stored in TvContract
+             preview programs, search suggestions and recommendations, and are later read
+             by the system TV launcher / Search UI, which cannot hold an app-defined
+             permission. Access is instead restricted by served-path validation in
+             XBMCFileContentProvider. -->
         <provider
             android:name=".content.XBMCFileContentProvider"
             android:authorities="@APP_PACKAGE@.file"

--- a/tools/android/packaging/xbmc/src/content/XBMCFileContentProvider.java.in
+++ b/tools/android/packaging/xbmc/src/content/XBMCFileContentProvider.java.in
@@ -97,8 +97,8 @@ public class XBMCFileContentProvider extends XBMCContentProvider
     {
       String decodedUrl = uri.getFragment();
       // Log.d(TAG, "  decodedUrl: " + decodedUrl);
-      if (decodedUrl == null)
-        return null;
+      if (!isServablePath(decodedUrl))
+        throw new FileNotFoundException("Refusing to serve path: " + decodedUrl);
 
       pipe = ParcelFileDescriptor.createPipe();
 
@@ -113,6 +113,22 @@ public class XBMCFileContentProvider extends XBMCContentProvider
     }
 
     return (pipe[0]);
+  }
+
+  // Callers only ever legitimately request Kodi VFS URLs (image://, special://,
+  // videodb://, smb://, http(s)://, ...), never bare filesystem paths. Requiring
+  // a scheme and rejecting ".." segments stops a caller from walking the pipe
+  // straight to an arbitrary local file (e.g. "/data/data/.../databases/x.db"
+  // or "special://home/../../../etc/hosts").
+  private static boolean isServablePath(String path)
+  {
+    if (path == null || path.isEmpty())
+      return false;
+    if (!path.contains("://"))
+      return false;
+    if (path.contains(".."))
+      return false;
+    return true;
   }
 
   static class TransferThread extends Thread


### PR DESCRIPTION
## Description
`XBMCFileContentProvider.openFile()` piped `uri.getFragment()` straight into the native VFS open call. It now requires a proper `scheme://` VFS URL and rejects paths containing `..` segments before the path reaches `XBMCFile.Open`; anything else throws `FileNotFoundException`. A manifest comment documents why the provider must stay openly exported (its URIs are stored in TvContract preview programs, search suggestions and recommendations, and are later read by the system TV launcher / Search UI, which cannot hold an app-defined permission).

## Motivation and context
Any app on the device could read arbitrary local files (e.g. Kodi's own databases, or `special://` URLs escaping via `..`) through the exported provider's pipe. Legitimate callers only ever request Kodi VFS URLs (`image://`, `special://`, `smb://`, `http(s)://`, ...), never bare filesystem paths.

Fixes #28479.

## How has this been tested?
Built via CI.

## What is the effect on users?
No functional change for users; third-party apps on the same device can no longer read arbitrary files from Kodi's private storage through the content provider.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed