### PR TITLE
[RetroPlayer] Shaders: Skip redundant parameter resolution

### DIFF
--- a/xbmc/addons/ShaderPreset.cpp
+++ b/xbmc/addons/ShaderPreset.cpp
@@ -127,11 +127,8 @@ bool CShaderPresetAddon::LoadPreset(const std::string& presetPath,
     video_shader videoShader = {};
     if (shaderPresetAddon->ReadShaderPreset(videoShader))
     {
-      if (shaderPresetAddon->ResolveParameters(videoShader))
-      {
-        TranslateShaderPreset(videoShader, shaderPreset);
-        bSuccess = true;
-      }
+      TranslateShaderPreset(videoShader, shaderPreset);
+      bSuccess = true;
       shaderPresetAddon->FreeShaderPreset(videoShader);
     }
   }


### PR DESCRIPTION
## Description

This PR skips redundant parameter resolution when loading shader presets.

## Motivation and context

Partially fixes https://github.com/xbmc/xbmc/issues/28997

## How has this been tested?

Adding to next round of test builds.

## What is the effect on users?

* Fixed ignored shader paramters

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
