### PR TITLE
[Android] Save resume position when app is paused

### DIFF
--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -13,6 +13,7 @@
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "application/Application.h"
 #include "application/ApplicationComponents.h"
 #include "application/ApplicationPlayer.h"
 #include "application/ApplicationStackHelper.h"
@@ -419,6 +420,21 @@ void CApplicationPlayerCallback::OnPlayBackPaused()
 
   CGUIMessage msg(GUI_MSG_PLAYBACK_PAUSED, 0, 0);
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
+
+#if defined(TARGET_ANDROID)
+  // Android calls the ON_PAUSE when app goes out of focus, but calls nothing else when the app is closed. 
+  // So we need to save the resume playback position here.
+  const auto appPlayer{CServiceBroker::GetAppComponents().GetComponent<CApplicationPlayer>()};
+  if (appPlayer->IsPlayingVideo())
+  {
+    CBookmark bookmark;
+    bookmark.timeInSeconds = static_cast<double>(appPlayer->GetTime()) / 1000.0;
+    bookmark.totalTimeInSeconds = static_cast<double>(appPlayer->GetTotalTime()) / 1000.0;
+    bookmark.player = appPlayer->GetCurrentPlayer();
+    bookmark.playerState = appPlayer->GetPlayerState();
+    CSaveFileState::DoWork(g_application.CurrentFileItem(), bookmark, false);
+  }
+#endif // TARGET_ANDROID
 }
 
 void CApplicationPlayerCallback::OnPlayBackResumed()


### PR DESCRIPTION
## Description
Change player to save the resume position when the onPause event occurs on Android.

## Motivation and context
On Android, if you leave Kodi paused for a while, the system may kill the application. The resume point is then lost.
Steps to reproduce:
- play an unwatched movie (or one without resume position)
- skip forward to 50%
- press HOME button twice and close Kodi app
- relaunch Kodi and verify that the movie has no resume position set

## How has this been tested?
I tested on both the Android Emulator and on a Shield TV.
Steps to reproduce:
- play an unwatched movie (or one without resume position)
- skip forward to 50%
- press HOME button (app should pause)
- press the HOME button twice (app overview) then close the Kodi app
- relaunch Kodi and verify that the movie has a resume position set

## What is the effect on users?
Positive effect: will improve the user's experience by remembering the resume point, even if the application is somehow killed.

## Screenshots (if appropriate):

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
