### PR TITLE
fixed: remove the test suite's temporary profile once its databases are closed

### DIFF
--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -107,9 +107,10 @@ void TestBasicEnvironment::SetUp()
 
 void TestBasicEnvironment::TearDown()
 {
-  XFILE::CDirectory::RemoveRecursive(m_tempPath);
-
   g_application.m_ServiceManager->DeinitTesting();
+
+  // Removal after release of all open files
+  XFILE::CDirectory::RemoveRecursive(m_tempPath);
 
   CServiceBroker::UnregisterAppMessenger();
 


### PR DESCRIPTION
## What

`TestBasicEnvironment::TearDown` removed the temporary profile *before* deinitializing the service manager, which holds the addon database open. Deinitialize first, then remove.

## Why

Every run of the test suite left its entire temporary profile behind. On my machine 753 of them had accumulated over five days, holding **1.8 TB**.

`CWin32Directory::RemoveRecursive` abandons everything on the first file it cannot delete — it sets `success = false` and `break`s, and the failure propagates up through each parent. With `Database/Addons33.db` still open, the removal stopped dead. `Database` sorts first in directory order, so nothing was deleted at all, not even entries the walk had yet to reach.

The size is what made it visible rather than merely untidy. `TestZipFile.BigRead64` reads a 5 GB member of a zip64 archive, and `CZipFile::Open` copies any deflated member over 4 MB into `special://temp` before reading it. So a full suite run wrote 5 GB that was then never reclaimed. A filtered run leaked only an empty profile, which is why this went unnoticed for so long.

## Why the new order is safe

Nothing the removal needs is gone by the time it runs:

- the settings component it reaches through `URIUtils::SubstitutePath` outlives this, being unregistered later in `CAppEnvironment::TearDown`
- `CDirectoryFactory`'s VFS add-on lookup is reached only for a path carrying a protocol, and is in any case guarded by `CServiceBroker::IsAddonInterfaceUp()`

## Testing

Full suite on Windows, 3753 tests from 287 suites, all passing — and the temporary directory is gone afterwards, where before the fix every run left one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)