### PR TITLE
[GUILIB] CGUIImage: let interrupted crossfades finish fading out

### DIFF
--- a/xbmc/guilib/GUIImage.cpp
+++ b/xbmc/guilib/GUIImage.cpp
@@ -16,6 +16,7 @@
 #include "windowing/WinSystem.h"
 
 #include <cassert>
+#include <memory>
 
 using namespace KODI::GUILIB;
 
@@ -131,16 +132,32 @@ void CGUIImage::Process(unsigned int currentTime, CDirtyRegionList &dirtyregions
 
   ProcessAllocation();
 
-  if (!m_isTransitioning ||
-      (!m_textureNext->ReadyToRender() && !m_textureNext->GetFileName().empty()))
-    ProcessNoTransition(currentTime);
-  else if (!m_crossFadeTime)
-    ProcessInstantTransition(currentTime);
-  else
-    ProcessFadingTransition(currentTime);
+  // the clock is never reset, so a fade pending across a processing gap
+  // settles on resume instead of replaying stale content
+  unsigned int frameTime = 0;
+  if (m_lastRenderTime)
+    frameTime = currentTime - m_lastRenderTime;
+  if (!frameTime)
+    frameTime = (unsigned int)(1000 / CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS());
+  m_lastRenderTime = currentTime;
+
+  // swap the new image in once it has something to show (or clears the image)
+  if (m_isTransitioning && (m_textureNext->ReadyToRender() || m_textureNext->GetFileName().empty()))
+  {
+    if (m_crossFadeTime)
+      StartFadeTransition();
+    else
+      ProcessInstantTransition();
+  }
+
+  if (m_crossFadeTime)
+    ProcessFades(currentTime, frameTime);
 
   if (!m_textureCurrent->GetDiffuseColor().HasInfo())
     UpdateDiffuseColor(nullptr);
+
+  if (m_textureCurrent->Process(currentTime))
+    MarkDirtyRegion();
 
   CGUIControl::Process(currentTime, dirtyregions);
 }
@@ -161,24 +178,12 @@ void CGUIImage::ProcessState()
     if (m_textureCurrent->GetFileName() == fileName && m_nameCurrent != fileName)
       m_nameCurrent = fileName;
 
+    // the current texture is already what we want, so cancel the incoming one
     if (m_isTransitioning)
     {
-      if (m_textureNext->ReadyToRender() || m_textureNext->GetFileName().empty())
-      {
-        // if the current texture (which is fading out) is our desired texture,
-        // reverse the animation.
-        std::swap(m_textureCurrent, m_textureNext);
-        std::swap(m_nameCurrent, m_nameNext);
-        m_currentFadeTime = m_crossFadeTime - m_currentFadeTime;
-      }
-      else
-      {
-        // if we are about to fade but the new texture is not ready, we want to
-        // keep the current texture, and cancel the new texture.
-        m_isTransitioning = false;
-        m_textureNext->SetFileName("");
-        m_nameNext = "";
-      }
+      m_textureNext->SetFileName("");
+      m_nameNext = "";
+      m_isTransitioning = false;
     }
 
     m_hasNewStagingTexture = false;
@@ -193,28 +198,9 @@ void CGUIImage::ProcessState()
     if (m_textureNext->GetFileName() == fileName && m_nameNext != fileName)
       m_nameNext = fileName;
 
-    // ensure that the transition is on its way.
-    if (!m_isTransitioning &&
-        (m_textureNext->ReadyToRender() || m_textureNext->GetFileName().empty()))
-      m_isTransitioning = true;
-
+    m_isTransitioning = true;
     m_hasNewStagingTexture = false;
     return;
-  }
-
-  // finish an interrupted fade on its more visible side so the new fade starts clean
-  if (m_isTransitioning && (m_textureNext->ReadyToRender() || m_textureNext->GetFileName().empty()))
-  {
-    // an image-less current has nothing to show, so a ready incoming always wins
-    if (m_textureNext->ReadyToRender() &&
-        (!m_textureCurrent->ReadyToRender() || m_currentFadeTime * 2 >= m_crossFadeTime))
-    {
-      std::swap(m_textureCurrent, m_textureNext);
-      std::swap(m_nameCurrent, m_nameNext);
-    }
-    m_textureCurrent->SetAlpha(0xff);
-    m_currentFadeTime = 0;
-    MarkDirtyRegion();
   }
 
   // replace the in-flight texture, so the latest request always wins
@@ -250,17 +236,7 @@ void CGUIImage::ProcessAllocation()
   }
 }
 
-void CGUIImage::ProcessNoTransition(unsigned int currentTime)
-{
-  // keep the clock current while not fading (v21 never reset it), so a fade pending
-  // across a processing gap settles on resume instead of replaying stale content
-  m_lastRenderTime = currentTime;
-
-  if (m_textureCurrent->Process(currentTime))
-    MarkDirtyRegion();
-}
-
-void CGUIImage::ProcessInstantTransition(unsigned int currentTime)
+void CGUIImage::ProcessInstantTransition()
 {
   std::swap(m_textureCurrent, m_textureNext);
   std::swap(m_nameCurrent, m_nameNext);
@@ -268,55 +244,105 @@ void CGUIImage::ProcessInstantTransition(unsigned int currentTime)
   m_nameNext = "";
   m_textureNext->SetFileName("");
 
-  // the incoming texture carries a partial alpha when it completes an in-flight fade
   m_textureCurrent->SetAlpha(0xff);
   m_currentFadeTime = 0;
+  m_isTransitioning = false;
 
-  m_textureCurrent->Process(currentTime);
+  m_fadingTextures.clear();
 
+  MarkDirtyRegion();
+}
+
+void CGUIImage::StartFadeTransition()
+{
+  if (m_textureCurrent->ReadyToRender())
+  { // save the current image, so it can fade out on its own clock
+    // the oldest texture is the most faded out, so kill that one off first
+    if (m_fadingTextures.size() >= MAX_FADING_TEXTURES)
+      m_fadingTextures.erase(m_fadingTextures.begin());
+
+    m_fadingTextures.emplace_back(
+        std::make_unique<CFadingTexture>(m_textureCurrent.get(), m_currentFadeTime));
+  }
+
+  std::swap(m_textureCurrent, m_textureNext);
+  std::swap(m_nameCurrent, m_nameNext);
+
+  m_nameNext = "";
+  m_textureNext->SetFileName("");
+
+  m_currentFadeTime = 0;
   m_isTransitioning = false;
 
   MarkDirtyRegion();
 }
 
