### PR TITLE
[VideoInfoScanner] Revalidate an unchanged image instead of caching it again.

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -130,7 +130,7 @@ void CTextureCache::BackgroundCacheImage(const std::string& url, const std::stri
     return;
 
   // needs (re)caching
-  AddJob(new CTextureCacheJob(path, details.hash, knownHash));
+  AddJob(new CTextureCacheJob(path, details, knownHash));
 }
 
 bool CTextureCache::StartCacheImage(const std::string& image)
@@ -168,13 +168,33 @@ std::string CTextureCache::CacheImage(
   {
     m_processinglist.insert(url);
     lock.unlock();
+
+    // Retrieve the hash the image was last cached with, so an unchanged source can be revalidated
+    CTextureDetails cached;
+    GetCachedImage(url, cached);
+
+    CTextureDetails oldDetails{cached};
+    if (texture)
+      oldDetails.file.clear();
+
     // cache the texture directly
-    CTextureCacheJob job(url, "", knownHash);
-    bool success = job.CacheTexture(texture);
+    CTextureCacheJob job(url, oldDetails, knownHash);
+    const bool success = job.CacheTexture(texture);
     OnCachingComplete(success, &job);
-    if (success && details)
+    if (!success)
+      return "";
+
+    // Unchanged, so the copy already in the cache stands
+    if (job.m_details.hashRevalidated)
+    {
+      if (details)
+        *details = cached;
+      return GetCachedPath(cached.file);
+    }
+
+    if (details)
       *details = job.m_details;
-    return success ? GetCachedPath(job.m_details.file) : "";
+    return GetCachedPath(job.m_details.file);
   }
   lock.unlock();
 

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -30,13 +30,19 @@
 #include "PlatformDefs.h"
 
 CTextureCacheJob::CTextureCacheJob(const std::string& url,
-                                   const std::string& oldHash,
+                                   const CTextureDetails& oldDetails,
                                    const std::string& knownHash)
   : m_url(url),
-    m_oldHash(oldHash),
+    m_oldDetails(oldDetails),
     m_knownHash(knownHash),
     m_cachePath(CTextureCache::GetCacheFile(m_url))
 {
+}
+
+bool CTextureCacheJob::HasCachedFile() const
+{
+  return !m_oldDetails.file.empty() &&
+         XFILE::CFile::Exists(CTextureCache::GetCachedPath(m_oldDetails.file));
 }
 
 CTextureCacheJob::~CTextureCacheJob() = default;
@@ -103,7 +109,8 @@ bool CTextureCacheJob::CacheTexture(std::unique_ptr<CTexture>* out_texture)
     if (m_details.hash.empty())
       return false;
 
-    if (m_details.hash == m_oldHash)
+    // Unchanged, so the copy already in the cache stands - as long as it is still there
+    if (m_details.hash == m_oldDetails.hash && HasCachedFile())
     {
       m_details.hashRevalidated = true;
       return true;
@@ -118,7 +125,8 @@ bool CTextureCacheJob::CacheTexture(std::unique_ptr<CTexture>* out_texture)
     else
       m_details.file = m_cachePath + ".jpg";
 
-    CLog::Log(LOGDEBUG, "{} image '{}' to '{}':", m_oldHash.empty() ? "Caching" : "Recaching",
+    CLog::Log(LOGDEBUG,
+              "{} image '{}' to '{}':", m_oldDetails.hash.empty() ? "Caching" : "Recaching",
               CURL::GetRedacted(image), m_details.file);
 
     unsigned int cached_width = 0;

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -59,11 +59,13 @@ public:
 
   /*!
    \param url location of the image
-   \param oldHash hash the image was previously cached with, if any
+   \param oldDetails what the image is already cached as, if anything. Its hash is only set once
+          the image is due its periodic check, and an unchanged image is then revalidated rather
+          than cached all over again.
    \param knownHash hash of the source file, if the caller already knows it (see GetImageHash())
    */
   CTextureCacheJob(const std::string& url,
-                   const std::string& oldHash = "",
+                   const CTextureDetails& oldDetails = {},
                    const std::string& knownHash = "");
   ~CTextureCacheJob() override;
 
@@ -93,10 +95,16 @@ public:
   static std::string GetImageHash(const CFileItem& listedFile);
 
   std::string m_url;
-  std::string m_oldHash;
+  CTextureDetails m_oldDetails;
   CTextureDetails m_details;
 
 private:
+  /*! \brief Whether the copy this image was previously cached to is still present
+   Revalidating leaves that copy in place rather than writing it again, so it has to still be
+   there - if it has been deleted the image needs caching again.
+   */
+  bool HasCachedFile() const;
+
   /*! \brief retrieve a hash for the given image
    Combines the size, ctime and mtime of the image file into a "unique" hash
    \param url location of the image


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Only update images if changed (synchronous path).
Also verifies image still exists when revalidating (both paths).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The asynchronous path already does this; the synchronous one fetched and wrote the image afresh every time it was checked, even if unchanged. 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally as part of a larger PR #28921 

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
