### PR TITLE
fixed: keep the database manager initialized when logging off the master profile

### DIFF
--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -41,9 +41,10 @@ public:
   bool Initialize();
 
   /*! \brief Reset the database manager state.
-   Must be called on profile changes (LoadProfile / LogOff) so that the
-   next call to Initialize() re-runs the schema version check and migration
-   for all databases under the new profile's database folder.
+   Call this immediately before Initialize() when switching profile, so that
+   Initialize() re-runs the schema version check and migration for all databases
+   under the new profile's database folder. No database can be opened again until
+   Initialize() has run.
    */
   void Deinitialize();
 

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -469,12 +469,6 @@ void CProfileManager::LogOff()
 
   networkManager.NetworkMessage(CNetworkBase::SERVICES_DOWN, 1);
 
-  // Reset the database manager so the master profile's databases are
-  // re-initialized cleanly when the login screen is shown again.
-  CServiceBroker::GetDatabaseManager().Deinitialize();
-
-  // LoadMasterProfileForLogin calls LoadProfile, which closes and re-opens
-  // all databases at the correct point in the switch sequence.
   LoadMasterProfileForLogin();
 
   g_passwordManager.bMasterUser = false;


### PR DESCRIPTION
## Description

`CDatabaseManager::Deinitialize()` clears `m_dbDetails`, and `CDatabase::Open()` refuses to open any database whose base name is absent from that map:

```cpp
// CDatabase::Open, Database.cpp
if (!CServiceBroker::GetDatabaseManager().CanOpen(GetBaseDBName()))
  return false;
```

so the call must always be followed by `Initialize()`.

`CProfileManager::LoadProfile()` pairs them. `CProfileManager::LogOff()` called `Deinitialize()` on its own, relying on `LoadMasterProfileForLogin()` to reach `LoadProfile()`:

```cpp
CServiceBroker::GetDatabaseManager().Deinitialize();

LoadMasterProfileForLogin();
```

`LoadMasterProfileForLogin()` only calls `LoadProfile()` when the current profile is not the master one, so **logging off the master profile leaves the manager reset and every later `CDatabase::Open()` fails**.

Logging back in does not recover it. `LoadProfile()` returns early for a master-to-master load, before the `Initialize()` call:

```cpp
if (index == MASTER_PROFILE_ID && IsMasterProfile())
{
  ...
  FinalizeLoadProfile();
  return true;      // never reaches GetDatabaseManager().Initialize()
}
```

This drops the unpaired call. `LoadProfile()` already resets the manager immediately before initializing it, so nothing is lost when a profile switch does occur.

`Deinitialize()` documented itself as something to call on a profile change in either `LoadProfile()` or `LogOff()`, which is what invited the unpaired call in the first place. Its doc comment now describes the pairing with `Initialize()`, and states that no database can be opened until `Initialize()` has run.

## Motivation and context

Introduced by b6315c95f331dffdfcec5b61bd20d748ce469c81, whose own commit message describes the intended usage as calling `Deinitialize()` "right before `Initialize()`". That holds in `LoadProfile()` but not in `LogOff()`.

This is a regression against v21 and is present in 22.0b1. It is not the cause of #27771 — that reporter is on 21.3.0 — but it sits on the same code path, and it is only observable once the network services survive the log off, since otherwise the API used to die first.

## How has this been tested?

Windows x64, two profiles, `useloginscreen` enabled, `System.LogOff` driven over JSON-RPC.

| step | before | after |
| --- | --- | --- |
| logged into master, `VideoLibrary.GetMovies` | 1156 movies | 1156 movies |
| after `System.LogOff` | `-32603 Internal error` | 1156 movies |
| after logging back in as the master user | `-32603 Internal error` | 1156 movies |

Verifying this requires the network services to still be up after the log off, so the measurement was taken with the fix for #27771 also applied locally. The two changes are otherwise independent.

Full gtest suite green (3570 tests, 273 suites). `clang-format` clean on the touched lines.

## What is the effect on users?

With `useloginscreen` enabled, logging off the master profile no longer leaves every database unopenable for the rest of the session — the library, and anything else backed by a database, keeps working instead of needing a restart.

## Types of change

- Bug fix (non-breaking change which fixes an issue)
