### PR TITLE
[ActiveAE] Initialize m_lastSamplePts to zero and handle missing PTS

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -499,6 +499,21 @@ bool CActiveAEBufferPoolAtempo::ProcessBuffers()
     {
       in = m_inputSamples.front();
       m_inputSamples.pop_front();
+
+      // Update sample PTS and extrapolate missing timestamps for atempo processing
+      if (in->timestamp)
+      {
+        m_lastSamplePts = in->timestamp;
+      }
+      else
+      {
+        in->pkt_start_offset = 0;
+        in->timestamp = m_lastSamplePts;
+      }
+
+      m_lastSamplePts += static_cast<int64_t>(in->pkt->nb_samples - in->pkt_start_offset) * 1000 /
+                         m_format.m_sampleRate;
+
       m_outputSamples.push_back(in);
       busy = true;
     }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -51,7 +51,7 @@ public:
   void Return();
   std::unique_ptr<CSoundPacket> pkt;
   CActiveAEBufferPool *pool = nullptr;
-  int64_t timestamp;
+  int64_t timestamp = 0;
   int pkt_start_offset = 0;
   int refCount = 0;
   double centerMixLevel;
@@ -145,7 +145,7 @@ protected:
   bool m_drain;
   bool m_changeFilter;
   float m_tempo;
-  int64_t m_lastSamplePts;
+  int64_t m_lastSamplePts = 0;
   bool m_fillPackets;
 };
 


### PR DESCRIPTION
## Description
Initializes `m_lastSamplePts` and `timestamp` to `0` by default, and updates the Atempo filter to calculate missing packet timestamps from `m_lastSamplePts`.

## Motivation and context
Split from #28074. Prevents uninitialized timestamp variables from causing audio timing gaps when seeking or resuming tempo playback.

## How has this been tested?
Tested on Raspberry Pi 4 (LibreELEC) seeking at 1.0x and 1.6x speed.

## What is the effect on users?
Audio resumes smoothly without gaps or silence after seeking.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
