### PR TITLE
VAAPI: add hardware scaling

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -22523,7 +22523,26 @@ msgctxt "#36642"
 msgid "No orphaned add-ons to remove."
 msgstr ""
 
-#empty strings from id 36643 to 36898
+#. Label for a video playback setting
+#: system/settings/linux.xml
+msgctxt "#36643"
+msgid "Use VAAPI hardware scaling"
+msgstr ""
+
+#. Help text for setting with label #36643
+#: system/settings/linux.xml
+msgctxt "#36644"
+msgid "Scales decoded video to the display resolution using the VAAPI video processing pipeline's hardware scaler, instead of the renderer's shader-based scaling."
+msgstr ""
+
+#. Value shown in place of the scaling method spinner when VAAPI hardware
+#. scaling is enabled in settings
+#: xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+msgctxt "#36645"
+msgid "VAAPI hardware scaling enabled"
+msgstr ""
+
+#empty strings from id 36646 to 36898
 
 #. Description of setting with label #729 "Enable SSL"
 #: system/settings/settings.xml

--- a/system/settings/linux.xml
+++ b/system/settings/linux.xml
@@ -173,6 +173,18 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="videoplayer.vaapihwscaling" type="boolean" parent="videoplayer.usevaapi" label="36643" help="36644">
+          <requirement>HAS_GLES</requirement>
+          <visible>true</visible>
+          <dependencies>
+            <dependency type="enable">
+              <condition setting="videoplayer.usevaapi" operator="is">true</condition>
+            </dependency>
+          </dependencies>
+          <level>3</level>
+          <default>true</default>
+          <control type="toggle" />
+        </setting>
         <setting id="videoplayer.useprimedecoder" type="boolean" label="13430" help="36172">
           <requirement>HAS_GLES</requirement>
           <visible>false</visible>

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -16,6 +16,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/lib/Setting.h"
+#include "utils/MathUtils.h"
 #include "utils/MemUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/XTimeUtils.h"
@@ -24,6 +25,7 @@
 #include "windowing/WinSystem.h"
 
 #include <array>
+#include <cmath>
 #include <mutex>
 #include <optional>
 
@@ -64,6 +66,7 @@ constexpr auto SETTING_VIDEOPLAYER_USEVAAPIVC1 = "videoplayer.usevaapivc1";
 constexpr auto SETTING_VIDEOPLAYER_USEVAAPIVP8 = "videoplayer.usevaapivp8";
 constexpr auto SETTING_VIDEOPLAYER_USEVAAPIVP9 = "videoplayer.usevaapivp9";
 constexpr auto SETTING_VIDEOPLAYER_PREFERVAAPIRENDER = "videoplayer.prefervaapirender";
+constexpr auto SETTING_VIDEOPLAYER_VAAPIHWSCALING = "videoplayer.vaapihwscaling";
 
 void VAAPI::VaErrorCallback(void *user_context, const char *message)
 {
@@ -132,6 +135,7 @@ bool CVAAPIContext::EnsureContext(CVAAPIContext **ctx, CDecoder *decoder)
   }
 
   m_context = new CVAAPIContext();
+  m_context->m_refCount = 1;
   *ctx = m_context;
   {
     std::unique_lock gLock(CServiceBroker::GetWinSystem()->GetGfxContext());
@@ -143,8 +147,6 @@ bool CVAAPIContext::EnsureContext(CVAAPIContext **ctx, CDecoder *decoder)
       return false;
     }
   }
-
-  m_context->m_refCount++;
 
   if (!m_context->IsValidDecoder(decoder))
     m_context->m_decoders.push_back(decoder);
@@ -820,9 +822,31 @@ void CDecoder::Close()
 {
   CLog::Log(LOGINFO, "VAAPI::{}", __FUNCTION__);
 
+  if (m_registeredDispResource)
+  {
+    if (auto winSystem = CServiceBroker::GetWinSystem())
+      winSystem->Unregister(this);
+    m_registeredDispResource = false;
+
+    constexpr int MAX_WAIT_MS = 2000;
+    int waitedMs = 0;
+    while (m_activeResetDisplayCalls > 0 && waitedMs < MAX_WAIT_MS)
+    {
+      KODI::TIME::Sleep(1ms);
+      waitedMs++;
+    }
+    if (m_activeResetDisplayCalls > 0)
+    {
+      CLog::Log(LOGWARNING,
+                "VAAPI::{} - timed out after {} ms waiting for OnResetDisplay() to finish, "
+                "proceeding anyway",
+                __FUNCTION__, MAX_WAIT_MS);
+    }
+  }
+
   std::unique_lock lock(m_DecoderSection);
 
-  FiniVAAPIOutput();
+  FiniVAAPIOutput(true);
 
   m_deviceRef.reset();
 
@@ -1307,46 +1331,200 @@ bool CDecoder::ConfigVAAPI()
     m_videoSurfaces.AddSurface(surfaces[i]);
   }
 
-  // initialize output
-  std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
-  m_vaapiConfig.stats = &m_bufferStats;
-  m_bufferStats.Reset();
-  m_vaapiOutput.Start();
-  Message *reply;
-  if (m_vaapiOutput.m_controlPort.SendOutMessageSync(COutputControlProtocol::INIT, &reply, 2s,
-                                                     &m_vaapiConfig, sizeof(m_vaapiConfig)))
   {
-    bool success = reply->signal == COutputControlProtocol::ACC ? true : false;
-    if (!success)
+    // Release the gfx lock before taking decoder/resource locks to avoid
+    // lock-order inversion.
+    std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
+
+    GetScaleTarget(m_vaapiConfig.vidWidth, m_vaapiConfig.vidHeight, m_vaapiConfig.aspect,
+                   m_vaapiConfig.scaleWidth, m_vaapiConfig.scaleHeight);
+    if (m_vaapiConfig.scaleWidth > 0 && m_vaapiConfig.scaleHeight > 0)
     {
+      CLog::Log(LOGINFO, "VAAPI - hardware scaling {}x{} -> {}x{} (VPP, VA_FILTER_SCALING_HQ)",
+                m_vaapiConfig.vidWidth, m_vaapiConfig.vidHeight, m_vaapiConfig.scaleWidth,
+                m_vaapiConfig.scaleHeight);
+    }
+
+    m_vaapiConfig.stats = &m_bufferStats;
+    m_bufferStats.Reset();
+    m_vaapiOutput.Start();
+    Message* reply;
+    if (m_vaapiOutput.m_controlPort.SendOutMessageSync(COutputControlProtocol::INIT, &reply, 2s,
+                                                       &m_vaapiConfig, sizeof(m_vaapiConfig)))
+    {
+      bool success = reply->signal == COutputControlProtocol::ACC ? true : false;
+      if (!success)
+      {
+        reply->Release();
+        CLog::Log(LOGERROR, "VAAPI::{} - vaapi output returned error", __FUNCTION__);
+        m_vaapiOutput.Dispose();
+        return false;
+      }
       reply->Release();
-      CLog::Log(LOGERROR, "VAAPI::{} - vaapi output returned error", __FUNCTION__);
+    }
+    else
+    {
+      CLog::Log(LOGERROR, "VAAPI::{} - failed to init output", __FUNCTION__);
       m_vaapiOutput.Dispose();
       return false;
     }
-    reply->Release();
-  }
-  else
-  {
-    CLog::Log(LOGERROR, "VAAPI::{} - failed to init output", __FUNCTION__);
-    m_vaapiOutput.Dispose();
-    return false;
   }
 
   m_inMsgEvent.Reset();
-  m_vaapiConfigured = true;
+  {
+    std::unique_lock decoderLock(m_DecoderSection);
+    m_vaapiConfigured = true;
+  }
   m_ErrorCount = 0;
+
+  if (!m_registeredDispResource)
+  {
+    auto settingsComponent = CServiceBroker::GetSettingsComponent();
+    auto settings = settingsComponent ? settingsComponent->GetSettings() : nullptr;
+    auto winSystem = CServiceBroker::GetWinSystem();
+    if (settings && settings->GetBool(SETTING_VIDEOPLAYER_VAAPIHWSCALING) && winSystem &&
+        winSystem->GetName().rfind(WINDOW_SYSTEM_NAME_GBM, 0) == 0)
+    {
+      winSystem->Register(this);
+      m_registeredDispResource = true;
+    }
+  }
 
   return true;
 }
 
