### PR TITLE
[VideoPlayer] Snap near-standard container frame rates at demux time

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -36,6 +36,8 @@
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
 
+#include <cstdio>
+#include <cstdlib>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -1668,6 +1670,51 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
                          pStream->codecpar->field_order == AV_FIELD_BB ||
                          pStream->codecpar->field_order == AV_FIELD_TB ||
                          pStream->codecpar->field_order == AV_FIELD_BT;
+
+        // mkvmerge derives DefaultDuration as the modal frame duration when
+        // the source provides no exact rate, and Matroska block timestamps
+        // are stored at the default TimestampScale of 1ms. Real 23.976
+        // content then declares 42ms -> 500/21 = 23.810fps (29.97 -> 33ms ->
+        // 30.303, 59.94 -> 17ms -> 58.824). The wrong rate misses the
+        // resolution whitelist at playback start and the later measured-rate
+        // correction (CalcFrameRate) forces a display mode switch seconds
+        // into playback. Snap such millisecond-quantised declarations back
+        // to the standard rate; rates quantising to the same duration
+        // (23.976 vs 24) are resolved with the muxer's own statistics tags,
+        // or by preferring the fractional rate when no statistics exist (PAL
+        // rates quantise exactly and never enter this path). CalcFrameRate
+        // remains the backstop if a snap were ever wrong.
+        if (m_bMatroska && !st->interlaced && !st->bVFR)
+        {
+          double statsFps = 0.0;
+          const AVDictionaryEntry* statFrames =
+              av_dict_get(pStream->metadata, "NUMBER_OF_FRAMES", nullptr, AV_DICT_IGNORE_SUFFIX);
+          const AVDictionaryEntry* statDuration =
+              av_dict_get(pStream->metadata, "DURATION", nullptr, AV_DICT_IGNORE_SUFFIX);
+          if (statFrames && statDuration)
+          {
+            int hours = 0;
+            int minutes = 0;
+            double seconds = 0.0;
+            const int64_t frameCount = std::atoll(statFrames->value);
+            if (sscanf(statDuration->value, "%d:%d:%lf", &hours, &minutes, &seconds) == 3)
+            {
+              const double totalSeconds = hours * 3600.0 + minutes * 60.0 + seconds;
+              if (frameCount > 0 && totalSeconds > 0.0)
+                statsFps = static_cast<double>(frameCount) / totalSeconds;
+            }
+          }
+
+          const int declaredRate = st->iFpsRate;
+          const int declaredScale = st->iFpsScale;
+          if (CDVDDemuxUtils::SnapMsQuantisedFrameRate(st->iFpsRate, st->iFpsScale, statsFps))
+            CLog::Log(LOGINFO,
+                      "CDVDDemuxFFmpeg::AddStream - stream {}: snapping ms-quantised container "
+                      "fps {:.3f} ({}/{}) to {}/{} (statistics fps: {:.3f})",
+                      pStream->index,
+                      static_cast<double>(declaredRate) / declaredScale, declaredRate,
+                      declaredScale, st->iFpsRate, st->iFpsScale, statsFps);
+        }
 
         st->iWidth = pStream->codecpar->width;
         st->iHeight = pStream->codecpar->height;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
@@ -19,6 +19,7 @@ extern "C"
 }
 
 #include <algorithm>
+#include <cmath>
 
 void CDVDDemuxUtils::FreeDemuxPacket(DemuxPacket* pPacket)
 {
@@ -151,4 +152,57 @@ std::vector<ChapterFFmpeg> CDVDDemuxUtils::LoadChapters(std::span<AVChapter*> ch
     result.insert(result.begin(), ChapterFFmpeg{0ms, 0ms, ""});
 
   return result;
+}
+
+bool CDVDDemuxUtils::SnapMsQuantisedFrameRate(int& fpsRate, int& fpsScale, double hintFps)
+{
+  if (fpsRate <= 0 || fpsScale <= 0)
+    return false;
+
+  // A rate derived from a whole-millisecond frame duration reduces to
+  // exactly 1000/N (e.g. 42ms -> 500/21). Anything else is not the
+  // mkvmerge modal-duration fingerprint and is left alone.
+  const int64_t num = 1000LL * fpsScale;
+  if (num % fpsRate != 0)
+    return false;
+  const int64_t durationMs = num / fpsRate;
+
+  // Fractional NTSC rates come first per pair: they are the fallback choice
+  // when no statistics disambiguate rates quantising to the same duration.
+  static constexpr AVRational standardRates[] = {{24000, 1001}, {24, 1}, {25, 1},
+                                                 {30000, 1001}, {30, 1}, {50, 1},
+                                                 {60000, 1001}, {60, 1}};
+
+  const AVRational* fallback = nullptr;
+  const AVRational* bestHinted = nullptr;
+  double bestHintDiff = 0.005; // statistics must land within 0.5% of a candidate
+
+  for (const AVRational& rate : standardRates)
+  {
+    if (std::lround(1000.0 * rate.den / rate.num) != durationMs)
+      continue;
+    if (static_cast<int64_t>(rate.num) * fpsScale == static_cast<int64_t>(rate.den) * fpsRate)
+      return false; // declared rate already is the standard one (PAL 25 = exactly 40ms)
+
+    if (!fallback)
+      fallback = &rate;
+
+    if (hintFps > 0.0)
+    {
+      const double diff = std::fabs(hintFps - av_q2d(rate)) / av_q2d(rate);
+      if (diff <= bestHintDiff)
+      {
+        bestHintDiff = diff;
+        bestHinted = &rate;
+      }
+    }
+  }
+
+  const AVRational* chosen = hintFps > 0.0 ? bestHinted : fallback;
+  if (!chosen)
+    return false;
+
+  fpsRate = chosen->num;
+  fpsScale = chosen->den;
+  return true;
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h
@@ -36,4 +36,18 @@ public:
                                           unsigned int encryptedSubsampleCount);
   static void StoreSideData(DemuxPacket* pkt, AVPacket* src);
   static std::vector<ChapterFFmpeg> LoadChapters(std::span<AVChapter*> chapters);
+
+  /*!
+   * \brief Snap a container-declared frame rate that is exactly 1000/N fps
+   * (a whole number of milliseconds N per frame, the fingerprint of a rate
+   * derived from millisecond-quantised Matroska timestamps) to the standard
+   * rate whose millisecond-rounded frame duration equals N.
+   * \param[in,out] fpsRate frame rate numerator, rewritten on success
+   * \param[in,out] fpsScale frame rate denominator, rewritten on success
+   * \param hintFps measured rate from container statistics (frame count /
+   * duration) used to resolve rates that quantise to the same duration
+   * (23.976 vs 24); pass 0 when unknown to prefer the fractional rate
+   * \return true when the rate was rewritten
+   */
+  static bool SnapMsQuantisedFrameRate(int& fpsRate, int& fpsScale, double hintFps);
 };

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxUtils.cpp
@@ -112,3 +112,63 @@ TEST(TestDVDDemuxUtils, ReadChaptersInvalid)
   output = CDVDDemuxUtils::LoadChapters(std::span<AVChapter*>{&avcptr, 0});
   EXPECT_TRUE(output.empty());
 }
+
+struct TestSnapRate
+{
+  int inRate;
+  int inScale;
+  double hintFps;
+  bool expectSnapped;
+  int expectRate;
+  int expectScale;
+};
+
+// clang-format off
+const TestSnapRate testSnapRates[] = {
+  // 42ms header (real 23.976 quantised to whole ms): no statistics -> fractional bias
+  {500, 21, 0.0, true, 24000, 1001},
+  // statistics resolve the 42ms tie in either direction
+  {500, 21, 23.976, true, 24000, 1001},
+  {500, 21, 24.0001, true, 24, 1},
+  // statistics contradicting every candidate: leave the rate alone
+  {500, 21, 30.0, false, 500, 21},
+  {500, 21, 23.80, false, 500, 21},
+  // 33ms sibling (29.97/30) and 17ms sibling (59.94/60)
+  {1000, 33, 0.0, true, 30000, 1001},
+  {1000, 33, 30.0001, true, 30, 1},
+  {1000, 17, 0.0, true, 60000, 1001},
+  {1000, 17, 59.9401, true, 60000, 1001},
+  // PAL rates quantise to whole milliseconds exactly: already standard
+  {25, 1, 0.0, false, 25, 1},
+  {50, 1, 0.0, false, 50, 1},
+  // exact and float-rounded declarations are not 1000/N shaped
+  {24000, 1001, 0.0, false, 24000, 1001},
+  {23976, 1000, 0.0, false, 23976, 1000},
+  // near-standard but not millisecond-quantised: not the muxer fingerprint
+  {2497, 100, 0.0, false, 2497, 100},
+  // legitimate non-standard rates
+  {48, 1, 0.0, false, 48, 1},
+  {120, 1, 0.0, false, 120, 1},
+  // whole-millisecond durations that map to no standard rate
+  {1000, 41, 0.0, false, 1000, 41},
+  {1000, 8, 0.0, false, 1000, 8},
+  {20, 1, 0.0, false, 20, 1},
+};
+// clang-format on
+
+class SnapRateTester : public testing::WithParamInterface<TestSnapRate>, public testing::Test
+{
+};
+
+TEST_P(SnapRateTester, TestSnapMsQuantisedFrameRate)
+{
+  const TestSnapRate& param = GetParam();
+  int rate = param.inRate;
+  int scale = param.inScale;
+  EXPECT_EQ(param.expectSnapped,
+            CDVDDemuxUtils::SnapMsQuantisedFrameRate(rate, scale, param.hintFps));
+  EXPECT_EQ(param.expectRate, rate);
+  EXPECT_EQ(param.expectScale, scale);
+}
+
+INSTANTIATE_TEST_SUITE_P(TestDVDDemuxUtils, SnapRateTester, testing::ValuesIn(testSnapRates));


### PR DESCRIPTION
**Description**

Matroska files sometimes declare a wrong constant frame rate. The mechanism (thanks to the review below for pinning it down fully): mkvmerge derives DefaultDuration as the modal frame duration when the source provides no exact rate, and Matroska block timestamps are stored at the default TimestampScale of 1ms. Real 23.976 content muxed that way declares 42ms per frame, which avformat reduces to exactly 500/21 = 23.810fps. The same arithmetic turns 29.97 into 33ms = 30.303fps and 59.94 into 17ms = 58.824fps; PAL rates quantise to whole milliseconds exactly and never show the problem. MediaInfo derives its rate from block timestamps rather than the header, so affected files look correct there while ffprobe shows the quantised value.

With a resolution whitelist and "Adjust display refresh rate" enabled, the wrong rate matches nothing (the whitelist compares with 0.01Hz absolute tolerance), so playback starts in the GUI refresh rate. A few seconds in, `CalcFrameRate` measures the real rate and the whitelist re-match forces a display mode switch in the middle of playback: black screen, dropped frames, audio sink reopen. On passthrough setups the receiver re-locks as well, which some users then hear as desync.

This detects the muxer's fingerprint - a declared rate of exactly 1000/N fps for a whole number of milliseconds N - and snaps it to the standard rate whose millisecond-rounded duration equals N, before the first frame. That covers the 42ms, 33ms and 17ms cases alike, with no tolerance band.

Rates that quantise to the same duration (23.976 vs 24, 29.97 vs 30, 59.94 vs 60) cannot be distinguished from the header at all. They are resolved with the muxer's own statistics tags (`NUMBER_OF_FRAMES` / `DURATION`, present in mkvmerge output since v7), which separate 23.976 from 24.000 decisively over any real duration; without statistics the fractional rate is preferred as a documented bias. Statistics that contradict every candidate leave the rate untouched. Exact declarations are not 1000/N shaped and pass through unmodified, and `CalcFrameRate` stays in place as the backstop.

The decision logic is a pure function in `CDVDDemuxUtils`; the demuxer wires it up for Matroska, progressive, non-VFR streams only.

**How has this been tested?**

The snap table, both tie-break directions, the contradicting-statistics case and the leave-alone cases (exact rates, PAL, near-standard-but-not-quantised, whole-ms durations mapping to no standard rate) are covered by a gtest in `TestDVDDemuxUtils.cpp` - 19 parameterised cases.

Root cause was confirmed from a debug log of an affected setup: three playbacks, each showing the whitelist miss at start ("fps: 23.810", "No resolution matched"), the `CalcFrameRate` correction about 7 seconds in, and the mode switch right after it. The affected file carries the statistics tags, and frame count / duration works out to 23.9760.

Synthetic repro, no affected file needed: mux any 23.976 stream into mkv, then patch the video track's DefaultDuration from 41708333 to 42000000 (nanoseconds). ffprobe then reports 500/21 while MediaInfo still shows 23.976.
