### PR TITLE
RetroPlayer: don't offer the whole filesystem as savestates

### DIFF
--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -122,6 +122,15 @@ bool CSavestateDatabase::GetSavestatesNav(CFileItemList& items,
 {
   const std::string savesFolder = MakePath(gamePath);
 
+  // MakePath() gives back nothing if it couldn't make the folder, and listing
+  // an empty path walks the root of the filesystem instead. Every directory
+  // there then turns up as a savestate to load.
+  if (savesFolder.empty())
+  {
+    CLog::Log(LOGERROR, "Failed to find a savestate folder for {}", CURL::GetRedacted(gamePath));
+    return false;
+  }
+
   XFILE::CDirectory::CHints hints;
   hints.mask = SAVESTATE_EXTENSION;
 


### PR DESCRIPTION
## Description

`CSavestateDatabase::MakePath()` returns an empty string whenever it cannot create the savestate folder — either the shared `saves/` folder or the per-game one beneath it, which is named after the game's file. `GetSavestatesNav()` never checks for that and passes the empty path straight to `CDirectory::GetDirectory()`, which enumerates the root of the filesystem instead.

This adds the missing check: treat the empty path as the failure it is, log which game it was for, and return false.

Nine lines in one file, no API or behaviour change on the working path.

## Motivation and context

This is a live bug on `master` today, with two visible consequences:

1. **The savestate dialog offers the filesystem.** `/bin`, `/dev` and `/root` turn up as savestates to load, and picking any of them fails.
2. **The game becomes unplayable.** That dialog is shown before a game client is chosen, and cancelling it aborts playback — so a game whose savestate folder cannot be created cannot be started at all.

The trigger is filesystem- and VFS-dependent rather than tied to any one character in a filename: a `userdata` folder that is read-only or full will do it, as will a name the underlying filesystem or VFS rejects. `MakePath()` already logs `Failed to create folder: …` when it happens; nothing acted on it.

@garbear — this one is split out of the OpenGL/OpenGL ES hardware-rendering branch, where it was found. It has nothing to do with hardware rendering and stands entirely on its own, so it seemed better upstream now than sitting behind a much larger PR. Merging it also takes it off that branch's diff, which is the same tidying exercise we did for the v22-safe fixes in kodi-game/game.libretro (#166, #167, #168) — I'm working through the rest of the branch on the same basis and this was the only commit that cherry-picked onto `master` cleanly and compiled without hardware-rendering infrastructure.

## How has this been tested?

Desktop GL build, Wayland, Mesa 26.0.3 / Intel Arc, `fceumm` playing an NES title.

The failure path was forced deterministically rather than waited for: with a plain file placed where `userdata/saves/` needs to be, `CDirectory::Create()` cannot succeed, so `MakePath()` returns empty. Log from that run:

```
error <general>: Failed to create folder: special://home/saves/
error <general>: Failed to find a savestate folder for /home/chris/Downloads/smb.nes
```

The second line is the new guard. The game then loaded and played normally, with no filesystem entries enumerated.

Removing the blocking file and repeating gives the normal path: the per-game folder is created and savestates are written to it as before (`Saving savestate to special://home/saves/<game>/…`, `Wrote savestate of 243384 bytes`), so the change is inert when folder creation succeeds.

Worth being precise about one thing: I verified the guard is reached and that playback survives, and read the unguarded path on `master` (`GetSavestatesNav()` → `CDirectory::GetDirectory("")`). I did not re-run an unpatched build to watch `/bin` and `/dev` appear again — that symptom is from when the bug was originally found.

## What is the effect on users?

A game whose savestate folder cannot be created is playable again instead of being blocked at launch, and the load-savestate dialog no longer lists directories from the root of the filesystem.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
