### PR TITLE
[Video][Bluray] Improvements to episode identification algorithms.

### DIFF
--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -438,6 +438,10 @@ void ProcessPlaylist(PlaylistMap& playlists, PlaylistInformation& titleInfo, Cli
     }
   }
 
+  info.videoStreams = titleInfo.videoStreams;
+  info.audioStreams = titleInfo.audioStreams;
+  info.pgStreams = titleInfo.pgStreams;
+
   // Get languages
   const std::string langs{fmt::format(
       "{}", fmt::join(titleInfo.audioStreams | std::views::transform(&StreamInfo::language), ","))};

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -120,22 +120,22 @@ void CDiscDirectoryHelper::InitialiseEpisodePlaylistSearch(int episodeIndex,
   if (m_isSpecial == IsSpecial::SPECIAL && m_numEpisodes > 0)
     m_allEpisodes = AllEpisodes::ALL;
 
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "*** Episode Search Start ***");
+  CLog::LogF(LOGDEBUG, "*** Episode Search Start ***");
 
   if (m_allEpisodes == AllEpisodes::SINGLE)
   {
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Looking for season {} episode {} duration {}",
-                episodesOnDisc[episodeIndex].iSeason, episodesOnDisc[episodeIndex].iEpisode,
-                episodesOnDisc[episodeIndex].duration);
+    CLog::LogF(LOGDEBUG, "Looking for season {} episode {} duration {}",
+               episodesOnDisc[episodeIndex].iSeason, episodesOnDisc[episodeIndex].iEpisode,
+               episodesOnDisc[episodeIndex].duration);
   }
   else
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Looking for all episodes on disc");
+    CLog::LogF(LOGDEBUG, "Looking for all episodes on disc");
 
   // List episodes expected on disc
   for (const auto& e : episodesOnDisc)
   {
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Expected on disc - season {} episode {} duration {}",
-                e.iSeason, e.iEpisode, e.duration);
+    CLog::LogF(LOGDEBUG, "Expected on disc - season {} episode {} duration {}", e.iSeason,
+               e.iEpisode, e.duration);
   }
 }
 
@@ -402,10 +402,9 @@ bool PlaylistsMatchEpisodeDurationsInOrder(const PlaylistMap& playlists,
     const std::chrono::milliseconds episodeDuration{episodesOnDisc[index].duration * 1000ms};
     if (episodeDuration > 0ms && !CheckDurationsWithinTolerance(episodeDuration, playlist.duration))
     {
-      CLog::LogFC(LOGDEBUG, LOGBLURAY,
-                  "Playlist {} duration {} does not match episode {} duration {}",
-                  playlist.playlist, static_cast<int>(playlist.duration.count() / 1000),
-                  episodesOnDisc[index].iEpisode, episodesOnDisc[index].duration);
+      CLog::LogF(LOGDEBUG, "Playlist {} duration {} does not match episode {} duration {}",
+                 playlist.playlist, static_cast<int>(playlist.duration.count() / 1000),
+                 episodesOnDisc[index].iEpisode, episodesOnDisc[index].duration);
       return false;
     }
     ++index;
@@ -474,19 +473,19 @@ EpisodeExtents DivideClipsIntoEpisodes(const PlaylistInformation& information,
     const std::chrono::milliseconds clipDuration{clipIt->second.duration};
     if (clipDuration < minEpisodeDuration)
     {
-      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Rejecting playlist {} - clip {} duration {} is too short",
-                  information.playlist, clip, static_cast<int>(clipDuration.count() / 1000));
+      CLog::LogF(LOGDEBUG, "Rejecting playlist {} - clip {} duration {} is too short",
+                 information.playlist, clip, static_cast<int>(clipDuration.count() / 1000));
       return {};
     }
 
     const std::chrono::milliseconds episodeDuration{episodesOnDisc[index].duration * 1000ms};
     if (episodeDuration > 0ms && !CheckDurationsWithinTolerance(episodeDuration, clipDuration))
     {
-      CLog::LogFC(LOGDEBUG, LOGBLURAY,
-                  "Rejecting playlist {} - clip {} duration {} does not match episode {} duration "
-                  "{}",
-                  information.playlist, clip, static_cast<int>(clipDuration.count() / 1000),
-                  episodesOnDisc[index].iEpisode, episodesOnDisc[index].duration);
+      CLog::LogF(LOGDEBUG,
+                 "Rejecting playlist {} - clip {} duration {} does not match episode {} duration "
+                 "{}",
+                 information.playlist, clip, static_cast<int>(clipDuration.count() / 1000),
+                 episodesOnDisc[index].iEpisode, episodesOnDisc[index].duration);
       return {};
     }
 
@@ -570,10 +569,10 @@ EpisodeExtents DivideMultipleEpisodePlaylist(const PlaylistInformation& informat
                                                      minEpisodeDuration)};
   if (episodes.empty())
   {
-    CLog::LogFC(LOGDEBUG, LOGBLURAY,
-                "Playlist {} covers {} episodes but its {} chapters do not divide into that many "
-                "of near-equal duration",
-                information.playlist, multiple, information.chapters.size());
+    CLog::LogF(LOGDEBUG,
+               "Playlist {} covers {} episodes but its {} chapters do not divide into that many "
+               "of near-equal duration",
+               information.playlist, multiple, information.chapters.size());
   }
 
   return episodes;
@@ -590,9 +589,9 @@ EpisodeExtent GetEpisodeExtent(const EpisodeExtents& episodes,
     return {0ms, 0ms};
 
   const auto& [start, duration]{episodes[offset]};
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Episode {} of {} in playlist {} - starts at {} runs for {}",
-              offset + 1, numEpisodesInPlaylist, playlist, static_cast<int>(start.count() / 1000),
-              static_cast<int>(duration.count() / 1000));
+  CLog::LogF(LOGDEBUG, "Episode {} of {} in playlist {} - starts at {} runs for {}", offset + 1,
+             numEpisodesInPlaylist, playlist, static_cast<int>(start.count() / 1000),
+             static_cast<int>(duration.count() / 1000));
 
   return {start, duration};
 }
@@ -693,7 +692,7 @@ void CDiscDirectoryHelper::StorePlayAllPlaylist(
     const PlaylistInformation& playlistInformation,
     const std::map<unsigned int, std::vector<unsigned int>>& playAllPlaylistClipMap)
 {
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Potential play all playlist {}", playlistNumber);
+  CLog::LogF(LOGDEBUG, "Potential play all playlist {}", playlistNumber);
   m_playAllPlaylists.insert(CandidatePlaylistInformation{
       .playlist = playlistNumber,
       .playAllPlaylistEpisodesStartOffset = playAllPlaylistEpisodesStartOffset,
@@ -730,10 +729,10 @@ void CDiscDirectoryHelper::FindPlayAllPlaylists(const ClipMap& clips,
     if (!ArePlayAllPlaylistClipsEpisodes(clips, playlistInformation, episodesOnDisc, m_numSpecials,
                                          m_minEpisodeDuration))
     {
-      CLog::LogFC(LOGDEBUG, LOGBLURAY,
-                  "Rejecting potential play all playlist {} - its clips are the wrong length to be "
-                  "the episodes",
-                  playlistNumber);
+      CLog::LogF(LOGDEBUG,
+                 "Rejecting potential play all playlist {} - its clips are the wrong length to be "
+                 "the episodes",
+                 playlistNumber);
       continue;
     }
 
@@ -749,7 +748,7 @@ void CDiscDirectoryHelper::FindPlayAllPlaylists(const ClipMap& clips,
   }
 
   if (m_playAllPlaylists.empty())
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "No play all playlists found");
+    CLog::LogF(LOGDEBUG, "No play all playlists found");
 }
 
 void CDiscDirectoryHelper::FindGroups(const PlaylistMap& playlists, const Episodes& episodesOnDisc)
@@ -761,7 +760,7 @@ void CDiscDirectoryHelper::FindGroups(const PlaylistMap& playlists, const Episod
 
   if (m_numEpisodes < 2)
   {
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "No group search as single episode or specials only");
+    CLog::LogF(LOGDEBUG, "No group search as single episode or specials only");
     return;
   }
 
@@ -803,7 +802,7 @@ void CDiscDirectoryHelper::FindGroups(const PlaylistMap& playlists, const Episod
   // Assumption has to be playlists match episodes in ascending order
   if (m_groups.empty() && m_numSpecials == 0)
   {
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Looking exact number of non-consecutive playlists");
+    CLog::LogF(LOGDEBUG, "Looking exact number of non-consecutive playlists");
 
     // Where there are more playlists than episodes, remove those whose durations are not within
     // 20% of any of the episodes, in the hope of leaving exactly numEpisodes of them
@@ -878,11 +877,11 @@ void CDiscDirectoryHelper::FindGroups(const PlaylistMap& playlists, const Episod
   }
 
   if (m_groups.empty())
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "No playlist groups found");
+    CLog::LogF(LOGDEBUG, "No playlist groups found");
   else
     for (const auto& group : m_groups)
-      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Playlist group found from {} to {}", group.front().playlist,
-                  group.back().playlist);
+      CLog::LogF(LOGDEBUG, "Playlist group found from {} to {}", group.front().playlist,
+                 group.back().playlist);
 }
 
 void CDiscDirectoryHelper::FindRelaxedPlayAllPlaylists(const PlaylistMap& playlists)
@@ -929,11 +928,11 @@ void CDiscDirectoryHelper::FindRelaxedPlayAllPlaylists(const PlaylistMap& playli
     if (!CheckDurationsWithinTolerance(episodesDuration, group.front().duration,
                                        DURATION_TOLERANCE_RELAXED_PLAYALLPLAYLIST_PERCENT))
     {
-      CLog::LogFC(LOGDEBUG, LOGBLURAY,
-                  "Rejecting potential play all playlist {} duration {} - the {} following "
-                  "playlist(s) in the group total {}",
-                  playAllPlaylist, playAllPlaylistDuration, group.size() - 1,
-                  static_cast<int>(episodesDuration.count() / 1000));
+      CLog::LogF(LOGDEBUG,
+                 "Rejecting potential play all playlist {} duration {} - the {} following "
+                 "playlist(s) in the group total {}",
+                 playAllPlaylist, playAllPlaylistDuration, group.size() - 1,
+                 static_cast<int>(episodesDuration.count() / 1000));
       continue;
     }
 
@@ -950,8 +949,8 @@ void CDiscDirectoryHelper::FindRelaxedPlayAllPlaylists(const PlaylistMap& playli
               std::ranges::find(episodePlaylists, 0, &CandidatePlaylistInformation::multiple)};
           notMultiple != episodePlaylists.end())
       {
-        CLog::LogFC(
-            LOGDEBUG, LOGBLURAY,
+        CLog::LogF(
+            LOGDEBUG,
             "Rejecting potential play all playlist {} duration {} - episode playlist {} "
             "duration {} is not a whole multiple of {} (the average shortest episode "
             "playlist in the group)",
@@ -963,29 +962,28 @@ void CDiscDirectoryHelper::FindRelaxedPlayAllPlaylists(const PlaylistMap& playli
       {
         const auto multiples{episodePlaylists |
                              std::views::transform(&CandidatePlaylistInformation::multiple)};
-        CLog::LogFC(LOGDEBUG, LOGBLURAY,
-                    "Rejecting potential play all playlist {} duration {} - the {} following "
-                    "playlist(s) in the group account for {} episode(s), not the {} on disc",
-                    playAllPlaylist, playAllPlaylistDuration, episodePlaylists.size(),
-                    std::accumulate(multiples.begin(), multiples.end(), 0), m_numEpisodes);
+        CLog::LogF(LOGDEBUG,
+                   "Rejecting potential play all playlist {} duration {} - the {} following "
+                   "playlist(s) in the group account for {} episode(s), not the {} on disc",
+                   playAllPlaylist, playAllPlaylistDuration, episodePlaylists.size(),
+                   std::accumulate(multiples.begin(), multiples.end(), 0), m_numEpisodes);
       }
       continue;
     }
 
-    CLog::LogFC(LOGDEBUG, LOGBLURAY,
-                "Potential play all playlist {} duration {} with {} episode playlist(s)",
-                playAllPlaylist, playAllPlaylistDuration, episodePlaylists.size());
+    CLog::LogF(LOGDEBUG, "Potential play all playlist {} duration {} with {} episode playlist(s)",
+               playAllPlaylist, playAllPlaylistDuration, episodePlaylists.size());
     for (const auto& episodePlaylist : episodePlaylists)
-      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Episode playlist {} duration {} contains {} episode(s)",
-                  episodePlaylist.playlist,
-                  static_cast<int>(episodePlaylist.duration.count() / 1000),
-                  episodePlaylist.multiple);
+      CLog::LogF(LOGDEBUG, "Episode playlist {} duration {} contains {} episode(s)",
+                 episodePlaylist.playlist,
+                 static_cast<int>(episodePlaylist.duration.count() / 1000),
+                 episodePlaylist.multiple);
 
     m_playAllPlaylistEpisodeMap[playAllPlaylist] = std::move(episodePlaylists);
   }
 
   if (m_playAllPlaylistEpisodeMap.empty())
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "No play all playlists found using the relaxed method");
+    CLog::LogF(LOGDEBUG, "No play all playlists found using the relaxed method");
 }
 
 void CDiscDirectoryHelper::UsePlayAllPlaylistMethod(int episodeIndex, const PlaylistMap& playlists)
