### PR TITLE
fix(dbwrappers): escape %s conversions that follow a literal percent

### DIFF
--- a/xbmc/dbwrappers/dataset.cpp
+++ b/xbmc/dbwrappers/dataset.cpp
@@ -73,6 +73,20 @@ std::string Database::prepare(const char* format, ...)
   return result;
 }
 
+void Database::EscapeStringConversions(std::string& format)
+{
+  size_t pos = 0;
+  while ((pos = format.find('%', pos)) != std::string::npos && pos + 1 < format.size())
+  {
+    // Everything that is not "%s" is either the literal percent "%%" asks for, or some other
+    // conversion (%i, %02d, %I64 ...) whose remaining characters cannot contain a percent. Either
+    // way resuming the search past these two is enough to stay in step.
+    if (format[pos + 1] == 's')
+      format.replace(pos, 2, "%q");
+    pos += 2;
+  }
+}
+
 //************* Dataset implementation ***************
 
 Dataset::Dataset() = default;

--- a/xbmc/dbwrappers/dataset.h
+++ b/xbmc/dbwrappers/dataset.h
@@ -173,6 +173,14 @@ public:
   virtual std::string vprepare(std::string_view format, va_list args) = 0;
 
   virtual bool in_transaction() { return false; }
+
+protected:
+  /*! \brief Rewrite each "%s" conversion sequence to "%q", the quote-escaping form.
+   \param format - C printf compliant format string, rewritten in place
+
+   Scanning is left to right so that %% is consumed as the literal percent it is.
+   */
+  static void EscapeStringConversions(std::string& format);
 };
 
 /******************* Class Dataset definition *********************

--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -736,23 +736,14 @@ bool MysqlDatabase::exists()
 std::string MysqlDatabase::vprepare(std::string_view format, va_list args)
 {
   std::string strFormat{format};
-  std::string strResult;
-  size_t pos;
+  //  Transform the %s printf format specifier to the Sqlite specific %q for sql-safe escape of
+  //  quotes in format parameters. mysql_vmprintf() is derived from sqlite3.c and understands it
+  //  the same way.
+  EscapeStringConversions(strFormat);
 
-  //  %q is the sqlite format string for %s.
-  //  Any bad character, like "'", will be replaced with a proper one
-  pos = 0;
-  while ((pos = strFormat.find("%s", pos)) != std::string::npos)
-  {
-    // %%s is meant as a literal % followed by s, skip
-    if (pos == 0 || strFormat[pos - 1] != '%')
-      strFormat.replace(pos, 2, "%q");
-    pos++;
-  }
-
-  strResult = mysql_vmprintf(strFormat.c_str(), args);
+  std::string strResult = mysql_vmprintf(strFormat.c_str(), args);
   //  RAND() is the mysql form of RANDOM()
-  pos = 0;
+  size_t pos = 0;
   while ((pos = strResult.find("RANDOM()", pos)) != std::string::npos)
   {
     strResult.replace(pos, 8, "RAND()");

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -633,31 +633,21 @@ void SqliteDatabase::rollback_transaction()
 std::string SqliteDatabase::vprepare(std::string_view format, va_list args)
 {
   std::string strFormat{format};
-  std::string strResult;
-  char* p;
-  size_t pos;
-
-  //  %q is the sqlite format string for %s.
-  //  Any bad character, like "'", will be replaced with a proper one
-  pos = 0;
-  while ((pos = strFormat.find("%s", pos)) != std::string::npos)
-  {
-    // %%s is meant as a literal % followed by s, skip
-    if (pos == 0 || strFormat[pos - 1] != '%')
-      strFormat.replace(pos, 2, "%q");
-    pos += 2;
-  }
+  //  Transform the %s printf format specifier to the Sqlite specific %q for sql-safe escape of
+  //  quotes in format parameters
+  EscapeStringConversions(strFormat);
 
   //  the %I64 enhancement is not supported by sqlite3_vmprintf
   //  must be %ll instead
-  pos = 0;
+  size_t pos = 0;
   while ((pos = strFormat.find("%I64", pos)) != std::string::npos)
   {
     strFormat.replace(pos, 4, "%ll");
     pos++;
   }
 
-  p = sqlite3_vmprintf(strFormat.c_str(), args);
+  std::string strResult;
+  char* p = sqlite3_vmprintf(strFormat.c_str(), args);
   if (p)
   {
     strResult = p;

--- a/xbmc/dbwrappers/test/TestVPrepare.cpp
+++ b/xbmc/dbwrappers/test/TestVPrepare.cpp
@@ -19,7 +19,7 @@
 namespace
 {
 template<std::derived_from<dbiplus::Database> T>
-std::string PrepareSQL(std::string_view sqlFormat, ...)
+std::string TestPrepareSQL(std::string_view sqlFormat, ...)
 {
   std::string strResult;
   T db;
@@ -31,7 +31,68 @@ std::string PrepareSQL(std::string_view sqlFormat, ...)
 
   return strResult;
 }
+
+//! \brief Reaches the protected conversion pass. Abstract and never instantiated, so the pure
+//! virtuals of Database can stay unimplemented.
+class TestDatabase : public dbiplus::Database
+{
+public:
+  using dbiplus::Database::EscapeStringConversions;
+};
+
+std::string TestEscapeStringConversions(std::string_view format)
+{
+  std::string result{format};
+  TestDatabase::EscapeStringConversions(result);
+  return result;
+}
 } // namespace
+
+struct EscapeConversionsTest
+{
+  std::string format;
+  std::string expected;
+};
+
+const auto EscapeConversionsTests = std::array{
+    // nothing to rewrite
+    EscapeConversionsTest{"", ""},
+    EscapeConversionsTest{"SELECT foo", "SELECT foo"},
+    // %s is the escaping conversion and becomes %q
+    EscapeConversionsTest{"%s", "%q"},
+    EscapeConversionsTest{"WHERE name = '%s'", "WHERE name = '%q'"},
+    EscapeConversionsTest{"%s%s", "%q%q"},
+    // %% is a literal percent, so the %s that %%s hides is the literal "%s" and must survive
+    EscapeConversionsTest{"%%s", "%%s"},
+    EscapeConversionsTest{"strftime(\"%%s\",c01)", "strftime(\"%%s\",c01)"},
+    // ... while the LIKE wildcard idiom is a literal percent followed by a conversion
+    EscapeConversionsTest{"'%%%s%%'", "'%%%q%%'"},
+    EscapeConversionsTest{"'%%%s'", "'%%%q'"},
+    EscapeConversionsTest{"'%s%%'", "'%q%%'"},
+    // a literal %s does not consume the conversion that follows it
+    EscapeConversionsTest{"%%s '%s'", "%%s '%q'"},
+    // any other conversion is stepped over whole, keeping the scan in step with the percents that
+    // follow it. VIDEODB_ID_* queries look exactly like this.
+    EscapeConversionsTest{"%i %s", "%i %q"},
+    EscapeConversionsTest{"WHERE c%02d LIKE '%%%s%%'", "WHERE c%02d LIKE '%%%q%%'"},
+    // a trailing percent has no second half to read
+    EscapeConversionsTest{"100%", "100%"},
+};
+
+class EscapeConversionsTester : public testing::WithParamInterface<EscapeConversionsTest>,
+                                public testing::Test
+{
+};
+
+TEST_P(EscapeConversionsTester, EscapeStringConversions)
+{
+  const auto params = GetParam();
+  EXPECT_EQ(params.expected, TestEscapeStringConversions(params.format));
+}
+
+INSTANTIATE_TEST_SUITE_P(TestDbWrappers,
+                         EscapeConversionsTester,
+                         testing::ValuesIn(EscapeConversionsTests));
 
 struct VPrepareNoParamTest
 {
@@ -79,17 +140,59 @@ class VPrepareNoParamTester : public testing::WithParamInterface<VPrepareNoParam
 TEST_P(VPrepareNoParamTester, Sqlite)
 {
   const auto params = GetParam();
-  EXPECT_EQ(params.expectedSqlite, PrepareSQL<dbiplus::SqliteDatabase>(params.format));
+  EXPECT_EQ(params.expectedSqlite, TestPrepareSQL<dbiplus::SqliteDatabase>(params.format));
 }
 
 #if defined(HAS_MYSQL) || defined(HAS_MARIADB)
 TEST_P(VPrepareNoParamTester, MySql)
 {
   const auto params = GetParam();
-  EXPECT_EQ(params.expectedMySql, PrepareSQL<dbiplus::MysqlDatabase>(params.format));
+  EXPECT_EQ(params.expectedMySql, TestPrepareSQL<dbiplus::MysqlDatabase>(params.format));
 }
 #endif
 
 INSTANTIATE_TEST_SUITE_P(TestDbWrappers,
                          VPrepareNoParamTester,
                          testing::ValuesIn(VPrepareNoParamTests));
+
+/*!
+ * Sqlite only: escaping a value is what these cover, and MySQL escapes through
+ * mysql_real_escape_string(), which needs the live connection a unit test has no way to hand it.
+ * Which conversions become %q is backend independent - the pass is shared - so the format strings
+ * below still stand in for both.
+ */
+struct VPrepareStringParamTest
+{
+  std::string format;
+  std::string param;
+  std::string expected;
+};
+
+const auto VPrepareStringParamTests = std::array{
+    // %s is the escaping conversion: a quote in the value has to come out doubled
+    VPrepareStringParamTest{"WHERE name = '%s'", "O'Brien", "WHERE name = 'O''Brien'"},
+    // ... including behind the LIKE wildcards, where the %% before it is a literal percent and
+    // does not turn the %s into the literal "%s" that %%s asks for
+    VPrepareStringParamTest{"WHERE name LIKE '%%%s%%'", "O'Brien", "WHERE name LIKE '%O''Brien%'"},
+    VPrepareStringParamTest{"WHERE name LIKE '%%%s'", "O'Brien", "WHERE name LIKE '%O''Brien'"},
+    VPrepareStringParamTest{"WHERE name LIKE '%s%%'", "O'Brien", "WHERE name LIKE 'O''Brien%'"},
+    // a literal %s still survives, and does not consume the conversion that follows it
+    VPrepareStringParamTest{"CAST(strftime(\"%%s\",c01) AS REAL) = '%s'", "O'Brien",
+                            "CAST(strftime(\"%s\",c01) AS REAL) = 'O''Brien'"},
+};
+
+class VPrepareStringParamTester : public testing::WithParamInterface<VPrepareStringParamTest>,
+                                  public testing::Test
+{
+};
+
+TEST_P(VPrepareStringParamTester, Sqlite)
+{
+  const auto params = GetParam();
+  EXPECT_EQ(params.expected,
+            TestPrepareSQL<dbiplus::SqliteDatabase>(params.format, params.param.c_str()));
+}
+
+INSTANTIATE_TEST_SUITE_P(TestDbWrappers,
+                         VPrepareStringParamTester,
+                         testing::ValuesIn(VPrepareStringParamTests));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

