### PR TITLE
[python] fix LanguageInvoker reuse races with concurrent plugin scripts

### DIFF
--- a/xbmc/interfaces/generic/LanguageInvokerThread.cpp
+++ b/xbmc/interfaces/generic/LanguageInvokerThread.cpp
@@ -37,6 +37,7 @@ InvokerState CLanguageInvokerThread::GetState() const
 
 void CLanguageInvokerThread::Release()
 {
+  std::unique_lock<std::mutex> lck(m_mutex);
   m_bStop = true;
   m_condition.notify_one();
 }
@@ -46,17 +47,20 @@ bool CLanguageInvokerThread::execute(const std::string &script, const std::vecto
   if (m_invoker == NULL || script.empty())
     return false;
 
-  m_script = script;
-  m_args = arguments;
-
   if (CThread::IsRunning())
   {
     std::unique_lock<std::mutex> lck(m_mutex);
+    m_script = script;
+    m_args = arguments;
     m_restart = true;
     m_condition.notify_one();
   }
   else
+  {
+    m_script = script;
+    m_args = arguments;
     Create();
+  }
 
   //Todo wait until running
 
@@ -104,7 +108,15 @@ void CLanguageInvokerThread::Process()
   do
   {
     m_restart = false;
-    m_invoker->Execute(m_script, m_args);
+    const std::string script = m_script;
+    const std::vector<std::string> args = m_args;
+    // Execute() talks to the GUI and to other invokers. Holding m_mutex
+    // across it deadlocks Home.xml load: a JobWorker in Release()/restart
+    // waits for this lock, the app thread waits for that job, and this
+    // script waits for the GUI.
+    lckdl.unlock();
+    m_invoker->Execute(script, args);
+    lckdl.lock();
 
     if (m_invoker->GetState() != InvokerStateScriptDone)
       m_reusable = false;

--- a/xbmc/interfaces/generic/LanguageInvokerThread.cpp
+++ b/xbmc/interfaces/generic/LanguageInvokerThread.cpp
@@ -42,25 +42,45 @@ void CLanguageInvokerThread::Release()
   m_condition.notify_one();
 }
 
+bool CLanguageInvokerThread::Claim()
+{
+  bool unclaimed = false;
+  return m_claimed.compare_exchange_strong(unclaimed, true);
+}
+
+void CLanguageInvokerThread::ReleaseClaim()
+{
+  m_claimed = false;
+}
+
 bool CLanguageInvokerThread::execute(const std::string &script, const std::vector<std::string> &arguments)
 {
   if (m_invoker == NULL || script.empty())
     return false;
 
+  std::unique_lock<std::mutex> lck(m_mutex);
+
+  // The Process() loop has gone but the thread has not: CThread::IsRunning()
+  // stays true all through OnExit()/Py_EndInterpreter, so a restart set here
+  // would notify a condition variable nobody waits on and the script would
+  // silently never run. Create() is not an alternative either - it calls
+  // exit(1) while the previous thread has not fulfilled its promise. Refuse,
+  // and let the caller start a fresh thread.
+  if (m_processDone)
+    return false;
+
+  m_script = script;
+  m_args = arguments;
+
   if (CThread::IsRunning())
   {
-    std::unique_lock<std::mutex> lck(m_mutex);
-    m_script = script;
-    m_args = arguments;
     m_restart = true;
     m_condition.notify_one();
+    return true;
   }
-  else
-  {
-    m_script = script;
-    m_args = arguments;
-    Create();
-  }
+
+  lck.unlock();
+  Create();
 
   //Todo wait until running
 
@@ -105,7 +125,8 @@ void CLanguageInvokerThread::Process()
     return;
 
   std::unique_lock<std::mutex> lckdl(m_mutex);
-  do
+  bool keepGoing = true;
+  while (keepGoing)
   {
     m_restart = false;
     const std::string script = m_script;
@@ -118,12 +139,22 @@ void CLanguageInvokerThread::Process()
     m_invoker->Execute(script, args);
     lckdl.lock();
 
-    if (m_invoker->GetState() != InvokerStateScriptDone)
+    // A claimed invoker was Reset() on purpose by whoever claimed it, so its
+    // state says nothing about whether this thread is still worth keeping.
+    // Reading it unconditionally raced that Reset() and retired the very
+    // thread the claimer was about to run its script on.
+    if (!IsClaimed() && m_invoker->GetState() != InvokerStateScriptDone)
       m_reusable = false;
 
-    m_condition.wait(lckdl, [this] { return m_bStop || m_restart || !m_reusable; });
+    m_condition.wait(lckdl,
+                     [this] { return m_bStop || m_restart || (!m_reusable && !IsClaimed()); });
 
-  } while (m_reusable && !m_bStop);
+    // A claim keeps the loop open, so a stop request does not have to be
+    // ignored to protect a script that has just been handed to this thread.
+    keepGoing = (m_restart || m_reusable || IsClaimed()) && !m_bStop;
+    if (!keepGoing)
+      m_processDone = true; // set under m_mutex, before execute() can look again
+  }
 }
 
 void CLanguageInvokerThread::OnExit()

--- a/xbmc/interfaces/generic/LanguageInvokerThread.h
+++ b/xbmc/interfaces/generic/LanguageInvokerThread.h
@@ -11,6 +11,7 @@
 #include "interfaces/generic/ILanguageInvoker.h"
 #include "threads/Thread.h"
 
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -26,12 +27,21 @@ public:
 
   virtual InvokerState GetState() const;
 
-  const std::string& GetScript() const { return m_script; }
   std::shared_ptr<ILanguageInvoker> GetInvoker() const { return m_invoker; }
   bool Reuseable(const std::string& script) const
   {
-    return !m_bStop && m_reusable && GetState() == InvokerStateScriptDone && m_script == script;
-  };
+    // Cheap, independently-synchronised checks first, so the common "not
+    // reusable" answer does not contend with a running script for m_mutex.
+    if (m_bStop || GetState() != InvokerStateScriptDone)
+      return false;
+
+    // m_script and m_reusable are written by execute() and Process() under
+    // m_mutex. Reading them unlocked from the manager thread was a data race on
+    // a std::string: a concurrent assignment can reallocate the buffer while
+    // the comparison walks it.
+    std::unique_lock<std::mutex> lck(m_mutex);
+    return m_reusable && m_script == script;
+  }
   virtual void Release();
 
 protected:
@@ -49,7 +59,10 @@ private:
   std::string m_script;
   std::vector<std::string> m_args;
 
-  std::mutex m_mutex;
+  //! Guards m_script, m_args and m_reusable. Taken while m_critSection is held
+  //! (CScriptInvocationManager -> Reuseable()/Release()); never the other way
+  //! round, which is why Process() drops it across Execute().
+  mutable std::mutex m_mutex;
   std::condition_variable m_condition;
   bool m_restart = false;
   bool m_reusable = false;

--- a/xbmc/interfaces/generic/LanguageInvokerThread.h
+++ b/xbmc/interfaces/generic/LanguageInvokerThread.h
@@ -11,6 +11,7 @@
 #include "interfaces/generic/ILanguageInvoker.h"
 #include "threads/Thread.h"
 
+#include <atomic>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -32,7 +33,7 @@ public:
   {
     // Cheap, independently-synchronised checks first, so the common "not
     // reusable" answer does not contend with a running script for m_mutex.
-    if (m_bStop || GetState() != InvokerStateScriptDone)
+    if (m_bStop || IsClaimed() || IsProcessDone() || GetState() != InvokerStateScriptDone)
       return false;
 
     // m_script and m_reusable are written by execute() and Process() under
@@ -42,6 +43,72 @@ public:
     std::unique_lock<std::mutex> lck(m_mutex);
     return m_reusable && m_script == script;
   }
+
+  /*!
+   * \brief Try to take the claim on this thread.
+   *
+   * A claim marks the thread as spoken for from the moment it is handed out
+   * until its owner drops it, which is what covers the gap between Reset() and
+   * the script actually running. Only one claim can be held at a time.
+   *
+   * \return True if the claim was taken, false if somebody else already holds it
+   */
+  bool Claim();
+
+  //! \brief Drop the claim taken by Claim().
+  void ReleaseClaim();
+
+  bool IsClaimed() const { return m_claimed; }
+
+  //! \brief True once Release()/stop() has asked this thread to finish.
+  //! Deliberately not IsStopping(): that is an ILanguageInvoker virtual meaning
+  //! "the invoker reached InvokerStateStopping", which is a different question.
+  bool IsStopRequested() const { return m_bStop; }
+
+  /*!
+   * \brief True once the Process() loop has left and will accept no more work.
+   *
+   * CThread::IsRunning() stays true until OnExit() (and Py_EndInterpreter) have
+   * finished, so it cannot answer this on its own.
+   */
+  bool IsProcessDone() const { return m_processDone; }
+
+  /*!
+   * \brief True unless this thread is idle and safe to retire.
+   *
+   * IsActive() cannot answer this on its own: it is false for
+   * InvokerStateUninitialized, which is where a thread sits both when a claimer
+   * has Reset() it and when it has been published as the reusable one but has
+   * not started. Releasing either loses a script that nothing will run again.
+   * The state alone cannot answer it either - a claim dropped without ever
+   * running leaves the same Uninitialized, and that one must stay releasable or
+   * it pins the slot for the session.
+   */
+  bool IsBusy() const
+  {
+    if (IsClaimed())
+      return true;
+
+    // The loop has left. Nothing more can run here whatever the invoker says,
+    // and the slot has to be given up or it is pinned for good.
+    if (IsProcessDone())
+      return false;
+
+    // Published as the reusable thread, but execute() has not reached Create()
+    // yet. A Release() landing here sets m_bStop, Create() clears it again, and
+    // the loop then parks for ever on a thread nothing can reach: the
+    // interpreter is retained and the script stays marked running.
+    if (!CThread::IsRunning())
+      return true;
+
+    // The loop is parked. Busy only if a script is already running or queued -
+    // execute() returns as soon as it has set the restart, and the handle-less
+    // path drops its claim at that point, so the queued script is all that is
+    // left marking the thread. An invoker left Uninitialized by a claim that
+    // was dropped without running is idle and must stay releasable.
+    return m_invoker->IsActive() || HasQueuedScript();
+  }
+
   virtual void Release();
 
 protected:
@@ -54,16 +121,25 @@ protected:
   void OnException() override;
 
 private:
+  //! \brief True once execute() has queued a script the Process() loop has not taken yet.
+  bool HasQueuedScript() const
+  {
+    std::unique_lock<std::mutex> lck(m_mutex);
+    return m_restart;
+  }
+
   std::shared_ptr<ILanguageInvoker> m_invoker;
   CScriptInvocationManager *m_invocationManager;
   std::string m_script;
   std::vector<std::string> m_args;
 
-  //! Guards m_script, m_args and m_reusable. Taken while m_critSection is held
+  //! Guards m_script, m_args, m_restart and m_reusable. Taken while m_critSection is held
   //! (CScriptInvocationManager -> Reuseable()/Release()); never the other way
   //! round, which is why Process() drops it across Execute().
   mutable std::mutex m_mutex;
   std::condition_variable m_condition;
   bool m_restart = false;
   bool m_reusable = false;
+  std::atomic<bool> m_claimed{false};
+  std::atomic<bool> m_processDone{false};
 };

--- a/xbmc/interfaces/generic/RunningScriptsHandler.h
+++ b/xbmc/interfaces/generic/RunningScriptsHandler.h
@@ -35,12 +35,21 @@ protected:
     if (script == nullptr || addon == nullptr)
       return false;
 
-    // reuse an existing script handle or get a new one if necessary
-    int handle = CScriptInvocationManager::GetInstance().GetReusablePluginHandle(addon->LibPath());
-    if (handle < 0)
-      handle = GetNewScriptHandle(script);
-    else
+    // Claim the reusable invoker for as long as the script runs. Destroying the
+    // claim - here or on any early return - is what hands it back, so no exit
+    // path can leave the slot marked in use.
+    const CReusableInvokerClaim claim =
+        CScriptInvocationManager::GetInstance().ClaimReusableInvoker(addon->LibPath());
+
+    // reuse the claimed script handle or get a new one if necessary
+    HandleType handle;
+    if (claim.IsValid())
+    {
+      handle = claim.GetPluginHandle();
       ReuseScriptHandle(handle, script);
+    }
+    else
+      handle = GetNewScriptHandle(script);
 
     // run the script
     auto result = CScriptRunner::RunScript(addon, url, handle, resume);

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -25,6 +25,29 @@
 #include <utility>
 #include <vector>
 
+CReusableInvokerClaim& CReusableInvokerClaim::operator=(CReusableInvokerClaim&& other) noexcept
+{
+  if (this != &other)
+  {
+    Release();
+    m_thread = std::move(other.m_thread);
+    m_pluginHandle = other.m_pluginHandle;
+    other.m_thread = nullptr;
+    other.m_pluginHandle = -1;
+  }
+  return *this;
+}
+
+void CReusableInvokerClaim::Release()
+{
+  if (!m_thread)
+    return;
+
+  m_thread->ReleaseClaim();
+  m_thread = nullptr;
+  m_pluginHandle = -1;
+}
+
 CScriptInvocationManager::~CScriptInvocationManager()
 {
   Uninitialize();
@@ -65,6 +88,7 @@ void CScriptInvocationManager::Uninitialize()
 
   // it is safe to release early, thread must be in m_scripts too
   m_lastInvokerThread = nullptr;
+  m_lastPluginHandle = -1;
 
   // make sure all scripts are done
   std::vector<LanguageInvokerThread> tempList;
@@ -157,36 +181,63 @@ bool CScriptInvocationManager::HasLanguageInvoker(const std::string &script) con
   return it != m_invocationHandlers.end() && it->second != nullptr;
 }
 
-int CScriptInvocationManager::GetReusablePluginHandle(const std::string& script)
+CReusableInvokerClaim CScriptInvocationManager::ClaimReusableInvoker(const std::string& script)
 {
   std::unique_lock lock(m_critSection);
 
   if (m_lastInvokerThread)
   {
-    if (m_lastInvokerThread->Reuseable(script))
-      return m_lastPluginHandle;
-    m_lastInvokerThread->Release();
-    m_lastInvokerThread = nullptr;
+    // The interpreter is only worth claiming together with the plugin handle it
+    // was created for. Without one the caller has to allocate a new handle and
+    // would run on a fresh invoker anyway, so claiming here would just mark a
+    // slot that the returned claim could never be matched back to.
+    if (m_lastPluginHandle >= 0 && m_lastInvokerThread->Reuseable(script) &&
+        m_lastInvokerThread->Claim())
+    {
+      m_lastInvokerThread->GetInvoker()->Reset();
+      CLog::Log(LOGDEBUG, "{} - claimed reusable plugin handle {} on LanguageInvokerThread {}",
+                __FUNCTION__, m_lastPluginHandle, m_lastInvokerThread->GetId());
+      return {m_lastInvokerThread, m_lastPluginHandle};
+    }
+    ReleaseLastInvokerIfIdle();
   }
-  return -1;
+  return {};
 }
 
 std::shared_ptr<ILanguageInvoker> CScriptInvocationManager::GetLanguageInvoker(
-    const std::string& script)
+    const std::string& script, int pluginHandle /* = -1 */)
 {
   std::unique_lock lock(m_critSection);
 
   if (m_lastInvokerThread)
   {
-    if (m_lastInvokerThread->Reuseable(script))
+    // The caller holds a claim on this thread, which was granted for this script
+    // and stops anyone else taking it, so the reuse checks were already made at
+    // claim time. Stop() can still have run since, which is what is left to test.
+    const bool claimedByCaller =
+        pluginHandle >= 0 && pluginHandle == m_lastPluginHandle && m_lastInvokerThread->IsClaimed();
+    if (claimedByCaller)
     {
-      CLog::Log(LOGDEBUG, "{} - Reusing LanguageInvokerThread {} for script {}", __FUNCTION__,
-                m_lastInvokerThread->GetId(), script);
-      m_lastInvokerThread->GetInvoker()->Reset();
-      return m_lastInvokerThread->GetInvoker();
+      if (!m_lastInvokerThread->IsStopRequested() && !m_lastInvokerThread->IsProcessDone())
+        return m_lastInvokerThread->GetInvoker();
     }
-    m_lastInvokerThread->Release();
-    m_lastInvokerThread = nullptr;
+    else
+    {
+      // Scripts run without a plugin handle have no claim holder of their own,
+      // so take the claim here; ExecuteAsync drops it once the thread has been
+      // handed the script. A claim held by somebody else fails this and falls
+      // through to a new invoker.
+      if (pluginHandle < 0 && m_lastInvokerThread->Reuseable(script) &&
+          m_lastInvokerThread->Claim())
+      {
+        CLog::Log(LOGDEBUG, "{} - Reusing LanguageInvokerThread {} for script {}", __FUNCTION__,
+                  m_lastInvokerThread->GetId(), script);
+        m_lastInvokerThread->GetInvoker()->Reset();
+        return m_lastInvokerThread->GetInvoker();
+      }
+      // A concurrent script must not Release() a claimed or running invoker.
+      ReleaseLastInvokerIfIdle();
+    }
   }
 
   std::string extension = URIUtils::GetExtension(script);
@@ -215,7 +266,7 @@ int CScriptInvocationManager::ExecuteAsync(
     return -1;
   }
 
-  auto invoker = GetLanguageInvoker(script);
+  auto invoker = GetLanguageInvoker(script, pluginHandle);
   return ExecuteAsync(script, invoker, addon, arguments, reuseable, pluginHandle);
 }
 
@@ -245,27 +296,52 @@ int CScriptInvocationManager::ExecuteAsync(
 
     // After we leave the lock, m_lastInvokerThread can be released -> copy!
     auto invokerThread = m_lastInvokerThread;
+    // A claim taken by GetLanguageInvoker for a script without a plugin handle
+    // has no other owner, so it is dropped once the thread has the script.
+    // Handing over is safe because the invoker was Reset() out of ScriptDone to
+    // run this script, and IsBusy() counts anything but a parked ScriptDone
+    // thread as occupied, so nothing can Release() it in the gap.
+    const bool ownsClaim = pluginHandle < 0;
     lock.unlock();
-    invokerThread->Execute(script, arguments);
+    const bool started = invokerThread->Execute(script, arguments);
+    if (ownsClaim)
+      invokerThread->ReleaseClaim();
 
-    return invokerThread->GetId();
+    if (started)
+      return invokerThread->GetId();
+
+    // Only reachable if the thread was stopped between the claim and here. Say
+    // so rather than handing back an id for a script that will never run and
+    // leaving the caller to wait on it.
+    CLog::Log(LOGDEBUG, "{} - LanguageInvokerThread {} refused {}, it is stopping", __FUNCTION__,
+              invokerThread->GetId(), script);
+    return -1;
   }
 
-  m_lastInvokerThread = std::make_shared<CLanguageInvokerThread>(languageInvoker, this, reuseable);
-  if (m_lastInvokerThread == nullptr)
-    return -1;
+  const bool lastBusy = LastInvokerOccupied();
+  auto invokerThread =
+      std::make_shared<CLanguageInvokerThread>(languageInvoker, this, reuseable && !lastBusy);
 
   if (addon != nullptr)
-    m_lastInvokerThread->SetAddon(addon);
+    invokerThread->SetAddon(addon);
 
-  m_lastInvokerThread->SetId(m_nextId++);
-  m_lastPluginHandle = pluginHandle;
+  invokerThread->SetId(m_nextId++);
 
-  LanguageInvokerThread thread = {m_lastInvokerThread, script, false};
-  m_scripts.insert(std::make_pair(m_lastInvokerThread->GetId(), thread));
-  m_scriptPaths.insert(std::make_pair(script, m_lastInvokerThread->GetId()));
-  // After we leave the lock, m_lastInvokerThread can be released -> copy!
-  auto invokerThread = m_lastInvokerThread;
+  LanguageInvokerThread thread = {invokerThread, script, false};
+  m_scripts.insert(std::make_pair(invokerThread->GetId(), thread));
+  m_scriptPaths.insert(std::make_pair(script, invokerThread->GetId()));
+
+  // Do not steal the reusable slot from a claimed or running last thread, and
+  // only ever park a thread there that is allowed to be reused. A service
+  // add-on runs until shutdown, so letting one occupy the slot pinned it for
+  // the session and turned reuselanguageinvoker off for everything else.
+  if (!lastBusy && reuseable)
+  {
+    ReleaseLastInvokerIfIdle();
+    m_lastInvokerThread = invokerThread;
+    m_lastPluginHandle = pluginHandle;
+  }
+
   lock.unlock();
   invokerThread->Execute(script, arguments);
 
@@ -391,6 +467,21 @@ void CScriptInvocationManager::OnExecutionDone(int scriptId)
   const auto script = m_scripts.find(scriptId);
   if (script != m_scripts.end())
     script->second.done = true;
+}
+
+bool CScriptInvocationManager::LastInvokerOccupied() const
+{
+  return m_lastInvokerThread && m_lastInvokerThread->IsBusy();
+}
+
+void CScriptInvocationManager::ReleaseLastInvokerIfIdle()
+{
+  if (!LastInvokerOccupied() && m_lastInvokerThread)
+  {
+    m_lastInvokerThread->Release();
+    m_lastInvokerThread = nullptr;
+    m_lastPluginHandle = -1;
+  }
 }
 
 CScriptInvocationManager::LanguageInvokerThread CScriptInvocationManager::getInvokerThread(int scriptId) const

--- a/xbmc/interfaces/generic/ScriptInvocationManager.h
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.h
@@ -15,9 +15,51 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <utility>
 #include <vector>
 
 class CLanguageInvokerThread;
+
+/*!
+ * \brief RAII claim on the reusable language invoker and its plugin handle.
+ *
+ * While a claim is held CScriptInvocationManager will neither hand that invoker
+ * to another script nor release it as idle. Dropping the claim - on scope exit,
+ * an early return, or an exception - is what puts the slot back in circulation,
+ * so a caller cannot leak the claimed state by forgetting to clean up.
+ */
+class CReusableInvokerClaim
+{
+public:
+  CReusableInvokerClaim() = default;
+  ~CReusableInvokerClaim() { Release(); }
+
+  CReusableInvokerClaim(CReusableInvokerClaim&& other) noexcept { *this = std::move(other); }
+  CReusableInvokerClaim& operator=(CReusableInvokerClaim&& other) noexcept;
+
+  CReusableInvokerClaim(const CReusableInvokerClaim&) = delete;
+  CReusableInvokerClaim& operator=(const CReusableInvokerClaim&) = delete;
+
+  //! \brief True if a reusable invoker and its plugin handle were claimed.
+  bool IsValid() const { return m_thread != nullptr; }
+
+  //! \brief The claimed plugin handle, or -1 if nothing was claimed.
+  int GetPluginHandle() const { return m_pluginHandle; }
+
+  //! \brief Drop the claim. Safe to call on an invalid claim and more than once.
+  void Release();
+
+private:
+  friend class CScriptInvocationManager;
+  CReusableInvokerClaim(std::shared_ptr<CLanguageInvokerThread> thread, int pluginHandle)
+    : m_thread(std::move(thread)),
+      m_pluginHandle(pluginHandle)
+  {
+  }
+
+  std::shared_ptr<CLanguageInvokerThread> m_thread;
+  int m_pluginHandle{-1};
+};
 
 class CScriptInvocationManager
 {
@@ -30,13 +72,32 @@ public:
   void RegisterLanguageInvocationHandler(ILanguageInvocationHandler *invocationHandler, const std::string &extension);
   void RegisterLanguageInvocationHandler(ILanguageInvocationHandler *invocationHandler, const std::set<std::string> &extensions);
   void UnregisterLanguageInvocationHandler(ILanguageInvocationHandler *invocationHandler);
-  bool HasLanguageInvoker(const std::string &script) const;
-  std::shared_ptr<ILanguageInvoker> GetLanguageInvoker(const std::string& script);
+  bool HasLanguageInvoker(const std::string& script) const;
 
   /*!
-  * \brief Returns addon_handle if last reusable invoker is ready to use.
-  */
-  int GetReusablePluginHandle(const std::string& script);
+   * \brief Returns the invoker to run the given script with.
+   *
+   * \param script Path to the script to be executed
+   * \param pluginHandle The plugin handle the script will run with, or -1 if it
+   *        is not a plugin invocation. A handle matching an outstanding claim
+   *        (see ClaimReusableInvoker) resolves to that claim's invoker.
+   * \return The invoker to use, or a new one if nothing reusable is available
+   */
+  std::shared_ptr<ILanguageInvoker> GetLanguageInvoker(const std::string& script,
+                                                       int pluginHandle = -1);
+
+  /*!
+   * \brief Claim the reusable invoker for the given script, if there is one.
+   *
+   * A valid claim gives the caller exclusive use of a parked interpreter and the
+   * plugin handle it was created for. Hold it for as long as the script runs;
+   * destroying it hands the invoker back. An invalid claim means the caller has
+   * to allocate its own handle and will get a fresh invoker.
+   *
+   * \param script Path to the script about to be executed
+   * \return The claim, which is invalid if nothing reusable was available
+   */
+  CReusableInvokerClaim ClaimReusableInvoker(const std::string& script);
 
   /*!
    * \brief Executes the given script asynchronously in a separate thread.
@@ -144,6 +205,10 @@ private:
   using LanguageInvocationHandlerMap = std::map<std::string, ILanguageInvocationHandler*>;
 
   LanguageInvokerThread getInvokerThread(int scriptId) const;
+  void ReleaseLastInvokerIfIdle();
+  //! True if the last reusable thread is claimed, has a script queued, or is
+  //! running one. Caller must hold m_critSection.
+  bool LastInvokerOccupied() const;
 
   LanguageInvocationHandlerMap m_invocationHandlers;
   LanguageInvokerThreadMap m_scripts;


### PR DESCRIPTION
I'm experimenting with a fork of Estuary that uses plugin widgets to load Jellyfin content. Loading multiple widgets in parallel crashes Kodi.

Supersedes #29041, which covered the plugin-handle half of this separately. The two turned out not to be separable: the claim added here is what closes the crash window, so they are one change.

## Description

`CScriptInvocationManager` keeps one reusable `LanguageInvokerThread` and the plugin handle it was created for. Nothing recorded that an idle reusable thread was already spoken for, and two distinct failures follow from that.

`GetLanguageInvoker` used to `Release()` the thread whenever `Reuseable()` was false. "Not reusable" also means "already taken", so a second widget refresh aborted a thread a first one had just started on, and `Py_EndInterpreter` raced `execute()` — a SIGSEGV in libpython on a LanguageInvoker thread.

Separately, two `CDirectoryProvider`s for the same add-on could both take `m_lastPluginHandle` before either began, so both listings ran on one `xbmcplugin` handle: one listing's `endOfDirectory` completed the other's waiter, and a widget stayed empty or stale until a skin reload.

Three commits:

1. **Don't hold the invoker mutex across script execution.** `Process()` held `m_mutex` for the whole of `Execute()`. `Release()` needs that mutex, so a JobWorker calling it blocked until the script finished, the app thread blocked on that job, and the script blocked on the GUI — `Home.xml` deadlocked on the splash screen.
2. **Read the invoker thread's script under its mutex.** `Reuseable()` compared `m_script` with no lock while `execute()` assigned it under one — a data race on a `std::string` whose result decides whether an interpreter is handed out for the wrong script. `GetScript()` had the same problem and no callers, so it is removed.
3. **Claim the reusable invoker explicitly.** `CLanguageInvokerThread` gains a claim taken by compare-exchange, and `CReusableInvokerClaim` is an RAII handle over it held by `CRunningScriptsHandler` for as long as the script runs. Every exit path — early return, failed lookup, exception — hands the invoker back, and a listing that cannot claim allocates its own handle and gets its own interpreter. A claim is only granted with a real handle to hand back, and only a thread that may be reused is parked in the slot: a Python service add-on runs until shutdown, so letting one occupy it pinned the slot for the session and disabled `reuselanguageinvoker` for everything else. The `Process()` loop answers to the claim too, or it retires the very thread the claimer is about to run on — it used to re-read a state the claimer had deliberately `Reset()`. In exchange a claim holds the loop open, so `m_bStop` no longer has to be overridden and `Stop()`/`Uninitialize()` stop running an extra script on a torn-down invoker. `execute()` used `CThread::IsRunning()` — true all through `OnExit()` — to choose between a restart and `Create()`, so a restart could be set on a loop nobody was running and the script silently never ran; `m_processDone` records that, and `execute()` refuses rather than calling `Create()`, which would `exit(1)` while the previous thread has not fulfilled its promise. Occupancy is finally made to mean “not idle” rather than “claimed or currently running”, because `IsActive()` is false for `Uninitialized` and two paths sit there with a script already committed. A script run without a plugin handle (`RunPlugin`, `RunScriptWithParams`) has no claim holder to keep a claim across the run, so `ExecuteAsync` drops it as soon as the thread has the script and a concurrent release can stop a script that has already been reported as started. A thread only just published as the reusable one is worse: it stays `Uninitialized` until `execute()` reaches `Create()`, and `Create()` clears the `m_bStop` a concurrent `Release()` set, so the script runs but the loop then parks for ever on a thread nothing can reach, retaining the interpreter and leaving the script marked running for the session. The state alone cannot decide it either — a claim dropped without ever running leaves the same `Uninitialized` and must stay releasable — so `IsBusy()` asks in order whether the thread is claimed, whether the loop has left, whether it has started at all, and only then whether the invoker is running or a restart is queued.

## Motivation and context

Fixes #21653. A reusable plugin invoker is first-come, one slot, and concurrent listings of the same add-on are normal: skins put several `plugin://` widgets on Home, and `OnPlayBackStarted` refreshes them together.

## How has this been tested?

Linux x86_64, Kodi 22 (Piers) as a Flatpak from the Flathub `tv.kodi.Kodi` **beta** recipe (Freedesktop 25.08, Python 3.13, GLES), debug logging on. jurialmunkey's [plugin.video.testcase](https://github.com/jurialmunkey/plugin.video.testcase) at `dff8505`.

**Contention harness, on the final commit.** Two callers are driven against each other: `RunPlugin` over the EventServer runs on the app thread and takes the handle-less path (handle `-1`, the claim taken and dropped inside `ExecuteAsync`), while concurrent `Files.GetDirectory` JSON-RPC calls run on HTTP worker threads and take the claim path. 300 iterations of one `RunPlugin` against five simultaneous listings:

| | |
|---|---|
| script launches | 1800 (300 handle-less, 1500 claim path) |
| completions | 1800 |
| claims granted | 212 of 1500 listings |
| handle-less reuses | 108 of 300 |
| refusals, script errors, crashes | 0 |

Every launch completed. The listings refused the claim ran on their own handle and their own interpreter, which is the plugin-handle sharing fix under real contention rather than a staged pair. Reuse kept working throughout on a single interpreter thread, which is the check that the claim is not leaked and that the busy predicate does not over-report — either would pin the slot and silently disable `reuselanguageinvoker` for the session.

**Skin-level reproduction of #21653**, on an earlier build in this series (before the last of the three commits): the Estuary `Home.xml` patch from #21653, two `plugin://` widgets whose `<content>` carries `$INFO[Window(Home).Property(reload)]`. Uncontended, the two serialise and each owns the handle exclusively for its run; with a 1 s delay added to the plugin so the second listing arrives while the first still holds the claim, the second is refused and gets its own handle and its own interpreter, identically over four consecutive refreshes, with one interpreter thread reused across all of them.

Note for anyone reproducing that: the two widgets render identical labels (`Item_0_Label` … `Item_19_Label`) regardless of the reload value, so the screen cannot distinguish "both refreshed" from "one went stale". The handles in the debug log are the discriminator.

No Python-invoker crash on any build in this series. For comparison, three core dumps from before the fix, on the same box, are all the invoker race (top frames in `libpython3.13`, on a LanguageInvoker thread), including the one cited in the original report.

The harness figures above were measured before the occupancy predicate was broadened to cover a thread published but not yet started; that part is not in them and will be re-run. The races involved are sub-millisecond windows inside Kodi with no way to widen them from the add-on side, so the harness covers the code paths but does not claim to have sampled the windows. Not tested: Omega, Android, webOS. Not covered: `WaitOnScriptResult` for a playable plugin that never calls `setResolvedUrl`/`endOfDirectory` — unchanged by this PR.

## What is the effect on users?

Stops Kodi dying or sticking on the splash when a skin refreshes several plugin widgets at once, and stops two widgets sharing one plugin handle so one no longer stays empty or stale until a skin reload. Add-ons with `<reuselanguageinvoker>true</reuselanguageinvoker>` were the ones that hit it — and on any install with a Python service add-on, reuse was silently disabled for the whole session, which this also fixes.

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
