### PR TITLE
[smb] Drop redundant smbc_init setup

### DIFF
--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -36,7 +36,6 @@
 #include <unordered_map>
 
 #include <libsmbclient.h>
-#include <samba/version.h>
 
 using namespace XFILE;
 
@@ -332,9 +331,8 @@ void xb_smbc_auth(
 {
 }
 
-// This flag protects against an old Samba bug where smbc_set_context()
-// returns an already freed pointer on subsequent inits. It is still
-// needed on some current Samba 4.0 installations.
+// Track whether initialization has completed so an existing SMB configuration
+// directory is accepted only during the first initialization.
 bool CSMB::IsFirstInit = true;
 
 CSMB::CSMB()
@@ -480,16 +478,6 @@ void CSMB::Init()
       }
     }
 
-#if SAMBA_VERSION_MAJOR <= 4 && SAMBA_VERSION_MINOR <= 18
-    // reads smb.conf so this MUST be after we create smb.conf
-    // multiple smbc_init calls are ignored by libsmbclient.
-    // note: this is important as it initializes the smb old
-    // interface compatibility. Samba 3.4.0 or higher has the new interface.
-    // smbc_init is deprecated but still required for the old-interface
-    // compatibility used by smbc_set_context / smbc_free_context.
-    smbc_init(xb_smbc_auth, 0);
-#endif
-
     // setup our context
     m_context = smbc_new_context();
     if (!m_context)
@@ -530,16 +518,8 @@ void CSMB::Init()
     if (smbc_init_context(m_context))
     {
       // setup context using the smb old interface compatibility
-      SMBCCTX* old_context = smbc_set_context(m_context);
-
-      // There is a bug in old Samba versions where smbc_set_context may
-      // return an already freed pointer on subsequent inits. IsFirstInit
-      // guarantees we only free the very first compatibility context once.
-      if (old_context && IsFirstInit)
-      {
-        smbc_free_context(old_context, 1);
-        IsFirstInit = false;
-      }
+      smbc_set_context(m_context);
+      IsFirstInit = false;
 
       // Cache the remove_unused_server function pointer.
       g_removeUnusedFn = smbc_getFunctionRemoveUnusedServer(m_context);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Kodi already creates, configures, and initializes its own SMBCCTX before installing it with smbc_set_context(). Samba has documented that smbc_set_context() can be used before smbc_init() since the older API releases, so smbc_init() only creates a temporary compatibility context that Kodi immediately replaces.

Avoiding that call also removes the version check and its dependency on samba/version.h, which distributions do not ship with libsmbclient development headers. Mark the first initialization complete after installing Kodi’s context so SMB configuration handling remains unchanged and a stale context is never treated as the temporary one.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [x] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
