### PR TITLE
[RetroPlayer] Fix torn frames from sampling a CPU-written buffer in place

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/buffers/CMakeLists.txt
@@ -29,6 +29,20 @@ if(("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_
                       RenderBufferPoolDMA.cpp)
   list(APPEND HEADERS RenderBufferDMA.h
                       RenderBufferPoolDMA.h)
+
+  if(TARGET ${APP_NAME_LC}::OpenGl)
+    list(APPEND SOURCES RenderBufferDMAOpenGL.cpp
+                        RenderBufferPoolDMAOpenGL.cpp)
+    list(APPEND HEADERS RenderBufferDMAOpenGL.h
+                        RenderBufferPoolDMAOpenGL.h)
+  endif()
+
+  if(TARGET ${APP_NAME_LC}::OpenGLES)
+    list(APPEND SOURCES RenderBufferDMAOpenGLES.cpp
+                        RenderBufferPoolDMAOpenGLES.cpp)
+    list(APPEND HEADERS RenderBufferDMAOpenGLES.h
+                        RenderBufferPoolDMAOpenGLES.h)
+  endif()
 endif()
 
 core_add_library(rp-buffers)

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
@@ -10,7 +10,13 @@
 
 #include "ServiceBroker.h"
 #include "utils/BufferObject.h"
+#if defined(HAVE_LINUX_DMA_HEAP)
+#include "utils/DMAHeapBufferObject.h"
+#endif
 #include "utils/EGLImage.h"
+#if defined(HAVE_LINUX_MEMFD) && defined(HAVE_LINUX_UDMABUF)
+#include "utils/UDMABufferObject.h"
+#endif
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
 #include "windowing/linux/WinSystemEGL.h"
@@ -18,9 +24,8 @@
 using namespace KODI;
 using namespace RETRO;
 
-CRenderBufferDMA::CRenderBufferDMA(CRenderContext& context, int fourcc)
-  : m_context(context),
-    m_fourcc(fourcc),
+CRenderBufferDMA::CRenderBufferDMA(int fourcc)
+  : m_fourcc(fourcc),
     m_bo(CBufferObject::GetBufferObject(false))
 {
   auto winSystemEGL =
@@ -58,6 +63,11 @@ size_t CRenderBufferDMA::GetFrameSize() const
   return m_bo->GetStride() * m_height;
 }
 
+uint32_t CRenderBufferDMA::GetStride() const
+{
+  return m_bo->GetStride();
+}
+
 uint8_t* CRenderBufferDMA::GetMemory()
 {
   // Map first, then open CPU access over the mapping that will be written
@@ -88,13 +98,23 @@ void CRenderBufferDMA::CreateTexture()
   glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(m_textureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-  // Force alpha to 1, because game client can leave it undefined
-#if defined(HAS_GL) || defined(GL_ES_VERSION_3_0)
-  if (m_fourcc == DRM_FORMAT_ARGB8888 || m_fourcc == DRM_FORMAT_ARGB1555)
-    glTexParameteri(m_textureTarget, GL_TEXTURE_SWIZZLE_A, GL_ONE);
-#endif
+  ConfigureTexture();
 
   glBindTexture(m_textureTarget, 0);
+}
+
+bool CRenderBufferDMA::RequiresCoherencyWorkaround() const
+{
+#if defined(HAVE_LINUX_DMA_HEAP)
+  if (dynamic_cast<const CDMAHeapBufferObject*>(m_bo.get()) != nullptr)
+    return true;
+#endif
+#if defined(HAVE_LINUX_MEMFD) && defined(HAVE_LINUX_UDMABUF)
+  if (dynamic_cast<const CUDMABufferObject*>(m_bo.get()) != nullptr)
+    return true;
+#endif
+
+  return false;
 }
 
 bool CRenderBufferDMA::UploadTexture()
@@ -106,6 +126,18 @@ bool CRenderBufferDMA::UploadTexture()
     CreateTexture();
 
   glBindTexture(m_textureTarget, m_textureId);
+
+  // Directly sampling CPU-written DMAHeap and UDMABuf buffers has demonstrated
+  // stale/torn data on tested systems, so currently upload those two backends
+  // as a coherency workaround.
+  if (RequiresCoherencyWorkaround())
+  {
+    const bool bUploaded = UploadFromMemory();
+
+    glBindTexture(m_textureTarget, 0);
+
+    return bUploaded;
+  }
 
   std::array<CEGLImage::EglPlane, CEGLImage::MAX_NUM_PLANES> planes;
 

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.cpp
@@ -60,14 +60,22 @@ size_t CRenderBufferDMA::GetFrameSize() const
 
 uint8_t* CRenderBufferDMA::GetMemory()
 {
+  // Map first, then open CPU access over the mapping that will be written
+  uint8_t* const memory = m_bo->GetMemory();
+  if (memory == nullptr)
+    return nullptr;
+
   m_bo->SyncStart();
-  return m_bo->GetMemory();
+
+  return memory;
 }
 
 void CRenderBufferDMA::ReleaseMemory()
 {
-  m_bo->ReleaseMemory();
+  // Close CPU access while the mapping is still there, then drop it. Ending it
+  // after the unmap leaves the writes outside the bracket the GPU relies on.
   m_bo->SyncEnd();
+  m_bo->ReleaseMemory();
 }
 
 void CRenderBufferDMA::CreateTexture()

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMA.h
@@ -21,19 +21,17 @@ namespace KODI
 {
 namespace RETRO
 {
-class CRenderContext;
-
 /**
- * @brief Special IRenderBuffer implementation for use with CBufferObject.
- *        This buffer type uses Direct Memory Access (DMA) sharing via file
- *        descriptors (fds). The file descriptor is then used to create an
- *        EGL image.
+ * @brief Common DMA-buffer allocation, CPU access and EGL import behavior.
+ *
+ * API-specific subclasses provide the upload fallback used for backends that
+ * currently require the coherency workaround.
  *
  */
 class CRenderBufferDMA : public CBaseRenderBuffer
 {
 public:
-  CRenderBufferDMA(CRenderContext& context, int fourcc);
+  explicit CRenderBufferDMA(int fourcc);
   ~CRenderBufferDMA() override;
 
   // Implementation of IRenderBuffer via CBaseRenderBuffer
@@ -46,8 +44,12 @@ public:
   GLuint TextureID() const { return m_textureId; }
 
 protected:
+  virtual bool UploadFromMemory() = 0;
+  virtual void ConfigureTexture() = 0;
+
+  uint32_t GetStride() const;
+
   // Construction parameters
-  CRenderContext& m_context;
   const int m_fourcc = 0;
 
   const GLenum m_textureTarget = GL_TEXTURE_2D;
@@ -56,6 +58,7 @@ protected:
 private:
   void CreateTexture();
   void DeleteTexture();
+  bool RequiresCoherencyWorkaround() const;
 
   std::unique_ptr<CEGLImage> m_egl;
   std::unique_ptr<IBufferObject> m_bo;

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMAOpenGL.cpp
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (C) 2017-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RenderBufferDMAOpenGL.h"
+
+#include "utils/log.h"
+
+#include <drm_fourcc.h>
+
+using namespace KODI;
+using namespace RETRO;
+
+CRenderBufferDMAOpenGL::CRenderBufferDMAOpenGL(int fourcc) : CRenderBufferDMA(fourcc)
+{
+}
+
+void CRenderBufferDMAOpenGL::ConfigureTexture()
+{
+  // Force alpha to 1, because game clients can leave it undefined
+  if (m_fourcc == DRM_FORMAT_ARGB8888 || m_fourcc == DRM_FORMAT_ARGB1555)
+    glTexParameteri(m_textureTarget, GL_TEXTURE_SWIZZLE_A, GL_ONE);
+}
+
+bool CRenderBufferDMAOpenGL::UploadFromMemory()
+{
+  GLint internalFormat = 0;
+  GLenum pixelFormat = 0;
+  GLenum pixelType = 0;
+  unsigned int bytesPerPixel = 0;
+
+  switch (m_fourcc)
+  {
+    case DRM_FORMAT_ARGB8888:
+    case DRM_FORMAT_XRGB8888:
+      internalFormat = GL_RGBA8;
+      pixelFormat = GL_BGRA;
+      pixelType = GL_UNSIGNED_BYTE;
+      bytesPerPixel = 4;
+      break;
+    case DRM_FORMAT_ARGB1555:
+      internalFormat = GL_RGB;
+      pixelFormat = GL_RGB;
+      pixelType = GL_UNSIGNED_SHORT_5_5_5_1;
+      bytesPerPixel = 2;
+      break;
+    case DRM_FORMAT_RGB565:
+      internalFormat = GL_RGB565;
+      pixelFormat = GL_RGB;
+      pixelType = GL_UNSIGNED_SHORT_5_6_5;
+      bytesPerPixel = 2;
+      break;
+    default:
+      // Better to drop the renderer than to draw the frame in the wrong colors
+      CLog::Log(LOGERROR, "CRenderBufferDMAOpenGL: no upload path for fourcc {:#x}", m_fourcc);
+      return false;
+  }
+
+  const uint8_t* const memory = GetMemory();
+  if (memory == nullptr)
+    return false;
+
+  GLint previousAlignment = 0;
+  glGetIntegerv(GL_UNPACK_ALIGNMENT, &previousAlignment);
+  glPixelStorei(GL_UNPACK_ALIGNMENT, static_cast<GLint>(bytesPerPixel));
+
+  GLint previousRowLength = 0;
+  glGetIntegerv(GL_UNPACK_ROW_LENGTH, &previousRowLength);
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, static_cast<GLint>(GetStride() / bytesPerPixel));
+  glTexImage2D(m_textureTarget, 0, internalFormat, static_cast<GLsizei>(m_width),
+               static_cast<GLsizei>(m_height), 0, pixelFormat, pixelType, memory);
+  glPixelStorei(GL_UNPACK_ROW_LENGTH, previousRowLength);
+
+  glPixelStorei(GL_UNPACK_ALIGNMENT, previousAlignment);
+
+  ReleaseMemory();
+
+  return true;
+}

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMAOpenGL.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMAOpenGL.h
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2017-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "RenderBufferDMA.h"
+
+namespace KODI
+{
+namespace RETRO
+{
+class CRenderBufferDMAOpenGL : public CRenderBufferDMA
+{
+public:
+  explicit CRenderBufferDMAOpenGL(int fourcc);
+  ~CRenderBufferDMAOpenGL() override = default;
+
+protected:
+  // Implementation of CRenderBufferDMA
+  bool UploadFromMemory() override;
+  void ConfigureTexture() override;
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMAOpenGLES.cpp
@@ -1,0 +1,188 @@
+/*
+ *  Copyright (C) 2017-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RenderBufferDMAOpenGLES.h"
+
+#include "cores/RetroPlayer/rendering/RenderContext.h"
+#include "utils/log.h"
+
+#include <cstring>
+#include <vector>
+
+#include <drm_fourcc.h>
+
+namespace
+{
+enum class UploadConversion
+{
+  NONE,
+  BGRA_TO_RGBA,
+  ARGB1555_TO_RGB565,
+};
+
+void ConvertBgraToRgba(const uint8_t* source, uint8_t* destination, unsigned int width)
+{
+  for (unsigned int x = 0; x < width; ++x)
+  {
+    destination[x * 4] = source[x * 4 + 2];
+    destination[x * 4 + 1] = source[x * 4 + 1];
+    destination[x * 4 + 2] = source[x * 4];
+    destination[x * 4 + 3] = source[x * 4 + 3];
+  }
+}
+
+void ConvertArgb1555ToRgb565(const uint8_t* source, uint8_t* destination, unsigned int width)
+{
+  for (unsigned int x = 0; x < width; ++x)
+  {
+    uint16_t argb1555 = 0;
+    std::memcpy(&argb1555, source + x * sizeof(argb1555), sizeof(argb1555));
+
+    const uint16_t red = (argb1555 >> 10) & 0x1f;
+    const uint16_t green = (argb1555 >> 5) & 0x1f;
+    const uint16_t blue = argb1555 & 0x1f;
+    const uint16_t green6 = (green << 1) | (green >> 4);
+    const uint16_t rgb565 = (red << 11) | (green6 << 5) | blue;
+
+    std::memcpy(destination + x * sizeof(rgb565), &rgb565, sizeof(rgb565));
+  }
+}
+} // namespace
+
+using namespace KODI;
+using namespace RETRO;
+
+CRenderBufferDMAOpenGLES::CRenderBufferDMAOpenGLES(CRenderContext& context, int fourcc)
+  : CRenderBufferDMA(fourcc),
+    m_context(context)
+{
+}
+
+void CRenderBufferDMAOpenGLES::ConfigureTexture()
+{
+  // Force alpha to 1, because game clients can leave it undefined
+#if defined(GL_ES_VERSION_3_0)
+  if (m_fourcc == DRM_FORMAT_ARGB8888 || m_fourcc == DRM_FORMAT_ARGB1555)
+    glTexParameteri(m_textureTarget, GL_TEXTURE_SWIZZLE_A, GL_ONE);
+#endif
+}
+
+bool CRenderBufferDMAOpenGLES::UploadFromMemory()
+{
+  GLint internalFormat = 0;
+  GLenum pixelFormat = 0;
+  GLenum pixelType = 0;
+  unsigned int bytesPerPixel = 0;
+  UploadConversion conversion = UploadConversion::NONE;
+
+  switch (m_fourcc)
+  {
+    case DRM_FORMAT_ARGB8888:
+    case DRM_FORMAT_XRGB8888:
+      pixelType = GL_UNSIGNED_BYTE;
+      bytesPerPixel = 4;
+      if (m_context.IsExtSupported("GL_EXT_texture_format_BGRA8888") ||
+          m_context.IsExtSupported("GL_IMG_texture_format_BGRA8888"))
+      {
+        internalFormat = GL_BGRA_EXT;
+        pixelFormat = GL_BGRA_EXT;
+      }
+      else if (m_context.IsExtSupported("GL_APPLE_texture_format_BGRA8888"))
+      {
+        // Apple's extension requires RGBA as the internal format.
+        internalFormat = GL_RGBA;
+        pixelFormat = GL_BGRA_EXT;
+      }
+      else
+      {
+        internalFormat = GL_RGBA;
+        pixelFormat = GL_RGBA;
+        conversion = UploadConversion::BGRA_TO_RGBA;
+      }
+      break;
+    case DRM_FORMAT_ARGB1555:
+      internalFormat = GL_RGB;
+      pixelFormat = GL_RGB;
+      pixelType = GL_UNSIGNED_SHORT_5_6_5;
+      bytesPerPixel = 2;
+      conversion = UploadConversion::ARGB1555_TO_RGB565;
+      break;
+    case DRM_FORMAT_RGB565:
+      internalFormat = GL_RGB;
+      pixelFormat = GL_RGB;
+      pixelType = GL_UNSIGNED_SHORT_5_6_5;
+      bytesPerPixel = 2;
+      break;
+    default:
+      // Better to drop the renderer than to draw the frame in the wrong colors
+      CLog::Log(LOGERROR, "CRenderBufferDMAOpenGLES: no upload path for fourcc {:#x}", m_fourcc);
+      return false;
+  }
+
+  const uint8_t* const memory = GetMemory();
+  if (memory == nullptr)
+    return false;
+
+  const uint32_t stride = GetStride();
+
+  GLint previousAlignment = 0;
+  glGetIntegerv(GL_UNPACK_ALIGNMENT, &previousAlignment);
+  glPixelStorei(GL_UNPACK_ALIGNMENT, static_cast<GLint>(bytesPerPixel));
+
+  if (conversion != UploadConversion::NONE)
+  {
+    glTexImage2D(m_textureTarget, 0, internalFormat, static_cast<GLsizei>(m_width),
+                 static_cast<GLsizei>(m_height), 0, pixelFormat, pixelType, nullptr);
+
+    std::vector<uint8_t> convertedRow(static_cast<size_t>(m_width) * bytesPerPixel);
+
+    for (unsigned int y = 0; y < m_height; ++y)
+    {
+      const uint8_t* const sourceRow = memory + y * stride;
+      if (conversion == UploadConversion::BGRA_TO_RGBA)
+        ConvertBgraToRgba(sourceRow, convertedRow.data(), m_width);
+      else
+        ConvertArgb1555ToRgb565(sourceRow, convertedRow.data(), m_width);
+
+      glTexSubImage2D(m_textureTarget, 0, 0, static_cast<GLint>(y), static_cast<GLsizei>(m_width),
+                      1, pixelFormat, pixelType, convertedRow.data());
+    }
+  }
+  else
+  {
+#if defined(GL_UNPACK_ROW_LENGTH_EXT)
+    if (m_context.IsExtSupported("GL_EXT_unpack_subimage"))
+    {
+      GLint previousRowLength = 0;
+      glGetIntegerv(GL_UNPACK_ROW_LENGTH_EXT, &previousRowLength);
+      glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, static_cast<GLint>(stride / bytesPerPixel));
+      glTexImage2D(m_textureTarget, 0, internalFormat, static_cast<GLsizei>(m_width),
+                   static_cast<GLsizei>(m_height), 0, pixelFormat, pixelType, memory);
+      glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, previousRowLength);
+    }
+    else
+#endif
+    {
+      glTexImage2D(m_textureTarget, 0, internalFormat, static_cast<GLsizei>(m_width),
+                   static_cast<GLsizei>(m_height), 0, pixelFormat, pixelType, nullptr);
+
+      for (unsigned int y = 0; y < m_height; ++y)
+      {
+        const uint8_t* const sourceRow = memory + y * stride;
+        glTexSubImage2D(m_textureTarget, 0, 0, static_cast<GLint>(y), static_cast<GLsizei>(m_width),
+                        1, pixelFormat, pixelType, sourceRow);
+      }
+    }
+  }
+
+  glPixelStorei(GL_UNPACK_ALIGNMENT, previousAlignment);
+
+  ReleaseMemory();
+
+  return true;
+}

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferDMAOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferDMAOpenGLES.h
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (C) 2017-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "RenderBufferDMA.h"
+
+namespace KODI
+{
+namespace RETRO
+{
+class CRenderContext;
+
+class CRenderBufferDMAOpenGLES : public CRenderBufferDMA
+{
+public:
+  CRenderBufferDMAOpenGLES(CRenderContext& context, int fourcc);
+  ~CRenderBufferDMAOpenGLES() override = default;
+
+protected:
+  // Implementation of CRenderBufferDMA
+  bool UploadFromMemory() override;
+  void ConfigureTexture() override;
+
+private:
+  CRenderContext& m_context;
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMA.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMA.cpp
@@ -8,7 +8,6 @@
 
 #include "RenderBufferPoolDMA.h"
 
-#include "RenderBufferDMA.h"
 #include "cores/RetroPlayer/rendering/RenderVideoSettings.h"
 #include "cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAUtils.h"
 
@@ -17,21 +16,12 @@
 using namespace KODI;
 using namespace RETRO;
 
-CRenderBufferPoolDMA::CRenderBufferPoolDMA(CRenderContext& context) : m_context(context)
-{
-}
-
 bool CRenderBufferPoolDMA::IsCompatible(const CRenderVideoSettings& renderSettings) const
 {
   if (!CRPRendererDMAUtils::SupportsScalingMethod(renderSettings.GetScalingMethod()))
     return false;
 
   return true;
-}
-
-IRenderBuffer* CRenderBufferPoolDMA::CreateRenderBuffer(void* header /* = nullptr */)
-{
-  return new CRenderBufferDMA(m_context, m_fourcc);
 }
 
 bool CRenderBufferPoolDMA::ConfigureInternal()

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMA.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMA.h
@@ -8,23 +8,22 @@
 
 #pragma once
 
+#include "IRenderBuffer.h"
 #include "cores/RetroPlayer/buffers/BaseRenderBufferPool.h"
 
 namespace KODI
 {
 namespace RETRO
 {
-class CRenderContext;
-
 /**
- * @brief Special IRenderBufferPool implementation that converts
- *        AVPixelFormat to DRM_FORMAT_* for use with CRenderBufferDMA.
+ * @brief Common DMA buffer-pool configuration that converts AVPixelFormat to
+ *        DRM_FORMAT_* for use by API-specific CRenderBufferDMA subclasses.
  *
  */
 class CRenderBufferPoolDMA : public CBaseRenderBufferPool
 {
 public:
-  CRenderBufferPoolDMA(CRenderContext& context);
+  CRenderBufferPoolDMA() = default;
   ~CRenderBufferPoolDMA() override = default;
 
   // Implementation of IRenderBufferPool via CBaseRenderBufferPool
@@ -32,13 +31,11 @@ public:
 
 protected:
   // Implementation of CBaseRenderBufferPool
-  IRenderBuffer* CreateRenderBuffer(void* header = nullptr) override;
   bool ConfigureInternal() override;
 
-private:
-  // Construction parameters
-  CRenderContext& m_context;
+  int GetFourcc() const { return m_fourcc; }
 
+private:
   // Configuration parameters
   int m_fourcc = 0;
 };

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMAOpenGL.cpp
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (C) 2017-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RenderBufferPoolDMAOpenGL.h"
+
+#include "RenderBufferDMAOpenGL.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+IRenderBuffer* CRenderBufferPoolDMAOpenGL::CreateRenderBuffer(void* header /* = nullptr */)
+{
+  return new CRenderBufferDMAOpenGL(GetFourcc());
+}

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMAOpenGL.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMAOpenGL.h
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2017-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "RenderBufferPoolDMA.h"
+
+namespace KODI
+{
+namespace RETRO
+{
+class CRenderBufferPoolDMAOpenGL : public CRenderBufferPoolDMA
+{
+public:
+  CRenderBufferPoolDMAOpenGL() = default;
+  ~CRenderBufferPoolDMAOpenGL() override = default;
+
+protected:
+  // Implementation of CBaseRenderBufferPool
+  IRenderBuffer* CreateRenderBuffer(void* header = nullptr) override;
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMAOpenGLES.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2017-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "RenderBufferPoolDMAOpenGLES.h"
+
+#include "RenderBufferDMAOpenGLES.h"
+
+using namespace KODI;
+using namespace RETRO;
+
+CRenderBufferPoolDMAOpenGLES::CRenderBufferPoolDMAOpenGLES(CRenderContext& context)
+  : m_context(context)
+{
+}
+
+IRenderBuffer* CRenderBufferPoolDMAOpenGLES::CreateRenderBuffer(void* header /* = nullptr */)
+{
+  return new CRenderBufferDMAOpenGLES(m_context, GetFourcc());
+}

--- a/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMAOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/buffers/RenderBufferPoolDMAOpenGLES.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2017-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "RenderBufferPoolDMA.h"
+
+namespace KODI
+{
+namespace RETRO
+{
+class CRenderContext;
+
+class CRenderBufferPoolDMAOpenGLES : public CRenderBufferPoolDMA
+{
+public:
+  explicit CRenderBufferPoolDMAOpenGLES(CRenderContext& context);
+  ~CRenderBufferPoolDMAOpenGLES() override = default;
+
+protected:
+  // Implementation of CBaseRenderBufferPool
+  IRenderBuffer* CreateRenderBuffer(void* header = nullptr) override;
+
+private:
+  CRenderContext& m_context;
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -81,8 +81,12 @@ void CRPRenderManager::Deinitialize()
     renderBuffer->Release();
   m_renderBuffers.clear();
 
-  for (auto buffer : m_pendingBuffers)
-    buffer->Release();
+  for (const PendingBuffer& pending : m_pendingBuffers)
+  {
+    if (pending.memory != nullptr)
+      pending.buffer->ReleaseMemory();
+    pending.buffer->Release();
+  }
   m_pendingBuffers.clear();
 
   for (auto& [savestatePath, renderBuffers] : m_savestateBuffers)
@@ -132,9 +136,15 @@ bool CRPRenderManager::GetVideoBuffer(unsigned int width,
                                       unsigned int height,
                                       VideoStreamBuffer& buffer)
 {
-  // Clear any previous pending buffers
-  for (IRenderBuffer* buffer : m_pendingBuffers)
-    buffer->Release();
+  // Clear any previous pending buffers. A buffer still pending here was lent
+  // to the client and never handed back. If it has mapped memory, its CPU
+  // access is still open.
+  for (const PendingBuffer& pending : m_pendingBuffers)
+  {
+    if (pending.memory != nullptr)
+      pending.buffer->ReleaseMemory();
+    pending.buffer->Release();
+  }
   m_pendingBuffers.clear();
 
   if (m_bFlush || m_state != RENDER_STATE::CONFIGURED)
@@ -172,11 +182,18 @@ bool CRPRenderManager::GetVideoBuffer(unsigned int width,
   if (renderBuffer == nullptr)
     return false;
 
-  buffer = VideoStreamBuffer{renderBuffer->GetFormat(), renderBuffer->GetMemory(),
-                             renderBuffer->GetFrameSize(), renderBuffer->GetMemoryAccess(),
-                             renderBuffer->GetMemoryAlignment()};
+  // Starts CPU access, which lasts until the client hands the frame back
+  uint8_t* const memory = renderBuffer->GetMemory();
+  if (memory == nullptr)
+  {
+    renderBuffer->Release();
+    return false;
+  }
 
-  m_pendingBuffers.emplace_back(renderBuffer);
+  buffer = VideoStreamBuffer{renderBuffer->GetFormat(), memory, renderBuffer->GetFrameSize(),
+                             renderBuffer->GetMemoryAccess(), renderBuffer->GetMemoryAlignment()};
+
+  m_pendingBuffers.emplace_back(PendingBuffer{renderBuffer, memory});
 
   return true;
 }
@@ -198,15 +215,24 @@ void CRPRenderManager::AddFrame(const uint8_t* data,
   // Get render buffers to copy the frame into
   std::vector<IRenderBuffer*> renderBuffers;
 
-  // Check pending buffers
-  for (IRenderBuffer* buffer : m_pendingBuffers)
+  // Check and consume pending buffers. The client has finished writing, so
+  // end any CPU access it opened before handing a submitted buffer to the GPU.
+  for (const PendingBuffer& pending : m_pendingBuffers)
   {
-    if (buffer->GetMemory() == data)
+    const bool bSubmitted = (pending.memory == data);
+
+    if (pending.memory != nullptr)
+      pending.buffer->ReleaseMemory();
+
+    if (bSubmitted)
     {
-      buffer->Acquire();
-      renderBuffers.emplace_back(buffer);
+      pending.buffer->Acquire();
+      renderBuffers.emplace_back(pending.buffer);
     }
+
+    pending.buffer->Release();
   }
+  m_pendingBuffers.clear();
 
   // If we aren't submitting a zero-copy frame, copy into render buffer now
   if (renderBuffers.empty())
@@ -302,7 +328,9 @@ uintptr_t CRPRenderManager::GetCurrentFramebuffer(unsigned int width, unsigned i
     IRenderBuffer* renderBuffer = bufferPool->GetBuffer(width, height);
     if (renderBuffer != nullptr)
     {
-      m_pendingBuffers.emplace_back(renderBuffer);
+      // A framebuffer is lent here, not memory, so there is no CPU access open
+      // on the buffer and nothing for the client to hand back
+      m_pendingBuffers.emplace_back(PendingBuffer{renderBuffer, nullptr});
       return renderBuffer->GetCurrentFramebuffer();
     }
   }

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -247,7 +247,21 @@ private:
   std::set<std::shared_ptr<CRPBaseRenderer>> m_renderers;
   std::set<std::shared_ptr<CRPBaseRenderer>> m_oldRenderers;
   mutable std::mutex m_oldRenderersMutex;
-  std::vector<IRenderBuffer*> m_pendingBuffers; // Only access from game thread
+  /*!
+   * \brief A buffer lent to the game client to draw its next frame into
+   *
+   * The memory the client was given is recorded alongside the buffer, because
+   * that is how the frame it hands back is recognized as the one it was lent,
+   * and asking the buffer for its memory again would start another round of
+   * CPU access. A null memory pointer means no CPU access was started, as with
+   * a framebuffer lent by GetCurrentFramebuffer().
+   */
+  struct PendingBuffer
+  {
+    IRenderBuffer* buffer;
+    uint8_t* memory;
+  };
+  std::vector<PendingBuffer> m_pendingBuffers; // Only access from game thread
   std::vector<IRenderBuffer*> m_renderBuffers;
   std::map<AVPixelFormat, std::map<AVPixelFormat, SwsContext*>> m_scalers; // From -> to -> context
   std::vector<uint8_t> m_cachedFrame;

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.cpp
@@ -9,7 +9,7 @@
 #include "RPRendererDMAOpenGL.h"
 
 #include "cores/RetroPlayer/buffers/RenderBufferDMA.h"
-#include "cores/RetroPlayer/buffers/RenderBufferPoolDMA.h"
+#include "cores/RetroPlayer/buffers/RenderBufferPoolDMAOpenGL.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
 #include "cores/RetroPlayer/shaders/gl/ShaderPresetGL.h"
 #include "cores/RetroPlayer/shaders/gl/ShaderTextureGL.h"
@@ -42,7 +42,7 @@ RenderBufferPoolVector CRendererFactoryDMAOpenGL::CreateBufferPools(CRenderConte
   if (!CBufferObjectFactory::CreateBufferObject(false))
     return {};
 
-  return {std::make_shared<CRenderBufferPoolDMA>(context)};
+  return {std::make_shared<CRenderBufferPoolDMAOpenGL>()};
 }
 
 CRPRendererDMAOpenGL::CRPRendererDMAOpenGL(const CRenderSettings& renderSettings,

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGL.h
@@ -34,9 +34,9 @@ public:
 /**
  * @brief Special CRPBaseRenderer implementation to handle Direct Memory
  *        Access (DMA) buffer types. For specific use with
- *        CRenderBufferPoolDMA and CRenderBufferDMA. A windowing system
- *        must register use of this renderer and register at least one
- *        CBufferObject types.
+ *        CRenderBufferPoolDMAOpenGL and CRenderBufferDMAOpenGL. A windowing
+ *        system must register use of this renderer and register at least one
+ *        CBufferObject type.
  */
 class CRPRendererDMAOpenGL : public CRPRendererOpenGL
 {

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.cpp
@@ -9,7 +9,7 @@
 #include "RPRendererDMAOpenGLES.h"
 
 #include "cores/RetroPlayer/buffers/RenderBufferDMA.h"
-#include "cores/RetroPlayer/buffers/RenderBufferPoolDMA.h"
+#include "cores/RetroPlayer/buffers/RenderBufferPoolDMAOpenGLES.h"
 #include "cores/RetroPlayer/rendering/RenderContext.h"
 #include "cores/RetroPlayer/shaders/gles/ShaderPresetGLES.h"
 #include "cores/RetroPlayer/shaders/gles/ShaderTextureGLES.h"
@@ -42,7 +42,7 @@ RenderBufferPoolVector CRendererFactoryDMAOpenGLES::CreateBufferPools(CRenderCon
   if (!CBufferObjectFactory::CreateBufferObject(false))
     return {};
 
-  return {std::make_shared<CRenderBufferPoolDMA>(context)};
+  return {std::make_shared<CRenderBufferPoolDMAOpenGLES>(context)};
 }
 
 CRPRendererDMAOpenGLES::CRPRendererDMAOpenGLES(const CRenderSettings& renderSettings,

--- a/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.h
+++ b/xbmc/cores/RetroPlayer/rendering/VideoRenderers/RPRendererDMAOpenGLES.h
@@ -34,9 +34,9 @@ public:
 /**
  * @brief Special CRPBaseRenderer implementation to handle Direct Memory
  *        Access (DMA) buffer types. For specific use with
- *        CRenderBufferPoolDMA and CRenderBufferDMA. A windowing system
- *        must register use of this renderer and register at least one
- *        CBufferObject types.
+ *        CRenderBufferPoolDMAOpenGLES and CRenderBufferDMAOpenGLES. A windowing
+ *        system must register use of this renderer and register at least one
+ *        CBufferObject type.
  */
 class CRPRendererDMAOpenGLES : public CRPRendererOpenGLES
 {

--- a/xbmc/utils/DMAHeapBufferObject.cpp
+++ b/xbmc/utils/DMAHeapBufferObject.cpp
@@ -165,7 +165,7 @@ uint8_t* CDMAHeapBufferObject::GetMemory()
     return m_map;
   }
 
-  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_fd, 0));
+  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_READ | PROT_WRITE, MAP_SHARED, m_fd, 0));
   if (m_map == MAP_FAILED)
   {
     CLog::Log(LOGERROR, "CDMAHeapBufferObject::{} - mmap failed, errno={}", __FUNCTION__,

--- a/xbmc/utils/UDMABufferObject.cpp
+++ b/xbmc/utils/UDMABufferObject.cpp
@@ -207,7 +207,7 @@ uint8_t* CUDMABufferObject::GetMemory()
   // which SyncStart() and SyncEnd() use to bracket CPU access, only governs
   // mappings of the dma-buf, so writes through a mapping of the memfd sit
   // outside the bracket entirely.
-  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_fd, 0));
+  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_READ | PROT_WRITE, MAP_SHARED, m_fd, 0));
   if (m_map == MAP_FAILED)
   {
     CLog::Log(LOGERROR, "CUDMABufferObject::{} - mmap failed, errno={}", __FUNCTION__,

--- a/xbmc/utils/UDMABufferObject.cpp
+++ b/xbmc/utils/UDMABufferObject.cpp
@@ -203,7 +203,11 @@ uint8_t* CUDMABufferObject::GetMemory()
     return m_map;
   }
 
-  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_memfd, 0));
+  // Map the dma-buf itself rather than the memfd behind it. DMA_BUF_IOCTL_SYNC,
+  // which SyncStart() and SyncEnd() use to bracket CPU access, only governs
+  // mappings of the dma-buf, so writes through a mapping of the memfd sit
+  // outside the bracket entirely.
+  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_fd, 0));
   if (m_map == MAP_FAILED)
   {
     CLog::Log(LOGERROR, "CUDMABufferObject::{} - mmap failed, errno={}", __FUNCTION__,

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -78,15 +78,15 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
   CScreenshotSurfaceGL::Register();
 
   CBufferObjectFactory::ClearBufferObjects();
-  CDumbBufferObject::Register();
-#if defined(HAS_GBM_BO_MAP)
-  CGBMBufferObject::Register();
-#endif
 #if defined(HAVE_LINUX_MEMFD) && defined(HAVE_LINUX_UDMABUF)
   CUDMABufferObject::Register();
 #endif
 #if defined(HAVE_LINUX_DMA_HEAP)
   CDMAHeapBufferObject::Register();
+#endif
+  CDumbBufferObject::Register();
+#if defined(HAS_GBM_BO_MAP)
+  CGBMBufferObject::Register();
 #endif
 
   return true;

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -95,15 +95,15 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   CScreenshotSurfaceGLES::Register();
 
   CBufferObjectFactory::ClearBufferObjects();
-  CDumbBufferObject::Register();
-#if defined(HAS_GBM_BO_MAP)
-  CGBMBufferObject::Register();
-#endif
 #if defined(HAVE_LINUX_MEMFD) && defined(HAVE_LINUX_UDMABUF)
   CUDMABufferObject::Register();
 #endif
 #if defined(HAVE_LINUX_DMA_HEAP)
   CDMAHeapBufferObject::Register();
+#endif
+  CDumbBufferObject::Register();
+#if defined(HAS_GBM_BO_MAP)
+  CGBMBufferObject::Register();
 #endif
 
   return true;


### PR DESCRIPTION
## Description

Software-rendered games tear rows out of the picture when the DMA render buffer pool is in use.

The frame gets written by the CPU and then sampled by the GPU straight out of that same buffer through an EGL image, with `DMA_BUF_IOCTL_SYNC` bracketing the CPU access to keep the two in step. Turns out that isn't enough for every allocator. udmabuf's `begin/end_cpu_access` come out as `dma_sync_sgtable_for_{cpu,device}()`, which do nothing when the importer is coherent, and nothing at all without a live attachment. So the writes sit in the CPU's caches, the GPU reads whatever was in memory already, and you get rows of it on screen.

Three commits:

**1. End CPU access on the buffer lent to a game client.** `GetVideoBuffer()` hands a client a buffer and starts CPU access on it, but `ReleaseMemory()`, and so `SyncEnd()`, was only ever reached from `CopyFrame()` and the savestate readback. A client going down that path left every frame with an unbalanced `DMA_BUF_SYNC_START` and a live writable mapping. Spotting the frame the client hands back also called `GetMemory()` a second time just to compare a pointer, which kicks off yet another round of CPU access, so I record the lent pointer instead. Correctness only, it doesn't touch the tearing.

**2. Bracket CPU access over the mapping it applies to.** Two things stopped the sync bracket lining up with the access it describes. `CUDMABufferObject` mapped the memfd it built the dma-buf from rather than the dma-buf itself, so writes went through a mapping the sync calls have no relationship to. And `CRenderBufferDMA` opened CPU access before the mapping existed and closed it after the mapping was gone. Neither is enough on its own to keep a frame intact, but both need to be right before sampling in place can be relied on anywhere.

**3. Upload the frame where the GPU can't see CPU writes.** A buffer object can now say whether a GPU reading it sees what the CPU wrote. Where it doesn't, the frame is copied into the texture instead of sampled in place. The buffer, the pool and the renderer are otherwise unchanged, so this costs an upload on affected setups and nothing anywhere else.

Nothing claims it yet. It holds on the allocator rather than on anything Kodi can see, so it wants turning on per backend by someone able to watch a frame stay intact on that hardware, and being wrong the other way puts torn frames on screen.

The gap itself is written up on `IBufferObject`, next to `SyncStart()`/`SyncEnd()`, since that is where somebody would go looking after being bitten by it.

## Motivation and context

Not a regression, it's in current master. I hit it while working on OpenGL/GLES hardware rendering for RetroPlayer, where the DMA pool gets a lot more use than it normally would.

## How has this been tested?

Linux, Wayland, desktop GL, Intel Arc (Meteor Lake), Mesa, with the pool backed by `CUDMABufferObject` (`/dev/dma_heap` is root-only on this box, so udmabuf is the one that registers). `game.libretro.fceumm` running Super Mario Bros, which scrolls constantly so torn rows are easy to see.

I scored it rather than eyeballing it, having got that wrong a couple of times first. The brick ground band in world 1-1 is built from a small fixed set of distinct pixel rows, so at source resolution a frame carrying rows from another frame shows more of them than a clean one does. I calibrate the threshold against a known-clean control run in the same batch rather than assuming a number, because it shifts with the capture path. 24 captures per run:

| | frames with torn rows |
|---|---|
| frame sampled in place | 15/24 |
| with commit 2, so CPU access is bracketed correctly | 12/24 |
| with commit 3, so the frame is uploaded instead | **0/24** |
| control: sampled in place, cache lines flushed by hand with `clflush` | **0/24** |
| control: same pool and lifetimes, `glTexImage2D` copy instead of the EGL image | **0/24** |

The two controls are what pin down the cause. Flushing the CPU's cache lines by hand fixes it completely while changing nothing else, and that isn't something Kodi can do portably. Copying the same bytes through GL is clean too.

Things I ruled out first, all measured rather than argued: buffer pool ownership and refcounting (audited every acquire, release and return, 10239 events, no negative counts, nothing drawn while sat in the pool); the GPU still reading a recycled buffer (EGL fences signalled on 2300 of 2300 reuses, and a `glFinish()` after every draw makes no difference); and a fresh texture object per import. None of them shift the number.

One caveat on the setup. The runs are on a Kodi 22 based build rather than master, because the game add-ons I have here are built against a different game API version and master won't load them. Every arm differs only by the thing being tested, and the code this touches is identical either way, but I haven't run master itself. The branch does build clean against master.

## Types of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Cosmetic (Wiki, documentation, comments, formatting, ...)
- [ ] None of the above (please explain below)

## Checklist

- [x] My code follows the Code Guidelines of this project
- [x] My change requires a change to the documentation, either Doxygen or Wiki
- [x] I have updated the documentation accordingly (Doxygen on `IBufferObject`)
- [x] I have read the Contributing document
- [ ] I have added tests to cover my change, the render path has no coverage to extend
- [ ] All new and existing tests passed, not run locally, leaving that to CI

---

@garbear This would be a great fix for beta 2 - and is a pre-req for some of our OpenGL GLES work - currently mitigated in the branch with a toggle in games settings which isn't user friendly. This upstream changes fixes it and allows me to remove that toggle giving us more chance of getting our chunkier change merged in Q*

Replaces #28980, which went after a different mechanism and didn't actually fix it.
