### PR TITLE
[depends][target][python] build as a real iOS platform

### DIFF
--- a/tools/depends/Makefile.include.in
+++ b/tools/depends/Makefile.include.in
@@ -31,6 +31,10 @@ SHA256SUM=@SHA256SUM@
 SHASUM=@SHASUM@
 HASH_TOOL_FLAGS=-c --status
 
+ifeq ($(findstring apple-darwin,@use_host@),apple-darwin)
+  APPLE_DEPLOYMENT_TARGET=@target_minver@
+endif
+
 HAS_ZLIB=@has_zlib@
 NEED_LIBICONV=@need_libiconv@
 LINK_ICONV=@link_iconv@

--- a/tools/depends/target/python3/16-ios-platform.patch
+++ b/tools/depends/target/python3/16-ios-platform.patch
@@ -1,0 +1,142 @@
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
+@@ -317,39 +317,7 @@ then
+        # ac_sys_system and ac_sys_release are used for setting
+        # a lot of different things including 'define_xopen_source'
+        # in the case statement below.
+-	case "$host" in
+-	*-*-linux-android*)
+-		ac_sys_system=Linux-android
+-		;;
+-	*-*-linux*)
+-		ac_sys_system=Linux
+-		;;
+-	*-*-darwin*)
+-		ac_sys_system=Darwin
+-		;;
+-	*-*-cygwin*)
+-		ac_sys_system=Cygwin
+-		;;
+-	*-apple-ios*)
+-		ac_sys_system=iOS
+-		;;
+-	*-*-darwin*)
+-		ac_sys_system=Darwin
+-		;;
+-	*-*-vxworks*)
+-	    ac_sys_system=VxWorks
+-	    ;;
+-	*-*-emscripten)
+-	    ac_sys_system=Emscripten
+-	    ;;
+-	*-*-wasi*)
+-	    ac_sys_system=WASI
+-	    ;;
+-	*)
+-		# for now, limit cross builds to known configurations
+-		MACHDEP="unknown"
+-		AC_MSG_ERROR([cross build not supported for $host])
+-	esac
++	ac_sys_system=iOS
+ 	ac_sys_release=
+     else
+ 	ac_sys_system=`uname -s`
+@@ -570,7 +538,6 @@ AC_ARG_ENABLE([framework],
+ 	case $enableval in
+ 	no)
+ 		case $ac_sys_system in
+-			iOS) AC_MSG_ERROR([iOS builds must use --enable-framework]) ;;
+ 			*)
+ 				PYTHONFRAMEWORK=
+ 				PYTHONFRAMEWORKDIR=no-framework
+@@ -680,7 +647,6 @@ AC_ARG_ENABLE([framework],
+ 		esac
+ 	],[
+ 	case $ac_sys_system in
+-		iOS) AC_MSG_ERROR([iOS builds must use --enable-framework]) ;;
+ 		*)
+ 			PYTHONFRAMEWORK=
+ 			PYTHONFRAMEWORKDIR=no-framework
+@@ -764,29 +730,9 @@ AC_SUBST([APP_STORE_COMPLIANCE_PATCH])
+ 
+ AC_SUBST([_PYTHON_HOST_PLATFORM])
+ if test "$cross_compiling" = yes; then
+-	case "$host" in
+-	*-*-linux*)
+-		case "$host_cpu" in
+-		arm*)
+-			_host_ident=arm
+-			;;
+-		*)
+-			_host_ident=$host_cpu
+-		esac
+-		;;
+-	*-*-cygwin*)
+-		_host_ident=
+-		;;
+-	*-*-darwin*)
+-		;;
+-	*-apple-ios*)
+-		_host_os=`echo $host | cut -d '-' -f3`
+-		_host_device=`echo $host | cut -d '-' -f4`
+-		_host_device=${_host_device:=os}
+ 
+ 		# IPHONEOS_DEPLOYMENT_TARGET is the minimum supported iOS version
+ 		AC_MSG_CHECKING([iOS deployment target])
+-		IPHONEOS_DEPLOYMENT_TARGET=$(echo ${_host_os} | cut -c4-)
+ 		IPHONEOS_DEPLOYMENT_TARGET=${IPHONEOS_DEPLOYMENT_TARGET:=13.0}
+ 		AC_MSG_RESULT([$IPHONEOS_DEPLOYMENT_TARGET])
+ 
+@@ -798,30 +744,6 @@ if test "$cross_compiling" = yes; then
+ 				_host_ident=${IPHONEOS_DEPLOYMENT_TARGET}-$host_cpu-iphone${_host_device}
+ 				;;
+ 		esac
+-		;;
+-	*-*-darwin*)
+-		case "$host_cpu" in
+-		arm*)
+-			_host_ident=arm
+-			;;
+-		*)
+-			_host_ident=$host_cpu
+-		esac
+-		;;
+-	*-*-vxworks*)
+-		_host_ident=$host_cpu
+-		;;
+-	*-*-emscripten)
+-		_host_ident=$(emcc -dumpversion | cut -f1 -d-)-$host_cpu
+-		;;
+-	wasm32-*-* | wasm64-*-*)
+-		_host_ident=$host_cpu
+-		;;
+-	*)
+-		# for now, limit cross builds to known configurations
+-		MACHDEP="unknown"
+-		AC_MSG_ERROR([cross build not supported for $host])
+-	esac
+ 	_PYTHON_HOST_PLATFORM="$MACHDEP${_host_ident:+-$_host_ident}"
+ fi
+ 
+@@ -3658,7 +3580,7 @@ then
+ 			fi
+ 			LINKFORSHARED="$LINKFORSHARED"
+ 		elif test $ac_sys_system = "iOS"; then
+-			LINKFORSHARED="-Wl,-stack_size,$stack_size $LINKFORSHARED "'$(PYTHONFRAMEWORKDIR)/$(PYTHONFRAMEWORK)'
++			LINKFORSHARED="-Wl,-stack_size,$stack_size $LINKFORSHARED "
+ 		fi
+ 		;;
+ 	OpenUNIX*|UnixWare*) LINKFORSHARED="-Wl,-Bexport";;
+diff --git a/Lib/_ios_support.py b/Lib/_ios_support.py
+--- a/Lib/_ios_support.py
++++ b/Lib/_ios_support.py
+@@ -13,7 +13,7 @@ else:
+     lib = util.find_library("objc")
+     if lib is None:
+         # Failed to load the objc library
+-        raise ImportError("ObjC runtime library couldn't be loaded")
++        lib = "/usr/lib/libobjc.dylib"
+ 
+     objc = cdll.LoadLibrary(lib)
+     objc.objc_getClass.restype = c_void_p

--- a/tools/depends/target/python3/Makefile
+++ b/tools/depends/target/python3/Makefile
@@ -7,7 +7,8 @@ DEPS = ../../Makefile.include Makefile PYTHON3-VERSION ../../download-files.incl
                                  11-android-ctypes.patch \
                                  13-wasm-em-config-clang.patch \
                                  14-wasm-build-wasm-default.patch \
-                                 15-wasm-static-hacl.patch
+                                 15-wasm-static-hacl.patch \
+                                 16-ios-platform.patch
 
 ifeq ($(findstring apple-darwin, $(HOST)), apple-darwin)
   ifeq ($(OS), darwin_embedded)
@@ -79,6 +80,12 @@ PY_MODULES+= py_cv_module__decimal=n/a \
 ifeq ($(OS), darwin_embedded)
   PY_MODULES+= py_cv_module__posixsubprocess=n/a \
                py_cv_module__scproxy=n/a
+
+  ifeq ($(findstring iphone,$(TARGET_PLATFORM)),iphone)
+    # see 16-ios-platform.patch
+    export IPHONEOS_DEPLOYMENT_TARGET=$(APPLE_DEPLOYMENT_TARGET)
+    export _host_device=$(subst iphone,,$(TARGET_PLATFORM))
+  endif
 endif
 
 # configuration settings
@@ -118,6 +125,9 @@ ifeq ($(OS),wasm)
 	cd $(PLATFORM); patch -p1 -i ../13-wasm-em-config-clang.patch
 	cd $(PLATFORM); patch -p1 -i ../14-wasm-build-wasm-default.patch
 	cd $(PLATFORM); patch -p1 -i ../15-wasm-static-hacl.patch
+endif
+ifeq ($(findstring iphone,$(TARGET_PLATFORM)),iphone)
+	cd $(PLATFORM); patch -p1 -i ../16-ios-platform.patch
 endif
 	cd $(PLATFORM); $(AUTORECONF)
 	cd $(PLATFORM); $(CONFIGURE)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
This change builds Python as a real iOS platform instead of just Darwin-like:
- `sys.platform` reports `ios` instead of `darwin`
- `platform.platform()` returns `iPadOS-15.8.8-iPad5,4-arm64-64bit` instead of `macOS-15.8.8-iPad5,4-64bit` for an iPad running iOS 15

As a positive side effect, `Pycryptodome` library (coming from `script.module.pycryptodome`) starts working on iOS. Previously it failed at loading native binary libs (it uses custom loading logic unlike PIL for example) with
```
EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'ModuleNotFoundError'>
                                                   Error Contents: No module named '_posixsubprocess'
                                                   Traceback (most recent call last):
                                                     File "/var/containers/Bundle/Application/29AAD392-8750-432E-99FB-8ABD7CE94F82/Kodi.app/Frameworks/lib/python3.14/site-packages/Cryptodome/Util/_raw_api.py", line 85, in <module>
                                                       from cffi import FFI
                                                   ModuleNotFoundError: No module named 'cffi'
```

The new patch does the following:
1. enforces platform to be iOS. Default platform detection doesn't work because python inspects `host` / `host_alias` which we set as `aarch64-apple-darwin` and overriding those isn't possible because values in `config.site` have the highest priority.
2. strips requirement to build as a (dynamic) framework and related flags. There's no real requirement to package Python as a framework, probably apart from convenient packaging of python code.
3. injects `IPHONEOS_DEPLOYMENT_TARGET` from environment. By default python is trying to infer the deployment target from `host` (which isn't possible in our case) and sets 13.0 as a fallback (the officially supported minimum iOS version). But we target 12.0 currently.
4. removes exception when Python can't load the system objc library using its internal mechanism and forces lib path to a well-known location `/usr/lib/libobjc.dylib`. This happens on iOS 12 (and possibly 13 as well) due to the [following python logic](https://github.com/python/cpython/blob/802a2c8b7a91d700c8bf342a27cd096ac444af41/Lib/ctypes/macholib/dyld.py#L121): try to read from disk from standard system locations (this always fails due to app sandboxing) or obtain lib path from dyld cache if possible (respective function `_dyld_shared_cache_contains_path` is available only on iOS >= 14). But a simple test showed that while you can't `stat` or check existence of the library file at `/usr/lib` (sandboxing), `dlopen` still succeeds in loading such a library.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Preparation for TestFlight / AppStore. When Python detects that it was built for iOS (actually for Apple non-macOS if you [look at the code](https://github.com/python/cpython/blob/802a2c8b7a91d700c8bf342a27cd096ac444af41/Lib/importlib/_bootstrap_external.py#L1541-L1545)), it enables [AppleFrameworkLoader](https://docs.python.org/3/library/importlib.html#importlib.machinery.AppleFrameworkLoader) that can load binary libs from custom locations (for AppStore it must be `<app bundle>/Frameworks`). It requires proper packaging though and will be done in a following PR.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local test on iOS 12, 15 and 26 devices

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
addons that rely on `script.module.pycryptodome` can be used on iOS now

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
