### PR TITLE
[settings] Show monitor menu on multi-monitor systems

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -25147,5 +25147,5 @@ msgstr ""
 #. Description of setting with label #246 "Monitor"
 #: system/settings/settings.xml
 msgctxt "#40803"
-msgid "Monitor change requires restart in GBM mode."
+msgid "Monitor change may require restart."
 msgstr ""

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -25143,3 +25143,9 @@ msgstr ""
 msgctxt "#40802"
 msgid "If enabled, a confirmation dialog will be displayed when files shall be deleted. If disabled, files will be deleted without user confirmation."
 msgstr ""
+
+#. Description of setting with label #246 "Monitor"
+#: system/settings/settings.xml
+msgctxt "#40803"
+msgid "Monitor change requires restart in GBM mode."
+msgstr ""

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2814,7 +2814,7 @@
   <section id="system" label="13000" help="36349">
     <category id="display" label="14220" help="36603">
       <group id="1" label="16000">
-        <setting id="videoscreen.monitor" type="string" label="246" help="">
+        <setting id="videoscreen.monitor" type="string" label="246" help="40803">
           <requirement>
             <or>
               <condition>HAVE_X11</condition>
@@ -2831,7 +2831,12 @@
             <options>monitors</options>
           </constraints>
           <dependencies>
-            <dependency type="enable" on="property" name="SupportsScreenMove" />
+            <dependency type="enable">
+              <or>
+                <condition on="property" name="SupportsScreenMove" />
+                <condition on="property" name="HasMultipleMonitors" />
+              </or>
+            </dependency>
             <dependency type="update" setting="videoscreen.screenmode" />
           </dependencies>
           <control type="spinner" format="string" delayed="true" />

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -357,6 +357,9 @@ void CSettingConditions::Initialize()
 #ifdef HAVE_WAYLAND
   m_simpleConditions.emplace("have_wayland");
 #endif
+#ifdef HAVE_GBM
+  m_simpleConditions.emplace("have_gbm");
+#endif
 #ifdef HAS_GL
   m_simpleConditions.emplace("has_gl");
 #endif

--- a/xbmc/settings/SettingConditions.cpp
+++ b/xbmc/settings/SettingConditions.cpp
@@ -102,6 +102,13 @@ bool HasSystemSdrPeakLuminance(const std::string& /*condition*/,
   return CServiceBroker::GetWinSystem()->HasSystemSdrPeakLuminance();
 }
 
+bool HasMultipleMonitors(const std::string& /*condition*/,
+                         const std::string& /*value*/,
+                         const SettingConstPtr& /*setting*/)
+{
+  return CServiceBroker::GetWinSystem()->GetPhysicalOutputCount() > 1;
+}
+
 bool SupportsVideoSuperResolution(const std::string& /*condition*/,
                                   const std::string& /*value*/,
                                   const SettingConstPtr& /*setting*/)
@@ -453,6 +460,7 @@ void CSettingConditions::Initialize()
   m_complexConditions.try_emplace("hasrumblecontroller", HasRumbleController);
   m_complexConditions.try_emplace("haspowerofffeature", HasPowerOffFeature);
   m_complexConditions.try_emplace("hassystemsdrpeakluminance", HasSystemSdrPeakLuminance);
+  m_complexConditions.try_emplace("hasmultiplemonitors", HasMultipleMonitors);
   m_complexConditions.try_emplace("supportsscreenmove", SupportsScreenMove);
   m_complexConditions.try_emplace("supportsvideosuperresolution", SupportsVideoSuperResolution);
   m_complexConditions.try_emplace("supportsdolbyvision", SupportsDolbyVision);

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -23,6 +23,8 @@
 #include <string>
 #include <vector>
 
+inline constexpr const char* OUTPUT_NAME_DEFAULT = "Default";
+
 struct RESOLUTION_WHR
 {
   // user-defined ctor required for XCode 15.2 and emplace_back
@@ -286,6 +288,23 @@ public:
   virtual DEBUG_INFO_RENDER GetDebugInfo() { return {}; }
 
   virtual std::vector<std::string> GetConnectedOutputs() { return {}; }
+
+  /*!
+    * \brief Returns the number of physical monitors/outputs.
+    *
+    * Every backend's GetConnectedOutputs() includes OUTPUT_NAME_DEFAULT as
+    * the first entry; this is a placeholder (not a physical display) that
+    * means "let the system choose". This method excludes that placeholder
+    * from the count.
+    *
+    * \return Number of physical monitors/outputs.
+    */
+  virtual size_t GetPhysicalOutputCount()
+  {
+    const auto outputs = GetConnectedOutputs();
+    return (!outputs.empty() && outputs[0] == OUTPUT_NAME_DEFAULT) ? outputs.size() - 1
+                                                                   : outputs.size();
+  }
 
   /*!
    * \brief Return true when HDR display is available and enabled in settings

--- a/xbmc/windowing/X11/WinSystemX11.cpp
+++ b/xbmc/windowing/X11/WinSystemX11.cpp
@@ -140,7 +140,7 @@ bool CWinSystemX11::ResizeWindow(int newWidth, int newHeight, int newLeft, int n
 {
   m_userOutput = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR);
   XOutput *out = NULL;
-  if (m_userOutput.compare("Default") != 0)
+  if (m_userOutput.compare(OUTPUT_NAME_DEFAULT) != 0)
   {
     out = g_xrandr.GetOutput(m_userOutput);
     if (out)
@@ -178,7 +178,7 @@ void CWinSystemX11::FinishWindowResize(int newWidth, int newHeight)
 {
   m_userOutput = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR);
   XOutput *out = NULL;
-  if (m_userOutput.compare("Default") != 0)
+  if (m_userOutput.compare(OUTPUT_NAME_DEFAULT) != 0)
   {
     out = g_xrandr.GetOutput(m_userOutput);
     if (out)
@@ -311,13 +311,13 @@ void CWinSystemX11::UpdateResolutions()
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   bool switchOnOff = settings->GetBool(CSettings::SETTING_VIDEOSCREEN_BLANKDISPLAYS);
   m_userOutput = settings->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR);
-  if (m_userOutput.compare("Default") == 0)
+  if (m_userOutput.compare(OUTPUT_NAME_DEFAULT) == 0)
     switchOnOff = false;
 
   if(g_xrandr.Query(true, !switchOnOff))
   {
     XOutput *out = NULL;
-    if (m_userOutput.compare("Default") != 0)
+    if (m_userOutput.compare(OUTPUT_NAME_DEFAULT) != 0)
     {
       out = g_xrandr.GetOutput(m_userOutput);
       if (out)
@@ -470,7 +470,7 @@ std::vector<std::string> CWinSystemX11::GetConnectedOutputs()
   std::vector<XOutput> outs;
   g_xrandr.Query(true);
   outs = g_xrandr.GetModes();
-  outputs.emplace_back("Default");
+  outputs.emplace_back(OUTPUT_NAME_DEFAULT);
   for(unsigned int i=0; i<outs.size(); ++i)
   {
     outputs.emplace_back(outs[i].name);
@@ -481,7 +481,8 @@ std::vector<std::string> CWinSystemX11::GetConnectedOutputs()
 
 bool CWinSystemX11::IsCurrentOutput(const std::string& output)
 {
-  return (StringUtils::EqualsNoCase(output, "Default")) || (m_currentOutput.compare(output.c_str()) == 0);
+  return (StringUtils::EqualsNoCase(output, OUTPUT_NAME_DEFAULT)) ||
+         (m_currentOutput.compare(output.c_str()) == 0);
 }
 
 void CWinSystemX11::ShowOSMouse(bool show)

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -381,7 +381,13 @@ std::unique_ptr<CVideoSync> CWinSystemGbm::GetVideoSync(CVideoReferenceClock* cl
 
 std::vector<std::string> CWinSystemGbm::GetConnectedOutputs()
 {
-  return m_DRM->GetConnectedConnectorNames();
+  std::vector<std::string> outputs;
+  outputs.emplace_back(OUTPUT_NAME_DEFAULT);
+  for (const auto& name : m_DRM->GetConnectedConnectorNames())
+  {
+    outputs.emplace_back(name);
+  }
+  return outputs;
 }
 
 bool CWinSystemGbm::SetVideoOutput(const VideoPicture* videoPicture)

--- a/xbmc/windowing/ios/WinSystemIOS.mm
+++ b/xbmc/windowing/ios/WinSystemIOS.mm
@@ -475,7 +475,7 @@ CVEAGLContext CWinSystemIOS::GetEAGLContextObj()
 std::vector<std::string> CWinSystemIOS::GetConnectedOutputs()
 {
   std::vector<std::string> outputs;
-  outputs.emplace_back("Default");
+  outputs.emplace_back(OUTPUT_NAME_DEFAULT);
   outputs.emplace_back(CONST_TOUCHSCREEN);
   if ([[UIScreen screens] count] > 1)
   {

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -53,7 +53,6 @@ using namespace std::chrono_literals;
 namespace
 {
 constexpr int MAX_DISPLAYS = 32;
-constexpr const char* DEFAULT_SCREEN_NAME = "Default";
 } // namespace
 
 static std::array<NSWindowController*, MAX_DISPLAYS> blankingWindowControllers;
@@ -172,12 +171,6 @@ EdgeInsets GetScreenEdgeInsets(NSUInteger screenIdx)
 
 NSString* screenNameForDisplay(NSUInteger screenIdx)
 {
-  // screen id 0 is always called "Default"
-  if (screenIdx == 0)
-  {
-    return @(DEFAULT_SCREEN_NAME);
-  }
-
   const CGDirectDisplayID displayID = GetDisplayID(screenIdx);
   NSString* screenName = GetScreenName(screenIdx);
 
@@ -1334,18 +1327,12 @@ std::unique_ptr<CVideoSync> CWinSystemOSX::GetVideoSync(CVideoReferenceClock* cl
 std::vector<std::string> CWinSystemOSX::GetConnectedOutputs()
 {
   std::vector<std::string> outputs;
-  outputs.emplace_back(DEFAULT_SCREEN_NAME);
+  outputs.emplace_back(OUTPUT_NAME_DEFAULT);
 
-  // screen 0 is always the "Default" setting, avoid duplicating the available
-  // screens here.
   const NSUInteger numDisplays = NSScreen.screens.count;
-  if (numDisplays > 1)
+  for (NSUInteger disp = 0; disp < numDisplays; disp++)
   {
-    for (NSUInteger disp = 1; disp <= numDisplays - 1; disp++)
-    {
-      NSString* const dispName = screenNameForDisplay(disp);
-      outputs.emplace_back(dispName.UTF8String);
-    }
+    outputs.emplace_back(screenNameForDisplay(disp).UTF8String);
   }
 
   return outputs;

--- a/xbmc/windowing/tvos/WinSystemTVOS.mm
+++ b/xbmc/windowing/tvos/WinSystemTVOS.mm
@@ -443,7 +443,7 @@ CVEAGLContext CWinSystemTVOS::GetEAGLContextObj()
 std::vector<std::string> CWinSystemTVOS::GetConnectedOutputs()
 {
   std::vector<std::string> outputs;
-  outputs.emplace_back("Default");
+  outputs.emplace_back(OUTPUT_NAME_DEFAULT);
   outputs.emplace_back(CONST_HDMI);
 
   return outputs;

--- a/xbmc/windowing/wayland/WinSystemWayland.cpp
+++ b/xbmc/windowing/wayland/WinSystemWayland.cpp
@@ -444,6 +444,7 @@ std::vector<std::string> CWinSystemWayland::GetConnectedOutputs()
 {
   std::unique_lock lock(m_outputsMutex);
   std::vector<std::string> outputs;
+  outputs.emplace_back(OUTPUT_NAME_DEFAULT);
   std::ranges::transform(m_outputs, std::back_inserter(outputs),
                          [this](decltype(m_outputs)::value_type const& pair)
                          { return UserFriendlyOutputName(pair.second); });

--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -721,6 +721,7 @@ void CWinSystemWin32::SetMinimized(bool minimized)
 std::vector<std::string> CWinSystemWin32::GetConnectedOutputs()
 {
   std::vector<std::string> outputs;
+  outputs.emplace_back(OUTPUT_NAME_DEFAULT);
 
   for (auto& display : m_displays)
   {


### PR DESCRIPTION
## Description
Show monitor menu on multi-monitor systems.

## Motivation and context
Currently, for systems with GBM and multiple monitors, there's no option to select a monitor in the menu (it's invisible).

## How has this been tested?
The changes were tested in GBM mode with two monitors.

## What is the effect on users?
Changes allow you to see this menu when you have more than one monitor connected.

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
