### PR TITLE
fixed: script add-on arguments lost to a second parse, and an inert Addons.ExecuteAddon wait parameter

### DIFF
--- a/xbmc/interfaces/builtins/AddonBuiltins.cpp
+++ b/xbmc/interfaces/builtins/AddonBuiltins.cpp
@@ -104,6 +104,9 @@ static int RunPlugin(const std::vector<std::string>& params)
   return 0;
 }
 
+template<bool OnlyApple = false>
+static int RunScript(const std::vector<std::string>& params);
+
 /*! \brief Run a script, plugin or game add-on.
  *  \param params The parameters.
  *  \details params[0] = add-on id.
@@ -172,10 +175,10 @@ static int RunAddon(const std::vector<std::string>& params)
              CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, AddonType::SCRIPT_LIBRARY,
                                                     OnlyEnabled::CHOICE_YES))
     {
-      // Pass the script name (addonid) and all the parameters
-      // (params[1] ... params[x]) separated by a comma to RunScript
-      CBuiltins::GetInstance().Execute(
-          StringUtils::Format("RunScript({})", StringUtils::Join(params, ",")));
+      // RunScript takes the vector as it stands. Routing it through a builtin string would
+      // re-parse it with CUtil::SplitParams, which ends a parameter at any comma not inside
+      // quotes.
+      RunScript(params);
     }
     else if (CServiceBroker::GetAddonMgr().GetAddon(addonid, addon, AddonType::GAMEDLL,
                                                     OnlyEnabled::CHOICE_YES))
@@ -221,7 +224,7 @@ static int RunAddon(const std::vector<std::string>& params)
  *           Set the OnlyApple template parameter to true to only attempt
  *           execution of applescripts.
  */
-template<bool OnlyApple=false>
+template<bool OnlyApple>
 static int RunScript(const std::vector<std::string>& params)
 {
 #if defined(TARGET_DARWIN_OSX)

--- a/xbmc/interfaces/json-rpc/AddonsExecuteAddon.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsExecuteAddon.cpp
@@ -30,7 +30,7 @@ std::string BuildArguments(const CVariant& params)
       {
         argv += ",";
       }
-      argv += it->first + "=" + it->second.asString();
+      argv += StringUtils::Paramify(it->first + "=" + it->second.asString());
     }
   }
   else if (params.isArray())

--- a/xbmc/interfaces/json-rpc/AddonsExecuteAddon.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsExecuteAddon.cpp
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "AddonsExecuteAddon.h"
+
+#include "utils/StringUtils.h"
+#include "utils/Variant.h"
+
+#include <string>
+
+namespace JSONRPC
+{
+
+namespace
+{
+std::string BuildArguments(const CVariant& params)
+{
+  std::string argv;
+
+  if (params.isObject())
+  {
+    for (CVariant::const_iterator_map it = params.begin_map(); it != params.end_map(); ++it)
+    {
+      if (it != params.begin_map())
+      {
+        argv += ",";
+      }
+      argv += it->first + "=" + it->second.asString();
+    }
+  }
+  else if (params.isArray())
+  {
+    for (CVariant::const_iterator_array it = params.begin_array(); it != params.end_array(); ++it)
+    {
+      if (it != params.begin_array())
+      {
+        argv += ",";
+      }
+      argv += StringUtils::Paramify(it->asString());
+    }
+  }
+  else if (params.isString())
+  {
+    if (!params.empty())
+    {
+      argv = StringUtils::Paramify(params.asString());
+    }
+  }
+
+  return argv;
+}
+} // unnamed namespace
+
+ParsedExecuteAddon ParseExecuteAddonParams(const CVariant& parameterObject)
+{
+  const std::string id = parameterObject["addonid"].asString();
+  const CVariant& params = parameterObject["params"];
+
+  ParsedExecuteAddon parsed;
+  parsed.wait = parameterObject["wait"].asBoolean();
+
+  const std::string argv = BuildArguments(params);
+  if (params.empty())
+  {
+    parsed.command = StringUtils::Format("RunAddon({})", id);
+  }
+  else
+  {
+    parsed.command = StringUtils::Format("RunAddon({}, {})", id, argv);
+  }
+
+  return parsed;
+}
+
+} // namespace JSONRPC

