### PR TITLE
[Video] Fix unable to play trailer through the information dialog of a bluray resolved to a playlist.

### DIFF
--- a/xbmc/utils/ContentUtils.cpp
+++ b/xbmc/utils/ContentUtils.cpp
@@ -10,6 +10,7 @@
 
 #include "FileItem.h"
 #include "utils/StringUtils.h"
+#include "video/Bookmark.h"
 #include "video/VideoInfoTag.h"
 
 namespace
@@ -54,6 +55,19 @@ std::unique_ptr<CFileItem> ContentUtils::GeneratePlayableTrailerItem(const CFile
   CVideoInfoTag* videoInfoTag = trailerItem->GetVideoInfoTag();
   *videoInfoTag = *item.GetVideoInfoTag();
   videoInfoTag->m_streamDetails.Reset();
+  videoInfoTag->SetFileNameAndPath(item.GetVideoInfoTag()->m_strTrailer);
+  videoInfoTag->m_strFile.clear();
+  videoInfoTag->m_strPath.clear();
+  CBookmark resumePoint;
+  resumePoint.type = CBookmark::RESUME;
+  videoInfoTag->SetResumePoint(resumePoint);
+  videoInfoTag->m_iBookmarkId = -1;
+  // Assign a new bookmark rather than Reset(), which doesn't clear the saved player state
+  CBookmark epBookmark;
+  epBookmark.type = CBookmark::EPISODE;
+  videoInfoTag->m_EpBookmark = epBookmark;
+  videoInfoTag->ResetPlayCount();
+  videoInfoTag->m_lastPlayed.Reset();
   videoInfoTag->m_strTitle = StringUtils::Format("{} ({})", videoInfoTag->m_strTitle, label);
   trailerItem->SetArt(item.GetArt());
   videoInfoTag->m_iDbId = -1;

--- a/xbmc/utils/test/CMakeLists.txt
+++ b/xbmc/utils/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES TestAlarmClock.cpp
             TestCharsetConverter.cpp
             TestCPUInfo.cpp
             TestComponentContainer.cpp
+            TestContentUtils.cpp
             TestCrc32.cpp
             TestDatabaseUtils.cpp
             TestDigest.cpp

--- a/xbmc/utils/test/TestContentUtils.cpp
+++ b/xbmc/utils/test/TestContentUtils.cpp
@@ -1,0 +1,154 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileItem.h"
+#include "XBDateTime.h"
+#include "utils/ContentUtils.h"
+#include "utils/StreamDetails.h"
+#include "video/Bookmark.h"
+#include "video/VideoInfoTag.h"
+
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr const char* MOVIE_PATH{"/movies/Movie (2007)/Movie (2007).bluray.iso"};
+constexpr const char* TRAILER_PATH{"/movies/Movie (2007)/Movie (2007)-trailer.mkv"};
+constexpr const char* PLAYLIST_PATH{
+    "bluray://udf%3a%2f%2f%252fmovies%252fMovie%2520(2007).bluray.iso%2f/BDMV/PLAYLIST/00601.mpls"};
+
+/*!
+ * \brief Build a movie item as it looks after having been played, ie. with playback state and
+ *        with the paths of a disc image resolved to the played playlist.
+ */
+CFileItem GetPlayedMovie()
+{
+  CFileItem movie;
+  movie.SetPath(MOVIE_PATH);
+  movie.SetArt("poster", "image://poster.jpg/");
+
+  CVideoInfoTag* tag{movie.GetVideoInfoTag()};
+  tag->m_type = MediaTypeMovie;
+  tag->m_strTitle = "Movie";
+  tag->m_strTrailer = TRAILER_PATH;
+  tag->m_iDbId = 42;
+  tag->m_iFileId = 43;
+  tag->m_strFile = "Movie (2007).bluray.iso";
+  tag->m_strPath = "/movies/Movie (2007)/";
+
+  // Playing a disc image resolves the tag path to the playlist that was played
+  tag->SetFileNameAndPath(PLAYLIST_PATH);
+
+  auto* video{new CStreamDetailVideo()};
+  video->m_iWidth = 1920;
+  video->m_iHeight = 1080;
+  video->m_strCodec = "h264";
+  tag->m_streamDetails.AddStream(video);
+
+  CBookmark resumePoint;
+  resumePoint.type = CBookmark::RESUME;
+  resumePoint.timeInSeconds = 1234.0;
+  resumePoint.totalTimeInSeconds = 5678.0;
+  resumePoint.playerState = "<player></player>";
+  tag->SetResumePoint(resumePoint);
+
+  tag->m_iBookmarkId = 7;
+  tag->m_EpBookmark.type = CBookmark::EPISODE;
+  tag->m_EpBookmark.timeInSeconds = 12.0;
+  tag->m_EpBookmark.totalTimeInSeconds = 34.0;
+  tag->m_EpBookmark.playerState = "<player></player>";
+
+  tag->SetPlayCount(3);
+  tag->m_lastPlayed = CDateTime(2026, 8, 10, 1, 4, 18);
+
+  return movie;
+}
+} // namespace
+
+TEST(TestContentUtils, GeneratePlayableTrailerItemUsesTrailerPath)
+{
+  const CFileItem movie{GetPlayedMovie()};
+  const std::unique_ptr<CFileItem> trailer{
+      ContentUtils::GeneratePlayableTrailerItem(movie, "Trailer")};
+
+  EXPECT_EQ(trailer->GetPath(), TRAILER_PATH);
+  EXPECT_EQ(trailer->GetDynPath(), TRAILER_PATH);
+  EXPECT_FALSE(trailer->HasDynPath());
+}
+
+TEST(TestContentUtils, GeneratePlayableTrailerItemDoesNotInheritTheMoviePath)
+{
+  const CFileItem movie{GetPlayedMovie()};
+  const std::unique_ptr<CFileItem> trailer{
+      ContentUtils::GeneratePlayableTrailerItem(movie, "Trailer")};
+  const CVideoInfoTag* tag{trailer->GetVideoInfoTag()};
+
+  // The tag must describe the trailer. If the movie's path is left behind then the resolved
+  // bluray:// playlist path is played instead of the trailer.
+  EXPECT_EQ(tag->GetPath(), TRAILER_PATH);
+  EXPECT_EQ(tag->m_strFileNameAndPath, TRAILER_PATH);
+  EXPECT_TRUE(tag->m_strFile.empty());
+  EXPECT_TRUE(tag->m_strPath.empty());
+}
+
+TEST(TestContentUtils, GeneratePlayableTrailerItemResetsPlaybackState)
+{
+  const CFileItem movie{GetPlayedMovie()};
+  const std::unique_ptr<CFileItem> trailer{
+      ContentUtils::GeneratePlayableTrailerItem(movie, "Trailer")};
+  const CVideoInfoTag* tag{trailer->GetVideoInfoTag()};
+
+  // The trailer must not resume where the movie was left, nor show as watched
+  const CBookmark resumePoint{tag->GetResumePoint()};
+  EXPECT_FALSE(resumePoint.IsSet());
+  EXPECT_EQ(resumePoint.type, CBookmark::RESUME);
+  EXPECT_FALSE(resumePoint.HasSavedPlayerState());
+
+  EXPECT_EQ(tag->m_iBookmarkId, -1);
+  EXPECT_FALSE(tag->m_EpBookmark.IsSet());
+  EXPECT_EQ(tag->m_EpBookmark.type, CBookmark::EPISODE);
+  EXPECT_FALSE(tag->m_EpBookmark.HasSavedPlayerState());
+
+  EXPECT_FALSE(tag->IsPlayCountSet());
+  EXPECT_FALSE(tag->m_lastPlayed.IsValid());
+
+  EXPECT_FALSE(tag->HasStreamDetails());
+
+  EXPECT_EQ(tag->m_iDbId, -1);
+  EXPECT_EQ(tag->m_iFileId, -1);
+}
+
+TEST(TestContentUtils, GeneratePlayableTrailerItemKeepsMovieDetails)
+{
+  const CFileItem movie{GetPlayedMovie()};
+  const std::unique_ptr<CFileItem> trailer{
+      ContentUtils::GeneratePlayableTrailerItem(movie, "Trailer")};
+  const CVideoInfoTag* tag{trailer->GetVideoInfoTag()};
+
+  EXPECT_EQ(tag->m_strTitle, "Movie (Trailer)");
+  EXPECT_EQ(tag->m_type, MediaTypeMovie);
+  EXPECT_EQ(trailer->GetArt("poster"), "image://poster.jpg/");
+}
+
+TEST(TestContentUtils, GeneratePlayableTrailerItemLeavesTheMovieItemUntouched)
+{
+  const CFileItem movie{GetPlayedMovie()};
+  const std::unique_ptr<CFileItem> trailer{
+      ContentUtils::GeneratePlayableTrailerItem(movie, "Trailer")};
+  const CVideoInfoTag* tag{movie.GetVideoInfoTag()};
+
+  EXPECT_EQ(movie.GetPath(), MOVIE_PATH);
+  EXPECT_EQ(tag->GetPath(), PLAYLIST_PATH);
+  EXPECT_EQ(tag->m_strTitle, "Movie");
+  EXPECT_EQ(tag->m_iDbId, 42);
+  EXPECT_TRUE(tag->GetResumePoint().IsSet());
+  EXPECT_EQ(tag->GetPlayCount(), 3);
+}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Ensures the copied VideoInfoTag that contains the trailer is properly constructed.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #28913.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.
Confirmed fixed by bug reporter

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have updated the documentation accordingly
- [X] All new and existing tests passed
