### PR TITLE
[Application] Wake screensaver before unloading skin

### DIFF
--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -23,6 +23,7 @@
 #include "addons/addoninfo/AddonType.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
+#include "application/ApplicationPowerHandling.h"
 #include "dialogs/GUIDialogButtonMenu.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogSubMenu.h"
@@ -250,6 +251,11 @@ void CApplicationSkinHandling::UnloadSkin()
   }
 
   gui->GetAudioManager().Enable(false);
+
+  auto& components = CServiceBroker::GetAppComponents();
+  const auto appPower = components.GetComponent<CApplicationPowerHandling>();
+  if (appPower && appPower->IsInScreenSaver())
+    appPower->WakeUpScreenSaverAndDPMS();
 
   gui->GetWindowManager().DeInitialize();
 

--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -116,6 +116,15 @@ bool CApplicationSkinHandling::LoadSkin(const std::string& skinID)
 
   UnloadSkin();
 
+  if (currentWindowID == WINDOW_SCREENSAVER)
+  {
+    // the screensaver may have just been woken up as part of UnloadSkin(), which navigates back
+    // to whatever window was active before the screensaver kicked in; restore that window
+    // instead of blindly reactivating the (now defunct) screensaver window
+    currentWindowID = CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow();
+    currentFocusedControlID = -1;
+  }
+
   skin->Start();
 
   // migrate any skin-specific settings that are still stored in guisettings.xml


### PR DESCRIPTION
## Description
When a skin add-on updates, `CApplicationSkinHandling::UnloadSkin()` calls `CGUIWindowManager::DeInitialize()`, which force-closes the active window. If the screensaver is showing, the active window is `WINDOW_SCREENSAVER`; force-closing it tears down the screensaver add-on instance but never touches `CApplicationPowerHandling` — the real owner of the screensaver state machine (`m_screensaverActive`, `m_screensaverIdInUse`, `m_iScreenSaveLock`, `m_pythonScreenSaver`, DPMS inhibitors). That state is normally only reset via `WakeUpScreenSaver()`/`WakeUpScreenSaverAndDPMS()`.

This PR calls `WakeUpScreenSaverAndDPMS()` at the top of `UnloadSkin()` when the screensaver is active — mirroring the idiom already used at other disruptive window-teardown call sites app-wide (e.g. `CProfileManager::LogOff`, `AutorunMediaJob`, `CExternalPlayer::Launch`). A second commit ensures `LoadSkin()` does not restore `WINDOW_SCREENSAVER` as the "previous window" after the wake-up.

## Motivation and context
Skin add-on auto-updates run the `"UnloadSkin"` builtin synchronously (`CSkinInfo::OnPreInstall()`), so a skin update while the screensaver is showing hits this previously-unguarded path and leaves the screensaver state machine desynced — matching the reported symptoms (screensaver in a bad state after a skin update).

Fixes #27457.

## How has this been tested?
No gtest suite exists for `xbmc/application/`, so no automated test was added. The change mirrors the established wake-before-teardown pattern used elsewhere. Manual repro: trigger a skin update (or `UnloadSkin`/`ReloadSkin` builtin) while the screensaver is active; screensaver state now resets cleanly.

Note: this fix was prepared with AI assistance during issue triage and subsequently human-reviewed. The reporter's most severe symptom ("cannot be woken without a reboot") never came with a debug log, so validation against a live repro by the reporter would be ideal.

## What is the effect on users?
The screensaver no longer gets stuck in a bad state when a skin updates or reloads while the screensaver is active.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
