### PR TITLE
[Video] Fix unchanged disc stacks can be rescraped (v2) and non-first folder stack part changes are ignored by the scraper.

### DIFF
--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -24,6 +24,7 @@
 #include "utils/Archive.h"
 #include "utils/ArtUtils.h"
 #include "utils/Crc32.h"
+#include "utils/Digest.h"
 #include "utils/FileExtensionProvider.h"
 #include "utils/Random.h"
 #include "utils/RegExp.h"
@@ -39,6 +40,7 @@
 #include <vector>
 
 using namespace KODI;
+using KODI::UTILITY::CDigest;
 using namespace XFILE;
 
 CFileItemList::CFileItemList() : CFileItem("", true)
@@ -860,6 +862,22 @@ void CFileItemList::Stack()
     baseItem->SetPath(stackPath);
     baseItem->SetLabel(stackName);
     baseItem->SetSize(size);
+
+    // Record a digest of every part so that a change to any part is recognised in the scraper
+    CDigest partsDigest{CDigest::Type::MD5};
+    for (const int i : stack)
+    {
+      const auto& part{Get(i)};
+      partsDigest.Update(part->GetPath());
+
+      const int64_t partSize{part->GetSize()};
+      partsDigest.Update(&partSize, sizeof(partSize));
+
+      time_t partTime{0};
+      part->GetDateTime().GetAsTime(partTime);
+      partsDigest.Update(&partTime, sizeof(partTime));
+    }
+    baseItem->SetProperty(PROPERTY_STACK_DIGEST, partsDigest.Finalize());
   }
 
   // Delete unneeded items

--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -27,6 +27,10 @@
 //! the stored hash; Stack() skips the disc structure probes for such folders
 static constexpr const char* PROPERTY_UNCHANGED{"scanner:unchanged"};
 
