### PR TITLE
[cmake][apple] deployment target improvements

### DIFF
--- a/cmake/addons/CMakeLists.txt
+++ b/cmake/addons/CMakeLists.txt
@@ -120,7 +120,6 @@ endif()
 if(CMAKE_TOOLCHAIN_FILE)
   list(APPEND BUILD_ARGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
   message(STATUS "Toolchain specified")
-  message(STATUS ${BUILD_ARGS})
 endif()
 
 # used for addons where need special folders to store there content (if
@@ -187,6 +186,9 @@ if(NOT WIN32)
     message(STATUS "NEED_SUDO: ${NEED_SUDO} (no write permission for ${CMAKE_INSTALL_PREFIX})")
   endif()
 endif()
+
+# show the final build args
+message(DEBUG "Addon build args:\n${BUILD_ARGS}")
 
 ### prepare the build environment for the binary addons
 # copy the PrepareEnv.cmake script to the depends path so that we can include it

--- a/cmake/scripts/darwin_embedded/ArchSetup.cmake
+++ b/cmake/scripts/darwin_embedded/ArchSetup.cmake
@@ -51,20 +51,6 @@ set(CMAKE_XCODE_ATTRIBUTE_INLINES_ARE_PRIVATE_EXTERN OFF)
 set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN OFF)
 set(CMAKE_XCODE_ATTRIBUTE_COPY_PHASE_STRIP OFF)
 
-# Tahoe seems to be setting environment variables at the xcode project level that
-# causes issues on shell based build objects that we use. Forcefully blank the most
-# problematic variables
-set(CMAKE_XCODE_ATTRIBUTE_DRIVERKIT_DEPLOYMENT_TARGET "")
-set(CMAKE_XCODE_ATTRIBUTE_WATCHOS_DEPLOYMENT_TARGET "")
-set(CMAKE_XCODE_ATTRIBUTE_XROS_DEPLOYMENT_TARGET "")
-set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "")
-
-if(CORE_PLATFORM_NAME_LC STREQUAL tvos)
-  set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "")
-else()
-  set(CMAKE_XCODE_ATTRIBUTE_TVOS_DEPLOYMENT_TARGET "")
-endif()
-
 include(cmake/scripts/darwin/Macros.cmake)
 enable_arc()
 

--- a/cmake/scripts/osx/ArchSetup.cmake
+++ b/cmake/scripts/osx/ArchSetup.cmake
@@ -24,15 +24,6 @@ else()
   endif()
 endif()
 
-# Tahoe seems to be setting environment variables at the xcode project level that
-# causes issues on shell based build objects that we use. Forcefully blank the most
-# problematic variables
-set(CMAKE_XCODE_ATTRIBUTE_DRIVERKIT_DEPLOYMENT_TARGET "")
-set(CMAKE_XCODE_ATTRIBUTE_WATCHOS_DEPLOYMENT_TARGET "")
-set(CMAKE_XCODE_ATTRIBUTE_XROS_DEPLOYMENT_TARGET "")
-set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "")
-set(CMAKE_XCODE_ATTRIBUTE_TVOS_DEPLOYMENT_TARGET "")
-
 # m1 macs can execute x86_64 code via rosetta
 if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" AND
    CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")

--- a/cmake/scripts/osx/ArchSetup.cmake
+++ b/cmake/scripts/osx/ArchSetup.cmake
@@ -53,11 +53,6 @@ list(APPEND DEPLIBS "-framework DiskArbitration" "-framework IOKit"
                     "-framework GameController" "-framework Speech"
                     "-framework AVFoundation")
 
-if(ARCH STREQUAL aarch64)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0)
-else()
-  set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
-endif()
 set(CMAKE_XCODE_ATTRIBUTE_CLANG_LINK_OBJC_RUNTIME OFF)
 
 include(cmake/scripts/darwin/Macros.cmake)

--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -67,6 +67,7 @@ if(CORE_SYSTEM_NAME STREQUAL darwin_embedded)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET @target_minver@)
   set(CMAKE_OSX_SYSROOT @use_sdk_path@)
   set(CMAKE_XCODE_ATTRIBUTE_ARCHS ${CPU})
 endif()

--- a/tools/depends/target/Toolchain_binaddons.cmake.in
+++ b/tools/depends/target/Toolchain_binaddons.cmake.in
@@ -40,6 +40,7 @@ elseif(OS STREQUAL darwin_embedded)
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set(CMAKE_OSX_DEPLOYMENT_TARGET @target_minver@)
   set(CMAKE_OSX_SYSROOT @use_sdk_path@)
   set(CMAKE_LIBRARY_PATH ${CMAKE_FIND_ROOT_PATH}/lib:@use_sdk_path@/lib:/usr/X11R6/lib)
   set(CMAKE_INCLUDE_PATH ${CMAKE_FIND_ROOT_PATH}/include:@use_sdk_path@/include:/usr/X11R6/include)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
