### PR TITLE
ImageDecoder: add-on API correctness fixes

### DIFF
--- a/xbmc/addons/ImageDecoder.cpp
+++ b/xbmc/addons/ImageDecoder.cpp
@@ -21,15 +21,14 @@ struct AddonFormat
 {
   unsigned int kodiFormat;
   ADDON_IMG_FMT addonFormat;
-  size_t bytesPerPixel;
   bool hasAlpha;
 };
 
 constexpr std::array<AddonFormat, 4> KodiToAddonFormat = {
-    {{XB_FMT_A8R8G8B8, ADDON_IMG_FMT_A8R8G8B8, sizeof(uint8_t) * 4, true},
-     {XB_FMT_A8, ADDON_IMG_FMT_A8, sizeof(uint8_t) * 1, true},
-     {XB_FMT_RGBA8, ADDON_IMG_FMT_RGBA8, sizeof(uint8_t) * 4, true},
-     {XB_FMT_RGB8, ADDON_IMG_FMT_RGB8, sizeof(uint8_t) * 3, false}}};
+    {{XB_FMT_A8R8G8B8, ADDON_IMG_FMT_A8R8G8B8, true},
+     {XB_FMT_A8, ADDON_IMG_FMT_A8, true},
+     {XB_FMT_RGBA8, ADDON_IMG_FMT_RGBA8, true},
+     {XB_FMT_RGB8, ADDON_IMG_FMT_RGB8, false}}};
 
 } /* namespace */
 