-void CDecoder::FiniVAAPIOutput()
+void CDecoder::GetScaleTarget(
+    int vidWidth, int vidHeight, AVRational sar, int& scaleWidth, int& scaleHeight)
+{
+  scaleWidth = 0;
+  scaleHeight = 0;
+
+#if defined(HAS_GLES)
+  auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  auto settings = settingsComponent ? settingsComponent->GetSettings() : nullptr;
+  auto winSystem = CServiceBroker::GetWinSystem();
+  if (settings && settings->GetBool(SETTING_VIDEOPLAYER_VAAPIHWSCALING) && winSystem &&
+      winSystem->GetName().rfind(WINDOW_SYSTEM_NAME_GBM, 0) == 0 && vidWidth > 0 && vidHeight > 0)
+  {
+    // Read RESOLUTION_INFO under the gfx-context lock.
+    RESOLUTION_INFO resInfo;
+    {
+      std::unique_lock gfxLock(winSystem->GetGfxContext());
+      resInfo = winSystem->GetGfxContext().GetResInfo();
+    }
+
+    // Calculate the aspect-correct destination rectangle.
+    const double effectiveAspect = (sar.num > 0 && sar.den > 0)
+                                       ? (double)vidWidth * sar.num / ((double)vidHeight * sar.den)
+                                       : (double)vidWidth / vidHeight;
+    // Screen resolutions can use non-square pixels (fPixelRatio != 1), so the
+    // on-screen aspect ratio isn't always iScreenWidth/iScreenHeight.
+    const double screenAspect =
+        (resInfo.iScreenHeight > 0)
+            ? static_cast<double>(resInfo.iScreenWidth) *
+                  static_cast<double>(resInfo.fPixelRatio > 0.0f ? resInfo.fPixelRatio : 1.0f) /
+                  resInfo.iScreenHeight
+            : 0.0;
+
+    if (screenAspect > 0.0 && vidWidth > 0 && vidHeight > 0)
+    {
+      int destWidth;
+      int destHeight;
+      if (effectiveAspect > screenAspect)
+      {
+        // Fill width and letterbox vertically.
+        destWidth = resInfo.iScreenWidth;
+        destHeight = MathUtils::round_int(destWidth / effectiveAspect);
+      }
+      else
+      {
+        // Fill height and pillarbox horizontally.
+        destHeight = resInfo.iScreenHeight;
+        destWidth = MathUtils::round_int(destHeight * effectiveAspect);
+      }
+
+      // Tolerance avoids triggering hw scaling for a near-1:1 fit that only
+      // differs by integer-rounding noise (a pixel or two).
+      constexpr double SCALE_RATIO_TOLERANCE = 0.02; // ~2%
+      const double ratioW = (double)destWidth / vidWidth;
+      const double ratioH = (double)destHeight / vidHeight;
+      const bool needsScaling = std::fabs(ratioW - 1.0) > SCALE_RATIO_TOLERANCE ||
+                                std::fabs(ratioH - 1.0) > SCALE_RATIO_TOLERANCE;
+
+      CLog::Log(LOGDEBUG, LOGVIDEO,
+                "VAAPI - scale check: vid {}x{} sar={}/{} displayAspect={:.4f} fit {}x{} "
+                "(screen {}x{}) needsScaling={}",
+                vidWidth, vidHeight, sar.num, sar.den, effectiveAspect, destWidth, destHeight,
+                resInfo.iScreenWidth, resInfo.iScreenHeight, needsScaling);
+
+      if (needsScaling)
+      {
+        scaleWidth = destWidth;
+        scaleHeight = destHeight;
+      }
+    }
+  }
+#endif
+}
+
+void CDecoder::OnResetDisplay()
+{
+  m_activeResetDisplayCalls++;
+  struct ScopeGuard
+  {
+    std::atomic<int>& counter;
+    ~ScopeGuard() { counter--; }
+  } activeCallGuard{m_activeResetDisplayCalls};
+
+  int vidWidth;
+  int vidHeight;
+  AVRational sar;
+  int curScaleWidth;
+  int curScaleHeight;
+  bool configured;
+  {
+    std::unique_lock lock(m_DecoderSection);
+    configured = m_vaapiConfigured;
+    vidWidth = m_vaapiConfig.vidWidth;
+    vidHeight = m_vaapiConfig.vidHeight;
+    sar = m_vaapiConfig.aspect;
+    curScaleWidth = m_vaapiConfig.scaleWidth;
+    curScaleHeight = m_vaapiConfig.scaleHeight;
+  }
+  if (!configured)
+    return;
+
+  // Avoid lock inversion with the graphics context
+  int scaleWidth;
+  int scaleHeight;
+  GetScaleTarget(vidWidth, vidHeight, sar, scaleWidth, scaleHeight);
+
+  if (scaleWidth == curScaleWidth && scaleHeight == curScaleHeight)
+    return;
+
+  {
+    std::unique_lock lock(m_DecoderSection);
+    if (!m_vaapiConfigured)
+      return;
+    m_vaapiConfig.scaleWidth = scaleWidth;
+    m_vaapiConfig.scaleHeight = scaleHeight;
+
+    CLog::Log(LOGINFO, "VAAPI - display reset, updating hw scale target {}x{} -> {}x{}",
+              curScaleWidth, curScaleHeight, scaleWidth, scaleHeight);
+
+    SScaleTarget target{scaleWidth, scaleHeight};
+    m_vaapiOutput.m_controlPort.SendOutMessage(COutputControlProtocol::SETSCALETARGET, &target,
+                                               sizeof(target));
+  }
+}
+
+void CDecoder::FiniVAAPIOutput(bool force)
 {
   if (!m_vaapiConfigured)
     return;
 
   // uninit output
-  m_vaapiOutput.Dispose();
+  m_vaapiOutput.Dispose(force);
   m_vaapiConfigured = false;
 
   // destroy surfaces
@@ -1634,7 +1812,7 @@ COutput::~COutput()
   Dispose();
 }
 
-void COutput::Dispose()
+void COutput::Dispose(bool force)
 {
   std::unique_lock lock(CServiceBroker::GetWinSystem()->GetGfxContext());
   m_bStop = true;
@@ -1642,6 +1820,13 @@ void COutput::Dispose()
   StopThread();
   m_controlPort.Purge();
   m_dataPort.Purge();
+
+  if (force && !m_discardedPostprocs.empty())
+  {
+    CLog::Log(LOGWARNING, "VAAPI output: force-releasing {} postproc(s) still awaiting disposal",
+              m_discardedPostprocs.size());
+    m_discardedPostprocs.clear();
+  }
 }
 
 void COutput::OnStartup()
@@ -1770,6 +1955,20 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
           m_state = O_TOP_UNCONFIGURED;
           m_extTimeout = 10s;
           return;
+        case COutputControlProtocol::SETSCALETARGET:
+        {
+          // Defer postproc recreation until the IDLE state.
+          SScaleTarget* target = reinterpret_cast<SScaleTarget*>(msg->data);
+          if (target &&
+              (target->width != m_config.scaleWidth || target->height != m_config.scaleHeight))
+          {
+            m_config.scaleWidth = target->width;
+            m_config.scaleHeight = target->height;
+            m_scaleTargetChanged = true;
+          }
+          m_extTimeout = 0ms;
+          return;
+        }
         default:
           break;
         }
@@ -1812,6 +2011,20 @@ void COutput::StateMachine(int signal, Protocol *port, Message *msg)
         switch (signal)
         {
         case COutputControlProtocol::TIMEOUT:
+          if (m_scaleTargetChanged)
+          {
+            m_scaleTargetChanged = false;
+            if (m_pp)
+            {
+              CLog::Log(LOGDEBUG, LOGVIDEO,
+                        "VAAPI output: scale target changed, discarding postproc");
+              std::shared_ptr<CPostproc> pp(m_pp);
+              m_discardedPostprocs.push_back(pp);
+              m_pp->Discard(this, &COutput::ReadyForDisposal);
+              m_pp = nullptr;
+              m_config.processInfo->SetVideoDeintMethod("unknown");
+            }
+          }
           ProcessSyncPicture();
           m_extTimeout = 100ms;
           if (HasWork())
@@ -2189,20 +2402,44 @@ void COutput::InitCycle()
     }
     if (!m_pp)
     {
+      bool preInitOk;
       if (method == VS_INTERLACEMETHOD_DEINTERLACE ||
           method == VS_INTERLACEMETHOD_RENDER_BOB)
       {
         CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI output: Initializing ffmpeg postproc");
         m_pp = new CFFmpegPostproc();
         m_config.stats->SetVpp(false);
+        preInitOk = m_pp->PreInit(m_config);
       }
       else
       {
+        const bool wantsHwScaling = (m_config.scaleWidth > 0 && m_config.scaleHeight > 0);
+        const bool hwScalingBlocked = wantsHwScaling && !m_discardedPostprocs.empty();
+        if (hwScalingBlocked)
+        {
+          CLog::Log(LOGWARNING,
+                    "VAAPI output: hw scaling deferred for deinterlace postproc - {} "
+                    "postproc(s) still awaiting disposal",
+                    m_discardedPostprocs.size());
+        }
+
         CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI output: Initializing vaapi postproc");
         m_pp = new CVppPostproc();
         m_config.stats->SetVpp(true);
+
+        const int savedScaleWidth = m_config.scaleWidth;
+        const int savedScaleHeight = m_config.scaleHeight;
+        if (hwScalingBlocked)
+        {
+          m_config.scaleWidth = 0;
+          m_config.scaleHeight = 0;
+        }
+        preInitOk = m_pp->PreInit(m_config);
+        m_config.scaleWidth = savedScaleWidth;
+        m_config.scaleHeight = savedScaleHeight;
       }
-      if (m_pp->PreInit(m_config))
+
+      if (preInitOk)
       {
         m_pp->Init(method);
       }
@@ -2232,17 +2469,34 @@ void COutput::InitCycle()
     {
       const bool preferVaapiRender = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
           SETTING_VIDEOPLAYER_PREFERVAAPIRENDER);
+      // Hardware scaling requires the VAAPI VPP pipeline.
+      const bool wantsHwScaling = (m_config.scaleWidth > 0 && m_config.scaleHeight > 0);
 
-      m_config.stats->SetVpp(false);
-      if (!preferVaapiRender)
+      const bool hwScalingBlocked = wantsHwScaling && !m_discardedPostprocs.empty();
+      if (hwScalingBlocked)
+      {
+        CLog::Log(LOGWARNING,
+                  "VAAPI output: hw scaling deferred - {} postproc(s) still awaiting disposal",
+                  m_discardedPostprocs.size());
+      }
+
+      if (wantsHwScaling && !hwScalingBlocked)
+      {
+        CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI output: Initializing vaapi postproc for hw scaling");
+        m_pp = new CVppPostproc();
+        m_config.stats->SetVpp(true);
+      }
+      else if (!preferVaapiRender)
       {
         CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI output: Initializing ffmpeg postproc");
         m_pp = new CFFmpegPostproc();
+        m_config.stats->SetVpp(false);
       }
       else
       {
         CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI output: Initializing skip postproc");
         m_pp = new CSkipPostproc();
+        m_config.stats->SetVpp(false);
       }
       if (m_pp->PreInit(m_config))
       {
@@ -2296,6 +2550,8 @@ CVaapiRenderPicture* COutput::ProcessPicture(CVaapiProcessedPicture &pic)
     av_frame_move_ref(retPic->avFrame, pic.frame);
     pic.source->ClearRef(pic);
     retPic->procPic.videoSurface = VA_INVALID_ID;
+    retPic->procPic.outWidth = 0;
+    retPic->procPic.outHeight = 0;
   }
 
   retPic->DVDPic.dts = DVD_NOPTS_VALUE;
@@ -2505,6 +2761,19 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
   attrib->value.type = VAGenericValueTypeInteger;
   attrib->value.value.i = VA_FOURCC_NV12;
 
+  // Use the VPP target size when scaling.
+  m_scalingRequested = (config.scaleWidth > 0 && config.scaleHeight > 0);
+  if (m_scalingRequested)
+  {
+    m_scaleWidth = config.scaleWidth;
+    m_scaleHeight = config.scaleHeight;
+  }
+  else
+  {
+    m_scaleWidth = m_config.surfaceWidth;
+    m_scaleHeight = m_config.surfaceHeight;
+  }
+
   // create surfaces
   VASurfaceID surfaces[32];
   unsigned int format = VA_RT_FORMAT_YUV420;
@@ -2514,10 +2783,9 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
     attrib->value.value.i = VA_FOURCC_P010;
   }
   int nb_surfaces = NUM_RENDER_PICS;
-  if (!CheckSuccess(
-      vaCreateSurfaces(m_config.dpy, format, m_config.surfaceWidth, m_config.surfaceHeight,
-          surfaces, nb_surfaces,
-          attribs, 1), "vaCreateSurfaces"))
+  if (!CheckSuccess(vaCreateSurfaces(m_config.dpy, format, m_scaleWidth, m_scaleHeight, surfaces,
+                                     nb_surfaces, attribs, 1),
+                    "vaCreateSurfaces"))
   {
     CLog::Log(LOGDEBUG, LOGVIDEO, "CVppPostproc::PreInit  - VPP init failed in vaCreateSurfaces");
 
@@ -2529,10 +2797,9 @@ bool CVppPostproc::PreInit(CVaapiConfig &config, SDiMethods *methods)
   }
 
   // create vaapi decoder context
-  if (!CheckSuccess(
-      vaCreateContext(m_config.dpy, m_configId, m_config.surfaceWidth, m_config.surfaceHeight, 0,
-          surfaces,
-          nb_surfaces, &m_contextId), "vaCreateContext"))
+  if (!CheckSuccess(vaCreateContext(m_config.dpy, m_configId, m_scaleWidth, m_scaleHeight, 0,
+                                    surfaces, nb_surfaces, &m_contextId),
+                    "vaCreateContext"))
   {
     m_contextId = VA_INVALID_ID;
     CLog::Log(LOGDEBUG, LOGVIDEO, "CVppPostproc::PreInit  - VPP init failed in vaCreateContext");
@@ -2785,15 +3052,32 @@ bool CVppPostproc::Filter(CVaapiProcessedPicture &outPic)
   }
   memset(pipelineParams, 0, sizeof(VAProcPipelineParameterBuffer));
 
