### PR TITLE
[darwin] use os_log() instead of NSLog()

### DIFF
--- a/xbmc/platform/darwin/ios/XBMCApplication.mm
+++ b/xbmc/platform/darwin/ios/XBMCApplication.mm
@@ -68,6 +68,13 @@
   PRINT_SIGNATURE();
 }
 
+- (BOOL)application:(UIApplication*)app
+            openURL:(NSURL*)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options
+{
+  return NO;
+}
+
 - (void)screenDidConnect:(NSNotification *)aNotification
 {
   [IOSScreenManager updateResolutions];

--- a/xbmc/platform/darwin/utils/DarwinInterfaceForCLog.mm
+++ b/xbmc/platform/darwin/utils/DarwinInterfaceForCLog.mm
@@ -10,7 +10,7 @@
 
 #include <string>
 
-#import <Foundation/Foundation.h>
+#include <os/log.h>
 #include <spdlog/sinks/dist_sink.h>
 #include <spdlog/spdlog.h>
 
@@ -35,7 +35,28 @@ void CDarwinInterfaceForCLog::log(const spdlog::details::log_msg& msg)
   spdlog::memory_buf_t formatted;
   m_formatter->format(msg, formatted);
   formatted.push_back('\0');
-  NSLog(@"%s", formatted.data());
+
+  os_log_type_t logType;
+  switch (msg.level)
+  {
+    case spdlog::level::trace:
+    case spdlog::level::debug:
+      logType = OS_LOG_TYPE_DEBUG;
+      break;
+    case spdlog::level::info:
+      logType = OS_LOG_TYPE_INFO;
+      break;
+    case spdlog::level::err:
+      logType = OS_LOG_TYPE_ERROR;
+      break;
+    case spdlog::level::critical:
+      logType = OS_LOG_TYPE_FAULT;
+      break;
+    default:
+      logType = OS_LOG_TYPE_DEFAULT;
+      break;
+  }
+  os_log_with_type(OS_LOG_DEFAULT, logType, "%{public}s", formatted.data());
 }
 
 void CDarwinInterfaceForCLog::flush()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
- using `os_log()` with `{public}` attribute allows reading device logs that have `%s` (basically 99% of Kodi logs) without running from Xcode. Right now with `NSLog()` you'd see `<private>` instead of the actual string if you try reading device logs via Console.app when Kodi is launched not from Xcode.
- also small iOS crash fix on opening an external file with Kodi. In my case I long-tapped a zip file in Files app - Open with - Kodi - and app crashed with
```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Application has LSSupportsOpeningDocumentsInPlace key, but doesn't implement application:openURL:options: on delegate <XBMCApplicationDelegate: 0x14030a920>'
```

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local test

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
users can read Kodi logs without Xcode

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