@@ -993,13 +991,13 @@ void CDiscDirectoryHelper::UsePlayAllPlaylistMethod(int episodeIndex, const Play
   if (m_playAllPlaylists.empty())
     return;
 
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using Play All playlist method");
+  CLog::LogF(LOGDEBUG, "Using Play All playlist method");
 
   // Get the playlist
   const auto& playlistInformation{*m_playAllPlaylists.begin()};
   const unsigned int playAllPlaylist{playlistInformation.playlist};
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using candidate play all playlist {} duration {}",
-              playAllPlaylist, static_cast<int>(playlistInformation.duration.count() / 1000));
+  CLog::LogF(LOGDEBUG, "Using candidate play all playlist {} duration {}", playAllPlaylist,
+             static_cast<int>(playlistInformation.duration.count() / 1000));
 
   // Find the clip for the episode(s)
   const int episodeOffset{
@@ -1019,7 +1017,7 @@ void CDiscDirectoryHelper::UsePlayAllPlaylistMethod(int episodeIndex, const Play
         return;
       }
 
-      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Clip is {}", clip);
+      CLog::LogF(LOGDEBUG, "Clip is {}", clip);
 
       // Find playlist(s) with that clip from map populated earlier
       const auto& singleEpisodePlaylists{it->second.find(clip)->second};
@@ -1036,8 +1034,8 @@ void CDiscDirectoryHelper::UsePlayAllPlaylistMethod(int episodeIndex, const Play
         const PlaylistInformation& singleEpisodePlaylistInformation{
             playlists.find(singleEpisodePlaylist)->second};
 
-        CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {} duration {}", singleEpisodePlaylist,
-                    static_cast<int>(singleEpisodePlaylistInformation.duration.count() / 1000));
+        CLog::LogF(LOGDEBUG, "Candidate playlist {} duration {}", singleEpisodePlaylist,
+                   static_cast<int>(singleEpisodePlaylistInformation.duration.count() / 1000));
 
         m_candidatePlaylists.try_emplace(
             singleEpisodePlaylist,
@@ -1061,12 +1059,12 @@ void CDiscDirectoryHelper::UseRelaxedPlayAllPlaylistMethod(int episodeIndex,
   if (m_playAllPlaylistEpisodeMap.empty())
     return;
 
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using Relaxed Play All playlist method");
+  CLog::LogF(LOGDEBUG, "Using Relaxed Play All playlist method");
 
   // Get the playlist
   const auto& [playAllPlaylist, episodes]{*m_playAllPlaylistEpisodeMap.begin()};
 
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using candidate play all playlist {}", playAllPlaylist);
+  CLog::LogF(LOGDEBUG, "Using candidate play all playlist {}", playAllPlaylist);
 
   // Start at numSpecials as specials (S00) are before episodes in episodesOnDisc
   unsigned int index{m_numSpecials};
@@ -1096,8 +1094,8 @@ void CDiscDirectoryHelper::UseRelaxedPlayAllPlaylistMethod(int episodeIndex,
     {
       if (m_allEpisodes == AllEpisodes::ALL || std::cmp_equal(index, episodeIndex))
       {
-        CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {} duration {}", singleEpisodePlaylist,
-                    static_cast<int>(singleEpisodePlaylistInformation.duration.count() / 1000));
+        CLog::LogF(LOGDEBUG, "Candidate playlist {} duration {}", singleEpisodePlaylist,
+                   static_cast<int>(singleEpisodePlaylistInformation.duration.count() / 1000));
 
         // The extent of this episode within the playlist, when the chapters gave it
         const auto [episodeStart, episodeDuration]{
@@ -1160,8 +1158,8 @@ void CDiscDirectoryHelper::UseLongOrCommonMethodForSingleEpisode(int episodeInde
   {
     // If only one long playlist, then assume it's that
     const auto& [playlist, playlistInformation] = *episodeLengthPlaylists.begin();
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Single Episode - found using single long playlist method");
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {}", playlist);
+    CLog::LogF(LOGDEBUG, "Single Episode - found using single long playlist method");
+    CLog::LogF(LOGDEBUG, "Candidate playlist {}", playlist);
     m_candidatePlaylists.try_emplace(
         playlist, CandidatePlaylistInformation{
                       .playlist = playlist,
@@ -1175,8 +1173,8 @@ void CDiscDirectoryHelper::UseLongOrCommonMethodForSingleEpisode(int episodeInde
   {
     // Found a common playlist, so assume it's that
     const auto& playlistInformation{playlists.at(*commonPlaylist)};
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Single Episode - found using common playlist method");
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {}", *commonPlaylist);
+    CLog::LogF(LOGDEBUG, "Single Episode - found using common playlist method");
+    CLog::LogF(LOGDEBUG, "Candidate playlist {}", *commonPlaylist);
     m_candidatePlaylists.try_emplace(
         *commonPlaylist,
         CandidatePlaylistInformation{
@@ -1225,7 +1223,7 @@ void CDiscDirectoryHelper::GetPlaylistsFromGroup(
                                                                   .chapters = group[i].chapters,
                                                                   .clips = group[i].clips,
                                                                   .languages = group[i].languages});
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {}", group[i].playlist);
+    CLog::LogF(LOGDEBUG, "Candidate playlist {}", group[i].playlist);
   }
 }
 
@@ -1285,12 +1283,12 @@ bool CDiscDirectoryHelper::CheckGroupMultipleDurations(
           !CheckDurationsWithinTolerance(scrapedDuration, episodeFromPlaylistDuration,
                                          DURATION_TOLERANCE_SCRAPED_PERCENT))
       {
-        CLog::LogFC(LOGDEBUG, LOGBLURAY,
-                    "Rejecting group - playlist {} covers {} episode(s) at {} each, which does not "
-                    "match episode {} duration {}",
-                    playlist.playlist, playlist.multiple,
-                    static_cast<int>(episodeFromPlaylistDuration.count() / 1000),
-                    episodesOnDisc[index].iEpisode, episodesOnDisc[index].duration);
+        CLog::LogF(LOGDEBUG,
+                   "Rejecting group - playlist {} covers {} episode(s) at {} each, which does not "
+                   "match episode {} duration {}",
+                   playlist.playlist, playlist.multiple,
+                   static_cast<int>(episodeFromPlaylistDuration.count() / 1000),
+                   episodesOnDisc[index].iEpisode, episodesOnDisc[index].duration);
         return false;
       }
     }
@@ -1346,7 +1344,7 @@ void CDiscDirectoryHelper::UseGroupMethod(int episodeIndex,
   // Groups are already contain at least numEpisodes playlists of minimum duration
   // Firstly look just at groups that contain exactly numEpisodes playlists
   // Having removed duplicates
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using group method - exact number of playlists");
+  CLog::LogF(LOGDEBUG, "Using group method - exact number of playlists");
 
   const std::vector groups{GetGroupsWithoutDuplicates(m_groups)};
   for (const auto& group : groups)
@@ -1365,7 +1363,7 @@ void CDiscDirectoryHelper::UseGroupMethod(int episodeIndex,
     // Now look for groups that contain same/more than numEpisodes playlists (with duplicates)
     // Check that the first numEpisodes playlists have a duration within 20% of the desired episode
     // Exclude episodes with 0 duration as this will skew results
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using group method - relaxed number of playlists");
+    CLog::LogF(LOGDEBUG, "Using group method - relaxed number of playlists");
     std::chrono::milliseconds episodeDuration;
     if (m_allEpisodes == AllEpisodes::ALL)
       episodeDuration = GetAverageEpisodeDuration(episodesOnDisc);
@@ -1456,7 +1454,7 @@ void CDiscDirectoryHelper::UseGroupMethod(int episodeIndex,
   }
 
   if (m_candidatePlaylists.empty())
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "No candidate playlists found");
+    CLog::LogF(LOGDEBUG, "No candidate playlists found");
 }
 
 namespace
@@ -1581,7 +1579,7 @@ void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(int episodeIndex,
 {
   // No groups of numEpisodes length so see if there could be double episode playlists
   // Assume more than one playlist
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using groups with multiples method");
+  CLog::LogF(LOGDEBUG, "Using groups with multiples method");
   for (auto& group : GetGroupsWithoutDuplicates(m_allGroups))
   {
     if (!CalculateGroupMultiples(group, m_numEpisodes))
@@ -1622,8 +1620,8 @@ void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(int episodeIndex,
               GetEpisodeExtent(episodeExtents, static_cast<size_t>(i), playlist.playlist,
                                playlist.multiple);
           m_candidatePlaylists.try_emplace(playlist.playlist, playlistInformation);
-          CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {} for episode {}",
-                      playlist.playlist, episodesOnDisc[index].iEpisode);
+          CLog::LogF(LOGDEBUG, "Candidate playlist {} for episode {}", playlist.playlist,
+                     episodesOnDisc[index].iEpisode);
         }
         ++index;
       }
@@ -1632,7 +1630,7 @@ void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(int episodeIndex,
   }
 
   if (m_candidatePlaylists.empty())
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "No candidate playlists found");
+    CLog::LogF(LOGDEBUG, "No candidate playlists found");
 }
 
 void CDiscDirectoryHelper::UseSingleEpisodeClipsPlaylistMethod(int episodeIndex,
@@ -1666,7 +1664,7 @@ void CDiscDirectoryHelper::UseSingleEpisodeClipsPlaylistMethod(int episodeIndex,
   if (information.clips.size() != m_numEpisodes)
     return;
 
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using single playlist with episode clips method");
+  CLog::LogF(LOGDEBUG, "Using single playlist with episode clips method");
 
   const EpisodeExtents episodeExtents{
       DivideClipsIntoEpisodes(information, clips, episodesOnDisc, m_minEpisodeDuration)};
@@ -1679,8 +1677,8 @@ void CDiscDirectoryHelper::UseSingleEpisodeClipsPlaylistMethod(int episodeIndex,
   const unsigned int index{
       m_allEpisodes == AllEpisodes::SINGLE ? static_cast<unsigned int>(episodeIndex) : 0u};
 
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {} for episode {}", information.playlist,
-              episodesOnDisc[index].iEpisode);
+  CLog::LogF(LOGDEBUG, "Candidate playlist {} for episode {}", information.playlist,
+             episodesOnDisc[index].iEpisode);
 
   const auto [episodeStart,
               episodeDuration]{m_allEpisodes == AllEpisodes::SINGLE
@@ -1743,16 +1741,16 @@ void CDiscDirectoryHelper::ChooseSingleBestPlaylist(const Episodes& episodesOnDi
     // Keep the playlist with most chapters and closest duration
     if (filteredCandidatePlaylists.empty())
     {
-      CLog::LogFC(LOGDEBUG, LOGBLURAY, "No candidate playlists found for episode index {}",
-                  currentEpisodeIndex);
+      CLog::LogF(LOGDEBUG, "No candidate playlists found for episode index {}",
+                 currentEpisodeIndex);
       return;
     }
     const unsigned int playlist{filteredCandidatePlaylists[0].playlist};
     m_candidatePlaylists.try_emplace(playlist, filteredCandidatePlaylists[0]);
 
-    CLog::LogFC(LOGDEBUG, LOGBLURAY,
-                "Remaining candidate playlist (closest in duration) is {} for episode index {}",
-                playlist, currentEpisodeIndex);
+    CLog::LogF(LOGDEBUG,
+               "Remaining candidate playlist (closest in duration) is {} for episode index {}",
+               playlist, currentEpisodeIndex);
   }
 }
 
@@ -1779,15 +1777,14 @@ void CDiscDirectoryHelper::AddIdenticalPlaylists(const PlaylistMap& playlists)
         // choose between them
         if (candidate != playlists.end() && IsStreamSubset(playlistInformation, candidate->second))
         {
-          CLog::LogFC(LOGDEBUG, LOGBLURAY,
-                      "Ignoring playlist {} - its streams are a subset of those of playlist {}",
-                      playlist, candidatePlaylist);
+          CLog::LogF(LOGDEBUG,
+                     "Ignoring playlist {} - its streams are a subset of those of playlist {}",
+                     playlist, candidatePlaylist);
           continue;
         }
 
-        CLog::LogFC(LOGDEBUG, LOGBLURAY,
-                    "Adding playlist {} as same duration and clips as playlist {}", playlist,
-                    candidatePlaylist);
+        CLog::LogF(LOGDEBUG, "Adding playlist {} as same duration and clips as playlist {}",
+                   playlist, candidatePlaylist);
 
         // Copy the candidate but with this playlist's own number and languages
         CandidatePlaylistInformation identicalPlaylistInformation{candidatePlaylistInformation};
@@ -1826,7 +1823,7 @@ void CDiscDirectoryHelper::FindCandidatePlaylists(const Episodes& episodesOnDisc
   //    episode playlists at all.
 
   if (m_allEpisodes == AllEpisodes::ALL)
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Looking for all episodes on disc");
+    CLog::LogF(LOGDEBUG, "Looking for all episodes on disc");
 
   m_candidatePlaylists.clear();
   m_candidateSpecials.clear();
@@ -1997,7 +1994,7 @@ void AddStreamDetails(const StreamDetailsProvider& getStreamDetails,
 
   if (!allTitles.Contains(item.GetPath()))
   {
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Playlist {} not found in disc titles", playlist);
+    CLog::LogF(LOGDEBUG, "Playlist {} not found in disc titles", playlist);
     return;
   }
 
@@ -2013,7 +2010,7 @@ void AddStreamDetails(const StreamDetailsProvider& getStreamDetails,
 
 void CDiscDirectoryHelper::EndEpisodePlaylistSearch()
 {
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "*** Episode Search End ***");
+  CLog::LogF(LOGDEBUG, "*** Episode Search End ***");
 }
 
 void CDiscDirectoryHelper::PopulateEpisodeFileItems(const CURL& url,
@@ -2070,8 +2067,7 @@ void CDiscDirectoryHelper::PopulateEpisodeFileItems(const CURL& url,
                                              playlist.episodeStart, playlist.episodeDuration)};
       if (!newItem)
       {
-        CLog::LogFC(LOGDEBUG, LOGBLURAY, "Failed to generate FileItem for playlist {}",
-                    playlist.playlist);
+        CLog::LogF(LOGDEBUG, "Failed to generate FileItem for playlist {}", playlist.playlist);
         continue;
       }
 
@@ -2100,7 +2096,7 @@ void CDiscDirectoryHelper::PopulateEpisodeFileItems(const CURL& url,
       const auto newItem{GenerateEpisodeItem(url, playlist, information, episode, true)}; // Special
       if (!newItem)
       {
-        CLog::LogFC(LOGDEBUG, LOGBLURAY, "Failed to generate FileItem for playlist {}", playlist);
+        CLog::LogF(LOGDEBUG, "Failed to generate FileItem for playlist {}", playlist);
         continue;
       }
 
@@ -2126,14 +2122,14 @@ void CDiscDirectoryHelper::LogEpisodePlaylistSearchResult(const CFileItemList& i
 
   if (m_allEpisodes == AllEpisodes::ALL)
   {
-    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Episode search for all episodes on disc found playlist(s) {}",
-                playlistList);
+    CLog::LogF(LOGDEBUG, "Episode search for all episodes on disc found playlist(s) {}",
+               playlistList);
     return;
   }
 
   const Episode& episode{episodesOnDisc[episodeIndex]};
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Episode search for season {} episode {} found playlist(s) {}",
-              episode.iSeason, episode.iEpisode, playlistList);
+  CLog::LogF(LOGDEBUG, "Episode search for season {} episode {} found playlist(s) {}",
+             episode.iSeason, episode.iEpisode, playlistList);
 }
 
 bool CDiscDirectoryHelper::GetEpisodePlaylists(
@@ -2246,8 +2242,7 @@ void PopulateAllEpisodesFileItems(const CURL& url,
     const auto newItem{GenerateAllEpisodesItem(url, playlist.playlist, information)};
     if (!newItem)
     {
-      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Failed to generate FileItem for playlist {}",
-                  playlist.playlist);
+      CLog::LogF(LOGDEBUG, "Failed to generate FileItem for playlist {}", playlist.playlist);
       continue;
     }
 
@@ -2319,7 +2314,7 @@ void InitialiseMoviePlaylistSearch(std::vector<PlaylistInformation>& playlists,
   std::ranges::transform(playlistMap, std::back_inserter(playlists),
                          [](const PlaylistMapEntry& pair) { return pair.second; });
 
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "*** Movie Search Start ***");
+  CLog::LogF(LOGDEBUG, "*** Movie Search Start ***");
 }
 
 bool FilterMoviePlaylists(std::vector<PlaylistInformation>& playlists, GetTitle job)
@@ -2383,7 +2378,7 @@ void GetMainMoviePlaylists(std::vector<PlaylistInformation>& playlists,
 
 void EndMoviePlaylistSearch()
 {
-  CLog::LogFC(LOGDEBUG, LOGBLURAY, "*** Movie Search End ***");
+  CLog::LogF(LOGDEBUG, "*** Movie Search End ***");
 }
 
 std::shared_ptr<CFileItem> GenerateMovieItem(const CURL& url,
@@ -2456,8 +2451,7 @@ void PopulateMovieFileItems(
     const auto newItem{GenerateMovieItem(url, playlist.playlist, mainPlaylist, playlist)};
     if (!newItem)
     {
-      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Failed to generate FileItem for playlist {}",
-                  playlist.playlist);
+      CLog::LogF(LOGDEBUG, "Failed to generate FileItem for playlist {}", playlist.playlist);
       continue;
     }
 
@@ -2682,10 +2676,9 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(const CFileItem& item,
     // Silent
     if (sourceItems.Size() > 1 && !returnMultipleItems)
     {
-      CLog::LogFC(LOGDEBUG, LOGBLURAY,
-                  "Automatically selected playlist {} of the {} offered for {}",
-                  sourceItems[0]->GetProperty("bluray_playlist").asInteger32(0), sourceItems.Size(),
-                  CURL::GetRedacted(directory));
+      CLog::LogF(LOGDEBUG, "Automatically selected playlist {} of the {} offered for {}",
+                 sourceItems[0]->GetProperty("bluray_playlist").asInteger32(0), sourceItems.Size(),
+                 CURL::GetRedacted(directory));
     }
   }
 

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -1258,6 +1258,47 @@ bool CDiscDirectoryHelper::CheckGroupDurations(
                              });
 }
 
+// Whether each playlist of a group is of a length consistent with the episodes it would cover.
+//
+// A group here has fewer playlists than there are episodes, as a playlist may cover several of
+// them, so the playlists cannot be compared with the episodes one for one as CheckGroupDurations()
+// does. Divide each playlist's duration by the number of episodes it covers instead, and compare
+// that with each of them. Only the check episodes scraped so far (no duration otherwise)
+bool CDiscDirectoryHelper::CheckGroupMultipleDurations(
+    const std::vector<CandidatePlaylistInformation>& group, const Episodes& episodesOnDisc) const
+{
+  size_t index{m_numSpecials}; // Specials (S00) are before episodes in episodesOnDisc
+  for (const auto& playlist : group)
+  {
+    if (playlist.multiple < 1)
+      return false;
+
+    const std::chrono::milliseconds episodeFromPlaylistDuration{playlist.duration /
+                                                                playlist.multiple};
+    for (int i = 0; i < playlist.multiple; ++i, ++index)
+    {
+      if (index >= episodesOnDisc.size())
+        return false;
+
+      const std::chrono::milliseconds scrapedDuration{episodesOnDisc[index].duration * 1000ms};
+      if (scrapedDuration > 0ms &&
+          !CheckDurationsWithinTolerance(scrapedDuration, episodeFromPlaylistDuration,
+                                         DURATION_TOLERANCE_SCRAPED_PERCENT))
+      {
+        CLog::LogFC(LOGDEBUG, LOGBLURAY,
+                    "Rejecting group - playlist {} covers {} episode(s) at {} each, which does not "
+                    "match episode {} duration {}",
+                    playlist.playlist, playlist.multiple,
+                    static_cast<int>(episodeFromPlaylistDuration.count() / 1000),
+                    episodesOnDisc[index].iEpisode, episodesOnDisc[index].duration);
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 // Decide if the group identified is likely to contain the episodes
 // We might be in a position where we have a group of shorter playlists but the actual episode (longer)
 // playlists are not in a group
@@ -1362,13 +1403,32 @@ void CDiscDirectoryHelper::UseGroupMethod(int episodeIndex,
     {
       // Now ensure there are no other playlists of similar length to the longest
       // Get the next longest playlist
+      //
+      // A playlist offering the same clips for the same length as one already chosen is another
+      // copy of that episode rather than a rival for it, so it is left out - a disc commonly offers
+      // each episode several times over, once per set of audio and subtitle streams, and those
+      // copies must not be taken for other playlists of a similar length
+      const auto isCopyOfChosenPlaylist{
+          [this](const PlaylistInformation& p)
+          {
+            return std::ranges::any_of(m_nthLongestPlaylists,
+                                       [&p](const CandidatePlaylistInformation& chosen)
+                                       {
+                                         return chosen.playlist != p.playlist &&
+                                                chosen.duration == p.duration &&
+                                                chosen.clips == p.clips;
+                                       });
+          }};
+
       std::vector<PlaylistInformation> tmp;
       tmp.reserve(playlists.size());
-      std::ranges::copy(
-          playlists | std::views::values |
-              std::views::filter([this](const PlaylistInformation& p)
-                                 { return !m_playAllPlaylists.contains(p.playlist); }),
-          std::back_inserter(tmp));
+      std::ranges::copy(playlists | std::views::values |
+                            std::views::filter(
+                                [this, &isCopyOfChosenPlaylist](const PlaylistInformation& p) {
+                                  return !m_playAllPlaylists.contains(p.playlist) &&
+                                         !isCopyOfChosenPlaylist(p);
+                                }),
+                        std::back_inserter(tmp));
 
       // If there is no playlist beyond the m_nthLongestPlaylists ones, there is nothing
       // to compare against, so there cannot be a next playlist of similar length
@@ -1525,6 +1585,11 @@ void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(int episodeIndex,
   for (auto& group : GetGroupsWithoutDuplicates(m_allGroups))
   {
     if (!CalculateGroupMultiples(group, m_numEpisodes))
+      continue;
+
+    // The multiples adding up does not make the group the episodes - a run of extras can do that
+    // too, so check the playlists are of a length to hold the episodes they would be given
+    if (!CheckGroupMultipleDurations(group, episodesOnDisc))
       continue;
 
     // Save candidate episode(s)

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -343,6 +343,165 @@ std::chrono::milliseconds GetAverageEpisodeDuration(const Episodes& episodesOnDi
   return std::chrono::milliseconds(count ? static_cast<long long>(sum / count) : 0) * 1000;
 }
 
+// Where an episode starts within a playlist, and how long it runs for
+// Zero for both means the episode is the whole playlist
+using EpisodeExtent = std::pair<std::chrono::milliseconds, std::chrono::milliseconds>;
+
+// The extent of every episode of a playlist covering several of them, in episode order
+using EpisodeExtents = std::vector<EpisodeExtent>;
+
+// Where each episode of a playlist made up of one clip per episode starts, and how long it runs
+// for. Returns an empty vector when the clips do not line up with the episodes on disc.
+//
+// The clips are taken to be in episode order and each is checked against the duration of the
+// episode in its position. Only the episodes scraped so far have a duration, so the rest are
+// checked only for being long enough to be an episode at all.
+EpisodeExtents DivideClipsIntoEpisodes(const PlaylistInformation& information,
+                                       const ClipMap& clips,
+                                       const Episodes& episodesOnDisc,
+                                       std::chrono::milliseconds minEpisodeDuration)
+{
+  if (information.clips.size() != episodesOnDisc.size())
+    return {};
+
+  EpisodeExtents episodes;
+  episodes.reserve(information.clips.size());
+  std::chrono::milliseconds start{0ms};
+  for (size_t index = 0; const unsigned int clip : information.clips)
+  {
+    const auto clipIt{clips.find(clip)};
+    if (clipIt == clips.end())
+    {
+      CLog::LogF(LOGERROR, "Clip {} missing in clip map", clip);
+      return {};
+    }
+
+    const std::chrono::milliseconds clipDuration{clipIt->second.duration};
+    if (clipDuration < minEpisodeDuration)
+    {
+      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Rejecting playlist {} - clip {} duration {} is too short",
+                  information.playlist, clip, static_cast<int>(clipDuration.count() / 1000));
+      return {};
+    }
+
+    const std::chrono::milliseconds episodeDuration{episodesOnDisc[index].duration * 1000ms};
+    if (episodeDuration > 0ms && !CheckDurationsWithinTolerance(episodeDuration, clipDuration))
+    {
+      CLog::LogFC(LOGDEBUG, LOGBLURAY,
+                  "Rejecting playlist {} - clip {} duration {} does not match episode {} duration "
+                  "{}",
+                  information.playlist, clip, static_cast<int>(clipDuration.count() / 1000),
+                  episodesOnDisc[index].iEpisode, episodesOnDisc[index].duration);
+      return {};
+    }
+
+    episodes.emplace_back(start, clipDuration);
+    start += clipDuration;
+    ++index;
+  }
+
+  return episodes;
+}
+
+// Look for the number of chapters per episode that divides the playlist into runs of near-equal
+// duration, each long enough to be an episode, with too little left over at the end to be another.
+// Returns an empty vector when the chapters do not divide up that way.
+//
+// A chapter is where it starts within the playlist, so an episode of chaptersPerEpisode chapters
+// runs from the start of its first chapter to the start of the chapter that begins the next episode
+// - or to the end of the playlist for the last of them.
+EpisodeExtents DivideChaptersIntoEpisodes(const std::vector<std::chrono::milliseconds>& chapters,
+                                          std::chrono::milliseconds playlistDuration,
+                                          unsigned int numEpisodes,
+                                          std::chrono::milliseconds minEpisodeDuration)
+{
+  if (numEpisodes < 2 || chapters.size() < numEpisodes)
+    return {};
+
+  // Where the given chapter starts within the playlist
+  // An index of one past the last chapter returns the end of the playlist
+  const auto chapterStart{
+      [&chapters, playlistDuration](size_t chapter) -> std::chrono::milliseconds
+      { return chapter < chapters.size() ? chapters[chapter] : playlistDuration; }};
+
+  const size_t maxChaptersPerEpisode{chapters.size() / numEpisodes};
+  for (size_t chaptersPerEpisode = 1; chaptersPerEpisode <= maxChaptersPerEpisode;
+       ++chaptersPerEpisode)
+  {
+    // Derive the start and duration of each episode from the chapters
+    EpisodeExtents episodes;
+    episodes.reserve(numEpisodes);
+    for (unsigned int episode = 0; episode < numEpisodes; ++episode)
+    {
+      const std::chrono::milliseconds start{chapterStart(episode * chaptersPerEpisode)};
+      const std::chrono::milliseconds end{chapterStart((episode + 1) * chaptersPerEpisode)};
+      episodes.emplace_back(start, end - start);
+    }
+
+    // Whatever is left over must be too short to be an episode of its own, otherwise this is not
+    // the number of chapters per episode
+    if (playlistDuration - chapterStart(numEpisodes * chaptersPerEpisode) >= minEpisodeDuration)
+      continue;
+
+    // Every run must be long enough to be an episode
+    const auto durations{episodes | std::views::values};
+    if (std::ranges::any_of(durations, [minEpisodeDuration](const std::chrono::milliseconds d)
+                            { return d < minEpisodeDuration; }))
+      continue;
+
+    // The runs must be of near-equal duration
+    const std::chrono::milliseconds mean{std::accumulate(durations.begin(), durations.end(), 0ms) /
+                                         numEpisodes};
+    if (std::ranges::all_of(durations, [mean](const std::chrono::milliseconds d)
+                            { return CheckDurationsWithinTolerance(mean, d); }))
+      return episodes;
+  }
+
+  return {};
+}
+
+// Divides a playlist covering more than one episode into them by its chapters, for the methods that
+// map several episodes onto a single playlist. Returns an empty vector when the playlist covers
+// only one episode, or when its chapters give no boundaries between them.
+EpisodeExtents DivideMultipleEpisodePlaylist(const PlaylistInformation& information,
+                                             int multiple,
+                                             std::chrono::milliseconds minEpisodeDuration)
+{
+  if (multiple < 2)
+    return {};
+
+  EpisodeExtents episodes{DivideChaptersIntoEpisodes(information.chapters, information.duration,
+                                                     static_cast<unsigned int>(multiple),
+                                                     minEpisodeDuration)};
+  if (episodes.empty())
+  {
+    CLog::LogFC(LOGDEBUG, LOGBLURAY,
+                "Playlist {} covers {} episodes but its {} chapters do not divide into that many "
+                "of near-equal duration",
+                information.playlist, multiple, information.chapters.size());
+  }
+
+  return episodes;
+}
+
+// The extent of the offset'th episode of a playlist that has been divided into episodes, or zero
+// start and duration where it has not - taken as the episode being the whole playlist.
+EpisodeExtent GetEpisodeExtent(const EpisodeExtents& episodes,
+                               size_t offset,
+                               unsigned int playlist,
+                               int numEpisodesInPlaylist)
+{
+  if (offset >= episodes.size())
+    return {0ms, 0ms};
+
+  const auto& [start, duration]{episodes[offset]};
+  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Episode {} of {} in playlist {} - starts at {} runs for {}",
+              offset + 1, numEpisodesInPlaylist, playlist, static_cast<int>(start.count() / 1000),
+              static_cast<int>(duration.count() / 1000));
+
+  return {start, duration};
+}
+
 // Whether candidateStream offers everything stream does.
 //
 // The two must have the same language, name and flags - and the candidate must then
@@ -812,6 +971,14 @@ void CDiscDirectoryHelper::UseRelaxedPlayAllPlaylistMethod(int episodeIndex,
     const PlaylistInformation& singleEpisodePlaylistInformation{
         playlists.find(singleEpisodePlaylist)->second};
 
+    // Where a playlist covers more than one episode, see if its chapters give the boundaries
+    // between them. Only for a single episode, as one covering them all is the whole playlist.
+    const EpisodeExtents episodeExtents{
+        m_allEpisodes == AllEpisodes::SINGLE
+            ? DivideMultipleEpisodePlaylist(singleEpisodePlaylistInformation,
+                                            episodePlaylist.multiple, m_minEpisodeDuration)
+            : EpisodeExtents{}};
+
     // A playlist may cover more than one episode (a double/triple episode)
     for (int i = 0; i < episodePlaylist.multiple; ++i)
     {
@@ -819,6 +986,11 @@ void CDiscDirectoryHelper::UseRelaxedPlayAllPlaylistMethod(int episodeIndex,
       {
         CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {} duration {}", singleEpisodePlaylist,
                     static_cast<int>(singleEpisodePlaylistInformation.duration.count() / 1000));
+
+        // The extent of this episode within the playlist, when the chapters gave it
+        const auto [episodeStart, episodeDuration]{
+            GetEpisodeExtent(episodeExtents, static_cast<size_t>(i), singleEpisodePlaylist,
+                             episodePlaylist.multiple)};
 
         m_candidatePlaylists.try_emplace(
             singleEpisodePlaylist,
@@ -829,7 +1001,9 @@ void CDiscDirectoryHelper::UseRelaxedPlayAllPlaylistMethod(int episodeIndex,
                                          .chapters = static_cast<unsigned int>(
                                              singleEpisodePlaylistInformation.chapters.size()),
                                          .clips = singleEpisodePlaylistInformation.clips,
-                                         .languages = singleEpisodePlaylistInformation.languages});
+                                         .languages = singleEpisodePlaylistInformation.languages,
+                                         .episodeStart = episodeStart,
+                                         .episodeDuration = episodeDuration});
       }
       ++index;
     }
@@ -1228,7 +1402,8 @@ bool CDiscDirectoryHelper::CalculateGroupMultiples(std::vector<CandidatePlaylist
 }
 
 void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(int episodeIndex,
-                                                        const Episodes& episodesOnDisc)
+                                                        const Episodes& episodesOnDisc,
+                                                        const PlaylistMap& playlists)
 {
   // No groups of numEpisodes length so see if there could be double episode playlists
   // Assume more than one playlist
@@ -1244,11 +1419,29 @@ void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(int episodeIndex,
     for (const auto& playlist : group)
     {
       auto playlistInformation{playlist};
+
+      if (!playlists.contains(playlist.playlist))
+      {
+        CLog::LogF(LOGERROR, "Playlist {} missing in playlist map", playlist.playlist);
+        return;
+      }
+
+      // Where a playlist covers more than one episode, see if its chapters give the boundaries
+      // between them. Only for a single episode, as one covering them all is the whole playlist.
+      const EpisodeExtents episodeExtents{
+          m_allEpisodes == AllEpisodes::SINGLE
+              ? DivideMultipleEpisodePlaylist(playlists.find(playlist.playlist)->second,
+                                              playlist.multiple, m_minEpisodeDuration)
+              : EpisodeExtents{}};
+
       for (int i = 0; i < playlist.multiple; ++i)
       {
         if (m_allEpisodes == AllEpisodes::ALL || std::cmp_equal(index, episodeIndex))
         {
           playlistInformation.index = index;
+          std::tie(playlistInformation.episodeStart, playlistInformation.episodeDuration) =
+              GetEpisodeExtent(episodeExtents, static_cast<size_t>(i), playlist.playlist,
+                               playlist.multiple);
           m_candidatePlaylists.try_emplace(playlist.playlist, playlistInformation);
           CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {} for episode {}",
                       playlist.playlist, episodesOnDisc[index].iEpisode);
@@ -1296,60 +1489,25 @@ void CDiscDirectoryHelper::UseSingleEpisodeClipsPlaylistMethod(int episodeIndex,
 
   CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using single playlist with episode clips method");
 
-  // Derive the start of each clip within the playlist, validating as we go
-  std::vector<std::chrono::milliseconds> clipStarts;
-  clipStarts.reserve(information.clips.size());
-  std::chrono::milliseconds start{0ms};
-  for (unsigned int index = 0; const unsigned int clip : information.clips)
-  {
-    const auto clipIt{clips.find(clip)};
-    if (clipIt == clips.end())
-    {
-      CLog::LogF(LOGERROR, "Clip {} missing in clip map", clip);
-      return;
-    }
+  const EpisodeExtents episodeExtents{
+      DivideClipsIntoEpisodes(information, clips, episodesOnDisc, m_minEpisodeDuration)};
+  if (episodeExtents.empty())
+    return;
 
-    const std::chrono::milliseconds clipDuration{clipIt->second.duration};
-    if (clipDuration < m_minEpisodeDuration)
-    {
-      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Rejecting playlist {} - clip {} duration {} is too short",
-                  information.playlist, clip, static_cast<int>(clipDuration.count() / 1000));
-      return;
-    }
+  // Save the candidate episode. Only one entry can be stored, as m_candidatePlaylists is keyed on
+  // playlist and every episode here shares the same playlist. When all episodes are wanted, the
+  // playlist is returned once, covering them all.
+  const unsigned int index{
+      m_allEpisodes == AllEpisodes::SINGLE ? static_cast<unsigned int>(episodeIndex) : 0u};
 
-    // Only episodes scraped so far have a duration, so unknown ones are left to the check above
-    const std::chrono::milliseconds episodeDuration{episodesOnDisc[index].duration * 1000ms};
-    if (episodeDuration > 0ms && !CheckDurationsWithinTolerance(episodeDuration, clipDuration))
-    {
-      CLog::LogFC(LOGDEBUG, LOGBLURAY,
-                  "Rejecting playlist {} - clip {} duration {} does not match episode {} duration "
-                  "{}",
-                  information.playlist, clip, static_cast<int>(clipDuration.count() / 1000),
-                  episodesOnDisc[index].iEpisode, episodesOnDisc[index].duration);
-      return;
-    }
+  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {} for episode {}", information.playlist,
+              episodesOnDisc[index].iEpisode);
 
-    clipStarts.emplace_back(start);
-    start += clipDuration;
-    ++index;
-  }
-
-  // Save the candidate episode. Only one entry can be stored
-  unsigned int index{0};
-  std::chrono::milliseconds episodeStart{0ms};
-  std::chrono::milliseconds episodeDuration{information.duration};
-  if (m_allEpisodes == AllEpisodes::SINGLE)
-  {
-    index = static_cast<unsigned int>(episodeIndex);
-    episodeStart = clipStarts[index];
-    episodeDuration = clips.find(information.clips[index])->second.duration;
-  }
-
-  CLog::LogFC(LOGDEBUG, LOGBLURAY,
-              "Candidate playlist {} for episode {} - starts at {} runs for {}",
-              information.playlist, episodesOnDisc[index].iEpisode,
-              static_cast<int>(episodeStart.count() / 1000),
-              static_cast<int>(episodeDuration.count() / 1000));
+  const auto [episodeStart,
+              episodeDuration]{m_allEpisodes == AllEpisodes::SINGLE
+                                   ? GetEpisodeExtent(episodeExtents, index, information.playlist,
+                                                      static_cast<int>(m_numEpisodes))
+                                   : EpisodeExtent{0ms, 0ms}};
 
   m_candidatePlaylists.try_emplace(
       information.playlist, CandidatePlaylistInformation{
@@ -1504,7 +1662,7 @@ void CDiscDirectoryHelper::FindCandidatePlaylists(const Episodes& episodesOnDisc
     UseGroupMethod(episodeIndex, episodesOnDisc, playlists);
 
   if (m_candidatePlaylists.empty() && !m_allGroups.empty() && m_numEpisodes > 1)
-    UseGroupsWithMultiplesMethod(episodeIndex, episodesOnDisc);
+    UseGroupsWithMultiplesMethod(episodeIndex, episodesOnDisc, playlists);
 
   if (m_candidatePlaylists.empty() && m_numEpisodes > 1 && m_isSpecial == IsSpecial::EPISODE)
     UseSingleEpisodeClipsPlaylistMethod(episodeIndex, episodesOnDisc, clips, playlists);
@@ -1652,7 +1810,8 @@ std::shared_ptr<CFileItem> GenerateEpisodeItem(const CURL& url,
 void AddStreamDetails(const StreamDetailsProvider& getStreamDetails,
                       const CFileItemList& allTitles,
                       unsigned int playlist,
-                      CFileItem& item)
+                      CFileItem& item,
+                      std::chrono::milliseconds episodeDuration = 0ms)
 {
   if (!getStreamDetails)
     return;
@@ -1664,6 +1823,12 @@ void AddStreamDetails(const StreamDetailsProvider& getStreamDetails,
   }
 
   getStreamDetails(playlist, item);
+
+  if (episodeDuration > 0ms)
+  {
+    item.GetVideoInfoTag()->m_streamDetails.SetVideoDuration(
+        0, static_cast<int>(episodeDuration.count() / 1000));
+  }
 }
 } // namespace
 
@@ -1731,7 +1896,8 @@ void CDiscDirectoryHelper::PopulateEpisodeFileItems(const CURL& url,
         continue;
       }
 
-      AddStreamDetails(m_getStreamDetails, allTitles, playlist.playlist, *newItem);
+      AddStreamDetails(m_getStreamDetails, allTitles, playlist.playlist, *newItem,
+                       playlist.episodeDuration);
 
       items.Add(newItem);
     }
@@ -2352,6 +2518,20 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(const CFileItem& item,
         if (const CBookmark & bookmark{selectedItem.GetVideoInfoTag()->m_EpBookmark};
             bookmark.IsSet())
           tag->m_EpBookmark = bookmark;
+
+        // The duration of the playlist, or of the episode's part of it where several share one, is
+        // measured from the disc and so is preferred over the scraper's.
+        // Loose sanity check that the scraper and found durations are similar, to avoid a
+        // mis-identified playlist from overwriting the episode's duration and affecting future
+        // playlist identification.
+        static constexpr int SCRAPED_DURATION_TOLERANCE_PERCENT{50};
+        const unsigned int scrapedDuration{tag->GetStaticDuration()};
+        if (const unsigned int discDuration{selectedItem.GetVideoInfoTag()->GetDuration()};
+            discDuration > 0 &&
+            (scrapedDuration == 0 ||
+             CheckDurationsWithinTolerance(scrapedDuration * 1000ms, discDuration * 1000ms,
+                                           SCRAPED_DURATION_TOLERANCE_PERCENT)))
+          tag->SetDuration(static_cast<int>(discDuration));
 
         if (tag->GetAssetInfo().GetTitle().empty())
           tag->GetAssetInfo().SetTitle(

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -1122,10 +1122,12 @@ std::vector<std::vector<CDiscDirectoryHelper::CandidatePlaylistInformation>> CDi
   std::vector<std::vector<CandidatePlaylistInformation>> uniqueGroups;
   for (const auto& playlistGroup : groups)
   {
-    std::set<int64_t> seenDurations;
+    // A playlist is a duplicate of another in its group when it offers the same clips for the same
+    // length
+    std::set<std::pair<int64_t, std::vector<unsigned int>>> seenPlaylists;
     auto CandidatePlaylistInformationNotDuplicate{
-        [&seenDurations](const CandidatePlaylistInformation& c) noexcept
-        { return seenDurations.insert(c.duration.count()).second; }};
+        [&seenPlaylists](const CandidatePlaylistInformation& c)
+        { return seenPlaylists.insert({c.duration.count(), c.clips}).second; }};
 
     std::ranges::copy_if(playlistGroup, std::back_inserter(uniqueGroups.emplace_back()),
                          CandidatePlaylistInformationNotDuplicate);

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -298,6 +298,27 @@ bool CheckDurationsWithinTolerance(std::chrono::milliseconds episodeDuration,
   return episodeDuration > 0ms && std::chrono::abs(playlistDuration - episodeDuration) <= tolerance;
 }
 
+bool AnyEpisodeDurationKnown(const Episodes& episodesOnDisc)
+{
+  return std::ranges::any_of(episodesOnDisc, [](const Episode& e) { return e.duration > 0; });
+}
+
+// Whether a playlist's duration is within tolerance of any of the episode durations known for the
+// disc.
+//
+// Episode durations are filled in as a disc is scanned, so on any given search some of them may
+// still be zero. Comparing against each known duration in turn (rather than against their average)
+// keeps the outcome stable as the scan progresses whereas the average can fluctuate.
+bool MatchesAnyEpisodeDuration(const Episodes& episodesOnDisc,
+                               std::chrono::milliseconds playlistDuration)
+{
+  // CheckDurationsWithinTolerance() rejects a zero episode duration, so unknown episodes are
+  // ignored here
+  return std::ranges::any_of(
+      episodesOnDisc, [playlistDuration](const Episode& e)
+      { return CheckDurationsWithinTolerance(e.duration * 1000ms, playlistDuration); });
+}
+
 std::chrono::milliseconds GetAverageEpisodeDuration(const Episodes& episodesOnDisc)
 {
   auto nonZeroEpisodes{episodesOnDisc |
@@ -516,12 +537,11 @@ void CDiscDirectoryHelper::FindGroups(const PlaylistMap& playlists, const Episod
   if (m_groups.empty() && m_numSpecials == 0)
   {
     CLog::LogFC(LOGDEBUG, LOGBLURAY, "Looking exact number of non-consecutive playlists");
-    // Remove playlists whose durations are not within 20% of episodes' average
-    const auto episodeDuration{GetAverageEpisodeDuration(episodesOnDisc)};
-    if (episodeDuration > 0ms)
+    // Remove playlists whose durations are not within 20% of one of the episodes' durations
+    if (AnyEpisodeDurationKnown(episodesOnDisc))
     {
-      std::erase_if(longPlaylists, [episodeDuration](const PlaylistMapEntry& p)
-                    { return !CheckDurationsWithinTolerance(episodeDuration, p.second.duration); });
+      std::erase_if(longPlaylists, [&episodesOnDisc](const PlaylistMapEntry& p)
+                    { return !MatchesAnyEpisodeDuration(episodesOnDisc, p.second.duration); });
     }
 
     // See if exact number remaining

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -325,6 +325,35 @@ bool MatchesAnyEpisodeDuration(const Episodes& episodesOnDisc,
       { return CheckDurationsWithinTolerance(e.duration * 1000ms, playlistDuration); });
 }
 
+// Whether each playlist matches the duration of the episode in the same position, taking the
+// playlists in ascending order as the episodes are.
+//
+// Only the episodes scraped so far have a duration, so the rest are not checked. That keeps the
+// outcome the same however far through a disc the scan has got, where a tolerance window derived
+// from the durations known so far moves as more of them arrive.
+bool PlaylistsMatchEpisodeDurationsInOrder(const PlaylistMap& playlists,
+                                           const Episodes& episodesOnDisc)
+{
+  if (playlists.size() != episodesOnDisc.size())
+    return false;
+
+  for (size_t index = 0; const PlaylistInformation& playlist : std::views::values(playlists))
+  {
+    const std::chrono::milliseconds episodeDuration{episodesOnDisc[index].duration * 1000ms};
+    if (episodeDuration > 0ms && !CheckDurationsWithinTolerance(episodeDuration, playlist.duration))
+    {
+      CLog::LogFC(LOGDEBUG, LOGBLURAY,
+                  "Playlist {} duration {} does not match episode {} duration {}",
+                  playlist.playlist, static_cast<int>(playlist.duration.count() / 1000),
+                  episodesOnDisc[index].iEpisode, episodesOnDisc[index].duration);
+      return false;
+    }
+    ++index;
+  }
+
+  return true;
+}
+
 std::chrono::milliseconds GetAverageEpisodeDuration(const Episodes& episodesOnDisc)
 {
   auto nonZeroEpisodes{episodesOnDisc |
@@ -702,15 +731,19 @@ void CDiscDirectoryHelper::FindGroups(const PlaylistMap& playlists, const Episod
   if (m_groups.empty() && m_numSpecials == 0)
   {
     CLog::LogFC(LOGDEBUG, LOGBLURAY, "Looking exact number of non-consecutive playlists");
-    // Remove playlists whose durations are not within 20% of one of the episodes' durations
-    if (AnyEpisodeDurationKnown(episodesOnDisc))
+
+    // Where there are more playlists than episodes, remove those whose durations are not within
+    // 20% of any of the episodes, in the hope of leaving exactly numEpisodes of them
+    if (longPlaylists.size() != m_numEpisodes && AnyEpisodeDurationKnown(episodesOnDisc))
     {
       std::erase_if(longPlaylists, [&episodesOnDisc](const PlaylistMapEntry& p)
                     { return !MatchesAnyEpisodeDuration(episodesOnDisc, p.second.duration); });
     }
 
-    // See if exact number remaining
-    if (longPlaylists.size() == m_numEpisodes)
+    // Exactly numEpisodes playlists are the episodes, provided each matches the duration of the
+    // episode in its position
+    if (longPlaylists.size() == m_numEpisodes &&
+        PlaylistsMatchEpisodeDurationsInOrder(longPlaylists, episodesOnDisc))
     {
       std::vector<CandidatePlaylistInformation> group;
       std::ranges::transform(longPlaylists, std::back_inserter(group),

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -525,24 +525,35 @@ void CDiscDirectoryHelper::FindRelaxedPlayAllPlaylists(const PlaylistMap& playli
   // More relaxed assumptions than FindPlayAllPlaylists. Ignores clips.
   //   1) The playall playlist will be first and the episode playlists will be sequentially numbered
   //      after it as part of a group
-  //   2) There will only be n+1 playlists longer than the minimum episode duration
-  //      (the playall playlist and the n episode playlists) in the group
-  //   3) The sum of the durations of the episode playlsits will be within 5% of the duration
+  //   2) There will be at most n+1 playlists longer than the minimum episode duration
+  //      (the playall playlist and the n episode playlists) in the group. There may be fewer if a
+  //      playlist contains more than one episode (eg. a double episode), in which case each
+  //      episode playlist must be a whole multiple of the shortest episode playlist and those
+  //      multiples must account for all n episodes
+  //   3) The sum of the durations of the episode playlists will be within 5% of the duration
   //      of the playall playlist
 
+  // A group of two cannot be distinguished from a pair of episodes, so require at least the
+  // playall playlist and two episode playlists
+  static constexpr size_t MIN_RELAXED_PLAYALL_GROUP_SIZE{3};
+
   // Only look for play all playlists if enough playlists and more than one episode on disc and groups found
-  if (m_numEpisodes < 2 || playlists.size() < m_numEpisodes || m_groups.empty())
+  if (m_numEpisodes < 2 || playlists.size() < MIN_RELAXED_PLAYALL_GROUP_SIZE || m_allGroups.empty())
     return;
 
-  for (const auto& group : m_groups)
+  for (const auto& group : m_allGroups)
   {
-    // Group is n+1 playlists
-    if (group.size() != m_numEpisodes + 1)
+    // Group is at most n+1 playlists
+    if (group.size() < MIN_RELAXED_PLAYALL_GROUP_SIZE || group.size() > m_numEpisodes + 1)
       continue;
 
     // Group is consecutively numbered
     if (!ArePlaylistsConsecutive(group))
       continue;
+
+    const unsigned int playAllPlaylist{group.front().playlist};
+    const auto playAllPlaylistDuration{
+        static_cast<int>(group.front().duration.count() / 1000)}; // For logging
 
     // Potential episode playlists duration's sum is within 5% of the playall playlist duration
     const std::chrono::milliseconds episodesDuration{std::accumulate(
@@ -550,15 +561,60 @@ void CDiscDirectoryHelper::FindRelaxedPlayAllPlaylists(const PlaylistMap& playli
         [](auto acc, const CandidatePlaylistInformation& p) { return acc + p.duration; })};
     if (!CheckDurationsWithinTolerance(episodesDuration, group.front().duration,
                                        DURATION_TOLERANCE_RELAXED_PLAYALLPLAYLIST_PERCENT))
-      continue;
-
-    m_playAllPlaylistEpisodeMap[group.front().playlist] = [&]
     {
-      std::vector<unsigned int> episodePlaylists;
-      std::for_each(group.begin() + 1, group.end(), [&](const CandidatePlaylistInformation& i)
-                    { episodePlaylists.emplace_back(i.playlist); });
-      return episodePlaylists;
-    }();
+      CLog::LogFC(LOGDEBUG, LOGBLURAY,
+                  "Rejecting potential play all playlist {} duration {} - the {} following "
+                  "playlist(s) in the group total {}",
+                  playAllPlaylist, playAllPlaylistDuration, group.size() - 1,
+                  static_cast<int>(episodesDuration.count() / 1000));
+      continue;
+    }
+
+    // Each episode playlist must be a whole multiple of the shortest and the multiples must add
+    // up to the number of episodes on disc. For a group of n+1 every multiple will be one.
+    std::vector<CandidatePlaylistInformation> episodePlaylists(std::ranges::next(group.begin()),
+                                                               group.end());
+    if (!CalculateGroupMultiples(episodePlaylists, m_numEpisodes))
+    {
+      // CalculateGroupMultiples() fails either because a playlist is not a whole multiple of the
+      // shortest episode playlist, or because the multiples do not add up to the number of
+      // episodes on disc. The multiples are assigned either way, so report which it was.
+      if (const auto& notMultiple{
+              std::ranges::find(episodePlaylists, 0, &CandidatePlaylistInformation::multiple)};
+          notMultiple != episodePlaylists.end())
+      {
+        CLog::LogFC(
+            LOGDEBUG, LOGBLURAY,
+            "Rejecting potential play all playlist {} duration {} - episode playlist {} "
+            "duration {} is not a whole multiple of {} (the average shortest episode "
+            "playlist in the group)",
+            playAllPlaylist, playAllPlaylistDuration, notMultiple->playlist,
+            static_cast<int>(notMultiple->duration.count() / 1000),
+            static_cast<int>(CalculateAverageOfShortEpisodes(episodePlaylists).count() / 1000));
+      }
+      else
+      {
+        const auto multiples{episodePlaylists |
+                             std::views::transform(&CandidatePlaylistInformation::multiple)};
+        CLog::LogFC(LOGDEBUG, LOGBLURAY,
+                    "Rejecting potential play all playlist {} duration {} - the {} following "
+                    "playlist(s) in the group account for {} episode(s), not the {} on disc",
+                    playAllPlaylist, playAllPlaylistDuration, episodePlaylists.size(),
+                    std::accumulate(multiples.begin(), multiples.end(), 0), m_numEpisodes);
+      }
+      continue;
+    }
+
+    CLog::LogFC(LOGDEBUG, LOGBLURAY,
+                "Potential play all playlist {} duration {} with {} episode playlist(s)",
+                playAllPlaylist, playAllPlaylistDuration, episodePlaylists.size());
+    for (const auto& episodePlaylist : episodePlaylists)
+      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Episode playlist {} duration {} contains {} episode(s)",
+                  episodePlaylist.playlist,
+                  static_cast<int>(episodePlaylist.duration.count() / 1000),
+                  episodePlaylist.multiple);
+
+    m_playAllPlaylistEpisodeMap[playAllPlaylist] = std::move(episodePlaylists);
   }
 
   if (m_playAllPlaylistEpisodeMap.empty())
@@ -643,34 +699,40 @@ void CDiscDirectoryHelper::UseRelaxedPlayAllPlaylistMethod(int episodeIndex,
 
   CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using candidate play all playlist {}", playAllPlaylist);
 
-  unsigned int i{0};
-  const int episodeOffset{episodeIndex - static_cast<int>(m_numSpecials)};
-  for (const auto& singleEpisodePlaylist : episodes)
+  // Start at numSpecials as specials (S00) are before episodes in episodesOnDisc
+  unsigned int index{m_numSpecials};
+  for (const auto& episodePlaylist : episodes)
   {
-    if (m_allEpisodes == AllEpisodes::ALL || std::cmp_equal(i, episodeOffset))
+    const unsigned int singleEpisodePlaylist{episodePlaylist.playlist};
+    if (!playlists.contains(singleEpisodePlaylist))
     {
-      if (!playlists.contains(singleEpisodePlaylist))
-      {
-        CLog::LogF(LOGERROR, "Single episode playlist {} missing in playlist map",
-                   singleEpisodePlaylist);
-        return;
-      }
-      // Get playlist information
-      const PlaylistInformation& singleEpisodePlaylistInformation{
-          playlists.find(singleEpisodePlaylist)->second};
-
-      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {} duration {}", singleEpisodePlaylist,
-                  static_cast<int>(singleEpisodePlaylistInformation.duration.count() / 1000));
-
-      m_candidatePlaylists.try_emplace(
-          singleEpisodePlaylist,
-          CandidatePlaylistInformation{.playlist = singleEpisodePlaylist,
-                                       .index = i + m_numSpecials,
-                                       .duration = singleEpisodePlaylistInformation.duration,
-                                       .clips = singleEpisodePlaylistInformation.clips,
-                                       .languages = singleEpisodePlaylistInformation.languages});
+      CLog::LogF(LOGERROR, "Single episode playlist {} missing in playlist map",
+                 singleEpisodePlaylist);
+      return;
     }
-    ++i;
+    // Get playlist information
+    const PlaylistInformation& singleEpisodePlaylistInformation{
+        playlists.find(singleEpisodePlaylist)->second};
+
+    // A playlist may cover more than one episode (a double/triple episode)
+    for (int i = 0; i < episodePlaylist.multiple; ++i)
+    {
+      if (m_allEpisodes == AllEpisodes::ALL || std::cmp_equal(index, episodeIndex))
+      {
+        CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {} duration {}", singleEpisodePlaylist,
+                    static_cast<int>(singleEpisodePlaylistInformation.duration.count() / 1000));
+
+        m_candidatePlaylists.try_emplace(
+            singleEpisodePlaylist,
+            CandidatePlaylistInformation{.playlist = singleEpisodePlaylist,
+                                         .index = index,
+                                         .duration = singleEpisodePlaylistInformation.duration,
+                                         .multiple = episodePlaylist.multiple,
+                                         .clips = singleEpisodePlaylistInformation.clips,
+                                         .languages = singleEpisodePlaylistInformation.languages});
+      }
+      ++index;
+    }
   }
 }
 
@@ -922,7 +984,8 @@ void CDiscDirectoryHelper::UseGroupMethod(int episodeIndex,
       bool nextPlaylistIsClose{false};
       if (tmp.size() > m_nthLongestPlaylists.size())
       {
-        std::ranges::nth_element(tmp, tmp.begin() + (m_nthLongestPlaylists.size()),
+        std::ranges::nth_element(tmp,
+                                 tmp.begin() + static_cast<unsigned>(m_nthLongestPlaylists.size()),
                                  [](const PlaylistInformation& a, const PlaylistInformation& b)
                                  { return a.duration > b.duration; });
 
@@ -947,18 +1010,59 @@ void CDiscDirectoryHelper::UseGroupMethod(int episodeIndex,
 
 namespace
 {
+// A playlist containing more than one episode is normally shorter than the individual episode
+// playlists for those episodes added together, because the intro/recap/end credits that each
+// single episode playlist carries appear only once. Every additional episode in the playlist
+// omits another set, so the shortfall that can be tolerated grows with the number of episodes.
+//
+// In the other direction there is nothing to omit - a multiple episode playlist should not be
+// materially longer than the individual episode playlists added together. So the upper bound is
+// a fixed percentage that does not grow with the number of episodes.
+
+// Both bounds are a percentage of the whole multiple
+constexpr double MULTIPLE_UPPER_TOLERANCE_PERCENT{5.0};
+constexpr double MULTIPLE_LOWER_TOLERANCE_PERCENT{15.0};
+
+// The lower tolerance is increased by this factor for each episode in the playlist beyond the
+// first (ie. 15%, 16.5%, 18.15%, ...), up to a maximum
+constexpr double MULTIPLE_LOWER_TOLERANCE_GROWTH_FACTOR{1.1};
+constexpr double MULTIPLE_LOWER_TOLERANCE_MAX_PERCENT{50.0};
+
+// The range of multiples of a single episode's duration that a playlist containing the given
+// number of episodes may occupy
+constexpr std::pair<double, double> MultipleBounds(int episodes)
+{
+  double lowerTolerancePercent{MULTIPLE_LOWER_TOLERANCE_PERCENT};
+  for (int episode = 1; episode < episodes; ++episode)
+    lowerTolerancePercent *= MULTIPLE_LOWER_TOLERANCE_GROWTH_FACTOR;
+  lowerTolerancePercent = std::min(lowerTolerancePercent, MULTIPLE_LOWER_TOLERANCE_MAX_PERCENT);
+
+  const auto count{static_cast<double>(episodes)};
+  return {count * (1.0 - lowerTolerancePercent / 100.0),
+          count * (1.0 + MULTIPLE_UPPER_TOLERANCE_PERCENT / 100.0)};
+}
+
+// Returns the number of episodes that duration represents as a multiple of averageShortest, or 0
+// if it does not fall within the tolerated range for any number of episodes.
+// A playlist cannot hold more episodes than there are on the disc. The ranges are disjoint for
+// the first few multiples but begin to overlap as the tolerated shortfall accumulates, so search
+// ascending and take the fewest episodes that fit.
 int CalculateMultiple(std::chrono::milliseconds duration,
                       std::chrono::milliseconds averageShortest,
-                      double multiplePercent)
+                      unsigned int numEpisodes)
 {
-  if (averageShortest == 0ms)
+  if (averageShortest <= 0ms || duration <= 0ms)
     return 0;
 
-  double multiple{static_cast<double>(duration.count()) /
-                  static_cast<double>(averageShortest.count())};
-  int integerMultiple{static_cast<int>(std::round(multiple))};
-  if (abs(multiple - integerMultiple) < multiplePercent / 100.0)
-    return integerMultiple;
+  const double multiple{static_cast<double>(duration.count()) /
+                        static_cast<double>(averageShortest.count())};
+
+  for (int episodes = 1; std::cmp_less_equal(episodes, numEpisodes); ++episodes)
+  {
+    const auto [lower, upper]{MultipleBounds(episodes)};
+    if (multiple >= lower && multiple <= upper)
+      return episodes;
+  }
 
   return 0;
 }
@@ -997,6 +1101,29 @@ std::chrono::milliseconds CDiscDirectoryHelper::CalculateAverageOfShortEpisodes(
   return averageShortest;
 }
 
+// Assign each playlist in the group the number of episodes it is likely to contain, being the
+// whole multiple of the average shortest playlist in the group that its duration represents.
+// Returns false unless every playlist is such a multiple and the multiples account for exactly
+// numEpisodes episodes.
+bool CDiscDirectoryHelper::CalculateGroupMultiples(std::vector<CandidatePlaylistInformation>& group,
+                                                   unsigned int numEpisodes)
+{
+  const std::chrono::milliseconds averageShortest{CalculateAverageOfShortEpisodes(group)};
+
+  for (auto& playlist : group)
+    playlist.multiple = CalculateMultiple(playlist.duration, averageShortest, numEpisodes);
+
+  // Check there are no playlists that are not a multiple
+  if (std::ranges::any_of(group,
+                          [](const CandidatePlaylistInformation& i) { return i.multiple == 0; }))
+    return false;
+
+  // Check that multiples add up to numEpisodes
+  auto groupMultiples{group | std::views::transform(&CandidatePlaylistInformation::multiple)};
+  return std::accumulate(groupMultiples.begin(), groupMultiples.end(), 0) ==
+         static_cast<int>(numEpisodes);
+}
+
 void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(int episodeIndex,
                                                         const Episodes& episodesOnDisc)
 {
@@ -1005,27 +1132,10 @@ void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(int episodeIndex,
   CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using groups with multiples method");
   for (auto& group : GetGroupsWithoutDuplicates(m_allGroups))
   {
-    // Calculate multiples
-    const std::chrono::milliseconds averageShortest{CalculateAverageOfShortEpisodes(group)};
-
-    // Multiples of average shortest playlists (within 15% of the average)
-    constexpr double MULTIPLE_PERCENT{15.0};
-    for (auto& playlist : group)
-      playlist.multiple = CalculateMultiple(playlist.duration, averageShortest, MULTIPLE_PERCENT);
-
-    // Check there are no playlists that are not a multiple
-    if (std::ranges::any_of(group,
-                            [](const CandidatePlaylistInformation& i) { return i.multiple == 0; }))
-      continue;
-
-    // Check that multiples add up to numEpisodes
-    auto groupMultiples{group | std::views::transform(&CandidatePlaylistInformation::multiple)};
-    if (std::accumulate(groupMultiples.begin(), groupMultiples.end(), 0) !=
-        static_cast<int>(m_numEpisodes))
+    if (!CalculateGroupMultiples(group, m_numEpisodes))
       continue;
 
     // Save candidate episode(s)
-    const int episodeOffset{episodeIndex - static_cast<int>(m_numSpecials)};
     unsigned int index{
         m_numSpecials}; // Start at numSpecials as specials (S00) are before episodes in episodesOnDisc
     for (const auto& playlist : group)
@@ -1033,7 +1143,7 @@ void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(int episodeIndex,
       auto playlistInformation{playlist};
       for (int i = 0; i < playlist.multiple; ++i)
       {
-        if (m_allEpisodes == AllEpisodes::ALL || std::cmp_equal(index, episodeOffset))
+        if (m_allEpisodes == AllEpisodes::ALL || std::cmp_equal(index, episodeIndex))
         {
           playlistInformation.index = index;
           m_candidatePlaylists.try_emplace(playlist.playlist, playlistInformation);
@@ -1457,7 +1567,7 @@ bool CDiscDirectoryHelper::GetEpisodePlaylists(
   InitialiseEpisodePlaylistSearch(episodeIndex, episodesOnDisc);
   FindPlayAllPlaylists(clips, playlists);
   FindGroups(playlists, episodesOnDisc);
-  FindRelaxedPlayAllPlaylists(playlists); // Uses m_groups
+  FindRelaxedPlayAllPlaylists(playlists); // Uses m_allGroups
   FindCandidatePlaylists(episodesOnDisc, episodeIndex, playlists);
   FindSpecials(playlists);
   EndEpisodePlaylistSearch();

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -141,6 +141,12 @@ void CDiscDirectoryHelper::InitialiseEpisodePlaylistSearch(int episodeIndex,
 
 namespace
 {
+void SortEpisodes(Episodes& episodes)
+{
+  std::ranges::sort(episodes, std::ranges::less{}, [](const Episode& e)
+                    { return std::tie(e.iSeason, e.iEpisode, e.iSubepisode); });
+}
+
 bool IsPotentialPlayAllPlaylist(const PlaylistInformation& playlistInformation,
                                 unsigned int numEpisodes)
 {
@@ -1976,8 +1982,14 @@ bool CDiscDirectoryHelper::GetEpisodePlaylists(
 
   // Sort (subsequent routines assume that specials (season 0) are before episodes)
   auto episodesOnDisc{episodesOnDiscUnsorted};
-  std::ranges::sort(episodesOnDisc, std::ranges::less{}, [](const Episode& e)
-                    { return std::tie(e.iSeason, e.iEpisode, e.iSubepisode); });
+  SortEpisodes(episodesOnDisc);
+  if (episodeIndex >= 0)
+  {
+    // Adjust index
+    const auto& wantedEpisode{episodesOnDiscUnsorted[episodeIndex]};
+    const auto it{std::ranges::find(episodesOnDisc, wantedEpisode)};
+    episodeIndex = static_cast<int>(std::ranges::distance(episodesOnDisc.begin(), it));
+  }
 
   InitialiseEpisodePlaylistSearch(episodeIndex, episodesOnDisc);
   FindPlayAllPlaylists(clips, playlists);
@@ -2109,8 +2121,7 @@ bool CDiscDirectoryHelper::GetAllEpisodePlaylists(
   if (!episodesOnDiscUnsorted.empty())
   {
     auto episodesOnDisc{episodesOnDiscUnsorted};
-    std::ranges::sort(episodesOnDisc, std::ranges::less{}, [](const Episode& e)
-                      { return std::tie(e.iSeason, e.iEpisode, e.iSubepisode); });
+    SortEpisodes(episodesOnDisc);
 
     InitialiseEpisodePlaylistSearch(ALL_PLAYLISTS, episodesOnDisc);
     FindPlayAllPlaylists(clips, playlistMap);

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -72,17 +72,28 @@ private:
 
 CDiscDirectoryHelper::CDiscDirectoryHelper()
 {
-  m_playAllPlaylists.clear();
-  m_playAllPlaylistsMap.clear();
-  m_groups.clear();
-  m_candidatePlaylists.clear();
-  m_candidateSpecials.clear();
-  m_nthLongestPlaylists.clear();
+  Reset();
 
   m_minEpisodeDuration = std::chrono::milliseconds(CServiceBroker::GetSettingsComponent()
                                                        ->GetAdvancedSettings()
                                                        ->m_minimumEpisodePlaylistDuration *
                                                    1000);
+}
+
+void CDiscDirectoryHelper::Reset()
+{
+  m_allEpisodes = AllEpisodes::SINGLE;
+  m_isSpecial = IsSpecial::EPISODE;
+  m_numEpisodes = 0;
+  m_numSpecials = 0;
+  m_playAllPlaylists.clear();
+  m_playAllPlaylistsMap.clear();
+  m_playAllPlaylistEpisodeMap.clear();
+  m_groups.clear();
+  m_allGroups.clear();
+  m_candidatePlaylists.clear();
+  m_candidateSpecials.clear();
+  m_nthLongestPlaylists.clear();
 }
 
 CDiscDirectoryHelper::CDiscDirectoryHelper(StreamDetailsProvider getStreamDetails)
@@ -257,6 +268,15 @@ bool ProcessPlaylistClips(const ClipMap& clips,
                        allowBeginningAndEnd, minEpisodeDuration))
       return false;
 
+    // A short first/last clip is an extra intro or ending clip, not an episode playlist
+    // A short clip elsewhere would fail ClipQualifies
+    // Record it with no episode playlists, so UsePlayAllPlaylistMethod skips over it
+    if (clipInformation.duration < minEpisodeDuration)
+    {
+      playAllPlaylistClipMap[clip] = {};
+      continue;
+    }
+
     // See if the playlists associated with the clip are valid as a single episodes
     std::vector<unsigned int> playAllPlaylistMap;
     if (!CheckClip(playlists, clips, playlistNumber, clipInformation, clip, minEpisodeDuration,
@@ -299,6 +319,27 @@ std::chrono::milliseconds GetAverageEpisodeDuration(const Episodes& episodesOnDi
       })};
 
   return std::chrono::milliseconds(count ? static_cast<long long>(sum / count) : 0) * 1000;
+}
+
+template<std::ranges::input_range R>
+bool ArePlaylistsConsecutive(const R& items)
+{
+  auto it = std::ranges::begin(items);
+  auto end = std::ranges::end(items);
+
+  if (it == end)
+    return false; // empty
+
+  auto prev = it->playlist;
+  ++it;
+  for (; it != end; ++it)
+  {
+    if (it->playlist != prev + 1)
+      return false;
+    prev = it->playlist;
+  }
+
+  return true;
 }
 } // namespace
 
@@ -477,8 +518,58 @@ void CDiscDirectoryHelper::FindGroups(const PlaylistMap& playlists, const Episod
                   group.back().playlist);
 }
 
+void CDiscDirectoryHelper::FindRelaxedPlayAllPlaylists(const PlaylistMap& playlists)
+{
+  // Look for a potential play all playlist (gives episode order)
+  //
+  // More relaxed assumptions than FindPlayAllPlaylists. Ignores clips.
+  //   1) The playall playlist will be first and the episode playlists will be sequentially numbered
+  //      after it as part of a group
+  //   2) There will only be n+1 playlists longer than the minimum episode duration
+  //      (the playall playlist and the n episode playlists) in the group
+  //   3) The sum of the durations of the episode playlsits will be within 5% of the duration
+  //      of the playall playlist
+
+  // Only look for play all playlists if enough playlists and more than one episode on disc and groups found
+  if (m_numEpisodes < 2 || playlists.size() < m_numEpisodes || m_groups.empty())
+    return;
+
+  for (const auto& group : m_groups)
+  {
+    // Group is n+1 playlists
+    if (group.size() != m_numEpisodes + 1)
+      continue;
+
+    // Group is consecutively numbered
+    if (!ArePlaylistsConsecutive(group))
+      continue;
+
+    // Potential episode playlists duration's sum is within 5% of the playall playlist duration
+    const std::chrono::milliseconds episodesDuration{std::accumulate(
+        std::ranges::next(group.begin()), group.end(), std::chrono::milliseconds{0},
+        [](auto acc, const CandidatePlaylistInformation& p) { return acc + p.duration; })};
+    if (!CheckDurationsWithinTolerance(episodesDuration, group.front().duration,
+                                       DURATION_TOLERANCE_RELAXED_PLAYALLPLAYLIST_PERCENT))
+      continue;
+
+    m_playAllPlaylistEpisodeMap[group.front().playlist] = [&]
+    {
+      std::vector<unsigned int> episodePlaylists;
+      std::for_each(group.begin() + 1, group.end(), [&](const CandidatePlaylistInformation& i)
+                    { episodePlaylists.emplace_back(i.playlist); });
+      return episodePlaylists;
+    }();
+  }
+
+  if (m_playAllPlaylistEpisodeMap.empty())
+    CLog::LogFC(LOGDEBUG, LOGBLURAY, "No play all playlists found using the relaxed method");
+}
+
 void CDiscDirectoryHelper::UsePlayAllPlaylistMethod(int episodeIndex, const PlaylistMap& playlists)
 {
+  if (m_playAllPlaylists.empty())
+    return;
+
   CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using Play All playlist method");
 
   // Get the playlist
@@ -534,6 +625,50 @@ void CDiscDirectoryHelper::UsePlayAllPlaylistMethod(int episodeIndex, const Play
                 .clips = singleEpisodePlaylistInformation.clips,
                 .languages = singleEpisodePlaylistInformation.languages});
       }
+    }
+    ++i;
+  }
+}
+
+void CDiscDirectoryHelper::UseRelaxedPlayAllPlaylistMethod(int episodeIndex,
+                                                           const PlaylistMap& playlists)
+{
+  if (m_playAllPlaylistEpisodeMap.empty())
+    return;
+
+  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using Relaxed Play All playlist method");
+
+  // Get the playlist
+  const auto& [playAllPlaylist, episodes]{*m_playAllPlaylistEpisodeMap.begin()};
+
+  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using candidate play all playlist {}", playAllPlaylist);
+
+  unsigned int i{0};
+  const int episodeOffset{episodeIndex - static_cast<int>(m_numSpecials)};
+  for (const auto& singleEpisodePlaylist : episodes)
+  {
+    if (m_allEpisodes == AllEpisodes::ALL || std::cmp_equal(i, episodeOffset))
+    {
+      if (!playlists.contains(singleEpisodePlaylist))
+      {
+        CLog::LogF(LOGERROR, "Single episode playlist {} missing in playlist map",
+                   singleEpisodePlaylist);
+        return;
+      }
+      // Get playlist information
+      const PlaylistInformation& singleEpisodePlaylistInformation{
+          playlists.find(singleEpisodePlaylist)->second};
+
+      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {} duration {}", singleEpisodePlaylist,
+                  static_cast<int>(singleEpisodePlaylistInformation.duration.count() / 1000));
+
+      m_candidatePlaylists.try_emplace(
+          singleEpisodePlaylist,
+          CandidatePlaylistInformation{.playlist = singleEpisodePlaylist,
+                                       .index = i + m_numSpecials,
+                                       .duration = singleEpisodePlaylistInformation.duration,
+                                       .clips = singleEpisodePlaylistInformation.clips,
+                                       .languages = singleEpisodePlaylistInformation.languages});
     }
     ++i;
   }
@@ -1018,6 +1153,8 @@ void CDiscDirectoryHelper::FindCandidatePlaylists(const Episodes& episodesOnDisc
 
   if (m_playAllPlaylists.size() == 1)
     UsePlayAllPlaylistMethod(episodeIndex, playlists);
+  else if (m_playAllPlaylistEpisodeMap.size() == 1)
+    UseRelaxedPlayAllPlaylistMethod(episodeIndex, playlists);
   else if (m_numEpisodes == 1)
     UseLongOrCommonMethodForSingleEpisode(episodeIndex, playlists);
   else if (!m_groups.empty())
@@ -1268,6 +1405,31 @@ void CDiscDirectoryHelper::PopulateEpisodeFileItems(const CURL& url,
       items.Add(newItem);
     }
   }
+
+  LogEpisodePlaylistSearchResult(items, episodeIndex, episodesOnDisc);
+}
+
+void CDiscDirectoryHelper::LogEpisodePlaylistSearchResult(const CFileItemList& items,
+                                                          int episodeIndex,
+                                                          const Episodes& episodesOnDisc) const
+{
+  std::vector<std::string> foundPlaylists;
+  foundPlaylists.reserve(items.Size());
+  for (const auto& item : items)
+    foundPlaylists.emplace_back(item->GetProperty("bluray_playlist").asString());
+  const std::string playlistList{foundPlaylists.empty() ? "none"
+                                                        : StringUtils::Join(foundPlaylists, ",")};
+
+  if (m_allEpisodes == AllEpisodes::ALL)
+  {
+    CLog::LogFC(LOGDEBUG, LOGBLURAY, "Episode search for all episodes on disc found playlist(s) {}",
+                playlistList);
+    return;
+  }
+
+  const Episode& episode{episodesOnDisc[episodeIndex]};
+  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Episode search for season {} episode {} found playlist(s) {}",
+              episode.iSeason, episode.iEpisode, playlistList);
 }
 
 bool CDiscDirectoryHelper::GetEpisodePlaylists(
@@ -1280,6 +1442,7 @@ bool CDiscDirectoryHelper::GetEpisodePlaylists(
     const PlaylistMap& playlists)
 {
   items.Clear();
+  Reset();
 
   // Checks
   if (playlists.empty() || clips.empty() || episodeIndex < -1 ||
@@ -1294,6 +1457,7 @@ bool CDiscDirectoryHelper::GetEpisodePlaylists(
   InitialiseEpisodePlaylistSearch(episodeIndex, episodesOnDisc);
   FindPlayAllPlaylists(clips, playlists);
   FindGroups(playlists, episodesOnDisc);
+  FindRelaxedPlayAllPlaylists(playlists); // Uses m_groups
   FindCandidatePlaylists(episodesOnDisc, episodeIndex, playlists);
   FindSpecials(playlists);
   EndEpisodePlaylistSearch();
@@ -1410,6 +1574,7 @@ bool CDiscDirectoryHelper::GetAllEpisodePlaylists(
     const PlaylistMap& playlistMap)
 {
   items.Clear();
+  Reset();
 
   // Checks
   if (playlistMap.empty() || clips.empty())
@@ -1603,6 +1768,7 @@ bool CDiscDirectoryHelper::GetMoviePlaylists(const CURL& url,
                                              const PlaylistMap& playlistMap)
 {
   items.Clear();
+  Reset();
 
   // Checks
   if (playlistMap.empty() || clips.empty())

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -304,6 +304,66 @@ bool CheckDurationsWithinTolerance(std::chrono::milliseconds episodeDuration,
   return episodeDuration > 0ms && std::chrono::abs(playlistDuration - episodeDuration) <= tolerance;
 }
 
+// Whether the clips of a potential play all playlist look like the episodes on the disc.
+//
+// Having the right number of clips does not make a playlist the episodes - a disc's extras are
+// commonly gathered into a play all playlist of their own (examples The Expanse S3D3 and The Last
+// of Us S2D1 Bluray, where the featurettes are collected alongside the episodes). Two things
+// tell them apart:
+//   1) Episodes of one another are of near-equal duration
+//   2) Each clip is of a length matching the episode it would be given
+//
+// The first alone is not enough, as a disc's extras can happen to be of similar lengths, and the
+// second alone is not enough, as only one episode's duration is known on a disc's first search.
+//
+// The tolerance is loose because this only has to reject clips plainly unlike the episodes - a
+// disc's episodes can legitimately vary in length, a feature length finale most of all, and a
+// scraper commonly gives no more than the broadcast slot.
+bool ArePlayAllPlaylistClipsEpisodes(const ClipMap& clips,
+                                     const PlaylistInformation& playlistInformation,
+                                     const Episodes& episodesOnDisc,
+                                     unsigned int numSpecials,
+                                     std::chrono::milliseconds minEpisodeDuration)
+{
+  // Any short clip is an intro or credits rather than an episode (see ProcessPlaylistClips())
+  std::vector<std::chrono::milliseconds> durations;
+  durations.reserve(playlistInformation.clips.size());
+  for (const unsigned int clip : playlistInformation.clips)
+  {
+    if (const auto it{clips.find(clip)};
+        it != clips.end() && it->second.duration >= minEpisodeDuration)
+      durations.emplace_back(it->second.duration);
+  }
+
+  if (durations.empty())
+    return false;
+
+  // Of near-equal duration
+  const std::chrono::milliseconds mean{std::accumulate(durations.begin(), durations.end(), 0ms) /
+                                       static_cast<int>(durations.size())};
+  if (!std::ranges::all_of(durations,
+                           [mean](const std::chrono::milliseconds duration) {
+                             return CheckDurationsWithinTolerance(
+                                 mean, duration, DURATION_TOLERANCE_SCRAPED_PERCENT);
+                           }))
+    return false;
+
+  // Of a length matching the episode each would be given
+  for (size_t index = 0; const std::chrono::milliseconds duration : durations)
+  {
+    const size_t episode{numSpecials + index++};
+    if (episode >= episodesOnDisc.size())
+      break;
+
+    const std::chrono::milliseconds scrapedDuration{episodesOnDisc[episode].duration * 1000ms};
+    if (scrapedDuration > 0ms && !CheckDurationsWithinTolerance(scrapedDuration, duration,
+                                                                DURATION_TOLERANCE_SCRAPED_PERCENT))
+      return false;
+  }
+
+  return true;
+}
+
 bool AnyEpisodeDurationKnown(const Episodes& episodesOnDisc)
 {
   return std::ranges::any_of(episodesOnDisc, [](const Episode& e) { return e.duration > 0; });
@@ -644,7 +704,9 @@ void CDiscDirectoryHelper::StorePlayAllPlaylist(
   m_playAllPlaylistsMap[playlistNumber] = playAllPlaylistClipMap;
 }
 
-void CDiscDirectoryHelper::FindPlayAllPlaylists(const ClipMap& clips, const PlaylistMap& playlists)
+void CDiscDirectoryHelper::FindPlayAllPlaylists(const ClipMap& clips,
+                                                const PlaylistMap& playlists,
+                                                const Episodes& episodesOnDisc)
 {
   // Look for a potential play all playlist (gives episode order)
   //
@@ -654,6 +716,7 @@ void CDiscDirectoryHelper::FindPlayAllPlaylists(const ClipMap& clips, const Play
   //   3) Each clip (bar the last) will be at least MIN_EPISODE_DURATION long
   //   4) Each potential individual episode playlist containing a clip from the potential play all playlist
   //      will have at most one other clip before/after
+  //   5) The clips look like the episodes (see ArePlayAllPlaylistClipsEpisodes())
 
   // Only look for play all playlists if enough playlists and more than one episode on disc
   if (m_numEpisodes < 2 || playlists.size() < m_numEpisodes)
@@ -663,6 +726,16 @@ void CDiscDirectoryHelper::FindPlayAllPlaylists(const ClipMap& clips, const Play
   {
     if (!IsPotentialPlayAllPlaylist(playlistInformation, m_numEpisodes))
       continue;
+
+    if (!ArePlayAllPlaylistClipsEpisodes(clips, playlistInformation, episodesOnDisc, m_numSpecials,
+                                         m_minEpisodeDuration))
+    {
+      CLog::LogFC(LOGDEBUG, LOGBLURAY,
+                  "Rejecting potential play all playlist {} - its clips are the wrong length to be "
+                  "the episodes",
+                  playlistNumber);
+      continue;
+    }
 
     std::map<unsigned int, std::vector<unsigned int>> playAllPlaylistClipMap;
     unsigned int playAllPlaylistEpisodesStartOffset{0};
@@ -2027,7 +2100,7 @@ bool CDiscDirectoryHelper::GetEpisodePlaylists(
   }
 
   InitialiseEpisodePlaylistSearch(episodeIndex, episodesOnDisc);
-  FindPlayAllPlaylists(clips, playlists);
+  FindPlayAllPlaylists(clips, playlists, episodesOnDisc);
   FindGroups(playlists, episodesOnDisc);
   FindRelaxedPlayAllPlaylists(playlists); // Uses m_allGroups
   FindCandidatePlaylists(episodesOnDisc, episodeIndex, clips, playlists);
@@ -2159,7 +2232,7 @@ bool CDiscDirectoryHelper::GetAllEpisodePlaylists(
     SortEpisodes(episodesOnDisc);
 
     InitialiseEpisodePlaylistSearch(ALL_PLAYLISTS, episodesOnDisc);
-    FindPlayAllPlaylists(clips, playlistMap);
+    FindPlayAllPlaylists(clips, playlistMap, episodesOnDisc);
   }
 
   std::vector<PlaylistInformation> playlists;

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -1263,6 +1263,106 @@ void CDiscDirectoryHelper::UseGroupsWithMultiplesMethod(int episodeIndex,
     CLog::LogFC(LOGDEBUG, LOGBLURAY, "No candidate playlists found");
 }
 
+void CDiscDirectoryHelper::UseSingleEpisodeClipsPlaylistMethod(int episodeIndex,
+                                                               const Episodes& episodesOnDisc,
+                                                               const ClipMap& clips,
+                                                               const PlaylistMap& playlists)
+{
+  // Method 3 - Some discs author the episodes as a single playlist made up of one clip per episode,
+  //            with no individual episode playlists at all, so there is nothing for the play-all
+  //            playlist or group methods to point at (example Tin Man S1D1 UK BD).
+  //
+  // Assumptions
+  //   1) There is exactly one playlist at least the minimum episode duration long
+  //   2) It has one clip per episode on disc, each at least the minimum episode duration long
+  //   3) Where an episode's duration is known, it matches the duration of the clip in its position
+  //   4) The clips are in episode order
+
+  if (m_numSpecials > 0)
+    return; // No way of telling which clip is the special
+
+  // Find the sole playlist long enough to hold the episodes
+  auto longPlaylists{playlists | std::views::values |
+                     std::views::filter([this](const PlaylistInformation& p)
+                                        { return p.duration >= m_minEpisodeDuration; })};
+  const auto it{std::ranges::begin(longPlaylists)};
+  const auto end{std::ranges::end(longPlaylists)};
+  if (it == end || std::ranges::next(it) != end)
+    return; // No playlist, or more than one, long enough to hold all the episodes
+
+  const PlaylistInformation& information{*it};
+  if (information.clips.size() != m_numEpisodes)
+    return;
+
+  CLog::LogFC(LOGDEBUG, LOGBLURAY, "Using single playlist with episode clips method");
+
+  // Derive the start of each clip within the playlist, validating as we go
+  std::vector<std::chrono::milliseconds> clipStarts;
+  clipStarts.reserve(information.clips.size());
+  std::chrono::milliseconds start{0ms};
+  for (unsigned int index = 0; const unsigned int clip : information.clips)
+  {
+    const auto clipIt{clips.find(clip)};
+    if (clipIt == clips.end())
+    {
+      CLog::LogF(LOGERROR, "Clip {} missing in clip map", clip);
+      return;
+    }
+
+    const std::chrono::milliseconds clipDuration{clipIt->second.duration};
+    if (clipDuration < m_minEpisodeDuration)
+    {
+      CLog::LogFC(LOGDEBUG, LOGBLURAY, "Rejecting playlist {} - clip {} duration {} is too short",
+                  information.playlist, clip, static_cast<int>(clipDuration.count() / 1000));
+      return;
+    }
+
+    // Only episodes scraped so far have a duration, so unknown ones are left to the check above
+    const std::chrono::milliseconds episodeDuration{episodesOnDisc[index].duration * 1000ms};
+    if (episodeDuration > 0ms && !CheckDurationsWithinTolerance(episodeDuration, clipDuration))
+    {
+      CLog::LogFC(LOGDEBUG, LOGBLURAY,
+                  "Rejecting playlist {} - clip {} duration {} does not match episode {} duration "
+                  "{}",
+                  information.playlist, clip, static_cast<int>(clipDuration.count() / 1000),
+                  episodesOnDisc[index].iEpisode, episodesOnDisc[index].duration);
+      return;
+    }
+
+    clipStarts.emplace_back(start);
+    start += clipDuration;
+    ++index;
+  }
+
+  // Save the candidate episode. Only one entry can be stored
+  unsigned int index{0};
+  std::chrono::milliseconds episodeStart{0ms};
+  std::chrono::milliseconds episodeDuration{information.duration};
+  if (m_allEpisodes == AllEpisodes::SINGLE)
+  {
+    index = static_cast<unsigned int>(episodeIndex);
+    episodeStart = clipStarts[index];
+    episodeDuration = clips.find(information.clips[index])->second.duration;
+  }
+
+  CLog::LogFC(LOGDEBUG, LOGBLURAY,
+              "Candidate playlist {} for episode {} - starts at {} runs for {}",
+              information.playlist, episodesOnDisc[index].iEpisode,
+              static_cast<int>(episodeStart.count() / 1000),
+              static_cast<int>(episodeDuration.count() / 1000));
+
+  m_candidatePlaylists.try_emplace(
+      information.playlist, CandidatePlaylistInformation{
+                                .playlist = information.playlist,
+                                .index = index,
+                                .duration = information.duration,
+                                .chapters = static_cast<unsigned int>(information.chapters.size()),
+                                .clips = information.clips,
+                                .languages = information.languages,
+                                .episodeStart = episodeStart,
+                                .episodeDuration = episodeDuration});
+}
+
 void CDiscDirectoryHelper::ChooseSingleBestPlaylist(const Episodes& episodesOnDisc)
 {
   // Rebuild candidatePlaylists
@@ -1368,6 +1468,7 @@ void CDiscDirectoryHelper::AddIdenticalPlaylists(const PlaylistMap& playlists)
 
 void CDiscDirectoryHelper::FindCandidatePlaylists(const Episodes& episodesOnDisc,
                                                   int episodeIndex,
+                                                  const ClipMap& clips,
                                                   const PlaylistMap& playlists)
 {
   // At this stage we have a number of ways of trying to determine the correct playlist for an episode
@@ -1383,6 +1484,9 @@ void CDiscDirectoryHelper::FindCandidatePlaylists(const Episodes& episodesOnDisc
   // 2b) For single episode discs, look for the longest playlist.
   //     There are some discs where there are extras that are longer than the episode itself, in this case
   //     we look for the playlist with a common starting number (eg. 1, 800 etc..)
+  //
+  // 3) Using a single playlist that holds every episode as a clip, where the disc has no individual
+  //    episode playlists at all.
 
   if (m_allEpisodes == AllEpisodes::ALL)
     CLog::LogFC(LOGDEBUG, LOGBLURAY, "Looking for all episodes on disc");
@@ -1401,6 +1505,9 @@ void CDiscDirectoryHelper::FindCandidatePlaylists(const Episodes& episodesOnDisc
 
   if (m_candidatePlaylists.empty() && !m_allGroups.empty() && m_numEpisodes > 1)
     UseGroupsWithMultiplesMethod(episodeIndex, episodesOnDisc);
+
+  if (m_candidatePlaylists.empty() && m_numEpisodes > 1 && m_isSpecial == IsSpecial::EPISODE)
+    UseSingleEpisodeClipsPlaylistMethod(episodeIndex, episodesOnDisc, clips, playlists);
 
   // Now deal with the possibility there may be more than one playlist (per episode)
   // For this, see which is closest in duration to the desired episode duration (from the scraper)
@@ -1477,7 +1584,9 @@ std::shared_ptr<CFileItem> GenerateEpisodeItem(const CURL& url,
                                                unsigned int playlist,
                                                const PlaylistInformation& information,
                                                const Episode& episode,
-                                               bool isSpecial)
+                                               bool isSpecial,
+                                               std::chrono::milliseconds episodeStart = 0ms,
+                                               std::chrono::milliseconds episodeDuration = 0ms)
 {
   CURL path{url};
   std::string buf{StringUtils::Format("BDMV/PLAYLIST/{:05}.mpls", playlist)};
@@ -1485,13 +1594,23 @@ std::shared_ptr<CFileItem> GenerateEpisodeItem(const CURL& url,
   const auto item{std::make_shared<CFileItem>(path.Get(), false)};
 
   // Get clips
-  const std::chrono::milliseconds duration{information.duration};
+  const std::chrono::milliseconds duration{episodeDuration > 0ms ? episodeDuration
+                                                                 : information.duration};
 
   // Get languages
   const std::string langs{information.languages};
 
   CVideoInfoTag* itemTag{item->GetVideoInfoTag()};
   itemTag->SetDuration(static_cast<int>(duration.count() / 1000));
+
+  // Write an episode bookmark
+  if (episodeStart > 0ms)
+  {
+    itemTag->m_EpBookmark.timeInSeconds = static_cast<double>(episodeStart.count()) / 1000.0;
+    itemTag->m_EpBookmark.totalTimeInSeconds =
+        static_cast<double>(information.duration.count()) / 1000.0;
+  }
+
   item->SetProperty("bluray_playlist", playlist);
 
   // Get episode title
@@ -1603,7 +1722,8 @@ void CDiscDirectoryHelper::PopulateEpisodeFileItems(const CURL& url,
       }
       const auto& information{playlists.find(playlist.playlist)->second};
       const auto newItem{GenerateEpisodeItem(url, playlist.playlist, information,
-                                             episodesOnDisc[playlist.index], false)}; // Episode
+                                             episodesOnDisc[playlist.index], false, // Episode
+                                             playlist.episodeStart, playlist.episodeDuration)};
       if (!newItem)
       {
         CLog::LogFC(LOGDEBUG, LOGBLURAY, "Failed to generate FileItem for playlist {}",
@@ -1697,7 +1817,7 @@ bool CDiscDirectoryHelper::GetEpisodePlaylists(
   FindPlayAllPlaylists(clips, playlists);
   FindGroups(playlists, episodesOnDisc);
   FindRelaxedPlayAllPlaylists(playlists); // Uses m_allGroups
-  FindCandidatePlaylists(episodesOnDisc, episodeIndex, playlists);
+  FindCandidatePlaylists(episodesOnDisc, episodeIndex, clips, playlists);
   FindSpecials(playlists);
   EndEpisodePlaylistSearch();
   PopulateEpisodeFileItems(url, items, allTitles, episodeIndex, episodesOnDisc, playlists);
@@ -2227,6 +2347,12 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(const CFileItem& item,
         const auto tag{newItem->GetVideoInfoTag()};
         tag->SetFileNameAndPath(selectedItem.GetDynPath());
         tag->m_streamDetails = selectedItem.GetVideoInfoTag()->m_streamDetails;
+
+        // Episode bookmarks
+        if (const CBookmark & bookmark{selectedItem.GetVideoInfoTag()->m_EpBookmark};
+            bookmark.IsSet())
+          tag->m_EpBookmark = bookmark;
+
         if (tag->GetAssetInfo().GetTitle().empty())
           tag->GetAssetInfo().SetTitle(
               CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
@@ -2258,6 +2384,7 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(const CFileItem& item,
     for (const auto& sourceItem : sourceItems)
       items.Add(GenerateItem(item, *sourceItem, item));
   }
+
   return true;
 }
 

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -22,6 +22,7 @@
 #include "settings/VideoVersionsSettings.h"
 #include "threads/IRunnable.h"
 #include "utils/RegExp.h"
+#include "utils/StreamUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -321,6 +322,74 @@ std::chrono::milliseconds GetAverageEpisodeDuration(const Episodes& episodesOnDi
   return std::chrono::milliseconds(count ? static_cast<long long>(sum / count) : 0) * 1000;
 }
 
+// Whether candidateStream offers everything stream does.
+//
+// The two must have the same language, name and flags - and the candidate must then
+// carry it at least as well - ie. no fewer channels and no 'poorer' a codec.
+bool IsStreamCovered(const AudioStreamInfo& stream, const AudioStreamInfo& candidateStream)
+{
+  if (stream.language != candidateStream.language || stream.name != candidateStream.name ||
+      stream.flags != candidateStream.flags)
+    return false;
+
+  // A channel count of zero means unknown, so only compare them when both are known
+  if (stream.channels > 0 && candidateStream.channels > 0 &&
+      stream.channels > candidateStream.channels)
+    return false;
+
+  return StreamUtils::GetCodecPriority(stream.codecName) <=
+         StreamUtils::GetCodecPriority(candidateStream.codecName);
+}
+
+// Subtitle streams have no comparable ordering of quality, so they have to match
+bool IsStreamCovered(const SubtitleStreamInfo& stream, const SubtitleStreamInfo& candidateStream)
+{
+  return stream == candidateStream;
+}
+
+// Whether every stream of subset has a distinct counterpart in superset that covers it. Streams are
+// matched without regard to their position in the stream number table, as a playlist may list the
+// same streams in a different order, to present a particular one first.
+template<typename T>
+bool AreStreamsContained(const std::vector<T>& subset, const std::vector<T>& superset)
+{
+  if (subset.size() > superset.size())
+    return false;
+
+  // A stream can only account for one of subset's streams, so that a playlist offering the same
+  // stream twice is not contained in one offering it once
+  std::vector<bool> matched(superset.size(), false);
+  for (const T& stream : subset)
+  {
+    bool found{false};
+    for (size_t i = 0; i < superset.size() && !found; ++i)
+    {
+      if (!matched[i] && IsStreamCovered(stream, superset[i]))
+      {
+        matched[i] = true;
+        found = true;
+      }
+    }
+
+    if (!found)
+      return false;
+  }
+
+  return true;
+}
+
+// Whether playlist offers no audio or subtitle stream that candidate does not also offer, ie. it is
+// the same content with a reduced set of streams.
+// False when the streams of candidate are unknown, as nothing can then be concluded.
+bool IsStreamSubset(const PlaylistInformation& playlist, const PlaylistInformation& candidate)
+{
+  if (candidate.audioStreams.empty() && candidate.pgStreams.empty())
+    return false;
+
+  return AreStreamsContained(playlist.audioStreams, candidate.audioStreams) &&
+         AreStreamsContained(playlist.pgStreams, candidate.pgStreams);
+}
+
 template<std::ranges::input_range R>
 bool ArePlaylistsConsecutive(const R& items)
 {
@@ -354,6 +423,7 @@ void CDiscDirectoryHelper::StorePlayAllPlaylist(
       .playlist = playlistNumber,
       .playAllPlaylistEpisodesStartOffset = playAllPlaylistEpisodesStartOffset,
       .duration = playlistInformation.duration,
+      .chapters = static_cast<unsigned int>(playlistInformation.chapters.size()),
       .clips = playlistInformation.clips,
       .languages = playlistInformation.languages});
   m_playAllPlaylistsMap[playlistNumber] = playAllPlaylistClipMap;
@@ -424,10 +494,12 @@ void CDiscDirectoryHelper::FindGroups(const PlaylistMap& playlists, const Episod
 
   for (const auto& [playlist, playlistInformation] : longPlaylists)
   {
-    CandidatePlaylistInformation groupPlaylist{.playlist = playlist,
-                                               .duration = playlistInformation.duration,
-                                               .clips = {},
-                                               .languages = {}};
+    CandidatePlaylistInformation groupPlaylist{
+        .playlist = playlist,
+        .duration = playlistInformation.duration,
+        .chapters = static_cast<unsigned int>(playlistInformation.chapters.size()),
+        .clips = playlistInformation.clips,
+        .languages = playlistInformation.languages};
     if (!m_groups.empty() && m_groups.back().back().playlist == playlist - 1)
       m_groups.back().emplace_back(groupPlaylist);
     else
@@ -462,8 +534,10 @@ void CDiscDirectoryHelper::FindGroups(const PlaylistMap& playlists, const Episod
                                const auto& [playlist, playlistInformation] = PlaylistInformation;
                                return {.playlist = playlist,
                                        .duration = playlistInformation.duration,
-                                       .clips = {},
-                                       .languages = {}};
+                                       .chapters = static_cast<unsigned int>(
+                                           playlistInformation.chapters.size()),
+                                       .clips = playlistInformation.clips,
+                                       .languages = playlistInformation.languages};
                              });
       m_groups.emplace_back(std::move(group));
     }
@@ -483,10 +557,12 @@ void CDiscDirectoryHelper::FindGroups(const PlaylistMap& playlists, const Episod
                              std::views::transform(
                                  [](const PlaylistInformation& p)
                                  {
-                                   return CandidatePlaylistInformation{.playlist = p.playlist,
-                                                                       .duration = p.duration,
-                                                                       .clips = p.clips,
-                                                                       .languages = p.languages};
+                                   return CandidatePlaylistInformation{
+                                       .playlist = p.playlist,
+                                       .duration = p.duration,
+                                       .chapters = static_cast<unsigned int>(p.chapters.size()),
+                                       .clips = p.clips,
+                                       .languages = p.languages};
                                  }) |
                              std::views::filter([this](const CandidatePlaylistInformation& cpi)
                                                 { return !m_playAllPlaylists.contains(cpi); }),
@@ -678,6 +754,8 @@ void CDiscDirectoryHelper::UsePlayAllPlaylistMethod(int episodeIndex, const Play
                 .playlist = singleEpisodePlaylist,
                 .index = i + m_numSpecials - playlistInformation.playAllPlaylistEpisodesStartOffset,
                 .duration = singleEpisodePlaylistInformation.duration,
+                .chapters =
+                    static_cast<unsigned int>(singleEpisodePlaylistInformation.chapters.size()),
                 .clips = singleEpisodePlaylistInformation.clips,
                 .languages = singleEpisodePlaylistInformation.languages});
       }
@@ -728,6 +806,8 @@ void CDiscDirectoryHelper::UseRelaxedPlayAllPlaylistMethod(int episodeIndex,
                                          .index = index,
                                          .duration = singleEpisodePlaylistInformation.duration,
                                          .multiple = episodePlaylist.multiple,
+                                         .chapters = static_cast<unsigned int>(
+                                             singleEpisodePlaylistInformation.chapters.size()),
                                          .clips = singleEpisodePlaylistInformation.clips,
                                          .languages = singleEpisodePlaylistInformation.languages});
       }
@@ -781,6 +861,7 @@ void CDiscDirectoryHelper::UseLongOrCommonMethodForSingleEpisode(int episodeInde
                       .playlist = playlist,
                       .index = m_allEpisodes == AllEpisodes::ALL ? m_numSpecials : episodeIndex,
                       .duration = playlistInformation.duration,
+                      .chapters = static_cast<unsigned int>(playlistInformation.chapters.size()),
                       .clips = playlistInformation.clips,
                       .languages = playlistInformation.languages});
   }
@@ -792,12 +873,13 @@ void CDiscDirectoryHelper::UseLongOrCommonMethodForSingleEpisode(int episodeInde
     CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {}", *commonPlaylist);
     m_candidatePlaylists.try_emplace(
         *commonPlaylist,
-        CandidatePlaylistInformation{.playlist = *commonPlaylist,
-                                     .index = m_allEpisodes == AllEpisodes::ALL ? m_numSpecials
-                                                                                : episodeIndex,
-                                     .duration = playlistInformation.duration,
-                                     .clips = playlistInformation.clips,
-                                     .languages = playlistInformation.languages});
+        CandidatePlaylistInformation{
+            .playlist = *commonPlaylist,
+            .index = m_allEpisodes == AllEpisodes::ALL ? m_numSpecials : episodeIndex,
+            .duration = playlistInformation.duration,
+            .chapters = static_cast<unsigned int>(playlistInformation.chapters.size()),
+            .clips = playlistInformation.clips,
+            .languages = playlistInformation.languages});
   }
 }
 
@@ -832,6 +914,7 @@ void CDiscDirectoryHelper::GetPlaylistsFromGroup(
                                      CandidatePlaylistInformation{.playlist = group[i].playlist,
                                                                   .index = i + m_numSpecials,
                                                                   .duration = group[i].duration,
+                                                                  .chapters = group[i].chapters,
                                                                   .clips = group[i].clips,
                                                                   .languages = group[i].languages});
     CLog::LogFC(LOGDEBUG, LOGBLURAY, "Candidate playlist {}", group[i].playlist);
@@ -1218,8 +1301,14 @@ void CDiscDirectoryHelper::ChooseSingleBestPlaylist(const Episodes& episodesOnDi
 
 void CDiscDirectoryHelper::AddIdenticalPlaylists(const PlaylistMap& playlists)
 {
+  // Collect the additions separately, so newly added playlists are not themselves
+  // used as candidates to match against
+  CandidatePlaylistsMap identicalPlaylists;
+
   for (const auto& [candidatePlaylist, candidatePlaylistInformation] : m_candidatePlaylists)
   {
+    const auto candidate{playlists.find(candidatePlaylist)};
+
     // Find all other playlists of same duration with same clips
     for (const auto& [playlist, playlistInformation] : playlists)
     {
@@ -1228,13 +1317,33 @@ void CDiscDirectoryHelper::AddIdenticalPlaylists(const PlaylistMap& playlists)
           candidatePlaylistInformation.languages != playlistInformation.languages &&
           candidatePlaylistInformation.clips == playlistInformation.clips)
       {
+        // A playlist offering no streams the candidate does not already offer is a reduced
+        // presentation of the same content rather than an alternative, so there is nothing to
+        // choose between them
+        if (candidate != playlists.end() && IsStreamSubset(playlistInformation, candidate->second))
+        {
+          CLog::LogFC(LOGDEBUG, LOGBLURAY,
+                      "Ignoring playlist {} - its streams are a subset of those of playlist {}",
+                      playlist, candidatePlaylist);
+          continue;
+        }
+
         CLog::LogFC(LOGDEBUG, LOGBLURAY,
                     "Adding playlist {} as same duration and clips as playlist {}", playlist,
                     candidatePlaylist);
-        m_candidatePlaylists.try_emplace(playlist, candidatePlaylistInformation);
+
+        // Copy the candidate but with this playlist's own number and languages
+        CandidatePlaylistInformation identicalPlaylistInformation{candidatePlaylistInformation};
+        identicalPlaylistInformation.playlist = playlist;
+        identicalPlaylistInformation.chapters =
+            static_cast<unsigned int>(playlistInformation.chapters.size());
+        identicalPlaylistInformation.languages = playlistInformation.languages;
+        identicalPlaylists.try_emplace(playlist, identicalPlaylistInformation);
       }
     }
   }
+
+  m_candidatePlaylists.merge(identicalPlaylists);
 }
 
 void CDiscDirectoryHelper::FindCandidatePlaylists(const Episodes& episodesOnDisc,
@@ -2083,8 +2192,10 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(const CFileItem& item,
     // Silent
     if (sourceItems.Size() > 1 && !returnMultipleItems)
     {
-      CLog::LogF(LOGERROR, "Unable to automatically determine main playlist for {}", directory);
-      return false;
+      CLog::LogFC(LOGDEBUG, LOGBLURAY,
+                  "Automatically selected playlist {} of the {} offered for {}",
+                  sourceItems[0]->GetProperty("bluray_playlist").asInteger32(0), sourceItems.Size(),
+                  CURL::GetRedacted(directory));
     }
   }
 

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -172,6 +172,10 @@ class CDiscDirectoryHelper
     std::vector<unsigned int> clips;
     std::string languages;
 
+    // Set only when several episodes share this playlist
+    std::chrono::milliseconds episodeStart{0ms};
+    std::chrono::milliseconds episodeDuration{0ms};
+
     // Used for inserting into a set where playlist is the key
     auto operator<=>(const CandidatePlaylistInformation& rhs) const noexcept
     {
@@ -326,10 +330,15 @@ private:
   static bool CalculateGroupMultiples(std::vector<CandidatePlaylistInformation>& group,
                                       unsigned int numEpisodes);
   void UseGroupsWithMultiplesMethod(int episodeIndex, const Episodes& episodesOnDisc);
+  void UseSingleEpisodeClipsPlaylistMethod(int episodeIndex,
+                                           const Episodes& episodesOnDisc,
+                                           const ClipMap& clips,
+                                           const PlaylistMap& playlists);
   void ChooseSingleBestPlaylist(const Episodes& episodesOnDisc);
   void AddIdenticalPlaylists(const PlaylistMap& playlists);
   void FindCandidatePlaylists(const Episodes& episodesOnDisc,
                               int episodeIndex,
+                              const ClipMap& clips,
                               const PlaylistMap& playlists);
   void FindSpecials(const PlaylistMap& playlists);
   static void EndEpisodePlaylistSearch();

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -134,6 +134,7 @@ using Episodes = std::vector<KODI::VIDEO::EPISODE>;
 static constexpr std::chrono::milliseconds MAX_EPISODE_DIFFERENCE{30 * 1000}; // 30 seconds
 static constexpr std::chrono::milliseconds MIN_SPECIAL_DURATION{5 * 60 * 1000}; // 5 minutes
 static constexpr int DURATION_TOLERANCE_PERCENT{20};
+static constexpr int DURATION_TOLERANCE_RELAXED_PLAYALLPLAYLIST_PERCENT{5};
 
 // Movies
 static constexpr std::chrono::milliseconds MIN_MOVIE_DURATION{30 * 60 * 1000}; // 30 minutes
@@ -290,6 +291,7 @@ protected:
                                 bool silent = false);
 
 private:
+  void Reset();
   void InitialiseEpisodePlaylistSearch(int episodeIndex, const Episodes& episodesOnDisc);
   void StorePlayAllPlaylist(
       unsigned int playlistNumber,
@@ -298,7 +300,9 @@ private:
       const std::map<unsigned int, std::vector<unsigned int>>& playAllPlaylistClipMap);
   void FindPlayAllPlaylists(const ClipMap& clips, const PlaylistMap& playlists);
   void FindGroups(const PlaylistMap& playlists, const Episodes& episodesOnDisc);
+  void FindRelaxedPlayAllPlaylists(const PlaylistMap& playlists);
   void UsePlayAllPlaylistMethod(int episodeIndex, const PlaylistMap& playlists);
+  void UseRelaxedPlayAllPlaylistMethod(int episodeIndex, const PlaylistMap& playlists);
   void UseLongOrCommonMethodForSingleEpisode(int episodeIndex, const PlaylistMap& playlists);
   static std::vector<std::vector<CandidatePlaylistInformation>> GetGroupsWithoutDuplicates(
       const std::vector<std::vector<CandidatePlaylistInformation>>& groups);
@@ -331,6 +335,9 @@ private:
                                 int episodeIndex,
                                 const Episodes& episodesOnDisc,
                                 const PlaylistMap& playlists) const;
+  void LogEpisodePlaylistSearchResult(const CFileItemList& items,
+                                      int episodeIndex,
+                                      const Episodes& episodesOnDisc) const;
   bool FilterAllEpisodesPlaylists(std::vector<PlaylistInformation>& playlists, GetTitle job);
 
   //! Describes the streams of a title, supplied by the disc's directory implementation
@@ -363,7 +370,15 @@ private:
   };
 
   std::set<CandidatePlaylistInformation, Compare> m_playAllPlaylists;
+
+  // UsePlayAllPlaylistMethod() selects the clip corresponding to each requested episode,
+  // then looks up that clip in m_playAllPlaylistsMap.
+  // The resulting single-episode playlist numbers become m_candidatePlaylists.
+  // play-all playlist (map index) -> clip (second map index) -> single-episode playlists
   std::map<unsigned int, std::map<unsigned int, std::vector<unsigned int>>> m_playAllPlaylistsMap;
+
+  std::map<unsigned int, std::vector<unsigned int>> m_playAllPlaylistEpisodeMap;
+
   std::vector<std::vector<CandidatePlaylistInformation>> m_groups;
   std::vector<std::vector<CandidatePlaylistInformation>> m_allGroups;
   std::map<unsigned int, CandidatePlaylistInformation> m_candidatePlaylists;

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -329,7 +329,9 @@ private:
       const std::vector<CandidatePlaylistInformation>& group);
   static bool CalculateGroupMultiples(std::vector<CandidatePlaylistInformation>& group,
                                       unsigned int numEpisodes);
-  void UseGroupsWithMultiplesMethod(int episodeIndex, const Episodes& episodesOnDisc);
+  void UseGroupsWithMultiplesMethod(int episodeIndex,
+                                    const Episodes& episodesOnDisc,
+                                    const PlaylistMap& playlists);
   void UseSingleEpisodeClipsPlaylistMethod(int episodeIndex,
                                            const Episodes& episodesOnDisc,
                                            const ClipMap& clips,

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -321,6 +321,8 @@ private:
                   const Episodes& episodesOnDisc) const;
   static std::chrono::milliseconds CalculateAverageOfShortEpisodes(
       const std::vector<CandidatePlaylistInformation>& group);
+  static bool CalculateGroupMultiples(std::vector<CandidatePlaylistInformation>& group,
+                                      unsigned int numEpisodes);
   void UseGroupsWithMultiplesMethod(int episodeIndex, const Episodes& episodesOnDisc);
   void ChooseSingleBestPlaylist(const Episodes& episodesOnDisc);
   void AddIdenticalPlaylists(const PlaylistMap& playlists);
@@ -377,7 +379,11 @@ private:
   // play-all playlist (map index) -> clip (second map index) -> single-episode playlists
   std::map<unsigned int, std::map<unsigned int, std::vector<unsigned int>>> m_playAllPlaylistsMap;
 
-  std::map<unsigned int, std::vector<unsigned int>> m_playAllPlaylistEpisodeMap;
+  // UseRelaxedPlayAllPlaylistMethod() walks the episode playlists in order, using each one's
+  // multiple to determine how many consecutive episodes it covers (a multiple > 1 is a double
+  // or triple episode).
+  // play-all playlist -> episode playlists, in episode order
+  std::map<unsigned int, std::vector<CandidatePlaylistInformation>> m_playAllPlaylistEpisodeMap;
 
   std::vector<std::vector<CandidatePlaylistInformation>> m_groups;
   std::vector<std::vector<CandidatePlaylistInformation>> m_allGroups;

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -179,6 +179,8 @@ class CDiscDirectoryHelper
     }
   };
 
+  using CandidatePlaylistsMap = std::map<unsigned int, CandidatePlaylistInformation>;
+
 public:
   CDiscDirectoryHelper();
 
@@ -387,7 +389,7 @@ private:
 
   std::vector<std::vector<CandidatePlaylistInformation>> m_groups;
   std::vector<std::vector<CandidatePlaylistInformation>> m_allGroups;
-  std::map<unsigned int, CandidatePlaylistInformation> m_candidatePlaylists;
+  CandidatePlaylistsMap m_candidatePlaylists;
   std::set<unsigned int> m_candidateSpecials;
   std::vector<CandidatePlaylistInformation> m_nthLongestPlaylists;
 

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -329,6 +329,8 @@ private:
   bool CheckGroupDurations(const std::vector<CandidatePlaylistInformation>& groupA,
                            const std::vector<CandidatePlaylistInformation>& groupB,
                            int durationTolerancePercent = DURATION_TOLERANCE_PERCENT) const;
+  bool CheckGroupMultipleDurations(const std::vector<CandidatePlaylistInformation>& group,
+                                   const Episodes& episodesOnDisc) const;
   bool CheckGroup(const std::vector<CandidatePlaylistInformation>& group,
                   const Episodes& episodesOnDisc) const;
   static std::chrono::milliseconds CalculateAverageOfShortEpisodes(

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -135,6 +135,10 @@ static constexpr std::chrono::milliseconds MAX_EPISODE_DIFFERENCE{30 * 1000}; //
 static constexpr std::chrono::milliseconds MIN_SPECIAL_DURATION{5 * 60 * 1000}; // 5 minutes
 static constexpr int DURATION_TOLERANCE_PERCENT{20};
 static constexpr int DURATION_TOLERANCE_RELAXED_PLAYALLPLAYLIST_PERCENT{5};
+// For comparing a playlist against a scraped episode duration, which is approximate and often no
+// more than the broadcast slot rounded to whole minutes (eg. Battlestar Galactica (2003), where an
+// hour is given for 44 minutes of content). Only wide mismatches are meaningful.
+static constexpr int DURATION_TOLERANCE_SCRAPED_PERCENT{40};
 
 // Movies
 static constexpr std::chrono::milliseconds MIN_MOVIE_DURATION{30 * 60 * 1000}; // 30 minutes
@@ -304,7 +308,9 @@ private:
       unsigned int playAllPlaylistEpisodesStartOffset,
       const PlaylistInformation& playlistInformation,
       const std::map<unsigned int, std::vector<unsigned int>>& playAllPlaylistClipMap);
-  void FindPlayAllPlaylists(const ClipMap& clips, const PlaylistMap& playlists);
+  void FindPlayAllPlaylists(const ClipMap& clips,
+                            const PlaylistMap& playlists,
+                            const Episodes& episodesOnDisc);
   void FindGroups(const PlaylistMap& playlists, const Episodes& episodesOnDisc);
   void FindRelaxedPlayAllPlaylists(const PlaylistMap& playlists);
   void UsePlayAllPlaylistMethod(int episodeIndex, const PlaylistMap& playlists);

--- a/xbmc/filesystem/bluray/MPLSParser.cpp
+++ b/xbmc/filesystem/bluray/MPLSParser.cpp
@@ -386,8 +386,8 @@ constexpr unsigned int OFFSET_STREAM_TABLE_NUM_VIDEO_STREAMS = 4;
 constexpr unsigned int OFFSET_STREAM_TABLE_NUM_AUDIO_STREAMS = 5;
 constexpr unsigned int OFFSET_STREAM_TABLE_NUM_PG_STREAMS = 6;
 constexpr unsigned int OFFSET_STREAM_TABLE_NUM_IG_STREAMS = 7;
-constexpr unsigned int OFFSET_STREAM_TABLE_NUM_SECONDARY_VIDEO_STREAMS = 8;
-constexpr unsigned int OFFSET_STREAM_TABLE_NUM_SECONDARY_AUDIO_STREAMS = 9;
+constexpr unsigned int OFFSET_STREAM_TABLE_NUM_SECONDARY_AUDIO_STREAMS = 8;
+constexpr unsigned int OFFSET_STREAM_TABLE_NUM_SECONDARY_VIDEO_STREAMS = 9;
 constexpr unsigned int OFFSET_STREAM_TABLE_NUM_PIP_STREAMS = 10;
 constexpr unsigned int OFFSET_STREAM_TABLE_NUM_DV_STREAMS = 11;
 
@@ -501,10 +501,10 @@ bool ParsePlayItem(std::vector<std::byte>& buffer,
       GetByte(buffer, offset + OFFSET_STREAM_TABLE_NUM_PG_STREAMS)};
   const unsigned int numInteractiveGraphicStreams{
       GetByte(buffer, offset + OFFSET_STREAM_TABLE_NUM_IG_STREAMS)};
-  const unsigned int numSecondaryVideoStreams{
-      GetByte(buffer, offset + OFFSET_STREAM_TABLE_NUM_SECONDARY_VIDEO_STREAMS)};
   const unsigned int numSecondaryAudioStreams{
       GetByte(buffer, offset + OFFSET_STREAM_TABLE_NUM_SECONDARY_AUDIO_STREAMS)};
+  const unsigned int numSecondaryVideoStreams{
+      GetByte(buffer, offset + OFFSET_STREAM_TABLE_NUM_SECONDARY_VIDEO_STREAMS)};
   const unsigned int numPictureInPictureSubtitleStreams{
       GetByte(buffer, offset + OFFSET_STREAM_TABLE_NUM_PIP_STREAMS)};
   const unsigned int numDolbyVisionStreams{
@@ -537,6 +537,15 @@ bool ParsePlayItem(std::vector<std::byte>& buffer,
   {
     playItem.presentationGraphicStreams.emplace_back(
         ParseStream(buffer, offset, STREAM_TYPE::PRESENTATION_GRAPHIC_STREAM));
+  }
+
+  // The picture-in-picture subtitle entries share the presentation graphic block, immediately
+  // following it
+  playItem.pictureInPictureSubtitleStreams.reserve(numPictureInPictureSubtitleStreams);
+  for (unsigned int k = 0; k < numPictureInPictureSubtitleStreams; ++k)
+  {
+    playItem.pictureInPictureSubtitleStreams.emplace_back(
+        ParseStream(buffer, offset, STREAM_TYPE::PICTURE_IN_PICTURE_SUBTITLE_STREAM));
   }
 
   playItem.interactiveGraphicStreams.reserve(numInteractiveGraphicStreams);

--- a/xbmc/filesystem/bluray/MPLSParser.h
+++ b/xbmc/filesystem/bluray/MPLSParser.h
@@ -192,6 +192,7 @@ struct PlayItemInformation
   std::vector<StreamInformation> videoStreams;
   std::vector<StreamInformation> audioStreams;
   std::vector<StreamInformation> presentationGraphicStreams;
+  std::vector<StreamInformation> pictureInPictureSubtitleStreams;
   std::vector<StreamInformation> interactiveGraphicStreams;
   std::vector<StreamInformation> secondaryAudioStreams;
   std::vector<StreamInformation> secondaryVideoStreams;

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -2666,6 +2666,167 @@ TEST_F(TestDiscDirectoryHelper,
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 }
 
+// The disc has a single long playlist holding one clip per episode and no individual episode
+// playlists, so every episode resolves to that playlist. Each episode after the first carries an
+// episode bookmark giving the start of its clip.
+// (Example Tin Man S1D1 UK BD)
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_SingleEpisodeClipsPlaylistMethod)
+{
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeEpisode(1, 1, 5400), // 90 min
+                    MakeEpisode(1, 2, 5400), MakeEpisode(1, 3, 5400)};
+
+  PlaylistMap playlists{
+      {0u, MakePlaylist(0u, 16065s, {0u, 1u, 2u}, {5492s, 5262s, 5311s})},
+      {1u, MakePlaylist(1u, 16s, {4u, 5u}, {10s, 6s})}, // Logo/trailer
+  };
+  ClipMap clips{
+      {0u, MakeClip(5492s, {0u})}, {1u, MakeClip(5262s, {0u})}, {2u, MakeClip(5311s, {0u})},
+      {4u, MakeClip(10s, {1u})},   {5u, MakeClip(6s, {1u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  // Each episode is the same playlist, offset by the durations of the clips before it
+  static constexpr std::array<std::pair<unsigned int, double>, 3> EXPECTED{
+      {{5492u, 0.0}, {5262u, 5492.0}, {5311u, 10754.0}}};
+
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(EXPECTED.size()); ++episodeIndex)
+  {
+    const auto& [expectedDuration, expectedStart]{EXPECTED[episodeIndex]};
+
+    CDiscDirectoryHelper helper;
+    EXPECT_TRUE(
+        helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips, playlists))
+        << "episode index " << episodeIndex;
+    ASSERT_EQ(items.Size(), 1) << "episode index " << episodeIndex;
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 0u);
+
+    // The episode's duration is its own clip, not the whole playlist
+    const CVideoInfoTag* tag{items[0]->GetVideoInfoTag()};
+    EXPECT_EQ(tag->GetDuration(), static_cast<int>(expectedDuration));
+
+    // The first episode starts at zero so needs no bookmark
+    EXPECT_DOUBLE_EQ(tag->m_EpBookmark.timeInSeconds, expectedStart);
+    if (expectedStart > 0.0)
+    {
+      EXPECT_DOUBLE_EQ(tag->m_EpBookmark.totalTimeInSeconds, 16065.0);
+    }
+  }
+
+  CDiscDirectoryHelper helper;
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1); // All episodes
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{0u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 1);
+  returned = GetPlaylists(items);
+  expected = {0u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 2);
+  returned = GetPlaylists(items);
+  expected = {0u, 1u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// As above, but a clip does not match the duration of the episode in its position, so the disc
+// does not fit the single-playlist assumption and no playlist is returned.
+TEST_F(TestDiscDirectoryHelper,
+       GetEpisodePlaylists_ThreeEpisodes_SingleEpisodeClipsPlaylistMethod_ClipDurationMismatch)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeEpisode(1, 1, 5400), // 90 min
+                    MakeEpisode(1, 2, 5400), MakeEpisode(1, 3, 5400)};
+
+  PlaylistMap playlists{
+      {0u, MakePlaylist(0u, 14265s, {0u, 1u, 2u}, {5492s, 5262s, 3511s})}, // Clip 2 far too short
+      {1u, MakePlaylist(1u, 16s, {4u, 5u}, {10s, 6s})},
+  };
+  ClipMap clips{
+      {0u, MakeClip(5492s, {0u})}, {1u, MakeClip(5262s, {0u})}, {2u, MakeClip(3511s, {0u})},
+      {4u, MakeClip(10s, {1u})},   {5u, MakeClip(6s, {1u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 0);
+
+  EXPECT_FALSE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 1);
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected = {0u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 2);
+  returned = GetPlaylists(items);
+  expected = {0u, 1u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// As above, but the playlist has more clips than there are episodes on the disc, so which clip is
+// which episode cannot be determined and no playlist is returned.
+TEST_F(TestDiscDirectoryHelper,
+       GetEpisodePlaylists_ThreeEpisodes_SingleEpisodeClipsPlaylistMethod_TooManyClips)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeEpisode(1, 1, 5400), // 90 min
+                    MakeEpisode(1, 2, 5400), MakeEpisode(1, 3, 5400)};
+
+  PlaylistMap playlists{
+      {0u, MakePlaylist(0u, 21465s, {0u, 1u, 2u, 3u}, {5492s, 5262s, 5311s, 5400s})},
+      {1u, MakePlaylist(1u, 16s, {4u, 5u}, {10s, 6s})},
+  };
+  ClipMap clips{
+      {0u, MakeClip(5492s, {0u})}, {1u, MakeClip(5262s, {0u})}, {2u, MakeClip(5311s, {0u})},
+      {3u, MakeClip(5400s, {0u})}, {4u, MakeClip(10s, {1u})},   {5u, MakeClip(6s, {1u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 0);
+
+  EXPECT_FALSE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 1);
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected = {0u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 2);
+  returned = GetPlaylists(items);
+  expected = {0u, 1u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
 // There is no play-all playlist, nor any consecutive groups of playlists (of the correct number)
 // There are n long playlists but there is a valid group of shorter playlists that is the same length as the number of episodes
 // (Example It Welcome to Derry S1D1 UK UHD)

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -40,19 +40,7 @@ public:
     // Force all advanced settings to be reset to defaults
     const auto settings = CServiceBroker::GetSettingsComponent();
     const auto advancedSettings = settings->GetAdvancedSettings();
-    m_oldMinimumEpisodePlaylistDuration = advancedSettings->m_minimumEpisodePlaylistDuration;
-    advancedSettings->m_minimumEpisodePlaylistDuration = 10 * 60; // 10 minutes
   }
-
-  ~AdvancedSettingsResetBase() override
-  {
-    const auto settings = CServiceBroker::GetSettingsComponent();
-    settings->GetAdvancedSettings()->m_minimumEpisodePlaylistDuration =
-        m_oldMinimumEpisodePlaylistDuration;
-  }
-
-private:
-  int m_oldMinimumEpisodePlaylistDuration{0};
 };
 
 class TestDiscDirectoryHelper : public AdvancedSettingsResetBase
@@ -226,8 +214,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_EmptyInputs)
   CFileItemList allTitles;
   Episodes episodes{MakeEpisode(1, 1, 3600)};
 
-  PlaylistMap playlists{{800u, MakePlaylist(800u, 5min, {1u}, {5min})}};
-  ClipMap clips{{1u, MakeClip(5min, {800u})}};
+  PlaylistMap playlists{{800u, MakePlaylist(800u, 4min, {1u}, {4min})}};
+  ClipMap clips{{1u, MakeClip(4min, {800u})}};
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, {}, {}));
@@ -249,8 +237,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_AllPlaylistsBelowMinEpisodeD
   CFileItemList allTitles;
   Episodes episodes{MakeEpisode(1, 1, 3600)};
 
-  PlaylistMap playlists{{800u, MakePlaylist(800u, 5min, {1u}, {5min})}};
-  ClipMap clips{{1u, MakeClip(5min, {800u})}};
+  PlaylistMap playlists{{800u, MakePlaylist(800u, 4min, {1u}, {4min})}};
+  ClipMap clips{{1u, MakeClip(4min, {800u})}};
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
@@ -317,13 +305,13 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_SingleEpisode_MultiplePlayli
   Episodes episodes{MakeEpisode(1, 1, 3600)};
 
   PlaylistMap playlists{{800u, MakePlaylist(800u, 60min, {1u}, {60min})},
-                        {1u, MakePlaylist(1u, 5min, {2u}, {5min})},
-                        {10u, MakePlaylist(10u, 5min, {3u}, {5min})},
-                        {100u, MakePlaylist(100u, 5min, {4u}, {5min})}};
+                        {1u, MakePlaylist(1u, 4min, {2u}, {4min})},
+                        {10u, MakePlaylist(10u, 4min, {3u}, {4min})},
+                        {100u, MakePlaylist(100u, 4min, {4u}, {4min})}};
   ClipMap clips{{1u, MakeClip(60min, {800u})},
-                {2u, MakeClip(5min, {1u})},
-                {3u, MakeClip(5min, {10u})},
-                {4u, MakeClip(5min, {100u})}};
+                {2u, MakeClip(4min, {1u})},
+                {3u, MakeClip(4min, {10u})},
+                {4u, MakeClip(4min, {100u})}};
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
@@ -362,12 +350,12 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_SingleEpisode_MultiplePlayli
   Episodes episodes{MakeEpisode(1, 1, 3600)};
 
   PlaylistMap playlists{{800u, MakePlaylist(800u, 60min, {1u}, {60min})},
-                        {1u, MakePlaylist(1u, 5min, {2u}, {5min})},
-                        {10u, MakePlaylist(10u, 5min, {3u}, {5min})},
+                        {1u, MakePlaylist(1u, 4min, {2u}, {4min})},
+                        {10u, MakePlaylist(10u, 4min, {3u}, {4min})},
                         {100u, MakePlaylist(100u, 40min, {4u}, {40min})}};
   ClipMap clips{{1u, MakeClip(60min, {800u})},
-                {2u, MakeClip(5min, {1u})},
-                {3u, MakeClip(5min, {10u})},
+                {2u, MakeClip(4min, {1u})},
+                {3u, MakeClip(4min, {10u})},
                 {4u, MakeClip(40min, {100u})}};
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -411,12 +399,12 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_SingleEpisode_MultiplePlayli
                     MakeEpisode(1, 1, 3600)};
 
   PlaylistMap playlists{{800u, MakePlaylist(800u, 60min, {1u}, {60min})},
-                        {1u, MakePlaylist(1u, 5min, {2u}, {5min})},
-                        {10u, MakePlaylist(10u, 5min, {3u}, {5min})},
+                        {1u, MakePlaylist(1u, 6min, {2u}, {6min})},
+                        {10u, MakePlaylist(10u, 6min, {3u}, {6min})},
                         {100u, MakePlaylist(100u, 30min, {4u}, {30min})}};
   ClipMap clips{{1u, MakeClip(60min, {800u})},
-                {2u, MakeClip(5min, {1u})},
-                {3u, MakeClip(5min, {10u})},
+                {2u, MakeClip(6min, {1u})},
+                {3u, MakeClip(6min, {10u})},
                 {4u, MakeClip(30min, {100u})}};
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -442,9 +430,9 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_SingleEpisode_MultiplePlayli
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  ASSERT_EQ(items.Size(), 2);
+  ASSERT_EQ(items.Size(), 4);
   returned = GetPlaylists(items);
-  expected = {100u, 800u};
+  expected = {1u, 10u, 100u, 800u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
@@ -475,8 +463,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist)
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {100u, MakePlaylist(100u, 125min, {1u, 2u, 3u}, {45min, 42min, 38min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {802u, MakePlaylist(802u, 42min, {2u}, {42min})},
@@ -484,8 +472,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist)
   };
   ClipMap clips{
       {1u, MakeClip(45min, {100u, 800u})}, {2u, MakeClip(42min, {100u, 802u})},
-      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(5min, {1u})},
-      {5u, MakeClip(5min, {10u})},
+      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(4min, {1u})},
+      {5u, MakeClip(4min, {10u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -545,8 +533,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_WithSpecial)
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 6min, {4u}, {6min})},
+      {10u, MakePlaylist(10u, 6min, {5u}, {6min})},
       {100u, MakePlaylist(100u, 125min, {1u, 2u, 3u}, {45min, 42min, 38min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {802u, MakePlaylist(802u, 42min, {2u}, {42min})},
@@ -554,8 +542,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_WithSpecial)
   };
   ClipMap clips{
       {1u, MakeClip(45min, {100u, 800u})}, {2u, MakeClip(42min, {100u, 802u})},
-      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(5min, {1u})},
-      {5u, MakeClip(5min, {10u})},
+      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(6min, {1u})},
+      {5u, MakeClip(6min, {10u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -590,9 +578,9 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_WithSpecial)
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  ASSERT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 5);
   returned = GetPlaylists(items);
-  expected = {800u, 802u, 804u};
+  expected = {1u, 10u, 800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
@@ -621,8 +609,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips)
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {100u, MakePlaylist(100u, 128min, {6u, 1u, 2u, 3u}, {3min, 45min, 42min, 38min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {802u, MakePlaylist(802u, 42min, {2u}, {42min})},
@@ -630,8 +618,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips)
   };
   ClipMap clips{
       {1u, MakeClip(45min, {100u, 800u})}, {2u, MakeClip(42min, {100u, 802u})},
-      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(5min, {1u})},
-      {5u, MakeClip(5min, {10u})},         {6u, MakeClip(3min, {100u})},
+      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(4min, {1u})},
+      {5u, MakeClip(4min, {10u})},         {6u, MakeClip(3min, {100u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -691,8 +679,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2)
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {100u, MakePlaylist(100u, 128min, {1u, 2u, 3u, 6u}, {45min, 42min, 38min, 3min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {802u, MakePlaylist(802u, 42min, {2u}, {42min})},
@@ -700,8 +688,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2)
   };
   ClipMap clips{
       {1u, MakeClip(45min, {100u, 800u})}, {2u, MakeClip(42min, {100u, 802u})},
-      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(5min, {1u})},
-      {5u, MakeClip(5min, {10u})},         {6u, MakeClip(3min, {100u})},
+      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(4min, {1u})},
+      {5u, MakeClip(4min, {10u})},         {6u, MakeClip(3min, {100u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -762,8 +750,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2a
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {100u, MakePlaylist(100u, 7500500ms, {1u, 2u, 3u, 6u}, {45min, 42min, 38min, 500ms})},
       {800u, MakePlaylist(800u, 2700500ms, {1u, 6u}, {45min, 500ms})},
       {802u, MakePlaylist(802u, 2520500ms, {2u, 6u}, {42min, 500ms})},
@@ -771,8 +759,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2a
   };
   ClipMap clips{
       {1u, MakeClip(45min, {100u, 800u})}, {2u, MakeClip(42min, {100u, 802u})},
-      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(5min, {1u})},
-      {5u, MakeClip(5min, {10u})},         {6u, MakeClip(500ms, {100u, 800u, 802u, 804u})},
+      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(4min, {1u})},
+      {5u, MakeClip(4min, {10u})},         {6u, MakeClip(500ms, {100u, 800u, 802u, 804u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -833,8 +821,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2b
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {7u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {8u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {7u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {8u}, {4min})},
       {100u,
        MakePlaylist(100u, 9900500ms, {6u, 1u, 2u, 3u, 4u}, {500ms, 45min, 42min, 38min, 40min})},
       {800u, MakePlaylist(800u, 2700500ms, {6u, 1u}, {500ms, 45min})},
@@ -848,8 +836,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2b
       {3u, MakeClip(38min, {100u, 804u})},
       {4u, MakeClip(40min, {100u, 806u})},
       {6u, MakeClip(500ms, {100u, 800u, 802u, 804u, 806u})},
-      {7u, MakeClip(5min, {1u})},
-      {8u, MakeClip(5min, {10u})},
+      {7u, MakeClip(4min, {1u})},
+      {8u, MakeClip(4min, {10u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -913,8 +901,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips3)
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {100u, MakePlaylist(100u, 131min, {6u, 1u, 2u, 3u, 7u}, {3min, 45min, 42min, 38min, 3min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {802u, MakePlaylist(802u, 42min, {2u}, {42min})},
@@ -922,8 +910,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips3)
   };
   ClipMap clips{
       {1u, MakeClip(45min, {100u, 800u})}, {2u, MakeClip(42min, {100u, 802u})},
-      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(5min, {1u})},
-      {5u, MakeClip(5min, {10u})},         {6u, MakeClip(3min, {100u})},
+      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(4min, {1u})},
+      {5u, MakeClip(4min, {10u})},         {6u, MakeClip(3min, {100u})},
       {7u, MakeClip(3min, {100u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
@@ -984,8 +972,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraIndivid
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {100u, MakePlaylist(100u, 125min, {1u, 2u, 3u}, {45min, 42min, 38min})},
       {800u, MakePlaylist(800u, 48min, {1u, 6u}, {45min, 3min})},
       {802u, MakePlaylist(802u, 48min, {7u, 2u, 8u}, {3min, 42min, 3min})},
@@ -993,8 +981,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraIndivid
   };
   ClipMap clips{
       {1u, MakeClip(45min, {100u, 800u})}, {2u, MakeClip(42min, {100u, 802u})},
-      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(5min, {1u})},
-      {5u, MakeClip(5min, {10u})},         {6u, MakeClip(3min, {800u})},
+      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(4min, {1u})},
+      {5u, MakeClip(4min, {10u})},         {6u, MakeClip(3min, {800u})},
       {7u, MakeClip(3min, {802u})},        {8u, MakeClip(3min, {802u})},
       {9u, MakeClip(3min, {804u})},
   };
@@ -1055,8 +1043,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail)
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {100u, MakePlaylist(100u, 125min, {1u, 2u, 3u}, {45min, 42min, 38min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {802u, MakePlaylist(802u, 42min, {2u}, {42min})},
@@ -1065,8 +1053,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail)
   };
   ClipMap clips{
       {1u, MakeClip(45min, {100u, 800u})}, {2u, MakeClip(42min, {100u, 802u})},
-      {3u, MakeClip(38min, {100u})},       {4u, MakeClip(5min, {1u})},
-      {5u, MakeClip(5min, {10u})},         {6u, MakeClip(38min, {804u})},
+      {3u, MakeClip(38min, {100u})},       {4u, MakeClip(4min, {1u})},
+      {5u, MakeClip(4min, {10u})},         {6u, MakeClip(38min, {804u})},
       {7u, MakeClip(40min, {900u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
@@ -1114,8 +1102,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail2)
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {100u, MakePlaylist(100u, 155min, {6u, 1u, 2u, 3u, 7u}, {15min, 45min, 42min, 38min, 15min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {802u, MakePlaylist(802u, 42min, {2u}, {42min})},
@@ -1124,8 +1112,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail2)
   };
   ClipMap clips{
       {1u, MakeClip(45min, {100u, 800u})}, {2u, MakeClip(42min, {100u, 802u})},
-      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(5min, {1u})},
-      {5u, MakeClip(5min, {10u})},         {6u, MakeClip(15min, {100u})},
+      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(4min, {1u})},
+      {5u, MakeClip(4min, {10u})},         {6u, MakeClip(15min, {100u})},
       {7u, MakeClip(15min, {100u})},       {8u, MakeClip(40min, {900u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
@@ -1173,8 +1161,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail3)
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {100u, MakePlaylist(100u, 125min, {1u, 2u, 3u}, {45min, 42min, 38min})},
       {800u, MakePlaylist(800u, 48min, {1u, 6u}, {45min, 3min})},
       {802u, MakePlaylist(802u, 60min, {7u, 2u, 8u}, {3min, 42min, 15min})},
@@ -1182,8 +1170,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail3)
   };
   ClipMap clips{
       {1u, MakeClip(45min, {100u, 800u})}, {2u, MakeClip(42min, {100u, 802u})},
-      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(5min, {1u})},
-      {5u, MakeClip(5min, {10u})},         {6u, MakeClip(3min, {800u})},
+      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(4min, {1u})},
+      {5u, MakeClip(4min, {10u})},         {6u, MakeClip(3min, {800u})},
       {7u, MakeClip(3min, {802u})},        {8u, MakeClip(15min, {802u})},
       {9u, MakeClip(3min, {804u})},
   };
@@ -1209,6 +1197,166 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail3)
   ASSERT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u, 802u, 804u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// The disc gathers its four featurettes into a play all playlist (355) as well as its four episodes
+// (800-803, which have no play all playlist of their own).
+// (Example The Expanse (2015) S3D3 UK Bluray)
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_OfExtrasIgnored)
+{
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(0, 24), // Featurettes, of unknown length
+      MakeEpisode(0, 25),       MakeEpisode(0, 26),       MakeEpisode(0, 27),
+      MakeEpisode(3, 10, 2520), // 42 minutes
+      MakeEpisode(3, 11, 2640), MakeEpisode(3, 12, 2520), MakeEpisode(3, 13, 2520),
+  };
+
+  PlaylistMap playlists{
+      {351u, MakePlaylist(351u, 2200s, {301u, 302u}, {2196s, 4s})}, // The featurettes
+      {352u, MakePlaylist(352u, 378s, {304u, 305u}, {374s, 4s})},
+      {353u, MakePlaylist(353u, 381s, {307u, 308u}, {377s, 4s})},
+      {354u, MakePlaylist(354u, 345s, {50609u, 50610u}, {341s, 4s})},
+      {355u, MakePlaylist(355u, 3292s, {301u, 304u, 307u, 50609u, 50610u}, // Their play all
+                          {2196s, 374s, 377s, 341s, 4s})},
+      {800u, MakePlaylist(800u, 2532s, {800u}, {2532s})}, // The episodes
+      {801u, MakePlaylist(801u, 2667s, {801u}, {2667s})},
+      {802u, MakePlaylist(802u, 2529s, {802u}, {2529s})},
+      {803u, MakePlaylist(803u, 2495s, {50606u}, {2495s})},
+      // The disc also offers each featurette's clip on its own
+      {301u, MakePlaylist(301u, 2196s, {301u}, {2196s})},
+      {304u, MakePlaylist(304u, 374s, {304u}, {374s})},
+      {307u, MakePlaylist(307u, 377s, {307u}, {377s})},
+      {1106u, MakePlaylist(1106u, 341s, {50609u}, {341s})},
+      {1107u, MakePlaylist(1107u, 4s, {50610u}, {4s})},
+  };
+  ClipMap clips{
+      {301u, MakeClip(2196s, {301u, 351u, 355u})},
+      {302u, MakeClip(4s, {351u})},
+      {304u, MakeClip(374s, {304u, 352u, 355u})},
+      {305u, MakeClip(4s, {352u})},
+      {307u, MakeClip(377s, {307u, 353u, 355u})},
+      {308u, MakeClip(4s, {353u})},
+      {50609u, MakeClip(341s, {354u, 355u, 1106u})},
+      {50610u, MakeClip(4s, {354u, 355u, 1107u})},
+      {800u, MakeClip(2532s, {800u})},
+      {801u, MakeClip(2667s, {801u})},
+      {802u, MakeClip(2529s, {802u})},
+      {50606u, MakeClip(2495s, {803u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  // The episodes follow the featurettes in episodesOnDisc, so are at indexes 4 to 7
+  static constexpr std::array<unsigned int, 4> EXPECTED_PLAYLISTS{800u, 801u, 802u, 803u};
+  for (int episode = 0; episode < static_cast<int>(EXPECTED_PLAYLISTS.size()); ++episode)
+  {
+    CDiscDirectoryHelper helper;
+    EXPECT_TRUE(
+        helper.GetEpisodePlaylists(url, items, allTitles, episode + 4, episodes, clips, playlists))
+        << "episode " << episode + 10;
+    ASSERT_EQ(items.Size(), 1) << "episode " << episode + 10;
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), EXPECTED_PLAYLISTS[episode]);
+  }
+
+  CDiscDirectoryHelper helper;
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 8, episodes, clips,
+                                          playlists)); // Invalid episode index
+  ASSERT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 4); // All episodes
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{800u, 801u, 802u, 803u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 13);
+  returned = GetPlaylists(items);
+  expected = {301u, 304u, 307u, 351u, 352u, 353u, 354u, 355u, 800u, 801u, 802u, 803u, 1106u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 14);
+  returned = GetPlaylists(items);
+  expected = {301u, 304u, 307u, 351u, 352u, 353u, 354u, 355u, 800u, 801u, 802u, 803u, 1106u, 1107u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// As GetEpisodePlaylists_PlayAllPlaylist_OfExtrasIgnored, but the extras gathered into playlist 201
+// are of similar lengths to one another, so being near-equal does not tell them from episodes.
+// (Example The Last of Us S2D1 Bluray)
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_OfSimilarLengthExtrasIgnored)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(2, 1, 3540), // 59 minutes
+      MakeEpisode(2, 2, 3420),
+      MakeEpisode(2, 3, 3420),
+  };
+
+  PlaylistMap playlists{
+      // A play all playlist of the three extras, which are of similar lengths to one another
+      {201u, MakePlaylist(201u, 1813s, {71u, 72u, 70u}, {533s, 548s, 732s})},
+      {202u, MakePlaylist(202u, 533s, {71u}, {533s})},
+      {203u, MakePlaylist(203u, 548s, {72u}, {548s})},
+      {204u, MakePlaylist(204u, 732s, {70u}, {732s})},
+      {207u, MakePlaylist(207u, 673s, {68u}, {673s})},
+      {801u, MakePlaylist(801u, 3529s, {63u}, {3529s})}, // The episodes
+      {802u, MakePlaylist(802u, 3373s, {65u}, {3373s})},
+      {803u, MakePlaylist(803u, 3369s, {66u}, {3369s})},
+  };
+  ClipMap clips{
+      {63u, MakeClip(3529s, {801u})},      {65u, MakeClip(3373s, {802u})},
+      {66u, MakeClip(3369s, {803u})},      {68u, MakeClip(673s, {207u})},
+      {70u, MakeClip(732s, {201u, 204u})}, {71u, MakeClip(533s, {201u, 202u})},
+      {72u, MakeClip(548s, {201u, 203u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  static constexpr std::array<unsigned int, 3> EXPECTED_PLAYLISTS{801u, 802u, 803u};
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(EXPECTED_PLAYLISTS.size());
+       ++episodeIndex)
+  {
+    EXPECT_TRUE(
+        helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips, playlists))
+        << "episode index " << episodeIndex;
+    ASSERT_EQ(items.Size(), 1) << "episode index " << episodeIndex;
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), EXPECTED_PLAYLISTS[episodeIndex]);
+  }
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 4, episodes, clips,
+                                          playlists)); // Invalid episode index
+  ASSERT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 3); // All episodes
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{801u, 802u, 803u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 8);
+  returned = GetPlaylists(items);
+  expected = {201u, 202u, 203u, 204u, 207u, 801u, 802u, 803u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 8);
+  returned = GetPlaylists(items);
+  expected = {201u, 202u, 203u, 204u, 207u, 801u, 802u, 803u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 }
 
@@ -2242,15 +2390,15 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod)
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {801u, MakePlaylist(801u, 42min, {2u}, {42min})},
       {802u, MakePlaylist(802u, 38min, {3u}, {38min})},
   };
   ClipMap clips{
       {1u, MakeClip(45min, {800u})}, {2u, MakeClip(42min, {801u})}, {3u, MakeClip(38min, {802u})},
-      {4u, MakeClip(5min, {1u})},    {5u, MakeClip(5min, {10u})},
+      {4u, MakeClip(4min, {1u})},    {5u, MakeClip(4min, {10u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -2309,15 +2457,15 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Lo
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {800u, MakePlaylist(800u, 142min, {1u}, {142min})},
       {801u, MakePlaylist(801u, 45min, {2u}, {45min})},
       {802u, MakePlaylist(802u, 38min, {3u}, {38min})},
   };
   ClipMap clips{
       {1u, MakeClip(142min, {800u})}, {2u, MakeClip(45min, {801u})}, {3u, MakeClip(38min, {802u})},
-      {4u, MakeClip(5min, {1u})},     {5u, MakeClip(5min, {10u})},
+      {4u, MakeClip(4min, {1u})},     {5u, MakeClip(4min, {10u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -2376,15 +2524,15 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Wi
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 6min, {4u}, {6min})},
+      {10u, MakePlaylist(10u, 6min, {5u}, {6min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {801u, MakePlaylist(801u, 42min, {2u}, {42min})},
       {802u, MakePlaylist(802u, 38min, {3u}, {38min})},
   };
   ClipMap clips{
       {1u, MakeClip(45min, {800u})}, {2u, MakeClip(42min, {801u})}, {3u, MakeClip(38min, {802u})},
-      {4u, MakeClip(5min, {1u})},    {5u, MakeClip(5min, {10u})},
+      {4u, MakeClip(6min, {1u})},    {5u, MakeClip(6min, {10u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -2420,9 +2568,9 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Wi
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  ASSERT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 5);
   returned = GetPlaylists(items);
-  expected = {800u, 801u, 802u};
+  expected = {1u, 10u, 800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
@@ -2447,15 +2595,15 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Wi
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 6min, {4u}, {6min})},
+      {10u, MakePlaylist(10u, 6min, {5u}, {6min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {801u, MakePlaylist(801u, 42min, {2u}, {42min})},
       {802u, MakePlaylist(802u, 38min, {3u}, {38min})},
   };
   ClipMap clips{
       {1u, MakeClip(45min, {800u})}, {2u, MakeClip(42min, {801u})}, {3u, MakeClip(38min, {802u})},
-      {4u, MakeClip(5min, {1u})},    {5u, MakeClip(5min, {10u})},
+      {4u, MakeClip(6min, {1u})},    {5u, MakeClip(6min, {10u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -2492,9 +2640,9 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Wi
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  ASSERT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 5);
   returned = GetPlaylists(items);
-  expected = {800u, 801u, 802u};
+  expected = {1u, 10u, 800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
@@ -2593,8 +2741,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Lo
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {801u, MakePlaylist(801u, 42min, {2u}, {42min})},
       {802u, MakePlaylist(802u, 38min, {3u}, {38min})},
@@ -2602,7 +2750,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Lo
   };
   ClipMap clips{
       {1u, MakeClip(45min, {800u})}, {2u, MakeClip(42min, {801u})}, {3u, MakeClip(38min, {802u})},
-      {4u, MakeClip(5min, {1u})},    {5u, MakeClip(5min, {10u})},   {7u, MakeClip(38min, {803u})},
+      {4u, MakeClip(4min, {1u})},    {5u, MakeClip(4min, {10u})},   {7u, MakeClip(38min, {803u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -2660,17 +2808,17 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Tw
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
       {2u, MakePlaylist(2u, 45min, {6u}, {45min})},
       {3u, MakePlaylist(3u, 45min, {7u}, {45min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {801u, MakePlaylist(801u, 42min, {2u}, {42min})},
       {802u, MakePlaylist(802u, 38min, {3u}, {38min})},
   };
   ClipMap clips{
       {1u, MakeClip(45min, {800u})}, {2u, MakeClip(42min, {801u})}, {3u, MakeClip(38min, {802u})},
-      {4u, MakeClip(5min, {1u})},    {5u, MakeClip(5min, {10u})},   {6u, MakeClip(45min, {2u})},
+      {4u, MakeClip(4min, {1u})},    {5u, MakeClip(4min, {10u})},   {6u, MakeClip(45min, {2u})},
       {7u, MakeClip(45min, {3u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
@@ -2729,7 +2877,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_TwoEpisodes_GroupMethod_TwoG
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
       {2u, MakePlaylist(2u, 30min, {5u}, {30min})},
       {3u, MakePlaylist(3u, 30min, {6u}, {30min})},
       {801u, MakePlaylist(801u, 45min, {1u}, {45min})},
@@ -2739,7 +2887,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_TwoEpisodes_GroupMethod_TwoG
   };
   ClipMap clips{
       {1u, MakeClip(45min, {801u, 851u})}, {2u, MakeClip(42min, {802u, 852u})},
-      {4u, MakeClip(5min, {1u})},          {5u, MakeClip(30min, {2u})},
+      {4u, MakeClip(4min, {1u})},          {5u, MakeClip(30min, {2u})},
       {6u, MakeClip(30min, {3u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
@@ -2794,15 +2942,15 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Fa
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
-      {801u, MakePlaylist(801u, 5min, {2u}, {5min})},
+      {801u, MakePlaylist(801u, 4min, {2u}, {4min})},
       {802u, MakePlaylist(802u, 38min, {3u}, {38min})},
   };
   ClipMap clips{
-      {1u, MakeClip(45min, {800u})}, {2u, MakeClip(5min, {801u})}, {3u, MakeClip(38min, {802u})},
-      {4u, MakeClip(5min, {1u})},    {5u, MakeClip(5min, {10u})},
+      {1u, MakeClip(45min, {800u})}, {2u, MakeClip(4min, {801u})}, {3u, MakeClip(38min, {802u})},
+      {4u, MakeClip(4min, {1u})},    {5u, MakeClip(4min, {10u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -2847,8 +2995,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Fa
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {801u, MakePlaylist(801u, 142min, {2u}, {142min})},
       {802u, MakePlaylist(802u, 38min, {3u}, {38min})},
@@ -2856,7 +3004,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Fa
   };
   ClipMap clips{
       {1u, MakeClip(45min, {800u})}, {2u, MakeClip(142min, {801u})}, {3u, MakeClip(38min, {802u})},
-      {4u, MakeClip(5min, {1u})},    {5u, MakeClip(5min, {10u})},    {7u, MakeClip(40min, {803u})},
+      {4u, MakeClip(4min, {1u})},    {5u, MakeClip(4min, {10u})},    {7u, MakeClip(40min, {803u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -3489,15 +3637,15 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FourEpisodesOneDouble_GroupM
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {801u, MakePlaylist(801u, 42min, {2u}, {42min})},
       {802u, MakePlaylist(802u, 85min, {3u}, {85min})},
   };
   ClipMap clips{
       {1u, MakeClip(45min, {800u})}, {2u, MakeClip(42min, {801u})}, {3u, MakeClip(85min, {802u})},
-      {4u, MakeClip(5min, {1u})},    {5u, MakeClip(5min, {10u})},
+      {4u, MakeClip(4min, {1u})},    {5u, MakeClip(4min, {10u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -3562,8 +3710,8 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FourEpisodesOneDouble_GroupM
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {801u, MakePlaylist(801u, 42min, {2u}, {42min})},
       {802u, MakePlaylist(802u, 85min, {3u},
@@ -3573,7 +3721,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FourEpisodesOneDouble_GroupM
   };
   ClipMap clips{
       {1u, MakeClip(45min, {800u})}, {2u, MakeClip(42min, {801u})}, {3u, MakeClip(85min, {802u})},
-      {4u, MakeClip(5min, {1u})},    {5u, MakeClip(5min, {10u})},
+      {4u, MakeClip(4min, {1u})},    {5u, MakeClip(4min, {10u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -3633,15 +3781,15 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FourEpisodesOneDouble_GroupM
   };
 
   PlaylistMap playlists{
-      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
-      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {1u, MakePlaylist(1u, 4min, {4u}, {4min})},
+      {10u, MakePlaylist(10u, 4min, {5u}, {4min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {801u, MakePlaylist(801u, 42min, {2u}, {42min})},
       {802u, MakePlaylist(802u, 57min, {3u}, {57min})},
   };
   ClipMap clips{
       {1u, MakeClip(45min, {800u})}, {2u, MakeClip(42min, {801u})}, {3u, MakeClip(57min, {802u})},
-      {4u, MakeClip(5min, {1u})},    {5u, MakeClip(5min, {10u})},
+      {4u, MakeClip(4min, {1u})},    {5u, MakeClip(4min, {10u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -3730,11 +3878,11 @@ TEST_F(TestDiscDirectoryHelper, GetMoviePlaylists_AllPlaylistsTooShort)
 
   PlaylistMap playlists{
       {1u, MakePlaylist(1u, 20min, {1u}, {20min})},
-      {2u, MakePlaylist(2u, 5min, {2u}, {5min})},
+      {2u, MakePlaylist(2u, 4min, {2u}, {4min})},
   };
   ClipMap clips{
       {1u, MakeClip(20min, {1u})},
-      {2u, MakeClip(5min, {2u})},
+      {2u, MakeClip(4min, {2u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -3767,18 +3915,18 @@ TEST_F(TestDiscDirectoryHelper, GetMoviePlaylists_MultiplePlaylists)
   // 120min = longest
   //  90min = 75% of longest → included in MAIN (>= 70% threshold of 84min)
   //  80min = 67% of longest → excluded in MAIN (< 84min)
-  //   5min = too short      → filtered by MIN_MOVIE_DURATION for SINGLE/MAIN
+  //   4min = too short      → filtered by MIN_MOVIE_DURATION for SINGLE/MAIN
   PlaylistMap playlists{
       {1u, MakePlaylist(1u, 120min, {1u}, {120min})},
       {2u, MakePlaylist(2u, 90min, {2u}, {90min})},
       {3u, MakePlaylist(3u, 80min, {3u}, {80min})},
-      {4u, MakePlaylist(4u, 5min, {4u}, {5min})},
+      {4u, MakePlaylist(4u, 4min, {4u}, {4min})},
   };
   ClipMap clips{
       {1u, MakeClip(120min, {1u})},
       {2u, MakeClip(90min, {2u})},
       {3u, MakeClip(80min, {3u})},
-      {4u, MakeClip(5min, {4u})},
+      {4u, MakeClip(4min, {4u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -3900,12 +4048,12 @@ TEST_F(TestDiscDirectoryHelper, GetMoviePlaylists_ChapterFiltering)
   PlaylistMap playlists{
       {1u, MakePlaylist(1u, 120min, {1u}, {60min, 60min})}, // 2 chapters
       {2u, MakePlaylist(2u, 115min, {2u}, {115min})}, // 1 chapter
-      {3u, MakePlaylist(3u, 5min, {3u}, {5min})}, // Too short
+      {3u, MakePlaylist(3u, 4min, {3u}, {4min})}, // Too short
   };
   ClipMap clips{
       {1u, MakeClip(120min, {1u})},
       {2u, MakeClip(115min, {2u})},
-      {3u, MakeClip(5min, {3u})},
+      {3u, MakeClip(4min, {3u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
@@ -3940,12 +4088,12 @@ TEST_F(TestDiscDirectoryHelper, GetMoviePlaylists_ChapterFiltering_MainPlaylistP
   PlaylistMap playlists{
       {1u, MakePlaylist(1u, 120min, {1u}, {60min, 60min})}, // 2 chapters
       {2u, MakePlaylist(2u, 80min, {2u}, {80min})}, // 1 chapter, mainPlaylist
-      {3u, MakePlaylist(3u, 5min, {3u}, {5min})}, // Too short
+      {3u, MakePlaylist(3u, 4min, {3u}, {4min})}, // Too short
   };
   ClipMap clips{
       {1u, MakeClip(120min, {1u})},
       {2u, MakeClip(80min, {2u})},
-      {3u, MakeClip(5min, {3u})},
+      {3u, MakeClip(4min, {3u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -692,6 +692,158 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2)
 // Playlist 100 = play-all; 800 = episode 1; 802 = episode 2; 804 = episode 3
 // Playlists not sequential to prevent group matching
 // Play-all playlist is allowed to have short clips at the beginning and/or end (eg. intro/ending credits)
+// Clip 6 is an ending clip, and is present at the end of each episode as well
+// Example is Planet Earth (2006) S1D1
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2a)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 1, 2400), // 40 minutes
+      MakeEpisode(1, 2, 2400),
+      MakeEpisode(1, 3, 2400),
+  };
+
+  PlaylistMap playlists{
+      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
+      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {100u, MakePlaylist(100u, 7500500ms, {1u, 2u, 3u, 6u}, {45min, 42min, 38min, 500ms})},
+      {800u, MakePlaylist(800u, 2700500ms, {1u, 6u}, {45min, 500ms})},
+      {802u, MakePlaylist(802u, 2520500ms, {2u, 6u}, {42min, 500ms})},
+      {804u, MakePlaylist(804u, 2280500ms, {3u, 6u}, {38min, 500ms})},
+  };
+  ClipMap clips{
+      {1u, MakeClip(45min, {100u, 800u})}, {2u, MakeClip(42min, {100u, 802u})},
+      {3u, MakeClip(38min, {100u, 804u})}, {4u, MakeClip(5min, {1u})},
+      {5u, MakeClip(5min, {10u})},         {6u, MakeClip(500ms, {100u, 800u, 802u, 804u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 800);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 802);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 2, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 804);
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
+                                          playlists)); // Invalid episode index
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 3); // All episodes
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{800u, 802u, 804u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 3);
+  returned = GetPlaylists(items);
+  expected = {800u, 802u, 804u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 6);
+  returned = GetPlaylists(items);
+  expected = {1u, 10u, 100u, 800u, 802u, 804u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// Disc has a play-all playlist (clips shared with individual episode playlists)
+// Playlist 100 = play-all; 800 = episode 1; 802 = episode 2; 804 = episode 3; 806 = episode 4
+// Playlists not sequential to prevent group matching
+// Play-all playlist is allowed to have short clips at the beginning and/or end (eg. intro/ending credits)
+// Clip 6 is an intro clip, and is present at the start of each episode as well
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2b)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 1, 2700), // 45 minutes
+      MakeEpisode(1, 2, 2520), // 42 minutes
+      MakeEpisode(1, 3, 2280), // 38 minutes
+      MakeEpisode(1, 4, 2400), // 40 minutes
+  };
+
+  PlaylistMap playlists{
+      {1u, MakePlaylist(1u, 5min, {7u}, {5min})},
+      {10u, MakePlaylist(10u, 5min, {8u}, {5min})},
+      {100u,
+       MakePlaylist(100u, 9900500ms, {6u, 1u, 2u, 3u, 4u}, {500ms, 45min, 42min, 38min, 40min})},
+      {800u, MakePlaylist(800u, 2700500ms, {6u, 1u}, {500ms, 45min})},
+      {802u, MakePlaylist(802u, 2520500ms, {6u, 2u}, {500ms, 42min})},
+      {804u, MakePlaylist(804u, 2280500ms, {6u, 3u}, {500ms, 38min})},
+      {806u, MakePlaylist(806u, 2400500ms, {6u, 4u}, {500ms, 40min})},
+  };
+  ClipMap clips{
+      {1u, MakeClip(45min, {100u, 800u})},
+      {2u, MakeClip(42min, {100u, 802u})},
+      {3u, MakeClip(38min, {100u, 804u})},
+      {4u, MakeClip(40min, {100u, 806u})},
+      {6u, MakeClip(500ms, {100u, 800u, 802u, 804u, 806u})},
+      {7u, MakeClip(5min, {1u})},
+      {8u, MakeClip(5min, {10u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 800);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 802);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 2, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 804);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 806);
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 4, episodes, clips,
+                                          playlists)); // Invalid episode index
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 4); // All episodes
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{800u, 802u, 804u, 806u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 4);
+  returned = GetPlaylists(items);
+  expected = {800u, 802u, 804u, 806u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 7);
+  returned = GetPlaylists(items);
+  expected = {1u, 10u, 100u, 800u, 802u, 804u, 806u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// Disc has a play-all playlist (clips shared with individual episode playlists)
+// Playlist 100 = play-all; 800 = episode 1; 802 = episode 2; 804 = episode 3
+// Playlists not sequential to prevent group matching
+// Play-all playlist is allowed to have short clips at the beginning and/or end (eg. intro/ending credits)
 // Clip 6 is an intro clip and clip 7 is an ending clip
 TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips3)
 {
@@ -1002,6 +1154,242 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail3)
   EXPECT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u, 802u, 804u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+//
+// ---- GetEpisodePlaylists – relaxed play-all playlist method -------------------------
+//
+
+// Disc has a play-all playlist (clips shared with individual episode playlists)
+// Playlist 600 = play-all; 601-608 = episodes 1-8
+// Clip layout is more complex and fails PlayAllPlaylist method
+// Similar to the Last Airbender (2005) Bluray S1D1
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 1, 2400), // 40 minutes
+      MakeEpisode(1, 2, 2400), MakeEpisode(1, 3, 2400), MakeEpisode(1, 4, 2400),
+      MakeEpisode(1, 5, 2400), MakeEpisode(1, 6, 2400), MakeEpisode(1, 7, 2400),
+      MakeEpisode(1, 8, 2400),
+  };
+
+  PlaylistMap playlists{
+      {600u, MakePlaylist(600u, 19411s,
+                          {1100u, 1000u, 1001u, 1002u, 1003u, 1004u, 1005u, 1006u, 1007u, 1008u,
+                           1009u, 1010u, 1011u, 1012u, 1013u, 1014u},
+                          {1s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s,
+                           30s, 2400s, 30s, 2400s})},
+      {601u, MakePlaylist(601u, 2401s, {1100u, 1000u}, {1s, 2400s})},
+      {602u, MakePlaylist(602u, 2431s, {1100u, 1001u, 1002u}, {1s, 30s, 2400s})},
+      {603u, MakePlaylist(603u, 2431s, {1100u, 1003u, 1004u}, {1s, 30s, 2400s})},
+      {604u, MakePlaylist(604u, 2431s, {1100u, 1005u, 1006u}, {1s, 30s, 2400s})},
+      {605u, MakePlaylist(605u, 2431s, {1100u, 1007u, 1008u}, {1s, 30s, 2400s})},
+      {606u, MakePlaylist(606u, 2431s, {1100u, 1009u, 1010u}, {1s, 30s, 2400s})},
+      {607u, MakePlaylist(607u, 2431s, {1100u, 1011u, 1012u}, {1s, 30s, 2400s})},
+      {608u, MakePlaylist(608u, 2431s, {1100u, 1013u, 1014u}, {1s, 30s, 2400s})}};
+  ClipMap clips{
+      {1000u, MakeClip(2400s, {600u, 601u})},
+      {1001u, MakeClip(30s, {600u, 602u})},
+      {1002u, MakeClip(2400s, {600u, 602u})},
+      {1003u, MakeClip(30s, {600u, 603u})},
+      {1004u, MakeClip(2400s, {600u, 603u})},
+      {1005u, MakeClip(30s, {600u, 604u})},
+      {1006u, MakeClip(2400s, {600u, 604u})},
+      {1007u, MakeClip(30s, {600u, 605u})},
+      {1008u, MakeClip(2400s, {600u, 605u})},
+      {1009u, MakeClip(30s, {600u, 606u})},
+      {1010u, MakeClip(2400s, {600u, 606u})},
+      {1011u, MakeClip(30s, {600u, 607u})},
+      {1012u, MakeClip(2400s, {600u, 607u})},
+      {1013u, MakeClip(30s, {600u, 608u})},
+      {1014u, MakeClip(2400s, {600u, 608u})},
+      {1100u, MakeClip(1s, {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 601);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 7, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 608);
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 8, episodes, clips,
+                                          playlists)); // Invalid episode index
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 8); // All episodes
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 9);
+  returned = GetPlaylists(items);
+  expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 9);
+  returned = GetPlaylists(items);
+  expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// Disc has a play-all playlist (clips shared with individual episode playlists)
+// Playlist 600 = play-all; 601-607 = episodes 1-7
+// Clip layout is more complex and fails PlayAllPlaylist method
+// Fail as only 7 episodes and 9 playlists in the group
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_Fail)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 1, 2400), // 40 minutes
+      MakeEpisode(1, 2, 2400), MakeEpisode(1, 3, 2400), MakeEpisode(1, 4, 2400),
+      MakeEpisode(1, 5, 2400), MakeEpisode(1, 6, 2400), MakeEpisode(1, 7, 2400),
+  };
+
+  PlaylistMap playlists{
+      {600u, MakePlaylist(600u, 19411s,
+                          {1100u, 1000u, 1001u, 1002u, 1003u, 1004u, 1005u, 1006u, 1007u, 1008u,
+                           1009u, 1010u, 1011u, 1012u, 1013u, 1014u},
+                          {1s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s,
+                           30s, 2400s, 30s, 2400s})},
+      {601u, MakePlaylist(601u, 2401s, {1100u, 1000u}, {1s, 2400s})},
+      {602u, MakePlaylist(602u, 2431s, {1100u, 1001u, 1002u}, {1s, 30s, 2400s})},
+      {603u, MakePlaylist(603u, 2431s, {1100u, 1003u, 1004u}, {1s, 30s, 2400s})},
+      {604u, MakePlaylist(604u, 2431s, {1100u, 1005u, 1006u}, {1s, 30s, 2400s})},
+      {605u, MakePlaylist(605u, 2431s, {1100u, 1007u, 1008u}, {1s, 30s, 2400s})},
+      {606u, MakePlaylist(606u, 2431s, {1100u, 1009u, 1010u}, {1s, 30s, 2400s})},
+      {607u, MakePlaylist(607u, 2431s, {1100u, 1011u, 1012u}, {1s, 30s, 2400s})},
+      {608u, MakePlaylist(608u, 2431s, {1100u, 1013u, 1014u}, {1s, 30s, 2400s})}};
+  ClipMap clips{
+      {1000u, MakeClip(2400s, {600u, 601u})},
+      {1001u, MakeClip(30s, {600u, 602u})},
+      {1002u, MakeClip(2400s, {600u, 602u})},
+      {1003u, MakeClip(30s, {600u, 603u})},
+      {1004u, MakeClip(2400s, {600u, 603u})},
+      {1005u, MakeClip(30s, {600u, 604u})},
+      {1006u, MakeClip(2400s, {600u, 604u})},
+      {1007u, MakeClip(30s, {600u, 605u})},
+      {1008u, MakeClip(2400s, {600u, 605u})},
+      {1009u, MakeClip(30s, {600u, 606u})},
+      {1010u, MakeClip(2400s, {600u, 606u})},
+      {1011u, MakeClip(30s, {600u, 607u})},
+      {1012u, MakeClip(2400s, {600u, 607u})},
+      {1013u, MakeClip(30s, {600u, 608u})},
+      {1014u, MakeClip(2400s, {600u, 608u})},
+      {1100u, MakeClip(1s, {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_FALSE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 9);
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 9);
+  returned = GetPlaylists(items);
+  expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// Disc has a play-all playlist (clips shared with individual episode playlists)
+// Playlist 600 = play-all; 601-608 = episodes 1-8
+// Clip layout is more complex and fails PlayAllPlaylist method
+// Fail as the playlist durations don't add up to the total duration of the first (play-all) playlist
+// Second playlist 602 is too long
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_Fail2)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 1, 2400), // 40 minutes
+      MakeEpisode(1, 2, 2400), MakeEpisode(1, 3, 2400), MakeEpisode(1, 4, 2400),
+      MakeEpisode(1, 5, 2400), MakeEpisode(1, 6, 2400), MakeEpisode(1, 7, 2400),
+      MakeEpisode(1, 8, 2400),
+  };
+
+  PlaylistMap playlists{
+      {600u, MakePlaylist(600u, 19411s,
+                          {1100u, 1000u, 1001u, 1022u, 1003u, 1004u, 1005u, 1006u, 1007u, 1008u,
+                           1009u, 1010u, 1011u, 1012u, 1013u, 1014u},
+                          {1s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s,
+                           30s, 2400s, 30s, 2400s})},
+      {601u, MakePlaylist(601u, 2401s, {1100u, 1000u}, {1s, 2400s})},
+      {602u, MakePlaylist(602u, 4431s, {1100u, 1001u, 1002u}, {1s, 30s, 4400s})},
+      {603u, MakePlaylist(603u, 2431s, {1100u, 1003u, 1004u}, {1s, 30s, 2400s})},
+      {604u, MakePlaylist(604u, 2431s, {1100u, 1005u, 1006u}, {1s, 30s, 2400s})},
+      {605u, MakePlaylist(605u, 2431s, {1100u, 1007u, 1008u}, {1s, 30s, 2400s})},
+      {606u, MakePlaylist(606u, 2431s, {1100u, 1009u, 1010u}, {1s, 30s, 2400s})},
+      {607u, MakePlaylist(607u, 2431s, {1100u, 1011u, 1012u}, {1s, 30s, 2400s})},
+      {608u, MakePlaylist(608u, 2431s, {1100u, 1013u, 1014u}, {1s, 30s, 2400s})}};
+  ClipMap clips{
+      {1000u, MakeClip(2400s, {600u, 601u})},
+      {1001u, MakeClip(30s, {600u, 602u})},
+      {1002u, MakeClip(4400s, {602u})},
+      {1003u, MakeClip(30s, {600u, 603u})},
+      {1004u, MakeClip(2400s, {600u, 603u})},
+      {1005u, MakeClip(30s, {600u, 604u})},
+      {1006u, MakeClip(2400s, {600u, 604u})},
+      {1007u, MakeClip(30s, {600u, 605u})},
+      {1008u, MakeClip(2400s, {600u, 605u})},
+      {1009u, MakeClip(30s, {600u, 606u})},
+      {1010u, MakeClip(2400s, {600u, 606u})},
+      {1011u, MakeClip(30s, {600u, 607u})},
+      {1012u, MakeClip(2400s, {600u, 607u})},
+      {1013u, MakeClip(30s, {600u, 608u})},
+      {1014u, MakeClip(2400s, {600u, 608u})},
+      {1022u, MakeClip(2400s, {600u})},
+      {1100u, MakeClip(1s, {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_FALSE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 9);
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 9);
+  returned = GetPlaylists(items);
+  expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 }
 

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -2568,6 +2568,50 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FiveEpisodes_GroupMethod_Exa
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 }
 
+// As GetEpisodePlaylists_FiveEpisodes_GroupMethod_ExactNumberOfPlaylists
+// Simulates the disc scanning process where the durations of the episodes are only known after they have been scanned
+// Playlist 7 is shorter, but within tolerance
+// (Example Twisted Metal S1D2 UK UHD)
+TEST_F(TestDiscDirectoryHelper,
+       GetEpisodePlaylists_FiveEpisodes_GroupMethod_ExactNumberOfPlaylists_PartialDurations)
+{
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+
+  static constexpr std::array<unsigned int, 5> DURATIONS{1740, 1920, 1740, 1440, 1980};
+
+  PlaylistMap playlists{
+      {0u, MakePlaylist(0u, 1702s, {0u, 2u}, {1702s})},
+      {1u, MakePlaylist(1u, 1886s, {3u, 2u}, {1886s})},
+      {2u, MakePlaylist(2u, 1697s, {7u, 2u}, {1697s})},
+      {7u, MakePlaylist(7u, 1422s, {10u, 2u}, {1422s})},
+      {8u, MakePlaylist(8u, 1952s, {11u, 2u}, {1952s})},
+  };
+  ClipMap clips{
+      {0u, MakeClip(1702s, {0u})},  {2u, MakeClip(0min, {0u, 1u, 2u, 7u, 8u})},
+      {3u, MakeClip(1886s, {1u})},  {7u, MakeClip(1697s, {2u})},
+      {10u, MakeClip(1422s, {7u})}, {11u, MakeClip(1952s, {8u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  static constexpr std::array<unsigned int, 5> EXPECTED_PLAYLISTS{0u, 1u, 2u, 7u, 8u};
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(DURATIONS.size()); ++episodeIndex)
+  {
+    // Only the durations of the episodes scanned so far are known
+    Episodes episodes;
+    for (int i = 0; i < static_cast<int>(DURATIONS.size()); ++i)
+      episodes.emplace_back(MakeEpisode(1, i + 1, i <= episodeIndex ? DURATIONS[i] : 0));
+
+    CDiscDirectoryHelper helper;
+    EXPECT_TRUE(
+        helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips, playlists))
+        << "episode index " << episodeIndex;
+    ASSERT_EQ(items.Size(), 1) << "episode index " << episodeIndex;
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), EXPECTED_PLAYLISTS[episodeIndex]);
+  }
+}
+
 // There is no play-all playlist, nor any consecutive groups of playlists (of the correct number)
 // There are only n playlists of the appropriate l length, so the assumption is these map to episodes
 // in ascending numerical order.

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -2725,6 +2725,78 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Eq
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 }
 
+// As GetEpisodePlaylists_ThreeEpisodes_GroupMethod_EqualEpisodeDurations, at the point in a scan
+// where the episodes already identified have taken their duration from the disc while the one being
+// looked for still has the scraper's hour long slot. The disc then looks inconsistent with itself,
+// and the last episode must still be found.
+// (Example Battlestar Galactica (2003) S1D3 Bluray, scanning the last episode of the disc)
+TEST_F(TestDiscDirectoryHelper,
+       GetEpisodePlaylists_ThreeEpisodes_GroupMethod_PartlyMeasuredDurations)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 11, 2625), // Measured from the disc when these were identified
+      MakeEpisode(1, 12, 2623), MakeEpisode(1, 13, 3600), // Still the scraper's hour long slot
+  };
+
+  PlaylistMap playlists{
+      {20u, MakePlaylist(20u, 2625s, {11u}, {2625s})},
+      {21u, MakePlaylist(21u, 2623s, {12u}, {2623s})},
+      {22u, MakePlaylist(22u, 2625s, {13u}, {2625s})},
+      {30u, MakePlaylist(30u, 2625s, {11u}, {2625s})}, // Duplicates of 20-22
+      {31u, MakePlaylist(31u, 2623s, {12u}, {2623s})},
+      {32u, MakePlaylist(32u, 2625s, {13u}, {2625s})},
+      {52u, MakePlaylist(52u, 752s, {14u}, {752s})}, // Extras, one of them nearer the hour
+      {99u, MakePlaylist(99u, 2908s, {15u}, {2908s})},
+  };
+  ClipMap clips{
+      {11u, MakeClip(2625s, {20u, 30u})}, {12u, MakeClip(2623s, {21u, 31u})},
+      {13u, MakeClip(2625s, {22u, 32u})}, {14u, MakeClip(752s, {52u})},
+      {15u, MakeClip(2908s, {99u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 20u);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 21u);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 2, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 22u);
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
+                                          playlists)); // Invalid episode index
+  ASSERT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 3); // All episodes
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected = {20u, 21u, 22u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 8);
+  returned = GetPlaylists(items);
+  expected = {20u, 21u, 22u, 30u, 31u, 32u, 52u, 99u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 8);
+  returned = GetPlaylists(items);
+  expected = {20u, 21u, 22u, 30u, 31u, 32u, 52u, 99u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
 // Consecutive playlists → group method assigns the nth playlist to episode n
 // Playlist 800 = episode 1; 801 = episode 2; 802 = episode 3
 // The group is 800-803. The episodes are mapped to the start of the group
@@ -3616,6 +3688,63 @@ TEST_F(TestDiscDirectoryHelper,
   returned = GetPlaylists(items);
   expected = {800u, 811u, 812u, 817u, 818u, 820u, 821u, 822u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// The disc offers each of its two episodes three times over (800/814/816 and 807/815/817), and has
+// two extras that happen to be consecutively numbered (820 and 821, and again as 824 and 825).
+// A run of two extras is as many playlists as there are episodes, so their multiples add up, but
+// they are minutes long where an episode is an hour - the group is not the episodes.
+// (Example Dune Prophecy S1D1 UK Bluray)
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_TwoEpisodes_GroupsWithMultiples_ExtrasRejected)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeEpisode(1, 1, 3960), MakeEpisode(1, 2, 3780)}; // 66 and 63 minutes
+
+  static const std::string ALL_LANGS{"eng,fra,deu,ita,spa,ces"};
+  PlaylistMap playlists{
+      {800u, MakePlaylist(800u, 3945s, {75u}, {3945s}, ALL_LANGS)}, // Episode 1
+      {807u, MakePlaylist(807u, 3767s, {76u}, {3767s}, ALL_LANGS)}, // Episode 2
+      {812u, MakePlaylist(812u, 356s, {81u}, {356s}, "eng")}, // Extras
+      {813u, MakePlaylist(813u, 324s, {82u}, {324s}, "eng")},
+      {814u, MakePlaylist(814u, 3945s, {75u}, {3945s}, ALL_LANGS)}, // The episodes again
+      {815u, MakePlaylist(815u, 3767s, {76u}, {3767s}, ALL_LANGS)},
+      {816u, MakePlaylist(816u, 3945s, {75u}, {3945s}, "eng")},
+      {817u, MakePlaylist(817u, 3767s, {76u}, {3767s}, "eng")},
+      {820u, MakePlaylist(820u, 356s, {81u}, {356s}, "eng")}, // And the extras again
+      {821u, MakePlaylist(821u, 324s, {82u}, {324s}, "eng")},
+      {824u, MakePlaylist(824u, 356s, {81u}, {356s}, "eng")},
+      {825u, MakePlaylist(825u, 324s, {82u}, {324s}, "eng")},
+  };
+  ClipMap clips{
+      {75u, MakeClip(3945s, {800u, 814u, 816u})},
+      {76u, MakeClip(3767s, {807u, 815u, 817u})},
+      {81u, MakeClip(356s, {812u, 820u, 824u})},
+      {82u, MakeClip(324s, {813u, 821u, 825u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  // Each episode gets the playlist offering its own clip, and never an extra. Which of the copies
+  // is offered is not important, so they are identified by the clip they hold.
+  static constexpr std::array<unsigned int, 2> EXPECTED_CLIPS{75u, 76u};
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(EXPECTED_CLIPS.size()); ++episodeIndex)
+  {
+    EXPECT_TRUE(
+        helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips, playlists))
+        << "episode index " << episodeIndex;
+    ASSERT_GT(items.Size(), 0) << "episode index " << episodeIndex;
+
+    for (const auto& item : items)
+    {
+      const unsigned int playlist{GetPlaylistFromPath(item->GetPath())};
+      ASSERT_TRUE(playlists.contains(playlist));
+      const std::vector<unsigned int> expectedClips{EXPECTED_CLIPS[episodeIndex]};
+      EXPECT_EQ(playlists.at(playlist).clips, expectedClips)
+          << "episode index " << episodeIndex << " given playlist " << playlist;
+    }
+  }
 }
 
 // Consecutive playlists → group method assigns the nth playlist to episode n

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -2506,6 +2506,78 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Wi
 }
 
 // Consecutive playlists → group method assigns the nth playlist to episode n
+// Playlists 20-22 are the episodes, and 30-32 offer the same clips again
+// Episodes 11 and 13 are cut to the same length
+// (Example Battlestar Galactica (2003) S1D3 Bluray)
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_EqualEpisodeDurations)
+{
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 11, 3600),
+      MakeEpisode(1, 12, 3600),
+      MakeEpisode(1, 13, 3600),
+  };
+
+  PlaylistMap playlists{
+      {20u, MakePlaylist(20u, 2625s, {11u}, {2625s})},
+      {21u, MakePlaylist(21u, 2623s, {12u}, {2623s})},
+      {22u, MakePlaylist(22u, 2625s, {13u}, {2625s})}, // Same length as episode 11's playlist
+      {30u, MakePlaylist(30u, 2625s, {11u}, {2625s})}, // Duplicates of 20-22
+      {31u, MakePlaylist(31u, 2623s, {12u}, {2623s})},
+      {32u, MakePlaylist(32u, 2625s, {13u}, {2625s})},
+      {52u, MakePlaylist(52u, 752s, {14u}, {752s})}, // Extras
+      {99u, MakePlaylist(99u, 2908s, {15u}, {2908s})},
+  };
+  ClipMap clips{
+      {11u, MakeClip(2625s, {20u, 30u})}, {12u, MakeClip(2623s, {21u, 31u})},
+      {13u, MakeClip(2625s, {22u, 32u})}, {14u, MakeClip(752s, {52u})},
+      {15u, MakeClip(2908s, {99u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  static constexpr std::array<unsigned int, 3> EXPECTED_PLAYLISTS{20u, 21u, 22u};
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(EXPECTED_PLAYLISTS.size());
+       ++episodeIndex)
+  {
+    CDiscDirectoryHelper helper;
+    EXPECT_TRUE(
+        helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips, playlists))
+        << "episode index " << episodeIndex;
+    ASSERT_EQ(items.Size(), 1) << "episode index " << episodeIndex;
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), EXPECTED_PLAYLISTS[episodeIndex]);
+  }
+
+  CDiscDirectoryHelper helper;
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
+                                          playlists)); // Invalid episode index
+  ASSERT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 3); // All episodes
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected = {20u, 21u, 22u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 8);
+  returned = GetPlaylists(items);
+  expected = {20u, 21u, 22u, 30u, 31u, 32u, 52u, 99u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 8);
+  returned = GetPlaylists(items);
+  expected = {20u, 21u, 22u, 30u, 31u, 32u, 52u, 99u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// Consecutive playlists → group method assigns the nth playlist to episode n
 // Playlist 800 = episode 1; 801 = episode 2; 802 = episode 3
 // The group is 800-803. The episodes are mapped to the start of the group
 TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_LongerGroup)

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -15,6 +15,7 @@
 #include "settings/SettingsComponent.h"
 #include "video/Episode.h"
 
+#include <array>
 #include <chrono>
 #include <numeric>
 #include <ranges>
@@ -1212,13 +1213,16 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist)
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
-  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
-  ASSERT_EQ(items.Size(), 1);
-  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 601);
-
-  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 7, episodes, clips, playlists));
-  ASSERT_EQ(items.Size(), 1);
-  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 608);
+  static constexpr std::array<unsigned int, 8> expectedPlaylists{601u, 602u, 603u, 604u,
+                                                                 605u, 606u, 607u, 608u};
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(expectedPlaylists.size());
+       ++episodeIndex)
+  {
+    EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips,
+                                           playlists));
+    ASSERT_EQ(items.Size(), 1);
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), expectedPlaylists[episodeIndex]);
+  }
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 8, episodes, clips,
                                           playlists)); // Invalid episode index
@@ -1390,6 +1394,230 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_Fail2
   EXPECT_EQ(items.Size(), 9);
   returned = GetPlaylists(items);
   expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// Disc has a play-all playlist (clips shared with individual episode playlists)
+// Playlist 600 = play-all; 601-603 = episodes 1-3; 604 = episodes 4 and 5; 605-608 = episodes 6-9
+// Clip layout is more complex and fails PlayAllPlaylist method
+// Nine episodes accounted for by eight playlists, all of the same duration bar the double episode
+// Similar to the Last Airbender (2005) Bluray S2D2
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithDoubleEpisode2)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 1, 2400), // 40 minutes
+      MakeEpisode(1, 2, 2400), MakeEpisode(1, 3, 2400), MakeEpisode(1, 4, 2400),
+      MakeEpisode(1, 5, 2400), MakeEpisode(1, 6, 2400), MakeEpisode(1, 7, 2400),
+      MakeEpisode(1, 8, 2400), MakeEpisode(1, 9, 2400),
+  };
+
+  PlaylistMap playlists{
+      {600u, MakePlaylist(600u, 21602s,
+                          {1100u, 1000u, 1001u, 1002u, 1003u, 1010u, 1011u, 1012u, 1013u, 1014u},
+                          {1s, 2400s, 2400s, 2400s, 30s, 4771s, 2400s, 2400s, 2400s, 2400s})},
+      {601u, MakePlaylist(601u, 2401s, {1100u, 1000u}, {1s, 2400s})},
+      {602u, MakePlaylist(602u, 2401s, {1100u, 1001u}, {1s, 2400s})},
+      {603u, MakePlaylist(603u, 2401s, {1100u, 1002u}, {1s, 2400s})},
+      {604u, MakePlaylist(604u, 4802s, {1100u, 1003u, 1010u}, {1s, 30s, 4771s})}, // Double episode
+      {605u, MakePlaylist(605u, 2401s, {1100u, 1011u}, {1s, 2400s})},
+      {606u, MakePlaylist(606u, 2401s, {1100u, 1012u}, {1s, 2400s})},
+      {607u, MakePlaylist(607u, 2401s, {1100u, 1013u}, {1s, 2400s})},
+      {608u, MakePlaylist(608u, 2401s, {1100u, 1014u}, {1s, 2400s})},
+      {1004u, MakePlaylist(1004u, 1s, {1100u}, {1s})},
+      {1006u, MakePlaylist(1006u, 30s, {1003u}, {30s})},
+  };
+  ClipMap clips{
+      {1000u, MakeClip(2400s, {600u, 601u})},
+      {1001u, MakeClip(2400s, {600u, 602u})},
+      {1002u, MakeClip(2400s, {600u, 603u})},
+      {1003u, MakeClip(30s, {600u, 604u, 1006u})},
+      {1010u, MakeClip(4771s, {600u, 604u})},
+      {1011u, MakeClip(2400s, {600u, 605u})},
+      {1012u, MakeClip(2400s, {600u, 606u})},
+      {1013u, MakeClip(2400s, {600u, 607u})},
+      {1014u, MakeClip(2400s, {600u, 608u})},
+      {1100u, MakeClip(1s, {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u, 1004u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  static constexpr std::array<unsigned int, 9> expectedPlaylists{601u, 602u, 603u, 604u, 604u,
+                                                                 605u, 606u, 607u, 608u};
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(expectedPlaylists.size());
+       ++episodeIndex)
+  {
+    EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips,
+                                           playlists));
+    ASSERT_EQ(items.Size(), 1);
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), expectedPlaylists[episodeIndex]);
+  }
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 9, episodes, clips,
+                                          playlists)); // Invalid episode index
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(),
+            8); // 604 is only returned once as it's the same playlist for episodes 4 and 5
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 9);
+  returned = GetPlaylists(items);
+  expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 11);
+  returned = GetPlaylists(items);
+  expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u, 1004u, 1006u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// Disc has a play-all playlist (clips shared with individual episode playlists)
+// Playlist 600 = play-all; 601 = episode 1; 602 = episodes 2-5 (a feature length cut of a
+// four part story)
+// The same four episodes are also present individually as playlists 251-254, but those are English
+// only and are not referenced by the play-all playlist, so the 60x group is preferred
+// Similar to Avatar the Last Airbender (2005) Bluray S3D3
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithFourEpisodePlaylist)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(3, 17, 1500), // 25 minutes
+      MakeEpisode(3, 18, 1380), MakeEpisode(3, 19, 1380),
+      MakeEpisode(3, 20, 1380), MakeEpisode(3, 21, 1440),
+  };
+
+  PlaylistMap playlists{
+      {250u, MakePlaylist(250u, 1474s, {1093u, 1062u}, {1s, 1473s})},
+      {251u, MakePlaylist(251u, 1464s, {1096u}, {1464s})},
+      {252u, MakePlaylist(252u, 1471s, {1097u}, {1471s})},
+      {253u, MakePlaylist(253u, 1464s, {1098u}, {1464s})},
+      {254u, MakePlaylist(254u, 1472s, {1099u}, {1472s})},
+      {255u, MakePlaylist(255u, 1127s, {1100u}, {1127s})},
+      {256u, MakePlaylist(256u, 678s, {1101u}, {678s})},
+      {257u, MakePlaylist(257u, 2191s, {1102u}, {2191s})},
+      {600u, MakePlaylist(600u, 6952s, {1093u, 1062u, 1086u, 1095u}, {1s, 1473s, 47s, 5431s})},
+      {601u, MakePlaylist(601u, 1474s, {1093u, 1062u}, {1s, 1473s})},
+      {602u, MakePlaylist(602u, 5479s, {1093u, 1086u, 1095u}, {1s, 47s, 5431s})}, // Four episodes
+      {1601u, MakePlaylist(1601u, 1473s, {1062u}, {1473s})},
+      {1602u, MakePlaylist(1602u, 47s, {1086u}, {47s})},
+      {1617u, MakePlaylist(1617u, 1s, {1093u}, {1s})},
+      {1619u, MakePlaylist(1619u, 5431s, {1095u}, {5431s})},
+  };
+  ClipMap clips{
+      {1062u, MakeClip(1473s, {250u, 600u, 601u, 1601u})},
+      {1086u, MakeClip(47s, {600u, 602u, 1602u})},
+      {1093u, MakeClip(1s, {250u, 600u, 601u, 602u, 1617u})},
+      {1095u, MakeClip(5431s, {600u, 602u, 1619u})},
+      {1096u, MakeClip(1464s, {251u})},
+      {1097u, MakeClip(1471s, {252u})},
+      {1098u, MakeClip(1464s, {253u})},
+      {1099u, MakeClip(1472s, {254u})},
+      {1100u, MakeClip(1127s, {255u})},
+      {1101u, MakeClip(678s, {256u})},
+      {1102u, MakeClip(2191s, {257u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  static constexpr std::array<unsigned int, 5> expectedPlaylists{601u, 602u, 602u, 602u, 602u};
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(expectedPlaylists.size());
+       ++episodeIndex)
+  {
+    EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips,
+                                           playlists));
+    ASSERT_EQ(items.Size(), 1);
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), expectedPlaylists[episodeIndex]);
+  }
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 5, episodes, clips,
+                                          playlists)); // Invalid episode index
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(),
+            2); // 602 is only returned once as it's the same playlist for episodes 18-21
+  const auto returned{GetPlaylists(items)};
+  const std::set<unsigned int> expected{601u, 602u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// As GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithDoubleEpisode2 but only eight episodes on disc
+// Fail as the playlists' multiples account for nine episodes, not eight
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithDoubleEpisode_Fail)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 1, 2400), // 40 minutes
+      MakeEpisode(1, 2, 2400), MakeEpisode(1, 3, 2400), MakeEpisode(1, 4, 2400),
+      MakeEpisode(1, 5, 2400), MakeEpisode(1, 6, 2400), MakeEpisode(1, 7, 2400),
+      MakeEpisode(1, 8, 2400),
+  };
+
+  PlaylistMap playlists{
+      {600u, MakePlaylist(600u, 21602s,
+                          {1100u, 1000u, 1001u, 1002u, 1003u, 1010u, 1011u, 1012u, 1013u, 1014u},
+                          {1s, 2400s, 2400s, 2400s, 30s, 4771s, 2400s, 2400s, 2400s, 2400s})},
+      {601u, MakePlaylist(601u, 2401s, {1100u, 1000u}, {1s, 2400s})},
+      {602u, MakePlaylist(602u, 2401s, {1100u, 1001u}, {1s, 2400s})},
+      {603u, MakePlaylist(603u, 2401s, {1100u, 1002u}, {1s, 2400s})},
+      {604u, MakePlaylist(604u, 4802s, {1100u, 1003u, 1010u}, {1s, 30s, 4771s})}, // Double episode
+      {605u, MakePlaylist(605u, 2401s, {1100u, 1011u}, {1s, 2400s})},
+      {606u, MakePlaylist(606u, 2401s, {1100u, 1012u}, {1s, 2400s})},
+      {607u, MakePlaylist(607u, 2401s, {1100u, 1013u}, {1s, 2400s})},
+      {608u, MakePlaylist(608u, 2401s, {1100u, 1014u}, {1s, 2400s})},
+      {1004u, MakePlaylist(1004u, 1s, {1100u}, {1s})},
+      {1006u, MakePlaylist(1006u, 30s, {1003u}, {30s})},
+  };
+  ClipMap clips{
+      {1000u, MakeClip(2400s, {600u, 601u})},
+      {1001u, MakeClip(2400s, {600u, 602u})},
+      {1002u, MakeClip(2400s, {600u, 603u})},
+      {1003u, MakeClip(30s, {600u, 604u, 1006u})},
+      {1010u, MakeClip(4771s, {600u, 604u})},
+      {1011u, MakeClip(2400s, {600u, 605u})},
+      {1012u, MakeClip(2400s, {600u, 606u})},
+      {1013u, MakeClip(2400s, {600u, 607u})},
+      {1014u, MakeClip(2400s, {600u, 608u})},
+      {1100u, MakeClip(1s, {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u, 1004u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_FALSE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  EXPECT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 9);
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  EXPECT_EQ(items.Size(), 11);
+  returned = GetPlaylists(items);
+  expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u, 1004u, 1006u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 }
 
@@ -2159,6 +2387,8 @@ TEST_F(TestDiscDirectoryHelper,
 
 // Consecutive playlists → group method assigns the nth playlist to episode n
 // Playlist 800 = episode 1; 801 = episode 2; 802 = episodes 3 and 4
+// 802 is a little shorter than 800 and 801 added together, as the intro/recap/credits that each
+// single episode playlist carries appear only once
 // (Example The Expanse S1D2 R1 Bluray - episodes 9 and 10 are combined into a single playlist)
 TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FourEpisodesOneDouble_GroupMethod)
 {
@@ -2178,10 +2408,10 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FourEpisodesOneDouble_GroupM
       {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
       {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
       {801u, MakePlaylist(801u, 42min, {2u}, {42min})},
-      {802u, MakePlaylist(802u, 92min, {3u}, {92min})},
+      {802u, MakePlaylist(802u, 85min, {3u}, {85min})},
   };
   ClipMap clips{
-      {1u, MakeClip(45min, {800u})}, {2u, MakeClip(42min, {801u})}, {3u, MakeClip(92min, {802u})},
+      {1u, MakeClip(45min, {800u})}, {2u, MakeClip(42min, {801u})}, {3u, MakeClip(85min, {802u})},
       {4u, MakeClip(5min, {1u})},    {5u, MakeClip(5min, {10u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -14,6 +14,7 @@
 #include "filesystem/DiscDirectoryHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
 #include "video/Episode.h"
 
 #include <array>
@@ -58,10 +59,28 @@ class TestDiscDirectoryHelper : public AdvancedSettingsResetBase
 {
 };
 
+// A playlist holds where each of its chapters starts, not duration
+// Chapters are given here as durations, as a disc describes them and as
+// the .mpls parser logs them, and turned into the start times a playlist
+// actually holds.
+std::vector<std::chrono::milliseconds> MakeChapterStarts(
+    const std::vector<std::chrono::milliseconds>& chapterDurations)
+{
+  std::vector<std::chrono::milliseconds> starts;
+  starts.reserve(chapterDurations.size());
+  std::chrono::milliseconds start{0ms};
+  for (const std::chrono::milliseconds duration : chapterDurations)
+  {
+    starts.emplace_back(start);
+    start += duration;
+  }
+  return starts;
+}
+
 PlaylistInformation MakePlaylist(unsigned int playlist,
                                  std::chrono::milliseconds duration,
                                  std::vector<unsigned int> clips,
-                                 std::vector<std::chrono::milliseconds> chapterDurations,
+                                 const std::vector<std::chrono::milliseconds>& chapterDurations,
                                  std::string languages = "",
                                  std::vector<AudioStreamInfo> audioStreams = {},
                                  std::vector<SubtitleStreamInfo> pgStreams = {})
@@ -70,7 +89,7 @@ PlaylistInformation MakePlaylist(unsigned int playlist,
   info.playlist = playlist;
   info.duration = duration;
   info.clips = std::move(clips);
-  info.chapters = std::move(chapterDurations);
+  info.chapters = MakeChapterStarts(chapterDurations);
   info.languages = std::move(languages);
   info.audioStreams = std::move(audioStreams);
   info.pgStreams = std::move(pgStreams);
@@ -165,10 +184,21 @@ bool Validate(ClipMap& clips, PlaylistMap& playlists)
     if (duration != playlistInformation.duration)
       return false; // Playlist duration does not match total of the clips(s)
 
-    const auto chapter_duration{std::accumulate(playlistInformation.chapters.begin(),
-                                                playlistInformation.chapters.end(), 0ms)};
-    if (chapter_duration != playlistInformation.duration)
-      return false; // Playlist duration does not match total of the chapter(s)
+    // Chapters are where each starts within the playlist, so they run from its beginning, in order,
+    // and all begin before it ends
+    if (!playlistInformation.chapters.empty())
+    {
+      if (playlistInformation.chapters.front() != 0ms)
+        return false; // First chapter does not start at the beginning of the playlist
+
+      if (!std::ranges::is_sorted(playlistInformation.chapters) ||
+          std::ranges::adjacent_find(playlistInformation.chapters) !=
+              playlistInformation.chapters.end())
+        return false; // Chapters are not in ascending order of where they start
+
+      if (playlistInformation.chapters.back() >= playlistInformation.duration)
+        return false; // A chapter starts at or after the end of the playlist
+    }
   }
 
   for (const auto& clipInfo : clips | std::views::values)
@@ -1710,7 +1740,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithF
   };
 
   PlaylistMap playlists{
-      {250u, MakePlaylist(250u, 1474s, {1093u, 1062u}, {1s, 1473s})},
+      {250u, MakePlaylist(250u, 1475s, {1093u, 1062u}, {1s, 1474s})},
       {251u, MakePlaylist(251u, 1464s, {1096u}, {1464s})},
       {252u, MakePlaylist(252u, 1471s, {1097u}, {1471s})},
       {253u, MakePlaylist(253u, 1464s, {1098u}, {1464s})},
@@ -1718,16 +1748,22 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithF
       {255u, MakePlaylist(255u, 1127s, {1100u}, {1127s})},
       {256u, MakePlaylist(256u, 678s, {1101u}, {678s})},
       {257u, MakePlaylist(257u, 2191s, {1102u}, {2191s})},
-      {600u, MakePlaylist(600u, 6952s, {1093u, 1062u, 1086u, 1095u}, {1s, 1473s, 47s, 5431s})},
-      {601u, MakePlaylist(601u, 1474s, {1093u, 1062u}, {1s, 1473s})},
-      {602u, MakePlaylist(602u, 5479s, {1093u, 1086u, 1095u}, {1s, 47s, 5431s})}, // Four episodes
-      {1601u, MakePlaylist(1601u, 1473s, {1062u}, {1473s})},
+      {600u, MakePlaylist(600u, 6953s, {1093u, 1062u, 1086u, 1095u}, {1s, 1474s, 47s, 5431s})},
+      {601u, MakePlaylist(601u, 1475s, {1093u, 1062u}, {1s, 1474s})},
+      // Four episodes, each marked up with three chapters, then a two chapter credits tail
+      {602u, MakePlaylist(602u, 5479s, {1093u, 1086u, 1095u},
+                          {516s, 444s, 434s, // Episode 18
+                           306s, 546s, 502s, // Episode 19
+                           394s, 370s, 581s, // Episode 20
+                           499s, 354s, 488s, // Episode 21
+                           44s, 1s})}, // Credits
+      {1601u, MakePlaylist(1601u, 1474s, {1062u}, {1474s})},
       {1602u, MakePlaylist(1602u, 47s, {1086u}, {47s})},
       {1617u, MakePlaylist(1617u, 1s, {1093u}, {1s})},
       {1619u, MakePlaylist(1619u, 5431s, {1095u}, {5431s})},
   };
   ClipMap clips{
-      {1062u, MakeClip(1473s, {250u, 600u, 601u, 1601u})},
+      {1062u, MakeClip(1474s, {250u, 600u, 601u, 1601u})},
       {1086u, MakeClip(47s, {600u, 602u, 1602u})},
       {1093u, MakeClip(1s, {250u, 600u, 601u, 602u, 1617u})},
       {1095u, MakeClip(5431s, {600u, 602u, 1619u})},
@@ -1741,14 +1777,38 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithF
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
-  static constexpr std::array<unsigned int, 5> expectedPlaylists{601u, 602u, 602u, 602u, 602u};
-  for (int episodeIndex = 0; episodeIndex < static_cast<int>(expectedPlaylists.size());
-       ++episodeIndex)
+  // Episode 17 is a playlist of its own, so runs for all of it. Episodes 18-21 share playlist 602,
+  // each running for its own three chapters of it, and each after the first carrying an episode
+  // bookmark of where it starts.
+  struct Expected
   {
+    unsigned int playlist;
+    int duration;
+    double bookmark;
+  };
+  static constexpr std::array<Expected, 5> EXPECTED{{{601u, 1475, 0.0},
+                                                     {602u, 1394, 0.0},
+                                                     {602u, 1354, 1394.0},
+                                                     {602u, 1345, 2748.0},
+                                                     {602u, 1341, 4093.0}}};
+
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(EXPECTED.size()); ++episodeIndex)
+  {
+    const auto& expectedEpisode{EXPECTED[episodeIndex]};
+
     EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips,
                                            playlists));
-    ASSERT_EQ(items.Size(), 1);
-    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), expectedPlaylists[episodeIndex]);
+    ASSERT_EQ(items.Size(), 1) << "episode index " << episodeIndex;
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), expectedEpisode.playlist);
+
+    const CVideoInfoTag* tag{items[0]->GetVideoInfoTag()};
+    EXPECT_EQ(tag->GetDuration(), expectedEpisode.duration) << "episode index " << episodeIndex;
+    EXPECT_DOUBLE_EQ(tag->m_EpBookmark.timeInSeconds, expectedEpisode.bookmark)
+        << "episode index " << episodeIndex;
+    if (expectedEpisode.bookmark > 0.0)
+    {
+      EXPECT_DOUBLE_EQ(tag->m_EpBookmark.totalTimeInSeconds, 5479.0);
+    }
   }
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 5, episodes, clips,
@@ -1762,6 +1822,192 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithF
   const auto returned{GetPlaylists(items)};
   const std::set<unsigned int> expected{601u, 602u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  // Asking for all episodes gives the whole of 602, not one episode of it
+  const auto allEpisodeItem{std::ranges::find_if(
+      items, [](const auto& i) { return GetPlaylistFromPath(i->GetPath()) == 602u; })};
+  ASSERT_NE(allEpisodeItem, items.cend());
+  EXPECT_EQ((*allEpisodeItem)->GetVideoInfoTag()->GetDuration(), 5479);
+  EXPECT_DOUBLE_EQ((*allEpisodeItem)->GetVideoInfoTag()->m_EpBookmark.timeInSeconds, 0.0);
+}
+
+// As GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithFourEpisodePlaylist, but with the stream
+// details a disc's directory supplies. Those describe the whole playlist, so for the episodes
+// sharing 602 the duration must be replaced with the episode's own - otherwise every one of them is
+// reported as running for the length of all four.
+TEST_F(TestDiscDirectoryHelper,
+       GetEpisodePlaylists_RelaxedPlayAllPlaylist_FourEpisodePlaylistStreamDetails)
+{
+  CURL url("bluray://test/");
+  CFileItemList items;
+  Episodes episodes{
+      MakeEpisode(3, 17, 1500), // 25 minutes
+      MakeEpisode(3, 18, 1380), MakeEpisode(3, 19, 1380),
+      MakeEpisode(3, 20, 1380), MakeEpisode(3, 21, 1440),
+  };
+
+  PlaylistMap playlists{
+      {600u, MakePlaylist(600u, 6953s, {1093u, 1062u, 1086u, 1095u}, {1s, 1474s, 47s, 5431s})},
+      {601u, MakePlaylist(601u, 1475s, {1093u, 1062u}, {1s, 1474s})},
+      {602u, MakePlaylist(602u, 5479s, {1093u, 1086u, 1095u},
+                          {516s, 444s, 434s, 306s, 546s, 502s, 394s, 370s, 581s, 499s, 354s, 488s,
+                           44s, 1s})},
+  };
+  ClipMap clips{
+      {1062u, MakeClip(1474s, {600u, 601u})},
+      {1086u, MakeClip(47s, {600u, 602u})},
+      {1093u, MakeClip(1s, {600u, 601u, 602u})},
+      {1095u, MakeClip(5431s, {600u, 602u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  // Every playlist on the disc, as CBlurayDirectory supplies them
+  CFileItemList allTitles;
+  for (const unsigned int playlist : std::views::keys(playlists))
+  {
+    allTitles.Add(std::make_shared<CFileItem>(
+        StringUtils::Format("bluray://test/BDMV/PLAYLIST/{:05}.mpls", playlist), false));
+  }
+
+  // Describes the streams of a whole playlist, as CBlurayDirectory::SetStreamDetails does
+  CDiscDirectoryHelper helper{
+      [&playlists](unsigned int playlist, CFileItem& item)
+      {
+        VideoStreamInfo video;
+        video.valid = true;
+        const auto duration{static_cast<int>(playlists.at(playlist).duration.count() / 1000)};
+        item.GetVideoInfoTag()->m_streamDetails.SetStreams(video, duration, AudioStreamInfo{},
+                                                           SubtitleStreamInfo{});
+      }};
+
+  // Episode 17 has playlist 601 to itself, so runs for all of it. Episodes 18-21 share 602 and each
+  // runs for its own three chapters of it.
+  static constexpr std::array<int, 5> EXPECTED_DURATIONS{1475, 1394, 1354, 1345, 1341};
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(EXPECTED_DURATIONS.size());
+       ++episodeIndex)
+  {
+    EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips,
+                                           playlists));
+    ASSERT_EQ(items.Size(), 1) << "episode index " << episodeIndex;
+
+    const CVideoInfoTag* tag{items[0]->GetVideoInfoTag()};
+    EXPECT_EQ(tag->m_streamDetails.GetVideoDuration(), EXPECTED_DURATIONS[episodeIndex])
+        << "episode index " << episodeIndex;
+    EXPECT_EQ(tag->GetDuration(), static_cast<unsigned int>(EXPECTED_DURATIONS[episodeIndex]))
+        << "episode index " << episodeIndex;
+  }
+}
+
+// As GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithFourEpisodePlaylist, but playlist 602's
+// chapters do not divide into four runs of near-equal duration.
+TEST_F(TestDiscDirectoryHelper,
+       GetEpisodePlaylists_RelaxedPlayAllPlaylist_FourEpisodePlaylistChaptersDoNotDivide)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(3, 17, 1500), // 25 minutes
+      MakeEpisode(3, 18, 1380), MakeEpisode(3, 19, 1380),
+      MakeEpisode(3, 20, 1380), MakeEpisode(3, 21, 1440),
+  };
+
+  PlaylistMap playlists{
+      {600u, MakePlaylist(600u, 6952s, {1093u, 1062u, 1086u, 1095u}, {1s, 1473s, 47s, 5431s})},
+      {601u, MakePlaylist(601u, 1474s, {1093u, 1062u}, {1s, 1473s})},
+      // One chapter per episode would divide evenly, but the runs are nothing like equal
+      {602u, MakePlaylist(602u, 5479s, {1093u, 1086u, 1095u}, {2500s, 1200s, 1100s, 679s})},
+  };
+  ClipMap clips{
+      {1062u, MakeClip(1473s, {600u, 601u})},
+      {1086u, MakeClip(47s, {600u, 602u})},
+      {1093u, MakeClip(1s, {600u, 601u, 602u})},
+      {1095u, MakeClip(5431s, {600u, 602u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  static constexpr std::array<unsigned int, 5> EXPECTED_PLAYLISTS{601u, 602u, 602u, 602u, 602u};
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(EXPECTED_PLAYLISTS.size());
+       ++episodeIndex)
+  {
+    EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips,
+                                           playlists));
+    ASSERT_EQ(items.Size(), 1) << "episode index " << episodeIndex;
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), EXPECTED_PLAYLISTS[episodeIndex]);
+
+    // No episode bookmark, and the whole playlist as the duration
+    const CVideoInfoTag* tag{items[0]->GetVideoInfoTag()};
+    EXPECT_DOUBLE_EQ(tag->m_EpBookmark.timeInSeconds, 0.0) << "episode index " << episodeIndex;
+    if (EXPECTED_PLAYLISTS[episodeIndex] == 602u)
+    {
+      EXPECT_EQ(tag->GetDuration(), 5479) << "episode index " << episodeIndex;
+    }
+  }
+}
+
+// Disc has a play-all playlist (clips shared with individual episode playlists)
+// Playlist 600 = play-all; 601 = episode 17; 602 = episode 18; 603 = episodes 19 and 20 as one
+// continuous stream, marked up with three chapters each and a two chapter credits tail
+// Similar to Avatar the Last Airbender (2005) Bluray S2D3
+TEST_F(TestDiscDirectoryHelper,
+       GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithDoubleEpisodeChapters)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(2, 17, 1470), // 24.5 minutes
+      MakeEpisode(2, 18, 1470),
+      MakeEpisode(2, 19, 1470),
+      MakeEpisode(2, 20, 1470),
+  };
+
+  PlaylistMap playlists{
+      {600u, MakePlaylist(600u, 5894s, {1093u, 1062u, 1086u, 1101u, 1102u},
+                          {1s, 1473s, 1473s, 46s, 2901s})},
+      {601u, MakePlaylist(601u, 1474s, {1093u, 1062u}, {1s, 1473s})},
+      {602u, MakePlaylist(602u, 1474s, {1093u, 1086u}, {1s, 1473s})},
+      {603u, MakePlaylist(603u, 2948s, {1093u, 1101u, 1102u},
+                          {520s, 540s, 414s, // Episode 19
+                           480s, 500s, 448s, // Episode 20
+                           45s, 1s})}, // Credits
+  };
+  ClipMap clips{
+      {1062u, MakeClip(1473s, {600u, 601u})},          {1086u, MakeClip(1473s, {600u, 602u})},
+      {1093u, MakeClip(1s, {600u, 601u, 602u, 603u})}, {1101u, MakeClip(46s, {600u, 603u})},
+      {1102u, MakeClip(2901s, {600u, 603u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  struct Expected
+  {
+    unsigned int playlist;
+    int duration;
+    double bookmark;
+  };
+  static constexpr std::array<Expected, 4> EXPECTED{
+      {{601u, 1474, 0.0}, {602u, 1474, 0.0}, {603u, 1474, 0.0}, {603u, 1428, 1474.0}}};
+
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(EXPECTED.size()); ++episodeIndex)
+  {
+    const auto& expectedEpisode{EXPECTED[episodeIndex]};
+
+    EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips,
+                                           playlists));
+    ASSERT_EQ(items.Size(), 1) << "episode index " << episodeIndex;
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), expectedEpisode.playlist);
+
+    const CVideoInfoTag* tag{items[0]->GetVideoInfoTag()};
+    EXPECT_EQ(tag->GetDuration(), expectedEpisode.duration) << "episode index " << episodeIndex;
+    EXPECT_DOUBLE_EQ(tag->m_EpBookmark.timeInSeconds, expectedEpisode.bookmark)
+        << "episode index " << episodeIndex;
+    if (expectedEpisode.bookmark > 0.0)
+    {
+      EXPECT_DOUBLE_EQ(tag->m_EpBookmark.totalTimeInSeconds, 2948.0);
+    }
+  }
 }
 
 // Disc has a play-all playlist (clips shared with individual episode playlists)
@@ -3019,6 +3265,77 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FourEpisodesOneDouble_GroupM
   returned = GetPlaylists(items);
   expected = {1u, 10u, 800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// As GetEpisodePlaylists_FourEpisodesOneDouble_GroupMethod, but the double episode playlist 802 is
+// marked up with three chapters per episode and a single credits chapter, so where episode 4 starts
+// within it can be told
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FourEpisodesOneDouble_GroupMethod_Chapters)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 1, 2700), // 45 min
+      MakeEpisode(1, 2, 2700),
+      MakeEpisode(1, 3, 2700),
+      MakeEpisode(1, 4, 2700),
+  };
+
+  PlaylistMap playlists{
+      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
+      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
+      {801u, MakePlaylist(801u, 42min, {2u}, {42min})},
+      {802u, MakePlaylist(802u, 85min, {3u},
+                          {900s, 850s, 800s, // Episode 3
+                           880s, 870s, 780s, // Episode 4
+                           20s})}, // Credits
+  };
+  ClipMap clips{
+      {1u, MakeClip(45min, {800u})}, {2u, MakeClip(42min, {801u})}, {3u, MakeClip(85min, {802u})},
+      {4u, MakeClip(5min, {1u})},    {5u, MakeClip(5min, {10u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  struct Expected
+  {
+    unsigned int playlist;
+    int duration;
+    double bookmark;
+  };
+  static constexpr std::array<Expected, 4> EXPECTED{
+      {{800u, 2700, 0.0}, {801u, 2520, 0.0}, {802u, 2550, 0.0}, {802u, 2530, 2550.0}}};
+
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(EXPECTED.size()); ++episodeIndex)
+  {
+    const auto& expectedEpisode{EXPECTED[episodeIndex]};
+
+    EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips,
+                                           playlists));
+    ASSERT_EQ(items.Size(), 1) << "episode index " << episodeIndex;
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), expectedEpisode.playlist);
+
+    const CVideoInfoTag* tag{items[0]->GetVideoInfoTag()};
+    EXPECT_EQ(tag->GetDuration(), expectedEpisode.duration) << "episode index " << episodeIndex;
+    EXPECT_DOUBLE_EQ(tag->m_EpBookmark.timeInSeconds, expectedEpisode.bookmark)
+        << "episode index " << episodeIndex;
+    if (expectedEpisode.bookmark > 0.0)
+    {
+      EXPECT_DOUBLE_EQ(tag->m_EpBookmark.totalTimeInSeconds, 5100.0);
+    }
+  }
+
+  // Asking for all episodes gives the whole of 802, not one episode of it
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 3);
+  const auto allEpisodeItem{std::ranges::find_if(
+      items, [](const auto& i) { return GetPlaylistFromPath(i->GetPath()) == 802u; })};
+  ASSERT_NE(allEpisodeItem, items.cend());
+  EXPECT_EQ((*allEpisodeItem)->GetVideoInfoTag()->GetDuration(), 5100);
+  EXPECT_DOUBLE_EQ((*allEpisodeItem)->GetVideoInfoTag()->m_EpBookmark.timeInSeconds, 0.0);
 }
 
 // Consecutive playlists → group method assigns the nth playlist to episode n

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -2433,6 +2433,78 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Wi
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 }
 
+// As GetEpisodePlaylists_ThreeEpisodes_GroupMethod_WithSpecial, but the episodes are given with the
+// special last rather than first
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_WithSpecialLast)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 1, 2700), // 45 min
+      MakeEpisode(1, 2, 2700), MakeEpisode(1, 3, 2700), MakeEpisode(0, 1, 1800), // Special
+  };
+
+  PlaylistMap playlists{
+      {1u, MakePlaylist(1u, 5min, {4u}, {5min})},
+      {10u, MakePlaylist(10u, 5min, {5u}, {5min})},
+      {800u, MakePlaylist(800u, 45min, {1u}, {45min})},
+      {801u, MakePlaylist(801u, 42min, {2u}, {42min})},
+      {802u, MakePlaylist(802u, 38min, {3u}, {38min})},
+  };
+  ClipMap clips{
+      {1u, MakeClip(45min, {800u})}, {2u, MakeClip(42min, {801u})}, {3u, MakeClip(38min, {802u})},
+      {4u, MakeClip(5min, {1u})},    {5u, MakeClip(5min, {10u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 800);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 801);
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 2, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 802);
+
+  // The special, at the end of the list rather than the start
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 2);
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{1u, 10u};
+  EXPECT_TRUE(std::ranges::includes(
+      returned, expected)); // Any of the 2 remaining playlists could be the special
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 4, episodes, clips,
+                                          playlists)); // Invalid episode index
+  ASSERT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 3); // All episodes
+  returned = GetPlaylists(items);
+  expected = {800u, 801u, 802u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 3);
+  returned = GetPlaylists(items);
+  expected = {800u, 801u, 802u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 5);
+  returned = GetPlaylists(items);
+  expected = {1u, 10u, 800u, 801u, 802u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
 // Consecutive playlists → group method assigns the nth playlist to episode n
 // Playlist 800 = episode 1; 801 = episode 2; 802 = episode 3
 // The group is 800-803. The episodes are mapped to the start of the group

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -2930,6 +2930,140 @@ TEST_F(TestDiscDirectoryHelper,
   }
 }
 
+// As GetEpisodePlaylists_FiveEpisodes_GroupMethod_ExactNumberOfPlaylists_PartialDurations, but the
+// last episode is feature length
+// (Example The Expanse S6D2 UK Bluray - episode 6 is the feature length finale)
+TEST_F(TestDiscDirectoryHelper,
+       GetEpisodePlaylists_ThreeEpisodes_GroupMethod_ExactNumberOfPlaylists_LongFinale)
+{
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+
+  static constexpr std::array<unsigned int, 3> DURATIONS{2820, 2880, 3780};
+
+  PlaylistMap playlists{
+      {0u, MakePlaylist(0u, 27s, {6u}, {27s})}, // Too short to be an episode
+      {1u, MakePlaylist(1u, 2829s, {2u}, {2829s})}, {3u, MakePlaylist(3u, 2886s, {3u}, {2886s})},
+      {4u, MakePlaylist(4u, 3815s, {4u}, {3815s})}, // The finale
+      {7u, MakePlaylist(7u, 16s, {7u}, {16s})},
+  };
+  ClipMap clips{
+      {2u, MakeClip(2829s, {1u})}, {3u, MakeClip(2886s, {3u})}, {4u, MakeClip(3815s, {4u})},
+      {6u, MakeClip(27s, {0u})},   {7u, MakeClip(16s, {7u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  static constexpr std::array<unsigned int, 3> EXPECTED_PLAYLISTS{1u, 3u, 4u};
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(DURATIONS.size()); ++episodeIndex)
+  {
+    // Only the durations of the episodes scanned so far are known
+    Episodes episodes;
+    for (int i = 0; i < static_cast<int>(DURATIONS.size()); ++i)
+      episodes.emplace_back(MakeEpisode(6, i + 4, i <= episodeIndex ? DURATIONS[i] : 0));
+
+    CDiscDirectoryHelper helper;
+    EXPECT_TRUE(
+        helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips, playlists))
+        << "episode index " << episodeIndex;
+    ASSERT_EQ(items.Size(), 1) << "episode index " << episodeIndex;
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), EXPECTED_PLAYLISTS[episodeIndex]);
+  }
+
+  CDiscDirectoryHelper helper;
+  Episodes episodes;
+  for (int i = 0; i < static_cast<int>(DURATIONS.size()); ++i)
+    episodes.emplace_back(MakeEpisode(1, i + 1, DURATIONS[i]));
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 3); // All episodes
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{1u, 3u, 4u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 3);
+  returned = GetPlaylists(items);
+  expected = {1u, 3u, 4u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 5);
+  returned = GetPlaylists(items);
+  expected = {0u, 1u, 3u, 4u, 7u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// There is no play-all playlist, nor any consecutive groups of playlists (of the correct number)
+// There is one more playlist long enough to be an episode than there are episodes - playlist 810 is
+// a feature length extra - so the one whose duration is nothing like an episode's is removed, and
+// the rest map to episodes in ascending numerical order
+TEST_F(TestDiscDirectoryHelper,
+       GetEpisodePlaylists_FiveEpisodes_GroupMethod_ExactNumberOfPlaylists_LongExtraRemoved)
+{
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 1, 2700), // 45 min
+      MakeEpisode(1, 2, 2700), MakeEpisode(1, 3, 2700),
+      MakeEpisode(1, 4, 2700), MakeEpisode(1, 5, 2700),
+  };
+
+  // Non-consecutive, so there is no group of playlists to use
+  PlaylistMap playlists{
+      {800u, MakePlaylist(800u, 2700s, {1u}, {2700s})},
+      {802u, MakePlaylist(802u, 2640s, {2u}, {2640s})},
+      {804u, MakePlaylist(804u, 2760s, {3u}, {2760s})},
+      {806u, MakePlaylist(806u, 2700s, {4u}, {2700s})},
+      {808u, MakePlaylist(808u, 2580s, {5u}, {2580s})},
+      {810u, MakePlaylist(810u, 6000s, {6u}, {6000s})}, // Feature length extra
+  };
+  ClipMap clips{
+      {1u, MakeClip(2700s, {800u})}, {2u, MakeClip(2640s, {802u})}, {3u, MakeClip(2760s, {804u})},
+      {4u, MakeClip(2700s, {806u})}, {5u, MakeClip(2580s, {808u})}, {6u, MakeClip(6000s, {810u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  static constexpr std::array<unsigned int, 5> EXPECTED_PLAYLISTS{800u, 802u, 804u, 806u, 808u};
+  for (int episodeIndex = 0; episodeIndex < static_cast<int>(EXPECTED_PLAYLISTS.size());
+       ++episodeIndex)
+  {
+    CDiscDirectoryHelper helper;
+    EXPECT_TRUE(
+        helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips, playlists))
+        << "episode index " << episodeIndex;
+    ASSERT_EQ(items.Size(), 1) << "episode index " << episodeIndex;
+    EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), EXPECTED_PLAYLISTS[episodeIndex]);
+  }
+
+  CDiscDirectoryHelper helper;
+
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 5); // All episodes
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{800u, 802u, 804u, 806u, 808u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 6);
+  returned = GetPlaylists(items);
+  expected = {800u, 802u, 804u, 806u, 808u, 810u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 6);
+  returned = GetPlaylists(items);
+  expected = {800u, 802u, 804u, 806u, 808u, 810u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
 // There is no play-all playlist, nor any consecutive groups of playlists (of the correct number)
 // There are only n playlists of the appropriate l length, so the assumption is these map to episodes
 // in ascending numerical order.

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -10,6 +10,7 @@
 #include "FileItemList.h"
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "cores/VideoPlayer/Interface/StreamInfo.h"
 #include "filesystem/DiscDirectoryHelper.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
@@ -61,7 +62,9 @@ PlaylistInformation MakePlaylist(unsigned int playlist,
                                  std::chrono::milliseconds duration,
                                  std::vector<unsigned int> clips,
                                  std::vector<std::chrono::milliseconds> chapterDurations,
-                                 std::string languages = "")
+                                 std::string languages = "",
+                                 std::vector<AudioStreamInfo> audioStreams = {},
+                                 std::vector<SubtitleStreamInfo> pgStreams = {})
 {
   PlaylistInformation info;
   info.playlist = playlist;
@@ -69,6 +72,27 @@ PlaylistInformation MakePlaylist(unsigned int playlist,
   info.clips = std::move(clips);
   info.chapters = std::move(chapterDurations);
   info.languages = std::move(languages);
+  info.audioStreams = std::move(audioStreams);
+  info.pgStreams = std::move(pgStreams);
+  return info;
+}
+
+// A channel count of zero means unknown, as it is when a clip's stream map is unavailable
+AudioStreamInfo MakeAudioStream(std::string codecName, std::string language, int channels = 0)
+{
+  AudioStreamInfo info;
+  info.valid = true;
+  info.codecName = std::move(codecName);
+  info.language = std::move(language);
+  info.channels = channels;
+  return info;
+}
+
+SubtitleStreamInfo MakeSubtitleStream(std::string language)
+{
+  SubtitleStreamInfo info;
+  info.valid = true;
+  info.language = std::move(language);
   return info;
 }
 
@@ -177,13 +201,13 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_EmptyInputs)
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, {}, {}));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, {}));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, {}, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 }
 
 TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_AllPlaylistsBelowMinEpisodeDuration)
@@ -200,15 +224,15 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_AllPlaylistsBelowMinEpisodeD
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                              playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 1);
+  ASSERT_EQ(items.Size(), 1);
   EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 800);
 }
 
@@ -235,7 +259,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_SingleEpisode_OnePlaylist)
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -244,12 +268,12 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_SingleEpisode_OnePlaylist)
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 1);
+  ASSERT_EQ(items.Size(), 1);
   EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 800);
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 1);
+  ASSERT_EQ(items.Size(), 1);
   EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 800);
 }
 
@@ -278,7 +302,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_SingleEpisode_MultiplePlayli
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -287,12 +311,12 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_SingleEpisode_MultiplePlayli
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 1);
+  ASSERT_EQ(items.Size(), 1);
   EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 800);
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 4);
+  ASSERT_EQ(items.Size(), 4);
   const auto returned{GetPlaylists(items)};
   const std::set<unsigned int> expected{1u, 10u, 100u, 800u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -323,7 +347,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_SingleEpisode_MultiplePlayli
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -332,14 +356,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_SingleEpisode_MultiplePlayli
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 2);
+  ASSERT_EQ(items.Size(), 2);
   auto returned{GetPlaylists(items)};
   std::set<unsigned int> expected{100u, 800u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 4);
+  ASSERT_EQ(items.Size(), 4);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -379,7 +403,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_SingleEpisode_MultiplePlayli
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 2, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -388,14 +412,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_SingleEpisode_MultiplePlayli
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 2);
+  ASSERT_EQ(items.Size(), 2);
   returned = GetPlaylists(items);
   expected = {100u, 800u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 4);
+  ASSERT_EQ(items.Size(), 4);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -449,7 +473,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist)
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -460,14 +484,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist)
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 3);
   returned = GetPlaylists(items);
   expected = {800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 6);
+  ASSERT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -525,7 +549,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_WithSpecial)
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 4, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -536,14 +560,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_WithSpecial)
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 3);
   returned = GetPlaylists(items);
   expected = {800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 6);
+  ASSERT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -595,7 +619,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips)
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -606,14 +630,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips)
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 3);
   returned = GetPlaylists(items);
   expected = {800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 6);
+  ASSERT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -665,7 +689,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2)
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -676,14 +700,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2)
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 3);
   returned = GetPlaylists(items);
   expected = {800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 6);
