### PR TITLE
[i18n] fix Flemish being unreachable by name

### DIFF
--- a/xbmc/utils/i18n/Iso639_2_Table.h
+++ b/xbmc/utils/i18n/Iso639_2_Table.h
@@ -581,7 +581,7 @@ constexpr std::array<struct LCENTRY, ISO639_2_ADDL_NAMES_COUNT> TableISO639_2_Na
     {StringToLongCode("nds"), "German, Low"},
     {StringToLongCode("nds"), "Saxon Low"},
     {StringToLongCode("new"), "Newari"},
-    {StringToLongCode("nld"), "Flemish "},
+    {StringToLongCode("nld"), "Flemish"},
     {StringToLongCode("nno"), "Nynorsk, Norwegian"},
     {StringToLongCode("nob"), "Norwegian Bokmål"},
     {StringToLongCode("nso"), "Sepedi"},

--- a/xbmc/utils/i18n/test/TestIso639_2.cpp
+++ b/xbmc/utils/i18n/test/TestIso639_2.cpp
@@ -79,6 +79,12 @@ TEST(TestI18nIso639_2, LookupByName)
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(*result, "fin");
 
+  // A name is matched with EqualsNoCase and nothing trims it, so a stray space in the table
+  // leaves the entry unreachable
+  result = CIso639_2::LookupByName("Flemish");
+  EXPECT_TRUE(result.has_value());
+  EXPECT_EQ(*result, "nld");
+
   result = CIso639_2::LookupByName("not a language");
   EXPECT_FALSE(result.has_value());
 }


### PR DESCRIPTION
## Description

The additional-names table spells Flemish with a trailing space. Names are matched with
`EqualsNoCase` and nothing trims them, so `CIso639_2::LookupByName` never answers for it and
`Flemish` does not resolve to `nld`. A NFO or an addon naming a track that way leaves it
unrecognized.

```diff
-    {StringToLongCode("nld"), "Flemish "},
+    {StringToLongCode("nld"), "Flemish"},
```

Only the reverse direction was affected. Looking the code up by number reads the by-code table,
which carries the preferred name, so nothing ever displayed the stray space.

## How has this been tested?

Full unit test suite on Windows: 3518/3519. The one failure is `TestHTTPDirectory`, which draws a
random port with no retry and collides with `TestWebServer`; it passes when either suite is run
alone, and the test that fails moves between runs.

The `LookupByName` test now covers Flemish. I confirmed it fails without this change:

```
TestIso639_2.cpp(85): error: Value of: result.has_value()
TestIso639_2.cpp(86): error: Expected equality of these values:  Which is: ""
```

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)