### PR TITLE
python3: disable dup3/pipe2 detection on darwin_embedded

### DIFF
--- a/tools/depends/target/python3/Makefile
+++ b/tools/depends/target/python3/Makefile
@@ -17,7 +17,9 @@ ifeq ($(findstring apple-darwin, $(HOST)), apple-darwin)
                     ac_cv_func_posix_spawn=no ac_cv_func_posix_spawnp=no \
                     ac_cv_func_forkpty=no ac_cv_lib_util_forkpty=no \
                     ac_cv_func_getgroups=no \
-                    ac_cv_func_system=no
+                    ac_cv_func_system=no \
+                    ac_cv_func_dup3=no \
+                    ac_cv_func_pipe2=no
     export SDKROOT
   endif
   ifeq ($(OS), osx)


### PR DESCRIPTION
Building against the iOS/iOS Simulator SDKs shipped with recent Xcode (26.x) fails compiling posixmodule.c: configure's link-only check detects dup3/pipe2 as present because newer libSystem exports the symbols, but they are not declared in the embedded-platform headers, so the actual build hits -Werror=implicit-function-declaration.

Neither function is part of iOS's public API, so force them off the same way the other iOS-unavailable functions in this block already are.

see https://github.com/python/cpython/issues/153711