### PR TITLE
[addoninfo] use literal dot in shared lib suffix regex match

### DIFF
--- a/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
+++ b/xbmc/addons/addoninfo/AddonInfoBuilder.cpp
@@ -33,6 +33,18 @@ namespace
 {
 // Note that all of these characters are url-safe
 const std::string VALID_ADDON_IDENTIFIER_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_@!$";
+
+std::string GetSharedLibraryNameRegexPattern()
+{
+  // in most cases suffix starts with a dot
+  // but even if it's not a dot, having a leading \ is still safe as it simply turns next character into literal match
+  std::string suffix = CCompileInfo::CCompileInfo::GetSharedLibrarySuffix();
+  if (!suffix.empty())
+    suffix.insert(suffix.cbegin(), '\\');
+
+  // linux is different and has the version number after the suffix
+  return "^.*" + suffix + R"(\.?\d*\.?\d*\.?\d*$)";
+}
 }
 
 namespace ADDON
@@ -653,10 +665,7 @@ bool CAddonInfoBuilder::ParseXMLTypes(CAddonType& addonType,
 
       try
       {
-        // linux is different and has the version number after the suffix
-        static const std::regex libRegex("^.*" +
-                                        CCompileInfo::CCompileInfo::GetSharedLibrarySuffix() +
-                                        "\\.?[0-9]*\\.?[0-9]*\\.?[0-9]*$");
+        static const std::regex libRegex{GetSharedLibraryNameRegexPattern()};
         if (std::regex_match(library, libRegex))
         {
           info->SetBinary(true);

--- a/xbmc/addons/test/TestAddonInfoBuilder.cpp
+++ b/xbmc/addons/test/TestAddonInfoBuilder.cpp
@@ -6,6 +6,7 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "CompileInfo.h"
 #include "addons/Repository.h"
 #include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonInfoBuilder.h"
@@ -13,6 +14,7 @@
 #include "utils/XBMCTinyXML2.h"
 
 #include <set>
+#include <string>
 
 #include <gtest/gtest.h>
 
@@ -48,6 +50,29 @@ const std::string addonXML = R"xml(
   </extension>
 </addon>
 )xml";
+
+namespace
+{
+AddonInfoPtr GenerateWithLibrary(const std::string& libraryName)
+{
+  const std::string xml = R"xml(
+<addon id="binary.blablabla.org"
+       name="The Binary Bla Bla Bla Addon"
+       version="1.2.3"
+       provider-name="Team Kodi">
+  <extension point="xbmc.python.module" library=")xml" +
+                          libraryName + R"xml("/>
+  <extension point="kodi.addon.metadata">
+    <platform>all</platform>
+  </extension>
+</addon>
+)xml";
+
+  CXBMCTinyXML2 doc;
+  EXPECT_TRUE(doc.Parse(xml));
+  return CAddonInfoBuilder::Generate(doc.RootElement(), RepositoryDirInfo{});
+}
+} // namespace
 
 class TestAddonInfoBuilder : public ::testing::Test
 {
@@ -126,6 +151,29 @@ TEST_F(TestAddonInfoBuilder, TestGenerate_Repo)
   auto info = addon->ExtraInfo().find("language");
   ASSERT_NE(info, addon->ExtraInfo().end());
   EXPECT_EQ(info->second, "marsian");
+}
+
+TEST_F(TestAddonInfoBuilder, BinaryDetection_AcceptsPlatformSharedLibrary)
+{
+  const std::string suffix = CCompileInfo::GetSharedLibrarySuffix();
+
+  EXPECT_TRUE(GenerateWithLibrary("libfoo" + suffix)->IsBinary());
+  // linux is different and has the version number after the suffix
+  EXPECT_TRUE(GenerateWithLibrary("libfoo" + suffix + ".1")->IsBinary());
+  EXPECT_TRUE(GenerateWithLibrary("libfoo" + suffix + ".1.2.3")->IsBinary());
+}
+
+TEST_F(TestAddonInfoBuilder, BinaryDetection_RejectsNonSharedLibrary)
+{
+  const std::string suffix = CCompileInfo::GetSharedLibrarySuffix();
+  ASSERT_TRUE(suffix.starts_with('.')); // the escaping in the regex depends on this
+
+  // the dot of the suffix must be matched literally, not as "any character"
+  EXPECT_FALSE(GenerateWithLibrary("libfooX" + suffix.substr(1))->IsBinary());
+  EXPECT_FALSE(GenerateWithLibrary("libfoo_" + suffix.substr(1))->IsBinary());
+
+  EXPECT_FALSE(GenerateWithLibrary("blablabla.xml")->IsBinary());
+  EXPECT_FALSE(GenerateWithLibrary("default.py")->IsBinary());
 }
 
 TEST_F(TestAddonInfoBuilder, TestGenerate_DBEntry)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Current regex is not strictly correct as it doesn't escape the leading dot. The shared lib suffix provided by CMake starts with a dot, e.g. `.dylib` on Apple. Even if it would be not a dot but any non-empty string, having leading `\` is still completely safe.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local test

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
