### PR TITLE
VideoInfoScanner: make disc entries use fasthash

### DIFF
--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -672,8 +672,11 @@ void ChangeFolderToFile(const std::shared_ptr<CFileItem>& item, const std::strin
 
 void ConvertDiscFoldersToFiles(std::vector<std::shared_ptr<CFileItem>> items)
 {
-  auto folderItems{items | std::views::filter([](const std::shared_ptr<CFileItem>& item)
-                                              { return item->IsFolder(); })};
+  auto folderItems{items | std::views::filter(
+                               [](const std::shared_ptr<CFileItem>& item) {
+                                 return item->IsFolder() &&
+                                        !item->GetProperty("unchanged").asBoolean();
+                               })};
   for (const auto& item : folderItems)
   {
     if (auto playPath{VIDEO::UTILS::GetOpticalMediaPath(*item)}; !playPath.empty())

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -675,7 +675,7 @@ void ConvertDiscFoldersToFiles(std::vector<std::shared_ptr<CFileItem>> items)
   auto folderItems{items | std::views::filter(
                                [](const std::shared_ptr<CFileItem>& item) {
                                  return item->IsFolder() &&
-                                        !item->GetProperty("unchanged").asBoolean();
+                                        !item->GetProperty(PROPERTY_UNCHANGED).asBoolean();
                                })};
   for (const auto& item : folderItems)
   {

--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -23,6 +23,10 @@
 #include <utility>
 #include <vector>
 
+//! item property set by the video library scanner on subfolders whose fast hash matches
+//! the stored hash; Stack() skips the disc structure probes for such folders
+static constexpr const char* PROPERTY_UNCHANGED{"scanner:unchanged"};
+
 /*!
   \brief Represents a list of files
   \sa CFileItemList, CFileItem

--- a/xbmc/filesystem/IDirectory.h
+++ b/xbmc/filesystem/IDirectory.h
@@ -25,6 +25,13 @@ namespace XFILE
  */
 static constexpr size_t MAX_ITEM_RESOLVE_ATTEMPTS{5};
 
+/*! \brief Optional item properties a GetDirectory implementation may set.
+ Raw stat times in seconds since epoch, exactly as the filesystem reported
+ them, no local time conversion; consumers decide any mtime/ctime fallback.
+ */
+static constexpr const char* DIR_PROPERTY_STAT_MTIME{"stat:st_mtime"};
+static constexpr const char* DIR_PROPERTY_STAT_CTIME{"stat:st_ctime"};
+
 enum class CacheType
 {
   NEVER = 0, ///< Never cache this directory to memory

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -155,6 +155,11 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     item->SetFolder(isDir);
     if (!isDir)
       item->SetSize(size);
+    else
+    { // raw values; the DateTime above is local-time converted
+      item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(st.st_mtime));
+      item->SetProperty(DIR_PROPERTY_STAT_CTIME, static_cast<int64_t>(st.st_ctime));
+    }
     if (hidden)
       item->SetProperty("file:hidden", true);
   }

--- a/xbmc/platform/win32/filesystem/Win32Directory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32Directory.cpp
@@ -111,6 +111,14 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
     if (isHidden)
       item->SetProperty("file:hidden", true);
 
+    if (isDir)
+    { // raw values; the DateTime above is local-time converted
+      item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(
+                                                     findData.ftLastWriteTime)));
+      item->SetProperty(DIR_PROPERTY_STAT_CTIME,
+                        static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(findData.ftCreationTime)));
+    }
+
   } while (FindNextFileW(hSearch, &findData));
 
   items.AddItems(std::move(fileItems));

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -7,17 +7,24 @@
  */
 
 #include "FileItem.h"
+#include "FileItemList.h"
 #include "LangInfo.h"
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "Util.h"
+#include "filesystem/Directory.h"
 #include "media/MediaType.h"
+#include "platform/Filesystem.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/SettingsManager.h"
+#include "utils/URIUtils.h"
 #include "video/VideoInfoTag.h"
+
+#include <fstream>
 
 #include <gtest/gtest.h>
 
@@ -1100,3 +1107,36 @@ INSTANTIATE_TEST_SUITE_P(EpisodeLabel,
                          ValuesIn(EpisodeLabelCases),
                          [](const testing::TestParamInfo<EpisodeLabelTestCase>& info)
                          { return info.param.testName; });
+
+TEST(TestFileItemList, StackSkipsUnchangedFolders)
+{
+  std::error_code ec;
+  const std::string tempPath = KODI::PLATFORM::FILESYSTEM::create_temp_directory(ec);
+  EXPECT_FALSE(ec);
+  std::string moviePath = URIUtils::AddFileToFolder(tempPath, "movie");
+  EXPECT_TRUE(CUtil::CreateDirectoryEx(moviePath));
+  {
+    std::ofstream of(URIUtils::AddFileToFolder(moviePath, "VIDEO_TS.IFO"));
+  }
+  URIUtils::AddSlashAtEnd(moviePath);
+
+  {
+    // a disc structure folder is converted to a file item
+    // (the list needs a path or Stack() bails out as a virtual directory root)
+    CFileItemList items(tempPath);
+    items.Add(std::make_shared<CFileItem>(moviePath, true));
+    items.Stack();
+    EXPECT_FALSE(items[0]->IsFolder());
+  }
+  {
+    // unless it is marked unchanged by the library scanner
+    CFileItemList items(tempPath);
+    const auto folder = std::make_shared<CFileItem>(moviePath, true);
+    folder->SetProperty(PROPERTY_UNCHANGED, true);
+    items.Add(folder);
+    items.Stack();
+    EXPECT_TRUE(items[0]->IsFolder());
+  }
+
+  XFILE::CDirectory::RemoveRecursive(tempPath);
+}

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -43,6 +43,17 @@ TEST_F(TestURIUtils, PathHasParent)
   EXPECT_FALSE(URIUtils::PathHasParent("/path/to/movie.avi", "/path/2/"));
 }
 
+TEST_F(TestURIUtils, RemoveDiscPath)
+{
+  EXPECT_EQ("smb://somepath/Movie/",
+            URIUtils::RemoveDiscPath("smb://somepath/Movie/BDMV/index.bdmv"));
+  EXPECT_EQ("smb://somepath/Movie/",
+            URIUtils::RemoveDiscPath("smb://somepath/Movie/VIDEO_TS/VIDEO_TS.IFO"));
+  // base of a disc file sitting directly in the movie folder has no trailing slash
+  EXPECT_EQ("smb://somepath/Movie", URIUtils::RemoveDiscPath("smb://somepath/Movie/VIDEO_TS.IFO"));
+  EXPECT_EQ("", URIUtils::RemoveDiscPath("smb://somepath/Movie/movie.mkv"));
+}
+
 TEST_F(TestURIUtils, GetDirectory)
 {
   EXPECT_EQ("/path/to/", URIUtils::GetDirectory("/path/to/movie.avi"));

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -446,15 +446,22 @@ CVideoInfoScanner::~CVideoInfoScanner()
         // the disc structure probes in Stack() and the recursion loop (which also
         // drops them from m_pathsToScan) skip marked items. Full listing hashes
         // never match here, so folders containing subfolders are still visited.
+        std::vector<CRegExp> stackRegExps{m_advancedSettings->m_folderStackRegExps};
         for (int i = items.Size() - 1; i >= 0; --i)
         {
           if (!items[i]->IsFolder())
             continue;
+          // a marked folder-stack member (label like "cd1") stays a folder in
+          // Stack() and its stack cannot form; leave such folders unmarked
+          std::string label = StringUtils::ToLower(items[i]->GetLabel());
+          URIUtils::RemoveSlashAtEnd(label);
           std::string dbh;
           int64_t rawTime = items[i]->GetProperty(DIR_PROPERTY_STAT_MTIME).asInteger(0);
           if (rawTime == 0)
             rawTime = items[i]->GetProperty(DIR_PROPERTY_STAT_CTIME).asInteger(0);
           if (m_advancedSettings->m_bVideoLibraryUseFastHash &&
+              std::none_of(stackRegExps.begin(), stackRegExps.end(),
+                           [&label](CRegExp& re) { return re.RegFind(label) != -1; }) &&
               m_database.GetPathHash(items[i]->GetPath(), dbh) && !dbh.empty() &&
               StringUtils::EqualsNoCase(rawTime != 0 ? GetFastHash(regexps, rawTime)
                                                      : GetFastHash(items[i]->GetPath(), regexps),

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -420,6 +420,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     }
 
     std::string hash, dbHash;
+    bool listingHash = false; // hash came from GetPathHash over a fetched listing
     if (content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS)
     {
       if (m_handle)
@@ -477,7 +478,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
         items.Sort(SortBy::FILE, SortOrder::ASCENDING, SortAttributeNone);
 
         // check whether to re-use previously computed fast hash
-        if (!CanFastHash(items, regexps) || fastHash.empty())
+        listingHash = !CanFastHash(items, regexps) || fastHash.empty();
+        if (listingHash)
           GetPathHash(items, hash);
         else
           hash = fastHash;
@@ -486,7 +488,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (StringUtils::EqualsNoCase(hash, dbHash))
       { // hash matches - skipping
         CLog::Log(LOGDEBUG, "VideoInfoScanner: Skipping dir '{}' due to no change{}",
-                  CURL::GetRedacted(strDirectory), !fastHash.empty() ? " (fasthash)" : "");
+                  CURL::GetRedacted(strDirectory), listingHash ? "" : " (fasthash)");
         bSkip = true;
       }
       else if (hash.empty())
@@ -560,10 +562,13 @@ CVideoInfoScanner::~CVideoInfoScanner()
       }
       else
       {
-        // an all-folder listing can never import; store the hash here or the
-        // mismatch recurs every scan
+        // an all-folder listing has nothing to directly import, so foundSomething
+        // is false here even when nothing changed; store the hash or GetPathHash
+        // output never matches dbHash and every scan repeats the full rescan.
+        // Only store a listing-hash, as an mtime-hash would match the fasthash
+        // gate before the listing is fetched, hiding content that never imported.
         if ((content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS) &&
-            !URIUtils::IsArchive(CURL(strDirectory)) &&
+            listingHash && !URIUtils::IsArchive(CURL(strDirectory)) &&
             std::all_of(items.begin(), items.end(),
                         [](const auto& item) { return item->IsFolder(); }))
           m_database.SetPathHash(strDirectory, hash);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -621,7 +621,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       // forms. ISOs hash normally as plain files and never reach this block.
       if (content == ContentType::MOVIES && m_advancedSettings->m_bVideoLibraryUseFastHash &&
           !URIUtils::IsPlugin(strDirectory) && !pItem->IsFolder() &&
-          URIUtils::IsOpticalMediaFile(pItem->GetPath()))
+          !URIUtils::IsStack(pItem->GetPath()) && URIUtils::IsOpticalMediaFile(pItem->GetPath()))
       {
         std::string discFolder = URIUtils::RemoveDiscPath(pItem->GetPath());
         URIUtils::AddSlashAtEnd(discFolder);
@@ -779,7 +779,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     {
       CFileItemPtr pItem = items[i];
 
-      if (pItem->GetProperty(PROPERTY_UNCHANGED).asBoolean())
+      if (pItem->IsFolder() && pItem->GetProperty(PROPERTY_UNCHANGED).asBoolean())
         continue;
 
       // we do this since we may have a override per dir

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -441,9 +441,23 @@ CVideoInfoScanner::~CVideoInfoScanner()
       { // need to fetch the folder
         CDirectory::GetDirectory(strDirectory, items, CServiceBroker::GetFileExtensionProvider().GetVideoExtensions(),
                                  DIR_FLAG_DEFAULTS);
-        // do not consider inner folders with .nomedia
-        erase_if(items, [](const std::shared_ptr<CFileItem>& item)
-                 { return item->IsFolder() && HasNoMedia(item->GetPath()); });
+
+        // mark subfolders whose stored fast hash matches the listing mtime digest;
+        // the disc structure probes in Stack() and the recursion loop (which also
+        // drops them from m_pathsToScan) skip marked items. Full listing hashes
+        // never match here, so folders containing subfolders are still visited.
+        for (int i = items.Size() - 1; i >= 0; --i)
+        {
+          if (!items[i]->IsFolder())
+            continue;
+          std::string dbh;
+          if (m_advancedSettings->m_bVideoLibraryUseFastHash &&
+              m_database.GetPathHash(items[i]->GetPath(), dbh) && !dbh.empty() &&
+              StringUtils::EqualsNoCase(GetFastHash(items[i]->GetPath(), regexps), dbh))
+            items[i]->SetProperty("unchanged", true);
+          else if (HasNoMedia(items[i]->GetPath()))
+            items.Remove(i);
+        }
         items.Stack();
 
         // force sorting consistency to avoid hash mismatch between platforms
@@ -578,6 +592,13 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (content != ContentType::TVSHOWS && settings.recurse > 0 && pItem->IsFolder() &&
           !pItem->IsParentFolder() && !PLAYLIST::IsPlayList(*pItem))
       {
+        if (pItem->GetProperty("unchanged").asBoolean())
+        {
+          CLog::Log(LOGDEBUG, "VideoInfoScanner: Skipping dir '{}' due to no change (fasthash)",
+                    CURL::GetRedacted(pItem->GetPath()));
+          m_pathsToScan.erase(pItem->GetPath());
+          continue;
+        }
         if (const auto [scanComplete, foundContentOnRecursion] = DoScan(pItem->GetPath());
             scanComplete == ScanComplete::Stopped)
         {

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -560,6 +560,13 @@ CVideoInfoScanner::~CVideoInfoScanner()
       }
       else
       {
+        // an all-folder listing can never import; store the hash here or the
+        // mismatch recurs every scan
+        if ((content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS) &&
+            !URIUtils::IsArchive(CURL(strDirectory)) &&
+            std::all_of(items.begin(), items.end(),
+                        [](const auto& item) { return item->IsFolder(); }))
+          m_database.SetPathHash(strDirectory, hash);
         if (m_bClean)
           m_pathsToClean.insert(m_database.GetPathId(strDirectory));
         CLog::Log(LOGDEBUG, "VideoInfoScanner: No (new) information was found in dir {}",
@@ -597,6 +604,35 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
         // no further processing required
         continue;
+      }
+
+      // Disc rips are anchored in files/path several ways: BD subfolder rips
+      // under the raw BDMV/ row (older imports or failed playlist detection)
+      // or under a bluray:// playlist row (current imports); DVD rips under
+      // VIDEO_TS/; flat rips with the structure file directly in the movie
+      // folder. In every form the movie folder itself, the item the scanner
+      // lists, has no hashed row, so each parent rescan re-imports the movie
+      // from NFO. Store its fast hash here; GetMovieId resolves all anchor
+      // forms. ISOs hash normally as plain files and never reach this block.
+      if (content == ContentType::MOVIES && m_advancedSettings->m_bVideoLibraryUseFastHash &&
+          !URIUtils::IsPlugin(strDirectory) && !pItem->IsFolder() &&
+          URIUtils::IsOpticalMediaFile(pItem->GetPath()))
+      {
+        std::string discFolder = URIUtils::RemoveDiscPath(pItem->GetPath());
+        URIUtils::AddSlashAtEnd(discFolder);
+        if (!URIUtils::PathEquals(discFolder, strDirectory, true))
+        {
+          int64_t rawTime = pItem->GetProperty(DIR_PROPERTY_STAT_MTIME).asInteger(0);
+          if (rawTime == 0)
+            rawTime = pItem->GetProperty(DIR_PROPERTY_STAT_CTIME).asInteger(0);
+          const std::string fh =
+              rawTime != 0 ? GetFastHash(regexps, rawTime) : GetFastHash(discFolder, regexps);
+          std::string dbh;
+          if (!fh.empty() &&
+              !(m_database.GetPathHash(discFolder, dbh) && StringUtils::EqualsNoCase(fh, dbh)) &&
+              m_database.HasMovieInfo(pItem->GetDynPath()))
+            m_database.SetPathHash(discFolder, fh);
+        }
       }
 
       // if we have a directory item (non-playlist) we then recurse into that folder
@@ -737,6 +773,9 @@ CVideoInfoScanner::~CVideoInfoScanner()
     for (int i = 0; i < items.Size(); ++i)
     {
       CFileItemPtr pItem = items[i];
+
+      if (pItem->GetProperty(PROPERTY_UNCHANGED).asBoolean())
+        continue;
 
       // we do this since we may have a override per dir
       ScraperPtr info2 = m_database.GetScraperForPath(

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -451,9 +451,14 @@ CVideoInfoScanner::~CVideoInfoScanner()
           if (!items[i]->IsFolder())
             continue;
           std::string dbh;
+          int64_t rawTime = items[i]->GetProperty(DIR_PROPERTY_STAT_MTIME).asInteger(0);
+          if (rawTime == 0)
+            rawTime = items[i]->GetProperty(DIR_PROPERTY_STAT_CTIME).asInteger(0);
           if (m_advancedSettings->m_bVideoLibraryUseFastHash &&
               m_database.GetPathHash(items[i]->GetPath(), dbh) && !dbh.empty() &&
-              StringUtils::EqualsNoCase(GetFastHash(items[i]->GetPath(), regexps), dbh))
+              StringUtils::EqualsNoCase(rawTime != 0 ? GetFastHash(regexps, rawTime)
+                                                     : GetFastHash(items[i]->GetPath(), regexps),
+                                        dbh))
             items[i]->SetProperty("unchanged", true);
           else if (HasNoMedia(items[i]->GetPath()))
             items.Remove(i);
@@ -2514,11 +2519,6 @@ CVideoInfoScanner::~CVideoInfoScanner()
   std::string CVideoInfoScanner::GetFastHash(const std::string &directory,
       const std::vector<std::string> &excludes) const
   {
-    CDigest digest{CDigest::Type::MD5};
-
-    if (!excludes.empty())
-      digest.Update(StringUtils::Join(excludes, "|"));
-
     struct __stat64 buffer;
     if (XFILE::CFile::Stat(directory, &buffer) == 0)
     {
@@ -2526,12 +2526,21 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (!time)
         time = buffer.st_ctime;
       if (time)
-      {
-        digest.Update((unsigned char *)&time, sizeof(time));
-        return digest.Finalize();
-      }
+        return GetFastHash(excludes, time);
     }
     return "";
+  }
+
+  std::string CVideoInfoScanner::GetFastHash(const std::vector<std::string>& excludes,
+                                             int64_t time) const
+  {
+    CDigest digest{CDigest::Type::MD5};
+
+    if (!excludes.empty())
+      digest.Update(StringUtils::Join(excludes, "|"));
+
+    digest.Update((unsigned char*)&time, sizeof(time));
+    return digest.Finalize();
   }
 
   std::string CVideoInfoScanner::GetRecursiveFastHash(const std::string &directory,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -459,7 +459,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
               StringUtils::EqualsNoCase(rawTime != 0 ? GetFastHash(regexps, rawTime)
                                                      : GetFastHash(items[i]->GetPath(), regexps),
                                         dbh))
-            items[i]->SetProperty("unchanged", true);
+            items[i]->SetProperty(PROPERTY_UNCHANGED, true);
           else if (HasNoMedia(items[i]->GetPath()))
             items.Remove(i);
         }
@@ -597,7 +597,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       if (content != ContentType::TVSHOWS && settings.recurse > 0 && pItem->IsFolder() &&
           !pItem->IsParentFolder() && !PLAYLIST::IsPlayList(*pItem))
       {
-        if (pItem->GetProperty("unchanged").asBoolean())
+        if (pItem->GetProperty(PROPERTY_UNCHANGED).asBoolean())
         {
           CLog::Log(LOGDEBUG, "VideoInfoScanner: Skipping dir '{}' due to no change (fasthash)",
                     CURL::GetRedacted(pItem->GetPath()));

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -277,6 +277,9 @@ namespace KODI::VIDEO
      */
     std::string GetFastHash(const std::string &directory, const std::vector<std::string> &excludes) const;
 
+    /*! \brief As above but from an already known raw modification time */
+    std::string GetFastHash(const std::vector<std::string>& excludes, int64_t time) const;
+
     /*! \brief Retrieve a "fast" hash of the given directory recursively (if available)
      Performs a stat() on the directory, and uses modified time to create a "fast"
      hash of each folder. If no modified time is available, the create time is used,


### PR DESCRIPTION
## Description
Disc folder rips (VIDEO_TS/BDMV) did not participate in the fast hash scheme: no hash was ever stored for them, so every source rescan re-imported them from their NFOs. Store a fast hash for the disc base folder at import time so the fast hash gate skips them like any other unchanged folder.

Based on #28645 and requires it.

## Motivation and context
Existing disc rips were re-imported on every scan that found new content.

## How has this been tested?
5000 dummy folders in library with BDMV dummy rips: after one scan stores the hashes, later scans no longer touch unchanged disc rips. Adds a RemoveDiscPath unit test; full suite passes. Scan takes ~2s vs ~35s.

## What is the effect on users?
Adding new movies no longer re-imports existing DVD/Bluray folder rips.

## Types of change
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
- [X] My code follows the **Code Guidelines** of this project
- [X] I have read the **Contributing** document
- [X] All new and existing tests passed
