### PR TITLE
[Android] Do not block on MediaCodec while dropping pictures

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -1300,7 +1300,8 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecAndroidMediaCodec::GetPicture(VideoPictur
     // try to fetch an input buffer
     if (m_indexInputBuffer < 0)
     {
-      m_indexInputBuffer = m_codec->dequeueInputBuffer(5000 /*timeout*/);
+      m_indexInputBuffer =
+          m_codec->dequeueInputBuffer((m_codecControlFlags & DVD_CODEC_CTRL_DROP) ? 0 : 5000);
       if (xbmc_jnienv()->ExceptionCheck())
       {
         xbmc_jnienv()->ExceptionDescribe();
@@ -1617,6 +1618,10 @@ int CDVDVideoCodecAndroidMediaCodec::GetOutputPicture(void)
 {
   int rtn = 0;
   int64_t timeout_us = (m_state == MEDIACODEC_STATE_WAIT_ENDOFSTREAM) ? 100000 : 10000;
+
+  if (m_codecControlFlags & DVD_CODEC_CTRL_DROP)
+    timeout_us = 0;
+
   CJNIMediaCodecBufferInfo bufferInfo;
 
   ssize_t index = m_codec->dequeueOutputBuffer(bufferInfo, timeout_us);


### PR DESCRIPTION
## Description

Pictures dropped via `DVD_CODEC_CTRL_DROP` are released without ever being rendered, so nothing
waits for them and there is no deadline to meet. `GetOutputPicture()` nevertheless blocks for up
to 10ms waiting for an output buffer, and `GetPicture()` for up to 5ms waiting for a free input
buffer. Every dropped frame therefore costs a round trip to the decoder.

This polls instead of blocking while the drop flag is set. Behaviour outside of dropping is
untouched.

## Motivation and context

This is what makes the pre-roll of an accurate seek expensive. After the demuxer lands on the
keyframe preceding the requested time, `CVideoPlayer::CheckPlayerInit()` marks every packet up to
that time as dropped. Those frames still have to go through the decoder to build the reference
chain, but not one of them is shown — and each of them pays the wait above.

On low-power Android devices the resulting freeze after a seek is very noticeable. Profiling
showed it was almost entirely waiting rather than decoding.

## How has this been tested?

MediaTek MT8696, 4x Cortex-A55 @ 2.0GHz, armeabi-v7a, `c2.mtk.avc.decoder`,
playing 1080p50 h264 through inputstream.adaptive.

The pre-roll was measured with a temporary patch logging one summary per seek. A summary rather
than per-packet logging was necessary because `CheckPlayerInit()` already logs a line per dropped
packet at debug level, and that logging alone accounts for roughly 2ms per frame — enough to
dominate what is being measured. Debug logging was off for all numbers below.

Before:

```
seek pre-roll: 213 frames in 2185.1 ms - AddData 344.1 ms, GetPicture 1061.8 ms  (10.26 ms/frame)
seek pre-roll: 215 frames in 2352.3 ms - AddData 422.6 ms, GetPicture 1157.0 ms  (10.94 ms/frame)
```

After:

```
seek pre-roll: 253 frames in 1231.7 ms - AddData 499.9 ms, GetPicture 162.4 ms   (4.87 ms/frame)
seek pre-roll: 216 frames in 1098.1 ms - AddData 448.8 ms, GetPicture 179.3 ms   (5.08 ms/frame)
seek pre-roll: 173 frames in  886.0 ms - AddData 344.3 ms, GetPicture 140.3 ms   (5.12 ms/frame)
seek pre-roll: 305 frames in 1644.7 ms - AddData 654.6 ms, GetPicture 229.0 ms   (5.39 ms/frame)
```

Time spent in `GetOutputPicture()` drops from 4.99ms to 0.64ms per frame. In other words the
pre-roll runs at 3.9x realtime instead of 1.95x.

For reference, a standalone `AMediaCodec` program decoding and discarding the same content on the
same device manages 3.0ms per frame, so what remains is not the decoder.

Also exercised: extended normal playback of the above stream and of an h264 mp4 over http, plus
repeated seeking back and forth, both absolute and by skip steps. No regressions observed. Not
covered by my testing: trick-play, DRM/secure playback, PVR, and platforms other than Android.

## What is the effect on users?

Seeking in a video is roughly twice as fast on Android. For a typical 4s gap between the keyframe
and the seek target in a 50fps stream, the freeze after a seek goes from about 2.2s to about 1.1s
on the device above. Faster devices will see a smaller absolute gain, since the wait is bounded by
how quickly the decoder produces output. Nothing changes about where a seek lands.

## Screenshots (if appropriate):

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed