### PR TITLE
ImageDecoder: set hasAlpha from decoded addon pixel format

### DIFF
--- a/xbmc/addons/ImageDecoder.cpp
+++ b/xbmc/addons/ImageDecoder.cpp
@@ -206,5 +206,9 @@ bool CImageDecoder::Decode(unsigned char* const pixels,
   m_width = width;
   m_height = height;
 
+  // Only these two addon-facing formats carry a per-pixel alpha channel.
+  if (result)
+    m_hasAlpha = (addonFmt == ADDON_IMG_FMT_A8R8G8B8 || addonFmt == ADDON_IMG_FMT_RGBA8);
+
   return result;
 }


### PR DESCRIPTION
## Description

`CImageDecoder::Decode()` never sets `IImage::m_hasAlpha`, so the output of every
`kodi.imagedecoder` add-on is treated as fully opaque. `CFFmpegImage` already derives it from
the decoded pixel format; this does the same from the add-on-facing format. Only
`ADDON_IMG_FMT_A8R8G8B8` and `ADDON_IMG_FMT_RGBA8` carry a per-pixel alpha channel, so nothing
else changes behaviour.

## Motivation and context

Found while writing an SVG image decoder add-on, where transparent areas rendered as opaque
black through the normal skin texture path. Not SVG-specific — any image decoder add-on
returning an alpha-bearing format is affected, so `imagedecoder.heif`/`.raw`/`.mpo` benefit
equally.

## How has this been tested?

Reproduced and fixed end-to-end on Linux/x86_64 against current master: a skin `<texture>`
referencing an `.svg` with a transparent field, decoded by a `kodi.imagedecoder` add-on
returning `ADDON_IMG_FMT_A8R8G8B8`, drawn over a solid background.

- Unpatched master: the transparent area composites as an opaque black box.
- With this patch: the background shows through correctly.

Same skin, same add-on, same harness — only the patch differs.

Previously confirmed the same way on real hardware (Ugoos SK1, CoreELEC, aarch64), and reproduced on macOS/arm64
(Xcode 26.6, SDK 26.5) with the same result.

Full test suite passes: 3807 tests from 294 suites (`kodi-test`).

## What is the effect on users?

Image decoder add-ons that return alpha now composite correctly instead of showing black where
the image is transparent. No change for formats without alpha.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
