### PR TITLE
[VideoPlayer] Fix subtitles not appearing after backward chapter or large seek

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4482,6 +4482,10 @@ void CVideoPlayer::FlushBuffers(double pts, bool accurate, bool sync)
   m_VideoPlayerRadioRDS->Flush();
   m_VideoPlayerAudioID3->Flush();
 
+  // drop queued pre-seek frames to avoid starving RenderManager's buffer pool so post-seek overlays/subtitles do not get dropped
+  if (sync)
+    m_renderManager.DiscardBuffer();
+
   if (m_playSpeed == DVD_PLAYSPEED_NORMAL || m_playSpeed == DVD_PLAYSPEED_PAUSE ||
       m_processInfo->IsTempoAllowed(static_cast<float>(m_playSpeed) / DVD_PLAYSPEED_NORMAL))
   {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fix subtitles not appearing after backward chapter or large seek.

The change adds DiscardBuffer + m_presentpts reset to FlushBuffers for (sync = true) cases. The issue is caused by queued pre-seek frames starving RenderManager's buffer pool so post-seek overlays get dropped.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On WebOS and possibly other platforms, the problem occurs during a backward chapter seek or large 10-min seeks. These seeks are performed when the user presses the down button on the remote control. Chapter seek is performed if video file has chapter markers, or a large seek is performed if video file does not have chapter markers.

The seek functions in these scenarios call SynchronizeDemuxer.

The issue happens because SynchronizeDemuxer stalls the video thread flush, causing a GUI timeout. The queued pre-seek frames starve RenderManager's buffer pool so post-seek overlays get dropped.

In FlushBuffers, DiscardBuffer is filtered to be called only if FlushBuffers sync = true which is used in the chapter and large seeks. DiscardBuffer is also modified to reset m_presentpts to DVD_NOPTS_VALUE.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on WebOS version.

Test scenario 1:

Play an MKV file with chapter markers and subtitles.
Seek forwards, then do one or more chapter seek backwards (e.g. using the down button). 
Before fix: The subtitles will not appear after seeking backwards.
After fix: The correct subtitles will appear after seeking backwards.

Test scenario 2:

Play an MKV file with no chapter markers and subtitles.
Seek forwards, then do one or more large seek backwards (e.g. using the down button). 
Before fix: The subtitles will not appear after seeking backwards.
After fix: The correct subtitles will appear after seeking backwards.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Fix subtitles not appearing after backward chapter or large seek.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
