### PR TITLE
Search function fix and improvement for movies with versions and/or extras

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24843,6 +24843,7 @@ msgstr ""
 #. Button label for video extras
 #: addons/skin.estuary/xml/DialogVideoInfo.xml
 #: xbmc/filesystem/VideoDatabaseDirectory.cpp
+#: xbmc/video/windows/GUIWindowVideoNav.cpp
 #: addons/skin.estuary/xml/Variables.xml
 msgctxt "#40211"
 msgid "Extras"

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -9779,6 +9779,75 @@ void CVideoDatabase::GetMusicVideoDirectorsByName(const std::string& strSearch, 
   }
 }
 
+void CVideoDatabase::GetMovieExtrasByName(const std::string& name, CFileItemList& items)
+{
+  std::string strSQL;
+
+  try
+  {
+    if (nullptr == m_pDB)
+      return;
+    if (nullptr == m_pDS)
+      return;
+
+    strSQL =
+        PrepareSQL("SELECT movie.idMovie, vvt.name, path.strPath, files.idFile "
+                   "FROM movie "
+                   "  JOIN videoversion vv ON "
+                   "    vv.idMedia = movie.idMovie AND vv.media_type = '%s' AND vv.itemType = %i "
+                   "  JOIN videoversiontype vvt ON "
+                   "    vvt.id = vv.idType AND vvt.itemType = vv.itemType "
+                   "  JOIN files ON files.idFile = vv.idFile "
+                   "  JOIN path ON path.idPath = files.idPath "
+                   "WHERE vvt.name LIKE '%%%s%%'",
+                   MediaTypeMovie, VideoAssetType::EXTRA, name.c_str());
+
+    m_pDS->query(strSQL);
+
+    static const int idxMovieId = m_pDS->fieldIndex("idMovie");
+    static const int idxName = m_pDS->fieldIndex("name");
+    static const int idxPath = m_pDS->fieldIndex("strPath");
+    static const int idxFileId = m_pDS->fieldIndex("idFile");
+
+    if (idxMovieId == -1 || idxName == -1 || idxPath == -1 || idxFileId == -1)
+    {
+      CLog::LogF(LOGERROR, "column index not found");
+      m_pDS->close();
+      return;
+    }
+
+    while (!m_pDS->eof())
+    {
+      if (m_profileManager.GetMasterProfile().getLockMode() != LockMode::EVERYONE &&
+          !g_passwordManager.bMasterUser)
+        if (!g_passwordManager.IsDatabasePathUnlocked(
+                m_pDS->fv(idxPath).get_asString(),
+                *CMediaSourceSettings::GetInstance().GetSources("video")))
+        {
+          m_pDS->next();
+          continue;
+        }
+
+      const int movieId = m_pDS->fv(idxMovieId).get_asInt();
+      const int fileId = m_pDS->fv(idxFileId).get_asInt();
+      std::string path = StringUtils::Format("videodb://movies/titles/{}/{}/{}", movieId,
+                                             VideoAssetType::EXTRA, fileId);
+
+      auto pItem = std::make_shared<CFileItem>(m_pDS->fv(idxName).get_asString());
+      pItem->SetPath(std::move(path));
+      pItem->SetFolder(false);
+      items.Add(std::move(pItem));
+      m_pDS->next();
+    }
+    m_pDS->close();
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "({}) failed", strSQL);
+    m_pDS->close();
+  }
+}
+
 void CVideoDatabase::CleanDatabase(CGUIDialogProgressBarHandle* handle,
                                    const std::set<int>& paths,
                                    bool showProgress)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -642,6 +642,8 @@ public:
   void GetEpisodesByName(const std::string& strSearch, CFileItemList& items);
   void GetMusicVideosByName(const std::string& strSearch, CFileItemList& items);
 
+  void GetMovieExtrasByName(const std::string& strSearch, CFileItemList& items);
+
   std::string GetPlotByShowId(int idShow);
   void GetEpisodesByPlot(const std::string& strSearch, CFileItemList& items);
   void GetMoviesByPlot(const std::string& strSearch, CFileItemList& items);

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -1386,24 +1386,37 @@ void CGUIWindowVideoBase::OnSearchItemFound(const CFileItem* pSelItem)
   }
   else
   {
-    std::string strPath = URIUtils::GetDirectory(pSelItem->GetPath());
+    const std::string selPath = pSelItem->GetPath();
+    std::string selPathWithSlash = selPath;
+    URIUtils::AddSlashAtEnd(selPathWithSlash);
+    const bool isMovieUrl = selPath.starts_with("videodb://movies/titles/") ||
+                            selPath.starts_with("videodb://movies/sets/");
+    const bool isVideoDb = VIDEO::IsVideoDb(*pSelItem);
+    const std::string parentPath = URIUtils::GetDirectory(selPath);
 
-    Update(strPath);
+    Update(parentPath);
 
     if (VIDEO::IsVideoDb(*pSelItem) &&
         CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
             CSettings::SETTING_MYVIDEOS_FLATTEN))
       SetHistoryForPath("");
     else
-      SetHistoryForPath(strPath);
+      SetHistoryForPath(parentPath);
 
     for (int i = 0; i < m_vecItems->Size(); i++)
     {
       CFileItemPtr pItem = m_vecItems->Get(i);
-      CURL url(pItem->GetPath());
-      if (VIDEO::IsVideoDb(*pSelItem))
+      const std::string itemPath = pItem->GetPath();
+      CURL url(itemPath);
+      if (isVideoDb)
         url.SetOptions("");
-      if (url.Get() == pSelItem->GetPath())
+      const std::string urlPath = url.Get();
+      // Relax match condition for movie with versions / extras
+      // The selected item looks like videodb://movies/titles/1234 but the list items look
+      // like videodb://movies/titles/1234/-2/
+      // Allow a match on the beginning of the string instead of an exact match.
+      // Same for movies in sets (url starts with videodb://movies/sets/)
+      if (urlPath == selPath || (isMovieUrl && urlPath.starts_with(selPathWithSlash)))
       {
         m_viewControl.SetSelectedItem(i);
         break;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -627,63 +627,38 @@ void CGUIWindowVideoNav::DoSearch(const std::string& strSearch, CFileItemList& i
   const auto entries = std::array{
       Entry{20338,
             [&strSearch, &tempItems, this]() { m_database.GetMoviesByName(strSearch, tempItems); }},
-      Entry{20359, [&strSearch, &tempItems,
-                    this]() { m_database.GetEpisodesByName(strSearch, tempItems); }},
-      Entry{20364, [&strSearch, &tempItems,
-                    this]() { m_database.GetTvShowsByName(strSearch, tempItems); }},
-      Entry{20391, [&strSearch, &tempItems,
-                    this]() { m_database.GetMusicVideosByName(strSearch, tempItems); }},
-      Entry{558, [&strSearch, &tempItems,
-                  this]() { m_database.GetMusicVideosByAlbum(strSearch, tempItems); }},
-      Entry{20342,
-            [&strSearch, &tempItems, this]() {
-              m_database.GetMovieGenresByName(strSearch, tempItems);
-            },
-            515},
-      Entry{20343,
-            [&strSearch, &tempItems, this]() {
-              m_database.GetTvShowGenresByName(strSearch, tempItems);
-            },
-            515},
-      Entry{20389,
-            [&strSearch, &tempItems, this]() {
-              m_database.GetMusicVideoGenresByName(strSearch, tempItems);
-            },
-            515},
-      Entry{20342,
-            [&strSearch, &tempItems, this]() {
-              m_database.GetMovieActorsByName(strSearch, tempItems);
-            },
-            20337},
-      Entry{20343,
-            [&strSearch, &tempItems, this]() {
-              m_database.GetTvShowsActorsByName(strSearch, tempItems);
-            },
-            20337},
-      Entry{20389,
-            [&strSearch, &tempItems, this]() {
-              m_database.GetMusicVideoArtistsByName(strSearch, tempItems);
-            },
-            20337},
-      Entry{20342,
-            [&strSearch, &tempItems, this]() {
-              m_database.GetMovieDirectorsByName(strSearch, tempItems);
-            },
-            20339},
-      Entry{20343,
-            [&strSearch, &tempItems, this]() {
-              m_database.GetTvShowsDirectorsByName(strSearch, tempItems);
-            },
-            20339},
-      Entry{20389,
-            [&strSearch, &tempItems, this]() {
-              m_database.GetMusicVideoDirectorsByName(strSearch, tempItems);
-            },
-            20339},
-      Entry{20365, [&strSearch, &tempItems,
-                    this]() { m_database.GetEpisodesByPlot(strSearch, tempItems); }},
+      Entry{20359, [&strSearch, &tempItems, this]()
+            { m_database.GetEpisodesByName(strSearch, tempItems); }},
+      Entry{20364, [&strSearch, &tempItems, this]()
+            { m_database.GetTvShowsByName(strSearch, tempItems); }},
+      Entry{20391, [&strSearch, &tempItems, this]()
+            { m_database.GetMusicVideosByName(strSearch, tempItems); }},
+      Entry{558, [&strSearch, &tempItems, this]()
+            { m_database.GetMusicVideosByAlbum(strSearch, tempItems); }},
+      Entry{20342, [&strSearch, &tempItems, this]()
+            { m_database.GetMovieGenresByName(strSearch, tempItems); }, 515},
+      Entry{20343, [&strSearch, &tempItems, this]()
+            { m_database.GetTvShowGenresByName(strSearch, tempItems); }, 515},
+      Entry{20389, [&strSearch, &tempItems, this]()
+            { m_database.GetMusicVideoGenresByName(strSearch, tempItems); }, 515},
+      Entry{20342, [&strSearch, &tempItems, this]()
+            { m_database.GetMovieActorsByName(strSearch, tempItems); }, 20337},
+      Entry{20343, [&strSearch, &tempItems, this]()
+            { m_database.GetTvShowsActorsByName(strSearch, tempItems); }, 20337},
+      Entry{20389, [&strSearch, &tempItems, this]()
+            { m_database.GetMusicVideoArtistsByName(strSearch, tempItems); }, 20337},
+      Entry{20342, [&strSearch, &tempItems, this]()
+            { m_database.GetMovieDirectorsByName(strSearch, tempItems); }, 20339},
+      Entry{20343, [&strSearch, &tempItems, this]()
+            { m_database.GetTvShowsDirectorsByName(strSearch, tempItems); }, 20339},
+      Entry{20389, [&strSearch, &tempItems, this]()
+            { m_database.GetMusicVideoDirectorsByName(strSearch, tempItems); }, 20339},
+      Entry{20365, [&strSearch, &tempItems, this]()
+            { m_database.GetEpisodesByPlot(strSearch, tempItems); }},
       Entry{20323,
             [&strSearch, &tempItems, this]() { m_database.GetMoviesByPlot(strSearch, tempItems); }},
+      Entry{40211, [&strSearch, &tempItems, this]()
+            { m_database.GetMovieExtrasByName(strSearch, tempItems); }},
   };
 
   std::for_each(entries.begin(), entries.end(), [this, &items, &tempItems](const auto& entry) {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

- The Search function doesn't work well for movies with versions and extras because of a disconnect between the videodb urls generated in GetMoviesByName (search function) and by GetMoviesByWhere (media list). The later appends /-2/ to enable navigation to the movie's versions and extras.

Due to the way the media window locates the search match, a modification of the `GetMoviesByName` doesn't show the chosen movie in a list of all movies but shows the movie's versions and extras, which I don't think is the expected result, and is inconsistent with other movie searches but I'm willing to change according to feedback.

I didn't find a really satisfying way to implement this and ended up allowing matching of partial videodb urls to avoid leaking too much knowledge about videodb urls for versions and extras all over the place.

- Created a new function `CVideoDatabase::GetMovieExtrasByName` to integrate extra names in the queries of the Search function. Piggy-backing on GetMoviesByWhere led to display inconsistencies and a confusing list of all extras of all movies. As a result, implemented a dedicated query, which is a bit faster and respects profiles. Selecting an extra goes to the list of extras of the movie.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Search function doesn't work well for movies with versions or extras. The movie is displayed in the search results but is not brought to view or selected in the media window.

Movie extras are not searchable.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Movies with/without versions, extras, in a set or not, with/without the setting to group set members in folders

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Search works for movies with versions or extras and returns matches from extra names.

## Screenshots (if appropriate):
"Big Buck Bunny" is a movie with multiple versions and some extras.

Go to the Search function
<img width="528" height="582" alt="image" src="https://github.com/user-attachments/assets/2fc98726-bd8d-4ee8-91c5-4fc508085eda" />

Search for "Bunny"
<img width="1103" height="273" alt="image" src="https://github.com/user-attachments/assets/e6cd2703-6307-4ab5-a1e3-fd206b12764e" />

Choose either item, before PR (selection remains at the top of the list):
<img width="1676" height="395" alt="image" src="https://github.com/user-attachments/assets/0749e58b-a7d2-4250-b2b0-acd7577002ab" />

Choose either item , with the PR (the movie is selected / scrolled into view when necessary)
<img width="1679" height="413" alt="image" src="https://github.com/user-attachments/assets/17166005-e4ae-4019-b52a-ce9c7fc6f282" />

New with the PR: search for "extra1"
<img width="1098" height="288" alt="image" src="https://github.com/user-attachments/assets/353096eb-bc36-430e-9363-a3d6d333b2f8" />

Choose the second item:
<img width="1431" height="706" alt="image" src="https://github.com/user-attachments/assets/81963377-bc98-4e91-a565-e17f34efc305" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
