### PR TITLE
[Android][Peripherals] Fix crash on controller "motion" input

### DIFF
--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -20,6 +20,7 @@ import android.view.Choreographer;
 import android.view.View;
 import android.view.WindowInsets;
 import android.view.WindowInsetsController;
+import android.view.WindowManager;
 import android.widget.RelativeLayout;
 
 import java.util.ArrayList;
@@ -118,6 +119,10 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
     System.loadLibrary("@APP_NAME_LC@");
 
     super.onCreate(savedInstanceState);
+
+    // Kodi's main rendering window does not host an Android text editor. Prevent controller
+    // motion events from being dispatched to the IME before NativeActivity.
+    getWindow().addFlags(WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM);
 
     setContentView(R.layout.activity_main);
     setVolumeControlStream(AudioManager.STREAM_MUSIC);


### PR DESCRIPTION
## Description

Prevent controller motion events from being dispatched to Android's input method before reaching Kodi's native input queue.

Kodi's main rendering window does not host an Android text editor, so it is marked with `FLAG_ALT_FOCUSABLE_IM`. Android consequently bypasses `InputMethodManager` for this window and forwards controller events to NativeActivity/Kodi.

The change:

- Does not change or pin the target SDK.
- Does not contain an Android-version check.
- Does not discard valid joystick movement.
- Applies only to Kodi's main window. Separate IME-capable windows, such as the native keyboard dialog proposed in #28580, retain their own window flags and remain able to use the system keyboard.

CC @joseluismarti 

## Motivation and context

Fixes https://github.com/xbmc/xbmc/issues/26055

On affected Android 14 devices, joystick D-pad or analog movement terminates Kodi with:

`InputVerifier::ensureTouchingPointersMatch()` → `InputPublisher::publishMotionEvent()` → `NativeInputEventSender::sendMotionEvent()`

Android's affected verifier incorrectly applies touchscreen-style DOWN/MOVE/UP validation to legitimate joystick `ACTION_MOVE` events.

The issue's tombstone shows that the abort occurs in:

`ViewRootImpl.ImeInputStage` → `InputMethodManager.dispatchInputEvent()` → `NativeInputEventSender`

This is before `NativePostImeInputStage`, NativeActivity's input queue, Kodi's input handlers, and `AInputQueue_finishEvent()`. Therefore changing Kodi's handled return value cannot prevent this crash. A pointer-count guard is also ineffective because the reported event has one pointer and Kodi never receives it before the abort.

The underlying Android verifier was later corrected to skip non-pointer input sources:

https://android.googlesource.com/platform/frameworks/native/+/2d151ac3e2f6280f541fd75a9578ee1ab13ea405

This change avoids the affected IME publishing path for Kodi's main NativeActivity window across supported Android versions.

## How has this been tested?

The complete generated `Main.java` source was compile-checked against the official Android API 37 `android.jar` using Java 17 with `-Xlint:all -Werror`.

The nearest existing controller tests were run:

`build/kodi-test --gtest_filter='TestControllerState.*:TestPortNodeInput.*'`

Result: 11 tests passed.

`git diff --check` also passed.

A complete Android APK build was not available on the test host because it is ARM64 and does not have the required Android NDK or configured Kodi depends tree.

Testing on an affected physical Android 14 device is still required, including:

- D-pad and analog controller movement.
- Controller hotplugging.
- Touch, mouse, and physical keyboard input.
- Kodi's on-screen keyboard.
- Controller movement while any system-IME dialog is visible.

## What is the effect on users?

Controller D-pad and analog input no longer enters the Android system-IME path while Kodi's main window is focused, preventing the reported process abort on affected Android builds.

Touch, mouse, keyboard, and valid joystick input continue to be delivered normally. Other platforms are unaffected.

Kodi's main window can no longer act as an Android IME target. This does not change current behavior because that window does not contain an Android text editor. Separate dialog windows can still use the system IME.

## Screenshots (if appropriate):

Not applicable.

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
