### PR TITLE
added: the JSON-RPC error taxonomy to the schema

### DIFF
--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -340,44 +340,18 @@ inline void CJSONRPC::BuildResponse(const CVariant& request, JSONRPC_STATUS code
     case ACK:
       response["result"] = "OK";
       break;
-    case NotFound:
-      response["error"]["code"] = NotFound;
-      response["error"]["message"] = "Not found.";
-      break;
-    case Unavailable:
-      response["error"]["code"] = Unavailable;
-      response["error"]["message"] = "Requested item is unavailable.";
-      break;
-    case InvalidRequest:
-      response["error"]["code"] = InvalidRequest;
-      response["error"]["message"] = "Invalid request.";
-      break;
-    case InvalidParams:
-      response["error"]["code"] = InvalidParams;
-      response["error"]["message"] = "Invalid params.";
-      if (!result.isNull())
+    default:
+    {
+      const JsonRpcStatusDescription* status = StatusToDescription(code);
+      if (status == nullptr)
+        status = StatusToDescription(InternalError);
+
+      response["error"]["code"] = status->status;
+      response["error"]["message"] = status->message;
+      if (status->hasData && !result.isNull())
         response["error"]["data"] = result;
       break;
-    case MethodNotFound:
-      response["error"]["code"] = MethodNotFound;
-      response["error"]["message"] = "Method not found.";
-      break;
-    case ParseError:
-      response["error"]["code"] = ParseError;
-      response["error"]["message"] = "Parse error.";
-      break;
-    case BadPermission:
-      response["error"]["code"] = BadPermission;
-      response["error"]["message"] = "Bad client permission.";
-      break;
-    case FailedToExecute:
-      response["error"]["code"] = FailedToExecute;
-      response["error"]["message"] = "Failed to execute method.";
-      break;
-    default:
-      response["error"]["code"] = InternalError;
-      response["error"]["message"] = "Internal error.";
-      break;
+    }
   }
 }
 

--- a/xbmc/interfaces/json-rpc/JSONRPCUtils.h
+++ b/xbmc/interfaces/json-rpc/JSONRPCUtils.h
@@ -12,6 +12,7 @@
 #include "ITransportLayer.h"
 #include "utils/Artwork.h"
 
+#include <array>
 #include <map>
 #include <memory>
 #include <string>
@@ -42,6 +43,72 @@ enum JSONRPC_STATUS
   Unavailable = -32097,
   FailedToExecute = -32100
 };
+
+/*!
+ \ingroup jsonrpc
+ \brief Describes a JSONRPC_STATUS that is reported to a client as an error
+
+ The message is what CJSONRPC::BuildResponse puts in "error.message"; the description is
+ served through JSONRPC.Introspect so that a client can discover how a call may fail
+ without reading this header.
+ */
+struct JsonRpcStatusDescription
+{
+  JSONRPC_STATUS status;
+  const char* name;
+  const char* message;
+  const char* description;
+  //! Whether responses with this status populate the optional "error.data" member
+  bool hasData;
+};
+
+/*!
+ \ingroup jsonrpc
+ \brief The error taxonomy of the JSON-RPC API
+
+ Every JSONRPC_STATUS that reaches a client as an error appears here exactly once. OK and
+ ACK are absent because they produce a result rather than an error.
+ */
+inline constexpr std::array<JsonRpcStatusDescription, 9> JSONRPC_STATUS_DESCRIPTIONS{{
+    {ParseError, "ParseError", "Parse error.", "The request could not be parsed as JSON.", false},
+    {InvalidRequest, "InvalidRequest", "Invalid request.",
+     "The request parsed as JSON but is not a well-formed JSON-RPC 2.0 request object.", false},
+    {MethodNotFound, "MethodNotFound", "Method not found.",
+     "The requested method does not exist, or the client lacks the permission to see it.", false},
+    {InvalidParams, "InvalidParams", "Invalid params.",
+     "The given parameters do not validate against the schema of the method. The \"data\" member "
+     "names the offending parameter and the constraint it failed.",
+     true},
+    {InternalError, "InternalError", "Internal error.",
+     "The method failed for a reason that no other status describes.", false},
+    {FailedToExecute, "FailedToExecute", "Failed to execute method.",
+     "The method was called correctly but the operation it requested did not succeed. Note that "
+     "-32100 sits one code point below the -32099..-32000 range that JSON-RPC 2.0 reserves for "
+     "implementation-defined server errors; this is long-standing and is retained for "
+     "compatibility with existing clients.",
+     false},
+    {BadPermission, "BadPermission", "Bad client permission.",
+     "The client does not hold every permission the method requires.", false},
+    {NotFound, "NotFound", "Not found.", "The requested item does not exist.", false},
+    {Unavailable, "Unavailable", "Requested item is unavailable.",
+     "The requested item exists but cannot be provided at the moment.", false},
+}};
+
+/*!
+ \brief Returns the description of the given JSONRPC_STATUS
+ \param status Specific JSONRPC_STATUS
+ \return Description of the given status, or nullptr if it is not reported as an error
+ */
+inline const JsonRpcStatusDescription* StatusToDescription(JSONRPC_STATUS status)
+{
+  for (const auto& description : JSONRPC_STATUS_DESCRIPTIONS)
+  {
+    if (description.status == status)
+      return &description;
+  }
+
+  return nullptr;
+}
 
 /*!
  \brief Function pointer for JSON-RPC methods

--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -31,6 +31,7 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <memory>
 
 using namespace JSONRPC;
@@ -1819,6 +1820,7 @@ JSONRPC_STATUS CJSONServiceDescription::Print(CVariant &result, ITransportLayer 
   std::map<std::string, JSONSchemaTypeDefinitionPtr> types;
   CJsonRpcMethodMap methods;
   std::map<std::string, CVariant> notifications;
+  std::vector<const JsonRpcStatusDescription*> errors;
 
   int clientPermissions = client->GetPermissionFlags();
   int transportCapabilities = transport->GetCapabilities();
@@ -1873,6 +1875,17 @@ JSONRPC_STATUS CJSONServiceDescription::Print(CVariant &result, ITransportLayer 
       else
         return InvalidParams;
     }
+    else if (filterByType == "error")
+    {
+      const auto errorIterator =
+          std::find_if(JSONRPC_STATUS_DESCRIPTIONS.begin(), JSONRPC_STATUS_DESCRIPTIONS.end(),
+                       [&name](const JsonRpcStatusDescription& description)
+                       { return name == description.name; });
+      if (errorIterator != JSONRPC_STATUS_DESCRIPTIONS.end())
+        errors.push_back(&(*errorIterator));
+      else
+        return InvalidParams;
+    }
     else
       return InvalidParams;
 
@@ -1911,6 +1924,10 @@ JSONRPC_STATUS CJSONServiceDescription::Print(CVariant &result, ITransportLayer 
     types = m_types;
     methods = m_actionMap;
     notifications = m_notifications;
+
+    errors.reserve(JSONRPC_STATUS_DESCRIPTIONS.size());
+    for (const auto& description : JSONRPC_STATUS_DESCRIPTIONS)
+      errors.push_back(&description);
   }
 
   // Print the header
@@ -1974,6 +1991,20 @@ JSONRPC_STATUS CJSONServiceDescription::Print(CVariant &result, ITransportLayer 
   std::map<std::string, CVariant>::const_iterator notificationIteratorEnd = notifications.end();
   for (notificationIterator = notifications.begin(); notificationIterator != notificationIteratorEnd; ++notificationIterator)
     result["notifications"][notificationIterator->first] = notificationIterator->second[notificationIterator->first];
+
+  // Print the error taxonomy
+  for (const auto* status : errors)
+  {
+    CVariant currentError = CVariant(CVariant::VariantTypeObject);
+
+    currentError["code"] = status->status;
+    currentError["message"] = status->message;
+    if (printDescriptions)
+      currentError["description"] = status->description;
+    currentError["hasdata"] = status->hasData;
+
+    result["errors"][status->name] = currentError;
+  }
 
   return OK;
 }

--- a/xbmc/interfaces/json-rpc/schema/methods.json
+++ b/xbmc/interfaces/json-rpc/schema/methods.json
@@ -27,7 +27,7 @@
           "id": {
             "type": "string",
             "required": true,
-            "description": "Name of a namespace, method or type"
+            "description": "Name of a namespace, method, type, notification or error"
           },
           "type": {
             "type": "string",
@@ -36,7 +36,8 @@
               "method",
               "namespace",
               "type",
-              "notification"
+              "notification",
+              "error"
             ],
             "description": "Type of the given name"
           },

--- a/xbmc/interfaces/json-rpc/test/CMakeLists.txt
+++ b/xbmc/interfaces/json-rpc/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES TestJSONRPCPermission.cpp
+            TestJSONRPCStatus.cpp
             TestVideoLibrarySetSourceContent.cpp)
 
 core_add_test_library(jsonrpc_test)

--- a/xbmc/interfaces/json-rpc/test/TestJSONRPCStatus.cpp
+++ b/xbmc/interfaces/json-rpc/test/TestJSONRPCStatus.cpp
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "interfaces/json-rpc/JSONRPCUtils.h"
+
+#include <array>
+#include <set>
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+using namespace JSONRPC;
+
+namespace
+{
+//! Every JSONRPC_STATUS that reaches a client as an error. OK and ACK produce a result.
+constexpr std::array<JSONRPC_STATUS, 9> ERROR_STATUSES{
+    ParseError,      InvalidRequest, MethodNotFound, InvalidParams, InternalError,
+    FailedToExecute, BadPermission,  NotFound,       Unavailable};
+} // namespace
+
+//! \brief A status added to JSONRPC_STATUS must also be described, or clients cannot discover it
+TEST(TestJSONRPCStatus, EveryErrorStatusIsDescribed)
+{
+  for (const auto status : ERROR_STATUSES)
+    EXPECT_NE(nullptr, StatusToDescription(status))
+        << "undescribed status " << static_cast<int>(status);
+
+  EXPECT_EQ(ERROR_STATUSES.size(), JSONRPC_STATUS_DESCRIPTIONS.size());
+}
+
+TEST(TestJSONRPCStatus, SuccessStatusesAreNotDescribed)
+{
+  EXPECT_EQ(nullptr, StatusToDescription(OK));
+  EXPECT_EQ(nullptr, StatusToDescription(ACK));
+}
+
+TEST(TestJSONRPCStatus, CodesAndNamesAreUnique)
+{
+  std::set<int> codes;
+  std::set<std::string_view> names;
+
+  for (const auto& description : JSONRPC_STATUS_DESCRIPTIONS)
+  {
+    EXPECT_TRUE(codes.insert(static_cast<int>(description.status)).second)
+        << "duplicate code " << static_cast<int>(description.status);
+    EXPECT_TRUE(names.insert(description.name).second) << "duplicate name " << description.name;
+  }
+}
+
+//! \brief CJSONRPC::BuildResponse populates "error.data" for InvalidParams and nothing else
+TEST(TestJSONRPCStatus, OnlyInvalidParamsCarriesData)
+{
+  for (const auto& description : JSONRPC_STATUS_DESCRIPTIONS)
+    EXPECT_EQ(description.status == InvalidParams, description.hasData) << description.name;
+}
+
+TEST(TestJSONRPCStatus, EveryDescriptionIsPopulated)
+{
+  for (const auto& description : JSONRPC_STATUS_DESCRIPTIONS)
+  {
+    EXPECT_FALSE(std::string_view(description.name).empty());
+    EXPECT_FALSE(std::string_view(description.message).empty());
+    EXPECT_FALSE(std::string_view(description.description).empty());
+  }
+}


### PR DESCRIPTION
The JSON-RPC error codes are a C++ enum in `JSONRPCUtils.h` and appear in none of `methods.json`, `types.json` or `notifications.json`, so `JSONRPC.Introspect` has never served them.

The consequence is easy to miss. Generate an API description from the schema today and you get 182 methods with no statement of how any of them can fail — every generated client models the success path only. It is also why no documentation has ever quoted a code such as `-32602`: there was no machine-readable source to quote.

### What this adds

`JSONRPC.Introspect` now carries an `errors` section alongside `types`, `methods` and `notifications`, giving each status its code, symbolic name, message and a description of when it is returned:

```json
"errors": {
  "NotFound": {
    "code": -32098,
    "message": "Not found.",
    "description": "The requested item does not exist.",
    "hasdata": false
  },
  "InvalidParams": {
    "code": -32602,
    "message": "Invalid params.",
    "description": "The given parameters do not validate against the schema of the method. The \"data\" member names the offending parameter and the constraint it failed.",
    "hasdata": true
  }
}
```

`getdescriptions: false` drops the prose as it does elsewhere. `filter.type` accepts `"error"` so a single entry can be fetched, and filtering now narrows errors as it already narrowed every other section.

### The taxonomy is declared once

`CJSONRPC::BuildResponse` previously repeated every status message in a nine-case switch. It now reads the same table that `Introspect` serves, so the wire message and the served description cannot drift apart. The enum stays the definition of the codes, because every handler returns one; what the table adds is the naming and the prose.

The alternative was a fourth schema file, which would have meant changing `JsonSchemaBuilder` — a native build tool that a cross-compiling build may supply prebuilt via `-DWITH_JSONSCHEMABUILDER`. Emitting from the existing table avoids that coordination entirely, and follows the precedent already in `CJSONRPC::Initialize`, which injects runtime-computed enums into the schema.

`-32100` sits one code point below the range JSON-RPC 2.0 reserves for implementation-defined server errors. That is long-standing and clients depend on it, so it is documented as deliberate rather than renumbered.

### Deliberately not done here

Declaring which errors an *individual* method can return. That is a call-graph audit across 234 method-specific return sites, most of which reach the caller through shared helpers such as `FileItemHandler` and `HandleFileItemList` rather than being local to a handler. A declared-but-wrong error set is worse than none, because generated clients branch on it. Tracked separately.

### The first commit

`xbmc/interfaces/json-rpc` had no test directory, so nothing under it was tested even where it could be in isolation. The first commit adds the target and covers the permission mapping, which is pure and needs none of the services `InitForTesting` omits. It pins behaviour worth knowing: `StringToPermission` has no failure signal, so an unrecognised or wrongly cased name silently reads as `ReadData`, the least privileged value.

It is the base commit here rather than its own PR, per the pattern set on #28850.

### Testing

- Full suite: 3581 tests, 3581 pass, 0 fail.
- `TestJSONRPCPermission` verified checked out on the first commit alone, to confirm that commit stands on its own.
- Verified against a running Kodi over the TCP interface: the `errors` section is served with all nine statuses; `getdescriptions: false` drops descriptions; `filter.type: "error"` returns one entry and an unknown name returns `-32602`; an unfiltered introspect returns 180 methods, 202 types, 42 notifications and 9 errors.
- The `BuildResponse` change is behaviour-neutral on the wire: an unknown method still returns a bare `{-32601, "Method not found."}`, and `Player.GetItem` with a string `playerid` still returns `-32602` carrying the full `data.stack` payload.
