### PR TITLE
[peripherals] apply settings on OK

### DIFF
--- a/xbmc/peripherals/Peripherals.cpp
+++ b/xbmc/peripherals/Peripherals.cpp
@@ -478,6 +478,28 @@ bool CPeripherals::GetMappingForDevice(const CPeripheralBus& bus,
   return false;
 }
 
+bool CPeripherals::MappingMatchesPeripheral(const PeripheralDeviceMapping& mapping,
+                                            const CPeripheral& peripheral)
+{
+  bool bProductMatch = false;
+  if (mapping.m_PeripheralID.empty())
+    bProductMatch = true;
+  else
+  {
+    for (const auto& peripheralID : mapping.m_PeripheralID)
+      if (peripheralID.m_iVendorId == peripheral.VendorId() &&
+          peripheralID.m_iProductId == peripheral.ProductId())
+        bProductMatch = true;
+  }
+
+  bool bBusMatch =
+      (mapping.m_busType == PERIPHERAL_BUS_UNKNOWN || mapping.m_busType == peripheral.GetBusType());
+  bool bClassMatch =
+      (mapping.m_class == PERIPHERAL_UNKNOWN || mapping.m_class == peripheral.Type());
+
+  return bBusMatch && bProductMatch && bClassMatch;
+}
+
 void CPeripherals::GetSettingsFromMapping(CPeripheral& peripheral) const
 {
   std::unique_lock lock(m_critSectionMappings);
@@ -485,28 +507,36 @@ void CPeripherals::GetSettingsFromMapping(CPeripheral& peripheral) const
   /* check all mappings in the order in which they are defined in peripherals.xml */
   for (const auto& mapping : m_mappings)
   {
-    bool bProductMatch = false;
-    if (mapping.m_PeripheralID.empty())
-      bProductMatch = true;
-    else
-    {
-      for (const auto& peripheralID : mapping.m_PeripheralID)
-        if (peripheralID.m_iVendorId == peripheral.VendorId() &&
-            peripheralID.m_iProductId == peripheral.ProductId())
-          bProductMatch = true;
-    }
-
-    bool bBusMatch = (mapping.m_busType == PERIPHERAL_BUS_UNKNOWN ||
-                      mapping.m_busType == peripheral.GetBusType());
-    bool bClassMatch =
-        (mapping.m_class == PERIPHERAL_UNKNOWN || mapping.m_class == peripheral.Type());
-
-    if (bBusMatch && bProductMatch && bClassMatch)
+    if (MappingMatchesPeripheral(mapping, peripheral))
     {
       for (auto itr = mapping.m_settings.begin(); itr != mapping.m_settings.end(); ++itr)
         peripheral.AddSetting((*itr).first, (*itr).second.m_setting, (*itr).second.m_order);
     }
   }
+}
+
+std::map<std::string, std::string> CPeripherals::GetDefaultSettingsFromMapping(
+    const CPeripheral& peripheral) const
+{
+  std::map<std::string, std::string> defaults;
+
+  std::unique_lock lock(m_critSectionMappings);
+
+  /* check all mappings in the order in which they are defined in peripherals.xml, so a later
+   * mapping overrides an earlier one exactly as it does in GetSettingsFromMapping() */
+  for (const auto& mapping : m_mappings)
+  {
+    if (MappingMatchesPeripheral(mapping, peripheral))
+    {
+      for (const auto& [settingId, deviceSetting] : mapping.m_settings)
+      {
+        if (deviceSetting.m_setting)
+          defaults[settingId] = deviceSetting.m_setting->ToString();
+      }
+    }
+  }
+
+  return defaults;
 }
 
 #define SS(x) ((x) ? x : "")

--- a/xbmc/peripherals/Peripherals.h
+++ b/xbmc/peripherals/Peripherals.h
@@ -163,6 +163,15 @@ public:
   void GetSettingsFromMapping(CPeripheral& peripheral) const;
 
   /*!
+   * @brief Get the default values defined in the mappings file for a peripheral, without
+   * applying them to it.
+   * @param peripheral The peripheral to get the defaults for.
+   * @return The default value of each setting, keyed by setting id.
+   */
+  std::map<std::string, std::string> GetDefaultSettingsFromMapping(
+      const CPeripheral& peripheral) const;
+
+  /*!
    * @brief Trigger a device scan on all known busses
    */
   void TriggerDeviceScan(const PeripheralBusType type = PERIPHERAL_BUS_UNKNOWN);
@@ -366,6 +375,8 @@ public:
 
 private:
   bool LoadMappings();
+  static bool MappingMatchesPeripheral(const PeripheralDeviceMapping& mapping,
+                                       const CPeripheral& peripheral);
   bool GetMappingForDevice(const CPeripheralBus& bus, PeripheralScanResult& result) const;
   static void GetSettingsFromMappingsFile(
       tinyxml2::XMLElement* xmlNode, std::map<std::string, PeripheralDeviceSetting>& m_settings);

--- a/xbmc/peripherals/devices/Peripheral.cpp
+++ b/xbmc/peripherals/devices/Peripheral.cpp
@@ -445,7 +445,7 @@ const std::string CPeripheral::GetSettingString(const std::string& strKey) const
   return "";
 }
 
-bool CPeripheral::SetSetting(const std::string& strKey, bool bValue)
+bool CPeripheral::SetSetting(const std::string& strKey, bool bValue, bool bNotify /* = true */)
 {
   bool bChanged(false);
   std::map<std::string, PeripheralDeviceSetting>::iterator it = m_settings.find(strKey);
@@ -457,14 +457,14 @@ bool CPeripheral::SetSetting(const std::string& strKey, bool bValue)
     {
       bChanged = boolSetting->GetValue() != bValue;
       boolSetting->SetValue(bValue);
-      if (bChanged && m_bInitialised)
+      if (bChanged && bNotify && m_bInitialised)
         m_changedSettings.insert(strKey);
     }
   }
   return bChanged;
 }
 
-bool CPeripheral::SetSetting(const std::string& strKey, int iValue)
+bool CPeripheral::SetSetting(const std::string& strKey, int iValue, bool bNotify /* = true */)
 {
   bool bChanged(false);
   std::map<std::string, PeripheralDeviceSetting>::iterator it = m_settings.find(strKey);
@@ -476,14 +476,14 @@ bool CPeripheral::SetSetting(const std::string& strKey, int iValue)
     {
       bChanged = intSetting->GetValue() != iValue;
       intSetting->SetValue(iValue);
-      if (bChanged && m_bInitialised)
+      if (bChanged && bNotify && m_bInitialised)
         m_changedSettings.insert(strKey);
     }
   }
   return bChanged;
 }
 
-bool CPeripheral::SetSetting(const std::string& strKey, float fValue)
+bool CPeripheral::SetSetting(const std::string& strKey, float fValue, bool bNotify /* = true */)
 {
   bool bChanged(false);
   std::map<std::string, PeripheralDeviceSetting>::iterator it = m_settings.find(strKey);
@@ -495,7 +495,7 @@ bool CPeripheral::SetSetting(const std::string& strKey, float fValue)
     {
       bChanged = floatSetting->GetValue() != static_cast<double>(fValue);
       floatSetting->SetValue(static_cast<double>(fValue));
-      if (bChanged && m_bInitialised)
+      if (bChanged && bNotify && m_bInitialised)
         m_changedSettings.insert(strKey);
     }
   }
@@ -517,7 +517,9 @@ bool CPeripheral::IsSettingVisible(const std::string& strKey) const
   return false;
 }
 