`CMAKE_OSX_DEPLOYMENT_TARGET` is now set for Apple platforms as the standard CMake way to handle deployment target, ~~respective Xcode attributes removed~~ (in the future we should allow user to set desired `target_minver` which may be useful for testing).

In relation to this #27496 is reverted - no idea how that was Tahoe related (probably Xcode 26?), but on Xcode 26.3 all builds fine atm.

Also added a small change that fixes binary addons args output - it was missing `;` separator between the list elements.

Before:
> -DCMAKE_PREFIX_PATH=/Users/kambala/dev/kodi/xbmc/tools/depends/target/binary-addons/iphoneos26.2_arm64-target-debug/build/depends/Users/kambala/dev/kodi/xbmc/addons-DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>-DPACKAGE_CONFIG_PATH=/Users/kambala/dev/kodi/xbmc/tools/depends/target/binary-addons/iphoneos26.2_arm64-target-debug/build/depends/lib/pkgconfig-DADDON_DEPENDS_PATH=/Users/kambala/dev/kodi/xbmc/tools/depends/target/binary-addons/iphoneos26.2_arm64-target-debug/build/depends-DOVERRIDE_PATHS=-DCMAKE_BUILD_TYPE=Release-DCMAKE_USER_MAKE_RULES_OVERRIDE=-DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX=-DCORE_SYSTEM_NAME=darwin_embedded-DBUILD_SHARED_LIBS=1-DCMAKE_C_FLAGS=-std=gnu11 -ftree-vectorize -pipe -Wno-trigraphs -fpascal-strings -Wreturn-type -Wunused-variable -fmessage-length=0 -gdwarf-2 -g -D_DEBUG  -arch arm64 -miphoneos-version-min=12.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.2.sdk-DCMAKE_CXX_FLAGS= -g -D_DEBUG  -arch arm64 -miphoneos-version-min=12.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.2.sdk-DPACKAGE_ZIP=ON-DPACKAGE_DIR=/Users/kambala/dev/kodi/xbmc/tools/depends/target/binary-addons/iphoneos26.2_arm64-target-debug/build/zips-DCMAKE_TOOLCHAIN_FILE=/Users/kambala/dev/kodi/xbmc/tools/depends/target/binary-addons/iphoneos26.2_arm64-target-debug/build/depends/share/Toolchain_binaddons.cmake

After:
> -DCMAKE_PREFIX_PATH=/Users/kambala/dev/kodi/xbmc/tools/depends/target/binary-addons/iphoneos26.2_arm64-target-debug/build/depends;/Users/kambala/dev/kodi/xbmc/addons;-DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>;-DPACKAGE_CONFIG_PATH=/Users/kambala/dev/kodi/xbmc/tools/depends/target/binary-addons/iphoneos26.2_arm64-target-debug/build/depends/lib/pkgconfig;-DADDON_DEPENDS_PATH=/Users/kambala/dev/kodi/xbmc/tools/depends/target/binary-addons/iphoneos26.2_arm64-target-debug/build/depends;-DOVERRIDE_PATHS=;-DCMAKE_BUILD_TYPE=Release;-DCMAKE_USER_MAKE_RULES_OVERRIDE=;-DCMAKE_USER_MAKE_RULES_OVERRIDE_CXX=;-DCORE_SYSTEM_NAME=darwin_embedded;-DBUILD_SHARED_LIBS=1;-DCMAKE_C_FLAGS=-std=gnu11 -ftree-vectorize -pipe -Wno-trigraphs -fpascal-strings -Wreturn-type -Wunused-variable -fmessage-length=0 -gdwarf-2 -g -D_DEBUG  -arch arm64 -miphoneos-version-min=12.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.2.sdk;-DCMAKE_CXX_FLAGS= -g -D_DEBUG  -arch arm64 -miphoneos-version-min=12.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.2.sdk;-DPACKAGE_ZIP=ON;-DPACKAGE_DIR=/Users/kambala/dev/kodi/xbmc/tools/depends/target/binary-addons/iphoneos26.2_arm64-target-debug/build/zips;-DCMAKE_TOOLCHAIN_FILE=/Users/kambala/dev/kodi/xbmc/tools/depends/target/binary-addons/iphoneos26.2_arm64-target-debug/build/depends/share/Toolchain_binaddons.cmake

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
using standard CMake approach

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build for iOS

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
no effect

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
