### PR TITLE
[cec] only hand volume to an amp while system audio mode is on

### DIFF
--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -43,6 +43,10 @@ using namespace std::chrono_literals;
 
 #define CEC_LIB_SUPPORTED_VERSION LIBCEC_VERSION_TO_UINT(4, 0, 0)
 
+/* SystemAudioModeStatus() was added in libCEC 7.1.0 */
+#define CEC_LIB_HAS_SYSTEM_AUDIO_MODE_STATUS \
+  (CEC_LIB_VERSION_MAJOR > 7 || (CEC_LIB_VERSION_MAJOR == 7 && CEC_LIB_VERSION_MINOR >= 1))
+
 /* time in seconds to ignore standby commands from devices after the screensaver has been activated
  */
 #define SCREENSAVER_TIMEOUT 20
@@ -107,14 +111,13 @@ void CPeripheralCecAdapter::ResetMembers(void)
   m_bStarted = false;
   m_bHasButton = false;
   m_bIsReady = false;
-  m_bHasConnectedAudioSystem = false;
+  m_bAmpControlsVolume = false;
   m_strMenuLanguage = "???";
   m_lastKeypress = {};
   m_lastChange = VOLUME_CHANGE_NONE;
   m_iExitCode = EXITCODE_QUIT;
 
-  //! @todo fetch the correct initial value when system audiostatus is
-  //! implemented in libCEC
+  /* replaced by the amp's own mute state once it reports one */
   m_bIsMuted = false;
 
   m_bGoingToStandby = false;
@@ -470,13 +473,19 @@ void CPeripheralCecAdapter::Process(void)
 bool CPeripheralCecAdapter::HasAudioControl(void)
 {
   std::unique_lock lock(m_critSection);
-  return m_bHasConnectedAudioSystem;
+  return m_bAmpControlsVolume;
 }
 
-void CPeripheralCecAdapter::SetAudioSystemConnected(bool bSetTo)
+void CPeripheralCecAdapter::SetAmpControlsVolume(bool bSetTo)
 {
   std::unique_lock lock(m_critSection);
-  m_bHasConnectedAudioSystem = bSetTo;
+  m_bAmpControlsVolume = bSetTo;
+}
+
+void CPeripheralCecAdapter::SetAmpMuted(bool bSetTo)
+{
+  std::unique_lock lock(m_critSection);
+  m_bIsMuted = bSetTo;
 }
 
 void CPeripheralCecAdapter::ProcessVolumeChange(void)
@@ -749,6 +758,18 @@ void CPeripheralCecAdapter::CecCommand(void* cbParam, const cec_command* command
             adapter->PushCecKeypress(key);
           }
         }
+        break;
+      case CEC_OPCODE_SET_SYSTEM_AUDIO_MODE:
+      case CEC_OPCODE_SYSTEM_AUDIO_MODE_STATUS:
+        /* the amp only acts on volume keypresses while system audio mode is on, so follow it for
+           as long as it is: volume falls back to Kodi's own the moment the amp bows out */
+        if (command->initiator == CECDEVICE_AUDIOSYSTEM && command->parameters.size == 1)
+          adapter->SetAmpControlsVolume(command->parameters[0] == CEC_SYSTEM_AUDIO_STATUS_ON);
+        break;
+      case CEC_OPCODE_REPORT_AUDIO_STATUS:
+        if (command->initiator == CECDEVICE_AUDIOSYSTEM && command->parameters.size == 1)
+          adapter->SetAmpMuted((command->parameters[0] & CEC_AUDIO_MUTE_STATUS_MASK) ==
+                               CEC_AUDIO_MUTE_STATUS_MASK);
         break;
       default:
         break;
@@ -1643,30 +1664,47 @@ std::string CPeripheralCecAdapterUpdateThread::UpdateAudioSystemStatus(void)
 {
   std::string strAmpName;
 
-  /* disable the mute setting when an amp is found, because the amp handles the mute setting and
-       set PCM output to 100% */
-  if (m_adapter->m_cecAdapter->IsActiveDeviceType(CEC_DEVICE_TYPE_AUDIO_SYSTEM))
+  if (!m_adapter->m_cecAdapter->IsActiveDeviceType(CEC_DEVICE_TYPE_AUDIO_SYSTEM))
   {
-    // request the OSD name of the amp
-    std::string ampName(m_adapter->m_cecAdapter->GetDeviceOSDName(CECDEVICE_AUDIOSYSTEM));
-    CLog::Log(LOGDEBUG,
-              "{} - CEC capable amplifier found ({}). volume will be controlled on the amp",
-              __FUNCTION__, ampName);
-    strAmpName += ampName;
-
-    // set amp present
-    m_adapter->SetAudioSystemConnected(true);
-    auto& components = CServiceBroker::GetAppComponents();
-    const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
-    appVolume->SetMute(false);
-    appVolume->SetVolume(CApplicationVolumeHandling::VOLUME_MAXIMUM, false);
-  }
-  else
-  {
-    // set amp present
     CLog::Log(LOGDEBUG, "{} - no CEC capable amplifier found", __FUNCTION__);
-    m_adapter->SetAudioSystemConnected(false);
+    m_adapter->SetAmpControlsVolume(false);
+    return strAmpName;
   }
+
+  // request the OSD name of the amp
+  std::string ampName(m_adapter->m_cecAdapter->GetDeviceOSDName(CECDEVICE_AUDIOSYSTEM));
+  strAmpName += ampName;
+
+#if CEC_LIB_HAS_SYSTEM_AUDIO_MODE_STATUS
+  /* an amp only acts on volume keypresses while system audio mode is on. handing it the volume
+     while it is off leaves the user with no working volume control at all, since CEC 1.4b has no
+     way to change the volume anywhere else. */
+  if (m_adapter->m_cecAdapter->SystemAudioModeStatus() != CEC_SYSTEM_AUDIO_STATUS_ON)
+  {
+    CLog::Log(LOGDEBUG,
+              "{} - CEC capable amplifier found ({}), but system audio mode is off. volume will be "
+              "controlled by Kodi",
+              __FUNCTION__, ampName);
+    m_adapter->SetAmpControlsVolume(false);
+    return strAmpName;
+  }
+#endif
+
+  CLog::Log(LOGDEBUG, "{} - CEC capable amplifier found ({}). volume will be controlled on the amp",
+            __FUNCTION__, ampName);
+
+  /* the amp handles volume and mute from here on, so let Kodi pass its audio through unchanged */
+  m_adapter->SetAmpControlsVolume(true);
+  auto& components = CServiceBroker::GetAppComponents();
+  const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+  appVolume->SetMute(false);
+  appVolume->SetVolume(CApplicationVolumeHandling::VOLUME_MAXIMUM, false);
+
+  /* adopt the amp's mute state, so the first mute keypress does not toggle it the wrong way */
+  const uint8_t audioStatus = m_adapter->m_cecAdapter->AudioStatus();
+  if (audioStatus != CEC_AUDIO_VOLUME_STATUS_UNKNOWN)
+    m_adapter->SetAmpMuted((audioStatus & CEC_AUDIO_MUTE_STATUS_MASK) ==
+                           CEC_AUDIO_MUTE_STATUS_MASK);
 
   return strAmpName;
 }

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -478,6 +478,24 @@ bool CPeripheralCecAdapter::HasAudioControl(void)
 
 void CPeripheralCecAdapter::SetAmpControlsVolume(bool bSetTo)
 {
+  {
+    std::unique_lock lock(m_critSection);
+    if (m_bAmpControlsVolume == bSetTo)
+      return;
+  }
+
+  /* hand Kodi's volume over before the amp takes it: from that point on a mute keypress is
+     forwarded to the amp rather than clearing Kodi's own mute, which would leave Kodi muted
+     with no way to unmute it. setting the volume to maximum lets Kodi pass its audio through
+     unchanged, so the amp is the only thing attenuating it */
+  if (bSetTo)
+  {
+    auto& components = CServiceBroker::GetAppComponents();
+    const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
+    appVolume->SetMute(false);
+    appVolume->SetVolume(CApplicationVolumeHandling::VOLUME_MAXIMUM, false);
+  }
+
   std::unique_lock lock(m_critSection);
   m_bAmpControlsVolume = bSetTo;
 }
@@ -1693,12 +1711,7 @@ std::string CPeripheralCecAdapterUpdateThread::UpdateAudioSystemStatus(void)
   CLog::Log(LOGDEBUG, "{} - CEC capable amplifier found ({}). volume will be controlled on the amp",
             __FUNCTION__, ampName);
 
-  /* the amp handles volume and mute from here on, so let Kodi pass its audio through unchanged */
   m_adapter->SetAmpControlsVolume(true);
-  auto& components = CServiceBroker::GetAppComponents();
-  const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
-  appVolume->SetMute(false);
-  appVolume->SetVolume(CApplicationVolumeHandling::VOLUME_MAXIMUM, false);
 
   /* adopt the amp's mute state, so the first mute keypress does not toggle it the wrong way */
   const uint8_t audioStatus = m_adapter->m_cecAdapter->AudioStatus();

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -159,7 +159,8 @@ private:
   void PushCecKeypress(const CecButtonPress& key);
   void GetNextKey(void);
 
-  void SetAudioSystemConnected(bool bSetTo);
+  void SetAmpControlsVolume(bool bSetTo);
+  void SetAmpMuted(bool bSetTo);
   void SetMenuLanguage(const char* strLanguage);
   void OnTvStandby(void);
 
@@ -179,7 +180,8 @@ private:
   bool m_bStarted;
   bool m_bHasButton;
   bool m_bIsReady;
-  bool m_bHasConnectedAudioSystem;
+  /* set while an amp is present and has system audio mode on: it, not Kodi, handles volume */
+  bool m_bAmpControlsVolume;
   std::string m_strMenuLanguage;
   CDateTime m_standbySent;
   std::vector<CecButtonPress> m_buttonQueue;

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -159,6 +159,13 @@ private:
   void PushCecKeypress(const CecButtonPress& key);
   void GetNextKey(void);
 
+  /*!
+   * @brief Move volume control between the amp and Kodi.
+   * @param bSetTo True to let the amp handle volume and mute, false to keep them in Kodi.
+   *
+   * Unmutes Kodi and sets its volume to maximum when the amp takes over, so that all attenuation
+   * happens in one place. Does nothing when control is already where it is asked to be.
+   */
   void SetAmpControlsVolume(bool bSetTo);
   void SetAmpMuted(bool bSetTo);
   void SetMenuLanguage(const char* strLanguage);


### PR DESCRIPTION
## Description

Kodi decides that a CEC amplifier owns the volume based on `IsActiveDeviceType(CEC_DEVICE_TYPE_AUDIO_SYSTEM)` alone — that is, on *something* answering on the audio system logical address. Once that fires, `CPeripherals::OnAction` swallows every `ACTION_VOLUME_UP`/`ACTION_VOLUME_DOWN` and forwards it as a CEC keypress, and Kodi's own volume is pinned at `VOLUME_MAXIMUM`.

An amp only acts on those keypresses while **system audio mode** is on. When it is off, the keypresses go nowhere — and since CEC 1.4b has no way to change the volume anywhere else, the user is left with no working volume control at all. `VolumeUp`/`VolumeDown` are dead in every keymap, while `SetVolume(70)` and JSON-RPC `Application.SetVolume` still work, because those call `CApplicationVolumeHandling::SetVolume` directly and never pass the interception point. That asymmetry is exactly what #25854 reports.

## What changed

**Gate the handover on system audio mode.** An amp gets the volume only when it reports system audio mode on; otherwise the amp is logged and the volume stays with Kodi.

**Keep following it.** `<Set System Audio Mode>` and `<System Audio Mode Status>` from `CECDEVICE_AUDIOSYSTEM` are now handled in the command callback, so toggling the mode at the amp mid-session moves the volume between amp and Kodi instead of freezing whichever answer startup happened to get.

**Seed the mute state from the amp.** `<Report Audio Status>` updates it live, and the initial handover reads `AudioStatus()`, ignoring `CEC_AUDIO_VOLUME_STATUS_UNKNOWN`. This retires the `@todo fetch the correct initial value when system audiostatus is implemented in libCEC`.

`m_bHasConnectedAudioSystem` becomes `m_bAmpControlsVolume`, since the flag now means "the amp is handling volume" rather than "an amp exists"; `SetAudioSystemConnected` follows it to `SetAmpControlsVolume`.

Only the blocking queries run on the update thread. The command callback parses the parameters carried by the command itself and never calls back into libCEC, so it cannot re-enter the adapter from inside a libCEC callback.

## libCEC version guard

`SystemAudioModeStatus()` was added in libCEC 7.1.0, so the initial query sits behind a named capability test:

```c
/* SystemAudioModeStatus() was added in libCEC 7.1.0 */
#define CEC_LIB_HAS_SYSTEM_AUDIO_MODE_STATUS \
  (CEC_LIB_VERSION_MAJOR > 7 || (CEC_LIB_VERSION_MAJOR == 7 && CEC_LIB_VERSION_MINOR >= 1))
```

Built from the public `CEC_LIB_VERSION_MAJOR`/`MINOR` rather than libCEC's private `_LIBCEC_VERSION_CURRENT`, which encodes only major.minor anyway. Undefined macros evaluate to 0 in `#if`, so a header too old to define them falls back to current behaviour rather than failing the build. Builds against libCEC older than 7.1.0 keep handing the volume to any amp present.

The runtime tracking and the mute state are not guarded — those opcodes and constants are present as far back as libCEC 4.

## Testing

Compiled against libCEC 6.0, 7.0 and 8.1 headers; the guard expands to off, off and on respectively. The expansion was checked across a version matrix (4.0, 6.0, 7.0, 7.1, 7.2, 8.0, 8.1, 9.0, and with the macros absent) and turns on exactly at 7.1.0.

Tested on hardware with libCEC 8.

Closes #25854
