### PR TITLE
GLES/GBM: push updated HDR MaxCLL/MaxFALL live

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.cpp
@@ -103,3 +103,15 @@ bool VideoPicture::IsSameParams(const VideoPicture& pic) const
          this->color_transfer == pic.color_transfer && this->hdrType == pic.hdrType &&
          CompareDisplayMetadata(pic);
 }
+
+bool VideoPicture::CompareLightMetadata(const VideoPicture& pic) const
+{
+  if (this->hasLightMetadata != pic.hasLightMetadata)
+    return false;
+
+  if (!pic.hasLightMetadata)
+    return true;
+
+  return this->lightMetadata.MaxCLL == pic.lightMetadata.MaxCLL &&
+         this->lightMetadata.MaxFALL == pic.lightMetadata.MaxFALL;
+}

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -42,6 +42,7 @@ public:
   VideoPicture& SetParams(const VideoPicture &pic);
   void Reset(); // reinitialize members, videoBuffer will be released if set!
   bool IsSameParams(const VideoPicture& pic) const;
+  bool CompareLightMetadata(const VideoPicture& pic) const;
 
   CVideoBuffer *videoBuffer = nullptr;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.h
@@ -66,6 +66,7 @@ public:
   virtual void SetBufferSize(int numBuffers) { }
   virtual void ReleaseBuffer(int idx) { }
   virtual bool NeedBuffer(int idx) { return false; }
+  virtual void UpdateLightMetadata(const VideoPicture& picture) {}
   virtual bool IsGuiLayer() { return true; }
   //! True when video never reaches the framebuffer: a DRM plane, an Android
   //! SurfaceView, the Amlogic video layer. Such a renderer must produce its

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.cpp
@@ -266,6 +266,23 @@ void CLinuxRendererGLES::AddVideoPicture(const VideoPicture &picture, int index)
   }
 }
 
+void CLinuxRendererGLES::UpdateLightMetadata(const VideoPicture& picture)
+{
+  for (auto& buf : m_buffers)
+  {
+    if (!buf.videoBuffer)
+      continue;
+
+    buf.hasLightMetadata = picture.hasLightMetadata && picture.lightMetadata.MaxCLL != 0;
+    buf.lightMetadata = picture.lightMetadata;
+  }
+
+  // In passthrough, the display consumes MaxCLL/MaxFALL via HDR_OUTPUT_METADATA,
+  // not the tone-map shader above - push it there too, without a reconfigure.
+  if (m_passthroughHDR)
+    CServiceBroker::GetWinSystem()->RefreshHDRLightMetadata(&picture);
+}
+
 void CLinuxRendererGLES::ReleaseBuffer(int idx)
 {
   CPictureBuffer &buf = m_buffers[idx];

--- a/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/LinuxRendererGLES.h
@@ -68,6 +68,7 @@ public:
   bool Configure(const VideoPicture& picture, float fps, unsigned int orientation) override;
   bool IsConfigured() override { return m_bConfigured; }
   void AddVideoPicture(const VideoPicture& picture, int index) override;
+  void UpdateLightMetadata(const VideoPicture& picture) override;
   void UnInit() override;
   bool Flush(bool saveBuffers) override;
   void SetBufferSize(int numBuffers) override { m_NumYUVBuffers = numBuffers; }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -99,6 +99,14 @@ bool CRenderManager::Configure(const VideoPicture& picture, float fps, unsigned 
     if (m_pRenderer != nullptr && m_picture.IsSameParams(picture) && m_orientation == orientation &&
         m_NumberBuffers == buffers && !m_pRenderer->ConfigChanged(picture))
     {
+      // check if HDR light metadata changes during playback
+      if (!m_picture.CompareLightMetadata(picture))
+      {
+        CLog::Log(LOGDEBUG, "CRenderManager::Configure - HDR light metadata has changed");
+        m_picture.SetParams(picture);
+        m_pRenderer->UpdateLightMetadata(picture);
+      }
+
       if (m_fps != fps)
       {
         CLog::Log(LOGDEBUG, "CRenderManager::Configure - framerate changed from {:4.2f} to {:4.2f}",

--- a/xbmc/windowing/WinSystem.h
+++ b/xbmc/windowing/WinSystem.h
@@ -244,6 +244,8 @@ public:
    *
    */
   virtual bool SetHDR(const VideoPicture* videoPicture) { return false; }
+  //! Update MaxCLL/MaxFALL on an already-active HDR output without a full SetHDR().
+  virtual bool RefreshHDRLightMetadata(const VideoPicture* videoPicture) { return false; }
   virtual bool IsHDRDisplay() { return false; }
   virtual HDR_STATUS ToggleHDR() { return HDR_STATUS::HDR_UNSUPPORTED; }
   virtual HDR_STATUS GetOSHDRStatus() { return HDR_STATUS::HDR_UNSUPPORTED; }

--- a/xbmc/windowing/gbm/WinSystemGbm.cpp
+++ b/xbmc/windowing/gbm/WinSystemGbm.cpp
@@ -474,6 +474,85 @@ void CWinSystemGbm::SetColorimetry(const VideoPicture* videoPicture)
   }
 }
 
+namespace
+{
+void BuildHDRMetadata(const VideoPicture& videoPicture,
+                      KODI::UTILS::Eotf eotf,
+                      hdr_output_metadata& hdr_metadata)
+{
+  hdr_metadata = {};
+  hdr_metadata.metadata_type = KODI::UTILS::HDMI_STATIC_METADATA_TYPE1;
+  hdr_metadata.hdmi_metadata_type1.eotf = static_cast<uint8_t>(eotf);
+  hdr_metadata.hdmi_metadata_type1.metadata_type = KODI::UTILS::HDMI_STATIC_METADATA_TYPE1;
+
+  if (!hdr_metadata.hdmi_metadata_type1.eotf)
+    return;
+
+  const AVMasteringDisplayMetadata* mdmd = KODI::UTILS::GetMasteringDisplayMetadata(videoPicture);
+  if (mdmd && mdmd->has_primaries)
+  {
+    // 0.00002 units; 0x0000 = 0, 0xC350 = 1.0000
+    for (int i = 0; i < 3; i++)
+    {
+      hdr_metadata.hdmi_metadata_type1.display_primaries[i].x =
+          std::round(av_q2d(mdmd->display_primaries[i][0]) * 50000.0);
+      hdr_metadata.hdmi_metadata_type1.display_primaries[i].y =
+          std::round(av_q2d(mdmd->display_primaries[i][1]) * 50000.0);
+
+      CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - display_primaries[{}].x: {}", __FUNCTION__,
+                i, hdr_metadata.hdmi_metadata_type1.display_primaries[i].x);
+      CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - display_primaries[{}].y: {}", __FUNCTION__,
+                i, hdr_metadata.hdmi_metadata_type1.display_primaries[i].y);
+    }
+    hdr_metadata.hdmi_metadata_type1.white_point.x =
+        std::round(av_q2d(mdmd->white_point[0]) * 50000.0);
+    hdr_metadata.hdmi_metadata_type1.white_point.y =
+        std::round(av_q2d(mdmd->white_point[1]) * 50000.0);
+
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - white_point.x: {}", __FUNCTION__,
+              hdr_metadata.hdmi_metadata_type1.white_point.x);
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - white_point.y: {}", __FUNCTION__,
+              hdr_metadata.hdmi_metadata_type1.white_point.y);
+  }
+  if (mdmd && mdmd->has_luminance)
+  {
+    // 1 cd/m2 units
+    hdr_metadata.hdmi_metadata_type1.max_display_mastering_luminance =
+        std::round(av_q2d(mdmd->max_luminance));
+
+    // 0.0001 cd/m2 units
+    hdr_metadata.hdmi_metadata_type1.min_display_mastering_luminance =
+        std::round(av_q2d(mdmd->min_luminance) * 10000.0);
+
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - max_display_mastering_luminance: {}",
+              __FUNCTION__, hdr_metadata.hdmi_metadata_type1.max_display_mastering_luminance);
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - min_display_mastering_luminance: {}",
+              __FUNCTION__, hdr_metadata.hdmi_metadata_type1.min_display_mastering_luminance);
+  }
+
+  const AVContentLightMetadata* clmd = KODI::UTILS::GetContentLightMetadata(videoPicture);
+  if (clmd)
+  {
+    hdr_metadata.hdmi_metadata_type1.max_cll = clmd->MaxCLL;
+    hdr_metadata.hdmi_metadata_type1.max_fall = clmd->MaxFALL;
+
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - max_cll: {}", __FUNCTION__,
+              hdr_metadata.hdmi_metadata_type1.max_cll);
+    CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - max_fall: {}", __FUNCTION__,
+              hdr_metadata.hdmi_metadata_type1.max_fall);
+  }
+}
+} // namespace
+
+CDRMPropertyBlob& CWinSystemGbm::PushHDRBlob(int fd, const void* data, std::size_t size)
+{
+  m_hdrBlobs.emplace_back(fd, data, size);
+  while (m_hdrBlobs.size() > 2)
+    m_hdrBlobs.pop_front();
+
+  return m_hdrBlobs.back();
+}
+
 bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
 {
   auto settingsComponent = CServiceBroker::GetSettingsComponent();
@@ -502,8 +581,6 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
       CLog::LogF(LOGDEBUG, "clearing HDR_OUTPUT_METADATA");
       drm->AddProperty(connector, "HDR_OUTPUT_METADATA", 0);
       drm->SetActive(true);
-
-      m_hdrBlob.Reset();
     }
 
     m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
