### PR TITLE
[VideoPlayer][Android] Recognize Codec2 c2.mtk.* decoders for MTK DTS-as-PTS quirk

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -921,7 +921,7 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
 
   if (m_codecname.starts_with("OMX.Nvidia"))
     m_invalidPTSValue = AV_NOPTS_VALUE;
-  else if (m_codecname.starts_with("OMX.MTK"))
+  else if (m_codecname.starts_with("OMX.MTK") || m_codecname.starts_with("c2.mtk"))
     m_invalidPTSValue = -1; //Use DTS
   else
     m_invalidPTSValue = 0;


### PR DESCRIPTION
## Description
Extends the MediaTek vendor quirk in `CDVDVideoCodecAndroidMediaCodec::Open` to also match Codec2 decoder names (`c2.mtk*`), not just the legacy OMX prefix (`OMX.MTK*`):

```cpp
else if (m_codecname.starts_with("OMX.MTK") || m_codecname.starts_with("c2.mtk"))
  m_invalidPTSValue = -1; //Use DTS
```

## Motivation and context
PR #24491 added this quirk so MediaTek MediaCodec decoders fall back to DTS as `presentationTimeUs` when no real PTS is available — required for VC-1/WMV3 tracks stored as `V_MS/VFW/FOURCC` in Matroska, since FFmpeg's matroska demuxer always delivers these dts-only (`pts == AV_NOPTS_VALUE`).

Since Android 14, MediaTek exposes its decoders through the Codec2 (Treble) HAL under names like `c2.mtk.vc1.decoder` instead of `OMX.MTK.*`. The `starts_with("OMX.MTK")` check silently fails to match, `m_invalidPTSValue` stays `0`, every VC-1 packet gets `presentationTimeUs = 0`, and VideoPlayer permanently hurries/drops frames. Reported on a Sony Bravia (mt5897, Android 14) with:

```
CDVDVideoCodecAndroidMediaCodec::Open Using codec: c2.mtk.vc1.decoder
```

`m_codecname` comes verbatim (case-preserving) from JNI `MediaCodecInfo.getName()`, so the lowercase `c2.mtk.*` name reaches this check unmodified.

Fixes #28576.

## How has this been tested?
Single-line change matching the existing pattern for this decoder family; self-reviewed against the root-cause analysis in the issue. No local Android build was run — relying on CI. Hardware confirmation from the reporter's Sony Bravia/mt5897 device would be welcome.

Note: this fix was prepared with AI assistance during issue triage and subsequently human-reviewed.

## What is the effect on users?
VC-1/WMV3 video in Matroska plays with correct timestamps (no permanent frame dropping) on MediaTek Android 14+ devices using Codec2 decoders.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
