### PR TITLE
[VideoInfoScanner] Ensure that empty directories with content in subdirectories (eg. Disc 1 etc.) are hashed so they are not rescanned on every library update.

### DIFF
--- a/xbmc/InfoScanner.h
+++ b/xbmc/InfoScanner.h
@@ -70,9 +70,10 @@ protected:
     Completed
   };
 
-  enum class ContentFound : bool
+  enum class ContentFound
   {
     None,
+    ExistingContentFound,
     NewContentFound
   };
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -370,6 +370,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     CFileItemList items;
     bool foundDirectly = false;
     bool bSkip = false;
+    bool bExistingContent = false;
 
     SScanSettings settings;
     ScraperPtr info =
@@ -443,6 +444,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
         CLog::Log(LOGDEBUG, "VideoInfoScanner: Skipping dir '{}' due to no change{}",
                   CURL::GetRedacted(strDirectory), !fastHash.empty() ? " (fasthash)" : "");
         bSkip = true;
+
+        // Has content
+        if (!hash.empty())
+          bExistingContent = true;
       }
       else if (hash.empty())
       { // directory empty or non-existent - add to clean list and skip
@@ -532,7 +537,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
     if (m_handle)
       OnDirectoryScanned(strDirectory);
 
-    bool foundSomethingInArchive = false;
+    bool foundSomethingInSubfolder = false;
     for (int i = 0; i < items.Size(); ++i)
     {
       CFileItemPtr pItem = items[i];
@@ -565,33 +570,37 @@ CVideoInfoScanner::~CVideoInfoScanner()
           m_bStop = true;
         }
         // If this subdirectory is an archive and content was found inside it,
-        // store the hash for the physical parent directory instead of the archive (eg. rar://) path.
+        // or if it is empty but there are subdirectories with content (eg. Disc 1),
+        // store the hash for the physical parent directory instead of the archive (eg. rar://) path,
+        // or no path.
         // This ensures change detection works correctly on the real filesystem path.
         else if (!foundSomething && !m_bStop &&
-                 foundContentOnRecursion == ContentFound::NewContentFound &&
-                 (content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS) &&
-                 URIUtils::IsArchive(CURL(pItem->GetPath())))
+                 (foundContentOnRecursion == ContentFound::NewContentFound ||
+                  foundContentOnRecursion == ContentFound::ExistingContentFound) &&
+                 (content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS))
         {
-          foundSomethingInArchive = true;
+          foundSomethingInSubfolder = true;
         }
       }
     }
 
-    // If the direct scan found nothing but an archive subfolder scan did,
+    // If the direct scan found nothing but a subfolder scan did,
     // store the hash for the physical directory so it is used for change detection
-    // rather than the archive (eg. rar://) virtual path.
-    if (!bSkip && !m_bStop && foundSomethingInArchive && !URIUtils::IsArchive(CURL(strDirectory)))
+    // rather than the archive (eg. rar://) virtual path, or not storing path at all.
+    if (!bSkip && !m_bStop && foundSomethingInSubfolder && !URIUtils::IsArchive(CURL(strDirectory)))
     {
       m_database.SetPathHash(strDirectory, hash);
-      CLog::LogF(LOGDEBUG,
-                 "Stored hash for physical dir '{}' after finding content in "
-                 "archive subfolder",
+      CLog::LogF(LOGDEBUG, "Stored hash for physical dir '{}' after finding content in a subfolder",
                  CURL::GetRedacted(strDirectory));
     }
 
-    return std::make_pair(m_bStop ? ScanComplete::Stopped : ScanComplete::Completed,
-                          foundSomething || foundSomethingInArchive ? ContentFound::NewContentFound
-                                                                    : ContentFound::None);
+    ContentFound contentFound = ContentFound::None;
+    if (foundSomething)
+      contentFound = ContentFound::NewContentFound;
+    else if (bExistingContent || foundSomethingInSubfolder)
+      contentFound = ContentFound::ExistingContentFound;
+
+    return std::make_pair(m_bStop ? ScanComplete::Stopped : ScanComplete::Completed, contentFound);
   }
 
   bool CVideoInfoScanner::UpdateSetInTag(CVideoInfoTag& tag)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Hash empty folders with content in subfolders the same way archives are handled.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed when reviewing #28645 that folders that are empty but contain subfolders with content are not hashed and therefore re-examined every update.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

Before:
```
2026-07-21 17:47:59.058 T:37912   debug <general>: VideoInfoScanner: Scanning dir 'D:\Local Tests\Movies\Terminator 2 Judgement Day (1991)\' as not in the database
2026-07-21 17:47:59.064 T:37912   debug <general>: VideoInfoScanner: No (new) information was found in dir D:\Local Tests\Movies\Terminator 2 Judgement Day (1991)\
```

After:
```
2026-07-21 20:09:33.426 T:5320    debug <general>: VideoInfoScanner: Skipping dir 'D:\Local Tests\Movies\Terminator 2 Judgement Day (1991)\' due to no change (fasthash)
2026-07-21 20:09:33.427 T:5320    debug <general>: VideoInfoScanner: Skipping dir 'D:\Local Tests\Movies\Terminator 2 Judgement Day (1991)\Disc 1\' due to no change (fasthash)
2026-07-21 20:09:33.429 T:5320    debug <general>: VideoInfoScanner: Skipping dir 'D:\Local Tests\Movies\Terminator 2 Judgement Day (1991)\Disc 2\' due to no change (fasthash)
```

Entry in path table:
<img width="2383" height="174" alt="image" src="https://github.com/user-attachments/assets/1e4d11fa-6170-4d14-8387-b309754f3fc6" />

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
