### PR TITLE
[Filesystem] Add file stat cache.

### DIFF
--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -496,6 +496,21 @@ std::shared_ptr<XFILE::CBlurayDiscCache> CServiceBroker::GetBlurayDiscCache()
   return g_serviceBroker.m_blurayDiscCache;
 }
 
+void CServiceBroker::RegisterStatCache(const std::shared_ptr<XFILE::CStatCache>& cache)
+{
+  g_serviceBroker.m_statCache = cache;
+}
+
+void CServiceBroker::UnregisterStatCache()
+{
+  g_serviceBroker.m_statCache.reset();
+}
+
+std::shared_ptr<XFILE::CStatCache> CServiceBroker::GetStatCache()
+{
+  return g_serviceBroker.m_statCache;
+}
+
 CSubTagRegistryManager& CServiceBroker::GetSubTagRegistry()
 {
   return g_application.m_ServiceManager->GetSubTagRegistryManager();

--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -512,6 +512,21 @@ std::shared_ptr<XFILE::CBlurayDiscCache> CServiceBroker::GetBlurayDiscCache()
   return g_serviceBroker.m_blurayDiscCache;
 }
 
+void CServiceBroker::RegisterStatCache(const std::shared_ptr<XFILE::CStatCache>& cache)
+{
+  g_serviceBroker.m_statCache = cache;
+}
+
+void CServiceBroker::UnregisterStatCache()
+{
+  g_serviceBroker.m_statCache.reset();
+}
+
+std::shared_ptr<XFILE::CStatCache> CServiceBroker::GetStatCache()
+{
+  return g_serviceBroker.m_statCache;
+}
+
 CSubTagRegistryManager& CServiceBroker::GetSubTagRegistry()
 {
   return g_application.m_ServiceManager->GetSubTagRegistryManager();

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -125,6 +125,7 @@ class ISpeechRecognition;
 namespace XFILE
 {
 class CBlurayDiscCache;
+class CStatCache;
 }
 
 namespace KODI::UTILS::I18N
@@ -251,6 +252,10 @@ public:
   static void UnregisterBlurayDiscCache();
   static std::shared_ptr<XFILE::CBlurayDiscCache> GetBlurayDiscCache();
 
+  static void RegisterStatCache(const std::shared_ptr<XFILE::CStatCache>& cache);
+  static void UnregisterStatCache();
+  static std::shared_ptr<XFILE::CStatCache> GetStatCache();
+
 private:
   std::shared_ptr<CAppParams> m_appParams;
   std::unique_ptr<CLog> m_logging;
@@ -271,6 +276,7 @@ private:
   std::shared_ptr<CSlideShowDelegator> m_slideshowDelegator;
   std::shared_ptr<CDNSNameCache> m_dnsNameCache;
   std::shared_ptr<XFILE::CBlurayDiscCache> m_blurayDiscCache;
+  std::shared_ptr<XFILE::CStatCache> m_statCache;
 };
 
 XBMC_GLOBAL_REF(CServiceBroker, g_serviceBroker);

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -133,6 +133,7 @@ class ISpeechRecognition;
 namespace XFILE
 {
 class CBlurayDiscCache;
+class CStatCache;
 }
 
 namespace KODI::UTILS::I18N
@@ -264,6 +265,10 @@ public:
   static void UnregisterBlurayDiscCache();
   static std::shared_ptr<XFILE::CBlurayDiscCache> GetBlurayDiscCache();
 
+  static void RegisterStatCache(const std::shared_ptr<XFILE::CStatCache>& cache);
+  static void UnregisterStatCache();
+  static std::shared_ptr<XFILE::CStatCache> GetStatCache();
+
 private:
   std::shared_ptr<CAppParams> m_appParams;
   std::unique_ptr<CLog> m_logging;
@@ -285,6 +290,7 @@ private:
   std::shared_ptr<CSlideShowDelegator> m_slideshowDelegator;
   std::shared_ptr<CDNSNameCache> m_dnsNameCache;
   std::shared_ptr<XFILE::CBlurayDiscCache> m_blurayDiscCache;
