### PR TITLE
[Video][Bluray] Support automatic recognition of bluray playlist video versions.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24832,7 +24832,13 @@ msgctxt "#40041"
 msgid "Assign playlist to current movie version?"
 msgstr ""
 
-#empty strings with id 40042 to 40201
+#. Different video version found dialog text for blurays
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40042"
+msgid "Found a different version of the movie \"{0:s}\" in playlist {1:s} of {2:s} - length {3:s}. Would you like to convert it into an additional version of the original?"
+msgstr ""
+
+#empty strings with id 40043 to 40201
 
 #. Ignore different video versions settting
 #: system/settings/settings.xml

--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -46,6 +46,14 @@ const TiXmlElement* CNfoFile::GetRootElement() const
   return m_xmlDoc.RootElement();
 }
 
+int CNfoFile::GetBlurayPlaylist() const
+{
+  int playlist{-1};
+  if (const TiXmlElement * root{GetRootElement()}; root)
+    XMLUtils::GetInt(root, "playlist", playlist);
+  return playlist;
+}
+
 CInfoScanner::InfoType CNfoFile::TryParsing(ADDON::AddonType addonType) const
 {
   using enum CInfoScanner::InfoType;

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -55,6 +55,13 @@ public:
   ADDON::ScraperPtr GetScraperInfo() { return m_info; }
   const CScraperUrl &ScraperUrl() const { return m_scurl; }
 
+  /*! \brief The bluray playlist given by a <playlist> element, if any.
+   Read from the same (indexed) element as GetDetails(), so multi-version nfos give the playlist
+   belonging to the version that was parsed.
+   \return the playlist number, or -1 if the nfo does not specify one
+   */
+  int GetBlurayPlaylist() const;
+
 private:
   CInfoScanner::InfoType TryParsing(ADDON::AddonType addonType) const;
   CInfoScanner::InfoType TryParsing(const CURL& nfoPath,

--- a/xbmc/application/ApplicationPlay.cpp
+++ b/xbmc/application/ApplicationPlay.cpp
@@ -253,8 +253,11 @@ bool CApplicationPlay::GetPlaylistIfDisc()
     case SILENT:
     {
       // Select playlist, showing simple menu if needed
-      if (!CDiscDirectoryHelper::GetOrShowPlaylistSelection(m_item, menuDecision))
+      CFileItemList items;
+      if (!CDiscDirectoryHelper::GetOrShowPlaylistSelection(m_item, items, menuDecision) ||
+          items.IsEmpty())
         return false; // User cancelled
+      m_item = *items[0];
 
       // Reset any resume state as new playlist chosen
       m_options.starttime = m_options.startpercent = 0.0;

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -373,6 +373,12 @@ bool CDVDFileInfo::CanExtract(const CFileItem& fileItem)
       fileItem.IsDiscImage() || VIDEO::IsDVDFile(fileItem, false, true))
     return false;
 
+  // A resolved disc item keeps the disc file in its path while its dynpath is the bluray://
+  // playlist, so the checks above (which look at one or the other) can miss it
+  if (URIUtils::IsBlurayPath(fileItem.GetDynPath()) ||
+      URIUtils::IsOpticalMediaFile(fileItem.GetPath()) || URIUtils::IsDiscImage(fileItem.GetPath()))
+    return false;
+
   // For HTTP/FTP we only allow extraction when on a LAN
   if (URIUtils::IsRemote(fileItem.GetPath()) && !URIUtils::IsOnLAN(fileItem.GetPath()) &&
       (URIUtils::IsFTP(fileItem.GetPath()) || URIUtils::IsHTTP(fileItem.GetPath())))

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -247,8 +247,7 @@ CDVDInputStream::UpdateState CDVDInputStream::UpdateItemFromPlaylistDetails(
     closed = false; // Feed back to VideoPlayer
 
   const int playlist{it3->playlist};
-  if (item.HasVideoInfoTag())
-    item.GetVideoInfoTag()->m_iTrack = playlist;
+  item.SetProperty("bluray_playlist", playlist);
   CLog::LogF(LOGDEBUG, "Main playlist {}", playlist);
 
   if (type == DVDSTREAM_TYPE_DVD && item.GetProperty("update_stream_details").asBoolean(false) &&

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -54,7 +54,7 @@ bool CGUIDialogSimpleMenu::ShowPlaylistSelection(
     if (!usedPlaylists.empty())
     {
       // See if playlist already used
-      const int newPlaylist{selectedItem.GetProperty("bluray_playlist").asInteger32(0)};
+      const int newPlaylist{selectedItem.GetProperty("bluray_playlist").asInteger32(-1)};
       auto matchingPlaylists{usedPlaylists |
                              std::views::filter([newPlaylist](const CVideoDatabase::PlaylistInfo& p)
                                                 { return p.playlist == newPlaylist; })};

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -728,7 +728,7 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
         helper.GetMoviePlaylists(m_url, items, allTitles, GetMainPlaylist(), GetTitle::SINGLE,
                                  clips, playlists);
       else if (file == "root/main/all")
-        helper.GetMoviePlaylists(m_url, items, allTitles, GetMainPlaylist(), GetTitle::ALL, clips,
+        helper.GetMoviePlaylists(m_url, items, allTitles, GetMainPlaylist(), GetTitle::MAIN, clips,
                                  playlists);
       else
         CLog::LogF(LOGDEBUG, "Invalid path {} for bluray playlist parsing", file);

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -179,6 +179,12 @@ bool GetPlaylistsFromDisc(const CURL& url,
       }
     }
   }
+
+  if (playlists.empty())
+  {
+    CLog::LogF(LOGERROR, "No playlists could be read from {}", CURL::GetRedacted(url2.Get()));
+    return false;
+  }
   return true;
 }
 
@@ -290,7 +296,9 @@ int GetMainPlaylistFromDisc(const CURL& url)
   return playlist;
 }
 
-bool FilterPlaylists(std::vector<PlaylistInformation>& playlists)
+} // namespace
+
+bool CBlurayDirectory::FilterPlaylists(std::vector<PlaylistInformation>& playlists)
 {
   // Remove playlists with no clips
   std::erase_if(playlists,
@@ -316,6 +324,8 @@ bool FilterPlaylists(std::vector<PlaylistInformation>& playlists)
   return !playlists.empty();
 }
 
+namespace
+{
 void AddPlaylists(const CURL& url,
                   const std::string& realPath,
                   CFileItemList& items,
@@ -328,12 +338,14 @@ void AddPlaylists(const CURL& url,
   for (auto& title : playlists)
     items.Add(GetFileItem(url, realPath, title, clipCache, StreamDetails::DEFER));
 }
-bool GetPlaylists(const CURL& url,
-                  const std::string& realPath,
-                  int flags,
-                  int playlist,
-                  CFileItemList& items,
-                  std::map<unsigned int, ClipInformation>& clipCache)
+} // namespace
+
+bool CBlurayDirectory::GetPlaylists(const CURL& url,
+                                    const std::string& realPath,
+                                    int flags,
+                                    int playlist,
+                                    CFileItemList& items,
+                                    std::map<unsigned int, ClipInformation>& clipCache)
 {
   try
   {
@@ -389,6 +401,8 @@ bool GetPlaylists(const CURL& url,
   }
 }
 
+namespace
+{
 void ProcessPlaylist(PlaylistMap& playlists, PlaylistInformation& titleInfo, ClipMap& clips)
 {
   const unsigned int playlist{titleInfo.playlist};
@@ -432,14 +446,15 @@ void ProcessPlaylist(PlaylistMap& playlists, PlaylistInformation& titleInfo, Cli
 
   playlists[playlist] = info;
 }
+} // namespace
 
-bool GetPlaylistsInformation(const CURL& url,
-                             const std::string& realPath,
-                             int flags,
-                             CFileItemList& allTitles,
-                             ClipMap& clips,
-                             PlaylistMap& playlists,
-                             std::map<unsigned int, ClipInformation>& clipCache)
+bool CBlurayDirectory::GetPlaylistsInformation(const CURL& url,
+                                               const std::string& realPath,
+                                               int flags,
+                                               CFileItemList& allTitles,
+                                               ClipMap& clips,
+                                               PlaylistMap& playlists,
+                                               std::map<unsigned int, ClipInformation>& clipCache)
 {
   try
   {
@@ -488,6 +503,15 @@ bool GetPlaylistsInformation(const CURL& url,
 
     CLog::LogF(LOGDEBUG, "*** Playlist information End ***");
 
+    // Nothing could be read from the disc
+    // Don't cache in case temporary read error etc.
+    if (playlists.empty() || clips.empty())
+    {
+      CLog::LogF(LOGERROR, "No playlist information could be read from {}, so not caching it",
+                 CURL::GetRedacted(path));
+      return false;
+    }
+
     // Cache
     CServiceBroker::GetBlurayDiscCache()->SetMaps(path, playlists, clips, allTitles);
     CLog::LogF(LOGDEBUG, "Playlist information for {} cached", path);
@@ -508,7 +532,6 @@ bool GetPlaylistsInformation(const CURL& url,
   }
   return false;
 }
-} // namespace
 
 CBlurayDirectory::CBlurayDirectory()
 {

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -476,10 +476,10 @@ bool CBlurayDirectory::GetPlaylistsInformation(const CURL& url,
 
     for (const auto& title : allTitles)
     {
-      const int playlist{title->GetProperty("bluray_playlist").asInteger32(0)};
+      const int playlist{title->GetProperty("bluray_playlist").asInteger32(-1)};
       PlaylistInformation titleInfo;
-      if (!GetPlaylistInfoFromDisc(url, realPath, playlist, StreamDetails::DEFER, titleInfo,
-                                   clipCache))
+      if (playlist == -1 || !GetPlaylistInfoFromDisc(url, realPath, playlist, StreamDetails::DEFER,
+                                                     titleInfo, clipCache))
       {
         CLog::LogF(LOGDEBUG, "Unable to get playlist {}", playlist);
         continue;

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -19,11 +19,14 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include <libbluray/bluray.h>
 
 class CFileItem;
 class CFileItemList;
+
+class TestBlurayDirectory;
 
 namespace XFILE
 {
@@ -54,6 +57,8 @@ public:
   std::string GetBlurayID();
 
 private:
+  friend class ::TestBlurayDirectory;
+
   /*!
    \brief Populate the stream details of a playlist on this disc.
    Deriving these means parsing the playlist's m2ts, so it is only done once a playlist is known
@@ -63,6 +68,39 @@ private:
    \param item the item to populate
    */
   void SetPlaylistStreamDetails(unsigned int playlist, CFileItem& item);
+
+  /*!
+   \brief Discard the playlists that are not a movie/episode.
+   Removes those with no clips, shorter than a second, with a clip repeated within them, and those
+   that duplicate an earlier playlist.
+   \param playlists the playlists to filter, in place
+   \return true if any playlist remains
+   */
+  static bool FilterPlaylists(std::vector<PlaylistInformation>& playlists);
+
+  /*!
+   \brief Get the playlist(s) on the disc as FileItems, without their stream details.
+   \param playlist a single playlist to return, or ALL_PLAYLISTS for every valid one
+   \return true if any playlist was found
+   */
+  static bool GetPlaylists(const CURL& url,
+                           const std::string& realPath,
+                           int flags,
+                           int playlist,
+                           CFileItemList& items,
+                           std::map<unsigned int, ClipInformation>& clipCache);
+
+  /*!
+   \brief Describe every playlist on the disc and the clips they share, caching the result.
+   \return true if the information was read from the disc and cached
+   */
+  static bool GetPlaylistsInformation(const CURL& url,
+                                      const std::string& realPath,
+                                      int flags,
+                                      CFileItemList& allTitles,
+                                      ClipMap& clips,
+                                      PlaylistMap& playlists,
+                                      std::map<unsigned int, ClipInformation>& clipCache);
 
   enum class DiscInfo : uint8_t
   {

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -1831,8 +1831,17 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(const CFileItem& item,
 
   items.Clear();
   if (!selectedItem.GetPath().empty())
+  {
     // If SelectedItem is not empty then we have a user selected playlist, so return it
-    items.Add(GenerateItem(item, selectedItem, item));
+    const auto newItem{GenerateItem(item, selectedItem, item)};
+
+    // GenerateItem points the paths in the tag at the newly selected playlist
+    // Flag so CSaveFileStateJob can tell playlist has changed
+    if (selectedItem.GetDynPath() != item.GetDynPath())
+      newItem->SetProperty("new_playlist_path", true);
+
+    items.Add(newItem);
+  }
   else if (!returnMultipleItems)
     // Return single item
     items.Add(GenerateItem(item, *sourceItems[0], item));

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -17,13 +17,16 @@
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "settings/VideoVersionsSettings.h"
 #include "threads/IRunnable.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoManagerTypes.h"
 
 #include <algorithm>
 #include <array>
@@ -1216,6 +1219,12 @@ void CDiscDirectoryHelper::PopulateEpisodeFileItems(const CURL& url,
         CLog::LogF(LOGERROR, "Playlist {} missing in playlist map", playlist.playlist);
         continue;
       }
+      if (playlist.index >= episodesOnDisc.size())
+      {
+        CLog::LogF(LOGERROR, "Playlist {} index out of range ({}) in episodesOnDisc ({})",
+                   playlist.playlist, playlist.index, episodesOnDisc.size());
+        continue;
+      }
       const auto& information{playlists.find(playlist.playlist)->second};
       const auto newItem{GenerateEpisodeItem(url, playlist.playlist, information,
                                              episodesOnDisc[playlist.index], false)}; // Episode
@@ -1658,26 +1667,31 @@ std::vector<CVideoInfoTag> CDiscDirectoryHelper::GetEpisodesOnDisc(const CURL& u
   return episodesOnDisc;
 }
 
-bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, MenuDecision playback)
+bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(const CFileItem& item,
+                                                      CFileItemList& items,
+                                                      MenuDecision playback)
 {
   const bool silent{playback == MenuDecision::SILENT};
-  const std::string originalDynPath{
-      item.GetDynPath()}; // Overwritten by dialog selection. Needed for screen refresh.
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  const auto action = static_cast<SimilarVideoScanAction>(
+      settings->GetInt(CSettings::SETTING_VIDEOLIBRARY_SIMILARVIDEOACTION));
+  const bool returnMultipleItems{(silent && action != SimilarVideoScanAction::NONE &&
+                                  item.GetVideoContentType() == VideoDbContentType::MOVIES)};
 
   const std::string directory{
-      [&item, &originalDynPath, playback]
+      [&item, &playback, &returnMultipleItems]
       {
         const bool forceSelection{item.GetProperty("force_playlist_selection").asBoolean(false)};
 
         // All episodes
         if (item.HasProperty("episodes_start"))
-          return URIUtils::GetBlurayAllEpisodesPath(originalDynPath);
+          return URIUtils::GetBlurayAllEpisodesPath(item.GetDynPath());
 
         // Single episode
         if (item.GetVideoContentType() == VideoDbContentType::EPISODES && !forceSelection)
         {
           const CVideoInfoTag* tag{item.GetVideoInfoTag()};
-          return URIUtils::GetBlurayEpisodePath(originalDynPath, tag->m_iSeason, tag->m_iEpisode);
+          return URIUtils::GetBlurayEpisodePath(item.GetDynPath(), tag->m_iSeason, tag->m_iEpisode);
         }
 
         // Playlists > 70% longest
@@ -1686,19 +1700,23 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, MenuDecis
         if (playback == SHOW_SIMPLE_MENU)
         {
           if (item.GetVideoContentType() == EPISODES || item.GetVideoContentType() == TVSHOWS)
-          {
-            return URIUtils::GetBlurayTitlesPath(originalDynPath, URIUtils::GetAllTitles::LONG,
+            return URIUtils::GetBlurayTitlesPath(item.GetDynPath(), URIUtils::GetAllTitles::LONG,
                                                  URIUtils::AllTitlesOptions::EPISODES);
-          }
           else
-          {
-            return URIUtils::GetBlurayTitlesPath(originalDynPath, URIUtils::GetAllTitles::LONG,
+            return URIUtils::GetBlurayTitlesPath(item.GetDynPath(), URIUtils::GetAllTitles::LONG,
                                                  URIUtils::AllTitlesOptions::MOVIES);
-          }
         }
 
-        // Single main title
-        return URIUtils::GetBlurayMainTitlePath(originalDynPath);
+        if (item.GetVideoContentType() == EPISODES || item.GetVideoContentType() == TVSHOWS ||
+            forceSelection)
+          // Single main title
+          return URIUtils::GetBlurayMainTitlePath(item.GetDynPath());
+        else if (returnMultipleItems)
+          // Versions
+          return URIUtils::GetBlurayMainTitlePath(item.GetDynPath(), URIUtils::GetAllTitles::ALL);
+        else
+          // Single main title
+          return URIUtils::GetBlurayMainTitlePath(item.GetDynPath());
       }()};
 
   // Get playlists that are already used (to avoid duplicates in file table)
@@ -1721,8 +1739,8 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, MenuDecis
   }
 
   // Get items
-  CFileItemList items;
-  if (!GetItems(items, directoryDuration, silent))
+  CFileItemList sourceItems;
+  if (!GetItems(sourceItems, directoryDuration, silent))
   {
     // No main movie or episode playlist found
     if (silent)
@@ -1732,11 +1750,11 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, MenuDecis
     const std::string fallbackDirectory{
         item.GetVideoContentType() == VideoDbContentType::EPISODES ||
                 item.GetVideoContentType() == VideoDbContentType::TVSHOWS
-            ? URIUtils::GetBlurayTitlesPath(originalDynPath, URIUtils::GetAllTitles::ALL,
+            ? URIUtils::GetBlurayTitlesPath(item.GetDynPath(), URIUtils::GetAllTitles::ALL,
                                             URIUtils::AllTitlesOptions::EPISODES)
-            : URIUtils::GetBlurayTitlesPath(originalDynPath, URIUtils::GetAllTitles::ALL,
+            : URIUtils::GetBlurayTitlesPath(item.GetDynPath(), URIUtils::GetAllTitles::ALL,
                                             URIUtils::AllTitlesOptions::MOVIES)};
-    if (!GetItems(items, fallbackDirectory, silent))
+    if (!GetItems(sourceItems, fallbackDirectory, silent))
     {
       CGUIDialogOK::ShowAndGetInput(
           CVariant{257},
@@ -1751,14 +1769,15 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, MenuDecis
   {
     if (playback == MenuDecision::SHOW_SIMPLE_MENU)
     {
-      usedPlaylists = database.GetPlaylistsByPath(URIUtils::GetBlurayPlaylistPath(originalDynPath));
+      usedPlaylists =
+          database.GetPlaylistsByPath(URIUtils::GetBlurayPlaylistPath(item.GetDynPath()));
 
       // If replacing existing playlist (FORCE_PLAYLIST_SELECTION), remove it from exclude list
       // as user could choose the same playlist again
       if (item.GetProperty("force_playlist_selection").asBoolean(false))
       {
         CRegExp regex{true, CRegExp::autoUtf8, R"(\/(\d{5}).mpls$)"};
-        if (regex.RegFind(originalDynPath) != -1)
+        if (regex.RegFind(item.GetDynPath()) != -1)
         {
           const int playlist{std::stoi(regex.GetMatch(1))};
           std::erase_if(usedPlaylists, [&playlist](const CVideoDatabase::PlaylistInfo& p)
@@ -1769,7 +1788,8 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, MenuDecis
       // Use simple menu dialog to select playlist
       while (true)
       {
-        if (!CGUIDialogSimpleMenu::ShowPlaylistSelection(item, selectedItem, items, usedPlaylists))
+        if (!CGUIDialogSimpleMenu::ShowPlaylistSelection(item, selectedItem, sourceItems,
+                                                         usedPlaylists))
           return false;
 
         // If a non-folder item is selected, we're done
@@ -1777,7 +1797,7 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, MenuDecis
           break;
 
         // Folder selected - retrieve all titles within it
-        if (!GetItems(items, selectedItem.GetDynPath(), silent))
+        if (!GetItems(sourceItems, selectedItem.GetDynPath(), silent))
           return false;
       }
     }
@@ -1785,20 +1805,43 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(CFileItem& item, MenuDecis
   else
   {
     // Silent
-    if (items.Size() > 1)
+    if (sourceItems.Size() > 1 && !returnMultipleItems)
     {
       CLog::LogF(LOGERROR, "Unable to automatically determine main playlist for {}", directory);
       return false;
     }
   }
 
-  if (selectedItem.GetPath().empty())
-    selectedItem = *items[0]; // Main item
+  auto GenerateItem{
+      [](const CFileItem& originalItem, const CFileItem& selectedItem, const CFileItem& item)
+      {
+        auto newItem{std::make_shared<CFileItem>(originalItem)};
+        newItem->SetDynPath(selectedItem.GetDynPath());
+        const auto tag{newItem->GetVideoInfoTag()};
+        tag->SetFileNameAndPath(selectedItem.GetDynPath());
+        tag->m_streamDetails = selectedItem.GetVideoInfoTag()->m_streamDetails;
+        if (tag->GetAssetInfo().GetTitle().empty())
+          tag->GetAssetInfo().SetTitle(
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
+                  VIDEO_VERSION_ID_DEFAULT));
+        newItem->SetProperty("bluray_playlist", selectedItem.GetProperty("bluray_playlist"));
+        newItem->SetProperty("original_listitem_url", item.GetDynPath());
+        return newItem;
+      }};
 
-  item.SetDynPath(selectedItem.GetDynPath());
-  item.GetVideoInfoTag()->m_streamDetails = selectedItem.GetVideoInfoTag()->m_streamDetails;
-  item.SetProperty("original_listitem_url", originalDynPath);
-
+  items.Clear();
+  if (!selectedItem.GetPath().empty())
+    // If SelectedItem is not empty then we have a user selected playlist, so return it
+    items.Add(GenerateItem(item, selectedItem, item));
+  else if (!returnMultipleItems)
+    // Return single item
+    items.Add(GenerateItem(item, *sourceItems[0], item));
+  else
+  {
+    // Return all items
+    for (const auto& sourceItem : sourceItems)
+      items.Add(GenerateItem(item, *sourceItem, item));
+  }
   return true;
 }
 

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -31,17 +31,17 @@ using namespace std::chrono_literals;
 
 static constexpr int ALL_PLAYLISTS{-1};
 
-enum class GetTitle : int
+enum class GetTitle : uint8_t
 {
-  SINGLE = -1,
-  MAIN = -2,
-  EPISODES = -3,
-  ALL = -4
+  SINGLE,
+  MAIN,
+  EPISODES,
+  ALL
 };
 
 enum class SortTitles : uint8_t
 {
-  SORT_TITLES_NONE = 0,
+  SORT_TITLES_NONE,
   SORT_TITLES_EPISODE,
   SORT_TITLES_MOVIE
 };
@@ -275,11 +275,13 @@ public:
 
   /*!
    * \brief Either shows simple menu to select playlist, chooses main feature (movie/episode) playlists or returns if disc menu will be used later.
-   * \param item FileItem containing details of desired movie/episode. This is updated with the selected playlist.
+   * \param item FileItem containing details of desired movie/episode.
    * \param playback Determines if the simple dialog should be shown or the main title selected (if possible).
    * \return true if a playlist was selected or if the disc menu will be used later, false if the user cancelled.
    */
-  static bool GetOrShowPlaylistSelection(CFileItem& item, MenuDecision playback);
+  static bool GetOrShowPlaylistSelection(const CFileItem& item,
+                                         CFileItemList& items,
+                                         MenuDecision playback);
 
 protected:
   static bool GetDirectoryItems(const std::string& path,

--- a/xbmc/filesystem/test/CMakeLists.txt
+++ b/xbmc/filesystem/test/CMakeLists.txt
@@ -6,6 +6,10 @@ set(SOURCES TestDirectory.cpp
             TestZipFile.cpp
             TestZipManager.cpp)
 
+if(TARGET ${APP_NAME_LC}::Bluray)
+  list(APPEND SOURCES TestBlurayDirectory.cpp)
+endif()
+
 if(TARGET ${APP_NAME_LC}::MicroHttpd)
   list(APPEND SOURCES TestHTTPDirectory.cpp)
 endif()

--- a/xbmc/filesystem/test/TestBlurayDirectory.cpp
+++ b/xbmc/filesystem/test/TestBlurayDirectory.cpp
@@ -1,0 +1,170 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "filesystem/BlurayDirectory.h"
+#include "filesystem/DiscDirectoryHelper.h"
+
+#include <chrono>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace XFILE;
+using namespace std::chrono_literals;
+
+class TestBlurayDirectory : public ::testing::Test
+{
+protected:
+  static bool FilterPlaylists(std::vector<PlaylistInformation>& playlists)
+  {
+    return CBlurayDirectory::FilterPlaylists(playlists);
+  }
+};
+
+namespace
+{
+PlaylistInformation MakePlaylist(unsigned int playlist,
+                                 std::chrono::milliseconds duration,
+                                 std::vector<unsigned int> clips,
+                                 std::vector<std::chrono::milliseconds> chapters = {1min})
+{
+  PlaylistInformation info;
+  info.playlist = playlist;
+  info.duration = duration;
+  info.clips = std::move(clips);
+  info.chapters = std::move(chapters);
+  return info;
+}
+
+std::vector<unsigned int> PlaylistNumbers(const std::vector<PlaylistInformation>& playlists)
+{
+  std::vector<unsigned int> numbers;
+  numbers.reserve(playlists.size());
+  for (const PlaylistInformation& playlist : playlists)
+    numbers.emplace_back(playlist.playlist);
+  return numbers;
+}
+} // namespace
+
+//
+// ---- FilterPlaylists -------------------------------------------------------
+//
+
+// No playlists at all
+TEST_F(TestBlurayDirectory, FilterPlaylists_NoPlaylists)
+{
+  std::vector<PlaylistInformation> playlists;
+
+  EXPECT_FALSE(FilterPlaylists(playlists));
+  EXPECT_TRUE(playlists.empty());
+}
+
+// No valid playlists
+TEST_F(TestBlurayDirectory, FilterPlaylists_EveryPlaylistDiscarded)
+{
+  std::vector<PlaylistInformation> playlists{
+      MakePlaylist(800u, 0ms, {}), // No clips
+      MakePlaylist(801u, 500ms, {1u}), // Under a second
+      MakePlaylist(802u, 2h, {1u, 1u}), // Repeated clip
+  };
+
+  EXPECT_FALSE(FilterPlaylists(playlists));
+  EXPECT_TRUE(playlists.empty());
+}
+
+// A single playlist means the duplicate comparison has no pair to consider
+TEST_F(TestBlurayDirectory, FilterPlaylists_SinglePlaylistIsKept)
+{
+  std::vector<PlaylistInformation> playlists{MakePlaylist(800u, 2h, {1u})};
+
+  EXPECT_TRUE(FilterPlaylists(playlists));
+  EXPECT_EQ(PlaylistNumbers(playlists), std::vector<unsigned int>{800u});
+}
+
+TEST_F(TestBlurayDirectory, FilterPlaylists_RemovesPlaylistsWithoutClips)
+{
+  std::vector<PlaylistInformation> playlists{
+      MakePlaylist(800u, 2h, {}),
+      MakePlaylist(801u, 2h, {1u}),
+  };
+
+  EXPECT_TRUE(FilterPlaylists(playlists));
+  EXPECT_EQ(PlaylistNumbers(playlists), std::vector<unsigned int>{801u});
+}
+
+TEST_F(TestBlurayDirectory, FilterPlaylists_RemovesPlaylistsShorterThanASecond)
+{
+  std::vector<PlaylistInformation> playlists{
+      MakePlaylist(800u, 999ms, {1u}),
+      MakePlaylist(801u, 1s, {2u}),
+  };
+
+  EXPECT_TRUE(FilterPlaylists(playlists));
+  EXPECT_EQ(PlaylistNumbers(playlists), std::vector<unsigned int>{801u});
+}
+
+TEST_F(TestBlurayDirectory, FilterPlaylists_RemovesPlaylistsWithARepeatedClip)
+{
+  std::vector<PlaylistInformation> playlists{
+      MakePlaylist(800u, 2h, {1u, 2u, 1u}),
+      MakePlaylist(801u, 2h, {3u, 4u}),
+  };
+
+  EXPECT_TRUE(FilterPlaylists(playlists));
+  EXPECT_EQ(PlaylistNumbers(playlists), std::vector<unsigned int>{801u});
+}
+
+// Duplicates are matched on clips, chapters, audio and subtitle streams.
+// The earlier playlist is the one kept.
+TEST_F(TestBlurayDirectory, FilterPlaylists_RemovesDuplicatesKeepingTheFirst)
+{
+  std::vector<PlaylistInformation> playlists{
+      MakePlaylist(800u, 2h, {1u, 2u}),
+      MakePlaylist(801u, 2h, {1u, 2u}),
+  };
+
+  EXPECT_TRUE(FilterPlaylists(playlists));
+  EXPECT_EQ(PlaylistNumbers(playlists), std::vector<unsigned int>{800u});
+}
+
+// Differing in any compared field is enough to be a distinct title
+TEST_F(TestBlurayDirectory, FilterPlaylists_KeepsPlaylistsDifferingByClips)
+{
+  std::vector<PlaylistInformation> playlists{
+      MakePlaylist(800u, 2h, {1u, 2u}),
+      MakePlaylist(801u, 2h, {3u, 4u}),
+  };
+
+  EXPECT_TRUE(FilterPlaylists(playlists));
+  EXPECT_EQ(PlaylistNumbers(playlists), (std::vector<unsigned int>{800u, 801u}));
+}
+
+TEST_F(TestBlurayDirectory, FilterPlaylists_KeepsPlaylistsDifferingByChapters)
+{
+  std::vector<PlaylistInformation> playlists{
+      MakePlaylist(800u, 2h, {1u}, {1min}),
+      MakePlaylist(801u, 2h, {1u}, {1min, 2min}),
+  };
+
+  EXPECT_TRUE(FilterPlaylists(playlists));
+  EXPECT_EQ(PlaylistNumbers(playlists), (std::vector<unsigned int>{800u, 801u}));
+}
+
+// Three copies must all collapse to the first, not just the adjacent pair
+TEST_F(TestBlurayDirectory, FilterPlaylists_RemovesAllCopiesOfADuplicate)
+{
+  std::vector<PlaylistInformation> playlists{
+      MakePlaylist(800u, 2h, {1u}),
+      MakePlaylist(801u, 2h, {1u}),
+      MakePlaylist(802u, 2h, {1u}),
+      MakePlaylist(803u, 2h, {2u}),
+  };
+
+  EXPECT_TRUE(FilterPlaylists(playlists));
+  EXPECT_EQ(PlaylistNumbers(playlists), (std::vector<unsigned int>{800u, 803u}));
+}

--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -256,13 +256,12 @@ std::string GetLocalArtBaseFilename(const CFileItem& item,
       }
       case PLAYLIST:
       {
-        const CVideoInfoTag* tag{item.GetVideoInfoTag()};
-        if (tag->m_iTrack > -1)
+        const int playlist{item.GetProperty("bluray_playlist").asInteger32(-1)};
+        if (playlist > -1)
         {
           std::string baseFile{file};
           URIUtils::RemoveExtension(baseFile);
-          strFile =
-              fmt::format("{}-{:05}{}", baseFile, tag->m_iTrack, URIUtils::GetExtension(file));
+          strFile = fmt::format("{}-{:05}{}", baseFile, playlist, URIUtils::GetExtension(file));
           useFolder = false;
         }
         break;

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -234,6 +234,8 @@ void CSaveFileState::DoWork(CFileItem& item,
                   !URIUtils::IsStack(tag->m_strFileNameAndPath) &&
                   tag->m_strFileNameAndPath != item.GetDynPath())
                 return true; // Bluray path to update
+              if (item.GetProperty("new_playlist_path").asBoolean(false))
+                return true; // Bluray playlist replaced by user selection
               if (item.GetProperty("new_stack_path").asBoolean(false))
                 return true; // Stack path to update
               return false;
@@ -269,6 +271,9 @@ void CSaveFileState::DoWork(CFileItem& item,
           CGUIMessage message(GUI_MSG_NOTIFY_ALL, CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow(), 0, GUI_MSG_UPDATE_ITEM, 0, msgItem);
           CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(message);
         }
+
+        CLog::LogF(LOGDEBUG, "Finished saving file state for video item {} (listing update {})",
+                   redactPath, updateListing ? "sent" : "not needed");
 
         videodatabase.Close();
       }

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -713,9 +713,12 @@ std::string URIUtils::GetBlurayTitlesPath(const std::string& path,
   return newPath;
 }
 
-std::string URIUtils::GetBlurayMainTitlePath(const std::string& path)
+std::string URIUtils::GetBlurayMainTitlePath(const std::string& path, GetAllTitles getAllTitles)
 {
-  return AddFileToFolder(GetBlurayPath(path), "root", "main");
+  std::string newPath{AddFileToFolder(GetBlurayPath(path), "root", "main")};
+  if (getAllTitles == GetAllTitles::ALL)
+    newPath = AddFileToFolder(newPath, "all");
+  return newPath;
 }
 
 std::string URIUtils::GetBlurayEpisodePath(const std::string& path, int season, int episode)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -2004,3 +2004,12 @@ std::string URIUtils::SanitiseUrlEncoding(std::string_view path)
   out += path.substr(hostEnd);
   return out;
 }
+
+std::string URIUtils::GetDecodedPath(const std::string& path)
+{
+  std::string decodedPath{path};
+  static constexpr unsigned int MAX_DECODE_PASSES = 5;
+  for (unsigned int i = 0; decodedPath.find('%') != std::string::npos && i < MAX_DECODE_PASSES; ++i)
+    decodedPath = CURL::Decode(decodedPath);
+  return decodedPath;
+}

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -160,9 +160,11 @@ public:
 
   /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path to main title.
    \param path the ISO/index.BDMV path.
+   \param getAllTitles whether to get a single title or those within 70% of longest (most likely to be movies/episodes)
    \return the bluray:// root/main path.
    */
-  static std::string GetBlurayMainTitlePath(const std::string& path);
+  static std::string GetBlurayMainTitlePath(const std::string& path,
+                                            GetAllTitles getAllTitles = GetAllTitles::LONG);
 
   /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path to a given episode.
    \param path the ISO/index.BDMV path.

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -416,6 +416,8 @@ public:
    */
   static std::string SanitiseUrlEncoding(std::string_view path);
 
+  static std::string GetDecodedPath(const std::string& path);
+
 private:
   static std::string resolvePath(const std::string &path);
 

--- a/xbmc/utils/test/TestArtUtils.cpp
+++ b/xbmc/utils/test/TestArtUtils.cpp
@@ -283,7 +283,7 @@ TEST_P(GetLocalArtBaseFilenameTest, GetLocalArtBaseFilename)
   CVideoInfoTag* tag{item.GetVideoInfoTag()};
   tag->m_iSeason = GetParam().season;
   tag->m_iEpisode = GetParam().episode;
-  tag->m_iTrack = GetParam().playlist;
+  item.SetProperty("bluray_playlist", GetParam().playlist);
   bool useFolder = GetParam().force_use_folder ? true : GetParam().isFolder;
 
   const std::string res =
@@ -899,7 +899,7 @@ TEST_P(TestLocalArt, GetLocalArt)
   CVideoInfoTag* tag{item.GetVideoInfoTag()};
   tag->m_iSeason = GetParam().season;
   tag->m_iEpisode = GetParam().episode;
-  tag->m_iTrack = GetParam().playlist;
+  item.SetProperty("bluray_playlist", GetParam().playlist);
   std::string path = ART::GetLocalArt(item, GetParam().art, GetParam().use_folder,
                                       GetParam().additionalIdentifiers);
   EXPECT_EQ(path, GetParam().base);

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -2714,3 +2714,14 @@ TEST_F(TestURIUtils, IsLocalOrLAN)
   // videodb:// is a virtual path - not HD, not LAN, not an internet stream
   EXPECT_FALSE(URIUtils::IsLocalOrLAN("videodb://tvshows/titles/1/1/42"));
 }
+
+TEST_F(TestURIUtils, GetDecodedPath)
+{
+  std::string encoded = "bluray://udf%3a%2f%2fsmb%253a%252f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/00800.mpls";
+  std::string decoded = "bluray://udf://smb://somepath/path/movie.iso//BDMV/PLAYLIST/00800.mpls";
+  EXPECT_EQ(decoded, URIUtils::GetDecodedPath(encoded));
+  
+  encoded = "bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls";
+  decoded = "bluray://smb://somepath/path//BDMV/PLAYLIST/00800.mpls";
+  EXPECT_EQ(decoded, URIUtils::GetDecodedPath(encoded));
+}

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11473,7 +11473,6 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
           if (tag->IsDefaultVideoVersion())
             SetDefaultVideoVersion(VideoDbContentType::MOVIES, lastMovieId, tag->m_iFileId);
         }
-        scanner.AddVideo(&item, nullptr, useFolders, true, nullptr, true, ContentType::MOVIES);
         current++;
       }
       else if (StringUtils::CompareNoCase(movie->Value(), MediaTypeMusicVideo, 10) == 0)
@@ -12671,14 +12670,15 @@ bool CVideoDatabase::SetDefaultVideoVersion(VideoDbContentType itemType, int dbI
   if (path.empty())
     return false;
 
+  int idOldFile{-1};
+
   try
   {
     BeginTransaction();
 
     if (itemType == VideoDbContentType::MOVIES)
     {
-      const int idOldFile{
-          GetSingleValueInt(PrepareSQL("SELECT idFile FROM movie WHERE idMovie=%i", dbId))};
+      idOldFile = GetSingleValueInt(PrepareSQL("SELECT idFile FROM movie WHERE idMovie=%i", dbId));
 
       if (idOldFile != idFile)
       {
@@ -12699,6 +12699,16 @@ bool CVideoDatabase::SetDefaultVideoVersion(VideoDbContentType itemType, int dbI
     }
 
     CommitTransaction();
+
+    if (itemType == VideoDbContentType::MOVIES)
+    {
+      if (idOldFile == idFile)
+        CLog::LogF(LOGDEBUG, "Default version of movie id {} unchanged (file id {})", dbId, idFile);
+      else
+        CLog::LogF(LOGDEBUG, "Default version of movie id {} changed from file id {} to file id {}",
+                   dbId, idOldFile, idFile);
+    }
+
     return true;
   }
   catch (...)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1100,6 +1100,20 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return InfoRet::ADDED;
   }
 
+  namespace
+  {
+  void ResolveBlurayPlaylist(CFileItem* item)
+  {
+    if (::UTILS::DISCS::IsBlurayDiscImage(item->GetPath()) || URIUtils::IsBDFile(item->GetPath()))
+    {
+      CFileItemList items;
+      if (CDiscDirectoryHelper::GetOrShowPlaylistSelection(*item, items, MenuDecision::SILENT) &&
+          !items.IsEmpty())
+        *item = *items[0];
+    }
+  }
+  } // unnamed namespace
+
   CInfoScanner::InfoRet CVideoInfoScanner::RetrieveInfoForMovie(CFileItem* pItem,
                                                                 bool bDirNames,
                                                                 ScraperPtr& info2,
@@ -1269,6 +1283,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
         applyEdition(pItem);
 
+        // Determine bluray playlist(s) (if possible)
+        // Also populates streamdetails if playlist(s) found
+        ResolveBlurayPlaylist(pItem);
+
         const int dbId{static_cast<int>(AddVideo(pItem, info2, bDirNames, useLocal))};
         if (dbId < 0)
           return InfoRet::INFO_ERROR;
@@ -1297,6 +1315,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
         return InfoRet::INFO_ERROR;
 
       applyEdition(pItem);
+
+      // Determine bluray playlist(s) (if possible)
+      // Also populates streamdetails if playlist(s) found
+      ResolveBlurayPlaylist(pItem);
 
       const int dbId{static_cast<int>(AddVideo(pItem, info2, bDirNames, useLocal))};
       if (dbId < 0)
@@ -1806,20 +1828,6 @@ CVideoInfoScanner::~CVideoInfoScanner()
     {
       strTitle = StringUtils::Format("{} - {}x{} - {}", showInfo->m_strTitle,
                                      movieDetails.m_iSeason, movieDetails.m_iEpisode, strTitle);
-    }
-
-    // Determine bluray playlist (if possible)
-    // Also populates streamdetails
-    if (!libraryImport && !pItem->GetProperty("from_nfo").asBoolean(false) &&
-        (::UTILS::DISCS::IsBlurayDiscImage(path) || URIUtils::IsBDFile(path)))
-    {
-      CFileItemList items;
-      if (CDiscDirectoryHelper::GetOrShowPlaylistSelection(*pItem, items, MenuDecision::SILENT))
-      {
-        *pItem = *items[0];
-        path = pItem->GetDynPath();
-        pItem->GetVideoInfoTag()->SetFileNameAndPath(path);
-      }
     }
 
     if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
@@ -2493,6 +2501,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
           scraperItem.GetVideoInfoTag()->m_iSeason = guide->iSeason;
         if (scraperItem.GetVideoInfoTag()->m_iEpisode == -1)
           scraperItem.GetVideoInfoTag()->m_iEpisode = guide->iEpisode;
+
+        // Determine bluray playlist(s) (if possible)
+        // Also populates streamdetails if playlist(s) found
+        ResolveBlurayPlaylist(&scraperItem);
 
         if (AddVideo(&scraperItem, info, file->isFolder, useLocal, &showInfo, false,
                      ContentType::TVSHOWS) < 0)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -80,6 +80,23 @@ using KODI::UTILITY::CDigest;
 
 namespace
 {
+//! \brief The grouping of similar videos setting, for logging
+const char* SimilarVideoScanActionToStr(SimilarVideoScanAction action)
+{
+  switch (action)
+  {
+    using enum SimilarVideoScanAction;
+    case NONE:
+      return "off";
+    case ASK:
+      return "ask";
+    case AUTO:
+      return "automatic";
+    default:
+      return "unknown";
+  }
+}
+
 /*! \brief Retrieve the art type for an image from the given size.
  \param width the width of the image.
  \param height the height of the image.
@@ -263,7 +280,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
       m_bCanInterrupt = true;
 
-      CLog::Log(LOGINFO, "VideoInfoScanner: Starting scan ..");
+      CLog::Log(LOGINFO, "VideoInfoScanner: Starting scan .. (grouping of similar videos is {})",
+                SimilarVideoScanActionToStr(m_similarVideoAction));
       CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary,
                                                          "OnScanStarted");
 
@@ -1102,15 +1120,30 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
   namespace
   {
-  void ResolveBlurayPlaylist(CFileItem* item)
+  // Populates CFileItemList items with every candidate (version) bluray playlist found for item (if any).
+  // item is updated in place to the first (main) playlist; any further items are additional playlists presumed to
+  // be other versions of the same movie (only populated when returned by CDiscDirectoryHelper when
+  // not SimilarVideoScanAction::NONE).
+  void ResolveBlurayPlaylist(CFileItem* item, CFileItemList& items)
   {
     if (::UTILS::DISCS::IsBlurayDiscImage(item->GetPath()) || URIUtils::IsBDFile(item->GetPath()))
     {
-      CFileItemList items;
       if (CDiscDirectoryHelper::GetOrShowPlaylistSelection(*item, items, MenuDecision::SILENT) &&
           !items.IsEmpty())
         *item = *items[0];
     }
+  }
+
+  // An edition extracted from the filename is applied only when an asset title hasn't been set yet (NFO wins).
+  void ApplyEdition(CFileItem* item, const std::string& editionFromFilename)
+  {
+    if (editionFromFilename.empty())
+      return;
+
+    // Creation of a tag if one doesn't exist yet is on purpose
+    CVideoInfoTag* tag{item->GetVideoInfoTag()};
+    if (tag && tag->GetAssetInfo().GetTitle().empty())
+      tag->GetAssetInfo().SetTitle(editionFromFilename);
   }
   } // unnamed namespace
 
@@ -1138,16 +1171,46 @@ CVideoInfoScanner::~CVideoInfoScanner()
     //! available filesystem characters. ex. "directors cut" in file name vs "Director's Cut"
     const std::string editionFromFilename{filenameAttributes.GetEdition()};
 
-    // An edition extracted from the filename is applied only when an asset title hasn't been set yet (NFO wins).
-    const auto applyEdition = [&editionFromFilename](CFileItem* item)
+    // Handle sets, filename-derived edition, bluray playlist(s) (if any) and add to the library
+    const auto HandleMovieSetAndVersions = [this, pItem, &info2, bDirNames, useLocal,
+                                            &editionFromFilename]() -> InfoRet
     {
-      if (editionFromFilename.empty())
-        return;
+      if (UpdateSetInTag(*pItem->GetVideoInfoTag()) && !AddSet(pItem->GetVideoInfoTag()->m_set))
+        return InfoRet::INFO_ERROR;
 
-      // Creation of a tag if one doesn't exist yet is on purpose
-      CVideoInfoTag* tag{item->GetVideoInfoTag()};
-      if (tag && tag->GetAssetInfo().GetTitle().empty())
-        tag->GetAssetInfo().SetTitle(editionFromFilename);
+      ApplyEdition(pItem, editionFromFilename);
+
+      // Determine bluray playlist(s) (if possible)
+      // Also populates streamdetails if playlist(s) found
+      CFileItemList blurayItems;
+      ResolveBlurayPlaylist(pItem, blurayItems);
+      if (!blurayItems.IsEmpty())
+        return AddBlurayPlaylistVersions(blurayItems, info2, bDirNames, useLocal);
+
+      const int movieDbId{static_cast<int>(AddVideo(pItem, info2, bDirNames, useLocal))};
+      if (movieDbId < 0)
+        return InfoRet::INFO_ERROR;
+
+      if ((m_similarVideoAction == SimilarVideoScanAction::ASK ||
+           m_similarVideoAction == SimilarVideoScanAction::AUTO))
+      {
+        [[maybe_unused]] const auto [result, targetMovieDbId] =
+            ProcessVideoVersion(VideoDbContentType::MOVIES, movieDbId);
+        switch (result)
+        {
+          case VersionConversionResult::SUCCESS:
+            return InfoRet::HAVE_ALREADY;
+          case VersionConversionResult::NOT_NEEDED:
+          case VersionConversionResult::CANCELLED:
+          case VersionConversionResult::NOT_ALLOWED:
+            return InfoRet::ADDED;
+          case VersionConversionResult::FAILED:
+            return InfoRet::INFO_ERROR;
+        }
+      }
+
+      // No version processing
+      return InfoRet::ADDED;
     };
 
     InfoType result = InfoType::NONE;
@@ -1162,6 +1225,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     {
       // Add the movie entry
       int movieId{-1};
+      bool mergedIntoExistingMovie{false};
       item.SetProperty("from_nfo", true);
 
       CVideoInfoTag* tag{item.GetVideoInfoTag()};
@@ -1175,6 +1239,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         {
           // Movie already exists
           movieId = items[0]->GetVideoInfoTag()->m_iDbId;
+          mergedIntoExistingMovie = true;
           CLog::LogF(LOGDEBUG,
                      "Movie '{}' already exists in the library as id {} - adding as version",
                      tag->GetTitle(), movieId);
@@ -1190,7 +1255,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       // Existing movie cannot be found or is not version - add it
       if (movieId < 0)
       {
-        applyEdition(&item);
+        ApplyEdition(&item, editionFromFilename);
 
         movieId = static_cast<int>(AddVideo(&item, info2, bDirNames, true));
         if (movieId < 0)
@@ -1234,7 +1299,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         m_database.SetDefaultVideoVersion(VideoDbContentType::MOVIES, movieId,
                                           defaultVersionFileId);
 
-      return InfoRet::ADDED;
+      return mergedIntoExistingMovie ? InfoRet::HAVE_ALREADY : InfoRet::ADDED;
     }
 
     // If no nfo then return here if movie already in library
@@ -1277,25 +1342,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
                      (result == InfoType::COMBINED || result == InfoType::OVERRIDE) ? loader.get()
                                                                                     : nullptr,
                      pDlgProgress))
-      {
-        if (UpdateSetInTag(*pItem->GetVideoInfoTag()) && !AddSet(pItem->GetVideoInfoTag()->m_set))
-          return InfoRet::INFO_ERROR;
-
-        applyEdition(pItem);
-
-        // Determine bluray playlist(s) (if possible)
-        // Also populates streamdetails if playlist(s) found
-        ResolveBlurayPlaylist(pItem);
-
-        const int dbId{static_cast<int>(AddVideo(pItem, info2, bDirNames, useLocal))};
-        if (dbId < 0)
-          return InfoRet::INFO_ERROR;
-        if ((m_similarVideoAction == SimilarVideoScanAction::ASK ||
-             m_similarVideoAction == SimilarVideoScanAction::AUTO) &&
-            ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
-          return InfoRet::HAVE_ALREADY;
-        return InfoRet::ADDED;
-      }
+        return HandleMovieSetAndVersions();
     }
 
     if (pURL && pURL->HasUrls())
@@ -1310,25 +1357,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
                    (result == InfoType::COMBINED || result == InfoType::OVERRIDE) ? loader.get()
                                                                                   : nullptr,
                    pDlgProgress))
-    {
-      if (UpdateSetInTag(*pItem->GetVideoInfoTag()) && !AddSet(pItem->GetVideoInfoTag()->m_set))
-        return InfoRet::INFO_ERROR;
+      return HandleMovieSetAndVersions();
 
-      applyEdition(pItem);
-
-      // Determine bluray playlist(s) (if possible)
-      // Also populates streamdetails if playlist(s) found
-      ResolveBlurayPlaylist(pItem);
-
-      const int dbId{static_cast<int>(AddVideo(pItem, info2, bDirNames, useLocal))};
-      if (dbId < 0)
-        return InfoRet::INFO_ERROR;
-      if ((m_similarVideoAction == SimilarVideoScanAction::ASK ||
-           m_similarVideoAction == SimilarVideoScanAction::AUTO) &&
-          ProcessVideoVersion(VideoDbContentType::MOVIES, dbId))
-        return InfoRet::HAVE_ALREADY;
-      return InfoRet::ADDED;
-    }
     //! @todo This is not strictly correct as we could fail to download information here or error, or be cancelled
     return InfoRet::NOT_FOUND;
   }
@@ -1787,15 +1817,20 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
     const ContentType content{
         !scraper || contentOverride != ContentType::NONE ? contentOverride : scraper->Content()};
-    const bool usingLocalScraper{scraper && scraper->ID() == "metadata.local"};
+    const bool usingLocalScraper{!scraper || scraper->ID() == "metadata.local"};
     const UseRemoteArtWithLocalScraper useRemoteArt{
         usingLocalScraper && m_advancedSettings->m_bNoRemoteArtWithLocalScraper
             ? UseRemoteArtWithLocalScraper::NO
             : UseRemoteArtWithLocalScraper::YES};
 
-    std::string path{pItem->GetPath()};
+    std::string path{pItem->GetDynPath()};
     const int playlist{pItem->GetProperty("bluray_playlist").asInteger32(-1)};
-    if (playlist > -1 && (::UTILS::DISCS::IsBlurayDiscImage(path) || URIUtils::IsBDFile(path)))
+
+    // The versions loop in RetrieveInfoForMovie() reuses one item for every <movie> in the nfo, so
+    // the dynpath may still hold the previous version's playlist.
+    if (playlist > -1 &&
+        (::UTILS::DISCS::IsBlurayDiscImage(path) || URIUtils::IsBDFile(path) ||
+         (URIUtils::IsBlurayPath(path) && URIUtils::GetBlurayPlaylistFromPath(path) != playlist)))
     {
       path = URIUtils::GetBlurayPlaylistPath(path, playlist);
       pItem->SetDynPath(path);
@@ -1871,8 +1906,11 @@ CVideoInfoScanner::~CVideoInfoScanner()
                     });
 
       // Deal with 'Disc n' subdirectories
-      // Unless dealing with a full nfo in which case details are taken from there already
-      if (!pItem->GetProperty("from_nfo").asBoolean(false) && !pItem->IsStack())
+      // Unless dealing with a full nfo or a library import, in which case the title and set are
+      // taken from there already. Only occurs on first addition of the movie.
+      const bool newMovie{m_database.GetMovieId(path) < 0};
+      if (newMovie && !libraryImport && !pItem->GetProperty("from_nfo").asBoolean(false) &&
+          !pItem->IsStack())
       {
         const std::string discNum{CUtil::GetPartNumberFromPath(movieDetails.m_strFileNameAndPath)};
         if (!discNum.empty())
@@ -2509,7 +2547,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
         // Determine bluray playlist(s) (if possible)
         // Also populates streamdetails if playlist(s) found
-        ResolveBlurayPlaylist(&scraperItem);
+        CFileItemList blurayItems;
+        ResolveBlurayPlaylist(&scraperItem, blurayItems);
 
         if (AddVideo(&scraperItem, info, file->isFolder, useLocal, &showInfo, false,
                      ContentType::TVSHOWS) < 0)
@@ -2956,9 +2995,73 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return true;
   }
 
-  bool CVideoInfoScanner::ProcessVideoVersion(VideoDbContentType itemType, int dbId)
+  CInfoScanner::InfoRet CVideoInfoScanner::AddBlurayPlaylistVersions(
+      const CFileItemList& blurayItems, const ScraperPtr& scraper, bool bDirNames, bool useLocal)
   {
-    return CGUIDialogVideoManagerVersions::ProcessVideoVersion(itemType, dbId);
+    if (blurayItems.IsEmpty())
+    {
+      CLog::LogF(LOGDEBUG, "No bluray playlist versions to add for the movie");
+      return InfoRet::NOT_NEEDED;
+    }
+
+    bool added{false};
+    bool versioned{false};
+    int targetDbId{-1};
+    for (const auto& item : blurayItems)
+    {
+      const int newMovieDbId{static_cast<int>(
+          AddVideo(item.get(), scraper, bDirNames, useLocal, nullptr, false, ContentType::MOVIES))};
+      if (newMovieDbId < 0)
+      {
+        CLog::LogF(LOGERROR, "Failed to add bluray playlist '{}' for movie",
+                   CURL::GetRedacted(item->GetDynPath()));
+        continue;
+      }
+      added = true;
+
+      // Each playlist is added as a movie in its own right first, then merged as a version of the
+      // one before it. Nothing to merge into if versioning is turned off, so they stay separate
+      if (m_similarVideoAction != SimilarVideoScanAction::ASK &&
+          m_similarVideoAction != SimilarVideoScanAction::AUTO)
+        continue;
+
+      const auto [result, chosenTargetMovieDbId] =
+          ProcessVideoVersion(ContentToVideoDbType(ContentType::MOVIES), newMovieDbId, targetDbId);
+      if (result == VersionConversionResult::SUCCESS)
+      {
+        CLog::LogF(LOGDEBUG, "Added bluray playlist '{}' as a version of movie id {}",
+                   CURL::GetRedacted(item->GetDynPath()), chosenTargetMovieDbId);
+        targetDbId = chosenTargetMovieDbId;
+        versioned = true;
+      }
+      else if (result == VersionConversionResult::FAILED ||
+               result == VersionConversionResult::CANCELLED)
+      {
+        // Declined, or merging was not possible
+        if (m_database.DeleteMovie(newMovieDbId))
+          m_database.DeleteFile(item->GetVideoInfoTag()->m_iFileId);
+        CLog::LogF(LOGDEBUG,
+                   "Not adding bluray playlist '{}' as a version - declined or merge not possible",
+                   CURL::GetRedacted(item->GetDynPath()));
+      }
+    }
+
+    if (added && targetDbId >= 0)
+      RemovePartNumberFromTitle(targetDbId, VideoDbContentType::MOVIES, m_database);
+    return !added ? InfoRet::INFO_ERROR : (versioned ? InfoRet::HAVE_ALREADY : InfoRet::ADDED);
+  }
+
+  std::pair<VersionConversionResult, int> CVideoInfoScanner::ProcessVideoVersion(
+      VideoDbContentType itemType, int dbId, int targetDbId /* = -1 */)
+  {
+    return CGUIDialogVideoManagerVersions::ProcessVideoVersion(itemType, dbId, targetDbId);
+  }
+
+  void CVideoInfoScanner::RemovePartNumberFromTitle(int dbId,
+                                                    VideoDbContentType itemType,
+                                                    CVideoDatabase& db)
+  {
+    return CGUIDialogVideoManagerVersions::RemovePartNumberFromTitle(dbId, itemType, db);
   }
 
   void CVideoInfoScanner::SkipRelatedDirectories(std::string_view originalDirectory)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1794,7 +1794,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
             : UseRemoteArtWithLocalScraper::YES};
 
     std::string path{pItem->GetPath()};
-    const int playlist{pItem->HasVideoInfoTag() ? pItem->GetVideoInfoTag()->m_iTrack : -1};
+    const int playlist{pItem->GetProperty("bluray_playlist").asInteger32(-1)};
     if (playlist > -1 && (::UTILS::DISCS::IsBlurayDiscImage(path) || URIUtils::IsBDFile(path)))
     {
       path = URIUtils::GetBlurayPlaylistPath(path, playlist);
@@ -2062,6 +2062,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
         infoTag.Reset();
       auto result = loader->Load(infoTag, false);
 
+      // A <playlist> nfo element identifies the disc playlist the info belongs to
+      if (const int playlist{loader->GetBlurayPlaylist()}; playlist > -1)
+        item.SetProperty("bluray_playlist", playlist);
+
       // keep some properties only if advancedsettings.xml says so
       if (!m_advancedSettings->m_bVideoLibraryImportWatchedState)
         infoTag.ResetPlayCount();
@@ -2149,7 +2153,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
                                                   : ART::AdditionalIdentifiers::NONE);
         }
         else if (content == ContentType::MOVIE_VERSIONS ||
-                 (pItem->HasVideoVersions() && pItem->GetVideoInfoTag()->m_iTrack > -1))
+                 (pItem->HasVideoVersions() &&
+                  pItem->GetProperty("bluray_playlist").asInteger32(-1) > -1))
         {
           // Add playlist identifier only when there are multiple versions of the movie on the same disc
           path =
@@ -2553,6 +2558,11 @@ CVideoInfoScanner::~CVideoInfoScanner()
       }
 
       *pItem->GetVideoInfoTag() = movieDetails;
+
+      // A <playlist> nfo element identifies the disc playlist the info belongs to
+      if (const int playlist{loader ? loader->GetBlurayPlaylist() : -1}; playlist > -1)
+        pItem->SetProperty("bluray_playlist", playlist);
+
       return true;
     }
     return false; // no info found, or cancelled

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1813,8 +1813,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
     if (!libraryImport && !pItem->GetProperty("from_nfo").asBoolean(false) &&
         (::UTILS::DISCS::IsBlurayDiscImage(path) || URIUtils::IsBDFile(path)))
     {
-      if (CDiscDirectoryHelper::GetOrShowPlaylistSelection(*pItem, MenuDecision::SILENT))
+      CFileItemList items;
+      if (CDiscDirectoryHelper::GetOrShowPlaylistSelection(*pItem, items, MenuDecision::SILENT))
       {
+        *pItem = *items[0];
         path = pItem->GetDynPath();
         pItem->GetVideoInfoTag()->SetFileNameAndPath(path);
       }

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -10,6 +10,7 @@
 
 #include "InfoScanner.h"
 #include "VideoDatabase.h"
+#include "VideoManagerTypes.h"
 #include "addons/Scraper.h"
 #include "settings/VideoVersionsSettings.h"
 #include "utils/Artwork.h"
@@ -334,7 +335,25 @@ namespace KODI::VIDEO
     bool ProcessItemByVideoInfoTag(const CFileItem *item, EPISODELIST &episodeList);
 
     bool AddVideoExtras(CFileItemList& items, ADDON::ContentType content, const std::string& path);
-    bool ProcessVideoVersion(VideoDbContentType itemType, int dbId);
+    static std::pair<VersionConversionResult, int> ProcessVideoVersion(VideoDbContentType itemType,
+                                                                       int dbId,
+                                                                       int targetDbId = -1);
+    static void RemovePartNumberFromTitle(int dbId,
+                                          VideoDbContentType itemType,
+                                          CVideoDatabase& db);
+
+    /*!
+     * \brief Add bluray playlists found for the same disc as movie and/or versions.
+     * \param[in] blurayItems all candidate playlists found for the disc
+     * \param[in] scraper scraper used for the lookup
+     * \param[in] bDirNames whether directory names are used for identification
+     * \param[in] useLocal whether to use local information for artwork etc.
+     * \return InfoRet::INFO_ERROR on failure, InfoRet::ADDED if movie added, InfoRet::HAVE_ALREADY if versions added
+     */
+    InfoRet AddBlurayPlaylistVersions(const CFileItemList& blurayItems,
+                                      const ADDON::ScraperPtr& scraper,
+                                      bool bDirNames,
+                                      bool useLocal);
 
     std::pair<InfoType, std::unique_ptr<IVideoInfoTagLoader>> ReadInfoTag(
         CFileItem& item, const ADDON::ScraperPtr& scraper, bool lookInFolder, bool resetTag);

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -1279,7 +1279,9 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
 
   if (XMLUtils::GetString(movie, "filenameandpath", value))
     SetFileNameAndPath(value);
-  XMLUtils::GetInt(movie, "playlist", m_iTrack);
+  // Note <playlist> is not parsed here - it is a bluray playlist, not part of the tag.
+  // See CNfoFile::GetBlurayPlaylist()
+
   XMLUtils::GetBoolean(movie, "hasvideoversions", m_hasVideoVersions);
   XMLUtils::GetBoolean(movie, "isdefaultvideoversion", m_isDefaultVideoVersion);
 

--- a/xbmc/video/VideoManagerTypes.h
+++ b/xbmc/video/VideoManagerTypes.h
@@ -10,6 +10,8 @@
 
 #include "media/MediaType.h"
 
+#include <cstdint>
+
 enum class VideoAssetTypeOwner
 {
   UNKNOWN = -1,
@@ -33,6 +35,15 @@ enum class MediaRole
 {
   NewVersion,
   Parent
+};
+
+enum class VersionConversionResult : uint8_t
+{
+  SUCCESS,
+  CANCELLED,
+  FAILED,
+  NOT_NEEDED,
+  NOT_ALLOWED
 };
 
 static constexpr int VIDEO_VERSION_ID_BEGIN = 40400;

--- a/xbmc/video/dialogs/GUIDialogVideoManager.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.h
@@ -29,6 +29,10 @@ public:
   virtual void SetSelectedVideoAsset(const std::shared_ptr<CFileItem>& asset);
   virtual bool HasUpdatedItems() const { return m_hasUpdatedItems; }
 
+  static int ChooseVideoAsset(const std::shared_ptr<CFileItem>& item,
+                              VideoAssetType assetType,
+                              const std::string& defaultName);
+
 protected:
   void OnInitWindow() override;
   void OnDeinitWindow(int nextWindowID) override;
@@ -53,9 +57,6 @@ protected:
 
   void UpdateControls();
 
-  static int ChooseVideoAsset(const std::shared_ptr<CFileItem>& item,
-                              VideoAssetType assetType,
-                              const std::string& defaultName);
   void AppendItemFolderToFileBrowserSources(std::vector<CMediaSource>& sources);
   void RefreshSelectedVideoAsset();
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -368,78 +368,80 @@ bool CGUIDialogVideoManagerVersions::ChoosePlaylist(const std::shared_ptr<CFileI
   item->SetProperty("force_playlist_selection", true);
   const int idMovie{m_database.GetMovieId(oldPath)};
 
-  if (XFILE::CDiscDirectoryHelper::GetOrShowPlaylistSelection(
-          *item, XFILE::MenuDecision::SHOW_SIMPLE_MENU) &&
-      oldPath != item->GetDynPath())
+  CFileItemList items;
+  if (!XFILE::CDiscDirectoryHelper::GetOrShowPlaylistSelection(
+          *item, items, XFILE::MenuDecision::SHOW_SIMPLE_MENU) ||
+      items.IsEmpty())
+    return false;
+  if (oldPath == items[0]->GetDynPath())
+    return false;
+  *item = *items[0];
+
+  // Add playlist file as bluray://
+  int idFile;
+  bool videoDbSuccess{false};
+  m_database.BeginTransaction();
+  if (replaceExistingFile == ReplaceExistingFile::YES)
   {
-    // Add playlist file as bluray://
-    int idFile;
-    bool videoDbSuccess{false};
-    m_database.BeginTransaction();
-    if (replaceExistingFile == ReplaceExistingFile::YES)
-    {
-      idFile = m_database.SetFileForMedia(
-          item->GetDynPath(), item->GetVideoContentType(), item->GetVideoInfoTag()->m_iDbId,
-          CVideoDatabase::FileRecord{.m_idFile = item->GetVideoInfoTag()->m_iFileId,
-                                     .m_dateAdded = item->GetVideoInfoTag()->m_dateAdded});
-      videoDbSuccess = idFile > 0;
-      if (videoDbSuccess)
-      {
-        m_database.SetStreamDetailsForFile(item->GetVideoInfoTag()->m_streamDetails,
-                                           item->GetDynPath());
-
-        // Notify all windows to update the file item
-        CFileItem oldItem{*item};
-        oldItem.SetPath(oldPath);
-        CGUIMessage msg{GUI_MSG_NOTIFY_ALL,
-                        0,
-                        0,
-                        GUI_MSG_UPDATE_ITEM,
-                        GUI_MSG_FLAG_FORCE_UPDATE,
-                        std::make_shared<CFileItem>(oldItem)};
-        CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
-      }
-    }
-    else
-    {
-      // Choose a video version for the video
-      const int idVideoVersion{ChooseVideoAsset(item, VideoAssetType::VERSION, "")};
-      if (idVideoVersion < 0)
-        return false;
-
-      idFile = m_database.AddFile(item->GetDynPath(), "", item->GetVideoInfoTag()->m_dateAdded);
-      if (idFile > 0)
-      {
-        videoDbSuccess = true;
-        m_database.SetStreamDetailsForFileId(item->GetVideoInfoTag()->m_streamDetails, idFile);
-        if (!m_database.AddOrUpdateVideoVersion(item->GetVideoContentType(), idMovie, idFile,
-                                                idVideoVersion, VideoAssetType::VERSION))
-          return false;
-      }
-
-      // Remove (Disc n) from title if we are now spanning discs or folders
-      if (!URIUtils::CompareDiscPaths(m_videoAsset->GetDynPath(), item->GetDynPath()))
-        RemovePartNumberFromTitle();
-    }
-
+    idFile = m_database.SetFileForMedia(
+        item->GetDynPath(), item->GetVideoContentType(), item->GetVideoInfoTag()->m_iDbId,
+        CVideoDatabase::FileRecord{.m_idFile = item->GetVideoInfoTag()->m_iFileId,
+                                   .m_dateAdded = item->GetVideoInfoTag()->m_dateAdded});
+    videoDbSuccess = idFile > 0;
     if (videoDbSuccess)
     {
-      // New disc video version will not have any art so use the art from the disc
-      m_database.SetArtForItem(idFile, MediaTypeVideoVersion, item->GetArt());
-      m_database.CommitTransaction();
+      m_database.SetStreamDetailsForFile(item->GetVideoInfoTag()->m_streamDetails,
+                                         item->GetDynPath());
+
+      // Notify all windows to update the file item
+      CFileItem oldItem{*item};
+      oldItem.SetPath(oldPath);
+      CGUIMessage msg{GUI_MSG_NOTIFY_ALL,
+                      0,
+                      0,
+                      GUI_MSG_UPDATE_ITEM,
+                      GUI_MSG_FLAG_FORCE_UPDATE,
+                      std::make_shared<CFileItem>(oldItem)};
+      CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
     }
-    else
-      m_database.RollbackTransaction();
+  }
+  else
+  {
+    // Choose a video version for the video
+    const int idVideoVersion{ChooseVideoAsset(item, VideoAssetType::VERSION, "")};
+    if (idVideoVersion < 0)
+      return false;
 
-    // refresh data and controls
-    Refresh();
-    UpdateControls();
-    m_hasUpdatedItems = true;
+    idFile = m_database.AddFile(item->GetDynPath(), "", item->GetVideoInfoTag()->m_dateAdded);
+    if (idFile > 0)
+    {
+      videoDbSuccess = true;
+      m_database.SetStreamDetailsForFileId(item->GetVideoInfoTag()->m_streamDetails, idFile);
+      if (!m_database.AddOrUpdateVideoVersion(item->GetVideoContentType(), idMovie, idFile,
+                                              idVideoVersion, VideoAssetType::VERSION))
+        return false;
+    }
 
-    return videoDbSuccess;
+    // Remove (Disc n) from title if we are now spanning discs or folders
+    if (!URIUtils::CompareDiscPaths(m_videoAsset->GetDynPath(), item->GetDynPath()))
+      RemovePartNumberFromTitle();
   }
 
-  return false;
+  if (videoDbSuccess)
+  {
+    // New disc video version will not have any art so use the art from the disc
+    m_database.SetArtForItem(idFile, MediaTypeVideoVersion, item->GetArt());
+    m_database.CommitTransaction();
+  }
+  else
+    m_database.RollbackTransaction();
+
+  // refresh data and controls
+  Refresh();
+  UpdateControls();
+  m_hasUpdatedItems = true;
+
+  return videoDbSuccess;
 }
 
 bool CGUIDialogVideoManagerVersions::ManageVideoVersions(const std::shared_ptr<CFileItem>& item)

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -13,7 +13,6 @@
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "URL.h"
-#include "Util.h"
 #include "cores/VideoPlayer/DVDFileInfo.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogOK.h"
@@ -37,12 +36,15 @@
 #include "video/VideoManagerTypes.h"
 #include "video/VideoThumbLoader.h"
 
-#include <algorithm>
+#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 static constexpr unsigned int CONTROL_BUTTON_ADD_VERSION = 22;
 static constexpr unsigned int CONTROL_BUTTON_RENAME_VERSION = 24;
 static constexpr unsigned int CONTROL_BUTTON_SET_DEFAULT = 25;
+static constexpr int NO_VERSION = -1;
 
 CGUIDialogVideoManagerVersions::CGUIDialogVideoManagerVersions()
   : CGUIDialogVideoManager(WINDOW_DIALOG_MANAGE_VIDEO_VERSIONS),
@@ -265,9 +267,10 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersion()
 
         const auto tag{m_videoAsset->GetVideoInfoTag()};
 
-        return ChooseVideoAndConvertToVideoVersion(items, m_videoAsset->GetVideoContentType(),
-                                                   tag->m_type, tag->m_iDbId, videoDb,
-                                                   MediaRole::Parent, Mode::INTERACTIVE, false);
+        [[maybe_unused]] const auto [result, movieDbId] = ChooseVideoAndConvertToVideoVersion(
+            items, m_videoAsset->GetVideoContentType(), tag->m_iDbId, videoDb, MediaRole::Parent,
+            Mode::INTERACTIVE, false);
+        return result == VersionConversionResult::SUCCESS;
       }
 
       case CGUIDialogYesNo::DIALOG_RESULT_YES:
@@ -321,9 +324,10 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersion()
 
     const auto tag{m_videoAsset->GetVideoInfoTag()};
 
-    return ChooseVideoAndConvertToVideoVersion(items, m_videoAsset->GetVideoContentType(),
-                                               tag->m_type, tag->m_iDbId, videoDb,
-                                               MediaRole::Parent, Mode::INTERACTIVE, false);
+    [[maybe_unused]] const auto [result, movieDbId] = ChooseVideoAndConvertToVideoVersion(
+        items, m_videoAsset->GetVideoContentType(), tag->m_iDbId, videoDb, MediaRole::Parent,
+        Mode::INTERACTIVE, false);
+    return result == VersionConversionResult::SUCCESS;
   }
   return false;
 }
@@ -338,18 +342,16 @@ int GetPartNumberInTitle(const std::string& title)
 }
 } // namespace
 
-void CGUIDialogVideoManagerVersions::RemovePartNumberFromTitle()
+void CGUIDialogVideoManagerVersions::RemovePartNumberFromTitle(int dbId,
+                                                               VideoDbContentType itemType,
+                                                               CVideoDatabase& db)
 {
-  if (!m_videoAsset || !m_videoAsset->HasVideoInfoTag())
-    return;
-
-  CVideoInfoTag* tag{m_videoAsset->GetVideoInfoTag()};
-  std::string& title{tag->m_strTitle};
+  CVideoInfoTag tag{db.GetDetailsByTypeAndId(itemType, dbId)};
+  std::string title{tag.m_strTitle};
   if (const int offset{GetPartNumberInTitle(title)}; offset >= 0)
   {
     title.erase(offset);
-    VideoDbContentType iType{m_videoAsset->GetVideoContentType()};
-    m_database.UpdateMovieTitle(tag->m_iDbId, title, iType);
+    db.UpdateMovieTitle(dbId, title, itemType);
   }
 }
 
@@ -373,68 +375,84 @@ bool CGUIDialogVideoManagerVersions::ChoosePlaylist(const std::shared_ptr<CFileI
           *item, items, XFILE::MenuDecision::SHOW_SIMPLE_MENU) ||
       items.IsEmpty())
     return false;
-  if (oldPath == items[0]->GetDynPath())
-    return false;
   *item = *items[0];
 
   // Add playlist file as bluray://
-  int idFile;
   bool videoDbSuccess{false};
-  m_database.BeginTransaction();
-  if (replaceExistingFile == ReplaceExistingFile::YES)
+  try
   {
-    idFile = m_database.SetFileForMedia(
-        item->GetDynPath(), item->GetVideoContentType(), item->GetVideoInfoTag()->m_iDbId,
-        CVideoDatabase::FileRecord{.m_idFile = item->GetVideoInfoTag()->m_iFileId,
-                                   .m_dateAdded = item->GetVideoInfoTag()->m_dateAdded});
-    videoDbSuccess = idFile > 0;
+    int idFile{-1};
+    m_database.BeginTransaction();
+    if (replaceExistingFile == ReplaceExistingFile::YES)
+    {
+      idFile = m_database.SetFileForMedia(
+          item->GetDynPath(), item->GetVideoContentType(), item->GetVideoInfoTag()->m_iDbId,
+          CVideoDatabase::FileRecord{.m_idFile = item->GetVideoInfoTag()->m_iFileId,
+                                     .m_dateAdded = item->GetVideoInfoTag()->m_dateAdded});
+      videoDbSuccess = idFile > 0;
+      if (videoDbSuccess)
+      {
+        m_database.SetStreamDetailsForFile(item->GetVideoInfoTag()->m_streamDetails,
+                                           item->GetDynPath());
+
+        // Notify all windows to update the file item
+        CFileItem oldItem{*item};
+        oldItem.SetPath(oldPath);
+        CGUIMessage msg{GUI_MSG_NOTIFY_ALL,
+                        0,
+                        0,
+                        GUI_MSG_UPDATE_ITEM,
+                        GUI_MSG_FLAG_FORCE_UPDATE,
+                        std::make_shared<CFileItem>(oldItem)};
+        CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+      }
+    }
+    else
+    {
+      // Choose a video version for the video
+      const int idVideoVersion{ChooseVideoAsset(item, VideoAssetType::VERSION, "")};
+      if (idVideoVersion < 0)
+      {
+        m_database.RollbackTransaction();
+        return false;
+      }
+
+      idFile = m_database.AddFile(item->GetDynPath(), "", item->GetVideoInfoTag()->m_dateAdded);
+      if (idFile > 0)
+      {
+        videoDbSuccess = true;
+        m_database.SetStreamDetailsForFileId(item->GetVideoInfoTag()->m_streamDetails, idFile);
+        if (!m_database.AddOrUpdateVideoVersion(item->GetVideoContentType(), idMovie, idFile,
+                                                idVideoVersion, VideoAssetType::VERSION))
+        {
+          m_database.RollbackTransaction();
+          return false;
+        }
+      }
+    }
+
     if (videoDbSuccess)
     {
-      m_database.SetStreamDetailsForFile(item->GetVideoInfoTag()->m_streamDetails,
-                                         item->GetDynPath());
+      // Remove (Disc n) from title if we are now spanning discs or folders
+      if (!URIUtils::CompareDiscPaths(m_videoAsset->GetDynPath(), item->GetDynPath()))
+        RemovePartNumberFromTitle(m_videoAsset->GetVideoInfoTag()->m_iDbId,
+                                  m_videoAsset->GetVideoContentType(), m_database);
 
-      // Notify all windows to update the file item
-      CFileItem oldItem{*item};
-      oldItem.SetPath(oldPath);
-      CGUIMessage msg{GUI_MSG_NOTIFY_ALL,
-                      0,
-                      0,
-                      GUI_MSG_UPDATE_ITEM,
-                      GUI_MSG_FLAG_FORCE_UPDATE,
-                      std::make_shared<CFileItem>(oldItem)};
-      CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+      // New disc video version will not have any art so use the art from the disc
+      m_database.SetArtForItem(idFile, MediaTypeVideoVersion, item->GetArt());
+
+      m_database.CommitTransaction();
     }
+    else
+      m_database.RollbackTransaction();
   }
-  else
+  catch (...)
   {
-    // Choose a video version for the video
-    const int idVideoVersion{ChooseVideoAsset(item, VideoAssetType::VERSION, "")};
-    if (idVideoVersion < 0)
-      return false;
-
-    idFile = m_database.AddFile(item->GetDynPath(), "", item->GetVideoInfoTag()->m_dateAdded);
-    if (idFile > 0)
-    {
-      videoDbSuccess = true;
-      m_database.SetStreamDetailsForFileId(item->GetVideoInfoTag()->m_streamDetails, idFile);
-      if (!m_database.AddOrUpdateVideoVersion(item->GetVideoContentType(), idMovie, idFile,
-                                              idVideoVersion, VideoAssetType::VERSION))
-        return false;
-    }
-
-    // Remove (Disc n) from title if we are now spanning discs or folders
-    if (!URIUtils::CompareDiscPaths(m_videoAsset->GetDynPath(), item->GetDynPath()))
-      RemovePartNumberFromTitle();
-  }
-
-  if (videoDbSuccess)
-  {
-    // New disc video version will not have any art so use the art from the disc
-    m_database.SetArtForItem(idFile, MediaTypeVideoVersion, item->GetArt());
-    m_database.CommitTransaction();
-  }
-  else
+    CLog::LogF(LOGERROR, "Exception adding bluray playlist '{}'",
+               CURL::GetRedacted(item->GetDynPath()));
     m_database.RollbackTransaction();
+    return false;
+  }
 
   // refresh data and controls
   Refresh();
@@ -499,15 +517,14 @@ std::shared_ptr<CFileItem> ChooseVideo(CFileItemList& items, MediaRole role)
 }
 } // namespace
 
-bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
-    CFileItemList& items,
-    VideoDbContentType itemType,
-    const std::string& mediaType,
-    int dbId,
-    CVideoDatabase& videoDb,
-    MediaRole role,
-    Mode mode,
-    bool setDefaultVersion)
+std::pair<VersionConversionResult, int> CGUIDialogVideoManagerVersions::
+    ChooseVideoAndConvertToVideoVersion(CFileItemList& items,
+                                        VideoDbContentType itemType,
+                                        int dbId,
+                                        CVideoDatabase& videoDb,
+                                        MediaRole role,
+                                        Mode mode,
+                                        bool setDefaultVersion)
 {
   std::shared_ptr<CFileItem> selectedItem;
 
@@ -519,11 +536,25 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
   if (!selectedItem)
   {
     if (mode == Mode::NON_INTERACTIVE)
-      CLog::Log(LOGINFO,
-                "Automated video version creation stopped by multiple existing similar videos");
-    return false;
+      CLog::LogF(LOGINFO,
+                 "Automated video version creation stopped by multiple existing similar videos");
+
+    return {VersionConversionResult::CANCELLED, NO_VERSION};
   }
 
+  return ConvertToVideoVersion(selectedItem, itemType, dbId, videoDb, role, mode,
+                               setDefaultVersion);
+}
+
+std::pair<VersionConversionResult, int> CGUIDialogVideoManagerVersions::ConvertToVideoVersion(
+    const std::shared_ptr<CFileItem>& selectedItem,
+    VideoDbContentType itemType,
+    int dbId,
+    CVideoDatabase& videoDb,
+    MediaRole role,
+    Mode mode,
+    bool setDefaultVersion)
+{
   int sourceDbId, targetDbId;
   switch (role)
   {
@@ -536,7 +567,7 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
       targetDbId = dbId;
       break;
     default:
-      return false;
+      return {VersionConversionResult::FAILED, NO_VERSION};
   }
 
   CFileItemList list;
@@ -548,12 +579,13 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
                           !CGUIDialogYesNo::ShowAndGetInput(CVariant{40014}, CVariant{40037})))
   {
     if (mode == Mode::NON_INTERACTIVE)
-      CLog::Log(LOGINFO,
-                "Automated video version creation stopped by multiple versions of the source video "
-                "dbid {} path '{}'",
-                sourceDbId, CURL::GetRedacted(selectedItem->GetDynPath()));
+      CLog::LogF(
+          LOGINFO,
+          "Automated video version creation stopped by multiple versions of the source video "
+          "dbid {} path '{}'",
+          sourceDbId, CURL::GetRedacted(selectedItem->GetDynPath()));
 
-    return false;
+    return {VersionConversionResult::CANCELLED, NO_VERSION};
   }
 
   // Selection of the version type. Leave unchanged by default.
@@ -563,19 +595,39 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
   {
     versionTypeId = ChooseVideoAsset(selectedItem, VideoAssetType::VERSION, "");
     if (versionTypeId < 0)
-      return false;
+      return {VersionConversionResult::CANCELLED, NO_VERSION};
   }
 
-  const int idFile = videoDb.GetFileIdByMovie(sourceDbId);
+  // The file of the source movie, needed to make the new version the default one.
+  // Must be retrieved before the conversion, which reassigns the file to the target movie.
+  const int idFile{videoDb.GetFileIdByMovie(sourceDbId)};
+
+  // Preserve streamdetails if bluray playlist
+  CFileItem sourceItem;
+  const bool isSourceBluray{videoDb.GetDetailsByTypeAndId(sourceItem, itemType, sourceDbId) &&
+                            sourceItem.IsBluray()};
+  const DeleteMovieCascadeAction cascadeAction{
+      isSourceBluray ? DeleteMovieCascadeAction::ALL_ASSETS_NOT_STREAMDETAILS
+                     : DeleteMovieCascadeAction::ALL_ASSETS};
 
   if (!videoDb.ConvertVideoToVersion(itemType, sourceDbId, targetDbId, versionTypeId,
-                                     VideoAssetType::VERSION, DeleteMovieCascadeAction::ALL_ASSETS))
-    return false;
+                                     VideoAssetType::VERSION, cascadeAction))
+  {
+    CLog::LogF(LOGERROR, "Failed to convert movie id {} into a version of movie id {}", sourceDbId,
+               targetDbId);
+    return {VersionConversionResult::FAILED, NO_VERSION};
+  }
 
-  if (setDefaultVersion)
-    return (idFile >= 0 && videoDb.SetDefaultVideoVersion(itemType, targetDbId, idFile));
+  CLog::LogF(LOGDEBUG, "Converted movie id {} ('{}') into a version of movie id {}", sourceDbId,
+             CURL::GetRedacted(sourceItem.GetDynPath()), targetDbId);
 
-  return true;
+  if (setDefaultVersion &&
+      (idFile < 0 || !videoDb.SetDefaultVideoVersion(itemType, targetDbId, idFile)))
+    CLog::LogF(LOGERROR, "Failed to set file id {} as the default version of movie id {}", idFile,
+               targetDbId);
+
+  // Success is returned even if the default version could not be set, since the conversion itself was successful.
+  return {VersionConversionResult::SUCCESS, targetDbId};
 }
 
 bool CGUIDialogVideoManagerVersions::GetAllOtherMovies(const std::shared_ptr<CFileItem>& item,
@@ -605,37 +657,56 @@ bool CGUIDialogVideoManagerVersions::GetAllOtherMovies(const std::shared_ptr<CFi
                 ? SortAttributeIgnoreArticle
                 : SortAttributeNone);
 
-  if (!PostProcessList(list, item->GetVideoInfoTag()->m_iDbId))
-    return false;
+  PostProcessList(list, item->GetVideoInfoTag()->m_iDbId);
 
   return true;
 }
 
-bool CGUIDialogVideoManagerVersions::ProcessVideoVersion(VideoDbContentType itemType, int dbId)
+std::pair<VersionConversionResult, int> CGUIDialogVideoManagerVersions::ProcessVideoVersion(
+    VideoDbContentType itemType, int dbId, int targetDbId /* = -1 */)
 {
   if (itemType != VideoDbContentType::MOVIES)
-    return false;
+    return {VersionConversionResult::FAILED, NO_VERSION};
+
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  const auto action = static_cast<SimilarVideoScanAction>(
+      settings->GetInt(CSettings::SETTING_VIDEOLIBRARY_SIMILARVIDEOACTION));
+  if (action == SimilarVideoScanAction::NONE)
+  {
+    CLog::LogF(LOGDEBUG, "Version creation disabled by settings");
+    return {VersionConversionResult::NOT_ALLOWED, NO_VERSION};
+  }
 
   CVideoDatabase videodb;
   if (!videodb.Open())
   {
     CLog::LogF(LOGERROR, "Failed to open video database!");
-    return false;
+    return {VersionConversionResult::FAILED, NO_VERSION};
   }
 
   CFileItem item;
   if (!videodb.GetDetailsByTypeAndId(item, itemType, dbId))
-    return false;
+    return {VersionConversionResult::FAILED, NO_VERSION};
 
+  // If the caller already knows which movie dbId should become a version of, use it
+  // (eg. a merge already confirmed for an earlier, related item ie. for bluray versions)
+  std::shared_ptr<CFileItem> targetItem;
+  if (targetDbId >= 0)
+  {
+    targetItem = std::make_shared<CFileItem>();
+    if (!videodb.GetDetailsByTypeAndId(*targetItem, itemType, targetDbId))
+      return {VersionConversionResult::FAILED, NO_VERSION};
+  }
+
+  // Get items for merge choice (if not target already identified)
   CFileItemList list;
-  videodb.GetSameVideoItems(item, list);
+  if (!targetItem)
+  {
+    videodb.GetSameVideoItems(item, list);
 
-  if (list.Size() < 2)
-    return false;
-
-  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  const auto action = static_cast<SimilarVideoScanAction>(
-      settings->GetInt(CSettings::SETTING_VIDEOLIBRARY_SIMILARVIDEOACTION));
+    if (list.Size() < 2)
+      return {VersionConversionResult::NOT_NEEDED, NO_VERSION};
+  }
 
   switch (action)
   {
@@ -644,13 +715,28 @@ bool CGUIDialogVideoManagerVersions::ProcessVideoVersion(VideoDbContentType item
       std::string path;
       videodb.GetFilePathById(dbId, path, itemType);
 
-      if (!CGUIDialogYesNo::ShowAndGetInput(
-              CVariant{40008},
-              StringUtils::Format(
-                  CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40009),
-                  item.GetVideoInfoTag()->GetTitle(), path)))
+      if (URIUtils::IsBlurayPath(path))
       {
-        return false;
+        if (!CGUIDialogYesNo::ShowAndGetInput(
+                CVariant{40008},
+                StringUtils::Format(
+                    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40042),
+                    item.GetVideoInfoTag()->GetTitle(),
+                    std::to_string(URIUtils::GetBlurayPlaylistFromPath(item.GetDynPath())),
+                    URIUtils::GetDiscBase(CURL::GetRedacted(item.GetDynPath())),
+                    StringUtils::SecondsToTimeString(
+                        static_cast<long>(item.GetVideoInfoTag()->GetDuration())))))
+          return {VersionConversionResult::CANCELLED, NO_VERSION};
+      }
+      else
+      {
+        if (!CGUIDialogYesNo::ShowAndGetInput(
+                CVariant{40008},
+                StringUtils::Format(
+                    CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40009),
+                    item.GetVideoInfoTag()->GetTitle(),
+                    URIUtils::GetDecodedPath(CURL::GetRedacted(path)))))
+          return {VersionConversionResult::CANCELLED, NO_VERSION};
       }
       break;
     }
@@ -658,21 +744,34 @@ bool CGUIDialogVideoManagerVersions::ProcessVideoVersion(VideoDbContentType item
       // permission granted through the settings
       break;
     case SimilarVideoScanAction::NONE:
-    default:
-      // no action or unknown value: abort
-      return false;
+      return {VersionConversionResult::NOT_ALLOWED, NO_VERSION}; // Should never get here
   }
 
-  if (!PostProcessList(list, dbId))
-    return false;
+  const Mode mode{action == SimilarVideoScanAction::ASK ? Mode::INTERACTIVE
+                                                        : Mode::NON_INTERACTIVE};
 
-  const MediaType mediaType{item.GetVideoInfoTag()->m_type};
+  const bool isDefault{settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_NEWVERSIONSAREDEFAULT)};
 
-  const auto isDefault = settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_NEWVERSIONSAREDEFAULT);
+  if (targetItem)
+    return ConvertToVideoVersion(targetItem, itemType, dbId, videodb, MediaRole::NewVersion, mode,
+                                 isDefault);
 
-  return ChooseVideoAndConvertToVideoVersion(
-      list, itemType, mediaType, dbId, videodb, MediaRole::NewVersion,
-      action == SimilarVideoScanAction::ASK ? Mode::INTERACTIVE : Mode::NON_INTERACTIVE, isDefault);
+  PostProcessList(list, dbId);
+
+  // Remove same disc items (unless there is only 1 other item)
+  if (URIUtils::IsBlurayPath(item.GetDynPath()) && list.Size() > 2)
+  {
+    const std::string base{URIUtils::GetDiscBase(item.GetDynPath())};
+    erase_if(list,
+             [&base](const std::shared_ptr<CFileItem>& current)
+             {
+               const std::string currentBase{URIUtils::GetDiscBase(current->GetDynPath())};
+               return !currentBase.empty() && currentBase == base;
+             });
+  }
+
+  return ChooseVideoAndConvertToVideoVersion(list, itemType, dbId, videodb, MediaRole::NewVersion,
+                                             mode, isDefault);
 }
 
 bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
@@ -787,7 +886,8 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()
         if (idNewVideoVersion != -1)
         {
           // Remove (Disc n) from title
-          RemovePartNumberFromTitle();
+          RemovePartNumberFromTitle(m_videoAsset->GetVideoInfoTag()->m_iDbId,
+                                    m_videoAsset->GetVideoContentType(), m_database);
           return m_database.ConvertVideoToVersion(itemType, newAsset.m_idMedia, dbId,
                                                   idNewVideoVersion, VideoAssetType::VERSION,
                                                   DeleteMovieCascadeAction::ALL_ASSETS);
@@ -836,8 +936,7 @@ bool CGUIDialogVideoManagerVersions::GetSimilarMovies(const std::shared_ptr<CFil
     return true;
   }
 
-  if (!PostProcessList(list, item->GetVideoInfoTag()->m_iDbId))
-    return false;
+  PostProcessList(list, item->GetVideoInfoTag()->m_iDbId);
 
   return true;
 }
@@ -852,11 +951,12 @@ bool CGUIDialogVideoManagerVersions::AddSimilarMovieAsVersion(
     return false;
   }
 
-  // Choose playlist for blurays
+  // Choose playlist for blurays, unless one has already been determined
   DeleteMovieCascadeAction cascadeAction{DeleteMovieCascadeAction::ALL_ASSETS};
   if (itemMovie->IsBluray())
   {
-    if (!ChoosePlaylist(itemMovie, ReplaceExistingFile::YES))
+    if (!URIUtils::IsBlurayPath(itemMovie->GetDynPath()) &&
+        !ChoosePlaylist(itemMovie, ReplaceExistingFile::YES))
       return false;
     cascadeAction = DeleteMovieCascadeAction::ALL_ASSETS_NOT_STREAMDETAILS;
   }
@@ -867,7 +967,8 @@ bool CGUIDialogVideoManagerVersions::AddSimilarMovieAsVersion(
     return false;
 
   // Remove (Disc n) from title
-  RemovePartNumberFromTitle();
+  RemovePartNumberFromTitle(m_videoAsset->GetVideoInfoTag()->m_iDbId,
+                            m_videoAsset->GetVideoContentType(), m_database);
 
   const int sourceDbId{itemMovie->GetVideoInfoTag()->m_iDbId};
   const int targetDbId{m_videoAsset->GetVideoInfoTag()->m_iDbId};
@@ -875,7 +976,7 @@ bool CGUIDialogVideoManagerVersions::AddSimilarMovieAsVersion(
                                           idVideoVersion, VideoAssetType::VERSION, cascadeAction);
 }
 
-bool CGUIDialogVideoManagerVersions::PostProcessList(CFileItemList& list, int dbId)
+void CGUIDialogVideoManagerVersions::PostProcessList(CFileItemList& list, int dbId)
 {
   // Exclude the provided dbId and decorate the items
 
@@ -893,9 +994,7 @@ bool CGUIDialogVideoManagerVersions::PostProcessList(CFileItemList& list, int db
       continue;
     }
 
-    item->SetLabel2(itemtag->m_strFileNameAndPath);
+    item->SetLabel2(URIUtils::GetDecodedPath(CURL::GetRedacted(itemtag->m_strFileNameAndPath)));
     ++i;
   }
-
-  return true;
 }

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -10,14 +10,17 @@
 
 #include "video/dialogs/GUIDialogVideoManager.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 
 class CFileItem;
 
 enum class VideoDbContentType;
 enum class VideoAssetType;
 enum class MediaRole;
+enum class VersionConversionResult : uint8_t;
 
 class CGUIDialogVideoManagerVersions : public CGUIDialogVideoManager
 {
@@ -27,7 +30,31 @@ public:
 
   void SetVideoAsset(const std::shared_ptr<CFileItem>& item) override;
 
-  static bool ProcessVideoVersion(VideoDbContentType itemType, int dbId);
+  /*!
+   * \brief Find a movie in the library similar to dbId and, if confirmed, convert dbId into an
+   * additional version of it.
+   * \param[in] itemType content type of dbId
+   * \param[in] dbId id of the movie to convert
+   * \param[in] targetDbId when >= 0, skip searching the library for a similar movie and
+   * reuse this movie id as the merge target instead - used to apply a merge decision already
+   * made for an earlier, related item (e.g. another bluray playlist on the same disc) without
+   * re-prompting for the same target.
+   * \return a pair containing the result of the conversion and the id of the movie ends up attached to as a new version, -1 if not converted
+   */
+  static std::pair<VersionConversionResult, int> ProcessVideoVersion(VideoDbContentType itemType,
+                                                                     int dbId,
+                                                                     int targetDbId = -1);
+
+  /*!
+   * \brief Strip a trailing part/disc number from a movie's title, if present, and persist the
+   * change. Used when a movie ends up spanning several bluray playlists/discs or folders, where
+   * the number no longer makes sense as part of the (now shared) title.
+   * \param[in] dbId id of the movie
+   * \param[in] itemType content type of the movie
+   * \param[in] db database connection to use
+   */
+  static void RemovePartNumberFromTitle(int dbId, VideoDbContentType itemType, CVideoDatabase& db);
+
   /*!
    * \brief Open the Manage Versions dialog for a video
    * \param item video to manage
@@ -74,7 +101,6 @@ private:
    * and perform the version conversion according to the role parameter.
    * \param[in] items The items for the user to choose from
    * \param[in] itemType Type of the item being chosen
-   * \param[in] mediaType ?
    * \param[in] dbId id of the video being added if role is NewVersion, id of the video being added
    * to if role is Parent
    * \param[in] videoDb Database connection
@@ -87,16 +113,39 @@ private:
    *                        place of user input
    * \param[in] setDefaultVersion true to make the new version the default for the media
    *
-   * \return True: success, a version was created and attached, false otherwise.
+   * \return A pair containing the result of the conversion and the id of the movie ends up attached to as a new version, -1 if not converted
    */
-  static bool ChooseVideoAndConvertToVideoVersion(CFileItemList& items,
-                                                  VideoDbContentType itemType,
-                                                  const std::string& mediaType,
-                                                  int dbId,
-                                                  CVideoDatabase& videoDb,
-                                                  MediaRole role,
-                                                  Mode mode,
-                                                  bool setDefaultVersion);
+  static std::pair<VersionConversionResult, int> ChooseVideoAndConvertToVideoVersion(
+      CFileItemList& items,
+      VideoDbContentType itemType,
+      int dbId,
+      CVideoDatabase& videoDb,
+      MediaRole role,
+      Mode mode,
+      bool setDefaultVersion);
+
+  /*!
+   * \brief Convert dbId into a new version of the already-chosen selectedItem: confirm (as
+   * needed), ask for the version type (as needed), and perform the conversion.
+   * \param[in] selectedItem the movie dbId is to become a version of (role NewVersion) or that is
+   * to become a version of dbId (role Parent)
+   * \param[in] itemType Type of the item being chosen
+   * \param[in] dbId id of the video being added if role is NewVersion, id of the video being
+   * added to if role is Parent
+   * \param[in] videoDb Database connection
+   * \param[in] role see ChooseVideoAndConvertToVideoVersion
+   * \param[in] mode see ChooseVideoAndConvertToVideoVersion
+   * \param[in] setDefaultVersion whether to set the new version as the default version
+   * \return A pair containing the result of the conversion and the id of the movie ends up attached to as a new version, -1 if not converted
+   */
+  static std::pair<VersionConversionResult, int> ConvertToVideoVersion(
+      const std::shared_ptr<CFileItem>& selectedItem,
+      VideoDbContentType itemType,
+      int dbId,
+      CVideoDatabase& videoDb,
+      MediaRole role,
+      Mode mode,
+      bool setDefaultVersion);
 
   /*!
    * \brief Use a file picker to select a file to add as a new version of a movie.
@@ -138,9 +187,8 @@ private:
    * \brief Shared post processing of lists after extraction and before display
    * \param[in,out] list the list of movies
    * \param[in] dbId item to remove from the list
-   * \return True for success, false otherwise.
    */
-  static bool PostProcessList(CFileItemList& list, int dbId);
+  static void PostProcessList(CFileItemList& list, int dbId);
 
   /*!
    * \brief Prompts the user to choose a playlist from the current disc
@@ -150,8 +198,6 @@ private:
    */
   bool ChoosePlaylist(const std::shared_ptr<CFileItem>& item,
                       ReplaceExistingFile replaceExistingFile);
-
-  void RemovePartNumberFromTitle();
 
   std::shared_ptr<CFileItem> m_defaultVideoVersion;
 };

--- a/xbmc/video/tags/IVideoInfoTagLoader.h
+++ b/xbmc/video/tags/IVideoInfoTagLoader.h
@@ -49,6 +49,11 @@ public:
   //! \brief Returns url associated with obtained URL (NFO_URL et al).
   const CScraperUrl& ScraperUrl() const { return m_url; }
 
+  //! \brief Returns the bluray playlist the loaded info refers to, -1 if none was given.
+  //! Only carried by nfos (a <playlist> element); other loaders have no notion of a playlist.
+  //! Valid once Load() has been called.
+  virtual int GetBlurayPlaylist() const { return -1; }
+
   //! \brief Returns current scaper info.
   const ADDON::ScraperPtr GetAddonInfo() const { return m_info; }
 

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -122,6 +122,14 @@ CInfoScanner::InfoType CVideoTagLoaderNFO::Load(CVideoInfoTag& tag,
   return result;
 }
 
+int CVideoTagLoaderNFO::GetBlurayPlaylist() const
+{
+  if (!m_nfoParsed)
+    return -1;
+
+  return m_nfoReader.GetBlurayPlaylist();
+}
+
 std::string CVideoTagLoaderNFO::FindNFO(const CFileItem& item,
                                         bool movieFolder) const
 {

--- a/xbmc/video/tags/VideoTagLoaderNFO.h
+++ b/xbmc/video/tags/VideoTagLoaderNFO.h
@@ -33,6 +33,9 @@ public:
                               bool prioritise,
                               std::vector<EmbeddedArt>* = nullptr) override;
 
+  //! \brief Returns the bluray playlist from a <playlist> nfo element, -1 if there isn't one.
+  int GetBlurayPlaylist() const override;
+
 protected:
   //! \brief Find nfo file for item
   //! \param item The item to find NFO file for


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Extend #28349 to bluray playlists.

Rebased to include @CrystalP's make most recent version default.

There are 2 todos (can be future PR):
1) Extend version/edition determination to folder name as well as filename for discs.
2) On a disc with multiple versions, the last added is default. Choose the 'best' version.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

