### PR TITLE
fixed: keep a resolved dynamic path when merging item info

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1381,7 +1381,8 @@ void CFileItem::UpdateInfo(const CFileItem& item,
     m_epgSearchFilter = item.m_epgSearchFilter;
     SetInvalid();
   }
-  SetDynPath(item.GetDynPath());
+  if (item.HasDynPath())
+    SetDynPath(item.GetDynPath());
 
   // Alter label to episode number(s) if requested
   std::string label;
@@ -1472,7 +1473,8 @@ void CFileItem::MergeInfo(const CFileItem& item)
     m_epgSearchFilter = item.m_epgSearchFilter;
     SetInvalid();
   }
-  SetDynPath(item.GetDynPath());
+  if (item.HasDynPath())
+    SetDynPath(item.GetDynPath());
   if (!item.GetLabel().empty())
     SetLabel(item.GetLabel());
   if (!item.GetLabel2().empty())
@@ -1695,6 +1697,11 @@ const std::string &CFileItem::GetDynPath() const
     return m_strDynPath;
   else
     return m_strPath;
+}
+
+bool CFileItem::HasDynPath() const
+{
+  return !m_strDynPath.empty();
 }
 
 void CFileItem::SetDynPath(std::string path)

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -137,6 +137,7 @@ public:
   void SetDynURL(const CURL& url);
   const std::string &GetDynPath() const;
   void SetDynPath(std::string path);
+  bool HasDynPath() const;
 
   CFileItem& operator=(const CFileItem& item);
   void Archive(CArchive& ar) override;

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -1008,6 +1008,62 @@ TEST(TestFileItem, TestSimplePathSet)
   EXPECT_EQ("/local/path/dynamic/file.txt", item.GetDynURL().Get());
 }
 
+namespace
+{
+// A plugin item as it looks once playback has resolved it: the path is still the original
+// plugin url, and the dyn path is the thing actually being played.
+// See CPluginDirectory::GetPluginResult.
+CFileItem MakeResolvedPluginItem()
+{
+  CFileItem item;
+  item.SetPath("plugin://plugin.video.test/play/1");
+  item.SetDynPath("/resolved/real-stream.mkv");
+  return item;
+}
+
+// What an add-on hands to Player.updateInfoTag: the original url, and no dyn path of its own.
+CFileItem MakeAddonUpdateItem()
+{
+  CFileItem item;
+  item.SetPath("plugin://plugin.video.test/play/1");
+  return item;
+}
+} // namespace
+
+TEST(TestFileItem, UpdateInfoKeepsAResolvedDynPath)
+{
+  CFileItem target = MakeResolvedPluginItem();
+
+  CFileItem source = MakeAddonUpdateItem();
+  source.SetLabel("Updated title");
+
+  target.UpdateInfo(source);
+
+  EXPECT_EQ("Updated title", target.GetLabel());
+  EXPECT_EQ("/resolved/real-stream.mkv", target.GetDynPath());
+}
+
+TEST(TestFileItem, UpdateInfoTakesADynPathTheSourceActuallyHas)
+{
+  CFileItem target = MakeResolvedPluginItem();
+
+  CFileItem source = MakeAddonUpdateItem();
+  source.SetDynPath("/resolved/replacement.mkv");
+
+  target.UpdateInfo(source);
+
+  EXPECT_EQ("/resolved/replacement.mkv", target.GetDynPath());
+}
+
+TEST(TestFileItem, MergeInfoKeepsAResolvedDynPath)
+{
+  CFileItem target = MakeResolvedPluginItem();
+
+  target.MergeInfo(MakeAddonUpdateItem());
+
+  EXPECT_EQ("/resolved/real-stream.mkv", target.GetDynPath());
+}
+
 TEST(TestFileItem, TestLabel)
 {
   CFileItem item("My Item Label");


### PR DESCRIPTION
`CFileItem::UpdateInfo` and `MergeInfo` could silently discard a resolved dynamic path and replace it with the unresolved one. Found while reviewing the same write for xbmc/xbmc#28871.

Unlike most of what I have been looking at, **this one is unit-testable and comes with a test that fails on master.**

## The defect

`GetDynPath()` falls back to the plain path when no dynamic path has been set (`FileItem.cpp:1692-1698`). So a source item that has *no* dynamic path still reports one — its plain path. Both `UpdateInfo` and `MergeInfo` copied that unconditionally:

```cpp
SetDynPath(item.GetDynPath());
```

which writes a plain path into the target as though it were resolved, discarding whatever the target had resolved. The fallback is a *read* convenience; laundering it into a *write* is the bug.

## It is reachable from a documented add-on API

1. `CPluginDirectory::GetPluginResult` (`PluginDirectory.cpp:150-152`) stores the original url in `original_listitem_url` and sets the dynamic path to the **resolved** stream.
2. An add-on calls `Player.updateInfoTag(listitem)` (`interfaces/legacy/Player.cpp:419-427`).
3. `ApplicationMessageHandling.cpp:481-486` matches with `IsSamePath` and merges.
4. `IsSamePath` matches on the stored url (`FileItem.cpp:1305-1306`), so a ListItem carrying the original `plugin://` url matches — the normal shape, not an abuse.
5. The ListItem has no dynamic path of its own, so the resolved stream url is replaced by the `plugin://` url it was resolved from.

Everything reading `GetDynPath()` afterwards then sees the unresolved path — mime type detection (`FileItem.cpp:1176-1178`), bluray path checks, internet stream checks.

## The change

Ask whether the source holds a dynamic path, rather than inferring it from a value the getter may have synthesised:

```cpp
if (item.HasDynPath())
  SetDynPath(item.GetDynPath());
```

`HasDynPath()` is added for this. It could have been an inline `!item.m_strDynPath.empty()` at both sites, but the accessor is what stops the next caller re-laying the same trap, which is the actual failure mode here — every current caller survives only by happening to pass an item with a path.

**`CFileItem::operator=` already copied `m_strDynPath` directly** rather than going through the getter (`FileItem.cpp:420`). These two were the outliers, not the fix.

`MergeInfo` has a single caller today which sets the same value immediately beforehand, so it is unaffected in practice — but it carries the identical write and is fixed alongside.

## Tests

Three added to `xbmc/test/TestFileItem.cpp`:

- `UpdateInfoKeepsAResolvedDynPath` — fails on master with `"plugin://plugin.video.test/play/1"` where the resolved path should be.
- `MergeInfoKeepsAResolvedDynPath` — same.
- `UpdateInfoTakesADynPathTheSourceActuallyHas` — passes before and after, pinning the behaviour the fix must not break. Without it the fix could "pass" by never writing at all.

Full suite green (3573).

## Deliberately not included

`CFileItem::IsSamePath` carries a bluray-specific guard (`FileItem.cpp:1249-1250`) comparing dynamic paths when either side is a bluray path. It looks related, and it is the same underlying tension, but it answers a different question — one disc path hosts many playlists, and the dynamic path is what tells them apart. This change stops a dynamic path being *destroyed*; that guard stops two distinct ones being *conflated*. Removing it would regress disc playback identity, so it stays.
