### PR TITLE
[filesystem][CurlFile] Don't log the contents of TLS records

### DIFF
--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -75,6 +75,15 @@ extern "C" int debug_callback(CURL_HANDLE *handle, curl_infotype info, char *out
   if (!CServiceBroker::GetLogging().CanLogComponent(LOGCURL))
     return 0;
 
+  // TLS records are binary, logging their contents as text yields hundreds of
+  // unreadable lines per handshake, so only note that they went by
+  if (info == CURLINFO_SSL_DATA_IN || info == CURLINFO_SSL_DATA_OUT)
+  {
+    const char* direction = info == CURLINFO_SSL_DATA_IN ? "IN" : "OUT";
+    CLog::Log(LOGDEBUG, "Curl::Debug - SSL_DATA_{}: {} bytes", direction, size);
+    return 0;
+  }
+
   std::string strLine;
   strLine.append(output, size);
   std::vector<std::string> vecLines;
@@ -87,8 +96,6 @@ extern "C" int debug_callback(CURL_HANDLE *handle, curl_infotype info, char *out
     case CURLINFO_TEXT         : infotype = "TEXT: "; break;
     case CURLINFO_HEADER_IN    : infotype = "HEADER_IN: "; break;
     case CURLINFO_HEADER_OUT   : infotype = "HEADER_OUT: "; break;
-    case CURLINFO_SSL_DATA_IN  : infotype = "SSL_DATA_IN: "; break;
-    case CURLINFO_SSL_DATA_OUT : infotype = "SSL_DATA_OUT: "; break;
     case CURLINFO_END          : infotype = "END: "; break;
     default                    : infotype = ""; break;
   }


### PR DESCRIPTION
With the `curl` log component on, `debug_callback` sends `CURLINFO_SSL_DATA_IN` and
`CURLINFO_SSL_DATA_OUT` through the text logger. Those are raw TLS records, so the
ciphertext gets tokenized on whatever CR/LF bytes it happens to contain and one
handshake turns into hundreds of unreadable lines. In a log I captured while
debugging a WebDAVS problem they were 739915 of 763276 lines, 97% of a 64 MB file,
which makes the useful lines hard to find and the log awkward to share.

Payload data (`CURLINFO_DATA_IN`/`OUT`) is already dropped a few lines above, the SSL
pair looks like it was simply missed. This keeps the events but logs the direction and
byte count instead of the contents, so TLS activity and timing stay visible:

```
Curl::Debug - SSL_DATA_OUT: 1553 bytes
Curl::Debug - SSL_DATA_IN: 4096 bytes
```

instead of

```
Curl::Debug - SSL_DATA_OUT: ^V^C^A^F^Q
Curl::Debug - SSL_DATA_OUT: ^A^@^F
Curl::Debug - SSL_DATA_OUT: ^C^C^[M-2_M-WM-HM-+xM-^RM-dM-^[^@M-}M-^TM-GpM-yM-/#M-ypM-\<M-IM-Sl^U^?CJM-^Jrm
```