### PR TITLE
[cmake][darwin] restore blanking of unused Apple deployment targets

### DIFF
--- a/cmake/scripts/darwin_embedded/ArchSetup.cmake
+++ b/cmake/scripts/darwin_embedded/ArchSetup.cmake
@@ -51,6 +51,21 @@ set(CMAKE_XCODE_ATTRIBUTE_INLINES_ARE_PRIVATE_EXTERN OFF)
 set(CMAKE_XCODE_ATTRIBUTE_GCC_SYMBOLS_PRIVATE_EXTERN OFF)
 set(CMAKE_XCODE_ATTRIBUTE_COPY_PHASE_STRIP OFF)
 
+# Xcode sets a deployment target for every Apple platform it knows about, not just the one
+# being built for, and exports them all into Run Script build phases. clang rejects an
+# invocation that sees more than one, which breaks internal dependencies that configure or
+# build through a shell. See cmake/scripts/osx/ArchSetup.cmake.
+set(CMAKE_XCODE_ATTRIBUTE_DRIVERKIT_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_WATCHOS_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_XROS_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET "")
+
+if(CORE_PLATFORM_NAME_LC STREQUAL tvos)
+  set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "")
+else()
+  set(CMAKE_XCODE_ATTRIBUTE_TVOS_DEPLOYMENT_TARGET "")
+endif()
+
 include(cmake/scripts/darwin/Macros.cmake)
 enable_arc()
 

--- a/cmake/scripts/osx/ArchSetup.cmake
+++ b/cmake/scripts/osx/ArchSetup.cmake
@@ -24,6 +24,20 @@ else()
   endif()
 endif()
 
+# Xcode sets a deployment target for every Apple platform it knows about, not just the one
+# being built for, and exports them all into Run Script build phases. clang rejects an
+# invocation that sees more than one:
+#   clang: error: conflicting deployment targets, both '26.5' and '25.5' are present in environment
+# which breaks internal dependencies that configure or build through a shell. Blank the
+# platforms we do not build for; MACOSX_DEPLOYMENT_TARGET stays, it is what
+# CMAKE_OSX_DEPLOYMENT_TARGET feeds. Check with:
+#   xcodebuild -target build-<dep> -showBuildSettings | grep _DEPLOYMENT_TARGET
+set(CMAKE_XCODE_ATTRIBUTE_DRIVERKIT_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_WATCHOS_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_XROS_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET "")
+set(CMAKE_XCODE_ATTRIBUTE_TVOS_DEPLOYMENT_TARGET "")
+
 # m1 macs can execute x86_64 code via rosetta
 if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64" AND
    CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Restores the `*_DEPLOYMENT_TARGET` blanking added in #27496 (fb7c6b57ed) and reverted in #28811
(0f39075074).

Xcode populates a deployment target for every Apple platform it knows about, not just the one
being built for, and exports them all as environment variables into Run Script build phases.
clang rejects an invocation that sees more than one:

```text
clang: error: conflicting deployment targets, both '26.5' and '25.5' are present in environment
```

which breaks every internal dependency that configures or builds through a shell.

The code is byte identical to fb7c6b57ed. Only the comment is rewritten, to name the mechanism,
quote the error and give the command that shows the leaked variables, so the block can be judged
without reproducing the failure first.

`MACOSX_DEPLOYMENT_TARGET` is deliberately left alone on macOS: it is what
`CMAKE_OSX_DEPLOYMENT_TARGET` feeds, and the app target needs it. This does not undo #28811 -
the two are orthogonal, one sets the macOS target and this clears the five that are not macOS.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The revert in #28811 was made on the grounds that the problem could not be reproduced:

> In relation to this #27496 is reverted - no idea how that was Tahoe related (probably Xcode 26?),
> but on Xcode 26.3 all builds fine atm.

It reproduces on Xcode 26.6. #28940 hit it two days after the revert merged, on the `build-udfread`
meson configure step, with all six deployment targets exported to the Run Script phase of a target
whose `PLATFORM_NAME` and `SUPPORTED_PLATFORMS` are both `macosx`. Credit to @garbear for that
reproduction, which is the evidence the revert lacked.

#28940 proposes fixing this by stripping the variables from the environment in `DEP_BUILDENV`
instead. Both work. This one is proposed in preference because it acts where the settings are
decided rather than at one group of consumers, so it also covers targets that shell out without
going through `DEP_BUILDENV`, and because it leaves master with one mechanism for this rather
than two.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Environment: Apple Silicon, macOS 26.5.2, Xcode 26.6 (17F113), CMake 4.3.4, Xcode generator.

Tested with a minimal CMake project reproducing the arrangement this code sits in -
`CMAKE_OSX_DEPLOYMENT_TARGET` set as the toolchain now sets it after #28811, one regular target
and one `ExternalProject_Add` target - and reading back `xcodebuild -showBuildSettings`:

| | regular target | `ExternalProject` aggregate target |
| --- | --- | --- |
| without the blanking | `DRIVERKIT` 25.5, `IPHONEOS`/`TVOS`/`WATCHOS`/`XROS` 26.5, `MACOSX` 11.0 | identical, all six |
| with the blanking | `MACOSX_DEPLOYMENT_TARGET = 11.0` only | `MACOSX_DEPLOYMENT_TARGET = 11.0` only |

Two things this establishes:

- the values match those reported in #28940 exactly, so the minimal project reproduces the real
  failure;
- `CMAKE_XCODE_ATTRIBUTE_*` reaches `ExternalProject_Add` aggregate targets, which is the target
  kind the internal dependency builds use. This was the open question about whether the fix belongs
  at project generation at all.

The resulting state - exactly one deployment target left set - is the state #28940 verified as
sufficient, by passing the same five as empty on the `xcodebuild` command line while leaving
`MACOSX_DEPLOYMENT_TARGET` populated.

Not tested: a full Kodi macOS build, and the `darwin_embedded` half of this change. The
`darwin_embedded` block is restored unchanged from fb7c6b57ed, but it also blanks
`MACOSX_DEPLOYMENT_TARGET`, and #28811 changed what feeds deployment targets on that path as well,
so an iOS or tvOS configure would be worth a look before merging. I do not have one to hand.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Fixes building Kodi on macOS with the Xcode generator on Xcode versions that export deployment
targets for multiple Apple platforms into Run Script build phases. No runtime behaviour change.

## Screenshots (if appropriate):

n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed

cc @fuzzard @kambala-decapitator @garbear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
