### PR TITLE
fixed: make file agree with filetype for a movie with versions or extras

### DIFF
--- a/xbmc/interfaces/json-rpc/FileItemHandler.cpp
+++ b/xbmc/interfaces/json-rpc/FileItemHandler.cpp
@@ -375,8 +375,15 @@ void CFileItemHandler::HandleFileItem(const char* ID,
     {
       if (allowFile)
       {
-        if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->GetPath().empty())
+        //! @todo get rid of "videos with versions as folder" hack!
+        if (fields.contains("filetype") && item->GetProperty("IsHybridFolder").asBoolean(false))
+        {
+          object["file"] = item->GetPath().c_str();
+        }
+        else if (item->HasVideoInfoTag() && !item->GetVideoInfoTag()->GetPath().empty())
+        {
           object["file"] = item->GetVideoInfoTag()->GetPath().c_str();
+        }
         if (item->HasMusicInfoTag() && !item->GetMusicInfoTag()->GetURL().empty())
           object["file"] = item->GetMusicInfoTag()->GetURL().c_str();
         if (item->HasPVRTimerInfoTag() && !item->GetPVRTimerInfoTag()->Path().empty())


### PR DESCRIPTION
## Description
A movie with versions or extras is listed as a folder, but `Files.GetDirectory` reported its `file` as the default version's plain path — `filetype: "directory"` next to a value that cannot be expanded. `file` now carries the item path where `filetype` is reported next to it.

Before: `{ "file": "smb://.../Twelve.Monkeys.1995.mkv", "filetype": "directory" }` — recursing on it fails with Invalid params.
After: `{ "file": "videodb://movies/titles/2/-2/", "filetype": "directory" }` — recursing on it lists the versions.

`VideoLibrary.GetMovies` and `VideoLibrary.GetMovieDetails` are unchanged; the value clients pass to `Player.Open` still names the default version. A minor `JSONRPC_VERSION` bump may be warranted; left out pending coordination with other in-flight JSON-RPC branches.

## Motivation and context
A client that recurses on `filetype` fails on the follow-up call. Fixes #27569.

## How has this been tested?
On a running instance against a movie with a second version: `Files.GetDirectory` (titles node and smart playlist), the follow-up call on the reported value, both `VideoLibrary` methods, and sets/tvshow folders compared before and after. Full gtest suite green.

## What is the effect on users?
JSON-RPC clients can browse into a movie's versions and extras from a directory listing.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
