### PR TITLE
fix(music): two bugs that lose artist discography data

### DIFF
--- a/xbmc/interfaces/json-rpc/AudioLibrary.cpp
+++ b/xbmc/interfaces/json-rpc/AudioLibrary.cpp
@@ -750,7 +750,9 @@ JSONRPC_STATUS CAudioLibrary::SetArtistDetails(const std::string &method, ITrans
     return InternalError;
 
   CArtist artist;
-  if (!musicdatabase.GetArtist(id, artist) || artist.idArtist <= 0)
+  // fetchAll: UpdateArtist() below replaces the discography and video links wholesale from this
+  // CArtist, so anything not loaded here is deleted from the database.
+  if (!musicdatabase.GetArtist(id, artist, true) || artist.idArtist <= 0)
     return NotFound;
 
   if (ParameterNotNull(parameterObject, "artist"))

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2207,12 +2207,18 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist& artist, bool fetchAll /* =
     artist.videolinks.clear();
     if (fetchAll)
     {
-      strSQL = PrepareSQL("SELECT idSong, strTitle, strMusicBrainzTrackID, strVideoURL, url "
-                          "FROM song JOIN album_artist ON song.idAlbum = album_artist.idAlbum "
-                          "LEFT JOIN art ON art.media_id = song.idSong AND art.type = 'videothumb' "
-                          "WHERE album_artist.idArtist = %i AND "
-                          "song.strVideoURL is not NULL GROUP by song.strVideoURL ORDER BY idSong",
-                          idArtist);
+      // Group by every column that ends up in an ArtistVideoLinks, so that the same video listed
+      // against several copies of a song yields one entry, without collapsing distinct songs that
+      // happen to share a video URL - those are separate links, and UpdateArtist() writes back
+      // exactly what is read here.
+      strSQL =
+          PrepareSQL("SELECT MIN(song.idSong), strTitle, strMusicBrainzTrackID, strVideoURL, url "
+                     "FROM song JOIN album_artist ON song.idAlbum = album_artist.idAlbum "
+                     "LEFT JOIN art ON art.media_id = song.idSong AND art.type = 'videothumb' "
+                     "WHERE album_artist.idArtist = %i AND song.strVideoURL is not NULL "
+                     "GROUP BY strTitle, strMusicBrainzTrackID, strVideoURL, url "
+                     "ORDER BY MIN(song.idSong)",
+                     idArtist);
       debugSQL += strSQL;
       m_pDS->query(strSQL);
       while (!m_pDS->eof())

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -2191,9 +2191,14 @@ bool CMusicDatabase::GetArtist(int idArtist, CArtist& artist, bool fetchAll /* =
         const dbiplus::sql_record* const record = m_pDS->get_sql_record();
         CDiscoAlbum discoAlbum;
         discoAlbum.strAlbum = record->at(discographyOffset + 1).get_asString();
-        discoAlbum.strYear = record->at(discographyOffset + 2).get_asString();
-        discoAlbum.strReleaseGroupMBID = record->at(discographyOffset + 3).get_asString();
-        artist.discography.emplace_back(discoAlbum);
+        // Skip entries with no title: the LEFT JOIN yields one all-NULL row for an artist with
+        // no discography, and a titleless entry is useless to callers regardless.
+        if (!discoAlbum.strAlbum.empty())
+        {
+          discoAlbum.strYear = record->at(discographyOffset + 2).get_asString();
+          discoAlbum.strReleaseGroupMBID = record->at(discographyOffset + 3).get_asString();
+          artist.discography.emplace_back(discoAlbum);
+        }
         m_pDS->next();
       }
     }

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -115,6 +115,67 @@ void AnnounceUpdate(const std::string& content, int id, bool added = false)
     data["added"] = true;
   CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::AudioLibrary, "OnUpdate", data);
 }
+
+/*!
+ \brief Owner of a temporary table that CREATE TEMPORARY TABLE can not provide.
+
+ Some queries need a table to hold intermediate results but can not use CREATE TEMPORARY TABLE
+ (see GetArtistDiscography for why), so the table has to be an ordinary one. Being ordinary it
+ survives the call that made it and is visible to every client of a shared library, so this
+ owner drops it when it goes out of scope, on the exceptional path as well as the ordinary
+ ones, giving it the lifetime a real temporary table would have had.
+*/
+class CTemporaryTable
+{
+public:
+  /*!
+   \brief Create the table, replacing one an earlier call may have left behind.
+
+   A crash, or a kill between creating the table and dropping it, is the only way a leftover
+   comes to exist. Failure to provide the table is left to propagate: the caller can not
+   continue without it, and an object that fails to construct is never destroyed, so no
+   half-made table is dropped on the way out.
+
+   \param ds dataset of an open connection, which must outlive this object
+   \param name name of the table
+   \param columns parenthesised column definitions used to create the table
+   \throws dbiplus::DbErrors when the table can not be created
+  */
+  CTemporaryTable(dbiplus::Dataset& ds, std::string name, const std::string& columns)
+    : m_ds(ds),
+      m_name(std::move(name))
+  {
+    m_ds.exec("DROP TABLE IF EXISTS " + m_name);
+    m_ds.exec("CREATE TABLE " + m_name + " " + columns);
+  }
+
+  //! \brief Drop the table. Best effort: the caller is done with it either way, and the next
+  //! call recovers from one left behind.
+  ~CTemporaryTable()
+  {
+    try
+    {
+      m_ds.exec("DROP TABLE IF EXISTS " + m_name);
+    }
+    catch (const dbiplus::DbErrors& e)
+    {
+      CLog::Log(LOGWARNING, "Unable to drop temporary table {}: {}", m_name, e.getMsg());
+    }
+    catch (...)
+    {
+      CLog::Log(LOGWARNING, "Unable to drop temporary table {}", m_name);
+    }
+  }
+
+  CTemporaryTable(const CTemporaryTable&) = delete;
+  CTemporaryTable& operator=(const CTemporaryTable&) = delete;
+  CTemporaryTable(CTemporaryTable&&) = delete;
+  CTemporaryTable& operator=(CTemporaryTable&&) = delete;
+
+private:
+  dbiplus::Dataset& m_ds;
+  const std::string m_name;
+};
 } // unnamed namespace
 
 CMusicDatabase::CMusicDatabase() : CDatabase(KODI::DATABASE::TYPE_MUSIC)
@@ -2369,22 +2430,26 @@ bool CMusicDatabase::DeleteArtistDiscography(int idArtist)
 
 bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
 {
+  if (nullptr == m_pDB)
+    return false;
+  if (nullptr == m_pDS)
+    return false;
+
+  /* Combine entries from discography and album tables.
+
+     Can not use CREATE TEMPORARY TABLE: MySQL can not refer to a temporary table more than once
+     in the same statement (ERROR 1137 "Can't reopen table"), which the year fixup below does.
+     The workaround MySQL documents for this is a common table expression, needing MySQL 8.0 -
+     above the 5.7.9 minimum this code supports.
+
+     Being ordinary tables they outlive this call, so CTemporaryTable owns them: it creates them,
+     replacing any an earlier failure left behind, and drops them on every exit path below.
+  */
   try
   {
-    if (nullptr == m_pDB)
-      return false;
-    if (nullptr == m_pDS)
-      return false;
-
-    /* Combine entries from discography and album tables
-       Can not use CREATE TEMPORARY TABLE as MySQL does not support updates of table using
-       correlated subqueries to a temp table. An updatable join to temp table would work in MySQL
-       but SQLite not support updatable joins.
-    */
-    m_pDS->exec("CREATE TABLE tempDisco "
-                "(strAlbum TEXT, strYear VARCHAR(4), mbid TEXT, idAlbum INTEGER)");
-    m_pDS->exec("CREATE TABLE tempAlbum "
-                "(strAlbum TEXT, strYear VARCHAR(4), mbid TEXT, idAlbum INTEGER)");
+    const std::string columns{"(strAlbum TEXT, strYear VARCHAR(4), mbid TEXT, idAlbum INTEGER)"};
+    const CTemporaryTable tempDisco{*m_pDS, "tempDisco", columns};
+    const CTemporaryTable tempAlbum{*m_pDS, "tempAlbum", columns};
 
     std::string strSQL;
     strSQL = PrepareSQL("INSERT INTO tempDisco(strAlbum, strYear, mbid, idAlbum) "
@@ -2446,6 +2511,7 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
 
     if (!m_pDS->query(strSQL))
       return false;
+
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -2471,15 +2537,15 @@ bool CMusicDatabase::GetArtistDiscography(int idArtist, CFileItemList& items)
 
     // cleanup
     m_pDS->close();
-    m_pDS->exec("DROP TABLE tempDisco");
-    m_pDS->exec("DROP TABLE tempAlbum");
 
     return true;
   }
+  catch (const dbiplus::DbErrors& e)
+  {
+    CLog::LogF(LOGERROR, "failed: {}", e.getMsg());
+  }
   catch (...)
   {
-    m_pDS->exec("DROP TABLE tempDisco");
-    m_pDS->exec("DROP TABLE tempAlbum");
     CLog::LogF(LOGERROR, "failed");
   }
   return false;


### PR DESCRIPTION
## Description

Two independent bugs that lose artist discography data. Both were found while chasing @the-black-eagle's report in https://github.com/xbmc/xbmc/pull/28770#issuecomment-5167084694.

**1. `GetArtistDiscography` leaks its temp tables.** `tempDisco` and `tempAlbum` are created with `CREATE TABLE`, not `CREATE TEMPORARY TABLE` (deliberately — see the comment in the function), so they outlive the call and live in `MyMusic*.db`. Two exit paths returned without dropping them: a failed `query()`, and the early return when the final `UNION` yields no rows.

That early return is reached for any artist with neither scraped discography entries nor albums in `album_artist` — a song-only artist such as a featured performer or composer that has never been scraped. The tables are left behind, and the *next* artist information dialog fails at `CREATE TABLE` with `table tempDisco already exists`, logging

```
ERROR <general>: CMusicDatabase::GetArtistDiscography: failed
```

and showing an empty discography. The `catch` block dropped the tables, so the call after that succeeded and the failure alternated.

Cleanup now goes through one helper used by every exit path, and runs before the tables are created so leftovers from an earlier failure are cleared — including any already sitting in a user's database. The helper uses `DROP TABLE IF EXISTS` and handles its own errors, so unlike the previous `catch` block it can no longer throw out of the function when the tables were never created.

**2. `AudioLibrary.SetArtistDetails` wipes discography and video links.** `UpdateArtist()` replaces both wholesale from the `CArtist` it is given: `DeleteArtistDiscography()` followed by inserting whatever `artist.discography` holds, and the same for video links. `SetArtistDetails` loaded the artist with `GetArtist(id, artist)`, leaving `fetchAll` at its default of `false`, so both vectors arrived empty. Changing any single artist field over JSON-RPC therefore deleted the artist's entire scraped discography and all of its video links — silently, with nothing logged.

Loading with `fetchAll` needs one accompanying fix to be safe: `GetArtist(fetchAll)` reads the discography from a `LEFT JOIN`, which yields one all-NULL row for an artist with no discography rows, and appended that as a blank `CDiscoAlbum`. Harmless while the result was only displayed, but it would now be written back as an empty discography row. Entries with no album title are skipped, matching what `GetArtistDiscography` already does when building the display list.

**Not** in scope, noted for the record: the XML import path (`MusicDatabase.cpp:12320`) has the same shape of bug. It does use `fetchAll=true`, but `MergeScrapedArtist` unconditionally does `discography = source.discography` and `CArtist::Load` calls `Reset()`, so importing an NFO with no `<album>` elements still clears the discography. Fixing that means deciding whether an import should be able to clear a discography at all, which is a design decision rather than a bug fix.

## Motivation and context

@the-black-eagle reported that "half the music library is not functional", naming discography and videolinks, and pasted `AddArtistDiscography` on the assumption that single-quote escaping had regressed.

That assumption does not hold for `AddArtistDiscography`. Its format string is `VALUES(%i, '%s', '%s', '%s')` with no `%%` anywhere, so `vprepare()` rewrites all three `%s` to `%q` and apostrophes are escaped correctly. The function is also unchanged since 2018. I verified this rather than assuming — see the testing section.

The videolinks half of that report is real and is fixed by #28870 (`LIKE '%%%s%%'`, broken by a35315e70). `MusicDatabase.cpp:2284` is the only music-side call site of that pattern. The discography half was unexplained; these are the two bugs behind it. Bug 1 is the source of the discography error line in his log. Bug 2 is the more damaging of the two, because it loses data with no log line at all.

Neither bug is a regression: bug 1 dates to 876fb9c100 (2018), bug 2 to d0c413ae71 (2013).

## How has this been tested?

**These changes have not been run inside Kodi — I had no build environment available.** Please treat the runtime behaviour as unverified and test before merging. What I did do instead:

Both bugs and both fixes were reproduced against real `sqlite3` using harnesses that copy the functions under test verbatim — master's `CDatabase::PrepareSQL(std::string_view, ...)` and `SqliteDatabase::vprepare()`, and the control flow of `GetArtistDiscography` — running against the real schema from `MusicDatabase.cpp:239`.

Ruling out the escaping theory for `AddArtistDiscography`:

```
INSERT ... VALUES(42, 'Rock ''n'' Roll', '1987', 'rg-mbid-2')   -> ok (1 row changed)
INSERT ... VALUES(42, '100% Dynamite', '1998', 'rg-mbid-3')     -> ok (1 row changed)
INSERT ... VALUES(42, 'Some Album', '', '')                     -> ok (1 row changed)
```

Apostrophes, literal `%` in the data, and empty strings all produce valid SQL and insert successfully. The same harness reproduces the videolinks failure that #28870 fixes, which confirms the harness is faithful:

```
... strTitle LIKE '%Sweet Child O' Mine%'  -> FAILED: near "Mine": syntax error
... strTitle LIKE '%Paradise City%'        -> ok
```

Bug 1, before and after. Sequence is: an artist with albums, then a song-only artist, then the first artist twice.

Before:
```
1. artist 1 (has albums)                (1 rows returned)                    leftover: 0
2. artist 2 (song-only, never scraped)  (0 rows -> early return)             leftover: 2
3. artist 1 again                       THREW: table tempDisco already exists
                                        LOG: GetArtistDiscography: failed    leftover: 0
4. artist 1 again                       (1 rows returned)                    leftover: 0
```

After:
```
1. artist 1 (has albums)                (1 rows returned)                    leftover: 0
2. artist 2 (song-only, never scraped)  (0 rows -> early return)             leftover: 0
3. artist 1 again                       (1 rows returned)                    leftover: 0
4. artist 1 again                       (1 rows returned)                    leftover: 0
```

One portability note on the blank-row guard in `GetArtist`: the obvious test, `get_isNull()` on the joined `discography.idArtist` column, is not portable. `MysqlDataset` only sets the null flag for `MYSQL_TYPE_NULL`; a NULL in an INTEGER column takes the `MYSQL_TYPE_LONG` branch, which calls `set_asInt(0)` and leaves `is_null` false (`mysqldataset.cpp:2062`). Testing the album title works on both backends and is what the display path already does.

`git clang-format --diff vendor/master` reports no changes.

## What is the effect on users?

Editing any artist field over JSON-RPC — which is what skins, remotes and scripts use to change artist details — no longer deletes that artist's scraped discography and music video links. Previously they were silently destroyed until the artist was scraped again.

Artist information dialogs no longer intermittently show an empty discography, and stray `tempDisco`/`tempAlbum` tables already present in a user's music database are cleaned up on the first call after upgrading.

## Screenshots (if appropriate):

N/A

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
