### PR TITLE
Peripherals cec per location settings

### DIFF
--- a/xbmc/peripherals/PeripheralTypes.h
+++ b/xbmc/peripherals/PeripheralTypes.h
@@ -345,10 +345,16 @@ public:
 
   PeripheralType m_type = PERIPHERAL_UNKNOWN;
   std::string m_strLocation;
+  // Stable physical/topology location, used to key per-adapter settings. Empty if unavailable.
+  std::string m_strPhysicalLocation;
   int m_iVendorId = 0;
   int m_iProductId = 0;
   PeripheralType m_mappedType = PERIPHERAL_UNKNOWN;
   std::string m_strDeviceName;
+  // Generic name from the peripherals.xml mapping. Kept separate from m_strDeviceName,
+  // which a bus may override with a per-adapter name, so a settings file keyed by the
+  // generic name can still be found.
+  std::string m_strMappedDeviceName;
   PeripheralBusType m_busType = PERIPHERAL_BUS_UNKNOWN;
   PeripheralBusType m_mappedBusType = PERIPHERAL_BUS_UNKNOWN;
   unsigned int m_iSequence = 0; // when more than one adapter of the same type is found

--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -469,6 +469,7 @@ bool CPeripherals::GetMappingForDevice(const CPeripheralBus& bus,
                 strProductId, mapping.m_strDeviceName,
                 PeripheralTypeTranslator::TypeToString(mapping.m_mappedTo));
       result.m_mappedType = mapping.m_mappedTo;
+      result.m_strMappedDeviceName = mapping.m_strDeviceName;
       if (result.m_strDeviceName.empty() && !mapping.m_strDeviceName.empty())
         result.m_strDeviceName = mapping.m_strDeviceName;
       return true;

--- a/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
+++ b/xbmc/peripherals/bus/virtual/PeripheralBusCEC.cpp
@@ -44,7 +44,17 @@ bool CPeripheralBusCEC::PerformDeviceScan(PeripheralScanResults& results)
     result.m_iVendorId = deviceList[iDevicePtr].iVendorId;
     result.m_iProductId = deviceList[iDevicePtr].iProductId;
     result.m_strLocation = deviceList[iDevicePtr].strComName;
+    // physical device path, stable across reboots/replugs unlike the com port name
+    result.m_strPhysicalLocation = deviceList[iDevicePtr].strComPath;
+    if (result.m_strPhysicalLocation.empty())
+      result.m_strPhysicalLocation = deviceList[iDevicePtr].strComName;
     result.m_type = PERIPHERAL_CEC;
+
+    // Display name assigned by libCEC (e.g. "HDMI 1"/"HDMI 2" for the kernel CEC
+    // nodes on a multi-HDMI board, "USB-CEC Adapter N" for USB), so multiple
+    // adapters aren't listed as identical entries. Left empty for adapters libCEC
+    // didn't name, which then fall back to the generic peripherals.xml mapping.
+    result.m_strDeviceName = deviceList[iDevicePtr].strDeviceName;
 
     // override the bus type, so users don't have to reconfigure their adapters
     switch (deviceList[iDevicePtr].adapterType)

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -35,6 +35,7 @@
 #include "utils/log.h"
 
 #include <utility>
+#include <vector>
 
 using namespace KODI;
 using namespace JOYSTICK;
@@ -70,6 +71,8 @@ CPeripheral::CPeripheral(CPeripherals& manager,
 {
   PeripheralTypeTranslator::FormatHexString(scanResult.m_iVendorId, m_strVendorId);
   PeripheralTypeTranslator::FormatHexString(scanResult.m_iProductId, m_strProductId);
+  m_strPhysicalLocation = scanResult.m_strPhysicalLocation;
+  m_strMappedDeviceName = scanResult.m_strMappedDeviceName;
   if (scanResult.m_iSequence > 0)
   {
     m_strFileLocation =
@@ -170,28 +173,95 @@ bool CPeripheral::Initialise(void)
 
   m_manager.GetSettingsFromMapping(*this);
 
+  const std::string busStr = PeripheralTypeTranslator::BusTypeToString(m_mappedBusType);
+
   std::string safeDeviceName = m_strDeviceName;
   StringUtils::Replace(safeDeviceName, ' ', '_');
+  safeDeviceName = CUtil::MakeLegalFileName(std::move(safeDeviceName), LegalPath::WIN32_COMPAT);
 
+  // Disambiguates settings for adapters of the same model (identical vendor/product/name).
+  std::string safeLocation = m_strPhysicalLocation;
+  StringUtils::Replace(safeLocation, ' ', '_');
+  safeLocation = CUtil::MakeLegalFileName(std::move(safeLocation), LegalPath::WIN32_COMPAT);
+
+  // A settings file may be keyed by either the bus-reported per-adapter name
+  // (e.g. "HDMI 1") or the generic peripherals.xml mapping name, so both are tried below.
+  std::string safeMappedDeviceName = m_strMappedDeviceName;
+  StringUtils::Replace(safeMappedDeviceName, ' ', '_');
+  safeMappedDeviceName =
+      CUtil::MakeLegalFileName(std::move(safeMappedDeviceName), LegalPath::WIN32_COMPAT);
+
+  // Candidate settings files that don't encode a physical location, in preference order,
+  // so settings saved without a location are still found. The first is also the name
+  // written back when this adapter has no location (see the fallback below).
+  std::vector<std::string> legacyCandidates;
   if (m_iVendorId == 0x0000 && m_iProductId == 0x0000)
   {
-    m_strSettingsFile = StringUtils::Format(
-        "special://profile/peripheral_data/{}_{}.xml",
-        PeripheralTypeTranslator::BusTypeToString(m_mappedBusType),
-        CUtil::MakeLegalFileName(std::move(safeDeviceName), LegalPath::WIN32_COMPAT));
+    legacyCandidates.emplace_back(
+        StringUtils::Format("special://profile/peripheral_data/{}_{}.xml", busStr, safeDeviceName));
+
+    if (!safeMappedDeviceName.empty() && safeMappedDeviceName != safeDeviceName)
+      legacyCandidates.emplace_back(StringUtils::Format(
+          "special://profile/peripheral_data/{}_{}.xml", busStr, safeMappedDeviceName));
   }
   else
   {
-    // Backwards compatibility - old settings files didn't include the device name
-    m_strSettingsFile = StringUtils::Format(
-        "special://profile/peripheral_data/{}_{}_{}.xml",
-        PeripheralTypeTranslator::BusTypeToString(m_mappedBusType), m_strVendorId, m_strProductId);
+    legacyCandidates.emplace_back(StringUtils::Format(
+        "special://profile/peripheral_data/{}_{}_{}.xml", busStr, m_strVendorId, m_strProductId));
 
-    if (!CFileUtils::Exists(m_strSettingsFile))
-      m_strSettingsFile = StringUtils::Format(
-          "special://profile/peripheral_data/{}_{}_{}_{}.xml",
-          PeripheralTypeTranslator::BusTypeToString(m_mappedBusType), m_strVendorId, m_strProductId,
-          CUtil::MakeLegalFileName(std::move(safeDeviceName), LegalPath::WIN32_COMPAT));
+    // variant that also appends the device name
+    legacyCandidates.emplace_back(
+        StringUtils::Format("special://profile/peripheral_data/{}_{}_{}_{}.xml", busStr,
+                            m_strVendorId, m_strProductId, safeDeviceName));
+
+    if (!safeMappedDeviceName.empty() && safeMappedDeviceName != safeDeviceName)
+      legacyCandidates.emplace_back(
+          StringUtils::Format("special://profile/peripheral_data/{}_{}_{}_{}.xml", busStr,
+                              m_strVendorId, m_strProductId, safeMappedDeviceName));
+  }
+
+  // None on disk yet: fall back to the first candidate, the location-less name that is
+  // also written back when this adapter has no physical location.
+  std::string legacyFile = legacyCandidates.front();
+  for (const auto& candidate : legacyCandidates)
+  {
+    if (CFileUtils::Exists(candidate))
+    {
+      legacyFile = candidate;
+      break;
+    }
+  }
+
+  // Settings file scoped to this adapter's physical location. The display name
+  // must not be part of the identity (it can change - e.g. a CEC adapter is
+  // "HDMI" alone but "HDMI 1"/"HDMI 2" once a second one appears - which would
+  // orphan the saved settings).
+  std::string locationFile;
+  if (m_iVendorId == 0x0000 && m_iProductId == 0x0000)
+  {
+    locationFile =
+        StringUtils::Format("special://profile/peripheral_data/{}_{}.xml", busStr, safeLocation);
+  }
+  else
+  {
+    locationFile = StringUtils::Format("special://profile/peripheral_data/{}_{}_{}_{}.xml", busStr,
+                                       m_strVendorId, m_strProductId, safeLocation);
+  }
+
+  // Write to the per-location file, but keep reading the location-less file until a write
+  // supersedes it, so read-only sessions don't migrate.
+  if (safeLocation.empty())
+  {
+    m_strSettingsFile = legacyFile;
+    m_strSettingsFileLoad = legacyFile;
+  }
+  else
+  {
+    m_strSettingsFile = locationFile;
+    if (!CFileUtils::Exists(locationFile) && CFileUtils::Exists(legacyFile))
+      m_strSettingsFileLoad = legacyFile;
+    else
+      m_strSettingsFileLoad = locationFile;
   }
 
   // Load settings and initialize state
@@ -639,7 +709,7 @@ void CPeripheral::PersistSettings(bool bExiting /* = false */)
 void CPeripheral::LoadPersistedSettings(void)
 {
   CXBMCTinyXML2 doc;
-  if (doc.LoadFile(m_strSettingsFile))
+  if (doc.LoadFile(m_strSettingsFileLoad))
   {
     const auto* setting = doc.RootElement()->FirstChildElement("setting");
     while (setting != nullptr)

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -325,8 +325,11 @@ protected:
   PeripheralBusType m_mappedBusType;
   std::string m_strLocation;
   std::string m_strDeviceName;
-  std::string m_strSettingsFile;
+  std::string m_strSettingsFile; // settings file to write
+  std::string m_strSettingsFileLoad; // settings file to read
   std::string m_strFileLocation;
+  std::string m_strPhysicalLocation; // stable physical/topology location
+  std::string m_strMappedDeviceName; // generic name from the peripherals.xml mapping
   int m_iVendorId;
   std::string m_strVendorId;
   int m_iProductId;


### PR DESCRIPTION
## Description

_This is a PR on top of #28656 and needs a rebase after that one's been merged in_

Give each CEC adapter its own `peripheral_data` settings file, keyed by the adapter's stable physical location.

Multiple CEC adapters of the same model (e.g. both HDMI CEC devices on a Raspberry Pi, or two USB-CEC adapters) report identical vendor/product ids, so they all resolved to the same `peripheral_data` settings file and clobbered each other's configuration.

This change:

- Adds `m_strPhysicalLocation` to the scan result / peripheral, populated from libCEC's `strComPath` (the physical device path, stable across reboots/replugs unlike the com port name), falling back to `strComName` when the path is empty.
- Scopes the settings file name by that physical location, so same-model adapters no longer share a file. The **display name is deliberately not part of the file name**: it is not stable, since a lone CEC adapter is shown as `HDMI` but becomes `HDMI 1`/`HDMI 2` once a second one appears — using it would orphan saved settings.
- Keeps reading the legacy (location-less) settings file until a write supersedes it, so existing single-adapter setups migrate transparently and read-only sessions don't migrate. `m_strSettingsFile` (write target) and `m_strSettingsFileLoad` (read source) are now tracked separately.
- Surfaces the per-adapter display name libCEC now assigns (`strDeviceName`), so adapters are listed distinctly instead of as identical `CEC Adapter` entries. Left empty for adapters libCEC didn't name, which then fall back to the generic `peripherals.xml` mapping.

## Motivation and context

On any board with more than one CEC device (dual-HDMI SoCs, or a second USB-CEC dongle) the two adapters are indistinguishable by vendor/product id, so Kodi wrote both of their settings to one file and each adapter overwrote the other. Keying on the stable physical location fixes this without breaking existing single-adapter configs.

## How has this been tested?

Tested on a Raspberry Pi 4 running LibreELEC, which exposes multiple kernel CEC nodes:

- Confirmed each adapter now resolves to its own `peripheral_data/*.xml` file and that per-adapter settings no longer clobber each other.
- Confirmed an existing single-adapter config (legacy location-less file) is still read, and is only rewritten to the new per-location file on the first settings write.
- Confirmed adapters are listed with distinct display names (`HDMI 1`/`HDMI 2`) instead of identical entries.

## What is the effect on users?

Users with more than one CEC adapter can now configure each one independently; previously the adapters shared and overwrote a single settings file. Single-adapter setups are unaffected. Their existing settings are read as before and migrated to the new file name only when settings are next saved.

## Types of change
- [X] **Bug fix** (multiple same-model CEC adapters no longer clobber each other's settings)
- [ ] **Clean up**
- [X] **Improvement** (per-adapter display names; separate read/write settings paths)
- [ ] **New feature**
- [ ] **Breaking change**
- [ ] **Cosmetic change**
- [ ] **Student submission**
- [ ] **None of the above**

## Checklist:
- [X] My code follows the **Code Guidelines** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **Contributing** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed