### PR TITLE
[Video] Fix unchanged stacks can be rescraped.

### DIFF
--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -861,6 +861,27 @@ void CFileItemList::Stack()
     baseItem->SetPath(stackPath);
     baseItem->SetLabel(stackName);
     baseItem->SetSize(size);
+
+    // The library scanner marks a part it need not look at again, and the first part becomes the
+    // stack, so its mark would speak for parts that may well have changed. Only a stack whose
+    // every part is unchanged is unchanged - the other parts are dropped below, leaving no way to
+    // tell afterwards.
+    if (std::ranges::any_of(stack, [this](const int i)
+                            { return !Get(i)->GetProperty(PROPERTY_UNCHANGED).asBoolean(); }))
+      baseItem->ClearProperty(PROPERTY_UNCHANGED);
+
+    // For the same reason the date of the stack, which is the date of its first part, says nothing
+    // about the others: record the newest of them so that a change to any part is still visible in
+    // a hash of the listing (the size set above is likewise the total of all of them)
+    time_t newestPart{0};
+    for (const int i : stack)
+    {
+      time_t partTime{0};
+      Get(i)->GetDateTime().GetAsTime(partTime);
+      newestPart = std::max(newestPart, partTime);
+    }
+    if (newestPart != 0)
+      baseItem->SetProperty(PROPERTY_STACK_NEWEST_PART, static_cast<int64_t>(newestPart));
   }
 
   // Delete unneeded items

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -675,11 +675,12 @@ void ChangeFolderToFile(const std::shared_ptr<CFileItem>& item, const std::strin
 
 void ConvertDiscFoldersToFiles(std::vector<std::shared_ptr<CFileItem>> items)
 {
-  auto folderItems{items | std::views::filter(
-                               [](const std::shared_ptr<CFileItem>& item) {
-                                 return item->IsFolder() &&
-                                        !item->GetProperty(PROPERTY_UNCHANGED).asBoolean();
-                               })};
+  // Every folder is probed, including one the library scanner has marked unchanged. The listing
+  // hash the scanner stores describes the stacked listing, so leaving a marked folder unconverted
+  // would change that hash and force a rescan of the parent on the next scan. The scanner skips a
+  // marked item after stacking instead (which is where the expensive work is).
+  auto folderItems{items | std::views::filter([](const std::shared_ptr<CFileItem>& item)
+                                              { return item->IsFolder(); })};
   for (const auto& item : folderItems)
   {
     if (auto playPath{VIDEO::UTILS::GetOpticalMediaPath(*item)}; !playPath.empty())

--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -24,8 +24,13 @@
 #include <vector>
 
 //! item property set by the video library scanner on subfolders whose fast hash matches
-//! the stored hash; Stack() skips the disc structure probes for such folders
+//! the stored hash; a stack of such folders is marked in turn by Stack()
 static constexpr const char* PROPERTY_UNCHANGED{"scanner:unchanged"};
+
+//! item property set by Stack() on a stack: the date of its newest part, as a time_t. All but the
+//! first part are dropped from the listing, so the hash the video library scanner takes of it
+//! (CVideoInfoScanner::GetPathHash) would otherwise not describe them
+static constexpr const char* PROPERTY_STACK_NEWEST_PART{"scanner:stacknewestpart"};
 
 /*!
   \brief Represents a list of files

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -239,6 +239,64 @@ std::string CStackDirectory::GetParentPath(const std::string& stackPath)
   return GetBasePath(stackPath);
 }
 
+namespace
+{
+// Whether a path names a disc - its structure, the image holding it, or a playlist of one
+bool IsDiscPart(const std::string& path)
+{
+  return URIUtils::IsBlurayPath(path) || URIUtils::IsBDFile(path) || URIUtils::IsDVDFile(path) ||
+         URIUtils::IsDiscImage(path);
+}
+
+} // unnamed namespace
+
+bool CStackDirectory::HasDiscPart(const std::string& stackPath)
+{
+  std::vector<std::string> paths;
+  if (!URIUtils::IsStack(stackPath) || !GetPaths(stackPath, paths))
+    return false;
+
+  return std::ranges::any_of(paths, IsDiscPart);
+}
+
+bool CStackDirectory::IsSameDiscStack(const std::string& stackPath,
+                                      const std::string& otherStackPath)
+{
+  std::vector<std::string> paths;
+  std::vector<std::string> otherPaths;
+  if (!URIUtils::IsStack(stackPath) || !URIUtils::IsStack(otherStackPath) ||
+      !GetPaths(stackPath, paths) || !GetPaths(otherStackPath, otherPaths) || paths.empty() ||
+      paths.size() != otherPaths.size())
+    return false;
+
+  for (size_t part{0}; part < paths.size(); ++part)
+  {
+    const std::string& path{paths[part]};
+    const std::string& otherPath{otherPaths[part]};
+
+    // A disc is compared as a disc and not as a path, so that the options of a url, or a trailing
+    // slash, cannot make the same disc look like another one
+    if (IsDiscPart(path) || IsDiscPart(otherPath))
+    {
+      if (!URIUtils::CompareDiscPaths(path, otherPath))
+        return false;
+
+      // When both sides name a playlist it has to be the same one, as a disc can hold a cut, or
+      // a feature, per playlist. Where either states none the disc is all there is to compare.
+      if (URIUtils::IsBlurayPath(path) && URIUtils::IsBlurayPath(otherPath) &&
+          CURL(path).GetFileName() != CURL(otherPath).GetFileName())
+        return false;
+
+      continue;
+    }
+
+    // Neither names a disc - CompareDiscPaths() would compare the folders holding them
+    if (!URIUtils::PathEquals(path, otherPath, true, true))
+      return false;
+  }
+  return true;
+}
+
 std::string CStackDirectory::GetBasePath(const std::string& stackPath)
 {
   std::vector<std::string> paths;

--- a/xbmc/filesystem/StackDirectory.h
+++ b/xbmc/filesystem/StackDirectory.h
@@ -76,6 +76,26 @@ namespace XFILE
                                    const std::string& newPath = {});
 
     /*!
+    \brief Whether any part of a stack:// path names a disc - a disc structure
+    (BDMV/index.bdmv, VIDEO_TS/VIDEO_TS.IFO), a disc image, or a bluray:// playlist of one.
+    Only such a stack can be held in the library under a path that differs from the one listed.
+    \param stackPath The stack:// path
+    \return True if at least one part names a disc, false otherwise
+    */
+    static bool HasDiscPart(const std::string& stackPath);
+
+    /*!
+    \brief Whether two stack:// paths describe the same movie on the same discs. A part naming a
+    playlist is only equal to a part naming the same playlist, as a disc can hold a cut (or a
+    feature) per playlist; where either side states no playlist the discs are compared instead,
+    so a stack listed from disc matches the resolved form of itself in the library.
+    \param stackPath The stack:// path
+    \param otherStackPath The stack:// path to compare it with
+    \return True if both describe the same movie, false otherwise
+    */
+    static bool IsSameDiscStack(const std::string& stackPath, const std::string& otherStackPath);
+
+    /*!
     \brief Get the base/parent path in common from all the parts of a stack:// path
     \param stackPath The stack:// path
     \return The base/parent path

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -24,7 +24,9 @@
 #include "utils/URIUtils.h"
 #include "video/VideoInfoTag.h"
 
+#include <array>
 #include <fstream>
+#include <utility>
 
 #include <gtest/gtest.h>
 
@@ -1228,6 +1230,126 @@ TEST(TestFileItemList, StackConvertsDiscFolders)
     items.Stack();
     EXPECT_FALSE(items[0]->IsFolder());
   }
+
+  XFILE::CDirectory::RemoveRecursive(tempPath);
+}
+
+TEST(TestFileItemList, StackIsUnchangedOnlyWhenEveryPartIs)
+{
+  std::error_code ec;
+  const std::string tempPath = KODI::PLATFORM::FILESYSTEM::create_temp_directory(ec);
+  EXPECT_FALSE(ec);
+
+  // two disc folders that form a folder stack
+  std::array<std::string, 2> partPaths;
+  for (int part{1}; const auto& name : {"movie_part1", "movie_part2"})
+  {
+    std::string path{URIUtils::AddFileToFolder(tempPath, name)};
+    EXPECT_TRUE(CUtil::CreateDirectoryEx(path));
+    {
+      std::ofstream of(URIUtils::AddFileToFolder(path, "VIDEO_TS.IFO"));
+    }
+    URIUtils::AddSlashAtEnd(path);
+    partPaths[part++ - 1] = path;
+  }
+
+  struct StackResult
+  {
+    int size{0};
+    bool isStack{false};
+    bool unchanged{false};
+  };
+
+  const auto stackOf = [&partPaths, &tempPath](bool firstMarked, bool secondMarked)
+  {
+    CFileItemList items(tempPath);
+    for (const auto& [path, marked] :
+         {std::pair{partPaths[0], firstMarked}, std::pair{partPaths[1], secondMarked}})
+    {
+      auto item = std::make_shared<CFileItem>(path, true);
+      item->SetLabel(URIUtils::GetFileOrFolderName(path));
+      if (marked)
+        item->SetProperty(PROPERTY_UNCHANGED, true);
+      items.Add(std::move(item));
+    }
+    items.Stack();
+
+    StackResult result{.size = items.Size()};
+    if (result.size > 0)
+    {
+      result.isStack = items[0]->IsStack();
+      result.unchanged = items[0]->GetProperty(PROPERTY_UNCHANGED).asBoolean();
+    }
+    return result;
+  };
+
+  // the first part becomes the stack, so its mark alone must not speak for the second
+  const StackResult firstOnly{stackOf(true, false)};
+  EXPECT_EQ(firstOnly.size, 1);
+  EXPECT_TRUE(firstOnly.isStack);
+  EXPECT_FALSE(firstOnly.unchanged);
+
+  // ..nor may a mark on a later part speak for the first
+  const StackResult secondOnly{stackOf(false, true)};
+  EXPECT_EQ(secondOnly.size, 1);
+  EXPECT_FALSE(secondOnly.unchanged);
+
+  // a stack is only unchanged when every one of its parts is
+  const StackResult both{stackOf(true, true)};
+  EXPECT_EQ(both.size, 1);
+  EXPECT_TRUE(both.isStack);
+  EXPECT_TRUE(both.unchanged);
+
+  // and an unmarked stack stays unmarked
+  const StackResult neither{stackOf(false, false)};
+  EXPECT_EQ(neither.size, 1);
+  EXPECT_FALSE(neither.unchanged);
+
+  XFILE::CDirectory::RemoveRecursive(tempPath);
+}
+
+TEST(TestFileItemList, StackRecordsTheDateOfItsNewestPart)
+{
+  std::error_code ec;
+  const std::string tempPath = KODI::PLATFORM::FILESYSTEM::create_temp_directory(ec);
+  EXPECT_FALSE(ec);
+
+  const auto stackDates = [&tempPath](const CDateTime& firstPart, const CDateTime& secondPart)
+  {
+    CFileItemList items(tempPath);
+    for (const auto& [name, date] :
+         {std::pair{"movie_part1", firstPart}, std::pair{"movie_part2", secondPart}})
+    {
+      auto item = std::make_shared<CFileItem>(
+          URIUtils::AddFileToFolder(tempPath, name, "VIDEO_TS.IFO"), false);
+      item->SetLabel(name);
+      item->SetDateTime(date);
+      items.Add(std::move(item));
+    }
+    items.Stack();
+
+    time_t newest{0};
+    if (items.Size() == 1)
+      newest = static_cast<time_t>(items[0]->GetProperty(PROPERTY_STACK_NEWEST_PART).asInteger(0));
+    return std::pair{items.Size(), newest};
+  };
+
+  const CDateTime older{2020, 1, 1, 0, 0, 0};
+  const CDateTime newer{2026, 1, 1, 0, 0, 0};
+  time_t olderTime{0};
+  time_t newerTime{0};
+  older.GetAsTime(olderTime);
+  newer.GetAsTime(newerTime);
+
+  // the first part becomes the stack, so its date is the one the listing holds - the date of the
+  // newest part has to be recorded or a change to a later part is invisible to a listing hash
+  const auto [firstNewerSize, firstNewer] = stackDates(newer, older);
+  EXPECT_EQ(firstNewerSize, 1);
+  EXPECT_EQ(firstNewer, newerTime);
+
+  const auto [secondNewerSize, secondNewer] = stackDates(older, newer);
+  EXPECT_EQ(secondNewerSize, 1);
+  EXPECT_EQ(secondNewer, newerTime);
 
   XFILE::CDirectory::RemoveRecursive(tempPath);
 }

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -1198,7 +1198,7 @@ INSTANTIATE_TEST_SUITE_P(EpisodeLabel,
                          [](const testing::TestParamInfo<EpisodeLabelTestCase>& info)
                          { return info.param.testName; });
 
-TEST(TestFileItemList, StackSkipsUnchangedFolders)
+TEST(TestFileItemList, StackConvertsDiscFolders)
 {
   std::error_code ec;
   const std::string tempPath = KODI::PLATFORM::FILESYSTEM::create_temp_directory(ec);
@@ -1219,13 +1219,14 @@ TEST(TestFileItemList, StackSkipsUnchangedFolders)
     EXPECT_FALSE(items[0]->IsFolder());
   }
   {
-    // unless it is marked unchanged by the library scanner
+    // including one the library scanner has marked unchanged - the listing it hashes has to
+    // describe the same items whether or not the folder is marked
     CFileItemList items(tempPath);
     const auto folder = std::make_shared<CFileItem>(moviePath, true);
     folder->SetProperty(PROPERTY_UNCHANGED, true);
     items.Add(folder);
     items.Stack();
-    EXPECT_TRUE(items[0]->IsFolder());
+    EXPECT_FALSE(items[0]->IsFolder());
   }
 
   XFILE::CDirectory::RemoveRecursive(tempPath);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -834,11 +834,72 @@ int CVideoDatabase::GetFileId(const std::string& strFilenameAndPath)
         m_pDS->close();
         return idFile;
       }
+      m_pDS->close();
+
+      // A stack of discs is stored resolved to the bluray:// playlist of each member, so the
+      // unresolved form the scanner and NFOs use never matches by name
+      return GetDiscStackFileId(strFilenameAndPath);
     }
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
+  }
+  return -1;
+}
+
+int CVideoDatabase::GetDiscStackFileId(const std::string& stackPath)
+{
+  // Only a disc is stored in a form that can differ from the one given here, so a stack of
+  // ordinary files was already covered by the lookup by name
+  if (!URIUtils::IsStack(stackPath) || !CStackDirectory::HasDiscPart(stackPath))
+    return -1;
+
+  try
+  {
+    if (!m_pDB || !m_pDS)
+      return -1;
+
+    std::string strPath;
+    std::string strFileName;
+    SplitPath(stackPath, strPath, strFileName);
+    const int idPath{GetPathId(strPath)};
+    if (idPath < 0)
+      return -1;
+
+    // Both forms of a stack reduce to the same base path (the common parent of its discs), so
+    // only the few stacks stored there have to be compared. Were the two ever to reduce
+    // differently the stack would simply not be found here, and be scraped as a new one
+    m_pDS->query(PrepareSQL("SELECT idFile, strFileName FROM files "
+                            "WHERE idPath=%i AND strFileName LIKE 'stack://%%'",
+                            idPath));
+    int idFile{-1};
+    int matches{0};
+    while (!m_pDS->eof())
+    {
+      if (CStackDirectory::IsSameDiscStack(stackPath, m_pDS->fv(1).get_asString()))
+      {
+        idFile = m_pDS->fv(0).get_asInt();
+        ++matches;
+      }
+      m_pDS->next();
+    }
+    m_pDS->close();
+
+    // The rows are in no particular order, so an ambiguous match cannot be resolved by taking one
+    // of them. It says the library holds several stacks of these discs that only a playlist tells
+    // apart, and the caller asked without one - leave the stack unknown rather than guess.
+    if (matches > 1)
+    {
+      CLog::LogF(LOGWARNING, "'{}' matches {} stacks of the same discs - none can be chosen",
+                 CURL::GetRedacted(stackPath), matches);
+      return -1;
+    }
+    return idFile;
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "({}) failed", CURL::GetRedacted(stackPath));
   }
   return -1;
 }

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1081,6 +1081,18 @@ protected:
    */
   int GetFileId(const std::string& url);
 
+  /*! \brief Get the id of a stack of discs, however its members are expressed.
+   A stack holding a bluray (a BDMV folder or a disc image) is stored resolved to the
+   bluray:// playlist of each member, a form only a playlist scan of the discs can produce.
+   The same stack listed from disc, or read from an NFO, names the disc structures instead,
+   so it cannot be found by path. Both forms describe the same discs, which is what is
+   matched here. A match has to be unique: where several stacks of these discs differ only by
+   the playlist of each part, nothing distinguishes them from a stack named without one.
+   \param stackPath a stack:// path of which at least one member is a bluray
+   \return id of the file, -1 if it is not in the db or several stacks match.
+   */
+  int GetDiscStackFileId(const std::string& stackPath);
+
   int AddToTable(const std::string& table, const std::string& firstField, const std::string& secondField, const std::string& value);
   int UpdateRatings(int mediaId, const char *mediaType, const RatingMap& values, const std::string& defaultRating);
   int AddRatings(int mediaId,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -547,9 +547,12 @@ CVideoInfoScanner::~CVideoInfoScanner()
                                  DIR_FLAG_DEFAULTS);
 
         // mark subfolders whose stored fast hash matches the listing mtime digest;
-        // the disc structure probes in Stack() and the recursion loop (which also
-        // drops them from m_pathsToScan) skip marked items. Full listing hashes
-        // never match here, so folders containing subfolders are still visited.
+        // RetrieveVideoInfo and the recursion loop (which also drops a folder from
+        // m_pathsToScan) skip marked items. Marking must not change the listing
+        // itself - Stack() converts a marked disc folder like any other, so that
+        // the listing hash below describes the same items on every scan. Full
+        // listing hashes never match here, so folders containing subfolders are
+        // still visited.
         std::vector<CRegExp> stackRegExps{m_advancedSettings->m_folderStackRegExps};
         for (int i = items.Size() - 1; i >= 0; --i)
         {
@@ -700,12 +703,16 @@ CVideoInfoScanner::~CVideoInfoScanner()
         // an all-folder listing has nothing to directly import, so foundSomething
         // is false here even when nothing changed; store the hash or GetPathHash
         // output never matches dbHash and every scan repeats the full rescan.
-        // Only store a listing-hash, as an mtime-hash would match the fasthash
-        // gate before the listing is fetched, hiding content that never imported.
+        // A marked item counts as one of those - it imported on an earlier scan
+        // and holds a hash of its own, and it is not necessarily a folder as
+        // Stack() converts a marked disc folder like any other. Only store a
+        // listing-hash, as an mtime-hash would match the fasthash gate before the
+        // listing is fetched, hiding content that never imported.
         if ((content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS) &&
             listingHash && !URIUtils::IsArchive(CURL(strDirectory)) &&
-            std::all_of(items.begin(), items.end(),
-                        [](const auto& item) { return item->IsFolder(); }))
+            std::all_of(
+                items.begin(), items.end(), [](const auto& item)
+                { return item->IsFolder() || item->GetProperty(PROPERTY_UNCHANGED).asBoolean(); }))
           m_database.SetPathHash(strDirectory, hash);
         if (m_bClean)
           m_pathsToClean.insert(m_database.GetPathId(strDirectory));
@@ -914,7 +921,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
     {
       CFileItemPtr pItem = items[i];
 
-      if (pItem->IsFolder() && pItem->GetProperty(PROPERTY_UNCHANGED).asBoolean())
+      // Nothing has changed below a marked item since it was imported. It is not necessarily a
+      // folder any more - Stack() converts a marked disc folder to a playable file item so that
+      // the listing hash stays stable - but there is still nothing to read or scrape for it.
+      if (pItem->GetProperty(PROPERTY_UNCHANGED).asBoolean())
         continue;
 
       // we do this since we may have a override per dir

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -550,25 +550,20 @@ CVideoInfoScanner::~CVideoInfoScanner()
         // RetrieveVideoInfo and the recursion loop (which also drops a folder from
         // m_pathsToScan) skip marked items. Marking must not change the listing
         // itself - Stack() converts a marked disc folder like any other, so that
-        // the listing hash below describes the same items on every scan. Full
-        // listing hashes never match here, so folders containing subfolders are
-        // still visited.
-        std::vector<CRegExp> stackRegExps{m_advancedSettings->m_folderStackRegExps};
+        // the listing hash below describes the same items on every scan, and a
+        // marked folder still forms a stack. Full listing hashes never match here,
+        // so folders containing subfolders are still visited.
         for (int i = items.Size() - 1; i >= 0; --i)
         {
           if (!items[i]->IsFolder())
             continue;
-          // a marked folder-stack member (label like "cd1") stays a folder in
-          // Stack() and its stack cannot form; leave such folders unmarked
-          std::string label = StringUtils::ToLower(items[i]->GetLabel());
-          URIUtils::RemoveSlashAtEnd(label);
+          // A folder-stack member is marked like any other: it still stacks (Stack() converts a
+          // marked folder too) and the stack is only marked when all of its parts are.
           std::string dbh;
           int64_t rawTime = items[i]->GetProperty(DIR_PROPERTY_STAT_MTIME).asInteger(0);
           if (rawTime == 0)
             rawTime = items[i]->GetProperty(DIR_PROPERTY_STAT_CTIME).asInteger(0);
           if (m_advancedSettings->m_bVideoLibraryUseFastHash &&
-              std::none_of(stackRegExps.begin(), stackRegExps.end(),
-                           [&label](CRegExp& re) { return re.RegFind(label) != -1; }) &&
               m_database.GetPathHash(items[i]->GetPath(), dbh) && !dbh.empty() &&
               StringUtils::EqualsNoCase(rawTime != 0 ? GetFastHash(regexps, rawTime)
                                                      : GetFastHash(items[i]->GetPath(), regexps),
@@ -753,32 +748,74 @@ CVideoInfoScanner::~CVideoInfoScanner()
         continue;
       }
 
-      // Disc rips are anchored in files/path several ways: BD subfolder rips
-      // under the raw BDMV/ row (older imports or failed playlist detection)
-      // or under a bluray:// playlist row (current imports); DVD rips under
-      // VIDEO_TS/; flat rips with the structure file directly in the movie
-      // folder. In every form the movie folder itself, the item the scanner
-      // lists, has no hashed row, so each parent rescan re-imports the movie
-      // from NFO. Store its fast hash here; GetMovieId resolves all anchor
-      // forms. ISOs hash normally as plain files and never reach this block.
+      // The item the scanner lists for a movie held in a folder of its own is never that folder:
+      // a disc rip is listed as its structure (BDMV/ or VIDEO_TS/, in the movie folder or below
+      // it) and a stack has absorbed the parts it is made of. The folder is left with no hash of
+      // its own, so nothing marks the movie unchanged and every parent rescan re-reads its NFO
+      // and re-resolves the disc of every part. Hash each folder here, so that the next scan of
+      // the parent can mark what has not changed.
       if (content == ContentType::MOVIES && m_advancedSettings->m_bVideoLibraryUseFastHash &&
-          !URIUtils::IsPlugin(strDirectory) && !pItem->IsFolder() &&
-          !URIUtils::IsStack(pItem->GetPath()) && URIUtils::IsOpticalMediaFile(pItem->GetPath()))
+          !URIUtils::IsPlugin(strDirectory) && !pItem->IsFolder())
       {
-        std::string discFolder = URIUtils::RemoveDiscPath(pItem->GetPath());
-        URIUtils::AddSlashAtEnd(discFolder);
-        if (!URIUtils::PathEquals(discFolder, strDirectory, true))
+        // The media a movie is held in: the item itself, or every part of it when the item is a
+        // stack. Hashing a folder is only of use if it can end in the item being marked, and a
+        // stack is marked only when every one of its parts is (see Stack()).
+        // Hash the folder of every part of a stack, or of none.
+        std::vector<std::string> media;
+        if (URIUtils::IsStack(pItem->GetPath()))
+          CStackDirectory::GetPaths(pItem->GetPath(), media);
+        else
+          media.emplace_back(pItem->GetPath());
+
+        std::vector<std::string> folders;
+        folders.reserve(media.size());
+        for (const std::string& path : media)
         {
-          int64_t rawTime = pItem->GetProperty(DIR_PROPERTY_STAT_MTIME).asInteger(0);
+          std::string folder;
+          if (URIUtils::IsOpticalMediaFile(path))
+            folder = URIUtils::RemoveDiscPath(path); // the movie folder, above BDMV/ or VIDEO_TS/
+          else if (URIUtils::IsBlurayPath(path))
+            folder = URIUtils::GetDiscBasePath(path); // an already resolved part names its disc
+          else
+            folder = URIUtils::GetDirectory(path); // an image or a plain file
+
+          if (!folder.empty())
+            URIUtils::AddSlashAtEnd(folder);
+          if (folder.empty() || URIUtils::PathEquals(folder, strDirectory, true))
+          {
+            folders.clear();
+            break;
+          }
+
+          folders.emplace_back(std::move(folder));
+        }
+
+        // The listing states the date of the folder the item itself is held in; the folder of any
+        // other part of a stack has to be asked for it
+        int64_t rawTime{0};
+        if (folders.size() == 1)
+        {
+          rawTime = pItem->GetProperty(DIR_PROPERTY_STAT_MTIME).asInteger(0);
           if (rawTime == 0)
             rawTime = pItem->GetProperty(DIR_PROPERTY_STAT_CTIME).asInteger(0);
-          const std::string fh =
-              rawTime != 0 ? GetFastHash(regexps, rawTime) : GetFastHash(discFolder, regexps);
+        }
+
+        std::vector<std::pair<std::string, std::string>> hashes; // folder and its fast hash
+        for (const std::string& folder : folders)
+        {
+          const std::string fh{rawTime != 0 ? GetFastHash(regexps, rawTime)
+                                            : GetFastHash(folder, regexps)};
           std::string dbh;
           if (!fh.empty() &&
-              !(m_database.GetPathHash(discFolder, dbh) && StringUtils::EqualsNoCase(fh, dbh)) &&
-              m_database.HasMovieInfo(pItem->GetDynPath()))
-            m_database.SetPathHash(discFolder, fh);
+              !(m_database.GetPathHash(folder, dbh) && StringUtils::EqualsNoCase(fh, dbh)))
+            hashes.emplace_back(folder, fh);
+        }
+
+        // Only a hash that has to be written is worth asking the library about the movie for
+        if (!hashes.empty() && m_database.HasMovieInfo(pItem->GetDynPath()))
+        {
+          for (const auto& [folder, fh] : hashes)
+            m_database.SetPathHash(folder, fh);
         }
       }
 
@@ -925,7 +962,20 @@ CVideoInfoScanner::~CVideoInfoScanner()
       // folder any more - Stack() converts a marked disc folder to a playable file item so that
       // the listing hash stays stable - but there is still nothing to read or scrape for it.
       if (pItem->GetProperty(PROPERTY_UNCHANGED).asBoolean())
-        continue;
+      {
+        // Only a folder is ever marked, and the hash that marks it outlives the movie it was
+        // hashed for. Where Stack() has since made the item something else - a disc structure, or
+        // a stack of several of them - the mark can therefore stand for a movie that is no longer
+        // in the library: removed by hand, or cleaned away because a part of its stack went
+        // missing, which also leaves the surviving part listed on its own. The library has the
+        // last word on such an item; a folder is still marked for itself alone.
+        if (pItem->IsFolder() || m_database.HasMovieInfo(pItem->GetDynPath()))
+          continue;
+
+        CLog::Log(LOGDEBUG, "VideoInfoScanner: '{}' is no longer in the library - importing",
+                  CURL::GetRedacted(pItem->GetPath()));
+        pItem->ClearProperty(PROPERTY_UNCHANGED);
+      }
 
       // we do this since we may have a override per dir
       ScraperPtr info2 = m_database.GetScraperForPath(
@@ -2971,6 +3021,13 @@ CVideoInfoScanner::~CVideoInfoScanner()
         time_t tt{};
         pItem->GetDateTime().GetAsTime(tt);
         digest.Update(&tt, sizeof(tt));
+
+        // A stack is one item made of several, all but the first of which are no longer listed.
+        // Its date is the date of that first part, so the date of the newest of them is taken as
+        // well - a change to any part has to be visible here or the directory is never rescanned.
+        if (const int64_t newestPart{pItem->GetProperty(PROPERTY_STACK_NEWEST_PART).asInteger(0)};
+            newestPart != 0)
+          digest.Update(&newestPart, sizeof(newestPart));
       }
       if (IsVideo(*pItem) && !PLAYLIST::IsPlayList(*pItem) && !pItem->IsNFO())
         count++;
@@ -2989,6 +3046,12 @@ CVideoInfoScanner::~CVideoInfoScanner()
       // For the purposes of fast hashing archives are not considered folders
       if (items[i]->IsFolder() && !URIUtils::IsArchive(CURL(items[i]->GetPath())) &&
           !CUtil::ExcludeFileOrFolder(items[i]->GetPath(), excludes, &m_regexpCache))
+        return false;
+
+      // A stack is made of parts Stack() has already dropped from the listing, and of folders it
+      // may have turned into files. The mtime of the directory says nothing about any of them, so
+      // the listing has to be hashed to see a change to a stack (see GetPathHash)
+      if (items[i]->IsStack())
         return false;
     }
     return true;

--- a/xbmc/video/test/TestStacks.cpp
+++ b/xbmc/video/test/TestStacks.cpp
@@ -243,6 +243,175 @@ TEST_F(TestStacks, TestStackIsNotItselfADiscImage)
   EXPECT_TRUE(CURL(R"(D:\Movies\Movie.iso)").IsDiscImage());
 }
 
+TEST_F(TestStacks, TestStackHasDiscPart)
+{
+  // Any stack holding a disc can be held in the library under a path that differs from the one
+  // listed, as the playlist of each disc is only known once the discs have been scanned. Which
+  // form each part happens to take says nothing about that - a disc image, in particular, names
+  // itself in both forms
+  EXPECT_TRUE(CStackDirectory::HasDiscPart(
+      R"(stack://D:\Movies\Movie_PART1\BDMV\index.bdmv , D:\Movies\Movie_PART2\BDMV\index.bdmv)"));
+  EXPECT_TRUE(
+      CStackDirectory::HasDiscPart(R"(stack://D:\Movies\Movie.CD1.iso , D:\Movies\Movie.CD2.iso)"));
+  EXPECT_TRUE(CStackDirectory::HasDiscPart(
+      R"(stack://D:\Movies\Movie_PART1\VIDEO_TS\VIDEO_TS.IFO , D:\Movies\Movie_PART2\VIDEO_TS\VIDEO_TS.IFO)"));
+  EXPECT_TRUE(CStackDirectory::HasDiscPart(
+      R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00800.mpls , )"
+      R"(bluray://D%3a%5cMovies%5cMovie_PART2%5c/BDMV/PLAYLIST/00801.mpls)"));
+
+  // a mixed stack still holds a disc
+  EXPECT_TRUE(CStackDirectory::HasDiscPart(
+      R"(stack://D:\Movies\Movie_PART1\VIDEO_TS\VIDEO_TS.IFO , D:\Movies\Movie.CD2.iso)"));
+  EXPECT_TRUE(
+      CStackDirectory::HasDiscPart(R"(stack://D:\Movies\Movie.CD1.mkv , D:\Movies\Movie.CD2.iso)"));
+
+  // A stack of ordinary files holds none, and is stored as it is listed
+  EXPECT_FALSE(
+      CStackDirectory::HasDiscPart(R"(stack://D:\Movies\Movie.CD1.mkv , D:\Movies\Movie.CD2.mkv)"));
+  EXPECT_FALSE(CStackDirectory::HasDiscPart(
+      R"(stack://D:\Movies\Movie.part1.mp4 , D:\Movies\Movie.part2.mp4)"));
+
+  // Anything that is not a stack is answered for rather than unwrapped
+  EXPECT_FALSE(CStackDirectory::HasDiscPart(R"(D:\Movies\Movie_PART1\BDMV\index.bdmv)"));
+  EXPECT_FALSE(CStackDirectory::HasDiscPart("D:\\a.iso"));
+  EXPECT_FALSE(CStackDirectory::HasDiscPart(""));
+}
+
+TEST_F(TestStacks, TestStackBasePathIsIndependentOfPlaylistResolution)
+{
+  // A stack of discs is looked up among the rows stored under its base path (see
+  // CVideoDatabase::GetDiscStackFileId), so both forms of one have to reduce to the same base
+  // path or a stack already in the library is not found and is scraped again
+  EXPECT_EQ(
+      CStackDirectory::GetBasePath(
+          R"(stack://D:\Movies\Movie_PART1\BDMV\index.bdmv , D:\Movies\Movie_PART2\BDMV\index.bdmv)"),
+      CStackDirectory::GetBasePath(
+          R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00800.mpls , )"
+          R"(bluray://D%3a%5cMovies%5cMovie_PART2%5c/BDMV/PLAYLIST/00801.mpls)"));
+
+  // ..a stack of disc images, which resolves through udf://
+  EXPECT_EQ(
+      CStackDirectory::GetBasePath(R"(stack://D:\Movies\Movie.CD1.iso , D:\Movies\Movie.CD2.iso)"),
+      CStackDirectory::GetBasePath(
+          R"(stack://bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD1.iso%2f/BDMV/PLAYLIST/01003.mpls , )"
+          R"(bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD2.iso%2f/BDMV/PLAYLIST/01003.mpls)"));
+
+  // ..a rip held in the movie folder itself rather than a folder per part
+  EXPECT_EQ(CStackDirectory::GetBasePath(
+                R"(stack://D:\Movies\Movie\BDMV\index.bdmv , D:\Movies\Movie2\BDMV\index.bdmv)"),
+            CStackDirectory::GetBasePath(
+                R"(stack://bluray://D%3a%5cMovies%5cMovie%5c/BDMV/PLAYLIST/00800.mpls , )"
+                R"(bluray://D%3a%5cMovies%5cMovie2%5c/BDMV/PLAYLIST/00800.mpls)"));
+
+  // ..and a stack whose parts are not all held the same way
+  EXPECT_EQ(
+      CStackDirectory::GetBasePath(
+          R"(stack://D:\Movies\Movie_PART1\BDMV\index.bdmv , D:\Movies\Movie.CD2.iso)"),
+      CStackDirectory::GetBasePath(
+          R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00800.mpls , )"
+          R"(bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD2.iso%2f/BDMV/PLAYLIST/01003.mpls)"));
+}
+
+TEST_F(TestStacks, TestSameDiscStack)
+{
+  const std::string bdStack{
+      R"(stack://D:\Movies\Movie_PART1\BDMV\index.bdmv , D:\Movies\Movie_PART2\BDMV\index.bdmv)"};
+  const std::string resolvedBdStack{
+      R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00800.mpls , )"
+      R"(bluray://D%3a%5cMovies%5cMovie_PART2%5c/BDMV/PLAYLIST/00801.mpls)"};
+
+  // A stack listed from disc names no playlist, so it matches the resolved form of itself in the
+  // library - the point of the comparison
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(bdStack, resolvedBdStack));
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(resolvedBdStack, bdStack));
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(bdStack, bdStack));
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(resolvedBdStack, resolvedBdStack));
+
+  // ..but a disc can hold a cut, or a feature, per playlist, so two resolved stacks of the same
+  // discs that name different playlists are different movies
+  const std::string otherPlaylists{
+      R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00900.mpls , )"
+      R"(bluray://D%3a%5cMovies%5cMovie_PART2%5c/BDMV/PLAYLIST/00901.mpls)"};
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(resolvedBdStack, otherPlaylists));
+
+  // one differing part is enough
+  const std::string onePlaylistDiffers{
+      R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00800.mpls , )"
+      R"(bluray://D%3a%5cMovies%5cMovie_PART2%5c/BDMV/PLAYLIST/00901.mpls)"};
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(resolvedBdStack, onePlaylistDiffers));
+
+  // Different discs, and a different number of them, never match
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(
+      bdStack,
+      R"(stack://D:\Movies\Other_PART1\BDMV\index.bdmv , D:\Movies\Other_PART2\BDMV\index.bdmv)"));
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(
+      bdStack, R"(stack://D:\Movies\Movie_PART1\BDMV\index.bdmv , )"
+               R"(D:\Movies\Movie_PART2\BDMV\index.bdmv , D:\Movies\Movie_PART3\BDMV\index.bdmv)"));
+
+  // ..nor do the same discs in a different order
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(
+      bdStack,
+      R"(stack://D:\Movies\Movie_PART2\BDMV\index.bdmv , D:\Movies\Movie_PART1\BDMV\index.bdmv)"));
+
+  // A stack of disc images behaves the same way through udf://
+  const std::string isoStack{R"(stack://D:\Movies\Movie.CD1.iso , D:\Movies\Movie.CD2.iso)"};
+  const std::string resolvedIsoStack{
+      R"(stack://bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD1.iso%2f/BDMV/PLAYLIST/01003.mpls , )"
+      R"(bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD2.iso%2f/BDMV/PLAYLIST/01003.mpls)"};
+  const std::string resolvedIsoStackOtherPlaylist{
+      R"(stack://bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD1.iso%2f/BDMV/PLAYLIST/01050.mpls , )"
+      R"(bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD2.iso%2f/BDMV/PLAYLIST/01050.mpls)"};
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(isoStack, resolvedIsoStack));
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(resolvedIsoStack, resolvedIsoStackOtherPlaylist));
+
+  // A stack of plain files is compared as it is listed, and is not a stack of these discs
+  const std::string fileStack{R"(stack://D:\Movies\Movie.CD1.mkv , D:\Movies\Movie.CD2.mkv)"};
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(fileStack, fileStack));
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(fileStack, isoStack));
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(
+      fileStack, R"(stack://D:\Movies\Movie.CD1.mkv , D:\Movies\Movie.CD3.mkv)"));
+
+  // Neither side is unwrapped unless it is a stack
+  EXPECT_FALSE(
+      CStackDirectory::IsSameDiscStack(bdStack, R"(D:\Movies\Movie_PART1\BDMV\index.bdmv)"));
+  EXPECT_FALSE(
+      CStackDirectory::IsSameDiscStack(R"(D:\Movies\Movie_PART1\BDMV\index.bdmv)", bdStack));
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack("D:\\a.iso", "D:\\a.iso"));
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack("", ""));
+}
+
+TEST_F(TestStacks, TestSameDiscStackIgnoresSourceOptions)
+{
+  // The options of a url are no part of the disc a part is held on, nor of the playlist, so a
+  // stack has to keep matching the one in the library when they change
+  const std::string stack{
+      R"(stack://bluray://smb%3a%2f%2fhost%2fshare%2fMovie_PART1%2f/BDMV/PLAYLIST/00800.mpls , )"
+      R"(bluray://smb%3a%2f%2fhost%2fshare%2fMovie_PART2%2f/BDMV/PLAYLIST/00800.mpls)"};
+  const std::string withOptions{
+      R"(stack://bluray://smb%3a%2f%2fhost%2fshare%2fMovie_PART1%2f/BDMV/PLAYLIST/00800.mpls?opt=1 , )"
+      R"(bluray://smb%3a%2f%2fhost%2fshare%2fMovie_PART2%2f/BDMV/PLAYLIST/00800.mpls?opt=1)"};
+
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(stack, withOptions));
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(withOptions, stack));
+
+  // ..while a different playlist of those same discs is still a different movie
+  const std::string otherPlaylist{
+      R"(stack://bluray://smb%3a%2f%2fhost%2fshare%2fMovie_PART1%2f/BDMV/PLAYLIST/00900.mpls?opt=1 , )"
+      R"(bluray://smb%3a%2f%2fhost%2fshare%2fMovie_PART2%2f/BDMV/PLAYLIST/00900.mpls?opt=1)"};
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(stack, otherPlaylist));
+
+  // A trailing slash on a disc root says nothing about the disc either
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(
+      R"(stack://D:\Movies\Movie_PART1\BDMV\index.bdmv , D:\Movies\Movie_PART2\BDMV\index.bdmv)",
+      R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00800.mpls , )"
+      R"(bluray://D%3a%5cMovies%5cMovie_PART2%5c/BDMV/PLAYLIST/00800.mpls)"));
+
+  // A part that is an ordinary file is compared as one, so two files in a folder stay apart
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(
+      R"(stack://smb://host/share/Movie.CD1.mkv , smb://host/share/Movie.CD2.mkv)",
+      R"(stack://smb://host/share/Movie.CD1.mkv , smb://host/share/Movie.CD3.mkv)"));
+}
+
 TEST_F(TestStacks, TestStackHasNoBlurayPath)
 {
   // Each member of a stack of disc folders is its own disc, so there is no single disc root to


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

After applying the first commit:
- Intial scrape - https://paste.kodi.tv/okosewefop.kodi
- Unchanged update - this time nothing is rescraped - https://paste.kodi.tv/vimaqawaga.kodi
- But after adding a new movie - **BUT the stack is rescraped** - https://paste.kodi.tv/ufihixeyoq.kodi

With all commits:
- Initial scrape - https://paste.kodi.tv/oyaqiqizes.kodi
- Library update - everything is unchanged, nothing rescraped - https://paste.kodi.tv/ukogehukov.kodi
- Adding new movie - only the new movie is scraped, stack is left alone - https://paste.kodi.tv/efiropupuc.kodi
- Modifiying part of a stack (by adding a dummy file) - stack is appropriately rescraped but unchanged - https://paste.kodi.tv/wivebivura.kodi
- Removing a stack (fellowship extended edition) from library and it being appopriately rescraped on update - https://paste.kodi.tv/osireviwes.kodi

See individual commits for description.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Noticed in #28776 and reproduced here.

Before this PR:
- Scraped a movie scource containing some stacks - https://paste.kodi.tv/cewiyugeki.kodi
- Despite an unchanged source the movie a library update rescrapes the Fellowship Extended Edition stack - https://paste.kodi.tv/cizonulolu.kodi

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have updated the documentation accordingly
- [X] All new and existing tests passed
