### PR TITLE
[osx] fix black GUI when videoscreen.monitor is still Default

### DIFF
--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -191,6 +191,11 @@ void CheckAndUpdateCurrentMonitor(NSUInteger screenNumber)
 {
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   const std::string storedScreenName = settings->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR);
+  // OUTPUT_NAME_DEFAULT is a placeholder resolving to screen 0, not a stale name.
+  // Rewriting it before the render system exists leaves the GUI without a viewport.
+  if (storedScreenName == OUTPUT_NAME_DEFAULT && screenNumber == 0)
+    return;
+
   const std::string currentScreenName = screenNameForDisplay(screenNumber).UTF8String;
   if (storedScreenName != currentScreenName)
   {


### PR DESCRIPTION
### Description

`CheckAndUpdateCurrentMonitor` treats `OUTPUT_NAME_DEFAULT` as a stale monitor name and resolves it to the display's own name. Since #28633 made `Default` a true placeholder ("let the system choose") rather than the literal name of screen 0, that rewrite now fires on every macOS launch whose `videoscreen.monitor` is still `Default` — which is the shipped default, so every fresh profile and every existing profile that never changed the setting.

From `CWinSystemOSX::CreateNewWindow` the rewrite blanks the GUI:

1. `CDisplaySettings::SetMonitor()` runs the `videoscreen.monitor` handler, which calls `SetVideoResolution(newRes, true)`.
2. That reaches `CRenderSystemGL::ResetRenderSystem()` before `InitRenderSystem()` has run, so it returns early on `!m_bRenderCreated` — but `m_Resolution` and `m_bFullScreenRoot` are updated regardless, and `CWinSystemOSXGL::SetFullScreen()` reports success either way.
3. `CApplication::InitWindow`'s own `SetVideoResolution(res, false)` then hits the "same resolution, same fullscreen" early return in `SetVideoResolutionInternal()` and skips the reset.

The GL viewport and projection are never configured, so every frame renders black. A second launch is fine: the stored name is concrete by then and no rewrite happens.

The fix skips the rewrite only when the stored value is the placeholder **and** the window is on screen 0 — the display the placeholder resolves to, where there is nothing to correct. Moving the window to a secondary display still pins the real monitor name, as before.

### Motivation and context

Regression from #28633. Symptom is a black GUI on first launch after upgrading (or on any fresh profile), recoverable by restarting.

### How has this been tested?

Caught by an automated macOS smoke test that launches Kodi with a fresh portable profile and screenshots the home screen: without this change every frame is a uniform black 1920x1080 capture, and `GL: Maximum texture width` (logged only from `ResetRenderSystem`) is absent from the log.

### Types of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the Code Guidelines of this project
- [x] My change requires a change to the documentation — no