### PR TITLE
Game API 7.1.0: tell a game client the speed it is running at

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
@@ -408,6 +408,34 @@ public:
   //----------------------------------------------------------------------------
 
   //============================================================================
+  /// @brief **Callback to Kodi Function**\n
+  /// Get the speed the game is being played back at
+  ///
+  /// @return The speed as a multiple of normal speed
+  ///
+  /// The value is the same one Kodi shows the user, so it follows the player's
+  /// fast-forward and rewind semantics:
+  ///
+  ///   - `1.0` is normal speed
+  ///   - `0.0` is paused
+  ///   - greater than `1.0` is fast-forward
+  ///   - between `0.0` and `1.0` is slow motion
+  ///   - less than `0.0` is rewind
+  ///
+  /// Rewind is driven by Kodi replaying saved states, so a client is run
+  /// forwards even while the speed is negative. A client that changes its
+  /// behaviour with the speed should read the sign as "the user is going
+  /// backwards", not as a direction to run in.
+  ///
+  /// @remarks Only called from the add-on itself
+  ///
+  double KodiGetPlaybackSpeed()
+  {
+    return m_instanceData->toKodi->GetPlaybackSpeed(m_instanceData->toKodi->kodiInstance);
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
   /// @defgroup cpp_kodi_addon_game_Operation_CStream Class: CStream
   /// @ingroup cpp_kodi_addon_game_Operation
   /// @brief @cpp_class{ kodi::addon::CInstanceGame::CStream }

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
@@ -1227,6 +1227,7 @@ extern "C"
 
     bool (*EnableHardwareRendering)(void*, const game_hw_rendering_properties*);
     void (*CloseGame)(KODI_HANDLE kodiInstance);
+    double (*GetPlaybackSpeed)(KODI_HANDLE kodiInstance);
     KODI_GAME_STREAM_HANDLE (*OpenStream)(KODI_HANDLE, const struct game_stream_properties*);
     bool (*GetStreamBuffer)(KODI_HANDLE,
                             KODI_GAME_STREAM_HANDLE,

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -97,8 +97,8 @@
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_DEPENDS   "c-api/addon-instance/audioencoder.h" \
                                                       "addon-instance/AudioEncoder.h"
 
-#define ADDON_INSTANCE_VERSION_GAME                   "7.0.0"
-#define ADDON_INSTANCE_VERSION_GAME_MIN               "7.0.0"
+#define ADDON_INSTANCE_VERSION_GAME                   "7.1.0"
+#define ADDON_INSTANCE_VERSION_GAME_MIN               "7.1.0"
 #define ADDON_INSTANCE_VERSION_GAME_XML_ID            "kodi.binary.instance.game"
 #define ADDON_INSTANCE_VERSION_GAME_DEPENDS           "addon-instance/Game.h"
 

--- a/xbmc/cores/RetroPlayer/RetroPlayer.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.cpp
@@ -663,6 +663,12 @@ void CRetroPlayer::OnSpeedChange(double newSpeed)
   m_input->SetSpeed(newSpeed);
   m_renderManager->SetSpeed(newSpeed);
   m_processInfo->SetSpeed(static_cast<float>(newSpeed));
+
+  // Told rather than asked, because a client can ask for this from any thread
+  // and at any point inside a call of its own, where reaching back into the
+  // player would mean locking against the thread that is driving it.
+  if (m_gameClient)
+    m_gameClient->SetPlaybackSpeed(newSpeed);
 }
 
 void CRetroPlayer::CreatePlayback(const std::string& savestatePath)

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -173,6 +173,7 @@ bool CGameClient::Initialize(void)
   m_ifc.game->toKodi->kodiInstance = this;
   m_ifc.game->toKodi->EnableHardwareRendering = cb_enable_hardware_rendering;
   m_ifc.game->toKodi->CloseGame = cb_close_game;
+  m_ifc.game->toKodi->GetPlaybackSpeed = cb_get_playback_speed;
   m_ifc.game->toKodi->OpenStream = cb_open_stream;
   m_ifc.game->toKodi->GetStreamBuffer = cb_get_stream_buffer;
   m_ifc.game->toKodi->AddStreamData = cb_add_stream_data;
@@ -701,6 +702,15 @@ void CGameClient::cb_close_game(KODI_HANDLE kodiInstance)
 {
   CServiceBroker::GetAppMessenger()->PostMsg(TMSG_GUI_ACTION, WINDOW_INVALID, -1,
                                              static_cast<void*>(new CAction(ACTION_STOP)));
+}
+
+double CGameClient::cb_get_playback_speed(KODI_HANDLE kodiInstance)
+{
+  CGameClient* gameClient = static_cast<CGameClient*>(kodiInstance);
+  if (!gameClient)
+    return 0.0;
+
+  return gameClient->m_playbackSpeed;
 }
 
 KODI_GAME_STREAM_HANDLE CGameClient::cb_open_stream(KODI_HANDLE kodiInstance,

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -172,6 +172,19 @@ public:
   double GetSampleRate() const { return m_samplerate; }
   void RunFrame();
 
+  /*!
+   * \brief Tell the client what speed the player is running at
+   *
+   * \param speed The speed as a multiple of normal speed, with the player's own
+   *              meaning: 1.0 normal, 0.0 paused, above 1.0 fast-forward,
+   *              between 0.0 and 1.0 slow motion, below 0.0 rewind
+   *
+   * Kept so the client can answer for it when asked. Clients that care use it
+   * to drop work the user will not see at speed, and the audio limiter is the
+   * usual one.
+   */
+  void SetPlaybackSpeed(double speed) { m_playbackSpeed = speed; }
+
   // Access memory
   size_t SerializeSize() const { return m_serializeSize; }
   bool Serialize(uint8_t* data, size_t size);
@@ -210,6 +223,7 @@ private:
   static bool cb_enable_hardware_rendering(void* kodiInstance,
                                            const game_hw_rendering_properties* properties);
   static void cb_close_game(KODI_HANDLE kodiInstance);
+  static double cb_get_playback_speed(KODI_HANDLE kodiInstance);
   static KODI_GAME_STREAM_HANDLE cb_open_stream(KODI_HANDLE kodiInstance,
                                                 const game_stream_properties* properties);
   static bool cb_get_stream_buffer(KODI_HANDLE kodiInstance,
@@ -261,6 +275,17 @@ private:
   // Properties of the current playing file
   std::atomic_bool m_bIsPlaying; // True between OpenFile() and CloseFile()
   std::atomic_bool m_hasFrameRun{false};
+  // The speed the player is running at, as a multiple of normal speed. Written
+  // by the thread that changes the speed and read by the client's own, so it is
+  // atomic; a client asks for it from inside a call of its own, which can be on
+  // any thread.
+  //
+  // Starts at normal speed rather than zero because clients ask this while
+  // loading, before the player has set a speed for the first time, and the
+  // honest answer to "am I being fast-forwarded" at that point is no. Zero
+  // would read as paused and have a client behave as though the user had
+  // stopped the game before it started.
+  std::atomic<double> m_playbackSpeed{1.0};
   std::string m_gamePath;
   bool m_bRequiresGameLoop = false;
   size_t m_serializeSize = 0;


### PR DESCRIPTION
## Description

A game client has no way to find out that the user is fast-forwarding or rewinding. Speed reaches the stream manager, the input handler, the render manager and the process info, and stops there — nothing reaches the client.

This adds `GetPlaybackSpeed()` to the callbacks a client can make, carrying the player's own semantics:

| Value | Meaning |
|---|---|
| `1.0` | normal |
| `0.0` | paused |
| `> 1.0` | fast-forward |
| `0.0` – `1.0` | slow motion |
| `< 0.0` | rewind |

## Motivation and context

Clients that emulate a console want this. The libretro API has cores ask their frontend whether it is fast-forwarding, and they use the answer to drop work the user will not see and, more often, to decide whether to hold audio to real time.

A wrapper add-on asked that question by Kodi today has nothing to answer with, so it has to guess. Guessing wrong is not a small matter: Flycast does

```c
if (settings.rend.ThreadedRendering)
  if (environ_cb(RETRO_ENVIRONMENT_GET_FASTFORWARDING, &fastforward))
    settings.aica.LimitFPS = !fastforward;
```

and leaves `LimitFPS` at `0` if the call is declined, which makes it skip every audio flush. Dreamcast games were silent and ran at roughly double speed. That was worked around in kodi-game/game.libretro#167 by answering a flat "no", and @garbear rightly pointed out that Kodi does have fast-forward and rewind, so a flat "no" is just a better-behaved guess. This is the honest answer.

Rewind is documented explicitly, because it is the part that misleads: Kodi rewinds by replaying saved states around a client that only knows how to run forwards. A negative speed means "the user is going backwards", not "run backwards".

## Design notes

The value is pushed into the client on the existing speed change rather than pulled back through the player. A client can ask for this from any thread and from inside a call of its own, where reaching back into the player would mean locking against the thread driving it. `CRetroPlayer::OnSpeedChange()` already fans out to four subsystems; this is a fifth.

It starts at normal speed rather than zero, because clients ask while loading, before the player has set a speed for the first time. Zero would read as paused and have a client behave as though the user had stopped the game before it started.

## Compatibility

Appended to `AddonToKodiFuncTable_Game`, so every offset an existing add-on binary was built against is unchanged. The game instance version moves to **7.1.0** with `_MIN` left at **7.0.0** — clients built against 7.0.0 keep loading and simply never make the call.

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change**

## Testing

Built and ran on Linux (GBM and Wayland). The paired add-on change is kodi-game/game.libretro#167, which was built against this branch and answers both `GET_FASTFORWARDING` and `GET_THROTTLE_STATE` from the value.
