### PR TITLE
[CMake][Android] Forward APP_PACKAGE override to CompileInfo.cpp gene…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,6 +366,7 @@ add_custom_command(OUTPUT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp
                                             -DCORE_BUILD_DIR=${CORE_BUILD_DIR}
                                             -DCMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}
                                             -DARCH_DEFINES="${ARCH_DEFINES}"
+                                            -DAPP_PACKAGE=${APP_PACKAGE}
                                             -DAPP_SCMID=${APP_SCMID}
                                             -DAPP_COPYRIGHT_YEARS=${APP_COPYRIGHT_YEARS}
                                             -DAPP_BUILD_DATE=${APP_BUILD_DATE}


### PR DESCRIPTION
## Description
Forward `-DAPP_PACKAGE=<value>` to the standalone `GenerateCompileInfo.cmake` invocation, so the override reaches `CompileInfo.cpp` the same way it already reaches the Android packaging templates.

## Motivation and context
`CompileInfo.cpp` is generated by a separate `cmake -P` process (`cmake/scripts/common/GenerateCompileInfo.cmake`) invoked via `add_custom_command` in the top-level `CMakeLists.txt`. That invocation forwards `APP_SCMID`, `APP_COPYRIGHT_YEARS`, etc., but not `APP_PACKAGE`. Since `Macros.cmake`'s `core_find_versions()` only honors an override if `APP_PACKAGE` is already set in that process, the standalone process always falls back to the `version.txt` default — even when the main configure pass correctly picked up `-DAPP_PACKAGE` for `build.gradle`/`AndroidManifest.xml`.

On Android this is load-bearing: `CJNIMainActivity::RegisterNatives()` builds its `JNIEnv::FindClass()` lookup from `CCompileInfo::GetClass()`. With a mismatched package id between the Java side (correct) and the native side (stale default), the class lookup fails and the app crashes on first launch with a `ClassNotFoundException`.

## How has this been tested?
Configured locally with `-DAPP_PACKAGE=org.xbmc.kodi.dev` for an Android build; confirmed `CompileInfo.cpp` now contains the overridden value and the app launches correctly (previously crashed with `ClassNotFoundException` on the mismatched class path).

## What is the effect on users?
Fixes crash-on-launch for anyone building Android/Flatpak-style packages with a custom `APP_PACKAGE` override.

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the Code Guidelines of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the Contributing document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed