### PR TITLE
RetroPlayer: say when the audio sink refuses a game's frames

### DIFF
--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
@@ -17,12 +17,16 @@
 #include "cores/RetroPlayer/process/RPProcessInfo.h"
 #include "utils/log.h"
 
+#include <chrono>
 #include <cmath>
 
 using namespace KODI;
 using namespace RETRO;
 
 const double MAX_DELAY = 0.3; // seconds
+
+// How long to stay quiet between log lines.
+const std::chrono::seconds DROP_LOG_INTERVAL{10};
 
 CRetroPlayerAudio::CRetroPlayerAudio(CRPProcessInfo& processInfo) : m_processInfo(processInfo)
 {
@@ -125,7 +129,29 @@ void CRetroPlayerAudio::AddStreamData(const StreamPacket& packet)
                   delaySecs * 1000);
       }
 
-      m_pAudioStream->AddData(&audioPacket.data, 0, frameCount, nullptr);
+      const unsigned int accepted =
+          m_pAudioStream->AddData(&audioPacket.data, 0, frameCount, nullptr);
+
+      // Dropping what the sink won't take is deliberate; being silent about it
+      // is not.
+      if (accepted < frameCount)
+      {
+        m_droppedFrames += frameCount - accepted;
+        ++m_dropEvents;
+
+        const auto now = std::chrono::steady_clock::now();
+
+        if (!m_lastDropLog || now - *m_lastDropLog >= DROP_LOG_INTERVAL)
+        {
+          CLog::Log(LOGDEBUG,
+                    "RetroPlayer[AUDIO]: Sink accepted {} of {} frames, {} refusals since the last "
+                    "message, {} frames dropped so far",
+                    accepted, frameCount, m_dropEvents, m_droppedFrames);
+
+          m_lastDropLog = now;
+          m_dropEvents = 0;
+        }
+      }
     }
   }
 }

--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.h
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.h
@@ -11,7 +11,10 @@
 #include "IRetroPlayerStream.h"
 #include "cores/AudioEngine/Interfaces/AE.h"
 
+#include <chrono>
+#include <cstdint>
 #include <memory>
+#include <optional>
 
 class IAEStream;
 
@@ -64,6 +67,10 @@ private:
   CRPProcessInfo& m_processInfo;
   IAE::StreamPtr m_pAudioStream;
   bool m_bAudioEnabled = true;
+
+  uint64_t m_droppedFrames = 0;
+  uint64_t m_dropEvents = 0;
+  std::optional<std::chrono::steady_clock::time_point> m_lastDropLog;
 };
 } // namespace RETRO
 } // namespace KODI


### PR DESCRIPTION
## Description

`CRetroPlayerAudio::AddStreamData()` discards what `AddData()` returns, so audio the sink will not take disappears without a word.

Dropping it stays the right behaviour — the alternative is waiting on the sink, and a game's timing does not belong to it. This only counts what was refused and says so, at most once every few hundred refusals. Nothing about what happens to the audio changes.

## Motivation and context

Follow-up to review on #29031, where @garbear asked whether I meant to log this or address it. Logging: "addressing" it means blocking or retrying, which makes audio a second thing that can pace the game thread — the design that PR got wrong.

The rate limit matters because a sink that is refusing at all is usually refusing every packet, and those arrive at frame rate.

## How has this been tested?

Desktop GL build, Wayland, `fceumm` playing an NES title. The line fired on the first run, on a session that looked healthy:

```
RetroPlayer[AUDIO]: Sink accepted 0 of 799 frames, 799 dropped so far
```

The opening packet of the session is refused outright. That was not visible before, and it is the sort of thing this is meant to surface — worth knowing when tracking down audio that sounds wrong at the start of a game.

Steady-state play produced no further lines, so it is quiet when nothing is being dropped.

## What is the effect on users?

None directly — a debug log line. It makes dropped audio diagnosable from a log instead of only by ear.

## Screenshots (if appropriate):

## Types of change
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
