### PR TITLE
[GSoC 2021] RetroPlayer: Add Achievements (all remaining student code)

### DIFF
--- a/xbmc/cores/RetroPlayer/cheevos/Cheevos.cpp
+++ b/xbmc/cores/RetroPlayer/cheevos/Cheevos.cpp
@@ -11,6 +11,7 @@
 #include "FileItem.h"
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "filesystem/CurlFile.h"
 #include "filesystem/File.h"
 #include "games/addons/GameClient.h"
@@ -24,7 +25,6 @@
 #include "utils/log.h"
 
 #include <string_view>
-#include <vector>
 
 using namespace KODI;
 using namespace RETRO;
@@ -41,6 +41,13 @@ constexpr auto PUBLISHER = "Publisher";
 constexpr auto DEVELOPER = "Developer";
 constexpr auto GENRE = "Genre";
 constexpr auto CONSOLE_NAME = "ConsoleName";
+
+constexpr auto ACHIEVEMENTS = "Achievements";
+constexpr auto MEM_ADDR = "MemAddr";
+constexpr auto CHEEVO_ID = "ID";
+constexpr auto FLAGS = "Flags";
+constexpr auto CHEEVO_TITLE = "Title";
+constexpr auto BADGE_NAME = "BadgeName";
 
 constexpr int RESPONSE_SIZE = 64;
 
@@ -86,6 +93,8 @@ constexpr auto extensionToConsole = make_map<std::string_view, RConsoleID>({
 });
 } // namespace
 
+std::unordered_map<unsigned, std::vector<std::string>> CCheevos::m_activatedCheevoMap;
+
 CCheevos::CCheevos(GAME::CGameClient* gameClient,
                    const std::string& userName,
                    const std::string& loginToken)
@@ -93,6 +102,7 @@ CCheevos::CCheevos(GAME::CGameClient* gameClient,
     m_userName(userName),
     m_loginToken(loginToken)
 {
+  m_gameClient->Cheevos().SetRetroAchievementsCredentials(m_userName.c_str(), m_loginToken.c_str());
 }
 
 void CCheevos::ResetRuntime()
@@ -175,6 +185,22 @@ bool CCheevos::LoadData()
   CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_PLAYER_ITEM, -1, -1,
                                              static_cast<void*>(file.release()));
 
+  const CVariant& achievements = data[PATCH_DATA][ACHIEVEMENTS];
+  for (auto it = achievements.begin_array(); it != achievements.end_array(); it++)
+  {
+    const CVariant& achievement = *it;
+    if (achievement[FLAGS].asUnsignedInteger() == 3)
+    {
+      m_activatedCheevoMap[static_cast<unsigned int>(achievement[CHEEVO_ID].asUnsignedInteger())] =
+          {achievement[MEM_ADDR].asString(), achievement[CHEEVO_TITLE].asString(),
+           achievement[BADGE_NAME].asString()};
+    }
+    else
+    {
+      CLog::Log(LOGINFO, "We are not considering unofficial achievements");
+    }
+  }
+
   return true;
 }
 
@@ -191,6 +217,28 @@ void CCheevos::EnableRichPresence()
 
   m_gameClient->Cheevos().RCEnableRichPresence(m_richPresenceScript);
   m_richPresenceScript.clear();
+}
+
+void CCheevos::ActivateAchievement()
+{
+  if (m_activatedCheevoMap.empty())
+  {
+    if (!LoadData())
+    {
+      CLog::Log(LOGERROR, "Cheevos: Couldn't load patch file");
+      return;
+    }
+    else
+    {
+      CLog::Log(LOGERROR, "No active core achievement for the game");
+    }
+  }
+  for (auto& it : m_activatedCheevoMap)
+  {
+    m_gameClient->Cheevos().ActivateAchievement(it.first, it.second[0].c_str());
+  }
+  //call for checking triggered achievement
+  CheckTriggeredAchievement();
 }
 
 std::string CCheevos::GetRichPresenceEvaluation()
@@ -221,4 +269,23 @@ RConsoleID CCheevos::ConsoleID()
 {
   const std::string extension = URIUtils::GetExtension(m_gameClient->GetGamePath());
   return extensionToConsole.get(extension).value_or(RConsoleID::RC_INVALID_ID);
+}
+
+void CCheevos::CallbackUrlId(const std::string& achievementUrl, unsigned int cheevoId)
+{
+  XFILE::CCurlFile curl;
+  std::string res;
+  curl.Get(achievementUrl, res);
+  std::string description = m_activatedCheevoMap[cheevoId][1];
+  std::string header = std::string("Congratulations, ") + std::string("Achievement Unlocked");
+
+  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, header, description);
+}
+
+void CCheevos::CheckTriggeredAchievement()
+{
+  // Callback for triggered achievement URL and ID
+  m_gameClient->Cheevos().GetAchievementUrlId(
+      [](const std::string& achievementUrl, unsigned int cheevoId)
+      { CallbackUrlId(achievementUrl, cheevoId); });
 }

--- a/xbmc/cores/RetroPlayer/cheevos/Cheevos.h
+++ b/xbmc/cores/RetroPlayer/cheevos/Cheevos.h
@@ -12,6 +12,8 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 namespace KODI
 {
@@ -31,6 +33,12 @@ public:
   void ResetRuntime();
   void EnableRichPresence();
   std::string GetRichPresenceEvaluation();
+
+  void ActivateAchievement();
+  static void CallbackUrlId(const std::string& achievementUrl, unsigned int cheevoId);
+  void CheckTriggeredAchievement();
+
+  static std::unordered_map<unsigned, std::vector<std::string>> m_activatedCheevoMap;
 
 private:
   bool LoadData();


### PR DESCRIPTION
## Description

This PR merges the remaining work done by @Shardul555 for GSoC 2021, "RetroPlayer Achievements". It is the final unmerged code from https://github.com/xbmc/xbmc/pull/22652. Not enabled yet.

## Motivation and context

I want @Shardul555 to have git ownership of the gsoc 2021 work, and it keeps getting rebased into currently ongoing work. So let's immortalize the commit and build on it.

## How has this been tested?

Untested.

No runtime path is affected, other than on game load. It should safely ignore the currently-broken RA credential handling.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [x] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
