### PR TITLE
Let the by-id database getters distinguish a missing record from a failed lookup

### DIFF
--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -96,6 +96,16 @@ public:
     std::string where;
   };
 
+  /*!
+   \brief The outcome of a query for a single record.
+   */
+  enum class GetResult
+  {
+    Ok, ///< the record was found and has been returned
+    NotFound, ///< the database was queried successfully and holds no such record
+    Error, ///< the record could not be returned, so whether it exists may be unknown
+  };
+
   explicit CDatabase(const std::string& dbType);
   virtual ~CDatabase();
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -1218,14 +1218,19 @@ int CMusicDatabase::AddSong(const int idSong,
 
 bool CMusicDatabase::GetSong(int idSong, CSong& song)
 {
+  return TryGetSong(idSong, song) == GetResult::Ok;
+}
+
+CMusicDatabase::GetResult CMusicDatabase::TryGetSong(int idSong, CSong& song)
+{
   try
   {
     song.Clear();
 
     if (nullptr == m_pDB)
-      return false;
+      return GetResult::Error;
     if (nullptr == m_pDS)
-      return false;
+      return GetResult::Error;
 
     std::string strSQL =
         PrepareSQL("SELECT songview.*,songartistview.* FROM songview "
@@ -1235,12 +1240,12 @@ bool CMusicDatabase::GetSong(int idSong, CSong& song)
                    idSong);
 
     if (!m_pDS->query(strSQL))
-      return false;
+      return GetResult::Error;
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
       m_pDS->close();
-      return false;
+      return GetResult::NotFound;
     }
 
     int songArtistOffset = song_enumCount;
@@ -1259,14 +1264,14 @@ bool CMusicDatabase::GetSong(int idSong, CSong& song)
       m_pDS->next();
     }
     m_pDS->close(); // cleanup recordset data
-    return true;
+    return GetResult::Ok;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "({}) failed", idSong);
   }
 
-  return false;
+  return GetResult::Error;
 }
 
 bool CMusicDatabase::UpdateSong(CSong& song, bool bArtists /*= true*/, bool bArtistLinks /*= true*/)
@@ -1612,15 +1617,25 @@ int CMusicDatabase::UpdateAlbum(int idAlbum,
 
 bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = true */)
 {
+  if (TryGetAlbum(idAlbum, album, getSongs) != GetResult::Ok)
+    return false;
+
+  return !getSongs || !album.songs.empty();
+}
+
+CMusicDatabase::GetResult CMusicDatabase::TryGetAlbum(int idAlbum,
+                                                      CAlbum& album,
+                                                      bool getSongs /* = true */)
+{
   try
   {
     if (nullptr == m_pDB)
-      return false;
+      return GetResult::Error;
     if (nullptr == m_pDS)
-      return false;
+      return GetResult::Error;
 
     if (idAlbum == -1)
-      return false; // not in the database
+      return GetResult::NotFound; // not in the database
 
     //Get album, song and album song info data using separate queries/datasets because we can have
     //multiple roles per artist for songs and that makes a single combined join impractical
@@ -1635,11 +1650,11 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
 
     CLog::Log(LOGDEBUG, "{}", sql);
     if (!m_pDS->query(sql))
-      return false;
+      return GetResult::Error;
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
-      return false;
+      return GetResult::NotFound;
     }
 
     int albumArtistOffset = album_enumCount;
@@ -1670,11 +1685,11 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
 
       CLog::Log(LOGDEBUG, "{}", sql);
       if (!m_pDS->query(sql))
-        return false;
+        return GetResult::Error;
       if (m_pDS->num_rows() == 0) //Album with no songs
       {
         m_pDS->close();
-        return false;
+        return GetResult::Ok;
       }
 
       int songArtistOffset = song_enumCount;
@@ -1703,14 +1718,14 @@ bool CMusicDatabase::GetAlbum(int idAlbum, CAlbum& album, bool getSongs /* = tru
       m_pDS->close(); // cleanup recordset data
     }
 
-    return true;
+    return GetResult::Ok;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "({}) failed", idAlbum);
   }
 
-  return false;
+  return GetResult::Error;
 }
 
 bool CMusicDatabase::ClearAlbumLastScrapedTime(int idAlbum)
@@ -2089,18 +2104,25 @@ bool CMusicDatabase::UpdateArtistScrapedMBID(int idArtist,
 
 bool CMusicDatabase::GetArtist(int idArtist, CArtist& artist, bool fetchAll /* = false */)
 {
+  return TryGetArtist(idArtist, artist, fetchAll) == GetResult::Ok;
+}
+
+CMusicDatabase::GetResult CMusicDatabase::TryGetArtist(int idArtist,
+                                                       CArtist& artist,
+                                                       bool fetchAll /* = false */)
+{
   try
   {
     auto start = std::chrono::steady_clock::now();
     if (nullptr == m_pDB)
-      return false;
+      return GetResult::Error;
     if (nullptr == m_pDS)
-      return false;
+      return GetResult::Error;
     if (nullptr == m_pDS2)
-      return false;
+      return GetResult::Error;
 
     if (idArtist == -1)
-      return false; // not in the database
+      return GetResult::NotFound; // not in the database
 
     std::string strSQL;
     if (fetchAll)
@@ -2112,11 +2134,11 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist& artist, bool fetchAll /* =
       strSQL = PrepareSQL("SELECT * FROM artistview WHERE artistview.idArtist = %i", idArtist);
 
     if (!m_pDS->query(strSQL))
-      return false;
+      return GetResult::Error;
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
-      return false;
+      return GetResult::NotFound;
     }
     std::string debugSQL = strSQL + " - ";
     int discographyOffset = artist_enumCount;
@@ -2168,44 +2190,49 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist& artist, bool fetchAll /* =
     auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
 
     CLog::LogF(LOGDEBUG, "{} - took {} ms", debugSQL, duration.count());
-    return true;
+    return GetResult::Ok;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
 
-  return false;
+  return GetResult::Error;
 }
 
 bool CMusicDatabase::GetArtistExists(int idArtist)
 {
+  return TryGetArtistExists(idArtist) == GetResult::Ok;
+}
+
+CMusicDatabase::GetResult CMusicDatabase::TryGetArtistExists(int idArtist)
+{
   try
   {
     if (nullptr == m_pDB)
-      return false;
+      return GetResult::Error;
     if (nullptr == m_pDS)
-      return false;
+      return GetResult::Error;
 
     std::string strSQL =
         PrepareSQL("SELECT 1 FROM artist WHERE artist.idArtist = %i LIMIT 1", idArtist);
 
     if (!m_pDS->query(strSQL))
-      return false;
+      return GetResult::Error;
     if (m_pDS->num_rows() == 0)
     {
       m_pDS->close();
-      return false;
+      return GetResult::NotFound;
     }
     m_pDS->close(); // cleanup recordset data
-    return true;
+    return GetResult::Ok;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "({}) failed", idArtist);
   }
 
-  return false;
+  return GetResult::Error;
 }
 
 int CMusicDatabase::GetLastArtist() const

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -11510,17 +11510,17 @@ int CMusicDatabase::GetSongIDFromPath(const std::string& filePath)
 
 bool CMusicDatabase::CommitTransaction()
 {
-  if (CDatabase::CommitTransaction())
-  { // number of items in the db has likely changed, so reset the infomanager cache
-    CGUIComponent* gui = CServiceBroker::GetGUI();
-    if (gui)
-    {
-      gui->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider().SetLibraryBool(
-          LIBRARY_HAS_MUSIC, GetSongsCount() > 0);
-      return true;
-    }
+  if (!CDatabase::CommitTransaction())
+    return false;
+
+  // number of items in the db has likely changed, so reset the infomanager cache
+  if (CGUIComponent* gui = CServiceBroker::GetGUI())
+  {
+    gui->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider().SetLibraryBool(
+        LIBRARY_HAS_MUSIC, GetSongsCount() > 0);
   }
-  return false;
+
+  return true;
 }
 
 bool CMusicDatabase::SetScraperAll(const std::string& strBaseDir, const ADDON::ScraperPtr& scraper)

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -171,6 +171,13 @@ public:
               const ReplayGain& replayGain);
   bool GetSong(int idSong, CSong& song);
 
+  /*! \brief Retrieve a song, distinguishing a missing song from a failed lookup.
+   \param idSong the database id of the song.
+   \param song [out] the song to fill.
+   \return GetResult::Ok if retrieved, NotFound if there is no such song, Error otherwise.
+   */
+  GetResult TryGetSong(int idSong, CSong& song);
+
   /*! \brief Update a song and all its nested entities (genres, artists, contributors)
     \param song [in/out] the song to update, artist ids are returned in artist credits
     \param bArtists to update artist credits and contributors, default is true
@@ -310,6 +317,15 @@ public:
    \return true if the album is retrieved, false otherwise.
    */
   bool GetAlbum(int idAlbum, CAlbum& album, bool getSongs = true);
+
+  /*! \brief Retrieve an album, distinguishing a missing album from a failed lookup.
+   \param idAlbum the database id of the album.
+   \param album [out] the album to fill.
+   \param getSongs whether or not to retrieve songs, defaults to true.
+   \return GetResult::Ok if retrieved, NotFound if there is no such album, Error otherwise.
+           An album with no songs is retrieved with an empty song list.
+   */
+  GetResult TryGetAlbum(int idAlbum, CAlbum& album, bool getSongs = true);
   int UpdateAlbum(int idAlbum,
                   const std::string& strAlbum,
                   const std::string& strMusicBrainzAlbumID,
@@ -378,7 +394,22 @@ public:
                 const std::string& strMusicBrainzArtistID,
                 bool bScrapedMBID = false);
   bool GetArtist(int idArtist, CArtist& artist, bool fetchAll = false);
+
+  /*! \brief Retrieve an artist, distinguishing a missing artist from a failed lookup.
+   \param idArtist the database id of the artist.
+   \param artist [out] the artist to fill.
+   \param fetchAll whether or not to retrieve the discography and video links.
+   \return GetResult::Ok if retrieved, NotFound if there is no such artist, Error otherwise.
+   */
+  GetResult TryGetArtist(int idArtist, CArtist& artist, bool fetchAll = false);
+
   bool GetArtistExists(int idArtist);
+
+  /*! \brief Establish whether an artist exists, distinguishing a miss from a failed lookup.
+   \param idArtist the database id of the artist.
+   \return GetResult::Ok if the artist exists, NotFound if it does not, Error otherwise.
+   */
+  GetResult TryGetArtistExists(int idArtist);
   int GetLastArtist() const;
   int GetArtistFromMBID(const std::string& strMusicBrainzArtistID, std::string& artistname);
   int UpdateArtist(int idArtist,

--- a/xbmc/music/test/CMakeLists.txt
+++ b/xbmc/music/test/CMakeLists.txt
@@ -1,3 +1,4 @@
-set(SOURCES TestMusicFileItemClassify.cpp)
+set(SOURCES TestMusicDatabaseGetResult.cpp
+            TestMusicFileItemClassify.cpp)
 
 core_add_test_library(music_test)

--- a/xbmc/music/test/TestMusicDatabaseGetResult.cpp
+++ b/xbmc/music/test/TestMusicDatabaseGetResult.cpp
@@ -1,0 +1,176 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "filesystem/SpecialProtocol.h"
+#include "music/Album.h"
+#include "music/Artist.h"
+#include "music/MusicDatabase.h"
+#include "music/Song.h"
+#include "settings/AdvancedSettings.h"
+#include "utils/StringUtils.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using GetResult = CDatabase::GetResult;
+
+// An id that no test ever inserts, so every lookup of it misses.
+constexpr int MISSING_ID = 4242;
+
+// The album the songless-album test adds.
+constexpr int ALBUM_ID = 4243;
+
+DatabaseSettings SqliteSettings()
+{
+  DatabaseSettings settings;
+  settings.type = "sqlite3";
+  settings.host = CSpecialProtocol::TranslatePath("special://temp/");
+  return settings;
+}
+
+} // namespace
+
+class MusicDatabaseGetResultTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    ASSERT_EQ(m_db.Connect("TestMusicDatabaseGetResult", SqliteSettings(), true),
+              CDatabase::ConnectionState::STATE_CONNECTED);
+  }
+
+  void TearDown() override { m_db.Close(); }
+
+  CMusicDatabase m_db;
+};
+
+TEST(MusicDatabaseGetResultUnconnectedTest, EveryGetterReportsError)
+{
+  CMusicDatabase db;
+  CSong song;
+  CAlbum album;
+  CArtist artist;
+
+  EXPECT_EQ(db.TryGetSong(MISSING_ID, song), GetResult::Error);
+  EXPECT_EQ(db.TryGetAlbum(MISSING_ID, album), GetResult::Error);
+  EXPECT_EQ(db.TryGetArtist(MISSING_ID, artist), GetResult::Error);
+  EXPECT_EQ(db.TryGetArtistExists(MISSING_ID), GetResult::Error);
+}
+
+TEST_F(MusicDatabaseGetResultTest, MissingRowsAreNotFound)
+{
+  CSong song;
+  CAlbum album;
+  CArtist artist;
+
+  EXPECT_EQ(m_db.TryGetSong(MISSING_ID, song), GetResult::NotFound);
+  EXPECT_EQ(m_db.TryGetAlbum(MISSING_ID, album), GetResult::NotFound);
+  EXPECT_EQ(m_db.TryGetArtist(MISSING_ID, artist), GetResult::NotFound);
+  EXPECT_EQ(m_db.TryGetArtistExists(MISSING_ID), GetResult::NotFound);
+}
+
+TEST_F(MusicDatabaseGetResultTest, BoolOverloadsStillReportFalseForMissingRows)
+{
+  CSong song;
+  CAlbum album;
+  CArtist artist;
+
+  EXPECT_FALSE(m_db.GetSong(MISSING_ID, song));
+  EXPECT_FALSE(m_db.GetAlbum(MISSING_ID, album));
+  EXPECT_FALSE(m_db.GetArtist(MISSING_ID, artist));
+  EXPECT_FALSE(m_db.GetArtistExists(MISSING_ID));
+}
+
+// A negative id is rejected before any query runs, which is still an answer
+// about the record.
+TEST_F(MusicDatabaseGetResultTest, NegativeIdIsNotFound)
+{
+  CAlbum album;
+  CArtist artist;
+
+  EXPECT_EQ(m_db.TryGetAlbum(-1, album), GetResult::NotFound);
+  EXPECT_EQ(m_db.TryGetArtist(-1, artist), GetResult::NotFound);
+}
+
+// An album the database holds is retrieved even when it carries no songs, because an empty
+// list is a result rather than a failure. The bool overload keeps reporting it as a failure.
+TEST(MusicDatabaseGetResultSonglessAlbumTest, AlbumWithNoSongsIsRetrievedWithAnEmptySongList)
+{
+  CMusicDatabase db;
+  // A database of this test's own, because it adds rows.
+  ASSERT_EQ(db.Connect("TestMusicDatabaseSonglessAlbum", SqliteSettings(), true),
+            CDatabase::ConnectionState::STATE_CONNECTED);
+
+  // An album credited to the artist the schema seeds, and deliberately no songs.
+  ASSERT_TRUE(db.ExecuteQuery(
+      StringUtils::Format("INSERT INTO album (idAlbum, strAlbum) VALUES ({}, 'Album')", ALBUM_ID)));
+  ASSERT_TRUE(db.ExecuteQuery(
+      StringUtils::Format("INSERT INTO album_artist (idArtist, idAlbum, iOrder, strArtist) "
+                          "VALUES ({}, {}, 0, 'Artist')",
+                          BLANKARTIST_ID, ALBUM_ID)));
+
+  CAlbum album;
+  EXPECT_EQ(db.TryGetAlbum(ALBUM_ID, album, false), GetResult::Ok);
+  EXPECT_EQ(album.strAlbum, "Album");
+
+  CAlbum withSongs;
+  EXPECT_EQ(db.TryGetAlbum(ALBUM_ID, withSongs, true), GetResult::Ok);
+  EXPECT_TRUE(withSongs.songs.empty());
+
+  // Unchanged from before the distinction existed.
+  EXPECT_TRUE(db.GetAlbum(ALBUM_ID, album, false));
+  EXPECT_FALSE(db.GetAlbum(ALBUM_ID, withSongs, true));
+
+  db.Close();
+}
+
+// Refreshing the library info is a side effect of a commit, not a condition of it.
+TEST(MusicDatabaseTransactionTest, CommitSucceedsWithoutAGui)
+{
+  CMusicDatabase db;
+  ASSERT_EQ(db.Connect("TestMusicDatabaseTransaction", SqliteSettings(), true),
+            CDatabase::ConnectionState::STATE_CONNECTED);
+
+  db.BeginTransaction();
+  EXPECT_TRUE(db.CommitTransaction());
+
+  db.Close();
+}
+
+TEST(MusicDatabaseGetResultQueryFailureTest, FailedQueryReportsError)
+{
+  CMusicDatabase db;
+  // A database of this test's own, because it damages the schema.
+  ASSERT_EQ(db.Connect("TestMusicDatabaseGetResultQueryFailure", SqliteSettings(), true),
+            CDatabase::ConnectionState::STATE_CONNECTED);
+
+  // Remove what each getter selects from, so the query itself fails.
+  ASSERT_TRUE(db.ExecuteQuery("DROP VIEW songview"));
+  ASSERT_TRUE(db.ExecuteQuery("DROP VIEW albumview"));
+  ASSERT_TRUE(db.ExecuteQuery("DROP VIEW artistview"));
+  ASSERT_TRUE(db.ExecuteQuery("DROP TABLE artist"));
+
+  CSong song;
+  CAlbum album;
+  CArtist artist;
+
+  EXPECT_EQ(db.TryGetSong(MISSING_ID, song), GetResult::Error);
+  EXPECT_EQ(db.TryGetAlbum(MISSING_ID, album), GetResult::Error);
+  EXPECT_EQ(db.TryGetArtist(MISSING_ID, artist), GetResult::Error);
+  EXPECT_EQ(db.TryGetArtistExists(MISSING_ID), GetResult::Error);
+
+  // The bool overloads return the same false here as they do for a missing row.
+  EXPECT_FALSE(db.GetSong(MISSING_ID, song));
+  EXPECT_FALSE(db.GetAlbum(MISSING_ID, album));
+  EXPECT_FALSE(db.GetArtist(MISSING_ID, artist));
+  EXPECT_FALSE(db.GetArtistExists(MISSING_ID));
+
+  db.Close();
+}

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1887,16 +1887,27 @@ bool CVideoDatabase::GetMovieInfo(const std::string& strFilenameAndPath,
                                   int idFile /* = -1 */,
                                   int getDetails /* = VideoDbDetailsAll */)
 {
+  return TryGetMovieInfo(strFilenameAndPath, details, idMovie, idVersion, idFile, getDetails) ==
+         GetResult::Ok;
+}
+
+CVideoDatabase::GetResult CVideoDatabase::TryGetMovieInfo(const std::string& strFilenameAndPath,
+                                                          CVideoInfoTag& details,
+                                                          int idMovie /* = -1 */,
+                                                          int idVersion /* = -1 */,
+                                                          int idFile /* = -1 */,
+                                                          int getDetails /* = VideoDbDetailsAll */)
+{
   try
   {
     if (m_pDB == nullptr || m_pDS == nullptr)
-      return false;
+      return GetResult::Error;
 
     if (idMovie < 0)
       idMovie = GetMovieId(strFilenameAndPath);
 
     if (idMovie < 0)
-      return false;
+      return GetResult::NotFound;
 
     std::string sql;
     if (idFile >= 0)
@@ -1924,16 +1935,16 @@ bool CVideoDatabase::GetMovieInfo(const std::string& strFilenameAndPath,
                        idMovie);
 
     if (!m_pDS->query(sql))
-      return false;
+      return GetResult::Error;
 
     details = GetDetailsForMovie(*m_pDS, getDetails);
-    return !details.IsEmpty();
+    return details.IsEmpty() ? GetResult::NotFound : GetResult::Ok;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "({}, {}, {}) failed", strFilenameAndPath, idMovie, idFile);
   }
-  return false;
+  return GetResult::Error;
 }
 
 std::string CVideoDatabase::GetMovieTitle(int idMovie)
@@ -1956,26 +1967,36 @@ bool CVideoDatabase::GetTvShowInfo(const std::string& strPath,
                                    CFileItem* item /* = nullptr */,
                                    int getDetails /* = VideoDbDetailsAll */)
 {
+  return TryGetTvShowInfo(strPath, details, idTvShow, item, getDetails) == GetResult::Ok;
+}
+
+CVideoDatabase::GetResult CVideoDatabase::TryGetTvShowInfo(const std::string& strPath,
+                                                           CVideoInfoTag& details,
+                                                           int idTvShow /* = -1 */,
+                                                           CFileItem* item /* = nullptr */,
+                                                           int getDetails /* = VideoDbDetailsAll */)
+{
   try
   {
     if (m_pDB == nullptr || m_pDS == nullptr)
-      return false;
+      return GetResult::Error;
 
     if (idTvShow < 0)
       idTvShow = GetTvShowId(strPath);
-    if (idTvShow < 0) return false;
+    if (idTvShow < 0)
+      return GetResult::NotFound;
 
     std::string sql = PrepareSQL("SELECT * FROM tvshow_view WHERE idShow=%i GROUP BY idShow", idTvShow);
     if (!m_pDS->query(sql))
-      return false;
+      return GetResult::Error;
     details = GetDetailsForTvShow(*m_pDS, getDetails, item);
-    return !details.IsEmpty();
+    return details.IsEmpty() ? GetResult::NotFound : GetResult::Ok;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "({}) failed", strPath);
   }
