### PR TITLE
[Video] Translate 'dca' audio codec to 'dts' when importing from an nfo.

### DIFF
--- a/addons/skin.estuary/xml/Includes_Maps.xml
+++ b/addons/skin.estuary/xml/Includes_Maps.xml
@@ -17,7 +17,6 @@
 		<entry key="avc">AVC</entry>
 		<entry key="cdda">CDDA</entry>
 		<entry key="dolbydigital">Dolby Digital</entry>
-		<entry key="dca">DTS</entry>
 		<entry key="dts">DTS</entry>
 		<entry key="dtshd_hra">DTS-HD HRA</entry>
 		<entry key="dtshd_ma">DTS-HD MA</entry>

--- a/xbmc/utils/StreamUtils.cpp
+++ b/xbmc/utils/StreamUtils.cpp
@@ -117,6 +117,16 @@ std::string StreamUtils::GetCodecName(int codecId, int profile)
   return codecName;
 }
 
+std::string StreamUtils::NormalizeAudioCodecName(const std::string& codec)
+{
+  // 'dca' (name of ffmpeg's DTS decoder) was previously used in error for 'dts'
+  // Corrected in database schema v145
+  if (codec == "dca")
+    return "dts";
+
+  return codec;
+}
+
 std::string StreamUtils::GetDefaultLayout(unsigned int channels)
 {
   static constexpr std::array layouts{

--- a/xbmc/utils/StreamUtils.h
+++ b/xbmc/utils/StreamUtils.h
@@ -41,6 +41,14 @@ public:
   static std::string GetCodecName(int codecId, int profile);
 
   /*!
+   * \brief Normalise an externally supplied (eg. NFO) audio codec name to the name Kodi uses
+   *
+   * \param codec The audio codec name, lowercased
+   * \return The equivalent Kodi codec name, or the codec name unchanged if nothing maps
+   */
+  static std::string NormalizeAudioCodecName(const std::string& codec);
+
+  /*!
    * \brief Return a default channel layout in x.y.z form for a channel count.
    * \param[in] channels the count of channels
    * \return the default layout

--- a/xbmc/utils/test/TestStreamUtils.cpp
+++ b/xbmc/utils/test/TestStreamUtils.cpp
@@ -25,3 +25,11 @@ TEST(TestStreamUtils, General)
   EXPECT_EQ(10, StreamUtils::GetCodecPriority("dtshd_ma_x_imax"));
   EXPECT_EQ(11, StreamUtils::GetCodecPriority("truehd_atmos"));
 }
+
+TEST(TestStreamUtils, NormalizeAudioCodecName)
+{
+  EXPECT_EQ("dts", StreamUtils::NormalizeAudioCodecName("dca"));
+  EXPECT_EQ("dts", StreamUtils::NormalizeAudioCodecName("dts"));
+  EXPECT_EQ("ac3", StreamUtils::NormalizeAudioCodecName("ac3"));
+  EXPECT_EQ("", StreamUtils::NormalizeAudioCodecName(""));
+}

--- a/xbmc/video/VideoInfoTag.cpp
+++ b/xbmc/video/VideoInfoTag.cpp
@@ -16,6 +16,7 @@
 #include "settings/SettingsComponent.h"
 #include "utils/Archive.h"
 #include "utils/LangCodeExpander.h"
+#include "utils/StreamUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
@@ -1505,6 +1506,7 @@ void CVideoInfoTag::ParseNative(const TiXmlElement* movie, bool prioritise)
         XMLUtils::GetInt(nodeDetail, "channels", p->m_iChannels);
         StringUtils::ToLower(p->m_strCodec);
         StringUtils::ToLower(p->m_strLanguage);
+        p->m_strCodec = StreamUtils::NormalizeAudioCodecName(p->m_strCodec);
         m_streamDetails.AddStream(p);
       }
       nodeDetail = nullptr;


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Translate `dca` to `dts` when importing from nfo.

Also removes an orphaned `dca` entry from Estuary.

The video database was upgraded with schema v145.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Issue highlighted in https://github.com/xbmc/xbmc/pull/28140#issuecomment-5384443971 with tinyMediaManager.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
