### PR TITLE
[MUSIC][AUDIOBOOKS] Add the nero Chpl atom reader back to audiobooks

### DIFF
--- a/xbmc/filesystem/AudioBookFileDirectory.cpp
+++ b/xbmc/filesystem/AudioBookFileDirectory.cpp
@@ -25,6 +25,7 @@
 #include "resources/ResourcesComponent.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/Mp4ChplReader.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -156,6 +157,35 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url, CFileItemList& items
 
   float chapter_size = 0;
   bool chapter_error = false;
+
+  ChplChapterResult neroChapterResult{chplNone};
+  std::vector<ChplChapter> nero;
+
+  if (m_fctx->nb_chapters > 1)
+  {
+
+    if (isAudioBook)
+    {
+      neroChapterResult = CChplChapterReader::ScanNeroChapters(url, nero);
+      if (neroChapterResult.IsError())
+      {
+        CLog::Log(LOGERROR,
+                  "AudioBookFileDirectory: Error scanning for Nero style chapters in file {}. The "
+                  "error returned was {}",
+                  url.GetRedacted(), *neroChapterResult.errorMessage);
+      }
+      else if (neroChapterResult.IsNone())
+      { // can't get here without some form of chapter so must be QT style chapters (chap atom)
+        CLog::Log(
+            LOGDEBUG,
+            "AudioBookFileDirectory: Scanned for nero style chapters but didn't find any in {}, "
+            "using QT chapters",
+            url.GetRedacted());
+      }
+    }
+  }
+    const size_t ns = nero.size();
+
   for (unsigned int i = 0; m_fctx->chapters && i < m_fctx->nb_chapters; ++i)
   {
     if (!m_fctx->chapters[i] || m_fctx->chapters[i]->start < 0) // null or negative start time
@@ -191,6 +221,9 @@ bool CAudioBookFileDirectory::GetDirectory(const CURL& url, CFileItemList& items
           chapauthor = tag->value;
         else if (StringUtils::CompareNoCase(tag->key, "album") == 0)
           chapalbum = tag->value;
+        // Prefer nero titles if we have them over QT titles and they are different
+        if (neroChapterResult.IsFound() && (i < ns) && (nero[i].title != chaptitle))
+          chaptitle = nero[i].title;
       }
       item->GetMusicInfoTag()->SetTitle(chaptitle);
       item->GetMusicInfoTag()->SetAlbum(chapalbum.empty() ? album.empty() ? title : album


### PR DESCRIPTION
## Description
As it says, this PR adds back the Nero CHPL atom reader for m4b files (actually any QT style file) to `CAudioBookFileDirectory.cpp`

## Motivation and context
No idea why it was removed in the first place.  It seems to have been dropped in the re-factor to use the Taglib Matroska tag reader,  but I have a lot of audiobooks where the chapters are much better titled in the CHPL atom rather than the standard QT version. Most likely an accidental change in the original PR.

## How has this been tested?
Built it locally on top of Kodi's master branch.  Verified that the result matched expectations.

## What is the effect on users?
Audiobook users will have better descriptive titles shown in Kodi, if they exist in their books and they aren't the same as the standard QT titles.

## Screenshots (if appropriate):

Without the CHPL reader
<img width="1920" height="1080" alt="Without nero reader" src="https://github.com/user-attachments/assets/3afd8d5a-ae56-4131-a511-057b4c4ab093" />

With the CHPL reader
<img width="1920" height="1080" alt="With nero reader" src="https://github.com/user-attachments/assets/adba6ec4-10f1-4b73-9700-cf46c4a3cfb0" />


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X All new and existing tests passed
