### PR TITLE
fixed: null media manager in the unit test environment

### DIFF
--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -87,6 +87,8 @@ bool CServiceManager::InitForTesting()
   m_extsMimeSupportList = std::make_unique<ADDONS::CExtsMimeSupportList>(*m_addonMgr);
   m_fileExtensionProvider->Initialize(*m_addonMgr);
 
+  m_mediaManager = std::make_unique<CMediaManager>();
+
   m_subTagRegistryManager = std::make_unique<KODI::UTILS::I18N::CSubTagRegistryManager>();
   m_subTagRegistryManager->Initialize();
 
@@ -98,6 +100,7 @@ void CServiceManager::DeinitTesting()
 {
   init_level = 0;
   m_subTagRegistryManager.reset();
+  m_mediaManager.reset();
   m_fileExtensionProvider->Deinitialize();
   m_extsMimeSupportList.reset();
   m_dataCacheCore.reset();

--- a/xbmc/test/CMakeLists.txt
+++ b/xbmc/test/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCES TestAutoSwitch.cpp
             TestEpisodeUtils.cpp
             TestFileItem.cpp
             TestLangInfo.cpp
+            TestMediaManager.cpp
             TestMediaSource.cpp
             TestPasswordManager.cpp
             TestURL.cpp

--- a/xbmc/test/TestMediaManager.cpp
+++ b/xbmc/test/TestMediaManager.cpp
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ServiceBroker.h"
+#include "storage/MediaManager.h"
+
+#include <gtest/gtest.h>
+
+TEST(TestMediaManager, IsAvailableInTheTestEnvironment)
+{
+  EXPECT_NO_FATAL_FAILURE(CServiceBroker::GetMediaManager());
+}
+
+//! The exact call that CDVDFactoryInputStream::CreateInputStream makes.
+TEST(TestMediaManager, TranslateDevicePathDoesNotRequireInitialize)
+{
+  // The value is platform dependent and may legitimately be empty; that the call returns
+  // at all is the point.
+  EXPECT_NO_FATAL_FAILURE(CServiceBroker::GetMediaManager().TranslateDevicePath(""));
+}


### PR DESCRIPTION
## Description

`CServiceManager::GetMediaManager()` dereferences `m_mediaManager` with no guard, and
`CServiceManager::InitForTesting()` never created it. Any unit test that reached the service
therefore dereferenced a null `unique_ptr` and took the whole test binary down with an access
violation and no stack.

This is reachable from ordinary code rather than being a corner case. Under
`HAS_OPTICAL_DRIVE`, `CDVDFactoryInputStream::CreateInputStream` consults the media manager on
every call:

https://github.com/xbmc/xbmc/blob/master/xbmc/cores/VideoPlayer/DVDInputStreams/DVDFactoryInputStream.cpp#L95

so **no unit test could open a media file at all** — which rules out the demuxer, the codec
factory, `SeekAndDecodeFirstPicture`, `GetFileStreamDetails` and anything built on them.

The failure mode is the awkward part: a bare `0xc0000005` with no message, so the natural
conclusion is "the code I just wrote is broken", not "the test environment is incomplete".

Reduced to a single call to confirm the cause:

```cpp
TEST(Diag, MediaManager)
{
  CServiceBroker::GetMediaManager().TranslateDevicePath("");  // access violation
}
```

Note the addon manager *is* initialised by `InitForTesting`, so the earlier `GetAddonMgr()`
call in the same function is a red herring; the media manager is the first unregistered
service the factory touches.

## Approach

Construct `CMediaManager` in `InitForTesting`, and reset it in `DeinitTesting`.

It is deliberately **not** `Initialize()`d. That call creates a platform storage provider and
enumerates optical drives, which a headless test process has no business doing, and nothing
reachable from the test environment needs it — `TranslateDevicePath`, the call
`CreateInputStream` makes, reads only plain members with safe defaults.

## Effect

The change restores the ability to unit test the whole file-opening path. Verified locally
with a test that previously killed the test binary and now opens and decodes from a real 4K
HEVC file in ~460 ms.

## Tests

`xbmc/test/TestMediaManager.cpp` — asserts the service is available in the test environment,
and that the specific call `CreateInputStream` makes returns rather than crashing.

## Not addressed here

Several other `CServiceManager` accessors have the same shape, returning `*m_member` with no
guard, so any use before the owning init stage is undefined behaviour rather than a
diagnosable error. Making those fail with the name of the missing service would turn a class
of crashes into readable diagnostics, but it is a wider change and is left out to keep this
one to the reported fault. Happy to follow up if that is wanted.

## Checklist

- Builds and passes the test suite locally (MSVC, Windows x64).
- New test file additionally checked with clang 19 on Linux at `-std=c++20 -Wall -Wextra
  -Werror`; no warnings attributable to it.
- No behaviour change outside the unit test environment: `InitForTesting` and `DeinitTesting`
  are not used by the application.
