### PR TITLE
VideoPlayer: detect video bit depth in CDVDDemuxClient

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -23,6 +23,7 @@
 extern "C"
 {
 #include <libavcodec/defs.h>
+#include <libavutil/pixdesc.h>
 }
 
 class CDemuxStreamClientInternal
@@ -273,6 +274,18 @@ bool CDVDDemuxClient::ParsePacket(DemuxPacket* pkt)
           stv->changes++;
           stv->disabled = false;
         }
+        // no 8-bit default here unlike CDVDDemuxFFmpeg, 0 keeps the depth
+        // unknown so consumers derive it from the pixel format
+        const AVPixFmtDescriptor* desc =
+            av_pix_fmt_desc_get(static_cast<AVPixelFormat>(stream->m_parser->format));
+        if (desc != nullptr && desc->comp[0].depth != 0 && desc->comp[0].depth != stv->bitDepth)
+        {
+          CLog::LogF(LOGDEBUG, "({}) bitdepth changed from {} to {}", st->uniqueId, stv->bitDepth,
+                     desc->comp[0].depth);
+          stv->bitDepth = desc->comp[0].depth;
+          stv->changes++;
+          stv->disabled = false;
+        }
         if (stream->m_context->sample_aspect_ratio.num && stream->m_context->height)
         {
           double fAspect =
@@ -313,6 +326,24 @@ bool CDVDDemuxClient::ParsePacket(DemuxPacket* pkt)
   return change;
 }
 
+void CDVDDemuxClient::InvalidateParsedBitDepth()
+{
+  // a parsed bit depth belongs to the coded stream it came from, and after a
+  // stream change with no replacement extradata the stopped parser cannot
+  // re-derive it, so return it to unknown
+  for (auto& st : m_streams)
+  {
+    auto streamVideo =
+        std::dynamic_pointer_cast<CDemuxStreamClientInternalTpl<CDemuxStreamVideo>>(st.second);
+    if (streamVideo && streamVideo->extraData && streamVideo->bitDepth != 0)
+    {
+      CLog::LogF(LOGDEBUG, "({}) parsed bitdepth {} reset to unknown", st.first,
+                 streamVideo->bitDepth);
+      streamVideo->bitDepth = 0;
+    }
+  }
+}
+
 DemuxPacket* CDVDDemuxClient::Read()
 {
   if (!m_IDemux)
@@ -329,12 +360,14 @@ DemuxPacket* CDVDDemuxClient::Read()
 
   if (m_packet->iStreamId == DMX_SPECIALID_STREAMINFO)
   {
+    InvalidateParsedBitDepth();
     RequestStreams();
     CDVDDemuxUtils::FreeDemuxPacket(m_packet.release());
     return CDVDDemuxUtils::AllocateDemuxPacket(0);
   }
   else if (m_packet->iStreamId == DMX_SPECIALID_STREAMCHANGE)
   {
+    InvalidateParsedBitDepth();
     RequestStreams();
   }
   else if (m_packet->iStreamId >= 0 && m_streams.contains(m_packet->iStreamId))
@@ -486,6 +519,10 @@ void CDVDDemuxClient::SetStreamProps(CDemuxStream *stream, std::map<int, std::sh
     streamVideo->iBitRate = source->iBitRate;
     if (source->extraData)
     {
+      // a parsed bit depth belongs to the coded stream it came from, reset to
+      // unknown when the add-on replaces the extradata
+      if (source->extraData != streamVideo->extraData)
+        streamVideo->bitDepth = 0;
       streamVideo->extraData = source->extraData;
     }
     streamVideo->colorPrimaries = source->colorPrimaries;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -49,6 +49,7 @@ protected:
   void SetStreamProps(CDemuxStream *stream, std::map<int, std::shared_ptr<CDemuxStream>> &map, bool forceInit);
   bool ParsePacket(DemuxPacket* pPacket);
   void DisposeStreams();
+  void InvalidateParsedBitDepth();
   std::shared_ptr<CDemuxStream> GetStreamInternal(int iStreamId);
   bool IsVideoReady();
 


### PR DESCRIPTION
## Description

Streams demuxed by PVR and inputstream add-ons always report a bit depth of 0. Neither add-on API carries the field, and CDVDDemuxClient never reads the pixel format from the packet parser it already runs. Fill it from the parser the way width and height are handled. The value lands in the parse window that already resolves extradata, before any packet reaches the player, so it rides the existing stream change and does not add one.

This only covers streams the parser actually runs on, which in practice means PVR and similar TS style content delivered without upfront extradata. Streams that arrive with extradata keep reporting 0, as does VP9 which has no parser path here.

## Motivation and context

I want to show the coded bit depth in the player info on CoreELEC, and filling it here means the value is correct for any consumer of the stream info rather than living in a downstream patch.

## How has this been tested?

- Live TV over pvr.hts, an 8 bit H.264 and a 10 bit HEVC channel, Linux x64 with software decode. The log shows the field latch in the same parser pass that resolves extradata and profile, with the codec created once after that pass, and behavior is otherwise identical to a master build.
- The same content over inputstream.ffmpegdirect is unchanged. That add-on supplies extradata up front, so the parser path never runs there.

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
