### PR TITLE
windowing/gbm: ignore a vblank timestamp the kernel could not determine 

### DIFF
--- a/xbmc/windowing/gbm/VideoSyncGbm.cpp
+++ b/xbmc/windowing/gbm/VideoSyncGbm.cpp
@@ -123,6 +123,11 @@ void CVideoSyncGbm::Run(CEvent& stopEvent)
     if (sequence == m_sequence)
       continue;
 
+    // Zero is how the kernel marks a timestamp it could not determine
+    // e.g. during a modeset
+    if (ns == 0)
+      continue;
+
     m_refClock->UpdateClock(sequence - m_sequence, MonotonicToHostCounter(ns));
     m_sequence = sequence;
   }

--- a/xbmc/windowing/gbm/VideoSyncGbm.cpp
+++ b/xbmc/windowing/gbm/VideoSyncGbm.cpp
@@ -92,8 +92,8 @@ bool CVideoSyncGbm::Setup()
     return false;
   }
 
-  CLog::Log(LOGINFO, "CVideoSyncGbm::{}: opened (fd:{} crtc:{} seq:{} ns:{}:{})", __FUNCTION__,
-            m_fd, m_crtcId, m_sequence, ns, MonotonicToHostCounter(ns));
+  CLog::Log(LOGINFO, "CVideoSyncGbm::{}: opened (fd:{} crtc:{} seq:{} ns:{})", __FUNCTION__, m_fd,
+            m_crtcId, m_sequence, ns);
   return true;
 }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
drmCrtcGetSequence() can succeed and hand back a sequence_ns of zero. Zero
is not a time: drm_reset_vblank_timestamp() uses it to mark the timestamp
invalid when the scanout position cannot be read while vblank is being
enabled for a modeset.

Skip the sample. m_sequence is deliberately left alone so the vblanks it
covers are counted against the next timestamp that can be used, rather
than being lost.
## Motivation and context
https://github.com/xbmc/xbmc/pull/28844#issuecomment-5232820396

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Pi5 with "sync playback to display enabled"
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
