### PR TITLE
[Windows] Avoid unnecessary audio sink reinitialization

### DIFF
--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
+++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
@@ -77,8 +77,7 @@ AESinkDevice CAESinkFactory::ParseDevice(const std::string& device)
   return dev;
 }
 
-std::unique_ptr<IAESink> CAESinkFactory::Create(const std::string& device,
-                                                AEAudioFormat& desiredFormat)
+std::unique_ptr<IAESink> CAESinkFactory::Create(std::string& device, AEAudioFormat& desiredFormat)
 {
   // extract the driver from the device string if it exists
   const AESinkDevice dev = ParseDevice(device);
@@ -96,6 +95,7 @@ std::unique_ptr<IAESink> CAESinkFactory::Create(const std::string& device,
     if (sink)
     {
       desiredFormat = tmpFormat;
+      device = dev.driver.empty() ? tmpDevice : dev.driver + ":" + tmpDevice;
       return sink;
     }
   }

--- a/xbmc/cores/AudioEngine/AESinkFactory.h
+++ b/xbmc/cores/AudioEngine/AESinkFactory.h
@@ -62,7 +62,7 @@ public:
   static bool HasSinks();
 
   static AESinkDevice ParseDevice(const std::string& device);
-  static std::unique_ptr<IAESink> Create(const std::string& device, AEAudioFormat& desiredFormat);
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
   static void EnumerateEx(std::vector<AESinkInfo>& list, bool force, const std::string& driver);
   static void Cleanup();
 

--- a/xbmc/cores/AudioEngine/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/CMakeLists.txt
@@ -22,6 +22,7 @@ set(HEADERS AEResampleFactory.h
             Encoders/AEEncoderFFmpeg.h
             Engines/ActiveAE/ActiveAE.h
             Engines/ActiveAE/ActiveAEBuffer.h
+            Engines/ActiveAE/ActiveAEDeviceChange.h
             Engines/ActiveAE/ActiveAEFilter.h
             Engines/ActiveAE/ActiveAESink.h
             Engines/ActiveAE/ActiveAESound.h

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -8,6 +8,7 @@
 
 #include "ActiveAE.h"
 
+#include "ActiveAEDeviceChange.h"
 #include "ActiveAESettings.h"
 #include "ActiveAESound.h"
 #include "ActiveAEStream.h"
@@ -21,6 +22,7 @@
 #include "cores/DataCacheCore.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
 
@@ -40,6 +42,28 @@ constexpr float MIN_WATER_LEVEL = 0.02f; // min buffer time to prevent underrun
 constexpr float MIN_WATER_LEVEL_RESAMPLE = 0.1f; // min buffer time in resample mode
 constexpr float BUFFER_LEVEL_INCREMENT = 0.0001f; // increment step for ramp-up
 constexpr double MAX_BUFFER_TIME = 0.1; // max time of a buffer in seconds;
+
+bool IsDefaultDevice(const AESinkDevice& device)
+{
+  return StringUtils::EqualsNoCase(device.name, "default");
+}
+
+bool IsSameDevice(const std::string& driver, const std::string& name, const AESinkDevice& device)
+{
+  return driver == device.driver && name == device.name;
+}
+
+bool IsPreferredDeviceAvailable(const AESinkDevice& configured, const AESinkDevice& validated)
+{
+  if (configured.driver != validated.driver)
+    return false;
+
+  if (configured.name == validated.name)
+    return true;
+
+  return !configured.friendlyName.empty() && !validated.friendlyName.empty() &&
+         configured.friendlyName == validated.friendlyName;
+}
 } // unnamed namespace
 
 void CEngineStats::Reset(unsigned int sampleRate, bool pcm)
@@ -460,6 +484,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
             return;
 
           case CActiveAEControlProtocol::DEVICECHANGE:
+          case CActiveAEControlProtocol::DEFAULTDEVICECHANGE:
           case CActiveAEControlProtocol::DEVICECOUNTCHANGE:
             LoadSettings();
             if (!m_settings.device.empty() && CAESinkFactory::HasSinks())
@@ -656,28 +681,10 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           }
           return;
         case CActiveAEControlProtocol::DEVICECOUNTCHANGE:
-          const char* param;
-          param = reinterpret_cast<const char*>(msg->data);
-          CLog::Log(LOGDEBUG, "CActiveAE - device count change event from driver: {}", param);
-          m_sink.EnumerateSinkList(true, param);
-          if (!m_sink.DeviceExist(m_settings.driver, m_currDevice))
-          {
-            UnconfigureSink();
-            LoadSettings();
-            ValidateOutputDevices(false);
-            m_extError = false;
-            Configure();
-            if (!m_extError)
-            {
-              m_state = AE_TOP_CONFIGURED_PLAY;
-              m_extTimeout = 0ms;
-            }
-            else
-            {
-              m_state = AE_TOP_ERROR;
-              m_extTimeout = 500ms;
-            }
-          }
+          HandleDeviceCountChange(reinterpret_cast<const char*>(msg->data), false);
+          return;
+        case CActiveAEControlProtocol::DEFAULTDEVICECHANGE:
+          HandleDeviceCountChange("", true);
           return;
         case CActiveAEControlProtocol::PAUSESTREAM:
           CActiveAEStream *stream;
@@ -883,6 +890,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           if (!displayReset)
           {
             m_controlPort.PurgeOut(CActiveAEControlProtocol::DEVICECHANGE);
+            m_controlPort.PurgeOut(CActiveAEControlProtocol::DEFAULTDEVICECHANGE);
             m_controlPort.PurgeOut(CActiveAEControlProtocol::DEVICECOUNTCHANGE);
             m_sink.EnumerateSinkList(true, "");
             LoadSettings();
@@ -905,6 +913,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           m_extDeferData = false;
           return;
         case CActiveAEControlProtocol::DEVICECHANGE:
+        case CActiveAEControlProtocol::DEFAULTDEVICECHANGE:
         case CActiveAEControlProtocol::DEVICECOUNTCHANGE:
           return;
         default:
@@ -1190,6 +1199,7 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
   std::string device = (m_sinkRequestFormat.m_dataFormat == AE_FMT_RAW) ? m_settings.passthroughdevice : m_settings.device;
 
   const AESinkDevice dev = CAESinkFactory::ParseDevice(device);
+  const bool requestedDefaultDevice = IsDefaultDevice(dev);
 
   if ((!CompareFormat(m_sinkRequestFormat, m_sinkFormat) &&
        !CompareFormat(m_sinkRequestFormat, oldSinkRequestFormat)) ||
@@ -1200,6 +1210,8 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
       return;
     m_settings.driver = dev.driver;
     m_currDevice = dev.name;
+    m_currentDeviceFollowsDefault =
+        requestedDefaultDevice || !IsSameDevice(m_openedDriver, m_openedDevice, dev);
     initSink = true;
     m_stats.Reset(m_sinkFormat.m_sampleRate, m_mode == MODE_PCM);
     m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::VOLUME, &m_volume, sizeof(float));
@@ -1878,6 +1890,12 @@ bool CActiveAE::InitSink()
     if (data)
     {
       m_sinkFormat = data->format;
+      if (data->device)
+      {
+        const AESinkDevice openedDevice = CAESinkFactory::ParseDevice(*data->device);
+        m_openedDriver = openedDevice.driver;
+        m_openedDevice = openedDevice.name;
+      }
       m_sinkHasVolume = data->hasVolume;
       m_stats.SetSinkCacheTotal(data->cacheTotal);
       m_stats.SetSinkLatency(data->latency);
@@ -1948,6 +1966,9 @@ void CActiveAE::UnconfigureSink()
 
   // make sure we open sink on next configure
   m_currDevice = "";
+  m_openedDevice = "";
+  m_openedDriver = "";
+  m_currentDeviceFollowsDefault = false;
 
   m_inMsgEvent.Reset();
 }
@@ -2805,6 +2826,53 @@ void CActiveAE::ValidateOutputDevices(bool saveChanges)
   }
 }
 
+void CActiveAE::HandleDeviceCountChange(const std::string& driver, bool defaultDeviceChanged)
+{
+  CLog::Log(LOGDEBUG, "CActiveAE - {}device change event from driver: {}",
+            defaultDeviceChanged ? "default " : "count ", driver);
+
+  const std::string currentDriver = m_openedDriver;
+  const std::string currentDevice = m_openedDevice;
+
+  m_sink.EnumerateSinkList(true, driver);
+
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  const bool passthrough = m_mode == MODE_RAW;
+  const std::string configuredDevice =
+      settings->GetString(passthrough ? CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE
+                                      : CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE);
+  const AESinkDevice configured = CAESinkFactory::ParseDevice(configuredDevice);
+  const std::string validatedDevice = m_sink.ValidateOuputDevice(configuredDevice, passthrough);
+  const AESinkDevice validated = CAESinkFactory::ParseDevice(validatedDevice);
+
+  const INTERNAL::DeviceChangeDecision decision{
+      m_sink.DeviceExist(currentDriver, currentDevice),
+      defaultDeviceChanged,
+      m_currentDeviceFollowsDefault,
+      IsDefaultDevice(configured),
+      !validatedDevice.empty() && IsPreferredDeviceAvailable(configured, validated),
+      IsSameDevice(currentDriver, currentDevice, validated)};
+
+  if (!INTERNAL::ShouldReconfigure(decision))
+    return;
+
+  UnconfigureSink();
+  LoadSettings();
+  ValidateOutputDevices(false);
+  m_extError = false;
+  Configure();
+  if (!m_extError)
+  {
+    m_state = AE_TOP_CONFIGURED_PLAY;
+    m_extTimeout = 0ms;
+  }
+  else
+  {
+    m_state = AE_TOP_ERROR;
+    m_extTimeout = 500ms;
+  }
+}
+
 void CActiveAE::Start()
 {
   Create();
@@ -3056,6 +3124,11 @@ void CActiveAE::KeepConfiguration(unsigned int millis)
 void CActiveAE::DeviceChange()
 {
   m_controlPort.SendOutMessage(CActiveAEControlProtocol::DEVICECHANGE);
+}
+
+void CActiveAE::DefaultDeviceChange()
+{
+  m_controlPort.SendOutMessage(CActiveAEControlProtocol::DEFAULTDEVICECHANGE);
 }
 
 void CActiveAE::DeviceCountChange(const std::string& driver)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -2828,19 +2828,19 @@ void CActiveAE::ValidateOutputDevices(bool saveChanges)
 
 void CActiveAE::HandleDeviceCountChange(const std::string& driver, bool defaultDeviceChanged)
 {
-  CLog::Log(LOGDEBUG, "CActiveAE - {}device change event from driver: {}",
-            defaultDeviceChanged ? "default " : "count ", driver);
+  if (defaultDeviceChanged)
+    CLog::LogF(LOGDEBUG, "default device change event");
+  else
+    CLog::LogF(LOGDEBUG, "device count change event from driver: {}", driver);
 
   const std::string currentDriver = m_openedDriver;
   const std::string currentDevice = m_openedDevice;
 
   m_sink.EnumerateSinkList(true, driver);
 
-  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   const bool passthrough = m_mode == MODE_RAW;
   const std::string configuredDevice =
-      settings->GetString(passthrough ? CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE
-                                      : CSettings::SETTING_AUDIOOUTPUT_AUDIODEVICE);
+      passthrough ? m_settings.passthroughdevice : m_settings.device;
   const AESinkDevice configured = CAESinkFactory::ParseDevice(configuredDevice);
   const std::string validatedDevice = m_sink.ValidateOuputDevice(configuredDevice, passthrough);
   const AESinkDevice validated = CAESinkFactory::ParseDevice(validatedDevice);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -80,6 +80,7 @@ public:
     RECONFIGURE,
     SUSPEND,
     DEVICECHANGE,
+    DEFAULTDEVICECHANGE,
     DEVICECOUNTCHANGE,
     MUTE,
     VOLUME,
@@ -268,6 +269,7 @@ public:
   bool IsSettingVisible(const std::string &settingId) override;
   void KeepConfiguration(unsigned int millis) override;
   void DeviceChange() override;
+  void DefaultDeviceChange() override;
   void DeviceCountChange(const std::string& driver) override;
   bool GetCurrentSinkFormat(AEAudioFormat &SinkFormat) override;
 
@@ -311,6 +313,7 @@ protected:
   void Dispose();
   void LoadSettings();
   void ValidateOutputDevices(bool saveChanges);
+  void HandleDeviceCountChange(const std::string& driver, bool defaultDeviceChanged);
   bool NeedReconfigureBuffers();
   bool NeedReconfigureSink();
   void ApplySettingsToFormat(AEAudioFormat& format,
@@ -372,6 +375,9 @@ protected:
   CEngineStats m_stats;
   IAEEncoder *m_encoder;
   std::string m_currDevice;
+  std::string m_openedDevice;
+  std::string m_openedDriver;
+  bool m_currentDeviceFollowsDefault{false};
   std::unique_ptr<CActiveAESettings> m_settingsHandler;
 
   // buffers

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEDeviceChange.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEDeviceChange.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+namespace ActiveAE::INTERNAL
+{
+struct DeviceChangeDecision
+{
+  bool currentDeviceExists{false};
+  bool defaultDeviceChanged{false};
+  bool currentDeviceFollowsDefault{false};
+  bool preferredDeviceIsDefault{false};
+  bool preferredDeviceAvailable{false};
+  bool preferredDeviceIsCurrent{false};
+};
+
+constexpr bool ShouldReconfigure(const DeviceChangeDecision& decision)
+{
+  if (!decision.currentDeviceExists)
+    return true;
+
+  if (decision.defaultDeviceChanged &&
+      (decision.preferredDeviceIsDefault || decision.currentDeviceFollowsDefault))
+  {
+    return true;
+  }
+
+  return !decision.preferredDeviceIsDefault && decision.preferredDeviceAvailable &&
+         !decision.preferredDeviceIsCurrent;
+}
+} // namespace ActiveAE::INTERNAL

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -270,6 +270,7 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
           {
             SinkReply reply;
             reply.format = m_sinkFormat;
+            reply.device = &m_device;
             //! @todo
             //! use max raw packet size, for now use max size of an IEC packed packet
             //! maxIECPpacket > maxRawPacket
@@ -965,6 +966,10 @@ void CActiveAESink::OpenSink()
     m_extError = true;
     return;
   }
+
+  m_device = device;
+  const AESinkDevice openedDevice = CAESinkFactory::ParseDevice(m_device);
+  GetDeviceFriendlyName(openedDevice.name);
 
   m_sink->SetVolume(m_volume);
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -38,6 +38,7 @@ struct SinkConfig
 struct SinkReply
 {
   AEAudioFormat format;
+  const std::string* device;
   float cacheTotal;
   float latency;
   bool hasVolume;

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -254,6 +254,11 @@ public:
   virtual void DeviceChange() {}
 
   /*!
+   * \brief Notify AE that the system default output device changed
+   */
+  virtual void DefaultDeviceChange() {}
+
+  /*!
    * \brief Instruct AE to re-initialize, e.g. after ELD change event
    */
   virtual void DeviceCountChange(const std::string& driver) {}

--- a/xbmc/cores/AudioEngine/Sinks/test/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/Sinks/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(SOURCES TestActiveAEDeviceChange.cpp)
+
 if(MACOSX)
   list(APPEND SOURCES TestAESinkDARWINOSX.cpp)
 endif()

--- a/xbmc/cores/AudioEngine/Sinks/test/TestActiveAEDeviceChange.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/test/TestActiveAEDeviceChange.cpp
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/AudioEngine/Engines/ActiveAE/ActiveAEDeviceChange.h"
+
+#include <gtest/gtest.h>
+
+using namespace ActiveAE::INTERNAL;
+
+TEST(TestActiveAEDeviceChange, KeepsHealthyExplicitDeviceForUnrelatedChange)
+{
+  const DeviceChangeDecision decision{true, false, false, false, true, true};
+  EXPECT_FALSE(ShouldReconfigure(decision));
+}
+
+TEST(TestActiveAEDeviceChange, ReconfiguresWhenCurrentDeviceDisappears)
+{
+  const DeviceChangeDecision decision{false, false, false, false, false, false};
+  EXPECT_TRUE(ShouldReconfigure(decision));
+}
+
+TEST(TestActiveAEDeviceChange, RestoresAvailablePreferredDevice)
+{
+  const DeviceChangeDecision decision{true, false, true, false, true, false};
+  EXPECT_TRUE(ShouldReconfigure(decision));
+}
+
+TEST(TestActiveAEDeviceChange, KeepsFallbackWhilePreferredDeviceIsUnavailable)
+{
+  const DeviceChangeDecision decision{true, false, true, false, false, false};
+  EXPECT_FALSE(ShouldReconfigure(decision));
+}
+
+TEST(TestActiveAEDeviceChange, TracksDefaultDeviceChanges)
+{
+  const DeviceChangeDecision configuredDefault{true, true, true, true, true, false};
+  const DeviceChangeDecision fallbackDefault{true, true, true, false, false, false};
+
+  EXPECT_TRUE(ShouldReconfigure(configuredDefault));
+  EXPECT_TRUE(ShouldReconfigure(fallbackDefault));
+}
+
+TEST(TestActiveAEDeviceChange, IgnoresDefaultChangeForHealthyExplicitDevice)
+{
+  const DeviceChangeDecision decision{true, true, false, false, true, true};
+  EXPECT_FALSE(ShouldReconfigure(decision));
+}

--- a/xbmc/platform/win32/IMMNotificationClient.h
+++ b/xbmc/platform/win32/IMMNotificationClient.h
@@ -75,7 +75,7 @@ public:
   HRESULT STDMETHODCALLTYPE OnDefaultDeviceChanged(EDataFlow flow, ERole role, LPCWSTR pwstrDeviceId)
   {
     // if the default device changes this function is called four times.
-    // therefore we call CServiceBroker::GetActiveAE()->DeviceChange() only for one role.
+    // therefore we notify AE only for one role.
     std::string pszFlow = "?????";
     std::string pszRole = "?????";
 
@@ -99,7 +99,8 @@ public:
       break;
     case eCommunications:
       pszRole = "eCommunications";
-      NotifyAE();
+      if (flow == eRender)
+        NotifyAEDefaultDeviceChange();
       break;
     }
 
@@ -111,14 +112,14 @@ public:
   HRESULT STDMETHODCALLTYPE OnDeviceAdded(LPCWSTR pwstrDeviceId)
   {
     CLog::Log(LOGDEBUG, "{}: Added device: {}", __FUNCTION__, FromW(pwstrDeviceId));
-    NotifyAE();
+    NotifyAEDeviceCountChange();
     return S_OK;
   }
 
   HRESULT STDMETHODCALLTYPE OnDeviceRemoved(LPCWSTR pwstrDeviceId)
   {
     CLog::Log(LOGDEBUG, "{}: Removed device: {}", __FUNCTION__, FromW(pwstrDeviceId));
-    NotifyAE();
+    NotifyAEDeviceCountChange();
     return S_OK;
   }
 
@@ -142,7 +143,7 @@ public:
       break;
     }
     CLog::Log(LOGDEBUG, "{}: New device state is DEVICE_STATE_{}", __FUNCTION__, pszState);
-    NotifyAE();
+    NotifyAEDeviceCountChange();
     return S_OK;
   }
 
@@ -158,9 +159,15 @@ public:
     return S_OK;
   }
 
-  void STDMETHODCALLTYPE NotifyAE()
+  void STDMETHODCALLTYPE NotifyAEDefaultDeviceChange()
   {
-    if(!CWin32PowerSyscall::IsSuspending())
-      CServiceBroker::GetActiveAE()->DeviceChange();
+    if (!CWin32PowerSyscall::IsSuspending())
+      CServiceBroker::GetActiveAE()->DefaultDeviceChange();
+  }
+
+  void STDMETHODCALLTYPE NotifyAEDeviceCountChange()
+  {
+    if (!CWin32PowerSyscall::IsSuspending())
+      CServiceBroker::GetActiveAE()->DeviceCountChange("");
   }
 };


