### PR TITLE
[Video][Bluray] Multiple speed-ups for bluray access and processing.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -259,6 +259,15 @@ bool CDVDInputStreamBluray::Open()
   else
   {
     m_rootPath = root;
+
+#if defined(HAS_UDFREAD)
+    // Only in files mode does libbluray reach the disc through Kodi's filesystem, opening a dozen
+    // or so files and directories on it, and then the clips as they play. On a disc image each of
+    // those opens would otherwise re-mount the image's UDF volume, so keep it mounted for as long
+    // as the disc is open. (Stream mode reads the image itself, disc mode is a physical disc.)
+    m_udfMount.emplace(root);
+#endif
+
     if (!bd_open_files(m_bd, &m_rootPath, CBlurayCallback::dir_open, CBlurayCallback::file_open))
     {
       CLog::Log(LOGERROR, "CDVDInputStreamBluray::Open - failed to open {} in files mode",
@@ -413,6 +422,11 @@ void CDVDInputStreamBluray::Close()
   m_bd = nullptr;
   m_pstream.reset();
   m_rootPath.clear();
+
+#if defined(HAS_UDFREAD)
+  // Released last, as the files opened from the volume are closed above
+  m_udfMount.reset();
+#endif
 }
 
 void CDVDInputStreamBluray::FreeTitleInfo()

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -11,10 +11,14 @@
 #include "BlurayStateSerializer.h"
 #include "DVDInputStream.h"
 #include "threads/CriticalSection.h"
+#if defined(HAS_UDFREAD)
+#include "filesystem/UDFContext.h"
+#endif
 
 #include <chrono>
 #include <list>
 #include <memory>
+#include <optional>
 #include <string>
 
 extern "C"
@@ -195,6 +199,11 @@ protected:
     void FreeTitleInfo();
     std::unique_ptr<CDVDInputStreamFile> m_pstream;
     std::string m_rootPath;
+
+#if defined(HAS_UDFREAD)
+    // Keeps a disc image's UDF volume mounted for as long as the disc is open
+    std::optional<XFILE::CUDFMount> m_udfMount;
+#endif
 
     /*! Bluray state serializer handler */
     CBlurayStateSerializer m_blurayStateSerializer;

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -21,6 +21,9 @@
 #include "filesystem/BlurayCallback.h"
 #include "filesystem/Directory.h"
 #include "filesystem/DirectoryFactory.h"
+#if defined(HAS_UDFREAD)
+#include "filesystem/UDFContext.h"
+#endif
 #include "utils/EpisodeUtils.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/RegExp.h"
@@ -644,6 +647,13 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   // Most requests are now served from the disc cache or by parsing a single playlist.
   // Neither needs libbluray or disc.inf, so both are deferred.
   SetRealPath(root);
+
+#if defined(HAS_UDFREAD)
+  // Serving this request means reading a number of small files from the disc - a playlist for every
+  // title when determining them, and then the m2ts of the one wanted. On a disc image each of those
+  // opens would otherwise re-mount the image's UDF volume, so keep it mounted throughout.
+  const CUDFMount mount{root}; // The path the reads below are built from, not the resolved one
+#endif
 
   //
   // These options also return 'All Titles' and 'Menu' options (if supported on disc)

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -493,6 +493,7 @@ void CBlurayDirectory::Dispose()
     bd_close(m_bd);
     m_bd = nullptr;
   }
+  m_blurayInitialized = false;
 }
 
 bool CBlurayDirectory::Resolve(CFileItem& item) const
@@ -531,19 +532,19 @@ std::string CBlurayDirectory::GetBasePath(const CURL& url)
   return url2.Get(); // BDMV
 }
 
-std::string CBlurayDirectory::GetBlurayTitle() const
+std::string CBlurayDirectory::GetBlurayTitle()
 {
   return GetDiscInfoString(DiscInfo::TITLE);
 }
 
-std::string CBlurayDirectory::GetBlurayID() const
+std::string CBlurayDirectory::GetBlurayID()
 {
   return GetDiscInfoString(DiscInfo::ID);
 }
 
-std::string CBlurayDirectory::GetDiscInfoString(DiscInfo info) const
+std::string CBlurayDirectory::GetDiscInfoString(DiscInfo info)
 {
-  if (!m_blurayInitialized)
+  if (!EnsureBlurayOpen())
     return "";
 
   const BLURAY_DISC_INFO* discInfo{GetDiscInfo()};
@@ -597,8 +598,10 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   URIUtils::RemoveSlashAtEnd(file);
   URIUtils::RemoveSlashAtEnd(root);
 
-  if (!InitializeBluray(root))
-    return false;
+  // Resolve the path but leave the disc closed.
+  // Most requests are now served from the disc cache or by parsing a single playlist.
+  // Neither needs libbluray, so opening it is deferred.
+  SetRealPath(root);
 
   // See if there is a playlist in disc.inf
   const int mainPlaylist{GetMainPlaylistFromDisc(m_url)};
@@ -648,7 +651,7 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
       // Add all titles and menu option (if menus supported on disc)
       if (!StringUtils::EndsWith(file, "/all"))
         AddOptionsAndSortMethods(m_url, items, CDiscDirectoryHelper::AllTitles::MOVIES,
-                                 m_blurayMenuSupport);
+                                 HasMenuSupport());
 
       return success;
     }
@@ -727,7 +730,7 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
                                       clips, playlists);
         success = !items.IsEmpty();
         AddOptionsAndSortMethods(m_url, items, CDiscDirectoryHelper::AllTitles::EPISODES,
-                                 m_blurayMenuSupport);
+                                 HasMenuSupport());
       }
       else
       {
@@ -782,8 +785,25 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   return true;
 }
 
-bool CBlurayDirectory::InitializeBluray(const std::string& root)
+void CBlurayDirectory::SetRealPath(const std::string& root)
 {
+  m_realPath = root;
+
+  if (const auto fileHandler{CDirectoryFactory::Create(CURL{root})}; fileHandler)
+    m_realPath = fileHandler->ResolveMountPoint(root);
+}
+
+bool CBlurayDirectory::EnsureBlurayOpen()
+{
+  if (m_blurayInitialized)
+    return true;
+
+  if (m_realPath.empty())
+  {
+    CLog::LogF(LOGERROR, "No disc path, SetRealPath must be called first");
+    return false;
+  }
+
   bd_set_debug_handler(CBlurayCallback::bluray_logger);
   bd_set_debug_mask(DBG_CRIT | DBG_BLURAY | DBG_NAV);
 
@@ -799,22 +819,36 @@ bool CBlurayDirectory::InitializeBluray(const std::string& root)
   g_LangCodeExpander.ConvertToISO6392T(g_langInfo.GetDVDMenuLanguage(), langCode);
   bd_set_player_setting_str(m_bd, BLURAY_PLAYER_SETTING_MENU_LANG, langCode.c_str());
 
-  m_realPath = root;
-
-  if (const auto fileHandler{CDirectoryFactory::Create(CURL{root})}; fileHandler)
-    m_realPath = fileHandler->ResolveMountPoint(root);
-
   if (!bd_open_files(m_bd, &m_realPath, CBlurayCallback::dir_open, CBlurayCallback::file_open))
   {
-    CLog::LogF(LOGERROR, "Failed to open {}", CURL::GetRedacted(root));
+    CLog::LogF(LOGERROR, "Failed to open {}", CURL::GetRedacted(m_realPath));
+    Dispose();
     return false;
   }
   m_blurayInitialized = true;
 
-  const BLURAY_DISC_INFO* discInfo{GetDiscInfo()};
-  m_blurayMenuSupport = discInfo && !discInfo->no_menu_support;
-
   return true;
+}
+
+bool CBlurayDirectory::InitializeBluray(const std::string& root)
+{
+  SetRealPath(root);
+  return EnsureBlurayOpen();
+}
+
+bool CBlurayDirectory::HasMenuSupport()
+{
+  // Only libbluray can answer this, so the disc has to be opened
+  if (!EnsureBlurayOpen())
+    return false;
+
+  const BLURAY_DISC_INFO* discInfo{GetDiscInfo()};
+  const bool menuSupport{discInfo && !discInfo->no_menu_support};
+
+  CLog::LogF(LOGDEBUG, "Disc {} {} menus", CURL::GetRedacted(m_realPath),
+             menuSupport ? "supports" : "does not support");
+
+  return menuSupport;
 }
 
 const BLURAY_DISC_INFO* CBlurayDirectory::GetDiscInfo() const

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -185,13 +185,14 @@ void RemoveDuplicatePlaylists(std::vector<PlaylistInformation>& playlists)
                 { return duplicatePlaylists.contains(p.playlist); });
 }
 
-void SetStreamDetails(const CURL& url,
+bool SetStreamDetails(const CURL& url,
                       const std::string& realPath,
                       CFileItem& item,
                       PlaylistInformation& title,
                       std::map<unsigned int, ClipInformation>& clipCache)
 {
-  GetPlaylistInfoFromDisc(url, realPath, title.playlist, true, title, clipCache);
+  if (!GetPlaylistInfoFromDisc(url, realPath, title.playlist, true, title, clipCache))
+    return false;
 
   // Video stream (first one only)
   CVideoInfoTag* info{item.GetVideoInfoTag()};
@@ -211,12 +212,20 @@ void SetStreamDetails(const CURL& url,
     info->m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitle));
 
   info->m_streamDetails.DetermineBestStreams();
+  return true;
 }
+
+enum class StreamDetails : bool
+{
+  DEFER,
+  INCLUDE
+};
 
 std::shared_ptr<CFileItem> GetFileItem(const CURL& url,
                                        const std::string& realPath,
                                        PlaylistInformation& title,
-                                       std::map<unsigned int, ClipInformation>& clipCache)
+                                       std::map<unsigned int, ClipInformation>& clipCache,
+                                       StreamDetails getStreamDetails)
 {
   CURL path{url};
   path.SetFileName(StringUtils::Format("BDMV/PLAYLIST/{:05}.mpls", title.playlist));
@@ -225,7 +234,12 @@ std::shared_ptr<CFileItem> GetFileItem(const CURL& url,
   item->GetVideoInfoTag()->SetDuration(duration);
   item->SetProperty("bluray_playlist", title.playlist);
 
-  SetStreamDetails(url, realPath, *item, title, clipCache);
+  // Stream details are deferred when the playlist is only a candidate
+  // as parsing the m2ts is expensive
+  if (getStreamDetails == StreamDetails::INCLUDE &&
+      !SetStreamDetails(url, realPath, *item, title, clipCache))
+    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Unable to get stream details for playlist {} of {}",
+                title.playlist, CURL::GetRedacted(url.Get()));
 
   return item;
 }
@@ -294,7 +308,7 @@ void AddPlaylists(const CURL& url,
     return;
 
   for (auto& title : playlists)
-    items.Add(GetFileItem(url, realPath, title, clipCache));
+    items.Add(GetFileItem(url, realPath, title, clipCache, StreamDetails::DEFER));
 }
 bool GetPlaylists(const CURL& url,
                   const std::string& realPath,
@@ -318,7 +332,7 @@ bool GetPlaylists(const CURL& url,
       }
 
       // Generate FileItem including stream details
-      items.Add(GetFileItem(url, realPath, playlists[0], clipCache));
+      items.Add(GetFileItem(url, realPath, playlists[0], clipCache, StreamDetails::INCLUDE));
     }
     else
     {
@@ -333,7 +347,7 @@ bool GetPlaylists(const CURL& url,
       if (!FilterPlaylists(playlists))
         return false; // No playlists remain
 
-      // Generate FileItemList including stream details for each FileItem
+      // Generate FileItemList (stream details are filled in later, per selected playlist)
       AddPlaylists(url, realPath, items, playlists, clipCache);
     }
 
@@ -532,6 +546,17 @@ std::string CBlurayDirectory::GetBasePath(const CURL& url)
   return url2.Get(); // BDMV
 }
 
+void CBlurayDirectory::SetPlaylistStreamDetails(unsigned int playlist, CFileItem& item)
+{
+  // Only the playlist number is needed, the rest is read from the disc (or the disc cache)
+  PlaylistInformation information;
+  information.playlist = playlist;
+
+  if (!XFILE::SetStreamDetails(m_url, m_realPath, item, information, m_clipCache))
+    CLog::LogF(LOGDEBUG, "Unable to get stream details for playlist {} of {}", playlist,
+               CURL::GetRedacted(m_url.Get()));
+}
+
 std::string CBlurayDirectory::GetBlurayTitle()
 {
   return GetDiscInfoString(DiscInfo::TITLE);
@@ -630,7 +655,8 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     CFileItemList allTitles;
     GetPlaylistsInformation(m_url, m_realPath, m_flags, allTitles, clips, playlists, m_clipCache);
 
-    CDiscDirectoryHelper helper;
+    CDiscDirectoryHelper helper{[this](unsigned int playlist, CFileItem& item)
+                                { SetPlaylistStreamDetails(playlist, item); }};
 
     if (StringUtils::StartsWith(file, "root/titles") && file != "root/titles/episodes")
     {

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -80,20 +80,34 @@ std::string GetCachePath(const CURL& url, const std::string& realPath)
 bool GetPlaylistInfoFromCache(const CURL& url,
                               const std::string& realPath,
                               unsigned int playlist,
+                              StreamDetails streamDetails,
                               BlurayPlaylistInformation& bpi,
                               std::map<unsigned int, ClipInformation>& clipCache)
 {
-  // Check cache
-  if (const std::string path{GetCachePath(url, realPath)};
-      !CServiceBroker::GetBlurayDiscCache()->GetPlaylistInfo(path, playlist, bpi))
-  {
-    // Retrieve from disc
-    if (!CMPLSParser::ReadMPLS(url, playlist, bpi, clipCache))
-      return false;
+  const std::string path{GetCachePath(url, realPath)};
 
-    // Cache and return
-    CServiceBroker::GetBlurayDiscCache()->SetPlaylistInfo(path, playlist, bpi);
+  // Check cache
+  if (CServiceBroker::GetBlurayDiscCache()->GetPlaylistInfo(path, playlist, bpi))
+  {
+    if (streamDetails == StreamDetails::DEFER || bpi.clipStreamsRead)
+      return true;
+
+    // The cached playlist was read without its clips' stream information
+    // Retrieve that rather than parsing the .mpls a second time
+    if (CMPLSParser::ReadClipStreams(url, bpi, clipCache))
+    {
+      CServiceBroker::GetBlurayDiscCache()->SetPlaylistInfo(path, playlist, bpi);
+      return true;
+    }
   }
+
+  // Retrieve from disc
+  bpi = {}; // May hold a cached entry that could not be upgraded
+  if (!CMPLSParser::ReadMPLS(url, playlist, bpi, clipCache, streamDetails))
+    return false;
+
+  // Cache and return
+  CServiceBroker::GetBlurayDiscCache()->SetPlaylistInfo(path, playlist, bpi);
 
   return true;
 }
@@ -101,16 +115,16 @@ bool GetPlaylistInfoFromCache(const CURL& url,
 bool GetPlaylistInfoFromDisc(const CURL& url,
                              const std::string& realPath,
                              unsigned int playlist,
-                             bool parseM2TS,
+                             StreamDetails streamDetails,
                              PlaylistInformation& playlistInformation,
                              std::map<unsigned int, ClipInformation>& clipCache)
 {
   BlurayPlaylistInformation bpi;
-  if (!GetPlaylistInfoFromCache(url, realPath, playlist, bpi, clipCache))
+  if (!GetPlaylistInfoFromCache(url, realPath, playlist, streamDetails, bpi, clipCache))
     return false;
 
   StreamMap streams;
-  if (parseM2TS)
+  if (streamDetails == StreamDetails::INCLUDE)
   {
     const std::string path{GetCachePath(url, realPath)};
 
@@ -126,7 +140,7 @@ bool GetPlaylistInfoFromDisc(const CURL& url,
     }
   }
 
-  CStreamParser::ConvertBlurayPlaylistInformation(bpi, playlistInformation, streams);
+  CStreamParser::ConvertBlurayPlaylistInformation(bpi, playlistInformation, streams, streamDetails);
 
   return true;
 }
@@ -155,7 +169,7 @@ bool GetPlaylistsFromDisc(const CURL& url,
       const unsigned int playlist{static_cast<unsigned int>(std::stoi(pl.GetMatch(1)))};
 
       PlaylistInformation& t = playlists.emplace_back();
-      if (!GetPlaylistInfoFromDisc(url, realPath, playlist, false, t, clipCache))
+      if (!GetPlaylistInfoFromDisc(url, realPath, playlist, StreamDetails::DEFER, t, clipCache))
       {
         CLog::LogF(LOGDEBUG, "Unable to get playlist {}", playlist);
         playlists.pop_back();
@@ -167,6 +181,8 @@ bool GetPlaylistsFromDisc(const CURL& url,
 
 void RemoveDuplicatePlaylists(std::vector<PlaylistInformation>& playlists)
 {
+  // The stream number table describes what a playlist exposes rather than what its clip contains,
+  // so two playlists sharing a clip but offering different streams are not seen as identical.
   std::unordered_set<unsigned int> duplicatePlaylists;
   for (unsigned int i = 0; i < playlists.size() - 1; ++i)
   {
@@ -191,7 +207,8 @@ bool SetStreamDetails(const CURL& url,
                       PlaylistInformation& title,
                       std::map<unsigned int, ClipInformation>& clipCache)
 {
-  if (!GetPlaylistInfoFromDisc(url, realPath, title.playlist, true, title, clipCache))
+  if (!GetPlaylistInfoFromDisc(url, realPath, title.playlist, StreamDetails::INCLUDE, title,
+                               clipCache))
     return false;
 
   // Video stream (first one only)
@@ -214,12 +231,6 @@ bool SetStreamDetails(const CURL& url,
   info->m_streamDetails.DetermineBestStreams();
   return true;
 }
-
-enum class StreamDetails : bool
-{
-  DEFER,
-  INCLUDE
-};
 
 std::shared_ptr<CFileItem> GetFileItem(const CURL& url,
                                        const std::string& realPath,
@@ -326,9 +337,10 @@ bool GetPlaylists(const CURL& url,
     std::vector<PlaylistInformation> playlists;
     if (playlist >= 0)
     {
-      // Single playlist
+      // Single playlist. Read the stream details now, as GetFileItem wants them straight away and
+      // asking for them later would mean reading the .mpls a second time.
       PlaylistInformation& t = playlists.emplace_back();
-      if (!GetPlaylistInfoFromDisc(url, realPath, playlist, false, t, clipCache))
+      if (!GetPlaylistInfoFromDisc(url, realPath, playlist, StreamDetails::INCLUDE, t, clipCache))
       {
         CLog::LogF(LOGDEBUG, "Unable to get playlist {}", playlist);
         playlists.pop_back();
@@ -448,7 +460,8 @@ bool GetPlaylistsInformation(const CURL& url,
     {
       const int playlist{title->GetProperty("bluray_playlist").asInteger32(0)};
       PlaylistInformation titleInfo;
-      if (!GetPlaylistInfoFromDisc(url, realPath, playlist, false, titleInfo, clipCache))
+      if (!GetPlaylistInfoFromDisc(url, realPath, playlist, StreamDetails::DEFER, titleInfo,
+                                   clipCache))
       {
         CLog::LogF(LOGDEBUG, "Unable to get playlist {}", playlist);
         continue;

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -255,7 +255,6 @@ int GetMainPlaylistFromDisc(const CURL& url)
 
   if (file.Open(discInfPath))
   {
-    CLog::LogF(LOGDEBUG, "disc.inf found");
     CRegExp pl{true, CRegExp::autoUtf8, R"((?:playlists=)(\d+))"};
     uint8_t maxLines{100};
     while ((maxLines > 0) && file.ReadLine(line))
@@ -268,6 +267,11 @@ int GetMainPlaylistFromDisc(const CURL& url)
       }
     }
     file.Close();
+
+    if (playlist >= 0)
+      CLog::LogF(LOGDEBUG, "disc.inf main playlist {}", playlist);
+    else
+      CLog::LogF(LOGDEBUG, "disc.inf found but no main playlist");
   }
   return playlist;
 }
@@ -625,11 +629,8 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 
   // Resolve the path but leave the disc closed.
   // Most requests are now served from the disc cache or by parsing a single playlist.
-  // Neither needs libbluray, so opening it is deferred.
+  // Neither needs libbluray or disc.inf, so both are deferred.
   SetRealPath(root);
-
-  // See if there is a playlist in disc.inf
-  const int mainPlaylist{GetMainPlaylistFromDisc(m_url)};
 
   //
   // These options also return 'All Titles' and 'Menu' options (if supported on disc)
@@ -662,10 +663,10 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     {
 
       if (file == "root/titles")
-        helper.GetMoviePlaylists(url, items, allTitles, mainPlaylist, GetTitle::MAIN, clips,
+        helper.GetMoviePlaylists(m_url, items, allTitles, GetMainPlaylist(), GetTitle::MAIN, clips,
                                  playlists);
       else if (file == "root/titles/all")
-        helper.GetMoviePlaylists(url, items, allTitles, mainPlaylist, GetTitle::ALL, clips,
+        helper.GetMoviePlaylists(m_url, items, allTitles, GetMainPlaylist(), GetTitle::ALL, clips,
                                  playlists);
       else if (file == "root/titles/episodes/all")
         helper.GetAllEpisodePlaylists(m_url, items, allTitles, GetTitle::ALL, {}, clips, playlists);
@@ -685,10 +686,10 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     if (StringUtils::StartsWith(file, "root/main"))
     {
       if (file == "root/main")
-        helper.GetMoviePlaylists(url, items, allTitles, mainPlaylist, GetTitle::SINGLE, clips,
-                                 playlists);
+        helper.GetMoviePlaylists(m_url, items, allTitles, GetMainPlaylist(), GetTitle::SINGLE,
+                                 clips, playlists);
       else if (file == "root/main/all")
-        helper.GetMoviePlaylists(url, items, allTitles, mainPlaylist, GetTitle::ALL, clips,
+        helper.GetMoviePlaylists(m_url, items, allTitles, GetMainPlaylist(), GetTitle::ALL, clips,
                                  playlists);
       else
         CLog::LogF(LOGDEBUG, "Invalid path {} for bluray playlist parsing", file);
@@ -864,17 +865,39 @@ bool CBlurayDirectory::InitializeBluray(const std::string& root)
 
 bool CBlurayDirectory::HasMenuSupport()
 {
+  const std::string path{GetCachePath(m_url, m_realPath)};
+
+  if (bool menuSupport{false};
+      CServiceBroker::GetBlurayDiscCache()->GetMenuSupport(path, menuSupport))
+    return menuSupport;
+
   // Only libbluray can answer this, so the disc has to be opened
   if (!EnsureBlurayOpen())
-    return false;
+    return false; // Not cached, so a disc that failed to open is retried rather than written off
 
   const BLURAY_DISC_INFO* discInfo{GetDiscInfo()};
   const bool menuSupport{discInfo && !discInfo->no_menu_support};
+  CServiceBroker::GetBlurayDiscCache()->SetMenuSupport(path, menuSupport);
 
   CLog::LogF(LOGDEBUG, "Disc {} {} menus", CURL::GetRedacted(m_realPath),
              menuSupport ? "supports" : "does not support");
 
   return menuSupport;
+}
+
+int CBlurayDirectory::GetMainPlaylist()
+{
+  const std::string path{GetCachePath(m_url, m_realPath)};
+
+  if (int mainPlaylist{-1};
+      CServiceBroker::GetBlurayDiscCache()->GetMainPlaylist(path, mainPlaylist))
+    return mainPlaylist;
+
+  // Cache main playlist from disc.inf (or -1 if not found)
+  const int mainPlaylist{GetMainPlaylistFromDisc(m_url)};
+  CServiceBroker::GetBlurayDiscCache()->SetMainPlaylist(path, mainPlaylist);
+
+  return mainPlaylist;
 }
 
 const BLURAY_DISC_INFO* CBlurayDirectory::GetDiscInfo() const

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -184,9 +184,9 @@ void RemoveDuplicatePlaylists(std::vector<PlaylistInformation>& playlists)
   // The stream number table describes what a playlist exposes rather than what its clip contains,
   // so two playlists sharing a clip but offering different streams are not seen as identical.
   std::unordered_set<unsigned int> duplicatePlaylists;
-  for (unsigned int i = 0; i < playlists.size() - 1; ++i)
+  for (size_t i = 0; i + 1 < playlists.size(); ++i)
   {
-    for (unsigned int j = i + 1; j < playlists.size(); ++j)
+    for (size_t j = i + 1; j < playlists.size(); ++j)
     {
       if (playlists[i].audioStreams == playlists[j].audioStreams &&
           playlists[i].pgStreams == playlists[j].pgStreams &&

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -648,13 +648,6 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   // Neither needs libbluray or disc.inf, so both are deferred.
   SetRealPath(root);
 
-#if defined(HAS_UDFREAD)
-  // Serving this request means reading a number of small files from the disc - a playlist for every
-  // title when determining them, and then the m2ts of the one wanted. On a disc image each of those
-  // opens would otherwise re-mount the image's UDF volume, so keep it mounted throughout.
-  const CUDFMount mount{root}; // The path the reads below are built from, not the resolved one
-#endif
-
   //
   // These options also return 'All Titles' and 'Menu' options (if supported on disc)
   //
@@ -841,6 +834,10 @@ void CBlurayDirectory::SetRealPath(const std::string& root)
 
   if (const auto fileHandler{CDirectoryFactory::Create(CURL{root})}; fileHandler)
     m_realPath = fileHandler->ResolveMountPoint(root);
+
+#if defined(HAS_UDFREAD)
+  m_udfMount.emplace(root);
+#endif
 }
 
 bool CBlurayDirectory::EnsureBlurayOpen()

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -38,10 +38,16 @@ public:
   bool GetDirectory(const CURL& url, CFileItemList& items) override;
   bool Resolve(CFileItem& item) const override;
 
-  bool InitializeBluray(const std::string &root);
+  /*!
+   \brief Resolve the underlying path and open the disc with libbluray.
+   Only needed by callers that want the disc's own metadata (see GetBlurayTitle/GetBlurayID).
+   GetDirectory resolves the path but leaves libbluray closed until something needs it.
+   \return true if libbluray could open the disc, ie. this is a bluray
+   */
+  bool InitializeBluray(const std::string& root);
   static std::string GetBasePath(const CURL& url);
-  std::string GetBlurayTitle() const;
-  std::string GetBlurayID() const;
+  std::string GetBlurayTitle();
+  std::string GetBlurayID();
 
 private:
   enum class DiscInfo : uint8_t
@@ -50,15 +56,33 @@ private:
     ID
   };
 
+  /*!
+   \brief Resolve the disc's path through its directory handler, without touching the disc.
+   */
+  void SetRealPath(const std::string& root);
+
+  /*!
+   \brief Open the disc with libbluray, unless already open.
+   Opening costs a dozen round trips to the disc (index.bdmv, the BDMV/META localisations,
+   CERTIFICATE/id.bdmv and the AACS probe), which is why it is deferred until a caller needs
+   something only libbluray can answer. SetRealPath must have been called first.
+   \return true if libbluray has the disc open
+   */
+  bool EnsureBlurayOpen();
+
+  /*!
+   \brief Get whether this disc supports menus, opening it only if needed.
+   */
+  bool HasMenuSupport();
+
   void Dispose();
-  std::string GetDiscInfoString(DiscInfo info) const;
+  std::string GetDiscInfoString(DiscInfo info);
   const BLURAY_DISC_INFO* GetDiscInfo() const;
 
   CURL m_url;
   std::string m_realPath;
   BLURAY* m_bd{nullptr};
   bool m_blurayInitialized{false};
-  bool m_blurayMenuSupport{false};
 
   std::map<unsigned int, ClipInformation> m_clipCache;
 };

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -12,8 +12,12 @@
 #include "IDirectory.h"
 #include "URL.h"
 #include "bluray/MPLSParser.h"
+#if defined(HAS_UDFREAD)
+#include "filesystem/UDFContext.h"
+#endif
 
 #include <map>
+#include <optional>
 #include <string>
 
 #include <libbluray/bluray.h>
@@ -99,6 +103,11 @@ private:
   std::string m_realPath;
   BLURAY* m_bd{nullptr};
   bool m_blurayInitialized{false};
+
+#if defined(HAS_UDFREAD)
+  //! Keeps a disc image's UDF volume mounted for as long as this disc is in use
+  std::optional<CUDFMount> m_udfMount;
+#endif
 
   std::map<unsigned int, ClipInformation> m_clipCache;
 };

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -81,9 +81,15 @@ private:
   bool EnsureBlurayOpen();
 
   /*!
-   \brief Get whether this disc supports menus, opening it only if needed.
+   \brief Get whether this disc supports menus, opening it only on the first call per disc.
    */
   bool HasMenuSupport();
+
+  /*!
+   \brief Get the main playlist named in the disc's disc.inf, reading it only once per disc.
+   \return the playlist number, or -1 if the disc names none
+   */
+  int GetMainPlaylist();
 
   void Dispose();
   std::string GetDiscInfoString(DiscInfo info);

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -50,6 +50,16 @@ public:
   std::string GetBlurayID();
 
 private:
+  /*!
+   \brief Populate the stream details of a playlist on this disc.
+   Deriving these means parsing the playlist's m2ts, so it is only done once a playlist is known
+   to be wanted rather than for every playlist on the disc during playlist determination. Handed to
+   CDiscDirectoryHelper as a StreamDetailsProvider so that it stays agnostic of the disc type.
+   \param playlist the playlist to describe
+   \param item the item to populate
+   */
+  void SetPlaylistStreamDetails(unsigned int playlist, CFileItem& item);
+
   enum class DiscInfo : uint8_t
   {
     TITLE,

--- a/xbmc/filesystem/BlurayDiscCache.cpp
+++ b/xbmc/filesystem/BlurayDiscCache.cpp
@@ -82,6 +82,36 @@ void CBlurayDiscCache::SetPlaylistStreamInfo(const std::string& path,
   disc.streamMap[playlist] = streams;
 }
 
+void CBlurayDiscCache::SetMenuSupport(const std::string& path, bool menuSupport)
+{
+  std::unique_lock lock(m_cs);
+
+  // Get rid of any URL options, else the compare may be wrong
+  std::string storedPath{CURL(path).GetWithoutOptions()};
+  URIUtils::RemoveSlashAtEnd(storedPath);
+
+  auto i{m_cache.find(storedPath)};
+  if (i == m_cache.end())
+    i = SetDisc(path);
+  auto& [_, disc] = *i;
+  disc.menuSupport = menuSupport;
+}
+
+void CBlurayDiscCache::SetMainPlaylist(const std::string& path, int mainPlaylist)
+{
+  std::unique_lock lock(m_cs);
+
+  // Get rid of any URL options, else the compare may be wrong
+  std::string storedPath{CURL(path).GetWithoutOptions()};
+  URIUtils::RemoveSlashAtEnd(storedPath);
+
+  auto i{m_cache.find(storedPath)};
+  if (i == m_cache.end())
+    i = SetDisc(path);
+  auto& [_, disc] = *i;
+  disc.mainPlaylist = mainPlaylist;
+}
+
 bool CBlurayDiscCache::GetPlaylistInfo(const std::string& path,
                                        unsigned int playlist,
                                        BlurayPlaylistInformation& playlistInfo) const
@@ -149,6 +179,46 @@ bool CBlurayDiscCache::GetPlaylistStreamInfo(const std::string& path,
     {
       const auto& [_, info] = *j;
       streams = info;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool CBlurayDiscCache::GetMenuSupport(const std::string& path, bool& menuSupport) const
+{
+  std::unique_lock lock(m_cs);
+
+  // Get rid of any URL options, else the compare may be wrong
+  std::string storedPath{CURL(path).GetWithoutOptions()};
+  URIUtils::RemoveSlashAtEnd(storedPath);
+
+  if (const auto& i{m_cache.find(storedPath)}; i != m_cache.end())
+  {
+    const auto& [_, disc] = *i;
+    if (disc.menuSupport)
+    {
+      menuSupport = *disc.menuSupport;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool CBlurayDiscCache::GetMainPlaylist(const std::string& path, int& mainPlaylist) const
+{
+  std::unique_lock lock(m_cs);
+
+  // Get rid of any URL options, else the compare may be wrong
+  std::string storedPath{CURL(path).GetWithoutOptions()};
+  URIUtils::RemoveSlashAtEnd(storedPath);
+
+  if (const auto& i{m_cache.find(storedPath)}; i != m_cache.end())
+  {
+    const auto& [_, disc] = *i;
+    if (disc.mainPlaylist)
+    {
+      mainPlaylist = *disc.mainPlaylist;
       return true;
     }
   }

--- a/xbmc/filesystem/BlurayDiscCache.cpp
+++ b/xbmc/filesystem/BlurayDiscCache.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2025 Team Kodi
+ *  Copyright (C) 2005-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -13,18 +13,67 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <algorithm>
+#include <ranges>
+
 using namespace XFILE;
 
-CacheMap::iterator CBlurayDiscCache::SetDisc(const std::string& path)
+namespace
 {
-  std::unique_lock lock(m_cs);
+/*!
+ \brief Number of discs to keep information for.
+ Holds - a playlist for every title on the disc. Each playlist entry holds information for each clip.
+       - a FileItem for most playlists
+ The total cache size for each disc could be 2-3MB
+ Only the disc in use is normally wanted; the allowance is for going back and forth between the
+ discs of a set.
+ */
+constexpr size_t MAX_CACHED_DISCS{10};
+static_assert(MAX_CACHED_DISCS >= 1);
 
-  // Get rid of any URL options, else the compare may be wrong
-  std::string storedPath{CURL(path).GetWithoutOptions()};
-  URIUtils::RemoveSlashAtEnd(storedPath);
+//! Discs are keyed on their path without URL options or a trailing slash, else the compare may be
+//! wrong
+std::string GetDiscKey(const std::string& path)
+{
+  std::string key{CURL(path).GetWithoutOptions()};
+  URIUtils::RemoveSlashAtEnd(key);
+  return key;
+}
+} // namespace
 
-  const auto [it, _]{m_cache.try_emplace(storedPath)};
-  return it;
+const Disc* CBlurayDiscCache::Find(const std::string& path) const
+{
+  const auto it{m_cache.find(GetDiscKey(path))};
+  if (it == m_cache.end())
+    return nullptr;
+
+  it->second.lastUsed = ++m_useCounter;
+
+  return &it->second;
+}
+
+Disc& CBlurayDiscCache::FindOrCreate(const std::string& path)
+{
+  const auto [it, inserted]{m_cache.try_emplace(GetDiscKey(path))};
+  it->second.lastUsed = ++m_useCounter;
+
+  // The disc just used is the most recent, so is never the one dropped
+  if (inserted)
+    Evict();
+
+  return it->second;
+}
+
+void CBlurayDiscCache::Evict()
+{
+  while (m_cache.size() > MAX_CACHED_DISCS)
+  {
+    const auto oldest{std::ranges::min_element(m_cache, {}, [](const CacheMap::value_type& entry)
+                                               { return entry.second.lastUsed; })};
+
+    CLog::LogF(LOGDEBUG, "Dropping cached information for {}", CURL::GetRedacted(oldest->first));
+    m_cache.erase(oldest);
+  }
 }
 
 void CBlurayDiscCache::SetPlaylistInfo(const std::string& path,
@@ -33,15 +82,7 @@ void CBlurayDiscCache::SetPlaylistInfo(const std::string& path,
 {
   std::unique_lock lock(m_cs);
 
-  // Get rid of any URL options, else the compare may be wrong
-  std::string storedPath{CURL(path).GetWithoutOptions()};
-  URIUtils::RemoveSlashAtEnd(storedPath);
-
-  auto i{m_cache.find(storedPath)};
-  if (i == m_cache.end())
-    i = SetDisc(path);
-  auto& [_, disc] = *i;
-  disc.playlists[playlist] = playlistInfo;
+  FindOrCreate(path).playlists[playlist] = playlistInfo;
 }
 
 void CBlurayDiscCache::SetMaps(const std::string& path,
@@ -51,14 +92,7 @@ void CBlurayDiscCache::SetMaps(const std::string& path,
 {
   std::unique_lock lock(m_cs);
 
-  // Get rid of any URL options, else the compare may be wrong
-  std::string storedPath{CURL(path).GetWithoutOptions()};
-  URIUtils::RemoveSlashAtEnd(storedPath);
-
-  auto i{m_cache.find(storedPath)};
-  if (i == m_cache.end())
-    i = SetDisc(path);
-  auto& [_, disc] = *i;
+  Disc& disc{FindOrCreate(path)};
   disc.playlistMap = playlistmap;
   disc.clipMap = clipmap;
   disc.itemMap.Copy(itemmap);
@@ -71,45 +105,21 @@ void CBlurayDiscCache::SetPlaylistStreamInfo(const std::string& path,
 {
   std::unique_lock lock(m_cs);
 
-  // Get rid of any URL options, else the compare may be wrong
-  std::string storedPath{CURL(path).GetWithoutOptions()};
-  URIUtils::RemoveSlashAtEnd(storedPath);
-
-  auto i{m_cache.find(storedPath)};
-  if (i == m_cache.end())
-    i = SetDisc(path);
-  auto& [_, disc] = *i;
-  disc.streamMap[playlist] = streams;
+  FindOrCreate(path).streamMap[playlist] = streams;
 }
 
 void CBlurayDiscCache::SetMenuSupport(const std::string& path, bool menuSupport)
 {
   std::unique_lock lock(m_cs);
 
-  // Get rid of any URL options, else the compare may be wrong
-  std::string storedPath{CURL(path).GetWithoutOptions()};
-  URIUtils::RemoveSlashAtEnd(storedPath);
-
-  auto i{m_cache.find(storedPath)};
-  if (i == m_cache.end())
-    i = SetDisc(path);
-  auto& [_, disc] = *i;
-  disc.menuSupport = menuSupport;
+  FindOrCreate(path).menuSupport = menuSupport;
 }
 
 void CBlurayDiscCache::SetMainPlaylist(const std::string& path, int mainPlaylist)
 {
   std::unique_lock lock(m_cs);
 
-  // Get rid of any URL options, else the compare may be wrong
-  std::string storedPath{CURL(path).GetWithoutOptions()};
-  URIUtils::RemoveSlashAtEnd(storedPath);
-
-  auto i{m_cache.find(storedPath)};
-  if (i == m_cache.end())
-    i = SetDisc(path);
-  auto& [_, disc] = *i;
-  disc.mainPlaylist = mainPlaylist;
+  FindOrCreate(path).mainPlaylist = mainPlaylist;
 }
 
 bool CBlurayDiscCache::GetPlaylistInfo(const std::string& path,
@@ -118,18 +128,11 @@ bool CBlurayDiscCache::GetPlaylistInfo(const std::string& path,
 {
   std::unique_lock lock(m_cs);
 
-  // Get rid of any URL options, else the compare may be wrong
-  std::string storedPath{CURL(path).GetWithoutOptions()};
-  URIUtils::RemoveSlashAtEnd(storedPath);
-
-  if (const auto& i{m_cache.find(storedPath)}; i != m_cache.end())
+  if (const Disc * disc{Find(path)}; disc)
   {
-    const auto& [_, disc] = *i;
-    const auto& j{disc.playlists.find(playlist)};
-    if (j != disc.playlists.end())
+    if (const auto& it{disc->playlists.find(playlist)}; it != disc->playlists.end())
     {
-      const auto& [_, info] = *j;
-      playlistInfo = info;
+      playlistInfo = it->second;
       return true;
     }
   }
@@ -143,20 +146,12 @@ bool CBlurayDiscCache::GetMaps(const std::string& path,
 {
   std::unique_lock lock(m_cs);
 
-  // Get rid of any URL options, else the compare may be wrong
-  std::string storedPath{CURL(path).GetWithoutOptions()};
-  URIUtils::RemoveSlashAtEnd(storedPath);
-
-  if (const auto& i{m_cache.find(storedPath)}; i != m_cache.end())
+  if (const Disc * disc{Find(path)}; disc && disc->mapsSet)
   {
-    const auto& [_, disc] = *i;
-    if (disc.mapsSet)
-    {
-      clipmap = disc.clipMap;
-      playlistmap = disc.playlistMap;
-      itemmap.Copy(disc.itemMap);
-      return true;
-    }
+    clipmap = disc->clipMap;
+    playlistmap = disc->playlistMap;
+    itemmap.Copy(disc->itemMap);
+    return true;
   }
   return false;
 }
@@ -167,18 +162,11 @@ bool CBlurayDiscCache::GetPlaylistStreamInfo(const std::string& path,
 {
   std::unique_lock lock(m_cs);
 
-  // Get rid of any URL options, else the compare may be wrong
-  std::string storedPath{CURL(path).GetWithoutOptions()};
-  URIUtils::RemoveSlashAtEnd(storedPath);
-
-  if (const auto& i{m_cache.find(storedPath)}; i != m_cache.end())
+  if (const Disc * disc{Find(path)}; disc)
   {
-    const auto& [_, disc] = *i;
-    const auto& j{disc.streamMap.find(playlist)};
-    if (j != disc.streamMap.end())
+    if (const auto& it{disc->streamMap.find(playlist)}; it != disc->streamMap.end())
     {
-      const auto& [_, info] = *j;
-      streams = info;
+      streams = it->second;
       return true;
     }
   }
@@ -189,18 +177,10 @@ bool CBlurayDiscCache::GetMenuSupport(const std::string& path, bool& menuSupport
 {
   std::unique_lock lock(m_cs);
 
-  // Get rid of any URL options, else the compare may be wrong
-  std::string storedPath{CURL(path).GetWithoutOptions()};
-  URIUtils::RemoveSlashAtEnd(storedPath);
-
-  if (const auto& i{m_cache.find(storedPath)}; i != m_cache.end())
+  if (const Disc * disc{Find(path)}; disc && disc->menuSupport)
   {
-    const auto& [_, disc] = *i;
-    if (disc.menuSupport)
-    {
-      menuSupport = *disc.menuSupport;
-      return true;
-    }
+    menuSupport = *disc->menuSupport;
+    return true;
   }
   return false;
 }
@@ -209,18 +189,10 @@ bool CBlurayDiscCache::GetMainPlaylist(const std::string& path, int& mainPlaylis
 {
   std::unique_lock lock(m_cs);
 
-  // Get rid of any URL options, else the compare may be wrong
-  std::string storedPath{CURL(path).GetWithoutOptions()};
-  URIUtils::RemoveSlashAtEnd(storedPath);
-
-  if (const auto& i{m_cache.find(storedPath)}; i != m_cache.end())
+  if (const Disc * disc{Find(path)}; disc && disc->mainPlaylist)
   {
-    const auto& [_, disc] = *i;
-    if (disc.mainPlaylist)
-    {
-      mainPlaylist = *disc.mainPlaylist;
-      return true;
-    }
+    mainPlaylist = *disc->mainPlaylist;
+    return true;
   }
   return false;
 }
@@ -229,15 +201,12 @@ void CBlurayDiscCache::ClearDisc(const std::string& path)
 {
   std::unique_lock lock(m_cs);
 
-  // Get rid of any URL options, else the compare may be wrong
-  std::string storedPath{CURL(path).GetWithoutOptions()};
-  URIUtils::RemoveSlashAtEnd(storedPath);
-
-  m_cache.erase(storedPath);
+  m_cache.erase(GetDiscKey(path));
 }
 
 void CBlurayDiscCache::Clear()
 {
   std::unique_lock lock(m_cs);
+
   m_cache.clear();
 }

--- a/xbmc/filesystem/BlurayDiscCache.h
+++ b/xbmc/filesystem/BlurayDiscCache.h
@@ -15,6 +15,7 @@
 #include "threads/CriticalSection.h"
 
 #include <map>
+#include <optional>
 
 struct Disc
 {
@@ -27,6 +28,9 @@ struct Disc
   CFileItemList itemMap;
 
   std::map<unsigned int, XFILE::StreamMap, std::less<>> streamMap;
+
+  std::optional<bool> menuSupport;
+  std::optional<int> mainPlaylist;
 };
 
 using CacheMapEntry = std::pair<std::string, Disc>;
@@ -55,6 +59,8 @@ public:
   void SetPlaylistStreamInfo(const std::string& path,
                              unsigned int playlist,
                              const StreamMap& streams);
+  void SetMenuSupport(const std::string& path, bool menuSupport);
+  void SetMainPlaylist(const std::string& path, int mainPlaylist);
 
   bool GetPlaylistInfo(const std::string& path,
                        unsigned int playlist,
@@ -66,6 +72,20 @@ public:
   bool GetPlaylistStreamInfo(const std::string& path,
                              unsigned int playlist,
                              StreamMap& streams) const;
+
+  /*!
+   \brief Get whether this disc supports menus, if already determined.
+   \param[out] menuSupport set only when true is returned
+   \return true if the disc has been probed for menu support before
+   */
+  bool GetMenuSupport(const std::string& path, bool& menuSupport) const;
+
+  /*!
+   \brief Get the main playlist named in the disc's disc.inf, if already looked for.
+   \param[out] mainPlaylist set only when true is returned, -1 when the disc names no playlist
+   \return true if the disc has been examined for a main playlist before
+   */
+  bool GetMainPlaylist(const std::string& path, int& mainPlaylist) const;
 
   void ClearDisc(const std::string& path);
 

--- a/xbmc/filesystem/BlurayDiscCache.h
+++ b/xbmc/filesystem/BlurayDiscCache.h
@@ -14,8 +14,10 @@
 #include "bluray/PlaylistStructure.h"
 #include "threads/CriticalSection.h"
 
+#include <cstdint>
 #include <map>
 #include <optional>
+#include <string>
 
 struct Disc
 {
@@ -31,9 +33,12 @@ struct Disc
 
   std::optional<bool> menuSupport;
   std::optional<int> mainPlaylist;
+
+  //! When this disc was last used, to decide which to drop when the cache is full. Mutable as
+  //! recency is not part of what the cache holds, so reading a disc's information updates it too.
+  mutable uint64_t lastUsed{0};
 };
 
-using CacheMapEntry = std::pair<std::string, Disc>;
 using CacheMap = std::map<std::string, Disc, std::less<>>;
 
 namespace XFILE
@@ -48,7 +53,6 @@ public:
 
   void Clear();
 
-  CacheMap::iterator SetDisc(const std::string& path);
   void SetPlaylistInfo(const std::string& path,
                        unsigned int playlist,
                        const BlurayPlaylistInformation& playlistInfo);
@@ -87,10 +91,29 @@ public:
    */
   bool GetMainPlaylist(const std::string& path, int& mainPlaylist) const;
 
+  //! Drop everything held for a disc, as its information no longer describes what is in the drive
   void ClearDisc(const std::string& path);
 
 private:
+  /*!
+   \brief Find a disc, recording that it has been used. m_cs must be held.
+   \return the disc, or nullptr if nothing is held for it
+   */
+  const Disc* Find(const std::string& path) const;
+
+  /*!
+   \brief Find a disc, adding it if nothing is held for it yet, and recording that it has been
+   used. Adding may drop the least recently used disc. m_cs must be held.
+   */
+  Disc& FindOrCreate(const std::string& path);
+
+  //! Drop the least recently used discs until the cache is within its limit. m_cs must be held.
+  void Evict();
+
   CacheMap m_cache;
+
+  //! Ticks on every use, to order the discs by how recently they were used
+  mutable uint64_t m_useCounter{0};
 
   mutable CCriticalSection m_cs;
 };

--- a/xbmc/filesystem/CMakeLists.txt
+++ b/xbmc/filesystem/CMakeLists.txt
@@ -137,9 +137,11 @@ endif()
 
 if(TARGET ${APP_NAME_LC}::Udfread)
   list(APPEND SOURCES UDFBlockInput.cpp
+                      UDFContext.cpp
                       UDFDirectory.cpp
                       UDFFile.cpp)
   list(APPEND HEADERS UDFBlockInput.h
+                      UDFContext.h
                       UDFDirectory.h
                       UDFFile.h)
 endif()

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -82,6 +82,12 @@ CDiscDirectoryHelper::CDiscDirectoryHelper()
                                                    1000);
 }
 
+CDiscDirectoryHelper::CDiscDirectoryHelper(StreamDetailsProvider getStreamDetails)
+  : CDiscDirectoryHelper()
+{
+  m_getStreamDetails = std::move(getStreamDetails);
+}
+
 void CDiscDirectoryHelper::InitialiseEpisodePlaylistSearch(int episodeIndex,
                                                            const Episodes& episodesOnDisc)
 {
@@ -1142,6 +1148,25 @@ std::shared_ptr<CFileItem> GenerateEpisodeItem(const CURL& url,
 
   return item;
 }
+
+// Stream details are deferred during title determination, as deriving them for every title on a
+// disc is expensive.
+void AddStreamDetails(const StreamDetailsProvider& getStreamDetails,
+                      const CFileItemList& allTitles,
+                      unsigned int playlist,
+                      CFileItem& item)
+{
+  if (!getStreamDetails)
+    return;
+
+  if (!allTitles.Contains(item.GetPath()))
+  {
+    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Playlist {} not found in disc titles", playlist);
+    return;
+  }
+
+  getStreamDetails(playlist, item);
+}
 } // namespace
 
 void CDiscDirectoryHelper::EndEpisodePlaylistSearch()
@@ -1201,12 +1226,7 @@ void CDiscDirectoryHelper::PopulateEpisodeFileItems(const CURL& url,
         continue;
       }
 
-      if (const auto detailsItem{allTitles.Get(newItem->GetPath())}; detailsItem)
-        newItem->GetVideoInfoTag()->m_streamDetails =
-            detailsItem->GetVideoInfoTag()->m_streamDetails;
-      else
-        CLog::LogFC(LOGDEBUG, LOGBLURAY, "Failed to find streamdetails for playlist {}",
-                    playlist.playlist);
+      AddStreamDetails(m_getStreamDetails, allTitles, playlist.playlist, *newItem);
 
       items.Add(newItem);
     }
@@ -1234,11 +1254,7 @@ void CDiscDirectoryHelper::PopulateEpisodeFileItems(const CURL& url,
         continue;
       }
 
-      if (const auto detailsItem{allTitles.Get(newItem->GetPath())}; detailsItem)
-        newItem->GetVideoInfoTag()->m_streamDetails =
-            detailsItem->GetVideoInfoTag()->m_streamDetails;
-      else
-        CLog::LogFC(LOGDEBUG, LOGBLURAY, "Failed to find streamdetails for playlist {}", playlist);
+      AddStreamDetails(m_getStreamDetails, allTitles, playlist, *newItem);
 
       items.Add(newItem);
     }
@@ -1248,7 +1264,7 @@ void CDiscDirectoryHelper::PopulateEpisodeFileItems(const CURL& url,
 bool CDiscDirectoryHelper::GetEpisodePlaylists(
     const CURL& url,
     CFileItemList& items,
-    const CFileItemList& allTitles, // FileItem for each playlist including stream details
+    const CFileItemList& allTitles, // FileItem for each playlist on the disc (no stream details)
     int episodeIndex,
     const Episodes& episodesOnDiscUnsorted,
     const ClipMap& clips,
@@ -1329,7 +1345,8 @@ void PopulateAllEpisodesFileItems(const CURL& url,
                                   CFileItemList& items,
                                   const CFileItemList& allTitles,
                                   const std::vector<PlaylistInformation>& playlists,
-                                  const PlaylistMap& playlistMap)
+                                  const PlaylistMap& playlistMap,
+                                  const StreamDetailsProvider& getStreamDetails)
 {
   // Sort by playlist
   auto sortedPlaylists = playlists;
@@ -1351,11 +1368,7 @@ void PopulateAllEpisodesFileItems(const CURL& url,
       continue;
     }
 
-    if (const auto detailsItem{allTitles.Get(newItem->GetPath())}; detailsItem)
-      newItem->GetVideoInfoTag()->m_streamDetails = detailsItem->GetVideoInfoTag()->m_streamDetails;
-    else
-      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Failed to find streamdetails for playlist {}",
-                  playlist.playlist);
+    AddStreamDetails(getStreamDetails, allTitles, playlist.playlist, *newItem);
 
     items.Add(newItem);
   }
@@ -1381,7 +1394,7 @@ bool CDiscDirectoryHelper::FilterAllEpisodesPlaylists(std::vector<PlaylistInform
 bool CDiscDirectoryHelper::GetAllEpisodePlaylists(
     const CURL& url,
     CFileItemList& items,
-    const CFileItemList& allTitles, // FileItem for each playlist including stream details
+    const CFileItemList& allTitles, // FileItem for each playlist on the disc (no stream details)
     GetTitle job,
     const Episodes& episodesOnDiscUnsorted,
     const ClipMap& clips,
@@ -1409,7 +1422,7 @@ bool CDiscDirectoryHelper::GetAllEpisodePlaylists(
   if (!FilterAllEpisodesPlaylists(playlists, job))
     return false;
   EndEpisodePlaylistSearch();
-  PopulateAllEpisodesFileItems(url, items, allTitles, playlists, playlistMap);
+  PopulateAllEpisodesFileItems(url, items, allTitles, playlists, playlistMap, m_getStreamDetails);
 
   return !items.IsEmpty();
 }
@@ -1534,8 +1547,9 @@ void PopulateMovieFileItems(
     const CURL& url,
     CFileItemList& items,
     int mainPlaylist,
-    const CFileItemList& allTitles, // FileItem for each playlist including stream details
-    const std::vector<PlaylistInformation>& playlists)
+    const CFileItemList& allTitles, // FileItem for each playlist on the disc (no stream details)
+    const std::vector<PlaylistInformation>& playlists,
+    const StreamDetailsProvider& getStreamDetails)
 {
   // Sort by duration (putting mainPlaylist first if present)
   auto sortedPlaylists = playlists;
@@ -1564,11 +1578,7 @@ void PopulateMovieFileItems(
       continue;
     }
 
-    if (const auto detailsItem{allTitles.Get(newItem->GetPath())}; detailsItem)
-      newItem->GetVideoInfoTag()->m_streamDetails = detailsItem->GetVideoInfoTag()->m_streamDetails;
-    else
-      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Failed to find streamdetails for playlist {}",
-                  playlist.playlist);
+    AddStreamDetails(getStreamDetails, allTitles, playlist.playlist, *newItem);
 
     items.Add(newItem);
   }
@@ -1594,7 +1604,7 @@ bool CDiscDirectoryHelper::GetMoviePlaylists(const CURL& url,
   if (!FilterMoviePlaylists(playlists, job))
     return false;
   GetMainMoviePlaylists(playlists, job, mainPlaylist);
-  PopulateMovieFileItems(url, items, mainPlaylist, allTitles, playlists);
+  PopulateMovieFileItems(url, items, mainPlaylist, allTitles, playlists, m_getStreamDetails);
   EndMoviePlaylistSearch();
 
   return !items.IsEmpty();

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -14,6 +14,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <set>
 #include <string>
@@ -138,6 +139,12 @@ static constexpr int DURATION_TOLERANCE_PERCENT{20};
 static constexpr std::chrono::milliseconds MIN_MOVIE_DURATION{30 * 60 * 1000}; // 30 minutes
 static constexpr int MAIN_TITLE_LENGTH_PERCENT{70};
 
+/*!
+ \brief Populates the stream details of item for the given title on the disc.
+ Supplied by the disc's directory implementation.
+ */
+using StreamDetailsProvider = std::function<void(unsigned int title, CFileItem& item)>;
+
 class CDiscDirectoryHelper
 {
   enum class IsSpecial : bool
@@ -173,6 +180,14 @@ class CDiscDirectoryHelper
 
 public:
   CDiscDirectoryHelper();
+
+  /*!
+   * \brief Construct a helper that can describe the streams of the titles it returns.
+   * \param getStreamDetails supplied by the disc's directory implementation. When empty the
+   *        returned items carry no stream details.
+   */
+  explicit CDiscDirectoryHelper(StreamDetailsProvider getStreamDetails);
+
   CDiscDirectoryHelper(const CDiscDirectoryHelper&) = delete;
   CDiscDirectoryHelper& operator=(const CDiscDirectoryHelper&) = delete;
 
@@ -315,6 +330,9 @@ private:
                                 const Episodes& episodesOnDisc,
                                 const PlaylistMap& playlists) const;
   bool FilterAllEpisodesPlaylists(std::vector<PlaylistInformation>& playlists, GetTitle job);
+
+  //! Describes the streams of a title, supplied by the disc's directory implementation
+  StreamDetailsProvider m_getStreamDetails;
 
   std::chrono::milliseconds m_minEpisodeDuration{0ms};
 

--- a/xbmc/filesystem/UDFContext.cpp
+++ b/xbmc/filesystem/UDFContext.cpp
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "UDFContext.h"
+
+#include "URL.h"
+#include "threads/CriticalSection.h"
+#include "utils/log.h"
+
+#include <map>
+#include <mutex>
+
+#include <udfread/udfread.h>
+
+using namespace XFILE;
+
+namespace
+{
+CCriticalSection g_mountLock;
+
+//! Volumes currently mounted, so that concurrent readers of one image share a single mount
+std::map<std::string, std::weak_ptr<CUDFContext>, std::less<>> g_mounts;
+} // namespace
+
+CUDFContext::~CUDFContext()
+{
+  if (m_udf)
+    udfread_close(m_udf); // Closes the block input too
+}
+
+bool CUDFContext::Mount(const std::string& image)
+{
+  m_udf = udfread_init();
+  if (!m_udf)
+    return false;
+
+  udfread_block_input* blockInput{m_blockInput.GetBlockInput(image)};
+  if (!blockInput)
+  {
+    udfread_close(m_udf);
+    m_udf = nullptr;
+    return false;
+  }
+
+  if (udfread_open_input(m_udf, blockInput) < 0)
+  {
+    blockInput->close(blockInput);
+    udfread_close(m_udf);
+    m_udf = nullptr;
+    return false;
+  }
+
+  return true;
+}
+
+std::shared_ptr<CUDFContext> CUDFContext::Get(const std::string& image)
+{
+  std::unique_lock lock(g_mountLock);
+
+  if (const auto it{g_mounts.find(image)}; it != g_mounts.end())
+  {
+    if (std::shared_ptr<CUDFContext> context{it->second.lock()}; context)
+      return context;
+
+    g_mounts.erase(it);
+  }
+
+  // Cannot use make_shared as the constructor is private
+  std::shared_ptr<CUDFContext> context{new CUDFContext()};
+  if (!context->Mount(image))
+    return nullptr;
+
+  // One line per mount, so a run of reads that is sharing one mount is distinguishable from one
+  // that is re-mounting for every file
+  CLog::LogF(LOGDEBUG, "Mounted UDF volume of {}", CURL::GetRedacted(image));
+
+  // Forget any volumes that have since been unmounted
+  std::erase_if(g_mounts, [](const auto& mount) { return mount.second.expired(); });
+
+  g_mounts[image] = context;
+
+  return context;
+}
+
+CUDFMount::CUDFMount(const std::string& path)
+{
+  if (const CURL url{path}; url.IsProtocol("udf"))
+    m_context = CUDFContext::Get(url.GetHostName());
+}

--- a/xbmc/filesystem/UDFContext.h
+++ b/xbmc/filesystem/UDFContext.h
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "filesystem/UDFBlockInput.h"
+
+#include <memory>
+#include <string>
+
+struct udfread;
+
+namespace XFILE
+{
+/*!
+ \brief A mounted UDF volume, shared by everything reading from the same image.
+
+ Mounting parses the volume descriptor sequence, the file set descriptor and the root directory -
+ a dozen or so reads of the image, and so a dozen round trips when the image is on a network share.
+ That is paid on every file open unless the volume is shared, which made examining a bluray image
+ (one open per playlist, of which a disc can have hundreds) dominated by re-mounting the same
+ volume.
+
+ libudfread supports a shared handle: its lazily built directory cache is maintained with atomic
+ compare-and-exchange, per-file and per-directory read positions live in the UDFFILE/UDFDIR
+ handles, and the only other shared state is the block input, whose reads CUDFBlockInput
+ serialises.
+ */
+class CUDFContext
+{
+public:
+  ~CUDFContext();
+  CUDFContext(const CUDFContext&) = delete;
+  CUDFContext& operator=(const CUDFContext&) = delete;
+  CUDFContext(CUDFContext&&) = delete;
+  CUDFContext& operator=(CUDFContext&&) = delete;
+
+  /*!
+   \brief Get the mounted volume of an image, mounting it if nothing holds it mounted already.
+   The volume stays mounted until the last holder lets go - it is never held by the cache alone, as
+   that would leave a handle open on the image and, on Windows, stop the user deleting or renaming
+   it. A single open is therefore no cheaper than before; to make a run of opens share one mount,
+   hold a CUDFMount across them.
+   \param image path to the image
+   \return the mounted volume, or nullptr if the image could not be mounted
+   */
+  static std::shared_ptr<CUDFContext> Get(const std::string& image);
+
+  udfread* GetHandle() const { return m_udf; }
+
+private:
+  CUDFContext() = default;
+  bool Mount(const std::string& image);
+
+  CUDFBlockInput m_blockInput;
+  udfread* m_udf{nullptr};
+};
+
+/*!
+ \brief Keeps the UDF volume of an image mounted for as long as the guard lives.
+
+ Hold one across a run of reads from the same image - examining a bluray reads one file per
+ playlist - so that they share a single mount instead of re-mounting the volume for each. Costs
+ nothing for a path that does not name a file on a UDF image.
+ */
+class CUDFMount
+{
+public:
+  /*!
+   \param path any path or URL. Nothing is held unless it is a udf:// URL.
+   */
+  explicit CUDFMount(const std::string& path);
+
+  ~CUDFMount() = default;
+  CUDFMount(const CUDFMount&) = delete;
+  CUDFMount& operator=(const CUDFMount&) = delete;
+  CUDFMount(CUDFMount&&) noexcept = default;
+  CUDFMount& operator=(CUDFMount&&) noexcept = default;
+
+private:
+  std::shared_ptr<CUDFContext> m_context;
+};
+} // namespace XFILE

--- a/xbmc/filesystem/UDFDirectory.cpp
+++ b/xbmc/filesystem/UDFDirectory.cpp
@@ -15,7 +15,7 @@
 #include "FileItemList.h"
 #include "URL.h"
 #include "Util.h"
-#include "filesystem/UDFBlockInput.h"
+#include "filesystem/UDFContext.h"
 #include "utils/URIUtils.h"
 
 #include <udfread/udfread.h>
@@ -38,27 +38,16 @@ bool CUDFDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   URIUtils::AddSlashAtEnd(strRoot);
   URIUtils::AddSlashAtEnd(strSub);
 
-  auto udf = udfread_init();
-
-  if (!udf)
+  // Held for as long as this directory is being read
+  const auto context{CUDFContext::Get(url2.GetHostName())};
+  if (!context)
     return false;
 
-  CUDFBlockInput udfbi;
-
-  auto bi = udfbi.GetBlockInput(url2.GetHostName());
-
-  if (udfread_open_input(udf, bi) < 0)
-  {
-    udfread_close(udf);
-    return false;
-  }
+  udfread* udf{context->GetHandle()};
 
   auto path = udfread_opendir(udf, strSub.c_str());
   if (!path)
-  {
-    udfread_close(udf);
     return false;
-  }
 
   struct udfread_dirent dirent;
 
@@ -97,7 +86,6 @@ bool CUDFDirectory::GetDirectory(const CURL& url, CFileItemList& items)
   }
 
   udfread_closedir(path);
-  udfread_close(udf);
 
   return true;
 }

--- a/xbmc/filesystem/UDFFile.cpp
+++ b/xbmc/filesystem/UDFFile.cpp
@@ -14,36 +14,21 @@
 
 using namespace XFILE;
 
-CUDFFile::CUDFFile() : m_bi{std::make_unique<CUDFBlockInput>()}
+CUDFFile::~CUDFFile()
 {
+  Close();
 }
 
 bool CUDFFile::Open(const CURL& url)
 {
-  if (m_udf && m_file)
+  if (m_context && m_file)
     return true;
 
-  m_udf = udfread_init();
-
-  if (!m_udf)
+  m_context = CUDFContext::Get(url.GetHostName());
+  if (!m_context)
     return false;
 
-  auto bi = m_bi->GetBlockInput(url.GetHostName());
-
-  if (!bi)
-  {
-    udfread_close(m_udf);
-    return false;
-  }
-
-  if (udfread_open_input(m_udf, bi) < 0)
-  {
-    bi->close(bi);
-    udfread_close(m_udf);
-    return false;
-  }
-
-  m_file = udfread_file_open(m_udf, url.GetFileName().c_str());
+  m_file = udfread_file_open(m_context->GetHandle(), url.GetFileName().c_str());
   if (!m_file)
   {
     Close();
@@ -55,22 +40,19 @@ bool CUDFFile::Open(const CURL& url)
 
 void CUDFFile::Close()
 {
+  // The file must be closed before the volume it was opened from is let go
   if (m_file)
   {
     udfread_file_close(m_file);
     m_file = nullptr;
   }
 
-  if (m_udf)
-  {
-    udfread_close(m_udf);
-    m_udf = nullptr;
-  }
+  m_context.reset();
 }
 
 int CUDFFile::Stat(const CURL& url, struct __stat64* buffer)
 {
-  if (!m_udf || !m_file || !buffer)
+  if (!m_context || !m_file || !buffer)
     return -1;
 
   *buffer = {};

--- a/xbmc/filesystem/UDFFile.h
+++ b/xbmc/filesystem/UDFFile.h
@@ -9,11 +9,10 @@
 #pragma once
 
 #include "IFile.h"
-#include "filesystem/UDFBlockInput.h"
+#include "filesystem/UDFContext.h"
 
 #include <memory>
 
-class udfread;
 typedef struct udfread_file UDFFILE;
 
 namespace XFILE
@@ -22,8 +21,10 @@ namespace XFILE
 class CUDFFile : public IFile
 {
 public:
-  CUDFFile();
-  ~CUDFFile() override = default;
+  CUDFFile() = default;
+
+  //! Closes the file, so that the volume it was opened from is not left mounted
+  ~CUDFFile() override;
 
   bool Open(const CURL& url) override;
   void Close() override;
@@ -39,9 +40,9 @@ public:
   bool Exists(const CURL& url) override;
 
 private:
-  std::unique_ptr<CUDFBlockInput> m_bi{nullptr};
+  //! The mounted volume, held for as long as this file is open
+  std::shared_ptr<CUDFContext> m_context;
 
-  udfread* m_udf{nullptr};
   UDFFILE* m_file{nullptr};
 };
 

--- a/xbmc/filesystem/bluray/MPLSParser.cpp
+++ b/xbmc/filesystem/bluray/MPLSParser.cpp
@@ -326,6 +326,7 @@ bool ParseCLPI(std::vector<std::byte>& buffer, ClipInformation& clipInformation,
 
   clipInformation.version = version;
   clipInformation.clip = clip;
+  clipInformation.streamsRead = true;
 
   const unsigned int programInformationStartAddress{
       GetDWord(buffer, OFFSET_CLPI_PROGRAM_INFORMATION)};
@@ -703,7 +704,8 @@ constexpr unsigned int OFFSET_MPLS_PLAYLISTMARK_DURATION = 10;
 
 bool ProcessClips(const CURL& url,
                   BlurayPlaylistInformation& playlistInformation,
-                  std::map<unsigned int, ClipInformation>& clipCache)
+                  std::map<unsigned int, ClipInformation>& clipCache,
+                  StreamDetails streamDetails)
 {
   for (const auto& playItem : playlistInformation.playItems)
   {
@@ -713,6 +715,15 @@ bool ProcessClips(const CURL& url,
       {
         // In local cache
         playlistInformation.clips.push_back(it->second);
+        continue;
+      }
+
+      if (streamDetails == StreamDetails::DEFER)
+      {
+        // The .clpi holds nothing but the clip's stream information, and reading one per clip is
+        // the bulk of the cost of examining a disc. Record the clip as named by the play item -
+        // its timings are derived from the play item anyway (see DeriveChaptersAndTimings).
+        playlistInformation.clips.push_back(clip);
         continue;
       }
 
@@ -763,7 +774,8 @@ bool ParsePlaylist(const CURL& url,
                    std::vector<std::byte>& buffer,
                    unsigned int& offset,
                    BlurayPlaylistInformation& playlistInformation,
-                   std::map<unsigned int, ClipInformation>& clipCache)
+                   std::map<unsigned int, ClipInformation>& clipCache,
+                   StreamDetails streamDetails)
 {
   if (const unsigned int playlistSize{GetDWord(buffer, offset)};
       buffer.size() < playlistSize + offset)
@@ -796,7 +808,7 @@ bool ParsePlaylist(const CURL& url,
     CLog::LogFC(LOGDEBUG, LOGBLURAY, "Playlist duration {}", fmt::format("{:%H:%M:%S}", duration));
 
     // Process clips
-    if (!ProcessClips(url, playlistInformation, clipCache))
+    if (!ProcessClips(url, playlistInformation, clipCache, streamDetails))
       return false;
   }
 
@@ -945,7 +957,8 @@ bool ParseMPLS(const CURL& url,
                std::vector<std::byte>& buffer,
                BlurayPlaylistInformation& playlistInformation,
                unsigned int playlist,
-               std::map<unsigned int, ClipInformation>& clipCache)
+               std::map<unsigned int, ClipInformation>& clipCache,
+               StreamDetails streamDetails)
 {
   // Check size
   if (buffer.size() < MPLS_HEADER_SIZE)
@@ -990,7 +1003,7 @@ bool ParseMPLS(const CURL& url,
 
   // Parse Playlist
   offset = playlistPosition;
-  if (!ParsePlaylist(url, buffer, offset, playlistInformation, clipCache))
+  if (!ParsePlaylist(url, buffer, offset, playlistInformation, clipCache, streamDetails))
     return false;
 
   // Parse PlayListMark
@@ -1040,10 +1053,13 @@ ChapterInformation::ChapterInformation(unsigned int newChapter,
 bool CMPLSParser::ReadMPLS(const CURL& url,
                            unsigned int playlist,
                            BlurayPlaylistInformation& playlistInformation,
-                           std::map<unsigned int, ClipInformation>& clipCache)
+                           std::map<unsigned int, ClipInformation>& clipCache,
+                           StreamDetails streamDetails)
 {
   try
   {
+    playlistInformation.clipStreamsRead = streamDetails == StreamDetails::INCLUDE;
+
     const std::string& path{url.GetHostName()};
     const std::string playlistFile{
         URIUtils::AddFileToFolder(path, "BDMV", "PLAYLIST", fmt::format("{:05}.mpls", playlist))};
@@ -1058,7 +1074,7 @@ bool CMPLSParser::ReadMPLS(const CURL& url,
     file.Close();
 
     if (read == size)
-      return ParseMPLS(url, buffer, playlistInformation, playlist, clipCache);
+      return ParseMPLS(url, buffer, playlistInformation, playlist, clipCache, streamDetails);
     return false;
   }
   catch (const std::out_of_range& e)
@@ -1074,6 +1090,63 @@ bool CMPLSParser::ReadMPLS(const CURL& url,
   catch (...)
   {
     CLog::LogF(LOGERROR, "MPLS parsing failed");
+    return false;
+  }
+}
+
+bool CMPLSParser::ReadClipStreams(const CURL& url,
+                                  BlurayPlaylistInformation& playlistInformation,
+                                  std::map<unsigned int, ClipInformation>& clipCache)
+{
+  try
+  {
+    for (ClipInformation& clip : playlistInformation.clips)
+    {
+      if (clip.streamsRead)
+        continue;
+
+      // Only the stream information is taken.
+      // The clip's timings were derived from the play items (see DeriveChaptersAndTimings)
+      if (const auto& it{clipCache.find(clip.clip)};
+          it != clipCache.end() && it->second.streamsRead)
+      {
+        const auto& [_, cachedClip] = *it;
+        clip.version = cachedClip.version;
+        clip.programs = cachedClip.programs;
+        clip.streamsRead = true;
+        continue;
+      }
+
+      ClipInformation clipInformation;
+      if (!ReadCLPI(url, clip.clip, clipInformation))
+      {
+        CLog::LogFC(LOGDEBUG, LOGBLURAY, "Cannot read clip {} information", clip.clip);
+        return false;
+      }
+      clipCache[clip.clip] = clipInformation;
+
+      clip.version = std::move(clipInformation.version);
+      clip.programs = std::move(clipInformation.programs);
+      clip.streamsRead = true;
+    }
+
+    playlistInformation.clipStreamsRead = true;
+
+    return true;
+  }
+  catch (const std::out_of_range& e)
+  {
+    CLog::LogF(LOGERROR, "CLPI parsing failed - error {}", e.what());
+    return false;
+  }
+  catch (const std::exception& e)
+  {
+    CLog::LogF(LOGERROR, "CLPI parsing failed - error {}", e.what());
+    return false;
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "CLPI parsing failed");
     return false;
   }
 }

--- a/xbmc/filesystem/bluray/MPLSParser.h
+++ b/xbmc/filesystem/bluray/MPLSParser.h
@@ -24,6 +24,18 @@ enum class ENCODING_TYPE : uint8_t;
 
 using namespace std::chrono_literals;
 
+/*!
+ \brief Whether a playlist's stream details are wanted.
+ Deriving them means reading the .clpi of every clip the playlist references and parsing the m2ts
+ of the longest, so during playlist determination - where only the structure of each playlist on
+ the disc matters - they are deferred until a playlist is known to be wanted.
+ */
+enum class StreamDetails : bool
+{
+  DEFER,
+  INCLUDE
+};
+
 enum class BLURAY_PLAYBACK_TYPE : unsigned int
 {
   SEQUENTIAL = 1,
@@ -118,6 +130,7 @@ struct ClipInformation
   std::string codec;
   std::chrono::milliseconds time{0ms}; // calculated from playItem
   std::chrono::milliseconds duration{0ms}; // calculated from playItem
+  bool streamsRead{false}; // whether the clip's .clpi has been read
   std::vector<ProgramInformation> programs;
 };
 
@@ -188,9 +201,26 @@ struct PlayItemInformation
 class CMPLSParser
 {
 public:
+  /*!
+   \brief Parse a playlist's .mpls into playlistInformation.
+   \param streamDetails when INCLUDE, the .clpi of each clip the playlist references is read for
+          its stream information. When DEFER the clips are recorded by number only, which is all
+          playlist determination needs and costs no further reads.
+   */
   static bool ReadMPLS(const CURL& url,
                        unsigned int playlist,
                        BlurayPlaylistInformation& playlistInformation,
-                       std::map<unsigned int, ClipInformation>& clipCache);
+                       std::map<unsigned int, ClipInformation>& clipCache,
+                       StreamDetails streamDetails);
+
+  /*!
+   \brief Fill in the stream information of a playlist read with StreamDetails::DEFER, by reading
+   the .clpi of each of its clips that has not been read yet.
+   \return true if every clip's stream information is now present, in which case
+           playlistInformation.clipStreamsRead is set
+   */
+  static bool ReadClipStreams(const CURL& url,
+                              BlurayPlaylistInformation& playlistInformation,
+                              std::map<unsigned int, ClipInformation>& clipCache);
 };
 } // namespace XFILE

--- a/xbmc/filesystem/bluray/PlaylistStructure.h
+++ b/xbmc/filesystem/bluray/PlaylistStructure.h
@@ -36,21 +36,35 @@ struct BlurayPlaylistInformation
   std::vector<SubPlayItemInformation> extensionSubPlayItems;
   std::vector<PlaylistMarkInformation> playlistMarks;
   std::vector<ChapterInformation> chapters;
+
+  //! Whether the clips carry the stream information from their .clpi (see CMPLSParser::ReadMPLS)
+  bool clipStreamsRead{false};
 };
 
-// The first angle clip of the longest play item, or nullptr if the playlist has no play items or
-// the longest play item has no clips.
-// A playlist may contain several clips with differing streams, so both the M2TS analysis and the
-// stream information taken from the CLPI must use this same clip for the packet identifiers (and
-// hence the stream details) to correspond.
-inline const ClipInformation* GetLongestPlayItemClip(const BlurayPlaylistInformation& playlist)
+// The longest play item of the playlist, or nullptr if the playlist has no play items.
+// A playlist may contain several clips with differing streams, so the M2TS analysis and the stream
+// information - whether taken from the CLPI or from the play item's stream number table - must all
+// describe this same play item for the packet identifiers (and hence the stream details) to
+// correspond.
+inline const PlayItemInformation* GetLongestPlayItem(const BlurayPlaylistInformation& playlist)
 {
   const auto it{std::ranges::max_element(playlist.playItems, {},
                                          [](const PlayItemInformation& playItem)
                                          { return playItem.outTime - playItem.inTime; })};
-  if (it == playlist.playItems.end() || it->angleClips.empty())
+  if (it == playlist.playItems.end())
     return nullptr;
 
-  return &it->angleClips.front();
+  return &*it;
+}
+
+// The first angle clip of the longest play item, or nullptr if the playlist has no play items or
+// the longest play item has no clips.
+inline const ClipInformation* GetLongestPlayItemClip(const BlurayPlaylistInformation& playlist)
+{
+  const PlayItemInformation* playItem{GetLongestPlayItem(playlist)};
+  if (!playItem || playItem->angleClips.empty())
+    return nullptr;
+
+  return &playItem->angleClips.front();
 }
 } // namespace XFILE

--- a/xbmc/filesystem/bluray/StreamParser.cpp
+++ b/xbmc/filesystem/bluray/StreamParser.cpp
@@ -244,11 +244,72 @@ AudioStreamInfo PopulateAudioStreamInfo(const StreamInformation& stream,
 
   return asi;
 }
+
+// Add one elementary stream to the playlist, refined by the M2TS analysis in s where it has been
+// done (s is empty when stream details were deferred).
+void AddStream(const StreamInformation& stream,
+               const StreamMap& s,
+               unsigned int playlist,
+               PlaylistInformation& p)
+{
+  // Find stream in StreamMap to get accurate details
+  const auto bs{s.find(stream.packetIdentifier)};
+  switch (stream.coding)
+  {
+    using enum ENCODING_TYPE;
+    case VIDEO_MPEG2:
+    case VIDEO_VC1:
+    case VIDEO_H264:
+    case VIDEO_H264_MVC:
+    case VIDEO_HEVC:
+      p.videoStreams.emplace_back(PopulateVideoStreamInfo(
+          stream, bs != s.end() ? dynamic_cast<TSVideoStreamInfo*>(bs->second.get()) : nullptr));
+      break;
+    case AUDIO_LPCM:
+    case AUDIO_AC3:
+    case AUDIO_DTS:
+    case AUDIO_TRUHD:
+    case AUDIO_AC3PLUS:
+    case AUDIO_DTSHD:
+    case AUDIO_DTSHD_MASTER:
+    case AUDIO_AC3PLUS_SECONDARY:
+    case AUDIO_DTSHD_SECONDARY:
+    {
+      const auto* bsai{bs != s.end() ? dynamic_cast<TSAudioStreamInfo*>(bs->second.get())
+                                     : nullptr};
+      if (!bsai && !s.empty())
+        CLog::LogF(LOGDEBUG,
+                   "Playlist {} - no parsed stream information for audio PID 0x{} coding 0x{} "
+                   "- {} - channel count will be unknown",
+                   playlist, fmt::format("{:04x}", stream.packetIdentifier),
+                   fmt::format("{:02x}", static_cast<int>(stream.coding)),
+                   bs == s.end() ? "packet identifier not present in stream map"
+                                 : "stream in map is not an audio stream");
+
+      p.audioStreams.emplace_back(PopulateAudioStreamInfo(stream, bsai));
+      break;
+    }
+    case SUB_PG:
+    case SUB_TEXT:
+    {
+      SubtitleStreamInfo ssi;
+      ssi.valid = true;
+      ssi.language = stream.language;
+
+      p.pgStreams.emplace_back(std::move(ssi));
+      break;
+    }
+    case SUB_IG:
+    default:
+      break;
+  }
+}
 } // namespace
 
 void CStreamParser::ConvertBlurayPlaylistInformation(const BlurayPlaylistInformation& b,
                                                      PlaylistInformation& p,
-                                                     const StreamMap& s)
+                                                     const StreamMap& s,
+                                                     StreamDetails streamDetails)
 {
   // Parse BlurayPlaylistInformation (from MPLS) and stream information (from M2TS) into PlaylistInformation
   p.clear();
@@ -263,6 +324,25 @@ void CStreamParser::ConvertBlurayPlaylistInformation(const BlurayPlaylistInforma
     p.clips.emplace_back(clip.clip);
     p.clipDuration[clip.clip] = clip.duration;
   }
+
+  if (streamDetails == StreamDetails::DEFER)
+  {
+    // Neither the .clpi nor the m2ts has been read, so describe the streams from the play item's
+    // stream number table. That gives the coding and language of every stream the playlist
+    // exposes, which is what telling playlists apart and listing their languages needs - only the
+    // details the m2ts carries (channel counts, resolutions) are missing.
+    if (const PlayItemInformation * playItem{GetLongestPlayItem(b)}; playItem)
+    {
+      for (const auto* streams : {&playItem->videoStreams, &playItem->audioStreams,
+                                  &playItem->presentationGraphicStreams})
+      {
+        for (const StreamInformation& stream : *streams)
+          AddStream(stream, s, b.playlist, p);
+      }
+    }
+    return;
+  }
+
   // Stream information must come from the same clip the M2TS analysis used (see
   // CM2TSParser::GetStreams), otherwise the packet identifiers will not correspond and no parsed
   // details will be found for some (or all) streams
@@ -283,60 +363,7 @@ void CStreamParser::ConvertBlurayPlaylistInformation(const BlurayPlaylistInforma
   if (streamClip && !streamClip->programs.empty())
   {
     for (const StreamInformation& stream : streamClip->programs[0].streams)
-    {
-      // Find stream in StreamMap to get accurate details
-      const auto bs{s.find(stream.packetIdentifier)};
-      switch (stream.coding)
-      {
-        using enum ENCODING_TYPE;
-        case VIDEO_MPEG2:
-        case VIDEO_VC1:
-        case VIDEO_H264:
-        case VIDEO_H264_MVC:
-        case VIDEO_HEVC:
-          p.videoStreams.emplace_back(PopulateVideoStreamInfo(
-              stream,
-              bs != s.end() ? dynamic_cast<TSVideoStreamInfo*>(bs->second.get()) : nullptr));
-          break;
-        case AUDIO_LPCM:
-        case AUDIO_AC3:
-        case AUDIO_DTS:
-        case AUDIO_TRUHD:
-        case AUDIO_AC3PLUS:
-        case AUDIO_DTSHD:
-        case AUDIO_DTSHD_MASTER:
-        case AUDIO_AC3PLUS_SECONDARY:
-        case AUDIO_DTSHD_SECONDARY:
-        {
-          const auto* bsai{bs != s.end() ? dynamic_cast<TSAudioStreamInfo*>(bs->second.get())
-                                         : nullptr};
-          if (!bsai && !s.empty())
-            CLog::LogF(LOGDEBUG,
-                       "Playlist {} - no parsed stream information for audio PID 0x{} coding 0x{} "
-                       "- {} - channel count will be unknown",
-                       b.playlist, fmt::format("{:04x}", stream.packetIdentifier),
-                       fmt::format("{:02x}", static_cast<int>(stream.coding)),
-                       bs == s.end() ? "packet identifier not present in stream map"
-                                     : "stream in map is not an audio stream");
-
-          p.audioStreams.emplace_back(PopulateAudioStreamInfo(stream, bsai));
-          break;
-        }
-        case SUB_PG:
-        case SUB_TEXT:
-        {
-          SubtitleStreamInfo ssi;
-          ssi.valid = true;
-          ssi.language = stream.language;
-
-          p.pgStreams.emplace_back(std::move(ssi));
-          break;
-        }
-        case SUB_IG:
-        default:
-          break;
-      }
-    }
+      AddStream(stream, s, b.playlist, p);
   }
 }
 } // namespace XFILE

--- a/xbmc/filesystem/bluray/StreamParser.h
+++ b/xbmc/filesystem/bluray/StreamParser.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "M2TSParser.h"
+#include "MPLSParser.h"
 
 namespace XFILE
 {
@@ -18,8 +19,15 @@ struct PlaylistInformation;
 class CStreamParser
 {
 public:
+  /*!
+   \brief Convert the parsed .mpls of a playlist into the form the directory handlers use.
+   \param streamDetails when INCLUDE, the stream information comes from the clip's .clpi refined by
+          the M2TS analysis in s. When DEFER, neither has been read, so it comes from the play
+          item's stream number table - enough to tell playlists apart and to list their languages.
+   */
   static void ConvertBlurayPlaylistInformation(const BlurayPlaylistInformation& b,
                                                PlaylistInformation& p,
-                                               const StreamMap& s);
+                                               const StreamMap& s,
+                                               StreamDetails streamDetails);
 };
 } // namespace XFILE


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

See individual commit descriptions.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Optimisations made whilst implimenting other bluray improvements.

Also fixes #28809 - this is because the languages are now derived from the playlist/playitem in mpls (as the should be) rather than the clip data.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally and part of larger PR in #28776

Speed testing

Both runs scanned the same 51 show directories from network share into an empty library (every dir logged "as not in the database").
<img width="1398" height="246" alt="image" src="https://github.com/user-attachments/assets/32f1e309-8478-43ca-85ab-88d96d323e83" />
Method: the scan is serial on one thread (T:9444 old, T:30632 new). "Online" = wall-clock where that thread is blocked inside a scraper script (CScriptRunner: running add-on script → script successfully run). Everything else is local work. Art downloads run on a separate thread (T:38040 / T:10200) and don't block the scan.

Where the local saving came from — time attributed by log function on the scanner thread:
<img width="1396" height="297" alt="image" src="https://github.com/user-attachments/assets/5747299c-09ff-4a16-8dee-a811cd42a919" />
So essentially all of the win is the M2TS stream parsing: 950 s → 39 s, with the parser called 6.5× less often. Consistent with the caching added in BlurayDiscCache / UDFContext / StreamParser in the "Speed" commit.

Caveat on the online figure: the two runs aren't comparable on the online axis. The old run cached 2,933 images; the new run only 380, because the texture cache was already warm from the old run. The −51 s online difference is mostly that, not a code effect. The local figure is the meaningful one.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
