### PR TITLE
[Video][Bluray] DVD chapter seeks fail.

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -3058,55 +3058,63 @@ void CVideoPlayer::HandleMessages()
 
       CDVDMsgPlayerSeekChapter& msg(*std::static_pointer_cast<CDVDMsgPlayerSeekChapter>(pMsg));
       double start = DVD_NOPTS_VALUE;
-      int offset = 0;
+      int64_t offset = 0;
+      int newChapter{std::max(1, msg.GetChapter())};
+      bool inCut{false};
+      bool seekDone{false};
+      const int64_t beforeSeek = GetTime();
 
-      // This should always be the case.
+      const auto FinishChapterSeek = [this, &offset, &start, &newChapter, &seekDone, beforeSeek]()
+      {
+        FlushBuffers(start, true, true);
+        if (start != DVD_NOPTS_VALUE)
+        {
+          const int64_t targetTime{
+              m_Edl.GetTimeWithoutCuts(std::chrono::milliseconds(DVD_TIME_TO_MSEC(start))).count()};
+          offset = targetTime - beforeSeek;
+        }
+        m_callback.OnPlayBackSeekChapter(newChapter);
+        m_processInfo->SeekFinished(offset);
+        seekDone = true;
+      };
+
       if (m_pDemuxer)
       {
-        // SeekChapter does not know about EDL cuts as demuxers are EDL agnostic
-        // So get and adjust chapter time
-        const std::chrono::milliseconds position{m_pDemuxer->GetChapterPos(msg.GetChapter())};
-        const auto hasEdit{m_Edl.InEdit(position)};
-        double time{static_cast<double>(position.count())};
-        if (hasEdit)
+        const bool forward{newChapter > GetChapter()};
+        std::chrono::milliseconds position{m_pDemuxer->GetChapterPos(newChapter)};
+        const int chapterCount{m_pDemuxer->GetChapterCount()};
+        auto inEdit{m_Edl.InEdit(position)};
+        inCut = inEdit && inEdit.value()->action == EDL::Action::CUT;
+        if (inCut)
         {
-          const auto& edit{hasEdit.value()};
-          if (edit->action == EDL::Action::CUT)
+          const int step{forward ? 1 : -1};
+          while (inCut && ((forward && newChapter < chapterCount) || (!forward && newChapter > 1)))
           {
-            // Ensure moving backward/forward doesn't take us past the beginning/end point (which may be cut)
-            const bool forward{msg.GetChapter() > GetChapter()};
-            const std::chrono::milliseconds absoluteTime{forward ? edit->start : edit->end};
-            const std::chrono::milliseconds adjustedTime{m_Edl.GetTimeWithoutCuts(absoluteTime)};
-            const auto endTime{std::chrono::duration<double, std::milli>(m_State.timeMax)};
-            if (adjustedTime + 50ms > endTime)
-              // If close to end then use end of stream otherwise adjustedTime can be a few ms over the end
-              // and still cause the video to freeze
-              time = m_pDemuxer->GetStreamLength();
-            else
-              time = static_cast<double>(absoluteTime.count());
+            newChapter += step;
+            position = m_pDemuxer->GetChapterPos(newChapter);
+            inEdit = m_Edl.InEdit(position);
+            inCut = inEdit && inEdit.value()->action == EDL::Action::CUT;
           }
         }
 
-        if (m_pDemuxer->SeekTime(time, true, &start))
+        if (inCut && newChapter == 1)
         {
-          FlushBuffers(start, true, true);
-          int64_t beforeSeek = GetTime();
-          offset = DVD_TIME_TO_MSEC(start) - static_cast<int>(beforeSeek);
-          m_callback.OnPlayBackSeekChapter(msg.GetChapter());
+          // If the first chapter is in an edit, we can't seek to it, so just seek to the end of the edit
+          if (m_pDemuxer->SeekTime(static_cast<double>(inEdit.value()->end.count()), true, &start))
+            FinishChapterSeek();
+        }
+        else if (!inCut)
+        {
+          if (m_pDemuxer->SeekChapter(newChapter, &start))
+            FinishChapterSeek();
         }
       }
-      else if (m_pInputStream)
+      if (!inCut && !seekDone && m_pInputStream)
       {
         CDVDInputStream::IChapter* pChapter = m_pInputStream->GetIChapter();
-        if (pChapter && pChapter->SeekChapter(msg.GetChapter()))
-        {
-          FlushBuffers(start, true, true);
-          int64_t beforeSeek = GetTime();
-          offset = DVD_TIME_TO_MSEC(start) - static_cast<int>(beforeSeek);
-          m_callback.OnPlayBackSeekChapter(msg.GetChapter());
-        }
+        if (pChapter && pChapter->SeekChapter(newChapter))
+          FinishChapterSeek();
       }
-      m_processInfo->SeekFinished(offset);
     }
     else if (pMsg->IsType(CDVDMsg::DEMUXER_RESET))
     {
@@ -5546,12 +5554,12 @@ void CVideoPlayer::UpdatePlayState(double timeout)
 
   // Convert to second resolution used outside of VideoPlayer for chapter positions
   std::vector<std::pair<std::string, int64_t>> chapters;
+  chapters.reserve(state.chapters.size());
   for (const auto& chapter : state.chapters)
   {
-    chapters.emplace_back(
-        chapter.first,
-        static_cast<int64_t>(std::chrono::round<std::chrono::seconds>(chapter.second).count()));
-  };
+    chapters.emplace_back(chapter.first,
+                          std::chrono::round<std::chrono::seconds>(chapter.second).count());
+  }
 
   CServiceBroker::GetDataCacheCore().SetChapters(chapters);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -71,6 +71,7 @@
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <ranges>
 #include <utility>
 
 using namespace KODI;
@@ -3078,11 +3079,14 @@ void CVideoPlayer::HandleMessages()
         seekDone = true;
       };
 
+      // newChapter is kept in "visible" chapter numbering throughout (as reported by
+      // GetChapter()/GetChapterCount()); it is translated to the demuxer/inputstream's own
+      // chapter numbering via ToRawChapter() only at the point of calling into them.
       if (m_pDemuxer)
       {
         const bool forward{newChapter > GetChapter()};
-        std::chrono::milliseconds position{m_pDemuxer->GetChapterPos(newChapter)};
-        const int chapterCount{m_pDemuxer->GetChapterCount()};
+        std::chrono::milliseconds position{m_pDemuxer->GetChapterPos(ToRawChapter(newChapter))};
+        const int chapterCount{GetChapterCount()};
         auto inEdit{m_Edl.InEdit(position)};
         inCut = inEdit && inEdit.value()->action == EDL::Action::CUT;
         if (inCut)
@@ -3091,7 +3095,7 @@ void CVideoPlayer::HandleMessages()
           while (inCut && ((forward && newChapter < chapterCount) || (!forward && newChapter > 1)))
           {
             newChapter += step;
-            position = m_pDemuxer->GetChapterPos(newChapter);
+            position = m_pDemuxer->GetChapterPos(ToRawChapter(newChapter));
             inEdit = m_Edl.InEdit(position);
             inCut = inEdit && inEdit.value()->action == EDL::Action::CUT;
           }
@@ -3105,15 +3109,26 @@ void CVideoPlayer::HandleMessages()
         }
         else if (!inCut)
         {
-          if (m_pDemuxer->SeekChapter(newChapter, &start))
+          if (m_pDemuxer->SeekChapter(ToRawChapter(newChapter), &start))
             FinishChapterSeek();
         }
       }
       if (!inCut && !seekDone && m_pInputStream)
       {
         CDVDInputStream::IChapter* pChapter = m_pInputStream->GetIChapter();
-        if (pChapter && pChapter->SeekChapter(newChapter))
-          FinishChapterSeek();
+        if (pChapter)
+        {
+          const int rawChapter{ToRawChapter(newChapter)};
+          if (pChapter->SeekChapter(rawChapter))
+          {
+            // IChapter::SeekChapter() has no startpts out param, unlike the demuxer's
+            // SeekChapter()/SeekTime(), so approximate the landed position with the
+            // chapter's nominal (raw) start instead of leaving start/offset at 0.
+            start =
+                DVD_MSEC_TO_TIME(static_cast<double>(pChapter->GetChapterPos(rawChapter).count()));
+            FinishChapterSeek();
+          }
+        }
       }
     }
     else if (pMsg->IsType(CDVDMsg::DEMUXER_RESET))
