### PR TITLE
application: fix two shutdown deadlocks on the manager lock

### DIFF
--- a/xbmc/guilib/handlers/player/GUIPlayerAnnouncementHandler.cpp
+++ b/xbmc/guilib/handlers/player/GUIPlayerAnnouncementHandler.cpp
@@ -14,6 +14,7 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "interfaces/AnnouncementManager.h"
+#include "messaging/ApplicationMessenger.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
@@ -62,8 +63,9 @@ void CGUIPlayerAnnouncementHandler::Announce(ANNOUNCEMENT::AnnouncementFlag flag
     if (CServiceBroker::GetGUI()->GetWindowManager().GetActiveWindow() !=
         WINDOW_DIALOG_PLAYER_PROCESS_INFO)
     {
-      CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(
-          WINDOW_DIALOG_PLAYER_PROCESS_INFO);
+      // post: a synchronous activation blocks this thread until the dialog closes
+      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTIVATE_WINDOW,
+                                                 WINDOW_DIALOG_PLAYER_PROCESS_INFO, 0);
     }
   }
   else if (message == "OnPlaybackFailed")

--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -496,6 +496,9 @@ bool CTCPServer::InitializeTCP()
 
 void CTCPServer::Deinitialize()
 {
+  // unregister first so no Announce callback runs during teardown
+  CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
+
   std::unique_lock lock(m_connectionsCritSection);
 
   for (unsigned int i = 0; i < m_connections.size(); i++)
@@ -516,8 +519,6 @@ void CTCPServer::Deinitialize()
     sdp_close((sdp_session_t*)m_sdpd);
   m_sdpd = NULL;
 #endif
-
-  CServiceBroker::GetAnnouncementManager()->RemoveAnnouncer(this);
 }
 
 CTCPServer::CTCPClient::CTCPClient()


### PR DESCRIPTION
## Description

Fix shutdown deadlock when quitting with the `PlayerProcessInfo` dialog open

Quitting while DialogPlayerProcessInfo is open deadlocks shutdown until the service manager kills the process:

Announce thread holds manager lock, ActivateWindow via synchronous SendMsg... completes only when the modal dialog closes main thread CApplication::Stop, joins TCPServer thread TCPServer thread  Deinitialize -> RemoveAnnouncer, blocked on manager lock

Main waits on TCPServer, TCPServer on the lock, the lock holder on main. Regression from edb9c9052a: the handler runs
ActivateWindow on the announce thread, where it becomes a blocking cross-thread send; previously ACTION_PLAYER_PROCESS_INFO activated from the main thread.

Fix: post the activation instead (same pattern as JSON-RPC GUI.ActivateWindow). Also unregister the TCPServer announcer before taking m_connectionsCritSection in Deinitialize - holding it across RemoveAnnouncer inverts lock order against the broadcast path (latent, from #28219).

Repro: play anything, open the process info OSD, send SIGTERM.


## Motivation and context
Exiting Kodi hangs if OSD PlayerProcessInfo is up.

## How has this been tested?
Intel N250 / Linux GBM

## What is the effect on users?
not much on real users, big help for testing

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