+  ASSERT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -736,7 +760,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2a
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -747,14 +771,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2a
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 3);
   returned = GetPlaylists(items);
   expected = {800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 6);
+  ASSERT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -817,7 +841,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2b
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 4, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -828,14 +852,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips2b
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 4);
+  ASSERT_EQ(items.Size(), 4);
   returned = GetPlaylists(items);
   expected = {800u, 802u, 804u, 806u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 7);
+  ASSERT_EQ(items.Size(), 7);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u, 802u, 804u, 806u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -888,7 +912,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips3)
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -899,14 +923,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraClips3)
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 3);
   returned = GetPlaylists(items);
   expected = {800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 6);
+  ASSERT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -960,7 +984,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraIndivid
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -971,14 +995,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_ExtraIndivid
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 3);
   returned = GetPlaylists(items);
   expected = {800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 6);
+  ASSERT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -1018,15 +1042,15 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail)
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 5);
+  ASSERT_EQ(items.Size(), 5);
   auto returned{GetPlaylists(items)};
   std::set<unsigned int> expected{100u, 800u, 802u, 804u,
                                   900u}; // 100u included as not a valid play-all playlist
@@ -1034,7 +1058,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail)
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 7);
+  ASSERT_EQ(items.Size(), 7);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u, 802u, 804u, 900u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -1077,15 +1101,15 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail2)
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 5);
+  ASSERT_EQ(items.Size(), 5);
   auto returned{GetPlaylists(items)};
   std::set<unsigned int> expected{100u, 800u, 802u, 804u,
                                   900u}; // 100u included as not a valid play-all playlist
