### PR TITLE
guilib: fix typo in GL extension preprocessor checks

### DIFF
--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -27,7 +27,7 @@ namespace
 // clang-format off
 constexpr auto TextureMapping =  make_map<KD_TEX_FMT, TextureFormat>(
 {
-#if defined(GL_EXT_texture_sRGB_R8) && (GL_EXT_texture_sRGB_RG8)
+#if defined(GL_EXT_texture_sRGB_R8) && defined(GL_EXT_texture_sRGB_RG8)
   {KD_TEX_FMT_SDR_R8, {GL_R8, GL_SR8_EXT, GL_RED}},
   {KD_TEX_FMT_SDR_RG8, {GL_RG8, GL_SRG8_EXT, GL_RG}},
 #else
@@ -50,7 +50,7 @@ constexpr auto TextureMapping =  make_map<KD_TEX_FMT, TextureFormat>(
   {KD_TEX_FMT_HDR_RGBA16f, {GL_RGBA16F, GL_FALSE, GL_RGBA, GL_HALF_FLOAT}},
 #endif
 
-#if defined(GL_EXT_texture_compression_s3tc) && (GL_EXT_texture_sRGB)
+#if defined(GL_EXT_texture_compression_s3tc) && defined(GL_EXT_texture_sRGB)
   {KD_TEX_FMT_S3TC_RGB8, {GL_COMPRESSED_RGB_S3TC_DXT1_EXT, GL_COMPRESSED_SRGB_S3TC_DXT1_EXT}},
   {KD_TEX_FMT_S3TC_RGB8_A1, {GL_COMPRESSED_RGBA_S3TC_DXT1_EXT, GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT}},
   {KD_TEX_FMT_S3TC_RGB8_A4, {GL_COMPRESSED_RGBA_S3TC_DXT3_EXT, GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT}},

--- a/xbmc/guilib/TextureGL.cpp
+++ b/xbmc/guilib/TextureGL.cpp
@@ -85,7 +85,7 @@ constexpr auto TextureMapping =  make_map<KD_TEX_FMT, TextureFormat>(
   {KD_TEX_FMT_ETC2_RGBA8, {GL_COMPRESSED_RGBA8_ETC2_EAC, GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC}},
 #endif
 
-#if defined(GL_KHR_texture_compression_astc_ldr) || (GL_KHR_texture_compression_astc_hdr)
+#if defined(GL_KHR_texture_compression_astc_ldr) || defined(GL_KHR_texture_compression_astc_hdr)
   {KD_TEX_FMT_ASTC_LDR_4x4, {GL_COMPRESSED_RGBA_ASTC_4x4_KHR, GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR}},
   {KD_TEX_FMT_ASTC_LDR_5x4, {GL_COMPRESSED_RGBA_ASTC_5x4_KHR, GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR}},
   {KD_TEX_FMT_ASTC_LDR_5x5, {GL_COMPRESSED_RGBA_ASTC_5x5_KHR, GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR}},
@@ -318,7 +318,7 @@ GLenum CGLTexture::GetSwizzleTarget()
   // GL_TEXTURE_SWIZZLE_RGBA and GL_TEXTURE_SWIZZLE_RGBA_EXT should be the same token, but just
   // to be sure we cache whichever one this GL implementation actually supports.
   m_swizzleTarget = GL_FALSE;
-#if defined(GL_VERSION_3_3) || (GL_ARB_texture_swizzle)
+#if defined(GL_VERSION_3_3) || defined(GL_ARB_texture_swizzle)
   if (m_isOglVersion33orNewer ||
       CGLExtensions::IsExtensionSupported(CGLExtensions::ARB_texture_swizzle))
     m_swizzleTarget = GL_TEXTURE_SWIZZLE_RGBA;

--- a/xbmc/guilib/TextureGLES.cpp
+++ b/xbmc/guilib/TextureGLES.cpp
@@ -65,7 +65,7 @@ constexpr auto TextureMappingGLES20 = make_map<KD_TEX_FMT, TextureFormat>(
 #if defined(GL_ES_VERSION_3_0)
 constexpr auto TextureMappingGLES30 = make_map<KD_TEX_FMT, TextureFormat>(
 {
-#if defined(GL_EXT_texture_sRGB_R8) && (GL_EXT_texture_sRGB_RG8) // in gl2ext.h, but spec says >= 3.0
+#if defined(GL_EXT_texture_sRGB_R8) && defined(GL_EXT_texture_sRGB_RG8) // in gl2ext.h, but spec says >= 3.0
   {KD_TEX_FMT_SDR_R8, {GL_R8, GL_SR8_EXT, GL_RED}},
   {KD_TEX_FMT_SDR_RG8, {GL_RG8, GL_SRG8_EXT, GL_RG}},
 #else
@@ -98,7 +98,7 @@ constexpr auto TextureMappingGLES30 = make_map<KD_TEX_FMT, TextureFormat>(
 // Common GLES extensions (texture compression)
 constexpr auto TextureMappingGLESExtensions = make_map<KD_TEX_FMT, TextureFormat>(
 {
-#if defined(GL_EXT_texture_compression_s3tc) && (GL_EXT_texture_compression_s3tc_srgb)
+#if defined(GL_EXT_texture_compression_s3tc) && defined(GL_EXT_texture_compression_s3tc_srgb)
   {KD_TEX_FMT_S3TC_RGB8, {GL_COMPRESSED_RGB_S3TC_DXT1_EXT, GL_COMPRESSED_SRGB_S3TC_DXT1_EXT}},
   {KD_TEX_FMT_S3TC_RGB8_A1, {GL_COMPRESSED_RGBA_S3TC_DXT1_EXT, GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT}},
   {KD_TEX_FMT_S3TC_RGB8_A4, {GL_COMPRESSED_RGBA_S3TC_DXT3_EXT, GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT}},

--- a/xbmc/guilib/TextureGLES.cpp
+++ b/xbmc/guilib/TextureGLES.cpp
@@ -45,7 +45,7 @@ constexpr auto TextureMappingGLES20 = make_map<KD_TEX_FMT, TextureFormat>(
   {KD_TEX_FMT_SDR_RGBA8, {GL_RGBA}},
 #endif
 
-#if defined(GL_EXT_texture_format_BGRA8888) || (GL_IMG_texture_format_BGRA8888)
+#if defined(GL_EXT_texture_format_BGRA8888) || defined(GL_IMG_texture_format_BGRA8888)
   {KD_TEX_FMT_SDR_BGRA8, {GL_BGRA_EXT}},
 #endif
 
@@ -123,7 +123,7 @@ constexpr auto TextureMappingGLESExtensions = make_map<KD_TEX_FMT, TextureFormat
   {KD_TEX_FMT_BPTC_RGBA8, {GL_COMPRESSED_RGBA_BPTC_UNORM_EXT, GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT}},
 #endif
 
-#if defined(GL_KHR_texture_compression_astc_ldr) || (GL_KHR_texture_compression_astc_hdr)
+#if defined(GL_KHR_texture_compression_astc_ldr) || defined(GL_KHR_texture_compression_astc_hdr)
   {KD_TEX_FMT_ASTC_LDR_4x4, {GL_COMPRESSED_RGBA_ASTC_4x4_KHR, GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR}},
   {KD_TEX_FMT_ASTC_LDR_5x4, {GL_COMPRESSED_RGBA_ASTC_5x4_KHR, GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR}},
   {KD_TEX_FMT_ASTC_LDR_5x5, {GL_COMPRESSED_RGBA_ASTC_5x5_KHR, GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR}},


### PR DESCRIPTION
Several #if conditions used `|| (EXT_NAME)` instead of `|| defined(EXT_NAME)`, which always evaluates true regardless of whether the extension macro is actually defined.
