### PR TITLE
RetroPlayer: stop the game loop fast-forwarding to repay a stall

### DIFF
--- a/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
+++ b/xbmc/cores/RetroPlayer/playback/GameLoop.cpp
@@ -22,6 +22,10 @@ constexpr double DEFAULT_FPS = 60.0;
 
 // Duration to sleep while the game loop is paused
 constexpr auto PAUSE_SLEEP = 5s;
+
+// How many frames the loop may fall behind before it gives up the deficit
+// rather than trying to run them back to back
+constexpr unsigned int MAX_FRAME_DEFICIT = 2;
 } // namespace
 
 CGameLoop::CGameLoop(IGameLoopCallback* callback, double fps)
@@ -121,7 +125,21 @@ void CGameLoop::Process(void)
       m_lastFrameUs = nextFrameUs;
 
       // Calculate how much time to sleep before the next frame should be processed
-      const std::chrono::microseconds sleepTimeUs = (nextFrameUs - NowUs());
+      std::chrono::microseconds sleepTimeUs = (nextFrameUs - NowUs());
+
+      // A frame that overruns leaves the loop behind, and the deficit is
+      // carried into the next one so that ordinary jitter averages out to the
+      // right rate. A long stall is not jitter: opening a game leaves hundreds
+      // of milliseconds owed, and carrying that makes the loop repay it by
+      // running frames back to back with no sleep at all, which the player sees
+      // as the game fast-forwarding. Past a few frames, give the deficit up and
+      // carry on from now -- those frames are late whatever happens, and
+      // running them early does not make them less so.
+      if (-sleepTimeUs > FrameTimeUs() * MAX_FRAME_DEFICIT)
+      {
+        m_lastFrameUs = NowUs();
+        sleepTimeUs = std::chrono::microseconds::zero();
+      }
 
       // Only sleep if there is time left before the next frame
       if (sleepTimeUs > std::chrono::microseconds::zero())


### PR DESCRIPTION
## Description

`CGameLoop::Process()` advances `m_lastFrameUs` by exactly one frame time each iteration and never clamps it to now, so a frame that overruns leaves a deficit which is carried indefinitely.

Carrying a little of it is deliberate and right — ordinary jitter averages out and the game holds its rate. Carrying all of it is not: a long stall makes the loop repay the whole deficit by running frames back to back with no sleep at all, which the player sees as the game fast-forwarding.

Past a few frames, the deficit is given up and the loop carries on from now. Those frames are late whatever happens, and running them early does not make them less so.

## Motivation and context

Opening a game is long enough to trigger it. Instrumenting the loop and running `fceumm` at 60 fps, loading the game banked **364 ms of debt — about 22 frames — and the loop spent the next 63 frames running with no sleep at all** to work it off.

Follow-up to review on #29031, where @garbear correctly pointed out that FPS is the arbiter of game timing, not audio. That PR tried to pace the client from the audio sink; this is the same symptom addressed where the timing actually lives.

@garbear also notes that v22 lengthened opening times for videos and that games may be affected too. This does not fix that — it makes a slow open stop producing a burst of fast-forward, whatever the open costs. The open time itself is worth chasing separately and I have it on my list.

## How has this been tested?

Desktop GL build, Wayland, `fceumm` playing an NES title, with the loop instrumented to count frames that got no sleep. Same game and same build either side of the change:

```
before   300 frames, 63 no-sleep (21.0%), worst debt 364 ms
after    300 frames,  2 no-sleep  (0.7%), worst debt 184 ms
```

Held over a longer run: the count stayed at 2 through 1,200 frames, so steady-state pacing is unchanged and the game still runs at rate. The two that remain are the stall itself being observed once before the deficit is dropped, rather than a burst being repaid.

The instrumentation was removed before committing; it is not part of this change.

## What is the effect on users?

A game that takes a moment to open no longer sprints when it starts. Steady-state speed and pacing are unchanged.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
