### PR TITLE
Fix stale ACTION_VIEW intent being reprocessed after process killed by Android

### DIFF
--- a/tools/android/packaging/xbmc/src/Main.java.in
+++ b/tools/android/packaging/xbmc/src/Main.java.in
@@ -126,9 +126,15 @@ public class Main extends NativeActivity implements Choreographer.FrameCallback
     getApplicationContext().getContentResolver().registerContentObserver(android.provider.Settings.System.CONTENT_URI, true, mSettingsContentObserver);
 
     // Delayed Intent
+    // savedInstanceState is non-null when the Activity is being recreated
+    // rather than started with a new intent, so we treat the old intent as
+    // expired and don't replay it.
     if (getIntent().getData() != null)
     {
-      mDelayedIntents.add(new DelayedIntent(new Intent(getIntent()), 5000));
+      if (savedInstanceState == null)
+      {
+        mDelayedIntents.add(new DelayedIntent(new Intent(getIntent()), 5000));
+      }
       getIntent().setData(null);
     }
 


### PR DESCRIPTION
## Description
When Kodi is launched via an Android `ACTION_VIEW` intent, Android retains that intent at the task level. If the Kodi process is later killed by the OS and the app is reopened, the old intent is redelivered and processed again, reopening the same media URL - with no user action triggering it. 

Fixes #29018 All the ADB commands to reproduce this bug are here

## Root cause
`Main.onCreate()` unconditionally queues any intent with non-null data:

```java
if (getIntent().getData() != null)
{
    mDelayedIntents.add(new DelayedIntent(new Intent(getIntent()), 5000));
    getIntent().setData(null);
}
```

`getIntent().setData(null)` only clears the local, in-process copy of the `Intent`. It doesn't affect the `Intent` retained by `system` for the task, so on the next process recreation the same original intent - data, action, and flags is delivered again, identical to the first delivery. Confirmed via `dumpsys activity activities`: the persisted intent is unchanged between a fresh launch and a post-kill restore, so the intent's content/flags alone can't distinguish the two cases.

## Fix
`savedInstanceState` provides a reliable signal instead: it's non-null when the activity is being recreated rather than started with a new intent — this includes process death + restore, but also other system-driven recreations. This depends on lifecycle state, not intent content, so a legitimate later `ACTION_VIEW` for the same URL is unaffected.

```java
// Delayed Intent
if (getIntent().getData() != null)
{
    if (savedInstanceState == null)
    {
        mDelayedIntents.add(new DelayedIntent(new Intent(getIntent()), 5000));
    }
    getIntent().setData(null);
}
```
## Types of change
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed *(manual verification via `adb` steps in #29018)*