### PR TITLE
docs: add agent comment-discipline guidance for Copilot and Claude Code

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,22 @@
+# Copilot instructions
+
+## Comments
+
+Default to no comments. Code with clear names already says what it does — don't restate that.
+
+Only add a comment when it captures something the code cannot express on its own:
+- A non-obvious constraint or invariant ("must run before X or Y breaks")
+- A workaround for a specific external bug/quirk, ideally with a reference
+- Domain/external knowledge a competent developer wouldn't have without reading
+  other source (e.g. "Kodi's NetworkServices::Start() disables the webserver
+  when auth is on with an empty password")
+- Behavior that would genuinely surprise a reader skimming the diff
+
+Before writing a comment, ask: if I deleted this, would a competent reader be
+confused or make a wrong assumption? If no, delete it.
+
+Never write comments that:
+- Describe what the next line does in plain English ("# loop over items")
+- Reference the current task/ticket/PR ("added for the login fix")
+- Restate the function/variable name in prose
+- Span multiple paragraphs — one line, max two, per comment

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,3 +20,4 @@ Never write comments that:
 - Reference the current task/ticket/PR ("added for the login fix")
 - Restate the function/variable name in prose
 - Span multiple paragraphs — one line, max two, per comment
+- Use non-ASCII characters (no smart quotes, em dashes, arrows, etc.) — plain ASCII only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# CLAUDE.md
+
+## Comments
+
+Default to no comments. Code with clear names already says what it does — don't restate that.
+
+Only add a comment when it captures something the code cannot express on its own:
+- A non-obvious constraint or invariant ("must run before X or Y breaks")
+- A workaround for a specific external bug/quirk, ideally with a reference
+- Domain/external knowledge a competent developer wouldn't have without reading
+  other source (e.g. "Kodi's NetworkServices::Start() disables the webserver
+  when auth is on with an empty password")
+- Behavior that would genuinely surprise a reader skimming the diff
+
+Before writing a comment, ask: if I deleted this, would a competent reader be
+confused or make a wrong assumption? If no, delete it.
+
+Never write comments that:
+- Describe what the next line does in plain English ("# loop over items")
+- Reference the current task/ticket/PR ("added for the login fix")
+- Restate the function/variable name in prose
+- Span multiple paragraphs — one line, max two, per comment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,3 +20,4 @@ Never write comments that:
 - Reference the current task/ticket/PR ("added for the login fix")
 - Restate the function/variable name in prose
 - Span multiple paragraphs — one line, max two, per comment
+- Use non-ASCII characters (no smart quotes, em dashes, arrows, etc.) — plain ASCII only


### PR DESCRIPTION
Encodes the "only comment on non-obvious WHY, never restate WHAT" rule so coding agents stop producing verbose narration comments by default.

## Description
Add some guidance for Copilot and Claude Code about comment

## Motivation and context
Both Claude and Copilot tend to be a bit verbose 

## How has this been tested?
Test in progress

## What is the effect on users?
None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
