### PR TITLE
Games: Make rumble reach the controller

### DIFF
--- a/xbmc/games/addons/input/GameClientJoystick.cpp
+++ b/xbmc/games/addons/input/GameClientJoystick.cpp
@@ -199,6 +199,15 @@ void CGameClientJoystick::ClearSource()
   m_sourcePeripheral.reset();
 }
 
+JOYSTICK::IInputReceiver* CGameClientJoystick::InputReceiver(void)
+{
+  // Answer with the port's receiver, not this handler's. CPortInput is what
+  // registers with the peripheral, so it is what the peripheral attaches its
+  // receiver to; this class sits behind it and is never given one, so every
+  // motor event a game produced was dropped, for every core.
+  return m_portInput ? m_portInput->InputReceiver() : nullptr;
+}
+
 bool CGameClientJoystick::SetRumble(const std::string& feature, float magnitude)
 {
   bool bHandled = false;

--- a/xbmc/games/addons/input/GameClientJoystick.h
+++ b/xbmc/games/addons/input/GameClientJoystick.h
@@ -73,6 +73,7 @@ public:
                         float position,
                         unsigned int motionTimeMs) override;
   void OnInputFrame() override {}
+  JOYSTICK::IInputReceiver* InputReceiver(void) override;
 
   // Input accessors
   const std::string& GetPortAddress() const { return m_portAddress; }

--- a/xbmc/input/joysticks/interfaces/IInputHandler.h
+++ b/xbmc/input/joysticks/interfaces/IInputHandler.h
@@ -161,7 +161,16 @@ public:
   // Input receiver interface
   void SetInputReceiver(IInputReceiver* receiver) { m_receiver = receiver; }
   void ResetInputReceiver(void) { m_receiver = nullptr; }
-  IInputReceiver* InputReceiver(void) { return m_receiver; }
+
+  /*!
+   * \brief The receiver that input can be sent back to
+   *
+   * A handler that is registered with a peripheral is given a receiver and
+   * answers with it. A handler that sits behind another one is never given
+   * one, and overrides this to answer with the receiver of the handler in
+   * front of it, so that callers can ask the handler they hold.
+   */
+  virtual IInputReceiver* InputReceiver(void) { return m_receiver; }
 
 private:
   IInputReceiver* m_receiver = nullptr;

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -9,6 +9,9 @@
 #include "AddonButtonMap.h"
 
 #include "PeripheralAddonTranslator.h"
+#include "games/controllers/Controller.h"
+#include "games/controllers/ControllerManager.h"
+#include "games/controllers/input/PhysicalFeature.h"
 #include "input/joysticks/JoystickUtils.h"
 #include "peripherals/Peripherals.h"
 #include "peripherals/devices/Peripheral.h"
@@ -180,6 +183,29 @@ bool CAddonButtonMap::GetScalar(const FeatureName& feature, CDriverPrimitive& pr
     {
       primitive = CPeripheralAddonTranslator::TranslatePrimitive(
           addonFeature.Primitive(JOYSTICK_SCALAR_PRIMITIVE));
+      retVal = true;
+    }
+  }
+  else
+  {
+    // Nothing has mapped this feature. If the controller profile calls it a
+    // motor, map it here by position rather than leaving it unmapped.
+    //
+    // Motors cannot be mapped the way everything else is. The configuration
+    // wizard asks the user to activate each feature in turn, and a motor is
+    // not something that can be activated, so the wizard never offers one and
+    // no button map has ever contained a motor entry. The result is that a
+    // game asking for rumble finds nothing to drive, on every controller.
+    //
+    // Position is the only thing available to map by, and it is what the
+    // drivers use: the first motor a controller declares is the strong one,
+    // the second the weak one, matching the order evdev reports them. A
+    // controller with no motors, or a device with fewer than it declares,
+    // yields an index the driver rejects, which is the same as today.
+    unsigned int motorIndex = 0;
+    if (GetMotorIndex(feature, motorIndex))
+    {
+      primitive = CDriverPrimitive(PRIMITIVE_TYPE::MOTOR, motorIndex);
       retVal = true;
     }
   }
@@ -554,6 +580,31 @@ void CAddonButtonMap::RevertButtonMap()
 {
   if (auto addon = m_addon.lock())
     addon->RevertButtonMap(m_device);
+}
+
+bool CAddonButtonMap::GetMotorIndex(const FeatureName& feature, unsigned int& motorIndex) const
+{
+  const KODI::GAME::ControllerPtr controller =
+      m_manager.GetControllerProfiles().GetController(m_strControllerId);
+  if (!controller)
+    return false;
+
+  unsigned int index = 0;
+  for (const auto& physicalFeature : controller->Features())
+  {
+    if (physicalFeature.Type() != KODI::JOYSTICK::FEATURE_TYPE::MOTOR)
+      continue;
+
+    if (physicalFeature.Name() == feature)
+    {
+      motorIndex = index;
+      return true;
+    }
+
+    ++index;
+  }
+
+  return false;
 }
 
 CAddonButtonMap::DriverMap CAddonButtonMap::CreateLookupTable(const FeatureMap& features)

--- a/xbmc/peripherals/addons/AddonButtonMap.h
+++ b/xbmc/peripherals/addons/AddonButtonMap.h
@@ -122,6 +122,17 @@ private:
   typedef std::map<KODI::JOYSTICK::CDriverPrimitive, KODI::JOYSTICK::FeatureName> DriverMap;
   typedef std::vector<KODI::JOYSTICK::CDriverPrimitive> JoystickPrimitiveVector;
 
+  /*!
+   * \brief Position of a motor among the motors this controller declares
+   *
+   * Motors are never mapped by the configuration wizard, because a motor is
+   * not something the user can activate on request. Position is what the
+   * drivers order them by, so it is what they are matched on here.
+   *
+   * \return True if the controller declares this feature as a motor
+   */
+  bool GetMotorIndex(const KODI::JOYSTICK::FeatureName& feature, unsigned int& motorIndex) const;
+
   // Utility functions
   static DriverMap CreateLookupTable(const FeatureMap& features);
 


### PR DESCRIPTION
## Description

Rumble does not work for any game client, with any controller. There are two causes on the Kodi side and this fixes both.

**The request never reaches the peripheral.** `CGameClientJoystick::SetRumble` reads `InputReceiver()`, which is always null there. The receiver belongs to `CPortInput` — that is what calls `RegisterInputHandler`, so that is what `CAddonInputHandling` attaches its `CDriverReceiving` to. `CGameClientJoystick` sits behind it and is never given one, so every motor event a game produced was dropped.

**Nothing ever maps a motor.** With the above fixed, the request reaches the peripheral and is refused, because the button map has no entry for the feature. Every other feature is mapped by the configuration wizard, which asks the user to activate each one in turn. A motor cannot be activated on request, so the wizard never offers one — and no button map contains a motor entry. Not the shipped ones (none of the 43 Linux button maps has a motor), and not user-generated ones, because there is no path in the UI to create one.

Position is the only thing available to map a motor by, and it is what the drivers order them by: the first motor a controller declares is the strong one, the second the weak one, matching the order evdev reports them. When the button map has no entry and the controller profile calls the feature a motor, this maps it to that position.

A controller declaring no motors is unaffected. A device with fewer motors than the controller declares yields an index its driver rejects, which is what happens today.

## Motivation and context

Rumble has never worked in RetroPlayer. The failure is silent from every angle: the core requests the rumble interface and gets it, the game add-on maps the motor to a controller feature, the request is well-formed the whole way down, and nothing happens. Nothing logs a reason, so from a user's perspective it is indistinguishable from a controller that cannot rumble or an emulator that does not use it.

Two further causes outside Kodi were also involved and are addressed in xbmc/peripheral.joystick#347: the Linux driver defaulting to a backend with no force feedback at all (`CJoystickLinux` has no `SetMotorState`), and a force-feedback effect-slot leak that exhausted the device after a few buzzes. This PR is the Kodi half; both halves are needed.

## How has this been tested?

Confirmed on hardware, not inferred.

**Environment:** LibreELEC 13.0 (x86_64, GBM/GLES), Kodi 22, 8BitDo Pro 2 over Bluetooth.

**Cores:** Flycast (Dreamcast), Mupen64Plus-Next (N64), and a PlayStation core.

The two faults were isolated one at a time by instrumenting the failure point, and the log shows each being reached in turn as the previous was resolved:

1. Before the receiver fix — the request stopped at a null receiver.
2. After it — the request reached the peripheral, which then refused it, revealing that nothing maps a motor.
3. After the motor mapping — the peripheral accepted a real non-zero magnitude.

With the peripheral.joystick fixes applied alongside, the controller physically rumbles in games. Regression-checked that ordinary input (buttons, analog sticks, triggers) is unaffected on the same controllers.

The instrumentation used to find this was deliberately not included here; it is diagnostic scaffolding rather than part of the fix.

## What is the effect on users?

Rumble works in RetroPlayer games for controllers that support it, where previously it never did on any platform.

No effect on users whose controllers have no motors, and no change to any other input handling.

## Screenshots (if appropriate):

N/A — the effect is haptic.

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

Being straight about the last two rather than ticking them: I have not added unit tests, and I have not run the full test suite — this was verified by running games on hardware. Happy to add coverage if you would like it, though the fault is in the interaction between three classes and a driver, which unit tests would struggle to reach.

One thing worth reviewer attention: the motor mapping matches by **position**, because there is nothing else to match on. That relies on drivers ordering motors consistently — strong first, weak second — which they do, but it is a convention rather than something the button map states. If you would prefer it expressed explicitly I am happy to rework it.
