### PR TITLE
[VideoPlayer] Detect forced subtitles that are only named as forced

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24546,7 +24546,14 @@ msgctxt "#39210"
 msgid "If enabled, Dolby Vision files will have level 5 (active area) metadata overridden to zero offsets. Enable if your display has issues with incorrectly cropped image in Dolby Vision playback."
 msgstr ""
 
-#empty strings from id 39211 to 39899
+#. Option of setting "Preferred subtitle language". Behaves as "Forced only" but also accepts
+#. subtitle tracks that are named as forced without the file setting the forced flag.
+#: xbmc/LangInfo.cpp
+msgctxt "#39211"
+msgid "Forced only (include tracks named forced)"
+msgstr ""
+
+#empty strings from id 39212 to 39899
 
 #. List formatting: pattern used to join a list of exactly two items, e.g. "A and B"
 #. STR_LIST_AND_TWO

--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -214,6 +214,7 @@ constexpr auto specialAudioLangSettings = std::array{
 constexpr auto specialSubtitlesLangSettings = std::array{
     SpecialLanguageSetting{subLanguageNone, 231},
     SpecialLanguageSetting{subLanguageForcedOnly, 13207},
+    SpecialLanguageSetting{subLanguageForcedOnlyLenient, 39233},
     SpecialLanguageSetting{subLanguageOriginal, 308},
     SpecialLanguageSetting{subLanguageDefault, 309},
 };

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -57,6 +57,14 @@ constexpr std::string_view audioLanguageDefault = "default";
 // subtitles language special values
 constexpr std::string_view subLanguageNone = "none";
 constexpr std::string_view subLanguageForcedOnly = "forced_only";
+/*!
+ * \brief As forced_only, but a subtitle track whose name contains "forced" is treated as forced
+ *        even when the file never sets the forced flag, which many releases get wrong.
+ *        Modelled as a value of this setting rather than a separate toggle so the behaviour is
+ *        self contained: it cannot silently affect the other modes, and there is no second
+ *        setting whose interaction has to be understood.
+ */
+constexpr std::string_view subLanguageForcedOnlyLenient = "forced_only_lenient";
 constexpr std::string_view subLanguageOriginal = "original";
 constexpr std::string_view subLanguageDefault = "default";
 } // namespace KODI::LANGINFO

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -14,6 +14,7 @@
 #include "DVDInputStreams/DVDInputStreamBluray.h"
 #endif
 #include "DVDInputStreams/DVDInputStreamFFmpeg.h"
+#include "LangInfo.h"
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
@@ -1898,6 +1899,41 @@ CDemuxStream* CDVDDemuxFFmpeg::AddStream(int streamIdx)
     stream->pPrivate = pStream;
     stream->flags =
         static_cast<StreamFlags>(static_cast<int>(stream->flags) | pStream->disposition);
+
+    // Plenty of releases label a subtitle track "Forced" in its title but never set the forced
+    // disposition, which leaves automatic forced subtitle selection with nothing to match on.
+    // External subtitles already get the same treatment from their filename in
+    // CUtil::GetExternalStreamDetailsFromFilename(), so apply the convention to embedded
+    // tracks too rather than silently missing them.
+    // Only in the lenient forced mode. Applying this in the other modes would be a silent change
+    // of behaviour there: a track treated as forced is never picked as an ordinary full subtitle
+    // track, so blanket subtitle selection by language would quietly lose tracks.
+    const auto settingsComponent = CServiceBroker::GetSettingsComponent();
+    const auto settings = settingsComponent ? settingsComponent->GetSettings() : nullptr;
+    const bool forcedFromTitle =
+        settings &&
+        StringUtils::EqualsNoCase(settings->GetString(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE),
+                                  KODI::LANGINFO::subLanguageForcedOnlyLenient);
+
+    if (forcedFromTitle && pStream->codecpar->codec_type == AVMEDIA_TYPE_SUBTITLE &&
+        (stream->flags & StreamFlags::FLAG_FORCED) == 0)
+    {
+      const AVDictionaryEntry* titleTag = av_dict_get(pStream->metadata, "title", nullptr, 0);
+      if (titleTag && titleTag->value)
+      {
+        std::string title{titleTag->value};
+        StringUtils::ToLower(title);
+        if (title.find("forced") != std::string::npos)
+        {
+          stream->flags =
+              static_cast<StreamFlags>(static_cast<int>(stream->flags) | StreamFlags::FLAG_FORCED);
+          CLog::LogF(LOGDEBUG,
+                     "Treating subtitle stream {} as forced, its title says so but the forced "
+                     "disposition is not set",
+                     pStream->index);
+        }
+      }
+    }
 
     AVDictionaryEntry* langTag = av_dict_get(pStream->metadata, "language", NULL, 0);
     if (!langTag)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -114,7 +114,11 @@ public:
 
     m_isSubNone = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageNone);
     m_isPrefOriginal = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageOriginal);
-    m_isPrefForced = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageForcedOnly);
+    // both forced modes select forced subtitles the same way, they only differ in how a track
+    // gets its forced flag (see CDVDDemuxFFmpeg::AddStream)
+    m_isPrefForced =
+        StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageForcedOnly) ||
+        StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageForcedOnlyLenient);
     m_isPrefHearingImp = settings->GetBool(CSettings::SETTING_ACCESSIBILITY_SUBHEARING);
 
     m_subLang = g_langInfo.GetSubtitleLanguage(false);
@@ -289,7 +293,11 @@ public:
         settings->GetString(CSettings::SETTING_LOCALE_SUBTITLELANGUAGE);
 
     m_isPrefOriginal = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageOriginal);
-    m_isPrefForced = StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageForcedOnly);
+    // both forced modes select forced subtitles the same way, they only differ in how a track
+    // gets its forced flag (see CDVDDemuxFFmpeg::AddStream)
+    m_isPrefForced =
+        StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageForcedOnly) ||
+        StringUtils::EqualsNoCase(subLangSetting, LANGINFO::subLanguageForcedOnlyLenient);
     m_isPrefHearingImp = settings->GetBool(CSettings::SETTING_ACCESSIBILITY_SUBHEARING);
 
     m_subLang = g_langInfo.GetSubtitleLanguage(false);


### PR DESCRIPTION
Forced subtitle selection matches on `StreamFlags::FLAG_FORCED`, which comes straight from the demuxer disposition:

```cpp
stream->flags = static_cast<StreamFlags>(static_cast<int>(stream->flags) | pStream->disposition);
```

A forced track is therefore only detectable when the file actually sets the forced disposition. Many releases only put "Forced" in the track *title* and never set the flag, so `PredicateSubtitleFilter` has nothing to match on and those tracks are never selected automatically.

Kodi already applies exactly this name convention to **external** subtitles in `CUtil::GetExternalStreamDetailsFromFilename()`; embedded tracks were simply missing the same treatment.

### Approach

Rather than adding a separate toggle, this adds a new value to the existing subtitle language setting: **"Forced only (include tracks named forced)"**.

That choice is deliberate. Name based detection applies **only** in the new mode, so it cannot alter the other modes. This matters because a track treated as forced is never selected as an ordinary full subtitle track — with a global toggle, selecting subtitles by language would quietly lose tracks that happen to be named "forced". Keeping it as a mode also avoids a two setting interaction that a user would have to understand.

Language matching is unchanged and still gates selection, so a track named "forced" in a different language is not selected.

### Testing

Verified on Android (Nvidia Shield) with files whose subtitle tracks are titled "Forced" but carry no forced disposition — these are now selected automatically in the new mode, and behaviour in every other mode is unchanged.
