### PR TITLE
[Video][Bluray] Fix toggling audio passthrough resets bluray stream.

### DIFF
--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -15,6 +15,7 @@
 #include "cores/playercorefactory/PlayerCoreFactory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
+#include "messaging/ApplicationMessenger.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
 #include "video/VideoFileItemClassify.h"
@@ -300,6 +301,16 @@ bool CApplicationPlayer::IsLiveStream() const
     return player->IsLiveStream();
 
   return false;
+}
+
+void CApplicationPlayer::OnAudioPassthroughSettingChanged()
+{
+  // Give the current player a chance to reconfigure its audio pipeline in place (e.g.
+  // VideoPlayer can switch a stream between passthrough and decoded without restarting).
+  // Fall back to a full close/reopen of the file if it can't (or there is no player).
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (!player || !player->OnAudioPassthroughSettingChanged())
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_RESTART);
 }
 
 void CApplicationPlayer::Pause()

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -140,6 +140,7 @@ public:
   bool IsPlayingGame() const;
   bool IsPlayingRDS() const;
   bool IsLiveStream() const;
+  void OnAudioPassthroughSettingChanged();
   void LoadPage(int p, int sp, unsigned char* buffer);
   bool OnAction(const CAction &action);
   void OnNothingToQueueNotify();

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -136,6 +136,7 @@ public:
   bool IsPlayingGame() const;
   bool IsPlayingRDS() const;
   bool IsLiveStream() const;
+  void OnAudioPassthroughSettingChanged();
   void LoadPage(int p, int sp, unsigned char* buffer);
   bool OnAction(const CAction &action);
   void OnNothingToQueueNotify();

--- a/xbmc/application/ApplicationSettingsHandling.cpp
+++ b/xbmc/application/ApplicationSettingsHandling.cpp
@@ -19,7 +19,6 @@
 #include "application/ApplicationVolumeHandling.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "messaging/ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -134,9 +133,7 @@ void CApplicationSettingsHandling::OnSettingChanged(const std::shared_ptr<const 
           CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution(), true);
   }
   else if (settingId == CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH)
-  {
-    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_RESTART);
-  }
+    components.GetComponent<CApplicationPlayer>()->OnAudioPassthroughSettingChanged();
 }
 
 void CApplicationSettingsHandling::OnSettingAction(const std::shared_ptr<const CSetting>& setting)

--- a/xbmc/application/ApplicationSettingsHandling.cpp
+++ b/xbmc/application/ApplicationSettingsHandling.cpp
@@ -21,7 +21,6 @@
 #include "application/ApplicationVolumeHandling.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "messaging/ApplicationMessenger.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
@@ -140,7 +139,7 @@ void CApplicationSettingsHandling::OnSettingChanged(const std::shared_ptr<const 
   }
   else if (settingId == CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH)
   {
-    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_RESTART);
+    components.GetComponent<CApplicationPlayer>()->OnAudioPassthroughSettingChanged();
   }
   else if (settingId == CSettings::SETTING_VIDEOLIBRARY_FLATTENVERSIONS)
   {

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -97,6 +97,13 @@ public:
   virtual bool OpenFile(const CFileItem& file, const CPlayerOptions& options){ return false;}
   virtual bool QueueNextFile(const CFileItem &file) { return false; }
   virtual void OnNothingToQueueNotify() {}
+  /*!
+   \brief Called when a live-adjustable audio output setting changes (e.g. "Allow passthrough")
+   while this player is open. Implementations able to reconfigure their audio pipeline in place
+   should do so and return true. The default returns false, telling the caller no in-place
+   handling was possible so it should fall back to closing and reopening the file.
+  */
+  virtual bool OnAudioPassthroughSettingChanged() { return false; }
   virtual bool CloseFile(bool reopen = false) = 0;
   virtual bool IsPlaying() const { return false;}
   virtual bool CanPause() const { return true; }

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -94,6 +94,13 @@ public:
   virtual bool OpenFile(const CFileItem& file, const CPlayerOptions& options){ return false;}
   virtual bool QueueNextFile(const CFileItem &file) { return false; }
   virtual void OnNothingToQueueNotify() {}
+  /*!
+   \brief Called when a live-adjustable audio output setting changes (e.g. "Allow passthrough")
+   while this player is open. Implementations able to reconfigure their audio pipeline in place
+   should do so and return true. The default returns false, telling the caller no in-place
+   handling was possible so it should fall back to closing and reopening the file.
+  */
+  virtual bool OnAudioPassthroughSettingChanged() { return false; }
   virtual bool CloseFile(bool reopen = false) = 0;
   virtual bool IsPlaying() const { return false;}
   virtual bool CanPause() const { return true; }

--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -54,6 +54,7 @@ public:
     PLAYER_REPORT_STATE,
     PLAYER_FRAME_ADVANCE,
     PLAYER_DISPLAY_RESET,           // report display reset event
+    PLAYER_AUDIO_RECONFIGURE,      // re-check audio passthrough eligibility in place, without a stream/demuxer restart
 
     // demuxer related messages
     DEMUXER_PACKET,                 // data packet

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5815,6 +5815,18 @@ void CVideoPlayer::OnResetDisplay()
   m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_DISPLAY_RESET), 1);
 }
 
