### PR TITLE
fixed: delete the temporary file TestMediaSourceSettings writes

### DIFF
--- a/xbmc/settings/test/TestMediaSourceSettings.cpp
+++ b/xbmc/settings/test/TestMediaSourceSettings.cpp
@@ -43,7 +43,6 @@ TEST(TestMediaSourceSettings, SaveString)
   XFILE::CFile* file;
   file = XBMC_CREATETEMPFILE(".xml");
   std::string xmlfile = XBMC_TEMPFILEPATH(file);
-  std::cout << "Reference file generated at '" << XBMC_TEMPFILEPATH(file) << "'" << std::endl;
   file->Close();
 
   EXPECT_TRUE(ms.Save(xmlfile));
@@ -65,6 +64,8 @@ TEST(TestMediaSourceSettings, SaveString)
   EXPECT_EQ(picturessources->size(), refpictures);
   auto gamessources = ms.GetSources("games");
   EXPECT_EQ(gamessources->size(), refgames);
+
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(file));
 }
 
 TEST(TestMediaSourceSettings, GetSource)


### PR DESCRIPTION
**TL;DR:** Bug fix, test-only. `TestMediaSourceSettings.SaveString` leaked the temporary file it saved to, leaving a `sources.xml` in the system temp directory on every run. It now deletes it like every other test that creates one.

## Description
`TestMediaSourceSettings.SaveString` creates a temporary file, saves the sources to it and reads them back, but never deletes it.

`XBMC_CREATETEMPFILE` hands back a `CTempFile` whose destructor removes the file. The test kept it in a raw pointer and never called `XBMC_DELETETEMPFILE`, so the object leaked, the destructor never ran, and every run of the suite left another saved `sources.xml` in the system temp directory.

The `std::cout` line goes with it: it described a file that is now deleted, and nothing referenced the path it printed.

## Motivation and context
It is the only unbalanced use of the helper — every other test that creates a temporary file deletes it:

| file | create | delete |
|---|---|---|
| `filesystem/test/TestFile.cpp` | 9 | 9 |
| `settings/test/TestMediaSourceSettings.cpp` | 1 | **0** |
| `test/TestBasicEnvironment.cpp` | 1 | 1 |
| `utils/test/TestAliasShortcutUtils.cpp` | 4 | 4 |
| `utils/test/TestFileOperationJob.cpp` | 7 | 7 |
| `utils/test/TestLabelFormatter.cpp` | 2 | 2 |
| `video/test/TestVideoFileItemClassify.cpp` | 1 | 1 |

Note these files land in the *system* temp directory rather than `special://temp`, because `CXBMCTestUtils::CreateTempFile` goes through `KODI::PLATFORM::FILESYSTEM::temp_file_path`. So they sit outside the test profile, where no profile cleanup can reach them. Related but separate: #28933 fixes the profile itself never being removed.

## How has this been tested?
Full suite on Windows, 3753 tests from 287 suites, all passing. Confirmed by comparing the system temp directory before and after a run: the stray file is gone.

## What is the effect on users?
None. Test-only change.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
