### PR TITLE
[filesystem] Apply stored credentials in the CCurlFile helpers

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -19,6 +19,7 @@
 #include "threads/SystemClock.h"
 #include "utils/Base64.h"
 #include "utils/Map.h"
+#include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
 
 #include <algorithm>
@@ -1998,8 +1999,13 @@ bool CCurlFile::GetHttpHeader(const CURL &url, CHttpHeader &headers)
 {
   try
   {
+    // Apply any stored credentials (passwords.xml). CFile::Stat() does this for its callers,
+    // but this helper drives CCurlFile directly, so without it an authenticated http/dav
+    // source is queried anonymously and gets a 401.
+    const CURL authUrl = URIUtils::AddCredentials(url);
+
     CCurlFile file;
-    if(file.Stat(url, NULL) == 0)
+    if (file.Stat(authUrl, NULL) == 0)
     {
       headers = file.GetHttpHeader();
       return true;
@@ -2020,9 +2026,14 @@ bool CCurlFile::GetMimeType(const CURL &url, std::string &content, const std::st
   if (!useragent.empty())
     file.SetUserAgent(useragent);
 
+  // Apply any stored credentials (passwords.xml). CFile::Stat() does this for its callers,
+  // but this helper drives CCurlFile directly, so without it an authenticated http/dav
+  // source is queried anonymously, gets a 401 and mime type detection always fails.
+  const CURL authUrl = URIUtils::AddCredentials(url);
+
   struct __stat64 buffer;
   std::string redactUrl = url.GetRedacted();
-  if( file.Stat(url, &buffer) == 0 )
+  if (file.Stat(authUrl, &buffer) == 0)
   {
     if (buffer.st_mode == _S_IFDIR)
       content = "x-directory/normal";
@@ -2042,9 +2053,14 @@ bool CCurlFile::GetContentType(const CURL &url, std::string &content, const std:
   if (!useragent.empty())
     file.SetUserAgent(useragent);
 
+  // Apply any stored credentials (passwords.xml). CFile::Stat() does this for its callers,
+  // but this helper drives CCurlFile directly, so without it an authenticated http/dav
+  // source is queried anonymously, gets a 401 and content type detection always fails.
+  const CURL authUrl = URIUtils::AddCredentials(url);
+
   struct __stat64 buffer;
   std::string redactUrl = url.GetRedacted();
-  if (file.Stat(url, &buffer) == 0)
+  if (file.Stat(authUrl, &buffer) == 0)
   {
     if (buffer.st_mode == _S_IFDIR)
       content = "x-directory/normal";

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -10,6 +10,7 @@
 #  include <windows.h>
 #endif
 
+#include "PasswordManager.h"
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "filesystem/CurlFile.h"
@@ -70,10 +71,14 @@ protected:
 
     SetupMediaSources();
 
-    webserver.Start(webserverPort, "", "");
+    webserver.Start(webserverPort, GetServerUsername(), GetServerPassword());
     webserver.RegisterRequestHandler(&m_jsonRpcHandler);
     webserver.RegisterRequestHandler(&m_vfsHandler);
   }
+
+  //! \brief Credentials the test web server requires. Empty means no authentication.
+  virtual std::string GetServerUsername() const { return ""; }
+  virtual std::string GetServerPassword() const { return ""; }
 
   void TearDown() override
   {
@@ -927,4 +932,128 @@ TEST_F(TestWebServer, CanGetCachedRangedFileWithNewerIfRange)
   curl.SetRequestHeader(MHD_HTTP_HEADER_IF_RANGE, lastModifiedNewer.GetAsRFC1123DateTime());
   ASSERT_TRUE(curl.Get(GetUrlOfTestFile(TEST_FILES_RANGES), result));
   CheckRangesTestFileResponse(curl, result, ranges);
+}
+
+/*!
+ \brief Web server requiring authentication, with the credentials held by the password manager
+ rather than being part of the requested url.
+
+ This is what adding a source with a username/password gives us: sources.xml holds the plain url
+ and passwords.xml holds the credentials, so every request has to pick them up from
+ CPasswordManager. Anything talking to the server directly instead of going through CFile has to
+ apply them itself, which is what these tests cover.
+ */
+class TestWebServerAuth : public TestWebServer
+{
+protected:
+  std::string GetServerUsername() const override { return "kodi"; }
+  std::string GetServerPassword() const override { return "secret"; }
+
+  void SetUp() override
+  {
+    CPasswordManager::GetInstance().Clear();
+    TestWebServer::SetUp();
+
+    // remember the credentials for the server, as saving a source with a username/password does
+    CURL authenticatedUrl{baseUrl};
+    authenticatedUrl.SetUserName(GetServerUsername());
+    authenticatedUrl.SetPassword(GetServerPassword());
+    CPasswordManager::GetInstance().SaveAuthenticatedURL(authenticatedUrl, false);
+  }
+
+  void TearDown() override
+  {
+    CPasswordManager::GetInstance().Clear();
+
+    TestWebServer::TearDown();
+  }
+};
+
+// The static CCurlFile helpers that talk to the server directly and so have to apply the stored
+// credentials themselves. Each is invoked through a uniform bool(const CURL&) wrapper (discarding
+// the header/type output and only reporting success) so the same test can cover all of them.
+bool InvokeGetMimeType(const CURL& url)
+{
+  std::string content;
+  return CCurlFile::GetMimeType(url, content);
+}
+
+bool InvokeGetContentType(const CURL& url)
+{
+  std::string content;
+  return CCurlFile::GetContentType(url, content);
+}
+
+bool InvokeGetHttpHeader(const CURL& url)
+{
+  CHttpHeader headers;
+  return CCurlFile::GetHttpHeader(url, headers);
+}
+
+struct AuthHelperCase
+{
+  const char* name;
+  bool (*invoke)(const CURL& url);
+  bool withCredentials;
+};
+
+class TestWebServerAuthHelper : public TestWebServerAuth,
+                                public testing::WithParamInterface<AuthHelperCase>
+{
+};
+
+// Every helper must succeed when the credentials are known to the password manager and fail when
+// they are not (proving authentication is really being applied, not that the server lets us in).
+TEST_P(TestWebServerAuthHelper, AppliesStoredCredentials)
+{
+  const AuthHelperCase& helper = GetParam();
+
+  // TestWebServerAuth::SetUp() has seeded the credentials; drop them again for the negative cases
+  if (!helper.withCredentials)
+    CPasswordManager::GetInstance().Clear();
+
+  // the url deliberately carries no credentials, they have to come from the password manager
+  const CURL url{GetUrlOfTestFile(TEST_FILES_RANGES)};
+  ASSERT_TRUE(url.GetUserName().empty());
+
+  EXPECT_EQ(helper.withCredentials, helper.invoke(url));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Helpers,
+    TestWebServerAuthHelper,
+    testing::Values(AuthHelperCase{"GetMimeType_WithCredentials", InvokeGetMimeType, true},
+                    AuthHelperCase{"GetMimeType_NoCredentials", InvokeGetMimeType, false},
+                    AuthHelperCase{"GetContentType_WithCredentials", InvokeGetContentType, true},
+                    AuthHelperCase{"GetContentType_NoCredentials", InvokeGetContentType, false},
+                    AuthHelperCase{"GetHttpHeader_WithCredentials", InvokeGetHttpHeader, true},
+                    AuthHelperCase{"GetHttpHeader_NoCredentials", InvokeGetHttpHeader, false}),
+    [](const testing::TestParamInfo<AuthHelperCase>& info) { return info.param.name; });
+
+TEST_F(TestWebServerAuth, GetMimeTypeReturnsTheCorrectType)
+{
+  // the url deliberately carries no credentials, they have to come from the password manager
+  const CURL url{GetUrlOfTestFile(TEST_FILES_RANGES)};
+  ASSERT_TRUE(url.GetUserName().empty());
+
+  std::string mimeType;
+  ASSERT_TRUE(CCurlFile::GetMimeType(url, mimeType));
+  EXPECT_STREQ("text/plain", mimeType.c_str());
+}
+
+TEST_F(TestWebServerAuth, GetContentTypeReturnsTheCorrectType)
+{
+  const CURL url{GetUrlOfTestFile(TEST_FILES_RANGES)};
+  ASSERT_TRUE(url.GetUserName().empty());
+
+  std::string contentType;
+  ASSERT_TRUE(CCurlFile::GetContentType(url, contentType));
+  EXPECT_TRUE(contentType.find("text/plain") != std::string::npos);
+}
+
+TEST_F(TestWebServerAuth, CanStatWithStoredCredentials)
+{
+  // CFile::Stat() has always applied the stored credentials, unlike the CCurlFile helpers above
+  struct __stat64 buffer;
+  ASSERT_EQ(0, CFile::Stat(CURL{GetUrlOfTestFile(TEST_FILES_RANGES)}, &buffer));
 }

--- a/xbmc/test/CMakeLists.txt
+++ b/xbmc/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES TestAutoSwitch.cpp
             TestFileItem.cpp
             TestLangInfo.cpp
             TestMediaSource.cpp
+            TestPasswordManager.cpp
             TestURL.cpp
             TestUtil.cpp
             TestUtils.cpp)

--- a/xbmc/test/TestPasswordManager.cpp
+++ b/xbmc/test/TestPasswordManager.cpp
@@ -1,0 +1,145 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PasswordManager.h"
+#include "URL.h"
+#include "utils/URIUtils.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr const char* USERNAME = "kodi";
+constexpr const char* PASSWORD = "secret";
+
+CURL AuthenticatedUrl(const std::string& path)
+{
+  CURL url{path};
+  url.SetUserName(USERNAME);
+  url.SetPassword(PASSWORD);
+  return url;
+}
+} // namespace
+
+class TestPasswordManager : public testing::Test
+{
+protected:
+  // the password manager is a singleton, so make sure no state leaks between tests
+  void SetUp() override { CPasswordManager::GetInstance().Clear(); }
+  void TearDown() override { CPasswordManager::GetInstance().Clear(); }
+
+  static void Remember(const std::string& path)
+  {
+    CPasswordManager::GetInstance().SaveAuthenticatedURL(AuthenticatedUrl(path), false);
+  }
+
+  static void ExpectAuthenticated(const CURL& url)
+  {
+    EXPECT_STREQ(USERNAME, url.GetUserName().c_str());
+    EXPECT_STREQ(PASSWORD, url.GetPassWord().c_str());
+  }
+};
+
+TEST_F(TestPasswordManager, AuthenticatesPathBelowTheRememberedShare)
+{
+  // this is what a source with a username/password gives us: the credentials are remembered for
+  // the source and every item below it has to pick them up again
+  Remember("http://192.168.0.1:8910/media/");
+
+  CURL url{"http://192.168.0.1:8910/media/Movies/movie.mkv"};
+  ASSERT_TRUE(CPasswordManager::GetInstance().AuthenticateURL(url));
+  ExpectAuthenticated(url);
+}
+
+TEST_F(TestPasswordManager, LookupIgnoresThePort)
+{
+  // the lookup key is built from the host name only, so the port must not influence the match.
+  // passwords.xml therefore holds port-less <from> keys even for a server on a custom port.
+  Remember("http://192.168.0.1:8910/media/");
+
+  CURL url{"http://192.168.0.1:1234/media/Movies/movie.mkv"};
+  ASSERT_TRUE(CPasswordManager::GetInstance().AuthenticateURL(url));
+  ExpectAuthenticated(url);
+}
+
+TEST_F(TestPasswordManager, FallsBackToTheServerForAnotherShare)
+{
+  // different shares on the same host reuse the credentials
+  Remember("http://192.168.0.1:8910/media/");
+
+  CURL url{"http://192.168.0.1:8910/other/file.mkv"};
+  ASSERT_TRUE(CPasswordManager::GetInstance().AuthenticateURL(url));
+  ExpectAuthenticated(url);
+}
+
+TEST_F(TestPasswordManager, DoesNotAuthenticateAnUnknownServer)
+{
+  Remember("http://192.168.0.1:8910/media/");
+
+  CURL url{"http://192.168.0.2:8910/media/Movies/movie.mkv"};
+  EXPECT_FALSE(CPasswordManager::GetInstance().AuthenticateURL(url));
+  EXPECT_TRUE(url.GetUserName().empty());
+  EXPECT_TRUE(url.GetPassWord().empty());
+}
+
+TEST_F(TestPasswordManager, DoesNotAuthenticateWithNothingRemembered)
+{
+  CURL url{"http://192.168.0.1:8910/media/Movies/movie.mkv"};
+  EXPECT_FALSE(CPasswordManager::GetInstance().AuthenticateURL(url));
+  EXPECT_TRUE(url.GetUserName().empty());
+  EXPECT_TRUE(url.GetPassWord().empty());
+}
+
+TEST_F(TestPasswordManager, DoesNotRememberAUrlWithoutAUserName)
+{
+  CPasswordManager::GetInstance().SaveAuthenticatedURL(CURL{"http://192.168.0.1:8910/media/"},
+                                                       false);
+
+  CURL url{"http://192.168.0.1:8910/media/Movies/movie.mkv"};
+  EXPECT_FALSE(CPasswordManager::GetInstance().AuthenticateURL(url));
+}
+
+TEST_F(TestPasswordManager, SupportsTheProtocolsThatCanCarryCredentials)
+{
+  CPasswordManager& manager = CPasswordManager::GetInstance();
+
+  EXPECT_TRUE(manager.IsURLSupported(CURL{"http://host/share/"}));
+  EXPECT_TRUE(manager.IsURLSupported(CURL{"https://host/share/"}));
+  EXPECT_TRUE(manager.IsURLSupported(CURL{"dav://host/share/"}));
+  EXPECT_TRUE(manager.IsURLSupported(CURL{"davs://host/share/"}));
+  EXPECT_TRUE(manager.IsURLSupported(CURL{"smb://host/share/"}));
+  EXPECT_TRUE(manager.IsURLSupported(CURL{"nfs://host/share/"}));
+  EXPECT_TRUE(manager.IsURLSupported(CURL{"ftp://host/share/"}));
+  EXPECT_TRUE(manager.IsURLSupported(CURL{"ftps://host/share/"}));
+  EXPECT_TRUE(manager.IsURLSupported(CURL{"sftp://host/share/"}));
+
+  EXPECT_FALSE(manager.IsURLSupported(CURL{"/local/path/file.mkv"}));
+}
+
+TEST_F(TestPasswordManager, AddCredentialsFillsInTheRememberedCredentials)
+{
+  Remember("http://192.168.0.1:8910/media/");
+
+  // URIUtils::AddCredentials() is what the file system layer uses to authenticate a plain url
+  const CURL url{URIUtils::AddCredentials(CURL{"http://192.168.0.1:8910/media/Movies/movie.mkv"})};
+  ExpectAuthenticated(url);
+}
+
+TEST_F(TestPasswordManager, AddCredentialsKeepsCredentialsAlreadyInTheUrl)
+{
+  Remember("http://192.168.0.1:8910/media/");
+
+  // credentials that are already part of the url win over the remembered ones
+  CURL explicitUrl{"http://192.168.0.1:8910/media/Movies/movie.mkv"};
+  explicitUrl.SetUserName("other");
+  explicitUrl.SetPassword("password");
+
+  const CURL url{URIUtils::AddCredentials(explicitUrl)};
+  EXPECT_STREQ("other", url.GetUserName().c_str());
+  EXPECT_STREQ("password", url.GetPassWord().c_str());
+}


### PR DESCRIPTION
## Description

When browsing files via http,https,webdev, etc.  If the server require auth, Kodi, fails to include the auth when doing a HEAD/stat request. Kodi, having failed to get metadata for the file, just tries loading it as an image which ends up loading entire gigabyte video files and passing them to the image loading code. This ends up running out of memory on things like tVOS and probably Android.

Long version:

CCurlFile::GetMimeType(), GetContentType() and GetHttpHeader() drive CCurlFile directly instead of going through CFile, and so were the only http code paths that never applied the credentials held by CPasswordManager. Every CFile entry point (Open(), Stat(), Exists(), ...) authenticates its url with URIUtils::AddCredentials() first, these three did not.

Adding a source with a username/password stores the plain url in sources.xml and the credentials in passwords.xml, so the url these helpers are handed carries no credentials. Against a server that requires authentication they therefore always requested anonymously, got a 401, and - because CURLOPT_FAILONERROR is set - failed with CURLE_HTTP_RETURNED_ERROR:

    CCurlFile::Stat - <http://.../Movie.m4v> Failed: HTTP response code said error(22)
    CCurlFile::GetMimeType - <http://.../Movie.m4v> -> failed

The visible damage is worse than a missing mime type. With detection failing, CFileItem::FillInMimeType() leaves the item untyped and the file  etcends up being handed to the texture cache as if it were artwork. CTexture::LoadFromFileInternal() then calls CFile::LoadFile(), which *does* authenticate, succeeds, and reads the entire video into a std::vector<uint8_t>. Scrolling a movie list over an authenticated http source therefore tried to pull every movie into memory:

    CFile::LoadFile: Failed to load .../Movie.m4v: out of memory

On a memory constrained device that is fatal - on tvOS the app is jetsam killed (no crash report, no hang, it simply disappears). Reproduced on an Apple TV 4K by opening a movie folder on an authenticated http source and scrolling: 47 failed Stats and 35 out of memory LoadFile attempts in two minutes, ending in the app being killed. With this change the mime types resolve (video/x-m4v, video/mp4, video/x-msvideo), the file is never treated as an image, and both the out of memory storm and the kill are gone.

## Motivation and context

Motiviation = fixing a crash.

## How has this been tested?

TestWebServerAuth: a CWebServer that requires authentication, with the credentials held by CPasswordManager rather than in the requested url - which is exactly what saving a source with a username/password produces. The mime type and content type tests fail without this change and pass with it. A CFile::Stat() case is included as a control (it has always authenticated, which is the asymmetry that is the bug) and a case without stored credentials guards against the fixture passing if authentication were not really enforced.

TestPasswordManager: CPasswordManager had no test coverage at all. Covers the lookup being host based (the port is deliberately not part of the key, which is why passwords.xml holds port-less <from> entries), the fallback to the server for another share on the same host, the negative cases, and URIUtils::AddCredentials() both filling in remembered credentials and leaving existing ones alone.

## What is the effect on users?

Any user using authenticated web servers on tvOS and probably Android would be affected. That said, most people use SMB or local storage or if they are using a web server it's probably unautenticated so maybe not that many users. Still, it's a bug and it was crashing for me

## Screenshots (if appropriate):

N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed


Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


