### PR TITLE
fixed: a network stall mid-file ending playback as if the file were complete

### DIFF
--- a/cmake/installdata/test-reference-data.txt
+++ b/cmake/installdata/test-reference-data.txt
@@ -8,6 +8,7 @@ xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebasedinterleavedcuts.edl
 xbmc/cores/VideoPlayer/Edl/test/testdata/mplayertimebasedmixed.edl
 xbmc/cores/VideoPlayer/Edl/test/testdata/snapstream.mkv.chapters.xml
 xbmc/cores/VideoPlayer/Edl/test/testdata/videoredo.Vprj
+xbmc/cores/VideoPlayer/test/testdata/h264_8bit_320x240.mkv
 xbmc/filesystem/test/data/audiobook/chaptered.mka
 xbmc/filesystem/test/data/audiobook/chapternames-only.mka
 xbmc/filesystem/test/data/audiobook/lateredition.mka

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -172,9 +172,13 @@ static int dvd_file_read(void* h, uint8_t* buf, int size)
   std::shared_ptr<CDVDInputStream> pInputStream = static_cast<CDVDDemuxFFmpeg*>(h)->m_pInput;
   int len = pInputStream->Read(buf, size);
   if (len == 0)
+  {
+    // A file input that has bytes left is a stalled source rather than the end
+    if (pInputStream->IsStreamType(DVDSTREAM_TYPE_FILE) && !pInputStream->IsEOF())
+      return AVERROR(EAGAIN);
     return AVERROR_EOF;
-  else
-    return len;
+  }
+  return len;
 }
 /*
 static int dvd_file_write(URLContext* h, uint8_t* buf, int size)
@@ -1060,9 +1064,14 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
     std::unique_lock lock(m_critSection); // open lock scope
     if (m_pFormatContext)
     {
-      // assume we are not eof
+      // assume we are not eof; clear stale io error so a failure below is this read's own
       if (m_pFormatContext->pb)
+      {
         m_pFormatContext->pb->eof_reached = 0;
+        m_pFormatContext->pb->error = 0;
+      }
+
+      bool readPacingExpired = false;
 
       // check for saved packet after a program change
       if (m_pkt.result < 0)
@@ -1071,10 +1080,16 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
         m_pkt.pkt.size = 0;
         m_pkt.pkt.data = NULL;
 
-        // timeout reads after 100ms
-        m_timeout.Set(20s);
+        m_timeout.Set(m_readTimeout);
         m_pkt.result = av_read_frame(m_pFormatContext, &m_pkt.pkt);
+        readPacingExpired = m_timeout.IsTimePast();
         m_timeout.SetInfinite();
+      }
+
+      if (m_inputStalled && m_pkt.result >= 0)
+      {
+        m_inputStalled = false;
+        CLog::LogF(LOGINFO, "input recovered");
       }
 
       if (m_pkt.result == AVERROR(EINTR) || m_pkt.result == AVERROR(EAGAIN))
@@ -1084,10 +1099,18 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
       }
       else if (m_pkt.result == AVERROR_EOF)
       {
+        if (WaitingOutInputStall(readPacingExpired))
+          bReturnEmpty = true;
       }
       else if (m_pkt.result < 0)
       {
-        Flush();
+        // A source that blocks inside av_read_frame trips the read timer before its io
+        // error can propagate, so an expired timer is read as pacing rather than an abort
+        if ((m_pkt.result != AVERROR_EXIT || readPacingExpired) &&
+            WaitingOutInputStall(readPacingExpired))
+          bReturnEmpty = true;
+        else
+          Flush();
       }
       // check size and stream index for being in a valid range
       else if (m_pkt.pkt.size < 0 || m_pkt.pkt.stream_index < 0 ||
@@ -1271,6 +1294,53 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
     pPacket->demuxerId = GetDemuxerId();
   }
   return pPacket;
+}
+
+bool CDVDDemuxFFmpeg::WaitingOutInputStall(bool readPacingExpired)
+{
+  if (!m_pInput || !m_pInput->IsStreamType(DVDSTREAM_TYPE_FILE) || m_pInput->IsEOF())
+    return false;
+
+  // Opening the window takes evidence of a stall: an io-reported failure, or the read pacing
+  // expiring around a blocked read.
+  if (!m_inputStalled && !readPacingExpired &&
+      (!m_pFormatContext || !m_pFormatContext->pb || m_pFormatContext->pb->error == 0))
+    return false;
+
+  if (!m_inputStalled)
+  {
+    m_inputStalled = true;
+    m_stallDeadline.Set(m_stallRecoveryWindow);
+    m_nextStallProbe.SetExpired();
+    CLog::LogF(LOGWARNING, "input stalled short of its length, polling for up to {} s",
+               std::chrono::duration_cast<std::chrono::seconds>(m_stallRecoveryWindow).count());
+  }
+  else if (m_stallDeadline.IsTimePast())
+    return false;
+
+  if (!m_nextStallProbe.IsTimePast())
+    return true;
+
+  m_nextStallProbe.Set(STALL_PROBE_INTERVAL);
+
+  // Only the input stream can report recovery: the demuxer's io state stays latched from the
+  // failed reads.
+  const int64_t position = m_pInput->Seek(0, SEEK_CUR);
+  if (position >= 0)
+  {
+    uint8_t probe = 0;
+    if (m_pInput->Read(&probe, 1) >= 0)
+    {
+      m_pInput->Seek(position, SEEK_SET);
+      // A seek is what resets the demuxer's latched end-of-file
+      if (m_pFormatContext && m_currentPts != DVD_NOPTS_VALUE)
+        av_seek_frame(m_pFormatContext, -1, static_cast<int64_t>(m_currentPts),
+                      AVSEEK_FLAG_BACKWARD);
+      CLog::LogF(LOGINFO, "input answered again, resuming");
+    }
+  }
+
+  return true;
 }
 
 DemuxPacket* CDVDDemuxFFmpeg::Read()

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -93,6 +93,12 @@ public:
   void SetSpeed(int iSpeed) override;
   std::string GetFileName() override;
 
+  /*! \brief How long a stalled input is polled before playback ends. */
+  void SetStallRecoveryWindow(std::chrono::milliseconds window) { m_stallRecoveryWindow = window; }
+
+  /*! \brief How long one read is given before it counts as pacing rather than an abort. */
+  void SetReadTimeout(std::chrono::milliseconds timeout) { m_readTimeout = timeout; }
+
   DemuxPacket* Read() override;
   DemuxPacket* ReadInternal(bool keep);
 
@@ -134,6 +140,7 @@ protected:
   AVDictionary* GetFFMpegOptionsFromInput();
   double ConvertTimestamp(int64_t pts, int den, int num);
   bool IsProgramChange();
+  bool WaitingOutInputStall(bool readPacingExpired);
   unsigned int HLSSelectProgram();
 
   std::string GetStereoModeFromMetadata(AVDictionary* pMetadata);
@@ -162,6 +169,19 @@ protected:
   int m_seekStream;
 
   XbmcThreads::EndTime<> m_timeout;
+
+  // Long enough to ride out a network share dropping individual connections for a minute or two
+  static constexpr auto STALL_RECOVERY_WINDOW{std::chrono::minutes(2)};
+  static constexpr auto READ_TIMEOUT{std::chrono::seconds(20)};
+  // The recovery probe blocks until the source fails and holds m_critSection while it does,
+  // so it is paced rather than run on every read
+  static constexpr auto STALL_PROBE_INTERVAL{std::chrono::seconds(1)};
+
+  bool m_inputStalled = false;
+  XbmcThreads::EndTime<> m_stallDeadline;
+  XbmcThreads::EndTime<> m_nextStallProbe;
+  std::chrono::milliseconds m_stallRecoveryWindow{STALL_RECOVERY_WINDOW};
+  std::chrono::milliseconds m_readTimeout{READ_TIMEOUT};
 
   // Due to limitations of ffmpeg, we only can detect a program change
   // with a packet. This struct saves the packet for the next read and

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/test/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/test/CMakeLists.txt
@@ -1,3 +1,4 @@
-set(SOURCES TestDVDDemuxUtils.cpp)
+set(SOURCES TestDVDDemuxFFmpeg.cpp
+            TestDVDDemuxUtils.cpp)
 
 core_add_test_library(dvddemuxers_test)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/test/TestDVDDemuxFFmpeg.cpp
