### PR TITLE
[Android] Kodi deep link activity for Android

### DIFF
--- a/cmake/scripts/android/Install.cmake
+++ b/cmake/scripts/android/Install.cmake
@@ -50,6 +50,7 @@ set(package_files strings.xml
                   src/XBMCFile.java
                   src/XBMCTextureCache.java
                   src/XBMCURIUtils.java
+                  src/KodiDeepLinkActivity.java
                   src/channels/SyncChannelJobService.java
                   src/channels/SyncProgramsJobService.java
                   src/channels/model/XBMCDatabase.java

--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -157,6 +157,18 @@
                 android:resource="@xml/searchable" />
         </activity>
 
+        <activity android:name=".KodiDeepLinkActivity"
+                  android:exported="true"
+                  android:theme="@android:style/Theme.NoDisplay"
+                  android:noHistory="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="kodi" />
+            </intent-filter>
+        </activity>
+
        <service
            android:name=".channels.SyncChannelJobService"
            android:exported="false"

--- a/tools/android/packaging/xbmc/src/KodiDeepLinkActivity.java.in
+++ b/tools/android/packaging/xbmc/src/KodiDeepLinkActivity.java.in
@@ -9,41 +9,13 @@ import android.util.Log;
 
 // KodiDeepLinkActivity
 //
-// Class to provide deep links for use with Google's Android TV Remote protocol v2, which is used by
-// clients like androidtvremote2, a Python library used by Home Assistant and others to launch
-// Android TV applications and do various other remote control things that otherwise would require
-// adb. The protocol is far superior to adb, because (a) it has far less latency, and (b) it
-// requires no setup by the user beyond entering a pairing code they see on the TV when using a
-// remote for the first time. This class lets an androidtvremote2 object named "remote" launch Kodi
-// with:
+// Class to provide deep links for Kodi as described here:
 //
-// remote.send_launch_app_command("kodi://") -or-
-// remote.send_launch_app_command("kodi://launch")
+// https://developer.android.com/training/app-links/create-deeplinks
 //
-// It should be possible to implement other "host" strings to provide deep linking to content, pages
-// in Kodi's UI, etc.
-//
-// Deep linking became necessary sometime in 2026, after Google removed the former trick that
-// consisted of adding the prefix "market://launch?id=" to strings that didn't appear to be URLs, so
-// that passing "org.xbmc.kodi" to send_launch_app_command would work. As documented on
-// androidtvremote2's github and discussed in the Home Assistant forums, this no longer works, and
-// the only alternative has been to use adb to launch Kodi.
-//
-// The class is necessary, because while adding a scheme "kodi" to AndroidManifest.xml can work to
-// launch Kodi, Kodi always tries to "play" the URL, even if it's empty like with "kodi://", and
-// it goes on to display a modal error box titled "Playback failed" with the message "One or more
-// items failed to play". Logfile errors also appear, including:
-//
-// CreateLoader - unsupported protocol(kodi) in kodi://?mimetype=application%2foctet-stream/
-// CVideoPlayer::OpenInputStream - error opening [kodi://]
-//
-// Nothing I tried or Gemini and Claude suggested worked to avoid these problems that seem to be
-// inherent to merely modifying the manifest, so with Claude's help, KodiDeepLinkActivity was born.
-// It runs Kodi or brings it to the foreground as necessary, and if Kodi was already the foreground
-// app, it has no effect other than to momentarily blank the screen if Kodi is playing video, the
-// same behavior as the old "market://" prefix, and the same as using adb to start
-// "org.xbmc.kodi/.Splash". This can be avoided by checking if Kodi is the current app and simply
-// not issuing the call if it is.
+// These are "custom deep links" as defined on that page and start with
+// the prefix "kodi://", with that exact string and "kodi://launch" serving
+// to start Kodi.
 
 public class KodiDeepLinkActivity extends Activity
 {
@@ -63,13 +35,10 @@ public class KodiDeepLinkActivity extends Activity
       return;
     }
 
-    // Other deep link actions could be handled below.
-
     switch (host)
     {
       case "launch":
       case "":
-        // Both "kodi://launch" and "kodi://" work.
         doLaunch();
         break;
       default:

--- a/tools/android/packaging/xbmc/src/KodiDeepLinkActivity.java.in
+++ b/tools/android/packaging/xbmc/src/KodiDeepLinkActivity.java.in
@@ -1,0 +1,89 @@
+package @APP_PACKAGE@;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Bundle;
+import android.util.Log;
+
+// KodiDeepLinkActivity
+//
+// Class to provide deep links for use with Google's Android TV Remote protocol v2, which is used by
+// clients like androidtvremote2, a Python library used by Home Assistant and others to launch
+// Android TV applications and do various other remote control things that otherwise would require
+// adb. The protocol is far superior to adb, because (a) it has far less latency, and (b) it
+// requires no setup by the user beyond entering a pairing code they see on the TV when using a
+// remote for the first time. This class lets an androidtvremote2 object named "remote" launch Kodi
+// with:
+//
+// remote.send_launch_app_command("kodi://") -or-
+// remote.send_launch_app_command("kodi://launch")
+//
+// It should be possible to implement other "host" strings to provide deep linking to content, pages
+// in Kodi's UI, etc.
+//
+// Deep linking became necessary sometime in 2026, after Google removed the former trick that
+// consisted of adding the prefix "market://launch?id=" to strings that didn't appear to be URLs, so
+// that passing "org.xbmc.kodi" to send_launch_app_command would work. As documented on
+// androidtvremote2's github and discussed in the Home Assistant forums, this no longer works, and
+// the only alternative has been to use adb to launch Kodi.
+//
+// The class is necessary, because while adding a scheme "kodi" to AndroidManifest.xml can work to
+// launch Kodi, Kodi always tries to "play" the URL, which causes it to display a modal error box
+// titled "Playback failed" with the message "One or more items failed to play". Logfile errors also
+// appear, including:
+//
+// CreateLoader - unsupported protocol(kodi) in kodi://?mimetype=application%2foctet-stream/
+// CVideoPlayer::OpenInputStream - error opening [kodi://]
+//
+// Nothing I tried or Gemini and Claude suggested worked to avoid these problems that seem to be
+// inherent to merely modifying the manifest, so with Claude's help, KodiDeepLinkActivity was born.
+
+public class KodiDeepLinkActivity extends Activity
+{
+  private static final String TAG = "@APP_NAME@";
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState)
+  {
+    super.onCreate(savedInstanceState);
+
+    Uri data = getIntent().getData();
+    String host = (data != null) ? data.getHost() : null;
+
+    if (host == null)
+    {
+      finish();
+      return;
+    }
+
+    // Other deep link actions could be handled below.
+
+    switch (host)
+    {
+      case "launch":
+      case "":
+        // Both "kodi://launch" and "kodi://" work.
+        doLaunch();
+        break;
+      default:
+        Log.e(TAG, "Deep link: Unknown action: " + host);
+        break;
+    }
+
+    finish();
+  }
+
+  private void doLaunch()
+  {
+    Log.i(TAG, "Deep link: launch");
+    PackageManager pm = getPackageManager();
+    Intent launch = pm.getLaunchIntentForPackage(getPackageName());
+    if (launch != null)
+    {
+      launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      startActivity(launch);
+    }
+  }
+}

--- a/tools/android/packaging/xbmc/src/KodiDeepLinkActivity.java.in
+++ b/tools/android/packaging/xbmc/src/KodiDeepLinkActivity.java.in
@@ -30,15 +30,20 @@ import android.util.Log;
 // the only alternative has been to use adb to launch Kodi.
 //
 // The class is necessary, because while adding a scheme "kodi" to AndroidManifest.xml can work to
-// launch Kodi, Kodi always tries to "play" the URL, which causes it to display a modal error box
-// titled "Playback failed" with the message "One or more items failed to play". Logfile errors also
-// appear, including:
+// launch Kodi, Kodi always tries to "play" the URL, even if it's empty like with "kodi://", and
+// it goes on to display a modal error box titled "Playback failed" with the message "One or more
+// items failed to play". Logfile errors also appear, including:
 //
 // CreateLoader - unsupported protocol(kodi) in kodi://?mimetype=application%2foctet-stream/
 // CVideoPlayer::OpenInputStream - error opening [kodi://]
 //
 // Nothing I tried or Gemini and Claude suggested worked to avoid these problems that seem to be
 // inherent to merely modifying the manifest, so with Claude's help, KodiDeepLinkActivity was born.
+// It runs Kodi or brings it to the foreground as necessary, and if Kodi was already the foreground
+// app, it has no effect other than to momentarily blank the screen if Kodi is playing video, the
+// same behavior as the old "market://" prefix, and the same as using adb to start
+// "org.xbmc.kodi/.Splash". This can be avoided by checking if Kodi is the current app and simply
+// not issuing the call if it is.
 
 public class KodiDeepLinkActivity extends Activity
 {


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

This PR adds a deep link capability to Kodi running on Android so that it can be launched programmatically with Google's Android TV Remote protocol v2 by the Python library androidtvremote2 and software that uses it such as Home Assistant. This takes the form of URL-like strings beginning with "kodi://", which itself serves to launch Kodi. The form "kodi://launch" is also accepted, and actions could likely be added to support playing content, opening pages in the UI, etc. This submission, however, is concerned only with launching Kodi, as that capability has recently been lost to the protocol due to changes Google has made.

The implementation takes the form of a small addition to AndroidManifest.xml that defines an activity for the android:scheme "kodi" and a new Java class, KodiDeepLinkActivity, delivered in file KodiDeepLinkActivity.java. This activity is peer to pre-existing ones like ".Splash", the main activity for starting Kodi, which unfortunately, I was unable to adapt, as it always tried to play the URL sent by the Remote protocol, causing Kodi to show a modal error box the user has to dismiss.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Python libraries like androidtvremote2 used to be able to launch Kodi given "org.xbmc.kodi" by prefixing it with "market://launch?id=". Google recently removed this method, and the only remaining way to launch Kodi programmatically is to use ADB. This is a problem because the remote protocol has essentially zero latency, while ADB is terrible, so remote apps want to use the remote protocol for that reason, and also because enabling ADB is a cumbersome process requiring the user to "become a developer", enable the inaptly named "USB debugging" in Developer Options, and authenticate on their TV. Moreover, it's even harder on CCwGTV post Dec 2024 and Sony Bravia TVs that have applied Sony's June 2026 update, because these updates require wireless pairing before enabling ADB for network use, which is a huge hassle for people using wired networking. Then there are the Onn streamers, which have a bug that disables USB network adapters if the device is rebooted with the aforementioned "USB debugging" enabled, meaning you have to disable it, reboot again, and re-enable it to get your network adapter back and continue to use ADB.

Recent discussions of the issue can be found below:

https://community.home-assistant.io/t/android-tv-remote-no-longer-launching-apps/1021224/9

https://github.com/tronikos/androidtvremote2/issues/46

In particular, it addresses the comment in the second thread from androidtvremote2 author, tronikos, "The change is on the Google side. I changed the demo to use deep links instead. Not for Kodi though since it doesn't have any deep links."

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested it on my Sony Bravia 8 TV and an Onn 4K streamer, both running Android 14, sending them commands from my software that uses Python library androidtvremote2. In all my testing, it behaved identically to the method that used to work with androidtvremote2 (Google Android TV Remote protocol v2) as well as the fallback, adb shell am start -n "org.xbmc.kodi/.Splash". I also tested with these ADB commands that invoke the deep links:

```
adb shell am start -W -a android.intent.action.VIEW -d "kodi://" org.xbmc.kodi
adb shell am start -W -a android.intent.action.VIEW -d "kodi://launch" org.xbmc.kodi
```

This is the same syntax for testing given in Google's documentation:

https://developer.android.com/training/app-links/create-deeplinks

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

It restores the ability to launch Kodi from Home assistant and other software that uses Google's Android TV Remote protocol v2, often by way of Python library androidtvremote2, so that they don't have to use the far more cumbersome ADB.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
