### PR TITLE
[Scraping] Further speedups when importing using local scraper.

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -130,7 +130,7 @@ void CTextureCache::BackgroundCacheImage(const std::string &url)
     return;
 
   // needs (re)caching
-  AddJob(new CTextureCacheJob(path, details.hash));
+  AddJob(new CTextureCacheJob(path, details));
 }
 
 bool CTextureCache::StartCacheImage(const std::string& image)
@@ -168,13 +168,32 @@ std::string CTextureCache::CacheImage(
   {
     m_processinglist.insert(url);
     lock.unlock();
+
+    // Retrieve the hash the image was last cached with, so an unchanged source can be revalidated
+    CTextureDetails cached;
+    GetCachedImage(url, cached);
+
     // cache the texture directly
-    CTextureCacheJob job(url, "", knownHash);
-    bool success = job.CacheTexture(texture);
+    CTextureCacheJob job(url, cached, knownHash);
+    const bool success = job.CacheTexture(texture);
     OnCachingComplete(success, &job);
-    if (success && details)
+    if (!success)
+      return "";
+
+    if (job.m_details.hashRevalidated)
+    {
+      // Unchanged, so the copy already in the cache stands
+      if (details)
+        *details = cached;
+      const std::string cachedPath{GetCachedPath(cached.file)};
+      if (texture)
+        *texture = CTexture::LoadFromFile(cachedPath, idealWidth, idealHeight, aspectRatio);
+      return cachedPath;
+    }
+
+    if (details)
       *details = job.m_details;
-    return success ? GetCachedPath(job.m_details.file) : "";
+    return GetCachedPath(job.m_details.file);
   }
   lock.unlock();
 

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -14,7 +14,6 @@
 #include "commons/ilog.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "filesystem/File.h"
-#include "filesystem/IFileTypes.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Texture.h"
@@ -30,10 +29,9 @@
 #include "utils/log.h"
 
 #include <chrono>
-#include <exception>
+#include <cstring>
 #include <mutex>
 #include <optional>
-#include <string.h>
 
 using namespace XFILE;
 using namespace std::chrono_literals;
@@ -147,13 +145,19 @@ bool CTextureCache::StartCacheImage(const std::string& image)
   return false;
 }
 
