### PR TITLE
RFC: VideoLibrary.RelocatePath - let a moved library item keep its entry

### DIFF
--- a/xbmc/interfaces/json-rpc/schema/methods.json
+++ b/xbmc/interfaces/json-rpc/schema/methods.json
@@ -5351,6 +5351,48 @@
     ],
     "returns": "string"
   },
+  "VideoLibrary.RelocatePath": {
+    "type": "method",
+    "description": "Rewrites the location the library stores for items whose files have moved, keeping each item, its identifiers, its playback state and its artwork",
+    "transport": "Response",
+    "permission": "UpdateData",
+    "params": [
+      {
+        "name": "from",
+        "type": "string",
+        "required": true,
+        "minLength": 1,
+        "description": "Path prefix the library currently stores. A trailing separator is added if missing"
+      },
+      {
+        "name": "to",
+        "type": "string",
+        "required": true,
+        "minLength": 1,
+        "description": "Path prefix to store in its place. Must lie within a video source"
+      }
+    ],
+    "returns": {
+      "type": "object",
+      "properties": {
+        "paths": {
+          "type": "integer",
+          "required": true,
+          "description": "Number of stored paths rewritten"
+        },
+        "items": {
+          "type": "integer",
+          "required": true,
+          "description": "Number of library items whose stored location changed"
+        },
+        "art": {
+          "type": "integer",
+          "required": true,
+          "description": "Number of artwork locations rewritten"
+        }
+      }
+    }
+  },
   "VideoLibrary.Export": {
     "type": "method",
     "description": "Exports all items from the video library",


### PR DESCRIPTION
**TL;DR:** RFC, draft, schema only. Proposes `VideoLibrary.RelocatePath { from, to }` so a renamed directory or moved source can be corrected in the library without removing and rescanning, which discards playcounts, resume points and artwork. No handler is included; this is here to settle the shape.

RFC document: https://malard.github.io/xbmc/rfc/library-relocate/

## Description
**This PR is the proposed schema alone, for comment.** There is deliberately no handler, so the method does not register and `CJSONServiceDescription` logs a missing implementation. It is not a merge candidate in this state — it is here to settle the shape before anything is built.

```
VideoLibrary.RelocatePath { from, to } -> { paths, items, art }
```

The unit is the path rather than the item. A rename is a prefix change, and because playback state and identifiers hang off the file row, rewriting the prefix carries every episode of a show with it untouched. An item-shaped call would have to derive the same rewrite, and could not express a show's season directories without assuming a layout; a method per media type would multiply for no gain. The same call also covers a whole source moving to a new host, which today has no answer other than path substitution — and that remaps at runtime without ever repairing the database.

`version.txt` goes to 13.17.0 for the added method.

**What has to exist behind it.** A `RelocatePath` on `CVideoDatabase` and `CMusicDatabase`: a transactional prefix rewrite over

| table | column | holds |
|---|---|---|
| `path` | `strPath` | the canonical row |
| `movie`, `musicvideo` | `c22` (`VIDEODB_ID_BASEPATH`) | a copy of the base path |
| `episode` | `c18` (`VIDEODB_ID_EPISODE_BASEPATH`) | a copy of the base path |
| `art` | `url` | local art, and embedded thumbs as `image://video@…` |

clearing the path hash so the next scan is honest. No new columns, so no database schema migration.

**Open questions.**

1. One method spanning both databases, or one per namespace?
2. Does rewriting `art.url` need anything done for the texture cache, or does it simply re-cache?
3. Directory moves only, or file renames as well? Movies with versions carry several file rows each.
4. Must the destination exist on disk, or only lie within a source — as `VideoLibrary.Scan` already requires?

Non-goals: editing `sources.xml`, and moving anything on disk. Kodi is told what happened; it does not do it.

## Motivation and context
Rename a directory on disk and Kodi cannot be told about it. The library keeps pointing at the old location, and the only way to correct it is `VideoLibrary.RemoveTVShow` followed by a scan — which discards playcount, last played, resume points, date added, user rating, tags and artwork overrides, and issues fresh identifiers, in order to fix a spelling mistake. The same holds for a movie, a music video, an album, and for an entire source when a NAS is renamed.

There is no existing capability to expose here. No `Set*Details` method accepts a path, and nothing in `CVideoDatabase` or `CMusicDatabase` rewrites `path.strPath`; the interface cannot do it either.

## How has this been tested?
Not applicable. The schema registers with no implementation, by design.

## What is the effect on users?
None in this state. Once implemented, a renamed folder or moved source can be corrected in the library without losing watched state, resume points or artwork.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
