### PR TITLE
fixed: clear PAPlayer's finished latch when a new song starts

### DIFF
--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -214,6 +214,9 @@ bool PAPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
 
   {
     std::unique_lock lock(m_streamsLock);
+    // A new playback request; the queue is no longer exhausted. Nothing else clears this, so
+    // a reused player would otherwise carry it into the next song.
+    m_isFinished = false;
     m_jobCounter++;
   }
   CServiceBroker::GetJobManager()->Submit([=, this]() { QueueNextFileEx(file, false); }, this,


### PR DESCRIPTION
Fixes #27664.

With repeat-all on an audio playlist, skipping to the last track and seeking near its end makes playback wrap to the second track instead of the first. The playlist advances twice at the wrap, so a track is skipped.

The cause is in PAPlayer, not the JSON-RPC layer the report used to trigger it, so it can happen from any control surface that seeks the last track of a repeat-all playlist.

### Testing

Reproduced and verified fixed against a running Kodi: the wrap now lands on the first track, and a playlist played to its natural end (no repeat) still stops correctly. Full gtest suite green (3882 tests).
