### PR TITLE
[Video][Music] Optimise reading of nfos.

### DIFF
--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -35,6 +35,17 @@ std::vector<ScraperPtr> GetScrapers(AddonType type, const ScraperPtr& selectedSc
 
 } // unnamed namespace
 
+const TiXmlElement* CNfoFile::GetRootElement() const
+{
+  if (!m_xmlParsed)
+  {
+    if (m_headPos < m_doc.size())
+      m_xmlDoc.Parse(m_doc.substr(m_headPos), TIXML_ENCODING_UNKNOWN);
+    m_xmlParsed = true;
+  }
+  return m_xmlDoc.RootElement();
+}
+
 CInfoScanner::InfoType CNfoFile::TryParsing(ADDON::AddonType addonType) const
 {
   using enum CInfoScanner::InfoType;
@@ -42,12 +53,7 @@ CInfoScanner::InfoType CNfoFile::TryParsing(ADDON::AddonType addonType) const
 
   // Classification only needs the root element (to avoid a full ParseNative)
   // and its "override" attribute (for videos)
-  if (m_headPos >= m_doc.size())
-    return NONE;
-
-  CXBMCTinyXML doc;
-  doc.Parse(m_doc.substr(m_headPos), TIXML_ENCODING_UNKNOWN);
-  const TiXmlElement* root = doc.RootElement();
+  const TiXmlElement* root = GetRootElement();
   if (!root)
     return NONE;
 
@@ -180,6 +186,8 @@ void CNfoFile::Close()
   m_doc.clear();
   m_headPos = 0;
   m_scurl.Clear();
+  m_xmlDoc.Clear();
+  m_xmlParsed = false;
 }
 
 namespace

--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -11,16 +11,17 @@
 
 #include "NfoFile.h"
 
-#include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "addons/AddonManager.h"
 #include "addons/AddonSystemSettings.h"
 #include "addons/addoninfo/AddonType.h"
 #include "filesystem/File.h"
-#include "music/Album.h"
-#include "music/Artist.h"
+#include "utils/StringUtils.h"
+#include "utils/XMLUtils.h"
 #include "video/VideoInfoDownloader.h"
 
+#include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -39,21 +40,25 @@ CInfoScanner::InfoType CNfoFile::TryParsing(ADDON::AddonType addonType) const
   using enum CInfoScanner::InfoType;
   using enum ADDON::AddonType;
 
-  if (addonType == SCRAPER_ALBUMS)
-  {
-    CAlbum album;
-    return GetDetails(album) ? FULL : NONE;
-  }
-  if (addonType == SCRAPER_ARTISTS)
-  {
-    CArtist artist;
-    return GetDetails(artist) ? FULL : NONE;
-  }
+  // Classification only needs the root element (to avoid a full ParseNative)
+  // and its "override" attribute (for videos)
+  if (m_headPos >= m_doc.size())
+    return NONE;
+
+  CXBMCTinyXML doc;
+  doc.Parse(m_doc.substr(m_headPos), TIXML_ENCODING_UNKNOWN);
+  const TiXmlElement* root = doc.RootElement();
+  if (!root)
+    return NONE;
+
+  if (addonType == SCRAPER_ALBUMS || addonType == SCRAPER_ARTISTS)
+    return FULL;
+
   if (addonType == SCRAPER_MOVIES || addonType == SCRAPER_TVSHOWS ||
       addonType == SCRAPER_MUSICVIDEOS)
   {
-    if (CVideoInfoTag details; GetDetails(details))
-      return details.GetOverride() ? OVERRIDE : FULL;
+    return StringUtils::EqualsNoCase(XMLUtils::GetAttribute(root, "override"), "true") ? OVERRIDE
+                                                                                       : FULL;
   }
   return NONE;
 }

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -36,15 +36,18 @@ public:
   template<class T>
   bool GetDetails(T& details, const char* document = nullptr, bool prioritise = false) const
   {
-    CXBMCTinyXML doc;
     if (document)
+    {
+      CXBMCTinyXML doc;
       doc.Parse(document, TIXML_ENCODING_UNKNOWN);
-    else if (m_headPos < m_doc.size())
-      doc.Parse(m_doc.substr(m_headPos), TIXML_ENCODING_UNKNOWN);
-    else
+      return details.Load(doc.RootElement(), true, prioritise);
+    }
+
+    const TiXmlElement* root = GetRootElement();
+    if (!root)
       return false;
 
-    return details.Load(doc.RootElement(), true, prioritise);
+    return details.Load(root, true, prioritise);
   }
 
   void Close();
@@ -61,10 +64,16 @@ private:
                                                  const ADDON::ScraperPtr& info);
   bool SeekToMovieIndex(int index);
 
+  // Returns the root element of m_doc (from m_headPos)
+  const TiXmlElement* GetRootElement() const;
+
   std::string m_doc;
   size_t m_headPos = 0;
   ADDON::ScraperPtr m_info;
   CScraperUrl m_scurl;
+
+  mutable CXBMCTinyXML m_xmlDoc;
+  mutable bool m_xmlParsed = false;
 
   int Load(const CURL&);
 };

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -83,16 +83,20 @@ CInfoScanner::InfoType CVideoTagLoaderNFO::Load(CVideoInfoTag& tag,
   CInfoScanner::InfoType result = NONE;
   if (m_info)
   {
-    CNfoFile nfoReader;
-    result = nfoReader.Create(m_path, m_info, GetNfoIndex(m_item, m_info));
+    if (!m_nfoParsed)
+    {
+      m_parseResult = m_nfoReader.Create(m_path, m_info, GetNfoIndex(m_item, m_info));
+      m_nfoParsed = true;
+    }
+    result = m_parseResult;
 
     if (result == FULL || result == COMBINED || result == OVERRIDE)
-      nfoReader.GetDetails(tag, nullptr, prioritise);
+      m_nfoReader.GetDetails(tag, nullptr, prioritise);
 
     if (result == URL || result == COMBINED)
     {
-      m_url = nfoReader.ScraperUrl();
-      m_info = nfoReader.GetScraperInfo();
+      m_url = m_nfoReader.ScraperUrl();
+      m_info = m_nfoReader.GetScraperInfo();
     }
   }
 

--- a/xbmc/video/tags/VideoTagLoaderNFO.h
+++ b/xbmc/video/tags/VideoTagLoaderNFO.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "IVideoInfoTagLoader.h"
+#include "NfoFile.h"
 
 #include <string>
 #include <vector>
@@ -39,4 +40,10 @@ protected:
   std::string FindNFO(const CFileItem& item, bool movieFolder) const;
 
   std::string m_path; //!< Path to nfo file
+
+private:
+  // Cache of the parsed nfo file, populated on the first call to Load()
+  CNfoFile m_nfoReader;
+  bool m_nfoParsed = false;
+  CInfoScanner::InfoType m_parseResult = CInfoScanner::InfoType::NONE;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

```
| Content | Result   | Disk reads | DOM parses | Field-walks | Scraper-URL search |
|---------|----------|------------|------------|-------------|---------------------|
| Video   | FULL     | 1 -> 1     | 2 -> 1     | 2 -> 1      | 1 -> 1              |
| Video   | COMBINED | 2 -> 1     | 4 -> 1     | 4 -> 2      | 2 -> 1              |
| Video   | OVERRIDE | 2 -> 1     | 4 -> 1     | 4 -> 2      | 2 -> 1              |
| Music   | FULL     | 1 -> 1     | 2 -> 1     | 2 -> 1      | 1 -> 1              |
| Music   | COMBINED | 1 -> 1     | 2 -> 1     | 1 -> 1      | 1 -> 1              |
| Music   | OVERRIDE | 1 -> 1     | 2 -> 1     | 1 -> 1      | 1 -> 1              |
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Investigating scraping speed.

Noticed that a full ParseNative was called simply to determine if override nfo (set in XML root).
Note that ParseNative can legitimately be called twice - with different prioritise values.

Video Combined/Override nfos were read twice from disc (once in ReadInfoTag and once in VideoInfoScraper::GetDetails)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
