### PR TITLE
VideoPlayer: add option to not auto-enable subtitles in the audio language

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24500,7 +24500,19 @@ msgctxt "#39210"
 msgid "If enabled, Dolby Vision files will have level 5 (active area) metadata overridden to zero offsets. Enable if your display has issues with incorrectly cropped image in Dolby Vision playback."
 msgstr ""
 
-#empty strings from id 39211 to 39899
+#. Title of the setting that skips subtitles whose language matches the audio language
+#: system/settings/settings.xml
+msgctxt "#39211"
+msgid "Don't show subtitles matching the audio language"
+msgstr ""
+
+#. Help text for setting "Don't show subtitles matching the audio language" of label #39211
+#: system/settings/settings.xml
+msgctxt "#39212"
+msgid "Do not turn on subtitles that are in the same language as the audio being played. Forced subtitles are not affected."
+msgstr ""
+
+#empty strings from id 39213 to 39899
 
 #. List formatting: pattern used to join a list of exactly two items, e.g. "A and B"
 #. STR_LIST_AND_TWO

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -595,6 +595,19 @@
           </constraints>
           <control type="list" format="string" />
         </setting>
+        <setting id="subtitles.hidesameaudiolanguage" parent="locale.subtitlelanguage" type="boolean" label="39211" help="39212">
+          <level>1</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable">
+              <and>
+                <condition setting="locale.subtitlelanguage" operator="!is">none</condition>
+                <condition setting="locale.subtitlelanguage" operator="!is">forced_only</condition>
+              </and>
+            </dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
       </group>
       <group id="3" label="37032">
         <setting id="accessibility.audiovisual" type="boolean" label="37034" help="37035">

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -72,6 +72,7 @@
 #include <memory>
 #include <mutex>
 #include <ranges>
+#include <string_view>
 #include <utility>
 
 using namespace KODI;
@@ -87,6 +88,14 @@ using namespace std::chrono_literals;
       return (lh) > (rh); \
   } while(0)
 
+namespace
+{
+constexpr bool IsKnownLanguage(std::string_view language)
+{
+  return !language.empty() && language != "und";
+}
+} // unnamed namespace
+
 class PredicateSubtitleFilter
 {
 private:
@@ -98,6 +107,7 @@ private:
   bool m_isPrefForced;
   bool m_isPrefHearingImp;
   bool m_isSubNone;
+  bool m_hideSameAudioLang;
   int m_subStream;
 
 public:
@@ -116,6 +126,7 @@ public:
     m_isPrefOriginal = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageOriginal);
     m_isPrefForced = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageForcedOnly);
     m_isPrefHearingImp = settings->GetBool(CSettings::SETTING_ACCESSIBILITY_SUBHEARING);
+    m_hideSameAudioLang = settings->GetBool(CSettings::SETTING_SUBTITLES_HIDESAMEAUDIOLANGUAGE);
 
     m_subLang = g_langInfo.GetSubtitleLanguage(false);
     if (m_subLang.empty()) // No language set (due to none, original, forced_only settings)
@@ -143,12 +154,22 @@ public:
     const bool isCC = STREAM_SOURCE_MASK(ss.source) == STREAM_SOURCE_VIDEOMUX;
 
     // External subtitles with unknown language always allow it
-    if (isExternal && (ss.language.empty() || ss.language == "und"))
+    if (isExternal && !IsKnownLanguage(ss.language))
     {
       return false;
     }
 
     const bool isSameSubLang = g_LangCodeExpander.CompareISO639Codes(ss.language, m_subLang);
+
+    // The user does not want to read subtitles in a language they are already listening to.
+    // Forced subtitles are kept, as they usually only translate foreign language parts.
+    // Both languages must be declared, a stream that states none is never assumed to match.
+    if (m_hideSameAudioLang && (ss.flags & FLAG_FORCED) == 0 &&
+        IsKnownLanguage(m_playedAudioLang) && IsKnownLanguage(ss.language) &&
+        g_LangCodeExpander.CompareISO639Codes(ss.language, m_playedAudioLang))
+    {
+      return true;
+    }
 
     if (m_isPrefHearingImp)
     {
@@ -158,7 +179,7 @@ public:
 
       // to consider CC streams may not have the language code
       if ((ss.flags & StreamFlags::FLAG_HEARING_IMPAIRED) &&
-          (isSameSubLang || (isCC && (ss.language.empty() || ss.language == "und"))))
+          (isSameSubLang || (isCC && !IsKnownLanguage(ss.language))))
       {
         return false;
       }
@@ -184,7 +205,7 @@ public:
 
     // can fall here only when "forced" and "impaired" are disabled,
     // it always enable subs if language is unknown for external and CC
-    if ((isSameSubLang || (isCC && (ss.language.empty() || ss.language == "und"))) &&
+    if ((isSameSubLang || (isCC && !IsKnownLanguage(ss.language))) &&
         (ss.flags & FLAG_FORCED) == 0 && (ss.flags & FLAG_HEARING_IMPAIRED) == 0)
     {
       return false;
@@ -392,8 +413,8 @@ public:
     // if all previous conditions do not match, allow fallback to "unknown" language
     if (!m_isPrefForced)
     {
-      PREDICATE_RETURN(isLincluded && (lh.language.empty() || lh.language == "und"),
-                       isRincluded && (rh.language.empty() || rh.language == "und"));
+      PREDICATE_RETURN(isLincluded && !IsKnownLanguage(lh.language),
+                       isRincluded && !IsKnownLanguage(rh.language));
     }
 
     return false;

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -151,6 +151,7 @@ public:
   static constexpr auto SETTING_MYVIDEOS_EXTRACTTHUMB = "myvideos.extractthumb";
   static constexpr auto SETTING_MYVIDEOS_STACKVIDEOS = "myvideos.stackvideos";
   static constexpr auto SETTING_LOCALE_SUBTITLELANGUAGE = "locale.subtitlelanguage";
+  static constexpr auto SETTING_SUBTITLES_HIDESAMEAUDIOLANGUAGE = "subtitles.hidesameaudiolanguage";
   static constexpr auto SETTING_SUBTITLES_PARSECAPTIONS = "subtitles.parsecaptions";
   static constexpr auto SETTING_SUBTITLES_CAPTIONSALIGN = "subtitles.captionsalign";
   static constexpr auto SETTING_SUBTITLES_CAPTIONSIMPAIRED = "subtitles.captionsimpaired";


### PR DESCRIPTION
Adds a setting that stops Kodi from automatically switching subtitles on when they are in the same language as the audio you are already listening to.

When the preferred subtitle language happens to be the language that is also spoken in the media, Kodi turns the subtitles on. If you understand that language they are only in the way, and the only way around it at the moment is to disable the subtitle stream by hand for every item you play. Many video files contain a subtitle track in the same language as the audio.

This adds **Don't show subtitles matching the audio language** under Settings/Player/Language, directly below the preferred subtitle language. It is off by default, so existing behaviour is unchanged.

With it enabled, `PredicateSubtitleFilter` stops treating a subtitle stream as relevant when its language matches the language of the audio stream that was actually selected for playback. It uses `as.language` from `OpenDefaultStreams`, so it follows the preferred audio language rather than whichever track happens to carry the default flag. The stream is still opened and remains selectable from the OSD, it just is not enabled on its own.

Left enabled on purpose:

* forced subtitles, since they generally only translate foreign language parts or on screen text and stay useful when the audio is understood

It composes with "prefer subtitles for the hearing impaired" rather than being disabled by it. With both enabled those subtitles are still preferred, they are just not turned on when their language matches the audio, which gives subtitles for the hearing impaired only on media that is not already in a language you understand.

Both streams have to declare a language. If the audio stream carries none, or `und`, nothing is hidden. There is no guessing from file names or stream titles.

The comparison is done when the streams are opened, so changing the audio track during playback does not re-evaluate it. That is consistent with the rest of the language based preselection, which also only runs in `OpenDefaultStreams`, and it is spelled out in the help text.

## Testing

Built and run on LibreELEC 13 (RPi4, aarch64). With preferred audio and subtitle language both set to Swedish, three files were played with the setting off and then on, reading back `Player.GetProperties` over JSON-RPC. Per file video settings were cleared between every run so nothing carried over.

| stream layout | setting off | setting on |
|---|---|---|
| 1 audio (swe), 1 subtitle (swe) | audio swe, sub swe, enabled **true** | audio swe, sub swe, enabled **false** |
| 1 audio (swe), 7 subtitles (eng default, incl. swe) | audio swe, sub swe, enabled **true** | audio swe, sub swe, enabled **false** |
| 6 audio (eng default, incl. swe), 5 subtitles | audio swe, sub swe, enabled **true** | audio swe, sub swe, enabled **false** |

The last case is the interesting one. There are six audio tracks with English flagged as default, Kodi selects the Swedish one because of the audio language preference, and the comparison is made against that track rather than the default flagged one.

## On audio streams without a language

Since this depends on the audio stream declaring a language, I checked 1202 files from my own library with ffprobe. 89% declare a language on the audio stream that ends up being selected. Of the 11% that do not, only 2% of the whole set have any subtitles at all, so on those the setting is simply inert rather than doing the wrong thing. Falling back to parsing the file name felt like guesswork, so it deliberately does nothing there.