### PR TITLE
[GUI] Fix fixedlist Page Up/Down jumps to respect focusposition

### DIFF
--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -574,7 +574,7 @@ bool CGUIBaseContainer::OnMessage(CGUIMessage& message)
       if (message.GetSenderId() == m_pageControl && IsVisible())
       { // update our page if we're visible - not much point otherwise
         if (message.GetParam1() != GetOffset())
-          m_pageChangeTimer.StartZero();
+          StartPageChangeTimer();
         ScrollToOffset(message.GetParam1());
         return true;
       }
@@ -1065,6 +1065,11 @@ void CGUIBaseContainer::UpdatePageControl(int offset)
     SendWindowMessage(msg);
     m_lastPageControlOffset = offset;
   }
+}
+
+void CGUIBaseContainer::StartPageChangeTimer()
+{
+  m_pageChangeTimer.StartZero();
 }
 
 void CGUIBaseContainer::UpdateVisibility(const CGUIListItem *item)

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -123,6 +123,7 @@ protected:
   virtual void UpdateLayout(bool refreshAllItems = false);
   virtual void SetPageControlRange();
   virtual void UpdatePageControl(int offset);
+  void StartPageChangeTimer();
   virtual void CalculateLayout();
   virtual void SelectItem(int item) {}
   virtual bool SelectItemFromPoint(const CPoint& point) { return false; }

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -9,6 +9,7 @@
 #include "GUIFixedListContainer.h"
 
 #include "GUIListItemLayout.h"
+#include "GUIMessage.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 
@@ -48,13 +49,13 @@ bool CGUIFixedListContainer::OnAction(const CAction &action)
   {
   case ACTION_PAGE_UP:
     {
-      Scroll(-GetPageSize());
+      SelectItem(std::max(GetSelectedItem() - GetPageSize(), 0));
       return true;
     }
     break;
   case ACTION_PAGE_DOWN:
     {
-      Scroll(GetPageSize());
+      SelectItem(std::min(GetSelectedItem() + GetPageSize(), static_cast<int>(m_items.size()) - 1));
       return true;
     }
     break;
@@ -87,6 +88,26 @@ bool CGUIFixedListContainer::OnAction(const CAction &action)
     break;
   }
   return CGUIBaseContainer::OnAction(action);
+}
+
+bool CGUIFixedListContainer::OnMessage(CGUIMessage& message)
+{
+  if (message.GetControlId() == GetID() && message.GetMessage() == GUI_MSG_PAGE_CHANGE &&
+      message.GetSenderId() == m_pageControl && IsVisible())
+  {
+    const int maxOffset = std::max(static_cast<int>(GetRows()) - GetPageSize(), 0);
+    const int pageOffset = std::min(std::max(message.GetParam1(), 0), maxOffset);
+    const int currentPageOffset =
+        m_lastPageControlOffset.value_or(std::min(std::max(GetOffset(), 0), maxOffset));
+    const int targetItem = GetSelectedItem() + pageOffset - currentPageOffset;
+    if (pageOffset != currentPageOffset)
+      StartPageChangeTimer();
+    SelectItem(std::min(std::max(targetItem, 0), static_cast<int>(m_items.size()) - 1));
+    m_lastPageControlOffset = pageOffset;
+    return true;
+  }
+
+  return CGUIBaseContainer::OnMessage(message);
 }
 
 bool CGUIFixedListContainer::MoveUp(bool wrapAround)
@@ -266,6 +287,8 @@ void CGUIFixedListContainer::SelectItem(int item)
   // only select an item if it's in a valid range
   if (item >= 0 && item < (int)m_items.size())
   {
+    m_lastPageControlOffset.reset();
+
     // Select the item requested - we first set the cursor position
     // which may be different at either end of the list, then the offset
     int minCursor, maxCursor;
@@ -283,6 +306,18 @@ void CGUIFixedListContainer::SelectItem(int item)
     SetCursor(cursor);
     ScrollToOffset(item - GetCursor());
     MarkDirtyRegion();
+  }
+}
+
+void CGUIFixedListContainer::UpdatePageControl(int offset)
+{
+  const int maxOffset = std::max(static_cast<int>(GetRows()) - GetPageSize(), 0);
+  const int pageOffset = std::min(std::max(offset, 0), maxOffset);
+  if (m_pageControl && m_lastPageControlOffset != pageOffset)
+  {
+    CGUIMessage msg(GUI_MSG_ITEM_SELECT, GetID(), m_pageControl, pageOffset);
+    SendWindowMessage(msg);
+    m_lastPageControlOffset = pageOffset;
   }
 }
 

--- a/xbmc/guilib/GUIFixedListContainer.h
+++ b/xbmc/guilib/GUIFixedListContainer.h
@@ -46,6 +46,7 @@ public:
   CGUIFixedListContainer* Clone() const override { return new CGUIFixedListContainer(*this); }
 
   bool OnAction(const CAction &action) override;
+  bool OnMessage(CGUIMessage& message) override;
 
 protected:
   void Scroll(int amount) override;
@@ -56,6 +57,7 @@ protected:
   bool SelectItemFromPoint(const CPoint &point) override;
   int GetCursorFromPoint(const CPoint &point, CPoint *itemPoint = NULL) const override;
   void SelectItem(int item) override;
+  void UpdatePageControl(int offset) override;
   bool HasNextPage() const override;
   bool HasPreviousPage() const override;
   int GetCurrentPage() const override;