-void CGUIImage::ProcessFadingTransition(unsigned int currentTime)
+void CGUIImage::ProcessFades(unsigned int currentTime, unsigned int frameTime)
 {
-  unsigned int frameTime = 0;
-  if (m_lastRenderTime)
-    frameTime = currentTime - m_lastRenderTime;
-  if (!frameTime)
-    frameTime = (unsigned int)(1000 / CServiceBroker::GetWinSystem()->GetGfxContext().GetFPS());
-  m_lastRenderTime = currentTime;
+  if (!m_fadingTextures.empty())
+  { // have some fading images
+    // anything other than the last old texture needs to be faded out as per usual
+    for (auto i = m_fadingTextures.begin(); i != m_fadingTextures.end() - 1;)
+    {
+      if (!ProcessFading(**i, frameTime, currentTime))
+        i = m_fadingTextures.erase(i);
+      else
+        ++i;
+    }
 
-  m_currentFadeTime += frameTime;
-  if (m_currentFadeTime > m_crossFadeTime ||
-      frameTime == 0) // for if we allocate straight away on creation
-    m_currentFadeTime = m_crossFadeTime;
+    if (m_textureCurrent->ReadyToRender() || m_textureCurrent->GetFileName().empty())
+    { // fade out the last one as well
+      if (!ProcessFading(*m_fadingTextures.back(), frameTime, currentTime))
+        m_fadingTextures.pop_back();
+    }
+    else
+    { // keep the last one fading in
+      CFadingTexture& texture = *m_fadingTextures.back();
+      texture.m_fadeTime += frameTime;
+      if (texture.m_fadeTime > m_crossFadeTime)
+        texture.m_fadeTime = m_crossFadeTime;
 
-  if (m_currentFadeTime < m_crossFadeTime)
-  {
-    m_textureCurrent->SetAlpha(GetFadeLevel(m_crossFadeTime - m_currentFadeTime));
-
-    m_textureNext->SetAlpha(GetFadeLevel(m_currentFadeTime));
-    m_textureNext->Process(currentTime);
+      if (texture.m_texture->SetAlpha(GetFadeLevel(texture.m_fadeTime)))
+        MarkDirtyRegion();
+      if (texture.m_texture->SetDiffuseColor(m_diffuseColor))
+        MarkDirtyRegion();
+      if (texture.m_texture->Process(currentTime))
+        MarkDirtyRegion();
+    }
   }
-  else
-  {
-    std::swap(m_textureCurrent, m_textureNext);
-    std::swap(m_nameCurrent, m_nameNext);
 
-    m_textureCurrent->SetAlpha(0xff);
-
-    m_nameNext = "";
-    m_textureNext->SetFileName("");
-
-    m_currentFadeTime = 0;
-    m_isTransitioning = false;
+  if (m_textureCurrent->ReadyToRender() || m_textureCurrent->GetFileName().empty())
+  { // fade the new one in
+    m_currentFadeTime += frameTime;
+    if (m_currentFadeTime > m_crossFadeTime ||
+        frameTime == 0) // for if we allocate straight away on creation
+      m_currentFadeTime = m_crossFadeTime;
   }
 
-  m_textureCurrent->Process(currentTime);
+  if (m_textureCurrent->SetAlpha(GetFadeLevel(m_currentFadeTime)))
+    MarkDirtyRegion();
+}
 
-  MarkDirtyRegion();
+bool CGUIImage::ProcessFading(CFadingTexture& texture,
+                              unsigned int frameTime,
+                              unsigned int currentTime)
+{
+  if (texture.m_fadeTime <= frameTime)
+  { // time to kill off the texture
+    MarkDirtyRegion();
+    return false;
+  }
+  // render this texture
+  texture.m_fadeTime -= frameTime;
+
+  if (texture.m_texture->SetAlpha(GetFadeLevel(texture.m_fadeTime)))
+    MarkDirtyRegion();
+  if (texture.m_texture->SetDiffuseColor(m_diffuseColor))
+    MarkDirtyRegion();
+  if (texture.m_texture->Process(currentTime))
+    MarkDirtyRegion();
+
+  return true;
 }
 
 void CGUIImage::Render()
@@ -324,11 +350,11 @@ void CGUIImage::Render()
   if (!IsVisible())
     return;
 
-  m_textureCurrent->Render();
+  // what is left of the old images hides behind the new one
+  for (const auto& fadingTexture : m_fadingTextures)
+    fadingTexture->m_texture->Render();
 
-  // incoming above outgoing (v21), so a fading-out tail hides behind the new image
-  if (m_isTransitioning)
-    m_textureNext->Render();
+  m_textureCurrent->Render();
 
   CGUIControl::Render();
 }
@@ -370,6 +396,8 @@ void CGUIImage::AllocResources()
 
 void CGUIImage::FreeTextures(bool immediately /* = false */)
 {
+  m_fadingTextures.clear();
+
   m_textureNext->FreeResources(immediately);
   m_textureNext->SetFileName("");
   m_nameNext = "";
@@ -434,8 +462,8 @@ CRect CGUIImage::CalcRenderRegion() const
 {
   CRect region = m_textureCurrent->GetRenderRect();
 
-  if (m_isTransitioning && m_textureNext->ReadyToRender())
-    region.Union(m_textureNext->GetRenderRect());
+  for (const auto& fadingTexture : m_fadingTextures)
+    region.Union(fadingTexture->m_texture->GetRenderRect());
 
   return CGUIControl::CalcRenderRegion().Intersect(region);
 }

--- a/xbmc/guilib/GUIImage.h
+++ b/xbmc/guilib/GUIImage.h
@@ -37,7 +37,6 @@ public:
       m_texture.reset(texture->Clone());
       m_texture->AllocResources();
       m_fadeTime = fadeTime;
-      m_fading = false;
     };
     ~CFadingTexture()
     {
@@ -45,8 +44,7 @@ public:
     };
 
     std::unique_ptr<CGUITexture> m_texture; ///< texture to fade out
-    unsigned int m_fadeTime; ///< time to fade out (ms)
-    bool         m_fading;   ///< whether we're fading out
+    unsigned int m_fadeTime; ///< time left to fade out (ms)
 
   private:
     CFadingTexture(const CFadingTexture&) = delete;
@@ -101,9 +99,10 @@ protected:
   std::string GetFallback(const std::string& currentName);
   void ProcessState();
   void ProcessAllocation();
-  void ProcessNoTransition(unsigned int currentTime);
-  void ProcessInstantTransition(unsigned int currentTime);
-  void ProcessFadingTransition(unsigned int currentTime);
+  void ProcessInstantTransition();
+  void StartFadeTransition();
+  void ProcessFades(unsigned int currentTime, unsigned int frameTime);
+  bool ProcessFading(CFadingTexture& texture, unsigned int frameTime, unsigned int currentTime);
 
   /*!
    * \brief Update the diffuse color based on the current item infos
@@ -125,6 +124,10 @@ protected:
 
   std::unique_ptr<CGUITexture> m_textureCurrent;
   std::unique_ptr<CGUITexture> m_textureNext;
+
+  // bounded, so fast image changes can't pile up textures
+  static constexpr size_t MAX_FADING_TEXTURES = 2;
+  std::vector<std::unique_ptr<CFadingTexture>> m_fadingTextures; ///< fading out, oldest first
 
   std::string m_nameCurrent{};
   std::string m_nameNext{};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
A new image requested during a crossfade cuts the running fade short, snapping the more visible texture to full alpha. A replaced image instead finishes its fade out on its own clock while the newest one fades in as usual.

Outgoing textures are capped at two. Outside of overlapping fades it is the same two textures as before, and at most one image loads at a time.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Regression from #28515, reported in the forum since the 20260728 nightly. Fadetime seems to have no effect and backgrounds flicker while scrolling. https://forum.kodi.tv/showthread.php?tid=388039

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built on current master, tested in Estuary and my own skin. Test build in the forum thread, the reporter confirms it is fixed.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Crossfades respect fadetime again.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