+std::string CTextureCache::CacheImage(const std::string& image, const std::string& knownHash)
+{
+  return CacheImage(image, nullptr, nullptr, 0, 0, CAspectRatio::CENTER, knownHash);
+}
+
 std::string CTextureCache::CacheImage(
     const std::string& image,
     std::unique_ptr<CTexture>* texture /*= nullptr*/,
     CTextureDetails* details /*= nullptr*/,
     unsigned int idealWidth /*= 0*/,
     unsigned int idealHeight /*= 0*/,
-    CAspectRatio::AspectRatio aspectRatio /*= CAspectRatio::CENTER*/)
+    CAspectRatio::AspectRatio aspectRatio /*= CAspectRatio::CENTER*/,
+    const std::string& knownHash /*= ""*/)
 {
   std::string url = IMAGE_FILES::ToCacheKey(image);
   if (url.empty())
@@ -165,7 +169,7 @@ std::string CTextureCache::CacheImage(
     m_processinglist.insert(url);
     lock.unlock();
     // cache the texture directly
-    CTextureCacheJob job(url);
+    CTextureCacheJob job(url, "", knownHash);
     bool success = job.CacheTexture(texture);
     OnCachingComplete(success, &job);
     if (success && details)

--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -36,12 +36,35 @@
 using namespace XFILE;
 using namespace std::chrono_literals;
 
+namespace
+{
+//! \brief Images to cache at once in the background
+//! Half of what the priority allows, whilst still scraping (to avoid saturating the source)
+unsigned int BackgroundJobsAtOnce()
+{
+  return std::max(1U, CJobManager::GetMaxPausableWorkers() / 2);
+}
+} // namespace
+
 CTextureCache::CTextureCache()
-  : CJobQueue(false, 1, CJob::PRIORITY_LOW_PAUSABLE), m_cleanTimer{[this]() { CleanTimer(); }}
+  : CJobQueue(false, BackgroundJobsAtOnce(), CJob::PRIORITY_LOW_PAUSABLE),
+    m_cleanTimer{[this]() { CleanTimer(); }}
 {
 }
 
 CTextureCache::~CTextureCache() = default;
+
+void CTextureCache::AddThrottle()
+{
+  if (++m_throttles == 1)
+    SetJobsAtOnce(1);
+}
+
+void CTextureCache::RemoveThrottle()
+{
+  if (--m_throttles == 0)
+    SetJobsAtOnce(BackgroundJobsAtOnce());
+}
 
 void CTextureCache::Initialize()
 {
@@ -163,18 +186,15 @@ std::string CTextureCache::CacheImage(
   if (url.empty())
     return "";
 
-  std::unique_lock lock(m_processingSection);
-  if (!m_processinglist.contains(url))
+  if (StartCacheImage(url))
   {
-    m_processinglist.insert(url);
-    lock.unlock();
-
     // Retrieve the hash the image was last cached with, so an unchanged source can be revalidated
     CTextureDetails cached;
     GetCachedImage(url, cached);
 
-    // cache the texture directly
+    // cache the texture directly. The url was reserved above, so this job owns that reservation
     CTextureCacheJob job(url, cached, knownHash);
+    job.m_holdsProcessingClaim = true;
     const bool success = job.CacheTexture(texture);
     OnCachingComplete(success, &job);
     if (!success)
@@ -195,9 +215,8 @@ std::string CTextureCache::CacheImage(
       *details = job.m_details;
     return GetCachedPath(job.m_details.file);
   }
-  lock.unlock();
 
-  // wait for currently processing job to end.
+  // wait for currently processing job to end
   while (true)
   {
     m_completeEvent.Wait(1000ms);
@@ -334,6 +353,7 @@ void CTextureCache::OnCachingComplete(bool success, CTextureCacheJob *job)
       AddCachedTexture(job->m_url, job->m_details);
   }
 
+  if (job->m_holdsProcessingClaim)
   { // remove from our processing list
     std::unique_lock lock(m_processingSection);
     std::set<std::string>::iterator i = m_processinglist.find(job->m_url);

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -42,6 +42,26 @@ class CTexture;
 class CTextureCache : public CJobQueue, public CPowerState
 {
 public:
+  /*! \brief Holds background caching back to one image at a time while it exists
+
+   Background caching competes for the same source eg. scraping and art caching.
+   Caching then catches up afterwards, when it has the source to itself.
+
+   Counted, so that concurrent holders (a video and a music scan, say) each keep it in force.
+   */
+  class CBackgroundThrottle
+  {
+  public:
+    explicit CBackgroundThrottle(CTextureCache& cache) : m_cache(cache) { m_cache.AddThrottle(); }
+    ~CBackgroundThrottle() { m_cache.RemoveThrottle(); }
+
+    CBackgroundThrottle(const CBackgroundThrottle&) = delete;
+    CBackgroundThrottle& operator=(const CBackgroundThrottle&) = delete;
+
+  private:
+    CTextureCache& m_cache;
+  };
+
   CTextureCache();
   ~CTextureCache() override;
 
@@ -185,6 +205,15 @@ private:
   // private construction, and no assignments; use the provided singleton methods
   CTextureCache(const CTextureCache&) = delete;
   CTextureCache const& operator=(CTextureCache const&) = delete;
+
+  //! \brief Take a hold on background caching, limiting it if this is the first
+  void AddThrottle();
+
+  //! \brief Release a hold on background caching, restoring it if this was the last
+  void RemoveThrottle();
+
+  //! Outstanding CBackgroundThrottle holds
+  std::atomic<unsigned int> m_throttles{0};
 
   /*! \brief Check if the given image is a cached image
    \param image url of the image

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -97,6 +97,7 @@ public:
    \param idealWidth the ideal width of the returned texture (defaults to 0, no ideal width). Only matters if texture is not null.
    \param idealHeight the ideal height of the returned texture (defaults to 0, no ideal height). Only matters if texture is not null.
    \param aspectRatio the aspect ratio mode of the texture (defaults to "center"). Only matters if texture is not null.
+   \param knownHash hash of the source file, in the form CTextureCacheJob::GetImageHash() produces, if known.
    \return cached url of this image
    \sa CTextureCacheJob::CacheTexture
    */
@@ -105,7 +106,8 @@ public:
                          CTextureDetails* details = nullptr,
                          unsigned int idealWidth = 0,
                          unsigned int idealHeight = 0,
-                         CAspectRatio::AspectRatio aspectRatio = CAspectRatio::CENTER);
+                         CAspectRatio::AspectRatio aspectRatio = CAspectRatio::CENTER,
+                         const std::string& knownHash = "");
 
   /*! \brief Cache an image to image cache if not already cached, returning the image details.
    \param image url of the image to cache.
@@ -114,6 +116,18 @@ public:
    \sa CTextureCacheJob::CacheTexture
    */
   bool CacheImage(const std::string &image, CTextureDetails &details);
+
+  /*! \brief Cache an image whose source file hash the caller already knows
+
+   Saves the texture cache stat'ing the file to build that hash itself
+
+   \param image url of the image to cache
+   \param knownHash hash of the source file, in the form CTextureCacheJob::GetImageHash() produces.
+          Pass empty to have it determined as usual.
+   \return cached url of this image
+   \sa CTextureCacheJob::CacheTexture
+   */
+  std::string CacheImage(const std::string& image, const std::string& knownHash);
 
   /*! \brief Check whether an image is in the cache
    Note: If the image url won't normally be cached (eg a skin image) this function will return false.

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -30,13 +30,19 @@
 #include "PlatformDefs.h"
 
 CTextureCacheJob::CTextureCacheJob(const std::string& url,
-                                   const std::string& oldHash,
+                                   const CTextureDetails& oldDetails,
                                    const std::string& knownHash)
   : m_url(url),
-    m_oldHash(oldHash),
+    m_oldDetails(oldDetails),
     m_knownHash(knownHash),
     m_cachePath(CTextureCache::GetCacheFile(m_url))
 {
+}
+
+bool CTextureCacheJob::HasCachedFile() const
+{
+  return !m_oldDetails.file.empty() &&
+         XFILE::CFile::Exists(CTextureCache::GetCachedPath(m_oldDetails.file));
 }
 
 CTextureCacheJob::~CTextureCacheJob() = default;
@@ -106,7 +112,8 @@ bool CTextureCacheJob::CacheTexture(std::unique_ptr<CTexture>* out_texture)
     if (m_details.hash.empty())
       return false;
 
-    if (m_details.hash == m_oldHash)
+    // Unchanged, so the copy already in the cache stands - as long as it is still there
+    if (m_details.hash == m_oldDetails.hash && HasCachedFile())
     {
       m_details.hashRevalidated = true;
       return true;
@@ -121,7 +128,8 @@ bool CTextureCacheJob::CacheTexture(std::unique_ptr<CTexture>* out_texture)
     else
       m_details.file = m_cachePath + ".jpg";
 
-    CLog::Log(LOGDEBUG, "{} image '{}' to '{}':", m_oldHash.empty() ? "Caching" : "Recaching",
+    CLog::Log(LOGDEBUG,
+              "{} image '{}' to '{}':", m_oldDetails.hash.empty() ? "Caching" : "Recaching",
               CURL::GetRedacted(image), m_details.file);
 
     unsigned int cached_width = 0;

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -65,7 +65,9 @@ bool CTextureCacheJob::DoWork()
   std::string path(CServiceBroker::GetTextureCache()->CheckCachedImage(m_url, needsRecaching));
   if (!path.empty() && !needsRecaching)
     return false;
-  if (CServiceBroker::GetTextureCache()->StartCacheImage(m_url))
+
+  m_holdsProcessingClaim = CServiceBroker::GetTextureCache()->StartCacheImage(m_url);
+  if (m_holdsProcessingClaim)
     return CacheTexture();
 
   return false;

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -13,30 +13,29 @@
 #include "TextureCache.h"
 #include "TextureDatabase.h"
 #include "URL.h"
-#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/audiodecoder.h"
 #include "commons/ilog.h"
 #include "filesystem/File.h"
+#include "filesystem/IDirectory.h"
 #include "guilib/Texture.h"
 #include "imagefiles/ImageFileURL.h"
 #include "imagefiles/SpecialImageLoaderFactory.h"
 #include "pictures/Picture.h"
-#include "settings/AdvancedSettings.h"
-#include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
-#include <cstdlib>
 #include <cstring>
-#include <exception>
 #include <utility>
 
 #include "PlatformDefs.h"
 
-CTextureCacheJob::CTextureCacheJob(const std::string &url, const std::string &oldHash):
-  m_url(url),
-  m_oldHash(oldHash),
-  m_cachePath(CTextureCache::GetCacheFile(m_url))
+CTextureCacheJob::CTextureCacheJob(const std::string& url,
+                                   const std::string& oldHash,
+                                   const std::string& knownHash)
+  : m_url(url),
+    m_oldHash(oldHash),
+    m_knownHash(knownHash),
+    m_cachePath(CTextureCache::GetCacheFile(m_url))
 {
 }
 
@@ -102,8 +101,8 @@ bool CTextureCacheJob::CacheTexture(std::unique_ptr<CTexture>* out_texture)
 
   if (m_details.updateable)
   {
-    // generate the hash
-    m_details.hash = GetImageHash(image);
+    // generate the hash, unless the caller already knows it (saves a file stat)
+    m_details.hash = m_knownHash.empty() ? GetImageHash(image) : m_knownHash;
     if (m_details.hash.empty())
       return false;
 
@@ -200,6 +199,29 @@ std::unique_ptr<CTexture> CTextureCacheJob::LoadImage(const IMAGE_FILES::CImageF
   return texture;
 }
 
+std::string CTextureCacheJob::GetImageHash(int64_t modificationTime, int64_t size)
+{
+  if (modificationTime == 0 && size == 0)
+    return "";
+
+  return StringUtils::Format("d{}s{}", modificationTime, size);
+}
+
+std::string CTextureCacheJob::GetImageHash(const CFileItem& listedFile)
+{
+  // The raw values the listing carried, rather than the item's date/time (UTC conversion -> DST issues)
+  int64_t modificationTime{listedFile.GetProperty(XFILE::DIR_PROPERTY_STAT_MTIME).asInteger(0)};
+  if (modificationTime == 0)
+    modificationTime = listedFile.GetProperty(XFILE::DIR_PROPERTY_STAT_CTIME).asInteger(0);
+
+  // Not every VFS layer fills these in. Without a time the size alone would not match a stat-based
+  // hash, so say nothing is known and let the file be stat'ed as usual
+  if (modificationTime == 0)
+    return "";
+
+  return GetImageHash(modificationTime, listedFile.GetSize());
+}
+
 std::string CTextureCacheJob::GetImageHash(const std::string &url)
 {
   // silently ignore - we cannot stat these
@@ -214,8 +236,9 @@ std::string CTextureCacheJob::GetImageHash(const std::string &url)
     int64_t time = st.st_mtime;
     if (!time)
       time = st.st_ctime;
-    if (time || st.st_size)
-      return StringUtils::Format("d{}s{}", time, st.st_size);
+
+    if (const std::string hash{GetImageHash(time, st.st_size)}; !hash.empty())
+      return hash;
 
     // the image exists but we couldn't determine the mtime/ctime and/or size
     // so set an obviously bad hash

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -49,13 +49,10 @@ CTextureCacheJob::~CTextureCacheJob() = default;
 
 bool CTextureCacheJob::Equals(const CJob* job) const
 {
-  if (strcmp(job->GetType(),GetType()) == 0)
-  {
-    const CTextureCacheJob* cacheJob = dynamic_cast<const CTextureCacheJob*>(job);
-    if (cacheJob && cacheJob->m_cachePath == m_cachePath)
-      return true;
-  }
-  return false;
+  if (strcmp(job->GetType(), GetType()) != 0)
+    return false;
+
+  return static_cast<const CTextureCacheJob*>(job)->m_cachePath == m_cachePath;
 }
 
 bool CTextureCacheJob::DoWork()

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -59,11 +59,13 @@ public:
 
   /*!
    \param url location of the image
-   \param oldHash hash the image was previously cached with, if any
+   \param oldDetails what the image is already cached as, if anything. Its hash is only set once
+          the image is due its periodic check, and an unchanged image is then revalidated rather
+          than cached all over again.
    \param knownHash hash of the source file, if the caller already knows it (see GetImageHash())
    */
   CTextureCacheJob(const std::string& url,
-                   const std::string& oldHash = "",
+                   const CTextureDetails& oldDetails = {},
                    const std::string& knownHash = "");
   ~CTextureCacheJob() override;
 
@@ -93,9 +95,15 @@ public:
   static std::string GetImageHash(const CFileItem& listedFile);
 
   std::string m_url;
-  std::string m_oldHash;
+  CTextureDetails m_oldDetails;
   CTextureDetails m_details;
 private:
+  /*! \brief Whether the copy this image was previously cached to is still present
+   Revalidating leaves that copy in place rather than writing it again, so it has to still be
+   there - if it has been deleted the image needs caching again.
+   */
+  bool HasCachedFile() const;
+
   /*! \brief retrieve a hash for the given image
    Combines the size, ctime and mtime of the image file into a "unique" hash
    \param url location of the image

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -97,6 +97,13 @@ public:
   std::string m_url;
   CTextureDetails m_oldDetails;
   CTextureDetails m_details;
+
+  /*! \brief Whether this job is the one that reserved m_url in the texture cache.
+   Only the reserver may release it.
+   \sa CTextureCache::StartCacheImage, CTextureCache::OnCachingComplete
+   */
+  bool m_holdsProcessingClaim{false};
+
 private:
   /*! \brief Whether the copy this image was previously cached to is still present
    Revalidating leaves that copy in place rather than writing it again, so it has to still be

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+class CFileItem;
 class CTexture;
 namespace IMAGE_FILES
 {
@@ -56,7 +57,14 @@ class CTextureCacheJob : public CJob
 public:
   static constexpr const char* JOB_TYPE_CACHE_IMAGE = "cacheimage";
 
-  CTextureCacheJob(const std::string &url, const std::string &oldHash = "");
+  /*!
+   \param url location of the image
+   \param oldHash hash the image was previously cached with, if any
+   \param knownHash hash of the source file, if the caller already knows it (see GetImageHash())
+   */
+  CTextureCacheJob(const std::string& url,
+                   const std::string& oldHash = "",
+                   const std::string& knownHash = "");
   ~CTextureCacheJob() override;
 
   const char* GetType() const override { return JOB_TYPE_CACHE_IMAGE; }
@@ -77,6 +85,13 @@ public:
                             uint8_t*& result,
                             size_t& result_size);
 
+  /*! \brief Retrieve a hash for a file already returned by a directory listing
+   \param listedFile the file, as listed by CDirectory::GetDirectory() without DIR_FLAG_NO_FILE_INFO
+   \return a hash string for this file, or empty if the listing didn't provide the information -
+           not every VFS layer does, and the caller should then let the file be stat'ed as usual
+   */
+  static std::string GetImageHash(const CFileItem& listedFile);
+
   std::string m_url;
   std::string m_oldHash;
   CTextureDetails m_details;
@@ -87,6 +102,16 @@ private:
    \return a hash string for this image
    */
   static std::string GetImageHash(const std::string &url);
+
+  /*! \brief Format a hash from a file's modification time and size
+
+   \param modificationTime the file's modification time, as a unix timestamp
+   \param size the file's size in bytes
+   \return the hash, or empty if neither value was usable
+   */
+  static std::string GetImageHash(int64_t modificationTime, int64_t size);
+
+  std::string m_knownHash;
 
   /*! \brief Load an image at a given target size and orientation.
 

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -276,6 +276,10 @@ bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     item->SetFolder(isDir);
     item->SetSize(dirent->size);
 
+    // raw values; the DateTime above is local-time converted
+    item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(dirent->mtime.tv_sec));
+    item->SetProperty(DIR_PROPERTY_STAT_CTIME, static_cast<int64_t>(dirent->ctime.tv_sec));
+
     if (name[0] == '.')
       item->SetProperty("file:hidden", true);
   }

--- a/xbmc/jobs/JobManager.cpp
+++ b/xbmc/jobs/JobManager.cpp
@@ -215,7 +215,7 @@ void CJobManager::StartWorkers(CJob::PRIORITY priority)
   std::unique_lock lock(m_section);
 
   // check how many free threads we have
-  if (m_processing.size() >= GetMaxWorkers(priority))
+  if (!CanStart(priority))
     return;
 
   // do we have any sleeping threads?
@@ -238,8 +238,7 @@ CJob* CJobManager::PopJob()
     if (priority == CJob::PRIORITY_LOW_PAUSABLE && m_pauseJobs)
       continue;
 
-    if (!m_jobQueue[priority].empty() &&
-        m_processing.size() < GetMaxWorkers(CJob::PRIORITY(priority)))
+    if (!m_jobQueue[priority].empty() && CanStart(CJob::PRIORITY(priority)))
     {
       // pop the job off the queue
       const CWorkItem job{m_jobQueue[priority].front()};
@@ -258,6 +257,12 @@ void CJobManager::PauseJobs()
 {
   std::unique_lock lock(m_section);
   m_pauseJobs = true;
+}
+
+bool CJobManager::ArePausableJobsPaused() const
+{
+  std::unique_lock lock(m_section);
+  return m_pauseJobs;
 }
 
 void CJobManager::UnPauseJobs()
@@ -410,4 +415,25 @@ unsigned int CJobManager::GetMaxWorkers(CJob::PRIORITY priority)
   if (priority == CJob::PRIORITY_DEDICATED)
     return 10000; // A large number..
   return max_workers - (CJob::PRIORITY_HIGH - priority);
+}
+
+unsigned int CJobManager::GetMaxPausableWorkers()
+{
+  // hardware_concurrency() rather than CCPUInfo, to keep the job manager free of the service
+  // broker. It reports 0 when it cannot tell, which counts as "not many".
+  return std::thread::hardware_concurrency() >= 4 ? 4 : 2;
+}
+
+bool CJobManager::CanStart(CJob::PRIORITY priority) const
+{
+  // PRIORITY_LOW_PAUSABLE is background work that spends its time waiting on a source rather than
+  // on a core. Currently only used for texture cache.
+  const auto pausable{static_cast<size_t>(
+      std::ranges::count_if(m_processing, [](const CWorkItem& item)
+                            { return item.GetPriority() == CJob::PRIORITY_LOW_PAUSABLE; }))};
+
+  if (priority == CJob::PRIORITY_LOW_PAUSABLE)
+    return pausable < GetMaxPausableWorkers();
+
+  return m_processing.size() - pausable < GetMaxWorkers(priority);
 }

--- a/xbmc/jobs/JobManager.h
+++ b/xbmc/jobs/JobManager.h
@@ -129,6 +129,18 @@ public:
    */
   void UnPauseJobs();
 
+  /*! \brief Whether jobs of priority PRIORITY_LOW_PAUSABLE are currently suspended
+   \sa PauseJobs, UnPauseJobs
+   */
+  bool ArePausableJobsPaused() const;
+
+  /*! \brief Maximum jobs to run at once at PRIORITY_LOW_PAUSABLE
+
+   \return the limit
+   \sa CJobQueue
+   */
+  static unsigned int GetMaxPausableWorkers();
+
   /*!
    \brief Checks to see if any jobs with specific priority are currently processing.
    \param priority to search for
@@ -228,7 +240,18 @@ private:
 
   void StartWorkers(CJob::PRIORITY priority);
   void RemoveWorker(const CJobWorker* worker);
+
+  /*! \brief Number of workers available to a priority, excluding PRIORITY_LOW_PAUSABLE
+   Each level leaves headroom for the ones above it, so that a busy background never stops
+   higher-priority work from starting.
+   */
   static unsigned int GetMaxWorkers(CJob::PRIORITY priority);
+
+  /*! \brief Whether another job of this priority may start now
+   \param priority priority of the job wanting to start
+   \return true if there is room for it
+   */
+  bool CanStart(CJob::PRIORITY priority) const;
 
   unsigned int m_jobCounter{0};
 

--- a/xbmc/jobs/JobQueue.cpp
+++ b/xbmc/jobs/JobQueue.cpp
@@ -86,6 +86,7 @@ bool CJobQueue::AddJob(CJob* job)
   else
     m_jobQueue.emplace_front(job);
 
+  m_idleEvent.Reset();
   QueueNextJob();
 
   return true;
@@ -102,6 +103,9 @@ void CJobQueue::OnJobNotify(const CJob* job)
 
   // request a new job be queued
   QueueNextJob();
+
+  if (m_jobQueue.empty() && m_processing.empty())
+    m_idleEvent.Set();
 }
 
 void CJobQueue::QueueNextJob()
@@ -128,12 +132,26 @@ void CJobQueue::CancelJobs()
   std::ranges::for_each(m_jobQueue, [](CJobPointer& jp) { jp.FreeJob(); });
   m_jobQueue.clear();
   m_processing.clear();
+  m_idleEvent.Set();
+}
+
+void CJobQueue::SetJobsAtOnce(unsigned int jobsAtOnce)
+{
+  std::unique_lock lock(m_section);
+  m_jobsAtOnce = jobsAtOnce;
+  QueueNextJob(); // in case the limit went up and something is waiting
 }
 
 bool CJobQueue::IsProcessing() const
 {
+  std::unique_lock lock(m_section);
   return CServiceBroker::GetJobManager()->IsRunning() &&
          (!m_processing.empty() || !m_jobQueue.empty());
+}
+
+bool CJobQueue::WaitForCompletion(std::chrono::milliseconds timeout)
+{
+  return m_idleEvent.Wait(timeout);
 }
 
 bool CJobQueue::QueueEmpty() const

--- a/xbmc/jobs/JobQueue.h
+++ b/xbmc/jobs/JobQueue.h
@@ -12,7 +12,9 @@
 #include "jobs/Job.h"
 #include "jobs/LambdaJob.h"
 #include "threads/CriticalSection.h"
+#include "threads/Event.h"
 
+#include <chrono>
 #include <queue>
 #include <vector>
 
@@ -88,9 +90,32 @@ public:
   void CancelJobs();
 
   /*!
+   \brief Change how many jobs this queue runs at once
+
+   Takes effect from the next job dispatched: lowering it lets those already running finish, and
+   raising it starts more straight away if any are waiting.
+
+   \param jobsAtOnce number of jobs to run at once from now on
+   */
+  void SetJobsAtOnce(unsigned int jobsAtOnce);
+
+  /*!
    \brief Check whether the queue is processing a job
    */
   bool IsProcessing() const;
+
+  /*!
+   \brief Wait for every job added to this queue to finish
+
+   Returns as soon as nothing is queued or in progress, so a queue that was already idle returns
+   at once. Note that a queue whose priority is currently suspended will not drain: callers should
+   treat a timeout as a reason to check, rather than as a reason to keep waiting.
+
+   \param timeout how long to wait for
+   \return true if the queue is now idle, false if it timed out first
+   \sa IsProcessing
+   */
+  bool WaitForCompletion(std::chrono::milliseconds timeout);
 
   /*!
    \brief The callback used when a job completes.
@@ -156,6 +181,9 @@ private:
   using Processing = std::vector<CJobPointer>;
   Queue m_jobQueue;
   Processing m_processing;
+
+  //! Set whenever nothing is queued or in progress
+  CEvent m_idleEvent{true, true};
 
   unsigned int m_jobsAtOnce{1};
   CJob::PRIORITY m_priority{CJob::PRIORITY::PRIORITY_LOW};

--- a/xbmc/platform/posix/filesystem/PosixDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/PosixDirectory.cpp
@@ -81,6 +81,10 @@ bool CPosixDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 
           item->SetDateTime(localTime);
           item->SetSize(isDir ? 0 : buffer.st_size);
+
+          // raw values; the DateTime above is local-time converted
+          item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(buffer.st_mtime));
+          item->SetProperty(DIR_PROPERTY_STAT_CTIME, static_cast<int64_t>(buffer.st_ctime));
         }
       }
 

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -155,11 +155,10 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     item->SetFolder(isDir);
     if (!isDir)
       item->SetSize(size);
-    else
-    { // raw values; the DateTime above is local-time converted
-      item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(st.st_mtime));
-      item->SetProperty(DIR_PROPERTY_STAT_CTIME, static_cast<int64_t>(st.st_ctime));
-    }
+
+    // raw values; the DateTime above is local-time converted
+    item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(st.st_mtime));
+    item->SetProperty(DIR_PROPERTY_STAT_CTIME, static_cast<int64_t>(st.st_ctime));
     if (hidden)
       item->SetProperty("file:hidden", true);
   }

--- a/xbmc/platform/win32/filesystem/Win32Directory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32Directory.cpp
@@ -111,13 +111,11 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
     if (isHidden)
       item->SetProperty("file:hidden", true);
 
-    if (isDir)
-    { // raw values; the DateTime above is local-time converted
-      item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(
-                                                     findData.ftLastWriteTime)));
-      item->SetProperty(DIR_PROPERTY_STAT_CTIME,
-                        static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(findData.ftCreationTime)));
-    }
+    // raw values; the DateTime above is local-time converted
+    item->SetProperty(DIR_PROPERTY_STAT_MTIME,
+                      static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(findData.ftLastWriteTime)));
+    item->SetProperty(DIR_PROPERTY_STAT_CTIME,
+                      static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(findData.ftCreationTime)));
 
   } while (FindNextFileW(hSearch, &findData));
 

--- a/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
@@ -186,6 +186,12 @@ bool CWin32SMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     if (!isDir)
       item->SetSize((static_cast<int64_t>(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow);
 
+    // raw values; the DateTime above is local-time converted
+    item->SetProperty(DIR_PROPERTY_STAT_MTIME,
+                      static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(findData.ftLastWriteTime)));
+    item->SetProperty(DIR_PROPERTY_STAT_CTIME,
+                      static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(findData.ftCreationTime)));
+
     if (isHidden)
       item->SetProperty("file:hidden", true);
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5511,6 +5511,51 @@ std::string CVideoDatabase::GetArtForItem(int mediaId, const MediaType &mediaTyp
   return GetSingleValue(query, *m_pDS2);
 }
 
+std::map<std::string, std::string> CVideoDatabase::GetArtForActors(
+    const std::vector<std::string>& names)
+{
+  std::map<std::string, std::string> art;
+  if (!m_pDS2 || names.empty())
+    return art;
+
+  // Name trimming, truncation and comparison match AddActor()
+  std::string nameMatches;
+  for (const auto& name : names)
+  {
+    std::string trimmedName = name;
+    StringUtils::Trim(trimmedName);
+    if (trimmedName.empty())
+      continue;
+
+    if (!nameMatches.empty())
+      nameMatches += " OR ";
+    nameMatches += PrepareSQL("actor.name LIKE '%s'", trimmedName.substr(0, 255).c_str());
+  }
+  if (nameMatches.empty())
+    return art;
+
+  try
+  {
+    m_pDS2->query("SELECT actor.name, art.url FROM actor"
+                  " JOIN art ON art.media_id = actor.actor_id"
+                  " WHERE (" +
+                  nameMatches +
+                  ")"
+                  " AND art.media_type = 'actor' AND art.type = 'thumb'");
+    while (!m_pDS2->eof())
+    {
+      art.emplace(m_pDS2->fv(0).get_asString(), m_pDS2->fv(1).get_asString());
+      m_pDS2->next();
+    }
+    m_pDS2->close();
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "failed for {} actors", names.size());
+  }
+  return art;
+}
+
 bool CVideoDatabase::RemoveArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType)
 {
   return ExecuteQuery(PrepareSQL("DELETE FROM art WHERE media_id=%i AND media_type='%s' AND type='%s'", mediaId, mediaType.c_str(), artType.c_str()));

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -18,6 +18,7 @@
 
 #include <array>
 #include <functional>
+#include <map>
 #include <memory>
 #include <set>
 #include <stdexcept>
@@ -850,6 +851,14 @@ public:
   bool SetArtForItem(int mediaId, const MediaType& mediaType, const KODI::ART::Artwork& art);
   bool GetArtForItem(int mediaId, const MediaType& mediaType, KODI::ART::Artwork& art);
   std::string GetArtForItem(int mediaId, const MediaType &mediaType, const std::string &artType);
+
+  /*!
+   \brief Retrieve the thumbs already held for a group of actors
+   \param names the actors' names, matched as CVideoDatabase::AddActor() would match them
+   \return the art url for each of those actors that is in the library and has a thumb, keyed on
+           the name as the library holds it, which may differ in case from the name asked for
+   */
+  std::map<std::string, std::string> GetArtForActors(const std::vector<std::string>& names);
 
   void UpdateArtForItem(int mediaId, const MediaType& mediaType) const;
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -34,6 +34,9 @@
 #include "guilib/GUIWindowManager.h"
 #include "imagefiles/ImageFileURL.h"
 #include "interfaces/AnnouncementManager.h"
+#include "jobs/Job.h"
+#include "jobs/JobManager.h"
+#include "jobs/JobQueue.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
 #include "playlists/PlayListFileItemClassify.h"
@@ -44,6 +47,7 @@
 #include "settings/SettingsComponent.h"
 #include "tags/SetInfoTagLoaderFactory.h"
 #include "tags/VideoInfoTagLoaderFactory.h"
+#include "threads/Event.h"
 #include "utils/ArtUtils.h"
 #include "utils/Digest.h"
 #include "utils/DiscsUtils.h"
@@ -65,6 +69,7 @@
 #include "video/dialogs/GUIDialogVideoManagerVersions.h"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <map>
 #include <memory>
@@ -73,6 +78,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 using namespace XFILE;
 using namespace ADDON;
@@ -258,6 +264,9 @@ void CacheArtwork(const std::string& url,
   CLog::LogF(LOGDEBUG, "Synchronous art caching for {} failed", url);
 }
 
+//! so jobs that were queued but hadn't started are discarded and will never complete.
+constexpr auto ART_CACHE_JOB_POLL_INTERVAL{std::chrono::milliseconds{1000}};
+
 //! \brief An artwork url to cache, with the hash of its source file if that is already known
 struct ArtToCache
 {
@@ -265,11 +274,6 @@ struct ArtToCache
   std::string hash; //!< empty if unknown, leaving the texture cache to determine it
 };
 
-/*! \brief Cache a group of artwork
- Empty and duplicate urls are dropped first, so callers don't have to.
- \param art the images to cache. Order is not preserved.
- \param retrieveArtDuringScrape whether to fetch the art now, or queue it for background caching
- */
 void CacheArtwork(std::vector<ArtToCache> art, bool retrieveArtDuringScrape)
 {
   std::erase_if(art, [](const ArtToCache& a) { return a.url.empty(); });
@@ -285,8 +289,44 @@ void CacheArtwork(std::vector<ArtToCache> art, bool retrieveArtDuringScrape)
                     });
   art.erase(std::ranges::begin(std::ranges::unique(art, {}, &ArtToCache::url)), art.end());
 
+  // The background path only queues the urls, so there is nothing to overlap.
+  if (!retrieveArtDuringScrape || art.size() < 2)
+  {
+    for (const auto& a : art)
+      CacheArtwork(a.url, retrieveArtDuringScrape, a.hash);
+    return;
+  }
+
+  // Caching an image is mostly waiting on the source, so let a few overlap. PRIORITY_LOW_PAUSABLE
+  // is what the texture cache queues its own work at, so this shares one allowance with it rather
+  // than competing, and yields to playback the same way.
+  CJobQueue queue{false, CJobManager::GetMaxPausableWorkers(), CJob::PRIORITY_LOW_PAUSABLE};
   for (const auto& a : art)
-    CacheArtwork(a.url, retrieveArtDuringScrape, a.hash);
+    queue.Submit([a]() { CacheArtwork(a.url, true, a.hash); });
+
+  const auto jobManager{CServiceBroker::GetJobManager()};
+  while (!queue.WaitForCompletion(ART_CACHE_JOB_POLL_INTERVAL))
+  {
+    if (!jobManager->IsRunning())
+    {
+      // Shutting down - whatever is left is abandoned when the queue goes out of scope
+      CLog::LogF(LOGDEBUG, "Abandoning art caching, the job manager has been shut down");
+      break;
+    }
+
+    if (jobManager->ArePausableJobsPaused())
+    {
+      // Playback has started, so nothing still queued here will be dispatched until it stops, and
+      // waiting that long would hold up the scrape. Hand what is left to the background path
+      // instead: its queue outlives this call, so the images are still cached once playback ends
+      // rather than being left for something to ask for them. Anything already cached costs only
+      // the lookup that finds it there.
+      CLog::LogF(LOGDEBUG, "Handing remaining art to background caching, playback has started");
+      for (const auto& a : art)
+        CacheArtwork(a.url, false, a.hash);
+      break;
+    }
+  }
 }
 } // namespace
 
