### PR TITLE
[MySQL] Fix inherited MyISAM storage engine on upgrade

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -12,6 +12,7 @@
 #include "Util.h"
 #include "network/DNSNameCache.h"
 #include "network/WakeOnAccess.h"
+#include "utils/Set.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
@@ -52,6 +53,9 @@ constexpr std::string_view MARIADB_10_HACK_PREFIX = "5.5.5-";
 // Minimum MySQL and MariaDB versions required for the default large index size needed by utf8mb4
 constexpr std::string_view MIN_MYSQL_STR = "5.7.9";
 constexpr std::string_view MIN_MARIADB_STR = "10.2.5";
+
+// Fallback storage engine when the server default storage engine is not usable.
+constexpr std::string_view DEFAULT_STORAGE_ENGINE = "InnoDB";
 
 struct MySQLDbVersion
 {
@@ -94,6 +98,26 @@ bool IsValidIdentifier(std::string_view id)
 
   return std::ranges::all_of(id, [](char c)
                              { return StringUtils::isasciialphanum(c) || c == '_' || c == '$'; });
+}
+
+/*!
+ * \brief Storage engines that must never be used for Kodi databases.
+ *        All names must be in lower case.
+ * MyISAM: maximum index key length too low for the utf8mb4 character set
+ */
+constexpr auto BLACKLISTED_ENGINES = make_set<std::string_view>({"myisam"});
+
+constexpr bool isLowercaseString(std::string_view w)
+{
+  return std::ranges::all_of(w, [](char c) { return StringUtils::isasciilowercaseletter(c); });
+}
+static_assert(std::ranges::all_of(BLACKLISTED_ENGINES,
+                                  [](std::string_view t) { return isLowercaseString(t); }),
+              "all engines must be in lower case");
+
+bool IsBlacklistedEngine(std::string_view engine)
+{
+  return BLACKLISTED_ENGINES.contains(StringUtils::ToLower(engine));
 }
 } // unnamed namespace
 
@@ -407,6 +431,8 @@ int MysqlDatabase::copy(const char* backup_name)
       throw DbErrors("The source database was unexpectedly empty.");
     }
 
+    const std::string resolvedEngine = ResolveStorageEngine();
+
     // create the new database
     sqlcmd = StringUtils::Format("CREATE DATABASE `{}` {}", backup_name, SQL_CHARSET_COLLATION);
     ret = query_with_reconnect(sqlcmd);
@@ -427,7 +453,7 @@ int MysqlDatabase::copy(const char* backup_name)
         continue;
       }
 
-      // copy the table definition
+      // Copy the table definition
       sqlcmd = StringUtils::Format("CREATE TABLE `{}`.`{}` LIKE `{}`", backup_name, row[0], row[0]);
       ret = query_with_reconnect(sqlcmd);
       if (ret != MYSQL_OK)
@@ -436,8 +462,15 @@ int MysqlDatabase::copy(const char* backup_name)
         throw DbErrors("Can't copy schema for table '%s' (%d)", row[0], ret);
       }
 
-      // copied tables inherit the charset and collation of the original.
-      // set the character set and collation of the table (including current and future columns)
+      // The copy inherits the storage engine, alter it for safety before setting the character set
+      if (!ChangeStorageEngine(backup_name, row[0], resolvedEngine))
+      {
+        mysql_free_result(res);
+        throw DbErrors("Unable to change the storage engine of '%s'.'%s'", backup_name, row[0]);
+      }
+
+      // The copy inherits the charset and collation of the original.
+      // Set the character set and collation of the table (including current and future columns)
       sqlcmd = StringUtils::Format("ALTER TABLE `{}`.{} CONVERT TO {}", backup_name, row[0],
                                    SQL_CHARSET_COLLATION);
       ret = query_with_reconnect(sqlcmd);
@@ -2201,4 +2234,103 @@ void MysqlDataset::interrupt()
   // Impossible
 }
 
+std::string MysqlDatabase::GetServerDefaultEngine()
+{
+  // @@default_storage_engine is available since MySQL/MariaDB 5.5
+  static constexpr std::string_view query{"SELECT @@default_storage_engine"};
+  if (MYSQL_OK == query_with_reconnect(query))
+  {
+    if (MYSQL_RES* res = mysql_store_result(conn); res != nullptr)
+    {
+      std::string engine;
+      // A row is always expected - don't need to distinguish EOF from error
+      if (const MYSQL_ROW row = mysql_fetch_row(res); row != nullptr && row[0] != nullptr)
+        engine = row[0];
+      mysql_free_result(res);
+
+      if (!engine.empty())
+        return engine;
+    }
+  }
+  CLog::Log(LOGWARNING, "MYSQL: Unable to retrieve the server default storage engine ({}).",
+            mysql_errno(conn));
+  return {};
+}
+
+bool MysqlDatabase::ChangeStorageEngine(std::string_view db,
+                                        const char* table,
+                                        std::string_view targetEngine)
+{
+  const std::string engineQuery{
+      StringUtils::Format("SELECT engine FROM information_schema.tables "
+                          "WHERE table_schema = '{}' AND table_name = '{}'",
+                          db, table)};
+
+  if (const int ret = query_with_reconnect(engineQuery); ret != MYSQL_OK)
+  {
+    CLog::LogF(LOGERROR, "Metadata query failed ({})", ret);
+    return false;
+  }
+
+  MYSQL_RES* res = mysql_store_result(conn);
+  if (res == nullptr)
+  {
+    CLog::LogF(LOGERROR, "Unable to retrieve results");
+    return false;
+  }
+
+  const MYSQL_ROW row = mysql_fetch_row(res);
+  // A row is always expected - don't need to distinguish EOF from error
+  const std::string currentEngine = (row != nullptr && row[0] != nullptr) ? row[0] : "";
+  mysql_free_result(res);
+
+  if (currentEngine.empty())
+  {
+    CLog::LogF(LOGERROR, "No current storage engine returned");
+    return false;
+  }
+
+  if (StringUtils::EqualsNoCase(currentEngine, targetEngine))
+  {
+    return true;
+  }
+  else
+  {
+    CLog::Log(LOGINFO, "MYSQL: Migrating '{}'.`{}` from engine {} to {}.", db, table, currentEngine,
+              targetEngine);
+
+    const std::string sqlCmd =
+        StringUtils::Format("ALTER TABLE `{}`.`{}` ENGINE = {}", db, table, targetEngine);
+    if (const int ret = query_with_reconnect(sqlCmd); ret == MYSQL_OK)
+      return true;
+    else
+      CLog::LogF(LOGERROR, "Can't migrate table {} to engine {} ({})", table, targetEngine, ret);
+  }
+  return false;
+}
+
+std::string MysqlDatabase::ResolveStorageEngine()
+{
+  const std::string serverDefault = GetServerDefaultEngine();
+  if (!serverDefault.empty())
+  {
+    if (IsBlacklistedEngine(serverDefault))
+    {
+      CLog::Log(LOGWARNING,
+                "MYSQL: Server default storage engine '{}' is blacklisted. Falling back to the "
+                "application default.",
+                serverDefault);
+    }
+    else
+    {
+      CLog::Log(LOGINFO, "MYSQL: Using server default storage engine '{}' for database copy.",
+                serverDefault);
+      return serverDefault;
+    }
+  }
+
+  CLog::Log(LOGINFO, "MYSQL: Falling back to {} storage engine for database copy.",
+            DEFAULT_STORAGE_ENGINE);
+  return std::string{DEFAULT_STORAGE_ENGINE};
+}
 } // namespace dbiplus

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -308,7 +308,7 @@ int MysqlDatabase::connect(bool create_new)
       {
         const std::string sqlcmd{
             StringUtils::Format("CREATE DATABASE `{}` {}", db, SQL_CHARSET_COLLATION)};
-        const int ret = query_with_reconnect(sqlcmd.c_str());
+        const int ret = query_with_reconnect(sqlcmd);
         if (ret != MYSQL_OK)
         {
           throw DbErrors("Can't create new database: '%s' (%d)", db.c_str(), ret);
@@ -370,7 +370,7 @@ int MysqlDatabase::drop()
     throw DbErrors("Can't drop database: no active connection...");
 
   const std::string sqlcmd{StringUtils::Format("DROP DATABASE `{}`", db)};
-  const int ret = query_with_reconnect(sqlcmd.c_str());
+  const int ret = query_with_reconnect(sqlcmd);
   if (ret != MYSQL_OK)
     throw DbErrors("Can't drop database: '%s' (%d)", db.c_str(), ret);
 
@@ -392,7 +392,7 @@ int MysqlDatabase::copy(const char* backup_name)
 
   // grab a list of base tables only (no views)
   std::string sqlcmd{"SHOW FULL TABLES WHERE Table_type = 'BASE TABLE'"};
-  ret = query_with_reconnect(sqlcmd.c_str());
+  ret = query_with_reconnect(sqlcmd);
   if (ret != MYSQL_OK)
     throw DbErrors("Can't determine base tables for copy (%d)", ret);
 
@@ -409,7 +409,7 @@ int MysqlDatabase::copy(const char* backup_name)
 
     // create the new database
     sqlcmd = StringUtils::Format("CREATE DATABASE `{}` {}", backup_name, SQL_CHARSET_COLLATION);
-    ret = query_with_reconnect(sqlcmd.c_str());
+    ret = query_with_reconnect(sqlcmd);
     if (ret != MYSQL_OK)
     {
       mysql_free_result(res);
@@ -429,7 +429,7 @@ int MysqlDatabase::copy(const char* backup_name)
 
       // copy the table definition
       sqlcmd = StringUtils::Format("CREATE TABLE `{}`.`{}` LIKE `{}`", backup_name, row[0], row[0]);
-      ret = query_with_reconnect(sqlcmd.c_str());
+      ret = query_with_reconnect(sqlcmd);
       if (ret != MYSQL_OK)
       {
         mysql_free_result(res);
@@ -440,7 +440,7 @@ int MysqlDatabase::copy(const char* backup_name)
       // set the character set and collation of the table (including current and future columns)
       sqlcmd = StringUtils::Format("ALTER TABLE `{}`.{} CONVERT TO {}", backup_name, row[0],
                                    SQL_CHARSET_COLLATION);
-      ret = query_with_reconnect(sqlcmd.c_str());
+      ret = query_with_reconnect(sqlcmd);
       if (ret != MYSQL_OK)
       {
         mysql_free_result(res);
@@ -450,7 +450,7 @@ int MysqlDatabase::copy(const char* backup_name)
       // copy the table data
       sqlcmd = StringUtils::Format("INSERT INTO `{}`.`{}` SELECT * FROM `{}`", backup_name, row[0],
                                    row[0]);
-      ret = query_with_reconnect(sqlcmd.c_str());
+      ret = query_with_reconnect(sqlcmd);
       if (ret != MYSQL_OK)
       {
         mysql_free_result(res);
@@ -483,7 +483,7 @@ int MysqlDatabase::drop_analytics()
       "SELECT DISTINCT table_name, index_name FROM information_schema.statistics WHERE index_name "
       "!= 'PRIMARY' AND table_schema = '{}'",
       db)};
-  ret = query_with_reconnect(sqlcmd.c_str());
+  ret = query_with_reconnect(sqlcmd);
   if (ret != MYSQL_OK)
     throw DbErrors("Can't determine list of indexes to drop (%d)", ret);
 
@@ -496,7 +496,7 @@ int MysqlDatabase::drop_analytics()
     while ((row = mysql_fetch_row(res)) != nullptr)
     {
       sqlcmd = StringUtils::Format("ALTER TABLE `{}`.`{}` DROP INDEX `{}`", db, row[0], row[1]);
-      ret = query_with_reconnect(sqlcmd.c_str());
+      ret = query_with_reconnect(sqlcmd);
 
       if (ret != MYSQL_OK)
       {
@@ -512,7 +512,7 @@ int MysqlDatabase::drop_analytics()
   // next topic is a views list
   sqlcmd = StringUtils::Format(
       "SELECT table_name FROM information_schema.views WHERE table_schema = '{}'", db);
-  ret = query_with_reconnect(sqlcmd.c_str());
+  ret = query_with_reconnect(sqlcmd);
   if (ret != MYSQL_OK)
     throw DbErrors("Can't determine list of views to drop. (%d)", ret);
 
@@ -524,7 +524,7 @@ int MysqlDatabase::drop_analytics()
     {
       /* we do not need IF EXISTS because these views are exist */
       sqlcmd = StringUtils::Format("DROP VIEW `{}`.`{}`", db, row[0]);
-      ret = query_with_reconnect(sqlcmd.c_str());
+      ret = query_with_reconnect(sqlcmd);
       if (ret != MYSQL_OK)
       {
         mysql_free_result(res);
@@ -550,7 +550,7 @@ int MysqlDatabase::drop_analytics()
     while ((row = mysql_fetch_row(res)) != nullptr)
     {
       sqlcmd = StringUtils::Format("DROP TRIGGER `{}`.`{}`", db, row[0]);
-      ret = query_with_reconnect(sqlcmd.c_str());
+      ret = query_with_reconnect(sqlcmd);
       if (ret != MYSQL_OK)
       {
         mysql_free_result(res);
@@ -577,7 +577,7 @@ int MysqlDatabase::drop_analytics()
     while ((row = mysql_fetch_row(res)) != nullptr)
     {
       sqlcmd = StringUtils::Format("DROP FUNCTION `{}`.`{}`", db, row[0]);
-      ret = query_with_reconnect(sqlcmd.c_str());
+      ret = query_with_reconnect(sqlcmd);
       if (ret != MYSQL_OK)
       {
         mysql_free_result(res);
@@ -590,13 +590,13 @@ int MysqlDatabase::drop_analytics()
   return 1;
 }
 
-int MysqlDatabase::query_with_reconnect(const char* query)
+int MysqlDatabase::query_with_reconnect(std::string_view query)
 {
   int attempts = 5;
   int result;
 
   // try to reconnect if server is gone
-  while (((result = mysql_real_query(conn, query, strlen(query))) != MYSQL_OK) &&
+  while (((result = mysql_real_query(conn, query.data(), query.size())) != MYSQL_OK) &&
          ((result = mysql_errno(conn)) == CR_SERVER_GONE_ERROR || result == CR_SERVER_LOST) &&
          (attempts-- > 0))
   {
@@ -620,7 +620,7 @@ long MysqlDatabase::nextid(const char* sname)
   int id;
   std::string sqlcmd{
       StringUtils::Format("SELECT nextid FROM {} WHERE seq_name = '{}'", seq_table, sname)};
-  int err = query_with_reconnect(sqlcmd.c_str());
+  int err = query_with_reconnect(sqlcmd);
   CLog::LogFC(LOGDEBUG, LOGDATABASE, "will request");
   if (err != 0)
   {
@@ -635,7 +635,7 @@ long MysqlDatabase::nextid(const char* sname)
       sqlcmd = StringUtils::Format("INSERT INTO {} (nextid,seq_name) VALUES ({},'{}')", seq_table,
                                    id, sname);
       mysql_free_result(res);
-      err = query_with_reconnect(sqlcmd.c_str());
+      err = query_with_reconnect(sqlcmd);
       if (err != 0)
         return DB_UNEXPECTED_RESULT;
 
@@ -647,7 +647,7 @@ long MysqlDatabase::nextid(const char* sname)
       sqlcmd = StringUtils::Format("UPDATE {} SET nextid=%d WHERE seq_name = '{}'", seq_table, id,
                                    sname);
       mysql_free_result(res);
-      err = query_with_reconnect(sqlcmd.c_str());
+      err = query_with_reconnect(sqlcmd);
       if (err != 0)
         return DB_UNEXPECTED_RESULT;
 
@@ -1817,7 +1817,7 @@ void MysqlDataset::make_query(StringList& _sql)
     {
       query = i;
       Dataset::parse_sql(query);
-      if ((static_cast<MysqlDatabase*>(db)->query_with_reconnect(query.c_str())) != MYSQL_OK)
+      if ((static_cast<MysqlDatabase*>(db)->query_with_reconnect(query)) != MYSQL_OK)
       {
         throw DbErrors("%s", db->getErrorMsg());
       }
@@ -1937,7 +1937,7 @@ int MysqlDataset::exec(const std::string& sql)
   const auto start = std::chrono::steady_clock::now();
 
   const int res =
-      db->setErr(static_cast<MysqlDatabase*>(db)->query_with_reconnect(qry.c_str()), qry.c_str());
+      db->setErr(static_cast<MysqlDatabase*>(db)->query_with_reconnect(qry), qry.c_str());
 
   const auto end = std::chrono::steady_clock::now();
   const auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
@@ -1985,8 +1985,7 @@ bool MysqlDataset::query(const std::string& query)
   MYSQL_RES* stmt = nullptr;
 
   if (static_cast<MysqlDatabase*>(db)->setErr(
-          static_cast<MysqlDatabase*>(db)->query_with_reconnect(qry.c_str()), qry.c_str()) !=
-      MYSQL_OK)
+          static_cast<MysqlDatabase*>(db)->query_with_reconnect(qry), qry.c_str()) != MYSQL_OK)
     throw DbErrors("%s", db->getErrorMsg());
 
   MYSQL* conn = handle();

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -11,6 +11,7 @@
 #include "dataset.h"
 
 #include <string>
+#include <string_view>
 
 #ifdef HAS_MYSQL
 #include <mysql/mysql.h>
@@ -81,6 +82,29 @@ public:
 private:
   char et_getdigit(double* val, int* cnt) const;
   std::string mysql_vmprintf(const char* zFormat, va_list ap);
+
+  /*!
+   * \brief Query the server's default storage engine.
+   * \return the server's default storage engine, empty in case of error.
+   */
+  std::string GetServerDefaultEngine();
+
+  /*!
+   * \brief Set the storage engine of a table.
+   *        No action if \p targetEngine is already the engine of the table.
+   * \param[in] db Schema/database name containing the table.
+   * \param[in] table Table name
+   * \param[in] targetEngine Engine name to set
+   * \return true for success or no change necessary, false for failure.
+   */
+  bool ChangeStorageEngine(std::string_view db, const char* table, std::string_view targetEngine);
+
+  /*!
+   * \brief Resolve the storage engine to use when copying tables.
+   *        Use the server default if not blacklisted with fallback to hardcoded default
+   * \return Resolved engine name, never empty.
+   */
+  std::string ResolveStorageEngine();
 };
 
 /***************** Class MysqlDataset definition *******************

--- a/xbmc/dbwrappers/mysqldataset.h
+++ b/xbmc/dbwrappers/mysqldataset.h
@@ -75,7 +75,7 @@ public:
   std::string vprepare(std::string_view format, va_list args) override;
 
   bool in_transaction() override { return _in_transaction; }
-  int query_with_reconnect(const char* query);
+  int query_with_reconnect(std::string_view query);
   void configure_connection();
 
 private:

--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -324,34 +324,36 @@ public:
   /* The next several isasciiXX and asciiXXvalue functions are locale independent (US-ASCII only),
    * as opposed to standard ::isXX (::isalpha, ::isdigit...) which are locale dependent.
    * Next functions get parameter as char and don't need double cast ((int)(unsigned char) is required for standard functions). */
-  [[nodiscard]] inline static bool isasciidigit(char chr) noexcept // locale independent
+  [[nodiscard]] constexpr static bool isasciidigit(char chr) noexcept // locale independent
   {
     return chr >= '0' && chr <= '9';
   }
-  [[nodiscard]] inline static bool isasciixdigit(char chr) noexcept // locale independent
+  [[nodiscard]] constexpr static bool isasciixdigit(char chr) noexcept // locale independent
   {
     return (chr >= '0' && chr <= '9') || (chr >= 'a' && chr <= 'f') || (chr >= 'A' && chr <= 'F');
   }
   [[nodiscard]] static int asciidigitvalue(char chr) noexcept; // locale independent
   [[nodiscard]] static int asciixdigitvalue(char chr) noexcept; // locale independent
-  [[nodiscard]] inline static bool isasciiuppercaseletter(char chr) noexcept // locale independent
+  [[nodiscard]] constexpr static bool isasciiuppercaseletter(
+      char chr) noexcept // locale independent
   {
     return (chr >= 'A' && chr <= 'Z');
   }
-  [[nodiscard]] inline static bool isasciilowercaseletter(char chr) noexcept // locale independent
+  [[nodiscard]] constexpr static bool isasciilowercaseletter(
+      char chr) noexcept // locale independent
   {
     return (chr >= 'a' && chr <= 'z');
   }
-  [[nodiscard]] inline static bool isasciiletter(char chr) noexcept // locale independent
+  [[nodiscard]] constexpr static bool isasciiletter(char chr) noexcept // locale independent
   {
     return isasciiuppercaseletter(chr) || isasciilowercaseletter(chr);
   }
-  [[nodiscard]] inline static bool IsAsciiLetters(
+  [[nodiscard]] constexpr static bool IsAsciiLetters(
       std::string_view str) noexcept // locale independent
   {
     return std::ranges::all_of(str, [](char c) { return StringUtils::isasciiletter(c); }, {});
   }
-  [[nodiscard]] inline static bool isasciialphanum(char chr) noexcept // locale independent
+  [[nodiscard]] constexpr static bool isasciialphanum(char chr) noexcept // locale independent
   {
     return isasciiletter(chr) || isasciidigit(chr);
   }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Alter tables storage engine during database upgrade to the server default engine (usually InnoDB).
If the server default is in a blacklist of engines (MyISAM at this time), the code falls back to a hardcoded InnoDB default.
No action when the table already uses the wanted engine.

I toyed with an advanced setting to let the user control the engine used with Kodi, but decided against as the new database creation path would then also have to be modified for consistency, and how many users would practically take advantage of the setting...

The server default storage engine is already used for new database creation so the results are consistent with the upgrade path.

Deserves a note in the wiki, with the other server requirements.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The default storage engine of MySQL / MariaDB many years ago was MyISAM, and the table storage engine is preserved during database migrations.

However Kodi uses large text field indexes that exceed the capabilities of the MyISAM storage engine of MySQL / MariaDB after the change to the utf8mb4 character set.
There are other compelling reasons to move away from MyISAM (no ACID compliance)

All db engine versions supported by Kodi include more capable storage engines such InnoDB, usually the default engine.

No backport to be considered since the charset was changed in v22

fix #28553

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Altered individual tables engines before db version upgrade.
Altered the server default engine.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Smooth upgrade to v22 for MySQL/MariaDB databases created in the 2010 era and upgraded since then.

## Screenshots (if appropriate):

The art table was changed to MyISAM engine for the migration test:
```
info <general>: Old database found - updating from version 146 to 147
debug <general>: dbiplus::MysqlDatabase::copy: Copying from MyVideos_Next146 to MyVideos_Next147 at 192.168.2.2
info <general>: MYSQL: Using server default storage engine 'InnoDB' for database copy.
info <general>: MYSQL: Migrating 'MyVideos_Next147'.`art` from engine MyISAM to InnoDB.
info <general>: Attempting to update the database MyVideos_Next147 from version 146 to 147
...
```

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
