### PR TITLE
osx: fall back to software rendering if no accelerated GL context is available

### DIFF
--- a/xbmc/windowing/osx/OpenGL/OSXGLView.mm
+++ b/xbmc/windowing/osx/OpenGL/OSXGLView.mm
@@ -12,6 +12,8 @@
 #include "utils/log.h"
 #import "windowing/osx/WinSystemOSX.h"
 
+#include <vector>
+
 #include "system_gl.h"
 
 @implementation OSXGLView
@@ -31,36 +33,48 @@
 
 - (id)initWithFrame:(NSRect)frameRect
 {
-  // clang-format off
-  NSOpenGLPixelFormatAttribute wattrs[] = {
-    NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core,
-    NSOpenGLPFAAccelerated,
-    NSOpenGLPFAAlphaSize, 8,
-    NSOpenGLPFAColorSize, 32,
-    NSOpenGLPFADepthSize, 24,
-    NSOpenGLPFADoubleBuffer,
-    NSOpenGLPFANoRecovery,
-    0
-  };
-  // clang-format on
-  auto createGLContext = [&wattrs]
+  auto createGLContext = [](NSOpenGLPixelFormatAttribute profile, bool accelerated)
   {
-    auto pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:wattrs];
+    // clang-format off
+    std::vector<NSOpenGLPixelFormatAttribute> wattrs = {
+      NSOpenGLPFAOpenGLProfile, profile,
+    };
+    if (accelerated)
+      wattrs.push_back(NSOpenGLPFAAccelerated);
+    wattrs.insert(wattrs.end(), {
+      NSOpenGLPFAAlphaSize, 8,
+      NSOpenGLPFAColorSize, 32,
+      NSOpenGLPFADepthSize, 24,
+      NSOpenGLPFADoubleBuffer,
+      NSOpenGLPFANoRecovery,
+      0
+    });
+    // clang-format on
+
+    auto pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:wattrs.data()];
     return [[NSOpenGLContext alloc] initWithFormat:pixelFormat shareContext:nil];
   };
 
   self = [super initWithFrame:frameRect];
   if (self)
   {
-    m_glcontext = createGLContext();
+    m_glcontext = createGLContext(NSOpenGLProfileVersion3_2Core, true);
     if (!m_glcontext)
     {
       CLog::Log(LOGERROR,
                 "failed to create NSOpenGLContext, falling back to legacy OpenGL profile");
-
-      wattrs[1] = NSOpenGLProfileVersionLegacy;
-      m_glcontext = createGLContext();
-      assert(m_glcontext);
+      m_glcontext = createGLContext(NSOpenGLProfileVersionLegacy, true);
+    }
+    if (!m_glcontext)
+    {
+      CLog::Log(LOGWARNING, "failed to create accelerated NSOpenGLContext, falling back to a "
+                            "software-rendered context");
+      m_glcontext = createGLContext(NSOpenGLProfileVersionLegacy, false);
+    }
+    if (!m_glcontext)
+    {
+      CLog::Log(LOGERROR, "failed to create any NSOpenGLContext");
+      return nil;
     }
   }
   self.wantsBestResolutionOpenGLSurface = YES;


### PR DESCRIPTION
## Description
Add a third attempt that drops NSOpenGLPFAAccelerated, falling back to Apple's software renderer. Real hardware is unaffected - the accelerated attempts are tried first, in the same order as before.

## Motivation and context
Running Kodi in GitHub-hosted macos-14 CI runner

## How has this been tested?
Running in Github CI and capturing screenshot 

## What is the effect on users?
Can run on MacOS without GPU acceleration


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
