### PR TITLE
[PVR] CPVRFileItemListModifier: Exclude parent folder items from resolution

### DIFF
--- a/xbmc/pvr/guilib/PVRFileItemListModifier.cpp
+++ b/xbmc/pvr/guilib/PVRFileItemListModifier.cpp
@@ -27,8 +27,12 @@ bool NeedsResolving(const CFileItem& item)
   // Items created by add-ons that only know the item's path (rather than by PVR-internal code,
   // which always attaches the respective PVR tag) need to be resolved before use, e.g. to be
   // able to show proper art and info for them.
-  return URIUtils::IsPVR(item.GetPath()) && !item.HasPVRChannelInfoTag() &&
-         !item.HasPVRRecordingInfoTag() && !item.HasEPGInfoTag() && !item.HasPVRTimerInfoTag();
+  // Note: Parent folder items ("..") must never be resolved. They only carry the path of the
+  // parent folder as navigation aid and resolving them would wrongly decorate them with the
+  // parent folder's data, for example watched/total counts and overlay icons.
+  return !item.IsParentFolder() && URIUtils::IsPVR(item.GetPath()) &&
+         !item.HasPVRChannelInfoTag() && !item.HasPVRRecordingInfoTag() && !item.HasEPGInfoTag() &&
+         !item.HasPVRTimerInfoTag();
 }
 } // unnamed namespace
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Do not calculate watched/unwatched states for parent ("..") folders. See screenshot for problem description.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes a small regression introduced with #28893

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually, by checking visually.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Looks like before (and should look like). Those numbers/status icon attached to the parent folder item are correct, but of no value, at least is confusing. And computation costs some extra time (parent directory listing when populating child directory).

## Screenshots (if appropriate):
<img width="1710" height="1107" alt="Screenshot 2026-08-12 at 07 46 12" src="https://github.com/user-attachments/assets/8c80137c-b5df-4822-b13f-df6a32f8efc1" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
