### PR TITLE
fixed: replace deprecated subtags with their preferred value when canonicalizing

### DIFF
--- a/xbmc/utils/i18n/Bcp47.cpp
+++ b/xbmc/utils/i18n/Bcp47.cpp
@@ -41,6 +41,7 @@ std::optional<CBcp47> CBcp47::ParseTag(std::string str, const CSubTagRegistryMan
     registry = &CServiceBroker::GetSubTagRegistry();
 
   CBcp47 tag;
+  tag.m_registry = registry;
   tag.m_type = p->m_type;
   tag.m_language = std::move(p->m_language);
   tag.m_extLangs = std::move(p->m_extLangs);
@@ -226,19 +227,53 @@ std::string CBcp47::Format(Bcp47FormattingStyle style) const
 
 void CBcp47::Canonicalize()
 {
-  // RFC 5646 - 4.5
+  // RFC 5646 - 4.5, whose steps are applied in order
   //
   // 1. Sort the extensions alphabetically
   std::ranges::sort(m_extensions, {}, &Bcp47Extension::name);
 
-  //! @todo once registry support is available:
-  //! @todo grandfathered tags preferred replacements
-  //! @todo subtags replacement with preferred values
-  //! @todo extlang replacement for canonical form - recreate extlang for extlang form
-  //! @todo reordering of variants using prefixes
-  //! @todo replacement of deprecated with preferred
-  //! @todo suppress script - not part of official canonicalization, but tags should not use
-  //! a script unless it adds information
+  //! @todo 2. Replace a redundant or grandfathered tag by its preferred value - that value is an
+  //! extended language range and can span several subtags, so it has to be parsed rather than
+  //! substituted
+
+  // 3. Replace a subtag by its preferred value. Language and region only for now, which the RFC
+  //    notes covers renamed countries and clerical corrections to ISO 639-1. A subtag deprecated
+  //    without a preferred value is already canonical and stays. The registry spells a preferred
+  //    value as its own record does, so a region arrives upper case while the tag holds subtags
+  //    in lower case.
+  bool replaced{false};
+
+  if (m_registrySubTags.has_value())
+  {
+    const TagSubTags& subTags = m_registrySubTags.value();
+
+    if (subTags.m_language.has_value() && !subTags.m_language->m_preferredValue.empty())
+    {
+      m_language = StringUtils::ToLower(subTags.m_language->m_preferredValue);
+      replaced = true;
+    }
+
+    if (subTags.m_region.has_value() && !subTags.m_region->m_preferredValue.empty())
+    {
+      m_region = StringUtils::ToLower(subTags.m_region->m_preferredValue);
+      replaced = true;
+    }
+  }
+
+  // The cached records still describe the subtags that were dropped, so formatting by description
+  // would name what the replacement retired.
+  if (replaced)
+  {
+    m_registrySubTags.reset();
+    LoadRegistrySubTags(m_registry);
+  }
+
+  //! @todo the rest of step 3 - extlang and variant preferred values. An extlang also replaces
+  //! the primary language subtag, and the canonical form carries no extlang at all, so this is
+  //! also where the extlang form would be recreated
+  //! @todo what 4.5 leaves optional - reordering variants by the 4.1 recommendations, and
+  //! regularizing subtag case - plus suppressing a script that adds no information, which the
+  //! RFC does not count as canonicalization at all
 }
 
 void CBcp47::LoadRegistrySubTags(const CSubTagRegistryManager* registry)

--- a/xbmc/utils/i18n/Bcp47.h
+++ b/xbmc/utils/i18n/Bcp47.h
@@ -84,5 +84,9 @@ private:
   //! @todo when the implementation is mature, revisit whether to keep all fields of the subtags
   //! or just the descriptions, and whether to use std::optional or a smart pointer
   std::optional<TagSubTags> m_registrySubTags;
+
+  //! The registry the tag was parsed against, so canonicalization resolves a replacement subtag
+  //! against the same one. Not owned - a registry outlives the tags parsed from it.
+  const CSubTagRegistryManager* m_registry{nullptr};
 };
 } // namespace KODI::UTILS::I18N

--- a/xbmc/utils/i18n/test/TestBcp47.cpp
+++ b/xbmc/utils/i18n/test/TestBcp47.cpp
@@ -196,6 +196,56 @@ TEST(TestI18nBcp47, Canonicalize)
   EXPECT_EQ(tag->Format(), "ab-a-bc-d-ef-g-hi");
 }
 
+TEST(TestI18nBcp47, CanonicalizeReplacesDeprecatedLanguages)
+{
+  // Moldavian was merged into Romanian in 2008
+  auto tag = CBcp47::ParseTag("mo");
+  tag->Canonicalize();
+  EXPECT_EQ(tag->Format(), "ro");
+  EXPECT_TRUE(tag->IsValid());
+
+  // Only the language subtag is replaced
+  tag = CBcp47::ParseTag("iw-Hebr-IL");
+  tag->Canonicalize();
+  EXPECT_EQ(tag->Format(), "he-Hebr-IL");
+
+  // A current subtag has no preferred value
+  tag = CBcp47::ParseTag("ro");
+  tag->Canonicalize();
+  EXPECT_EQ(tag->Format(), "ro");
+}
+
+TEST(TestI18nBcp47, CanonicalizeReplacesDeprecatedRegions)
+{
+  // Burma became Myanmar, Zaire became the Democratic Republic of the Congo. The registry
+  // spells a region upper case, the tag holds it lower case.
+  auto tag = CBcp47::ParseTag("en-BU");
+  tag->Canonicalize();
+  EXPECT_EQ(tag->Format(), "en-MM");
+
+  tag = CBcp47::ParseTag("fr-ZR");
+  tag->Canonicalize();
+  EXPECT_EQ(tag->Format(), "fr-CD");
+
+  // Both subtags of a tag can be withdrawn
+  tag = CBcp47::ParseTag("mo-DD");
+  tag->Canonicalize();
+  EXPECT_EQ(tag->Format(), "ro-DE");
+}
+
+TEST(TestI18nBcp47, CanonicalizeRefreshesTheRegistryDescriptions)
+{
+  // The registry records cached at parse time describe the subtags that were dropped, so a name
+  // taken from them would read Moldovan and English (Burma)
+  auto tag = CBcp47::ParseTag("mo");
+  tag->Canonicalize();
+  EXPECT_EQ(tag->Format(Bcp47FormattingStyle::FORMAT_ENGLISH), "Romanian");
+
+  tag = CBcp47::ParseTag("en-BU");
+  tag->Canonicalize();
+  EXPECT_EQ(tag->Format(Bcp47FormattingStyle::FORMAT_ENGLISH), "English (Myanmar)");
+}
+
 TEST(TestI18nBcp47, RegistryDI)
 {
   // System registry


### PR DESCRIPTION
A further improvement on top of the language work in #28852. **It should land after that PR** —
see *Relationship to #28852* below.

`CBcp47::Canonicalize()` sorted the extension sequences and stopped, so a tag carrying a withdrawn
subtag kept the withdrawn spelling everywhere it went: JSON-RPC, track selection, whatever a skin
displays. A track tagged `mo` never satisfied a preference for Romanian, and `en-BU` named a
country that has been Myanmar since 1989.

The registry already had the answer. `SubTagLoader` parses `Preferred-Value` into
`BaseSubTag::m_preferredValue` for every subtag type, and `LoadRegistrySubTags` already resolves a
parsed tag against the registry — nothing read it. In `system/language-subtag-registry.txt`, 108
language subtags and 6 region subtags carry one.

## Scope

This is **step 3 of RFC 5646 §4.5**, and only the language and region part of it — which the RFC
itself notes covers "Region subtags where the country name or designation has changed or clerical
corrections to ISO 639-1".

**Step 2 is deliberately left alone** and marked in place, between steps 1 and 3, rather than as a
footnote: a redundant or grandfathered tag's preferred value is an *extended language range* that
can span several subtags, so it has to be parsed rather than substituted. §4.5 defines its steps
as applying in order, so a reader tracing 1 → 3 needs to see that 2 is absent.

The remaining `@todo`s are the extlang and variant half of step 3, and what §4.5 marks `MAY` /
OPTIONAL. The function went from six `@todo`s to three.

## Two things the substitution cannot do on its own

**The cached registry records go stale.** `CBcp47Formatter` reads `m_registrySubTags` for
`FORMAT_ENGLISH`, so substituting a subtag without refreshing left `mo` formatting as *"Moldovan"*
and `en-BU` as *"English (Burma)"* — the tag says `ro` while its own English name says otherwise.
The records are reloaded after a replacement. `CanonicalizeRefreshesTheRegistryDescriptions`
covers it.

**Case.** `Bcp47Parser` lowercases the whole tag and the formatter uppercases regions on output,
but `m_preferredValue` is stored as its own registry record spells it — so a region preferred value
arrives as `MM`, not `mm`, and would miss on the reload lookup.

That reload needs the registry, which `Canonicalize()` had no way to reach. The tag now keeps the
registry it was parsed against, rather than taking one as a parameter — this leaves the existing
signature untouched, and makes it impossible to canonicalize a tag against a different registry
than the one it was validated with.

A subtag deprecated *without* a preferred value is already canonical per §4.5 and is left alone.

## Relationship to #28852

No code dependency — this branches from master and touches `Bcp47.cpp`, which #28852 does not.
But the two overlap on behaviour and this one should merge second:

#28852 added three rows (`ji`, `jw`, `mo`) to `DeprecatedLanguageCodes` in `TableLanguageCodes.h`
to fix the same `mo` symptom through the ISO 639-2/B narrowing path. Once canonicalization applies
preferred values, those rows are no longer reachable through `ConvertToBcp47`. They stay live for
direct `ConvertISO6391ToISO6392B` callers, so it is not a clean revert — but a hand-maintained
list standing in for data the registry already ships is a second source of truth, and shrinking it
is best done as a follow-up once both have landed.

## Tests

Three new cases in `TestBcp47.cpp`, each failing before the change and passing after: language
replacement, region replacement, and the description refresh. Full suite green (3526 passed, with
the port-collision-flaky `TestWebServer` / `TestHTTPDirectory` suites filtered). clang-format clean
on the touched lines.
