### PR TITLE
DRMPRIME and VAAPI buffer lifetime cache

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -1,6 +1,7 @@
 xbmc/addons/gui/skin/test         test/skin
 xbmc/addons/test                  test/addons
 xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
+xbmc/cores/VideoPlayer/Buffers/test test/videoplayer_buffers
 xbmc/cores/VideoPlayer/test       test/videoplayer
 xbmc/cores/VideoPlayer/DVDDemuxers/test test/dvddemuxers
 xbmc/cores/VideoPlayer/Edl/test   test/edl

--- a/docs/README.Linux.md
+++ b/docs/README.Linux.md
@@ -3,6 +3,8 @@
 # Linux build guide
 This is the general Linux build guide. Please read it in full before you proceed to familiarize yourself with the build procedure.
 
+Builds with VAAPI or DRMPRIME video acceleration require Linux kernel 5.3 or later at runtime: the video player identifies dma-buf memory by inode, which the kernel allocates uniquely from 5.3 on.
+
 Several distribution **[specific build guides](README.md)** are available.
 
 ## Table of Contents

--- a/xbmc/cores/VideoPlayer/Buffers/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/Buffers/CMakeLists.txt
@@ -2,10 +2,12 @@ set(SOURCES VideoBuffer.cpp)
 set(HEADERS VideoBuffer.h)
 
 if("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC)
-  list(APPEND SOURCES VideoBufferDMA.cpp
+  list(APPEND SOURCES DmaBufIdentity.cpp
+                      VideoBufferDMA.cpp
                       VideoBufferDRMPRIME.cpp
                       VideoBufferPoolDMA.cpp)
-  list(APPEND HEADERS VideoBufferDMA.h
+  list(APPEND HEADERS DmaBufIdentity.h
+                      VideoBufferDMA.h
                       VideoBufferDRMPRIME.h
                       VideoBufferPoolDMA.h)
 endif()

--- a/xbmc/cores/VideoPlayer/Buffers/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/Buffers/CMakeLists.txt
@@ -3,10 +3,12 @@ set(HEADERS VideoBuffer.h)
 
 if("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC)
   list(APPEND SOURCES DmaBufIdentity.cpp
+                      DmaBufIdentityCache.cpp
                       VideoBufferDMA.cpp
                       VideoBufferDRMPRIME.cpp
                       VideoBufferPoolDMA.cpp)
   list(APPEND HEADERS DmaBufIdentity.h
+                      DmaBufIdentityCache.h
                       VideoBufferDMA.h
                       VideoBufferDRMPRIME.h
                       VideoBufferPoolDMA.h)

--- a/xbmc/cores/VideoPlayer/Buffers/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/Buffers/CMakeLists.txt
@@ -1,7 +1,8 @@
 set(SOURCES VideoBuffer.cpp)
 set(HEADERS VideoBuffer.h)
 
-if("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC)
+if("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC
+   OR "x11" IN_LIST CORE_PLATFORM_NAME_LC)
   list(APPEND SOURCES DmaBufIdentity.cpp
                       DmaBufIdentityCache.cpp
                       VideoBufferDMA.cpp

--- a/xbmc/cores/VideoPlayer/Buffers/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/Buffers/CMakeLists.txt
@@ -1,16 +1,20 @@
 set(SOURCES VideoBuffer.cpp)
 set(HEADERS VideoBuffer.h)
 
+# dma-buf identity is consumed by the VAAPI EGL path, which builds on x11 too
 if("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC
    OR "x11" IN_LIST CORE_PLATFORM_NAME_LC)
   list(APPEND SOURCES DmaBufIdentity.cpp
-                      DmaBufIdentityCache.cpp
-                      VideoBufferDMA.cpp
+                      DmaBufIdentityCache.cpp)
+  list(APPEND HEADERS DmaBufIdentity.h
+                      DmaBufIdentityCache.h)
+endif()
+
+if("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC)
+  list(APPEND SOURCES VideoBufferDMA.cpp
                       VideoBufferDRMPRIME.cpp
                       VideoBufferPoolDMA.cpp)
-  list(APPEND HEADERS DmaBufIdentity.h
-                      DmaBufIdentityCache.h
-                      VideoBufferDMA.h
+  list(APPEND HEADERS VideoBufferDMA.h
                       VideoBufferDRMPRIME.h
                       VideoBufferPoolDMA.h)
 endif()

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentity.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentity.cpp
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DmaBufIdentity.h"
+
+#include <sys/stat.h>
+
+namespace DRMPRIME
+{
+
+bool StatInode(int fd, uint64_t& inode)
+{
+  struct stat st
+  {
+  };
+  if (fstat(fd, &st) != 0)
+    return false;
+
+  inode = st.st_ino;
+  return true;
+}
+
+bool DmaBufIdentity::SameMemory(const DmaBufIdentity& other) const
+{
+  auto contains = [](const DmaBufIdentity& haystack, uint64_t needle)
+  {
+    for (int i = 0; i < haystack.nbObjects; i++)
+      if (haystack.inode[i] == needle)
+        return true;
+    return false;
+  };
+  for (int i = 0; i < nbObjects; i++)
+    if (!contains(other, inode[i]))
+      return false;
+  for (int i = 0; i < other.nbObjects; i++)
+    if (!contains(*this, other.inode[i]))
+      return false;
+  return true;
+}
+
+std::optional<DmaBufIdentity> ComputeDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
+                                                    uint32_t width,
+                                                    uint32_t height,
+                                                    const StatInodeFn& statInode)
+{
+  if (!descriptor || descriptor->nb_layers < 1 || descriptor->nb_objects < 1 ||
+      descriptor->nb_objects > AV_DRM_MAX_PLANES)
+    return std::nullopt;
+
+  const AVDRMLayerDescriptor& layer = descriptor->layers[0];
+  if (layer.nb_planes < 1 || layer.nb_planes > AV_DRM_MAX_PLANES)
+    return std::nullopt;
+
+  DmaBufIdentity identity;
+  identity.nbObjects = descriptor->nb_objects;
+  for (int i = 0; i < descriptor->nb_objects; i++)
+  {
+    if (!statInode(descriptor->objects[i].fd, identity.inode[i]))
+      return std::nullopt;
+    identity.modifier[i] = descriptor->objects[i].format_modifier;
+  }
+
+  identity.width = width;
+  identity.height = height;
+  identity.format = layer.format;
+  identity.nbPlanes = layer.nb_planes;
+  for (int i = 0; i < layer.nb_planes; i++)
+  {
+    identity.objectIndex[i] = layer.planes[i].object_index;
+    identity.offset[i] = layer.planes[i].offset;
+    identity.pitch[i] = layer.planes[i].pitch;
+  }
+
+  return identity;
+}
+
+} // namespace DRMPRIME

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentity.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentity.cpp
@@ -15,9 +15,7 @@ namespace DRMPRIME
 
 bool StatInode(int fd, uint64_t& inode)
 {
-  struct stat st
-  {
-  };
+  struct stat st = {};
   if (fstat(fd, &st) != 0)
     return false;
 
@@ -43,10 +41,15 @@ bool DmaBufIdentity::SameMemory(const DmaBufIdentity& other) const
   return true;
 }
 
-std::optional<DmaBufIdentity> ComputeDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
-                                                    uint32_t width,
-                                                    uint32_t height,
-                                                    const StatInodeFn& statInode)
+namespace
+{
+
+// templated so the hot path calls StatInode directly, without a std::function
+template<typename StatFn>
+std::optional<DmaBufIdentity> Compute(const AVDRMFrameDescriptor* descriptor,
+                                      uint32_t width,
+                                      uint32_t height,
+                                      const StatFn& statInode)
 {
   if (!descriptor || descriptor->nb_layers < 1 || descriptor->nb_objects < 1 ||
       descriptor->nb_objects > AV_DRM_MAX_PLANES)
@@ -68,6 +71,7 @@ std::optional<DmaBufIdentity> ComputeDmaBufIdentity(const AVDRMFrameDescriptor* 
   identity.width = width;
   identity.height = height;
   identity.format = layer.format;
+  identity.nbLayers = descriptor->nb_layers;
   identity.nbPlanes = layer.nb_planes;
   for (int i = 0; i < layer.nb_planes; i++)
   {
@@ -77,6 +81,23 @@ std::optional<DmaBufIdentity> ComputeDmaBufIdentity(const AVDRMFrameDescriptor* 
   }
 
   return identity;
+}
+
+} // namespace
+
+std::optional<DmaBufIdentity> ComputeDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
+                                                    uint32_t width,
+                                                    uint32_t height)
+{
+  return Compute(descriptor, width, height, &StatInode);
+}
+
+std::optional<DmaBufIdentity> ComputeDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
+                                                    uint32_t width,
+                                                    uint32_t height,
+                                                    const StatInodeFn& statInode)
+{
+  return Compute(descriptor, width, height, statInode);
 }
 
 } // namespace DRMPRIME

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentity.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentity.cpp
@@ -85,17 +85,17 @@ std::optional<DmaBufIdentity> Compute(const AVDRMFrameDescriptor* descriptor,
 
 } // namespace
 
-std::optional<DmaBufIdentity> ComputeDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
-                                                    uint32_t width,
-                                                    uint32_t height)
+std::optional<DmaBufIdentity> GetDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
+                                                uint32_t width,
+                                                uint32_t height)
 {
   return Compute(descriptor, width, height, &StatInode);
 }
 
-std::optional<DmaBufIdentity> ComputeDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
-                                                    uint32_t width,
-                                                    uint32_t height,
-                                                    const StatInodeFn& statInode)
+std::optional<DmaBufIdentity> GetDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
+                                                uint32_t width,
+                                                uint32_t height,
+                                                const StatInodeFn& statInode)
 {
   return Compute(descriptor, width, height, statInode);
 }

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentity.h
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentity.h
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <optional>
+
+extern "C"
+{
+#include <libavutil/hwcontext_drm.h>
+}
+
+namespace DRMPRIME
+{
+
+//! \brief Writes the dma-buf inode for fd; false on failure.
+using StatInodeFn = std::function<bool(int fd, uint64_t& inode)>;
+
+// fstat st_ino; unique and never reused for dma-bufs (kernel 5.3+)
+bool StatInode(int fd, uint64_t& inode);
+
+//! \brief Identifies a frame's memory and layout across file descriptor reuse.
+struct DmaBufIdentity
+{
+  // memory: dma-buf inode per descriptor object, in object order
+  int nbObjects{0};
+  std::array<uint64_t, AV_DRM_MAX_PLANES> inode{};
+  std::array<uint64_t, AV_DRM_MAX_PLANES> modifier{};
+  // layout: everything AddFB2 / EGL import consume besides the memory
+  uint32_t width{0};
+  uint32_t height{0};
+  uint32_t format{0};
+  int nbPlanes{0};
+  std::array<int, AV_DRM_MAX_PLANES> objectIndex{};
+  std::array<uint64_t, AV_DRM_MAX_PLANES> offset{};
+  std::array<uint64_t, AV_DRM_MAX_PLANES> pitch{};
+
+  bool operator==(const DmaBufIdentity& other) const = default;
+
+  //! \brief True when the underlying memory (inodes) matches, layout aside.
+  bool SameMemory(const DmaBufIdentity& other) const;
+};
+
+//! \brief Identity of descriptor layer[0]; nullopt on null descriptor or unreadable inode.
+std::optional<DmaBufIdentity> ComputeDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
+                                                    uint32_t width,
+                                                    uint32_t height,
+                                                    const StatInodeFn& statInode = StatInode);
+
+} // namespace DRMPRIME

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentity.h
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentity.h
@@ -38,21 +38,30 @@ struct DmaBufIdentity
   uint32_t width{0};
   uint32_t height{0};
   uint32_t format{0};
+  int nbLayers{0};
   int nbPlanes{0};
   std::array<int, AV_DRM_MAX_PLANES> objectIndex{};
   std::array<uint64_t, AV_DRM_MAX_PLANES> offset{};
   std::array<uint64_t, AV_DRM_MAX_PLANES> pitch{};
 
+  // compares the arrays' unused tails too; sound only for value-initialized, never-mutated instances
   bool operator==(const DmaBufIdentity& other) const = default;
 
   //! \brief True when the underlying memory (inodes) matches, layout aside.
   bool SameMemory(const DmaBufIdentity& other) const;
 };
 
-//! \brief Identity of descriptor layer[0]; nullopt on null descriptor or unreadable inode.
+//! \brief Identity of descriptor layer[0] only; nbLayers is keyed, layers 1+ are
+//! not inspected: a consumer that reads layers 1+ must not key on this identity.
+//! Returns nullopt for a missing or malformed descriptor or an unreadable inode.
+std::optional<DmaBufIdentity> ComputeDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
+                                                    uint32_t width,
+                                                    uint32_t height);
+
+//! \brief Test seam: same, with an injectable stat function.
 std::optional<DmaBufIdentity> ComputeDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
                                                     uint32_t width,
                                                     uint32_t height,
-                                                    const StatInodeFn& statInode = StatInode);
+                                                    const StatInodeFn& statInode);
 
 } // namespace DRMPRIME

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentity.h
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentity.h
@@ -54,14 +54,14 @@ struct DmaBufIdentity
 //! \brief Identity of descriptor layer[0] only; nbLayers is keyed, layers 1+ are
 //! not inspected: a consumer that reads layers 1+ must not key on this identity.
 //! Returns nullopt for a missing or malformed descriptor or an unreadable inode.
-std::optional<DmaBufIdentity> ComputeDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
-                                                    uint32_t width,
-                                                    uint32_t height);
+std::optional<DmaBufIdentity> GetDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
+                                                uint32_t width,
+                                                uint32_t height);
 
 //! \brief Test seam: same, with an injectable stat function.
-std::optional<DmaBufIdentity> ComputeDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
-                                                    uint32_t width,
-                                                    uint32_t height,
-                                                    const StatInodeFn& statInode);
+std::optional<DmaBufIdentity> GetDmaBufIdentity(const AVDRMFrameDescriptor* descriptor,
+                                                uint32_t width,
+                                                uint32_t height,
+                                                const StatInodeFn& statInode);
 
 } // namespace DRMPRIME

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.cpp
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DmaBufIdentityCache.h"
+
+#include <algorithm>
+
+namespace DRMPRIME
+{
+
+uint32_t CDmaBufIdentityCache::Lookup(const DmaBufIdentity& identity, uint64_t salt)
+{
+  for (auto it = m_entries.begin(); it != m_entries.end(); ++it)
+  {
+    if (it->salt == salt && it->identity == identity)
+    {
+      it->lastUse = ++m_useCounter;
+      return it->handle;
+    }
+
+    // same memory in a new shape: the old object can never be valid again
+    if (it->salt == salt && it->identity.SameMemory(identity))
+    {
+      m_doomed.push_back(it->handle);
+      m_entries.erase(it);
+      return 0;
+    }
+  }
+  return 0;
+}
+
+void CDmaBufIdentityCache::Insert(const DmaBufIdentity& identity, uint32_t handle, uint64_t salt)
+{
+  if (!handle)
+    return;
+
+  m_entries.push_back(Entry{identity, salt, handle, ++m_useCounter});
+}
+
+std::vector<uint32_t> CDmaBufIdentityCache::Reap(uint32_t protectA, uint32_t protectB)
+{
+  std::vector<uint32_t> reaped;
+
+  auto protectedHandle = [&](uint32_t handle) { return handle == protectA || handle == protectB; };
+
+  auto it = m_doomed.begin();
+  while (it != m_doomed.end())
+  {
+    if (protectedHandle(*it))
+    {
+      ++it;
+      continue;
+    }
+    reaped.push_back(*it);
+    it = m_doomed.erase(it);
+  }
+
+  while (m_entries.size() > m_maxEntries)
+  {
+    auto victim = m_entries.end();
+    for (auto candidate = m_entries.begin(); candidate != m_entries.end(); ++candidate)
+    {
+      if (protectedHandle(candidate->handle))
+        continue;
+      if (victim == m_entries.end() || candidate->lastUse < victim->lastUse)
+        victim = candidate;
+    }
+    if (victim == m_entries.end())
+      break;
+
+    reaped.push_back(victim->handle);
+    m_entries.erase(victim);
+  }
+
+  return reaped;
+}
+
+std::vector<uint32_t> CDmaBufIdentityCache::TakeAll()
+{
+  std::vector<uint32_t> all = std::move(m_doomed);
+  m_doomed.clear();
+  for (const Entry& entry : m_entries)
+    all.push_back(entry.handle);
+  m_entries.clear();
+  return all;
+}
+
+} // namespace DRMPRIME

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.cpp
@@ -80,6 +80,13 @@ std::vector<uint32_t> CDmaBufIdentityCache::Reap(uint32_t protectA, uint32_t pro
   return reaped;
 }
 
+void CDmaBufIdentityCache::InvalidateAll()
+{
+  for (const Entry& entry : m_entries)
+    m_doomed.push_back(entry.handle);
+  m_entries.clear();
+}
+
 std::vector<uint32_t> CDmaBufIdentityCache::TakeAll()
 {
   std::vector<uint32_t> all = std::move(m_doomed);

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.cpp
@@ -42,11 +42,15 @@ void CDmaBufIdentityCache::Insert(const DmaBufIdentity& identity, uint32_t handl
   m_entries.push_back(Entry{identity, salt, handle, ++m_useCounter});
 }
 
-std::vector<uint32_t> CDmaBufIdentityCache::Reap(uint32_t protectA, uint32_t protectB)
+std::vector<uint32_t> CDmaBufIdentityCache::Reap(std::span<const uint32_t> protectedHandles)
 {
   std::vector<uint32_t> reaped;
 
-  auto protectedHandle = [&](uint32_t handle) { return handle == protectA || handle == protectB; };
+  auto protectedHandle = [&](uint32_t handle)
+  {
+    return std::find(protectedHandles.begin(), protectedHandles.end(), handle) !=
+           protectedHandles.end();
+  };
 
   auto it = m_doomed.begin();
   while (it != m_doomed.end())

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.cpp
@@ -22,13 +22,16 @@ uint32_t CDmaBufIdentityCache::Lookup(const DmaBufIdentity& identity, uint64_t s
       it->lastUse = ++m_useCounter;
       return it->handle;
     }
+  }
 
+  for (auto it = m_entries.begin(); it != m_entries.end(); ++it)
+  {
     // same memory in a new shape: the old object can never be valid again
     if (it->salt == salt && it->identity.SameMemory(identity))
     {
       m_doomed.push_back(it->handle);
       m_entries.erase(it);
-      return 0;
+      break;
     }
   }
   return 0;

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.cpp
@@ -8,6 +8,8 @@
 
 #include "DmaBufIdentityCache.h"
 
+#include "utils/log.h"
+
 #include <algorithm>
 
 namespace DRMPRIME
@@ -80,6 +82,14 @@ std::vector<uint32_t> CDmaBufIdentityCache::Reap(std::span<const uint32_t> prote
     if (victim == m_entries.end())
       break;
 
+    if (!m_warnedEviction)
+    {
+      m_warnedEviction = true;
+      CLog::Log(LOGWARNING,
+                "CDmaBufIdentityCache: {} entries exceed cap {}, evicting LRU; expect per-frame "
+                "reimports",
+                m_entries.size(), m_maxEntries);
+    }
     reaped.push_back(victim->handle);
     m_entries.erase(victim);
   }

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.cpp
@@ -86,9 +86,9 @@ std::vector<uint32_t> CDmaBufIdentityCache::Reap(std::span<const uint32_t> prote
     {
       m_warnedEviction = true;
       CLog::Log(LOGWARNING,
-                "CDmaBufIdentityCache: {} entries exceed cap {}, evicting LRU; expect per-frame "
-                "reimports",
-                m_entries.size(), m_maxEntries);
+                "CDmaBufIdentityCache({}): {} entries exceed cap {}, evicting LRU; expect "
+                "per-frame reimports",
+                m_name, m_entries.size(), m_maxEntries);
     }
     reaped.push_back(victim->handle);
     m_entries.erase(victim);

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.h
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.h
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "cores/VideoPlayer/Buffers/DmaBufIdentity.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace DRMPRIME
+{
+
+//! \brief Ioctl-free bookkeeping for one caller-owned kernel object per dma-buf identity.
+class CDmaBufIdentityCache
+{
+public:
+  explicit CDmaBufIdentityCache(size_t maxEntries) : m_maxEntries(maxEntries) {}
+
+  //! \brief Handle for an exact identity+salt match, 0 on miss; a same-memory mismatch dooms the entry.
+  uint32_t Lookup(const DmaBufIdentity& identity, uint64_t salt = 0);
+
+  //! \brief Register a nonzero handle for identity+salt.
+  void Insert(const DmaBufIdentity& identity, uint32_t handle, uint64_t salt = 0);
+
+  //! \brief Handles to destroy now (doomed plus LRU overflow); protectA/protectB are never returned.
+  std::vector<uint32_t> Reap(uint32_t protectA, uint32_t protectB);
+
+  //! \brief Every live and doomed handle; the cache is emptied.
+  std::vector<uint32_t> TakeAll();
+
+  size_t Size() const { return m_entries.size(); }
+
+private:
+  struct Entry
+  {
+    DmaBufIdentity identity;
+    uint64_t salt{0};
+    uint32_t handle{0};
+    uint64_t lastUse{0};
+  };
+
+  std::vector<Entry> m_entries;
+  std::vector<uint32_t> m_doomed;
+  uint64_t m_useCounter{0};
+  size_t m_maxEntries;
+};
+
+} // namespace DRMPRIME

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.h
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.h
@@ -31,6 +31,9 @@ public:
   //! \brief Handles to destroy now (doomed plus LRU overflow); protectA/protectB are never returned.
   std::vector<uint32_t> Reap(uint32_t protectA, uint32_t protectB);
 
+  //! \brief Invalidate every entry; handles surface through later Reap calls, honoring protection.
+  void InvalidateAll();
+
   //! \brief Every live and doomed handle; the cache is emptied.
   std::vector<uint32_t> TakeAll();
 

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.h
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.h
@@ -58,6 +58,7 @@ private:
   std::vector<uint32_t> m_doomed;
   uint64_t m_useCounter{0};
   size_t m_maxEntries;
+  bool m_warnedEviction{false};
 };
 
 } // namespace DRMPRIME

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.h
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.h
@@ -13,6 +13,8 @@
 #include <cstdint>
 #include <initializer_list>
 #include <span>
+#include <string>
+#include <string_view>
 #include <vector>
 
 namespace DRMPRIME
@@ -22,7 +24,11 @@ namespace DRMPRIME
 class CDmaBufIdentityCache
 {
 public:
-  explicit CDmaBufIdentityCache(size_t maxEntries) : m_maxEntries(maxEntries) {}
+  CDmaBufIdentityCache(size_t maxEntries, std::string_view name)
+    : m_maxEntries(maxEntries),
+      m_name(name)
+  {
+  }
 
   //! \brief Handle for an exact identity+salt match, 0 on miss; a same-memory mismatch dooms the entry.
   uint32_t Lookup(const DmaBufIdentity& identity, uint64_t salt = 0);
@@ -58,6 +64,7 @@ private:
   std::vector<uint32_t> m_doomed;
   uint64_t m_useCounter{0};
   size_t m_maxEntries;
+  std::string m_name;
   bool m_warnedEviction{false};
 };
 

--- a/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.h
+++ b/xbmc/cores/VideoPlayer/Buffers/DmaBufIdentityCache.h
@@ -11,6 +11,8 @@
 #include "cores/VideoPlayer/Buffers/DmaBufIdentity.h"
 
 #include <cstdint>
+#include <initializer_list>
+#include <span>
 #include <vector>
 
 namespace DRMPRIME
@@ -28,8 +30,12 @@ public:
   //! \brief Register a nonzero handle for identity+salt.
   void Insert(const DmaBufIdentity& identity, uint32_t handle, uint64_t salt = 0);
 
-  //! \brief Handles to destroy now (doomed plus LRU overflow); protectA/protectB are never returned.
-  std::vector<uint32_t> Reap(uint32_t protectA, uint32_t protectB);
+  //! \brief Handles to destroy now (doomed plus LRU overflow); protected handles are never returned.
+  std::vector<uint32_t> Reap(std::span<const uint32_t> protectedHandles);
+  std::vector<uint32_t> Reap(std::initializer_list<uint32_t> protectedHandles)
+  {
+    return Reap(std::span<const uint32_t>(protectedHandles.begin(), protectedHandles.size()));
+  }
 
   //! \brief Invalidate every entry; handles surface through later Reap calls, honoring protection.
   void InvalidateAll();

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.cpp
@@ -19,9 +19,8 @@ extern "C"
 #include <libavutil/pixdesc.h>
 }
 
-CVideoBufferDMA::CVideoBufferDMA(
-    IVideoBufferPool& pool, int id, uint32_t fourcc, uint32_t planes, uint64_t size)
-  : CVideoBufferDRMPRIMEFFmpeg(pool, id),
+CVideoBufferDMA::CVideoBufferDMA(int id, uint32_t fourcc, uint32_t planes, uint64_t size)
+  : CVideoBufferDRMPRIME(id),
     m_bo(CBufferObject::GetBufferObject(true)),
     m_planes(planes),
     m_fourcc(fourcc),

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDMA.h
@@ -14,18 +14,18 @@
 
 class IBufferObject;
 
-class CVideoBufferDMA : public CVideoBufferDRMPRIMEFFmpeg
+class CVideoBufferDMA : public CVideoBufferDRMPRIME
 {
 public:
-  CVideoBufferDMA(IVideoBufferPool& pool, int id, uint32_t fourcc, uint32_t planes, uint64_t size);
+  CVideoBufferDMA(int id, uint32_t fourcc, uint32_t planes, uint64_t size);
   ~CVideoBufferDMA() override;
 
-  // implementation of CVideoBufferDRMPRIME via CVideoBufferDRMPRIMEFFmpeg
+  // implementation of CVideoBufferDRMPRIME
   uint32_t GetWidth() const override { return m_width; }
   uint32_t GetHeight() const override { return m_height; }
   AVDRMFrameDescriptor* GetDescriptor() const override;
 
-  // implementation of CVideoBuffer via CVideoBufferDRMPRIMEFFmpeg
+  // implementation of CVideoBuffer via CVideoBufferDRMPRIME
   void GetPlanes(uint8_t* (&planes)[YuvImage::MAX_PLANES]) override;
   void GetStrides(int (&strides)[YuvImage::MAX_PLANES]) override;
   uint8_t* GetMemPtr() override;

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
@@ -57,6 +57,12 @@ CVideoBufferDRMPRIME::CVideoBufferDRMPRIME(int id) : CVideoBuffer(id)
   m_pixFormat = AV_PIX_FMT_DRM_PRIME;
 }
 
+bool CVideoBufferDRMPRIME::IsValid() const
+{
+  AVDRMFrameDescriptor* descriptor = GetDescriptor();
+  return descriptor && descriptor->nb_layers;
+}
+
 CVideoBufferDRMPRIMEFFmpeg::CVideoBufferDRMPRIMEFFmpeg(IVideoBufferPool& pool, int id)
   : CVideoBufferDRMPRIME(id)
 {
@@ -77,12 +83,6 @@ void CVideoBufferDRMPRIMEFFmpeg::SetRef(AVFrame* frame)
 void CVideoBufferDRMPRIMEFFmpeg::Unref()
 {
   av_frame_unref(m_pFrame);
-}
-
-bool CVideoBufferDRMPRIMEFFmpeg::IsValid() const
-{
-  AVDRMFrameDescriptor* descriptor = GetDescriptor();
-  return descriptor && descriptor->nb_layers;
 }
 
 CVideoBufferPoolDRMPRIMEFFmpeg::~CVideoBufferPoolDRMPRIMEFFmpeg()

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.cpp
@@ -91,7 +91,7 @@ CVideoBufferPoolDRMPRIMEFFmpeg::~CVideoBufferPoolDRMPRIMEFFmpeg()
     delete buf;
 }
 
-CVideoBuffer* CVideoBufferPoolDRMPRIMEFFmpeg::Get()
+CVideoBufferDRMPRIMEFFmpeg* CVideoBufferPoolDRMPRIMEFFmpeg::Get()
 {
   std::unique_lock lock(m_critSection);
 

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
@@ -41,8 +41,6 @@ public:
   virtual bool AcquireDescriptor() { return true; }
   virtual void ReleaseDescriptor() {}
 
-  uint32_t m_fb_id = 0;
-
 protected:
   explicit CVideoBufferDRMPRIME(int id);
 

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
@@ -69,7 +69,7 @@ class CVideoBufferPoolDRMPRIMEFFmpeg : public IVideoBufferPool
 public:
   ~CVideoBufferPoolDRMPRIMEFFmpeg() override;
   void Return(int id) override;
-  CVideoBuffer* Get() override;
+  CVideoBufferDRMPRIMEFFmpeg* Get() override;
 
 protected:
   CCriticalSection m_critSection;

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h
@@ -37,7 +37,7 @@ public:
   virtual uint32_t GetHeight() const { return GetPicture().iHeight; }
 
   virtual AVDRMFrameDescriptor* GetDescriptor() const = 0;
-  virtual bool IsValid() const { return true; }
+  virtual bool IsValid() const;
   virtual bool AcquireDescriptor() { return true; }
   virtual void ReleaseDescriptor() {}
 
@@ -61,7 +61,6 @@ public:
   {
     return reinterpret_cast<AVDRMFrameDescriptor*>(m_pFrame->data[0]);
   }
-  bool IsValid() const override;
 
 protected:
   AVFrame* m_pFrame = nullptr;

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.cpp
@@ -44,7 +44,7 @@ CVideoBuffer* CVideoBufferPoolDMA::Get()
   else
   {
     int id = m_all.size();
-    buf = new CVideoBufferDMA(*this, id, m_fourcc, m_planes, m_size);
+    buf = new CVideoBufferDMA(id, m_fourcc, m_planes, m_size);
 
     if (!buf->Alloc())
     {
@@ -64,7 +64,6 @@ void CVideoBufferPoolDMA::Return(int id)
 {
   std::unique_lock lock(m_critSection);
 
-  m_all[id]->Unref();
   auto it = m_used.begin();
   while (it != m_used.end())
   {

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.cpp
@@ -29,7 +29,7 @@ CVideoBufferPoolDMA::~CVideoBufferPoolDMA()
     delete buf;
 }
 
-CVideoBuffer* CVideoBufferPoolDMA::Get()
+CVideoBufferDMA* CVideoBufferPoolDMA::Get()
 {
   std::unique_lock lock(m_critSection);
 

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBufferPoolDMA.h
@@ -9,10 +9,9 @@
 #pragma once
 
 #include "cores/VideoPlayer/Buffers/VideoBuffer.h"
+#include "cores/VideoPlayer/Buffers/VideoBufferDMA.h"
 
 #include <memory>
-
-class CVideoBufferDMA;
 
 class CVideoBufferPoolDMA : public IVideoBufferPool
 {
@@ -21,7 +20,7 @@ public:
   ~CVideoBufferPoolDMA() override;
 
   // implementation of IVideoBufferPool
-  CVideoBuffer* Get() override;
+  CVideoBufferDMA* Get() override;
   void Return(int id) override;
   void Configure(AVPixelFormat format, int size) override;
   bool IsConfigured() override;

--- a/xbmc/cores/VideoPlayer/Buffers/test/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/Buffers/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 if("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC)
   set(SOURCES TestDmaBufIdentity.cpp
+              TestDmaBufIdentityCache.cpp
               TestVideoBufferDMA.cpp)
 
   core_add_test_library(videoplayer_buffers_test)

--- a/xbmc/cores/VideoPlayer/Buffers/test/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/Buffers/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+if("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC)
+  set(SOURCES TestDmaBufIdentity.cpp
+              TestVideoBufferDMA.cpp)
+
+  core_add_test_library(videoplayer_buffers_test)
+endif()

--- a/xbmc/cores/VideoPlayer/Buffers/test/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/Buffers/test/CMakeLists.txt
@@ -1,7 +1,12 @@
-if("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC)
+if("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC
+   OR "x11" IN_LIST CORE_PLATFORM_NAME_LC)
   set(SOURCES TestDmaBufIdentity.cpp
-              TestDmaBufIdentityCache.cpp
-              TestVideoBufferDMA.cpp)
+              TestDmaBufIdentityCache.cpp)
+
+  # needs the buffer-object stack, which only gbm/wayland build
+  if("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC)
+    list(APPEND SOURCES TestVideoBufferDMA.cpp)
+  endif()
 
   core_add_test_library(videoplayer_buffers_test)
 endif()

--- a/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentity.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentity.cpp
@@ -1,0 +1,180 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/VideoPlayer/Buffers/DmaBufIdentity.h"
+
+#include <map>
+
+#include <gtest/gtest.h>
+
+using namespace DRMPRIME;
+
+namespace
+{
+
+AVDRMFrameDescriptor MakeDescriptor()
+{
+  AVDRMFrameDescriptor descriptor{};
+  descriptor.nb_objects = 1;
+  descriptor.objects[0].fd = 40;
+  descriptor.objects[0].format_modifier = 0x100;
+  descriptor.nb_layers = 1;
+  descriptor.layers[0].format = 0x3231564e; // NV12
+  descriptor.layers[0].nb_planes = 2;
+  descriptor.layers[0].planes[0].object_index = 0;
+  descriptor.layers[0].planes[0].offset = 0;
+  descriptor.layers[0].planes[0].pitch = 1920;
+  descriptor.layers[0].planes[1].object_index = 0;
+  descriptor.layers[0].planes[1].offset = 1920 * 1080;
+  descriptor.layers[0].planes[1].pitch = 1920;
+  return descriptor;
+}
+
+StatInodeFn FixedInodes(std::map<int, uint64_t> inodes)
+{
+  return [inodes = std::move(inodes)](int fd, uint64_t& inode)
+  {
+    auto it = inodes.find(fd);
+    if (it == inodes.end())
+      return false;
+    inode = it->second;
+    return true;
+  };
+}
+
+} // namespace
+
+TEST(TestDmaBufIdentity, ComputeFillsInodesPerObject)
+{
+  AVDRMFrameDescriptor descriptor = MakeDescriptor();
+  descriptor.nb_objects = 2;
+  descriptor.objects[1].fd = 41;
+  descriptor.objects[1].format_modifier = 0x200;
+  descriptor.layers[0].planes[1].object_index = 1;
+
+  auto identity = ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}, {41, 8}}));
+  ASSERT_TRUE(identity);
+  EXPECT_EQ(identity->nbObjects, 2);
+  EXPECT_EQ(identity->inode[0], 7u);
+  EXPECT_EQ(identity->inode[1], 8u);
+  EXPECT_EQ(identity->modifier[0], 0x100u);
+  EXPECT_EQ(identity->modifier[1], 0x200u);
+  EXPECT_EQ(identity->width, 1920u);
+  EXPECT_EQ(identity->height, 1080u);
+  EXPECT_EQ(identity->format, 0x3231564eu);
+  EXPECT_EQ(identity->nbPlanes, 2);
+  EXPECT_EQ(identity->objectIndex[1], 1);
+  EXPECT_EQ(identity->offset[1], static_cast<uint64_t>(1920 * 1080));
+  EXPECT_EQ(identity->pitch[1], 1920u);
+}
+
+TEST(TestDmaBufIdentity, NullDescriptorReturnsNullopt)
+{
+  EXPECT_FALSE(ComputeDmaBufIdentity(nullptr, 1920, 1080, FixedInodes({{40, 7}})));
+}
+
+TEST(TestDmaBufIdentity, ZeroLayersReturnsNullopt)
+{
+  AVDRMFrameDescriptor descriptor = MakeDescriptor();
+  descriptor.nb_layers = 0;
+  EXPECT_FALSE(ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}})));
+}
+
+TEST(TestDmaBufIdentity, StatFailureReturnsNullopt)
+{
+  AVDRMFrameDescriptor descriptor = MakeDescriptor();
+  descriptor.nb_objects = 2;
+  descriptor.objects[1].fd = 41;
+
+  // the second object's fd is unknown to the stat fn
+  EXPECT_FALSE(ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}})));
+}
+
+TEST(TestDmaBufIdentity, FdRecyclingProducesDifferentIdentity)
+{
+  AVDRMFrameDescriptor descriptor = MakeDescriptor();
+
+  auto before = ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}}));
+  auto after = ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 8}}));
+  ASSERT_TRUE(before);
+  ASSERT_TRUE(after);
+  EXPECT_FALSE(*before == *after);
+  EXPECT_FALSE(before->SameMemory(*after));
+}
+
+TEST(TestDmaBufIdentity, SameMemoryDifferentFdNumbersMatch)
+{
+  AVDRMFrameDescriptor descA = MakeDescriptor();
+  AVDRMFrameDescriptor descB = MakeDescriptor();
+  descB.objects[0].fd = 99;
+
+  auto a = ComputeDmaBufIdentity(&descA, 1920, 1080, FixedInodes({{40, 7}}));
+  auto b = ComputeDmaBufIdentity(&descB, 1920, 1080, FixedInodes({{99, 7}}));
+  ASSERT_TRUE(a);
+  ASSERT_TRUE(b);
+  EXPECT_TRUE(*a == *b);
+  EXPECT_TRUE(a->SameMemory(*b));
+}
+
+TEST(TestDmaBufIdentity, LayoutFieldChangesBreakEquality)
+{
+  const auto stat = FixedInodes({{40, 7}});
+  AVDRMFrameDescriptor base = MakeDescriptor();
+  auto reference = ComputeDmaBufIdentity(&base, 1920, 1080, stat);
+  ASSERT_TRUE(reference);
+
+  auto differs = [&](const AVDRMFrameDescriptor& descriptor, uint32_t width, uint32_t height)
+  {
+    auto other = ComputeDmaBufIdentity(&descriptor, width, height, stat);
+    EXPECT_TRUE(other);
+    if (!other)
+      return false;
+    EXPECT_TRUE(reference->SameMemory(*other));
+    return !(*reference == *other);
+  };
+
+  EXPECT_TRUE(differs(base, 1280, 1080));
+  EXPECT_TRUE(differs(base, 1920, 720));
+
+  AVDRMFrameDescriptor d = MakeDescriptor();
+  d.objects[0].format_modifier = 0x101;
+  EXPECT_TRUE(differs(d, 1920, 1080));
+
+  d = MakeDescriptor();
+  d.layers[0].format = 0x30313050; // P010
+  EXPECT_TRUE(differs(d, 1920, 1080));
+
+  d = MakeDescriptor();
+  d.layers[0].planes[1].offset = 4096;
+  EXPECT_TRUE(differs(d, 1920, 1080));
+
+  d = MakeDescriptor();
+  d.layers[0].planes[0].pitch = 2048;
+  EXPECT_TRUE(differs(d, 1920, 1080));
+
+  d = MakeDescriptor();
+  d.layers[0].planes[1].object_index = 1;
+  d.nb_objects = 2;
+  d.objects[1].fd = 40;
+  EXPECT_TRUE(differs(d, 1920, 1080));
+}
+
+TEST(TestDmaBufIdentity, MultiObjectSecondInodeCompared)
+{
+  AVDRMFrameDescriptor descriptor = MakeDescriptor();
+  descriptor.nb_objects = 2;
+  descriptor.objects[1].fd = 41;
+  descriptor.layers[0].planes[1].object_index = 1;
+
+  auto a = ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}, {41, 8}}));
+  auto b = ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}, {41, 9}}));
+  ASSERT_TRUE(a);
+  ASSERT_TRUE(b);
+  EXPECT_FALSE(*a == *b);
+  EXPECT_FALSE(a->SameMemory(*b));
+}

--- a/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentity.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentity.cpp
@@ -162,6 +162,10 @@ TEST(TestDmaBufIdentity, LayoutFieldChangesBreakEquality)
   d.nb_objects = 2;
   d.objects[1].fd = 40;
   EXPECT_TRUE(differs(d, 1920, 1080));
+
+  d = MakeDescriptor();
+  d.nb_layers = 2;
+  EXPECT_TRUE(differs(d, 1920, 1080));
 }
 
 TEST(TestDmaBufIdentity, MultiObjectSecondInodeCompared)

--- a/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentity.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentity.cpp
@@ -57,7 +57,7 @@ TEST(TestDmaBufIdentity, ComputeFillsInodesPerObject)
   descriptor.objects[1].format_modifier = 0x200;
   descriptor.layers[0].planes[1].object_index = 1;
 
-  auto identity = ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}, {41, 8}}));
+  auto identity = GetDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}, {41, 8}}));
   ASSERT_TRUE(identity);
   EXPECT_EQ(identity->nbObjects, 2);
   EXPECT_EQ(identity->inode[0], 7u);
@@ -75,14 +75,14 @@ TEST(TestDmaBufIdentity, ComputeFillsInodesPerObject)
 
 TEST(TestDmaBufIdentity, NullDescriptorReturnsNullopt)
 {
-  EXPECT_FALSE(ComputeDmaBufIdentity(nullptr, 1920, 1080, FixedInodes({{40, 7}})));
+  EXPECT_FALSE(GetDmaBufIdentity(nullptr, 1920, 1080, FixedInodes({{40, 7}})));
 }
 
 TEST(TestDmaBufIdentity, ZeroLayersReturnsNullopt)
 {
   AVDRMFrameDescriptor descriptor = MakeDescriptor();
   descriptor.nb_layers = 0;
-  EXPECT_FALSE(ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}})));
+  EXPECT_FALSE(GetDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}})));
 }
 
 TEST(TestDmaBufIdentity, StatFailureReturnsNullopt)
@@ -92,15 +92,15 @@ TEST(TestDmaBufIdentity, StatFailureReturnsNullopt)
   descriptor.objects[1].fd = 41;
 
   // the second object's fd is unknown to the stat fn
-  EXPECT_FALSE(ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}})));
+  EXPECT_FALSE(GetDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}})));
 }
 
 TEST(TestDmaBufIdentity, FdRecyclingProducesDifferentIdentity)
 {
   AVDRMFrameDescriptor descriptor = MakeDescriptor();
 
-  auto before = ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}}));
-  auto after = ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 8}}));
+  auto before = GetDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}}));
+  auto after = GetDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 8}}));
   ASSERT_TRUE(before);
   ASSERT_TRUE(after);
   EXPECT_FALSE(*before == *after);
@@ -113,8 +113,8 @@ TEST(TestDmaBufIdentity, SameMemoryDifferentFdNumbersMatch)
   AVDRMFrameDescriptor descB = MakeDescriptor();
   descB.objects[0].fd = 99;
 
-  auto a = ComputeDmaBufIdentity(&descA, 1920, 1080, FixedInodes({{40, 7}}));
-  auto b = ComputeDmaBufIdentity(&descB, 1920, 1080, FixedInodes({{99, 7}}));
+  auto a = GetDmaBufIdentity(&descA, 1920, 1080, FixedInodes({{40, 7}}));
+  auto b = GetDmaBufIdentity(&descB, 1920, 1080, FixedInodes({{99, 7}}));
   ASSERT_TRUE(a);
   ASSERT_TRUE(b);
   EXPECT_TRUE(*a == *b);
@@ -125,12 +125,12 @@ TEST(TestDmaBufIdentity, LayoutFieldChangesBreakEquality)
 {
   const auto stat = FixedInodes({{40, 7}});
   AVDRMFrameDescriptor base = MakeDescriptor();
-  auto reference = ComputeDmaBufIdentity(&base, 1920, 1080, stat);
+  auto reference = GetDmaBufIdentity(&base, 1920, 1080, stat);
   ASSERT_TRUE(reference);
 
   auto differs = [&](const AVDRMFrameDescriptor& descriptor, uint32_t width, uint32_t height)
   {
-    auto other = ComputeDmaBufIdentity(&descriptor, width, height, stat);
+    auto other = GetDmaBufIdentity(&descriptor, width, height, stat);
     EXPECT_TRUE(other);
     if (!other)
       return false;
@@ -175,8 +175,8 @@ TEST(TestDmaBufIdentity, MultiObjectSecondInodeCompared)
   descriptor.objects[1].fd = 41;
   descriptor.layers[0].planes[1].object_index = 1;
 
-  auto a = ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}, {41, 8}}));
-  auto b = ComputeDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}, {41, 9}}));
+  auto a = GetDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}, {41, 8}}));
+  auto b = GetDmaBufIdentity(&descriptor, 1920, 1080, FixedInodes({{40, 7}, {41, 9}}));
   ASSERT_TRUE(a);
   ASSERT_TRUE(b);
   EXPECT_FALSE(*a == *b);

--- a/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentityCache.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentityCache.cpp
@@ -1,0 +1,147 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/VideoPlayer/Buffers/DmaBufIdentityCache.h"
+
+#include <algorithm>
+
+#include <gtest/gtest.h>
+
+using namespace DRMPRIME;
+
+namespace
+{
+
+DmaBufIdentity MakeIdentity(uint64_t inode, uint64_t pitch = 1920)
+{
+  DmaBufIdentity identity;
+  identity.nbObjects = 1;
+  identity.inode[0] = inode;
+  identity.width = 1920;
+  identity.height = 1080;
+  identity.format = 0x3231564e; // NV12
+  identity.nbPlanes = 2;
+  identity.pitch[0] = pitch;
+  identity.pitch[1] = pitch;
+  return identity;
+}
+
+} // namespace
+
+TEST(TestDmaBufIdentityCache, MissThenHit)
+{
+  CDmaBufIdentityCache cache{4};
+  const DmaBufIdentity identity = MakeIdentity(7);
+
+  EXPECT_EQ(cache.Lookup(identity), 0u);
+  cache.Insert(identity, 100);
+  EXPECT_EQ(cache.Lookup(identity), 100u);
+  EXPECT_EQ(cache.Size(), 1u);
+}
+
+TEST(TestDmaBufIdentityCache, SaltDistinguishesEntries)
+{
+  CDmaBufIdentityCache cache{4};
+  const DmaBufIdentity identity = MakeIdentity(7);
+
+  cache.Insert(identity, 100, 1);
+  cache.Insert(identity, 200, 2);
+  EXPECT_EQ(cache.Lookup(identity, 1), 100u);
+  EXPECT_EQ(cache.Lookup(identity, 2), 200u);
+}
+
+TEST(TestDmaBufIdentityCache, ExactLayoutRequiredForHit)
+{
+  CDmaBufIdentityCache cache{4};
+  cache.Insert(MakeIdentity(7, 1920), 100);
+
+  // same memory, different pitch: miss, and the old handle is doomed
+  EXPECT_EQ(cache.Lookup(MakeIdentity(7, 2048)), 0u);
+  EXPECT_EQ(cache.Size(), 0u);
+
+  const auto reaped = cache.Reap(0, 0);
+  ASSERT_EQ(reaped.size(), 1u);
+  EXPECT_EQ(reaped[0], 100u);
+}
+
+TEST(TestDmaBufIdentityCache, FdRecyclingCannotAlias)
+{
+  CDmaBufIdentityCache cache{4};
+  cache.Insert(MakeIdentity(7), 100);
+  cache.Insert(MakeIdentity(8), 200);
+
+  EXPECT_EQ(cache.Lookup(MakeIdentity(7)), 100u);
+  EXPECT_EQ(cache.Lookup(MakeIdentity(8)), 200u);
+  EXPECT_EQ(cache.Size(), 2u);
+}
+
+TEST(TestDmaBufIdentityCache, ReapDrainsDoomedExceptProtected)
+{
+  CDmaBufIdentityCache cache{4};
+  cache.Insert(MakeIdentity(7, 1920), 100);
+  EXPECT_EQ(cache.Lookup(MakeIdentity(7, 2048)), 0u); // dooms 100
+
+  // 100 is protected: stays queued
+  EXPECT_TRUE(cache.Reap(100, 0).empty());
+
+  const auto reaped = cache.Reap(0, 0);
+  ASSERT_EQ(reaped.size(), 1u);
+  EXPECT_EQ(reaped[0], 100u);
+}
+
+TEST(TestDmaBufIdentityCache, EvictionOverCapIsLRU)
+{
+  CDmaBufIdentityCache cache{2};
+  cache.Insert(MakeIdentity(1), 100);
+  cache.Insert(MakeIdentity(2), 200);
+  cache.Insert(MakeIdentity(3), 300);
+  cache.Insert(MakeIdentity(4), 400);
+
+  // touch the oldest so it is no longer the LRU victim
+  EXPECT_EQ(cache.Lookup(MakeIdentity(1)), 100u);
+
+  const auto reaped = cache.Reap(0, 0);
+  ASSERT_EQ(reaped.size(), 2u);
+  EXPECT_NE(std::find(reaped.begin(), reaped.end(), 200u), reaped.end());
+  EXPECT_NE(std::find(reaped.begin(), reaped.end(), 300u), reaped.end());
+  EXPECT_EQ(cache.Size(), 2u);
+  EXPECT_EQ(cache.Lookup(MakeIdentity(1)), 100u);
+  EXPECT_EQ(cache.Lookup(MakeIdentity(4)), 400u);
+}
+
+TEST(TestDmaBufIdentityCache, EvictionNeverReturnsProtected)
+{
+  CDmaBufIdentityCache cache{1};
+  cache.Insert(MakeIdentity(1), 100);
+  cache.Insert(MakeIdentity(2), 200);
+  cache.Insert(MakeIdentity(3), 300);
+
+  // the two LRU victims are protected: only 300 is evictable, cap stays exceeded
+  const auto reaped = cache.Reap(100, 200);
+  ASSERT_EQ(reaped.size(), 1u);
+  EXPECT_EQ(reaped[0], 300u);
+  EXPECT_EQ(cache.Size(), 2u);
+}
+
+TEST(TestDmaBufIdentityCache, TakeAllReturnsEverythingAndEmpties)
+{
+  CDmaBufIdentityCache cache{4};
+  cache.Insert(MakeIdentity(7, 1920), 100);
+  EXPECT_EQ(cache.Lookup(MakeIdentity(7, 2048)), 0u); // dooms 100
+  cache.Insert(MakeIdentity(8), 200);
+  cache.Insert(MakeIdentity(9), 300);
+
+  auto all = cache.TakeAll();
+  std::sort(all.begin(), all.end());
+  ASSERT_EQ(all.size(), 3u);
+  EXPECT_EQ(all[0], 100u);
+  EXPECT_EQ(all[1], 200u);
+  EXPECT_EQ(all[2], 300u);
+  EXPECT_EQ(cache.Size(), 0u);
+  EXPECT_TRUE(cache.Reap(0, 0).empty());
+}

--- a/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentityCache.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentityCache.cpp
@@ -145,3 +145,25 @@ TEST(TestDmaBufIdentityCache, TakeAllReturnsEverythingAndEmpties)
   EXPECT_EQ(cache.Size(), 0u);
   EXPECT_TRUE(cache.Reap(0, 0).empty());
 }
+
+TEST(TestDmaBufIdentityCache, InvalidateAllFreesEverythingExceptProtected)
+{
+  CDmaBufIdentityCache cache{4};
+  cache.Insert(MakeIdentity(7), 100);
+  cache.Insert(MakeIdentity(8), 200);
+  cache.Insert(MakeIdentity(9), 300);
+
+  cache.InvalidateAll();
+  EXPECT_EQ(cache.Size(), 0u);
+  EXPECT_EQ(cache.Lookup(MakeIdentity(7)), 0u);
+
+  auto reaped = cache.Reap(100, 0);
+  std::sort(reaped.begin(), reaped.end());
+  ASSERT_EQ(reaped.size(), 2u);
+  EXPECT_EQ(reaped[0], 200u);
+  EXPECT_EQ(reaped[1], 300u);
+
+  reaped = cache.Reap(0, 0);
+  ASSERT_EQ(reaped.size(), 1u);
+  EXPECT_EQ(reaped[0], 100u);
+}

--- a/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentityCache.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentityCache.cpp
@@ -69,6 +69,18 @@ TEST(TestDmaBufIdentityCache, ExactLayoutRequiredForHit)
   EXPECT_EQ(reaped[0], 100u);
 }
 
+TEST(TestDmaBufIdentityCache, ExactMatchWinsOverStaleSameMemoryEntry)
+{
+  CDmaBufIdentityCache cache{4};
+  cache.Insert(MakeIdentity(7, 1920), 100);
+  cache.Insert(MakeIdentity(7, 2048), 200);
+
+  // same memory under an old layout sits first in scan order; the exact match must still win
+  EXPECT_EQ(cache.Lookup(MakeIdentity(7, 2048)), 200u);
+  EXPECT_EQ(cache.Size(), 2u);
+  EXPECT_TRUE(cache.Reap({}).empty());
+}
+
 TEST(TestDmaBufIdentityCache, FdRecyclingCannotAlias)
 {
   CDmaBufIdentityCache cache{4};

--- a/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentityCache.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentityCache.cpp
@@ -64,7 +64,7 @@ TEST(TestDmaBufIdentityCache, ExactLayoutRequiredForHit)
   EXPECT_EQ(cache.Lookup(MakeIdentity(7, 2048)), 0u);
   EXPECT_EQ(cache.Size(), 0u);
 
-  const auto reaped = cache.Reap(0, 0);
+  const auto reaped = cache.Reap({});
   ASSERT_EQ(reaped.size(), 1u);
   EXPECT_EQ(reaped[0], 100u);
 }
@@ -87,9 +87,9 @@ TEST(TestDmaBufIdentityCache, ReapDrainsDoomedExceptProtected)
   EXPECT_EQ(cache.Lookup(MakeIdentity(7, 2048)), 0u); // dooms 100
 
   // 100 is protected: stays queued
-  EXPECT_TRUE(cache.Reap(100, 0).empty());
+  EXPECT_TRUE(cache.Reap({100}).empty());
 
-  const auto reaped = cache.Reap(0, 0);
+  const auto reaped = cache.Reap({});
   ASSERT_EQ(reaped.size(), 1u);
   EXPECT_EQ(reaped[0], 100u);
 }
@@ -105,7 +105,7 @@ TEST(TestDmaBufIdentityCache, EvictionOverCapIsLRU)
   // touch the oldest so it is no longer the LRU victim
   EXPECT_EQ(cache.Lookup(MakeIdentity(1)), 100u);
 
-  const auto reaped = cache.Reap(0, 0);
+  const auto reaped = cache.Reap({});
   ASSERT_EQ(reaped.size(), 2u);
   EXPECT_NE(std::find(reaped.begin(), reaped.end(), 200u), reaped.end());
   EXPECT_NE(std::find(reaped.begin(), reaped.end(), 300u), reaped.end());
@@ -122,10 +122,25 @@ TEST(TestDmaBufIdentityCache, EvictionNeverReturnsProtected)
   cache.Insert(MakeIdentity(3), 300);
 
   // the two LRU victims are protected: only 300 is evictable, cap stays exceeded
-  const auto reaped = cache.Reap(100, 200);
+  const auto reaped = cache.Reap({100, 200});
   ASSERT_EQ(reaped.size(), 1u);
   EXPECT_EQ(reaped[0], 300u);
   EXPECT_EQ(cache.Size(), 2u);
+}
+
+TEST(TestDmaBufIdentityCache, EvictionHonorsMoreThanTwoProtectedHandles)
+{
+  CDmaBufIdentityCache cache{1};
+  cache.Insert(MakeIdentity(1), 100);
+  cache.Insert(MakeIdentity(2), 200);
+  cache.Insert(MakeIdentity(3), 300);
+  cache.Insert(MakeIdentity(4), 400);
+
+  // three protected handles: only 400 is evictable, cap stays exceeded
+  const auto reaped = cache.Reap({100, 200, 300});
+  ASSERT_EQ(reaped.size(), 1u);
+  EXPECT_EQ(reaped[0], 400u);
+  EXPECT_EQ(cache.Size(), 3u);
 }
 
 TEST(TestDmaBufIdentityCache, TakeAllReturnsEverythingAndEmpties)
@@ -143,7 +158,7 @@ TEST(TestDmaBufIdentityCache, TakeAllReturnsEverythingAndEmpties)
   EXPECT_EQ(all[1], 200u);
   EXPECT_EQ(all[2], 300u);
   EXPECT_EQ(cache.Size(), 0u);
-  EXPECT_TRUE(cache.Reap(0, 0).empty());
+  EXPECT_TRUE(cache.Reap({}).empty());
 }
 
 TEST(TestDmaBufIdentityCache, InvalidateAllFreesEverythingExceptProtected)
@@ -157,13 +172,13 @@ TEST(TestDmaBufIdentityCache, InvalidateAllFreesEverythingExceptProtected)
   EXPECT_EQ(cache.Size(), 0u);
   EXPECT_EQ(cache.Lookup(MakeIdentity(7)), 0u);
 
-  auto reaped = cache.Reap(100, 0);
+  auto reaped = cache.Reap({100});
   std::sort(reaped.begin(), reaped.end());
   ASSERT_EQ(reaped.size(), 2u);
   EXPECT_EQ(reaped[0], 200u);
   EXPECT_EQ(reaped[1], 300u);
 
-  reaped = cache.Reap(0, 0);
+  reaped = cache.Reap({});
   ASSERT_EQ(reaped.size(), 1u);
   EXPECT_EQ(reaped[0], 100u);
 }

--- a/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentityCache.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/test/TestDmaBufIdentityCache.cpp
@@ -35,7 +35,7 @@ DmaBufIdentity MakeIdentity(uint64_t inode, uint64_t pitch = 1920)
 
 TEST(TestDmaBufIdentityCache, MissThenHit)
 {
-  CDmaBufIdentityCache cache{4};
+  CDmaBufIdentityCache cache{4, "test"};
   const DmaBufIdentity identity = MakeIdentity(7);
 
   EXPECT_EQ(cache.Lookup(identity), 0u);
@@ -46,7 +46,7 @@ TEST(TestDmaBufIdentityCache, MissThenHit)
 
 TEST(TestDmaBufIdentityCache, SaltDistinguishesEntries)
 {
-  CDmaBufIdentityCache cache{4};
+  CDmaBufIdentityCache cache{4, "test"};
   const DmaBufIdentity identity = MakeIdentity(7);
 
   cache.Insert(identity, 100, 1);
@@ -57,7 +57,7 @@ TEST(TestDmaBufIdentityCache, SaltDistinguishesEntries)
 
 TEST(TestDmaBufIdentityCache, ExactLayoutRequiredForHit)
 {
-  CDmaBufIdentityCache cache{4};
+  CDmaBufIdentityCache cache{4, "test"};
   cache.Insert(MakeIdentity(7, 1920), 100);
 
   // same memory, different pitch: miss, and the old handle is doomed
@@ -71,7 +71,7 @@ TEST(TestDmaBufIdentityCache, ExactLayoutRequiredForHit)
 
 TEST(TestDmaBufIdentityCache, ExactMatchWinsOverStaleSameMemoryEntry)
 {
-  CDmaBufIdentityCache cache{4};
+  CDmaBufIdentityCache cache{4, "test"};
   cache.Insert(MakeIdentity(7, 1920), 100);
   cache.Insert(MakeIdentity(7, 2048), 200);
 
@@ -83,7 +83,7 @@ TEST(TestDmaBufIdentityCache, ExactMatchWinsOverStaleSameMemoryEntry)
 
 TEST(TestDmaBufIdentityCache, FdRecyclingCannotAlias)
 {
-  CDmaBufIdentityCache cache{4};
+  CDmaBufIdentityCache cache{4, "test"};
   cache.Insert(MakeIdentity(7), 100);
   cache.Insert(MakeIdentity(8), 200);
 
@@ -94,7 +94,7 @@ TEST(TestDmaBufIdentityCache, FdRecyclingCannotAlias)
 
 TEST(TestDmaBufIdentityCache, ReapDrainsDoomedExceptProtected)
 {
-  CDmaBufIdentityCache cache{4};
+  CDmaBufIdentityCache cache{4, "test"};
   cache.Insert(MakeIdentity(7, 1920), 100);
   EXPECT_EQ(cache.Lookup(MakeIdentity(7, 2048)), 0u); // dooms 100
 
@@ -108,7 +108,7 @@ TEST(TestDmaBufIdentityCache, ReapDrainsDoomedExceptProtected)
 
 TEST(TestDmaBufIdentityCache, EvictionOverCapIsLRU)
 {
-  CDmaBufIdentityCache cache{2};
+  CDmaBufIdentityCache cache{2, "test"};
   cache.Insert(MakeIdentity(1), 100);
   cache.Insert(MakeIdentity(2), 200);
   cache.Insert(MakeIdentity(3), 300);
@@ -128,7 +128,7 @@ TEST(TestDmaBufIdentityCache, EvictionOverCapIsLRU)
 
 TEST(TestDmaBufIdentityCache, EvictionNeverReturnsProtected)
 {
-  CDmaBufIdentityCache cache{1};
+  CDmaBufIdentityCache cache{1, "test"};
   cache.Insert(MakeIdentity(1), 100);
   cache.Insert(MakeIdentity(2), 200);
   cache.Insert(MakeIdentity(3), 300);
@@ -142,7 +142,7 @@ TEST(TestDmaBufIdentityCache, EvictionNeverReturnsProtected)
 
 TEST(TestDmaBufIdentityCache, EvictionHonorsMoreThanTwoProtectedHandles)
 {
-  CDmaBufIdentityCache cache{1};
+  CDmaBufIdentityCache cache{1, "test"};
   cache.Insert(MakeIdentity(1), 100);
   cache.Insert(MakeIdentity(2), 200);
   cache.Insert(MakeIdentity(3), 300);
@@ -157,7 +157,7 @@ TEST(TestDmaBufIdentityCache, EvictionHonorsMoreThanTwoProtectedHandles)
 
 TEST(TestDmaBufIdentityCache, TakeAllReturnsEverythingAndEmpties)
 {
-  CDmaBufIdentityCache cache{4};
+  CDmaBufIdentityCache cache{4, "test"};
   cache.Insert(MakeIdentity(7, 1920), 100);
   EXPECT_EQ(cache.Lookup(MakeIdentity(7, 2048)), 0u); // dooms 100
   cache.Insert(MakeIdentity(8), 200);
@@ -175,7 +175,7 @@ TEST(TestDmaBufIdentityCache, TakeAllReturnsEverythingAndEmpties)
 
 TEST(TestDmaBufIdentityCache, InvalidateAllFreesEverythingExceptProtected)
 {
-  CDmaBufIdentityCache cache{4};
+  CDmaBufIdentityCache cache{4, "test"};
   cache.Insert(MakeIdentity(7), 100);
   cache.Insert(MakeIdentity(8), 200);
   cache.Insert(MakeIdentity(9), 300);

--- a/xbmc/cores/VideoPlayer/Buffers/test/TestVideoBufferDMA.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/test/TestVideoBufferDMA.cpp
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/VideoPlayer/Buffers/DmaBufIdentity.h"
+#include "cores/VideoPlayer/Buffers/VideoBufferDMA.h"
+#include "utils/BufferObject.h"
+#include "utils/BufferObjectFactory.h"
+
+#include <map>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+using namespace DRMPRIME;
+
+namespace
+{
+
+constexpr int FAKE_FD = 4242;
+constexpr uint32_t FOURCC_NV12 = 0x3231564e;
+
+// heap-backed stand-in so CVideoBufferDMA is usable without a kernel
+class FakeBufferObject : public CBufferObject
+{
+public:
+  bool CreateBufferObject(uint32_t format, uint32_t width, uint32_t height) override
+  {
+    return false;
+  }
+  bool CreateBufferObject(uint64_t size) override
+  {
+    m_memory = std::make_unique<uint8_t[]>(size);
+    m_fd = FAKE_FD;
+    return true;
+  }
+  void DestroyBufferObject() override
+  {
+    m_memory.reset();
+    m_fd = -1;
+  }
+  uint8_t* GetMemory() override { return m_memory.get(); }
+  void ReleaseMemory() override {}
+  std::string GetName() const override { return "FakeBufferObject"; }
+
+private:
+  std::unique_ptr<uint8_t[]> m_memory;
+};
+
+struct CountingStat
+{
+  std::map<int, uint64_t> inodes;
+  int calls{0};
+
+  StatInodeFn Fn()
+  {
+    return [this](int fd, uint64_t& inode)
+    {
+      calls++;
+      auto it = inodes.find(fd);
+      if (it == inodes.end())
+        return false;
+      inode = it->second;
+      return true;
+    };
+  }
+};
+
+class TestVideoBufferDMA : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    CBufferObjectFactory::ClearBufferObjects();
+    CBufferObjectFactory::RegisterBufferObject([] { return std::make_unique<FakeBufferObject>(); });
+  }
+  void TearDown() override { CBufferObjectFactory::ClearBufferObjects(); }
+};
+
+} // namespace
+
+// identity is derived fresh from the descriptor; layout changes must land in it
+TEST_F(TestVideoBufferDMA, DescriptorIdentityTracksLayout)
+{
+  auto buffer = std::make_unique<CVideoBufferDMA>(0, FOURCC_NV12, 2, 1920 * 1080 * 3 / 2);
+  ASSERT_TRUE(buffer->Alloc());
+
+  const int strides[YuvImage::MAX_PLANES] = {1920, 1920, 0};
+  const int offsets[YuvImage::MAX_PLANES] = {0, 1920 * 1080, 0};
+  buffer->SetDimensions(1920, 1080, strides, offsets);
+
+  CountingStat stat{{{FAKE_FD, 7}}};
+  const auto first = ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
+                                           buffer->GetHeight(), stat.Fn());
+  ASSERT_TRUE(first);
+
+  const auto repeat = ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
+                                            buffer->GetHeight(), stat.Fn());
+  ASSERT_TRUE(repeat);
+  EXPECT_TRUE(*first == *repeat);
+
+  const int changed[YuvImage::MAX_PLANES] = {2048, 1920, 0};
+  buffer->SetDimensions(1920, 1080, changed, offsets);
+  const auto relaid = ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
+                                            buffer->GetHeight(), stat.Fn());
+  ASSERT_TRUE(relaid);
+  EXPECT_FALSE(*first == *relaid);
+  EXPECT_TRUE(first->SameMemory(*relaid));
+}
+
+TEST_F(TestVideoBufferDMA, IsValidGateSurvivesCollapse)
+{
+  auto buffer = std::make_unique<CVideoBufferDMA>(0, FOURCC_NV12, 2, 1920 * 1080 * 3 / 2);
+  ASSERT_TRUE(buffer->Alloc());
+
+  // descriptor has no layers until dimensions are set
+  EXPECT_FALSE(buffer->IsValid());
+
+  const int strides[YuvImage::MAX_PLANES] = {1920, 1920, 0};
+  const int offsets[YuvImage::MAX_PLANES] = {0, 1920 * 1080, 0};
+  buffer->SetDimensions(1920, 1080, strides, offsets);
+  EXPECT_TRUE(buffer->IsValid());
+}

--- a/xbmc/cores/VideoPlayer/Buffers/test/TestVideoBufferDMA.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/test/TestVideoBufferDMA.cpp
@@ -94,19 +94,19 @@ TEST_F(TestVideoBufferDMA, DescriptorIdentityTracksLayout)
   buffer->SetDimensions(1920, 1080, strides, offsets);
 
   CountingStat stat{{{FAKE_FD, 7}}};
-  const auto first = ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
-                                           buffer->GetHeight(), stat.Fn());
+  const auto first = GetDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
+                                       buffer->GetHeight(), stat.Fn());
   ASSERT_TRUE(first);
 
-  const auto repeat = ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
-                                            buffer->GetHeight(), stat.Fn());
+  const auto repeat = GetDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
+                                        buffer->GetHeight(), stat.Fn());
   ASSERT_TRUE(repeat);
   EXPECT_TRUE(*first == *repeat);
 
   const int changed[YuvImage::MAX_PLANES] = {2048, 1920, 0};
   buffer->SetDimensions(1920, 1080, changed, offsets);
-  const auto relaid = ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
-                                            buffer->GetHeight(), stat.Fn());
+  const auto relaid = GetDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
+                                        buffer->GetHeight(), stat.Fn());
   ASSERT_TRUE(relaid);
   EXPECT_FALSE(*first == *relaid);
   EXPECT_TRUE(first->SameMemory(*relaid));

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -259,12 +259,16 @@ int CDVDVideoCodecDRMPRIME::GetBuffer(struct AVCodecContext* avctx, AVFrame* fra
     }
 
     CDVDVideoCodecDRMPRIME* ctx = static_cast<CDVDVideoCodecDRMPRIME*>(avctx->opaque);
-    // no lock: ffmpeg serializes get_buffer2 calls even with frame threading
+    // no lock: ffmpeg serializes get_buffer2 even with frame threading, and the codec's
+    // own accesses are safe because avcodec flush/free join the frame threads first
     if (!ctx->m_swVideoBufferPool || !ctx->m_swVideoBufferPool->IsCompatible(avctx->pix_fmt, size))
     {
       ctx->m_swVideoBufferPool = std::make_shared<CVideoBufferPoolDMA>();
       ctx->m_swVideoBufferPool->Configure(avctx->pix_fmt, size);
     }
+
+    if (!ctx->m_swVideoBufferPool->IsConfigured())
+      return -1;
 
     CVideoBufferDMA* buffer = ctx->m_swVideoBufferPool->Get();
     if (!buffer)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -91,7 +91,7 @@ CDVDVideoCodecDRMPRIME::CDVDVideoCodecDRMPRIME(CProcessInfo& processInfo)
   : CDVDVideoCodec(processInfo)
 {
   m_pFrame = av_frame_alloc();
-  m_videoBufferPool = std::make_shared<CVideoBufferPoolDRMPRIMEFFmpeg>();
+  m_hwVideoBufferPool = std::make_shared<CVideoBufferPoolDRMPRIMEFFmpeg>();
 }
 
 CDVDVideoCodecDRMPRIME::~CDVDVideoCodecDRMPRIME()
@@ -266,7 +266,7 @@ int CDVDVideoCodecDRMPRIME::GetBuffer(struct AVCodecContext* avctx, AVFrame* fra
       ctx->m_swVideoBufferPool->Configure(avctx->pix_fmt, size);
     }
 
-    auto* buffer = static_cast<CVideoBufferDMA*>(ctx->m_swVideoBufferPool->Get());
+    CVideoBufferDMA* buffer = ctx->m_swVideoBufferPool->Get();
     if (!buffer)
       return -1;
 
@@ -651,8 +651,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
 
   if (IsSupportedHwFormat(static_cast<AVPixelFormat>(m_pFrame->format)))
   {
-    CVideoBufferDRMPRIMEFFmpeg* buffer =
-        dynamic_cast<CVideoBufferDRMPRIMEFFmpeg*>(m_videoBufferPool->Get());
+    CVideoBufferDRMPRIMEFFmpeg* buffer = m_hwVideoBufferPool->Get();
     buffer->SetPictureParams(*pVideoPicture);
     buffer->SetRef(m_pFrame);
     pVideoPicture->videoBuffer = buffer;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -11,6 +11,7 @@
 #include "ServiceBroker.h"
 #include "cores/VideoPlayer/Buffers/VideoBufferDMA.h"
 #include "cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h"
+#include "cores/VideoPlayer/Buffers/VideoBufferPoolDMA.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDCodecs.h"
 #include "cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.h"
 #include "settings/Settings.h"
@@ -258,8 +259,14 @@ int CDVDVideoCodecDRMPRIME::GetBuffer(struct AVCodecContext* avctx, AVFrame* fra
     }
 
     CDVDVideoCodecDRMPRIME* ctx = static_cast<CDVDVideoCodecDRMPRIME*>(avctx->opaque);
-    auto buffer = dynamic_cast<CVideoBufferDMA*>(
-        ctx->m_processInfo.GetVideoBufferManager().Get(avctx->pix_fmt, size, nullptr));
+    // no lock: ffmpeg serializes get_buffer2 calls even with frame threading
+    if (!ctx->m_swVideoBufferPool || !ctx->m_swVideoBufferPool->IsCompatible(avctx->pix_fmt, size))
+    {
+      ctx->m_swVideoBufferPool = std::make_shared<CVideoBufferPoolDMA>();
+      ctx->m_swVideoBufferPool->Configure(avctx->pix_fmt, size);
+    }
+
+    auto* buffer = static_cast<CVideoBufferDMA*>(ctx->m_swVideoBufferPool->Get());
     if (!buffer)
       return -1;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -14,6 +14,8 @@
 
 #include <memory>
 
+class CVideoBufferPoolDMA;
+
 class CDVDVideoCodecDRMPRIME : public CDVDVideoCodec
 {
 public:
@@ -45,4 +47,5 @@ protected:
   AVCodecContext* m_pCodecContext = nullptr;
   AVFrame* m_pFrame = nullptr;
   std::shared_ptr<IVideoBufferPool> m_videoBufferPool;
+  std::shared_ptr<CVideoBufferPoolDMA> m_swVideoBufferPool;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.h
@@ -15,6 +15,7 @@
 #include <memory>
 
 class CVideoBufferPoolDMA;
+class CVideoBufferPoolDRMPRIMEFFmpeg;
 
 class CDVDVideoCodecDRMPRIME : public CDVDVideoCodec
 {
@@ -46,6 +47,6 @@ protected:
   double m_DAR = 1.0;
   AVCodecContext* m_pCodecContext = nullptr;
   AVFrame* m_pFrame = nullptr;
-  std::shared_ptr<IVideoBufferPool> m_videoBufferPool;
+  std::shared_ptr<CVideoBufferPoolDRMPRIMEFFmpeg> m_hwVideoBufferPool;
   std::shared_ptr<CVideoBufferPoolDMA> m_swVideoBufferPool;
 };

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -962,6 +962,12 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext* avctx, AVFrame* pFrame
   { // we have a new frame from decoder
 
     VASurfaceID surf = (VASurfaceID)(uintptr_t)pFrame->data[3];
+    // surface IDs are only meaningful within the decoder generation that allocated them
+    if (pFrame->buf[0] && av_buffer_get_opaque(pFrame->buf[0]) != this)
+    {
+      CLog::Log(LOGWARNING, "VAAPI::Decode - ignoring frame of a previous decoder generation");
+      return CDVDVideoCodec::VC_BUFFER;
+    }
     // ffmpeg vc-1 decoder does not flush, make sure the data buffer is still valid
     if (!m_videoSurfaces.IsValid(surf))
     {

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -962,7 +962,8 @@ CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext* avctx, AVFrame* pFrame
   { // we have a new frame from decoder
 
     VASurfaceID surf = (VASurfaceID)(uintptr_t)pFrame->data[3];
-    // surface IDs are only meaningful within the decoder generation that allocated them
+    // surface IDs are only meaningful within the decoder generation that allocated them;
+    // comparing the opaque is safe: FFGetBuffer's Acquire keeps the old decoder alive
     if (pFrame->buf[0] && av_buffer_get_opaque(pFrame->buf[0]) != this)
     {
       CLog::Log(LOGWARNING, "VAAPI::Decode - ignoring frame of a previous decoder generation");

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMECaptureGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMECaptureGLES.cpp
@@ -45,7 +45,7 @@ bool CaptureDRMPRIMEVideo(CVideoBufferDRMPRIME* buffer,
   // the capture runs with the GL context current, so the display is at hand
   CDRMPRIMETexture texture;
   texture.Init(eglGetCurrentDisplay());
-  if (!texture.Map(buffer))
+  if (!texture.Import(buffer))
   {
     CLog::Log(LOGWARNING,
               "CaptureDRMPRIMEVideo: OES import of the video buffer failed ({}x{}); video "
@@ -143,7 +143,7 @@ bool CaptureDRMPRIMEVideo(CVideoBufferDRMPRIME* buffer,
     glEnable(GL_SCISSOR_TEST);
   glDeleteFramebuffers(1, &fbo);
   glDeleteTextures(1, &fboTexture);
-  texture.Unmap();
+  texture.Reset();
   return ok;
 #endif
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -60,9 +60,9 @@ void CDRMPRIMETexture::Init(EGLDisplay eglDisplay)
   m_eglImage = std::make_unique<CEGLImage>(eglDisplay);
 }
 
-bool CDRMPRIMETexture::Map(CVideoBufferDRMPRIME* buffer)
+bool CDRMPRIMETexture::Import(CVideoBufferDRMPRIME* buffer)
 {
-  if (m_primebuffer)
+  if (m_imported)
     return true;
 
   if (!buffer->AcquireDescriptor())
@@ -113,25 +113,20 @@ bool CDRMPRIMETexture::Map(CVideoBufferDRMPRIME* buffer)
     glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     m_eglImage->UploadImage(m_textureTarget);
     glBindTexture(m_textureTarget, 0);
+    m_imported = true;
   }
 
-  m_primebuffer = buffer;
-  m_primebuffer->Acquire();
-
-  return true;
+  buffer->ReleaseDescriptor();
+  return m_imported;
 }
 
-void CDRMPRIMETexture::Unmap()
+void CDRMPRIMETexture::Reset()
 {
-  if (!m_primebuffer)
+  if (!m_imported)
     return;
 
   m_eglImage->DestroyImage();
-
-  m_primebuffer->ReleaseDescriptor();
-
-  m_primebuffer->Release();
-  m_primebuffer = nullptr;
+  m_imported = false;
 }
 
 namespace
@@ -193,9 +188,9 @@ bool CDRMPRIMETextureYUV::SupportsFormat(uint32_t fourcc)
 // extended to the per-plane texture array.
 CDRMPRIMETextureYUV::~CDRMPRIMETextureYUV()
 {
-  // Release any active mapping (EGL images, descriptor, buffer ref).
-  Unmap();
-  // Delete the GL texture objects that Map() may have generated.
+  // Release any active mapping (EGL images).
+  Reset();
+  // Delete the GL texture objects that Import() may have generated.
   for (int i = 0; i < MAX_PLANES; i++)
   {
     if (m_textures[i])
@@ -210,15 +205,15 @@ void CDRMPRIMETextureYUV::Init(EGLDisplay eglDisplay)
 
 // Descriptor acquire/release lifecycle and the per-plane
 // glIsTexture/glGenTextures + glBindTexture + glTexParameteri x4 +
-// UploadImage + unbind sequence are taken from CDRMPRIMETexture::Map
-// (above) and CVaapi2Texture::Map (VaapiEGL.cpp:438-560). What is new
+// UploadImage + unbind sequence are taken from CDRMPRIMETexture::Import
+// (above) and CVaapi2Texture::Import (VaapiEGL.cpp). What is new
 // here is the per-plane DRM fourcc derivation (single-layer N-plane
 // descriptor split into N separate EGL images) and the multi-plane
 // loop. Single-layer-N-plane is the shape ffmpeg HW decoders and the
 // SW-decode -> DMA path produce.
-bool CDRMPRIMETextureYUV::Map(CVideoBufferDRMPRIME* buffer)
+bool CDRMPRIMETextureYUV::Import(CVideoBufferDRMPRIME* buffer)
 {
-  if (m_primebuffer)
+  if (m_imported)
     return true;
 
   if (!buffer->AcquireDescriptor())
@@ -289,7 +284,7 @@ bool CDRMPRIMETextureYUV::Map(CVideoBufferDRMPRIME* buffer)
 
     if (!m_eglImages[i]->CreateImage(attribs))
     {
-      // Roll back any planes we already imported in this Map() call.
+      // Roll back any planes we already imported in this Import() call.
       for (int j = 0; j < i; j++)
         m_eglImages[j]->DestroyImage();
       m_numPlanes = 0;
@@ -308,16 +303,14 @@ bool CDRMPRIMETextureYUV::Map(CVideoBufferDRMPRIME* buffer)
     glBindTexture(GL_TEXTURE_2D, 0);
   }
 
-  m_primebuffer = buffer;
-  m_primebuffer->Acquire();
+  buffer->ReleaseDescriptor();
+  m_imported = true;
   return true;
 }
 
-// DestroyImage + ReleaseDescriptor + buffer Release + null sequence is
-// taken from CDRMPRIMETexture::Unmap (above), looped over planes.
-void CDRMPRIMETextureYUV::Unmap()
+void CDRMPRIMETextureYUV::Reset()
 {
-  if (!m_primebuffer)
+  if (!m_imported)
     return;
 
   for (int i = 0; i < m_numPlanes; i++)
@@ -326,8 +319,111 @@ void CDRMPRIMETextureYUV::Unmap()
       m_eglImages[i]->DestroyImage();
   }
   m_numPlanes = 0;
+  m_imported = false;
+}
 
-  m_primebuffer->ReleaseDescriptor();
-  m_primebuffer->Release();
-  m_primebuffer = nullptr;
+void CDRMPRIMETexturePool::Init(EGLDisplay eglDisplay)
+{
+  m_eglDisplay = eglDisplay;
+}
+
+CDRMPRIMETexture* CDRMPRIMETexturePool::GetOES(CVideoBufferDRMPRIME* buffer)
+{
+  const auto identity = DRMPRIME::ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
+                                                        buffer->GetHeight());
+  if (!identity)
+    return nullptr;
+
+  // the OES import bakes the colorspace and range hints into the image
+  const VideoPicture& picture = buffer->GetPicture();
+  const uint64_t salt = (static_cast<uint64_t>(GetEGLColorSpace(picture)) << 32) |
+                        static_cast<uint32_t>(GetEGLColorRange(picture));
+
+  uint32_t handle = m_oesCache.Lookup(*identity, salt);
+  if (!handle)
+  {
+    size_t slot;
+    if (!m_oesFree.empty())
+    {
+      slot = m_oesFree.back();
+      m_oesFree.pop_back();
+    }
+    else
+    {
+      slot = m_oesEntries.size();
+      m_oesEntries.push_back(std::make_unique<CDRMPRIMETexture>());
+      m_oesEntries[slot]->Init(m_eglDisplay);
+    }
+
+    if (!m_oesEntries[slot]->Import(buffer))
+    {
+      m_oesFree.push_back(slot);
+      return nullptr;
+    }
+    handle = static_cast<uint32_t>(slot) + 1;
+    m_oesCache.Insert(*identity, handle, salt);
+  }
+
+  for (uint32_t doomed : m_oesCache.Reap(handle, 0))
+  {
+    m_oesEntries[doomed - 1]->Reset();
+    m_oesFree.push_back(doomed - 1);
+  }
+
+  return m_oesEntries[handle - 1].get();
+}
+
+CDRMPRIMETextureYUV* CDRMPRIMETexturePool::GetYUV(CVideoBufferDRMPRIME* buffer)
+{
+  const auto identity = DRMPRIME::ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
+                                                        buffer->GetHeight());
+  if (!identity)
+    return nullptr;
+
+  uint32_t handle = m_yuvCache.Lookup(*identity);
+  if (!handle)
+  {
+    size_t slot;
+    if (!m_yuvFree.empty())
+    {
+      slot = m_yuvFree.back();
+      m_yuvFree.pop_back();
+    }
+    else
+    {
+      slot = m_yuvEntries.size();
+      m_yuvEntries.push_back(std::make_unique<CDRMPRIMETextureYUV>());
+      m_yuvEntries[slot]->Init(m_eglDisplay);
+    }
+
+    if (!m_yuvEntries[slot]->Import(buffer))
+    {
+      m_yuvFree.push_back(slot);
+      return nullptr;
+    }
+    handle = static_cast<uint32_t>(slot) + 1;
+    m_yuvCache.Insert(*identity, handle);
+  }
+
+  for (uint32_t doomed : m_yuvCache.Reap(handle, 0))
+  {
+    m_yuvEntries[doomed - 1]->Reset();
+    m_yuvFree.push_back(doomed - 1);
+  }
+
+  return m_yuvEntries[handle - 1].get();
+}
+
+void CDRMPRIMETexturePool::ReleaseAll()
+{
+  for (auto& entry : m_oesEntries)
+    entry->Reset();
+  for (auto& entry : m_yuvEntries)
+    entry->Reset();
+  m_oesCache.TakeAll();
+  m_yuvCache.TakeAll();
+  m_oesEntries.clear();
+  m_yuvEntries.clear();
+  m_oesFree.clear();
+  m_yuvFree.clear();
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -344,12 +344,25 @@ void RecycleDoomed(DRMPRIME::CDmaBufIdentityCache& cache,
   }
 }
 
+// some buffer types build the descriptor in AcquireDescriptor, so acquire before reading it
+std::optional<DRMPRIME::DmaBufIdentity> AcquiredIdentity(CVideoBufferDRMPRIME* buffer)
+{
+  if (!buffer->AcquireDescriptor())
+  {
+    CLog::Log(LOGERROR, "CDRMPRIMETexturePool - failed to acquire descriptor");
+    return std::nullopt;
+  }
+  const auto identity = DRMPRIME::ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
+                                                        buffer->GetHeight());
+  buffer->ReleaseDescriptor();
+  return identity;
+}
+
 } // namespace
 
 CDRMPRIMETexture* CDRMPRIMETexturePool::GetOES(CVideoBufferDRMPRIME* buffer)
 {
-  const auto identity = DRMPRIME::ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
-                                                        buffer->GetHeight());
+  const auto identity = AcquiredIdentity(buffer);
   if (!identity)
     return nullptr;
 
@@ -391,8 +404,7 @@ CDRMPRIMETexture* CDRMPRIMETexturePool::GetOES(CVideoBufferDRMPRIME* buffer)
 
 CDRMPRIMETextureYUV* CDRMPRIMETexturePool::GetYUV(CVideoBufferDRMPRIME* buffer)
 {
-  const auto identity = DRMPRIME::ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
-                                                        buffer->GetHeight());
+  const auto identity = AcquiredIdentity(buffer);
   if (!identity)
     return nullptr;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -327,6 +327,25 @@ void CDRMPRIMETexturePool::Init(EGLDisplay eglDisplay)
   m_eglDisplay = eglDisplay;
 }
 
+namespace
+{
+
+// destroy reaped textures and recycle their slots
+template<typename EntryVec>
+void RecycleDoomed(DRMPRIME::CDmaBufIdentityCache& cache,
+                   EntryVec& entries,
+                   std::vector<size_t>& freeSlots,
+                   std::initializer_list<uint32_t> protectedHandles)
+{
+  for (uint32_t doomed : cache.Reap(protectedHandles))
+  {
+    entries[doomed - 1]->Reset();
+    freeSlots.push_back(doomed - 1);
+  }
+}
+
+} // namespace
+
 CDRMPRIMETexture* CDRMPRIMETexturePool::GetOES(CVideoBufferDRMPRIME* buffer)
 {
   const auto identity = DRMPRIME::ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
@@ -358,17 +377,14 @@ CDRMPRIMETexture* CDRMPRIMETexturePool::GetOES(CVideoBufferDRMPRIME* buffer)
     if (!m_oesEntries[slot]->Import(buffer))
     {
       m_oesFree.push_back(slot);
+      RecycleDoomed(m_oesCache, m_oesEntries, m_oesFree, {});
       return nullptr;
     }
     handle = static_cast<uint32_t>(slot) + 1;
     m_oesCache.Insert(*identity, handle, salt);
   }
 
-  for (uint32_t doomed : m_oesCache.Reap(handle, 0))
-  {
-    m_oesEntries[doomed - 1]->Reset();
-    m_oesFree.push_back(doomed - 1);
-  }
+  RecycleDoomed(m_oesCache, m_oesEntries, m_oesFree, {handle});
 
   return m_oesEntries[handle - 1].get();
 }
@@ -399,17 +415,14 @@ CDRMPRIMETextureYUV* CDRMPRIMETexturePool::GetYUV(CVideoBufferDRMPRIME* buffer)
     if (!m_yuvEntries[slot]->Import(buffer))
     {
       m_yuvFree.push_back(slot);
+      RecycleDoomed(m_yuvCache, m_yuvEntries, m_yuvFree, {});
       return nullptr;
     }
     handle = static_cast<uint32_t>(slot) + 1;
     m_yuvCache.Insert(*identity, handle);
   }
 
-  for (uint32_t doomed : m_yuvCache.Reap(handle, 0))
-  {
-    m_yuvEntries[doomed - 1]->Reset();
-    m_yuvFree.push_back(doomed - 1);
-  }
+  RecycleDoomed(m_yuvCache, m_yuvEntries, m_yuvFree, {handle});
 
   return m_yuvEntries[handle - 1].get();
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.cpp
@@ -352,8 +352,8 @@ std::optional<DRMPRIME::DmaBufIdentity> AcquiredIdentity(CVideoBufferDRMPRIME* b
     CLog::Log(LOGERROR, "CDRMPRIMETexturePool - failed to acquire descriptor");
     return std::nullopt;
   }
-  const auto identity = DRMPRIME::ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
-                                                        buffer->GetHeight());
+  const auto identity =
+      DRMPRIME::GetDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(), buffer->GetHeight());
   buffer->ReleaseDescriptor();
   return identity;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
@@ -106,8 +106,8 @@ public:
 
 private:
   EGLDisplay m_eglDisplay{nullptr};
-  DRMPRIME::CDmaBufIdentityCache m_oesCache{MAX_ENTRIES};
-  DRMPRIME::CDmaBufIdentityCache m_yuvCache{MAX_ENTRIES};
+  DRMPRIME::CDmaBufIdentityCache m_oesCache{MAX_ENTRIES, "oes"};
+  DRMPRIME::CDmaBufIdentityCache m_yuvCache{MAX_ENTRIES, "yuv"};
   // cache handle = entry index + 1; freed slots are recycled
   std::vector<std::unique_ptr<CDRMPRIMETexture>> m_oesEntries;
   std::vector<std::unique_ptr<CDRMPRIMETextureYUV>> m_yuvEntries;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
@@ -8,11 +8,13 @@
 
 #pragma once
 
+#include "cores/VideoPlayer/Buffers/DmaBufIdentityCache.h"
 #include "cores/VideoPlayer/Buffers/VideoBufferDRMPRIME.h"
 #include "utils/EGLImage.h"
 #include "utils/Geometry.h"
 
 #include <array>
+#include <vector>
 
 #include "system_gl.h"
 
@@ -22,27 +24,27 @@ public:
   CDRMPRIMETexture() = default;
   ~CDRMPRIMETexture();
 
-  bool Map(CVideoBufferDRMPRIME* buffer);
-  void Unmap();
+  bool Import(CVideoBufferDRMPRIME* buffer);
+  void Reset();
   void Init(EGLDisplay eglDisplay);
 
   GLuint GetTexture() { return m_texture; }
   CSizeInt GetTextureSize() { return {m_texWidth, m_texHeight}; }
 
 protected:
-  CVideoBufferDRMPRIME* m_primebuffer{nullptr};
   std::unique_ptr<CEGLImage> m_eglImage;
 
   const GLenum m_textureTarget{GL_TEXTURE_EXTERNAL_OES};
   GLuint m_texture{0};
   int m_texWidth{0};
   int m_texHeight{0};
+  bool m_imported{false};
 };
 
 /*
  * CDRMPRIMETextureYUV: import a DRMPRIME dma-buf as separate per-plane
  * GL_TEXTURE_2D textures, the same way VAAPIGLES handles VA-API surfaces
- * (see CVaapi2Texture::Map). Used by the limited-range render path on
+ * (see CVaapi2Texture::Import). Used by the limited-range render path on
  * CRendererDRMPRIMEGLES so the YUV->RGB matrix can be applied in a
  * standard BaseYUV2RGBGLSLShader instead of being baked in by the OES
  * external sampler's full-range-only Mesa matrix.
@@ -63,8 +65,8 @@ public:
   CDRMPRIMETextureYUV& operator=(const CDRMPRIMETextureYUV&) = delete;
 
   void Init(EGLDisplay eglDisplay);
-  bool Map(CVideoBufferDRMPRIME* buffer);
-  void Unmap();
+  bool Import(CVideoBufferDRMPRIME* buffer);
+  void Reset();
 
   GLuint GetTexture(int plane) const { return m_textures[plane]; }
   int GetNumPlanes() const { return m_numPlanes; }
@@ -75,7 +77,6 @@ public:
   static bool SupportsFormat(uint32_t fourcc);
 
 protected:
-  CVideoBufferDRMPRIME* m_primebuffer{nullptr};
   EGLDisplay m_eglDisplay{nullptr};
   std::array<std::unique_ptr<CEGLImage>, MAX_PLANES> m_eglImages;
   std::array<GLuint, MAX_PLANES> m_textures{{0, 0, 0}};
@@ -83,4 +84,32 @@ protected:
   int m_texWidth{0};
   int m_texHeight{0};
   uint32_t m_sourceFormat{0};
+  bool m_imported{false};
+};
+
+//! \brief Textures cached per dma-buf identity; the render slot's buffer reference pins content.
+class CDRMPRIMETexturePool
+{
+public:
+  static constexpr size_t MAX_ENTRIES = 16;
+
+  void Init(EGLDisplay eglDisplay);
+  //! \brief Imported OES texture for the buffer's dma-buf; nullptr on import failure.
+  //! The returned pointer is valid only until the pool's next Get or ReleaseAll call.
+  CDRMPRIMETexture* GetOES(CVideoBufferDRMPRIME* buffer);
+  //! \brief Imported per-plane textures for the buffer's dma-buf; nullptr on import failure.
+  //! The returned pointer is valid only until the pool's next Get or ReleaseAll call.
+  CDRMPRIMETextureYUV* GetYUV(CVideoBufferDRMPRIME* buffer);
+  //! \brief Destroy every image and texture; needs the GL context current.
+  void ReleaseAll();
+
+private:
+  EGLDisplay m_eglDisplay{nullptr};
+  DRMPRIME::CDmaBufIdentityCache m_oesCache{MAX_ENTRIES};
+  DRMPRIME::CDmaBufIdentityCache m_yuvCache{MAX_ENTRIES};
+  // cache handle = entry index + 1; freed slots are recycled
+  std::vector<std::unique_ptr<CDRMPRIMETexture>> m_oesEntries;
+  std::vector<std::unique_ptr<CDRMPRIMETextureYUV>> m_yuvEntries;
+  std::vector<size_t> m_oesFree;
+  std::vector<size_t> m_yuvFree;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/DRMPRIMEEGL.h
@@ -91,7 +91,8 @@ protected:
 class CDRMPRIMETexturePool
 {
 public:
-  static constexpr size_t MAX_ENTRIES = 16;
+  // must exceed the decoder's dma-buf pool (v4l2m2m has been seen with 20+ CAPTURE buffers)
+  static constexpr size_t MAX_ENTRIES = 32;
 
   void Init(EGLDisplay eglDisplay);
   //! \brief Imported OES texture for the buffer's dma-buf; nullptr on import failure.

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -24,8 +24,6 @@
 #include "windowing/gbm/WinSystemGbm.h"
 #include "windowing/gbm/drm/DRMAtomic.h"
 
-#include <typeinfo>
-
 using namespace KODI::WINDOWING::GBM;
 
 CRendererDRMPRIME::~CRendererDRMPRIME()
@@ -186,12 +184,9 @@ void CRendererDRMPRIME::AddVideoPicture(const VideoPicture& picture, int index)
   buf.videoBuffer = picture.videoBuffer;
   buf.videoBuffer->Acquire();
 
-  //! @todo skip only the exact CVideoBufferDRMPRIMEFFmpeg type, which
-  //! CDVDVideoCodecDRMPRIME always fills at decode; its subclass
-  //! CVideoBufferDMA also arrives from CAddonVideoCodec unfilled, so it is
-  //! set here (a duplicate set for the ffmpeg software path, accepted).
+  // CDVDVideoCodecDRMPRIME fills its buffers at decode; CVideoBufferDMA arrives unfilled
   auto* drmBuffer = dynamic_cast<CVideoBufferDRMPRIME*>(picture.videoBuffer);
-  if (drmBuffer && typeid(*drmBuffer) != typeid(CVideoBufferDRMPRIMEFFmpeg))
+  if (drmBuffer && !dynamic_cast<CVideoBufferDRMPRIMEFFmpeg*>(drmBuffer))
     drmBuffer->SetPictureParams(picture);
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -38,6 +38,10 @@ CRendererDRMPRIME::~CRendererDRMPRIME()
   winSystem->SetHDR(nullptr);
   winSystem->SetColorimetry(nullptr);
 
+  // queue the video plane off before FindGuiPlane nulls m_video_plane
+  if (m_videoLayerBridge)
+    m_videoLayerBridge->Disable();
+
   //! @todo Restore single-plane state after D2P playback: null m_video_plane
   //! via direct FindGuiPlane, mirroring Create's direct FindVideoAndGuiPlane.
   //! D2P cannot share single-plane's teardown via winSystem->SetVideoOutput

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIME.cpp
@@ -37,20 +37,6 @@ CRendererDRMPRIME::~CRendererDRMPRIME()
   winSystem->SetGuiCompositing(false);
   winSystem->SetHDR(nullptr);
   winSystem->SetColorimetry(nullptr);
-
-  // queue the video plane off before FindGuiPlane nulls m_video_plane
-  if (m_videoLayerBridge)
-    m_videoLayerBridge->Disable();
-
-  //! @todo Restore single-plane state after D2P playback: null m_video_plane
-  //! via direct FindGuiPlane, mirroring Create's direct FindVideoAndGuiPlane.
-  //! D2P cannot share single-plane's teardown via winSystem->SetVideoOutput
-  //! (nullptr) because the renderer factory hands Create a CVideoBuffer*
-  //! (not a VideoPicture*) and start has no buffer-shaped winsystem entry.
-  //! Future: unified plane API for D2P and single-plane to share teardown.
-  auto drm = winSystem->GetDrm();
-  auto* gui = drm->GetGuiPlane();
-  drm->FindGuiPlane(gui->GetFormat(), gui->GetModifier());
 }
 
 CBaseRenderer* CRendererDRMPRIME::Create(CVideoBuffer* buffer)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -123,14 +123,13 @@ bool CRendererDRMPRIMEGLES::Configure(const VideoPicture& picture,
 
   EGLDisplay eglDisplay = winSystemEGL->GetEGLDisplay();
 
+  m_texturePool.ReleaseAll();
+  m_texturePool.Init(eglDisplay);
+
   for (auto&& buf : m_buffers)
   {
     if (!buf.fence)
-    {
-      buf.texture.Init(eglDisplay);
-      buf.yuvTexture.Init(eglDisplay);
       buf.fence = std::make_unique<CEGLFence>(eglDisplay);
-    }
   }
 
   m_configured = true;
@@ -271,6 +270,7 @@ void CRendererDRMPRIMEGLES::UnInit()
     CServiceBroker::GetWinSystem()->SetVideoOutput(nullptr);
   }
 
+  m_texturePool.ReleaseAll();
   m_yuvShader.reset();
   m_configured = false;
 }
@@ -283,8 +283,6 @@ void CRendererDRMPRIMEGLES::AddVideoPicture(const VideoPicture& picture, int ind
     CLog::LogF(LOGERROR, "unreleased video buffer");
     if (buf.fence)
       buf.fence->DestroyFence();
-    buf.texture.Unmap();
-    buf.yuvTexture.Unmap();
     buf.videoBuffer->Release();
   }
   buf.videoBuffer = picture.videoBuffer;
@@ -311,9 +309,6 @@ void CRendererDRMPRIMEGLES::ReleaseBuffer(int index)
 
   if (buf.fence)
     buf.fence->DestroyFence();
-
-  buf.texture.Unmap();
-  buf.yuvTexture.Unmap();
 
   if (buf.videoBuffer)
   {
@@ -469,10 +464,11 @@ void CRendererDRMPRIMEGLES::Render(unsigned int flags, int index)
   // the user can toggle the setting at runtime and the next frame picks
   // up the new path without any rebuild.
   auto* winSystem = CServiceBroker::GetWinSystem();
-  const bool useYUVPath =
-      m_yuvShader && winSystem && winSystem->UseLimitedColor() && buf.yuvTexture.Map(buffer);
+  CDRMPRIMETextureYUV* yuvTexture = nullptr;
+  if (m_yuvShader && winSystem && winSystem->UseLimitedColor())
+    yuvTexture = m_texturePool.GetYUV(buffer);
 
-  if (useYUVPath)
+  if (yuvTexture)
   {
     // Limited-range YUV path: per-plane sampler2D + BaseYUV2RGBGLSLShader.
     // Vertex/cord array setup is taken from CLinuxRendererGLES::RenderSinglePass
@@ -481,18 +477,18 @@ void CRendererDRMPRIMEGLES::Render(unsigned int flags, int index)
     // -- specifically, the SHADER_NV12_RRG case binds the UV texture to BOTH
     // U and V samplers so .r returns U and .g returns V via the GR88 / GR1616
     // import.
-    const int numPlanes = buf.yuvTexture.GetNumPlanes();
+    const int numPlanes = yuvTexture->GetNumPlanes();
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, buf.yuvTexture.GetTexture(0));
+    glBindTexture(GL_TEXTURE_2D, yuvTexture->GetTexture(0));
     glActiveTexture(GL_TEXTURE1);
-    glBindTexture(GL_TEXTURE_2D, buf.yuvTexture.GetTexture(1));
+    glBindTexture(GL_TEXTURE_2D, yuvTexture->GetTexture(1));
     glActiveTexture(GL_TEXTURE2);
     // 3-plane (YV12_HI): plane 2 is V. 2-plane (NV12_RRG): rebind plane 1
     // (UV) so sampV samples the same texture as sampU.
-    glBindTexture(GL_TEXTURE_2D, buf.yuvTexture.GetTexture(numPlanes == 3 ? 2 : 1));
+    glBindTexture(GL_TEXTURE_2D, yuvTexture->GetTexture(numPlanes == 3 ? 2 : 1));
     glActiveTexture(GL_TEXTURE0);
 
-    const CSizeInt texSize = buf.yuvTexture.GetTextureSize();
+    const CSizeInt texSize = yuvTexture->GetTextureSize();
     m_yuvShader->SetWidth(texSize.Width());
     m_yuvShader->SetHeight(texSize.Height());
     m_yuvShader->SetAlpha(1.0f);
@@ -563,10 +559,11 @@ void CRendererDRMPRIMEGLES::Render(unsigned int flags, int index)
   }
 
   // Full-range OES path (unchanged).
-  if (!buf.texture.Map(buffer))
+  CDRMPRIMETexture* texture = m_texturePool.GetOES(buffer);
+  if (!texture)
     return;
 
-  DrawTexture(*renderSystem, buf.texture.GetTexture(), m_rotatedDestCoords);
+  DrawTexture(*renderSystem, texture->GetTexture(), m_rotatedDestCoords);
 
   buf.fence->DestroyFence();
   buf.fence->CreateFence();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.cpp
@@ -27,7 +27,6 @@
 #include "windowing/linux/WinSystemEGL.h"
 
 #include <memory>
-#include <typeinfo>
 
 using namespace KODI::UTILS::EGL;
 
@@ -291,12 +290,9 @@ void CRendererDRMPRIMEGLES::AddVideoPicture(const VideoPicture& picture, int ind
   buf.videoBuffer = picture.videoBuffer;
   buf.videoBuffer->Acquire();
 
-  //! @todo skip only the exact CVideoBufferDRMPRIMEFFmpeg type, which
-  //! CDVDVideoCodecDRMPRIME always fills at decode; its subclass
-  //! CVideoBufferDMA also arrives from CAddonVideoCodec unfilled, so it is
-  //! set here (a duplicate set for the ffmpeg software path, accepted).
+  // CDVDVideoCodecDRMPRIME fills its buffers at decode; CVideoBufferDMA arrives unfilled
   auto* drmBuffer = dynamic_cast<CVideoBufferDRMPRIME*>(picture.videoBuffer);
-  if (drmBuffer && typeid(*drmBuffer) != typeid(CVideoBufferDRMPRIMEFFmpeg))
+  if (drmBuffer && !dynamic_cast<CVideoBufferDRMPRIMEFFmpeg*>(drmBuffer))
     drmBuffer->SetPictureParams(picture);
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererDRMPRIMEGLES.h
@@ -89,7 +89,7 @@ private:
   {
     CVideoBuffer* videoBuffer = nullptr;
     std::unique_ptr<KODI::UTILS::EGL::CEGLFence> fence;
-    CDRMPRIMETexture texture;
-    CDRMPRIMETextureYUV yuvTexture;
   } m_buffers[NUM_BUFFERS];
+
+  CDRMPRIMETexturePool m_texturePool;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -91,11 +91,10 @@ bool CRendererVAAPIGL::Configure(const VideoPicture& picture, float fps, unsigne
     interop.glEGLImageTargetTexture2DOES = (PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)eglGetProcAddress("glEGLImageTargetTexture2DOES");
     interop.eglDisplay = CRendererVAAPIGL::m_pWinSystem->GetEGLDisplay();
 
+    m_texturePool.ReleaseAll();
+    m_texturePool.Init(interop);
     for (auto &tex : m_vaapiTextures)
-    {
-      tex = std::make_unique<VAAPI::CVaapi2Texture>();
-      tex->Init(interop);
-    }
+      tex = nullptr;
   }
 
   for (auto &fence : m_fences)
@@ -111,9 +110,7 @@ bool CRendererVAAPIGL::Flush(bool saveBuffers)
   for (auto &vaapiTexture : m_vaapiTextures)
   {
     if (m_isVAAPIBuffer)
-    {
-      vaapiTexture->Unmap();
-    }
+      vaapiTexture = nullptr;
   }
   return CLinuxRendererGL::Flush(saveBuffers);
 }
@@ -220,7 +217,9 @@ bool CRendererVAAPIGL::UploadTexture(int index)
     return UploadNV12Texture(index);
   }
 
-  m_vaapiTextures[index]->Map(pic);
+  m_vaapiTextures[index] = m_texturePool.Get(pic);
+  if (!m_vaapiTextures[index])
+    return false;
 
   const YuvImage& im = buf.image;
   CYuvPlane (&planes)[3] = buf.fields[0];
@@ -300,8 +299,7 @@ void CRendererVAAPIGL::ReleaseBuffer(int idx)
     m_fences[idx] = {};
   }
   if (m_isVAAPIBuffer)
-  {
-    m_vaapiTextures[idx]->Unmap();
-  }
+    m_vaapiTextures[idx] = nullptr;
+
   CLinuxRendererGL::ReleaseBuffer(idx);
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -71,6 +71,8 @@ CRendererVAAPIGL::~CRendererVAAPIGL()
   {
     DeleteTexture(i);
   }
+  // renderer destruction runs on the render thread with the GL context current
+  m_texturePool.ReleaseAll();
 }
 
 bool CRendererVAAPIGL::Configure(const VideoPicture& picture, float fps, unsigned int orientation)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.cpp
@@ -217,7 +217,7 @@ bool CRendererVAAPIGL::UploadTexture(int index)
     return UploadNV12Texture(index);
   }
 
-  m_vaapiTextures[index] = m_texturePool.Get(pic);
+  m_vaapiTextures[index] = m_texturePool.Get(pic, m_vaapiTextures);
   if (!m_vaapiTextures[index])
     return false;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGL.h
@@ -52,7 +52,8 @@ protected:
   EShaderFormat GetShaderFormat() override;
 
   bool m_isVAAPIBuffer = true;
-  std::unique_ptr<VAAPI::CVaapiTexture> m_vaapiTextures[NUM_BUFFERS];
+  VAAPI::CVaapiTexturePool m_texturePool;
+  VAAPI::CVaapiTexture* m_vaapiTextures[NUM_BUFFERS]{};
   GLsync m_fences[NUM_BUFFERS];
   static VAAPI::IVaapiWinSystem *m_pWinSystem;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
@@ -98,11 +98,10 @@ bool CRendererVAAPIGLES::Configure(const VideoPicture& picture, float fps, unsig
         (PFNGLEGLIMAGETARGETTEXTURE2DOESPROC)eglGetProcAddress("glEGLImageTargetTexture2DOES");
     interop.eglDisplay = m_pWinSystem->GetEGLDisplay();
 
+    m_texturePool.ReleaseAll();
+    m_texturePool.Init(interop);
     for (auto& tex : m_vaapiTextures)
-    {
-      tex = std::make_unique<VAAPI::CVaapi2Texture>();
-      tex->Init(interop);
-    }
+      tex = nullptr;
 
     for (auto& fence : m_fences)
     {
@@ -264,7 +263,9 @@ bool CRendererVAAPIGLES::UploadTexture(int index)
     return false;
   }
 
-  m_vaapiTextures[index]->Map(pic);
+  m_vaapiTextures[index] = m_texturePool.Get(pic);
+  if (!m_vaapiTextures[index])
+    return false;
 
   YuvImage &im = buf.image;
   CYuvPlane (&planes)[3] = buf.fields[0];
@@ -335,9 +336,7 @@ void CRendererVAAPIGLES::ReleaseBuffer(int index)
     m_fences[index]->DestroyFence();
 
   if (m_isVAAPIBuffer)
-  {
-    m_vaapiTextures[index]->Unmap();
-  }
+    m_vaapiTextures[index] = nullptr;
 
   CLinuxRendererGLES::ReleaseBuffer(index);
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
@@ -76,6 +76,8 @@ CRendererVAAPIGLES::~CRendererVAAPIGLES()
   {
     DeleteTexture(i);
   }
+  // renderer destruction runs on the render thread with the GL context current
+  m_texturePool.ReleaseAll();
 }
 
 bool CRendererVAAPIGLES::Configure(const VideoPicture& picture, float fps, unsigned int orientation)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
@@ -263,7 +263,7 @@ bool CRendererVAAPIGLES::UploadTexture(int index)
     return false;
   }
 
-  m_vaapiTextures[index] = m_texturePool.Get(pic);
+  m_vaapiTextures[index] = m_texturePool.Get(pic, m_vaapiTextures);
   if (!m_vaapiTextures[index])
     return false;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.h
@@ -64,7 +64,8 @@ protected:
   // YUY2 / Y210 / Y212 / Y216). Captured at Configure and read by
   // GetShaderFormat to pick the matching sampling path.
   std::int32_t m_vaapiFourcc{};
-  std::unique_ptr<VAAPI::CVaapiTexture> m_vaapiTextures[NUM_BUFFERS];
+  VAAPI::CVaapiTexturePool m_texturePool;
+  VAAPI::CVaapiTexture* m_vaapiTextures[NUM_BUFFERS]{};
   std::array<std::unique_ptr<KODI::UTILS::EGL::CEGLFence>, NUM_BUFFERS> m_fences;
   static VAAPI::IVaapiWinSystem *m_pWinSystem;
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -13,6 +13,7 @@
 #include "utils/log.h"
 
 #include <drm_fourcc.h>
+#include <unistd.h>
 #include <va/va_drmcommon.h>
 
 using namespace VAAPI;
@@ -23,19 +24,15 @@ void CVaapi2Texture::Init(InteropInfo& interop)
   m_hasPlaneModifiers = CEGLUtils::HasExtension(m_interop.eglDisplay, "EGL_EXT_image_dma_buf_import_modifiers");
 }
 
-bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
+bool CVaapi2Texture::Import(CVaapiRenderPicture* pic)
 {
-  if (m_vaapiPic)
+  if (m_imported)
     return true;
 
-  m_vaapiPic = pic;
-  m_vaapiPic->Acquire();
-
-  // Pairs with the Acquire() above; nulling lets a retry see unmapped state.
-  auto failMap = [this]()
+  auto failImport = [this]()
   {
-    m_vaapiPic->Release();
-    m_vaapiPic = nullptr;
+    // also destroys images/textures a partly failed import created
+    Reset();
     return false;
   };
 
@@ -50,12 +47,12 @@ bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
 
   if (status != VA_STATUS_SUCCESS)
   {
-    CLog::Log(LOGWARNING, "CVaapi2Texture::Map: vaExportSurfaceHandle failed - Error: {} ({})",
+    CLog::Log(LOGWARNING, "CVaapi2Texture::Import: vaExportSurfaceHandle failed - Error: {} ({})",
               vaErrorStr(status), status);
-    return failMap();
+    return failImport();
   }
 
-  // Take ownership of the exported fds (RAII closes them on Unmap). num_objects
+  // Take ownership of the exported fds (RAII closes them on Reset). num_objects
   // is bounded by the libva descriptor's fixed objects[] array == m_drmFDs.size().
   for (uint32_t object = 0; object < surface.num_objects && object < m_drmFDs.size(); object++)
     m_drmFDs[object].attach(surface.objects[object].fd);
@@ -63,9 +60,9 @@ bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
   status = vaSyncSurface(pic->vadsp, pic->procPic.videoSurface);
   if (status != VA_STATUS_SUCCESS)
   {
-    CLog::Log(LOGERROR, "CVaapi2Texture::Map: vaSyncSurface - Error: {} ({})", vaErrorStr(status),
-              status);
-    return failMap();
+    CLog::Log(LOGERROR, "CVaapi2Texture::Import: vaSyncSurface - Error: {} ({})",
+              vaErrorStr(status), status);
+    return failImport();
   }
 
   m_textureSize.Set(pic->DVDPic.iWidth, pic->DVDPic.iHeight);
@@ -77,17 +74,17 @@ bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
     if (layer.num_planes != 1)
     {
       CLog::Log(LOGDEBUG,
-                "CVaapi2Texture::Map: DRM-exported layer has {} planes - only 1 supported",
+                "CVaapi2Texture::Import: DRM-exported layer has {} planes - only 1 supported",
                 layer.num_planes);
-      return failMap();
+      return failImport();
     }
     // Driver-supplied object_index is untrusted; reject OOB before indexing.
     if (layer.object_index[plane] >= surface.num_objects)
     {
       CLog::Log(LOGERROR,
-                "CVaapi2Texture::Map: layer {} plane {} object_index {} >= num_objects {}", layerNo,
-                plane, layer.object_index[plane], surface.num_objects);
-      return failMap();
+                "CVaapi2Texture::Import: layer {} plane {} object_index {} >= num_objects {}",
+                layerNo, plane, layer.object_index[plane], surface.num_objects);
+      return failImport();
     }
     auto const& object = surface.objects[layer.object_index[plane]];
 
@@ -121,15 +118,15 @@ bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
             }
             break;
           default:
-            failMap();
+            failImport();
             throw std::logic_error("Impossible layer number");
         }
         break;
       default:
         CLog::Log(LOGDEBUG,
-                  "CVaapi2Texture::Map: DRM-exported surface {} layers - only 1 or 2 supported",
+                  "CVaapi2Texture::Import: DRM-exported surface {} layers - only 1 or 2 supported",
                   surface.num_layers);
-        return failMap();
+        return failImport();
     }
 
     // Mesa Y210 / Y212 / Y216 import quirk: Mesa imports those DRM fourccs
@@ -168,7 +165,7 @@ bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
     if (!texture->eglImage)
     {
       CEGLUtils::Log(LOGERROR, "Failed to import VA DRM surface into EGL image");
-      return failMap();
+      return failImport();
     }
 
     glGenTextures(1, &texture->glTexture);
@@ -177,13 +174,12 @@ bool CVaapi2Texture::Map(CVaapiRenderPicture* pic)
     glBindTexture(m_interop.textureTarget, 0);
   }
 
+  m_imported = true;
   return true;
 }
 
-void CVaapi2Texture::Unmap()
+void CVaapi2Texture::Reset()
 {
-  if (!m_vaapiPic)
-    return;
 
   for (auto texture : {&m_y, &m_vu})
   {
@@ -200,8 +196,7 @@ void CVaapi2Texture::Unmap()
     fd.reset();
   }
 
-  m_vaapiPic->Release();
-  m_vaapiPic = nullptr;
+  m_imported = false;
 }
 
 GLuint CVaapi2Texture::GetTextureY()
@@ -217,6 +212,124 @@ GLuint CVaapi2Texture::GetTextureVU()
 CSizeInt CVaapi2Texture::GetTextureSize()
 {
   return m_textureSize;
+}
+
+namespace
+{
+
+// separate-layers export: one plane per layer, keyed like the DRMPRIME path
+std::optional<DRMPRIME::DmaBufIdentity> IdentityFromVaDescriptor(
+    const VADRMPRIMESurfaceDescriptor& surface)
+{
+  if (surface.num_objects < 1 || surface.num_objects > AV_DRM_MAX_PLANES ||
+      surface.num_layers < 1 || surface.num_layers > AV_DRM_MAX_PLANES)
+    return std::nullopt;
+
+  DRMPRIME::DmaBufIdentity identity;
+  identity.nbObjects = surface.num_objects;
+  for (uint32_t i = 0; i < surface.num_objects; i++)
+  {
+    if (!DRMPRIME::StatInode(surface.objects[i].fd, identity.inode[i]))
+      return std::nullopt;
+    identity.modifier[i] = surface.objects[i].drm_format_modifier;
+  }
+
+  identity.width = surface.width;
+  identity.height = surface.height;
+  identity.format = surface.fourcc;
+  identity.nbPlanes = surface.num_layers;
+  for (uint32_t i = 0; i < surface.num_layers; i++)
+  {
+    identity.objectIndex[i] = surface.layers[i].object_index[0];
+    identity.offset[i] = surface.layers[i].offset[0];
+    identity.pitch[i] = surface.layers[i].pitch[0];
+  }
+
+  return identity;
+}
+
+} // namespace
+
+void CVaapiTexturePool::Init(InteropInfo& interop)
+{
+  m_interop = interop;
+}
+
+CVaapi2Texture* CVaapiTexturePool::Get(CVaapiRenderPicture* pic)
+{
+  VADRMPRIMESurfaceDescriptor surface;
+  VAStatus status = vaExportSurfaceHandle(
+      pic->vadsp, pic->procPic.videoSurface, VA_SURFACE_ATTRIB_MEM_TYPE_DRM_PRIME_2,
+      VA_EXPORT_SURFACE_READ_ONLY | VA_EXPORT_SURFACE_SEPARATE_LAYERS, &surface);
+  if (status != VA_STATUS_SUCCESS)
+  {
+    CLog::Log(LOGWARNING, "CVaapiTexturePool::{}: vaExportSurfaceHandle failed - Error: {} ({})",
+              __FUNCTION__, vaErrorStr(status), status);
+    return nullptr;
+  }
+
+  // this export only identifies the memory; Import on a miss re-exports its own fds
+  const auto identity = IdentityFromVaDescriptor(surface);
+  for (uint32_t i = 0; i < surface.num_objects; i++)
+    close(surface.objects[i].fd);
+  if (!identity)
+    return nullptr;
+
+  uint32_t handle = m_cache.Lookup(*identity);
+  if (handle)
+  {
+    // Import syncs only on a miss; a cached texture still needs this frame's decode done
+    status = vaSyncSurface(pic->vadsp, pic->procPic.videoSurface);
+    if (status != VA_STATUS_SUCCESS)
+    {
+      CLog::Log(LOGERROR, "CVaapiTexturePool::{}: vaSyncSurface - Error: {} ({})", __FUNCTION__,
+                vaErrorStr(status), status);
+      return nullptr;
+    }
+  }
+  else
+  {
+    size_t slot;
+    if (!m_free.empty())
+    {
+      slot = m_free.back();
+      m_free.pop_back();
+    }
+    else
+    {
+      slot = m_entries.size();
+      m_entries.push_back(std::make_unique<CVaapi2Texture>());
+      m_entries[slot]->Init(m_interop);
+    }
+
+    if (!m_entries[slot]->Import(pic))
+    {
+      m_free.push_back(slot);
+      return nullptr;
+    }
+    handle = static_cast<uint32_t>(slot) + 1;
+    m_cache.Insert(*identity, handle);
+  }
+
+  for (uint32_t doomed : m_cache.Reap(handle, 0))
+  {
+    m_entries[doomed - 1]->Reset();
+    m_free.push_back(doomed - 1);
+  }
+
+  return m_entries[handle - 1].get();
+}
+
+void CVaapiTexturePool::ReleaseAll()
+{
+  m_cache.TakeAll();
+  for (auto& entry : m_entries)
+  {
+    if (entry)
+      entry->Reset();
+  }
+  m_entries.clear();
+  m_free.clear();
 }
 
 bool CVaapi2Texture::TestEsh(VADisplay vaDpy, EGLDisplay eglDisplay, std::uint32_t rtFormat, std::int32_t pixelFormat)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -12,6 +12,8 @@
 #include "utils/EGLUtils.h"
 #include "utils/log.h"
 
+#include "platform/posix/utils/FileHandle.h"
+
 #include <algorithm>
 
 #include <drm_fourcc.h>
@@ -54,10 +56,10 @@ bool CVaapi2Texture::Import(CVaapiRenderPicture* pic)
     return failImport();
   }
 
-  // Take ownership of the exported fds (RAII closes them on Reset). num_objects
-  // is bounded by the libva descriptor's fixed objects[] array == m_drmFDs.size().
-  for (uint32_t object = 0; object < surface.num_objects && object < m_drmFDs.size(); object++)
-    m_drmFDs[object].attach(surface.objects[object].fd);
+  // EGL takes its own dma-buf reference at import; the fds need not outlive this function
+  std::array<KODI::UTILS::POSIX::CFileHandle, 4> drmFDs;
+  for (uint32_t object = 0; object < surface.num_objects && object < drmFDs.size(); object++)
+    drmFDs[object].attach(surface.objects[object].fd);
 
   status = vaSyncSurface(pic->vadsp, pic->procPic.videoSurface);
   if (status != VA_STATUS_SUCCESS)
@@ -182,7 +184,6 @@ bool CVaapi2Texture::Import(CVaapiRenderPicture* pic)
 
 void CVaapi2Texture::Reset()
 {
-
   for (auto texture : {&m_y, &m_vu})
   {
     if (texture->eglImage != EGL_NO_IMAGE_KHR)
@@ -191,11 +192,6 @@ void CVaapi2Texture::Reset()
       texture->eglImage = EGL_NO_IMAGE_KHR;
       glDeleteTextures(1, &texture->glTexture);
     }
-  }
-
-  for (auto& fd : m_drmFDs)
-  {
-    fd.reset();
   }
 
   m_imported = false;
@@ -219,9 +215,11 @@ CSizeInt CVaapi2Texture::GetTextureSize()
 namespace
 {
 
-// separate-layers export: one plane per layer, keyed like the DRMPRIME path
+// separate-layers export: one plane per layer, keyed like the DRMPRIME path.
+// width/height are the picture dims because CVaapi2Texture::Import sizes the
+// EGL images from those, not from the aligned surface dims.
 std::optional<DRMPRIME::DmaBufIdentity> IdentityFromVaDescriptor(
-    const VADRMPRIMESurfaceDescriptor& surface)
+    const VADRMPRIMESurfaceDescriptor& surface, uint32_t width, uint32_t height)
 {
   if (surface.num_objects < 1 || surface.num_objects > AV_DRM_MAX_PLANES ||
       surface.num_layers < 1 || surface.num_layers > AV_DRM_MAX_PLANES)
@@ -236,8 +234,8 @@ std::optional<DRMPRIME::DmaBufIdentity> IdentityFromVaDescriptor(
     identity.modifier[i] = surface.objects[i].drm_format_modifier;
   }
 
-  identity.width = surface.width;
-  identity.height = surface.height;
+  identity.width = width;
+  identity.height = height;
   identity.format = surface.fourcc;
   identity.nbLayers = surface.num_layers;
   identity.nbPlanes = surface.num_layers;
@@ -273,7 +271,7 @@ CVaapi2Texture* CVaapiTexturePool::Get(CVaapiRenderPicture* pic,
   }
 
   // this export only identifies the memory; Import on a miss re-exports its own fds
-  const auto identity = IdentityFromVaDescriptor(surface);
+  const auto identity = IdentityFromVaDescriptor(surface, pic->DVDPic.iWidth, pic->DVDPic.iHeight);
   for (uint32_t i = 0; i < surface.num_objects; i++)
     close(surface.objects[i].fd);
   if (!identity)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -239,6 +239,7 @@ std::optional<DRMPRIME::DmaBufIdentity> IdentityFromVaDescriptor(
   identity.width = surface.width;
   identity.height = surface.height;
   identity.format = surface.fourcc;
+  identity.nbLayers = surface.num_layers;
   identity.nbPlanes = surface.num_layers;
   for (uint32_t i = 0; i < surface.num_layers; i++)
   {

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.cpp
@@ -12,6 +12,8 @@
 #include "utils/EGLUtils.h"
 #include "utils/log.h"
 
+#include <algorithm>
+
 #include <drm_fourcc.h>
 #include <unistd.h>
 #include <va/va_drmcommon.h>
@@ -255,7 +257,8 @@ void CVaapiTexturePool::Init(InteropInfo& interop)
   m_interop = interop;
 }
 
-CVaapi2Texture* CVaapiTexturePool::Get(CVaapiRenderPicture* pic)
+CVaapi2Texture* CVaapiTexturePool::Get(CVaapiRenderPicture* pic,
+                                       std::span<CVaapiTexture* const> inUse)
 {
   VADRMPRIMESurfaceDescriptor surface;
   VAStatus status = vaExportSurfaceHandle(
@@ -311,7 +314,19 @@ CVaapi2Texture* CVaapiTexturePool::Get(CVaapiRenderPicture* pic)
     m_cache.Insert(*identity, handle);
   }
 
-  for (uint32_t doomed : m_cache.Reap(handle, 0))
+  // protect the returned texture and every texture in use. scan m_entries, not the
+  // cache: a texture whose cache entry Lookup already doomed is gone from the cache
+  // but can still be in use
+  std::vector<uint32_t> protect;
+  protect.reserve(inUse.size() + 1);
+  protect.push_back(handle);
+  for (size_t slot = 0; slot < m_entries.size(); slot++)
+  {
+    if (std::find(inUse.begin(), inUse.end(), m_entries[slot].get()) != inUse.end())
+      protect.push_back(static_cast<uint32_t>(slot) + 1);
+  }
+
+  for (uint32_t doomed : m_cache.Reap(protect))
   {
     m_entries[doomed - 1]->Reset();
     m_free.push_back(doomed - 1);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
@@ -8,12 +8,15 @@
 
 #pragma once
 
+#include "cores/VideoPlayer/Buffers/DmaBufIdentityCache.h"
 #include "utils/Geometry.h"
 
 #include "platform/posix/utils/FileHandle.h"
 
 #include <array>
 #include <cstdint>
+#include <memory>
+#include <vector>
 
 #include <va/va.h>
 
@@ -44,8 +47,8 @@ public:
   virtual ~CVaapiTexture() = default;
 
   virtual void Init(InteropInfo &interop) = 0;
-  virtual bool Map(CVaapiRenderPicture *pic) = 0;
-  virtual void Unmap() = 0;
+  virtual bool Import(CVaapiRenderPicture* pic) = 0;
+  virtual void Reset() = 0;
 
   virtual GLuint GetTextureY() = 0;
   virtual GLuint GetTextureVU() = 0;
@@ -55,8 +58,8 @@ public:
 class CVaapi2Texture : public CVaapiTexture
 {
 public:
-  bool Map(CVaapiRenderPicture *pic) override;
-  void Unmap() override;
+  bool Import(CVaapiRenderPicture* pic) override;
+  void Reset() override;
   void Init(InteropInfo &interop) override;
 
   GLuint GetTextureY() override;
@@ -77,12 +80,34 @@ private:
   };
 
   InteropInfo m_interop;
-  CVaapiRenderPicture* m_vaapiPic{};
   bool m_hasPlaneModifiers{false};
+  bool m_imported{false};
   std::array<KODI::UTILS::POSIX::CFileHandle, 4> m_drmFDs;
   MappedTexture m_y, m_vu;
   CSizeInt m_textureSize;
 };
 
+//! \brief Textures cached per dma-buf identity; the render slot's picture reference pins content.
+class CVaapiTexturePool
+{
+public:
+  // must exceed the largest VAAPI surface pool (AV1: 27) or cycling evicts every frame
+  static constexpr size_t MAX_ENTRIES = 32;
+
+  ~CVaapiTexturePool() { ReleaseAll(); }
+
+  void Init(InteropInfo& interop);
+  //! \brief Imported texture for the picture's surface dma-buf; nullptr on export or import failure.
+  CVaapi2Texture* Get(CVaapiRenderPicture* pic);
+  //! \brief Reset and drop every cached texture; needs the GL context current.
+  void ReleaseAll();
+
+private:
+  InteropInfo m_interop{};
+  DRMPRIME::CDmaBufIdentityCache m_cache{MAX_ENTRIES};
+  // cache handle = entry index + 1; freed slots are recycled
+  std::vector<std::unique_ptr<CVaapi2Texture>> m_entries;
+  std::vector<size_t> m_free;
+};
 }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
@@ -101,7 +101,7 @@ public:
 
 private:
   InteropInfo m_interop{};
-  DRMPRIME::CDmaBufIdentityCache m_cache{MAX_ENTRIES};
+  DRMPRIME::CDmaBufIdentityCache m_cache{MAX_ENTRIES, "vaapi"};
   // cache handle = entry index + 1; freed slots are recycled
   std::vector<std::unique_ptr<CVaapi2Texture>> m_entries;
   std::vector<size_t> m_free;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
@@ -11,8 +11,6 @@
 #include "cores/VideoPlayer/Buffers/DmaBufIdentityCache.h"
 #include "utils/Geometry.h"
 
-#include "platform/posix/utils/FileHandle.h"
-
 #include <array>
 #include <cstdint>
 #include <memory>
@@ -83,7 +81,6 @@ private:
   InteropInfo m_interop;
   bool m_hasPlaneModifiers{false};
   bool m_imported{false};
-  std::array<KODI::UTILS::POSIX::CFileHandle, 4> m_drmFDs;
   MappedTexture m_y, m_vu;
   CSizeInt m_textureSize;
 };
@@ -94,8 +91,6 @@ class CVaapiTexturePool
 public:
   // must exceed the largest VAAPI surface pool (AV1: 27) or cycling evicts every frame
   static constexpr size_t MAX_ENTRIES = 32;
-
-  ~CVaapiTexturePool() { ReleaseAll(); }
 
   void Init(InteropInfo& interop);
   //! \brief Imported texture for the picture's surface dma-buf; nullptr on export or import failure.

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VaapiEGL.h
@@ -16,6 +16,7 @@
 #include <array>
 #include <cstdint>
 #include <memory>
+#include <span>
 #include <vector>
 
 #include <va/va.h>
@@ -98,7 +99,8 @@ public:
 
   void Init(InteropInfo& interop);
   //! \brief Imported texture for the picture's surface dma-buf; nullptr on export or import failure.
-  CVaapi2Texture* Get(CVaapiRenderPicture* pic);
+  //! Textures in inUse are protected from eviction while a render slot still names them.
+  CVaapi2Texture* Get(CVaapiRenderPicture* pic, std::span<CVaapiTexture* const> inUse);
   //! \brief Reset and drop every cached texture; needs the GL context current.
   void ReleaseAll();
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -28,6 +28,10 @@ CVideoLayerBridgeDRMPRIME::~CVideoLayerBridgeDRMPRIME()
 {
   Release(m_prev_buffer);
   Release(m_buffer);
+
+  // the plane-off commit from Disable has run by now, so these are plain frees
+  for (uint32_t fbId : m_fbCache.TakeAll())
+    drmModeRmFB(m_DRM->GetFileDescriptor(), fbId);
 }
 
 void CVideoLayerBridgeDRMPRIME::Disable()
@@ -41,16 +45,18 @@ void CVideoLayerBridgeDRMPRIME::Disable()
   m_DRM->AddProperty(plane, "CRTC_ID", 0);
 }
 
-void CVideoLayerBridgeDRMPRIME::Acquire(CVideoBufferDRMPRIME* buffer)
+void CVideoLayerBridgeDRMPRIME::Acquire(CVideoBufferDRMPRIME* buffer, uint32_t fbId)
 {
   // release the buffer that is no longer presented on screen
   Release(m_prev_buffer);
 
   // release the buffer currently being presented next call
   m_prev_buffer = m_buffer;
+  m_prev_fb_id = m_fb_id;
 
   // reference count the buffer that is going to be presented on screen
   m_buffer = buffer;
+  m_fb_id = fbId;
   m_buffer->Acquire();
 }
 
@@ -59,15 +65,11 @@ void CVideoLayerBridgeDRMPRIME::Release(CVideoBufferDRMPRIME* buffer)
   if (!buffer)
     return;
 
-  Unmap(buffer);
   buffer->Release();
 }
 
-bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
+bool CVideoLayerBridgeDRMPRIME::PrepareBuffer(CVideoBufferDRMPRIME* buffer)
 {
-  if (buffer->m_fb_id)
-    return true;
-
   if (!buffer->AcquireDescriptor())
   {
     CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to acquire descriptor",
@@ -75,7 +77,45 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
     return false;
   }
 
+  const auto identity = DRMPRIME::ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
+                                                        buffer->GetHeight());
+  if (!identity)
+  {
+    buffer->ReleaseDescriptor();
+    CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to identify buffer memory",
+              __FUNCTION__);
+    return false;
+  }
+
+  uint32_t fbId = m_fbCache.Lookup(*identity);
+  if (!fbId)
+  {
+    fbId = CreateFramebuffer(buffer);
+    if (!fbId)
+    {
+      buffer->ReleaseDescriptor();
+      return false;
+    }
+    m_fbCache.Insert(*identity, fbId);
+  }
+  buffer->ReleaseDescriptor();
+
+  if (m_buffer != buffer)
+    Acquire(buffer, fbId);
+  else
+    m_fb_id = fbId;
+
+  // reap after the id shift so protection covers the new presented pair
+  for (uint32_t doomed : m_fbCache.Reap(m_fb_id, m_prev_fb_id))
+    drmModeRmFB(m_DRM->GetFileDescriptor(), doomed);
+
+  return true;
+}
+
+uint32_t CVideoLayerBridgeDRMPRIME::CreateFramebuffer(CVideoBufferDRMPRIME* buffer)
+{
   AVDRMFrameDescriptor* descriptor = buffer->GetDescriptor();
+  uint32_t fbId = 0;
   uint32_t objectHandles[AV_DRM_MAX_PLANES] = {};
   uint32_t handles[4] = {}, pitches[4] = {}, offsets[4] = {}, flags = 0;
   uint64_t modifier[4] = {};
@@ -119,10 +159,12 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
     // add the video frame FB
     ret = drmModeAddFB2WithModifiers(m_DRM->GetFileDescriptor(), buffer->GetWidth(),
                                      buffer->GetHeight(), layer->format, handles, pitches, offsets,
-                                     modifier, &buffer->m_fb_id, flags);
+                                     modifier, &fbId, flags);
     if (ret < 0)
-      CLog::Log(LOGERROR, "CVideoLayerBridgeDRMPRIME::{} - failed to add fb {}, ret = {}",
-                __FUNCTION__, buffer->m_fb_id, ret);
+      CLog::Log(LOGERROR,
+                "CVideoLayerBridgeDRMPRIME::{} - failed to add fb, format {:#x} modifier {:#x} "
+                "ret = {}",
+                __FUNCTION__, layer->format, modifier[0], ret);
   }
 
   // close the GEM handles now: the fb holds its own references, and the
@@ -139,21 +181,9 @@ bool CVideoLayerBridgeDRMPRIME::Map(CVideoBufferDRMPRIME* buffer)
   }
 
   if (ret < 0)
-    return false;
+    return 0;
 
-  Acquire(buffer);
-  return true;
-}
-
-void CVideoLayerBridgeDRMPRIME::Unmap(CVideoBufferDRMPRIME* buffer)
-{
-  if (buffer->m_fb_id)
-  {
-    drmModeRmFB(m_DRM->GetFileDescriptor(), buffer->m_fb_id);
-    buffer->m_fb_id = 0;
-  }
-
-  buffer->ReleaseDescriptor();
+  return fbId;
 }
 
 void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
@@ -181,13 +211,10 @@ void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, cons
   if (!plane)
     return;
 
-  if (!Map(buffer))
-  {
-    Unmap(buffer);
+  if (!PrepareBuffer(buffer))
     return;
-  }
 
-  m_DRM->AddProperty(plane, "FB_ID", buffer->m_fb_id);
+  m_DRM->AddProperty(plane, "FB_ID", m_fb_id);
   m_DRM->AddProperty(plane, "CRTC_ID", m_DRM->GetCrtc()->GetCrtcId());
   m_DRM->AddProperty(plane, "SRC_X", 0);
   m_DRM->AddProperty(plane, "SRC_Y", 0);
@@ -201,13 +228,13 @@ void CVideoLayerBridgeDRMPRIME::SetVideoPlane(CVideoBufferDRMPRIME* buffer, cons
 
 void CVideoLayerBridgeDRMPRIME::UpdateVideoPlane()
 {
-  if (!m_buffer || !m_buffer->m_fb_id)
+  if (!m_buffer || !m_fb_id)
     return;
 
   auto plane = m_DRM->GetVideoPlane();
   if (!plane)
     return;
 
-  m_DRM->AddProperty(plane, "FB_ID", m_buffer->m_fb_id);
+  m_DRM->AddProperty(plane, "FB_ID", m_fb_id);
   m_DRM->AddProperty(plane, "CRTC_ID", m_DRM->GetCrtc()->GetCrtcId());
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -188,6 +188,11 @@ uint32_t CVideoLayerBridgeDRMPRIME::CreateFramebuffer(CVideoBufferDRMPRIME* buff
 
 void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
 {
+  // a new renderer generation brings a new buffer pool; old entries can never match again
+  m_fbCache.InvalidateAll();
+  for (uint32_t doomed : m_fbCache.Reap(m_fb_id, m_prev_fb_id))
+    drmModeRmFB(m_DRM->GetFileDescriptor(), doomed);
+
   auto plane = m_DRM->GetVideoPlane();
   if (!plane)
     return;

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -106,7 +106,7 @@ bool CVideoLayerBridgeDRMPRIME::PrepareBuffer(CVideoBufferDRMPRIME* buffer)
     m_fb_id = fbId;
 
   // reap after the id shift so protection covers the new presented pair
-  for (uint32_t doomed : m_fbCache.Reap(m_fb_id, m_prev_fb_id))
+  for (uint32_t doomed : m_fbCache.Reap({m_fb_id, m_prev_fb_id}))
     drmModeRmFB(m_DRM->GetFileDescriptor(), doomed);
 
   return true;
@@ -190,7 +190,7 @@ void CVideoLayerBridgeDRMPRIME::Configure(CVideoBufferDRMPRIME* buffer)
 {
   // a new renderer generation brings a new buffer pool; old entries can never match again
   m_fbCache.InvalidateAll();
-  for (uint32_t doomed : m_fbCache.Reap(m_fb_id, m_prev_fb_id))
+  for (uint32_t doomed : m_fbCache.Reap({m_fb_id, m_prev_fb_id}))
     drmModeRmFB(m_DRM->GetFileDescriptor(), doomed);
 
   auto plane = m_DRM->GetVideoPlane();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.cpp
@@ -77,8 +77,8 @@ bool CVideoLayerBridgeDRMPRIME::PrepareBuffer(CVideoBufferDRMPRIME* buffer)
     return false;
   }
 
-  const auto identity = DRMPRIME::ComputeDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(),
-                                                        buffer->GetHeight());
+  const auto identity =
+      DRMPRIME::GetDmaBufIdentity(buffer->GetDescriptor(), buffer->GetWidth(), buffer->GetHeight());
   if (!identity)
   {
     buffer->ReleaseDescriptor();

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "cores/VideoPlayer/Buffers/DmaBufIdentityCache.h"
 #include "cores/VideoPlayer/Interface/StreamInfo.h"
 #include "windowing/gbm/VideoLayerBridge.h"
 
@@ -43,11 +44,17 @@ protected:
   std::shared_ptr<KODI::WINDOWING::GBM::CDRMAtomic> m_DRM;
 
 private:
-  void Acquire(CVideoBufferDRMPRIME* buffer);
+  void Acquire(CVideoBufferDRMPRIME* buffer, uint32_t fbId);
   void Release(CVideoBufferDRMPRIME* buffer);
-  bool Map(CVideoBufferDRMPRIME* buffer);
-  void Unmap(CVideoBufferDRMPRIME* buffer);
+  bool PrepareBuffer(CVideoBufferDRMPRIME* buffer);
+  //! \brief Convert the buffer's descriptor to a framebuffer; 0 on failure.
+  uint32_t CreateFramebuffer(CVideoBufferDRMPRIME* buffer);
 
+  static constexpr size_t MAX_FB_CACHE = 32;
+
+  DRMPRIME::CDmaBufIdentityCache m_fbCache{MAX_FB_CACHE};
   CVideoBufferDRMPRIME* m_buffer = nullptr;
   CVideoBufferDRMPRIME* m_prev_buffer = nullptr;
+  uint32_t m_fb_id{0};
+  uint32_t m_prev_fb_id{0};
 };

--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/VideoLayerBridgeDRMPRIME.h
@@ -52,7 +52,7 @@ private:
 
   static constexpr size_t MAX_FB_CACHE = 32;
 
-  DRMPRIME::CDmaBufIdentityCache m_fbCache{MAX_FB_CACHE};
+  DRMPRIME::CDmaBufIdentityCache m_fbCache{MAX_FB_CACHE, "bridge-fb"};
   CVideoBufferDRMPRIME* m_buffer = nullptr;
   CVideoBufferDRMPRIME* m_prev_buffer = nullptr;
   uint32_t m_fb_id{0};

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -321,10 +321,17 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
 
   m_DRM->FlipPage(bo, rendered, videoLayer, async);
 
-  if (m_videoLayerBridge && !videoLayer)
+  // !videoLayer alone cannot gate teardown: FlipPage also runs with videoLayer
+  // false during a mode switch or renderer swap. use_count reaches 1 only when
+  // CRendererDRMPRIME drops its bridge reference, which happens at video stop.
+  if (m_videoLayerBridge && !videoLayer && m_videoLayerBridge.use_count() == 1)
   {
     // delete video layer bridge when video layer no longer is active
     m_videoLayerBridge.reset();
+
+    //! @todo unify D2P and single-plane teardown behind one winsystem plane API
+    auto* gui = m_DRM->GetGuiPlane();
+    m_DRM->FindGuiPlane(gui->GetFormat(), gui->GetModifier());
   }
 }
 

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -330,6 +330,7 @@ void CWinSystemGbm::FlipPage(bool rendered, bool videoLayer, bool async)
     m_videoLayerBridge.reset();
 
     //! @todo unify D2P and single-plane teardown behind one winsystem plane API
+    m_DRM->ReleaseVideoPlane();
     auto* gui = m_DRM->GetGuiPlane();
     m_DRM->FindGuiPlane(gui->GetFormat(), gui->GetModifier());
   }

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -70,6 +70,7 @@ public:
   bool IsHDRDisplay() override;
   CHDRCapabilities GetDisplayHDRCapabilities() const override;
 
+  // holding the returned reference defers video plane teardown until it is released
   std::shared_ptr<CVideoLayerBridge> GetVideoLayerBridge() const { return m_videoLayerBridge; }
   void RegisterVideoLayerBridge(std::shared_ptr<CVideoLayerBridge> bridge)
   {

--- a/xbmc/windowing/gbm/drm/DRMUtils.cpp
+++ b/xbmc/windowing/gbm/drm/DRMUtils.cpp
@@ -179,7 +179,6 @@ bool CDRMUtils::FindGuiPlane(uint32_t format, uint64_t modifier)
                DRMHELPERS::ModifierToString(modifier), m_crtc->GetId());
     m_gui_plane->SetFormat(format);
     m_gui_plane->SetModifier(modifier);
-    m_video_plane = nullptr;
     return true;
   }
 
@@ -213,6 +212,8 @@ bool CDRMUtils::FindGuiPlane(uint32_t format, uint64_t modifier)
       plane->SetModifier(modifier);
       m_old_crtc = m_crtc;
       m_crtc = crtc;
+      if (m_video_plane)
+        CLog::LogF(LOGWARNING, "gui plane moved, releasing live D2P video plane reservation");
       m_video_plane = nullptr;
       m_gui_plane = plane.get();
       CLog::LogF(LOGINFO, "Using gui plane [{}x{}] id:{}, format:{}, modifier:{}, crtc id:{}",

--- a/xbmc/windowing/gbm/drm/DRMUtils.h
+++ b/xbmc/windowing/gbm/drm/DRMUtils.h
@@ -72,6 +72,9 @@ public:
   bool FindGuiPlane(uint32_t format, uint64_t modifier);
   bool FindVideoPlane(uint32_t format, uint64_t modifier);
   bool FindVideoAndGuiPlane(uint32_t format, uint64_t modifier, uint64_t width, uint64_t height);
+  // FindGuiPlane never releases a D2P video plane reservation; a caller that
+  // means "video is over" states it here before revalidating the gui plane.
+  void ReleaseVideoPlane() { m_video_plane = nullptr; }
   bool HasQuirk(int quirk) const { return m_drm_quirks & quirk; }
 
   std::vector<std::string> GetConnectedConnectorNames();


### PR DESCRIPTION
## Description

This is a substantial refactor of framebuffer and imported-texture management for DRMPRIME and VAAPI. Prior to this, the derived objects (GEM handle, framebuffer, EGL image, GL texture) were rebuilt every frame from unchanged buffer memory; this builds them once per buffer, keyed by dma-buf identity, and reuses them. It impacts GBM, Wayland, and X11 WinSystems, and the DRMPRIME, DRMPRIMEGLES, and VAAPI renderers. The motivation comes from the new screenshot and bookmark handlers, which exposed latent lifetime issues--most seriously that the per-frame GEM handle open/close can destroy a handle shared with mesa on the same DRM fd. This makes video rendering across these paths more robust, with a modest perf win.

The decoder pools cycle a handful of buffers, but previously every path rebuilt its per-buffer objects on every displayed frame:
```
direct-to-plane   fd -> GEM handle -> AddFB2 -> GEM_CLOSE, RmFB two
                  frames later: 4 ioctls + a GEM object + an sg-table
                  rebuild per frame, on memory that never changed
DRMPRIME-GLES     EGL image + GL texture created and destroyed per frame
VAAPI GL/GLES     vaExportSurfaceHandle + EGL image + texture per frame
```

This series makes those objects belong to the buffer memory they were built from, keyed by identity, cached until the memory goes away.
```
CRendererDRMPRIME + bridge (fb cache)   GBM only (and GLES build)
CRendererDRMPRIMEGLES (texture pool)    GBM or Wayland, GLES builds
VAAPI texture pool                      any VAAPI+EGL build: GBM, Wayland, X11
```

Identity. The only exact name for dma-buf memory is its inode: dma_buf_getfile assigns i_ino from a monotonic counter (kernel 5.3+), unique and never reused, shared by every fd of the buffer. fd numbers recycle and are not identity. DmaBufIdentity = the inodes plus the layout (dimensions, format, modifier, offsets, pitches):

```
exact match                     reuse the cached object
same inodes, different layout   memory was recycled with a new
                                descriptor: evict the stale entry
```
The identity is derived fresh from the descriptor at each use, one fstat per object, so no cached state exists to go stale and no mutation of a buffer can serve an outdated identity.

Consumers.

VideoLayerBridgeDRMPRIME: framebuffer per identity (cap 32); eviction never touches the two framebuffers currently on or leaving the plane
RendererDRMPRIMEGLES: EGL image + texture per identity (cap 16); OES entries also keyed by colorspace/range
VAAPI renderers: same pool; per-frame probe export + fstat, cached EGL import; (cap 32; > max surface pool, AV1 = 27)

Steady-state cost per frame:
```
                     before                          after
D2P hw decode        4 ioctls + GEM churn            1 fstat
D2P sw/addon codec   4 ioctls + GEM churn            1 fstat
DRMPRIME-GLES        EGL image create + destroy      1 fstat
VAAPI                export + EGL create + destroy   export + fstat
```
*D2P = Direct-to-plane


Multi-consumer safety. Kodi's GBM device shares its DRM fd with mesa, drmPrimeFDToHandle returns the existing handle when a dma-buf is already imported on that fd, and handles have no refcount (GEM_CLOSE destroys the handle for every user). Before, the bridge opened and closed a handle every frame, so any concurrent EGL import of the same buffer (a screenshot, a capture) could have its handle destroyed under it. Now the open and close happen once per framebuffer conversion, each buffer converts once per stream generation rather than every frame (there is a theoretical ~microsecond window during codec format transition+reconfig and simultaneous bookmark that could still puke, but it's a vanishing rare scenario and I can't repro so not addressing).

Plane teardown. The per-frame RmFB on a still-scanned-out framebuffer was what disabled the video plane at stop (the kernel's forced atomic_remove_fb path). With framebuffers cached, ~CRendererDRMPRIME now disables the plane explicitly before releasing it.

Tests. 19 unit tests (identity, cache policy) built on GBM/Wayland; fd recycling, layout changes, and eviction/protection are covered without a device.

NOTE: this effectively makes Linux kernel 5.3+ a minimum requirement for Kodi with VAAPI or DRMPRIME.

NOTE: I did a lot of this design, Claude Fable made it work and fixed bugs.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Buffer reuse and sharing was fragile particularly on DRMPRIME. This mostly supports "screenshot rework" series.

## How has this been tested?
Intel N250 Linux GBM/GLES, DRMPRIME, DRMPRIMEGLES on N250 and RPi4.

## What is the effect on users?
Fewer crashes and fewer stalls on video playback during screenshots, bookmarks and perf-constrained video (like 4K60)

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
