### PR TITLE
[VideoInfoScanner][Database] Hold  the actor table in memory for the duration of a scan.

### DIFF
--- a/xbmc/dbwrappers/Database.h
+++ b/xbmc/dbwrappers/Database.h
@@ -110,7 +110,7 @@ public:
 
   void BeginTransaction();
   virtual bool CommitTransaction();
-  void RollbackTransaction();
+  virtual void RollbackTransaction();
   bool InTransaction() const;
   void CopyDB(const std::string& latestDb);
   void DropAnalytics();

--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES Bookmark.cpp
             SetInfoTag.cpp
             Teletext.cpp
             VideoDatabase.cpp
+            VideoDatabaseActorCache.cpp
             VideoDatabaseDDL.cpp
             VideoDatabaseMigration.cpp
             VideoDbUrl.cpp
@@ -34,6 +35,7 @@ set(HEADERS Bookmark.h
             Teletext.h
             TeletextDefines.h
             VideoDatabase.h
+            VideoDatabaseActorCache.h
             VideoDatabaseColumns.h
             VideoDatabaseDDL.h
             VideoDbUrl.h

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -109,7 +109,20 @@ CVideoDatabase::~CVideoDatabase() = default;
 //********************************************************************************************************************************
 bool CVideoDatabase::Open()
 {
+  if (!IsOpen())
+    m_actorCache.Release();
+
   return CDatabase::Open(CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_databaseVideo);
+}
+
+void CVideoDatabase::RollbackTransaction()
+{
+  CDatabase::RollbackTransaction();
+
+  // AddActor() inserts inside the caller's transaction, so any actor added during this one has
+  // just been undone.
+  if (m_actorCache.IsLoaded())
+    LoadActorCache();
 }
 
 void CVideoDatabase::CreateTables()
@@ -1516,6 +1529,16 @@ int CVideoDatabase::AddTag(const std::string& name)
   return AddToTable("tag", "tag_id", "name", name);
 }
 
+void CVideoDatabase::LoadActorCache()
+{
+  m_actorCache.Load(m_pDS2.get());
+}
+
+void CVideoDatabase::ReleaseActorCache()
+{
+  m_actorCache.Release();
+}
+
 int CVideoDatabase::AddActor(const std::string& name, const std::string& thumbURLs, const std::string &thumb)
 {
   try
@@ -1527,30 +1550,78 @@ int CVideoDatabase::AddActor(const std::string& name, const std::string& thumbUR
     int idActor = -1;
 
     // ATTENTION: the trimming of actor names should really not be done here but after the scraping / NFO-parsing
-    std::string trimmedName = name;
-    StringUtils::Trim(trimmedName);
+    const std::string storedName{KODI::VIDEO::CActorCache::StoredName(name)};
 
-    std::string strSQL=PrepareSQL("select actor_id from actor where name like '%s'", trimmedName.substr(0, 255).c_str());
-    m_pDS->query(strSQL);
-    if (m_pDS->num_rows() == 0)
+    bool known = false;
+    std::string storedArtUrls;
+    bool haveArtUrls = false;
+
+    if (m_actorCache.IsLoaded())
     {
-      m_pDS->close();
-      // doesn't exists, add it
-      strSQL=PrepareSQL("insert into actor (actor_id, name, art_urls) values(NULL, '%s', '%s')", trimmedName.substr(0,255).c_str(), thumbURLs.c_str());
-      m_pDS->exec(strSQL);
-      idActor = static_cast<int>(m_pDS->lastinsertid());
+      // The cache stands in for the whole table, so a name it doesn't hold is one we haven't seen
+      if (const auto* cached = m_actorCache.Find(storedName))
+      {
+        idActor = cached->id;
+        storedArtUrls = cached->artUrls;
+        haveArtUrls = true;
+        known = true;
+      }
     }
     else
     {
-      idActor = m_pDS->fv(0).get_asInt();
-      m_pDS->close();
-      // update the thumb url's
-      if (!thumbURLs.empty())
+      // Only the name is asked for, so that the index over it covers the query
+      m_pDS->query(
+          PrepareSQL("select actor_id from actor where name like '%s'", storedName.c_str()));
+      if (m_pDS->num_rows() > 0)
       {
-        strSQL=PrepareSQL("update actor set art_urls = '%s' where actor_id = %i", thumbURLs.c_str(), idActor);
-        m_pDS->exec(strSQL);
+        idActor = m_pDS->fv(0).get_asInt();
+        known = true;
+      }
+      m_pDS->close();
+    }
+
+    if (!known)
+    {
+      try
+      {
+        m_pDS->exec(
+            PrepareSQL("insert into actor (actor_id, name, art_urls) values(NULL, '%s', '%s')",
+                       storedName.c_str(), thumbURLs.c_str()));
+        idActor = static_cast<int>(m_pDS->lastinsertid());
+        storedArtUrls = thumbURLs;
+        haveArtUrls = true;
+      }
+      catch (...)
+      {
+        // Something else added this actor since the cache was read. Take the row it created,
+        // including its art urls - those are not ours to assume
+        m_pDS->query(PrepareSQL("select actor_id, art_urls from actor where name like '%s'",
+                                storedName.c_str()));
+        if (m_pDS->num_rows() == 0)
+        {
+          m_pDS->close();
+          throw;
+        }
+        idActor = m_pDS->fv(0).get_asInt();
+        storedArtUrls = m_pDS->fv(1).get_asString();
+        m_pDS->close();
+        haveArtUrls = true;
+        known = true;
       }
     }
+
+    // update the thumb url's, skipping the write where the row is known to hold them already
+    if (known && !thumbURLs.empty() && (!haveArtUrls || thumbURLs != storedArtUrls))
+    {
+      m_pDS->exec(PrepareSQL("update actor set art_urls = '%s' where actor_id = %i",
+                             thumbURLs.c_str(), idActor));
+      storedArtUrls = thumbURLs;
+      haveArtUrls = true;
+    }
+
+    if (m_actorCache.IsLoaded() && idActor > 0 && haveArtUrls)
+      m_actorCache.Set(storedName, idActor, storedArtUrls);
+
     // add artwork
     if (!thumb.empty())
       SetArtForItem(idActor, "actor", "thumb", thumb);

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -15,6 +15,7 @@
 #include "utils/Artwork.h"
 #include "utils/SortUtils.h"
 #include "utils/UrlOptions.h"
+#include "video/VideoDatabaseActorCache.h"
 
 #include <array>
 #include <functional>
@@ -197,6 +198,7 @@ public:
 
   bool Open() override;
   bool CommitTransaction() override;
+  void RollbackTransaction() override;
 
   int AddNewEpisode(int idShow, CVideoInfoTag& details);
 
@@ -1193,6 +1195,15 @@ private:
   void CreateTables() override;
   void CreateAnalytics() override;
   void UpdateTables(int version) override;
+
+  /*! \brief Load / discard the in-memory actor cache
+   Held through CActorCacheScope, which is the intended way for a caller to turn it on
+   */
+  void LoadActorCache();
+  void ReleaseActorCache();
+  friend class KODI::VIDEO::CActorCacheScope;
+
+  KODI::VIDEO::CActorCache m_actorCache;
 
   /*! \brief Helper to get a database id given a query.
    Returns an integer, -1 if not found, and greater than 0 if found.

--- a/xbmc/video/VideoDatabaseActorCache.cpp
+++ b/xbmc/video/VideoDatabaseActorCache.cpp
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VideoDatabaseActorCache.h"
+
+#include "dbwrappers/dataset.h"
+#include "utils/StringUtils.h"
+#include "utils/log.h"
+#include "video/VideoDatabase.h"
+
+namespace KODI::VIDEO
+{
+
+std::string CActorCache::StoredName(const std::string& name)
+{
+  std::string stored{name};
+  StringUtils::Trim(stored);
+  return stored.substr(0, 255);
+}
+
+std::string CActorCache::Key(const std::string& storedName)
+{
+  std::string key{storedName};
+  StringUtils::ToLower(key);
+  return key;
+}
+
+void CActorCache::Load(dbiplus::Dataset* dataset)
+{
+  m_actors.clear();
+  m_loaded = false;
+  if (!dataset)
+  {
+    CLog::LogF(LOGERROR, "no dataset - actors will be looked up individually");
+    return;
+  }
+
+  try
+  {
+    dataset->query("SELECT actor_id, name, art_urls FROM actor");
+    while (!dataset->eof())
+    {
+      Set(StoredName(dataset->fv(1).get_asString()), dataset->fv(0).get_asInt(),
+          dataset->fv(2).get_asString());
+      dataset->next();
+    }
+    dataset->close();
+    m_loaded = true;
+    CLog::LogF(LOGDEBUG, "holding {} actors", m_actors.size());
+  }
+  catch (...)
+  {
+    CLog::LogF(LOGERROR, "failed - actors will be looked up individually");
+    m_actors.clear();
+  }
+}
+
+void CActorCache::Release()
+{
+  m_loaded = false;
+  m_actors.clear();
+}
+
+const CActorCache::Actor* CActorCache::Find(const std::string& storedName) const
+{
+  const auto actor{m_actors.find(Key(storedName))};
+  return actor != m_actors.cend() ? &actor->second : nullptr;
+}
+
+void CActorCache::Set(const std::string& storedName, int id, const std::string& artUrls)
+{
+  m_actors.insert_or_assign(Key(storedName), Actor{id, artUrls});
+}
+
+CActorCacheScope::CActorCacheScope(CVideoDatabase& db) : m_db(db)
+{
+  m_db.LoadActorCache();
+}
+
+CActorCacheScope::~CActorCacheScope()
+{
+  m_db.ReleaseActorCache();
+}
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoDatabaseActorCache.h
+++ b/xbmc/video/VideoDatabaseActorCache.h
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+class CVideoDatabase;
+
+namespace dbiplus
+{
+class Dataset;
+}
+
+namespace KODI::VIDEO
+{
+
+/*!
+ \brief The actor table, held in memory
+
+ CVideoDatabase::AddActor() matches names case-insensitively, which the actor table's index cannot
+ serve, so every cast member, director and writer otherwise costs a scan of that table - tens of
+ thousands of scans over a full scrape, against a table growing to a similar size. Reading the
+ table once answers all of them from memory instead.
+
+ While loaded the cache stands in for the whole table: a name it does not hold is taken to be new.
+ Nothing else may add actors meanwhile, and it must be released before anything removes them.
+
+ \sa CActorCacheScope, which is how a caller should hold one
+ */
+class CActorCache
+{
+public:
+  struct Actor
+  {
+    int id{-1};
+    std::string artUrls;
+  };
+
+  /*! \brief Read the actor table
+   Failure leaves the cache unloaded rather than partial, so lookups simply go back to the database
+   \param dataset the dataset to query on
+   */
+  void Load(dbiplus::Dataset* dataset);
+
+  //! \brief Discard the cache, so that lookups go back to the database
+  void Release();
+
+  //! \brief Whether the cache is loaded and may be treated as the whole actor table
+  bool IsLoaded() const { return m_loaded; }
+
+  /*! \brief A name as the actor table holds it
+   Trimmed and truncated the way CVideoDatabase::AddActor() writes it, so that a name looked up
+   here matches the row it would have created
+   \param name the actor's name, as scraped
+   \return the name the actor table would hold
+   */
+  static std::string StoredName(const std::string& name);
+
+  /*! \brief Find an actor by name
+   \param storedName the name as the actor table holds it - see StoredName()
+   \return the actor, or nullptr if the cache doesn't hold that name
+   */
+  const Actor* Find(const std::string& storedName) const;
+
+  /*! \brief Record an actor, replacing anything held for that name
+   \param storedName the name as the actor table holds it - trimmed and truncated
+   \param id the actor's id
+   \param artUrls the actor's art urls, as last written
+   */
+  void Set(const std::string& storedName, int id, const std::string& artUrls);
+
+private:
+  /*! \brief The key a name is matched on
+   Folded to lower case in ASCII only, which is what the LIKE comparison it stands in for does
+   */
+  static std::string Key(const std::string& storedName);
+
+  std::unordered_map<std::string, Actor> m_actors;
+  bool m_loaded{false};
+};
+
+/*!
+ \brief Holds a video database's actor cache for as long as the object lives
+
+ Loading is worthwhile for a scan and wrong to leave in place afterwards, so ownership is explicit.
+ */
+class CActorCacheScope
+{
+public:
+  explicit CActorCacheScope(CVideoDatabase& db);
+  ~CActorCacheScope();
+
+  CActorCacheScope(const CActorCacheScope&) = delete;
+  CActorCacheScope& operator=(const CActorCacheScope&) = delete;
+
+private:
+  CVideoDatabase& m_db;
+};
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -67,6 +67,7 @@
 #include <chrono>
 #include <map>
 #include <memory>
+#include <optional>
 #include <ranges>
 #include <set>
 #include <string>
@@ -329,6 +330,11 @@ CVideoInfoScanner::~CVideoInfoScanner()
       // result in unexpected behaviour.
       m_bCanInterrupt = false;
 
+      // Database lookup cannot use the table's index as case insensitivity needed
+      // Hold the table in memory for the scan instead
+      std::optional<KODI::VIDEO::CActorCacheScope> actorCache;
+      actorCache.emplace(m_database);
+
       bool bCancelled = false;
       while (!bCancelled && !m_pathsToScan.empty())
       {
@@ -380,6 +386,9 @@ CVideoInfoScanner::~CVideoInfoScanner()
           }
         }
       }
+
+      // The cached ids would not survive cleaning, which removes actors
+      actorCache.reset();
 
       if (!bCancelled)
       {

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES TestBookmark.cpp
             TestFilenameAttributes.cpp
             TestPlayerControllerActions.cpp
             TestStacks.cpp
+            TestVideoDatabaseActorCache.cpp
             TestVideoDbUrl.cpp
             TestVideoFileItemClassify.cpp
             TestVideoInfoTag.cpp

--- a/xbmc/video/test/TestVideoDatabaseActorCache.cpp
+++ b/xbmc/video/test/TestVideoDatabaseActorCache.cpp
@@ -1,0 +1,149 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "video/VideoDatabaseActorCache.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+using namespace KODI::VIDEO;
+
+// The cache stands in for a lookup the database does with LIKE, so what matters is that it matches
+// names the same way that lookup would, and that a caller can tell whether it is answering at all.
+
+TEST(TestVideoDatabaseActorCacheStoredName, TrimsSurroundingWhitespace)
+{
+  EXPECT_EQ(CActorCache::StoredName("  Heath Ledger  "), "Heath Ledger");
+  EXPECT_EQ(CActorCache::StoredName("\t\nHeath Ledger\r\n"), "Heath Ledger");
+  EXPECT_EQ(CActorCache::StoredName("Heath Ledger"), "Heath Ledger");
+}
+
+TEST(TestVideoDatabaseActorCacheStoredName, KeepsInnerWhitespaceAndCase)
+{
+  EXPECT_EQ(CActorCache::StoredName("Joseph Gordon-Levitt"), "Joseph Gordon-Levitt");
+  EXPECT_EQ(CActorCache::StoredName("HEATH LEDGER"), "HEATH LEDGER");
+}
+
+TEST(TestVideoDatabaseActorCacheStoredName, TruncatesToTheColumnWidth)
+{
+  // The actor table holds 255 characters, so anything longer has to be cut the same way here or a
+  // lookup would miss the row it created
+  const std::string longName(300, 'a');
+  EXPECT_EQ(CActorCache::StoredName(longName).size(), 255U);
+  EXPECT_EQ(CActorCache::StoredName(std::string(255, 'a')).size(), 255U);
+  EXPECT_EQ(CActorCache::StoredName(std::string(254, 'a')).size(), 254U);
+}
+
+TEST(TestVideoDatabaseActorCacheStoredName, TrimsBeforeTruncating)
+{
+  // 255 characters of name plus padding must still yield the full 255, not 255 including spaces
+  const std::string padded{"  " + std::string(255, 'a') + "  "};
+  EXPECT_EQ(CActorCache::StoredName(padded), std::string(255, 'a'));
+}
+
+TEST(TestVideoDatabaseActorCacheStoredName, HandlesEmptyAndWhitespaceOnly)
+{
+  EXPECT_EQ(CActorCache::StoredName(""), "");
+  EXPECT_EQ(CActorCache::StoredName("   "), "");
+}
+
+TEST(TestVideoDatabaseActorCache, StartsEmptyAndUnloaded)
+{
+  const CActorCache cache;
+
+  EXPECT_FALSE(cache.IsLoaded());
+  EXPECT_EQ(cache.Find("Heath Ledger"), nullptr);
+}
+
+TEST(TestVideoDatabaseActorCache, FindsWhatWasSet)
+{
+  CActorCache cache;
+  cache.Set("Heath Ledger", 42, "thumb://ledger");
+
+  const auto* actor{cache.Find("Heath Ledger")};
+  ASSERT_NE(actor, nullptr);
+  EXPECT_EQ(actor->id, 42);
+  EXPECT_EQ(actor->artUrls, "thumb://ledger");
+}
+
+TEST(TestVideoDatabaseActorCache, MissesNamesItDoesNotHold)
+{
+  CActorCache cache;
+  cache.Set("Heath Ledger", 42, "");
+
+  EXPECT_EQ(cache.Find("Julia Stiles"), nullptr);
+  EXPECT_EQ(cache.Find(""), nullptr);
+}
+
+TEST(TestVideoDatabaseActorCache, MatchesAsciiCaseInsensitively)
+{
+  // AddActor() matches with LIKE, which folds ASCII case, so the cache has to agree
+  CActorCache cache;
+  cache.Set("Heath Ledger", 42, "");
+
+  EXPECT_NE(cache.Find("HEATH LEDGER"), nullptr);
+  EXPECT_NE(cache.Find("heath ledger"), nullptr);
+  EXPECT_NE(cache.Find("hEaTh LeDgEr"), nullptr);
+}
+
+TEST(TestVideoDatabaseActorCache, DoesNotFoldNonAsciiCase)
+{
+  // SQLite's LIKE only folds ASCII, so these are separate actors in the library and must stay
+  // separate here - folding them would merge two rows the database keeps apart
+  CActorCache cache;
+  cache.Set("BJ\xC3\x96RK", 1, ""); // BJORK with a capital O-umlaut
+
+  EXPECT_NE(cache.Find("bj\xC3\x96rk"), nullptr); // ASCII letters folded, umlaut untouched
+  EXPECT_EQ(cache.Find("bj\xC3\xB6rk"), nullptr); // lower case umlaut is a different name
+}
+
+TEST(TestVideoDatabaseActorCache, SetReplacesAnEntryRegardlessOfCase)
+{
+  CActorCache cache;
+  cache.Set("Heath Ledger", 1, "first");
+  cache.Set("HEATH LEDGER", 2, "second");
+
+  const auto* actor{cache.Find("heath ledger")};
+  ASSERT_NE(actor, nullptr);
+  EXPECT_EQ(actor->id, 2);
+  EXPECT_EQ(actor->artUrls, "second");
+}
+
+TEST(TestVideoDatabaseActorCache, RoundTripsNamesNeedingNormalisation)
+{
+  // How a caller is meant to use it: normalise once, then look up
+  CActorCache cache;
+  cache.Set(CActorCache::StoredName("  Heath Ledger  "), 42, "");
+
+  EXPECT_NE(cache.Find(CActorCache::StoredName("Heath Ledger")), nullptr);
+  EXPECT_NE(cache.Find(CActorCache::StoredName("\theath ledger ")), nullptr);
+}
+
+TEST(TestVideoDatabaseActorCache, ReleaseEmptiesAndUnloads)
+{
+  CActorCache cache;
+  cache.Set("Heath Ledger", 42, "");
+  cache.Release();
+
+  EXPECT_FALSE(cache.IsLoaded());
+  EXPECT_EQ(cache.Find("Heath Ledger"), nullptr);
+}
+
+TEST(TestVideoDatabaseActorCache, LoadWithoutADatasetLeavesItUnloaded)
+{
+  // Nothing may be treated as authoritative if the read didn't happen, or a name missing from the
+  // cache would be taken for a new actor and inserted over an existing row
+  CActorCache cache;
+  cache.Set("Heath Ledger", 42, "");
+
+  cache.Load(nullptr);
+
+  EXPECT_FALSE(cache.IsLoaded());
+  EXPECT_EQ(cache.Find("Heath Ledger"), nullptr);
+}


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

 Read the table once at the start of a scan and cache it.
Ownership is explicit through CActorCacheScope.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

AddActor() has to match names case-insensitively, which the actor table's index cannot serve.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally. See below.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

# Actor cache — SMB measurement

Comparison of Kodi 22 master against the same tree carrying only the in-memory actor cache, over
SMB on Windows.

Logs: `smbbase1/2` (master) and `smbcache1/2` (actor cache).

---

## 1. What the change does

`CVideoDatabase::AddActor()` looks up every cast member, director and writer by name. The match has
to be case-insensitive, which the actor table's index cannot serve:

```
WHERE name LIKE 'x'  ->  SCAN actor USING COVERING INDEX ix_actor_1
WHERE name =    'x'  ->  SEARCH actor USING COVERING INDEX ix_actor_1 (name=?)
```

So each call scans the whole index. On this library that is 17,662 + 398 + 693 = **18,753 calls per
scrape**, against a table growing to 15,039 rows — on the order of 140 million index-entry
comparisons, on the scanner thread.

The change reads the actor table once at the start of a scan and answers from memory. While loaded
the cache stands in for the table, so a name it does not hold is new and is inserted without asking
the database. It also skips the `UPDATE actor SET art_urls` that previously fired on every hit,
rewriting an identical value ~9,800 times a scrape.

---

## 2. Are the runs comparable?

Yes.

| Property | Value (all 4 runs) |
|---|---|
| Base commit | `c9386e0442` (cache runs `-dirty`, being uncommitted) |
| Build type | **Release** x64 |
| Compiler | MSVC 195136256, compiled 2026-08-22 |
| Source | `smb://MediaMaster.localdomain/Media/My Movies/` |
| Directories processed / skipped | 362 / 0 |
| Movies added | 358 |
| `Recaching image` | 0 |
| Warnings / errors | 5 / 0 |
| Actor cache load failures | 0 |

All four were clean scrapes from an empty texture cache.

---

## 3. Scan time

| Configuration | Run 1 | Run 2 | Mean |
|---|---|---|---|
| master | 40.01 s | 40.62 s | **40.31 s** |
| actor cache | 36.09 s | 35.43 s | **35.76 s** |

**−11.3%**, non-overlapping — both cache runs beat both master runs.

Per-directory cost agrees, and is the better figure since it averages 362 samples rather than one
total:

| Configuration | Run 1 | Run 2 |
|---|---|---|
| master | 0.0960 s | 0.0980 s |
| actor cache | **0.0853 s** | **0.0835 s** |

**−12.6%**, also non-overlapping.

---

## 4. Where the time went

The scan splits into three logged phases per film. Only one of them contains `AddActor`.

Mean / median milliseconds per film:

| Phase | base1 | base2 | cache1 | cache2 |
|---|---|---|---|---|
| Directory listing → NFO found | 19.47 / 18 | 19.78 / 18 | 20.55 / 18 | 20.08 / 18 |
| NFO found → AddVideo | 28.27 / 22 | 30.21 / 22 | 30.08 / 23 | 29.17 / 22 |
| **AddVideo → Finished** | **32.73 / 28** | **32.46 / 28** | **18.66 / 16** | **17.98 / 16** |

The third window is the one that runs `SetDetailsForMovie` → `AddCast` → `AddActor`
(`VideoInfoScanner.cpp:2191` logs its start, `:2256` makes the call).

- **Both control phases are unchanged** — median 18 ms and 22 ms in all four runs, master and cache
  alike. The change cannot touch directory listing or NFO parsing, and it doesn't.
- **The AddActor window falls 43.8%**, from 32.59 to 18.32 ms/film (median 28 → 16).

### The arithmetic closes

```
14.27 ms/film saved x 358 films  =  5.11 s predicted
observed scan saving             =  4.55 s
```

The phase saving accounts for the entire improvement. Nothing is left unexplained, and nothing
regressed elsewhere to offset it.

---

## 5. Conclusions

1. **Scan time improves 11.3%** on SMB, non-overlapping across two runs each.
2. **The saving is where the change acts** — the window containing `AddActor` drops 43.8%, while
   the two phases it cannot affect are identical across all four runs.
3. **The measured saving matches the predicted one** (5.11 s predicted, 4.55 s observed).
4. **Nothing else moved.** Directory listing and NFO parsing are unchanged.

This is a scanner-thread, database-side saving, so unlike the art-hash commit it is not expected to
vary by protocol — the same win should appear on NFS and on local sources. Worth one NFS run to
confirm, but there is no mechanism by which it would differ.

### Caveats

- Two runs per configuration. The separation is clean on both scan time and per-directory cost, and
  the phase breakdown is consistent between the two cache runs (18.66 and 17.98 ms/film).
- **Art caching throughput is not comparable here.** Both cache runs were stopped much earlier — a
  post-scan window of 22–24 s against 64–68 s for the baselines — so the caching figures reflect
  when Kodi was closed, not throughput. The change does not touch art caching in any case.
- No run drained its art queue.


## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
