### PR TITLE
[PAPlayer] Implement audio stream switching.

### DIFF
--- a/system/keymaps/keyboard.xml
+++ b/system/keymaps/keyboard.xml
@@ -543,6 +543,7 @@
       <m>OSD</m>
       <menu>OSD</menu>
       <i>Info</i>
+      <language>AudioNextLanguage</language>
       <p>ActivateWindow(VisualisationPresetList)</p>
       <v>Addon.Default.OpenSettings(xbmc.player.musicviz)</v>
       <text>Addon.Default.OpenSettings(xbmc.player.musicviz)</text>
@@ -553,6 +554,7 @@
       <right mod="longpress">FastForward</right>
       <up>SkipNext</up>
       <down>SkipPrevious</down>
+      <up mod="longpress">AudioNextLanguage</up>
       <o>PlayerProcessInfo</o>
       <l>LockPreset</l>
       <escape>FullScreen</escape>
@@ -568,6 +570,7 @@
       <menu>Back</menu>
       <i>Info</i>
       <o>PlayerProcessInfo</o>
+      <language>AudioNextLanguage</language>
       <p>ActivateWindow(VisualisationPresetList)</p>
       <v>Addon.Default.OpenSettings(xbmc.player.musicviz)</v>
       <text>Addon.Default.OpenSettings(xbmc.player.musicviz)</text>

--- a/system/keymaps/remote.xml
+++ b/system/keymaps/remote.xml
@@ -260,6 +260,7 @@
       <rootmenu>OSD</rootmenu>
       <start>OSD</start>
       <info>Info</info>
+      <hash>AudioNextLanguage</hash>
       <guide>ActivateWindow(TVGuide)</guide>
       <playlist>ActivateWindow(PVROSDChannels)</playlist>
       <zero>Number0</zero>
@@ -281,6 +282,7 @@
       <rootmenu>Back</rootmenu>
       <title>Info</title>
       <info>PlayerProcessInfo</info>
+      <hash>AudioNextLanguage</hash>
     </remote>
   </MusicOSD>
   <VisualisationPresetList>

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/input/action_ids.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/gui/input/action_ids.h
@@ -192,7 +192,7 @@ enum ADDON_ACTION
   /// @brief <b>`55 `</b>: Decrease avsync delay.  Can b used in videoFullScreen.xml window id=2005
   ADDON_ACTION_AUDIO_DELAY_PLUS = 55,
 
-  /// @brief <b>`56 `</b>: Select next language in movie.  Can b used in videoFullScreen.xml window id=2005
+  /// @brief <b>`56 `</b>: Select the next audio stream. Despite the name, the streams it cycles need not differ in language, and it applies to music playback as well as video.
   ADDON_ACTION_AUDIO_NEXT_LANGUAGE = 56,
 
   /// @brief <b>`57 `</b>: Switch 2 next resolution. Can b used during screen calibration settingsScreenCalibration.xml windowid=11

--- a/xbmc/cores/paplayer/AudioDecoder.cpp
+++ b/xbmc/cores/paplayer/AudioDecoder.cpp
@@ -63,7 +63,7 @@ void CAudioDecoder::Destroy()
   m_canPlay = false;
 }
 
-bool CAudioDecoder::Create(const CFileItem &file, int64_t seekOffset)
+bool CAudioDecoder::Create(const CFileItem& file, int64_t seekOffset, int streamIndex)
 {
   Destroy();
 
@@ -92,17 +92,13 @@ bool CAudioDecoder::Create(const CFileItem &file, int64_t seekOffset)
     Destroy();
     return false;
   }
-  unsigned int blockSize = (m_codec->m_bitsPerSample >> 3) * m_codec->m_format.m_channelLayout.Count();
+  // select the requested stream before buffer sizing (assumes Init() starts on stream 0)
+  m_streamIndex = 0;
+  if (streamIndex > 0 && streamIndex < m_codec->GetStreamCount() && m_codec->SetStream(streamIndex))
+    m_streamIndex = streamIndex;
 
-  if (blockSize == 0)
-  {
-    CLog::Log(LOGERROR, "CAudioDecoder: Codec provided invalid parameters ({}-bit, {} channels)",
-              m_codec->m_bitsPerSample, GetFormat().m_channelLayout.Count());
+  if (!CreatePcmBuffer())
     return false;
-  }
-
-  /* allocate the pcmBuffer for 2 seconds of audio */
-  m_pcmBuffer.Create(2 * blockSize * m_codec->m_format.m_sampleRate);
 
   if (file.HasMusicInfoTag())
   {
@@ -129,25 +125,51 @@ bool CAudioDecoder::Create(const CFileItem &file, int64_t seekOffset)
       m_codec->m_tag.SetReplayGain(rgInfo);
   }
 
-  if (seekOffset)
+  // Selecting a stream probes it, which consumes packets, so seek back
+  if (seekOffset || streamIndex > 0)
     m_codec->Seek(seekOffset);
 
-  // Pre-compute the startup-buffer threshold once. Format is immutable for the
-  // lifetime of m_codec, so the per-packet recomputation in ReadSamples is
-  // wasted work. 64-bit intermediate prevents wrap for extreme hi-res
-  // multichannel (see ReadSamples for the original sizing rationale).
-  constexpr unsigned int STARTUP_BUFFER_MS = 200;
-  m_startThresholdBytes = (static_cast<uint64_t>(STARTUP_BUFFER_MS) *
-                           static_cast<uint64_t>(m_codec->m_bitsPerSample >> 3) *
-                           static_cast<uint64_t>(m_codec->m_format.m_channelLayout.Count()) *
-                           static_cast<uint64_t>(m_codec->m_format.m_sampleRate)) /
-                          1000;
+  UpdateStartThreshold();
 
   m_status = STATUS_QUEUING;
 
   m_rawBufferSize = 0;
 
   return true;
+}
+
+bool CAudioDecoder::CreatePcmBuffer()
+{
+  // Enough for two seconds of what is being decoded
+  constexpr unsigned int PCM_BUFFER_SECONDS = 2;
+
+  const unsigned int blockSize =
+      (m_codec->m_bitsPerSample >> 3) * m_codec->m_format.m_channelLayout.Count();
+  if (blockSize == 0)
+  {
+    CLog::Log(LOGERROR, "CAudioDecoder: Codec provided invalid parameters ({}-bit, {} channels)",
+              m_codec->m_bitsPerSample, m_codec->m_format.m_channelLayout.Count());
+    return false;
+  }
+
+  // CRingBuffer::Create() allocates without freeing what it is holding
+  m_pcmBuffer.Destroy();
+  m_pcmBuffer.Create(PCM_BUFFER_SECONDS * blockSize * m_codec->m_format.m_sampleRate);
+
+  return true;
+}
+
+void CAudioDecoder::UpdateStartThreshold()
+{
+  // Pre-compute the startup-buffer threshold, so that the per-packet recomputation in ReadSamples
+  // is not wasted work. 64-bit intermediate prevents wrap for extreme hi-res multichannel (see
+  // ReadSamples for the original sizing rationale).
+  constexpr unsigned int STARTUP_BUFFER_MS = 200;
+  m_startThresholdBytes = (static_cast<uint64_t>(STARTUP_BUFFER_MS) *
+                           static_cast<uint64_t>(m_codec->m_bitsPerSample >> 3) *
+                           static_cast<uint64_t>(m_codec->m_format.m_channelLayout.Count()) *
+                           static_cast<uint64_t>(m_codec->m_format.m_sampleRate)) /
+                          1000;
 }
 
 AEAudioFormat CAudioDecoder::GetFormat()
@@ -202,7 +224,15 @@ unsigned int CAudioDecoder::GetDataSize(bool checkPktSize)
       else if (checkPktSize && m_pcmBuffer.getMaxReadSize() < PACKET_SIZE)
         m_status = STATUS_ENDED;
     }
-    return std::min(m_pcmBuffer.getMaxReadSize() / (m_codec->m_bitsPerSample >> 3), (unsigned int)OUTPUT_SAMPLES);
+    const unsigned int bytesPerSample = m_codec->m_bitsPerSample >> 3;
+    if (bytesPerSample == 0)
+    {
+      CLog::Log(LOGERROR, "CAudioDecoder::GetDataSize - Codec reports {} bits per sample",
+                m_codec->m_bitsPerSample);
+      return 0;
+    }
+
+    return std::min(m_pcmBuffer.getMaxReadSize() / bytesPerSample, (unsigned int)OUTPUT_SAMPLES);
   }
   else
   {
@@ -421,4 +451,68 @@ float CAudioDecoder::GetReplayGain(float &peakVal)
 
   peakVal = peak;
   return replaygain;
+}
+
+int CAudioDecoder::GetStreamCount() const
+{
+  std::unique_lock lock(m_critSection);
+  if (m_codec)
+    return m_codec->GetStreamCount();
+  return 0;
+}
+
+int CAudioDecoder::GetStreamIndex() const
+{
+  std::unique_lock lock(m_critSection);
+  return m_streamIndex;
+}
+
+bool CAudioDecoder::IsUsable() const
+{
+  std::unique_lock lock(m_critSection);
+
+  // A codec describing neither a rate nor a sample size has nothing to decode through - which is
+  // what one left behind by a failed stream switch reports.
+  return m_codec && m_codec->m_format.m_sampleRate != 0 && m_codec->m_bitsPerSample != 0;
+}
+
+bool CAudioDecoder::SetStream(int index)
+{
+  std::unique_lock lock(m_critSection);
+  if (!m_codec)
+    return false;
+
+  const int64_t totalTime = m_codec->m_TotalTime;
+
+  if (!m_codec->SetStream(index))
+  {
+    m_codec->m_TotalTime = totalTime;
+    return false;
+  }
+
+  m_codec->m_TotalTime = totalTime;
+
+  m_streamIndex = index;
+
+  // Reset for new stream
+  m_eof = false;
+  if (m_status == STATUS_ENDING || m_status == STATUS_ENDED)
+    m_status = STATUS_PLAYING;
+
+  m_rawBufferSize = 0;
+  if (!CreatePcmBuffer())
+    return false;
+
+  UpdateStartThreshold();
+
+  return true;
+}
+
+void CAudioDecoder::GetStreamInfo(int index, AudioStreamInfo& info) const
+{
+  std::unique_lock lock(m_critSection);
+  if (m_codec)
+    m_codec->GetStreamInfo(index, info);
+  else
+    info.valid = false;
 }

--- a/xbmc/cores/paplayer/AudioDecoder.h
+++ b/xbmc/cores/paplayer/AudioDecoder.h
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 
+struct AudioStreamInfo;
 struct AEAudioFormat;
 class CFileItem;
 class ICodec;
@@ -45,7 +46,7 @@ public:
   CAudioDecoder();
   ~CAudioDecoder();
 
-  bool Create(const CFileItem &file, int64_t seekOffset);
+  bool Create(const CFileItem& file, int64_t seekOffset, int streamIndex);
   void Destroy();
 
   int ReadSamples(int numsamples);
@@ -67,6 +68,12 @@ public:
   ICodec *GetCodec() const { return m_codec; }
   float GetReplayGain(float &peakVal);
 
+  int GetStreamCount() const;
+  int GetStreamIndex() const;
+  bool IsUsable() const;
+  bool SetStream(int index);
+  void GetStreamInfo(int index, AudioStreamInfo& info) const;
+
 private:
   // pcm buffer
   CRingBuffer m_pcmBuffer;
@@ -86,13 +93,25 @@ private:
   int m_status;
   bool m_canPlay;
 
-  // Cached startup-buffer threshold in bytes, computed once per codec in
-  // Create() from the immutable format (bits/ch/rate). Avoids recomputing a
-  // 64-bit multiply/divide in the ReadSamples hot loop while STATUS_QUEUING.
+  /*! \brief Work out the startup-buffer threshold for the format now being decoded */
+  void UpdateStartThreshold();
+
+  /*! \brief Size the pcm buffer for the format now being decoded
+   *
+   * \return false if the codec describes an invalid format, true if buffer created
+   */
+  bool CreatePcmBuffer();
+
+  // Cached startup-buffer threshold in bytes, computed from the format of the stream being
+  // decoded. Avoids recomputing a 64-bit multiply/divide in the ReadSamples hot loop while
+  // STATUS_QUEUING.
   uint64_t m_startThresholdBytes;
 
   // the codec we're using
   ICodec* m_codec;
 
-  CCriticalSection m_critSection;
+  // current stream
+  int m_streamIndex = 0;
+
+  mutable CCriticalSection m_critSection;
 };

--- a/xbmc/cores/paplayer/ICodec.h
+++ b/xbmc/cores/paplayer/ICodec.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "cores/AudioEngine/Utils/AEAudioFormat.h"
+#include "cores/VideoPlayer/Interface/StreamInfo.h"
 #include "filesystem/File.h"
 #include "music/tags/MusicInfoTag.h"
 
@@ -69,6 +70,22 @@ public:
 
   virtual bool IsCaching()    const    {return false;}
   virtual int GetCacheLevel() const    {return -1;}
+
+  // Audio stream support (e.g. for .mka files with multiple audio streams)
+  virtual int GetStreamCount() const { return 1; }
+
+  /*!
+   * \brief Select the audio stream to decode
+   *
+   * Selecting a stream may consume input while the codec works out what it is decoding, so
+   * the caller has to position it afterwards. A selection that fails can leave the codec
+   * with nothing it can decode.
+   */
+  virtual bool SetStream([[maybe_unused]] int index) { return false; }
+  virtual void GetStreamInfo([[maybe_unused]] int index, AudioStreamInfo& info) const
+  {
+    info.valid = false;
+  }
 
   int64_t m_TotalTime;  // time in ms
   int m_bitRate;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -1083,6 +1083,23 @@ int PAPlayer::GetCacheLevel() const
 
 void PAPlayer::GetAudioStreamInfo(int index, AudioStreamInfo& info) const
 {
+  std::unique_lock lock(m_streamsLock);
+
+  const StreamInfo* si = PlayingStream();
+  if (!si)
+    return;
+
+  if (index == CURRENT_STREAM)
+    index = si->m_audioStream;
+
+  // Language, name and codec description are only known to the demuxer, so get from decoder
+  si->m_decoder.GetStreamInfo(index, info);
+
+  if (index != si->m_audioStream)
+    return;
+
+  // For the stream being decoded prefer the values the codec reports
+  info.valid = true;
   info.bitrate = m_playerGUIData.m_audioBitrate;
   info.channels = m_playerGUIData.m_channelCount;
   info.codecName = m_playerGUIData.m_codec;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -1244,6 +1244,12 @@ PAPlayer::StreamInfo* PAPlayer::PlayingStream() const
   return m_streams.empty() ? nullptr : m_streams.front();
 }
 
+void PAPlayer::GetAudioCapabilities(std::vector<IPlayerAudioCaps>& caps) const
+{
+  if (GetAudioStreamCount() > 1)
+    caps.emplace_back(IPlayerAudioCaps::SELECT_STREAM);
+}
+
 int PAPlayer::GetAudioStreamCount() const
 {
   std::unique_lock lock(m_streamsLock);

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -30,6 +30,7 @@
 #include "utils/log.h"
 #include "video/Bookmark.h"
 
+#include <algorithm>
 #include <memory>
 #include <mutex>
 
@@ -205,6 +206,8 @@ bool PAPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
   m_defaultCrossfadeMS = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(CSettings::SETTING_MUSICPLAYER_CROSSFADE) * 1000;
   m_fullScreen = options.fullscreen;
 
+  m_requestedAudioStream = -1;
+
   if (m_streams.size() > 1 || !m_defaultCrossfadeMS || m_isPaused)
   {
     CloseAllStreams(!m_isPaused);
@@ -328,7 +331,7 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
     starttime = 0; // No resume point
   }
 
-  if (!si->m_decoder.Create(file, si->m_startOffset, 0))
+  if (!si->m_decoder.Create(file, si->m_startOffset, m_preferredAudioStream))
   {
     CLog::Log(LOGWARNING, "PAPlayer::QueueNextFileEx - Failed to create the decoder");
 
@@ -367,6 +370,7 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
   UpdateCrossfadeTime(*si->m_fileItem);
 
   /* init the streaminfo struct */
+  si->m_audioStream = si->m_decoder.GetStreamIndex();
   si->m_audioFormat = si->m_decoder.GetFormat();
   // si->m_startOffset already initialized
   si->m_endOffset = file.GetEndOffset();
@@ -381,6 +385,7 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
   si->m_volume = (fadeIn && m_upcomingCrossfadeMS) ? 0.0f : 1.0f;
   si->m_fadeOutTriggered = false;
   si->m_isSlaved = false;
+  si->m_slavedTo = nullptr;
 
   si->m_decoderTotal = si->m_decoder.TotalTime();
   int64_t streamTotalTime = si->m_decoderTotal;
@@ -414,6 +419,10 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
 
   if (m_currentStream && ((m_currentStream->m_audioFormat.m_dataFormat == AE_FMT_RAW) || (si->m_audioFormat.m_dataFormat == AE_FMT_RAW)))
   {
+    CLog::Log(LOGDEBUG,
+              "PAPlayer::QueueNextFileEx - Waiting for the {} raw stream to drain before the next "
+              "track starts",
+              m_currentStream->m_audioFormat.m_dataFormat == AE_FMT_RAW ? "current" : "next");
     m_currentStream->m_prepareTriggered = false;
     m_currentStream->m_waitOnDrain = true;
     m_currentStream->m_prepareNextAtFrame = 0;
@@ -499,7 +508,10 @@ inline bool PAPlayer::PrepareStream(StreamInfo *si)
   if (m_currentStream && m_currentStream != si && !m_upcomingCrossfadeMS)
   {
     /* slave the stream for gapless */
+    CLog::Log(LOGDEBUG,
+              "PAPlayer::PrepareStream - Slaved to the stream playing now, for a gapless start");
     si->m_isSlaved = true;
+    si->m_slavedTo = m_currentStream;
     m_currentStream->m_stream->RegisterSlave(si->m_stream.get());
   }
 
@@ -619,7 +631,18 @@ inline void PAPlayer::ProcessStreams(double &freeBufferTime)
     {
       itt = m_finishing.erase(itt);
       CloseFileCB(*si);
+
+      for (StreamInfo* remaining : m_streams)
+      {
+        if (remaining->m_slavedTo == si)
+        {
+          remaining->m_isSlaved = false;
+          remaining->m_slavedTo = nullptr;
+        }
+      }
+
       delete si;
+
       CLog::Log(LOGDEBUG, "PAPlayer::ProcessStreams - Stream Freed");
     }
     else
@@ -629,6 +652,9 @@ inline void PAPlayer::ProcessStreams(double &freeBufferTime)
   sharedLock.unlock();
   std::unique_lock lock(m_streamsLock);
 
+  /* apply any pending audio stream change before we touch the streams again */
+  ProcessAudioStreamChange(lock);
+
   for(StreamList::iterator itt = m_streams.begin(); itt != m_streams.end(); ++itt)
   {
     StreamInfo* si = *itt;
@@ -636,6 +662,10 @@ inline void PAPlayer::ProcessStreams(double &freeBufferTime)
     {
       m_currentStream = si;
       UpdateGUIData(si); //update for GUI
+
+      // The track was queued before the listener's choice was made, so ask for it now
+      if (si->m_audioStream != m_preferredAudioStream)
+        QueueAudioStreamRequest(m_preferredAudioStream);
     }
     /* if the stream is finishing */
     if ((si->m_playNextTriggered && si->m_stream && !si->m_stream->IsFading()) || !ProcessStream(si, freeBufferTime))
@@ -676,6 +706,9 @@ inline void PAPlayer::ProcessStreams(double &freeBufferTime)
         {
           m_currentStream = *itt;
           UpdateGUIData(*itt); //update for GUI
+
+          if ((*itt)->m_audioStream != m_preferredAudioStream)
+            QueueAudioStreamRequest(m_preferredAudioStream);
         }
       }
 
@@ -1169,7 +1202,9 @@ void PAPlayer::CloseFileCB(StreamInfo &si)
   bookmark.totalTimeInSeconds = total / 1000;
   bookmark.timeInSeconds = (static_cast<double>(si.m_framesSent) /
                             static_cast<double>(si.m_audioFormat.m_sampleRate));
-  bookmark.timeInSeconds -= si.m_stream->GetDelay();
+
+  if (si.m_stream)
+    bookmark.timeInSeconds -= si.m_stream->GetDelay();
   bookmark.player = m_name;
   bookmark.playerState = GetPlayerState();
   CServiceBroker::GetJobManager()->Submit([=]() { cb->OnPlayerCloseFile(fileItem, bookmark); },
@@ -1182,4 +1217,396 @@ void PAPlayer::AdvancePlaylistOnError(CFileItem &fileItem)
     m_callback.OnPlayBackStarted(fileItem);
   m_signalStarted = true;
   m_callback.OnAVStarted(fileItem);
+}
+
+PAPlayer::StreamInfo* PAPlayer::PlayingStream() const
+{
+  if (m_currentStream)
+    return m_currentStream;
+
+  return m_streams.empty() ? nullptr : m_streams.front();
+}
+
+int PAPlayer::GetAudioStreamCount() const
+{
+  std::unique_lock lock(m_streamsLock);
+  const StreamInfo* si = PlayingStream();
+  return si ? si->m_decoder.GetStreamCount() : 0;
+}
+
+int PAPlayer::GetAudioStream()
+{
+  std::unique_lock lock(m_streamsLock);
+  const StreamInfo* si = PlayingStream();
+  return si ? si->m_audioStream : -1;
+}
+
+inline PAPlayer::RecreateResult PAPlayer::RecreateStream(StreamInfo* si,
+                                                         std::unique_lock<CCriticalSection>& lock)
+{
+  if (!si)
+    return RecreateResult::FAILED;
+
+  const bool wasStarted = si->m_started;
+
+  StreamInfo* slave = nullptr;
+  for (auto itt = m_streams.begin(); itt != m_streams.end(); ++itt)
+  {
+    if (*itt == si)
+    {
+      if (++itt != m_streams.end() && (*itt)->m_isSlaved && (*itt)->m_stream)
+        slave = *itt;
+      break;
+    }
+  }
+
+  // The old stream has to be gone before the replacement is made
+  if (si->m_stream)
+  {
+    si->m_stream->UnRegisterAudioCallback();
+    si->m_stream.reset();
+  }
+
+  AEAudioFormat format = si->m_audioFormat;
+  si->m_stream = CServiceBroker::GetActiveAE()->MakeStream(format, AESTREAM_PAUSED);
+  if (!si->m_stream)
+  {
+    CLog::Log(LOGDEBUG, "PAPlayer::RecreateStream - Failed to get IAEStream");
+    return RecreateResult::FAILED;
+  }
+
+  // A stream that is already playing has finished fading in
+  si->m_stream->SetVolume(wasStarted ? 1.0f : si->m_volume);
+
+  float peak = 1.0f;
+  float gain = si->m_decoder.GetReplayGain(peak);
+  if (peak * gain <= 1.0f)
+    si->m_stream->SetReplayGain(gain);
+  else if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+               CSettings::SETTING_MUSICPLAYER_REPLAYGAINAVOIDCLIPPING))
+    si->m_stream->SetReplayGain(1.0f / fabs(peak));
+  else
+    si->m_stream->SetAmplification(gain);
+
+  if (slave)
+    si->m_stream->RegisterSlave(slave->m_stream.get());
+
+  // Unlike PrepareStream() this runs on the player thread, so it must not outlive a stop
+  while (si->m_stream->IsBuffering() && !m_bStop)
+  {
+    int status = si->m_decoder.GetStatus();
+    if (status == STATUS_ENDED || status == STATUS_NO_FILE ||
+        si->m_decoder.ReadSamples(PACKET_SIZE) == RET_ERROR)
+    {
+      CLog::Log(LOGINFO, "PAPlayer::RecreateStream - Stream Finished");
+      break;
+    }
+
+    if (!QueueData(si))
+    {
+      // The replacement is in place but was never started, so hand it back to ProcessStream()
+      // to take from the top rather than leaving it paused and unregistered.
+      si->m_started = false;
+      return RecreateResult::FAILED;
+    }
+
+    lock.unlock();
+    CThread::Sleep(1ms);
+    lock.lock();
+
+    // CloseFile() empties the stream list from another thread before stopping this one, so si is
+    // only ours while the lock is held.
+    if (std::ranges::find(m_streams, si) == m_streams.end())
+      return RecreateResult::ABANDONED;
+  }
+
+  if (wasStarted)
+  {
+    si->m_stream->RegisterAudioCallback(m_audioCallback);
+
+    // The master that would have resumed si is gone along with the old IAEStream, so si now
+    // has to drive itself.
+    si->m_isSlaved = false;
+    si->m_slavedTo = nullptr;
+
+    // Paused playback stays paused
+    if (!m_isPaused)
+      si->m_stream->Resume();
+  }
+
+  CLog::Log(LOGINFO, "PAPlayer::RecreateStream - Ready");
+  return RecreateResult::OK;
+}
+
+void PAPlayer::SetAudioStream(int iStream)
+{
+  {
+    std::unique_lock lock(m_streamsLock);
+    const StreamInfo* si = PlayingStream();
+    if (!si || iStream < 0 || iStream >= si->m_decoder.GetStreamCount())
+    {
+      CLog::Log(LOGERROR, "PAPlayer::SetAudioStream - Invalid audio stream {}", iStream);
+      return;
+    }
+
+    if (iStream == si->m_audioStream)
+      return;
+  }
+
+  // The switch tears down and rebuilds the StreamInfo's decoder and IAEStream in ProcessStreams()
+  m_requestedAudioStream = iStream;
+}
+
+void PAPlayer::DropStream(StreamInfo* si)
+{
+  // Nothing can be done with a StreamInfo that has no IAEStream
+  m_streams.remove(si);
+  if (m_currentStream == si)
+    m_currentStream = nullptr;
+
+  if (!si->m_prepareTriggered)
+  {
+    si->m_prepareTriggered = true;
+    m_callback.OnQueueNextItem();
+  }
+
+  // Record where it had reached
+  CloseFileCB(*si);
+
+  // Nothing can wait on a stream that is dropped
+  for (StreamInfo* remaining : m_streams)
+  {
+    if (remaining->m_slavedTo == si)
+    {
+      remaining->m_isSlaved = false;
+      remaining->m_slavedTo = nullptr;
+    }
+  }
+
+  si->m_decoder.Destroy();
+  delete si;
+}
+
+void PAPlayer::QueueAudioStreamRequest(int iStream)
+{
+  // Not if a newer request has been made since this one was taken
+  int expected = -1;
+  m_requestedAudioStream.compare_exchange_strong(expected, iStream);
+}
+
+void PAPlayer::DiscardQueuedStreams(StreamInfo* si)
+{
+  bool discarded = false;
+  for (auto itt = m_streams.begin(); itt != m_streams.end();)
+  {
+    StreamInfo* queued = *itt;
+    if (queued == si || queued == m_currentStream || queued->m_started)
+    {
+      ++itt;
+      continue;
+    }
+
+    if (si->m_stream && queued->m_slavedTo == si)
+      si->m_stream->RegisterSlave(nullptr);
+
+    itt = m_streams.erase(itt);
+    queued->m_decoder.Destroy();
+    delete queued;
+    discarded = true;
+  }
+
+  if (!discarded)
+    return;
+
+  // Leave si as QueueNextFileEx() leaves a track it has refused a gapless start to, so that what
+  // was discarded here is asked for again once si has drained
+  si->m_prepareTriggered = false;
+  si->m_waitOnDrain = true;
+  si->m_prepareNextAtFrame = 0;
+}
+
+void PAPlayer::ProcessAudioStreamChange(std::unique_lock<CCriticalSection>& lock)
+{
+  const int iStream = m_requestedAudioStream.exchange(-1);
+  if (iStream < 0)
+  {
+    m_audioStreamDeferred = false;
+    return;
+  }
+
+  // Leave the request pending rather than dropping it if there is nothing to apply it to yet
+  StreamInfo* si = m_currentStream;
+  if (!si)
+  {
+    QueueAudioStreamRequest(iStream);
+    return;
+  }
+
+  if (iStream == si->m_audioStream)
+  {
+    m_audioStreamDeferred = false;
+    return;
+  }
+
+  if (iStream >= si->m_decoder.GetStreamCount())
+  {
+    // A request carried over from a track with more streams than this one has
+    CLog::Log(LOGDEBUG,
+              "PAPlayer::ProcessAudioStreamChange - Dropping request for audio stream "
+              "{}, this track has {}",
+              iStream, si->m_decoder.GetStreamCount());
+    m_audioStreamDeferred = false;
+    return;
+  }
+
+  // The end of the track is in the same situation
+  const int status = si->m_decoder.GetStatus();
+  if (status == STATUS_ENDING || status == STATUS_ENDED || status == STATUS_NO_FILE)
+  {
+    if (!m_audioStreamDeferred)
+    {
+      CLog::Log(LOGINFO,
+                "PAPlayer::ProcessAudioStreamChange - Deferring switch to audio stream {}, track "
+                "has run out",
+                iStream);
+      m_audioStreamDeferred = true;
+    }
+    QueueAudioStreamRequest(iStream);
+    return;
+  }
+
+  // Don't swap during fade
+  if (si->m_playNextTriggered || si->m_fadeOutTriggered || si->m_isSlaved ||
+      (si->m_stream && si->m_stream->IsFading()))
+  {
+    // Leave the request pending instead - for the new track
+    if (!m_audioStreamDeferred)
+    {
+      CLog::Log(LOGINFO,
+                "PAPlayer::ProcessAudioStreamChange - Deferring switch to audio stream {}, waiting "
+                "for the handover to finish",
+                iStream);
+      m_audioStreamDeferred = true;
+    }
+    QueueAudioStreamRequest(iStream);
+    return;
+  }
+
+  m_audioStreamDeferred = false;
+
+  // Capture what the listener is currently hearing, before changing stream format/state, and
+  // where the decoder had reached, which is ahead of it by whatever the sink still holds
+  int64_t currentTime = si->m_startOffset;
+  int64_t decodedTime = si->m_startOffset;
+  if (si->m_audioFormat.m_sampleRate > 0)
+  {
+    const double sent =
+        static_cast<double>(si->m_framesSent) / static_cast<double>(si->m_audioFormat.m_sampleRate);
+    decodedTime += static_cast<int64_t>(sent * 1000.0);
+
+    double time = sent;
+    if (si->m_stream)
+      time -= si->m_stream->GetDelay();
+
+    currentTime += static_cast<int64_t>(time * 1000.0);
+    currentTime = std::max(currentTime, si->m_startOffset);
+  }
+
+  if (!si->m_decoder.SetStream(iStream))
+  {
+    // A failed switch either left the stream that was playing restored, in which case the track
+    // carries on as it was, or left the codec with nothing it can decode
+    if (si->m_decoder.IsUsable())
+    {
+      // Probing moves position so seek back. The IAEStream and the audio queued in it are
+      // still there, so resume where the decoder had reached rather than where the listener
+      // is, which would queue that audio a second time.
+      si->m_decoder.Seek(decodedTime);
+
+      CLog::Log(LOGWARNING,
+                "PAPlayer::ProcessAudioStreamChange - Failed to switch to stream {}, carrying on "
+                "with stream {}",
+                iStream, si->m_audioStream);
+      return;
+    }
+
+    CLog::Log(LOGERROR,
+              "PAPlayer::ProcessAudioStreamChange - Failed to switch to stream {}, ending the "
+              "track as its decoder can no longer be used",
+              iStream);
+    si->m_decoder.Destroy();
+    return;
+  }
+
+  si->m_audioStream = iStream;
+  m_preferredAudioStream = iStream;
+
+  AEAudioFormat newFormat = si->m_decoder.GetFormat();
+  CLog::Log(LOGDEBUG,
+            "PAPlayer::ProcessAudioStreamChange - Stream {} is {} Hz, {} channels, {}, with {} "
+            "stream(s) queued",
+            iStream, newFormat.m_sampleRate, newFormat.m_channelLayout.Count(),
+            newFormat.m_dataFormat == AE_FMT_RAW
+                ? CAEUtil::StreamTypeToStr(newFormat.m_streamInfo.m_type)
+                : CAEUtil::DataFormatToStr(newFormat.m_dataFormat),
+            m_streams.size());
+  si->m_audioFormat = newFormat;
+  si->m_bytesPerSample = CAEUtil::DataFormatToBits(newFormat.m_dataFormat) >> 3;
+  si->m_bytesPerFrame = si->m_bytesPerSample * newFormat.m_channelLayout.Count();
+
+  // Seek using the captured pre-switch playback time.
+  si->m_decoder.Seek(currentTime);
+
+  // Rebase the frame counter onto the new sample rate before priming the new sink. It counts
+  // from the start of the track, not the start of the file.
+  si->m_framesSent = static_cast<int>(
+      ((currentTime - si->m_startOffset) * static_cast<int64_t>(si->m_audioFormat.m_sampleRate)) /
+      1000);
+  si->m_seekFrame = -1;
+  si->m_seekNextAtFrame = 0;
+
+  // Recalculate trigger points for the new sample rate.
+  si->m_decoderTotal = si->m_decoder.TotalTime();
+  int64_t streamTotalTime = si->m_decoderTotal;
+  if (si->m_endOffset)
+    streamTotalTime = si->m_endOffset - si->m_startOffset;
+
+  si->m_prepareNextAtFrame = 0;
+  // QueueNextFileEx() parks a track that it has refused a gapless start to until this one drains.
+  // Re-arming here would ask for that track again on every switch, only to have it refused again.
+  const bool waitingToDrain = si->m_waitOnDrain && si->m_audioFormat.m_dataFormat == AE_FMT_RAW;
+  if (!waitingToDrain && streamTotalTime >= TIME_TO_CACHE_NEXT_FILE + m_defaultCrossfadeMS)
+  {
+    si->m_prepareNextAtFrame =
+        static_cast<int>((streamTotalTime - TIME_TO_CACHE_NEXT_FILE - m_defaultCrossfadeMS) *
+                         si->m_audioFormat.m_sampleRate / 1000.0f);
+  }
+
+  UpdateStreamInfoPlayNextAtFrame(si, m_upcomingCrossfadeMS);
+
+  // AE holds a raw stream on its own or not at all, so a track queued behind this one has to go
+  // back to being queued rather than block the switch
+  if (newFormat.m_dataFormat == AE_FMT_RAW ||
+      std::ranges::any_of(m_streams,
+                          [si](const StreamInfo* other) {
+                            return other != si && other->m_audioFormat.m_dataFormat == AE_FMT_RAW;
+                          }))
+  {
+    DiscardQueuedStreams(si);
+  }
+
+  const RecreateResult recreated = RecreateStream(si, lock);
+  if (recreated == RecreateResult::ABANDONED)
+    return;
+
+  if (recreated == RecreateResult::FAILED || !si->m_stream)
+  {
+    CLog::Log(LOGERROR, "PAPlayer::ProcessAudioStreamChange - Failed to recreate IAEStream");
+    if (!si->m_stream)
+      DropStream(si);
+    return;
+  }
+
+  UpdateGUIData(si);
+  CLog::Log(LOGINFO, "PAPlayer::ProcessAudioStreamChange - Switched to audio stream {}", iStream);
 }

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -328,7 +328,7 @@ bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn)
     starttime = 0; // No resume point
   }
 
-  if (!si->m_decoder.Create(file, si->m_startOffset))
+  if (!si->m_decoder.Create(file, si->m_startOffset, 0))
   {
     CLog::Log(LOGWARNING, "PAPlayer::QueueNextFileEx - Failed to create the decoder");
 

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -49,7 +49,7 @@ public:
   void SetTotalTime(int64_t time) override;
   void SetTime(int64_t time) override;
   void SeekTime(int64_t iTime = 0) override;
-  void GetAudioCapabilities(std::vector<IPlayerAudioCaps>& caps) const override {}
+  void GetAudioCapabilities(std::vector<IPlayerAudioCaps>& caps) const override;
 
   void GetAudioStreamInfo(int index, AudioStreamInfo& info) const override;
   int GetAudioStreamCount() const override;

--- a/xbmc/cores/paplayer/PAPlayer.h
+++ b/xbmc/cores/paplayer/PAPlayer.h
@@ -10,7 +10,6 @@
 
 #include "AudioDecoder.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
-#include "cores/AudioEngine/Interfaces/IAudioCallback.h"
 #include "cores/IPlayer.h"
 #include "jobs/IJobCallback.h"
 #include "threads/CriticalSection.h"
@@ -18,6 +17,7 @@
 
 #include <atomic>
 #include <list>
+#include <mutex>
 #include <vector>
 
 class IAEStream;
@@ -47,13 +47,14 @@ public:
   void SetSpeed(float speed = 0) override;
   int GetCacheLevel() const override;
   void SetTotalTime(int64_t time) override;
-  void GetAudioStreamInfo(int index, AudioStreamInfo& info) const override;
   void SetTime(int64_t time) override;
   void SeekTime(int64_t iTime = 0) override;
   void GetAudioCapabilities(std::vector<IPlayerAudioCaps>& caps) const override {}
 
-  int GetAudioStreamCount() const override { return 1; }
-  int GetAudioStream() override { return 0; }
+  void GetAudioStreamInfo(int index, AudioStreamInfo& info) const override;
+  int GetAudioStreamCount() const override;
+  int GetAudioStream() override;
+  void SetAudioStream(int iStream) override;
 
   // implementation of IJobCallback
   void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
@@ -87,6 +88,7 @@ private:
     int64_t m_startOffset;               /* the stream start offset */
     int64_t m_endOffset;                 /* the stream end offset */
     int64_t m_decoderTotal = 0;
+    int m_audioStream = 0; /* the audio stream being decoded */
     AEAudioFormat m_audioFormat;
     unsigned int m_bytesPerSample;       /* number of bytes per audio sample */
     unsigned int m_bytesPerFrame;        /* number of bytes per audio frame */
@@ -106,6 +108,7 @@ private:
     float m_volume;                      /* the initial volume level to set the stream to on creation */
 
     bool m_isSlaved;                     /* true if the stream has been slaved to another */
+    StreamInfo* m_slavedTo = nullptr; /* the stream that owns it while slaved, and resumes it */
     bool m_waitOnDrain;                  /* wait for stream being drained in AE */
   };
 
@@ -124,7 +127,11 @@ private:
   StreamInfo* m_currentStream = nullptr;
   IAudioCallback*     m_audioCallback;       /* the viz audio callback */
 
-  CCriticalSection    m_streamsLock;         /* lock for the stream list */
+  std::atomic_int m_requestedAudioStream{-1}; /* audio stream to switch to, -1 for none */
+  std::atomic_int m_preferredAudioStream{0}; /* audio stream to open the next track on */
+  bool m_audioStreamDeferred = false; /* if a pending request has been reported as deferred */
+
+  mutable CCriticalSection m_streamsLock; /* lock for the stream list */
   StreamList          m_streams;             /* playing streams */
   StreamList          m_finishing;           /* finishing streams */
   int m_jobCounter = 0;
@@ -150,5 +157,53 @@ private:
   bool SetTotalTimeInternal(int64_t time);
   void CloseFileCB(StreamInfo &si);
   void AdvancePlaylistOnError(CFileItem &fileItem);
+
+  /*!
+   * \brief Replace a StreamInfo's IAEStream with one matching its current audio format.
+   *
+   * Must be called on the player thread with m_streamsLock held. The lock is released while the
+   * replacement is filled, so si may be gone by the time this returns.
+   */
+  enum class RecreateResult
+  {
+    OK,
+    FAILED,
+    ABANDONED, /* the stream was closed while the lock was released */
+  };
+
+  RecreateResult RecreateStream(StreamInfo* si, std::unique_lock<CCriticalSection>& lock);
+
+  /*!
+   * \brief The stream being played, or the one about to take over mid handover.
+   *
+   * Must be called with m_streamsLock held.
+   */
+  StreamInfo* PlayingStream() const;
+
+  /*!
+   * \brief Discard a StreamInfo that has been left without an IAEStream.
+   *
+   * Must be called on the player thread with m_streamsLock held, and not while walking m_streams.
+   */
+  void DropStream(StreamInfo* si);
+
+  /*!
+   * rief Discard the tracks queued behind si, leaving it to ask for them again.
+   *
+   * Must be called on the player thread with m_streamsLock held, and not while walking m_streams.
+   */
+  void DiscardQueuedStreams(StreamInfo* si);
+
+  /*!
+   * \brief Carry out a pending SetAudioStream() request, if any.
+   *
+   * Must be called on the player thread with m_streamsLock held.
+   */
+  void ProcessAudioStreamChange(std::unique_lock<CCriticalSection>& lock);
+
+  /*!
+   * \brief Ask for a stream, unless something has already been asked for.
+   */
+  void QueueAudioStreamRequest(int iStream);
 };
 

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -21,6 +21,8 @@
 #include "utils/StringUtils.h"
 #include "utils/log.h"
 
