### PR TITLE
[filesystem][CurlFile] Treat CURLE_SEND_ERROR as a transient error

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -163,7 +163,7 @@ static bool IsTransientCurlError(CURLcode result)
 {
   return result == CURLE_OPERATION_TIMEDOUT || result == CURLE_PARTIAL_FILE ||
          result == CURLE_COULDNT_CONNECT || result == CURLE_HTTP2_STREAM ||
-         result == CURLE_RECV_ERROR;
+         result == CURLE_RECV_ERROR || result == CURLE_SEND_ERROR;
 }
 
 static CURLcode PerformWithTransientRetries(CURL_HANDLE* easyHandle,


### PR DESCRIPTION
## Description

`IsTransientCurlError()` retries `CURLE_RECV_ERROR` (56) but not its write-side counterpart `CURLE_SEND_ERROR` (55). Both are commonly raised when an established connection is discovered to be dead — which one surfaces depends only on whether curl's next syscall on that socket happened to be a read or a write.

In `CReadState::FillBuffer()` a transient error reaches the reconnect path that calls `SetResume()` and re-adds the easy handle. Everything else (apart from the range-error special case) returns `FILLBUFFER_FAIL` without reconnecting. A 55 therefore ends the transfer permanently: `CFileCache` keeps retrying the read until it runs out of buffered data, reports EOF, and `VideoPlayer` treats that as a clean end of file — so playback stops in the middle of an item and the item is reported as *ended* rather than failed.

## Motivation and context

This has bitten me repeatedly in normal use: pause a movie playing from a WebDAV/HTTPS share for a few minutes, come back, resume, and playback silently ends partway through. Because Kodi reports it as a normal end of playback there is no error on screen and nothing obviously wrong in the log unless you go looking for the curl error.

From a single 24-hour log on a Kodi 22 client (nginx origin, HTTP/2) there were nine curl transport errors on the streaming path:

* **8 ×** `Failed: Failure when receiving data from the peer(56)` — each immediately followed by `Reconnect, (re)try 1`, all recovered and playback continued
* **1 ×** `Failed: Failed sending data to the peer(55)` — no reconnect logged, then:

```
22:34:06 error CCurlFile::CReadState::FillBuffer - Failed: Failed sending data to the peer(55)
22:34:08 warning CFileCache::Process - source read returned -1! Will retry
   ...     (repeated "source read returned 0! Will retry")
22:35:06 error CFileCache::Process - source read didn't return any data before eof!
22:35:08 info  Process - eof reading from demuxer
22:35:08 info  CVideoPlayer::OnExit()
22:35:09 debug CApplicationPlayerCallback::OnPlayBackEnded(): call
```

45 minutes into a ~1h40m movie. Same code, same machine, same session — the outcome split purely on which error code curl returned.

## Relationship to #26476

This is a direct follow-up to b3a279293350b78509a31f433a8a5c63dc5d317a (#26476) by @EBADBEEF, which added `CURLE_HTTP2_STREAM` to this same list, for this same pause-and-resume scenario. That fixed the code which surfaced in that reporter's setup. On HTTP/2 a dead idle connection can equally surface as 55 or 56 depending on timing — the resumed transfer must emit a `WINDOW_UPDATE` before it can receive more data, so the first syscall on the dead socket can be a write — so the send side was left behind.

cc @EBADBEEF — you may well recognise this failure mode.

## How has this been tested?

I want to be straightforward about this: **not by a controlled reproduction.**

The failure is timing dependent and I could not force it synthetically. Restarting or reloading nginx does not sever a paused stream, because nginx keeps its old worker processes alive to finish in-flight requests. Killing the connection from the client side did not land reliably either, because once Kodi's cache is full the socket sits idle and sends nothing to trigger the failure. Several attempts along both lines either recovered normally or produced no error at all.

The basis for the change is therefore the production logs above plus the code path, not a green test run. What supports it:

* The change is symmetrical with the `CURLE_RECV_ERROR` handling that is already there, so it introduces no new class of retry behaviour.
* The `!m_bFirstLoop` guard is untouched, so streaming recovery stays limited to transfers that had already started successfully.
* The other consumer, `PerformWithTransientRetries()` (used by `Exists()` and `Stat()`), also picks this up. Those are HEAD or short-range GET probes, so retrying them on a send error is safe and desirable for the same reason.

Happy to adjust the wording or scope if maintainers would rather see this restricted to just the `FillBuffer()` path.

## Types of change

* Bugfix
