### PR TITLE
Screencap rework part 4: bookmark worker

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -225,10 +225,19 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
     }
     else
     {
-      CLog::Log(LOGWARNING, "RendererDRMPRIMEGLES::Configure: limited-range "
-                            "YUV shader compile/link failed; OES path will "
-                            "be used regardless of user setting");
+      CLog::Log(LOGERROR, "RendererDRMPRIMEGLES::Configure: limited-range "
+                          "YUV shader compile/link failed");
     }
+  }
+
+  if (!m_yuvShader && winSystem->UseLimitedColor())
+  {
+    CLog::Log(LOGERROR,
+              "RendererDRMPRIMEGLES::Configure: fourcc {:#x} cannot be converted to limited "
+              "range; switching videoscreen.limitedrange off so the GUI matches the video",
+              sourceFourcc);
+    CServiceBroker::GetSettingsComponent()->GetSettings()->SetBool(
+        CSettings::SETTING_VIDEOSCREEN_LIMITEDRANGE, false);
   }
 
   winSystem->SetColorimetry(&picture);

--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -706,7 +706,9 @@ bool CFFmpegImage::CreateThumbnailFromSurface(unsigned char* bufferin, unsigned 
       break;
   }
   AVPixelFormat dstFmt = jpg_output ? AV_PIX_FMT_YUV420P : is16bit ? fmt16bit : AV_PIX_FMT_RGBA;
-  tdm.sws = sws_getContext(width, height, srcFmt, width, height, dstFmt, 0, 0, 0, 0);
+  // SWS_ACCURATE_RND skips RGB->YUV fast paths that ignore the range set below
+  tdm.sws = sws_getContext(width, height, srcFmt, width, height, dstFmt,
+                           jpg_output ? SWS_ACCURATE_RND : 0, nullptr, nullptr, nullptr);
   if (!tdm.sws)
   {
     CLog::Log(LOGERROR, "Could not setup scaling context for thumbnail: {}", destFile);

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -23,7 +23,6 @@
 
 class CGUIDialog;
 class CGUIMediaWindow;
-class CScreenShot;
 
 #ifdef TARGET_WINDOWS_STORE
 #pragma pack(push, 8)
@@ -51,7 +50,6 @@ class CGUIWindowManager : public KODI::MESSAGING::IMessageTarget
 {
   friend CGUIDialog;
   friend CGUIMediaWindow;
-  friend CScreenShot;
 
 public:
   CGUIWindowManager();

--- a/xbmc/pictures/Picture.cpp
+++ b/xbmc/pictures/Picture.cpp
@@ -64,7 +64,8 @@ bool CPicture::CreateThumbnailFromSurface(const unsigned char* buffer,
                                           unsigned int format,
                                           const ImageColorMetadata& color)
 {
-  CLog::Log(LOGDEBUG, "cached image '{}' size {}x{}", CURL::GetRedacted(thumbFile), width, height);
+  CLog::Log(LOGDEBUG, "encoding image '{}' size {}x{}", CURL::GetRedacted(thumbFile), width,
+            height);
 
   unsigned char *thumb = NULL;
   unsigned int thumbsize=0;

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -11,10 +11,7 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
-#include "guilib/GUIComponent.h"
-#include "guilib/GUIWindowManager.h"
 #include "guilib/TextureFormats.h"
-#include "messaging/ApplicationMessenger.h"
 #include "pictures/Picture.h"
 #include "rendering/capture/CaptureHandle.h"
 #include "rendering/capture/CapturePixels.h"
@@ -26,14 +23,10 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "settings/windows/GUIControlSettings.h"
-#include "threads/SystemClock.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
-#include <chrono>
 #include <memory>
-
-using namespace std::chrono_literals;
 
 std::vector<std::function<std::unique_ptr<IScreenshotSurface>()>> CScreenShot::m_screenShotSurfaces;
 
@@ -126,28 +119,6 @@ void CScreenShot::TakeScreenshot(const std::string& filename,
   auto handle = captureService->Submit(spec, [filename](const CaptureResult& result)
                                        { WriteCapture(result, filename); });
   handle->Detach();
-}
-
-bool CScreenShot::PumpForCapture(KODI::RENDERING::CAPTURE::CCaptureHandle& handle,
-                                 std::chrono::milliseconds timeout)
-{
-  using namespace KODI::RENDERING::CAPTURE;
-
-  const auto appMessenger = CServiceBroker::GetAppMessenger();
-  const bool processThread = appMessenger && appMessenger->IsProcessThread();
-  auto* gui = CServiceBroker::GetGUI();
-
-  XbmcThreads::EndTime<> deadline(timeout);
-  while (!deadline.IsTimePast())
-  {
-    if (handle.Wait(processThread ? 5ms : 50ms))
-      return true;
-    if (handle.GetState() == CaptureState::FAILED)
-      return false;
-    if (processThread && gui)
-      gui->GetWindowManager().ProcessRenderLoop(false);
-  }
-  return false;
 }
 
 namespace

--- a/xbmc/utils/Screenshot.cpp
+++ b/xbmc/utils/Screenshot.cpp
@@ -113,9 +113,8 @@ void CScreenShot::TakeScreenshot(const std::string& filename,
   spec.content = content;
   spec.format = CaptureFormat::NATIVE;
 
-  // the write runs on the service worker, and ONLY on a successful
-  // delivery (the callback never fires on failure), so a failed capture
-  // leaves no empty file behind
+  // failure dispatches an empty result because some consumers must act on
+  // it (a bookmark still writes its DB row); here WriteCapture declines it
   auto handle = captureService->Submit(spec, [filename](const CaptureResult& result)
                                        { WriteCapture(result, filename); });
   handle->Detach();

--- a/xbmc/utils/Screenshot.h
+++ b/xbmc/utils/Screenshot.h
@@ -11,16 +11,10 @@
 #include "IScreenshotSurface.h"
 #include "rendering/capture/CaptureTypes.h"
 
-#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
 #include <vector>
-
-namespace KODI::RENDERING::CAPTURE
-{
-class CCaptureHandle;
-}
 
 class CScreenShot
 {
@@ -41,15 +35,6 @@ public:
   //! rendered frame into two files in the configured folder
   //! (screenshotNNNNN.png and screenshotNNNNN-video.png).
   static void TakeScreenshotBoth();
-
-  //! \brief Block until a one-shot capture is delivered, returning true on
-  //! success. On the render/process thread the wait pumps real frames (a
-  //! plain wait there would starve the frame the capture needs); off-thread
-  //! it waits passively. Returns false as soon as the request fails.
-  //! Pumping calls the private CGUIWindowManager::ProcessRenderLoop; other
-  //! waiters (the bookmarks dialog) call this instead of becoming friends.
-  static bool PumpForCapture(KODI::RENDERING::CAPTURE::CCaptureHandle& handle,
-                             std::chrono::milliseconds timeout);
 
 private:
   static std::vector<std::function<std::unique_ptr<IScreenshotSurface>()>> m_screenShotSurfaces;

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -35,7 +35,6 @@
 #include "settings/SettingsComponent.h"
 #include "threads/SystemClock.h"
 #include "utils/Crc32.h"
-#include "utils/Screenshot.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
@@ -57,7 +56,6 @@
 #define CONTROL_THUMBS                11
 
 using namespace KODI::VIDEO;
-using namespace std::chrono_literals;
 
 CGUIDialogVideoBookmarks::CGUIDialogVideoBookmarks()
   : CGUIDialog(WINDOW_DIALOG_VIDEO_BOOKMARKS, "VideoOSDBookmarks.xml")
@@ -480,60 +478,76 @@ bool CGUIDialogVideoBookmarks::AddBookmark(CVideoInfoTag* tag)
 
   using namespace KODI::RENDERING::CAPTURE;
 
-  std::vector<uint8_t> pixels(height * width * 4);
-  bool hasImage = false;
-
   const auto captureService = CServiceBroker::GetCaptureService();
-  if (captureService)
-  {
-    CaptureSpec spec;
-    spec.content = CaptureContent::VIDEO;
-    spec.width = width;
-    spec.height = height;
-    // native depth so HDR passthrough sessions tonemap from full precision
-    spec.format = CaptureFormat::NATIVE;
-    const auto handle = captureService->Submit(spec);
-
-    // PumpForCapture lives on CScreenShot: it is the friend of CGUIWindowManager
-    if (CScreenShot::PumpForCapture(*handle, 1000ms))
-      hasImage = CaptureToBGRA(handle->GetResult(), width, height, pixels.data());
-  }
-
-  if (hasImage)
-  {
-    const std::shared_ptr<CProfileManager> profileManager = CServiceBroker::GetSettingsComponent()->GetProfileManager();
-
-    auto crc = Crc32::ComputeFromLowerCase(g_application.CurrentFileItem().GetDynPath());
-    bookmark.thumbNailImage =
-        StringUtils::Format("{:08x}_{}.jpg", crc, (int)bookmark.timeInSeconds);
-    bookmark.thumbNailImage = URIUtils::AddFileToFolder(profileManager->GetBookmarksThumbFolder(), bookmark.thumbNailImage);
-
-    if (!CPicture::CreateThumbnailFromSurface(pixels.data(), width, height, width * 4,
-                                              bookmark.thumbNailImage))
-    {
-      CLog::Log(LOGERROR, "CGUIDialogVideoBookmarks: failed to create thumbnail");
-      bookmark.thumbNailImage.clear();
-    }
-  }
-  else
-    CLog::Log(LOGERROR, "CGUIDialogVideoBookmarks: failed to capture video frame");
-
-  CVideoDatabase videoDatabase;
-  if (!videoDatabase.Open())
+  if (!captureService)
     return false;
 
-  if (tag)
-    videoDatabase.AddBookMarkForEpisode(*tag, bookmark);
-  else
-  {
-    const std::string path{g_application.CurrentFileItem().GetDynPath()};
-    videoDatabase.AddBookMarkToFile(path, bookmark, CBookmark::STANDARD);
+  // deterministic thumb path (file CRC + bookmark time), resolved here so the
+  // worker callback needs no g_application or profile access
+  const std::string dynPath{g_application.CurrentFileItem().GetDynPath()};
+  const std::shared_ptr<CProfileManager> profileManager =
+      CServiceBroker::GetSettingsComponent()->GetProfileManager();
+  bookmark.thumbNailImage = URIUtils::AddFileToFolder(
+      profileManager->GetBookmarksThumbFolder(),
+      StringUtils::Format("{:08x}_{}.jpg", Crc32::ComputeFromLowerCase(dynPath),
+                          (int)bookmark.timeInSeconds));
 
+  // player OSD markers are an in-memory player update; done on this thread so
+  // the marker shows at once and the worker touches no player state
+  if (!tag)
+  {
     std::vector<std::chrono::milliseconds> positions = appPlayer->GetBookmarks();
     CBookmark::AddToPositions(bookmark, positions);
     appPlayer->SetBookmarks(positions);
   }
-  videoDatabase.Close();
+
+  // tag is a caller local (episode list); copy it for the deferred callback
+  const bool episode{tag != nullptr};
+  CVideoInfoTag episodeTag;
+  if (episode)
+    episodeTag = *tag;
+
+  // convert (HDR tonemap), encode and the DB write run on the capture service
+  // worker, off the render thread; the render thread pays only the readback tap
+  CaptureSpec spec;
+  spec.content = CaptureContent::VIDEO;
+  spec.width = width;
+  spec.height = height;
+  // native depth so HDR passthrough sessions tonemap from full precision
+  spec.format = CaptureFormat::NATIVE;
+
+  auto handle = captureService->Submit(
+      spec,
+      [bookmark, width, height, dynPath, episode, episodeTag](const CaptureResult& result) mutable
+      {
+        std::vector<uint8_t> pixels(static_cast<size_t>(height) * width * 4);
+        const bool converted = CaptureToBGRA(result, width, height, pixels.data());
+        const bool encoded =
+            converted && CPicture::CreateThumbnailFromSurface(pixels.data(), width, height,
+                                                              width * 4, bookmark.thumbNailImage);
+        if (!encoded)
+        {
+          CLog::Log(LOGERROR, "CGUIDialogVideoBookmarks: failed to create bookmark thumbnail");
+          bookmark.thumbNailImage.clear();
+        }
+
+        CVideoDatabase videoDatabase;
+        if (videoDatabase.Open())
+        {
+          if (episode)
+            videoDatabase.AddBookMarkForEpisode(episodeTag, bookmark);
+          else
+            videoDatabase.AddBookMarkToFile(dynPath, bookmark, CBookmark::STANDARD);
+          videoDatabase.Close();
+        }
+
+        // an open bookmarks dialog reloads the now-written thumb on the app thread
+        if (auto* gui = CServiceBroker::GetGUI())
+          gui->GetWindowManager().SendThreadMessage(
+              CGUIMessage(GUI_MSG_REFRESH_LIST, 0, WINDOW_DIALOG_VIDEO_BOOKMARKS));
+      });
+  handle->Detach();
+
   return true;
 }
 


### PR DESCRIPTION
## Description

Requires #28664, #28660, #28567 (stacked on them here).

Part 4 of the capture rework. Moves bookmark thumbnail creation off the render thread: `AddBookmark` submits the video capture with a completion callback that runs the convert (HDR->SDR tonemap), encode and db write on the capture service worker, so the render thread only pays the readback tap.

Two range fixes:
-  RendererDRMPRIMEGLES::Configure automatically now turns videoscreen.limitedrange off when the source has no per-plane import (P030, NV15, etc depending on hw) - the OES-external sampler only emits full range.  the limited-range support from DRMPRIME-GLES depends on using shader which was failing, so disable it when that path fails.
- CreateThumbnailFromSurface passes SWS_ACCURATE_RND: swscale's unscaled RGB->YUV fast paths hardcode limited range; some ffmpeg implementations were squeezing the range.

## Motivation and Context
On 4K HDR passthrough the thumbnail tonemap is ~2 s; run inline it stalled the decoder and cascaded dropped frames. Off-thread it produces the same thumbnail with none.

## How Has This Been Tested?
Built; ctrl-b bookmark on SDR 1080p and 4K HDR clips. Per-bookmark render-thread cost ~2 s -> ~10 ms (readback tap only), no dropped frames, thumbnails unchanged. Tested on Intel N250/GBM/GLES/VAAPI, and separately on RPi4/DRMPRIME.

## What is the effect on users?
Bookmarks no longer causes many seconds of video glitches and dropped frames.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
