### PR TITLE
[Video][Bluray] Always include bluray disc menu on simple menu.

### DIFF
--- a/xbmc/filesystem/BlurayDirectory.cpp
+++ b/xbmc/filesystem/BlurayDirectory.cpp
@@ -65,9 +65,14 @@ void AddOptionsAndSortMethods(const CURL& url,
                               bool blurayMenuSupport)
 {
   // Add all titles and menu options
+  std::string file{url.GetFileName()};
+  URIUtils::RemoveSlashAtEnd(file);
   CDiscDirectoryHelper::AddRootOptions(url, items, allTitlesType,
-                                       blurayMenuSupport ? AddMenuOption::ADD_MENU
-                                                         : AddMenuOption::NO_MENU);
+                                       (!StringUtils::EndsWith(file, "/all")
+                                            ? AddMenuAndAllTitlesOptions::ADD_ALL_TITLES
+                                            : AddMenuAndAllTitlesOptions::NONE) |
+                                           (blurayMenuSupport ? AddMenuAndAllTitlesOptions::ADD_MENU
+                                                              : AddMenuAndAllTitlesOptions::NONE));
 
   items.AddSortMethod(SortBy::TRACK_NUMBER, 554,
                       LABEL_MASKS("%L", "%D", "%L", "")); // FileName, Duration | Foldername, empty
@@ -744,14 +749,14 @@ bool CBlurayDirectory::GetDirectory(const CURL& url, CFileItemList& items)
       else
         CLog::LogF(LOGDEBUG, "Invalid path {} for bluray playlist parsing", file);
 
-      const bool success{!items.IsEmpty()};
+      if (items.IsEmpty())
+        return false;
 
       // Add all titles and menu option (if menus supported on disc)
-      if (!StringUtils::EndsWith(file, "/all"))
-        AddOptionsAndSortMethods(m_url, items, CDiscDirectoryHelper::AllTitles::MOVIES,
-                                 HasMenuSupport());
+      AddOptionsAndSortMethods(m_url, items, CDiscDirectoryHelper::AllTitles::MOVIES,
+                               HasMenuSupport());
 
-      return success;
+      return true;
     }
 
     if (StringUtils::StartsWith(file, "root/main"))

--- a/xbmc/filesystem/DiscDirectoryHelper.cpp
+++ b/xbmc/filesystem/DiscDirectoryHelper.cpp
@@ -2813,24 +2813,28 @@ bool CDiscDirectoryHelper::GetMoviePlaylists(const CURL& url,
 void CDiscDirectoryHelper::AddRootOptions(const CURL& url,
                                           CFileItemList& items,
                                           AllTitles allTitlesType,
-                                          AddMenuOption addMenuOption)
+                                          AddMenuAndAllTitlesOptions addMenuAndAllTitlesOptions)
 {
-  CURL path{url};
-  if (allTitlesType == AllTitles::MOVIES)
-    path.SetFileName(URIUtils::AddFileToFolder("root", "titles", "all"));
-  else if (allTitlesType == AllTitles::EPISODES)
-    path.SetFileName(URIUtils::AddFileToFolder("root", "titles", "episodes", "all"));
-
-  auto item{std::make_shared<CFileItem>(path.Get(), true)};
-  item->SetLabel(
-      CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25002) /* All titles */);
-  item->SetArt("icon", "DefaultVideoPlaylists.png");
-  items.Add(item);
-
-  if (addMenuOption == AddMenuOption::ADD_MENU)
+  if (addMenuAndAllTitlesOptions & AddMenuAndAllTitlesOptions::ADD_ALL_TITLES)
   {
+    CURL path{url};
+    if (allTitlesType == AllTitles::MOVIES)
+      path.SetFileName(URIUtils::AddFileToFolder("root", "titles", "all"));
+    else if (allTitlesType == AllTitles::EPISODES)
+      path.SetFileName(URIUtils::AddFileToFolder("root", "titles", "episodes", "all"));
+
+    auto item{std::make_shared<CFileItem>(path.Get(), true)};
+    item->SetLabel(
+        CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25002) /* All titles */);
+    item->SetArt("icon", "DefaultVideoPlaylists.png");
+    items.Add(item);
+  }
+
+  if (addMenuAndAllTitlesOptions & AddMenuAndAllTitlesOptions::ADD_MENU)
+  {
+    CURL path{url};
     path.SetFileName("menu");
-    item = {std::make_shared<CFileItem>(path.Get(), false)};
+    auto item{std::make_shared<CFileItem>(path.Get(), false)};
     item->SetLabel(
         CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(25003) /* Menu */);
     item->SetArt("icon", "DefaultProgram.png");

--- a/xbmc/filesystem/DiscDirectoryHelper.h
+++ b/xbmc/filesystem/DiscDirectoryHelper.h
@@ -46,11 +46,24 @@ enum class SortTitles : uint8_t
   SORT_TITLES_MOVIE
 };
 
-enum class AddMenuOption : bool
+enum class AddMenuAndAllTitlesOptions : uint8_t
 {
-  NO_MENU,
-  ADD_MENU
+  NONE = 0x00,
+  ADD_MENU = 0x01,
+  ADD_ALL_TITLES = 0x02
 };
+
+constexpr AddMenuAndAllTitlesOptions operator|(AddMenuAndAllTitlesOptions lhs,
+                                               AddMenuAndAllTitlesOptions rhs)
+{
+  return static_cast<AddMenuAndAllTitlesOptions>(static_cast<uint8_t>(lhs) |
+                                                 static_cast<uint8_t>(rhs));
+}
+
+constexpr bool operator&(AddMenuAndAllTitlesOptions lhs, AddMenuAndAllTitlesOptions rhs)
+{
+  return (static_cast<uint8_t>(lhs) & static_cast<uint8_t>(rhs)) != 0;
+}
 
 enum class MenuDecision : uint8_t
 {
@@ -287,12 +300,12 @@ public:
    * \param url bluray:// episode url
    * \param items CFileItemList to populate
    * \param allTitlesType Determines whether to add All Episodes or All Movies option
-   * \param addMenuOption Bluray disc has menu, so add Menu Option
+   * \param addMenuAndAllTitlesOptions whether to add Disc Menu and All Titles options
    */
   static void AddRootOptions(const CURL& url,
                              CFileItemList& items,
                              AllTitles allTitlesType,
-                             AddMenuOption addMenuOption);
+                             AddMenuAndAllTitlesOptions addMenuAndAllTitlesOptions);
 
   /*!
    * \brief Either shows simple menu to select playlist, chooses main feature (movie/episode) playlists or returns if disc menu will be used later.


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Include the disc menu option (if supported) on all simple menu instances.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #28974.

When viewing a disc through Video->Files, if a default playlist cannot be identified then the simple menu will display all titles, which didn't include the disc menu option.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
