### PR TITLE
[pvr] Stop calling into add-ons that do not implement IsEPGTagPlayable

### DIFF
--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -494,6 +494,7 @@ void CPVRClient::ResetProperties()
   m_menuhooks.reset();
   m_timertypes.clear();
   m_clientCapabilities.clear();
+  m_epgTagPlayableImplemented = true;
 
   m_ifc.pvr->props->strUserPath = m_strUserPath.c_str();
   m_ifc.pvr->props->strClientPath = m_strClientPath.c_str();
@@ -989,14 +990,23 @@ PVR_ERROR CPVRClient::IsRecordable(const std::shared_ptr<const CPVREpgInfoTag>& 
 PVR_ERROR CPVRClient::IsPlayable(const std::shared_ptr<const CPVREpgInfoTag>& tag,
                                  bool& bIsPlayable) const
 {
-  return DoAddonCall(
+  const PVR_ERROR error{DoAddonCall(
       std::source_location::current().function_name(),
       [tag, &bIsPlayable](const AddonInstance* addon)
       {
         CAddonEpgTag addonTag(*tag);
         return addon->toAddon->IsEPGTagPlayable(addon, &addonTag, &bIsPlayable);
       },
-      m_clientCapabilities.SupportsEPG());
+      m_clientCapabilities.SupportsEPG() && m_epgTagPlayableImplemented)};
+
+  // The function is optional and the answer cannot change while the add-on is loaded, so
+  // take it once rather than on every tag.
+  if (error == PVR_ERROR_NOT_IMPLEMENTED)
+  {
+    m_epgTagPlayableImplemented = false;
+  }
+
+  return error;
 }
 
 void CPVRClient::WriteStreamProperties(std::span<PVR_NAMED_VALUE*> properties,

--- a/xbmc/pvr/addons/PVRClient.h
+++ b/xbmc/pvr/addons/PVRClient.h
@@ -1161,6 +1161,8 @@ private:
   std::string m_strConnectionString; /*!< the cached connection string */
   std::string m_strBackendHostname; /*!< the cached backend hostname */
   CPVRClientCapabilities m_clientCapabilities; /*!< the cached add-on's capabilities */
+  mutable std::atomic<bool> m_epgTagPlayableImplemented{
+      true}; /*!< cleared once the add-on has answered that it does not implement IsEPGTagPlayable */
   mutable std::shared_ptr<CPVRClientMenuHooks> m_menuhooks; /*!< the menu hooks for this add-on */
 
   /* stored strings to make sure const char* members in AddonProperties_PVR stay valid */


### PR DESCRIPTION
## Description
`CPVRClient::IsPlayable` gated only on `SupportsEPG()` and crossed the add-on boundary for every EPG tag, even when the add-on had already answered `PVR_ERROR_NOT_IMPLEMENTED`. The answer is now taken once, fed back through `DoAddonCall`'s existing `bIsImplemented` parameter; `ResetProperties` re-arms the flag alongside the cached capabilities, so a reconnecting add-on is asked again.

## Motivation and context
`IsEPGTagPlayable` is optional and has no covering client capability. The guide window asks once per visible cell per render pass, so add-ons that stub it (pvr.hts, pvr.hdhomerun) receive a steady stream of calls that can only ever answer the same way. Came out of the same investigation as #18642's outstanding items.

## How has this been tested?
Full gtest suite: 3569/3570 passed; the one failure is a known machine-local `TestHTTPDirectory` flake unrelated to this change. `clang-format` clean on the touched lines.

## What is the effect on users?
Less overhead in the EPG grid for tvheadend and HDHomeRun users.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
