### PR TITLE
[Profiles][Addons] Fix add-on database staying closed after profile switch

### DIFF
--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -69,9 +69,13 @@ bool CDatabaseManager::InitializeInternal()
   const std::shared_ptr<CAdvancedSettings> advancedSettings =
       CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
 
-  // NOTE: CAddonDatabase initialized in the constructor
   // NOTE: Order here is important. In particular, CTextureDatabase has to be updated
   //       before CVideoDatabase.
+  // NOTE: CAddonDatabase must be re-registered here too (not just in the constructor), as
+  //       Deinitialize() clears m_dbStatus on every profile switch, which would otherwise
+  //       leave the addon database unable to reopen for the remainder of the new profile.
+  if (ADDON::CAddonDatabase db; !UpdateDatabase(db))
+    return false;
   if (CViewDatabase db; !UpdateDatabase(db))
     return false;
   if (CTextureDatabase db; !UpdateDatabase(db))

--- a/xbmc/addons/gui/GUIDialogAddonInfo.cpp
+++ b/xbmc/addons/gui/GUIDialogAddonInfo.cpp
@@ -850,8 +850,8 @@ bool CGUIDialogAddonInfo::SetItem(const CFileItemPtr& item)
 
   m_item = std::make_shared<CFileItem>(*item);
   m_localAddon.reset();
-  if (CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), m_localAddon,
-                                             OnlyEnabled::CHOICE_NO))
+  if (!CServiceBroker::GetAddonMgr().GetAddon(item->GetAddonInfo()->ID(), m_localAddon,
+                                              OnlyEnabled::CHOICE_NO))
   {
     CLog::LogF(LOGDEBUG, "Addon with id {} not found locally.", item->GetAddonInfo()->ID());
   }

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -404,7 +404,9 @@ void CProfileManager::FinalizeLoadProfile()
   networkManager.NetworkMessage(CNetworkBase::SERVICES_UP, 1);
 
   // reload the add-ons, or we will first load all add-ons from the master account without checking disabled status
-  addonManager.ReInit();
+  if (!addonManager.ReInit())
+    CLog::Log(LOGERROR, "Failed to reinitialize the add-on manager for profile \"{}\"",
+              GetCurrentProfile().getName());
 
   // let CApplication know that we are logging into a new profile
   g_application.SetLoggingIn(true);


### PR DESCRIPTION
## Description
Fixes add-ons becoming unmanageable (enable/disable has no lasting effect) after switching from the master profile to a user profile.

Changes:
1. `xbmc/DatabaseManager.cpp`: `InitializeInternal()` now also calls `UpdateDatabase()` for `ADDON::CAddonDatabase`, mirroring the existing pattern for the other databases, so the add-on database is re-registered as READY on every profile switch (not only at process startup). Replaced the stale comment.
2. `xbmc/addons/gui/GUIDialogAddonInfo.cpp`: fixed an inverted condition in `SetItem()` that logged "not found locally" exactly when the add-on *was* found.
3. `xbmc/profiles/ProfileManager.cpp`: `FinalizeLoadProfile()` now logs an error if `CAddonMgr::ReInit()` fails instead of silently ignoring the return value.

## Motivation and context
Root cause:
- `CDatabaseManager`'s constructor opens `CAddonDatabase` exactly once at app startup, recording it as READY in `m_dbStatus["Addons"]`.
- `CProfileManager::LoadProfile()` calls `CDatabaseManager::Deinitialize()` (`m_dbStatus.clear()`) followed by `Initialize()` on every profile switch.
- `InitializeInternal()` re-registered the View/Texture/Music/Video/PVR/Epg databases but skipped `CAddonDatabase`, per a stale comment assuming the constructor already handled it — true only for the first profile.
- `CProfileManager::FinalizeLoadProfile()` then calls `CAddonMgr::ReInit()`, which reopens the add-on database via `CDatabase::Open()`. `Open()` gates on `CDatabaseManager::CanOpen("Addons")`, which now returns `false`, so the add-on database silently stays closed for the rest of the profile session and add-on enable/disable writes have no lasting effect.

Fixes #28550.

## How has this been tested?
Repro from the report: create a second profile, install/enable/disable an add-on while in that profile, and confirm the change now persists (including across a subsequent profile switch). Also confirms the add-on-info debug log no longer misreports found add-ons as "not found locally". No test infrastructure exists for `CDatabaseManager` or `CGUIDialogAddonInfo` (heavy `CServiceBroker`/GUI fixture requirements), so no automated test was added.

Note: this fix was prepared with AI assistance during issue triage and subsequently human-reviewed.

## What is the effect on users?
Add-ons can be enabled/disabled/managed normally after switching profiles; the changes persist.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