-  return false;
+  return GetResult::Error;
 }
 
 bool CVideoDatabase::GetSeasonInfo(const std::string& path,
@@ -2020,23 +2041,45 @@ bool CVideoDatabase::GetSeasonInfo(int idSeason,
                                    bool allDetails,
                                    CFileItem* item)
 {
+  return TryGetSeasonInfo(idSeason, details, allDetails, item) == GetResult::Ok;
+}
+
+CVideoDatabase::GetResult CVideoDatabase::TryGetSeasonInfo(int idSeason,
+                                                           CVideoInfoTag& details,
+                                                           bool allDetails /* = true */)
+{
+  return TryGetSeasonInfo(idSeason, details, allDetails, nullptr);
+}
+
+CVideoDatabase::GetResult CVideoDatabase::TryGetSeasonInfo(int idSeason,
+                                                           CVideoInfoTag& details,
+                                                           CFileItem* item)
+{
+  return TryGetSeasonInfo(idSeason, details, true, item);
+}
+
+CVideoDatabase::GetResult CVideoDatabase::TryGetSeasonInfo(int idSeason,
+                                                           CVideoInfoTag& details,
+                                                           bool allDetails,
+                                                           CFileItem* item)
+{
   if (idSeason < 0)
-    return false;
+    return GetResult::NotFound;
 
   try
   {
     if (!m_pDB || !m_pDS)
-      return false;
+      return GetResult::Error;
 
     const std::string sql = PrepareSQL("SELECT idSeason, idShow, season, name, userrating, plot "
                                        "FROM seasons WHERE idSeason = %i",
                                        idSeason);
 
     if (!m_pDS->query(sql))
-      return false;
+      return GetResult::Error;
 
     if (m_pDS->num_rows() != 1)
-      return false;
+      return GetResult::NotFound;
 
     if (allDetails)
     {
@@ -2046,13 +2089,15 @@ bool CVideoDatabase::GetSeasonInfo(int idSeason,
       m_pDS->close();
 
       if (idShow < 0)
-        return false;
+        return GetResult::Error;
 
       CFileItemList seasons;
       if (!GetSeasonsNav(StringUtils::Format("videodb://tvshows/titles/{}/", idShow), seasons, -1,
-                         -1, -1, -1, idShow, false) ||
-          seasons.Size() <= 0)
-        return false;
+                         -1, -1, -1, idShow, false))
+        return GetResult::Error;
+
+      if (seasons.Size() <= 0)
+        return GetResult::Error;
 
       for (int index = 0; index < seasons.Size(); index++)
       {
@@ -2062,11 +2107,11 @@ bool CVideoDatabase::GetSeasonInfo(int idSeason,
           details = *season->GetVideoInfoTag();
           if (item)
             *item = *season;
-          return true;
+          return GetResult::Ok;
         }
       }
 
-      return false;
+      return GetResult::Error;
     }
 
     const int season = m_pDS->fv(2).get_asInt();
@@ -2092,13 +2137,13 @@ bool CVideoDatabase::GetSeasonInfo(int idSeason,
     details.m_iIdShow = m_pDS->fv(1).get_asInt();
     details.m_strPlot = m_pDS->fv(5).get_asString();
 
-    return true;
+    return GetResult::Ok;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "({}) failed", idSeason);
   }
-  return false;
+  return GetResult::Error;
 }
 
 bool CVideoDatabase::GetEpisodeBasicInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idEpisode /* = -1 */)
