### PR TITLE
fixed: report AirPlay cover art through Player.GetItem

### DIFF
--- a/xbmc/application/ApplicationMessageHandling.cpp
+++ b/xbmc/application/ApplicationMessageHandling.cpp
@@ -402,7 +402,7 @@ void CApplicationMessageHandling::OnApplicationMessage(MESSAGING::ThreadMessage*
     case TMSG_UPDATE_PLAYER_ITEM:
     {
       std::unique_ptr<CFileItem> item{static_cast<CFileItem*>(pMsg->lpVoid)};
-      if (item)
+      if (item && m_app.CurrentFileItem().IsSamePath(item.get()))
       {
         m_app.CurrentFileItem().UpdateInfo(*item);
         CServiceBroker::GetGUI()->GetInfoManager().UpdateCurrentItem(m_app.CurrentFileItem());

--- a/xbmc/network/AirTunesServer.cpp
+++ b/xbmc/network/AirTunesServer.cpp
@@ -150,6 +150,23 @@ void CAirTunesServer::RefreshCoverArt(const char *outputFilename/* = NULL*/)
   //update the ui
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL,0,0,GUI_MSG_REFRESH_THUMBS);
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+
+  // The info manager and the application hold separate items; only the latter is serialised.
+  const std::string pipeName =
+      ServerInstance != nullptr && ServerInstance->m_pPipe != nullptr
+          ? ServerInstance->m_pPipe->GetName()
+          : std::string{};
+  if (!pipeName.empty())
+  {
+    // UpdateInfo overwrites the mime type, and an empty url clears the previous thumbnail.
+    CFileItem* item = new CFileItem();
+    item->SetPath(pipeName);
+    item->SetMimeType("audio/x-xbmc-pcm");
+    item->SetArt("thumb", CFile::Exists(coverArtFile) ? coverArtFile : "");
+
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_UPDATE_PLAYER_ITEM, -1, -1,
+                                               static_cast<void*>(item));
+  }
 }
 
 void CAirTunesServer::SetMetadataFromBuffer(const char *buffer, unsigned int size)


### PR DESCRIPTION
**TL;DR:** Bug fix, untested for want of an AirPlay sender. AirPlay cover art was written only to the info manager's item, so the NowPlaying screen showed it while `Player.GetItem` reported an empty thumbnail. The art is now posted through `TMSG_UPDATE_PLAYER_ITEM`, which serves both. Testers with an iOS device wanted.

## Description
`CAirTunesServer::RefreshCoverArt` sets the cover art via `CGUIInfoManager::SetCurrentAlbumThumb`, which writes to `CGUIInfoManager::m_currentFile`. `Player.GetItem` serialises `g_application.CurrentFileItem()` — a **different object**, which never receives the art. So the NowPlaying screen shows the cover while JSON-RPC reports `"thumbnail": ""`.

Neither existing fallback can cover it:

- The audio branch of `Player.GetItem` falls back to `GetCurrentSongTag()` and copies a `CMusicInfoTag`. Art is not part of the music tag — it lives on the `CFileItem` — so this path cannot carry a thumbnail even when it fires. (This is why the *title* and *artist* do come through and only the art does not.)
- The thumb loader path in `CFileItemHandler` requires `GetDatabaseId() > -1`, and an AirPlay stream has no database id.

The `@todo` already in `PlayerOperations.cpp` names this class of problem: *"remove this once there is no route to playback that updates GUI item without also updating app item"*.

**The change.** `TMSG_UPDATE_PLAYER_ITEM` already does the right thing — it updates the application item and then refreshes the info manager from it — so posting the art there serves both surfaces from one path. `CFileItem::UpdateInfo` copies art, so it arrives intact.

The posted item carries the playing item's path and mime type so that `UpdateInfo`, which copies both, leaves them unchanged. An empty url is posted when the art file is gone, so that `ResetMetadata` still clears a previous track's thumbnail instead of leaving it stale.

The existing `SetCurrentAlbumThumb` call is deliberately **kept**. It drives the skin refresh that depends on the empty-then-set sequence, and removing it would change GUI behaviour that currently works. This PR is additive to the GUI path.

**Risks.**

- **Mime type.** `UpdateInfo` calls `SetMimeType` + `UpdateMimeType`. The posted item sets `audio/x-xbmc-pcm` to match the playing item so this should be a no-op — but if anything reads the mime type after playback has started, that assumption is worth a second pair of eyes.
- The change is platform-neutral C++ in `xbmc/network` and applies anywhere `ENABLE_AIRTUNES` is on, which is everywhere except tvOS and wasm. Labelled `Platform: Linux` because that is where the issue was reported; it is not Linux-specific.

**Not done here.** `ShoutcastFile.cpp` posts the same GUI-only `TMSG_UPDATE_CURRENT_ITEM` pattern for internet radio metadata, which looks like the same root cause behind #25507. I have left that alone rather than widen this PR; happy to follow up separately if this approach is accepted.

## Motivation and context
Fixes #25347.

## How has this been tested?
**I have no AirPlay sender to test against, so this fix is reasoned from the code and has not been observed working.** It compiles clean, but that proves nothing about the behaviour. If you have an iOS device and a Kodi with AirTunes enabled, the check is quick:

1. Play a song to Kodi over AirPlay from an iOS device.
2. Confirm the NowPlaying screen still shows the cover art (this must not regress).
3. Ask for the thumbnail over JSON-RPC:

```
{"jsonrpc":"2.0","method":"Player.GetItem","params":{"playerid":0,"properties":["thumbnail"]},"id":1}
```

Before this change `thumbnail` is `""`. After it, it should be an `image://` url.

4. Worth also checking that the thumbnail **clears** when a track without art follows one with art, rather than showing the previous track's cover.

Reviewers who know this area: I would especially like a second opinion on the mime type write, called out under "Risks" above.

## What is the effect on users?
Remotes and add-ons that read the playing item over JSON-RPC see the cover art of a track played to Kodi over AirPlay.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
