### PR TITLE
DRMPRIME: publish video dimensions from output frames for OSD

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecDRMPRIME.cpp
@@ -391,7 +391,6 @@ void CDVDVideoCodecDRMPRIME::UpdateProcessInfo(struct AVCodecContext* avctx,
 {
   const char* pixFmtName = av_get_pix_fmt_name(pix_fmt);
   m_processInfo.SetVideoPixelFormat(pixFmtName ? pixFmtName : "");
-  m_processInfo.SetVideoDimensions(avctx->coded_width, avctx->coded_height);
 
   if (avctx->codec && avctx->codec->name)
     m_name = std::string("ff-") + avctx->codec->name;
@@ -628,6 +627,12 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecDRMPRIME::GetPicture(VideoPicture* pVideo
               err, ret);
     return VC_ERROR;
   }
+
+  // ffmpeg's v4l2m2m resizes without re-invoking our GetFormat callback; republish from the frames
+  int piWidth, piHeight;
+  m_processInfo.GetVideoDimensions(piWidth, piHeight);
+  if (m_pFrame->width != piWidth || m_pFrame->height != piHeight)
+    m_processInfo.SetVideoDimensions(m_pFrame->width, m_pFrame->height);
 
   SetPictureParams(pVideoPicture);
 


### PR DESCRIPTION
## Description

GetFormat published coded dimensions: v4l2m2m never re-invokes it on a mid-stream resolution change, leaving the OSD stale, and the sw decoders re-invoke it several frames before the old-size frames finish draining, so the OSD bounced between old and new size. Frames carry display dimensions in output order.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

## Motivation and context
DRMPRIME needs to show resolution changes in PlayerProcessInfo

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
RPi4 using the well known "netflix test"

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
Resolution is now shown accurately across resolution changes

<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