@@ -5162,6 +5177,15 @@ std::optional<std::chrono::milliseconds> CVideoPlayer::GetChapterPosMs(int chapt
   return std::nullopt;
 }
 
+int CVideoPlayer::ToRawChapter(int visibleChapter) const
+{
+  std::unique_lock lock(m_StateSection);
+  if (visibleChapter > 0 && visibleChapter <= static_cast<int>(m_State.rawChapters.size()))
+    return m_State.rawChapters[visibleChapter - 1];
+
+  return visibleChapter;
+}
+
 int CVideoPlayer::GetPreviousChapter()
 {
   // 5-second grace period from chapter start to skip backwards to previous chapter
@@ -5378,6 +5402,32 @@ int CalculateCurrentChapter(
 
   return 0;
 }
+
+// A chapter is fully cut (i.e. not reachable/visible to the user) if its whole
+// [start, end) span, on the original (pre-EDL) timeline, is covered by the union of one or
+// more contiguous/overlapping EDL CUTs.
+bool IsChapterFullyCut(const CEdl& edl,
+                       std::chrono::milliseconds chapterStart,
+                       std::chrono::milliseconds chapterEnd)
+{
+  if (!edl.HasCuts())
+    return false;
+
+  // GetRawEditList() is sorted ascending by start
+  std::chrono::milliseconds covered{chapterStart};
+  for (const EDL::Edit& edit : edl.GetRawEditList())
+  {
+    if (edit.action != EDL::Action::CUT || edit.end <= covered)
+      continue;
+    if (edit.start > covered)
+      break; // gap between cuts - some visible content remains
+
+    covered = edit.end;
+    if (covered >= chapterEnd)
+      return true;
+  }
+  return false;
+}
 } // namespace
 
 void CVideoPlayer::UpdatePlayState(double timeout)
@@ -5417,14 +5467,27 @@ void CVideoPlayer::UpdatePlayState(double timeout)
       chapterNbEnabled = true;
     }
 
+    const std::chrono::milliseconds rawStreamLength{m_pDemuxer->GetStreamLength()};
+
     state.chapters.clear();
+    state.rawChapters.clear();
     if (const int chapterCount = m_pDemuxer->GetChapterCount(); chapterCount > 0)
     {
       for (int i = 0, ie = chapterCount; i < ie; ++i)
       {
-        auto& p = state.chapters.emplace_back(
-            std::string{}, m_Edl.GetTimeWithoutCuts(m_pDemuxer->GetChapterPos(i + 1)));
+        const std::chrono::milliseconds rawStart{m_pDemuxer->GetChapterPos(i + 1)};
+        // GetStreamLength() returns 0 when the duration is unknown (e.g. live/network
+        // streams)
+        const std::chrono::milliseconds rawEnd{
+            i + 1 < ie ? m_pDemuxer->GetChapterPos(i + 2)
+                       : (rawStreamLength > rawStart ? rawStreamLength
+                                                     : std::chrono::milliseconds::max())};
+        if (IsChapterFullyCut(m_Edl, rawStart, rawEnd))
+          continue;
+
+        auto& p = state.chapters.emplace_back(std::string{}, m_Edl.GetTimeWithoutCuts(rawStart));
         m_pDemuxer->GetChapterName(p.first, i + 1);
+        state.rawChapters.emplace_back(i + 1);
       }
     }
     state.time = DVD_TIME_TO_MSEC(m_clock.GetClock());
@@ -5433,7 +5496,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
         state.time < DVD_TIME_TO_MSEC(m_CurrentVideo.startpts))
       state.time = DVD_TIME_TO_MSEC(m_CurrentVideo.startpts);
 
-    state.timeMax = m_pDemuxer->GetStreamLength();
+    state.timeMax = static_cast<double>(rawStreamLength.count());
   }
 
   state.canpause = false;
