### PR TITLE
added: hold playback until an audio format change has settled downstream

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -18203,6 +18203,30 @@ msgctxt "#34113"
 msgid "To keep certain AVRs powered we send an inaudible random noise signal. You can disable this setting if you are using headphone or analog output."
 msgstr ""
 
+#. label for setting audiooutput.delayformatchange
+#: system/settings/settings.xml
+msgctxt "#34131"
+msgid "Wait for the receiver after an audio format change"
+msgstr ""
+
+#. Description of setting with label #34131 "Wait for the receiver after an audio format change"
+#: system/settings/settings.xml
+msgctxt "#34132"
+msgid "Hold playback while a receiver locks on to a new audio format, so the start of a film is not lost. Applies when the format on the wire changes. A maximum, not a fixed wait."
+msgstr ""
+
+#. label for setting audiooutput.silencefiller
+#: system/settings/settings.xml
+msgctxt "#34133"
+msgid "Repeat the last audio frame while waiting"
+msgstr ""
+
+#. Description of setting with label #34133 "Repeat the last audio frame while waiting"
+#: system/settings/settings.xml
+msgctxt "#34134"
+msgid "Keeps a valid frame on the wire during the wait above, so the receiver does not lose the format and have to find it again."
+msgstr ""
+
 #. Indicates if Audio Engine should include lfe when downmixing
 #: system/settings/settings.xml
 msgctxt "#34114"

--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -1,6 +1,7 @@
 xbmc/addons/gui/skin/test         test/skin
 xbmc/addons/test                  test/addons
 xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
+xbmc/cores/AudioEngine/Utils/test test/audioengine_utils
 xbmc/cores/RetroPlayer/playback/test test/retroplayer_playback
 xbmc/cores/RetroPlayer/rendering/test test/retroplayer_rendering
 xbmc/cores/RetroPlayer/savestates/test test/retroplayer_savestates

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3424,6 +3424,14 @@
           <default>true</default>
           <control type="toggle" />
         </setting>
+        <setting id="audiooutput.delayformatchange" type="integer" label="34131" help="34132">
+          <level>2</level>
+          <default>0</default>
+          <constraints>
+            <options>refreshchangedelays</options>
+          </constraints>
+          <control type="list" format="string" />
+        </setting>
         <setting id="audiooutput.mixsublevel" type="integer" label="34114" help="34115">
           <level>2</level>
           <default>0</default>
@@ -3604,6 +3612,14 @@
                 <condition setting="audiooutput.passthrough" operator="is">true</condition>
               </and>
             </dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
+        <setting id="audiooutput.silencefiller" type="boolean" label="34133" help="34134">
+          <level>2</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="enable" setting="audiooutput.passthrough" operator="is">true</dependency>
           </dependencies>
           <control type="toggle" />
         </setting>

--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -777,6 +777,13 @@ void CApplicationPlayer::SetDynamicRangeCompression(long drc)
     player->SetDynamicRangeCompression(drc);
 }
 
+void CApplicationPlayer::NotifyAudioChainReady()
+{
+  std::shared_ptr<IPlayer> player = GetInternal();
+  if (player)
+    player->NotifyAudioChainReady();
+}
+
 void CApplicationPlayer::LoadPage(int p, int sp, unsigned char* buffer)
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -151,6 +151,7 @@ public:
   void SetAVDelay(float fValue = 0.0f);
   void SetBookmarks(const std::vector<std::chrono::milliseconds>& bookmarks);
   void SetDynamicRangeCompression(long drc);
+  void NotifyAudioChainReady();
   void SetMute(bool bOnOff);
   bool SetPlayerState(const std::string& state);
   void SetSubtitle(int iStream);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -1229,6 +1229,9 @@ void CActiveAE::Configure(AEAudioFormat *desiredFmt)
     m_currentDeviceFollowsDefault =
         requestedDefaultDevice || !IsSameDevice(m_openedDriver, m_openedDevice, dev);
     initSink = true;
+    // The wire format changed, so a downstream device has to acquire it again.
+    for (auto* activeStream : m_streams)
+      activeStream->m_sinkFormatChanged = true;
     m_stats.Reset(m_sinkFormat.m_sampleRate, m_mode == MODE_PCM);
     m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::VOLUME, &m_volume, sizeof(float));
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -9,11 +9,14 @@
 #include "ActiveAESink.h"
 
 #include "ActiveAE.h"
+#include "ServiceBroker.h"
 #include "cores/AudioEngine/AEResampleFactory.h"
 #include "cores/AudioEngine/Sinks/AESinkNULL.h"
 #include "cores/AudioEngine/Utils/AEBitstreamPacker.h"
 #include "cores/AudioEngine/Utils/AEStreamInfo.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
 #include "utils/EndianSwap.h"
 #include "utils/MemUtils.h"
 #include "utils/log.h"
@@ -1040,6 +1043,14 @@ void CActiveAESink::OpenSink()
     m_sampleOfSilence.pkt->pause_burst_ms = m_sinkFormat.m_streamInfo.GetDuration();
   }
 
