### PR TITLE
[Windows] Fix font glitches

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -1152,29 +1152,30 @@ void CGUIFontTTF::RenderCharacter(CGraphicContext& context,
 
 #if defined(HAS_DX)
   // D3D: triangle lists
+  // D3D rasterizer uses half-pixel-center convention; no nudge needed.
 
   v[0].u = tl;
   v[0].v = tt;
-  v[0].x = vertex.x1 - xOffset - 0.5f;
-  v[0].y = vertex.y1 - yOffset - 0.5f;
+  v[0].x = vertex.x1 - xOffset;
+  v[0].y = vertex.y1 - yOffset;
   v[0].z = 0;
 
   v[1].u = tr;
   v[1].v = tt;
-  v[1].x = vertex.x2 - xOffset + 0.5f;
-  v[1].y = vertex.y1 - yOffset - 0.5f;
+  v[1].x = vertex.x2 - xOffset;
+  v[1].y = vertex.y1 - yOffset;
   v[1].z = 0;
 
   v[2].u = tr;
   v[2].v = tb;
-  v[2].x = vertex.x2 - xOffset + 0.5f;
-  v[2].y = vertex.y2 - yOffset + 0.5f;
+  v[2].x = vertex.x2 - xOffset;
+  v[2].y = vertex.y2 - yOffset;
   v[2].z = 0;
 
   v[3].u = tl;
   v[3].v = tb;
-  v[3].x = vertex.x1 - xOffset - 0.5f;
-  v[3].y = vertex.y2 - yOffset + 0.5f;
+  v[3].x = vertex.x1 - xOffset;
+  v[3].y = vertex.y2 - yOffset;
   v[3].z = 0;
 #else
   // GL / GLES uses triangle strips, not quads, so have to rearrange the vertex order

--- a/xbmc/guilib/GUIFontTTFDX.cpp
+++ b/xbmc/guilib/GUIFontTTFDX.cpp
@@ -319,15 +319,28 @@ std::unique_ptr<CTexture> CGUIFontTTFDX::ReallocTexture(unsigned int& newHeight)
     return nullptr;
   }
 
+  ComPtr<ID3D11DeviceContext> pContext = DX::DeviceResources::Get()->GetImmediateContext();
+  if (!pContext)
+    return nullptr;
+
   // There might be data to copy from the previous texture
-  if (newSpeedupTexture && m_speedupTexture)
+  if (m_speedupTexture)
   {
     CD3D11_BOX rect(0, 0, 0, m_textureWidth, m_textureHeight, 1);
-    ComPtr<ID3D11DeviceContext> pContext = DX::DeviceResources::Get()->GetImmediateContext();
     pContext->CopySubresourceRegion(newSpeedupTexture->Get(), 0, 0, 0, 0, m_speedupTexture->Get(),
                                     0, &rect);
   }
 
+  // Zero the previously unused part of the resource
+  //! @todo avoid the CPU/GPU synchronization with a GPU clear
+  if (newHeight > m_textureHeight)
+  {
+    const unsigned int startRow = m_speedupTexture ? m_textureHeight : 0;
+    CD3D11_BOX rect(0, startRow, 0, m_textureWidth, newHeight, 1);
+    std::vector<uint8_t> black(m_textureWidth * (newHeight - startRow), 0);
+    pContext->UpdateSubresource(newSpeedupTexture->Get(), 0, &rect, black.data(), m_textureWidth,
+                                0);
+  }
   m_texture.reset();
 
   m_textureHeight = newHeight;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follow up of #28483 to address a couple glitches / differences between D3D and OpenGL/GLES

- Coordinates are center-pixel in D3D already, no need for half-pixel adjustments

- Zero initialize the font atlas textures before use. Uninitialized textures didn't matter until #24605 extended the texture coordinates beyond the glyph. The memory was often zeroed already but that can't be relied on and the textures accumulated noise after moving from screen to screen.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

AMD Intel NVidia Warp software renderer.
The font texture was not zero-initialized under Renderdoc which made the problem more visible > no artifacts with the PR

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

No visual artifacts around characters after moving Kodi between screens of different resolutions

## Screenshots (if appropriate):

Before:
<img width="572" height="115" alt="image" src="https://github.com/user-attachments/assets/a7e4dc2b-02fc-4980-b850-c4a26708f283" />

After:
<img width="555" height="112" alt="image" src="https://github.com/user-attachments/assets/6863552b-b4ad-43a5-9d10-943450e17168" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
