### PR TITLE
VideoRenderers: fix EGL fence leak in CRendererVAAPIGLES::AfterRenderHook

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/HwDecRender/RendererVAAPIGLES.cpp
@@ -321,7 +321,10 @@ bool CRendererVAAPIGLES::UploadTexture(int index)
 void CRendererVAAPIGLES::AfterRenderHook(int index)
 {
   if (m_fences[index])
+  {
+    m_fences[index]->DestroyFence();
     m_fences[index]->CreateFence();
+  }
 }
 
 bool CRendererVAAPIGLES::NeedBuffer(int index)


### PR DESCRIPTION
Fixes #16277

`AfterRenderHook()` creates a new EGL fence via `CreateFence()` on every
render of a buffer, but `CreateFence()` unconditionally overwrites the
stored handle without releasing any fence still pending from a previous
render. The matching `DestroyFence()` only runs in `ReleaseBuffer()`,
which fires when a buffer slot is recycled for a newly decoded frame —
not when the same already-rendered buffer is redrawn again (e.g.
GUI/OSD redraws while paused). Each such redraw leaks one EGL sync
object -> one DRM syncobj -> one pinned `i915_request`, at the display
refresh rate rather than the stream's frame rate.

This brings `AfterRenderHook()` in line with the sibling renderers,
which already destroy the previous fence before creating a new one:
`RendererVAAPIGL::AfterRenderHook()` (raw GL `glDeleteSync`/`glFenceSync`)
and `RendererDRMPRIMEGLES::AfterRenderHook()` (`DestroyFence`/`CreateFence`).

### Testing
- Isolated EGL fence reproducer matching the real calling pattern
  (unflushed GPU work pending at fence-creation time, same Mesa build
  Kodi links): sustained `i915_request` growth with create-only, zero
  growth with destroy-then-create.
- Rebuilt `kodi-wayland` from source with this change against current
  master and ran it directly (not simulated): `i915_request` growth
  during a 90s pause of VAAPI H.264 playback dropped from ~59/s
  (unpatched) to ~1.4/s (patched), on Alder-Lake-N / Mesa 26.1.6 /
  kernel 6.12.
- Confirmed independently working by @smp79 (original reporter) on
  their own setup — see #16277.