### PR TITLE
windowing/gbm: convert the vblank timestamp with a current clock reading

### DIFF
--- a/xbmc/windowing/gbm/VideoSyncGbm.cpp
+++ b/xbmc/windowing/gbm/VideoSyncGbm.cpp
@@ -20,10 +20,33 @@
 #include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <time.h>
 
 #include <unistd.h>
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+
+namespace
+{
+/*!
+ * \brief Express a DRM vblank timestamp in the reference clock's time base
+ *
+ * DRM reports vblank timestamps on CLOCK_MONOTONIC while CurrentHostCounter(),
+ * and therefore CVideoReferenceClock, uses CLOCK_MONOTONIC_RAW. Read both
+ * clocks here rather than applying an offset sampled earlier: the elapsed time
+ * since the vblank then cancels, and the two clocks do not tick at the same
+ * rate so any offset kept from before is already out of date.
+ */
+uint64_t MonotonicToHostCounter(uint64_t ns)
+{
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
+    return CurrentHostCounter();
+
+  const uint64_t now = static_cast<uint64_t>(ts.tv_sec) * 1000000000ULL + ts.tv_nsec;
+  return CurrentHostCounter() - (now - ns);
+}
+} // namespace
 
 CVideoSyncGbm::CVideoSyncGbm(CVideoReferenceClock* clock)
   : CVideoSync(clock), m_winSystem(CServiceBroker::GetWinSystem())
@@ -63,7 +86,6 @@ bool CVideoSyncGbm::Setup()
   m_crtcId = crtc->GetCrtcId();
   m_fd = drm->GetFileDescriptor();
   int s = drmCrtcGetSequence(m_fd, m_crtcId, &m_sequence, &ns);
-  m_offset = CurrentHostCounter() - ns;
   if (s != 0)
   {
     CLog::Log(LOGWARNING, "CVideoSyncGbm::{}: drmCrtcGetSequence failed ({})", __FUNCTION__, s);
@@ -71,7 +93,7 @@ bool CVideoSyncGbm::Setup()
   }
 
   CLog::Log(LOGINFO, "CVideoSyncGbm::{}: opened (fd:{} crtc:{} seq:{} ns:{}:{})", __FUNCTION__,
-            m_fd, m_crtcId, m_sequence, ns, m_offset + ns);
+            m_fd, m_crtcId, m_sequence, ns, MonotonicToHostCounter(ns));
   return true;
 }
 
@@ -101,7 +123,7 @@ void CVideoSyncGbm::Run(CEvent& stopEvent)
     if (sequence == m_sequence)
       continue;
 
-    m_refClock->UpdateClock(sequence - m_sequence, m_offset + ns);
+    m_refClock->UpdateClock(sequence - m_sequence, MonotonicToHostCounter(ns));
     m_sequence = sequence;
   }
 }

--- a/xbmc/windowing/gbm/VideoSyncGbm.h
+++ b/xbmc/windowing/gbm/VideoSyncGbm.h
@@ -36,7 +36,6 @@ private:
   int m_fd = -1;
   uint32_t m_crtcId = 0;
   uint64_t m_sequence = 0;
-  uint64_t m_offset = 0;
   std::atomic<bool> m_abort{false};
 
   CWinSystemBase* m_winSystem;


### PR DESCRIPTION
## Description
Fix "sync playback to display" for GBM users.
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

CVideoSyncGbm hands CVideoReferenceClock the vblank timestamp reported by DRM, which is CLOCK_MONOTONIC, converted into the CLOCK_MONOTONIC_RAW that CurrentHostCounter() - and so the reference clock - works in. That conversion was a single offset sampled once, in Setup():

  int s = drmCrtcGetSequence(m_fd, m_crtcId, &m_sequence, &ns);
  m_offset = CurrentHostCounter() - ns;

Two things are wrong with it.

ns is the timestamp of the last vblank rather than a reading of now, so the offset also absorbs however much of the refresh period had already elapsed when Setup() happened to run, and applies that error to every timestamp for the rest of the playback. Over four playbacks of one file on a Raspberry Pi 4 at 50Hz the offset came out at +18.73, +1.55, +2.27 and +12.44 ms: spread across a whole refresh period, and different every time the same file is opened.

The two clocks also do not tick at the same rate. NTP slews CLOCK_MONOTONIC and by definition never CLOCK_MONOTONIC_RAW, so an offset sampled once goes stale at the frequency correction for as long as the file plays.

The timestamps therefore slide away from the reference clock's own idea of now. Once they are about a third of a refresh period past it, CVideoReferenceClock::GetTime() starts finding that the vblank it expected has not arrived and runs the clock forward itself; by two thirds of a period it does so on every vblank. Past about one and a third periods frame pacing fails outright.

Measured on a Raspberry Pi 4, 23.976fps on a 50Hz output with videoplayer.usedisplayasclock enabled:

 - One uninterrupted 1h55m playback drifted from -15.5 to -0.3 ms, a monotonic 2.58 ppm, against the -2.551 ppm the kernel reported as its own frequency correction. Invented vblanks went from none in the first sixteen minutes to 3954 by the end. That run began at a fortunate -15.5 ms and the film ended before the drift reached the failure point.

 - Applying a -200 ppm frequency offset reproduces the same drift in five minutes instead of two hours. Timestamps ran -13.8 -> +51.6 ms, the clock invented 14778 vblanks, and 33% of pictures were shown on the wrong vblank, rising to 98% once the drift passed +27 ms. With this change the timestamps stayed at -0.8 ms for the whole run, the clock invented 45, and 0.48% of pictures missed their slot.

Because the starting error is whatever part of the refresh period Setup() landed in, time to failure varies from roughly 40 to 140 minutes on identical hardware playing the same file. A short test never reaches it; watching a feature sometimes does.

Read both clocks next to each timestamp instead. The elapsed part then cancels and only the genuine difference between the two clocks is applied, for one extra clock_gettime() per vblank.


## Motivation and context
While GBM implements a VideoSync method and "sync playback to display" can be enabled, its always been unreliable.
Video playback becomes stuttery in a hard to reproduce way


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Tested on Pi4 with Claude instrumenting and analysing:
https://claude.ai/code/artifact/2b314fbc-15bf-4cf4-829b-47b0a9c0cf2a

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
Smooth video with "sync playback to display" enabled, which is useful for playing 24fps videos on 50Hz display, for example.
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
