### PR TITLE
[VideoPlayer] Keep a first chapter placed on a keyframe as chapter one

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.cpp
@@ -146,9 +146,22 @@ std::vector<ChapterFFmpeg> CDVDDemuxUtils::LoadChapters(std::span<AVChapter*> ch
 
   std::ranges::sort(result, std::less(), &ChapterFFmpeg::m_startPts);
 
-  // Videoplayer expects the first chapter to start at 00:00:00 - make one up if needed.
-  if (result.front().m_startPts != 0ms)
-    result.insert(result.begin(), ChapterFFmpeg{0ms, 0ms, ""});
+  // Videoplayer expects the first chapter to start at 00:00:00.
+  // The timestamp of the first chapter may be a key frame a few ms in, allow a bit of leeway
+  // before the creation of a virtual additional chapter.
+  ChapterFFmpeg& first = result.front();
+  if (first.m_startPts != 0ms)
+  {
+    if (first.m_startPts < KEYFRAME_OFFSET_LIMIT)
+    {
+      // A chapter marker (start == end) stays one once snapped.
+      if (first.m_endPts == first.m_startPts)
+        first.m_endPts = 0ms;
+      first.m_startPts = 0ms;
+    }
+    else
+      result.insert(result.begin(), ChapterFFmpeg{0ms, 0ms, ""});
+  }
 
   return result;
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h
@@ -30,6 +30,10 @@ struct ChapterFFmpeg
 class CDVDDemuxUtils
 {
 public:
+  //! How far in a first chapter may start and still count as starting at zero: longer than a
+  //! keyframe interval, shorter than anything worth seeking to.
+  static constexpr std::chrono::milliseconds KEYFRAME_OFFSET_LIMIT{1000};
+
   static void FreeDemuxPacket(DemuxPacket* pPacket);
   static DemuxPacket* AllocateDemuxPacket(int iDataSize = 0);
   static DemuxPacket* AllocateDemuxPacket(unsigned int iDataSize,

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxUtils.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxUtils.cpp
@@ -35,6 +35,10 @@ struct TestChapter
   std::vector<ChapterFFmpeg> expected;
 };
 
+// So that the case sitting on the boundary keeps testing the boundary if the tolerance moves.
+constexpr auto Tolerance = CDVDDemuxUtils::KEYFRAME_OFFSET_LIMIT;
+constexpr int64_t ToleranceMs = std::chrono::milliseconds{Tolerance}.count();
+
 // clang-format off
 const TestChapter testChapters[] = {
   {{{{1, 1, 0, 1, "A"}, {1, 1, 1, 2, "B"}}},
@@ -53,9 +57,18 @@ const TestChapter testChapters[] = {
   // Out of order chapters
   {{{{1, 1, 10, 20, "B"}, {1, 1, 0, 10, "A"}}},
     {{{0s, 10s, "A"}, {10s, 20s, "B"}}}},
-  // 1st chapter is not at 00:00:00
-  {{{{1, 1, 1, 2, "A"}}},
-    {{{0s, 0s, ""}, {1s, 2s, "A"}}}},
+  // 1st chapter on an early keyframe is tolerated and snapped to 00:00:00
+  {{{{1, 1000, 80, 2000, "A"}}},
+    {{{0s, 2s, "A"}}}},
+  // ... and only the 1st chapter is snapped
+  {{{{1, 1000, 80, 2000, "A"}, {1, 1000, 2080, 4000, "B"}}},
+    {{{0s, 2s, "A"}, {2080ms, 4s, "B"}}}},
+  // ... and a chapter marker stays a marker
+  {{{{1, 1000, 80, 80, "A"}}},
+    {{{0s, 0s, "A"}}}},
+  // First chapter timestamp past tolerance
+  {{{{1, 1000, ToleranceMs, ToleranceMs * 2, "A"}}},
+    {{{0s, 0s, ""}, {Tolerance, Tolerance * 2, "A"}}}},
 };
 // clang-format on
 


### PR DESCRIPTION
## Description
`CDVDDemuxUtils::LoadChapters()` inserts a nameless chapter at 00:00:00 whenever a file's first chapter starts later than zero. This limits that to gaps long enough to be real: a first chapter starting within `KEYFRAME_OFFSET_LIMIT` (1s) is moved back to zero instead, and a longer gap still gets its chapter.

## Motivation and context
Rippers place the first chapter on the first video keyframe, which need not be the first packet in the file. A MakeMKV rip of a concert Blu-ray declares 34 chapters, and its video stream starts 80ms after its audio:

```
format start_time = 0.000000
video  start_time = 0.080000     <- first chapter is here
audio  start_time = 0.000000
```

Kodi lists 35. The first named chapter is chapter two, so every chapter is off by one against the sleeve, and the extra entry is nameless and 80ms long - not something a viewer can seek to or would want to.

A longer gap is left alone, since a file can genuinely open with unchaptered material - a warning screen, a logo reel. Collapsing that into the first chapter would name content the chapter does not hold and lose the seek point where it really starts.

Three things reviewers may want to weigh in on:

- **The 1s limit is a magic number**, chosen as wider than any keyframe interval and shorter than anything worth seeking to. The rip that prompted this is 80ms, so there is headroom either way.
- **Where a chapter is still inserted it keeps its `{0ms, 0ms, ""}` end**, so it claims to end before the chapter after it begins. That looks wrong, but fixing it changes an expectation the existing tests pin, so it is left out rather than widening this change. Happy to fold it in.
- **The keyframe explanation comes from one sample.** The mechanism is verified on the rip above - video stream start and first chapter start agree at 80ms. Whether MakeMKV always aligns the first chapter that way, or how other rippers behave, is not checked.

## How has this been tested?
`TestDVDDemuxUtils` gains three cases: the sub-second offset moving to zero, the same with a following chapter to show only the first one moves, and a gap at the limit still getting its own chapter. The eight existing cases are untouched, including the one pinning a chapter one second in.

```
[==========] 11 tests from 2 test suites ran. (149 ms total)
[  PASSED  ] 11 tests.
```

Built and tested on macOS (arm64, Xcode). Checked against a 34-chapter MakeMKV rip, which now lists 34 chapters starting with its own first chapter rather than 35 starting with an empty one.

## What is the effect on users?
Files whose first chapter sits on a keyframe rather than at zero - typical of disc rips - are numbered as the disc numbers them, instead of having every chapter shifted by one behind a nameless entry too short to seek to. Files that genuinely open with unchaptered material are unaffected.

## Screenshots (if appropriate):
N/A

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
