### PR TITLE
application-guilib: fix SIGSEGV on shutdown destroying stranded windows

### DIFF
--- a/xbmc/guilib/GUIComponent.cpp
+++ b/xbmc/guilib/GUIComponent.cpp
@@ -56,10 +56,11 @@ void CGUIComponent::Init()
 
 void CGUIComponent::Deinit()
 {
-  CServiceBroker::UnregisterGUI();
-
+  // must precede UnregisterGUI: window teardown releases textures through GetGUI()
   if (m_pWindowManager)
     m_pWindowManager->DeInitialize();
+
+  CServiceBroker::UnregisterGUI();
 
   // Now safe to release skin - all windows deinitialized
   m_skinInfo.reset();

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -1602,6 +1602,11 @@ void CGUIWindowManager::DeInitialize()
   m_vecCustomWindows.clear();
   m_activeDialogs.clear();
 
+  // FrameMove is the only other drain and stops running at shutdown
+  for (const auto& window : m_deleteWindows)
+    window->FreeResources(true);
+  m_deleteWindows.clear();
+
   m_initialized = false;
 }
 


### PR DESCRIPTION
## Description

Fix hard-to-repro SIGSEGV on shutdown.

Windows queued on m_deleteWindows after the render loop stops are destroyed by ~CGUIWindowManager once CServiceBroker::GetGUI() is null, which CGUITexture::FreeResources() dereferences unchecked. DeInitialize() now clears m_deleteWindows, and Deinit() unregisters the GUI after calling it.

## Motivation and context
Fix SIGSEGV

## How has this been tested?
AMD / Linux / GBM

Repro plugin created by Claude:
```
"""Repro for the shutdown SIGSEGV in ~CGUIWindowManager.

Quits Kodi itself, so nothing depends on your timing. Two independent triggers
are armed in the same run, because both can be live at once.

What the crash needs, and why both halves are hard to get together:

  Uploaded. CGLESTexture::DestroyTextureObject() is gated on m_texture, the GL
  name, which only CreateTextureObject() inside LoadToGPU() sets, and that runs
  from CGUITexture::Render. A window that never drew cannot crash.

  Stranded and unfreed. CGUIWindowManager::Delete() queues the window on
  m_deleteWindows. Only FrameMove() drains it, and CApplication::Run() stops
  calling FrameMove once m_bStop is set. Any window that instead goes through
  GUI_MSG_WINDOW_DEINIT has FreeResources() called on it and is harmless.

Trigger A, the core file browser.
  CGUIDialogFileBrowser::ShowAndGetFile() calls browser->Open() and then
  CGUIWindowManager::Delete(browser->GetID()) unconditionally. Open() is
  CGUIDialog::Open_Internal(), whose modal loop is
  "while (m_active) { if (!ProcessRenderLoop(false)) break; }", and
  ProcessRenderLoop returns false once g_application.m_bStop is set. Quitting
  while the browser is up breaks that loop with m_active still true, so the
  dialog is never closed, deinited or freed, having already rendered. The
  Delete() that follows queues it after the last FrameMove and takes it out of
  m_mapWindows, so DeInitialize() cannot reach it either.

  browse(0, ...) reaches that function through Dialog::browseSingle and
  ShowAndGetDirectory. GetUniqueBrowserInstance builds a fresh window per call.

Trigger B, an addon WindowXMLDialog held open across shutdown.
  This is the shape in the captured backtrace, where
  WindowXMLInterceptor::~WindowXMLInterceptor sits under ~CGUIWindowManager.
  The window is shown, left open, and never disposed; the interceptor holds a
  strong Ref to the Python object, so dropping the Python reference would not
  dispose it anyway.

Expect "Cleanup: Having to cleanup texture ..." at skin unload, then the crash
in ~CGUIComponent.

Install to ~/.kodi/addons/script.repro.deletewindows and enable it. It quits
about five seconds after the skin comes up.
"""

import threading

import xbmc
import xbmcaddon
import xbmcgui

ADDON_ID = "script.repro.deletewindows"
WINDOW_XML = "script-repro-window.xml"

SECONDS_BEFORE_QUIT = 5

# held forever on purpose: trigger B needs this window still open at shutdown
WINDOW = None


class ReproWindow(xbmcgui.WindowXMLDialog):
    pass


def log(message):
    xbmc.log("repro.deletewindows: " + message, xbmc.LOGINFO)


def quit_while_open():
    # both windows have to have drawn, so LoadToGPU has given their textures
    # their GL names
    if xbmc.Monitor().waitForAbort(SECONDS_BEFORE_QUIT):
        return
    log("requesting quit with both windows still open")
    xbmc.executebuiltin("Quit")


def main():
    global WINDOW

    monitor = xbmc.Monitor()

    while not xbmc.getCondVisibility("Window.IsVisible(home)"):
        if monitor.waitForAbort(0.25):
            return

    path = xbmcaddon.Addon(ADDON_ID).getAddonInfo("path")

    # trigger B
    WINDOW = ReproWindow(WINDOW_XML, path)
    WINDOW.show()
    xbmc.sleep(1000)
    log("addon dialog shown and left open")

    threading.Thread(target=quit_while_open).start()

    # trigger A: blocks this thread while the app thread runs the modal loop,
    # and returns when that loop breaks on m_bStop, whereupon ShowAndGetFile
    # calls Delete() on a window that was never freed
    log("opening the file browser modally")
    xbmcgui.Dialog().browse(0, "repro deleteWindows", "files")
    log("browse returned, browser is stranded in m_deleteWindows")


if __name__ == "__main__":
    main()
```
## What is the effect on users?
Clean shutdown

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