-bool CPeripheral::SetSetting(const std::string& strKey, const std::string& strValue)
+bool CPeripheral::SetSetting(const std::string& strKey,
+                             const std::string& strValue,
+                             bool bNotify /* = true */)
 {
   bool bChanged(false);
   std::map<std::string, PeripheralDeviceSetting>::iterator it = m_settings.find(strKey);
@@ -537,7 +539,7 @@ bool CPeripheral::SetSetting(const std::string& strKey, const std::string& strVa
 
         bChanged = !StringUtils::EqualsNoCase(stringSetting->GetValue(), strValue);
         stringSetting->SetValue(strValue);
-        if (bChanged && m_bInitialised)
+        if (bChanged && bNotify && m_bInitialised)
           m_changedSettings.insert(strKey);
 
         if (strKey == SETTING_LAST_ACTIVE && !strValue.empty())
@@ -549,11 +551,13 @@ bool CPeripheral::SetSetting(const std::string& strKey, const std::string& strVa
       }
     }
     else if ((*it).second.m_setting->GetType() == SettingType::Integer)
-      bChanged = SetSetting(strKey, strValue.empty() ? 0 : atoi(strValue.c_str()));
+      bChanged = SetSetting(strKey, strValue.empty() ? 0 : atoi(strValue.c_str()), bNotify);
     else if ((*it).second.m_setting->GetType() == SettingType::Number)
-      bChanged = SetSetting(strKey, (float)(strValue.empty() ? 0 : atof(strValue.c_str())));
+      bChanged =
+          SetSetting(strKey, (float)(strValue.empty() ? 0 : atof(strValue.c_str())), bNotify);
     else if ((*it).second.m_setting->GetType() == SettingType::Boolean)
-      bChanged = SetSetting(strKey, strValue == "1" || StringUtils::EqualsNoCase(strValue, "true"));
+      bChanged = SetSetting(strKey, strValue == "1" || StringUtils::EqualsNoCase(strValue, "true"),
+                            bNotify);
   }
   return bChanged;
 }

--- a/xbmc/peripherals/devices/Peripheral.h
+++ b/xbmc/peripherals/devices/Peripheral.h
@@ -210,18 +210,30 @@ public:
    * @return The value or an empty string if it wasn't found.
    */
   virtual const std::string GetSettingString(const std::string& strKey) const;
-  virtual bool SetSetting(const std::string& strKey, const std::string& strValue);
+
+  /*!
+   * @brief Set the value of a setting.
+   * @param strKey The key of the setting.
+   * @param strValue The new value.
+   * @param bNotify True to notify the peripheral of the change when the settings are persisted,
+   *        false when the value originates from the peripheral itself and doesn't have to be
+   *        sent back to it.
+   * @return True when the value changed, false otherwise.
+   */
+  virtual bool SetSetting(const std::string& strKey,
+                          const std::string& strValue,
+                          bool bNotify = true);
   virtual void SetSettingVisible(const std::string& strKey, bool bSetTo);
   virtual bool IsSettingVisible(const std::string& strKey) const;
 
   virtual int GetSettingInt(const std::string& strKey) const;
-  virtual bool SetSetting(const std::string& strKey, int iValue);
+  virtual bool SetSetting(const std::string& strKey, int iValue, bool bNotify = true);
 
   virtual bool GetSettingBool(const std::string& strKey) const;
-  virtual bool SetSetting(const std::string& strKey, bool bValue);
+  virtual bool SetSetting(const std::string& strKey, bool bValue, bool bNotify = true);
 
   virtual float GetSettingFloat(const std::string& strKey) const;
-  virtual bool SetSetting(const std::string& strKey, float fValue);
+  virtual bool SetSetting(const std::string& strKey, float fValue, bool bNotify = true);
 
   virtual void SetAddonSetting(const std::string& strKey, const std::string& addonId);
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -1321,6 +1321,9 @@ void CPeripheralCecAdapter::CecLogMessage(void* cbParam, const cec_log_message* 
 
 void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configuration& config)
 {
+  // these values are reported by libCEC, so they must not be marked as changed. sending them back
+  // to libCEC when the settings are persisted would needlessly reconfigure the adapter, and make
+  // Kodi the active source again when 'activate_source' is enabled
   bool bChanged(false);
 
   // set the primary device type
@@ -1335,13 +1338,13 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
 
   // set the connected device
   m_configuration.baseDevice = config.baseDevice;
-  bChanged |=
-      SetSetting("connected_device",
-                 config.baseDevice == CECDEVICE_AUDIOSYSTEM ? LOCALISED_ID_AVR : LOCALISED_ID_TV);
+  bChanged |= SetSetting(
+      "connected_device",
+      config.baseDevice == CECDEVICE_AUDIOSYSTEM ? LOCALISED_ID_AVR : LOCALISED_ID_TV, false);
 
   // set the HDMI port number
   m_configuration.iHDMIPort = config.iHDMIPort;
-  bChanged |= SetSetting("cec_hdmi_port", config.iHDMIPort);
+  bChanged |= SetSetting("cec_hdmi_port", config.iHDMIPort, false);
 
   // set the physical address, when baseDevice or iHDMIPort are not set
   std::string strPhysicalAddress("0");
@@ -1352,7 +1355,7 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
     m_configuration.iPhysicalAddress = config.iPhysicalAddress;
     strPhysicalAddress = StringUtils::Format("{:x}", config.iPhysicalAddress);
   }
