### PR TITLE
fixed: don't hold a setting's lock while its change callbacks run

### DIFF
--- a/xbmc/settings/lib/Setting.cpp
+++ b/xbmc/settings/lib/Setting.cpp
@@ -333,6 +333,41 @@ void CSetting::Copy(const CSetting &setting)
   m_changed = setting.m_changed;
 }
 
+template<class TSetting, typename TValue, typename TValidate>
+CSetting::ApplyResult CSetting::ApplyValue(TValue& storage, const TValue& value, TValidate validate)
+{
+  TValue oldValue;
+  {
+    std::unique_lock lock(m_critical);
+
+    if (storage == value)
+      return ApplyResult::Unchanged;
+
+    if (!validate())
+      return ApplyResult::Rejected;
+
+    oldValue = storage;
+    storage = value;
+  }
+
+  if (OnSettingChanging(shared_from_base<TSetting>()))
+    return ApplyResult::Applied;
+
+  {
+    std::unique_lock lock(m_critical);
+    // Undo only this call's write; a value another thread stored during the callbacks stands.
+    if (storage == value)
+      storage = oldValue;
+  }
+
+  // the setting couldn't be changed because one of the
+  // callback handlers failed the OnSettingChanging()
+  // callback so we need to let all the callback handlers
+  // know that the setting hasn't changed
+  OnSettingChanging(shared_from_base<TSetting>());
+  return ApplyResult::Rejected;
+}
+
 Logger CSettingList::s_logger;
 
 CSettingList::CSettingList(std::string_view id,
@@ -516,33 +551,40 @@ bool CSettingList::FromString(const std::vector<std::string> &value)
 
 bool CSettingList::SetValue(const SettingList &values)
 {
-  std::unique_lock lock(m_critical);
-
-  if (static_cast<int>(values.size()) < m_minimumItems ||
-      (m_maximumItems > 0 && static_cast<int>(values.size()) > m_maximumItems))
-    return false;
-
-  bool equal = values.size() == m_values.size();
-  for (size_t index = 0; index < values.size(); index++)
+  SettingList oldValues;
   {
-    if (values[index]->GetType() != GetElementType())
+    std::unique_lock lock(m_critical);
+
+    if (static_cast<int>(values.size()) < m_minimumItems ||
+        (m_maximumItems > 0 && static_cast<int>(values.size()) > m_maximumItems))
       return false;
 
-    if (equal &&
-        !values[index]->Equals(m_values[index]->ToString()))
-      equal = false;
+    bool equal = values.size() == m_values.size();
+    for (size_t index = 0; index < values.size(); index++)
+    {
+      if (values[index]->GetType() != GetElementType())
+        return false;
+
+      if (equal && !values[index]->Equals(m_values[index]->ToString()))
+        equal = false;
+    }
+
+    if (equal)
+      return true;
+
+    oldValues = m_values;
+    m_values.clear();
+    m_values.insert(m_values.begin(), values.begin(), values.end());
   }
-
-  if (equal)
-    return true;
-
-  SettingList oldValues = m_values;
-  m_values.clear();
-  m_values.insert(m_values.begin(), values.begin(), values.end());
 
   if (!OnSettingChanging(shared_from_base<CSettingList>()))
   {
-    m_values = oldValues;
+    {
+      std::unique_lock lock(m_critical);
+      // shared_ptr elements: this compares by identity, not by value
+      if (m_values == values)
+        m_values = oldValues;
+    }
 
     // the setting couldn't be changed because one of the
     // callback handlers failed the OnSettingChanging()
@@ -552,7 +594,10 @@ bool CSettingList::SetValue(const SettingList &values)
     return false;
   }
 
-  m_changed = toString(m_values) != toString(m_defaults);
+  {
+    std::unique_lock lock(m_critical);
+    m_changed = toString(m_values) != toString(m_defaults);
+  }
   OnSettingChanged(shared_from_base<CSettingList>());
   return true;
 }
@@ -745,27 +790,14 @@ bool CSettingBool::CheckValidity(const std::string &value) const
 
 bool CSettingBool::SetValue(bool value)
 {
-  std::unique_lock lock(m_critical);
+  const ApplyResult result{ApplyValue<CSettingBool>(m_value, value, [] { return true; })};
+  if (result != ApplyResult::Applied)
+    return result == ApplyResult::Unchanged;
 
-  if (value == m_value)
-    return true;
-
-  bool oldValue = m_value;
-  m_value = value;
-
-  if (!OnSettingChanging(shared_from_base<CSettingBool>()))
   {
-    m_value = oldValue;
-
-    // the setting couldn't be changed because one of the
-    // callback handlers failed the OnSettingChanging()
-    // callback so we need to let all the callback handlers
-    // know that the setting hasn't changed
-    OnSettingChanging(shared_from_base<CSettingBool>());
-    return false;
+    std::unique_lock lock(m_critical);
+    m_changed = m_value != m_default;
   }
-
-  m_changed = m_value != m_default;
   OnSettingChanged(shared_from_base<CSettingBool>());
   return true;
 }
@@ -1024,30 +1056,15 @@ bool CSettingInt::CheckValidity(int value) const
 
 bool CSettingInt::SetValue(int value)
 {
-  std::unique_lock lock(m_critical);
+  const ApplyResult result{
+      ApplyValue<CSettingInt>(m_value, value, [&] { return CheckValidity(value); })};
+  if (result != ApplyResult::Applied)
+    return result == ApplyResult::Unchanged;
 
-  if (value == m_value)
-    return true;
-
-  if (!CheckValidity(value))
-    return false;
-
-  int oldValue = m_value;
-  m_value = value;
-
-  if (!OnSettingChanging(shared_from_base<CSettingInt>()))
   {
-    m_value = oldValue;
-
-    // the setting couldn't be changed because one of the
-    // callback handlers failed the OnSettingChanging()
-    // callback so we need to let all the callback handlers
-    // know that the setting hasn't changed
-    OnSettingChanging(shared_from_base<CSettingInt>());
-    return false;
+    std::unique_lock lock(m_critical);
+    m_changed = m_value != m_default;
   }
-
-  m_changed = m_value != m_default;
   OnSettingChanged(shared_from_base<CSettingInt>());
   return true;
 }
@@ -1294,30 +1311,15 @@ bool CSettingNumber::CheckValidity(double value) const
 
 bool CSettingNumber::SetValue(double value)
 {
-  std::unique_lock lock(m_critical);
+  const ApplyResult result{
+      ApplyValue<CSettingNumber>(m_value, value, [&] { return CheckValidity(value); })};
+  if (result != ApplyResult::Applied)
+    return result == ApplyResult::Unchanged;
 
-  if (value == m_value)
-    return true;
-
-  if (!CheckValidity(value))
-    return false;
-
-  double oldValue = m_value;
-  m_value = value;
-
-  if (!OnSettingChanging(shared_from_base<CSettingNumber>()))
   {
-    m_value = oldValue;
-
-    // the setting couldn't be changed because one of the
-    // callback handlers failed the OnSettingChanging()
-    // callback so we need to let all the callback handlers
-    // know that the setting hasn't changed
-    OnSettingChanging(shared_from_base<CSettingNumber>());
-    return false;
+    std::unique_lock lock(m_critical);
+    m_changed = m_value != m_default;
   }
-
-  m_changed = m_value != m_default;
   OnSettingChanged(shared_from_base<CSettingNumber>());
   return true;
 }
@@ -1517,30 +1519,15 @@ bool CSettingString::CheckValidity(const std::string &value) const
 
 bool CSettingString::SetValue(const std::string &value)
 {
-  std::unique_lock lock(m_critical);
+  const ApplyResult result{
+      ApplyValue<CSettingString>(m_value, value, [&] { return CheckValidity(value); })};
+  if (result != ApplyResult::Applied)
+    return result == ApplyResult::Unchanged;
 
-  if (value == m_value)
-    return true;
-
-  if (!CheckValidity(value))
-    return false;
-
-  std::string oldValue = m_value;
-  m_value = value;
-
-  if (!OnSettingChanging(shared_from_base<CSettingString>()))
   {
-    m_value = oldValue;
-
-    // the setting couldn't be changed because one of the
-    // callback handlers failed the OnSettingChanging()
-    // callback so we need to let all the callback handlers
-    // know that the setting hasn't changed
-    OnSettingChanging(shared_from_base<CSettingString>());
-    return false;
+    std::unique_lock lock(m_critical);
+    m_changed = m_value != m_default;
   }
-
-  m_changed = m_value != m_default;
   OnSettingChanged(shared_from_base<CSettingString>());
   return true;
 }

--- a/xbmc/settings/lib/Setting.h
+++ b/xbmc/settings/lib/Setting.h
@@ -128,6 +128,22 @@ protected:
     return std::static_pointer_cast<TSetting>(shared_from_this());
   }
 
+  enum class ApplyResult
+  {
+    Unchanged,
+    Applied,
+    Rejected //!< the value was invalid, or a callback refused it and it has been reverted
+  };
+
+  /*! \brief Store a value and run the change callbacks.
+
+   The callbacks run with m_critical released, unless the caller already holds it, because
+   one of them reading this setting back on another thread would otherwise deadlock against
+   the write. validate is the exception: it is called while the lock is held.
+   */
+  template<class TSetting, typename TValue, typename TValidate>
+  ApplyResult ApplyValue(TValue& storage, const TValue& value, TValidate validate);
+
   ISettingCallback *m_callback = nullptr;
   bool m_enabled = true;
   std::string m_parentSetting;

--- a/xbmc/settings/lib/test/TestSettingsManager.cpp
+++ b/xbmc/settings/lib/test/TestSettingsManager.cpp
@@ -6,13 +6,19 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "settings/lib/ISettingCallback.h"
+#include "settings/lib/Setting.h"
 #include "settings/lib/SettingsManager.h"
 #include "utils/XBMCTinyXML.h"
 #include "utils/XMLUtils.h"
 
+#include <atomic>
+#include <chrono>
+#include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <thread>
 
 #include <gtest/gtest.h>
 
@@ -201,4 +207,113 @@ TEST(TestSettingsManager, LocateSettingNull)
 
   elem = CSettingsManager::LocateSetting(doc.RootElement(), "");
   EXPECT_EQ(nullptr, elem);
+}
+
+namespace
+{
+class CConcurrentReadCallback : public ISettingCallback
+{
+public:
+  std::shared_ptr<CSettingBool> m_setting;
+  std::atomic<bool> m_readCompleted{false};
+
+  bool OnSettingChanging(const std::shared_ptr<const CSetting>& setting) override
+  {
+    const auto s = m_setting;
+    const auto done = std::make_shared<std::atomic<bool>>(false);
+
+    std::thread(
+        [s, done]()
+        {
+          (void)s->GetValue(); // shared_lock on the setting whose value is being changed
+          done->store(true);
+        })
+        .detach();
+
+    // Bounded, so a regression fails the test rather than hanging it
+    for (int i = 0; i < 200 && !done->load(); ++i)
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    m_readCompleted.store(done->load());
+    return true;
+  }
+};
+} // namespace
+
+// A setting change must not prevent another thread from reading the same setting while the
+// OnSettingChanging handler runs. Regression test for xbmc/xbmc#20371 (JSON-RPC deadlock when
+// setting videoscreen.blankdisplays).
+TEST(TestSettingsManager, ValueIsReadableFromAnotherThreadDuringOnSettingChanging)
+{
+  const auto setting = std::make_shared<CSettingBool>("test", nullptr);
+  CConcurrentReadCallback callback;
+  callback.m_setting = setting;
+  setting->SetCallback(&callback);
+
+  setting->SetValue(true);
+
+  EXPECT_TRUE(callback.m_readCompleted.load())
+      << "the setting could not be read from another thread while OnSettingChanging ran - "
+         "SetValue held the setting's exclusive lock across the callback (xbmc/xbmc#20371)";
+}
+
+namespace
+{
+// The write happens once: a rejection re-runs OnSettingChanging to announce the reverted
+// value, and that call must not write again.
+class CRejectAfterConcurrentWriteCallback : public ISettingCallback
+{
+public:
+  std::shared_ptr<CSettingInt> m_setting;
+  int m_concurrentValue{0};
+  std::atomic<bool> m_writeCompleted{false};
+
+  bool OnSettingChanging(const std::shared_ptr<const CSetting>& setting) override
+  {
+    if (m_written ||
+        std::static_pointer_cast<const CSettingInt>(setting)->GetValue() == m_concurrentValue)
+      return true;
+
+    m_written = true;
+
+    const auto done = std::make_shared<std::atomic<bool>>(false);
+    const auto s = m_setting;
+    const int concurrentValue = m_concurrentValue;
+    std::thread(
+        [s, done, concurrentValue]()
+        {
+          s->SetValue(concurrentValue);
+          done->store(true);
+        })
+        .detach();
+
+    // Bounded, so a lock still held across this callback fails the test rather than hanging it
+    for (int i = 0; i < 200 && !done->load(); ++i)
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    m_writeCompleted.store(done->load());
+    return false;
+  }
+
+private:
+  bool m_written{false};
+};
+} // namespace
+
+// Rejecting a change undoes only that change. A value another thread wrote in the meantime,
+// which its own callbacks accepted, must survive the rejection.
+TEST(TestSettingsManager, RejectedChangeDoesNotUndoAConcurrentWrite)
+{
+  const auto setting = std::make_shared<CSettingInt>("test", nullptr);
+  CRejectAfterConcurrentWriteCallback callback;
+  callback.m_setting = setting;
+  callback.m_concurrentValue = 2;
+  setting->SetCallback(&callback);
+
+  EXPECT_FALSE(setting->SetValue(1));
+
+  ASSERT_TRUE(callback.m_writeCompleted.load())
+      << "the concurrent write never completed - SetValue held the setting's exclusive lock "
+         "across OnSettingChanging";
+  EXPECT_EQ(2, setting->GetValue());
 }


### PR DESCRIPTION
**TL;DR:** Bug fix. Changing `videoscreen.blankdisplays` over JSON-RPC deadlocked Kodi, because a setting's exclusive lock was held while its change callbacks ran. `CSetting::SetValue` now releases the lock before invoking them.

## Description
`CSetting::SetValue` now holds the lock only for the value change itself and releases it before invoking the callbacks, for every setting type.

## Motivation and context
Fixes #20371.

Setting `videoscreen.blankdisplays` over JSON-RPC freezes Kodi. The setting's exclusive lock is held while its `OnSettingChanging` handler runs, and that handler ends up reading the same setting back from the main thread, which blocks on the lock — a deadlock. It only shows on the JSON-RPC/EventServer path (a GUI change is already on the main thread) on Windows/macOS in fullscreen.

## How has this been tested?
A new bounded test reproduces the deadlock at the settings layer (fails before the change, passes after). Full gtest suite green.

## What is the effect on users?
Changing a display setting from a remote or an add-on no longer freezes Kodi.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
