### PR TITLE
[Video] Fix movie set info folder path encoding for URL-based sources

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1786,6 +1786,15 @@ std::string URIUtils::AddFileToFolder(const std::string& strFolder,
   return strResult;
 }
 
+std::string URIUtils::AddFileToFolderMatchingEncoding(const std::string& strFolder,
+                                                      const std::string& strFile)
+{
+  if (HasEncodedFilename(CURL(strFolder)))
+    return AddFileToFolder(strFolder, CURL::Encode(strFile));
+
+  return AddFileToFolder(strFolder, strFile);
+}
+
 std::string URIUtils::GetDirectory(const std::string &strFilePath)
 {
   // Will from a full filename return the directory the file resides in.

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -354,6 +354,21 @@ public:
     return AddFileToFolder(newPath, args...);
   }
 
+  /*!
+   \brief Append a segment to a folder, matching the folder's filename encoding.
+
+   Sources whose paths keep the filename portion percent-encoded (WebDAV, http, ...)
+   cannot resolve a path built by appending a raw, human readable segment, because the
+   result ends up with mixed encoding. This helper percent-encodes \p strFile when
+   \p strFolder reports an encoded filename and appends it verbatim otherwise.
+
+   \param strFolder base folder, either a local path or a URL
+   \param strFile raw (unencoded) segment to append
+   \return the combined path, consistently encoded
+   */
+  static std::string AddFileToFolderMatchingEncoding(const std::string& strFolder,
+                                                     const std::string& strFile);
+
   static bool HasParentInHostname(const CURL& url);
   static bool HasEncodedHostname(const CURL& url);
   static bool HasEncodedFilename(const CURL& url);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -1268,6 +1268,25 @@ TEST_F(TestURIUtils, AddFileToFolder)
   EXPECT_EQ(ref, var);
 }
 
+TEST_F(TestURIUtils, AddFileToFolderEncodedFilename)
+{
+  // Base folders that report an encoded filename (e.g. WebDAV) must have any raw, human
+  // readable segment percent-encoded before being appended, otherwise the resulting URL
+  // ends up with mixed encoding (see xbmc/video/VideoInfoScanner.cpp GetMovieSetInfoFolder).
+  const std::string base = "davs://user:pass@host/Movie%20Set%20Information%20Folder/";
+  std::string title = "Star Wars Collection";
+
+  if (URIUtils::HasEncodedFilename(CURL(base)))
+    title = CURL::Encode(title);
+  const std::string result = URIUtils::AddFileToFolder(base, title);
+
+  const std::string ref =
+      "davs://user:pass@host/Movie%20Set%20Information%20Folder/Star%20Wars%20Collection";
+  EXPECT_EQ(ref, result);
+  // No literal spaces should remain in the filename portion of the URL.
+  EXPECT_EQ(std::string::npos, CURL(result).GetFileName().find(' '));
+}
+
 TEST_F(TestURIUtils, HasParentInHostname)
 {
   EXPECT_TRUE(URIUtils::HasParentInHostname(CURL("zip://")));

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -1268,23 +1268,92 @@ TEST_F(TestURIUtils, AddFileToFolder)
   EXPECT_EQ(ref, var);
 }
 
-TEST_F(TestURIUtils, AddFileToFolderEncodedFilename)
+TEST_F(TestURIUtils, AddFileToFolderMatchingEncodingEncodedFolder)
 {
   // Base folders that report an encoded filename (e.g. WebDAV) must have any raw, human
   // readable segment percent-encoded before being appended, otherwise the resulting URL
   // ends up with mixed encoding (see xbmc/video/VideoInfoScanner.cpp GetMovieSetInfoFolder).
-  const std::string base = "davs://user:pass@host/Movie%20Set%20Information%20Folder/";
-  std::string title = "Star Wars Collection";
+  std::string ref = "davs://user:pass@host/Movie%20Set%20Information%20Folder/"
+                    "Star%20Wars%20Collection";
+  std::string var = URIUtils::AddFileToFolderMatchingEncoding(
+      "davs://user:pass@host/Movie%20Set%20Information%20Folder/", "Star Wars Collection");
+  EXPECT_EQ(ref, var);
+  // No literal space may remain in the filename portion of the URL.
+  EXPECT_EQ(std::string::npos, CURL(var).GetFileName().find(' '));
 
-  if (URIUtils::HasEncodedFilename(CURL(base)))
-    title = CURL::Encode(title);
-  const std::string result = URIUtils::AddFileToFolder(base, title);
+  // Same for the non-secure WebDAV, http and https protocols.
+  ref = "dav://host/sets/Star%20Wars%20Collection";
+  var = URIUtils::AddFileToFolderMatchingEncoding("dav://host/sets/", "Star Wars Collection");
+  EXPECT_EQ(ref, var);
 
-  const std::string ref =
-      "davs://user:pass@host/Movie%20Set%20Information%20Folder/Star%20Wars%20Collection";
-  EXPECT_EQ(ref, result);
-  // No literal spaces should remain in the filename portion of the URL.
-  EXPECT_EQ(std::string::npos, CURL(result).GetFileName().find(' '));
+  ref = "http://host/sets/Star%20Wars%20Collection";
+  var = URIUtils::AddFileToFolderMatchingEncoding("http://host/sets/", "Star Wars Collection");
+  EXPECT_EQ(ref, var);
+
+  ref = "https://host/sets/Star%20Wars%20Collection";
+  var = URIUtils::AddFileToFolderMatchingEncoding("https://host/sets/", "Star Wars Collection");
+  EXPECT_EQ(ref, var);
+
+  // A missing slash at the end of the folder is handled as by AddFileToFolder().
+  ref = "https://host/sets/Star%20Wars%20Collection";
+  var = URIUtils::AddFileToFolderMatchingEncoding("https://host/sets", "Star Wars Collection");
+  EXPECT_EQ(ref, var);
+
+  // An empty segment leaves the folder untouched (bar the trailing slash).
+  ref = "https://host/sets/";
+  var = URIUtils::AddFileToFolderMatchingEncoding("https://host/sets/", "");
+  EXPECT_EQ(ref, var);
+}
+
+TEST_F(TestURIUtils, AddFileToFolderMatchingEncodingSpecialCharacters)
+{
+  // Characters that are legal in a file name but not in a URL must be encoded as well,
+  // otherwise the server sees a query/fragment/separator instead of a name.
+  std::string ref = "https://host/sets/Fast%20%26%20Furious%20Collection";
+  std::string var =
+      URIUtils::AddFileToFolderMatchingEncoding("https://host/sets/", "Fast & Furious Collection");
+  EXPECT_EQ(ref, var);
+
+  ref = "https://host/sets/Marvel%27s%20Avengers";
+  var = URIUtils::AddFileToFolderMatchingEncoding("https://host/sets/", "Marvel's Avengers");
+  EXPECT_EQ(ref, var);
+
+  // A percent sign in the title must be escaped, not passed through as an escape sequence.
+  ref = "https://host/sets/100%25%20Collection";
+  var = URIUtils::AddFileToFolderMatchingEncoding("https://host/sets/", "100% Collection");
+  EXPECT_EQ(ref, var);
+
+  // Non-ASCII titles are encoded byte-wise (UTF-8, lowercase hex as produced by URLEncode).
+  ref = "https://host/sets/Am%c3%a9lie%20Collection";
+  var = URIUtils::AddFileToFolderMatchingEncoding("https://host/sets/", "Amélie Collection");
+  EXPECT_EQ(ref, var);
+
+  // Characters exempt from encoding per RFC1738 are kept verbatim.
+  ref = "https://host/sets/Alien-Quadrilogy_(1979).!";
+  var =
+      URIUtils::AddFileToFolderMatchingEncoding("https://host/sets/", "Alien-Quadrilogy_(1979).!");
+  EXPECT_EQ(ref, var);
+}
+
+TEST_F(TestURIUtils, AddFileToFolderMatchingEncodingUnencodedFolder)
+{
+  // Folders that don't use an encoded file name must behave exactly like AddFileToFolder(),
+  // i.e. the segment is appended verbatim and stays human readable.
+  const std::array<std::string, 5> folders = {"/home/user/sets/", "smb://host/share/sets/",
+                                              "nfs://host/export/sets/", "C:\\videos\\sets\\",
+                                              "ftp://host/sets/"};
+
+  const std::string title = "Star Wars Collection";
+  for (const auto& folder : folders)
+  {
+    const std::string var = URIUtils::AddFileToFolderMatchingEncoding(folder, title);
+    EXPECT_EQ(URIUtils::AddFileToFolder(folder, title), var) << "folder: " << folder;
+    EXPECT_NE(std::string::npos, var.find(title)) << "folder: " << folder;
+  }
+
+  // An empty folder is passed through unchanged as well.
+  EXPECT_EQ(URIUtils::AddFileToFolder("", "Star Wars Collection"),
+            URIUtils::AddFileToFolderMatchingEncoding("", "Star Wars Collection"));
 }
 
 TEST_F(TestURIUtils, HasParentInHostname)

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -10673,8 +10673,10 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           }
         }
 
-        const std::string itemPath = URIUtils::AddFileToFolder(
-            movieSetsDir, CUtil::MakeLegalFileName(title, LegalPath::WIN32_COMPAT));
+        std::string safeTitle = CUtil::MakeLegalFileName(title, LegalPath::WIN32_COMPAT);
+        if (URIUtils::HasEncodedFilename(CURL(movieSetsDir)))
+          safeTitle = CURL::Encode(safeTitle);
+        const std::string itemPath = URIUtils::AddFileToFolder(movieSetsDir, safeTitle);
         if (CDirectory::Exists(itemPath) || CDirectory::Create(itemPath))
         {
           // get set information and generate .nfo

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11285,9 +11285,11 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         item.SetArt(artItem.GetArt());
         if (item.GetVideoInfoTag()->m_set.HasTitle())
         {
-          std::string setPath = URIUtils::AddFileToFolder(
-              movieSetsDir, CUtil::MakeLegalFileName(item.GetVideoInfoTag()->m_set.GetTitle(),
-                                                     LegalPath::WIN32_COMPAT));
+          std::string safeSetTitle = CUtil::MakeLegalFileName(
+              item.GetVideoInfoTag()->m_set.GetTitle(), LegalPath::WIN32_COMPAT);
+          if (URIUtils::HasEncodedFilename(CURL(movieSetsDir)))
+            safeSetTitle = CURL::Encode(safeSetTitle);
+          std::string setPath = URIUtils::AddFileToFolder(movieSetsDir, safeSetTitle);
           if (CDirectory::Exists(setPath))
           {
             KODI::ART::Artwork setArt;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -10673,10 +10673,8 @@ void CVideoDatabase::ExportToXML(const std::string &path, bool singleFile /* = t
           }
         }
 
-        std::string safeTitle = CUtil::MakeLegalFileName(title, LegalPath::WIN32_COMPAT);
-        if (URIUtils::HasEncodedFilename(CURL(movieSetsDir)))
-          safeTitle = CURL::Encode(safeTitle);
-        const std::string itemPath = URIUtils::AddFileToFolder(movieSetsDir, safeTitle);
+        const std::string itemPath = URIUtils::AddFileToFolderMatchingEncoding(
+            movieSetsDir, CUtil::MakeLegalFileName(title, LegalPath::WIN32_COMPAT));
         if (CDirectory::Exists(itemPath) || CDirectory::Create(itemPath))
         {
           // get set information and generate .nfo
@@ -11285,11 +11283,9 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         item.SetArt(artItem.GetArt());
         if (item.GetVideoInfoTag()->m_set.HasTitle())
         {
-          std::string safeSetTitle = CUtil::MakeLegalFileName(
-              item.GetVideoInfoTag()->m_set.GetTitle(), LegalPath::WIN32_COMPAT);
-          if (URIUtils::HasEncodedFilename(CURL(movieSetsDir)))
-            safeSetTitle = CURL::Encode(safeSetTitle);
-          std::string setPath = URIUtils::AddFileToFolder(movieSetsDir, safeSetTitle);
+          std::string setPath = URIUtils::AddFileToFolderMatchingEncoding(
+              movieSetsDir, CUtil::MakeLegalFileName(item.GetVideoInfoTag()->m_set.GetTitle(),
+                                                     LegalPath::WIN32_COMPAT));
           if (CDirectory::Exists(setPath))
           {
             KODI::ART::Artwork setArt;

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1891,8 +1891,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
         CSettings::SETTING_VIDEOLIBRARY_MOVIESETSFOLDER);
     if (path.empty())
       return "";
-    path = URIUtils::AddFileToFolder(path,
-                                     CUtil::MakeLegalFileName(setTitle, LegalPath::WIN32_COMPAT));
+    std::string safeTitle = CUtil::MakeLegalFileName(setTitle, LegalPath::WIN32_COMPAT);
+    if (URIUtils::HasEncodedFilename(CURL(path)))
+      safeTitle = CURL::Encode(safeTitle);
+    path = URIUtils::AddFileToFolder(path, safeTitle);
     URIUtils::AddSlashAtEnd(path);
     CLog::Log(LOGDEBUG,
         "VideoInfoScanner: Looking for local artwork for movie set '{}' in folder '{}'",

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1891,10 +1891,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
         CSettings::SETTING_VIDEOLIBRARY_MOVIESETSFOLDER);
     if (path.empty())
       return "";
-    std::string safeTitle = CUtil::MakeLegalFileName(setTitle, LegalPath::WIN32_COMPAT);
-    if (URIUtils::HasEncodedFilename(CURL(path)))
-      safeTitle = CURL::Encode(safeTitle);
-    path = URIUtils::AddFileToFolder(path, safeTitle);
+    path = URIUtils::AddFileToFolderMatchingEncoding(
+        path, CUtil::MakeLegalFileName(setTitle, LegalPath::WIN32_COMPAT));
     URIUtils::AddSlashAtEnd(path);
     CLog::Log(LOGDEBUG,
         "VideoInfoScanner: Looking for local artwork for movie set '{}' in folder '{}'",


### PR DESCRIPTION
## Description
`CVideoInfoScanner::GetMovieSetInfoFolder()` and the movie-set NFO export in `CVideoDatabase::ExportToXML()` built the movie set artwork/NFO folder path by appending the raw (space-containing) set title to the *Movie Set Information Folder* setting via `URIUtils::AddFileToFolder()`.

For URL-style sources such as WebDAV (`davs://`), the base folder path stays percent-encoded (`CURL::Parse()` never decodes the filename portion), but the appended title was left un-encoded, producing a mixed-encoding URL:

```
davs://host/Movie%20Set%20Information%20Folder/Star Wars Collection/
```

which the WebDAV client cannot resolve, so local set artwork is never found (`CDirectory::Exists()` fails) and NFO export writes to the wrong path.

Both call sites now use the idiom already used by `CStackDirectory::GetStackedTitlePath()`: check `URIUtils::HasEncodedFilename()` on the base folder's `CURL` and, if true, `CURL::Encode()` the legalized title before appending. A second commit applies the same treatment to the movie-set import path in `CVideoDatabase`, so importing from an encoded backend resolves the same folder.

`CVideoItemArtworkMovieSetHandler::GetLocalArt()` / `AddItemPathToFileBrowserSources()` call `GetMovieSetInfoFolder()`, so they are fixed too with no changes there.

## Motivation and context
Movie set artwork stored under a *Movie Set Information Folder* on a WebDAV source is never picked up when the set title contains spaces (or other URL-encodable characters).

Fixes #26190.

## How has this been tested?
Added `TestURIUtils.AddFileToFolderEncodedFilename` (`xbmc/utils/test/TestURIUtils.cpp`), exercising the encode-then-append pattern against a WebDAV-style base path and a title containing spaces, asserting the resulting URL is fully and consistently percent-encoded. Manual verification against a live WebDAV source with a set title containing spaces is recommended.

Note: this fix was prepared with AI assistance during issue triage and subsequently human-reviewed.

## What is the effect on users?
Movie set artwork and NFOs in a *Movie Set Information Folder* on WebDAV (and other URL-encoded) sources are found and exported correctly for set titles containing spaces.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
