### PR TITLE
VideoPlayer: don't let a seek past the end scan the whole file

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1285,21 +1285,49 @@ bool CDVDDemuxFFmpeg::SeekTime(double time, bool backwards, double* startpts)
   int ret;
   {
     std::unique_lock lock(m_critSection);
-    ret = av_seek_frame(m_pFormatContext, m_seekStream, seek_pts, backwards ? AVSEEK_FLAG_BACKWARD : 0);
+
+    // mp3 and .sup get no start_time added to seek_pts above, so the threshold has none either
+    int64_t starttime = (ismp3 || m_bSup) ? 0 : m_pFormatContext->start_time;
+    if (m_checkTransportStream)
+    {
+      AVStream* st = m_pFormatContext->streams[m_seekStream];
+      starttime =
+          av_rescale(static_cast<int64_t>(m_startTime), st->time_base.num, st->time_base.den);
+    }
+
+    // an unknown timing is AV_NOPTS_VALUE, i.e. INT64_MIN, and would put the threshold
+    // below every possible target
+    const bool timingsKnown =
+        m_pFormatContext->duration > 0 && starttime != static_cast<int64_t>(AV_NOPTS_VALUE);
+    const bool beyondEof = timingsKnown && seek_pts >= (m_pFormatContext->duration + starttime);
+
+    // a duration derived from the bitrate undershoots on VBR content, so it is no boundary
+    // to decide a seek on
+    const bool durationIsMeasured =
+        m_pFormatContext->duration_estimation_method != AVFMT_DURATION_FROM_BITRATE;
+
+    // past the end there is no index entry to seek to, so av_seek_frame() scans the rest of
+    // the file packet by packet before failing - minutes on a network source. The outcome is
+    // known here, so skip it. Not for transport streams (target in ticks vs duration in
+    // AV_TIME_BASE units) or realtime sources (the file may have grown past its duration).
+    const bool skipSeek =
+        beyondEof && durationIsMeasured && !m_checkTransportStream && !m_pInput->IsRealtime();
+
+    if (skipSeek)
+    {
+      CLog::Log(LOGDEBUG,
+                "CDVDDemuxFFmpeg::{} - target {} is past the end of the stream, skipping the seek",
+                __FUNCTION__, seek_pts);
+      ret = -1;
+    }
+    else
+      ret = av_seek_frame(m_pFormatContext, m_seekStream, seek_pts,
+                          backwards ? AVSEEK_FLAG_BACKWARD : 0);
 
     if (ret < 0)
     {
-      int64_t starttime = m_pFormatContext->start_time;
-      if (m_checkTransportStream)
-      {
-        AVStream* st = m_pFormatContext->streams[m_seekStream];
-        starttime =
-            av_rescale(static_cast<int64_t>(m_startTime), st->time_base.num, st->time_base.den);
-      }
-
       // demuxer can return failure, if seeking behind eof
-      if (m_pFormatContext->duration &&
-          seek_pts >= (m_pFormatContext->duration + starttime))
+      if (beyondEof)
       {
         // force eof
         // files of realtime streams may grow


### PR DESCRIPTION
## Description

Seeking to or past the end of a stream freezes the player for as long as it takes to read the rest
of the file. On a 1.5 hour HTTP stream that is one to three minutes, and it ends only when the read
finally reaches eof and the seek is reported as failed.

A target past the end has no index entry that could satisfy it, so `av_seek_frame()` falls back to
`seek_frame_generic()`, which walks the file packet by packet through `av_read_frame()` looking for
a timestamp that cannot be there. Every one of those packets is pulled through `CFileCache` and, for
a network source, off the wire.

`SeekTime()` already recognises this case — it checks whether the target lies past `duration` and
then forces eof by closing the input — but only *after* `av_seek_frame()` has returned, so the
pointless search happens first. This hoists the check in front of the call:

```cpp
const bool timingsKnown =
    m_pFormatContext->duration > 0 && starttime != static_cast<int64_t>(AV_NOPTS_VALUE);
const bool beyondEof = timingsKnown && seek_pts >= (m_pFormatContext->duration + starttime);

const bool skipSeek = beyondEof && !m_checkTransportStream && !m_pInput->IsRealtime();

if (skipSeek)
{
  CLog::Log(LOGDEBUG, ...);
  ret = -1;
}
else
  ret = av_seek_frame(m_pFormatContext, m_seekStream, seek_pts,
                      backwards ? AVSEEK_FLAG_BACKWARD : 0);
```

The `starttime` computation is moved up so both sites can see it. The end of stream handling below is
unchanged and now keys off `beyondEof` instead of repeating the condition.

Deciding *whether* to seek is a heavier job than explaining a failure that already happened, so the
condition gained three guards it did not need in its old position:

- **`AV_NOPTS_VALUE`.** Both `duration` and `start_time` can be unknown — raw H.264, ADTS, `.sup`,
  some transport streams — and the value is `INT64_MIN`. Unguarded, `duration + starttime` sits below
  every possible target, so *every* seek would report itself as past the end and close the input.
  The guard on `start_time` mirrors the one already present ~20 lines above where `seek_pts` is
  built; `duration > 0` matches `GetStreamLength()`. This also corrects the check in its existing
  position, where an unknown timing could close the input after any failed seek rather than only
  after one past the end — a fix beyond the stated scope of this PR, but not one worth leaving in
  place once the expression is load-bearing.

- **`start_time` is dropped for mp3 and `.sup`.** `seek_pts` deliberately does not get `start_time`
  added for those two, ~20 lines above, while `starttime` here took it unconditionally — so the two
  sides of the comparison differed by exactly that offset and the skip could never fire for them.
  The threshold now mirrors what was actually added to the target. In its old position this only
  made the eof detection stricter than intended, which is why it went unnoticed.

- **Transport streams and realtime sources still call `av_seek_frame()`.** In the
  `m_checkTransportStream` branch `seek_pts` is in stream ticks while `duration` stays in
  `AV_TIME_BASE` units, so the comparison is not meaningful there (pre-existing, and harmless while
  it only ran after a failure). And a realtime file may have grown past the duration it recorded —
  which is exactly why that branch keeps the seek alive. In both cases the demuxer stays the
  authority and the outcome is identical to today, reached after the call rather than in place of it.

Skipping the search is logged at debug level, so a wrong verdict here is distinguishable from a
genuine seek failure in a user log.

## Motivation and context

Reported as "Kodi sometimes doesn't stop playback when you seek to the end". It always stops
eventually — it just takes minutes, so it reads as a hang.

The blocked player thread, captured with lldb while stalled:

```
CVideoPlayer::HandleMessages
└─ CDVDDemuxFFmpeg::SeekTime(time=5357952, backwards=false)
   └─ av_seek_frame                                    seek.c:656
      └─ seek_frame_internal                           seek.c:636
         └─ seek_frame_generic                         seek.c:562
            └─ av_read_frame                           demux.c:1599
               └─ ff_read_packet                       demux.c:659
                  └─ mov_read_packet
                     └─ avio_read → fill_buffer        aviobuf.c:551
                        └─ dvd_file_read
                           └─ XFILE::CFileCache::Read
                              └─ CCircularCache::WaitForData
```

The `FileCache` thread is not deadlocked, it is in `__recvfrom` under `Curl_sendrecv` — actively
downloading. Nothing is stuck; the demuxer is simply asking for the whole rest of the file.

Instrumenting a single seek to ~1s past the end of a 1 GB, 01:29:17 stream, counting *every* ffmpeg
IO callback rather than only slow ones:

```
av_seek_frame: ret -1 after 39455 ms | reads 2330 (1 eof) 38994 ms (max 10182 ms)
                                     | seeks 2 434 ms | unaccounted 26 ms
```

2330 reads, and 98.8% of the call spent inside them. Counting only calls over a threshold shows
nothing here, because the reads are individually fast — that is what made this look like a lock-up
rather than a scan at first.

Duration scales with how much file is left and how fast the source is: the same file over the same
CDN stalled 39s and 55s on a Mac and 177s on an Android device. Local files are effectively immune,
which is presumably why this has survived so long.

## How has this been tested?

macOS (Apple Silicon, debug build) against a 1 GB H.264 MP4 served over HTTPS, duration 01:29:17.06.

Before the change, seeking past the end stalled 39–55s per attempt, ending in
`VideoPlayer: seek failed or hit end of stream`. After the change playback ends immediately, with
the same log line and the same resulting state.

Normal seeking within the file was exercised as well and is unaffected — that is the regression risk
here, since a wrongly-true `beyondEof` would break every seek.

Note that a well-formed mp4 is the case where both `start_time` and `duration` are known, i.e. the
one that cannot go wrong. The states that would break the fast path are the unknown ones, and they
are precisely the ones now excluded from it: `timingsKnown` falls back to `av_seek_frame()`, as do
transport streams and realtime sources. So those untested paths are untested in the sense that they
behave exactly as they do on master, not in the sense that they take new code.

The one exception is mp3 and `.sup` with a non-zero `start_time`, which do take new code — the
threshold there is now `duration` alone. Untested; the reasoning is that the target it is compared
against is built the same way, ~20 lines above.

## What is the effect on users?

Seeking to or past the end of a network stream ends playback immediately instead of appearing to
freeze for minutes. No change for seeks inside the stream, and no change to what happens after the
seek fails.

One behaviour change worth naming: seeking to *exactly* `duration` is treated as past the end, as
the old post-failure check already did — with `AVSEEK_FLAG_BACKWARD` such a seek could previously
land on the last keyframe and keep playing, where it now ends playback. Secondly, a stream without
usable timings no longer has its input closed after an unrelated seek failure; it falls through to
the `IsEOF()` branch as it should. Thirdly, an mp3 or `.sup` with a non-zero `start_time` now
recognises a past-the-end seek at all, where the offset mismatch previously hid it and left the seek
to fail its way into the `IsEOF()` branch.

## Screenshots (if appropriate):

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed