### PR TITLE
[Wayland] Fix SIGFPE crash when sync output refresh rate is unknown

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoReferenceClock.cpp
+++ b/xbmc/cores/VideoPlayer/VideoReferenceClock.cpp
@@ -232,6 +232,16 @@ void CVideoReferenceClock::UpdateRefreshrate()
 {
   std::unique_lock SingleLock(m_CritSection);
   m_RefreshRate = static_cast<double>(m_pVideoSync->GetFps());
+  if (m_RefreshRate <= 0.0)
+  {
+    // A video sync backend should never report an invalid refreshrate, but guard against it
+    // here as well since m_RefreshRate is used as a divisor further down the line.
+    CLog::Log(LOGWARNING,
+              "CVideoReferenceClock: Invalid refreshrate {:.3f} hertz reported, defaulting to "
+              "60 hertz",
+              m_RefreshRate);
+    m_RefreshRate = 60.0;
+  }
   m_ClockSpeed = 1.0;
 
   CLog::Log(LOGDEBUG, "CVideoReferenceClock: Detected refreshrate: {:.3f} hertz", m_RefreshRate);

--- a/xbmc/windowing/wayland/VideoSyncWpPresentation.cpp
+++ b/xbmc/windowing/wayland/VideoSyncWpPresentation.cpp
@@ -31,6 +31,18 @@ bool CVideoSyncWpPresentation::Setup()
   m_stopEvent.Reset();
   m_fps = m_winSystem.GetSyncOutputRefreshRate();
 
+  if (m_fps <= 0.0f)
+  {
+    // The compositor has not (yet) sent a wp_presentation_feedback::sync_output event,
+    // so the real refresh rate is not known yet. Fall back to a sane default to avoid
+    // a division by zero further down the line (e.g. in CVideoReferenceClock).
+    CLog::Log(LOGWARNING,
+              "CVideoSyncWpPresentation::{} - sync output refresh rate not yet known, defaulting "
+              "to 60 Hz",
+              __FUNCTION__);
+    m_fps = 60.0f;
+  }
+
   return true;
 }
 
@@ -63,7 +75,11 @@ void CVideoSyncWpPresentation::HandlePresentation(timespec tv, std::uint32_t ref
             static_cast<std::uint64_t>(tv.tv_sec), static_cast<std::uint64_t>(tv.tv_nsec), refresh,
             1.0e9 / refresh, syncOutputID, syncOutputRefreshRate, msc, mscDiff);
 
-  if (m_fps != syncOutputRefreshRate || (m_syncOutputID != 0 && m_syncOutputID != syncOutputID))
+  // A syncOutputRefreshRate of 0 means the compositor has not reported a real rate yet
+  // (e.g. presented before sync_output), so it must not be compared against m_fps or it
+  // would spuriously look like a refresh rate change and restart video sync forever.
+  if ((syncOutputRefreshRate > 0.0f && m_fps != syncOutputRefreshRate) ||
+      (m_syncOutputID != 0 && m_syncOutputID != syncOutputID))
   {
     // Restart if fps changes or sync output changes (which means that the msc jumps)
     CLog::Log(LOGDEBUG, "fps or sync output changed, restarting Wayland video sync");


### PR DESCRIPTION
## Description
- `xbmc/windowing/wayland/VideoSyncWpPresentation.cpp`: `Setup()` now falls back to 60 Hz (with a `LOGWARNING`) when `m_winSystem.GetSyncOutputRefreshRate()` returns `<= 0.0f`, and `HandlePresentation()` avoids a spurious video sync restart while the refresh rate is still unknown.
- `xbmc/cores/VideoPlayer/VideoReferenceClock.cpp`: `UpdateRefreshrate()` gets a parallel defense-in-depth guard, falling back to 60 Hz (with a `LOGWARNING`) if the video-sync backend ever reports an invalid (`<= 0.0`) refresh rate.

## Motivation and context
`CVideoSyncWpPresentation::Setup()` set `m_fps` directly from `CWinSystemWayland::GetSyncOutputRefreshRate()`, which is default-initialized to `0.0f` and only populated asynchronously by the `wp_presentation_feedback::sync_output` event. Some compositors — confirmed on KWin/Plasma, see KDE bug 495056 — can deliver the very first `presented` event before ever sending `sync_output`, so `GetFps()` can return `0.0` right when playback starts.

That `0.0` flows unguarded into `CVideoReferenceClock::UpdateRefreshrate()` and from there into `TimeOfNextVblank()`'s `m_SystemFrequency / MathUtils::round_int(m_RefreshRate)` — an integer division by zero raising SIGFPE as soon as `PlayFile` runs with "Sync playback to display" enabled. This matches the reporter's backtrace (`GetTime` → `CDVDClock` ctor → `CVideoPlayer` ctor → `PlayFile`). Not reproducible on Weston, which sends `sync_output` before the first `presented` event.

Every other `GetFps()` implementation already guards against an invalid refresh rate with the same fallback — `CGraphicContext::GetFPS()` returns `60.0f` when the detected rate is `<= 0`, `VideoSyncD3D::GetFps()` does `if (m_fps == 0.0) m_fps = 60.0f;`. `CVideoSyncWpPresentation` was the only backend missing that guard; this PR mirrors the established convention. Once the real `sync_output` event arrives, the existing `m_fps != syncOutputRefreshRate` check detects the mismatch against the temporary fallback and restarts the video sync with the correct rate.

Fixes #25850.

## How has this been tested?
No wayland-windowing gtest scaffold exists to unit-test this path; verification is by review against the existing `VideoSyncD3D.cpp` / `GraphicContext.cpp` precedent. Ideally the original reporter (who has a reproducing KWin/Plasma Wayland session) confirms the crash no longer occurs with "Sync playback to display" enabled.

Note: this fix was prepared with AI assistance during issue triage and subsequently human-reviewed.

## What is the effect on users?
Kodi no longer crashes (SIGFPE) when starting video playback under a Plasma/KWin Wayland session with "Sync playback to display" enabled.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
