### PR TITLE
[webOS] Add native on-screen keyboard

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16815,7 +16815,7 @@ msgctxt "#24161"
 msgid "This prevents you from accidental tap/swipe/pan action when you grab the remote in your hand"
 msgstr ""
 
-#: system/settings/darwin_tvos.xml
+#: system/settings/settings.xml
 msgctxt "#24162"
 msgid "Use Kodi virtual keyboard"
 msgstr ""
@@ -18087,9 +18087,9 @@ msgctxt "#34007"
 msgid "Windows media audio 2 (FFmpeg wmav2)"
 msgstr ""
 
-#: system/settings/darwin_tvos.xml
+#: system/settings/settings.xml
 msgctxt "#34008"
-msgid "When you need to enter some text, Kodi virtual keyboard will show up instead of the built-in tvOS keyboard"
+msgid "When you need to enter some text, Kodi virtual keyboard will show up instead of the built-in platform keyboard"
 msgstr ""
 
 #: system/settings/darwin_tvos.xml

--- a/cmake/scripts/webos/ExtraTargets.cmake
+++ b/cmake/scripts/webos/ExtraTargets.cmake
@@ -1,5 +1,7 @@
 # generate webos wayland protocols
-set(WEBOS_PROTOCOL_XMLS "${WAYLANDPROTOCOLSWEBOS_PROTOCOLSDIR}/webos-shell.xml"
+set(WEBOS_PROTOCOL_XMLS "${WAYLANDPROTOCOLSWEBOS_PROTOCOLSDIR}/input-method.xml"
+                        "${WAYLANDPROTOCOLSWEBOS_PROTOCOLSDIR}/text.xml"
+                        "${WAYLANDPROTOCOLSWEBOS_PROTOCOLSDIR}/webos-shell.xml"
                         "${WAYLANDPROTOCOLSWEBOS_PROTOCOLSDIR}/webos-foreign.xml"
 )
 add_custom_command(OUTPUT "${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-webos-protocols.hpp" "${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-webos-protocols.cpp"

--- a/system/settings/darwin_tvos.xml
+++ b/system/settings/darwin_tvos.xml
@@ -77,11 +77,6 @@
           </constraints>
           <control type="spinner" format="integer" delayed="false"/>
         </setting>
-        <setting id="input.tvosusekodikeyboard" type="boolean" label="24162" help="34008">
-          <level>1</level>
-          <default>false</default>
-          <control type="toggle" />
-        </setting>
       </group>
     </category>
   </section>

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3612,6 +3612,22 @@
           <control type="toggle" />
         </setting>
       </group>
+      <group id="4" label="35150">
+        <setting id="input.usekodikeyboard" type="boolean" label="24162" help="34008">
+          <requirement>
+            <or>
+              <condition>HAVE_TVOS</condition>
+              <condition>HAVE_WEBOS</condition>
+            </or>
+          </requirement>
+          <level>1</level>
+          <default>false</default>
+          <updates>
+            <update type="rename">input.tvosusekodikeyboard</update>
+          </updates>
+          <control type="toggle" />
+        </setting>
+      </group>
     </category>
     <category id="network" label="798" help="36379">
       <group id="1" label="16000">

--- a/tools/depends/target/webos-wayland-extensions/01-text-model-v1-abi.patch
+++ b/tools/depends/target/webos-wayland-extensions/01-text-model-v1-abi.patch
@@ -1,0 +1,65 @@
+--- a/protocol/text.xml
++++ b/protocol/text.xml
+@@ -168,6 +168,13 @@
+       <entry name="previous" value="7" summary="show a Previous button"/>
+     </enum>
+ 
++    <request name="set_enter_key_type">
++      <description summary="set type of enter key">
++        Sets the type of the enter key on an input panel (virtual keyboard).
++      </description>
++      <arg name="enter_key_type" type="uint"/>
++    </request>
++
+     <request name="invoke_action">
+       <description summary="invoke action">
+         Invokes a button action on a given position.
+@@ -184,6 +191,20 @@
+       </description>
+     </request>
+ 
++    <request name="set_max_text_length">
++      <description summary="set max length of input field">
++        Sets the maximum length of an input field.
++      </description>
++      <arg name="length" type="uint"/>
++    </request>
++
++    <request name="set_platform_data">
++      <description summary="set platform specific data">
++        Sets the platform specific data (text).
++      </description>
++      <arg name="text" type="string"/>
++    </request>
++
+     <event name="commit_string">
+       <description summary="text to commit">
+         Notifies when text should be inserted into the editor widget. The text
+@@ -344,27 +365,6 @@
+       <arg name="height" type="uint"/>
+     </event>
+ 
+-    <request name="set_max_text_length">
+-      <description summary="set max length of input field">
+-        Sets the maximum length of an input field.
+-      </description>
+-      <arg name="length" type="uint"/>
+-    </request>
+-
+-    <request name="set_platform_data">
+-      <description summary="set platform specific data">
+-        Sets the platform specific data (text).
+-      </description>
+-      <arg name="text" type="string"/>
+-    </request>
+-
+-    <request name="set_enter_key_type">
+-      <description summary="set type of enter key">
+-        Sets the type of the enter key on an input panel (virtual keyboard).
+-      </description>
+-      <arg name="enter_key_type" type="uint"/>
+-    </request>
+-
+     <request name="set_input_panel_rect">
+       <description summary="set rect of the input panel">
+         Requests the geometry of the input panel to change. The geometry should

--- a/tools/depends/target/webos-wayland-extensions/Makefile
+++ b/tools/depends/target/webos-wayland-extensions/Makefile
@@ -1,6 +1,8 @@
 -include ../../Makefile.include
 include WEBOS-WAYLAND-EXTENSIONS-VERSION
-DEPS = WEBOS-WAYLAND-EXTENSIONS-VERSION Makefile ../../download-files.include
+DEPS = WEBOS-WAYLAND-EXTENSIONS-VERSION Makefile \
+       01-text-model-v1-abi.patch \
+       ../../download-files.include
 
 ifeq ($(CROSS_COMPILING), yes)
   DEPS += ../../Makefile.include
@@ -14,12 +16,12 @@ all: .installed-$(PLATFORM)
 .configured-$(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
+	cd $(PLATFORM); patch -p1 -i ../01-text-model-v1-abi.patch
 	touch $@
 
 .installed-$(PLATFORM): .configured-$(PLATFORM)
 	mkdir -p $(PREFIX)/share/wayland-webos $(PREFIX)/lib/pkgconfig
-	cp $(PLATFORM)/protocol/webos-shell.xml $(PREFIX)/share/wayland-webos
-	cp $(PLATFORM)/protocol/webos-foreign.xml $(PREFIX)/share/wayland-webos
+	cp $(PLATFORM)/protocol/*.xml $(PREFIX)/share/wayland-webos
 	touch $@
 
 clean:

--- a/xbmc/dialogs/GUIDialogKeyboardTouch.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboardTouch.cpp
@@ -9,6 +9,8 @@
 #include "GUIDialogKeyboardTouch.h"
 #if defined(TARGET_DARWIN_EMBEDDED)
 #include "platform/darwin/ios-common/DarwinEmbedKeyboard.h"
+#elif defined(TARGET_WEBOS)
+#include "windowing/wayland/WebOSKeyboard.h"
 #endif
 
 CGUIDialogKeyboardTouch::CGUIDialogKeyboardTouch()
@@ -23,6 +25,8 @@ bool CGUIDialogKeyboardTouch::ShowAndGetInput(char_callback_t pCallback, const s
 {
 #if defined(TARGET_DARWIN_EMBEDDED)
   m_keyboard.reset(new CDarwinEmbedKeyboard());
+#elif defined(TARGET_WEBOS)
+  m_keyboard = std::make_unique<KODI::WINDOWING::WAYLAND::CWebOSKeyboard>();
 #endif
 
   if (!m_keyboard)
@@ -83,4 +87,18 @@ void CGUIDialogKeyboardTouch::Process()
     m_confirmed = m_keyboard->ShowAndGetInput(m_pCharCallback, m_initialString, m_typedString, m_heading, m_bHiddenInput);
   }
   Close();
+}
+
+void CGUIDialogKeyboardTouch::Process(unsigned int currentTime, CDirtyRegionList& dirtyregions)
+{
+  if (m_keyboard && m_keyboard->ConsumeRenderDirty())
+    MarkDirtyRegion();
+  CGUIDialog::Process(currentTime, dirtyregions);
+}
+
+void CGUIDialogKeyboardTouch::Render()
+{
+  CGUIDialog::Render();
+  if (m_keyboard)
+    m_keyboard->Render();
 }

--- a/xbmc/dialogs/GUIDialogKeyboardTouch.h
+++ b/xbmc/dialogs/GUIDialogKeyboardTouch.h
@@ -26,7 +26,9 @@ public:
 protected:
   void OnInitWindow() override;
   using CGUIControlGroup::Process;
+  void Process(unsigned int currentTime, CDirtyRegionList& dirtyregions) override;
   void Process() override;
+  void Render() override;
 
   char_callback_t m_pCharCallback;
   std::string m_initialString;

--- a/xbmc/guilib/GUIKeyboard.h
+++ b/xbmc/guilib/GUIKeyboard.h
@@ -54,6 +54,12 @@ class CGUIKeyboard : public ITimerCallback
 
     virtual int GetWindowId() const {return 0;}
 
+    /*! \brief Render platform-specific keyboard content on the GUI thread. */
+    virtual void Render() {}
+
+    /*! \brief Return whether platform-specific keyboard content needs to be redrawn. */
+    virtual bool ConsumeRenderDirty() { return false; }
+
     // CTimer Interface for autoclose
     void OnTimeout() override
     {

--- a/xbmc/guilib/GUIKeyboardFactory.cpp
+++ b/xbmc/guilib/GUIKeyboardFactory.cpp
@@ -22,10 +22,12 @@
 #include "utils/Digest.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
-#if defined(TARGET_DARWIN_EMBEDDED)
+#if defined(TARGET_DARWIN_EMBEDDED) || defined(TARGET_WEBOS)
 #include "dialogs/GUIDialogKeyboardTouch.h"
 
+#if defined(TARGET_DARWIN_EMBEDDED)
 #include "platform/darwin/ios-common/DarwinEmbedKeyboard.h"
+#endif
 #endif
 
 using namespace KODI::MESSAGING;
@@ -91,23 +93,21 @@ bool CGUIKeyboardFactory::ShowAndGetInput(std::string& aTextString,
         (uint32_t)heading.asInteger());
 
   bool useKodiKeyboard = true;
-#if defined(TARGET_DARWIN_EMBEDDED)
-#if defined(TARGET_DARWIN_TVOS)
+#if defined(TARGET_DARWIN_TVOS) || defined(TARGET_WEBOS)
   useKodiKeyboard = CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-      CSettings::SETTING_INPUT_TVOSUSEKODIKEYBOARD);
-#else
+      CSettings::SETTING_INPUT_USEKODIKEYBOARD);
+#elif defined(TARGET_DARWIN_EMBEDDED)
   useKodiKeyboard = CDarwinEmbedKeyboard::hasExternalKeyboard();
-#endif // defined(TARGET_DARWIN_TVOS)
 #endif
 
   auto& winManager = CServiceBroker::GetGUI()->GetWindowManager();
   CGUIKeyboard* kb = nullptr;
   if (useKodiKeyboard)
     kb = winManager.GetWindow<CGUIDialogKeyboardGeneric>(WINDOW_DIALOG_KEYBOARD);
-#if defined(TARGET_DARWIN_EMBEDDED)
+#if defined(TARGET_DARWIN_EMBEDDED) || defined(TARGET_WEBOS)
   else
     kb = winManager.GetWindow<CGUIDialogKeyboardTouch>(WINDOW_DIALOG_KEYBOARD_TOUCH);
-#endif // defined(TARGET_DARWIN_EMBEDDED)
+#endif
 
   if (kb)
   {
@@ -239,4 +239,3 @@ int CGUIKeyboardFactory::ShowAndVerifyPassword(std::string& strPassword, const s
     else return 1;
   }
 }
-

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -433,7 +433,7 @@ public:
       "input.siriremotehorizontalsensitivity";
   static constexpr auto SETTING_INPUT_SIRIREMOTEVERTICALSENSITIVITY =
       "input.siriremoteverticalsensitivity";
-  static constexpr auto SETTING_INPUT_TVOSUSEKODIKEYBOARD = "input.tvosusekodikeyboard";
+  static constexpr auto SETTING_INPUT_USEKODIKEYBOARD = "input.usekodikeyboard";
   static constexpr auto SETTING_NETWORK_USEHTTPPROXY = "network.usehttpproxy";
   static constexpr auto SETTING_NETWORK_HTTPPROXYTYPE = "network.httpproxytype";
   static constexpr auto SETTING_NETWORK_HTTPPROXYSERVER = "network.httpproxyserver";

--- a/xbmc/windowing/wayland/CMakeLists.txt
+++ b/xbmc/windowing/wayland/CMakeLists.txt
@@ -72,11 +72,13 @@ if(TARGET_WEBOS)
   list(APPEND SOURCES OSScreenSaverWebOS.cpp
                       SeatWebOS.cpp
                       ShellSurfaceWebOSShell.cpp
+                      WebOSKeyboard.cpp
                       WinSystemWaylandWebOS.cpp
                       ${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-webos-protocols.cpp)
   list(APPEND HEADERS OSScreenSaverWebOS.h
                       SeatWebOS.h
                       ShellSurfaceWebOSShell.h
+                      WebOSKeyboard.h
                       WinSystemWaylandWebOS.h
                       ${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-webos-protocols.hpp)
 endif()

--- a/xbmc/windowing/wayland/WebOSKeyboard.cpp
+++ b/xbmc/windowing/wayland/WebOSKeyboard.cpp
@@ -1,0 +1,316 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "WebOSKeyboard.h"
+
+#include "ServiceBroker.h"
+#include "WinSystemWaylandWebOS.h"
+#include "guilib/GUIFont.h"
+#include "guilib/GUIFontManager.h"
+#include "guilib/GUITextLayout.h"
+#include "guilib/GUITexture.h"
+#include "utils/CharsetConverter.h"
+#include "utils/log.h"
+#include "windowing/GraphicContext.h"
+#include "windowing/WinSystem.h"
+
+#include <algorithm>
+#include <cstdint>
+
+#include <xkbcommon/xkbcommon-keysyms.h>
+
+namespace KODI::WINDOWING::WAYLAND
+{
+
+CWebOSKeyboard::CWebOSKeyboard() = default;
+CWebOSKeyboard::~CWebOSKeyboard() = default;
+
+bool CWebOSKeyboard::ShowAndGetInput(const char_callback_t callback,
+                                     const std::string& initialString,
+                                     std::string& typedString,
+                                     const std::string& heading,
+                                     const bool hiddenInput)
+{
+  m_winSystem = dynamic_cast<CWinSystemWaylandWebOS*>(CServiceBroker::GetWinSystem());
+  if (!m_winSystem || !m_winSystem->HasTextInput())
+  {
+    CLog::LogF(LOGWARNING, "webOS text input protocol is unavailable");
+    return false;
+  }
+
+  m_textModel = m_winSystem->CreateTextModel();
+  if (!m_textModel)
+    return false;
+
+  {
+    std::unique_lock lock(m_mutex);
+    m_text = initialString;
+    m_preedit.clear();
+    m_preeditCommit.clear();
+    m_cursor = m_text.size();
+    m_callback = callback;
+    m_confirmed = false;
+    m_active = true;
+    m_panelShown = false;
+    m_hiddenInput = hiddenInput;
+    m_inputPanelRect = {};
+    m_renderDirty = true;
+    m_finished.Reset();
+  }
+
+  m_textModel.on_commit_string() = [this](const std::uint32_t, const std::string& text)
+  {
+    {
+      std::unique_lock lock(m_mutex);
+      m_preedit.clear();
+      m_preeditCommit.clear();
+      m_text.insert(m_cursor, text);
+      m_cursor += text.size();
+      UpdateSurroundingText();
+    }
+    TextChanged();
+  };
+  m_textModel.on_preedit_string() =
+      [this](const std::uint32_t, const std::string& text, const std::string& commit)
+  {
+    {
+      std::unique_lock lock(m_mutex);
+      m_preedit = text;
+      m_preeditCommit = commit;
+    }
+    TextChanged();
+  };
+  m_textModel.on_delete_surrounding_text() =
+      [this](const std::uint32_t, const std::int32_t index, const std::uint32_t length)
+  {
+    {
+      std::unique_lock lock(m_mutex);
+      const auto cursor = static_cast<std::int64_t>(m_cursor);
+      const auto start = std::clamp<std::int64_t>(cursor + index, 0, m_text.size());
+      const auto byteStart = static_cast<std::size_t>(start);
+      const auto count = std::min<std::size_t>(length, m_text.size() - byteStart);
+      m_text.erase(byteStart, count);
+      m_cursor = byteStart;
+      UpdateSurroundingText();
+    }
+    TextChanged();
+  };
+  m_textModel.on_keysym() = [this](const std::uint32_t, const std::uint32_t,
+                                   const std::uint32_t sym, const std::uint32_t state,
+                                   const std::uint32_t)
+  {
+    if (state == 0)
+      return;
+    if (sym == XKB_KEY_BackSpace)
+      Backspace();
+    else if (sym == XKB_KEY_Return || sym == XKB_KEY_KP_Enter)
+      Finish(true);
+    else if (sym == XKB_KEY_Escape)
+      Finish(false);
+  };
+  m_textModel.on_input_panel_state() = [this](const std::uint32_t state)
+  {
+    std::unique_lock lock(m_mutex);
+    if (state != 0)
+      m_panelShown = true;
+    else if (m_panelShown)
+    {
+      lock.unlock();
+      Finish(false);
+    }
+  };
+  m_textModel.on_input_panel_rect() = [this](const std::int32_t x, const std::int32_t y,
+                                             const std::uint32_t width, const std::uint32_t height)
+  {
+    const CRectInt panelRect{x, y, x + static_cast<int>(width), y + static_cast<int>(height)};
+    {
+      std::unique_lock lock(m_mutex);
+      m_inputPanelRect = panelRect;
+      m_renderDirty = true;
+    }
+  };
+  m_textModel.on_leave() = [this] { Finish(false); };
+
+  const auto hint = hiddenInput ? wayland::text_model_content_hint::password
+                                : wayland::text_model_content_hint::_default;
+  const auto purpose = hiddenInput ? wayland::text_model_content_purpose::password
+                                   : wayland::text_model_content_purpose::normal;
+  m_textModel.set_content_type(static_cast<std::uint32_t>(hint),
+                               static_cast<std::uint32_t>(purpose));
+  m_textModel.set_enter_key_type(
+      static_cast<std::uint32_t>(wayland::text_model_enter_key_type::done));
+  UpdateSurroundingText();
+
+  if (!m_winSystem->ActivateTextModel(m_textModel))
+  {
+    Finish(false);
+    {
+      std::unique_lock lock(m_mutex);
+      m_active = false;
+      m_callback = nullptr;
+    }
+    m_textModel = {};
+    return false;
+  }
+  m_textModel.show_input_panel();
+  m_finished.Wait();
+
+  m_textModel.hide_input_panel();
+  m_winSystem->DeactivateTextModel(m_textModel);
+  {
+    std::unique_lock lock(m_mutex);
+    if (m_confirmed)
+      typedString = m_text;
+    m_active = false;
+    m_callback = nullptr;
+  }
+  m_textModel = {};
+  return m_confirmed;
+}
+
+bool CWebOSKeyboard::SetTextToKeyboard(const std::string& text, const bool closeKeyboard)
+{
+  {
+    std::unique_lock lock(m_mutex);
+    if (!m_active)
+      return false;
+    m_text = text;
+    m_preedit.clear();
+    m_preeditCommit.clear();
+    m_cursor = text.size();
+    m_textModel.reset(0);
+    UpdateSurroundingText();
+  }
+  TextChanged();
+  if (closeKeyboard)
+    Finish(true);
+  return true;
+}
+
+void CWebOSKeyboard::Cancel()
+{
+  Finish(false);
+}
+
+void CWebOSKeyboard::Render()
+{
+  std::string text;
+  CRectInt panel;
+  bool hiddenInput;
+  {
+    std::unique_lock lock(m_mutex);
+    if (!m_active)
+      return;
+    text = m_text;
+    text.insert(m_cursor, m_preedit);
+    panel = m_inputPanelRect;
+    hiddenInput = m_hiddenInput;
+  }
+
+  if (panel.IsEmpty())
+    return;
+
+  auto& context = CServiceBroker::GetWinSystem()->GetGfxContext();
+  context.SetRenderingResolution(context.GetResInfo(), false);
+
+  const float screenWidth = context.GetWidth();
+  const float screenHeight = context.GetHeight();
+  const float padding = screenWidth * 0.15f;
+  const float height = std::max(64.0f, screenHeight * 0.08f);
+  const float x = panel.x1;
+  const float y = panel.y1 - height;
+  const float width = screenWidth - x;
+
+  if (hiddenInput)
+    text.assign(CCharsetConverter::utf8ToUtf32(text, false).size(), '*');
+  text += '|';
+
+  CGUITexture::DrawQuad(CRect{x, y, x + width, y + height}, 0xff1c1d1e);
+
+  if (!m_previewLayout)
+  {
+    CGUIFont* font = g_fontManager.GetDefaultFont();
+    if (!font)
+      return;
+    m_previewLayout = std::make_unique<CGUITextLayout>(font, false, height - 2.0f * padding);
+  }
+
+  m_previewLayout->Update(text, width - 2.0f * padding);
+  const float textY = y + (height - m_previewLayout->GetTextHeight()) * 0.5f;
+  m_previewLayout->Render(x + padding, textY, 0.0f, 0xffffffff, 0xff000000, XBFONT_TRUNCATED_LEFT,
+                          width - 2.0f * padding);
+}
+
+bool CWebOSKeyboard::ConsumeRenderDirty()
+{
+  return m_renderDirty.exchange(false);
+}
+
+void CWebOSKeyboard::Backspace()
+{
+  {
+    std::unique_lock lock(m_mutex);
+    if (m_cursor == 0 || m_cursor > m_text.size())
+      return;
+
+    std::size_t start = m_cursor - 1;
+    while (start > 0 && (static_cast<unsigned char>(m_text[start]) & 0xc0) == 0x80)
+      --start;
+
+    m_text.erase(start, m_cursor - start);
+    m_cursor = start;
+    UpdateSurroundingText();
+  }
+  TextChanged();
+}
+
+void CWebOSKeyboard::CommitPreedit()
+{
+  if (!m_preedit.empty() || !m_preeditCommit.empty())
+  {
+    const std::string& text = m_preeditCommit.empty() ? m_preedit : m_preeditCommit;
+    m_text.insert(m_cursor, text);
+    m_cursor += text.size();
+    m_preedit.clear();
+    m_preeditCommit.clear();
+  }
+}
+
+void CWebOSKeyboard::UpdateSurroundingText()
+{
+  m_textModel.set_surrounding_text(m_text, m_cursor, m_cursor);
+  m_textModel.commit();
+}
+
+void CWebOSKeyboard::TextChanged()
+{
+  char_callback_t callback;
+  std::string text;
+  {
+    std::unique_lock lock(m_mutex);
+    callback = m_callback;
+    text = m_text;
+    text.insert(m_cursor, m_preedit);
+    m_renderDirty = true;
+  }
+  if (callback)
+    callback(this, text);
+}
+
+void CWebOSKeyboard::Finish(const bool confirmed)
+{
+  std::unique_lock lock(m_mutex);
+  if (!m_active || m_finished.Signaled())
+    return;
+  if (confirmed)
+    CommitPreedit();
+  m_confirmed = confirmed;
+  m_finished.Set();
+}
+
+} // namespace KODI::WINDOWING::WAYLAND

--- a/xbmc/windowing/wayland/WebOSKeyboard.h
+++ b/xbmc/windowing/wayland/WebOSKeyboard.h
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "guilib/GUIKeyboard.h"
+#include "threads/CriticalSection.h"
+#include "threads/Event.h"
+#include "utils/Geometry.h"
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+
+#include <wayland-webos-protocols.hpp>
+
+class CGUITextLayout;
+
+namespace KODI::WINDOWING::WAYLAND
+{
+
+class CWinSystemWaylandWebOS;
+
+/**
+ * \brief Native on-screen keyboard using the webOS Wayland text model protocol.
+ *
+ * The keyboard delegates text entry and rendering to the webOS compositor. Protocol events are
+ * translated into Kodi keyboard callbacks while \ref ShowAndGetInput waits for the user to either
+ * confirm or cancel the input.
+ */
+class CWebOSKeyboard : public CGUIKeyboard
+{
+public:
+  CWebOSKeyboard();
+  ~CWebOSKeyboard() override;
+
+  /**
+   * \brief Show the native webOS keyboard and wait for it to close.
+   * \param callback Callback invoked whenever the complete input text changes.
+   * \param initialString Text with which to initialize the keyboard.
+   * \param typedString Receives the entered text when the input is confirmed.
+   * \param heading Dialog heading supplied by the caller. The webOS text model does not display it.
+   * \param hiddenInput Whether to request password-style input from the compositor.
+   * \return True when the user confirmed the input, false when it was canceled or could not be
+   * opened.
+   */
+  bool ShowAndGetInput(char_callback_t callback,
+                       const std::string& initialString,
+                       std::string& typedString,
+                       const std::string& heading,
+                       bool hiddenInput) override;
+
+  /**
+   * \brief Replace the current keyboard text.
+   * \param text New complete input text.
+   * \param closeKeyboard Whether to confirm and close the keyboard after updating the text.
+   * \return True when a native keyboard is active, otherwise false.
+   */
+  bool SetTextToKeyboard(const std::string& text, bool closeKeyboard = false) override;
+
+  /**
+   * \brief Cancel the active keyboard and unblock \ref ShowAndGetInput.
+   */
+  void Cancel() override;
+
+  /** \brief Render the current input above the compositor-owned keyboard. */
+  void Render() override;
+
+  /** \brief Return whether the keyboard preview needs to be redrawn. */
+  bool ConsumeRenderDirty() override;
+
+private:
+  void Backspace();
+  void CommitPreedit();
+  void UpdateSurroundingText();
+  void TextChanged();
+  void Finish(bool confirmed);
+
+  CWinSystemWaylandWebOS* m_winSystem{nullptr};
+  wayland::text_model_t m_textModel;
+  CCriticalSection m_mutex;
+  CEvent m_finished{true};
+  std::string m_text;
+  std::string m_preedit;
+  std::string m_preeditCommit;
+  std::size_t m_cursor{0};
+  char_callback_t m_callback{nullptr};
+  bool m_confirmed{false};
+  bool m_active{false};
+  bool m_panelShown{false};
+  bool m_hiddenInput{false};
+  CRectInt m_inputPanelRect;
+  std::unique_ptr<CGUITextLayout> m_previewLayout;
+  std::atomic_bool m_renderDirty{false};
+};
+
+} // namespace KODI::WINDOWING::WAYLAND

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.cpp
@@ -57,6 +57,7 @@ bool CWinSystemWaylandWebOS::InitWindowSystem()
 
   m_webosRegistry = std::make_unique<CRegistry>(*GetConnection());
   m_webosRegistry->RequestSingleton(m_compositor, 1, 4);
+  m_webosRegistry->RequestSingleton(m_textModelFactory, 1, 1, false);
   // available since webOS 5.0
   m_webosRegistry->RequestSingleton(m_webosForeign, 1, 2, false);
   m_webosRegistry->Bind();
@@ -78,6 +79,8 @@ bool CWinSystemWaylandWebOS::DestroyWindowSystem()
 {
   m_exportedSurface = wayland::webos_exported_t{};
   m_webosForeign = wayland::webos_foreign_t{};
+  m_textModelFactory = wayland::text_model_factory_t{};
+  m_textInputSeat = wayland::seat_t{};
 
   if (m_webosRegistry)
   {
@@ -162,7 +165,37 @@ std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> CWinSystemWaylandWebOS::GetOSSc
 
 std::unique_ptr<CSeat> CWinSystemWaylandWebOS::CreateSeat(std::uint32_t name, wayland::seat_t& seat)
 {
+  if (!m_textInputSeat)
+    m_textInputSeat = seat;
   return std::make_unique<CSeatWebOS>(name, seat, *GetConnection());
+}
+
+bool CWinSystemWaylandWebOS::HasTextInput() const
+{
+  return m_textModelFactory && m_textInputSeat;
+}
+
+wayland::text_model_t CWinSystemWaylandWebOS::CreateTextModel()
+{
+  if (!HasTextInput())
+    return {};
+
+  return m_textModelFactory.create_text_model();
+}
+
+bool CWinSystemWaylandWebOS::ActivateTextModel(wayland::text_model_t& textModel)
+{
+  if (!textModel || !HasTextInput())
+    return false;
+
+  textModel.activate(++m_textModelSerial, m_textInputSeat, GetMainSurface());
+  return true;
+}
+
+void CWinSystemWaylandWebOS::DeactivateTextModel(wayland::text_model_t& textModel)
+{
+  if (textModel && m_textInputSeat)
+    textModel.deactivate(m_textInputSeat);
 }
 
 bool CWinSystemWaylandWebOS::OnAppLifecycleEventWrapper(LSHandle* sh, LSMessage* reply, void* ctx)

--- a/xbmc/windowing/wayland/WinSystemWaylandWebOS.h
+++ b/xbmc/windowing/wayland/WinSystemWaylandWebOS.h
@@ -53,6 +53,11 @@ public:
   float GetGuiSdrPeakLuminance() const override;
   bool IsHDRDisplay() override;
 
+  bool HasTextInput() const;
+  wayland::text_model_t CreateTextModel();
+  bool ActivateTextModel(wayland::text_model_t& textModel);
+  void DeactivateTextModel(wayland::text_model_t& textModel);
+
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;
   std::unique_ptr<CSeat> CreateSeat(std::uint32_t name, wayland::seat_t& seat) override;
@@ -68,6 +73,11 @@ private:
   wayland::compositor_t m_compositor;
   wayland::webos_exported_t m_exportedSurface;
   wayland::webos_foreign_t m_webosForeign;
+
+  // On-screen keyboard support
+  wayland::text_model_factory_t m_textModelFactory;
+  wayland::seat_t m_textInputSeat;
+  std::uint32_t m_textModelSerial{0};
 
   std::unique_ptr<HContext, int (*)(HContext*)> m_requestContext{new HContext(),
                                                                  HUnregisterServiceCallback};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Use the webOS Wayland text-model protocol to show the platform keyboard instead of the Kodi virtual keyboard when requested.

Expose the platform keyboard through CGUIDialogKeyboardTouch and add GUI-thread rendering hooks for platform implementations. Generalize the tvOS keyboard preference to input.usekodikeyboard so it can select between native and Kodi keyboards on both tvOS and webOS, while migrating the previous tvOS setting.

Android implementation pending in #28580

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Requested on forums by @OfficerKD637 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