-  bChanged |= SetSetting("physical_address", strPhysicalAddress);
+  bChanged |= SetSetting("physical_address", strPhysicalAddress, false);
 
   // set the devices to wake when starting
   m_configuration.wakeDevices = config.wakeDevices;
@@ -1365,16 +1368,17 @@ void CPeripheralCecAdapter::SetConfigurationFromLibCEC(const CEC::libcec_configu
 
   // set the boolean settings
   m_configuration.bActivateSource = config.bActivateSource;
-  bChanged |= SetSetting("activate_source", m_configuration.bActivateSource == 1);
+  bChanged |= SetSetting("activate_source", m_configuration.bActivateSource == 1, false);
 
   m_configuration.iDoubleTapTimeoutMs = config.iDoubleTapTimeoutMs;
-  bChanged |= SetSetting("double_tap_timeout_ms", (int)m_configuration.iDoubleTapTimeoutMs);
+  bChanged |= SetSetting("double_tap_timeout_ms", (int)m_configuration.iDoubleTapTimeoutMs, false);
 
   m_configuration.iButtonRepeatRateMs = config.iButtonRepeatRateMs;
-  bChanged |= SetSetting("button_repeat_rate_ms", (int)m_configuration.iButtonRepeatRateMs);
+  bChanged |= SetSetting("button_repeat_rate_ms", (int)m_configuration.iButtonRepeatRateMs, false);
 
   m_configuration.iButtonReleaseDelayMs = config.iButtonReleaseDelayMs;
-  bChanged |= SetSetting("button_release_delay_ms", (int)m_configuration.iButtonReleaseDelayMs);
+  bChanged |=
+      SetSetting("button_release_delay_ms", (int)m_configuration.iButtonReleaseDelayMs, false);
 
   m_configuration.bPowerOffOnStandby = config.bPowerOffOnStandby;
 
@@ -1484,8 +1488,10 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
 
   if (GetSettingBool("pause_playback_on_deactivate"))
   {
-    SetSetting("pause_or_stop_playback_on_deactivate", LOCALISED_ID_PAUSE);
-    SetSetting("pause_playback_on_deactivate", false);
+    // migration of a deprecated setting. the new value is read when it's needed, so it doesn't
+    // have to be marked as changed
+    SetSetting("pause_or_stop_playback_on_deactivate", LOCALISED_ID_PAUSE, false);
+    SetSetting("pause_playback_on_deactivate", false, false);
   }
 }
 
@@ -1540,7 +1546,8 @@ bool CPeripheralCecAdapter::WriteLogicalAddresses(const cec_logical_addresses& a
       if (addresses[iPtr])
         strPowerOffDevices += StringUtils::Format(" {:X}", iPtr);
     StringUtils::Trim(strPowerOffDevices);
-    bChanged = SetSetting(strAdvancedSettingName, strPowerOffDevices);
+    // reported by libCEC, so don't mark it as changed
+    bChanged = SetSetting(strAdvancedSettingName, strPowerOffDevices, false);
   }
 
   int iSettingPowerOffDevices = LOCALISED_ID_NONE;