@@ -5444,6 +5507,20 @@ void CVideoPlayer::UpdatePlayState(double timeout)
 
   if (m_pInputStream)
   {
+    CDVDInputStream::ITimes* pTimes = m_pInputStream->GetITimes();
+    CDVDInputStream::IDisplayTime* pDisplayTime = m_pInputStream->GetIDisplayTime();
+
+    CDVDInputStream::ITimes::Times times;
+    const bool haveTimes = pTimes && pTimes->GetTimes(times);
+
+    // Raw (pre-EDL) upper bound of the stream, needed below to tell whether the last
+    // chapter is fully contained within a trailing EDL cut.
+    std::chrono::milliseconds rawStreamEnd{std::chrono::milliseconds::max()};
+    if (haveTimes)
+      rawStreamEnd = std::chrono::milliseconds(DVD_TIME_TO_MSEC(times.ptsEnd - times.ptsStart));
+    else if (pDisplayTime && pDisplayTime->GetTotalTime() > 0)
+      rawStreamEnd = std::chrono::milliseconds(pDisplayTime->GetTotalTime());
+
     CDVDInputStream::IChapter* pChapter = m_pInputStream->GetIChapter();
     if (pChapter)
     {
@@ -5458,21 +5535,25 @@ void CVideoPlayer::UpdatePlayState(double timeout)
       }
 
       state.chapters.clear();
+      state.rawChapters.clear();
       if (const int chapterCount = pChapter->GetChapterCount(); chapterCount > 0)
       {
         for (int i = 0, ie = chapterCount; i < ie; ++i)
         {
-          auto& p = state.chapters.emplace_back(std::string{}, pChapter->GetChapterPos(i + 1));
+          const std::chrono::milliseconds rawStart{pChapter->GetChapterPos(i + 1)};
+          const std::chrono::milliseconds rawEnd{i + 1 < ie ? pChapter->GetChapterPos(i + 2)
+                                                            : rawStreamEnd};
+          if (IsChapterFullyCut(m_Edl, rawStart, rawEnd))
+            continue;
+
+          auto& p = state.chapters.emplace_back(std::string{}, m_Edl.GetTimeWithoutCuts(rawStart));
           pChapter->GetChapterName(p.first, i + 1);
+          state.rawChapters.emplace_back(i + 1);
         }
       }
     }
 
-    CDVDInputStream::ITimes* pTimes = m_pInputStream->GetITimes();
-    CDVDInputStream::IDisplayTime* pDisplayTime = m_pInputStream->GetIDisplayTime();
-
-    CDVDInputStream::ITimes::Times times;
-    if (pTimes && pTimes->GetTimes(times))
+    if (haveTimes)
     {
       state.startTime = times.startTime;
       state.time = (m_clock.GetClock() - times.ptsStart) * 1000 / DVD_TIME_BASE;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5428,6 +5428,18 @@ bool IsChapterFullyCut(const CEdl& edl,
   }
   return false;
 }
+
+// Translate a raw demuxer/inputstream chapter number to the corresponding 1-based visible
+// chapter number using a just-built rawChapters map. Returns 0 if rawChapter has no visible
+// counterpart (e.g. it was filtered out as fully cut).
+int ToVisibleChapter(const std::vector<int>& rawChapters, int rawChapter)
+{
+  const auto it = std::ranges::find(rawChapters, rawChapter);
+  if (it != rawChapters.end())
+    return static_cast<int>(std::distance(rawChapters.begin(), it)) + 1;
+
+  return 0;
+}
 } // namespace
 
 void CVideoPlayer::UpdatePlayState(double timeout)
@@ -5457,16 +5469,6 @@ void CVideoPlayer::UpdatePlayState(double timeout)
 
   if (m_pDemuxer)
   {
-    if (IsInMenuInternal() && pMenu && !pMenu->CanSeek())
-    {
-      state.chapter = 0;
-    }
-    else
-    {
-      state.chapter = m_pDemuxer->GetChapter();
-      chapterNbEnabled = true;
-    }
-
     const std::chrono::milliseconds rawStreamLength{m_pDemuxer->GetStreamLength()};
 
     state.chapters.clear();
@@ -5490,6 +5492,17 @@ void CVideoPlayer::UpdatePlayState(double timeout)
         state.rawChapters.emplace_back(i + 1);
       }
     }
