### PR TITLE
[Video][Bluray] Two small fixes in the bluray M2TSParser used to identify stream details at scrape.

### DIFF
--- a/xbmc/filesystem/bluray/M2TSParser.cpp
+++ b/xbmc/filesystem/bluray/M2TSParser.cpp
@@ -1351,6 +1351,19 @@ bool ParseH265SPS(const std::span<std::byte>& buffer, TSVideoStreamInfo* streamI
   return true;
 }
 
+void ParseH264ScalingList(BitReader& br, int sizeOfScalingList)
+{
+  int lastScale{8};
+  int nextScale{8};
+  for (int j = 0; j < sizeOfScalingList; j++)
+  {
+    if (nextScale != 0)
+      nextScale = (lastScale + br.ReadSE() + 256) % 256;
+    if (nextScale != 0)
+      lastScale = nextScale;
+  }
+}
+
 bool ParseH264SPS(const std::span<std::byte>& buffer, TSVideoStreamInfo* streamInfo)
 {
   CLog::LogFC(LOGDEBUG, LOGBLURAY, "Parsing H264 SPS");
@@ -1378,7 +1391,8 @@ bool ParseH264SPS(const std::span<std::byte>& buffer, TSVideoStreamInfo* streamI
     if (br.ReadBits(1) == 1) // seq_scaling_matrix_present_flag
     {
       for (int i = 0; i < ((chroma_format != 3) ? 8 : 12); i++)
-        br.SkipBits(1);
+        if (br.ReadBits(1) == 1) // seq_scaling_list_present_flag[i]
+          ParseH264ScalingList(br, i < 6 ? 16 : 64);
     }
   }
   else
@@ -1423,10 +1437,13 @@ bool ParseH264SPS(const std::span<std::byte>& buffer, TSVideoStreamInfo* streamI
     frame_crop_bottom_offset = br.ReadUE();
   }
 
+  // Crop offsets are in units of CropUnitX/CropUnitY, not luma samples (7-19 to 7-22). Blurays are
+  // always 4:2:0, so CropUnitX is 2 and CropUnitY is 2 * (2 - frame_mbs_only_flag)
+  const unsigned int cropUnitY{frame_mbs_only_flag ? 2u : 4u};
   streamInfo->width =
       pic_width_in_mbs * 16 - (frame_crop_left_offset + frame_crop_right_offset) * 2;
   streamInfo->height = (2 - (frame_mbs_only_flag ? 1 : 0)) * pic_height_in_map_units * 16 -
-                       (frame_crop_top_offset + frame_crop_bottom_offset) * 2;
+                       (frame_crop_top_offset + frame_crop_bottom_offset) * cropUnitY;
 
   if (br.ReadBits(1) == 1) // vui_parameters_present_flag
     streamInfo->aspectRatio = ParseVUI(br);

--- a/xbmc/filesystem/bluray/StreamParser.cpp
+++ b/xbmc/filesystem/bluray/StreamParser.cpp
@@ -145,99 +145,68 @@ AudioStreamInfo PopulateAudioStreamInfo(const StreamInformation& stream,
   AudioStreamInfo asi;
   asi.valid = true;
 
-  if (bsai)
-  {
-    asi.channels = bsai->channels > 8
-                       ? 8
-                       : static_cast<int>(bsai->channels); // Limit to max 7.1 for display purposes
+  // The coding in the playlist is the authoritative codec - some discs declare only the core
+  // codec in the M2TS program map.
+  asi.channels = bsai ? (bsai->channels > 8 ? 8 : static_cast<int>(bsai->channels))
+                      : 0; // Limit to max 7.1 for display purposes
 
-    switch (bsai->streamType)
-    {
-      using enum ENCODING_TYPE;
-      case AUDIO_AC3:
-        asi.codecName = "ac3";
-        break;
-      case AUDIO_AC3PLUS:
-      case AUDIO_AC3PLUS_SECONDARY:
-      {
-        if (bsai->isAtmos)
-          asi.codecName = "eac3_ddp_atmos";
-        else
-          asi.codecName = "eac3";
-        break;
-      }
-      case AUDIO_LPCM:
-        asi.codecName = "pcm_bluray";
-        break;
-      case AUDIO_DTS:
-        asi.codecName = "dts";
-        break;
-      case AUDIO_DTSHD:
-      case AUDIO_DTSHD_SECONDARY:
-      {
-        if (bsai->isXLL)
-          asi.codecName = "dtshd_hra";
-        else
-          asi.codecName = "dts";
-        break;
-      }
-      case AUDIO_DTSHD_MASTER:
-      {
-        if (bsai->isXLLXIMAX)
-          asi.codecName = "dtshd_ma_x_imax";
-        else if (bsai->isXLLX)
-          asi.codecName = "dtshd_ma_x";
-        else
-          asi.codecName = "dtshd_ma";
-        break;
-      }
-      case AUDIO_TRUHD:
-      {
-        if (bsai->isAtmos)
-          asi.codecName = "truehd_atmos";
-        else
-          asi.codecName = "truehd";
-        break;
-      }
-      default:
-        asi.codecName = "";
-        break;
-    }
-  }
-  else
+  switch (stream.coding)
   {
-    asi.channels = 0; // Only basic mono/stereo/multichannel is stored in BLURAY_TITLE_INFO
-
-    switch (stream.coding)
+    using enum ENCODING_TYPE;
+    case AUDIO_AC3:
+      asi.codecName = "ac3";
+      break;
+    case AUDIO_AC3PLUS:
+    case AUDIO_AC3PLUS_SECONDARY:
     {
-      using enum ENCODING_TYPE;
-      case AUDIO_AC3:
-        asi.codecName = "ac3";
-        break;
-      case AUDIO_AC3PLUS:
-      case AUDIO_AC3PLUS_SECONDARY:
+      if (bsai && bsai->isAtmos)
+        asi.codecName = "eac3_ddp_atmos";
+      else
         asi.codecName = "eac3";
-        break;
-      case AUDIO_LPCM:
-        asi.codecName = "pcm";
-        break;
-      case AUDIO_DTS:
-        asi.codecName = "dts";
-        break;
-      case AUDIO_DTSHD:
-      case AUDIO_DTSHD_SECONDARY:
-        asi.codecName = "dtshd";
-        break;
-      case AUDIO_DTSHD_MASTER:
-        asi.codecName = "dtshd_ma";
-        break;
-      case AUDIO_TRUHD:
-        asi.codecName = "truehd";
-        break;
-      default:
-        asi.codecName = "";
-        break;
+      break;
     }
+    case AUDIO_LPCM:
+      asi.codecName = bsai ? "pcm_bluray" : "pcm";
+      break;
+    case AUDIO_DTS:
+      asi.codecName = "dts";
+      break;
+    case AUDIO_DTSHD:
+    case AUDIO_DTSHD_SECONDARY:
+    {
+      if (!bsai)
+        asi.codecName = "dtshd";
+      else if (bsai->isXLLXIMAX)
+        asi.codecName = "dtshd_ma_x_imax";
+      else if (bsai->isXLLX)
+        asi.codecName = "dtshd_ma_x";
+      else if (bsai->isXLL)
+        asi.codecName = "dtshd_ma";
+      else
+        asi.codecName = "dtshd_hra";
+      break;
+    }
+    case AUDIO_DTSHD_MASTER:
+    {
+      if (bsai && bsai->isXLLXIMAX)
+        asi.codecName = "dtshd_ma_x_imax";
+      else if (bsai && bsai->isXLLX)
+        asi.codecName = "dtshd_ma_x";
+      else
+        asi.codecName = "dtshd_ma";
+      break;
+    }
+    case AUDIO_TRUHD:
+    {
+      if (bsai && bsai->isAtmos)
+        asi.codecName = "truehd_atmos";
+      else
+        asi.codecName = "truehd";
+      break;
+    }
+    default:
+      asi.codecName = "";
+      break;
   }
 
   asi.language = stream.language;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Failed to properly parse H264ScalingList that led to a desync in the bitstream.

Give the audio stream information in the MPLS priority over M2TS - use the latter for lossless flags and channel count.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Wrong stream identification on Ice Age bluray - highlighted in #28776.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