+  const auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  const auto settings = settingsComponent ? settingsComponent->GetSettings() : nullptr;
+  m_silenceFiller = passthrough && settings && settings->GetBool("audiooutput.silencefiller");
+  m_fillerArmed = m_silenceFiller;
+  m_fillerUsed = false;
+  if (m_silenceFiller)
+    CLog::Log(LOGINFO, "CActiveAESink::OpenSink - content filler armed for the opening hold");
+
   m_swapState = CHECK_SWAP;
 }
 
@@ -1086,20 +1097,73 @@ unsigned int CActiveAESink::OutputSamples(CSampleBuffer* samples)
     bool skipSwap = false;
     if (m_needIecPack)
     {
+      enum class RawOut
+      {
+        NONE,
+        DATA,
+        FILLER,
+        PAUSE
+      };
+      static RawOut lastOut = RawOut::NONE;
+      RawOut out = lastOut;
+      const char* why = "";
       if (frames > 0)
       {
         m_packer->Reset();
         m_packer->Pack(m_sinkFormat.m_streamInfo, buffer[0], frames);
+        out = RawOut::DATA;
+        // Content after the filler is the film starting: the opening is over.
+        if (m_fillerUsed)
+          m_fillerArmed = false;
       }
       else if (samples->pkt->pause_burst_ms > 0)
       {
         // construct a pause burst if we have already output valid audio
         bool burst = m_extStreaming && (m_packer->GetBuffer()[0] != 0);
-        if (!m_packer->PackPause(m_sinkFormat.m_streamInfo, samples->pkt->pause_burst_ms, burst))
+        // ActiveAE reports STREAMING false for the whole of a hold, so burst
+        // cannot gate this.
+        const bool haveFormat = m_packer->GetBuffer()[0] != 0;
+        // Sync gaps request arbitrary lengths and stay as pause bursts.
+        bool filled = false;
+        const bool wholeFrame = samples->pkt->pause_burst_ms ==
+                                static_cast<int>(m_sinkFormat.m_streamInfo.GetDuration());
+        // The opening only: repeating a burst across a later gap is audible.
+        if (m_silenceFiller && m_fillerArmed && haveFormat && wholeFrame)
+        {
+          filled = m_packer->PackLastBurst();
+          if (filled)
+            m_fillerUsed = true;
+          if (!filled)
+            why = " [filler: no burst retained]";
+        }
+        else if (m_silenceFiller)
+          why = !m_fillerArmed ? " [filler: past the opening]"
+                : !haveFormat  ? " [filler: no prior burst]"
+                : !wholeFrame  ? " [filler: partial frame]"
+                               : "";
+        // Not skipSwap: the retained burst is copied in fresh and still needs it.
+        if (!filled &&
+            !m_packer->PackPause(m_sinkFormat.m_streamInfo, samples->pkt->pause_burst_ms, burst))
           skipSwap = true;
+        out = filled ? RawOut::FILLER : RawOut::PAUSE;
       }
       else
+      {
         m_packer->Reset();
+        out = RawOut::NONE;
+      }
+
+      if (out != lastOut)
+      {
+        static const char* const names[] = {"none", "data", "filler", "pause"};
+        CLog::Log(
+            LOGINFO,
+            "CActiveAESink::OutputSamples - raw output {} -> {} (type {}, repeat {}, {} ms){}",
+            names[static_cast<int>(lastOut)], names[static_cast<int>(out)],
+            static_cast<int>(m_sinkFormat.m_streamInfo.m_type), m_sinkFormat.m_streamInfo.m_repeat,
+            samples->pkt->pause_burst_ms, why);
+        lastOut = out;
+      }
 
       unsigned int size = m_packer->GetSize();
       packBuffer = m_packer->GetBuffer();

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -162,6 +162,10 @@ protected:
   int m_sinkLatency;
   std::unique_ptr<CAEBitstreamPacker> m_packer;
   bool m_needIecPack{false};
+  bool m_silenceFiller{false};
+  //! \brief Armed at sink open, dropped once content follows the filler.
+  bool m_fillerArmed{false};
+  bool m_fillerUsed{false};
   bool m_streamNoise;
 };
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -572,6 +572,11 @@ enum AEDataFormat CActiveAEStream::GetDataFormat() const
   return m_format.m_dataFormat;
 }
 
+bool CActiveAEStream::HasSinkFormatChanged() const
+{
+  return m_sinkFormatChanged;
+}
+
 void CActiveAEStream::RegisterAudioCallback(IAudioCallback* pCallback)
 {
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.h
@@ -179,6 +179,7 @@ public:
 
   unsigned int GetSampleRate() const override ;
   enum AEDataFormat GetDataFormat() const override;
+  bool HasSinkFormatChanged() const override;
 
   double GetResampleRatio() override;
   void SetResampleRatio(double ratio) override;
@@ -241,6 +242,8 @@ protected:
   double m_clockSpeed;
   enum AVMatrixEncoding m_matrixEncoding;
   enum AVAudioServiceType m_audioServiceType;
+  //! Set by CActiveAE when it reinitialises the sink under this stream.
+  std::atomic<bool> m_sinkFormatChanged{false};
   bool m_forceResampler;
   IAEClockCallback *m_pClock;
   CSyncError m_syncError;

--- a/xbmc/cores/AudioEngine/Interfaces/AEStream.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AEStream.h
@@ -219,6 +219,15 @@ public:
   virtual enum AEDataFormat GetDataFormat() const = 0;
 
   /**
+   * Whether the sink was reconfigured to carry this stream, so that the format on the wire
+   * changed and a downstream device has to acquire it again.
+   * @note Latched for the life of the stream. False where the engine reused the existing sink
+   *       configuration, as a fixed output configuration does when only the source rate changed.
+   * @return True when the wire format changed
+   */
+  virtual bool HasSinkFormatChanged() const = 0;
+
+  /**
    * Return the resample ratio
    * @note This will return an undefined value if the stream is not resampling
    * @return the current resample ratio or undefined if the stream is not resampling

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.cpp
@@ -71,6 +71,8 @@ void CAEBitstreamPacker::Pack(CAEStreamInfo &info, uint8_t* data, int size)
     default:
       CLog::Log(LOGERROR, "CAEBitstreamPacker::Pack - no pack function");
   }
+
+  RetainBurst();
 }
 
 bool CAEBitstreamPacker::PackPause(CAEStreamInfo &info, unsigned int millis, bool iecBursts)
@@ -110,6 +112,27 @@ bool CAEBitstreamPacker::PackPause(CAEStreamInfo &info, unsigned int millis, boo
   return true;
 }
 
+bool CAEBitstreamPacker::PackLastBurst()
+{
+  if (m_lastBurst.empty())
+    return false;
+
+  memcpy(m_packedBuffer, m_lastBurst.data(), m_lastBurst.size());
+  m_dataSize = static_cast<unsigned int>(m_lastBurst.size());
+  m_pauseDuration = 0;
+  return true;
+}
+
+void CAEBitstreamPacker::RetainBurst()
+{
+  // Whole bursts only: DTS-HD and E-AC3 leave m_dataSize at zero while
+  // they accumulate.
+  if (m_dataSize == 0 || m_dataSize > sizeof(m_packedBuffer))
+    return;
+
+  m_lastBurst.assign(m_packedBuffer, m_packedBuffer + m_dataSize);
+}
+
 unsigned int CAEBitstreamPacker::GetSize() const
 {
   return m_dataSize;
@@ -124,6 +147,8 @@ void CAEBitstreamPacker::Reset()
 {
   m_dataSize = 0;
   m_pauseDuration = 0;
+  // The retained burst belongs to the stream that is ending.
+  m_lastBurst.clear();
   m_packedBuffer[0] = 0;
 }
 

--- a/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
+++ b/xbmc/cores/AudioEngine/Utils/AEBitstreamPacker.h
@@ -25,6 +25,11 @@ public:
 
   void Pack(CAEStreamInfo &info, uint8_t* data, int size);
   bool PackPause(CAEStreamInfo &info, unsigned int millis, bool iecBursts);
+
+  //! Re-emit the last complete burst. Returns false when none has been packed
+  //! yet; the caller skips byte-swapping, as the retained burst is already
+  //! swapped.
+  bool PackLastBurst();
   void Reset();
   uint8_t* GetBuffer();
   unsigned int GetSize() const;
@@ -34,6 +39,11 @@ public:
 private:
   void PackDTSHD(CAEStreamInfo &info, uint8_t* data, int size);
   void PackEAC3(CAEStreamInfo &info, uint8_t* data, int size);
+  void RetainBurst();
+
+  //! The last complete burst handed to the sink, kept apart from m_packedBuffer
+  //! so re-emitting it cannot disturb an assembly in progress.
+  std::vector<uint8_t> m_lastBurst;
 
   std::vector<uint8_t> m_dtsHD;
   unsigned int m_dtsHDSize = 0;

--- a/xbmc/cores/AudioEngine/Utils/test/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/Utils/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestAEBitstreamPacker.cpp)
+
+core_add_test_library(audioengine_utils_test)

--- a/xbmc/cores/AudioEngine/Utils/test/TestAEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/test/TestAEBitstreamPacker.cpp
@@ -1,0 +1,117 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/AudioEngine/Utils/AEBitstreamPacker.h"
+#include "cores/AudioEngine/Utils/AEStreamInfo.h"
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+// An AC3 frame is wrapped rather than parsed, save for the bitstream mode in byte 5, so a frame
+// of arbitrary bytes packs exactly as a real one does.
+std::vector<uint8_t> MakeAc3Frame(uint8_t seed)
+{
+  std::vector<uint8_t> frame(64);
+  for (size_t i = 0; i < frame.size(); ++i)
+    frame[i] = static_cast<uint8_t>(seed + i);
+  return frame;
+}
+
+CAEStreamInfo MakeAc3Info()
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_AC3;
+  info.m_sampleRate = 48000;
+  info.m_channels = 2;
+  return info;
+}
+
+std::vector<uint8_t> Snapshot(CAEBitstreamPacker& packer)
+{
+  return std::vector<uint8_t>(packer.GetBuffer(), packer.GetBuffer() + packer.GetSize());
+}
+} // namespace
+
+TEST(TestAEBitstreamPacker, LastBurstIsUnavailableBeforeOneIsPacked)
+{
+  CAEBitstreamPacker packer;
+
+  EXPECT_FALSE(packer.PackLastBurst());
+}
+
+TEST(TestAEBitstreamPacker, LastBurstReturnsTheStreamsOwnBurstAfterAPause)
+{
+  CAEBitstreamPacker packer;
+  CAEStreamInfo info{MakeAc3Info()};
+  const std::vector<uint8_t> frame{MakeAc3Frame(0x10)};
+
+  packer.Pack(info, const_cast<uint8_t*>(frame.data()), static_cast<int>(frame.size()));
+  const std::vector<uint8_t> burst{Snapshot(packer)};
+  ASSERT_FALSE(burst.empty());
+
+  // A pause burst is what the sink would otherwise put on the wire, and reads as non-audio
+  packer.PackPause(info, 100, true);
+  EXPECT_NE(burst, Snapshot(packer));
+
+  ASSERT_TRUE(packer.PackLastBurst());
+  EXPECT_EQ(burst, Snapshot(packer));
+}
+
+TEST(TestAEBitstreamPacker, LastBurstIsTheMostRecentOne)
+{
+  CAEBitstreamPacker packer;
+  CAEStreamInfo info{MakeAc3Info()};
+  const std::vector<uint8_t> first{MakeAc3Frame(0x10)};
+  const std::vector<uint8_t> second{MakeAc3Frame(0x40)};
+
+  packer.Pack(info, const_cast<uint8_t*>(first.data()), static_cast<int>(first.size()));
+  const std::vector<uint8_t> firstBurst{Snapshot(packer)};
+
+  packer.Pack(info, const_cast<uint8_t*>(second.data()), static_cast<int>(second.size()));
+  const std::vector<uint8_t> secondBurst{Snapshot(packer)};
+  ASSERT_NE(firstBurst, secondBurst);
+
+  packer.PackPause(info, 100, true);
+  ASSERT_TRUE(packer.PackLastBurst());
+  EXPECT_EQ(secondBurst, Snapshot(packer));
+}
+
+TEST(TestAEBitstreamPacker, RepeatingABurstDoesNotStrandTheNextPauseOfTheSameLength)
+{
+  CAEBitstreamPacker packer;
+  CAEStreamInfo info{MakeAc3Info()};
+  const std::vector<uint8_t> frame{MakeAc3Frame(0x10)};
+
+  packer.Pack(info, const_cast<uint8_t*>(frame.data()), static_cast<int>(frame.size()));
+  ASSERT_TRUE(packer.PackPause(info, 100, true));
+  const std::vector<uint8_t> pause{Snapshot(packer)};
+
+  ASSERT_TRUE(packer.PackLastBurst());
+
+  // PackPause reuses the buffer when asked for the duration it last packed, so repeating a burst
+  // over the top of it has to drop that record or the pause never reaches the wire again.
+  ASSERT_TRUE(packer.PackPause(info, 100, true));
+  EXPECT_EQ(pause, Snapshot(packer));
+}
+
+TEST(TestAEBitstreamPacker, ResetForgetsTheRetainedBurst)
+{
+  CAEBitstreamPacker packer;
+  CAEStreamInfo info{MakeAc3Info()};
+  const std::vector<uint8_t> frame{MakeAc3Frame(0x10)};
+
+  packer.Pack(info, const_cast<uint8_t*>(frame.data()), static_cast<int>(frame.size()));
+  ASSERT_TRUE(packer.PackLastBurst());
+
+  // The burst belongs to the stream that is ending, so it must not follow the next one
+  packer.Reset();
+  EXPECT_FALSE(packer.PackLastBurst());
+}

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -113,6 +113,14 @@ public:
   virtual void SetVolume(float volume){}
   virtual void SetDynamicRangeCompression(long drc){}
 
+  /*!
+   \brief Report that the downstream audio chain has finished settling
+
+   Ends a pass-through hold early. The player cannot see the chain, so this is
+   for an add-on that can - one per device. Ignored when nothing is holding.
+   */
+  virtual void NotifyAudioChainReady() {}
+
   virtual void SetAVDelay(float fValue = 0.0f) {}
   virtual float GetAVDelay() { return 0.0f; }
 

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.cpp
@@ -256,6 +256,15 @@ bool CAudioSinkAE::IsValidFormat(const DVDAudioFrame &audioframe)
   return true;
 }
 
+bool CAudioSinkAE::HasSinkFormatChanged()
+{
+  std::unique_lock lock(m_critSection);
+  if (!m_pAudioStream)
+    return false;
+
+  return m_pAudioStream->HasSinkFormatChanged();
+}
+
 double CAudioSinkAE::GetCacheTime()
 {
   std::unique_lock lock(m_critSection);

--- a/xbmc/cores/VideoPlayer/AudioSinkAE.h
+++ b/xbmc/cores/VideoPlayer/AudioSinkAE.h
@@ -38,6 +38,9 @@ public:
   void Resume();
   bool Create(const DVDAudioFrame &audioframe, AVCodecID codec, bool needresampler);
   bool IsValidFormat(const DVDAudioFrame &audioframe);
+  //! rief Whether the engine reconfigured the sink for this stream, ie. the format on
+  //!        the wire changed and a downstream device has to acquire it again.
+  bool HasSinkFormatChanged();
   void Destroy(bool finish);
   unsigned int AddPackets(const DVDAudioFrame &audioframe);
   double GetPlayingPts();

--- a/xbmc/cores/VideoPlayer/DVDMessage.h
+++ b/xbmc/cores/VideoPlayer/DVDMessage.h
@@ -54,6 +54,7 @@ public:
     PLAYER_REPORT_STATE,
     PLAYER_FRAME_ADVANCE,
     PLAYER_DISPLAY_RESET,           // report display reset event
+    PLAYER_AUDIO_FORMAT_CHANGE,     // the audio sink was reconfigured for a passthrough format
 
     // demuxer related messages
     DEMUXER_PACKET,                 // data packet

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -38,7 +38,9 @@
 #include "cores/FFmpeg.h"
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
+#include "dialogs/GUIDialogBusyNoCancel.h"
 #include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
 #include "guilib/StereoscopicsManager.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
@@ -1610,6 +1612,19 @@ void CVideoPlayer::Process()
       continue;
     }
 
+    // Does not service messages, like the display-lost guard above.
+    if (m_audioFormatHold)
+    {
+      if (!m_bAbortRequest && !m_audioFormatHoldTimer.IsTimePast() && !m_audioChainReady.load())
+      {
+        // Published from here: this guard skips the UpdatePlayState below it.
+        UpdatePlayState(200);
+        CThread::Sleep(50ms);
+        continue;
+      }
+      ReleaseAudioFormatHold();
+    }
+
     // check if in an edit (cut or commercial break) that should be automatically skipped
     CheckAutoSceneSkip();
 
@@ -2893,6 +2908,9 @@ void CVideoPlayer::OnExit()
 {
   CLog::Log(LOGINFO, "CVideoPlayer::OnExit()");
 
+  // The loop can exit on abort without reaching the release in it.
+  ReleaseAudioFormatHold();
+
   // set event to inform openfile something went wrong in case openfile is still waiting for this event
   SetCaching(CACHESTATE_DONE);
 
@@ -3543,6 +3561,10 @@ void CVideoPlayer::HandleMessages()
     {
       if (std::static_pointer_cast<CDVDMsgGeneralSynchronize>(pMsg)->Wait(100ms, SYNCSOURCE_PLAYER))
         CLog::Log(LOGDEBUG, "CVideoPlayer - CDVDMsg::GENERAL_SYNCHRONIZE");
+    }
+    else if (pMsg->IsType(CDVDMsg::PLAYER_AUDIO_FORMAT_CHANGE))
+    {
+      HoldForAudioFormatChange();
     }
     else if (pMsg->IsType(CDVDMsg::PLAYER_AVCHANGE))
     {
@@ -5793,7 +5815,7 @@ void CVideoPlayer::UpdatePlayState(double timeout)
 
   CServiceBroker::GetDataCacheCore().SetChapters(chapters);
 
-  if (m_caching > CACHESTATE_DONE && m_caching < CACHESTATE_PLAY)
+  if ((m_caching > CACHESTATE_DONE && m_caching < CACHESTATE_PLAY) || m_audioFormatHold)
     state.caching = true;
   else
     state.caching = false;
@@ -5812,6 +5834,14 @@ void CVideoPlayer::UpdatePlayState(double timeout)
     state.cache_level = std::min(1.0, queueTime / (m_messageQueueTimeSize * 1000.0));
     state.cache_offset = queueTime / state.timeMax;
     state.cache_time = queueTime / 1000.0;
+  }
+
+  if (m_audioFormatHold)
+  {
+    const double total =
+        static_cast<double>(m_audioFormatHoldTimer.GetInitialTimeoutValue().count());
+    const double left = static_cast<double>(m_audioFormatHoldTimer.GetTimeLeft().count());
+    state.cache_level = total > 0.0 ? std::max(0.01, std::min(1.0, 1.0 - left / total)) : 1.0;
   }
 
   XFILE::SCacheStatus status;
@@ -6026,11 +6056,80 @@ void CVideoPlayer::OnResetDisplay()
     return;
 
   CLog::Log(LOGINFO, "VideoPlayer: OnResetDisplay received");
+  m_displayLost = false;
+
+  // The format hold still wants playback down, and releases it itself
+  if (!m_audioFormatHold)
+  {
+    m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_PAUSE, false),
+                                    1);
+    m_VideoPlayerVideo->SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_PAUSE, false),
+                                    1);
+    m_clock.Pause(false);
+  }
+  m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_DISPLAY_RESET), 1);
+}
+
+void CVideoPlayer::HoldForAudioFormatChange()
+{
+  const int tenths = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_AUDIOOUTPUT_DELAYFORMATCHANGE);
+  if (tenths <= 0)
+    return;
+
+  // A further change during a hold restarts it: the chain has a new format to acquire, and the
+  // time already served was spent on the previous one.
+  m_audioChainReady = false;
+  m_audioFormatHoldTimer.Set(std::chrono::milliseconds(tenths * 100));
+  if (m_audioFormatHold)
+    return;
+
+  CLog::Log(LOGINFO, "VideoPlayer: holding playback {:.1f}s for the audio format change",
+            static_cast<double>(tenths) / 10.0);
+
+  if (m_VideoPlayerAudio->IsInited())
+    m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_PAUSE, true), 1);
+  if (m_VideoPlayerVideo->IsInited())
+    m_VideoPlayerVideo->SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_PAUSE, true), 1);
+  m_clock.Pause(true);
+
+  m_audioFormatHold = true;
+
+  // Opened without the render loop: the blocking form would not return.
+  CGUIDialog* busy = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusyNoCancel>(
+      WINDOW_DIALOG_BUSY_NOCANCEL);
+  if (busy)
+    busy->Open(false);
+}
+
+void CVideoPlayer::ReleaseAudioFormatHold()
+{
+  if (!m_audioFormatHold)
+    return;
+
+  const bool early = m_audioChainReady.load();
+  CLog::Log(LOGINFO, "VideoPlayer: audio format hold released after {:.1f}s ({})",
+            static_cast<double>((m_audioFormatHoldTimer.GetInitialTimeoutValue() -
+                                 m_audioFormatHoldTimer.GetTimeLeft())
+                                    .count()) /
+                1000.0,
+            early ? "chain reported ready" : "timed out");
   m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_PAUSE, false), 1);
   m_VideoPlayerVideo->SendMessage(std::make_shared<CDVDMsgBool>(CDVDMsg::GENERAL_PAUSE, false), 1);
   m_clock.Pause(false);
-  m_displayLost = false;
-  m_VideoPlayerAudio->SendMessage(std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_DISPLAY_RESET), 1);
+  m_audioFormatHold = false;
+  m_audioChainReady = false;
+
+  CGUIDialog* busy = CServiceBroker::GetGUI()->GetWindowManager().GetWindow<CGUIDialogBusyNoCancel>(
+      WINDOW_DIALOG_BUSY_NOCANCEL);
+  if (busy)
+    busy->Close();
+}
+
+void CVideoPlayer::NotifyAudioChainReady()
+{
+  if (!m_audioChainReady.exchange(true))
+    CLog::Log(LOGINFO, "VideoPlayer: audio chain reported ready");
 }
 
 void CVideoPlayer::UpdateFileItemStreamDetails(CFileItem& item, UpdateStreamDetails update)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -386,6 +386,19 @@ public:
   void OnLostDisplay() override;
   void OnResetDisplay() override;
 
+  /*!
+   \brief Hold presentation while a passthrough format change settles downstream
+
+   Opening a passthrough stream re-trains the HDMI link. On a chain with a matrix
+   or an AV processor in it the picture and sound can take many seconds to return,
+   and playback runs on regardless — the opening of the film is neither seen nor
+   heard. This is the audio-side counterpart of videoscreen.delayrefreshchange,
+   which only ever arms on a display mode change.
+   */
+  void HoldForAudioFormatChange();
+  void ReleaseAudioFormatHold();
+  void NotifyAudioChainReady() override;
+
   bool IsCaching() const override;
   int GetCacheLevel() const override;
 
@@ -562,6 +575,11 @@ protected:
 
   ECacheState  m_caching;
   XbmcThreads::EndTime<> m_cachingTimer;
+
+  //! Atomic: set on the player thread, read by OnResetDisplay on the windowing thread.
+  std::atomic<bool> m_audioFormatHold{false};
+  XbmcThreads::EndTime<> m_audioFormatHoldTimer;
+  std::atomic<bool> m_audioChainReady{false};
 
   std::unique_ptr<CProcessInfo> m_processInfo;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.cpp
@@ -350,6 +350,7 @@ void CVideoPlayerAudio::Process()
       m_stalled = true;
       m_audioClock = 0;
       audioframe.nb_frames = 0;
+      m_holdPending = false;
 
       if (sync)
       {
@@ -523,6 +524,13 @@ bool CVideoPlayerAudio::ProcessDecoderOutput(DVDAudioFrame &audioframe)
 
       if (!m_audioSink.Create(audioframe, m_streaminfo.codec, m_synctype == SYNC_RESAMPLE))
         CLog::Log(LOGERROR, "{} - failed to create audio renderer", __FUNCTION__);
+      else
+      {
+        // Armed here, resolved once real audio has reached the sink: whether the wire format
+        // changed is the engine's to answer, and it has not configured the sink yet.
+        m_holdPending = true;
+        m_holdDelivered = 0.0;
+      }
 
       m_prevsynctype = -1;
 
@@ -563,6 +571,20 @@ bool CVideoPlayerAudio::ProcessDecoderOutput(DVDAudioFrame &audioframe)
   m_audioClock += audioframe.duration * ((double)framesOutput / audioframe.nb_frames);
 
   audioframe.framesOut += framesOutput;
+
+  // INSYNC, not AddPackets: the sink is paused until the player syncs.
+  if (m_holdPending && m_syncState == IDVDStreamPlayer::SYNC_INSYNC && framesOutput > 0 &&
+      audioframe.nb_frames > 0)
+  {
+    m_holdDelivered +=
+        audioframe.duration * (static_cast<double>(framesOutput) / audioframe.nb_frames);
+    if (m_holdDelivered >= DVD_MSEC_TO_TIME(250))
+    {
+      m_holdPending = false;
+      if (m_audioSink.HasSinkFormatChanged())
+        m_messageParent.Put(std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_AUDIO_FORMAT_CHANGE));
+    }
+  }
 
   // signal to our parent that we have initialized
   if (m_syncState == IDVDStreamPlayer::SYNC_STARTING)

--- a/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayerAudio.h
@@ -104,6 +104,9 @@ protected:
   int m_synctype;
   int m_prevsynctype;
 
+  bool m_holdPending{false};
+  double m_holdDelivered{0.0};
+
   bool   m_prevskipped;
   double m_maxspeedadjust;
 

--- a/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
+++ b/xbmc/interfaces/json-rpc/JSONServiceDescription.cpp
@@ -63,6 +63,7 @@ JsonRpcMethodMap CJSONServiceDescription::m_methodMaps[] = {
   { "Player.Stop",                                  CPlayerOperations::Stop },
   { "Player.GetAudioDelay",                         CPlayerOperations::GetAudioDelay },
   { "Player.SetAudioDelay",                         CPlayerOperations::SetAudioDelay },
+  { "Player.NotifyAudioChainReady",                 CPlayerOperations::NotifyAudioChainReady },
   { "Player.SetSpeed",                              CPlayerOperations::SetSpeed },
   { "Player.SetTempo",                              CPlayerOperations::SetTempo },
   { "Player.Seek",                                  CPlayerOperations::Seek },

--- a/xbmc/interfaces/json-rpc/PlayerOperations.cpp
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.cpp
@@ -427,6 +427,17 @@ JSONRPC_STATUS CPlayerOperations::GetAudioDelay(const std::string& method,
   return OK;
 }
 
+JSONRPC_STATUS CPlayerOperations::NotifyAudioChainReady(const std::string& method,
+                                                        ITransportLayer* transport,
+                                                        IClient* client,
+                                                        const CVariant& parameterObject,
+                                                        CVariant& result)
+{
+  auto& components = CServiceBroker::GetAppComponents();
+  components.GetComponent<CApplicationPlayer>()->NotifyAudioChainReady();
+  return ACK;
+}
+
 JSONRPC_STATUS CPlayerOperations::SetAudioDelay(const std::string& method,
                                                 ITransportLayer* transport,
                                                 IClient* client,

--- a/xbmc/interfaces/json-rpc/PlayerOperations.h
+++ b/xbmc/interfaces/json-rpc/PlayerOperations.h
@@ -61,6 +61,11 @@ namespace JSONRPC
                                         IClient* client,
                                         const CVariant& parameterObject,
                                         CVariant& result);
+    static JSONRPC_STATUS NotifyAudioChainReady(const std::string& method,
+                                                ITransportLayer* transport,
+                                                IClient* client,
+                                                const CVariant& parameterObject,
+                                                CVariant& result);
     static JSONRPC_STATUS SetSpeed(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant &parameterObject, CVariant &result);
     static JSONRPC_STATUS SetTempo(const std::string& method,
                                    ITransportLayer* transport,

--- a/xbmc/interfaces/json-rpc/schema/methods.json
+++ b/xbmc/interfaces/json-rpc/schema/methods.json
@@ -579,6 +579,14 @@
     ],
     "returns": "string"
   },
+  "Player.NotifyAudioChainReady": {
+    "type": "method",
+    "description": "Report that the downstream audio chain has finished settling, releasing a playback hold early. Intended for an add-on that can observe an AV processor or receiver directly; ignored when nothing is holding",
+    "transport": "Response",
+    "permission": "ControlPlayback",
+    "params": [],
+    "returns": "string"
+  },
   "Player.GetAudioDelay": {
     "type": "method",
     "description": "Get the audio delay for the current playback",

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -409,6 +409,7 @@ public:
   static constexpr auto SETTING_AUDIOOUTPUT_ATEMPOTHRESHOLD = "audiooutput.atempothreshold";
   static constexpr auto SETTING_AUDIOOUTPUT_STREAMSILENCE = "audiooutput.streamsilence";
   static constexpr auto SETTING_AUDIOOUTPUT_STREAMNOISE = "audiooutput.streamnoise";
+  static constexpr auto SETTING_AUDIOOUTPUT_DELAYFORMATCHANGE = "audiooutput.delayformatchange";
   static constexpr auto SETTING_AUDIOOUTPUT_MIXSUBLEVEL = "audiooutput.mixsublevel";
   static constexpr auto SETTING_AUDIOOUTPUT_GUISOUNDMODE = "audiooutput.guisoundmode";
   static constexpr auto SETTING_AUDIOOUTPUT_GUISOUNDVOLUME = "audiooutput.guisoundvolume";


### PR DESCRIPTION
**TL;DR:** New feature, off by default. Two advanced audio settings hold playback until the chain downstream has acquired a new audio format, with an optional silence filler that keeps the receiver locked, and `Player.NotifyAudioChainReady` lets a hardware add-on end the hold early.

## Description
Holds playback while the audio chain downstream of Kodi acquires a new format, so the opening of a film is not played into a processor that is not yet decoding.

Two settings, both advanced level, both off by default:

- **`audiooutput.delayformatchange`** — the longest playback may be held. `0` disables the feature.
- **`audiooutput.silencefiller`** — keeps the stream's own last burst on the wire during the hold. A pause burst is non-audio, so a receiver drops decode and re-acquires when real audio returns, which is what the hold exists to prevent. Re-emitting the last real burst needs no encoder, so every pass-through format works.

The hold starts once real audio has reached the sink, not at sink open — until frames are on the wire there is nothing downstream to acquire. It ends on whichever comes first: something reporting the chain ready, or the time expiring. It reports as caching, so skins already show it.

Whether the wire format actually changed is the audio engine's question rather than the player's, so the player asks it. `CActiveAE::Configure()` already computes it when deciding to reinitialise the sink, and that answer is now surfaced on `IAEStream`. A source sample rate change that a fixed output configuration absorbs therefore never reaches the wire, and correctly does not hold.

`Player.NotifyAudioChainReady` (JSON-RPC) ends a hold early.

## Motivation and context
`videoscreen.delayrefreshchange` exists because changing display mode re-trains the HDMI link, and Kodi waits for it. There is no audio equivalent, yet opening a new audio format is also a change on the wire. An AVR, processor or matrix takes seconds to acquire it and Kodi plays on through that silence, so the first seconds of a film are lost.

### How an add-on works alongside this

Kodi cannot detect when the chain is ready — that means speaking a particular processor's own control protocol, which does not belong in the player. So this PR is the mechanism, and detection lives in a companion add-on.

A small service add-on covers one make of hardware and does two things:

1. **Sets the bound.** The add-on author knows what their hardware needs, so the add-on writes `audiooutput.delayformatchange` itself through `Settings.SetSettingValue`. The user never configures this by hand, or needs to know the setting exists.
2. **Ends the wait.** It watches the device however that vendor allows, and calls `Player.NotifyAudioChainReady` when the device reports lock.

The number is therefore both the add-on's working window and its own failsafe: if the add-on stops answering — crashed, device unplugged, a bug in its detection — playback still resumes when the time expires. The feature cannot hang playback, which is why the bound is not optional.

A user installs the one add-on matching their kit, or none. With one, the wait is as short as the hardware allows; on the chain this was developed against, a 15s bound is released at about 2.5s. Without one, the bound is simply a fixed wait — the same shape as the video setting above.

## How has this been tested?
Developed and used against a Trinnov processor, a projector and an HDMI matrix, with a companion add-on for the Trinnov releasing the hold on lock. Confirmed by ear that the opening of a title survives a pass-through format change with the hold on and is lost with it off, and that the filler keeps the receiver locked across the wait. Also run with no add-on installed, to confirm the bound expires and playback resumes, and at `0` to confirm nothing changes.

Full gtest suite passes, 3781 tests, Windows x64.

Five unit tests cover the burst repetition in `CAEBitstreamPacker`, including that repeating a burst does not strand the next pause of the same length — the interaction between the new code and `PackPause` reusing its buffer. The engine's sink-change reporting and the hold's behaviour across display loss are not unit tested: both need a live audio engine or a running player rather than a fixture.

## What is the effect on users?
None by default — `audiooutput.delayformatchange` is `0`, and no code path changes while it is.

Users whose AV processor or receiver takes time to lock on to a new audio format can stop losing the start of a film, either by setting the bound themselves or by installing an add-on for their hardware that sets it for them.

Adds `Player.NotifyAudioChainReady` to the JSON-RPC API and bumps the schema minor version.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
