### PR TITLE
VAAPI: don't recover in-place after the VA context is torn down

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -676,12 +676,17 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecFFmpeg::GetPicture(VideoPicture* pVideoPi
     if (ret == VC_PICTURE)
     {
       if (m_pHardware->GetPicture(m_pCodecContext, pVideoPicture))
+      {
+        m_hwFailedCount = 0;
         return VC_PICTURE;
+      }
       else
         return VC_ERROR;
     }
     else if (ret == VC_BUFFER)
       ;
+    else if (ret == VC_FATAL)
+      return HandleHwFatal();
     else
       return ret;
   }
@@ -739,7 +744,10 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecFFmpeg::GetPicture(VideoPicture* pVideoPi
       if (ret == VC_PICTURE)
       {
         if (m_pHardware->GetPicture(m_pCodecContext, pVideoPicture))
+        {
+          m_hwFailedCount = 0;
           return VC_PICTURE;
+        }
         else
           return VC_ERROR;
       }
@@ -851,13 +859,15 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecFFmpeg::GetPicture(VideoPicture* pVideoPi
     }
     else if (ret == VC_FATAL)
     {
-      m_decoderState = STATE_HW_FAILED;
-      return VC_REOPEN;
+      return HandleHwFatal();
     }
     else if (ret == VC_PICTURE)
     {
       if (m_pHardware->GetPicture(m_pCodecContext, pVideoPicture))
+      {
+        m_hwFailedCount = 0;
         return VC_PICTURE;
+      }
       else
         return VC_ERROR;
     }
@@ -970,6 +980,16 @@ void CDVDVideoCodecFFmpeg::Reopen()
   {
     Dispose();
   }
+}
+
+CDVDVideoCodec::VCReturn CDVDVideoCodecFFmpeg::HandleHwFatal()
+{
+  m_hwFailedCount++;
+  CLog::Log(LOGWARNING,
+            "CDVDVideoCodecFFmpeg::{} - hw decode failure {} (consecutive), retrying hardware",
+            __FUNCTION__, m_hwFailedCount);
+  m_decoderState = STATE_NONE;
+  return VC_REOPEN;
 }
 
 bool CDVDVideoCodecFFmpeg::GetPictureCommon(VideoPicture* pVideoPicture)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -49,6 +49,7 @@ public:
 
 protected:
   void Dispose();
+  CDVDVideoCodec::VCReturn HandleHwFatal();
   static enum AVPixelFormat GetFormat(struct AVCodecContext * avctx, const AVPixelFormat * fmt);
 
   int  FilterOpen(const std::string& filters, bool scale);
@@ -85,6 +86,7 @@ protected:
 
   std::string m_name;
   int m_decoderState;
+  int m_hwFailedCount = 0;
   IHardwareDecoder *m_pHardware = nullptr;
   int m_iLastKeyframe = 0;
   double m_dts = DVD_NOPTS_VALUE;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.cpp
@@ -99,23 +99,7 @@ void CVAAPIContext::Release(CDecoder *decoder)
     m_decoders.erase(it);
 
   m_refCount--;
-  if (m_refCount <= 0)
-  {
-    Close();
-    delete this;
-    m_context = 0;
-  }
-}
-
-void CVAAPIContext::Close()
-{
-  CLog::Log(LOGINFO, "VAAPI::Close - closing decoder context");
-  if (m_renderNodeFD >= 0)
-  {
-    close(m_renderNodeFD);
-  }
-
-  DestroyContext();
+  CLog::Log(LOGDEBUG, LOGVIDEO, "VAAPI::{} - refCount now {}", __FUNCTION__, m_refCount);
 }
 
 bool CVAAPIContext::EnsureContext(CVAAPIContext **ctx, CDecoder *decoder)
@@ -225,23 +209,6 @@ bool CVAAPIContext::CreateContext()
     return false;
 
   return true;
-}
-
-void CVAAPIContext::DestroyContext()
-{
-  delete[] m_profiles;
-  if (m_display)
-  {
-    if (CheckSuccess(vaTerminate(m_display), "vaTerminate"))
-    {
-      m_display = NULL;
-    }
-    else
-    {
-      vaSetErrorCallback(m_display, nullptr, nullptr);
-      vaSetInfoCallback(m_display, nullptr, nullptr);
-    }
-  }
 }
 
 void CVAAPIContext::QueryCaps()
@@ -1091,15 +1058,10 @@ CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
       m_vaapiConfig.context->Release(this);
     m_vaapiConfig.context = 0;
 
-    if (CVAAPIContext::EnsureContext(&m_vaapiConfig.context, this) && ConfigVAAPI())
-    {
-      m_DisplayState = VAAPI_OPEN;
-    }
+    m_vaapiConfigured = false;
+    m_DisplayState = VAAPI_ERROR;
 
-    if (state == VAAPI_RESET)
-      return CDVDVideoCodec::VC_FLUSHED;
-    else
-      return CDVDVideoCodec::VC_ERROR;
+    return CDVDVideoCodec::VC_FATAL;
   }
 
   if (m_getBufferError > 0 && m_getBufferError < 5)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -424,10 +424,8 @@ public:
   static void FFReleaseBuffer(void *opaque, uint8_t *data);
 private:
   CVAAPIContext();
-  void Close();
   void SetVaDisplayForSystem();
   bool CreateContext();
-  void DestroyContext();
   void QueryCaps();
   bool CheckSuccess(VAStatus status, const std::string& function);
   bool IsValidDecoder(CDecoder *decoder);
@@ -435,6 +433,8 @@ private:
   static CVAAPIContext *m_context;
   static CCriticalSection m_section;
   VADisplay m_display = NULL;
+  // Diagnostics-only: nothing branches on this value (see Release()) --
+  // logged on change to make decoder-lifecycle issues visible.
   int m_refCount;
   int m_profileCount;
   VAProfile *m_profiles;


### PR DESCRIPTION
## Description
## VAAPI: don't recover in-place after the VA context is torn down

`CDecoder::Check()`'s `VAAPI_RESET`/`VAAPI_ERROR` handling tried to recover by rebuilding the VA context in place and continuing to use the same `AVCodecContext`. ffmpeg's VAAPI hwaccel caches the `VADisplay`/`VAContextID` it actually decodes against internally, captured once during initial `get_format()` negotiation, and never
re-reads them — so this recovery attempt ranged from a persistent stream of "invalid VAContextID" errors to a segfault when the cached `VADisplay` had actually been freed.

`Check()` now tears down cleanly and returns `VC_FATAL` instead, signaling that only a full codec close/reopen can recover.

`CDVDVideoCodecFFmpeg::GetPicture()` handles `VC_FATAL` at both mid-stream hardware-decode call sites via a new `HandleHwFatal()`, which always retries hardware via a full `Reopen()` rather than
falling back to software — a hardware device that's genuinely, permanently gone still lands on software on its own, since `GetFormat()` has its own independent fallback for that case. The drain call site needs no distinct handling: `VC_FATAL` there is folded into the existing generic end-of-stream case, since retrying after the stream has already ended has nothing left to recover.

The shared, process-wide CVAAPIContext singleton was destroyed based on a simple refcount, but ffmpeg's own hwaccel state caches the raw VADisplay pointer independently. A slow-to-drain decoder from an earlier failure/channel-switch could drop the shared context's refcount to zero and vaTerminate() it while a different, still-active decoder was mid-use → later avcodec_free_context() crash. Fix: stop destroying the shared CVAAPIContext/VADisplay on refcount reaching zero — keep it alive for the process lifetime; EnsureContext() already reuses it.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
