### PR TITLE
Add AGENTS.md specifically for comment slop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md
+
+Guidance for AI agents contributing to Kodi.
+
+## Comments
+
+AI-generated comments should be concise and only explain information that is not obvious from the code.
+
+* Do not restate the code in prose.
+* Do not mention approaches that were tried, considered, replaced, or removed during implementation.
+* Do not leave comments that only make sense in the context of an agent's iteration history.
+* Prefer deleting an unnecessary comment over expanding or rewording it.
+* Document an idea once, where it naturally belongs.
+* Put implementation history, discarded alternatives, and review rationale in the commit message or PR description unless they are necessary to understand the finished code.
+
+Before submitting, review every comment you added and remove anything that does not help a future reader understand the code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Description

The team is varied on our use-of-AI opinions, but universally agree that AI comments are terrible. So add an AGENTS.md for specifically comments until we land on a general AI policy and expand this document.

This should make all AI comments more bearable going forward.

As an initial AGENTS.md, this is meant to be expanded upon, but addresses our most pressing concern, with little need for debate.

## Motivation and context

Easy win with no contention.

Initial AGENTS.md to expand upon as AI use evolves and we continue discussions about AGENTS.md. This is a quick win that can be expanded later.

Starting point only: Addresses main source of AI contention, behind commit history slop.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
