### PR TITLE
[cmake] Add mold separate debug file option

### DIFF
--- a/cmake/modules/buildtools/MOLD.cmake
+++ b/cmake/modules/buildtools/MOLD.cmake
@@ -1,4 +1,8 @@
 if(ENABLE_MOLD)
+  option(ENABLE_SEPARATE_DEBUG
+         "Enable mold separate debug file support"
+         OFF)
+
   if(CMAKE_CXX_COMPILER_ID STREQUAL GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
     # GCC < 12 doesn't support -fuse-ld=mold, so we have to use tools prefix path
     # if mold is installed in a non-standard dir, users can set -DMOLD_PREFIX=/path/to/mold_install_prefix
@@ -67,6 +71,12 @@ if(ENABLE_MOLD)
       set(CMAKE_EXE_LINKER_FLAGS "${LD_FLAGS} ${COMPILER_ARGS} ${CMAKE_EXE_LINKER_FLAGS}")
       set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
       set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}")
+      if(ENABLE_SEPARATE_DEBUG)
+        add_link_options(
+          "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:LINKER:--separate-debug-file>"
+        )
+        message(STATUS "Mold separate debug file enabled")
+      endif()
       message(STATUS "Linker: mold")
     endif()
     mark_as_advanced(MOLD_EXECUTABLE CMAKE_LINKER)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Mold can move debug information into a companion .dbg file while adding the GNU debug link to the executable automatically. This keeps the binary copied to a target small without requiring a post-link strip and objcopy step.

Expose this as the opt-in ENABLE_SEPARATE_DEBUG setting and apply it only to executable CMake targets. Avoid CMAKE_EXE_LINKER_FLAGS because Kodi passes that variable into the internal libdvd Autotools builds through LDFLAGS.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It significantly reduces the executable transferred to and stored on the target device (around 77 MB instead of 556 MB for a webOS debug build) without sacrificing source-level debugging.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
