### PR TITLE
LinuxRendererGLES: fix black screen after display resolution change while paused

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -414,17 +414,26 @@ bool CLinuxRendererGLES::Flush(bool saveBuffers)
 {
   glFinish();
 
-  for (int i = 0; i < m_NumYUVBuffers; i++)
+  // When asked to save buffers, leave the currently held textures/picture
+  // references alone so the renderer can keep presenting the last frame.
+  if (!saveBuffers)
   {
-    DeleteTexture(i);
+    for (int i = 0; i < m_NumYUVBuffers; i++)
+    {
+      DeleteTexture(i);
+    }
+
+    m_iYUVRenderBuffer = 0;
+
+    // Only invalidate the render target when we actually tore the buffers
+    // down above.
+    m_bValidated = false;
   }
 
   glFinish();
-  m_bValidated = false;
   m_fbo.fbo.Cleanup();
-  m_iYUVRenderBuffer = 0;
 
-  return false;
+  return saveBuffers;
 }
 
 void CLinuxRendererGLES::Update()


### PR DESCRIPTION
## Description
Changing the display resolution while video playback is paused leaves the video area permanently black until the video is unpaused. 

## Fix
CLinuxRendererGLES::Flush() now skips texture teardown and skips invalidating the render target when asked to save, and returns saveBuffers so CRenderManager keeps its present/queue state intact.

This is safe because a GBM resolution change only recreates the native EGL surface — the EGL context, and with it existing GL textures, VAAPI EGLImages, and shader state, survive untouched (CRenderSystemGLES::ResetRenderSystem() only reconfigures GL state/viewport, never the context) — so there's nothing that actually needs rebuilding when we're just carrying the current frame across a display reset.

## How has this been tested?
Tested on Intel TGL, LibreELEC 13.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
