### PR TITLE
[GUILabel] Fix setLabel(font=...) not changing rendered font

### DIFF
--- a/xbmc/guilib/GUIButtonControl.cpp
+++ b/xbmc/guilib/GUIButtonControl.cpp
@@ -388,10 +388,11 @@ void CGUIButtonControl::PythonSetLabel(const std::string& strFont,
                                        KODI::UTILS::COLOR::Color shadowColor,
                                        KODI::UTILS::COLOR::Color focusedColor)
 {
-  m_label.GetLabelInfo().font = g_fontManager.GetFont(strFont);
+  m_label.SetLabelFont(g_fontManager.GetFont(strFont));
   m_label.GetLabelInfo().textColor = textColor;
   m_label.GetLabelInfo().focusedColor = focusedColor;
   m_label.GetLabelInfo().shadowColor = shadowColor;
+  m_label2.SetLabelFont(g_fontManager.GetFont(strFont));
   SetLabel(strText);
 }
 

--- a/xbmc/guilib/GUILabel.cpp
+++ b/xbmc/guilib/GUILabel.cpp
@@ -51,6 +51,12 @@ bool CGUILabel::SetScrolling(bool scrolling)
   return changed;
 }
 
+void CGUILabel::SetLabelFont(CGUIFont* font)
+{
+  m_label.font = font;
+  m_textLayout.SetFont(font);
+}
+
 bool CGUILabel::SetOverflow(OVER_FLOW overflow)
 {
   bool changed = m_overflowType != overflow;

--- a/xbmc/guilib/GUILabel.h
+++ b/xbmc/guilib/GUILabel.h
@@ -197,6 +197,13 @@ public:
   const CLabelInfo& GetLabelInfo() const { return m_label; }
   CLabelInfo& GetLabelInfo() { return m_label; }
 
+  /*! \brief Set the font used to render this label
+   Updates both the label info and the underlying text layout, so that the new font actually
+   takes effect on the next render.
+   \param font the new font to use
+   */
+  void SetLabelFont(CGUIFont* font);
+
   /*! \brief Check a left aligned and right aligned label for overlap and cut the labels off so that no overlap occurs
 
    If a left-aligned label occupies some of the same space on screen as a right-aligned label, then we may be able to

--- a/xbmc/guilib/GUITextLayout.cpp
+++ b/xbmc/guilib/GUITextLayout.cpp
@@ -55,6 +55,17 @@ void CGUITextLayout::SetWrap(bool bWrap)
   m_wrap = bWrap;
 }
 
+void CGUITextLayout::SetFont(CGUIFont* font)
+{
+  const bool usingMonoFont = m_font != nullptr && m_font == m_monoFont;
+  m_varFont = font;
+  m_font = usingMonoFont ? m_monoFont : font;
+
+  // invalidate the cached text so the next Update()/UpdateW() re-lays out using the new font
+  m_lastUtf8Text.clear();
+  m_lastText.clear();
+}
+
 void CGUITextLayout::Render(float x,
                             float y,
                             float angle,

--- a/xbmc/guilib/GUITextLayout.h
+++ b/xbmc/guilib/GUITextLayout.h
@@ -128,6 +128,13 @@ public:
   void SetWrap(bool bWrap=true);
   void SetMaxHeight(float fHeight);
 
+  /*! \brief Set the font used to render this text, replacing the one given at construction
+   Invalidates any cached layout so that the next call to Update()/UpdateW() re-lays out the
+   text using the new font, even if the text itself has not changed.
+   \param font the new font to use
+   */
+  void SetFont(CGUIFont* font);
+
   static void DrawText(CGUIFont* font,
                        float x,
                        float y,

--- a/xbmc/guilib/test/CMakeLists.txt
+++ b/xbmc/guilib/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES TestGUIControlFactory.cpp
             TestGamesGUIInfo.cpp
+            TestGUILabel.cpp
             TestGUITextLayout.cpp
             TestSkinMapManager.cpp
 )

--- a/xbmc/guilib/test/TestGUILabel.cpp
+++ b/xbmc/guilib/test/TestGUILabel.cpp
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2005-2024 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "guilib/GUILabel.h"
+
+#include <gtest/gtest.h>
+
+// Regression test for the bug reported where CGUIButtonControl::PythonSetLabel (and thus
+// xbmcgui.ControlButton.setLabel()/ControlRadioButton.setLabel()) changed the font stored in the
+// label's CLabelInfo but never reached the CGUITextLayout that actually performs the rendering.
+// Because CGUITextLayout::Update() short-circuits when the text string itself hasn't changed, the
+// font change was silently dropped whenever the label text stayed the same. CGUILabel::SetLabelFont
+// must both update the label info and force the text layout to re-run on the next SetText() call,
+// even for otherwise unchanged text.
+TEST(TestGUILabel, SetLabelFontForcesRelayoutOfUnchangedText)
+{
+  CLabelInfo labelInfo;
+  ASSERT_EQ(labelInfo.font, nullptr);
+
+  CGUILabel label(0, 0, 100, 100, labelInfo, CGUILabel::OVER_FLOW_TRUNCATE);
+
+  // Initial SetText() always triggers a layout since the label starts invalid.
+  EXPECT_TRUE(label.SetText("hello"));
+
+  // Setting the exact same text again should not require any relayout.
+  EXPECT_FALSE(label.SetText("hello"));
+
+  // Changing the label's font (as PythonSetLabel does) must invalidate the cached layout, so that
+  // the very next SetText() call - even with unchanged text - is forced to relayout and pick up
+  // the new font.
+  label.SetLabelFont(nullptr);
+  EXPECT_EQ(label.GetLabelInfo().font, nullptr);
+  EXPECT_TRUE(label.SetText("hello"));
+
+  // With no further font changes, the cache behaves normally again.
+  EXPECT_FALSE(label.SetText("hello"));
+}


### PR DESCRIPTION
## Description
`CGUIButtonControl::PythonSetLabel` (backing `xbmcgui.ControlButton.setLabel()` / `ControlRadioButton.setLabel()`) set `m_label.GetLabelInfo().font = g_fontManager.GetFont(strFont)`, mutating `CLabelInfo` — but the actual text rendering goes through `CGUILabel`'s private `CGUITextLayout m_textLayout`, which captured its `CGUIFont*` once at construction and had no way to be repointed. Combined with `CGUITextLayout::Update()` short-circuiting when the text string is unchanged, `setLabel(text, font=...)` silently had no visual effect.

Changes:
- `xbmc/guilib/GUITextLayout.h/.cpp`: new public `SetFont(CGUIFont* font)` that updates `m_varFont`/`m_font` (respecting whichever of mono/var font is active) and clears the cached `m_lastText`/`m_lastUtf8Text`, forcing the next `Update()`/`UpdateW()` to re-lay out against the new font.
- `xbmc/guilib/GUILabel.h`: new `CGUILabel::SetLabelFont(CGUIFont* font)` forwarding method that updates `CLabelInfo::font` and calls `m_textLayout.SetFont(font)`.
- `xbmc/guilib/GUIButtonControl.cpp`: `PythonSetLabel` now uses `SetLabelFont()` for both the label and label2 instead of mutating `CLabelInfo` directly.
- `xbmc/guilib/test/TestGUILabel.cpp` (new): regression test asserting that after `SetLabelFont()`, `CGUILabel::SetText()` is forced to relayout even when called with unchanged text.

`CGUIRadioButtonControl` does not override `PythonSetLabel`, so both `ControlButton.setLabel` and `ControlRadioButton.setLabel` are covered by this single fix.

## Motivation and context
Python addons calling `setLabel('text', font='font60')` see no font change — the font change never reached the layout that renders the label.

Fixes #28581.

## How has this been tested?
New unit test `TestGUILabel` (registered in `xbmc/guilib/test/CMakeLists.txt`) covering the relayout-after-font-change behavior, plus review of the render path (`CGUITextLayout::Render` uses `m_font`, which is now correctly repointed).

Note: this fix was prepared with AI assistance during issue triage and subsequently human-reviewed.

## What is the effect on users?
`ControlButton.setLabel()` / `ControlRadioButton.setLabel()` with a `font` argument actually changes the rendered font in Python addons.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
