### PR TITLE
[cmake] FindGTest package search names are case sensitive

### DIFF
--- a/cmake/modules/FindGtest.cmake
+++ b/cmake/modules/FindGtest.cmake
@@ -39,6 +39,9 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
   endmacro()
 
   set(${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC gtest)
+  # search calls are case sensitive
+  set(${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME GTest)
+  set(${CMAKE_FIND_PACKAGE_NAME}_SEARCH_NAME_PC gtest)
 
   SETUP_BUILD_VARS()
 


### PR DESCRIPTION
## Description
cmake package search names are case sensitive. Fix immediate linux build failures by not failing the config search first.

## Motivation and context
Fixes current jenkins linux job failures when not building gtest.
There are actually two issues here. 
  1) find_package search to gtest was not succeeding, and then fell through to a pkgconfig search. In general the cmake config should always succeed. Debian ships cmake config files for libgtest-dev, and default build of gtest installs cmake config files
  2) The second issue is that when debug gtest is built, it adds a d postfix, the incorrect lib name is set in the pc file (``-lgtest`` instead of ``-lgtestd``), and therefore it cant be found. This is actually a hard problem, as a pc file is only for a single build type, whereas a cmake config can have multiple variants info provided. A solution for upstream is always going to be messy, so ive just left this with our understanding that a cmake config should always succeed for our purposes rather than trying to add a patch for an extreme corner case once issue 1 is resolved.

## How has this been tested?
linux test build. Inspected cmake link files, and cmake debug data showing config now succeeds in the failure case.

## What is the effect on users?
N/A

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
