### PR TITLE
[VideoInfoScanner][TextureCache] Take the art hash from the directory listing rather than stat'ing each image.

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -14,7 +14,6 @@
 #include "commons/ilog.h"
 #include "dialogs/GUIDialogProgress.h"
 #include "filesystem/File.h"
-#include "filesystem/IFileTypes.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "guilib/Texture.h"
@@ -30,10 +29,9 @@
 #include "utils/log.h"
 
 #include <chrono>
-#include <exception>
+#include <cstring>
 #include <mutex>
 #include <optional>
-#include <string.h>
 
 using namespace XFILE;
 using namespace std::chrono_literals;
@@ -117,7 +115,7 @@ std::string CTextureCache::CheckCachedImage(const std::string &url, bool &needsR
   return "";
 }
 
-void CTextureCache::BackgroundCacheImage(const std::string &url)
+void CTextureCache::BackgroundCacheImage(const std::string& url, const std::string& knownHash)
 {
   if (url.empty())
     return;
@@ -132,7 +130,7 @@ void CTextureCache::BackgroundCacheImage(const std::string &url)
     return;
 
   // needs (re)caching
-  AddJob(new CTextureCacheJob(path, details.hash));
+  AddJob(new CTextureCacheJob(path, details.hash, knownHash));
 }
 
 bool CTextureCache::StartCacheImage(const std::string& image)
@@ -147,13 +145,19 @@ bool CTextureCache::StartCacheImage(const std::string& image)
   return false;
 }
 
+std::string CTextureCache::CacheImage(const std::string& image, const std::string& knownHash)
+{
+  return CacheImage(image, nullptr, nullptr, 0, 0, CAspectRatio::CENTER, knownHash);
+}
+
 std::string CTextureCache::CacheImage(
     const std::string& image,
     std::unique_ptr<CTexture>* texture /*= nullptr*/,
     CTextureDetails* details /*= nullptr*/,
     unsigned int idealWidth /*= 0*/,
     unsigned int idealHeight /*= 0*/,
-    CAspectRatio::AspectRatio aspectRatio /*= CAspectRatio::CENTER*/)
+    CAspectRatio::AspectRatio aspectRatio /*= CAspectRatio::CENTER*/,
+    const std::string& knownHash /*= ""*/)
 {
   std::string url = IMAGE_FILES::ToCacheKey(image);
   if (url.empty())
@@ -165,7 +169,7 @@ std::string CTextureCache::CacheImage(
     m_processinglist.insert(url);
     lock.unlock();
     // cache the texture directly
-    CTextureCacheJob job(url);
+    CTextureCacheJob job(url, "", knownHash);
     bool success = job.CacheTexture(texture);
     OnCachingComplete(success, &job);
     if (success && details)

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -72,9 +72,12 @@ public:
    cache the image and add to the database [see CTextureCacheJob]
 
    \param image url of the image to cache
+   \param knownHash hash of the source file, if the caller already knows it. The listing that found
+                    the image carries what the hash is made of, so a caller working from one can
+                    save the job a stat (see CTextureCacheJob::GetImageHash())
    \sa CacheImage
    */
-  void BackgroundCacheImage(const std::string &image);
+  void BackgroundCacheImage(const std::string& image, const std::string& knownHash = "");
 
   /*! \brief Updates the in-process list.
 
@@ -97,6 +100,7 @@ public:
    \param idealWidth the ideal width of the returned texture (defaults to 0, no ideal width). Only matters if texture is not null.
    \param idealHeight the ideal height of the returned texture (defaults to 0, no ideal height). Only matters if texture is not null.
    \param aspectRatio the aspect ratio mode of the texture (defaults to "center"). Only matters if texture is not null.
+   \param knownHash hash of the source file, in the form CTextureCacheJob::GetImageHash() produces, if known.
    \return cached url of this image
    \sa CTextureCacheJob::CacheTexture
    */
@@ -105,7 +109,8 @@ public:
                          CTextureDetails* details = nullptr,
                          unsigned int idealWidth = 0,
                          unsigned int idealHeight = 0,
-                         CAspectRatio::AspectRatio aspectRatio = CAspectRatio::CENTER);
+                         CAspectRatio::AspectRatio aspectRatio = CAspectRatio::CENTER,
+                         const std::string& knownHash = "");
 
   /*! \brief Cache an image to image cache if not already cached, returning the image details.
    \param image url of the image to cache.
@@ -114,6 +119,18 @@ public:
    \sa CTextureCacheJob::CacheTexture
    */
   bool CacheImage(const std::string &image, CTextureDetails &details);
+
+  /*! \brief Cache an image whose source file hash the caller already knows
+
+   Saves the texture cache stat'ing the file to build that hash itself
+
+   \param image url of the image to cache
+   \param knownHash hash of the source file, in the form CTextureCacheJob::GetImageHash() produces.
+          Pass empty to have it determined as usual.
+   \return cached url of this image
+   \sa CTextureCacheJob::CacheTexture
+   */
+  std::string CacheImage(const std::string& image, const std::string& knownHash);
 
   /*! \brief Check whether an image is in the cache
    Note: If the image url won't normally be cached (eg a skin image) this function will return false.

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -13,30 +13,29 @@
 #include "TextureCache.h"
 #include "TextureDatabase.h"
 #include "URL.h"
-#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/audiodecoder.h"
 #include "commons/ilog.h"
 #include "filesystem/File.h"
+#include "filesystem/IDirectory.h"
 #include "guilib/Texture.h"
 #include "imagefiles/ImageFileURL.h"
 #include "imagefiles/SpecialImageLoaderFactory.h"
 #include "pictures/Picture.h"
-#include "settings/AdvancedSettings.h"
-#include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
-#include <cstdlib>
 #include <cstring>
-#include <exception>
 #include <utility>
 
 #include "PlatformDefs.h"
 
-CTextureCacheJob::CTextureCacheJob(const std::string &url, const std::string &oldHash):
-  m_url(url),
-  m_oldHash(oldHash),
-  m_cachePath(CTextureCache::GetCacheFile(m_url))
+CTextureCacheJob::CTextureCacheJob(const std::string& url,
+                                   const std::string& oldHash,
+                                   const std::string& knownHash)
+  : m_url(url),
+    m_oldHash(oldHash),
+    m_knownHash(knownHash),
+    m_cachePath(CTextureCache::GetCacheFile(m_url))
 {
 }
 
@@ -102,8 +101,8 @@ bool CTextureCacheJob::CacheTexture(std::unique_ptr<CTexture>* out_texture)
 
   if (m_details.updateable)
   {
-    // generate the hash
-    m_details.hash = GetImageHash(image);
+    // generate the hash, unless the caller already knows it (saves a file stat)
+    m_details.hash = m_knownHash.empty() ? GetImageHashFromStat(image) : m_knownHash;
     if (m_details.hash.empty())
       return false;
 
@@ -200,7 +199,30 @@ std::unique_ptr<CTexture> CTextureCacheJob::LoadImage(const IMAGE_FILES::CImageF
   return texture;
 }
 
-std::string CTextureCacheJob::GetImageHash(const std::string &url)
+std::string CTextureCacheJob::FormatImageHash(int64_t modificationTime, int64_t size)
+{
+  if (modificationTime == 0 && size == 0)
+    return "";
+
+  return StringUtils::Format("d{}s{}", modificationTime, size);
+}
+
+std::string CTextureCacheJob::GetImageHash(const CFileItem& listedFile)
+{
+  // The raw values the listing carried, rather than the item's date/time (UTC conversion -> DST issues)
+  int64_t modificationTime{listedFile.GetProperty(XFILE::DIR_PROPERTY_STAT_MTIME).asInteger(0)};
+  if (modificationTime == 0)
+    modificationTime = listedFile.GetProperty(XFILE::DIR_PROPERTY_STAT_CTIME).asInteger(0);
+
+  // Not every VFS layer fills these in. Without a time the size alone would not match a stat-based
+  // hash, so say nothing is known and let the file be stat'ed as usual
+  if (modificationTime == 0)
+    return "";
+
+  return FormatImageHash(modificationTime, listedFile.GetSize());
+}
+
+std::string CTextureCacheJob::GetImageHashFromStat(const std::string& url)
 {
   // silently ignore - we cannot stat these
   // in the case of upnp thumbs are/should be provided when filling the directory list, there's no reason to stat all object ids
@@ -214,8 +236,9 @@ std::string CTextureCacheJob::GetImageHash(const std::string &url)
     int64_t time = st.st_mtime;
     if (!time)
       time = st.st_ctime;
-    if (time || st.st_size)
-      return StringUtils::Format("d{}s{}", time, st.st_size);
+
+    if (const std::string hash{FormatImageHash(time, st.st_size)}; !hash.empty())
+      return hash;
 
     // the image exists but we couldn't determine the mtime/ctime and/or size
     // so set an obviously bad hash

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+class CFileItem;
 class CTexture;
 namespace IMAGE_FILES
 {
@@ -56,7 +57,14 @@ class CTextureCacheJob : public CJob
 public:
   static constexpr const char* JOB_TYPE_CACHE_IMAGE = "cacheimage";
 
-  CTextureCacheJob(const std::string &url, const std::string &oldHash = "");
+  /*!
+   \param url location of the image
+   \param oldHash hash the image was previously cached with, if any
+   \param knownHash hash of the source file, if the caller already knows it (see GetImageHash())
+   */
+  CTextureCacheJob(const std::string& url,
+                   const std::string& oldHash = "",
+                   const std::string& knownHash = "");
   ~CTextureCacheJob() override;
 
   const char* GetType() const override { return JOB_TYPE_CACHE_IMAGE; }
@@ -77,16 +85,34 @@ public:
                             uint8_t*& result,
                             size_t& result_size);
 
+  /*! \brief Retrieve a hash for a file already returned by a directory listing
+   \param listedFile the file, as listed by CDirectory::GetDirectory() without DIR_FLAG_NO_FILE_INFO
+   \return a hash string for this file, or empty if the listing didn't provide the information -
+           not every VFS layer does, and the caller should then let the file be stat'ed as usual
+   */
+  static std::string GetImageHash(const CFileItem& listedFile);
+
   std::string m_url;
   std::string m_oldHash;
   CTextureDetails m_details;
+
 private:
   /*! \brief retrieve a hash for the given image
    Combines the size, ctime and mtime of the image file into a "unique" hash
    \param url location of the image
    \return a hash string for this image
    */
-  static std::string GetImageHash(const std::string &url);
+  static std::string GetImageHashFromStat(const std::string& url);
+
+  /*! \brief Format a hash from a file's modification time and size
+
+   \param modificationTime the file's modification time, as a unix timestamp
+   \param size the file's size in bytes
+   \return the hash, or empty if neither value was usable
+   */
+  static std::string FormatImageHash(int64_t modificationTime, int64_t size);
+
+  std::string m_knownHash;
 
   /*! \brief Load an image at a given target size and orientation.
 

--- a/xbmc/filesystem/NFSDirectory.cpp
+++ b/xbmc/filesystem/NFSDirectory.cpp
@@ -276,6 +276,10 @@ bool CNFSDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     item->SetFolder(isDir);
     item->SetSize(dirent->size);
 
+    // raw values; the DateTime above is local-time converted
+    item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(dirent->mtime.tv_sec));
+    item->SetProperty(DIR_PROPERTY_STAT_CTIME, static_cast<int64_t>(dirent->ctime.tv_sec));
+
     if (name[0] == '.')
       item->SetProperty("file:hidden", true);
   }

--- a/xbmc/platform/posix/filesystem/PosixDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/PosixDirectory.cpp
@@ -81,6 +81,10 @@ bool CPosixDirectory::GetDirectory(const CURL& url, CFileItemList& items)
 
           item->SetDateTime(localTime);
           item->SetSize(isDir ? 0 : buffer.st_size);
+
+          // raw values; the DateTime above is local-time converted
+          item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(buffer.st_mtime));
+          item->SetProperty(DIR_PROPERTY_STAT_CTIME, static_cast<int64_t>(buffer.st_ctime));
         }
       }
 

--- a/xbmc/platform/posix/filesystem/SMBDirectory.cpp
+++ b/xbmc/platform/posix/filesystem/SMBDirectory.cpp
@@ -155,11 +155,10 @@ bool CSMBDirectory::GetDirectory(const CURL& url, CFileItemList& items)
     item->SetFolder(isDir);
     if (!isDir)
       item->SetSize(size);
-    else
-    { // raw values; the DateTime above is local-time converted
-      item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(st.st_mtime));
-      item->SetProperty(DIR_PROPERTY_STAT_CTIME, static_cast<int64_t>(st.st_ctime));
-    }
+
+    // raw values; the DateTime above is local-time converted
+    item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(st.st_mtime));
+    item->SetProperty(DIR_PROPERTY_STAT_CTIME, static_cast<int64_t>(st.st_ctime));
     if (hidden)
       item->SetProperty("file:hidden", true);
   }

--- a/xbmc/platform/win32/filesystem/Win32Directory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32Directory.cpp
@@ -111,13 +111,11 @@ bool CWin32Directory::GetDirectory(const CURL& url, CFileItemList &items)
     if (isHidden)
       item->SetProperty("file:hidden", true);
 
-    if (isDir)
-    { // raw values; the DateTime above is local-time converted
-      item->SetProperty(DIR_PROPERTY_STAT_MTIME, static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(
-                                                     findData.ftLastWriteTime)));
-      item->SetProperty(DIR_PROPERTY_STAT_CTIME,
-                        static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(findData.ftCreationTime)));
-    }
+    // raw values; the DateTime above is local-time converted
+    item->SetProperty(DIR_PROPERTY_STAT_MTIME,
+                      static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(findData.ftLastWriteTime)));
+    item->SetProperty(DIR_PROPERTY_STAT_CTIME,
+                      static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(findData.ftCreationTime)));
 
   } while (FindNextFileW(hSearch, &findData));
 

--- a/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
+++ b/xbmc/platform/win32/filesystem/Win32SMBDirectory.cpp
@@ -186,6 +186,12 @@ bool CWin32SMBDirectory::GetDirectory(const CURL& url, CFileItemList &items)
     if (!isDir)
       item->SetSize((static_cast<int64_t>(findData.nFileSizeHigh) << 32) + findData.nFileSizeLow);
 
+    // raw values; the DateTime above is local-time converted
+    item->SetProperty(DIR_PROPERTY_STAT_MTIME,
+                      static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(findData.ftLastWriteTime)));
+    item->SetProperty(DIR_PROPERTY_STAT_CTIME,
+                      static_cast<int64_t>(CWIN32Util::fileTimeToTimeT(findData.ftCreationTime)));
+
     if (isHidden)
       item->SetProperty("file:hidden", true);
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -15,6 +15,7 @@
 #include "ServiceBroker.h"
 #include "SetInfoTag.h"
 #include "TextureCache.h"
+#include "TextureCacheJob.h"
 #include "URL.h"
 #include "Util.h"
 #include "VideoInfoDownloader.h"
@@ -224,7 +225,9 @@ void OnDirectoryScanned(const std::string& strDirectory)
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
 }
 
-void CacheArtwork(const std::string& url, bool retrieveArtDuringScrape)
+void CacheArtwork(const std::string& url,
+                  bool retrieveArtDuringScrape,
+                  const std::string& knownHash = "")
 {
   if (url.empty())
     return;
@@ -232,7 +235,7 @@ void CacheArtwork(const std::string& url, bool retrieveArtDuringScrape)
   const auto& textureCache = CServiceBroker::GetTextureCache();
   if (!retrieveArtDuringScrape)
   {
-    textureCache->BackgroundCacheImage(url);
+    textureCache->BackgroundCacheImage(url, knownHash);
     return;
   }
 
@@ -245,15 +248,16 @@ void CacheArtwork(const std::string& url, bool retrieveArtDuringScrape)
   constexpr int MAX_SYNC_CACHE_ATTEMPTS = 3;
   for (int attempt = 1; attempt <= MAX_SYNC_CACHE_ATTEMPTS; ++attempt)
   {
-    if (!textureCache->CacheImage(url).empty())
+    if (!textureCache->CacheImage(url, knownHash).empty())
       return; // succeeded
   }
 
   // Synchronous fetch failed after several attempts (network timeout, etc.)
   // Fall back to the resilient background path.
-  textureCache->BackgroundCacheImage(url);
+  textureCache->BackgroundCacheImage(url, knownHash);
   CLog::LogF(LOGDEBUG, "Synchronous art caching for {} failed", url);
 }
+
 } // namespace
 
 namespace KODI::VIDEO
@@ -3133,11 +3137,12 @@ CVideoInfoScanner::~CVideoInfoScanner()
     CFileItemList items;
     // don't try to fetch anything local with plugin source
     if (!URIUtils::IsPlugin(actorsDir) && CDirectory::Exists(actorsDir))
-      CDirectory::GetDirectory(actorsDir, items, ".png|.jpg|.tbn",
-                               DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_NO_FILE_INFO);
+      CDirectory::GetDirectory(actorsDir, items, ".png|.jpg|.tbn", DIR_FLAG_NO_FILE_DIRS);
 
-    // Index the thumbs by filename (without extension)
+    // Index the thumbs by filename (without extension), and the hashes taken from the directory
+    // listing by url
     std::map<std::string, std::string> thumbs;
+    std::map<std::string, std::string> listedHashes;
     for (const auto& item : items)
     {
       if (item->IsFolder())
@@ -3146,6 +3151,8 @@ CVideoInfoScanner::~CVideoInfoScanner()
       std::string name{URIUtils::GetFileName(item->GetPath())};
       URIUtils::RemoveExtension(name);
       thumbs.try_emplace(std::move(name), item->GetPath());
+      if (std::string hash{CTextureCacheJob::GetImageHash(*item)}; !hash.empty())
+        listedHashes.emplace(item->GetPath(), std::move(hash));
     }
 
     for (auto& actor : actors)
@@ -3171,7 +3178,13 @@ CVideoInfoScanner::~CVideoInfoScanner()
             actor.thumbUrl.Clear();
         }
       }
-      CacheArtwork(actor.thumb, m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS);
+    }
+
+    for (const auto& actor : actors)
+    {
+      const auto hash{listedHashes.find(actor.thumb)};
+      CacheArtwork(actor.thumb, m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS,
+                   hash != listedHashes.end() ? hash->second : std::string{});
     }
   }
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

A listing already returns both details, so the scanner passes them in and the stat is skipped.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The texture cache identifies an image by a hash of its modification time and size, and stat'ed every image to build it.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally as part of a larger PR #28921

See below for windows analysis.

Quick run on linux as well:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/9fb44266-81b1-4858-ac69-6dffe4b85be3" />

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

# Art hash from directory listing — SMB and NFS measurement

Comparison of Kodi 22 master against a build carrying only the "take the art hash from the
directory listing rather than stat'ing each image" commit, over SMB and NFS.

Logs: `smbbase1/2`, `nfsbase1/2` (master) and `smbhash1/2`, `nfshash1/2` (hash commit).

---

## 1. Are the runs comparable?

Yes. Every one of the eight runs matches on all of the following.

| Property | Value (all 8 runs) |
|---|---|
| Kodi version | 22.0-BETA1 (21.90.801) |
| Build type | **Release** x64 |
| Compiler | MSVC 195136256 (identical across all builds) |
| Directories processed | 362 |
| Directories skipped | 0 |
| Movies added | 358 |
| `Recaching image` | 0 |
| Background caching threads | 3 |
| Warnings | 5 |
| advancedsettings footprint | identical |

Sources are consistent within each protocol:

- SMB — `smb://MediaMaster.localdomain/Media/My Movies/`
- NFS — `nfs://192.168.1.25/volume1/Media/My Movies/`

Every run was a clean scrape: all 362 directories logged `as not in the database`, none skipped,
and zero `Recaching image` lines, so each started from an empty texture cache. Actor thumbs are
**~92%** of all cached art, which is what this commit targets.

`nfshash1` contains a single error — an add-on repository digest mismatch from `mirrors.kodi.tv`.
Unrelated to scanning or caching.

### One important caveat

**No run drained its art queue.** In all eight the last cached image is 1–4 seconds before Kodi
exits, so totals are an arbitrary cut-off, not the work required:

| | art cached | movies covered (of 358) |
|---|---|---|
| smbbase1 / smbbase2 | 2596 / 2700 | 76 / 78 |
| smbhash1 / smbhash2 | 2779 / 2413 | 81 / 71 |
| nfsbase1 / nfsbase2 | 2469 / 2458 | 73 / 72 |
| nfshash1 / nfshash2 | 2539 / 2675 | 75 / 78 |

Totals therefore cannot be compared. **Throughput** can, because the post-scan measurement window
is near-identical in every run (63.7–67.5 s).

---

## 2. Scan time

The scan completed in all eight runs, so this is the one fully reliable figure.

| Configuration | Run 1 | Run 2 | Mean | Spread |
|---|---|---|---|---|
| SMB master | 40.01 s | 40.62 s | **40.31 s** | 1.5% |
| SMB hash | 40.17 s | 40.39 s | **40.28 s** | 0.5% |
| NFS master | 84.55 s | 87.48 s | **85.99 s** | 3.4% |
| NFS hash | 82.45 s | 82.28 s | **82.36 s** | 0.2% |

Change: **SMB −0.1%**, **NFS −4.2%**.

- **SMB is unchanged** — the two means differ by 30 ms.
- **NFS is faster, and the ranges do not overlap**: master 84.55–87.48 s against 82.28–82.45 s.
  Both commit runs beat both master runs. With two runs each this is suggestive rather than
  conclusive, but the separation is clean and the direction matches the mechanism.

Per-directory rate agrees: SMB 0.096 / 0.098 s/dir against 0.097 / 0.097; NFS 0.204 / 0.212
against 0.196 / 0.196.

---

## 3. Art caching throughput

Measured in two windows. The post-scan window is the cleaner of the two — once the scan has
finished, background caching has the source to itself.

### After the scan (uncontended)

| Configuration | Run 1 | Run 2 | Mean | vs master |
|---|---|---|---|---|
| SMB master | 27.0 img/s | 27.0 img/s | **27.0** | — |
| SMB hash | 28.6 img/s | 28.1 img/s | **28.4** | **+5.2%** |
| NFS master | 20.3 img/s | 19.5 img/s | **19.9** | — |
| NFS hash | 20.9 img/s | 22.1 img/s | **21.5** | **+8.0%** |

Both are non-overlapping — every commit run beats every master run — but the SMB margin is small
enough (1.1–1.6 img/s) that two runs cannot firmly establish it.

### During the scan (competing with the scanner)

| Configuration | Run 1 | Run 2 | Mean | vs master |
|---|---|---|---|---|
| SMB master | 25.5 img/s | 25.3 img/s | **25.4** | inconclusive |
| SMB hash | 25.5 img/s | 18.3 img/s | **21.9** | |
| NFS master | 15.7 img/s | 16.0 img/s | **15.9** | — |
| NFS hash | 17.3 img/s | 18.2 img/s | **17.8** | **+12%** |

`smbhash2` is an outlier at 18.3 img/s against 25.3–25.5 in the other three SMB runs; it cached
625 images during the scan where the others managed 866–877 in a near-identical window. The SMB
during-scan comparison is unusable as a result.

NFS is non-overlapping: master 15.7–16.0, commit 17.3–18.2.

### Stalls

Cumulative time in gaps longer than one second between consecutive cached images:

| Configuration | Run 1 | Run 2 |
|---|---|---|
| SMB master | 19.9 s | 18.6 s |
| SMB hash | 17.9 s | 28.4 s |
| NFS master | 19.0 s | 18.6 s |
| NFS hash | 31.7 s | 23.2 s |

No usable signal. SMB overlaps, and NFS is nominally *worse* on the commit build. Treat this
metric as noise at this sample size.

---

## 4. Does the commit help?

### NFS — yes, modestly

Three independent measures all move the same way, all with non-overlapping ranges:

| Measure | master | commit | change |
|---|---|---|---|
| Scan time | 85.99 s | 82.36 s | **−4.2%** |
| Caching, uncontended | 19.9 img/s | 21.5 img/s | **+8.0%** |
| Caching, during scan | 15.9 img/s | 17.8 img/s | **+12%** |

The mechanism fits. The commit removes one `stat` round trip per image, and with ~92% of the art
being actor thumbs almost every image benefits. NFS is the protocol where round trips are most
expensive — libnfs serialises all operations behind a process-wide lock — so removing one per image
is worth most there. It also explains why the scan itself gains: the actor-thumb listing happens on
the scanner thread.

### SMB — no meaningful change

Scan time is identical (−0.1%). Uncontended caching is nominally +5.2% and non-overlapping, but the
margin is small and the during-scan comparison is spoiled by the `smbhash2` outlier. The
defensible statement is **no measurable benefit on SMB, and no harm**.

That asymmetry is expected: a `stat` over SMB is comparatively cheap, so removing it changes little.

---

## 5. SMB versus NFS

### On master

| Metric | SMB master | NFS master | Ratio |
|---|---|---|---|
| Scan time | 40.31 s | 85.99 s | NFS **2.13× slower** |
| Per directory | 0.097 s | 0.208 s | NFS 2.14× slower |
| Caching, uncontended | 27.0 img/s | 19.9 img/s | SMB **1.36× faster** |
| Caching, during scan | 25.4 img/s | 15.9 img/s | SMB 1.60× faster |

NFS takes more than twice as long to scan identical content, and is about a third slower at caching
art. The scan gap is by far the larger, and is dominated by per-file metadata operations —
directory listings and NFO opens — consistent with libnfs serialising every operation.

### With the commit

| Metric | SMB hash | NFS hash | Ratio |
|---|---|---|---|
| Scan time | 40.28 s | 82.36 s | NFS 2.04× slower |
| Caching, uncontended | 28.4 img/s | 21.5 img/s | SMB 1.32× faster |

The gap narrows slightly on both measures, from 2.13× to 2.04× on scan time. NFS remains roughly
twice as slow overall; this commit does not change that, because most of the gap is scanner-side
work the commit does not touch.

---

## 6. Conclusions

1. **The scan is not slower anywhere.** SMB −0.1%, NFS −4.2%. The prerequisite is met, and on NFS
   the scan is measurably faster.
2. **NFS benefits, modestly and consistently** — −4.2% scan, +8% uncontended caching, +12% caching
   during the scan, all with non-overlapping ranges across four runs.
3. **SMB shows no meaningful change**, in either direction.
4. **NFS remains ~2× slower than SMB**, and this commit does not materially close that gap.

### Caveats

- Two runs per configuration. The NFS results are non-overlapping on three separate measures,
  which is the strongest evidence here; the SMB caching margin (+5.2%) is too small to establish at
  this sample size.
- No run drained its art queue, so only throughput is comparable — not totals, and not end-to-end
  time-to-complete.
- `smbhash2` is an outlier in the during-scan window and that comparison should be disregarded.
- The stall metric shows no consistent signal and should not be quoted.

### To strengthen this

- A third run per configuration, particularly on SMB, would settle whether the +5.2% caching
  margin is real.
- One run per configuration allowed to drain fully would give a real end-to-end import time rather
  than throughput alone.


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
