### PR TITLE
RetroPlayer: slow the game down when the audio sink is full, don't flush

### DIFF
--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
@@ -18,6 +18,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <limits>
 #include <chrono>
 #include <thread>
 
@@ -33,12 +34,19 @@ const double MAX_DELAY = 0.3; // seconds
 // stopped draining costs the game loop one frame rather than hanging it.
 constexpr auto MAX_WAIT = std::chrono::milliseconds(100);
 
-// How much audio to keep queued ahead of the speakers. This has to sit above
-// AudioEngine's own buffering floor, or the delay can never reach it and every
-// packet burns the full wait: at 0.1 the floor turned out to be around 0.2 and
-// games ran at about half a frame per second. MAX_DELAY is Kodi's own idea of
-// too much latency, and is comfortably above the floor.
-const double TARGET_DELAY = MAX_DELAY; // seconds
+// How much audio to keep queued ahead of what the sink reports when it has
+// nothing of ours left to play.
+//
+// Measured against that floor rather than against zero. GetDelay() includes the
+// sink's own latency, which is not a small or fixed number: AESinkPULSE asks for
+// a 400 ms buffer on the paths it considers high-latency. A fixed target below
+// that floor can never be reached, so every packet burns its whole wait and the
+// game ends up slower than real time -- seen at about half a frame per second
+// with a 0.1 s target against a floor near 0.2 s.
+//
+// Subtracting the observed floor makes the target mean the same thing on every
+// sink: how much of our audio is queued, not how much latency the device has.
+const double TARGET_AHEAD = 0.1; // seconds
 
 CRetroPlayerAudio::CRetroPlayerAudio(CRPProcessInfo& processInfo) : m_processInfo(processInfo)
 {
@@ -116,6 +124,9 @@ bool CRetroPlayerAudio::OpenStream(const StreamProperties& properties)
   m_processInfo.SetAudioSampleRate(audioFormat.m_sampleRate);
   m_processInfo.SetAudioBitsPerSample(CAEUtil::DataFormatToUsedBits(audioFormat.m_dataFormat));
 
+  // Learned per stream: a new one may be on a device with a different latency
+  m_floorDelaySecs = std::numeric_limits<double>::max();
+
   return true;
 }
 
@@ -129,6 +140,11 @@ void CRetroPlayerAudio::AddStreamData(const StreamPacket& packet)
     {
       const double delaySecs = m_pAudioStream->GetDelay();
 
+      // The smallest delay seen on this stream approximates the sink's own
+      // latency, which is what remains once everything we queued has played.
+      m_floorDelaySecs = std::min(m_floorDelaySecs, delaySecs);
+      const double targetDelay = m_floorDelaySecs + TARGET_AHEAD;
+
       const size_t frameSize = m_pAudioStream->GetChannelCount() *
                                (CAEUtil::DataFormatToBits(m_pAudioStream->GetDataFormat()) >> 3);
 
@@ -138,7 +154,7 @@ void CRetroPlayerAudio::AddStreamData(const StreamPacket& packet)
       // which means something other than a full sink is wrong -- a device that
       // stopped draining, or a client that raced ahead while the stream was
       // unable to take anything.
-      if (delaySecs > MAX_DELAY * 2.0)
+      if (delaySecs > targetDelay + MAX_DELAY)
       {
         m_pAudioStream->Flush();
         CLog::Log(LOGDEBUG, "RetroPlayer[AUDIO]: Audio delay ({:0.2f} ms) is too high - flushing",
@@ -185,12 +201,11 @@ void CRetroPlayerAudio::AddStreamData(const StreamPacket& packet)
       //
       // Bounded by the same deadline, so a stream that has stopped draining
       // costs the game loop a frame rather than hanging it.
-      // Never wait longer than the audio just handed over would take to play.
-      // That bound is what makes this safe: however wrong the target turns out
-      // to be for a given sink, the client can only ever be held to real time,
-      // never slower. Waiting a fixed 100 ms instead, with a target below the
-      // sink's floor, cost every packet the full wait and ran games at about
-      // half a frame per second.
+      // Never wait longer than the audio just handed over would take to play,
+      // so a packet cannot cost more than the time it represents. That caps how
+      // wrong this can go, but it does not make a wrong target free: the wait
+      // runs after the frame has been emulated, so a target the sink can never
+      // reach still adds to every frame. Hence measuring the floor above.
       const unsigned int sampleRate = m_pAudioStream->GetSampleRate();
       if (sampleRate > 0)
       {
@@ -199,7 +214,7 @@ void CRetroPlayerAudio::AddStreamData(const StreamPacket& packet)
                                    std::chrono::microseconds(static_cast<long long>(
                                        1000000.0 * frameCount / sampleRate)));
 
-        while (m_pAudioStream->GetDelay() > TARGET_DELAY &&
+        while (m_pAudioStream->GetDelay() > targetDelay &&
                std::chrono::steady_clock::now() < throttleUntil)
         {
           std::this_thread::sleep_for(std::chrono::milliseconds(1));

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
@@ -17,12 +17,28 @@
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
 #include "utils/log.h"
 
+#include <algorithm>
+#include <chrono>
+#include <thread>
+
 #include <cmath>
 
 using namespace KODI;
 using namespace RETRO;
 
 const double MAX_DELAY = 0.3; // seconds
+
+// How long a single packet may wait before it is given up on. Long enough to
+// ride out a sink that is merely busy, short enough that a sink which has
+// stopped draining costs the game loop one frame rather than hanging it.
+constexpr auto MAX_WAIT = std::chrono::milliseconds(100);
+
+// How much audio to keep queued ahead of the speakers. This has to sit above
+// AudioEngine's own buffering floor, or the delay can never reach it and every
+// packet burns the full wait: at 0.1 the floor turned out to be around 0.2 and
+// games ran at about half a frame per second. MAX_DELAY is Kodi's own idea of
+// too much latency, and is comfortably above the floor.
+const double TARGET_DELAY = MAX_DELAY; // seconds
 
 CRetroPlayerAudio::CRetroPlayerAudio(CRPProcessInfo& processInfo) : m_processInfo(processInfo)
 {
@@ -118,14 +134,77 @@ void CRetroPlayerAudio::AddStreamData(const StreamPacket& packet)
 
       const unsigned int frameCount = static_cast<unsigned int>(audioPacket.size / frameSize);
 
-      if (delaySecs > MAX_DELAY)
+      // Only when the delay is far past what waiting below should ever allow,
+      // which means something other than a full sink is wrong -- a device that
+      // stopped draining, or a client that raced ahead while the stream was
+      // unable to take anything.
+      if (delaySecs > MAX_DELAY * 2.0)
       {
         m_pAudioStream->Flush();
         CLog::Log(LOGDEBUG, "RetroPlayer[AUDIO]: Audio delay ({:0.2f} ms) is too high - flushing",
                   delaySecs * 1000);
       }
 
-      m_pAudioStream->AddData(&audioPacket.data, 0, frameCount, nullptr);
+      const std::chrono::steady_clock::time_point giveUpAt =
+          std::chrono::steady_clock::now() + MAX_WAIT;
+
+      // Feed the sink until it has taken everything, waiting if it is full.
+      unsigned int framesWritten = 0;
+      while (framesWritten < frameCount)
+      {
+        framesWritten += m_pAudioStream->AddData(&audioPacket.data, framesWritten,
+                                                 frameCount - framesWritten, nullptr);
+
+        if (framesWritten >= frameCount)
+          break;
+
+        if (std::chrono::steady_clock::now() >= giveUpAt)
+        {
+          CLog::Log(LOGDEBUG,
+                    "RetroPlayer[AUDIO]: Sink took {} of {} frames before the wait ran out",
+                    framesWritten, frameCount);
+          break;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+
+      // Then hold the client to the speed its own sound plays at.
+      //
+      // This is the throttle, and it has to watch the delay rather than the
+      // sink. AudioEngine buffers generously and takes a whole packet the
+      // moment it is offered, so a client rendering faster than real time is
+      // never blocked by a full sink -- it just runs flat out while the backlog
+      // grows until it is flushed. That is exactly what Dreamcast games did:
+      // roughly twice speed, with the delay climbing past 600 ms and being
+      // flushed over a hundred times a session.
+      //
+      // Libretro clients expect the frontend to pace them through audio;
+      // several have no other throttle. Waiting here for the queue to drain to
+      // TARGET_DELAY is what supplies that.
+      //
+      // Bounded by the same deadline, so a stream that has stopped draining
+      // costs the game loop a frame rather than hanging it.
+      // Never wait longer than the audio just handed over would take to play.
+      // That bound is what makes this safe: however wrong the target turns out
+      // to be for a given sink, the client can only ever be held to real time,
+      // never slower. Waiting a fixed 100 ms instead, with a target below the
+      // sink's floor, cost every packet the full wait and ran games at about
+      // half a frame per second.
+      const unsigned int sampleRate = m_pAudioStream->GetSampleRate();
+      if (sampleRate > 0)
+      {
+        const std::chrono::steady_clock::time_point throttleUntil =
+            std::min(giveUpAt, std::chrono::steady_clock::now() +
+                                   std::chrono::microseconds(static_cast<long long>(
+                                       1000000.0 * frameCount / sampleRate)));
+
+        while (m_pAudioStream->GetDelay() > TARGET_DELAY &&
+               std::chrono::steady_clock::now() < throttleUntil)
+        {
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+      }
     }
   }
 }

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.h
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.h
@@ -11,6 +11,7 @@
 #include "IRetroPlayerStream.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
 
+#include <limits>
 #include <memory>
 
 class IAEStream;
@@ -64,6 +65,12 @@ private:
   CRPProcessInfo& m_processInfo;
   IAE::StreamPtr m_pAudioStream;
   bool m_bAudioEnabled = true;
+
+  // Smallest delay this stream has reported, which stands in for the sink's own
+  // latency: what is left once everything queued has played. Sinks differ by
+  // hundreds of milliseconds, so the throttle target is measured from here
+  // rather than from zero.
+  double m_floorDelaySecs = std::numeric_limits<double>::max();
 };
 } // namespace RETRO
 } // namespace KODI


### PR DESCRIPTION
## Description

A game client is paced by how fast the frontend takes its audio. When the audio sink is full, `CRetroPlayerAudio::AddStreamData()` flushes it and carries on accepting — so nothing ever slows the client down, and it runs as fast as the machine allows.

This waits for the sink to drain instead, up to a bounded time, and keeps a target amount of audio queued ahead of the speakers.

## Motivation and context

Found on Dreamcast, where games ran at roughly **double speed**. It is not specific to that core or to hardware rendering — anything that delivers audio faster than real time is affected, because the throttle that is supposed to hold it back is the one thing being discarded.

Flushing is kept, but only for a delay far past anything the wait should allow. That means something other than a full sink is wrong — a device that stopped draining, or a client that raced ahead while the stream could not take anything.

## Two details worth knowing, both learned the hard way

**The wait has to be bounded.** A sink that has stopped draining altogether would otherwise hang the game loop. A capped wait costs one frame instead.

**The target cannot be a fixed figure.** `GetDelay()` includes the sink's own latency, and that varies by hundreds of milliseconds between devices — `AESinkPULSE::Initialize()` asks for a 400 ms buffer on the paths it treats as high-latency. A target below a device's floor can never be reached, so every packet burns its whole wait; because the wait runs *after* the frame is emulated, that time is added to the frame rather than absorbed by it and the game ends up slower than real time. Measured at about half a frame per second with a 0.1 s target against a floor near 0.2 s.

The target is therefore measured *from* the floor: the smallest delay the stream has reported, plus 100 ms, re-learned per stream. It then means the same thing on every device — how much of our audio is queued, not how much latency the hardware has.

## Types of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature**
- [ ] **Breaking change**

## Testing

Dreamcast (flycast) on Linux, GLES and desktop GL, where the double-speed problem was originally hit — audio and video now run at the correct rate. Also exercised with Dolphin, PPSSPP, melonDS, Mupen64Plus-Next and a software core to confirm no regression in pacing or dropped frames.

Split out of a larger RetroPlayer branch; it stands alone and touches one file.

