### PR TITLE
[Smart Playlists] Add setting to control the results watched mode

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -2741,6 +2741,7 @@ msgid "Date added"
 msgstr ""
 
 #: xbmc/playlists/SmartPlaylist.cpp
+#: xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
 #: xbmc/settings/SubtitlesSettings.cpp
 msgctxt "#571"
 msgid "Default"
@@ -14472,7 +14473,13 @@ msgctxt "#20478"
 msgid "DV profile"
 msgstr ""
 
-#empty strings from id 20479 to 21329
+#. Used in the smart playlist editor to define a watched mode
+#: xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+msgctxt "#20479"
+msgid "Watched Mode"
+msgstr ""
+
+#empty strings from id 20480 to 21329
 #up to 21329 is reserved for the video db !! !
 
 #: system/settings/settings.xml

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -6774,6 +6774,7 @@ msgstr ""
 #: xbmc/pvr/channels/PVRChannel.cpp
 #: xbmc/pvr/dialogs/GUIDialogPVRClientPriorities.cpp
 #: xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+#: xbmc/settings/MediaSettings.cpp
 #: xbmc/video/dialogs/GUIDialogAudioSubtitleSettings.cpp
 #: xbmc/video/PlayerController.cpp
 #: xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -9403,17 +9404,21 @@ msgstr ""
 
 #empty strings from id 16042 to 16099
 
-#: xbmc/video/windows/GUIWindowVideoNav.cpp
+#: xbmc/settings/MediaSettings.cpp
 #: xbmc/video/windows/VideoFileItemListModifier.cpp
 msgctxt "#16100"
 msgid "All videos"
 msgstr ""
 
+#: xbmc/settings/MediaSettings.cpp
+#: xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
 msgctxt "#16101"
 msgid "Unwatched"
 msgstr ""
 
 #: addons/skin.estuary/xml/Home.xml
+#: xbmc/settings/MediaSettings.cpp
+#: xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
 msgctxt "#16102"
 msgid "Watched"
 msgstr ""

--- a/addons/skin.estuary/xml/SmartPlaylistEditor.xml
+++ b/addons/skin.estuary/xml/SmartPlaylistEditor.xml
@@ -9,7 +9,7 @@
 			<width>1700</width>
 			<include content="DialogBackgroundCommons">
 				<param name="width" value="1700" />
-				<param name="height" value="790" />
+				<param name="height" value="870" />
 				<param name="header_label" value="" />
 				<param name="header_id" value="2" />
 			</include>
@@ -67,6 +67,11 @@
 					<width>700</width>
 					<include>SettingsItemCommon</include>
 					<label>$LOCALIZE[467]: $LOCALIZE[21459]</label>
+				</control>
+				<control type="button" id="25">
+					<width>700</width>
+					<label>$LOCALIZE[20479]</label>
+					<include>SettingsItemCommon</include>
 				</control>
 			</control>
 			<control type="image">

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -23,6 +23,7 @@
 #include "profiles/ProfileManager.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
+#include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/SortUtils.h"
@@ -46,6 +47,7 @@ using namespace KODI;
 #define CONTROL_ORDER_DIRECTION 19
 #define CONTROL_GROUP_BY        23
 #define CONTROL_GROUP_MIXED     24
+constexpr int CONTROL_WATCHED_MODE = 25;
 
 #define CONTROL_OK              20
 #define CONTROL_CANCEL          21
@@ -125,6 +127,8 @@ bool CGUIDialogSmartPlaylistEditor::OnMessage(CGUIMessage& message)
         OnGroupMixed();
       else if (iControl == CONTROL_RULE_LIST && (iAction == ACTION_CONTEXT_MENU || iAction == ACTION_MOUSE_RIGHT_CLICK))
         OnPopupMenu(GetSelectedItem());
+      else if (iControl == CONTROL_WATCHED_MODE)
+        OnWatchedMode();
       else
         return CGUIDialog::OnMessage(message);
       return true;
@@ -404,6 +408,44 @@ void CGUIDialogSmartPlaylistEditor::OnGroupMixed()
   UpdateButtons();
 }
 
+void CGUIDialogSmartPlaylistEditor::OnWatchedMode()
+{
+  // only valid for video types
+  if (!m_playlist.IsVideoType())
+    return;
+
+  CGUIDialogSelect* dialog =
+      CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogSelect>(
+          WINDOW_DIALOG_SELECT);
+  dialog->Reset();
+  dialog->SetHeading(CVariant{20479}); // "Watched Mode"
+
+  // Special entry to leave the watched mode of the result alone
+  dialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(571)); // "Default"
+
+  // Actual watched mode values
+  for (int i = 0; i < static_cast<int>(WatchedMode::COUNT); i++)
+    dialog->Add(CMediaSettings::GetInstance().LocalizeWatchedMode(WatchedMode{i}));
+
+  // Dialog indexes: 0 for nullopt, index = value + 1 otherwise
+  const int currentIndex = m_playlist.GetWatchedMode().has_value()
+                               ? static_cast<int>(m_playlist.GetWatchedMode().value()) + 1
+                               : 0;
+  dialog->SetSelected(currentIndex);
+  dialog->Open();
+
+  const int newSelected = dialog->GetSelectedItem();
+  if (!dialog->IsConfirmed() || newSelected < 0 || newSelected == currentIndex)
+    return;
+
+  if (newSelected == 0)
+    m_playlist.SetWatchedMode(std::nullopt);
+  else
+    m_playlist.SetWatchedMode(WatchedMode{newSelected - 1});
+
+  UpdateButtons();
+}
+
 void CGUIDialogSmartPlaylistEditor::UpdateButtons()
 {
   CONTROL_ENABLE(CONTROL_OK); // always enabled since we can have no rules -> match everything (as we do with default partymode playlists)
@@ -494,6 +536,22 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
     CONTROL_ENABLE(CONTROL_GROUP_BY);
     CONTROL_ENABLE_ON_CONDITION(CONTROL_GROUP_MIXED,
                                 PLAYLIST::CSmartPlaylistRule::CanGroupMix(currentGroup));
+  }
+
+  // watched mode
+  if (m_playlist.IsVideoType())
+  {
+    const std::string label =
+        m_playlist.GetWatchedMode().has_value()
+            ? CMediaSettings::GetInstance().LocalizeWatchedMode(*m_playlist.GetWatchedMode())
+            : CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(571); // "Default"
+    SET_CONTROL_LABEL2(CONTROL_WATCHED_MODE, label);
+    CONTROL_ENABLE(CONTROL_WATCHED_MODE);
+  }
+  else
+  {
+    SET_CONTROL_LABEL2(CONTROL_WATCHED_MODE, "");
+    CONTROL_DISABLE(CONTROL_WATCHED_MODE);
   }
 }
 

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -424,7 +424,7 @@ void CGUIDialogSmartPlaylistEditor::OnWatchedMode()
   dialog->Add(CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(571)); // "Default"
 
   // Actual watched mode values
