### PR TITLE
fixed: web server tests pick a random port and never check the bind

### DIFF
--- a/xbmc/filesystem/test/TestHTTPDirectory.cpp
+++ b/xbmc/filesystem/test/TestHTTPDirectory.cpp
@@ -21,7 +21,6 @@
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
 
-#include <random>
 #include <stdlib.h>
 
 #include <gtest/gtest.h>
@@ -68,15 +67,7 @@ using namespace XFILE;
 class TestHTTPDirectory : public testing::Test
 {
 protected:
-  TestHTTPDirectory() : m_sourcePath(XBMC_REF_FILE_PATH(SOURCE_PATH))
-  {
-    std::random_device rd;
-    std::mt19937 mt(rd());
-    std::uniform_int_distribution<uint16_t> dist(49152, 65535);
-    m_webServerPort = dist(mt);
-
-    m_baseUrl = StringUtils::Format("http://" WEBSERVER_HOST ":{}", m_webServerPort);
-  }
+  TestHTTPDirectory() : m_sourcePath(XBMC_REF_FILE_PATH(SOURCE_PATH)) {}
 
   ~TestHTTPDirectory() override = default;
 
@@ -87,7 +78,9 @@ protected:
 
     SetupMediaSources();
 
-    m_webServer.Start(m_webServerPort, "", "");
+    ASSERT_TRUE(m_webServer.Start(0, "", ""));
+    m_baseUrl = StringUtils::Format("http://" WEBSERVER_HOST ":{}", m_webServer.GetPort());
+
     m_webServer.RegisterRequestHandler(&m_vfsHandler);
   }
 
@@ -212,7 +205,6 @@ protected:
   }
 
   CWebServer m_webServer;
-  uint16_t m_webServerPort;
   std::string m_baseUrl;
   std::string const m_sourcePath;
   CHTTPVfsHandler m_vfsHandler;

--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -1242,6 +1242,21 @@ struct MHD_Daemon* CWebServer::StartMHD(unsigned int flags, int port)
       MHD_OPTION_END);
 }
 
+namespace
+{
+uint16_t GetDaemonPort(struct MHD_Daemon* daemon)
+{
+  if (daemon == nullptr)
+    return 0;
+
+  const union MHD_DaemonInfo* info = MHD_get_daemon_info(daemon, MHD_DAEMON_INFO_BIND_PORT);
+  if (info == nullptr)
+    return 0;
+
+  return info->port;
+}
+} // namespace
+
 bool CWebServer::Start(uint16_t port, const std::string& username, const std::string& password)
 {
   SetCredentials(username, password);
@@ -1256,13 +1271,27 @@ bool CWebServer::Start(uint16_t port, const std::string& username, const std::st
       closesocket(v6testSock);
       m_daemon_ip6 = StartMHD(MHD_USE_IPv6, port);
     }
-    m_daemon_ip4 = StartMHD(0, port);
+
+    // both daemons have to listen on the same port, so when the operating system picks it the
+    // IPv4 daemon must be given the port the IPv6 daemon was assigned rather than picking again
+    uint16_t listenPort = port;
+    if (port == 0 && m_daemon_ip6 != nullptr)
+    {
+      listenPort = GetDaemonPort(m_daemon_ip6);
+      if (listenPort == 0)
+      {
+        MHD_stop_daemon(m_daemon_ip6);
+        m_daemon_ip6 = nullptr;
+      }
+    }
+
+    m_daemon_ip4 = StartMHD(0, listenPort);
 
     m_running = (m_daemon_ip6 != nullptr) || (m_daemon_ip4 != nullptr);
     if (m_running)
     {
-      m_port = port;
-      m_logger->info("Started");
+      m_port = listenPort != 0 ? listenPort : GetDaemonPort(m_daemon_ip4);
+      m_logger->info("Started on port {}", m_port);
     }
     else
       m_logger->error("Failed to start");
@@ -1277,10 +1306,16 @@ bool CWebServer::Stop()
     return true;
 
   if (m_daemon_ip6 != nullptr)
+  {
     MHD_stop_daemon(m_daemon_ip6);
+    m_daemon_ip6 = nullptr;
+  }
 
   if (m_daemon_ip4 != nullptr)
+  {
     MHD_stop_daemon(m_daemon_ip4);
+    m_daemon_ip4 = nullptr;
+  }
 
   m_running = false;
   m_logger->info("Stopped");
@@ -1292,6 +1327,11 @@ bool CWebServer::Stop()
 bool CWebServer::IsStarted()
 {
   return m_running;
+}
+
+uint16_t CWebServer::GetPort() const
+{
+  return m_port;
 }
 
 bool CWebServer::WebServerSupportsSSL()

--- a/xbmc/network/WebServer.h
+++ b/xbmc/network/WebServer.h
@@ -28,9 +28,20 @@ public:
   CWebServer();
   virtual ~CWebServer() = default;
 
+  /*!
+   \brief Start listening on the given port
+   \param port port to listen on, or 0 to let the operating system assign a free one
+   \return true if at least one daemon is listening
+   */
   bool Start(uint16_t port, const std::string &username, const std::string &password);
   bool Stop();
   bool IsStarted();
+
+  /*!
+   \brief The port being listened on, which is only known after a successful Start()
+   \return the port, or 0 if the server is not running
+   */
+  uint16_t GetPort() const;
   static bool WebServerSupportsSSL();
   void SetCredentials(const std::string &username, const std::string &password);
 

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -28,7 +28,6 @@
 #include "utils/Variant.h"
 
 #include <errno.h>
-#include <random>
 #include <stdlib.h>
 
 #include <gtest/gtest.h>
@@ -51,16 +50,6 @@ protected:
     : webserver(),
       sourcePath(XBMC_REF_FILE_PATH("xbmc/network/test/data/webserver/"))
   {
-    static uint16_t port;
-    if (port == 0)
-    {
-      std::random_device rd;
-      std::mt19937 mt(rd());
-      std::uniform_int_distribution<uint16_t> dist(49152, 65535);
-      port = dist(mt);
-    }
-    webserverPort = port;
-    baseUrl = StringUtils::Format("http://" WEBSERVER_HOST ":{}", webserverPort);
   }
   ~TestWebServer() override = default;
 
@@ -71,7 +60,9 @@ protected:
 
     SetupMediaSources();
 
-    webserver.Start(webserverPort, GetServerUsername(), GetServerPassword());
+    ASSERT_TRUE(webserver.Start(0, GetServerUsername(), GetServerPassword()));
+    baseUrl = StringUtils::Format("http://" WEBSERVER_HOST ":{}", webserver.GetPort());
+
     webserver.RegisterRequestHandler(&m_jsonRpcHandler);
     webserver.RegisterRequestHandler(&m_vfsHandler);
   }
@@ -367,12 +358,29 @@ protected:
   CHTTPVfsHandler m_vfsHandler;
   std::string baseUrl;
   std::string sourcePath;
-  uint16_t webserverPort;
 };
 
 TEST_F(TestWebServer, IsStarted)
 {
   ASSERT_TRUE(webserver.IsStarted());
+}
+
+TEST_F(TestWebServer, ReportsThePortAssignedByTheOperatingSystem)
+{
+  ASSERT_TRUE(webserver.IsStarted());
+  EXPECT_NE(0, webserver.GetPort());
+}
+
+TEST_F(TestWebServer, TwoServersDoNotShareAPort)
+{
+  CWebServer other;
+  ASSERT_TRUE(other.Start(0, "", ""));
+
+  EXPECT_NE(0, other.GetPort());
+  EXPECT_NE(webserver.GetPort(), other.GetPort());
+
+  other.Stop();
+  EXPECT_EQ(0, other.GetPort());
 }
 
 TEST_F(TestWebServer, CanGetJsonRpcApiDescriptionWithHttpGet)


### PR DESCRIPTION
## Description

`TestWebServer` and `TestHTTPDirectory` each pick a random port in 49152-65535 and start a
`CWebServer` on it without checking that the bind succeeded. That is the ephemeral range, which is
also where the OS allocates local ports for outbound connections, so a collision is ordinary luck
rather than a rare event — and when it happens the tests fail, not the bind.

The two fixtures fail differently, and the second is the more misleading:

- `TestWebServer` draws into a `static`, so the port is chosen once per process and a collision
  fails **all** of its tests together. `IsStarted` fails instantly and every test after it waits out
  its curl timeouts against a server that was never listening.
- `TestHTTPDirectory` draws into a plain member in its constructor, so **every test rolls the dice
  independently**. A collision fails one arbitrary test while its neighbours pass, which reads like
  an intermittent bug in `CHTTPDirectory` rather than in the harness. Observed failing
  `BasicIndex` + `BasicMultilineIndex` on one run and only `BasicMultilineIndex` on the next.

The fix is to stop guessing: ask for port 0 and use the port the OS assigns.

## Reproduction

Pinning the pre-fix fixtures to a port already held by a listener reproduces it deterministically:

```
[  FAILED  ] TestWebServer.IsStarted                    (1 ms)      <- the bind
[----------] 29 tests from TestWebServer          (707743 ms)      <- 11.8 minutes
[  FAILED  ] TestHTTPDirectory.IsStarted                (1 ms)
[  FAILED  ] TestHTTPDirectory.ApacheDefaultIndex    (60975 ms)
```

34 failures before I stopped the run; 43/43 in 269 ms with this change applied.

**One qualification, because it is easy to conclude the opposite.** Holding the port on IPv4 alone
reproduces *nothing* — all tests pass. `Start()` runs a v6only IPv6 daemon and an IPv4 daemon, so
occupying one family leaves the other free to bind, and `localhost` resolves to `::1` first, so the
IPv6 daemon serves everything normally. A collision only does damage if it covers the family
`localhost` resolves to. The failure is real, but narrower than "any ephemeral collision".

The minutes come from Kodi's global curl defaults, which no fixture overrides —
`m_curlconnecttimeout = 30` and `m_curllowspeedtime = 20` (`AdvancedSettings.cpp:448-449`). Giving
the fixtures loopback-appropriate timeouts is a separate argument and deliberately not made here:
once the bind cannot fail, nothing waits.

## Changes

**`fixed: bind the web server to a port chosen by the operating system`**

`CWebServer::Start()` required the caller to name a port. Passing 0 straight through to
`MHD_start_daemon()` does not work on its own, because `Start()` runs two daemons — one IPv6, one
IPv4 — and each would be assigned a *different* port. It now starts the IPv6 daemon, reads back its
port with `MHD_DAEMON_INFO_BIND_PORT`, and starts the IPv4 daemon on that port. If the read back
fails the IPv6 daemon is stopped and the server falls back to IPv4 alone, rather than quietly
listening on two different ports.

The bound port is published through a new `GetPort()`. `m_port` was already being set and was never
read anywhere in the tree. It also goes into the `Started` log line, since the logger name is built
from the *requested* port and cannot name one the caller did not ask for.

`Stop()` now clears the daemon pointers. It did not, so on a host where the IPv6 socket probe fails
a `Start()` after a `Stop()` would have left a stale pointer in place — which `m_running` already
trusted, and which the new read back would have dereferenced.

**`fixed: stop the web server tests guessing a port`**

Both fixtures ask for port 0 and use what they are given, and both now `ASSERT_TRUE` the start, so
a bind that does fail is reported where it happened instead of surfacing as an assertion somewhere
unrelated. The base URL moves into `SetUp()` because the port is not known until the server is
running. Two tests are added covering the assigned port and two servers not sharing one.

## Notes

No `MHD_VERSION` guard was added. `MHD_DAEMON_INFO_BIND_PORT` carries no `@note Available since`
annotation in the pinned libmicrohttpd 1.0.1 header — which annotates everything added from ~0.9.52
onward — and does not appear in a ChangeLog going back to 2007, so it predates the
`#if (MHD_VERSION >= 0x00095207)` guard already in `WebServer.cpp`. Happy to add one if a supported
platform still ships something older.

There is a residual race in principle: between the IPv6 daemon being assigned a port and the IPv4
daemon binding it, another process could take that port on IPv4. `Start()` would still return `true`
via the IPv6 daemon, which is the pre-existing behaviour of `m_running = ip6 || ip4`.

## Testing

Full suite on Windows x64: **3572 passed, 0 failed**, 58.9 s. `TestHTTPDirectory` run five times
consecutively: 9/9 each time. `clang-format` clean on every changed line.
