### PR TITLE
[guilib][fonts] Fix ReloadTTFFonts aborting on the first font that fails to reload

### DIFF
--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -299,9 +299,11 @@ void GUIFontManager::ReloadTTFFonts(void)
       if (!pFontFile || !pFontFile->Load(strPath, newSize, aspect, 1.0f, fontInfo.border))
       {
         delete pFontFile;
-        // font could not be loaded
+        // This font could not be re-rasterised, but the rest still can. It
+        // keeps the CGUIFontTTF it already had, which m_vecFontFiles still
+        // owns, so it stays renderable at the old size.
         CLog::LogF(LOGERROR, "Couldn't re-load font file: '{}'", strPath);
-        return;
+        continue;
       }
 
       m_vecFontFiles.emplace_back(pFontFile);


### PR DESCRIPTION
## Description

One change, the only one reachable on master. Everything else has moved to #28583, where the groundwork it serves actually lives.

**`ReloadTTFFonts` aborted on the first font that failed to re-rasterise.**
It returned out of the loop, abandoning the reload of every font after it, which then kept rendering at the old scale until something else forced a reload. It now skips the failed entry. That entry keeps pointing at the `CGUIFontTTF` it already had, which `m_vecFontFiles` still owns, so it stays renderable at the old size rather than disappearing.

Four insertions, two deletions, one file.

## Motivation and context

Found while implementing add-on scoped fonts (#28534), proposed in #28583. An earlier revision of this PR also carried two changes that turned out to be groundwork for that feature rather than fixes in their own right, and the description overstated both. Following review they have moved to #28583. #28583 is based on this branch; the dependency runs one way only, so this PR does not need it.

## How has this been tested?

- Full suite on Linux x11/GL: 3418 of 3419 gtest cases pass. The one failure, `TestNetwork.PingHost`, is an environment limitation of the test machine (`net.ipv4.ping_group_range` is `1 0`, so an unprivileged `SOCK_DGRAM`/`IPPROTO_ICMP` socket gets `EACCES`) and is unrelated.
- Built and ran `kodi-x11` on current master with this branch applied, confirming Estuary's `Default` fontset loads and renders with no font errors in the log.
- `clang-format` clean on each commit individually.

Not covered by tests: `ReloadTTFFonts` cannot be exercised under `kodi-test`, because `TestBasicEnvironment` registers no `CWinSystemBase` and `LoadTTF` returns early at its `LOGFATAL` guard. I have not exercised the failure path itself, only reasoned it through: the skipped entry retains a pointer that `m_vecFontFiles` still owns.

## What is the effect on users?

After a resolution change, a font that fails to re-rasterise no longer prevents every later font from being reloaded.

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the Code Guidelines of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have read the Contributing document
- [ ] I have added tests to cover my change

