### PR TITLE
VideoPlayer: fix premature CACHESTATE_FULL on realtime streams

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -2113,11 +2113,25 @@ void CVideoPlayer::HandlePlaySpeed()
         SetCaching(CACHESTATE_INIT);
     }
 
-    // if audio stream stalled, wait until demux queue filled 10%
-    if (m_pInputStream->IsRealtime() &&
-        (m_CurrentAudio.id < 0 || m_VideoPlayerAudio->GetLevel() > 10))
+    // if audio stream stalled, wait until demux queues have filled to 10% before
+    // resuming playback. Both audio AND video need to be checked here - checking
+    // audio alone means buffering can end while video hasn't recovered at all
+    if (m_pInputStream->IsRealtime())
     {
-      SetCaching(CACHESTATE_INIT);
+      const bool audioReady = m_CurrentAudio.id < 0 || m_VideoPlayerAudio->GetLevel() > 10;
+      const bool videoReady = m_CurrentVideo.id < 0 || m_processInfo->GetLevelVQ() > 10;
+
+      if (audioReady && (videoReady || m_cachingTimer.IsTimePast()))
+      {
+        if (!videoReady)
+        {
+          CLog::Log(LOGDEBUG,
+                    "Stream stalled, caching timeout reached before video recovered. "
+                    "Audio: {} - Video: {}",
+                    m_VideoPlayerAudio->GetLevel(), m_processInfo->GetLevelVQ());
+        }
+        SetCaching(CACHESTATE_INIT);
+      }
     }
   }
 


### PR DESCRIPTION
## Description
Fixes intermittent jerky video that could occur after a stall on realtime (e.g. DVB) input streams, particularly after repeated/overlapping stalls.

When a realtime stream stalls, `CVideoPlayer::HandlePlaySpeed()` enters `CACHESTATE_FULL` and pauses playback until the demux queues have refilled.
The check that decides when to leave `CACHESTATE_FULL` only looked at the
**audio** queue level:

```cpp
    if (m_pInputStream->IsRealtime() &&
        (m_CurrentAudio.id < 0 || m_VideoPlayerAudio->GetLevel() > 10))
      SetCaching(CACHESTATE_INIT);

```

Audio and video queues are the same capacity by default (both get SetMaxTimeSize(m_messageQueueTimeSize)), so this isn't about queue size. The divergence comes from mux interleave skew and independent per-stream flush/refill behaviour after a stall, and from videopackets briefly lacking usable timestamps right after a resync, which routes CDVDMessageQueue::GetLevel() into its data-based fallback (a much higher effective threshold than the normal time-based one). Checking audio alone let playback resume with video still near-empty, producing jerky video right after a stall - intermittent, since it depends on exactly how far the two levels have diverged at that moment.

## Fix
Require both audio and video to be ready (level > 10%, matching the existing threshold), bounded by the existing 5s m_cachingTimer (armed by SetCaching() on entry to CACHESTATE_FULL, reused here the same way it's already used as an escape hatch in the CACHESTATE_INIT block below):

```cpp
    if (audioReady && (videoReady || m_cachingTimer.IsTimePast()))
      SetCaching(CACHESTATE_INIT);
```

The timeout is gated on audioReady rather than applied unconditionally. It exists for the case where data is flowing but video's level can't climb past 10% - the demux read loop stops feeding both queues once either is full, so video can get stuck below the threshold even after audio has recovered. It must not fire when the source has genuinely gone away with nothing arriving at all: that case needs to stay in CACHESTATE_FULL with the clock paused, same as before this change,
rather than falling through to CACHESTATE_PLAY with a running clock and no data.

A realtime stream with no audio (m_CurrentAudio.id < 0) previously left CACHESTATE_FULL on the first pass regardless of video level, effectively never buffering on a stall. It now waits for GetLevelVQ() > 10 (or the 5s timeout), same as an audio+video stream - audioReady is trivially true in that case, so this is exactly the "data flowing, video stuck" path above.

## How has this been tested?
Reproduced with a DVB tuner subject to repeated signal stalls.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