@@ -1,0 +1,202 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileItem.h"
+#include "cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h"
+#include "cores/VideoPlayer/DVDDemuxers/DVDDemuxUtils.h"
+#include "cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.h"
+#include "cores/VideoPlayer/Interface/DemuxPacket.h"
+#include "filesystem/File.h"
+#include "test/TestUtils.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+/* Serves a real file from memory and, once told to stall, behaves like the file cache over a
+ * frozen network flow: each read blocks and then reports an error.
+ */
+class CStallingInputStream : public CDVDInputStreamFile
+{
+public:
+  explicit CStallingInputStream(const CFileItem& fileitem) : CDVDInputStreamFile(fileitem, 0) {}
+
+  bool Open() override
+  {
+    XFILE::CFile file;
+    if (!file.Open(m_item.GetPath()))
+      return false;
+    const int64_t length = file.GetLength();
+    if (length <= 0)
+      return false;
+    m_data.resize(static_cast<size_t>(length));
+    int64_t total = 0;
+    while (total < length)
+    {
+      const ssize_t read = file.Read(m_data.data() + total, length - total);
+      if (read <= 0)
+        return false;
+      total += read;
+    }
+    m_pos = 0;
+    return true;
+  }
+
+  void Close() override {}
+
+  int Read(uint8_t* buf, int buf_size) override
+  {
+    if (m_stalled.load())
+    {
+      // Longer than the demuxer's read timer, so the timer fires before this failure surfaces
+      for (int i = 0; i < 20 && m_stalled.load(); ++i)
+        std::this_thread::sleep_for(100ms);
+      if (m_stalled.load())
+        return -1;
+    }
+    if (m_pos >= static_cast<int64_t>(m_data.size()))
+    {
+      m_eofLatched = true;
+      return 0;
+    }
+    const int count =
+        static_cast<int>(std::min<int64_t>(buf_size, static_cast<int64_t>(m_data.size()) - m_pos));
+    std::memcpy(buf, m_data.data() + m_pos, count);
+    m_pos += count;
+    return count;
+  }
+
+  int64_t Seek(int64_t offset, int whence) override
+  {
+    if (whence == DVDSTREAM_SEEK_POSSIBLE)
+      return 1;
+    int64_t target = -1;
+    if (whence == SEEK_SET)
+      target = offset;
+    else if (whence == SEEK_CUR)
+      target = m_pos + offset;
+    else if (whence == SEEK_END)
+      target = static_cast<int64_t>(m_data.size()) + offset;
+    if (target < 0 || target > static_cast<int64_t>(m_data.size()))
+      return -1;
+    m_pos = target;
+    m_eofLatched = false;
+    return m_pos;
+  }
+
+  bool IsEOF() override { return m_eofLatched; }
+  int64_t GetLength() override { return static_cast<int64_t>(m_data.size()); }
+  int GetBlockSize() override { return 0; }
+
+  void Stall(bool stalled) { m_stalled = stalled; }
+
+private:
+  std::vector<uint8_t> m_data;
+  int64_t m_pos = 0;
+  bool m_eofLatched = false;
+  std::atomic<bool> m_stalled{false};
+};
+} // namespace
+
+/* A container whose index ends before the physical file does - an mp4 with its
+ * moov after the mdat, the default layout - reaches its true end with the read
+ * position still short of the file length, and without a final zero-length
+ * read to latch the input's eof flag. That end must surface promptly.
+ */
+TEST(TestDVDDemuxFFmpeg, IndexedEofWithTrailingBytesIsPrompt)
+{
+  const std::string path = XBMC_REF_FILE_PATH("xbmc/utils/test/resources/no_chapters.mp4");
+  const CFileItem item(path, false);
+  auto input = std::make_shared<CDVDInputStreamFile>(item, 0);
+  ASSERT_TRUE(input->Open());
+
+  CDVDDemuxFFmpeg demux;
+  ASSERT_TRUE(demux.Open(input, false));
+
+  int dataPackets = 0;
+  int emptyPackets = 0;
+  while (DemuxPacket* packet = demux.Read())
+  {
+    if (packet->iSize > 0)
+      ++dataPackets;
+    else
+      ++emptyPackets;
+    CDVDDemuxUtils::FreeDemuxPacket(packet);
+    if (emptyPackets > 32)
+      break;
+  }
+
+  EXPECT_GT(dataPackets, 0) << "the fixture demuxed no data at all";
+  EXPECT_LE(emptyPackets, 32) << "a cleanly ended file was polled as a stalled one";
+}
+
+/* A source that freezes mid-file blocks inside av_read_frame, so the demuxer's
+ * own read timer fires before any io error can surface.
+ *
+ * The matroska fixture is generated:
+ *
+ *   ffmpeg -f lavfi -i "smptebars=s=320x240:r=10:d=2" \
+ *          -c:v libx264 -preset veryslow -crf 30 -pix_fmt yuv420p -g 10 \
+ *          h264_8bit_320x240.mkv
+ */
+TEST(TestDVDDemuxFFmpeg, StalledInputOutlivesTheReadTimer)
+{
+  const std::string path =
+      XBMC_REF_FILE_PATH("xbmc/cores/VideoPlayer/test/testdata/h264_8bit_320x240.mkv");
+  const CFileItem item(path, false);
+  auto input = std::make_shared<CStallingInputStream>(item);
+  ASSERT_TRUE(input->Open());
+
+  CDVDDemuxFFmpeg demux;
+  demux.SetReadTimeout(1s);
+  demux.SetStallRecoveryWindow(60s);
+  ASSERT_TRUE(demux.Open(input, false));
+
+  int dataPackets = 0;
+  while (dataPackets < 8)
+  {
+    DemuxPacket* packet = demux.Read();
+    ASSERT_NE(nullptr, packet) << "demuxing the healthy start of the file failed";
+    if (packet->iSize > 0)
+      ++dataPackets;
+    CDVDDemuxUtils::FreeDemuxPacket(packet);
+  }
+
+  input->Stall(true);
+  const auto stallStart = std::chrono::steady_clock::now();
+  while (std::chrono::steady_clock::now() - stallStart < 6s)
+  {
+    DemuxPacket* packet = demux.Read();
+    const auto stalledFor = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::steady_clock::now() - stallStart);
+    ASSERT_NE(nullptr, packet) << "demuxer gave up " << stalledFor.count()
+                               << "s into a recoverable stall";
+    CDVDDemuxUtils::FreeDemuxPacket(packet);
+  }
+  input->Stall(false);
+
+  int recovered = 0;
+  for (int i = 0; i < 256 && recovered == 0; ++i)
+  {
+    DemuxPacket* packet = demux.Read();
+    ASSERT_NE(nullptr, packet) << "demuxer did not survive the stall clearing";
+    if (packet->iSize > 0)
+      ++recovered;
+    CDVDDemuxUtils::FreeDemuxPacket(packet);
+  }
+  EXPECT_GT(recovered, 0) << "no data packet arrived after the input recovered";
+}

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStreamFile.cpp
@@ -100,7 +100,12 @@ int CDVDInputStreamFile::Read(uint8_t* buf, int buf_size)
 
   /* we currently don't support non completing reads */
   if (ret == 0)
-    m_eof = true;
+  {
+    // A zero read short of the file's length is a stalled source, not the end
+    const int64_t length = m_pFile->GetLength();
+    if (length <= 0 || m_pFile->GetPosition() >= length)
+      m_eof = true;
+  }
 
   return (int)ret;
 }

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -11,7 +11,6 @@
 #include "CircularCache.h"
 #include "File.h"
 #include "ServiceBroker.h"
-#include "URL.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "threads/Thread.h"
@@ -131,6 +130,7 @@ bool CFileCache::Open(const CURL& url)
 
   std::unique_lock lock(m_sync);
 
+  m_sourceUrl = url;
   m_sourcePath = url.GetRedacted();
 
   CLog::Log(LOGDEBUG, "CFileCache::{} - <{}> opening", __FUNCTION__, m_sourcePath);
@@ -167,7 +167,8 @@ bool CFileCache::Open(const CURL& url)
             "CFileCache::{} - <{}> source chunk size is {}, setting cache chunk size to {}",
             __FUNCTION__, m_sourcePath, m_source->GetChunkSize(), m_chunkSize);
 
-  m_fileSize = m_source->GetLength();
+  // A negative length means unknown size, not past the end
+  m_fileSize = std::max<int64_t>(0, m_source->GetLength());
 
   if (!m_pCache)
   {
@@ -286,7 +287,10 @@ void CFileCache::Process()
     bool seekRequested = false;
     if (m_sourcePositionValid)
     {
-      m_fileSize = m_source->GetLength();
+      // A dead source reports no length, which must not erase the real one mid-file
+      const int64_t sourceLength = m_source->GetLength();
+      if (sourceLength > 0)
+        m_fileSize = sourceLength;
       seekRequested = m_seekEvent.Wait(0ms);
     }
     else
@@ -410,6 +414,39 @@ void CFileCache::Process()
       iRead = m_source->Read(buffer.get(), maxSourceRead);
     if (iRead <= 0)
     {
+      // Mid-file on a seekable source this is a stalled or dropped connection, not the end
+      if (!m_bStop && m_seekPossible && m_fileSize > 0 && m_writePos < m_fileSize)
+      {
+        CLog::LogF(LOGWARNING, "<{}> source read returned {} at {} of {}, reconnecting",
+                   m_sourcePath, iRead, m_writePos, m_fileSize.load());
+
+        if (m_seekEvent.Wait(2000ms))
+        {
+          if (!m_bStop)
+            m_seekEvent.Set(); // hack so that later we realize seek is needed
+        }
+        else
+        {
+          m_source->Close();
+          if (m_source->Open(m_sourceUrl, READ_NO_CACHE | READ_TRUNCATED | READ_NO_BUFFER))
+          {
+            // A reopened source is a fresh protocol instance, so the source controls are
+            // reapplied
+            m_source->IoControl(IOControl::SET_CACHE, this);
+            bool retry = false;
+            m_source->IoControl(IOControl::SET_RETRY, &retry);
+            m_seekPossible = m_source->IoControl(IOControl::SEEK_POSSIBLE, nullptr);
+
+            if (m_seekPossible && m_source->Seek(m_writePos, SEEK_SET) == m_writePos)
+              CLog::LogF(LOGINFO, "<{}> source reconnected at {}", m_sourcePath, m_writePos);
+            else
+              m_source->Close();
+          }
+        }
+
+        continue; // while (!m_bStop)
+      }
+
       // Check for actual EOF and retry as long as we still have data in our cache
       if (m_writePos < m_fileSize && m_pCache->WaitForData(0, 0ms) > 0)
       {
@@ -573,6 +610,14 @@ retry:
     if (!m_sourcePositionValid)
     {
       SetLastError(m_seekError != 0 ? m_seekError : EIO);
+      return -1;
+    }
+
+    // Zero means end-of-file to every caller, so starvation has to surface as an error
+    if (iRc == 0 && m_readPos < m_fileSize)
+    {
+      CLog::LogF(LOGWARNING, "<{}> timeout waiting for data at {} of {}", m_sourcePath, m_readPos,
+                 m_fileSize.load());
       return -1;
     }
   }

--- a/xbmc/filesystem/FileCache.h
+++ b/xbmc/filesystem/FileCache.h
@@ -10,6 +10,7 @@
 
 #include "CacheStrategy.h"
 #include "IFile.h"
+#include "URL.h"
 #include "threads/CriticalSection.h"
 #include "threads/Thread.h"
 
@@ -93,6 +94,7 @@ public:
     std::unique_ptr<CCacheStrategy> m_pCache;
     int m_seekPossible = 0;
     std::unique_ptr<IFileCacheSource> m_source;
+    CURL m_sourceUrl;
     std::string m_sourcePath;
     CEvent m_seekEvent;
     CEvent m_seekEnded;

--- a/xbmc/filesystem/test/TestFileCache.cpp
+++ b/xbmc/filesystem/test/TestFileCache.cpp
@@ -8,6 +8,8 @@
 
 #include "URL.h"
 #include "filesystem/FileCache.h"
+#include "filesystem/IFileTypes.h"
+#include "filesystem/PipeFile.h"
 #include "threads/Event.h"
 
 #if !defined(TARGET_WINDOWS)
@@ -368,4 +370,88 @@ TEST(TestFileCache, ReadFailsPromptlyAfterQuarantinedCacheDrains)
   const auto [readResult, readError] = failedRead.get();
   EXPECT_EQ(-1, readResult);
   EXPECT_EQ(ECONNRESET, readError);
+}
+
+/* A source that merely stops answering must not surface as 0. A pipe stands in for
+ * one: reads block while it is empty and the cache's fill thread parks inside the
+ * read. A pipe is not seekable, so this does not exercise the reconnect path.
+ */
+TEST(TestFileCache, StalledSourceMidFileIsNotEof)
+{
+  const CURL pipeUrl("pipe://filecache-stall-test/");
+
+  CPipeFile writer;
+  ASSERT_TRUE(writer.OpenForWrite(pipeUrl));
+
+  CFileCache cache{static_cast<unsigned int>(READ_AUDIO_VIDEO)};
+  ASSERT_TRUE(cache.Open(pipeUrl));
+
+  // The cache refreshes the source's length every fill pass; report an honest
+  // size so the stall happens mid-file rather than at an unknown position.
+  constexpr int64_t fileSize = 10 * 1024 * 1024;
+  auto* source = static_cast<CPipeFile*>(cache.GetFileImp());
+  ASSERT_NE(nullptr, source);
+  source->SetLength(fileSize);
+
+  constexpr size_t delivered = 1024 * 1024;
+  const std::vector<char> data(delivered, 'x');
+  ASSERT_EQ(static_cast<ssize_t>(delivered), writer.Write(data.data(), delivered));
+
+  std::vector<char> buffer(64 * 1024);
+  size_t total = 0;
+  while (total < delivered)
+  {
+    const ssize_t read = cache.Read(buffer.data(), std::min(buffer.size(), delivered - total));
+    ASSERT_GT(read, 0) << "read failed at offset " << total << " with all data still available";
+    total += read;
+  }
+
+  // The source is now stalled with most of the file outstanding.
+  const ssize_t starved = cache.Read(buffer.data(), buffer.size());
+  EXPECT_NE(0, starved) << "a stalled source was reported as end-of-file at position "
+                        << cache.GetPosition() << " of " << cache.GetLength();
+
+  // Eof must be raised before Close: the fill thread may be blocked inside
+  // the pipe read, and Close waits for it to exit.
+  writer.SetEof();
+  cache.Close();
+  writer.Close();
+}
+
+/* When the source really is exhausted at its stated length, 0 is the correct
+ * answer and must keep being served.
+ */
+TEST(TestFileCache, ExhaustedSourceIsEof)
+{
+  const CURL pipeUrl("pipe://filecache-eof-test/");
+
+  CPipeFile writer;
+  ASSERT_TRUE(writer.OpenForWrite(pipeUrl));
+
+  CFileCache cache{static_cast<unsigned int>(READ_AUDIO_VIDEO)};
+  ASSERT_TRUE(cache.Open(pipeUrl));
+
+  constexpr int64_t fileSize = 256 * 1024;
+  auto* source = static_cast<CPipeFile*>(cache.GetFileImp());
+  ASSERT_NE(nullptr, source);
+  source->SetLength(fileSize);
+
+  const std::vector<char> data(fileSize, 'x');
+  ASSERT_EQ(static_cast<ssize_t>(fileSize), writer.Write(data.data(), fileSize));
+  writer.SetEof();
+
+  std::vector<char> buffer(64 * 1024);
+  int64_t total = 0;
+  while (total < fileSize)
+  {
+    const ssize_t read = cache.Read(buffer.data(), buffer.size());
+    ASSERT_GT(read, 0) << "read failed at offset " << total << " of a complete file";
+    total += read;
+  }
+
+  EXPECT_EQ(0, cache.Read(buffer.data(), buffer.size()))
+      << "a source exhausted at its stated length did not read as end-of-file";
+
+  cache.Close();
+  writer.Close();
 }


### PR DESCRIPTION
**TL;DR:** Bug fix. A network share that stalls mid-file was reported upward as a clean end of file, so playback ended with a resume point saved mid-film. The stall now surfaces as buffering, the cache reconnects, and the demuxer waits out the stall before a premature end is allowed to become the end.

## Description
A file source that stops answering mid-file is reported upward as a clean end of file, so the player ends playback and drops to the UI with a resume point saved mid-film. The failure chain and the fix are described in the commit message.

This was diagnosed against a NAS whose individual TCP flows freeze for 60-70 seconds and then heal. Any SMB/NFS source that hiccups for longer than the forward cache can bridge reproduces it: the film simply "ends" partway through.

With this change the stall surfaces as buffering; the cache reconnects a seekable source and resumes at the write position, and the demuxer waits out a stalled file input for up to two minutes before a premature end is allowed to become the end. A source that blocks inside `av_read_frame` trips the demuxer's 20 second read timer before any io error can propagate, and that `AVERROR_EXIT` is read as pacing rather than as an abort; once open, the recovery window holds by itself, because ffmpeg serves latched end-of-file state during a stall with no fresh io to cite. Recovery is probed against the input stream directly and healed with a seek back to the current timestamp, which resets the demuxer's latched end. Only stall evidence opens that window: a clean end of an index-driven container (an mp4 with its moov after the mdat finishes with the position short of the physical length) and a demuxer-level parse error both keep ending playback promptly.

## Motivation and context
Watching a film from a NAS with a transient network fault ends playback silently mid-film.

## How has this been tested?
- New unit tests drive the shipping `CFileCache` over a `pipe://` source: one stalls with most of the file outstanding (previously read as EOF, now an error), one exhausts at its stated length (still reads as EOF).
- A new unit test drives the shipping `CDVDDemuxFFmpeg` over an mp4 whose moov follows the mdat: the clean end must surface promptly rather than being polled as a stall.
- A new unit test drives the shipping `CDVDDemuxFFmpeg` over a generated matroska fed by an input that blocks like a frozen share: the demuxer must outlive its own 20 second read timer during the stall and resume real data packets once the input answers again. Written failing (playback previously died at exactly stall+20 s) and fixed by the pacing/probe handling above.
- Validated against the live NAS fault during real playback: freezes shorter than the read timer are bridged by the reconnecting cache and surface as a brief buffer; the fatal stall+20 s deaths reproduced three times on the previous revision and are covered by the new test.
- Full gtest suite green on Windows x64.

## What is the effect on users?
A film played from a network share that stalls for a minute or so buffers and resumes instead of ending silently partway through.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
