### PR TITLE
[cmake][webos] Fix libdvdread/libdvdnav build against glibc 2.12

### DIFF
--- a/cmake/modules/FindLibDvdNav.cmake
+++ b/cmake/modules/FindLibDvdNav.cmake
@@ -34,6 +34,14 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
       set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_libType static)
     endif()
 
+    if("webos" IN_LIST CORE_PLATFORM_NAME_LC)
+      # webos sysroot is glibc 2.12, which predates _DEFAULT_SOURCE (glibc 2.19). The
+      # libdvd* libraries build with -std=c17, so __STRICT_ANSI__ suppresses the
+      # _BSD_SOURCE/_SVID_SOURCE defaults and strdup/realpath/strcasecmp are never
+      # declared. Define _BSD_SOURCE explicitly to restore them.
+      string(APPEND ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_C_FLAGS " -D_BSD_SOURCE")
+    endif()
+
     generate_patchcommand("${patches}")
     unset(patches)
 

--- a/cmake/modules/FindLibDvdRead.cmake
+++ b/cmake/modules/FindLibDvdRead.cmake
@@ -46,7 +46,12 @@ if(NOT TARGET LIBRARY::${CMAKE_FIND_PACKAGE_NAME})
 
     if("webos" IN_LIST CORE_PLATFORM_NAME_LC)
       # PATH_MAX not defined in limits.h. Just match windows size libdvdcss uses.
-      set(${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_C_FLAGS "-DPATH_MAX=2048")
+      # webos sysroot is glibc 2.12, which predates _DEFAULT_SOURCE (glibc 2.19). The
+      # libdvd* libraries build with -std=c17, so __STRICT_ANSI__ suppresses the
+      # _BSD_SOURCE/_SVID_SOURCE defaults and strdup/realpath/strcasecmp are never
+      # declared. Define _BSD_SOURCE explicitly to restore them.
+      # Append, as -D_XBMC set above selects the kodi code paths in dvd_reader.c
+      string(APPEND ${${CMAKE_FIND_PACKAGE_NAME}_MODULE}_C_FLAGS " -DPATH_MAX=2048 -D_BSD_SOURCE")
     endif()
 
     if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.26)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Follow up to the equivalent libdvdcss fix. All three libdvd* libraries build with meson using `c_std=c17`, and the webOS SDK sysroot ships glibc 2.12. -std=c17 (rather than gnu17) defines `__STRICT_ANSI__`, so glibc 2.12's `features.h` skips its `_BSD_SOURCE/_SVID_SOURCE` defaults, and libdvd*'s own `-D_DEFAULT_SOURCE` is a no-op there because that macro was only added in glibc 2.19. The POSIX/BSD declarations gated behind `__USE_BSD/__USE_SVID` therefore never appear and GCC 15 fails the build:

```
  libdvdread: strdup, realpath, strcasecmp, strncasecmp
  libdvdnav:  strdup
```

Define `_BSD_SOURCE` explicitly for webOS in both modules to restore them.

FindLibDvdRead additionally used set() rather than string(APPEND) in the webOS branch, clobbering the `-D_XBMC` set a few lines above it. That is not cosmetic: `dvd_reader.c:584` guards on

```
  #if !defined(WIN32) && !defined(_XBMC)
```

and both `01-all-disableopendir.patch` and `02-all-disablesymlink.patch` key off `_XBMC` as well, so webOS was silently compiling the non-kodi `fchdir/getcwd` code path. It is also why realpath appeared among the errors at all. Switch it to append so `-D_XBMC` survives.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix building webOS with gcc 15

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified by building the full webOS target to completion.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