-  for (int i = 0; i < static_cast<int>(WatchedMode::COUNT); i++)
+  for (int i = 0; i < CMediaSettings::WatchedModesCount(); i++)
     dialog->Add(CMediaSettings::GetInstance().LocalizeWatchedMode(WatchedMode{i}));
 
   // Dialog indexes: 0 for nullopt, index = value + 1 otherwise

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
@@ -41,6 +41,7 @@ protected:
   void OnOrderDirection();
   void OnGroupBy();
   void OnGroupMixed();
+  void OnWatchedMode();
   void OnOK();
   void OnCancel();
   void OnPopupMenu(int item);

--- a/xbmc/filesystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/filesystem/SmartPlaylistDirectory.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -33,6 +33,7 @@
 #define PROPERTY_SORT_ASCENDING     "sort.ascending"
 #define PROPERTY_GROUP_BY           "group.by"
 #define PROPERTY_GROUP_MIXED        "group.mixed"
+constexpr char PROPERTY_WATCHED_MODE[] = "watchedmode";
 
 using namespace KODI;
 
@@ -315,6 +316,9 @@ namespace XFILE
                        ? SortAttributeIgnoreArticle
                        : SortAttributeNone);
     }
+
+    if (auto watchedMode = playlist.GetWatchedMode(); watchedMode.has_value())
+      items.SetProperty(PROPERTY_WATCHED_MODE, static_cast<int>(watchedMode.value()));
 
     // go through and set the playlist order
     for (int i = 0; i < items.Size(); i++)

--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -690,7 +690,7 @@ bool CSystemGUIInfo::GetBool(bool& value,
         if (window)
         {
           value = CMediaSettings::GetInstance().GetWatchedMode(
-                      window->CurrentDirectory().GetContent()) == WatchedModeUnwatched;
+                      window->CurrentDirectory().GetContent()) == WatchedMode::UNWATCHED;
           return true;
         }
       }

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1393,8 +1393,7 @@ bool CSmartPlaylist::Load(const CVariant &obj)
   {
     if (const CVariant v = obj[TAG_WATCHEDMODE]; v.isInteger())
     {
-      if (const int wm = v.asInteger(); wm >= 0 && wm < static_cast<int>(WatchedMode::COUNT))
-        m_watchedMode = WatchedMode{wm};
+      m_watchedMode = CMediaSettings::ToWatchedMode(v.asInteger());
     }
   }
 
@@ -1457,11 +1456,8 @@ bool CSmartPlaylist::LoadFromXML(const TiXmlNode *root, const std::string &encod
     m_orderField = CSmartPlaylistRule::TranslateOrder(order->FirstChild()->Value());
   }
 
-  if (int wm; XMLUtils::GetInt(root, TAG_WATCHEDMODE, wm) && wm >= 0 &&
-              wm < static_cast<int>(WatchedMode::COUNT))
-    m_watchedMode = WatchedMode{wm};
-  else
-    m_watchedMode.reset();
+  if (int wm; XMLUtils::GetInt(root, TAG_WATCHEDMODE, wm))
+    m_watchedMode = CMediaSettings::ToWatchedMode(wm);
 
   return true;
 }

--- a/xbmc/playlists/SmartPlayList.cpp
+++ b/xbmc/playlists/SmartPlayList.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -16,6 +16,7 @@
 #include "filesystem/SmartPlaylistDirectory.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
+#include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/DatabaseUtils.h"
@@ -175,6 +176,8 @@ static const auto groups = std::array{
 // clang-format on
 
 constexpr std::string_view RULE_VALUE_SEPARATOR = " / ";
+
+constexpr char TAG_WATCHEDMODE[] = "watchedmode";
 
 CSmartPlaylistRule::CSmartPlaylistRule() = default;
 
@@ -1384,6 +1387,17 @@ bool CSmartPlaylist::Load(const CVariant &obj)
     m_orderField = CSmartPlaylistRule::TranslateOrder(obj["order"]["method"].asString().c_str());
   }
 
+  // load the watched mode
+  m_watchedMode.reset();
+  if (obj.isMember(TAG_WATCHEDMODE))
+  {
+    if (const CVariant v = obj[TAG_WATCHEDMODE]; v.isInteger())
+    {
+      if (const int wm = v.asInteger(); wm >= 0 && wm < static_cast<int>(WatchedMode::COUNT))
+        m_watchedMode = WatchedMode{wm};
+    }
+  }
+
   return true;
 }
 
@@ -1442,6 +1456,13 @@ bool CSmartPlaylist::LoadFromXML(const TiXmlNode *root, const std::string &encod
 
     m_orderField = CSmartPlaylistRule::TranslateOrder(order->FirstChild()->Value());
   }
+
+  if (int wm; XMLUtils::GetInt(root, TAG_WATCHEDMODE, wm) && wm >= 0 &&
+              wm < static_cast<int>(WatchedMode::COUNT))
+    m_watchedMode = WatchedMode{wm};
+  else
+    m_watchedMode.reset();
+
   return true;
 }
 
@@ -1508,6 +1529,11 @@ bool CSmartPlaylist::Save(const std::string &path) const
     nodeOrder.InsertEndChild(order);
     pRoot->InsertEndChild(nodeOrder);
   }
+
+  // add the <watchedmode> tag
+  if (m_watchedMode.has_value())
+    XMLUtils::SetInt(pRoot, TAG_WATCHEDMODE, static_cast<int>(m_watchedMode.value()));
+
   return doc.SaveFile(path);
 }
 
@@ -1546,6 +1572,10 @@ bool CSmartPlaylist::Save(CVariant &obj, bool full /* = true */) const
     obj["order"]["ignorefolders"] = (m_orderAttributes & SortAttributeIgnoreFolders);
   }
 
+  // add "watchedmode"
+  if (m_watchedMode.has_value())
+    obj[TAG_WATCHEDMODE] = static_cast<int>(m_watchedMode.value());
+
   return true;
 }
 
@@ -1568,6 +1598,7 @@ void CSmartPlaylist::Reset()
   m_playlistType = "songs"; // sane default
   m_group.clear();
   m_groupMixed = false;
+  m_watchedMode.reset();
 }
 
 void CSmartPlaylist::SetName(const std::string &name)

--- a/xbmc/playlists/SmartPlayList.h
+++ b/xbmc/playlists/SmartPlayList.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -12,6 +12,7 @@
 #include "utils/SortUtils.h"
 #include "utils/XBMCTinyXML.h"
 
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -20,6 +21,7 @@ class CGUIDialogSmartPlaylistEditor;
 class CGUIDialogMediaFilter;
 class CURL;
 class CVariant;
+enum class WatchedMode;
 
 namespace KODI::PLAYLIST
 {
@@ -151,6 +153,9 @@ public:
   void SetGroupMixed(bool mixed) { m_groupMixed = mixed; }
   bool IsGroupMixed() const { return m_groupMixed; }
 
+  std::optional<WatchedMode> GetWatchedMode() const { return m_watchedMode; }
+  void SetWatchedMode(std::optional<WatchedMode> mode) { m_watchedMode = mode; }
+
   /*! \brief get the where clause for a playlist
    We handle playlists inside playlists separately in order to ensure we don't introduce infinite loops
    by playlist A including playlist B which also (perhaps via other playlists) then includes playlistA.
@@ -197,6 +202,7 @@ private:
   SortAttribute m_orderAttributes;
   std::string m_group;
   bool m_groupMixed;
+  std::optional<WatchedMode> m_watchedMode;
 
   CXBMCTinyXML m_xmlDoc;
 };

--- a/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
@@ -224,14 +224,14 @@ bool CGUIWindowPVRRecordingsBase::Update(const std::string& strDirectory,
 
 void CGUIWindowPVRRecordingsBase::UpdateButtons()
 {
-  int iWatchMode = CMediaSettings::GetInstance().GetWatchedMode("recordings");
+  const WatchedMode watchedMode = CMediaSettings::GetInstance().GetWatchedMode("recordings");
   int iStringId = 257; // "Error"
 
-  if (iWatchMode == WatchedModeAll)
+  if (watchedMode == WatchedMode::ALL)
     iStringId = 22015; // "All recordings"
-  else if (iWatchMode == WatchedModeUnwatched)
+  else if (watchedMode == WatchedMode::UNWATCHED)
     iStringId = 16101; // "Unwatched"
-  else if (iWatchMode == WatchedModeWatched)
+  else if (watchedMode == WatchedMode::WATCHED)
     iStringId = 16102; // "Watched"
 
   SET_CONTROL_LABEL(CONTROL_BTNSHOWMODE,
@@ -452,7 +452,7 @@ bool CGUIWindowPVRRecordingsBase::GetFilteredItems(const std::string& filter, CF
 {
   bool listchanged = CGUIWindowPVRBase::GetFilteredItems(filter, items);
 
-  int watchMode = CMediaSettings::GetInstance().GetWatchedMode("recordings");
+  const WatchedMode watchedMode = CMediaSettings::GetInstance().GetWatchedMode("recordings");
 
   CFileItemPtr item;
   for (int i = 0; i < items.Size(); i++)
@@ -466,8 +466,8 @@ bool CGUIWindowPVRRecordingsBase::GetFilteredItems(const std::string& filter, CF
       continue;
 
     int iPlayCount = item->GetPVRRecordingInfoTag()->GetPlayCount();
-    if ((watchMode == WatchedModeWatched && iPlayCount == 0) ||
-        (watchMode == WatchedModeUnwatched && iPlayCount > 0))
+    if ((watchedMode == WatchedMode::WATCHED && iPlayCount == 0) ||
+        (watchedMode == WatchedMode::UNWATCHED && iPlayCount > 0))
     {
       items.Remove(i);
       i--;

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -395,10 +395,13 @@ void CMediaSettings::CycleWatchedMode(const std::string& content)
 {
   std::unique_lock lock(m_critical);
   if (const auto it = m_watchedModes.find(GetWatchedContent(content)); it != m_watchedModes.end())
-  {
-    int next_val = (static_cast<int>(it->second) + 1) % static_cast<int>(WatchedMode::COUNT);
-    it->second = WatchedMode{next_val};
-  }
+    CycleWatchedMode(it->second);
+}
+
+void CMediaSettings::CycleWatchedMode(WatchedMode& mode)
+{
+  const int next_val = (static_cast<int>(mode) + 1) % static_cast<int>(WatchedMode::COUNT);
+  mode = WatchedMode{next_val};
 }
 
 std::string CMediaSettings::GetWatchedContent(const std::string &content)

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -157,16 +157,14 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
   pElement = settings->FirstChildElement("myvideos");
   if (pElement)
   {
-    constexpr int minValue = static_cast<int>(WatchedMode::ALL);
-    constexpr int maxValue = static_cast<int>(WatchedMode::COUNT) - 1;
     int tmp;
-    if (XMLUtils::GetInt(pElement, "watchmodemovies", tmp, minValue, maxValue))
+    if (XMLUtils::GetInt(pElement, "watchmodemovies", tmp) && IsValidWatchedMode(tmp))
       m_watchedModes["movies"] = WatchedMode{tmp};
-    if (XMLUtils::GetInt(pElement, "watchmodetvshows", tmp, minValue, maxValue))
+    if (XMLUtils::GetInt(pElement, "watchmodetvshows", tmp) && IsValidWatchedMode(tmp))
       m_watchedModes["tvshows"] = WatchedMode{tmp};
-    if (XMLUtils::GetInt(pElement, "watchmodemusicvideos", tmp, minValue, maxValue))
+    if (XMLUtils::GetInt(pElement, "watchmodemusicvideos", tmp) && IsValidWatchedMode(tmp))
       m_watchedModes["musicvideos"] = WatchedMode{tmp};
-    if (XMLUtils::GetInt(pElement, "watchmoderecordings", tmp, minValue, maxValue))
+    if (XMLUtils::GetInt(pElement, "watchmoderecordings", tmp) && IsValidWatchedMode(tmp))
       m_watchedModes["recordings"] = WatchedMode{tmp};
 
     const TiXmlElement *pChild = pElement->FirstChildElement("playlist");
@@ -400,7 +398,7 @@ void CMediaSettings::CycleWatchedMode(const std::string& content)
 
 void CMediaSettings::CycleWatchedMode(WatchedMode& mode)
 {
-  const int next_val = (static_cast<int>(mode) + 1) % static_cast<int>(WatchedMode::COUNT);
+  const int next_val = (static_cast<int>(mode) + 1) % WatchedModesCount();
   mode = WatchedMode{next_val};
 }
 
@@ -435,6 +433,22 @@ std::string CMediaSettings::LocalizeWatchedMode(WatchedMode mode)
 
   // Special handling for the COUNT sentinel value, excluded from the array
   // message 13205: Unknown
-  const int msgId = mode == WatchedMode::COUNT ? 13205 : messagesMap[static_cast<int>(mode)];
+  const int msgId = (mode == WatchedMode::COUNT) ? 13205 : messagesMap[static_cast<int>(mode)];
   return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(msgId);
+}
+
+bool CMediaSettings::IsValidWatchedMode(int value)
+{
+  return value >= static_cast<int>(WatchedMode::ALL) &&
+         value < static_cast<int>(WatchedMode::COUNT);
+}
+
+std::optional<WatchedMode> CMediaSettings::ToWatchedMode(int value)
+{
+  return IsValidWatchedMode(value) ? std::optional{WatchedMode{value}} : std::nullopt;
+}
+
+int CMediaSettings::WatchedModesCount()
+{
+  return static_cast<int>(WatchedMode::COUNT);
 }

--- a/xbmc/settings/MediaSettings.cpp
+++ b/xbmc/settings/MediaSettings.cpp
@@ -32,6 +32,8 @@
 #include "video/VideoDatabase.h"
 #include "video/VideoLibraryQueue.h"
 
+#include <algorithm>
+#include <array>
 #include <limits.h>
 #include <mutex>
 #include <string>
@@ -155,15 +157,17 @@ bool CMediaSettings::Load(const TiXmlNode *settings)
   pElement = settings->FirstChildElement("myvideos");
   if (pElement)
   {
+    constexpr int minValue = static_cast<int>(WatchedMode::ALL);
+    constexpr int maxValue = static_cast<int>(WatchedMode::COUNT) - 1;
     int tmp;
-    if (XMLUtils::GetInt(pElement, "watchmodemovies", tmp, (int)WatchedModeAll, (int)WatchedModeWatched))
-      m_watchedModes["movies"] = (WatchedMode)tmp;
-    if (XMLUtils::GetInt(pElement, "watchmodetvshows", tmp, (int)WatchedModeAll, (int)WatchedModeWatched))
-      m_watchedModes["tvshows"] = (WatchedMode)tmp;
-    if (XMLUtils::GetInt(pElement, "watchmodemusicvideos", tmp, (int)WatchedModeAll, (int)WatchedModeWatched))
-      m_watchedModes["musicvideos"] = (WatchedMode)tmp;
-    if (XMLUtils::GetInt(pElement, "watchmoderecordings", tmp, static_cast<int>(WatchedModeAll), static_cast<int>(WatchedModeWatched)))
-      m_watchedModes["recordings"] = static_cast<WatchedMode>(tmp);
+    if (XMLUtils::GetInt(pElement, "watchmodemovies", tmp, minValue, maxValue))
+      m_watchedModes["movies"] = WatchedMode{tmp};
+    if (XMLUtils::GetInt(pElement, "watchmodetvshows", tmp, minValue, maxValue))
+      m_watchedModes["tvshows"] = WatchedMode{tmp};
+    if (XMLUtils::GetInt(pElement, "watchmodemusicvideos", tmp, minValue, maxValue))
+      m_watchedModes["musicvideos"] = WatchedMode{tmp};
+    if (XMLUtils::GetInt(pElement, "watchmoderecordings", tmp, minValue, maxValue))
+      m_watchedModes["recordings"] = WatchedMode{tmp};
 
     const TiXmlElement *pChild = pElement->FirstChildElement("playlist");
     if (pChild)
@@ -267,10 +271,14 @@ bool CMediaSettings::Save(TiXmlNode *settings) const
       return false;
   }
 
-  XMLUtils::SetInt(pNode, "watchmodemovies", m_watchedModes.find("movies")->second);
-  XMLUtils::SetInt(pNode, "watchmodetvshows", m_watchedModes.find("tvshows")->second);
-  XMLUtils::SetInt(pNode, "watchmodemusicvideos", m_watchedModes.find("musicvideos")->second);
-  XMLUtils::SetInt(pNode, "watchmoderecordings", m_watchedModes.find("recordings")->second);
+  XMLUtils::SetInt(pNode, "watchmodemovies",
+                   static_cast<int>(m_watchedModes.find("movies")->second));
+  XMLUtils::SetInt(pNode, "watchmodetvshows",
+                   static_cast<int>(m_watchedModes.find("tvshows")->second));
+  XMLUtils::SetInt(pNode, "watchmodemusicvideos",
+                   static_cast<int>(m_watchedModes.find("musicvideos")->second));
+  XMLUtils::SetInt(pNode, "watchmoderecordings",
+                   static_cast<int>(m_watchedModes.find("recordings")->second));
 
   TiXmlElement videoPlaylistNode("playlist");
   playlistNode = pNode->InsertEndChild(videoPlaylistNode);
@@ -367,33 +375,29 @@ void CMediaSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& set
     CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "OnRefresh");
 }
 
-int CMediaSettings::GetWatchedMode(const std::string &content) const
+WatchedMode CMediaSettings::GetWatchedMode(const std::string& content) const
 {
   std::unique_lock lock(m_critical);
-  WatchedModes::const_iterator it = m_watchedModes.find(GetWatchedContent(content));
-  if (it != m_watchedModes.end())
+  if (const auto it = m_watchedModes.find(GetWatchedContent(content)); it != m_watchedModes.end())
     return it->second;
 
-  return WatchedModeAll;
+  return WatchedMode::ALL;
 }
 
 void CMediaSettings::SetWatchedMode(const std::string &content, WatchedMode mode)
 {
   std::unique_lock lock(m_critical);
-  WatchedModes::iterator it = m_watchedModes.find(GetWatchedContent(content));
-  if (it != m_watchedModes.end())
+  if (const auto it = m_watchedModes.find(GetWatchedContent(content)); it != m_watchedModes.end())
     it->second = mode;
 }
 
-void CMediaSettings::CycleWatchedMode(const std::string &content)
+void CMediaSettings::CycleWatchedMode(const std::string& content)
 {
   std::unique_lock lock(m_critical);
-  WatchedModes::iterator it = m_watchedModes.find(GetWatchedContent(content));
-  if (it != m_watchedModes.end())
+  if (const auto it = m_watchedModes.find(GetWatchedContent(content)); it != m_watchedModes.end())
   {
-    it->second = (WatchedMode)((int)it->second + 1);
-    if (it->second > WatchedModeWatched)
-      it->second = WatchedModeAll;
+    int next_val = (static_cast<int>(it->second) + 1) % static_cast<int>(WatchedMode::COUNT);
+    it->second = WatchedMode{next_val};
   }
 }
 
@@ -403,4 +407,31 @@ std::string CMediaSettings::GetWatchedContent(const std::string &content)
     return "tvshows";
 
   return content;
+}
+
+std::string CMediaSettings::LocalizeWatchedMode(WatchedMode mode)
+{
+  static constexpr int UNMAPPED = -1;
+
+  static constexpr auto messagesMap = []()
+  {
+    // WatchedMode::COUNT itself is excluded from the array
+    std::array<int, static_cast<std::size_t>(WatchedMode::COUNT)> messages{};
+    messages.fill(UNMAPPED);
+
+    messages[static_cast<int>(WatchedMode::ALL)] = 16100; // All videos
+    messages[static_cast<int>(WatchedMode::UNWATCHED)] = 16101; // Unwatched
+    messages[static_cast<int>(WatchedMode::WATCHED)] = 16102; // Watched
+
+    return messages;
+  }();
+
+  // Compile-time check that every enum value has a message
+  static_assert(std::ranges::find(messagesMap, UNMAPPED) == messagesMap.end(),
+                "message number missing for enum value");
+
+  // Special handling for the COUNT sentinel value, excluded from the array
+  // message 13205: Unknown
+  const int msgId = mode == WatchedMode::COUNT ? 13205 : messagesMap[static_cast<int>(mode)];
+  return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(msgId);
 }

--- a/xbmc/settings/MediaSettings.h
+++ b/xbmc/settings/MediaSettings.h
@@ -74,6 +74,13 @@ public:
   void CycleWatchedMode(const std::string &content);
 
   /*!
+   * \brief Cycle the watched mode \p mode
+   * \param[in] mode
+   * \sa GetWatchMode, SetWatchMode
+   */
+  void CycleWatchedMode(WatchedMode& mode);
+
+  /*!
    * \brief Returns the localized name of the watched mode \p mode
    * \param[in] mode The watch mode to localize
    * \return localized name

--- a/xbmc/settings/MediaSettings.h
+++ b/xbmc/settings/MediaSettings.h
@@ -74,13 +74,6 @@ public:
   void CycleWatchedMode(const std::string &content);
 
   /*!
-   * \brief Cycle the watched mode \p mode
-   * \param[in] mode
-   * \sa GetWatchMode, SetWatchMode
-   */
-  void CycleWatchedMode(WatchedMode& mode);
-
-  /*!
    * \brief Returns the localized name of the watched mode \p mode
    * \param[in] mode The watch mode to localize
    * \return localized name
@@ -102,6 +95,18 @@ public:
   void SetMusicNeedsUpdate(int version) { m_musicNeedsUpdate = version; }
   int GetVideoNeedsUpdate() const { return m_videoNeedsUpdate; }
   void SetVideoNeedsUpdate(int version) { m_videoNeedsUpdate = version; }
+
+  // Centralized WatchedMode logic for pseudo-encapsulation
+  /*!
+   * \brief Cycle the watched mode \p mode
+   * \param[in] mode
+   * \sa GetWatchMode, SetWatchMode
+   */
+  static void CycleWatchedMode(WatchedMode& mode);
+
+  static bool IsValidWatchedMode(int value);
+  static std::optional<WatchedMode> ToWatchedMode(int value);
+  static int WatchedModesCount();
 
 protected:
   CMediaSettings() = default;

--- a/xbmc/settings/MediaSettings.h
+++ b/xbmc/settings/MediaSettings.h
@@ -24,11 +24,14 @@ constexpr int VOLUME_DRC_MAXIMUM = 6000; // 60dB
 
 class TiXmlNode;
 
-enum WatchedMode
+enum class WatchedMode
 {
-  WatchedModeAll = 0,
-  WatchedModeUnwatched,
-  WatchedModeWatched
+  // Cycling the watched mode follows the declaration order. Enum values must be consecutive.
+  ALL = 0,
+  UNWATCHED,
+  WATCHED,
+  // add new values here
+  COUNT // do not use. sentinel value, must always be last.
 };
 
 class CMediaSettings : public ISettingCallback, public ISettingsHandler, public ISubSettings
@@ -55,7 +58,7 @@ public:
    \return the current watch mode for this content type, WATCH_MODE_ALL if the content type is unknown.
    \sa SetWatchMode
    */
-  int GetWatchedMode(const std::string &content) const;
+  WatchedMode GetWatchedMode(const std::string& content) const;
 
   /*! \brief Set the watched mode for the given content type
    \param content Current content type
@@ -69,6 +72,13 @@ public:
    \sa GetWatchMode, SetWatchMode
    */
   void CycleWatchedMode(const std::string &content);
+
+  /*!
+   * \brief Returns the localized name of the watched mode \p mode
+   * \param[in] mode The watch mode to localize
+   * \return localized name
+   */
+  std::string LocalizeWatchedMode(WatchedMode mode);
 
   void SetMusicPlaylistRepeat(bool repeats) { m_musicPlaylistRepeat = repeats; }
   void SetMusicPlaylistShuffled(bool shuffled) { m_musicPlaylistShuffle = shuffled; }
@@ -101,11 +111,11 @@ private:
   CGameSettings m_currentGameSettings;
 
   using WatchedModes = std::map<std::string, WatchedMode, std::less<>>;
-  WatchedModes m_watchedModes{{"files", WatchedModeAll},
-                              {"movies", WatchedModeAll},
-                              {"tvshows", WatchedModeAll},
-                              {"musicvideos", WatchedModeAll},
-                              {"recordings", WatchedModeAll}};
+  WatchedModes m_watchedModes{{"files", WatchedMode::ALL},
+                              {"movies", WatchedMode::ALL},
+                              {"tvshows", WatchedMode::ALL},
+                              {"musicvideos", WatchedMode::ALL},
+                              {"recordings", WatchedMode::ALL}};
 
   bool m_musicPlaylistRepeat{false};
   bool m_musicPlaylistShuffle{false};

--- a/xbmc/video/guilib/VideoGUIUtils.cpp
+++ b/xbmc/video/guilib/VideoGUIUtils.cpp
@@ -264,14 +264,14 @@ void CAsyncGetItemsForPlaylist::GetItemsForPlaylist(const std::shared_ptr<CFileI
       }
     }
 
