### PR TITLE
FileItem: fix data race on the CFileItem URL caches

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -609,8 +609,7 @@ void CFileItem::Archive(CArchive& ar)
     if (iType == 1)
       ar >> *GetGameInfoTag();
 
-    m_urlPath.reset();
-    m_urlDynPath.reset();
+    InvalidateCachedURLs();
     SetInvalid();
   }
 }
@@ -1642,8 +1641,9 @@ const std::string& CFileItem::GetPath() const
 
 void CFileItem::SetPath(std::string path)
 {
+  std::unique_lock lock(m_urlMutex);
   m_strPath = std::move(path);
-  m_urlPath.reset();
+  m_urlPathValid.store(false, std::memory_order_release);
 }
 
 void CFileItem::SetURL(const CURL& url)
@@ -1651,11 +1651,32 @@ void CFileItem::SetURL(const CURL& url)
   SetPath(url.Get());
 }
 
+const CURL& CFileItem::GetCachedURL(CURL& url,
+                                    std::atomic_bool& valid,
+                                    const std::string& path) const
+{
+  if (!valid.load(std::memory_order_acquire))
+  {
+    std::unique_lock lock(m_urlMutex);
+    if (!valid.load(std::memory_order_relaxed))
+    {
+      url = CURL(path);
+      valid.store(true, std::memory_order_release);
+    }
+  }
+  return url;
+}
+
+void CFileItem::InvalidateCachedURLs()
+{
+  std::unique_lock lock(m_urlMutex);
+  m_urlPathValid.store(false, std::memory_order_release);
+  m_urlDynPathValid.store(false, std::memory_order_release);
+}
+
 const CURL& CFileItem::GetURL() const
 {
-  if (!m_urlPath)
-    m_urlPath = CURL(m_strPath);
-  return *m_urlPath;
+  return GetCachedURL(m_urlPath, m_urlPathValid, m_strPath);
 }
 
 bool CFileItem::IsURL(const CURL& url) const
@@ -1676,17 +1697,9 @@ void CFileItem::SetDynURL(const CURL& url)
 const CURL& CFileItem::GetDynURL() const
 {
   if (!m_strDynPath.empty())
-  {
-    if (!m_urlDynPath)
-      m_urlDynPath = CURL(m_strDynPath);
-    return *m_urlDynPath;
-  }
+    return GetCachedURL(m_urlDynPath, m_urlDynPathValid, m_strDynPath);
   else
-  {
-    if (!m_urlPath)
-      m_urlPath = CURL(m_strPath);
-    return *m_urlPath;
-  }
+    return GetCachedURL(m_urlPath, m_urlPathValid, m_strPath);
 }
 
 const std::string &CFileItem::GetDynPath() const
@@ -1699,8 +1712,9 @@ const std::string &CFileItem::GetDynPath() const
 
 void CFileItem::SetDynPath(std::string path)
 {
+  std::unique_lock lock(m_urlMutex);
   m_strDynPath = std::move(path);
-  m_urlDynPath.reset();
+  m_urlDynPathValid.store(false, std::memory_order_release);
 }
 
 void CFileItem::SetCueDocument(const std::shared_ptr<CCueDocument>& cuePtr)

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -24,8 +24,9 @@
 #include "utils/SortUtils.h"
 #include "utils/XTimeUtils.h"
 
+#include <atomic>
 #include <memory>
-#include <optional>
+#include <mutex>
 #include <string>
 #include <string_view>
 
@@ -566,8 +567,24 @@ private:
    */
   void FillMusicInfoTag(const std::shared_ptr<const PVR::CPVREpgInfoTag>& tag);
 
-  mutable std::optional<CURL> m_urlPath;
-  mutable std::optional<CURL> m_urlDynPath;
+  /*!
+   \brief Return \p url, parsing \p path into it on first use.
+
+   The getters are const but fill their cache, so two readers are really two writers. Double-checked
+   locking keeps the already-filled case a single atomic load.
+   \sa GetURL, GetDynURL
+   */
+  const CURL& GetCachedURL(CURL& url, std::atomic_bool& valid, const std::string& path) const;
+
+  /*! \brief Mark both parsed URLs stale, so the next getter re-parses them. */
+  void InvalidateCachedURLs();
+
+  mutable std::mutex m_urlMutex; ///< guards the first fill of the URLs below
+  /// \brief Lazily parsed paths, readable only while their flag is set.
+  mutable std::atomic_bool m_urlPathValid{false};
+  mutable std::atomic_bool m_urlDynPathValid{false};
+  mutable CURL m_urlPath;
+  mutable CURL m_urlDynPath;
   std::string m_strPath;            ///< complete path to item
   std::string m_strDynPath;
 


### PR DESCRIPTION
## Description

`CFileItem` parses `m_strPath` / `m_strDynPath` into `CURL` objects on first use, inside `const`
getters and without any synchronization:

```cpp
const CURL& CFileItem::GetDynURL() const
{
  if (!m_urlDynPath)
    m_urlDynPath = CURL(m_strDynPath);
  return *m_urlDynPath;
}
```

A `const` getter that writes turns two plain *readers* of a shared item into a data race. Whichever
thread gets there first fills the cache under the other one, which then walks a half-built
`std::map` and crashes. Neither side has to mutate the item for this to happen.

This guards both caches with double-checked locking: an atomic flag per cache for the already-filled
fast path, a mutex around the fill itself, and the same mutex on the paths that invalidate them
(`SetPath()`, `SetDynPath()`, `Archive()`).

```cpp
const CURL& CFileItem::GetCachedURL(CURL& url,
                                    std::atomic_bool& valid,
                                    const std::string& path) const
{
  if (!valid.load(std::memory_order_acquire))
  {
    std::unique_lock lock(m_urlMutex);
    if (!valid.load(std::memory_order_relaxed))
    {
      url = CURL(path);
      valid.store(true, std::memory_order_release);
    }
  }
  return url;
}
```

`std::call_once` does not fit here: the caches are flushed whenever the path changes, and a
`once_flag` cannot be reset.

The flag carries the validity — the fast path cannot read `has_value()` without the lock — so the
caches are plain `CURL`s rather than optionals, and invalidating one is a single store.

Both caches share one mutex, because `GetDynURL()` falls back to filling `m_urlPath` when the
dynamic path is empty, so the two are not independent anyway.

### What this does not change

Concurrent readers are now safe. Writing to an item that is already shared stays the caller's
business, exactly as before: `SetPath()` can still drop a `CURL` that another thread holds a
reference to. Making that safe would mean changing the getters back to returning by value, which is
what 032277c2c4 deliberately moved away from because `CURL::Parse` is expensive.

## Motivation and context

Playback start crashed occasionally on Android with no tombstone and no Java stack — Kodi installs
no native crash handler on Android, so `ApplicationExitInfo` only reported `SIGNALED status=11` with
`trace=null`. Captured with a temporary in-process signal handler, the stack is:

```
signal 11 (SIGSEGV), code 1, fault addr 0x3f02

#03 std::map<std::string, CVariant>::insert(...)
#04 std::map<std::string, CVariant>::map(std::map const&)
#05 CURL::CURL(CURL const&)
#06 XFILE::CCurlFile::GetMimeType(CURL const&, std::string&, std::string const&)
#07 CFileItem::FillInMimeType(bool)
#08 CVideoPlayer::Process()
```

The fault address is a small garbage value rather than a null offset, which is the signature of a
torn container rather than a missing object: the protocol options map of the `CURL` being copied out
of `m_urlDynPath` is being built or freed by another thread at the same time.

The two racing sites in that particular crash sit three lines apart in `CVideoPlayer::OpenFile()`:

```cpp
Create();                              // player thread starts, Process() reads m_item
m_messenger.Init();
m_callback.OnPlayBackStarted(m_item);  // this thread hands out the same item
```

An earlier revision of this PR fixed exactly that call site, by filling both caches while the player
was still single threaded. That only closed one window. `CFileItem`s are handed between the GUI,
player, scanner and PVR threads in plenty of other places, and every one of them can hit the same
lazy write. The missing synchronization belongs to the class, so that is where this fixes it.

## How has this been tested?

The original crash came from Android (armeabi-v7a, Android 14) playing h264 over https, captured
with a temporary in-process signal handler, and it was intermittent — one playback start in many.

A throwaway gtest reproduced it on demand instead: every hardware thread piles up on a start
barrier and then hits the same freshly built item, alternating between `GetURL()` and `GetDynURL()`,
500 rounds. It is not part of this PR — its outcome depends on the scheduler, so it would pass on a
two-core runner with the bug back in place.

Without the locking (macOS arm64, Debug, only the getters reverted to the unsynchronized fill) it
dies on every single run:

```
run 1 exit=139   # SIGSEGV
run 2 exit=139
run 3 exit=138   # SIGBUS
run 4 exit=139
run 5 exit=1     # survived, but the two threads disagreed about the parsed URL
```

With the change, 5/5 runs pass, as does the rest of `TestFileItem*` and `TestURL*`.

Not covered by my testing: PVR, discs, and the MMS special case in `FillInMimeType()` — that one
calls `SetDynPath()` and therefore still invalidates the cache, but it only applies to two rare mime
types. No soak test on Android with this revision; the threaded reproducer is the stronger evidence
of the two anyway.

## What is the effect on users?

One less intermittent crash when starting playback of an internet stream, and every other pair of
threads sharing a `CFileItem` stops being a latent crash.

## Screenshots (if appropriate):

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed