### PR TITLE
[weather] Fix stale images after weather update

### DIFF
--- a/xbmc/weather/GUIWindowWeather.cpp
+++ b/xbmc/weather/GUIWindowWeather.cpp
@@ -87,6 +87,7 @@ bool CGUIWindowWeather::OnMessage(CGUIMessage& message)
       {
         UpdateLocations();
         SetProps();
+        RefreshImages();
         return true;
       }
       break;
@@ -294,4 +295,16 @@ void CGUIWindowWeather::ClearProps()
     if (!value.isNull())
       SetProperty(name, value);
   }
+}
+
+void CGUIWindowWeather::RefreshImages()
+{
+  // The add-on might have replaced the image files it provides (for example the images of an
+  // animated radar loop) without changing the window properties containing the image paths.
+  // Tell the controls of this window to reload their images to avoid displaying stale data.
+  // This is essential for controls that were hidden while the update was in progress (for
+  // example via 'Weather.IsUpdating'), because hidden controls do not re-evaluate their image
+  // paths and thus never notice changed content.
+  CGUIMessage msg{GUI_MSG_NOTIFY_ALL, GetID(), 0, GUI_MSG_REFRESH_THUMBS};
+  OnMessage(msg);
 }

--- a/xbmc/weather/GUIWindowWeather.h
+++ b/xbmc/weather/GUIWindowWeather.h
@@ -27,6 +27,7 @@ protected:
   void UpdateLocations();
   void SetProps();
   void ClearProps();
+  void RefreshImages();
   void SetLocation(int loc);
 
 private:


### PR DESCRIPTION
## Description

After a weather update completed, tell the controls of the weather window to reload their
images, using the existing `GUI_MSG_REFRESH_THUMBS` mechanism. Only controls with
non-constant image paths are affected; constant skin textures are left untouched.

A weather add-on may replace the image files it provides without changing the window
properties that contain the paths to these files. `multiimage` controls read their image
folder exactly once (`CGUIMultiImage::LoadDirectory()`); afterwards the file list is only
re-read when the *resolved path* changes (`CGUIMultiImage::UpdateInfo()`). Until now, this
happened by accident: `CGUIWindowWeather::ClearProps()` wipes all add-on supplied window
properties at the start of every update, and `CWeatherManager::GetProperty()` returns an
empty string for those properties while an update is in progress. Any *visible* control
therefore observed a path change and re-read its content afterwards.

A control that is hidden for the duration of the update - for example a group with
`<visible>!Weather.IsUpdating</visible>` - never observes that path change: while a group
is invisible its `Process()` is not called, and thus neither `UpdateVisibility()` nor
`UpdateInfo()` of its children. When the group becomes visible again, the property value is
identical to the value before the update, so no reload is triggered and the control keeps
serving its outdated file list.

## Motivation and context

Fixes https://github.com/xbmc/xbmc/issues/28059

The reporter's skin hides the weather content via `<visible>!Weather.IsUpdating</visible>`
and shows an animated BOM radar loop via a `multiimage` pointing at a folder filled by the
OzWeather add-on. That add-on renames every image in the loop folder on every refresh, so
after an update the control's cached file list refers exclusively to files that no longer
exist and nothing is rendered at all. Only a skin reload or leaving and re-entering the
weather window brought the radar back.

## How has this been tested?

Tested on macOS with the skin and the add-on named in the issue (a patched Confluence plus
OzWeather with extended features enabled and a rainy location configured).

- Before the change: triggering a refresh in the weather window makes the animated radars
  disappear permanently; they only return after a skin reload or after leaving and
  re-entering the weather window.
- After the change: the radars keep animating across refreshes and pick up the newly
  downloaded images.

## What is the effect on users?

Images supplied by a weather add-on are no longer stale after a weather update. This is most
visible with skins that hide parts of the weather window while an update is in progress (for
example via `Weather.IsUpdating`) and that display content whose files are replaced by the
add-on, such as animated radar loops.

## Screenshots (if appropriate):

See the screen recording in https://github.com/xbmc/xbmc/issues/28059.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
