### PR TITLE
[depends][libsmbclient] Samba 4.24.4 android fix

### DIFF
--- a/tools/depends/target/samba-gplv3/04-built-static.patch
+++ b/tools/depends/target/samba-gplv3/04-built-static.patch
@@ -71,14 +71,16 @@
                                          deps=deps,
                                          public_deps=public_deps,
                                          includes=includes,
-@@ -250,6 +259,6 @@
-                                         includes=includes,
+@@ -245,6 +254,8 @@
                                          header_path=header_path,
 -                                        builtin_cflags=builtin_cflags,
 +                                        builtin_cflags=TO_LIST(cflags) + TO_LIST(builtin_cflags) + builtin_extra_cflags,
                                          builtin_cflags_end=builtin_cflags_end,
                                          group=group,
                                          depends_on=depends_on,
++                                        autoproto=autoproto if obj_target is None else None,
++                                        autoproto_extra_source=autoproto_extra_source,
+                                         local_include=local_include,
 @@ -277,8 +293,13 @@
                              __require_builtin_deps=require_builtin_deps,
                              global_include = global_include)
@@ -115,12 +117,7 @@
      # remember empty subsystems, so we can strip the dependencies
      if ((source == '') or (source == [])):
          if not __force_empty and deps == '' and public_deps == '':
-@@ -901,8 +910,17 @@
-         if __require_builtin_deps:
-             raise Errors.WafError("subsystem[%s] provide_builtin_linking=True " +
-                                   "not allowed with __require_builtin_deps=True" %
-                                   modname)
-
+@@ -891 +919,10 @@
 +        if modname in ['gensec_util']:
 +            source = []
 +        builtin_extra_cflags = []
@@ -131,18 +128,37 @@
 +                '-DPACKAGE_NAME="Samba"',
 +            ]
          builtin_target = modname + '.builtin.objlist'
-         tbuiltin = __SAMBA_SUBSYSTEM_BUILTIN(bld, builtin_target, source,
-                                              deps=deps,
-@@ -908,7 +921,7 @@
-                                              public_deps=public_deps,
-                                              includes=includes,
+@@ -896,4 +933,4 @@
                                               header_path=header_path,
 -                                             builtin_cflags=builtin_cflags,
-+                                             builtin_cflags=TO_LIST(cflags) + TO_LIST(builtin_cflags) + builtin_extra_cflags,
 -                                             builtin_cflags_end='-D_PUBLIC_=_PRIVATE_',
++                                             builtin_cflags=TO_LIST(cflags) + TO_LIST(builtin_cflags) + builtin_extra_cflags,
 +                                             builtin_cflags_end='-D_PUBLIC_=',
                                               group=group,
-                                              depends_on=depends_on,
+--- a/buildtools/wafsamba/samba_deps.py
++++ b/buildtools/wafsamba/samba_deps.py
+@@ -56,0 +58,2 @@
++        builtin_subsystem = getattr(subsystem, 'samba_builtin_subsystem', None)
++        builtin_modules = []
+@@ -68,0 +72,8 @@
++                if builtin_subsystem is not None:
++                    module = bld.get_tgen_by_name(module_name)
++                    builtin_module = getattr(module, 'samba_builtin_subsystem', None)
++                    bld.ASSERT(
++                        builtin_module is not None,
++                        "Builtin subsystem %s: module %s has no builtin target" %
++                        (builtin_subsystem.sname, module_name))
++                    builtin_modules.append(builtin_module.sname)
+@@ -69,0 +81,4 @@
++        if builtin_subsystem is not None:
++            builtin_subsystem.samba_deps_extended.extend(builtin_modules)
++            builtin_subsystem.samba_deps_extended = unique_list(
++                builtin_subsystem.samba_deps_extended)
+@@ -206 +221,3 @@
+-    if sname.endswith('.objlist'):
++    if sname.endswith('.builtin.objlist'):
++        sname = sname[0:-16]
++    elif sname.endswith('.objlist'):
 --- a/source3/libsmb/smbclient.pc.in
 +++ b/source3/libsmb/smbclient.pc.in
 @@ -7,5 +7,7 @@
@@ -153,43 +169,6 @@
 +Requires.private: @REQUIRES_PRIVATE@
  Cflags: -I${includedir}
  URL: http://www.samba.org/
---- a/auth/gensec/wscript_build
-+++ b/auth/gensec/wscript_build
-@@ -2,9 +2,9 @@
- bld.SAMBA_LIBRARY('gensec',
--	source='gensec.c gensec_start.c gensec_util.c',
--	autoproto='gensec_toplevel_proto.h',
--	public_deps='tevent-util samba-util samba-errors auth_system_session samba-modules gensec_util asn1util',
--	private_headers='gensec.h',
--	deps='com_err',
--	private_library=True,
--	)
-+        source='gensec.c gensec_start.c gensec_util.c spnego.c',
-+        autoproto='gensec_toplevel_proto.h',
-+        public_deps='tevent-util samba-util samba-errors auth_system_session samba-modules gensec_util asn1util',
-+        private_headers='gensec.h',
-+        deps='com_err samba-credentials SPNEGO_PARSE',
-+        private_library=True,
-+        )
- 
---- a/auth/gensec/gensec_start.c
-+++ b/auth/gensec/gensec_start.c
-@@ -1092,7 +1092,9 @@
- {
--	static bool initialized = false;
-+        static bool initialized = false;
-+        extern NTSTATUS gensec_spnego_init(TALLOC_CTX *);
-+        extern NTSTATUS gensec_ntlmssp_init(TALLOC_CTX *);
- #define _MODULE_PROTO(init) extern NTSTATUS init(TALLOC_CTX *);
- #ifdef STATIC_gensec_MODULES
--	STATIC_gensec_MODULES_PROTO;
--	init_module_fn static_init[] = { STATIC_gensec_MODULES };
-+        STATIC_gensec_MODULES_PROTO;
-+        init_module_fn static_init[] = { STATIC_gensec_MODULES };
- #else
-@@ -1110,0 +1113,2 @@
-+        gensec_spnego_init(NULL);
-+        gensec_ntlmssp_init(NULL);
 --- a/libcli/security/wscript_build
 +++ b/libcli/security/wscript_build
 @@ -20,7 +20,7 @@

--- a/tools/depends/target/samba-gplv3/samba_android.patch
+++ b/tools/depends/target/samba-gplv3/samba_android.patch
@@ -106,3 +106,28 @@
  
  typedef struct winbindd_gr {
  	fstring gr_name;
+--- a/lib/util/overflow.h
++++ b/lib/util/overflow.h
+@@ -51,7 +51,20 @@
+ * @return True  pointer would over flow
+ *         False pointer would not overflow
+ */
++#if defined(__ANDROID__) && defined(__aarch64__)
++/*
++ * Android 11 and newer may tag heap pointers in the top byte. Such pointers
++ * are intentionally greater than INTPTR_MAX, so comparing them directly with
++ * INTPTR_MAX makes every non-zero offset look like an overflow. Ignore the
++ * top-byte tag when checking the address portion for overflow.
++ */
++#define ptr_overflow(ptr, offset, type) \
++	((uintptr_t)(offset) > \
++	 (((UINTPTR_MAX >> 8) - \
++	   ((uintptr_t)(ptr) & (UINTPTR_MAX >> 8))) / sizeof(type)))
++#else
+ #define ptr_overflow(ptr, offset, type) \
+-	offset_outside_range((ptr), ((type*)INTPTR_MAX), (offset))
++	offset_outside_range((ptr), ((type*)INTPTR_MAX), (offset))
++#endif
+-
++
+ #endif


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Samba 4.24 checks pointer additions against INTPTR_MAX. On Android 11 and newer, AArch64 heap pointers can carry a top-byte tag and therefore compare greater than INTPTR_MAX even when the address and offset are valid. The false overflow makes NTLMSSP challenge parsing return NT_STATUS_INVALID_PARAMETER.

The patched Waf build converts libraries and subsystems to built-in object lists for the static libsmbclient build, but module dependencies stayed attached to the original targets. Built-in-only libraries also lost their autoproto generation. This allowed libsmbclient to link while authentication implementations such as SPNEGO and NTLMSSP were absent from the runtime module table.

Map built-in object-list names back to their subsystem names, propagate module dependencies to the built-in targets, and preserve autoproto generation. This fixes module registration generally and removes the previous gensec-specific force-link workaround. This brings back the same subsystems as we had in 4.15.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #28837

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
