### PR TITLE
[Video][Bluray] Fix crash when selecting bluray disc menu from the Choose Playlist simple menu.

### DIFF
--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -2689,32 +2689,37 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(const CFileItem& item,
         newItem->SetDynPath(selectedItem.GetDynPath());
         const auto tag{newItem->GetVideoInfoTag()};
         tag->SetFileNameAndPath(selectedItem.GetDynPath());
-        tag->m_streamDetails = selectedItem.GetVideoInfoTag()->m_streamDetails;
+        if (selectedItem.HasVideoInfoTag())
+        {
+          if (selectedItem.GetVideoInfoTag()->HasStreamDetails())
+            tag->m_streamDetails = selectedItem.GetVideoInfoTag()->m_streamDetails;
 
-        // Episode bookmarks
-        if (const CBookmark & bookmark{selectedItem.GetVideoInfoTag()->m_EpBookmark};
-            bookmark.IsSet())
-          tag->m_EpBookmark = bookmark;
+          // Episode bookmarks
+          if (const CBookmark& bookmark{selectedItem.GetVideoInfoTag()->m_EpBookmark};
+              bookmark.IsSet())
+            tag->m_EpBookmark = bookmark;
 
-        // The duration of the playlist, or of the episode's part of it where several share one, is
-        // measured from the disc and so is preferred over the scraper's.
-        // Loose sanity check that the scraper and found durations are similar, to avoid a
-        // mis-identified playlist from overwriting the episode's duration and affecting future
-        // playlist identification.
-        static constexpr int SCRAPED_DURATION_TOLERANCE_PERCENT{50};
-        const unsigned int scrapedDuration{tag->GetStaticDuration()};
-        if (const unsigned int discDuration{selectedItem.GetVideoInfoTag()->GetDuration()};
-            discDuration > 0 &&
-            (scrapedDuration == 0 ||
-             CheckDurationsWithinTolerance(scrapedDuration * 1000ms, discDuration * 1000ms,
-                                           SCRAPED_DURATION_TOLERANCE_PERCENT)))
-          tag->SetDuration(static_cast<int>(discDuration));
+          // The duration of the playlist, or of the episode's part of it where several share one, is
+          // measured from the disc and so is preferred over the scraper's.
+          // Loose sanity check that the scraper and found durations are similar, to avoid a
+          // mis-identified playlist from overwriting the episode's duration and affecting future
+          // playlist identification.
+          static constexpr int SCRAPED_DURATION_TOLERANCE_PERCENT{50};
+          const unsigned int scrapedDuration{tag->GetStaticDuration()};
+          if (const unsigned int discDuration{selectedItem.GetVideoInfoTag()->GetDuration()};
+              discDuration > 0 &&
+              (scrapedDuration == 0 ||
+               CheckDurationsWithinTolerance(scrapedDuration * 1000ms, discDuration * 1000ms,
+                                             SCRAPED_DURATION_TOLERANCE_PERCENT)))
+            tag->SetDuration(static_cast<int>(discDuration));
+        }
 
         if (tag->GetAssetInfo().GetTitle().empty())
           tag->GetAssetInfo().SetTitle(
               CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(
                   VIDEO_VERSION_ID_DEFAULT));
-        newItem->SetProperty("bluray_playlist", selectedItem.GetProperty("bluray_playlist"));
+        if (selectedItem.HasProperty("bluray_playlist"))
+          newItem->SetProperty("bluray_playlist", selectedItem.GetProperty("bluray_playlist"));
         newItem->SetProperty("original_listitem_url", item.GetDynPath());
         return newItem;
       }};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Include HasVideoInfoTag() check when generating the FileItem for the selected playlist/menu.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Crash reported by @thexai 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have updated the documentation accordingly
- [X] All new and existing tests passed