`vprepare()` rewrites `%s` to `%q` so values are quote escaped, but it skipped the rewrite whenever a
percent preceded the `%s`, to leave the literal `%s` that `%%s` asks for alone.

One character of context cannot tell `%%s` from `%%` followed by `%s` — the LIKE wildcard idiom
`'%%%s%%'`. So in every LIKE query the value reached `sqlite3_vmprintf()`/`mysql_vmprintf()` through
a raw `%s`, unescaped.

Scanning the format string left to right consumes `%%` as the literal percent it is, which
distinguishes the two readings. The pass now lives in `Database::EscapeStringConversions()`: the two
backends had drifted apart here, and now share it.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

An unescaped value in a query string breaks the query when it contains an apostrophe, and is
injectable. It affects every LIKE search in the codebase, and the *contains*, *does not contain* and
*ends with* operators of every smart playlist.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`xbmc/dbwrappers/test/TestVPrepare.cpp` gains:

- unit tests of `EscapeStringConversions()` covering `%s`, the literal `%s` behind `%%`, the LIKE
  wildcard idiom in its three forms, and an unrelated conversion (`%02d`) ahead of the wildcards;
- end-to-end `vprepare()` tests through the Sqlite backend asserting that a value holding an
  apostrophe comes out doubled.

The end-to-end wildcard cases fail against the old pass and pass against the new one. The existing
`vprepare()` tests are unchanged and still pass, on Sqlite and MySQL.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Searching the library for a term containing an apostrophe now returns its results instead of
silently failing, as do the *contains*, *does not contain* and *ends with* smart playlist operators.

## Screenshots (if appropriate):

n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
