### PR TITLE
fixed: keep the network services running when logging off the master profile

### DIFF
--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -467,7 +467,11 @@ void CProfileManager::LogOff()
   // Stop PVR services
   CServiceBroker::GetPVRManager().Stop();
 
-  networkManager.NetworkMessage(CNetworkBase::SERVICES_DOWN, 1);
+  // Only stop the services when the profile switch that follows will start them again.
+  if (m_currentProfile != MASTER_PROFILE_ID)
+  {
+    networkManager.NetworkMessage(CNetworkBase::SERVICES_DOWN, 1);
+  }
 
   // Reset the database manager so the master profile's databases are
   // re-initialized cleanly when the login screen is shown again.


### PR DESCRIPTION
## Description

`CProfileManager::LogOff()` stopped the network services unconditionally and relied on the profile switch that follows to start them again:

```cpp
networkManager.NetworkMessage(CNetworkBase::SERVICES_DOWN, 1);
...
LoadMasterProfileForLogin();
```

`LoadMasterProfileForLogin()` only calls `LoadProfile()` when the current profile is not the master one:

```cpp
if (m_currentProfile != MASTER_PROFILE_ID)
{
  m_profileLoadedForLogin = true;
  LoadProfile(MASTER_PROFILE_ID);
  ...
}
```

So logging off **the master profile** stops the web server, the JSON-RPC server and the rest with nothing left to start them again. The application keeps running, so restarting Kodi is the only recovery.

Logging off any other profile is unaffected: `PrepareLoadProfile()` already stops the services for that case and `FinalizeLoadProfile()` starts them again — which is why the services are expected to be running on the login screen at all.

This change only stops the services when the profile switch that follows will start them again.

## Motivation and context

Fixes #27771 — the JSON-RPC API stops answering (`ECONNREFUSED` on the web server port) after logging out of the master user, and only a Kodi restart brings it back. The reporter notes that logging off any other profile works fine, which matches the two code paths above.

The `StartEventServer()` call at the end of `LogOff()` already covers one service on this path; the web server and the JSON-RPC server were left down. This makes the whole set consistent rather than adding a second special case, so that call is left untouched — with the guard in place the event server is never stopped on the master path, and `StartEventServer()` returns early when it is already running.

## How has this been tested?

Windows x64, two profiles, `useloginscreen` enabled, `System.LogOff` driven over JSON-RPC and the API polled afterwards.

**Logging off the master profile — before this change:**

| step | result |
| --- | --- |
| logged into master, `JSONRPC.Ping` | `pong` |
| `System.LogOff` | — |
| `JSONRPC.Ping`, polled every 2 s for 30 s | `ECONNREFUSED`, never recovers |

```
19:37:28.713  [probe] executing System.LogOff
19:37:28.743  CNetworkBase::NetworkMessage - Signaling network services to stop
19:37:28.745  CWebserver[...]: Stopped          <- nothing follows
```

**After this change:** the same sequence keeps answering `pong` throughout.

**Logging off a secondary profile — unchanged before and after**, and still logs the full sequence:

```
Signaling network services to stop     <- LogOff()
Signaling network services to stop     <- PrepareLoadProfile()
Starting network services              <- FinalizeLoadProfile()
```

Full gtest suite green (3570 tests, 273 suites). `clang-format` clean on the touched lines.

## What is the effect on users?

Controlling Kodi over the web interface or JSON-RPC keeps working after logging off the master profile, instead of needing a restart.

## Types of change

- Bug fix (non-breaking change which fixes an issue)
