### PR TITLE
[cmake][Windows] Fix building with generators other than Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,10 +390,10 @@ endif()
 if(WIN32)
   configure_file(${CMAKE_SOURCE_DIR}/xbmc/platform/win32/XBMC_PC.rc.in
                  ${CORE_BUILD_DIR}/xbmc/platform/win32/XBMC_PC.rc @ONLY)
-  add_library(resources OBJECT ${CORE_BUILD_DIR}/xbmc/platform/win32/XBMC_PC.rc)
-  set_target_properties(resources PROPERTIES FOLDER "Build Utilities")
-  target_include_directories(resources PRIVATE ${CMAKE_SOURCE_DIR}/tools/windows/packaging/media)
-  set(RESOURCES $<TARGET_OBJECTS:resources>)
+  add_library(windows_resources OBJECT ${CORE_BUILD_DIR}/xbmc/platform/win32/XBMC_PC.rc)
+  set_target_properties(windows_resources PROPERTIES FOLDER "Build Utilities")
+  target_include_directories(windows_resources PRIVATE ${CMAKE_SOURCE_DIR}/tools/windows/packaging/media)
+  set(RESOURCES $<TARGET_OBJECTS:windows_resources>)
 endif()
 
 # Generate messages

--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -111,6 +111,13 @@ macro(buildFFMPEG)
                                         --win10=${win10})
     set(INSTALL_COMMAND ${CMAKE_COMMAND} -E true)
 
+    foreach(_ffmpeg_pkg IN ITEMS ${FFMPEG_PKGS})
+      string(REGEX REPLACE "[>]?=.*" "" _libname ${_ffmpeg_pkg})
+      string(REGEX REPLACE "^lib" "" _name ${_libname})
+      list(APPEND _ffmpeg_byproducts ${MINGW_LIBS_DIR}/lib/${_name}.lib)
+    endforeach()
+    set(BUILD_BYPRODUCTS ${_ffmpeg_byproducts})
+
     BUILD_DEP_TARGET()
 
     set(FFMPEG_INCLUDE_DIRS ${MINGW_LIBS_DIR}/include)
@@ -265,7 +272,7 @@ macro(buildFFMPEG)
                                                 INTERFACE_INCLUDE_DIRECTORIES "${FFMPEG_INCLUDE_DIRS}")
 
       if(WIN32 OR WINDOWS_STORE)
-        string(REPLACE "lib" "" name ${_libname})
+        string(REGEX REPLACE "^lib" "" name ${_libname})
         set_target_properties(ffmpeg::${_libname} PROPERTIES
                                                   IMPORTED_LOCATION "${MINGW_LIBS_DIR}/lib/${name}.lib")
       endif()

--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -496,6 +496,16 @@ macro(BUILD_DEP_TARGET)
     else()
       set(BUILD_BYPRODUCTS BUILD_BYPRODUCTS "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_LIBRARY}")
     endif()
+
+    # For a windows shared dep, LIBRARY is the dll but consumers link the import lib.
+    # Ninja rejects a graph containing a link input that no rule produces, so declare both.
+    if(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_IMPLIB)
+      if(DEFINED ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_IMPLIB_DEBUG)
+        list(APPEND BUILD_BYPRODUCTS "$<IF:$<CONFIG:Debug,RelWithDebInfo>,${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_IMPLIB_DEBUG},${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_IMPLIB_RELEASE}>")
+      else()
+        list(APPEND BUILD_BYPRODUCTS "${${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_IMPLIB}")
+      endif()
+    endif()
   endif()
 
   if(NOT INSTALL_DIR)

--- a/cmake/scripts/windows/Macros.cmake
+++ b/cmake/scripts/windows/Macros.cmake
@@ -57,6 +57,7 @@ function(add_precompiled_header target pch_header pch_source)
       set_target_properties(${PCH_PCH_TARGET}_pch PROPERTIES COMPILE_PDB_NAME vc140
                                                              COMPILE_PDB_OUTPUT_DIRECTORY ${PRECOMPILEDHEADER_DIR}
                                                              FOLDER "Build Utilities")
+      core_target_link_libraries(${PCH_PCH_TARGET}_pch)
     endif()
     # From VS2012 onwards, precompiled headers have to be linked against (LNK2011).
     target_link_libraries(${target} PUBLIC ${PCH_PCH_TARGET}_pch)

--- a/cmake/treedata/windows/subdirs.txt
+++ b/cmake/treedata/windows/subdirs.txt
@@ -4,7 +4,6 @@ xbmc/cores/VideoPlayer/Process/windows cores/VideoPlayer/Process/windows
 xbmc/cores/VideoPlayer/VideoRenderers/windows cores/VideoPlayer/VideoRenderers/windows
 xbmc/input/touch                       input/touch
 xbmc/input/touch/generic               input/touch/generic
-xbmc/network/mdns                      network/mdns
 xbmc/platform/common/speech            platform/common/speech
 xbmc/platform/win32                    platform/win32
 xbmc/platform/win32/filesystem         platform/win32/filesystem

--- a/cmake/treedata/windowsstore/subdirs.txt
+++ b/cmake/treedata/windowsstore/subdirs.txt
@@ -2,7 +2,6 @@ xbmc/cores/VideoPlayer/Process/windows cores/VideoPlayer/Process/windows
 xbmc/cores/VideoPlayer/VideoRenderers/windows cores/VideoPlayer/VideoRenderers/windows
 xbmc/input/touch                       input/touch
 xbmc/input/touch/generic               input/touch/generic
-xbmc/network/mdns                      network/mdns
 xbmc/platform/common/speech            platform/common/speech
 xbmc/platform/win10                    platform/win10
 xbmc/platform/win10/filesystem         platform/win10/filesystem

--- a/lib/libUPnP/CMakeLists.txt
+++ b/lib/libUPnP/CMakeLists.txt
@@ -85,8 +85,7 @@ if(NOT CORE_SYSTEM_NAME STREQUAL windows AND NOT CORE_SYSTEM_NAME STREQUAL windo
     list(APPEND SOURCES Neptune/Source/System/Null/NptNullAutoreleasePool.cpp)
   endif()
 else()
-  list(APPEND SOURCES Neptune/Source/System/Win32/NptWin32Console.cpp
-                      Neptune/Source/System/Win32/NptWin32Debug.cpp
+  list(APPEND SOURCES Neptune/Source/System/Win32/NptWin32Debug.cpp
                       Neptune/Source/System/Win32/NptWin32DynamicLibraries.cpp
                       Neptune/Source/System/Win32/NptWin32MessageQueue.cpp
                       Neptune/Source/System/Win32/NptWin32Network.cpp


### PR DESCRIPTION
## Description

Six independent fixes to Kodi's CMake so that the Windows build works with generators
other than Visual Studio. None of them change anything for the Visual Studio generator.

| Commit | Fix |
|---|---|
| `[cmake] Rename the win32 rc OBJECT library to windows_resources` | The `.rc` OBJECT library took the bare name `resources`, colliding with the target `xbmc/resources/CMakeLists.txt` creates via `core_add_library()`. |
| `[cmake] Drop the duplicate mdns subdir from the windows tree lists` | `xbmc/network/mdns` was listed both unconditionally in the windows/windowsstore subdirs and, gated on `ENABLE_MDNS`, in `treedata/optional/common/mdns.txt`, so `add_subdirectory()` ran on it twice. |
| `[cmake] Declare the windows ffmpeg import libs as build byproducts` | `kodi.exe` links `ffmpeg::libav*` through `IMPORTED_LOCATION` paths under `mingwlibs` that nothing declared as outputs of the ffmpeg external project. |
| `[cmake] Declare windows import libs as byproducts of internal deps` | Same class, but in `BUILD_DEP_TARGET`: for a windows shared dep only `<MODULE>_LIBRARY` (the dll) was passed to `externalproject_add`, never `<MODULE>_IMPLIB` (the import lib consumers actually link). Affects dav1d, bluray, cec, lcms2, mariadb and xslt. |
| `[cmake] Give the windows pch target its dependency include dirs` | `kodi_pch` was created as a bare static library, so it never got the dep include dirs or the ordering against in-tree dep builds that `core_add_library` gives every other core library. |
| `[cmake] Drop Neptune's win32 console from the upnp build` | `NptWin32Console.cpp` defines:Output`, which `xbmc/network/upnp/UPnP.cpp` also defines (empty, to mute Neptune). |

## Motivation and context

Windows has only ever been built with the Visual Studio generator, and `CMakeLists.txt`
keys the per-directory static library split off the generator:

```cmake
# Build static libraries per directory
if(NOT CMAKE_GENERATOR MATCHES "Visual Studio" AND NOT CMAKE_GENERATOR STREQUAL Xcode)
  set(ENABLE_STATIC_LIBS TRUE)
```

So choosing any other generator on Windows silently also changes the library layout. That
exposes three distinct classes of latent defect, all of which had simply never been reachabl

* **Library layout** — `ENABLE_STATIC_LIBS` flips to `TRUE`, so `core_add_library()` starts
  creating real targets instead of calling `target_sources()`. That surfaces the two target
  name collisions, and makes `add_precompiled_header()` reachable for the first time (its only
  caller sits inside `if(ENABLE_STATIC_LIBS)`, guarded to Windows — a combination the Visual
  Studio generator makes impossible, so the function was effectively dead code). It also changes
  which objects the linker pulls out of static archives, turning the duplicate
  `NPT_Console::Output` from harmless into a fatal `LNK2005`.
* **Graph strictness** — Ninja validates the whole dependency graph before running anything
  rejects an input that no rule produces, whereas MSBuild resolves lazily at execution time.
  `add_dependencies()` was enough for the latter; the former needs `BUILD_BYPRODUCTS`.
* **Config model** — single-config vs multi-config output layout.

Every one of these is a genuine bug that the Visual Studio generator happened to mask.

## How has this been tested?

Full Windows x64 build with the Ninja generator on `windows-2025` (VS 2022 17.14, MSVC 19.44
Windows SDK 10.0.26100), configuring with:

```
cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Release ...
```

Configure completes, all 3755 objects compile, `kodi.exe` links, and Kodi launches and rende
a frame (verified by an end-to-end smoke job that starts the binary and captures a screenshot).

Not verified, and worth a second pair of eyes:

* **The Visual Studio generator.** The reasoning for why each change is a no-op there is in the
  individual commit messages, but I have not run a VS-generator build. The one that most des
  checking is the libUPnP change — the argument is that `UPnP.cpp.obj` is unconditionally in every
  link (Kodi references `CUPnP`), so its `NPT_Console::Output` is always defined; since the
  does *not* currently fail with `LNK2005`, `NptWin32Console.cpp.obj` provably never enters that
  link, and removing it cannot change the resulting binary. Note also that no other platform compiles
  a Neptune console implementation at all.
* **windowsstore/UWP**, and archs other than x64.

## What is the effect on users?

None. Build system only; no runtime behaviour changes on any platform.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionalit
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/his project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed