### PR TITLE
docs: fix stale Android debug launch command in README.Android.md

### DIFF
--- a/docs/README.Android.md
+++ b/docs/README.Android.md
@@ -354,7 +354,7 @@ adb -e install -r images/xbmcapp-debug.apk
 
 Launch Kodi on Android Emulator without the GUI:
 ```
-adb shell am start -a android.intent.action.MAIN -n org.xbmc.xbmc/android.app.NativeActivity
+adb shell am start -n org.xbmc.kodi/org.xbmc.kodi.Splash
 ```
 
 Kill a misbehaving Kodi:


### PR DESCRIPTION
## Description
The package is org.xbmc.kodi, not org.xbmc.xbmc, and the actual launchable component is .Splash (org.xbmc.kodi.Splash) - android.app.NativeActivity is just the framework base class Kodi's own .Main extends via the NDK glue, not a real component name. Confirmed against version.txt's APP_PACKAGE and tools/android/packaging/xbmc/AndroidManifest.xml.in while writing the adb-based Android E2E launcher, which needs the same package/activity names.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
