### PR TITLE
[VideoPlayer] Fix mediacodec fallback lost on mpegts H.264 resume

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -684,6 +684,7 @@ void CDVDDemuxFFmpeg::Flush()
   m_displayTime = 0;
   m_dtsAtDisplayTime = DVD_NOPTS_VALUE;
   m_seekToKeyFrame = false;
+  m_streamChangeDuringSeek = false;
 }
 
 void CDVDDemuxFFmpeg::Abort()
@@ -1205,6 +1206,20 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
 
 DemuxPacket* CDVDDemuxFFmpeg::Read()
 {
+  // A stream change was detected and discarded while SeekTime() was waiting for the
+  // transport stream to become ready. Deliver the deferred marker now, before any real
+  // data packet, so VideoPlayer::Process() still reopens the video codec with complete
+  // hints (see SeekTime()'s m_checkTransportStream wait loop).
+  if (m_streamChangeDuringSeek)
+  {
+    m_streamChangeDuringSeek = false;
+
+    DemuxPacket* pPacket = CDVDDemuxUtils::AllocateDemuxPacket(0);
+    pPacket->iStreamId = DMX_SPECIALID_STREAMCHANGE;
+    pPacket->demuxerId = GetDemuxerId();
+    return pPacket;
+  }
+
   return ReadInternal(false);
 }
 
@@ -1253,9 +1268,21 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double* startpts)
 
     while (!IsTransportStreamReady())
     {
-      DemuxPacket* pkt = Read();
+      // Call ReadInternal() directly rather than Read(): this loop must keep draining
+      // real packets until the transport stream is ready, so it must not be short-circuited
+      // by the deferred stream-change marker that Read() may hand out (see m_streamChangeDuringSeek).
+      DemuxPacket* pkt = ReadInternal(false);
       if (pkt)
+      {
+        // Read() would normally hand this marker to VideoPlayer so it can reopen the video
+        // codec with complete hints once mpegts/H.264 extradata parsing finishes. This loop
+        // discards it instead, so remember it and let the next Read() call after SeekTime()
+        // deliver it, once the caller starts reading normally again.
+        if (pkt->iStreamId == DMX_SPECIALID_STREAMCHANGE)
+          m_streamChangeDuringSeek = true;
+
         CDVDDemuxUtils::FreeDemuxPacket(pkt);
+      }
       else
         KODI::TIME::Sleep(10ms);
       m_pkt.result = -1;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -179,5 +179,10 @@ protected:
   double m_dtsAtDisplayTime;
   bool m_seekToKeyFrame = false;
   double m_startTime = 0;
+
+  // set when a DMX_SPECIALID_STREAMCHANGE packet is discarded by the m_checkTransportStream
+  // wait loop in SeekTime(); the next Read() call then synthesizes the marker so
+  // VideoPlayer::Process() still gets notified of the stream change it would otherwise miss
+  bool m_streamChangeDuringSeek = false;
   std::vector<ChapterFFmpeg> m_chapters;
 };


### PR DESCRIPTION
## Description
On mpegts + H.264 inputs, resuming playback at a non-zero position got stuck on the ffmpeg software decoder instead of mediacodec, even though starting from position 0 correctly used hardware decoding.

Changes in `CDVDDemuxFFmpeg`:
- New `m_streamChangeDuringSeek` member remembering that a stream-change marker was discarded during the seek wait loop.
- `SeekTime()`'s `m_checkTransportStream` wait loop now calls `ReadInternal()` directly (instead of the public `Read()`) so it isn't short-circuited by its own deferred marker, and sets `m_streamChangeDuringSeek` when it discards a `DMX_SPECIALID_STREAMCHANGE` packet. It still drains packets until `IsTransportStreamReady()` — only the notification to `VideoPlayer` was being lost.
- `Read()` checks `m_streamChangeDuringSeek` first and, if set, clears it and immediately returns a synthesized `DMX_SPECIALID_STREAMCHANGE` packet before any real data, reproducing the position-0 behavior.
- `Flush()` resets the flag so a stale marker can't survive into an unrelated seek/flush.

## Motivation and context
`CDVDDemuxFFmpeg` defers filling in extradata/dimensions for mpegts streams via `ParsePacket()` (the `m_checkTransportStream` path). The first video codec `Open()` therefore happens with incomplete hints and mediacodec rejects it, falling back to software. Once the SPS parse completes, `Read()` returns a synthetic `DMX_SPECIALID_STREAMCHANGE` packet; `VideoPlayer::Process()` reacts by calling `OpenDefaultStreams(false)`, which reopens the codec with complete hints and lets mediacodec succeed — that's why position-0 playback ends up on hardware.

When resuming at a non-zero position, `SeekTime()`'s wait loop calls `Read()` internally and unconditionally frees whatever packet comes back — including the `DMX_SPECIALID_STREAMCHANGE` marker — without inspecting `pkt->iStreamId`. `VideoPlayer::Process()` never sees the marker, `OpenDefaultStreams()` is never re-invoked, and the session stays on the software decoder for the rest of playback.

Fixes #28537.

## How has this been tested?
`CDVDDemuxFFmpeg` is tightly coupled to a live `AVFormatContext`/`CDVDInputStream` and isn't seamed for unit testing (the existing `TestDVDDemuxUtils.cpp` covers the separate helper functions), so no test was added. Manual verification: play an mpegts + H.264 file with a resume position set; a `CDVDDemuxFFmpeg::Read() stream change` debug log line now appears shortly after the seek (previously absent on resume, present on position-0 start). Confirmation on Android hardware that mediacodec is selected after resume would be welcome.

Note: this fix was prepared with AI assistance during issue triage and subsequently human-reviewed.

## What is the effect on users?
Resuming mpegts H.264 recordings at a saved position uses hardware decoding again instead of silently dropping to software decode.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
