### PR TITLE
[cmake][webos] Fix libdvdcss build against glibc 2.12 sysroot

### DIFF
--- a/cmake/modules/FindLibDvdCSS.cmake
+++ b/cmake/modules/FindLibDvdCSS.cmake
@@ -24,7 +24,10 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
 
     if("webos" IN_LIST CORE_PLATFORM_NAME_LC)
       # PATH_MAX not defined in limits.h. Just match windows size libdvdcss uses.
-      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_C_FLAGS "-DPATH_MAX=2048")
+      # webos sysroot is glibc 2.12, which predates _DEFAULT_SOURCE (glibc 2.19). libdvdcss
+      # builds with -std=c17, so __STRICT_ANSI__ suppresses the _BSD_SOURCE/_SVID_SOURCE
+      # defaults and strdup is never declared. Define _BSD_SOURCE explicitly to restore it.
+      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_C_FLAGS "-DPATH_MAX=2048 -D_BSD_SOURCE")
     endif()
 
     if(WIN32 OR WINDOWS_STORE)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
libdvdcss 1.5.0 builds with meson using `c_std=c17` and relies on `-D_DEFAULT_SOURCE` to expose `strdup`. The webOS SDK sysroot ships glibc 2.12, which predates `_DEFAULT_SOURCE` (added in glibc 2.19), so that define is a silent no-op there.

Because -std=c17 (rather than gnu17) defines `__STRICT_ANSI__`, glibc 2.12's features.h skips its `_BSD_SOURCE/_SVID_SOURCE` defaults. `strdup` in that string.h is gated on `__USE_SVID || __USE_BSD || __USE_XOPEN_EXTENDED || __USE_XOPEN2K8`, none of which end up set, so the declaration is hidden and GCC 15 fails the build:

```
  ../src/device.c:343:34: error: implicit declaration of function
  'strdup'; did you mean 'strcmp'? [-Wimplicit-function-declaration]
  ../src/libdvdcss.c:548:39: error: implicit declaration of function
  'strdup'; did you mean 'strcmp'? [-Wimplicit-function-declaration]
```

Define `_BSD_SOURCE` explicitly for webOS to restore the declaration. This keeps the flag scoped to the one platform that needs it, since `_BSD_SOURCE` is deprecated on glibc >= 2.20.

Regression from 9370ea763c ([dependencies] Bump libdvdcss 1.5.0); the previous autotools build did not compile in strict-ANSI mode.

The current SDK on ci is too old to catch the error.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix compilation on newer SDK

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
building kodi on webOS with new toolchain

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
