### PR TITLE
[Video][Bluray] Stream determination tweaks.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1975,7 +1975,14 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
         delete stream;
         return nullptr;
       }
-      std::static_pointer_cast<CDVDInputStreamBluray>(m_pInput)->GetStreamInfo(pStream->id, stream->language);
+      const auto bluray{std::static_pointer_cast<CDVDInputStreamBluray>(m_pInput)};
+      bluray->GetStreamInfo(pStream->id, stream->language);
+
+      // The transport stream of a bluray carries no disposition, so the default audio and subtitle
+      // streams have to be flagged from the clip information (see IsDefaultStream)
+      if (bluray->IsDefaultStream(pStream->id))
+        stream->flags =
+            static_cast<StreamFlags>(static_cast<int>(stream->flags) | StreamFlags::FLAG_DEFAULT);
     }
 #endif
     if (m_pInput->IsStreamType(DVDSTREAM_TYPE_DVD))

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -1078,6 +1078,11 @@ static bool find_stream(int pid, BLURAY_STREAM_INFO *info, int count, std::strin
   return true;
 }
 
+static bool is_first_stream(int pid, const BLURAY_STREAM_INFO* info, int count)
+{
+  return count > 0 && info[0].pid == static_cast<uint16_t>(pid);
+}
+
 void CDVDInputStreamBluray::GetStreamInfo(int pid, std::string &language)
 {
   if(!m_titleInfo || !m_clip)
@@ -1095,6 +1100,23 @@ void CDVDInputStreamBluray::GetStreamInfo(int pid, std::string &language)
     find_stream(pid, m_clip->ig_streams, m_clip->ig_stream_count, language);
   else
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::GetStreamInfo - unhandled pid {}", pid);
+}
+
+bool CDVDInputStreamBluray::IsDefaultStream(int pid) const
+{
+  if (!m_titleInfo || !m_clip)
+    return false;
+
+  // The clip's stream number table lists the primary streams in stream number order, and a player
+  // starts with audio stream number 1 (PSR1) and presentation graphic stream number 1 (PSR2), so
+  // the first entry of each is the disc's default.
+  if (HDMV_PID_AUDIO_FIRST <= pid && pid <= HDMV_PID_AUDIO_LAST)
+    return is_first_stream(pid, m_clip->audio_streams, m_clip->audio_stream_count);
+  if ((HDMV_PID_PG_FIRST <= pid && pid <= HDMV_PID_PG_LAST) ||
+      (HDMV_PID_PG_HDR_FIRST <= pid && pid <= HDMV_PID_PG_HDR_LAST))
+    return is_first_stream(pid, m_clip->pg_streams, m_clip->pg_stream_count);
+
+  return false;
 }
 
 CDVDInputStream::ENextStream CDVDInputStreamBluray::NextStream()

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.cpp
@@ -28,6 +28,7 @@
 #include "video/VideoInfoTag.h"
 
 #include <chrono>
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <string>
@@ -35,6 +36,7 @@
 
 #include <libbluray/bluray-version.h>
 #include <libbluray/bluray.h>
+#include <libbluray/clpi_data.h>
 #include <libbluray/log_control.h>
 
 #define LIBBLURAY_BYTESEEK 0
@@ -436,6 +438,30 @@ void CDVDInputStreamBluray::FreeTitleInfo()
 
   m_titleInfo = nullptr;
   m_clip = nullptr;
