### PR TITLE
[Music] Extract embedded cover art from Matroska-based audio files

### DIFF
--- a/xbmc/music/tags/MusicInfoTagLoaderFFmpeg.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderFFmpeg.cpp
@@ -70,6 +70,38 @@ bool CMusicInfoTagLoaderFFmpeg::Load(const std::string& strFileName, CMusicInfoT
     return false;
   }
 
+  // Embedded cover art, e.g. Matroska (.mka) attachments following the Matroska
+  // Cover Art Guidelines (single "front cover" image named cover.jpg/cover.png)
+  for (unsigned int i = 0; i < fctx->nb_streams; ++i)
+  {
+    const AVStream* stream = fctx->streams[i];
+    if ((stream->disposition & AV_DISPOSITION_ATTACHED_PIC) == 0)
+      continue;
+
+    const AVDictionaryEntry* filenameTag =
+        av_dict_get(stream->metadata, "filename", nullptr, AV_DICT_IGNORE_SUFFIX);
+    const AVDictionaryEntry* mimeTag =
+        av_dict_get(stream->metadata, "mimetype", nullptr, AV_DICT_IGNORE_SUFFIX);
+
+    if (filenameTag && mimeTag &&
+        (StringUtils::EqualsNoCase(filenameTag->value, "cover.jpg") ||
+         StringUtils::EqualsNoCase(filenameTag->value, "cover.png")))
+    {
+      // Validate attached picture data before publishing cover art metadata.
+      // Malformed/empty packets (null data or zero size) would cause undefined behavior
+      // in EmbeddedArt::Set (which does m_data.assign(data, data+size)).
+      if (stream->attached_pic.data != nullptr && stream->attached_pic.size > 0)
+      {
+        tag.SetCoverArtInfo(stream->attached_pic.size, mimeTag->value);
+        if (art)
+          art->Set(stream->attached_pic.data, stream->attached_pic.size, mimeTag->value);
+      }
+      // Per Matroska cover art guidelines, only one cover stream is expected,
+      // so break even if this attachment was invalid (no point continuing to scan).
+      break;
+    }
+  }
+
   /* ffmpeg supports the return of ID3v2 metadata but has its own naming system
      for some, but not all, of the keys. In particular the key for the conductor
      tag TPE3 is called "performer".


### PR DESCRIPTION
## Description
`CMusicInfoTagLoaderFFmpeg::Load` (used for `.mka`, `.dsf`, `.dff`) accepted an `EmbeddedArt* art` parameter but never read or wrote it, so cover art embedded in Matroska-based audio files was silently dropped — neither the library scanner nor the on-demand embedded-image loader could surface it.

After `avformat_open_input` succeeds and before the existing metadata-tag loop, the loader now scans `fctx->streams` for streams flagged `AV_DISPOSITION_ATTACHED_PIC`. Per the Matroska Cover Art Guidelines (and matching the single "front cover" semantics `CTagLoaderTagLib` already applies to mp3/flac/wma), a stream whose `filename` metadata is `cover.jpg` or `cover.png` is treated as the song's embedded thumb:

- `tag.SetCoverArtInfo(size, mime)` is always called, so the library scanner can record that cover art exists and generate an `image://` URL.
- When the caller passes a non-null `art` pointer (e.g. `CMusicEmbeddedImageFileLoader`), `art->Set(data, size, mime)` is also called — the same two-call pattern used throughout `TagLoaderTagLib.cpp`.

## Motivation and context
`CVideoTagLoaderFFmpeg::LoadMKV` already handles the identical Matroska attachment mechanism for `.mkv` video files; there was no equivalent on the audio side even though `.mka` shares the same container and cover-art convention.

Single-file change, no header/API changes, no new dependencies (pure libavformat logic already used in this file).

Fixes #15215.

## How has this been tested?
No existing unit tests or test-media fixture infrastructure cover `CMusicInfoTagLoaderFFmpeg` (or its video sibling), so no automated test was added. Manual verification: scan a `.mka` file with an embedded `cover.jpg`/`cover.png` attachment and confirm the cover shows in the library.

Note: this fix was prepared with AI assistance during issue triage and subsequently human-reviewed.

## What is the effect on users?
Cover art embedded in `.mka` audio files now shows up in the music library, matching the existing behavior for mp3/flac/wma.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