@@ -1093,7 +1117,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail2)
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 7);
+  ASSERT_EQ(items.Size(), 7);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u, 802u, 804u, 900u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -1136,15 +1160,15 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail3)
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 4);
+  ASSERT_EQ(items.Size(), 4);
   auto returned{GetPlaylists(items)};
   std::set<unsigned int> expected{100u, 800u, 802u,
                                   804u}; // 100u included as not a valid play-all playlist
@@ -1152,7 +1176,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail3)
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 6);
+  ASSERT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 100u, 800u, 802u, 804u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -1165,7 +1189,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_PlayAllPlaylist_Fail3)
 // Disc has a play-all playlist (clips shared with individual episode playlists)
 // Playlist 600 = play-all; 601-608 = episodes 1-8
 // Clip layout is more complex and fails PlayAllPlaylist method
-// Similar to the Last Airbender (2005) Bluray S1D1
+// Similar to the Avatar The Last Airbender (2005) Bluray S1D1
 TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist)
 {
   CDiscDirectoryHelper helper;
@@ -1226,7 +1250,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist)
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 8, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -1237,86 +1261,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist)
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 9);
+  ASSERT_EQ(items.Size(), 9);
   returned = GetPlaylists(items);
   expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 9);
-  returned = GetPlaylists(items);
-  expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
-  EXPECT_TRUE(std::ranges::includes(returned, expected));
-}
-
-// Disc has a play-all playlist (clips shared with individual episode playlists)
-// Playlist 600 = play-all; 601-607 = episodes 1-7
-// Clip layout is more complex and fails PlayAllPlaylist method
-// Fail as only 7 episodes and 9 playlists in the group
-TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_Fail)
-{
-  CDiscDirectoryHelper helper;
-  CURL url("bluray://test/");
-  CFileItemList items;
-  CFileItemList allTitles;
-  Episodes episodes{
-      MakeEpisode(1, 1, 2400), // 40 minutes
-      MakeEpisode(1, 2, 2400), MakeEpisode(1, 3, 2400), MakeEpisode(1, 4, 2400),
-      MakeEpisode(1, 5, 2400), MakeEpisode(1, 6, 2400), MakeEpisode(1, 7, 2400),
-  };
-
-  PlaylistMap playlists{
-      {600u, MakePlaylist(600u, 19411s,
-                          {1100u, 1000u, 1001u, 1002u, 1003u, 1004u, 1005u, 1006u, 1007u, 1008u,
-                           1009u, 1010u, 1011u, 1012u, 1013u, 1014u},
-                          {1s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s,
-                           30s, 2400s, 30s, 2400s})},
-      {601u, MakePlaylist(601u, 2401s, {1100u, 1000u}, {1s, 2400s})},
-      {602u, MakePlaylist(602u, 2431s, {1100u, 1001u, 1002u}, {1s, 30s, 2400s})},
-      {603u, MakePlaylist(603u, 2431s, {1100u, 1003u, 1004u}, {1s, 30s, 2400s})},
-      {604u, MakePlaylist(604u, 2431s, {1100u, 1005u, 1006u}, {1s, 30s, 2400s})},
-      {605u, MakePlaylist(605u, 2431s, {1100u, 1007u, 1008u}, {1s, 30s, 2400s})},
-      {606u, MakePlaylist(606u, 2431s, {1100u, 1009u, 1010u}, {1s, 30s, 2400s})},
-      {607u, MakePlaylist(607u, 2431s, {1100u, 1011u, 1012u}, {1s, 30s, 2400s})},
-      {608u, MakePlaylist(608u, 2431s, {1100u, 1013u, 1014u}, {1s, 30s, 2400s})}};
-  ClipMap clips{
-      {1000u, MakeClip(2400s, {600u, 601u})},
-      {1001u, MakeClip(30s, {600u, 602u})},
-      {1002u, MakeClip(2400s, {600u, 602u})},
-      {1003u, MakeClip(30s, {600u, 603u})},
-      {1004u, MakeClip(2400s, {600u, 603u})},
-      {1005u, MakeClip(30s, {600u, 604u})},
-      {1006u, MakeClip(2400s, {600u, 604u})},
-      {1007u, MakeClip(30s, {600u, 605u})},
-      {1008u, MakeClip(2400s, {600u, 605u})},
-      {1009u, MakeClip(30s, {600u, 606u})},
-      {1010u, MakeClip(2400s, {600u, 606u})},
-      {1011u, MakeClip(30s, {600u, 607u})},
-      {1012u, MakeClip(2400s, {600u, 607u})},
-      {1013u, MakeClip(30s, {600u, 608u})},
-      {1014u, MakeClip(2400s, {600u, 608u})},
-      {1100u, MakeClip(1s, {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u})},
-  };
-  ASSERT_TRUE(Validate(clips, playlists));
-
-  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
-
-  EXPECT_FALSE(
-      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
-
-  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
-                                            playlists));
-  EXPECT_EQ(items.Size(), 9);
-  auto returned{GetPlaylists(items)};
-  std::set<unsigned int> expected{600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
-  EXPECT_TRUE(std::ranges::includes(returned, expected));
-
-  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
-                                            playlists));
-  EXPECT_EQ(items.Size(), 9);
+  ASSERT_EQ(items.Size(), 9);
   returned = GetPlaylists(items);
   expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -1324,10 +1276,10 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_Fail)
 
 // Disc has a play-all playlist (clips shared with individual episode playlists)
 // Playlist 600 = play-all; 601-608 = episodes 1-8
-// Clip layout is more complex and fails PlayAllPlaylist method
-// Fail as the playlist durations don't add up to the total duration of the first (play-all) playlist
-// Second playlist 602 is too long
-TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_Fail2)
+// Playlist 250 has the same duration and clips as episode playlist 605, but a different
+// set of languages - so both should be offered for episode 5
+// Similar to Avatar The Last Airbender (2005) Bluray S2D2
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_IdenticalPlaylist)
 {
   CDiscDirectoryHelper helper;
   CURL url("bluray://test/");
@@ -1341,145 +1293,402 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_Fail2
   };
 
   PlaylistMap playlists{
+      {250u, MakePlaylist(250u, 2431s, {1100u, 1007u, 1008u}, {1s, 30s, 2400s}, "eng")},
       {600u, MakePlaylist(600u, 19411s,
-                          {1100u, 1000u, 1001u, 1022u, 1003u, 1004u, 1005u, 1006u, 1007u, 1008u,
+                          {1100u, 1000u, 1001u, 1002u, 1003u, 1004u, 1005u, 1006u, 1007u, 1008u,
                            1009u, 1010u, 1011u, 1012u, 1013u, 1014u},
                           {1s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s,
                            30s, 2400s, 30s, 2400s})},
       {601u, MakePlaylist(601u, 2401s, {1100u, 1000u}, {1s, 2400s})},
-      {602u, MakePlaylist(602u, 4431s, {1100u, 1001u, 1002u}, {1s, 30s, 4400s})},
+      {602u, MakePlaylist(602u, 2431s, {1100u, 1001u, 1002u}, {1s, 30s, 2400s})},
       {603u, MakePlaylist(603u, 2431s, {1100u, 1003u, 1004u}, {1s, 30s, 2400s})},
       {604u, MakePlaylist(604u, 2431s, {1100u, 1005u, 1006u}, {1s, 30s, 2400s})},
-      {605u, MakePlaylist(605u, 2431s, {1100u, 1007u, 1008u}, {1s, 30s, 2400s})},
+      {605u, MakePlaylist(605u, 2431s, {1100u, 1007u, 1008u}, {1s, 30s, 2400s}, "eng,spa,fra")},
       {606u, MakePlaylist(606u, 2431s, {1100u, 1009u, 1010u}, {1s, 30s, 2400s})},
       {607u, MakePlaylist(607u, 2431s, {1100u, 1011u, 1012u}, {1s, 30s, 2400s})},
       {608u, MakePlaylist(608u, 2431s, {1100u, 1013u, 1014u}, {1s, 30s, 2400s})}};
   ClipMap clips{
       {1000u, MakeClip(2400s, {600u, 601u})},
       {1001u, MakeClip(30s, {600u, 602u})},
-      {1002u, MakeClip(4400s, {602u})},
+      {1002u, MakeClip(2400s, {600u, 602u})},
       {1003u, MakeClip(30s, {600u, 603u})},
       {1004u, MakeClip(2400s, {600u, 603u})},
       {1005u, MakeClip(30s, {600u, 604u})},
       {1006u, MakeClip(2400s, {600u, 604u})},
-      {1007u, MakeClip(30s, {600u, 605u})},
-      {1008u, MakeClip(2400s, {600u, 605u})},
+      {1007u, MakeClip(30s, {250u, 600u, 605u})},
+      {1008u, MakeClip(2400s, {250u, 600u, 605u})},
       {1009u, MakeClip(30s, {600u, 606u})},
       {1010u, MakeClip(2400s, {600u, 606u})},
       {1011u, MakeClip(30s, {600u, 607u})},
       {1012u, MakeClip(2400s, {600u, 607u})},
       {1013u, MakeClip(30s, {600u, 608u})},
       {1014u, MakeClip(2400s, {600u, 608u})},
-      {1022u, MakeClip(2400s, {600u})},
-      {1100u, MakeClip(1s, {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u})},
+      {1100u, MakeClip(1s, {250u, 600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u})},
   };
   ASSERT_TRUE(Validate(clips, playlists));
 
-  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  // Episode 5 (playlist 605) has two playlists - 605 and its identical (different languages) twin 250
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 4, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 2);
+  // Most languages first
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 605u);
+  EXPECT_EQ(GetPlaylistFromPath(items[1]->GetPath()), 250u);
 
-  EXPECT_FALSE(
-      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
-
-  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
-                                            playlists));
-  EXPECT_EQ(items.Size(), 9);
-  auto returned{GetPlaylists(items)};
-  std::set<unsigned int> expected{600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
-  EXPECT_TRUE(std::ranges::includes(returned, expected));
-
-  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
-                                            playlists));
-  EXPECT_EQ(items.Size(), 9);
-  returned = GetPlaylists(items);
-  expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
-  EXPECT_TRUE(std::ranges::includes(returned, expected));
-}
-
-// Disc has a play-all playlist (clips shared with individual episode playlists)
-// Playlist 600 = play-all; 601-603 = episodes 1-3; 604 = episodes 4 and 5; 605-608 = episodes 6-9
-// Clip layout is more complex and fails PlayAllPlaylist method
-// Nine episodes accounted for by eight playlists, all of the same duration bar the double episode
-// Similar to the Last Airbender (2005) Bluray S2D2
-TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithDoubleEpisode2)
-{
-  CDiscDirectoryHelper helper;
-  CURL url("bluray://test/");
-  CFileItemList items;
-  CFileItemList allTitles;
-  Episodes episodes{
-      MakeEpisode(1, 1, 2400), // 40 minutes
-      MakeEpisode(1, 2, 2400), MakeEpisode(1, 3, 2400), MakeEpisode(1, 4, 2400),
-      MakeEpisode(1, 5, 2400), MakeEpisode(1, 6, 2400), MakeEpisode(1, 7, 2400),
-      MakeEpisode(1, 8, 2400), MakeEpisode(1, 9, 2400),
-  };
-
-  PlaylistMap playlists{
-      {600u, MakePlaylist(600u, 21602s,
-                          {1100u, 1000u, 1001u, 1002u, 1003u, 1010u, 1011u, 1012u, 1013u, 1014u},
-                          {1s, 2400s, 2400s, 2400s, 30s, 4771s, 2400s, 2400s, 2400s, 2400s})},
-      {601u, MakePlaylist(601u, 2401s, {1100u, 1000u}, {1s, 2400s})},
-      {602u, MakePlaylist(602u, 2401s, {1100u, 1001u}, {1s, 2400s})},
-      {603u, MakePlaylist(603u, 2401s, {1100u, 1002u}, {1s, 2400s})},
-      {604u, MakePlaylist(604u, 4802s, {1100u, 1003u, 1010u}, {1s, 30s, 4771s})}, // Double episode
-      {605u, MakePlaylist(605u, 2401s, {1100u, 1011u}, {1s, 2400s})},
-      {606u, MakePlaylist(606u, 2401s, {1100u, 1012u}, {1s, 2400s})},
-      {607u, MakePlaylist(607u, 2401s, {1100u, 1013u}, {1s, 2400s})},
-      {608u, MakePlaylist(608u, 2401s, {1100u, 1014u}, {1s, 2400s})},
-      {1004u, MakePlaylist(1004u, 1s, {1100u}, {1s})},
-      {1006u, MakePlaylist(1006u, 30s, {1003u}, {30s})},
-  };
-  ClipMap clips{
-      {1000u, MakeClip(2400s, {600u, 601u})},
-      {1001u, MakeClip(2400s, {600u, 602u})},
-      {1002u, MakeClip(2400s, {600u, 603u})},
-      {1003u, MakeClip(30s, {600u, 604u, 1006u})},
-      {1010u, MakeClip(4771s, {600u, 604u})},
-      {1011u, MakeClip(2400s, {600u, 605u})},
-      {1012u, MakeClip(2400s, {600u, 606u})},
-      {1013u, MakeClip(2400s, {600u, 607u})},
-      {1014u, MakeClip(2400s, {600u, 608u})},
-      {1100u, MakeClip(1s, {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u, 1004u})},
-  };
-  ASSERT_TRUE(Validate(clips, playlists));
-
-  static constexpr std::array<unsigned int, 9> expectedPlaylists{601u, 602u, 603u, 604u, 604u,
+  // Other episodes are unaffected
+  static constexpr std::array<unsigned int, 8> expectedPlaylists{601u, 602u, 603u, 604u,
                                                                  605u, 606u, 607u, 608u};
   for (int episodeIndex = 0; episodeIndex < static_cast<int>(expectedPlaylists.size());
        ++episodeIndex)
   {
+    if (episodeIndex == 4)
+      continue; // Two playlists, checked above
+
     EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, episodeIndex, episodes, clips,
                                            playlists));
     ASSERT_EQ(items.Size(), 1);
     EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), expectedPlaylists[episodeIndex]);
   }
 
-  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 9, episodes, clips,
-                                          playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
-
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
-  ASSERT_EQ(items.Size(),
-            8); // 604 is only returned once as it's the same playlist for episodes 4 and 5
+  ASSERT_EQ(items.Size(), 9); // All episodes
   auto returned{GetPlaylists(items)};
-  std::set<unsigned int> expected{601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  std::set<unsigned int> expected{250u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 9);
+  ASSERT_EQ(items.Size(), 10);
   returned = GetPlaylists(items);
-  expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  expected = {250u, 600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 11);
+  ASSERT_EQ(items.Size(), 10);
   returned = GetPlaylists(items);
-  expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u, 1004u, 1006u};
+  expected = {250u, 600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+namespace
+{
+// The disc of the GetEpisodePlaylists_IdenticalPlaylist_* tests below.
+// Playlist 600 = play-all; 601-603 = episodes 1-3
+// Playlist 650 has the same duration and clip as episode playlist 602, differing only in the
+// streams it offers. episodeAudioStreams overrides those of 602 where a test needs them to differ.
+PlaylistMap MakeIdenticalPlaylistDisc(PlaylistInformation twin,
+                                      std::vector<AudioStreamInfo> episodeAudioStreams = {})
+{
+  if (episodeAudioStreams.empty())
+    episodeAudioStreams = {MakeAudioStream("truehd", "eng"), MakeAudioStream("ac3", "spa"),
+                           MakeAudioStream("ac3", "fra")};
+
+  return PlaylistMap{
+      {600u, MakePlaylist(600u, 7200s, {1000u, 1001u, 1002u}, {2400s, 2400s, 2400s})},
+      {601u, MakePlaylist(601u, 2400s, {1000u}, {2400s})},
+      {602u,
+       MakePlaylist(602u, 2400s, {1001u}, {2400s}, "eng,spa,fra", std::move(episodeAudioStreams),
+                    {MakeSubtitleStream("eng"), MakeSubtitleStream("spa"),
+                     MakeSubtitleStream("fra"), MakeSubtitleStream("jpn")})},
+      {603u, MakePlaylist(603u, 2400s, {1002u}, {2400s})},
+      {650u, std::move(twin)}};
+}
+
+ClipMap MakeIdenticalPlaylistDiscClips()
+{
+  return ClipMap{{1000u, MakeClip(2400s, {600u, 601u})},
+                 {1001u, MakeClip(2400s, {600u, 602u, 650u})},
+                 {1002u, MakeClip(2400s, {600u, 603u})}};
+}
+
+Episodes MakeThreeEpisodes()
+{
+  return Episodes{MakeEpisode(1, 1, 2400), // 40 minutes
+                  MakeEpisode(1, 2, 2400), MakeEpisode(1, 3, 2400)};
+}
+} // namespace
+
+// Playlist 250 offers only streams that episode playlist 602 also offers - and lists them in a
+// different order - so it is a reduced presentation of the same content rather than an alternative,
+// and only 602 should be offered for episode 2
+// Similar to Dune Prophecy (2024) Bluray S1D3
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_IdenticalPlaylist_ReducedStreamsIgnored)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeThreeEpisodes()};
+
+  PlaylistMap playlists{MakeIdenticalPlaylistDisc(
+      MakePlaylist(650u, 2400s, {1001u}, {2400s}, "eng", {MakeAudioStream("truehd", "eng")},
+                   {MakeSubtitleStream("jpn"), MakeSubtitleStream("eng")}))};
+  ClipMap clips{MakeIdenticalPlaylistDiscClips()};
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 602u);
+
+  // Every episode has a single playlist
+  EXPECT_TRUE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 3);
+  const std::set<unsigned int> expected{601u, 602u, 603u};
+  EXPECT_EQ(GetPlaylists(items), expected);
+}
+
+// Playlist 250 offers a Japanese audio stream that episode playlist 602 does not, so it is a
+// genuine alternative and both should be offered for episode 2
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_IdenticalPlaylist_AlternativeStreamsOffered)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeThreeEpisodes()};
+
+  PlaylistMap playlists{MakeIdenticalPlaylistDisc(MakePlaylist(650u, 2400s, {1001u}, {2400s}, "jpn",
+                                                               {MakeAudioStream("truehd", "jpn")},
+                                                               {MakeSubtitleStream("eng")}))};
+  ClipMap clips{MakeIdenticalPlaylistDiscClips()};
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 2);
+  // Most languages first
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 602u);
+  EXPECT_EQ(GetPlaylistFromPath(items[1]->GetPath()), 650u);
+}
+
+// Playlist 650 offers English in a lossier codec than episode playlist 602, and no subtitles, so it
+// carries nothing 602 does not and only 602 should be offered for episode 2
+// Similar to Avatar the Last Airbender (2005) Bluray S3D3, where the individual episode playlists
+// are AC-3 English only against the play-all group's DTS-HD MA English plus Spanish and French
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_IdenticalPlaylist_LossierCodecIgnored)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeThreeEpisodes()};
+
+  PlaylistMap playlists{MakeIdenticalPlaylistDisc(
+      MakePlaylist(650u, 2400s, {1001u}, {2400s}, "eng", {MakeAudioStream("ac3", "eng")}))};
+  ClipMap clips{MakeIdenticalPlaylistDiscClips()};
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 602u);
+}
+
+// Playlist 650 offers English in a better codec than episode playlist 602, so it is a genuine
+// alternative even though it offers fewer languages, and both should be offered for episode 2
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_IdenticalPlaylist_BetterCodecOffered)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeThreeEpisodes()};
+
+  PlaylistMap playlists{MakeIdenticalPlaylistDisc(MakePlaylist(
+      650u, 2400s, {1001u}, {2400s}, "eng", {MakeAudioStream("truehd_atmos", "eng")}))};
+  ClipMap clips{MakeIdenticalPlaylistDiscClips()};
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 2);
+  const std::set<unsigned int> expected{602u, 650u};
+  EXPECT_EQ(GetPlaylists(items), expected);
+}
+
+// A playlist offering a language the candidate carries in a better codec, alongside one the
+// candidate does not carry at all, is a genuine alternative and both should be offered for
+// episode 2
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_IdenticalPlaylist_LossierCodecExtraLanguage)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeThreeEpisodes()};
+
+  PlaylistMap playlists{MakeIdenticalPlaylistDisc(
+      MakePlaylist(650u, 2400s, {1001u}, {2400s}, "eng,jpn",
+                   {MakeAudioStream("ac3", "eng"), MakeAudioStream("ac3", "jpn")}))};
+  ClipMap clips{MakeIdenticalPlaylistDiscClips()};
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 2);
+  const std::set<unsigned int> expected{602u, 650u};
+  EXPECT_EQ(GetPlaylists(items), expected);
+}
+
+// Playlist 650 offers English in the same codec as episode playlist 602 but in fewer channels, so
+// it carries nothing 602 does not and only 602 should be offered for episode 2.
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_IdenticalPlaylist_FewerChannelsIgnored)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeThreeEpisodes()};
+
+  PlaylistMap playlists{MakeIdenticalPlaylistDisc(
+      MakePlaylist(650u, 2400s, {1001u}, {2400s}, "eng", {MakeAudioStream("truehd", "eng", 2)}),
+      {MakeAudioStream("truehd", "eng", 6), MakeAudioStream("ac3", "spa", 6),
+       MakeAudioStream("ac3", "fra", 6)})};
+  ClipMap clips{MakeIdenticalPlaylistDiscClips()};
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 602u);
+}
+
+// Playlist 650 offers English in more channels than episode playlist 602, so it is a genuine
+// alternative and both should be offered for episode 2
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_IdenticalPlaylist_MoreChannelsOffered)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeThreeEpisodes()};
+
+  PlaylistMap playlists{MakeIdenticalPlaylistDisc(
+      MakePlaylist(650u, 2400s, {1001u}, {2400s}, "eng", {MakeAudioStream("truehd", "eng", 8)}),
+      {MakeAudioStream("truehd", "eng", 6), MakeAudioStream("ac3", "spa", 6),
+       MakeAudioStream("ac3", "fra", 6)})};
+  ClipMap clips{MakeIdenticalPlaylistDiscClips()};
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 2);
+  const std::set<unsigned int> expected{602u, 650u};
+  EXPECT_EQ(GetPlaylists(items), expected);
+}
+
+// Playlist 650's channel count is unknown, as it is when a clip's stream map is unavailable, so
+// nothing can be concluded from it and only the codec decides - leaving 650 a reduced presentation
+// of episode playlist 602
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_IdenticalPlaylist_UnknownChannelsIgnored)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeThreeEpisodes()};
+
+  PlaylistMap playlists{MakeIdenticalPlaylistDisc(
+      MakePlaylist(650u, 2400s, {1001u}, {2400s}, "eng", {MakeAudioStream("truehd", "eng")}),
+      {MakeAudioStream("truehd", "eng", 6), MakeAudioStream("ac3", "spa", 6),
+       MakeAudioStream("ac3", "fra", 6)})};
+  ClipMap clips{MakeIdenticalPlaylistDiscClips()};
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 602u);
+}
+
+// A playlist offering the same stream twice is not a reduced presentation of one offering it once,
+// so both should be offered for episode 2
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_IdenticalPlaylist_RepeatedStreamOffered)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeThreeEpisodes()};
+
+  PlaylistMap playlists{MakeIdenticalPlaylistDisc(
+      MakePlaylist(650u, 2400s, {1001u}, {2400s}, "eng,eng",
+                   {MakeAudioStream("truehd", "eng"), MakeAudioStream("truehd", "eng")},
+                   {MakeSubtitleStream("eng")}))};
+  ClipMap clips{MakeIdenticalPlaylistDiscClips()};
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 2);
+  const std::set<unsigned int> expected{650u, 602u};
+  EXPECT_EQ(GetPlaylists(items), expected);
+}
+
+// Where two playlists of the same duration are candidates for one episode, the one with the most
+// chapters is preferred. Both offer the same languages, so neither is offered as an alternative to
+// the other.
+// Playlist 600 = play-all; 601-603 = episodes 1-3; playlist 650 shares episode 2's clip
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_TwoCandidates_MostChaptersPreferred)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeThreeEpisodes()};
+
+  const auto MakeDisc{
+      [](std::vector<std::chrono::milliseconds> chapters602,
+         std::vector<std::chrono::milliseconds> chapters650)
+      {
+        return PlaylistMap{
+            {600u, MakePlaylist(600u, 7200s, {1000u, 1001u, 1002u}, {2400s, 2400s, 2400s})},
+            {601u, MakePlaylist(601u, 2400s, {1000u}, {2400s})},
+            {602u, MakePlaylist(602u, 2400s, {1001u}, std::move(chapters602), "eng")},
+            {603u, MakePlaylist(603u, 2400s, {1002u}, {2400s})},
+            {650u, MakePlaylist(650u, 2400s, {1001u}, std::move(chapters650), "eng")}};
+      }};
+  ClipMap clips{{1000u, MakeClip(2400s, {600u, 601u})},
+                {1001u, MakeClip(2400s, {600u, 602u, 650u})},
+                {1002u, MakeClip(2400s, {600u, 603u})}};
+
+  // Playlist 602 has the most chapters
+  PlaylistMap playlists{MakeDisc({1200s, 1200s}, {2400s})};
+  ASSERT_TRUE(Validate(clips, playlists));
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 602u);
+
+  // Playlist 650 has the most chapters
+  playlists = MakeDisc({2400s}, {1200s, 1200s});
+  ASSERT_TRUE(Validate(clips, playlists));
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 650u);
+}
+
+// The group method carries the clips and languages of each grouped playlist, so an identical
+// playlist is offered on a disc with no play-all playlist too.
+// Playlists 601-603 = episodes 1-3; playlist 650 has the same duration and clip as episode
+// playlist 602 but offers a Japanese audio stream that 602 does not
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_GroupMethod_IdenticalPlaylist)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{MakeThreeEpisodes()};
+
+  PlaylistMap playlists{
+      {601u, MakePlaylist(601u, 2400s, {1000u}, {2400s})},
+      {602u, MakePlaylist(602u, 2400s, {1001u}, {2400s}, "eng", {MakeAudioStream("truehd", "eng")},
+                          {MakeSubtitleStream("eng")})},
+      {603u, MakePlaylist(603u, 2400s, {1002u}, {2400s})},
+      {650u, MakePlaylist(650u, 2400s, {1001u}, {2400s}, "jpn", {MakeAudioStream("truehd", "jpn")},
+                          {MakeSubtitleStream("eng")})}};
+  ClipMap clips{{1000u, MakeClip(2400s, {601u})},
+                {1001u, MakeClip(2400s, {602u, 650u})},
+                {1002u, MakeClip(2400s, {603u})}};
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(helper.GetEpisodePlaylists(url, items, allTitles, 1, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 2);
+  const std::set<unsigned int> expected{602u, 650u};
+  EXPECT_EQ(GetPlaylists(items), expected);
 }
 
 // Disc has a play-all playlist (clips shared with individual episode playlists)
@@ -1544,7 +1753,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithF
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 5, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -1552,6 +1761,153 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithF
             2); // 602 is only returned once as it's the same playlist for episodes 18-21
   const auto returned{GetPlaylists(items)};
   const std::set<unsigned int> expected{601u, 602u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// Disc has a play-all playlist (clips shared with individual episode playlists)
+// Playlist 600 = play-all; 601-607 = episodes 1-7
+// Clip layout is more complex and fails PlayAllPlaylist method
+// Fail as only 7 episodes and 9 playlists in the group
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_Fail)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 1, 2400), // 40 minutes
+      MakeEpisode(1, 2, 2400), MakeEpisode(1, 3, 2400), MakeEpisode(1, 4, 2400),
+      MakeEpisode(1, 5, 2400), MakeEpisode(1, 6, 2400), MakeEpisode(1, 7, 2400),
+  };
+
+  PlaylistMap playlists{
+      {600u, MakePlaylist(600u, 19411s,
+                          {1100u, 1000u, 1001u, 1002u, 1003u, 1004u, 1005u, 1006u, 1007u, 1008u,
+                           1009u, 1010u, 1011u, 1012u, 1013u, 1014u},
+                          {1s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s,
+                           30s, 2400s, 30s, 2400s})},
+      {601u, MakePlaylist(601u, 2401s, {1100u, 1000u}, {1s, 2400s})},
+      {602u, MakePlaylist(602u, 2431s, {1100u, 1001u, 1002u}, {1s, 30s, 2400s})},
+      {603u, MakePlaylist(603u, 2431s, {1100u, 1003u, 1004u}, {1s, 30s, 2400s})},
+      {604u, MakePlaylist(604u, 2431s, {1100u, 1005u, 1006u}, {1s, 30s, 2400s})},
+      {605u, MakePlaylist(605u, 2431s, {1100u, 1007u, 1008u}, {1s, 30s, 2400s})},
+      {606u, MakePlaylist(606u, 2431s, {1100u, 1009u, 1010u}, {1s, 30s, 2400s})},
+      {607u, MakePlaylist(607u, 2431s, {1100u, 1011u, 1012u}, {1s, 30s, 2400s})},
+      {608u, MakePlaylist(608u, 2431s, {1100u, 1013u, 1014u}, {1s, 30s, 2400s})}};
+  ClipMap clips{
+      {1000u, MakeClip(2400s, {600u, 601u})},
+      {1001u, MakeClip(30s, {600u, 602u})},
+      {1002u, MakeClip(2400s, {600u, 602u})},
+      {1003u, MakeClip(30s, {600u, 603u})},
+      {1004u, MakeClip(2400s, {600u, 603u})},
+      {1005u, MakeClip(30s, {600u, 604u})},
+      {1006u, MakeClip(2400s, {600u, 604u})},
+      {1007u, MakeClip(30s, {600u, 605u})},
+      {1008u, MakeClip(2400s, {600u, 605u})},
+      {1009u, MakeClip(30s, {600u, 606u})},
+      {1010u, MakeClip(2400s, {600u, 606u})},
+      {1011u, MakeClip(30s, {600u, 607u})},
+      {1012u, MakeClip(2400s, {600u, 607u})},
+      {1013u, MakeClip(30s, {600u, 608u})},
+      {1014u, MakeClip(2400s, {600u, 608u})},
+      {1100u, MakeClip(1s, {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 0);
+
+  EXPECT_FALSE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 9);
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 9);
+  returned = GetPlaylists(items);
+  expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+}
+
+// Disc has a play-all playlist (clips shared with individual episode playlists)
+// Playlist 600 = play-all; 601-608 = episodes 1-8
+// Clip layout is more complex and fails PlayAllPlaylist method
+// Fail as the playlist durations don't add up to the total duration of the first (play-all) playlist
+// Second playlist 602 is too long
+TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_Fail2)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+  Episodes episodes{
+      MakeEpisode(1, 1, 2400), // 40 minutes
+      MakeEpisode(1, 2, 2400), MakeEpisode(1, 3, 2400), MakeEpisode(1, 4, 2400),
+      MakeEpisode(1, 5, 2400), MakeEpisode(1, 6, 2400), MakeEpisode(1, 7, 2400),
+      MakeEpisode(1, 8, 2400),
+  };
+
+  PlaylistMap playlists{
+      {600u, MakePlaylist(600u, 19411s,
+                          {1100u, 1000u, 1001u, 1022u, 1003u, 1004u, 1005u, 1006u, 1007u, 1008u,
+                           1009u, 1010u, 1011u, 1012u, 1013u, 1014u},
+                          {1s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s, 30s, 2400s,
+                           30s, 2400s, 30s, 2400s})},
+      {601u, MakePlaylist(601u, 2401s, {1100u, 1000u}, {1s, 2400s})},
+      {602u, MakePlaylist(602u, 4431s, {1100u, 1001u, 1002u}, {1s, 30s, 4400s})},
+      {603u, MakePlaylist(603u, 2431s, {1100u, 1003u, 1004u}, {1s, 30s, 2400s})},
+      {604u, MakePlaylist(604u, 2431s, {1100u, 1005u, 1006u}, {1s, 30s, 2400s})},
+      {605u, MakePlaylist(605u, 2431s, {1100u, 1007u, 1008u}, {1s, 30s, 2400s})},
+      {606u, MakePlaylist(606u, 2431s, {1100u, 1009u, 1010u}, {1s, 30s, 2400s})},
+      {607u, MakePlaylist(607u, 2431s, {1100u, 1011u, 1012u}, {1s, 30s, 2400s})},
+      {608u, MakePlaylist(608u, 2431s, {1100u, 1013u, 1014u}, {1s, 30s, 2400s})}};
+  ClipMap clips{
+      {1000u, MakeClip(2400s, {600u, 601u})},
+      {1001u, MakeClip(30s, {600u, 602u})},
+      {1002u, MakeClip(4400s, {602u})},
+      {1003u, MakeClip(30s, {600u, 603u})},
+      {1004u, MakeClip(2400s, {600u, 603u})},
+      {1005u, MakeClip(30s, {600u, 604u})},
+      {1006u, MakeClip(2400s, {600u, 604u})},
+      {1007u, MakeClip(30s, {600u, 605u})},
+      {1008u, MakeClip(2400s, {600u, 605u})},
+      {1009u, MakeClip(30s, {600u, 606u})},
+      {1010u, MakeClip(2400s, {600u, 606u})},
+      {1011u, MakeClip(30s, {600u, 607u})},
+      {1012u, MakeClip(2400s, {600u, 607u})},
+      {1013u, MakeClip(30s, {600u, 608u})},
+      {1014u, MakeClip(2400s, {600u, 608u})},
+      {1022u, MakeClip(2400s, {600u})},
+      {1100u, MakeClip(1s, {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 0);
+
+  EXPECT_FALSE(
+      helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
+  ASSERT_EQ(items.Size(), 0);
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 9);
+  auto returned{GetPlaylists(items)};
+  std::set<unsigned int> expected{600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
+  EXPECT_TRUE(std::ranges::includes(returned, expected));
+
+  EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
+                                            playlists));
+  ASSERT_EQ(items.Size(), 9);
+  returned = GetPlaylists(items);
+  expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 }
 
@@ -1600,22 +1956,22 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_RelaxedPlayAllPlaylist_WithD
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 9);
+  ASSERT_EQ(items.Size(), 9);
   auto returned{GetPlaylists(items)};
   std::set<unsigned int> expected{600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 11);
+  ASSERT_EQ(items.Size(), 11);
   returned = GetPlaylists(items);
   expected = {600u, 601u, 602u, 603u, 604u, 605u, 606u, 607u, 608u, 1004u, 1006u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -1666,7 +2022,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod)
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -1677,14 +2033,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod)
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 3);
   returned = GetPlaylists(items);
   expected = {800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 5);
+  ASSERT_EQ(items.Size(), 5);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -1733,7 +2089,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Lo
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -1744,14 +2100,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Lo
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 3);
   returned = GetPlaylists(items);
   expected = {800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 5);
+  ASSERT_EQ(items.Size(), 5);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -1807,7 +2163,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Wi
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 4, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -1818,14 +2174,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Wi
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 3);
   returned = GetPlaylists(items);
   expected = {800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 5);
+  ASSERT_EQ(items.Size(), 5);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -1874,7 +2230,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Lo
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -1885,14 +2241,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Lo
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 4);
+  ASSERT_EQ(items.Size(), 4);
   returned = GetPlaylists(items);
   expected = {800u, 801u, 802u, 803u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 6);
+  ASSERT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 800u, 801u, 802u, 803u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -1943,7 +2299,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Tw
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -1954,14 +2310,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Tw
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 5);
+  ASSERT_EQ(items.Size(), 5);
   returned = GetPlaylists(items);
   expected = {2u, 3u, 800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 7);
+  ASSERT_EQ(items.Size(), 7);
   returned = GetPlaylists(items);
   expected = {1u, 2u, 3u, 10u, 800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -2008,7 +2364,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_TwoEpisodes_GroupMethod_TwoG
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 2, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -2019,14 +2375,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_TwoEpisodes_GroupMethod_TwoG
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 6);
+  ASSERT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {2u, 3u, 801u, 802u, 851u, 852u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 7);
+  ASSERT_EQ(items.Size(), 7);
   returned = GetPlaylists(items);
   expected = {1u, 2u, 3u, 801u, 802u, 851u, 852u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -2061,22 +2417,22 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Fa
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 2);
+  ASSERT_EQ(items.Size(), 2);
   auto returned{GetPlaylists(items)};
   std::set<unsigned int> expected{800u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 5);
+  ASSERT_EQ(items.Size(), 5);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -2115,22 +2471,22 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Fa
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 4);
+  ASSERT_EQ(items.Size(), 4);
   auto returned{GetPlaylists(items)};
   std::set<unsigned int> expected{800u, 801u, 802u, 803u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 6);
+  ASSERT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 800u, 801u, 802u, 803u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -2188,7 +2544,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FiveEpisodes_GroupMethod_Exa
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 5, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -2199,14 +2555,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FiveEpisodes_GroupMethod_Exa
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 5);
+  ASSERT_EQ(items.Size(), 5);
   returned = GetPlaylists(items);
   expected = {0u, 1u, 2u, 7u, 8u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 5);
+  ASSERT_EQ(items.Size(), 5);
   returned = GetPlaylists(items);
   expected = {0u, 1u, 2u, 7u, 8u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -2245,22 +2601,22 @@ TEST_F(TestDiscDirectoryHelper,
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 5);
+  ASSERT_EQ(items.Size(), 5);
   auto returned{GetPlaylists(items)};
   std::set<unsigned int> expected{0u, 1u, 2u, 7u, 8u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 5);
+  ASSERT_EQ(items.Size(), 5);
   returned = GetPlaylists(items);
   expected = {0u, 1u, 2u, 7u, 8u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -2309,7 +2665,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Lo
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 3, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -2320,14 +2676,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_ThreeEpisodes_GroupMethod_Lo
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 6);
+  ASSERT_EQ(items.Size(), 6);
   returned = GetPlaylists(items);
   expected = {800u, 817u, 818u, 820u, 821u, 822u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 8);
+  ASSERT_EQ(items.Size(), 8);
   returned = GetPlaylists(items);
   expected = {800u, 811u, 812u, 817u, 818u, 820u, 821u, 822u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -2364,22 +2720,22 @@ TEST_F(TestDiscDirectoryHelper,
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 6);
+  ASSERT_EQ(items.Size(), 6);
   auto returned{GetPlaylists(items)};
   std::set<unsigned int> expected = {800u, 817u, 818u, 820u, 821u, 822u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 8);
+  ASSERT_EQ(items.Size(), 8);
   returned = GetPlaylists(items);
   expected = {800u, 811u, 812u, 817u, 818u, 820u, 821u, 822u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -2434,7 +2790,7 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FourEpisodesOneDouble_GroupM
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 4, episodes, clips,
                                           playlists)); // Invalid episode index
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
@@ -2447,14 +2803,14 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FourEpisodesOneDouble_GroupM
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 3);
   returned = GetPlaylists(items);
   expected = {800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 5);
+  ASSERT_EQ(items.Size(), 5);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -2490,22 +2846,22 @@ TEST_F(TestDiscDirectoryHelper, GetEpisodePlaylists_FourEpisodesOneDouble_GroupM
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetEpisodePlaylists(url, items, allTitles, 0, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(
       helper.GetEpisodePlaylists(url, items, allTitles, ALL_PLAYLISTS, episodes, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::MAIN, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 3);
+  ASSERT_EQ(items.Size(), 3);
   auto returned{GetPlaylists(items)};
   std::set<unsigned int> expected{800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 
   EXPECT_TRUE(helper.GetAllEpisodePlaylists(url, items, allTitles, GetTitle::ALL, episodes, clips,
                                             playlists));
-  EXPECT_EQ(items.Size(), 5);
+  ASSERT_EQ(items.Size(), 5);
   returned = GetPlaylists(items);
   expected = {1u, 10u, 800u, 801u, 802u};
   EXPECT_TRUE(std::ranges::includes(returned, expected));
@@ -2527,14 +2883,14 @@ TEST_F(TestDiscDirectoryHelper, GetMoviePlaylists_EmptyInputs)
   ASSERT_TRUE(Validate(clips, playlists));
 
   EXPECT_FALSE(helper.GetMoviePlaylists(url, items, allTitles, -1, GetTitle::SINGLE, {}, {}));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(helper.GetMoviePlaylists(url, items, allTitles, -1, GetTitle::SINGLE, clips, {}));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(
       helper.GetMoviePlaylists(url, items, allTitles, -1, GetTitle::SINGLE, {}, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 }
 
 // Single playlist above MIN_MOVIE_DURATION (30min)
@@ -2584,11 +2940,11 @@ TEST_F(TestDiscDirectoryHelper, GetMoviePlaylists_AllPlaylistsTooShort)
 
   EXPECT_FALSE(
       helper.GetMoviePlaylists(url, items, allTitles, -1, GetTitle::SINGLE, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   EXPECT_FALSE(
       helper.GetMoviePlaylists(url, items, allTitles, -1, GetTitle::MAIN, clips, playlists));
-  EXPECT_EQ(items.Size(), 0);
+  ASSERT_EQ(items.Size(), 0);
 
   // ALL job skips the duration filter, so short playlists are included
   EXPECT_TRUE(helper.GetMoviePlaylists(url, items, allTitles, -1, GetTitle::ALL, clips, playlists));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Multiple fixes. See individual commits.

Added tests.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Avatar The Last Airbender (2005) discs had some complex playlist/clip structures.

Multiple other episode (mis)-matches from logs.

Fix #28776 (part)

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally and in #28776

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
