### PR TITLE
fixed: job manager stalls when a callback blocks, and CancelJobs' lock scope for queued jobs

### DIFF
--- a/xbmc/jobs/JobManager.cpp
+++ b/xbmc/jobs/JobManager.cpp
@@ -103,33 +103,40 @@ void CJobManager::Restart()
 
 void CJobManager::CancelJobs()
 {
-  std::unique_lock lock(m_section);
-  m_running = false;
+  Processing pending;
 
-  // clear any pending jobs
-  for (unsigned int priority = CJob::PRIORITY_LOW_PAUSABLE; priority <= CJob::PRIORITY_DEDICATED;
-       ++priority)
   {
-    std::ranges::for_each(m_jobQueue[priority],
+    std::unique_lock lock(m_section);
+    m_running = false;
+
+    for (auto& queue : m_jobQueue)
+    {
+      for (auto& wi : queue)
+        pending.emplace_back(std::move(wi));
+      queue.clear();
+    }
+
+    // These stay under the lock: the job is owned by its worker, which may complete and
+    // free it the moment the lock is released.
+    std::ranges::for_each(m_processing,
                           [](CWorkItem& wi)
                           {
                             for (auto* callback : wi.GetCallbacks())
                               callback->OnJobAbort(wi.GetId(), wi.GetJob());
-                            wi.FreeJob();
+                            wi.Cancel();
                           });
-    m_jobQueue[priority].clear();
   }
 
-  // cancel any callbacks on jobs still processing
-  std::ranges::for_each(m_processing,
+  std::ranges::for_each(pending,
                         [](CWorkItem& wi)
                         {
                           for (auto* callback : wi.GetCallbacks())
                             callback->OnJobAbort(wi.GetId(), wi.GetJob());
-                          wi.Cancel();
+                          wi.FreeJob();
                         });
 
   // tell our workers to finish
+  std::unique_lock lock(m_section);
   while (!m_workers.empty())
   {
     lock.unlock();
@@ -215,15 +222,21 @@ void CJobManager::StartWorkers(CJob::PRIORITY priority)
   std::unique_lock lock(m_section);
 
   // check how many free threads we have
-  if (m_processing.size() >= GetMaxWorkers(priority))
+  if (GetBusyCount() >= GetMaxWorkers(priority))
     return;
 
   // do we have any sleeping threads?
-  if (m_processing.size() < m_workers.size())
+  if (m_idleWorkers > 0)
   {
     m_jobEvent.Set();
     return;
   }
+
+  // Bounds the pool. A worker in neither count is starting up or returning from a callback and
+  // will take a queued job; one that has timed out but not yet removed itself will not, which is
+  // a known gap.
+  if (m_workers.size() >= GetMaxWorkers(priority))
+    return;
 
   // everyone is busy - we need more workers
   m_workers.emplace_back(new CJobWorker(*this));
@@ -238,8 +251,7 @@ CJob* CJobManager::PopJob()
     if (priority == CJob::PRIORITY_LOW_PAUSABLE && m_pauseJobs)
       continue;
 
-    if (!m_jobQueue[priority].empty() &&
-        m_processing.size() < GetMaxWorkers(CJob::PRIORITY(priority)))
+    if (!m_jobQueue[priority].empty() && GetBusyCount() < GetMaxWorkers(CJob::PRIORITY(priority)))
     {
       // pop the job off the queue
       const CWorkItem job{m_jobQueue[priority].front()};
@@ -300,9 +312,11 @@ CJob* CJobManager::GetNextJob()
     if (job)
       return job;
     // no jobs are left - sleep for 30 seconds to allow new jobs to come in
+    ++m_idleWorkers;
     lock.unlock();
     bool newJob = m_jobEvent.Wait(30000ms);
     lock.lock();
+    --m_idleWorkers;
     if (!newJob)
       break;
   }
@@ -343,6 +357,7 @@ void CJobManager::OnJobComplete(bool success, CJob* job)
       // when another thread modifies m_processing during callback execution
       item.emplace(std::move(*i));
       m_processing.erase(i);
+      ++m_completing;
     }
     return item;
   }();
@@ -385,6 +400,9 @@ void CJobManager::OnJobComplete(bool success, CJob* job)
     }
 
     item->FreeJob();
+
+    std::unique_lock lock(m_section);
+    --m_completing;
   }
 }
 

--- a/xbmc/jobs/JobManager.h
+++ b/xbmc/jobs/JobManager.h
@@ -226,6 +226,11 @@ private:
    */
   CJob* PopJob();
 
+  /*! \brief Workers that are unavailable: running a job, or still in its callbacks.
+   Must be called with m_section held.
+   */
+  size_t GetBusyCount() const { return m_processing.size() + m_completing; }
+
   void StartWorkers(CJob::PRIORITY priority);
   void RemoveWorker(const CJobWorker* worker);
   static unsigned int GetMaxWorkers(CJob::PRIORITY priority);
@@ -239,7 +244,10 @@ private:
   std::array<JobQueue, CJob::PRIORITY_DEDICATED + 1> m_jobQueue;
   bool m_pauseJobs{false};
   Processing m_processing;
+  size_t m_completing{0};
   Workers m_workers;
+  // Incremented only across the m_jobEvent wait, always under m_section.
+  size_t m_idleWorkers{0};
 
   mutable CCriticalSection m_section;
   CEvent m_jobEvent;

--- a/xbmc/utils/test/TestJobManager.cpp
+++ b/xbmc/utils/test/TestJobManager.cpp
@@ -7,13 +7,16 @@
  */
 
 #include "ServiceBroker.h"
+#include "jobs/IJobCallback.h"
 #include "jobs/Job.h"
 #include "jobs/JobManager.h"
 #include "test/MtTestUtils.h"
 #include "utils/XTimeUtils.h"
 
 #include <atomic>
+#include <chrono>
 #include <mutex>
+#include <thread>
 
 #include <gtest/gtest.h>
 
@@ -210,4 +213,137 @@ TEST_F(TestJobManager, IsProcessing)
   EXPECT_EQ(0, CServiceBroker::GetJobManager()->IsProcessing(""));
 
   job->FinishAndStopBlocking();
+}
+
+namespace
+{
+class BlockingCallback : public IJobCallback
+{
+public:
+  ~BlockingCallback() override { Release(); }
+
+  void OnJobComplete(unsigned int jobID, bool success, CJob* job) override { Block(); }
+
+  void OnJobAbort(unsigned int jobID, CJob* job) override { Block(); }
+
+  bool HasEntered() const { return m_entered; }
+
+  void Release()
+  {
+    m_blocked = false;
+    while (m_entered && !m_exited)
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+private:
+  void Block()
+  {
+    m_entered = true;
+    while (m_blocked)
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    m_exited = true;
+  }
+
+  std::atomic<bool> m_blocked{true};
+  std::atomic<bool> m_entered{false};
+  std::atomic<bool> m_exited{false};
+};
+
+unsigned int AddDumbJob(Flags& flags, IJobCallback* callback, CJob::PRIORITY priority)
+{
+  return CServiceBroker::GetJobManager()->AddJob(new ReallyDumbJob(&flags), callback, priority);
+}
+} // namespace
+
+TEST_F(TestJobManager, BlockedCallbackDoesNotStallOtherJobs)
+{
+  BlockingCallback callback;
+  Flags blockedFlags;
+  AddDumbJob(blockedFlags, &callback, CJob::PRIORITY_NORMAL);
+  ASSERT_TRUE(poll([&callback]() { return callback.HasEntered(); }));
+
+  Flags flags;
+  AddDumbJob(flags, nullptr, CJob::PRIORITY_NORMAL);
+  EXPECT_TRUE(poll([&flags]() { return flags.finished.load(); }));
+
+  callback.Release();
+}
+
+TEST_F(TestJobManager, BlockedCallbackDoesNotStallDedicatedJobs)
+{
+  BlockingCallback callback;
+  Flags blockedFlags;
+  AddDumbJob(blockedFlags, &callback, CJob::PRIORITY_NORMAL);
+  ASSERT_TRUE(poll([&callback]() { return callback.HasEntered(); }));
+
+  Flags flags;
+  AddDumbJob(flags, nullptr, CJob::PRIORITY_DEDICATED);
+  EXPECT_TRUE(poll([&flags]() { return flags.finished.load(); }));
+
+  callback.Release();
+}
+
+TEST_F(TestJobManager, CallbacksCountTowardsTheConcurrencyLimit)
+{
+  BlockingCallback firstCallback;
+  BlockingCallback secondCallback;
+  Flags firstFlags;
+  Flags secondFlags;
+
+  AddDumbJob(firstFlags, &firstCallback, CJob::PRIORITY_LOW_PAUSABLE);
+  ASSERT_TRUE(poll([&firstCallback]() { return firstCallback.HasEntered(); }));
+  AddDumbJob(secondFlags, &secondCallback, CJob::PRIORITY_LOW_PAUSABLE);
+  ASSERT_TRUE(poll([&secondCallback]() { return secondCallback.HasEntered(); }));
+
+  Flags thirdFlags;
+  AddDumbJob(thirdFlags, nullptr, CJob::PRIORITY_LOW_PAUSABLE);
+  EXPECT_FALSE(poll(1000, [&thirdFlags]() { return thirdFlags.finished.load(); }));
+
+  firstCallback.Release();
+  secondCallback.Release();
+
+  EXPECT_TRUE(poll([&thirdFlags]() { return thirdFlags.finished.load(); }));
+}
+
+TEST_F(TestJobManager, CancelJobsDoesNotRunQueuedCallbacksUnderTheLock)
+{
+  CServiceBroker::GetJobManager()->PauseJobs();
+
+  BlockingCallback callback;
+  Flags flags;
+  AddDumbJob(flags, &callback, CJob::PRIORITY_LOW_PAUSABLE);
+
+  std::thread canceller([]() { CServiceBroker::GetJobManager()->CancelJobs(); });
+  std::thread observer;
+  // Declared before the Joiner so it outlives the thread that writes it: on a failed
+  // assertion the Joiner still joins that thread.
+  std::atomic<bool> queried{false};
+
+  // A joinable std::thread destructor calls std::terminate, which would kill the run instead
+  // of reporting the failed assertion.
+  struct Joiner
+  {
+    ~Joiner()
+    {
+      callback.Release();
+      if (canceller.joinable())
+        canceller.join();
+      if (observer.joinable())
+        observer.join();
+    }
+    BlockingCallback& callback;
+    std::thread& canceller;
+    std::thread& observer;
+  } joiner{callback, canceller, observer};
+
+  ASSERT_TRUE(poll([&callback]() { return callback.HasEntered(); }));
+
+  observer = std::thread(
+      [&queried]()
+      {
+        CServiceBroker::GetJobManager()->IsProcessing(CJob::PRIORITY_NORMAL);
+        queried = true;
+      });
+
+  EXPECT_TRUE(poll(2000, [&queried]() { return queried.load(); }));
 }


### PR DESCRIPTION
**TL;DR:** Bug fix. One job callback that blocks stops every job in Kodi for the rest of the process, because the worker is counted as idle while it runs; and `CancelJobs()` ran callbacks under its own lock. Both regressed in 22.0 Beta 1.

## Description
Two independent defects in the job manager. Both are in 22.0-BETA1.

### 1. One blocked callback kills the whole job system — #28894

`OnJobComplete()` removes the work item from `m_processing` *before* running the callbacks, so a worker sitting inside a callback is counted as idle. Once every live worker is in one, `StartWorkers()` always takes the "we have a sleeping thread" branch, sets `m_jobEvent` for a thread that will never return to `GetNextJob()`, and never creates a replacement.

**From that point no job submitted anywhere in Kodi runs again for the life of the process.** No log line, no warning. In the reported case the UI froze 64 minutes later in `~CVideoPlayer`, which spins on the application thread waiting for its job queue to drain.

Regression from v21, which erased from `m_processing` only *after* the callback returned, so a stuck worker still counted as busy and a replacement was spawned.

Fix: `m_completing` tracks jobs whose callbacks are still running, and both concurrency limits count it alongside `m_processing`. `m_idleWorkers` counts the workers actually parked on `m_jobEvent` rather than inferring them from `m_workers.size() - m_processing.size()`.

### 2. `CancelJobs()` invokes callbacks while holding `m_section`

Any callback that takes a lock of its own inverts the order against `CJobQueue::AddJob()`, which holds `CJobQueue::m_section` across `CJobManager::AddJob()`. Shutdown-only, so lower severity, but the same class of fault.

Fix: the queued work items are moved out under the lock; their callbacks run and their jobs are freed after it is released. Jobs still in `m_processing` are deliberately left as they are — a running worker owns them and may free them the moment the lock drops, and holding `m_section` is currently what keeps the `CJob*` alive for the call.

## Motivation and context
Fixes #28894. A job callback that blocks, such as one waiting on a network resource, silently disables the job system, and the symptom appears much later as a frozen UI with nothing in the log to point at the cause.

## How has this been tested?
Four new tests in `TestJobManager`. Each was written first, confirmed failing on master, and confirmed passing here — including a cross-check that no test silently became a no-op after the two branches were combined.

Full suite: 3757 passed, 0 failed. clang-format clean on the changed lines.

## What is the effect on users?
A blocked job callback no longer freezes Kodi. Background work, and the UI that waits on it, keeps running.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed

