### PR TITLE
Game API 7.0.0: Drive the asynchronous audio interface

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
@@ -632,7 +632,41 @@ public:
   //--==----==----==----==----==----==----==----==----==----==----==----==----==--
 
   //============================================================================
-  /// @defgroup cpp_kodi_addon_game_InputOperations 4. Input operations
+  ///
+  /// @defgroup cpp_kodi_addon_game_Audio 4. Audio operations
+  /// @ingroup cpp_kodi_addon_game
+  /// @brief **Audio operations**
+  ///
+  ///---------------------------------------------------------------------------
+  ///
+  /// **Audio operation parts in interface:**\n
+  /// Copy this to your project and extend with your parts or leave functions
+  /// complete away where not used or supported.
+  ///
+  /// @copydetails cpp_kodi_addon_game_Audio_header_addon_auto_check
+  /// @copydetails cpp_kodi_addon_game_Audio_source_addon_auto_check
+  ///
+  ///@{
+
+  //==========================================================================
+  /// @brief Tell the client the frontend is ready for audio
+  ///
+  /// Only implemented by clients that asked for the asynchronous audio
+  /// interface. Such a client produces no audio of its own accord: it waits to
+  /// be asked, then writes what it has through AddStreamData() on the thread
+  /// this was called from.
+  ///
+  /// @return The error, or GAME_ERROR_NO_ERROR if audio was handled
+  ///
+  virtual GAME_ERROR AudioAvailable() { return GAME_ERROR_NOT_IMPLEMENTED; }
+  //--------------------------------------------------------------------------
+
+  ///@}
+
+  //--==----==----==----==----==----==----==----==----==----==----==----==----==--
+
+  //============================================================================
+  /// @defgroup cpp_kodi_addon_game_InputOperations 5. Input operations
   /// @ingroup cpp_kodi_addon_game
   /// @brief **Input operations**
   ///
@@ -808,7 +842,7 @@ public:
   //--==----==----==----==----==----==----==----==----==----==----==----==----==--
 
   //============================================================================
-  /// @defgroup cpp_kodi_addon_game_SerializationOperations 5. Serialization operations
+  /// @defgroup cpp_kodi_addon_game_SerializationOperations 6. Serialization operations
   /// @ingroup cpp_kodi_addon_game
   /// @brief **Serialization operations**
   ///
@@ -861,7 +895,7 @@ public:
   //--==----==----==----==----==----==----==----==----==----==----==----==----==--
 
   //============================================================================
-  /// @defgroup cpp_kodi_addon_game_CheatOperations 6. Cheat operations
+  /// @defgroup cpp_kodi_addon_game_CheatOperations 7. Cheat operations
   /// @ingroup cpp_kodi_addon_game
   /// @brief **Cheat operations**
   ///
@@ -1080,7 +1114,7 @@ public:
   //--==----==----==----==----==----==----==----==----==----==----==----==----==--
 
   //============================================================================
-  /// @defgroup cpp_kodi_addon_game_DiscOperations 5. Disc operations
+  /// @defgroup cpp_kodi_addon_game_DiscOperations 8. Disc operations
   /// @ingroup cpp_kodi_addon_game
   /// @brief **Disc operations**
   ///
@@ -1243,6 +1277,8 @@ private:
     instance->game->toAddon->HwContextReset = ADDON_HwContextReset;
     instance->game->toAddon->HwContextDestroy = ADDON_HwContextDestroy;
 
+    instance->game->toAddon->AudioAvailable = ADDON_AudioAvailable;
+
     instance->game->toAddon->HasFeature = ADDON_HasFeature;
     instance->game->toAddon->GetTopology = ADDON_GetTopology;
     instance->game->toAddon->FreeTopology = ADDON_FreeTopology;
@@ -1360,6 +1396,13 @@ private:
   inline static GAME_ERROR ADDON_HwContextDestroy(const AddonInstance_Game* instance)
   {
     return static_cast<CInstanceGame*>(instance->toAddon->addonInstance)->HwContextDestroy();
+  }
+
+  // --- Audio operations --------------------------------------------------------
+
+  inline static GAME_ERROR ADDON_AudioAvailable(const AddonInstance_Game* instance)
+  {
+    return static_cast<CInstanceGame*>(instance->toAddon->addonInstance)->AudioAvailable();
   }
 
   // --- Input operations --------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
@@ -1262,6 +1262,7 @@ extern "C"
     GAME_ERROR(__cdecl* Reset)(const struct AddonInstance_Game*);
     GAME_ERROR(__cdecl* HwContextReset)(const struct AddonInstance_Game*);
     GAME_ERROR(__cdecl* HwContextDestroy)(const struct AddonInstance_Game*);
