### PR TITLE
[Input] Bind global keyboard Guide key to open TV Guide

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -115,6 +115,7 @@
       <!-- PVR windows -->
       <e>ActivateWindow(TVGuide)</e>
       <epg>ActivateWindow(TVGuide)</epg>
+      <guide>ActivateWindow(TVGuide)</guide>
       <h>ActivateWindow(TVChannels)</h>
       <j>ActivateWindow(RadioChannels)</j>
       <k>ActivateWindow(TVRecordings)</k>


### PR DESCRIPTION
## Description
Adds a single line to the global `<keyboard>` section of `system/keymaps/keyboard.xml`:

```xml
<guide>ActivateWindow(TVGuide)</guide>
```

placed next to the existing `<epg>ActivateWindow(TVGuide)</epg>` entry.

## Motivation and context
The global `<keyboard>` section never defined a `<guide>` button, even though it's already bound under `device=remote` (`remote.xml`) and `device=joystick` (`joystick.xml`). Platforms whose input backend maps a hardware/remote "Guide" key to the `XBMCK_GUIDE` keysym — webOS's Wayland seat via `XKB_KEY_WEBOS_TVGUIDE` (`XkbcommonKeymap.cpp`), Android via `AKEYCODE_GUIDE` — resolve that key to keyboard vkey `0xE0`, i.e. buttoncode `0xF0E0` (61664). With no default keyboard-device action bound to `"guide"`, pressing the remote's dedicated TV Guide key did nothing.

This matches what the reporter found: manually binding buttoncode `61664` to "Open TV-EPG" via the Keymap Editor add-on made the button work. This change makes that binding the default, mirroring the pre-existing `<i>Info</i>` / `<info>Info</info>` pattern in the same file. `CKeyboardTranslator::TranslateString("guide")` already resolved to `0xF0E0` before this change — only the default action was missing.

Fixes #27100.

## How has this been tested?
Single-line XML data change, no source code touched. Verified against the key-translation path (`XBMC_keytable.cpp` / `XBMC_vkeys.h`). Manual verification: send keyboard buttoncode `61664` (Keymap Editor or debug key injection) and confirm the TV Guide opens; final end-to-end confirmation on webOS hardware would be welcome.

Note: this change was prepared with AI assistance during issue triage and subsequently human-reviewed.

## What is the effect on users?
The dedicated Guide key on remotes that report it as a keyboard key (webOS, Android) opens the TV Guide out of the box.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
