### PR TITLE
Game API v7.2.0: Allow setting game FPS/samplerate

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
@@ -436,6 +436,23 @@ public:
   //----------------------------------------------------------------------------
 
   //============================================================================
+  /// @brief **Callback to Kodi Function**\n
+  /// Update the video and audio timing of the running game
+  ///
+  /// @param[in] timingInfo The new video frame rate and audio sample rate
+  ///
+  /// This updates timing reported by the add-on after gameplay has started.
+  /// Add-ons should call this when the game changes its timing dynamically.
+  ///
+  /// @remarks Only called from the add-on itself
+  ///
+  void SetGameTiming(const game_system_timing& timingInfo)
+  {
+    m_instanceData->toKodi->SetGameTiming(m_instanceData->toKodi->kodiInstance, &timingInfo);
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
   /// @defgroup cpp_kodi_addon_game_Operation_CStream Class: CStream
   /// @ingroup cpp_kodi_addon_game_Operation
   /// @brief @cpp_class{ kodi::addon::CInstanceGame::CStream }

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
@@ -1228,6 +1228,7 @@ extern "C"
     bool (*EnableHardwareRendering)(void*, const game_hw_rendering_properties*);
     void (*CloseGame)(KODI_HANDLE kodiInstance);
     double (*GetPlaybackSpeed)(KODI_HANDLE kodiInstance);
+    void (*SetGameTiming)(KODI_HANDLE kodiInstance, const struct game_system_timing* timing_info);
     KODI_GAME_STREAM_HANDLE (*OpenStream)(KODI_HANDLE, const struct game_stream_properties*);
     bool (*GetStreamBuffer)(KODI_HANDLE,
                             KODI_GAME_STREAM_HANDLE,

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -97,8 +97,8 @@
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_DEPENDS   "c-api/addon-instance/audioencoder.h" \
                                                       "addon-instance/AudioEncoder.h"
 
-#define ADDON_INSTANCE_VERSION_GAME                   "7.1.1"
-#define ADDON_INSTANCE_VERSION_GAME_MIN               "7.1.0"
+#define ADDON_INSTANCE_VERSION_GAME                   "7.2.0"
+#define ADDON_INSTANCE_VERSION_GAME_MIN               "7.2.0"
 #define ADDON_INSTANCE_VERSION_GAME_XML_ID            "kodi.binary.instance.game"
 #define ADDON_INSTANCE_VERSION_GAME_DEPENDS           "addon-instance/Game.h"
 

--- a/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
@@ -64,6 +64,11 @@ void CGameLoop::SetSpeed(double speedFactor)
   m_sleepEvent.Set();
 }
 
+void CGameLoop::SetFrameRate(double fps)
+{
+  m_fps.store(fps != 0.0 ? fps : DEFAULT_FPS);
+}
+
 void CGameLoop::PauseAsync()
 {
   // Pause the game loop asynchronously by setting speed to 0
@@ -133,7 +138,7 @@ std::chrono::microseconds CGameLoop::FrameTimeUs() const
   // Calculate the duration of one frame in microseconds based on the FPS and
   // speed factor
   const double factor = m_loopSpeedFactor != 0.0 ? std::abs(m_loopSpeedFactor) : 1.0;
-  return std::chrono::duration_cast<std::chrono::microseconds>(1s / m_fps / factor);
+  return std::chrono::duration_cast<std::chrono::microseconds>(1s / m_fps.load() / factor);
 }
 
 std::chrono::microseconds CGameLoop::NowUs() const

--- a/xbmc/cores/RetroPlayer/playback/GameLoop.h
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.h
@@ -72,7 +72,8 @@ public:
   void Start();
   void Stop();
 
-  double FPS() const { return m_fps; }
+  double FPS() const { return m_fps.load(); }
+  void SetFrameRate(double fps);
 
   double GetSpeed() const { return m_speedFactor.load(); }
   void SetSpeed(double speedFactor);
@@ -87,7 +88,7 @@ private:
   std::chrono::microseconds NowUs() const;
 
   IGameLoopCallback* const m_callback;
-  const double m_fps;
+  std::atomic<double> m_fps;
   std::atomic<double> m_speedFactor{0.0};
   double m_loopSpeedFactor{0.0};
   std::chrono::microseconds m_lastFrameUs{std::chrono::microseconds::zero()};

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -316,6 +316,7 @@ bool CReversiblePlayback::LoadSavestate(const std::string& savestatePath)
 void CReversiblePlayback::FrameEvent()
 {
   m_gameClient->RunFrame();
+  UpdateFrameRate();
 
   AddFrame();
 }
@@ -325,6 +326,7 @@ void CReversiblePlayback::RewindEvent()
   RewindFrames(1);
 
   m_gameClient->RunFrame();
+  UpdateFrameRate();
 }
 
 void CReversiblePlayback::EndEvent()
@@ -346,6 +348,15 @@ void CReversiblePlayback::AddFrame()
   }
 
   m_totalFrameCount++;
+}
+
+void CReversiblePlayback::UpdateFrameRate()
+{
+  const double previousFrameRate = m_gameLoop.FPS();
+  m_gameLoop.SetFrameRate(m_gameClient->GetFrameRate());
+
+  if (m_gameLoop.FPS() != previousFrameRate)
+    UpdateMemoryStream();
 }
 
 void CReversiblePlayback::RewindFrames(uint64_t frames)

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.h
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.h
@@ -72,6 +72,7 @@ public:
 
 private:
   void AddFrame();
+  void UpdateFrameRate();
   void RewindFrames(uint64_t frames);
   void AdvanceFrames(uint64_t frames);
   void UpdatePlaybackStats();

--- a/xbmc/cores/RetroPlayer/streams/IStreamManager.h
+++ b/xbmc/cores/RetroPlayer/streams/IStreamManager.h
@@ -38,6 +38,13 @@ public:
   virtual void CloseStream(StreamPtr stream) = 0;
 
   /*!
+   * \brief Update the video frame rate reported by the game
+   *
+   * \param fps The new frame rate
+   */
+  virtual void SetVideoFps(float fps) = 0;
+
+  /*!
    * \brief Get a symbol from the hardware context
    *
    * \param symbol The symbol's name

--- a/xbmc/cores/RetroPlayer/streams/RPStreamManager.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RPStreamManager.cpp
@@ -67,6 +67,11 @@ void CRPStreamManager::CloseStream(StreamPtr stream)
   }
 }
 
+void CRPStreamManager::SetVideoFps(float fps)
+{
+  m_processInfo.SetVideoFps(fps);
+}
+
 HwProcedureAddress CRPStreamManager::GetHwProcedureAddress(const char* symbol)
 {
   return m_processInfo.GetHwProcedureAddress(symbol);

--- a/xbmc/cores/RetroPlayer/streams/RPStreamManager.h
+++ b/xbmc/cores/RetroPlayer/streams/RPStreamManager.h
@@ -29,6 +29,7 @@ public:
   // Implementation of IStreamManager
   StreamPtr CreateStream(StreamType streamType) override;
   void CloseStream(StreamPtr stream) override;
+  void SetVideoFps(float fps) override;
   HwProcedureAddress GetHwProcedureAddress(const char* symbol) override;
 
 private:

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -41,6 +41,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <iterator>
 #include <memory>
@@ -174,6 +175,7 @@ bool CGameClient::Initialize(void)
   m_ifc.game->toKodi->EnableHardwareRendering = cb_enable_hardware_rendering;
   m_ifc.game->toKodi->CloseGame = cb_close_game;
   m_ifc.game->toKodi->GetPlaybackSpeed = cb_get_playback_speed;
+  m_ifc.game->toKodi->SetGameTiming = cb_set_game_timing;
   m_ifc.game->toKodi->OpenStream = cb_open_stream;
   m_ifc.game->toKodi->GetStreamBuffer = cb_get_stream_buffer;
   m_ifc.game->toKodi->AddStreamData = cb_add_stream_data;
@@ -711,6 +713,25 @@ double CGameClient::cb_get_playback_speed(KODI_HANDLE kodiInstance)
     return 0.0;
 
   return gameClient->m_playbackSpeed;
+}
+
+void CGameClient::cb_set_game_timing(KODI_HANDLE kodiInstance, const game_system_timing* timingInfo)
+{
+  CGameClient* gameClient = static_cast<CGameClient*>(kodiInstance);
+  if (gameClient == nullptr || timingInfo == nullptr)
+    return;
+
+  if (!std::isfinite(timingInfo->fps) || timingInfo->fps <= 0.0 ||
+      !std::isfinite(timingInfo->sample_rate) || timingInfo->sample_rate <= 0.0)
+  {
+    CLog::Log(LOGERROR, "GAME: Invalid timing info: FPS = {:f}, sample rate = {:f}",
+              timingInfo->fps, timingInfo->sample_rate);
+    return;
+  }
+
+  gameClient->m_framerate = timingInfo->fps;
+  gameClient->m_samplerate = timingInfo->sample_rate;
+  gameClient->Streams().SetGameTiming(*timingInfo);
 }
 
 KODI_GAME_STREAM_HANDLE CGameClient::cb_open_stream(KODI_HANDLE kodiInstance,

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -168,8 +168,8 @@ public:
   bool RequiresGameLoop() const { return m_bRequiresGameLoop; }
   bool IsPlaying() const { return m_bIsPlaying; }
   size_t GetSerializeSize() const { return m_serializeSize; }
-  double GetFrameRate() const { return m_framerate; }
-  double GetSampleRate() const { return m_samplerate; }
+  double GetFrameRate() const { return m_framerate.load(); }
+  double GetSampleRate() const { return m_samplerate.load(); }
   void RunFrame();
 
   /*!
@@ -224,6 +224,7 @@ private:
                                            const game_hw_rendering_properties* properties);
   static void cb_close_game(KODI_HANDLE kodiInstance);
   static double cb_get_playback_speed(KODI_HANDLE kodiInstance);
+  static void cb_set_game_timing(KODI_HANDLE kodiInstance, const game_system_timing* timingInfo);
   static KODI_GAME_STREAM_HANDLE cb_open_stream(KODI_HANDLE kodiInstance,
                                                 const game_stream_properties* properties);
   static bool cb_get_stream_buffer(KODI_HANDLE kodiInstance,
@@ -290,8 +291,8 @@ private:
   bool m_bRequiresGameLoop = false;
   size_t m_serializeSize = 0;
   IGameInputCallback* m_input = nullptr; // The input callback passed to OpenFile()
-  double m_framerate = 0.0; // Video frame rate (fps)
-  double m_samplerate = 0.0; // Audio sample rate (Hz)
+  std::atomic<double> m_framerate{0.0}; // Video frame rate (fps)
+  std::atomic<double> m_samplerate{0.0}; // Audio sample rate (Hz)
   GAME_REGION m_region = GAME_REGION_UNKNOWN; // Region of the loaded game
 
   // In-game saves

--- a/xbmc/games/addons/streams/GameClientStreamAudio.cpp
+++ b/xbmc/games/addons/streams/GameClientStreamAudio.cpp
@@ -19,6 +19,26 @@ CGameClientStreamAudio::CGameClientStreamAudio(double sampleRate) : m_sampleRate
 {
 }
 
+CGameClientStreamAudio::~CGameClientStreamAudio()
+{
+  CloseStream();
+}
+
+void CGameClientStreamAudio::SetSampleRate(double sampleRate)
+{
+  if (m_sampleRate == sampleRate)
+    return;
+
+  m_sampleRate = sampleRate;
+
+  if (m_stream != nullptr && m_properties != nullptr)
+  {
+    m_properties->sampleRate = sampleRate;
+    if (!m_stream->OpenStream(static_cast<const RETRO::StreamProperties&>(*m_properties)))
+      CLog::Log(LOGERROR, "GAME: Failed to reopen audio stream with sample rate {:f}", sampleRate);
+  }
+}
+
 bool CGameClientStreamAudio::OpenStream(RETRO::IRetroPlayerStream* stream,
                                         const game_stream_properties& properties)
 {
@@ -29,11 +49,10 @@ bool CGameClientStreamAudio::OpenStream(RETRO::IRetroPlayerStream* stream,
     return false;
   }
 
-  std::unique_ptr<RETRO::AudioStreamProperties> audioProperties(
-      TranslateProperties(properties.audio, m_sampleRate));
-  if (audioProperties)
+  m_properties.reset(TranslateProperties(properties.audio, m_sampleRate));
+  if (m_properties)
   {
-    if (audioStream->OpenStream(static_cast<const RETRO::StreamProperties&>(*audioProperties)))
+    if (audioStream->OpenStream(static_cast<const RETRO::StreamProperties&>(*m_properties)))
       m_stream = stream;
   }
 
@@ -47,6 +66,8 @@ void CGameClientStreamAudio::CloseStream()
     m_stream->CloseStream();
     m_stream = nullptr;
   }
+
+  m_properties.reset();
 }
 
 void CGameClientStreamAudio::AddData(const game_stream_packet& packet)

--- a/xbmc/games/addons/streams/GameClientStreamAudio.h
+++ b/xbmc/games/addons/streams/GameClientStreamAudio.h
@@ -11,6 +11,7 @@
 #include "IGameClientStream.h"
 #include "addons/kodi-dev-kit/include/kodi/addon-instance/Game.h"
 
+#include <memory>
 #include <vector>
 
 namespace KODI
@@ -31,7 +32,9 @@ class CGameClientStreamAudio : public IGameClientStream
 {
 public:
   CGameClientStreamAudio(double sampleRate);
-  ~CGameClientStreamAudio() override { CloseStream(); }
+  ~CGameClientStreamAudio() override;
+
+  void SetSampleRate(double sampleRate);
 
   // Implementation of IGameClientStream
   bool OpenStream(RETRO::IRetroPlayerStream* stream,
@@ -45,10 +48,11 @@ private:
       const game_stream_audio_properties& properties, double sampleRate);
 
   // Construction parameters
-  const double m_sampleRate;
+  double m_sampleRate;
 
   // Stream parameters
   RETRO::IRetroPlayerStream* m_stream = nullptr;
+  std::unique_ptr<RETRO::AudioStreamProperties> m_properties;
 };
 
 } // namespace GAME

--- a/xbmc/games/addons/streams/GameClientStreams.cpp
+++ b/xbmc/games/addons/streams/GameClientStreams.cpp
@@ -89,6 +89,19 @@ void CGameClientStreams::CloseStream(IGameClientStream* stream)
   }
 }
 
+void CGameClientStreams::SetGameTiming(const game_system_timing& timingInfo)
+{
+  if (m_streamManager != nullptr)
+    m_streamManager->SetVideoFps(static_cast<float>(timingInfo.fps));
+
+  for (const auto& streamEntry : m_streams)
+  {
+    CGameClientStreamAudio* audioStream = dynamic_cast<CGameClientStreamAudio*>(streamEntry.first);
+    if (audioStream != nullptr)
+      audioStream->SetSampleRate(timingInfo.sample_rate);
+  }
+}
+
 bool CGameClientStreams::EnableHardwareRendering(const game_hw_rendering_properties& properties)
 {
   if (properties.context_type == GAME_HW_CONTEXT_NONE)

--- a/xbmc/games/addons/streams/GameClientStreams.h
+++ b/xbmc/games/addons/streams/GameClientStreams.h
@@ -41,6 +41,7 @@ public:
   // Stream management functions
   IGameClientStream* OpenStream(const game_stream_properties& properties);
   void CloseStream(IGameClientStream* stream);
+  void SetGameTiming(const game_system_timing& timingInfo);
 
   // HW rendering functions
   bool EnableHardwareRendering(const game_hw_rendering_properties& properties);


### PR DESCRIPTION
## Description

Completes a TODO exposed by https://github.com/xbmc/xbmc/pull/29002 - we can now tell a client what speed we're running at, but the client can't update Kodi with a new video framerate or audio samplerate.

No games were observed to be broken due to this missing function, but it should be included for completeness to de-risk timing problems in future testing.

Corresponding game.libretro PR: https://github.com/kodi-game/game.libretro/pull/172

## Motivation and context

This was left as a TODO in the game.libretro code in the `RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO` libretro callback: https://github.com/kodi-game/game.libretro/blob/5e6c7e892/src/libretro/LibretroEnvironment.cpp#L435

This PR completes that TODO by adding a callback for setting the timing info at runtime.

## How has this been tested?

Included in latest test builds.

## What is the effect on users?

* None

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
