### PR TITLE
[depends][openssl][iOS/tvOS] remove legacy no longer needed patch

### DIFF
--- a/tools/depends/target/openssl/Makefile
+++ b/tools/depends/target/openssl/Makefile
@@ -73,9 +73,6 @@ ifeq ($(OS),android)
 endif
 	cd $(PLATFORM); cp ../16-kodi.conf ./Configurations/
 	cd $(PLATFORM); $(CONFIGURE)
-	if test "$(OS)" = "darwin_embedded"; then \
-		sed -E -ie "s|static volatile sig_atomic_t intr_signal;|static volatile intr_signal;|" "$(PLATFORM)/crypto/ui/ui_openssl.c"; \
-	fi
 	sed -ie "s|PROGRAMS=|PROGRAMS=#|" "$(PLATFORM)/Makefile";
 	touch $@
 


### PR DESCRIPTION
## Description
removes legacy patch that's no longer needed

## Motivation and context
some ancient thing, besides openssl fails to build using Xcode 26 with this patch:
```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -std=gnu23  -I. -Iinclude -Iproviders/common/include -Iproviders/implementations/include  -DSTATIC_LEGACY -fPIC  -ftree-vectorize -pipe -Wno-trigraphs -fpascal-strings -Wreturn-type -Wunused-variable -fmessage-length=0 -gdwarf-2 -g -D_DEBUG  -arch arm64 -miphoneos-version-min=12.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.2.sdk -isystem /Users/Shared/xbmc-depends/iphoneos26.2_arm64-target-debug/include -Wno-error=implicit-int -DOPENSSL_PIC -DOPENSSLDIR="\"/Users/Shared/xbmc-depends/iphoneos26.2_arm64-target-debug/ssl\"" -DENGINESDIR="\"/Users/Shared/xbmc-depends/iphoneos26.2_arm64-target-debug/lib/engines-3\"" -DMODULESDIR="\"/Users/Shared/xbmc-depends/iphoneos26.2_arm64-target-debug/lib/ossl-modules\"" -D_REENTRANT -DOPENSSL_BUILDING_OPENSSL -DZLIB -DNDEBUG -ftree-vectorize -pipe -Wno-trigraphs -fpascal-strings -Wreturn-type -Wunused-variable -fmessage-length=0 -gdwarf-2 -g -D_DEBUG  -arch arm64 -miphoneos-version-min=12.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.2.sdk -isystem /Users/Shared/xbmc-depends/iphoneos26.2_arm64-target-debug/include -MMD -MF crypto/ui/libcrypto-lib-ui_openssl.d.tmp -c -o crypto/ui/libcrypto-lib-ui_openssl.o crypto/ui/ui_openssl.c
crypto/ui/ui_openssl.c:273:17: error: a type specifier is required for all declarations
  273 | static volatile intr_signal;
      | ~~~~~~~~~~~~~~~ ^
1 error generated.
make[3]: *** [crypto/ui/libcrypto-lib-ui_openssl.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [build_sw] Error 2
make[1]: *** [iphoneos26.2_arm64-target-debug/libssl.a] Error 2
make: *** [openssl] Error 2
```

## How has this been tested?
local build

## What is the effect on users?
devs can build iOS/tvOS with Xcode 26

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
