### PR TITLE
Subtitles Selection - Avoid seek/audio and visual glitch when selecting the active but hidden current sub track

### DIFF
--- a/xbmc/video/guilib/VideoStreamSelectHelper.cpp
+++ b/xbmc/video/guilib/VideoStreamSelectHelper.cpp
@@ -512,7 +512,8 @@ void KODI::VIDEO::GUILIB::OpenDialogSelectSubtitleStream()
     }
     else if (id != STREAM_ID_NONE)
     {
-      appPlayer->SetSubtitle(id);
+      if (id != appPlayer->GetSubtitle())
+        appPlayer->SetSubtitle(id);
 
       if (!appPlayer->GetSubtitleVisible())
         appPlayer->SetSubtitleVisible(true);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Polish the transition to an active but hidden sub track with the stream selection dialog.

Videoplayer opens and processes the best sub track candidate when starting playback even if it's hidden because of the sub visibility setting. Videoplayer also keeps processing the current sub track after sub visibility is turned off.
It means that in those situations, sub content is available for display immediately and seeking to force a flush and re-read the video, with the related audio and visual interruption, is unnecessary.

The PR tests if the track selected in the dialog is already active; if so, the track switch is avoided and the visibility is toggled.

When the video has multiple sub tracks, switching to a track not read by vp already still causes the seek to provide sub text immediately.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The seek added by #27770 to display sub text faster is unnecessary when VP is already reading the sub track being switched to, and causes unnecessary visual and audio interruption.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Started playing with subtitles off. Then selected the first track > no seek (and subs appear instantly)
Started playing with subtitles on. Toggle subtitles off. Select the track that was originally visible > no seek (and subs appear instantly)
Switch sub tracks in a video with many tracks > the seek still happens, except when turning subs off/back on.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Partially restore unnoticeable sub track switching.

## Screenshots (if appropriate):
Start playback with subtitles off
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/8b137290-b2f5-4246-a9ed-a550c801cf9a" />

Activate the sub track, there is no seek / glitch.
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/b593fec4-034c-4b2d-92b1-5a5eed24fb8d" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
