### PR TITLE
[VideoPlayer] Tell the PGS decoder the video's colorimetry

### DIFF
--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -199,6 +199,9 @@ macro(buildFFMPEG)
                       COMMAND ${CMAKE_COMMAND} -E copy
                       ${CMAKE_SOURCE_DIR}/tools/depends/target/ffmpeg/002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch
                       <SOURCE_DIR>
+                      COMMAND ${CMAKE_COMMAND} -E copy
+                      ${CMAKE_SOURCE_DIR}/tools/depends/target/ffmpeg/008-ffmpeg-all-pgssubdec-use-caller-colorspace.patch
+                      <SOURCE_DIR>
     )
 
     if(NOT DISABLE_FFMPEG_SOURCE_PLUGINS)

--- a/tools/depends/target/ffmpeg/008-ffmpeg-all-pgssubdec-use-caller-colorspace.patch
+++ b/tools/depends/target/ffmpeg/008-ffmpeg-all-pgssubdec-use-caller-colorspace.patch
@@ -1,0 +1,79 @@
+diff --git a/libavutil/colorspace.h b/libavutil/colorspace.h
+--- a/libavutil/colorspace.h
++++ b/libavutil/colorspace.h
+@@ -51,6 +51,18 @@
+         b_add = ONE_HALF + FIX(1.8556 * 255.0 / 224.0) * cb;  \
+     }
+ 
++// Derived from ITU-R BT.2020-2 Table 4, non-constant luminance.
++// Kr = 0.2627, Kb = 0.0593.
++#define YUV_TO_RGB1_CCIR_BT2020_NCL(cb1, cr1)                     \
++    {                                                             \
++        cb    = (cb1) - 128;                                      \
++        cr    = (cr1) - 128;                                      \
++        r_add = ONE_HALF + FIX(1.474600 * 255.0 / 224.0) * cr;    \
++        g_add = ONE_HALF - FIX(0.164553 * 255.0 / 224.0) * cb -   \
++                           FIX(0.571353 * 255.0 / 224.0) * cr;    \
++        b_add = ONE_HALF + FIX(1.881400 * 255.0 / 224.0) * cb;    \
++    }
++
+ // To be used for the BT709 variant as well
+ #define YUV_TO_RGB2_CCIR(r, g, b, y1)\
+ {\
+diff --git a/libavcodec/pgssubdec.c b/libavcodec/pgssubdec.c
+--- a/libavcodec/pgssubdec.c
++++ b/libavcodec/pgssubdec.c
+@@ -336,6 +336,7 @@
+     int y, cb, cr, alpha;
+     int r, g, b, r_add, g_add, b_add;
+     int id;
++    enum AVColorSpace csp = avctx->colorspace;
+ 
+     id  = bytestream_get_byte(&buf);
+     palette = find_palette(id, &ctx->palettes);
+@@ -351,6 +352,23 @@
+     /* Skip palette version */
+     buf += 1;
+ 
++    /* A PGS palette carries no colorimetry of its own; it is authored to
++     * match the associated video stream, so only the caller can know it.
++     * A matrix with no conversion here, such as BT.2020 constant luminance
++     * or SMPTE 240M, keeps the frame-height guess rather than being decoded
++     * with a different matrix. */
++    switch (csp) {
++    case AVCOL_SPC_BT709:
++    case AVCOL_SPC_BT470BG:
++    case AVCOL_SPC_SMPTE170M:
++    case AVCOL_SPC_BT2020_NCL:
++        break;
++    default:
++        csp = (avctx->height <= 0 || avctx->height > 576) ? AVCOL_SPC_BT709
++                                                         : AVCOL_SPC_SMPTE170M;
++        break;
++    }
++
+     while (buf < buf_end) {
+         color_id  = bytestream_get_byte(&buf);
+         y         = bytestream_get_byte(&buf);
+@@ -358,11 +376,17 @@
+         cb        = bytestream_get_byte(&buf);
+         alpha     = bytestream_get_byte(&buf);
+ 
+-        /* Default to BT.709 colorspace. In case of <= 576 height use BT.601 */
+-        if (avctx->height <= 0 || avctx->height > 576) {
+-            YUV_TO_RGB1_CCIR_BT709(cb, cr);
+-        } else {
++        switch (csp) {
++        case AVCOL_SPC_BT2020_NCL:
++            YUV_TO_RGB1_CCIR_BT2020_NCL(cb, cr);
++            break;
++        case AVCOL_SPC_BT470BG:
++        case AVCOL_SPC_SMPTE170M:
+             YUV_TO_RGB1_CCIR(cb, cr);
++            break;
++        default:
++            YUV_TO_RGB1_CCIR_BT709(cb, cr);
++            break;
+         }
+ 
+         YUV_TO_RGB2_CCIR(r, g, b, y);

--- a/tools/depends/target/ffmpeg/CMakeLists.txt
+++ b/tools/depends/target/ffmpeg/CMakeLists.txt
@@ -162,6 +162,7 @@ if(NOT DISABLE_FFMPEG_SOURCE_PLUGINS)
 else()
   set(sourceplugin_patch PATCH_COMMAND patch -p1 -i <SOURCE_DIR>/002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch)
 endif()
+list(APPEND sourceplugin_patch COMMAND patch -p1 -i <SOURCE_DIR>/008-ffmpeg-all-pgssubdec-use-caller-colorspace.patch)
 
 include(ExternalProject)
 externalproject_add(ffmpeg

--- a/tools/depends/target/ffmpeg/Makefile
+++ b/tools/depends/target/ffmpeg/Makefile
@@ -3,7 +3,8 @@ include FFMPEG-VERSION
 DEPS = FFMPEG-VERSION Makefile ../../download-files.include \
                       CMakeLists.txt \
                       001-ffmpeg-all-libpostproc-plugin.patch \
-                      002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch
+                      002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch \
+                      008-ffmpeg-all-pgssubdec-use-caller-colorspace.patch
 
 BUILD_TYPE = Release
 ifeq ($(DEBUG_BUILD),yes)
@@ -46,7 +47,7 @@ all: .installed-$(PLATFORM)
 	rm -rf $(PLATFORM); mkdir -p $(PLATFORM)/build
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
 	cd $(PLATFORM); cp ../CMakeLists.txt ./
-	cd $(PLATFORM); cp ../001-ffmpeg-all-libpostproc-plugin.patch ../002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch ./
+	cd $(PLATFORM); cp ../001-ffmpeg-all-libpostproc-plugin.patch ../002-ffmpeg-libavutil-common-h-cpp11-constant-macros.patch ../008-ffmpeg-all-pgssubdec-use-caller-colorspace.patch ./
 	cd $(PLATFORM)/build; $(CMAKE) $(CMAKE_ARGS) ..
 	touch $@
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -57,6 +57,9 @@ bool CDVDOverlayCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &optio
   m_pCodecContext->debug = 0;
   m_pCodecContext->workaround_bugs = FF_BUG_AUTODETECT;
   m_pCodecContext->codec_tag = hints.codec_tag;
+  m_pCodecContext->colorspace = hints.colorSpace;
+  m_pCodecContext->color_primaries = hints.colorPrimaries;
+  m_pCodecContext->color_trc = hints.colorTransferCharacteristic;
   m_pCodecContext->time_base.num = 1;
   m_pCodecContext->time_base.den = DVD_TIME_BASE;
   m_pCodecContext->pkt_timebase.num = 1;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -4244,6 +4244,14 @@ bool CVideoPlayer::OpenStream(CCurrentStream& current, int64_t demuxerId, int iS
       }
       break;
     case StreamType::SUBTITLE:
+      // A PGS palette carries no colorimetry of its own; it is authored to
+      // match the video stream it accompanies, per BD-ROM Part 3.
+      if (hint.codec == AV_CODEC_ID_HDMV_PGS_SUBTITLE)
+      {
+        hint.colorSpace = m_CurrentVideo.hint.colorSpace;
+        hint.colorPrimaries = m_CurrentVideo.hint.colorPrimaries;
+        hint.colorTransferCharacteristic = m_CurrentVideo.hint.colorTransferCharacteristic;
+      }
       res = OpenSubtitleStream(hint);
       break;
     case StreamType::TELETEXT:


### PR DESCRIPTION
## Description
See also #28996 

Depends on #29054, which gives ffmpeg's `pgssubdec` an `avctx->colorspace` input. This PR then supplies the value.

`CVideoPlayer::OpenStream` copies the video stream's colorimetry onto the subtitle hint for PGS, and `CDVDOverlayCodecFFmpeg::Open` forwards it to the `AVCodecContext`. `color_range` is not copied: a PGS palette is limited-range by spec regardless of the video, and `pgssubdec` hardcodes that.

Enablement only. The palette still reaches the renderers as plain RGBA and they treat it exactly as today.

## Motivation and context

Only the player knows which video a subtitle track accompanies, so only the player can supply the matrix. Without it the palette on a BT.2020/PQ title is decoded as BT.709.

## What is the effect on users?

Subtitle colours change on BT.2020 titles, immediately. Neutral palette entries (white, grey) are unaffected because their chroma is 128/128 and all three matrices agree there. Coloured entries, including forced narrative subs and anti-aliased edges, now render with the intended hue
instead of a BT.709 misread.

## How has this been tested?

GBM/GLES on AMD, VAAPI decode, HDR10 HEVC with 1920x1080 PGS. Instrumented `pgssubdec` confirms it now receives `AVCOL_SPC_BT2020_NCL` and selects the BT.2020 matrix, where it previously got `AVCOL_SPC_UNSPECIFIED` and fell to the plane-height guess.

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
