### PR TITLE
Setting to flatten movie versions display

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24885,6 +24885,7 @@ msgstr ""
 #: addons/skin.estuary/xml/DialogVideoInfo.xml
 #: xbmc/filesystem/VideoDatabaseDirectory.cpp
 #: xbmc/video/windows/GUIWindowVideoNav.cpp
+#: xbmc/video/ContextMenus.h
 #: addons/skin.estuary/xml/Variables.xml
 msgctxt "#40211"
 msgid "Extras"

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24984,7 +24984,19 @@ msgctxt "#40228"
 msgid "After scrape"
 msgstr ""
 
-#empty strings from id 40229 to 40399
+#. "Flatten movie versions" setting
+#: system/settings/settings.xml
+msgctxt "#40229"
+msgid "Flatten movie versions"
+msgstr ""
+
+#. Help for setting Flatten movie versions
+#: system/settings/settings.xml
+msgctxt "#40230"
+msgid "Turn on to show individual versions in the movies view, turn off to group them"
+msgstr ""
+
+#empty strings from id 40231 to 40399
 
 # Video versions
 

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -80,6 +80,7 @@
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>
 	<variable name="ListLabelVar">
+		<value condition="System.GetBool(videolibrary.flattenversions) + ListItem.HasVideoVersions + !String.IsEqual(ListItem.VideoVersionName,$LOCALIZE[40400])">$INFO[ListItem.Label]$INFO[ListItem.VideoVersionName, [COLOR grey][,][/COLOR]]</value>
 		<value condition="ListItem.HasVideoVersions + Window.IsActive(videoplaylist)">$INFO[ListItem.Label]$INFO[ListItem.VideoVersionName, [I](,)[/I]]</value>
 		<value condition="String.IsEqual(ListItem.DbType,episode) + Window.IsActive(videoplaylist)">$INFO[ListItem.TVShowtitle,,: ]$INFO[ListItem.Season,,x]$INFO[ListItem.Episode,,. ]$INFO[ListItem.Title]</value>
 		<value condition="String.IsEqual(ListItem.DbType,musicvideo) + Window.IsActive(videoplaylist)">$INFO[ListItem.Artist,, - ]$INFO[ListItem.Title]</value>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -1248,6 +1248,11 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="videolibrary.flattenversions" type="boolean" label="40229" help="40230">
+          <level>2</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
         <setting id="videolibrary.flattentvshows" type="integer" label="20412" help="36144">
           <level>2</level>
           <default>1</default> <!-- if only one season -->

--- a/xbmc/ContextMenuManager.cpp
+++ b/xbmc/ContextMenuManager.cpp
@@ -111,6 +111,7 @@ void CContextMenuManager::Init()
       std::make_shared<CONTEXTMENU::CRemoveFavourite>(),
       std::make_shared<CONTEXTMENU::CAddRemoveFavourite>(),
       std::make_shared<CONTEXTMENU::CFavouritesTargetContextMenu>(),
+      std::make_shared<CONTEXTMENU::CVideoShowExtras>(),
   };
 
   ReloadAddonItems();

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1395,7 +1395,7 @@ void CUtil::DeleteVideoDatabaseDirectoryCache()
 
 void CUtil::DeleteDirectoryCache(const std::string &prefix)
 {
-  std::string searchPath = "special://temp/";
+  std::string searchPath = "special://temp/archive_cache/";
   CFileItemList items;
   if (!XFILE::CDirectory::GetDirectory(searchPath, items, ".fi", DIR_FLAG_NO_FILE_DIRS))
     return;

--- a/xbmc/application/ApplicationSettingsHandling.cpp
+++ b/xbmc/application/ApplicationSettingsHandling.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -8,7 +8,9 @@
 
 #include "ApplicationSettingsHandling.h"
 
+#include "GUIUserMessages.h"
 #include "ServiceBroker.h"
+#include "Util.h"
 #include "addons/AddonManager.h"
 #include "addons/addoninfo/AddonType.h"
 #include "addons/gui/GUIDialogAddonSettings.h"
@@ -49,32 +51,35 @@ void CApplicationSettingsHandling::RegisterSettings()
 
   settingsMgr->RegisterSettingsHandler(this);
 
-  settingsMgr->RegisterCallback(this, {CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH,
-                                       CSettings::SETTING_LOOKANDFEEL_SKIN,
-                                       CSettings::SETTING_LOOKANDFEEL_SKINSETTINGS,
-                                       CSettings::SETTING_LOOKANDFEEL_FONT,
-                                       CSettings::SETTING_LOOKANDFEEL_SKINTHEME,
-                                       CSettings::SETTING_LOOKANDFEEL_SKINCOLORS,
-                                       CSettings::SETTING_LOOKANDFEEL_SKINZOOM,
-                                       CSettings::SETTING_MUSICPLAYER_REPLAYGAINPREAMP,
-                                       CSettings::SETTING_MUSICPLAYER_REPLAYGAINNOGAINPREAMP,
-                                       CSettings::SETTING_MUSICPLAYER_REPLAYGAINTYPE,
-                                       CSettings::SETTING_MUSICPLAYER_REPLAYGAINAVOIDCLIPPING,
-                                       CSettings::SETTING_SCRAPERS_MUSICVIDEOSDEFAULT,
-                                       CSettings::SETTING_SCREENSAVER_MODE,
-                                       CSettings::SETTING_SCREENSAVER_PREVIEW,
-                                       CSettings::SETTING_SCREENSAVER_SETTINGS,
-                                       CSettings::SETTING_AUDIOCDS_SETTINGS,
-                                       CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION,
-                                       CSettings::SETTING_VIDEOSCREEN_TESTPATTERN,
-                                       CSettings::SETTING_VIDEOPLAYER_USEMEDIACODEC,
-                                       CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE,
-                                       CSettings::SETTING_VIDEOPLAYER_USEDECODERFILTER,
-                                       CSettings::SETTING_AUDIOOUTPUT_VOLUMESTEPS,
-                                       CSettings::SETTING_SOURCE_VIDEOS,
-                                       CSettings::SETTING_SOURCE_MUSIC,
-                                       CSettings::SETTING_SOURCE_PICTURES,
-                                       CSettings::SETTING_VIDEOSCREEN_FAKEFULLSCREEN});
+  settingsMgr->RegisterCallback(this, {
+                                          CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH,
+                                          CSettings::SETTING_LOOKANDFEEL_SKIN,
+                                          CSettings::SETTING_LOOKANDFEEL_SKINSETTINGS,
+                                          CSettings::SETTING_LOOKANDFEEL_FONT,
+                                          CSettings::SETTING_LOOKANDFEEL_SKINTHEME,
+                                          CSettings::SETTING_LOOKANDFEEL_SKINCOLORS,
+                                          CSettings::SETTING_LOOKANDFEEL_SKINZOOM,
+                                          CSettings::SETTING_MUSICPLAYER_REPLAYGAINPREAMP,
+                                          CSettings::SETTING_MUSICPLAYER_REPLAYGAINNOGAINPREAMP,
+                                          CSettings::SETTING_MUSICPLAYER_REPLAYGAINTYPE,
+                                          CSettings::SETTING_MUSICPLAYER_REPLAYGAINAVOIDCLIPPING,
+                                          CSettings::SETTING_SCRAPERS_MUSICVIDEOSDEFAULT,
+                                          CSettings::SETTING_SCREENSAVER_MODE,
+                                          CSettings::SETTING_SCREENSAVER_PREVIEW,
+                                          CSettings::SETTING_SCREENSAVER_SETTINGS,
+                                          CSettings::SETTING_AUDIOCDS_SETTINGS,
+                                          CSettings::SETTING_VIDEOSCREEN_GUICALIBRATION,
+                                          CSettings::SETTING_VIDEOSCREEN_TESTPATTERN,
+                                          CSettings::SETTING_VIDEOPLAYER_USEMEDIACODEC,
+                                          CSettings::SETTING_VIDEOPLAYER_USEMEDIACODECSURFACE,
+                                          CSettings::SETTING_VIDEOPLAYER_USEDECODERFILTER,
+                                          CSettings::SETTING_AUDIOOUTPUT_VOLUMESTEPS,
+                                          CSettings::SETTING_SOURCE_VIDEOS,
+                                          CSettings::SETTING_SOURCE_MUSIC,
+                                          CSettings::SETTING_SOURCE_PICTURES,
+                                          CSettings::SETTING_VIDEOSCREEN_FAKEFULLSCREEN,
+                                          CSettings::SETTING_VIDEOLIBRARY_FLATTENVERSIONS,
+                                      });
 
   auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
@@ -136,6 +141,15 @@ void CApplicationSettingsHandling::OnSettingChanged(const std::shared_ptr<const 
   else if (settingId == CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGH)
   {
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_RESTART);
+  }
+  else if (settingId == CSettings::SETTING_VIDEOLIBRARY_FLATTENVERSIONS)
+  {
+    // Versions flattening happens in the database, before caching the items list
+    // Toggling flattening mode requires removal of obsolete cache files in order for the media
+    // window to refresh and display according to the new mode.
+    CUtil::DeleteVideoDatabaseDirectoryCache();
+    CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE);
+    CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
   }
 }
 

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -70,6 +70,7 @@ public:
   static constexpr auto SETTING_VIDEOLIBRARY_SHOWUNWATCHEDPLOTS = "videolibrary.showunwatchedplots";
   static constexpr auto SETTING_VIDEOLIBRARY_ACTORTHUMBS = "videolibrary.actorthumbs";
   static constexpr auto SETTING_MYVIDEOS_FLATTEN = "myvideos.flatten";
+  static constexpr auto SETTING_VIDEOLIBRARY_FLATTENVERSIONS = "videolibrary.flattenversions";
   static constexpr auto SETTING_VIDEOLIBRARY_FLATTENTVSHOWS = "videolibrary.flattentvshows";
   static constexpr auto SETTING_VIDEOLIBRARY_TVSHOWSSELECTFIRSTUNWATCHEDITEM =
       "videolibrary.tvshowsselectfirstunwatcheditem";

--- a/xbmc/video/ContextMenus.cpp
+++ b/xbmc/video/ContextMenus.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2016-2018 Team Kodi
+ *  Copyright (C) 2016-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -23,6 +23,7 @@
 #include "utils/PlayerUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "video/VideoDbUrl.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
 #include "video/VideoLibraryQueue.h"
@@ -464,6 +465,44 @@ bool CTVShowScanForNewContent::Execute(const std::shared_ptr<CFileItem>& item) c
                                                     : item->GetPath()};
   CVideoLibraryQueue::GetInstance().ScanLibrary(strPath, true /* scanAll */,
                                                 true /* showProgress */);
+  return true;
+}
+
+bool CVideoShowExtras::IsVisible(const CFileItem& item) const
+{
+  return item.HasVideoInfoTag() && item.HasVideoExtras();
+}
+bool CVideoShowExtras::Execute(const std::shared_ptr<CFileItem>& item) const
+{
+  CVideoDbUrl videoUrl;
+  if (!videoUrl.FromString(item->GetPath()))
+    return false;
+
+  CVariant movieIdVariant;
+  if (!videoUrl.GetOption("movieid", movieIdVariant))
+    return false;
+
+  const int movieId = movieIdVariant.asInteger(-1);
+  if (movieId < 0)
+    return false;
+
+  const std::string path = StringUtils::Format("videodb://movies/titles/{}/{}/", movieId,
+                                               static_cast<int>(VideoAssetType::EXTRA));
+
+  const int target = WINDOW_VIDEO_NAV;
+
+  auto& windowMgr = CServiceBroker::GetGUI()->GetWindowManager();
+
+  if (target == windowMgr.GetActiveWindow())
+  {
+    CGUIMessage msg(GUI_MSG_NOTIFY_ALL, target, 0, GUI_MSG_UPDATE);
+    msg.SetStringParam(path);
+    windowMgr.SendMessage(msg);
+  }
+  else
+  {
+    windowMgr.ActivateWindow(target, {path, "return"});
+  }
   return true;
 }
 

--- a/xbmc/video/ContextMenus.h
+++ b/xbmc/video/ContextMenus.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2016-2018 Team Kodi
+ *  Copyright (C) 2016-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -144,6 +144,13 @@ struct CVideoPlayAndQueue : IContextMenuItem
 struct CTVShowScanForNewContent : CStaticContextMenuAction
 {
   CTVShowScanForNewContent() : CStaticContextMenuAction(13349) {} // Scan for new content
+  bool IsVisible(const CFileItem& item) const override;
+  bool Execute(const std::shared_ptr<CFileItem>& item) const override;
+};
+
+struct CVideoShowExtras : CStaticContextMenuAction
+{
+  CVideoShowExtras() : CStaticContextMenuAction(40211) {} // Extras
   bool IsVisible(const CFileItem& item) const override;
   bool Execute(const std::shared_ptr<CFileItem>& item) const override;
 };

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -7902,6 +7902,8 @@ bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filte
     const bool videoVersionNav{options.contains("videoversionid")};
     // navigation = list of assets of the movie
     const bool assetsNav{options.contains("assetType")};
+    const bool flattenVersions{CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+        CSettings::SETTING_VIDEOLIBRARY_FLATTENVERSIONS)};
 
     int total = -1;
 
@@ -7978,10 +7980,24 @@ bool CVideoDatabase::GetMoviesByWhere(const std::string& strBaseDir, const Filte
         {
           itemUrl.AppendPath(std::to_string(movie.m_iDbId));
 
-          // Turn a movie with versions or extras into a folder item that navigates to a list of
-          // the versions and a virtual Extras folder (special assetType -2 value).
-          if (movie.HasVideoVersions() || movie.HasVideoExtras())
+          if (flattenVersions && movie.HasVideoVersions())
           {
+            static std::string versionPath{
+                std::to_string(static_cast<int>(VideoAssetType::VERSION)) + "/"};
+            itemUrl.AppendPath(versionPath);
+            itemUrl.AppendPath(std::to_string(movie.m_iFileId));
+            // for recognition by IsVideoAssetFile()
+            //! @todo figure out a more efficient and robust way
+            itemUrl.AddOption("assetType", static_cast<int>(VideoAssetType::VERSION));
+            //! @todo reset hasvideoversions/hasvideoextras or not? have to let the implementation
+            //! mature to decide.
+            //item->GetVideoInfoTag()->SetHasVideoVersions(false);
+            //item->GetVideoInfoTag()->SetHasVideoExtras(false);
+          }
+          else if (!flattenVersions && (movie.HasVideoVersions() || movie.HasVideoExtras()))
+          {
+            // Turn a movie with versions or extras into a folder item that navigates to a list of
+            // the versions and a virtual Extras folder (special assetType -2 value).
             static std::string hybridFolderPath{
                 std::to_string(static_cast<int>(VideoAssetType::VERSIONSANDEXTRASFOLDER)) + "/"};
             item->SetProperty("IsHybridFolder", true);
@@ -11952,9 +11968,14 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
 
     if (!assetAware)
     {
-      //! @todo not necessary with current movie view but wouldn't hurt?
-      // filter.AppendWhere(PrepareSQL("videoVersionTypeItemType = %i", VideoAssetType::VERSION));
-      filter.AppendWhere("isDefaultVersion = 1");
+      const bool flattenVersions = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_VIDEOLIBRARY_FLATTENVERSIONS);
+
+      if (flattenVersions)
+        filter.AppendWhere(
+            PrepareSQL("videoVersionTypeItemType = %i", static_cast<int>(VideoAssetType::VERSION)));
+      else
+        filter.AppendWhere("isDefaultVersion = 1");
     }
 
     AppendIdLinkFilter("tag", "tag", "movie", "movie", "idMovie", options, filter);

--- a/xbmc/video/VideoDbUrl.cpp
+++ b/xbmc/video/VideoDbUrl.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2016-2018 Team Kodi
+ *  Copyright (C) 2016-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -42,6 +42,12 @@ bool CVideoDbUrl::parse()
     case NodeType::TITLE_MOVIES:
     case NodeType::SETS:
       m_type = "movies";
+      break;
+
+    // Leaf node
+    case NodeType::MOVIE_ASSETS:
+      m_type = "movies";
+      m_itemType = "movies";
       break;
 
     case NodeType::TVSHOWS_OVERVIEW:
@@ -141,6 +147,11 @@ bool CVideoDbUrl::parse()
 
     case NodeType::VIDEOVERSIONS:
       m_itemType = "videoversions";
+      break;
+
+    case NodeType::NONE:
+      if (m_type.empty() || m_itemType.empty())
+        return false;
       break;
 
     case NodeType::ROOT:

--- a/xbmc/video/VideoFileItemClassify.cpp
+++ b/xbmc/video/VideoFileItemClassify.cpp
@@ -125,6 +125,7 @@ bool IsVideoAssetFile(const CFileItem& item)
     return false;
 
   // @todo better encoding of video assets as path, they won't always be tied with movies.
+  // Info can also be retrieved with CVideoDbUrl::FromString but less efficient
   const CURL url{item.GetPath()};
   return (url.HasOption("videoversionid") || url.HasOption("assetType"));
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Added a setting in Media > Videos to display the versions of a movie "flattened" - not grouped in a directory (see screenshots)
movie_view already provided the necessary information for display and needed to be filtered differently by CVideoDatabase::GetMoviesByWhere() and the paths of the items had to be adjusted to point to the versions instead of the movie.

Added a context menu item to jump to the extras of a movie since the directory navigation to extras is not available anymore in flattened mode. It doesn't hurt to have it available in directory mode as well. The menu item is available only for movies that have extras and is hidden otherwise.

Maybe show other stream details
No attention paid to setting artwork yet. The context menu option is enabled.

There are probably many small details that don't work quite right and will need fine tuning. This is a significant change - though no impact when turned off.

Known issues:
- ~display the version name. Unsure how to make the information available to the skin, to be discussed in Slack~ done
- ~toggling flattening doesn't appear to take effect only after restart for large/slow libraries - cache files need to be flushed.~ done
- ~Flattened versions display the movie art instead of version art.~ fixed
- ~Info dialog shows movie art instead of versions art~ fixed
- ~Versions Manager opens on default version instead of currently displayed version of info dialog~ done in 28932
- ~Make Set art available for versions in Info dialog and context menu, with action on the displayed/selected version~ done in 28931
- ~Info dialog poster doesn't refresh after changing the art of the displayed version through Versions Manager~ fixed in 28932
- ~Movies list item art doesn't refresh after changing art of an item through info dialog > versions manager~ fixed in 28932
- Should the visual indication that a movie has multiple versions remain? It's enabled for now but is very easy to change.
Con: hides the extras indicator.
I kept the extras presence indicator.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Discussed in Slack. Avoid some of the drawbacks of the folder / default version approach.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Light testing at this point in Movies view, movies with/without versions, with/without extras

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Alternative display of versions.

## Screenshots (if appropriate):

Setting:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/54cb8c8e-6890-46d3-8b67-c58d63a87ef9" />

flattening turned off:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/e5df90b4-3106-4e5f-9217-ef1dda4d817b" />

flattening turned on:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/aa99f11c-359a-4301-8625-de659e4ee05b" />

context menu for extras:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/3504484e-c898-4589-a16d-aa4343534a7e" />

the extras appear, same view used with flattening off + folder navigation
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/bc820965-cae8-4f90-aa95-925b04d636db" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