@@ -1550,7 +1557,7 @@ bool CPeripheralCecAdapter::WriteLogicalAddresses(const cec_logical_addresses& a
     iSettingPowerOffDevices = LOCALISED_ID_TV;
   else if (addresses[CECDEVICE_AUDIOSYSTEM])
     iSettingPowerOffDevices = LOCALISED_ID_AVR;
-  return SetSetting(strSettingName, iSettingPowerOffDevices) || bChanged;
+  return SetSetting(strSettingName, iSettingPowerOffDevices, false) || bChanged;
 }
 
 CPeripheralCecAdapterUpdateThread::CPeripheralCecAdapterUpdateThread(

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -33,6 +33,9 @@ using namespace PERIPHERALS;
 namespace
 {
 constexpr const int CONTROL_ID_PERIPHERAL_ICON = 100;
+
+// Setting that holds the controller profile of a peripheral
+constexpr std::string_view SETTING_APPEARANCE = "appearance";
 } // namespace
 
 CGUIDialogPeripheralSettings::CGUIDialogPeripheralSettings()
@@ -46,7 +49,7 @@ CGUIDialogPeripheralSettings::~CGUIDialogPeripheralSettings()
   if (m_item != NULL)
     delete m_item;
 
-  m_settingsMap.clear();
+  m_changedValues.clear();
 }
 
 bool CGUIDialogPeripheralSettings::OnMessage(CGUIMessage& message)
@@ -63,6 +66,9 @@ bool CGUIDialogPeripheralSettings::OnMessage(CGUIMessage& message)
 
 void CGUIDialogPeripheralSettings::OnDeinitWindow(int nextWindowID)
 {
+  // discard any values that weren't applied by confirming the dialog
+  m_changedValues.clear();
+
   UpdateIcon({});
   CGUIDialogSettingsManualBase::OnDeinitWindow(nextWindowID);
 }
@@ -95,33 +101,27 @@ void CGUIDialogPeripheralSettings::OnSettingChanged(const std::shared_ptr<const 
 
   CGUIDialogSettingsManualBase::OnSettingChanged(setting);
 
-  const std::string& settingId = setting->GetId();
-
-  // we need to copy the new value of the setting from the copy to the
-  // original setting
-  std::map<std::string, std::shared_ptr<CSetting>>::iterator itSetting =
-      m_settingsMap.find(settingId);
-  if (itSetting == m_settingsMap.end())
+  // ignore the values that are set while the controls are being created
+  if (m_initialising)
     return;
 
-  itSetting->second->FromString(setting->ToString());
+  const std::string& settingId = setting->GetId();
 
   // Get peripheral associated with this setting
   PeripheralPtr peripheral;
   if (m_item != nullptr)
     peripheral = CServiceBroker::GetPeripherals().GetByPath(m_item->GetPath());
 
-  if (!peripheral)
+  if (!peripheral || !peripheral->HasSetting(settingId))
     return;
 
-  if (peripheral->SetSetting(settingId, setting->ToString()))
-    peripheral->OnSettingChanged(settingId);
+  // Remember the new value. It is applied to the peripheral when the dialog is confirmed, so
+  // that changes don't take effect while the user is still making them
+  m_changedValues[settingId] = setting->ToString();
 
-  // Refresh peripheral icon
-  UpdateIcon(peripheral->ControllerProfile());
-
-  // Persist settings so that the new setting takes effect immediately
-  Save();
+  // Refresh peripheral icon to show the selected appearance
+  if (settingId == SETTING_APPEARANCE)
+    UpdateIcon(CServiceBroker::GetGameControllerManager().GetController(setting->ToString()));
 }
 
 void CGUIDialogPeripheralSettings::UpdateIcon(const GAME::ControllerPtr& controller)
@@ -141,9 +141,22 @@ bool CGUIDialogPeripheralSettings::Save()
   if (!peripheral)
     return true;
 
+  // Apply the changed values. CPeripheral keeps track of the settings that actually changed, and
+  // notifies the peripheral of those changes when they are persisted
+  for (const auto& [settingId, value] : m_changedValues)
+    peripheral->SetSetting(settingId, value);
+
+  m_changedValues.clear();
+
   peripheral->PersistSettings();
 
   return true;
