### PR TITLE
[MUSIC] Allow for a chapter that both starts and ends at zero

### DIFF
--- a/xbmc/music/tags/MusicInfoTagLoaderMatroska.cpp
+++ b/xbmc/music/tags/MusicInfoTagLoaderMatroska.cpp
@@ -469,7 +469,8 @@ void CMusicInfoTagLoaderMatroska::GetMatroskaMusicTags(
           // Skip micro chapters less than 1 second long
           long long durationNs = std::abs(static_cast<long long>(chapter.timeEnd()) -
                                           static_cast<long long>(chapter.timeStart()));
-          if (durationNs < 1000000000LL)
+          bool isFirstChapter = (chapter.timeStart() == 0 && chapter.timeEnd() == 0);
+          if (durationNs < 1000000000LL && !isFirstChapter)
             continue;
 
           std::string chapterName;


### PR DESCRIPTION
## Description
The Matroska reader, as written, will skip the first chapter in a file as the start time is necessarily zero and the end times are often not set.  This can be seen later on in the code where the actual end time is calculated from the start time of the next chapter.

## Motivation and context
I used the scanner to scan in some of my music concerts and in some cases, the first chapter(song) was missing entirely.  Investigation proved that this occurs because the first chapter starts at 0 and if the end times for the chapters are not set (this is often the case) then it appears, at this part of the code, that the chapter is zero seconds long and so it is skipped.  The actual length is calculated later and is correct, but the check here stops the chapter being added to the vector in the first place.

## How has this been tested?
Ran it before and after against an mp4 file where all the chapter end times are zero.  Without this extra check, the first chapter is missing.

## What is the effect on users?
The first chapter will be correctly added.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
