### PR TITLE
[cec] let the screensaver power off devices while playback is paused

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19744,7 +19744,19 @@ msgctxt "#36054"
 msgid "Remote button double press timeout (ms) (0 = off)"
 msgstr ""
 
-#empty strings from id 36055 to 36095
+#. Item list value of setting with label #36009 "Put devices in standby mode when activating the screensaver"
+#: system/peripherals.xml
+msgctxt "#36055"
+msgid "Always"
+msgstr ""
+
+#. Item list value of setting with label #36009 "Put devices in standby mode when activating the screensaver"
+#: system/peripherals.xml
+msgctxt "#36056"
+msgid "Unless media is playing"
+msgstr ""
+
+#empty strings from id 36057 to 36095
 
 #. Label of setting "System / Display / Use system HDR/SDR brightness balance"
 #: system/settings/settings.xml

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -14,7 +14,8 @@
     <setting key="wake_devices" type="enum" value="36037" label="36007" lvalues="36037|36038|36039|231" order="3" />
     <setting key="standby_devices" type="enum" value="36037" label="36008" lvalues="36037|36038|36039|231" order="4" />
     <setting key="send_inactive_source" type="bool" value="1" label="36025" order="5" />
-    <setting key="cec_standby_screensaver" type="bool" value="0" label="36009" order="6" />
+    <setting key="cec_standby_screensaver" type="bool" value="0" label="36009" configurable="0" />
+    <setting key="cec_standby_screensaver_mode" type="enum" value="231" label="36009" order="6" lvalues="231|36055|36056" />
     <setting key="cec_wake_screensaver" type="bool" value="1" label="36010" order="7" />
     <setting key="standby_pc_on_tv_standby" type="enum" value="13011" label="36029" order="8" lvalues="36028|13005|13011|13010|13009|36044|36045" />
     <setting key="standby_tv_on_pc_standby" type="bool" value="1" label="36026" order="9" />

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -62,6 +62,8 @@ using namespace std::chrono_literals;
 #define LOCALISED_ID_RECORDING_DEVICE 36051
 #define LOCALISED_ID_PLAYBACK_DEVICE 36052
 #define LOCALISED_ID_TUNER_DEVICE 36053
+#define LOCALISED_ID_ALWAYS 36055
+#define LOCALISED_ID_UNLESS_PLAYING 36056
 
 #define LOCALISED_ID_NONE 231
 
@@ -135,7 +137,6 @@ void CPeripheralCecAdapter::ResetMembers(void)
   m_bPowerOnScreensaver = false;
   m_bUseTVMenuLanguage = false;
   m_bSendInactiveSource = false;
-  m_bPowerOffScreensaver = false;
   m_bShutdownOnStandby = false;
 
   m_currentButton.iButton = 0;
@@ -179,13 +180,19 @@ void CPeripheralCecAdapter::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
   else if (flag == ANNOUNCEMENT::GUI && sender == CAnnouncementManager::ANNOUNCEMENT_SENDER &&
            message == "OnScreensaverActivated" && m_bIsReady)
   {
-    // Don't put devices to standby if application is currently playing
-    const auto& components = CServiceBroker::GetAppComponents();
-    const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-    if (!appPlayer->IsPlaying() && m_bPowerOffScreensaver)
+    const int iStandbyMode = GetSettingInt("cec_standby_screensaver_mode");
+    if (iStandbyMode != LOCALISED_ID_NONE)
     {
+      // the screensaver doesn't activate while a video is playing, so this mainly keeps the
+      // devices on for audio playback over HDMI. paused playback doesn't count as playing.
+      const auto& components = CServiceBroker::GetAppComponents();
+      const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+      const bool bPlaying = (appPlayer->IsPlayingVideo() || appPlayer->IsPlayingAudio()) &&
+                            !appPlayer->IsPausedPlayback();
+
       // only power off when we're the active source
-      if (m_cecAdapter->IsLibCECActiveSource())
+      if ((iStandbyMode == LOCALISED_ID_ALWAYS || !bPlaying) &&
+          m_cecAdapter->IsLibCECActiveSource())
         StandbyDevices();
     }
   }
@@ -1476,7 +1483,6 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
   // read the boolean settings
   m_bUseTVMenuLanguage = GetSettingBool("use_tv_menu_language");
   m_configuration.bActivateSource = GetSettingBool("activate_source") ? 1 : 0;
-  m_bPowerOffScreensaver = GetSettingBool("cec_standby_screensaver");
   m_bPowerOnScreensaver = GetSettingBool("cec_wake_screensaver");
   m_bSendInactiveSource = GetSettingBool("send_inactive_source");
   m_configuration.bAutoWakeAVR = GetSettingBool("power_avr_on_as") ? 1 : 0;
@@ -1504,6 +1510,14 @@ void CPeripheralCecAdapter::SetConfigurationFromSettings(void)
     // have to be marked as changed
     SetSetting("pause_or_stop_playback_on_deactivate", LOCALISED_ID_PAUSE, false);
     SetSetting("pause_playback_on_deactivate", false, false);
+  }
+
+  if (GetSettingBool("cec_standby_screensaver"))
+  {
+    // migration of a deprecated setting. the new value is read when it's needed, so it doesn't
+    // have to be marked as changed
+    SetSetting("cec_standby_screensaver_mode", LOCALISED_ID_UNLESS_PLAYING, false);
+    SetSetting("cec_standby_screensaver", false, false);
   }
 }
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -208,7 +208,6 @@ private:
   bool m_bPowerOnScreensaver;
   bool m_bUseTVMenuLanguage;
   bool m_bSendInactiveSource;
-  bool m_bPowerOffScreensaver;
   bool m_bShutdownOnStandby;
 };
 


### PR DESCRIPTION
Fixes #28425: with the screensaver set to put devices in standby, a paused video leaves the TV on.

### Why

Kodi lets the screensaver activate on paused playback (`ApplicationPowerHandling.cpp:294` checks `IsPlayingVideo() && !IsPaused()`), but the CEC adapter's guard was `!appPlayer->IsPlaying()`, and `CVideoPlayer::IsPlaying()` is `!m_bStop` — true for a paused video. So the screensaver starts, the adapter declines, and the set stays on. `CECStandby` from `kodi-send` skips the guard entirely, which is why that works for the reporter.

This is not a regression. The guard was added in 6a6e6d405c (2012-03-07) as `!IsPlaying() || IsPaused()` to keep the TV on for **music over HDMI**, and I flipped it to `&&` in a15424bd23 (2012-12-28), which removed the paused case. 45475f7eff (2016) then dropped the `!IsPaused()` term after `IPlayer::IsPaused()` was removed, with no change for paused playback. So the reported behaviour has stood since Frodo.

A straight revert would fix the paused video and break the audio case the guard exists for, so the setting becomes tri-state instead.

### What changed

`cec_standby_screensaver` (bool) is superseded by `cec_standby_screensaver_mode` (enum), the same way `pause_playback_on_deactivate` was superseded by `pause_or_stop_playback_on_deactivate` a few lines up in `peripherals.xml`: the old key stays as `configurable="0"` and is migrated in `SetConfigurationFromSettings()`.

| Value | Behaviour |
| --- | --- |
| *None* (default) | never put devices in standby when the screensaver activates |
| *Always* | always |
| *Unless media is playing* | unless video or audio is playing and not paused |

Paused playback deliberately does not count as playing in the third mode: the video is frozen and the audio is silent by the time the screensaver activates, so there is nothing left to keep the TV on for. That means there is no setting for "power off, but not while paused" — the behaviour on master — which I don't believe has a use case.

### Upgrades

The default is *None*, matching the current default of the boolean, so nothing changes for an install that never enabled it. An install that did have it enabled migrates to *Unless media is playing*, keeping the audio-over-HDMI behaviour and gaining the fix.

### Testing

Compile-tested only; I have no way to hit this on hardware right now. The reporter's debug log in #28425 shows the sequence this addresses: `Player.OnPause` (speed 0) at 21:27:11, `GUI.OnScreensaverActivated` at 21:32:11, and no standby.