-  inputRegion.x = outputRegion.x = 0;
-  inputRegion.y = outputRegion.y = 0;
-  inputRegion.width = outputRegion.width = m_config.surfaceWidth;
-  inputRegion.height = outputRegion.height = m_config.surfaceHeight;
+  const bool scaling = m_scalingRequested;
+
+  inputRegion.x = 0;
+  inputRegion.y = 0;
+  outputRegion.x = 0;
+  outputRegion.y = 0;
+  if (scaling)
+  {
+    // Scale only the visible decoded picture, not codec padding.
+    inputRegion.width = m_config.vidWidth;
+    inputRegion.height = m_config.vidHeight;
+    outputRegion.width = m_scaleWidth;
+    outputRegion.height = m_scaleHeight;
+  }
+  else
+  {
+    inputRegion.width = m_config.surfaceWidth;
+    inputRegion.height = m_config.surfaceHeight;
+    outputRegion.width = m_config.surfaceWidth;
+    outputRegion.height = m_config.surfaceHeight;
+  }
 
   pipelineParams->output_region = &outputRegion;
   pipelineParams->surface_region = &inputRegion;
   pipelineParams->output_background_color = 0xff000000;
-  pipelineParams->filter_flags = 0;
+  pipelineParams->filter_flags = scaling ? VA_FILTER_SCALING_HQ : 0;
 
   VASurfaceID forwardRefs[32];
   VASurfaceID backwardRefs[32];
@@ -2906,6 +3190,16 @@ bool CVppPostproc::Filter(CVaapiProcessedPicture &outPic)
   outPic.DVDPic.iFlags &= ~(DVP_FLAG_TOP_FIELD_FIRST |
                             DVP_FLAG_REPEAT_TOP_FIELD |
                             DVP_FLAG_INTERLACED);
+  if (scaling)
+  {
+    outPic.outWidth = m_scaleWidth;
+    outPic.outHeight = m_scaleHeight;
+  }
+  else
+  {
+    outPic.outWidth = 0;
+    outPic.outHeight = 0;
+  }
 
   return true;
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -11,6 +11,7 @@
 #include "DVDVideoCodec.h"
 #include "cores/VideoPlayer/Buffers/VideoBuffer.h"
 #include "cores/VideoSettings.h"
+#include "guilib/DispResource.h"
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
 #include "threads/SharedSection.h"
@@ -20,6 +21,7 @@
 
 #include "platform/linux/sse4/DllLibSSE4.h"
 
+#include <atomic>
 #include <cstdint>
 #include <list>
 #include <map>
@@ -200,6 +202,9 @@ struct CVaapiConfig
   // pictures so the renderer can pick its sampling path per-fourcc without
   // re-inspecting the surface.
   std::int32_t pixelFormat{};
