### PR TITLE
Fix inconsistent subtitle tracks order and subtitle actions

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21792,16 +21792,16 @@ msgctxt "#36446"
 msgid "Sorted"
 msgstr ""
 
-#. Name of the setting of the stream display order in the stream selection screen and the OSD
+#. Name of the setting of the stream order in the stream selection screen and the OSD for video files
 #: system/settings/settings.xml
 msgctxt "#36447"
-msgid "Stream display order"
+msgid "Video file stream display order"
 msgstr ""
 
-#. Description of setting with label #36447 "Stream display order"
+#. Description of setting with label #36447 "Video file stream display order"
 #: system/settings/settings.xml
 msgctxt "#36448"
-msgid "Display order of the audio, video and subtitle streams. [Media] stream order in the media, [Sorted] sorted using the stream attributes"
+msgid "Video files only: display order in the stream selection dialogs. [Media] stream order in the media, [Sorted] sorted using the stream attributes[CR]"
 msgstr ""
 
 #empty strings from id 36449 to 36459

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -21786,7 +21786,25 @@ msgctxt "#36445"
 msgid "Select this option to allow using double refresh rates (playing 29.97 FPS video on a 59.94 Hz monitor or playing 30 FPS video on a 60 Hz monitor). You may want to use this option if your monitor doesn't have a 29.97 Hz or 30 Hz mode."
 msgstr ""
 
-#empty strings from id 36446 to 36459
+#. Value of the track order settings #36448 #36450 #36452
+#: system/settings/settings.xml
+msgctxt "#36446"
+msgid "Sorted"
+msgstr ""
+
+#. Name of the setting of the stream display order in the stream selection screen and the OSD
+#: system/settings/settings.xml
+msgctxt "#36447"
+msgid "Stream display order"
+msgstr ""
+
+#. Description of setting with label #36447 "Stream display order"
+#: system/settings/settings.xml
+msgctxt "#36448"
+msgid "Display order of the audio, video and subtitle streams. [Media] stream order in the media, [Sorted] sorted using the stream attributes"
+msgstr ""
+
+#empty strings from id 36449 to 36459
 
 #. Description of settings with label #14112 "Enable event logging"
 #: system/settings/settings.xml

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -309,19 +309,6 @@
           <control type="toggle" />
         </setting>
       </group>
-      <group id="6" label="128">
-        <setting id="videoplayer.streamdisplayorder" type="integer" label="36447" help="36448">
-          <level>2</level>
-          <default>0</default>
-          <constraints>
-            <options>
-              <option label="14211">0</option> <!-- media -->
-              <option label="36446">1</option> <!-- sorted -->
-            </options>
-          </constraints>
-          <control type="spinner" format="integer" />
-        </setting>
-      </group>
     </category>
     <category id="musicplayer" label="14216" help="38104">
       <group id="1" label="14230">
@@ -965,7 +952,20 @@
       </group>
     </category>
     <category id="advanced" label="14187" help="38113">
-      <group id="1" label="14188">
+      <group id="1" label="128">
+        <setting id="videoplayer.filestreamdisplayorder" type="integer" label="36447" help="36448">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="14211">0</option> <!-- media -->
+              <option label="36446">1</option> <!-- sorted -->
+            </options>
+          </constraints>
+          <control type="spinner" format="integer" />
+        </setting>
+      </group>
+      <group id="2" label="14188">
         <setting id="videoplayer.queuetimesize" type="integer" label="37130" help="37131">
           <level>2</level>
           <default>40</default> <!-- 4.0 s -->

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -309,6 +309,19 @@
           <control type="toggle" />
         </setting>
       </group>
+      <group id="6" label="128">
+        <setting id="videoplayer.streamdisplayorder" type="integer" label="36447" help="36448">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <options>
+              <option label="14211">0</option> <!-- media -->
+              <option label="36446">1</option> <!-- sorted -->
+            </options>
+          </constraints>
+          <control type="spinner" format="integer" />
+        </setting>
+      </group>
     </category>
     <category id="musicplayer" label="14216" help="38104">
       <group id="1" label="14230">

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -143,6 +143,7 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_CONVERTDOVI = "videoplayer.convertdovi";
   static constexpr auto SETTING_VIDEOPLAYER_ALLOWEDHDRFORMATS = "videoplayer.allowedhdrformats";
   static constexpr auto SETTING_VIDEOPLAYER_DOVIZEROLEVEL5 = "videoplayer.dovizerolevel5";
+  static constexpr auto SETTING_VIDEOPLAYER_STREAMDISPLAYORDER = "videoplayer.streamdisplayorder";
   static constexpr auto SETTING_VIDEOPLAYER_QUEUETIMESIZE = "videoplayer.queuetimesize";
   static constexpr auto SETTING_VIDEOPLAYER_QUEUEDATASIZE = "videoplayer.queuedatasize";
   static constexpr auto SETTING_MYVIDEOS_SELECTACTION = "myvideos.selectaction";

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -143,7 +143,8 @@ public:
   static constexpr auto SETTING_VIDEOPLAYER_CONVERTDOVI = "videoplayer.convertdovi";
   static constexpr auto SETTING_VIDEOPLAYER_ALLOWEDHDRFORMATS = "videoplayer.allowedhdrformats";
   static constexpr auto SETTING_VIDEOPLAYER_DOVIZEROLEVEL5 = "videoplayer.dovizerolevel5";
-  static constexpr auto SETTING_VIDEOPLAYER_STREAMDISPLAYORDER = "videoplayer.streamdisplayorder";
+  static constexpr auto SETTING_VIDEOPLAYER_FILESTREAMDISPLAYORDER =
+      "videoplayer.filestreamdisplayorder";
   static constexpr auto SETTING_VIDEOPLAYER_QUEUETIMESIZE = "videoplayer.queuetimesize";
   static constexpr auto SETTING_VIDEOPLAYER_QUEUEDATASIZE = "videoplayer.queuedatasize";
   static constexpr auto SETTING_MYVIDEOS_SELECTACTION = "myvideos.selectaction";

--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES Bookmark.cpp
             FilenameAttributes.cpp
             GUIViewStateVideo.cpp
             PlayerController.cpp
+            PlayerControllerActions.cpp
             SetInfoTag.cpp
             Teletext.cpp
             VideoDatabase.cpp
@@ -28,6 +29,7 @@ set(HEADERS Bookmark.h
             FilenameAttributes.h
             GUIViewStateVideo.h
             PlayerController.h
+            PlayerControllerActions.h
             SetInfoTag.h
             Teletext.h
             TeletextDefines.h

--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES Bookmark.cpp
             VideoInfoTag.cpp
             VideoItemArtworkHandler.cpp
             VideoLibraryQueue.cpp
+            VideoStreamSelect.cpp
             VideoThumbLoader.cpp
             VideoUtils.cpp
             ViewModeSettings.cpp)
@@ -42,6 +43,7 @@ set(HEADERS Bookmark.h
             VideoInfoTag.h
             VideoItemArtworkHandler.h
             VideoLibraryQueue.h
+            VideoStreamSelect.h
             VideoThumbLoader.h
             VideoUtils.h
             VideoManagerTypes.h

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -31,9 +31,12 @@
 #include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
+#include "video/VideoStreamSelect.h"
 #include "video/dialogs/GUIDialogAudioSettings.h"
 #include "video/guilib/VideoStreamSelectHelper.h"
 #include "windowing/WinSystem.h"
+
+#include <algorithm>
 
 using namespace KODI;
 using namespace UTILS;
@@ -117,54 +120,68 @@ bool CPlayerController::OnAction(const CAction &action)
         if (appPlayer->GetSubtitleCount() == 0)
           return true;
 
-        int currentSub = appPlayer->GetSubtitle();
-        bool currentSubVisible = true;
+        using namespace KODI::VIDEO;
+        const std::vector<SubtitleStreamInfoExt> streams =
+            CVideoStreamSelect::GetSubtitleStreams(appPlayer.get());
+
+        // Find the current logical sub track from the internal id
+        const int currentStreamId = appPlayer->GetSubtitle();
+        auto it = std::ranges::find(streams, currentStreamId, &SubtitleStreamInfoExt::streamId);
+        if (it == streams.end())
+          return true;
+
+        bool subVisible = true;
 
         if (appPlayer->GetSubtitleVisible())
         {
-          currentSub += (action.GetID() == ACTION_PREV_SUBTITLE) ? -1 : 1;
-          if (currentSub < 0 || currentSub >= appPlayer->GetSubtitleCount())
+          int delta = action.GetID() == ACTION_PREV_SUBTITLE ? -1 : 1;
+
+          // The position before begin() is UB. Clamp.
+          if (it == streams.begin() && delta < 0)
+            subVisible = false;
+          else
+            std::advance(it, delta);
+
+          if (it == streams.end())
           {
-            currentSub = 0;
+            it = streams.begin();
             if (action.GetID() != ACTION_CYCLE_SUBTITLE)
-            {
-              appPlayer->SetSubtitleVisible(false);
-              currentSubVisible = false;
-            }
+              subVisible = false;
           }
-          appPlayer->SetSubtitle(currentSub);
+
+          if (!subVisible)
+            appPlayer->SetSubtitleVisible(false);
+          if (currentStreamId != it->streamId)
+            appPlayer->SetSubtitle(it->streamId);
         }
         else if (action.GetID() != ACTION_CYCLE_SUBTITLE)
         {
-          if (currentSub == 0 && action.GetID() == ACTION_PREV_SUBTITLE)
+          if (it == streams.begin() && action.GetID() == ACTION_PREV_SUBTITLE)
           {
-            currentSub = appPlayer->GetSubtitleCount() - 1;
-            appPlayer->SetSubtitle(currentSub);
+            it = std::prev(streams.end());
+            if (currentStreamId != it->streamId)
+              appPlayer->SetSubtitle(it->streamId);
           }
           appPlayer->SetSubtitleVisible(true);
         }
 
-        std::string sub, lang;
-        if (currentSubVisible)
+        std::string sub;
+        if (subVisible)
         {
-          SubtitleStreamInfo info;
-          appPlayer->GetSubtitleStreamInfo(currentSub, info);
-          if (!g_LangCodeExpander.Lookup(info.language, lang))
-            lang =
-                CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
+          sub = it->languageDesc;
 
-          if (info.name.empty())
-            sub = lang;
-          else
-            sub = StringUtils::Format("{} - {}", lang, info.name);
+          if (!it->name.empty())
+            sub += " - " + it->name;
 
-          if (!info.codecDesc.empty())
-            sub.append(StringUtils::Format(" ({})", info.codecDesc));
-          else if (!info.codecName.empty())
-            sub.append(StringUtils::Format(" ({})", info.codecName));
+          if (!it->codecDesc.empty())
+            sub += " (" + it->codecDesc + ")";
+          else if (!it->codecName.empty())
+            sub += " (" + it->codecName + ")";
         }
         else
+        {
           sub = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1223);
+        }
 
         CGUIDialogKaiToast::QueueNotification(
             CGUIDialogKaiToast::Info,
@@ -268,27 +285,31 @@ bool CPlayerController::OnAction(const CAction &action)
         if (appPlayer->GetAudioStreamCount() == 1)
           return true;
 
-        int currentAudio = appPlayer->GetAudioStream();
-        int audioStreamCount = appPlayer->GetAudioStreamCount();
+        using namespace KODI::VIDEO;
+        const std::vector<AudioStreamInfoExt> streams =
+            CVideoStreamSelect::GetAudioStreams(appPlayer.get());
 
-        if (++currentAudio >= audioStreamCount)
-          currentAudio = 0;
-        appPlayer->SetAudioStream(currentAudio); // Set the audio stream to the one selected
+        // Find the current logical sub track from the internal id
+        const int currentStreamId = appPlayer->GetAudioStream();
+        auto it = std::ranges::find(streams, currentStreamId, &AudioStreamInfoExt::streamId);
+        if (it == streams.end())
+          return true;
+        const int currentIndex = static_cast<int>(std::distance(streams.begin(), it));
 
-        std::string lan;
-        AudioStreamInfo info;
-        appPlayer->GetAudioStreamInfo(currentAudio, info);
-        if (!g_LangCodeExpander.Lookup(info.language, lan))
-          lan = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
+        const int newIndex = (currentIndex + 1) % streams.size();
 
-        std::string textInfo = lan;
-        if (!info.name.empty())
-          textInfo += " - " + info.name;
-        if (!info.codecDesc.empty())
-          textInfo += " (" + info.codecDesc + ")";
+        it = streams.begin() + newIndex;
+        appPlayer->SetAudioStream(it->streamId);
+
+        // Toast
+        std::string textInfo = it->languageDesc;
+        if (!it->name.empty())
+          textInfo += " - " + it->name;
+        if (!it->codecDesc.empty())
+          textInfo += " (" + it->codecDesc + ")";
 
         std::string caption = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(460);
-        caption += StringUtils::Format(" ({}/{})", currentAudio + 1, audioStreamCount);
+        caption += StringUtils::Format(" ({}/{})", newIndex + 1, streams.size());
         CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, caption, textInfo,
                                               DisplTime, false, MsgTime);
         return true;
@@ -305,18 +326,28 @@ bool CPlayerController::OnAction(const CAction &action)
         if (appPlayer->GetVideoStreamCount() == 1)
           return true;
 
-        int currentVideo = appPlayer->GetVideoStream();
-        int videoStreamCount = appPlayer->GetVideoStreamCount();
+        using namespace KODI::VIDEO;
+        const std::vector<VideoStreamInfoExt> streams =
+            CVideoStreamSelect::GetVideoStreams(appPlayer.get());
 
-        if (++currentVideo >= videoStreamCount)
-          currentVideo = 0;
-        appPlayer->SetVideoStream(currentVideo);
-        VideoStreamInfo info;
-        appPlayer->GetVideoStreamInfo(currentVideo, info);
+        // Find the current logical sub track from the internal id
+        const int currentStreamId = appPlayer->GetVideoStream();
+        auto it = std::ranges::find(streams, currentStreamId, &VideoStreamInfoExt::streamId);
+        if (it == streams.end())
+          return true;
+        const int currentIndex = static_cast<int>(std::distance(streams.begin(), it));
+
+        const int newIndex = (currentIndex + 1) % streams.size();
+
+        it = streams.begin() + newIndex;
+        appPlayer->SetVideoStream(it->streamId);
+
+        // Toast
         std::string caption =
             CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(38031);
-        caption += StringUtils::Format(" ({}/{})", currentVideo + 1, videoStreamCount);
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, caption, info.name, DisplTime, false, MsgTime);
+        caption += StringUtils::Format(" ({}/{})", newIndex + 1, streams.size());
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, caption, it->name,
+                                              DisplTime, false, MsgTime);
         return true;
       }
 

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -31,6 +31,7 @@
 #include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
+#include "video/PlayerControllerActions.h"
 #include "video/VideoStreamSelect.h"
 #include "video/dialogs/GUIDialogAudioSettings.h"
 #include "video/guilib/VideoStreamSelectHelper.h"
@@ -129,44 +130,33 @@ bool CPlayerController::OnAction(const CAction &action)
         auto it = std::ranges::find(streams, currentStreamId, &SubtitleStreamInfoExt::streamId);
         if (it == streams.end())
           return true;
+        const int currentIndex = static_cast<int>(std::distance(streams.begin(), it));
 
-        bool subVisible = true;
+        const bool visible = appPlayer->GetSubtitleVisible();
 
-        if (appPlayer->GetSubtitleVisible())
-        {
-          int delta = action.GetID() == ACTION_PREV_SUBTITLE ? -1 : 1;
+        SubtitleTrackAction act = SubtitleTrackAction::NEXT;
+        if (action.GetID() == ACTION_PREV_SUBTITLE)
+          act = SubtitleTrackAction::PREV;
+        else if (action.GetID() == ACTION_CYCLE_SUBTITLE)
+          act = SubtitleTrackAction::CYCLE;
 
-          // The position before begin() is UB. Clamp.
-          if (it == streams.begin() && delta < 0)
-            subVisible = false;
-          else
-            std::advance(it, delta);
+        const auto [newIndex, newVisible] = CPlayerControllerActions::ExecSubtitleTrackAction(
+            static_cast<int>(streams.size()), currentIndex, visible, act);
 
-          if (it == streams.end())
-          {
-            it = streams.begin();
-            if (action.GetID() != ACTION_CYCLE_SUBTITLE)
-              subVisible = false;
-          }
+        if (newIndex < 0 || newIndex >= static_cast<int>(streams.size()))
+          return true;
 
-          if (!subVisible)
-            appPlayer->SetSubtitleVisible(false);
-          if (currentStreamId != it->streamId)
-            appPlayer->SetSubtitle(it->streamId);
-        }
-        else if (action.GetID() != ACTION_CYCLE_SUBTITLE)
-        {
-          if (it == streams.begin() && action.GetID() == ACTION_PREV_SUBTITLE)
-          {
-            it = std::prev(streams.end());
-            if (currentStreamId != it->streamId)
-              appPlayer->SetSubtitle(it->streamId);
-          }
-          appPlayer->SetSubtitleVisible(true);
-        }
+        it = streams.begin() + newIndex;
 
+        // Change track and visibility
+        if (newVisible != visible)
+          appPlayer->SetSubtitleVisible(newVisible);
+        if (it->streamId != currentStreamId)
+          appPlayer->SetSubtitle(it->streamId);
+
+        // Toast
         std::string sub;
-        if (subVisible)
+        if (newVisible)
         {
           sub = it->languageDesc;
 
@@ -180,7 +170,8 @@ bool CPlayerController::OnAction(const CAction &action)
         }
         else
         {
-          sub = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1223);
+          sub =
+              CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(1223); // "Disabled"
         }
 
         CGUIDialogKaiToast::QueueNotification(

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -67,6 +67,7 @@ bool CPlayerController::OnAction(const CAction &action)
     {
       case ACTION_SHOW_SUBTITLES:
       {
+        //! @todo combine processing of ACTION_SHOW_SUBTITLES with ACTION_NEXT_SUBTITLE and the other stream actions
         if (appPlayer->GetSubtitleCount() == 0)
         {
           CGUIDialogKaiToast::QueueNotification(

--- a/xbmc/video/PlayerController.h
+++ b/xbmc/video/PlayerController.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2018 Team Kodi
+ *  Copyright (C) 2012-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later

--- a/xbmc/video/PlayerControllerActions.cpp
+++ b/xbmc/video/PlayerControllerActions.cpp
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PlayerControllerActions.h"
+
+namespace KODI::VIDEO
+{
+SubtitleTrackResult CPlayerControllerActions::ExecSubtitleTrackAction(int streamCount,
+                                                                      int currentIndex,
+                                                                      bool visible,
+                                                                      SubtitleTrackAction action)
+{
+  int newIndex = currentIndex;
+  bool newVisible = visible;
+
+  if (streamCount == 0 || currentIndex >= streamCount)
+    return {newIndex, newVisible};
+
+  if (visible)
+  {
+    const int delta = (action == SubtitleTrackAction::PREV) ? -1 : 1;
+    if (currentIndex == 0 && delta < 0)
+    {
+      newVisible = false;
+    }
+    else
+    {
+      newIndex += delta;
+      if (newIndex >= streamCount)
+      {
+        newIndex = 0;
+        if (action != SubtitleTrackAction::CYCLE)
+          newVisible = false;
+      }
+    }
+  }
+  else
+  {
+    if (action != SubtitleTrackAction::CYCLE)
+    {
+      if (currentIndex == 0 && action == SubtitleTrackAction::PREV)
+        newIndex = streamCount - 1;
+      newVisible = true;
+    }
+  }
+
+  return {newIndex, newVisible};
+}
+} // namespace KODI::VIDEO

--- a/xbmc/video/PlayerControllerActions.h
+++ b/xbmc/video/PlayerControllerActions.h
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+namespace KODI::VIDEO
+{
+enum class SubtitleTrackAction
+{
+  NEXT,
+  PREV,
+  CYCLE
+};
+
+struct SubtitleTrackResult
+{
+  int newIndex;
+  bool newVisible;
+};
+
+class CPlayerControllerActions
+{
+private:
+  CPlayerControllerActions() = delete;
+
+public:
+  /*!
+   * \brief Pure navigation logic invoked for subtitle actions.
+   * \param[in] streamCount Count of streams
+   * \param[in] currentIndex Current index
+   * \param[in] visible Current visibility
+   * \param[in] action Action
+   * \return New state
+   */
+  static SubtitleTrackResult ExecSubtitleTrackAction(int streamCount,
+                                                     int currentIndex,
+                                                     bool visible,
+                                                     SubtitleTrackAction action);
+};
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoStreamSelect.cpp
+++ b/xbmc/video/VideoStreamSelect.cpp
@@ -1,0 +1,241 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "video/VideoStreamSelect.h"
+
+#include "ServiceBroker.h"
+#include "application/ApplicationComponents.h"
+#include "application/ApplicationPlayer.h"
+#include "resources/LocalizeStrings.h"
+#include "resources/ResourcesComponent.h"
+#include "utils/LangCodeExpander.h"
+
+#include <algorithm>
+
+namespace KODI::VIDEO
+{
+namespace
+{
+struct SortComparerStreamVideo
+{
+  bool operator()(const VideoStreamInfoExt& a, const VideoStreamInfoExt& b)
+  {
+    if (a.language != b.language)
+    {
+      return a.language < b.language;
+    }
+    if (a.codecName != b.codecName)
+    {
+      return a.codecName < b.codecName;
+    }
+    if (a.hdrType != b.hdrType)
+    {
+      return a.hdrType < b.hdrType;
+    }
+    if (a.fps != b.fps)
+    {
+      return a.fps < b.fps;
+    }
+    if (a.height != b.height)
+    {
+      return a.height < b.height;
+    }
+    if (a.width != b.width)
+    {
+      return a.width < b.width;
+    }
+    return a.bitrate < b.bitrate;
+  }
+};
+
+struct SortComparerStreamAudio
+{
+  bool operator()(const AudioStreamInfoExt& a, const AudioStreamInfoExt& b)
+  {
+    if (a.languageDesc != b.languageDesc)
+    {
+      return a.languageDesc < b.languageDesc;
+    }
+    if (a.isOriginal != b.isOriginal)
+    {
+      return a.isOriginal < b.isOriginal;
+    }
+    if (a.isHearingImpaired != b.isHearingImpaired)
+    {
+      return a.isHearingImpaired < b.isHearingImpaired;
+    }
+    if (a.isVisualImpaired != b.isVisualImpaired)
+    {
+      return a.isVisualImpaired < b.isVisualImpaired;
+    }
+    if (a.isForced != b.isForced)
+    {
+      return a.isForced < b.isForced;
+    }
+    if (a.channels != b.channels)
+    {
+      return a.channels < b.channels;
+    }
+    if (a.bitrate != b.bitrate)
+    {
+      return a.bitrate < b.bitrate;
+    }
+    if (a.samplerate != b.samplerate)
+    {
+      return a.samplerate < b.samplerate;
+    }
+    return a.codecName < b.codecName;
+  }
+};
+
+struct SortComparerStreamSubtitle
+{
+  bool operator()(const SubtitleStreamInfoExt& a, const SubtitleStreamInfoExt& b)
+  {
+    if (a.isExternal != b.isExternal)
+    {
+      return a.isExternal > b.isExternal;
+    }
+    if (a.languageDesc != b.languageDesc)
+    {
+      return a.languageDesc < b.languageDesc;
+    }
+    if (a.isOriginal != b.isOriginal)
+    {
+      return a.isOriginal < b.isOriginal;
+    }
+    if (a.isHearingImpaired != b.isHearingImpaired)
+    {
+      return a.isHearingImpaired < b.isHearingImpaired;
+    }
+    if (a.isVisualImpaired != b.isVisualImpaired)
+    {
+      return a.isVisualImpaired < b.isVisualImpaired;
+    }
+    if (a.isForced != b.isForced)
+    {
+      return a.isForced < b.isForced;
+    }
+    return a.codecName < b.codecName;
+  }
+};
+} // namespace
+
+VideoStreamInfoExt::VideoStreamInfoExt(int id, const VideoStreamInfo& info) : VideoStreamInfo(info)
+{
+  streamId = id;
+  isDefault = info.flags & StreamFlags::FLAG_DEFAULT;
+  isForced = info.flags & StreamFlags::FLAG_FORCED;
+  isHearingImpaired = info.flags & StreamFlags::FLAG_HEARING_IMPAIRED;
+  isVisualImpaired = info.flags & StreamFlags::FLAG_VISUAL_IMPAIRED;
+
+  fps = static_cast<float>(info.fpsRate);
+  if (fps > 0.0f && info.fpsScale > 0)
+    fps /= info.fpsScale;
+}
+
+AudioStreamInfoExt::AudioStreamInfoExt(int id, const AudioStreamInfo& info) : AudioStreamInfo(info)
+{
+  streamId = id;
+
+  if (!g_LangCodeExpander.Lookup(info.language, languageDesc))
+    languageDesc =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
+
+  isDefault = info.flags & StreamFlags::FLAG_DEFAULT;
+  isForced = info.flags & StreamFlags::FLAG_FORCED;
+  isHearingImpaired = info.flags & StreamFlags::FLAG_HEARING_IMPAIRED;
+  isVisualImpaired = info.flags & StreamFlags::FLAG_VISUAL_IMPAIRED;
+  isOriginal = info.flags & StreamFlags::FLAG_ORIGINAL;
+}
+
+SubtitleStreamInfoExt::SubtitleStreamInfoExt(int id, const SubtitleStreamInfo& info)
+  : SubtitleStreamInfo(info)
+{
+  streamId = id;
+
+  if (!g_LangCodeExpander.Lookup(info.language, languageDesc))
+    languageDesc =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
+
+  isDefault = info.flags & StreamFlags::FLAG_DEFAULT;
+  isForced = info.flags & StreamFlags::FLAG_FORCED;
+  isHearingImpaired = info.flags & StreamFlags::FLAG_HEARING_IMPAIRED;
+  isVisualImpaired = info.flags & StreamFlags::FLAG_VISUAL_IMPAIRED;
+  isOriginal = info.flags & StreamFlags::FLAG_ORIGINAL;
+}
+
+std::vector<VideoStreamInfoExt> CVideoStreamSelect::GetVideoStreams()
+{
+  auto& components = CServiceBroker::GetAppComponents();
+  auto appPlayer = components.GetComponent<CApplicationPlayer>();
+
+  const int streamCount = appPlayer->GetVideoStreamCount();
+
+  std::vector<VideoStreamInfoExt> streams;
+  streams.reserve(streamCount);
+
+  // Collect all streams
+  for (int i = 0; i < streamCount; ++i)
+  {
+    VideoStreamInfo info;
+    appPlayer->GetVideoStreamInfo(i, info);
+    streams.emplace_back(i, info);
+  }
+
+  std::sort(streams.begin(), streams.end(), SortComparerStreamVideo());
+
+  return streams;
+}
+
+std::vector<AudioStreamInfoExt> CVideoStreamSelect::GetAudioStreams()
+{
+  auto& components = CServiceBroker::GetAppComponents();
+  auto appPlayer = components.GetComponent<CApplicationPlayer>();
+
+  const int streamCount = appPlayer->GetAudioStreamCount();
+
+  std::vector<AudioStreamInfoExt> streams;
+  streams.reserve(streamCount);
+
+  // Collect all streams
+  for (int i = 0; i < streamCount; ++i)
+  {
+    AudioStreamInfo info;
+    appPlayer->GetAudioStreamInfo(i, info);
+    streams.emplace_back(i, info);
+  }
+
+  std::sort(streams.begin(), streams.end(), SortComparerStreamAudio());
+
+  return streams;
+}
+
+std::vector<SubtitleStreamInfoExt> CVideoStreamSelect::GetSubtitleStreams()
+{
+  auto& components = CServiceBroker::GetAppComponents();
+  auto appPlayer = components.GetComponent<CApplicationPlayer>();
+
+  const int streamCount = appPlayer->GetSubtitleCount();
+
+  std::vector<SubtitleStreamInfoExt> streams;
+  streams.reserve(streamCount);
+
+  // Collect all streams
+  for (int i = 0; i < streamCount; ++i)
+  {
+    SubtitleStreamInfo info;
+    appPlayer->GetSubtitleStreamInfo(i, info);
+    streams.emplace_back(i, info);
+  }
+
+  std::sort(streams.begin(), streams.end(), SortComparerStreamSubtitle());
+
+  return streams;
+}
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoStreamSelect.cpp
+++ b/xbmc/video/VideoStreamSelect.cpp
@@ -28,9 +28,9 @@ struct SortComparerStreamVideo
 {
   bool operator()(const VideoStreamInfoExt& a, const VideoStreamInfoExt& b)
   {
-    if (a.language != b.language)
+    if (a.languageDesc != b.languageDesc)
     {
-      return a.language < b.language;
+      return a.languageDesc < b.languageDesc;
     }
     if (a.codecName != b.codecName)
     {
@@ -132,6 +132,11 @@ struct SortComparerStreamSubtitle
 VideoStreamInfoExt::VideoStreamInfoExt(int id, const VideoStreamInfo& info) : VideoStreamInfo(info)
 {
   streamId = id;
+
+  if (!g_LangCodeExpander.Lookup(info.language, languageDesc))
+    languageDesc =
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
+
   isDefault = info.flags & StreamFlags::FLAG_DEFAULT;
   isForced = info.flags & StreamFlags::FLAG_FORCED;
   isHearingImpaired = info.flags & StreamFlags::FLAG_HEARING_IMPAIRED;

--- a/xbmc/video/VideoStreamSelect.cpp
+++ b/xbmc/video/VideoStreamSelect.cpp
@@ -16,6 +16,7 @@
 #include "utils/LangCodeExpander.h"
 
 #include <algorithm>
+#include <functional>
 
 namespace KODI::VIDEO
 {
@@ -170,72 +171,67 @@ SubtitleStreamInfoExt::SubtitleStreamInfoExt(int id, const SubtitleStreamInfo& i
   isOriginal = info.flags & StreamFlags::FLAG_ORIGINAL;
 }
 
-std::vector<VideoStreamInfoExt> CVideoStreamSelect::GetVideoStreams()
+namespace
+{
+// Concepts to safeguard the template
+template<typename F, typename Player>
+concept StreamCountGetter = requires(F f, Player* p) {
+  { std::invoke(f, p) } -> std::convertible_to<int>;
+};
+
+template<typename F, typename Player, typename InfoT>
+concept StreamInfoGetter = requires(F f, Player* p, int i, InfoT& info) {
+  { std::invoke(f, p, i, info) } -> std::same_as<void>;
+};
+
+template<typename StreamInfoExtT,
+         typename StreamInfoT,
+         typename GetCountFn,
+         typename GetInfoFn,
+         typename Comparer>
+  requires StreamCountGetter<GetCountFn, CApplicationPlayer> &&
+           StreamInfoGetter<GetInfoFn, CApplicationPlayer, StreamInfoT>
+std::vector<StreamInfoExtT> GetStreams(GetCountFn getCount, GetInfoFn getInfo, Comparer comparer)
 {
   auto& components = CServiceBroker::GetAppComponents();
   auto appPlayer = components.GetComponent<CApplicationPlayer>();
 
-  const int streamCount = appPlayer->GetVideoStreamCount();
-
-  std::vector<VideoStreamInfoExt> streams;
+  const int streamCount = std::invoke(getCount, appPlayer.get());
+  std::vector<StreamInfoExtT> streams;
   streams.reserve(streamCount);
 
   // Collect all streams
   for (int i = 0; i < streamCount; ++i)
   {
-    VideoStreamInfo info;
-    appPlayer->GetVideoStreamInfo(i, info);
+    StreamInfoT info;
+    std::invoke(getInfo, appPlayer.get(), i, info);
     streams.emplace_back(i, info);
   }
 
-  std::sort(streams.begin(), streams.end(), SortComparerStreamVideo());
+  std::sort(streams.begin(), streams.end(), comparer);
 
   return streams;
+}
+} // namespace
+
+std::vector<VideoStreamInfoExt> CVideoStreamSelect::GetVideoStreams()
+{
+  return GetStreams<VideoStreamInfoExt, VideoStreamInfo>(&CApplicationPlayer::GetVideoStreamCount,
+                                                         &CApplicationPlayer::GetVideoStreamInfo,
+                                                         SortComparerStreamVideo{});
 }
 
 std::vector<AudioStreamInfoExt> CVideoStreamSelect::GetAudioStreams()
 {
-  auto& components = CServiceBroker::GetAppComponents();
-  auto appPlayer = components.GetComponent<CApplicationPlayer>();
-
-  const int streamCount = appPlayer->GetAudioStreamCount();
-
-  std::vector<AudioStreamInfoExt> streams;
-  streams.reserve(streamCount);
-
-  // Collect all streams
-  for (int i = 0; i < streamCount; ++i)
-  {
-    AudioStreamInfo info;
-    appPlayer->GetAudioStreamInfo(i, info);
-    streams.emplace_back(i, info);
-  }
-
-  std::sort(streams.begin(), streams.end(), SortComparerStreamAudio());
-
-  return streams;
+  return GetStreams<AudioStreamInfoExt, AudioStreamInfo>(&CApplicationPlayer::GetAudioStreamCount,
+                                                         &CApplicationPlayer::GetAudioStreamInfo,
+                                                         SortComparerStreamAudio{});
 }
 
 std::vector<SubtitleStreamInfoExt> CVideoStreamSelect::GetSubtitleStreams()
 {
-  auto& components = CServiceBroker::GetAppComponents();
-  auto appPlayer = components.GetComponent<CApplicationPlayer>();
-
-  const int streamCount = appPlayer->GetSubtitleCount();
-
-  std::vector<SubtitleStreamInfoExt> streams;
-  streams.reserve(streamCount);
-
-  // Collect all streams
-  for (int i = 0; i < streamCount; ++i)
-  {
-    SubtitleStreamInfo info;
-    appPlayer->GetSubtitleStreamInfo(i, info);
-    streams.emplace_back(i, info);
-  }
-
-  std::sort(streams.begin(), streams.end(), SortComparerStreamSubtitle());
-
-  return streams;
+  return GetStreams<SubtitleStreamInfoExt, SubtitleStreamInfo>(
+      &CApplicationPlayer::GetSubtitleCount, &CApplicationPlayer::GetSubtitleStreamInfo,
+      SortComparerStreamSubtitle{});
 }
 } // namespace KODI::VIDEO

--- a/xbmc/video/VideoStreamSelect.cpp
+++ b/xbmc/video/VideoStreamSelect.cpp
@@ -13,6 +13,8 @@
 #include "application/ApplicationPlayer.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/LangCodeExpander.h"
 
 #include <algorithm>
@@ -184,17 +186,23 @@ concept StreamInfoGetter = requires(F f, Player* p, int i, InfoT& info) {
   { std::invoke(f, p, i, info) } -> std::same_as<void>;
 };
 
+template<typename F, typename InfoExtT, typename Order>
+concept StreamOrderer = requires(F f, std::vector<InfoExtT>& i, Order o) {
+  { std::invoke(f, i, o) } -> std::same_as<void>;
+};
+
 template<typename StreamInfoExtT,
          typename StreamInfoT,
          typename GetCountFn,
          typename GetInfoFn,
-         typename Comparer>
+         typename OrderFn>
   requires StreamCountGetter<GetCountFn, CApplicationPlayer> &&
-           StreamInfoGetter<GetInfoFn, CApplicationPlayer, StreamInfoT>
+           StreamInfoGetter<GetInfoFn, CApplicationPlayer, StreamInfoT> &&
+           StreamOrderer<OrderFn, StreamInfoExtT, CVideoStreamSelect::TrackOrder>
 std::vector<StreamInfoExtT> GetStreams(const CApplicationPlayer* appPlayer,
                                        GetCountFn getCount,
                                        GetInfoFn getInfo,
-                                       Comparer comparer)
+                                       OrderFn orderer)
 {
   if (appPlayer == nullptr)
     return {};
@@ -211,7 +219,12 @@ std::vector<StreamInfoExtT> GetStreams(const CApplicationPlayer* appPlayer,
     streams.emplace_back(i, info);
   }
 
-  std::sort(streams.begin(), streams.end(), comparer);
+  // Sort the streams
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  auto order = static_cast<CVideoStreamSelect::TrackOrder>(
+      settings->GetInt(CSettings::SETTING_VIDEOPLAYER_STREAMDISPLAYORDER));
+
+  std::invoke(orderer, streams, order);
 
   return streams;
 }
@@ -222,7 +235,7 @@ std::vector<VideoStreamInfoExt> CVideoStreamSelect::GetVideoStreams(
 {
   return GetStreams<VideoStreamInfoExt, VideoStreamInfo>(
       appPlayer, &CApplicationPlayer::GetVideoStreamCount, &CApplicationPlayer::GetVideoStreamInfo,
-      SortComparerStreamVideo{});
+      OrderVideoStreams);
 }
 
 std::vector<AudioStreamInfoExt> CVideoStreamSelect::GetAudioStreams(
@@ -230,7 +243,7 @@ std::vector<AudioStreamInfoExt> CVideoStreamSelect::GetAudioStreams(
 {
   return GetStreams<AudioStreamInfoExt, AudioStreamInfo>(
       appPlayer, &CApplicationPlayer::GetAudioStreamCount, &CApplicationPlayer::GetAudioStreamInfo,
-      SortComparerStreamAudio{});
+      OrderAudioStreams);
 }
 
 std::vector<SubtitleStreamInfoExt> CVideoStreamSelect::GetSubtitleStreams(
@@ -238,6 +251,27 @@ std::vector<SubtitleStreamInfoExt> CVideoStreamSelect::GetSubtitleStreams(
 {
   return GetStreams<SubtitleStreamInfoExt, SubtitleStreamInfo>(
       appPlayer, &CApplicationPlayer::GetSubtitleCount, &CApplicationPlayer::GetSubtitleStreamInfo,
-      SortComparerStreamSubtitle{});
+      OrderSubtitleStreams);
+}
+
+void CVideoStreamSelect::OrderVideoStreams(std::vector<VideoStreamInfoExt>& streams,
+                                           TrackOrder order)
+{
+  if (order == TrackOrder::SORTED)
+    std::sort(streams.begin(), streams.end(), SortComparerStreamVideo());
+}
+
+void CVideoStreamSelect::OrderAudioStreams(std::vector<AudioStreamInfoExt>& streams,
+                                           TrackOrder order)
+{
+  if (order == TrackOrder::SORTED)
+    std::sort(streams.begin(), streams.end(), SortComparerStreamAudio());
+}
+
+void CVideoStreamSelect::OrderSubtitleStreams(std::vector<SubtitleStreamInfoExt>& streams,
+                                              TrackOrder order)
+{
+  if (order == TrackOrder::SORTED)
+    std::sort(streams.begin(), streams.end(), SortComparerStreamSubtitle());
 }
 } // namespace KODI::VIDEO

--- a/xbmc/video/VideoStreamSelect.cpp
+++ b/xbmc/video/VideoStreamSelect.cpp
@@ -8,7 +8,9 @@
 
 #include "video/VideoStreamSelect.h"
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
+#include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
 #include "resources/LocalizeStrings.h"
@@ -16,6 +18,7 @@
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/LangCodeExpander.h"
+#include "utils/URIUtils.h"
 
 #include <algorithm>
 #include <functional>
@@ -180,6 +183,44 @@ SubtitleStreamInfoExt::SubtitleStreamInfoExt(int id, const SubtitleStreamInfo& i
 
 namespace
 {
+// This attempts to distinguish videos files, with may have streams muxed in a meaningful order,
+// from videos where stream order is more random and always benefits from reordering, for example
+// internet streaming protocols.
+bool IsTrackOrderMeaningful()
+{
+  //! @todo improve accuracy with detection in VideoPlayer
+
+  const auto item = g_application.CurrentFileItemPtr();
+
+  if (!item)
+    return true;
+
+  const std::string dynPath = item->GetDynPath();
+
+  // Detect file-based all protocols discretly since the macro test "IsNetworkFilesystem" interprets
+  // http as always file-based, which misidentifies masqueraded streaming
+  if (URIUtils::IsHD(dynPath) || URIUtils::IsSmb(dynPath) || URIUtils::IsNfs(dynPath) ||
+      URIUtils::IsFTP(dynPath) || URIUtils::IsProtocol(dynPath, "sftp") ||
+      URIUtils::IsProtocol(dynPath, "ssh") || URIUtils::IsDAV(dynPath))
+    return true;
+
+  const std::string path = item->GetPath();
+  if (URIUtils::IsUPnP(path))
+    return true;
+
+  return false;
+}
+
+CVideoStreamSelect::TrackOrder GetTrackOrder()
+{
+  if (!IsTrackOrderMeaningful())
+    return CVideoStreamSelect::TrackOrder::SORTED;
+
+  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+  return static_cast<CVideoStreamSelect::TrackOrder>(
+      settings->GetInt(CSettings::SETTING_VIDEOPLAYER_FILESTREAMDISPLAYORDER));
+}
+
 // Concepts to safeguard the template
 template<typename F, typename Player>
 concept StreamCountGetter = requires(F f, Player* p) {
@@ -225,11 +266,7 @@ std::vector<StreamInfoExtT> GetStreams(const CApplicationPlayer* appPlayer,
   }
 
   // Sort the streams
-  const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
-  auto order = static_cast<CVideoStreamSelect::TrackOrder>(
-      settings->GetInt(CSettings::SETTING_VIDEOPLAYER_STREAMDISPLAYORDER));
-
-  std::invoke(orderer, streams, order);
+  std::invoke(orderer, streams, GetTrackOrder());
 
   return streams;
 }

--- a/xbmc/video/VideoStreamSelect.cpp
+++ b/xbmc/video/VideoStreamSelect.cpp
@@ -191,12 +191,15 @@ template<typename StreamInfoExtT,
          typename Comparer>
   requires StreamCountGetter<GetCountFn, CApplicationPlayer> &&
            StreamInfoGetter<GetInfoFn, CApplicationPlayer, StreamInfoT>
-std::vector<StreamInfoExtT> GetStreams(GetCountFn getCount, GetInfoFn getInfo, Comparer comparer)
+std::vector<StreamInfoExtT> GetStreams(const CApplicationPlayer* appPlayer,
+                                       GetCountFn getCount,
+                                       GetInfoFn getInfo,
+                                       Comparer comparer)
 {
-  auto& components = CServiceBroker::GetAppComponents();
-  auto appPlayer = components.GetComponent<CApplicationPlayer>();
+  if (appPlayer == nullptr)
+    return {};
 
-  const int streamCount = std::invoke(getCount, appPlayer.get());
+  const int streamCount = std::invoke(getCount, appPlayer);
   std::vector<StreamInfoExtT> streams;
   streams.reserve(streamCount);
 
@@ -204,7 +207,7 @@ std::vector<StreamInfoExtT> GetStreams(GetCountFn getCount, GetInfoFn getInfo, C
   for (int i = 0; i < streamCount; ++i)
   {
     StreamInfoT info;
-    std::invoke(getInfo, appPlayer.get(), i, info);
+    std::invoke(getInfo, appPlayer, i, info);
     streams.emplace_back(i, info);
   }
 
@@ -214,24 +217,27 @@ std::vector<StreamInfoExtT> GetStreams(GetCountFn getCount, GetInfoFn getInfo, C
 }
 } // namespace
 
-std::vector<VideoStreamInfoExt> CVideoStreamSelect::GetVideoStreams()
+std::vector<VideoStreamInfoExt> CVideoStreamSelect::GetVideoStreams(
+    const CApplicationPlayer* appPlayer)
 {
-  return GetStreams<VideoStreamInfoExt, VideoStreamInfo>(&CApplicationPlayer::GetVideoStreamCount,
-                                                         &CApplicationPlayer::GetVideoStreamInfo,
-                                                         SortComparerStreamVideo{});
+  return GetStreams<VideoStreamInfoExt, VideoStreamInfo>(
+      appPlayer, &CApplicationPlayer::GetVideoStreamCount, &CApplicationPlayer::GetVideoStreamInfo,
+      SortComparerStreamVideo{});
 }
 
-std::vector<AudioStreamInfoExt> CVideoStreamSelect::GetAudioStreams()
+std::vector<AudioStreamInfoExt> CVideoStreamSelect::GetAudioStreams(
+    const CApplicationPlayer* appPlayer)
 {
-  return GetStreams<AudioStreamInfoExt, AudioStreamInfo>(&CApplicationPlayer::GetAudioStreamCount,
-                                                         &CApplicationPlayer::GetAudioStreamInfo,
-                                                         SortComparerStreamAudio{});
+  return GetStreams<AudioStreamInfoExt, AudioStreamInfo>(
+      appPlayer, &CApplicationPlayer::GetAudioStreamCount, &CApplicationPlayer::GetAudioStreamInfo,
+      SortComparerStreamAudio{});
 }
 
-std::vector<SubtitleStreamInfoExt> CVideoStreamSelect::GetSubtitleStreams()
+std::vector<SubtitleStreamInfoExt> CVideoStreamSelect::GetSubtitleStreams(
+    const CApplicationPlayer* appPlayer)
 {
   return GetStreams<SubtitleStreamInfoExt, SubtitleStreamInfo>(
-      &CApplicationPlayer::GetSubtitleCount, &CApplicationPlayer::GetSubtitleStreamInfo,
+      appPlayer, &CApplicationPlayer::GetSubtitleCount, &CApplicationPlayer::GetSubtitleStreamInfo,
       SortComparerStreamSubtitle{});
 }
 } // namespace KODI::VIDEO

--- a/xbmc/video/VideoStreamSelect.h
+++ b/xbmc/video/VideoStreamSelect.h
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "cores/VideoPlayer/Interface/StreamInfo.h"
+
+#include <string>
+#include <vector>
+
+namespace KODI::VIDEO
+{
+struct VideoStreamInfoExt : VideoStreamInfo
+{
+  VideoStreamInfoExt(int id, const VideoStreamInfo& info);
+
+  int streamId{0};
+  std::string languageDesc;
+  bool isDefault{false};
+  bool isForced{false};
+  bool isHearingImpaired{false};
+  bool isVisualImpaired{false};
+  float fps{0.0f};
+};
+
+struct AudioStreamInfoExt : AudioStreamInfo
+{
+  AudioStreamInfoExt(int id, const AudioStreamInfo& info);
+
+  int streamId{0};
+  std::string languageDesc;
+  bool isDefault{false};
+  bool isForced{false};
+  bool isHearingImpaired{false};
+  bool isVisualImpaired{false};
+  bool isOriginal{false};
+};
+
+struct SubtitleStreamInfoExt : SubtitleStreamInfo
+{
+  SubtitleStreamInfoExt(int id, const SubtitleStreamInfo& info);
+
+  int streamId{0};
+  std::string languageDesc;
+  bool isDefault{false};
+  bool isForced{false};
+  bool isHearingImpaired{false};
+  bool isVisualImpaired{false};
+  bool isOriginal{false};
+};
+
+class CVideoStreamSelect
+{
+private:
+  CVideoStreamSelect() = delete;
+  ~CVideoStreamSelect() = delete;
+
+public:
+  static std::vector<VideoStreamInfoExt> GetVideoStreams();
+  static std::vector<AudioStreamInfoExt> GetAudioStreams();
+  static std::vector<SubtitleStreamInfoExt> GetSubtitleStreams();
+};
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoStreamSelect.h
+++ b/xbmc/video/VideoStreamSelect.h
@@ -63,8 +63,18 @@ private:
   ~CVideoStreamSelect() = delete;
 
 public:
+  enum class TrackOrder
+  {
+    MEDIA = 0, // explicit IDs because persisted in settings.
+    SORTED = 1,
+  };
+
   static std::vector<VideoStreamInfoExt> GetVideoStreams(const CApplicationPlayer* appPlayer);
   static std::vector<AudioStreamInfoExt> GetAudioStreams(const CApplicationPlayer* appPlayer);
   static std::vector<SubtitleStreamInfoExt> GetSubtitleStreams(const CApplicationPlayer* appPlayer);
+
+  static void OrderVideoStreams(std::vector<VideoStreamInfoExt>& streams, TrackOrder order);
+  static void OrderAudioStreams(std::vector<AudioStreamInfoExt>& streams, TrackOrder order);
+  static void OrderSubtitleStreams(std::vector<SubtitleStreamInfoExt>& streams, TrackOrder order);
 };
 } // namespace KODI::VIDEO

--- a/xbmc/video/VideoStreamSelect.h
+++ b/xbmc/video/VideoStreamSelect.h
@@ -13,6 +13,8 @@
 #include <string>
 #include <vector>
 
+class CApplicationPlayer;
+
 namespace KODI::VIDEO
 {
 struct VideoStreamInfoExt : VideoStreamInfo
@@ -61,8 +63,8 @@ private:
   ~CVideoStreamSelect() = delete;
 
 public:
-  static std::vector<VideoStreamInfoExt> GetVideoStreams();
-  static std::vector<AudioStreamInfoExt> GetAudioStreams();
-  static std::vector<SubtitleStreamInfoExt> GetSubtitleStreams();
+  static std::vector<VideoStreamInfoExt> GetVideoStreams(const CApplicationPlayer* appPlayer);
+  static std::vector<AudioStreamInfoExt> GetAudioStreams(const CApplicationPlayer* appPlayer);
+  static std::vector<SubtitleStreamInfoExt> GetSubtitleStreams(const CApplicationPlayer* appPlayer);
 };
 } // namespace KODI::VIDEO

--- a/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogAudioSettings.cpp
@@ -29,11 +29,11 @@
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDefinitions.h"
 #include "settings/lib/SettingsManager.h"
-#include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoStreamSelect.h"
 
 #include <memory>
 #include <string>
@@ -380,27 +380,34 @@ void CGUIDialogAudioSettings::AudioStreamsOptionFiller(const SettingConstPtr& se
 {
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-  const int audioStreamCount = appPlayer->GetAudioStreamCount();
 
-  // cycle through each audio stream and add it to our list control
-  for (int i = 0; i < audioStreamCount; ++i)
+  if (appPlayer != nullptr)
   {
-    std::string textInfo;
+    using namespace KODI::VIDEO;
+    const std::vector<AudioStreamInfoExt> streams =
+        CVideoStreamSelect::GetAudioStreams(appPlayer.get());
+    const int streamCount = streams.size();
 
-    AudioStreamInfo info;
-    appPlayer->GetAudioStreamInfo(i, info);
+    // cycle through each audio stream and add it to our list control
+    for (int i = 0; i < streamCount; ++i)
+    {
+      const AudioStreamInfoExt& info = streams[i];
 
-    if (!g_LangCodeExpander.Lookup(info.language, textInfo))
-      textInfo = "[" + CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205) +
-                 "]"; // Unknown
+      std::string strItem = info.languageDesc;
 
-    if (!info.name.empty())
-      textInfo += " - " + info.name;
+      if (!info.name.empty())
+        strItem += " - " + info.name;
 
-    textInfo += FormatCodec(info);
-    textInfo += FormatFlags(info.flags);
-    textInfo += StringUtils::Format(" ({}/{})", i + 1, audioStreamCount);
-    list.emplace_back(std::move(textInfo), i);
+      strItem += FormatCodec(info);
+      strItem += FormatFlags(info.flags);
+      strItem += StringUtils::Format(" ({}/{})", i + 1, streamCount);
+
+      list.emplace_back(std::move(strItem), info.streamId);
+    }
+  }
+  else
+  {
+    CLog::LogF(LOGERROR, "No application player.");
   }
 
   if (list.empty())

--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -35,12 +35,12 @@
 #include "settings/lib/SettingDefinitions.h"
 #include "settings/lib/SettingsManager.h"
 #include "utils/FileUtils.h"
-#include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoStreamSelect.h"
 
 #include <string>
 #include <vector>
@@ -381,31 +381,32 @@ void CGUIDialogSubtitleSettings::SubtitleStreamsOptionFiller(
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
 
-  int subtitleStreamCount = appPlayer->GetSubtitleCount();
-
-  // cycle through each subtitle and add it to our entry list
-  for (int i = 0; i < subtitleStreamCount; ++i)
+  if (appPlayer != nullptr)
   {
-    SubtitleStreamInfo info;
-    appPlayer->GetSubtitleStreamInfo(i, info);
+    using namespace KODI::VIDEO;
+    const std::vector<SubtitleStreamInfoExt> streams =
+        CVideoStreamSelect::GetSubtitleStreams(appPlayer.get());
+    const int streamCount = streams.size();
 
-    std::string strItem;
-    std::string strLanguage;
+    for (int i = 0; i < streamCount; ++i)
+    {
+      const SubtitleStreamInfoExt& info = streams[i];
 
-    if (!g_LangCodeExpander.Lookup(info.language, strLanguage))
-      strLanguage =
-          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
+      std::string strItem = info.languageDesc;
 
-    if (info.name.empty())
-      strItem = strLanguage;
-    else
-      strItem = StringUtils::Format("{} - {}", strLanguage, info.name);
+      if (!info.name.empty())
+        strItem += " - " + info.name;
 
-    strItem += FormatCodec(info);
-    strItem += FormatFlags(info.flags);
-    strItem += StringUtils::Format(" ({}/{})", i + 1, subtitleStreamCount);
+      strItem += FormatCodec(info);
+      strItem += FormatFlags(info.flags);
+      strItem += StringUtils::Format(" ({}/{})", i + 1, streamCount);
 
-    list.emplace_back(strItem, i);
+      list.emplace_back(strItem, info.streamId);
+    }
+  }
+  else
+  {
+    CLog::LogF(LOGERROR, "No application player.");
   }
 
   // no subtitle streams - just add a "None" entry

--- a/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoSettings.cpp
@@ -25,11 +25,11 @@
 #include "settings/lib/Setting.h"
 #include "settings/lib/SettingDefinitions.h"
 #include "settings/lib/SettingsManager.h"
-#include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
 #include "utils/Variant.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoStreamSelect.h"
 #include "video/ViewModeSettings.h"
 #include "windowing/WinSystem.h"
 
@@ -492,43 +492,50 @@ void CGUIDialogVideoSettings::VideoStreamsOptionFiller(
   const auto& components = CServiceBroker::GetAppComponents();
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
 
-  int videoStreamCount = appPlayer->GetVideoStreamCount();
-  // cycle through each video stream and add it to our list control
-  for (int i = 0; i < videoStreamCount; ++i)
+  if (appPlayer != nullptr)
   {
-    std::string strItem;
-    std::string strLanguage;
+    using namespace KODI::VIDEO;
+    const std::vector<VideoStreamInfoExt> streams =
+        CVideoStreamSelect::GetVideoStreams(appPlayer.get());
+    const int streamCount = streams.size();
 
-    VideoStreamInfo info;
-    appPlayer->GetVideoStreamInfo(i, info);
-
-    g_LangCodeExpander.Lookup(info.language, strLanguage);
-
-    if (!info.name.empty())
+    // cycle through each video stream and add it to our list control
+    for (int i = 0; i < streamCount; ++i)
     {
-      if (!strLanguage.empty())
-        strItem = StringUtils::Format("{} - {}", strLanguage, info.name);
+      const VideoStreamInfoExt& info = streams[i];
+
+      std::string strItem;
+
+      if (!info.name.empty())
+      {
+        if (!info.languageDesc.empty())
+          strItem = StringUtils::Format("{} - {}", info.languageDesc, info.name);
+        else
+          strItem = info.name;
+      }
+      else if (!info.languageDesc.empty())
+      {
+        strItem = info.languageDesc;
+      }
+
+      if (info.codecName.empty())
+        strItem += StringUtils::Format(" ({}x{}", info.width, info.height);
       else
-        strItem = info.name;
+        strItem += StringUtils::Format(" ({}, {}x{}", info.codecName, info.width, info.height);
+
+      if (info.bitrate)
+        strItem += StringUtils::Format(", {} bps)", info.bitrate);
+      else
+        strItem += ")";
+
+      strItem += FormatFlags(info.flags);
+      strItem += StringUtils::Format(" ({}/{})", i + 1, streamCount);
+      list.emplace_back(strItem, info.streamId);
     }
-    else if (!strLanguage.empty())
-    {
-        strItem = strLanguage;
-    }
-
-    if (info.codecName.empty())
-      strItem += StringUtils::Format(" ({}x{}", info.width, info.height);
-    else
-      strItem += StringUtils::Format(" ({}, {}x{}", info.codecName, info.width, info.height);
-
-    if (info.bitrate)
-      strItem += StringUtils::Format(", {} bps)", info.bitrate);
-    else
-      strItem += ")";
-
-    strItem += FormatFlags(info.flags);
-    strItem += StringUtils::Format(" ({}/{})", i + 1, videoStreamCount);
-    list.emplace_back(strItem, i);
+  }
+  else
+  {
+    CLog::LogF(LOGERROR, "No application player.");
   }
 
   if (list.empty())

--- a/xbmc/video/guilib/VideoStreamSelectHelper.cpp
+++ b/xbmc/video/guilib/VideoStreamSelectHelper.cpp
@@ -143,10 +143,7 @@ void KODI::VIDEO::GUILIB::OpenDialogSelectVideoStream()
     fileItem->SetProperty("stream.id", info.streamId);
     fileItem->SetProperty("stream.description", info.name);
     fileItem->SetProperty("stream.codec", info.codecName);
-
-    std::string languageDesc;
-    g_LangCodeExpander.Lookup(info.language, languageDesc);
-    fileItem->SetProperty("stream.language", languageDesc);
+    fileItem->SetProperty("stream.language", info.languageDesc);
 
     fileItem->SetProperty("stream.resolution",
                           std::to_string(info.width) + "x" + std::to_string(info.height));

--- a/xbmc/video/guilib/VideoStreamSelectHelper.cpp
+++ b/xbmc/video/guilib/VideoStreamSelectHelper.cpp
@@ -23,6 +23,7 @@
 #include "utils/StreamUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/log.h"
+#include "video/VideoStreamSelect.h"
 
 namespace
 {
@@ -83,186 +84,6 @@ std::string ConvertFpsToString(float value)
   return str;
 }
 
-struct VideoStreamInfoExt : VideoStreamInfo
-{
-  VideoStreamInfoExt(int id, const VideoStreamInfo& info) : VideoStreamInfo(info)
-  {
-    streamId = id;
-    isDefault = info.flags & StreamFlags::FLAG_DEFAULT;
-    isForced = info.flags & StreamFlags::FLAG_FORCED;
-    isHearingImpaired = info.flags & StreamFlags::FLAG_HEARING_IMPAIRED;
-    isVisualImpaired = info.flags & StreamFlags::FLAG_VISUAL_IMPAIRED;
-
-    fps = static_cast<float>(info.fpsRate);
-    if (fps > 0.0f && info.fpsScale > 0)
-      fps /= info.fpsScale;
-  }
-
-  int streamId{0};
-  std::string languageDesc;
-  bool isDefault{false};
-  bool isForced{false};
-  bool isHearingImpaired{false};
-  bool isVisualImpaired{false};
-  float fps{0.0f};
-};
-
-struct AudioStreamInfoExt : AudioStreamInfo
-{
-  AudioStreamInfoExt(int id, const AudioStreamInfo& info) : AudioStreamInfo(info)
-  {
-    streamId = id;
-
-    if (!g_LangCodeExpander.Lookup(info.language, languageDesc))
-      languageDesc =
-          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
-
-    isDefault = info.flags & StreamFlags::FLAG_DEFAULT;
-    isForced = info.flags & StreamFlags::FLAG_FORCED;
-    isHearingImpaired = info.flags & StreamFlags::FLAG_HEARING_IMPAIRED;
-    isVisualImpaired = info.flags & StreamFlags::FLAG_VISUAL_IMPAIRED;
-    isOriginal = info.flags & StreamFlags::FLAG_ORIGINAL;
-  }
-
-  int streamId{0};
-  std::string languageDesc;
-  bool isDefault{false};
-  bool isForced{false};
-  bool isHearingImpaired{false};
-  bool isVisualImpaired{false};
-  bool isOriginal{false};
-};
-
-struct SubtitleStreamInfoExt : SubtitleStreamInfo
-{
-  SubtitleStreamInfoExt(int id, const SubtitleStreamInfo& info) : SubtitleStreamInfo(info)
-  {
-    streamId = id;
-
-    if (!g_LangCodeExpander.Lookup(info.language, languageDesc))
-      languageDesc =
-          CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // Unknown
-
-    isDefault = info.flags & StreamFlags::FLAG_DEFAULT;
-    isForced = info.flags & StreamFlags::FLAG_FORCED;
-    isHearingImpaired = info.flags & StreamFlags::FLAG_HEARING_IMPAIRED;
-    isVisualImpaired = info.flags & StreamFlags::FLAG_VISUAL_IMPAIRED;
-    isOriginal = info.flags & StreamFlags::FLAG_ORIGINAL;
-  }
-
-  int streamId{0};
-  std::string languageDesc;
-  bool isDefault{false};
-  bool isForced{false};
-  bool isHearingImpaired{false};
-  bool isVisualImpaired{false};
-  bool isOriginal{false};
-};
-
-struct SortComparerStreamVideo
-{
-  bool operator()(const VideoStreamInfoExt& a, const VideoStreamInfoExt& b)
-  {
-    if (a.language != b.language)
-    {
-      return a.language < b.language;
-    }
-    if (a.codecName != b.codecName)
-    {
-      return a.codecName < b.codecName;
-    }
-    if (a.hdrType != b.hdrType)
-    {
-      return a.hdrType < b.hdrType;
-    }
-    if (a.fps != b.fps)
-    {
-      return a.fps < b.fps;
-    }
-    if (a.height != b.height)
-    {
-      return a.height < b.height;
-    }
-    if (a.width != b.width)
-    {
-      return a.width < b.width;
-    }
-    return a.bitrate < b.bitrate;
-  }
-};
-
-struct SortComparerStreamAudio
-{
-  bool operator()(const AudioStreamInfoExt& a, const AudioStreamInfoExt& b)
-  {
-    if (a.languageDesc != b.languageDesc)
-    {
-      return a.languageDesc < b.languageDesc;
-    }
-    if (a.isOriginal != b.isOriginal)
-    {
-      return a.isOriginal < b.isOriginal;
-    }
-    if (a.isHearingImpaired != b.isHearingImpaired)
-    {
-      return a.isHearingImpaired < b.isHearingImpaired;
-    }
-    if (a.isVisualImpaired != b.isVisualImpaired)
-    {
-      return a.isVisualImpaired < b.isVisualImpaired;
-    }
-    if (a.isForced != b.isForced)
-    {
-      return a.isForced < b.isForced;
-    }
-    if (a.channels != b.channels)
-    {
-      return a.channels < b.channels;
-    }
-    if (a.bitrate != b.bitrate)
-    {
-      return a.bitrate < b.bitrate;
-    }
-    if (a.samplerate != b.samplerate)
-    {
-      return a.samplerate < b.samplerate;
-    }
-    return a.codecName < b.codecName;
-  }
-};
-
-struct SortComparerStreamSubtitle
-{
-  bool operator()(const SubtitleStreamInfoExt& a, const SubtitleStreamInfoExt& b)
-  {
-    if (a.isExternal != b.isExternal)
-    {
-      return a.isExternal > b.isExternal;
-    }
-    if (a.languageDesc != b.languageDesc)
-    {
-      return a.languageDesc < b.languageDesc;
-    }
-    if (a.isOriginal != b.isOriginal)
-    {
-      return a.isOriginal < b.isOriginal;
-    }
-    if (a.isHearingImpaired != b.isHearingImpaired)
-    {
-      return a.isHearingImpaired < b.isHearingImpaired;
-    }
-    if (a.isVisualImpaired != b.isVisualImpaired)
-    {
-      return a.isVisualImpaired < b.isVisualImpaired;
-    }
-    if (a.isForced != b.isForced)
-    {
-      return a.isForced < b.isForced;
-    }
-    return a.codecName < b.codecName;
-  }
-};
-
 bool SupportsAudioFeature(IPlayerAudioCaps feature, const std::vector<IPlayerAudioCaps>& caps)
 {
   for (IPlayerAudioCaps cap : caps)
@@ -299,22 +120,10 @@ void KODI::VIDEO::GUILIB::OpenDialogSelectVideoStream()
 
   auto& components = CServiceBroker::GetAppComponents();
   auto appPlayer = components.GetComponent<CApplicationPlayer>();
-  const int streamCount = appPlayer->GetVideoStreamCount();
   const int selectedId = appPlayer->GetVideoStream();
 
-  std::vector<VideoStreamInfoExt> streams;
-  streams.reserve(streamCount);
-
-  // Collect all streams
-  for (int i = 0; i < streamCount; ++i)
-  {
-    VideoStreamInfo info;
-    appPlayer->GetVideoStreamInfo(i, info);
-    streams.emplace_back(i, info);
-  }
-
-  // Sort streams
-  std::sort(streams.begin(), streams.end(), SortComparerStreamVideo());
+  using namespace KODI::VIDEO;
+  const std::vector<VideoStreamInfoExt> streams = CVideoStreamSelect::GetVideoStreams();
 
   // Convert streams to FileItem's
   CFileItemList itemsToDisplay;
@@ -382,22 +191,10 @@ void KODI::VIDEO::GUILIB::OpenDialogSelectAudioStream()
   if (!SupportsAudioFeature(IPlayerAudioCaps::SELECT_STREAM, caps))
     return;
 
-  const int streamCount = appPlayer->GetAudioStreamCount();
   const int selectedId = appPlayer->GetAudioStream();
 
-  std::vector<AudioStreamInfoExt> streams;
-  streams.reserve(streamCount);
-
-  // Collect all streams
-  for (int i = 0; i < streamCount; ++i)
-  {
-    AudioStreamInfo info;
-    appPlayer->GetAudioStreamInfo(i, info);
-    streams.emplace_back(i, info);
-  }
-
-  // Sort streams
-  std::sort(streams.begin(), streams.end(), SortComparerStreamAudio());
+  using namespace KODI::VIDEO;
+  const std::vector<AudioStreamInfoExt> streams = CVideoStreamSelect::GetAudioStreams();
 
   // Convert streams to FileItem's
   CFileItemList itemsToDisplay;
@@ -454,29 +251,17 @@ void KODI::VIDEO::GUILIB::OpenDialogSelectSubtitleStream()
   if (!SupportsSubtitleFeature(IPlayerSubtitleCaps::SELECT_STREAM, caps))
     return;
 
-  const int streamCount = appPlayer->GetSubtitleCount();
   const int selectedId = appPlayer->GetSubtitle();
   const bool isSubtitleEnabled = appPlayer->GetSubtitleVisible();
 
-  std::vector<SubtitleStreamInfoExt> streams;
-  streams.reserve(streamCount);
-
-  // Collect all streams
-  for (int i = 0; i < streamCount; ++i)
-  {
-    SubtitleStreamInfo info;
-    appPlayer->GetSubtitleStreamInfo(i, info);
-    streams.emplace_back(i, info);
-  }
-
-  // Sort streams
-  std::sort(streams.begin(), streams.end(), SortComparerStreamSubtitle());
+  using namespace KODI::VIDEO;
+  const std::vector<SubtitleStreamInfoExt> streams = CVideoStreamSelect::GetSubtitleStreams();
 
   // Convert streams to FileItem's
   CFileItemList itemsToDisplay;
   itemsToDisplay.Reserve(streams.size() + 1);
 
-  for (const SubtitleStreamInfoExt& info : streams)
+  for (const auto& info : streams)
   {
     CFileItemPtr fileItem = std::make_shared<CFileItem>(info.languageDesc);
     fileItem->SetProperty("stream.id", info.streamId);

--- a/xbmc/video/guilib/VideoStreamSelectHelper.cpp
+++ b/xbmc/video/guilib/VideoStreamSelectHelper.cpp
@@ -120,10 +120,18 @@ void KODI::VIDEO::GUILIB::OpenDialogSelectVideoStream()
 
   auto& components = CServiceBroker::GetAppComponents();
   auto appPlayer = components.GetComponent<CApplicationPlayer>();
+
+  if (appPlayer == nullptr)
+  {
+    CLog::LogF(LOGERROR, "No application player.");
+    return;
+  }
+
   const int selectedId = appPlayer->GetVideoStream();
 
   using namespace KODI::VIDEO;
-  const std::vector<VideoStreamInfoExt> streams = CVideoStreamSelect::GetVideoStreams();
+  const std::vector<VideoStreamInfoExt> streams =
+      CVideoStreamSelect::GetVideoStreams(appPlayer.get());
 
   // Convert streams to FileItem's
   CFileItemList itemsToDisplay;
@@ -186,6 +194,12 @@ void KODI::VIDEO::GUILIB::OpenDialogSelectAudioStream()
   auto& components = CServiceBroker::GetAppComponents();
   auto appPlayer = components.GetComponent<CApplicationPlayer>();
 
+  if (appPlayer == nullptr)
+  {
+    CLog::LogF(LOGERROR, "No application player.");
+    return;
+  }
+
   std::vector<IPlayerAudioCaps> caps;
   appPlayer->GetAudioCapabilities(caps);
   if (!SupportsAudioFeature(IPlayerAudioCaps::SELECT_STREAM, caps))
@@ -194,7 +208,8 @@ void KODI::VIDEO::GUILIB::OpenDialogSelectAudioStream()
   const int selectedId = appPlayer->GetAudioStream();
 
   using namespace KODI::VIDEO;
-  const std::vector<AudioStreamInfoExt> streams = CVideoStreamSelect::GetAudioStreams();
+  const std::vector<AudioStreamInfoExt> streams =
+      CVideoStreamSelect::GetAudioStreams(appPlayer.get());
 
   // Convert streams to FileItem's
   CFileItemList itemsToDisplay;
@@ -246,6 +261,12 @@ void KODI::VIDEO::GUILIB::OpenDialogSelectSubtitleStream()
   auto& components = CServiceBroker::GetAppComponents();
   auto appPlayer = components.GetComponent<CApplicationPlayer>();
 
+  if (appPlayer == nullptr)
+  {
+    CLog::LogF(LOGERROR, "No application player.");
+    return;
+  }
+
   std::vector<IPlayerSubtitleCaps> caps;
   appPlayer->GetSubtitleCapabilities(caps);
   if (!SupportsSubtitleFeature(IPlayerSubtitleCaps::SELECT_STREAM, caps))
@@ -255,7 +276,8 @@ void KODI::VIDEO::GUILIB::OpenDialogSelectSubtitleStream()
   const bool isSubtitleEnabled = appPlayer->GetSubtitleVisible();
 
   using namespace KODI::VIDEO;
-  const std::vector<SubtitleStreamInfoExt> streams = CVideoStreamSelect::GetSubtitleStreams();
+  const std::vector<SubtitleStreamInfoExt> streams =
+      CVideoStreamSelect::GetSubtitleStreams(appPlayer.get());
 
   // Convert streams to FileItem's
   CFileItemList itemsToDisplay;

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES TestBookmark.cpp
             TestVideoDbUrl.cpp
             TestVideoFileItemClassify.cpp
             TestVideoInfoTag.cpp
+            TestVideoStreamSelect.cpp
             TestVideoUtils.cpp)
 
 core_add_test_library(video_test)

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES TestBookmark.cpp
             TestFilenameAttributes.cpp
+            TestPlayerControllerActions.cpp
             TestStacks.cpp
             TestVideoDbUrl.cpp
             TestVideoFileItemClassify.cpp

--- a/xbmc/video/test/TestPlayerControllerActions.cpp
+++ b/xbmc/video/test/TestPlayerControllerActions.cpp
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "video/PlayerControllerActions.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI::VIDEO;
+
+namespace
+{
+struct SubtitleTrackTestParam
+{
+  int count;
+  int index;
+  bool visible;
+  SubtitleTrackAction action;
+  SubtitleTrackResult expected;
+};
+
+const SubtitleTrackTestParam SubtitleTrackTests[] = {
+    // single stream
+    // prev/next make visible
+    {1, 0, true, SubtitleTrackAction::NEXT, {0, false}},
+    {1, 0, true, SubtitleTrackAction::PREV, {0, false}},
+
+    // currently hidden
+    {1, 0, false, SubtitleTrackAction::NEXT, {0, true}},
+    {1, 0, false, SubtitleTrackAction::PREV, {0, true}},
+
+    // 3 streams
+    // next advances a visible track then hides then shows first again
+    {3, 0, true, SubtitleTrackAction::NEXT, {1, true}},
+    {3, 1, true, SubtitleTrackAction::NEXT, {2, true}},
+    {3, 2, true, SubtitleTrackAction::NEXT, {0, false}},
+    {3, 0, false, SubtitleTrackAction::NEXT, {0, true}},
+
+    // previous goes back then hides then shows last again
+    {3, 2, true, SubtitleTrackAction::PREV, {1, true}},
+    {3, 1, true, SubtitleTrackAction::PREV, {0, true}},
+    {3, 0, true, SubtitleTrackAction::PREV, {0, false}},
+    {3, 0, false, SubtitleTrackAction::PREV, {2, true}},
+
+    // cycle advances and returns to first
+    {3, 0, true, SubtitleTrackAction::CYCLE, {1, true}},
+    {3, 1, true, SubtitleTrackAction::CYCLE, {2, true}},
+    {3, 2, true, SubtitleTrackAction::CYCLE, {0, true}},
+
+    // prev and next make visible
+    {3, 1, false, SubtitleTrackAction::NEXT, {1, true}},
+    {3, 1, false, SubtitleTrackAction::PREV, {1, true}},
+
+    // corner case: no stream is a no-op
+    {0, 0, false, SubtitleTrackAction::NEXT, {0, false}},
+    {0, 0, true, SubtitleTrackAction::NEXT, {0, true}},
+    {0, 0, false, SubtitleTrackAction::PREV, {0, false}},
+    {0, 0, true, SubtitleTrackAction::PREV, {0, true}},
+    {0, 0, false, SubtitleTrackAction::CYCLE, {0, false}},
+    {0, 0, true, SubtitleTrackAction::CYCLE, {0, true}},
+
+    // corner case: ouf of bounds index is a no-op
+    {1, 1, false, SubtitleTrackAction::NEXT, {1, false}},
+    {1, 1, true, SubtitleTrackAction::NEXT, {1, true}},
+    {1, 1, false, SubtitleTrackAction::PREV, {1, false}},
+    {1, 1, true, SubtitleTrackAction::PREV, {1, true}},
+    {1, 1, false, SubtitleTrackAction::CYCLE, {1, false}},
+    {1, 1, true, SubtitleTrackAction::CYCLE, {1, true}},
+};
+} // namespace
+
+class SubtitleTrackTest : public testing::Test,
+                          public testing::WithParamInterface<SubtitleTrackTestParam>
+{
+};
+
+TEST_P(SubtitleTrackTest, Navigate)
+{
+  const auto& params = GetParam();
+  auto [index, visible] = CPlayerControllerActions::ExecSubtitleTrackAction(
+      params.count, params.index, params.visible, params.action);
+  EXPECT_EQ(index, params.expected.newIndex);
+  EXPECT_EQ(visible, params.expected.newVisible);
+}
+
+INSTANTIATE_TEST_SUITE_P(TestPlayerControllerActions,
+                         SubtitleTrackTest,
+                         testing::ValuesIn(SubtitleTrackTests));

--- a/xbmc/video/test/TestVideoStreamSelect.cpp
+++ b/xbmc/video/test/TestVideoStreamSelect.cpp
@@ -1,0 +1,433 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "video/VideoStreamSelect.h"
+
+#include <gtest/gtest.h>
+
+using namespace KODI::VIDEO;
+
+namespace
+{
+
+// ---------------------------------------------------------------------------
+// Video tests
+// ---------------------------------------------------------------------------
+
+struct MockVideoStreamInfo
+{
+  int streamId;
+  std::string language;
+  std::string codecName;
+  StreamHdrType hdrType{StreamHdrType::HDR_TYPE_NONE};
+  float fps{0.0f}; // stored directly in VideoStreamInfoExt (pre-computed)
+  int height{0};
+  int width{0};
+  int bitrate{0};
+};
+
+struct VideoSortTestParam
+{
+  std::string name;
+  std::vector<MockVideoStreamInfo> inputStreams;
+  CVideoStreamSelect::TrackOrder order;
+  std::vector<int> expectedStreamIds;
+};
+
+std::ostream& operator<<(std::ostream& os, const VideoSortTestParam& param)
+{
+  return os << param.name;
+}
+
+const VideoSortTestParam VideoSortTests[] = {
+    // MEDIA order: streams remain in their original sequence
+    {"MediaOrder",
+     {{0, "fre", "h264"}, {1, "eng", "h264"}},
+     CVideoStreamSelect::TrackOrder::MEDIA,
+     {0, 1}},
+
+    // SORTED order: sort streams using their attributes
+    {"LanguageAlphabetical",
+     {{0, "fre", "h264"}, {1, "eng", "h264"}},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+
+    {"CodecName",
+     {{0, "eng", "hevc"}, {1, "eng", "h264"}},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+
+    {"HdrType",
+     {{0, "eng", "hevc", StreamHdrType::HDR_TYPE_HDR10},
+      {1, "eng", "hevc", StreamHdrType::HDR_TYPE_NONE}},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+
+    {"Fps",
+     {{0, "eng", "hevc", StreamHdrType::HDR_TYPE_NONE, /*fps=*/60.0f},
+      {1, "eng", "hevc", StreamHdrType::HDR_TYPE_NONE, /*fps=*/24.0f}},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+
+    {"Height",
+     {{0, "eng", "hevc", StreamHdrType::HDR_TYPE_NONE, 24.0f, /*height=*/2160},
+      {1, "eng", "hevc", StreamHdrType::HDR_TYPE_NONE, 24.0f, /*height=*/1080}},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+
+    {"Width",
+     {{0, "eng", "hevc", StreamHdrType::HDR_TYPE_NONE, 24.0f, 1080, /*width=*/1920},
+      {1, "eng", "hevc", StreamHdrType::HDR_TYPE_NONE, 24.0f, 1080, /*width=*/1280}},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+
+    {"Bitrate",
+     {{0, "eng", "hevc", StreamHdrType::HDR_TYPE_NONE, 24.0f, 1080, 1280, /*bitrate=*/8000000},
+      {1, "eng", "hevc", StreamHdrType::HDR_TYPE_NONE, 24.0f, 1080, 1280, /*bitrate=*/4000000}},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+
+    // Single stream unchanged
+    {"SingleStreamMedia", {{0, "eng", "h264"}}, CVideoStreamSelect::TrackOrder::MEDIA, {0}},
+    {"SingleStreamSorted", {{0, "eng", "h264"}}, CVideoStreamSelect::TrackOrder::SORTED, {0}},
+
+    // Already-sorted input must remain stable.
+    {"AlreadySorted",
+     {{0, "eng", "h264"}, {1, "fre", "h264"}},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {0, 1}},
+};
+} // namespace
+
+class VideoStreamSelectVideoOrderTest : public testing::Test,
+                                        public testing::WithParamInterface<VideoSortTestParam>
+{
+};
+
+TEST_P(VideoStreamSelectVideoOrderTest, OrderVideo)
+{
+  const auto& params = GetParam();
+
+  // Instantiate SubtitleStreamInfoExt at execution time to avoid possible g_LangCodeExpander
+  // static initialization order issues.
+  std::vector<VideoStreamInfoExt> streams;
+  streams.reserve(params.inputStreams.size());
+  for (const auto& mock : params.inputStreams)
+  {
+    VideoStreamInfo info;
+    info.language = mock.language;
+    info.codecName = mock.codecName;
+    info.hdrType = mock.hdrType;
+    info.height = mock.height;
+    info.width = mock.width;
+    info.bitrate = mock.bitrate;
+    // Encode fps as fpsRate with fpsScale=1 so VideoStreamInfoExt computes the
+    // right float without floating-point error.
+    info.fpsRate = static_cast<uint32_t>(mock.fps);
+    info.fpsScale = 1;
+
+    streams.emplace_back(mock.streamId, info);
+  }
+
+  CVideoStreamSelect::OrderVideoStreams(streams, params.order);
+
+  ASSERT_EQ(params.expectedStreamIds.size(), streams.size());
+  //! @todo C++23 use zip algorithm
+  for (size_t i = 0; i < streams.size(); ++i)
+  {
+    EXPECT_EQ(params.expectedStreamIds[i], streams[i].streamId);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(TestVideoStreamSelect,
+                         VideoStreamSelectVideoOrderTest,
+                         testing::ValuesIn(VideoSortTests));
+
+// ---------------------------------------------------------------------------
+// Audio tests
+// ---------------------------------------------------------------------------
+
+namespace
+{
+struct MockAudioStreamInfo
+{
+  int streamId;
+  std::string language;
+  StreamFlags flags;
+  int channels{0};
+  int bitrate{0};
+  int samplerate{0};
+  std::string codecName;
+};
+
+// work around -Werror=missing-field-initializers on some platform builds
+MockAudioStreamInfo MakeAudioStream(int streamId,
+                                    std::string language,
+                                    StreamFlags flags,
+                                    int channels = 0,
+                                    int bitrate = 0,
+                                    int samplerate = 0,
+                                    std::string codecName = "")
+{
+  return {streamId,   std::move(language), flags, channels, bitrate,
+          samplerate, std::move(codecName)};
+}
+
+struct AudioSortTestParam
+{
+  std::string name;
+  std::vector<MockAudioStreamInfo> inputStreams;
+  CVideoStreamSelect::TrackOrder order;
+  std::vector<int> expectedStreamIds;
+};
+
+std::ostream& operator<<(std::ostream& os, const AudioSortTestParam& param)
+{
+  return os << param.name;
+}
+
+const AudioSortTestParam AudioSortTests[] = {
+    // MEDIA order: streams remain in their original sequence
+    {"MediaOrder",
+     {MakeAudioStream(0, "fre", FLAG_NONE), MakeAudioStream(1, "eng", FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::MEDIA,
+     {0, 1}},
+    // SORTED order: sort streams using their attributes
+    {"LanguageAlphabetical",
+     {MakeAudioStream(0, "fre", FLAG_NONE), MakeAudioStream(1, "eng", FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    {"OriginalFlag",
+     {MakeAudioStream(0, "eng", FLAG_ORIGINAL), MakeAudioStream(1, "eng", FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    {"HearingImpaired",
+     {MakeAudioStream(0, "eng", FLAG_HEARING_IMPAIRED), MakeAudioStream(1, "eng", FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    {"VisualImpaired",
+     {MakeAudioStream(0, "eng", FLAG_VISUAL_IMPAIRED), MakeAudioStream(1, "eng", FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    {"Forced",
+     {MakeAudioStream(0, "eng", FLAG_FORCED), MakeAudioStream(1, "eng", FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    {"Channels",
+     {MakeAudioStream(0, "en", FLAG_NONE, /*channels=*/6),
+      MakeAudioStream(1, "en", FLAG_NONE, /*channels=*/2)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    {"Bitrate",
+     {MakeAudioStream(0, "en", FLAG_NONE, 2, /*bitrate=*/320000),
+      MakeAudioStream(1, "en", FLAG_NONE, 2, /*bitrate=*/128000)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    {"Samplerate",
+     {MakeAudioStream(0, "en", FLAG_NONE, 2, 128000, /*samplerate=*/48000),
+      MakeAudioStream(1, "en", FLAG_NONE, 2, 128000, /*samplerate=*/44100)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    // Same samplerate: alphabetical codec name.
+    {"CodecName",
+     {MakeAudioStream(0, "en", FLAG_NONE, 2, 128000, 44100, "dts"),
+      MakeAudioStream(1, "en", FLAG_NONE, 2, 128000, 44100, "aac")},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    // Single stream unchanged
+    {"SingleStreamMedia",
+     {MakeAudioStream(0, "en", FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::MEDIA,
+     {0}},
+    {"SingleStreamSorted",
+     {MakeAudioStream(0, "en", FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {0}},
+    // Already-sorted input must remain stable.
+    {"AlreadySorted",
+     {MakeAudioStream(0, "en", FLAG_NONE, 2, 128000, 44100, "aac"),
+      MakeAudioStream(1, "fr", FLAG_NONE, 2, 128000, 44100, "aac")},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {0, 1}},
+};
+} // namespace
+
+class VideoStreamSelectAudioOrderTest : public testing::Test,
+                                        public testing::WithParamInterface<AudioSortTestParam>
+{
+};
+
+TEST_P(VideoStreamSelectAudioOrderTest, OrderAudio)
+{
+  const auto& params = GetParam();
+
+  // Instantiate AudioStreamInfoExt at execution time to avoid possible g_LangCodeExpander
+  // static initialization order issues.
+  std::vector<AudioStreamInfoExt> streams;
+  streams.reserve(params.inputStreams.size());
+  for (const auto& mock : params.inputStreams)
+  {
+    AudioStreamInfo info;
+    info.language = mock.language;
+    info.codecName = mock.codecName;
+    info.flags = mock.flags;
+    info.channels = mock.channels;
+    info.samplerate = mock.samplerate;
+    info.bitrate = mock.bitrate;
+
+    streams.emplace_back(mock.streamId, info);
+  }
+
+  CVideoStreamSelect::OrderAudioStreams(streams, params.order);
+
+  ASSERT_EQ(params.expectedStreamIds.size(), streams.size());
+  //! @todo C++23 use zip algorithm
+  for (size_t i = 0; i < streams.size(); ++i)
+  {
+    EXPECT_EQ(params.expectedStreamIds[i], streams[i].streamId);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(TestVideoStreamSelect,
+                         VideoStreamSelectAudioOrderTest,
+                         testing::ValuesIn(AudioSortTests));
+
+// ---------------------------------------------------------------------------
+// Subtitle tests
+// ---------------------------------------------------------------------------
+namespace
+{
+struct MockSubtitleStreamInfo
+{
+  int streamId;
+  std::string language;
+  bool isExternal;
+  StreamFlags flags;
+  std::string codecName;
+};
+
+// work around -Werror=missing-field-initializers on some platform builds
+MockSubtitleStreamInfo MakeSubtitleStream(int streamId,
+                                          std::string language,
+                                          bool isExternal,
+                                          StreamFlags flags,
+                                          std::string codecName = "")
+{
+  return {streamId, std::move(language), isExternal, flags, std::move(codecName)};
+}
+
+struct SubtitleSortTestParam
+{
+  std::string name;
+  std::vector<MockSubtitleStreamInfo> inputStreams;
+  CVideoStreamSelect::TrackOrder order;
+  std::vector<int> expectedStreamIds;
+};
+
+std::ostream& operator<<(std::ostream& os, const SubtitleSortTestParam& param)
+{
+  return os << param.name;
+}
+
+const SubtitleSortTestParam SubtitleSortTests[] = {
+    // MEDIA order: streams remain in their original sequence
+    {"MediaOrder",
+     {MakeSubtitleStream(0, "fre", false, FLAG_NONE),
+      MakeSubtitleStream(1, "eng", true, FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::MEDIA,
+     {0, 1}},
+    // SORTED order: sort streams using their attributes
+    {"ExternalFirst",
+     {MakeSubtitleStream(0, "eng", false, FLAG_NONE),
+      MakeSubtitleStream(1, "eng", true, FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    {"LanguageAlphabetical",
+     {MakeSubtitleStream(0, "fre", false, FLAG_NONE),
+      MakeSubtitleStream(1, "eng", false, FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    {"OriginalFlag",
+     {MakeSubtitleStream(0, "eng", false, FLAG_ORIGINAL),
+      MakeSubtitleStream(1, "eng", false, FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    {"HearingImpaired",
+     {MakeSubtitleStream(0, "eng", false, FLAG_HEARING_IMPAIRED),
+      MakeSubtitleStream(1, "eng", false, FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    {"VisualImpaired",
+     {MakeSubtitleStream(0, "eng", false, FLAG_VISUAL_IMPAIRED),
+      MakeSubtitleStream(1, "eng", false, FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    {"Forced",
+     {MakeSubtitleStream(0, "eng", false, FLAG_FORCED),
+      MakeSubtitleStream(1, "eng", false, FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    {"CodecName",
+     {MakeSubtitleStream(0, "eng", false, FLAG_NONE, "subrip"),
+      MakeSubtitleStream(1, "eng", false, FLAG_NONE, "ass")},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {1, 0}},
+    // Single stream unchanged
+    {"SingleStreamMedia",
+     {MakeSubtitleStream(0, "en", false, FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::MEDIA,
+     {0}},
+    {"SingleStreamSorted",
+     {MakeSubtitleStream(0, "en", false, FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {0}},
+    // Already-sorted input must remain stable.
+    {"AlreadySorted",
+     {MakeSubtitleStream(0, "en", false, FLAG_NONE), MakeSubtitleStream(1, "fr", false, FLAG_NONE)},
+     CVideoStreamSelect::TrackOrder::SORTED,
+     {0, 1}},
+};
+} // namespace
+
+class VideoStreamSelectSubtitleOrderTest : public testing::Test,
+                                           public testing::WithParamInterface<SubtitleSortTestParam>
+{
+};
+
+TEST_P(VideoStreamSelectSubtitleOrderTest, OrderSubtitles)
+{
+  const auto& params = GetParam();
+
+  // Instantiate SubtitleStreamInfoExt at execution time to avoid possible g_LangCodeExpander
+  // static initialization order issues.
+  std::vector<SubtitleStreamInfoExt> streams;
+  streams.reserve(params.inputStreams.size());
+  for (const auto& mock : params.inputStreams)
+  {
+    SubtitleStreamInfo info;
+    info.language = mock.language;
+    info.codecName = mock.codecName;
+    info.flags = mock.flags;
+    info.isExternal = mock.isExternal;
+
+    streams.emplace_back(mock.streamId, info);
+  }
+
+  CVideoStreamSelect::OrderSubtitleStreams(streams, params.order);
+
+  ASSERT_EQ(params.expectedStreamIds.size(), streams.size());
+  //! @todo C++23 use zip algorithm
+  for (size_t i = 0; i < streams.size(); ++i)
+  {
+    EXPECT_EQ(params.expectedStreamIds[i], streams[i].streamId);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(TestVideoStreamSelect,
+                         VideoStreamSelectSubtitleOrderTest,
+                         testing::ValuesIn(SubtitleSortTests));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The PR synchronizes the display order of video, audio and subtitle tracks in the classic video settings, the stream selection dialog and the previous/next/cycle actions.

The current discrepancies happened because the new stream selection dialog was developed with sorting for the needs of streaming videos, unlike the rest of the existing code and dialogs. For the streaming scenario, streams will always be sorted according to stream attributes.

For non-streaming, the order can be controlled with a new settings in Settings > Player > Advanced:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/9c4ef12d-bea4-4b6e-8340-d91fbb44f67c" />

The spinner control alternates between two values:
- Media: the tracks are in the order defined in the media (original order of the classic video settings and the actions)
- Sorted: the tracks are sorted using various attributes of the tracks (is external, language, original, hearing impaired, visual impaired, forced, codec) - (original algorithm used by the stream selection dialog)

The existing code creating the streams lists for the VideoStreamSelect dialog was extracted and is now shared with the OSD and the actions.
The shared code was placed in new files `video/VideoStreamSelect.h` and `.cpp`.

A small existing bug of the subtitle cycle action was corrected at the same time: when subtitles were hidden, the cycle action used to display a toast with the name of the active track. The toast message now says "Disabled".

The code of the subtitle next/prev/cycle actions is a bit intricate and was extracted in order to make it unit-testable.
Video and audio only have a straightforward next action and there was no need for the same effort.

Looks like a large PR but a lot of it moves code around and adds unit tests.

Open points:
~- should the same treatment be applied to audio tracks? If so, common setting or separate setting?~ yes
~- user interface: is Settings > Player > Languages the right location for the setting? It doesn't fit neatly into existing categories anywhere in settings.~ moved to Settings > Player > Videos
~- what should he default value be?~ Media

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The "classic" video settings dialog and the new stream selection dialog show the video, audio and subtitle tracks in different orders.

The video settings dialog follows the media order of tracks and the stream selection sorts tracks using track attributes (is external, language, original, hearing impaired, visual impaired, forced, codec)

In addition, the next/previous/cycle subtitle actions use the media order, with unexpected results in conjunction with the stream selection dialog.

There are valid cases for both orders: local files (anime) may have subs arranged in a convenient order, online sources may have a more or less random track order that would be confusing without organization.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

local file and inputstream stream with multiple video/audio/subs, open the dialogs with the two setting values, checked that the current stream (or "disabled") is selected on open and that the correct track is switched to, that the display is consistent between the 2 dialogs.
Then tried the previous/next/cycle subtitle actions using a custom keyboard keymap.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

User-controllable and consistent streams order in the Stream selection dialog, the OSD settings, and the previous/next/cycle actions.

## Screenshots (if appropriate):

Online stream with "Media" order:
<img width="1099" height="795" alt="image" src="https://github.com/user-attachments/assets/dbaa9696-e5fd-4efd-a4cd-8ba86e14ac3e" />

<img width="1363" height="788" alt="image" src="https://github.com/user-attachments/assets/d29156d4-367b-4493-b6a6-956bf56059b4" />

Online stream with "Sorted" order:
<img width="1096" height="785" alt="image" src="https://github.com/user-attachments/assets/2a20e57d-d50c-41c0-9b08-147aa21c3675" />

<img width="1363" height="783" alt="image" src="https://github.com/user-attachments/assets/4c1bede9-7e85-4532-aacf-63ce087ddab3" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
