### PR TITLE
[RetroPlayer] Don't lend GPU-shared memory to game clients

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/IRenderBufferPool.h
+++ b/xbmc/cores/RetroPlayer/buffers/IRenderBufferPool.h
@@ -72,6 +72,14 @@ public:
   virtual std::shared_ptr<IRenderBufferPool> GetPtr() { return shared_from_this(); }
 
   /*!
+   * \brief Whether the GPU reads the memory a frame was written into directly
+   *
+   * Such a pool saves uploading every frame, but the memory is sampled in
+   * place, so it must not be written to while a frame is being drawn from it.
+   */
+  virtual bool SharesMemoryWithGpu() const { return false; }
+
+  /*!
    * \brief Release resources tied to the rendering context
    *
    * This function is called when the render context is being destroyed.

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMA.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMA.h
@@ -29,6 +29,7 @@ public:
 
   // Implementation of IRenderBufferPool via CBaseRenderBufferPool
   bool IsCompatible(const CRenderVideoSettings& renderSettings) const override;
+  bool SharesMemoryWithGpu() const override { return true; }
 
 protected:
   // Implementation of CBaseRenderBufferPool

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -169,6 +169,13 @@ bool CRPRenderManager::GetVideoBuffer(unsigned int width,
 
   for (IRenderBufferPool* bufferPool : bufferPools)
   {
+    // Never lend out memory the GPU samples in place. A client treats the
+    // buffer it is given as its own framebuffer and keeps drawing into it, so
+    // the frame on screen would change under the GPU as it is sampled, tearing
+    // rows out of the picture. Such a pool can still be filled by copying.
+    if (bufferPool->SharesMemoryWithGpu())
+      continue;
+
     renderBuffer = bufferPool->GetBuffer(width, height);
     if (renderBuffer != nullptr)
       break;
@@ -183,8 +190,7 @@ bool CRPRenderManager::GetVideoBuffer(unsigned int width,
   uint8_t* const memory = renderBuffer->GetMemory();
 
   buffer = VideoStreamBuffer{renderBuffer->GetFormat(), memory, renderBuffer->GetFrameSize(),
-                             renderBuffer->GetMemoryAccess(),
-                             renderBuffer->GetMemoryAlignment()};
+                             renderBuffer->GetMemoryAccess(), renderBuffer->GetMemoryAlignment()};
 
   m_pendingBuffers.emplace_back(PendingBuffer{renderBuffer, memory});
 

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -81,8 +81,11 @@ void CRPRenderManager::Deinitialize()
     renderBuffer->Release();
   m_renderBuffers.clear();
 
-  for (auto buffer : m_pendingBuffers)
+  for (const auto& [buffer, memory] : m_pendingBuffers)
+  {
+    buffer->ReleaseMemory();
     buffer->Release();
+  }
   m_pendingBuffers.clear();
 
   for (auto& [savestatePath, renderBuffers] : m_savestateBuffers)
@@ -132,9 +135,13 @@ bool CRPRenderManager::GetVideoBuffer(unsigned int width,
                                       unsigned int height,
                                       VideoStreamBuffer& buffer)
 {
-  // Clear any previous pending buffers
-  for (IRenderBuffer* buffer : m_pendingBuffers)
+  // Clear any previous pending buffers. A buffer still pending here was lent
+  // to the client and never handed back, so its CPU access is still open.
+  for (const auto& [buffer, memory] : m_pendingBuffers)
+  {
+    buffer->ReleaseMemory();
     buffer->Release();
+  }
   m_pendingBuffers.clear();
 
   if (m_bFlush || m_state != RENDER_STATE::CONFIGURED)
@@ -172,11 +179,14 @@ bool CRPRenderManager::GetVideoBuffer(unsigned int width,
   if (renderBuffer == nullptr)
     return false;
 
-  buffer = VideoStreamBuffer{renderBuffer->GetFormat(), renderBuffer->GetMemory(),
-                             renderBuffer->GetFrameSize(), renderBuffer->GetMemoryAccess(),
+  // Starts CPU access, which lasts until the client hands the frame back
+  uint8_t* const memory = renderBuffer->GetMemory();
+
+  buffer = VideoStreamBuffer{renderBuffer->GetFormat(), memory, renderBuffer->GetFrameSize(),
+                             renderBuffer->GetMemoryAccess(),
                              renderBuffer->GetMemoryAlignment()};
 
-  m_pendingBuffers.emplace_back(renderBuffer);
+  m_pendingBuffers.emplace_back(PendingBuffer{renderBuffer, memory});
 
   return true;
 }
@@ -198,10 +208,15 @@ void CRPRenderManager::AddFrame(const uint8_t* data,
   // Get render buffers to copy the frame into
   std::vector<IRenderBuffer*> renderBuffers;
 
-  // Check pending buffers
-  for (IRenderBuffer* buffer : m_pendingBuffers)
+  // Check pending buffers. The client has finished writing, so end CPU access
+  // on everything it was lent before any of it is handed to the GPU.
+  for (const auto& [buffer, memory] : m_pendingBuffers)
   {
-    if (buffer->GetMemory() == data)
+    const bool bSubmitted = (memory == data);
+
+    buffer->ReleaseMemory();
+
+    if (bSubmitted)
     {
       buffer->Acquire();
       renderBuffers.emplace_back(buffer);

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -247,7 +247,20 @@ private:
   std::set<std::shared_ptr<CRPBaseRenderer>> m_renderers;
   std::set<std::shared_ptr<CRPBaseRenderer>> m_oldRenderers;
   mutable std::mutex m_oldRenderersMutex;
-  std::vector<IRenderBuffer*> m_pendingBuffers; // Only access from game thread
+  /*!
+   * \brief A buffer lent to the game client to draw its next frame into
+   *
+   * The memory the client was given is recorded alongside the buffer, because
+   * that is how the frame it hands back is recognized as the one it was lent,
+   * and asking the buffer for its memory again would start another round of
+   * CPU access.
+   */
+  struct PendingBuffer
+  {
+    IRenderBuffer* buffer;
+    uint8_t* memory;
+  };
+  std::vector<PendingBuffer> m_pendingBuffers; // Only access from game thread
   std::vector<IRenderBuffer*> m_renderBuffers;
   std::map<AVPixelFormat, std::map<AVPixelFormat, SwsContext*>> m_scalers; // From -> to -> context
   std::vector<uint8_t> m_cachedFrame;


### PR DESCRIPTION
## Description

Software-rendered games show rows torn out of the picture when the DMA render buffer pool is in use. This removes the dominant cause; see the testing section for what is left.

`CRPRenderManager::GetVideoBuffer()` lends a game client a render buffer to draw its next frame into. A libretro client treats the memory it is given as its own framebuffer and keeps drawing into it. For a pool the renderer copies out of that is harmless, but `CRenderBufferDMA` shares its memory with the GPU, which samples it in place through an EGL image. The frame on screen therefore changes under the GPU while it is being sampled.

Two commits:

**1. End CPU access on the buffer lent to a client.** `GetVideoBuffer()` calls `GetMemory()`, which starts CPU access (`DMA_BUF_IOCTL_SYNC` with `DMA_BUF_SYNC_START`), but `ReleaseMemory()` was only ever reached from `CopyFrame()` and the savestate readback. Every frame through the lend path left an unbalanced START and a live writable mapping. Recognising the frame the client hands back also called `GetMemory()` a second time purely to compare a pointer, starting yet another round of CPU access; the lent pointer is recorded instead.

**2. Do not lend out memory the GPU samples in place.** A pool can now say whether the GPU reads its memory directly, and `GetVideoBuffer()` skips those pools. They are still filled, by copying the finished frame, which is what pools that do not share memory with the GPU already do. Such a pool keeps its advantage either way, as the frame is still sampled in place rather than uploaded — the change costs one copy, not the pool's reason for existing.

Commit 1 is a correctness fix on its own but does not stop the tearing; commit 2 is what fixes it. They are kept separate for that reason.

## Motivation and context

This is a defect in current master, not a regression. `CRenderBufferDMA` has `SyncStart()`/`SyncEnd()` around CPU access, but that is cache coherency only — there is nothing anywhere that keeps a client from writing to a buffer while it is being drawn from, and `GetVideoBuffer()` hands out exactly such a buffer.

I found it while working on OpenGL/GLES hardware rendering for RetroPlayer, where the DMA pool gets a lot more exercise than it normally does.

## How has this been tested?

Linux, Wayland, desktop GL, Intel Arc (Meteor Lake), Mesa. The DMA pool is backed by `CUDMABufferObject` here (`/dev/dma_heap` is root-only on this machine, so the udmabuf backend is the one that registers). `game.libretro.fceumm` running Super Mario Bros, which scrolls continuously and makes torn rows obvious.

Confirmed for each run that the DMA path was actually in use — `Creating renderer for DMAOpenGL` and `CRenderBufferDMA: using BufferObject type: CUDMABufferObject`.

Eight screenshots per run, sampled a few seconds apart, judged by eye at the source resolution of 256x224:

| | Frames with visible tearing |
|---|---|
| master | 5 of 8, severe — one frame almost entirely destroyed |
| commit 1 only | 5 of 8, unchanged severity. The unbalanced `DMA_BUF_SYNC_START` is gone though: one `CUDMABufferObject::GetMemory - already mapped` line per frame, 2403 in a 40s run, drops to zero |
| commits 1 + 2 | 6 of 8, but far less severe — thin streaks rather than destroyed frames |
| control: same run with the DMA pool not selected | 0 of 8 |

**So this is a substantial reduction, not a complete fix, and I want to be straight about that.** It removes what is clearly the dominant cause, and the difference against master is large and obvious in the screenshots. But the control run shows the DMA path can be completely clean, and it is not yet, so something else is still tearing that I have not identified.

I also checked a different theory first, in case it saves someone the detour: that the pool was recycling buffers the GPU had not finished reading. I fenced every draw with an EGL sync and tested the fence when the buffer was next written. It was signalled on 2300 of 2300 reuses, and enforcing a wait changed nothing on screen. That is not what is happening here.

I am happy to keep digging at the remainder before this is merged if that is preferred — I raised it now because the two changes here are correct on their own terms and the first one is a plain resource-handling bug regardless of the tearing.

The changed code is identical on the Kodi 22 branch this was tested against and on master, and the branch here builds clean against master.

## Screenshots

To follow in a comment: contact sheets of all eight captures per run at source resolution, for master, for this PR, and for the control with the DMA pool not selected. The residual described above is visible in the middle one.

## Types of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic (Wiki, documentation, comments, formatting, ...)
- [ ] None of the above (please explain below)

## Checklist

- [x] My code follows the Code Guidelines of this project
- [x] My change requires a change to the documentation, either Doxygen or Wiki
- [x] I have updated the documentation accordingly (Doxygen on the new pool method)
- [x] I have read the Contributing document
- [ ] I have added tests to cover my change — the render path has no test coverage to extend
- [ ] All new and existing tests passed — not run locally, leaving this to CI

---

@garbear This would be a great fix for beta 2 - and is a pre-req for some of our OpenGL GLES work - currently mitigated in the branch with a toggle in games settings which isn't user friendly. This upstream changes fixes it and allows me to remove that toggle giving us more chance of getting our chunkier change merged in Q*
