### PR TITLE
[darwin_embedded] build fixes

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -162,6 +162,13 @@ macro(buildFFMPEG)
     string(REPLACE ";" "|" ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_MODULE_PATH "${CMAKE_MODULE_PATH}")
     set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIST_SEPARATOR LIST_SEPARATOR |)
 
+    # when cross-compiling (e.g. macOS x86_64 -> iOS device arm64), SDKROOT env var points to the target SDK
+    # this causes apple-clang to inject it as -isysroot to all invocations including host compiler checks
+    # in the aforementioned example the host compiler check fails because iOS SDK complains about x86_64 arch
+    if(XCODE)
+      set(extra_env_vars "SDKROOT=")
+    endif()
+
     set(CMAKE_ARGS -DCMAKE_MODULE_PATH=${FFMPEG_MODULE_PATH}
                    -DFFMPEG_VER=${FFMPEG_VER}
                    -DCORE_SYSTEM_NAME=${CORE_SYSTEM_NAME}
@@ -175,6 +182,7 @@ macro(buildFFMPEG)
                    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
                    -DCMAKE_EXE_LINKER_FLAGS=${LINKER_FLAGS}
                    -DDISABLE_FFMPEG_SOURCE_PLUGINS=${DISABLE_FFMPEG_SOURCE_PLUGINS}
+                   -DEXTRA_ENV_VARS=${extra_env_vars}
                    ${CROSS_ARGS}
                    ${FFMPEG_OPTIONS}
                    -DPKG_CONFIG_PATH=${CMAKE_BINARY_DIR}/${CORE_BUILD_DIR}/lib/pkgconfig)

--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -194,10 +194,6 @@ macro(buildFFMPEG)
       set(postproc_pkg_config_search "postproc=`PKG_CONFIG_PATH=${DEPENDS_PATH}/lib/pkgconfig ${PKG_CONFIG_EXECUTABLE} --libs --static libpostproc`")
     endif()
 
-    if(CMAKE_GENERATOR STREQUAL Xcode)
-      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_GENERATOR CMAKE_GENERATOR "Unix Makefiles")
-    endif()
-
     BUILD_DEP_TARGET()
 
     find_program(BASH_COMMAND bash)

--- a/docs/README.iOS.md
+++ b/docs/README.iOS.md
@@ -309,7 +309,7 @@ ls -l /Users/Shared/xbmc-depends
 Build Kodi:
 ```
 cd $HOME/kodi-build
-xcodebuild -config "Debug" -jobs $(getconf _NPROCESSORS_ONLN)
+xcodebuild -config "Debug"
 ```
 
 > [!TIP]

--- a/docs/README.macOS.md
+++ b/docs/README.macOS.md
@@ -281,7 +281,7 @@ Alternatively, you can also build via Xcode from the command-line with `xcodebui
 Build Kodi:
 ```
 cd $HOME/kodi-build
-xcodebuild -config "Debug" -jobs $(getconf _NPROCESSORS_ONLN)
+xcodebuild -config "Debug"
 ```
 
 > [!TIP]
@@ -291,7 +291,7 @@ xcodebuild -config "Debug" -jobs $(getconf _NPROCESSORS_ONLN)
 
 Build Kodi:
 ```
-/Users/Shared/xbmc-depends/x86_64-darwin17.5.0-native/bin/cmake --build . --config "Debug" -- -verbose -jobs $(getconf _NPROCESSORS_ONLN)
+/Users/Shared/xbmc-depends/x86_64-darwin17.5.0-native/bin/cmake --build . --config "Debug" -- -verbose
 ```
 
 > [!TIP]

--- a/docs/README.tvOS.md
+++ b/docs/README.tvOS.md
@@ -294,7 +294,7 @@ Alternatively, you can also build via Xcode from the command-line with `xcodebui
 Change to build directory:
 ```
 cd $HOME/kodi-build
-xcodebuild -config "Debug" -jobs $(getconf _NPROCESSORS_ONLN)
+xcodebuild -config "Debug"
 ```
 
 This will create a `Kodi.app` file located in `$HOME/kodi-build/build/Debug-appletvos`. This App can be deployed via Xcode to an AppleTV via `Window -> Devices and Simulators -> Select device and click +`

--- a/tools/darwin/Support/Codesign.command
+++ b/tools/darwin/Support/Codesign.command
@@ -30,8 +30,7 @@ if [ "${CODE_SIGN_IDENTITY_FOR_ITEMS}" = "" ] ; then
 fi
 echo "Code sign identity is '${CODE_SIGN_IDENTITY_FOR_ITEMS}'"
 
-# Delete existing codesign and provisioning file
-rm -f "${CONTENTS_PATH}/embedded.mobileprovision"
+# Delete existing codesigning folder
 rm -rf "${CONTENTS_PATH}/_CodeSignature"
 
 # If user has set a code_sign_identity we do a real codesign (for deployment on non-jailbroken devices)
@@ -88,6 +87,9 @@ elif [ ! "$MACOS" ]; then
   # Do fake sign - needed for iOS >=5.1 and tvOS >=10.2 jailbroken devices
   # See http://www.saurik.com/id/8
   echo "Doing a fake sign using ldid for jailbroken devices (main kodi binary and all Mach-O files)"
+
+  # Delete existing provisioning profile
+  rm -f "${CONTENTS_PATH}/embedded.mobileprovision"
 
   # Main 'kodi' binary
   "${LDID}" -S"${DARWIN_EMBEDDED_ENTITLEMENTS}" "${CONTENTS_PATH}/${EXECUTABLE_NAME}"

--- a/tools/depends/configure.ac
+++ b/tools/depends/configure.ac
@@ -906,13 +906,6 @@ EOF
 
 AC_OUTPUT
 
-if test "$platform_os" = "darwin_embedded"; then
-  if test "$use_platform" = "ios"; then
-    simulator_sdk_path=[`$use_xcrun --sdk iphonesimulator --show-sdk-path`]
-    echo -e "use simulator:\t $simulator_sdk_path"
-  fi
-fi
-
 cp -vf target/config.site $prefix/$deps_dir/share
 cp -vf target/config-binaddons.site $prefix/$tool_dir/share
 cp -vf target/Toolchain.cmake $prefix/$deps_dir/share
@@ -944,4 +937,10 @@ echo -e "depends:\t\t $prefix/$deps_dir"
 if test "$platform_os" = "android"; then
   echo -e "ndk-api-level:\t $use_ndk_api"
   echo -e "build-tools:\t $build_tools_path"
+fi
+if test "$platform_os" = "darwin_embedded"; then
+  if test "$use_platform" = "ios"; then
+    simulator_sdk_path=[`$use_xcrun --sdk iphonesimulator --show-sdk-path`]
+    echo -e "use simulator:\t $simulator_sdk_path"
+  fi
 fi

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -12,8 +12,10 @@ else()
                 )
 endif()
 
+set(env_vars ${EXTRA_ENV_VARS})
+
 if(CROSSCOMPILING)
-  set(pkgconf "PKG_CONFIG_LIBDIR=${DEPENDS_PATH}/lib/pkgconfig")
+  list(APPEND env_vars "PKG_CONFIG_LIBDIR=${DEPENDS_PATH}/lib/pkgconfig")
   list(APPEND ffmpeg_conf --pkg-config=${PKG_CONFIG_EXECUTABLE}
                           --pkg-config-flags=--static
                           --enable-cross-compile
@@ -127,7 +129,7 @@ endif()
 
 if(ENABLE_DAV1D)
   list(APPEND ffmpeg_conf --enable-libdav1d)
-  set(pkgconf_path "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}")
+  list(APPEND env_vars "PKG_CONFIG_PATH=${PKG_CONFIG_PATH}")
 else()
   list(APPEND ffmpeg_conf --disable-libdav1d)
 endif()
@@ -161,7 +163,7 @@ include(ExternalProject)
 externalproject_add(ffmpeg
                     SOURCE_DIR ${CMAKE_SOURCE_DIR}
                     ${sourceplugin_patch}
-                    CONFIGURE_COMMAND ${pkgconf} ${pkgconf_path} <SOURCE_DIR>/configure
+                    CONFIGURE_COMMAND ${env_vars} <SOURCE_DIR>/configure
                       --prefix=${CMAKE_INSTALL_PREFIX}
                       --extra-version="kodi-${FFMPEG_VER}"
                       ${ffmpeg_conf}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
1. Fixes building FFmpeg for iOS/tvOS device on an Intel Mac. `xcodebuild` injects a bunch of env vars to child processes, one of them being `SDKROOT` pointing to target SDK. Apple clang compiler takes this variable into account for all invocations including FFmpeg's host compiler checks and passes it as `-isysroot`. So the host compiler invocation is something like `-arch x86_64 -isysroot .../iPhoneOS.sdk` and some toolchain header (coming from the SDK) has `#error` for non-ARM archs. Cleaning this env var ensures that host compiler is invoked with correct SDK. There's still a warning `using sysroot for 'MacOSX' but targeting 'iPhone' [-Wincompatible-sysroot]` because `-triple` still points to iOS (iirc it was `x86_64-apple-ios12.0.0`), but that can be ignored.
2. Fixes making signed builds for iOS/tvOS device. Modern xcodebuild versions (dunno since which version) package provisioning profile before most of the target build steps, so we can't remove the file in our code signing script. 
<img width="1084" height="329" alt="Screenshot 2026-07-23 at 13 04 15" src="https://github.com/user-attachments/assets/b3a60cd2-53d8-4cc0-807f-cb30d8503be7" />

3. Removed forcing CMake generator from Xcode to Unix Makefiles in the FFmpeg script as it's done inside `BUILD_DEP_TARGET`
4. Moved darwin_embedded simulator info to the bottom of the configuration information as currently it looks rather ugly:
> config.status: creating native/Toolchain-Native.cmake
> -e use simulator:	 /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.2.sdk
> target/config.site -> /Users/Shared/xbmc-depends/iphoneos26.2_arm64-target-debug/share/config.site

We could even simply remove the simulator info, not sure what purpose it serves.

5. Removed passing `-jobs` parameter to xcodebuild from all the Apple docs as multicore builds are default already (like in Ninja).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- fixes building FFmpeg for iOS/tvOS device on an Intel Mac
- fixes running Kodi from Xcode on iOS/tvOS device

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- local test with Xcode 26
- building FFmpeg on an old Jenkins Intel slave: https://jenkins.kodi.tv/view/Apple/job/iOS-test/4/ (previous runs fail)
- building FFmpeg on a GitHub Intel runner: https://github.com/kambala-decapitator/workflow-test/actions/runs/30156358813/job/89674844853

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
devs can run Kodi from Xcode on iOS/tvOS device again

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
