### PR TITLE
Add exts to adv settings, don't try to re-scan chaptered music files

### DIFF
--- a/xbmc/filesystem/FileDirectoryFactory.cpp
+++ b/xbmc/filesystem/FileDirectoryFactory.cpp
@@ -297,7 +297,7 @@ IFileDirectory* CFileDirectoryFactory::Create(const CURL& url, CFileItem* pItem,
     // .mkv doubles as a video container — only treat a chaptered .mkv as an
     // audiobook when browsed from a Music source, or a chaptered movie in a
     // Video source would be expanded into chapter items.
-    if (strExtension == ".mkv" && !IsUnderMusicSource(url.Get()))
+    if ((strExtension == ".mkv" || strExtension == ".mp4") && !IsUnderMusicSource(url.Get()))
       return nullptr;
 
     // Already-expanded chapter rows (have a music tag and a positive end offset)

--- a/xbmc/music/MusicFileItemClassify.cpp
+++ b/xbmc/music/MusicFileItemClassify.cpp
@@ -57,8 +57,8 @@ bool IsAudio(const CFileItem& item)
 
 bool IsAudioBook(const CFileItem& item)
 {
-  return item.IsType(".m4b") || item.IsType(".mka") ||
-         (item.IsType(".mkv") && item.HasMusicInfoTag());
+  return (item.IsType(".m4b") || item.IsType(".mka") ||
+         item.IsType(".mkv") || item.IsType(".mp4"));
 }
 
 bool IsCDDA(const CFileItem& item)

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -604,6 +604,10 @@ CInfoScanner::InfoRet CMusicInfoScanner::ScanTags(const CFileItemList& items,
 
     m_currentItem++;
 
+    bool keepTags = false;
+    if (items.GetURL().HasExtension(".mkv|.mp4|.mka|.m4b"))
+      keepTags = true;
+
     CMusicInfoTag& tag = *pItem->GetMusicInfoTag();
     // Forced rescan must re-read tags from disk even if the item arrives with
     // tag.Loaded() already true (e.g. DB-enriched directory listings). The
@@ -611,7 +615,7 @@ CInfoScanner::InfoRet CMusicInfoScanner::ScanTags(const CFileItemList& items,
     // skip, but without this check ScanTags would still reuse cached tag
     // state on a per-file basis, defeating "Do full tag scan even when
     // unchanged".
-    if (!tag.Loaded() || (m_flags & SCAN_RESCAN))
+    if (!tag.Loaded() || ((m_flags & SCAN_RESCAN) && !keepTags))
     {
       std::unique_ptr<IMusicInfoTagLoader> pLoader (CMusicInfoTagLoaderFactory::CreateLoader(*pItem));
       if (nullptr != pLoader)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -516,7 +516,7 @@ void CAdvancedSettings::Initialize()
 
   m_pictureExtensions =
       ".png|.jpg|.jpeg|.bmp|.gif|.ico|.tif|.tiff|.tga|.pcx|.cbz|.zip|.rss|.webp|.jp2|.apng|.avif|.heif|.heic";
-  m_musicExtensions = ".b4s|.nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.gdm|.imf|.m15|.sfx|.uni|.ac3|.dts|.cue|.aif|.aiff|.wpl|.xspf|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.wv|.dsp|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.wtv|.mka|.tak|.opus|.dff|.dsf|.m4b|.dtshd";
+  m_musicExtensions = ".b4s|.nsv|.m4a|.flac|.aac|.strm|.pls|.rm|.rma|.mpa|.wav|.wma|.ogg|.mp3|.mp2|.m3u|.gdm|.imf|.m15|.sfx|.uni|.ac3|.dts|.cue|.aif|.aiff|.wpl|.xspf|.ape|.mac|.mpc|.mp+|.mpp|.shn|.zip|.wv|.dsp|.xsp|.xwav|.waa|.wvs|.wam|.gcm|.idsp|.mpdsp|.mss|.spt|.rsd|.sap|.cmc|.cmr|.dmc|.mpt|.mpd|.rmt|.tmc|.tm8|.tm2|.oga|.url|.pxml|.tta|.rss|.wtv|.mka|.tak|.opus|.dff|.dsf|.m4b|.dtshd|.mkv|.mp4";
   m_videoExtensions = ".m4v|.3g2|.3gp|.nsv|.tp|.ts|.ty|.strm|.pls|.rm|.rmvb|.mpd|.m3u|.m3u8|.ifo|.mov|.qt|.divx|.xvid|.bivx|.vob|.nrg|.img|.iso|.udf|.pva|.wmv|.asf|.asx|.ogm|.m2v|.avi|.bin|.dat|.mpg|.mpeg|.mp4|.mkv|.mk3d|.avc|.vp3|.svq3|.nuv|.viv|.dv|.fli|.flv|.001|.wpl|.xspf|.zip|.vdr|.dvr-ms|.xsp|.mts|.m2t|.m2ts|.evo|.ogv|.sdp|.avs|.rec|.url|.pxml|.vc1|.h264|.rcv|.rss|.mpls|.mpl|.webm|.bdmv|.bdm|.wtv|.trp|.f4v";
   m_subtitlesExtensions = ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.text|.ssa|.aqt|.jss|."
                           "ass|.vtt|.idx|.ifo|.zip|.sup";


### PR DESCRIPTION
## Description
This PR corrects several issues with chaptered music files.

## Motivation and context
Firstly, if the correct music extensions (mkv, mp4) are not added to `AdvancedSettings.cpp` then the music infoscanner will never scan chaptered music files (concerts etc) as `GetDirectory()` won't recognise the file as a valid music file.  Solution is to add ".mkv|.mp4" to the settings.  There are already guards in place to ensure that such files fall within a music source so as not to affect the video side of things.

Secondly, the logic for re-scanning files if the user selects "scan anyway, regardless of the files not changing" is correct for files that contain a single set of tags (such as a .flac file or an .mp3) but not correct for a chaptered file (such as .m4b or .mka) as the current logic will call `CMusicInfoTagLoaderMatroska::Load()`.  That returns a full set of tags for the file but the infoscanner is expecting exactly one set of tags.  The outcome is that the correctly tagged items (as prepared by `CAudioBookFileDirectory.cpp` are now over-written by the first set of tags in the file.  This means we end up with x amount of tracks all with the same name and the same duration.  If we are scanning or navigating via "files" then the tags will have been read by `CAudioBookFileDirectory.cpp` anyway.  I habitually click 'yes' on that dialog so this flagged itself quite quickly.

Thirdly, having allowed mp4 as a music extension, we have to make sure it sits under a music source.

Finally, the check for `isAudioBook()` (which isn't really just audiobook anymore!) needs the `HasMusicInfoTag()` check removing as it prevents actually scanning any of those file extensions into the music library.  An item can't have a tag until after it's been opened and the current logic was preventing that.

## How has this been tested?
Tested locally against multiple concerts, audiobooks and music files to ensure the scanner is triggered correctly, and that the song listings are correct.

## What is the effect on users?
Stuff scans in as expected.  mp4 and mkv concerts work, along with mka albums and m4b audiobooks.

## Screenshots (if appropriate):
Concerts, albums and audiobooks all living nicely together!

<img width="1920" height="1080" alt="concerts-audiobook-albums" src="https://github.com/user-attachments/assets/d643365a-0736-4c59-adf2-d907d148999c" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