+#include <algorithm>
+
 extern "C"
 {
 #include <libavcodec/defs.h>
@@ -199,6 +201,12 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
 
 bool VideoPlayerCodec::InitFormatFromStream(CDemuxStreamAudio* stream, bool allowFormatFallback)
 {
+  // A demuxer may rebuild its stream objects as it reads, so take what the probe below needs
+  // rather than holding the pointer across the reads it makes
+  const int64_t demuxerId = stream->demuxerId;
+  const int uniqueId = stream->uniqueId;
+  const int bitsPerCodedSample = stream->iBitsPerSample;
+
   // Reset format information
   m_srcFormat = {};
   m_format = {};
@@ -211,10 +219,20 @@ bool VideoPlayerCodec::InitFormatFromStream(CDemuxStreamAudio* stream, bool allo
   m_pResampler.reset();
   m_needConvert = false;
 
+  // The probe has to consume whatever it reads, so a skip left over from an earlier seek must not
+  // eat those packets. The caller seeks after us, which sets it again.
+  m_skipToPts = DVD_NOPTS_VALUE;
+  m_skipDecodedOutput = false;
+
   // Decode up to 10 packets to let the codec describe its output.
   // The first frame decoded may not reflect true format (eg. a partial DTS frame decodes as the 48kHz
   // core while the frames after it carry the 96kHz extension). Keep reading until two consecutive
   // frames agree.
+  //
+  // On a stream change this reads from demuxer current position rather than from the
+  // point we are about to seek to, so ffmpeg can log container parse errors here before the caller's Seek()
+  // puts it back on a cluster boundary. They are expected and recovered from. Probing after the seek
+  // would silence them, at the cost of a second seek to undo the packets the probe consumes.
   int nErrors = 0;
   bool stable = false;
   AEAudioFormat probed{};
@@ -248,13 +266,13 @@ bool VideoPlayerCodec::InitFormatFromStream(CDemuxStreamAudio* stream, bool allo
   if (!stable)
     CLog::Log(LOGDEBUG,
               "{}: Format of audio stream uniqueId={} did not settle, using {} Hz, {} channels",
-              __FUNCTION__, stream->uniqueId, probed.m_sampleRate, probed.m_channelLayout.Count());
+              __FUNCTION__, uniqueId, probed.m_sampleRate, probed.m_channelLayout.Count());
 
   m_srcFormat = probed;
   m_format = m_srcFormat;
   m_channels = m_srcFormat.m_channelLayout.Count();
   m_bitsPerSample = CAEUtil::DataFormatToBits(m_srcFormat.m_dataFormat);
-  m_bitsPerCodedSample = stream->iBitsPerSample;
+  m_bitsPerCodedSample = bitsPerCodedSample;
 
   if (m_channels == 0 || m_srcFormat.m_sampleRate == 0)
   {
@@ -262,7 +280,7 @@ bool VideoPlayerCodec::InitFormatFromStream(CDemuxStreamAudio* stream, bool allo
     if (!allowFormatFallback)
     {
       CLog::Log(LOGERROR, "{}: Could not determine the format of audio stream uniqueId={}",
-                __FUNCTION__, stream->uniqueId);
+                __FUNCTION__, uniqueId);
       return false;
     }
 
@@ -284,7 +302,7 @@ bool VideoPlayerCodec::InitFormatFromStream(CDemuxStreamAudio* stream, bool allo
   if (!m_bitRate && m_TotalTime)
     m_bitRate = (int)(((m_pInputStream->GetLength() * 1000) / m_TotalTime) * 8);
 
-  m_CodecName = m_pDemuxer->GetStreamCodecName(stream->demuxerId, m_nAudioStream);
+  m_CodecName = m_pDemuxer->GetStreamCodecName(demuxerId, m_nAudioStream);
 
   m_planes = AE_IS_PLANAR(m_srcFormat.m_dataFormat) ? m_channels : 1;
 
@@ -647,4 +665,157 @@ CAEStreamInfo::DataType VideoPlayerCodec::GetPassthroughStreamType(AVCodecID cod
     return format.m_streamInfo.m_type;
   else
     return CAEStreamInfo::DataType::STREAM_TYPE_NULL;
+}
+
+CDemuxStreamAudio* VideoPlayerCodec::GetAudioStream(int uniqueId) const
+{
+  const std::vector<CDemuxStreamAudio*> audioStreams = GetAudioStreams();
+  const auto it = std::ranges::find_if(audioStreams, [uniqueId](const CDemuxStreamAudio* stream)
+                                       { return stream->uniqueId == uniqueId; });
+  return it != audioStreams.end() ? *it : nullptr;
+}
+
+std::vector<CDemuxStreamAudio*> VideoPlayerCodec::GetAudioStreams() const
+{
+  std::vector<CDemuxStreamAudio*> audioStreams;
+  if (!m_pDemuxer)
+    return audioStreams;
+
+  for (auto* stream : m_pDemuxer->GetStreams())
+  {
+    if (stream && stream->type == StreamType::AUDIO)
+      audioStreams.push_back(static_cast<CDemuxStreamAudio*>(stream));
+  }
+  return audioStreams;
+}
+
+int VideoPlayerCodec::GetStreamCount() const
+{
+  return static_cast<int>(GetAudioStreams().size());
+}
+
+void VideoPlayerCodec::GetStreamInfo(int index, AudioStreamInfo& info) const
+{
+  auto audioStreams = GetAudioStreams();
+  if (index < 0 || index >= static_cast<int>(audioStreams.size()))
+  {
+    info.valid = false;
+    return;
+  }
+
+  CDemuxStreamAudio* stream = audioStreams[index];
+  info.valid = true;
+  info.language = stream->language;
+  info.name = stream->GetStreamName();
+  info.codecName = stream->codecName;
+  info.codecDesc = stream->GetStreamType();
+  info.channels = stream->iChannels;
+  info.samplerate = stream->iSampleRate;
+  info.bitspersample = stream->iBitsPerSample;
+  info.bitrate = stream->iBitRate;
+  info.flags = stream->flags;
+}
+
+bool VideoPlayerCodec::SetStream(int index)
+{
+  const std::vector<CDemuxStreamAudio*> audioStreams = GetAudioStreams();
+  if (index < 0 || index >= static_cast<int>(audioStreams.size()))
+  {
+    CLog::Log(LOGERROR, "{}: Invalid audio stream index {}", __FUNCTION__, index);
+    return false;
+  }
+
+  CDemuxStreamAudio* newStream = audioStreams[index];
+  if (newStream->uniqueId == m_nAudioStream)
+    return true;
+
+  // Remember the current stream so we can fall back to it if the switch goes bad
+  CDemuxStreamAudio* oldStream = nullptr;
+  for (auto* stream : audioStreams)
+  {
+    if (stream->uniqueId == m_nAudioStream)
+    {
+      oldStream = stream;
+      break;
+    }
+  }
+
+  const int newUniqueId = newStream->uniqueId;
+  const int oldUniqueId = m_nAudioStream;
+
+  const SwitchResult result = SwitchToStream(newStream, oldStream);
+  if (result == SwitchResult::NOT_STARTED)
+    return false;
+
+  if (result == SwitchResult::FAILED)
+  {
+    // The codec has already been destroyed, so try and restore. The switch may have rebuilt the
+    // stream objects, so take them again rather than reusing the pointers from before.
+    CDemuxStreamAudio* const restoreStream = GetAudioStream(oldUniqueId);
+    if (restoreStream &&
+        SwitchToStream(restoreStream, GetAudioStream(newUniqueId)) == SwitchResult::OK)
+      CLog::Log(LOGWARNING, "{}: Restored audio stream uniqueId={} after a failed switch",
+                __FUNCTION__, oldUniqueId);
+    else
+      CLog::Log(LOGERROR, "{}: Audio codec left unusable after a failed switch", __FUNCTION__);
+
+    return false;
+  }
+
+  CLog::Log(LOGDEBUG, "{}: Switched to audio stream {} (uniqueId={})", __FUNCTION__, index,
+            m_nAudioStream);
+  return true;
+}
+
+VideoPlayerCodec::SwitchResult VideoPlayerCodec::SwitchToStream(CDemuxStreamAudio* newStream,
+                                                                CDemuxStreamAudio* oldStream)
+{
+  const int64_t demuxerId = newStream->demuxerId;
+  const int uniqueId = newStream->uniqueId;
+  const bool hasOldStream = oldStream != nullptr;
+  const int64_t oldDemuxerId = hasOldStream ? oldStream->demuxerId : 0;
+  const int oldUniqueId = hasOldStream ? oldStream->uniqueId : -1;
+
+  // Open the stream before describing it. A demuxer is free to complete or correct a stream's
+  // properties as it opens it, and to rebuild the stream object while doing so.
+  m_pDemuxer->EnableStream(demuxerId, uniqueId, true);
+  m_pDemuxer->OpenStream(demuxerId, uniqueId);
+  newStream = GetAudioStream(uniqueId);
+
+  // Build the codec before anything else is disturbed, so that failure leaves the stream that
+  // is playing untouched
+  std::unique_ptr<CDVDAudioCodec> codec;
+  if (newStream)
+  {
+    CDVDStreamInfo hint(*newStream, true);
+    const CAEStreamInfo::DataType ptStreamType =
+        GetPassthroughStreamType(hint.codec, hint.samplerate, hint.profile);
+
+    codec = CDVDFactoryCodec::CreateAudioCodec(hint, *m_processInfo, true, true, ptStreamType);
+  }
+
+  if (!codec)
+  {
+    CLog::Log(LOGERROR, "{}: Could not create audio codec for stream uniqueId={}", __FUNCTION__,
+              uniqueId);
+    if (uniqueId != m_nAudioStream)
+      m_pDemuxer->EnableStream(demuxerId, uniqueId, false);
+    return SwitchResult::NOT_STARTED;
+  }
+
+  // Past this point we are committed to the new stream
+
+  if (hasOldStream)
+    m_pDemuxer->EnableStream(oldDemuxerId, oldUniqueId, false);
+
+  m_nAudioStream = uniqueId;
+
+  // m_audioFrame borrows buffers owned by the codec, so it must be dropped first
+  m_nDecodedLen = 0;
+  m_audioFrame = {};
+  m_pAudioCodec = std::move(codec);
+
+  m_pDemuxer->Flush();
+
+  return InitFormatFromStream(newStream, false) ? SwitchResult::OK : SwitchResult::FAILED;
 }

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -423,7 +423,7 @@ int VideoPlayerCodec::ReadPCM(uint8_t* pBuffer, size_t size, size_t* actualsize)
 
 int VideoPlayerCodec::ReadRaw(uint8_t **pBuffer, int *bufferSize)
 {
-  DemuxPacket* pPacket;
+  DemuxPacket* pPacket = nullptr;
 
   m_nDecodedLen = 0;
   DVDAudioFrame audioframe;
@@ -436,6 +436,8 @@ int VideoPlayerCodec::ReadRaw(uint8_t **pBuffer, int *bufferSize)
 
   do
   {
+    if (pPacket)
+      CDVDDemuxUtils::FreeDemuxPacket(pPacket);
     pPacket = m_pDemuxer->Read();
   } while (pPacket && pPacket->iStreamId != m_nAudioStream);
 

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -120,13 +120,11 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
 
   CDemuxStream* pStream = NULL;
   m_nAudioStream = -1;
-  int64_t demuxerId = -1;
   for (auto stream : m_pDemuxer->GetStreams())
   {
     if (stream && stream->type == StreamType::AUDIO)
     {
       m_nAudioStream = stream->uniqueId;
-      demuxerId = stream->demuxerId;
       pStream = stream;
       break;
     }
@@ -159,7 +157,7 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
     return false;
   }
 
-  //  Extract ReplayGain info
+  // Extract ReplayGain info
   // tagLoaderTagLib.Load will try to determine tag type by file extension, so set fallback by contentType
   std::string strFallbackFileExtension = "";
   if (m_strContentType == "audio/aacp" ||
@@ -173,37 +171,15 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
   CTagLoaderTagLib tagLoaderTagLib;
   tagLoaderTagLib.Load(file.GetDynPath(), m_tag, strFallbackFileExtension);
 
-  // we have to decode initial data in order to get channels/samplerate
-  // for sanity - we read no more than 10 packets
-  int nErrors = 0;
-  for (int nPacket = 0;
-       nPacket < 10 && (m_channels == 0 || m_format.m_sampleRate == 0 || m_format.m_frameSize == 0);
-       nPacket++)
-  {
-    uint8_t dummy[256];
-    size_t nSize = 256;
-    if (ReadPCM(dummy, nSize, &nSize) == READ_ERROR)
-      ++nErrors;
-
-    m_srcFormat = m_pAudioCodec->GetFormat();
-    m_format = m_srcFormat;
-    m_channels = m_srcFormat.m_channelLayout.Count();
-    m_bitsPerSample = CAEUtil::DataFormatToBits(m_srcFormat.m_dataFormat);
-    m_bitsPerCodedSample = static_cast<CDemuxStreamAudio*>(pStream)->iBitsPerSample;
-  }
-  if (nErrors >= 10)
-  {
-    CLog::Log(LOGDEBUG, "{}: Could not decode data", __FUNCTION__);
+  if (!InitFormatFromStream(static_cast<CDemuxStreamAudio*>(pStream), true))
     return false;
-  }
 
-  // test if seeking is supported
+  // Test seeking is supported (and rewind stream)
   m_bCanSeek = false;
   if (m_pInputStream->Seek(0, DVDSTREAM_SEEK_POSSIBLE))
   {
     if (Seek(1))
     {
-      // rewind stream to beginning
       Seek(0);
       m_bCanSeek = true;
     }
@@ -215,24 +191,103 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
     }
   }
 
-  if (m_channels == 0) // no data - just guess and hope for the best
+  m_strFileName = file.GetDynPath();
+  m_bInited = true;
+
+  return true;
+}
+
+bool VideoPlayerCodec::InitFormatFromStream(CDemuxStreamAudio* stream, bool allowFormatFallback)
+{
+  // Reset format information
+  m_srcFormat = {};
+  m_format = {};
+  m_channels = 0;
+  m_bitsPerSample = 0;
+  m_bitsPerCodedSample = 0;
+  m_planes = 0;
+
+  // The probe loop calls ReadPCM()
+  m_pResampler.reset();
+  m_needConvert = false;
+
+  // Decode up to 10 packets to let the codec describe its output.
+  // The first frame decoded may not reflect true format (eg. a partial DTS frame decodes as the 48kHz
+  // core while the frames after it carry the 96kHz extension). Keep reading until two consecutive
+  // frames agree.
+  int nErrors = 0;
+  bool stable = false;
+  AEAudioFormat probed{};
+  for (int nPacket = 0; nPacket < 10 && !stable; nPacket++)
   {
-    m_srcFormat.m_channelLayout = CAEChannelInfo(AE_CH_LAYOUT_2_0);
-    m_channels = m_srcFormat.m_channelLayout.Count();
+    uint8_t dummy[256];
+    size_t nSize = 256;
+    const int read = ReadPCM(dummy, nSize, &nSize);
+    if (read == READ_ERROR)
+      ++nErrors;
+    else if (read == READ_EOF)
+      break; // there is nothing left to describe the stream with
+
+    const AEAudioFormat previous = probed;
+    probed = m_pAudioCodec->GetFormat();
+
+    stable = probed.m_channelLayout.Count() != 0 && probed.m_sampleRate != 0 &&
+             probed.m_frameSize != 0 && probed.m_sampleRate == previous.m_sampleRate &&
+             probed.m_channelLayout.Count() == previous.m_channelLayout.Count() &&
+             probed.m_dataFormat == previous.m_dataFormat;
+
+    // Force move to next frame
+    m_nDecodedLen = 0;
+  }
+  if (nErrors >= 10)
+  {
+    CLog::Log(LOGDEBUG, "{}: Could not decode data", __FUNCTION__);
+    return false;
   }
 
-  if (m_srcFormat.m_sampleRate == 0)
-    m_srcFormat.m_sampleRate = 44100;
+  if (!stable)
+    CLog::Log(LOGDEBUG,
+              "{}: Format of audio stream uniqueId={} did not settle, using {} Hz, {} channels",
+              __FUNCTION__, stream->uniqueId, probed.m_sampleRate, probed.m_channelLayout.Count());
 
+  m_srcFormat = probed;
+  m_format = m_srcFormat;
+  m_channels = m_srcFormat.m_channelLayout.Count();
+  m_bitsPerSample = CAEUtil::DataFormatToBits(m_srcFormat.m_dataFormat);
+  m_bitsPerCodedSample = stream->iBitsPerSample;
+
+  if (m_channels == 0 || m_srcFormat.m_sampleRate == 0)
+  {
+    // Guessing only when opening the file
+    if (!allowFormatFallback)
+    {
+      CLog::Log(LOGERROR, "{}: Could not determine the format of audio stream uniqueId={}",
+                __FUNCTION__, stream->uniqueId);
+      return false;
+    }
+
+    if (m_channels == 0) // no data - just guess and hope for the best
+    {
+      m_srcFormat.m_channelLayout = CAEChannelInfo(AE_CH_LAYOUT_2_0);
+      m_channels = m_srcFormat.m_channelLayout.Count();
+    }
+
+    if (m_srcFormat.m_sampleRate == 0)
+      m_srcFormat.m_sampleRate = 44100;
+  }
+
+  m_format = m_srcFormat;
+
+  // Update duration, bitrate and codec name for this stream
   m_TotalTime = m_pDemuxer->GetStreamLength();
   m_bitRate = m_pAudioCodec->GetBitRate();
   if (!m_bitRate && m_TotalTime)
-  {
-    m_bitRate = (int)(((m_pInputStream->GetLength()*1000) / m_TotalTime) * 8);
-  }
-  m_CodecName = m_pDemuxer->GetStreamCodecName(demuxerId, m_nAudioStream);
+    m_bitRate = (int)(((m_pInputStream->GetLength() * 1000) / m_TotalTime) * 8);
 
-  m_needConvert = false;
+  m_CodecName = m_pDemuxer->GetStreamCodecName(stream->demuxerId, m_nAudioStream);
+
+  m_planes = AE_IS_PLANAR(m_srcFormat.m_dataFormat) ? m_channels : 1;
+
   if (NeedConvert(m_srcFormat.m_dataFormat))
   {
     m_needConvert = true;
@@ -278,14 +333,14 @@ bool VideoPlayerCodec::Init(const CFileItem &file, unsigned int filecache)
     m_pResampler->Init(dstConfig, srcConfig, false, false, M_SQRT1_2, NULL, AE_QUALITY_UNKNOWN,
                        false, 0.0f);
 
-    m_planes = AE_IS_PLANAR(m_srcFormat.m_dataFormat) ? m_channels : 1;
-    m_format = m_srcFormat;
     m_format.m_dataFormat = AE_FMT_FLOAT;
     m_bitsPerSample = CAEUtil::DataFormatToBits(m_format.m_dataFormat);
   }
 
-  m_strFileName = file.GetDynPath();
-  m_bInited = true;
+  // Drop partial frame so ReadPCM() starts on a frame boundary
+  m_nDecodedLen = 0;
+  m_audioFrame = {};
+  m_pAudioCodec->Reset();
 
   return true;
 }
@@ -354,8 +409,8 @@ bool VideoPlayerCodec::PacketIsBeforeSeek(const DemuxPacket& packet)
     return false;
   }
 
-  // Keep the packet that spans the requested time
-  if (pts + packet.duration > m_skipToPts)
+  // Keep the packet the requested time falls in, and any that starts at or after it.
+  if (pts >= m_skipToPts || pts + packet.duration > m_skipToPts)
   {
     m_skipToPts = DVD_NOPTS_VALUE;
     return false;

--- a/xbmc/cores/paplayer/VideoPlayerCodec.cpp
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.cpp
@@ -9,7 +9,6 @@
 #include "VideoPlayerCodec.h"
 
 #include "ServiceBroker.h"
-#include "URL.h"
 #include "cores/AudioEngine/AEResampleFactory.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
@@ -331,7 +330,38 @@ bool VideoPlayerCodec::Seek(int64_t iSeekTime)
 
   m_nDecodedLen = 0;
 
+  // A container can generally only seek to a point at or before the time asked for - for matroska
+  // the start of a cluster, which can be a second or more earlier. Decoding straight from there
+  // replays audio the caller believes it is already past, and since the caller keeps counting from
+  // the time it requested, so times drift.
+  // Note where we were asked to be so ReadPCM() can drop the packets in between.
+  m_skipToPts = ret ? DVD_MSEC_TO_TIME(iSeekTime) : DVD_NOPTS_VALUE;
+  m_skipDecodedOutput = false;
+
   return ret;
+}
+
+bool VideoPlayerCodec::PacketIsBeforeSeek(const DemuxPacket& packet)
+{
+  if (m_skipToPts == DVD_NOPTS_VALUE)
+    return false;
+
+  const double pts = packet.pts != DVD_NOPTS_VALUE ? packet.pts : packet.dts;
+  if (pts == DVD_NOPTS_VALUE)
+  {
+    // Nothing to compare against, so hand the packet over and stop trying for this seek
+    m_skipToPts = DVD_NOPTS_VALUE;
+    return false;
+  }
+
+  // Keep the packet that spans the requested time
+  if (pts + packet.duration > m_skipToPts)
+  {
+    m_skipToPts = DVD_NOPTS_VALUE;
+    return false;
+  }
+
+  return true;
 }
 
 int VideoPlayerCodec::ReadPCM(uint8_t* pBuffer, size_t size, size_t* actualsize)
@@ -378,6 +408,8 @@ int VideoPlayerCodec::ReadPCM(uint8_t* pBuffer, size_t size, size_t* actualsize)
       return READ_EOF;
     }
 
+    m_skipDecodedOutput = PacketIsBeforeSeek(*pPacket);
+
     pPacket->pts = DVD_NOPTS_VALUE;
     pPacket->dts = DVD_NOPTS_VALUE;
 
@@ -390,6 +422,16 @@ int VideoPlayerCodec::ReadPCM(uint8_t* pBuffer, size_t size, size_t* actualsize)
 
     m_pAudioCodec->GetData(m_audioFrame);
     bytes = m_audioFrame.nb_frames * m_audioFrame.framesize;
+  }
+
+  if (bytes && m_skipDecodedOutput)
+  {
+    // Audio from before the seek is decoded rather than skipped, so that a codec carrying state
+    // from one frame to the next has it, and dropped here instead. A codec that needs more than
+    // one packet to produce anything relies on returning without data, so do the same.
+    m_audioFrame = {};
+    *actualsize = 0;
+    return READ_SUCCESS;
   }
 
   m_nDecodedLen = bytes;
@@ -439,7 +481,7 @@ int VideoPlayerCodec::ReadRaw(uint8_t **pBuffer, int *bufferSize)
     if (pPacket)
       CDVDDemuxUtils::FreeDemuxPacket(pPacket);
     pPacket = m_pDemuxer->Read();
-  } while (pPacket && pPacket->iStreamId != m_nAudioStream);
+  } while (pPacket && (pPacket->iStreamId != m_nAudioStream || PacketIsBeforeSeek(*pPacket)));
 
   if (!pPacket)
   {

--- a/xbmc/cores/paplayer/VideoPlayerCodec.h
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.h
@@ -38,9 +38,15 @@ public:
   bool NeedConvert(AEDataFormat fmt);
   void SetPassthroughStreamType(CAEStreamInfo::DataType streamType);
 
+  int GetStreamCount() const override;
+  bool SetStream(int index) override;
+  void GetStreamInfo(int index, AudioStreamInfo& info) const override;
+
 private:
   CAEStreamInfo::DataType GetPassthroughStreamType(AVCodecID codecId, int samplerate, int profile);
 
+  std::vector<CDemuxStreamAudio*> GetAudioStreams() const;
+  CDemuxStreamAudio* GetAudioStream(int uniqueId) const;
   /*!
    * \brief Probe the currently selected stream and derive the output format from it.
    *
@@ -49,6 +55,21 @@ private:
    *                            change means decoding through an invented format.
    */
   bool InitFormatFromStream(CDemuxStreamAudio* stream, bool allowFormatFallback);
+
+  /*!
+   * \brief Commit to decoding \p newStream, disabling \p oldStream if given.
+   *
+   * On failure the codec state is undefined and the caller must either switch to another
+   * stream or treat the codec as unusable.
+   */
+  enum class SwitchResult
+  {
+    OK,
+    NOT_STARTED, /* nothing was changed, so the stream being decoded still plays */
+    FAILED,
+  };
+
+  SwitchResult SwitchToStream(CDemuxStreamAudio* newStream, CDemuxStreamAudio* oldStream);
 
   //! \brief Decide whether \p packet lies entirely before the time the last Seek() asked for.
   bool PacketIsBeforeSeek(const DemuxPacket& packet);

--- a/xbmc/cores/paplayer/VideoPlayerCodec.h
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.h
@@ -41,6 +41,9 @@ public:
 private:
   CAEStreamInfo::DataType GetPassthroughStreamType(AVCodecID codecId, int samplerate, int profile);
 
+  //! \brief Decide whether \p packet lies entirely before the time the last Seek() asked for.
+  bool PacketIsBeforeSeek(const DemuxPacket& packet);
+
   CDVDDemux* m_pDemuxer{nullptr};
   std::shared_ptr<CDVDInputStream> m_pInputStream;
   std::unique_ptr<CDVDAudioCodec> m_pAudioCodec;
@@ -49,6 +52,12 @@ private:
   std::string m_strFileName;
   int m_nAudioStream{-1};
   size_t m_nDecodedLen{0};
+
+  //! \brief Time the last Seek() was asked for, until a packet covering it has been read
+  double m_skipToPts{DVD_NOPTS_VALUE};
+
+  //! \brief Whether what the codec is decoding now belongs before that time
+  bool m_skipDecodedOutput{false};
 
   bool m_bInited{false};
   bool m_bCanSeek{false};

--- a/xbmc/cores/paplayer/VideoPlayerCodec.h
+++ b/xbmc/cores/paplayer/VideoPlayerCodec.h
@@ -41,6 +41,15 @@ public:
 private:
   CAEStreamInfo::DataType GetPassthroughStreamType(AVCodecID codecId, int samplerate, int profile);
 
+  /*!
+   * \brief Probe the currently selected stream and derive the output format from it.
+   *
+   * \param allowFormatFallback if the probe yields nothing, assume 44.1kHz stereo rather than
+   *                            failing. Only safe when opening the file - guessing on a stream
+   *                            change means decoding through an invented format.
+   */
+  bool InitFormatFromStream(CDemuxStreamAudio* stream, bool allowFormatFallback);
+
   //! \brief Decide whether \p packet lies entirely before the time the last Seek() asked for.
   bool PacketIsBeforeSeek(const DemuxPacket& packet);
 

--- a/xbmc/input/actions/ActionIDs.h
+++ b/xbmc/input/actions/ActionIDs.h
@@ -164,7 +164,9 @@ constexpr const int ACTION_AUDIO_DELAY_MIN = 54;
 //! Decrease avsync delay.  Can be used in videoFullScreen.xml window id=2005
 constexpr const int ACTION_AUDIO_DELAY_PLUS = 55;
 
-//! Select next language in movie.  Can be used in videoFullScreen.xml window id=2005
+//! Select the next audio stream. Despite the name, the streams it cycles need not differ in
+//! language - alternate mixes of one language are common in music files - and it applies to music
+//! playback as well as video.
 constexpr const int ACTION_AUDIO_NEXT_LANGUAGE = 56;
 
 //! Switch 2 next resolution. Can b used during screen calibration

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -1331,6 +1331,7 @@ JSONRPC_STATUS CPlayerOperations::SetAudioStream(const std::string &method, ITra
   switch (GetPlayer(parameterObject["playerid"]))
   {
     case Video:
+    case Audio:
     {
       auto& components = CServiceBroker::GetAppComponents();
       const auto appPlayer = components.GetComponent<CApplicationPlayer>();
@@ -1368,7 +1369,6 @@ JSONRPC_STATUS CPlayerOperations::SetAudioStream(const std::string &method, ITra
       break;
     }
 
-    case Audio:
     case Picture:
     default:
       return FailedToExecute;

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -269,39 +269,7 @@ bool CPlayerController::OnAction(const CAction &action)
       }
 
       case ACTION_AUDIO_NEXT_LANGUAGE:
-      {
-        if (appPlayer->GetAudioStreamCount() == 1)
-          return true;
-
-        using namespace KODI::VIDEO;
-        const std::vector<AudioStreamInfoExt> streams =
-            CVideoStreamSelect::GetAudioStreams(appPlayer.get());
-
-        // Find the current logical sub track from the internal id
-        const int currentStreamId = appPlayer->GetAudioStream();
-        auto it = std::ranges::find(streams, currentStreamId, &AudioStreamInfoExt::streamId);
-        if (it == streams.end())
-          return true;
-        const int currentIndex = static_cast<int>(std::distance(streams.begin(), it));
-
-        const int newIndex = (currentIndex + 1) % streams.size();
-
-        it = streams.begin() + newIndex;
-        appPlayer->SetAudioStream(it->streamId);
-
-        // Toast
-        std::string textInfo = it->languageDesc;
-        if (!it->name.empty())
-          textInfo += " - " + it->name;
-        if (!it->codecDesc.empty())
-          textInfo += " (" + it->codecDesc + ")";
-
-        std::string caption = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(460);
-        caption += StringUtils::Format(" ({}/{})", newIndex + 1, streams.size());
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, caption, textInfo,
-                                              DisplTime, false, MsgTime);
-        return true;
-      }
+        return NextAudioStream();
 
       case ACTION_DIALOG_SELECT_AUDIO:
       {
@@ -617,7 +585,59 @@ bool CPlayerController::OnAction(const CAction &action)
         break;
     }
   }
+  else if (appPlayer->IsPlayingAudio())
+  {
+    switch (action.GetID())
+    {
+      case ACTION_AUDIO_NEXT_LANGUAGE:
+        return NextAudioStream();
+
+      default:
+        break;
+    }
+  }
   return false;
+}
+
+bool CPlayerController::NextAudioStream()
+{
+  const unsigned int MsgTime = 300;
+  const unsigned int DisplTime = 2000;
+
+  auto& components = CServiceBroker::GetAppComponents();
+  const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+
+  if (appPlayer->GetAudioStreamCount() < 2)
+    return true;
+
+  using namespace KODI::VIDEO;
+  const std::vector<AudioStreamInfoExt> streams =
+      CVideoStreamSelect::GetAudioStreams(appPlayer.get());
+
+  // Find the current logical sub track from the internal id
+  const int currentStreamId = appPlayer->GetAudioStream();
+  auto it = std::ranges::find(streams, currentStreamId, &AudioStreamInfoExt::streamId);
+  if (it == streams.end())
+    return true;
+  const int currentIndex = static_cast<int>(std::distance(streams.begin(), it));
+
+  const int newIndex = (currentIndex + 1) % streams.size();
+
+  it = streams.begin() + newIndex;
+  appPlayer->SetAudioStream(it->streamId);
+
+  // Toast
+  std::string textInfo = it->languageDesc;
+  if (!it->name.empty())
+    textInfo += " - " + it->name;
+  if (!it->codecDesc.empty())
+    textInfo += " (" + it->codecDesc + ")";
+
+  std::string caption = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(460);
+  caption += StringUtils::Format(" ({}/{})", newIndex + 1, streams.size());
+  CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, caption, textInfo, DisplTime,
+                                        false, MsgTime);
+  return true;
 }
 
 void CPlayerController::ShowSlider(int action, int label, float value, float min, float delta, float max, bool modal)

--- a/xbmc/video/PlayerController.h
+++ b/xbmc/video/PlayerController.h
@@ -52,6 +52,11 @@ private:
    */
   void ShowSlider(int action, int label, float value, float min, float delta, float max, bool modal = false);
 
+  /*! \brief switch to the next audio stream of the playing file and notify the user
+   \return true if the action is considered handled
+   */
+  bool NextAudioStream();
+
   int m_sliderAction = 0; ///< \brief set to the action id for a slider being displayed \sa ShowSlider
   KODI::UTILS::MOVING_SPEED::CMovingSpeed m_movingSpeed;
 };


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add audio stream switching to PAPlayer.

Written with the help of Claude Opus 5.

Tested locally on .mka files with 6 audio streams.

Press long up arrow to change stream whilst in visualisation. '#' on remote.

Checked transitions (straight/cross fade), pause resume, switching right at start/end - using logs and AI to check for expected events occuring in correct order.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously requested

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

As above.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **New feature** (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