@@ -318,6 +358,12 @@ CVideoInfoScanner::~CVideoInfoScanner()
   {
     try
     {
+      // Background caching reads from the same source as this scan does, and that source is the
+      // limit rather than the CPU. Hold it back to one image at a time until the scan is done, so
+      // that the library becomes browsable as soon as it can - the backlog then catches up faster
+      // than it would have, with the source to itself.
+      const CTextureCache::CBackgroundThrottle throttle{*CServiceBroker::GetTextureCache()};
+
       m_actorThumbs.clear();
 
       const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -15,6 +15,7 @@
 #include "ServiceBroker.h"
 #include "SetInfoTag.h"
 #include "TextureCache.h"
+#include "TextureCacheJob.h"
 #include "URL.h"
 #include "Util.h"
 #include "VideoInfoDownloader.h"
@@ -224,7 +225,9 @@ void OnDirectoryScanned(const std::string& strDirectory)
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
 }
 
-void CacheArtwork(const std::string& url, bool retrieveArtDuringScrape)
+void CacheArtwork(const std::string& url,
+                  bool retrieveArtDuringScrape,
+                  const std::string& knownHash = "")
 {
   if (url.empty())
     return;
@@ -245,7 +248,7 @@ void CacheArtwork(const std::string& url, bool retrieveArtDuringScrape)
   constexpr int MAX_SYNC_CACHE_ATTEMPTS = 3;
   for (int attempt = 1; attempt <= MAX_SYNC_CACHE_ATTEMPTS; ++attempt)
   {
-    if (!textureCache->CacheImage(url).empty())
+    if (!textureCache->CacheImage(url, knownHash).empty())
       return; // succeeded
   }
 
@@ -253,6 +256,37 @@ void CacheArtwork(const std::string& url, bool retrieveArtDuringScrape)
   // Fall back to the resilient background path.
   textureCache->BackgroundCacheImage(url);
   CLog::LogF(LOGDEBUG, "Synchronous art caching for {} failed", url);
+}
+
+//! \brief An artwork url to cache, with the hash of its source file if that is already known
+struct ArtToCache
+{
+  std::string url;
+  std::string hash; //!< empty if unknown, leaving the texture cache to determine it
+};
+
+/*! \brief Cache a group of artwork
+ Empty and duplicate urls are dropped first, so callers don't have to.
+ \param art the images to cache. Order is not preserved.
+ \param retrieveArtDuringScrape whether to fetch the art now, or queue it for background caching
+ */
+void CacheArtwork(std::vector<ArtToCache> art, bool retrieveArtDuringScrape)
+{
+  std::erase_if(art, [](const ArtToCache& a) { return a.url.empty(); });
+
+  // Where the same url appears more than once, order any known hash first so that the copy kept
+  // below is the one that saves a stat
+  std::ranges::sort(art,
+                    [](const ArtToCache& a, const ArtToCache& b)
+                    {
+                      if (a.url != b.url)
+                        return a.url < b.url;
+                      return !a.hash.empty() && b.hash.empty();
+                    });
+  art.erase(std::ranges::begin(std::ranges::unique(art, {}, &ArtToCache::url)), art.end());
+
+  for (const auto& a : art)
+    CacheArtwork(a.url, retrieveArtDuringScrape, a.hash);
 }
 } // namespace
 
