### PR TITLE
DRMPRIME: close GEM handles right after AddFB2

### DIFF
--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
@@ -42,7 +42,6 @@ public:
   virtual void ReleaseDescriptor() {}
 
   uint32_t m_fb_id = 0;
-  uint32_t m_handles[AV_DRM_MAX_PLANES] = {};
 
 protected:
   explicit CVideoBufferDRMPRIME(int id);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -76,53 +76,70 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
   }
 
   AVDRMFrameDescriptor* descriptor = buffer->GetDescriptor();
+  uint32_t objectHandles[AV_DRM_MAX_PLANES] = {};
   uint32_t handles[4] = {}, pitches[4] = {}, offsets[4] = {}, flags = 0;
   uint64_t modifier[4] = {};
-  int ret;
+  int ret = 0;
 
   // convert Prime FD to GEM handle
   for (int object = 0; object < descriptor->nb_objects; object++)
   {
     ret = drmPrimeFDToHandle(m_DRM->GetFileDescriptor(), descriptor->objects[object].fd,
-                             &buffer->m_handles[object]);
+                             &objectHandles[object]);
     if (ret < 0)
     {
       CLog::Log(LOGERROR,
                 "CVideoLayerBridgeDRMPRIME::{} - failed to convert prime fd {} to gem handle {}, "
                 "ret = {}",
-                __FUNCTION__, descriptor->objects[object].fd, buffer->m_handles[object], ret);
-      return false;
+                __FUNCTION__, descriptor->objects[object].fd, objectHandles[object], ret);
+      break;
     }
   }
 
-  AVDRMLayerDescriptor* layer = &descriptor->layers[0];
-
-  for (int plane = 0; plane < layer->nb_planes; plane++)
+  if (ret == 0)
   {
-    int object = layer->planes[plane].object_index;
-    uint32_t handle = buffer->m_handles[object];
-    if (handle)
+    AVDRMLayerDescriptor* layer = &descriptor->layers[0];
+
+    for (int plane = 0; plane < layer->nb_planes; plane++)
     {
-      handles[plane] = handle;
-      pitches[plane] = layer->planes[plane].pitch;
-      offsets[plane] = layer->planes[plane].offset;
-      modifier[plane] = descriptor->objects[object].format_modifier;
+      int object = layer->planes[plane].object_index;
+      uint32_t handle = objectHandles[object];
+      if (handle)
+      {
+        handles[plane] = handle;
+        pitches[plane] = layer->planes[plane].pitch;
+        offsets[plane] = layer->planes[plane].offset;
+        modifier[plane] = descriptor->objects[object].format_modifier;
+      }
+    }
+
+    if (modifier[0] && modifier[0] != DRM_FORMAT_MOD_INVALID)
+      flags = DRM_MODE_FB_MODIFIERS;
+
+    // add the video frame FB
+    ret = drmModeAddFB2WithModifiers(m_DRM->GetFileDescriptor(), buffer->GetWidth(),
+                                     buffer->GetHeight(), layer->format, handles, pitches, offsets,
+                                     modifier, &buffer->m_fb_id, flags);
+    if (ret < 0)
+      CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to add fb {}, ret = {}",
+                __FUNCTION__, buffer->m_fb_id, ret);
+  }
+
+  // close the GEM handles now: the fb holds its own references, and the
+  // dedup entry drops with them, so a later importer of this dma-buf (the
+  // screencap EGL import) solely owns a fresh handle instead of sharing ours
+  for (int i = 0; i < AV_DRM_MAX_PLANES; i++)
+  {
+    if (objectHandles[i])
+    {
+      struct drm_gem_close gem_close;
+      gem_close.handle = objectHandles[i];
+      drmIoctl(m_DRM->GetFileDescriptor(), DRM_IOCTL_GEM_CLOSE, &gem_close);
     }
   }
 
-  if (modifier[0] && modifier[0] != DRM_FORMAT_MOD_INVALID)
-    flags = DRM_MODE_FB_MODIFIERS;
-
-  // add the video frame FB
-  ret = drmModeAddFB2WithModifiers(m_DRM->GetFileDescriptor(), buffer->GetWidth(),
-                                   buffer->GetHeight(), layer->format, handles, pitches, offsets,
-                                   modifier, &buffer->m_fb_id, flags);
   if (ret < 0)
-  {
-    CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to add fb {}, ret = {}",
-              __FUNCTION__, buffer->m_fb_id, ret);
     return false;
-  }
 
   Acquire(buffer);
   return true;
@@ -134,17 +151,6 @@ void CVideoLayerBridgeDRMPRIME::Unmap(CVideoBufferDRMPRIME* buffer)
   {
     drmModeRmFB(m_DRM->GetFileDescriptor(), buffer->m_fb_id);
     buffer->m_fb_id = 0;
-  }
-
-  for (int i = 0; i < AV_DRM_MAX_PLANES; i++)
-  {
-    if (buffer->m_handles[i])
-    {
-      struct drm_gem_close gem_close;
-      gem_close.handle = buffer->m_handles[i];
-      drmIoctl(m_DRM->GetFileDescriptor(), DRM_IOCTL_GEM_CLOSE, &gem_close);
-      buffer->m_handles[i] = 0;
-    }
   }
 
   buffer->ReleaseDescriptor();


### PR DESCRIPTION
## Description
Fix crash when using addon video codec with DRMPRIME. Uncovered debugging new screencap with DRMPRIME.

In VideoLayerBridgeDRMPRIME, GEM handles exist only as input to drmModeAddFB2WithModifiers; currently the Map() and Unmap() keep these handled open for the duration of frame handling, which is unnecessary and leads to resource collisions when other consumers try to use the same buffer handles. This PR rids the object of the m_handles state and just uses the handles briefly for the drmModeAddFB2WithModifiers setup.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
Cleanup DRMPRIME buffer state handling, fix crashing bug with screencap and DRMPRIME.

## How has this been tested?
Intel N250 in DRMPRIME configuration.

## What is the effect on users?
n/a

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [_] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
