### PR TITLE
Fix incorrect aspect ratio for SD (720x480/576) resolutions on GBM/DRM

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -32,6 +32,20 @@
 
 using namespace std::chrono_literals;
 
+namespace
+{
+// The content aspect ratio, derived from the display (post-DAR) picture dimensions, used to
+// prefer a whitelisted mode whose signalled aspect ratio (e.g. a DRM CEA VIC flag) matches the
+// video being played, when several modes share the same timing.
+float ContentAspectRatio(const VideoPicture& picture)
+{
+  if (picture.iDisplayWidth == 0 || picture.iDisplayHeight == 0)
+    return 0.0f;
+
+  return static_cast<float>(picture.iDisplayWidth) / picture.iDisplayHeight;
+}
+} // namespace
+
 void CRenderManager::CClockSync::Reset()
 {
   m_error = 0;
@@ -706,7 +720,8 @@ RESOLUTION CRenderManager::GetResolution()
 
   if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF)
     res = CResolutionUtils::ChooseBestResolution(m_fps, m_picture.iWidth, m_picture.iHeight,
-                                                 !m_picture.stereoMode.empty());
+                                                 !m_picture.stereoMode.empty(),
+                                                 ContentAspectRatio(m_picture));
 
   return res;
 }
@@ -898,7 +913,8 @@ void CRenderManager::UpdateResolution()
       if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_VIDEOPLAYER_ADJUSTREFRESHRATE) != ADJUST_REFRESHRATE_OFF && m_fps > 0.0f)
       {
         RESOLUTION res = CResolutionUtils::ChooseBestResolution(
-            m_fps, m_picture.iWidth, m_picture.iHeight, !m_picture.stereoMode.empty());
+            m_fps, m_picture.iWidth, m_picture.iHeight, !m_picture.stereoMode.empty(),
+            ContentAspectRatio(m_picture));
         CServiceBroker::GetWinSystem()->GetGfxContext().SetVideoResolution(res, false);
         UpdateLatencyTweak();
         if (m_pRenderer)

--- a/xbmc/settings/DisplaySettings.cpp
+++ b/xbmc/settings/DisplaySettings.cpp
@@ -31,6 +31,7 @@
 #include "windowing/WinSystem.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <float.h>
 #include <mutex>
@@ -81,13 +82,68 @@ std::string ModeFlagsToString(unsigned int flags, bool identifier)
   return res;
 }
 
+// Encodes a mode's signalled content aspect ratio (e.g. a DRM CEA VIC flag) as a single
+// character so that otherwise-identical width/height/refresh/flags modes that only differ in
+// signalled aspect ratio (a 4:3 and a 16:9 VIC at the same SD timing) round-trip to distinct
+// resolutions through the compact identifier string. '0' means unspecified, which also matches
+// identifiers saved before this encoding existed.
+char AspectRatioToChar(float aspectRatio)
+{
+  if (aspectRatio <= 0.0f)
+    return '0';
+  if (std::fabs(aspectRatio - 4.0f / 3.0f) < 0.01f)
+    return '4';
+  if (std::fabs(aspectRatio - 16.0f / 9.0f) < 0.01f)
+    return '6';
+  if (std::fabs(aspectRatio - 64.0f / 27.0f) < 0.01f)
+    return '2';
+  if (std::fabs(aspectRatio - 256.0f / 135.0f) < 0.01f)
+    return '5';
+  return '0';
+}
+
+float CharToAspectRatio(char c)
+{
+  switch (c)
+  {
+    case '4':
+      return 4.0f / 3.0f;
+    case '6':
+      return 16.0f / 9.0f;
+    case '2':
+      return 64.0f / 27.0f;
+    case '5':
+      return 256.0f / 135.0f;
+    default:
+      return 0.0f;
+  }
+}
+
+// Human-readable label for a mode's signalled aspect ratio, e.g. " (4:3)"; empty when unspecified.
+std::string AspectRatioLabel(float aspectRatio)
+{
+  switch (AspectRatioToChar(aspectRatio))
+  {
+    case '4':
+      return " (4:3)";
+    case '6':
+      return " (16:9)";
+    case '2':
+      return " (64:27)";
+    case '5':
+      return " (256:135)";
+    default:
+      return "";
+  }
+}
+
 // True when this mode is uncalibrated. Only works for live modes; dead or stale modes are
 // considered non-default always.
-bool IsDefaultCalibration(const RESOLUTION_INFO& info)
+bool IsDefaultCalibration(const RESOLUTION_INFO& info, float defaultPixelRatio)
 {
   return info.Overscan.left == 0 && info.Overscan.top == 0 && info.Overscan.right == info.iWidth &&
          info.Overscan.bottom == info.iHeight && info.iSubtitles == info.iHeight &&
-         info.fPixelRatio == 1.0f;
+         std::fabs(info.fPixelRatio - defaultPixelRatio) <= 0.0001f;
 }
 } // unnamed namespace
 
@@ -510,6 +566,8 @@ void CDisplaySettings::AddResolutionInfo(const RESOLUTION_INFO &resolution)
   std::unique_lock lock(m_critical);
   RESOLUTION_INFO res(resolution);
 
+  m_defaultPixelRatios[res.strMode] = res.fPixelRatio;
+
   if((res.dwFlags & D3DPRESENTFLAG_MODE3DTB) == 0)
   {
     /* add corrections for some special case modes frame packing modes */
@@ -529,6 +587,15 @@ void CDisplaySettings::AddResolutionInfo(const RESOLUTION_INFO &resolution)
     }
   }
   m_resolutions.push_back(res);
+}
+
+float CDisplaySettings::GetDefaultPixelRatio(const std::string& mode) const
+{
+  std::unique_lock lock(m_critical);
+  auto it = m_defaultPixelRatios.find(mode);
+  if (it != m_defaultPixelRatios.end())
+    return it->second;
+  return 1.0f;
 }
 
 void CDisplaySettings::ApplyCalibrations()
@@ -553,6 +620,10 @@ void CDisplaySettings::ApplyCalibrations()
             ((itCal->Overscan.right == 1280 && itCal->Overscan.bottom == 720) ||
              (itCal->Overscan.right == 1920 && itCal->Overscan.bottom == 1080)))
           break;
+
+        float defaultPixelRatio = 1.0f;
+        if (auto it = m_defaultPixelRatios.find(itCal->strMode); it != m_defaultPixelRatios.end())
+          defaultPixelRatio = it->second;
 
         // overscan
         m_resolutions[res].Overscan.left = itCal->Overscan.left;
@@ -585,11 +656,14 @@ void CDisplaySettings::ApplyCalibrations()
         if (m_resolutions[res].iSubtitles > m_resolutions[res].iHeight * 3 / 2)
           m_resolutions[res].iSubtitles = m_resolutions[res].iHeight * 3 / 2;
 
-        m_resolutions[res].fPixelRatio = itCal->fPixelRatio;
-        if (m_resolutions[res].fPixelRatio < 0.5f)
-          m_resolutions[res].fPixelRatio = 0.5f;
-        if (m_resolutions[res].fPixelRatio > 2.0f)
-          m_resolutions[res].fPixelRatio = 2.0f;
+        if (std::fabs(itCal->fPixelRatio - defaultPixelRatio) > 0.0001f)
+        {
+          m_resolutions[res].fPixelRatio = itCal->fPixelRatio;
+          if (m_resolutions[res].fPixelRatio < 0.5f)
+            m_resolutions[res].fPixelRatio = 0.5f;
+          if (m_resolutions[res].fPixelRatio > 2.0f)
+            m_resolutions[res].fPixelRatio = 2.0f;
+        }
         break;
       }
     }
@@ -619,7 +693,11 @@ void CDisplaySettings::UpdateCalibrations()
     if (res != m_resolutions.cend())
     {
       // A calibration whose mode is live and still at its defaults holds no user adjustment.
-      if (IsDefaultCalibration(*res))
+      float defaultPixelRatio = 1.0f;
+      if (auto defIt = m_defaultPixelRatios.find(res->strMode); defIt != m_defaultPixelRatios.end())
+        defaultPixelRatio = defIt->second;
+
+      if (IsDefaultCalibration(*res, defaultPixelRatio))
       {
         it = m_calibrations.erase(it);
         continue;
@@ -644,7 +722,7 @@ DisplayMode CDisplaySettings::GetCurrentDisplayMode() const
   return DM_FULLSCREEN;
 }
 
-RESOLUTION CDisplaySettings::FindBestMatchingResolution(const std::map<RESOLUTION, RESOLUTION_INFO> &resolutionInfos, int width, int height, float refreshrate, unsigned flags)
+RESOLUTION CDisplaySettings::FindBestMatchingResolution(const std::map<RESOLUTION, RESOLUTION_INFO> &resolutionInfos, int width, int height, float refreshrate, unsigned flags, float aspectRatio)
 {
   // find the closest match to these in our res vector.  If we have the screen, we score the res
   RESOLUTION bestRes = RES_DESKTOP;
@@ -666,6 +744,15 @@ RESOLUTION CDisplaySettings::FindBestMatchingResolution(const std::map<RESOLUTIO
       bestScore = score;
       bestRes = it->first;
     }
+    else if (score == bestScore && aspectRatio > 0.0f)
+    {
+      // Otherwise-identical candidates (e.g. a 4:3 and a 16:9 VIC at the same SD timing) are
+      // disambiguated by which one's signalled aspect ratio is closer to the requested one.
+      const RESOLUTION_INFO &best = resolutionInfos.at(bestRes);
+      if (std::fabs(info.fSignalledAspectRatio - aspectRatio) <
+          std::fabs(best.fSignalledAspectRatio - aspectRatio))
+        bestRes = it->first;
+    }
   }
 
   return bestRes;
@@ -680,7 +767,8 @@ RESOLUTION CDisplaySettings::GetResolutionFromString(const std::string &strResol
     return RES_WINDOW;
   else if (strResolution.size() >= 20)
   {
-    // format: WWWWWHHHHHRRR.RRRRRP333, where W = width, H = height, R = refresh, P = interlace, 3 = stereo mode
+    // format: WWWWWHHHHHRRR.RRRRRP333A, where W = width, H = height, R = refresh, P = interlace,
+    // 3 = stereo mode, A = signalled content aspect ratio (added later; absent means unspecified)
     const auto width =
         static_cast<int>(std::strtol(StringUtils::Mid(strResolution, 0, 5).c_str(), nullptr, 10));
     const auto height =
@@ -698,12 +786,16 @@ RESOLUTION CDisplaySettings::GetResolutionFromString(const std::string &strResol
     else if(StringUtils::Mid(strResolution, 20,3) == "tab")
       flags |= D3DPRESENTFLAG_MODE3DTB;
 
+    float aspectRatio = 0.0f;
+    if (strResolution.size() > 23)
+      aspectRatio = CharToAspectRatio(strResolution[23]);
+
     std::map<RESOLUTION, RESOLUTION_INFO> resolutionInfos;
     for (size_t resolution = RES_DESKTOP; resolution < CDisplaySettings::GetInstance().ResolutionInfoSize(); resolution++)
       resolutionInfos.try_emplace(static_cast<RESOLUTION>(resolution),
                                   CDisplaySettings::GetInstance().GetResolutionInfo(resolution));
 
-    return FindBestMatchingResolution(resolutionInfos, width, height, refresh, flags);
+    return FindBestMatchingResolution(resolutionInfos, width, height, refresh, flags, aspectRatio);
   }
 
   return RES_DESKTOP;
@@ -721,9 +813,10 @@ std::string CDisplaySettings::GetStringFromResolution(RESOLUTION resolution, flo
     // also handle RES_DESKTOP resolutions with non-default refresh rates
     if (resolution != RES_DESKTOP || (refreshrate > 0.0f && refreshrate != info.fRefreshRate))
     {
-      return StringUtils::Format("{:05}{:05}{:09.5f}{}", info.iScreenWidth, info.iScreenHeight,
+      return StringUtils::Format("{:05}{:05}{:09.5f}{}{}", info.iScreenWidth, info.iScreenHeight,
                                  refreshrate > 0.0f ? refreshrate : info.fRefreshRate,
-                                 ModeFlagsToString(info.dwFlags, true));
+                                 ModeFlagsToString(info.dwFlags, true),
+                                 AspectRatioToChar(info.fSignalledAspectRatio));
     }
   }
 
@@ -753,9 +846,12 @@ void CDisplaySettings::SettingOptionsModesFiller(const std::shared_ptr<const CSe
       const std::string screenmode =
           GetStringFromResolution(static_cast<RESOLUTION>(index), mode.fRefreshRate);
 
+      const std::string aspectLabel = AspectRatioLabel(mode.fSignalledAspectRatio);
+
       list.emplace_back(
-          StringUtils::Format("{}x{}{} {:0.2f}Hz", mode.iScreenWidth, mode.iScreenHeight,
-                              ModeFlagsToString(mode.dwFlags, false), mode.fRefreshRate),
+          StringUtils::Format("{}x{}{} {:0.2f}Hz{}", mode.iScreenWidth, mode.iScreenHeight,
+                              ModeFlagsToString(mode.dwFlags, false), mode.fRefreshRate,
+                              aspectLabel),
           screenmode);
     }
   }

--- a/xbmc/settings/DisplaySettings.h
+++ b/xbmc/settings/DisplaySettings.h
@@ -68,6 +68,7 @@ public:
   RESOLUTION_INFO& GetResolutionInfo(RESOLUTION resolution);
   size_t ResolutionInfoSize() const { return m_resolutions.size(); }
   void AddResolutionInfo(const RESOLUTION_INFO &resolution);
+  float GetDefaultPixelRatio(const std::string& mode) const;
 
   const RESOLUTION_INFO& GetCurrentResolutionInfo() const { return GetResolutionInfo(m_currentResolution); }
   RESOLUTION_INFO& GetCurrentResolutionInfo() { return GetResolutionInfo(m_currentResolution); }
@@ -146,7 +147,7 @@ protected:
   static std::string GetStringFromResolution(RESOLUTION resolution, float refreshrate = 0.0f);
   static RESOLUTION GetResolutionForScreen();
 
-  static RESOLUTION FindBestMatchingResolution(const std::map<RESOLUTION, RESOLUTION_INFO> &resolutionInfos, int width, int height, float refreshrate, unsigned int flags);
+  static RESOLUTION FindBestMatchingResolution(const std::map<RESOLUTION, RESOLUTION_INFO> &resolutionInfos, int width, int height, float refreshrate, unsigned int flags, float aspectRatio = 0.0f);
 
 private:
   // holds the real gui resolution
@@ -155,6 +156,7 @@ private:
   using ResolutionInfos = std::vector<RESOLUTION_INFO>;
   ResolutionInfos m_resolutions;
   ResolutionInfos m_calibrations;
+  std::map<std::string, float> m_defaultPixelRatios;
 
   float m_zoomAmount{1.0f}; // current zoom amount
   float m_pixelRatio{1.0f}; // current pixel ratio

--- a/xbmc/windowing/GraphicContext.cpp
+++ b/xbmc/windowing/GraphicContext.cpp
@@ -576,7 +576,7 @@ void CGraphicContext::ResetScreenParameters(RESOLUTION res)
   RESOLUTION_INFO& info = CDisplaySettings::GetInstance().GetResolutionInfo(res);
 
   info.iSubtitles = info.iHeight;
-  info.fPixelRatio = 1.0f;
+  info.fPixelRatio = CDisplaySettings::GetInstance().GetDefaultPixelRatio(info.strMode);
   info.iScreenWidth = info.iWidth;
   info.iScreenHeight = info.iHeight;
   ResetOverscan(res, info.Overscan);

--- a/xbmc/windowing/Resolution.cpp
+++ b/xbmc/windowing/Resolution.cpp
@@ -19,6 +19,7 @@
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
 
+#include <cmath>
 #include <cstdlib>
 #include <limits>
 
@@ -28,6 +29,18 @@ namespace
 const char* SETTING_VIDEOSCREEN_WHITELIST_PULLDOWN{"videoscreen.whitelistpulldown"};
 const char* SETTING_VIDEOSCREEN_WHITELIST_DOUBLEREFRESHRATE{
     "videoscreen.whitelistdoublerefreshrate"};
+
+// Extra selection cost for a candidate mode whose signalled content aspect ratio (e.g. a DRM
+// CEA picture-aspect-ratio VIC flag) does not match the aspect ratio of the video being played.
+// Zero when either side has no signalled/known aspect ratio, so modes without VIC aspect
+// signalling (the vast majority) are unaffected.
+unsigned int AspectMismatchPenalty(float infoAspectRatio, float contentAspectRatio)
+{
+  if (infoAspectRatio <= 0.0f || contentAspectRatio <= 0.0f)
+    return 0;
+
+  return static_cast<unsigned int>(std::fabs(infoAspectRatio - contentAspectRatio) * 1000.0f);
+}
 
 } // namespace
 
@@ -54,7 +67,8 @@ float RESOLUTION_INFO::DisplayRatio() const
   return iWidth * fPixelRatio / iHeight;
 }
 
-RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, int height, bool is3D)
+RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, int height, bool is3D,
+                                                   float contentAspectRatio)
 {
   RESOLUTION res = CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution();
   float weight = 0.0f;
@@ -63,7 +77,8 @@ RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, int heig
   {
     if (!FindResolutionFromOverride(fps, width, is3D, res, weight, true)) //if that fails find it from a fallback
     {
-      FindResolutionFromWhitelist(fps, width, height, is3D, res); //find a refreshrate from whitelist
+      FindResolutionFromWhitelist(fps, width, height, is3D, res,
+                                   contentAspectRatio); //find a refreshrate from whitelist
     }
   }
 
@@ -72,7 +87,9 @@ RESOLUTION CResolutionUtils::ChooseBestResolution(float fps, int width, int heig
   return res;
 }
 
-void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int height, bool is3D, RESOLUTION &resolution)
+void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int height, bool is3D,
+                                                     RESOLUTION& resolution,
+                                                     float contentAspectRatio)
 {
   RESOLUTION_INFO curr = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo(resolution);
   CLog::Log(LOGINFO,
@@ -127,7 +144,8 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
       CLog::Log(LOGDEBUG,
                 "[WHITELIST] Matched an exact resolution with an exact refresh rate {} ({})",
                 info.strMode, i);
-      unsigned int pen = abs(info.iScreenHeight - height) + abs(info.iScreenWidth - width);
+      unsigned int pen = abs(info.iScreenHeight - height) + abs(info.iScreenWidth - width) +
+                          AspectMismatchPenalty(info.fSignalledAspectRatio, contentAspectRatio);
       if (pen < penalty)
       {
         resolution = i;
@@ -162,7 +180,8 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
         CLog::Log(LOGDEBUG,
                   "[WHITELIST] Matched an exact resolution with double the refresh rate {} ({})",
                   info.strMode, i);
-        unsigned int pen = abs(info.iScreenHeight - height) + abs(info.iScreenWidth - width);
+        unsigned int pen = abs(info.iScreenHeight - height) + abs(info.iScreenWidth - width) +
+                            AspectMismatchPenalty(info.fSignalledAspectRatio, contentAspectRatio);
         if (pen < penalty)
         {
           resolution = i;
@@ -203,7 +222,8 @@ void CResolutionUtils::FindResolutionFromWhitelist(float fps, int width, int hei
             LOGDEBUG,
             "[WHITELIST] Matched an exact resolution with a 3:2 pulldown refresh rate {} ({})",
             info.strMode, i);
-        unsigned int pen = abs(info.iScreenHeight - height) + abs(info.iScreenWidth - width);
+        unsigned int pen = abs(info.iScreenHeight - height) + abs(info.iScreenWidth - width) +
+                            AspectMismatchPenalty(info.fSignalledAspectRatio, contentAspectRatio);
         if (pen < penalty)
         {
           resolution = i;

--- a/xbmc/windowing/Resolution.h
+++ b/xbmc/windowing/Resolution.h
@@ -98,6 +98,10 @@ struct RESOLUTION_INFO
   //!< Pixel aspect ratio
   float fPixelRatio;
 
+  //!< Content aspect ratio signalled for this mode (e.g. DRM picture-aspect-ratio VIC flag),
+  //!< 0 when the mode does not signal a specific content aspect ratio
+  float fSignalledAspectRatio{0.0f};
+
   //!< Refresh rate
   float fRefreshRate;
 
@@ -118,7 +122,8 @@ public:
 class CResolutionUtils
 {
 public:
-  static RESOLUTION ChooseBestResolution(float fps, int width, int height, bool is3D);
+  static RESOLUTION ChooseBestResolution(float fps, int width, int height, bool is3D,
+                                          float contentAspectRatio = 0.0f);
   static bool HasWhitelist();
   static void PrintWhitelist();
 
@@ -130,7 +135,8 @@ public:
   static void GetMaxAllowedScreenResolution(unsigned int& width, unsigned int& height);
 
 protected:
-  static void FindResolutionFromWhitelist(float fps, int width, int height, bool is3D, RESOLUTION &resolution);
+  static void FindResolutionFromWhitelist(float fps, int width, int height, bool is3D,
+                                           RESOLUTION& resolution, float contentAspectRatio = 0.0f);
   static bool FindResolutionFromOverride(float fps, int width, bool is3D, RESOLUTION &resolution, float& weight, bool fallback);
   static float RefreshWeight(float refresh, float fps);
 };

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -18,6 +18,8 @@
 
 #include "PlatformDefs.h"
 
+#include <algorithm>
+
 using namespace KODI::WINDOWING::GBM;
 
 namespace
@@ -531,7 +533,7 @@ bool CDRMUtils::InitDrm()
   }
 
 #if defined(DRM_CLIENT_CAP_ASPECT_RATIO)
-  ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_ASPECT_RATIO, 0);
+  ret = drmSetClientCap(m_fd, DRM_CLIENT_CAP_ASPECT_RATIO, 1);
   if (ret != 0)
     CLog::LogF(LOGERROR, "Aspect ratio capability is not supported: {}", strerror(errno));
 #endif
@@ -818,6 +820,41 @@ RESOLUTION_INFO CDRMUtils::GetResolutionInfo(drmModeModeInfoPtr mode)
     res.fRefreshRate = mode->vrefresh;
   res.iSubtitles = res.iHeight;
   res.fPixelRatio = 1.0f;
+  res.fSignalledAspectRatio = 0.0f;
+
+  std::string aspectSuffix;
+#if defined(DRM_MODE_FLAG_PIC_AR_4_3)
+  if (res.iScreenWidth > 0 && res.iScreenHeight > 0)
+  {
+    const float res_ratio = static_cast<float>(res.iScreenWidth) / res.iScreenHeight;
+    switch (mode->flags & DRM_MODE_FLAG_PIC_AR_MASK)
+    {
+      case DRM_MODE_FLAG_PIC_AR_4_3:
+        res.fSignalledAspectRatio = 4.0f / 3.0f;
+        res.fPixelRatio = res.fSignalledAspectRatio / res_ratio;
+        aspectSuffix = " (4:3)";
+        break;
+      case DRM_MODE_FLAG_PIC_AR_16_9:
+        res.fSignalledAspectRatio = 16.0f / 9.0f;
+        res.fPixelRatio = res.fSignalledAspectRatio / res_ratio;
+        aspectSuffix = " (16:9)";
+        break;
+      case DRM_MODE_FLAG_PIC_AR_64_27:
+        res.fSignalledAspectRatio = 64.0f / 27.0f;
+        res.fPixelRatio = res.fSignalledAspectRatio / res_ratio;
+        aspectSuffix = " (64:27)";
+        break;
+      case DRM_MODE_FLAG_PIC_AR_256_135:
+        res.fSignalledAspectRatio = 256.0f / 135.0f;
+        res.fPixelRatio = res.fSignalledAspectRatio / res_ratio;
+        aspectSuffix = " (256:135)";
+        break;
+      default:
+        break;
+    }
+  }
+#endif
+
   res.bFullScreen = true;
 
   if (mode->flags & DRM_MODE_FLAG_3D_MASK)
@@ -832,9 +869,9 @@ RESOLUTION_INFO CDRMUtils::GetResolutionInfo(drmModeModeInfoPtr mode)
   else
     res.dwFlags = D3DPRESENTFLAG_PROGRESSIVE;
 
-  res.strMode =
-      StringUtils::Format("{}x{}{} @ {:.6f} Hz", res.iScreenWidth, res.iScreenHeight,
-                          res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "", res.fRefreshRate);
+  res.strMode = StringUtils::Format("{}x{}{} @ {:.6f} Hz{}", res.iScreenWidth, res.iScreenHeight,
+                                     res.dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "",
+                                     res.fRefreshRate, aspectSuffix);
   return res;
 }
 
@@ -852,7 +889,12 @@ std::vector<RESOLUTION_INFO> CDRMUtils::GetModes()
   {
     RESOLUTION_INFO res = GetResolutionInfo(m_connector->GetModeForIndex(i));
     res.strId = std::to_string(i);
-    resolutions.push_back(res);
+
+    auto existing = std::find_if(resolutions.begin(), resolutions.end(),
+                                  [&](const RESOLUTION_INFO& other)
+                                  { return other.strMode == res.strMode; });
+    if (existing == resolutions.end())
+      resolutions.push_back(res);
   }
 
   return resolutions;


### PR DESCRIPTION
## Description
SD CEA display modes (720x480, 720x576) are raw 3:2 / 5:4 pixel-shaped, but represent 4:3 or 16:9 broadcast content. CDRMUtils::GetResolutionInfo() hardcoded fPixelRatio = 1.0f for every mode, so CBaseRenderer::CalcDestRect() sized video assuming square pixels. On a physically widescreen display, this produced a windowboxed/squashed picture for SD content played back at these output resolutions.

DRMUtils.cpp: `GetResolutionInfo()` now reads the mode's own `DRM_MODE_FLAG_PIC_AR_*` flag (per CTA-861) and computes `fPixelRatio` from the actual declared picture aspect ratio for *that specific mode*, instead of assuming square pixels.

DisplaySettings.cpp:  it unconditionally overwrites a resolution's fPixelRatio with whatever's stored in guisettings.xml, matched by strMode. Because UpdateCalibrations() persists an entry for any resolution not at "default" calibration, a stale fPixelRatio=1.0f written to disk before this fix existed (or from any prior session) gets silently reapplied on every subsequent launch — clobbering the newly-computed correct value immediately after UpdateResolutions() sets it, with no user action or explicit calibration involved. Since a saved 1.0f is indistinguishable from "never calibrated" vs. "user deliberately chose 1.0", ApplyCalibrations() now only applies the saved ratio when it's a real non-default value, or when the backend hasn't computed anything better itself.

## How has this been tested?
Intel TGL + LibreELEC 13 + DVDs + SDTV DVB broadcast streams.

## What is the effect on users?
SD video plays at native resolution with correct aspect ratio.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed