### PR TITLE
[Video] Store flags alongside audio and subtitle stream details.

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -453,6 +453,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
   {
     CStreamDetailSubtitle* sub = new CStreamDetailSubtitle();
     sub->m_strLanguage = subs[i].m_strLanguage;
+    sub->m_flags = subs[i].m_flags;
     sub->SetSource(CStreamDetail::MEDIA);
     details.AddStream(sub);
     result = true;
@@ -640,6 +641,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
       p->m_iChannels = static_cast<CDemuxStreamAudio*>(stream)->iChannels;
       p->m_strLanguage = stream->language;
       p->m_strCodec = pDemux->GetStreamCodecName(stream->demuxerId, stream->uniqueId);
+      p->m_flags = stream->flags;
       p->SetSource(CStreamDetail::MEDIA);
       details.AddStream(p);
       retVal = true;
@@ -649,6 +651,7 @@ bool CDVDFileInfo::DemuxerToStreamDetails(const std::shared_ptr<CDVDInputStream>
     {
       CStreamDetailSubtitle *p = new CStreamDetailSubtitle();
       p->m_strLanguage = stream->language;
+      p->m_flags = stream->flags;
       p->SetSource(CStreamDetail::MEDIA);
       details.AddStream(p);
       retVal = true;
@@ -713,11 +716,18 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const std::string &path, CStream
     if (!v.Open(filename, STREAM_SOURCE_NONE, vobsubfile))
       return false;
 
+    const ExternalStreamInfo idxInfo = CUtil::GetExternalStreamDetailsFromFilename(path, filename);
+
     for(CDemuxStream* stream : v.GetStreams())
     {
       CStreamDetailSubtitle *dsub = new CStreamDetailSubtitle();
       std::string lang = stream->language;
       dsub->m_strLanguage = g_LangCodeExpander.ConvertToISO6392B(lang);
+      // Mirror CVideoPlayer::AddSubtitleFile: a flag in the filename overrides the demuxer,
+      // so the scanner and the player agree
+      dsub->m_flags = static_cast<StreamFlags>(idxInfo.flag) != StreamFlags::FLAG_NONE
+                          ? static_cast<StreamFlags>(idxInfo.flag)
+                          : stream->flags;
       dsub->SetSource(CStreamDetail::MEDIA);
       details.AddStream(dsub);
     }
@@ -733,6 +743,7 @@ bool CDVDFileInfo::AddExternalSubtitleToDetails(const std::string &path, CStream
   CStreamDetailSubtitle *dsub = new CStreamDetailSubtitle();
   ExternalStreamInfo info = CUtil::GetExternalStreamDetailsFromFilename(path, filename);
   dsub->m_strLanguage = g_LangCodeExpander.ConvertToISO6392B(info.language);
+  dsub->m_flags = static_cast<StreamFlags>(info.flag);
   dsub->SetSource(CStreamDetail::MEDIA);
   details.AddStream(dsub);
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -6190,7 +6190,7 @@ void CVideoPlayer::GetAudioStreamInfo(int index, AudioStreamInfo& info) const
 
   if (index < 0 || index > GetAudioStreamCount() - 1)
   {
-    info.valid = false;
+    info = AudioStreamInfo{};
     return;
   }
 
@@ -6238,9 +6238,7 @@ void CVideoPlayer::GetSubtitleStreamInfo(int index, SubtitleStreamInfo& info) co
 
   if (index < 0 || index > GetSubtitleCount() - 1)
   {
-    info.valid = false;
-    info.language.clear();
-    info.flags = StreamFlags::FLAG_NONE;
+    info = SubtitleStreamInfo{};
     return;
   }
 

--- a/xbmc/utils/StreamDetails.cpp
+++ b/xbmc/utils/StreamDetails.cpp
@@ -12,6 +12,7 @@
 #include "StreamUtils.h"
 #include "utils/Archive.h"
 #include "utils/LangCodeExpander.h"
+#include "utils/StringUtils.h"
 #include "utils/Variant.h"
 
 #include <algorithm>
@@ -117,7 +118,8 @@ CStreamDetailAudio::CStreamDetailAudio(const AudioStreamInfo& info, Source sourc
   : CStreamDetail(CStreamDetail::AUDIO),
     m_iChannels(info.channels),
     m_strCodec(info.codecName),
-    m_strLanguage(info.language)
+    m_strLanguage(info.language),
+    m_flags(info.flags)
 {
   m_source = source;
 }
@@ -131,6 +133,7 @@ void CStreamDetailAudio::Archive(CArchive& ar)
     ar << m_iChannels;
     ar << static_cast<int>(m_source);
     ar << m_version;
+    ar << static_cast<int>(m_flags);
   }
   else
   {
@@ -141,6 +144,9 @@ void CStreamDetailAudio::Archive(CArchive& ar)
     ar >> s;
     m_source = static_cast<Source>(s);
     ar >> m_version;
+    int f;
+    ar >> f;
+    m_flags = static_cast<StreamFlags>(f);
   }
 }
 void CStreamDetailAudio::Serialize(CVariant& value) const
@@ -150,6 +156,7 @@ void CStreamDetailAudio::Serialize(CVariant& value) const
   value["channels"] = m_iChannels;
   value["source"] = static_cast<int>(m_source);
   value["version"] = m_version;
+  value["flags"] = static_cast<int>(m_flags);
 }
 
 bool CStreamDetailAudio::IsWorseThan(const CStreamDetail &that) const
@@ -169,7 +176,8 @@ CStreamDetailSubtitle::CStreamDetailSubtitle() :
 
 CStreamDetailSubtitle::CStreamDetailSubtitle(const SubtitleStreamInfo& info, Source source)
   : CStreamDetail(CStreamDetail::SUBTITLE),
-    m_strLanguage(info.language)
+    m_strLanguage(info.language),
+    m_flags(info.flags)
 {
   m_source = source;
 }
@@ -181,6 +189,7 @@ void CStreamDetailSubtitle::Archive(CArchive& ar)
     ar << m_strLanguage;
     ar << static_cast<int>(m_source);
     ar << m_version;
+    ar << static_cast<int>(m_flags);
   }
   else
   {
@@ -189,6 +198,9 @@ void CStreamDetailSubtitle::Archive(CArchive& ar)
     ar >> s;
     m_source = static_cast<Source>(s);
     ar >> m_version;
+    int f;
+    ar >> f;
+    m_flags = static_cast<StreamFlags>(f);
   }
 }
 void CStreamDetailSubtitle::Serialize(CVariant& value) const
@@ -196,6 +208,7 @@ void CStreamDetailSubtitle::Serialize(CVariant& value) const
   value["language"] = m_strLanguage;
   value["source"] = static_cast<int>(m_source);
   value["version"] = m_version;
+  value["flags"] = static_cast<int>(m_flags);
 }
 
 bool CStreamDetailSubtitle::IsWorseThan(const CStreamDetail &that) const
@@ -240,6 +253,7 @@ CStreamDetailSubtitle& CStreamDetailSubtitle::operator=(const CStreamDetailSubti
   {
     this->m_pParent = that.m_pParent;
     this->m_strLanguage = that.m_strLanguage;
+    this->m_flags = that.m_flags;
     this->m_source = that.m_source;
     this->m_version = that.m_version;
   }
@@ -298,6 +312,7 @@ bool CStreamDetails::operator ==(const CStreamDetails &right) const
     if (GetAudioCodec(iStream) != right.GetAudioCodec(iStream) ||
         GetAudioLanguage(iStream) != right.GetAudioLanguage(iStream) ||
         GetAudioChannels(iStream) != right.GetAudioChannels(iStream) ||
+        GetAudioFlags(iStream) != right.GetAudioFlags(iStream) ||
         GetSource(CStreamDetail::AUDIO, iStream) != right.GetSource(CStreamDetail::AUDIO, iStream))
       return false;
   }
@@ -305,6 +320,7 @@ bool CStreamDetails::operator ==(const CStreamDetails &right) const
   for (int iStream=1; iStream<=GetSubtitleStreamCount(); iStream++)
   {
     if (GetSubtitleLanguage(iStream) != right.GetSubtitleLanguage(iStream) ||
+        GetSubtitleFlags(iStream) != right.GetSubtitleFlags(iStream) ||
         GetSource(CStreamDetail::SUBTITLE, iStream) !=
             right.GetSource(CStreamDetail::SUBTITLE, iStream))
       return false;
@@ -554,6 +570,36 @@ int CStreamDetails::GetAudioChannels(int idx) const
     return -1;
 }
 
+std::vector<std::string> CStreamDetails::StreamFlagsToNames(StreamFlags flags)
+{
+  std::vector<std::string> names;
+  for (const auto& [flag, name] : STREAM_FLAG_NAMES)
+  {
+    if (flags & flag)
+      names.emplace_back(name);
+  }
+  return names;
+}
+
+StreamFlags CStreamDetails::StreamFlagFromName(std::string_view name)
+{
+  std::string trimmed{name};
+  StringUtils::Trim(trimmed);
+
+  const auto it = std::ranges::find_if(STREAM_FLAG_NAMES, [&trimmed](const FlagName& entry)
+                                       { return StringUtils::EqualsNoCase(trimmed, entry.name); });
+  return it == STREAM_FLAG_NAMES.end() ? StreamFlags::FLAG_NONE : it->flag;
+}
+
+StreamFlags CStreamDetails::GetAudioFlags(int idx) const
+{
+  const CStreamDetailAudio* item =
+      dynamic_cast<const CStreamDetailAudio*>(GetNthStream(CStreamDetail::AUDIO, idx));
+  if (item)
+    return item->m_flags;
+  else
+    return StreamFlags::FLAG_NONE;
+}
 std::string CStreamDetails::GetSubtitleLanguage(int idx) const
 {
   const CStreamDetailSubtitle* item =
@@ -562,6 +608,15 @@ std::string CStreamDetails::GetSubtitleLanguage(int idx) const
     return item->m_strLanguage;
   else
     return "";
+}
+StreamFlags CStreamDetails::GetSubtitleFlags(int idx) const
+{
+  const CStreamDetailSubtitle* item =
+      dynamic_cast<const CStreamDetailSubtitle*>(GetNthStream(CStreamDetail::SUBTITLE, idx));
+  if (item)
+    return item->m_flags;
+  else
+    return StreamFlags::FLAG_NONE;
 }
 
 int CStreamDetails::GetPreferredAudioStreamIndex(const std::string& language) const

--- a/xbmc/utils/StreamDetails.h
+++ b/xbmc/utils/StreamDetails.h
@@ -12,6 +12,7 @@
 #include "cores/VideoPlayer/Interface/StreamInfo.h"
 #include "utils/IArchivable.h"
 
+#include <algorithm>
 #include <array>
 #include <memory>
 #include <string>
@@ -27,7 +28,9 @@ struct SubtitleStreamInfo;
 class CStreamDetail : public IArchivable, public ISerializable
 {
 public:
-  static constexpr int STREAM_DETAILS_VERSION = 2;
+  static constexpr int STREAM_DETAILS_VERSION = 3;
+  static constexpr int STREAM_DETAILS_VERSION_FLAGS =
+      3; // Version that introduced flags to audio and subtitle streams
 
   enum StreamType {
     VIDEO,
@@ -102,6 +105,7 @@ public:
   int m_iChannels = -1;
   std::string m_strCodec;
   std::string m_strLanguage;
+  StreamFlags m_flags{StreamFlags::FLAG_NONE};
 };
 
 class CStreamDetailSubtitle final : public CStreamDetail
@@ -116,6 +120,7 @@ public:
   bool IsWorseThan(const CStreamDetail &that) const override;
 
   std::string m_strLanguage;
+  StreamFlags m_flags{StreamFlags::FLAG_NONE};
 };
 
 class CStreamDetails final : public IArchivable, public ISerializable
@@ -199,8 +204,54 @@ public:
       {2.76f, "2.76"},
   });
 
+  /*!
+   * \brief A stream flag, and the name Kodi reads and writes for it in an NFO.
+   */
+  struct FlagName
+  {
+    StreamFlags flag;
+    std::string_view name;
+  };
+
+  /*!
+   * \brief The vocabulary of stream flag names used in NFOs.
+   *
+   * Written out in alphabetical order.
+   */
+  static constexpr auto STREAM_FLAG_NAMES = std::to_array<FlagName>({
+      {StreamFlags::FLAG_COMMENT, "comment"},
+      {StreamFlags::FLAG_DEFAULT, "default"},
+      {StreamFlags::FLAG_DUB, "dub"},
+      {StreamFlags::FLAG_FORCED, "forced"},
+      {StreamFlags::FLAG_HEARING_IMPAIRED, "hearingimpaired"},
+      {StreamFlags::FLAG_KARAOKE, "karaoke"},
+      {StreamFlags::FLAG_LYRICS, "lyrics"},
+      {StreamFlags::FLAG_ORIGINAL, "original"},
+      {StreamFlags::FLAG_STILL_IMAGES, "stillimages"},
+      {StreamFlags::FLAG_VISUAL_IMPAIRED, "visualimpaired"},
+      {StreamFlags::FLAG_WEBVTT_DATA_PACKETS, "webvttdatapackets"},
+  });
+
+  static_assert(std::ranges::is_sorted(STREAM_FLAG_NAMES, {}, &FlagName::name),
+                "STREAM_FLAG_NAMES must be in alphabetical order - StreamFlagsToNames() walks it "
+                "in order and its callers rely on the names coming out sorted");
+
   static std::string VideoDimsToResolutionDescription(int iWidth, int iHeight);
   static std::string VideoAspectToAspectDescription(float fAspect);
+
+  /*!
+   * \brief Break a flag set out into its names, in alphabetical order.
+   * \param flags The flags to name.
+   * \return One entry per set bit that has a name; empty for FLAG_NONE.
+   */
+  static std::vector<std::string> StreamFlagsToNames(StreamFlags flags);
+
+  /*!
+   * \brief Look a single flag up by name.
+   * \param name The name to look up. Leading and trailing space is ignored, as is case.
+   * \return The matching flag, or FLAG_NONE if the name isn't known.
+   */
+  static StreamFlags StreamFlagFromName(std::string_view name);
 
   bool HasItems(void) const { return !m_vecItems.empty(); }
   int GetStreamCount(CStreamDetail::StreamType type) const;
@@ -234,9 +285,11 @@ public:
   std::string GetAudioCodec(int idx = 0) const;
   std::string GetAudioLanguage(int idx = 0) const;
   int GetAudioChannels(int idx = 0) const;
+  StreamFlags GetAudioFlags(int idx = 0) const;
   /*! @} */
 
   std::string GetSubtitleLanguage(int idx = 0) const;
+  StreamFlags GetSubtitleFlags(int idx = 0) const;
 
   /*!
    * \brief Get the index of the best audio stream in the given language.

--- a/xbmc/utils/test/TestStreamDetails.cpp
+++ b/xbmc/utils/test/TestStreamDetails.cpp
@@ -851,3 +851,145 @@ TEST(TestStreamDetails, FirstAudio_UnknownCodecAndChannelsArePassedThrough)
   EXPECT_EQ("", details.GetFirstAudioCodec());
   EXPECT_EQ(0, details.GetFirstAudioChannels());
 }
+
+TEST(TestStreamDetails, Flags_CopiedFromStreamInfo)
+{
+  // The scanner and the bluray parser both hand over a StreamInfo with the flags
+  // already set; the detail must keep them rather than drop them on the floor.
+  AudioStreamInfo audioInfo;
+  audioInfo.language = "eng";
+  audioInfo.channels = 6;
+  audioInfo.flags =
+      static_cast<StreamFlags>(StreamFlags::FLAG_DEFAULT | StreamFlags::FLAG_ORIGINAL);
+
+  SubtitleStreamInfo subtitleInfo;
+  subtitleInfo.language = "eng";
+  subtitleInfo.flags = StreamFlags::FLAG_FORCED;
+
+  CStreamDetails details;
+  details.AddStream(new CStreamDetailAudio(audioInfo, CStreamDetail::MEDIA));
+  details.AddStream(new CStreamDetailSubtitle(subtitleInfo, CStreamDetail::MEDIA));
+  details.DetermineBestStreams();
+
+  EXPECT_EQ(StreamFlags::FLAG_DEFAULT | StreamFlags::FLAG_ORIGINAL, details.GetAudioFlags(1));
+  EXPECT_EQ(StreamFlags::FLAG_FORCED, details.GetSubtitleFlags(1));
+}
+
+TEST(TestStreamDetails, Flags_DefaultToNoneAndAbsentStreamReportsNone)
+{
+  // Details that predate the flags column read back with no flags set, which must
+  // look the same as a stream that genuinely has none.
+  const CStreamDetails empty;
+  EXPECT_EQ(StreamFlags::FLAG_NONE, empty.GetAudioFlags(1));
+  EXPECT_EQ(StreamFlags::FLAG_NONE, empty.GetSubtitleFlags(1));
+
+  CStreamDetails details;
+  details.AddStream(new CStreamDetailAudio());
+  details.AddStream(new CStreamDetailSubtitle());
+  details.DetermineBestStreams();
+
+  EXPECT_EQ(StreamFlags::FLAG_NONE, details.GetAudioFlags(1));
+  EXPECT_EQ(StreamFlags::FLAG_NONE, details.GetSubtitleFlags(1));
+}
+
+TEST(TestStreamDetails, Flags_SurviveCopy)
+{
+  AudioStreamInfo audioInfo;
+  audioInfo.flags = StreamFlags::FLAG_VISUAL_IMPAIRED;
+
+  SubtitleStreamInfo subtitleInfo;
+  subtitleInfo.flags = StreamFlags::FLAG_HEARING_IMPAIRED;
+
+  CStreamDetails details;
+  details.AddStream(new CStreamDetailAudio(audioInfo, CStreamDetail::MEDIA));
+  details.AddStream(new CStreamDetailSubtitle(subtitleInfo, CStreamDetail::MEDIA));
+  details.DetermineBestStreams();
+
+  const CStreamDetails copy{details};
+  EXPECT_EQ(StreamFlags::FLAG_VISUAL_IMPAIRED, copy.GetAudioFlags(1));
+  EXPECT_EQ(StreamFlags::FLAG_HEARING_IMPAIRED, copy.GetSubtitleFlags(1));
+
+  // CStreamDetailSubtitle has its own operator=, which must carry the flags too.
+  CStreamDetailSubtitle subtitle;
+  subtitle.m_flags = StreamFlags::FLAG_FORCED;
+  CStreamDetailSubtitle subtitleCopy;
+  subtitleCopy = subtitle;
+  EXPECT_EQ(StreamFlags::FLAG_FORCED, subtitleCopy.m_flags);
+}
+
+TEST(TestStreamDetails, Flags_ParticipateInEquality)
+{
+  // SaveFileStateJob only writes stream details back to the database when the
+  // player's details differ from the stored ones, so a flags-only difference has
+  // to register as a difference. Otherwise flags are never backfilled for items
+  // scanned before the flags column existed.
+  AudioStreamInfo audioInfo;
+  audioInfo.codecName = "dts";
+  audioInfo.language = "eng";
+  audioInfo.channels = 6;
+
+  SubtitleStreamInfo subtitleInfo;
+  subtitleInfo.language = "eng";
+
+  const auto makeDetails = [&](StreamFlags audioFlags, StreamFlags subtitleFlags)
+  {
+    AudioStreamInfo audio{audioInfo};
+    audio.flags = audioFlags;
+    SubtitleStreamInfo subtitle{subtitleInfo};
+    subtitle.flags = subtitleFlags;
+
+    CStreamDetails details;
+    details.AddStream(new CStreamDetailAudio(audio, CStreamDetail::MEDIA));
+    details.AddStream(new CStreamDetailSubtitle(subtitle, CStreamDetail::MEDIA));
+    details.DetermineBestStreams();
+    return details;
+  };
+
+  const CStreamDetails flagless = makeDetails(StreamFlags::FLAG_NONE, StreamFlags::FLAG_NONE);
+
+  EXPECT_NE(flagless, makeDetails(StreamFlags::FLAG_DEFAULT, StreamFlags::FLAG_NONE));
+  EXPECT_NE(flagless, makeDetails(StreamFlags::FLAG_NONE, StreamFlags::FLAG_FORCED));
+  EXPECT_EQ(flagless, makeDetails(StreamFlags::FLAG_NONE, StreamFlags::FLAG_NONE));
+}
+
+TEST(TestStreamDetails, StreamFlagNames_EveryFlagRoundTrips)
+{
+  // A name missing from the table would be silently dropped on export, so the table has to
+  // cover every StreamFlags bit and each name has to map back to the flag it came from.
+  StreamFlags all{StreamFlags::FLAG_NONE};
+  for (const auto& [flag, name] : CStreamDetails::STREAM_FLAG_NAMES)
+  {
+    EXPECT_EQ(flag, CStreamDetails::StreamFlagFromName(name)) << "name: " << name;
+    all = static_cast<StreamFlags>(all | flag);
+  }
+
+  EXPECT_EQ(CStreamDetails::STREAM_FLAG_NAMES.size(),
+            CStreamDetails::StreamFlagsToNames(all).size());
+  EXPECT_TRUE(CStreamDetails::StreamFlagsToNames(StreamFlags::FLAG_NONE).empty());
+}
+
+TEST(TestStreamDetails, StreamFlagNames_UnknownAndUntidyNames)
+{
+  // NFOs are hand-edited, so leading/trailing space and casing must not matter, and a name
+  // from a newer Kodi that this build doesn't know must be ignored rather than misread.
+  EXPECT_EQ(StreamFlags::FLAG_DEFAULT, CStreamDetails::StreamFlagFromName("  DeFaUlT  "));
+  EXPECT_EQ(StreamFlags::FLAG_NONE, CStreamDetails::StreamFlagFromName("notaflag"));
+  EXPECT_EQ(StreamFlags::FLAG_NONE, CStreamDetails::StreamFlagFromName(""));
+}
+
+TEST(TestStreamDetails, StreamFlagNames_ReportedAlphabetically)
+{
+  // Names come out sorted regardless of the bit order they were set in, so an exported NFO
+  // is stable and two items with the same flags produce byte-identical output.
+  const std::vector<std::string> names =
+      CStreamDetails::StreamFlagsToNames(static_cast<StreamFlags>(
+          StreamFlags::FLAG_ORIGINAL | StreamFlags::FLAG_DEFAULT | StreamFlags::FLAG_FORCED));
+
+  EXPECT_EQ(std::vector<std::string>({"default", "forced", "original"}), names);
+
+  const std::vector<std::string> all = CStreamDetails::StreamFlagsToNames(
+      static_cast<StreamFlags>(StreamFlags::FLAG_WEBVTT_DATA_PACKETS |
+                               StreamFlags::FLAG_HEARING_IMPAIRED | StreamFlags::FLAG_COMMENT));
+
+  EXPECT_EQ(std::vector<std::string>({"comment", "hearingimpaired", "webvttdatapackets"}), all);
+}

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -3252,25 +3252,27 @@ bool CVideoDatabase::SetStreamDetailsForFileId(const CStreamDetails& details, in
     }
     for (int i = 1; i <= details.GetAudioStreamCount(); i++)
     {
-      m_pDS->exec(PrepareSQL("INSERT INTO streamdetails "
-                             "(idFile, iStreamType, strAudioCodec, iAudioChannels, "
-                             "strAudioLanguage, iSource, iVersion) "
-                             "VALUES (%i,%i,'%s',%i,'%s',%i, %i)",
-                             idFile, static_cast<int>(CStreamDetail::AUDIO),
-                             details.GetAudioCodec(i).c_str(), details.GetAudioChannels(i),
-                             details.GetAudioLanguage(i).c_str(),
-                             static_cast<int>(details.GetSource(CStreamDetail::AUDIO, i)),
-                             details.GetVersion(CStreamDetail::AUDIO, i)));
+      m_pDS->exec(PrepareSQL(
+          "INSERT INTO streamdetails "
+          "(idFile, iStreamType, strAudioCodec, iAudioChannels, "
+          "strAudioLanguage, iSource, iVersion, iFlags) "
+          "VALUES (%i,%i,'%s',%i,'%s',%i, %i, %i)",
+          idFile, static_cast<int>(CStreamDetail::AUDIO), details.GetAudioCodec(i).c_str(),
+          details.GetAudioChannels(i), details.GetAudioLanguage(i).c_str(),
+          static_cast<int>(details.GetSource(CStreamDetail::AUDIO, i)),
+          details.GetVersion(CStreamDetail::AUDIO, i), static_cast<int>(details.GetAudioFlags(i))));
     }
     for (int i = 1; i <= details.GetSubtitleStreamCount(); i++)
     {
       m_pDS->exec(PrepareSQL("INSERT INTO streamdetails "
-                             "(idFile, iStreamType, strSubtitleLanguage, iSource, iVersion) "
-                             "VALUES (%i,%i,'%s',%i, %i)",
+                             "(idFile, iStreamType, strSubtitleLanguage, iSource, iVersion, "
+                             "iFlags) "
+                             "VALUES (%i,%i,'%s',%i, %i, %i)",
                              idFile, static_cast<int>(CStreamDetail::SUBTITLE),
                              details.GetSubtitleLanguage(i).c_str(),
                              static_cast<int>(details.GetSource(CStreamDetail::SUBTITLE, i)),
-                             details.GetVersion(CStreamDetail::SUBTITLE, i)));
+                             details.GetVersion(CStreamDetail::SUBTITLE, i),
+                             static_cast<int>(details.GetSubtitleFlags(i))));
     }
 
     // update the runtime information, if empty
@@ -4657,6 +4659,8 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
           p->m_strLanguage = pDS->fv(8).get_asString();
           p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
           p->m_version = pDS->fv(16).get_asInt();
+          if (!pDS->fv(17).get_isNull())
+            p->m_flags = static_cast<StreamFlags>(pDS->fv(17).get_asInt());
           details.AddStream(p);
           retVal = true;
           break;
@@ -4667,6 +4671,8 @@ bool CVideoDatabase::GetStreamDetails(CVideoInfoTag& tag)
           p->m_strLanguage = pDS->fv(9).get_asString();
           p->m_source = static_cast<CStreamDetail::Source>(pDS->fv(15).get_asInt());
           p->m_version = pDS->fv(16).get_asInt();
+          if (!pDS->fv(17).get_isNull())
+            p->m_flags = static_cast<StreamFlags>(pDS->fv(17).get_asInt());
           details.AddStream(p);
           retVal = true;
           break;

--- a/xbmc/video/VideoDatabaseDDL.cpp
+++ b/xbmc/video/VideoDatabaseDDL.cpp
@@ -156,7 +156,7 @@ void CVideoDatabaseDDL::CreateTables(CDatabase& db)
       "strAudioCodec text, iAudioChannels integer, strAudioLanguage text, "
       "strSubtitleLanguage text, iVideoDuration integer, strStereoMode text, "
       "strVideoLanguage text, strHdrType text, strHdrDetail text, iSource integer, iVersion "
-      "integer)");
+      "integer, iFlags integer)");
 
   CLog::Log(LOGINFO, "create sets table");
   db.ExecuteQuery("CREATE TABLE `sets` ( idSet integer primary key, strSet text, strOverview text, "

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -1425,9 +1425,12 @@ void CVideoDatabase::UpdateTables(int iVersion)
     m_pDS->exec("ALTER TABLE streamdetails ADD iSource INTEGER DEFAULT 40");
     m_pDS->exec("ALTER TABLE streamdetails ADD iVersion INTEGER DEFAULT 1");
   }
+
+  if (iVersion < 149)
+    m_pDS->exec("ALTER TABLE streamdetails ADD iFlags INTEGER DEFAULT 0");
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 148;
+  return 149;
 }

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -29,6 +29,32 @@
 #include <string>
 #include <vector>
 
+namespace
+{
+/*!
+ * \brief Read the <flags> block of one <audio> or <subtitle> stream in an NFO.
+ * \param nodeDetail The stream element to read from.
+ * \return The flags named by its <flag> children. FLAG_NONE if there is no <flags> block.
+ */
+StreamFlags ParseStreamFlags(const TiXmlNode* nodeDetail)
+{
+  int flags{StreamFlags::FLAG_NONE};
+
+  const TiXmlNode* nodeFlags{nodeDetail->FirstChild("flags")};
+  if (nodeFlags)
+  {
+    const TiXmlNode* nodeFlag{nullptr};
+    while ((nodeFlag = nodeFlags->IterateChildren("flag", nodeFlag)))
+    {
+      if (nodeFlag->FirstChild())
+        flags |= CStreamDetails::StreamFlagFromName(nodeFlag->FirstChild()->ValueStr());
+    }
+  }
+
+  return static_cast<StreamFlags>(flags);
+}
+} // unnamed namespace
+
 void CVideoInfoTag::Reset()
 {
   m_director.clear();
@@ -278,12 +304,30 @@ bool CVideoInfoTag::Save(TiXmlNode *node, const std::string &tag, bool savePathI
       XMLUtils::SetString(&stream, "codec", m_streamDetails.GetAudioCodec(iStream));
       XMLUtils::SetString(&stream, "language", m_streamDetails.GetAudioLanguage(iStream));
       XMLUtils::SetInt(&stream, "channels", m_streamDetails.GetAudioChannels(iStream));
+      if (m_streamDetails.GetVersion(CStreamDetail::AUDIO, iStream) >=
+          CStreamDetail::STREAM_DETAILS_VERSION_FLAGS)
+      {
+        TiXmlElement flags("flags");
+        XMLUtils::SetStringArray(
+            &flags, "flag",
+            CStreamDetails::StreamFlagsToNames(m_streamDetails.GetAudioFlags(iStream)));
+        stream.InsertEndChild(flags);
+      }
       streamdetails.InsertEndChild(stream);
     }
     for (int iStream=1; iStream<=m_streamDetails.GetSubtitleStreamCount(); iStream++)
     {
       TiXmlElement stream("subtitle");
       XMLUtils::SetString(&stream, "language", m_streamDetails.GetSubtitleLanguage(iStream));
+      if (m_streamDetails.GetVersion(CStreamDetail::SUBTITLE, iStream) >=
+          CStreamDetail::STREAM_DETAILS_VERSION_FLAGS)
+      {
+        TiXmlElement flags("flags");
+        XMLUtils::SetStringArray(
+            &flags, "flag",
+            CStreamDetails::StreamFlagsToNames(m_streamDetails.GetSubtitleFlags(iStream)));
+        stream.InsertEndChild(flags);
+      }
       streamdetails.InsertEndChild(stream);
     }
     fileinfo.InsertEndChild(streamdetails);
@@ -1511,6 +1555,9 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
           p->m_strLanguage = StringUtils::Trim(value);
 
         XMLUtils::GetInt(nodeDetail, "channels", p->m_iChannels);
+
+        p->m_flags = ParseStreamFlags(nodeDetail);
+
         StringUtils::ToLower(p->m_strCodec);
         StringUtils::ToLower(p->m_strLanguage);
         m_streamDetails.AddStream(p);
@@ -1548,6 +1595,9 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
         auto* p = new CStreamDetailSubtitle();
         if (XMLUtils::GetString(nodeDetail, "language", value))
           p->m_strLanguage = StringUtils::Trim(value);
+
+        p->m_flags = ParseStreamFlags(nodeDetail);
+
         StringUtils::ToLower(p->m_strLanguage);
         m_streamDetails.AddStream(p);
       }

--- a/xbmc/video/test/TestVideoInfoTag.cpp
+++ b/xbmc/video/test/TestVideoInfoTag.cpp
@@ -49,6 +49,81 @@ TEST(TestVideoInfoTag, ReadTVShowSeasons)
   EXPECT_EQ(details.m_seasons, reference);
 }
 
+TEST(TestVideoInfoTag, ReadStreamDetailFlags)
+{
+  const std::string document =
+      R"(<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+         <movie>
+         <fileinfo>
+         <streamdetails>
+         <audio><codec>dts</codec><language>eng</language><channels>6</channels>
+           <flags><flag>default</flag><flag>original</flag></flags></audio>
+         <audio><codec>ac3</codec><language>fre</language><channels>2</channels></audio>
+         <audio><codec>aac</codec><language>ger</language><channels>2</channels>
+           <flags><flag>  Forced  </flag><flag>notaflag</flag><flag></flag></flags></audio>
+         <subtitle><language>eng</language><flags><flag>forced</flag></flags></subtitle>
+         <subtitle><language>fre</language></subtitle>
+         <subtitle><language>ger</language><flags></flags></subtitle>
+         </streamdetails>
+         </fileinfo>
+         </movie>)";
+
+  CXBMCTinyXML doc;
+  doc.Parse(document, TIXML_ENCODING_UNKNOWN);
+
+  CVideoInfoTag details;
+  EXPECT_TRUE(details.Load(doc.RootElement(), true, false));
+
+  const CStreamDetails& streams = details.m_streamDetails;
+  ASSERT_EQ(3, streams.GetAudioStreamCount());
+  ASSERT_EQ(3, streams.GetSubtitleStreamCount());
+
+  EXPECT_EQ(StreamFlags::FLAG_DEFAULT | StreamFlags::FLAG_ORIGINAL, streams.GetAudioFlags(1));
+  EXPECT_EQ(StreamFlags::FLAG_FORCED, streams.GetSubtitleFlags(1));
+
+  // An NFO written before flags existed has no <flags> element at all, which must
+  // read back as no flags rather than leaving the field uninitialised.
+  EXPECT_EQ(StreamFlags::FLAG_NONE, streams.GetAudioFlags(2));
+  EXPECT_EQ(StreamFlags::FLAG_NONE, streams.GetSubtitleFlags(2));
+
+  // Names are trimmed and case-insensitive; a name this build doesn't know, and an empty
+  // one, are skipped rather than failing the whole stream.
+  EXPECT_EQ(StreamFlags::FLAG_FORCED, streams.GetAudioFlags(3));
+
+  // An empty <flags> block is a positive statement that the stream has no flags.
+  EXPECT_EQ(StreamFlags::FLAG_NONE, streams.GetSubtitleFlags(3));
+}
+
+TEST(TestVideoInfoTag, WriteStreamDetailFlags)
+{
+  // Flags survive an export/import cycle, so a library rebuilt from exported NFOs
+  // keeps them.
+  AudioStreamInfo audioInfo;
+  audioInfo.codecName = "dts";
+  audioInfo.language = "eng";
+  audioInfo.channels = 6;
+  audioInfo.flags =
+      static_cast<StreamFlags>(StreamFlags::FLAG_DEFAULT | StreamFlags::FLAG_ORIGINAL);
+
+  SubtitleStreamInfo subtitleInfo;
+  subtitleInfo.language = "eng";
+  subtitleInfo.flags = StreamFlags::FLAG_FORCED;
+
+  CVideoInfoTag details;
+  details.m_streamDetails.AddStream(new CStreamDetailAudio(audioInfo, CStreamDetail::MEDIA));
+  details.m_streamDetails.AddStream(new CStreamDetailSubtitle(subtitleInfo, CStreamDetail::MEDIA));
+  details.m_streamDetails.DetermineBestStreams();
+
+  CXBMCTinyXML xmlDoc;
+  ASSERT_TRUE(details.Save(&xmlDoc, "movie"));
+
+  CVideoInfoTag reloaded;
+  ASSERT_TRUE(reloaded.Load(xmlDoc.RootElement(), true, false));
+
+  EXPECT_EQ(audioInfo.flags, reloaded.m_streamDetails.GetAudioFlags(1));
+  EXPECT_EQ(subtitleInfo.flags, reloaded.m_streamDetails.GetSubtitleFlags(1));
+}
+
 // Trick to make protected methods accessible for testing
 class CVideoInfoTagTest : public CVideoInfoTag
 {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Add a flags field for streamdetail information to the streamdetails table.

Add NFO support.
```
            <audio>
                <codec>dtshd_ma</codec>
                <language>eng</language>
                <channels>6</channels>
                <flags>
                    <flag>default</flag>
                </flags>
            </audio>
            <audio>
                <codec>ac3</codec>
                <language>eng</language>
                <channels>2</channels>
                <flags />
            </audio>
            <subtitle>
                <language>eng</language>
                <flags>
                    <flag>default</flag>
                    <flag>forced</flag>
                    <flag>original</flag>
                </flags>
            </subtitle>
```

Bumps streamdetails version to v3.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

To help determine default and original streams to synchronise what is displayed in the GUI and played/displayed by the player (although this is not implimented here).

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

None currently.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
