### PR TITLE
[Application] Avoid un-needed probe to determine if a bluray is removable.

### DIFF
--- a/xbmc/application/ApplicationPlayerCallback.cpp
+++ b/xbmc/application/ApplicationPlayerCallback.cpp
@@ -136,16 +136,14 @@ void UpdateRemovableBlurayPath(CFileItem& fileItem, bool updateStreamDetails)
       {
 #ifdef HAS_OPTICAL_DRIVE
         // Played through Video->Files or Movie/TV Shows etc..
-        // Only check if system supports optical (physical/mounted) drives
-        ::UTILS::DISCS::DiscInfo info{
-            CServiceBroker::GetMediaManager().GetDiscInfo(fileUrl.GetHostName())};
-        if (!info.empty() && info.type == ::UTILS::DISCS::DiscType::BLURAY)
-        {
-          url.Parse(CServiceBroker::GetMediaManager().GetDiskUniqueId(fileUrl.GetHostName()));
-        }
+        // GetDiskUniqueId() returns a bluray://... URL for physical Blu-ray media; it may return
+        // an empty string (or a non-bluray URL) for other media / failure cases.
+        url.Parse(CServiceBroker::GetMediaManager().GetDiskUniqueId(fileUrl.GetHostName()));
+        if (!url.IsProtocol("bluray")) // Not a bluray (ie. a DVD or CD)
+          url.Reset();
 #endif
       }
-      // Will be empty if not a physical/mounted disc (ie. an ISO file)
+      // Will be empty if not a physical/mounted disc (ie. a mounted ISO file)
       if (!url.Get().empty())
       {
         url.SetFileName(fileUrl.GetFileName());


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Can determine if disc is removable (mounted ISO/physical disc) by just looking at the return value of GetDiskUniqueId(), which was called anyway.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Un-needed calll to GetDiscInfo - which resulted an a libbluray instance and disc probe.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally. Removable discs are still detected as such.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
