### PR TITLE
[Resolution] Avoid mode switches for exact refresh-rate multiples

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -8565,7 +8565,12 @@ msgctxt "#14128"
 msgid "Allow double refresh rates"
 msgstr ""
 
-#empty strings from id 14129 to 14186
+#: system/settings/settings.xml
+msgctxt "#14129"
+msgid "Keep current refresh rate when compatible"
+msgstr ""
+
+#empty strings from id 14130 to 14186
 
 #: system/settings/settings.xml
 msgctxt "#14187"
@@ -21694,7 +21699,13 @@ msgctxt "#36445"
 msgid "Select this option to allow using double refresh rates (playing 29.97 FPS video on a 59.94 Hz monitor or playing 30 FPS video on a 60 Hz monitor). You may want to use this option if your monitor doesn't have a 29.97 Hz or 30 Hz mode."
 msgstr ""
 
-#empty strings from id 36446 to 36459
+#. Description of setting with label #14129 "Keep current refresh rate when compatible"
+#: system/settings/settings.xml
+msgctxt "#36446"
+msgid "Keep the current display mode when its refresh rate is an exact multiple of the video's frame rate (for example, 23.976 FPS at 119.88 Hz). This avoids a display mode change but may increase power use or affect display processing."
+msgstr ""
+
+#empty strings from id 36447 to 36459
 
 #. Description of settings with label #14112 "Enable event logging"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3167,6 +3167,11 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="videoscreen.keepcompatiblerefreshrate" type="boolean" parent="videoscreen.whitelist" label="14129" help="36446">
+          <level>3</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="4" label="14232">
         <setting id="videoscreen.stereoscopicmode" type="integer" label="36500" help="36539">

--- a/xbmc/test/CMakeLists.txt
+++ b/xbmc/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES TestAutoSwitch.cpp
             TestFileItem.cpp
             TestLangInfo.cpp
             TestMediaSource.cpp
+            TestResolution.cpp
             TestURL.cpp
             TestUtil.cpp
             TestUtils.cpp)

--- a/xbmc/test/TestResolution.cpp
+++ b/xbmc/test/TestResolution.cpp
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "windowing/Resolution.h"
+
+#include <gtest/gtest.h>
+
+TEST(TestResolution, CompatibleRefreshRateMultiples)
+{
+  constexpr float FPS_23_976 = 24000.0f / 1001.0f;
+  constexpr float FPS_29_97 = 30000.0f / 1001.0f;
+  constexpr float FPS_59_94 = 60000.0f / 1001.0f;
+  constexpr float REFRESH_119_88 = 120000.0f / 1001.0f;
+
+  EXPECT_TRUE(CResolutionUtils::IsRefreshRateMultiple(REFRESH_119_88, FPS_23_976));
+  EXPECT_TRUE(CResolutionUtils::IsRefreshRateMultiple(REFRESH_119_88, FPS_29_97));
+  EXPECT_TRUE(CResolutionUtils::IsRefreshRateMultiple(REFRESH_119_88, FPS_59_94));
+  EXPECT_TRUE(CResolutionUtils::IsRefreshRateMultiple(120.0f, 24.0f));
+  EXPECT_TRUE(CResolutionUtils::IsRefreshRateMultiple(100.0f, 25.0f));
+  EXPECT_TRUE(CResolutionUtils::IsRefreshRateMultiple(FPS_23_976, FPS_23_976));
+
+  EXPECT_FALSE(CResolutionUtils::IsRefreshRateMultiple(120.0f, FPS_23_976));
+  EXPECT_FALSE(CResolutionUtils::IsRefreshRateMultiple(REFRESH_119_88, 24.0f));
+  EXPECT_FALSE(CResolutionUtils::IsRefreshRateMultiple(60.0f, FPS_23_976));
+  EXPECT_FALSE(CResolutionUtils::IsRefreshRateMultiple(0.0f, FPS_23_976));
+  EXPECT_FALSE(CResolutionUtils::IsRefreshRateMultiple(REFRESH_119_88, 0.0f));
+}

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -28,6 +28,34 @@ namespace
 const char* SETTING_VIDEOSCREEN_WHITELIST_PULLDOWN{"videoscreen.whitelistpulldown"};
 const char* SETTING_VIDEOSCREEN_WHITELIST_DOUBLEREFRESHRATE{
     "videoscreen.whitelistdoublerefreshrate"};