+
+    if (IsInMenuInternal() && pMenu && !pMenu->CanSeek())
+    {
+      state.chapter = 0;
+    }
+    else
+    {
+      state.chapter = ToVisibleChapter(state.rawChapters, m_pDemuxer->GetChapter());
+      chapterNbEnabled = true;
+    }
+
     state.time = DVD_TIME_TO_MSEC(m_clock.GetClock());
     // Let the clock catch up after seek
     if (m_CurrentVideo.startpts != DVD_NOPTS_VALUE &&
@@ -5524,16 +5537,6 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     CDVDInputStream::IChapter* pChapter = m_pInputStream->GetIChapter();
     if (pChapter)
     {
-      if (IsInMenuInternal() && pMenu && !pMenu->CanSeek())
-      {
-        state.chapter = 0;
-      }
-      else
-      {
-        state.chapter = pChapter->GetChapter();
-        chapterNbEnabled = true;
-      }
-
       state.chapters.clear();
       state.rawChapters.clear();
       if (const int chapterCount = pChapter->GetChapterCount(); chapterCount > 0)
@@ -5550,6 +5553,16 @@ void CVideoPlayer::UpdatePlayState(double timeout)
           pChapter->GetChapterName(p.first, i + 1);
           state.rawChapters.emplace_back(i + 1);
         }
+      }
+
+      if (IsInMenuInternal() && pMenu && !pMenu->CanSeek())
+      {
+        state.chapter = 0;
+      }
+      else
+      {
+        state.chapter = ToVisibleChapter(state.rawChapters, pChapter->GetChapter());
+        chapterNbEnabled = true;
       }
     }
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -50,6 +50,7 @@ struct SPlayerState
     menuType = MenuType::NONE;
     chapter = 0;
     chapters.clear();
+    rawChapters.clear();
     m_bookmarks.clear();
     canpause = false;
     canseek = false;
@@ -78,9 +79,15 @@ struct SPlayerState
   MenuType menuType;
   bool streamsReady;
 
-  int chapter; // 1-based current chapter. <=0 means no chapter / unknown
-  // name and start timestamp of chapters.
+  // 1-based current chapter, numbered among the chapters visible to the user (i.e. excluding
+  // chapters fully hidden by an EDL cut). <=0 means no chapter / unknown
+  int chapter;
+  // name and start timestamp of chapters visible to the user (chapters fully contained within
+  // an EDL cut are omitted).
   std::vector<std::pair<std::string, std::chrono::milliseconds>> chapters;
+  // for each entry in `chapters`, the corresponding 1-based chapter index reported by the
+  // demuxer/inputstream, used to translate a visible chapter number back to a seekable one.
+  std::vector<int> rawChapters;
   // position of the bookmarks
   std::vector<std::chrono::milliseconds> m_bookmarks;
 
@@ -514,6 +521,10 @@ protected:
   void UpdateFileItemStreamDetails(CFileItem& item, UpdateStreamDetails update);
   int GetPreviousChapter();
   std::optional<std::chrono::milliseconds> GetChapterPosMs(int chapterIdx = -1) const;
+  // Translate a 1-based visible chapter number (as seen by GetChapter()/GetChapterCount())
+  // to the 1-based chapter index expected by the demuxer/inputstream. Falls back to
+  // returning visibleChapter unchanged if no mapping is available yet.
+  int ToRawChapter(int visibleChapter) const;
   int GetPreviousBookmark(std::chrono::milliseconds ts);
   int GetNextBookmark(std::chrono::milliseconds ts);
   std::optional<std::chrono::milliseconds> GetBookmarkPos(int idx);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Determine the next/previous chapter not in an EDL and use SeekChapter() again.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #27864.

Fix issue identified in comments of #26655.

Chapter seeking failed for DVDs and Blurays transiently showed an invalid seek distance.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
