### PR TITLE
fixed: address the test web server where it actually listens

### DIFF
--- a/xbmc/filesystem/test/TestHTTPDirectory.cpp
+++ b/xbmc/filesystem/test/TestHTTPDirectory.cpp
@@ -27,7 +27,7 @@
 
 using namespace XFILE;
 
-#define WEBSERVER_HOST "localhost"
+#define WEBSERVER_HOST "127.0.0.1"
 
 #define SOURCE_PATH "xbmc/filesystem/test/data/httpdirectory/"
 

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -34,7 +34,7 @@
 
 using namespace XFILE;
 
-#define WEBSERVER_HOST          "localhost"
+#define WEBSERVER_HOST          "127.0.0.1"
 
 #define TEST_URL_JSONRPC        "jsonrpc"
 


### PR DESCRIPTION
The web server test fixtures start the server on the loopback address, then address it as
`localhost`. Where `localhost` resolves to `::1` first, every request opens on an address the
server is not listening on. On a host that drops connections to a closed port rather than
refusing them, the request stalls until it times out instead of failing over.

Measured locally: a connect to a closed `::1` port had not answered after 10 s, while the same
port on `127.0.0.1` was refused in 2 s. `TestHTTPDirectory` hung indefinitely on `IsStarted`, and
`BasicIndex` timed out after 63 s in one run and 124 s in another, while its siblings passed in
single-digit milliseconds.

The host is defined separately in each fixture, so both are changed. Follows #28876, which
stopped the same two fixtures guessing the port.

Before: the full suite could not complete on this machine. After: all 43 tests across both
fixtures run in 247 ms, `BasicIndex` in 1 ms, and the full suite is green at 3781/3781.