+  std::shared_ptr<XFILE::CStatCache> m_statCache;
 };
 
 XBMC_GLOBAL_REF(CServiceBroker, g_serviceBroker);

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -62,6 +62,7 @@
 #include "filesystem/DirectoryCache.h"
 #include "filesystem/DllLibCurl.h"
 #include "filesystem/File.h"
+#include "filesystem/StatCache.h"
 #include "music/MusicFileItemClassify.h"
 #include "network/DNSNameCache.h"
 #include "network/NetworkFileItemClassify.h"
@@ -274,6 +275,8 @@ bool CApplication::Create()
   CServiceBroker::RegisterKeyboardLayoutManager(keyboardLayoutManager);
 
   CServiceBroker::RegisterDNSNameCache(std::make_shared<CDNSNameCache>());
+
+  CServiceBroker::RegisterStatCache(std::make_shared<XFILE::CStatCache>());
 
   m_ServiceManager = std::make_unique<CServiceManager>();
 
@@ -1753,6 +1756,8 @@ bool CApplication::Cleanup()
     }
 
     CServiceBroker::UnregisterDNSNameCache();
+
+    CServiceBroker::UnregisterStatCache();
 
     CServiceBroker::UnregisterKeyboardLayoutManager();
 

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -62,6 +62,7 @@
 #include "filesystem/DirectoryCache.h"
 #include "filesystem/DllLibCurl.h"
 #include "filesystem/File.h"
+#include "filesystem/StatCache.h"
 #include "music/MusicFileItemClassify.h"
 #include "network/DNSNameCache.h"
 #include "network/NetworkFileItemClassify.h"
@@ -281,6 +282,8 @@ bool CApplication::Create()
   CServiceBroker::RegisterKeyboardLayoutManager(keyboardLayoutManager);
 
   CServiceBroker::RegisterDNSNameCache(std::make_shared<CDNSNameCache>());
+
+  CServiceBroker::RegisterStatCache(std::make_shared<XFILE::CStatCache>());
 
   m_ServiceManager = std::make_unique<CServiceManager>();
 
@@ -1789,6 +1792,8 @@ bool CApplication::Cleanup()
     }
 
     CServiceBroker::UnregisterDNSNameCache();
+
+    CServiceBroker::UnregisterStatCache();
 
     CServiceBroker::UnregisterKeyboardLayoutManager();
 

--- a/xbmc/filesystem/CMakeLists.txt
+++ b/xbmc/filesystem/CMakeLists.txt
@@ -51,6 +51,7 @@ set(SOURCES AddonsDirectory.cpp
             SpecialProtocolDirectory.cpp
             SpecialProtocolFile.cpp
             StackDirectory.cpp
+            StatCache.cpp
             VideoDatabaseDirectory.cpp
             VideoDatabaseFile.cpp
             VirtualDirectory.cpp
@@ -117,6 +118,7 @@ set(HEADERS AddonsDirectory.h
             SpecialProtocolDirectory.h
             SpecialProtocolFile.h
             StackDirectory.h
+            StatCache.h
             VideoDatabaseDirectory.h
             VideoDatabaseFile.h
             VirtualDirectory.h

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -15,10 +15,9 @@
 #include "FileItemList.h"
 #include "PasswordManager.h"
 #include "ServiceBroker.h"
+#include "StatCache.h"
 #include "URL.h"
 #include "commons/Exception.h"
-#include "dialogs/GUIDialogBusy.h"
-#include "guilib/GUIWindowManager.h"
 #include "jobs/Job.h"
 #include "jobs/JobManager.h"
 #include "messaging/ApplicationMessenger.h"
@@ -35,6 +34,18 @@ using namespace XFILE;
 using namespace std::chrono_literals;
 
 #define TIME_TO_BUSY_DIALOG 500
+
+namespace
+{
+// a directory being created or removed changes its parent directory's own
+// metadata (e.g. modification time), so any cached stat for the parent is stale
+void InvalidateParentStat(const CURL& url)
+{
+  if (const auto statCache = CServiceBroker::GetStatCache())
+    // Strip options before computing the parent path
+    statCache->Remove(CURL(URIUtils::GetParentPath(url.GetWithoutOptions())));
+}
+} // namespace
 
 class CGetDirectory
 {
@@ -355,11 +366,17 @@ bool CDirectory::Create(const CURL& url)
 {
   try
   {
-    CURL authURL = URIUtils::AddCredentials(URIUtils::SubstitutePath(url));
+    const CURL realURL = URIUtils::SubstitutePath(url);
+    const CURL authURL = URIUtils::AddCredentials(realURL);
 
     std::unique_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(authURL));
     if (pDirectory && pDirectory->Create(authURL))
+    {
+      if (const auto statCache = CServiceBroker::GetStatCache())
+        statCache->Remove(realURL);
+      InvalidateParentStat(realURL);
       return true;
+    }
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
   catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
@@ -425,6 +442,10 @@ bool CDirectory::Remove(const CURL& url)
       if(pDirectory->Remove(authUrl))
       {
         g_directoryCache.ClearFile(realURL);
+        if (const auto statCache = CServiceBroker::GetStatCache())
+          // Drop any cached stats for child entries as well
+          statCache->RemoveRecursive(realURL);
+        InvalidateParentStat(realURL);
         return true;
       }
   }
@@ -447,6 +468,9 @@ bool CDirectory::RemoveRecursive(const CURL& url)
       if(pDirectory->RemoveRecursive(authUrl))
       {
         g_directoryCache.ClearFile(realURL);
+        if (const auto statCache = CServiceBroker::GetStatCache())
+          statCache->RemoveRecursive(realURL);
+        InvalidateParentStat(realURL);
         return true;
       }
   }

--- a/xbmc/filesystem/File.cpp
+++ b/xbmc/filesystem/File.cpp
@@ -16,6 +16,7 @@
 #include "FileFactory.h"
 #include "IFile.h"
 #include "ServiceBroker.h"
+#include "StatCache.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPowerHandling.h"
 #include "commons/Exception.h"
@@ -30,6 +31,18 @@
 #include "utils/log.h"
 
 using namespace XFILE;
+
+namespace
+{
+// creating, deleting or renaming a file changes its parent directory's own
+// metadata (e.g. modification time), so any cached stat for the parent is stale
+void InvalidateParentStat(const CURL& url)
+{
+  if (const auto statCache = CServiceBroker::GetStatCache())
+    // Strip options before computing the parent path
+    statCache->Remove(CURL(URIUtils::GetParentPath(url.GetWithoutOptions())));
+}
+} // namespace
 
 //////////////////////////////////////////////////////////////////////
 // Construction/Destruction
@@ -377,6 +390,7 @@ bool CFile::Open(const CURL& file, const unsigned int flags)
       m_bitStreamStats->Start();
     }
 
+    m_openedUrl = url;
     return true;
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
@@ -419,6 +433,11 @@ bool CFile::OpenForWrite(const CURL& file, bool bOverWrite)
     {
       // add this file to our directory cache (if it's stored)
       g_directoryCache.AddFile(url);
+      // the file is about to change, so any cached stat is now stale
+      if (const auto statCache = CServiceBroker::GetStatCache())
+        statCache->Remove(url);
+      InvalidateParentStat(url);
+      m_openedUrl = url;
       return true;
     }
     return false;
@@ -535,6 +554,12 @@ int CFile::Stat(const CURL& file, struct __stat64* buffer)
     return -1;
 
   CURL url(URIUtils::SubstitutePath(file));
+
+  const auto statCache = CServiceBroker::GetStatCache();
+
+  if (statCache && statCache->Get(url, buffer))
+    return 0;
+
   CURL authUrl = URIUtils::AddCredentials(url);
 
   try
@@ -542,7 +567,10 @@ int CFile::Stat(const CURL& file, struct __stat64* buffer)
     std::unique_ptr<IFile> pFile(CFileFactory::CreateLoader(url));
     if (!pFile)
       return -1;
-    return pFile->Stat(authUrl, buffer);
+    const int ret = pFile->Stat(authUrl, buffer);
+    if (ret == 0 && statCache)
+      statCache->Set(url, buffer);
+    return ret;
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
   catch (CRedirectException *pRedirectEx)
@@ -564,6 +592,8 @@ int CFile::Stat(const CURL& file, struct __stat64* buffer)
 
           if (!pImp->Stat(newAuthUrl, buffer))
           {
+            if (statCache)
+              statCache->Set(url, buffer);
             return 0;
           }
         }
@@ -572,6 +602,8 @@ int CFile::Stat(const CURL& file, struct __stat64* buffer)
       {
         if (pImp.get() && !pImp->Stat(authUrl, buffer))
         {
+          if (statCache)
+            statCache->Set(url, buffer);
           return 0;
         }
       }
@@ -676,6 +708,7 @@ void CFile::Close()
 
     m_pBuffer.reset();
     m_pFile.reset();
+    m_openedUrl.Reset();
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
   catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
@@ -725,7 +758,14 @@ int CFile::Truncate(int64_t iSize)
 
   try
   {
-    return m_pFile->Truncate(iSize);
+    const int ret = m_pFile->Truncate(iSize);
+    if (ret == 0)
+    {
+      // the file's size just changed, so any cached stat is now stale
+      if (const auto statCache = CServiceBroker::GetStatCache())
+        statCache->Remove(m_openedUrl);
+    }
+    return ret;
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
   catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
@@ -877,7 +917,14 @@ ssize_t CFile::Write(const void* lpBuf, size_t uiBufSize)
       return m_pFile->Write(&dummyBuf, 0);
     }
 
-    return m_pFile->Write(lpBuf, uiBufSize);
+    const ssize_t ret = m_pFile->Write(lpBuf, uiBufSize);
+    if (ret > 0)
+    {
+      // the file's content/size just changed, so any cached stat is now stale
+      if (const auto statCache = CServiceBroker::GetStatCache())
+        statCache->Remove(m_openedUrl);
+    }
+    return ret;
   }
   XBMCCOMMONS_HANDLE_UNCHECKED
   catch (...) { CLog::Log(LOGERROR, "{} - Unhandled exception", __FUNCTION__); }
@@ -905,6 +952,9 @@ bool CFile::Delete(const CURL& file)
     if(pFile->Delete(authUrl))
     {
       g_directoryCache.ClearFile(url);
+      if (const auto statCache = CServiceBroker::GetStatCache())
+        statCache->Remove(url);
+      InvalidateParentStat(url);
       return true;
     }
   }
@@ -940,6 +990,15 @@ bool CFile::Rename(const CURL& file, const CURL& newFile)
     {
       g_directoryCache.ClearFile(url);
       g_directoryCache.AddFile(urlnew);
+      if (const auto statCache = CServiceBroker::GetStatCache())
+      {
+        // Rename() is also used for directories, so any cached stats for entries below
+        // url/urlnew are now stale too, not just the entry for the (possible) directory itself
+        statCache->RemoveRecursive(url);
+        statCache->RemoveRecursive(urlnew);
+      }
+      InvalidateParentStat(url);
+      InvalidateParentStat(urlnew);
       return true;
     }
   }
@@ -962,12 +1021,19 @@ bool CFile::SetHidden(const CURL& file, bool hidden)
     CURL url(URIUtils::SubstitutePath(file));
     std::unique_ptr<IFile> pFile(CFileFactory::CreateLoader(url));
 
-    CURL authUrl = URIUtils::AddCredentials(std::move(url));
+    const CURL authUrl = URIUtils::AddCredentials(url);
 
     if (!pFile)
       return false;
 
-    return pFile->SetHidden(authUrl, hidden);
+    if (pFile->SetHidden(authUrl, hidden))
+    {
+      // st_mode can reflect the hidden attribute, so any cached stat is now stale
+      if (const auto statCache = CServiceBroker::GetStatCache())
+        statCache->Remove(url);
+      return true;
+    }
+    return false;
   }
   catch(...)
   {

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -207,6 +207,9 @@ private:
 
   unsigned int m_flags = 0;
   CURL                m_curl;
+  // URL of the currently open file (substituted, no credentials), used to invalidate
+  // the stat cache when the file is written to or truncated via this handle
+  CURL m_openedUrl;
   std::unique_ptr<IFile> m_pFile;
   std::unique_ptr<CFileStreamBuffer> m_pBuffer;
   std::unique_ptr<BitstreamStats> m_bitStreamStats;

--- a/xbmc/filesystem/StatCache.cpp
+++ b/xbmc/filesystem/StatCache.cpp
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "StatCache.h"
+
+#include "URL.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+
+#include <mutex>
+
+using namespace XFILE;
+
+namespace
+{
+std::string GetKey(const CURL& url)
+{
+  // Use the full URL, including options, as the key: for several protocols (eg. http)
+  // the options carry the query string which is part of the resource identity and must not be
+  // collapsed away (e.g. https://host/media?id=1 vs https://host/media?id=2).
+  // Only the path portion is normalized (trailing slash removed): the options are appended
+  // afterwards untouched, so a query string that happens to end in '/' isn't corrupted.
+  std::string path = url.GetWithoutOptions();
+  URIUtils::RemoveSlashAtEnd(path);
+  return path + url.GetOptions();
+}
+} // namespace
+
+bool CStatCache::Get(const CURL& url, struct __stat64* buffer)
+{
+  std::unique_lock lock(m_cs);
+
+  const std::string key = GetKey(url);
+
+  const auto i = m_cache.find(key);
+  if (i == m_cache.end())
+    return false;
+
+  CEntry& entry = i->second;
+  if (std::chrono::steady_clock::now() - entry.m_time > STAT_CACHE_TTL)
+  {
+    m_cache.erase(i);
+    return false;
+  }
+
+  *buffer = entry.m_stat;
+  entry.m_lastAccess = m_accessCounter++;
+  CLog::LogF(LOGDEBUG, "StatCache hit for {} ({} entries in cache, {} total hits)", key,
+             m_cache.size(), m_accessCounter);
+  return true;
+}
+
+void CStatCache::Set(const CURL& url, const struct __stat64* buffer)
+{
+  std::unique_lock lock(m_cs);
+
+  const std::string key = GetKey(url);
+  m_cache.erase(key);
+
+  CheckIfFull();
+
+  CEntry entry;
+  entry.m_stat = *buffer;
+  entry.m_time = std::chrono::steady_clock::now();
+  entry.m_lastAccess = m_accessCounter++;
+  m_cache.emplace(key, entry);
+}
+
+void CStatCache::Remove(const CURL& url)
+{
+  std::unique_lock lock(m_cs);
+
+  const std::string key = GetKey(url);
+  m_cache.erase(key);
+}
+
+void CStatCache::RemoveRecursive(const CURL& url)
+{
+  std::unique_lock lock(m_cs);
+
+  // Cache keys carry URL options, and options are a suffix of the URL
+  // rather than part of its path hierarchy.
+  // Remove options from both sides before comparing so a removed
+  // directory's descendants are matched.
+  std::string parentPath = url.GetWithoutOptions();
+  URIUtils::RemoveSlashAtEnd(parentPath);
+
+  std::erase_if(m_cache,
+                [&parentPath](const auto& i)
+                {
+                  std::string entryPath = CURL(i.first).GetWithoutOptions();
+                  URIUtils::RemoveSlashAtEnd(entryPath);
+                  return entryPath == parentPath || URIUtils::PathHasParent(entryPath, parentPath);
+                });
+}
+
+void CStatCache::Clear()
+{
+  std::unique_lock lock(m_cs);
+  m_cache.clear();
+}
+
+void CStatCache::CheckIfFull()
+{
+  // find the least recently accessed entry, and remove it if we're over the limit
+  if (m_cache.size() < MAX_CACHED_STATS)
+    return;
+
+  auto lastAccessed = m_cache.end();
+  for (auto i = m_cache.begin(); i != m_cache.end(); ++i)
+  {
+    if (lastAccessed == m_cache.end() || i->second.m_lastAccess < lastAccessed->second.m_lastAccess)
+      lastAccessed = i;
+  }
+  if (lastAccessed != m_cache.end())
+    m_cache.erase(lastAccessed);
+}

--- a/xbmc/filesystem/StatCache.h
+++ b/xbmc/filesystem/StatCache.h
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "threads/CriticalSection.h"
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include "PlatformDefs.h"
+
+class CURL;
+class TestStatCache;
+
+namespace XFILE
+{
+// Maximum number of stat results to keep in our cache
+static constexpr int MAX_CACHED_STATS{200};
+
+// How long a cached stat result is considered valid for
+static constexpr std::chrono::seconds STAT_CACHE_TTL{15};
+
+class CStatCache
+{
+public:
+  CStatCache() = default;
+  ~CStatCache() = default;
+  CStatCache(const CStatCache&) = delete;
+  CStatCache& operator=(const CStatCache&) = delete;
+
+  bool Get(const CURL& url, struct __stat64* buffer);
+  void Set(const CURL& url, const struct __stat64* buffer);
+  void Remove(const CURL& url);
+  // removes the entry for url as well as any entries for paths below it
+  void RemoveRecursive(const CURL& url);
+  void Clear();
+
+private:
+  friend class ::TestStatCache;
+
+  struct StringHash
+  {
+    using is_transparent = void; // Enables heterogeneous operations.
+    std::size_t operator()(std::string_view sv) const
+    {
+      std::hash<std::string_view> hasher;
+      return hasher(sv);
+    }
+  };
+
+  struct CEntry
+  {
+    struct __stat64 m_stat;
+    std::chrono::steady_clock::time_point m_time;
+    uint64_t m_lastAccess{0};
+  };
+
+  void CheckIfFull();
+
+  using StatCacheMap = std::unordered_map<std::string, CEntry, StringHash, std::equal_to<>>;
+  StatCacheMap m_cache;
+
+  mutable CCriticalSection m_cs;
+
+  uint64_t m_accessCounter{0};
+};
+} // namespace XFILE

--- a/xbmc/filesystem/test/CMakeLists.txt
+++ b/xbmc/filesystem/test/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES TestDirectory.cpp
             TestDiscDirectoryHelper.cpp
             TestFile.cpp
             TestFileFactory.cpp
+            TestStatCache.cpp
             TestZipFile.cpp
             TestZipManager.cpp)
 

--- a/xbmc/filesystem/test/TestStatCache.cpp
+++ b/xbmc/filesystem/test/TestStatCache.cpp
@@ -1,0 +1,240 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "URL.h"
+#include "filesystem/StatCache.h"
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "PlatformDefs.h"
+
+using namespace XFILE;
+using namespace std::chrono_literals;
+
+namespace
+{
+struct __stat64 MakeStat(long long size)
+{
+  struct __stat64 buffer
+  {
+  };
+  buffer.st_size = size;
+  return buffer;
+}
+} // namespace
+
+class TestStatCache : public ::testing::Test
+{
+protected:
+  void SetUp() override { cache = std::make_unique<CStatCache>(); }
+
+  void TearDown() override { cache.reset(); }
+
+  // Directly age every entry currently in the cache so it looks like it was
+  // stored STAT_CACHE_TTL (15s) or more in the past, without sleeping in the test.
+  void ExpireAllEntries() const
+  {
+    for (auto& entry : cache->m_cache)
+      entry.second.m_time -= (STAT_CACHE_TTL + 1s);
+  }
+
+  std::unique_ptr<CStatCache> cache;
+};
+
+TEST_F(TestStatCache, MissOnEmptyCache)
+{
+  struct __stat64 result
+  {
+  };
+  EXPECT_FALSE(cache->Get(CURL("smb://server/share/file.mkv"), &result));
+}
+
+TEST_F(TestStatCache, SetThenGetHits)
+{
+  CURL url("smb://server/share/file.mkv");
+  struct __stat64 stored = MakeStat(1234);
+  cache->Set(url, &stored);
+
+  struct __stat64 result
+  {
+  };
+  ASSERT_TRUE(cache->Get(url, &result));
+  EXPECT_EQ(1234, result.st_size);
+}
+
+TEST_F(TestStatCache, TrailingSlashIsNormalized)
+{
+  CURL urlWithSlash("smb://server/share/dir/");
+  struct __stat64 stored = MakeStat(1);
+  cache->Set(urlWithSlash, &stored);
+
+  struct __stat64 result
+  {
+  };
+  EXPECT_TRUE(cache->Get(CURL("smb://server/share/dir"), &result));
+}
+
+TEST_F(TestStatCache, DifferentOptionsAreDistinctKeys)
+{
+  CURL urlA("http://server/resource?id=1");
+  CURL urlB("http://server/resource?id=2");
+  CURL urlNoOptions("http://server/resource");
+
+  struct __stat64 storedA = MakeStat(111);
+  cache->Set(urlA, &storedA);
+
+  struct __stat64 result
+  {
+  };
+  EXPECT_TRUE(cache->Get(urlA, &result));
+  EXPECT_EQ(111, result.st_size);
+
+  // A different (or missing) query string is a different resource identity
+  // and must not be served from the entry cached for urlA.
+  EXPECT_FALSE(cache->Get(urlB, &result));
+  EXPECT_FALSE(cache->Get(urlNoOptions, &result));
+}
+
+TEST_F(TestStatCache, RemoveDropsExactEntry)
+{
+  CURL url("smb://server/share/file.mkv");
+  struct __stat64 stored = MakeStat(1);
+  cache->Set(url, &stored);
+
+  struct __stat64 result
+  {
+  };
+  ASSERT_TRUE(cache->Get(url, &result));
+
+  cache->Remove(url);
+  EXPECT_FALSE(cache->Get(url, &result));
+}
+
+TEST_F(TestStatCache, RemoveOnMissingEntryIsNoop)
+{
+  // Should not throw or affect unrelated entries.
+  CURL other("smb://server/share/other.mkv");
+  struct __stat64 stored = MakeStat(1);
+  cache->Set(other, &stored);
+
+  cache->Remove(CURL("smb://server/share/nonexistent.mkv"));
+
+  struct __stat64 result
+  {
+  };
+  EXPECT_TRUE(cache->Get(other, &result));
+}
+
+TEST_F(TestStatCache, RemoveRecursiveRemovesSelfAndDescendants)
+{
+  CURL dirUrl("smb://server/share/dir");
+  CURL childUrl("smb://server/share/dir/child.mkv");
+  CURL grandchildUrl("smb://server/share/dir/sub/grandchild.mkv");
+  CURL unrelatedUrl("smb://server/share/other.mkv");
+
+  struct __stat64 stored = MakeStat(1);
+  cache->Set(dirUrl, &stored);
+  cache->Set(childUrl, &stored);
+  cache->Set(grandchildUrl, &stored);
+  cache->Set(unrelatedUrl, &stored);
+
+  cache->RemoveRecursive(dirUrl);
+
+  struct __stat64 result
+  {
+  };
+  EXPECT_FALSE(cache->Get(dirUrl, &result));
+  EXPECT_FALSE(cache->Get(childUrl, &result));
+  EXPECT_FALSE(cache->Get(grandchildUrl, &result));
+  EXPECT_TRUE(cache->Get(unrelatedUrl, &result));
+}
+
+TEST_F(TestStatCache, RemoveRecursiveIgnoresOptions)
+{
+  // Cache keys carry URL options, but RemoveRecursive must still find and
+  // remove entries whose options differ from (or are absent from) the URL
+  // it's asked to invalidate, since options aren't part of the path hierarchy.
+  // Note: '?' is only parsed as URL options for a handful of protocols
+  // (eg. nfs, http) - see CURL::Parse - so use one of those here.
+  CURL dirUrl("nfs://server/share/dir?some=option");
+  CURL childNoOptions("nfs://server/share/dir/child.mkv");
+
+  struct __stat64 stored = MakeStat(1);
+  cache->Set(dirUrl, &stored);
+  cache->Set(childNoOptions, &stored);
+
+  cache->RemoveRecursive(CURL("nfs://server/share/dir"));
+
+  struct __stat64 result
+  {
+  };
+  EXPECT_FALSE(cache->Get(dirUrl, &result));
+  EXPECT_FALSE(cache->Get(childNoOptions, &result));
+}
+
+TEST_F(TestStatCache, ClearRemovesEverything)
+{
+  CURL url1("smb://server/share/file1.mkv");
+  CURL url2("smb://server/share/file2.mkv");
+  struct __stat64 stored = MakeStat(1);
+  cache->Set(url1, &stored);
+  cache->Set(url2, &stored);
+
+  cache->Clear();
+
+  struct __stat64 result
+  {
+  };
+  EXPECT_FALSE(cache->Get(url1, &result));
+  EXPECT_FALSE(cache->Get(url2, &result));
+}
+
+TEST_F(TestStatCache, EntryExpiresAfterTTL)
+{
+  CURL url("smb://server/share/file.mkv");
+  struct __stat64 stored = MakeStat(1);
+  cache->Set(url, &stored);
+
+  struct __stat64 result
+  {
+  };
+  ASSERT_TRUE(cache->Get(url, &result));
+
+  ExpireAllEntries();
+
+  EXPECT_FALSE(cache->Get(url, &result));
+}
+
+TEST_F(TestStatCache, EvictsLeastRecentlyUsedWhenFull)
+{
+  // MAX_CACHED_STATS is 200; fill the cache past that limit with unique
+  // entries and expect the oldest (least recently accessed) to be evicted.
+  struct __stat64 stored = MakeStat(1);
+  for (int i = 0; i < MAX_CACHED_STATS; ++i)
+    cache->Set(CURL("smb://server/share/file" + std::to_string(i) + ".mkv"), &stored);
+
+  // Touch file0 so it becomes the most-recently-accessed entry and should
+  // survive the eviction that happens when the next new entry is added.
+  struct __stat64 result
+  {
+  };
+  ASSERT_TRUE(cache->Get(CURL("smb://server/share/file0.mkv"), &result));
+
+  cache->Set(CURL("smb://server/share/file" + std::to_string(MAX_CACHED_STATS) + ".mkv"), &stored);
+
+  EXPECT_TRUE(cache->Get(CURL("smb://server/share/file0.mkv"), &result));
+  EXPECT_TRUE(cache->Get(
+      CURL("smb://server/share/file" + std::to_string(MAX_CACHED_STATS) + ".mkv"), &result));
+  // file1 was the least recently accessed entry at the time of the new
+  // insertion (file0 was refreshed, file2+ are newer), so it gets evicted.
+  EXPECT_FALSE(cache->Get(CURL("smb://server/share/file1.mkv"), &result));
+}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Cache CFile:Stats for 15 seconds (max 200 in cache).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Even with optimisations to scraping, there are still instances where the same file can be stat'd twice.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally. No difference in scraping. Log line shows cache is used. Tests added.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **New feature** (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
