### PR TITLE
[GUI] Fix widget directory job reuse with differing options

### DIFF
--- a/xbmc/guilib/listproviders/DirectoryProvider.cpp
+++ b/xbmc/guilib/listproviders/DirectoryProvider.cpp
@@ -227,6 +227,7 @@ public:
                 CDirectoryProvider::BrowseMode browse,
                 int parentID)
     : m_url(url),
+      m_targetKey(target),
       m_target(target),
       m_sort(sort),
       m_limit(limit),
@@ -242,7 +243,12 @@ public:
     if (strcmp(job->GetType(), GetType()) == 0)
     {
       const auto* dirJob = dynamic_cast<const CDirectoryJob*>(job);
-      if (dirJob && dirJob->m_url == m_url)
+      if (dirJob && dirJob->m_url == m_url && dirJob->m_targetKey == m_targetKey &&
+          dirJob->m_sort.sortBy == m_sort.sortBy && dirJob->m_sort.sortOrder == m_sort.sortOrder &&
+          dirJob->m_sort.sortAttributes == m_sort.sortAttributes &&
+          dirJob->m_sort.limitStart == m_sort.limitStart &&
+          dirJob->m_sort.limitEnd == m_sort.limitEnd && dirJob->m_limit == m_limit &&
+          dirJob->m_browse == m_browse && dirJob->m_parentID == m_parentID)
         return true;
     }
     return false;
@@ -352,6 +358,7 @@ public:
 
 private:
   std::string m_url;
+  std::string m_targetKey;
   std::string m_target;
   SortDescription m_sort;
   unsigned int m_limit{10};


### PR DESCRIPTION
## Description
Fixes directory provider job reuse for widgets that use the same content path with different sort, limit, browse, target, or parent options.

Previously, directory jobs were considered equal when their URL matched. After job callback sharing was added, multiple widgets using the same path could incorrectly receive the first widget's sorted or limited result set.

This updates the directory job equality check so jobs are only shared when all output-affecting options match.

## Motivation and context
Fixes widgets that display the wrong items when multiple home widgets use the same directory path with different content options.

Fixes #28328.

This appears to be a regression from #27622, where matching jobs can share callbacks instead of starting duplicate work. That exposed an existing weakness in directory provider job comparison: jobs using the same URL were treated as equal even when their output-affecting options differed.

## How has this been tested?
Tested with temporary Estuary skin changes using multiple home widgets with the same content path:

- `videodb://movies/titles/`, sorted by title ascending, limit 5
- same path, sorted by year ascending, limit 2
- same path, sorted by rating ascending, limit 3
- same path, sorted by studio ascending, limit 4
- duplicate title ascending widget with the same path/options to confirm identical jobs are still shared
- title descending widget to confirm sort order differences are handled
- same path/sort/order with different limits to confirm limit differences are handled
- same path/sort/order/limit with different browse modes to confirm browse differences are handled
- same path/sort/order/limit/browse with different targets to confirm target differences are handled

All widgets displayed the expected independent contents. Duplicate widgets with identical options displayed matching contents as expected.

Files: 
[Includes_Home.xml](https://github.com/user-attachments/files/31064746/Includes_Home.xml)
[Home.xml](https://github.com/user-attachments/files/31064747/Home.xml)

## What is the effect on users?
Home widgets using the same content path but different options now show the correct content for each widget.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed