### PR TITLE
[guilib][Python] Add-on scoped fonts for WindowXML / WindowXMLDialog

### DIFF
--- a/xbmc/guilib/CMakeLists.txt
+++ b/xbmc/guilib/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCES DDSImage.cpp
             GUIFont.cpp
             GUIFontCache.cpp
             GUIFontManager.cpp
+            GUIFontParsing.cpp
             GUIFontTTF.cpp
             GUIImage.cpp
             GUIIncludes.cpp
@@ -103,6 +104,7 @@ set(HEADERS AspectRatio.h
             GUIFont.h
             GUIFontCache.h
             GUIFontManager.h
+            GUIFontParsing.h
             GUIFontTTF.h
             GUIImage.h
             GUIIncludes.h

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -299,9 +299,11 @@ void GUIFontManager::ReloadTTFFonts(void)
       if (!pFontFile || !pFontFile->Load(strPath, newSize, aspect, 1.0f, fontInfo.border))
       {
         delete pFontFile;
-        // font could not be loaded
+        // This font could not be re-rasterised, but the rest still can. It
+        // keeps the CGUIFontTTF it already had, which m_vecFontFiles still
+        // owns, so it stays renderable at the old size.
         CLog::LogF(LOGERROR, "Couldn't re-load font file: '{}'", strPath);
-        return;
+        continue;
       }
 
       m_vecFontFiles.emplace_back(pFontFile);

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -74,7 +74,6 @@ bool LoadXMLData(const std::string& filepath, CXBMCTinyXML& xmlDoc)
 }
 } // unnamed namespace
 
-
 GUIFontManager::GUIFontManager() = default;
 
 GUIFontManager::~GUIFontManager()
@@ -215,13 +214,12 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName,
       return nullptr;
     }
 
-    m_vecFontFiles.emplace_back(pFontFile);
+    m_vecFontFiles.push_back(std::unique_ptr<CGUIFontTTF>(pFontFile));
   }
 
   // font file is loaded, create our CGUIFont
   CGUIFont* pNewFont = new CGUIFont(strFontName, iStyle, textColor, shadowColor, lineSpacing,
                                     static_cast<float>(iSize), pFontFile);
-  m_vecFonts.emplace_back(pNewFont);
 
   // Store the original TTF font info in case we need to reload it in a different resolution
   OrigFontInfo fontInfo;
@@ -232,7 +230,8 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName,
   fontInfo.sourceRes = *sourceRes;
   fontInfo.preserveAspect = preserveAspect;
   fontInfo.border = border;
-  m_vecFontInfo.emplace_back(fontInfo);
+
+  m_fonts.emplace_back(FontEntry{std::unique_ptr<CGUIFont>(pNewFont), fontInfo});
 
   return pNewFont;
 }
@@ -271,55 +270,67 @@ bool GUIFontManager::OnMessage(CGUIMessage& message)
   return false;
 }
 
+std::string GUIFontManager::MakeFontIdent(const std::string& fileName,
+                                          float size,
+                                          float aspect,
+                                          bool border)
+{
+  return StringUtils::Format("{}_{:f}_{:f}{}", fileName, size, aspect, border ? "_border" : "");
+}
+
+bool GUIFontManager::ReloadFontEntry(CWinSystemBase& winSystem, FontEntry& entry)
+{
+  OrigFontInfo fontInfo = entry.origInfo;
+
+  float aspect = fontInfo.aspect;
+  float newSize = static_cast<float>(fontInfo.size);
+  std::string& strPath = fontInfo.fontFilePath;
+
+  RescaleFontSizeAndAspect(winSystem.GetGfxContext(), &newSize, &aspect, fontInfo.sourceRes,
+                           fontInfo.preserveAspect);
+
+  const std::string fontIdent = MakeFontIdent(fontInfo.fileName, newSize, aspect, fontInfo.border);
+  CGUIFontTTF* pFontFile = GetFontFile(fontIdent);
+  if (!pFontFile)
+  {
+    pFontFile = CGUIFontTTF::CreateGUIFontTTF(fontIdent);
+    if (!pFontFile || !pFontFile->Load(strPath, newSize, aspect, 1.0f, fontInfo.border))
+    {
+      delete pFontFile;
+      CLog::LogF(LOGERROR, "Couldn't re-load font file: '{}'", strPath);
+      return false;
+    }
+
+    m_vecFontFiles.push_back(std::unique_ptr<CGUIFontTTF>(pFontFile));
+  }
+
+  entry.font->SetFont(pFontFile);
+  return true;
+}
+
 void GUIFontManager::ReloadTTFFonts(void)
 {
   CWinSystemBase* const winSystem = CServiceBroker::GetWinSystem();
-  if (m_vecFonts.empty() || !winSystem)
+  if (m_fonts.empty() || !winSystem)
     return; // we haven't even loaded fonts in yet
 
-  for (size_t i = 0; i < m_vecFonts.size(); ++i)
+  for (auto& entry : m_fonts)
   {
-    const auto& font = m_vecFonts[i];
-    OrigFontInfo fontInfo = m_vecFontInfo[i];
-
-    float aspect = fontInfo.aspect;
-    float newSize = static_cast<float>(fontInfo.size);
-    std::string& strPath = fontInfo.fontFilePath;
-    std::string& strFilename = fontInfo.fileName;
-
-    RescaleFontSizeAndAspect(winSystem->GetGfxContext(), &newSize, &aspect, fontInfo.sourceRes,
-                             fontInfo.preserveAspect);
-
-    const std::string fontIdent = StringUtils::Format("{}_{:f}_{:f}{}", strFilename, newSize,
-                                                      aspect, fontInfo.border ? "_border" : "");
-    CGUIFontTTF* pFontFile = GetFontFile(fontIdent);
-    if (!pFontFile)
-    {
-      pFontFile = CGUIFontTTF::CreateGUIFontTTF(fontIdent);
-      if (!pFontFile || !pFontFile->Load(strPath, newSize, aspect, 1.0f, fontInfo.border))
-      {
-        delete pFontFile;
-        // This font could not be re-rasterised, but the rest still can. It
-        // keeps the CGUIFontTTF it already had, which m_vecFontFiles still
-        // owns, so it stays renderable at the old size.
-        CLog::LogF(LOGERROR, "Couldn't re-load font file: '{}'", strPath);
-        continue;
-      }
-
-      m_vecFontFiles.emplace_back(pFontFile);
-    }
-
-    font->SetFont(pFontFile);
+    // One font failing to re-rasterise is no reason to leave every later font
+    // at the old resolution. ReloadFontEntry has already logged the failure,
+    // and the entry keeps pointing at its previous CGUIFontTTF, which is still
+    // owned by m_vecFontFiles.
+    ReloadFontEntry(*winSystem, entry);
   }
 }
 
 void GUIFontManager::Unload(const std::string& strFontName)
 {
-  for (auto iFont = m_vecFonts.begin(); iFont != m_vecFonts.end(); ++iFont)
+  for (auto it = m_fonts.begin(); it != m_fonts.end(); ++it)
   {
-    if (StringUtils::EqualsNoCase((*iFont)->GetFontName(), strFontName))
+    if (StringUtils::EqualsNoCase(it->font->GetFontName(), strFontName))
     {
-      m_vecFonts.erase(iFont);
+      m_fonts.erase(it);
       return;
     }
   }
@@ -350,9 +361,9 @@ CGUIFontTTF* GUIFontManager::GetFontFile(const std::string& fontIdent)
 
 CGUIFont* GUIFontManager::GetFont(const std::string& strFontName, bool fallback /*= true*/)
 {
-  for (const auto& it : m_vecFonts)
+  for (const auto& entry : m_fonts)
   {
-    CGUIFont* pFont = it.get();
+    CGUIFont* pFont = entry.font.get();
     if (StringUtils::EqualsNoCase(pFont->GetFontName(), strFontName))
       return pFont;
   }
@@ -367,20 +378,20 @@ CGUIFont* GUIFontManager::GetFont(const std::string& strFontName, bool fallback 
 CGUIFont* GUIFontManager::GetDefaultFont(bool border)
 {
   // first find "font13" or "__defaultborder__"
-  size_t font13index = m_vecFonts.size();
+  size_t font13index = m_fonts.size();
   CGUIFont* font13border = nullptr;
-  for (size_t i = 0; i < m_vecFonts.size(); i++)
+  for (size_t i = 0; i < m_fonts.size(); i++)
   {
-    CGUIFont* font = m_vecFonts[i].get();
+    CGUIFont* font = m_fonts[i].font.get();
     if (font->GetFontName() == "font13")
       font13index = i;
     else if (font->GetFontName() == "__defaultborder__")
       font13border = font;
   }
   // no "font13" means no default font is found - use the first font found.
-  if (font13index == m_vecFonts.size())
+  if (font13index == m_fonts.size())
   {
-    if (m_vecFonts.empty())
+    if (m_fonts.empty())
       return nullptr;
 
     font13index = 0;
@@ -390,23 +401,22 @@ CGUIFont* GUIFontManager::GetDefaultFont(bool border)
   {
     if (!font13border)
     { // create it
-      const auto& font13 = m_vecFonts[font13index];
-      OrigFontInfo fontInfo = m_vecFontInfo[font13index];
+      const FontEntry& entry = m_fonts[font13index];
+      OrigFontInfo fontInfo = entry.origInfo;
       font13border = LoadTTF("__defaultborder__", fontInfo.fileName, KODI::UTILS::COLOR::BLACK, 0,
-                             fontInfo.size, font13->GetStyle(), true, 1.0f, fontInfo.aspect,
+                             fontInfo.size, entry.font->GetStyle(), true, 1.0f, fontInfo.aspect,
                              &fontInfo.sourceRes, fontInfo.preserveAspect);
     }
     return font13border;
   }
 
-  return m_vecFonts[font13index].get();
+  return m_fonts[font13index].font.get();
 }
 
 void GUIFontManager::Clear()
 {
-  m_vecFonts.clear();
+  m_fonts.clear();
   m_vecFontFiles.clear();
-  m_vecFontInfo.clear();
 
 #if defined(HAS_GL)
   CGUIFontTTFGL::DestroyStaticVertexBuffers();

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -10,6 +10,7 @@
 
 #include "FileItemList.h"
 #include "GUIComponent.h"
+#include "GUIFontParsing.h"
 #include "GUIFontTTF.h"
 #include "GUIWindowManager.h"
 #include "addons/AddonManager.h"
@@ -28,7 +29,6 @@
 #include "GUIFontTTFGLES.h"
 #endif
 #include "FileItem.h"
-#include "GUIControlFactory.h"
 #include "GUIFont.h"
 #include "ServiceBroker.h"
 #include "URL.h"
@@ -47,6 +47,8 @@
 
 using namespace XFILE;
 using namespace ADDON;
+
+thread_local std::vector<GUIFontManager::ScopeStackEntry> GUIFontManager::ms_scopeStack;
 
 namespace
 {
@@ -135,7 +137,8 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName,
                                   float lineSpacing,
                                   float aspect,
                                   const RESOLUTION_INFO* sourceRes,
-                                  bool preserveAspect)
+                                  bool preserveAspect,
+                                  std::vector<FontEntry>* destination)
 {
   CWinSystemBase* const winSystem = CServiceBroker::GetWinSystem();
   if (!winSystem)
@@ -148,10 +151,14 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName,
 
   float originalAspect = aspect;
 
-  //check if font already exists
-  CGUIFont* pFont = GetFont(strFontName, false);
-  if (pFont)
-    return pFont;
+  std::vector<FontEntry>& fonts = destination ? *destination : m_fonts;
+
+  //check if font already exists in the destination
+  for (const auto& entry : fonts)
+  {
+    if (StringUtils::EqualsNoCase(entry.font->GetFontName(), strFontName))
+      return entry.font.get();
+  }
 
   if (!sourceRes) // no source res specified, so assume the skin res
     sourceRes = &m_skinResolution;
@@ -159,22 +166,23 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName,
   float newSize = static_cast<float>(iSize);
   RescaleFontSizeAndAspect(context, &newSize, &aspect, *sourceRes, preserveAspect);
 
-  // First try to load the font from the skin
+  const std::string skinFontsDir = URIUtils::AddFileToFolder(context.GetMediaDir(), "fonts");
+
   std::string strPath;
-  if (!CURL::IsFullPath(strFilename))
-  {
-    strPath = URIUtils::AddFileToFolder(context.GetMediaDir(), "fonts", strFilename);
-  }
-  else
+  if (CURL::IsFullPath(strFilename))
     strPath = strFilename;
+  else
+    strPath = URIUtils::AddFileToFolder(skinFontsDir, strFilename);
 
 #ifdef TARGET_POSIX
   strPath = CSpecialProtocol::TranslatePathConvertCase(strPath);
 #endif
 
-  // Check if the file exists, otherwise try loading it from the global media dir
+  // Check if the file exists, otherwise fall back to the skin, then to the
+  // global media dirs, then to any resource.font addon.
   std::string file = URIUtils::GetFileName(strFilename);
-  if (!CheckFont(strPath, "special://home/media/Fonts", file) &&
+  if (!CheckFont(strPath, skinFontsDir, file) &&
+      !CheckFont(strPath, "special://home/media/Fonts", file) &&
       !CheckFont(strPath, "special://xbmc/media/Fonts", file))
   {
     VECADDONS addons;
@@ -188,8 +196,7 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName,
   }
 
   // check if we already have this font file loaded (font object could differ only by color or style)
-  const std::string fontIdent =
-      StringUtils::Format("{}_{:f}_{:f}{}", strFilename, newSize, aspect, border ? "_border" : "");
+  const std::string fontIdent = MakeFontIdent(strFilename, newSize, aspect, border);
 
   CGUIFontTTF* pFontFile = GetFontFile(fontIdent);
   if (!pFontFile)
@@ -204,12 +211,13 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName,
       // font could not be loaded - try Arial.ttf, which we distribute
       if (strFilename != "arial.ttf")
       {
-        CLog::LogF(LOGERROR, "Couldn't load font name: {}({}), trying arial.ttf", strFontName,
-                   strFilename);
+        CLog::LogF(LOGERROR, "Couldn't load font name: {}({}), trying arial.ttf",
+                   EscapeFontName(strFontName), EscapeFontName(strFilename));
         return LoadTTF(strFontName, "arial.ttf", textColor, shadowColor, iSize, iStyle, border,
-                       lineSpacing, originalAspect);
+                       lineSpacing, originalAspect, sourceRes, preserveAspect, destination);
       }
-      CLog::LogF(LOGERROR, "Couldn't load font name:{} file:{}", strFontName, strPath);
+      CLog::LogF(LOGERROR, "Couldn't load font name:{} file:{}", EscapeFontName(strFontName),
+                 EscapeFontName(strPath));
 
       return nullptr;
     }
@@ -231,7 +239,7 @@ CGUIFont* GUIFontManager::LoadTTF(const std::string& strFontName,
   fontInfo.preserveAspect = preserveAspect;
   fontInfo.border = border;
 
-  m_fonts.emplace_back(FontEntry{std::unique_ptr<CGUIFont>(pNewFont), fontInfo});
+  fonts.emplace_back(FontEntry{std::unique_ptr<CGUIFont>(pNewFont), fontInfo});
 
   return pNewFont;
 }
@@ -297,7 +305,7 @@ bool GUIFontManager::ReloadFontEntry(CWinSystemBase& winSystem, FontEntry& entry
     if (!pFontFile || !pFontFile->Load(strPath, newSize, aspect, 1.0f, fontInfo.border))
     {
       delete pFontFile;
-      CLog::LogF(LOGERROR, "Couldn't re-load font file: '{}'", strPath);
+      CLog::LogF(LOGERROR, "Couldn't re-load font file: '{}'", EscapeFontName(strPath));
       return false;
     }
 
@@ -311,8 +319,8 @@ bool GUIFontManager::ReloadFontEntry(CWinSystemBase& winSystem, FontEntry& entry
 void GUIFontManager::ReloadTTFFonts(void)
 {
   CWinSystemBase* const winSystem = CServiceBroker::GetWinSystem();
-  if (m_fonts.empty() || !winSystem)
-    return; // we haven't even loaded fonts in yet
+  if (!winSystem)
+    return;
 
   for (auto& entry : m_fonts)
   {
@@ -321,6 +329,16 @@ void GUIFontManager::ReloadTTFFonts(void)
     // and the entry keeps pointing at its previous CGUIFontTTF, which is still
     // owned by m_vecFontFiles.
     ReloadFontEntry(*winSystem, entry);
+  }
+
+  std::unique_lock lock(m_critSection);
+  for (auto& [key, scope] : m_scopedFonts)
+  {
+    for (auto& entry : scope.fonts)
+    {
+      if (!ReloadFontEntry(*winSystem, entry))
+        return;
+    }
   }
 }
 
@@ -361,6 +379,31 @@ CGUIFontTTF* GUIFontManager::GetFontFile(const std::string& fontIdent)
 
 CGUIFont* GUIFontManager::GetFont(const std::string& strFontName, bool fallback /*= true*/)
 {
+  if (strFontName.empty())
+    return nullptr;
+
+  // Innermost scope first. Empty for skin windows, which is the common case:
+  // one branch on an empty vector.
+  for (auto it = ms_scopeStack.rbegin(); it != ms_scopeStack.rend(); ++it)
+  {
+    if (it->key.empty()) // null-scope marker for a window with no addon font scope
+      continue;
+
+    // Re-resolve the key under the lock rather than caching a FontScope*, so a
+    // concurrent Clear()/UnloadFontScope() cannot leave us dereferencing an
+    // erased map node.
+    std::unique_lock lock(m_critSection);
+    const auto scopeIt = m_scopedFonts.find(it->key);
+    if (scopeIt == m_scopedFonts.end())
+      continue;
+
+    for (const auto& entry : scopeIt->second.fonts)
+    {
+      if (StringUtils::EqualsNoCase(entry.font->GetFontName(), strFontName))
+        return entry.font.get();
+    }
+  }
+
   for (const auto& entry : m_fonts)
   {
     CGUIFont* pFont = entry.font.get();
@@ -368,11 +411,211 @@ CGUIFont* GUIFontManager::GetFont(const std::string& strFontName, bool fallback 
       return pFont;
   }
 
-  // fall back to "font13" if we have none
-  if (fallback && !strFontName.empty() && !StringUtils::EqualsNoCase(strFontName, "font13"))
-    return GetFont("font13");
+  if (!fallback)
+    return nullptr;
+
+  WarnFontFallback(strFontName);
+
+  if (StringUtils::EqualsNoCase(strFontName, "font13"))
+    return nullptr;
+
+  // Resolve the default from the global set directly rather than recursing,
+  // which would re-walk the whole scope stack.
+  for (const auto& entry : m_fonts)
+  {
+    if (StringUtils::EqualsNoCase(entry.font->GetFontName(), "font13"))
+      return entry.font.get();
+  }
 
   return nullptr;
+}
+
+void GUIFontManager::WarnFontFallback(const std::string& strFontName)
+{
+  // Only addon windows have a scope, so skin windows never warn. Dedup is per
+  // scope, so a 30-label dialog missing two fonts logs two lines, not thirty.
+  if (ms_scopeStack.empty() || ms_scopeStack.back().key.empty())
+    return;
+
+  // Re-resolve under the lock rather than caching a FontScope*, so a concurrent
+  // Clear()/UnloadFontScope() cannot leave us dereferencing an erased map node.
+  std::unique_lock lock(m_critSection);
+  const auto scopeIt = m_scopedFonts.find(ms_scopeStack.back().key);
+  if (scopeIt == m_scopedFonts.end())
+    return;
+
+  FontScope& scope = scopeIt->second;
+  if (!scope.warned.insert(strFontName).second)
+    return;
+
+  CLog::LogF(LOGWARNING,
+             "Font '{}' is defined by neither the addon window '{}' nor the active skin, "
+             "falling back to 'font13'",
+             EscapeFontName(strFontName), ms_scopeStack.back().key);
+}
+
+void GUIFontManager::PushFontScope(const std::string& scopeKey)
+{
+  // An empty key means the window has no addon font scope (a plain
+  // xbmcgui.Window, or any non-WindowXML window). Push a null-scope marker so
+  // push/pop stays balanced; GetFont and WarnFontFallback skip null entries.
+  if (scopeKey.empty())
+  {
+    ms_scopeStack.emplace_back(ScopeStackEntry{""});
+    return;
+  }
+
+  {
+    // Ensure the scope node (and its `warned` set) exists and survives; the key
+    // is re-resolved under the lock on every lookup, so we never cache the
+    // pointer.
+    std::unique_lock lock(m_critSection);
+    m_scopedFonts[scopeKey]; // default-constructs an unloaded scope
+  }
+
+  ms_scopeStack.emplace_back(ScopeStackEntry{scopeKey});
+}
+
+void GUIFontManager::PopFontScope()
+{
+  if (ms_scopeStack.empty())
+  {
+    CLog::LogF(LOGERROR, "Font scope stack underflow, unbalanced push/pop");
+    return;
+  }
+
+  ms_scopeStack.pop_back();
+}
+
+size_t GUIFontManager::FontScopeDepth() const
+{
+  return ms_scopeStack.size();
+}
+
+std::string GUIFontManager::InnermostFontScopeKey() const
+{
+  if (ms_scopeStack.empty())
+    return {};
+
+  return ms_scopeStack.back().key;
+}
+
+void GUIFontManager::MarkFontScopeLoaded(const std::string& scopeKey)
+{
+  std::unique_lock lock(m_critSection);
+  m_scopedFonts[scopeKey].loaded = true;
+}
+
+bool GUIFontManager::IsFontScopeLoaded(const std::string& scopeKey) const
+{
+  std::unique_lock lock(m_critSection);
+  const auto it = m_scopedFonts.find(scopeKey);
+  return it != m_scopedFonts.end() && it->second.loaded;
+}
+
+void GUIFontManager::UnloadFontScope(const std::string& scopeKey)
+{
+  std::unique_lock lock(m_critSection);
+  m_scopedFonts.erase(scopeKey); // absent key: silent no-op, by contract
+}
+
+std::string GUIFontManager::GetSkinDefaultFontFileName() const
+{
+  // Mirrors GetDefaultFont's choice: "font13" if the skin defines it, otherwise
+  // the first font it loaded. In practice that file is the skin's body face,
+  // and it follows the fontset the user picked in settings.
+  const FontEntry* first = nullptr;
+  for (const auto& entry : m_fonts)
+  {
+    if (!first)
+      first = &entry;
+
+    if (StringUtils::EqualsNoCase(entry.font->GetFontName(), "font13"))
+      return entry.origInfo.fileName;
+  }
+
+  return first ? first->origInfo.fileName : std::string{};
+}
+
+bool GUIFontManager::LoadFontsIntoScope(const std::string& scopeKey,
+                                        const std::string& fontXmlPath,
+                                        const RESOLUTION_INFO& sourceRes)
+{
+  {
+    std::unique_lock lock(m_critSection);
+    if (m_scopedFonts[scopeKey].loaded)
+      return true;
+  }
+
+  std::vector<FontDefinition> definitions;
+
+  // LoadXMLData is the existing file-scope helper at GUIFontManager.cpp:55. It
+  // checks existence, logs LOGDEBUG when absent and LOGERROR when malformed, so
+  // the caller need not probe with CFile::Exists first.
+  CXBMCTinyXML xmlDoc;
+  if (!fontXmlPath.empty() && LoadXMLData(fontXmlPath, xmlDoc))
+  {
+    // Never hand an addon-authored document to the skin's ResolveIncludes.
+    StripIncludes(xmlDoc.RootElement());
+
+    const TiXmlElement* fontsetElement = xmlDoc.RootElement()->FirstChildElement("fontset");
+    const TiXmlElement* chosen = nullptr;
+    for (; fontsetElement; fontsetElement = fontsetElement->NextSiblingElement("fontset"))
+    {
+      const char* idAttr = fontsetElement->Attribute("id");
+      if (!idAttr)
+        continue;
+
+      if (!chosen)
+        chosen = fontsetElement; // first fontset, the fallback
+      if (StringUtils::EqualsNoCase(idAttr, "Default"))
+      {
+        chosen = fontsetElement;
+        break;
+      }
+    }
+
+    if (chosen)
+      definitions = ParseFontSet(chosen->FirstChild("font"));
+    else
+      CLog::LogF(LOGERROR, "No valid <fontset> in addon font file '{}'", fontXmlPath);
+  }
+  // LoadXMLData already logged the absent/malformed case. An addon with no
+  // Font.xml lands here and gets a loaded-but-empty scope, which is correct.
+
+  const std::string skinTypeface = GetSkinDefaultFontFileName();
+
+  for (const FontDefinition& def : definitions)
+  {
+    // An addon declares size and style only; the typeface is always the skin's.
+    // Shipping a face was cut on review: it is the skin's prerogative, and an
+    // addon cannot know which scripts the user needs covered.
+    if (!def.fileName.empty())
+    {
+      CLog::LogF(LOGWARNING, "Font '{}': <filename> is ignored, addon fonts use the skin typeface",
+                 EscapeFontName(def.name));
+    }
+
+    if (skinTypeface.empty())
+    {
+      CLog::LogF(LOGWARNING, "Font '{}' inherits the skin typeface, but the skin loaded none",
+                 EscapeFontName(def.name));
+      continue;
+    }
+
+    std::vector<FontEntry>* destination = nullptr;
+    {
+      std::unique_lock lock(m_critSection);
+      destination = &m_scopedFonts[scopeKey].fonts;
+    }
+
+    LoadTTF(def.name, skinTypeface, def.textColor, def.shadowColor, def.size, def.style, false,
+            def.lineSpacing, def.aspect, &sourceRes, false, destination);
+  }
+
+  std::unique_lock lock(m_critSection);
+  m_scopedFonts[scopeKey].loaded = true; // loaded, even if empty
+  return true;
 }
 
 CGUIFont* GUIFontManager::GetDefaultFont(bool border)
@@ -418,6 +661,12 @@ void GUIFontManager::Clear()
   m_fonts.clear();
   m_vecFontFiles.clear();
 
+  {
+    std::unique_lock lock(m_critSection);
+    m_scopedFonts.clear();
+  }
+  ms_scopeStack.clear();
+
 #if defined(HAS_GL)
   CGUIFontTTFGL::DestroyStaticVertexBuffers();
 #endif
@@ -451,7 +700,7 @@ bool GUIFontManager::LoadFontsFromFile(const std::string& fontsetFilePath,
         if (StringUtils::EqualsNoCase(fontSet, idAttr))
         {
           // Found the requested fontset, so load the fonts and return
-          CLog::LogF(LOGINFO, "Loading <fontset> with name '{}' from '{}'", fontSet,
+          CLog::LogF(LOGINFO, "Loading <fontset> with name '{}' from '{}'", EscapeFontName(fontSet),
                      fontsetFilePath);
           LoadFonts(fontsetElement->FirstChild("font"));
           return true;
@@ -490,7 +739,7 @@ void GUIFontManager::LoadFonts(const std::string& fontSet)
     CLog::LogF(LOGWARNING,
                "Fontset with name '{}' was not found, "
                "defaulting to first fontset '{}' ",
-               fontSet, firstFontset);
+               EscapeFontName(fontSet), EscapeFontName(firstFontset));
     LoadFonts(firstFontset);
   }
   else
@@ -500,59 +749,18 @@ void GUIFontManager::LoadFonts(const std::string& fontSet)
 
 void GUIFontManager::LoadFonts(const TiXmlNode* fontNode)
 {
-  while (fontNode)
+  for (const FontDefinition& def : ParseFontSet(fontNode))
   {
-    std::string fontName;
-    std::string fileName;
-    int iSize = 20;
-    float aspect = 1.0f;
-    float lineSpacing = 1.0f;
-    KODI::UTILS::COLOR::Color shadowColor = 0;
-    KODI::UTILS::COLOR::Color textColor = 0;
-    int iStyle = FONT_STYLE_NORMAL;
-
-    XMLUtils::GetString(fontNode, "name", fontName);
-    XMLUtils::GetInt(fontNode, "size", iSize);
-    XMLUtils::GetFloat(fontNode, "linespacing", lineSpacing);
-    XMLUtils::GetFloat(fontNode, "aspect", aspect);
-    CGUIControlFactory::GetColor(fontNode, "shadow", shadowColor);
-    CGUIControlFactory::GetColor(fontNode, "color", textColor);
-    XMLUtils::GetString(fontNode, "filename", fileName);
-    GetStyle(fontNode, iStyle);
-
-    if (!fontName.empty() && URIUtils::HasExtension(fileName, ".ttf"))
+    // Only an addon font scope may omit <filename>, to inherit the skin's
+    // typeface. A skin has nothing to inherit from.
+    if (def.fileName.empty())
     {
-      LoadTTF(fontName, fileName, textColor, shadowColor, iSize, iStyle, false, lineSpacing,
-              aspect);
+      CLog::LogF(LOGWARNING, "Skin font '{}' has no <filename>", EscapeFontName(def.name));
+      continue;
     }
-    fontNode = fontNode->NextSibling("font");
-  }
-}
 
-void GUIFontManager::GetStyle(const TiXmlNode* fontNode, int& iStyle)
-{
-  std::string style;
-  iStyle = FONT_STYLE_NORMAL;
-  if (XMLUtils::GetString(fontNode, "style", style))
-  {
-    std::vector<std::string> styles = StringUtils::Tokenize(style, " ");
-    for (const std::string& i : styles)
-    {
-      if (i == "bold")
-        iStyle |= FONT_STYLE_BOLD;
-      else if (i == "italics")
-        iStyle |= FONT_STYLE_ITALICS;
-      else if (i == "bolditalics") // backward compatibility
-        iStyle |= (FONT_STYLE_BOLD | FONT_STYLE_ITALICS);
-      else if (i == "uppercase")
-        iStyle |= FONT_STYLE_UPPERCASE;
-      else if (i == "lowercase")
-        iStyle |= FONT_STYLE_LOWERCASE;
-      else if (i == "capitalize")
-        iStyle |= FONT_STYLE_CAPITALIZE;
-      else if (i == "lighten")
-        iStyle |= FONT_STYLE_LIGHT;
-    }
+    LoadTTF(def.name, def.fileName, def.textColor, def.shadowColor, def.size, def.style, false,
+            def.lineSpacing, def.aspect);
   }
 }
 

--- a/xbmc/guilib/GUIFontManager.h
+++ b/xbmc/guilib/GUIFontManager.h
@@ -20,8 +20,10 @@
 #include "utils/GlobalsHandling.h"
 #include "windowing/GraphicContext.h"
 
+#include <map>
 #include <memory>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -56,6 +58,18 @@ struct FontEntry
 {
   std::unique_ptr<CGUIFont> font;
   OrigFontInfo origInfo;
+};
+
+struct FontScope
+{
+  //! true once discovery has run, even if no fonts were found. Never test
+  //! `fonts.empty()` for this: an addon with no Font.xml has a legitimately
+  //! empty loaded scope, and an emptiness test would re-parse on every open.
+  bool loaded{false};
+  std::vector<FontEntry> fonts;
+  //! Per-scope, so a nested dialog's push does not wipe the outer window's
+  //! dedup state and cause it to re-warn.
+  std::set<std::string> warned;
 };
 
 struct FontMetadata
@@ -102,8 +116,58 @@ public:
                     float lineSpacing = 1.0f,
                     float aspect = 1.0f,
                     const RESOLUTION_INFO* res = nullptr,
-                    bool preserveAspect = false);
+                    bool preserveAspect = false,
+                    std::vector<FontEntry>* destination = nullptr);
   CGUIFont* GetFont(const std::string& strFontName, bool fallback = true);
+
+  /*!
+   \brief RAII bracket around a font scope. Pops even if the guarded call
+   throws, which Python-invoked control creation can.
+   */
+  class CScopeGuard
+  {
+  public:
+    CScopeGuard(GUIFontManager& manager, const std::string& scopeKey) : m_manager(manager)
+    {
+      m_manager.PushFontScope(scopeKey);
+    }
+    ~CScopeGuard() { m_manager.PopFontScope(); }
+
+    CScopeGuard(const CScopeGuard&) = delete;
+    CScopeGuard& operator=(const CScopeGuard&) = delete;
+
+  private:
+    GUIFontManager& m_manager;
+  };
+
+  void PushFontScope(const std::string& scopeKey);
+  void PopFontScope();
+
+  /*!
+   \brief File name of the typeface the active skin uses. Every scoped font is
+          rendered from it, so an addon adopts the skin's face.
+   \return the skin's "font13" file, else the first font it loaded, else empty
+   */
+  std::string GetSkinDefaultFontFileName() const;
+
+  /*!
+   \brief Register the fonts declared by an addon's Font.xml into one scope.
+   \param scopeKey the resolved window XML path, unique per window
+   \param fontXmlPath the addon's Font.xml; may be absent, which yields a
+          loaded-but-empty scope rather than an error
+   \param sourceRes the resolution the sizes are authored against
+   \return true; a missing or malformed file is not a failure for the caller
+
+   Idempotent: a scope already marked loaded is not re-parsed, so reopening a
+   window costs nothing. Every font takes its typeface from
+   GetSkinDefaultFontFileName; a <filename> in the addon's file is ignored and
+   warned about, because the face is the skin's to choose.
+   */
+  bool LoadFontsIntoScope(const std::string& scopeKey,
+                          const std::string& fontXmlPath,
+                          const RESOLUTION_INFO& sourceRes);
+  void UnloadFontScope(const std::string& scopeKey);
+  bool IsFontScopeLoaded(const std::string& scopeKey) const;
 
   /*! \brief return a default font
    \param border whether the font should be a font with an outline
@@ -126,11 +190,11 @@ public:
 
 protected:
   void ReloadTTFFonts();
-  bool ReloadFontEntry(CWinSystemBase& winSystem, FontEntry& entry);
   static std::string MakeFontIdent(const std::string& fileName,
                                    float size,
                                    float aspect,
                                    bool border);
+  bool ReloadFontEntry(CWinSystemBase& winSystem, FontEntry& entry);
   static void RescaleFontSizeAndAspect(CGraphicContext& context,
                                        float* size,
                                        float* aspect,
@@ -138,7 +202,13 @@ protected:
                                        bool preserveAspect);
   void LoadFonts(const TiXmlNode* fontNode);
   CGUIFontTTF* GetFontFile(const std::string& fontIdent);
-  static void GetStyle(const TiXmlNode* fontNode, int& iStyle);
+
+  //! \brief Depth of the calling thread's scope stack.
+  size_t FontScopeDepth() const;
+  //! \brief Key of the calling thread's innermost scope, empty if none.
+  std::string InnermostFontScopeKey() const;
+  //! \brief Mark a scope loaded without parsing its Font.xml.
+  void MarkFontScopeLoaded(const std::string& scopeKey);
 
   std::vector<FontEntry> m_fonts;
   std::vector<std::unique_ptr<CGUIFontTTF>> m_vecFontFiles;
@@ -150,9 +220,24 @@ private:
   bool LoadFontsFromFile(const std::string& fontsetFilePath,
                          const std::string& fontSet,
                          std::string& firstFontset);
+  void WarnFontFallback(const std::string& strFontName);
 
   mutable CCriticalSection m_critSection;
   std::vector<FontMetadata> m_userFontsCache;
+
+  //! Guarded by m_critSection.
+  std::map<std::string, FontScope> m_scopedFonts;
+
+  //! Per-thread resolution stack. Control::Create runs on the Python thread.
+  //! Only the key is stored, never a FontScope*: the key is re-resolved against
+  //! m_scopedFonts under m_critSection on every lookup, precisely so a
+  //! concurrent Clear()/UnloadFontScope() on another thread cannot leave a
+  //! dangling pointer into an erased map node.
+  struct ScopeStackEntry
+  {
+    std::string key;
+  };
+  static thread_local std::vector<ScopeStackEntry> ms_scopeStack;
 };
 
 /*!

--- a/xbmc/guilib/GUIFontManager.h
+++ b/xbmc/guilib/GUIFontManager.h
@@ -20,6 +20,7 @@
 #include "utils/GlobalsHandling.h"
 #include "windowing/GraphicContext.h"
 
+#include <memory>
 #include <set>
 #include <utility>
 #include <vector>
@@ -27,6 +28,7 @@
 // Forward
 class CGUIFont;
 class CGUIFontTTF;
+class CWinSystemBase;
 class CXBMCTinyXML;
 class TiXmlNode;
 class CSetting;
@@ -43,10 +45,24 @@ struct OrigFontInfo
   bool border;
 };
 
+/*!
+ \brief A loaded font together with the info needed to re-rasterise it.
+
+ These were two index-aligned vectors. Anything that erased from one without
+ erasing the other silently paired every later font with its neighbour's info,
+ so keep them in one entry and the misalignment cannot be expressed.
+ */
+struct FontEntry
+{
+  std::unique_ptr<CGUIFont> font;
+  OrigFontInfo origInfo;
+};
+
 struct FontMetadata
 {
   FontMetadata(const std::string& filename, const std::set<std::string>& familyNames)
-    : m_filename{filename}, m_familyNames{familyNames}
+    : m_filename{filename},
+      m_familyNames{familyNames}
   {
   }
 
@@ -110,6 +126,11 @@ public:
 
 protected:
   void ReloadTTFFonts();
+  bool ReloadFontEntry(CWinSystemBase& winSystem, FontEntry& entry);
+  static std::string MakeFontIdent(const std::string& fileName,
+                                   float size,
+                                   float aspect,
+                                   bool border);
   static void RescaleFontSizeAndAspect(CGraphicContext& context,
                                        float* size,
                                        float* aspect,
@@ -119,9 +140,8 @@ protected:
   CGUIFontTTF* GetFontFile(const std::string& fontIdent);
   static void GetStyle(const TiXmlNode* fontNode, int& iStyle);
 
-  std::vector<std::unique_ptr<CGUIFont>> m_vecFonts;
+  std::vector<FontEntry> m_fonts;
   std::vector<std::unique_ptr<CGUIFontTTF>> m_vecFontFiles;
-  std::vector<OrigFontInfo> m_vecFontInfo;
   RESOLUTION_INFO m_skinResolution;
   bool m_canReload{true};
 

--- a/xbmc/guilib/GUIFontParsing.cpp
+++ b/xbmc/guilib/GUIFontParsing.cpp
@@ -1,0 +1,138 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GUIFontParsing.h"
+
+#include "GUIControlFactory.h"
+#include "URL.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/XBMCTinyXML.h"
+#include "utils/XMLUtils.h"
+#include "utils/log.h"
+
+#include <string>
+#include <vector>
+
+int ParseFontStyle(const TiXmlNode* fontNode)
+{
+  int iStyle = FONT_STYLE_NORMAL;
+  std::string style;
+  if (XMLUtils::GetString(fontNode, "style", style))
+  {
+    std::vector<std::string> styles = StringUtils::Tokenize(style, " ");
+    for (const std::string& i : styles)
+    {
+      if (i == "bold")
+        iStyle |= FONT_STYLE_BOLD;
+      else if (i == "italics")
+        iStyle |= FONT_STYLE_ITALICS;
+      else if (i == "bolditalics") // backward compatibility
+        iStyle |= (FONT_STYLE_BOLD | FONT_STYLE_ITALICS);
+      else if (i == "uppercase")
+        iStyle |= FONT_STYLE_UPPERCASE;
+      else if (i == "lowercase")
+        iStyle |= FONT_STYLE_LOWERCASE;
+      else if (i == "capitalize")
+        iStyle |= FONT_STYLE_CAPITALIZE;
+      else if (i == "lighten")
+        iStyle |= FONT_STYLE_LIGHT;
+    }
+  }
+
+  return iStyle;
+}
+
+std::vector<FontDefinition> ParseFontSet(const TiXmlNode* firstFontNode)
+{
+  std::vector<FontDefinition> definitions;
+
+  for (const TiXmlNode* fontNode = firstFontNode; fontNode;
+       fontNode = fontNode->NextSibling("font"))
+  {
+    FontDefinition def;
+
+    XMLUtils::GetString(fontNode, "name", def.name);
+    XMLUtils::GetInt(fontNode, "size", def.size);
+    XMLUtils::GetFloat(fontNode, "linespacing", def.lineSpacing);
+    XMLUtils::GetFloat(fontNode, "aspect", def.aspect);
+    CGUIControlFactory::GetColor(fontNode, "shadow", def.shadowColor);
+    CGUIControlFactory::GetColor(fontNode, "color", def.textColor);
+    XMLUtils::GetString(fontNode, "filename", def.fileName);
+    def.style = ParseFontStyle(fontNode);
+
+    // An empty <filename> is allowed through. An addon font scope ignores the
+    // element either way and always uses the skin's typeface; the skin's own
+    // loader rejects an empty one, having nothing to inherit from.
+    if (def.name.empty() ||
+        (!def.fileName.empty() && !URIUtils::HasExtension(def.fileName, ".ttf")))
+    {
+      CLog::LogF(LOGDEBUG, "Skipping font entry, name '{}' filename '{}'", EscapeFontName(def.name),
+                 EscapeFontName(def.fileName));
+      continue;
+    }
+
+    definitions.emplace_back(std::move(def));
+  }
+
+  return definitions;
+}
+
+int StripIncludes(TiXmlElement* rootElement)
+{
+  if (!rootElement)
+    return 0;
+
+  int removed = 0;
+  TiXmlElement* include = rootElement->FirstChildElement("include");
+  while (include)
+  {
+    TiXmlElement* next = include->NextSiblingElement("include");
+    CLog::LogF(LOGWARNING, "Ignoring <include> in addon font definition");
+    rootElement->RemoveChild(include);
+    ++removed;
+    include = next;
+  }
+
+  return removed;
+}
+
+std::string EscapeFontName(const std::string& name)
+{
+  constexpr size_t MAX_LOGGED_NAME = 128;
+
+  std::string escaped;
+  escaped.reserve(name.size());
+
+  for (const char c : name)
+  {
+    switch (c)
+    {
+      case '\n':
+        escaped += "\\n";
+        break;
+      case '\r':
+        escaped += "\\r";
+        break;
+      case '\t':
+        escaped += "\\t";
+        break;
+      default:
+        escaped += c;
+        break;
+    }
+
+    if (escaped.size() >= MAX_LOGGED_NAME)
+      break;
+  }
+
+  if (escaped.size() > MAX_LOGGED_NAME)
+    escaped.resize(MAX_LOGGED_NAME);
+
+  return escaped;
+}

--- a/xbmc/guilib/GUIFontParsing.h
+++ b/xbmc/guilib/GUIFontParsing.h
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "GUIFont.h"
+#include "utils/ColorUtils.h"
+
+#include <string>
+#include <vector>
+
+class TiXmlElement;
+class TiXmlNode;
+
+struct FontDefinition
+{
+  std::string name;
+  std::string fileName;
+  int size{20};
+  float aspect{1.0f};
+  float lineSpacing{1.0f};
+  KODI::UTILS::COLOR::Color shadowColor{0};
+  KODI::UTILS::COLOR::Color textColor{0};
+  int style{FONT_STYLE_NORMAL};
+};
+
+/*!
+ \brief Parse the <style> element of a <font> node into a FONT_STYLE_ bitmask.
+ */
+int ParseFontStyle(const TiXmlNode* fontNode);
+
+/*!
+ \brief Parse a chain of <font> siblings into definitions.
+ \param firstFontNode the first <font> child of a <fontset>, or nullptr
+ \return one definition per usable <font>. Entries with an empty <name> or a
+         <filename> that is not a .ttf are skipped.
+
+ Free of GL, CWinSystemBase and CGraphicContext. However, parsing a <color> or
+ <shadow> element resolves the name through
+ CServiceBroker::GetGUI()->GetColorManager(), so a CGUIComponent must be
+ registered when the input contains such an element. The caller feeds each
+ definition to LoadTTF.
+ */
+std::vector<FontDefinition> ParseFontSet(const TiXmlNode* firstFontNode);
+
+/*!
+ \brief Remove every <include> child of an addon-authored document root.
+ \return the number of nodes removed
+
+ An addon Font.xml must never reach the active skin's ResolveIncludes:
+ <include file="resource://..."> loads addon-referenced XML into skin-global
+ include state and <include condition="..."> registers an addon expression
+ into the global InfoManager. Both cross a trust boundary.
+ */
+int StripIncludes(TiXmlElement* rootElement);
+
+/*!
+ \brief Make an addon-controlled font name safe to interpolate into a log line.
+ Escapes CR, LF and TAB so a name cannot forge or split a log record, and
+ truncates to 128 characters.
+ */
+std::string EscapeFontName(const std::string& name);

--- a/xbmc/guilib/test/CMakeLists.txt
+++ b/xbmc/guilib/test/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(SOURCES TestGUIControlFactory.cpp
+            TestGUIFontManager.cpp
+            TestGUIFontParsing.cpp
             TestGamesGUIInfo.cpp
             TestGUITextLayout.cpp)
 

--- a/xbmc/guilib/test/TestGUIFontManager.cpp
+++ b/xbmc/guilib/test/TestGUIFontManager.cpp
@@ -1,0 +1,163 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "guilib/GUIFontManager.h"
+#include "guilib/GUIFontParsing.h"
+
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+// GUIFontManager's font-loading paths need a CWinSystemBase, which kodi-test
+// does not register. Scope bookkeeping does not, so it is tested directly.
+//
+// Constructing one is safe here: the ctor is `= default`, and the dtor's
+// Clear() reaches CGUIFontTTFGL::DestroyStaticVertexBuffers(), which
+// early-returns because m_staticVertexBufferCreated is false without a GL
+// context (GUIFontTTFGL.cpp:474,482). Verified, not assumed.
+// Subclass to reach the protected scope seams. This mirrors CGFTestable at
+// TestGUIControlFactory.cpp:31 in this same directory, which is guilib's
+// established way of testing protected members.
+class CFontManagerTestable : public GUIFontManager
+{
+public:
+  using GUIFontManager::FontScopeDepth;
+  using GUIFontManager::InnermostFontScopeKey;
+  using GUIFontManager::MarkFontScopeLoaded;
+};
+
+class TestFontScope : public ::testing::Test
+{
+protected:
+  CFontManagerTestable m_mgr;
+};
+
+TEST_F(TestFontScope, PushAndPopReturnStackToEmpty)
+{
+  EXPECT_EQ(m_mgr.FontScopeDepth(), 0U);
+  m_mgr.PushFontScope("/addon/MyWindow.xml");
+  EXPECT_EQ(m_mgr.FontScopeDepth(), 1U);
+  m_mgr.PopFontScope();
+  EXPECT_EQ(m_mgr.FontScopeDepth(), 0U);
+}
+
+TEST_F(TestFontScope, NestedScopesResolveInnermostFirst)
+{
+  m_mgr.PushFontScope("/addon/Outer.xml");
+  m_mgr.PushFontScope("/addon/Inner.xml");
+  EXPECT_EQ(m_mgr.FontScopeDepth(), 2U);
+  EXPECT_EQ(m_mgr.InnermostFontScopeKey(), "/addon/Inner.xml");
+  m_mgr.PopFontScope();
+  EXPECT_EQ(m_mgr.InnermostFontScopeKey(), "/addon/Outer.xml");
+  m_mgr.PopFontScope();
+}
+
+TEST_F(TestFontScope, ScopeGuardPopsOnException)
+{
+  try
+  {
+    GUIFontManager::CScopeGuard guard(m_mgr, "/addon/MyWindow.xml");
+    EXPECT_EQ(m_mgr.FontScopeDepth(), 1U);
+    throw std::runtime_error("python blew up");
+  }
+  catch (const std::runtime_error&)
+  {
+  }
+
+  EXPECT_EQ(m_mgr.FontScopeDepth(), 0U);
+}
+
+TEST_F(TestFontScope, PopOnEmptyStackIsAnErrorNotACrash)
+{
+  m_mgr.PopFontScope(); // logs an error
+  EXPECT_EQ(m_mgr.FontScopeDepth(), 0U);
+
+  // A zero depth alone would also hold if the underflow had corrupted the
+  // container. Prove the stack still works. Task 6 makes this path reachable:
+  // doAddControl pushes an empty-key guard for every non-addon window.
+  m_mgr.PushFontScope("/addon/After.xml");
+  EXPECT_EQ(m_mgr.InnermostFontScopeKey(), "/addon/After.xml");
+  m_mgr.PopFontScope();
+  EXPECT_EQ(m_mgr.FontScopeDepth(), 0U);
+}
+
+TEST_F(TestFontScope, UnloadAbsentScopeIsSilentNoOp)
+{
+  m_mgr.UnloadFontScope("/never/loaded.xml"); // must not throw or log an error
+  EXPECT_FALSE(m_mgr.IsFontScopeLoaded("/never/loaded.xml"));
+}
+
+TEST_F(TestFontScope, TwoWindowsOfOneAddonGetDistinctScopes)
+{
+  // F1 regression. Keying on the addon script path collapsed a window and its
+  // dialog onto one scope, so tearing down either freed the other's fonts.
+  m_mgr.MarkFontScopeLoaded("/addon/MyWindow.xml");
+
+  EXPECT_TRUE(m_mgr.IsFontScopeLoaded("/addon/MyWindow.xml"));
+  EXPECT_FALSE(m_mgr.IsFontScopeLoaded("/addon/MyDialog.xml"));
+}
+
+TEST_F(TestFontScope, ScopeStackIsPerThread)
+{
+  // F2 regression. Control::Create resolves fonts on the Python thread while
+  // the app thread may be pushing a scope for a different window.
+  m_mgr.PushFontScope("/addon/AppThread.xml");
+
+  std::thread other(
+      [this]
+      {
+        EXPECT_EQ(m_mgr.FontScopeDepth(), 0U);
+        m_mgr.PushFontScope("/addon/PythonThread.xml");
+        EXPECT_EQ(m_mgr.InnermostFontScopeKey(), "/addon/PythonThread.xml");
+        m_mgr.PopFontScope();
+      });
+  other.join();
+
+  EXPECT_EQ(m_mgr.InnermostFontScopeKey(), "/addon/AppThread.xml");
+  m_mgr.PopFontScope();
+}
+
+TEST_F(TestFontScope, EmptyScopeKeyResolvesAgainstGlobalSetOnly)
+{
+  // A non-WindowXML window (a plain xbmcgui.Window) has no scope key.
+  // doAddControl still pushes a guard for it: the empty key must push a null
+  // scope, not index m_scopedFonts[""], and resolving must skip it, not crash.
+  GUIFontManager::CScopeGuard guard(m_mgr, "");
+  EXPECT_EQ(m_mgr.FontScopeDepth(), 1U);
+  EXPECT_EQ(m_mgr.InnermostFontScopeKey(), "");
+  EXPECT_EQ(m_mgr.GetFont("font12", false), nullptr); // no crash on null scope
+}
+
+TEST_F(TestFontScope, DistinctResolvedPathsOfOneAddonOwnFontsIndependently)
+{
+  // F1 fix, pinned at the reachable level. The key derivation lives in
+  // WindowXML's constructor (m_fontScopeKey = strSkinPath, the RESOLVED window
+  // XML path, not the shared script path). WindowXML cannot be constructed
+  // under kodi-test (it needs a skin, the window manager and Python), so the
+  // string derivation itself is verified manually. What IS reachable, and what
+  // actually makes the fix safe, is that two windows of one addon that resolve
+  // to different XML paths own and tear down their fonts independently: closing
+  // one must not free the other's. Keying on the shared script path would make
+  // these one scope and reintroduce the use-after-free.
+  const std::string window = "/addon/resources/skins/Default/720p/MyWindow.xml";
+  const std::string dialog = "/addon/resources/skins/Default/720p/MyDialog.xml";
+
+  m_mgr.MarkFontScopeLoaded(window);
+  m_mgr.MarkFontScopeLoaded(dialog);
+  ASSERT_TRUE(m_mgr.IsFontScopeLoaded(window));
+  ASSERT_TRUE(m_mgr.IsFontScopeLoaded(dialog));
+
+  // Tear down the dialog, as an ordinary forced unload would.
+  m_mgr.UnloadFontScope(dialog);
+
+  // The window's scope, and thus its fonts, survive.
+  EXPECT_TRUE(m_mgr.IsFontScopeLoaded(window));
+  EXPECT_FALSE(m_mgr.IsFontScopeLoaded(dialog));
+}

--- a/xbmc/guilib/test/TestGUIFontParsing.cpp
+++ b/xbmc/guilib/test/TestGUIFontParsing.cpp
@@ -1,0 +1,236 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GUIInfoManager.h"
+#include "ServiceBroker.h"
+#include "guilib/GUIColorManager.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIFontParsing.h"
+#include "utils/XBMCTinyXML.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+// Parses a <fontset> document and hands back the first <font> child, which is
+// what ParseFontSet expects, mirroring LoadFontsFromFile's call.
+const TiXmlNode* FirstFontNode(CXBMCTinyXML& doc, const std::string& xml)
+{
+  EXPECT_TRUE(doc.Parse(xml));
+  const TiXmlElement* root = doc.RootElement();
+  EXPECT_NE(root, nullptr);
+  return root->FirstChild("font");
+}
+} // namespace
+
+TEST(TestGUIFontParsing, ParseFontSetReadsNameFileAndSize)
+{
+  CXBMCTinyXML doc;
+  const auto* node = FirstFontNode(doc, R"(
+    <fontset id="Default">
+      <font><name>font12</name><filename>MyFont.ttf</filename><size>24</size></font>
+      <font><name>font14</name><filename>Other.ttf</filename><size>30</size></font>
+    </fontset>)");
+
+  const std::vector<FontDefinition> fonts = ParseFontSet(node);
+
+  ASSERT_EQ(fonts.size(), 2U);
+  EXPECT_EQ(fonts[0].name, "font12");
+  EXPECT_EQ(fonts[0].fileName, "MyFont.ttf");
+  EXPECT_EQ(fonts[0].size, 24);
+  EXPECT_EQ(fonts[1].name, "font14");
+  EXPECT_EQ(fonts[1].size, 30);
+}
+
+TEST(TestGUIFontParsing, ParseFontSetSkipsEmptyNameAndNonTtf)
+{
+  CXBMCTinyXML doc;
+  const auto* node = FirstFontNode(doc, R"(
+    <fontset id="Default">
+      <font><name></name><filename>MyFont.ttf</filename></font>
+      <font><name>font12</name><filename>MyFont.otf</filename></font>
+      <font><name>font13</name><filename>Good.ttf</filename></font>
+    </fontset>)");
+
+  const std::vector<FontDefinition> fonts = ParseFontSet(node);
+
+  ASSERT_EQ(fonts.size(), 1U);
+  EXPECT_EQ(fonts[0].name, "font13");
+}
+
+TEST(TestGUIFontParsing, ParseFontSetKeepsEntryWithNoFilename)
+{
+  // An omitted <filename> means "inherit the active skin's typeface". The
+  // parser must pass it through; only the skin's own loader rejects it.
+  CXBMCTinyXML doc;
+  const auto* node = FirstFontNode(doc, R"(
+    <fontset id="Default">
+      <font><name>title</name><size>46</size><style>bold</style></font>
+    </fontset>)");
+
+  const std::vector<FontDefinition> fonts = ParseFontSet(node);
+
+  ASSERT_EQ(fonts.size(), 1U);
+  EXPECT_EQ(fonts[0].name, "title");
+  EXPECT_TRUE(fonts[0].fileName.empty());
+  EXPECT_EQ(fonts[0].size, 46);
+  EXPECT_EQ(fonts[0].style, FONT_STYLE_BOLD);
+}
+
+TEST(TestGUIFontParsing, ParseFontSetStillSkipsNonTtfWhenFilenamePresent)
+{
+  // Allowing an empty filename must not let a non-ttf through.
+  CXBMCTinyXML doc;
+  const auto* node = FirstFontNode(doc, R"(
+    <fontset id="Default">
+      <font><name>bad</name><filename>MyFont.otf</filename></font>
+      <font><name>inherit</name></font>
+    </fontset>)");
+
+  const std::vector<FontDefinition> fonts = ParseFontSet(node);
+
+  ASSERT_EQ(fonts.size(), 1U);
+  EXPECT_EQ(fonts[0].name, "inherit");
+}
+
+TEST(TestGUIFontParsing, ParseFontSetAppliesDefaultsWhenAbsent)
+{
+  CXBMCTinyXML doc;
+  const auto* node = FirstFontNode(doc, R"(
+    <fontset id="Default">
+      <font><name>font13</name><filename>Good.ttf</filename></font>
+    </fontset>)");
+
+  const std::vector<FontDefinition> fonts = ParseFontSet(node);
+
+  ASSERT_EQ(fonts.size(), 1U);
+  EXPECT_EQ(fonts[0].size, 20);
+  EXPECT_FLOAT_EQ(fonts[0].aspect, 1.0f);
+  EXPECT_FLOAT_EQ(fonts[0].lineSpacing, 1.0f);
+  EXPECT_EQ(fonts[0].style, FONT_STYLE_NORMAL);
+}
+
+TEST(TestGUIFontParsing, ParseFontSetReadsStyleBitmask)
+{
+  CXBMCTinyXML doc;
+  const auto* node = FirstFontNode(doc, R"(
+    <fontset id="Default">
+      <font><name>f</name><filename>a.ttf</filename><style>bold italics</style></font>
+    </fontset>)");
+
+  const std::vector<FontDefinition> fonts = ParseFontSet(node);
+
+  ASSERT_EQ(fonts.size(), 1U);
+  EXPECT_EQ(fonts[0].style, FONT_STYLE_BOLD | FONT_STYLE_ITALICS);
+}
+
+TEST(TestGUIFontParsing, ParseFontSetOnNullNodeYieldsEmpty)
+{
+  EXPECT_TRUE(ParseFontSet(nullptr).empty());
+}
+
+namespace
+{
+// ParseFontSet resolves <color>/<shadow> names through the colour manager, so
+// this fixture registers a CGUIComponent the same way
+// TestGUIControlFactory.cpp does for its GetColor tests.
+class CGUITestColorManager : public CGUIColorManager
+{
+public:
+  CGUITestColorManager()
+  {
+    CXBMCTinyXML xmlDoc;
+    xmlDoc.Parse(std::string(R"(<colors>
+                      <color name="red">ffff0000</color>
+                      <color name="blue">ff0000ff</color>
+                    </colors>)"));
+    LoadXML(xmlDoc);
+  }
+};
+
+class CGUITestComponent : public CGUIComponent
+{
+public:
+  CGUITestComponent() : CGUIComponent(false)
+  {
+    m_guiColorManager = std::make_unique<CGUITestColorManager>();
+    m_guiInfoManager = std::make_unique<CGUIInfoManager>();
+    CServiceBroker::RegisterGUI(this);
+  }
+};
+} // namespace
+
+TEST(TestGUIFontParsing, ParseFontSetReadsColorAndShadow)
+{
+  CGUITestComponent comp;
+
+  CXBMCTinyXML doc;
+  const auto* node = FirstFontNode(doc, R"(
+    <fontset id="Default">
+      <font>
+        <name>font12</name>
+        <filename>MyFont.ttf</filename>
+        <color>red</color>
+        <shadow>blue</shadow>
+      </font>
+    </fontset>)");
+
+  const std::vector<FontDefinition> fonts = ParseFontSet(node);
+
+  ASSERT_EQ(fonts.size(), 1U);
+  EXPECT_EQ(fonts[0].textColor, 0xFFFF0000U);
+  EXPECT_EQ(fonts[0].shadowColor, 0xFF0000FFU);
+}
+
+TEST(TestGUIFontParsing, StripIncludesRemovesFileAndConditionIncludes)
+{
+  CXBMCTinyXML doc;
+  ASSERT_TRUE(doc.Parse(std::string(R"xml(
+    <fonts>
+      <include file="resource://resource.font.evil/Font.xml" />
+      <include condition="System.HasAddon(x)">Something</include>
+      <fontset id="Default"><font><name>f</name><filename>a.ttf</filename></font></fontset>
+    </fonts>)xml")));
+
+  EXPECT_EQ(StripIncludes(doc.RootElement()), 2);
+  EXPECT_EQ(doc.RootElement()->FirstChildElement("include"), nullptr);
+  EXPECT_NE(doc.RootElement()->FirstChildElement("fontset"), nullptr);
+}
+
+TEST(TestGUIFontParsing, StripIncludesLeavesCleanDocumentAlone)
+{
+  CXBMCTinyXML doc;
+  ASSERT_TRUE(doc.Parse(std::string(
+      R"(<fonts><fontset id="Default"><font><name>f</name><filename>a.ttf</filename></font></fontset></fonts>)")));
+
+  EXPECT_EQ(StripIncludes(doc.RootElement()), 0);
+  EXPECT_NE(doc.RootElement()->FirstChildElement("fontset"), nullptr);
+}
+
+TEST(TestGUIFontParsing, StripIncludesOnNullRootIsSafe)
+{
+  EXPECT_EQ(StripIncludes(nullptr), 0);
+}
+
+TEST(TestGUIFontParsing, EscapeFontNameNeutralisesLogInjection)
+{
+  EXPECT_EQ(EscapeFontName("font12"), "font12");
+  EXPECT_EQ(EscapeFontName("a\nERROR: forged"), "a\\nERROR: forged");
+  EXPECT_EQ(EscapeFontName("a\r\nb"), "a\\r\\nb");
+  EXPECT_EQ(EscapeFontName("a\tb"), "a\\tb");
+}
+
+TEST(TestGUIFontParsing, EscapeFontNameTruncatesAbsurdlyLongNames)
+{
+  const std::string huge(1000, 'x');
+  EXPECT_LE(EscapeFontName(huge).size(), 128U);
+}

--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -266,6 +266,9 @@ namespace XBMCAddon
       if (pGUIControl)
       {
         XBMCAddonUtils::GuiLock lock(languageHook, false);
+        // PythonSetLabel re-resolves the font at runtime; scope it to the owning
+        // window so an addon-defined <font> still resolves.
+        GUIFontManager::CScopeGuard fontScope(g_fontManager, GetParentWindowFontScopeKey());
         static_cast<CGUIButtonControl*>(pGUIControl)->PythonSetLabel(strFont, strText, textColor, shadowColor, focusedColor);
         static_cast<CGUIButtonControl*>(pGUIControl)->SetLabel2(strText2);
         static_cast<CGUIButtonControl*>(pGUIControl)->PythonSetDisabledColor(disabledColor);
@@ -682,6 +685,9 @@ namespace XBMCAddon
       if (pGUIControl)
       {
         XBMCAddonUtils::GuiLock lock(languageHook, false);
+        // PythonSetLabel re-resolves the font at runtime; scope it to the owning
+        // window so an addon-defined <font> still resolves.
+        GUIFontManager::CScopeGuard fontScope(g_fontManager, GetParentWindowFontScopeKey());
         static_cast<CGUIRadioButtonControl*>(pGUIControl)->PythonSetLabel(strFont, strText, textColor, shadowColor, focusedColor);
         static_cast<CGUIRadioButtonControl*>(pGUIControl)->PythonSetDisabledColor(disabledColor);
       }
@@ -743,6 +749,15 @@ namespace XBMCAddon
     // ============================================================
     // ============================================================
     Control::~Control() { deallocating(); }
+
+    String Control::GetParentWindowFontScopeKey() const
+    {
+      CGUIWindow* window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow(iParentId);
+      if (!window)
+        return {};
+
+      return window->GetProperty("fontscopekey").asString();
+    }
 
     CGUIControl* Control::Create()
     {

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -602,6 +602,11 @@ namespace XBMCAddon
 #endif
 
 #ifndef SWIG
+    protected:
+      //! \brief Font scope key of the window that owns this control.
+      String GetParentWindowFontScopeKey() const;
+
+    public:
       int iControlId = 0;
       int iParentId = 0;
       int dwPosX = 0;

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -15,6 +15,7 @@
 #include "guilib/GUIButtonControl.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIEditControl.h"
+#include "guilib/GUIFontManager.h"
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "input/actions/Action.h"
@@ -721,7 +722,13 @@ namespace XBMCAddon
         while (ref(window)->GetControl(pControl->iControlId));
       }
 
-      pControl->Create();
+      {
+        // Resolve <font> names against this window's addon font scope. The
+        // stack is thread_local, so pushing here cannot race the app thread.
+        // Empty for a non-WindowXML window, which pushes a harmless null scope.
+        GUIFontManager::CScopeGuard fontScope(g_fontManager, GetFontScopeKey());
+        pControl->Create();
+      }
 
       // set default navigation for control
       pControl->iControlUp = pControl->iControlId;

--- a/xbmc/interfaces/legacy/Window.h
+++ b/xbmc/interfaces/legacy/Window.h
@@ -245,6 +245,9 @@ namespace XBMCAddon
 
       SWIGHIDDENVIRTUAL void PulseActionEvent();
       SWIGHIDDENVIRTUAL bool WaitForActionEvent(unsigned int milliseconds);
+
+      //! \brief Font scope key of this window, empty unless it is a WindowXML.
+      virtual String GetFontScopeKey() const { return {}; }
 #endif
 
     public:

--- a/xbmc/interfaces/legacy/WindowXML.cpp
+++ b/xbmc/interfaces/legacy/WindowXML.cpp
@@ -17,6 +17,7 @@
 #include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonType.h"
 #include "guilib/GUIComponent.h"
+#include "guilib/GUIFontManager.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/TextureManager.h"
 #include "input/actions/Action.h"
@@ -89,7 +90,14 @@ namespace XBMCAddon
 
     };
 
-    WindowXML::~WindowXML() { XBMC_TRACE; deallocating();  }
+    WindowXML::~WindowXML()
+    {
+      XBMC_TRACE;
+      // Last chance to release the scope: a Python-held window can outlive its
+      // GUI teardown. A no-op if a skin change already Clear()ed the scope.
+      g_fontManager.UnloadFontScope(m_fontScopeKey);
+      deallocating();
+    }
 
     WindowXML::WindowXML(const String& xmlFilename,
                          const String& scriptPath,
@@ -143,10 +151,14 @@ namespace XBMCAddon
       }
 
       m_scriptPath = scriptPath;
-//      sXMLFileName = strSkinPath;
+      m_fontScopeKey = strSkinPath;
 
       interceptor = new WindowXMLInterceptor(this, lockingGetNextAvailableWindowId(),strSkinPath.c_str());
       setWindow(interceptor);
+      // Publish the scope key so a Control (which knows only its parent window
+      // id) can resolve fonts against this window's scope on setLabel. Mirrors
+      // the xmlfile property this class already round-trips.
+      ref(window)->SetProperty("fontscopekey", strSkinPath);
       interceptor->SetCoordsRes(res);
     }
 
@@ -424,6 +436,19 @@ namespace XBMCAddon
       URIUtils::RemoveSlashAtEnd(fallbackMediaPath);
       m_mediaDir = fallbackMediaPath;
 
+      // LoadFontsIntoScope is idempotent: it early-returns when the scope is
+      // already loaded, so a reopen does not re-parse. Passing a path that does
+      // not exist is fine and yields a loaded-but-empty scope. Load before the
+      // scope is pushed and before any control is created, so a control that
+      // resolves against this scope always sees it fully populated.
+      g_fontManager.LoadFontsIntoScope(m_fontScopeKey,
+                                       URIUtils::AddFileToFolder(tmpDir, "Font.xml"),
+                                       ref(window)->GetCoordsRes());
+
+      // Pushed even when there is no Font.xml (empty scope): this marks the
+      // window as an addon window and enables the fallback warning.
+      GUIFontManager::CScopeGuard fontScope(g_fontManager, m_fontScopeKey);
+
       //CLog::Log(LOGDEBUG, "CGUIPythonWindowXML::AllocResources called: {}", fallbackMediaPath);
       CServiceBroker::GetGUI()->GetTextureManager().AddTexturePath(m_mediaDir);
       ref(window)->AllocResources(forceLoad);
@@ -435,6 +460,13 @@ namespace XBMCAddon
       XBMC_TRACE;
 
       ref(window)->FreeResources(forceUnLoad);
+
+      // CGUIWindow::FreeResources only calls ClearAll(), destroying the
+      // controls that hold our raw CGUIFont*, when forceUnload is set. Addon
+      // windows are LOAD_ON_GUI_INIT, so an ordinary close keeps the controls
+      // alive and the fonts must outlive it.
+      if (forceUnLoad)
+        g_fontManager.UnloadFontScope(m_fontScopeKey);
     }
 
     void WindowXML::Process(unsigned int currentTime, CDirtyRegionList &regions)

--- a/xbmc/interfaces/legacy/WindowXML.h
+++ b/xbmc/interfaces/legacy/WindowXML.h
@@ -57,7 +57,64 @@ namespace XBMCAddon
     /// window.
     ///
     ///--------------------------------------------------------------------------
+    /// ### Add-on fonts
+    ///
+    /// A `<font>` name used by a control in your window xml is normally resolved
+    /// against the **active skin**. A skin that does not define the name you used
+    /// falls back to `font13`, so the same add-on renders differently from one
+    /// skin to the next.
+    ///
+    /// To fix that, place a **Font.xml** next to your window xml. The fonts it
+    /// declares are scoped to that one window: controls in the window resolve a
+    /// `<font>` name against this file first, then against the active skin, then
+    /// `font13`. A skin never sees your fonts, and you may safely reuse a name
+    /// the skin also defines.
+    ///
+    /// Declare only the **size** and the **style**. The typeface is always the
+    /// active skin's, so your window looks native on every skin and keeps
+    /// whatever script coverage the skinner chose.
+    ///
+    /// ~~~~~~~~~~~~~{.xml}
+    /// resources/skins/default/1080i/MyWindow.xml
+    /// resources/skins/default/1080i/Font.xml
+    ///
+    /// <!-- Font.xml -->
+    /// <fonts>
+    ///   <fontset id="Default">
+    ///     <font>
+    ///       <name>title</name>
+    ///       <size>46</size>
+    ///       <style>bold</style>
+    ///     </font>
+    ///   </fontset>
+    /// </fonts>
+    /// ~~~~~~~~~~~~~
+    ///
+    /// The `Default` fontset is used, or the first one declared if there is no
+    /// fontset with that id. The schema is the skin's, so `<style>`, `<aspect>`,
+    /// `<linespacing>`, `<color>` and `<shadow>` all work.
+    ///
+    /// The typeface is the file behind the skin's `font13`, or the first font the
+    /// skin loaded. Only the file is taken, never the skin's size, style or
+    /// colour, and it follows the fontset the user chose in settings. Bold and
+    /// italic are rendered from that same face, so `<style>` keeps working.
+    ///
+    /// \note An add-on cannot ship its own `.ttf`. A `<filename>` element is
+    /// ignored and a warning is logged. Which typeface a skin uses is the
+    /// skinner's decision, and an add-on cannot know which scripts a given user
+    /// needs covered.
+    ///
+    /// \note `<include>` elements are ignored.
+    ///
+    /// \note A `<font>` name that neither your Font.xml nor the skin defines
+    /// still falls back to `font13`, and now logs one warning per window load.
+    ///
+    /// An add-on that ships no Font.xml is unaffected.
+    ///
+    ///--------------------------------------------------------------------------
     /// @python_v18 New param added **isMedia**.
+    /// @python_v22 A **Font.xml** placed beside the window xml now registers
+    /// fonts scoped to that window.
     ///
     /// **Example:**
     /// ~~~~~~~~~~~~~{.py}
@@ -429,7 +486,13 @@ namespace XBMCAddon
       void SetupShares();
       String m_scriptPath;
       String m_mediaDir;
+      //! Resolved window XML path. The scope key: unique per window, stable
+      //! across reopens. NOT m_scriptPath, which every window of one addon
+      //! shares, which would make them share and prematurely free fonts.
+      String m_fontScopeKey;
       bool m_isMedia;
+
+      String GetFontScopeKey() const override { return m_fontScopeKey; }
 
       friend class WindowXMLInterceptor;
 #endif
@@ -458,6 +521,10 @@ namespace XBMCAddon
     /// \python_class{ xbmcgui.WindowXMLDialog(xmlFilename, scriptPath[, defaultSkin, defaultRes]) }
     ///
     /// Creates a new xml file based window dialog class.
+    ///
+    /// \note A **Font.xml** beside this dialog's xml registers fonts scoped to
+    /// the dialog, exactly as for \ref python_xbmcgui_window_xml. A dialog owns
+    /// its fonts independently of the window that opened it.
     ///
     /// @param xmlFilename              string - the name of the xml file to
     ///                                 look for.


### PR DESCRIPTION

Depends on #28582. Please merge that first; this branch is based on it.

**Scaled down on review.** Add-ons no longer ship font files. A scoped font always uses the active skin's own typeface; the add-on declares the size and the style and nothing else. A `<filename>` in an add-on `Font.xml` is ignored with a warning. That removed the filename confinement check, the extra search directory, and the pool-keying commit, which is the entire untrusted-file surface.

Following review on #28582, the `FontEntry` merge now lives here rather than there, since the scoped design is what needs it. #28582 is reduced to the one fix reachable on master.

Fixes #28534.

## Description

An add-on that builds its UI with `xbmcgui.WindowXMLDialog` controls its own XML layout, its
textures, its navigation and its logic, but not its typography. A control's `<font>` may only
name a font the **active skin** defines. Where it does not, `GUIFontManager::GetFont` silently
falls back to `font13`, with nothing in the log.

This change lets an add-on ship a `Font.xml` beside its window XML. Its windows then resolve
`<font>` names against their own scope first, then the skin, then `font13`.

An add-on does not ship a `.ttf` at all. **The typeface is always the active skin's**, so the
add-on declares only the sizes and styles it wants and still looks native on every skin:

```xml
<font>
  <name>title</name>
  <size>46</size>
  <style>bold</style>
</font>
```

The inherited face is the file behind the skin's `font13`, or the first font the skin loaded. That
is the one numbered name every skin defines, and in practice it is the skin's body face
(`NotoSans-Regular.ttf` on Estuary, `MC360.ttf` on Arctic Zephyr Mod). Only the file is inherited,
never the skin's size, style or colour, and it follows the fontset the user chose in settings. Bold
and italic are synthesised from that face, so `<style>` keeps working.

A `<filename>` in an add-on `Font.xml` is ignored and logged at `LOGWARNING`. Shipping a face was
cut on review: the typeface is the skin's prerogative, and an add-on cannot know which scripts the
user needs covered, so a Latin-only add-on face would render `.notdef` boxes with no recourse for
the skinner.

Implementation:

- `GUIFontManager` gains per-window font scopes: a `std::map<std::string, FontScope>` keyed on the
  **resolved window XML path**, guarded by `m_critSection`, plus a `thread_local` resolution stack.
  The stack must be per-thread because `Control::Create` resolves fonts on the add-on's Python
  thread, invoked from `Window::doAddControl` outside the `MaybeLock` there.
- Scopes are pushed in the three places a `<font>` name is resolved: `WindowXML::AllocResources`,
  `Window::doAddControl`, and `ControlButton`/`ControlRadioButton::setLabel`. All three live in
  `interfaces/legacy`. **`CGUIControlFactory` and the `guilib` control classes are untouched.**
- A scope's `CGUIFont` objects are freed only when the controls pointing at them are destroyed,
  i.e. on `FreeResources(forceUnload=true)` and in `~WindowXML`. Add-on windows are
  `LOAD_ON_GUI_INIT`, so an ordinary close keeps the controls alive and the fonts must outlive it.
- An add-on's `Font.xml` is untrusted input. `<include>` children are stripped rather than passed
  to the active skin's `ResolveIncludes` (which would load add-on-referenced files into
  skin-global include state and register add-on expressions into the global InfoManager);
  and add-on controlled names are escaped before they reach the log. There is no file path to
  validate, since the typeface always comes from the skin.
- A font named by neither the add-on nor the skin now logs one `LOGWARNING` per distinct name per
  window load, instead of silently collapsing to `font13`. Skin windows never warn.

## Motivation and context

Fixes #28534. On a skin such as `skin.arctic.zephyr.mod`, which among numbered names defines only
`font13`, every `font10`/`font12`/`font14` reference in an add-on dialog collapses to the same
~30px face. The size hierarchy disappears: titles render at body size. The same add-on XML looks
correct on Estuary and wrong on Arctic, and the author has no API to detect or correct it.

Existing workarounds are all poor. `<font>` is not an info expression, so `$INFO`/`$VAR` cannot
select a font. There is no `setFont()` on `xbmcgui` control classes. Parsing the active skin's
`Font.xml` at runtime and regenerating substituted XML is fragile and duplicates the skin's font
logic in every add-on.

## How has this been tested?

Unit tests (`kodi-test`, 22 cases across `TestGUIFontParsing.cpp` and `TestGUIFontManager.cpp`):
fontset parsing, `<include>` stripping, log-name escaping, scope push/pop and nesting, RAII pop on
exception, per-scope warning dedup, per-thread scope stacks, and that unloading an absent scope is
a silent no-op. Full suite 3440 of 3441, the one failure being `TestNetwork.PingHost`, an
environment limitation of my machine (`net.ipv4.ping_group_range`).

Manually, on Linux/x11/GL, driving a purpose-built add-on that ships a `Font.xml`:

- **Lifetime.** A dialog opened from a window, then the parent closed, deleted and garbage
  collected. The dialog keeps rendering its own fonts and accepts a later `setLabel`. Keying the
  scope on the add-on script path instead would free the dialog's fonts here, because
  `WindowXMLDialog` shares its parent's `scriptPath`.
- **Skin independence.** The dialog's `font12` label has a white-glyph bounding box of exactly
  1409x46 under Estuary (which defines `font12`) and under a skin carrying Arctic Zephyr Mod's real
  font set (which does not). Identical geometry, identical face and size.
- **Skin change with add-on windows open.** Estuary -> Arctic-font skin -> Estuary via JSON-RPC
  while a `WindowXML` and a `WindowXMLDialog` were showing. No crash: each window gets
  `FreeResources(forceUnload=true)`, whose `ClearAll()` destroys the controls, and only then does
  `Clear()` drop the scopes.
- **Resize.** A fullscreen toggle re-rasterises scoped fonts via `ReloadTTFFonts`, no stale glyphs.
- **Reopen.** Closing and re-showing the same window parses `Font.xml` zero further times.
- **Security.** `<include>` stripped; `/etc/passwd.ttf`, `special://home/media/Fonts/arial.ttf` and
  `../../../../etc/x.ttf` all rejected and logged; neither loads.
- **Warning dedup.** A missing font named by two controls logs exactly one warning. Skin windows
  log none.
- **Inherited typeface.** A `<font>` declaring only `<size>` and `<style>` rendered in
  `NotoSans-Regular.ttf` under Estuary, `MC360.ttf` under a skin carrying Arctic Zephyr Mod's font
  set, and `Inter-Regular.ttf` under Arctic Fuse 3, at the add-on's size, bold in all three. Same
  add-on, unmodified.
- **Inheritance survives skin indirection.** Arctic Fuse declares its fonts through
  `<include content="Font_Default">` with `$PARAM` substitution: its `font13` is literally
  `<filename>$PARAM[font_regular]</filename>`. The inherited file is read after the include engine
  has resolved it, so this works. With Fuse's `Default (Unicode)` fontset the inherited value is
  `resource://resource.font.robotocjksc/Inter-Unicode-Regular.ttf`; `LoadTTF` takes its existing
  `CURL::IsFullPath` branch and the font renders. An inherited file skips the add-on
  path-confinement check by design: it comes from the skin, not from the add-on.
- **Own file beats the skin's.** An add-on shipping a serif face named `NotoSans-Regular.ttf`, a
  name Estuary also ships, renders its own serif rather than Estuary's sans.

Full suite: 1028 of 1029 pass. The one failure, `TestNetwork.PingHost`, is an environment
limitation of the test machine (`net.ipv4.ping_group_range` is `1 0`) and is unrelated.
`clang-format` clean on each commit individually.

**What is not covered by automated tests, and why.** `guilib` has no GL test harness:
`TestBasicEnvironment` registers no `CWinSystemBase`, so `LoadTTF` returns early at its `LOGFATAL`
guard and nothing that rasterises a glyph can run under `kodi-test`. The pure logic is unit-tested;
the end-to-end behaviour above is manual. I am happy to add a harness if the team wants one.

## Known limitation, pre-existing and unrelated

`setLabel(font=...)` correctly pushes the add-on scope (verified: a missing name warns naming the
add-on's dialog), but the new font never reaches the screen. `CGUILabel` passes `labelInfo.font`
to `CGUITextLayout` at construction, and `CGUITextLayout` exposes only `SetMonoFont`, so
`CGUIButtonControl::PythonSetLabel`'s `m_label.GetLabelInfo().font = ...` cannot affect rendering,
for any font, scoped or skin. This reproduces on unmodified `master`. Filed separately as
#28581. The scope guard here is correct and becomes effective once that is fixed.

## What is the effect on users?

Purely additive. An add-on that ships no `Font.xml` gets a loaded-but-empty scope and behaves
exactly as today. No skin changes. Add-on authors can now ship their own fonts and get the same
typography on every skin.

The one visible difference for existing add-ons: a `<font>` name defined by neither the add-on nor
the skin now produces one `WARNING` per window load naming the font and the window, where before it
was silent.

## Screenshots
<img width="1584" height="498" alt="prinherit3skins" src="https://github.com/user-attachments/assets/e264dc29-1dee-4a49-95c3-7d915261a7b8" />

<img width="1540" height="540" alt="prf1dialogsurvives" src="https://github.com/user-attachments/assets/c87c7c00-780b-42e8-84b9-f891e98324b8" />

<img width="1540" height="400" alt="prf4nopoolcollision" src="https://github.com/user-attachments/assets/2b8ff42d-7d30-47bc-a6a8-2c9be7d209c9" />


## Types of change

- [X] **New feature** (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the Code Guidelines of this project
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the Contributing document
- [X] I have added tests to cover my change  <!-- pure seams only; see above -->

### Documentation

The Python API reference is generated from the Doxygen in `xbmc/interfaces/legacy/WindowXML.h`, so
this PR documents the feature there: where `Font.xml` goes, the schema, the scoping and fallback
rules, and a `@python_v22` note. `WindowXMLDialog` gets a short note that
it owns its fonts independently of the window that opened it.

The **wiki** (https://kodi.wiki/view/Add-on_development) also needs a paragraph. That lives outside
this repository, so it is not part of this PR. Happy to write it once this lands, or to hand the
text to whoever maintains that page.



