### PR TITLE
[i18n] Compile-time check against accidental leading/trailing white space in ISO table language and country names

### DIFF
--- a/xbmc/utils/StringUtils.h
+++ b/xbmc/utils/StringUtils.h
@@ -359,6 +359,16 @@ public:
   {
     return 'A' <= c && c <= 'Z' ? c - 'A' + 'a' : c;
   }
+  [[nodiscard]] constexpr static bool isasciiwhitespace(char chr) noexcept // locale independent
+  {
+    return chr == ' ' || chr == '\t' || chr == '\n' || chr == '\v' || chr == '\f' || chr == '\r';
+  }
+  [[nodiscard]] constexpr static bool IsAsciiTrimmed(
+      std::string_view str) noexcept // locale independent
+  {
+    return str.empty() || (!StringUtils::isasciiwhitespace(str.front()) &&
+                           !StringUtils::isasciiwhitespace(str.back()));
+  }
   [[nodiscard]] static std::string SizeToString(int64_t size);
   static const std::string Empty;
   [[nodiscard]] static size_t FindWords(std::string_view str,

--- a/xbmc/utils/i18n/Iso3166_1_Table.h
+++ b/xbmc/utils/i18n/Iso3166_1_Table.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "utils/StringUtils.h"
+
 #include <algorithm>
 #include <array>
 #include <string_view>
@@ -285,6 +287,11 @@ inline constexpr std::array<ISO3166_1, ISO3166_1_COUNT> TableISO3166_1 = {{
 // clang-format on
 
 static_assert(std::ranges::is_sorted(TableISO3166_1, {}, &ISO3166_1::alpha2));
+
+static_assert(std::ranges::all_of(
+    TableISO3166_1,
+    [](std::string_view name) { return StringUtils::IsAsciiTrimmed(name); },
+    &ISO3166_1::name));
 
 constexpr auto CreateTableISO3166_1ByAlpha3()
 {

--- a/xbmc/utils/i18n/Iso639_1_Table.h
+++ b/xbmc/utils/i18n/Iso639_1_Table.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/StringUtils.h"
 #include "utils/i18n/Iso639.h"
 
 #include <algorithm>
@@ -221,6 +222,11 @@ constexpr std::array<struct LCENTRY, ISO639_1_COUNT> TableISO639_1 = {{
 }};
 // clang-format on
 
+static_assert(std::ranges::all_of(
+    TableISO639_1,
+    [](std::string_view name) { return StringUtils::IsAsciiTrimmed(name); },
+    &LCENTRY::name));
+
 inline constexpr int ISO639_1_DEPRECATED_COUNT = 7;
 
 // clang-format off
@@ -251,6 +257,11 @@ inline constexpr std::array<struct LCENTRY, ISO639_1_DEPRECATED_COUNT> TableISO6
     {StringToLongCode("bh"), "Bihari"},
 }};
 // clang-format on
+
+static_assert(std::ranges::all_of(
+    TableISO639_1_Depr,
+    [](std::string_view name) { return StringUtils::IsAsciiTrimmed(name); },
+    &LCENTRY::name));
 
 // Prepare sorted arrays to enable binary search
 

--- a/xbmc/utils/i18n/Iso639_2_Table.h
+++ b/xbmc/utils/i18n/Iso639_2_Table.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "utils/StringUtils.h"
 #include "utils/i18n/Iso639.h"
 
 #include <algorithm>
@@ -529,6 +530,11 @@ constexpr std::array<struct LCENTRY, ISO639_2_COUNT> TableISO639_2ByCode = {{
 
 static_assert(std::ranges::is_sorted(TableISO639_2ByCode, {}, &LCENTRY::code));
 
+static_assert(std::ranges::all_of(
+    TableISO639_2ByCode,
+    [](std::string_view name) { return StringUtils::IsAsciiTrimmed(name); },
+    &LCENTRY::name));
+
 // Additional names for ISO 639-2 codes that have multiple names
 // 79 from the standard, 3 Kodi additions
 static constexpr int ISO639_2_ADDL_NAMES_COUNT = 79 + 3;
@@ -621,6 +627,11 @@ constexpr std::array<struct LCENTRY, ISO639_2_ADDL_NAMES_COUNT> TableISO639_2_Na
 // clang-format on
 
 static_assert(std::ranges::is_sorted(TableISO639_2_Names, {}, &LCENTRY::code));
+
+static_assert(std::ranges::all_of(
+    TableISO639_2_Names,
+    [](std::string_view name) { return StringUtils::IsAsciiTrimmed(name); },
+    &LCENTRY::name));
 
 // 20 pairs of active ISO 639-2/T and /B codes and 2 inactive pairs (deprecated B codes)
 inline static constexpr int ISO639_2_TB_COUNT = 22;

--- a/xbmc/utils/i18n/test/TestIso639_2.cpp
+++ b/xbmc/utils/i18n/test/TestIso639_2.cpp
@@ -79,12 +79,6 @@ TEST(TestI18nIso639_2, LookupByName)
   EXPECT_TRUE(result.has_value());
   EXPECT_EQ(*result, "fin");
 
-  // A name is matched with EqualsNoCase and nothing trims it, so a stray space in the table
-  // leaves the entry unreachable
-  result = CIso639_2::LookupByName("Flemish");
-  EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(*result, "nld");
-
   result = CIso639_2::LookupByName("not a language");
   EXPECT_FALSE(result.has_value());
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Remove unnecessary unit test added by #28857 in favor of compile time validations that the names of languages and countries defined in the ISO tables don't accidentally contain leading or trailing white space.

For now only ASCII white space is checked. Those files may contain UTF-8 encoded unicode characters, more complicated to check. This implementation is enough to catch the data issue corrected by 28857)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The unit test attacked the problem incorrectly - we can't possibly define a unit test for each language and country.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It builds. Reverting the data fix of #28857 for Flemish makes the assert and the build fail, as expected.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

none directly, safeguards future updates of the iso table files.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
