### PR TITLE
[posix][smb] Harden SMB client to recover reads after transient disconnects

### DIFF
--- a/xbmc/filesystem/test/CMakeLists.txt
+++ b/xbmc/filesystem/test/CMakeLists.txt
@@ -14,4 +14,8 @@ if(TARGET ${APP_NAME_LC}::NFS)
   list(APPEND SOURCES TestNfsFile.cpp)
 endif()
 
+if(TARGET ${APP_NAME_LC}::SmbClient)
+  list(APPEND SOURCES TestSMBFile.cpp)
+endif()
+
 core_add_test_library(filesystem_test)

--- a/xbmc/filesystem/test/TestSMBFile.cpp
+++ b/xbmc/filesystem/test/TestSMBFile.cpp
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "platform/posix/filesystem/SMBFile.h"
+
+#include <gtest/gtest.h>
+
+using namespace XFILE;
+
+TEST(TestSMBFileRecovery, ReconnectableReadErrors)
+{
+#ifdef ENETRESET
+  EXPECT_TRUE(SMBFileRecovery::IsReconnectableReadError(ENETRESET));
+#endif
+  EXPECT_TRUE(SMBFileRecovery::IsReconnectableReadError(ECONNRESET));
+  EXPECT_TRUE(SMBFileRecovery::IsReconnectableReadError(ECONNABORTED));
+  EXPECT_TRUE(SMBFileRecovery::IsReconnectableReadError(ENOTCONN));
+  EXPECT_TRUE(SMBFileRecovery::IsReconnectableReadError(EPIPE));
+  EXPECT_TRUE(SMBFileRecovery::IsReconnectableReadError(ETIMEDOUT));
+
+  EXPECT_FALSE(SMBFileRecovery::IsReconnectableReadError(0));
+  EXPECT_FALSE(SMBFileRecovery::IsReconnectableReadError(EACCES));
+  EXPECT_FALSE(SMBFileRecovery::IsReconnectableReadError(ENOENT));
+  EXPECT_FALSE(SMBFileRecovery::IsReconnectableReadError(EINVAL));
+  EXPECT_FALSE(SMBFileRecovery::IsReconnectableReadError(EIO));
+}
+
+TEST(TestSMBFileRecovery, ZeroBytesBeforeKnownFileEndIsInvalidEof)
+{
+  EXPECT_FALSE(SMBFileRecovery::IsValidEof(4095, 4096));
+}
+
+TEST(TestSMBFileRecovery, ZeroBytesAtOrBeyondKnownFileEndIsValidEof)
+{
+  EXPECT_TRUE(SMBFileRecovery::IsValidEof(4096, 4096));
+  EXPECT_TRUE(SMBFileRecovery::IsValidEof(8192, 4096));
+}

--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -27,12 +27,14 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <array>
 #include <chrono>
 #include <cstring>
 #include <inttypes.h>
 #include <list>
 #include <mutex>
 #include <regex>
+#include <thread>
 #include <unordered_map>
 
 #include <libsmbclient.h>
@@ -69,6 +71,8 @@ namespace
 // 15 is a safe value - the total stays under 20 even with the library's
 // additional overhead.
 constexpr size_t MAX_CACHED_SERVERS = 15;
+constexpr std::array<std::chrono::milliseconds, 3> SMB_RECONNECT_BACKOFF{
+    std::chrono::milliseconds{100}, std::chrono::milliseconds{250}, std::chrono::milliseconds{500}};
 
 // Cached remove_unused_server function pointer, obtained once during Init.
 smbc_remove_unused_server_fn g_removeUnusedFn = nullptr;
@@ -688,7 +692,11 @@ bool CSMBFile::Open(const CURL& url)
     CLog::Log(LOGINFO, "SMBFile->Open: Bad URL : '{}'", url.GetRedacted());
     return false;
   }
-  m_url = url;
+  // Keep the URL used for reconnects password-free. Explicit credentials are
+  // copied to the password manager after the initial open succeeds.
+  m_url = CURL(url.GetWithoutUserDetails());
+  m_url.SetDomain(url.GetDomain());
+  m_url.SetUserName(url.GetUserName());
 
   // opening a file to another computer share will create a new session
   // when opening smb://server xbms will try to find folder.jpg in all shares
@@ -706,9 +714,24 @@ bool CSMBFile::Open(const CURL& url)
     return false;
   }
 
+  if (!url.GetPassWord().empty())
+  {
+    CPasswordManager& passwordManager = CPasswordManager::GetInstance();
+    passwordManager.SaveAuthenticatedURL(url, false);
+
+    const CURL resolvedUrl = CSMB::GetResolvedUrl(url);
+    if (resolvedUrl.GetHostName() != url.GetHostName())
+      passwordManager.SaveAuthenticatedURL(resolvedUrl, false);
+  }
+
   std::unique_lock lock(smb);
   if (!smb.IsSmbValid())
+  {
+    // Deinit() closes open files when destroying the SMB context, so only
+    // the now-invalid descriptor needs to be reset here.
+    m_fd = -1;
     return false;
+  }
   struct stat tmpBuffer;
   if (smbc_stat(strFileName.c_str(), &tmpBuffer) < 0)
   {
@@ -726,6 +749,10 @@ bool CSMBFile::Open(const CURL& url)
     m_fd = -1;
     return false;
   }
+
+  m_reopenEnabled = true;
+  m_readPosition = ret;
+
   // We've successfully opened the file!
   return true;
 }
@@ -822,13 +849,53 @@ int CSMBFile::Truncate(int64_t size)
   return 0;
 }
 
+bool CSMBFile::ReopenAtPositionLocked(int64_t offset, const std::string& reopenPath)
+{
+  if (!smb.IsSmbValid())
+  {
+    errno = ENOTCONN;
+    return false;
+  }
+
+  if (!m_reopenEnabled)
+  {
+    errno = EINVAL;
+    return false;
+  }
+
+  errno = 0;
+  const int newFd = smbc_open(reopenPath.c_str(), O_RDONLY, 0);
+  if (newFd < 0)
+  {
+    if (errno == 0)
+      errno = EIO;
+    return false;
+  }
+
+  struct stat tmpBuffer = {};
+  errno = 0;
+  const bool fileSizeAvailable = smbc_fstat(newFd, &tmpBuffer) == 0;
+
+  errno = 0;
+  const int64_t actualOffset = smbc_lseek(newFd, offset, SEEK_SET);
+  if (actualOffset != offset)
+  {
+    const int seekErrno = actualOffset < 0 && errno != 0 ? errno : EIO;
+    smbc_close(newFd);
+    errno = seekErrno;
+    return false;
+  }
+
+  if (fileSizeAvailable)
+    m_fileSize = tmpBuffer.st_size;
+  m_fd = newFd;
+  return true;
+}
+
 ssize_t CSMBFile::Read(void* lpBuf, size_t uiBufSize)
 {
   if (uiBufSize > SSIZE_MAX)
     uiBufSize = SSIZE_MAX;
-
-  if (m_fd == -1)
-    return -1;
 
   // Some external libs (libass) use test read with zero size and
   // null buffer pointer to check whether file is readable, but
@@ -836,27 +903,153 @@ ssize_t CSMBFile::Read(void* lpBuf, size_t uiBufSize)
   // regardless of buffer size.
   // To overcome this, force return "0" in that case.
   if (uiBufSize == 0 && lpBuf == NULL)
-    return 0;
+    return m_fd == -1 ? -1 : 0;
 
   std::unique_lock lock(smb); // Init not called since it has to be "inited" by now
   if (!smb.IsSmbValid())
     return -1;
-  smb.SetActivityTime();
 
-  ssize_t bytesRead = smbc_read(m_fd, lpBuf, (int)uiBufSize);
-
-  if (m_allowRetry && bytesRead < 0 && errno == EINVAL)
+  if (m_fd == -1)
   {
-    CLog::Log(LOGERROR, "{} - Error( {}, {}, {} ) - Retrying", __FUNCTION__, bytesRead, errno,
-              strerror(errno));
-    bytesRead = smbc_read(m_fd, lpBuf, (int)uiBufSize);
+    if (!m_reopenOnNextRead)
+      return -1;
+
+    const CURL reopenUrl = m_url;
+    const int64_t reopenOffset = m_readPosition;
+    lock.unlock();
+    const std::string reopenPath = GetAuthenticatedPath(reopenUrl);
+    lock.lock();
+
+    if (!m_reopenOnNextRead || !ReopenAtPositionLocked(reopenOffset, reopenPath))
+      return -1;
+    m_reopenOnNextRead = false;
   }
 
-  if (bytesRead < 0)
-    CLog::Log(LOGERROR, "{} - Error( {}, {}, {} )", __FUNCTION__, bytesRead, errno,
-              strerror(errno));
+  smb.SetActivityTime();
 
-  return bytesRead;
+  const int64_t failedReadOffset = m_readPosition;
+  auto readLocked = [&]()
+  {
+    errno = 0;
+    ssize_t result = smbc_read(m_fd, lpBuf, uiBufSize);
+    int readErrno = result < 0 ? errno : 0;
+
+    if (m_allowRetry && result < 0 && readErrno == EINVAL)
+    {
+      CLog::Log(LOGERROR, "{} - Error( {}, {}, {} ) - Retrying", __FUNCTION__, result, readErrno,
+                strerror(readErrno));
+      errno = 0;
+      result = smbc_read(m_fd, lpBuf, uiBufSize);
+      readErrno = result < 0 ? errno : 0;
+    }
+
+    if (result < 0 && readErrno == 0)
+      readErrno = EIO;
+    errno = readErrno;
+    return result;
+  };
+
+  ssize_t bytesRead = readLocked();
+  if (bytesRead > 0)
+  {
+    m_readPosition += bytesRead;
+    return bytesRead;
+  }
+
+  int readErrno = errno;
+  const bool unexpectedEof =
+      bytesRead == 0 && !SMBFileRecovery::IsValidEof(failedReadOffset, m_fileSize);
+  if (!m_reopenEnabled || (!unexpectedEof && !SMBFileRecovery::IsReconnectableReadError(readErrno)))
+  {
+    if (bytesRead < 0)
+      CLog::Log(LOGERROR, "{} - Error( {}, {}, {} )", __FUNCTION__, bytesRead, readErrno,
+                strerror(readErrno));
+    errno = readErrno;
+    return bytesRead;
+  }
+
+  const int originalReadErrno = unexpectedEof ? EIO : readErrno;
+
+  if (!m_allowRetry)
+  {
+    // Let the caller schedule retries, but ensure its next Read() reopens the connection instead of
+    // using the failed descriptor again.
+    const int failedFd = m_fd;
+    m_fd = -1;
+    m_reopenOnNextRead = true;
+    smbc_close(failedFd);
+    errno = originalReadErrno;
+    return bytesRead;
+  }
+
+  int finalErrno = originalReadErrno;
+  const CURL reopenUrl = m_url;
+  const int failedFd = m_fd;
+  m_fd = -1;
+  smbc_close(failedFd);
+  errno = originalReadErrno;
+  lock.unlock();
+
+  unsigned int attempts = 0;
+  for (const auto backoff : SMB_RECONNECT_BACKOFF)
+  {
+    ++attempts;
+    std::this_thread::sleep_for(backoff);
+    const std::string reopenPath = GetAuthenticatedPath(reopenUrl);
+    lock.lock();
+
+    if (!ReopenAtPositionLocked(failedReadOffset, reopenPath))
+    {
+      finalErrno = errno != 0 ? errno : EIO;
+      lock.unlock();
+      if (!SMBFileRecovery::IsReconnectableReadError(finalErrno))
+        break;
+      continue;
+    }
+
+    bytesRead = readLocked();
+    readErrno = errno;
+    if (bytesRead > 0)
+    {
+      m_readPosition += bytesRead;
+      CLog::Log(LOGWARNING, "SMB read recovered at offset {} on attempt {}", failedReadOffset,
+                attempts);
+      errno = 0;
+      return bytesRead;
+    }
+
+    if (bytesRead == 0 && SMBFileRecovery::IsValidEof(failedReadOffset, m_fileSize))
+    {
+      CLog::Log(LOGWARNING, "SMB read recovered at offset {} on attempt {}", failedReadOffset,
+                attempts);
+      errno = 0;
+      return 0;
+    }
+
+    const bool retryUnexpectedEof = bytesRead == 0;
+    finalErrno = retryUnexpectedEof ? originalReadErrno : readErrno;
+    const int replacementFd = m_fd;
+    m_fd = -1;
+    smbc_close(replacementFd);
+    errno = finalErrno;
+    lock.unlock();
+
+    if (!retryUnexpectedEof && !SMBFileRecovery::IsReconnectableReadError(finalErrno))
+      break;
+  }
+
+  lock.lock();
+  m_fd = -1;
+  m_reopenEnabled = false;
+  m_reopenOnNextRead = false;
+  m_readPosition = 0;
+  lock.unlock();
+
+  CLog::Log(LOGERROR, "SMB read recovery failed at offset {} after {} attempts: errno {}",
+            failedReadOffset, attempts, finalErrno);
+  errno = finalErrno;
+
+  return -1;
 }
 
 int64_t CSMBFile::Seek(int64_t iFilePosition, int iWhence)
