### PR TITLE
[Android][Windowing][GLES] Detect HDR colourspace from transfer characteristic, not display metadata

### DIFF
--- a/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
+++ b/xbmc/windowing/android/WinSystemAndroidGLESContext.cpp
@@ -232,22 +232,20 @@ bool CWinSystemAndroidGLESContext::SetHDR(const VideoPicture* videoPicture)
 #if EGL_EXT_gl_colorspace_bt2020_linear
   if (m_hasHDRConfig && m_hasEGL_BT2020_PQ_Colorspace_Extension && m_hasEGL_ST2086_Extension)
   {
-    HDRColorSpace = EGL_NONE;
-    if (videoPicture && videoPicture->hasDisplayMetadata)
-    {
-      switch (videoPicture->color_space)
-      {
-      case AVCOL_SPC_BT2020_NCL:
-      case AVCOL_SPC_BT2020_CL:
-      case AVCOL_SPC_BT709:
-        HDRColorSpace = EGL_GL_COLORSPACE_BT2020_PQ_EXT;
-        break;
-      default:
-        m_displayMetadata = nullptr;
-        m_lightMetadata = nullptr;
-      }
-    }
-    else
+    // Mastering display / content light level metadata is optional.
+    // Tag PQ based on the actual transfer curve where available.
+    // When transfer is unspecified, fall back to inferred HDR10/HDR10+.
+    // Dolby Vision is treated as PQ unless its base transfer is HLG.
+    const bool isHdrContent =
+        videoPicture && (videoPicture->color_transfer == AVCOL_TRC_SMPTE2084 ||
+                         (videoPicture->hdrType == StreamHdrType::HDR_TYPE_DOLBYVISION &&
+                          videoPicture->color_transfer != AVCOL_TRC_ARIB_STD_B67) ||
+                         (videoPicture->color_transfer == AVCOL_TRC_UNSPECIFIED &&
+                          (videoPicture->hdrType == StreamHdrType::HDR_TYPE_HDR10 ||
+                           videoPicture->hdrType == StreamHdrType::HDR_TYPE_HDR10PLUS)));
+    HDRColorSpace = isHdrContent ? EGL_GL_COLORSPACE_BT2020_PQ_EXT : EGL_NONE;
+
+    if (!isHdrContent || !videoPicture->hasDisplayMetadata)
     {
       m_displayMetadata = nullptr;
       m_lightMetadata = nullptr;
@@ -258,10 +256,10 @@ bool CWinSystemAndroidGLESContext::SetHDR(const VideoPicture* videoPicture)
       CLog::Log(LOGDEBUG, "CWinSystemAndroidGLESContext::SetHDR: ColorSpace: {}", HDRColorSpace);
 
       m_HDRColorSpace = HDRColorSpace;
-      m_displayMetadata =
-          m_HDRColorSpace == EGL_NONE
-              ? nullptr
-              : std::make_unique<AVMasteringDisplayMetadata>(videoPicture->displayMetadata);
+      m_displayMetadata = nullptr;
+      if (isHdrContent && videoPicture->hasDisplayMetadata)
+        m_displayMetadata =
+            std::make_unique<AVMasteringDisplayMetadata>(videoPicture->displayMetadata);
       // TODO: discuss with NVIDIA why this prevent turning HDR display off
       //m_lightMetadata = !videoPicture || m_HDRColorSpace == EGL_NONE ? nullptr : std::unique_ptr<AVContentLightMetadata>(new AVContentLightMetadata(videoPicture->lightMetadata));
       m_pGLContext.DestroySurface();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
`CWinSystemAndroidGLESContext::SetHDR()` decided whether to tag the GUI/OSD EGL surface as BT.2020 PQ using two unreliable conditions:
- whether mastering display metadata was present
- whether color_space matched BT.2020 or BT.709

Neither reliably means the video is HDR. Mastering display and content light metadata are optional, and colour matrix does not imply transfer characteristic.

This change determines tagging directly from:
- `color_transfer == AVCOL_TRC_SMPTE2084`
- Dolby Vision whose transfer is not HLG
- inferred HDR10/HDR10+ when the transfer is unspecified

Mastering display / content light metadata are still attached only when the source actually provides them. Metadata presence no longer gates whether tagging happens.

Only the EGL colourspace branch is touched.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
HDR10 mastering display and content light metadata are optional. Many legitimate PQ streams are encoded or remuxed without them. Under the previous logic, such content left the GUI surface untagged even though the video was HDR.

`color_space` is also the wrong signal: it describes the YUV-to-RGB matrix, not the ST.2084 transfer function.

This fix was prompted by [feedback](https://github.com/xbmc/xbmc/pull/28996#issuecomment-5338645005) noting that SetHDR should be based on the actual video transfer characteristic rather than optional metadata.

The EGL colourspace branch it fixes is legacy Android HDR handling. It may be removed or replaced later by a broader HDR cleanup, but until then this change makes the existing path less incorrect without expanding its use.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by code inspection and build only.

The change replaces an unreliable condition with one directly based on the video's transfer characteristic, and the new path is null-safe by construction.

Not yet tested on hardware that uses this legacy EGL colourspace path. On-device verification would need an Android device with the EGL BT.2020 PQ extension and HDR content lacking mastering display metadata.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
No change for content that already carries mastering display metadata and had a matching colour matrix.

On Android devices using the EGL extension path, HDR10 or Dolby Vision content without mastering metadata now gets the GUI surface correctly tagged BT.2020 PQ instead of left untagged.

No settings or configuration changes are introduced.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
