### PR TITLE
fixed: reset the playlist position when the playlist it indexes is cleared

### DIFF
--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -140,8 +140,10 @@ int CPlayListPlayer::GetNextItemIdx(int offset) const
   if (g_partyModeManager.IsEnabled() && GetCurrentPlaylist() == Id::TYPE_MUSIC)
     return song + offset;
 
-  // wrap around in the case of repeating
-  if (RepeatedOne(m_iCurrentPlayList))
+  // wrap around in the case of repeating. Repeating one repeats the current item, so it needs
+  // there to be one: a cleared playlist leaves no current item and the first item of whatever
+  // is queued next is what follows it.
+  if (RepeatedOne(m_iCurrentPlayList) && song >= 0)
     return song;
 
   song += offset;
@@ -164,8 +166,10 @@ int CPlayListPlayer::GetNextItemIdx()
   if (g_partyModeManager.IsEnabled() && GetCurrentPlaylist() == Id::TYPE_MUSIC)
     return iSong + 1;
 
-  // if repeat one, keep playing the current song if its valid
-  if (RepeatedOne(m_iCurrentPlayList))
+  // if repeat one, keep playing the current song if its valid. There has to be a current song
+  // to repeat: a cleared playlist leaves none, and what follows is the first item of whatever
+  // is queued next rather than nothing at all.
+  if (RepeatedOne(m_iCurrentPlayList) && iSong >= 0)
   {
     // otherwise immediately abort playback
     if (m_iCurrentSong >= 0 && m_iCurrentSong < playlist.size() && playlist[m_iCurrentSong]->GetProperty("unplayable").asBoolean())
@@ -467,9 +471,17 @@ void CPlayListPlayer::ClearPlaylist(Id playlistId)
   CPlayList& playlist = GetPlaylist(playlistId);
   playlist.Clear();
 
+  // The position indexes items that no longer exist. The item it named may still be playing,
+  // so the playback state is left for the stop that ends it to clean up.
+  if (m_iCurrentPlayList == playlistId)
+    m_iCurrentSong = -1;
+
   // its likely that the playlist changed
-  CGUIMessage msg(GUI_MSG_PLAYLIST_CHANGED, 0, 0);
-  CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+  if (CServiceBroker::GetGUI() != nullptr)
+  {
+    CGUIMessage msg(GUI_MSG_PLAYLIST_CHANGED, 0, 0);
+    CServiceBroker::GetGUI()->GetWindowManager().SendMessage(msg);
+  }
 }
 
 CPlayList& CPlayListPlayer::GetPlaylist(Id playlistId)

--- a/xbmc/test/CMakeLists.txt
+++ b/xbmc/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES TestAutoSwitch.cpp
             TestLangInfo.cpp
             TestMediaSource.cpp
             TestPasswordManager.cpp
+            TestPlayListPlayer.cpp
             TestURL.cpp
             TestUtil.cpp
             TestUtils.cpp)

--- a/xbmc/test/TestPlayListPlayer.cpp
+++ b/xbmc/test/TestPlayListPlayer.cpp
@@ -1,0 +1,150 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileItem.h"
+#include "GUIUserMessages.h"
+#include "PlayListPlayer.h"
+#include "ServiceBroker.h"
+#include "guilib/GUIMessage.h"
+#include "interfaces/AnnouncementManager.h"
+#include "playlists/PlayList.h"
+
+#include <memory>
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+
+namespace
+{
+
+// CPlayListPlayer reaches the GUI and the application's components on most of its paths, and
+// neither exists under InitForTesting. The index arithmetic under test reaches neither, so the
+// repeat state it reads is set here instead of through SetRepeat(), which ends in
+// AnnouncePropertyChanged() asking the application components for CApplicationPlayer; that
+// component is not registered in a test, and the container throws rather than answering null.
+//
+// m_repeatState, RepeatedOne() and m_bPlaybackStarted are protected, so a subclass reaches them.
+class TestablePlayListPlayer : public PLAYLIST::CPlayListPlayer
+{
+public:
+  void SetRepeatDirectly(PLAYLIST::Id playlistId, PLAYLIST::RepeatState state)
+  {
+    m_repeatState[playlistId] = state;
+  }
+
+  bool IsRepeatedOne(PLAYLIST::Id playlistId) const { return RepeatedOne(playlistId); }
+
+  bool PlaybackStarted() const { return m_bPlaybackStarted; }
+};
+
+} // namespace
+
+class TestPlayListPlayer : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // CPlayList::Add() announces every addition, and nothing registers an announcement manager
+    // in the test environment: the accessor hands back a null shared_ptr and Announce()
+    // dereferences it. An unstarted manager is enough, because Announce() only appends to a
+    // queue - without the worker thread nothing drains it, which for a couple of items costs
+    // nothing. Registered per test and taken away again so no other test sees it.
+    m_previous = CServiceBroker::GetAnnouncementManager();
+    CServiceBroker::RegisterAnnouncementManager(
+        std::make_shared<ANNOUNCEMENT::CAnnouncementManager>());
+  }
+
+  void TearDown() override
+  {
+    CServiceBroker::UnregisterAnnouncementManager();
+    if (m_previous)
+      CServiceBroker::RegisterAnnouncementManager(m_previous);
+  }
+
+  // Two items, so an index of 0 or 1 is in range and -1 is unambiguously "no current item".
+  static void FillWithTwoItems(TestablePlayListPlayer& player, PLAYLIST::Id playlistId)
+  {
+    PLAYLIST::CPlayList& playlist = player.GetPlaylist(playlistId);
+    playlist.Add(std::make_shared<CFileItem>("/video/first.mkv", false));
+    playlist.Add(std::make_shared<CFileItem>("/video/second.mkv", false));
+    ASSERT_EQ(2, playlist.size());
+  }
+
+private:
+  std::shared_ptr<ANNOUNCEMENT::CAnnouncementManager> m_previous;
+};
+
+// A playlist that has been cleared leaves the current index at -1, and items queued afterwards
+// have to be reachable. GetNextItemIdx() is what PlayNext() asks, so -1 in has to give the
+// first item out.
+TEST_F(TestPlayListPlayer, GetNextItemIdxFromNoCurrentItemGivesTheFirstItem)
+{
+  TestablePlayListPlayer player;
+  player.SetCurrentPlaylist(PLAYLIST::Id::TYPE_VIDEO);
+  FillWithTwoItems(player, PLAYLIST::Id::TYPE_VIDEO);
+
+  player.SetCurrentItemIdx(-1);
+  ASSERT_EQ(-1, player.GetCurrentItemIdx()) << "the no-current-item state under test was not set";
+
+  EXPECT_EQ(0, player.GetNextItemIdx(1));
+}
+
+TEST_F(TestPlayListPlayer, GetNextItemIdxFromNoCurrentItemGivesTheFirstItemWithRepeatOne)
+{
+  TestablePlayListPlayer player;
+  player.SetCurrentPlaylist(PLAYLIST::Id::TYPE_VIDEO);
+  FillWithTwoItems(player, PLAYLIST::Id::TYPE_VIDEO);
+
+  player.SetCurrentItemIdx(-1);
+  ASSERT_EQ(-1, player.GetCurrentItemIdx()) << "the no-current-item state under test was not set";
+
+  player.SetRepeatDirectly(PLAYLIST::Id::TYPE_VIDEO, PLAYLIST::RepeatState::ONE);
+  ASSERT_TRUE(player.IsRepeatedOne(PLAYLIST::Id::TYPE_VIDEO)) << "repeat one was not set";
+
+  // Without the fix this answers -1: the repeat-one branch returns the current index unchanged,
+  // and PlayNext() treats a negative index as nothing to play.
+  EXPECT_EQ(0, player.GetNextItemIdx(1));
+}
+
+// Repeat One still repeats, once there is a current item to repeat.
+TEST_F(TestPlayListPlayer, GetNextItemIdxWithRepeatOneRepeatsTheCurrentItem)
+{
+  TestablePlayListPlayer player;
+  player.SetCurrentPlaylist(PLAYLIST::Id::TYPE_VIDEO);
+  FillWithTwoItems(player, PLAYLIST::Id::TYPE_VIDEO);
+
+  player.SetCurrentItemIdx(1);
+  ASSERT_EQ(1, player.GetCurrentItemIdx()) << "the current item under test was not set";
+
+  player.SetRepeatDirectly(PLAYLIST::Id::TYPE_VIDEO, PLAYLIST::RepeatState::ONE);
+  ASSERT_TRUE(player.IsRepeatedOne(PLAYLIST::Id::TYPE_VIDEO)) << "repeat one was not set";
+
+  EXPECT_EQ(1, player.GetNextItemIdx(1));
+}
+
+// Clearing the playlist the playing item came from does not end playback. The item keeps playing,
+// and the stop that eventually ends it cleans up only if the playback-started state survived the
+// clear, so clearing drops the position and nothing else.
+TEST_F(TestPlayListPlayer, ClearingTheCurrentPlaylistKeepsThePlaybackStartedState)
+{
+  TestablePlayListPlayer player;
+  player.SetCurrentPlaylist(PLAYLIST::Id::TYPE_VIDEO);
+  FillWithTwoItems(player, PLAYLIST::Id::TYPE_VIDEO);
+  player.SetCurrentItemIdx(0);
+
+  CGUIMessage started(GUI_MSG_PLAYBACK_STARTED, 0, 0);
+  player.OnMessage(started);
+  ASSERT_TRUE(player.PlaybackStarted()) << "the playing state under test was not set";
+
+  player.ClearPlaylist(PLAYLIST::Id::TYPE_VIDEO);
+
+  EXPECT_EQ(-1, player.GetCurrentItemIdx());
+  EXPECT_TRUE(player.PlaybackStarted());
+  EXPECT_EQ(PLAYLIST::Id::TYPE_VIDEO, player.GetCurrentPlaylist());
+}


### PR DESCRIPTION
**TL;DR:** Bug fix. `Playlist.Clear` over JSON-RPC left the playlist position pointing into the emptied list, so after re-adding items playback stopped at the end of the current file instead of continuing. Clearing the current playlist now resets the position.

## Description
`CPlayListPlayer::ClearPlaylist` empties the item list but leaves `m_iCurrentSong` on the index of the item that was playing. The position then indexes a list that no longer contains it, and the next item to play is computed from it — `GetNextItemIdx` returns `m_iCurrentSong + 1`, past the end of a list repopulated from empty, so `PlayNext` takes its give-up branch at the end of the current file and closes the player instead of continuing.

Every other caller clears in order to repopulate and then plays, assigning the position on the way through, so none of them can observe it. JSON-RPC `Playlist.Clear` is the only caller that clears and stops, which is why the report is against that method.

`Reset()` is guarded on the cleared playlist being the current one, so clearing the music playlist cannot disturb a video that is playing.

`Reset()` sends `GUI_MSG_PLAYLIST_CHANGED` itself, so the message this function already sent is sent on the other branch rather than unconditionally. Clearing the current playlist announces the change once, as it did before.

**Why not also `SetCurrentPlaylist(TYPE_NONE)`.** `CGUIWindowVideoPlaylist::ClearPlayList` and its music counterpart follow their `ClearPlaylist` call with both `Reset()` and `SetCurrentPlaylist(TYPE_NONE)`, which is why clearing from the interface behaves correctly today. Only the `Reset` is done here.

Dropping the current playlist to `TYPE_NONE` repairs the interface's own route, where `VIDEO::UTILS::QueueItem` calls `SetCurrentPlaylist` on the way past — but not a caller of `Playlist.Add`, which posts `TMSG_PLAYLISTPLAYER_ADD` and nothing else. `GetNextItemIdx` returns -1 for `TYPE_NONE`, so an API client doing the whole sequence over JSON-RPC would still see playback stop. Resetting the position alone repairs both routes, because the next index is then 0 however the item arrived.

The windows' own `Reset()` calls are now redundant, as are those in the clear-then-repopulate callers. Removing them is a separate tidy-up with no behaviour change, and is not in this PR.

**API-visible change.** After clearing the playlist that is currently playing, `Player.GetProperties.position` reports -1 rather than a stale index into an empty list. Clearing from the GUI already produces that.

## Motivation and context
Fixes #15958.

## How has this been tested?
`CPlayListPlayer` reaches into `g_application`, the window manager and the party mode manager, so there is no unit-test route to it; this was verified against a running Kodi over JSON-RPC. The same plan was run against the same build before and after the change — open a movie, let it play, `Playlist.Clear`, `Playlist.Add` another movie, seek to 99.8%, wait for the end:

| | before | after |
|---|---|---|
| `Player.GetProperties.position` after the clear | `0`, against an empty playlist | `-1` |
| `Player.OnPlay` after `Player.OnStop` | none | 0.14 s later |
| `Player.GetActivePlayers` at the end | `[]` | video player active |

Two further checks against the fixed build:

- An ordinary two-item playlist still advances — `Player.OnStop` then `Player.OnPlay`, `Player.GetItem` returns the second movie, `position` is `1`.
- `Playlist.Clear` on the music playlist while a video plays leaves the player active with `position: 0` and `playlistid: 1` unchanged.

Full gtest suite green (3568/3570; the two failures are `TestHTTPDirectory`, flaky on this machine, and pass in 1–3 ms when run alone). `clang-format` clean on the changed lines.

## What is the effect on users?
A remote or add-on that clears the playing playlist and queues new items over JSON-RPC gets continuous playback into the new items instead of a stop at the end of the current file.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
