### PR TITLE
 Fix SMB shares becoming unreachable when a host name resolves to loopback

### DIFF
--- a/xbmc/filesystem/test/CMakeLists.txt
+++ b/xbmc/filesystem/test/CMakeLists.txt
@@ -20,7 +20,9 @@ if(TARGET ${APP_NAME_LC}::NFS)
   list(APPEND SOURCES TestNfsFile.cpp)
 endif()
 
-if(TARGET ${APP_NAME_LC}::SmbClient)
+# the tested implementation is the posix one, windows has its own
+if(TARGET ${APP_NAME_LC}::SmbClient AND NOT CORE_SYSTEM_NAME STREQUAL windows AND
+   NOT CORE_SYSTEM_NAME STREQUAL windowsstore)
   list(APPEND SOURCES TestSMBFile.cpp)
 endif()
 

--- a/xbmc/filesystem/test/TestSMBFile.cpp
+++ b/xbmc/filesystem/test/TestSMBFile.cpp
@@ -40,3 +40,34 @@ TEST(TestSMBFileRecovery, ZeroBytesAtOrBeyondKnownFileEndIsValidEof)
   EXPECT_TRUE(SMBFileRecovery::IsValidEof(4096, 4096));
   EXPECT_TRUE(SMBFileRecovery::IsValidEof(8192, 4096));
 }
+
+TEST(TestSMBUrlEncode, HostNameIsEncoded)
+{
+  const CURL url("smb://kodi:secret@MEDIABOX/MEDIA/TEST");
+  EXPECT_EQ(smb.URLEncode(url), "smb://kodi:secret@MEDIABOX/MEDIA/TEST");
+}
+
+TEST(TestSMBUrlEncode, FileNameIsEncoded)
+{
+  const CURL url("smb://MEDIABOX/MEDIA/TEST/01 Mr. Blue Sky.flac");
+  EXPECT_EQ(smb.URLEncode(url), "smb://MEDIABOX/MEDIA/TEST/01%20Mr.%20Blue%20Sky.flac");
+}
+
+TEST(TestSMBUrlEncode, IPv6HostNameIsBracketed)
+{
+  const CURL url("smb://kodi:secret@[fd00::1]/MEDIA/TEST");
+  EXPECT_EQ(smb.URLEncode(url), "smb://kodi:secret@[fd00::1]/MEDIA/TEST");
+}
+
+TEST(TestSMBUrlEncode, IPv6HostNameWithPortIsBracketed)
+{
+  const CURL url("smb://[fd00::1]:445/MEDIA/TEST");
+  EXPECT_EQ(smb.URLEncode(url), "smb://[fd00::1]:445/MEDIA/TEST");
+}
+
+TEST(TestSMBUrlEncode, IPv6HostNameSubstitutedForAResolvedNameIsBracketed)
+{
+  CURL url("smb://kodi:secret@MEDIABOX/MEDIA/TEST");
+  url.SetHostName("fd00::1");
+  EXPECT_EQ(smb.URLEncode(url), "smb://kodi:secret@[fd00::1]/MEDIA/TEST");
+}

--- a/xbmc/network/DNSNameCache.cpp
+++ b/xbmc/network/DNSNameCache.cpp
@@ -11,7 +11,9 @@
 #include "network/Network.h"
 #include "utils/log.h"
 
+#include <cstdint>
 #include <mutex>
+#include <string>
 #include <tuple>
 #include <utility>
 
@@ -28,6 +30,37 @@
 #if defined(TARGET_FREEBSD)
 #include <sys/socket.h>
 #endif
