### PR TITLE
[Build][Windows] Kodi builds but fails to run with cec.dll missing error.

### DIFF
--- a/cmake/modules/FindCEC.cmake
+++ b/cmake/modules/FindCEC.cmake
@@ -20,19 +20,18 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
       set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LOCATION_POSTFIX "dylib")
     endif()
 
-    if(WIN32 OR WINDOWS_STORE)
-      # libcec installs the .dll and its import .lib into the install prefix root
-      # on Windows (LIB_DESTINATION "." in its CheckPlatformSupport.cmake), not
-      # bin/ and lib/. Point the module at that layout so the library is found.
-      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LOCATION_PATH ".")
-      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_IMPLIB_PATH ".")
-    endif()
+    # libcec installs the .dll and its import .lib into the install prefix root
+    # on Windows (LIB_DESTINATION "." in its CheckPlatformSupport.cmake) instead
+    # of bin/ and lib/. Patch it to use the GNUInstallDirs layout that all other
+    # dependencies (and cmake/installdata/windows/dlls.txt) expect.
+    generate_patchcommand("${CMAKE_SOURCE_DIR}/tools/depends/target/${${CMAKE_FIND_PACKAGE_NAME}_MODULE_LC}/001-win-install-layout.patch")
 
     set(CMAKE_ARGS -DBUILD_SHARED_LIBS=ON
                    -DSKIP_PYTHON_WRAPPER=ON
                    -DDISABLE_BUILDINFO=ON
                    -DDISABLE_CLIENT=ON
                    -DDISABLE_STATIC=ON
+                   -DCMAKE_INSTALL_BINDIR=bin
                    -DCMAKE_INSTALL_LIBDIR=lib
                    -DCMAKE_INSTALL_INCLUDEDIR=include
                    -DCMAKE_PLATFORM_NO_VERSIONED_SONAME=ON)

--- a/tools/depends/target/cec/001-win-install-layout.patch
+++ b/tools/depends/target/cec/001-win-install-layout.patch
@@ -1,0 +1,22 @@
+--- a/src/libcec/cmake/CheckPlatformSupport.cmake
++++ b/src/libcec/cmake/CheckPlatformSupport.cmake
+@@ -40,7 +40,7 @@
+ if(WIN32)
+   # Windows
+   add_definitions(-DTARGET_WINDOWS -DNOMINMAX -D_CRT_SECURE_NO_WARNINGS -D_WINSOCKAPI_)
+-  set(LIB_DESTINATION ".")
++  set(LIB_DESTINATION "${CMAKE_INSTALL_BINDIR}")
+
+   set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+
+--- a/src/libcec/CMakeLists.txt
++++ b/src/libcec/CMakeLists.txt
+@@ -250,7 +250,7 @@
+ install(TARGETS ${CEC_INSTALL_TARGETS}
+         EXPORT libcec
+         RUNTIME DESTINATION ${LIB_DESTINATION}
+-        ARCHIVE DESTINATION ${LIB_DESTINATION}
++        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+         LIBRARY DESTINATION ${LIB_DESTINATION})
+
+ include(CMakePackageConfigHelpers)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Now dll is shared, copy into correct location.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Even after successful build, current master fails to run on windows x64.
Missing cec.dll error.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have updated the documentation accordingly
- [X] All new and existing tests passed
