### PR TITLE
[Versions] Turn a removed movie version back into a movie

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -24765,7 +24765,7 @@ msgstr ""
 #. Remove video version dialog text
 #: xbmc/video/dialogs/GUIDialogVideoManager.cpp
 msgctxt "#40020"
-msgid "Are you sure to remove version \"{0:s}\"?"
+msgid "Are you sure to remove version \"{0:s}\" from the library?"
 msgstr ""
 
 #. Remove item from library text if item has multiple versions
@@ -24901,7 +24901,31 @@ msgctxt "#40042"
 msgid "Found a different version of the movie \"{0:s}\" in playlist {1:s} of {2:s} - length {3:s}. Would you like to convert it into an additional version of the original?"
 msgstr ""
 
-#empty strings with id 40043 to 40201
+#. Ungroup video version dialog title
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40043"
+msgid "Ungroup video version"
+msgstr ""
+
+#. Manage versions, ungroup: ungrouping the default version of a movie is not allowed.
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40044"
+msgid "The default version of a movie cannot be ungrouped. Set a different default version and try again."
+msgstr ""
+
+#. Ungroup video version dialog text
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40045"
+msgid "Are you sure to ungroup version \"{0:s}\"?[CR]It will be turned into a library movie entry."
+msgstr ""
+
+#. Button name for video version ungroup function of the manage versions dialog
+#: xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+msgctxt "#40046"
+msgid "Ungroup"
+msgstr ""
+
+#empty strings with id 40047 to 40201
 
 #. Ignore different video versions settting
 #: system/settings/settings.xml

--- a/addons/skin.estuary/xml/DialogVideoManager.xml
+++ b/addons/skin.estuary/xml/DialogVideoManager.xml
@@ -82,7 +82,7 @@
 				<left>1460</left>
 				<top>80</top>
 				<width>300</width>
-				<height>565</height>
+				<height>625</height>
 				<onleft condition="Integer.IsGreater(Container(50).NumItems,0)">100</onleft>
 				<itemgap>dialogbuttons_itemgap</itemgap>
 				<scrolltime tween="quadratic">200</scrolltime>
@@ -117,6 +117,11 @@
 				<include content="DefaultDialogButton">
 					<param name="id" value="26" />
 					<param name="label" value="$LOCALIZE[15015]" />
+				</include>
+                <include content="DefaultDialogButton">
+					<param name="id" value="29" />
+					<param name="label" value="$LOCALIZE[40046]" />
+					<param name="visible">Window.IsVisible(managevideoversions)</param>
 				</include>
 				<include content="DefaultDialogButton">
 					<param name="id" value="25" />

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -733,6 +733,12 @@ void CVideoDatabase::ClearPathHash(const std::string& strPath)
   }
 }
 
+bool CVideoDatabase::LinkMovieToTvshows(int idMovie, std::vector<int> shows, bool remove)
+{
+  return std::ranges::all_of(shows, [this, idMovie, remove](int idShow)
+                             { return this->LinkMovieToTvshow(idMovie, idShow, remove); });
+}
+
 bool CVideoDatabase::LinkMovieToTvshow(int idMovie, int idShow, bool bRemove)
 {
    try

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5493,7 +5493,7 @@ bool CVideoDatabase::GetArtForAsset(int assetId,
       m_pDS2->next();
     }
     m_pDS2->close();
-    return !art.empty();
+    return true;
   }
   catch (...)
   {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -653,6 +653,15 @@ public:
   void GetEpisodesByPlot(const std::string& strSearch, CFileItemList& items);
   void GetMoviesByPlot(const std::string& strSearch, CFileItemList& items);
 
+  /*!
+   * \brief Link or unlink a movie with a list of shows.
+   * \param idMovie Id of the movie
+   * \param shows List of show identifiers
+   * \param remove true: remove link, false: add link
+   * \return true for successful link/unlink of all shows, false on the first error otherwise.
+   * \note Attempting to link an already linked show results in failure.
+   */
+  bool LinkMovieToTvshows(int idMovie, std::vector<int> shows, bool remove);
   bool LinkMovieToTvshow(int idMovie, int idShow, bool bRemove);
   bool IsLinkedToTvshow(int idMovie);
   bool GetLinksToTvShow(int idMovie, std::vector<int>& ids);

--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -459,7 +459,8 @@ bool CVideoThumbLoader::FillLibraryArt(CFileItem &item)
                item.GetVideoInfoTag()->GetAssetInfo().GetType() != VideoAssetType::VERSION)
                   ? ArtFallbackOptions::NONE
                   : ArtFallbackOptions::PARENT,
-              artwork))
+              artwork) &&
+          !artwork.empty())
         item.AppendArt(artwork);
     }
     else if (m_videoDatabase->GetArtForItem(tag.m_iDbId, tag.m_type, artwork) && !artwork.empty())

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -215,6 +215,8 @@ void CGUIDialogVideoManager::Refresh()
   const int dbId{m_videoAsset->GetVideoInfoTag()->m_iDbId};
   const MediaType mediaType{m_videoAsset->GetVideoInfoTag()->m_type};
   const VideoDbContentType itemType{m_videoAsset->GetVideoContentType()};
+  const int selectedId =
+      m_selectedVideoAsset != nullptr ? m_selectedVideoAsset->GetVideoInfoTag()->m_iDbId : -1;
 
   //! @todo db refactor: should not be versions, but assets
   m_database.GetVideoVersions(itemType, dbId, *m_videoAssetsList, GetVideoAssetType());
@@ -225,6 +227,9 @@ void CGUIDialogVideoManager::Refresh()
   for (auto& item : *m_videoAssetsList)
   {
     loader.LoadItem(item.get());
+
+    if (selectedId != -1 && item.get()->GetVideoInfoTag()->m_iDbId == selectedId)
+      m_selectedVideoAsset = item;
   }
 
   CGUIMessage msg{GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST_ASSETS, 0, 0, m_videoAssetsList.get()};

--- a/xbmc/video/dialogs/GUIDialogVideoManager.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManager.cpp
@@ -305,7 +305,8 @@ void CGUIDialogVideoManager::Remove()
   }
 
   // confirm the removal
-  if (!CGUIDialogYesNo::ShowAndGetInput(
+  if (!m_selectedVideoAsset || !m_selectedVideoAsset->HasVideoInfoTag() ||
+      !CGUIDialogYesNo::ShowAndGetInput(
           titleMsgId,
           StringUtils::Format(
               CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(textMsgId),
@@ -314,16 +315,32 @@ void CGUIDialogVideoManager::Remove()
     return;
   }
 
-  m_database.DeleteVideoAsset(m_selectedVideoAsset->GetVideoInfoTag()->m_iDbId);
+  bool success{false};
+  m_database.BeginTransaction();
 
-  // If a version of a bluray then remove the idFile as well
-  if (URIUtils::IsBlurayPath(m_selectedVideoAsset->GetDynPath()))
-    m_database.DeleteFile(m_selectedVideoAsset->GetVideoInfoTag()->m_iFileId);
+  if (m_database.DeleteVideoAsset(m_selectedVideoAsset->GetVideoInfoTag()->m_iDbId))
+  {
+    // If a version of a bluray then remove the idFile as well
+    const bool isblurayPath = URIUtils::IsBlurayPath(m_selectedVideoAsset->GetDynPath());
+    if (!isblurayPath || m_database.DeleteFile(m_selectedVideoAsset->GetVideoInfoTag()->m_iFileId))
+    {
+      success = true;
+    }
+  }
 
-  // refresh data and controls
-  Refresh();
-  RefreshSelectedVideoAsset();
-  UpdateControls();
+  if (success)
+  {
+    m_database.CommitTransaction();
+
+    // refresh data and controls
+    Refresh();
+    RefreshSelectedVideoAsset();
+    UpdateControls();
+  }
+  else
+  {
+    m_database.RollbackTransaction();
+  }
 }
 
 void CGUIDialogVideoManager::Rename()

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.cpp
@@ -46,6 +46,7 @@
 static constexpr unsigned int CONTROL_BUTTON_ADD_VERSION = 22;
 static constexpr unsigned int CONTROL_BUTTON_RENAME_VERSION = 24;
 static constexpr unsigned int CONTROL_BUTTON_SET_DEFAULT = 25;
+static constexpr unsigned int CONTROL_BUTTON_UNGROUP_VERSION = 29;
 static constexpr int NO_VERSION = -1;
 
 CGUIDialogVideoManagerVersions::CGUIDialogVideoManagerVersions()
@@ -84,6 +85,10 @@ bool CGUIDialogVideoManagerVersions::OnMessage(CGUIMessage& message)
       {
         SetDefault();
       }
+      else if (control == CONTROL_BUTTON_UNGROUP_VERSION)
+      {
+        Ungroup();
+      }
       break;
     }
   }
@@ -109,11 +114,13 @@ void CGUIDialogVideoManagerVersions::UpdateButtons()
       m_defaultVideoVersion->GetVideoInfoTag()->m_iDbId)
   {
     DisableRemove();
+    CONTROL_DISABLE(CONTROL_BUTTON_UNGROUP_VERSION);
     CONTROL_DISABLE(CONTROL_BUTTON_SET_DEFAULT);
   }
   else
   {
     EnableRemove();
+    CONTROL_ENABLE(CONTROL_BUTTON_UNGROUP_VERSION);
     CONTROL_ENABLE(CONTROL_BUTTON_SET_DEFAULT);
   }
 
@@ -171,6 +178,87 @@ void CGUIDialogVideoManagerVersions::Remove()
   }
 
   CGUIDialogVideoManager::Remove();
+}
+
+void CGUIDialogVideoManagerVersions::Ungroup()
+{
+  const MediaType mediaType{m_videoAsset->GetVideoInfoTag()->m_type};
+
+  // default video version is not allowed
+  if (m_database.IsDefaultVideoVersion(m_selectedVideoAsset->GetVideoInfoTag()->m_iDbId))
+  {
+    CGUIDialogOK::ShowAndGetInput(CVariant{40043}, CVariant{40044});
+    return;
+  }
+
+  // confirm the action
+  if (!m_selectedVideoAsset || !m_selectedVideoAsset->HasVideoInfoTag() ||
+      !CGUIDialogYesNo::ShowAndGetInput(
+          40043, StringUtils::Format(
+                     CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(40045),
+                     m_selectedVideoAsset->GetVideoInfoTag()->GetAssetInfo().GetTitle())))
+  {
+    return;
+  }
+
+  if (UngroupImpl())
+  {
+    // refresh data and controls
+    Refresh();
+    RefreshSelectedVideoAsset();
+    UpdateControls();
+  }
+}
+
+bool CGUIDialogVideoManagerVersions::UngroupImpl()
+{
+  m_database.BeginTransaction();
+
+  // Strategy: capture version-level information (artwork, name, stream details) and recreate the
+  // version as a movie after deletion.
+  // The existing code and architecture favor that approach rather than building up the stored
+  // version data into a movie.
+
+  const CVideoInfoTag* versionDetails = m_selectedVideoAsset->GetVideoInfoTag();
+
+  KODI::ART::Artwork artwork;
+  if (m_videoAsset->HasVideoInfoTag() &&
+      m_database.GetArtForAsset(versionDetails->m_iDbId, ArtFallbackOptions::PARENT, artwork) &&
+      m_database.DeleteVideoAsset(versionDetails->m_iDbId))
+  {
+    // The item used to open the dialog contains the correct movie information because all
+    // versions of a movie share fields.
+    CVideoInfoTag details = *m_videoAsset->GetVideoInfoTag();
+    const int origMovieId = details.m_iDbId;
+    // Force a movie record creation - the parent movie is found otherwise.
+    details.m_iDbId = -1;
+    // Then modify the persisted fields with the removed version info
+    details.m_iFileId = versionDetails->m_iFileId;
+    details.m_strFileNameAndPath = versionDetails->m_strFileNameAndPath;
+    details.m_basePath = versionDetails->m_basePath;
+    details.m_parentPathID = versionDetails->m_parentPathID;
+    details.m_dateAdded = versionDetails->m_dateAdded;
+    details.m_streamDetails = versionDetails->m_streamDetails;
+    // Preserve the version name
+    details.GetAssetInfo().Clear();
+    details.GetAssetInfo().SetTitle(versionDetails->GetAssetInfo().GetTitle());
+
+    const int movieId = m_database.SetDetailsForMovie(details, artwork);
+    if (movieId >= 0 && movieId != origMovieId)
+    {
+      std::vector<int> showIds;
+      if (m_database.GetLinksToTvShow(origMovieId, showIds) &&
+          (showIds.empty() || m_database.LinkMovieToTvshows(movieId, showIds, false)))
+      {
+        m_database.CommitTransaction();
+        m_hasUpdatedItems = true;
+        return true;
+      }
+    }
+  }
+
+  m_database.RollbackTransaction();
+  return false;
 }
 
 void CGUIDialogVideoManagerVersions::SetDefault()

--- a/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
+++ b/xbmc/video/dialogs/GUIDialogVideoManagerVersions.h
@@ -91,7 +91,18 @@ private:
    * \return true if a version was added, false otherwise.
    */
   bool AddVideoVersion();
+
+  /*!
+   * \brief Set as default button handler
+   */
   void SetDefault();
+
+  /*!
+   * \brief Ungroup button handler
+   */
+  void Ungroup();
+  bool UngroupImpl();
+
   void UpdateDefaultVideoVersionSelection();
 
   enum class Mode


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

The PR adds a button to the "Versions Manager" dialog to change movie versions back to standalone movies in the library.

<img width="1559" height="706" alt="image" src="https://github.com/user-attachments/assets/ffec671a-d7b4-454e-8f04-94dd672018a6" />

The new button is ID 29 in DialogVideoManager.xml

Confirmation message:
<img width="834" height="360" alt="image" src="https://github.com/user-attachments/assets/01555512-b1ad-4403-9c79-39025a95845a" />

The message of the "Remove" button was clarified:
<img width="835" height="357" alt="image" src="https://github.com/user-attachments/assets/b6fabba1-4281-4af3-a029-c419dd0eb5c6" />

Approach: the version is still fully deleted from the database, but enough information is kept in memory to automatically create a movie library entry for the same video, mimicking the library scanner's movie creation.
The movie data is a combination from the version parent (available without db lookup in the versions manager dialog, and relevant because all versions of a movie share most attributes, such as plot, actors, ratings, ...) and the removed version (version name, artwork, stream details).

Modifying the existing version record and completing it with a movie record would have been more complicated, as that would have gone against the design of most of the existing video database code.

Two small issues fixed at the same time:
- the selected item internal data was stale after "Rename". Rename immediately followed by Ungroup of the same version showed the wrong version name in the message. That was also likely causing problems with other buttons, which rely in the selected item data.
- missing transaction around removal and cleanup of bluray traces.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Users have the reasonable expectation that removing a version from a movie returns it to the library as a standalone movie. It came up a few times in support and more recently in Slack.

Up to now, the version was removed and there was no trace left. The user had to launch a library scan for the video to reappear in the library.
With the recent automatic version creation, the video was added as a version again. In order to have the video as a library entry, the user had to remove the version, turn off automatic creation, scan, turn the settin back on.

I decided to keep the existing action and supplement it with another one called "ungroup" because users could start getting confused in the version flattening mode, and bluray piggybacking on the dialog for versions that never were library entries in the first place.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested version ungrouping and removal with the versions manager opened from:
movie > info
movie > manage
flattened version > info
flattened version > manage
version in folder > info
version in folder > manage

Same paths used to check that extras removal did not change.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Versions removed from movies may be returned to the library as movies. The version name, artwork, play status and other fields are preserved.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
