### PR TITLE
[VideoPlayer][DRMPRIME] Set the frame HDR type used by info displays

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -557,6 +557,8 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
             m_pCodecContext->profile == AV_PROFILE_H264_HIGH_10_INTRA))
     pVideoPicture->colorBits = 10;
 
+  pVideoPicture->hdrType = m_hints.hdrType;
+
   pVideoPicture->hasDisplayMetadata = false;
   AVFrameSideData* sd = av_frame_get_side_data(m_pFrame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
   if (sd)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -559,6 +559,19 @@ void CDVDVideoCodecDRMPRIME::SetPictureParams(VideoPicture* pVideoPicture)
 
   pVideoPicture->hdrType = m_hints.hdrType;
 
+  if (pVideoPicture->hdrType == StreamHdrType::HDR_TYPE_HDR10 ||
+      pVideoPicture->hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION)
+  {
+    AVFrameSideData* sd = av_frame_get_side_data(m_pFrame, AV_FRAME_DATA_DYNAMIC_HDR_PLUS);
+    if (sd)
+    {
+      if (pVideoPicture->hdrType == StreamHdrType::HDR_TYPE_HDR10)
+        pVideoPicture->hdrType = StreamHdrType::HDR_TYPE_HDR10PLUS;
+      else
+        pVideoPicture->hdrTypeAlt = StreamHdrType::HDR_TYPE_HDR10PLUS;
+    }
+  }
+
   pVideoPicture->hasDisplayMetadata = false;
   AVFrameSideData* sd = av_frame_get_side_data(m_pFrame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
   if (sd)


### PR DESCRIPTION
## Description

Sets the frame HDR type that info displays read on pictures decoded by CDVDVideoCodecDRMPRIME, matching what CDVDVideoCodecFFmpeg does, including the HDR10 to HDR10+ promotion from frame side data and the alternate type for streams carrying both Dolby Vision and HDR10+. The field was never assigned on this path, and because the player reuses one VideoPicture it held whatever the previous file left behind, so the HDR type labels could disagree or report stale values on DRMPRIME platforms. This does not change what is signalled to the display.

## Motivation and context

Found while working on the frame metadata info labels (see #28896). Standalone fix, no dependency between the two.

## How has this been tested?

Builds clean on Ubuntu 24.04 x86_64. Code-level verification only, as no DRMPRIME-capable hardware was available first hand. Runtime confirmation on RPi or another DRMPRIME platform would be welcome.

## What is the effect on users?

HDR type info labels report correctly on DRMPRIME platforms.

## Types of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the Code Guidelines of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
