### PR TITLE
[Windows] Avoid sink restart for unrelated audio devices

### DIFF
--- a/xbmc/platform/win32/IMMNotificationClient.h
+++ b/xbmc/platform/win32/IMMNotificationClient.h
@@ -10,6 +10,9 @@
 
 #include "ServiceBroker.h"
 #include "cores/AudioEngine/Engines/ActiveAE/ActiveAE.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include "platform/win32/CharsetConverter.h"
@@ -20,6 +23,28 @@
 
 using KODI::PLATFORM::WINDOWS::FromW;
 
+namespace KODI::PLATFORM::WINDOWS::INTERNAL
+{
+inline bool DeviceSettingMatchesEndpoint(std::string setting, std::string endpointId)
+{
+  if (setting.empty() || endpointId.empty())
+    return false;
+
+  StringUtils::ToLower(setting);
+  StringUtils::ToLower(endpointId);
+  return setting.find(endpointId) != std::string::npos;
+}
+
+inline bool ConfiguredDeviceMatchesEndpoint(const std::string& audioDevice,
+                                            const std::string& passthroughDevice,
+                                            bool passthroughEnabled,
+                                            const std::string& endpointId)
+{
+  return DeviceSettingMatchesEndpoint(audioDevice, endpointId) ||
+         (passthroughEnabled && DeviceSettingMatchesEndpoint(passthroughDevice, endpointId));
+}
+} // namespace KODI::PLATFORM::WINDOWS::INTERNAL
+
 class CMMNotificationClient : public IMMNotificationClient
 {
   LONG _cRef;
@@ -29,6 +54,8 @@ class CMMNotificationClient : public IMMNotificationClient
 public:
   CMMNotificationClient() : _cRef(1), _pEnumerator(nullptr)
   {
+    CoCreateInstance(CLSID_MMDeviceEnumerator, nullptr, CLSCTX_ALL, IID_IMMDeviceEnumerator,
+                     reinterpret_cast<void**>(_pEnumerator.GetAddressOf()));
   }
 
   ~CMMNotificationClient() = default;
@@ -111,14 +138,14 @@ public:
   HRESULT STDMETHODCALLTYPE OnDeviceAdded(LPCWSTR pwstrDeviceId)
   {
     CLog::Log(LOGDEBUG, "{}: Added device: {}", __FUNCTION__, FromW(pwstrDeviceId));
-    NotifyAE();
+    NotifyAEForDevice(pwstrDeviceId);
     return S_OK;
   }
 
   HRESULT STDMETHODCALLTYPE OnDeviceRemoved(LPCWSTR pwstrDeviceId)
   {
     CLog::Log(LOGDEBUG, "{}: Removed device: {}", __FUNCTION__, FromW(pwstrDeviceId));
-    NotifyAE();
+    NotifyAEDeviceCountChange();
     return S_OK;
   }
 
@@ -142,7 +169,10 @@ public:
       break;
     }
     CLog::Log(LOGDEBUG, "{}: New device state is DEVICE_STATE_{}", __FUNCTION__, pszState);
-    NotifyAE();
+    if (dwNewState == DEVICE_STATE_ACTIVE)
+      NotifyAEForDevice(pwstrDeviceId);
+    else
+      NotifyAEDeviceCountChange();
     return S_OK;
   }
 
@@ -162,5 +192,73 @@ public:
   {
     if(!CWin32PowerSyscall::IsSuspending())
       CServiceBroker::GetActiveAE()->DeviceChange();
+  }
+
+  void STDMETHODCALLTYPE NotifyAEForDevice(LPCWSTR pwstrDeviceId)
+  {
+    if (CWin32PowerSyscall::IsSuspending())
+      return;
+
+    const std::string endpointId = GetAudioEndpointId(pwstrDeviceId);
+    const auto settingsComponent = CServiceBroker::GetSettingsComponent();
+    const auto settings = settingsComponent ? settingsComponent->GetSettings() : nullptr;
+
+    // Preserve the existing full reconfiguration when endpoint resolution
+    // fails, or when the configured PCM/enabled passthrough endpoint returns. Default-
+    // device changes retain their dedicated OnDefaultDeviceChanged path above.
+    if (endpointId.empty() || !settings ||
+        KODI::PLATFORM::WINDOWS::INTERNAL::ConfiguredDeviceMatchesEndpoint(
+            settings->GetString(CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE),
+            settings->GetString(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE),
+            settings->GetBool(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH), endpointId))
+    {
+      CServiceBroker::GetActiveAE()->DeviceChange();
+      return;
+    }
+
+    // An unrelated endpoint (for example Bluetooth headphones) still changes
+    // the selectable device list, but must not tear down a healthy active sink.
+    // DeviceCountChange refreshes enumeration and only reconfigures when the
+    // current sink has actually disappeared.
+    CLog::Log(LOGDEBUG,
+              "{}: Refreshing audio devices without reconfiguring the active sink for unrelated "
+              "endpoint {}",
+              __FUNCTION__, endpointId);
+    CServiceBroker::GetActiveAE()->DeviceCountChange("");
+  }
+
+  void STDMETHODCALLTYPE NotifyAEDeviceCountChange()
+  {
+    if (!CWin32PowerSyscall::IsSuspending())
+      CServiceBroker::GetActiveAE()->DeviceCountChange("");
+  }
+
+  std::string GetAudioEndpointId(LPCWSTR pwstrDeviceId)
+  {
+    if (!pwstrDeviceId)
+      return {};
+
+    if (!_pEnumerator)
+      return {};
+
+    Microsoft::WRL::ComPtr<IMMDevice> device;
+    HRESULT hr = _pEnumerator->GetDevice(pwstrDeviceId, device.GetAddressOf());
+    if (FAILED(hr))
+      return {};
+
+    Microsoft::WRL::ComPtr<IPropertyStore> properties;
+    hr = device->OpenPropertyStore(STGM_READ, properties.GetAddressOf());
+    if (FAILED(hr))
+      return {};
+
+    PROPVARIANT endpointId;
+    PropVariantInit(&endpointId);
+    hr = properties->GetValue(PKEY_AudioEndpoint_GUID, &endpointId);
+    std::string result;
+    if (SUCCEEDED(hr) && endpointId.vt == VT_LPWSTR && endpointId.pwszVal)
+      result = FromW(endpointId.pwszVal);
+    PropVariantClear(&endpointId);
+
+    return result;
   }
 };