+}
+
+void CGUIDialogPeripheralSettings::OnCancel()
+{
+  // discard the changed values
+  m_changedValues.clear();
 }
 
 void CGUIDialogPeripheralSettings::OnResetSettings()
@@ -157,6 +170,9 @@ void CGUIDialogPeripheralSettings::OnResetSettings()
 
   if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{10041}, CVariant{10042}))
     return;
+
+  // the settings that were changed in this dialog are replaced by the defaults
+  m_changedValues.clear();
 
   // reset the settings in the peripheral
   peripheral->ResetDefaultSettings();
@@ -210,7 +226,7 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
     return;
   }
 
-  m_settingsMap.clear();
+  m_changedValues.clear();
   CGUIDialogSettingsManualBase::InitializeSettings();
 
   const std::shared_ptr<CSettingCategory> category = AddCategory("peripheralsettings", -1);
@@ -324,7 +340,6 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
     {
       settingCopy->SetLevel(SettingLevel::Basic);
       group->AddSetting(settingCopy);
-      m_settingsMap.insert(std::make_pair(setting->GetId(), setting));
     }
   }
 

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.cpp
@@ -68,6 +68,7 @@ void CGUIDialogPeripheralSettings::OnDeinitWindow(int nextWindowID)
 {
   // discard any values that weren't applied by confirming the dialog
   m_changedValues.clear();
+  m_resetRequested = false;
 
   UpdateIcon({});
   CGUIDialogSettingsManualBase::OnDeinitWindow(nextWindowID);
@@ -141,12 +142,20 @@ bool CGUIDialogPeripheralSettings::Save()
   if (!peripheral)
     return true;
 
+  // A reset was confirmed in this dialog, so let the peripheral reset itself now that the
+  // dialog is confirmed too. This covers what resetting means beyond the values shown here,
+  // such as a joystick's button map. The changed values are applied on top, so a setting
+  // edited after the reset still wins
+  if (m_resetRequested)
+    peripheral->ResetDefaultSettings();
+
   // Apply the changed values. CPeripheral keeps track of the settings that actually changed, and
   // notifies the peripheral of those changes when they are persisted
   for (const auto& [settingId, value] : m_changedValues)
     peripheral->SetSetting(settingId, value);
 
   m_changedValues.clear();
+  m_resetRequested = false;
 
   peripheral->PersistSettings();
 
@@ -157,6 +166,7 @@ void CGUIDialogPeripheralSettings::OnCancel()
 {
   // discard the changed values
   m_changedValues.clear();
+  m_resetRequested = false;
 }
 
 void CGUIDialogPeripheralSettings::OnResetSettings()
@@ -171,17 +181,17 @@ void CGUIDialogPeripheralSettings::OnResetSettings()
   if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{10041}, CVariant{10042}))
     return;
 
-  // the settings that were changed in this dialog are replaced by the defaults
-  m_changedValues.clear();
+  // Buffer the defaults like any other change made in this dialog: they are shown in the
+  // controls straight away, but only reach the peripheral once the dialog itself is
+  // confirmed, and are discarded if it isn't. Confirming this prompt says which values to
+  // put in the dialog, not that the dialog is done.
+  m_pendingDefaults = CServiceBroker::GetPeripherals().GetDefaultSettingsFromMapping(*peripheral);
+  m_resetRequested = true;
 
-  // reset the settings in the peripheral
-  peripheral->ResetDefaultSettings();
-
-  // re-create all settings and their controls
+  // re-create all settings and their controls, so they show the defaults
   SetupView();
 
-  // Persist settings so that resetting takes effect immediately
-  Save();
+  m_pendingDefaults.clear();
 }
 
 void CGUIDialogPeripheralSettings::SetupView()
@@ -338,6 +348,14 @@ void CGUIDialogPeripheralSettings::InitializeSettings()
 
     if (settingCopy != NULL && settingCopy->GetControl() != NULL)
     {
+      // Seed the control with the default the user asked to reset to, and remember it as a
+      // change so that confirming the dialog applies it through the usual path. Done here
+      // rather than by resetting the peripheral, which would take effect before the dialog
+      // is confirmed.
+      const auto itDefault = m_pendingDefaults.find(settingCopy->GetId());
+      if (itDefault != m_pendingDefaults.end() && settingCopy->FromString(itDefault->second))
+        m_changedValues[settingCopy->GetId()] = itDefault->second;
+
       settingCopy->SetLevel(SettingLevel::Basic);
       group->AddSetting(settingCopy);
     }

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
@@ -61,5 +61,13 @@ protected:
   //! The values that were changed in this dialog, keyed by setting ID. They are applied to the
   //! peripheral when the dialog is confirmed, and discarded when it isn't
   std::map<std::string, std::string> m_changedValues;
+
+  // Defaults waiting to be shown by the next InitializeSettings(), set by OnResetSettings().
+  // Only populated while the controls are being re-created.
+  std::map<std::string, std::string> m_pendingDefaults;
+
+  //! Whether a reset to defaults was confirmed in this dialog. The peripheral is reset when the
+  //! dialog itself is confirmed, and not at all when it isn't
+  bool m_resetRequested{false};
 };
 } // namespace PERIPHERALS

--- a/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
+++ b/xbmc/peripherals/dialogs/GUIDialogPeripheralSettings.h
@@ -44,6 +44,7 @@ protected:
   // specialization of CGUIDialogSettingsBase
   bool AllowResettingSettings() const override { return false; }
   bool Save() override;
+  void OnCancel() override;
   void OnResetSettings() override;
   void SetupView() override;
 
@@ -56,6 +57,9 @@ protected:
   CPeripherals* m_manager{nullptr};
   CFileItem* m_item;
   bool m_initialising = false;
-  std::map<std::string, std::shared_ptr<CSetting>> m_settingsMap;
+
+  //! The values that were changed in this dialog, keyed by setting ID. They are applied to the
+  //! peripheral when the dialog is confirmed, and discarded when it isn't
+  std::map<std::string, std::string> m_changedValues;
 };
 } // namespace PERIPHERALS


### PR DESCRIPTION
## Description

The peripheral settings dialog applied and persisted every change the moment a control was operated, instead of when the dialog was confirmed. For a CEC adapter this is very visible: changing any setting reconfigures the adapter, and with `activate_source` enabled that makes Kodi the active source again, so the TV switches to Kodi's input while the user is still in the settings dialog. The cancel button didn't cancel anything either.

Three changes:

**1. Don't send settings that were reported by a peripheral back to it**

`CPeripheral::SetSetting()` records every changed setting in `m_changedSettings`, and `PersistSettings()` notifies the peripheral of those changes by calling `OnSettingChanged()` for each of them.

`CPeripheralCecAdapter::SetConfigurationFromLibCEC()` stores the configuration that libCEC reported to us through `CPeripheral::SetSetting()`, so those settings were marked as changed too, and were sent straight back to libCEC the next time the settings were persisted. libCEC then reported the configuration back to us again, which marked the settings as changed again, so this repeated on every persist.

A `bNotify` parameter is added to `CPeripheral::SetSetting()`, defaulting to `true`. `SetConfigurationFromLibCEC()`, `WriteLogicalAddresses()` and the deprecated `pause_playback_on_deactivate` migration pass `false`: the values are still stored and persisted, they just aren't sent back to the peripheral.

**2. Only apply peripheral settings when the dialog is confirmed**

`CGUIDialogPeripheralSettings` now keeps the changed values, and applies them to the peripheral in `Save()`, which is called when the dialog is confirmed. The values are discarded when the dialog is closed without confirming it, so cancelling works as expected.

This also fixes the write-through that made the settings dialog a no-op for the peripheral: the new value was written directly into the peripheral's `CSetting` (the dialog held the peripheral's own instances, not copies) *before* `CPeripheral::SetSetting()` was called with that same value. `SetSetting()` therefore never saw a change, never recorded one, and never returned `true`, so the `OnSettingChanged()` call added in #26605 could not fire and the peripheral was not notified at all. Applying the values in one place fixes that.

**3. Don't apply a settings reset before the dialog is confirmed**

