### PR TITLE
[ActiveAE] Skip 3x sync check delay when Atempo filter is active

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -203,9 +203,17 @@ double CActiveAEStream::CalcResampleRatio(double error)
 std::chrono::milliseconds CActiveAEStream::GetErrorInterval()
 {
   std::chrono::milliseconds ret = m_errorInterval;
-  double rr = m_processingBuffers->GetRR();
+
+  // If atempo is active, we don't want to slow down the sync checks.
+  // The normal 3x wait is meant to keep standard resampling smooth,
+  // but for Atempo it just makes sync recovery take too long.
+  if (m_processingBuffers->IsAtempoActive())
+    return ret;
+
+  const double rr = m_processingBuffers->GetRR();
   if (rr > 1.02 || rr < 0.98)
     ret *= 3;
+
   return ret;
 }
 
@@ -778,4 +786,9 @@ bool CActiveAEStreamBuffers::HasWork()
     return true;
 
   return false;
+}
+
+bool CActiveAEStreamBuffers::IsAtempoActive() const
+{
+  return m_atempoBuffers && m_atempoBuffers->GetTempo() != 1.0f;
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -118,6 +118,8 @@ public:
   std::unique_ptr<CActiveAEBufferPool> GetResampleBuffers();
   std::unique_ptr<CActiveAEBufferPool> GetAtempoBuffers();
 
+  bool IsAtempoActive() const;
+
   AEAudioFormat m_inputFormat;
   std::deque<CSampleBuffer*> m_outputSamples;
   std::deque<CSampleBuffer*> m_inputSamples;


### PR DESCRIPTION
## Description
Adds `IsAtempoActive()` helper and skips the 3x error check delay penalty in `GetErrorInterval()` when Atempo playback is active.

## Motivation and context
Split from #28074. Standard playback uses a 3x check delay during speed changes to avoid pitch artifacts. Atempo already preserves pitch, so skipping the extra wait allows much faster sync recovery.

## How has this been tested?
Tested seek recovery on RPi4 at 1.6x tempo. Sync recovery time improved from ~10s to below 5s.

## What is the effect on users?
Faster lip-sync recovery after seeking during tempo playback.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
