### PR TITLE
[cmake] Strip Xcode deployment targets from dependency builds

### DIFF
--- a/tools/depends/target/Toolchain.cmake.in
+++ b/tools/depends/target/Toolchain.cmake.in
@@ -230,7 +230,21 @@ set(PROJECT_BUILDENV CC_FOR_BUILD=${CC_FOR_BUILD}
                      )
 
 # variable to easily set host/target env for non cmake internal dep builds
-set(DEP_BUILDENV ${CMAKE_COMMAND} -E env ${PROJECT_TARGETENV} ${PROJECT_BUILDENV})
+set(DEP_BUILDENV ${CMAKE_COMMAND} -E env)
+
+# Xcode exports deployment targets for multiple Apple platforms into Run Script
+# build phases. Clang treats multiple deployment target environment variables as
+# conflicting. Dependency builds already specify their target platform and
+# minimum version explicitly in the compiler flags, so don't propagate these.
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  list(APPEND DEP_BUILDENV --unset=DRIVERKIT_DEPLOYMENT_TARGET
+                           --unset=IPHONEOS_DEPLOYMENT_TARGET
+                           --unset=MACOSX_DEPLOYMENT_TARGET
+                           --unset=TVOS_DEPLOYMENT_TARGET
+                           --unset=WATCHOS_DEPLOYMENT_TARGET
+                           --unset=XROS_DEPLOYMENT_TARGET)
+endif()
+list(APPEND DEP_BUILDENV ${PROJECT_TARGETENV} ${PROJECT_BUILDENV})
 
 # version populated from tools/depends/target/python3/PYTHON3-VERSION file
 set(PYTHON_VER @target_py_version@)


### PR DESCRIPTION
AI use:

## Description

Prevent Xcode-provided deployment target environment variables for unrelated Apple platforms from leaking into internal dependency builds on macOS.

When using the Xcode generator, Xcode exports deployment target variables for multiple platforms into Run Script phases. For non-CMake dependency builds, these variables are inherited through `DEP_BUILDENV` and can cause Clang to reject compiler invocations because multiple Apple deployment targets are set simultaneously.

On Darwin, strip the inherited deployment target variables before invoking internal dependency build tools. The depends build already specifies the intended platform, minimum version and SDK explicitly through its compiler flags.

## Motivation and context

With recent Xcode versions, a macOS Kodi build can expose environment variables such as:

```text
MACOSX_DEPLOYMENT_TARGET=26.5
IPHONEOS_DEPLOYMENT_TARGET=26.5
TVOS_DEPLOYMENT_TARGET=26.5
WATCHOS_DEPLOYMENT_TARGET=26.5
XROS_DEPLOYMENT_TARGET=26.5
DRIVERKIT_DEPLOYMENT_TARGET=25.5
```

These are passed to Xcode Run Script phases even for a target whose `PLATFORM_NAME` and `SUPPORTED_PLATFORMS` are both `macosx`.

This caused the internal `libudfread` Meson configure step to fail while probing Clang with errors such as:

```text
clang: error: conflicting deployment targets, both '26.5' and '26.5' are present in environment
clang: error: conflicting deployment targets, both '26.5' and '25.5' are present in environment
clang: warning: using sysroot for 'MacOSX' but targeting 'XR'
```

`libudfread` is only where the problem was first observed. The environment is shared by non-CMake internal dependency builds, so the fix belongs in the common `DEP_BUILDENV` setup rather than in the individual dependency.

The dependency toolchain already provides the actual target architecture, minimum deployment version and SDK using compiler flags such as `-mmacosx-version-min=11.0` and `-isysroot`, so the inherited Xcode deployment target variables are unnecessary.

## How has this been tested?

Reproduced on:

* Apple Silicon MacBook Pro
* macOS / Darwin 25.5.0
* Apple Clang 21.0.0
* Xcode 26.6
* macOS 26.5 SDK
* Xcode generator
* arm64 Kodi build

The failure was reproduced during the `build-udfread` Meson configure step.

Verified the cause with:

```bash
xcodebuild -target build-udfread -configuration Debug -showBuildSettings
```

which showed deployment target variables populated simultaneously for macOS, iOS, tvOS, watchOS, xrOS and DriverKit despite the target being macOS-only.

Verified that removing the unrelated deployment target variables allows the previously failing `build-udfread` target to build successfully:

```bash
xcodebuild \
  -target build-udfread \
  -configuration Debug \
  IPHONEOS_DEPLOYMENT_TARGET= \
  TVOS_DEPLOYMENT_TARGET= \
  WATCHOS_DEPLOYMENT_TARGET= \
  XROS_DEPLOYMENT_TARGET= \
  DRIVERKIT_DEPLOYMENT_TARGET=
```

This change performs the equivalent cleanup centrally for internal dependency builds on Darwin.

## What is the effect on users?

Fixes building Kodi on macOS with Xcode versions that export deployment targets for multiple Apple platforms into Run Script build phases.

No runtime behavior change.

## Types of change

* [x] **Bug fix** (non-breaking change which fixes an issue)
* [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
* [ ] **Improvement** (non-breaking change which improves existing functionality)
* [ ] **New feature** (non-breaking change which adds functionality)
* [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
* [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
* [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
* [ ] **None of the above** (please explain below)
