### PR TITLE
guilib: fix CGLTexture::SupportsFormat to check actual swizzle support

### DIFF
--- a/xbmc/guilib/TextureBase.cpp
+++ b/xbmc/guilib/TextureBase.cpp
@@ -16,6 +16,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cstdint>
 #include <cstring>
 #include <exception>
@@ -407,6 +408,8 @@ void CTextureBase::SetKDFormat(XB_FMT xbFMT)
 
 bool CTextureBase::ConvertToLegacy(uint32_t width, uint32_t height, uint8_t* src)
 {
+  // Covers only the swizzles TexturePacker emits today; SwizzleMap also lists RGB1/GGG1/111G/
+  // GGGA/GGGG, which fall through to a hard upload failure below if TexturePacker ever emits them.
   if (m_textureFormat == KD_TEX_FMT_SDR_BGRA8 && m_textureSwizzle == KD_TEX_SWIZ_RGBA)
   {
     m_format = XB_FMT_A8R8G8B8;
@@ -417,15 +420,22 @@ bool CTextureBase::ConvertToLegacy(uint32_t width, uint32_t height, uint8_t* src
   {
     if (m_textureSwizzle != KD_TEX_SWIZ_111R && m_textureSwizzle != KD_TEX_SWIZ_RRR1 &&
         m_textureSwizzle != KD_TEX_SWIZ_RRRR)
+    {
+      assert(false && "TexturePacker is not expected to emit this R8 swizzle; add a case here");
       return false;
+    }
   }
   else if (m_textureFormat == KD_TEX_FMT_SDR_RG8)
   {
     if (m_textureSwizzle != KD_TEX_SWIZ_RRRG)
+    {
+      assert(false && "TexturePacker is not expected to emit this RG8 swizzle; add a case here");
       return false;
+    }
   }
   else
   {
+    assert(false && "TexturePacker is not expected to emit this format/swizzle; add a case here");
     return false;
   }
 

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -292,28 +292,43 @@ void CGLTexture::BindToUnit(unsigned int unit)
 
 void CGLTexture::SetSwizzle()
 {
+  GLenum swizzleTarget = GetSwizzleTarget();
+  if (swizzleTarget == GL_FALSE)
+    return;
+
   if (!SwizzleMap.contains(m_textureSwizzle))
     return;
 
   Textureswizzle swiz = SwizzleMap.at(m_textureSwizzle);
+  glTexParameteriv(GL_TEXTURE_2D, swizzleTarget, &swiz.r);
+}
 
-  // GL_TEXTURE_SWIZZLE_RGBA and GL_TEXTURE_SWIZZLE_RGBA_EXT should be the same
-  // token, but just to be sure...
+bool CGLTexture::SupportsFormat(KD_TEX_FMT textureFormat, KD_TEX_SWIZ textureSwizzle)
+{
+  // Non-identity swizzles need GL_ARB/EXT_texture_swizzle to be applied by SetSwizzle(),
+  // otherwise the texture is sampled with the wrong channel mapping.
+  return textureSwizzle == KD_TEX_SWIZ_RGBA || GetSwizzleTarget() != GL_FALSE;
+}
+
+GLenum CGLTexture::GetSwizzleTarget()
+{
+  if (m_swizzleTarget)
+    return *m_swizzleTarget;
+
+  // GL_TEXTURE_SWIZZLE_RGBA and GL_TEXTURE_SWIZZLE_RGBA_EXT should be the same token, but just
+  // to be sure we cache whichever one this GL implementation actually supports.
+  m_swizzleTarget = GL_FALSE;
 #if defined(GL_VERSION_3_3) || (GL_ARB_texture_swizzle)
   if (m_isOglVersion33orNewer ||
       CGLExtensions::IsExtensionSupported(CGLExtensions::ARB_texture_swizzle))
-  {
-    glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA, &swiz.r);
-    return;
-  }
+    m_swizzleTarget = GL_TEXTURE_SWIZZLE_RGBA;
 #endif
 #if defined(GL_EXT_texture_swizzle)
-  if (CGLExtensions::IsExtensionSupported(CGLExtensions::EXT_texture_swizzle))
-  {
-    glTexParameteriv(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_RGBA_EXT, &swiz.r);
-    return;
-  }
+  if (*m_swizzleTarget == GL_FALSE &&
+      CGLExtensions::IsExtensionSupported(CGLExtensions::EXT_texture_swizzle))
+    m_swizzleTarget = GL_TEXTURE_SWIZZLE_RGBA_EXT;
 #endif
+  return *m_swizzleTarget;
 }
 
 TextureFormat CGLTexture::GetFormatGL(KD_TEX_FMT textureFormat)

--- a/xbmc/guilib/TextureGL.h
+++ b/xbmc/guilib/TextureGL.h
@@ -10,6 +10,8 @@
 
 #include "Texture.h"
 
+#include <optional>
+
 #include "system_gl.h"
 
 struct TextureFormat
@@ -44,10 +46,7 @@ public:
   void SyncGPU() override;
   void BindToUnit(unsigned int unit) override;
 
-  bool SupportsFormat(KD_TEX_FMT textureFormat, KD_TEX_SWIZ textureSwizzle) override
-  {
-    return true;
-  }
+  bool SupportsFormat(KD_TEX_FMT textureFormat, KD_TEX_SWIZ textureSwizzle) override;
 
   // GL interface
   GLuint GetTextureID() const;
@@ -56,8 +55,15 @@ protected:
   void SetSwizzle();
   TextureFormat GetFormatGL(KD_TEX_FMT textureFormat);
 
+  // Probed lazily, not in the constructor: instances can exist before InitRenderSystem() runs
+  // (e.g. CWinSystemX11::CreateIconPixmap()), and IsExtensionSupported() caches forever.
+  GLenum GetSwizzleTarget();
+
   GLuint m_texture{0};
   bool m_isOglVersion3orNewer{false};
   bool m_isOglVersion33orNewer{false};
+
+private:
+  std::optional<GLenum> m_swizzleTarget;
 };
 


### PR DESCRIPTION
CGLTexture::SupportsFormat unconditionally returned true regardless of
swizzle, unlike CGLESTexture's equivalent which correctly checks
whether the GL implementation can actually apply one. SetSwizzle()
already silently no-ops when neither GL_ARB_texture_swizzle nor
GL_EXT_texture_swizzle is available, so on such a GL implementation a
non-identity-swizzle texture (e.g. a gradient/shadow alpha mask) got
uploaded and sampled with the wrong channel mapping instead of being
routed through CTexture::ConvertToLegacy()'s existing CPU-side
conversion.

This went unnoticed because essentially every real GPU driver advertises one of those extensions. It surfaced via the E2E POC's new screenshot check against Apple's software renderer (used by the previous commit's accelerated-context fallback), whose GL 2.1 context advertises neither extension - visible as solid green fills replacing what should be gradient/shadow overlays in the Estuary skin.

## Screenshots (if appropriate):
Before: 
<img width="1920" height="1080" alt="screenshot00000" src="https://github.com/user-attachments/assets/63fa07d9-2370-4fe3-b288-f3754f78a4af" />

After: 
<img width="1920" height="1080" alt="screenshot00001" src="https://github.com/user-attachments/assets/30d928d7-ae09-4a13-9c1e-43e6fa9fc2e6" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
