### PR TITLE
[Video][Database] Fix incomplete removal of movies when source content set to none.

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -55,7 +55,6 @@
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/XMLUtils.h"
-#include "utils/i18n/TableLanguageCodes.h"
 #include "utils/log.h"
 #include "video/VideoDatabaseColumns.h"
 #include "video/VideoDatabaseDDL.h"
@@ -300,7 +299,9 @@ int CVideoDatabase::RunQuery(const std::string &sql)
   return rows;
 }
 
-bool CVideoDatabase::GetSubPaths(const std::string &basepath, std::vector<std::pair<int, std::string>>& subpaths)
+bool CVideoDatabase::GetSubPaths(const std::string& basepath,
+                                 std::vector<std::pair<int, std::string>>& subpaths,
+                                 bool excludeDiscPaths /* = true */)
 {
   std::string sql;
   try
@@ -308,13 +309,29 @@ bool CVideoDatabase::GetSubPaths(const std::string &basepath, std::vector<std::p
     if (!m_pDB || !m_pDS)
       return false;
 
+    // Generate encoded paths
     std::string path(basepath);
     URIUtils::AddSlashAtEnd(path);
-    sql = PrepareSQL(
-        "SELECT idPath,strPath FROM path WHERE SUBSTR(strPath,1,%i)='%s'"
-        " AND idPath NOT IN (SELECT idPath FROM files WHERE strFileName LIKE 'video_ts.ifo')"
-        " AND idPath NOT IN (SELECT idPath FROM files WHERE strFileName LIKE 'index.bdmv')",
-        StringUtils::utf8_strlen(path), path.c_str());
+    CURL url("udf://");
+    url.SetHostName(path);
+    std::string filePath{url.Get()};
+    URIUtils::RemoveSlashAtEnd(filePath);
+    url = CURL("bluray://");
+    url.SetHostName(filePath);
+    std::string isoPath{url.Get()};
+    URIUtils::RemoveSlashAtEnd(isoPath);
+    constexpr size_t udfPrefixLength = 6; // length of "udf://"
+    filePath = filePath.substr(udfPrefixLength); // Remove udf://
+
+    sql = "SELECT idPath, strPath FROM path WHERE (strPath LIKE '%s%%'";
+    if (excludeDiscPaths)
+      sql += " AND idPath NOT IN (SELECT idPath FROM files WHERE strFileName LIKE 'video_ts.ifo')"
+             " AND idPath NOT IN (SELECT idPath FROM files WHERE strFileName LIKE 'index.bdmv')";
+    sql += ") OR (strPath LIKE '%s%%' OR strPath LIKE 'bluray://%s%%'"
+           " OR strPath LIKE 'zip://%s%%' OR strPath LIKE 'rar://%s%%' OR strPath LIKE "
+           "'archive://%s%%')";
+    sql = PrepareSQL(sql, path.c_str(), isoPath.c_str(), filePath.c_str(), filePath.c_str(),
+                     filePath.c_str(), filePath.c_str());
 
     m_pDS->query(sql);
     while (!m_pDS->eof())
@@ -323,6 +340,7 @@ bool CVideoDatabase::GetSubPaths(const std::string &basepath, std::vector<std::p
       m_pDS->next();
     }
     m_pDS->close();
+
     return true;
   }
   catch (...)
@@ -5886,7 +5904,7 @@ void CVideoDatabase::RemoveContentForPath(const std::string& strPath,
       progress->ShowProgressBar(true);
     }
     std::vector<std::pair<int, std::string> > paths;
-    GetSubPaths(strPath, paths);
+    GetSubPaths(strPath, paths, false);
     int iCurr = 0;
     for (const auto& [pathId, path] : paths)
     {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11498,7 +11498,7 @@ void CVideoDatabase::InvalidatePathHash(const std::string& strPath)
                                                          : strPath};
 
   ScraperPtr info = GetScraperForPath(path, settings, foundDirectly);
-  SetPathHash(path, "");
+  SetPathHash(strPath, "");
   if (!info)
     return;
   if (info->Content() == ContentType::TVSHOWS ||

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -601,9 +601,12 @@ public:
   /*! \brief retrieve subpaths of a given path.  Assumes a hierarchical folder structure
    \param basepath the root path to retrieve subpaths for
    \param subpaths the returned subpaths
+   \param excludeDiscPaths exclude disc paths that contain VIDEO_TS.IFO or INDEX.BDMV (default true)
    \return true if we successfully retrieve subpaths (may be zero), false on error
    */
-  bool GetSubPaths(const std::string& basepath, std::vector< std::pair<int, std::string> >& subpaths);
+  bool GetSubPaths(const std::string& basepath,
+                   std::vector<std::pair<int, std::string>>& subpaths,
+                   bool excludeDiscPaths = true);
 
   bool GetSourcePath(const std::string &path, std::string &sourcePath);
   bool GetSourcePath(const std::string& path,


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Ensure vfs paths (eg. bluray://, rar:// etc..) are resolved to the base path.
Don't exclude disc file paths (VIDEO_TS / BDMV) from `GetSubPaths()` when called to remove assets.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #28587.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

Created a test source with a:

Bluray ISO movie
DVD ISO movie
Bluray file (BDMV) movie
DVD file (VIDEO_TS) movie
Normal MKV movie
RAR archive containing a movie

Scraped - movies, online scraper, each movie in separate folder

movie table
<img width="670" height="388" alt="image" src="https://github.com/user-attachments/assets/6a725001-2060-436f-b6f9-7784c8002675" />

files table
<img width="1363" height="404" alt="image" src="https://github.com/user-attachments/assets/854bf199-66f0-417f-8e2a-675a169d937b" />

path table
<img width="2089" height="544" alt="image" src="https://github.com/user-attachments/assets/40a5be5b-62aa-48e0-8699-ad531eb7854f" />

Content changed to none and remove all

movie table (BEFORE)
<img width="684" height="302" alt="image" src="https://github.com/user-attachments/assets/65c390e5-25c9-49c1-8efa-0120c32f0011" />

files and path table unchanged

movie table (AFTER)
<img width="980" height="306" alt="image" src="https://github.com/user-attachments/assets/6bbef39d-0d38-413b-82b5-6f3dc0d71e4e" />

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
