### PR TITLE
[VideoPlayer][Android] Fix InstanceGuard release race in CDVDVideoCodecAndroidMediaCodec

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecAndroidMediaCodec.cpp
@@ -336,14 +336,14 @@ bool CDVDVideoCodecAndroidMediaCodec::Open(CDVDStreamInfo &hints, CDVDCodecOptio
   int profile(0);
   CJNIUUID uuid(0, 0);
 
-  m_opened = false;
-  m_needSecureDecoder = false;
   // allow only 1 instance here
   if (m_InstanceGuard.exchange(true))
   {
     CLog::Log(LOGERROR, "CDVDVideoCodecAndroidMediaCodec::Open - InstanceGuard locked");
     return false;
   }
+  m_opened = false;
+  m_needSecureDecoder = false;
 
   // mediacodec crashes with null size. Trap this...
   if (!hints.width || !hints.height)


### PR DESCRIPTION
## Description

`Open()` cleared `m_opened` before checking the static `m_InstanceGuard`. If an already-open codec instance attempted to open again while the guard remained set, the guard check returned `false` after `m_opened` had already been cleared. A later `Dispose()` then returned early at `if (!m_opened) return;` and never released the guard, preventing subsequent MediaCodec instances from opening.

Move the `m_opened` and `m_needSecureDecoder` resets after successful guard acquisition. A rejected owning instance now retains its opened state so `Dispose()` releases the guard, while a fresh rejected instance remains unopened and cannot release another instance's guard. Failures after acquisition continue to release the guard through the existing `FAIL` path.

This mirrors the ordering fix used by CoreELEC for the Amlogic codec path (referenced in #20021: [`c63342329f31d0071a8e1d8d1a0d8c0cbad1e513`](https://github.com/CoreELEC/xbmc/commit/c63342329f31d0071a8e1d8d1a0d8c0cbad1e513)).

## Motivation and context

Confirmed the underlying InstanceGuard race independently in a different trigger path than the original #20021 report: live DASH playback with SSAI ad insertion via `inputstream.adaptive` on a Fire TV Stick (MediaTek), where every Period boundary forces a codec reinitialization that can race the still-releasing prior instance. Related: #29051 and #29057.

## How this has been tested

- Tested by @thexai on NVIDIA Shield with no issues found.
- Kodi CI completed successfully for Android ARM, ARM64, and x86. The overall multi-platform job was aborted after its 200-minute timeout while waiting for TVOS; all 16 completed sub-builds succeeded.
- The final change is a two-line reorder and passes `git diff --check`.

## Types of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md) document
- [x] My code follows the Code Guidelines of this project
- [ ] My change requires a change to the Wiki documentation
- [ ] I have updated the documentation accordingly
