### PR TITLE
Lazy creation of IDirectory - save work for cached items

### DIFF
--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -155,9 +155,7 @@ bool CDirectory::GetDirectory(const CURL& url, CFileItemList &items, const std::
 
 bool CDirectory::GetDirectory(const CURL& url, CFileItemList &items, const CHints &hints)
 {
-  CURL realURL = URIUtils::SubstitutePath(url);
-  std::shared_ptr<IDirectory> pDirectory(CDirectoryFactory::Create(realURL));
-  return CDirectory::GetDirectory(url, pDirectory, items, hints);
+  return CDirectory::GetDirectoryInternal(url, nullptr, items, hints);
 }
 
 bool CDirectory::GetDirectory(const CURL& url,
@@ -165,11 +163,20 @@ bool CDirectory::GetDirectory(const CURL& url,
                               CFileItemList& items,
                               const CHints& hints)
 {
+  if (!pDirectory)
+    return false;
+
+  return GetDirectoryInternal(url, pDirectory, items, hints);
+}
+
+bool CDirectory::GetDirectoryInternal(const CURL& url,
+                                      std::shared_ptr<IDirectory> pDirectory,
+                                      CFileItemList& items,
+                                      const CHints& hints)
+{
   try
   {
     CURL realURL = URIUtils::SubstitutePath(url);
-    if (!pDirectory)
-      return false;
 
     // check our cache for this path
     if (g_directoryCache.GetDirectory(realURL, items,
@@ -181,6 +188,12 @@ bool CDirectory::GetDirectory(const CURL& url,
       // and (re)fetch the folder
       if (!(hints.flags & DIR_FLAG_BYPASS_CACHE))
         g_directoryCache.ClearDirectory(realURL);
+
+      if (!pDirectory)
+        pDirectory.reset(CDirectoryFactory::Create(realURL));
+
+      if (!pDirectory)
+        return false;
 
       pDirectory->SetFlags(hints.flags);
       items.SetURL(url);
@@ -255,19 +268,37 @@ bool CDirectory::GetDirectory(const CURL& url,
     }
 
     // now filter for allowed files
-    if (!pDirectory->AllowAll())
+    //! @todo find a way to filter cached items and no pDirectory provided without instantiating
+    //! a new IDirectory, to save the costly creation for some directory types (ex. rar)
+    //! For now avoid the creation for an empty mask, since IsAllowed always returns true for an empty mask.
+    if (!hints.mask.empty())
     {
-      pDirectory->SetMask(hints.mask);
-      for (int i = 0; i < items.Size(); ++i)
+      if (!pDirectory)
       {
-        CFileItemPtr item = items[i];
-        if (!item->IsFolder() && !pDirectory->IsAllowed(item->GetURL()))
+        pDirectory.reset(CDirectoryFactory::Create(realURL));
+
+        if (!pDirectory)
         {
-          items.Remove(i);
-          i--; // don't confuse loop
+          items.Clear();
+          return false;
+        }
+      }
+
+      if (!pDirectory->AllowAll())
+      {
+        pDirectory->SetMask(hints.mask);
+        for (int i = 0; i < items.Size(); ++i)
+        {
+          CFileItemPtr item = items[i];
+          if (!item->IsFolder() && !pDirectory->IsAllowed(item->GetURL()))
+          {
+            items.Remove(i);
+            i--; // don't confuse loop
+          }
         }
       }
     }
+
     // filter hidden files
     //! @todo we shouldn't be checking the gui setting here, callers should use getHidden instead
     if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_SHOWHIDDEN) && !(hints.flags & DIR_FLAG_GET_HIDDEN))

--- a/xbmc/filesystem/Directory.cpp
+++ b/xbmc/filesystem/Directory.cpp
@@ -287,30 +287,19 @@ bool CDirectory::GetDirectoryInternal(const CURL& url,
       if (!pDirectory->AllowAll())
       {
         pDirectory->SetMask(hints.mask);
-        for (int i = 0; i < items.Size(); ++i)
-        {
-          CFileItemPtr item = items[i];
-          if (!item->IsFolder() && !pDirectory->IsAllowed(item->GetURL()))
-          {
-            items.Remove(i);
-            i--; // don't confuse loop
-          }
-        }
+        erase_if(items, [&pDirectory](const CFileItemPtr& item)
+                 { return !item->IsFolder() && !pDirectory->IsAllowed(item->GetURL()); });
       }
     }
 
     // filter hidden files
     //! @todo we shouldn't be checking the gui setting here, callers should use getHidden instead
-    if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_SHOWHIDDEN) && !(hints.flags & DIR_FLAG_GET_HIDDEN))
+    if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+            CSettings::SETTING_FILELISTS_SHOWHIDDEN) &&
+        !(hints.flags & DIR_FLAG_GET_HIDDEN))
     {
-      for (int i = 0; i < items.Size(); ++i)
-      {
-        if (items[i]->GetProperty("file:hidden").asBoolean())
-        {
-          items.Remove(i);
-          i--; // don't confuse loop
-        }
-      }
+      erase_if(items, [](const CFileItemPtr& item)
+               { return item->GetProperty("file::hidden").asBoolean(); });
     }
 
     //  Should any of the files we read be treated as a directory?

--- a/xbmc/filesystem/Directory.h
+++ b/xbmc/filesystem/Directory.h
@@ -102,5 +102,11 @@ public:
   */
   static void FilterFileDirectories(CFileItemList &items, const std::string &mask,
                                     bool expandImages=false);
+
+private:
+  static bool GetDirectoryInternal(const CURL& url,
+                                   std::shared_ptr<IDirectory> pDirectory,
+                                   CFileItemList& items,
+                                   const CHints& hints);
 };
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Have CDirectory create IDirectory instances only when necessary (item not in cache, bypass cache, ...)
IDirectory instances have varying creation costs (local vs network vs archive file) and should not be created when not needed.

The GetDirectory overload that receives an existing IDirectory instance could probably be improved in a follow up PR and delegate the creation to GetDirectory to benefit from a similar lazy creation.
This PR is meant to support 28498 only.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Alternative base for #28498 to speed up rar archives but has its own benefits and saves unnecessary work.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Kodi runs

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Minor speed gain in directory enumeration.


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
