### PR TITLE
[platform][linux] Sort hardware keyboard layouts by displayed label

### DIFF
--- a/xbmc/platform/linux/input/LibInputSettings.cpp
+++ b/xbmc/platform/linux/input/LibInputSettings.cpp
@@ -27,7 +27,7 @@ namespace
 {
   inline bool LayoutSort(const StringSettingOption& i, const StringSettingOption& j)
   {
-    return (i.value < j.value);
+    return (i.label < j.label);
   }
 } // unnamed namespace
 


### PR DESCRIPTION
## Description
Sorts the libinput hardware keyboard layout options by their displayed label instead of their internal XKB layout code, via a new testable `CLibInputSettings::SortLayouts()`.

## Motivation and context
The layout spinner in settings was ordered by XKB layout code, so related layouts (e.g. "English (US)" and "English (UK)") appeared far apart and the list looked unordered to the user.

Fixes #28527.

## How has this been tested?
New `TestLibInputSettings` gtest covering the ordering, registered for Linux test builds via `cmake/treedata/linux/tests.txt` and a new `test/CMakeLists.txt`. Full suite run via CI.

## What is the effect on users?
On Linux with libinput, the hardware keyboard layout selection list is alphabetically ordered by the visible name.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed