### PR TITLE
[cmake] Retry swig build-dep downloads instead of failing the configure

### DIFF
--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -493,6 +493,90 @@ function(core_optional_package_lib)
   set(final_message ${final_message} PARENT_SCOPE)
 endfunction()
 
+# Download a file, retrying failed attempts.
+# file(DOWNLOAD) fails the configure on the first timeout or mirror hiccup.
+# Arguments:
+#   url         url to download from
+#   destination full path of the file to write
+# Optional Arguments:
+#   HASH:        expected hash in cmake <ALGO>=<value> notation. A destination
+#                already matching it is kept, a download not matching it is
+#                retried.
+#   RETRIES:     number of retries after a failed attempt (default: 3)
+#   RETRY_DELAY: seconds to wait between attempts (default: 5)
+# On return:
+#   The file is downloaded to destination, otherwise a FATAL_ERROR is raised.
+#   A failed attempt never leaves a partial file behind.
+function(core_file_download url destination)
+  cmake_parse_arguments(arg "" "HASH;RETRIES;RETRY_DELAY" "" ${ARGN})
+
+  # An empty variable expands to nothing, so a mistyped HASH ${VAR} would leave
+  # the keyword bare and download the file unverified
+  if(arg_KEYWORDS_MISSING_VALUES)
+    message(FATAL_ERROR "core_file_download - missing value for: ${arg_KEYWORDS_MISSING_VALUES}")
+  endif()
+  if(arg_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "core_file_download - unknown arguments: ${arg_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(NOT DEFINED arg_RETRIES)
+    set(arg_RETRIES 3)
+  endif()
+  if(NOT DEFINED arg_RETRY_DELAY)
+    set(arg_RETRY_DELAY 5)
+  endif()
+
+  if(DEFINED arg_HASH)
+    if(NOT arg_HASH MATCHES "^([A-Za-z0-9_]+)=([0-9A-Fa-f]+)$")
+      message(FATAL_ERROR "core_file_download - malformed HASH: ${arg_HASH}, expected <ALGO>=<value>")
+    endif()
+    string(TOUPPER ${CMAKE_MATCH_1} hash_algo)
+    string(TOLOWER ${CMAKE_MATCH_2} expected_hash)
+
+    # Nothing to do if we already have a good copy of the file
+    if(EXISTS ${destination})
+      file(${hash_algo} ${destination} existing_hash)
+      if(existing_hash STREQUAL expected_hash)
+        return()
+      endif()
+      file(REMOVE ${destination})
+    endif()
+  endif()
+
+  math(EXPR attempts "${arg_RETRIES} + 1")
+  set(attempt 1)
+  while(TRUE)
+    file(DOWNLOAD ${url} ${destination} SHOW_PROGRESS STATUS dl_status LOG dl_log)
+    list(GET dl_status 0 dl_retcode)
+    list(GET dl_status 1 dl_error)
+
+    if(dl_retcode EQUAL 0 AND DEFINED arg_HASH)
+      file(${hash_algo} ${destination} dl_hash)
+      if(NOT dl_hash STREQUAL expected_hash)
+        set(dl_retcode 1)
+        set(dl_error "hash mismatch, expected ${hash_algo}=${expected_hash}, got ${hash_algo}=${dl_hash}")
+      endif()
+    endif()
+
+    if(dl_retcode EQUAL 0)
+      break()
+    endif()
+
+    # Leave nothing behind that a later run could mistake for a good copy
+    file(REMOVE ${destination})
+
+    if(attempt GREATER_EQUAL attempts)
+      message(FATAL_ERROR "core_file_download - failed to download ${url} after ${attempts} attempts:"
+                          " ${dl_error}\nlog: ${dl_log}")
+    endif()
+
+    message(STATUS "core_file_download - download of ${url} failed (attempt ${attempt} of ${attempts}):"
+                   " ${dl_error}. Retrying in ${arg_RETRY_DELAY} seconds")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E sleep ${arg_RETRY_DELAY})
+    math(EXPR attempt "${attempt} + 1")
+  endwhile()
+endfunction()
+
 function(core_file_read_filtered result filepattern)
   # Reads STRINGS from text files
   #  with comments filtered out

--- a/xbmc/interfaces/swig/CMakeLists.txt
+++ b/xbmc/interfaces/swig/CMakeLists.txt
@@ -74,8 +74,8 @@ set(APACHE_COMMONS_TEXT_URL ${KODI_MIRROR}/build-deps/sources/${APACHE_COMMONS_T
 set(APACHE_COMMONS_TEXT_URL_HASH SHA512=6d1fcbd85a85f38e95ea33c9ab7f58798723b0e6357077246a135c417e75c7b39e278ebdb77fcc8f9b56b52b1eeff113eea9463eaaaee8d38df9afdc149b6421)
 
 if(NOT groovy_SOURCE_DIR)
-  # file wont be downloaded if EXPECTED_HASH matches existing archive
-  file(DOWNLOAD ${GROOVY_URL} ${TARBALL_DIR}/${GROOVY_ARCHIVE} SHOW_PROGRESS EXPECTED_HASH ${GROOVY_URL_HASH})
+  # file won't be downloaded if HASH matches existing archive
+  core_file_download(${GROOVY_URL} ${TARBALL_DIR}/${GROOVY_ARCHIVE} HASH ${GROOVY_URL_HASH})
 
   set(groovy_exe_name groovy)
   if(WIN32 OR WINDOWS_STORE)
@@ -109,8 +109,8 @@ if(NOT groovy_SOURCE_DIR)
 endif()
 
 if(NOT apache-commons-lang_SOURCE_DIR)
-  # file wont be downloaded if EXPECTED_HASH matches existing archive
-  file(DOWNLOAD ${APACHE_COMMONS_LANG_URL} ${TARBALL_DIR}/${APACHE_COMMONS_LANG_ARCHIVE} SHOW_PROGRESS EXPECTED_HASH ${APACHE_COMMONS_LANG_URL_HASH})
+  # file won't be downloaded if HASH matches existing archive
+  core_file_download(${APACHE_COMMONS_LANG_URL} ${TARBALL_DIR}/${APACHE_COMMONS_LANG_ARCHIVE} HASH ${APACHE_COMMONS_LANG_URL_HASH})
 
   if(NOT EXISTS ${DEPENDS_PATH}/share/java/lang/commons-lang3-${APACHE_COMMONS_LANG_VER}.jar)
 
@@ -128,8 +128,8 @@ if(NOT apache-commons-lang_SOURCE_DIR)
 endif()
 
 if(NOT apache-commons-text_SOURCE_DIR)
-  # file wont be downloaded if EXPECTED_HASH matches existing archive
-  file(DOWNLOAD ${APACHE_COMMONS_TEXT_URL} ${TARBALL_DIR}/${APACHE_COMMONS_TEXT_ARCHIVE} SHOW_PROGRESS EXPECTED_HASH ${APACHE_COMMONS_TEXT_URL_HASH})
+  # file won't be downloaded if HASH matches existing archive
+  core_file_download(${APACHE_COMMONS_TEXT_URL} ${TARBALL_DIR}/${APACHE_COMMONS_TEXT_ARCHIVE} HASH ${APACHE_COMMONS_TEXT_URL_HASH})
 
   if(NOT EXISTS ${DEPENDS_PATH}/share/java/text/commons-text-${APACHE_COMMONS_TEXT_VER}.jar)
 


### PR DESCRIPTION
## Description
The three build-dependency downloads in `xbmc/interfaces/swig/CMakeLists.txt` (groovy, commons-lang, commons-text) now go through a new `core_file_download()` helper in `cmake/scripts/common/Macros.cmake` instead of a bare `file(DOWNLOAD)`.

The helper:
- retries a failed transfer (3 retries, 5s apart, both configurable per call),
- treats a hash mismatch as a retryable failure rather than a hard abort,
- deletes the file after every failed attempt, so a truncated archive is never cached for a later configure,
- skips the download when the destination already matches the expected hash, which is what `EXPECTED_HASH` did before,
- raises `FATAL_ERROR` once the retries are exhausted.

## Motivation and context
A single timeout against the mirror currently fails the configure:

```
CMake Error at xbmc/interfaces/swig/CMakeLists.txt:78 (file):
  file DOWNLOAD cannot compute hash on failed download

    status: [28;"Timeout was reached"]
```

Because `file(DOWNLOAD)` errors are not fatal, configuring continues and the next error the reader sees is unrelated to the real cause:

```
CMake Error at xbmc/interfaces/swig/CMakeLists.txt:105 (file):
  file RENAME failed to rename

    /home/runner/work/xbmc/xbmc/build/build/share/groovy-4.0.30

  to

    /home/runner/work/xbmc/xbmc/build/build/share/groovy

  because: No such file or directory
```

The failed download left no archive, so the extraction produced nothing to rename. Retrying removes the flaky failure, and the `FATAL_ERROR` stops the configure at the download so the second, misleading error can no longer appear.

## How has this been tested?
`core_file_download()` was exercised standalone with `cmake -P` (CMake 4.3.4, macOS), covering:

- successful download against a `file://` URL,
- existing destination matching the hash: skipped, no transfer,
- existing destination with a wrong hash: removed and re-downloaded,
- call without `HASH`,
- unreachable URL: retried, then `FATAL_ERROR`, leaving no file behind,
- hash mismatch: retried rather than aborting on the first attempt,
- malformed `HASH` argument: rejected with a clear error.

`Macros.cmake` was verified to still parse. I have not run a full Kodi configure with these changes; a CI run on this PR would cover that.

## What is the effect on users?
None for end-users. Build-system only: fewer spurious configure failures for people building Kodi and for CI.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
