### PR TITLE
GUIFontManager: let enabled RESOURCE_FONT add-ons register their own fonts

### DIFF
--- a/xbmc/addons/FontResource.cpp
+++ b/xbmc/addons/FontResource.cpp
@@ -7,14 +7,9 @@
  */
 #include "FontResource.h"
 
-#include "ServiceBroker.h"
-#include "addons/AddonManager.h"
 #include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonType.h"
 #include "filesystem/SpecialProtocol.h"
-#include "messaging/ApplicationMessenger.h"
-#include "settings/Settings.h"
-#include "settings/SettingsComponent.h"
 #include "utils/FileUtils.h"
 
 namespace ADDON
@@ -23,17 +18,6 @@ namespace ADDON
 CFontResource::CFontResource(const AddonInfoPtr& addonInfo)
   : CResource(addonInfo, AddonType::RESOURCE_FONT)
 {
-}
-
-void CFontResource::OnPostInstall(bool update, bool modal)
-{
-  std::string skin = CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_LOOKANDFEEL_SKIN);
-  const auto& deps =
-      CServiceBroker::GetAddonMgr().GetDepsRecursive(skin, OnlyEnabledRootAddon::CHOICE_YES);
-  for (const auto& it : deps)
-    if (it.id == ID())
-      CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
-                                                 "ReloadSkin");
 }
 
 bool CFontResource::GetFont(const std::string& file, std::string& path) const

--- a/xbmc/addons/FontResource.h
+++ b/xbmc/addons/FontResource.h
@@ -29,7 +29,6 @@ public:
   bool GetFont(const std::string& file, std::string& path) const;
 
   //! \brief Callback executed after installation
-  void OnPostInstall(bool update, bool modal) override;
 };
 
 }

--- a/xbmc/guilib/GUIFontManager.cpp
+++ b/xbmc/guilib/GUIFontManager.cpp
@@ -12,11 +12,14 @@
 #include "GUIComponent.h"
 #include "GUIFontTTF.h"
 #include "GUIWindowManager.h"
+#include "addons/AddonEvents.h"
 #include "addons/AddonManager.h"
 #include "addons/FontResource.h"
 #include "addons/Skin.h"
+#include "addons/addoninfo/AddonInfo.h"
 #include "addons/addoninfo/AddonType.h"
 #include "filesystem/SpecialProtocol.h"
+#include "messaging/ApplicationMessenger.h"
 #include "windowing/GraphicContext.h"
 #include "windowing/WinSystem.h"
 
@@ -79,6 +82,8 @@ GUIFontManager::GUIFontManager() = default;
 
 GUIFontManager::~GUIFontManager()
 {
+  if (m_addonEventsSubscribed && CServiceBroker::IsAddonInterfaceUp())
+    CServiceBroker::GetAddonMgr().Events().Unsubscribe(this);
   Clear();
 }
 
@@ -463,7 +468,10 @@ void GUIFontManager::LoadFonts(const std::string& fontSet)
   // Try to load the fontset from Font.xml
   const std::string fontsetFilePath = skin->GetSkinPath("Font.xml", &m_skinResolution);
   if (LoadFontsFromFile(fontsetFilePath, fontSet, firstFontset))
+  {
+    LoadAddonFonts(fontSet);
     return;
+  }
 
   // If we got here, then the requested fontset was not found in the skin's Font.xml file
   // Look at additional fontsets that are defined in .xml files in the skin's fonts directory
@@ -472,7 +480,10 @@ void GUIFontManager::LoadFonts(const std::string& fontSet)
                            ".xml", DIR_FLAG_BYPASS_CACHE);
   for (int i = 0; i < xmlFileItems.Size(); i++)
     if (LoadFontsFromFile(xmlFileItems[i]->GetPath(), fontSet, firstFontset))
+    {
+      LoadAddonFonts(fontSet);
       return;
+    }
 
   // Requested fontset was not found, try the first
   if (!firstFontset.empty())
@@ -486,6 +497,80 @@ void GUIFontManager::LoadFonts(const std::string& fontSet)
   else
     CLog::LogF(LOGERROR, "No valid <fontset> found in '{}' or in xml files in fonts directory",
                fontsetFilePath);
+}
+
+void GUIFontManager::LoadAddonFonts(const std::string& fontSet)
+{
+  if (!m_addonEventsSubscribed)
+  {
+    m_addonEventsSubscribed = true;
+    CServiceBroker::GetAddonMgr().Events().Subscribe(this, [this](const ADDON::AddonEvent& event)
+                                                     { OnAddonEvent(event); });
+  }
+
+  VECADDONS addons;
+  CServiceBroker::GetAddonMgr().GetAddons(addons, AddonType::RESOURCE_FONT);
+  // Built aside: an event arriving mid-load must see the last complete set
+  std::set<std::string> addonFontIds;
+  for (const auto& addon : addons)
+  {
+    // Tracked even without a Font.xml: it may supply files to other declarations
+    addonFontIds.insert(addon->ID());
+
+    const auto fontResource = std::static_pointer_cast<CFontResource>(addon);
+    const std::string addonFontsetFilePath =
+        CSpecialProtocol::TranslatePathConvertCase(fontResource->Path() + "/resources/Font.xml");
+    if (!CFileUtils::Exists(addonFontsetFilePath))
+      continue;
+
+    // First fontset is the base set; one named like the skin's specializes on top
+    std::string addonFirstFontset;
+    LoadFontsFromFile(addonFontsetFilePath, fontSet, addonFirstFontset);
+    if (!addonFirstFontset.empty() && !StringUtils::EqualsNoCase(addonFirstFontset, fontSet))
+    {
+      std::string unused;
+      LoadFontsFromFile(addonFontsetFilePath, addonFirstFontset, unused);
+    }
+  }
+
+  std::unique_lock lock(m_critSection);
+  m_addonFontIds = std::move(addonFontIds);
+}
+
+void GUIFontManager::OnAddonEvent(const ADDON::AddonEvent& event)
+{
+  bool reload = false;
+  if (typeid(event) == typeid(AddonEvents::Enabled) ||
+      typeid(event) == typeid(AddonEvents::ReInstalled))
+  {
+    AddonPtr addon;
+    reload = CServiceBroker::GetAddonMgr().GetAddon(event.addonId, addon, AddonType::RESOURCE_FONT,
+                                                    OnlyEnabled::CHOICE_YES);
+
+    if (!reload && typeid(event) == typeid(AddonEvents::ReInstalled))
+    {
+      // the update dropped the font extension, but the old fonts are still loaded
+      std::unique_lock lock(m_critSection);
+      reload = m_addonFontIds.count(event.addonId) != 0;
+    }
+  }
+  else if (typeid(event) == typeid(AddonEvents::Disabled))
+  {
+    // Still installed, so the add-on manager can answer; the tracked set may be mid-load
+    AddonPtr addon;
+    reload = CServiceBroker::GetAddonMgr().GetAddon(event.addonId, addon, AddonType::RESOURCE_FONT,
+                                                    OnlyEnabled::CHOICE_NO);
+  }
+  else if (typeid(event) == typeid(AddonEvents::UnInstalled))
+  {
+    // Gone from the manager, so the last completed load decides
+    std::unique_lock lock(m_critSection);
+    reload = m_addonFontIds.count(event.addonId) != 0;
+  }
+
+  if (reload)
+    CServiceBroker::GetAppMessenger()->PostMsg(TMSG_EXECUTE_BUILT_IN, -1, -1, nullptr,
+                                               "ReloadSkin");
 }
 
 void GUIFontManager::LoadFonts(const TiXmlNode* fontNode)

--- a/xbmc/guilib/GUIFontManager.h
+++ b/xbmc/guilib/GUIFontManager.h
@@ -25,6 +25,10 @@
 #include <vector>
 
 // Forward
+namespace ADDON
+{
+struct AddonEvent;
+}
 class CGUIFont;
 class CGUIFontTTF;
 class CXBMCTinyXML;
@@ -130,8 +134,14 @@ private:
   bool LoadFontsFromFile(const std::string& fontsetFilePath,
                          const std::string& fontSet,
                          std::string& firstFontset);
+  //! \brief Merge in fonts declared by enabled RESOURCE_FONT add-ons; the skin's win
+  void LoadAddonFonts(const std::string& fontSet);
+
+  void OnAddonEvent(const ADDON::AddonEvent& event);
 
   mutable CCriticalSection m_critSection;
+  bool m_addonEventsSubscribed{false};
+  std::set<std::string> m_addonFontIds;
   std::vector<FontMetadata> m_userFontsCache;
 };
 


### PR DESCRIPTION
## Description

`GUIFontManager` only loads font definitions from the **active** skin's `Font.xml`. `LoadAddonFonts()` also merges declarations from enabled `RESOURCE_FONT` add-ons that ship their own `resources/Font.xml`.

This completes a mechanism that is already half there: `LoadTTF()` has long searched enabled `RESOURCE_FONT` add-ons for a font **file** it cannot find. What was missing is any way for an add-on to contribute the **declaration** — the name, size and style a control refers to.

Additive, with no new precedence logic. `LoadTTF()` already returns the existing `CGUIFont` for a name that is defined, so an add-on can only add names the skin has not defined; the skin always wins. `GetAddons()` filters to enabled add-ons, so a disabled one contributes nothing.

The add-on's fontset is matched by name, falling back to the add-on's first fontset — an add-on cannot know what the active skin calls its fontsets (estuary ships both `Default` and `Arial`, and it is a user setting), so requiring them to coincide would make its fonts vanish whenever the user switched.

## Motivation and context

An add-on drawing its own `WindowXML` screens has no supported way to ship the fonts they use. The workaround in the field is to **mutate the user's active skin**: copy the files in and append to its `Font.xml`, as [posted by a Kodi dev in 2013](https://forum.kodi.tv/showthread.php?tid=174694).

That is not cheap. An add-on doing it has to prompt for consent, namespace every injected id, force a restart, version-track what it injected, copy the whole skin out of a read-only filesystem first (CoreELEC's squashfs), and handle Windows separately under `C:\Program Files`. All to register a font name.

Fonts are the only skin-scoped add-on resource with this problem; image decoders, for instance, are already looked up globally by type. This brings `resource.font` add-ons in line.

## How has this been tested?

End to end on Linux/x86_64 against master, estuary active, with a `resource.font` add-on declaring `prtest_addon_font` at 72pt — a name in no skin's `Font.xml` — used by a `WindowXML` label.

Unpatched, the add-on's `Font.xml` is never opened and the label falls back to the skin default. Patched, its fontset loads alongside the skin's and the label renders as declared. The fontset fallback was verified with an id no skin uses. Collision was checked in the same run: the add-on also declares `font12` at 200pt, which estuary declares at 25pt, and it renders at 25pt.

`kodi-test` 3814/295 pass. Previously confirmed on hardware (Ugoos SK1, CoreELEC aarch64) and on macOS/arm64.

## Known constraint: font filenames resolve skin-first

`LoadTTF()` resolves a relative `<filename>` against the skin's `fonts` directory first, so an add-on declaring a filename the skin also ships gets the skin's file, silently. This is pre-existing `LoadTTF()` behaviour, not something this adds, and it matches the precedence used for font names. Changing it would mean threading add-on context through `LoadTTF()`, altering resolution for skins too. Add-on authors should namespace the filename, as they already must the name.

## What is the effect on users?

None unless a `RESOURCE_FONT` add-on shipping `resources/Font.xml` is installed and enabled. Skins are unaffected.

## Types of change
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
