### PR TITLE
fixed: report a missing PVR add-on without blocking the caller

### DIFF
--- a/xbmc/pvr/windows/GUIWindowPVRBase.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRBase.cpp
@@ -16,6 +16,7 @@
 #include "addons/AddonManager.h"
 #include "addons/addoninfo/AddonType.h"
 #include "dialogs/GUIDialogExtendedProgressBar.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogSelect.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIMessage.h"
@@ -23,7 +24,6 @@
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
 #include "messaging/ApplicationMessenger.h"
-#include "messaging/helpers/DialogOKHelper.h"
 #include "pvr/PVRManager.h"
 #include "pvr/PVRPlaybackState.h"
 #include "pvr/PVRThumbLoader.h"
@@ -50,7 +50,6 @@
 using namespace std::chrono_literals;
 
 using namespace PVR;
-using namespace KODI::MESSAGING;
 
 namespace
 {
@@ -419,9 +418,12 @@ bool CGUIWindowPVRBase::CanBeActivated() const
   // check if there is at least one enabled PVR add-on
   if (!CServiceBroker::GetAddonMgr().HasAddons(ADDON::AddonType::PVRDLL))
   {
-    HELPERS::ShowOKDialogText(
-        CVariant{19296},
-        CVariant{19272}); // No PVR add-on enabled, You need a tuner, backend software...
+    // Notify without blocking. A modal dialog would run its own render loop and hold up
+    // whatever asked for this window until someone dismissed it at the device.
+    const CLocalizeStrings& strings{CServiceBroker::GetResourcesComponent().GetLocalizeStrings()};
+    CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning,
+                                          strings.Get(19296), // No PVR add-on enabled
+                                          strings.Get(19272)); // To use PVR you need to install...
     return false;
   }
 


### PR DESCRIPTION
**TL;DR:** Bug fix. Activating a PVR window with no PVR add-on enabled raised a modal dialog inside the activation, which held up every caller, including startup when a PVR window is the start window. The message is now a notification, and the window still declines to open.

## Description
`CGUIWindowPVRBase::CanBeActivated` raised a modal OK dialog when no PVR add-on was enabled. `CGUIDialog::Open_Internal` runs its own render loop, so `CGUIWindowManager::ActivateWindow_Internal` did not return until that dialog was dismissed, and every caller of `ActivateWindow` waited with it.

The cost lands at startup. With a PVR window configured as the start window and no PVR add-on enabled, `CApplication::Initialize` blocks inside the activation until the dialog is answered.

The message does not need acknowledgement. It states why the window will not open and offers nothing to decide, so a notification carries it without holding up the caller. The activation result is unchanged: `CanBeActivated` still returns false and the window manager still declines the window.

The `DialogOKHelper` include and the `KODI::MESSAGING` using-directive go with it; that dialog call was the last user of either.

## Motivation and context
Noticed while working on #28912, which addresses the same startup stall from the other side — that PR moves the remote interfaces above the first window activation so a dialog raised there can at least be answered remotely. This removes one of the dialogs that causes the stall in the first place.

The two are independent. #28912 is still needed: the master lock prompt blocks the same way, as does any dialog a skin's start window raises.

## How has this been tested?
Portable Windows build, start window set to "TV guide", `pvr.iptvsimple` disabled so no PVR add-on is enabled.

With debug logging on, the whole activation sequence now completes within a single millisecond:

```
10:53:28.951  Activating window ID: 12997      (splash)
10:53:28.951  Activating window ID: 12999      (Startup.xml)
10:53:28.951  Activating window ID: 10702      (TV guide - CanBeActivated returns false)
10:53:28.951  Activating window ID: 10000      (Home)
10:53:28.951  ------ Window Init (Home.xml) ------
10:53:28.984  initialize done
10:53:29.017  ------ Window Init (DialogNotification.xml) ------
```

`DialogConfirm.xml` no longer appears; `DialogNotification.xml` carries the message instead. Kodi reaches Home and finishes initialising without any input. The fallback to Home is unchanged - `WINDOW_STARTUP_ANIM` is active at that point, so `ActivateWindow_Internal` takes its existing `ActivateWindow(WINDOW_HOME)` path.

Estuary's `DialogNotification.xml` uses `fadelabel` for both lines, so the longer second line scrolls rather than being cut off.

Full gtest suite: 3693 tests, 3692 passed. The one failure was `TestHTTPDirectory`, which is flaky on this machine - a different test in that suite times out at ~6.7s on each run and the suite passes clean on re-run. `clang-format` clean on the touched lines.

`CGUIWindowPVRBase` has no test harness; verified against the running application as above.

## What is the effect on users?
Selecting a PVR window with no PVR add-on enabled shows a notification instead of a dialog that has to be dismissed. The window still does not open. When a PVR window is the configured start window, startup is no longer held up waiting for that dialog to be answered.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
