### PR TITLE
Make new scanned versions of existing movies the default versions

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24906,7 +24906,19 @@ msgctxt "#40222"
 msgid "Group the different versions of videos"
 msgstr ""
 
-#empty strings from id 40223 to 40399
+#. "The newly scanned versions replace the default versions of movies" setting
+#: system/settings/settings.xml
+msgctxt "#40223"
+msgid "Make the most recent version the default version"
+msgstr ""
+
+#. Help for setting New versions replace the default versions
+#: system/settings/settings.xml
+msgctxt "#40224"
+msgid "Make the most recently scanned version of a movie the movie's default version.[CR]Helps identify new movie versions as recently added and locate them when the \"Unwatched\" filter of the library is turned on."
+msgstr ""
+
+#empty strings from id 40225 to 40399
 
 # Video versions
 

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -997,6 +997,14 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
+        <setting id="videolibrary.newversionsaredefault" type="boolean" label="40223" help="40224" parent="videolibrary.similarvideoaction">
+          <level>2</level>
+          <default>true</default>
+          <dependencies>
+            <dependency type="visible" setting="videolibrary.similarvideoaction" operator="greaterthan">0</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
         <setting id="videolibrary.ignorevideoextras" type="boolean" label="40204" help="40205">
           <level>1</level>
           <default>true</default>

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -97,6 +97,8 @@ public:
   static constexpr auto SETTING_VIDEOLIBRARY_SHOWPERFORMERS =
       "videolibrary.musicvideosallperformers";
   static constexpr auto SETTING_VIDEOLIBRARY_SIMILARVIDEOACTION = "videolibrary.similarvideoaction";
+  static constexpr auto SETTING_VIDEOLIBRARY_NEWVERSIONSAREDEFAULT =
+      "videolibrary.newversionsaredefault";
   static constexpr auto SETTING_VIDEOLIBRARY_IGNOREVIDEOEXTRAS = "videolibrary.ignorevideoextras";
   static constexpr auto SETTING_LOCALE_AUDIOLANGUAGE = "locale.audiolanguage";
   static constexpr auto SETTING_VIDEOPLAYER_PREFERDEFAULTFLAG = "videoplayer.preferdefaultflag";

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -12409,23 +12409,44 @@ bool CVideoDatabase::ConvertVideoToVersion(VideoDbContentType itemType,
   if (dbIdSource != dbIdTarget)
   {
     // Transfer all assets (versions, extras,...) to the new movie.
-    UpdateAssetsOwner(mediaType, dbIdSource, dbIdTarget);
+    if (!UpdateAssetsOwner(mediaType, dbIdSource, dbIdTarget))
+    {
+      RollbackTransaction();
+      return false;
+    }
 
     // version-level art doesn't need any change.
     // 'movie' art is converted to 'videoversion' art.
-    SetVideoVersionDefaultArt(idFile, dbIdSource, mediaType);
+    if (!SetVideoVersionDefaultArt(idFile, dbIdSource, mediaType))
+    {
+      RollbackTransaction();
+      return false;
+    }
 
     if (itemType == VideoDbContentType::MOVIES)
-      DeleteMovie(dbIdSource, cascadeAction, DeleteMovieHashAction::HASH_PRESERVE);
+    {
+      if (!DeleteMovie(dbIdSource, cascadeAction, DeleteMovieHashAction::HASH_PRESERVE))
+      {
+        RollbackTransaction();
+        return false;
+      }
+    }
   }
 
   // Rename the default version when provided
+  std::string query;
   if (idVideoVersion < 0)
-    ExecuteQuery(
-        PrepareSQL("UPDATE videoversion SET itemType = %i WHERE idFile = %i", assetType, idFile));
+    query =
+        PrepareSQL("UPDATE videoversion SET itemType = %i WHERE idFile = %i", assetType, idFile);
   else
-    ExecuteQuery(PrepareSQL("UPDATE videoversion SET idType = %i, itemType = %i WHERE idFile = %i",
-                            idVideoVersion, assetType, idFile));
+    query = PrepareSQL("UPDATE videoversion SET idType = %i, itemType = %i WHERE idFile = %i",
+                       idVideoVersion, assetType, idFile);
+
+  if (!ExecuteQuery(query))
+  {
+    RollbackTransaction();
+    return false;
+  }
 
   CommitTransaction();
 
@@ -12479,17 +12500,19 @@ bool CVideoDatabase::AddOrUpdateVideoVersion(VideoDbContentType itemType,
   return false;
 }
 
-void CVideoDatabase::SetDefaultVideoVersion(VideoDbContentType itemType, int dbId, int idFile)
+bool CVideoDatabase::SetDefaultVideoVersion(VideoDbContentType itemType, int dbId, int idFile)
 {
   if (!m_pDB || !m_pDS)
-    return;
+    return false;
 
   std::string path = GetFileBasePathById(idFile);
   if (path.empty())
-    return;
+    return false;
 
   try
   {
+    BeginTransaction();
+
     if (itemType == VideoDbContentType::MOVIES)
     {
       const int idOldFile{
@@ -12512,11 +12535,16 @@ void CVideoDatabase::SetDefaultVideoVersion(VideoDbContentType itemType, int dbI
                                MediaTypeMovie, dbId, idFile, MediaTypeVideoVersion));
       }
     }
+
+    CommitTransaction();
+    return true;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "failed for video {}", dbId);
+    RollbackTransaction();
   }
+  return false;
 }
 
 bool CVideoDatabase::IsDefaultVideoVersion(int idFile)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -974,7 +974,7 @@ public:
                                int idVideoVersion,
                                VideoAssetType assetType);
 
-  void SetDefaultVideoVersion(VideoDbContentType itemType, int dbId, int idFile);
+  bool SetDefaultVideoVersion(VideoDbContentType itemType, int dbId, int idFile);
   void SetVideoVersion(int idFile, int idVideoVersion);
   int AddOrValidateVideoVersionType(const std::string& typeVideoVersion);
   int AddVideoVersionType(const std::string& typeVideoVersion,

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -666,9 +666,11 @@ bool CGUIDialogVideoManagerVersions::ProcessVideoVersion(VideoDbContentType item
 
   const MediaType mediaType{item.GetVideoInfoTag()->m_type};
 
+  const auto isDefault = settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_NEWVERSIONSAREDEFAULT);
+
   return ChooseVideoAndConvertToVideoVersion(
       list, itemType, mediaType, dbId, videodb, MediaRole::NewVersion,
-      action == SimilarVideoScanAction::ASK ? Mode::INTERACTIVE : Mode::NON_INTERACTIVE, true);
+      action == SimilarVideoScanAction::ASK ? Mode::INTERACTIVE : Mode::NON_INTERACTIVE, isDefault);
 }
 
 bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -267,7 +267,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersion()
 
         return ChooseVideoAndConvertToVideoVersion(items, m_videoAsset->GetVideoContentType(),
                                                    tag->m_type, tag->m_iDbId, videoDb,
-                                                   MediaRole::Parent, Mode::INTERACTIVE);
+                                                   MediaRole::Parent, Mode::INTERACTIVE, false);
       }
 
       case CGUIDialogYesNo::DIALOG_RESULT_YES:
@@ -323,7 +323,7 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersion()
 
     return ChooseVideoAndConvertToVideoVersion(items, m_videoAsset->GetVideoContentType(),
                                                tag->m_type, tag->m_iDbId, videoDb,
-                                               MediaRole::Parent, Mode::INTERACTIVE);
+                                               MediaRole::Parent, Mode::INTERACTIVE, false);
   }
   return false;
 }
@@ -504,7 +504,8 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
     int dbId,
     CVideoDatabase& videoDb,
     MediaRole role,
-    Mode mode)
+    Mode mode,
+    bool setDefaultVersion)
 {
   std::shared_ptr<CFileItem> selectedItem;
 
@@ -563,9 +564,16 @@ bool CGUIDialogVideoManagerVersions::ChooseVideoAndConvertToVideoVersion(
       return false;
   }
 
-  return videoDb.ConvertVideoToVersion(itemType, sourceDbId, targetDbId, versionTypeId,
-                                       VideoAssetType::VERSION,
-                                       DeleteMovieCascadeAction::ALL_ASSETS);
+  const int idFile = videoDb.GetFileIdByMovie(sourceDbId);
+
+  if (!videoDb.ConvertVideoToVersion(itemType, sourceDbId, targetDbId, versionTypeId,
+                                     VideoAssetType::VERSION, DeleteMovieCascadeAction::ALL_ASSETS))
+    return false;
+
+  if (setDefaultVersion)
+    return (idFile >= 0 && videoDb.SetDefaultVideoVersion(itemType, targetDbId, idFile));
+
+  return true;
 }
 
 bool CGUIDialogVideoManagerVersions::GetAllOtherMovies(const std::shared_ptr<CFileItem>& item,
@@ -660,7 +668,7 @@ bool CGUIDialogVideoManagerVersions::ProcessVideoVersion(VideoDbContentType item
 
   return ChooseVideoAndConvertToVideoVersion(
       list, itemType, mediaType, dbId, videodb, MediaRole::NewVersion,
-      action == SimilarVideoScanAction::ASK ? Mode::INTERACTIVE : Mode::NON_INTERACTIVE);
+      action == SimilarVideoScanAction::ASK ? Mode::INTERACTIVE : Mode::NON_INTERACTIVE, true);
 }
 
 bool CGUIDialogVideoManagerVersions::AddVideoVersionFilePicker()

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -80,10 +80,12 @@ private:
    * \param[in] videoDb Database connection
    * \param[in] role NewVersion: dbId will be converted to a version of the movie chosen by
    *                 the user from the whole library.
+   *                 Parent: dbId will have another movie chosen by the user from the whole library
+   *                 as a new version.
    * \param[in] interaction INTERACTIVE: ask the user to choose and confirm as needed.
    *                        NON_INTERACTIVE false: no user interaction allowed, use heuristics in
    *                        place of user input
-   * Parent: dbId will have another movie chosen by the user from the whole library as a new version.
+   * \param[in] setDefaultVersion true to make the new version the default for the media
    *
    * \return True: success, a version was created and attached, false otherwise.
    */
@@ -93,7 +95,9 @@ private:
                                                   int dbId,
                                                   CVideoDatabase& videoDb,
                                                   MediaRole role,
-                                                  Mode mode);
+                                                  Mode mode,
+                                                  bool setDefaultVersion);
+
   /*!
    * \brief Use a file picker to select a file to add as a new version of a movie.
    * \return True when a version was added, false otherwise


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Usability follow up of #28349 (creation of new versions on library scan)

Set the newly scanned version of a movie already in the library as the default version after creation of the version.
The version creation by library scan is the only modified path (with user input or background addition).
Version creation by the versions manager dialog did not change.

See details in motivation and context.

With this we could consider making the automatic creation of versions the default.

Users who prefer managing default version themselves (for ex. the highest quality is the default) and don't want the default versions altered by new scans can turn off the feature with a new setting.
The setting default value is On.

<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/47943ebe-0ea2-413e-810a-0f69a4d7eba9" />

(setting hidden when version creation is turned off)

The default version after the addition of multiple versions of the same movie will be one of the added version. It is not possible to ensure which of the new version will be the new default version.

More work is necessary to sort out import with nfo present.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The movie upgrade user experience (ex. bluray to uhd bluray) or the addition of a new edition is not great: the existing version typically has the status "watched" and the new version, while unwatched, doesn't make the movie appear in the "Recently Added" or in the list of unwatched movies.

The typical workaround (until the versions feature is reworked in depth) is to go in the library, change the view mode to watched/all movies, find the movie and open the version manager dialog to set the new version as default. Change library view back to unwatched mode. The movie then appears as recently added and in the list of unwatched movies.

The PR automates that workaround and automatically sets the new movie versions as the movie's default version.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Add movie that already has versions in the library or not.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Movies with recently scanned new versions appear in the recently added and in the unwatched movies lists.

## Screenshots (if appropriate):

All movies are watched > no recently added and movies list with "Unwatched" filter is empty.

Scan for new versions
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/824bdaf7-2a97-4f14-9a2f-98286898ed01" />

Movie visible in the library:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/6973da7f-bbd0-4040-a1dd-67954f8565da" />

The new version is the default version:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/1ebd7181-54dc-4a5a-a94b-8914e6dba872" />

The movie appears as recently added and unwatched:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/00b75933-c43e-40be-b0d0-0a12f6e9ec4f" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
