### PR TITLE
[VideoInfoDownloader] Propagate real scrape result from threaded GetDetails/GetEpisodeDetails/GetEpisodeList

### DIFF
--- a/xbmc/video/VideoInfoDownloader.cpp
+++ b/xbmc/video/VideoInfoDownloader.cpp
@@ -62,9 +62,11 @@ void CVideoInfoDownloader::Process()
   // note here that we're calling our external functions but we're calling them with
   // no progress bar set, so they're effectively calling our internal functions directly.
   m_found = 0;
+  m_result = false;
   if (m_state == FIND_MOVIE)
   {
-    if (!(m_found=FindMovie(m_movieTitle, m_movieYear, m_movieList)))
+    m_found = FindMovie(m_movieTitle, m_movieYear, m_movieList);
+    if (!m_found)
       CLog::Log(LOGERROR, "{}: Error looking up item {} ({})", __FUNCTION__, m_movieTitle,
                 m_movieYear);
     m_state = DO_NOTHING;
@@ -80,19 +82,22 @@ void CVideoInfoDownloader::Process()
   }
   else if (m_state == GET_DETAILS)
   {
-    if (!GetDetails(m_uniqueIDs, m_url, m_movieDetails))
+    m_result = GetDetails(m_uniqueIDs, m_url, m_movieDetails);
+    if (!m_result)
       CLog::Log(LOGERROR, "{}: Error getting details from {}", __FUNCTION__,
                 m_url.GetFirstThumbUrl());
   }
   else if (m_state == GET_EPISODE_DETAILS)
   {
-    if (!GetEpisodeDetails(m_url, m_movieDetails))
+    m_result = GetEpisodeDetails(m_url, m_movieDetails);
+    if (!m_result)
       CLog::Log(LOGERROR, "{}: Error getting episode details from {}", __FUNCTION__,
                 m_url.GetFirstThumbUrl());
   }
   else if (m_state == GET_EPISODE_LIST)
   {
-    if (!GetEpisodeList(m_url, m_episode))
+    m_result = GetEpisodeList(m_url, m_episode);
+    if (!m_result)
       CLog::Log(LOGERROR, "{}: Error getting episode list from {}", __FUNCTION__,
                 m_url.GetFirstThumbUrl());
   }
@@ -177,8 +182,9 @@ bool CVideoInfoDownloader::GetDetails(const ADDON::CScraper::UniqueIDs& uniqueID
       CThread::Sleep(1ms);
     }
     movieDetails = m_movieDetails;
+    bool result = m_result;
     CloseThread();
-    return true;
+    return result;
   }
   else  // unthreaded
     return m_info->GetVideoDetails(*m_http, m_uniqueIDs, url, true /*fMovie*/, movieDetails);
@@ -212,8 +218,9 @@ bool CVideoInfoDownloader::GetEpisodeDetails(const CScraperUrl &url,
       CThread::Sleep(1ms);
     }
     movieDetails = m_movieDetails;
+    bool result = m_result;
     CloseThread();
-    return true;
+    return result;
   }
   else  // unthreaded
     return m_info->GetVideoDetails(*m_http, m_uniqueIDs, url, false /*fMovie*/, movieDetails);
@@ -247,8 +254,9 @@ bool CVideoInfoDownloader::GetEpisodeList(const CScraperUrl& url,
       CThread::Sleep(1ms);
     }
     movieDetails = m_episode;
+    bool result = m_result;
     CloseThread();
-    return true;
+    return result;
   }
   else  // unthreaded
     return !(movieDetails = m_info->GetEpisodeList(*m_http, url)).empty();

--- a/xbmc/video/VideoInfoDownloader.h
+++ b/xbmc/video/VideoInfoDownloader.h
@@ -13,6 +13,7 @@
 #include "addons/Scraper.h"
 #include "threads/Thread.h"
 
+#include <atomic>
 #include <string>
 #include <vector>
 
@@ -80,8 +81,9 @@ protected:
   CVideoInfoTag       m_movieDetails;
   CScraperUrl         m_url;
   KODI::VIDEO::EPISODELIST m_episode;
-  LOOKUP_STATE m_state = DO_NOTHING;
-  int m_found = 0;
+  std::atomic<LOOKUP_STATE> m_state{DO_NOTHING};
+  std::atomic<int> m_found{0};
+  std::atomic<bool> m_result{false};
   ADDON::ScraperPtr   m_info;
 
   // threaded stuff


### PR DESCRIPTION
## Description
The threaded (progress-dialog) branches of `CVideoInfoDownloader::GetDetails()`, `GetEpisodeDetails()` and `GetEpisodeList()` unconditionally returned `true` after their worker thread finished, regardless of whether the scraper call inside `Process()` actually succeeded.

Changes:
- Added a `bool m_result` member to `CVideoInfoDownloader` to carry the real per-call result, separate from `m_found`, which remains purely a "thread finished" signal for the wait loops (`FIND_MOVIE` already relies on `m_found` carrying its real result, so it is left untouched). `m_result` is reset at the start of `Process()`.
- In `Process()`, the `GET_DETAILS`, `GET_EPISODE_DETAILS`, and `GET_EPISODE_LIST` branches store the actual boolean result of the inner call into `m_result`.
- The threaded branches of the three public methods now return that result (copied before `CloseThread()`) instead of hardcoded `true`.

## Motivation and context
`Process()` already computed the real success/failure of the inner scraper call (previously used only for error logging), but the public threaded wrapper always reported success. When a scraper's identifier-based lookup fails (e.g. the TVDB v4 add-on's `getdetails` failing for a `{tvdb-######}`-tagged folder, as in the reporter's debug log), callers explicitly designed to fall back to a title search on failure — `VideoLibraryRefreshingJob::DoWork()` and `CVideoInfoScanner::RetrieveInfoForTvShow()` — never saw the failure, so the fallback never ran and a near-empty `CVideoInfoTag` was written into the library.

This restores already-intended fallback behavior; the unthreaded (`pProgress == nullptr`) code paths already returned the real result and are unchanged.

Fixes #27208.

## How has this been tested?
`CVideoInfoDownloader` calls into `ADDON::CScraper` (non-virtual, add-on-backed network calls) and drives a real `CGUIDialogProgress`, so a focused gtest would need mocking infrastructure that doesn't exist for this module; no test was added. Manual repro: source folder named `Show (Year) {tvdb-<bad_id>}` with a scraper failing `getdetails` for that id during library refresh (progress dialog shown). Before: a near-empty item is silently added with no fallback search. After: the fallback title search runs and is logged.

Note: this fix was prepared with AI assistance during issue triage and subsequently human-reviewed.

## What is the effect on users?
When a scraper lookup by unique id fails, Kodi falls back to a title search as intended instead of silently adding a nearly empty library entry.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed

