### PR TITLE
[Video][Player] Notify dependent resources of HDR toggle via ResolutionChanged().

### DIFF
--- a/xbmc/windowing/windows/WinSystemWin32.cpp
+++ b/xbmc/windowing/windows/WinSystemWin32.cpp
@@ -1332,7 +1332,10 @@ bool CWinSystemWin32::MessagePump()
 void CWinSystemWin32::SetTogglingHDR(bool toggling)
 {
   if (toggling)
+  {
     SetTimer(m_hWnd, ID_TIMER_HDR, 6000U, nullptr);
+    ResolutionChanged();
+  }
 
   m_IsTogglingHDR = toggling;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fix as suggested by @thexai.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Whenever I try and play media that is both HDR and passthrough audio, almost always I end up with no audio until I toggle passthrough on and off.

I asked Claude AI to analyse this log - https://paste.kodi.tv/suyakevolo.kodi

It said:
```
Looking at the timestamps and event sequence, both problems trace back to the same root cause: the first playback of this HDR/Dolby Atmos disc forces two separate display-mode renegotiations over the same HDMI link that also carries the TrueHD passthrough bitstream, while later "toggles" don't.

Walking through the first playback attempt:

20:05:37.710 – OnDisplayLost fires because Kodi has to correct the refresh rate to 23.976 Hz. The display doesn't come back until 20:05:39.957 (OnDisplayReset) — a ~2.2s renegotiation window.
20:05:39.990 – right in the middle of that window, CVideoPlayerAudio: display reset occurred, checking for passthrough fires, and Kodi opens the TrueHD stream as pass-through 8ch/48kHz.
20:05:40.093 – the WASAPI exclusive-mode sink actually opens the IEC61937 bitstream (AE_FMT_S16NE, 192000, 8) and starts feeding your Denon AVR.
20:05:40.669 – almost simultaneously, Kodi does its first Windows HDR switch: ToggleWindowsHDR: Set Windows HDR On, which forces DX::DeviceResources::ToggleHDR: Re-create swapchain due HDR <-> SDR switch. This is expensive enough that the video renderer actually times out: CRenderManager::Configure - timeout waiting for configure (20:05:41.653) and OutputPicture - failed to configure renderer (20:05:42.487). The HDR switch doesn't finish until ~20:05:42.5.

So you have refresh-rate change + HDR SDR→HDR switch stacked back-to-back, and Kodi starts pushing the TrueHD bitstream to the AVR while the receiver's HDMI input is still re-locking to the new video/HDR signal. Kodi's own logs show everything succeeding (sink opened, stream started) — there's no error — because from Kodi's side it did succeed. The AVR simply mutes/drops audio during its own HDMI relock and never gets a clean start of the bitstream.
```

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
