### PR TITLE
[GUI] Fix fixedlist PageUp/PageDown to use the count of fully visible…

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -29,6 +29,7 @@
 #include "utils/StringUtils.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
+#include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
 #include <algorithm>
@@ -70,6 +71,10 @@ CGUIBaseContainer::CGUIBaseContainer(int parentID,
   m_offset = 0;
   m_lastHoldTime = 0;
   m_itemsPerPage = 10;
+  m_pageSize = 10;
+  m_hasScreenRange = false;
+  m_screenStart = 0.0f;
+  m_screenEnd = 0.0f;
   m_pageControl = 0;
   m_orientation = orientation;
   m_analogScrollCount = 0;
@@ -92,6 +97,10 @@ CGUIBaseContainer::CGUIBaseContainer(const CGUIBaseContainer& other)
     m_lastHoldTime(other.m_lastHoldTime),
     m_orientation(other.m_orientation),
     m_itemsPerPage(other.m_itemsPerPage),
+    m_pageSize(other.m_pageSize),
+    m_hasScreenRange(other.m_hasScreenRange),
+    m_screenStart(other.m_screenStart),
+    m_screenEnd(other.m_screenEnd),
     m_pageControl(other.m_pageControl),
     m_layoutCondition(other.m_layoutCondition),
     m_focusedLayoutCondition(other.m_focusedLayoutCondition),
@@ -1042,7 +1051,7 @@ void CGUIBaseContainer::SetPageControlRange()
 {
   if (m_pageControl)
   {
-    CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), m_pageControl, m_itemsPerPage, GetRows());
+    CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), m_pageControl, GetPageSize(), GetRows());
     SendWindowMessage(msg);
     m_lastPageControlOffset.reset(); // invalidate cache when range changes
   }
@@ -1187,7 +1196,11 @@ void CGUIBaseContainer::CalculateLayout()
   if (oldLayout == m_layout && oldFocusedLayout == m_focusedLayout)
     return; // nothing has changed, so don't update stuff
 
-  m_itemsPerPage = std::max((int)((Size() - m_focusedLayout->Size(m_orientation)) / m_layout->Size(m_orientation)) + 1, 1);
+  m_itemsPerPage = std::max(static_cast<int>((Size() - m_focusedLayout->Size(m_orientation)) /
+                                             m_layout->Size(m_orientation)) +
+                                1,
+                            1);
+  CalculatePageSize();
 
   // Pre-allocate render items vector to avoid per-frame allocations
   m_renderItems.reserve(m_itemsPerPage + m_cacheItems * 2 + 1);
@@ -1491,7 +1504,10 @@ std::string CGUIBaseContainer::GetLabel(int info) const
   switch (info)
   {
   case CONTAINER_NUM_PAGES:
-    label = std::to_string((GetRows() + m_itemsPerPage - 1) / m_itemsPerPage);
+  {
+    const int pageSize = GetPageSize();
+    label = std::to_string((GetRows() + pageSize - 1) / pageSize);
+  }
     break;
   case CONTAINER_CURRENT_PAGE:
     label = std::to_string(GetCurrentPage());
@@ -1537,9 +1553,107 @@ std::string CGUIBaseContainer::GetLabel(int info) const
 
 int CGUIBaseContainer::GetCurrentPage() const
 {
-  if (GetOffset() + m_itemsPerPage >= (int)GetRows())  // last page
-    return (GetRows() + m_itemsPerPage - 1) / m_itemsPerPage;
-  return GetOffset() / m_itemsPerPage + 1;
+  const int pageSize = GetPageSize();
+  if (GetOffset() + pageSize >= static_cast<int>(GetRows())) // last page
+    return (GetRows() + pageSize - 1) / pageSize;
+  return GetOffset() / pageSize + 1;
+}
+
+int CGUIBaseContainer::GetPageSize() const
+{
+  return m_pageSize;
+}
+
+void CGUIBaseContainer::CalculatePageSize()
+{
+  CalculateScreenRange();
+
+  if (!m_layout || !m_focusedLayout)
+  {
+    m_pageSize = std::max(m_itemsPerPage, 1);
+    return;
+  }
+
+  const float listStart = (m_orientation == HORIZONTAL) ? m_posX : m_posY;
+  const float listSize = (m_orientation == HORIZONTAL) ? m_width : m_height;
+  const float itemSize = m_layout->Size(m_orientation);
+  const float focusedItemSize = m_focusedLayout->Size(m_orientation);
+  if (itemSize <= 0.0f || focusedItemSize <= 0.0f)
+  {
+    m_pageSize = 1;
+    return;
+  }
+
+  float screenStart = 0.0f;
+  float screenEnd = 0.0f;
+  if (!GetScreenRange(screenStart, screenEnd))
+  {
+    m_pageSize = std::max(m_itemsPerPage, 1);
+    return;
+  }
+
+  const float visibleStart = std::max(0.0f, screenStart - listStart);
+  const float visibleEnd = std::min(listSize, screenEnd - listStart);
+
+  float itemStart = 0.0f;
+  int pageSize = 0;
+
+  for (int cursor = 0; cursor < m_itemsPerPage; ++cursor)
+  {
+    const float layoutSize = (cursor == GetCursor()) ? focusedItemSize : itemSize;
+    const float itemEnd = itemStart + layoutSize;
+
+    if (itemStart >= visibleStart && itemEnd <= visibleEnd)
+      ++pageSize;
+
+    itemStart = itemEnd;
+  }
+
+  m_pageSize = std::max(pageSize, 1);
+}
+
+bool CGUIBaseContainer::CalculateScreenRange()
+{
+  const CWinSystemBase* winSystem = CServiceBroker::GetWinSystem();
+  if (!winSystem)
+  {
+    m_hasScreenRange = false;
+    m_screenStart = 0.0f;
+    m_screenEnd = 0.0f;
+    return false;
+  }
+
+  const CGraphicContext& gfxContext = winSystem->GetGfxContext();
+  m_screenStart = 0.0f;
+  m_screenEnd = (m_orientation == HORIZONTAL) ? gfxContext.GetWidth() : gfxContext.GetHeight();
+
+  if (m_orientation == HORIZONTAL)
+  {
+    float y = m_posY;
+    gfxContext.InvertFinalCoords(m_screenStart, y);
+    y = m_posY + m_height;
+    gfxContext.InvertFinalCoords(m_screenEnd, y);
+  }
+  else
+  {
+    float x = m_posX;
+    gfxContext.InvertFinalCoords(x, m_screenStart);
+    x = m_posX + m_width;
+    gfxContext.InvertFinalCoords(x, m_screenEnd);
+  }
+
+  if (m_screenStart > m_screenEnd)
+    std::swap(m_screenStart, m_screenEnd);
+
+  m_hasScreenRange = true;
+  return true;
+}
+
+bool CGUIBaseContainer::GetScreenRange(float& screenStart, float& screenEnd) const
+{
+  screenStart = m_screenStart;
+  screenEnd = m_screenEnd;
+  return m_hasScreenRange;
 }
 
 void CGUIBaseContainer::GetCacheOffsets(int &cacheBefore, int &cacheAfter) const

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -29,6 +29,7 @@
 #include "utils/StringUtils.h"
 #include "utils/TimeUtils.h"
 #include "utils/log.h"
+#include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
 #include <algorithm>
@@ -1042,7 +1043,7 @@ void CGUIBaseContainer::SetPageControlRange()
 {
   if (m_pageControl)
   {
-    CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), m_pageControl, m_itemsPerPage, GetRows());
+    CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), m_pageControl, GetPageSize(), GetRows());
     SendWindowMessage(msg);
     m_lastPageControlOffset.reset(); // invalidate cache when range changes
   }
@@ -1491,7 +1492,10 @@ std::string CGUIBaseContainer::GetLabel(int info) const
   switch (info)
   {
   case CONTAINER_NUM_PAGES:
-    label = std::to_string((GetRows() + m_itemsPerPage - 1) / m_itemsPerPage);
+  {
+    const int pageSize = GetPageSize();
+    label = std::to_string((GetRows() + pageSize - 1) / pageSize);
+  }
     break;
   case CONTAINER_CURRENT_PAGE:
     label = std::to_string(GetCurrentPage());
@@ -1537,9 +1541,78 @@ std::string CGUIBaseContainer::GetLabel(int info) const
 
 int CGUIBaseContainer::GetCurrentPage() const
 {
-  if (GetOffset() + m_itemsPerPage >= (int)GetRows())  // last page
-    return (GetRows() + m_itemsPerPage - 1) / m_itemsPerPage;
-  return GetOffset() / m_itemsPerPage + 1;
+  const int pageSize = GetPageSize();
+  if (GetOffset() + pageSize >= (int)GetRows()) // last page
+    return (GetRows() + pageSize - 1) / pageSize;
+  return GetOffset() / pageSize + 1;
+}
+
+int CGUIBaseContainer::GetPageSize() const
+{
+  if (!m_layout || !m_focusedLayout)
+    return std::max(m_itemsPerPage, 1);
+
+  const float listStart = (m_orientation == HORIZONTAL) ? m_posX : m_posY;
+  const float listSize = (m_orientation == HORIZONTAL) ? m_width : m_height;
+  const float itemSize = m_layout->Size(m_orientation);
+  const float focusedItemSize = m_focusedLayout->Size(m_orientation);
+  if (itemSize <= 0.0f || focusedItemSize <= 0.0f)
+    return 1;
+
+  float screenStart = 0.0f;
+  float screenEnd = 0.0f;
+  if (!GetScreenRange(screenStart, screenEnd))
+    return std::max(m_itemsPerPage, 1);
+
+  const float visibleStart = std::max(0.0f, screenStart - listStart);
+  const float visibleEnd = std::min(listSize, screenEnd - listStart);
+
+  float itemStart = 0.0f;
+  int pageSize = 0;
+
+  for (int cursor = 0; cursor < m_itemsPerPage; ++cursor)
+  {
+    const float layoutSize = (cursor == GetCursor()) ? focusedItemSize : itemSize;
+    const float itemEnd = itemStart + layoutSize;
+
+    if (itemStart >= visibleStart && itemEnd <= visibleEnd)
+      ++pageSize;
+
+    itemStart = itemEnd;
+  }
+
+  return std::max(pageSize, 1);
+}
+
+bool CGUIBaseContainer::GetScreenRange(float& screenStart, float& screenEnd) const
+{
+  const CWinSystemBase* winSystem = CServiceBroker::GetWinSystem();
+  if (!winSystem)
+    return false;
+
+  const CGraphicContext& gfxContext = winSystem->GetGfxContext();
+  screenStart = 0.0f;
+  screenEnd = (m_orientation == HORIZONTAL) ? gfxContext.GetWidth() : gfxContext.GetHeight();
+
+  if (m_orientation == HORIZONTAL)
+  {
+    float y = m_posY;
+    gfxContext.InvertFinalCoords(screenStart, y);
+    y = m_posY + m_height;
+    gfxContext.InvertFinalCoords(screenEnd, y);
+  }
+  else
+  {
+    float x = m_posX;
+    gfxContext.InvertFinalCoords(x, screenStart);
+    x = m_posX + m_width;
+    gfxContext.InvertFinalCoords(x, screenEnd);
+  }
+
+  if (screenStart > screenEnd)
+    std::swap(screenStart, screenEnd);
+
+  return true;
 }
 
 void CGUIBaseContainer::GetCacheOffsets(int &cacheBefore, int &cacheAfter) const

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -130,6 +130,24 @@ protected:
   virtual void Reset();
   virtual size_t GetNumItems() const { return m_items.size(); }
   virtual int GetCurrentPage() const;
+  /*!
+   * \brief Get the number of fully visible items in the container area.
+   * \note Use for page navigation, not for layout/rendering where partially visible items matter.
+   * \return Cached number of items fully visible in the current viewport when the screen range can
+   *         be determined. Falls back to the calculated item count, which can include partially
+   *         visible items.
+   */
+  int GetPageSize() const;
+  /*! \brief Calculate and cache the page navigation size. */
+  void CalculatePageSize();
+  /*! \brief Calculate and cache the visible screen range for this container. */
+  virtual bool CalculateScreenRange();
+  /*! \brief Get the visible screen range for this container's scroll orientation in skin coordinates.
+   \param screenStart start of the visible screen range.
+   \param screenEnd end of the visible screen range.
+   \return true if the cached screen range was determined, false otherwise.
+   */
+  bool GetScreenRange(float& screenStart, float& screenEnd) const;
   bool InsideLayout(const CGUIListItemLayout *layout, const CPoint &point) const;
   void OnFocus() override;
   void OnUnFocus() override;
@@ -146,7 +164,11 @@ protected:
   unsigned int m_lastHoldTime;
 
   ORIENTATION m_orientation;
-  int m_itemsPerPage;
+  int m_itemsPerPage; ///< \brief number of layout slots in the container area, including partial slots
+  int m_pageSize; ///< \brief cached number of fully visible items used for page navigation
+  bool m_hasScreenRange;
+  float m_screenStart;
+  float m_screenEnd;
 
   std::vector<std::shared_ptr<CGUIListItem>> m_items;
   typedef std::vector<std::shared_ptr<CGUIListItem>>::iterator iItems;

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -130,6 +130,17 @@ protected:
   virtual void Reset();
   virtual size_t GetNumItems() const { return m_items.size(); }
   virtual int GetCurrentPage() const;
+  /*! \brief Get the number of fully visible items in the current page.
+   \return number of items fully visible in the current viewport, or the calculated item count if
+   the screen range cannot be determined.
+   */
+  int GetPageSize() const;
+  /*! \brief Get the visible screen range for this container's scroll orientation in skin coordinates.
+   \param screenStart start of the visible screen range.
+   \param screenEnd end of the visible screen range.
+   \return true if the screen range was determined, false otherwise.
+   */
+  virtual bool GetScreenRange(float& screenStart, float& screenEnd) const;
   bool InsideLayout(const CGUIListItemLayout *layout, const CPoint &point) const;
   void OnFocus() override;
   void OnUnFocus() override;

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -12,6 +12,7 @@
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 
+#include <algorithm>
 #include <functional>
 
 CGUIFixedListContainer::CGUIFixedListContainer(int parentID,
@@ -47,13 +48,13 @@ bool CGUIFixedListContainer::OnAction(const CAction &action)
   {
   case ACTION_PAGE_UP:
     {
-      Scroll(-m_itemsPerPage);
+      Scroll(-GetPageSize());
       return true;
     }
     break;
   case ACTION_PAGE_DOWN:
     {
-      Scroll(m_itemsPerPage);
+      Scroll(GetPageSize());
       return true;
     }
     break;
@@ -292,15 +293,17 @@ bool CGUIFixedListContainer::HasPreviousPage() const
 
 bool CGUIFixedListContainer::HasNextPage() const
 {
-  return (GetOffset() < (int)m_items.size() - m_itemsPerPage && (int)m_items.size() >= m_itemsPerPage);
+  return (GetOffset() < static_cast<int>(m_items.size()) - GetPageSize() &&
+          static_cast<int>(m_items.size()) >= GetPageSize());
 }
 
 int CGUIFixedListContainer::GetCurrentPage() const
 {
+  const int pageSize = GetPageSize();
   int offset = CorrectOffset(GetOffset(), GetCursor());
-  if (offset + m_itemsPerPage - GetCursor() >= (int)GetRows())  // last page
-    return (GetRows() + m_itemsPerPage - 1) / m_itemsPerPage;
-  return offset / m_itemsPerPage + 1;
+  if (offset + pageSize - GetCursor() >= static_cast<int>(GetRows())) // last page
+    return (GetRows() + pageSize - 1) / pageSize;
+  return offset / pageSize + 1;
 }
 
 void CGUIFixedListContainer::GetCursorRange(int &minCursor, int &maxCursor) const

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -12,6 +12,7 @@
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 
+#include <algorithm>
 #include <functional>
 
 CGUIFixedListContainer::CGUIFixedListContainer(int parentID,
@@ -47,13 +48,13 @@ bool CGUIFixedListContainer::OnAction(const CAction &action)
   {
   case ACTION_PAGE_UP:
     {
-      Scroll(-m_itemsPerPage);
+      Scroll(-GetPageSize());
       return true;
     }
     break;
   case ACTION_PAGE_DOWN:
     {
-      Scroll(m_itemsPerPage);
+      Scroll(GetPageSize());
       return true;
     }
     break;
@@ -292,15 +293,17 @@ bool CGUIFixedListContainer::HasPreviousPage() const
 
 bool CGUIFixedListContainer::HasNextPage() const
 {
-  return (GetOffset() < (int)m_items.size() - m_itemsPerPage && (int)m_items.size() >= m_itemsPerPage);
+  return (GetOffset() < (int)m_items.size() - GetPageSize() &&
+          (int)m_items.size() >= GetPageSize());
 }
 
 int CGUIFixedListContainer::GetCurrentPage() const
 {
+  const int pageSize = GetPageSize();
   int offset = CorrectOffset(GetOffset(), GetCursor());
-  if (offset + m_itemsPerPage - GetCursor() >= (int)GetRows())  // last page
-    return (GetRows() + m_itemsPerPage - 1) / m_itemsPerPage;
-  return offset / m_itemsPerPage + 1;
+  if (offset + pageSize - GetCursor() >= (int)GetRows()) // last page
+    return (GetRows() + pageSize - 1) / pageSize;
+  return offset / pageSize + 1;
 }
 
 void CGUIFixedListContainer::GetCursorRange(int &minCursor, int &maxCursor) const

--- a/xbmc/guilib/test/CMakeLists.txt
+++ b/xbmc/guilib/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES TestGUIControlFactory.cpp
             TestGamesGUIInfo.cpp
+            TestGUIFixedListContainer.cpp
             TestGUILabel.cpp
             TestGUITextLayout.cpp
             TestSkinMapManager.cpp

--- a/xbmc/guilib/test/CMakeLists.txt
+++ b/xbmc/guilib/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES TestGUIControlFactory.cpp
             TestGamesGUIInfo.cpp
+            TestGUIFixedListContainer.cpp
             TestGUILabel.cpp
             TestGUITextLayout.cpp
             TestGUIWindowOnAction.cpp

--- a/xbmc/guilib/test/TestGUIFixedListContainer.cpp
+++ b/xbmc/guilib/test/TestGUIFixedListContainer.cpp
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "guilib/GUIFixedListContainer.h"
+#include "guilib/GUIListItem.h"
+#include "guilib/GUIListItemLayout.h"
+#include "input/actions/Action.h"
+#include "input/actions/ActionIDs.h"
+
+#include <gtest/gtest.h>
+
+class TestGUIFixedListContainer : public CGUIFixedListContainer
+{
+public:
+  TestGUIFixedListContainer(float left,
+                            float width,
+                            float screenStart,
+                            float screenEnd,
+                            float itemWidth,
+                            float focusedItemWidth,
+                            int focusPosition)
+    : CGUIFixedListContainer(0,
+                             1,
+                             left,
+                             0,
+                             width,
+                             100,
+                             HORIZONTAL,
+                             CScroller(0),
+                             0,
+                             focusPosition,
+                             0,
+                             0,
+                             FixedListAlignY::CENTER),
+      m_screenStart(screenStart),
+      m_screenEnd(screenEnd)
+  {
+    m_layout = &m_layouts.emplace_back();
+    m_layout->SetWidth(itemWidth);
+    m_layout->SetHeight(100);
+
+    m_focusedLayout = &m_focusedLayouts.emplace_back();
+    m_focusedLayout->SetWidth(focusedItemWidth);
+    m_focusedLayout->SetHeight(100);
+  }
+
+  bool CalculateScreenRange() override
+  {
+    CGUIBaseContainer::m_screenStart = m_screenStart;
+    CGUIBaseContainer::m_screenEnd = m_screenEnd;
+    CGUIBaseContainer::m_hasScreenRange = true;
+    return true;
+  }
+
+  void AddItems(int count)
+  {
+    for (int i = 0; i < count; ++i)
+      m_items.emplace_back(std::make_shared<CGUIListItem>(std::to_string(i)));
+  }
+
+  int GetPageSizeForTest() const { return GetPageSize(); }
+
+  void PrepareForAction()
+  {
+    m_wasReset = true;
+    CalculatePageSize();
+  }
+
+private:
+  float m_screenStart;
+  float m_screenEnd;
+};
+
+TEST(TestGUIFixedListContainer, PageActionsUseVisiblePageSizeFromFixedCursor)
+{
+  for (int focusPosition = 1; focusPosition <= 4; ++focusPosition)
+  {
+    TestGUIFixedListContainer container(-100, 2200, 0, 1920, 300, 400, focusPosition);
+    container.AddItems(20);
+    container.PrepareForAction();
+
+    EXPECT_EQ(container.GetPageSizeForTest(), 5);
+    EXPECT_EQ(container.GetSelectedItem(), focusPosition);
+
+    EXPECT_TRUE(container.OnAction(CAction(ACTION_PAGE_DOWN)));
+    EXPECT_EQ(container.GetSelectedItem(), focusPosition + 5);
+
+    EXPECT_TRUE(container.OnAction(CAction(ACTION_PAGE_UP)));
+    EXPECT_EQ(container.GetSelectedItem(), focusPosition);
+  }
+}
+
+TEST(TestGUIFixedListContainer, PageActionsSkipPartiallyVisibleSlots)
+{
+  TestGUIFixedListContainer container(-100, 2000, 0, 1920, 400, 400, 1);
+  container.AddItems(20);
+  container.PrepareForAction();
+
+  EXPECT_EQ(container.GetPageSizeForTest(), 4);
+  EXPECT_EQ(container.GetSelectedItem(), 1);
+
+  EXPECT_TRUE(container.OnAction(CAction(ACTION_PAGE_DOWN)));
+  EXPECT_EQ(container.GetSelectedItem(), 5);
+}

--- a/xbmc/guilib/test/TestGUIFixedListContainer.cpp
+++ b/xbmc/guilib/test/TestGUIFixedListContainer.cpp
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "guilib/GUIFixedListContainer.h"
+#include "guilib/GUIListItem.h"
+#include "guilib/GUIListItemLayout.h"
+#include "input/actions/Action.h"
+#include "input/actions/ActionIDs.h"
+
+#include <gtest/gtest.h>
+
+class TestGUIFixedListContainer : public CGUIFixedListContainer
+{
+public:
+  TestGUIFixedListContainer(float left,
+                            float width,
+                            float screenStart,
+                            float screenEnd,
+                            float itemWidth,
+                            float focusedItemWidth,
+                            int focusPosition)
+    : CGUIFixedListContainer(0,
+                             1,
+                             left,
+                             0,
+                             width,
+                             100,
+                             HORIZONTAL,
+                             CScroller(0),
+                             0,
+                             focusPosition,
+                             0,
+                             0,
+                             FixedListAlignY::CENTER),
+      m_screenStart(screenStart),
+      m_screenEnd(screenEnd)
+  {
+    m_layout = &m_layouts.emplace_back();
+    m_layout->SetWidth(itemWidth);
+    m_layout->SetHeight(100);
+
+    m_focusedLayout = &m_focusedLayouts.emplace_back();
+    m_focusedLayout->SetWidth(focusedItemWidth);
+    m_focusedLayout->SetHeight(100);
+  }
+
+  bool GetScreenRange(float& screenStart, float& screenEnd) const override
+  {
+    screenStart = m_screenStart;
+    screenEnd = m_screenEnd;
+    return true;
+  }
+
+  void AddItems(int count)
+  {
+    for (int i = 0; i < count; ++i)
+      m_items.emplace_back(std::make_shared<CGUIListItem>(std::to_string(i)));
+  }
+
+  void PrepareForAction() { m_wasReset = true; }
+
+private:
+  float m_screenStart;
+  float m_screenEnd;
+};
+
+TEST(TestGUIFixedListContainer, PageActionsUseVisiblePageSizeFromFixedCursor)
+{
+  for (int focusPosition = 1; focusPosition <= 4; ++focusPosition)
+  {
+    TestGUIFixedListContainer container(0, 3840, 0, 1920, 317, 490, focusPosition);
+    container.AddItems(20);
+    container.PrepareForAction();
+
+    EXPECT_EQ(container.GetSelectedItem(), focusPosition);
+
+    EXPECT_TRUE(container.OnAction(CAction(ACTION_PAGE_DOWN)));
+    EXPECT_EQ(container.GetSelectedItem(), focusPosition + 5);
+
+    EXPECT_TRUE(container.OnAction(CAction(ACTION_PAGE_UP)));
+    EXPECT_EQ(container.GetSelectedItem(), focusPosition);
+  }
+}
+
+TEST(TestGUIFixedListContainer, PageActionsSkipPartiallyVisibleSlots)
+{
+  TestGUIFixedListContainer container(-150, 2131, 0, 1920, 370, 370, 1);
+  container.AddItems(20);
+  container.PrepareForAction();
+
+  EXPECT_EQ(container.GetSelectedItem(), 1);
+
+  EXPECT_TRUE(container.OnAction(CAction(ACTION_PAGE_DOWN)));
+  EXPECT_EQ(container.GetSelectedItem(), 5);
+}


### PR DESCRIPTION
…rendered items.

## Description
Fix fixedlist PageUp/PageDown navigation so it uses the number of fully visible rendered items instead of the configured `m_itemsPerPage` value.

The page size is now calculated from the actual item slots that are fully visible onscreen. The visible screen bounds are converted into Kodi GUI coordinates first, so the calculation remains correct when the window size, resolution, or aspect ratio changes.

The calculation also accounts for fixedlist controls that are positioned partially offscreen, focused layouts with different sizes, and partially clipped items at either edge of the screen.

## Motivation and context
Fixedlist page navigation could jump too far when a skin used an oversized or partially offscreen fixedlist. This caused PageUp/PageDown and page control behaviour to include items that were not fully rendered onscreen.

This fixes https://github.com/xbmc/xbmc/issues/28783.

## How has this been tested?
Tested locally on Windows 11 using a Win64/x64 Debug build configured with Visual Studio 2022.

Automated checks run:
- `clang-format --dry-run --Werror` on the changed C++ files
- `git -C C:\xbmc diff --check`
- `cmake --build C:\xbmc-build --target kodi-test --config Debug -- /m:1`
- `C:\xbmc-build\Debug\kodi-test.exe --gtest_filter=TestGUIFixedListContainer.*`
- `cmake --build C:\xbmc-build --target kodi --config Debug -- /m:1`

Added regression tests for:
- a poster-style fixedlist with a wider focused layout, where five items are fully visible
- a shift-style fixedlist with a negative `left` position, where only four items are fully visible

Manual testing was done in Kodi using Estuary viewtypes 51 and 53 at:
- 1920x1080 (16:9)
- 1280x720 (16:9)
- 1280x960 (4:3)
- 1280x548 (21:9)

Additional manual testing was done by changing skin viewtype sizes and positions to check that partially visible items were not included in the page jump.

## What is the effect on users?
PageUp/PageDown navigation in fixedlist views now jumps by the number of fully visible onscreen items. This prevents skipping past items when skins use oversized, scaled, or partially offscreen fixedlists.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed