### PR TITLE
Support #EXTVLCOPT:input-slave external subtitles in M3U playlists

### DIFF
--- a/xbmc/playlists/PlayListM3U.cpp
+++ b/xbmc/playlists/PlayListM3U.cpp
@@ -194,6 +194,34 @@ bool CPlayListM3U::Load(const std::string& strFileName)
           newItem->SetProperty(prop.first, prop.second);
         }
 
+        const std::string inputSlave = newItem->GetProperty("input-slave").asString();
+
+        if (!inputSlave.empty())
+        {
+          std::vector<std::string> subtitles = StringUtils::Split(inputSlave, "#");
+
+          size_t index = 1;
+          while (newItem->HasProperty(StringUtils::Format("subtitle:{}", index)))
+            ++index;
+
+          for (std::string& subtitle : subtitles)
+          {
+            StringUtils::Trim(subtitle);
+
+            if (!subtitle.empty())
+            {
+              CUtil::GetQualifiedFilename(m_strBasePath, subtitle);
+
+              CFileItem subtitleItem(subtitle, false);
+
+              if (VIDEO::IsSubtitle(subtitleItem))
+              {
+                newItem->SetProperty(StringUtils::Format("subtitle:{}", index++), subtitle);
+              }
+            }
+          }
+        }
+
         newItem->SetMimeType(newItem->GetProperty("mimetype").asString());
         if (!newItem->GetMimeType().empty())
           newItem->SetContentLookup(false);


### PR DESCRIPTION
## Description
Add support for external subtitle files specified through the `#EXTVLCOPT:input-slave=` option in M3U playlists.

When the `input-slave` option is present, its value is parsed and exposed as `subtitle:N` properties on the playlist item, allowing Kodi to associate external subtitle files with the media item during playback.

## Motivation and context
Some M3U playlists include external subtitles using the `#EXTVLCOPT:input-slave=` option. This change ensures those subtitle files are parsed and made available to the player.

## How has this been tested?
Tested with M3U playlists containing the `#EXTVLCOPT:input-slave=` option and verified that the referenced external subtitle files are associated with the playlist item and available during playback.

## What is the effect on users?
External subtitles referenced through the `#EXTVLCOPT:input-slave=` option in M3U playlists are now automatically available during playback.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