Resetting to defaults was the one path still breaking the contract the previous commit establishes. `OnResetSettings()` reset the peripheral and persisted the result straight away, so confirming the "restore settings to default?" prompt reconfigured the adapter and rewrote the settings file while the dialog was still open, and cancelling afterwards could undo neither.

It was written that way because `InitializeSettings()` builds its controls from `peripheral->GetSettings()`, so mutating the peripheral was the only way to make the re-created controls show defaults. `CPeripherals::GetDefaultSettingsFromMapping()` now returns the mapping defaults without applying them; they are buffered like any other change and seeded into the controls, so they reach the peripheral when the dialog is confirmed and are dropped when it isn't. The mapping-match test is factored out into `MappingMatchesPeripheral()` and shared with `GetSettingsFromMapping()` so the two cannot drift.

`CPeripheral::ResetDefaultSettings()` is deferred rather than dropped: it is called from `Save()` when a reset was confirmed in the dialog, since it covers what resetting means beyond the values the dialog shows — `CPeripheralJoystick` overrides it to reset and save the button map. The buffered values are applied on top, so a setting edited after the reset still wins.

## Motivation and context

Fixes #26897.

Related history: #19207 / #26604 (settings not taking effect until Kodi was restarted), #26286 (added the immediate apply + persist on every change) and #26605 (added the peripheral notification that could never fire).

## How has this been tested?

Tested on hardware on a Raspberry Pi 4 (aarch64) running LibreELEC `devel-20260729100840-61bdccf`, with libCEC 8.1.1 and two CEC adapters (`/dev/cec0`, `/dev/cec1`). Kodi was built from LibreELEC's pinned commit plus #28656, #28657, #28666 and this PR, with all LibreELEC Kodi patches applying cleanly.

Every result below is evidenced by the `CPeripheralCecAdapter` debug log markers (`closing the CEC connection`, `starting the CEC connection`, `sending the updated configuration to libCEC`) and by the contents and mtime of the per-adapter file in `peripheral_data`. Where a test asserts that *nothing* happened, the same log contains those markers from the surrounding tests, so the absence is evidenced rather than assumed.

- **Nothing is applied before OK.** Settings changed with the dialog left open produced no CEC markers at all; pressing OK produced exactly one `closing the CEC connection`, at that moment, and nothing afterwards.
- **Enable/disable now takes effect on OK, without restarting Kodi.** Toggling the adapter back on and confirming produced a single `starting the CEC connection` at the moment of OK, and CEC worked again without a restart. Before this PR that required a restart.
- **Cancel discards.** The change was neither applied nor persisted.
- **Non-`enabled` settings** (`double_tap_timeout_ms`) behave the same: one `sending the updated configuration to libCEC`, at OK.
- **Opening the dialog and closing it without changing anything** — with Cancel and with OK — produced no CEC markers at all. This is the direct test of the first commit: the configuration libCEC reports back is no longer marked as changed and pushed into `SetConfiguration()`.
- **Reset to defaults.** Confirming the prompt alone changes only what the dialog shows: no markers, settings file untouched, and cancelling afterwards leaves it untouched. Confirming the dialog afterwards applies the defaults and rewrites the file. Before the third commit, confirming the prompt alone reconfigured the adapter and rewrote the file.
- **Per-adapter settings files** (#28657 in the same tree): saving one adapter's settings did not touch the other's file.

Not covered by that run:

- Anything joystick-specific — no controller was attached to the test box. That covers the controller appearance setting and a joystick's button map.
- The deferred `ResetDefaultSettings()` call was added after the hardware run, in response to review: at the time reset was tested, the third commit restored the mapping defaults only. What was verified on hardware is that a reset reaches the peripheral only when the dialog is confirmed, which is the part that changed observably for CEC; the call it now makes at that point has been compile-tested but not exercised on hardware.

## What is the effect on users?

Changing a peripheral setting now takes effect when the settings dialog is confirmed, instead of while it is still open, and closing the dialog without confirming it discards the changes. For CEC adapters this stops the TV from switching to Kodi's input while the CEC settings are being edited, and enabling or disabling the adapter now takes effect without restarting Kodi.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