-    int watchedMode;
+    WatchedMode watchedMode;
     if (m_resume)
-      watchedMode = WatchedModeUnwatched;
+      watchedMode = WatchedMode::UNWATCHED;
     else
       watchedMode = CMediaSettings::GetInstance().GetWatchedMode(items.GetContent());
 
-    const bool unwatchedOnly = watchedMode == WatchedModeUnwatched;
-    const bool watchedOnly = watchedMode == WatchedModeWatched;
+    const bool unwatchedOnly = watchedMode == WatchedMode::UNWATCHED;
+    const bool watchedOnly = watchedMode == WatchedMode::WATCHED;
     bool fetchedPlayCounts = false;
     for (const auto& i : items)
     {

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -216,7 +216,7 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTNSHOWMODE)
       {
-        CMediaSettings::GetInstance().CycleWatchedMode(m_watchedMode);
+        CMediaSettings::CycleWatchedMode(m_watchedMode);
         if (m_persistWatchedMode)
         {
           CMediaSettings::GetInstance().SetWatchedMode(m_vecItems->GetContent(), m_watchedMode);
@@ -404,10 +404,9 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
     m_persistWatchedMode = true;
     if (const CVariant prop = items.GetProperty(PROPERTY_WATCHED_MODE); prop.isInteger())
     {
-      const int wm = prop.asInteger();
-      if (wm >= 0 && wm < static_cast<int>(WatchedMode::COUNT))
+      if (const auto wm = CMediaSettings::ToWatchedMode(prop.asInteger()); wm.has_value())
       {
-        m_watchedMode = WatchedMode{wm};
+        m_watchedMode = wm.value();
         m_persistWatchedMode = false;
       }
     }

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -221,10 +221,11 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTNSHOWALL)
       {
-        if (CMediaSettings::GetInstance().GetWatchedMode(m_vecItems->GetContent()) == WatchedModeAll)
-          CMediaSettings::GetInstance().SetWatchedMode(m_vecItems->GetContent(), WatchedModeUnwatched);
+        const std::string content = m_vecItems->GetContent();
+        if (CMediaSettings::GetInstance().GetWatchedMode(content) == WatchedMode::ALL)
+          CMediaSettings::GetInstance().SetWatchedMode(content, WatchedMode::UNWATCHED);
         else
-          CMediaSettings::GetInstance().SetWatchedMode(m_vecItems->GetContent(), WatchedModeAll);
+          CMediaSettings::GetInstance().SetWatchedMode(content, WatchedMode::ALL);
         CServiceBroker::GetSettingsComponent()->GetSettings()->Save();
         OnFilterItems(GetProperty("filter").asString());
         UpdateButtons();
@@ -412,7 +413,8 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
                         (itemsSize == 2 && iFlatten == 1 &&                                                // flatten if one season + specials
                          (items[firstIndex]->GetVideoInfoTag()->m_iSeason == 0 || items[firstIndex + 1]->GetVideoInfoTag()->m_iSeason == 0));
 
-        if (iFlatten > 0 && !bFlatten && (WatchedMode)CMediaSettings::GetInstance().GetWatchedMode("tvshows") == WatchedModeUnwatched)
+        if (iFlatten > 0 && !bFlatten &&
+            CMediaSettings::GetInstance().GetWatchedMode("tvshows") == WatchedMode::UNWATCHED)
         {
           int count = 0;
           for(int i = 0; i < items.Size(); i++)
@@ -589,12 +591,11 @@ void CGUIWindowVideoNav::UpdateButtons()
 
   SET_CONTROL_LABEL(CONTROL_FILTER, strLabel);
 
-  int watchMode = CMediaSettings::GetInstance().GetWatchedMode(m_vecItems->GetContent());
-  SET_CONTROL_LABEL(
-      CONTROL_BTNSHOWMODE,
-      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(16100 + watchMode));
+  WatchedMode watchedMode = CMediaSettings::GetInstance().GetWatchedMode(m_vecItems->GetContent());
+  SET_CONTROL_LABEL(CONTROL_BTNSHOWMODE,
+                    CMediaSettings::GetInstance().LocalizeWatchedMode(watchedMode));
 
-  SET_CONTROL_SELECTED(GetID(), CONTROL_BTNSHOWALL, watchMode != WatchedModeAll);
+  SET_CONTROL_SELECTED(GetID(), CONTROL_BTNSHOWALL, watchedMode != WatchedMode::ALL);
 
   SET_CONTROL_SELECTED(GetID(),CONTROL_BTNPARTYMODE, g_partyModeManager.IsEnabled());
 
@@ -1112,7 +1113,7 @@ bool CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
       (PLAYLIST::IsSmartPlayList(items) || items.IsLibraryFolder()))
     node = NodeType::TITLE_TVSHOWS; // so that the check below works
 
-  int watchMode = CMediaSettings::GetInstance().GetWatchedMode(m_vecItems->GetContent());
+  WatchedMode watchedMode = CMediaSettings::GetInstance().GetWatchedMode(m_vecItems->GetContent());
 
   for (int i = 0; i < items.Size(); i++)
   {
@@ -1120,11 +1121,11 @@ bool CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
 
     if (item->HasVideoInfoTag() && (node == NodeType::TITLE_TVSHOWS || node == NodeType::SEASONS))
     {
-      if (watchMode == WatchedModeUnwatched)
+      if (watchedMode == WatchedMode::UNWATCHED)
         item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("unwatchedepisodes").asInteger();
-      if (watchMode == WatchedModeWatched)
+      if (watchedMode == WatchedMode::WATCHED)
         item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("watchedepisodes").asInteger();
-      if (watchMode == WatchedModeAll)
+      if (watchedMode == WatchedMode::ALL)
         item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("totalepisodes").asInteger();
       item->SetProperty("numepisodes", item->GetVideoInfoTag()->m_iEpisode);
       listchanged = true;
@@ -1132,9 +1133,9 @@ bool CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
 
     if (filterWatched)
     {
-      if(!item->IsParentFolder() && // Don't delete the go to parent folder
-         ((watchMode == WatchedModeWatched   && item->GetVideoInfoTag()->GetPlayCount() == 0) ||
-          (watchMode == WatchedModeUnwatched && item->GetVideoInfoTag()->GetPlayCount() > 0)))
+      if (!item->IsParentFolder() && // Don't delete the go to parent folder
+          ((watchedMode == WatchedMode::WATCHED && item->GetVideoInfoTag()->GetPlayCount() == 0) ||
+           (watchedMode == WatchedMode::UNWATCHED && item->GetVideoInfoTag()->GetPlayCount() > 0)))
       {
         items.Remove(i);
         i--;

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -76,10 +76,13 @@ using namespace KODI::MESSAGING;
 
 #define CONTROL_UPDATE_LIBRARY    20
 
+constexpr char PROPERTY_WATCHED_MODE[] = "watchedmode";
+
 CGUIWindowVideoNav::CGUIWindowVideoNav(void)
     : CGUIWindowVideoBase(WINDOW_VIDEO_NAV, "MyVideoNav.xml")
 {
   m_thumbLoader.SetObserver(this);
+  m_watchedMode = WatchedMode::ALL;
 }
 
 CGUIWindowVideoNav::~CGUIWindowVideoNav(void) = default;
@@ -213,20 +216,27 @@ bool CGUIWindowVideoNav::OnMessage(CGUIMessage& message)
       }
       else if (iControl == CONTROL_BTNSHOWMODE)
       {
-        CMediaSettings::GetInstance().CycleWatchedMode(m_vecItems->GetContent());
-        CServiceBroker::GetSettingsComponent()->GetSettings()->Save();
+        CMediaSettings::GetInstance().CycleWatchedMode(m_watchedMode);
+        if (m_persistWatchedMode)
+        {
+          CMediaSettings::GetInstance().SetWatchedMode(m_vecItems->GetContent(), m_watchedMode);
+          CServiceBroker::GetSettingsComponent()->GetSettings()->Save();
+        }
         OnFilterItems(GetProperty("filter").asString());
         UpdateButtons();
         return true;
       }
       else if (iControl == CONTROL_BTNSHOWALL)
       {
-        const std::string content = m_vecItems->GetContent();
-        if (CMediaSettings::GetInstance().GetWatchedMode(content) == WatchedMode::ALL)
-          CMediaSettings::GetInstance().SetWatchedMode(content, WatchedMode::UNWATCHED);
+        if (m_watchedMode == WatchedMode::ALL)
+          m_watchedMode = WatchedMode::UNWATCHED;
         else
-          CMediaSettings::GetInstance().SetWatchedMode(content, WatchedMode::ALL);
-        CServiceBroker::GetSettingsComponent()->GetSettings()->Save();
+          m_watchedMode = WatchedMode::ALL;
+        if (m_persistWatchedMode)
+        {
+          CMediaSettings::GetInstance().SetWatchedMode(m_vecItems->GetContent(), m_watchedMode);
+          CServiceBroker::GetSettingsComponent()->GetSettings()->Save();
+        }
         OnFilterItems(GetProperty("filter").asString());
         UpdateButtons();
         return true;
@@ -391,6 +401,20 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
   bool bResult = CGUIWindowVideoBase::GetDirectory(strDirectory, items);
   if (bResult)
   {
+    m_persistWatchedMode = true;
+    if (const CVariant prop = items.GetProperty(PROPERTY_WATCHED_MODE); prop.isInteger())
+    {
+      const int wm = prop.asInteger();
+      if (wm >= 0 && wm < static_cast<int>(WatchedMode::COUNT))
+      {
+        m_watchedMode = WatchedMode{wm};
+        m_persistWatchedMode = false;
+      }
+    }
+
+    if (m_persistWatchedMode)
+      m_watchedMode = CMediaSettings::GetInstance().GetWatchedMode(items.GetContent());
+
     if (VIDEO::IsVideoDb(items))
     {
       XFILE::CVideoDatabaseDirectory dir;
@@ -413,8 +437,7 @@ bool CGUIWindowVideoNav::GetDirectory(const std::string &strDirectory, CFileItem
                         (itemsSize == 2 && iFlatten == 1 &&                                                // flatten if one season + specials
                          (items[firstIndex]->GetVideoInfoTag()->m_iSeason == 0 || items[firstIndex + 1]->GetVideoInfoTag()->m_iSeason == 0));
 
-        if (iFlatten > 0 && !bFlatten &&
-            CMediaSettings::GetInstance().GetWatchedMode("tvshows") == WatchedMode::UNWATCHED)
+        if (iFlatten > 0 && !bFlatten && m_watchedMode == WatchedMode::UNWATCHED)
         {
           int count = 0;
           for(int i = 0; i < items.Size(); i++)
@@ -591,11 +614,10 @@ void CGUIWindowVideoNav::UpdateButtons()
 
   SET_CONTROL_LABEL(CONTROL_FILTER, strLabel);
 
-  WatchedMode watchedMode = CMediaSettings::GetInstance().GetWatchedMode(m_vecItems->GetContent());
   SET_CONTROL_LABEL(CONTROL_BTNSHOWMODE,
-                    CMediaSettings::GetInstance().LocalizeWatchedMode(watchedMode));
+                    CMediaSettings::GetInstance().LocalizeWatchedMode(m_watchedMode));
 
-  SET_CONTROL_SELECTED(GetID(), CONTROL_BTNSHOWALL, watchedMode != WatchedMode::ALL);
+  SET_CONTROL_SELECTED(GetID(), CONTROL_BTNSHOWALL, m_watchedMode != WatchedMode::ALL);
 
   SET_CONTROL_SELECTED(GetID(),CONTROL_BTNPARTYMODE, g_partyModeManager.IsEnabled());
 
@@ -1113,19 +1135,17 @@ bool CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
       (PLAYLIST::IsSmartPlayList(items) || items.IsLibraryFolder()))
     node = NodeType::TITLE_TVSHOWS; // so that the check below works
 
-  WatchedMode watchedMode = CMediaSettings::GetInstance().GetWatchedMode(m_vecItems->GetContent());
-
   for (int i = 0; i < items.Size(); i++)
   {
     CFileItemPtr item = items.Get(i);
 
     if (item->HasVideoInfoTag() && (node == NodeType::TITLE_TVSHOWS || node == NodeType::SEASONS))
     {
-      if (watchedMode == WatchedMode::UNWATCHED)
+      if (m_watchedMode == WatchedMode::UNWATCHED)
         item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("unwatchedepisodes").asInteger();
-      if (watchedMode == WatchedMode::WATCHED)
+      if (m_watchedMode == WatchedMode::WATCHED)
         item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("watchedepisodes").asInteger();
-      if (watchedMode == WatchedMode::ALL)
+      if (m_watchedMode == WatchedMode::ALL)
         item->GetVideoInfoTag()->m_iEpisode = (int)item->GetProperty("totalepisodes").asInteger();
       item->SetProperty("numepisodes", item->GetVideoInfoTag()->m_iEpisode);
       listchanged = true;
@@ -1134,8 +1154,10 @@ bool CGUIWindowVideoNav::ApplyWatchedFilter(CFileItemList &items)
     if (filterWatched)
     {
       if (!item->IsParentFolder() && // Don't delete the go to parent folder
-          ((watchedMode == WatchedMode::WATCHED && item->GetVideoInfoTag()->GetPlayCount() == 0) ||
-           (watchedMode == WatchedMode::UNWATCHED && item->GetVideoInfoTag()->GetPlayCount() > 0)))
+          ((m_watchedMode == WatchedMode::WATCHED &&
+            item->GetVideoInfoTag()->GetPlayCount() == 0) ||
+           (m_watchedMode == WatchedMode::UNWATCHED &&
+            item->GetVideoInfoTag()->GetPlayCount() > 0)))
       {
         items.Remove(i);
         i--;

--- a/xbmc/video/windows/GUIWindowVideoNav.h
+++ b/xbmc/video/windows/GUIWindowVideoNav.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -11,6 +11,7 @@
 #include "GUIWindowVideoBase.h"
 
 class CFileItemList;
+enum class WatchedMode;
 
 enum class SelectFirstUnwatchedItem
 {
@@ -57,6 +58,8 @@ protected:
   std::string GetStartFolder(const std::string &dir) override;
 
   std::vector<CMediaSource> m_shares;
+  WatchedMode m_watchedMode; // forward-declared type, initialized in constructor to avoid #include
+  bool m_persistWatchedMode = true;
 
 private:
   virtual SelectFirstUnwatchedItem GetSettingSelectFirstUnwatchedItem();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add a setting in the smart playlist editor / .xsp format to optionally set a watched mode for the displayed results.

<img width="1733" height="899" alt="image" src="https://github.com/user-attachments/assets/25d5dcac-6f58-49d1-acdc-1ad9fd9511ef" />

<img width="1250" height="407" alt="image" src="https://github.com/user-attachments/assets/14ac1bdb-7ebf-42b4-89fb-164d2650e94d" />

- Default: current behavior, the media view reuses the watched mode chosen by the user for the content type
- All videos, Watched, Unwatched: temporary override of the watched mode for the playlist results. The user can still toggle the mode but the change is not persisted.

dialog new control id: 25

Technically the SmartPlayListDirectory generates the CFileItems list for smart playlists and attaches a `watchedmode` property according to the new editor setting. No property when the setting value is 'Default'.
GUIWindowVideoNav recognizes the property after retrieving new lists of items and uses its value as default value for the window watched mode. To make this work smoothly the window was modified to manage the current watched mode value and whether it must be persisted locally, instead of constantly retrieving/setting a global mode. When the property is absent, the global mode is retrieved and updated as before.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Some smart playlists require a specific watched mode in the media window for correct results, and I got tired of manually toggling the watched mode after executing a smartplaylist, and restoring it when leaving.

example: recently watched movies playlist that requires watched mode "All videos" while movies watched mode is "Unwatched"
With the PR, the playlist can temporarily change the watched mode to All videos, without disturbing the Unwatched setting for movies.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Navigated to movies, shows, seasons and episodes and cycle the watched mode
Then tried a playlist that sets each available mode + default, which is just the behaviour pre-PR.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Control the watched mode used to display smart playlist results

## Screenshots (if appropriate):

initial situation: Sintel was played and is in progress, Tears of Steel was played and watched to the end.
<img width="1424" height="382" alt="image" src="https://github.com/user-attachments/assets/e30a6076-852f-4a5c-b7eb-fb90ed228e60" />

change watched mode to Unwatched and Tears of Steel disappears as expected:
<img width="1347" height="297" alt="image" src="https://github.com/user-attachments/assets/b7d5a8ee-6a3c-46a1-a708-3219005f395e" />

Define a smart playlist to view the recently played movies (could be in progress or watched to the end):
<img width="1730" height="902" alt="image" src="https://github.com/user-attachments/assets/b8cb95cd-a37d-4265-855b-9b0f6c32bca7" />

Enter the smart playlist:
<img width="1913" height="280" alt="image" src="https://github.com/user-attachments/assets/5019242d-15f0-41d3-b858-00decee5646b" />
The watched mode was changed to "All videos" per the smart playlist, and the two last played movies appear.

Return to Movies and the Unwatched mode set earlier is still active:
<img width="1915" height="276" alt="image" src="https://github.com/user-attachments/assets/6732f840-da4b-4c32-93ab-cfbcb52dfaca" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