+  FreeClipInfo();
+}
+
+void CDVDInputStreamBluray::FreeClipInfo()
+{
+  if (m_clipInfo)
+    bd_free_clpi(m_clipInfo);
+
+  m_clipInfo = nullptr;
+}
+
+void CDVDInputStreamBluray::UpdateClipInfo(unsigned int playItem)
+{
+  FreeClipInfo();
+
+  // A copy of the .clpi libbluray read when it opened the title, so this costs no disc access.
+  // The play items of the playlist being played and the clips of the open title are both in the
+  // order the .mpls lists them, so the index of one is the index of the other.
+  m_clipInfo = bd_get_clpi(m_bd, playItem);
+  if (!m_clipInfo)
+    CLog::Log(LOGDEBUG,
+              "CDVDInputStreamBluray::UpdateClipInfo - no clip information for play item {} - the "
+              "streams the playlist does not present will have no language",
+              playItem);
 }
 
 void CDVDInputStreamBluray::ProcessEvent() {
@@ -563,7 +589,10 @@ void CDVDInputStreamBluray::ProcessEvent() {
   case BD_EVENT_PLAYITEM:
     CLog::Log(LOGDEBUG, "CDVDInputStreamBluray - BD_EVENT_PLAYITEM {}", m_event.param);
     if (m_titleInfo && m_event.param < m_titleInfo->clip_count)
+    {
       m_clip = &m_titleInfo->clips[m_event.param];
+      UpdateClipInfo(m_event.param);
+    }
     break;
 
   case BD_EVENT_CHAPTER:
@@ -1083,23 +1112,67 @@ static bool is_first_stream(int pid, const BLURAY_STREAM_INFO* info, int count)
   return count > 0 && info[0].pid == static_cast<uint16_t>(pid);
 }
 
+bool CDVDInputStreamBluray::GetPlaylistStreamLanguage(int pid, std::string& language) const
+{
+  if (pid == HDMV_PID_VIDEO)
+    return find_stream(pid, m_clip->video_streams, m_clip->video_stream_count, language);
+  if (HDMV_PID_AUDIO_FIRST <= pid && pid <= HDMV_PID_AUDIO_LAST)
+    return find_stream(pid, m_clip->audio_streams, m_clip->audio_stream_count, language);
+  if ((HDMV_PID_PG_FIRST <= pid && pid <= HDMV_PID_PG_LAST) ||
+      (HDMV_PID_PG_HDR_FIRST <= pid && pid <= HDMV_PID_PG_HDR_LAST))
+    return find_stream(pid, m_clip->pg_streams, m_clip->pg_stream_count, language);
+  if (HDMV_PID_IG_FIRST <= pid && pid <= HDMV_PID_IG_LAST)
+    return find_stream(pid, m_clip->ig_streams, m_clip->ig_stream_count, language);
+
+  CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::GetStreamInfo - unhandled pid {}", pid);
+  return false;
+}
+
+bool CDVDInputStreamBluray::GetClipStreamLanguage(int pid, std::string& language) const
+{
+  if (!m_clipInfo)
+    return false;
+
+  const CLPI_PROG_INFO& programs{m_clipInfo->program};
+  for (unsigned int i = 0; i < programs.num_prog; ++i)
+  {
+    const CLPI_PROG& program{programs.progs[i]};
+    for (unsigned int j = 0; j < program.num_streams; ++j)
+    {
+      const CLPI_PROG_STREAM& stream{program.streams[j]};
+      if (stream.pid != static_cast<uint16_t>(pid))
+        continue;
+
+      // The language is three characters, and absent for a stream that has none (video)
+      if (stream.lang[0] == 0)
+        return false;
+
+      language = std::string(stream.lang, strnlen(stream.lang, sizeof(stream.lang)));
+      return true;
+    }
+  }
+
+  return false;
+}
+
 void CDVDInputStreamBluray::GetStreamInfo(int pid, std::string &language)
 {
   if(!m_titleInfo || !m_clip)
     return;
 
-  if (pid == HDMV_PID_VIDEO)
-    find_stream(pid, m_clip->video_streams, m_clip->video_stream_count, language);
-  else if (HDMV_PID_AUDIO_FIRST <= pid && pid <= HDMV_PID_AUDIO_LAST)
-    find_stream(pid, m_clip->audio_streams, m_clip->audio_stream_count, language);
-  else if (HDMV_PID_PG_FIRST <= pid && pid <= HDMV_PID_PG_LAST)
-    find_stream(pid, m_clip->pg_streams, m_clip->pg_stream_count, language);
-  else if (HDMV_PID_PG_HDR_FIRST <= pid && pid <= HDMV_PID_PG_HDR_LAST)
-    find_stream(pid, m_clip->pg_streams, m_clip->pg_stream_count, language);
-  else if (HDMV_PID_IG_FIRST <= pid && pid <= HDMV_PID_IG_LAST)
-    find_stream(pid, m_clip->ig_streams, m_clip->ig_stream_count, language);
-  else
-    CLog::Log(LOGDEBUG, "CDVDInputStreamBluray::GetStreamInfo - unhandled pid {}", pid);
+  if (GetPlaylistStreamLanguage(pid, language))
+    return;
+
+  // The playlist's stream number table lists only the streams it presents, whereas the m2ts of its
+  // clip commonly carries more - two playlists sharing a clip each present their own selection of
+  // them. The demuxer exposes every stream of the transport stream, so the language of one the
+  // playlist does not present comes from the clip information, leaving it named rather than
+  // unknown. Which stream the playlist starts on is unaffected (see IsDefaultStream).
+  if (!GetClipStreamLanguage(pid, language))
+    CLog::Log(LOGDEBUG,
+              "CDVDInputStreamBluray::GetStreamInfo - no language for pid {} in the playlist or "
+              "its clip",
+              pid);
 }
 
 bool CDVDInputStreamBluray::IsDefaultStream(int pid) const

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -133,6 +133,14 @@ public:
 
   void GetStreamInfo(int pid, std::string &language);
 
+  /*!
+   * \brief Check whether a stream is the default of the playlist being played, ie. audio stream
+   *        number 1 or presentation graphic stream number 1 of the current clip.
+   * \param pid The packet identifier of the stream
+   * \return True if the stream is the default audio or subtitle stream, false otherwise
+   */
+  bool IsDefaultStream(int pid) const;
+
   void OverlayCallback(const BD_OVERLAY * const);
 #ifdef HAVE_LIBBLURAY_BDJ
   void OverlayCallbackARGB(const struct bd_argb_overlay_s * const);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamBluray.h
@@ -170,6 +170,10 @@ protected:
   BLURAY_TITLE_INFO* m_titleInfo = nullptr;
   uint32_t m_playlist = MAX_PLAYLIST_ID + 1;
   BLURAY_CLIP_INFO* m_clip = nullptr;
+
+  //! The clip information of the play item being played, ie. every stream its m2ts carries (see
+  //! GetStreamInfo). Owned, and only valid while m_clip refers to the same play item.
+  struct clpi_cl* m_clipInfo = nullptr;
   uint32_t m_angle = 0;
   bool m_menu = false;
   bool m_isInMainMenu = false;
@@ -205,6 +209,29 @@ protected:
     bool OpenStream(CFileItem &item);
     void SetupPlayerSettings();
     void FreeTitleInfo();
+    void FreeClipInfo();
+
+    /*!
+     * \brief Read the clip information of a play item of the playlist being played.
+     * \param playItem The index of the play item, as BD_EVENT_PLAYITEM reports it
+     */
+    void UpdateClipInfo(unsigned int playItem);
+
+    /*!
+     * \brief Find the language of a stream in the stream number table of the current play item.
+     * \param pid The packet identifier of the stream
+     * \param language Filled in with the language of the stream, if it is found
+     * \return True if the playlist presents the stream, false otherwise
+     */
+    bool GetPlaylistStreamLanguage(int pid, std::string& language) const;
+
+    /*!
+     * \brief Find the language of a stream in the clip information of the current play item.
+     * \param pid The packet identifier of the stream
+     * \param language Filled in with the language of the stream, if it is found
+     * \return True if the clip carries the stream, false otherwise
+     */
+    bool GetClipStreamLanguage(int pid, std::string& language) const;
     std::unique_ptr<CDVDInputStreamFile> m_pstream;
     std::string m_rootPath;
 

--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -427,27 +427,15 @@ bool CBlurayDirectory::GetPlaylists(const CURL& url,
   }
 }
 
-namespace
-{
-void ProcessPlaylist(PlaylistMap& playlists, PlaylistInformation& titleInfo, ClipMap& clips)
+void CBlurayDirectory::ProcessPlaylist(PlaylistMap& playlists,
+                                       PlaylistInformation& titleInfo,
+                                       ClipMap& clips)
 {
   const unsigned int playlist{titleInfo.playlist};
 
-  // Save playlist
-  PlaylistInformation info;
-  info.playlist = playlist;
-
-  // Save playlist duration and chapters
-  info.duration = titleInfo.duration;
-  info.chapters = titleInfo.chapters;
-
-  // Get clips
+  // Record which playlists each clip belongs to, and how long it is
   for (const auto& clip : titleInfo.clips)
   {
-    // Add clip to playlist
-    info.clips.push_back(clip);
-
-    // Add/extend clip information
     const auto& it = clips.find(clip);
     if (it == clips.end())
     {
@@ -465,19 +453,19 @@ void ProcessPlaylist(PlaylistMap& playlists, PlaylistInformation& titleInfo, Cli
     }
   }
 
-  info.videoStreams = titleInfo.videoStreams;
-  info.audioStreams = titleInfo.audioStreams;
-  info.pgStreams = titleInfo.pgStreams;
-
   // Get languages
-  const std::string langs{fmt::format(
-      "{}", fmt::join(titleInfo.audioStreams | std::views::transform(&StreamInfo::language), ","))};
-  info.languages = langs;
-  titleInfo.languages = langs;
+  titleInfo.languages = fmt::format(
+      "{}", fmt::join(titleInfo.audioStreams | std::views::transform(&StreamInfo::language), ","));
 
-  playlists[playlist] = info;
+  // Saved as a whole, so a field added to PlaylistInformation reaches the playlist map without
+  // having to be added here too
+  PlaylistInformation info{titleInfo};
+
+  // The duration of each clip is held once, in the clip map above
+  info.clipDuration.clear();
+
+  playlists[playlist] = std::move(info);
 }
-} // namespace
 
 bool CBlurayDirectory::GetPlaylistsInformation(const CURL& url,
                                                const std::string& realPath,

--- a/xbmc/filesystem/BlurayDirectory.h
+++ b/xbmc/filesystem/BlurayDirectory.h
@@ -82,6 +82,16 @@ private:
   static bool FilterPlaylists(std::vector<PlaylistInformation>& playlists);
 
   /*!
+   \brief Record a playlist and how it and its clips reference one another.
+   \param playlists the playlist map to add the playlist to
+   \param titleInfo the playlist, whose languages are filled in from its audio streams
+   \param clips the clip map to add the playlist's clips to
+   */
+  static void ProcessPlaylist(PlaylistMap& playlists,
+                              PlaylistInformation& titleInfo,
+                              ClipMap& clips);
+
+  /*!
    \brief Get the playlist(s) on the disc as FileItems, without their stream details.
    \param playlist a single playlist to return, or ALL_PLAYLISTS for every valid one
    \return true if any playlist was found

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -33,6 +33,7 @@
 #include <array>
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <iterator>
 #include <map>
 #include <memory>
@@ -2443,6 +2444,16 @@ bool IsSamePresentation(const PlaylistInformation& a,
 }
 
 /*!
+ * \brief Whether the playlist presents the content picture-in-picture.
+ *
+ * \note Kodi does not play the secondary video stream.
+ */
+bool IsPictureInPicturePresentation(const PlaylistInformation& playlist)
+{
+  return playlist.hasSecondaryVideo;
+}
+
+/*!
  * \brief The playlist presenting the movie most fully of those of (near) the longest length.
  *
  * Playlists within MOVIE_EQUAL_LENGTH_TOLERANCE of one another are the same movie presented
@@ -2460,9 +2471,16 @@ const PlaylistInformation& GetBestMoviePlaylist(const std::vector<PlaylistInform
                                  return a.pgStreams.size() > b.pgStreams.size();
                                }};
 
-  const auto longest{std::ranges::max_element(playlists, {}, &PlaylistInformation::duration)};
+  // A picture-in-picture presentation is only the best a disc offers when it is all it offers
+  const bool anyFeature{
+      std::ranges::any_of(playlists, std::not_fn(IsPictureInPicturePresentation))};
+  auto candidates{
+      std::views::filter(playlists, [anyFeature](const PlaylistInformation& playlist)
+                         { return !anyFeature || !IsPictureInPicturePresentation(playlist); })};
+
+  const auto longest{std::ranges::max_element(candidates, {}, &PlaylistInformation::duration)};
   const PlaylistInformation* best{&*longest};
-  for (const auto& playlist : playlists)
+  for (const auto& playlist : candidates)
   {
     if (std::chrono::abs(playlist.duration - longest->duration) <= MOVIE_EQUAL_LENGTH_TOLERANCE &&
         offersMoreStreams(playlist, *best))
@@ -2749,7 +2767,8 @@ void PopulateMovieFileItems(
     const std::vector<PlaylistInformation>& playlists,
     const StreamDetailsProvider& getStreamDetails)
 {
-  // Sort by duration (putting mainPlaylist first if present)
+  // Sort by duration (putting mainPlaylist first if present, and any picture-in-picture
+  // presentation last however long it runs)
   auto sortedPlaylists = playlists;
   std::ranges::sort(sortedPlaylists,
                     [mainPlaylist](const PlaylistInformation& a, const PlaylistInformation& b)
@@ -2759,6 +2778,11 @@ void PopulateMovieFileItems(
 
                       if (aIsMain || bIsMain)
                         return aIsMain && !bIsMain;
+
+                      const bool aIsPiP{IsPictureInPicturePresentation(a)};
+                      const bool bIsPiP{IsPictureInPicturePresentation(b)};
+                      if (aIsPiP != bIsPiP)
+                        return bIsPiP;
 
                       if (a.duration != b.duration)
                         return a.duration > b.duration;

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -601,6 +601,13 @@ EpisodeExtent GetEpisodeExtent(const EpisodeExtents& episodes,
   return {start, duration};
 }
 
+// Which stream a playlist starts on says nothing about what it offers, so FLAG_DEFAULT is not
+// part of comparing one stream with another. Everything else about a stream is.
+StreamFlags GetComparableFlags(StreamFlags flags)
+{
+  return static_cast<StreamFlags>(flags & ~StreamFlags::FLAG_DEFAULT);
+}
+
 // Whether candidateStream offers everything stream does.
 //
 // The two must have the same language, name and flags - and the candidate must then
@@ -608,7 +615,7 @@ EpisodeExtent GetEpisodeExtent(const EpisodeExtents& episodes,
 bool IsStreamCovered(const AudioStreamInfo& stream, const AudioStreamInfo& candidateStream)
 {
   if (stream.language != candidateStream.language || stream.name != candidateStream.name ||
-      stream.flags != candidateStream.flags)
+      GetComparableFlags(stream.flags) != GetComparableFlags(candidateStream.flags))
     return false;
 
   // A channel count of zero means unknown, so only compare them when both are known
@@ -623,7 +630,14 @@ bool IsStreamCovered(const AudioStreamInfo& stream, const AudioStreamInfo& candi
 // Subtitle streams have no comparable ordering of quality, so they have to match
 bool IsStreamCovered(const SubtitleStreamInfo& stream, const SubtitleStreamInfo& candidateStream)
 {
-  return stream == candidateStream;
+  // Compared as a whole rather than field by field, so a field added to SubtitleStreamInfo is
+  // taken into account here without having to be added here too
+  SubtitleStreamInfo comparable{stream};
+  SubtitleStreamInfo comparableCandidate{candidateStream};
+  comparable.flags = GetComparableFlags(comparable.flags);
+  comparableCandidate.flags = GetComparableFlags(comparableCandidate.flags);
+
+  return comparable == comparableCandidate;
 }
 
 // Whether every stream of subset has a distinct counterpart in superset that covers it. Streams are

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -105,6 +105,10 @@ struct PlaylistInformation
   std::vector<SubtitleStreamInfo> pgStreams;
   std::string languages;
 
+  //! Whether the playlist carries a secondary video stream, ie. it presents the content
+  //! picture-in-picture (see IsPictureInPicturePresentation)
+  bool hasSecondaryVideo{false};
+
   void clear()
   {
     playlist = 0;
@@ -116,6 +120,7 @@ struct PlaylistInformation
     audioStreams.clear();
     pgStreams.clear();
     languages.clear();
+    hasSecondaryVideo = false;
   }
 };
 

--- a/xbmc/filesystem/bluray/M2TSParser.cpp
+++ b/xbmc/filesystem/bluray/M2TSParser.cpp
@@ -1042,14 +1042,15 @@ bool ParseTrueHDHeader(const std::span<std::byte>& buffer, TSAudioStreamInfo* st
       audio_sampling_frequency < sampleRates.size() && sampleRates[audio_sampling_frequency] != 0)
     streamInfo->sampleRate = sampleRates[audio_sampling_frequency];
 
-  bool ch6_multichannel_type{GetBits(format_info, 28, 1) == 1};
-  bool ch8_multichannel_type{GetBits(format_info, 27, 1) == 1};
-  unsigned int ch2_presentation_channel_modifier{GetBits(format_info, 26, 2)};
-  unsigned int ch6_presentation_channel_assignment{GetBits(format_info, 22, 5)};
-  unsigned int ch8_presentation_channel_assignment{GetBits(format_info, 15, 13)};
-  bool ch8_flag{GetBits(flags, 12, 1) == 1};
+  const unsigned int ch2_presentation_channel_modifier{GetBits(format_info, 24, 2)};
+  const unsigned int ch6_presentation_channel_assignment{GetBits(format_info, 20, 5)};
+  const unsigned int ch8_presentation_channel_assignment{GetBits(format_info, 13, 13)};
+  const bool ch8_flag{GetBits(flags, 12, 1) == 1};
 
-  if (ch8_multichannel_type)
+  const unsigned int header{GetByte(buffer, 16)};
+  const unsigned int substreams{GetBits(header, 8, 4)};
+
+  if (substreams > 2)
   {
     unsigned int ch8_1;
     unsigned int ch8_2;
@@ -1065,18 +1066,19 @@ bool ParseTrueHDHeader(const std::span<std::byte>& buffer, TSAudioStreamInfo* st
     }
     streamInfo->channels = std::popcount(ch8_2) * 2 + std::popcount(ch8_1);
   }
-  else if (ch6_multichannel_type)
+  else
   {
-    unsigned int ch6_1{ch6_presentation_channel_assignment & CH8_16_SINGLE_CHANNEL_ALTERNATE_MASK};
-    unsigned int ch6_2{ch6_presentation_channel_assignment & CH8_16_DUAL_CHANNEL_ALTERNATE_MASK};
+    const unsigned int ch6_1{ch6_presentation_channel_assignment &
+                             CH8_16_SINGLE_CHANNEL_ALTERNATE_MASK};
+    const unsigned int ch6_2{ch6_presentation_channel_assignment &
+                             CH8_16_DUAL_CHANNEL_ALTERNATE_MASK};
     streamInfo->channels = std::popcount(ch6_2) * 2 + std::popcount(ch6_1);
   }
-  else
+
+  if (streamInfo->channels == 0)
     streamInfo->channels = (ch2_presentation_channel_modifier == 3) ? 1 : 2;
 
   // Look for extended channel info
-  unsigned int header{GetByte(buffer, 16)};
-  unsigned int substreams{GetBits(header, 8, 4)};
   unsigned int substream_info{GetByte(buffer, 17)};
   bool ch16_present{GetBits(substream_info, 8, 1) == 1};
   uint64_t channel_meaning{GetQWord(buffer, 18)};

--- a/xbmc/filesystem/bluray/M2TSParser.cpp
+++ b/xbmc/filesystem/bluray/M2TSParser.cpp
@@ -114,6 +114,8 @@ inline constexpr std::array DTS_CHANNEL_COUNTS{1u, 2u, 2u, 2u, 2u, 3u, 3u, 4u,
                                                4u, 5u, 6u, 6u, 6u, 7u, 8u, 8u};
 
 constexpr unsigned int DTS_HEADER_SIZE = 14;
+constexpr unsigned int DTS_SYNCWORD_SIZE = 4;
+constexpr unsigned int DTS_MAX_PRESENTATIONS = 8;
 constexpr unsigned int HEADERS_PARSED_FOR_COMPLETE = 2;
 // The DTS:X and IMAX extension sync words are not present in every frame, so more frames need to
 // be examined before concluding an extension substream is plain DTS-HD Master Audio
@@ -962,6 +964,69 @@ std::optional<unsigned int> FindDTSSyncWord(const std::span<std::byte>& buffer,
   return std::nullopt;
 }
 
+std::optional<unsigned int> ParseDTSExtensionSubstreamChannels(BitReader& br)
+{
+  br.SkipBits(8); // UserDefinedBits
+  const unsigned int substreamIndex{br.ReadBits(2)}; // nExtSSIndex
+  const bool longSizeFields{br.ReadBits(1) == 1}; // bHeaderSizeType
+  const unsigned int bitsForHeaderSize{longSizeFields ? 12u : 8u};
+  const unsigned int bitsForFrameSize{longSizeFields ? 20u : 16u};
+  br.SkipBits(bitsForHeaderSize); // nuExtSSHeaderSize
+  br.SkipBits(bitsForFrameSize); // nuExtSSFsize
+
+  unsigned int numAssets{1};
+  const bool staticFieldsPresent{br.ReadBits(1) == 1}; // bStaticFieldsPresent
+  if (staticFieldsPresent)
+  {
+    br.SkipBits(2); // nuRefClockCode
+    br.SkipBits(3); // nuExSSFrameDurationCode
+    if (br.ReadBits(1) == 1) // bTimeStampFlag
+      br.SkipBits(36); // nuTimeStamp and nLSB
+
+    const unsigned int numPresentations{br.ReadBits(3) + 1}; // nuNumAudioPresnt
+    numAssets = br.ReadBits(3) + 1; // nuNumAssets
+
+    // Each presentation names the substreams it is carried by, and then holds one asset mask
+    // byte for each of them
+    std::array<unsigned int, DTS_MAX_PRESENTATIONS> activeSubstreamMask{};
+    for (unsigned int i = 0; i < numPresentations; ++i)
+      activeSubstreamMask[i] = br.ReadBits(substreamIndex + 1); // nuActiveExSSMask
+    for (unsigned int i = 0; i < numPresentations; ++i)
+      br.SkipBits(static_cast<uint32_t>(std::popcount(activeSubstreamMask[i])) *
+                  8); // nuActiveAssetMask
+
+    if (br.ReadBits(1) == 1) // bMixMetadataEnbl
+    {
+      br.SkipBits(2); // nuMixMetadataAdjLevel
+      const unsigned int bitsForSpeakerMask{(br.ReadBits(2) + 1) << 2}; // nuBits4MixOutMask
+      const unsigned int numMixConfigurations{br.ReadBits(2) + 1}; // nuNumMixOutConfigs
+      br.SkipBits(numMixConfigurations * bitsForSpeakerMask); // nuMixOutChMask
+    }
+  }
+
+  // The size of every asset, and then the descriptor of the first of them
+  br.SkipBits(numAssets * bitsForFrameSize); // nuAssetFsize
+  br.SkipBits(9); // nuAssetDescriptFsize
+  br.SkipBits(3); // nuAssetIndex
+
+  // The channel count is one of the descriptor's static fields, so without them the asset says
+  // nothing the core has not already said
+  if (!staticFieldsPresent)
+    return std::nullopt;
+
+  if (br.ReadBits(1) == 1) // bAssetTypeDescrPresent
+    br.SkipBits(4); // nuAssetTypeDescriptor
+  if (br.ReadBits(1) == 1) // bLanguageDescrPresent
+    br.SkipBits(24); // LanguageDescriptor
+  if (br.ReadBits(1) == 1) // bInfoTextPresent
+    br.SkipBits((br.ReadBits(10) + 1) * 8); // nuInfoTextByteSize and InfoTextString
+
+  br.SkipBits(5); // nuBitResolution
+  br.SkipBits(4); // nuMaxSampleRate
+
+  return br.ReadBits(8) + 1; // nuTotalNumChs
+}
+
 bool ParseDTSBitstream(const std::span<std::byte>& buffer, TSAudioStreamInfo* streamInfo)
 {
   if (buffer.size() < DTS_HEADER_SIZE)
@@ -971,7 +1036,10 @@ bool ParseDTSBitstream(const std::span<std::byte>& buffer, TSAudioStreamInfo* st
   if (!dtsData)
     return false;
 
-  bool substreamPresent{dtsData->syncWord == DTSSyncWords::SUBSTREAM};
+  // A frame that starts with the substream sync word has no core
+  std::optional<unsigned int> substreamPos{dtsData->syncWord == DTSSyncWords::SUBSTREAM
+                                               ? std::optional{dtsData->syncPos}
+                                               : std::nullopt};
   if (dtsData->syncWord == DTSSyncWords::CORE_16BIT_BE)
   {
     // Parse 16-bit DTS core header
@@ -998,12 +1066,13 @@ bool ParseDTSBitstream(const std::span<std::byte>& buffer, TSAudioStreamInfo* st
       streamInfo->channels++; // Add LFE channel
 
     // See if there is a DTS substream header in this block
-    substreamPresent =
-        FindDTSSyncWord(buffer, dtsData->syncPos + DTS_HEADER_SIZE, DTS_SYNCWORD_SUBSTREAM)
-            .has_value();
+    const unsigned int searchStart{dtsData->syncPos + DTS_HEADER_SIZE};
+    if (const auto found{FindDTSSyncWord(buffer, searchStart, DTS_SYNCWORD_SUBSTREAM)};
+        found.has_value())
+      substreamPos = searchStart + found.value();
   }
 
-  if (substreamPresent)
+  if (substreamPos.has_value())
   {
     // Substream header found
     streamInfo->hasSubstream = true;
@@ -1017,6 +1086,16 @@ bool ParseDTSBitstream(const std::span<std::byte>& buffer, TSAudioStreamInfo* st
     if (auto xllximax{FindDTSSyncWord(buffer, dtsData->syncPos + 10, DTS_SYNCWORD_XLL_X_IMAX)};
         xllximax.has_value())
       streamInfo->isXLLXIMAX = true;
+
+    // The extension describes the full mix, of which the core is only a downmix
+    if (const unsigned int headerPos{substreamPos.value() + DTS_SYNCWORD_SIZE};
+        headerPos < buffer.size())
+    {
+      BitReader br(buffer.subspan(headerPos));
+      if (const auto channels{ParseDTSExtensionSubstreamChannels(br)};
+          channels.has_value() && channels.value() > streamInfo->channels)
+        streamInfo->channels = channels.value();
+    }
   }
 
   // An XLL substream may still be DTS:X or DTS:X IMAX - neither marker is in every frame, so keep

--- a/xbmc/filesystem/bluray/StreamParser.cpp
+++ b/xbmc/filesystem/bluray/StreamParser.cpp
@@ -357,28 +357,36 @@ void CStreamParser::ConvertBlurayPlaylistInformation(const BlurayPlaylistInforma
     p.clipDuration[clip.clip] = clip.duration;
   }
 
-  if (streamDetails == StreamDetails::DEFER)
+  const DefaultStreams defaults{GetDefaultStreams(b)};
+
+  // The PlayItem's stream number table is what the playlist exposes, and in stream number order.
+  // The clip's program list is everything the m2ts carries.
+  const PlayItemInformation* playItem{GetLongestPlayItem(b)};
+  if (playItem && !(playItem->videoStreams.empty() && playItem->audioStreams.empty() &&
+                    playItem->presentationGraphicStreams.empty()))
   {
-    // Neither the .clpi nor the m2ts has been read, so describe the streams from the play item's
-    // stream number table. That gives the coding and language of every stream the playlist
-    // exposes, which is what telling playlists apart and listing their languages needs - only the
-    // details the m2ts carries (channel counts, resolutions) are missing.
-    if (const PlayItemInformation * playItem{GetLongestPlayItem(b)}; playItem)
+    if (streamDetails != StreamDetails::DEFER)
+      LogDefaultStreams(b);
+
+    for (const auto* streams :
+         {&playItem->videoStreams, &playItem->audioStreams, &playItem->presentationGraphicStreams})
     {
-      const DefaultStreams defaults{GetDefaultStreams(b)};
-      for (const auto* streams : {&playItem->videoStreams, &playItem->audioStreams,
-                                  &playItem->presentationGraphicStreams})
-      {
-        for (const StreamInformation& stream : *streams)
-          AddStream(stream, s, b.playlist, defaults, p);
-      }
+      for (const StreamInformation& stream : *streams)
+        AddStream(stream, s, b.playlist, defaults, p);
     }
     return;
   }
 
-  // Stream information must come from the same clip the M2TS analysis used (see
-  // CM2TSParser::GetStreams), otherwise the packet identifiers will not correspond and no parsed
-  // details will be found for some (or all) streams
+  if (streamDetails == StreamDetails::DEFER)
+    return;
+
+  // If the playlist has no stream number table then fall back to every stream the clip carries.
+  // Stream information must come from the same clip the M2TS analysis used, otherwise the packet
+  // identifiers will not correspond and no parsed details will be found for some (or all) streams.
+  CLog::LogFC(LOGDEBUG, LOGBLURAY,
+              "Playlist {} - no stream number table - falling back to the clip's streams",
+              b.playlist);
+
   const ClipInformation* streamClip{nullptr};
   if (const ClipInformation * playItemClip{GetLongestPlayItemClip(b)}; playItemClip)
   {
@@ -395,8 +403,6 @@ void CStreamParser::ConvertBlurayPlaylistInformation(const BlurayPlaylistInforma
 
   if (streamClip && !streamClip->programs.empty())
   {
-    LogDefaultStreams(b);
-    const DefaultStreams defaults{GetDefaultStreams(b)};
     for (const StreamInformation& stream : streamClip->programs[0].streams)
       AddStream(stream, s, b.playlist, defaults, p);
   }

--- a/xbmc/filesystem/bluray/StreamParser.cpp
+++ b/xbmc/filesystem/bluray/StreamParser.cpp
@@ -15,7 +15,9 @@
 
 #include <algorithm>
 #include <map>
+#include <optional>
 #include <ranges>
+#include <string_view>
 #include <vector>
 
 #include <fmt/format.h>
@@ -214,11 +216,66 @@ AudioStreamInfo PopulateAudioStreamInfo(const StreamInformation& stream,
   return asi;
 }
 
+// The packet identifiers of the streams a player starts playback with (see GetDefaultStreams)
+struct DefaultStreams
+{
+  std::optional<unsigned int> audio;
+  std::optional<unsigned int> subtitle;
+};
+
+// The play item's stream number table lists the primary streams in stream number order, and a
+// player starts with audio stream number 1 (PSR1) and presentation graphic stream number 1 (PSR2),
+// so the first entry of each is the disc's default. Both are only a starting point - the player
+// moves to another stream number when the user's language preferences (PSR16/PSR18) match one, and
+// HDMV/BD-J code can select whatever it likes. For subtitles the stream number says nothing about
+// whether subtitles are displayed to begin with, as that is a separate flag of PSR2 the .mpls does
+// not carry.
+DefaultStreams GetDefaultStreams(const BlurayPlaylistInformation& b)
+{
+  DefaultStreams defaults;
+
+  const PlayItemInformation* playItem{GetLongestPlayItem(b)};
+  if (!playItem)
+    return defaults;
+
+  if (!playItem->audioStreams.empty())
+    defaults.audio = playItem->audioStreams.front().packetIdentifier;
+  if (!playItem->presentationGraphicStreams.empty())
+    defaults.subtitle = playItem->presentationGraphicStreams.front().packetIdentifier;
+
+  return defaults;
+}
+
+void LogDefaultStreams(const BlurayPlaylistInformation& b)
+{
+  const PlayItemInformation* playItem{GetLongestPlayItem(b)};
+  if (!playItem)
+    return;
+
+  const auto logStream = [&b](const std::vector<StreamInformation>& streams, std::string_view type)
+  {
+    if (streams.empty())
+      return;
+
+    const StreamInformation& stream{streams.front()};
+    CLog::LogF(LOGDEBUG,
+               "Playlist {} - {} stream number 1 (the default) is PID 0x{} coding 0x{} language {}"
+               " - of {} {} streams",
+               b.playlist, type, fmt::format("{:04x}", stream.packetIdentifier),
+               fmt::format("{:02x}", static_cast<int>(stream.coding)),
+               stream.language.empty() ? "unknown" : stream.language, streams.size(), type);
+  };
+
+  logStream(playItem->audioStreams, "audio");
+  logStream(playItem->presentationGraphicStreams, "subtitle");
+}
+
 // Add one elementary stream to the playlist, refined by the M2TS analysis in s where it has been
 // done (s is empty when stream details were deferred).
 void AddStream(const StreamInformation& stream,
                const StreamMap& s,
                unsigned int playlist,
+               const DefaultStreams& defaults,
                PlaylistInformation& p)
 {
   // Find stream in StreamMap to get accurate details
@@ -255,7 +312,11 @@ void AddStream(const StreamInformation& stream,
                    bs == s.end() ? "packet identifier not present in stream map"
                                  : "stream in map is not an audio stream");
 
-      p.audioStreams.emplace_back(PopulateAudioStreamInfo(stream, bsai));
+      AudioStreamInfo asi{PopulateAudioStreamInfo(stream, bsai)};
+      if (defaults.audio == stream.packetIdentifier)
+        asi.flags = static_cast<StreamFlags>(asi.flags | StreamFlags::FLAG_DEFAULT);
+
+      p.audioStreams.emplace_back(std::move(asi));
       break;
     }
     case SUB_PG:
@@ -264,6 +325,8 @@ void AddStream(const StreamInformation& stream,
       SubtitleStreamInfo ssi;
       ssi.valid = true;
       ssi.language = stream.language;
+      if (defaults.subtitle == stream.packetIdentifier)
+        ssi.flags = static_cast<StreamFlags>(ssi.flags | StreamFlags::FLAG_DEFAULT);
 
       p.pgStreams.emplace_back(std::move(ssi));
       break;
@@ -302,11 +365,12 @@ void CStreamParser::ConvertBlurayPlaylistInformation(const BlurayPlaylistInforma
     // details the m2ts carries (channel counts, resolutions) are missing.
     if (const PlayItemInformation * playItem{GetLongestPlayItem(b)}; playItem)
     {
+      const DefaultStreams defaults{GetDefaultStreams(b)};
       for (const auto* streams : {&playItem->videoStreams, &playItem->audioStreams,
                                   &playItem->presentationGraphicStreams})
       {
         for (const StreamInformation& stream : *streams)
-          AddStream(stream, s, b.playlist, p);
+          AddStream(stream, s, b.playlist, defaults, p);
       }
     }
     return;
@@ -331,8 +395,10 @@ void CStreamParser::ConvertBlurayPlaylistInformation(const BlurayPlaylistInforma
 
   if (streamClip && !streamClip->programs.empty())
   {
+    LogDefaultStreams(b);
+    const DefaultStreams defaults{GetDefaultStreams(b)};
     for (const StreamInformation& stream : streamClip->programs[0].streams)
-      AddStream(stream, s, b.playlist, p);
+      AddStream(stream, s, b.playlist, defaults, p);
   }
 }
 } // namespace XFILE

--- a/xbmc/filesystem/bluray/StreamParser.cpp
+++ b/xbmc/filesystem/bluray/StreamParser.cpp
@@ -368,6 +368,10 @@ void CStreamParser::ConvertBlurayPlaylistInformation(const BlurayPlaylistInforma
     if (streamDetails != StreamDetails::DEFER)
       LogDefaultStreams(b);
 
+    // The secondary video stream is not one Kodi plays, but it tells the playlist apart from one
+    // presenting the same content without it (see IsPictureInPicturePresentation)
+    p.hasSecondaryVideo = !playItem->secondaryVideoStreams.empty();
+
     for (const auto* streams :
          {&playItem->videoStreams, &playItem->audioStreams, &playItem->presentationGraphicStreams})
     {

--- a/xbmc/filesystem/bluray/StreamParser.h
+++ b/xbmc/filesystem/bluray/StreamParser.h
@@ -21,9 +21,13 @@ class CStreamParser
 public:
   /*!
    \brief Convert the parsed .mpls of a playlist into the form the directory handlers use.
-   \param streamDetails when INCLUDE, the stream information comes from the clip's .clpi refined by
-          the M2TS analysis in s. When DEFER, neither has been read, so it comes from the play
-          item's stream number table - enough to tell playlists apart and to list their languages.
+
+   The streams are from the play item's stream number table, ie. what the playlist exposes,
+   in stream number order.
+   \param streamDetails when INCLUDE, each stream is refined by the M2TS analysis, adding the
+          details only the m2ts carries (channel counts, resolutions). When DEFER, neither the
+          .clpi nor the m2ts has been read, so the .mpls is what the streams are described from -
+          enough to tell playlists apart and to list their languages.
    */
   static void ConvertBlurayPlaylistInformation(const BlurayPlaylistInformation& b,
                                                PlaylistInformation& p,

--- a/xbmc/filesystem/test/CMakeLists.txt
+++ b/xbmc/filesystem/test/CMakeLists.txt
@@ -7,7 +7,8 @@ set(SOURCES TestDirectory.cpp
             TestZipManager.cpp)
 
 if(TARGET ${APP_NAME_LC}::Bluray)
-  list(APPEND SOURCES TestBlurayDirectory.cpp)
+  list(APPEND SOURCES TestBlurayDirectory.cpp
+                      TestStreamParser.cpp)
 endif()
 
 if(TARGET ${APP_NAME_LC}::MicroHttpd)

--- a/xbmc/filesystem/test/TestBlurayDirectory.cpp
+++ b/xbmc/filesystem/test/TestBlurayDirectory.cpp
@@ -24,6 +24,13 @@ protected:
   {
     return CBlurayDirectory::FilterPlaylists(playlists);
   }
+
+  static void ProcessPlaylist(PlaylistMap& playlists,
+                              PlaylistInformation& titleInfo,
+                              ClipMap& clips)
+  {
+    CBlurayDirectory::ProcessPlaylist(playlists, titleInfo, clips);
+  }
 };
 
 namespace
@@ -217,4 +224,42 @@ TEST_F(TestBlurayDirectory, FilterPlaylists_RemovesAllCopiesOfADuplicate)
 
   EXPECT_TRUE(FilterPlaylists(playlists));
   EXPECT_EQ(PlaylistNumbers(playlists), (std::vector<unsigned int>{800u, 803u}));
+}
+
+// What a playlist offers has to survive being recorded, or the movie and episode searches decide
+// on a playlist described differently to the one the disc holds
+TEST_F(TestBlurayDirectory, ProcessPlaylist_CarriesThePlaylistThrough)
+{
+  PlaylistInformation titleInfo{MakePlaylist(801u, 2h, {1u, 2u}, {1min, 2min})};
+  titleInfo.clipDuration = {{1u, 1h}, {2u, 1h}};
+  titleInfo.hasSecondaryVideo = true;
+
+  AudioStreamInfo audio;
+  audio.language = "eng";
+  titleInfo.audioStreams.emplace_back(audio);
+
+  SubtitleStreamInfo subtitle;
+  subtitle.language = "fra";
+  titleInfo.pgStreams.emplace_back(subtitle);
+
+  PlaylistMap playlists;
+  ClipMap clips;
+  ProcessPlaylist(playlists, titleInfo, clips);
+
+  ASSERT_TRUE(playlists.contains(801u));
+  const PlaylistInformation& recorded{playlists[801u]};
+  EXPECT_EQ(recorded.playlist, 801u);
+  EXPECT_EQ(recorded.duration, 2h);
+  EXPECT_EQ(recorded.clips, (std::vector<unsigned int>{1u, 2u}));
+  EXPECT_EQ(recorded.chapters.size(), titleInfo.chapters.size());
+  EXPECT_EQ(recorded.audioStreams.size(), 1U);
+  EXPECT_EQ(recorded.pgStreams.size(), 1U);
+  EXPECT_EQ(recorded.languages, "eng");
+  EXPECT_TRUE(recorded.hasSecondaryVideo);
+
+  // The clips are recorded once, in the clip map, along with which playlists reference them
+  EXPECT_TRUE(recorded.clipDuration.empty());
+  ASSERT_TRUE(clips.contains(1u));
+  EXPECT_EQ(clips[1u].duration, 1h);
+  EXPECT_EQ(clips[1u].playlists, (std::vector<unsigned int>{801u}));
 }

--- a/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/test/TestDiscDirectoryHelper.cpp
@@ -4797,6 +4797,69 @@ TEST_F(TestDiscDirectoryHelper, GetMoviePlaylists_Resolution_MultipleVersions)
   EXPECT_TRUE(std::ranges::includes(returned, expected));
 }
 
+// Sherlock Holmes (2009) offers the feature as playlist 100 and, as playlist 101, an in-movie
+// experience carrying a host over the film - which runs longer than the feature and drops the
+// other languages. Both present the movie so both are offered, but the feature has to lead, as
+// the presentation offered first becomes the version the library plays by default.
+TEST_F(TestDiscDirectoryHelper, GetMoviePlaylists_PictureInPicturePresentationNeverLeads)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+
+  auto inMovieExperience{MakePlaylist(101u, 131min + 41s, {101u}, {65min, 66min + 41s}, "eng",
+                                      {MakeAudioStream("truehd", "eng")},
+                                      {MakeSubtitleStream("eng")}, 1080)};
+  inMovieExperience.hasSecondaryVideo = true;
+
+  PlaylistMap playlists{
+      {100u, MakePlaylist(100u, 128min + 24s, {100u}, {64min, 64min + 24s}, "eng",
+                          {MakeAudioStream("truehd", "eng"), MakeAudioStream("ac3", "fra")},
+                          {MakeSubtitleStream("eng"), MakeSubtitleStream("fra")}, 1080)},
+      {101u, std::move(inMovieExperience)},
+  };
+  ClipMap clips{
+      {100u, MakeClip(128min + 24s, {100u})},
+      {101u, MakeClip(131min + 41s, {101u})},
+  };
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(
+      helper.GetMoviePlaylists(url, items, allTitles, -1, GetTitle::MAIN, clips, playlists));
+  ASSERT_EQ(items.Size(), 2);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 100u);
+
+  // The longer run of the in-movie experience must not win it a single choice either
+  EXPECT_TRUE(
+      helper.GetMoviePlaylists(url, items, allTitles, -1, GetTitle::SINGLE, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 100u);
+}
+
+// A disc offering nothing but a picture-in-picture presentation still offers it
+TEST_F(TestDiscDirectoryHelper, GetMoviePlaylists_PictureInPicturePresentationAlone)
+{
+  CDiscDirectoryHelper helper;
+  CURL url("bluray://test/");
+  CFileItemList items;
+  CFileItemList allTitles;
+
+  auto inMovieExperience{MakePlaylist(101u, 131min + 41s, {101u}, {65min, 66min + 41s}, "eng",
+                                      {MakeAudioStream("truehd", "eng")},
+                                      {MakeSubtitleStream("eng")}, 1080)};
+  inMovieExperience.hasSecondaryVideo = true;
+
+  PlaylistMap playlists{{101u, std::move(inMovieExperience)}};
+  ClipMap clips{{101u, MakeClip(131min + 41s, {101u})}};
+  ASSERT_TRUE(Validate(clips, playlists));
+
+  EXPECT_TRUE(
+      helper.GetMoviePlaylists(url, items, allTitles, -1, GetTitle::SINGLE, clips, playlists));
+  ASSERT_EQ(items.Size(), 1);
+  EXPECT_EQ(GetPlaylistFromPath(items[0]->GetPath()), 101u);
+}
+
 // Playlists without video stream information are neither discarded nor used for comparison,
 // and the known main playlist is never discarded for its resolution
 TEST_F(TestDiscDirectoryHelper, GetMoviePlaylists_Resolution_UnknownAndMainPlaylist)

