### PR TITLE
Games: name the game database file rather than spelling it inline

### DIFF
--- a/xbmc/games/database/GameDatabase.h
+++ b/xbmc/games/database/GameDatabase.h
@@ -16,6 +16,14 @@ namespace KODI
 namespace GAME
 {
 /*!
+ * \brief Base name of the database file, before the schema version suffix
+ *
+ * Kodi opens "Games" + the schema version, so this is the name every version
+ * of the file shares. Changing it orphans the user's existing database.
+ */
+constexpr const char* GAME_DATABASE_NAME = "Games";
+
+/*!
  * \ingroup games
  *
  * \brief The database of everything Kodi remembers about games
@@ -45,7 +53,7 @@ protected:
   void CreateAnalytics() override;
   void UpdateTables(int version) override;
   int GetSchemaVersion() const override { return 1; }
-  const char* GetBaseDBName() const override { return "Games"; }
+  const char* GetBaseDBName() const override { return GAME_DATABASE_NAME; }
 
 private:
   // Tables


### PR DESCRIPTION
## Description

Follow-up to [a review comment on #28965](https://github.com/xbmc/xbmc/pull/28965#discussion_r3820826088), which asked for the magic string to be at the top of the file rather than inline in `GetBaseDBName()`. That PR merged with it noted as non-blocking, so this is the tidy-up on its own.

The constant carries the doc note that actually matters: Kodi opens this name plus the schema version, so it is the part every version of the file shares, and changing it orphans the user's existing database.

@garbear

## Motivation and context

Purely a readability change requested in review. No behaviour change — `GetBaseDBName()` returns the same `"Games"`, so the file on disk and any migration are untouched.

Worth flagging one thing so it is a deliberate choice rather than an oversight: every other database in the tree spells its name inline the same way `CGameDatabase` did — `MyVideos`, `MyMusic`, `Textures`, `TV`, `Epg`, `ViewModes`. So this makes the games database the odd one out. Happy either way; it seemed better to raise it than to quietly diverge.

## How has this been tested?

Not runtime-tested — it is a named constant substituted for the identical literal in the same translation unit, and `"Games"` appears nowhere else in the tree.

## What is the effect on users?

None.

## Screenshots (if appropriate):

## Types of change
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed