### PR TITLE
[Video][Bluray] Fix no valid playlist found.

### DIFF
--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -1715,11 +1715,24 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, MenuDecis
   if (!GetItems(items, directoryDuration, silent))
   {
     // No main movie or episode playlist found
-    if (!silent)
+    if (silent)
+      return false;
+
+    // Not silent so fallback to all titles
+    const std::string fallbackDirectory{
+        item.GetVideoContentType() == VideoDbContentType::EPISODES ||
+                item.GetVideoContentType() == VideoDbContentType::TVSHOWS
+            ? URIUtils::GetBlurayTitlesPath(originalDynPath, URIUtils::GetAllTitles::ALL,
+                                            URIUtils::AllTitlesOptions::EPISODES)
+            : URIUtils::GetBlurayTitlesPath(originalDynPath, URIUtils::GetAllTitles::ALL,
+                                            URIUtils::AllTitlesOptions::MOVIES)};
+    if (!GetItems(items, fallbackDirectory, silent))
+    {
       CGUIDialogOK::ShowAndGetInput(
           CVariant{257},
           CVariant{item.GetVideoContentType() == VideoDbContentType::EPISODES ? 25017 : 25016});
-    return false;
+      return false;
+    }
   }
 
   // Select item


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Present user with all title list.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

If playlist matching fails when playing a bluray through the library the user gets a no valid playlist found error rather than a list of all playlists to select from.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