+//! item property set by Stack() on a stack: a digest of what each of its parts is,
+//! to allow the scraper to detect changes to any part
+static constexpr const char* PROPERTY_STACK_DIGEST{"scanner:stackdigest"};
+
 /*!
   \brief Represents a list of files
   \sa CFileItemList, CFileItem

--- a/xbmc/filesystem/StackDirectory.cpp
+++ b/xbmc/filesystem/StackDirectory.cpp
@@ -239,6 +239,62 @@ std::string CStackDirectory::GetParentPath(const std::string& stackPath)
   return GetBasePath(stackPath);
 }
 
+namespace
+{
+// Whether a path refers to a disc (bluray://, VIDEO_TS, BDMV, or disc image)
+bool IsDiscPart(const std::string& path)
+{
+  return URIUtils::IsBlurayPath(path) || URIUtils::IsBDFile(path) || URIUtils::IsDVDFile(path) ||
+         URIUtils::IsDiscImage(path);
+}
+
+} // unnamed namespace
+
+bool CStackDirectory::HasDiscPart(const std::string& stackPath)
+{
+  std::vector<std::string> paths;
+  if (!URIUtils::IsStack(stackPath) || !GetPaths(stackPath, paths))
+    return false;
+
+  return std::ranges::any_of(paths, IsDiscPart);
+}
+
+bool CStackDirectory::IsSameDiscStack(const std::string& stackPath,
+                                      const std::string& otherStackPath)
+{
+  std::vector<std::string> paths;
+  std::vector<std::string> otherPaths;
+  if (!URIUtils::IsStack(stackPath) || !URIUtils::IsStack(otherStackPath) ||
+      !GetPaths(stackPath, paths) || !GetPaths(otherStackPath, otherPaths) || paths.empty() ||
+      paths.size() != otherPaths.size())
+    return false;
+
+  for (size_t part{0}; part < paths.size(); ++part)
+  {
+    const std::string& path{paths[part]};
+    const std::string& otherPath{otherPaths[part]};
+
+    // A disc is compared as a disc and not as a path
+    if (IsDiscPart(path) && IsDiscPart(otherPath))
+    {
+      if (!URIUtils::CompareDiscPaths(path, otherPath))
+        return false;
+
+      // When both sides name a playlist it has to be the same one
+      if (URIUtils::IsBlurayPath(path) && URIUtils::IsBlurayPath(otherPath) &&
+          CURL(path).GetFileName() != CURL(otherPath).GetFileName())
+        return false;
+
+      continue;
+    }
+
+    // Neither is a disc
+    if (!URIUtils::PathEquals(path, otherPath, true, true))
+      return false;
+  }
+  return true;
+}
+
 std::string CStackDirectory::GetBasePath(const std::string& stackPath)
 {
   std::vector<std::string> paths;

--- a/xbmc/filesystem/StackDirectory.h
+++ b/xbmc/filesystem/StackDirectory.h
@@ -76,6 +76,22 @@ namespace XFILE
                                    const std::string& newPath = {});
 
     /*!
+    \brief Whether any part of a stack:// path names a disc - a disc structure
+    (BDMV/index.bdmv, VIDEO_TS/VIDEO_TS.IFO), a disc image, or a bluray:// playlist of one.
+    \param stackPath The stack:// path
+    \return True if at least one part names a disc, false otherwise
+    */
+    static bool HasDiscPart(const std::string& stackPath);
+
+    /*!
+    \brief Whether two stack:// paths describe the same movie on the same discs
+    \param stackPath The stack:// path
+    \param otherStackPath The stack:// path to compare it with
+    \return True if both describe the same movie, false otherwise
+    */
+    static bool IsSameDiscStack(const std::string& stackPath, const std::string& otherStackPath);
+
+    /*!
     \brief Get the base/parent path in common from all the parts of a stack:// path
     \param stackPath The stack:// path
     \return The base/parent path

--- a/xbmc/test/TestFileItem.cpp
+++ b/xbmc/test/TestFileItem.cpp
@@ -25,6 +25,8 @@
 #include "video/VideoInfoTag.h"
 
 #include <fstream>
+#include <tuple>
+#include <utility>
 
 #include <gtest/gtest.h>
 
@@ -1197,6 +1199,50 @@ INSTANTIATE_TEST_SUITE_P(EpisodeLabel,
                          ValuesIn(EpisodeLabelCases),
                          [](const testing::TestParamInfo<EpisodeLabelTestCase>& info)
                          { return info.param.testName; });
+
+TEST(TestFileItemList, StackRecordsWhatItsPartsAre)
+{
+  // Nothing is read from disc here: a part naming a disc structure stacks on its label alone
+  const auto digestOf = [](const CDateTime& firstDate, int64_t firstSize,
+                           const CDateTime& secondDate, int64_t secondSize)
+  {
+    CFileItemList items(R"(D:\Movies\)");
+    for (const auto& [name, date, size] : {std::tuple{"movie_part1", firstDate, firstSize},
+                                           std::tuple{"movie_part2", secondDate, secondSize}})
+    {
+      auto item = std::make_shared<CFileItem>(
+          std::string{R"(D:\Movies\)"} + name + R"(\VIDEO_TS.IFO)", false);
+      item->SetLabel(name);
+      item->SetDateTime(date);
+      item->SetSize(size);
+      items.Add(std::move(item));
+    }
+    items.Stack();
+
+    EXPECT_EQ(items.Size(), 1);
+    return items.Size() == 1 ? items[0]->GetProperty(PROPERTY_STACK_DIGEST).asString() : "";
+  };
+
+  const CDateTime older{2020, 1, 1, 0, 0, 0};
+  const CDateTime middle{2023, 1, 1, 0, 0, 0};
+  const CDateTime newer{2026, 1, 1, 0, 0, 0};
+
+  const std::string stack{digestOf(newer, 100, older, 100)};
+  EXPECT_FALSE(stack.empty());
+
+  // the same parts always describe the same stack
+  EXPECT_EQ(digestOf(newer, 100, older, 100), stack);
+
+  // the stack takes the date and the total size of its first part, so neither a part that has
+  // changed without becoming the newest..
+  EXPECT_NE(digestOf(newer, 100, middle, 100), stack);
+
+  // ..nor one that has changed without altering the total may look the same
+  EXPECT_NE(digestOf(newer, 90, older, 110), stack);
+
+  // a change to the first part is of course seen as well
+  EXPECT_NE(digestOf(middle, 100, older, 100), stack);
+}
 
 TEST(TestFileItemList, StackSkipsUnchangedFolders)
 {

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -836,11 +836,67 @@ int CVideoDatabase::GetFileId(const std::string& strFilenameAndPath)
         m_pDS->close();
         return idFile;
       }
+      m_pDS->close();
+
+      // A stack of discs may be stored as bluray:// playlists but the scanner
+      // may pass a stack:// with the base paths
+      return GetDiscStackFileId(strFilenameAndPath);
     }
   }
   catch (...)
   {
     CLog::LogF(LOGERROR, "({}) failed", strFilenameAndPath);
+  }
+  return -1;
+}
+
+int CVideoDatabase::GetDiscStackFileId(const std::string& stackPath)
+{
+  if (!URIUtils::IsStack(stackPath) || !CStackDirectory::HasDiscPart(stackPath))
+    return -1;
+
+  try
+  {
+    if (!m_pDB || !m_pDS)
+      return -1;
+
+    std::string strPath;
+    std::string strFileName;
+    SplitPath(stackPath, strPath, strFileName);
+    const int idPath{GetPathId(strPath)};
+    if (idPath < 0)
+      return -1;
+
+    // All forms of a folder stack reduce to the same base path
+    m_pDS->query(PrepareSQL("SELECT idFile, strFileName FROM files "
+                            "WHERE idPath=%i AND strFileName LIKE 'stack://%%'",
+                            idPath));
+    int idFile{-1};
+    int matches{0};
+    while (!m_pDS->eof())
+    {
+      if (CStackDirectory::IsSameDiscStack(stackPath, m_pDS->fv(1).get_asString()))
+      {
+        idFile = m_pDS->fv(0).get_asInt();
+        ++matches;
+      }
+      m_pDS->next();
+    }
+    m_pDS->close();
+
+    // If there is more than one match then we cannot be sure which one a stack:// with base paths
+    // is referring to.
+    if (matches > 1)
+    {
+      CLog::LogF(LOGWARNING, "'{}' matches {} stacks of the same discs - none can be chosen",
+                 CURL::GetRedacted(stackPath), matches);
+      return -1;
+    }
+    return idFile;
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "({}) failed", CURL::GetRedacted(stackPath));
   }
   return -1;
 }

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -1081,6 +1081,15 @@ protected:
    */
   int GetFileId(const std::string& url);
 
+  /*! \brief Get the id of a stack of discs, however its parts are expressed.
+   A stack holding a bluray folders or disc images may be stored resolved to the
+   bluray:// playlist of each part, whereas the scraper will be looking for a
+   stack:// of the base paths.
+   \param stackPath a stack:// path of which at least one part is a disc
+   \return id of the file, -1 if it is not in the db or several stacks match.
+   */
+  int GetDiscStackFileId(const std::string& stackPath);
+
   int AddToTable(const std::string& table, const std::string& firstField, const std::string& secondField, const std::string& value);
   int UpdateRatings(int mediaId, const char *mediaType, const RatingMap& values, const std::string& defaultRating);
   int AddRatings(int mediaId,

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -2950,17 +2950,27 @@ CVideoInfoScanner::~CVideoInfoScanner()
       }
       else
       {
-        const int64_t size{pItem->GetSize()};
-        digest.Update(&size, sizeof(size));
         // linux and windows platform don't follow the same output format
         // (linux return a zero value for milliseconds member).
         // for consistency, use less precise format instead which discard
         // milliseconds value.
         // Unless a modification occur during the 1 second window when
         // kodi hash and update this particular file, we are safe.
-        time_t tt{};
-        pItem->GetDateTime().GetAsTime(tt);
-        digest.Update(&tt, sizeof(tt));
+        if (const std::string stackParts{pItem->GetProperty(PROPERTY_STACK_DIGEST).asString()};
+            !stackParts.empty())
+        {
+          // add a digest of every part (calculated in Stack())
+          digest.Update(stackParts);
+        }
+        else
+        {
+          const int64_t size{pItem->GetSize()};
+          digest.Update(&size, sizeof(size));
+
+          time_t tt{};
+          pItem->GetDateTime().GetAsTime(tt);
+          digest.Update(&tt, sizeof(tt));
+        }
       }
       if (IsVideo(*pItem) && !PLAYLIST::IsPlayList(*pItem) && !pItem->IsNFO())
         count++;

--- a/xbmc/video/test/TestStacks.cpp
+++ b/xbmc/video/test/TestStacks.cpp
@@ -243,6 +243,175 @@ TEST_F(TestStacks, TestStackIsNotItselfADiscImage)
   EXPECT_TRUE(CURL(R"(D:\Movies\Movie.iso)").IsDiscImage());
 }
 
+TEST_F(TestStacks, TestStackHasDiscPart)
+{
+  // Any stack holding a disc can be held in the library under a path that differs from the one
+  // listed, as the playlist of each disc is only known once the discs have been scanned. Which
+  // form each part happens to take says nothing about that - a disc image, in particular, names
+  // itself in both forms
+  EXPECT_TRUE(CStackDirectory::HasDiscPart(
+      R"(stack://D:\Movies\Movie_PART1\BDMV\index.bdmv , D:\Movies\Movie_PART2\BDMV\index.bdmv)"));
+  EXPECT_TRUE(
+      CStackDirectory::HasDiscPart(R"(stack://D:\Movies\Movie.CD1.iso , D:\Movies\Movie.CD2.iso)"));
+  EXPECT_TRUE(CStackDirectory::HasDiscPart(
+      R"(stack://D:\Movies\Movie_PART1\VIDEO_TS\VIDEO_TS.IFO , D:\Movies\Movie_PART2\VIDEO_TS\VIDEO_TS.IFO)"));
+  EXPECT_TRUE(CStackDirectory::HasDiscPart(
+      R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00800.mpls , )"
+      R"(bluray://D%3a%5cMovies%5cMovie_PART2%5c/BDMV/PLAYLIST/00801.mpls)"));
+
+  // a mixed stack still holds a disc
+  EXPECT_TRUE(CStackDirectory::HasDiscPart(
+      R"(stack://D:\Movies\Movie_PART1\VIDEO_TS\VIDEO_TS.IFO , D:\Movies\Movie.CD2.iso)"));
+  EXPECT_TRUE(
+      CStackDirectory::HasDiscPart(R"(stack://D:\Movies\Movie.CD1.mkv , D:\Movies\Movie.CD2.iso)"));
+
+  // A stack of ordinary files holds none, and is stored as it is listed
+  EXPECT_FALSE(
+      CStackDirectory::HasDiscPart(R"(stack://D:\Movies\Movie.CD1.mkv , D:\Movies\Movie.CD2.mkv)"));
+  EXPECT_FALSE(CStackDirectory::HasDiscPart(
+      R"(stack://D:\Movies\Movie.part1.mp4 , D:\Movies\Movie.part2.mp4)"));
+
+  // Anything that is not a stack is answered for rather than unwrapped
+  EXPECT_FALSE(CStackDirectory::HasDiscPart(R"(D:\Movies\Movie_PART1\BDMV\index.bdmv)"));
+  EXPECT_FALSE(CStackDirectory::HasDiscPart("D:\\a.iso"));
+  EXPECT_FALSE(CStackDirectory::HasDiscPart(""));
+}
+
+TEST_F(TestStacks, TestStackBasePathIsIndependentOfPlaylistResolution)
+{
+  // A stack of discs is looked up among the rows stored under its base path (see
+  // CVideoDatabase::GetDiscStackFileId), so both forms of one have to reduce to the same base
+  // path or a stack already in the library is not found and is scraped again
+  EXPECT_EQ(
+      CStackDirectory::GetBasePath(
+          R"(stack://D:\Movies\Movie_PART1\BDMV\index.bdmv , D:\Movies\Movie_PART2\BDMV\index.bdmv)"),
+      CStackDirectory::GetBasePath(
+          R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00800.mpls , )"
+          R"(bluray://D%3a%5cMovies%5cMovie_PART2%5c/BDMV/PLAYLIST/00801.mpls)"));
+
+  // ..a stack of disc images, which resolves through udf://
+  EXPECT_EQ(
+      CStackDirectory::GetBasePath(R"(stack://D:\Movies\Movie.CD1.iso , D:\Movies\Movie.CD2.iso)"),
+      CStackDirectory::GetBasePath(
+          R"(stack://bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD1.iso%2f/BDMV/PLAYLIST/01003.mpls , )"
+          R"(bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD2.iso%2f/BDMV/PLAYLIST/01003.mpls)"));
+
+  // ..a rip held in the movie folder itself rather than a folder per part
+  EXPECT_EQ(CStackDirectory::GetBasePath(
+                R"(stack://D:\Movies\Movie\BDMV\index.bdmv , D:\Movies\Movie2\BDMV\index.bdmv)"),
+            CStackDirectory::GetBasePath(
+                R"(stack://bluray://D%3a%5cMovies%5cMovie%5c/BDMV/PLAYLIST/00800.mpls , )"
+                R"(bluray://D%3a%5cMovies%5cMovie2%5c/BDMV/PLAYLIST/00800.mpls)"));
+
+  // ..and a stack whose parts are not all held the same way
+  EXPECT_EQ(
+      CStackDirectory::GetBasePath(
+          R"(stack://D:\Movies\Movie_PART1\BDMV\index.bdmv , D:\Movies\Movie.CD2.iso)"),
+      CStackDirectory::GetBasePath(
+          R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00800.mpls , )"
+          R"(bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD2.iso%2f/BDMV/PLAYLIST/01003.mpls)"));
+}
+
+TEST_F(TestStacks, TestSameDiscStack)
+{
+  const std::string bdStack{
+      R"(stack://D:\Movies\Movie_PART1\BDMV\index.bdmv , D:\Movies\Movie_PART2\BDMV\index.bdmv)"};
+  const std::string resolvedBdStack{
+      R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00800.mpls , )"
+      R"(bluray://D%3a%5cMovies%5cMovie_PART2%5c/BDMV/PLAYLIST/00801.mpls)"};
+
+  // A stack listed from disc names no playlist, so it matches the resolved form of itself in the
+  // library - the point of the comparison
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(bdStack, resolvedBdStack));
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(resolvedBdStack, bdStack));
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(bdStack, bdStack));
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(resolvedBdStack, resolvedBdStack));
+
+  // ..but a disc can hold a cut, or a feature, per playlist, so two resolved stacks of the same
+  // discs that name different playlists are different movies
+  const std::string otherPlaylists{
+      R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00900.mpls , )"
+      R"(bluray://D%3a%5cMovies%5cMovie_PART2%5c/BDMV/PLAYLIST/00901.mpls)"};
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(resolvedBdStack, otherPlaylists));
+
+  // one differing part is enough
+  const std::string onePlaylistDiffers{
+      R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00800.mpls , )"
+      R"(bluray://D%3a%5cMovies%5cMovie_PART2%5c/BDMV/PLAYLIST/00901.mpls)"};
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(resolvedBdStack, onePlaylistDiffers));
+
+  // Different discs, and a different number of them, never match
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(
+      bdStack,
+      R"(stack://D:\Movies\Other_PART1\BDMV\index.bdmv , D:\Movies\Other_PART2\BDMV\index.bdmv)"));
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(
+      bdStack, R"(stack://D:\Movies\Movie_PART1\BDMV\index.bdmv , )"
+               R"(D:\Movies\Movie_PART2\BDMV\index.bdmv , D:\Movies\Movie_PART3\BDMV\index.bdmv)"));
+
+  // ..nor do the same discs in a different order
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(
+      bdStack,
+      R"(stack://D:\Movies\Movie_PART2\BDMV\index.bdmv , D:\Movies\Movie_PART1\BDMV\index.bdmv)"));
+
+  // A stack of disc images behaves the same way through udf://
+  const std::string isoStack{R"(stack://D:\Movies\Movie.CD1.iso , D:\Movies\Movie.CD2.iso)"};
+  const std::string resolvedIsoStack{
+      R"(stack://bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD1.iso%2f/BDMV/PLAYLIST/01003.mpls , )"
+      R"(bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD2.iso%2f/BDMV/PLAYLIST/01003.mpls)"};
+  const std::string resolvedIsoStackOtherPlaylist{
+      R"(stack://bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD1.iso%2f/BDMV/PLAYLIST/01050.mpls , )"
+      R"(bluray://udf%3a%2f%2fD%253a%255cMovies%255cMovie.CD2.iso%2f/BDMV/PLAYLIST/01050.mpls)"};
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(isoStack, resolvedIsoStack));
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(resolvedIsoStack, resolvedIsoStackOtherPlaylist));
+
+  // A stack of plain files is compared as it is listed, and is not a stack of these discs
+  const std::string fileStack{R"(stack://D:\Movies\Movie.CD1.mkv , D:\Movies\Movie.CD2.mkv)"};
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(fileStack, fileStack));
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(fileStack, isoStack));
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(
+      fileStack, R"(stack://D:\Movies\Movie.CD1.mkv , D:\Movies\Movie.CD3.mkv)"));
+
+  // Neither side is unwrapped unless it is a stack
+  EXPECT_FALSE(
+      CStackDirectory::IsSameDiscStack(bdStack, R"(D:\Movies\Movie_PART1\BDMV\index.bdmv)"));
+  EXPECT_FALSE(
+      CStackDirectory::IsSameDiscStack(R"(D:\Movies\Movie_PART1\BDMV\index.bdmv)", bdStack));
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack("D:\\a.iso", "D:\\a.iso"));
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack("", ""));
+}
+
+TEST_F(TestStacks, TestSameDiscStackIgnoresSourceOptions)
+{
+  // The options of a url are no part of the disc a part is held on, nor of the playlist, so a
+  // stack has to keep matching the one in the library when they change
+  const std::string stack{
+      R"(stack://bluray://smb%3a%2f%2fhost%2fshare%2fMovie_PART1%2f/BDMV/PLAYLIST/00800.mpls , )"
+      R"(bluray://smb%3a%2f%2fhost%2fshare%2fMovie_PART2%2f/BDMV/PLAYLIST/00800.mpls)"};
+  const std::string withOptions{
+      R"(stack://bluray://smb%3a%2f%2fhost%2fshare%2fMovie_PART1%2f/BDMV/PLAYLIST/00800.mpls?opt=1 , )"
+      R"(bluray://smb%3a%2f%2fhost%2fshare%2fMovie_PART2%2f/BDMV/PLAYLIST/00800.mpls?opt=1)"};
+
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(stack, withOptions));
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(withOptions, stack));
+
+  // ..while a different playlist of those same discs is still a different movie
+  const std::string otherPlaylist{
+      R"(stack://bluray://smb%3a%2f%2fhost%2fshare%2fMovie_PART1%2f/BDMV/PLAYLIST/00900.mpls?opt=1 , )"
+      R"(bluray://smb%3a%2f%2fhost%2fshare%2fMovie_PART2%2f/BDMV/PLAYLIST/00900.mpls?opt=1)"};
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(stack, otherPlaylist));
+
+  // A trailing slash on a disc root says nothing about the disc either
+  EXPECT_TRUE(CStackDirectory::IsSameDiscStack(
+      R"(stack://D:\Movies\Movie_PART1\BDMV\index.bdmv , D:\Movies\Movie_PART2\BDMV\index.bdmv)",
+      R"(stack://bluray://D%3a%5cMovies%5cMovie_PART1%5c/BDMV/PLAYLIST/00800.mpls , )"
+      R"(bluray://D%3a%5cMovies%5cMovie_PART2%5c/BDMV/PLAYLIST/00800.mpls)"));
+
+  // A part that is an ordinary file is compared as one, so two files in a folder stay apart
+  EXPECT_FALSE(CStackDirectory::IsSameDiscStack(
+      R"(stack://smb://host/share/Movie.CD1.mkv , smb://host/share/Movie.CD2.mkv)",
+      R"(stack://smb://host/share/Movie.CD1.mkv , smb://host/share/Movie.CD3.mkv)"));
+}
+
 TEST_F(TestStacks, TestStackHasNoBlurayPath)
 {
   // Each member of a stack of disc folders is its own disc, so there is no single disc root to


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

A resolved bluray:// stack takes the form stack://bluray://xxx , bluray://yyy whereas the scraper looks for it with base paths eg: stack://xxx , yyy - so extend GetFileId() to also look for resolved stacks:// - with an early exit for non-stack paths so no overhead.

When hashing a stack, hash both the first part (existing behaviour) and the newest part. Will lead to a one off rehashing of all stacks in library.

Note 212 lines are tests.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

After a scrape, a folder stack containing discs is rescraped.

Changes in any part other than the first part of a folder stack are not detected (not disc specific).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
