### PR TITLE
[test] skip the disc-part stack test in builds without libbluray

### DIFF
--- a/xbmc/video/test/TestStacks.cpp
+++ b/xbmc/video/test/TestStacks.cpp
@@ -148,6 +148,8 @@ TEST_F(TestStacks, TestMovieFilesStackFolderFilesPart2)
   }
 }
 
+#ifdef HAVE_LIBBLURAY
+// The Blu-ray part is only recognised as a disc folder when libbluray is available.
 TEST_F(TestStacks, TestMovieFilesStackFolderFilesDiscPart)
 {
   const std::string movieFolder =
@@ -175,6 +177,7 @@ TEST_F(TestStacks, TestMovieFilesStackFolderFilesDiscPart)
     EXPECT_EQ(URIUtils::IsBDFile(paths[1]), true);
   }
 }
+#endif
 
 TEST_F(TestStacks, TestStackIsNotItselfADiscFile)
 {


### PR DESCRIPTION
### Description

`TestStacks.TestMovieFilesStackFolderFilesDiscPart` stacks a DVD folder (`VIDEO_TS/VIDEO_TS.IFO`) with a Blu-ray folder (`BDMV/index.bdmv`). Stacking converts each disc folder to its playable file through `VIDEO::UTILS::GetOpticalMediaPath()`, whose Blu-ray filenames are conditional:

```cpp
const auto files{std::array{
    "VIDEO_TS.IFO"s,
    "VIDEO_TS/VIDEO_TS.IFO"s,
#ifdef HAVE_LIBBLURAY
    "index.bdmv"s,
    "BDMV/index.bdmv"s,
    ...
#endif
}};
```

In a build without libbluray the Blu-ray part is never recognised, the two parts do not stack, and the test fails:

```
../xbmc/video/test/TestStacks.cpp:161: Failure
  items.Size()
    Which is: 2
  1
../xbmc/video/test/TestStacks.cpp:165: Failure
  item->IsStack()
    Which is: false
  true
../xbmc/video/test/TestStacks.cpp:171: Failure
  paths.size()
    Which is: 1
  2
```

`ENABLE_BLURAY` is optional, so this is a legal configuration — anyone building without libbluray, distro packagers included, sees a red suite for a feature they did not ask for.

The sibling test file already handles this: `TestVideoUtils.cpp:68` gates its `GetOpticalMediaPath` Blu-ray cases with the same `#ifdef HAVE_LIBBLURAY`. This applies that to the one test in `TestStacks.cpp` that touches a Blu-ray folder on disk. The remaining Blu-ray tests there operate on `stack://` strings and do not go through `GetOpticalMediaPath`, so they are unaffected.

### Motivation and context

Found by running `kodi-test` on a Linux build configured with `BLURAY enabled: No`; 3796 of 3797 tests pass, this one fails. The same suite passes in full on macOS and Windows, whose dependency trees include libbluray.

### How has this been tested?

The failure quoted above is from a Linux/x86_64 build configured with `BLURAY enabled: No` (Ubuntu 22.04, GitHub Actions), running `kodi-test` unpatched. The same suite passes in full on macOS and Windows.

I have not yet run a build with this patch applied - the change is a compile-time guard mirroring `TestVideoUtils.cpp`, and CI on my branch will exercise it.

### Types of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] My code follows the Code Guidelines of this project
- [x] My change requires a change to the documentation — no
