### PR TITLE
[Android] Introduce ACCESS_LOCAL_NETWORK manifest permission for SDK 37+

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <uses-feature

--- a/tools/android/packaging/xbmc/src/Splash.java.in
+++ b/tools/android/packaging/xbmc/src/Splash.java.in
@@ -57,12 +57,15 @@ public class Splash extends Activity
   private static final int CheckExternalStorage = 12;
   private static final int RecordAudioPermission = 13;
   private static final int RecordAudioInfo = 14;
+  private static final int AccessLocalNetworkPermission = 15;
+  private static final int AccessLocalNetworkInfo = 16;
   private static final int StartingXBMC = 99;
 
   private static final String TAG = "@APP_NAME@";
 
   private static final int RECORDAUDIO_RESULT_CODE = 8946;
   private static final int PERMISSION_RESULT_CODE = 8947;
+  private static final int LOCAL_NETWORK_RESULT_CODE = 8948;
 
   private String mErrorMsg = "";
 
@@ -110,7 +113,14 @@ public class Splash extends Activity
           break;
         case RecordAudioPermission:
           requestPermissions(new String[]{Manifest.permission.RECORD_AUDIO},
-                  RECORDAUDIO_RESULT_CODE);
+                             RECORDAUDIO_RESULT_CODE);
+          break;
+        case AccessLocalNetworkInfo:
+          showInfoDialog(getString(R.string.networkperm_dialog, "@APP_NAME@"), AccessLocalNetworkPermission);
+          break;
+        case AccessLocalNetworkPermission:
+          requestPermissions(new String[]{Manifest.permission.ACCESS_LOCAL_NETWORK},
+                             LOCAL_NETWORK_RESULT_CODE);
           break;
         case CheckingPermissions:
           if (Build.VERSION.SDK_INT >= 33 || (Build.VERSION.SDK_INT >= 30 && !isAndroidTV()))
@@ -528,6 +538,18 @@ public class Splash extends Activity
       if (permissionCheck == PERMISSION_GRANTED)
         retVal = true;
     }
+
+    if (Build.VERSION.SDK_INT >= 37)
+    {
+      int permissionCheck;
+      permissionCheck = checkSelfPermission(Manifest.permission.ACCESS_LOCAL_NETWORK);
+      if (permissionCheck == PERMISSION_GRANTED)
+      {
+        retVal &= true;
+      } else {
+        retVal = false;
+      }
+    }
     return retVal;
   }
 
@@ -549,7 +571,27 @@ public class Splash extends Activity
       }
       case RECORDAUDIO_RESULT_CODE:
       {
-        mStateMachine.sendEmptyMessage(CheckingPermissionsDone);
+        // ACCESS_LOCAL_NETWORK manifest permission checks from SDK37+
+        if (Build.VERSION.SDK_INT >= 37) {
+          mStateMachine.sendEmptyMessage(AccessLocalNetworkInfo);
+        } else {
+          mStateMachine.sendEmptyMessage(CheckingPermissionsDone);
+        }
+        break;
+      }
+      case LOCAL_NETWORK_RESULT_CODE:
+      {
+        int permissionCheck;
+        permissionCheck = checkSelfPermission(Manifest.permission.ACCESS_LOCAL_NETWORK);
+        if (permissionCheck == PERMISSION_GRANTED) {
+          mPermissionOK &= true;
+          mStateMachine.sendEmptyMessage(CheckingPermissionsDone);
+        } else {
+          mPermissionOK = false;
+          mErrorMsg = getString(R.string.permission_denied);
+          mStateMachine.sendEmptyMessage(InError);
+        }
+        break;
       }
     }
   }
@@ -565,6 +607,13 @@ public class Splash extends Activity
         mPermissionOK = true;
       }
       mStateMachine.sendEmptyMessage(RecordAudioInfo);
+    }
+    else if (requestCode == RECORDAUDIO_RESULT_CODE)
+    {
+      if (Build.VERSION.SDK_INT >= 37)
+      {
+        mStateMachine.sendEmptyMessage(AccessLocalNetworkInfo);
+      }
     }
   }
 

--- a/tools/android/packaging/xbmc/strings.xml.in
+++ b/tools/android/packaging/xbmc/strings.xml.in
@@ -12,6 +12,7 @@
     <string name="info_title">Info</string>
     <string name="exit_button">Exit</string>
     <string name="notice_dialog">%1$s requires access to your device media and files to function. Please allow this via the following dialogue box or %1$s will exit.</string>
+    <string name="networkperm_dialog">%1$s requires access to your network to function. Please allow this via the following dialogue box or %1$s will exit.</string>
     <string name="record_audio_dialog">%1$s asks for permission to record audio. This is only used for voice search. Please allow or deny this in the following dialogue box.</string>
     <string name="asking_permissions">Asking for permissions…</string>
     <string name="clearing_cache">Clearing cache…</string>


### PR DESCRIPTION
## Description
Introduce ACCESS_LOCAL_NETWORK manifest permission for SDK 37+.
Android 17 introduces a new permission for network usage. This effects things like pvr addons (eg pvr.hdhomerun doesnt populate/work) network filesystems (eg. NFS doesnt search and cant manually connect to NFS share)

## Motivation and context
Fixes #28557

@joseluismarti mind running your eyes over these, or even if you want to improve it in some manner. Im not really across the android stuff, so happy for any info/direction you can provide.

One thing i noticed, the ``CheckingPermissions*`` stuff should probably not be named so generic. its only checking a specific permission itself, so should probably be renamed to suit.
From what i understand, the multiple permissions requests in a single function doesnt really work well when there are SDK version requirements. Is there a better "modern" way to handle requests?

## How has this been tested?
Pixel 10a android 17 before network usage doesnt work, after patch, permission is requested, and network services work.

## What is the effect on users?
Android 17 users can use network services (addons/network filesystems etc)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