+bool CVideoPlayer::OnAudioPassthroughSettingChanged()
+{
+  if (!m_VideoPlayerAudio->IsInited())
+    return false;
+
+  // Re-check whether the current audio stream should now be passthrough or decoded, without
+  // restarting the demuxer/BD navigation or losing the current playback position.
+  CLog::Log(LOGINFO, "VideoPlayer: audio passthrough setting changed, checking for passthrough");
+  m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_AUDIO_RECONFIGURE), 1);
+  return true;
+}
+
 void CVideoPlayer::UpdateFileItemStreamDetails(CFileItem& item, UpdateStreamDetails update)
 {
   if (update == UpdateStreamDetails::UPDATE_IF_FLAGGED)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5947,6 +5947,18 @@ void CVideoPlayer::OnResetDisplay()
   m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_DISPLAY_RESET), 1);
 }
 
+bool CVideoPlayer::OnAudioPassthroughSettingChanged()
+{
+  if (!m_VideoPlayerAudio->IsInited())
+    return false;
+
+  // Re-check whether the current audio stream should now be passthrough or decoded, without
+  // restarting the demuxer/BD navigation or losing the current playback position.
+  CLog::Log(LOGINFO, "VideoPlayer: audio passthrough setting changed, checking for passthrough");
+  m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_AUDIO_RECONFIGURE), 1);
+  return true;
+}
+
 void CVideoPlayer::UpdateFileItemStreamDetails(CFileItem& item, UpdateStreamDetails update)
 {
   if (update == UpdateStreamDetails::UPDATE_IF_FLAGGED)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -281,6 +281,7 @@ public:
   bool HasRDS() const override;
   bool HasID3() const override;
   bool IsPassthrough() const override;
+  bool OnAudioPassthroughSettingChanged() override;
   bool CanSeek() const override;
   void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride) override;
   bool SeekScene(Direction seekDirection) override;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -289,6 +289,7 @@ public:
   bool HasRDS() const override;
   bool HasID3() const override;
   bool IsPassthrough() const override;
+  bool OnAudioPassthroughSettingChanged() override;
   bool CanSeek() const override;
   void Seek(bool bPlus, bool bLargeStep, bool bChapterOverride) override;
   bool SeekScene(Direction seekDirection) override;

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -446,6 +446,14 @@ void CVideoPlayerAudio::Process()
     {
       m_displayReset = true;
     }
+    else if (pMsg->IsType(CDVDMsg::PLAYER_AUDIO_RECONFIGURE))
+    {
+      // Apply the recheck immediately (while paused/starved, 
+      // no new DEMUXER_PACKET messages are processed)
+      m_recheckPassthrough = true;
+      if (SwitchCodecIfNeeded())
+        audioframe.nb_frames = 0;
+    }
   }
 }
 
@@ -459,6 +467,13 @@ bool CVideoPlayerAudio::ProcessDecoderOutput(DVDAudioFrame &audioframe)
 
     if (audioframe.nb_frames == 0)
     {
+      // Even if we have no decoded frame, honor any pending passthrough recheck request.
+      // This ensures passthrough toggles apply immediately, even when paused or starved.
+      if (m_displayReset || m_recheckPassthrough)
+      {
+        SwitchCodecIfNeeded();
+      }
+
       return false;
     }
 
@@ -498,9 +513,9 @@ bool CVideoPlayerAudio::ProcessDecoderOutput(DVDAudioFrame &audioframe)
       }
     }
 
-    // Display reset event has occurred
-    // See if we should enable passthrough
-    if (m_displayReset)
+    // Display reset event has occurred, or the audio passthrough setting was changed while
+    // playing - see if we should enable/disable passthrough, without restarting playback
+    if (m_displayReset || m_recheckPassthrough)
     {
       if (SwitchCodecIfNeeded())
       {
@@ -653,10 +668,13 @@ bool CVideoPlayerAudio::SwitchCodecIfNeeded()
 {
   if (m_displayReset)
     CLog::Log(LOGINFO, "CVideoPlayerAudio: display reset occurred, checking for passthrough");
+  else if (m_recheckPassthrough)
+    CLog::Log(LOGINFO, "CVideoPlayerAudio: passthrough setting changed, checking for passthrough");
   else
     CLog::Log(LOGDEBUG, "CVideoPlayerAudio: stream props changed, checking for passthrough");
 
   m_displayReset = false;
+  m_recheckPassthrough = false;
 
   bool allowpassthrough = !CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_VIDEOPLAYER_USEDISPLAYASCLOCK);
   if (m_processInfo.IsRealtimeStream() || m_synctype == SYNC_RESAMPLE)
@@ -674,6 +692,16 @@ bool CVideoPlayerAudio::SwitchCodecIfNeeded()
   }
 
   m_pAudioCodec = std::move(codec);
+
+  // Update audio metadata to reflect the new codec/passthrough state, matching
+  // the normal initialization path. This ensures GUI info labels and AV-change
+  // callbacks receive updated decoder info immediately.
+  m_processInfo.SetAudioDecoderName(m_pAudioCodec->GetName());
+  {
+    std::unique_lock lock(m_info_section);
+    m_info.passthrough = m_pAudioCodec->NeedPassthrough();
+  }
+  m_messageParent.Put(std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_AVCHANGE));
 
   return true;
 }

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -118,6 +118,7 @@ protected:
   SInfo            m_info;
 
   bool m_displayReset = false;
+  bool m_recheckPassthrough = false;
   unsigned int m_disconAdjustTimeMs = 50; // maximum sync-off before adjusting
   int m_disconAdjustCounter = 0;
 };

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -40,13 +40,16 @@
 #include <utility>
 #include <vector>
 
+// clang-format off
 #define SETTING_AUDIO_VOLUME                   "audio.volume"
 #define SETTING_AUDIO_VOLUME_AMPLIFICATION     "audio.volumeamplification"
 #define SETTING_AUDIO_CENTERMIXLEVEL           "audio.centermixlevel"
 #define SETTING_AUDIO_DELAY                    "audio.delay"
 #define SETTING_AUDIO_STREAM                   "audio.stream"
 #define SETTING_AUDIO_PASSTHROUGH              "audio.digitalanalog"
+#define SETTING_AUDIO_ISPASSTHROUGH            "audio.isplayingpassthrough"
 #define SETTING_AUDIO_MAKE_DEFAULT             "audio.makedefault"
+// clang-format on
 
 CGUIDialogAudioSettings::CGUIDialogAudioSettings()
   : CGUIDialogSettingsManualBase(WINDOW_DIALOG_AUDIO_OSD_SETTINGS, "DialogSettings.xml")
@@ -73,6 +76,12 @@ void CGUIDialogAudioSettings::FrameMove()
     GetSettingsManager()->SetNumber(SETTING_AUDIO_DELAY,
                                     static_cast<double>(videoSettings.m_AudioDelay));
     GetSettingsManager()->SetBool(SETTING_AUDIO_PASSTHROUGH, CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH));
+
+    // the player may switch in/out of passthrough asynchronously (e.g. after the passthrough
+    // setting above is toggled, or the stream's own properties change) - keep this in sync every
+    // frame so the volume/amplification/centermix dependencies below get re-evaluated as soon as
+    // it actually changes, rather than only when the passthrough setting itself changes
+    GetSettingsManager()->SetBool(SETTING_AUDIO_ISPASSTHROUGH, appPlayer->IsPassthrough());
   }
 
   CGUIDialogSettingsManualBase::FrameMove();
@@ -247,15 +256,16 @@ void CGUIDialogAudioSettings::InitializeSettings()
     appPlayer->GetAudioCapabilities(m_audioCaps);
   }
 