--- a/xbmc/guilib/test/TestGUIFixedListContainer.cpp
+++ b/xbmc/guilib/test/TestGUIFixedListContainer.cpp
@@ -9,6 +9,8 @@
 #include "guilib/GUIFixedListContainer.h"
 #include "guilib/GUIListItem.h"
 #include "guilib/GUIListItemLayout.h"
+#include "guilib/GUIMessage.h"
+#include "guilib/GUIMessageIDs.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 
@@ -64,11 +66,23 @@ public:
   }
 
   int GetPageSizeForTest() const { return GetPageSize(); }
+  int GetOffsetForTest() const { return GetOffset(); }
+  int GetCursorForTest() const { return GetCursor(); }
 
   void PrepareForAction()
   {
     m_wasReset = true;
     CalculatePageSize();
+  }
+
+  void SelectItemForTest(int item) { SelectItem(item); }
+  void SetPageControlForTest(int pageControl) { m_pageControl = pageControl; }
+  void SetPageControlOffsetForTest(int offset) { m_lastPageControlOffset = offset; }
+
+  bool SendPageChangeForTest(int offset)
+  {
+    CGUIMessage message(GUI_MSG_PAGE_CHANGE, m_pageControl, GetID(), offset);
+    return OnMessage(message);
   }
 
 private:
@@ -106,4 +120,53 @@ TEST(TestGUIFixedListContainer, PageActionsSkipPartiallyVisibleSlots)
 
   EXPECT_TRUE(container.OnAction(CAction(ACTION_PAGE_DOWN)));
   EXPECT_EQ(container.GetSelectedItem(), 5);
+}
+
+TEST(TestGUIFixedListContainer, PageControlPreservesStartBoundaryOffset)
+{
+  TestGUIFixedListContainer container(0, 1000, 0, 1000, 100, 100, 5);
+  container.AddItems(20);
+  container.PrepareForAction();
+  container.SetPageControlForTest(10);
+  container.SelectItemForTest(0);
+
+  EXPECT_EQ(container.GetPageSizeForTest(), 10);
+  EXPECT_EQ(container.GetCursorForTest(), 5);
+  EXPECT_EQ(container.GetOffsetForTest(), -5);
+
+  EXPECT_TRUE(container.SendPageChangeForTest(10));
+  EXPECT_EQ(container.GetSelectedItem(), 10);
+}
+
+TEST(TestGUIFixedListContainer, PageControlPreservesEndBoundaryOffset)
+{
+  TestGUIFixedListContainer container(0, 1000, 0, 1000, 100, 100, 5);
+  container.AddItems(20);
+  container.PrepareForAction();
+  container.SetPageControlForTest(10);
+  container.SelectItemForTest(19);
+
+  EXPECT_EQ(container.GetPageSizeForTest(), 10);
+  EXPECT_EQ(container.GetCursorForTest(), 5);
+  EXPECT_EQ(container.GetOffsetForTest(), 14);
+
+  EXPECT_TRUE(container.SendPageChangeForTest(0));
+  EXPECT_EQ(container.GetSelectedItem(), 9);
+}
+
+TEST(TestGUIFixedListContainer, PageControlUsesPreviousControlOffsetForRepeatedPaging)
+{
+  TestGUIFixedListContainer container(0, 1000, 0, 1000, 100, 100, 5);
+  container.AddItems(40);
+  container.PrepareForAction();
+  container.SetPageControlForTest(10);
+  container.SelectItemForTest(0);
+  container.SetPageControlOffsetForTest(0);
+
+  EXPECT_TRUE(container.SendPageChangeForTest(10));
+  EXPECT_EQ(container.GetSelectedItem(), 10);
+  EXPECT_EQ(container.GetOffsetForTest(), 5);
+
+  EXPECT_TRUE(container.SendPageChangeForTest(20));
+  EXPECT_EQ(container.GetSelectedItem(), 20);
 }


### PR DESCRIPTION
## Description
Fix fixedlist page navigation so Page Up/Down and scrollbar/page-control jumps respect the fixed focus position.

Fixedlist controls can use `<focusposition>` together with `<movement>`, `<startmovement>`, or `<endmovement>` so the focused item is positioned differently near the start/end of the list. Page navigation was changing the raw list offset directly, which bypassed the fixedlist item-selection logic that recalculates the cursor and offset together.

This changes fixedlist page navigation to route through `SelectItem()`, keeping the selected item and visual focus position in sync.

## Motivation and context
With a fixedlist using `movement` and `focusposition`, Page Up/Down could focus the expected item but leave it visually in the wrong position until a later Up/Down action corrected the list.

Scrollbar/page-control paging had the same issue because page-change messages were handled as raw offset changes.

This fixes both paths so fixedlist page jumps apply the same focus-position logic as normal item selection.

Fixes https://github.com/xbmc/xbmc/issues/16348

## How has this been tested?
Tested on Windows with a local Debug build.

Tested with Estuary `View_50_List.xml` using `<movement>6</movement>` and `<focusposition>5</focusposition>`.

Verified:
- Keyboard Page Up moves to the expected item and immediately places it at the expected focus position.
- Keyboard Page Down behaves the same.
- Repeated Page Up/Down reaches the first/last item as before.
- Scrollbar/page-control paging also keeps the focused item at the expected fixedlist position.
- A normal `list` control was checked to confirm behaviour is unaffected.

## What is the effect on users?
Fixedlist page navigation now behaves consistently: the focused item and visual focus position update together when paging by keyboard or scrollbar.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed