### PR TITLE
Group By Show in Recently Added TV Show

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -1004,3 +1004,15 @@ msgstr ""
 msgctxt "#31615"
 msgid "Subtitle language"
 msgstr ""
+
+#: /xml/Includes_MediaMenu.xml
+#. Label for the View Options toggle that switches Recently Added Episodes to a shows-grouped view
+msgctxt "#31616"
+msgid "Group by show"
+msgstr ""
+
+#: /xml/Includes_MediaMenu.xml
+#. Label for the View Options toggle that switches back to the episodes view
+msgctxt "#31617"
+msgid "Group by episode"
+msgstr ""

--- a/addons/skin.estuary/playlists/recent_tvshows.xsp
+++ b/addons/skin.estuary/playlists/recent_tvshows.xsp
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<smartplaylist type="tvshows">
+    <name>Recently added TV shows</name>
+    <match>all</match>
+    <rule field="dateadded" operator="after">
+        <value>1970-01-01</value>
+    </rule>
+    <limit>25</limit>
+    <order direction="descending">dateadded</order>
+</smartplaylist>

--- a/addons/skin.estuary/xml/Includes_MediaMenu.xml
+++ b/addons/skin.estuary/xml/Includes_MediaMenu.xml
@@ -395,6 +395,14 @@
 				<visible>Control.IsEnabled(4)</visible>
 				<onclick>SendClick(4)</onclick>
 			</control>
+			<control type="button" id="6054">
+				<include>MediaMenuItemsCommon</include>
+				<label condition="String.IsEqual(Container.FolderPath,videodb://recentlyaddedepisodes/)">$LOCALIZE[31616]</label>
+				<label>$LOCALIZE[31617]</label>
+				<visible>String.IsEqual(Container.FolderPath,videodb://recentlyaddedepisodes/) | String.IsEqual(Container.FolderPath,special://skin/playlists/recent_tvshows.xsp)</visible>
+				<onclick condition="String.IsEqual(Container.FolderPath,videodb://recentlyaddedepisodes/)">Container.Update(special://skin/playlists/recent_tvshows.xsp,replace)</onclick>
+				<onclick condition="String.IsEqual(Container.FolderPath,special://skin/playlists/recent_tvshows.xsp)">Container.Update(videodb://recentlyaddedepisodes/,replace)</onclick>
+			</control>
 			<include condition="Window.IsVisible(Videos) | Window.IsVisible(Music)">MediaMenuSearchButton</include>
 			<control type="button" id="19">
 				<visible>Container.CanFilter + !Container.CanFilterAdvanced</visible>


### PR DESCRIPTION
## Description
Add a group by toggle in the Recently added category. When toggled, instead of showing each episodes, this
groups the entries by show. 

## Motivation and context
When adding many episodes of different shows, its currently difficult to see what show where added.
This makes it easy.

## How has this been tested?
I tested this change manually.

## What is the effect on users?
The effect is documented in the Description.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

I need some assistance with the unchecked check boxes please.
