### PR TITLE
RetroPlayer: Show error message in v22 for v23 compressed savestate

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19423,7 +19423,15 @@ msgctxt "#35280"
 msgid "Select disc"
 msgstr ""
 
-#empty strings from id 35281 to 35504
+#empty strings from id 35281 to 35297
+
+#. Error message shown when trying to load a compressed savestate in an unsupported version of Kodi
+#: xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+msgctxt "#35298"
+msgid "This savestate is compressed and can't be loaded by this version of Kodi."
+msgstr ""
+
+#empty strings from id 35299 to 35504
 
 #. connection state "host unreachable"
 #: xbmc/pvr/addons/PVRClients.cpp

--- a/xbmc/cores/RetroPlayer/messages/savestate.fbs
+++ b/xbmc/cores/RetroPlayer/messages/savestate.fbs
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2018 Team Kodi
+//  Copyright (C) 2018-2026 Team Kodi
 //  This file is part of Kodi - https://kodi.tv
 //
 //  SPDX-License-Identifier: MIT
@@ -11,7 +11,7 @@ include "video.fbs";
 namespace KODI.RETRO.SAVESTATE;
 
 // Savestate schema
-// Version 4
+// Version 5
 
 file_identifier "SAV_";
 
@@ -19,6 +19,10 @@ enum SaveType : uint8 {
   Unknown,
   Auto,
   Manual
+}
+
+enum CompressionType : uint8 {
+  None,
 }
 
 table Savestate {
@@ -58,9 +62,15 @@ table Savestate {
   video_height:uint16 (id: 20);
   display_aspect_ratio:float (id: 23);
   rotation_ccw:VideoRotation (id: 21);
+  video_data_compressed:[uint8] (id: 27);
+  video_data_compression:CompressionType = None (id: 28);
+  video_data_uncompressed_size:uint64 = 0 (id: 29);
 
   // Memory properties
   memory_data:[uint8] (id: 10);
+  memory_data_compressed:[uint8] (id: 24);
+  memory_data_compression:CompressionType = None (id: 25);
+  memory_data_uncompressed_size:uint64 = 0 (id: 26);
 }
 
 root_type Savestate;

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -277,10 +277,14 @@ bool CReversiblePlayback::LoadSavestate(const std::string& savestatePath)
   std::unique_ptr<ISavestate> savestate = CSavestateDatabase::AllocateSavestate();
   if (m_savestateDatabase->GetSavestate(savestatePath, *savestate))
   {
-    if (savestate->GetMemorySize() != memorySize)
+    if (!savestate->PrepareMemoryData(memorySize))
     {
-      CLog::Log(LOGERROR, "Invalid memory size, got {}, expected {}", memorySize,
-                savestate->GetMemorySize());
+      CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Failed to prepare memory data");
+    }
+    else if (savestate->GetMemorySize() != memorySize)
+    {
+      CLog::Log(LOGERROR, "Invalid memory size, got {}, expected {}", savestate->GetMemorySize(),
+                memorySize);
     }
     else
     {

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -1070,6 +1070,12 @@ void CRPRenderManager::LoadVideoFrameSync(const std::string& savestatePath)
   if (!db.GetSavestate(savestatePath, *savestate))
     return;
 
+  if (!savestate->PrepareVideoData())
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Failed to prepare video data");
+    return;
+  }
+
   // Load video data
   const AVPixelFormat format = savestate->GetPixelFormat();
   const uint8_t* data = savestate->GetVideoData();

--- a/xbmc/cores/RetroPlayer/savestates/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/savestates/CMakeLists.txt
@@ -1,8 +1,10 @@
 set(SOURCES SavestateDatabase.cpp
+            SavestateBlob.cpp
             SavestateFlatBuffer.cpp
 )
 
 set(HEADERS ISavestate.h
+            SavestateBlob.h
             SavestateDatabase.h
             SavestateFlatBuffer.h
             SavestateTypes.h

--- a/xbmc/cores/RetroPlayer/savestates/ISavestate.h
+++ b/xbmc/cores/RetroPlayer/savestates/ISavestate.h
@@ -148,6 +148,11 @@ public:
   virtual const uint8_t* GetVideoData() const = 0;
 
   /*!
+   * \brief Validate and prepare the frame's video data for reading
+   */
+  virtual bool PrepareVideoData() = 0;
+
+  /*!
    * \brief The size of the frame's video data, in bytes
    */
   virtual size_t GetVideoSize() const = 0;
@@ -183,9 +188,24 @@ public:
   virtual const uint8_t* GetMemoryData() const = 0;
 
   /*!
+   * \brief Return true if any savestate data uses compression
+   */
+  virtual bool IsCompressed() const = 0;
+
+  /*!
+   * \brief Validate and prepare the memory data for reading
+   */
+  virtual bool PrepareMemoryData(size_t expectedSize) = 0;
+
+  /*!
    * \brief The size of the memory region returned by GetMemoryData()
    */
   virtual size_t GetMemorySize() const = 0;
+
+  /*!
+   * \brief Copy the memory data to another savestate without requiring decompression
+   */
+  virtual bool CopyMemoryDataTo(ISavestate& target) const = 0;
   ///}
 
   /// @name Builders for setting individual fields

--- a/xbmc/cores/RetroPlayer/savestates/SavestateBlob.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateBlob.cpp
@@ -1,0 +1,272 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "SavestateBlob.h"
+
+#include "utils/log.h"
+
+#include <limits>
+
+using namespace KODI;
+using namespace RETRO;
+
+namespace
+{
+constexpr size_t MAX_SAVESTATE_MEMORY_SIZE = 512 * 1024 * 1024;
+constexpr size_t MAX_SAVESTATE_VIDEO_SIZE = 128 * 1024 * 1024;
+
+/*!
+ * \brief Get the number of bytes used by one pixel in a savestate pixel format
+ *
+ * \param pixelFormat The savestate pixel format
+ * \param bytesPerPixel Receives the number of bytes per pixel for a supported format
+ *
+ * \return True if the pixel format is supported, false otherwise
+ */
+bool GetVideoBytesPerPixel(SAVESTATE::PixelFormat pixelFormat, size_t& bytesPerPixel)
+{
+  switch (pixelFormat)
+  {
+    case SAVESTATE::PixelFormat_RGBA_8888:
+    case SAVESTATE::PixelFormat_XRGB_8888:
+    case SAVESTATE::PixelFormat_BGRX_8888:
+      bytesPerPixel = 4;
+      return true;
+
+    case SAVESTATE::PixelFormat_RGB_565_BE:
+    case SAVESTATE::PixelFormat_RGB_565_LE:
+    case SAVESTATE::PixelFormat_RGB_555_BE:
+    case SAVESTATE::PixelFormat_RGB_555_LE:
+      bytesPerPixel = 2;
+      return true;
+
+    default:
+      break;
+  }
+
+  return false;
+}
+
+/*!
+ * \brief Calculate the minimum packed size of a savestate video frame
+ *
+ * The calculation validates the pixel format and dimensions, guards against
+ * overflow, and enforces the maximum supported savestate video size.
+ *
+ * \param savestate The savestate containing the video metadata
+ * \param packedMinimumSize Receives the minimum packed video size in bytes
+ *
+ * \return True if the metadata is valid and the size is supported, false otherwise
+ */
+bool GetPackedMinimumVideoSize(const SAVESTATE::Savestate& savestate, size_t& packedMinimumSize)
+{
+  const unsigned int width = savestate.video_width();
+  const unsigned int height = savestate.video_height();
+  size_t bytesPerPixel = 0;
+
+  if (width == 0 || height == 0 || !GetVideoBytesPerPixel(savestate.pixel_format(), bytesPerPixel))
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid video metadata in savestate");
+    return false;
+  }
+
+  if (width > std::numeric_limits<size_t>::max() / height)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Video dimensions overflow size calculation");
+    return false;
+  }
+
+  const size_t pixels = static_cast<size_t>(width) * height;
+  if (pixels > std::numeric_limits<size_t>::max() / bytesPerPixel)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Video size overflows size calculation");
+    return false;
+  }
+
+  packedMinimumSize = pixels * bytesPerPixel;
+  if (packedMinimumSize == 0 || packedMinimumSize > MAX_SAVESTATE_VIDEO_SIZE)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Video minimum size {} exceeds limit {}",
+              packedMinimumSize, MAX_SAVESTATE_VIDEO_SIZE);
+    return false;
+  }
+
+  return true;
+}
+} // namespace
+
+void PendingSavestateBlob::Clear()
+{
+  raw.clear();
+  compressed.clear();
+  uncompressedSize = 0;
+  compression = SAVESTATE::CompressionType_None;
+}
+
+bool PendingSavestateBlob::HasCompressedData() const
+{
+  //! @todo Add support for new compression types
+  switch (compression)
+  {
+    case SAVESTATE::CompressionType_None:
+      return false;
+    default:
+      break;
+  }
+
+  return false;
+}
+
+SavestateBlobOffsets CSavestateBlob::CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
+                                                        const std::vector<uint8_t>& rawData,
+                                                        const char* /* fieldName */)
+{
+  SavestateBlobOffsets offsets;
+
+  //! @todo Compress rawData with zstd if a smaller representation is available
+
+  offsets.raw = builder.CreateVector(rawData);
+  return offsets;
+}
+
+SavestateBlobOffsets CSavestateBlob::CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
+                                                        const PendingSavestateBlob& pending,
+                                                        const char* fieldName)
+{
+  if (!pending.HasCompressedData())
+    return CreateWriteOffsets(builder, pending.raw, fieldName);
+
+  if (pending.uncompressedSize == 0 || pending.compressed.size() > pending.uncompressedSize)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed {} pending blob",
+              fieldName ? fieldName : "blob");
+    return CreateWriteOffsets(builder, pending.raw, fieldName);
+  }
+
+  SavestateBlobOffsets offsets;
+
+  const std::vector<uint8_t> emptyData;
+  offsets.raw = builder.CreateVector(emptyData);
+  offsets.compressed = builder.CreateVector(pending.compressed);
+  offsets.compressionType = pending.compression;
+  offsets.uncompressedSize = pending.uncompressedSize;
+
+  return offsets;
+}
+
+bool CSavestateBlob::PrepareMemoryData(const SAVESTATE::Savestate& savestate,
+                                       size_t expectedSize,
+                                       std::vector<uint8_t>& decompressedMemoryData)
+{
+  decompressedMemoryData.clear();
+
+  if (!IsSupportedMemorySize(expectedSize))
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid memory size: {}", expectedSize);
+    return false;
+  }
+
+  if (savestate.memory_data_uncompressed_size() != expectedSize)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed memory size {}, expected {}",
+              savestate.memory_data_uncompressed_size(), expectedSize);
+    return false;
+  }
+
+  const auto* compressed = savestate.memory_data_compressed();
+  if (compressed == nullptr || compressed->size() == 0 || compressed->size() > expectedSize ||
+      compressed->size() > MAX_SAVESTATE_MEMORY_SIZE)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed memory data size");
+    return false;
+  }
+
+  //! @todo Decompress the memory data into decompressedMemoryData
+  CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Compressed memory data is not supported by this version");
+
+  return false;
+}
+
+bool CSavestateBlob::PrepareVideoData(const SAVESTATE::Savestate& savestate,
+                                      std::vector<uint8_t>& decompressedVideoData)
+{
+  decompressedVideoData.clear();
+
+  size_t packedMinimumSize = 0;
+  if (!GetPackedMinimumVideoSize(savestate, packedMinimumSize))
+    return false;
+
+  const uint64_t uncompressedSize = savestate.video_data_uncompressed_size();
+  if (uncompressedSize == 0 || uncompressedSize > MAX_SAVESTATE_VIDEO_SIZE ||
+      uncompressedSize < packedMinimumSize)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed video size {}", uncompressedSize);
+    return false;
+  }
+
+  const size_t expectedSize = static_cast<size_t>(uncompressedSize);
+  const auto* compressed = savestate.video_data_compressed();
+  if (compressed == nullptr || compressed->size() == 0 || compressed->size() > expectedSize ||
+      compressed->size() > MAX_SAVESTATE_VIDEO_SIZE)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed video data size");
+    return false;
+  }
+
+  //! @todo Decompress the video data into decompressedVideoData
+
+  CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Compressed video data is not supported by this version");
+  return false;
+}
+
+bool CSavestateBlob::IsValidRawMemoryData(const SAVESTATE::Savestate& savestate,
+                                          size_t expectedSize)
+{
+  if (!IsSupportedMemorySize(expectedSize))
+    return false;
+
+  const auto* memoryData = savestate.memory_data();
+  return memoryData != nullptr && memoryData->size() == expectedSize;
+}
+
+bool CSavestateBlob::HasRawVideoData(const SAVESTATE::Savestate& savestate)
+{
+  return savestate.video_data() != nullptr && savestate.video_data()->size() > 0;
+}
+
+bool CSavestateBlob::IsValidCopiedCompressedMemoryData(const SAVESTATE::Savestate& savestate)
+{
+  const auto* compressed = savestate.memory_data_compressed();
+  const uint64_t uncompressedSize = savestate.memory_data_uncompressed_size();
+
+  if (compressed == nullptr || compressed->size() == 0 ||
+      compressed->size() > MAX_SAVESTATE_MEMORY_SIZE || uncompressedSize == 0 ||
+      uncompressedSize > MAX_SAVESTATE_MEMORY_SIZE || compressed->size() > uncompressedSize)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid compressed memory data size");
+    return false;
+  }
+
+  return true;
+}
+
+bool CSavestateBlob::IsValidMemoryDataSize(size_t size)
+{
+  if (size > MAX_SAVESTATE_MEMORY_SIZE)
+    return false;
+
+  return true;
+}
+
+bool CSavestateBlob::IsSupportedMemorySize(size_t expectedSize)
+{
+  if (expectedSize == 0 || expectedSize > MAX_SAVESTATE_MEMORY_SIZE)
+    return false;
+
+  return true;
+}

--- a/xbmc/cores/RetroPlayer/savestates/SavestateBlob.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateBlob.h
@@ -1,0 +1,189 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "savestate_generated.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <flatbuffers/flatbuffers.h>
+
+namespace KODI
+{
+namespace RETRO
+{
+/*!
+ * \brief FlatBuffer offsets and metadata for a serialized savestate blob
+ *
+ * A blob is stored as either raw data or compressed data. The offsets are
+ * owned by the FlatBufferBuilder used to create them.
+ */
+struct SavestateBlobOffsets
+{
+  //! \brief Offset of the raw blob data
+  flatbuffers::Offset<flatbuffers::Vector<uint8_t>> raw;
+
+  //! \brief Offset of the compressed blob data
+  flatbuffers::Offset<flatbuffers::Vector<uint8_t>> compressed;
+
+  //! \brief Compression applied to the compressed blob data
+  SAVESTATE::CompressionType compressionType{SAVESTATE::CompressionType_None};
+
+  //! \brief Size of the blob after decompression, or zero for raw data
+  uint64_t uncompressedSize{0};
+};
+
+/*!
+ * \brief Blob data retained while a savestate is being constructed
+ *
+ * This allows an existing compressed blob to be copied without decompressing
+ * it, for example when changing savestate metadata.
+ */
+struct PendingSavestateBlob
+{
+  //! \brief Uncompressed blob data
+  std::vector<uint8_t> raw;
+
+  //! \brief Compressed blob data
+  std::vector<uint8_t> compressed;
+
+  //! \brief Size of the compressed blob after decompression
+  uint64_t uncompressedSize{0};
+
+  //! \brief Compression applied to the compressed blob data
+  SAVESTATE::CompressionType compression{SAVESTATE::CompressionType_None};
+
+  /*!
+   * \brief Clear the blob data and reset its compression metadata
+   */
+  void Clear();
+
+  /*!
+   * \brief Check whether this object contains supported compressed data
+   *
+   * \return True if the blob contains non-empty zstd-compressed data, false otherwise
+   */
+  bool HasCompressedData() const;
+};
+
+/*!
+ * \brief Helpers for serializing and validating savestate data blobs
+ */
+class CSavestateBlob
+{
+public:
+  /*!
+   * \brief Create FlatBuffer offsets for raw blob data
+   *
+   * \param builder The builder that will own the returned offsets
+   * \param rawData The raw blob data to serialize
+   * \param fieldName The blob field name used for diagnostic logging
+   *
+   * \return Offsets and metadata for the serialized blob
+   */
+  static SavestateBlobOffsets CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
+                                                 const std::vector<uint8_t>& rawData,
+                                                 const char* fieldName);
+
+  /*!
+   * \brief Create FlatBuffer offsets for pending raw or compressed blob data
+   *
+   * Valid compressed data is copied without decompression. Invalid compressed
+   * metadata falls back to the pending raw data.
+   *
+   * \param builder The builder that will own the returned offsets
+   * \param pending The pending blob data and compression metadata
+   * \param fieldName The blob field name used for diagnostic logging
+   *
+   * \return Offsets and metadata for the serialized blob
+   */
+  static SavestateBlobOffsets CreateWriteOffsets(flatbuffers::FlatBufferBuilder& builder,
+                                                 const PendingSavestateBlob& pending,
+                                                 const char* fieldName);
+
+  /*!
+   * \brief Validate and prepare compressed memory data for reading
+   *
+   * The destination is cleared before validation. Compression is unsupported
+   * by this version, so valid compressed data is rejected after validation.
+   *
+   * \param savestate The savestate containing the compressed memory data
+   * \param expectedSize The expected decompressed memory size in bytes
+   * \param decompressedMemoryData Receives the decompressed memory data
+   *
+   * \return True if the memory data was prepared, false on invalid or unsupported data
+   */
+  static bool PrepareMemoryData(const SAVESTATE::Savestate& savestate,
+                                size_t expectedSize,
+                                std::vector<uint8_t>& decompressedMemoryData);
+
+  /*!
+   * \brief Validate and prepare compressed video data for reading
+   *
+   * The destination is cleared before validation. Compression is unsupported
+   * by this version, so valid compressed data is rejected after validation.
+   *
+   * \param savestate The savestate containing the compressed video data
+   * \param decompressedVideoData Receives the decompressed video data
+   *
+   * \return True if the video data was prepared, false on invalid or unsupported data
+   */
+  static bool PrepareVideoData(const SAVESTATE::Savestate& savestate,
+                               std::vector<uint8_t>& decompressedVideoData);
+
+  /*!
+   * \brief Check whether raw memory data has the expected supported size
+   *
+   * \param savestate The savestate containing the raw memory data
+   * \param expectedSize The required memory size in bytes
+   *
+   * \return True if the raw memory data is valid, false otherwise
+   */
+  static bool IsValidRawMemoryData(const SAVESTATE::Savestate& savestate, size_t expectedSize);
+
+  /*!
+   * \brief Check whether a savestate contains non-empty raw video data
+   *
+   * \param savestate The savestate to inspect
+   *
+   * \return True if raw video data is present, false otherwise
+   */
+  static bool HasRawVideoData(const SAVESTATE::Savestate& savestate);
+
+  /*!
+   * \brief Validate compressed memory data before copying it unchanged
+   *
+   * \param savestate The savestate containing the compressed memory data
+   *
+   * \return True if the compressed and uncompressed sizes are valid, false otherwise
+   */
+  static bool IsValidCopiedCompressedMemoryData(const SAVESTATE::Savestate& savestate);
+
+  /*!
+   * \brief Check whether a memory data buffer is within the storage limit
+   *
+   * \param size The memory data size in bytes
+   *
+   * \return True if the size is within the limit, false otherwise
+   */
+  static bool IsValidMemoryDataSize(size_t size);
+
+  /*!
+   * \brief Check whether an expected memory size is non-zero and within the storage limit
+   *
+   * \param expectedSize The expected memory size in bytes
+   *
+   * \return True if the size is supported, false otherwise
+   */
+  static bool IsSupportedMemorySize(size_t expectedSize);
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -206,8 +206,8 @@ std::unique_ptr<ISavestate> CSavestateDatabase::RenameSavestate(const std::strin
   newSavestate->SetGameClientID(savestate->GameClientID());
   newSavestate->SetGameClientVersion(savestate->GameClientVersion());
 
-  size_t memorySize = savestate->GetMemorySize();
-  std::memcpy(newSavestate->GetMemoryBuffer(memorySize), savestate->GetMemoryData(), memorySize);
+  if (!savestate->CopyMemoryDataTo(*newSavestate))
+    return {};
 
   newSavestate->Finalize();
 

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
@@ -8,6 +8,7 @@
 
 #include "SavestateFlatBuffer.h"
 
+#include "SavestateBlob.h"
 #include "XBDateTime.h"
 #include "savestate_generated.h"
 #include "utils/log.h"
@@ -22,8 +23,11 @@ using namespace RETRO;
 
 namespace
 {
-const uint8_t SCHEMA_VERSION = 3;
+const uint8_t SCHEMA_VERSION = 5;
 const uint8_t SCHEMA_MIN_VERSION = 1;
+
+constexpr const char* SCHEMA_VIDEO_DATA_FIELD_NAME = "video_data";
+constexpr const char* SCHEMA_MEMORY_DATA_FIELD_NAME = "memory_data";
 
 //! \brief The number of nanoseconds per second
 constexpr double NANOSECONDS_PER_SECOND = 1000.0 * 1000.0 * 1000.0;
@@ -218,6 +222,31 @@ void CSavestateFlatBuffer::Reset()
   m_builder = std::make_unique<flatbuffers::FlatBufferBuilder>(INITIAL_FLATBUFFER_SIZE);
   m_data.clear();
   m_savestate = nullptr;
+
+  m_type = SAVE_TYPE::UNKNOWN;
+  m_slot = 0;
+  m_labelOffset.reset();
+  m_captionOffset.reset();
+  m_createdOffset.reset();
+  m_gameFileNameOffset.reset();
+  m_timestampFrames = 0;
+  m_timestampWallClock = 0.0;
+  m_emulatorAddonIdOffset.reset();
+  m_emulatorVersionOffset.reset();
+  m_pixelFormat = AV_PIX_FMT_NONE;
+  m_nominalWidth = 0;
+  m_nominalHeight = 0;
+  m_nominalDisplayAspectRatio = 0.0f;
+  m_maxWidth = 0;
+  m_maxHeight = 0;
+  m_videoData.clear();
+  m_videoDataDecompressed.clear();
+  m_videoWidth = 0;
+  m_videoHeight = 0;
+  m_displayAspectRatio = 0.0f;
+  m_rotationCCW = 0;
+  m_memoryData.Clear();
+  m_memoryDataDecompressed.clear();
 }
 
 bool CSavestateFlatBuffer::Serialize(const uint8_t*& data, size_t& size) const
@@ -461,14 +490,51 @@ void CSavestateFlatBuffer::SetMaxHeight(unsigned int maxHeight)
 
 const uint8_t* CSavestateFlatBuffer::GetVideoData() const
 {
+  if (!m_videoDataDecompressed.empty())
+    return m_videoDataDecompressed.data();
+
   if (m_savestate != nullptr && m_savestate->video_data())
     return m_savestate->video_data()->data();
 
   return nullptr;
 }
 
+bool CSavestateFlatBuffer::PrepareVideoData()
+{
+  m_videoDataDecompressed.clear();
+
+  if (m_savestate == nullptr)
+    return false;
+
+  //! @todo Add support for new compression types
+  switch (m_savestate->video_data_compression())
+  {
+    case SAVESTATE::CompressionType_None:
+    {
+      //! @todo Also validate the raw blob against untrusted video metadata
+      if (!CSavestateBlob::HasRawVideoData(*m_savestate))
+      {
+        CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid video data");
+        return false;
+      }
+      break;
+    }
+    default:
+    {
+      CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Unsupported video compression type {}",
+                static_cast<unsigned int>(m_savestate->video_data_compression()));
+      return false;
+    }
+  }
+
+  return true;
+}
+
 size_t CSavestateFlatBuffer::GetVideoSize() const
 {
+  if (!m_videoDataDecompressed.empty())
+    return m_videoDataDecompressed.size();
+
   if (m_savestate != nullptr && m_savestate->video_data())
     return m_savestate->video_data()->size();
 
@@ -477,12 +543,9 @@ size_t CSavestateFlatBuffer::GetVideoSize() const
 
 uint8_t* CSavestateFlatBuffer::GetVideoBuffer(size_t size)
 {
-  uint8_t* videoBuffer = nullptr;
+  m_videoData.assign(size, 0);
 
-  m_videoDataOffset =
-      std::make_unique<VectorOffset>(m_builder->CreateUninitializedVector(size, &videoBuffer));
-
-  return videoBuffer;
+  return m_videoData.empty() ? nullptr : m_videoData.data();
 }
 
 unsigned int CSavestateFlatBuffer::GetVideoWidth() const
@@ -539,32 +602,131 @@ void CSavestateFlatBuffer::SetRotationDegCCW(unsigned int rotationCCW)
 
 const uint8_t* CSavestateFlatBuffer::GetMemoryData() const
 {
+  if (!m_memoryDataDecompressed.empty())
+    return m_memoryDataDecompressed.data();
+
   if (m_savestate != nullptr && m_savestate->memory_data())
     return m_savestate->memory_data()->data();
 
   return nullptr;
 }
 
+bool CSavestateFlatBuffer::IsCompressed() const
+{
+  if (m_savestate != nullptr)
+  {
+    if (m_savestate->memory_data_compression() != SAVESTATE::CompressionType_None)
+      return true;
+
+    if (m_savestate->video_data_compression() != SAVESTATE::CompressionType_None)
+      return true;
+  }
+
+  return false;
+}
+
+bool CSavestateFlatBuffer::PrepareMemoryData(size_t expectedSize)
+{
+  m_memoryDataDecompressed.clear();
+
+  if (m_savestate == nullptr)
+    return false;
+
+  //! @todo Add support for new compression types
+  switch (m_savestate->memory_data_compression())
+  {
+    case SAVESTATE::CompressionType_None:
+    {
+      if (!CSavestateBlob::IsValidRawMemoryData(*m_savestate, expectedSize))
+      {
+        CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid memory size {}", expectedSize);
+        return false;
+      }
+      break;
+    }
+    default:
+    {
+      CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Unsupported memory compression type {}",
+                static_cast<unsigned int>(m_savestate->memory_data_compression()));
+      return false;
+    }
+  }
+
+  return true;
+}
+
 size_t CSavestateFlatBuffer::GetMemorySize() const
 {
+  if (!m_memoryDataDecompressed.empty())
+    return m_memoryDataDecompressed.size();
+
   if (m_savestate != nullptr && m_savestate->memory_data())
     return m_savestate->memory_data()->size();
 
   return 0;
 }
 
+bool CSavestateFlatBuffer::CopyMemoryDataTo(ISavestate& target) const
+{
+  auto* targetFlatBuffer = dynamic_cast<CSavestateFlatBuffer*>(&target);
+  if (targetFlatBuffer == nullptr || m_savestate == nullptr)
+    return false;
+
+  targetFlatBuffer->m_memoryData.Clear();
+  targetFlatBuffer->m_memoryDataDecompressed.clear();
+
+  //! @todo Add support for new compression types
+  switch (m_savestate->memory_data_compression())
+  {
+    case SAVESTATE::CompressionType_None:
+    {
+      const auto* memoryData = m_savestate->memory_data();
+      if (memoryData == nullptr)
+        return false;
+
+      if (!CSavestateBlob::IsValidMemoryDataSize(memoryData->size()))
+      {
+        CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Invalid memory data size: {}", memoryData->size());
+        return false;
+      }
+
+      if (memoryData->size() > 0)
+      {
+        targetFlatBuffer->m_memoryData.raw.assign(memoryData->data(),
+                                                  memoryData->data() + memoryData->size());
+      }
+
+      break;
+    }
+    default:
+    {
+      CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Unsupported memory compression type {}",
+                static_cast<unsigned int>(m_savestate->memory_data_compression()));
+      return false;
+    }
+  }
+
+  return true;
+}
+
 uint8_t* CSavestateFlatBuffer::GetMemoryBuffer(size_t size)
 {
-  uint8_t* memoryBuffer = nullptr;
+  m_memoryData.Clear();
+  m_memoryData.raw.assign(size, 0);
 
-  m_memoryDataOffset =
-      std::make_unique<VectorOffset>(m_builder->CreateUninitializedVector(size, &memoryBuffer));
-
-  return memoryBuffer;
+  return m_memoryData.raw.empty() ? nullptr : m_memoryData.raw.data();
 }
 
 void CSavestateFlatBuffer::Finalize()
 {
+  if (m_builder == nullptr)
+    return;
+
+  const SavestateBlobOffsets videoBlob =
+      CSavestateBlob::CreateWriteOffsets(*m_builder, m_videoData, SCHEMA_VIDEO_DATA_FIELD_NAME);
+  const SavestateBlobOffsets memoryBlob =
+      CSavestateBlob::CreateWriteOffsets(*m_builder, m_memoryData, SCHEMA_MEMORY_DATA_FIELD_NAME);
+
   // Helper class to build the nested Savestate table
   SAVESTATE::SavestateBuilder savestateBuilder(*m_builder);
 
@@ -625,11 +787,11 @@ void CSavestateFlatBuffer::Finalize()
 
   savestateBuilder.add_max_height(m_maxHeight);
 
-  if (m_videoDataOffset)
-  {
-    savestateBuilder.add_video_data(*m_videoDataOffset);
-    m_videoDataOffset.reset();
-  }
+  savestateBuilder.add_video_data(videoBlob.raw);
+  if (videoBlob.compressed.o != 0)
+    savestateBuilder.add_video_data_compressed(videoBlob.compressed);
+  savestateBuilder.add_video_data_compression(videoBlob.compressionType);
+  savestateBuilder.add_video_data_uncompressed_size(videoBlob.uncompressedSize);
 
   savestateBuilder.add_video_width(m_videoWidth);
 
@@ -639,11 +801,11 @@ void CSavestateFlatBuffer::Finalize()
 
   savestateBuilder.add_rotation_ccw(TranslateRotation(m_rotationCCW));
 
-  if (m_memoryDataOffset)
-  {
-    savestateBuilder.add_memory_data(*m_memoryDataOffset);
-    m_memoryDataOffset.reset();
-  }
+  savestateBuilder.add_memory_data(memoryBlob.raw);
+  if (memoryBlob.compressed.o != 0)
+    savestateBuilder.add_memory_data_compressed(memoryBlob.compressed);
+  savestateBuilder.add_memory_data_compression(memoryBlob.compressionType);
+  savestateBuilder.add_memory_data_uncompressed_size(memoryBlob.uncompressedSize);
 
   auto savestate = savestateBuilder.Finish();
   FinishSavestateBuffer(*m_builder, savestate);

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "ISavestate.h"
+#include "SavestateBlob.h"
 
 #include <memory>
 
@@ -49,13 +50,17 @@ public:
   unsigned int GetMaxWidth() const override;
   unsigned int GetMaxHeight() const override;
   const uint8_t* GetVideoData() const override;
+  bool PrepareVideoData() override;
   size_t GetVideoSize() const override;
   unsigned int GetVideoWidth() const override;
   unsigned int GetVideoHeight() const override;
   float GetDisplayAspectRatio() const override;
   unsigned int GetRotationDegCCW() const override;
   const uint8_t* GetMemoryData() const override;
+  bool IsCompressed() const override;
+  bool PrepareMemoryData(size_t expectedSize) override;
   size_t GetMemorySize() const override;
+  bool CopyMemoryDataTo(ISavestate& target) const override;
   void SetType(SAVE_TYPE type) override;
   void SetSlot(uint8_t slot) override;
   void SetLabel(const std::string& label) override;
@@ -102,7 +107,6 @@ private:
   const SAVESTATE::Savestate* m_savestate = nullptr;
 
   using StringOffset = flatbuffers::Offset<flatbuffers::String>;
-  using VectorOffset = flatbuffers::Offset<flatbuffers::Vector<uint8_t>>;
 
   // Temporary deserialization variables
   SAVE_TYPE m_type = SAVE_TYPE::UNKNOWN;
@@ -121,12 +125,14 @@ private:
   float m_nominalDisplayAspectRatio{0.0f};
   unsigned int m_maxWidth{0};
   unsigned int m_maxHeight{0};
-  std::unique_ptr<VectorOffset> m_videoDataOffset;
+  std::vector<uint8_t> m_videoData;
+  std::vector<uint8_t> m_videoDataDecompressed;
   unsigned int m_videoWidth{0};
   unsigned int m_videoHeight{0};
   float m_displayAspectRatio{0.0f};
   unsigned int m_rotationCCW{0};
-  std::unique_ptr<VectorOffset> m_memoryDataOffset;
+  PendingSavestateBlob m_memoryData;
+  std::vector<uint8_t> m_memoryDataDecompressed;
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/games/GameUtils.cpp
+++ b/xbmc/games/GameUtils.cpp
@@ -18,6 +18,7 @@
 #include "addons/addoninfo/AddonType.h"
 #include "cores/RetroPlayer/savestates/ISavestate.h"
 #include "cores/RetroPlayer/savestates/SavestateDatabase.h"
+#include "dialogs/GUIDialogOK.h"
 #include "filesystem/SpecialProtocol.h"
 #include "games/addons/GameClient.h"
 #include "games/dialogs/GUIDialogSelectGameClient.h"
@@ -59,6 +60,16 @@ bool CGameUtils::FillInGameClient(CFileItem& item, std::string& savestatePath)
         RETRO::CSavestateDatabase db;
         std::unique_ptr<RETRO::ISavestate> save = RETRO::CSavestateDatabase::AllocateSavestate();
         db.GetSavestate(savestatePath, *save);
+
+        //! @todo Remove this when we can load compressed savestates
+        if (save->IsCompressed())
+        {
+          // "Error"
+          // "This savestate is compressed and can't be loaded by this version of Kodi."
+          CGUIDialogOK::ShowAndGetInput(257, 35298);
+          return false;
+        }
+
         item.GetGameInfoTag()->SetGameClient(save->GameClientID());
       }
       else

--- a/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
+++ b/xbmc/games/dialogs/osd/DialogInGameSaves.cpp
@@ -302,6 +302,17 @@ void CDialogInGameSaves::OnLoad(CFileItem& focusedItem)
   }
   else
   {
+    //! @todo Remove this when support for savestate compression is added
+    RETRO::CSavestateDatabase db;
+    std::unique_ptr<RETRO::ISavestate> savestate = RETRO::CSavestateDatabase::AllocateSavestate();
+    if (db.GetSavestate(focusedItem.GetPath(), *savestate) && savestate->IsCompressed())
+    {
+      // "Error"
+      // "This savestate is compressed and can't be loaded by this version of Kodi."
+      CGUIDialogOK::ShowAndGetInput(257, 35298);
+      return;
+    }
+
     // "Error"
     // "An unknown error has occurred."
     CGUIDialogOK::ShowAndGetInput(257, 24071);


### PR DESCRIPTION
## Description

V23 adds Zstandard savestate compression: https://github.com/xbmc/xbmc/pull/28511

This PR imports some of the compression handling (but no compression), enough to provide a compatible savestate flatbuffer message and an `IsCompressed()` function, for safety when a v23 save is loaded in v22. This function is checked on load, and a specific compressed savestate error message is shown to the user.

## Motivation and context

Loading a v23 savestate with compression in v22 has unknown consequences. Likely, a generic error message is shown. This PR adds a specific message if v23 savestates with compression are loaded in v22.

## How has this been tested?

Savestate code tested in https://github.com/xbmc/xbmc/pull/28511.

Preparing RetroPlayer builds now.

## What is the effect on users?

* Only affects users if v23 is installed, a game is played, then the savestate is loaded in v22.

## Screenshots (if appropriate):

DialogGameSaves:

<img width="1835" height="909" alt="DialogGameSaves" src="https://github.com/user-attachments/assets/c79ad228-35c3-48f1-b920-ca15104703ed" />

DialogInGameSaves:

<img width="1836" height="909" alt="DialogInGameSaves" src="https://github.com/user-attachments/assets/750666b9-1674-4b63-961a-a34d9861e5cd" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
