### PR TITLE
[Video][Database][Bluray] Transition to static file table (idFile) entries for each asset on Bluray disc.

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -17122,7 +17122,13 @@ msgctxt "#25020"
 msgid "Mb/s"
 msgstr ""
 
-#empty strings from id 25021 to 29800
+#. Inform user that the playlist could not be taken from the item already holding it
+#: xbmc/dialogs/GUIDialogSimpleMenu.cpp
+msgctxt "#25021"
+msgid "The selected playlist could not be reassigned, so it has been left as it was."
+msgstr ""
+
+#empty strings from id 25022 to 29800
 
 #: unused
 msgctxt "#29801"

--- a/xbmc/application/ApplicationPlay.cpp
+++ b/xbmc/application/ApplicationPlay.cpp
@@ -191,9 +191,13 @@ MenuDecision GetMenuDecisions(const CFileItem& item,
   if (isExternalPlayer || isRemotePlayer)
     return NO_ACTION;
 
+  // A library entry for a title on a disc whose playlist could not be determined when it was
+  // scanned
+  const bool isSelectPath{URIUtils::IsBluraySelectPath(item.GetDynPath())};
+
   // See if disc image is a Blu-ray (as an image could be a DVD as well) or if the path is a BDMV folder
   const bool isBluray{::UTILS::DISCS::IsBlurayDiscImage(item) ||
-                      URIUtils::IsBDFile(item.GetDynPath())};
+                      URIUtils::IsBDFile(item.GetDynPath()) || isSelectPath};
 
   // If already a bluray:// path then playlist selection may not be needed
   // Unless overridden by context menu 'Choose Playlist' or 'Simple Menu' in settings
@@ -233,6 +237,10 @@ MenuDecision GetMenuDecisions(const CFileItem& item,
   if (forceSelectionAtStart && isBlurayPath && atStart)
     return SHOW_SIMPLE_MENU;
 
+  // Needs manual playlist selection
+  if (isSelectPath)
+    return SHOW_SIMPLE_MENU;
+
   return NO_ACTION;
 }
 } // namespace
@@ -266,7 +274,18 @@ bool CApplicationPlay::GetPlaylistIfDisc()
       break;
     }
     case NO_ACTION:
+    {
+      // A select path stands in for a title on a disc and names no file of its own, so anything
+      // that declined to choose a playlist - an external or remote player, which does its own
+      // disc handling - is given the disc instead
+      if (URIUtils::IsBluraySelectPath(m_item.GetDynPath()))
+      {
+        if (const std::string discFile{URIUtils::GetDiscFile(m_item.GetDynPath())};
+            !discFile.empty())
+          m_item.SetDynPath(discFile);
+      }
       break;
+    }
   }
   return true;
 }

--- a/xbmc/application/ApplicationStackHelper.cpp
+++ b/xbmc/application/ApplicationStackHelper.cpp
@@ -106,7 +106,7 @@ bool CApplicationStackHelper::InitializeStack(const CFileItem& item)
       const std::string& partPath{part->GetDynPath()};
 
       std::chrono::milliseconds partTime{0ms};