+    GAME_ERROR(__cdecl* AudioAvailable)(const AddonInstance_Game*);
     bool(__cdecl* HasFeature)(const struct AddonInstance_Game*, const char*, const char*);
     game_input_topology*(__cdecl* GetTopology)(const struct AddonInstance_Game*);
     void(__cdecl* FreeTopology)(const struct AddonInstance_Game*, struct game_input_topology*);

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -97,8 +97,8 @@
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_DEPENDS   "c-api/addon-instance/audioencoder.h" \
                                                       "addon-instance/AudioEncoder.h"
 
-#define ADDON_INSTANCE_VERSION_GAME                   "6.0.0"
-#define ADDON_INSTANCE_VERSION_GAME_MIN               "6.0.0"
+#define ADDON_INSTANCE_VERSION_GAME                   "7.0.0"
+#define ADDON_INSTANCE_VERSION_GAME_MIN               "7.0.0"
 #define ADDON_INSTANCE_VERSION_GAME_XML_ID            "kodi.binary.instance.game"
 #define ADDON_INSTANCE_VERSION_GAME_DEPENDS           "addon-instance/Game.h"
 

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -549,6 +549,17 @@ void CGameClient::RunFrame()
     try
     {
       LogError(m_ifc.game->toAddon->RunFrame(m_ifc.game), "RunFrame()");
+
+      // A client using the asynchronous audio interface produces no audio of
+      // its own accord: it waits to be asked, once per frame, and writes what
+      // it has from this thread. One that is never asked is silent, and since
+      // the frame rate is paced against the audio it delivers, it also runs as
+      // fast as the machine allows. Clients on the ordinary synchronous path
+      // answer this with GAME_ERROR_NOT_IMPLEMENTED and are unaffected.
+      const GAME_ERROR audioError = m_ifc.game->toAddon->AudioAvailable(m_ifc.game);
+      if (audioError != GAME_ERROR_NO_ERROR && audioError != GAME_ERROR_NOT_IMPLEMENTED)
+        LogError(audioError, "AudioAvailable()");
+
       m_hasFrameRun = true;
     }
     catch (...)


### PR DESCRIPTION
## Description

Kodi accepts a game client's registration for the asynchronous audio interface and then never asks it for audio.

A client on that interface produces no audio of its own accord — it waits to be asked, and writes what it has from the thread it was asked on. Since nothing ever asks, it stays silent for the whole session.

`game.libretro` has had the client half implemented for years, with a comment noting *"this function is not part of the Game API yet"*. This adds `AudioAvailable()` to the Game API and calls it once per frame, alongside `RunFrame()`.

Adding an entry to `KodiToAddonFuncTable_Game` changes the layout of a struct shared with add-on binaries, so the game instance version moves to **7.0.0** with `_MIN` to match.

## Motivation and context

Silence is not the only symptom. The frame rate is paced against the audio a client delivers, so a client that is never asked also runs as fast as the machine allows rather than at the speed of the console. That is how this was found: a Dreamcast core running at roughly double speed with no sound at all.

Clients on the ordinary synchronous audio path are unaffected — they inherit the default `AudioAvailable()`, which returns `GAME_ERROR_NOT_IMPLEMENTED`.

Reviewed and approved by @garbear on garbear/xbmc#153, who asked for API changes to be raised against master ahead of the B2 freeze.

**Sequencing note for maintainers:** garbear/xbmc#150 (RetroAchievements callbacks) also moves this version to 7.0.0 and will conflict with this PR on `versions.h`. @garbear mentioned plotting a path to merge both Game API bumps together.

## How has this been tested?

**Environment:** LibreELEC 13.0 (x86_64, GBM/GLES), Kodi 22.

**Core:** Flycast (Dreamcast) via `game.libretro`.

The client goes from producing no audio at all to producing audio, and the frame pacing follows rather than running unbounded.

Verified that synchronous-audio clients are unaffected by running Mupen64Plus-Next, PPSSPP, melonDS and a NES core on the same build — all answer `GAME_ERROR_NOT_IMPLEMENTED` and behave exactly as before.

One caveat stated plainly: Flycast needed a separate `game.libretro` fix (answering `RETRO_ENVIRONMENT_GET_FASTFORWARDING`) before it produced any audio at all, so that core exercised both changes together. The reasoning for this change stands on its own — the interface is registered by the frontend and then never driven — but I would rather flag that than imply a cleaner isolation than I had.

## What is the effect on users?

Game add-ons using the asynchronous audio interface produce sound, where previously they were silent and ran unthrottled.

**Add-on compatibility:** the Game API version moves to 7.0.0 and `_MIN` with it, so existing game add-ons need rebuilding against the new API. No source change is required in them.

## Screenshots (if appropriate):

N/A — the effect is audible.

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [X] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

Marked as both: the behaviour change is a fix, but the ABI bump means existing game add-ons must be rebuilt.

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

The documentation boxes refer to the Doxygen comments added alongside the new API function in `Game.h` and `game.h`, describing what a client should do with it.

Being straight about the last two rather than ticking them: no unit tests added, and I have not run the full suite — this was verified by running games on hardware.
