### PR TITLE
VideoPlayer: correct color and tonemap HDR in extracted thumbnails

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -227,6 +227,10 @@ std::unique_ptr<CTexture> CDVDFileInfo::ExtractThumbToTexture(const CFileItem& f
 
           if (context)
           {
+            // dstRange is ignored for RGB destinations; the tables drive YUV->RGB
+            sws_setColorspaceDetails(context, sws_getCoefficients(picture.color_space),
+                                     picture.color_range == 1 ? 1 : 0,
+                                     sws_getCoefficients(AVCOL_SPC_BT709), 1, 0, 1 << 16, 1 << 16);
             uint8_t* planes[YuvImage::MAX_PLANES];
             int stride[YuvImage::MAX_PLANES];
             picture.videoBuffer->GetPlanes(planes);

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -51,6 +51,7 @@
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
+#include <libavutil/mastering_display_metadata.h>
 #include <libswscale/swscale.h>
 }
 
@@ -221,28 +222,101 @@ std::unique_ptr<CTexture> CDVDFileInfo::ExtractThumbToTexture(const CFileItem& f
 
           result = CTexture::CreateTexture(nWidth, nHeight);
           result->SetAlpha(false);
-          struct SwsContext* context =
-              sws_getContext(picture.iWidth, picture.iHeight, AV_PIX_FMT_YUV420P, nWidth, nHeight,
-                             AV_PIX_FMT_BGRA, SWS_FAST_BILINEAR, NULL, NULL, NULL);
+          result->SetOrientation(DegreeToOrientation(hint.orientation));
 
-          if (context)
+          uint8_t* planes[YuvImage::MAX_PLANES];
+          int stride[YuvImage::MAX_PLANES];
+          picture.videoBuffer->GetPlanes(planes);
+          picture.videoBuffer->GetStrides(stride);
+
+          bool converted = false;
+
+#if LIBSWSCALE_BUILD >= AV_VERSION_INT(9, 0, 100)
           {
-            // dstRange is ignored for RGB destinations; the tables drive YUV->RGB
-            sws_setColorspaceDetails(context, sws_getCoefficients(picture.color_space),
-                                     picture.color_range == 1 ? 1 : 0,
-                                     sws_getCoefficients(AVCOL_SPC_BT709), 1, 0, 1 << 16, 1 << 16);
-            uint8_t* planes[YuvImage::MAX_PLANES];
-            int stride[YuvImage::MAX_PLANES];
-            picture.videoBuffer->GetPlanes(planes);
-            picture.videoBuffer->GetStrides(stride);
-            uint8_t* src[4] = {planes[0], planes[1], planes[2], 0};
-            int srcStride[] = {stride[0], stride[1], stride[2], 0};
-            uint8_t* dst[] = {result->GetPixels(), 0, 0, 0};
-            int dstStride[] = {static_cast<int>(result->GetPitch()), 0, 0, 0};
-            result->SetOrientation(DegreeToOrientation(hint.orientation));
-            sws_scale(context, src, srcStride, 0, picture.iHeight, dst, dstStride);
-            sws_freeContext(context);
+            AVFrame* srcFrame = av_frame_alloc();
+            AVFrame* dstFrame = av_frame_alloc();
+            SwsContext* sws = sws_alloc_context();
+            if (srcFrame && dstFrame && sws)
+            {
+              srcFrame->width = static_cast<int>(picture.iWidth);
+              srcFrame->height = static_cast<int>(picture.iHeight);
+              srcFrame->format = picture.videoBuffer->GetFormat();
+              for (int i = 0; i < YuvImage::MAX_PLANES; i++)
+              {
+                srcFrame->data[i] = planes[i];
+                srcFrame->linesize[i] = stride[i];
+              }
+              srcFrame->colorspace = picture.color_space;
+              srcFrame->color_range =
+                  picture.color_range == 1 ? AVCOL_RANGE_JPEG : AVCOL_RANGE_MPEG;
+              srcFrame->color_primaries = picture.color_primaries;
+              srcFrame->color_trc = picture.color_transfer;
+              srcFrame->chroma_location = picture.chroma_position;
+
+              if (picture.hasDisplayMetadata)
+              {
+                AVMasteringDisplayMetadata* mdm =
+                    av_mastering_display_metadata_create_side_data(srcFrame);
+                if (mdm)
+                  *mdm = picture.displayMetadata;
+              }
+              if (picture.hasLightMetadata)
+              {
+                AVContentLightMetadata* clm = av_content_light_metadata_create_side_data(srcFrame);
+                if (clm)
+                  *clm = picture.lightMetadata;
+              }
+
+              dstFrame->width = static_cast<int>(nWidth);
+              dstFrame->height = static_cast<int>(nHeight);
+              dstFrame->format = AV_PIX_FMT_BGRA;
+              dstFrame->data[0] = result->GetPixels();
+              dstFrame->linesize[0] = static_cast<int>(result->GetPitch());
+              dstFrame->colorspace = AVCOL_SPC_RGB;
+              dstFrame->color_range = AVCOL_RANGE_JPEG;
+              dstFrame->color_primaries = AVCOL_PRI_BT709;
+              dstFrame->color_trc = AVCOL_TRC_BT709;
+
+              sws->flags = SWS_BILINEAR;
+              sws->intent = SWS_INTENT_PERCEPTUAL;
+
+              const int res = sws_scale_frame(sws, dstFrame, srcFrame);
+              if (res < 0)
+                CLog::LogF(LOGWARNING, "sws_scale_frame failed ({}), using legacy conversion", res);
+              else
+                converted = true;
+            }
+            sws_free_context(&sws);
+            av_frame_free(&srcFrame);
+            av_frame_free(&dstFrame);
           }
+#endif
+
+          if (!converted)
+          {
+            struct SwsContext* context = sws_getContext(
+                picture.iWidth, picture.iHeight, picture.videoBuffer->GetFormat(), nWidth, nHeight,
+                AV_PIX_FMT_BGRA, SWS_FAST_BILINEAR, NULL, NULL, NULL);
+
+            if (context)
+            {
+              // dstRange is ignored for RGB destinations; the tables drive YUV->RGB
+              sws_setColorspaceDetails(context, sws_getCoefficients(picture.color_space),
+                                       picture.color_range == 1 ? 1 : 0,
+                                       sws_getCoefficients(AVCOL_SPC_BT709), 1, 0, 1 << 16,
+                                       1 << 16);
+              uint8_t* src[4] = {planes[0], planes[1], planes[2], 0};
+              int srcStride[] = {stride[0], stride[1], stride[2], 0};
+              uint8_t* dst[] = {result->GetPixels(), 0, 0, 0};
+              int dstStride[] = {static_cast<int>(result->GetPitch()), 0, 0, 0};
+              sws_scale(context, src, srcStride, 0, picture.iHeight, dst, dstStride);
+              sws_freeContext(context);
+              converted = true;
+            }
+          }
+
+          if (!converted)
+            result.reset();
         }
         else
         {

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -95,6 +95,176 @@ int DegreeToOrientation(int degrees)
   }
 }
 
+namespace
+{
+//! Seek to the thumbnail position (chapter start or one third in) and decode the
+//! first clean picture.
+bool SeekAndDecodeFirstPicture(CDVDDemux& demuxer,
+                               CDVDVideoCodec& codec,
+                               int videoStream,
+                               int chapterNumber,
+                               const std::string& redactPath,
+                               VideoPicture& picture,
+                               int& packetsTried)
+{
+  const int nTotalLen = demuxer.GetStreamLength();
+
+  const bool seekToChapter = chapterNumber > 0 && demuxer.GetChapterCount() > 0;
+  const int64_t nSeekTo =
+      seekToChapter ? demuxer.GetChapterPos(chapterNumber).count() : nTotalLen / 3;
+
+  CLog::LogF(LOGDEBUG, "seeking to pos {}ms (total: {}ms) in {}", nSeekTo, nTotalLen, redactPath);
+
+  if (!demuxer.SeekTime(static_cast<double>(nSeekTo), true))
+    return false;
+
+  CDVDVideoCodec::VCReturn iDecoderState = CDVDVideoCodec::VC_NONE;
+
+  // num streams * 160 frames, should get a valid frame, if not abort.
+  for (int attemptsLeft = demuxer.GetNrOfStreams() * 160; attemptsLeft >= 0; attemptsLeft--)
+  {
+    DemuxPacket* pPacket = demuxer.Read();
+    packetsTried++;
+
+    if (!pPacket)
+      break;
+
+    if (pPacket->iStreamId != videoStream)
+    {
+      CDVDDemuxUtils::FreeDemuxPacket(pPacket);
+      continue;
+    }
+
+    codec.AddData(*pPacket);
+    CDVDDemuxUtils::FreeDemuxPacket(pPacket);
+
+    iDecoderState = CDVDVideoCodec::VC_NONE;
+    while (iDecoderState == CDVDVideoCodec::VC_NONE)
+    {
+      iDecoderState = codec.GetPicture(&picture);
+    }
+
+    if (iDecoderState == CDVDVideoCodec::VC_PICTURE)
+    {
+      if (!(picture.iFlags & DVP_FLAG_DROPPED))
+        break;
+    }
+  }
+
+  return iDecoderState == CDVDVideoCodec::VC_PICTURE && !(picture.iFlags & DVP_FLAG_DROPPED);
+}
+
+//! Convert a decoded picture to a BGRA texture sized for the thumbnail cache.
+std::unique_ptr<CTexture> PictureToTexture(const VideoPicture& picture, const CDVDStreamInfo& hint)
+{
+  const unsigned int nWidth =
+      std::min(picture.iDisplayWidth,
+               CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageRes);
+  double aspect =
+      static_cast<double>(picture.iDisplayWidth) / static_cast<double>(picture.iDisplayHeight);
+  if (hint.forced_aspect && hint.aspect != 0)
+    aspect = hint.aspect;
+  const auto nHeight = static_cast<unsigned int>(static_cast<double>(nWidth) / aspect);
+
+  std::unique_ptr<CTexture> result = CTexture::CreateTexture(nWidth, nHeight);
+  result->SetAlpha(false);
+  result->SetOrientation(DegreeToOrientation(hint.orientation));
+
+  uint8_t* planes[YuvImage::MAX_PLANES];
+  int stride[YuvImage::MAX_PLANES];
+  picture.videoBuffer->GetPlanes(planes);
+  picture.videoBuffer->GetStrides(stride);
+
+  bool converted = false;
+
+#if LIBSWSCALE_BUILD >= AV_VERSION_INT(9, 0, 100)
+  {
+    AVFrame* srcFrame = av_frame_alloc();
+    AVFrame* dstFrame = av_frame_alloc();
+    SwsContext* sws = sws_alloc_context();
+    if (srcFrame && dstFrame && sws)
+    {
+      srcFrame->width = static_cast<int>(picture.iWidth);
+      srcFrame->height = static_cast<int>(picture.iHeight);
+      srcFrame->format = picture.videoBuffer->GetFormat();
+      for (int i = 0; i < YuvImage::MAX_PLANES; i++)
+      {
+        srcFrame->data[i] = planes[i];
+        srcFrame->linesize[i] = stride[i];
+      }
+      srcFrame->colorspace = picture.color_space;
+      srcFrame->color_range = picture.color_range == 1 ? AVCOL_RANGE_JPEG : AVCOL_RANGE_MPEG;
+      srcFrame->color_primaries = picture.color_primaries;
+      srcFrame->color_trc = picture.color_transfer;
+      srcFrame->chroma_location = picture.chroma_position;
+
+      if (picture.hasDisplayMetadata)
+      {
+        AVMasteringDisplayMetadata* mdm = av_mastering_display_metadata_create_side_data(srcFrame);
+        if (mdm)
+          *mdm = picture.displayMetadata;
+      }
+      if (picture.hasLightMetadata)
+      {
+        AVContentLightMetadata* clm = av_content_light_metadata_create_side_data(srcFrame);
+        if (clm)
+          *clm = picture.lightMetadata;
+      }
+
+      dstFrame->width = static_cast<int>(nWidth);
+      dstFrame->height = static_cast<int>(nHeight);
+      dstFrame->format = AV_PIX_FMT_BGRA;
+      dstFrame->data[0] = result->GetPixels();
+      dstFrame->linesize[0] = static_cast<int>(result->GetPitch());
+      dstFrame->colorspace = AVCOL_SPC_RGB;
+      dstFrame->color_range = AVCOL_RANGE_JPEG;
+      dstFrame->color_primaries = AVCOL_PRI_BT709;
+      dstFrame->color_trc = AVCOL_TRC_BT709;
+
+      sws->flags = SWS_BILINEAR;
+      sws->intent = SWS_INTENT_PERCEPTUAL;
+
+      const int res = sws_scale_frame(sws, dstFrame, srcFrame);
+      if (res < 0)
+        CLog::LogF(LOGWARNING, "sws_scale_frame failed ({}), using legacy conversion", res);
+      else
+        converted = true;
+    }
+    sws_free_context(&sws);
+    av_frame_free(&srcFrame);
+    av_frame_free(&dstFrame);
+  }
+#endif
+
+  if (!converted)
+  {
+    struct SwsContext* context =
+        sws_getContext(picture.iWidth, picture.iHeight, picture.videoBuffer->GetFormat(), nWidth,
+                       nHeight, AV_PIX_FMT_BGRA, SWS_FAST_BILINEAR, NULL, NULL, NULL);
+
+    if (context)
+    {
+      // dstRange is ignored for RGB destinations; the tables drive YUV->RGB
+      sws_setColorspaceDetails(context, sws_getCoefficients(picture.color_space),
+                               picture.color_range == 1 ? 1 : 0,
+                               sws_getCoefficients(AVCOL_SPC_BT709), 1, 0, 1 << 16, 1 << 16);
+      uint8_t* src[4] = {planes[0], planes[1], planes[2], 0};
+      int srcStride[] = {stride[0], stride[1], stride[2], 0};
+      uint8_t* dst[] = {result->GetPixels(), 0, 0, 0};
+      int dstStride[] = {static_cast<int>(result->GetPitch()), 0, 0, 0};
+      sws_scale(context, src, srcStride, 0, picture.iHeight, dst, dstStride);
+      sws_freeContext(context);
+      converted = true;
+    }
+  }
+
+  if (!converted)
+    result.reset();
+
+  return result;
+}
+} // namespace
+
 std::unique_ptr<CTexture> CDVDFileInfo::ExtractThumbToTexture(const CFileItem& fileItem,
                                                               int chapterNumber)
 {
@@ -168,166 +338,12 @@ std::unique_ptr<CTexture> CDVDFileInfo::ExtractThumbToTexture(const CFileItem& f
 
     if (pVideoCodec)
     {
-      int nTotalLen = demuxer->GetStreamLength();
-
-      bool seekToChapter = chapterNumber > 0 && demuxer->GetChapterCount() > 0;
-      int64_t nSeekTo =
-          seekToChapter ? demuxer->GetChapterPos(chapterNumber).count() : nTotalLen / 3;
-
-      CLog::LogF(LOGDEBUG, "seeking to pos {}ms (total: {}ms) in {}", nSeekTo, nTotalLen,
-                 redactPath);
-
-      if (demuxer->SeekTime(static_cast<double>(nSeekTo), true))
-      {
-        CDVDVideoCodec::VCReturn iDecoderState = CDVDVideoCodec::VC_NONE;
-        VideoPicture picture = {};
-
-        // num streams * 160 frames, should get a valid frame, if not abort.
-        int abort_index = demuxer->GetNrOfStreams() * 160;
-        do
-        {
-          DemuxPacket* pPacket = demuxer->Read();
-          packetsTried++;
-
-          if (!pPacket)
-            break;
-
-          if (pPacket->iStreamId != nVideoStream)
-          {
-            CDVDDemuxUtils::FreeDemuxPacket(pPacket);
-            continue;
-          }
-
-          pVideoCodec->AddData(*pPacket);
-          CDVDDemuxUtils::FreeDemuxPacket(pPacket);
-
-          iDecoderState = CDVDVideoCodec::VC_NONE;
-          while (iDecoderState == CDVDVideoCodec::VC_NONE)
-          {
-            iDecoderState = pVideoCodec->GetPicture(&picture);
-          }
-
-          if (iDecoderState == CDVDVideoCodec::VC_PICTURE)
-          {
-            if (!(picture.iFlags & DVP_FLAG_DROPPED))
-              break;
-          }
-
-        } while (abort_index--);
-
-        if (iDecoderState == CDVDVideoCodec::VC_PICTURE && !(picture.iFlags & DVP_FLAG_DROPPED))
-        {
-          unsigned int nWidth =
-              std::min(picture.iDisplayWidth,
-                       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_imageRes);
-          double aspect = (double)picture.iDisplayWidth / (double)picture.iDisplayHeight;
-          if (hint.forced_aspect && hint.aspect != 0)
-            aspect = hint.aspect;
-          unsigned int nHeight = (unsigned int)((double)nWidth / aspect);
-
-          result = CTexture::CreateTexture(nWidth, nHeight);
-          result->SetAlpha(false);
-          result->SetOrientation(DegreeToOrientation(hint.orientation));
-
-          uint8_t* planes[YuvImage::MAX_PLANES];
-          int stride[YuvImage::MAX_PLANES];
-          picture.videoBuffer->GetPlanes(planes);
-          picture.videoBuffer->GetStrides(stride);
-
-          bool converted = false;
-
-#if LIBSWSCALE_BUILD >= AV_VERSION_INT(9, 0, 100)
-          {
-            AVFrame* srcFrame = av_frame_alloc();
-            AVFrame* dstFrame = av_frame_alloc();
-            SwsContext* sws = sws_alloc_context();
-            if (srcFrame && dstFrame && sws)
-            {
-              srcFrame->width = static_cast<int>(picture.iWidth);
-              srcFrame->height = static_cast<int>(picture.iHeight);
-              srcFrame->format = picture.videoBuffer->GetFormat();
-              for (int i = 0; i < YuvImage::MAX_PLANES; i++)
-              {
-                srcFrame->data[i] = planes[i];
-                srcFrame->linesize[i] = stride[i];
-              }
-              srcFrame->colorspace = picture.color_space;
-              srcFrame->color_range =
-                  picture.color_range == 1 ? AVCOL_RANGE_JPEG : AVCOL_RANGE_MPEG;
-              srcFrame->color_primaries = picture.color_primaries;
-              srcFrame->color_trc = picture.color_transfer;
-              srcFrame->chroma_location = picture.chroma_position;
-
-              if (picture.hasDisplayMetadata)
-              {
-                AVMasteringDisplayMetadata* mdm =
-                    av_mastering_display_metadata_create_side_data(srcFrame);
-                if (mdm)
-                  *mdm = picture.displayMetadata;
-              }
-              if (picture.hasLightMetadata)
-              {
-                AVContentLightMetadata* clm = av_content_light_metadata_create_side_data(srcFrame);
-                if (clm)
-                  *clm = picture.lightMetadata;
-              }
-
-              dstFrame->width = static_cast<int>(nWidth);
-              dstFrame->height = static_cast<int>(nHeight);
-              dstFrame->format = AV_PIX_FMT_BGRA;
-              dstFrame->data[0] = result->GetPixels();
-              dstFrame->linesize[0] = static_cast<int>(result->GetPitch());
-              dstFrame->colorspace = AVCOL_SPC_RGB;
-              dstFrame->color_range = AVCOL_RANGE_JPEG;
-              dstFrame->color_primaries = AVCOL_PRI_BT709;
-              dstFrame->color_trc = AVCOL_TRC_BT709;
-
-              sws->flags = SWS_BILINEAR;
-              sws->intent = SWS_INTENT_PERCEPTUAL;
-
-              const int res = sws_scale_frame(sws, dstFrame, srcFrame);
-              if (res < 0)
-                CLog::LogF(LOGWARNING, "sws_scale_frame failed ({}), using legacy conversion", res);
-              else
-                converted = true;
-            }
-            sws_free_context(&sws);
-            av_frame_free(&srcFrame);
-            av_frame_free(&dstFrame);
-          }
-#endif
-
-          if (!converted)
-          {
-            struct SwsContext* context = sws_getContext(
-                picture.iWidth, picture.iHeight, picture.videoBuffer->GetFormat(), nWidth, nHeight,
-                AV_PIX_FMT_BGRA, SWS_FAST_BILINEAR, NULL, NULL, NULL);
-
-            if (context)
-            {
-              // dstRange is ignored for RGB destinations; the tables drive YUV->RGB
-              sws_setColorspaceDetails(context, sws_getCoefficients(picture.color_space),
-                                       picture.color_range == 1 ? 1 : 0,
-                                       sws_getCoefficients(AVCOL_SPC_BT709), 1, 0, 1 << 16,
-                                       1 << 16);
-              uint8_t* src[4] = {planes[0], planes[1], planes[2], 0};
-              int srcStride[] = {stride[0], stride[1], stride[2], 0};
-              uint8_t* dst[] = {result->GetPixels(), 0, 0, 0};
-              int dstStride[] = {static_cast<int>(result->GetPitch()), 0, 0, 0};
-              sws_scale(context, src, srcStride, 0, picture.iHeight, dst, dstStride);
-              sws_freeContext(context);
-              converted = true;
-            }
-          }
-
-          if (!converted)
-            result.reset();
-        }
-        else
-        {
-          CLog::LogF(LOGDEBUG, "decode failed in {} after {} packets.", redactPath, packetsTried);
-        }
-      }
+      VideoPicture picture = {};
+      if (SeekAndDecodeFirstPicture(*demuxer, *pVideoCodec, nVideoStream, chapterNumber, redactPath,
+                                    picture, packetsTried))
+        result = PictureToTexture(picture, hint);
+      else
+        CLog::LogF(LOGDEBUG, "decode failed in {} after {} packets.", redactPath, packetsTried);
     }
   }
 

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -153,6 +153,11 @@ std::unique_ptr<CTexture> CDVDFileInfo::ExtractThumbToTexture(const CFileItem& f
     std::unique_ptr<CProcessInfo> pProcessInfo(CProcessInfo::CreateInstance());
     std::vector<AVPixelFormat> pixFmts;
     pixFmts.push_back(AV_PIX_FMT_YUV420P);
+    pixFmts.push_back(AV_PIX_FMT_YUV420P10);
+    pixFmts.push_back(AV_PIX_FMT_YUV422P);
+    pixFmts.push_back(AV_PIX_FMT_YUV422P10);
+    pixFmts.push_back(AV_PIX_FMT_YUV444P);
+    pixFmts.push_back(AV_PIX_FMT_YUV444P10);
     pProcessInfo->SetPixFormats(pixFmts);
 
     CDVDStreamInfo hint(*demuxer->GetStream(demuxerId, nVideoStream), true);


### PR DESCRIPTION
## Description

Extracted video thumbnails now respect the source's color metadata. HDR gets tonemapped to SDR for the GUI, which is sRGB. Also note:  previously ALL thumbnails were decoded as if they were BT.601, aka DVD colorspace. Blu-ray (BT.709) and UHD (BT.2020) sources are now decoded with their correct matrices and converted to the GUI colorspace, with BT.2020 additionally gamut-mapped.

Three commits, each standalone:

1. Feed the picture's matrix and range to the conversion.
2. Convert via libswscale 9 color management (FFmpeg 8+): PQ/HLG is tonemapped and BT.2020 gamut-mapped to SDR BT.709. Older FFmpeg and rejected conversions fall back to the legacy path.
3. Let the decoder deliver its native planar format (10-bit, 4:2:2, 4:4:4) so the conversion runs once, at full precision.

## Motivation and context

All HD/UHD thumbnails are decoded with swscale's BT.601 default matrix, and HDR thumbnails get no transfer handling at all, producing the familiar washed-out gray thumbs. 10-bit sources also lose their extra precision before conversion because decoder output was pinned to 8-bit YUV420P.

## How has this been tested?

Linux GBM, Intel N250, bundled FFmpeg 8.1.2. HDR10 PQ BT.2020 sources produce correctly tonemapped SDR thumbnails, verified visually in the sRGB GUI. Re-extraction forced per file via JSON-RPC Textures.RemoveTexture; the extractor picks the same source frame every run, so before/after images are directly comparable.

## What is the effect on users?

Extracted and chapter thumbnails show correct colors for HD/UHD content, and HDR videos get proper SDR thumbnails instead of washed-out gray ones. Cached thumbnails change only when regenerated. On system FFmpeg 7.x builds (eg currently shipping Debian Trixie) only the matrix/range fix applies; tonemapping needs 8.0+. 

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
