### PR TITLE
[Video] Add advanced setting to ignore folder names within archives for movie name determination.

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1932,6 +1932,9 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
 {
   std::string strMovieName{m_strPath};
 
+  const bool ignoreFolderNamesInArchives{
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_ignoreFolderNamesInArchives};
+
   if (IsMultiPath())
     strMovieName = CMultiPathDirectory::GetFirstPath(m_strPath);
   if (strMovieName.empty())
@@ -1993,7 +1996,7 @@ std::string CFileItem::GetBaseMoviePath(bool bUseFolderNames) const
         }
       }
       const std::string folder{URIUtils::GetDirectory(url.GetFileName())};
-      if (folder.empty())
+      if (folder.empty() || ignoreFolderNamesInArchives)
       {
         // Not in folder in archive so use folder archive is in
         const std::string name{strMovieName};

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -408,6 +408,8 @@ void CAdvancedSettings::Initialize()
   m_caseSensitiveLocalArtMatch = true; // case sensitive local art matching
   m_bNoRemoteArtWithLocalScraper =
       false; // If local nfo file refers to online art, it will be retrieved
+  m_ignoreFolderNamesInArchives =
+      true; // Whether the folder name inside an archive (if present) should be ignored when determining the movie name
 
   m_iEpgUpdateCheckInterval = 300; /* Check every X seconds, if EPG data need to be updated. This does not mean that
                                       every X seconds an EPG update is actually triggered, it's just the interval how
@@ -913,6 +915,7 @@ void CAdvancedSettings::ParseSettingsFile(const std::string &file)
     XMLUtils::GetInt(pElement, "minimumepisodeplaylistduration", m_minimumEpisodePlaylistDuration);
     XMLUtils::GetBoolean(pElement, "disableepisoderanges", m_disableEpisodeRanges);
     XMLUtils::GetBoolean(pElement, "noremoteartwithlocalscraper", m_bNoRemoteArtWithLocalScraper);
+    XMLUtils::GetBoolean(pElement, "ignorefoldernamesinarchives", m_ignoreFolderNamesInArchives);
   }
 
   pElement = pRootElement->FirstChildElement("videoscanner");

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -301,6 +301,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     int m_minimumEpisodePlaylistDuration; // seconds
     bool m_disableEpisodeRanges{false};
     bool m_bNoRemoteArtWithLocalScraper{false};
+    bool m_ignoreFolderNamesInArchives{true};
 
     CLangInfo::Tokens m_vecTokens;
 

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -30,6 +30,7 @@ struct TestFileData
   const char* file;
   bool use_folder;
   const char* base;
+  const char* base2{};
 };
 
 struct TestNameData
@@ -37,6 +38,7 @@ struct TestNameData
   const char* file;
   bool use_folder;
   const char* name;
+  const char* name2{};
 };
 
 class AdvancedSettingsResetBase : public Test
@@ -195,11 +197,11 @@ const TestFileData BaseMovies[] = {
     {"zip://smb%3a%2f%2fsomepath%2fmovies%2fmovie.zip/movie/film.avi", false,
      "zip://smb%3a%2f%2fsomepath%2fmovies%2fmovie.zip/movie/film.avi"},
     {"zip://smb%3a%2f%2fsomepath%2fmovies%2ffilm.zip/movie/film.avi", true,
-     "zip://smb%3a%2f%2fsomepath%2fmovies%2ffilm.zip/movie/"},
+     "zip://smb%3a%2f%2fsomepath%2fmovies%2ffilm.zip/movie/", "smb://somepath/movies/"},
     {"zip://smb%3a%2f%2fsomepath%2fmovies%2fmovies.zip/movie/BDMV/index.bdmv", false,
      "zip://smb%3a%2f%2fsomepath%2fmovies%2fmovies.zip/movie/"},
     {"zip://smb%3a%2f%2fsomepath%2fmovies%2fmovies.zip/movie/BDMV/index.bdmv", true,
-     "zip://smb%3a%2f%2fsomepath%2fmovies%2fmovies.zip/movie/"},
+     "zip://smb%3a%2f%2fsomepath%2fmovies%2fmovies.zip/movie/", "smb://somepath/movies/"},
     {"zip://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.zip/BDMV/index.bdmv", false,
      "smb://somepath/movie/disc 1/movie_disc.zip"},
     {"zip://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.zip/BDMV/index.bdmv", true,
@@ -218,11 +220,11 @@ const TestFileData BaseMovies[] = {
     {"rar://smb%3a%2f%2fsomepath%2fmovies%2fmovie.rar/movie/film.avi", false,
      "rar://smb%3a%2f%2fsomepath%2fmovies%2fmovie.rar/movie/film.avi"},
     {"rar://smb%3a%2f%2fsomepath%2fmovies%2ffilm.rar/movie/film.avi", true,
-     "rar://smb%3a%2f%2fsomepath%2fmovies%2ffilm.rar/movie/"},
+     "rar://smb%3a%2f%2fsomepath%2fmovies%2ffilm.rar/movie/", "smb://somepath/movies/"},
     {"rar://smb%3a%2f%2fsomepath%2fmovies%2fmovies.rar/movie/BDMV/index.bdmv", false,
      "rar://smb%3a%2f%2fsomepath%2fmovies%2fmovies.rar/movie/"},
     {"rar://smb%3a%2f%2fsomepath%2fmovies%2fmovies.rar/movie/BDMV/index.bdmv", true,
-     "rar://smb%3a%2f%2fsomepath%2fmovies%2fmovies.rar/movie/"},
+     "rar://smb%3a%2f%2fsomepath%2fmovies%2fmovies.rar/movie/", "smb://somepath/movies/"},
     {"rar://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.rar/BDMV/index.bdmv", false,
      "smb://somepath/movie/disc 1/movie_disc.rar"},
     {"rar://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.rar/BDMV/index.bdmv", true,
@@ -242,11 +244,11 @@ const TestFileData BaseMovies[] = {
     {"archive://smb%3a%2f%2fsomepath%2fmovies%2fmovie.tar.gz/movie/film.avi", false,
      "archive://smb%3a%2f%2fsomepath%2fmovies%2fmovie.tar.gz/movie/film.avi"},
     {"archive://smb%3a%2f%2fsomepath%2fmovies%2ffilm.tar.gz/movie/film.avi", true,
-     "archive://smb%3a%2f%2fsomepath%2fmovies%2ffilm.tar.gz/movie/"},
+     "archive://smb%3a%2f%2fsomepath%2fmovies%2ffilm.tar.gz/movie/", "smb://somepath/movies/"},
     {"archive://smb%3a%2f%2fsomepath%2fmovies%2fmovies.tar.gz/movie/BDMV/index.bdmv", false,
      "archive://smb%3a%2f%2fsomepath%2fmovies%2fmovies.tar.gz/movie/"},
     {"archive://smb%3a%2f%2fsomepath%2fmovies%2fmovies.tar.gz/movie/BDMV/index.bdmv", true,
-     "archive://smb%3a%2f%2fsomepath%2fmovies%2fmovies.tar.gz/movie/"},
+     "archive://smb%3a%2f%2fsomepath%2fmovies%2fmovies.tar.gz/movie/", "smb://somepath/movies/"},
     {"archive://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.tar.gz/BDMV/index.bdmv", false,
      "smb://somepath/movie/disc 1/movie_disc.tar.gz"},
     {"archive://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2fmovie_disc.tar.gz/BDMV/index.bdmv", true,
@@ -279,11 +281,11 @@ const TestFileData BaseMovies[] = {
     {"zip://%2fsomepath%2fmovies%2fmovie.zip/movie/film.avi", false,
      "zip://%2fsomepath%2fmovies%2fmovie.zip/movie/film.avi"},
     {"zip://%2fsomepath%2fmovies%2ffilm.zip/movie/film.avi", true,
-     "zip://%2fsomepath%2fmovies%2ffilm.zip/movie/"},
+     "zip://%2fsomepath%2fmovies%2ffilm.zip/movie/", "/somepath/movies/"},
     {"zip://%2fsomepath%2fmovies%2fmovies.zip/movie/BDMV/index.bdmv", false,
      "zip://%2fsomepath%2fmovies%2fmovies.zip/movie/"},
     {"zip://%2fsomepath%2fmovies%2fmovies.zip/movie/BDMV/index.bdmv", true,
-     "zip://%2fsomepath%2fmovies%2fmovies.zip/movie/"},
+     "zip://%2fsomepath%2fmovies%2fmovies.zip/movie/", "/somepath/movies/"},
     {"zip://%2fsomepath%2fdisc%201%2fmovie.zip/BDMV/index.bdmv", false,
      "/somepath/disc 1/movie.zip"},
     {"zip://%2fsomepath%2fdisc%201%2fmovie.zip/BDMV/index.bdmv", true, "/somepath/"},
@@ -298,11 +300,11 @@ const TestFileData BaseMovies[] = {
     {"rar://%2fsomepath%2fmovies%2fmovie.rar/movie/film.avi", false,
      "rar://%2fsomepath%2fmovies%2fmovie.rar/movie/film.avi"},
     {"rar://%2fsomepath%2fmovies%2ffilm.rar/movie/film.avi", true,
-     "rar://%2fsomepath%2fmovies%2ffilm.rar/movie/"},
+     "rar://%2fsomepath%2fmovies%2ffilm.rar/movie/", "/somepath/movies/"},
     {"rar://%2fsomepath%2fmovies%2fmovies.rar/movie/BDMV/index.bdmv", false,
      "rar://%2fsomepath%2fmovies%2fmovies.rar/movie/"},
     {"rar://%2fsomepath%2fmovies%2fmovies.rar/movie/BDMV/index.bdmv", true,
-     "rar://%2fsomepath%2fmovies%2fmovies.rar/movie/"},
+     "rar://%2fsomepath%2fmovies%2fmovies.rar/movie/", "/somepath/movies/"},
     {"rar://%2fsomepath%2fdisc%201%2fmovie_disc.rar/BDMV/index.bdmv", false,
      "/somepath/disc 1/movie_disc.rar"},
     {"rar://%2fsomepath%2fdisc%201%2fmovie_disc.rar/BDMV/index.bdmv", true, "/somepath/"},
@@ -319,11 +321,11 @@ const TestFileData BaseMovies[] = {
     {"archive://%2fsomepath%2fmovies%2fmovie.tar.gz/movie/film.avi", false,
      "archive://%2fsomepath%2fmovies%2fmovie.tar.gz/movie/film.avi"},
     {"archive://%2fsomepath%2fmovies%2ffilm.tar.gz/movie/film.avi", true,
-     "archive://%2fsomepath%2fmovies%2ffilm.tar.gz/movie/"},
+     "archive://%2fsomepath%2fmovies%2ffilm.tar.gz/movie/", "/somepath/movies/"},
     {"archive://%2fsomepath%2fmovies%2fmovies.tar.gz/movie/BDMV/index.bdmv", false,
      "archive://%2fsomepath%2fmovies%2fmovies.tar.gz/movie/"},
     {"archive://%2fsomepath%2fmovies%2fmovies.tar.gz/movie/BDMV/index.bdmv", true,
-     "archive://%2fsomepath%2fmovies%2fmovies.tar.gz/movie/"},
+     "archive://%2fsomepath%2fmovies%2fmovies.tar.gz/movie/", "/somepath/movies/"},
     {"archive://%2fsomepath%2fdisc%201%2fmovie.tar.gz/BDMV/index.bdmv", false,
      "/somepath/disc 1/movie.tar.gz"},
     {"archive://%2fsomepath%2fdisc%201%2fmovie.tar.gz/BDMV/index.bdmv", true, "/somepath/"},
@@ -356,11 +358,11 @@ const TestFileData BaseMovies[] = {
     {"zip://D%3a%5cmovies%5cmovie%5cmovie.zip/movie/film.avi", false,
      "zip://D%3a%5cmovies%5cmovie%5cmovie.zip/movie/film.avi"},
     {"zip://D%3a%5cmovies%5cmovie%5cfilm.zip/movie/film.avi", true,
-     "zip://D%3a%5cmovies%5cmovie%5cfilm.zip/movie/"},
+     "zip://D%3a%5cmovies%5cmovie%5cfilm.zip/movie/", "D:\\movies\\movie\\"},
     {"zip://D%3a%5cmovies%5cmovies.zip/movie/BDMV/index.bdmv", false,
      "zip://D%3a%5cmovies%5cmovies.zip/movie/"},
     {"zip://D%3a%5cmovies%5cmovies.zip/movie/BDMV/index.bdmv", true,
-     "zip://D%3a%5cmovies%5cmovies.zip/movie/"},
+     "zip://D%3a%5cmovies%5cmovies.zip/movie/", "D:\\movies\\"},
     {"zip://D%3a%5cmovies%5cmovie%5cdisc%201%5cmovie.zip/BDMV/index.bdmv", false,
      "D:\\movies\\movie\\disc 1\\movie.zip"},
     {"zip://D%3a%5cmovies%5cmovie%5cdisc%201%5cmovie.zip/BDMV/index.bdmv", true,
@@ -377,11 +379,11 @@ const TestFileData BaseMovies[] = {
     {"rar://D%3a%5cmovies%5cmovie%5cmovie.rar/movie/film.avi", false,
      "rar://D%3a%5cmovies%5cmovie%5cmovie.rar/movie/film.avi"},
     {"rar://D%3a%5cmovies%5cmovie%5cfilm.rar/movie/film.avi", true,
-     "rar://D%3a%5cmovies%5cmovie%5cfilm.rar/movie/"},
+     "rar://D%3a%5cmovies%5cmovie%5cfilm.rar/movie/", "D:\\movies\\movie\\"},
     {"rar://D%3a%5cmovies%5cmovies.rar/movie/BDMV/index.bdmv", false,
      "rar://D%3a%5cmovies%5cmovies.rar/movie/"},
     {"rar://D%3a%5cmovies%5cmovies.rar/movie/BDMV/index.bdmv", true,
-     "rar://D%3a%5cmovies%5cmovies.rar/movie/"},
+     "rar://D%3a%5cmovies%5cmovies.rar/movie/", "D:\\movies\\"},
     {"rar://D%3a%5cmovies%5cmovie%5cdisc%201%5cmovie.rar/BDMV/index.bdmv", false,
      "D:\\movies\\movie\\disc 1\\movie.rar"},
     {"rar://D%3a%5cmovies%5cmovie%5cdisc%201%5cmovie.rar/BDMV/index.bdmv", true,
@@ -398,11 +400,11 @@ const TestFileData BaseMovies[] = {
     {"archive://D%3a%5cmovies%5cmovie%5cmovie.tar.gz/movie/film.avi", false,
      "archive://D%3a%5cmovies%5cmovie%5cmovie.tar.gz/movie/film.avi"},
     {"archive://D%3a%5cmovies%5cmovie%5cfilm.tar.gz/movie/film.avi", true,
-     "archive://D%3a%5cmovies%5cmovie%5cfilm.tar.gz/movie/"},
+     "archive://D%3a%5cmovies%5cmovie%5cfilm.tar.gz/movie/", "D:\\movies\\movie\\"},
     {"archive://D%3a%5cmovies%5cmovies.tar.gz/movie/BDMV/index.bdmv", false,
      "archive://D%3a%5cmovies%5cmovies.tar.gz/movie/"},
     {"archive://D%3a%5cmovies%5cmovies.tar.gz/movie/BDMV/index.bdmv", true,
-     "archive://D%3a%5cmovies%5cmovies.tar.gz/movie/"},
+     "archive://D%3a%5cmovies%5cmovies.tar.gz/movie/", "D:\\movies\\"},
     {"archive://D%3a%5cmovies%5cmovie%5cdisc%201%5cmovie.tar.gz/BDMV/index.bdmv", false,
      "D:\\movies\\movie\\disc 1\\movie.tar.gz"},
     {"archive://D%3a%5cmovies%5cmovie%5cdisc%201%5cmovie.tar.gz/BDMV/index.bdmv", true,
@@ -444,11 +446,11 @@ const TestFileData BaseMovies[] = {
     {"zip://%5c%5cServer%5cMovies%5cmovie%5cmovie.zip/movie/film.avi", false,
      "zip://%5c%5cServer%5cMovies%5cmovie%5cmovie.zip/movie/film.avi"},
     {"zip://%5c%5cServer%5cMovies%5cmovie%5cfilm.zip/movie/film.avi", true,
-     "zip://%5c%5cServer%5cMovies%5cmovie%5cfilm.zip/movie/"},
+     "zip://%5c%5cServer%5cMovies%5cmovie%5cfilm.zip/movie/", "\\\\Server\\Movies\\movie\\"},
     {"zip://%5c%5cServer%5cMovies%5cmovies.zip/movie/BDMV/index.bdmv", false,
      "zip://%5c%5cServer%5cMovies%5cmovies.zip/movie/"},
     {"zip://%5c%5cServer%5cMovies%5cmovies.zip/movie/BDMV/index.bdmv", true,
-     "zip://%5c%5cServer%5cMovies%5cmovies.zip/movie/"},
+     "zip://%5c%5cServer%5cMovies%5cmovies.zip/movie/", "\\\\Server\\Movies\\"},
     {"zip://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie.zip/BDMV/index.bdmv", false,
      "\\\\Server\\Movies\\Movie\\disc 1\\movie.zip"},
     {"zip://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie.zip/BDMV/index.bdmv", true,
@@ -467,11 +469,11 @@ const TestFileData BaseMovies[] = {
     {"rar://%5c%5cServer%5cMovies%5cmovie%5cmovie.rar/movie/film.avi", false,
      "rar://%5c%5cServer%5cMovies%5cmovie%5cmovie.rar/movie/film.avi"},
     {"rar://%5c%5cServer%5cMovies%5cmovie%5cfilm.rar/movie/film.avi", true,
-     "rar://%5c%5cServer%5cMovies%5cmovie%5cfilm.rar/movie/"},
+     "rar://%5c%5cServer%5cMovies%5cmovie%5cfilm.rar/movie/", "\\\\Server\\Movies\\movie\\"},
     {"rar://%5c%5cServer%5cMovies%5cmovies.rar/movie/BDMV/index.bdmv", false,
      "rar://%5c%5cServer%5cMovies%5cmovies.rar/movie/"},
     {"rar://%5c%5cServer%5cMovies%5cmovies.rar/movie/BDMV/index.bdmv", true,
-     "rar://%5c%5cServer%5cMovies%5cmovies.rar/movie/"},
+     "rar://%5c%5cServer%5cMovies%5cmovies.rar/movie/", "\\\\Server\\Movies\\"},
     {"rar://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie.rar/BDMV/index.bdmv", false,
      "\\\\Server\\Movies\\Movie\\disc 1\\movie.rar"},
     {"rar://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie.rar/BDMV/index.bdmv", true,
@@ -491,11 +493,11 @@ const TestFileData BaseMovies[] = {
     {"archive://%5c%5cServer%5cMovies%5cmovie%5cmovie.tar.gz/movie/film.avi", false,
      "archive://%5c%5cServer%5cMovies%5cmovie%5cmovie.tar.gz/movie/film.avi"},
     {"archive://%5c%5cServer%5cMovies%5cmovie%5cfilm.tar.gz/movie/film.avi", true,
-     "archive://%5c%5cServer%5cMovies%5cmovie%5cfilm.tar.gz/movie/"},
+     "archive://%5c%5cServer%5cMovies%5cmovie%5cfilm.tar.gz/movie/", "\\\\Server\\Movies\\movie\\"},
     {"archive://%5c%5cServer%5cMovies%5cmovies.tar.gz/movie/BDMV/index.bdmv", false,
      "archive://%5c%5cServer%5cMovies%5cmovies.tar.gz/movie/"},
     {"archive://%5c%5cServer%5cMovies%5cmovies.tar.gz/movie/BDMV/index.bdmv", true,
-     "archive://%5c%5cServer%5cMovies%5cmovies.tar.gz/movie/"},
+     "archive://%5c%5cServer%5cMovies%5cmovies.tar.gz/movie/", "\\\\Server\\Movies\\"},
     {"archive://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie.tar.gz/BDMV/index.bdmv", false,
      "\\\\Server\\Movies\\Movie\\disc 1\\movie.tar.gz"},
     {"archive://%5c%5cServer%5cMovies%5cMovie%5cdisc%201%5cmovie.tar.gz/BDMV/index.bdmv", true,
@@ -503,11 +505,24 @@ const TestFileData BaseMovies[] = {
 
 TEST_P(TestFileItemBasePath, GetBaseMoviePath)
 {
+  const auto settings = CServiceBroker::GetSettingsComponent();
+  const bool old = settings->GetAdvancedSettings()->m_ignoreFolderNamesInArchives;
+  settings->GetAdvancedSettings()->m_ignoreFolderNamesInArchives = false;
+
   CFileItem item;
   item.SetPath(GetParam().file);
-  std::string path = CURL(item.GetBaseMoviePath(GetParam().use_folder)).Get();
-  std::string compare = CURL(GetParam().base).Get();
+  std::string path = item.GetBaseMoviePath(GetParam().use_folder);
+  std::string compare = GetParam().base;
   EXPECT_EQ(compare, path);
+
+  settings->GetAdvancedSettings()->m_ignoreFolderNamesInArchives = true;
+
+  item.SetPath(GetParam().file);
+  path = item.GetBaseMoviePath(GetParam().use_folder);
+  compare = GetParam().base2 ? GetParam().base2 : GetParam().base;
+  EXPECT_EQ(compare, path);
+
+  settings->GetAdvancedSettings()->m_ignoreFolderNamesInArchives = old;
 }
 
 INSTANTIATE_TEST_SUITE_P(BaseNameMovies, TestFileItemBasePath, ValuesIn(BaseMovies));
@@ -613,9 +628,10 @@ const TestNameData BaseNames[] = {
     {"zip://smb%3a%2f%2fsomepath%2fmovie%2fmovie.zip/film.avi", false, "film"},
     {"zip://smb%3a%2f%2fsomepath%2fmovie%2ffilm.zip/film.avi", true, "movie"},
     {"zip://smb%3a%2f%2fsomepath%2fmovies%2fmovie.zip/movie/film.avi", false, "film"},
-    {"zip://smb%3a%2f%2fsomepath%2fmovies%2ffilm.zip/movie/film.avi", true, "movie"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovies%2ffilm.zip/movie/film.avi", true, "movie", "movies"},
     {"zip://smb%3a%2f%2fsomepath%2fmovies%2fmovies.zip/movie/BDMV/index.bdmv", false, "movie"},
-    {"zip://smb%3a%2f%2fsomepath%2fmovies%2fmovies.zip/movie/BDMV/index.bdmv", true, "movie"},
+    {"zip://smb%3a%2f%2fsomepath%2fmovies%2fmovies.zip/movie/BDMV/index.bdmv", true, "movie",
+     "movies"},
     {"zip://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2ffilm.zip/BDMV/index.bdmv", false, "film"},
     {"zip://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2ffilm.zip/BDMV/index.bdmv", true, "movie"},
     //
@@ -626,9 +642,10 @@ const TestNameData BaseNames[] = {
     {"rar://smb%3a%2f%2fsomepath%2fmovie%2fmovie.rar/film.avi", false, "film"},
     {"rar://smb%3a%2f%2fsomepath%2fmovie%2ffilm.rar/film.avi", true, "movie"},
     {"rar://smb%3a%2f%2fsomepath%2fmovies%2fmovie.rar/movie/film.avi", false, "film"},
-    {"rar://smb%3a%2f%2fsomepath%2fmovies%2ffilm.rar/movie/film.avi", true, "movie"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovies%2ffilm.rar/movie/film.avi", true, "movie", "movies"},
     {"rar://smb%3a%2f%2fsomepath%2fmovies%2fmovies.rar/movie/BDMV/index.bdmv", false, "movie"},
-    {"rar://smb%3a%2f%2fsomepath%2fmovies%2fmovies.rar/movie/BDMV/index.bdmv", true, "movie"},
+    {"rar://smb%3a%2f%2fsomepath%2fmovies%2fmovies.rar/movie/BDMV/index.bdmv", true, "movie",
+     "movies"},
     {"rar://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2ffilm.rar/BDMV/index.bdmv", false, "film"},
     {"rar://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2ffilm.rar/BDMV/index.bdmv", true, "movie"},
     //
@@ -639,11 +656,12 @@ const TestNameData BaseNames[] = {
     {"archive://smb%3a%2f%2fsomepath%2fmovie%2fmovie.tar.gz/film.avi", false, "film"},
     {"archive://smb%3a%2f%2fsomepath%2fmovie%2ffilm.tar.gz/film.avi", true, "movie"},
     {"archive://smb%3a%2f%2fsomepath%2fmovies%2fmovie.tar.gz/movie/film.avi", false, "film"},
-    {"archive://smb%3a%2f%2fsomepath%2fmovies%2ffilm.tar.gz/movie/film.avi", true, "movie"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovies%2ffilm.tar.gz/movie/film.avi", true, "movie",
+     "movies"},
     {"archive://smb%3a%2f%2fsomepath%2fmovies%2fmovies.tar.gz/movie/BDMV/index.bdmv", false,
      "movie"},
-    {"archive://smb%3a%2f%2fsomepath%2fmovies%2fmovies.tar.gz/movie/BDMV/index.bdmv", true,
-     "movie"},
+    {"archive://smb%3a%2f%2fsomepath%2fmovies%2fmovies.tar.gz/movie/BDMV/index.bdmv", true, "movie",
+     "movies"},
     {"archive://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2ffilm.tar.gz/BDMV/index.bdmv", false,
      "film"},
     {"archive://smb%3a%2f%2fsomepath%2fmovie%2fdisc%201%2ffilm.tar.gz/BDMV/index.bdmv", true,
@@ -668,9 +686,9 @@ const TestNameData BaseNames[] = {
     {"zip://%2fsomepath%2fmovie%2fmovie.zip/film.avi", false, "film"},
     {"zip://%2fsomepath%2fmovie%2ffilm.zip/film.avi", true, "movie"},
     {"zip://%2fsomepath%2fmovies%2fmovie.zip/movie/film.avi", false, "film"},
-    {"zip://%2fsomepath%2fmovies%2ffilm.zip/movie/film.avi", true, "movie"},
+    {"zip://%2fsomepath%2fmovies%2ffilm.zip/movie/film.avi", true, "movie", "movies"},
     {"zip://%2fsomepath%2fmovies%2fmovies.zip/movie/BDMV/index.bdmv", false, "movie"},
-    {"zip://%2fsomepath%2fmovies%2fmovies.zip/movie/BDMV/index.bdmv", true, "movie"},
+    {"zip://%2fsomepath%2fmovies%2fmovies.zip/movie/BDMV/index.bdmv", true, "movie", "movies"},
     {"zip://%2fsomepath%2fmovie%2fmovie%2fdisc%201%2ffilm.zip/BDMV/index.bdmv", false, "film"},
     {"zip://%2fsomepath%2fmovie%2fmovie%2fdisc%201%2ffilm.zip/BDMV/index.bdmv", true, "movie"},
     //
@@ -681,9 +699,9 @@ const TestNameData BaseNames[] = {
     {"rar://%2fsomepath%2fmovie%2fmovie.rar/film.avi", false, "film"},
     {"rar://%2fsomepath%2fmovie%2ffilm.rar/film.avi", true, "movie"},
     {"rar://%2fsomepath%2fmovies%2fmovie.rar/movie/film.avi", false, "film"},
-    {"rar://%2fsomepath%2fmovies%2ffilm.rar/movie/film.avi", true, "movie"},
+    {"rar://%2fsomepath%2fmovies%2ffilm.rar/movie/film.avi", true, "movie", "movies"},
     {"rar://%2fsomepath%2fmovies%2fmovies.rar/movie/BDMV/index.bdmv", false, "movie"},
-    {"rar://%2fsomepath%2fmovies%2fmovies.rar/movie/BDMV/index.bdmv", true, "movie"},
+    {"rar://%2fsomepath%2fmovies%2fmovies.rar/movie/BDMV/index.bdmv", true, "movie", "movies"},
     {"rar://%2fsomepath%2fmovie%2fdisc%201%2ffilm.rar/BDMV/index.bdmv", false, "film"},
     {"rar://%2fsomepath%2fmovie%2fdisc%201%2ffilm.rar/BDMV/index.bdmv", true, "movie"},
     //
@@ -694,9 +712,10 @@ const TestNameData BaseNames[] = {
     {"archive://%2fsomepath%2fmovie%2fmovie.tar.gz/film.avi", false, "film"},
     {"archive://%2fsomepath%2fmovie%2ffilm.tar.gz/film.avi", true, "movie"},
     {"archive://%2fsomepath%2fmovies%2fmovie.tar.gz/movie/film.avi", false, "film"},
-    {"archive://%2fsomepath%2fmovies%2ffilm.tar.gz/movie/film.avi", true, "movie"},
+    {"archive://%2fsomepath%2fmovies%2ffilm.tar.gz/movie/film.avi", true, "movie", "movies"},
     {"archive://%2fsomepath%2fmovies%2fmovies.tar.gz/movie/BDMV/index.bdmv", false, "movie"},
-    {"archive://%2fsomepath%2fmovies%2fmovies.tar.gz/movie/BDMV/index.bdmv", true, "movie"},
+    {"archive://%2fsomepath%2fmovies%2fmovies.tar.gz/movie/BDMV/index.bdmv", true, "movie",
+     "movies"},
     {"archive://%2fsomepath%2fmovie%2fdisc%201%2ffilm.tar.gz/BDMV/index.bdmv", false, "film"},
     {"archive://%2fsomepath%2fmovie%2fdisc%201%2ffilm.tar.gz/BDMV/index.bdmv", true, "movie"},
     // Embedded DOS path tests
@@ -720,9 +739,9 @@ const TestNameData BaseNames[] = {
     {"zip://C%3a%5cmovies%5cmovie%5cmovie.zip/film.avi", false, "film"},
     {"zip://C%3a%5cmovies%5cmovie%5cfilm.zip/film.avi", true, "movie"},
     {"zip://C%3a%5cmovies%5cmovie%5cmovie.zip/movie/film.avi", false, "film"},
-    {"zip://C%3a%5cmovies%5cmovie%5cfilm.zip/movie/film.avi", true, "movie"},
+    {"zip://C%3a%5cmovies%5cmovie%5cfilm.zip/movie/film.avi", true, "movie", "movie"},
     {"zip://C%3a%5cmovies%5cmovies.zip/movie/BDMV/index.bdmv", false, "movie"},
-    {"zip://C%3a%5cmovies%5cmovies.zip/movie/BDMV/index.bdmv", true, "movie"},
+    {"zip://C%3a%5cmovies%5cmovies.zip/movie/BDMV/index.bdmv", true, "movie", "movies"},
     {"zip://C%3a%5cmovies%5cmovie%5cdisc%201%5cfilm.zip/BDMV/index.bdmv", false, "film"},
     {"zip://C%3a%5cmovies%5cmovie%5cdisc%201%5cfilm.zip/BDMV/index.bdmv", true, "movie"},
     //
@@ -733,9 +752,9 @@ const TestNameData BaseNames[] = {
     {"rar://C%3a%5cmovies%5cmovie%5cmovie.rar/film.avi", false, "film"},
     {"rar://C%3a%5cmovies%5cmovie%5cfilm.rar/film.avi", true, "movie"},
     {"rar://C%3a%5cmovies%5cmovie%5cmovie.rar/movie/film.avi", false, "film"},
-    {"rar://C%3a%5cmovies%5cmovie%5cfilm.rar/movie/film.avi", true, "movie"},
+    {"rar://C%3a%5cmovies%5cmovie%5cfilm.rar/movie/film.avi", true, "movie", "movie"},
     {"rar://C%3a%5cmovies%5cmovies.rar/movie/BDMV/index.bdmv", false, "movie"},
-    {"rar://C%3a%5cmovies%5cmovies.rar/movie/BDMV/index.bdmv", true, "movie"},
+    {"rar://C%3a%5cmovies%5cmovies.rar/movie/BDMV/index.bdmv", true, "movie", "movies"},
     {"rar://C%3a%5cmovies%5cmovie%5cdisc%201%5cfilm.rar/BDMV/index.bdmv", false, "film"},
     {"rar://C%3a%5cmovies%5cmovie%5cdisc%201%5cfilm.rar/BDMV/index.bdmv", true, "movie"},
     //
@@ -746,9 +765,9 @@ const TestNameData BaseNames[] = {
     {"archive://C%3a%5cmovies%5cmovie%5cmovie.tar.gz/film.avi", false, "film"},
     {"archive://C%3a%5cmovies%5cmovie%5cfilm.tar.gz/film.avi", true, "movie"},
     {"archive://C%3a%5cmovies%5cmovie%5cmovie.tar.gz/movie/film.avi", false, "film"},
-    {"archive://C%3a%5cmovies%5cmovie%5cfilm.tar.gz/movie/film.avi", true, "movie"},
+    {"archive://C%3a%5cmovies%5cmovie%5cfilm.tar.gz/movie/film.avi", true, "movie", "movie"},
     {"archive://C%3a%5cmovies%5cmovies.tar.gz/movie/BDMV/index.bdmv", false, "movie"},
-    {"archive://C%3a%5cmovies%5cmovies.tar.gz/movie/BDMV/index.bdmv", true, "movie"},
+    {"archive://C%3a%5cmovies%5cmovies.tar.gz/movie/BDMV/index.bdmv", true, "movie", "movies"},
     {"archive://C%3a%5cmovies%5cmovie%5cdisc%201%5cfilm.tar.gz/BDMV/index.bdmv", false, "film"},
     {"archive://C%3a%5cmovies%5cmovie%5cdisc%201%5cfilm.tar.gz/BDMV/index.bdmv", true, "movie"},
     // Embedded Windows server path tests
@@ -775,9 +794,9 @@ const TestNameData BaseNames[] = {
     {"zip://%5c%5cServer%5cMovies%5cmovie%5cmovie.zip/film.avi", false, "film"},
     {"zip://%5c%5cServer%5cMovies%5cmovie%5cfilm.zip/film.avi", true, "movie"},
     {"zip://%5c%5cServer%5cMovies%5cmovie%5cmovie.zip/movie/film.avi", false, "film"},
-    {"zip://%5c%5cServer%5cMovies%5cmovie%5cfilm.zip/movie/film.avi", true, "movie"},
+    {"zip://%5c%5cServer%5cMovies%5cmovie%5cfilm.zip/movie/film.avi", true, "movie", "movie"},
     {"zip://%5c%5cServer%5cMovies%5cmovies.zip/movie/BDMV/index.bdmv", false, "movie"},
-    {"zip://%5c%5cServer%5cMovies%5cmovies.zip/movie/BDMV/index.bdmv", true, "movie"},
+    {"zip://%5c%5cServer%5cMovies%5cmovies.zip/movie/BDMV/index.bdmv", true, "movie", "Movies"},
     {"zip://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cfilm.zip/BDMV/index.bdmv", false, "film"},
     {"zip://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cfilm.zip/BDMV/index.bdmv", true, "movie"},
     //
@@ -788,9 +807,9 @@ const TestNameData BaseNames[] = {
     {"rar://%5c%5cServer%5cMovies%5cmovie%5cmovie.rar/film.avi", false, "film"},
     {"rar://%5c%5cServer%5cMovies%5cmovie%5cfilm.rar/film.avi", true, "movie"},
     {"rar://%5c%5cServer%5cMovies%5cmovie%5cmovie.rar/movie/film.avi", false, "film"},
-    {"rar://%5c%5cServer%5cMovies%5cmovie%5cfilm.rar/movie/film.avi", true, "movie"},
+    {"rar://%5c%5cServer%5cMovies%5cmovie%5cfilm.rar/movie/film.avi", true, "movie", "movie"},
     {"rar://%5c%5cServer%5cMovies%5cmovies.rar/movie/BDMV/index.bdmv", false, "movie"},
-    {"rar://%5c%5cServer%5cMovies%5cmovies.rar/movie/BDMV/index.bdmv", true, "movie"},
+    {"rar://%5c%5cServer%5cMovies%5cmovies.rar/movie/BDMV/index.bdmv", true, "movie", "Movies"},
     {"rar://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cfilm.rar/BDMV/index.bdmv", false, "film"},
     {"rar://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cfilm.rar/BDMV/index.bdmv", true, "movie"},
     //
@@ -801,9 +820,11 @@ const TestNameData BaseNames[] = {
     {"archive://%5c%5cServer%5cMovies%5cmovie%5cmovie.tar.gz/film.avi", false, "film"},
     {"archive://%5c%5cServer%5cMovies%5cmovie%5cfilm.tar.gz/film.avi", true, "movie"},
     {"archive://%5c%5cServer%5cMovies%5cmovie%5cmovie.tar.gz/movie/film.avi", false, "film"},
-    {"archive://%5c%5cServer%5cMovies%5cmovie%5cfilm.tar.gz/movie/film.avi", true, "movie"},
+    {"archive://%5c%5cServer%5cMovies%5cmovie%5cfilm.tar.gz/movie/film.avi", true, "movie",
+     "movie"},
     {"archive://%5c%5cServer%5cMovies%5cmovies.tar.gz/movie/BDMV/index.bdmv", false, "movie"},
-    {"archive://%5c%5cServer%5cMovies%5cmovies.tar.gz/movie/BDMV/index.bdmv", true, "movie"},
+    {"archive://%5c%5cServer%5cMovies%5cmovies.tar.gz/movie/BDMV/index.bdmv", true, "movie",
+     "Movies"},
     {"archive://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cfilm.tar.gz/BDMV/index.bdmv", false,
      "film"},
     {"archive://%5c%5cServer%5cMovies%5cmovie%5cdisc%201%5cfilm.tar.gz/BDMV/index.bdmv", true,
@@ -811,11 +832,24 @@ const TestNameData BaseNames[] = {
 
 TEST_P(TestFileItemMovieName, GetMovieName)
 {
+  const auto settings = CServiceBroker::GetSettingsComponent();
+  const bool old = settings->GetAdvancedSettings()->m_ignoreFolderNamesInArchives;
+  settings->GetAdvancedSettings()->m_ignoreFolderNamesInArchives = false;
+
   CFileItem item;
   item.SetPath(GetParam().file);
-  std::string path = CURL(item.GetMovieName(GetParam().use_folder)).Get();
-  std::string compare = CURL(GetParam().name).Get();
+  std::string path = item.GetMovieName(GetParam().use_folder);
+  std::string compare = GetParam().name;
   EXPECT_EQ(compare, path);
+
+  settings->GetAdvancedSettings()->m_ignoreFolderNamesInArchives = true;
+
+  item.SetPath(GetParam().file);
+  path = item.GetMovieName(GetParam().use_folder);
+  compare = GetParam().name2 ? GetParam().name2 : GetParam().name;
+  EXPECT_EQ(compare, path);
+
+  settings->GetAdvancedSettings()->m_ignoreFolderNamesInArchives = old;
 }
 
 INSTANTIATE_TEST_SUITE_P(NameMovies, TestFileItemMovieName, ValuesIn(BaseNames));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add advanced setting `ignorefoldernamesinarchives`:

FALSE (default) - if the movie file IN the archive is in a folder, AND the scraper is set to `movies are in separate folders that match the movie title` is true - then the folder IN the archive is used to name the movie.

TRUE - if the scraper is set to `movies are in separate folders that match the movie title`  then any folders IN the archive are ignored and the name is taken from the folder containing the archive itself.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #28586.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally and by bug reporter.

Tests added.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