--- a/xbmc/interfaces/json-rpc/AddonsExecuteAddon.h
+++ b/xbmc/interfaces/json-rpc/AddonsExecuteAddon.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+
+class CVariant;
+
+namespace JSONRPC
+{
+
+struct ParsedExecuteAddon
+{
+  std::string command;
+  bool wait{false};
+};
+
+/*! \brief Build the RunAddon builtin that Addons.ExecuteAddon executes.
+
+ Every parameter is quoted with StringUtils::Paramify: CUtil::SplitParams ends a parameter
+ at any comma not inside quotes. The object form quotes the whole "key=value" pair, so a
+ comma in either half is covered.
+
+ The add-on id is not validated here; the caller resolves it against the add-on manager first.
+
+ \param parameterObject the JSON-RPC parameters, with schema defaults already applied
+ \return the builtin to execute, and whether the caller asked to wait for it
+ */
+ParsedExecuteAddon ParseExecuteAddonParams(const CVariant& parameterObject);
+
+} // namespace JSONRPC

--- a/xbmc/interfaces/json-rpc/AddonsOperations.cpp
+++ b/xbmc/interfaces/json-rpc/AddonsOperations.cpp
@@ -8,6 +8,7 @@
 
 #include "AddonsOperations.h"
 
+#include "AddonsExecuteAddon.h"
 #include "JSONUtils.h"
 #include "ServiceBroker.h"
 #include "TextureCache.h"
@@ -182,42 +183,18 @@ JSONRPC_STATUS CAddonsOperations::ExecuteAddon(const std::string &method, ITrans
       addon->Type() >= AddonType::MAX_TYPES)
     return InvalidParams;
 
-  std::string argv;
-  CVariant params = parameterObject["params"];
-  if (params.isObject())
-  {
-    for (CVariant::const_iterator_map it = params.begin_map(); it != params.end_map(); ++it)
-    {
-      if (it != params.begin_map())
-        argv += ",";
-      argv += it->first + "=" + it->second.asString();
-    }
-  }
-  else if (params.isArray())
-  {
-    for (CVariant::const_iterator_array it = params.begin_array(); it != params.end_array(); ++it)
-    {
-      if (it != params.begin_array())
-        argv += ",";
-      argv += StringUtils::Paramify(it->asString());
-    }
-  }
-  else if (params.isString())
-  {
-    if (!params.empty())
-      argv = StringUtils::Paramify(params.asString());
-  }
+  const ParsedExecuteAddon parsed = ParseExecuteAddonParams(parameterObject);
 
-  std::string cmd;
-  if (params.empty())
-    cmd = StringUtils::Format("RunAddon({})", id);
+  if (parsed.wait)
+  {
+    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
+                                               parsed.command);
+  }
   else
-    cmd = StringUtils::Format("RunAddon({}, {})", id, argv);
-
-  if (params["wait"].asBoolean())
-    CServiceBroker::GetAppMessenger()->SendMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
-  else
-    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr, cmd);
+  {
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
+                                               parsed.command);
+  }
 
   return ACK;
 }

--- a/xbmc/interfaces/json-rpc/CMakeLists.txt
+++ b/xbmc/interfaces/json-rpc/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES AddonsOperations.cpp
+set(SOURCES AddonsExecuteAddon.cpp
+            AddonsOperations.cpp
             ApplicationOperations.cpp
             AudioLibrary.cpp
             DatabaseOperations.cpp
@@ -21,7 +22,8 @@ set(SOURCES AddonsOperations.cpp
             VideoLibrarySetSourceContent.cpp
             XBMCOperations.cpp)
 
-set(HEADERS AddonsOperations.h
+set(HEADERS AddonsExecuteAddon.h
+            AddonsOperations.h
             ApplicationOperations.h
             AudioLibrary.h
             DatabaseOperations.h

--- a/xbmc/interfaces/json-rpc/test/CMakeLists.txt
+++ b/xbmc/interfaces/json-rpc/test/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES TestJSONRPCPermission.cpp
+set(SOURCES TestAddonsExecuteAddon.cpp
+            TestJSONRPCPermission.cpp
             TestJSONRPCStatus.cpp
             TestVideoLibrarySetSourceContent.cpp)
 

--- a/xbmc/interfaces/json-rpc/test/TestAddonsExecuteAddon.cpp
+++ b/xbmc/interfaces/json-rpc/test/TestAddonsExecuteAddon.cpp
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "interfaces/json-rpc/AddonsExecuteAddon.h"
+#include "utils/ExecString.h"
+#include "utils/Variant.h"
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace JSONRPC;
+
+namespace
+{
+constexpr const char* ADDON_ID = "script.toolbox";
+
+CVariant MakeRequest(const CVariant& params)
+{
+  CVariant request(CVariant::VariantTypeObject);
+  request["addonid"] = ADDON_ID;
+  request["params"] = params;
+  request["wait"] = false;
+
+  return request;
+}
+
+CVariant ObjectParams(const std::string& key, const std::string& value)
+{
+  CVariant params(CVariant::VariantTypeObject);
+  params[key] = value;
+
+  return params;
+}
+
+/*! \brief The arguments the add-on actually receives.
+
+ CBuiltins::Execute parses the command through CExecString, so what reaches the add-on is the
+ result of that split rather than the command string itself.
+ */
+std::vector<std::string> ArgumentsSeenByTheAddon(const std::string& command)
+{
+  const CExecString exec(command);
+  EXPECT_TRUE(exec.IsValid()) << command;
+
+  return exec.GetParams();
+}
+} // unnamed namespace
+
+TEST(TestExecuteAddonParams, NoParamsGivesTheBareBuiltin)
+{
+  CVariant request(CVariant::VariantTypeObject);
+  request["addonid"] = ADDON_ID;
+  request["params"] = "";
+  request["wait"] = false;
+
+  EXPECT_EQ("RunAddon(script.toolbox)", ParseExecuteAddonParams(request).command);
+}
+
+TEST(TestExecuteAddonParams, ObjectParamsBecomeKeyValueArguments)
+{
+  CVariant params(CVariant::VariantTypeObject);
+  params["info"] = "builtin";
+  params["id"] = "ReloadSkin()";
+
+  const std::vector<std::string> argv =
+      ArgumentsSeenByTheAddon(ParseExecuteAddonParams(MakeRequest(params)).command);
+
+  ASSERT_EQ(3U, argv.size());
+  EXPECT_EQ(ADDON_ID, argv[0]);
+  // CVariant orders an object's members by key, so "id" precedes "info".
+  EXPECT_EQ("id=ReloadSkin()", argv[1]);
+  EXPECT_EQ("info=builtin", argv[2]);
+}
+
+TEST(TestExecuteAddonParams, WaitIsReadFromTheDeclaredTopLevelParameter)
+{
+  CVariant request = MakeRequest(ObjectParams("info", "builtin"));
+  request["wait"] = true;
+
+  EXPECT_TRUE(ParseExecuteAddonParams(request).wait);
+}
+
+TEST(TestExecuteAddonParams, WaitDefaultsToNotWaiting)
+{
+  EXPECT_FALSE(ParseExecuteAddonParams(MakeRequest(ObjectParams("info", "builtin"))).wait);
+}
+
+TEST(TestExecuteAddonParams, AWaitKeyInsideParamsIsJustAnAddonArgument)
+{
+  const ParsedExecuteAddon parsed =
+      ParseExecuteAddonParams(MakeRequest(ObjectParams("wait", "true")));
+
+  EXPECT_FALSE(parsed.wait);
+
+  const std::vector<std::string> argv = ArgumentsSeenByTheAddon(parsed.command);
+  ASSERT_EQ(2U, argv.size());
+  EXPECT_EQ("wait=true", argv[1]);
+}

--- a/xbmc/interfaces/json-rpc/test/TestAddonsExecuteAddon.cpp
+++ b/xbmc/interfaces/json-rpc/test/TestAddonsExecuteAddon.cpp
@@ -79,6 +79,37 @@ TEST(TestExecuteAddonParams, ObjectParamsBecomeKeyValueArguments)
   EXPECT_EQ("info=builtin", argv[2]);
 }
 
+TEST(TestExecuteAddonParams, ACommaInAnObjectValueStaysInOneArgument)
+{
+  const std::vector<std::string> argv = ArgumentsSeenByTheAddon(
+      ParseExecuteAddonParams(MakeRequest(ObjectParams("title", "Peaches, Herb"))).command);
+
+  ASSERT_EQ(2U, argv.size());
+  EXPECT_EQ(ADDON_ID, argv[0]);
+  EXPECT_EQ("title=Peaches, Herb", argv[1]);
+}
+
+TEST(TestExecuteAddonParams, AQuoteInAnObjectValueStaysInOneArgument)
+{
+  const std::vector<std::string> argv = ArgumentsSeenByTheAddon(
+      ParseExecuteAddonParams(MakeRequest(ObjectParams("quote", "say \"hi\", then go"))).command);
+
+  ASSERT_EQ(2U, argv.size());
+  EXPECT_EQ("quote=say \"hi\", then go", argv[1]);
+}
+
+TEST(TestExecuteAddonParams, ACommaInAnArrayValueStaysInOneArgument)
+{
+  CVariant params(CVariant::VariantTypeArray);
+  params.push_back("Peaches, Herb");
+
+  const std::vector<std::string> argv =
+      ArgumentsSeenByTheAddon(ParseExecuteAddonParams(MakeRequest(params)).command);
+
+  ASSERT_EQ(2U, argv.size());
+  EXPECT_EQ("Peaches, Herb", argv[1]);
+}
+
 TEST(TestExecuteAddonParams, WaitIsReadFromTheDeclaredTopLevelParameter)
 {
   CVariant request = MakeRequest(ObjectParams("info", "builtin"));


### PR DESCRIPTION
**TL;DR:** Bug fix. A script add-on's arguments were re-serialised and parsed a second time, so any value with a comma split in two; `Addons.ExecuteAddon` read its `wait` parameter from the wrong object and never escaped object-form `params`. All three are fixed, with eight tests. `JSONRPC_VERSION` 13.16.0 -> 13.16.1.

## Description
Three defects in the path from the `RunAddon` builtin to a Python script's `sys.argv`. They were found together, they overlap in the same fifteen lines, and they share a test, so they travel as one branch.

### 1. A script add-on's arguments are corrupted by a second parse

`RunAddon` resolved the add-on, then re-serialised its already-parsed parameter vector into a `RunScript(...)` string for `CBuiltins::Execute` to parse again. `CUtil::SplitParams` ends a parameter at any comma not inside quotes, and the re-serialisation quotes nothing, so a value containing a comma reached the script as two arguments — the second no longer attributable to any name.

`RunScript` already takes the vector, so it is now called directly. Nothing is serialised, so there is nothing to quote and no second parse to survive. Every caller benefits: keymap entries, skin `<onclick>` handlers and `Addons.ExecuteAddon` all arrive here.

The plugin branch above re-serialises the same way, but `RunPlugin` reads only `params[0]`, so its remaining arguments are discarded either way and it is left alone.

### 2. `Addons.ExecuteAddon` never consulted its `wait` parameter

The method declares `addonid`, `params` and `wait`, but the handler read `wait` out of the `params` object rather than from the parameters themselves. The blocking branch was unreachable through the documented API and the method always answered before the add-on had done anything, while a caller who happened to pass a `wait` key inside `params` got the blocking behaviour plus a spurious `wait=` argument handed to the add-on.

The receiver changed from the parameter object to the params object in 9e9396b073, which split `ExecBuiltIn` into `SendMsg` and `PostMsg`; nothing else in that commit touched this method, so the parameter has been inert since Kodi 16.

### 3. `Addons.ExecuteAddon` did not escape object-form `params`

The array and string forms of `params` were escaped with `StringUtils::Paramify` before being formatted into the builtin; the object form was concatenated raw, so the same comma problem applied before the value ever reached `RunAddon`. The object form is the one the method's own documentation shows, so this is the common path rather than a corner.

The assembled `key=value` pair is quoted rather than the value alone, so a comma in the key is covered as well. `SplitParams` strips the surrounding quotes again on the way out, so a caller whose keys and values contain none of these characters sees no change.

### Notes for review

- The parameter handling moves into `ParseExecuteAddonParams` so it can be tested without the add-on manager or the application messenger. The handler still resolves the add-on id itself, because that needs neither.
- The JSON-RPC interface had no test directory, so this adds one. **Heads-up:** #28882 also creates `xbmc/interfaces/json-rpc/test/`, so whichever of the two merges second will need a trivial rebase.
- `JSONRPC_VERSION` 13.16.0 -> 13.16.1. The schema is unaltered and no method signature changes; each method now simply does what it already declared. Happy to make it a minor bump instead if that is preferred for a behaviour change.

## Motivation and context
A script add-on launched from a keymap, a skin or JSON-RPC with an argument containing a comma received it as two arguments, and the documented `wait` parameter of `Addons.ExecuteAddon` did nothing.

## How has this been tested?
Eight new unit tests. They assert on the arguments *after* `CExecString` has parsed the emitted builtin, because the command string alone would not show whether a value survives the split.

Full test suite green.

Also verified against a running Kodi, with a script add-on that logs its own `sys.argv`, driven over the JSON-RPC TCP interface:

```
[argvprobe] argc=2 argv=['default.py', 'title=Peaches, Herb']
[argvprobe] argc=2 argv=['default.py', 'quote=say "hi", then go']
[argvprobe] argc=2 argv=['default.py', 'info=builtin']
```

The first two are single arguments that previously split. The third is a call with `wait: true` at the top level, which no longer leaks a `wait=true` argument to the add-on.

## What is the effect on users?
Script add-ons receive their arguments intact whatever characters they contain, and JSON-RPC clients that pass `wait: true` to `Addons.ExecuteAddon` get an answer once the add-on has finished.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
