### PR TITLE
changed: enumerate multi-path sources without a progress dialog

### DIFF
--- a/xbmc/filesystem/MultiPathDirectory.cpp
+++ b/xbmc/filesystem/MultiPathDirectory.cpp
@@ -11,21 +11,15 @@
 #include "Directory.h"
 #include "FileItem.h"
 #include "FileItemList.h"
-#include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
-#include "dialogs/GUIDialogProgress.h"
-#include "guilib/GUIComponent.h"
-#include "guilib/GUIWindowManager.h"
-#include "threads/SystemClock.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
-#include "utils/Variant.h"
 #include "utils/log.h"
 
-using namespace XFILE;
+#include <chrono>
 
-using namespace std::chrono_literals;
+using namespace XFILE;
 
 //
 // multipath://{path1}/{path2}/{path3}/.../{path-N}
@@ -46,36 +40,9 @@ bool CMultiPathDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   if (!GetPaths(url, vecPaths))
     return false;
 
-  XbmcThreads::EndTime<> progressTime(3000ms); // 3 seconds before showing progress bar
-  CGUIDialogProgress* dlgProgress = NULL;
-
   unsigned int iFailures = 0;
   for (unsigned int i = 0; i < vecPaths.size(); ++i)
   {
-    // show the progress dialog if we have passed our time limit
-    if (progressTime.IsTimePast() && !dlgProgress)
-    {
-      dlgProgress = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogProgress>(WINDOW_DIALOG_PROGRESS);
-      if (dlgProgress)
-      {
-        dlgProgress->SetHeading(CVariant{15310});
-        dlgProgress->SetLine(0, CVariant{15311});
-        dlgProgress->SetLine(1, CVariant{""});
-        dlgProgress->SetLine(2, CVariant{""});
-        dlgProgress->Open();
-        dlgProgress->ShowProgressBar(true);
-        dlgProgress->SetProgressMax((int)vecPaths.size()*2);
-        dlgProgress->Progress();
-      }
-    }
-    if (dlgProgress)
-    {
-      CURL url(vecPaths[i]);
-      dlgProgress->SetLine(1, CVariant{url.GetWithoutUserDetails()});
-      dlgProgress->SetProgressAdvance();
-      dlgProgress->Progress();
-    }
-
     CFileItemList tempItems;
     CLog::Log(LOGDEBUG, "Getting Directory ({})", CURL::GetRedacted(vecPaths[i]));
     if (CDirectory::GetDirectory(vecPaths[i], tempItems, m_strFileMask, m_flags))
@@ -85,16 +52,7 @@ bool CMultiPathDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       CLog::Log(LOGERROR, "Error Getting Directory ({})", CURL::GetRedacted(vecPaths[i]));
       iFailures++;
     }
-
-    if (dlgProgress)
-    {
-      dlgProgress->SetProgressAdvance();
-      dlgProgress->Progress();
-    }
   }
-
-  if (dlgProgress)
-    dlgProgress->Close();
 
   if (iFailures == vecPaths.size())
     return false;


### PR DESCRIPTION
**TL;DR:** Bug fix. `CMultiPathDirectory` opened its own modal progress dialog on a 3 second timer, so library scans and JSON-RPC calls walking a `multipath://` source got a dialog nobody was waiting on. The dialog is removed; the media window's cancellable busy dialog already covers the interactive case.

## Description
`CMultiPathDirectory::GetDirectory` opens `CGUIDialogProgress` itself, gated on nothing but a 3 second timer. Any caller slow enough gets a modal dialog — library scans, `Files.GetDirectory` over JSON-RPC, anything walking a `multipath://` source. None of them have a user waiting on them.

The dialog is removed. Removed as a consequence: an unguarded `CServiceBroker::GetGUI()` dereference reachable from any background thread.

`CGUIMediaWindow::GetDirectoryItems` already wraps directory fetches in `CGUIDialogBusy::Wait(&getItems, 100, true)`. It appears after 100 ms rather than 3 s and is genuinely cancellable; the dialog removed here rendered a Cancel button it never read, so pressing it appended " : Canceled" to the heading and the enumeration ran to completion regardless.

One case does lose feedback: `OnInitWindow` sets `m_backgroundLoad = false` for the initial fetch, so returning to a window whose path is a slow multi-path source now shows nothing. That fetch is synchronous on the app thread and freezes the UI whether or not a dialog is painted over it — a defect in the window, not a reason to keep a GUI dependency in the VFS.

String 15310 ("Opening multi-path source") is now unused and left in place. 15311 stays — Estuary still uses it.

## Motivation and context
Fixes #26382.

The dialog predates the split between foreground and background progress. In October 2012 the scanners were moved off their own modal dialogs onto the extended progress bar — 41dcd4da21 (music, #1558) and 27b5b041e2 (video, #1560). Since then `CGUIDialogProgress*` survives in `CVideoInfoScanner` only as a caller-supplied parameter defaulting to `nullptr`, because only the caller knows whether a user is waiting. `CProgressJob` codifies the same split with `SetProgressIndicators()` and `IsModal()`.

`CMultiPathDirectory` was missed by that sweep. It is the last self-owned modal dialog under `xbmc/filesystem` — the only other GUI user there, `DiscDirectoryHelper`, goes through `CGUIDialogBusy::Wait` — and `Directory.cpp` still carries the standing TODO that the layer must not depend on the GUI.

## How has this been tested?
Not reproduced on a live install: the dialog only appears once an enumeration exceeds 3 s, which needs genuinely slow network paths. The change is verified by build and the full gtest suite.

## What is the effect on users?
Library scans and remote clients enumerating a slow multi-path source no longer get a modal progress dialog. Browsing one in the GUI still shows the busy dialog, which can be cancelled.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