+  // VPP output size. 0/0 disables scaling.
+  int scaleWidth{};
+  int scaleHeight{};
 };
 
 /**
@@ -245,6 +250,8 @@ struct CVaapiProcessedPicture
     source = rhs.source;
     crop = rhs.crop;
     fourcc = rhs.fourcc;
+    outWidth = rhs.outWidth;
+    outHeight = rhs.outHeight;
     return *this;
   };
 
@@ -257,6 +264,9 @@ struct CVaapiProcessedPicture
   // VA fourcc of the underlying surface. Set by COutput from
   // CVaapiConfig::pixelFormat.
   std::int32_t fourcc{};
+  // Actual output surface size. 0/0 uses the decoded picture size.
+  unsigned int outWidth = 0;
+  unsigned int outHeight = 0;
 };
 
 class CVaapiRenderPicture : public CVideoBuffer
@@ -290,6 +300,8 @@ public:
     FLUSH,
     PRECLEANUP,
     TIMEOUT,
+    // Display resolution changed; payload is SScaleTarget.
+    SETSCALETARGET,
   };
   enum InSignal
   {
@@ -297,6 +309,13 @@ public:
     ERROR,
     STATS,
   };
+};
+
+// Payload for SETSCALETARGET.
+struct SScaleTarget
+{
+  int width;
+  int height;
 };
 
 class COutputDataProtocol : public Protocol
@@ -341,7 +360,7 @@ public:
   COutput(CDecoder &decoder, CEvent *inMsgEvent);
   ~COutput() override;
   void Start();
-  void Dispose();
+  void Dispose(bool force = false);
   COutputControlProtocol m_controlPort;
   COutputDataProtocol m_dataPort;
 protected:
@@ -380,6 +399,7 @@ protected:
   CPostproc *m_pp;
   std::list<std::shared_ptr<CPostproc>> m_discardedPostprocs;
   SDiMethods m_diMethods;
+  bool m_scaleTargetChanged = false;
 };
 
 //-----------------------------------------------------------------------------
@@ -532,8 +552,7 @@ public:
 // VAAPI main class
 //-----------------------------------------------------------------------------
 
-class CDecoder
- : public IHardwareDecoder
+class CDecoder : public IHardwareDecoder, public IDispResource
 {
    friend class CVaapiBufferPool;
 
@@ -555,6 +574,9 @@ public:
   const std::string Name() override { return "vaapi"; }
   void SetCodecControl(int flags) override;
 
+  // Update the VPP scaling target when the display mode changes.
+  void OnResetDisplay() override;
+
   void FFReleaseBuffer(uint8_t *data);
   static int FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags);
 
@@ -570,8 +592,13 @@ public:
 protected:
   void SetWidthHeight(int width, int height);
   bool ConfigVAAPI();
+
+  // Returns the VPP scaling target, or 0/0 if disabled.
+  static void GetScaleTarget(
+      int vidWidth, int vidHeight, AVRational aspect, int& scaleWidth, int& scaleHeight);
+
   bool CheckStatus(VAStatus vdp_st, int line);
-  void FiniVAAPIOutput();
+  void FiniVAAPIOutput(bool force = false);
   void ReturnRenderPicture(CVaapiRenderPicture *renderPic);
   long ReleasePicReference();
   bool CheckSuccess(VAStatus status, const std::string& function);
@@ -590,6 +617,9 @@ protected:
   CVaapiConfig  m_vaapiConfig;
   CVideoSurfaces m_videoSurfaces;
   int m_getBufferError;
+
+  std::atomic<bool> m_registeredDispResource{false};
+  std::atomic<int> m_activeResetDisplayCalls{0};
 
   COutput m_vaapiOutput;
   CVaapiBufferStats m_bufferStats;
@@ -694,6 +724,10 @@ protected:
   int m_currentIdx;
   int m_frameCount;
   EINTERLACEMETHOD m_vppMethod;
+  // Output surface size used by the VPP pipeline.
+  int m_scaleWidth = 0;
+  int m_scaleHeight = 0;
+  bool m_scalingRequested = false;
   ReadyToDispose m_cbDispose = nullptr;
   COutput *m_pOut = nullptr;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
@@ -83,6 +83,11 @@ CRendererVAAPIGLES::~CRendererVAAPIGLES()
 bool CRendererVAAPIGLES::Configure(const VideoPicture& picture, float fps, unsigned int orientation)
 {
   CVaapiRenderPicture *pic = dynamic_cast<CVaapiRenderPicture*>(picture.videoBuffer);
+  if (!pic)
+  {
+    CLog::Log(LOGERROR, "CRendererVAAPIGLES::Configure - videoBuffer is not a CVaapiRenderPicture");
+    return false;
+  }
   if (pic->procPic.videoSurface != VA_INVALID_ID)
     m_isVAAPIBuffer = true;
   else
@@ -117,6 +122,13 @@ bool CRendererVAAPIGLES::Configure(const VideoPicture& picture, float fps, unsig
 bool CRendererVAAPIGLES::ConfigChanged(const VideoPicture& picture)
 {
   CVaapiRenderPicture *pic = dynamic_cast<CVaapiRenderPicture*>(picture.videoBuffer);
+  if (!pic)
+  {
+    CLog::Log(LOGERROR,
+              "CRendererVAAPIGLES::ConfigChanged - videoBuffer is not a CVaapiRenderPicture");
+    return false;
+  }
+
   if ((pic->procPic.videoSurface != VA_INVALID_ID && !m_isVAAPIBuffer) ||
       (pic->procPic.videoSurface == VA_INVALID_ID && m_isVAAPIBuffer))
     return true;
@@ -265,6 +277,8 @@ bool CRendererVAAPIGLES::UploadTexture(int index)
     return false;
   }
 
+  m_hwScaled = false;
+
   m_vaapiTextures[index] = m_texturePool.Get(pic, m_vaapiTextures);
   if (!m_vaapiTextures[index])
     return false;
@@ -314,7 +328,21 @@ bool CRendererVAAPIGLES::UploadTexture(int index)
     VerifyGLState();
   }
 
-  CalculateTextureSourceRects(index, 3);
+  // Adjust texture coordinates when VPP produced a resized surface.
+  m_hwScaled = (pic->procPic.outWidth != 0 && pic->procPic.outHeight != 0);
+  // Guard against an invalid source size
+  if (m_hwScaled && m_sourceWidth > 0 && m_sourceHeight > 0)
+  {
+    const CRect savedSourceRect = m_sourceRect;
+    const float scaleX = static_cast<float>(size.Width()) / m_sourceWidth;
+    const float scaleY = static_cast<float>(size.Height()) / m_sourceHeight;
+    m_sourceRect = CRect(savedSourceRect.x1 * scaleX, savedSourceRect.y1 * scaleY,
+                         savedSourceRect.x2 * scaleX, savedSourceRect.y2 * scaleY);
+    CalculateTextureSourceRects(index, 3);
+    m_sourceRect = savedSourceRect;
+  }
+  else
+    CalculateTextureSourceRects(index, 3);
   return true;
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
@@ -50,6 +50,7 @@ protected:
   bool LoadShadersHook() override;
   bool RenderHook(int idx) override;
   void AfterRenderHook(int idx) override;
+  bool IsHwScaled() const override { return m_hwScaled; }
 
   // textures
   bool UploadTexture(int index) override;
@@ -60,6 +61,7 @@ protected:
 
   bool m_isVAAPIBuffer = true;
   bool m_nv12Allocated[NUM_BUFFERS]{};
+  bool m_hwScaled = false;
   // VA fourcc of the surfaces being received (NV12 / P010 / P012 / P016 /
   // YUY2 / Y210 / Y212 / Y216). Captured at Configure and read by
   // GetShaderFormat to pick the matching sampling path.

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -69,7 +69,9 @@ bool CVaapi2Texture::Import(CVaapiRenderPicture* pic)
     return failImport();
   }
 
-  m_textureSize.Set(pic->DVDPic.iWidth, pic->DVDPic.iHeight);
+  // Use the actual surface size when VPP scaling is active.
+  m_textureSize.Set(pic->procPic.outWidth ? pic->procPic.outWidth : pic->DVDPic.iWidth,
+                    pic->procPic.outHeight ? pic->procPic.outHeight : pic->DVDPic.iHeight);
 
   for (uint32_t layerNo = 0; layerNo < surface.num_layers; layerNo++)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -702,19 +702,30 @@ void CLinuxRendererGLES::UpdateVideoFilter()
 
   // TODO: GL also checks nonLinStretchChanged and cmsChanged in the early exit
   // and the reload check below. Add when non-linear stretch and CMS are ported to GLES.
+  const bool hwScaled = IsHwScaled();
   if (m_scalingMethodGui == m_videoSettings.m_ScalingMethod &&
-      viewRect.Height() == m_lastViewRect.Height() && viewRect.Width() == m_lastViewRect.Width())
+      viewRect.Height() == m_lastViewRect.Height() && viewRect.Width() == m_lastViewRect.Width() &&
+      hwScaled == m_lastHwScaled)
   {
     return;
   }
 
-  // Viewport-only change doesn't need shader reload -- only method changes do
-  if (m_scalingMethod != m_videoSettings.m_ScalingMethod)
+  // Reload when the hardware scaling state changes, even if the GUI method
+  // stays the same.
+  if (m_scalingMethod != m_videoSettings.m_ScalingMethod || hwScaled != m_lastHwScaled)
     m_reloadShaders = true;
 
   m_scalingMethodGui = m_videoSettings.m_ScalingMethod;
   m_scalingMethod = m_scalingMethodGui;
   m_lastViewRect = viewRect;
+  m_lastHwScaled = hwScaled;
+
+  if (hwScaled)
+  {
+    // VPP already scaled the texture to the display size, so avoid another
+    // scaling pass.
+    m_scalingMethod = VS_SCALINGMETHOD_LINEAR;
+  }
 
   if(!Supports(m_scalingMethod))
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -134,6 +134,9 @@ protected:
   virtual bool RenderHook(int idx) { return false; }
   virtual void AfterRenderHook(int idx) {}
 
+  // True if UploadTexture() received a VPP-scaled surface.
+  virtual bool IsHwScaled() const { return false; }
+
   struct
   {
     CFrameBufferObject fbo;
@@ -226,6 +229,7 @@ protected:
   size_t m_planeBufferSize = 0;
 
   CRect m_lastViewRect;
+  bool m_lastHwScaled = false;
 
   // HDR FBO compositing: when active, IsGuiLayer() returns false so
   // video renders separately from GUI via RenderUpdateVideo()

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -13,6 +13,7 @@
 #include "addons/Skin.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
+#include "cores/DataCacheCore.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
@@ -53,6 +54,12 @@
 
 #define SETTING_VIDEO_INTERLACEMETHOD     "video.interlacemethod"
 #define SETTING_VIDEO_SCALINGMETHOD       "video.scalingmethod"
+
+#define SETTING_VIDEOPLAYER_USEVAAPI "videoplayer.usevaapi"
+#define SETTING_VIDEOPLAYER_VAAPIHWSCALING "videoplayer.vaapihwscaling"
+
+// Display-only value used when VAAPI hardware scaling is active.
+#define SCALING_METHOD_VAAPI_HW_ACTIVE -1
 
 #define SETTING_VIDEO_STEREOSCOPICMODE    "video.stereoscopicmode"
 #define SETTING_VIDEO_STEREOSCOPICINVERT  "video.stereoscopicinvert"
@@ -371,37 +378,68 @@ void CGUIDialogVideoSettings::InitializeSettings()
     AddSpinner(groupVideo, SETTING_VIDEO_INTERLACEMETHOD, 16038, SettingLevel::Basic, static_cast<int>(method), entries);
   }
 
-  entries.clear();
-  entries.emplace_back(16301, VS_SCALINGMETHOD_NEAREST);
-  entries.emplace_back(16302, VS_SCALINGMETHOD_LINEAR);
-  entries.emplace_back(16303, VS_SCALINGMETHOD_CUBIC_B_SPLINE);
-  entries.emplace_back(16314, VS_SCALINGMETHOD_CUBIC_MITCHELL);
-  entries.emplace_back(16321, VS_SCALINGMETHOD_CUBIC_CATMULL);
-  entries.emplace_back(16326, VS_SCALINGMETHOD_CUBIC_0_075);
-  entries.emplace_back(16330, VS_SCALINGMETHOD_CUBIC_0_1);
-  entries.emplace_back(16304, VS_SCALINGMETHOD_LANCZOS2);
-  entries.emplace_back(16323, VS_SCALINGMETHOD_SPLINE36_FAST);
-  entries.emplace_back(16315, VS_SCALINGMETHOD_LANCZOS3_FAST);
-  entries.emplace_back(16322, VS_SCALINGMETHOD_SPLINE36);
-  entries.emplace_back(16305, VS_SCALINGMETHOD_LANCZOS3);
-  entries.emplace_back(16306, VS_SCALINGMETHOD_SINC8);
-  entries.emplace_back(16307, VS_SCALINGMETHOD_BICUBIC_SOFTWARE);
-  entries.emplace_back(16308, VS_SCALINGMETHOD_LANCZOS_SOFTWARE);
-  entries.emplace_back(16309, VS_SCALINGMETHOD_SINC_SOFTWARE);
-  entries.emplace_back(13120, VS_SCALINGMETHOD_VDPAU_HARDWARE);
-  entries.emplace_back(16319, VS_SCALINGMETHOD_DXVA_HARDWARE);
-  entries.emplace_back(16316, VS_SCALINGMETHOD_AUTO);
-
-  /* remove unsupported methods */
-  for(TranslatableIntegerSettingOptions::iterator it = entries.begin(); it != entries.end(); )
+  bool vaapiHwScalingEnabled = false;
+  if (const auto settingsComponent = CServiceBroker::GetSettingsComponent())
   {
-    if (appPlayer->Supports(static_cast<ESCALINGMETHOD>(it->value)))
-      ++it;
-    else
-      it = entries.erase(it);
+    if (const auto settings = settingsComponent->GetSettings())
+    {
+      const auto winSystem = CServiceBroker::GetWinSystem();
+      if (settings->GetBool(SETTING_VIDEOPLAYER_USEVAAPI) &&
+          settings->GetSetting(SETTING_VIDEOPLAYER_VAAPIHWSCALING) &&
+          settings->GetBool(SETTING_VIDEOPLAYER_VAAPIHWSCALING) && winSystem &&
+          winSystem->GetName().rfind(WINDOW_SYSTEM_NAME_GBM, 0) == 0)
+      {
+        auto& dataCache = CServiceBroker::GetDataCacheCore();
+        vaapiHwScalingEnabled = dataCache.IsVideoHwDecoder() &&
+                                dataCache.GetVideoDecoderName().find("vaapi") != std::string::npos;
+      }
+    }
   }
 
-  AddSpinner(groupVideo, SETTING_VIDEO_SCALINGMETHOD, 16300, SettingLevel::Basic, static_cast<int>(videoSettings.m_ScalingMethod), entries);
+  int scalingMethodCurrent = static_cast<int>(videoSettings.m_ScalingMethod);
+  entries.clear();
+  if (vaapiHwScalingEnabled)
+  {
+    // Show VAAPI scaling instead of the renderer scaling method.
+    entries.emplace_back(36645, SCALING_METHOD_VAAPI_HW_ACTIVE);
+    scalingMethodCurrent = SCALING_METHOD_VAAPI_HW_ACTIVE;
+  }
+  else
+  {
+    entries.emplace_back(16301, VS_SCALINGMETHOD_NEAREST);
+    entries.emplace_back(16302, VS_SCALINGMETHOD_LINEAR);
+    entries.emplace_back(16303, VS_SCALINGMETHOD_CUBIC_B_SPLINE);
+    entries.emplace_back(16314, VS_SCALINGMETHOD_CUBIC_MITCHELL);
+    entries.emplace_back(16321, VS_SCALINGMETHOD_CUBIC_CATMULL);
+    entries.emplace_back(16326, VS_SCALINGMETHOD_CUBIC_0_075);
+    entries.emplace_back(16330, VS_SCALINGMETHOD_CUBIC_0_1);
+    entries.emplace_back(16304, VS_SCALINGMETHOD_LANCZOS2);
+    entries.emplace_back(16323, VS_SCALINGMETHOD_SPLINE36_FAST);
+    entries.emplace_back(16315, VS_SCALINGMETHOD_LANCZOS3_FAST);
+    entries.emplace_back(16322, VS_SCALINGMETHOD_SPLINE36);
+    entries.emplace_back(16305, VS_SCALINGMETHOD_LANCZOS3);
+    entries.emplace_back(16306, VS_SCALINGMETHOD_SINC8);
+    entries.emplace_back(16307, VS_SCALINGMETHOD_BICUBIC_SOFTWARE);
+    entries.emplace_back(16308, VS_SCALINGMETHOD_LANCZOS_SOFTWARE);
+    entries.emplace_back(16309, VS_SCALINGMETHOD_SINC_SOFTWARE);
+    entries.emplace_back(13120, VS_SCALINGMETHOD_VDPAU_HARDWARE);
+    entries.emplace_back(16319, VS_SCALINGMETHOD_DXVA_HARDWARE);
+    entries.emplace_back(16316, VS_SCALINGMETHOD_AUTO);
+
+    /* remove unsupported methods */
+    for (TranslatableIntegerSettingOptions::iterator it = entries.begin(); it != entries.end();)
+    {
+      if (appPlayer->Supports(static_cast<ESCALINGMETHOD>(it->value)))
+        ++it;
+      else
+        it = entries.erase(it);
+    }
+  }
+
+  const auto scalingMethodSetting = AddSpinner(groupVideo, SETTING_VIDEO_SCALINGMETHOD, 16300,
+                                               SettingLevel::Basic, scalingMethodCurrent, entries);
+  if (scalingMethodSetting)
+    scalingMethodSetting->SetEnabled(!vaapiHwScalingEnabled);
 
   AddVideoStreams(groupVideoStream, SETTING_VIDEO_STREAM);
 

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -58,6 +58,9 @@ class CVideoReferenceClock;
 
 struct VideoPicture;
 
+//! Prefix of the name returned by CWinSystemBase::GetName() for the GBM backend.
+constexpr const char* WINDOW_SYSTEM_NAME_GBM = "gbm";
+
 class CWinSystemBase
 {
 public:


### PR DESCRIPTION
## Summary

This adds an optional VAAPI hardware scaling mode for the GBM/GLES renderer.

When enabled, the VAAPI Video Processing Pipeline (VPP) scales decoded frames directly to the current display resolution using `VA_FILTER_SCALING_HQ`. The renderer detects hardware-scaled surfaces and bypasses Kodi's shader-based scaling path.

The feature can be enabled in **Settings → Player → Videos → Use VAAPI hardware scaling**.

When this option is enabled, Kodi's **Video settings → Scaling method** setting is disabled, since the resize is performed entirely by the VAAPI VPP hardware scaler rather than the GLES renderer.

## How has this been tested?

Verified on Intel TGL using `LIBVA_TRACE`.

With hardware scaling enabled, the VPP pipeline receives the decoded frame as the input region, the display resolution as the output region, and requests the hardware HQ scaler:

```text
surface_region:
  width  = 640
  height = 480

output_region:
  width  = 3840
  height = 2160

filter_flags = 0x00000200
```

`filter_flags = 0x00000200` corresponds to `VA_FILTER_SCALING_HQ`, confirming that scaling is performed by the VAAPI VPP hardware scaler.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
