### PR TITLE
[Android][Peripherals] Fix game input for "Share" button on PS4 controller

### DIFF
--- a/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
+++ b/xbmc/platform/android/peripherals/AndroidJoystickState.cpp
@@ -360,6 +360,25 @@ bool CAndroidJoystickState::ProcessEvent(const AInputEvent* event)
 
       bool result = SetButtonValue(keycode, buttonState);
 
+      if (!result)
+      {
+        // Try shoehorning keys into buttons
+        switch (keycode)
+        {
+          case AKEYCODE_MENU:
+            result = SetButtonValue(AKEYCODE_BUTTON_START, buttonState);
+            break;
+          case AKEYCODE_BACK:
+            result = SetButtonValue(AKEYCODE_BUTTON_SELECT, buttonState);
+            break;
+          case AKEYCODE_HOME:
+            result = SetButtonValue(AKEYCODE_BUTTON_MODE, buttonState);
+            break;
+          default:
+            break;
+        }
+      }
+
       return result;
     }
 


### PR DESCRIPTION
## Description

Broken out from https://github.com/xbmc/xbmc/pull/25179. Unchanged from original PR 2 years ago.

## Motivation and context

Testing my PS4 controller on my NVidia Shield, the "Share" button doesn't work in-game. I asked AI, and it reproduced literally the fix I PR'd two years ago and later dropped from my test builds.

IT KNOWS.

So it's a good time to get this fix in.

## How has this been tested?

Last confirmed working in 2025 when I dropped https://github.com/xbmc/xbmc/pull/25179 from my test builds. Testing this commit in isolation is in progress.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
