### PR TITLE
depends: bump libdrm to 2.4.134

### DIFF
--- a/tools/depends/target/libdrm/Makefile
+++ b/tools/depends/target/libdrm/Makefile
@@ -2,9 +2,9 @@ include ../../Makefile.include
 DEPS =../../Makefile.include Makefile ../../download-files.include
 
 LIBNAME=libdrm
-VERSION=2.4.115
+VERSION=2.4.134
 ARCHIVE=$(LIBNAME)-$(VERSION).tar.xz
-SHA512=0c38d3cfd76f627b899f052527c2939d5fc87a417422dceb0761839ba21e69736703a87ba170b5ba7a4aca2506a240760c8c97ca1781a7fb78468225295293bd
+SHA512=ef2abddea59d1e93c83a48de920431b839ab50d6071ef4da3cf126e7d64ba7b235f2e34e1169d49ad9de2937a0a18acd66bb8d324b067239b1136e0ddbe792a1
 include ../../download-files.include
 
 MESON_BUILD_TYPE=release


### PR DESCRIPTION
## Description
Kodi's GBM windowing failed to start on the Linux E2E job with
"CDRMUtils::OpenDrm(): No drm devices found", even though the vkms device
node was directly openable by the same user (verified via a diagnostic that
opened /dev/dri/card0 with a plain os.open() - it succeeded). The actual
failure is inside libdrm's own drmGetDevices2() enumeration: vkms's device on
this kernel is backed by the "faux" bus subsystem
(/sys/dev/char/226:0 -> .../devices/faux/vkms/drm/card0), and libdrm 2.4.115's
subsystem-type table (xf86drm.c) has no "faux" entry at all - get_subsystem_type()
returns -EINVAL for the unmatched subsystem, and process_device()'s switch on
bus type falls to its default: return -1 case for the unrecognized type. The
device is dropped from enumeration as unclassifiable; it is never misdetected
as PCI, and PCI-specific sysfs parsing (vendor-id/device-id attributes) is
never reached. Confirmed by diffing xf86drm.c between versions: 2.4.134 adds
an explicit { "/faux", DRM_BUS_FAUX } table entry and DRM_BUS_FAUX handling
throughout; 2.4.115 predates the kernel's vkms-to-faux_device conversion
entirely.

All of this recipe's existing meson configure flags remain valid options in
2.4.134 (checked against its meson_options.txt) - no other changes needed.

## Motivation and context
Fix can't classify vkms's faux bus

## How has this been tested?
E2E CI is now properly running 
Before: https://github.com/clementperon/xbmc/actions/runs/29537951486/job/87753540393
After: https://github.com/clementperon/xbmc/actions/runs/29746028528/job/88364095264

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
