### PR TITLE
[Skin] Avoid false error when custom windows repeat across res folders

### DIFF
--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -50,6 +50,8 @@
 #include "video/dialogs/GUIDialogFullScreenInfo.h"
 #include "windowing/WinSystem.h"
 
+#include <set>
+
 using namespace KODI::MESSAGING;
 
 CApplicationSkinHandling::CApplicationSkinHandling(IMsgTargetCallback* msgCb,
@@ -283,6 +285,12 @@ bool CApplicationSkinHandling::LoadCustomWindows()
   std::vector<std::string> vecSkinPath;
   skin->GetSkinPaths(vecSkinPath);
 
+  // A skin can have more than one <res> folder (e.g. a resolution/aspect-matched folder
+  // plus a default fallback folder). The same custom*.xml is commonly present, unchanged,
+  // in more than one of these folders, so track which files have already been processed
+  // to tell an expected duplicate from a genuine window id collision.
+  std::set<std::string> processedSkinFiles;
+
   for (const auto& skinPath : vecSkinPath)
   {
     CLog::Log(LOGINFO, "Loading custom window XMLs from skin path {}", skinPath);
@@ -298,6 +306,9 @@ bool CApplicationSkinHandling::LoadCustomWindows()
         std::string skinFile = URIUtils::GetFileName(item->GetPath());
         if (StringUtils::StartsWithNoCase(skinFile, "custom"))
         {
+          std::string skinFileLower = skinFile;
+          StringUtils::ToLower(skinFileLower);
+
           CXBMCTinyXML xmlDoc;
           if (!xmlDoc.LoadFile(item->GetPath()))
           {
@@ -341,6 +352,20 @@ bool CApplicationSkinHandling::LoadCustomWindows()
           if (id == WINDOW_INVALID ||
               CServiceBroker::GetGUI()->GetWindowManager().GetWindow(windowId))
           {
+            // A skin file of the same name was already successfully loaded from a
+            // higher-priority skin path (e.g. the resolution-matched <res> folder). This is
+            // the expected fallback duplicate from a lower-priority <res> folder, not a
+            // genuine id collision, so skip it quietly.
+            if (id != WINDOW_INVALID &&
+                processedSkinFiles.find(skinFileLower) != processedSkinFiles.end())
+            {
+              CLog::Log(LOGDEBUG,
+                        "Skipping duplicate custom window {} already loaded from a "
+                        "higher-priority skin path",
+                        skinFile);
+              continue;
+            }
+
             // No id specified or id already in use
             CLog::Log(LOGERROR, "No id specified or id already in use for custom window in {}",
                       skinFile);
@@ -390,6 +415,7 @@ bool CApplicationSkinHandling::LoadCustomWindows()
                                                    : CGUIWindow::KEEP_IN_MEMORY);
 
           CServiceBroker::GetGUI()->GetWindowManager().AddCustomWindow(pWindow);
+          processedSkinFiles.insert(skinFileLower);
         }
       }
     }


### PR DESCRIPTION
## Description
`CSkinInfo::GetSkinPaths()` can return two skin directories for a skin with multiple `<res>` folders: the resolution/aspect-matched folder and, if different, the `default="true"` fallback folder. `LoadCustomWindows()` walks every `custom*.xml` in each of these folders in turn.

When a skin author keeps an identically-named `customXXX.xml` (same id) in both res folders — the normal case when only sizes/positions differ between resolutions — the window is registered from the matched folder, then the same numeric id is seen again in the default folder. This tripped the id-conflict check and logged:

```
No id specified or id already in use for custom window in customXXX.xml
```

even though nothing is wrong: the matched-resolution version is correctly the one in use.

In `CApplicationSkinHandling::LoadCustomWindows()`, this PR tracks the (case-insensitive) basenames of custom window files already loaded via `AddCustomWindow()`. When the id-conflict check fires for a file whose name was already processed, it is treated as the expected fallback duplicate from a lower-priority `<res>` folder and skipped quietly (`LOGDEBUG`). A collision between two *differently-named* custom window files (a genuine authoring mistake) still logs `LOGERROR`, as does a missing id.

## Motivation and context
Skin authors get a spurious error in the log for a perfectly valid multi-resolution skin layout, which causes noise when debugging real problems.

Fixes #26712.

## How has this been tested?
No `test/` directory exists for `xbmc/application/`, so no gtest was added. Manual verification: skin add-on with the same `customXXX.xml` id present in two `<res>` folders — the error is no longer logged; genuinely conflicting ids across differently-named files still log an error.

Note: this fix was prepared with AI assistance during issue triage and subsequently human-reviewed.

## What is the effect on users?
Skin developers no longer see a false "id already in use" error when custom windows are repeated across resolution folders.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
