### PR TITLE
[Video][Bluray] Trailer and fan art not found during scrape for blurays.

### DIFF
--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -317,15 +317,20 @@ std::string GetLocalFanart(const CFileItem& item)
     file = url.GetHostName();
   }
 
+  if (URIUtils::IsBlurayPath(file))
+    file = URIUtils::GetDiscFile(file);
+
   // no local fanart available for these
-  if (NETWORK::IsInternetStream(item) || URIUtils::IsUPnP(file) || URIUtils::IsBlurayPath(file) ||
-      item.IsLiveTV() || item.IsPlugin() || item.IsAddonsPath() || item.IsDVD() ||
+  if (NETWORK::IsInternetStream(item) || URIUtils::IsUPnP(file) || item.IsLiveTV() ||
+      item.IsPlugin() || item.IsAddonsPath() || item.IsDVD() ||
       (URIUtils::IsFTP(file) &&
        !CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bFTPThumbs) ||
       item.GetPath().empty())
     return "";
 
-  const std::string dir{URIUtils::GetDirectory(file)};
+  // For optical media the art is in the disc root, not in the BDMV/VIDEO_TS folder
+  const std::string dir{URIUtils::IsOpticalMediaFile(file) ? URIUtils::GetDiscBasePath(file)
+                                                           : URIUtils::GetDirectory(file)};
   if (dir.empty())
     return "";
 
@@ -333,15 +338,6 @@ std::string GetLocalFanart(const CFileItem& item)
   CDirectory::GetDirectory(dir, items,
                            CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(),
                            DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
-  if (item.IsOpticalMediaFile())
-  {
-    // Get files from the optical media parent folder as well
-    CFileItemList moreItems;
-    CDirectory::GetDirectory(item.GetLocalMetadataPath(), moreItems,
-                             CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(),
-                             DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
-    items.Append(moreItems);
-  }
   if (!alternateFile.empty())
   {
     // Get files from the alternate path as well

--- a/xbmc/utils/test/TestArtUtils.cpp
+++ b/xbmc/utils/test/TestArtUtils.cpp
@@ -22,6 +22,7 @@
 
 #include <array>
 #include <fstream>
+#include <optional>
 #include <random>
 
 #include <fmt/format.h>
@@ -301,7 +302,8 @@ INSTANTIATE_TEST_SUITE_P(TestArtUtils,
 struct FanartTest
 {
   std::string path;
-  std::string result;
+  std::string result; //!< art file created in the temporary folder (empty for no folder at all)
+  std::optional<std::string> expected{}; //!< expected return value, if not the created art file
 };
 
 class GetLocalFanartTest : public testing::WithParamInterface<FanartTest>, public testing::Test
@@ -322,6 +324,14 @@ const FanartTest local_fanart_tests[] = {
     {"https://some.where/foo.avi", ""},
     {"upnp://some.where/123", ""},
     {"bluray://1", ""},
+    // Blu-ray folder - bluray:// path is converted to <path>/BDMV/index.bdmv and the art is
+    // looked for in the disc root
+    {"bluray://#URLENCODED_DIRECTORY#/BDMV/PLAYLIST/00800.mpls", "fanart.jpg"},
+    // ..but not inside the BDMV folder
+    {"bluray://#URLENCODED_DIRECTORY#/BDMV/PLAYLIST/00800.mpls", "BDMV/fanart.jpg", ""},
+    // Blu-ray ISO - bluray:// path is converted to <path>/movie.iso, so the art is
+    // looked for in the folder containing the ISO
+    {"bluray://udf%3a%2f%2f#DOUBLE_URLENCODED_ISO#%2f/BDMV/PLAYLIST/00800.mpls", "fanart.jpg"},
     {"/home/user/1.pvr", ""},
     {"plugin://random.video/1", ""},
     {"addons://plugins/video/1", ""},
@@ -359,6 +369,13 @@ TEST_P(GetLocalFanartTest, GetLocalFanart)
       file_path = GetParam().path;
       StringUtils::Replace(file_path, "#URLENCODED_DIRECTORY#", CURL::Encode(path));
     }
+    else if (GetParam().path.find("#DOUBLE_URLENCODED_ISO#") != std::string::npos)
+    {
+      // The ISO path is nested twice (bluray://udf://<iso>/), so needs encoding twice
+      const std::string iso{URIUtils::AddFileToFolder(path, "movie.iso")};
+      file_path = GetParam().path;
+      StringUtils::Replace(file_path, "#DOUBLE_URLENCODED_ISO#", CURL::Encode(CURL::Encode(iso)));
+    }
     else if (GetParam().path.starts_with("videodb://"))
     {
       file_path = GetParam().path;
@@ -366,6 +383,14 @@ TEST_P(GetLocalFanartTest, GetLocalFanart)
     else
       file_path =
           URIUtils::AddFileToFolder(URIUtils::AddFileToFolder(tmpdir, uniq), GetParam().path);
+
+    if (URIUtils::IsBlurayPath(file_path))
+    {
+      // Create the underlying disc file (<path>/BDMV/index.bdmv or <path>/movie.iso)
+      const std::string discFile{URIUtils::GetDiscFile(file_path)};
+      XFILE::CDirectory::Create(URIUtils::GetDirectory(discFile));
+      std::ofstream(discFile, std::ios::out);
+    }
   }
 
   CFileItem item(file_path, false);
@@ -375,7 +400,8 @@ TEST_P(GetLocalFanartTest, GetLocalFanart)
   }
   const std::string res = ART::GetLocalFanart(item);
 
-  EXPECT_EQ(URIUtils::GetFileName(res), URIUtils::GetFileName(GetParam().result));
+  const std::string expected{GetParam().expected.value_or(GetParam().result)};
+  EXPECT_EQ(URIUtils::GetFileName(res), URIUtils::GetFileName(expected));
 
   if (!GetParam().result.empty())
     XFILE::CDirectory::RemoveRecursive(path);

--- a/xbmc/video/VideoUtils.cpp
+++ b/xbmc/video/VideoUtils.cpp
@@ -66,9 +66,12 @@ std::string FindTrailer(const CFileItem& item, KODI::REGEXP::RegExpCache* cache 
     strFile = URIUtils::AddFileToFolder(strParent, URIUtils::GetFileName(item.GetPath()));
   }
 
+  if (URIUtils::IsBlurayPath(strFile))
+    strFile = URIUtils::GetDiscFile(strFile);
+
   // no local trailer available for these
-  if (NETWORK::IsInternetStream(item) || URIUtils::IsUPnP(strFile) ||
-      URIUtils::IsBlurayPath(strFile) || item.IsLiveTV() || item.IsPlugin() || item.IsDVD())
+  if (NETWORK::IsInternetStream(item) || URIUtils::IsUPnP(strFile) || item.IsLiveTV() ||
+      item.IsPlugin() || item.IsDVD())
     return "";
 
   std::string strDir = URIUtils::GetDirectory(strFile);

--- a/xbmc/video/test/TestVideoUtils.cpp
+++ b/xbmc/video/test/TestVideoUtils.cpp
@@ -83,6 +83,7 @@ TEST_P(TrailerTest, FindTrailer)
     EXPECT_FALSE(ec);
     XFILE::CDirectory::Create(temp_path);
     const std::string file_path = URIUtils::AddFileToFolder(temp_path, GetParam().second);
+    XFILE::CDirectory::Create(URIUtils::GetDirectory(file_path));
     {
       std::ofstream of(file_path);
     }
@@ -119,6 +120,8 @@ const auto trailer_tests = std::array{
     TrailerDef{"zip://#URLENCODED_DIRECTORY#bar.zip/bar.mkv", "movie-trailer.ogm"},
     TrailerDef{"#DIRECTORY#bar.mkv", "bar-trailer.mkv"},
     TrailerDef{"#DIRECTORY#bar.mkv", "movie-trailer.avi"},
+    TrailerDef{"bluray://#URLENCODED_DIRECTORY#/BDMV/PLAYLIST/00800.mpls",
+               "BDMV/index-trailer.mov"},
 };
 
 INSTANTIATE_TEST_SUITE_P(TestVideoUtils, TrailerTest, testing::ValuesIn(trailer_tests));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Find trailers/art as per the wiki.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Investigating something else and came across this. bluray:// paths were being excluded needlessly.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
