### PR TITLE
[Linux] kodi.desktop: add Russian translations

### DIFF
--- a/tools/Linux/kodi.desktop.in
+++ b/tools/Linux/kodi.desktop.in
@@ -2,6 +2,7 @@
 Version=1.0
 Name=@APP_NAME@
 GenericName=Media Center
+GenericName[ru]=Медиацентр
 GenericName[zh_CN]=媒体中心
 Comment=Manage and view your media
 Comment[ru]=Просмотр и управление мультимедиа
@@ -16,10 +17,12 @@ Actions=Fullscreen;Standalone;
 
 [Desktop Action Fullscreen]
 Name=Open in fullscreen
+Name[ru]=Открыть в полноэкранном режиме
 Name[zh_CN]=全屏打开
 Exec=@APP_NAME_LC@ -fs
 
 [Desktop Action Standalone]
 Name=Open in standalone mode
+Name[ru]=Открыть в режиме standalone
 Name[zh_CN]=在独立模式下打开
 Exec=@APP_NAME_LC@ --standalone


### PR DESCRIPTION
## Description

`tools/Linux/kodi.desktop.in` already has a Russian `Comment`, but nothing else,
so on a Russian desktop the menu entry shows a mix of two languages: the comment
is translated while the generic name and both context-menu actions stay English.

This fills the three gaps, next to the existing Chinese lines:

* `GenericName[ru]=Медиацентр`
* action Fullscreen — `Name[ru]=Открыть в полноэкранном режиме`
* action Standalone — `Name[ru]=Открыть в режиме standalone`

For the wording I followed Kodi's own Russian catalogue: `#9` renders "Kodi media
center" as "Медиацентр Kodi" and `#35232` renders "Fullscreen" as "Полноэкранный
режим".

"standalone" is deliberately left in Latin. It is the name of a run mode tied to
the `--standalone` switch, and the ru catalogue translates "Standalone games" as
"Оффлайн игры" — which would read as "offline" here and mislead people.
If a Russian-speaking maintainer prefers a fully translated wording, I'm happy
to change it.

## How has this been tested?

Substituted `@APP_NAME@`/`@APP_NAME_LC@` and ran `desktop-file-validate` on the
result — clean. Then read the entry through `Gio.DesktopAppInfo` under
`LANG=ru_RU.UTF-8`: name Kodi, generic name "Медиацентр", both actions Russian.
Under `LANG=C` the output is byte-for-byte what it was before.

## What is the effect on users?

Russian users get a consistent menu entry instead of a half-translated one.

## Types of change
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)