+
+namespace
+{
+/*!
+ * \brief Check whether an address can never be used to reach a remote host
+ *
+ * Resolvers do hand out loopback addresses for names that belong to another machine, e.g. an
+ * AAAA record of ::1 for a host whose A record is its real address. RFC 6724 destination
+ * address sorting puts such an address first, so the first result of a lookup cannot be
+ * trusted to be reachable.
+ */
+bool IsUnusableForRemoteHost(const addrinfo* info)
+{
+  switch (info->ai_family)
+  {
+    case AF_INET:
+    {
+      const uint32_t address =
+          ntohl(reinterpret_cast<const sockaddr_in*>(info->ai_addr)->sin_addr.s_addr);
+      return address == INADDR_ANY || (address >> 24) == 127;
+    }
+    case AF_INET6:
+    {
+      const in6_addr& address = reinterpret_cast<const sockaddr_in6*>(info->ai_addr)->sin6_addr;
+      return IN6_IS_ADDR_UNSPECIFIED(&address) || IN6_IS_ADDR_LOOPBACK(&address);
+    }
+    default:
+      return true;
+  }
+}
+} // unnamed namespace
 
 bool CDNSNameCache::Lookup(const std::string& strHostName, std::string& strIpAddress)
 {
@@ -60,10 +93,35 @@ bool CDNSNameCache::Lookup(const std::string& strHostName, std::string& strIpAdd
 
   if (getaddrinfo(strHostName.c_str(), nullptr, &hints, &res) == 0)
   {
-    strIpAddress = CNetworkBase::GetIpStr(res->ai_addr);
+    // take the first address that can reach a remote host, but keep an unreachable one as a
+    // fallback so that a name which only resolves to loopback, e.g. "localhost", still works
+    std::string fallback;
+    for (const addrinfo* info = res; info; info = info->ai_next)
+    {
+      std::string address = CNetworkBase::GetIpStr(info->ai_addr);
+      if (address.empty())
+        continue;
+
+      if (IsUnusableForRemoteHost(info))
+      {
+        if (fallback.empty())
+          fallback = std::move(address);
+        continue;
+      }
+
+      strIpAddress = std::move(address);
+      break;
+    }
     freeaddrinfo(res);
-    Add(strHostName, strIpAddress);
-    return true;
+
+    if (strIpAddress.empty())
+      strIpAddress = std::move(fallback);
+
+    if (!strIpAddress.empty())
+    {
+      Add(strHostName, strIpAddress);
+      return true;
+    }
   }
 
   CLog::Log(LOGERROR, "Unable to lookup host: '{}'", strHostName);

--- a/xbmc/network/DNSNameCache.cpp
+++ b/xbmc/network/DNSNameCache.cpp
@@ -90,6 +90,9 @@ bool CDNSNameCache::Lookup(const std::string& strHostName, std::string& strIpAdd
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_flags |= AI_CANONNAME;
+  // don't get offered addresses of a family this host has no address configured for, they
+  // could never be connected to
+  hints.ai_flags |= AI_ADDRCONFIG;
 
   if (getaddrinfo(strHostName.c_str(), nullptr, &hints, &res) == 0)
   {

--- a/xbmc/platform/posix/filesystem/SMBFile.cpp
+++ b/xbmc/platform/posix/filesystem/SMBFile.cpp
@@ -565,7 +565,19 @@ std::string CSMB::URLEncode(const CURL& url)
     }
     flat += "@";
   }
-  flat += URLEncode(url.GetHostName());
+  const std::string& hostName = url.GetHostName();
+  if (hostName.find(':') != std::string::npos)
+  {
+    /* an IPv6 literal has to be bracketed and its colons must stay unencoded, otherwise
+       libsmbclient cannot read it back as an address */
+    flat += '[';
+    flat += hostName;
+    flat += ']';
+  }
+  else
+  {
+    flat += URLEncode(hostName);
+  }
 
   if (url.HasPort())
   {


### PR DESCRIPTION
## Description
An SMB source that has always worked stopped being reachable, with the host name in the failing path replaced by a percent encoded loopback address:
```
debug <general>: CGUIMediaWindow::GetDirectory (smb://USERNAME:PASSWORD@MEDIABOX/MEDIA/TEST/)
error <general>: CSMBDirectory::OpenDir: Unable to open directory : 'smb://USERNAME:PASSWORD@%3a%3a1/MEDIA/TEST'
                 unix_err:'6f' error : 'Connection refused'
```
%3a%3a1 is ::1. Every SMB request for that server was being sent to the local machine, which is why it fails with ECONNREFUSED rather than a name resolution error.

Two independent defects combine to produce this.

1. CDNSNameCache::Lookup trusts the first getaddrinfo result

CSMB::GetResolvedUrl() replaces the host name of every SMB URL with the result of CDNSNameCache::Lookup(). That function asked for all address families and then used res->ai_addr unconditionally. The name server serving the LAN in question answers both:
``` 
  MEDIABOX A    172.16.20.200
  MEDIABOX AAAA ::1
```
The bogus AAAA record comes from the resolver re-serving its own /etc/hosts, where the machine's host name sits on the ::1 localhost line. This is a   misconfiguration on that server, but it is a common one, and RFC 6724 destination address sorting ranks loopback highest, so getaddrinfo returns ::1 first and Kodi picks it. Reproduced on the affected machine with Kodi's exact hints:
```
Kodi hints (AI_CANONNAME only):
     [0] IPv6 ::1              <-- what Lookup() returned
     [1] IPv4 172.16.20.200
With AI_ADDRCONFIG:
     [0] IPv4 172.16.20.200
```
Note that `getent ahosts MEDIABOX` on the same machine shows only the IPv4 address and looks perfectly healthy. busybox getent passes AI_ADDRCONFIG, which drops the AAAA on a host with no global IPv6 address. Kodi does not, so Kodi was the only thing on the box that saw ::1. Anyone debugging this from getent output alone will conclude DNS is fine.

2. CSMB::URLEncode mangles IPv6 hosts
  
The URL passed to libsmbclient is assembled by hand, and the host was run through the same percent encoder as the path components. An IPv6 literal therefore came out as `smb://%3a%3a1/share` instead of `smb://[::1]/share` unbracketed and with its colons escaped. This has been latent since IPv6 host names became possible here, and is invisible in normal use only because libsmbclient percent decodes the URL again before parsing it. Any address substituted by CSMB::GetResolvedUrl() can be IPv6, so it is reachable in practice.

## Changes
  
Three commits, each independently revertable:

1. [network] DNSNameCache: don't resolve a host to an unreachable address — walk the addrinfo list and take the first address that can reach a remote host, skipping loopback and unspecified addresses. An unreachable address is kept as a fallback so that a name which only resolves to loopback, such as localhost, still resolves. This is the fix for the reported failure.
2. [network] DNSNameCache: only ask for address families this host can use — set AI_ADDRCONFIG. This covers the same class of failure that the address filter cannot catch: a host with a global AAAA record resolved to an IPv6 address on a machine with no IPv6 address configured. See the reviewer note below.
3. [posix][smb] don't percent encode the colons of an IPv6 host — bracket an IPv6 literal and leave its colons unencoded. Host names cannot contain a colon, so they keep being encoded exactly as before.

Note for reviewers:

Commit 2 is deliberately separate because AI_ADDRCONFIG has a known downside: on a machine whose only configured address is loopback, getaddrinfo then resolves nothing at all. This is why curl dropped the flag. Such a machine cannot reach a remote host either way, so the trade-off looks right here, but the commit can be dropped without affecting the fix — commits 1 and 3 stand on their own. CURL itself is untouched. Its parser already round-trips an unbracketed IPv6 host, and TestURL.cpp covers that; only the hand-built libsmbclient URL was wrong.

##  How has this been tested?

- Root cause reproduced on the affected hardware (LibreELEC 12.90.1, aarch64, Kodi 22.0-BETA1): the AAAA ::1 record confirmed by direct query against the name server, and the address ordering confirmed by running Kodi's exact getaddrinfo hints on the client.
- New unit tests in xbmc/filesystem/test/TestSMBFile.cpp cover host name encoding, path encoding, a bracketed IPv6 host, an IPv6 host with a port, and the GetResolvedUrl shape (parse a named URL, substitute an IPv6 host, check the result).

## What is the effect on users?
Some additional corner-cases with local networks and pi-hole etc. are correctly handled.

## Screenshots (if appropriate):

## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
