### PR TITLE
Game API v7.1.1: Remove branding from one API callback

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
@@ -429,7 +429,7 @@ public:
   ///
   /// @remarks Only called from the add-on itself
   ///
-  double KodiGetPlaybackSpeed()
+  double GetPlaybackSpeed()
   {
     return m_instanceData->toKodi->GetPlaybackSpeed(m_instanceData->toKodi->kodiInstance);
   }

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -97,7 +97,7 @@
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_DEPENDS   "c-api/addon-instance/audioencoder.h" \
                                                       "addon-instance/AudioEncoder.h"
 
-#define ADDON_INSTANCE_VERSION_GAME                   "7.1.0"
+#define ADDON_INSTANCE_VERSION_GAME                   "7.1.1"
 #define ADDON_INSTANCE_VERSION_GAME_MIN               "7.1.0"
 #define ADDON_INSTANCE_VERSION_GAME_XML_ID            "kodi.binary.instance.game"
 #define ADDON_INSTANCE_VERSION_GAME_DEPENDS           "addon-instance/Game.h"


### PR DESCRIPTION
## Description

As title says, renames one function to remove the "Kodi" prefix. Nonbreaking change.

## Motivation and context

game.libretro CI only builds against master, so once https://github.com/xbmc/xbmc/pull/29002 was merged I noticed a build error.

Needed for https://github.com/kodi-game/game.libretro/pull/171.

## How has this been tested?

Build succeeds. No add-ons use this API yet so runtime testing will come after the fixup is in master.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
