### PR TITLE
fixed: initialize the remote interfaces before activating the first window

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -665,9 +665,10 @@ bool CApplication::Initialize()
 
   const auto skinHandling = GetComponent<CApplicationSkinHandling>();
 
-  bool uiInitializationFinished = false;
+  const bool guiCreated = CServiceBroker::GetGUI()->GetWindowManager().Initialized();
+  bool uiInitializationFinished = !guiCreated;
 
-  if (CServiceBroker::GetGUI()->GetWindowManager().Initialized())
+  if (guiCreated)
   {
     const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
@@ -743,6 +744,22 @@ bool CApplication::Initialize()
     // because we need a real window in the background which gets
     // rendered while we load the main window or enter the master lock key
     CServiceBroker::GetGUI()->GetWindowManager().ActivateWindow(WINDOW_SPLASH);
+  }
+
+  // Must stay above the window activation below: that can raise a modal dialog, whose nested
+  // render loop reaches anything after it only once the dialog has been dismissed.
+  CJSONRPC::Initialize();
+
+  CServiceBroker::RegisterSpeechRecognition(speech::ISpeechRecognition::CreateInstance());
+
+  if (!m_ServiceManager->InitStageThree(profileManager))
+  {
+    CLog::Log(LOGERROR, "Application - Init3 failed");
+  }
+
+  if (guiCreated)
+  {
+    const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
     if (settings->GetBool(CSettings::SETTING_MASTERLOCK_STARTUPLOCK) &&
         profileManager->GetMasterProfile().getLockMode() != LockMode::EVERYONE &&
@@ -771,19 +788,6 @@ bool CApplication::Initialize()
       // the startup window is considered part of the initialization as it most likely switches to the final window
       uiInitializationFinished = firstWindow != WINDOW_STARTUP_ANIM;
     }
-  }
-  else //No GUI Created
-  {
-    uiInitializationFinished = true;
-  }
-
-  CJSONRPC::Initialize();
-
-  CServiceBroker::RegisterSpeechRecognition(speech::ISpeechRecognition::CreateInstance());
-
-  if (!m_ServiceManager->InitStageThree(profileManager))
-  {
-    CLog::Log(LOGERROR, "Application - Init3 failed");
   }
 
   g_sysinfo.Refresh();


### PR DESCRIPTION
## Description

Activating the configured start window can raise a modal dialog — the master lock prompt, or "No PVR add-on enabled" when the start window is a PVR window. `CGUIDialog::Open_Internal` runs its own render loop, so `CApplication::Initialize` did not reach `CJSONRPC::Initialize` or `CServiceManager::InitStageThree` until the dialog was dismissed.

The JSON-RPC servers themselves start from a queued `TMSG_NETWORKMESSAGE` that the nested loop does still pump, so a remote could connect — and was then answered `Method not found` (-32601) for every call it made, including the `Input.Select` that would have dismissed the dialog. CEC, started in stage three, did not come up at all. The dialog could only be answered from a locally attached keyboard or mouse.

Both initializations now run above the activation.

Making the PVR dialog non-blocking instead was considered and not done: it would leave the same hole open for the master lock prompt and for whatever dialog a skin's start window raises.

### What else moves with stage three

`InitStageThree` is not only the peripherals. Optical media detection, `CGameServices`, the context menu manager, `CPVRManager::Init()` (when not on the login screen), the player core factory and `CPlatform::InitStageThree` now all complete before the start window is activated and before the master lock prompt.

`CPVRManager::Init()` only submits a `PRIORITY_DEDICATED` job, so its ordering against the window activation was never deterministic; the activation still follows microseconds later, while client creation takes seconds.

The other consequence worth naming: if the master lock is failed down to `masterlock.maxretries`, Kodi now shuts down with those services already started. `DeinitStageThree` is guarded on `init_level`, so teardown is unaffected.

## Motivation and context

Fixes #28905.

## How has this been tested?

Portable Windows build, start window set to "TV guide", no PVR add-on enabled.

Before, from the log of a single run, the JSON-RPC socket was listening 17 ms after the dialog opened, but the method table and the CEC bus only appeared 88 seconds later — immediately after the dialog was dismissed at the keyboard. After, both are up before the dialog can appear; with the dialog up, `JSONRPC.Ping` answers `pong`, `GUI.GetProperties` reports the OK dialog as the current window, and `Input.Select` dismisses it, after which Kodi falls back to Home and initialization completes.

Full gtest suite: 3752 passed, 0 failed. `clang-format` clean on the touched lines.

## What is the effect on users?

A modal dialog raised by the start window, or the master lock prompt, can now be answered from a remote (CEC, JSON-RPC, EventServer) instead of only from a keyboard or mouse attached to the device.

## Screenshots (if appropriate):

n/a

## Types of change

* [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

* [x] My code follows the Code Guidelines of this project
* [x] My change requires a change to the documentation — no
* [x] I have read the CONTRIBUTING document
* [x] I have added tests to cover my changes — `CApplication::Initialize` has no test harness; verified against the running application as above
* [x] All new and existing tests passed
