### PR TITLE
Games: say when a rumble request goes nowhere

### DIFF
--- a/xbmc/games/addons/input/GameClientJoystick.cpp
+++ b/xbmc/games/addons/input/GameClientJoystick.cpp
@@ -212,8 +212,46 @@ bool CGameClientJoystick::SetRumble(const std::string& feature, float magnitude)
 {
   bool bHandled = false;
 
-  if (InputReceiver())
-    bHandled = InputReceiver()->SetRumbleState(feature, magnitude);
+  JOYSTICK::IInputReceiver* receiver = InputReceiver();
+
+  if (receiver != nullptr)
+    bHandled = receiver->SetRumbleState(feature, magnitude);
+
+  // Report the first motor event, and the first that fails, once each. A game
+  // asking for rumble and not producing any is otherwise entirely silent: the
+  // request is well-formed the whole way down and simply stops, either because
+  // no receiver was attached to this handler or because the peripheral's button
+  // map has no motor of that name for the connected device.
+  // Only a non-zero magnitude says anything: a game stopping a motor it never
+  // started is accepted just as readily, and reporting that as success is what
+  // made an unconnected chain look connected.
+  const bool bMeaningful = (magnitude > 0.0f);
+
+  if (bMeaningful && !(bHandled ? m_bLoggedRumble : m_bLoggedRumbleFailure))
+  {
+    if (bHandled)
+    {
+      CLog::Log(LOGDEBUG, "GAME: Rumble \"{}\" at {:0.2f} accepted by the peripheral", feature,
+                magnitude);
+      m_bLoggedRumble = true;
+    }
+    else if (receiver != nullptr)
+    {
+      // The chain is connected and the request was still turned down, which
+      // means the button map has no motor of that name for this device
+      CLog::Log(LOGWARNING, "GAME: Rumble \"{}\" went nowhere, the peripheral would not take it",
+                feature);
+      m_bLoggedRumbleFailure = true;
+    }
+    else
+    {
+      // Ports are wired up after the client starts, so a game that asks this
+      // early is told no and asks again once there is somewhere to send it.
+      // Reporting that as a warning described a broken chain that then worked.
+      CLog::Log(LOGDEBUG, "GAME: Rumble \"{}\" arrived before the port had a receiver", feature);
+      m_bLoggedRumbleFailure = true;
+    }
+  }
 
   return bHandled;
 }

--- a/xbmc/games/addons/input/GameClientJoystick.cpp
+++ b/xbmc/games/addons/input/GameClientJoystick.cpp
@@ -227,29 +227,42 @@ bool CGameClientJoystick::SetRumble(const std::string& feature, float magnitude)
   // made an unconnected chain look connected.
   const bool bMeaningful = (magnitude > 0.0f);
 
-  if (bMeaningful && !(bHandled ? m_bLoggedRumble : m_bLoggedRumbleFailure))
+  // A flag each, rather than one shared between the failures. The two failures
+  // are not the same event and the harmless one comes first: a game that asks
+  // before its port is wired would otherwise spend the only flag, and the
+  // warning that names a real gap in the button map would never be printed.
+  if (bMeaningful)
   {
     if (bHandled)
     {
-      CLog::Log(LOGDEBUG, "GAME: Rumble \"{}\" at {:0.2f} accepted by the peripheral", feature,
-                magnitude);
-      m_bLoggedRumble = true;
+      if (!m_bLoggedRumble)
+      {
+        CLog::Log(LOGDEBUG, "GAME: Rumble \"{}\" at {:0.2f} accepted by the peripheral", feature,
+                  magnitude);
+        m_bLoggedRumble = true;
+      }
     }
     else if (receiver != nullptr)
     {
       // The chain is connected and the request was still turned down, which
       // means the button map has no motor of that name for this device
-      CLog::Log(LOGWARNING, "GAME: Rumble \"{}\" went nowhere, the peripheral would not take it",
-                feature);
-      m_bLoggedRumbleFailure = true;
+      if (!m_bLoggedRumbleFailure)
+      {
+        CLog::Log(LOGWARNING, "GAME: Rumble \"{}\" went nowhere, the peripheral would not take it",
+                  feature);
+        m_bLoggedRumbleFailure = true;
+      }
     }
     else
     {
       // Ports are wired up after the client starts, so a game that asks this
       // early is told no and asks again once there is somewhere to send it.
       // Reporting that as a warning described a broken chain that then worked.
-      CLog::Log(LOGDEBUG, "GAME: Rumble \"{}\" arrived before the port had a receiver", feature);
-      m_bLoggedRumbleFailure = true;
+      if (!m_bLoggedRumbleUnwired)
+      {
+        CLog::Log(LOGDEBUG, "GAME: Rumble \"{}\" arrived before the port had a receiver", feature);
+        m_bLoggedRumbleUnwired = true;
+      }
     }
   }
 

--- a/xbmc/games/addons/input/GameClientJoystick.h
+++ b/xbmc/games/addons/input/GameClientJoystick.h
@@ -99,6 +99,10 @@ private:
   // Input parameters
   std::unique_ptr<CPortInput> m_portInput;
   PERIPHERALS::PeripheralPtr m_sourcePeripheral;
+
+  // Motor events are reported once each, not once per frame of rumble
+  bool m_bLoggedRumble{false};
+  bool m_bLoggedRumbleFailure{false};
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/addons/input/GameClientJoystick.h
+++ b/xbmc/games/addons/input/GameClientJoystick.h
@@ -103,6 +103,7 @@ private:
   // Motor events are reported once each, not once per frame of rumble
   bool m_bLoggedRumble{false};
   bool m_bLoggedRumbleFailure{false};
+  bool m_bLoggedRumbleUnwired{false};
 };
 } // namespace GAME
 } // namespace KODI


### PR DESCRIPTION
## Description

Follow-up to #28963, which made rumble reach the controller. This adds the reporting that would have made that bug obvious in the first place.

## Motivation and context

A game asking for rumble and getting none is entirely silent. The request is well-formed the whole way down and simply stops, for one of two reasons that look identical from a log:

- the port has no receiver yet, or
- the peripheral's button map has no motor of that name for the connected device

Neither is distinguishable from a game that never asked for rumble at all. #28963 took a while to find for exactly that reason.

This reports the first motor event and the first failure, once each — a handful of lines when a game starts, nothing during play.

**Only a non-zero magnitude counts.** A game stopping a motor it never started is accepted just as readily as one starting it, so counting that as success is what made an unconnected chain look connected. That detail is the reason the original bug hid as long as it did.

## Types of change

- [ ] **Bug fix**
- [x] **Improvement** (diagnostics only; no behaviour change)
- [ ] **Breaking change**

## Testing

Linux with an 8BitDo controller over udev, against flycast and dolphin: confirmed the accepted path logs once, and confirmed both failure paths by disconnecting the port and by asking for a motor the button map does not carry.
