### PR TITLE
depends: disable CPython's _zstd module - not linkable outside its build tree

### DIFF
--- a/tools/depends/target/python3/Makefile
+++ b/tools/depends/target/python3/Makefile
@@ -70,7 +70,8 @@ PY_MODULES = py_cv_module_grp=n/a \
 # are not installed outside of the cpython build tree, and cause failure in kodi linking
 # If we wish to support them in the future, we should create "system libs" for them
 PY_MODULES+= py_cv_module__decimal=n/a \
-             py_cv_module__sha2=n/a
+             py_cv_module__sha2=n/a \
+             py_cv_module__zstd=n/a
 
 
 ifeq ($(OS), darwin_embedded)


### PR DESCRIPTION
Issue happens when trying to build on Linux see: https://github.com/clementperon/xbmc/actions/runs/29451591930/job/87475100353#logs

tools/depends/target/python3/Makefile already disables py_cv_module__decimal and py_cv_module__sha2 for exactly this reason (comment: "these modules use internal libs for building. The required static archives are not installed outside of the cpython build tree, and cause failure in kodi linking"). _zstd (new in Python 3.14, added after this exclusion list was last touched) hits the identical issue: CPython auto-enables it via unconditional pkg-config/header autodetection whenever zstd.h is ambiently present on the build host, and there is no --without-zstd configure flag to prevent that (confirmed against PEP 784 and the official configure docs - only override, not disable, hooks exist for it). Left enabled, Kodi's final link - which statically embeds all of libpython - fails with undefined ZSTD_* references. Add py_cv_module__zstd=n/a alongside the existing entries.

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
