### PR TITLE
depends: add --with-platform=ios-simulator to support Simulator builds

### DIFF
--- a/docs/README.iOS.md
+++ b/docs/README.iOS.md
@@ -119,6 +119,9 @@ make -j$(getconf _NPROCESSORS_ONLN)
 ./configure --host=aarch64-apple-darwin --with-platform=ios --with-sdk=11.0
 ```
 
+> [!NOTE]  
+> `--with-platform=ios-simulator` targets the iOS Simulator instead of device hardware (`iphonesimulator` SDK rather than `iphoneos`).
+
 ### 4.1. Advanced Configure Options
 
 
@@ -302,7 +305,7 @@ ls -l /Users/Shared/xbmc-depends
 **Start Xcode, open the Kodi project file** (`kodi.xcodeproj`) located in `$HOME/kodi-build` and hit `Build`.
 
 > [!WARNING]  
-> If you have selected a specific iOS SDK Version in step 4 then you might need to adapt the active target to use the same iOS SDK version, otherwise build will fail. Be sure to select a device configuration. Building for simulator is not supported.
+> If you have selected a specific iOS SDK Version in step 4 then you might need to adapt the active target to use the same iOS SDK version, otherwise build will fail. Be sure to select a device configuration matching what you configured.
 
 **Alternatively**, you can also build via Xcode from the command-line with `xcodebuild`:
 

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -495,6 +495,10 @@ case $host in
         target_platform=iphoneos
         platform_os="darwin_embedded"
       ;;
+      ios-simulator)
+        target_platform=iphonesimulator
+        platform_os="darwin_embedded"
+      ;;
       macos)
         target_platform=macosx
         platform_os="osx"
@@ -566,7 +570,7 @@ case $host in
 esac
 
 case $use_platform in
-  ios|tvos|macos)
+  ios|ios-simulator|tvos|macos)
     ;;
   webos)
     ;;


### PR DESCRIPTION
## Description

Add ios-simulator platform

## Motivation

Allow to run E2E tests for iOS

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
