### PR TITLE
[Windows] Partial revert to fix text rendering

### DIFF
--- a/xbmc/guilib/GUIFontTTF.cpp
+++ b/xbmc/guilib/GUIFontTTF.cpp
@@ -1154,30 +1154,29 @@ void CGUIFontTTF::RenderCharacter(CGraphicContext& context,
 
 #if defined(HAS_DX)
   // D3D: triangle lists
-  // D3D rasterizer uses half-pixel-center convention; no nudge needed.
 
   v[0].u = tl;
   v[0].v = tt;
-  v[0].x = vertex.x1 - xOffset;
-  v[0].y = vertex.y1 - yOffset;
+  v[0].x = vertex.x1 - xOffset - 0.5f;
+  v[0].y = vertex.y1 - yOffset - 0.5f;
   v[0].z = 0;
 
   v[1].u = tr;
   v[1].v = tt;
-  v[1].x = vertex.x2 - xOffset;
-  v[1].y = vertex.y1 - yOffset;
+  v[1].x = vertex.x2 - xOffset + 0.5f;
+  v[1].y = vertex.y1 - yOffset - 0.5f;
   v[1].z = 0;
 
   v[2].u = tr;
   v[2].v = tb;
-  v[2].x = vertex.x2 - xOffset;
-  v[2].y = vertex.y2 - yOffset;
+  v[2].x = vertex.x2 - xOffset + 0.5f;
+  v[2].y = vertex.y2 - yOffset + 0.5f;
   v[2].z = 0;
 
   v[3].u = tl;
   v[3].v = tb;
-  v[3].x = vertex.x1 - xOffset;
-  v[3].y = vertex.y2 - yOffset;
+  v[3].x = vertex.x1 - xOffset - 0.5f;
+  v[3].y = vertex.y2 - yOffset + 0.5f;
   v[3].z = 0;
 #else
   // GL / GLES uses triangle strips, not quads, so have to rearrange the vertex order


### PR DESCRIPTION

## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Partly revert #28594, commit 2e969ab2764b3d12fec3a02f8456120818cbdc5e.
The pixel nudging didn't have to be changed and actually caused a misalignment. The discussion is in the original PR.
The background clearing is necessary and remains.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Text quality issues reported.

I thought you opened a PR for this @thexai but wasn't able to locate it? so here is another one.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Compared screenshots with 22a3 and 21.3

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Text rendering is back to normal on Windows.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