@@ -3133,11 +3167,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
     CFileItemList items;
     // don't try to fetch anything local with plugin source
     if (!URIUtils::IsPlugin(actorsDir) && CDirectory::Exists(actorsDir))
-      CDirectory::GetDirectory(actorsDir, items, ".png|.jpg|.tbn",
-                               DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_NO_FILE_INFO);
+      CDirectory::GetDirectory(actorsDir, items, ".png|.jpg|.tbn", DIR_FLAG_NO_FILE_DIRS);
 
     // Index the thumbs by filename (without extension)
-    std::map<std::string, std::string> thumbs;
+    std::map<std::string, ArtToCache> thumbs;
     for (const auto& item : items)
     {
       if (item->IsFolder())
@@ -3145,7 +3178,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
       std::string name{URIUtils::GetFileName(item->GetPath())};
       URIUtils::RemoveExtension(name);
-      thumbs.try_emplace(std::move(name), item->GetPath());
+      thumbs.try_emplace(std::move(name),
+                         ArtToCache{item->GetPath(), CTextureCacheJob::GetImageHash(*item)});
     }
 
     for (auto& actor : actors)
@@ -3159,7 +3193,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         StringUtils::Replace(thumbFile, ' ', '_');
         thumbFile = CUtil::MakeLegalFileName(std::move(thumbFile));
         if (const auto thumb{thumbs.find(thumbFile)}; thumb != thumbs.end())
-          actor.thumb = thumb->second;
+          actor.thumb = thumb->second.url;
         if (!actor.thumbUrl.GetFirstUrlByType().m_url.empty())
         {
           const std::string thumb{CScraperUrl::GetThumbUrl(actor.thumbUrl.GetFirstUrlByType())};
@@ -3171,8 +3205,27 @@ CVideoInfoScanner::~CVideoInfoScanner()
             actor.thumbUrl.Clear();
         }
       }
-      CacheArtwork(actor.thumb, m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS);
     }
+
+    // Index the hashes taken from the directory listing by url
+    std::map<std::string, std::string> listedHashes;
+    for (const auto& thumb : thumbs | std::views::values)
+    {
+      if (!thumb.hash.empty())
+        listedHashes.emplace(thumb.url, thumb.hash);
+    }
+
+    // Cache thumbs together (with hashes)
+    std::vector<ArtToCache> thumbsToCache;
+    thumbsToCache.reserve(actors.size());
+    for (const auto& actor : actors)
+    {
+      const auto hash{listedHashes.find(actor.thumb)};
+      thumbsToCache.push_back(
+          ArtToCache{actor.thumb, hash != listedHashes.end() ? hash->second : std::string{}});
+    }
+
+    CacheArtwork(std::move(thumbsToCache), m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS);
   }
 
   bool CVideoInfoScanner::DownloadFailed(CGUIDialogProgress* pDialog)

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -318,6 +318,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
   {
     try
     {
+      m_actorThumbs.clear();
+
       const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
       if (m_showDialog && !settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_BACKGROUNDUPDATE))
@@ -2477,7 +2479,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
                                      bool bApplyToDir,
                                      bool useLocal,
                                      const std::string& actorArtPath,
-                                     UseRemoteArtWithLocalScraper useRemoteArt /* = yes */) const
+                                     UseRemoteArtWithLocalScraper useRemoteArt /* = yes */)
   {
     int artLevel = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
         CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL);
@@ -3159,10 +3161,48 @@ CVideoInfoScanner::~CVideoInfoScanner()
     }
   }
 
-  void CVideoInfoScanner::FetchActorThumbs(
-      std::vector<SActorInfo>& actors,
-      const std::string& actorsDir,
-      UseRemoteArtWithLocalScraper useRemoteArt /* = YES */) const
+  namespace
+  {
+  std::string PrepareActorName(const std::string& name)
+  {
+    std::string folded{name};
+    StringUtils::Trim(folded);
+    StringUtils::ToLower(folded);
+    return folded;
+  }
+  } // namespace
+
+  void CVideoInfoScanner::ResolveActorThumbs(const std::vector<SActorInfo>& actors)
+  {
+    std::vector<std::string> unresolved;
+    for (const auto& actor : actors)
+    {
+      if (!actor.thumb.empty() && !m_actorThumbs.contains(PrepareActorName(actor.strName)))
+        unresolved.push_back(actor.strName);
+    }
+    if (unresolved.empty())
+      return;
+
+    const auto stored{m_database.GetArtForActors(unresolved)};
+
+    // Record every name asked about, so that one without art is not asked about again
+    for (const auto& name : unresolved)
+      m_actorThumbs.try_emplace(PrepareActorName(name));
+
+    const auto& textureCache{CServiceBroker::GetTextureCache()};
+    for (const auto& [name, url] : stored)
+    {
+      // Scraped art (http) is not reused, so that local art still takes preference over it. Note
+      // that this is not IsRemote(), which is also true of a file on a share - those are exactly
+      // the copies worth reusing
+      if (!url.empty() && !URIUtils::IsHTTP(url) && textureCache->HasCachedImage(url))
+        m_actorThumbs.insert_or_assign(PrepareActorName(name), url);
+    }
+  }
+
+  void CVideoInfoScanner::FetchActorThumbs(std::vector<SActorInfo>& actors,
+                                           const std::string& actorsDir,
+                                           UseRemoteArtWithLocalScraper useRemoteArt /* = YES */)
   {
     CFileItemList items;
     // don't try to fetch anything local with plugin source
@@ -3215,14 +3255,35 @@ CVideoInfoScanner::~CVideoInfoScanner()
         listedHashes.emplace(thumb.url, thumb.hash);
     }
 
+    // Art is held per actor, not per actor per film, so an actor is resolved once and the
+    // answer kept for the rest of the scan
+    const auto& textureCache{CServiceBroker::GetTextureCache()};
+    ResolveActorThumbs(actors);
+
     // Cache thumbs together (with hashes)
     std::vector<ArtToCache> thumbsToCache;
     thumbsToCache.reserve(actors.size());
-    for (const auto& actor : actors)
+    for (auto& actor : actors)
     {
+      if (actor.thumb.empty())
+        continue;
+
+      const std::string foldedName{PrepareActorName(actor.strName)};
+      const auto known{m_actorThumbs.find(foldedName)};
+
+      if (known != m_actorThumbs.end() && !known->second.empty() && known->second != actor.thumb)
+      {
+        actor.thumb = known->second;
+        continue;
+      }
+
       const auto hash{listedHashes.find(actor.thumb)};
       thumbsToCache.push_back(
           ArtToCache{actor.thumb, hash != listedHashes.end() ? hash->second : std::string{}});
+
+      // Scraped art (http) is not reused, so that local art still takes preference
+      if (!foldedName.empty() && !URIUtils::IsHTTP(actor.thumb))
+        m_actorThumbs.insert_or_assign(foldedName, actor.thumb);
     }
 
     CacheArtwork(std::move(thumbsToCache), m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS);

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <set>
 #include <string>
 #include <string_view>
@@ -131,13 +132,12 @@ namespace KODI::VIDEO
      \param actorArtPath the directory containing actor thumbs. Defaults to empty.
      \param useRemoteArt use remote art if also using local scraper. Defaults to yes.
      */
-    void GetArtwork(
-        CFileItem* pItem,
-        ADDON::ContentType content,
-        bool bApplyToDir = false,
-        bool useLocal = true,
-        const std::string& actorArtPath = "",
-        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES) const;
+    void GetArtwork(CFileItem* pItem,
+                    ADDON::ContentType content,
+                    bool bApplyToDir = false,
+                    bool useLocal = true,
+                    const std::string& actorArtPath = "",
+                    UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES);
 
     /*! \brief Get season thumbs for a tvshow.
      All seasons (regardless of whether the user has episodes) are added to the art map.
@@ -265,7 +265,14 @@ namespace KODI::VIDEO
     void FetchActorThumbs(
         std::vector<SActorInfo>& actors,
         const std::string& actorsDir,
-        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES) const;
+        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES);
+
+    /*! \brief Make sure m_actorThumbs holds an answer for every actor in a cast
+     Any not already resolved by an earlier film are looked up together, as one pass over the
+     actor table rather than one per cast member.
+     \param actors the cast to resolve
+     */
+    void ResolveActorThumbs(const std::vector<SActorInfo>& actors);
 
     static int GetPathHash(const CFileItemList &items, std::string &hash);
 
@@ -376,6 +383,9 @@ namespace KODI::VIDEO
 
     ArtRetrievalTiming m_artRetrievalTiming{ArtRetrievalTiming::BACKGROUND};
     CVideoDatabase m_database;
+
+    //! \brief Reusable thumb per actor, keyed on the actor's folded name.
+    std::map<std::string, std::string> m_actorThumbs;
     std::set<int> m_pathsToClean;
     std::shared_ptr<CAdvancedSettings> m_advancedSettings;
     CVideoDatabase::ScraperCache m_scraperCache;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

For discussion
Can be RC1 or Q depending on prevailing feeling - if felt to have merit at all
I've only tested on SMB/NFS/local (SSD) on windows - grateful for any other system tests.

3 speedups

1) Use 4 threads to retrieve art. As files are small there is significant protocol overhead, so parallel retrieval benefits. Doesn't matter if threads > CPU threads as not CPU intensive.

SMB benefit
<img width="670" height="544" alt="image" src="https://github.com/user-attachments/assets/f075c2c4-40a2-49fb-8be3-fea81a1aa50d" />

NFS benefit (less)
<img width="663" height="523" alt="image" src="https://github.com/user-attachments/assets/cfd26a77-edd6-40ef-9e60-7803e222b4de" />

No benefit with more threads.
<img width="646" height="263" alt="image" src="https://github.com/user-attachments/assets/015b2370-89a6-4b4d-ab5f-e55a3c2066ce" />
SMB uses about 4, NFS about 2

2) Calculate hash from directory listing (GetDirectory()) rather than stat

No benefit on windows SMB as it seems to have a stat cache at OS level

Benefit for NFS
<img width="663" height="573" alt="image" src="https://github.com/user-attachments/assets/fd345fae-f7b0-4453-8991-53f34884d75a" />

Addative benefit on NFS with speedup 1
<img width="654" height="301" alt="image" src="https://github.com/user-attachments/assets/99316149-7c6f-44ef-b8f6-e0d25e354860" />

3) Don’t store actor art if already in database unless remote > local.

SMB
<img width="675" height="573" alt="image" src="https://github.com/user-attachments/assets/53f62298-26d4-44f0-9f68-55d329137d01" />

Confirmed prevents re-caching of duplicate actors
<img width="665" height="403" alt="image" src="https://github.com/user-attachments/assets/c0f43f53-e431-4599-a127-fcb47a60ba81" />

NFS
<img width="803" height="786" alt="image" src="https://github.com/user-attachments/assets/345acda8-4175-49b1-93fa-a015af6ab709" />

<img width="795" height="446" alt="image" src="https://github.com/user-attachments/assets/c033e038-b8cf-4f33-bea8-942db2045097" />

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It was commented in #28776 that importing using local scraper was faster in v21.

I think this is confounded by art and bluray improvements in v22 but investigated.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

To produce a test source

Ensure Settings -> Media -> Videos -> Retrieve art is set to During Scrape (ensures all art completely retrieved when scrape finishes)
Scrape a large source using an online scraper.
Export to seperate files including art and actor art.

Delete the Thumbnail folder in the user directory along with the Database folder (or at least MyVideosxxx and Texturesxx)

Ensure that this is in advancedsettings (prevents online art retrieval):
```
  <videolibrary>
    <noremoteartwithlocalscraper>true</noremoteartwithlocalscraper>
  </videolibrary>
```

This creates a level playing field - no art in cache, all art retrieved from disc

Then try scraping the source with the local scraper.

Do one run with vanilla nightly and then one run with this PR.

On windows I'm seeing improvements like (times in ms):
<img width="939" height="318" alt="image" src="https://github.com/user-attachments/assets/2d0bef2e-9625-4c3c-8674-a5879a024357" />

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
