### PR TITLE
[Application] Allow exit whilst library update ongoing.

### DIFF
--- a/xbmc/InfoScanner.h
+++ b/xbmc/InfoScanner.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <set>
 #include <string>
 #include <utility>
@@ -81,7 +82,7 @@ protected:
   std::set<std::string, std::less<>> m_pathsToScan; //!< Set of paths to scan
   bool m_showDialog = false; //!< Whether or not to show progress bar dialog
   CGUIDialogProgressBarHandle* m_handle = nullptr; //!< Progress bar handle
-  bool m_bRunning = false; //!< Whether or not scanner is running
-  bool m_bCanInterrupt = false; //!< Whether or not scanner is currently interruptible
+  std::atomic<bool> m_bRunning{false}; //!< Whether or not scanner is running
+  std::atomic<bool> m_bCanInterrupt{false}; //!< Whether or not scanner is currently interruptible
   bool m_bClean = false; //!< Whether or not to perform cleaning during scanning
 };

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1891,15 +1891,13 @@ bool CApplication::Stop(int exitCode)
     m_ExitCode = exitCode;
     CLog::Log(LOGINFO, "Stopping all");
 
+    // Stop scanning before the job manager is cancelled below
+    // otherwise scans underway are not stopped
+    CMusicLibraryQueue::GetInstance().CancelAllJobs();
+    CVideoLibraryQueue::GetInstance().CancelAllJobs();
+
     // cancel any jobs from the jobmanager
     CServiceBroker::GetJobManager()->CancelJobs();
-
-    // stop scanning before we kill the network and so on
-    if (CMusicLibraryQueue::GetInstance().IsRunning())
-      CMusicLibraryQueue::GetInstance().CancelAllJobs();
-
-    if (CVideoLibraryQueue::GetInstance().IsRunning())
-      CVideoLibraryQueue::GetInstance().CancelAllJobs();
 
     CServiceBroker::GetAppMessenger()->Cleanup();
 

--- a/xbmc/music/MusicLibraryQueue.cpp
+++ b/xbmc/music/MusicLibraryQueue.cpp
@@ -25,6 +25,7 @@
 #include "utils/Variant.h"
 
 #include <mutex>
+#include <ranges>
 #include <utility>
 
 CMusicLibraryQueue::CMusicLibraryQueue()
@@ -263,6 +264,17 @@ void CMusicLibraryQueue::CancelJob(CMusicLibraryJob *job)
 void CMusicLibraryQueue::CancelAllJobs()
 {
   std::unique_lock lock(m_critical);
+
+  // Ask any job that is already being processed to stop to prevent slow shutdown
+  for (const auto& jobs : m_jobs | std::views::values)
+  {
+    for (const auto& job : jobs)
+    {
+      if (job->CanBeCancelled())
+        job->Cancel();
+    }
+  }
+
   CJobQueue::CancelJobs();
 
   // remove all scanning jobs

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -74,7 +74,6 @@ using KODI::UTILITY::CDigest;
 CMusicInfoScanner::CMusicInfoScanner()
 : m_fileCountReader(this, "MusicFileCounter")
 {
-  m_bStop = false;
   m_currentItem=0;
   m_itemCount=0;
   m_flags = 0;
@@ -84,7 +83,6 @@ CMusicInfoScanner::~CMusicInfoScanner() = default;
 
 void CMusicInfoScanner::Process()
 {
-  m_bStop = false;
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnScanStarted");
   try
   {
@@ -100,7 +98,8 @@ void CMusicInfoScanner::Process()
     // check if we only need to perform a cleaning
     if (m_bClean && m_pathsToScan.empty())
     {
-      CMusicLibraryQueue::GetInstance().CleanLibrary(false);
+      if (!m_bStop)
+        CMusicLibraryQueue::GetInstance().CleanLibrary(false);
       m_handle = NULL;
       m_bRunning = false;
 

--- a/xbmc/music/infoscanner/MusicInfoScanner.h
+++ b/xbmc/music/infoscanner/MusicInfoScanner.h
@@ -14,6 +14,7 @@
 #include "threads/Thread.h"
 #include "utils/RegExp.h"
 
+#include <atomic>
 #include <string>
 
 class CAlbum;
@@ -278,7 +279,8 @@ protected:
 
   int m_currentItem;
   int m_itemCount;
-  bool m_bStop;
+  //! Sticky - never reset, so a scanner instance is good for one scan only
+  std::atomic<bool> m_bStop{false};
   bool m_needsCleanup = false;
   int m_scanType = 0; // 0 - load from files, 1 - albums, 2 - artists
   int m_idSourcePath;

--- a/xbmc/music/jobs/MusicLibraryScanningJob.cpp
+++ b/xbmc/music/jobs/MusicLibraryScanningJob.cpp
@@ -21,9 +21,7 @@ CMusicLibraryScanningJob::~CMusicLibraryScanningJob() = default;
 
 bool CMusicLibraryScanningJob::Cancel()
 {
-  if (!m_scanner.IsScanning())
-    return true;
-
+  m_cancelled = true;
   m_scanner.Stop();
   return true;
 }
@@ -43,6 +41,9 @@ bool CMusicLibraryScanningJob::Equals(const CJob* job) const
 
 bool CMusicLibraryScanningJob::Work(CMusicDatabase &db)
 {
+  if (m_cancelled)
+    return true;
+
   m_scanner.ShowDialog(m_showProgress);
   if (m_flags & MUSIC_INFO::CMusicInfoScanner::SCAN_ALBUMS)
     // Scrape additional album information

--- a/xbmc/music/jobs/MusicLibraryScanningJob.h
+++ b/xbmc/music/jobs/MusicLibraryScanningJob.h
@@ -11,6 +11,7 @@
 #include "music/infoscanner/MusicInfoScanner.h"
 #include "music/jobs/MusicLibraryJob.h"
 
+#include <atomic>
 #include <string>
 
 /*!
@@ -44,6 +45,7 @@ protected:
 
 private:
   MUSIC_INFO::CMusicInfoScanner m_scanner;
+  std::atomic<bool> m_cancelled{false};
   std::string m_directory;
   bool m_showProgress;
   int m_flags;

--- a/xbmc/profiles/ProfileManager.cpp
+++ b/xbmc/profiles/ProfileManager.cpp
@@ -22,7 +22,6 @@
 #include "addons/Service.h" //! @todo Remove me
 #include "addons/Skin.h"
 #include "application/Application.h" //! @todo Remove me
-#include "application/ApplicationComponents.h"
 #include "application/ApplicationPowerHandling.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "events/EventLog.h"
@@ -53,7 +52,6 @@
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
-#include "utils/Variant.h"
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 #include "video/VideoLibraryQueue.h" //! @todo Remove me
@@ -461,8 +459,7 @@ void CProfileManager::LogOff()
   if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
     CMusicLibraryQueue::GetInstance().StopLibraryScanning();
 
-  if (CVideoLibraryQueue::GetInstance().IsRunning())
-    CVideoLibraryQueue::GetInstance().CancelAllJobs();
+  CVideoLibraryQueue::GetInstance().CancelAllJobs();
 
   // Stop PVR services
   CServiceBroker::GetPVRManager().Stop();

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -262,7 +262,6 @@ namespace KODI::VIDEO
 CVideoInfoScanner::CVideoInfoScanner()
   : m_advancedSettings(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings())
 {
-  m_bStop = false;
   m_scanAll = false;
 
   const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
@@ -283,8 +282,6 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
   void CVideoInfoScanner::Process()
   {
-    m_bStop = false;
-
     try
     {
       const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
@@ -301,8 +298,11 @@ CVideoInfoScanner::~CVideoInfoScanner()
       // check if we only need to perform a cleaning
       if (m_bClean && m_pathsToScan.empty())
       {
-        std::set<int> paths;
-        m_database.CleanDatabase(m_handle, paths, false);
+        if (!m_bStop)
+        {
+          std::set<int> paths;
+          m_database.CleanDatabase(m_handle, paths, false);
+        }
 
         if (m_handle)
           m_handle->MarkFinished();

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -16,6 +16,7 @@
 #include "utils/Artwork.h"
 #include "utils/RegExp.h"
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <set>
@@ -357,7 +358,8 @@ namespace KODI::VIDEO
     std::pair<InfoType, std::unique_ptr<IVideoInfoTagLoader>> ReadInfoTag(
         CFileItem& item, const ADDON::ScraperPtr& scraper, bool lookInFolder, bool resetTag);
 
-    bool m_bStop;
+    //! Sticky - never reset, so a scanner instance is good for one scan only
+    std::atomic<bool> m_bStop{false};
     bool m_scanAll;
 
     SimilarVideoScanAction m_similarVideoAction{SimilarVideoScanAction::NONE};

--- a/xbmc/video/VideoLibraryQueue.cpp
+++ b/xbmc/video/VideoLibraryQueue.cpp
@@ -21,6 +21,7 @@
 #include "video/jobs/VideoLibraryScanningJob.h"
 
 #include <mutex>
+#include <ranges>
 #include <utility>
 
 CVideoLibraryQueue::CVideoLibraryQueue()
@@ -217,6 +218,17 @@ void CVideoLibraryQueue::CancelJob(CVideoLibraryJob *job)
 void CVideoLibraryQueue::CancelAllJobs()
 {
   std::unique_lock lock(m_critical);
+
+  // Ask any job that is already being processed to stop to prevent slow shutdown
+  for (const auto& jobs : m_jobs | std::views::values)
+  {
+    for (const auto& job : jobs)
+    {
+      if (job->CanBeCancelled())
+        job->Cancel();
+    }
+  }
+
   CJobQueue::CancelJobs();
 
   // remove all scanning jobs

--- a/xbmc/video/jobs/VideoLibraryScanningJob.cpp
+++ b/xbmc/video/jobs/VideoLibraryScanningJob.cpp
@@ -21,9 +21,7 @@ CVideoLibraryScanningJob::~CVideoLibraryScanningJob() = default;
 
 bool CVideoLibraryScanningJob::Cancel()
 {
-  if (!m_scanner.IsScanning())
-    return true;
-
+  m_cancelled = true;
   m_scanner.Stop();
   return true;
 }
@@ -43,6 +41,9 @@ bool CVideoLibraryScanningJob::Equals(const CJob* job) const
 
 bool CVideoLibraryScanningJob::Work(CVideoDatabase &db)
 {
+  if (m_cancelled)
+    return true;
+
   m_scanner.ShowDialog(m_showProgress);
   m_scanner.Start(m_directory, m_scanAll);
 

--- a/xbmc/video/jobs/VideoLibraryScanningJob.h
+++ b/xbmc/video/jobs/VideoLibraryScanningJob.h
@@ -11,6 +11,7 @@
 #include "video/VideoInfoScanner.h"
 #include "video/jobs/VideoLibraryJob.h"
 
+#include <atomic>
 #include <string>
 
 /*!
@@ -46,6 +47,7 @@ protected:
 
 private:
   KODI::VIDEO::CVideoInfoScanner m_scanner;
+  std::atomic<bool> m_cancelled{false};
   std::string m_directory;
   bool m_showProgress;
   bool m_scanAll;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Properly cancel jobs in queue.
Also fixes close down ordering to make sure no information lost.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Trying to exit Kodi whilst a library update was ongoing led to a 'hang' until the update had finished.

Fix #24574 - I'm sure I've seen others as well

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
