### PR TITLE
[Video][Music] Fix always play first episode in season.

### DIFF
--- a/xbmc/music/MusicFileItemClassify.cpp
+++ b/xbmc/music/MusicFileItemClassify.cpp
@@ -13,7 +13,8 @@
 #include "URL.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/StringUtils.h"
-#include "utils/URIUtils.h"
+
+#include <string>
 
 namespace KODI::MUSIC
 {
@@ -56,7 +57,8 @@ bool IsAudio(const CFileItem& item)
 
 bool IsAudioBook(const CFileItem& item)
 {
-  return item.IsType(".m4b") || item.IsType(".mka") || item.IsType(".mkv");
+  return item.IsType(".m4b") || item.IsType(".mka") ||
+         (item.IsType(".mkv") && item.HasMusicInfoTag());
 }
 
 bool IsCDDA(const CFileItem& item)

--- a/xbmc/music/test/TestMusicFileItemClassify.cpp
+++ b/xbmc/music/test/TestMusicFileItemClassify.cpp
@@ -126,6 +126,54 @@ INSTANTIATE_TEST_SUITE_P(TestMusicFileItemClassify,
                          AudioBookTest,
                          testing::ValuesIn(audiobook_tests));
 
+class AudioBookMkvTest : public testing::WithParamInterface<AudioClassifyTest>, public testing::Test
+{
+};
+
+TEST_P(AudioBookMkvTest, IsAudioBook)
+{
+  const AudioClassifyTest& param = GetParam();
+
+  // Construct CFileItem at test runtime (after fixture SetUp)
+  CFileItem item(param.path, false);
+
+  switch (param.tag_type)
+  {
+    case 1:
+      item.GetVideoInfoTag()->m_strFileNameAndPath = param.path;
+      break;
+    case 2:
+      item.GetGameInfoTag()->SetGameClient("some_client");
+      break;
+    case 3:
+      item.GetMusicInfoTag()->SetPlayCount(1);
+      break;
+    case 4:
+      item.GetPictureInfoTag()->SetInfo("foo", "bar");
+      break;
+    default:
+      break;
+  }
+
+  EXPECT_EQ(MUSIC::IsAudioBook(item), param.result);
+}
+
+const auto audiobook_mkv_tests = std::array{
+    // Plain .mkv with no MusicInfoTag - most .mkv files are video
+    AudioClassifyTest{"/home/user/episode.mkv", false},
+    // A VideoInfoTag (e.g. a scraped TV episode)
+    AudioClassifyTest{"/home/user/episode.mkv", false, "", 1},
+    // A GameInfoTag or PictureInfoTag isn't a MusicInfoTag
+    AudioClassifyTest{"/home/user/episode.mkv", false, "", 2},
+    AudioClassifyTest{"/home/user/episode.mkv", false, "", 4},
+    // A MusicInfoTag set (a real mkv audiobook catalogued in the music library) IS an audiobook
+    AudioClassifyTest{"/home/user/book.mkv", true, "", 3},
+};
+
+INSTANTIATE_TEST_SUITE_P(TestMusicFileItemClassify,
+                         AudioBookMkvTest,
+                         testing::ValuesIn(audiobook_mkv_tests));
+
 class CuesheetTest : public testing::WithParamInterface<SimpleDefinition>, public testing::Test
 {
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add a guard to CMusicFileItemClassify::IsAudioBook() to ensure video .mkv files do not return true.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #28764.
Fix #28779.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

Added tests.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Correct episode playback when episode other than first is selected.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