@@ -208,7 +207,7 @@ bool CImageDecoder::Decode(unsigned char* const pixels,
     return false;
 
   const ADDON_IMG_FMT addonFmt = it->addonFormat;
-  const size_t size = width * height * it->bytesPerPixel;
+  const size_t size = static_cast<size_t>(pitch) * height;
   const bool result =
       m_ifc.imagedecoder->toAddon->decode(m_ifc.hdl, pixels, size, width, height, pitch, addonFmt);
   m_width = width;

--- a/xbmc/addons/ImageDecoder.cpp
+++ b/xbmc/addons/ImageDecoder.cpp
@@ -17,11 +17,19 @@ using namespace KODI::ADDONS;
 namespace
 {
 
-constexpr std::array<std::tuple<unsigned int, ADDON_IMG_FMT, size_t>, 4> KodiToAddonFormat = {
-    {{XB_FMT_A8R8G8B8, ADDON_IMG_FMT_A8R8G8B8, sizeof(uint8_t) * 4},
-     {XB_FMT_A8, ADDON_IMG_FMT_A8, sizeof(uint8_t) * 1},
-     {XB_FMT_RGBA8, ADDON_IMG_FMT_RGBA8, sizeof(uint8_t) * 4},
-     {XB_FMT_RGB8, ADDON_IMG_FMT_RGB8, sizeof(uint8_t) * 3}}};
+struct AddonFormat
+{
+  unsigned int kodiFormat;
+  ADDON_IMG_FMT addonFormat;
+  size_t bytesPerPixel;
+  bool hasAlpha;
+};
+
+constexpr std::array<AddonFormat, 4> KodiToAddonFormat = {
+    {{XB_FMT_A8R8G8B8, ADDON_IMG_FMT_A8R8G8B8, sizeof(uint8_t) * 4, true},
+     {XB_FMT_A8, ADDON_IMG_FMT_A8, sizeof(uint8_t) * 1, true},
+     {XB_FMT_RGBA8, ADDON_IMG_FMT_RGBA8, sizeof(uint8_t) * 4, true},
+     {XB_FMT_RGB8, ADDON_IMG_FMT_RGB8, sizeof(uint8_t) * 3, false}}};
 
 } /* namespace */
 
@@ -194,17 +202,20 @@ bool CImageDecoder::Decode(unsigned char* const pixels,
   if (!m_created || !m_ifc.imagedecoder->toAddon->decode)
     return false;
 
-  const auto it = std::ranges::find_if(KodiToAddonFormat,
-                                       [format](auto& p) { return std::get<0>(p) == format; });
+  const auto it =
+      std::ranges::find_if(KodiToAddonFormat, [format](auto& f) { return f.kodiFormat == format; });
   if (it == KodiToAddonFormat.end())
     return false;
 
-  const ADDON_IMG_FMT addonFmt = std::get<1>(*it);
-  const size_t size = width * height * std::get<2>(*it);
+  const ADDON_IMG_FMT addonFmt = it->addonFormat;
+  const size_t size = width * height * it->bytesPerPixel;
   const bool result =
       m_ifc.imagedecoder->toAddon->decode(m_ifc.hdl, pixels, size, width, height, pitch, addonFmt);
   m_width = width;
   m_height = height;
+
+  if (result)
+    m_hasAlpha = it->hasAlpha;
 
   return result;
 }

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/ImageDecoder.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/ImageDecoder.h
@@ -466,6 +466,7 @@ private:
 ///                            unsigned int& height) override;
 ///
 ///   bool Decode(uint8_t* pixels,
+///               size_t pixelBufferSize,
 ///               unsigned int width,
 ///               unsigned int height,
 ///               unsigned int pitch,
@@ -491,6 +492,7 @@ private:
 /// }
 ///
 /// bool CMyImageDecoder::Decode(uint8_t* pixels,
+///                              size_t pixelBufferSize,
 ///                              unsigned int width,
 ///                              unsigned int height,
 ///                              unsigned int pitch,
@@ -619,20 +621,22 @@ public:
   /// @brief Decode previously loaded image.
   ///
   /// @param[out] pixels Output buffer
+  /// @param[in] pixelBufferSize Size of the output buffer in bytes
   /// @param[in] width Width of output image
   /// @param[in] height Height of output image
   /// @param[in] pitch Byte offset between the start of one output row and the next
   /// @param[in] format Format of output image
   /// @return true if successful done, false on error
   ///
-  /// @note The buffer holds `height` rows of `pitch` bytes. Write no more than
-  /// `pitch` bytes per row, and no more than `height` rows. `pitch` already
-  /// accounts for `format`, so an add-on that writes a fixed number of bytes per
-  /// pixel regardless of `format` will overrun the buffer for any format
-  /// narrower than the one it assumes. Return false for a `format` the add-on
-  /// does not implement rather than falling through to a default.
+  /// @note The buffer holds `height` rows of `pitch` bytes, `pixelBufferSize` in
+  /// total. `pitch` already accounts for `format`, so an add-on that writes a
+  /// fixed number of bytes per pixel regardless of `format` will overrun the
+  /// buffer for any format narrower than the one it assumes. Return false for
+  /// a `format` the add-on does not implement rather than falling through to a
+  /// default.
   ///
   virtual bool Decode(uint8_t* pixels,
+                      size_t pixelBufferSize,
                       unsigned int width,
                       unsigned int height,
                       unsigned int pitch,
@@ -711,13 +715,14 @@ private:
 
   inline static bool ADDON_decode(const KODI_ADDON_IMAGEDECODER_HDL hdl,
                                   uint8_t* pixels,
-                                  size_t pixels_size,
+                                  size_t pixel_buffer_size,
                                   unsigned int width,
                                   unsigned int height,
                                   unsigned int pitch,
                                   enum ADDON_IMG_FMT format)
   {
-    return static_cast<CInstanceImageDecoder*>(hdl)->Decode(pixels, width, height, pitch, format);
+    return static_cast<CInstanceImageDecoder*>(hdl)->Decode(pixels, pixel_buffer_size, width,
+                                                            height, pitch, format);
   }
 };
 

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/imagedecoder.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/imagedecoder.h
@@ -418,7 +418,7 @@ extern "C"
   typedef bool(ATTR_APIENTRYP PFN_KODI_ADDON_IMAGEDECODER_DECODE_V1)(
       const KODI_ADDON_IMAGEDECODER_HDL hdl,
       uint8_t* pixels,
-      size_t pixels_size,
+      size_t pixel_buffer_size,
       unsigned int width,
       unsigned int height,
       unsigned int pitch,

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -102,8 +102,8 @@
 #define ADDON_INSTANCE_VERSION_GAME_XML_ID            "kodi.binary.instance.game"
 #define ADDON_INSTANCE_VERSION_GAME_DEPENDS           "addon-instance/Game.h"
 
-#define ADDON_INSTANCE_VERSION_IMAGEDECODER           "3.0.1"
-#define ADDON_INSTANCE_VERSION_IMAGEDECODER_MIN       "3.0.0"
+#define ADDON_INSTANCE_VERSION_IMAGEDECODER           "3.1.0"
+#define ADDON_INSTANCE_VERSION_IMAGEDECODER_MIN       "3.1.0"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_XML_ID    "kodi.binary.instance.imagedecoder"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER_DEPENDS   "c-api/addon-instance/imagedecoder.h" \
                                                       "addon-instance/ImageDecoder.h"


### PR DESCRIPTION
## Description

Rebased on current master now that #29067 is merged, and the history is cleaned up as asked:
the branch is now **two commits**, not four.

1. **`hasAlpha` from the decoded pixel format** — this supersedes #29024. The version you didn't
   like (a two-format condition inside `Decode()`) is gone from the history entirely; the commit
   introduces the fix in its final shape, as a column of the existing `KodiToAddonFormat` table,
   so a format cannot be added without answering the alpha question. Each commit is now correct
   on its own, not merely compilable.
2. **`ImageDecoder API v3.1.0`: pass the output buffer size to the add-on** — the C API's
   `decode()` carries `pixels_size` precisely so an add-on can bounds-check its writes, but the
   dev-kit's C++ wrapper received it and dropped it, handing the add-on a raw pointer with no
   extent. It is now part of the C++ `Decode()` signature, forwarded as `pitch * height` — the
   extent `CTexture::LoadIImage()` actually allocates.

Version bumped to **3.1.0 with the minimum raised to 3.1.0**, per your comment. Stating the
consequence explicitly: raising the minimum stops every already-built `imagedecoder.*` add-on
from loading until it is rebuilt against the new dev-kit. You offered to handle the rebuild and
release, so this is deliberate rather than accidental.

Still deliberately **not** in here, pending two open answers — whether `KD_TEX_*` should be
published into the dev-kit or mirrored by a separate add-on-facing enum, and whether the consumer
side (`Texture.cpp:324`, which hard-codes `A8R8G8B8`) is in scope: `decode_v2` with a composed
format value, the `ImageFactory` mimetype fabrication fix (it can break add-ons that declare the
fabricated `image/svg` as a workaround), and capability negotiation.

## Motivation and context

See the audit in #29024. The `pixels_size` drop is the one with teeth: the sibling
`imagedecoder.*` add-ons contain write patterns that overrun a Kodi-sized buffer for narrower
formats, latent only because Kodi currently always requests `A8R8G8B8`.

## How has this been tested?

Full build and `kodi-test` (3904 tests, 306 suites, all passing) on Linux/x86_64. **Each commit was built on its own**, and the
documented dev-kit example was extracted verbatim from the header and compiled against the real
headers. Both commits are `clang-format` clean individually.

## What is the effect on users?

None at runtime today. Add-on developers get a bounds-checkable buffer and a format table that is
safe to extend. Existing binary add-ons must be rebuilt because of the raised minimum version.

## Types of change

- [x] **Improvement** (non-breaking change which improves existing functionality)
- [x] **Breaking change** (fix or feature that would cause existing functionality to change) — source-breaking at recompile, plus the raised minimum version

## Checklist:

- [x] My code follows the [Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md) of this project
- [x] My change requires a change to the documentation, and this PR contains it
