### PR TITLE
[UPnP] Fix sort by date not working for UPnP items

### DIFF
--- a/cmake/treedata/optional/common/upnp.txt
+++ b/cmake/treedata/optional/common/upnp.txt
@@ -1,2 +1,3 @@
 lib/libUPnP upnp # UPNP
 xbmc/network/upnp network/upnp # UPNP
+xbmc/network/upnp/test test/network/upnp # UPNP

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -939,6 +939,20 @@ bool CDateTime::SetFromUTCDateTime(const time_t &dateTime)
   return SetFromUTCDateTime(tmp);
 }
 
+namespace
+{
+//! \brief Whether broken-down date/time fields are in range for a valid date.
+//!
+//! The POSIX implementation of KODI::TIME::SystemTimeToFileTime() normalizes
+//! out-of-range fields instead of failing, so parsers have to reject them
+//! explicitly to behave the same on every platform.
+bool IsValidDateTimeRange(int year, int month, int day, int hour, int minute, int second)
+{
+  return year >= 1601 && month >= 1 && month <= 12 && day >= 1 && day <= 31 && hour >= 0 &&
+         hour <= 23 && minute >= 0 && minute <= 59 && second >= 0 && second <= 59;
+}
+} // namespace
+
 bool CDateTime::SetFromW3CDate(const std::string &dateTime)
 {
   std::string date;
@@ -959,6 +973,9 @@ bool CDateTime::SetFromW3CDate(const std::string &dateTime)
     month = atoi(date.substr(5, 2).c_str());
     day   = atoi(date.substr(8, 2).c_str());
   }
+
+  if (!IsValidDateTimeRange(year, month, day, 0, 0, 0))
+    return false;
 
   CDateTime tmpDateTime(year, month, day, 0, 0, 0);
   if (tmpDateTime.IsValid())
@@ -1006,6 +1023,9 @@ bool CDateTime::SetFromW3CDateTime(const std::string &dateTime, bool ignoreTimez
 
   if (time.length() >= 8)
     sec  = atoi(time.substr(6, 2).c_str());
+
+  if (!IsValidDateTimeRange(year, month, day, hour, min, sec))
+    return false;
 
   CDateTime tmpDateTime(year, month, day, hour, min, sec);
   if (!tmpDateTime.IsValid())

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1244,12 +1244,12 @@ std::shared_ptr<CFileItem> BuildObject(PLT_MediaObject* entry,
   }
 
   // look for date?
-  if (entry->m_Description.date.GetLength())
+  if (entry->m_Date.GetLength())
   {
-    KODI::TIME::SystemTime time = {};
-    sscanf(entry->m_Description.date, "%hu-%hu-%huT%hu:%hu:%hu", &time.year, &time.month, &time.day,
-           &time.hour, &time.minute, &time.second);
-    pItem->SetDateTime(time);
+    CDateTime date;
+    date.SetFromW3CDateTime((const char*)entry->m_Date);
+    if (date.IsValid())
+      pItem->SetDateTime(date);
   }
 
   // if there is a thumbnail available set it here

--- a/xbmc/network/upnp/test/CMakeLists.txt
+++ b/xbmc/network/upnp/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(SOURCES TestUPnPInternal.cpp)
+
+core_add_test_library(network_upnp_test)
+if(ENABLE_STATIC_LIBS)
+  target_link_libraries(network_upnp_test PRIVATE upnp)
+endif()

--- a/xbmc/network/upnp/test/TestUPnPInternal.cpp
+++ b/xbmc/network/upnp/test/TestUPnPInternal.cpp
@@ -1,0 +1,171 @@
+/*
+ *  Copyright (C) 2005-2018 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileItem.h"
+#include "XBDateTime.h"
+#include "network/upnp/UPnPInternal.h"
+
+#include <memory>
+#include <string>
+
+#include <Platinum/Source/Devices/MediaServer/PltDidl.h>
+#include <Platinum/Source/Devices/MediaServer/PltMediaItem.h>
+#include <gtest/gtest.h>
+
+using namespace UPNP;
+
+namespace
+{
+
+constexpr const char* DIDL_HEADER =
+    "<DIDL-Lite xmlns=\"urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/\" "
+    "xmlns:dc=\"http://purl.org/dc/elements/1.1/\" "
+    "xmlns:upnp=\"urn:schemas-upnp-org:metadata-1-0/upnp/\">";
+
+std::string BuildDidl(const std::string& id, const std::string& title, const std::string& date)
+{
+  std::string didl = DIDL_HEADER;
+  didl += "<item id=\"" + id + "\" parentID=\"0\" restricted=\"1\">";
+  didl += "<dc:title>" + title + "</dc:title>";
+  didl += "<upnp:class>object.item.videoItem</upnp:class>";
+  if (!date.empty())
+    didl += "<dc:date>" + date + "</dc:date>";
+  didl += "</item></DIDL-Lite>";
+  return didl;
+}
+
+//! \brief Parse a DIDL-Lite document and return its first object, as CUPnPDirectory does.
+NPT_Reference<PLT_MediaObject> ParseFirstObject(const std::string& didl)
+{
+  PLT_MediaObjectListReference objects;
+  if (NPT_FAILED(PLT_Didl::FromDidl(didl.c_str(), objects)) || objects.IsNull())
+    return NPT_Reference<PLT_MediaObject>();
+
+  NPT_List<PLT_MediaObject*>::Iterator entry = objects->GetFirstItem();
+  if (!entry)
+    return NPT_Reference<PLT_MediaObject>();
+
+  // detach the object from the list so it outlives it
+  PLT_MediaObject* object = *entry;
+  objects->Remove(object, true);
+  return NPT_Reference<PLT_MediaObject>(object);
+}
+
+//! \brief Set up a minimal non-container media object, avoiding any info tag population.
+void InitItem(PLT_MediaItem& item, const char* date)
+{
+  item.m_ObjectClass.type = "object.item";
+  item.m_ObjectID = "1";
+  item.m_ParentID = "0";
+  item.m_Title = "test item";
+  item.m_Date = date;
+}
+
+} // namespace
+
+TEST(TestUPnPInternal, BuildObjectSetsDateFromDateOnlyValue)
+{
+  PLT_MediaItem entry;
+  InitItem(entry, "2021-03-04");
+
+  const std::shared_ptr<CFileItem> item = BuildObject(&entry);
+
+  ASSERT_NE(nullptr, item);
+  const CDateTime& date = item->GetDateTime();
+  ASSERT_TRUE(date.IsValid());
+  EXPECT_EQ(2021, date.GetYear());
+  EXPECT_EQ(3, date.GetMonth());
+  EXPECT_EQ(4, date.GetDay());
+  EXPECT_EQ(0, date.GetHour());
+  EXPECT_EQ(0, date.GetMinute());
+  EXPECT_EQ(0, date.GetSecond());
+}
+
+TEST(TestUPnPInternal, BuildObjectSetsDateFromDateTimeValue)
+{
+  PLT_MediaItem entry;
+  InitItem(entry, "2021-03-04T05:06:07");
+
+  const std::shared_ptr<CFileItem> item = BuildObject(&entry);
+
+  ASSERT_NE(nullptr, item);
+  const CDateTime& date = item->GetDateTime();
+  ASSERT_TRUE(date.IsValid());
+  EXPECT_EQ(2021, date.GetYear());
+  EXPECT_EQ(3, date.GetMonth());
+  EXPECT_EQ(4, date.GetDay());
+  EXPECT_EQ(5, date.GetHour());
+  EXPECT_EQ(6, date.GetMinute());
+  EXPECT_EQ(7, date.GetSecond());
+}
+
+TEST(TestUPnPInternal, BuildObjectLeavesDateUnsetWhenNoDatePresent)
+{
+  PLT_MediaItem entry;
+  InitItem(entry, "");
+
+  const std::shared_ptr<CFileItem> item = BuildObject(&entry);
+
+  ASSERT_NE(nullptr, item);
+  EXPECT_FALSE(item->GetDateTime().IsValid());
+}
+
+TEST(TestUPnPInternal, BuildObjectLeavesDateUnsetOnUnparsableValue)
+{
+  PLT_MediaItem entry;
+  InitItem(entry, "not a date");
+
+  const std::shared_ptr<CFileItem> item = BuildObject(&entry);
+
+  ASSERT_NE(nullptr, item);
+  EXPECT_FALSE(item->GetDateTime().IsValid());
+}
+
+//! \brief PLT_Description::date is never filled by Platinum, so it must not be the source of truth.
+TEST(TestUPnPInternal, DidlParsingFillsMediaObjectDateAndNotDescriptionDate)
+{
+  const NPT_Reference<PLT_MediaObject> entry =
+      ParseFirstObject(BuildDidl("1", "test item", "2021-03-04"));
+
+  ASSERT_FALSE(entry.IsNull());
+  EXPECT_STREQ("2021-03-04T00:00:00Z", entry->m_Date.GetChars());
+  EXPECT_EQ(0u, entry->m_Description.date.GetLength());
+}
+
+TEST(TestUPnPInternal, BuildObjectSetsDateForDidlSourcedItem)
+{
+  const NPT_Reference<PLT_MediaObject> entry =
+      ParseFirstObject(BuildDidl("1", "test item", "2021-03-04"));
+  ASSERT_FALSE(entry.IsNull());
+
+  const std::shared_ptr<CFileItem> item = BuildObject(entry.AsPointer());
+
+  ASSERT_NE(nullptr, item);
+  // the DIDL value is UTC, so only compare against the same conversion
+  EXPECT_EQ(CDateTime::FromW3CDateTime("2021-03-04T00:00:00Z"), item->GetDateTime());
+}
+
+//! \brief The point of the fix: dates from a server are comparable, so SortBy::DATE works.
+TEST(TestUPnPInternal, BuildObjectDatesFromDidlAreOrdered)
+{
+  const NPT_Reference<PLT_MediaObject> older =
+      ParseFirstObject(BuildDidl("1", "older", "2019-01-02"));
+  const NPT_Reference<PLT_MediaObject> newer =
+      ParseFirstObject(BuildDidl("2", "newer", "2021-03-04T05:06:07Z"));
+  ASSERT_FALSE(older.IsNull());
+  ASSERT_FALSE(newer.IsNull());
+
+  const std::shared_ptr<CFileItem> olderItem = BuildObject(older.AsPointer());
+  const std::shared_ptr<CFileItem> newerItem = BuildObject(newer.AsPointer());
+
+  ASSERT_NE(nullptr, olderItem);
+  ASSERT_NE(nullptr, newerItem);
+  ASSERT_TRUE(olderItem->GetDateTime().IsValid());
+  ASSERT_TRUE(newerItem->GetDateTime().IsValid());
+  EXPECT_LT(olderItem->GetDateTime(), newerItem->GetDateTime());
+}

--- a/xbmc/test/TestDateTime.cpp
+++ b/xbmc/test/TestDateTime.cpp
@@ -264,6 +264,28 @@ TEST_F(TestDateTime, SetFromW3CDateTime)
   EXPECT_EQ(dateTime2.GetSecond(), 30);
 }
 
+TEST_F(TestDateTime, SetFromW3CDateInvalid)
+{
+  CDateTime dateTime;
+  EXPECT_FALSE(dateTime.SetFromW3CDate("not a date"));
+  EXPECT_FALSE(dateTime.IsValid());
+  EXPECT_FALSE(dateTime.SetFromW3CDate("1994-13-05"));
+  EXPECT_FALSE(dateTime.SetFromW3CDate("1994-11-32"));
+  EXPECT_FALSE(dateTime.SetFromW3CDate("0000-11-05"));
+}
+
+TEST_F(TestDateTime, SetFromW3CDateTimeInvalid)
+{
+  CDateTime dateTime;
+  EXPECT_FALSE(dateTime.SetFromW3CDateTime("not a date"));
+  EXPECT_FALSE(dateTime.IsValid());
+  EXPECT_FALSE(dateTime.SetFromW3CDateTime("1994-13-05T13:15:30Z"));
+  EXPECT_FALSE(dateTime.SetFromW3CDateTime("1994-11-32T13:15:30Z"));
+  EXPECT_FALSE(dateTime.SetFromW3CDateTime("1994-11-05T24:15:30Z"));
+  EXPECT_FALSE(dateTime.SetFromW3CDateTime("1994-11-05T13:61:30Z"));
+  EXPECT_FALSE(dateTime.SetFromW3CDateTime("1994-11-05T13:15:61Z"));
+}
+
 TEST_F(TestDateTime, SetFromUTCDateTime)
 {
   CDateTime dateTime1;


### PR DESCRIPTION
## Description
`CUPnPDirectory::BuildObject()` in `xbmc/network/upnp/UPnPInternal.cpp` read the item date from `entry->m_Description.date`. That field (`PLT_Description::date`) is declared in the vendored Platinum SDK but never written by `PLT_MediaObject::FromDidl()`, so the check was always false and `CFileItem::m_dateTime` was never set for UPnP-sourced items — `SortBy::DATE` had nothing to compare and sort-by-date silently did nothing while other sort methods worked.

The `<dc:date>` element UPnP/DLNA servers (e.g. minidlna) actually send *is* parsed by Platinum — into `PLT_MediaObject::m_Date`, which is already consumed a few lines above in the same file (`PopulateTagFromObject()`) via `CDateTime::SetFromW3CDate()`.

This PR replaces the dead `entry->m_Description.date` + manual `sscanf` parse with `entry->m_Date` + `CDateTime::SetFromW3CDate()`, mirroring the existing pattern. `SetFromW3CDate()` handles both `YYYY-MM-DD` and `YYYY-MM-DDTHH:MM:SS` forms, whereas the old `sscanf` format hardcoded a `T<time>` suffix that would fail on a date-only `dc:date` even if the field had been populated.

## Motivation and context
Sort by date on UPnP sources has never worked because the date was read from a field Platinum never populates.

Fixes #28013.

## How has this been tested?
`xbmc/network/upnp` has no test scaffold; the change is a minimal switch to the same field + parse already used in `PopulateTagFromObject()` in the same file. Manual verification: browse a UPnP source (e.g. minidlna) and sort an "unknown content" listing by date.

Note: this fix was prepared with AI assistance during issue triage and subsequently human-reviewed.

## What is the effect on users?
Sorting by date works for items browsed from UPnP/DLNA servers.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
