### PR TITLE
[pvr] Cache EPG tag playability in the guide info provider

### DIFF
--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.cpp
@@ -55,11 +55,21 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 using namespace PVR;
 using namespace KODI::GUILIB::GUIINFO;
 using namespace std::chrono_literals;
+
+namespace
+{
+std::tuple<int, unsigned int, CDateTime, CDateTime> MakePlayableCacheKey(const CPVREpgInfoTag& tag)
+{
+  return {tag.EpgID(), tag.UniqueBroadcastID(), tag.StartAsUTC(), tag.EndAsUTC()};
+}
+} // unnamed namespace
 
 CPVRGUIInfo::CPVRGUIInfo() : CThread("PVRGUIInfo")
 {
@@ -101,6 +111,7 @@ void CPVRGUIInfo::ResetProperties()
   m_bIsPlayingActiveRecording = false;
   m_bHasTVChannels = false;
   m_bHasRadioChannels = false;
+  m_playableCache.clear();
 
   ClearQualityInfo(m_qualityInfo);
   ClearDescrambleInfo(m_descrambleInfo);
@@ -199,6 +210,10 @@ void CPVRGUIInfo::Process()
 
     if (!m_bStop)
       UpdateTimeshiftData();
+    std::this_thread::yield();
+
+    if (!m_bStop)
+      UpdatePlayableCache();
     std::this_thread::yield();
 
     if (!m_bStop)
@@ -326,6 +341,63 @@ void CPVRGUIInfo::UpdateMisc()
 void CPVRGUIInfo::UpdateTimeshiftData()
 {
   m_timesInfo.Update();
+}
+
+bool CPVRGUIInfo::IsPlayable(const std::shared_ptr<const CPVREpgInfoTag>& tag) const
+{
+  const auto key{MakePlayableCacheKey(*tag)};
+
+  {
+    std::unique_lock lock(m_critSection);
+    const auto it{m_playableCache.find(key)};
+    if (it != m_playableCache.end())
+    {
+      it->second.queried = true;
+      return it->second.playable;
+    }
+  }
+
+  // Not cached yet, for instance because the tag just became visible. Ask the client once,
+  // outside the lock; from here on the answer is refreshed by the update thread.
+  const bool playable{tag->IsPlayable()};
+
+  std::unique_lock lock(m_critSection);
+  m_playableCache.insert_or_assign(key, PlayableCacheEntry{tag, playable, true});
+  return playable;
+}
+
+void CPVRGUIInfo::UpdatePlayableCache()
+{
+  std::vector<std::pair<PlayableCacheKey, std::shared_ptr<const CPVREpgInfoTag>>> tags;
+  {
+    std::unique_lock lock(m_critSection);
+    for (auto it = m_playableCache.begin(); it != m_playableCache.end();)
+    {
+      if (it->second.queried)
+      {
+        it->second.queried = false;
+        tags.emplace_back(it->first, it->second.tag);
+        ++it;
+      }
+      else
+      {
+        // Nobody asked for this tag since the last update, so it is no longer displayed.
+        it = m_playableCache.erase(it);
+      }
+    }
+  }
+
+  // Asking the client can block for as long as the client takes to answer, and the rendering
+  // thread reads the cache for every visible tag, so this must happen without the lock held.
+  for (const auto& [key, tag] : tags)
+  {
+    const bool playable{tag->IsPlayable()};
+
+    std::unique_lock lock(m_critSection);
+    const auto it{m_playableCache.find(key)};
+    if (it != m_playableCache.end())
+      it->second.playable = playable;
+  }
 }
 
 bool CPVRGUIInfo::InitCurrentItem(CFileItem* item)
@@ -1562,7 +1634,7 @@ bool CPVRGUIInfo::GetListItemAndPlayerBool(const CFileItem* item,
     case LISTITEM_ISPLAYABLE:
       if (item->IsEPG())
       {
-        bValue = item->GetEPGInfoTag()->IsPlayable();
+        bValue = IsPlayable(item->GetEPGInfoTag());
         return true;
       }
       break;

--- a/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
+++ b/xbmc/pvr/guilib/guiinfo/PVRGUIInfo.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "XBDateTime.h"
 #include "guilib/guiinfo/GUIInfoProvider.h"
 #include "powermanagement/PowerState.h"
 #include "pvr/PVRDescrambleInfo.h"
@@ -19,7 +20,10 @@
 #include "threads/Thread.h"
 
 #include <atomic>
+#include <map>
+#include <memory>
 #include <string>
+#include <tuple>
 #include <vector>
 
 class CFileItem;
@@ -31,6 +35,8 @@ class CGUIInfo;
 
 namespace PVR
 {
+class CPVREpgInfoTag;
+
 class CPVRGUIInfo : public KODI::GUILIB::GUIINFO::CGUIInfoProvider,
                     private CThread,
                     public CPowerState
@@ -88,8 +94,16 @@ private:
   void UpdateNextTimer();
   void UpdateTimeshiftData();
   void UpdateTimeshiftProgressData();
+  void UpdatePlayableCache();
 
   void UpdateTimersToggle();
+
+  /*!
+   * @brief Get whether the given EPG tag is playable, from the playability cache.
+   * @param tag The EPG tag.
+   * @return True if the tag is playable, false otherwise.
+   */
+  bool IsPlayable(const std::shared_ptr<const CPVREpgInfoTag>& tag) const;
 
   bool GetListItemAndPlayerLabel(const CFileItem* item,
                                  const KODI::GUILIB::GUIINFO::CGUIInfo& info,
@@ -189,6 +203,22 @@ private:
 
   std::string m_channelNumberInput;
   bool m_previewAndPlayerShowInfo{false};
+
+  /*!
+   * @brief Identity of an EPG tag for the playability cache. Contains the tag's time
+   * boundaries as well as its ids, so that a tag whose times were changed does not match
+   * the answer cached for its previous times.
+   */
+  using PlayableCacheKey = std::tuple<int, unsigned int, CDateTime, CDateTime>;
+
+  struct PlayableCacheEntry
+  {
+    std::shared_ptr<const CPVREpgInfoTag> tag;
+    bool playable{false};
+    bool queried{true}; /*!< whether the value was read since the last cache update */
+  };
+
+  mutable std::map<PlayableCacheKey, PlayableCacheEntry> m_playableCache;
 
   mutable CCriticalSection m_critSection;
 


### PR DESCRIPTION
## What does this PR do?

Caches EPG tag playability in `CPVRGUIInfo`, so the guide window stops asking the PVR
add-on about every visible cell on every render pass. `CPVREpgInfoTag` is unchanged.

## Why is it needed?

`CPVREpgInfoTag::IsPlayable()` calls into the add-on on every invocation. It caches
nothing, copies the tag into a `CAddonEpgTag` each time, and holds the tag's critical
section across the call.

Estuary's `epggrid` draws `$VAR[PVRTimerIcon]` in both `itemlayout` and `focusedlayout`;
that variable's last branch is `ListItem.IsPlayable`, which resolves to `IsPlayable()` via
`CPVRGUIInfo::GetListItemAndPlayerBool`. List-item-dependent info bools are deliberately not
cached — `InfoBool::Get` re-runs `Update()` whenever an item pointer is supplied — so the
call happens per cell, per pass.

For most clients that is a linear scan over a channel vector and costs nothing. For two it
is not:

- **pvr.zattoo** runs a SQLite `SELECT` per call.
- **pvr.teleboy** enqueues a request to the Teleboy API per call. It caps that queue at 100
  with drop-oldest, and the comment says why: *"the user was probably just scrolling through
  the EPG. To avoid making too many requests to the teleboy API, we drop the oldest
  entries"*. It also marks already-loaded plots with a zero-width space *"to avoid making
  too many calls to the Teleboy API."*

Those workarounds exist because core gives add-ons nowhere else to put the problem.

## How it works

The cache lives in `CPVRGUIInfo`, which is where the calling pattern is, and is driven by
the update thread that provider already runs.

- `LISTITEM_ISPLAYABLE` reads the cache. A hit is a map lookup — no add-on call on the
  rendering thread.
- A miss asks the client once, when the tag first becomes visible, and stores the answer.
- `UpdatePlayableCache()` runs on the existing `Process()` tick. It re-asks the client for
  every entry that was read since the previous tick and erases every entry that was not, so
  the cache holds exactly what is on screen and empties when the guide closes.
- The refresh calls the client with the lock released, following the same "compute unlocked,
  assign locked" pattern as the other update steps in that file, so a slow client cannot
  stall the rendering thread's lookup.
- Entries are keyed on the tag's ids together with its start and end times, so an event
  whose times changed — an overlapping event having its end trimmed, for instance — never
  matches the answer cached for its previous times.

An answer is therefore at most one tick (500 ms) old, and the number of add-on calls is
bounded by the number of visible tags rather than by the frame rate.

Sparing the add-ons that never implement `IsEPGTagPlayable` at all is a separate concern and
belongs at the client; it is not in this PR.

Context: this is one of the items left unimplemented in #18642.

## Testing

Full gtest suite green (3570 tests). `clang-format` clean on the touched lines.

Not verified against a live catchup backend — pvr.zattoo and pvr.teleboy both need paid
service accounts. The behaviour above is from reading those add-ons' sources.
