### PR TITLE
[cec] let the TV handle volume when no amp does

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -14197,7 +14197,9 @@ msgstr ""
 
 #. Value for setting with label #170 "Player / Videos / Adjust display refresh rate"
 #. Value for setting with label #36098 "System / Display / Use 10 bit for SDR"
+#. Value for setting with label #36057 "Send volume commands over CEC"
 #: system/settings/settings.xml
+#: system/peripherals.xml
 msgctxt "#20422"
 msgid "Always"
 msgstr ""
@@ -19758,7 +19760,19 @@ msgctxt "#36056"
 msgid "Unless media is playing"
 msgstr ""
 
-#empty strings from id 36057 to 36095
+#. Label of CEC setting volume_control: whether Kodi's volume keys adjust the volume of the amplifier or TV over CEC instead of Kodi's own mixer
+#: system/peripherals.xml
+msgctxt "#36057"
+msgid "Send volume commands over CEC"
+msgstr ""
+
+#. Item list value of setting with label #36057 "Send volume commands over CEC": send them to an amplifier, or to a TV that reports CEC 2.0
+#: system/peripherals.xml
+msgctxt "#36058"
+msgid "Automatic"
+msgstr ""
+
+#empty strings from id 36059 to 36095
 
 #. Label of setting "System / Display / Use system HDR/SDR brightness balance"
 #: system/settings/settings.xml

--- a/system/peripherals.xml
+++ b/system/peripherals.xml
@@ -26,15 +26,16 @@
     <setting key="cec_hdmi_port" type="int" value="1" min="1" max="15" label="36015" order="13" />
     <setting key="physical_address" type="string" label="36021" value="0" order="14" />
     <setting key="power_avr_on_as" type="bool" label="36046" value="0" order="15" />
+    <setting key="volume_control" type="enum" value="36058" label="36057" lvalues="231|36058|20422" order="16" />
 
     <setting key="tv_vendor" type="int" value="0" configurable="0" />
     <setting key="device_name" type="string" value="Kodi" configurable="0" />
     <setting key="wake_devices_advanced" type="string" value="" configurable="0" />
     <setting key="standby_devices_advanced" type="string" value="" configurable="0" />
-    <setting key="double_tap_timeout_ms" type="int" min="0" max="1000" step="50" value="0" label="36054" order="16" />
-    <setting key="button_repeat_rate_ms" type="int" min="0" max="250" step="10" value="0" label="36048" order="17" />
-    <setting key="button_release_delay_ms" type="int" min="0" max="500" step="50" value="0" label="36049" order="18" />
-    <setting key="device_type" type="enum" value="36051" label="36013" lvalues="36051|36052|36053" order="19" />
+    <setting key="double_tap_timeout_ms" type="int" min="0" max="1000" step="50" value="0" label="36054" order="17" />
+    <setting key="button_repeat_rate_ms" type="int" min="0" max="250" step="10" value="0" label="36048" order="18" />
+    <setting key="button_release_delay_ms" type="int" min="0" max="500" step="50" value="0" label="36049" order="19" />
+    <setting key="device_type" type="enum" value="36051" label="36013" lvalues="36051|36052|36053" order="20" />
     <setting key="appearance" type="addon" addontype="kodi.game.controller" value="game.controller.cec.adapter" configurable="0"/>
   </peripheral>
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.cpp
@@ -68,6 +68,7 @@ using namespace std::chrono_literals;
 #define LOCALISED_ID_TUNER_DEVICE 36053
 #define LOCALISED_ID_ALWAYS 36055
 #define LOCALISED_ID_UNLESS_PLAYING 36056
+#define LOCALISED_ID_VOLUME_ALWAYS 20422
 
 #define LOCALISED_ID_NONE 231
 
@@ -119,7 +120,8 @@ void CPeripheralCecAdapter::ResetMembers(void)
   m_bStarted = false;
   m_bHasButton = false;
   m_bIsReady = false;
-  m_bAmpControlsVolume = false;
+  m_volumeTarget = CECDEVICE_UNKNOWN;
+  m_tvVolumeTarget = CECDEVICE_UNKNOWN;
   m_strMenuLanguage = "???";
   m_lastKeypress = {};
   m_lastChange = VOLUME_CHANGE_NONE;
@@ -485,23 +487,33 @@ void CPeripheralCecAdapter::Process(void)
 
 bool CPeripheralCecAdapter::HasAudioControl(void)
 {
-  std::unique_lock lock(m_critSection);
-  return m_bAmpControlsVolume;
+  return GetVolumeTarget() != CECDEVICE_UNKNOWN;
 }
 
-void CPeripheralCecAdapter::SetAmpControlsVolume(bool bSetTo)
+cec_logical_address CPeripheralCecAdapter::GetVolumeTarget(void)
+{
+  std::unique_lock lock(m_critSection);
+  return m_volumeTarget;
+}
+
+void CPeripheralCecAdapter::SetVolumeTarget(cec_logical_address address)
 {
   {
     std::unique_lock lock(m_critSection);
-    if (m_bAmpControlsVolume == bSetTo)
+    if (m_volumeTarget == address)
       return;
   }
 
-  /* hand Kodi's volume over before the amp takes it: from that point on a mute keypress is
-     forwarded to the amp rather than clearing Kodi's own mute, which would leave Kodi muted
+  CLog::Log(LOGDEBUG, "{} - volume will be controlled {}", __FUNCTION__,
+            address == CECDEVICE_AUDIOSYSTEM ? "on the amp"
+            : address == CECDEVICE_TV        ? "on the TV"
+                                             : "by Kodi");
+
+  /* hand Kodi's volume over before the target takes it: from that point on a mute keypress is
+     forwarded over CEC rather than clearing Kodi's own mute, which would leave Kodi muted
      with no way to unmute it. setting the volume to maximum lets Kodi pass its audio through
-     unchanged, so the amp is the only thing attenuating it */
-  if (bSetTo)
+     unchanged, so the target is the only thing attenuating it */
+  if (address != CECDEVICE_UNKNOWN)
   {
     auto& components = CServiceBroker::GetAppComponents();
     const auto appVolume = components.GetComponent<CApplicationVolumeHandling>();
@@ -510,21 +522,45 @@ void CPeripheralCecAdapter::SetAmpControlsVolume(bool bSetTo)
   }
 
   std::unique_lock lock(m_critSection);
-  m_bAmpControlsVolume = bSetTo;
+  m_volumeTarget = address;
+}
+
+cec_logical_address CPeripheralCecAdapter::GetTvVolumeTarget(void)
+{
+  std::unique_lock lock(m_critSection);
+  return m_tvVolumeTarget;
+}
+
+void CPeripheralCecAdapter::SetTvVolumeTarget(cec_logical_address address)
+{
+  std::unique_lock lock(m_critSection);
+  m_tvVolumeTarget = address;
+}
+
+void CPeripheralCecAdapter::SetAmpControlsVolume(bool bSetTo)
+{
+  /* the setting rules the amp out even while it has system audio mode on */
+  const bool bToAmp = bSetTo && GetSettingInt("volume_control") != LOCALISED_ID_NONE;
+  SetVolumeTarget(bToAmp ? CECDEVICE_AUDIOSYSTEM : GetTvVolumeTarget());
 }
 
 void CPeripheralCecAdapter::SetAmpMuted(bool bSetTo)
 {
   std::unique_lock lock(m_critSection);
-  m_bIsMuted = bSetTo;
+  /* the mute state belongs to whichever device handles volume, so leave it alone while the amp
+     reports one it is not acting on */
+  if (m_volumeTarget == CECDEVICE_AUDIOSYSTEM)
+    m_bIsMuted = bSetTo;
 }
 
 void CPeripheralCecAdapter::ProcessVolumeChange(void)
 {
   bool bSendRelease(false);
   CecVolumeChange pendingVolumeChange = VOLUME_CHANGE_NONE;
+  cec_logical_address target = CECDEVICE_UNKNOWN;
   {
     std::unique_lock lock(m_critSection);
+    target = m_volumeTarget;
     auto now = std::chrono::steady_clock::now();
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - m_lastKeypress);
     if (!m_volumeChangeQueue.empty())
@@ -565,16 +601,20 @@ void CPeripheralCecAdapter::ProcessVolumeChange(void)
     }
   }
 
+  /* the target can be cleared while changes are queued, so drain the queue but send nothing */
+  if (target == CECDEVICE_UNKNOWN)
+    return;
+
   switch (pendingVolumeChange)
   {
     case VOLUME_CHANGE_UP:
-      m_cecAdapter->SendKeypress(CECDEVICE_AUDIOSYSTEM, CEC_USER_CONTROL_CODE_VOLUME_UP, false);
+      m_cecAdapter->SendKeypress(target, CEC_USER_CONTROL_CODE_VOLUME_UP, false);
       break;
     case VOLUME_CHANGE_DOWN:
-      m_cecAdapter->SendKeypress(CECDEVICE_AUDIOSYSTEM, CEC_USER_CONTROL_CODE_VOLUME_DOWN, false);
+      m_cecAdapter->SendKeypress(target, CEC_USER_CONTROL_CODE_VOLUME_DOWN, false);
       break;
     case VOLUME_CHANGE_MUTE:
-      m_cecAdapter->SendKeypress(CECDEVICE_AUDIOSYSTEM, CEC_USER_CONTROL_CODE_MUTE, false);
+      m_cecAdapter->SendKeypress(target, CEC_USER_CONTROL_CODE_MUTE, false);
       {
         std::unique_lock lock(m_critSection);
         m_bIsMuted = !m_bIsMuted;
@@ -582,7 +622,7 @@ void CPeripheralCecAdapter::ProcessVolumeChange(void)
       break;
     case VOLUME_CHANGE_NONE:
       if (bSendRelease)
-        m_cecAdapter->SendKeyRelease(CECDEVICE_AUDIOSYSTEM, false);
+        m_cecAdapter->SendKeyRelease(target, false);
       break;
   }
 }
@@ -1704,9 +1744,34 @@ void CPeripheralCecAdapterUpdateThread::UpdateMenuLanguage(void)
   }
 }
 
+void CPeripheralCecAdapterUpdateThread::UpdateTvVolumeTarget(void)
+{
+  const int iVolumeControl = m_adapter->GetSettingInt("volume_control");
+  cec_logical_address target = CECDEVICE_UNKNOWN;
+
+  if (iVolumeControl != LOCALISED_ID_NONE)
+  {
+    /* CEC 2.0 is the first version that requires a TV to act on volume commands. TVs that report
+       an older version are only addressed when the user opted in. */
+    const cec_version version = m_adapter->m_cecAdapter->GetDeviceCecVersion(CECDEVICE_TV);
+    if (version >= CEC_VERSION_2_0 || iVolumeControl == LOCALISED_ID_VOLUME_ALWAYS)
+      target = CECDEVICE_TV;
+    else
+      CLog::Log(LOGDEBUG,
+                "{} - the TV reports CEC version {}, which does not require it to act on volume "
+                "commands",
+                __FUNCTION__, m_adapter->m_cecAdapter->ToString(version));
+  }
+
+  m_adapter->SetTvVolumeTarget(target);
+}
+
 std::string CPeripheralCecAdapterUpdateThread::UpdateAudioSystemStatus(void)
 {
   std::string strAmpName;
+
+  /* the TV takes over whenever the amp is not handling volume, so settle on it first */
+  UpdateTvVolumeTarget();
 
   if (!m_adapter->m_cecAdapter->IsActiveDeviceType(CEC_DEVICE_TYPE_AUDIO_SYSTEM))
   {
@@ -1721,21 +1786,17 @@ std::string CPeripheralCecAdapterUpdateThread::UpdateAudioSystemStatus(void)
 
 #if CEC_LIB_HAS_SYSTEM_AUDIO_MODE_STATUS
   /* an amp only acts on volume keypresses while system audio mode is on. handing it the volume
-     while it is off leaves the user with no working volume control at all, since CEC 1.4b has no
-     way to change the volume anywhere else. */
+     while it is off leaves the user with no working volume control at all. */
   if (m_adapter->m_cecAdapter->SystemAudioModeStatus() != CEC_SYSTEM_AUDIO_STATUS_ON)
   {
-    CLog::Log(LOGDEBUG,
-              "{} - CEC capable amplifier found ({}), but system audio mode is off. volume will be "
-              "controlled by Kodi",
+    CLog::Log(LOGDEBUG, "{} - CEC capable amplifier found ({}), but system audio mode is off",
               __FUNCTION__, ampName);
     m_adapter->SetAmpControlsVolume(false);
     return strAmpName;
   }
 #endif
 
-  CLog::Log(LOGDEBUG, "{} - CEC capable amplifier found ({}). volume will be controlled on the amp",
-            __FUNCTION__, ampName);
+  CLog::Log(LOGDEBUG, "{} - CEC capable amplifier found ({})", __FUNCTION__, ampName);
 
   m_adapter->SetAmpControlsVolume(true);
 

--- a/xbmc/peripherals/devices/PeripheralCecAdapter.h
+++ b/xbmc/peripherals/devices/PeripheralCecAdapter.h
@@ -162,11 +162,20 @@ private:
   void GetNextKey(void);
 
   /*!
-   * @brief Move volume control between the amp and Kodi.
-   * @param bSetTo True to let the amp handle volume and mute, false to keep them in Kodi.
+   * @brief Move volume control to a device on the bus, or back to Kodi.
+   * @param address The device that handles volume and mute, CECDEVICE_UNKNOWN for Kodi's own mixer.
    *
-   * Unmutes Kodi and sets its volume to maximum when the amp takes over, so that all attenuation
+   * Unmutes Kodi and sets its volume to maximum when a device takes over, so that all attenuation
    * happens in one place. Does nothing when control is already where it is asked to be.
+   */
+  void SetVolumeTarget(CEC::cec_logical_address address);
+  CEC::cec_logical_address GetVolumeTarget(void);
+  void SetTvVolumeTarget(CEC::cec_logical_address address);
+  CEC::cec_logical_address GetTvVolumeTarget(void);
+  /*!
+   * @brief Move volume control between the amp and whatever handles it in the amp's absence.
+   * @param bSetTo True to let the amp handle volume and mute, false to hand them to the TV, or to
+   *               Kodi when the TV is not expected to act on them.
    */
   void SetAmpControlsVolume(bool bSetTo);
   void SetAmpMuted(bool bSetTo);
@@ -189,8 +198,12 @@ private:
   bool m_bStarted;
   bool m_bHasButton;
   bool m_bIsReady;
-  /* set while an amp is present and has system audio mode on: it, not Kodi, handles volume */
-  bool m_bAmpControlsVolume;
+  /* device that receives volume and mute commands, or CECDEVICE_UNKNOWN when Kodi's own mixer
+     handles them */
+  CEC::cec_logical_address m_volumeTarget;
+  /* CECDEVICE_TV while the TV is expected to act on volume commands, so that it can take over
+     whenever no amp handles them. CECDEVICE_UNKNOWN leaves those to Kodi's own mixer */
+  CEC::cec_logical_address m_tvVolumeTarget;
   std::string m_strMenuLanguage;
   CDateTime m_standbySent;
   std::vector<CecButtonPress> m_buttonQueue;
@@ -232,6 +245,7 @@ public:
 
 protected:
   void UpdateMenuLanguage(void);
+  void UpdateTvVolumeTarget(void);
   std::string UpdateAudioSystemStatus(void);
   bool WaitReady(void);
   bool SetInitialConfiguration(void);


### PR DESCRIPTION
## Description

Lets Kodi's volume keys control the TV over CEC when there is no amplifier on the bus, instead of falling back to Kodi's own mixer.

`HasAudioControl()` no longer means "an amp is connected" but "some CEC device takes volume", backed by a new `m_volumeTarget` holding `CECDEVICE_AUDIOSYSTEM`, `CECDEVICE_TV` or `CECDEVICE_UNKNOWN`. Every existing caller — `CPeripherals::OnAction`, `ToggleMute`, `IsMuted` — keeps working unchanged, so no new action IDs and nothing outside the CEC adapter had to move.

The target is picked in `UpdateAudioSystemStatus()`, which already runs on the initial configuration and on every configuration update, so changing the setting re-evaluates it through the existing `OnSettingChanged` path.

New setting `volume_control`, default *Automatic*:

| Value | Behaviour |
| --- | --- |
| None | Never send volume over CEC — Kodi's own mixer, as today without an amp |
| Automatic | The amp if one is present, otherwise the TV if it reports CEC 2.0 |
| Always | The amp if one is present, otherwise the TV regardless of the version it reports |

CEC 2.0 is the first version that requires a TV to act on `<User Control Pressed>` volume commands, so the version the TV reports is what the default keys off. It is discovered with `GetDeviceCecVersion()`, which uses `<Get CEC Version>` — a CEC 1.4 opcode, so no CEC 2.0 support is needed in libCEC. *Always* covers TVs that honour volume commands without reporting 2.0.

Unmuting Kodi and pinning its volume to maximum, which previously happened only when an amp was found, now happens for whichever target is chosen and is skipped when volume stays with Kodi.

## Motivation and Context

Implements the request in https://forum.kodi.tv/showthread.php?tid=211527.

Supersedes #18521, which took a different approach: it added dedicated `ACTION_CEC_VOLUME_UP` / `ACTION_CEC_VOLUME_DOWN` actions. Those are not needed — `ACTION_VOLUME_UP` already reaches `CPeripherals::OnAction()` ahead of Kodi's global volume handling — and that PR kept the `HasAudioControl()` gate, so it did not change anything for the setup the forum request is about.

## How Has This Been Tested?

Not yet runtime tested; it compiles clean. Testing wanted on:
- an amp on the bus — behaviour should be unchanged
- a TV reporting CEC 2.0, no amp — volume keys should reach the TV
- a TV reporting CEC 1.4, no amp — volume keys should stay with Kodi on *Automatic* and reach the TV on *Always*

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Notes for reviewers

- The default changes behaviour for existing users with no amp and a CEC 2.0 TV: volume moves from Kodi's mixer to the TV, and Kodi is pinned to 100%. Happy to default to *None* if opt-in is preferred.
- Audio on a non-HDMI output (S/PDIF, USB) with HDMI video is the case this does not handle: volume keys drive a TV that is not rendering the audio, and *None* is the only way out. The amp path has always had the same flaw, so I kept the two consistent rather than fixing one half.
- Mute state is tracked locally and flipped on send. Nothing reconciles it with a TV that disagrees.
- #28855 reworks the same functions and conflicts with this; whichever lands first, the other gets rebased on top.
- New strings take 36055/36056. #28892 claims the same IDs, so one of the two will need renumbering.
