### PR TITLE
[interfaces/legacy] Add ControlVideoWindow to support getControl() on videowindow skin controls

### DIFF
--- a/xbmc/interfaces/legacy/Control.cpp
+++ b/xbmc/interfaces/legacy/Control.cpp
@@ -27,6 +27,7 @@
 #include "guilib/GUIRadioButtonControl.h"
 #include "guilib/GUISliderControl.h"
 #include "guilib/GUITextBox.h"
+#include "guilib/GUIVideoControl.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/listproviders/StaticProvider.h"
 #include "utils/StringUtils.h"
@@ -551,6 +552,30 @@ namespace XBMCAddon
                                          (float) dwPosY,
                                          (float) dwWidth,
                                          (float) dwHeight);
+      pGUIControl->SetVisible(m_visible);
+      return pGUIControl;
+    }
+
+    // ============================================================
+
+    // ============================================================
+    // ============================================================
+    ControlVideoWindow::ControlVideoWindow(long x, long y, long width, long height)
+    {
+      dwPosX = x;
+      dwPosY = y;
+      dwWidth = width;
+      dwHeight = height;
+    }
+
+    CGUIControl* ControlVideoWindow::Create()
+    {
+      pGUIControl = new CGUIVideoControl(iParentId,
+                                          iControlId,
+                                          (float)dwPosX,
+                                          (float)dwPosY,
+                                          (float)dwWidth,
+                                          (float)dwHeight);
       pGUIControl->SetVisible(m_visible);
       return pGUIControl;
     }

--- a/xbmc/interfaces/legacy/Control.h
+++ b/xbmc/interfaces/legacy/Control.h
@@ -2503,6 +2503,49 @@ namespace XBMCAddon
     };
     /// @}
 
+    // ControlVideoWindow class
+    ///
+    /// \defgroup python_xbmcgui_control_videowindow Subclass - ControlVideoWindow
+    /// \ingroup python_xbmcgui_control
+    /// @{
+    /// @brief **Used to embed the video window inside a group of other controls.**
+    ///
+    /// \python_class{ ControlVideoWindow(x, y, width, height) }
+    ///
+    /// The video window control is a placeholder that shows the video output of
+    /// the current playing video within an area of the skin, positioned and
+    /// sized like any other control.
+    ///
+    /// @note This class include also all calls from \ref python_xbmcgui_control "Control"
+    ///
+    /// @param x                    integer - x coordinate of control.
+    /// @param y                    integer - y coordinate of control.
+    /// @param width                integer - width of control.
+    /// @param height               integer - height of control.
+    ///
+    ///
+    ///--------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.py}
+    /// ...
+    /// self.videowindow = xbmcgui.ControlVideoWindow(100, 250, 125, 75)
+    /// ...
+    /// ~~~~~~~~~~~~~
+    ///
+    class ControlVideoWindow : public Control
+    {
+    public:
+      ControlVideoWindow(long x, long y, long width, long height);
+
+#ifndef SWIG
+      CGUIControl* Create() override;
+
+      inline ControlVideoWindow() = default;
+#endif
+    };
+    /// @}
+
     // ControlRadioButton class
     ///
     /// \defgroup python_xbmcgui_control_radiobutton Subclass - ControlRadioButton

--- a/xbmc/interfaces/legacy/Window.cpp
+++ b/xbmc/interfaces/legacy/Window.cpp
@@ -311,6 +311,9 @@ namespace XBMCAddon
       case CGUIControl::GUICONTROL_SLIDER:
         pControl = new ControlSlider();
         break;
+      case CGUIControl::GUICONTROL_VIDEO:
+        pControl = new ControlVideoWindow();
+        break;
       case CGUIControl::GUICONTAINER_LIST:
       case CGUIControl::GUICONTAINER_WRAPLIST:
       case CGUIControl::GUICONTAINER_FIXEDLIST:


### PR DESCRIPTION
## Description
Adds a `ControlVideoWindow` Python xbmcgui wrapper class so that `Window.getControl()` works for skin controls of type `<control type="videowindow">`.

Implementation follows the existing `ControlGroup` pattern exactly, since it's the closest analog — a control type with no skin-specific properties beyond position/size, which the base Python `Control` class already exposes generically (`getPosition`, `getX`, `getY`, `getWidth`, `getHeight`, `setPosition`, `setWidth`, `setHeight`):

1. `xbmc/interfaces/legacy/Control.h` — new `class ControlVideoWindow : public Control` with a `(long x, long y, long width, long height)` constructor and `CGUIControl* Create() override`, plus a Doxygen block modeled on `ControlGroup`'s.
2. `xbmc/interfaces/legacy/Control.cpp` — constructor and `Create()` (`new CGUIVideoControl(...)`).
3. `xbmc/interfaces/legacy/Window.cpp` — `case CGUIControl::GUICONTROL_VIDEO:` in the `getControl()` switch.

No SWIG interface changes needed — `AddonModuleXbmcgui.i` already does a blanket `%include "interfaces/legacy/Control.h"`.

## Motivation and context
`Window::getControl()` switches on `CGUIControl::GetControlType()` to build the right Python wrapper, but had no case for `CGUICONTROL_VIDEO`; it fell through to `default`, leaving `pControl == nullptr` and throwing `WindowException("Unknown control type for python")`. Any addon calling `self.getControl(id)` on a videowindow control hit this exception, even though the underlying `CGUIVideoControl` fully supports generic position/size handling (it reads `m_posX/m_posY/m_width/m_height` directly in `Render()` with no custom overrides).

Fixes #19467.

## How has this been tested?
No gtest suite exists for `xbmc/interfaces/legacy/`. Manual verification: skin with `<control type="videowindow">` plus `self.getControl(id).setPosition(...)` from a Python addon, per the original report.

Note: this change was prepared with AI assistance during issue triage and subsequently human-reviewed.

## What is the effect on users?
Python addons can retrieve and reposition/resize the videowindow control via `Window.getControl()` instead of getting an exception.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
