### PR TITLE
[VideoInfoScanner][Nfo] Reuse already parsed nfo to look for movie versions.

### DIFF
--- a/xbmc/NfoFile.cpp
+++ b/xbmc/NfoFile.cpp
@@ -90,24 +90,43 @@ bool CNfoFile::SeekToMovieIndex(int index)
   return m_headPos != std::string::npos;
 }
 
-CInfoScanner::InfoType CNfoFile::TryParsing(const CURL& nfoPath,
-                                            ADDON::ContentType contentType,
-                                            int index /* =1 */)
+CInfoScanner::InfoType CNfoFile::TryParsing(const CURL& nfoPath, ADDON::ContentType contentType)
 {
   if (Load(nfoPath) != 0) // Setup m_doc and m_headPos
     return CInfoScanner::InfoType::ERROR_NFO;
 
-  const AddonType addonType = ScraperTypeFromContent(contentType);
+  m_addonType = ScraperTypeFromContent(contentType);
 
-  if (addonType == ADDON::AddonType::SCRAPER_MOVIES && !SeekToMovieIndex(index))
+  if (m_addonType == ADDON::AddonType::SCRAPER_MOVIES && !SeekToMovieIndex(1))
     return CInfoScanner::InfoType::NONE;
 
-  return TryParsing(addonType);
+  return TryParsing(m_addonType);
 }
 
-CInfoScanner::InfoType CNfoFile::Create(const std::string& nfoPath,
-                                        const ScraperPtr& info,
-                                        int index)
+CInfoScanner::InfoType CNfoFile::Reparse(int index)
+{
+  using enum CInfoScanner::InfoType;
+
+  // Only movie nfos can hold more than one entry
+  if (m_doc.empty() || m_addonType != ADDON::AddonType::SCRAPER_MOVIES)
+    return NONE;
+
+  // Seek before discarding anything
+  const size_t previousHeadPos{m_headPos};
+  if (!SeekToMovieIndex(index))
+  {
+    m_headPos = previousHeadPos;
+    return NONE;
+  }
+
+  // Discard the element parsed previously and re-parse starting from the requested one
+  m_xmlDoc.Clear();
+  m_xmlParsed = false;
+
+  return TryParsing(m_addonType);
+}
+
+CInfoScanner::InfoType CNfoFile::Create(const std::string& nfoPath, const ScraperPtr& info)
 {
   /* `TryParsing` creates a close approximation to the desired result.
    * The desired result would be knowing if any valid URLs have been
@@ -131,7 +150,7 @@ CInfoScanner::InfoType CNfoFile::Create(const std::string& nfoPath,
    * This call is expensive as it encodes the NFO file into a URL param
    * and executes a python interpreter for each installed python scraper.
   */
-  const CInfoScanner::InfoType result = TryParsing(CURL{nfoPath}, info->Content(), index);
+  const CInfoScanner::InfoType result = TryParsing(CURL{nfoPath}, info->Content());
   if (result == CInfoScanner::InfoType::ERROR_NFO)
     return CInfoScanner::InfoType::NONE;
   return SearchNfoForScraperUrls(result, info);
@@ -193,6 +212,7 @@ void CNfoFile::Close()
 {
   m_doc.clear();
   m_headPos = 0;
+  m_addonType = {}; // ADDON::AddonType::UNKNOWN
   m_scurl.Clear();
   m_xmlDoc.Clear();
   m_xmlParsed = false;

--- a/xbmc/NfoFile.h
+++ b/xbmc/NfoFile.h
@@ -31,7 +31,15 @@ class CNfoFile
 public:
   virtual ~CNfoFile() { Close(); }
 
-  CInfoScanner::InfoType Create(const std::string&, const ADDON::ScraperPtr&, int index = 1);
+  CInfoScanner::InfoType Create(const std::string& nfoPath, const ADDON::ScraperPtr& info);
+
+  /*! \brief Re-parse the already loaded document, starting at its nth <movie> element.
+   Only valid after a successful Create(), and only for movie documents - nothing else can hold
+   more than one entry.
+   \param index 1-based index of the <movie> element to parse
+   \return the parse result, NONE if the document holds no such element
+   */
+  CInfoScanner::InfoType Reparse(int index);
 
   template<class T>
   bool GetDetails(T& details, const char* document = nullptr, bool prioritise = false) const
@@ -64,9 +72,7 @@ public:
 
 private:
   CInfoScanner::InfoType TryParsing(ADDON::AddonType addonType) const;
-  CInfoScanner::InfoType TryParsing(const CURL& nfoPath,
-                                    ADDON::ContentType contentType,
-                                    int index = 1);
+  CInfoScanner::InfoType TryParsing(const CURL& nfoPath, ADDON::ContentType contentType);
   CInfoScanner::InfoType SearchNfoForScraperUrls(CInfoScanner::InfoType parseResult,
                                                  const ADDON::ScraperPtr& info);
   bool SeekToMovieIndex(int index);
@@ -76,6 +82,7 @@ private:
 
   std::string m_doc;
   size_t m_headPos = 0;
+  ADDON::AddonType m_addonType{};
   ADDON::ScraperPtr m_info;
   CScraperUrl m_scurl;
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -1562,27 +1562,42 @@ CVideoInfoScanner::~CVideoInfoScanner()
         defaultVersionFileId = tag->m_iFileId; // Updated in AddMovie()
 
       // Look for versions (ie. subsequent <movie> entries in the .nfo file)
-      // These must be versions
+      // These must be versions. Reuse the loader.
       int index{1};
-      do
+      while (true)
       {
-        index++;
-        item.SetProperty("nfo_index", index); // Attempt to read next movie version
-        std::tie(result, loader) = ReadInfoTag(item, info2, bDirNames, true);
-        if (result == InfoType::FULL)
-        {
-          // Add the version entry
-          tag->m_iDbId = movieId;
-          const int versionId{static_cast<int>(AddVideo(&item, nullptr, bDirNames, true, nullptr,
-                                                        false, ContentType::MOVIE_VERSIONS))};
-          if (versionId < 0)
-            return InfoRet::INFO_ERROR;
+        tag->Reset();
+        const InfoType versionResult{loader->LoadVersion(++index, *tag)};
+        if (versionResult == InfoType::NONE)
+          break; // No further <movie> entries
+        if (versionResult != InfoType::FULL)
+          continue; // Entry cannot stand alone as a version - skip it, but keep looking
 
-          // Look for default version
-          if (tag->IsDefaultVideoVersion())
-            defaultVersionFileId = tag->m_iFileId; // Updated in AddVideoAsset()
-        }
-      } while (result == InfoType::FULL);
+        // A <playlist> nfo element identifies the disc playlist the info belongs to.
+        // The item is reused for every entry, so a version without one must not inherit the
+        // playlist of the entry before it
+        if (const int playlist{loader->GetBlurayPlaylist()}; playlist > -1)
+          item.SetProperty("bluray_playlist", playlist);
+        else
+          item.ClearProperty("bluray_playlist");
+
+        // Keep properties only if advancedsettings.xml says so
+        if (!m_advancedSettings->m_bVideoLibraryImportWatchedState)
+          tag->ResetPlayCount();
+        if (!m_advancedSettings->m_bVideoLibraryImportResumePoint)
+          tag->SetResumePoint(CBookmark());
+
+        // Add the version entry
+        tag->m_iDbId = movieId;
+        const int versionId{static_cast<int>(AddVideo(&item, nullptr, bDirNames, true, nullptr,
+                                                      false, ContentType::MOVIE_VERSIONS))};
+        if (versionId < 0)
+          return InfoRet::INFO_ERROR;
+
+        // Look for default version
+        if (tag->IsDefaultVideoVersion())
+          defaultVersionFileId = tag->m_iFileId; // Updated in AddVideoAsset()
+      }
 
       // Set default version
       if (defaultVersionFileId > -1)

--- a/xbmc/video/tags/IVideoInfoTagLoader.h
+++ b/xbmc/video/tags/IVideoInfoTagLoader.h
@@ -46,6 +46,17 @@ public:
                                       bool prioritise,
                                       std::vector<EmbeddedArt>* art = nullptr) = 0;
 
+  //! \brief Load an additional version of the item, if the source holds one.
+  //! \param index 1-based index of the version to load (2 is the first additional version)
+  //! \param tag Tag to load info into, only populated when the result is FULL
+  //! \returns The load result, NONE if there is no such version
+  //! Only nfo files can hold multiple versions currently.
+  //! Must not be called before Load().
+  virtual CInfoScanner::InfoType LoadVersion(int /*index*/, CVideoInfoTag& /*tag*/)
+  {
+    return CInfoScanner::InfoType::NONE;
+  }
+
   //! \brief Returns url associated with obtained URL (NFO_URL et al).
   const CScraperUrl& ScraperUrl() const { return m_url; }
 

--- a/xbmc/video/tags/VideoTagLoaderNFO.cpp
+++ b/xbmc/video/tags/VideoTagLoaderNFO.cpp
@@ -48,14 +48,6 @@ std::string InfoTypeToStr(CInfoScanner::InfoType infoType)
   }
 }
 
-int GetNfoIndex(const CFileItem& item, const ADDON::ScraperPtr& scraper)
-{
-  if (scraper->Content() == ADDON::ContentType::MOVIES && !item.IsFolder() &&
-      item.HasProperty("nfo_index"))
-    return item.GetProperty("nfo_index").asInteger32(1); // multiple versions (playlists) in nfo
-  return 1;
-}
-
 } // Unnamed namespace
 
 CVideoTagLoaderNFO::CVideoTagLoaderNFO(const CFileItem& item,
@@ -85,7 +77,7 @@ CInfoScanner::InfoType CVideoTagLoaderNFO::Load(CVideoInfoTag& tag,
   {
     if (!m_nfoParsed)
     {
-      m_parseResult = m_nfoReader.Create(m_path, m_info, GetNfoIndex(m_item, m_info));
+      m_parseResult = m_nfoReader.Create(m_path, m_info);
       m_nfoParsed = true;
     }
     result = m_parseResult;
@@ -101,25 +93,45 @@ CInfoScanner::InfoType CVideoTagLoaderNFO::Load(CVideoInfoTag& tag,
   }
 
   if (result != NONE)
-  {
-    const std::string type{InfoTypeToStr(result)};
-    if (m_item.HasProperty("nfo_index"))
-      CLog::Log(LOGDEBUG, "VideoInfoScanner: Found additional version ({}) in {} NFO file: {}",
-                m_item.GetProperty("nfo_index").asInteger32(), type, CURL::GetRedacted(m_path));
-    else
-      CLog::Log(LOGDEBUG, "VideoInfoScanner: Found matching {} NFO file: {}", type,
-                CURL::GetRedacted(m_path));
-  }
+    CLog::Log(LOGDEBUG, "VideoInfoScanner: Found matching {} NFO file: {}", InfoTypeToStr(result),
+              CURL::GetRedacted(m_path));
   else
-  {
-    if (m_item.HasProperty("nfo_index"))
-      CLog::Log(LOGDEBUG, "VideoInfoScanner: No additional versions found in NFO file.");
-    else
-      CLog::Log(LOGDEBUG, "VideoInfoScanner: No NFO file found. Using title search for '{}'",
-                CURL::GetRedacted(m_item.GetPath()));
-  }
+    CLog::Log(LOGDEBUG, "VideoInfoScanner: No NFO file found. Using title search for '{}'",
+              CURL::GetRedacted(m_item.GetPath()));
 
   return result;
+}
+
+CInfoScanner::InfoType CVideoTagLoaderNFO::LoadVersion(int index, CVideoInfoTag& tag)
+{
+  using enum CInfoScanner::InfoType;
+
+  // The document is only in memory once Load() has parsed it
+  if (!m_nfoParsed)
+    return NONE;
+
+  const CInfoScanner::InfoType result{m_nfoReader.Reparse(index)};
+  if (result == FULL)
+  {
+    m_nfoReader.GetDetails(tag, nullptr, false);
+    CLog::Log(LOGDEBUG, "VideoInfoScanner: Found additional version ({}) in {} NFO file: {}", index,
+              InfoTypeToStr(result), CURL::GetRedacted(m_path));
+    return result;
+  }
+
+  if (result != NONE)
+  {
+    // An override entry needs a scrape to merge into, and versions are added without a scraper.
+    // Report it so the caller can move on to the next entry rather than stop here
+    CLog::Log(LOGDEBUG,
+              "VideoInfoScanner: Ignoring additional {} entry ({}) in NFO file - only full entries "
+              "can be added as versions: {}",
+              InfoTypeToStr(result), index, CURL::GetRedacted(m_path));
+    return result;
+  }
+
+  CLog::Log(LOGDEBUG, "VideoInfoScanner: No additional versions found in NFO file.");
+  return NONE;
 }
 
 int CVideoTagLoaderNFO::GetBlurayPlaylist() const

--- a/xbmc/video/tags/VideoTagLoaderNFO.h
+++ b/xbmc/video/tags/VideoTagLoaderNFO.h
@@ -28,10 +28,16 @@ public:
   bool HasInfo() const override;
 
   //! \brief Load "tag" from nfo file.
-  //! \brief tag Tag to load info into
+  //! \param tag Tag to load info into
   CInfoScanner::InfoType Load(CVideoInfoTag& tag,
                               bool prioritise,
                               std::vector<EmbeddedArt>* = nullptr) override;
+
+  //! \brief Load an additional <movie> entry from the nfo file as a version.
+  //! \param index 1-based index of the entry to load (2 is the first additional version)
+  //! \param tag Tag to load info into, only populated when the result is FULL
+  //! The nfo file is already in memory after Load()
+  CInfoScanner::InfoType LoadVersion(int index, CVideoInfoTag& tag) override;
 
   //! \brief Returns the bluray playlist from a <playlist> nfo element, -1 if there isn't one.
   int GetBlurayPlaylist() const override;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Reuse already parsed nfo to look for movie versions.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Movie nfos were being read and parsed twice. Second time to look for versions.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

As below.
Also on several multi-version movies to ensure no regressions.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

# NFO version probe — reuse the loaded document instead of re-reading

Comparison of Kodi 22 master against a build carrying only the "reuse the already-parsed NFO
document for the video-version probe" change, over SMB and NFS.

Logs: `smbbase1/2`, `nfsbase1/2` (master `c9386e0442`) and `smbnfos1/2`, `nfsnfos1/2/3`
(branch `c0d95ea08c`).

`nfsnfos3` was run against a later branch build carrying four review fixes on top of the same
change (non-destructive `Reparse()` on a failed probe, parse addon type held by `CNfoFile` rather
than taken from the loader's scraper, `bluray_playlist` cleared for entries without one, doc-comment
tags). Behaviour and timings are unchanged by those, so it is treated as a third branch run.

## What the change does

When the scanner adds a movie from a full NFO it then probes for further `<movie>` elements in the
same file — additional video versions. On master that probe builds a **new** `CVideoTagLoaderNFO`
with `nfo_index` bumped, so `CNfoFile::Create()` runs from scratch: the file is re-opened and
re-read over the network, re-parsed, and `SearchNfoForScraperUrls()` runs a second time — a Python
interpreter invocation per installed video scraper — over a document the first loader already had
in memory.

The change adds `CNfoFile::Reparse()` and `CVideoTagLoaderNFO::LoadVersion()`, which re-seek to the
nth `<movie>` element in the buffer already held by the existing loader. The probe becomes a
`std::string::find` in RAM: no file access, no scraper pass.

---

## 1. Are the runs comparable?

Yes. All nine runs match on every property below.

| Property | Value (all 9 runs) |
|---|---|
| Kodi version | 22.0-BETA1 (21.90.801) |
| Build type | **Release** x64 |
| Compiler | MSVC 195136256 (identical across both builds) |
| Directories processed | 362 |
| Movies added | 358 |
| `Found matching full NFO` | 364 |
| Errors | 0 |
| Warnings | 5 (6 in `smbnfos2`) |

Sources are consistent within each protocol:

- SMB — `smb://MediaMaster.localdomain/Media/My Movies/`
- NFS — `nfs://192.168.1.25/volume1/Media/My Movies/`

Master runs come from `D:\Projects\kodi_test\kodi-build.x64\Release`, branch runs from
`D:\Projects\kodi_nfos\kodi-build.x64\Release`. Two runs per configuration, three for NFS
branch.

---

## 2. Behaviour is identical

The probe must still find genuine additional versions. It does — in all nine runs.

| | smbbase1/2 | smbnfos1/2 | nfsbase1/2 | nfsnfos1/2/3 |
|---|---|---|---|---|
| `Found matching full NFO` | 364 / 364 | 364 / 364 | 364 / 364 | 364 / 364 / 364 |
| `No additional versions found` | 364 / 364 | 364 / 364 | 364 / 364 | 364 / 364 / 364 |
| `Found additional version (2)` | 1 / 1 | 1 / 1 | 1 / 1 | 1 / 1 / 1 |

The one genuine multi-version file in the library — `Battlestar Galactica Razor (2007)/BSG_S40_RAZOR.nfo`
— is detected on both builds and both protocols. Log output is otherwise unchanged, by design.

---

## 3. The redundant read is gone

The NFS logs carry per-file `CNFSFile::Open` lines, so the mechanism can be counted directly.
(SMB has no equivalent logging.)

| | `.nfo` opens | expected |
|---|---|---|
| nfsbase1 | 729 | 2 × 364 + 1 |
| nfsbase2 | 729 | 2 × 364 + 1 |
| **nfsnfos1** | **364** | 1 × 364 |
| **nfsnfos2** | **364** | 1 × 364 |
| **nfsnfos3** | **364** | 1 × 364 |

Exactly one open per NFO file on the branch, down from two. The extra `+1` on master is the
multi-version file, which legitimately gets a third open there.

Summed `Open`→`Close` for those opens: **7.6 / 7.9 s → 3.8 / 3.8 / 3.8 s**, at an unchanged
~10.5 ms per open. 364 network round trips per scan removed.

---

## 4. Scan time

| Configuration | Run 1 | Run 2 | Run 3 | Mean | Spread |
|---|---|---|---|---|---|
| SMB master | 40.01 s | 40.62 s | — | **40.31 s** | 1.5% |
| SMB branch | 40.21 s | 40.24 s | — | **40.22 s** | 0.1% |
| NFS master | 84.55 s | 87.48 s | — | **86.02 s** | 3.4% |
| NFS branch | 79.22 s | 77.47 s | 78.49 s | **78.39 s** | 2.2% |

Change: **SMB −0.2%**, **NFS −8.9%**.

- **SMB is unchanged** — the means differ by 90 ms, well inside the 610 ms spread between the two
  master runs.
- **NFS is faster and the ranges do not overlap**: master 84.55–87.48 s against branch
  77.47–79.22 s. All three branch runs beat both master runs by a clear margin (5.3 s worst case,
  10.0 s best case), and the third run lands between the first two.

Per directory: SMB 0.111 s both builds; NFS 0.238 s → 0.217 s.

---

## 5. Where the time went

Per-movie phase breakdown, 358 clean pairs per run. This is the important table: the saving is
confined to exactly the window the change targets, and every other window is unchanged.

### NFS

| window | nfsbase1 | nfsbase2 | nfsnfos1 | nfsnfos2 | nfsnfos3 |
|---|---|---|---|---|---|
| dir scan → `Found matching full NFO` | 19.8 s | 20.5 s | 20.1 s | 20.1 s | 20.0 s |
| `Found NFO` → `Adding new item` | 22.6 s | 24.8 s | 24.7 s | 23.1 s | 23.8 s |
| **`Adding new item` → `No additional versions`** | **24.1 s** | **24.6 s** | **17.2 s** | **16.7 s** | **17.1 s** |
| `No additional versions` → `Finished dir` | 1.6 s | 1.6 s | 1.3 s | 1.3 s | 1.3 s |

The targeted window: mean **24.35 s → 17.00 s**, i.e. **−7.4 s (−30%)**, or 68.0 → 47.5 ms per
movie. Worst case per movie also drops, 145/140 ms → 118/96/105 ms. The three untouched windows
differ by less than their own run-to-run spread.

The −7.4 s in that window accounts for essentially all of the −7.6 s in scan total. Splitting it:

| component | cost | share |
|---|---|---|
| 364 eliminated network reads | 3.9 s | 364 × 10.6 ms `Open`→`Close` |
| eliminated re-parse + `SearchNfoForScraperUrls` | ~3.5 s | ~9.8 ms per movie |

So both halves of the original diagnosis are real, and the scraper pass is roughly as expensive as
the network read it accompanies.

### SMB

| window | smbbase1 | smbbase2 | smbnfos1 | smbnfos2 |
|---|---|---|---|---|
| dir scan → `Found matching full NFO` | 11.1 s | 11.3 s | 11.4 s | 11.5 s |
| `Found NFO` → `Adding new item` | 10.1 s | 10.8 s | 10.1 s | 10.3 s |
| **`Adding new item` → `No additional versions`** | **9.7 s** | **9.6 s** | **9.6 s** | **9.5 s** |
| `No additional versions` → `Finished dir` | 1.2 s | 1.2 s | 1.2 s | 1.2 s |

The targeted window moves 9.65 s → 9.55 s: 0.3 ms per movie. That is noise.

---

## 6. Why SMB gains nothing

The saving is per-round-trip, so it scales with per-open latency. On NFS an NFO open costs ~10.5 ms
and the probe was 68 ms of a 238 ms per-directory budget. On SMB the same open costs 1–2 ms.

Inspecting the window on SMB shows it is dominated by work the change does not touch:

```
14:39:20.292  Adding new item to movies:…A Good Day to Die Hard…
14:39:20.300  CVideoInfoScanner::AddSet: Adding new set Die Hard Collection   ← 8 ms of DB work
14:39:20.301  No additional versions found in NFO file.                        ← 1 ms probe
```

`AddVideo()` — the DB insert, set creation, art handling — is the bulk of that window. On SMB the
probe was already ~1 ms of ~27 ms, so removing it cannot register in a 40 s scan. This also
explains the residual on NFS: after the change that window is still 17.00 s, and it is now
essentially all `AddVideo()`. That is where any further gain in this phase would have to come from.

libnfs serialises all operations behind a process-wide lock, which is the usual reason NFS pays
disproportionately for per-file operations and why removing 364 of them is worth 8.9% there and
nothing over SMB.

---

## 7. SMB versus NFS

| Metric | SMB | NFS | Ratio |
|---|---|---|---|
| Scan time, master | 40.31 s | 86.02 s | NFS **2.13× slower** |
| Scan time, branch | 40.22 s | 78.39 s | NFS **1.95× slower** |
| Per directory, master | 0.111 s | 0.238 s | NFS 2.14× slower |
| Per directory, branch | 0.111 s | 0.217 s | NFS 1.95× slower |

The gap narrows from 2.13× to 1.95×, bringing it under 2× for the first time in these
measurements. NFS remains roughly twice as slow overall, because most of the remaining gap is
directory listing and `AddVideo()` work this change does not touch.

---

## 8. Conclusions

1. **Behaviour is unchanged.** 364/364 NFO matches, 364/364 version probes, and the single genuine
   additional version found, on both builds and both protocols.
2. **The mechanism is confirmed directly.** `.nfo` opens on NFS drop 729 → 364; summed open/close
   time halves, 7.75 s → 3.80 s.
3. **NFS is 8.9% faster end to end** — 86.02 s → 78.39 s, non-overlapping ranges, all three branch
   runs beating both master runs.
4. **The saving is where it should be.** −7.4 s in the targeted window accounts for the −7.6 s in
   scan total; the other three windows are unchanged within noise.
5. **SMB shows no measurable change** in either direction (−0.2%), which is expected: an SMB open
   is cheap enough that the probe was never a meaningful cost there.
6. Independent of timing, the change removes 364 network round trips and 364 Python scraper passes
   per scan and turns the probe into an in-memory string search. That stands on its own even where
   the clock does not move.

### Caveats

- Two runs per configuration, three on NFS branch. The NFS result is non-overlapping on three
  separate measures — scan total, targeted window, and open count — which is the strongest evidence
  here.
- SMB has no per-file open logging, so the mechanism is only counted directly on NFS. The identical
  364/364 log-line counts confirm the same code path ran.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