@@ -2129,94 +2174,142 @@ bool CVideoDatabase::GetEpisodeBasicInfo(const std::string& strFilenameAndPath, 
 
 bool CVideoDatabase::GetEpisodeInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idEpisode /* = -1 */, int getDetails /* = VideoDbDetailsAll */)
 {
+  return TryGetEpisodeInfo(strFilenameAndPath, details, idEpisode, getDetails) == GetResult::Ok;
+}
+
+CVideoDatabase::GetResult CVideoDatabase::TryGetEpisodeInfo(
+    const std::string& strFilenameAndPath,
+    CVideoInfoTag& details,
+    int idEpisode /* = -1 */,
+    int getDetails /* = VideoDbDetailsAll */)
+{
   try
   {
     if (m_pDB == nullptr || m_pDS == nullptr)
-      return false;
+      return GetResult::Error;
 
     if (idEpisode < 0)
       idEpisode = GetEpisodeId(strFilenameAndPath, details.m_iEpisode, details.m_iSeason);
-    if (idEpisode < 0) return false;
+    if (idEpisode < 0)
+      return GetResult::NotFound;
 
     std::string sql = PrepareSQL("select * from episode_view where idEpisode=%i",idEpisode);
     if (!m_pDS->query(sql))
-      return false;
+      return GetResult::Error;
     details = GetDetailsForEpisode(*m_pDS, getDetails);
-    return !details.IsEmpty();
+    return details.IsEmpty() ? GetResult::NotFound : GetResult::Ok;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
-  return false;
+  return GetResult::Error;
 }
 
 bool CVideoDatabase::GetMusicVideoInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idMVideo /* = -1 */, int getDetails /* = VideoDbDetailsAll */)
 {
+  return TryGetMusicVideoInfo(strFilenameAndPath, details, idMVideo, getDetails) == GetResult::Ok;
+}
+
+CVideoDatabase::GetResult CVideoDatabase::TryGetMusicVideoInfo(
+    const std::string& strFilenameAndPath,
+    CVideoInfoTag& details,
+    int idMVideo /* = -1 */,
+    int getDetails /* = VideoDbDetailsAll */)
+{
   try
   {
     if (m_pDB == nullptr || m_pDS == nullptr)
-      return false;
+      return GetResult::Error;
 
     if (idMVideo < 0)
       idMVideo = GetMusicVideoId(strFilenameAndPath);
-    if (idMVideo < 0) return false;
+    if (idMVideo < 0)
+      return GetResult::NotFound;
 
     std::string sql = PrepareSQL("select * from musicvideo_view where idMVideo=%i", idMVideo);
     if (!m_pDS->query(sql))
-      return false;
+      return GetResult::Error;
     details = GetDetailsForMusicVideo(*m_pDS, getDetails);
-    return !details.IsEmpty();
+    return details.IsEmpty() ? GetResult::NotFound : GetResult::Ok;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
-  return false;
+  return GetResult::Error;
 }
 
 bool CVideoDatabase::GetSetInfo(int idSet, CVideoInfoTag& details, CFileItem* item /* = nullptr */)
 {
+  return TryGetSetInfo(idSet, details, item) == GetResult::Ok;
+}
+
+CVideoDatabase::GetResult CVideoDatabase::TryGetSetInfo(int idSet,
+                                                        CVideoInfoTag& details,
+                                                        CFileItem* item /* = nullptr */)
+{
   try
   {
     if (idSet < 0)
-      return false;
+      return GetResult::NotFound;
 
     Filter filter;
     filter.where = PrepareSQL("`sets`.`idSet`=%d", idSet);
     CFileItemList items;
-    if (!GetSetsByWhere("videodb://movies/sets/", filter, items) ||
-        items.Size() != 1 ||
-        !items[0]->HasVideoInfoTag())
-      return false;
+    // GetSetsByWhere returns an empty list for no match, so false is a genuine failure
+    if (!GetSetsByWhere("videodb://movies/sets/", filter, items))
+      return GetResult::Error;
+
+    if (items.Size() == 0)
+      return GetResult::NotFound;
+
+    if (items.Size() != 1 || !items[0]->HasVideoInfoTag())
+      return GetResult::Error;
 
     details = *(items[0]->GetVideoInfoTag());
     if (item)
       *item = *items[0];
-    return !details.IsEmpty();
+    return details.IsEmpty() ? GetResult::NotFound : GetResult::Ok;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "({}) failed", idSet);
   }
-  return false;
+  return GetResult::Error;
 }
 
 bool CVideoDatabase::GetFileInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idFile /* = -1 */)
 {
+  return TryGetFileInfo(strFilenameAndPath, details, idFile) == GetResult::Ok;
+}
+
+CVideoDatabase::GetResult CVideoDatabase::TryGetFileInfo(const std::string& strFilenameAndPath,
+                                                         CVideoInfoTag& details,
+                                                         int idFile /* = -1 */)
+{
   try
   {
+    if (m_pDB == nullptr || m_pDS == nullptr)
+      return GetResult::Error;
+
     if (idFile < 0)
       idFile = GetFileId(strFilenameAndPath);
     if (idFile < 0)
-      return false;
+      return GetResult::NotFound;
 
     std::string sql = PrepareSQL("SELECT * FROM files "
                                 "JOIN path ON path.idPath = files.idPath "
                                 "LEFT JOIN bookmark ON bookmark.idFile = files.idFile AND bookmark.type = %i "
                                 "WHERE files.idFile = %i", CBookmark::RESUME, idFile);
     if (!m_pDS->query(sql))
-      return false;
+      return GetResult::Error;
+
+    if (m_pDS->num_rows() == 0)
+    {
+      m_pDS->close();
+      return GetResult::NotFound;
+    }
 
     details.m_iFileId = m_pDS->fv("files.idFile").get_asInt();
     details.m_strPath = m_pDS->fv("path.strPath").get_asString();
@@ -2240,13 +2333,13 @@ bool CVideoDatabase::GetFileInfo(const std::string& strFilenameAndPath, CVideoIn
     // get streamdetails
     GetStreamDetails(details);
 
-    return !details.IsEmpty();
+    return details.IsEmpty() ? GetResult::NotFound : GetResult::Ok;
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
   }
-  return false;
+  return GetResult::Error;
 }
 
 template<typename T>

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11727,15 +11727,20 @@ void CVideoDatabase::InvalidatePathHash(const std::string& strPath)
 
 bool CVideoDatabase::CommitTransaction()
 {
-  if (CDatabase::CommitTransaction())
-  { // number of items in the db has likely changed, so recalculate
-    GUIINFO::CLibraryGUIInfo& guiInfo = CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider();
+  if (!CDatabase::CommitTransaction())
+    return false;
+
+  // number of items in the db has likely changed, so recalculate
+  if (CGUIComponent* gui = CServiceBroker::GetGUI())
+  {
+    GUIINFO::CLibraryGUIInfo& guiInfo =
+        gui->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider();
     guiInfo.SetLibraryBool(LIBRARY_HAS_MOVIES, HasContent(VideoDbContentType::MOVIES));
     guiInfo.SetLibraryBool(LIBRARY_HAS_TVSHOWS, HasContent(VideoDbContentType::TVSHOWS));
     guiInfo.SetLibraryBool(LIBRARY_HAS_MUSICVIDEOS, HasContent(VideoDbContentType::MUSICVIDEOS));
-    return true;
   }
-  return false;
+
+  return true;
 }
 
 bool CVideoDatabase::SetSingleValue(VideoDbContentType type,

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -303,6 +303,82 @@ public:
   bool GetSetInfo(int idSet, CVideoInfoTag& details, CFileItem* item = nullptr);
   bool GetFileInfo(const std::string& strFilenameAndPath, CVideoInfoTag& details, int idFile = -1);
 
+  /*! \brief Retrieve a movie, distinguishing a missing movie from a failed lookup.
+   \param strFilenameAndPath the path of the movie, ignored when idMovie is given.
+   \param details [out] the details to fill.
+   \return GetResult::Ok if retrieved, NotFound if there is no such movie, Error otherwise.
+   */
+  GetResult TryGetMovieInfo(const std::string& strFilenameAndPath,
+                            CVideoInfoTag& details,
+                            int idMovie = -1,
+                            int idVersion = -1,
+                            int idFile = -1,
+                            int getDetails = VideoDbDetailsAll);
+
+  /*! \brief Retrieve a tv show, distinguishing a missing show from a failed lookup.
+   \param strPath the path of the tv show, ignored when idTvShow is given.
+   \param details [out] the details to fill.
+   \return GetResult::Ok if retrieved, NotFound if there is no such tv show, Error otherwise.
+   */
+  GetResult TryGetTvShowInfo(const std::string& strPath,
+                             CVideoInfoTag& details,
+                             int idTvShow = -1,
+                             CFileItem* item = nullptr,
+                             int getDetails = VideoDbDetailsAll);
+
+  /*! \brief Retrieve a season, distinguishing a missing season from a failed lookup.
+   \param idSeason the database id of the season.
+   \param details [out] the details to fill.
+   \param allDetails whether to fill the details from the season view rather than the season row.
+   \return GetResult::Ok if retrieved, NotFound if there is no such season, Error otherwise.
+   */
+  GetResult TryGetSeasonInfo(int idSeason, CVideoInfoTag& details, bool allDetails = true);
+
+  /*! \brief Retrieve a season, distinguishing a missing season from a failed lookup.
+   \param idSeason the database id of the season.
+   \param details [out] the details to fill.
+   \param item [out] the item to fill with the season.
+   \return GetResult::Ok if retrieved, NotFound if there is no such season, Error otherwise.
+   */
+  GetResult TryGetSeasonInfo(int idSeason, CVideoInfoTag& details, CFileItem* item);
+
+  /*! \brief Retrieve an episode, distinguishing a missing episode from a failed lookup.
+   \param strFilenameAndPath the path of the episode, ignored when idEpisode is given.
+   \param details [out] the details to fill.
+   \return GetResult::Ok if retrieved, NotFound if there is no such episode, Error otherwise.
+   */
+  GetResult TryGetEpisodeInfo(const std::string& strFilenameAndPath,
+                              CVideoInfoTag& details,
+                              int idEpisode = -1,
+                              int getDetails = VideoDbDetailsAll);
+
+  /*! \brief Retrieve a music video, distinguishing a missing one from a failed lookup.
+   \param strFilenameAndPath the path of the music video, ignored when idMVideo is given.
+   \param details [out] the details to fill.
+   \return GetResult::Ok if retrieved, NotFound if there is no such music video, Error otherwise.
+   */
+  GetResult TryGetMusicVideoInfo(const std::string& strFilenameAndPath,
+                                 CVideoInfoTag& details,
+                                 int idMVideo = -1,
+                                 int getDetails = VideoDbDetailsAll);
+
+  /*! \brief Retrieve a set, distinguishing a missing set from a failed lookup.
+   \param idSet the database id of the set.
+   \param details [out] the details to fill.
+   \param item [out] optional item to fill with the set.
+   \return GetResult::Ok if retrieved, NotFound if there is no such set, Error otherwise.
+   */
+  GetResult TryGetSetInfo(int idSet, CVideoInfoTag& details, CFileItem* item = nullptr);
+
+  /*! \brief Retrieve a file, distinguishing a missing file from a failed lookup.
+   \param strFilenameAndPath the path of the file, ignored when idFile is given.
+   \param details [in/out] the details to add the file information to.
+   \return GetResult::Ok if retrieved, NotFound if there is no such file, Error otherwise.
+   */
+  GetResult TryGetFileInfo(const std::string& strFilenameAndPath,
+                           CVideoInfoTag& details,
+                           int idFile = -1);
+
   int GetPathId(const std::string& strPath);
   int GetTvShowId(const std::string& strPath);
   int GetEpisodeId(const std::string& strFilenameAndPath, int idEpisode=-1, int idSeason=-1); // idEpisode, idSeason are used for multipart episodes as hints
@@ -1244,6 +1320,10 @@ private:
   CDateTime GetLastPlayed(int iFileId);
 
   bool GetSeasonInfo(int idSeason, CVideoInfoTag& details, bool allDetails, CFileItem* item);
+  GetResult TryGetSeasonInfo(int idSeason,
+                             CVideoInfoTag& details,
+                             bool allDetails,
+                             CFileItem* item);
 
   int GetMinSchemaVersion() const override { return 75; }
   int GetSchemaVersion() const override;

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES TestBookmark.cpp
             TestFilenameAttributes.cpp
             TestStacks.cpp
+            TestVideoDatabaseGetResult.cpp
             TestVideoDbUrl.cpp
             TestVideoFileItemClassify.cpp
             TestVideoInfoTag.cpp

--- a/xbmc/video/test/TestVideoDatabaseGetResult.cpp
+++ b/xbmc/video/test/TestVideoDatabaseGetResult.cpp
@@ -1,0 +1,146 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "filesystem/SpecialProtocol.h"
+#include "settings/AdvancedSettings.h"
+#include "video/VideoDatabase.h"
+#include "video/VideoInfoTag.h"
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+using GetResult = CDatabase::GetResult;
+
+// An id that no test ever inserts, so every lookup of it misses.
+constexpr int MISSING_ID = 4242;
+
+DatabaseSettings SqliteSettings()
+{
+  DatabaseSettings settings;
+  settings.type = "sqlite3";
+  settings.host = CSpecialProtocol::TranslatePath("special://temp/");
+  return settings;
+}
+
+} // namespace
+
+class VideoDatabaseGetResultTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    ASSERT_EQ(m_db.Connect("TestVideoDatabaseGetResult", SqliteSettings(), true),
+              CDatabase::ConnectionState::STATE_CONNECTED);
+  }
+
+  void TearDown() override { m_db.Close(); }
+
+  CVideoDatabase m_db;
+};
+
+TEST(VideoDatabaseGetResultUnconnectedTest, EveryGetterReportsError)
+{
+  CVideoDatabase db;
+  CVideoInfoTag details;
+
+  EXPECT_EQ(db.TryGetMovieInfo("", details, MISSING_ID), GetResult::Error);
+  EXPECT_EQ(db.TryGetTvShowInfo("", details, MISSING_ID), GetResult::Error);
+  EXPECT_EQ(db.TryGetSeasonInfo(MISSING_ID, details), GetResult::Error);
+  EXPECT_EQ(db.TryGetEpisodeInfo("", details, MISSING_ID), GetResult::Error);
+  EXPECT_EQ(db.TryGetMusicVideoInfo("", details, MISSING_ID), GetResult::Error);
+  EXPECT_EQ(db.TryGetSetInfo(MISSING_ID, details), GetResult::Error);
+  EXPECT_EQ(db.TryGetFileInfo("", details, MISSING_ID), GetResult::Error);
+}
+
+TEST_F(VideoDatabaseGetResultTest, MissingRowsAreNotFound)
+{
+  CVideoInfoTag details;
+
+  EXPECT_EQ(m_db.TryGetMovieInfo("", details, MISSING_ID), GetResult::NotFound);
+  EXPECT_EQ(m_db.TryGetTvShowInfo("", details, MISSING_ID), GetResult::NotFound);
+  EXPECT_EQ(m_db.TryGetSeasonInfo(MISSING_ID, details), GetResult::NotFound);
+  EXPECT_EQ(m_db.TryGetEpisodeInfo("", details, MISSING_ID), GetResult::NotFound);
+  EXPECT_EQ(m_db.TryGetMusicVideoInfo("", details, MISSING_ID), GetResult::NotFound);
+  EXPECT_EQ(m_db.TryGetSetInfo(MISSING_ID, details), GetResult::NotFound);
+  EXPECT_EQ(m_db.TryGetFileInfo("", details, MISSING_ID), GetResult::NotFound);
+}
+
+TEST_F(VideoDatabaseGetResultTest, BoolOverloadsStillReportFalseForMissingRows)
+{
+  CVideoInfoTag details;
+
+  EXPECT_FALSE(m_db.GetMovieInfo("", details, MISSING_ID));
+  EXPECT_FALSE(m_db.GetTvShowInfo("", details, MISSING_ID));
+  EXPECT_FALSE(m_db.GetSeasonInfo(MISSING_ID, details));
+  EXPECT_FALSE(m_db.GetEpisodeInfo("", details, MISSING_ID));
+  EXPECT_FALSE(m_db.GetMusicVideoInfo("", details, MISSING_ID));
+  EXPECT_FALSE(m_db.GetSetInfo(MISSING_ID, details));
+  EXPECT_FALSE(m_db.GetFileInfo("", details, MISSING_ID));
+}
+
+// A negative id is rejected before any query runs, which is still an answer
+// about the record.
+TEST_F(VideoDatabaseGetResultTest, NegativeIdIsNotFound)
+{
+  CVideoInfoTag details;
+
+  EXPECT_EQ(m_db.TryGetSeasonInfo(-1, details), GetResult::NotFound);
+  EXPECT_EQ(m_db.TryGetSetInfo(-1, details), GetResult::NotFound);
+}
+
+// Refreshing the library info is a side effect of a commit, not a condition of it.
+TEST(VideoDatabaseTransactionTest, CommitSucceedsWithoutAGui)
+{
+  CVideoDatabase db;
+  ASSERT_EQ(db.Connect("TestVideoDatabaseTransaction", SqliteSettings(), true),
+            CDatabase::ConnectionState::STATE_CONNECTED);
+
+  db.BeginTransaction();
+  EXPECT_TRUE(db.CommitTransaction());
+
+  db.Close();
+}
+
+TEST(VideoDatabaseGetResultQueryFailureTest, FailedQueryReportsError)
+{
+  CVideoDatabase db;
+  // A database of this test's own, because it damages the schema.
+  ASSERT_EQ(db.Connect("TestVideoDatabaseGetResultQueryFailure", SqliteSettings(), true),
+            CDatabase::ConnectionState::STATE_CONNECTED);
+
+  // Remove what each getter selects from, so the query itself fails.
+  ASSERT_TRUE(db.ExecuteQuery("DROP VIEW movie_view"));
+  ASSERT_TRUE(db.ExecuteQuery("DROP VIEW tvshow_view"));
+  ASSERT_TRUE(db.ExecuteQuery("DROP VIEW episode_view"));
+  ASSERT_TRUE(db.ExecuteQuery("DROP VIEW musicvideo_view"));
+  ASSERT_TRUE(db.ExecuteQuery("DROP TABLE seasons"));
+  ASSERT_TRUE(db.ExecuteQuery("DROP TABLE files"));
+
+  CVideoInfoTag details;
+
+  EXPECT_EQ(db.TryGetMovieInfo("", details, MISSING_ID), GetResult::Error);
+  EXPECT_EQ(db.TryGetTvShowInfo("", details, MISSING_ID), GetResult::Error);
+  EXPECT_EQ(db.TryGetSeasonInfo(MISSING_ID, details), GetResult::Error);
+  EXPECT_EQ(db.TryGetEpisodeInfo("", details, MISSING_ID), GetResult::Error);
+  EXPECT_EQ(db.TryGetMusicVideoInfo("", details, MISSING_ID), GetResult::Error);
+  EXPECT_EQ(db.TryGetSetInfo(MISSING_ID, details), GetResult::Error);
+  EXPECT_EQ(db.TryGetFileInfo("", details, MISSING_ID), GetResult::Error);
+
+  // The bool overloads return the same false here as they do for a missing row.
+  EXPECT_FALSE(db.GetMovieInfo("", details, MISSING_ID));
+  EXPECT_FALSE(db.GetTvShowInfo("", details, MISSING_ID));
+  EXPECT_FALSE(db.GetSeasonInfo(MISSING_ID, details));
+  EXPECT_FALSE(db.GetEpisodeInfo("", details, MISSING_ID));
+  EXPECT_FALSE(db.GetMusicVideoInfo("", details, MISSING_ID));
+  EXPECT_FALSE(db.GetSetInfo(MISSING_ID, details));
+  EXPECT_FALSE(db.GetFileInfo("", details, MISSING_ID));
+
+  db.Close();
+}


