### PR TITLE
[application] remove debug frame counters for #28373

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -905,42 +905,6 @@ void CApplication::Render()
                                                        appPlayer->IsRenderingVideoLayer());
 
   CTimeUtils::UpdateFrameTime(hasRendered);
-
-  // [debug hack] count gui-on-screen frames vs total played and skipped
-  {
-    static unsigned int s_video = 0;
-    static unsigned int s_ctrls = 0;
-    static unsigned int s_subs = 0;
-    static unsigned int s_skipGui = 0;
-    static unsigned int s_skipAny = 0;
-    if (!appPlayer->IsPlayingVideo())
-    {
-      s_video = 0;
-      s_ctrls = 0;
-      s_subs = 0;
-      s_skipGui = 0;
-      s_skipAny = 0;
-    }
-    else
-    {
-      ++s_video;
-      const bool ctrlsOn = CServiceBroker::GetGUI()->GetWindowManager().HasVisibleControls();
-      const bool subsOn = appPlayer->HasVisibleOverlay();
-      if (ctrlsOn)
-        ++s_ctrls;
-      if (subsOn)
-        ++s_subs;
-      if (m_skipGuiRender)
-      {
-        ++s_skipAny;
-        if (ctrlsOn || subsOn)
-          ++s_skipGui;
-      }
-      if (s_video % 240 == 0)
-        CLog::Log(LOGDEBUG, "TEMP: [framecount] video={} ctrls={} subs={} skip-gui={} skip-any={}",
-                  s_video, s_ctrls, s_subs, s_skipGui, s_skipAny);
-    }
-  }
 }
 
 bool CApplication::OnAction(const CAction &action)


### PR DESCRIPTION
## Description
Removes the debug frame counters from #28373.

## Motivation and context
Added during beta1 to gather telemetry on the render-skip logic. Telemetry collected, no longer needed.

## How has this been tested?
Build and playback on GBM/GLES (Intel ADL-N). Pure deletion, no functional change.

## What is the effect on users?
None.

## Screenshots (if appropriate):

## Types of change
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed