### PR TITLE
AddonVideoCodec: release frame buffer on non-picture returns

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VideoCodec.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/VideoCodec.h
@@ -327,6 +327,11 @@ public:
   /// @param[in,out] Structure which contains the necessary data
   /// @return The with @ref VIDEOCODEC_RETVAL return values
   ///
+  /// @note If this returns anything other than @ref VC_PICTURE while
+  /// picture.videoBufferHandle is set, Kodi releases that buffer. An addon
+  /// that releases a buffer itself must clear videoBufferHandle before
+  /// returning.
+  ///
   virtual VIDEOCODEC_RETVAL GetPicture(VIDEOCODEC_PICTURE& picture) { return VC_ERROR; }
   //----------------------------------------------------------------------------
 
@@ -360,7 +365,10 @@ public:
   /// @param[out] picture The buffer, or unmodified if false is returned
   /// @return In case buffer allocation fails, it return false.
   ///
-  /// @note If this returns true, buffer must be freed using @ref ReleaseFrameBuffer().
+  /// @note Ownership: the buffer belongs to the addon until it is either
+  /// handed back to Kodi inside a @ref VC_PICTURE result (as
+  /// @ref VIDEOCODEC_PICTURE::videoBufferHandle) or released with
+  /// @ref ReleaseFrameBuffer(). Buffers may be held across calls.
   ///
   /// @remarks Only called from addon itself
   ///

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/video_codec.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/video_codec.h
@@ -465,6 +465,10 @@ extern "C"
   typedef struct AddonToKodiFuncTable_VideoCodec
   {
     KODI_HANDLE kodiInstance;
+    //! @brief Obtain a frame buffer. Owned by the addon until returned in a
+    //! VC_PICTURE picture or passed to release_frame_buffer; a buffer still in
+    //! picture->videoBufferHandle on any other get_picture return is released
+    //! by Kodi.
     bool (*get_frame_buffer)(void* kodiInstance, struct VIDEOCODEC_PICTURE* picture);
     void (*release_frame_buffer)(void* kodiInstance, void* buffer);
     bool (*get_frame_buffer_platform_handle)(void* kodiInstance,

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -180,7 +180,7 @@
 #define ADDON_INSTANCE_VERSION_VISUALIZATION_DEPENDS  "addon-instance/Visualization.h" \
                                                       "c-api/addon-instance/visualization.h"
 
-#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "2.2.0"
+#define ADDON_INSTANCE_VERSION_VIDEOCODEC             "2.2.1"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_MIN         "2.1.0"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_XML_ID      "kodi.binary.instance.videocodec"
 #define ADDON_INSTANCE_VERSION_VIDEOCODEC_DEPENDS     "c-api/addon-instance/video_codec.h" \

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -499,8 +499,6 @@ const char* CAddonVideoCodec::GetName()
 
 void CAddonVideoCodec::Reset()
 {
-  CVideoBuffer *videoBuffer;
-
   CLog::Log(LOGDEBUG, "CAddonVideoCodec: Reset");
 
   // Get the remaining pictures out of the external decoder. Re-zero the
@@ -513,11 +511,12 @@ void CAddonVideoCodec::Reset()
     picture = {};
     picture.flags = VIDEOCODEC_PICTURE_FLAG_DRAIN;
     ret = m_ifc.videocodec->toAddon->get_picture(m_ifc.videocodec, &picture);
-    if (ret == VIDEOCODEC_RETVAL::VC_PICTURE)
+    // any buffer still referenced by the picture is ours to release, drained or abandoned
+    if (picture.videoBufferHandle)
     {
-      videoBuffer = static_cast<CVideoBuffer*>(picture.videoBufferHandle);
-      if (videoBuffer)
-        videoBuffer->Release();
+      CVideoBuffer* const videoBuffer = static_cast<CVideoBuffer*>(picture.videoBufferHandle);
+      videoBuffer->SyncEnd();
+      videoBuffer->Release();
     }
   } while (ret != VIDEOCODEC_RETVAL::VC_EOF);
   if (m_ifc.videocodec->toAddon->reset)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -367,7 +367,17 @@ CDVDVideoCodec::VCReturn CAddonVideoCodec::GetPicture(VideoPicture* pVideoPictur
   picture.flags = (m_codecFlags & DVD_CODEC_CTRL_DRAIN) ? VIDEOCODEC_PICTURE_FLAG_DRAIN
                                                         : VIDEOCODEC_PICTURE_FLAG_DROP;
 
-  switch (m_ifc.videocodec->toAddon->get_picture(m_ifc.videocodec, &picture))
+  const VIDEOCODEC_RETVAL ret = m_ifc.videocodec->toAddon->get_picture(m_ifc.videocodec, &picture);
+
+  // only VC_PICTURE hands the frame buffer to the caller; release it on any other return
+  if (ret != VIDEOCODEC_RETVAL::VC_PICTURE && picture.videoBufferHandle)
+  {
+    CVideoBuffer* const videoBuffer = static_cast<CVideoBuffer*>(picture.videoBufferHandle);
+    videoBuffer->SyncEnd();
+    videoBuffer->Release();
+  }
+
+  switch (ret)
   {
   case VIDEOCODEC_RETVAL::VC_NONE:
     return CDVDVideoCodec::VC_NONE;


### PR DESCRIPTION
## Description
An addon codec can take a frame buffer via get_frame_buffer and then fail. CAddonVideoCodec::GetPicture dropped the handle on every return except VC_PICTURE, leaking one full-frame allocation per call. A codec failing on every packet leaks without bound (observed: 4K addon codec in the thumbnail extractor, OOM kill).

## Motivation and context
OOM

## How has this been tested?
AMD 5300U / Linux GBM+GLES

## What is the effect on users?
inputstream.adaptive and others will be more reliable

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