@@ -876,20 +1069,27 @@ int64_t CSMBFile::Seek(int64_t iFilePosition, int iWhence)
     return -1;
   }
 
+  if (m_reopenEnabled)
+    m_readPosition = pos;
+
   return pos;
 }
 
 void CSMBFile::Close()
 {
-  if (m_fd != -1)
-  {
-    CLog::Log(LOGDEBUG, "CSMBFile::Close closing fd {}", m_fd);
-    std::unique_lock lock(smb);
-    if (!smb.IsSmbValid())
-      return;
-    smbc_close(m_fd);
-  }
+  std::unique_lock lock(smb);
+
+  const int fd = m_fd;
   m_fd = -1;
+  m_reopenEnabled = false;
+  m_reopenOnNextRead = false;
+  m_readPosition = 0;
+
+  if (fd != -1 && smb.IsSmbValid())
+  {
+    CLog::Log(LOGDEBUG, "CSMBFile::Close closing fd {}", fd);
+    smbc_close(fd);
+  }
 }
 
 ssize_t CSMBFile::Write(const void* lpBuf, size_t uiBufSize)

--- a/xbmc/platform/posix/filesystem/SMBFile.h
+++ b/xbmc/platform/posix/filesystem/SMBFile.h
@@ -19,6 +19,10 @@
 #include "filesystem/IFile.h"
 #include "threads/CriticalSection.h"
 
+#include <cerrno>
+#include <cstdint>
+#include <string>
+
 #define NT_STATUS_CONNECTION_REFUSED long(0xC0000000 | 0x0236)
 #define NT_STATUS_INVALID_HANDLE long(0xC0000000 | 0x0008)
 #define NT_STATUS_ACCESS_DENIED long(0xC0000000 | 0x0022)
@@ -58,6 +62,32 @@ extern CSMB smb;
 
 namespace XFILE
 {
+namespace SMBFileRecovery
+{
+constexpr bool IsReconnectableReadError(int error) noexcept
+{
+  switch (error)
+  {
+#ifdef ENETRESET
+    case ENETRESET:
+#endif
+    case ECONNRESET:
+    case ECONNABORTED:
+    case ENOTCONN:
+    case EPIPE:
+    case ETIMEDOUT:
+      return true;
+    default:
+      return false;
+  }
+}
+
+constexpr bool IsValidEof(int64_t offset, int64_t fileSize) noexcept
+{
+  return offset >= fileSize;
+}
+} // namespace SMBFileRecovery
+
 class CSMBFile : public IFile
 {
 public:
@@ -89,5 +119,12 @@ protected:
   int64_t m_fileSize;
   int m_fd;
   bool m_allowRetry;
+
+private:
+  bool ReopenAtPositionLocked(int64_t offset, const std::string& reopenPath);
+
+  bool m_reopenEnabled{false};
+  bool m_reopenOnNextRead{false};
+  int64_t m_readPosition{0};
 };
 }


### PR DESCRIPTION
## Description

This PR hardens the SMB client to survive TCP resets during playback.

It does this by reopening read-only SMB files at the failed byte offset and retrying transient transport errors instead of terminating playback.

Opening as a draft, because the offending TCP RST packets are being invented and spoofed inside my new Asus router. I'm working with Asus to see if this is expected behavior.

## Motivation and context

Fixes a problem in my shiny new Asus RT-BE96U router, unfolding here: https://zentalk.asus.com/t5/networking/rt-be96u-injects-spoofed-tcp-rst-packets-into-smb-connections/m-p/510275/highlight/true#M5184

The router is "inventing" RST packets and claiming they're from the server. This isn't abnormal behavior for firewalls, proxies, and intrusion-prevention systems, which can intentionally generate TCP RSTs. But an ordinary LAN router should not invent a reset, impersonate one endpoint, and terminate the session without a documented policy reason.

## How has this been tested?

Tested on my NVIDIA Shield. Playback survives the weird TCP resets generated by the router.

## What is the effect on users?

* Fixes occasional stopping of videos when routers be like WHAAAAA

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
