### PR TITLE
[Settings] Fix condition for enabling monitor selection

### DIFF
--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2869,10 +2869,10 @@
           </constraints>
           <dependencies>
             <dependency type="enable">
-              <or>
+              <and>
                 <condition on="property" name="SupportsScreenMove" />
                 <condition on="property" name="HasMultipleMonitors" />
-              </or>
+              </and>
             </dependency>
             <dependency type="update" setting="videoscreen.screenmode" />
           </dependencies>


### PR DESCRIPTION
## Description
The current condition wrongly uses "SupportsScreenMove OR HasMultipleMonitors" instead of AND which leads to the monitor selection being shown even if only a single monitor is connected.

SupportsScreenMove is currently true on all WinSystems, it's only defined in CWinSystemBase (returning true) and no WinSystem is overriding that. So the condition to enable the setting is basically a no-op.

Change the condition to AND to achieve the intended behaviour.

## Motivation and context
Showing the setting even if only a single monitor is confusing and users ask what's the difference between "Default" and "HDMI-A-1". See eg this LE forum post:
https://forum.libreelec.tv/thread/28426-nightly-builds/?postID=206968#post206968

## How has this been tested?
Running LibreELEC on RPi5 (GBM), with only a single monitor connected the setting is greyed out, with two monitors connected it's shown.

## What is the effect on users?
Less confusion on standard setups with only a single display connected

## Screenshots (if appropriate):

Single monitor connected:
<img width="1920" height="1200" alt="screenshot00013" src="https://github.com/user-attachments/assets/ef5ab80a-857f-44a8-9bc4-b5a0322cd88f" />

Two monitors connected:
<img width="1920" height="1200" alt="screenshot00014" src="https://github.com/user-attachments/assets/31ebfe8b-f160-421c-a35b-63f68dbb5539" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