-  // register IsPlayingPassthrough condition
-  GetSettingsManager()->AddDynamicCondition("IsPlayingPassthrough", IsPlayingPassthrough);
+  AddToggle(groupAudio, SETTING_AUDIO_ISPASSTHROUGH, 348, SettingLevel::Basic,
+            appPlayer->IsPassthrough(), false, false);
 
   CSettingDependency dependencyAudioOutputPassthroughDisabled(SettingDependencyType::Enable, GetSettingsManager());
   dependencyAudioOutputPassthroughDisabled.Or()
       ->Add(std::make_shared<CSettingDependencyCondition>(SETTING_AUDIO_PASSTHROUGH, "false",
                                                           SettingDependencyOperator::Equals, false,
                                                           GetSettingsManager()))
-      ->Add(std::make_shared<CSettingDependencyCondition>("IsPlayingPassthrough", "", "", true,
+      ->Add(std::make_shared<CSettingDependencyCondition>(SETTING_AUDIO_ISPASSTHROUGH, "false",
+                                                          SettingDependencyOperator::Equals, false,
                                                           GetSettingsManager()));
   SettingDependencies depsAudioOutputPassthroughDisabled;
   depsAudioOutputPassthroughDisabled.push_back(dependencyAudioOutputPassthroughDisabled);
@@ -281,9 +291,10 @@ void CGUIDialogAudioSettings::InitializeSettings()
 
   // downmix: center mix level
   {
-    AddSlider(groupAudio, SETTING_AUDIO_CENTERMIXLEVEL, 39112, SettingLevel::Basic,
-              videoSettings.m_CenterMixLevel, 14050, -10, 1, 30,
-              -1, false, false, true, 39113);
+    std::shared_ptr<CSettingInt> settingAudioCenterMixLevel =
+        AddSlider(groupAudio, SETTING_AUDIO_CENTERMIXLEVEL, 39112, SettingLevel::Basic,
+                  videoSettings.m_CenterMixLevel, 14050, -10, 1, 30, -1, false, false, true, 39113);
+    settingAudioCenterMixLevel->SetDependencies(depsAudioOutputPassthroughDisabled);
   }
 
   // audio delay setting
@@ -337,15 +348,6 @@ void CGUIDialogAudioSettings::AddAudioStreams(const std::shared_ptr<CSettingGrou
     m_audioStream = 0;
 
   AddList(group, settingId, 460, SettingLevel::Basic, m_audioStream, AudioStreamsOptionFiller, 460);
-}
-
-bool CGUIDialogAudioSettings::IsPlayingPassthrough(const std::string& condition,
-                                                   const std::string& value,
-                                                   const SettingConstPtr& setting)
-{
-  const auto& components = CServiceBroker::GetAppComponents();
-  const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-  return appPlayer->IsPassthrough();
 }
 
 namespace

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.h
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.h
@@ -49,10 +49,6 @@ protected:
 
   void AddAudioStreams(const std::shared_ptr<CSettingGroup>& group, const std::string& settingId);
 
-  static bool IsPlayingPassthrough(const std::string& condition,
-                                   const std::string& value,
-                                   const std::shared_ptr<const CSetting>& setting);
-
   static void AudioStreamsOptionFiller(const std::shared_ptr<const CSetting>& setting,
                                        std::vector<IntegerSettingOption>& list,
                                        int& current);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Use the existing `CVideoPlayerAudio::SwitchCodecIfNeeded()` code instead of `TMSG_MEDIA_RESTART`.

Second commit properly enables/disables the GUI controls.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When toggling audio passthrough whilst playing a bluray disc, playback starts from the beginning.

This appears to be because changing "Allow passthrough" is results in a settings callback:
```
// xbmc/application/ApplicationSettingsHandling.cpp:136-139
else if (settingId == CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH)
{
  CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_RESTART);
}
```

`TMSG_MEDIA_RESTART` is handled in `PlayListPlayer.cpp:1048-1050` → `g_application.Restart(true)`, which is 
```
CApplication::Restart() in Application.cpp:2496:
double time = GetTime();
std::string state = appPlayer->GetPlayerState();
m_itemCurrentFile->SetStartOffset(CUtil::ConvertSecsToMilliSecs(time));
if (PlayFile(*m_itemCurrentFile, "", true))
  appPlayer->SetPlayerState(state);
```

Calling `PlayFile()` for a BDMV disc that means the entire libbluray/BD-J stack gets torn down and rebuilt from scratch.

I also noticed that if you toggle passthrough off and on quickly, the volume settings are not greyed out (as the passthrough state hasn't changed yet). Downmix center is never level is never greyed out.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