### PR DESCRIPTION
This supersedes the original implementation in #28631. After closing that version, the policy decision was moved into ActiveAE to address the review feedback about keeping Windows notification handling separate from AudioEngine policy.

What changed:

- The Windows notifier treats endpoint IDs as opaque and only forwards generic device/default-change notifications.
- ActiveAE tracks the device and driver that Kodi actually opened, then decides whether a notification requires reconfiguration.
- With Kodi set to Windows Default, a genuine Windows default-device change—including switching to Bluetooth—still causes Kodi to follow it.
- With a specific endpoint selected, unrelated Bluetooth insertion/removal does not move playback to Bluetooth.
- If the selected endpoint disappears, normal fallback/recovery still occurs.

The primary fix is fewer redundant sink reopenings, eliminating some minor audio blips and resynchronizations. Because each unnecessary reopen can trigger another HDMI/AVR negotiation, the change may also reduce handshake-related failures in setups affected by that behavior. We did not establish how often this exact pattern causes a persistent failure, so this is a plausible secondary benefit rather than a guaranteed HDMI fix.

Validation:

- 6/6 focused ActiveAE device-change policy tests pass.
- Full Kodi build succeeds.
- In a live Bluetooth test, 30 post-startup endpoint enumerations produced zero Bluetooth-correlated sink reinitializations; the three OpenSink calls observed matched normal startup/playback/exit lifecycle.
- A Denon power-cycle correctly triggered reconfiguration when the active sink disappeared and Kodi remained alive. The already-running stream did not seamlessly resume after the cold AVR handshake and required playback restart; that recovery limitation is outside this change.

The earlier 65:14 A/B comparison belongs to the original implementation and remains historical context; it is not presented as evidence for this revised AE-level design.
