### PR TITLE
Revert non-RetroPlayer changes from RetroPlayer tearing fix

### DIFF
--- a/xbmc/utils/DMAHeapBufferObject.cpp
+++ b/xbmc/utils/DMAHeapBufferObject.cpp
@@ -165,7 +165,7 @@ uint8_t* CDMAHeapBufferObject::GetMemory()
     return m_map;
   }
 
-  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_READ | PROT_WRITE, MAP_SHARED, m_fd, 0));
+  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_fd, 0));
   if (m_map == MAP_FAILED)
   {
     CLog::Log(LOGERROR, "CDMAHeapBufferObject::{} - mmap failed, errno={}", __FUNCTION__,

--- a/xbmc/utils/DMAHeapBufferObject.cpp
+++ b/xbmc/utils/DMAHeapBufferObject.cpp
@@ -165,7 +165,7 @@ uint8_t* CDMAHeapBufferObject::GetMemory()
     return m_map;
   }
 
-  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_fd, 0));
+  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_READ | PROT_WRITE, MAP_SHARED, m_fd, 0));
   if (m_map == MAP_FAILED)
   {
     CLog::Log(LOGERROR, "CDMAHeapBufferObject::{} - mmap failed, errno={}", __FUNCTION__,

--- a/xbmc/utils/UDMABufferObject.cpp
+++ b/xbmc/utils/UDMABufferObject.cpp
@@ -203,7 +203,8 @@ uint8_t* CUDMABufferObject::GetMemory()
     return m_map;
   }
 
-  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_memfd, 0));
+  m_map =
+      static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_READ | PROT_WRITE, MAP_SHARED, m_memfd, 0));
   if (m_map == MAP_FAILED)
   {
     CLog::Log(LOGERROR, "CUDMABufferObject::{} - mmap failed, errno={}", __FUNCTION__,

--- a/xbmc/utils/UDMABufferObject.cpp
+++ b/xbmc/utils/UDMABufferObject.cpp
@@ -203,11 +203,7 @@ uint8_t* CUDMABufferObject::GetMemory()
     return m_map;
   }
 
-  // Map the dma-buf itself rather than the memfd behind it. DMA_BUF_IOCTL_SYNC,
-  // which SyncStart() and SyncEnd() use to bracket CPU access, only governs
-  // mappings of the dma-buf, so writes through a mapping of the memfd sit
-  // outside the bracket entirely.
-  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_READ | PROT_WRITE, MAP_SHARED, m_fd, 0));
+  m_map = static_cast<uint8_t*>(mmap(nullptr, m_size, PROT_WRITE, MAP_SHARED, m_memfd, 0));
   if (m_map == MAP_FAILED)
   {
     CLog::Log(LOGERROR, "CUDMABufferObject::{} - mmap failed, errno={}", __FUNCTION__,

--- a/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLContext.cpp
@@ -78,15 +78,15 @@ bool CWinSystemGbmGLContext::InitWindowSystem()
   CScreenshotSurfaceGL::Register();
 
   CBufferObjectFactory::ClearBufferObjects();
+  CDumbBufferObject::Register();
+#if defined(HAS_GBM_BO_MAP)
+  CGBMBufferObject::Register();
+#endif
 #if defined(HAVE_LINUX_MEMFD) && defined(HAVE_LINUX_UDMABUF)
   CUDMABufferObject::Register();
 #endif
 #if defined(HAVE_LINUX_DMA_HEAP)
   CDMAHeapBufferObject::Register();
-#endif
-  CDumbBufferObject::Register();
-#if defined(HAS_GBM_BO_MAP)
-  CGBMBufferObject::Register();
 #endif
 
   return true;

--- a/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbmGLESContext.cpp
@@ -95,15 +95,15 @@ bool CWinSystemGbmGLESContext::InitWindowSystem()
   CScreenshotSurfaceGLES::Register();
 
   CBufferObjectFactory::ClearBufferObjects();
+  CDumbBufferObject::Register();
+#if defined(HAS_GBM_BO_MAP)
+  CGBMBufferObject::Register();
+#endif
 #if defined(HAVE_LINUX_MEMFD) && defined(HAVE_LINUX_UDMABUF)
   CUDMABufferObject::Register();
 #endif
 #if defined(HAVE_LINUX_DMA_HEAP)
   CDMAHeapBufferObject::Register();
-#endif
-  CDumbBufferObject::Register();
-#if defined(HAS_GBM_BO_MAP)
-  CGBMBufferObject::Register();
 #endif
 
   return true;


### PR DESCRIPTION
## Description

The tearing fix, https://github.com/xbmc/xbmc/pull/28983, initially disabled a single code path in RetroPlayer. But then I got my hands on it, and I grew it in scope, paying down some technical debt, but I also prompted my agent to make changes outside of `cores/RetroPlayer`.

I misremembered these lines being added specifically for RetroPlayer, and didn't realize the fallout that changing them would likely have. They clearly affect outside code and deserve extensive testing, so I'm undoing those changes.

## Motivation and context

For comparison, @reardonia did similar changes, and spent ~6 weeks worth of of updates and reviews, including a huge amount of testing with the LibreELEC folks behind the scenes.

If the changes ever return, it'll be with the appropriate amount of care and scrutiny that my teammates give our codebase.

## How has this been tested?

Builds successfully. Code is returning to an exact point from 3 days ago.

## What is the effect on users?

This is an un-un-fix.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
