### PR TITLE
fix: write both meson pkg-config entry names in cross files

### DIFF
--- a/cmake/modules/buildtools/FindMeson.cmake
+++ b/cmake/modules/buildtools/FindMeson.cmake
@@ -16,7 +16,7 @@ if(NOT TARGET Meson::Meson)
                                       ${NATIVEPREFIX}/bin/Meson)
 
   if(MESON_EXECUTABLE)
-    execute_process(COMMAND ${MESON_EXECUTABLE} -version
+    execute_process(COMMAND ${MESON_EXECUTABLE} --version
                     OUTPUT_VARIABLE MESON_VERSION
                     ERROR_QUIET
                     OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/cmake/scripts/common/ModuleHelpers.cmake
+++ b/cmake/scripts/common/ModuleHelpers.cmake
@@ -798,7 +798,10 @@ function(create_mesonbinaries)
   endif()
 
   if(PKG_CONFIG_EXECUTABLE)
-    list(APPEND binariespairs "pkg-config" "PKG_CONFIG_EXECUTABLE")
+    # Both names, because meson renamed this entry from "pkgconfig" to "pkg-config"
+    # in 1.2.0. Duplicates are accepted as long as the values match.
+    list(APPEND binariespairs "pkg-config" "PKG_CONFIG_EXECUTABLE"
+                              "pkgconfig" "PKG_CONFIG_EXECUTABLE")
   endif()
 
   # Get/set loop limit (Size - 1) from size of binariespairs list


### PR DESCRIPTION
## Description

`create_mesonbinaries()` writes the pkg-config binary into the generated meson cross file under the entry name `pkg-config`. Meson only accepts that name from **1.2.0** onwards — before that the entry is `pkgconfig`.

Meson *ignores* an entry name it does not recognise rather than rejecting it, so on older meson the generated cross file silently ends up with no pkg-config binary at all, and any internal dependency that needs one fails to configure:

```
Found Pkg-config: NO
meson.build:91:0: ERROR: Pkg-config binary for machine 1 not found. Giving up.
```

This surfaces now that libdvdread builds with meson, on distributions shipping an older meson — Ubuntu 22.04 has meson 0.61.2.

This patch emits both entry names. Meson maps `pkgconfig` onto `pkg-config` and rejects the pair only when the two values differ, so the duplicate stays silent instead of raising a deprecation warning.

## Motivation and context

Fixes libdvdread/libdvdcss/libdvdnav configure failures on distributions with meson older than 1.2.0.

## How has this been tested?

The generated cross file was checked against meson 0.61.2, 1.0.0, 1.1.0, 1.2.0, 1.3.2 and 1.9.0:

| meson | `pkg-config` only (current) | `pkgconfig` only | both (this patch) |
| --- | --- | --- | --- |
| 0.61.2 (Ubuntu 22.04) | not found | found | found |
| 1.0.0 / 1.1.0 | not found | found | found |
| 1.2.0 / 1.3.2 (Ubuntu 24.04) / 1.9.0 | found | found, deprecation warning | found |

No deprecation warning is emitted on any version with both entries present.

## What is the effect on users?

Internal meson-built dependencies configure correctly on distributions shipping meson older than 1.2.0.

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)

---

Related: #28463 touches the same file but a different function — it adjusts the `pkg_config_libdir`/`pkg_config_path` *properties* in `create_mesonproperties()`, while this changes the binary *entry name* in `create_mesonbinaries()`. The two are independent and do not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
