### PR TITLE
[VideoInfoScanner] Don't dynamic_cast when comparing texture cache jobs.

### DIFF
--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -44,13 +44,10 @@ CTextureCacheJob::~CTextureCacheJob() = default;
 
 bool CTextureCacheJob::Equals(const CJob* job) const
 {
-  if (strcmp(job->GetType(),GetType()) == 0)
-  {
-    const CTextureCacheJob* cacheJob = dynamic_cast<const CTextureCacheJob*>(job);
-    if (cacheJob && cacheJob->m_cachePath == m_cachePath)
-      return true;
-  }
-  return false;
+  if (strcmp(job->GetType(), GetType()) != 0)
+    return false;
+
+  return static_cast<const CTextureCacheJob*>(job)->m_cachePath == m_cachePath;
 }
 
 bool CTextureCacheJob::DoWork()


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Matching the job type is what makes the cast safe so dynamic_cast is not needed.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A job queue checks every job it holds against each new one (thousands of imags -> millions of comparisons). 

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

Small speedup on large nfo based scrapes. See #28921 (est 1.8 seconds)

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
