### PR TITLE
fixed: crash when using a skin or language add-on from the Add-on browser

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2410,6 +2410,10 @@ void CApplication::Process()
   CServiceBroker::GetAppMessenger()->ProcessMessages();
   if (m_bStop) return; //we're done, everything has been unloaded
 
+  // the main loop reaches this with no GUI message handler suspended on the stack, which
+  // is what a deferred skin reload is waiting for
+  GetComponent<CApplicationSkinHandling>()->ProcessPendingSkinReload();
+
   // do any processing that isn't needed on each run
   if( m_slowTimer.GetElapsedMilliseconds() > 500 )
   {

--- a/xbmc/application/ApplicationSkinHandling.cpp
+++ b/xbmc/application/ApplicationSkinHandling.cpp
@@ -441,6 +441,16 @@ void CApplicationSkinHandling::ReloadSkin(bool confirm)
   if (!skin || m_bInitializing)
     return; // Don't allow reload before skin is loaded by system
 
+  // Reloading destroys every control in every window, and the GUI message handlers
+  // suspended below a nested render loop still hold pointers into that tree. Wait for
+  // the stack to unwind.
+  if (gui->GetWindowManager().IsNested())
+  {
+    m_pendingSkinReload = true;
+    m_pendingSkinReloadConfirm = m_pendingSkinReloadConfirm || confirm;
+    return;
+  }
+
   std::string oldSkin = skin->ID();
 
   CGUIMessage msg(GUI_MSG_LOAD_SKIN, -1, gui->GetWindowManager().GetActiveWindow());
@@ -500,6 +510,21 @@ void CApplicationSkinHandling::ReloadSkin(bool confirm)
     }
   }
   m_confirmSkinChange = true;
+}
+
+void CApplicationSkinHandling::ProcessPendingSkinReload()
+{
+  if (!m_pendingSkinReload)
+    return;
+
+  const auto gui = CServiceBroker::GetGUI();
+  if (gui == nullptr || gui->GetWindowManager().IsNested())
+    return;
+
+  const bool confirm = m_pendingSkinReloadConfirm;
+  m_pendingSkinReload = false;
+  m_pendingSkinReloadConfirm = false;
+  ReloadSkin(confirm);
 }
 
 bool CApplicationSkinHandling::OnSettingChanged(const CSetting& setting)

--- a/xbmc/application/ApplicationSkinHandling.h
+++ b/xbmc/application/ApplicationSkinHandling.h
@@ -44,9 +44,18 @@ protected:
  */
   void ProcessSkin() const;
 
+  /*!
+   * \brief Run a skin reload that was deferred out of a nested render loop.
+   *
+   * Does nothing unless a reload is pending and the render loop has unwound.
+   */
+  void ProcessPendingSkinReload();
+
   bool m_saveSkinOnUnloading = true;
   bool m_confirmSkinChange = true;
   bool m_ignoreSkinSettingChanges = false;
+  bool m_pendingSkinReload = false;
+  bool m_pendingSkinReloadConfirm = false;
   IMsgTargetCallback* m_msgCb;
   IWindowManagerCallback* m_wCb;
   bool& m_bInitializing;

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -430,8 +430,24 @@ bool CGUIWindow::OnAction(const CAction &action)
   {
     while (focusedControl && focusedControl != this)
     {
+      // noted while the control is known to be alive, as handling the action can free it
+      const uint32_t controlsGeneration = m_controlsGeneration;
+
       if (focusedControl->OnAction(action))
         return true;
+
+      // the controls were rebuilt under us, so focusedControl is dangling and its parent
+      // cannot be read. The generation is what makes this reliable: a freed control's
+      // address can be reused by the new tree, which pointer identity cannot detect.
+      if (m_controlsGeneration != controlsGeneration)
+      {
+        CLog::Log(LOGDEBUG,
+                  "CGUIWindow::OnAction: controls of window {} were destroyed while "
+                  "handling the action, not propagating it to the parent",
+                  GetID());
+        return true;
+      }
+
       focusedControl = focusedControl->GetParentControl();
     }
   }
@@ -816,6 +832,7 @@ void CGUIWindow::DynamicResourceAlloc(bool bOnOff)
 
 void CGUIWindow::ClearAll()
 {
+  ++m_controlsGeneration;
   OnWindowUnload();
   CGUIControlGroup::ClearAll();
   m_windowLoaded = false;

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -247,6 +247,9 @@ protected:
   RESOLUTION_INFO m_coordsRes; // resolution that the window coordinates are in.
   bool m_needsScaling;
   bool m_windowLoaded;  // true if the window's xml file has been loaded
+  //! bumped whenever the controls are cleared, so a control held across a call that may
+  //! destroy the tree can be told apart from one that is still alive
+  uint32_t m_controlsGeneration{0};
   LOAD_TYPE m_loadType;
   bool m_dynamicResourceAlloc;
   bool m_closing;

--- a/xbmc/guilib/GUIWindowManager.h
+++ b/xbmc/guilib/GUIWindowManager.h
@@ -133,6 +133,14 @@ public:
    */
   bool Initialized() const { return m_initialized; }
 
+  /*! \brief Return whether a nested render loop is currently running.
+   A modal dialog pumps the application from its own Open() loop, leaving the GUI
+   message handlers below it suspended while still holding pointers into the control
+   tree. Destroying windows or controls has to wait until the stack has unwound.
+   \return true if called from within a nested render loop, false otherwise.
+   */
+  bool IsNested() const { return m_iNested > 0; }
+
   /*! \brief Create and initialize all windows and dialogs
    */
   void CreateWindows();

--- a/xbmc/guilib/test/CMakeLists.txt
+++ b/xbmc/guilib/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES TestGUIControlFactory.cpp
             TestGamesGUIInfo.cpp
             TestGUILabel.cpp
             TestGUITextLayout.cpp
+            TestGUIWindowOnAction.cpp
             TestSkinMapManager.cpp
 )
 

--- a/xbmc/guilib/test/TestGUIWindowOnAction.cpp
+++ b/xbmc/guilib/test/TestGUIWindowOnAction.cpp
@@ -1,0 +1,134 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "guilib/GUIControl.h"
+#include "guilib/GUIControlGroup.h"
+#include "guilib/GUIWindow.h"
+#include "input/actions/Action.h"
+#include "input/actions/ActionIDs.h"
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+constexpr int WINDOW_ID = 5000;
+constexpr int GROUP_ID = 5001;
+constexpr int CHILD_ID = 5002;
+
+/*! \brief A focusable control that runs a callback when it is handed an action.
+ *
+ * Never handles the action, so CGUIWindow::OnAction goes on to walk up the chain.
+ */
+class CCallbackControl : public CGUIControl
+{
+public:
+  CCallbackControl(int parentId, int id, std::function<void()> onAction)
+    : CGUIControl(parentId, id, 0.0f, 0.0f, 10.0f, 10.0f),
+      m_onAction(std::move(onAction))
+  {
+  }
+
+  CCallbackControl* Clone() const override { return new CCallbackControl(*this); }
+
+  bool CanFocus() const override { return true; }
+
+  bool OnAction(const CAction& action) override
+  {
+    if (m_onAction)
+      m_onAction();
+    return false;
+  }
+
+private:
+  std::function<void()> m_onAction;
+};
+
+/*! \brief A group that records having been offered an action.
+ *
+ * The flag is held through a shared_ptr so the test can still read it after the group
+ * has been destroyed.
+ */
+class CRecordingGroup : public CGUIControlGroup
+{
+public:
+  CRecordingGroup(int parentId, int id, std::shared_ptr<bool> offered)
+    : CGUIControlGroup(parentId, id, 0.0f, 0.0f, 10.0f, 10.0f),
+      m_offered(std::move(offered))
+  {
+  }
+
+  CRecordingGroup* Clone() const override { return new CRecordingGroup(*this); }
+
+  bool OnAction(const CAction& action) override
+  {
+    *m_offered = true;
+    return false;
+  }
+
+private:
+  std::shared_ptr<bool> m_offered;
+};
+
+/*! \brief A window holding a group holding a focused control.
+ *
+ * The nesting matters: a control parented directly by the window ends the walk
+ * immediately, so there has to be a group in between for there to be a parent to
+ * walk up to.
+ */
+class CTestWindow : public CGUIWindow
+{
+public:
+  CTestWindow(std::shared_ptr<bool> parentOffered, std::function<void()> onChildAction)
+    : CGUIWindow(WINDOW_ID, "")
+  {
+    auto* group = new CRecordingGroup(WINDOW_ID, GROUP_ID, std::move(parentOffered));
+    auto* child = new CCallbackControl(GROUP_ID, CHILD_ID, std::move(onChildAction));
+    child->SetFocus(true);
+    group->AddControl(child);
+    AddControl(group);
+  }
+};
+
+} // namespace
+
+TEST(TestGUIWindowOnAction, PropagatesToTheParentWhenTheControlsSurvive)
+{
+  auto parentOffered = std::make_shared<bool>(false);
+  CTestWindow window(parentOffered, nullptr);
+
+  const CAction action(ACTION_MOVE_LEFT);
+  EXPECT_FALSE(window.OnAction(action));
+
+  // nothing destroyed the controls, so the unhandled action reaches the parent group
+  EXPECT_TRUE(*parentOffered);
+}
+
+TEST(TestGUIWindowOnAction, StopsPropagatingWhenTheControlsAreDestroyed)
+{
+  auto parentOffered = std::make_shared<bool>(false);
+
+  // A skin reload destroys every control in the window while the action is being
+  // handled. ClearAll() reproduces that: the focused control and its parent are freed
+  // before CGUIWindow::OnAction regains control.
+  CTestWindow* window = nullptr;
+  auto tearDown = [&window]() { window->ClearAll(); };
+
+  CTestWindow instance(parentOffered, tearDown);
+  window = &instance;
+
+  const CAction action(ACTION_MOVE_LEFT);
+  EXPECT_TRUE(instance.OnAction(action));
+
+  // the parent was freed by the teardown, so it must not have been offered the action
+  EXPECT_FALSE(*parentOffered);
+}


### PR DESCRIPTION
## Description

Fixes the use-after-free behind #27239, #27552 and #28899: selecting **Use** on a skin or
language add-on from the Add-on browser crashes Kodi, while making the same change from
Settings does not.

**Please read the verification section before merging — I have measured the mechanism, but I
have not been able to make the crash happen (or stop happening) on my own machine, so this
wants testing by the people who can reproduce it.**

### The defect

`CGUIWindow::OnAction` keeps the focused control in a raw pointer across
`focusedControl->OnAction(action)` and then reads `GetParentControl()` on it to walk up the
chain. Handling the action can destroy and rebuild the entire control tree, which leaves that
pointer dangling — the read ASAN reports in `CGUIControl::GetParentControl`.

The teardown gets there like this:

```
CGUIWindow::OnAction                   focusedControl->OnAction(action)
 CGUIBaseContainer::OnAction/OnClick   -> SendWindowMessage
  CGUIMediaWindow::OnMessage           OnSelect(iItem)
   CGUIWindowAddonBrowser::OnClick     -> CGUIDialogAddonInfo::ShowForItem -> Open()
    CGUIDialog::Open_Internal          while (m_active) ProcessRenderLoop(false)
     CApplication::Process             -> ProcessMessages -> ReloadSkin
      LoadSkin -> UnloadSkin -> CGUIWindowManager::DeInitialize()
       pWindow->FreeResources(true)    -> ClearAll -> every control deleted
```

`CGUIDialogAddonInfo::OnSelect` closes the dialog **without forcing it**, so the close
animation keeps `m_active` true for several more frames. The dialog's own render loop
therefore keeps pumping `CApplication::Process()` and drains the posted `ReloadSkin` while
`CGUIWindowAddonBrowser`'s message handler and `CGUIWindow::OnAction` are still suspended on
the stack beneath it. From Settings the click handler returns before the messenger is next
pumped, so the reload runs at the top of the main loop with nothing suspended — which is
exactly why only the Add-on browser path crashes.

This is **not a race between threads**, which was the working assumption on #27552. Both ASAN
traces put the free and the use on `thread T0` in a single call stack from one key event.

### The change

1. **`fixed: defer a skin reload out of a nested render loop`** — the actual fix.
   `ReloadSkin` records the request instead of acting when `CGUIWindowManager` reports a
   nested render loop, and `CApplication::Process()` runs it from the main loop, which is
   reached outside `ProcessRenderLoop`. This is @CrystalP's suggestion on #27552 ("make only
   the reload and the action processing handling exclusive") rather than narrowing the window.
   `m_iNested` already existed and was already used for exactly this purpose in one place —
   deferring queued window deletion until the render loop unwinds.

   Re-posting the message instead does not work: `CApplicationMessenger` drains its queue in a
   `while` loop, so a message posted from inside a handler is picked up in the same pass and
   never escapes the nested loop.

2. **`fixed: stop propagating an action once the window's controls are gone`** — defence in
   depth at the crash site, so any *other* path that destroys controls mid-action cannot
   resurrect this. A generation counter is bumped in `CGUIWindow::ClearAll()` and compared
   after the dispatch. A generation is used rather than re-looking-up the control because a
   freed control's address can be handed straight back to a control of the rebuilt tree, and
   pointer identity cannot tell those apart.

3. **`added: pin that an action stops at a window whose controls were destroyed`** — two tests
   in `xbmc/guilib/test/TestGUIWindowOnAction.cpp`. One pins that an unhandled action still
   reaches the parent group, which is what breaks if the crash is "fixed" by removing the parent
   walk. The other has the focused control destroy the window's controls while handling the
   action and pins that nothing is propagated afterwards.

   With the generation check removed the second one fails on the **return value**, not on
   reading the freed control, so it does not depend on what the freed memory happens to hold:

   ```
   [ RUN      ] TestGUIWindowOnAction.StopsPropagatingWhenTheControlsAreDestroyed
   error: Value of: instance.OnAction(action)
     Actual: false
   Expected: true
   [  FAILED  ]
   ```

Also fixes the class of crash in #21382 (`ReloadSkin` builtin executed with a modal dialog
open), which the stale bot closed in May rather than anyone fixing.

## How has this been tested?

Runtime tested on Windows against the Add-on browser repro from all three issues, and the full gtest suite passes (3750 tests).

**What I could not do: observe the crash.** Kodi never faulted for me. On the Windows release
heap the freed block stays mapped and is readily reused, so the dangling read silently
succeeds — which also matches this being reported as intermittent. Without PageHeap available
I would have been testing my luck with the allocator, not the fix.

So I measured the defect directly instead, with a temporary probe that recorded every address
passing through `~CGUIControl` during the dispatch and tested the pointer `CGUIWindow::OnAction`
still holds against it:

```
PROBE2: window 10040 - the control this frame still holds (0x1c6d4ca2b70) went through
        ~CGUIControl during the action (2549 controls destroyed in total)
```

Window 10040 is `WINDOW_ADDON_BROWSER` — the `CGUIMediaWindow::OnAction` frame in @neo1973's
trace. That is the use-after-free, observed rather than inferred. With the deferral applied the
same probe reports nothing and the language/skin still changes correctly.

| | control destructed mid-action | guard trips | change applied |
|---|---|---|---|
| without the deferral | yes (2549 controls) | yes | yes |
| with the deferral | no | no | yes |

Also checked, all with debug logging on so the guard is visible:

- Add-on browser -> language -> **Use** (#27239, #28899) — clean
- Add-on browser -> skin -> **Use** (#27552) — Confluence loads, clean
- The `ReloadSkin(confirm)` "keep this skin?" prompt still appears after being deferred, and
  answering **No** re-enters `SetString(oldSkin)` -> `ReloadSkin` and reverts correctly
- Changing language and skin from Settings — reloads normally, guard never trips
- Settings -> Interface navigation up/down/left/right/back — unaffected. Earlier attempts at
  this on #27552 broke navigation here by removing the parent walk; this keeps the walk and
  only stops it when the tree has actually been destroyed.

## Testing results so far

@DeltaMikeCharlie has tested this on Ubuntu 24 across seven fresh configurations:

- **Selecting "Use" on an installed skin or language — fixed.** Dozens of attempts across both,
  no crash. This is the path all three issues reproduce on.
- **Installing a language and answering "switch to this now" still crashes intermittently, with
  an unrelated backtrace** — `CBackgroundInfoLoader::Run` -> `CProgramThumbLoader::FillThumb` ->
  `CTextureCache::BackgroundCacheImage` -> `CJobQueue::AddJob`, on a background thread. No
  `CGUIWindow`, no control tree and no `OnAction`, so it is neither what this PR fixes nor
  something it appears to have caused. On that path the language switch is driven from the
  installer's job thread while the add-on list is refreshing its thumbnails. It wants its own
  issue rather than widening this one.

So the scope of this PR is the `CGUIWindow::OnAction` use-after-free, which is what the ASAN
traces on #27239 and #27552 show. It is not a claim that every crash reachable from the Add-on
browser is gone.

## What I would like tested

@CutterXYZ, @Sebastiii, @DeltaMikeCharlie — you can all reproduce the crash and I cannot.
Could you try this branch on your setups and confirm the crash is gone?

@neo1973 — could you re-run your ASAN build against it? Yours is the only setup here that can
show the undefined behaviour is actually *gone* rather than merely not faulting, and that is
the check I most want before this is trusted.

If it still reproduces for any of you, please say so and I will take it back — I would rather
this be reverted than land on the strength of instrumentation alone.

## What is the effect on users?

Selecting "Use" on a skin or language add-on from the Add-on browser no longer crashes. The
skin reload happens a few frames later than before, once the dialog has finished closing.

## Types of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