@CrystalP introduced automatic version recognition during scraping.

Also fixes #28798.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

If NONE is selected (default behaviour):

<img width="940" height="588" alt="image" src="https://github.com/user-attachments/assets/bf1a469a-d3f4-4165-b8e7-9d5998d75c29" />

If ASK is selected:

For each bluray playlist identified as a possible movie version:
<img width="940" height="383" alt="image" src="https://github.com/user-attachments/assets/328d363e-1ec6-4dfe-b736-990e2d6de5a8" />
<img width="940" height="373" alt="image" src="https://github.com/user-attachments/assets/f554d135-30fc-48c8-ae36-b2d8e9999afc" />

<img width="940" height="223" alt="image" src="https://github.com/user-attachments/assets/42eeefda-0336-43b6-a00d-117b7bcb6e9a" />

<img width="940" height="244" alt="image" src="https://github.com/user-attachments/assets/13df873d-fc6b-4fa3-85a3-8e43621134d7" />

End result:
<img width="940" height="294" alt="image" src="https://github.com/user-attachments/assets/c4704bc8-57ac-4123-b4e8-94fa77602235" />

If AUTO is selected:
<img width="940" height="328" alt="image" src="https://github.com/user-attachments/assets/21cb23d5-8a39-405a-9a3e-0521f3ec0650" />

Note all are 'Standard Edition' as version type cannot be determined from the bluray playlist.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