--- a/xbmc/filesystem/test/TestStreamParser.cpp
+++ b/xbmc/filesystem/test/TestStreamParser.cpp
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "filesystem/DiscDirectoryHelper.h"
+#include "filesystem/bluray/PlaylistStructure.h"
+#include "filesystem/bluray/StreamParser.h"
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace XFILE;
+using namespace std::chrono_literals;
+
+namespace
+{
+StreamInformation MakeStream(ENCODING_TYPE coding, unsigned int pid, std::string language)
+{
+  StreamInformation stream;
+  stream.coding = coding;
+  stream.packetIdentifier = pid;
+  stream.language = std::move(language);
+  return stream;
+}
+
+// A single clip carrying every stream of the disc's main feature, as the .clpi describes it.
+ClipInformation MakeClip(unsigned int clip)
+{
+  ClipInformation clipInfo{clip, "M2TS"};
+  clipInfo.streamsRead = true;
+
+  ProgramInformation program;
+  program.streams.emplace_back(MakeStream(ENCODING_TYPE::VIDEO_H264, 0x1011, ""));
+  program.streams.emplace_back(MakeStream(ENCODING_TYPE::AUDIO_DTSHD_MASTER, 0x1100, "eng"));
+  program.streams.emplace_back(MakeStream(ENCODING_TYPE::AUDIO_AC3, 0x1101, "jpn"));
+  program.streams.emplace_back(MakeStream(ENCODING_TYPE::SUB_PG, 0x1200, "eng"));
+  program.streams.emplace_back(MakeStream(ENCODING_TYPE::SUB_PG, 0x1201, "fra"));
+  program.streams.emplace_back(MakeStream(ENCODING_TYPE::SUB_PG, 0x1202, "jpn"));
+  clipInfo.programs.emplace_back(std::move(program));
+
+  return clipInfo;
+}
+
+// A playlist of that clip exposing only the streams given, in stream number order.
+BlurayPlaylistInformation MakePlaylist(unsigned int playlist,
+                                       unsigned int clip,
+                                       const std::vector<StreamInformation>& audioStreams,
+                                       const std::vector<StreamInformation>& subtitleStreams)
+{
+  BlurayPlaylistInformation info;
+  info.playlist = playlist;
+  info.duration = 2h;
+  info.clipStreamsRead = true;
+
+  PlayItemInformation playItem;
+  playItem.outTime = 2h;
+  playItem.angleClips.emplace_back(clip, "M2TS");
+  playItem.videoStreams.emplace_back(MakeStream(ENCODING_TYPE::VIDEO_H264, 0x1011, ""));
+  playItem.audioStreams = audioStreams;
+  playItem.presentationGraphicStreams = subtitleStreams;
+  info.playItems.emplace_back(std::move(playItem));
+
+  info.clips.emplace_back(MakeClip(clip));
+
+  return info;
+}
+
+std::vector<std::string> AudioLanguagesOf(const PlaylistInformation& p)
+{
+  std::vector<std::string> languages;
+  for (const auto& stream : p.audioStreams)
+    languages.emplace_back(stream.language);
+  return languages;
+}
+
+std::vector<std::string> SubtitleLanguagesOf(const PlaylistInformation& p)
+{
+  std::vector<std::string> languages;
+  for (const auto& stream : p.pgStreams)
+    languages.emplace_back(stream.language);
+  return languages;
+}
+} // namespace
+
+TEST(TestStreamParser, StreamsComeFromThePlaylistNotTheSharedClip)
+{
+  // Two playlists of the same feature share a clip but expose different streams - the second is
+  // the Japanese cut, starting on Japanese audio and subtitles. Describing them from the clip's
+  // program list would give both every stream the m2ts carries, making the versions
+  // indistinguishable and reporting the wrong stream as each one's default.
+  const std::vector<StreamInformation> allAudio{
+      MakeStream(ENCODING_TYPE::AUDIO_DTSHD_MASTER, 0x1100, "eng"),
+      MakeStream(ENCODING_TYPE::AUDIO_AC3, 0x1101, "jpn")};
+  const std::vector<StreamInformation> allSubtitles{
+      MakeStream(ENCODING_TYPE::SUB_PG, 0x1200, "eng"),
+      MakeStream(ENCODING_TYPE::SUB_PG, 0x1201, "fra"),
+      MakeStream(ENCODING_TYPE::SUB_PG, 0x1202, "jpn")};
+
+  PlaylistInformation english;
+  CStreamParser::ConvertBlurayPlaylistInformation(MakePlaylist(33, 30, allAudio, allSubtitles),
+                                                  english, {}, StreamDetails::INCLUDE);
+
+  EXPECT_EQ(AudioLanguagesOf(english), (std::vector<std::string>{"eng", "jpn"}));
+  EXPECT_EQ(SubtitleLanguagesOf(english), (std::vector<std::string>{"eng", "fra", "jpn"}));
+
+  const std::vector<StreamInformation> japaneseAudio{
+      MakeStream(ENCODING_TYPE::AUDIO_AC3, 0x1101, "jpn"),
+      MakeStream(ENCODING_TYPE::AUDIO_DTSHD_MASTER, 0x1100, "eng")};
+  const std::vector<StreamInformation> japaneseSubtitles{
+      MakeStream(ENCODING_TYPE::SUB_PG, 0x1202, "jpn"),
+      MakeStream(ENCODING_TYPE::SUB_PG, 0x1200, "eng")};
+
+  PlaylistInformation japanese;
+  CStreamParser::ConvertBlurayPlaylistInformation(
+      MakePlaylist(20, 30, japaneseAudio, japaneseSubtitles), japanese, {}, StreamDetails::INCLUDE);
+
+  EXPECT_EQ(AudioLanguagesOf(japanese), (std::vector<std::string>{"jpn", "eng"}));
+  EXPECT_EQ(SubtitleLanguagesOf(japanese), (std::vector<std::string>{"jpn", "eng"}));
+}
+
+TEST(TestStreamParser, TheFirstStreamOfEachTypeIsFlaggedAsTheDefault)
+{
+  // A player starts with audio stream number 1 and presentation graphic stream number 1, so those
+  // are the streams the disc expects playback to begin with
+  const std::vector<StreamInformation> audio{
+      MakeStream(ENCODING_TYPE::AUDIO_AC3, 0x1101, "jpn"),
+      MakeStream(ENCODING_TYPE::AUDIO_DTSHD_MASTER, 0x1100, "eng")};
+  const std::vector<StreamInformation> subtitles{MakeStream(ENCODING_TYPE::SUB_PG, 0x1202, "jpn"),
+                                                 MakeStream(ENCODING_TYPE::SUB_PG, 0x1200, "eng")};
+
+  PlaylistInformation p;
+  CStreamParser::ConvertBlurayPlaylistInformation(MakePlaylist(20, 30, audio, subtitles), p, {},
+                                                  StreamDetails::INCLUDE);
+
+  ASSERT_EQ(p.audioStreams.size(), 2U);
+  EXPECT_TRUE(p.audioStreams[0].flags & StreamFlags::FLAG_DEFAULT);
+  EXPECT_FALSE(p.audioStreams[1].flags & StreamFlags::FLAG_DEFAULT);
+
+  ASSERT_EQ(p.pgStreams.size(), 2U);
+  EXPECT_TRUE(p.pgStreams[0].flags & StreamFlags::FLAG_DEFAULT);
+  EXPECT_FALSE(p.pgStreams[1].flags & StreamFlags::FLAG_DEFAULT);
+}
+
+TEST(TestStreamParser, PlaylistWithoutAStreamNumberTableFallsBackToTheClip)
+{
+  // A stream number table is expected of a conforming playlist, but if it is missing the clip's
+  // program list is all there is to describe the playlist with
+  BlurayPlaylistInformation b{MakePlaylist(33, 30, {}, {})};
+  b.playItems[0].videoStreams.clear();
+
+  PlaylistInformation p;
+  CStreamParser::ConvertBlurayPlaylistInformation(b, p, {}, StreamDetails::INCLUDE);
+
+  EXPECT_EQ(AudioLanguagesOf(p), (std::vector<std::string>{"eng", "jpn"}));
+  EXPECT_EQ(SubtitleLanguagesOf(p), (std::vector<std::string>{"eng", "fra", "jpn"}));
+
+  // Nothing has been read when stream details are deferred, so there is nothing to fall back to
+  PlaylistInformation deferred;
+  CStreamParser::ConvertBlurayPlaylistInformation(b, deferred, {}, StreamDetails::DEFER);
+  EXPECT_TRUE(deferred.audioStreams.empty());
+  EXPECT_TRUE(deferred.pgStreams.empty());
+}

--- a/xbmc/filesystem/test/TestStreamParser.cpp
+++ b/xbmc/filesystem/test/TestStreamParser.cpp
@@ -147,6 +147,29 @@ TEST(TestStreamParser, TheFirstStreamOfEachTypeIsFlaggedAsTheDefault)
   EXPECT_FALSE(p.pgStreams[1].flags & StreamFlags::FLAG_DEFAULT);
 }
 
+TEST(TestStreamParser, SecondaryVideoMarksAPictureInPicturePresentation)
+{
+  const std::vector<StreamInformation> audio{
+      MakeStream(ENCODING_TYPE::AUDIO_DTSHD_MASTER, 0x1100, "eng")};
+
+  BlurayPlaylistInformation feature{MakePlaylist(100, 30, audio, {})};
+  PlaylistInformation p;
+  CStreamParser::ConvertBlurayPlaylistInformation(feature, p, {}, StreamDetails::INCLUDE);
+  EXPECT_FALSE(p.hasSecondaryVideo);
+
+  // An in-movie experience carries a second video stream to show over the film. Kodi does not play
+  // it, so it is not added as a stream of the playlist - it only marks what the playlist is.
+  BlurayPlaylistInformation inMovieExperience{MakePlaylist(101, 30, audio, {})};
+  inMovieExperience.playItems[0].secondaryVideoStreams.emplace_back(
+      MakeStream(ENCODING_TYPE::VIDEO_VC1, 0x1b00, ""));
+
+  PlaylistInformation pip;
+  CStreamParser::ConvertBlurayPlaylistInformation(inMovieExperience, pip, {},
+                                                  StreamDetails::INCLUDE);
+  EXPECT_TRUE(pip.hasSecondaryVideo);
+  EXPECT_EQ(pip.videoStreams.size(), p.videoStreams.size());
+}
+
 TEST(TestStreamParser, PlaylistWithoutAStreamNumberTableFallsBackToTheClip)
 {
   // A stream number table is expected of a conforming playlist, but if it is missing the clip's


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Properly parse DTS Extension Substreams and TrueHD substreams for streamdetails determination.

Also allows the videoplayer to properly identify all subtitles in a bluray played through Kodi.
Previously the subtitle details were taken from the playlist STN (which may restrict some of the subtitles) whereas videoplayer exposes all the subtitles in the m2ts.

For example - Batman Begins Bluray - has two playlists (exactly the same movie - same m2ts clips etc..)
33 - main presentation - when played through disc all subtitles other than Japanese are selectable
20 - Japanese presentation - only the English/Japanese subtitles are selectable when played through disc

When played through kodi - all are selectable but the 'prohibitied' ones came up as unknown pre this PR.

Playlist playlist 20

Before
<img width="200" alt="image" src="https://github.com/user-attachments/assets/9d4011d8-2e70-408a-9124-7176e74c81f7" />

After
<img width="200" alt="image" src="https://github.com/user-attachments/assets/1fa0109e-9380-4f57-9934-762df8d06cd4" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/3180d878-8175-4fb4-97cb-302890e0d951" />

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Audio stream misidentification in #28776 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
