### PR TITLE
[Video Versions] Fix art refresh after using the versions manager dialog, Improve default selected asset

### DIFF
--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -242,6 +242,18 @@ void CGUIDialogVideoManager::SetVideoAsset(const std::shared_ptr<CFileItem>& ite
   m_videoAsset = item;
 
   Refresh();
+
+  m_selectedVideoAsset.reset();
+  if (m_videoAsset->HasVideoInfoTag())
+  {
+    const int fileId{m_videoAsset->GetVideoInfoTag()->m_iFileId};
+    const auto it{std::find_if(
+        m_videoAssetsList->cbegin(), m_videoAssetsList->cend(), [fileId](const auto& entry)
+        { return entry->HasVideoInfoTag() && entry->GetVideoInfoTag()->m_iFileId == fileId; })};
+
+    if (it != m_videoAssetsList->cend())
+      m_selectedVideoAsset = (*it);
+  }
 }
 
 void CGUIDialogVideoManager::CloseAll()

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -329,6 +329,18 @@ void CGUIDialogVideoManager::ChooseArt()
   if (!CGUIDialogVideoInfo::ChooseAndManageVideoItemArtwork(m_selectedVideoAsset))
     return;
 
+  m_hasUpdatedItems = true;
+
+  // Sync the item art if the art was modified on the video asset the dialog was opened for
+  if (m_videoAsset->HasVideoInfoTag() && m_selectedVideoAsset->HasVideoInfoTag())
+  {
+    const auto tag = m_videoAsset->GetVideoInfoTag();
+    const auto selTag = m_selectedVideoAsset->GetVideoInfoTag();
+
+    if (tag->m_iFileId > 0 && tag->m_iFileId == selTag->m_iFileId)
+      m_videoAsset->SetArt(m_selectedVideoAsset->GetArt());
+  }
+
   // refresh data and controls
   Refresh();
   UpdateControls();

--- a/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerExtras.cpp
@@ -100,7 +100,7 @@ void CGUIDialogVideoManagerExtras::SetVideoAsset(const std::shared_ptr<CFileItem
 {
   CGUIDialogVideoManager::SetVideoAsset(item);
 
-  if (!m_videoAssetsList->IsEmpty())
+  if (m_selectedVideoAsset == nullptr && !m_videoAssetsList->IsEmpty())
     SetSelectedVideoAsset(m_videoAssetsList->Get(0));
 }
 

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -155,7 +155,8 @@ void CGUIDialogVideoManagerVersions::SetVideoAsset(const std::shared_ptr<CFileIt
 {
   CGUIDialogVideoManager::SetVideoAsset(item);
 
-  SetSelectedVideoAsset(m_defaultVideoVersion);
+  if (m_selectedVideoAsset == nullptr)
+    SetSelectedVideoAsset(m_defaultVideoVersion);
 }
 
 void CGUIDialogVideoManagerVersions::Remove()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Two small fixes/improvements of the versions/extras manager dialog:

1. Fixed poster / fanart of the video info dialog and the movie/versions list after making changes with the versions/extras manager dialog.
The art changes were not propagated back to the item used to open the dialog.

2. The item the dialog was opened from is selected on entry instead of always selecting the default version or the first extra.

Works well combined with 28931 (re-enable Choose art for movie versions) and 28673 (versions flattening)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix annoyances with the versions/extras manager dialog.

The art showed by the info dialog was not updated after changing art with the versions manager.
The art showed by the items list that opened the info dialog was not updated after changing art with the versions manager.
The versions/extras manager always opens with the default version or the first extra selected instead of the item the dialog was opened for.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

From movies list, from versions in a movie versions virtual folder, from extras in a movie extras virtual folder, from the top-level video versions node.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Experience with the versions/extras manager dialog closer to typical expectations.

## Screenshots (if appropriate):

Open manage > manage versions on an item that's not first or the default version:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/61178402-4f62-4171-b868-8fdecb72a85b" />

and that version is the default selection of the versions manager screen (PR change 2):
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/49c697b5-74be-4182-8452-2128f58ccfcf" />

Open the info dialog for a movie version:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/d9060dce-93ca-4c13-89c4-a34aadcdd90e" />

<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/d63e75b5-edc5-41a0-8e29-69d9918b8600" />

and modify the versions poster through the versions manager:
(notice that the version is now the default selection of the versions manager screen - PR change 2)
<img width="1610" height="731" alt="image" src="https://github.com/user-attachments/assets/3b9d73f9-f5ed-4e55-91d3-36142c68d6ba" />
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/3eb47d1a-a9bc-4b03-be3c-2106a793bc15" />
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/f44d53ed-f856-472d-924d-e075503aaa86" />

Returning to the info dialog shows the updated poster (was not updated before PR):
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/b2838601-579c-477d-8fe9-6c4b8bdb23ad" />

Returning to the versions list also shows the updated poster for that version (was not updated before PR):
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/40a09d54-0023-4060-8e1d-aadc80f7b74d" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
