### PR TITLE
changed: exclude JSON from clang-format

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,4 @@
+# clang-format has no JSON style of its own, so it formats JSON with the C++ rules. ColumnLimit
+# then breaks long string values onto a line of their own, and JSON has no comments, so the
+# "clang-format off" escape is not available to the schemas that would need it.
+**/*.json


### PR DESCRIPTION
## Description

Adds a `.clang-format-ignore` excluding `**/*.json`.

Split out of #28852 at @CrystalP's request, so it can be judged on its own.

## Motivation and context

clang-format has no JSON style of its own, so it formats JSON with the C++ rules. `ColumnLimit` then breaks a long string value onto a line of its own, which is not how the tree's JSON is written and not what the generator reading the JSON-RPC schemas expects to round-trip.

The usual escape is unavailable here: JSON has no comments, so a schema cannot carry a `clang-format off` marker the way a source file can. An ignore file is the only way to express it.

## How has this been tested?

Measured with clang-format 19 (`--output-replacements-xml`) over `xbmc/interfaces/json-rpc/schema/`:

| file | replacements without the ignore | with it |
|---|---|---|
| `methods.json` | 13 | 0 |
| `notifications.json` | 1 | 0 |
| `types.json` | 1 | 0 |

No code is touched, so there is nothing to build or run.

## What is the effect on users?

None.

## Types of change
- [X] **Cosmetic change** (non-breaking change that doesn't touch code)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