+const char* SETTING_VIDEOSCREEN_KEEP_COMPATIBLE_REFRESH_RATE{
+    "videoscreen.keepcompatiblerefreshrate"};
+
+bool IsCurrentResolutionAllowed(RESOLUTION resolution)
+{
+  const auto indexList = CServiceBroker::GetSettingsComponent()->GetSettings()->GetList(
+      CSettings::SETTING_VIDEOSCREEN_WHITELIST);
+  if (indexList.empty())
+    return true;
+
+  const RESOLUTION_INFO currentInfo =
+      CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(resolution);
+  for (const auto& mode : indexList)
+  {
+    const RESOLUTION_INFO info = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(
+        CDisplaySettings::GetInstance().GetResFromString(mode.asString()));
+    if (info.iScreenWidth == currentInfo.iScreenWidth &&
+        info.iScreenHeight == currentInfo.iScreenHeight &&
+        (info.dwFlags & D3DPRESENTFLAG_MODEMASK) ==
+            (currentInfo.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
+        MathUtils::FloatEquals(info.fRefreshRate, currentInfo.fRefreshRate, 0.01f))
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 } // namespace
 
@@ -57,6 +85,7 @@ float RESOLUTION_INFO::DisplayRatio() const
 RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, int height, bool is3D)
 {
   RESOLUTION res = CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution();
+  const RESOLUTION currentResolution{res};
   float weight = 0.0f;
 
   if (!FindResolutionFromOverride(fps, width, is3D, res, weight, false)) //find a refreshrate from overrides
@@ -64,12 +93,43 @@ RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, int heig
     if (!FindResolutionFromOverride(fps, width, is3D, res, weight, true)) //if that fails find it from a fallback
     {
       FindResolutionFromWhitelist(fps, width, height, is3D, res); //find a refreshrate from whitelist
+
+      if (res != currentResolution &&
+          CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+              SETTING_VIDEOSCREEN_KEEP_COMPATIBLE_REFRESH_RATE) &&
+          IsCurrentResolutionAllowed(currentResolution))
+      {
+        const RESOLUTION_INFO currentInfo =
+            CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(currentResolution);
+        const RESOLUTION_INFO selectedInfo =
+            CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(res);
+        if (currentInfo.iScreenWidth == selectedInfo.iScreenWidth &&
+            currentInfo.iScreenHeight == selectedInfo.iScreenHeight &&
+            (currentInfo.dwFlags & D3DPRESENTFLAG_MODEMASK) ==
+                (selectedInfo.dwFlags & D3DPRESENTFLAG_MODEMASK) &&
+            IsRefreshRateMultiple(currentInfo.fRefreshRate, fps))
+        {
+          CLog::Log(LOGDEBUG,
+                    "[WHITELIST] Keeping compatible current refresh rate {} instead of {}",
+                    currentInfo.fRefreshRate, selectedInfo.fRefreshRate);
+          res = currentResolution;
+        }
+      }
     }
   }
 
   CLog::Log(LOGINFO, "Display resolution ADJUST : {} ({}) (weight: {:.3f})",
             CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(res).strMode, res, weight);
   return res;
+}
+
+bool CResolutionUtils::IsRefreshRateMultiple(float refreshRate, float frameRate)
+{
+  if (refreshRate <= 0.0f || frameRate <= 0.0f)
+    return false;
+
+  const int multiple = MathUtils::round_int(static_cast<double>(refreshRate / frameRate));
+  return multiple >= 1 && MathUtils::FloatEquals(refreshRate, frameRate * multiple, 0.01f);
 }
 
 void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int height, bool is3D, RESOLUTION &resolution)

--- a/xbmc/windowing/Resolution.h
+++ b/xbmc/windowing/Resolution.h
@@ -119,6 +119,9 @@ class CResolutionUtils
 {
 public:
   static RESOLUTION ChooseBestResolution(float fps, int width, int height, bool is3D);
+
+  /*! \brief Return true when refreshRate is an integer multiple of frameRate. */
+  static bool IsRefreshRateMultiple(float refreshRate, float frameRate);
   static bool HasWhitelist();
   static void PrintWhitelist();
 


### PR DESCRIPTION
## Description

Add an opt-in Expert setting that avoids a refresh-only display-mode change when Kodi's current
refresh rate is already an exact integer multiple of the video's frame rate.

Kodi runs its existing resolution-selection logic first. The current refresh rate is retained only
when the selected mode has the same resolution and 3D/interlace flags, the current mode is allowed
by the active whitelist (if configured), and the current refresh rate is compatible. Resolution and
3D mode changes selected by the existing matcher are preserved. The setting defaults to off.

## Motivation and context

Kodi's automatic matcher recognizes direct, double, and 3:2-pulldown refresh-rate matches, but it
does not recognize higher integer multiples. For example, it can switch from 119.88 Hz to 23.976 Hz
even though 119.88 Hz is an exact 5x multiple. That display-mode change is unnecessary for smooth
cadence and can add HDMI resynchronization delay while lowering Kodi's playback GUI refresh rate.

This is a deliberately narrow alternative to the broader approach discussed in #24576. It does
not select the highest available refresh rate, change scaling policy, or replace the existing
matching algorithm. It only cancels an otherwise refresh-only mode change when the current refresh
rate is compatible.

## How has this been tested?

- Added `TestResolution.CompatibleRefreshRateMultiples` with six positive and five negative cases.
- Positive coverage includes 23.976, 29.97, and 59.94 FPS at 119.88 Hz, true 24 FPS at 120 Hz,
  true 25 FPS at 100 Hz, and a direct 1x match.
- Negative coverage includes fractional/integer mismatches such as 23.976 FPS at 120 Hz and true
  24 FPS at 119.88 Hz, plus invalid zero values.
- Verified the settings XML parses and the new English string IDs are unique.
- Ran `git diff --check` successfully.

- Kodi's Jenkins `BuildMulti-PR` check completed successfully for commit `9425b28996`.
- KodiAI's automated review returned `APPROVE` with no findings.

## What is the effect on users?

There is no change to default behavior. Users who enable the new Expert setting can avoid a
refresh-only display-mode change when the current rate already provides exact integer-multiple
cadence. Kodi still applies resolution, 3D, and interlace changes selected by its normal matcher.
Incompatible content also continues through the normal matcher. The setting help text notes that
retaining a higher refresh rate may increase power use or affect display processing.

## Screenshots (if appropriate):

Not applicable.

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [ ] All new and existing tests passed
