### PR TITLE
depends: avoid full rebuild on every ./configure by preserving Makefile.include mtime

### DIFF
--- a/tools/depends/.gitignore
+++ b/tools/depends/.gitignore
@@ -1,5 +1,6 @@
 /configure
 /Makefile.include
+/Makefile.include.tmp
 /autom4te.cache/
 /**/.gitignore
 /**/.configured-*

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -2,10 +2,20 @@ AC_PREREQ(2.59)
 AC_INIT([xbmc-depends], [2.00], [https://github.com/xbmc/xbmc])
 :${CFLAGS=""}
 AC_CONFIG_AUX_DIR([build-aux])
-AC_CONFIG_FILES([native/config.site.native Makefile.include
+# Only touch Makefile.include's mtime if its content actually changed, since every
+# dependency's rebuild stamp depends on it and an unconditional rewrite here would
+# force a full rebuild of all dependencies on every ./configure run.
+AC_CONFIG_FILES([native/config.site.native
+                 Makefile.include.tmp:Makefile.include.in
                  target/config.site target/config-binaddons.site
                  target/Toolchain.cmake target/Toolchain_binaddons.cmake
                  native/Toolchain-Native.cmake])
+AC_CONFIG_COMMANDS([Makefile.include],
+  [if test -f Makefile.include && cmp -s Makefile.include.tmp Makefile.include; then
+     rm -f Makefile.include.tmp
+   else
+     mv -f Makefile.include.tmp Makefile.include
+   fi])
 AC_CANONICAL_HOST
 AC_CANONICAL_BUILD
 


### PR DESCRIPTION
config.status unconditionally rewrote Makefile.include on every ./configure run, even with unchanged content. Since every dependency's .configured-*/.installed-* stamp depends on it, the mtime bump invalidated all ~138 dependencies at once, forcing rm -rf and a full rebuild regardless of whether anything changed.

Generate to Makefile.include.tmp and only replace the real file if the content actually differs, preserving its mtime otherwise.

## Description
This patch try to avoid recompiling every depends package when Makefile.include didn't change

## Motivation and context
Running ./configure and ./make in the depends folder then make rebuild everything even if Makefile.include didn't change just because the mtime changed.
I'm implement a CI E2E that cache the whole depends fo

## How has this been tested?
Run locally + CI with Cache rebuild Kodi in <5min 

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
