### PR TITLE
[ActiveAE] Limit resample integral to +-4% to prevent sync over-correction

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -13,6 +13,7 @@
 #include "cores/AudioEngine/Utils/AEUtil.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <mutex>
 
 using namespace ActiveAE;
@@ -178,7 +179,13 @@ double CActiveAEStream::CalcResampleRatio(double error)
   if (fabs(error) > 1000)
     m_resampleIntegral = 0;
   else if (fabs(error) > 5)
-    m_resampleIntegral += error / 1000 / 50;
+  {
+    // Limit the correction sum to +/-0.04 to prevent over-correction during large fixes
+    // This stops the system from swinging too far the other way after a big sync gap.
+    constexpr double MAX_RESAMPLE_INTEGRAL = 0.04;
+    m_resampleIntegral = std::clamp(m_resampleIntegral + error / 1000 / 50, -MAX_RESAMPLE_INTEGRAL,
+                                    MAX_RESAMPLE_INTEGRAL);
+  }
 
   double proportional = 0.0;
 


### PR DESCRIPTION
## Description
Clamps `m_resampleIntegral` to +-4% in `CalcResampleRatio()`. The 4% limit is based on empirical hardware testing.

## Motivation and context
Split from #28074. Prevents sync error correction from accumulating too much error during large seeks, which previously caused audio speed to swing back and forth before settling.

## How has this been tested?
Tested seeking on RPi4 at 1.6x tempo.

## What is the effect on users?
Audio sync recovers smoothly after seeking without swinging between too fast and too slow.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