-      if (URIUtils::IsBlurayPath(partPath))
+      if (URIUtils::IsBlurayPath(partPath) && !URIUtils::IsBluraySelectPath(partPath))
       {
         CFileItemList parts;
         if (CDirectory::GetDirectory(partPath, parts, "", DIR_FLAG_DEFAULTS) && !parts.IsEmpty() &&
@@ -250,12 +250,15 @@ bool CApplicationStackHelper::UpdateDiscStackAndTimes(const CFileItem& playedFil
     return false;
 
   // Get existing stacktimes (if any)
-  const std::string newStackPath{m_stackMap.begin()->second->stackItem->GetDynPath()};
+  const std::shared_ptr<CFileItem>& stackItem{m_stackMap.begin()->second->stackItem};
+  const std::string newStackPath{stackItem->GetDynPath()};
+  const int idFile{stackItem->HasVideoInfoTag() ? stackItem->GetVideoInfoTag()->m_iFileId : -1};
   const std::string path{!m_oldStackPath.empty() ? m_oldStackPath : newStackPath};
-  CLog::LogF(LOGDEBUG, "Looking for existing stacktimes ({})", path);
+  CLog::LogF(LOGDEBUG, "Looking for existing stacktimes (file {}, {})", idFile, path);
 
   std::vector<std::chrono::milliseconds> times;
-  const bool haveTimes{db.GetStackTimes(path, times)};
+  const bool haveTimes{idFile >= 0 ? db.GetStackTimes(idFile, times)
+                                   : db.GetStackTimes(path, times)};
 
   // See if new part played
   if (GetKnownStackParts() - 1 == static_cast<int>(times.size()))
@@ -269,7 +272,10 @@ bool CApplicationStackHelper::UpdateDiscStackAndTimes(const CFileItem& playedFil
 
     // Add this part's time to end of stacktimes
     times.emplace_back(totalTime);
-    db.SetStackTimes(newStackPath, times);
+    if (idFile >= 0)
+      db.SetStackTimes(idFile, times);
+    else
+      db.SetStackTimes(newStackPath, times);
     db.Close();
 
     // Update stack times (for bookmark and % played)
@@ -327,7 +333,9 @@ bool CApplicationStackHelper::IsPlayingResolvedDiscStack() const
   for (int i = 0; i <= m_currentStackPosition; ++i)
   {
     const std::string path{m_stackPaths[i]};
-    if (URIUtils::IsDiscImage(path) || URIUtils::IsDVDFile(path) || URIUtils::IsBDFile(path))
+    // A select path names the disc rather than a title on it, so its duration isn't known yet
+    if (URIUtils::IsBluraySelectPath(path) || URIUtils::IsDiscImage(path) ||
+        URIUtils::IsDVDFile(path) || URIUtils::IsBDFile(path))
       return false; // Stack part not resolved
   }
 
@@ -337,9 +345,14 @@ bool CApplicationStackHelper::IsPlayingResolvedDiscStack() const
 
 bool CApplicationStackHelper::HasDiscParts() const
 {
+  // A scanned part names a title on the disc with a select path, but one played from outside the
+  // library still names the disc itself - and a DVD has no playlist to choose, so it keeps doing
+  // so. Either way the part's duration is not known ahead of playing it.
   return std::ranges::any_of(m_stackPaths,
-                             [](const std::string& path) {
-                               return URIUtils::IsDiscImage(path) || URIUtils::IsDVDFile(path) ||
+                             [](const std::string& path)
+                             {
+                               return URIUtils::IsBluraySelectPath(path) ||
+                                      URIUtils::IsDiscImage(path) || URIUtils::IsDVDFile(path) ||
                                       URIUtils::IsBDFile(path);
                              });
 }

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -381,7 +381,7 @@ bool CDVDFileInfo::CanExtract(const CFileItem& fileItem)
 
   // ..nor from a stack still holding unresolved disc parts.
   // A stack of bluray:// playlists is extractable and DemuxerToStreamDetails() sums their durations
-  if (URIUtils::IsDiscImageStack(fileItem.GetDynPath()))
+  if (URIUtils::IsUnresolvedDiscStack(fileItem.GetDynPath()))
     return false;
 
   // For HTTP/FTP we only allow extraction when on a LAN

--- a/xbmc/dialogs/GUIDialogSimpleMenu.cpp
+++ b/xbmc/dialogs/GUIDialogSimpleMenu.cpp
@@ -9,9 +9,11 @@
 #include "GUIDialogSimpleMenu.h"
 
 #include "FileItem.h"
+#include "GUIDialogOK.h"
 #include "GUIDialogSelect.h"
 #include "GUIDialogYesNo.h"
 #include "ServiceBroker.h"
+#include "URL.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "utils/URIUtils.h"
@@ -65,9 +67,7 @@ bool CGUIDialogSimpleMenu::ShowPlaylistSelection(
         if (!CGUIDialogYesNo::ShowAndGetInput(CVariant{559}, CVariant{25015}))
           return false;
 
-        std::string base{item.GetDynPath()};
-        if (URIUtils::IsBlurayPath(base))
-          base = URIUtils::GetDiscFile(base);
+        const std::string& base{item.GetDynPath()};
 
         CVideoDatabase db;
         if (!db.Open())
@@ -76,18 +76,35 @@ bool CGUIDialogSimpleMenu::ShowPlaylistSelection(
           return false;
         }
 
+        // The displaced items are reverted together. A playlist belongs to the one title, so
+        // leaving any of them holding it would hand it to two at once - the selection is
+        // abandoned rather than half made.
+        db.BeginTransaction();
         for (const auto& it : matchingPlaylists)
         {
-          // Revert file to base file (BDMV/ISO)
-          db.BeginTransaction();
-          if (db.SetFileForMedia(base, it.mediaType, it.idMedia,
-                                 CVideoDatabase::FileRecord{
-                                     .m_idFile = it.idFile,
-                                     .m_dateAdded = item.GetVideoInfoTag()->m_dateAdded}) > 0)
-            db.CommitTransaction();
-          else
+          // Revert the displaced item to a select path. The playlist belongs to it alone, so its
+          // file record is simply renamed and keeps its idFile - and with it the item's bookmarks,
+          // stream details and settings.
+          const std::string revertPath{
+              it.mediaType == VideoDbContentType::EPISODES
+                  ? URIUtils::GetBluraySelectPath(base, it.season, it.episode)
+                  : URIUtils::GetBluraySelectPath(base)};
+          if (revertPath.empty() || !db.RenameFile(it.idFile, revertPath))
+          {
             db.RollbackTransaction();
+            db.Close();
+            CLog::LogF(LOGERROR,
+                       "Unable to revert file {} of {} to a select path, so playlist {} is left "
+                       "where it is",
+                       it.idFile, CURL::GetRedacted(base), newPlaylist);
+
+            // The user has just agreed to the change, so say that it hasn't happened rather than
+            // leave the dialog closing as though it had
+            CGUIDialogOK::ShowAndGetInput(CVariant{559}, CVariant{25021});
+            return false;
+          }
         }
+        db.CommitTransaction();
         db.Close();
       }
     }

--- a/xbmc/filesystem/BlurayFile.cpp
+++ b/xbmc/filesystem/BlurayFile.cpp
@@ -35,7 +35,7 @@ std::string CBlurayFile::TranslatePath(const CURL& url)
 
 bool CBlurayFile::Exists(const CURL& url)
 {
-  if (url.GetFileName() == "menu")
+  if (URIUtils::IsBlurayMenuPath(url.Get()) || URIUtils::IsBluraySelectPath(url.Get()))
     return CFile::Exists(URIUtils::GetDiscFile(url.Get()));
   return CFile::Exists(TranslatePath(url));
 }

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -2872,7 +2872,8 @@ bool CDiscDirectoryHelper::GetOrShowPlaylistSelection(const CFileItem& item,
   const std::string directory{
       [&item, &playback, &returnMultipleItems]
       {
-        const bool forceSelection{item.GetProperty("force_playlist_selection").asBoolean(false)};
+        const bool forceSelection{item.GetProperty("force_playlist_selection").asBoolean(false) ||
+                                  URIUtils::IsBluraySelectPath(item.GetDynPath())};
 
         // All episodes
         if (item.HasProperty("episodes_start"))

--- a/xbmc/filesystem/EpisodesDirectory.h
+++ b/xbmc/filesystem/EpisodesDirectory.h
@@ -24,5 +24,8 @@ public:
   bool GetDirectory(const CURL& url, CFileItemList& items) override;
   bool ContainsFiles(const CURL& url) override { return false; }
   bool Resolve(CFileItem& item) const override;
+
+  // Needed to return select paths
+  bool AllowAll() const override { return true; }
 };
 } // namespace XFILE

--- a/xbmc/utils/SaveFileStateJob.cpp
+++ b/xbmc/utils/SaveFileStateJob.cpp
@@ -106,6 +106,61 @@ void CSaveFileState::DoWork(CFileItem& item,
           }
         }
 
+        if (item.HasVideoInfoTag())
+        {
+          const CVideoInfoTag* tag{item.GetVideoInfoTag()};
+
+          // The tag's path is already pointed at what was played
+          const std::string oldPath{tag->m_iFileId >= 0
+                                        ? videodatabase.GetFileAndPathById(tag->m_iFileId)
+                                        : std::string{}};
+
+          const bool fileNeedsRenaming{
+              [&item, tag, &oldPath, &progressTrackingFile]
+              {
+                if (tag->m_iFileId < 0)
+                  return false; // No file to rename
+                if (tag->m_iDbId < 0 && item.GetVideoContentType() != VideoDbContentType::UNKNOWN)
+                  return false; // No video db item to update
+                if (URIUtils::IsBluraySelectPath(oldPath) && oldPath != progressTrackingFile)
+                  return true; // Playlist now known for a title scanned without one
+                if (URIUtils::IsBlurayPath(item.GetDynPath()) &&
+                    !URIUtils::IsStack(tag->m_strFileNameAndPath) &&
+                    tag->m_strFileNameAndPath != item.GetDynPath())
+                  return true; // Bluray path to update
+                if (item.GetProperty("new_playlist_path").asBoolean(false))
+                  return true; // Bluray playlist replaced by user selection
+                if (item.GetProperty("new_stack_path").asBoolean(false))
+                  return true; // Stack path to update
+                return false;
+              }()};
+
+          if (fileNeedsRenaming && oldPath != progressTrackingFile)
+          {
+            videodatabase.BeginTransaction();
+            if (videodatabase.RenameFile(tag->m_iFileId, progressTrackingFile))
+            {
+              videodatabase.CommitTransaction();
+              CLog::LogF(LOGDEBUG, "Renamed file {} from {} to {}", tag->m_iFileId,
+                         CURL::GetRedacted(oldPath), CURL::GetRedacted(progressTrackingFile));
+              item.GetVideoInfoTag()->SetFileNameAndPath(progressTrackingFile);
+            }
+            else
+            {
+              videodatabase.RollbackTransaction();
+              CLog::LogF(LOGWARNING, "Unable to rename file {} from {} to {}", tag->m_iFileId,
+                         CURL::GetRedacted(oldPath), CURL::GetRedacted(progressTrackingFile));
+
+              // The entry still names what it did before, so that is what this playback is
+              // recorded against. Recording it against the name the rename was refused would add
+              // a file no library item refers to, taking the resume point and the stream details
+              // with it.
+              if (!oldPath.empty())
+                progressTrackingFile = oldPath;
+            }
+          }
+        }
+
         bool updateListing = false;
         // No resume & watched status for livetv
         if (!item.IsLiveTV())
@@ -216,47 +271,6 @@ void CSaveFileState::DoWork(CFileItem& item,
               videodatabase.RollbackTransaction();
             }
           }
-        }
-
-        // See if idFile of library item needs updating
-        const CVideoInfoTag* tag{item.HasVideoInfoTag() ? item.GetVideoInfoTag() : nullptr};
-
-        const bool updateNeeded{
-            [&item, &tag]
-            {
-              if (!tag || tag->m_iFileId < 0)
-                return false; // No tag or file to update
-              if (tag->m_iDbId < 0 && item.GetVideoContentType() != VideoDbContentType::UNKNOWN)
-                return false; // No video db item to update
-              if (URIUtils::IsBlurayPath(item.GetDynPath()) &&
-                  !URIUtils::IsStack(tag->m_strFileNameAndPath) &&
-                  tag->m_strFileNameAndPath != item.GetDynPath())
-                return true; // Bluray path to update
-              if (item.GetProperty("new_playlist_path").asBoolean(false))
-                return true; // Bluray playlist replaced by user selection
-              if (item.GetProperty("new_stack_path").asBoolean(false))
-                return true; // Stack path to update
-              return false;
-            }()};
-
-        if (updateNeeded)
-        {
-          videodatabase.BeginTransaction();
-          // tag->m_iFileId contains the idFile originally played and may be different to the idFile
-          // in the movie table entry if it's a non-default video version
-          const int newFileId{videodatabase.SetFileForMedia(
-              progressTrackingFile, item.GetVideoContentType(), tag->m_iDbId,
-              CVideoDatabase::FileRecord{.m_idFile = tag->m_iFileId,
-                                         .m_playCount = tag->GetPlayCount(),
-                                         .m_lastPlayed = tag->m_lastPlayed,
-                                         .m_dateAdded = tag->m_dateAdded})};
-          if (newFileId > 0)
-          {
-            videodatabase.CommitTransaction();
-            item.GetVideoInfoTag()->m_iFileId = newFileId;
-          }
-          else
-            videodatabase.RollbackTransaction();
         }
 
         if (updateListing)

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1268,14 +1268,17 @@ bool URIUtils::IsDiscImage(const std::string& file)
   return HasExtension(file, ".img|.iso|.nrg|.udf");
 }
 
-bool URIUtils::IsDiscImageStack(const std::string& file)
+bool URIUtils::IsUnresolvedDiscStack(const std::string& file)
 {
   if (IsStack(file))
   {
     std::vector<std::string> paths;
     CStackDirectory::GetPaths(file, paths);
+    // A part naming a disc rather than a title on it is one still waiting for a playlist. A part
+    // the library has scanned names it with a select path; one played from outside the library
+    // has never been looked at, so it still names the disc itself.
     for (const std::string& path : paths)
-      if (IsDiscImage(path) || IsDVDFile(path) || IsBDFile(path))
+      if (IsBluraySelectPath(path) || IsDiscImage(path) || IsDVDFile(path) || IsBDFile(path))
         return true;
   }
   return false;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -757,6 +757,23 @@ std::string URIUtils::GetBlurayPlaylistPath(const std::string& path, int playlis
                          playlist != -1 ? StringUtils::Format("{:05}.mpls", playlist) : "");
 }
 
+std::string URIUtils::GetBluraySelectPath(const std::string& path,
+                                          int season /* = -1 */,
+                                          int episode /* = -1 */)
+{
+  if (IsContainerPath(path))
+    return {};
+
+  const std::string blurayPath{GetBlurayPath(path)};
+  if (blurayPath.empty())
+    return {};
+
+  const std::string file{season < 0 || episode < 0
+                             ? "select" // A movie, or an episode whose numbering isn't known
+                             : StringUtils::Format("select-{}-{}", season, episode)};
+  return AddFileToFolder(blurayPath, "BDMV", "PLAYLIST", file);
+}
+
 std::string URIUtils::GetBlurayPath(const std::string& path)
 {
   if (IsContainerPath(path))
@@ -1580,6 +1597,19 @@ bool URIUtils::IsBlurayPath(const std::string& strFile)
 bool URIUtils::IsBlurayMenuPath(const std::string& file)
 {
   return IsBlurayPath(file) && GetFileName(file) == "menu";
+}
+
+bool URIUtils::IsBluraySelectPath(const std::string& file)
+{
+  if (!IsBlurayPath(file))
+    return false;
+
+  // A folder item carries a trailing slash, which the name would otherwise be taken from
+  std::string path{file};
+  RemoveSlashAtEnd(path);
+
+  const std::string fileName{GetFileName(path)};
+  return fileName == "select" || StringUtils::StartsWith(fileName, "select-");
 }
 
 bool URIUtils::IsOpticalMediaFile(const std::string& file)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -315,7 +315,14 @@ public:
   static bool IsArchive(const std::string& strFile);
   static bool IsArchive(const CURL& url);
   static bool IsDiscImage(const std::string& file);
-  static bool IsDiscImageStack(const std::string& file);
+
+  /*! \brief Determines if a stack holds a part that names a disc rather than a title on it, and so
+   is still waiting for a playlist to be chosen for it (see IsBluraySelectPath).
+   \param file file path for determination.
+   \return true if any part of the stack has yet to be resolved.
+   */
+  static bool IsUnresolvedDiscStack(const std::string& file);
+
   static bool IsBlurayPath(const std::string& strFile);
   static bool IsBlurayMenuPath(const std::string& file);
 

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -191,6 +191,19 @@ public:
    */
   static int GetBlurayPlaylistFromPath(const std::string& path);
 
+  /*! \brief Given a path to an .ISO or index.BDMV, returns a bluray:// path standing in for a
+   title whose playlist is not (yet) known.
+   It names a file in the same playlist folder the playlist itself will occupy, so resolving it
+   later renames the file without adding or orphaning a path entry.
+   \param path the ISO/index.BDMV (or an existing bluray://) path.
+   \param season the season number, or -1 for a movie (or an episode of unknown season).
+   \param episode the episode number, or -1 for a movie (or an episode of unknown number).
+   \return the bluray:// select path - BDMV/PLAYLIST/select(-<season>-<episode>)
+   */
+  static std::string GetBluraySelectPath(const std::string& path,
+                                         int season = -1,
+                                         int episode = -1);
+
   /*! \brief Resolve two paths to their disc base (if needed) and compare for equality.
    \param path1 first path to resolve and compare
    \param path2 second path to resolve and compare
@@ -305,6 +318,13 @@ public:
   static bool IsDiscImageStack(const std::string& file);
   static bool IsBlurayPath(const std::string& strFile);
   static bool IsBlurayMenuPath(const std::string& file);
+
+  /*! \brief Determines if a path is one produced by GetBluraySelectPath, ie. a library entry on a
+   disc whose playlist has not been determined yet.
+   \param file file path for determination.
+   \return true if the path stands in for an as yet unresolved title.
+   */
+  static bool IsBluraySelectPath(const std::string& file);
 
   /*! \brief Determines if a file is from optical media (ie. index.bdmv, video_ts.ifo etc..)
    \param file file path for determination.

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -2271,6 +2271,59 @@ TEST_F(TestURIUtils, GetBlurayPlaylistPath)
       URIUtils::GetBlurayPlaylistPath("smb://somepath/path/movie.iso", 800));
 }
 
+TEST_F(TestURIUtils, GetBluraySelectPath)
+{
+  // Movie (or an episode of unknown numbering)
+  EXPECT_EQ("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/select",
+            URIUtils::GetBluraySelectPath("/somepath/path/BDMV/index.bdmv"));
+  EXPECT_EQ("bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/select",
+            URIUtils::GetBluraySelectPath("/somepath/path/movie.iso"));
+  EXPECT_EQ("bluray://D%3a%5cMovies%5c/BDMV/PLAYLIST/select",
+            URIUtils::GetBluraySelectPath("D:\\Movies\\BDMV\\index.bdmv"));
+  EXPECT_EQ("bluray://%5c%5cServer%5cMovies%5c/BDMV/PLAYLIST/select",
+            URIUtils::GetBluraySelectPath("\\\\Server\\Movies\\BDMV\\index.bdmv"));
+  EXPECT_EQ("bluray://smb%3a%2f%2fsomepath%2fpath%2f/BDMV/PLAYLIST/select",
+            URIUtils::GetBluraySelectPath("smb://somepath/path/BDMV/index.bdmv"));
+
+  // Episode - the same folder as the playlist it will become, so no path entry of its own
+  EXPECT_EQ("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/select-3-4",
+            URIUtils::GetBluraySelectPath("/somepath/path/BDMV/index.bdmv", 3, 4));
+  EXPECT_EQ("bluray://udf%3a%2f%2f%252fsomepath%252fpath%252fmovie.iso%2f/BDMV/PLAYLIST/select-3-4",
+            URIUtils::GetBluraySelectPath("/somepath/path/movie.iso", 3, 4));
+
+  // Specials are season 0
+  EXPECT_EQ("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/select-0-1",
+            URIUtils::GetBluraySelectPath("/somepath/path/BDMV/index.bdmv", 0, 1));
+
+  // An existing bluray:// path resolves to the same disc
+  EXPECT_EQ("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/select-3-4",
+            URIUtils::GetBluraySelectPath("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls",
+                                          3, 4));
+  EXPECT_EQ("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/select-3-4",
+            URIUtils::GetBluraySelectPath("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/select-1-2",
+                                          3, 4));
+
+  // Not a disc
+  EXPECT_EQ("", URIUtils::GetBluraySelectPath("/somepath/path/movie.mkv"));
+}
+
+TEST_F(TestURIUtils, IsBluraySelectPath)
+{
+  EXPECT_TRUE(URIUtils::IsBluraySelectPath("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/select"));
+  EXPECT_TRUE(
+      URIUtils::IsBluraySelectPath("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/select-3-4"));
+  EXPECT_FALSE(
+      URIUtils::IsBluraySelectPath("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/00800.mpls"));
+  EXPECT_FALSE(URIUtils::IsBluraySelectPath("bluray://%2fsomepath%2fpath%2f/menu"));
+  EXPECT_FALSE(URIUtils::IsBluraySelectPath("bluray://%2fsomepath%2fpath%2f/root/episode/3/4"));
+  EXPECT_FALSE(URIUtils::IsBluraySelectPath("/somepath/path/BDMV/index.bdmv"));
+
+  // A folder item carries a trailing slash, and still names the same title
+  EXPECT_TRUE(URIUtils::IsBluraySelectPath("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/select/"));
+  EXPECT_TRUE(
+      URIUtils::IsBluraySelectPath("bluray://%2fsomepath%2fpath%2f/BDMV/PLAYLIST/select-3-4/"));
+}
+
 TEST_F(TestURIUtils, GetBlurayPlaylistFromPath)
 {
   EXPECT_EQ(URIUtils::GetBlurayPlaylistFromPath(

--- a/xbmc/utils/test/TestUrlParsing.cpp
+++ b/xbmc/utils/test/TestUrlParsing.cpp
@@ -157,7 +157,7 @@ struct TestURLParseDetailsData
   bool expectedIsZIP = false;
   bool expectedIsArchive = false;
   bool expectedIsDiscImage = false;
-  bool expectedIsDiscImageStack = false;
+  bool expectedIsUnresolvedDiscStack = false;
   bool expectedIsSpecial = false;
   bool expectedIsPlugin = false;
   bool expectedIsScript = false;
@@ -337,7 +337,7 @@ TestURLParseDetailsData CreateParamFromJson(std::string filename)
     read(param.expectedIsZIP, json, "expectedIsZIP");
     read(param.expectedIsArchive, json, "expectedIsArchive");
     read(param.expectedIsDiscImage, json, "expectedIsDiscImage");
-    read(param.expectedIsDiscImageStack, json, "expectedIsDiscImageStack");
+    read(param.expectedIsUnresolvedDiscStack, json, "expectedIsUnresolvedDiscStack");
     read(param.expectedIsSpecial, json, "expectedIsSpecial");
     read(param.expectedIsPlugin, json, "expectedIsPlugin");
     read(param.expectedIsScript, json, "expectedIsScript");
@@ -510,7 +510,7 @@ void RunParseTest(const std::string& filename, const TestURLParseDetailsData& pa
   EXPECT_EQ(param.expectedIsArchive, curl.IsArchive());
   EXPECT_EQ(param.expectedIsDiscImage, URIUtils::IsDiscImage(p));
   EXPECT_EQ(param.expectedIsDiscImage, curl.IsDiscImage());
-  EXPECT_EQ(param.expectedIsDiscImageStack, URIUtils::IsDiscImageStack(p));
+  EXPECT_EQ(param.expectedIsUnresolvedDiscStack, URIUtils::IsUnresolvedDiscStack(p));
   EXPECT_EQ(param.expectedIsSpecial, URIUtils::IsSpecial(p));
   EXPECT_EQ(param.expectedIsPlugin, URIUtils::IsPlugin(p));
   EXPECT_EQ(param.expectedIsPlugin, curl.IsPlugin());
@@ -658,7 +658,7 @@ void RunParseTest(const std::string& filename, const TestURLParseDetailsData& pa
   write(jsonObj, "expectedIsZIP", URIUtils::IsZIP(p));
   write(jsonObj, "expectedIsArchive", URIUtils::IsArchive(p));
   write(jsonObj, "expectedIsDiscImage", URIUtils::IsDiscImage(p));
-  write(jsonObj, "expectedIsDiscImageStack", URIUtils::IsDiscImageStack(p));
+  write(jsonObj, "expectedIsUnresolvedDiscStack", URIUtils::IsUnresolvedDiscStack(p));
   write(jsonObj, "expectedIsSpecial", URIUtils::IsSpecial(p));
   write(jsonObj, "expectedIsPlugin", URIUtils::IsPlugin(p));
   write(jsonObj, "expectedIsScript", URIUtils::IsScript(p));

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -4583,7 +4583,7 @@ bool CVideoDatabase::GetResumePoint(CVideoInfoTag& tag)
 
   try
   {
-    if (URIUtils::IsDiscImageStack(tag.m_strFileNameAndPath))
+    if (URIUtils::IsUnresolvedDiscStack(tag.m_strFileNameAndPath))
     {
       CStackDirectory dir;
       CFileItemList fileList;
@@ -5777,11 +5777,16 @@ std::vector<std::string> CVideoDatabase::GetAvailableArtTypesForItem(int mediaId
 bool CVideoDatabase::GetStackTimes(const std::string& filePath,
                                    std::vector<std::chrono::milliseconds>& times)
 {
+  // obtain the FileID (if it exists)
+  return GetStackTimes(GetFileId(filePath), times);
+}
+
+bool CVideoDatabase::GetStackTimes(int idFile, std::vector<std::chrono::milliseconds>& times)
+{
   try
   {
-    // obtain the FileID (if it exists)
-    int idFile = GetFileId(filePath);
-    if (idFile < 0) return false;
+    if (idFile < 0)
+      return false;
     if (nullptr == m_pDB)
       return false;
     if (nullptr == m_pDS)
@@ -5817,14 +5822,20 @@ bool CVideoDatabase::GetStackTimes(const std::string& filePath,
 void CVideoDatabase::SetStackTimes(const std::string& filePath,
                                    const std::vector<std::chrono::milliseconds>& times)
 {
+  // The file is added when it is not in the library yet, as happens when the times are worked out
+  // during a scan, before the item itself has been added
+  SetStackTimes(AddFile(filePath), times);
+}
+
+void CVideoDatabase::SetStackTimes(int idFile, const std::vector<std::chrono::milliseconds>& times)
+{
   try
   {
+    if (idFile < 0)
+      return;
     if (nullptr == m_pDB)
       return;
     if (nullptr == m_pDS)
-      return;
-    int idFile = AddFile(filePath);
-    if (idFile < 0)
       return;
 
     // delete any existing items
@@ -5840,7 +5851,7 @@ void CVideoDatabase::SetStackTimes(const std::string& filePath,
   }
   catch (...)
   {
-    CLog::LogF(LOGERROR, "({}) failed", filePath);
+    CLog::LogF(LOGERROR, "({}) failed", idFile);
   }
 }
 

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -544,27 +544,11 @@ bool CVideoDatabase::GetSourcePath(const std::string &path, std::string &sourceP
   return false;
 }
 
-int CVideoDatabase::AddFile(const std::string& strFileNameAndPath,
+int CVideoDatabase::AddFile(const std::string& fileNameAndPath,
                             const std::string& parentPath /* = "" */,
                             const CDateTime& dateAdded /* = CDateTime() */,
                             int playCount /* = 0 */,
                             const CDateTime& lastPlayed /* = CDateTime() */)
-{
-  return AddOrUpdateFile(strFileNameAndPath, parentPath,
-                         FileRecord{
-                             .m_playCount = playCount,
-                             .m_lastPlayed = lastPlayed,
-                             .m_dateAdded = dateAdded,
-                         },
-                         FileExistsAction::ACTION_NONE);
-}
-
-//********************************************************************************************************************************
-//! @todo for more future flexibility add the rest of the fields to the struct and provide a mask to specify which fields to update
-int CVideoDatabase::AddOrUpdateFile(const std::string& fileAndPath,
-                                    const std::string& parentPath,
-                                    const FileRecord& fileInfo,
-                                    FileExistsAction existsAction)
 {
   if (nullptr == m_pDB || nullptr == m_pDS)
     return -1;
@@ -572,21 +556,15 @@ int CVideoDatabase::AddOrUpdateFile(const std::string& fileAndPath,
   std::string sql;
   try
   {
-    const CDateTime finalDateAdded{GetDateAdded(fileAndPath, fileInfo.m_dateAdded)};
+    const CDateTime finalDateAdded{GetDateAdded(fileNameAndPath, dateAdded)};
 
     std::string strFileName;
     std::string strPath;
-    SplitPath(fileAndPath, strPath, strFileName);
+    SplitPath(fileNameAndPath, strPath, strFileName);
 
     const int idPath{AddPath(strPath, parentPath, finalDateAdded)};
     if (idPath < 0)
       return -1;
-
-    const std::string playCount{fileInfo.m_playCount > 0 ? std::to_string(fileInfo.m_playCount)
-                                                         : "NULL"};
-    const std::string lastPlayed{fileInfo.m_lastPlayed.IsValid()
-                                     ? "'" + fileInfo.m_lastPlayed.GetAsDBDateTime() + "'"
-                                     : "NULL"};
 
     sql = PrepareSQL("SELECT idFile FROM files WHERE strFileName = '%s' AND idPath=%i",
                      strFileName.c_str(), idPath);
@@ -596,32 +574,19 @@ int CVideoDatabase::AddOrUpdateFile(const std::string& fileAndPath,
     {
       const int idFile{m_pDS->fv("idFile").get_asInt()};
       m_pDS->close();
-
-      if (existsAction == FileExistsAction::ACTION_UPDATE)
-      {
-        sql = PrepareSQL("UPDATE files "
-                         "SET playCount = " +
-                             playCount +
-                             ", "
-                             "lastPlayed = " +
-                             lastPlayed +
-                             ", "
-                             "dateAdded = '%s' "
-                             "WHERE idFile = %i",
-                         finalDateAdded.GetAsDBDateTime().c_str(), idFile);
-
-        m_pDS->exec(sql);
-      }
-
       return idFile;
     }
 
     m_pDS->close();
 
+    const std::string playCountValue{playCount > 0 ? std::to_string(playCount) : "NULL"};
+    const std::string lastPlayedValue{
+        lastPlayed.IsValid() ? "'" + lastPlayed.GetAsDBDateTime() + "'" : "NULL"};
+
     sql = PrepareSQL(
         "INSERT INTO files (idFile, idPath, strFileName, playCount, lastPlayed, dateAdded) "
         "VALUES(NULL, %i, '%s', " +
-            playCount + ", " + lastPlayed + ", '%s')",
+            playCountValue + ", " + lastPlayedValue + ", '%s')",
         idPath, strFileName.c_str(), finalDateAdded.GetAsDBDateTime().c_str());
 
     m_pDS->exec(sql);
@@ -630,7 +595,7 @@ int CVideoDatabase::AddOrUpdateFile(const std::string& fileAndPath,
   }
   catch (...)
   {
-    CLog::LogF(LOGERROR, "unable to add or update file ({})", sql);
+    CLog::LogF(LOGERROR, "unable to add file ({})", sql);
   }
   return -1;
 }
@@ -2818,144 +2783,47 @@ int CVideoDatabase::SetDetailsForSeason(const CVideoInfoTag& details,
   return -1;
 }
 
-int CVideoDatabase::SetFileForMedia(const std::string& fileAndPath,
-                                    VideoDbContentType type,
-                                    int mediaId,
-                                    const FileRecord& oldFile)
+bool CVideoDatabase::RenameFile(int idFile, const std::string& fileAndPath)
 {
-  if ((mediaId < 0 && type != VideoDbContentType::UNKNOWN) || oldFile.m_idFile < 0)
-    return -1;
-
-  const int newIdFile = AddOrUpdateFile(fileAndPath, "", oldFile, FileExistsAction::ACTION_UPDATE);
-  if (newIdFile < 0)
-    return -1;
-
-  switch (type)
-  {
-    using enum VideoDbContentType;
-
-    case MOVIES:
-      return SetFileForMovie(fileAndPath, mediaId, oldFile.m_idFile, newIdFile);
-    case EPISODES:
-      return SetFileForEpisode(fileAndPath, mediaId, oldFile.m_idFile, newIdFile);
-    case UNKNOWN:
-      // Used for removable blurays
-      return SetFileForUnknown(fileAndPath, oldFile.m_idFile, newIdFile);
-    default:
-      CLog::LogF(LOGDEBUG, "unsupported media type {}", type);
-      return -1;
-  }
-}
-
-int CVideoDatabase::SetFileForEpisode(const std::string& fileAndPath,
-                                      int idEpisode,
-                                      int oldIdFile,
-                                      int newIdFile)
-{
-  assert(m_pDB->in_transaction());
-
-  if (newIdFile < 0)
-    return -1;
-
-  if (newIdFile == oldIdFile)
-    return newIdFile; // Nothing to do, and the file must not be deleted below
+  if (!m_pDB || !m_pDS || idFile < 0 || fileAndPath.empty())
+    return false;
 
   try
   {
-    m_pDS->exec(
-        PrepareSQL("UPDATE episode SET idFile=%i WHERE idEpisode=%i", newIdFile, idEpisode));
-    m_pDS->exec(PrepareSQL("UPDATE settings SET idFile=%i WHERE idFile=%i", newIdFile, oldIdFile));
-    return DeleteFile(oldIdFile) ? newIdFile : -1;
+    // A file shared by several library items (as a disc entry added before select paths is) can't
+    // be renamed on behalf of just one of them
+    if (GetSingleValueInt(PrepareSQL("SELECT (SELECT COUNT(1) FROM episode WHERE idFile=%i) + "
+                                     "(SELECT COUNT(1) FROM videoversion WHERE idFile=%i)",
+                                     idFile, idFile)) > 1)
+      return false;
+
+    std::string strFileName;
+    std::string strPath;
+    SplitPath(fileAndPath, strPath, strFileName);
+
+    const int idPath{AddPath(strPath)};
+    if (idPath < 0)
+      return false;
+
+    // A file already of that name is a different library item that happens to share the path (two
+    // episodes on one playlist, say), so this one can't take it
+    if (const int existingIdFile{
+            GetSingleValueInt(PrepareSQL("SELECT idFile FROM files WHERE strFileName='%s' AND "
+                                         "idPath=%i",
+                                         strFileName.c_str(), idPath))};
+        existingIdFile > 0)
+      return existingIdFile == idFile; // Already named as asked, so nothing to do
+
+    m_pDS->exec(PrepareSQL("UPDATE files SET idPath=%i, strFileName='%s' WHERE idFile=%i", idPath,
+                           strFileName.c_str(), idFile));
+    return true;
   }
   catch (...)
   {
-    CLog::LogF(LOGERROR, " idFile {}, fileAndPath {}, idEpisode {}, oldIdFile {} - failed",
-               newIdFile, fileAndPath, idEpisode, oldIdFile);
+    CLog::LogF(LOGERROR, "idFile {}, fileAndPath {} - failed", idFile,
+               CURL::GetRedacted(fileAndPath));
   }
-  return -1;
-}
-
-int CVideoDatabase::SetFileForMovie(const std::string& fileAndPath,
-                                    int idMovie,
-                                    int oldIdFile,
-                                    int newIdFile)
-{
-  assert(m_pDB->in_transaction());
-
-  if (newIdFile < 0)
-    return -1;
-
-  if (newIdFile == oldIdFile)
-    return newIdFile; // Nothing to do
-
-  try
-  {
-    // The file played may already be a version of the movie in its own right
-    // eg. selecting a known version playlist through the bluray menu
-    // Only a version of this same movie is adopted. A file belonging to another movie, or held as
-    // an extra, is not the replacement that was asked for, so it falls through to fail and roll back
-    if (GetSingleValueInt(PrepareSQL("SELECT COUNT(1) FROM videoversion WHERE idFile=%i AND "
-                                     "media_type='movie' AND idMedia=%i AND itemType=%i",
-                                     newIdFile, idMovie,
-                                     static_cast<int>(VideoAssetType::VERSION))) > 0)
-    {
-      CLog::LogF(LOGDEBUG,
-                 "File {} ({}) is already a version of movie {} - keeping both it and "
-                 "file {}",
-                 newIdFile, CURL::GetRedacted(fileAndPath), idMovie, oldIdFile);
-      return newIdFile;
-    }
-
-    m_pDS->exec(PrepareSQL("UPDATE movie SET idFile=%i WHERE idFile=%i AND idMovie=%i", newIdFile,
-                           oldIdFile, idMovie));
-    m_pDS->exec(PrepareSQL(
-        "UPDATE videoversion SET idFile=%i WHERE idFile=%i AND media_type='movie' AND idMedia=%i",
-        newIdFile, oldIdFile, idMovie));
-    m_pDS->exec(
-        PrepareSQL("UPDATE art SET media_id=%i WHERE media_id=%i AND media_type='videoversion'",
-                   newIdFile, oldIdFile));
-    m_pDS->exec(
-        PrepareSQL("UPDATE streamdetails SET idFile=%i WHERE idFile=%i AND NOT EXISTS (SELECT 1 "
-                   "FROM streamdetails WHERE idFile=%i)",
-                   newIdFile, oldIdFile, newIdFile));
-    m_pDS->exec(PrepareSQL("UPDATE settings SET idFile=%i WHERE idFile=%i", newIdFile, oldIdFile));
-
-    return DeleteFile(oldIdFile) ? newIdFile : -1;
-  }
-  catch (...)
-  {
-    CLog::LogF(LOGERROR, " idFile {}, fileAndPath {}, idMovie {}, oldIdFile {} - failed", newIdFile,
-               fileAndPath, idMovie, oldIdFile);
-  }
-  return -1;
-}
-
-int CVideoDatabase::SetFileForUnknown(const std::string& fileAndPath, int oldIdFile, int newIdFile)
-{
-  assert(m_pDB->in_transaction());
-
-  if (newIdFile < 0)
-    return -1;
-
-  if (newIdFile == oldIdFile)
-    return newIdFile; // Nothing to do, and the file must not be deleted below
-
-  try
-  {
-    m_pDS->exec(
-        PrepareSQL("UPDATE streamdetails SET idFile=%i WHERE idFile=%i AND NOT EXISTS (SELECT 1 "
-                   "FROM streamdetails WHERE idFile=%i)",
-                   newIdFile, oldIdFile, newIdFile));
-    m_pDS->exec(PrepareSQL("UPDATE settings SET idFile=%i WHERE idFile=%i", newIdFile, oldIdFile));
-
-    return DeleteFile(oldIdFile) ? newIdFile : -1;
-  }
-  catch (...)
-  {
-    CLog::LogF(LOGERROR, " idFile {}, fileAndPath {}, oldIdFile {} - failed", newIdFile,
-               fileAndPath, oldIdFile);
-  }
-  return -1;
+  return false;
 }
 
 bool CVideoDatabase::DeleteFile(int idFile)
@@ -3298,12 +3166,13 @@ std::vector<CVideoDatabase::PlaylistInfo> CVideoDatabase::GetPlaylistsByPath(
       return playlists;
 
     const std::string strSQL{PrepareSQL(
-        "SELECT files.strFilename, files.idFile, episode.idEpisode, vv.idMedia FROM files "
+        "SELECT files.strFilename, files.idFile, episode.idEpisode, episode.c%02d AS epSeason, "
+        "episode.c%02d AS epEpisode, vv.idMedia FROM files "
         "LEFT JOIN episode ON episode.idFile=files.idFile "
         "LEFT JOIN videoversion vv ON vv.idFile = files.idFile AND vv.media_type='%s' "
         "INNER JOIN path ON path.idPath=files.idPath "
         "WHERE path.strPath='%s'",
-        MediaTypeMovie, path.c_str())};
+        VIDEODB_ID_EPISODE_SEASON, VIDEODB_ID_EPISODE_EPISODE, MediaTypeMovie, path.c_str())};
     m_pDS->query(strSQL);
 
     while (!m_pDS->eof())
@@ -3324,7 +3193,9 @@ std::vector<CVideoDatabase::PlaylistInfo> CVideoDatabase::GetPlaylistsByPath(
             playlists.emplace_back(PlaylistInfo{.playlist = std::stoi(filename),
                                                 .idFile = m_pDS->fv(idFileIndex).get_asInt(),
                                                 .mediaType = VideoDbContentType::EPISODES,
-                                                .idMedia = idEpisode});
+                                                .idMedia = idEpisode,
+                                                .season = m_pDS->fv("epSeason").get_asInt(),
+                                                .episode = m_pDS->fv("epEpisode").get_asInt()});
           if (idMovie > 0)
             playlists.emplace_back(PlaylistInfo{.playlist = std::stoi(filename),
                                                 .idFile = m_pDS->fv(idFileIndex).get_asInt(),
@@ -3487,24 +3358,21 @@ void CVideoDatabase::GetEpisodesByBlurayPath(const std::string& path,
 {
   try
   {
-    // url will be in vfs format (ie. bluray://.../episode/1/1)
-    // episode database entries will either have basepath path (ie. ISO/BDMV) if not yet played ...
-    const std::string baseFileAndPath{URIUtils::GetDiscFile(path)};
-    std::string baseFile;
-    std::string basePath;
-    SplitPath(baseFileAndPath, basePath, baseFile);
-
-    // ... or bluray:// path (ie. bluray://.../BDMV/00000.mpls) if already played
+    // path is one of the vfs episode listings (ie. bluray://.../root/episode/1/1)
     CURL url{path};
     url.SetFileName("");
     const std::string blurayPath{URIUtils::AddFileToFolder(url.Get(), "BDMV", "PLAYLIST", "")};
+
+    // Any one of the titles on the disc will do, as GetEpisodesByFileId goes on to find the rest
+    // by the disc they share. The dataset is finished with first, as that call reuses it.
     const std::string sql{
-        PrepareSQL("select idFile from episode_view "
-                   "where (strPath = '%s' and strFileName = '%s') or strPath = '%s'",
-                   basePath.c_str(), baseFile.c_str(), blurayPath.c_str())};
+        PrepareSQL("select idFile from episode_view where strPath = '%s'", blurayPath.c_str())};
     m_pDS->query(sql);
-    if (!m_pDS->eof())
-      return GetEpisodesByFileId(m_pDS->fv("idFile").get_asInt(), episodes);
+    const int idFile{m_pDS->eof() ? -1 : m_pDS->fv("idFile").get_asInt()};
+    m_pDS->close();
+
+    if (idFile >= 0)
+      GetEpisodesByFileId(idFile, episodes);
   }
   catch (...)
   {
@@ -4269,6 +4137,32 @@ std::string CVideoDatabase::GetFileBasePathById(int idFile)
   }
 
   return "";
+}
+
+std::string CVideoDatabase::GetFileAndPathById(int idFile)
+{
+  if (!m_pDB || !m_pDS || idFile < 0)
+    return {};
+
+  try
+  {
+    m_pDS->query(PrepareSQL("SELECT strPath, strFileName FROM path "
+                            "JOIN files ON path.idPath = files.idPath WHERE idFile = %i",
+                            idFile));
+
+    std::string fileAndPath;
+    if (!m_pDS->eof())
+      ConstructPath(fileAndPath, m_pDS->fv("strPath").get_asString(),
+                    m_pDS->fv("strFileName").get_asString());
+    m_pDS->close();
+    return fileAndPath;
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "failed for file {}", idFile);
+  }
+
+  return {};
 }
 
 int CVideoDatabase::GetFileIdByMovie(int idMovie)

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -496,6 +496,14 @@ public:
   bool EraseAllForFile(const std::string& fileNameAndPath);
 
   bool GetStackTimes(const std::string& filePath, std::vector<std::chrono::milliseconds>& times);
+
+  /*! \brief The stack times of a file, by its id rather than its path. A stack of discs is renamed
+   as each part is resolved to a playlist, so times recorded against a path would be left behind by
+   the entry they belong to.
+   */
+  bool GetStackTimes(int idFile, std::vector<std::chrono::milliseconds>& times);
+  void SetStackTimes(int idFile, const std::vector<std::chrono::milliseconds>& times);
+
   void SetStackTimes(const std::string& filePath,
                      const std::vector<std::chrono::milliseconds>& times);
 

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -356,20 +356,13 @@ public:
                            int idEpisode = -1);
 
   /*!
-   * @brief The FileInfo structure represents a DB record of the files table.
+   * \brief Rename an existing file record, keeping its idFile.
+   * \param idFile the file to rename.
+   * \param fileAndPath the path and filename to rename it to.
+   * \return true if the file was renamed (or already had that name), false if it could not be -
+   *         because several library items share it, or because another file already has that name.
    */
-  struct FileRecord
-  {
-    int m_idFile{-1};
-    int m_playCount{-1};
-    CDateTime m_lastPlayed{};
-    CDateTime m_dateAdded{};
-  };
-
-  int SetFileForMedia(const std::string& fileAndPath,
-                      VideoDbContentType type,
-                      int mediaId,
-                      const FileRecord& oldFile);
+  bool RenameFile(int idFile, const std::string& fileAndPath);
 
   int SetDetailsForMusicVideo(CVideoInfoTag& details,
                               const KODI::ART::Artwork& artwork,
@@ -391,6 +384,8 @@ public:
     int idFile{-1};
     VideoDbContentType mediaType{-1};
     int idMedia{-1};
+    int season{-1}; //!< Only set for episodes
+    int episode{-1}; //!< Only set for episodes
   };
 
   /*!
@@ -728,27 +723,16 @@ public:
                      const std::set<int>& paths = std::set<int>(),
                      bool showProgress = true);
 
-  enum class FileExistsAction
-  {
-    ACTION_NONE,
-    ACTION_UPDATE
-  };
-
-  int AddOrUpdateFile(const std::string& fileAndPath,
-                      const std::string& parentPath,
-                      const FileRecord& fileInfo,
-                      FileExistsAction existsAction);
-
   /*! \brief Add a file to the database, if necessary
    If the file is already in the database, we simply return its id.
-   \param url - full path of the file to add.
+   \param fileNameAndPath - full path of the file to add.
    \param parentPath the parent path of the path to add. If empty, URIUtils::GetParentPath() will determine the path.
    \param dateAdded datetime when the file was added to the filesystem/database
    \param playcount the playcount of the file to add.
    \param lastPlayed the date and time when the file to add was last played.
    \return id of the file, -1 if it could not be added.
    */
-  int AddFile(const std::string& url,
+  int AddFile(const std::string& fileNameAndPath,
               const std::string& parentPath = "",
               const CDateTime& dateAdded = CDateTime(),
               int playcount = 0,
@@ -1043,6 +1027,13 @@ public:
   std::string GetFileBasePathById(int idFile);
 
   /*!
+   * \brief Get the path and filename currently recorded for a file.
+   * \param idFile the file.
+   * \return the path and filename, or an empty string if there is no such file.
+   */
+  std::string GetFileAndPathById(int idFile);
+
+  /*!
    * @brief Check the passed in list of images if used in this database. Used to clean the image cache.
    * @param imagesToCheck
    * @return a list of the passed in images used by this database.
@@ -1181,13 +1172,6 @@ protected:
                              int min,
                              int max,
                              const T& offsets) const;
-
-  int SetFileForEpisode(const std::string& fileAndPath,
-                        int idEpisode,
-                        int oldIdFile,
-                        int newIdFile);
-  int SetFileForMovie(const std::string& fileAndPath, int idMovie, int oldIdFile, int newIdFile);
-  int SetFileForUnknown(const std::string& fileAndPath, int oldIdFile, int newIdFile);
 
 private:
   void CreateTables() override;

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -20,6 +20,7 @@
 #include "dbwrappers/dataset.h"
 #include "filesystem/File.h"
 #include "filesystem/MultiPathDirectory.h"
+#include "filesystem/StackDirectory.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
 #include "utils/DiscsUtils.h"
@@ -1446,8 +1447,8 @@ void CVideoDatabase::UpdateTables(int iVersion)
     std::map<std::string, int> pathMap;
     std::map<int, std::string> vacatedPaths;
 
-    // The path a select entry belongs under, adding it if the library hasn't got one yet
-    auto GetSelectPathId{
+    // The path an entry belongs under, adding it if the library hasn't got one yet
+    auto GetPathId{
         [&](const std::string& playlistPath)
         {
           if (const auto it{pathMap.find(playlistPath)}; it != pathMap.end())
@@ -1490,23 +1491,22 @@ void CVideoDatabase::UpdateTables(int iVersion)
           return idPath;
         }};
 
-    // The file already sitting where a select entry would go, or -1 where the way is clear. A
-    // select name belongs to the one title, so a file already holding it is that title and is
-    // used rather than a duplicate being created.
-    auto SelectFileTakenBy{[&](int idPath, const std::string& fileName, int idFile)
-                           {
-                             const int existing{GetSingleValueInt(
-                                 PrepareSQL("SELECT idFile FROM files WHERE idPath = %i AND "
-                                            "strFileName = '%s'",
-                                            idPath, fileName.c_str()))};
-                             return existing > 0 && existing != idFile ? existing : -1;
-                           }};
+    // The file already sitting where an entry would go, or -1 where the way is clear. A name
+    // belongs to the one title, so a file already holding it is that title and is used rather
+    // than a duplicate being created.
+    auto FileNameTakenBy{[&](int idPath, const std::string& fileName, int idFile)
+                         {
+                           const int existing{GetSingleValueInt(
+                               PrepareSQL("SELECT idFile FROM files WHERE idPath = %i AND "
+                                          "strFileName = '%s'",
+                                          idPath, fileName.c_str()))};
+                           return existing > 0 && existing != idFile ? existing : -1;
+                         }};
 
     // The file naming the bluray a library entry sits on, empty when the entry doesn't name one
     auto GetDiscFile{
-        [](const std::string& path, const std::string& fileName)
+        [](const std::string& file)
         {
-          const std::string file{URIUtils::AddFileToFolder(path, fileName)};
           if (URIUtils::IsBDFile(file))
             return file;
 
@@ -1544,7 +1544,8 @@ void CVideoDatabase::UpdateTables(int iVersion)
     m_pDS->query("SELECT DISTINCT f.idFile, f.idPath, p.strPath, f.strFileName, f.dateAdded "
                  "FROM files AS f "
                  "JOIN path AS p ON f.idPath = p.idPath "
-                 "JOIN episode AS e ON e.idFile = f.idFile");
+                 "JOIN episode AS e ON e.idFile = f.idFile "
+                 "WHERE f.strFileName NOT LIKE 'stack://%'");
     std::vector<std::tuple<int, int, std::string, std::string, std::string>> episodeFiles;
     while (!m_pDS->eof())
     {
@@ -1557,7 +1558,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
     for (const auto& [idFile, idOldPath, path, fileName, dateAdded] : episodeFiles)
     {
-      const std::string discFile{GetDiscFile(path, fileName)};
+      const std::string discFile{GetDiscFile(URIUtils::AddFileToFolder(path, fileName))};
       if (discFile.empty())
         continue;
 
@@ -1595,14 +1596,14 @@ void CVideoDatabase::UpdateTables(int iVersion)
         std::string fileNameNew;
         SplitSelectPath(discFile, season, episode, selectPath, fileNameNew);
 
-        const int idPath{GetSelectPathId(selectPath)};
+        const int idPath{GetPathId(selectPath)};
         if (idPath < 0)
           continue;
 
         // The episode's own file is already there, so it is moved onto it rather than the entry
         // being split into a name that is spoken for. Leaving it where it is would hand it to
         // whichever episode goes on to rename the shared entry.
-        if (const int existing{SelectFileTakenBy(idPath, fileNameNew, idFile)}; existing > 0)
+        if (const int existing{FileNameTakenBy(idPath, fileNameNew, idFile)}; existing > 0)
         {
           CLog::LogF(LOGDEBUG, "Moving episode {} of file {} to file {}, which already holds {}",
                      idEpisode, idFile, existing, fileNameNew);
@@ -1674,6 +1675,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
         "JOIN path AS p ON f.idPath = p.idPath "
         "WHERE f.idFile IN (SELECT idFile FROM movie UNION SELECT idFile FROM videoversion) "
         "AND f.idFile NOT IN (SELECT idFile FROM episode) "
+        "AND f.strFileName NOT LIKE 'stack://%' "
         "ORDER BY isMovie, f.idFile");
     std::vector<std::tuple<int, int, std::string, std::string>> movieFiles;
     while (!m_pDS->eof())
@@ -1686,7 +1688,7 @@ void CVideoDatabase::UpdateTables(int iVersion)
 
     for (const auto& [idFile, idOldPath, path, fileName] : movieFiles)
     {
-      const std::string discFile{GetDiscFile(path, fileName)};
+      const std::string discFile{GetDiscFile(URIUtils::AddFileToFolder(path, fileName))};
       if (discFile.empty())
         continue;
 
@@ -1694,11 +1696,11 @@ void CVideoDatabase::UpdateTables(int iVersion)
       std::string fileNameNew;
       SplitSelectPath(discFile, -1, -1, selectPath, fileNameNew);
 
-      const int idPath{GetSelectPathId(selectPath)};
+      const int idPath{GetPathId(selectPath)};
       if (idPath < 0)
         continue;
 
-      if (SelectFileTakenBy(idPath, fileNameNew, idFile) > 0)
+      if (FileNameTakenBy(idPath, fileNameNew, idFile) > 0)
       {
         CLog::LogF(LOGWARNING, "Not converting file {}, as {} is already taken", idFile,
                    fileNameNew);
@@ -1708,6 +1710,64 @@ void CVideoDatabase::UpdateTables(int iVersion)
       m_pDS2->exec(PrepareSQL("UPDATE files SET idPath = %i, strFileName = '%s' WHERE idFile = %i",
                               idPath, fileNameNew.c_str(), idFile));
       vacatedPaths.try_emplace(idOldPath, path);
+    }
+
+    // Stacks, where the whole stack is the one library item and so nothing is split - only the
+    // parts that name a disc are converted. A part is a disc in its own right, so it takes the
+    // plain select name whatever the stack holds.
+    m_pDS->query("SELECT DISTINCT f.idFile, f.strFileName "
+                 "FROM files AS f "
+                 "WHERE f.strFileName LIKE 'stack://%'");
+    std::vector<std::pair<int, std::string>> stackFiles;
+    while (!m_pDS->eof())
+    {
+      stackFiles.emplace_back(m_pDS->fv(0).get_asInt(), m_pDS->fv(1).get_asString());
+      m_pDS->next();
+    }
+    m_pDS->close();
+
+    for (const auto& [idFile, stackPath] : stackFiles)
+    {
+      std::vector<std::string> parts;
+      if (!CStackDirectory::GetPaths(stackPath, parts) || parts.empty())
+        continue;
+
+      bool converted{false};
+      for (std::string& part : parts)
+      {
+        const std::string discFile{GetDiscFile(part)};
+        if (discFile.empty())
+          continue;
+
+        std::string selectPath;
+        std::string selectFile;
+        SplitSelectPath(discFile, -1, -1, selectPath, selectFile);
+        part = URIUtils::AddFileToFolder(selectPath, selectFile);
+        converted = true;
+      }
+
+      std::string newStackPath;
+      if (!converted || !CStackDirectory::ConstructStackPath(parts, newStackPath))
+        continue;
+
+      // Held as a scan would hold it - the folder of the parts as the path, the whole stack as
+      // the name
+      std::string strPath;
+      std::string strFileName;
+      SplitPath(newStackPath, strPath, strFileName);
+
+      const int idPath{GetPathId(strPath)};
+      if (idPath < 0)
+        continue;
+
+      if (FileNameTakenBy(idPath, strFileName, idFile) > 0)
+      {
+        CLog::LogF(LOGWARNING, "Not converting stack of file {}, as it is already held", idFile);
+        continue;
+      }
+
+      m_pDS2->exec(PrepareSQL("UPDATE files SET idPath = %i, strFileName = '%s' WHERE idFile = %i",
+                              idPath, strFileName.c_str(), idFile));
     }
 
     // The entries have moved to bluray:// paths, leaving the disc's own BDMV folder holding

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -18,9 +18,11 @@
 #include "URL.h"
 #include "VideoDatabase.h"
 #include "dbwrappers/dataset.h"
+#include "filesystem/File.h"
 #include "filesystem/MultiPathDirectory.h"
 #include "resources/LocalizeStrings.h"
 #include "resources/ResourcesComponent.h"
+#include "utils/DiscsUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/i18n/TableLanguageCodes.h"
@@ -1425,9 +1427,319 @@ void CVideoDatabase::UpdateTables(int iVersion)
     m_pDS->exec("ALTER TABLE streamdetails ADD iSource INTEGER DEFAULT 40");
     m_pDS->exec("ALTER TABLE streamdetails ADD iVersion INTEGER DEFAULT 1");
   }
+
+  if (iVersion < 149)
+  {
+    // A title on a bluray was recorded under the disc's own index (index.bdmv, or the image
+    // holding one), which every title on that disc shared. Each is moved to a select entry of its
+    // own - select for a movie and select-<season>-<episode> per episode - so that a title has a
+    // file, and so a bookmark, stream details and a play count, that belong to it alone.
+    // Episodes already played have a playlist of their own and so no longer share the index entry;
+    // it survives only while at least one title still refers to it, so those still found here are
+    // exactly the ones left to convert.
+    constexpr int LOCAL_VIDEODB_ID_PARENTPATHID = 23;
+    constexpr int LOCAL_VIDEODB_ID_EPISODE_SEASON = 12;
+    constexpr int LOCAL_VIDEODB_ID_EPISODE_EPISODE = 13;
+    constexpr int LOCAL_VIDEODB_ID_EPISODE_BOOKMARK = 17;
+    constexpr int LOCAL_VIDEODB_ID_EPISODE_PARENTPATHID = 19;
+
+    std::map<std::string, int> pathMap;
+    std::map<int, std::string> vacatedPaths;
+
+    // The path a select entry belongs under, adding it if the library hasn't got one yet
+    auto GetSelectPathId{
+        [&](const std::string& playlistPath)
+        {
+          if (const auto it{pathMap.find(playlistPath)}; it != pathMap.end())
+            return it->second;
+
+          int idPath{-1};
+          m_pDS2->query(
+              PrepareSQL("SELECT idPath FROM path WHERE strPath = '%s'", playlistPath.c_str()));
+          if (!m_pDS2->eof())
+            idPath = m_pDS2->fv(0).get_asInt();
+          m_pDS2->close();
+
+          if (idPath < 0)
+          {
+            // Held as AddPath holds it, so that a converted entry's path is indistinguishable
+            // from one a scan would have made - the parent is recorded only where the library
+            // already has it, and is never added on its behalf
+            int idParentPath{-1};
+            if (const std::string parentPath{URIUtils::GetParentPath(playlistPath)};
+                !parentPath.empty())
+            {
+              m_pDS2->query(
+                  PrepareSQL("SELECT idPath FROM path WHERE strPath = '%s'", parentPath.c_str()));
+              if (!m_pDS2->eof())
+                idParentPath = m_pDS2->fv(0).get_asInt();
+              m_pDS2->close();
+            }
+
+            if (idParentPath >= 0)
+              m_pDS2->exec(PrepareSQL("INSERT INTO path (idPath, strPath, idParentPath) VALUES "
+                                      "(NULL, '%s', %i)",
+                                      playlistPath.c_str(), idParentPath));
+            else
+              m_pDS2->exec(PrepareSQL("INSERT INTO path (idPath, strPath) VALUES (NULL, '%s')",
+                                      playlistPath.c_str()));
+            idPath = static_cast<int>(m_pDS2->lastinsertid());
+          }
+
+          pathMap[playlistPath] = idPath;
+          return idPath;
+        }};
+
+    // The file already sitting where a select entry would go, or -1 where the way is clear. A
+    // select name belongs to the one title, so a file already holding it is that title and is
+    // used rather than a duplicate being created.
+    auto SelectFileTakenBy{[&](int idPath, const std::string& fileName, int idFile)
+                           {
+                             const int existing{GetSingleValueInt(
+                                 PrepareSQL("SELECT idFile FROM files WHERE idPath = %i AND "
+                                            "strFileName = '%s'",
+                                            idPath, fileName.c_str()))};
+                             return existing > 0 && existing != idFile ? existing : -1;
+                           }};
+
+    // The file naming the bluray a library entry sits on, empty when the entry doesn't name one
+    auto GetDiscFile{
+        [](const std::string& path, const std::string& fileName)
+        {
+          const std::string file{URIUtils::AddFileToFolder(path, fileName)};
+          if (URIUtils::IsBDFile(file))
+            return file;
+
+          // An image has to be read to tell what it holds, and one holding no bluray - a DVD, as
+          // a rule - is left alone with nothing to say about it.
+          if (URIUtils::IsDiscImage(file))
+          {
+            if (UTILS::DISCS::IsBlurayDiscImage(file))
+              return file;
+
+            // Reading it needs the media to hand, so an image on a share that is offline while
+            // the library is upgraded cannot be told apart from one holding no bluray, and is
+            // left as it is. The entry still names the image and so still plays, but the titles
+            // on it keep sharing the one entry, and as the upgrade runs once it is never looked
+            // at again - hence the warning naming what was passed over.
+            if (!XFILE::CFile::Exists(file))
+              CLog::LogF(LOGWARNING,
+                         "Leaving {} as it is, as it could not be read to tell whether it holds a "
+                         "bluray",
+                         CURL::GetRedacted(file));
+          }
+
+          return std::string{};
+        }};
+
+    // The path and name a title on a disc is held under, until a playlist has been chosen for it
+    auto SplitSelectPath{[](const std::string& discFile, int season, int episode,
+                            std::string& selectPath, std::string& selectFile)
+                         {
+                           URIUtils::Split(URIUtils::GetBluraySelectPath(discFile, season, episode),
+                                           selectPath, selectFile);
+                         }};
+
+    // Episodes first, as a disc entry shared by several of them is split rather than renamed
+    m_pDS->query("SELECT DISTINCT f.idFile, f.idPath, p.strPath, f.strFileName, f.dateAdded "
+                 "FROM files AS f "
+                 "JOIN path AS p ON f.idPath = p.idPath "
+                 "JOIN episode AS e ON e.idFile = f.idFile");
+    std::vector<std::tuple<int, int, std::string, std::string, std::string>> episodeFiles;
+    while (!m_pDS->eof())
+    {
+      episodeFiles.emplace_back(m_pDS->fv(0).get_asInt(), m_pDS->fv(1).get_asInt(),
+                                m_pDS->fv(2).get_asString(), m_pDS->fv(3).get_asString(),
+                                m_pDS->fv(4).get_asString());
+      m_pDS->next();
+    }
+    m_pDS->close();
+
+    for (const auto& [idFile, idOldPath, path, fileName, dateAdded] : episodeFiles)
+    {
+      const std::string discFile{GetDiscFile(path, fileName)};
+      if (discFile.empty())
+        continue;
+
+      m_pDS->query(PrepareSQL("SELECT idEpisode, c%02d, c%02d FROM episode WHERE idFile = %i "
+                              "ORDER BY CAST(c%02d AS integer), CAST(c%02d AS integer)",
+                              LOCAL_VIDEODB_ID_EPISODE_SEASON, LOCAL_VIDEODB_ID_EPISODE_EPISODE,
+                              idFile, LOCAL_VIDEODB_ID_EPISODE_SEASON,
+                              LOCAL_VIDEODB_ID_EPISODE_EPISODE));
+      std::vector<std::tuple<int, int, int>> episodes;
+      while (!m_pDS->eof())
+      {
+        episodes.emplace_back(m_pDS->fv(0).get_asInt(), m_pDS->fv(1).get_asInt(),
+                              m_pDS->fv(2).get_asInt());
+        m_pDS->next();
+      }
+      m_pDS->close();
+
+      // Everything the entry holds of what has been watched and what the disc looks like
+      auto DropFileState{
+          [&](int id)
+          {
+            m_pDS2->exec(PrepareSQL("DELETE FROM bookmark WHERE idFile = %i", id));
+            m_pDS2->exec(PrepareSQL("DELETE FROM settings WHERE idFile = %i", id));
+            m_pDS2->exec(PrepareSQL("DELETE FROM streamdetails WHERE idFile = %i", id));
+            m_pDS2->exec(PrepareSQL("DELETE FROM stacktimes WHERE idFile = %i", id));
+            m_pDS2->exec(PrepareSQL("UPDATE files SET playCount = NULL, "
+                                    "lastPlayed = NULL WHERE idFile = %i",
+                                    id));
+          }};
+
+      bool first{true};
+      for (const auto& [idEpisode, season, episode] : episodes)
+      {
+        std::string selectPath;
+        std::string fileNameNew;
+        SplitSelectPath(discFile, season, episode, selectPath, fileNameNew);
+
+        const int idPath{GetSelectPathId(selectPath)};
+        if (idPath < 0)
+          continue;
+
+        // The episode's own file is already there, so it is moved onto it rather than the entry
+        // being split into a name that is spoken for. Leaving it where it is would hand it to
+        // whichever episode goes on to rename the shared entry.
+        if (const int existing{SelectFileTakenBy(idPath, fileNameNew, idFile)}; existing > 0)
+        {
+          CLog::LogF(LOGDEBUG, "Moving episode {} of file {} to file {}, which already holds {}",
+                     idEpisode, idFile, existing, fileNameNew);
+          m_pDS2->exec(PrepareSQL("UPDATE episode SET idFile = %i WHERE idEpisode = %i", existing,
+                                  idEpisode));
+          continue;
+        }
+
+        if (first)
+        {
+          // The entry itself becomes the first episode, so that an idFile anything outside the
+          // library may have recorded still names something
+          m_pDS2->exec(PrepareSQL("UPDATE files SET idPath = %i, strFileName = '%s' WHERE "
+                                  "idFile = %i",
+                                  idPath, fileNameNew.c_str(), idFile));
+          vacatedPaths.try_emplace(idOldPath, path);
+          first = false;
+        }
+        else
+        {
+          m_pDS2->exec(PrepareSQL("INSERT INTO files (idFile, idPath, strFileName, dateAdded) "
+                                  "VALUES (NULL, %i, '%s', '%s')",
+                                  idPath, fileNameNew.c_str(), dateAdded.c_str()));
+          m_pDS2->exec(PrepareSQL("UPDATE episode SET idFile = %i WHERE idEpisode = %i",
+                                  static_cast<int>(m_pDS2->lastinsertid()), idEpisode));
+        }
+      }
+
+      const bool inUse{
+          GetSingleValueInt(PrepareSQL("SELECT COUNT(1) FROM episode WHERE idFile = %i", idFile)) >
+              0 ||
+          GetSingleValueInt(PrepareSQL("SELECT COUNT(1) FROM movie WHERE idFile = %i", idFile)) >
+              0 ||
+          GetSingleValueInt(
+              PrepareSQL("SELECT COUNT(1) FROM videoversion WHERE idFile = %i", idFile)) > 0};
+
+      if (!inUse)
+      {
+        // Every episode went onto a file of its own elsewhere, so the entry names the disc and
+        // nothing else. It is dropped rather than left behind as an index nothing refers to,
+        // taking what it held with it.
+        DropFileState(idFile);
+        m_pDS2->exec(PrepareSQL("DELETE FROM files WHERE idFile = %i", idFile));
+        vacatedPaths.try_emplace(idOldPath, path);
+      }
+      else if (episodes.size() > 1 && !first)
+      {
+        // Several episodes shared the entry, so what it held was recorded against the disc rather
+        // than any one title on it and can't be said to belong to an episode. It is dropped, the
+        // episode bookmarks with it, as each episode is now a title in its own right rather than
+        // an offset into a shared one.
+        // A disc holding a single episode is that episode, so there is nothing to tell apart and
+        // its bookmark, play count and stream details are kept, just as a movie's are - the entry
+        // is only renamed.
+        DropFileState(idFile);
+        for (const auto& idEpisode : episodes | std::views::elements<0>)
+          m_pDS2->exec(PrepareSQL("UPDATE episode SET c%02d = '-1' WHERE idEpisode = %i",
+                                  LOCAL_VIDEODB_ID_EPISODE_BOOKMARK, idEpisode));
+      }
+    }
+
+    // Movies, where the entry belongs to the one title and so is simply renamed. The movie itself
+    // is taken before any extra of it, as both would want the disc's plain select name and only
+    // the first to ask can have it.
+    m_pDS->query(
+        "SELECT DISTINCT f.idFile, f.idPath, p.strPath, f.strFileName, "
+        "CASE WHEN f.idFile IN (SELECT idFile FROM movie) THEN 0 ELSE 1 END AS isMovie "
+        "FROM files AS f "
+        "JOIN path AS p ON f.idPath = p.idPath "
+        "WHERE f.idFile IN (SELECT idFile FROM movie UNION SELECT idFile FROM videoversion) "
+        "AND f.idFile NOT IN (SELECT idFile FROM episode) "
+        "ORDER BY isMovie, f.idFile");
+    std::vector<std::tuple<int, int, std::string, std::string>> movieFiles;
+    while (!m_pDS->eof())
+    {
+      movieFiles.emplace_back(m_pDS->fv(0).get_asInt(), m_pDS->fv(1).get_asInt(),
+                              m_pDS->fv(2).get_asString(), m_pDS->fv(3).get_asString());
+      m_pDS->next();
+    }
+    m_pDS->close();
+
+    for (const auto& [idFile, idOldPath, path, fileName] : movieFiles)
+    {
+      const std::string discFile{GetDiscFile(path, fileName)};
+      if (discFile.empty())
+        continue;
+
+      std::string selectPath;
+      std::string fileNameNew;
+      SplitSelectPath(discFile, -1, -1, selectPath, fileNameNew);
+
+      const int idPath{GetSelectPathId(selectPath)};
+      if (idPath < 0)
+        continue;
+
+      if (SelectFileTakenBy(idPath, fileNameNew, idFile) > 0)
+      {
+        CLog::LogF(LOGWARNING, "Not converting file {}, as {} is already taken", idFile,
+                   fileNameNew);
+        continue;
+      }
+
+      m_pDS2->exec(PrepareSQL("UPDATE files SET idPath = %i, strFileName = '%s' WHERE idFile = %i",
+                              idPath, fileNameNew.c_str(), idFile));
+      vacatedPaths.try_emplace(idOldPath, path);
+    }
+
+    // The entries have moved to bluray:// paths, leaving the disc's own BDMV folder holding
+    // nothing. A scan of the same library from scratch never creates one, so it is removed - but
+    // only where nothing at all still refers to it. The folder holding a disc image is an ordinary
+    // library folder, which a scan does create, so that is left alone.
+    for (const auto& [idPath, path] : vacatedPaths)
+    {
+      std::string folder{path};
+      URIUtils::RemoveSlashAtEnd(folder);
+      folder = URIUtils::GetFileName(folder);
+      if (!StringUtils::EqualsNoCase(folder, "BDMV"))
+        continue;
+
+      if (GetSingleValueInt(PrepareSQL("SELECT COUNT(1) FROM files WHERE idPath = %i", idPath)) >
+              0 ||
+          GetSingleValueInt(
+              PrepareSQL("SELECT COUNT(1) FROM path WHERE idParentPath = %i", idPath)) > 0 ||
+          GetSingleValueInt(
+              PrepareSQL("SELECT COUNT(1) FROM tvshowlinkpath WHERE idPath = %i", idPath)) > 0 ||
+          GetSingleValueInt(PrepareSQL("SELECT COUNT(1) FROM movie WHERE c%02d = %i",
+                                       LOCAL_VIDEODB_ID_PARENTPATHID, idPath)) > 0 ||
+          GetSingleValueInt(PrepareSQL("SELECT COUNT(1) FROM episode WHERE c%02d = %i",
+                                       LOCAL_VIDEODB_ID_EPISODE_PARENTPATHID, idPath)) > 0)
+        continue;
+
+      m_pDS2->exec(PrepareSQL("DELETE FROM path WHERE idPath = %i", idPath));
+    }
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 148;
+  return 149;
 }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1226,16 +1226,21 @@ CVideoInfoScanner::~CVideoInfoScanner()
                                                          std::chrono::milliseconds{0});
     CStreamDetails streamDetails;
     int totalDuration{0};
-    size_t blurays{0};
+    size_t blurays{0}; // Parts resolved to a playlist, the first of which describes the streams
+    size_t discs{0}; // Parts naming a disc, whether resolved to a playlist or not
 
     for (size_t partIndex{0}; const std::string& path : paths)
     {
       const size_t part{partIndex++};
 
-      // Only resolve blurays
+      // Only blurays are resolved
       if (!IsBluray(path))
       {
-        fileParts.emplace_back(part);
+        // A part naming a disc of another kind has no duration to be had - reading one needs a
+        // player to answer the disc's navigation commands, and CDVDFileInfo::GetFileDuration has
+        // none - so it is left unknown rather than asked for
+        if (!URIUtils::IsDiscImage(path) && !URIUtils::IsDVDFile(path))
+          fileParts.emplace_back(part);
         playlistPaths.emplace_back(path);
         continue;
       }
@@ -1249,9 +1254,13 @@ CVideoInfoScanner::~CVideoInfoScanner()
       ResolveBlurayPlaylist(&partItem, partItems);
       if (partItems.IsEmpty())
       {
-        CLog::LogF(LOGERROR, "Unable to resolve a bluray playlist for {} of {}",
+        // A playlist is chosen when the part is first played, so until then it is named by a
+        // select path rather than by the disc that every title on it shares
+        CLog::LogF(LOGDEBUG, "No bluray playlist could be determined for {} of {} yet",
                    CURL::GetRedacted(path), CURL::GetRedacted(originalPath));
-        playlistPaths.emplace_back(path);
+        const std::string selectPath{URIUtils::GetBluraySelectPath(path)};
+        playlistPaths.emplace_back(selectPath.empty() ? path : selectPath);
+        ++discs;
         continue;
       }
 
@@ -1265,11 +1274,12 @@ CVideoInfoScanner::~CVideoInfoScanner()
       partDurations[part] = std::chrono::seconds{partDuration};
 
       ++blurays;
+      ++discs;
       playlistPaths.emplace_back(partItem.GetDynPath());
     }
 
-    // Not a stack of blurays at all, so there is nothing to do
-    if (blurays == 0)
+    // Not a stack of discs at all, so there is nothing to do
+    if (discs == 0)
       return false;
 
     // Durations of any plain file members

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2137,6 +2137,24 @@ CVideoInfoScanner::~CVideoInfoScanner()
       art["thumb"] = "";
 
     CVideoInfoTag &movieDetails = *pItem->GetVideoInfoTag();
+
+    // A disc whose playlist couldn't be determined is recorded under a 'select' path rather than
+    // the index.bdmv (or ISO) shared by everything on the disc.
+    if (!pItem->IsFolder() && (content == ContentType::MOVIES || content == ContentType::TVSHOWS) &&
+        (::UTILS::DISCS::IsBlurayDiscImage(path) || URIUtils::IsBDFile(path)))
+    {
+      const bool isEpisode{content == ContentType::TVSHOWS};
+      if (const std::string selectPath{
+              isEpisode ? URIUtils::GetBluraySelectPath(path, movieDetails.m_iSeason,
+                                                        movieDetails.m_iEpisode)
+                        : URIUtils::GetBluraySelectPath(path)};
+          !selectPath.empty())
+      {
+        path = selectPath;
+        pItem->SetDynPath(path);
+      }
+    }
+
     if (movieDetails.m_basePath.empty())
       movieDetails.m_basePath = pItem->GetBaseMoviePath(videoFolder);
     movieDetails.m_parentPathID =

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -218,8 +218,10 @@ bool CGUIDialogVideoManagerVersions::AddVideoVersion()
 
   if (m_selectedVideoAsset && m_selectedVideoAsset->IsBluray())
   {
-    // First see if the existing video asset has a playlist
-    if (!URIUtils::IsBlurayPath(m_selectedVideoAsset->GetDynPath()))
+    // First see if the existing video asset has a playlist. A select path is a bluray:// path but
+    // stands in for a title whose playlist has yet to be chosen, so it counts as having none.
+    if (!URIUtils::IsBlurayPath(m_selectedVideoAsset->GetDynPath()) ||
+        URIUtils::IsBluraySelectPath(m_selectedVideoAsset->GetDynPath()))
     {
       const int dlgResult{CGUIDialogYesNo::ShowAndGetInput(CVariant{40030}, CVariant{40041})};
       if (dlgResult == CGUIDialogYesNo::DIALOG_RESULT_YES &&
@@ -387,11 +389,8 @@ bool CGUIDialogVideoManagerVersions::ChoosePlaylist(const std::shared_ptr<CFileI
     m_database.BeginTransaction();
     if (replaceExistingFile == ReplaceExistingFile::YES)
     {
-      idFile = m_database.SetFileForMedia(
-          item->GetDynPath(), item->GetVideoContentType(), item->GetVideoInfoTag()->m_iDbId,
-          CVideoDatabase::FileRecord{.m_idFile = item->GetVideoInfoTag()->m_iFileId,
-                                     .m_dateAdded = item->GetVideoInfoTag()->m_dateAdded});
-      videoDbSuccess = idFile > 0;
+      idFile = item->GetVideoInfoTag()->m_iFileId;
+      videoDbSuccess = m_database.RenameFile(idFile, item->GetDynPath());
       if (videoDbSuccess)
       {
         m_database.SetStreamDetailsForFile(item->GetVideoInfoTag()->m_streamDetails,
@@ -440,7 +439,7 @@ bool CGUIDialogVideoManagerVersions::ChoosePlaylist(const std::shared_ptr<CFileI
         RemovePartNumberFromTitle(m_videoAsset->GetVideoInfoTag()->m_iDbId,
                                   m_videoAsset->GetVideoContentType(), m_database);
 
-      // New disc video version will not have any art so use the art from the disc
+      // Take the art from the disc
       m_database.SetArtForItem(idFile, MediaTypeVideoVersion, item->GetArt());
 
       m_database.CommitTransaction();
@@ -970,11 +969,13 @@ bool CGUIDialogVideoManagerVersions::AddSimilarMovieAsVersion(
     return false;
   }
 
-  // Choose playlist for blurays, unless one has already been determined
+  // Choose playlist for blurays, unless one has already been determined. A select path is a
+  // bluray:// path but stands in for a title whose playlist has yet to be chosen.
   DeleteMovieCascadeAction cascadeAction{DeleteMovieCascadeAction::ALL_ASSETS};
   if (itemMovie->IsBluray())
   {
-    if (!URIUtils::IsBlurayPath(itemMovie->GetDynPath()) &&
+    if ((!URIUtils::IsBlurayPath(itemMovie->GetDynPath()) ||
+         URIUtils::IsBluraySelectPath(itemMovie->GetDynPath())) &&
         !ChoosePlaylist(itemMovie, ReplaceExistingFile::YES))
       return false;
     cascadeAction = DeleteMovieCascadeAction::ALL_ASSETS_NOT_STREAMDETAILS;

--- a/xbmc/video/test/TestStacks.cpp
+++ b/xbmc/video/test/TestStacks.cpp
@@ -221,22 +221,36 @@ TEST_F(TestStacks, TestStackIsNotItselfADiscImage)
 {
   // A stack of .ISOs must not be classified from its tail either - otherwise it takes the disc
   // branch in eg. CVideoDatabase::GetMovieId/GetVideoVersionsByPath, which asks for a bluray://
-  // playlist path that a container cannot have. Use IsDiscImageStack() to spot these instead
+  // playlist path that a container cannot have
   const std::string isoStack{R"(stack://D:\Movies\Movie.CD1.iso , D:\Movies\Movie.CD2.iso)"};
 
   EXPECT_FALSE(URIUtils::IsDiscImage(isoStack));
   EXPECT_FALSE(CURL(isoStack).IsDiscImage());
   EXPECT_FALSE(CFileItem(isoStack, false).IsDiscImage());
 
-  // The stack as a whole is still recognised as one holding disc parts..
-  EXPECT_TRUE(URIUtils::IsDiscImageStack(isoStack));
-
-  // ..and the individual members are still disc images
+  // The individual members are still disc images
   std::vector<std::string> paths;
   CStackDirectory::GetPaths(isoStack, paths);
   ASSERT_EQ(paths.size(), 2U);
   EXPECT_TRUE(URIUtils::IsDiscImage(paths[0]));
   EXPECT_TRUE(URIUtils::IsDiscImage(paths[1]));
+
+  // A stack is waiting for a playlist while any part still names a disc rather than a title on
+  // it - whether the library has scanned it, and so named the title with a select path, or it is
+  // being played from outside the library and still names the disc itself
+  EXPECT_TRUE(URIUtils::IsUnresolvedDiscStack(isoStack));
+  EXPECT_TRUE(URIUtils::IsUnresolvedDiscStack(
+      R"(stack://bluray://D%3a%5cMovies%5cCD1%5c/BDMV/PLAYLIST/select , )"
+      R"(bluray://D%3a%5cMovies%5cCD2%5c/BDMV/PLAYLIST/select)"));
+  EXPECT_TRUE(URIUtils::IsUnresolvedDiscStack(
+      R"(stack://D:\Movies\CD1\VIDEO_TS\VIDEO_TS.IFO , D:\Movies\CD2\VIDEO_TS\VIDEO_TS.IFO)"));
+  EXPECT_TRUE(URIUtils::IsUnresolvedDiscStack(
+      R"(stack://D:\Movies\CD1\BDMV\index.bdmv , D:\Movies\CD2\BDMV\index.bdmv)"));
+
+  // A stack whose parts have been resolved to playlists is not waiting for anything
+  EXPECT_FALSE(URIUtils::IsUnresolvedDiscStack(
+      R"(stack://bluray://D%3a%5cMovies%5cCD1%5c/BDMV/PLAYLIST/00800.mpls , )"
+      R"(bluray://D%3a%5cMovies%5cCD2%5c/BDMV/PLAYLIST/00800.mpls)"));
 
   // A single .ISO is unaffected
   EXPECT_TRUE(URIUtils::IsDiscImage(R"(D:\Movies\Movie.iso)"));


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Read context first...

Give each media entity on the disc identifiable at scrape time (ie. each episode) a unique idFile at that point. Then it just needs renaming (ie. from a generic bluray:// entry to a bluray://xxx//0000.mpls).

This actually simplifies a chunk of code in VideoDatabase to do with the allocation of new idFiles. I've used Claude to write and test a PR that does this. There are really two parts - the retrospective updating of existing databases to generate bluray:// and dvd:// entries for existing index.bdmv/video_ts.ifo/.iso files. The prospective part is the adding them at scrape time.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix for #28807.

Background - in v21 - each disc only had a single index.bdmv or .iso entry in the file table. For episodes in particular, this meant that when you watched one (even when selecting a playlist through the simple menu), every episode on the disc showed the same progress bar, had the same streamdeatils and same bookmark. The same can still be seen for DVDs today.

Since https://github.com/xbmc/xbmc/pull/24720 - 2 years ago - this was fixed by allocating each episode a new idFile entry when watched - saving the playlist and the associated bookmark etc.. so this didn't happen. When the last unwatched episode was watched the index.bdmv/.iso file entry was deleted.

This is all transparent to the user.

It has never been an issue until - https://github.com/xbmc/xbmc/issues/28807 - which suggested it may break some plugins. Although this is the only report I've ever seen, we're still in alpha/beta - so I don't know how much the plugin authors look at what we are doing etc..

This then leads to an important question:

Is this going to be an issue??

We never document or contract that our internals will behave in a certain way. Is this even our problem??
BUT, if this is going to be a breaking issue - this leads to a second question

What do we want to do about it, and when do we want to do it??

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
