### PR TITLE
[GUI] Add fixedlist pageitems override

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -888,6 +888,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
   float buttonGap = 5;
   int startMovement = 0;
   int endMovement = 0;
+  int pageItems = 0;
   FixedListAlignY fixedListAlignY = FixedListAlignY::CENTER;
   CAspectRatio aspect;
   std::string allowHiddenFocus;
@@ -1203,6 +1204,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
 
   XMLUtils::GetBoolean(pControlNode, "showonepage", showOnePage);
   XMLUtils::GetInt(pControlNode, "focusposition", focusPosition);
+  XMLUtils::GetInt(pControlNode, "pageitems", pageItems);
   XMLUtils::GetInt(pControlNode, "scrolltime", scrollTime);
   XMLUtils::GetInt(pControlNode, "preloaditems", preloadItems, 0, 2);
 
@@ -1624,7 +1626,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID,
 
       control = new CGUIFixedListContainer(parentID, id, posX, posY, width, height, orientation,
                                            scroller, preloadItems, focusPosition, startMovement,
-                                           endMovement, fixedListAlignY);
+                                           endMovement, pageItems, fixedListAlignY);
       CGUIFixedListContainer* fcontrol = static_cast<CGUIFixedListContainer*>(control);
       fcontrol->LoadLayout(pControlNode);
       fcontrol->LoadListProvider(pControlNode, defaultControl, defaultAlways);

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -9,6 +9,7 @@
 #include "GUIFixedListContainer.h"
 
 #include "GUIListItemLayout.h"
+#include "GUIMessage.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 
@@ -26,6 +27,7 @@ CGUIFixedListContainer::CGUIFixedListContainer(int parentID,
                                                int fixedPosition,
                                                int startCursorRange,
                                                int endCursorRange,
+                                               int pageItems,
                                                FixedListAlignY alignY)
   : CGUIBaseContainer(
         parentID, controlID, posX, posY, width, height, orientation, scroller, preloadItems)
@@ -35,6 +37,7 @@ CGUIFixedListContainer::CGUIFixedListContainer(int parentID,
   m_fixedCursor = fixedPosition;
   m_startCursorRange = startCursorRange;
   m_endCursorRange = endCursorRange;
+  m_pageItems = pageItems;
   m_alignY = alignY;
   SetCursor(m_fixedCursor);
 }
@@ -47,13 +50,13 @@ bool CGUIFixedListContainer::OnAction(const CAction &action)
   {
   case ACTION_PAGE_UP:
     {
-      Scroll(-m_itemsPerPage);
+      Scroll(-GetPageItems());
       return true;
     }
     break;
   case ACTION_PAGE_DOWN:
     {
-      Scroll(m_itemsPerPage);
+      Scroll(GetPageItems());
       return true;
     }
     break;
@@ -292,15 +295,27 @@ bool CGUIFixedListContainer::HasPreviousPage() const
 
 bool CGUIFixedListContainer::HasNextPage() const
 {
-  return (GetOffset() < (int)m_items.size() - m_itemsPerPage && (int)m_items.size() >= m_itemsPerPage);
+  const int pageItems = GetPageItems();
+  return (GetOffset() < (int)m_items.size() - pageItems && (int)m_items.size() >= pageItems);
 }
 
 int CGUIFixedListContainer::GetCurrentPage() const
 {
   int offset = CorrectOffset(GetOffset(), GetCursor());
-  if (offset + m_itemsPerPage - GetCursor() >= (int)GetRows())  // last page
-    return (GetRows() + m_itemsPerPage - 1) / m_itemsPerPage;
-  return offset / m_itemsPerPage + 1;
+  const int pageItems = GetPageItems();
+  if (offset + pageItems - GetCursor() >= (int)GetRows()) // last page
+    return (GetRows() + pageItems - 1) / pageItems;
+  return offset / pageItems + 1;
+}
+
+void CGUIFixedListContainer::SetPageControlRange()
+{
+  if (m_pageControl)
+  {
+    CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), m_pageControl, GetPageItems(), GetRows());
+    SendWindowMessage(msg);
+    m_lastPageControlOffset.reset();
+  }
 }
 
 void CGUIFixedListContainer::GetCursorRange(int &minCursor, int &maxCursor) const
@@ -341,4 +356,9 @@ void CGUIFixedListContainer::GetCursorRange(int &minCursor, int &maxCursor) cons
 
   while (maxCursor - minCursor > static_cast<int>(m_items.size()) - 1)
     fn(minCursor, maxCursor, m_fixedCursor);
+}
+
+int CGUIFixedListContainer::GetPageItems() const
+{
+  return m_pageItems > 0 ? m_pageItems : m_itemsPerPage;
 }

--- a/xbmc/guilib/GUIFixedListContainer.dox
+++ b/xbmc/guilib/GUIFixedListContainer.dox
@@ -32,6 +32,7 @@ control is very flexible.
           <autoscroll>true</autoscroll>
           <focusposition>4</focusposition>
           <movement>6</movement>
+          <pageitems>5</pageitems>
 		  <aligny>top</aligny>
           <itemlayout width="250" height="29">
                     <control type="image">
@@ -126,6 +127,7 @@ important, as xml tags are case-sensitive.
 | startmovement | This will make the focused position scroll again at the beginning of the list. (ie. <b>`<startmovement>6</startmovement>`</b> if there are only 6 items above the focus, the focus moves up to the top) [Added in v22]
 | endmovement   | This will make the focused position scroll again at the end of the list. (ie. <b>`<endmovement>6</endmovement>`</b> if there are only 6 items below the focus, the focus moves down to the bottom) [Added in v22]
 | movement      | This will make the focused position scroll again at the beginning and end of the list and is used as the value of <b>`<startmovement>`</b> and <b>`<endmovement>`</b> when they are not specified (ie. <b>`<movement>6</movement>`</b> if there are only 6 items below the focus, the focus moves down to the bottom, and if there are only 6 items above the focus, the focus moves up to the top)
+| pageitems     | Specifies the number of items to move by when using page up/down or the page control. When not specified, the fixed list uses the number of displayable items.
 | itemlayout    | Specifies the layout of items in the list. Requires the height attribute set in a vertical list, and the width attribute set for a horizontal list. The <b>`<itemlayout>`</b> then contains as many label and image controls as required. [See here for more information](http://kodi.wiki/view/Container_Item_Layout).
 | focusedlayout | Specifies the layout of items in the list that have focus. Requires the height attribute set in a vertical list, and the width attribute set for a horizontal list. The <b>`<focusedlayout>`</b> then contains as many label and image controls as required. [See here for more information](http://kodi.wiki/view/Container_Item_Layout).
 | content       | Used to set the item content that this list will contain. Allows the skinner to setup a list anywhere they want with a static set of content, as a useful alternative to the grouplist control. [See here for more information](http://kodi.wiki/view/Static_List_Content).

--- a/xbmc/guilib/GUIFixedListContainer.h
+++ b/xbmc/guilib/GUIFixedListContainer.h
@@ -41,6 +41,7 @@ public:
                          int fixedPosition,
                          int startCursorRange,
                          int endCursorRange,
+                         int pageItems,
                          FixedListAlignY alignY);
   ~CGUIFixedListContainer(void) override;
   CGUIFixedListContainer* Clone() const override { return new CGUIFixedListContainer(*this); }
@@ -59,6 +60,7 @@ protected:
   bool HasNextPage() const override;
   bool HasPreviousPage() const override;
   int GetCurrentPage() const override;
+  void SetPageControlRange() override;
 
 private:
   /*!
@@ -72,10 +74,11 @@ private:
    \sa m_fixedCursor, m_cursorRange
    */
   void GetCursorRange(int &minCursor, int &maxCursor) const;
+  int GetPageItems() const;
 
   int m_fixedCursor; ///< default position the skinner wishes to use for the focused item
   int m_startCursorRange; ///< range that the focused item can vary when at the beginning end of the list
   int m_endCursorRange; ///< range that the focused item can vary when at the end of the list
+  int m_pageItems; ///< number of items to move by on page up/down, 0 uses the calculated page size
   FixedListAlignY m_alignY; //!< Vertical alignment of the items
 };
-

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -48,12 +48,12 @@ constexpr auto CONSTANT_ATTRIBUTES = make_set<std::string_view>({
 });
 
 constexpr auto CONSTANT_NODES = make_set<std::string_view>({
-    "bordersize",  "bottom",     "centerbottom",  "centerleft", "centerright", "centertop",
-    "depth",       "fadetime",   "focusposition", "height",     "itemgap",     "left",
-    "movement",    "offsetx",    "offsety",       "pauseatend", "posx",        "posy",
-    "radioheight", "radioposx",  "radioposy",     "radiowidth", "right",       "sliderheight",
-    "sliderwidth", "spinheight", "spinposx",      "spinposy",   "spinwidth",   "textoffsetx",
-    "textoffsety", "textwidth",  "timeperimage",  "top",        "width",
+    "bordersize",   "bottom",      "centerbottom",  "centerleft",   "centerright", "centertop",
+    "depth",        "fadetime",    "focusposition", "height",       "itemgap",     "left",
+    "movement",     "offsetx",     "offsety",       "pageitems",    "pauseatend",  "posx",
+    "posy",         "radioheight", "radioposx",     "radioposy",    "radiowidth",  "right",
+    "sliderheight", "sliderwidth", "spinheight",    "spinposx",     "spinposy",    "spinwidth",
+    "textoffsetx",  "textoffsety", "textwidth",     "timeperimage", "top",         "width",
 });
 
 constexpr std::string_view EXPRESSION_ATTRIBUTE = "condition";


### PR DESCRIPTION
## Description
Adds an optional `<pageitems>` tag for fixedlist controls so skinners can define how many items PageUp/PageDown and pagecontrol navigation should move.

When `<pageitems>` is not set, or is set to `0` or a negative value, fixedlist keeps the existing calculated page size behavior.

This also keeps keyboard/page actions and pagecontrol/scrollbar paging consistent by using the same page item count for both.

## Motivation and context
Fixedlist currently calculates its page movement from the number of displayable items. This works for many layouts, but not all skin designs map cleanly to the calculated item count.

Some fixedlist layouts use oversized controls, partially offscreen items, focused layouts with different dimensions, or visual masking/overlays. In those cases, the calculated page size can differ from the skinner's intended visual page movement.

This change lets the skinner explicitly define the intended page movement when the automatic calculation does not match the layout.

Related to xbmc/xbmc#28783

## How has this been tested?
Manual skin testing was done by temporarily adding the following values to Estuary fixedlist views:

- `addons/skin.estuary/xml/View_51_Poster.xml`
  - `<pageitems>5</pageitems>`
- `addons/skin.estuary/xml/View_53_Shift.xml`
  - `<pageitems>4</pageitems>`

With those values, PageUp/PageDown and pagecontrol navigation move to the intended partially visible/cut-off item for each layout.

Also tested:
- Lower positive values move by the configured number of items.
- `0` and negative values are ignored and fall back to the default calculated page size.

## What is the effect on users?
No change for existing skins unless they opt in to the new `<pageitems>` tag.

Skinners can use this to make fixedlist PageUp/PageDown and pagecontrol navigation match the intended visual page size for custom layouts.

## Screenshots (if appropriate):
<img width="1672" height="941" alt="call_WMDppRJE8kggZd38FmcKPvSO" src="https://github.com/user-attachments/assets/12080391-4bac-46bb-80bd-5afe0b2aae5c" />

<img width="1672" height="941" alt="call_WMGhiGyB45pRvXNWyGCT4EQY" src="https://github.com/user-attachments/assets/a55ee0dd-900c-4460-86eb-9574eefc98f1" />

<img width="1672" height="941" alt="call_6tb73IeebAaARWDP5OnkfyE1" src="https://github.com/user-attachments/assets/3c07e0cb-13df-44b9-98c4-e37dc4cca829" />

<img width="1672" height="941" alt="call_xhjnYogI1oFEtRJpdQpkqeM2" src="https://github.com/user-attachments/assets/a72ae406-6002-4b42-bfee-652571d273a4" />

<img width="1672" height="941" alt="call_cin5sq5i8MjNu8OKaXy9FZx9" src="https://github.com/user-attachments/assets/3cfb06dc-7dbd-430e-bc89-e9f2186bde22" />

<img width="1920" height="1080" alt="Clipboard_07-30-2026_01" src="https://github.com/user-attachments/assets/475dc75f-9136-4d3c-ac33-ba58caffd086" />


## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed