### PR TITLE
DVDDemuxFFmpeg: fix MPEG-TS fast probe breaking DTS/DTS-HD audio metadata

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -480,19 +480,34 @@ bool CDVDDemuxFFmpeg::Open(const std::shared_ptr<CDVDInputStream>& pInput, bool 
                          "empty. Please report this bug.");
   }
 
-  // don't re-open mpegts streams with hevc encoding as the params are not correctly detected again
-  if (iformat && (strcmp(iformat->name, "mpegts") == 0) && !url.IsProtocol("tcp") && !fileinfo &&
-      !isBluray && m_pFormatContext->nb_streams > 0 && m_pFormatContext->streams != nullptr &&
-      m_pFormatContext->streams[0]->codecpar->codec_id != AV_CODEC_ID_HEVC)
+  // Don't apply the mpegts analyzeduration optimization if any stream needs full analysis:
+  // HEVC params break on reopen; DTS and TrueHD need full analyzeduration for extensions and channels
+  // (DTS channel/sample-rate detection is unreliable at a truncated analyzeduration even for core DTS).
+  bool skipTsOptimization = false;
+  bool isMpegTsWithStreams = iformat && (strcmp(iformat->name, "mpegts") == 0) &&
+                             m_pFormatContext->nb_streams > 0 &&
+                             m_pFormatContext->streams != nullptr;
+  if (isMpegTsWithStreams)
+  {
+    for (unsigned int i = 0; i < m_pFormatContext->nb_streams; i++)
+    {
+      AVCodecID codec = m_pFormatContext->streams[i]->codecpar->codec_id;
+      if (codec == AV_CODEC_ID_HEVC || codec == AV_CODEC_ID_DTS || codec == AV_CODEC_ID_TRUEHD)
+      {
+        skipTsOptimization = true;
+        break;
+      }
+    }
+  }
+
+  if (isMpegTsWithStreams && !url.IsProtocol("tcp") && !fileinfo && !isBluray &&
+      !skipTsOptimization)
   {
     av_opt_set_int(m_pFormatContext, "analyzeduration", 500000, 0);
     m_checkTransportStream = true;
     skipCreateStreams = true;
   }
-  else if (!iformat || ((strcmp(iformat->name, "mpegts") != 0) ||
-                        ((strcmp(iformat->name, "mpegts") == 0) &&
-                         m_pFormatContext->nb_streams > 0 && m_pFormatContext->streams != nullptr &&
-                         m_pFormatContext->streams[0]->codecpar->codec_id == AV_CODEC_ID_HEVC)))
+  else if (!iformat || strcmp(iformat->name, "mpegts") != 0 || skipTsOptimization)
   {
     m_streaminfo = true;
   }


### PR DESCRIPTION
## Description
DVDDemuxFFmpeg applies a fast-probe optimization (500ms analyzeduration, skipCreateStreams) for MPEG-TS streams. Previously, it bypassed this optimization only if streams[0] was HEVC.

This PR extends the existing mpegts re-open optimization skip to also cover DTS and TrueHD audio streams. High-definition audio codecs like DTS, DTS-HD MA and TrueHD failed to populate channel maps and bit depths (e.g. "DTS 0 channels") because PMT parsing does not read elementary audio headers.

## Motivation and context
Fixes "DTS 0 channels" when playing an m2ts file with DTS, DTS-HD MA audio.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
