### PR TITLE
[python] don't reuse a plugin handle while a waiter still holds it

### DIFF
--- a/xbmc/interfaces/generic/ILanguageInvoker.h
+++ b/xbmc/interfaces/generic/ILanguageInvoker.h
@@ -45,7 +45,10 @@ public:
   InvokerState GetState() const { return m_state; }
   bool IsActive() const;
   bool IsRunning() const;
-  void Reset() { m_state = InvokerStateUninitialized; }
+  // Initialized, not Uninitialized: Reuseable() stays false (state is not
+  // ScriptDone) but IsActive() is true, so a concurrent GetLanguageInvoker
+  // will not Release() the thread that just claimed this invoker.
+  void Reset() { m_state = InvokerStateInitialized; }
 
 protected:
   friend class CLanguageInvokerThread;

--- a/xbmc/interfaces/generic/LanguageInvokerThread.cpp
+++ b/xbmc/interfaces/generic/LanguageInvokerThread.cpp
@@ -37,6 +37,7 @@ InvokerState CLanguageInvokerThread::GetState() const
 
 void CLanguageInvokerThread::Release()
 {
+  std::unique_lock<std::mutex> lck(m_mutex);
   m_bStop = true;
   m_condition.notify_one();
 }
@@ -46,17 +47,20 @@ bool CLanguageInvokerThread::execute(const std::string &script, const std::vecto
   if (m_invoker == NULL || script.empty())
     return false;
 
-  m_script = script;
-  m_args = arguments;
-
   if (CThread::IsRunning())
   {
     std::unique_lock<std::mutex> lck(m_mutex);
+    m_script = script;
+    m_args = arguments;
     m_restart = true;
     m_condition.notify_one();
   }
   else
+  {
+    m_script = script;
+    m_args = arguments;
     Create();
+  }
 
   //Todo wait until running
 
@@ -104,14 +108,24 @@ void CLanguageInvokerThread::Process()
   do
   {
     m_restart = false;
-    m_invoker->Execute(m_script, m_args);
+    const std::string script = m_script;
+    const std::vector<std::string> args = m_args;
+    // Execute() talks to the GUI and to other invokers. Holding m_mutex
+    // across it deadlocks Home.xml load: a JobWorker in Release()/restart
+    // waits for this lock, the app thread waits for that job, and this
+    // script waits for the GUI.
+    lckdl.unlock();
+    m_invoker->Execute(script, args);
+    lckdl.lock();
 
     if (m_invoker->GetState() != InvokerStateScriptDone)
       m_reusable = false;
 
     m_condition.wait(lckdl, [this] { return m_bStop || m_restart || !m_reusable; });
 
-  } while (m_reusable && !m_bStop);
+    // Drain a pending restart even if Release() set m_bStop during the wait.
+    // Otherwise OnExit/Py_EndInterpreter runs under the Execute that claimed us.
+  } while (m_restart || (m_reusable && !m_bStop));
 }
 
 void CLanguageInvokerThread::OnExit()

--- a/xbmc/interfaces/generic/LanguageInvokerThread.h
+++ b/xbmc/interfaces/generic/LanguageInvokerThread.h
@@ -32,6 +32,7 @@ public:
   {
     return !m_bStop && m_reusable && GetState() == InvokerStateScriptDone && m_script == script;
   };
+  bool IsBusy() const { return m_invoker && m_invoker->IsActive(); }
   virtual void Release();
 
 protected:

--- a/xbmc/interfaces/generic/RunningScriptsHandler.h
+++ b/xbmc/interfaces/generic/RunningScriptsHandler.h
@@ -47,6 +47,7 @@ protected:
 
     // remove the script handle if necessary
     RemoveScriptHandle(handle);
+    CScriptInvocationManager::GetInstance().OnPluginHandleReleased(handle);
 
     return result;
   }

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -165,8 +165,7 @@ int CScriptInvocationManager::GetReusablePluginHandle(const std::string& script)
   {
     if (m_lastInvokerThread->Reuseable(script))
       return m_lastPluginHandle;
-    m_lastInvokerThread->Release();
-    m_lastInvokerThread = nullptr;
+    ReleaseLastInvokerIfIdle();
   }
   return -1;
 }
@@ -185,8 +184,11 @@ std::shared_ptr<ILanguageInvoker> CScriptInvocationManager::GetLanguageInvoker(
       m_lastInvokerThread->GetInvoker()->Reset();
       return m_lastInvokerThread->GetInvoker();
     }
-    m_lastInvokerThread->Release();
-    m_lastInvokerThread = nullptr;
+    // A concurrent script must not Release() a claimed or running invoker.
+    // Reset() used to leave the state as Uninitialized, which looks idle, so
+    // the next widget refresh aborted the thread and Py_EndInterpreter raced
+    // the Execute that had just claimed it.
+    ReleaseLastInvokerIfIdle();
   }
 
   std::string extension = URIUtils::GetExtension(script);
@@ -251,21 +253,30 @@ int CScriptInvocationManager::ExecuteAsync(
     return invokerThread->GetId();
   }
 
-  m_lastInvokerThread = std::make_shared<CLanguageInvokerThread>(languageInvoker, this, reuseable);
-  if (m_lastInvokerThread == nullptr)
+  const bool lastBusy = m_lastInvokerThread && m_lastInvokerThread->IsBusy();
+  auto invokerThread =
+      std::make_shared<CLanguageInvokerThread>(languageInvoker, this, reuseable && !lastBusy);
+  if (invokerThread == nullptr)
     return -1;
 
   if (addon != nullptr)
-    m_lastInvokerThread->SetAddon(addon);
+    invokerThread->SetAddon(addon);
 
-  m_lastInvokerThread->SetId(m_nextId++);
-  m_lastPluginHandle = pluginHandle;
+  invokerThread->SetId(m_nextId++);
 
-  LanguageInvokerThread thread = {m_lastInvokerThread, script, false};
-  m_scripts.insert(std::make_pair(m_lastInvokerThread->GetId(), thread));
-  m_scriptPaths.insert(std::make_pair(script, m_lastInvokerThread->GetId()));
-  // After we leave the lock, m_lastInvokerThread can be released -> copy!
-  auto invokerThread = m_lastInvokerThread;
+  LanguageInvokerThread thread = {invokerThread, script, false};
+  m_scripts.insert(std::make_pair(invokerThread->GetId(), thread));
+  m_scriptPaths.insert(std::make_pair(script, invokerThread->GetId()));
+
+  // Do not steal the reusable slot from a claimed or running last thread.
+  // The caller that Reset() it still has to match GetInvoker() above.
+  if (!lastBusy)
+  {
+    ReleaseLastInvokerIfIdle();
+    m_lastInvokerThread = invokerThread;
+    m_lastPluginHandle = pluginHandle;
+  }
+
   lock.unlock();
   invokerThread->Execute(script, arguments);
 
@@ -391,6 +402,15 @@ void CScriptInvocationManager::OnExecutionDone(int scriptId)
   const auto script = m_scripts.find(scriptId);
   if (script != m_scripts.end())
     script->second.done = true;
+}
+
+void CScriptInvocationManager::ReleaseLastInvokerIfIdle()
+{
+  if (!m_lastInvokerThread || m_lastInvokerThread->IsBusy())
+    return;
+
+  m_lastInvokerThread->Release();
+  m_lastInvokerThread = nullptr;
 }
 
 CScriptInvocationManager::LanguageInvokerThread CScriptInvocationManager::getInvokerThread(int scriptId) const

--- a/xbmc/interfaces/generic/ScriptInvocationManager.cpp
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.cpp
@@ -65,6 +65,8 @@ void CScriptInvocationManager::Uninitialize()
 
   // it is safe to release early, thread must be in m_scripts too
   m_lastInvokerThread = nullptr;
+  m_lastPluginHandle = -1;
+  m_lastPluginHandleInUse = false;
 
   // make sure all scripts are done
   std::vector<LanguageInvokerThread> tempList;
@@ -163,25 +165,51 @@ int CScriptInvocationManager::GetReusablePluginHandle(const std::string& script)
 
   if (m_lastInvokerThread)
   {
-    if (m_lastInvokerThread->Reuseable(script))
+    // ScriptDone is not idle: a waiter may still hold the handle, and two
+    // widgets used to both take it before either Reset().
+    if (m_lastInvokerThread->Reuseable(script) && !m_lastPluginHandleInUse)
+    {
+      m_lastInvokerThread->GetInvoker()->Reset();
+      m_lastPluginHandleInUse = true;
+      CLog::Log(LOGDEBUG, "{} - claiming reusable plugin handle {} on LanguageInvokerThread {}",
+                __FUNCTION__, m_lastPluginHandle, m_lastInvokerThread->GetId());
       return m_lastPluginHandle;
+    }
     ReleaseLastInvokerIfIdle();
   }
   return -1;
 }
 
+void CScriptInvocationManager::OnPluginHandleReleased(int handle)
+{
+  if (handle < 0)
+    return;
+
+  std::unique_lock lock(m_critSection);
+  if (handle == m_lastPluginHandle)
+    m_lastPluginHandleInUse = false;
+}
+
 std::shared_ptr<ILanguageInvoker> CScriptInvocationManager::GetLanguageInvoker(
-    const std::string& script)
+    const std::string& script, int pluginHandle /* = -1 */)
 {
   std::unique_lock lock(m_critSection);
 
   if (m_lastInvokerThread)
   {
-    if (m_lastInvokerThread->Reuseable(script))
+    const bool sameHandle = pluginHandle >= 0 && pluginHandle == m_lastPluginHandle;
+    // GetReusablePluginHandle already Reset() to Initialized for this handle.
+    if (sameHandle && m_lastInvokerThread->GetState() == InvokerStateInitialized)
+      return m_lastInvokerThread->GetInvoker();
+
+    if (m_lastInvokerThread->Reuseable(script) && (pluginHandle < 0 || sameHandle) &&
+        !m_lastPluginHandleInUse)
     {
       CLog::Log(LOGDEBUG, "{} - Reusing LanguageInvokerThread {} for script {}", __FUNCTION__,
                 m_lastInvokerThread->GetId(), script);
       m_lastInvokerThread->GetInvoker()->Reset();
+      if (pluginHandle >= 0)
+        m_lastPluginHandleInUse = true;
       return m_lastInvokerThread->GetInvoker();
     }
     // A concurrent script must not Release() a claimed or running invoker.
@@ -217,7 +245,7 @@ int CScriptInvocationManager::ExecuteAsync(
     return -1;
   }
 
-  auto invoker = GetLanguageInvoker(script);
+  auto invoker = GetLanguageInvoker(script, pluginHandle);
   return ExecuteAsync(script, invoker, addon, arguments, reuseable, pluginHandle);
 }
 
@@ -253,7 +281,7 @@ int CScriptInvocationManager::ExecuteAsync(
     return invokerThread->GetId();
   }
 
-  const bool lastBusy = m_lastInvokerThread && m_lastInvokerThread->IsBusy();
+  const bool lastBusy = LastInvokerOccupied();
   auto invokerThread =
       std::make_shared<CLanguageInvokerThread>(languageInvoker, this, reuseable && !lastBusy);
   if (invokerThread == nullptr)
@@ -268,13 +296,14 @@ int CScriptInvocationManager::ExecuteAsync(
   m_scripts.insert(std::make_pair(invokerThread->GetId(), thread));
   m_scriptPaths.insert(std::make_pair(script, invokerThread->GetId()));
 
-  // Do not steal the reusable slot from a claimed or running last thread.
-  // The caller that Reset() it still has to match GetInvoker() above.
+  // Do not steal the reusable slot from a claimed or running last thread,
+  // or from one whose plugin handle still has a waiter.
   if (!lastBusy)
   {
     ReleaseLastInvokerIfIdle();
     m_lastInvokerThread = invokerThread;
     m_lastPluginHandle = pluginHandle;
+    m_lastPluginHandleInUse = pluginHandle >= 0;
   }
 
   lock.unlock();
@@ -404,13 +433,24 @@ void CScriptInvocationManager::OnExecutionDone(int scriptId)
     script->second.done = true;
 }
 
+bool CScriptInvocationManager::LastInvokerOccupied() const
+{
+  if (!m_lastInvokerThread)
+    return false;
+  return m_lastInvokerThread->IsBusy() || m_lastPluginHandleInUse;
+}
+
 void CScriptInvocationManager::ReleaseLastInvokerIfIdle()
 {
-  if (!m_lastInvokerThread || m_lastInvokerThread->IsBusy())
+  if (LastInvokerOccupied())
+    return;
+  if (!m_lastInvokerThread)
     return;
 
   m_lastInvokerThread->Release();
   m_lastInvokerThread = nullptr;
+  m_lastPluginHandle = -1;
+  m_lastPluginHandleInUse = false;
 }
 
 CScriptInvocationManager::LanguageInvokerThread CScriptInvocationManager::getInvokerThread(int scriptId) const

--- a/xbmc/interfaces/generic/ScriptInvocationManager.h
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.h
@@ -144,6 +144,7 @@ private:
   using LanguageInvocationHandlerMap = std::map<std::string, ILanguageInvocationHandler*>;
 
   LanguageInvokerThread getInvokerThread(int scriptId) const;
+  void ReleaseLastInvokerIfIdle();
 
   LanguageInvocationHandlerMap m_invocationHandlers;
   LanguageInvokerThreadMap m_scripts;

--- a/xbmc/interfaces/generic/ScriptInvocationManager.h
+++ b/xbmc/interfaces/generic/ScriptInvocationManager.h
@@ -31,12 +31,20 @@ public:
   void RegisterLanguageInvocationHandler(ILanguageInvocationHandler *invocationHandler, const std::set<std::string> &extensions);
   void UnregisterLanguageInvocationHandler(ILanguageInvocationHandler *invocationHandler);
   bool HasLanguageInvoker(const std::string &script) const;
-  std::shared_ptr<ILanguageInvoker> GetLanguageInvoker(const std::string& script);
+  std::shared_ptr<ILanguageInvoker> GetLanguageInvoker(const std::string& script,
+                                                       int pluginHandle = -1);
 
   /*!
-  * \brief Returns addon_handle if last reusable invoker is ready to use.
-  */
+   * \brief Returns the last plugin handle if the reusable invoker is idle.
+   *
+   * Claims the slot. ScriptDone is not idle while a waiter still holds the handle.
+   */
   int GetReusablePluginHandle(const std::string& script);
+
+  /*!
+   * \brief Clear the in-use mark after CRunningScriptsHandler drops the handle.
+   */
+  void OnPluginHandleReleased(int handle);
 
   /*!
    * \brief Executes the given script asynchronously in a separate thread.
@@ -145,11 +153,15 @@ private:
 
   LanguageInvokerThread getInvokerThread(int scriptId) const;
   void ReleaseLastInvokerIfIdle();
+  //! True if the last reusable thread is executing, claimed, or a plugin waiter
+  //! still holds m_lastPluginHandle. Caller must hold m_critSection.
+  bool LastInvokerOccupied() const;
 
   LanguageInvocationHandlerMap m_invocationHandlers;
   LanguageInvokerThreadMap m_scripts;
   std::shared_ptr<CLanguageInvokerThread> m_lastInvokerThread;
   int m_lastPluginHandle = -1;
+  bool m_lastPluginHandleInUse = false;
 
   std::map<std::string, int> m_scriptPaths;
   int m_nextId = 0;


### PR DESCRIPTION
Consolidated into #29039.

Splitting the crash fix from the plugin-handle fix turned out not to work: the handle
claim added there is what closes the remaining crash window, so #29039 on its own would
have had to be described as a partial fix, and this PR's mechanism
(`GetReusablePluginHandle` returning a bare handle, plus `m_lastPluginHandleInUse`) is
replaced by an RAII claim rather than built on. Reviewing both would have meant reading a
mechanism that a later commit deletes.

#29039 now carries the whole change as four commits and closes #21653 outright.
