### PR TITLE
[cmake][depends] Fix Windows patch EOL handling

### DIFF
--- a/cmake/scripts/common/HandleDepends.cmake
+++ b/cmake/scripts/common/HandleDepends.cmake
@@ -128,6 +128,7 @@ function(add_addon_depends addon searchpath)
         file(GLOB patches ${dir}/*.patch)
         list(SORT patches)
         foreach(patch ${patches})
+          set(patch_program ${PATCH_PROGRAM})
           if(NOT PATCH_PROGRAM OR "${PATCH_PROGRAM}" STREQUAL "")
             if(NOT PATCH_EXECUTABLE)
               # find the path to the patch executable
@@ -148,23 +149,29 @@ function(add_addon_depends addon searchpath)
               endif()
             endif()
 
-            set(PATCH_PROGRAM ${PATCH_EXECUTABLE})
+            set(patch_program ${PATCH_EXECUTABLE})
 
-            # On Windows "patch.exe" can only handle CR-LF line-endings.
-            # Our patches have LF-only line endings - except when they
-            # have been checked out as part of a dependency hosted on Git
-            # and core.autocrlf=true.
+            # On Windows "patch.exe" converts line endings unless --binary is
+            # used. Do not use --binary for CRLF-only patches, such as patches
+            # checked out with core.autocrlf=true.
             if(WIN32)
               file(READ ${patch} patch_content_hex HEX)
-              # Force handle LF-only line endings
-              if(NOT patch_content_hex MATCHES "0d0a")
-                list(APPEND PATCH_PROGRAM --binary)
-              endif()
+              # Split into exact bytes before looking for bare LF characters.
+              string(REGEX MATCHALL ".." patch_content_bytes "${patch_content_hex}")
+              set(previous_patch_byte "")
+              foreach(patch_byte IN LISTS patch_content_bytes)
+                # Force handling if any LF-only line endings remain
+                if("${patch_byte}" STREQUAL "0a" AND NOT "${previous_patch_byte}" STREQUAL "0d")
+                  list(APPEND patch_program --binary)
+                  break()
+                endif()
+                set(previous_patch_byte "${patch_byte}")
+              endforeach()
             endif()
           endif()
 
           set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${patch})
-          list(APPEND PATCH_COMMAND COMMAND ${PATCH_PROGRAM} -p1 -i ${patch})
+          list(APPEND PATCH_COMMAND COMMAND ${patch_program} -p1 -i ${patch})
         endforeach()
 
 


### PR DESCRIPTION
## Description

Build a fresh patch command for each dependency patch so Windows-specific flags do not leak between patches.

Detect bare LF bytes independently of CRLF pairs and pass `--binary` when applying LF-only or mixed-EOL patches. This preserves the existing behavior for CRLF-only patches while allowing patches generated from CRLF source files to apply correctly.

## Motivation and context

XRick fails to build on Windows: https://jenkins.kodi.tv/blue/organizations/jenkins/kodi-game%2Fgame.libretro.xrick/detail/master/160/pipeline

## How has this been tested?

Tested with a focused CMake harness exercising `add_addon_depends()` directly.

Verified:

* CRLF-only patches do not use `--binary`
* LF-only patches use `--binary`
* Mixed-EOL patches use `--binary`
* `--binary` does not leak between multiple patches
* An explicitly supplied `PATCH_PROGRAM` is preserved unchanged

The same harness against the previous implementation reproduced the mixed-EOL failure and cross-patch option leakage.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
