### PR TITLE
Application: don't hold the frame move guard while closing the player

### DIFF
--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -2231,11 +2231,17 @@ void CApplication::StopPlaying()
 
   if (gui)
   {
-    int iWin = gui->GetWindowManager().GetActiveWindow();
     const auto appPlayer = GetComponent<CApplicationPlayer>();
     if (appPlayer->IsPlaying())
     {
-      appPlayer->ClosePlayer();
+      {
+        // let script threads into the GUI while we close, or they can deadlock us
+        CSingleExit exitGfx(CServiceBroker::GetWinSystem()->GetGfxContext());
+        CSingleExit exitFrameMove(m_frameMoveGuard);
+        appPlayer->ClosePlayer();
+      }
+
+      const int iWin = gui->GetWindowManager().GetActiveWindow();
 
       // turn off visualisation window when stopping
       if ((iWin == WINDOW_VISUALISATION ||


### PR DESCRIPTION
## Motivation and context
Deadlock observed when stopping audio playback (PAPlayer)

## Description
Closing a player can block for a long time. PAPlayer::CloseFile fades its streams out (up to a second), waits for its thread to terminate, and then waits for outstanding jobs to drain. StopPlaying() is reached from CApplication::FrameMove(), which holds m_frameMoveGuard for the frame, so for that entire period no script thread can enter the GUI: XBMCAddonUtils::GuiLock, taken by xbmc.getCondVisibility() among much of the add-on GUI API, blocks on exactly that mutex.

That is normally only added latency. It deadlocks when something the close path waits on in turn needs a script thread to make progress: the main thread will not release the guard until the player has closed, and the script thread cannot run until the guard is released.

Seen on a Raspberry Pi while stopping an add-on supplied audio stream. Pressing Stop left Kodi unresponsive to all further input and it had to be restarted; the two threads involved were:

  Thread 1 (main):
    CApplication::OnAction -> StopPlaying -> CApplicationPlayer::ClosePlayer
      -> PAPlayer::CloseFile -> PAPlayer::SoftStop -> blocked on mutex

  Thread 27 (LanguageInvoker, plugin.video.youtube service.py):
    XBMCAddon::xbmc::getCondVisibility -> GuiLock -> blocked on mutex

Nothing about this is specific to that add-on; any script polling a GUI condition while music is stopped can be the second party.

CVideoPlayer::CloseFile already defends itself here, dropping the graphics context around StopThread(), which is why VideoPlayer playback does not show the problem and PAPlayer does. Rather than duplicating that in every player, release the door once at the point the player is closed, so script threads keep running for as long as the close takes and the cycle cannot form. The idiom matches CApplication::Process(), which already exits the graphics context and drops m_frameMoveGuard so script threads can shut down.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Tested on Pi4 with a reasonably repeatable test case (locking up every few stops).
No lockups seen on dozen of stops with this commit.

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
Fewer deadlocks
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
