### PR TITLE
Fix Kodi hanging on incomplete/unresponsive video files

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -21,6 +21,7 @@
 #include "pvr/utils/PVRStreamUtils.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "threads/Thread.h"
 #include "utils/MemUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -43,9 +44,15 @@
 #include "cores/FFmpeg.h"
 #include "filesystem/File.h"
 
+#include <atomic>
+#include <chrono>
 #include <cstdlib>
+#include <future>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -56,27 +63,166 @@ extern "C" {
 
 using namespace KODI;
 
-bool CDVDFileInfo::GetFileDuration(const std::string &path, int& duration)
+namespace
 {
-  std::unique_ptr<CDVDDemux> demux;
+constexpr std::chrono::seconds EXTRACT_TIMEOUT{30};
+constexpr std::chrono::seconds RETRY_COOLDOWN{120};
 
-  CFileItem item(path, false);
-  auto input = CDVDFactoryInputStream::CreateInputStream(NULL, item);
-  if (!input)
+std::mutex g_recentTimeoutsMutex;
+std::map<std::string, std::chrono::steady_clock::time_point> g_recentTimeouts;
+
+bool RecentlyTimedOut(const std::string& cacheKey)
+{
+  std::lock_guard<std::mutex> lock(g_recentTimeoutsMutex);
+  const auto it = g_recentTimeouts.find(cacheKey);
+  if (it == g_recentTimeouts.end())
     return false;
 
-  if (!input->Open())
+  if (std::chrono::steady_clock::now() - it->second > RETRY_COOLDOWN)
+  {
+    g_recentTimeouts.erase(it);
+    return false;
+  }
+  return true;
+}
+
+void RememberTimeout(const std::string& cacheKey)
+{
+  std::lock_guard<std::mutex> lock(g_recentTimeoutsMutex);
+  if (g_recentTimeouts.size() > 256)
+    g_recentTimeouts.clear();
+  g_recentTimeouts[cacheKey] = std::chrono::steady_clock::now();
+}
+
+constexpr std::chrono::milliseconds POLL_INTERVAL{100};
+
+constexpr int MAX_CONCURRENT_EXTRACTIONS = 8;
+
+std::atomic<int> g_activeExtractions{0};
+
+template<typename Func>
+auto RunWithTimeout(Func&& func, const std::string& redactPath, const char* what, bool& timedOut)
+{
+  using ResultT = decltype(func());
+  timedOut = false;
+
+  if (g_activeExtractions.fetch_add(1, std::memory_order_relaxed) >= MAX_CONCURRENT_EXTRACTIONS)
+  {
+    g_activeExtractions.fetch_sub(1, std::memory_order_relaxed);
+    CLog::LogF(LOGWARNING,
+               "at the cap of {} concurrent extraction attempts, skipping attempt to {} '{}'",
+               MAX_CONCURRENT_EXTRACTIONS, what, redactPath);
+    return ResultT{};
+  }
+
+  struct ActiveSlotGuard
+  {
+    ~ActiveSlotGuard() { g_activeExtractions.fetch_sub(1, std::memory_order_relaxed); }
+  } activeSlotGuard;
+
+  auto promise = std::make_shared<std::promise<ResultT>>();
+  std::future<ResultT> future = promise->get_future();
+
+  std::thread(
+      [promise, task = std::forward<Func>(func)]() mutable
+      {
+        try
+        {
+          promise->set_value(task());
+        }
+        catch (...)
+        {
+          try
+          {
+            promise->set_exception(std::current_exception());
+          }
+          catch (...)
+          {
+          }
+        }
+      })
+      .detach();
+
+  const CThread* callingThread = CThread::GetCurrentThread();
+
+  const auto deadline = std::chrono::steady_clock::now() + EXTRACT_TIMEOUT;
+  for (;;)
+  {
+    const auto now = std::chrono::steady_clock::now();
+    if (now >= deadline)
+    {
+      timedOut = true;
+      CLog::LogF(LOGWARNING,
+                 "timed out after {}s trying to {} '{}' - the file may be incomplete, still "
+                 "being written to, corrupt, or on an unresponsive share. Skipping for now "
+                 "and holding off retrying this path for {}s.",
+                 EXTRACT_TIMEOUT.count(), what, redactPath, RETRY_COOLDOWN.count());
+      return ResultT{};
+    }
+
+    if (callingThread && callingThread->IsStopRequested())
+    {
+      CLog::LogF(LOGDEBUG,
+                 "abandoning attempt to {} '{}' - this thread was asked to stop "
+                 "(e.g. the window/list requesting it was closed or refreshed)",
+                 what, redactPath);
+      return ResultT{};
+    }
+
+    const auto sliceWait = std::min<std::chrono::milliseconds>(
+        POLL_INTERVAL, std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now));
+
+    if (future.wait_for(sliceWait) == std::future_status::ready)
+    {
+      try
+      {
+        return future.get();
+      }
+      catch (...)
+      {
+        CLog::LogF(LOGERROR, "exception while trying to {} '{}'", what, redactPath);
+        return ResultT{};
+      }
+    }
+  }
+}
+} // namespace
+
+bool CDVDFileInfo::GetFileDuration(const std::string& path, int& duration)
+{
+  const std::string redactPath = CURL::GetRedacted(path);
+
+  if (RecentlyTimedOut(path))
+  {
+    CLog::LogF(LOGDEBUG, "skipping '{}' - it timed out recently, still in cooldown", redactPath);
+    return false;
+  }
+
+  bool timedOut = false;
+  const int result = RunWithTimeout(
+      [path]()
+      {
+        int dur = 0;
+        CFileItem item(path, false);
+        auto input = CDVDFactoryInputStream::CreateInputStream(NULL, item);
+        if (input && input->Open())
+        {
+          std::unique_ptr<CDVDDemux> demux{CDVDFactoryDemuxer::CreateDemuxer(input, true)};
+          if (demux)
+            dur = demux->GetStreamLength();
+        }
+        return dur;
+      },
+      redactPath, "read duration for", timedOut);
+
+  if (timedOut)
+    RememberTimeout(path);
+
+  if (result <= 0)
     return false;
 
-  demux.reset(CDVDFactoryDemuxer::CreateDemuxer(input, true));
-  if (!demux)
-    return false;
-
-  duration = demux->GetStreamLength();
-  if (duration > 0)
-    return true;
-  else
-    return false;
+  duration = result;
+  return true;
 }
 
 int DegreeToOrientation(int degrees)
@@ -253,13 +399,12 @@ std::unique_ptr<CTexture> PictureToTexture(const VideoPicture& picture, const CD
 }
 } // namespace
 
-std::unique_ptr<CTexture> CDVDFileInfo::ExtractThumbToTexture(const CFileItem& fileItem,
-                                                              int chapterNumber)
+namespace
 {
-  if (!CanExtract(fileItem))
-    return {};
-
-  const std::string redactPath = CURL::GetRedacted(fileItem.GetPath());
+std::unique_ptr<CTexture> ExtractThumbToTextureImpl(const CFileItem& fileItem,
+                                                    int chapterNumber,
+                                                    const std::string& redactPath)
+{
   auto start = std::chrono::steady_clock::now();
 
   CFileItem item(fileItem);
@@ -336,8 +481,8 @@ std::unique_ptr<CTexture> CDVDFileInfo::ExtractThumbToTexture(const CFileItem& f
                  redactPath);
 
       VideoPicture picture = {};
-      if (SeekAndDecodeFirstPicture(*demuxer, *pVideoCodec, nVideoStream, nSeekTo, picture,
-                                    packetsTried))
+      if (CDVDFileInfo::SeekAndDecodeFirstPicture(*demuxer, *pVideoCodec, nVideoStream, nSeekTo,
+                                                  picture, packetsTried))
         result = PictureToTexture(picture, hint);
       else
         CLog::LogF(LOGDEBUG, "decode failed in {} after {} packets.", redactPath, packetsTried);
@@ -348,6 +493,34 @@ std::unique_ptr<CTexture> CDVDFileInfo::ExtractThumbToTexture(const CFileItem& f
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
   CLog::LogF(LOGDEBUG, "measured {} ms to extract thumb from file <{}> in {} packets. ",
              duration.count(), redactPath, packetsTried);
+
+  return result;
+}
+} // namespace
+
+std::unique_ptr<CTexture> CDVDFileInfo::ExtractThumbToTexture(const CFileItem& fileItem,
+                                                              int chapterNumber)
+{
+  if (!CanExtract(fileItem))
+    return {};
+
+  const std::string path = fileItem.GetPath();
+  const std::string redactPath = CURL::GetRedacted(path);
+
+  if (RecentlyTimedOut(path))
+  {
+    CLog::LogF(LOGDEBUG, "skipping '{}' - it timed out recently, still in cooldown", redactPath);
+    return {};
+  }
+
+  bool timedOut = false;
+  auto result =
+      RunWithTimeout([fileItem, chapterNumber, redactPath]()
+                     { return ExtractThumbToTextureImpl(fileItem, chapterNumber, redactPath); },
+                     redactPath, "extract a thumbnail for", timedOut);
+
+  if (timedOut)
+    RememberTimeout(path);
 
   return result;
 }
@@ -389,6 +562,31 @@ bool CDVDFileInfo::CanExtract(const CFileItem& fileItem)
   return true;
 }
 
+bool CDVDFileInfo::ExtractStreamDetailsForPath(const std::string& playablePath,
+                                               const std::string& strFileNameAndPath,
+                                               CStreamDetails& details,
+                                               bool& isPvr)
+{
+  isPvr = false;
+
+  CFileItem item(playablePath, false);
+  item.SetMimeTypeForInternetFile();
+  auto pInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, item);
+  if (!pInputStream)
+    return false;
+
+  if (pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) || !pInputStream->Open())
+    return false;
+
+  isPvr = pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER);
+
+  std::unique_ptr<CDVDDemux> pDemuxer{CDVDFactoryDemuxer::CreateDemuxer(pInputStream, true)};
+  if (!pDemuxer)
+    return false;
+
+  return DemuxerToStreamDetails(pInputStream, pDemuxer.get(), details, strFileNameAndPath);
+}
+
 /**
  * \brief Open the item pointed to by pItem and extract streamdetails
  * \return true if the stream details have changed
@@ -412,32 +610,44 @@ bool CDVDFileInfo::GetFileStreamDetails(CFileItem *pItem)
   if (URIUtils::IsStack(playablePath))
     playablePath = XFILE::CStackDirectory::GetFirstStackedFile(playablePath);
 
-  CFileItem item(playablePath, false);
-  item.SetMimeTypeForInternetFile();
-  auto pInputStream = CDVDFactoryInputStream::CreateInputStream(NULL, item);
-  if (!pInputStream)
-    return false;
+  const std::string redactPath = CURL::GetRedacted(playablePath);
 
-  if (pInputStream->IsStreamType(DVDSTREAM_TYPE_DVD) || !pInputStream->Open())
+  if (RecentlyTimedOut(playablePath))
   {
+    CLog::LogF(LOGDEBUG, "skipping '{}' - it timed out recently, still in cooldown", redactPath);
     return false;
   }
 
-  CDVDDemux *pDemuxer = CDVDFactoryDemuxer::CreateDemuxer(pInputStream, true);
-  if (pDemuxer)
+  struct Extraction
   {
-    bool retVal = DemuxerToStreamDetails(pInputStream, pDemuxer, pItem->GetVideoInfoTag()->m_streamDetails, strFileNameAndPath);
+    bool success = false;
+    bool isPvr = false;
+    CStreamDetails details;
+  };
 
-    if (!pInputStream->IsStreamType(DVDSTREAM_TYPE_PVRMANAGER))
-      ProcessExternalSubtitles(pItem);
+  bool timedOut = false;
+  const Extraction extraction = RunWithTimeout(
+      [playablePath, strFileNameAndPath]()
+      {
+        Extraction result;
+        result.success = ExtractStreamDetailsForPath(playablePath, strFileNameAndPath,
+                                                     result.details, result.isPvr);
+        return result;
+      },
+      redactPath, "extract video information for", timedOut);
 
-    delete pDemuxer;
-    return retVal;
-  }
-  else
-  {
+  if (timedOut)
+    RememberTimeout(playablePath);
+
+  if (!extraction.success)
     return false;
-  }
+
+  pItem->GetVideoInfoTag()->m_streamDetails = extraction.details;
+
+  if (!extraction.isPvr)
+    ProcessExternalSubtitles(pItem);
+
+  return true;
 }
 
 bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>& pInputStream,

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.h
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.h
@@ -54,6 +54,11 @@ public:
   static bool GetFileDuration(const std::string& path, int& duration);
 
 private:
+  static bool ExtractStreamDetailsForPath(const std::string& playablePath,
+                                          const std::string& strFileNameAndPath,
+                                          CStreamDetails& details,
+                                          bool& isPvr);
+
   static bool DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>& pInputStream,
                                      CDVDDemux* pDemux,
                                      CStreamDetails& details,

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -69,6 +69,8 @@ public:
   virtual void StopThread(bool bWait = true);
   bool IsRunning() const;
 
+  bool IsStopRequested() const { return m_bStop; }
+
   bool IsCurrentThread() const;
   bool Join(std::chrono::milliseconds duration);
 


### PR DESCRIPTION
## Description
Browsing a folder, starting playback, or navigating away while a file's stream details/duration/thumbnail are being extracted can freeze Kodi indefinitely if that file is incomplete, corrupt, or on an unresponsive share. The only workaround was disabling "Extract video information from files" entirely.

## Root cause
CDVDDemuxFFmpeg's existing 30s timeout can't interrupt a single blocked CDVDInputStream::Read() call, since ffmpeg only checks its interrupt callback between its own I/O attempts, not during ours. A stuck Read() therefore blocks forever, on whichever thread called in including, in some cases, the main GUI thread.

## Fix
- Run extraction (GetFileStreamDetails, GetFileDuration, ExtractThumbToTexture) on a worker thread with a 30s deadline; give up and return if it's exceeded, without touching the caller's CFileItem.
- Cache recent timeouts for 2 minutes so the same bad file isn't re-probed (and re-frozen-on) by every subsequent touch.
- CVideoGUIInfo::InitCurrentItem() (runs on the GUI thread at playback start) now only does the fast, database-only lookup, never the file-opening one.
- The wait now polls in 100ms slices and checks whether its own thread has been asked to stop (CThread::IsStopRequested(), new), so leaving/refreshing a window while extraction is in flight no longer blocks on StopThread()'s join for the rest of the timeout.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