@@ -524,82 +601,57 @@ bool CWinSystemGbm::SetHDR(const VideoPicture* videoPicture)
   if (connector->SupportsProperty("HDR_OUTPUT_METADATA") && m_info &&
       m_info->SupportsHDRStaticMetadataType1() && m_info->SupportsEOTF(eotf))
   {
-    hdr_output_metadata hdr_metadata = {};
+    hdr_output_metadata hdr_metadata;
+    BuildHDRMetadata(*videoPicture, eotf, hdr_metadata);
 
-    hdr_metadata.metadata_type = KODI::UTILS::HDMI_STATIC_METADATA_TYPE1;
-    hdr_metadata.hdmi_metadata_type1.eotf = static_cast<uint8_t>(eotf);
-    hdr_metadata.hdmi_metadata_type1.metadata_type = KODI::UTILS::HDMI_STATIC_METADATA_TYPE1;
-
-    m_hdrBlob.Reset();
-
+    std::uint32_t blobId = 0;
     if (hdr_metadata.hdmi_metadata_type1.eotf)
-    {
-      const AVMasteringDisplayMetadata* mdmd =
-          KODI::UTILS::GetMasteringDisplayMetadata(*videoPicture);
-      if (mdmd && mdmd->has_primaries)
-      {
-        // Convert to unsigned 16-bit values in units of 0.00002,
-        // where 0x0000 represents zero and 0xC350 represents 1.0000
-        for (int i = 0; i < 3; i++)
-        {
-          hdr_metadata.hdmi_metadata_type1.display_primaries[i].x =
-              std::round(av_q2d(mdmd->display_primaries[i][0]) * 50000.0);
-          hdr_metadata.hdmi_metadata_type1.display_primaries[i].y =
-              std::round(av_q2d(mdmd->display_primaries[i][1]) * 50000.0);
+      blobId = PushHDRBlob(drm->GetFileDescriptor(), &hdr_metadata, sizeof(hdr_metadata)).Get();
 
-          CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - display_primaries[{}].x: {}",
-                    __FUNCTION__, i, hdr_metadata.hdmi_metadata_type1.display_primaries[i].x);
-          CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - display_primaries[{}].y: {}",
-                    __FUNCTION__, i, hdr_metadata.hdmi_metadata_type1.display_primaries[i].y);
-        }
-        hdr_metadata.hdmi_metadata_type1.white_point.x =
-            std::round(av_q2d(mdmd->white_point[0]) * 50000.0);
-        hdr_metadata.hdmi_metadata_type1.white_point.y =
-            std::round(av_q2d(mdmd->white_point[1]) * 50000.0);
-
-        CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - white_point.x: {}", __FUNCTION__,
-                  hdr_metadata.hdmi_metadata_type1.white_point.x);
-        CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - white_point.y: {}", __FUNCTION__,
-                  hdr_metadata.hdmi_metadata_type1.white_point.y);
-      }
-      if (mdmd && mdmd->has_luminance)
-      {
-        // Convert to unsigned 16-bit value in units of 1 cd/m2,
-        // where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2
-        hdr_metadata.hdmi_metadata_type1.max_display_mastering_luminance =
-            std::round(av_q2d(mdmd->max_luminance));
-
-        // Convert to unsigned 16-bit value in units of 0.0001 cd/m2,
-        // where 0x0001 represents 0.0001 cd/m2 and 0xFFFF represents 6.5535 cd/m2
-        hdr_metadata.hdmi_metadata_type1.min_display_mastering_luminance =
-            std::round(av_q2d(mdmd->min_luminance) * 10000.0);
-
-        CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - max_display_mastering_luminance: {}",
-                  __FUNCTION__, hdr_metadata.hdmi_metadata_type1.max_display_mastering_luminance);
-        CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - min_display_mastering_luminance: {}",
-                  __FUNCTION__, hdr_metadata.hdmi_metadata_type1.min_display_mastering_luminance);
-      }
-
-      const AVContentLightMetadata* clmd = KODI::UTILS::GetContentLightMetadata(*videoPicture);
-      if (clmd)
-      {
-        hdr_metadata.hdmi_metadata_type1.max_cll = clmd->MaxCLL;
-        hdr_metadata.hdmi_metadata_type1.max_fall = clmd->MaxFALL;
-
-        CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - max_cll: {}", __FUNCTION__,
-                  hdr_metadata.hdmi_metadata_type1.max_cll);
-        CLog::Log(LOGDEBUG, LOGVIDEO, "CWinSystemGbm::{} - max_fall: {}", __FUNCTION__,
-                  hdr_metadata.hdmi_metadata_type1.max_fall);
-      }
-
-      m_hdrBlob = CDRMPropertyBlob(drm->GetFileDescriptor(), &hdr_metadata, sizeof(hdr_metadata));
-    }
-
-    drm->AddProperty(connector, "HDR_OUTPUT_METADATA", m_hdrBlob.Get());
+    drm->AddProperty(connector, "HDR_OUTPUT_METADATA", blobId);
     drm->SetActive(true);
   }
 
-  return m_hdrBlob.IsValid();
+  return !m_hdrBlobs.empty() && m_hdrBlobs.back().IsValid();
+}
+
+bool CWinSystemGbm::RefreshHDRLightMetadata(const VideoPicture* videoPicture)
+{
+  if (!videoPicture || m_eotf == KODI::UTILS::Eotf::TRADITIONAL_SDR)
+    return false;
+
+  if (videoPicture->color_transfer != AVCOL_TRC_SMPTE2084 &&
+      videoPicture->color_transfer != AVCOL_TRC_ARIB_STD_B67)
+    return false;
+
+  auto drm = std::dynamic_pointer_cast<CDRMAtomic>(m_DRM);
+  if (!drm)
+    return false;
+
+  auto connector = drm->GetConnector();
+  if (!connector || !connector->SupportsProperty("HDR_OUTPUT_METADATA"))
+    return false;
+
+  if (!m_info || !m_info->SupportsHDRStaticMetadataType1() || !m_info->SupportsEOTF(m_eotf))
+    return false;
+
+  hdr_output_metadata hdr_metadata;
+  BuildHDRMetadata(*videoPicture, m_eotf, hdr_metadata);
+  if (!hdr_metadata.hdmi_metadata_type1.eotf)
+    return false;
+
+  CDRMPropertyBlob& blob =
+      PushHDRBlob(drm->GetFileDescriptor(), &hdr_metadata, sizeof(hdr_metadata));
+  if (!blob.IsValid())
+    return false;
+
+  // No SetActive() - rides the next ordinary FlipPage() commit, no forced modeset.
+  drm->AddProperty(connector, "HDR_OUTPUT_METADATA", blob.Get());
+
+  CLog::LogF(LOGDEBUG, "refreshed HDR light metadata (max_cll: {}, max_fall: {})",
+             hdr_metadata.hdmi_metadata_type1.max_cll, hdr_metadata.hdmi_metadata_type1.max_fall);
+
+  return true;
 }
 
 bool CWinSystemGbm::IsHDRDisplay()

--- a/xbmc/windowing/gbm/WinSystemGbm.h
+++ b/xbmc/windowing/gbm/WinSystemGbm.h
@@ -18,6 +18,7 @@
 
 #include "platform/linux/input/LibInputHandler.h"
 
+#include <deque>
 #include <utility>
 
 #include <gbm.h>
@@ -67,6 +68,7 @@ public:
   KODI::UTILS::Colorimetry GetColorimetry() const override { return m_colorimetry; }
   KODI::UTILS::Eotf GetEotf() const override { return m_eotf; }
   bool SetHDR(const VideoPicture* videoPicture) override;
+  bool RefreshHDRLightMetadata(const VideoPicture* videoPicture) override;
   bool IsHDRDisplay() override;
   CHDRCapabilities GetDisplayHDRCapabilities() const override;
 
@@ -99,7 +101,9 @@ protected:
   std::unique_ptr<CLibInputHandler> m_libinput;
 
 private:
-  CDRMPropertyBlob m_hdrBlob;
+  CDRMPropertyBlob& PushHDRBlob(int fd, const void* data, std::size_t size);
+
+  std::deque<CDRMPropertyBlob> m_hdrBlobs;
   KODI::UTILS::Eotf m_eotf = KODI::UTILS::Eotf::TRADITIONAL_SDR;
   KODI::UTILS::Colorimetry m_colorimetry = KODI::UTILS::Colorimetry::DEFAULT;
 

--- a/xbmc/windowing/gbm/drm/DRMAtomic.cpp
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.cpp
@@ -18,6 +18,7 @@
 
 #include <chrono>
 #include <errno.h>
+#include <mutex>
 #include <string.h>
 #include <thread>
 
@@ -30,6 +31,8 @@ using namespace KODI::WINDOWING::GBM;
 
 void CDRMAtomic::DrmAtomicCommit(int fb_id, int flags, bool rendered, bool videoLayer)
 {
+  std::unique_lock lock(m_reqSection);
+
   // Declared at function scope so the blob outlives drmModeAtomicCommit.
   // DRM requires the blob to remain alive for the duration of the commit;
   // destroying it before the commit returns leaves the atomic request
@@ -312,6 +315,8 @@ bool CDRMAtomic::AddProperty(CDRMObject* object, const char* name, uint64_t valu
 {
   if (!object)
     return false;
+
+  std::unique_lock lock(m_reqSection);
   return m_req->AddProperty(object, name, value);
 }
 

--- a/xbmc/windowing/gbm/drm/DRMAtomic.h
+++ b/xbmc/windowing/gbm/drm/DRMAtomic.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "DRMUtils.h"
+#include "threads/CriticalSection.h"
 #include "utils/log.h"
 
 #include <cstdint>
@@ -45,6 +46,8 @@ private:
 
   bool m_need_modeset{true};
   bool m_active = true;
+
+  CCriticalSection m_reqSection;
 
   class CDRMAtomicRequest
   {


### PR DESCRIPTION
### Background
#26731 fixed a real bug: some sources (e.g. seamless-branching Blu-ray) change MaxCLL/MaxFALL mid-stream despite it nominally being static HDR10 metadata, and the old `IsSameParams()` treated that like any other config change, forcing a full video reconfigure causing a glitch during metadata update.

> if we need to update light metadata on the display without triggering
> a complete video reconfigure (which causes a black screen), [it's]
> possible [to] use [the] same or similar Windows solution on Linux
> code path (out of scope of this PR)

This PR is that follow-up: it brings the Windows-style "push the new value straight to the display" behavior to the GBM/DRM Atomic path, while preserving #26731's guarantee — a light-metadata-only change never forces a reconfigure, on any platform, whether or not the active renderer can push a live update.

### What changed
- `VideoPicture` gains `CompareLightMetadata()`, compared independently of  `IsSameParams()` — which is otherwise untouched, so the reconfigure-skip decision in `Configure()` never depends on light metadata, on any
  renderer. No regression risk against #26731's fix.
- `CRenderManager::Configure()`: on the existing "nothing else changed" fast path, separately checks `CompareLightMetadata()`. If it changed, it updates `m_picture` and calls the renderer's `UpdateLightMetadata()` —
  without ever falling through to a full reconfigure, regardless of what the renderer does with it.
- `CBaseRenderer::UpdateLightMetadata()`: new no-op virtual. Every renderer/platform that doesn't override it keeps building and behaving exactly as before.
- `CLinuxRendererGLES::UpdateLightMetadata()` does two things:
  - Sweeps every populated buffer in the ring (not just the one
    `AddVideoPicture()` happens to be filling) and recomputes
    `hasLightMetadata` unconditionally — including clearing it to `false` —
    closing the latch gap. `CRendererVAAPIGLES` inherits this fix
    automatically since it doesn't override buffer handling.
  - When `m_passthroughHDR` is active, calls
    `CServiceBroker::GetWinSystem()->RefreshHDRLightMetadata(&picture)` to
    push the new value to the display.
- `CWinSystem::RefreshHDRLightMetadata()` (new, default `false`) and its GBM/DRM Atomic implementation: rebuilds the same `hdr_output_metadata` blob `SetHDR()` uses (factored into a shared `BuildHDRMetadata()` helper)
  and queues it on the connector — deliberately **without** calling `SetActive()`, so it rides the next ordinary page flip instead of forcing a modeset. This is the detail that actually avoids the black screen; an earlier version of this fix mistakenly called `SetHDR()` again for the passthrough push, which — since `SetHDR()` always ends in
  `drm->SetActive(true)`, and `CDRMAtomic::SetActive()` unconditionally sets `m_need_modeset = true` — reintroduced a forced modeset on every mid-stream change. Confirmed and fixed before landing here.
- Windows: no changes. `CRendererBase` already re-pushes HDR metadata every frame independent of Configure()`, so there's nothing extra to do.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
