### PR TITLE
[Subtitles] Safely handle missing family_name from FT_Face

### DIFF
--- a/xbmc/utils/FontUtils.cpp
+++ b/xbmc/utils/FontUtils.cpp
@@ -120,6 +120,14 @@ bool GetFontFamilyNames(const std::vector<uint8_t>& buffer, std::set<std::string
     std::string familyName = GetFamilyNameFromSfnt(face);
     if (familyName.empty())
     {
+      if (!face->family_name)
+      {
+        CLog::LogF(LOGERROR, "Family name missing in the font");
+        FT_Done_Face(face);
+        FT_Done_FreeType(m_library);
+        return false;
+      }
+
       CLog::LogF(LOGWARNING, "Failed to get the unicode family name for \"{}\", fallback to ASCII",
                  face->family_name);
       // ASCII font family name may differ from the unicode one, use this as fallback only
@@ -127,6 +135,8 @@ bool GetFontFamilyNames(const std::vector<uint8_t>& buffer, std::set<std::string
       if (familyName.empty())
       {
         CLog::LogF(LOGERROR, "Family name missing in the font");
+        FT_Done_Face(face);
+        FT_Done_FreeType(m_library);
         return false;
       }
     }
@@ -179,7 +189,7 @@ std::string GetFontFamily(std::vector<uint8_t>& buffer)
   }
 
   // Load the font face
-  FT_Face face;
+  FT_Face face{nullptr};
   std::string familyName;
   if (FT_New_Memory_Face(m_library, reinterpret_cast<const FT_Byte*>(buffer.data()), buffer.size(),
                          0, &face) == 0)
@@ -187,6 +197,14 @@ std::string GetFontFamily(std::vector<uint8_t>& buffer)
     familyName = GetFamilyNameFromSfnt(face);
     if (familyName.empty())
     {
+      if (!face->family_name)
+      {
+        CLog::LogF(LOGERROR, "Family name missing in the font");
+        FT_Done_Face(face);
+        FT_Done_FreeType(m_library);
+        return "";
+      }
+
       CLog::LogF(LOGWARNING, "Failed to get the unicode family name for \"{}\", fallback to ASCII",
                  face->family_name);
       // ASCII font family name may differ from the unicode one, use this as fallback only


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Custom fonts placed in .kodi/media/Fonts/ that have no family_name (or corrupted font files) caused Kodi to get stuck on the logo screen when calling CLog::LogF().

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It checks family_name before using it.
Free memory with FT_Done_Face() and FT_Done_FreeType() on error paths.
Moved FT_Done_Face() in function GetFontFamily() where FT_New_Memory_Face() succeed.
If FT_New_Memory_Face() fails then FT_Done_Face() crashes.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On LibreELEC-Generic.x86_64-13.0-nightly-20260711-3a340a8

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Using custom font without family_name still loads Kodi.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