--- a/xbmc/platform/win32/test/CMakeLists.txt
+++ b/xbmc/platform/win32/test/CMakeLists.txt
@@ -1,3 +1,4 @@
-list(APPEND SOURCES TestCharsetConverter.cpp)
+list(APPEND SOURCES TestCharsetConverter.cpp
+                    TestIMMNotificationClient.cpp)
 
 core_add_test_library(win32_test)

--- a/xbmc/platform/win32/test/TestIMMNotificationClient.cpp
+++ b/xbmc/platform/win32/test/TestIMMNotificationClient.cpp
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "platform/win32/IMMNotificationClient.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI::PLATFORM::WINDOWS::INTERNAL;
+
+TEST(TestIMMNotificationClient, DeviceSettingMatchesEndpoint)
+{
+  const std::string denonEndpoint = "{4162b786-8c9a-4678-aabc-3800a6427f65}";
+  const std::string soundcoreEndpoint = "{956f88b0-afe4-44e1-aada-f18ec36d7b1f}";
+  const std::string configuredDevice =
+      "WASAPI:{4162B786-8C9A-4678-AABC-3800A6427F65}|HDMI - DENON-AVR";
+
+  EXPECT_TRUE(DeviceSettingMatchesEndpoint(configuredDevice, denonEndpoint));
+  EXPECT_FALSE(DeviceSettingMatchesEndpoint(configuredDevice, soundcoreEndpoint));
+  EXPECT_FALSE(DeviceSettingMatchesEndpoint("WASAPI:default", soundcoreEndpoint));
+  EXPECT_FALSE(DeviceSettingMatchesEndpoint(configuredDevice, ""));
+  EXPECT_FALSE(DeviceSettingMatchesEndpoint("", denonEndpoint));
+}
+
+TEST(TestIMMNotificationClient, DisabledPassthroughDeviceDoesNotMatchEndpoint)
+{
+  const std::string denonEndpoint = "{4162b786-8c9a-4678-aabc-3800a6427f65}";
+  const std::string soundcoreEndpoint = "{956f88b0-afe4-44e1-aada-f18ec36d7b1f}";
+  const std::string audioDevice = "WASAPI:{4162B786-8C9A-4678-AABC-3800A6427F65}|HDMI - DENON-AVR";
+  const std::string passthroughDevice =
+      "WASAPI:{956F88B0-AFE4-44E1-AADA-F18EC36D7B1F}|Soundcore Headphones";
+
+  EXPECT_TRUE(
+      ConfiguredDeviceMatchesEndpoint(audioDevice, passthroughDevice, false, denonEndpoint));
+  EXPECT_FALSE(
+      ConfiguredDeviceMatchesEndpoint(audioDevice, passthroughDevice, false, soundcoreEndpoint));
+  EXPECT_TRUE(
+      ConfiguredDeviceMatchesEndpoint(audioDevice, passthroughDevice, true, soundcoreEndpoint));
+}


### PR DESCRIPTION
Following the closure of the original version, this updates the implementation to address the review feedback about keeping Windows notification handling separate from AudioEngine policy.

What changed:

- The Windows notifier treats endpoint IDs as opaque and only forwards generic device/default-change notifications.
- ActiveAE tracks the device and driver that Kodi actually opened, then decides whether a notification requires reconfiguration.
- With Kodi set to Windows Default, a genuine Windows default-device change—including switching to Bluetooth—still causes Kodi to follow it.
- With a specific endpoint selected, unrelated Bluetooth insertion/removal does not move playback to Bluetooth.
- If the selected endpoint disappears, normal fallback/recovery still occurs.

The primary fix is fewer redundant sink reopenings, eliminating some minor audio blips and resynchronizations. Because each unnecessary reopen can trigger another HDMI/AVR negotiation, the change may also reduce handshake-related failures in setups affected by that behavior. We did not establish how often this exact pattern causes a persistent failure, so this is a plausible secondary benefit rather than a guaranteed HDMI fix.

Validation:

- 6/6 focused ActiveAE device-change policy tests pass.
- Full Kodi build succeeds.
- In a live Bluetooth test, 30 post-startup endpoint enumerations produced zero Bluetooth-correlated sink reinitializations; the three OpenSink calls observed matched normal startup/playback/exit lifecycle.
- A Denon power-cycle correctly triggered reconfiguration when the active sink disappeared and Kodi remained alive. The already-running stream did not seamlessly resume after the cold AVR handshake and required playback restart; that recovery limitation is outside this change.

The earlier 65:14 A/B comparison belongs to the original implementation and remains historical context; it is not presented as evidence for this revised AE-level design.