### PR DESCRIPTION
**TL;DR:** Improvement, enabling work. The by-id getters of the music and video databases return `false` for both "no such row" and "the query failed"; each gains a `TryGet` variant returning `Ok`, `NotFound` or `Error`, with the existing `bool` getters as behaviour-neutral wrappers. Nothing consumes the new variants yet.

## Description
Adds a `TryGet` variant of each by-id getter returning a new `CDatabase::GetResult`:

| | |
|---|---|
| `Ok` | the record was found and has been returned |
| `NotFound` | the query succeeded and the database holds no such record |
| `Error` | the record could not be returned |

`NotFound` is reserved for a record the database does not hold. A record that exists but cannot be returned is `Error`, so a caller is never told a record is absent when it is present.

Each existing `bool` getter becomes a wrapper over its new variant, so **every existing caller is behaviour-neutral**. Nothing consumes the new variants yet; this is enabling work.

Converted: `GetSong`, `GetAlbum`, `GetArtist`, `GetArtistExists`, `GetMovieInfo`, `GetTvShowInfo`, `GetSeasonInfo`, `GetEpisodeInfo`, `GetMusicVideoInfo`, `GetSetInfo`, `GetFileInfo`.

**Worth a reviewer's attention.**

- **`GetAlbum` is the one wrapper that is not a plain comparison.** An album carrying no songs is now retrieved with an empty song list, because an empty list is a result rather than a failure. The `bool` wrapper keeps reporting it as `false` for the callers that have always seen that.
- **`TryGetFileInfo` gained a null-database guard and an empty-result check.** It had neither, so it read fields from an empty dataset and could report success for a file that does not exist when the caller passed a partly filled tag.
- **`TryGetSeasonInfo` mirrors the full `bool` overload set**, including the `CFileItem*` one. Without it, `TryGetSeasonInfo(id, details, item)` compiles and silently converts the pointer to the `allDetails` bool, discarding the item.

**The first commit.** `CVideoDatabase::CommitTransaction` dereferenced `CServiceBroker::GetGUI()` unconditionally, so it faulted in any GUI-less context — which is why neither database has ever had a unit test. `CMusicDatabase::CommitTransaction` guarded the same access but returned `false` after a successful commit when there was no GUI, and `CMusicDatabase::Cleanup` maps that to `ERROR_WRITING_CHANGES`. It leads the branch because the tests below cannot exist without it.

## Motivation and context
The by-id getters of `CMusicDatabase` and `CVideoDatabase` return `bool`, and `false` means **either** "no such row" **or** "the query failed" — a dead database, a SQL error, a caught exception. Callers cannot tell the two apart, so anything built on them reports database failures as client-side not-found.

The list getters settled this long ago: zero rows is `true` with an empty list, and `false` is a genuine failure only. That was decided for the music database in 556d548d4c ("0 items is a perfectly valid result when retrieving a list of items (it's not an error)") and reinforced for the video database in b3cec7ab66. The by-id family never received the same treatment.

## How has this been tested?
New `TestMusicDatabaseGetResult` and `TestVideoDatabaseGetResult` stand up real SQLite databases and pin the distinction for every converted getter: an unconnected database reports `Error`, a real but empty schema reports `NotFound`, and dropping the views a getter selects from reports `Error` where the `bool` overloads return the same `false` as for a missing row. A fixture with a real songless album pins the `GetAlbum` behaviour above.

Full suite green (3707 tests), clang-format clean on the touched lines.

## What is the effect on users?
None. Every existing caller keeps its behaviour.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [X] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
