### PR TITLE
windowing/gbm: fix OnLostDevice() reentrant Unregister() UB

### DIFF
--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -369,9 +369,23 @@ void CWinSystemGbm::OnLostDevice()
   CLog::Log(LOGDEBUG, "{} - notify display change event", __FUNCTION__);
   m_dispReset = true;
 
-  std::unique_lock lock(m_resourceSection);
-  for (auto resource : m_resources)
+  // OnLostDisplay() may cause resources to be unregistered, so don't iterate
+  // the live vector while callbacks are being dispatched.
+  std::vector<IDispResource*> resources;
+  {
+    std::unique_lock lock(m_resourceSection);
+    resources = m_resources;
+  }
+
+  for (auto resource : resources)
+  {
+    {
+      std::unique_lock lock(m_resourceSection);
+      if (find(m_resources.begin(), m_resources.end(), resource) == m_resources.end())
+        continue;
+    }
     resource->OnLostDisplay();
+  }
 }
 
 std::unique_ptr<CVideoSync> CWinSystemGbm::GetVideoSync(CVideoReferenceClock* clock)


### PR DESCRIPTION
## Description
CWinSystemGbm::OnLostDevice() iterates directly over m_resources while holding m_resourceSection.

IDispResource::OnLostDisplay() invokes arbitrary client code. During the callback, a resource can be destroyed synchronously as a side effect. Its destructor may call CWinSystemGbm::Unregister(), which erases the resource from m_resources while OnLostDevice() is still iterating the vector.

Although m_resourceSection is recursive and therefore does not deadlock in this situation, modifying the vector during the range-based iteration results in undefined behaviour.

Fix this by taking a snapshot of the registered resources before dispatching callbacks. Before invoking each callback, verify that the resource is still registered, since it may have been unregistered by an earlier callback.

## Motivation and context
This is a Claude finding. It fixed a crash when I was testing https://github.com/xbmc/xbmc/pull/28784 

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
