### PR TITLE
Fix handling of playlist files passed via Android Intent ACTION_VIEW

### DIFF
--- a/xbmc/platform/android/activity/XBMCApp.cpp
+++ b/xbmc/platform/android/activity/XBMCApp.cpp
@@ -12,6 +12,7 @@
 #include "CompileInfo.h"
 #include "FileItem.h"
 #include "FileItemList.h"
+#include "playlists/PlayList.h"
 #include "playlists/PlayListFactory.h"
 #include "utils/Mime.h"
 // Audio Engine includes for Factory and interfaces
@@ -1401,31 +1402,47 @@ void CXBMCApp::onNewIntent(CJNIIntent intent)
     }
     else
     {
-      CFileItem* item = new CFileItem(targetFile, false);
-      if (IsVideoDb(*item))
-      {
-        *(item->GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(item->GetURL());
-        item->SetPath(item->GetVideoInfoTag()->m_strFileNameAndPath);
-      }
-
       if (KODI::PLAYLIST::CPlayListFactory::IsPlaylist(targeturl))
       {
+        auto item = std::make_unique<CFileItem>(targetFile, false);
+
         std::string mimeType = CMime::GetMimeType(*item);
         if (!mimeType.empty())
         {
           item->SetMimeType(mimeType);
         }
 
-        CFileItemList* list = new CFileItemList();
-        list->Add(std::make_shared<CFileItem>(*item));
+        auto list = std::make_unique<CFileItemList>();
 
-        delete item;
+        std::unique_ptr<KODI::PLAYLIST::CPlayList> playlist(
+            KODI::PLAYLIST::CPlayListFactory::Create(*item));
+
+        if (playlist && playlist->Load(item->GetPath()))
+        {
+          for (int i = 0; i < playlist->size(); i++)
+          {
+            list->Add((*playlist)[i]);
+          }
+        }
+        else
+        {
+          // Fallback: If playlist parsing fails, append the original item
+          // to prevent sending an empty list to TMSG_MEDIA_PLAY
+          list->Add(std::make_shared<CFileItem>(*item));
+        }
 
         CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, -1, -1,
-                                                   static_cast<void*>(list));
+                                                   static_cast<void*>(list.release()));
       }
       else
       {
+        CFileItem* item = new CFileItem(targetFile, false);
+        if (IsVideoDb(*item))
+        {
+          *(item->GetVideoInfoTag()) = XFILE::CVideoDatabaseFile::GetVideoTag(item->GetURL());
+          item->SetPath(item->GetVideoInfoTag()->m_strFileNameAndPath);
+        }
+
         CServiceBroker::GetAppMessenger()->PostMsg(TMSG_MEDIA_PLAY, 0, 0, static_cast<void*>(item));
       }
     }


### PR DESCRIPTION
## Description
When receiving a playlist target URL via an Android Intent, parse and expand the playlist items into `CFileItemList` prior to sending via `TMSG_MEDIA_PLAY.`

Previously, the single playlist `CFileItem` was wrapped into a `CFileItemList` without parsing its contents before being passed to `TMSG_MEDIA_PLAY.` With this change, `KODI::PLAYLIST::CPlayListFactory` creates and loads the playlist, populating `CFileItemList` with all individual items before sending via `TMSG_MEDIA_PLAY.`

Previously, the code only wrapped the single playlist `CFileItem` into `CFileItemList` without parsing its contents, causing playback to fail or only load the playlist file itself rather than its contents. With this change, `KODI::PLAYLIST::CPlayListFactory` creates and loads the playlist, populating `CFileItemList` with all individual items before handing off to `TMSG_MEDIA_PLAY.`

This is a bug fix for https://github.com/xbmc/xbmc/pull/28661

## Motivation and context
Fixes an issue where opening playlist files (e.g., .m3u) from external Android applications via Android Intents failed to expand playlist contents before sending via `TMSG_MEDIA_PLAY`, leading to playback issues.

## How has this been tested?
Tested on an Android device by triggering external playlist URLs via Android Intents `ACTION_VIEW` third-party apps and verifying that all items inside the playlist are correctly expanded and passed when sending via `TMSG_MEDIA_PLAY`

## What is the effect on users?
Users launching playlists from external Android apps via Intents will now have the entire playlist parsed and properly populated when sending via `TMSG_MEDIA_PLAY.`

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
