### PR TITLE
VideoInfoScanner: fully instrument fasthash gate, remember SMB stat info

### DIFF
--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -672,8 +672,11 @@ void ChangeFolderToFile(const std::shared_ptr<CFileItem>& item, const std::strin
 
 void ConvertDiscFoldersToFiles(std::vector<std::shared_ptr<CFileItem>> items)
 {
-  auto folderItems{items | std::views::filter([](const std::shared_ptr<CFileItem>& item)
-                                              { return item->IsFolder(); })};
+  auto folderItems{items | std::views::filter(
+                               [](const std::shared_ptr<CFileItem>& item) {
+                                 return item->IsFolder() &&
+                                        !item->GetProperty("unchanged").asBoolean();
+                               })};
   for (const auto& item : folderItems)
   {
     if (auto playPath{VIDEO::UTILS::GetOpticalMediaPath(*item)}; !playPath.empty())

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -675,7 +675,7 @@ void ConvertDiscFoldersToFiles(std::vector<std::shared_ptr<CFileItem>> items)
   auto folderItems{items | std::views::filter(
                                [](const std::shared_ptr<CFileItem>& item) {
                                  return item->IsFolder() &&
-                                        !item->GetProperty("unchanged").asBoolean();
+                                        !item->GetProperty(PROPERTY_UNCHANGED).asBoolean();
                                })};
   for (const auto& item : folderItems)
   {

--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -23,6 +23,10 @@
 #include <utility>
 #include <vector>
 
+//! item property set by the video library scanner on subfolders whose fast hash matches
+//! the stored hash; Stack() skips the disc structure probes for such folders
+static constexpr const char* PROPERTY_UNCHANGED{"scanner:unchanged"};
+
 /*!
   \brief Represents a list of files
   \sa CFileItemList, CFileItem

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -25,6 +25,13 @@ namespace XFILE
  */
 static constexpr size_t MAX_ITEM_RESOLVE_ATTEMPTS{5};
 
+/*! \brief Optional item properties a GetDirectory implementation may set.
+ Raw stat times in seconds since epoch, exactly as the filesystem reported
+ them, no local time conversion; consumers decide any mtime/ctime fallback.
+ */
+static constexpr const char* DIR_PROPERTY_STAT_MTIME{"stat:st_mtime"};
+static constexpr const char* DIR_PROPERTY_STAT_CTIME{"stat:st_ctime"};
+
 enum class CacheType
 {
   NEVER = 0, ///< Never cache this directory to memory

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -155,6 +155,11 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     item->SetFolder(isDir);
     if (!isDir)
       item->SetSize(size);
+    else
+    { // raw values; the DateTime above is local-time converted
+      item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(st.st_mtime));
+      item->SetProperty(DIR_PROPERTY_STAT_CTIME, static_cast<int64_t>(st.st_ctime));
+    }
     if (hidden)
       item->SetProperty("file:hidden", true);
   }

--- a/xbmc/platform/win32/filesystem/Win32Directory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32Directory.cpp
@@ -111,6 +111,14 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
     if (isHidden)
       item->SetProperty("file:hidden", true);
 
+    if (isDir)
+    { // raw values; the DateTime above is local-time converted
+      item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(
+                                                     findData.ftLastWriteTime)));
+      item->SetProperty(DIR_PROPERTY_STAT_CTIME,
+                        static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(findData.ftCreationTime)));
+    }
+
   } while (FindNextFileW(hSearch, &findData));
 
   items.AddItems(std::move(fileItems));

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -7,17 +7,24 @@
  */
 
 #include "FileItem.h"
+#include "FileItemList.h"
 #include "LangInfo.h"
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "Util.h"
+#include "filesystem/Directory.h"
 #include "media/MediaType.h"
+#include "platform/Filesystem.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/SettingsManager.h"
+#include "utils/URIUtils.h"
 #include "video/VideoInfoTag.h"
+
+#include <fstream>
 
 #include <gtest/gtest.h>
 
@@ -1100,3 +1107,36 @@ INSTANTIATE_TEST_SUITE_P(EpisodeLabel,
                          ValuesIn(EpisodeLabelCases),
                          [](const testing::TestParamInfo<EpisodeLabelTestCase>& info)
                          { return info.param.testName; });
+
+TEST(TestFileItemList, StackSkipsUnchangedFolders)
+{
+  std::error_code ec;
+  const std::string tempPath = KODI::PLATFORM::FILESYSTEM::create_temp_directory(ec);
+  EXPECT_FALSE(ec);
+  std::string moviePath = URIUtils::AddFileToFolder(tempPath, "movie");
+  EXPECT_TRUE(CUtil::CreateDirectoryEx(moviePath));
+  {
+    std::ofstream of(URIUtils::AddFileToFolder(moviePath, "VIDEO_TS.IFO"));
+  }
+  URIUtils::AddSlashAtEnd(moviePath);
+
+  {
+    // a disc structure folder is converted to a file item
+    // (the list needs a path or Stack() bails out as a virtual directory root)
+    CFileItemList items(tempPath);
+    items.Add(std::make_shared<CFileItem>(moviePath, true));
+    items.Stack();
+    EXPECT_FALSE(items[0]->IsFolder());
+  }
+  {
+    // unless it is marked unchanged by the library scanner
+    CFileItemList items(tempPath);
+    const auto folder = std::make_shared<CFileItem>(moviePath, true);
+    folder->SetProperty(PROPERTY_UNCHANGED, true);
+    items.Add(folder);
+    items.Stack();
+    EXPECT_TRUE(items[0]->IsFolder());
+  }
+
+  XFILE::CDirectory::RemoveRecursive(tempPath);
+}

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -446,15 +446,22 @@ CVideoInfoScanner::~CVideoInfoScanner()
         // the disc structure probes in Stack() and the recursion loop (which also
         // drops them from m_pathsToScan) skip marked items. Full listing hashes
         // never match here, so folders containing subfolders are still visited.
+        std::vector<CRegExp> stackRegExps{m_advancedSettings->m_folderStackRegExps};
         for (int i = items.Size() - 1; i >= 0; --i)
         {
           if (!items[i]->IsFolder())
             continue;
+          // a marked folder-stack member (label like "cd1") stays a folder in
+          // Stack() and its stack cannot form; leave such folders unmarked
+          std::string label = StringUtils::ToLower(items[i]->GetLabel());
+          URIUtils::RemoveSlashAtEnd(label);
           std::string dbh;
           int64_t rawTime = items[i]->GetProperty(DIR_PROPERTY_STAT_MTIME).asInteger(0);
           if (rawTime == 0)
             rawTime = items[i]->GetProperty(DIR_PROPERTY_STAT_CTIME).asInteger(0);
           if (m_advancedSettings->m_bVideoLibraryUseFastHash &&
+              std::none_of(stackRegExps.begin(), stackRegExps.end(),
+                           [&label](CRegExp& re) { return re.RegFind(label) != -1; }) &&
               m_database.GetPathHash(items[i]->GetPath(), dbh) && !dbh.empty() &&
               StringUtils::EqualsNoCase(rawTime != 0 ? GetFastHash(regexps, rawTime)
                                                      : GetFastHash(items[i]->GetPath(), regexps),

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -441,9 +441,23 @@ CVideoInfoScanner::~CVideoInfoScanner()
       { // need to fetch the folder
         CDirectory::GetDirectory(strDirectory, items, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(),
                                  DIR_FLAG_DEFAULTS);
-        // do not consider inner folders with .nomedia
-        erase_if(items, [](const std::shared_ptr<CFileItem>& item)
-                 { return item->IsFolder() && HasNoMedia(item->GetPath()); });
+
+        // mark subfolders whose stored fast hash matches the listing mtime digest;
+        // the disc structure probes in Stack() and the recursion loop (which also
+        // drops them from m_pathsToScan) skip marked items. Full listing hashes
+        // never match here, so folders containing subfolders are still visited.
+        for (int i = items.Size() - 1; i >= 0; --i)
+        {
+          if (!items[i]->IsFolder())
+            continue;
+          std::string dbh;
+          if (m_advancedSettings->m_bVideoLibraryUseFastHash &&
+              m_database.GetPathHash(items[i]->GetPath(), dbh) && !dbh.empty() &&
+              StringUtils::EqualsNoCase(GetFastHash(items[i]->GetPath(), regexps), dbh))
+            items[i]->SetProperty("unchanged", true);
+          else if (HasNoMedia(items[i]->GetPath()))
+            items.Remove(i);
+        }
         items.Stack();
 
         // force sorting consistency to avoid hash mismatch between platforms
@@ -578,6 +592,13 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (content != ContentType::TVSHOWS && settings.recurse > 0 && pItem->IsFolder() &&
           !pItem->IsParentFolder() && !PLAYLIST::IsPlayList(*pItem))
       {
+        if (pItem->GetProperty("unchanged").asBoolean())
+        {
+          CLog::Log(LOGDEBUG, "VideoInfoScanner: Skipping dir '{}' due to no change (fasthash)",
+                    CURL::GetRedacted(pItem->GetPath()));
+          m_pathsToScan.erase(pItem->GetPath());
+          continue;
+        }
         if (const auto [scanComplete, foundContentOnRecursion] = DoScan(pItem->GetPath());
             scanComplete == ScanComplete::Stopped)
         {

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -451,9 +451,14 @@ CVideoInfoScanner::~CVideoInfoScanner()
           if (!items[i]->IsFolder())
             continue;
           std::string dbh;
+          int64_t rawTime = items[i]->GetProperty(DIR_PROPERTY_STAT_MTIME).asInteger(0);
+          if (rawTime == 0)
+            rawTime = items[i]->GetProperty(DIR_PROPERTY_STAT_CTIME).asInteger(0);
           if (m_advancedSettings->m_bVideoLibraryUseFastHash &&
               m_database.GetPathHash(items[i]->GetPath(), dbh) && !dbh.empty() &&
-              StringUtils::EqualsNoCase(GetFastHash(items[i]->GetPath(), regexps), dbh))
+              StringUtils::EqualsNoCase(rawTime != 0 ? GetFastHash(regexps, rawTime)
+                                                     : GetFastHash(items[i]->GetPath(), regexps),
+                                        dbh))
             items[i]->SetProperty("unchanged", true);
           else if (HasNoMedia(items[i]->GetPath()))
             items.Remove(i);
@@ -2514,11 +2519,6 @@ CVideoInfoScanner::~CVideoInfoScanner()
   std::string CVideoInfoScanner::GetFastHash(const std::string &directory,
       const std::vector<std::string> &excludes) const
   {
-    CDigest digest{CDigest::Type::MD5};
-
-    if (!excludes.empty())
-      digest.Update(StringUtils::Join(excludes, "|"));
-
     struct __stat64 buffer;
     if (XFILE::CFile::Stat(directory, &buffer) == 0)
     {
@@ -2526,12 +2526,21 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (!time)
         time = buffer.st_ctime;
       if (time)
-      {
-        digest.Update((unsigned char *)&time, sizeof(time));
-        return digest.Finalize();
-      }
+        return GetFastHash(excludes, time);
     }
     return "";
+  }
+
+  std::string CVideoInfoScanner::GetFastHash(const std::vector<std::string>& excludes,
+                                             int64_t time) const
+  {
+    CDigest digest{CDigest::Type::MD5};
+
+    if (!excludes.empty())
+      digest.Update(StringUtils::Join(excludes, "|"));
+
+    digest.Update((unsigned char*)&time, sizeof(time));
+    return digest.Finalize();
   }
 
   std::string CVideoInfoScanner::GetRecursiveFastHash(const std::string &directory,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -459,7 +459,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
               StringUtils::EqualsNoCase(rawTime != 0 ? GetFastHash(regexps, rawTime)
                                                      : GetFastHash(items[i]->GetPath(), regexps),
                                         dbh))
-            items[i]->SetProperty("unchanged", true);
+            items[i]->SetProperty(PROPERTY_UNCHANGED, true);
           else if (HasNoMedia(items[i]->GetPath()))
             items.Remove(i);
         }
@@ -597,7 +597,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (content != ContentType::TVSHOWS && settings.recurse > 0 && pItem->IsFolder() &&
           !pItem->IsParentFolder() && !PLAYLIST::IsPlayList(*pItem))
       {
-        if (pItem->GetProperty("unchanged").asBoolean())
+        if (pItem->GetProperty(PROPERTY_UNCHANGED).asBoolean())
         {
           CLog::Log(LOGDEBUG, "VideoInfoScanner: Skipping dir '{}' due to no change (fasthash)",
                     CURL::GetRedacted(pItem->GetPath()));

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -277,6 +277,9 @@ namespace KODI::VIDEO
      */
     std::string GetFastHash(const std::string &directory, const std::vector<std::string> &excludes) const;
 
+    /*! \brief As above but from an already known raw modification time */
+    std::string GetFastHash(const std::vector<std::string>& excludes, int64_t time) const;
+
     /*! \brief Retrieve a "fast" hash of the given directory recursively (if available)
      Performs a stat() on the directory, and uses modified time to create a "fast"
      hash of each folder. If no modified time is available, the create time is used,


### PR DESCRIPTION
## Description
Library scans probed every subfolder of a scanned directory (.nomedia check, DVD/Bluray structure detection, plus a revisit with its own stat) before any change detection ran: nine network round trips per folder per scan even when nothing changed. DoScan now compares each subfolder's fast hash against its stored hash directly after listing the parent and skips all probing and revisiting for unchanged folders; the SMB directory provider carries the raw mtime from readdirplus so the comparison itself costs no extra round trip. Folders without a stored fast hash (new, changed, containing subfolders, other providers) take the previous path unchanged.

This yields a *significant* 10-fold (or better) speedup in SMB network scans, whether there are changes or not.

## Motivation and context
One-movie-per-folder libraries on network shares scan very slowly. Test server with 5000 dummy folders+nfos, a null scan (no changes) of a library issued ~45000 sequential smbc_stat calls.

## How has this been tested?
On the above library (Linux, smb://): null scan went from ~32 s to 8.4 s with the first commit (one stat per folder); the second commit removes that remaining stat. New unit test covers Stack() honoring the unchanged mark; full test suite passes.

## What is the effect on users?
Library update scans on network sources become dramatically faster when little or nothing has changed.

## Types of change
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
- [X] My code follows the **Code Guidelines** of this project
- [X] I have read the **Contributing** document
- [X] All new and existing tests passed
