### PR TITLE
[Video] More scraping speedups.

### DIFF
--- a/xbmc/TextureCache.cpp
+++ b/xbmc/TextureCache.cpp
@@ -28,6 +28,7 @@
 #include "utils/URIUtils.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cstring>
 #include <mutex>
@@ -36,12 +37,34 @@
 using namespace XFILE;
 using namespace std::chrono_literals;
 
+namespace
+{
+//! \brief Images to cache at once in the background
+unsigned int BackgroundJobsAtOnce()
+{
+  return std::max(1U, CJobManager::GetMaxPausableWorkers() / 2);
+}
+} // namespace
+
 CTextureCache::CTextureCache()
   : CJobQueue(false, 1, CJob::PRIORITY_LOW_PAUSABLE), m_cleanTimer{[this]() { CleanTimer(); }}
 {
 }
 
 CTextureCache::~CTextureCache() = default;
+
+CTextureCache::CCachingQueue::CCachingQueue(CTextureCache& cache)
+  : CJobQueue(false, BackgroundJobsAtOnce(), CJob::PRIORITY_LOW_PAUSABLE),
+    m_cache(cache)
+{
+}
+
+void CTextureCache::CCachingQueue::OnJobComplete(unsigned int jobID, bool success, CJob* job)
+{
+  if (strcmp(job->GetType(), CTextureCacheJob::JOB_TYPE_CACHE_IMAGE) == 0)
+    m_cache.OnCachingComplete(success, static_cast<CTextureCacheJob*>(job));
+  return CJobQueue::OnJobComplete(jobID, success, job);
+}
 
 void CTextureCache::Initialize()
 {
@@ -54,6 +77,7 @@ void CTextureCache::Initialize()
 void CTextureCache::Deinitialize()
 {
   m_cleanTimer.Stop(true);
+  m_cachingQueue.CancelJobs();
   CancelJobs();
 
   std::unique_lock lock(m_databaseSection);
@@ -130,7 +154,7 @@ void CTextureCache::BackgroundCacheImage(const std::string& url, const std::stri
     return;
 
   // needs (re)caching
-  AddJob(new CTextureCacheJob(path, details, knownHash));
+  m_cachingQueue.AddJob(new CTextureCacheJob(path, details, knownHash));
 }
 
 bool CTextureCache::StartCacheImage(const std::string& image)
@@ -163,12 +187,8 @@ std::string CTextureCache::CacheImage(
   if (url.empty())
     return "";
 
-  std::unique_lock lock(m_processingSection);
-  if (!m_processinglist.contains(url))
+  if (StartCacheImage(url))
   {
-    m_processinglist.insert(url);
-    lock.unlock();
-
     // Retrieve the hash the image was last cached with, so an unchanged source can be revalidated
     CTextureDetails cached;
     GetCachedImage(url, cached);
@@ -177,8 +197,10 @@ std::string CTextureCache::CacheImage(
     if (texture)
       oldDetails.file.clear();
 
-    // cache the texture directly
+    // cache the texture directly. The url was reserved above, so this job owns that reservation
     CTextureCacheJob job(url, oldDetails, knownHash);
+    job.m_holdsProcessingClaim = true;
+
     const bool success = job.CacheTexture(texture);
     OnCachingComplete(success, &job);
     if (!success)
@@ -196,9 +218,8 @@ std::string CTextureCache::CacheImage(
       *details = job.m_details;
     return GetCachedPath(job.m_details.file);
   }
-  lock.unlock();
 
-  // wait for currently processing job to end.
+  // wait for currently processing job to end
   while (true)
   {
     m_completeEvent.Wait(1000ms);
@@ -335,6 +356,7 @@ void CTextureCache::OnCachingComplete(bool success, CTextureCacheJob *job)
       AddCachedTexture(job->m_url, job->m_details);
   }
 
+  if (job->m_holdsProcessingClaim)
   { // remove from our processing list
     std::unique_lock lock(m_processingSection);
     std::set<std::string>::iterator i = m_processinglist.find(job->m_url);
@@ -482,9 +504,14 @@ std::chrono::milliseconds CTextureCache::ScanOldestCache()
 
   const unsigned int cleanAmount = 1000;
   const auto result = cleaner->ScanOldestCache(cleanAmount);
+
+  // Something may have come to refer to one of these since the scan looked, a scan adding artwork
+  // being the obvious way, and removing it then would only have it fetched again
+  const auto usedSince = cleaner->GetUsedImages(result.imagesToClean);
   for (const auto& image : result.imagesToClean)
   {
-    ClearCachedImage(image);
+    if (std::ranges::find(usedSince, image) == usedSince.cend())
+      ClearCachedImage(image);
   }
 
   // update in the next 6 - 48 hours depending on number of items processed

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -189,6 +189,24 @@ private:
   CTextureCache(const CTextureCache&) = delete;
   CTextureCache const& operator=(CTextureCache const&) = delete;
 
+  /*! \brief Runs the caching jobs, apart from this object's own queue
+
+   The cleanup timer's job shares that one, and takes the images it is about to remove as unused
+   before deleting them. Letting a caching job run alongside it would allow one of those to be
+   written between the two, and then deleted.
+   */
+  class CCachingQueue final : public CJobQueue
+  {
+  public:
+    explicit CCachingQueue(CTextureCache& cache);
+    void OnJobComplete(unsigned int jobID, bool success, CJob* job) override;
+
+  private:
+    CTextureCache& m_cache;
+  };
+
+  CCachingQueue m_cachingQueue{*this};
+
   /*! \brief Check if the given image is a cached image
    \param image url of the image
    \return true if this is a cached image, false otherwise.

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -66,7 +66,9 @@ bool CTextureCacheJob::DoWork()
   std::string path(CServiceBroker::GetTextureCache()->CheckCachedImage(m_url, needsRecaching));
   if (!path.empty() && !needsRecaching)
     return false;
-  if (CServiceBroker::GetTextureCache()->StartCacheImage(m_url))
+
+  m_holdsProcessingClaim = CServiceBroker::GetTextureCache()->StartCacheImage(m_url);
+  if (m_holdsProcessingClaim)
     return CacheTexture();
 
   return false;

--- a/xbmc/TextureCacheJob.cpp
+++ b/xbmc/TextureCacheJob.cpp
@@ -20,6 +20,7 @@
 #include "imagefiles/ImageFileURL.h"
 #include "imagefiles/SpecialImageLoaderFactory.h"
 #include "pictures/Picture.h"
+#include "utils/Mime.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -169,6 +170,12 @@ bool CTextureCacheJob::ResizeTexture(const std::string& url,
   return success;
 }
 
+bool CTextureCacheJob::MayBeAnImage(const std::string& mimeType)
+{
+  return StringUtils::StartsWithNoCase(mimeType, "image/") ||
+         StringUtils::EqualsNoCase(mimeType, "application/octet-stream");
+}
+
 std::unique_ptr<CTexture> CTextureCacheJob::LoadImage(const IMAGE_FILES::CImageFileURL& imageURL)
 {
   if (imageURL.IsSpecialImage())
@@ -181,17 +188,34 @@ std::unique_ptr<CTexture> CTextureCacheJob::LoadImage(const IMAGE_FILES::CImageF
 
   // Validate file URL to see if it is an image
   CFileItem file(imageURL.GetTargetFile(), false);
+
+  // An extension naming an image type says what asking the source would, so take it from there
+  // and save a round trip. Anything else - a dynamic page, no extension at all - still asks.
+  const std::string namedType{file.IsPicture() ? CMime::GetMimeType(file) : ""};
+  file.SetMimeType(namedType);
   file.FillInMimeType();
+
   if (!(file.IsPicture() && !(file.IsZIP() || file.IsRAR() || file.IsCBR() || file.IsCBZ())) &&
-      !StringUtils::StartsWithNoCase(file.GetMimeType(), "image/") &&
-      !StringUtils::EqualsNoCase(file.GetMimeType(),
-                                 "application/octet-stream")) // ignore non-pictures
+      !MayBeAnImage(file.GetMimeType())) // ignore non-pictures
   {
     return {};
   }
 
   auto texture = CTexture::LoadFromFile(imageURL.GetTargetFile(), 0, 0, CAspectRatio::CENTER,
                                         file.GetMimeType());
+  if (!texture && !namedType.empty())
+  {
+    // The extension named a type that couldn't be read, so the source may be serving another and
+    // only it knows which. It may equally not be an image at all, in which case there is nothing
+    // to try again with.
+    file.SetMimeType("");
+    file.FillInMimeType();
+    if (MayBeAnImage(file.GetMimeType()))
+    {
+      texture = CTexture::LoadFromFile(imageURL.GetTargetFile(), 0, 0, CAspectRatio::CENTER,
+                                       file.GetMimeType());
+    }
+  }
   if (!texture)
     return {};
 

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -104,6 +104,12 @@ public:
   CTextureDetails m_oldDetails;
   CTextureDetails m_details;
 
+  /*! \brief Whether this job is the one that reserved m_url in the texture cache.
+   Only the reserver may release it.
+   \sa CTextureCache::StartCacheImage, CTextureCache::OnCachingComplete
+   */
+  bool m_holdsProcessingClaim{false};
+
 private:
   /*! \brief Whether the copy this image was previously cached to is still present
    Revalidating leaves that copy in place rather than writing it again, so it has to still be

--- a/xbmc/TextureCacheJob.h
+++ b/xbmc/TextureCacheJob.h
@@ -94,6 +94,12 @@ public:
    */
   static std::string GetImageHash(const CFileItem& listedFile);
 
+  /*! \brief Whether a mime type leaves an image possible
+   \param mimeType the type to consider, empty if nothing has said what it is
+   \return true for an image type, and for the type a source gives when it doesn't know
+   */
+  static bool MayBeAnImage(const std::string& mimeType);
+
   std::string m_url;
   CTextureDetails m_oldDetails;
   CTextureDetails m_details;

--- a/xbmc/addons/Scraper.cpp
+++ b/xbmc/addons/Scraper.cpp
@@ -41,6 +41,7 @@
 #include "utils/XMLUtils.h"
 #include "utils/log.h"
 #include "video/VideoDatabase.h"
+#include "video/VideoInfoTag.h"
 
 #include <algorithm>
 #include <array>
@@ -914,6 +915,34 @@ bool PythonDetails(const std::string& ID,
   const ADDON::CScraper::UniqueIDs ids;
   return PythonDetails(ID, key, url, action, pathSettings, ids, result);
 }
+//! \brief Length prefixed, so that no separator can appear in what it is separating
+std::string Keyed(std::string_view value)
+{
+  return StringUtils::Format("{}:{}", value.size(), value);
+}
+
+//! \brief Key a set of unique ids into something a result cache can look up
+std::string SerialiseUniqueIDs(const ADDON::CScraper::UniqueIDs& uniqueIDs)
+{
+  std::vector<std::string> ids;
+  ids.reserve(uniqueIDs.size());
+  for (const auto& [type, value] : uniqueIDs)
+    ids.emplace_back(Keyed(type) + Keyed(value));
+
+  std::ranges::sort(ids); // the ids are unordered, the key cannot be
+  return StringUtils::Join(ids, "");
+}
+
+//! \brief Key every url a scraper would be given, since it fetches each one it is handed
+std::string SerialiseUrls(const CScraperUrl& scurl)
+{
+  std::string key;
+  for (const auto& url : scurl.GetUrls())
+    key += Keyed(url.m_url) + Keyed(url.m_spoof) + Keyed(url.m_cache) +
+           Keyed(url.m_post ? "1" : "") + Keyed(url.m_isgz ? "1" : "");
+
+  return key;
+}
 } // unnamed namespace
 
 // fetch list of matching movies sorted by relevance (may be empty);
@@ -922,6 +951,28 @@ std::vector<CScraperUrl> CScraper::FindMovie(XFILE::IHttpClient& fcurl,
                                              const std::string& movieTitle,
                                              int movieYear,
                                              bool fFirst)
+{
+  // The title is cleaned below, so the arguments as given identify the search
+  const std::string key{StringUtils::Format("{}\n{}\n{}", movieTitle, movieYear, fFirst)};
+  if (const auto it = m_findCache.find(key); it != m_findCache.end())
+    return it->second;
+
+  auto result = FindMovieUncached(fcurl, movieTitle, movieYear, fFirst);
+
+  if (!result.empty())
+  {
+    if (m_findCache.size() >= MAX_CACHED_RESULTS)
+      m_findCache.clear();
+    m_findCache.emplace(key, result);
+  }
+
+  return result;
+}
+
+std::vector<CScraperUrl> CScraper::FindMovieUncached(XFILE::IHttpClient& fcurl,
+                                                     const std::string& movieTitle,
+                                                     int movieYear,
+                                                     bool fFirst)
 {
   // prepare parameters for URL creation
   std::string sTitle;
@@ -1364,6 +1415,33 @@ bool CScraper::GetVideoDetails(XFILE::IHttpClient& fcurl,
                                const CScraperUrl& scurl,
                                bool fMovie /*else episode*/,
                                CVideoInfoTag& video)
+{
+  // The id as well as the url, since an xml scraper is given both and two search results can
+  // carry the same url under different ids
+  const std::string key{Keyed(scurl.GetId()) + SerialiseUrls(scurl) + (fMovie ? "m" : "e") +
+                        SerialiseUniqueIDs(uniqueIDs)};
+  if (const auto it = m_detailsCache.find(key); it != m_detailsCache.end())
+  {
+    // A copy - the caller goes on to fill in where this came from and what art it ended up with
+    video = *it->second;
+    return true;
+  }
+
+  if (!GetVideoDetailsUncached(fcurl, uniqueIDs, scurl, fMovie, video))
+    return false;
+
+  if (m_detailsCache.size() >= MAX_CACHED_RESULTS)
+    m_detailsCache.clear();
+  m_detailsCache.emplace(key, std::make_shared<const CVideoInfoTag>(video));
+
+  return true;
+}
+
+bool CScraper::GetVideoDetailsUncached(XFILE::IHttpClient& fcurl,
+                                       const UniqueIDs& uniqueIDs,
+                                       const CScraperUrl& scurl,
+                                       bool fMovie,
+                                       CVideoInfoTag& video)
 {
   CLog::LogF(LOGDEBUG,
              "Reading {} '{}' using {} scraper (file: '{}', content: '{}', version: '{}')",

--- a/xbmc/addons/Scraper.h
+++ b/xbmc/addons/Scraper.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include <fmt/format.h>
@@ -189,6 +190,32 @@ private:
                           const CScraperUrl& url,
                           XFILE::IHttpClient& http,
                           const std::vector<std::string>* extras);
+
+  //! \brief FindMovie without the result cache in front of it
+  std::vector<CScraperUrl> FindMovieUncached(XFILE::IHttpClient& fcurl,
+                                             const std::string& movieTitle,
+                                             int movieYear,
+                                             bool fFirst);
+
+  //! \brief GetVideoDetails without the result cache in front of it
+  bool GetVideoDetailsUncached(XFILE::IHttpClient& fcurl,
+                               const UniqueIDs& uniqueIDs,
+                               const CScraperUrl& scurl,
+                               bool fMovie,
+                               CVideoInfoTag& video);
+
+  /*! \brief Cache scraper results rather than repeating the request.
+
+   Lifetime is this instance.
+   Repeats come from versions, discs and folders of the same title, which are scraped close together.
+   Not synchronised, matching the rest of CScraper: a scraper shared between threads needs the
+   caller to provide that.
+   */
+  static constexpr size_t MAX_CACHED_RESULTS{50};
+  std::unordered_map<std::string, std::vector<CScraperUrl>, StringHash, std::equal_to<>>
+      m_findCache;
+  std::unordered_map<std::string, std::shared_ptr<const CVideoInfoTag>, StringHash, std::equal_to<>>
+      m_detailsCache;
 
   bool m_fLoaded = false;
   bool m_isPython = false;

--- a/xbmc/imagefiles/ImageCacheCleaner.cpp
+++ b/xbmc/imagefiles/ImageCacheCleaner.cpp
@@ -70,6 +70,22 @@ CImageCacheCleaner::~CImageCacheCleaner()
     m_textureDB->Close();
 }
 
+std::vector<std::string> CImageCacheCleaner::GetUsedImages(
+    const std::vector<std::string>& images) const
+{
+  auto usedImages = m_videoDB->GetUsedImages(images);
+
+  auto nextUsedImages = m_musicDB->GetUsedImages(images);
+  usedImages.insert(usedImages.end(), std::make_move_iterator(nextUsedImages.begin()),
+                    std::make_move_iterator(nextUsedImages.end()));
+
+  nextUsedImages = m_addonDB->GetUsedImages(images);
+  usedImages.insert(usedImages.end(), std::make_move_iterator(nextUsedImages.begin()),
+                    std::make_move_iterator(nextUsedImages.end()));
+
+  return usedImages;
+}
+
 CleanerResult CImageCacheCleaner::ScanOldestCache(unsigned int imageLimit)
 {
   CLog::LogF(LOGDEBUG, "begin process to clean image cache");
@@ -83,15 +99,7 @@ CleanerResult CImageCacheCleaner::ScanOldestCache(unsigned int imageLimit)
   unsigned int processedCount = images.size();
   CLog::LogF(LOGDEBUG, "found {} old cached images to process", processedCount);
 
-  auto usedImages = m_videoDB->GetUsedImages(images);
-
-  auto nextUsedImages = m_musicDB->GetUsedImages(images);
-  usedImages.insert(usedImages.end(), std::make_move_iterator(nextUsedImages.begin()),
-                    std::make_move_iterator(nextUsedImages.end()));
-
-  nextUsedImages = m_addonDB->GetUsedImages(images);
-  usedImages.insert(usedImages.end(), std::make_move_iterator(nextUsedImages.begin()),
-                    std::make_move_iterator(nextUsedImages.end()));
+  auto usedImages = GetUsedImages(images);
 
   std::erase_if(images, [&usedImages](const std::string& image)
                 { return std::ranges::find(usedImages, image) != usedImages.cend(); });

--- a/xbmc/imagefiles/ImageCacheCleaner.h
+++ b/xbmc/imagefiles/ImageCacheCleaner.h
@@ -46,6 +46,17 @@ public:
 
   CleanerResult ScanOldestCache(unsigned int imageLimit);
 
+  /*! \brief Which of these images anything still refers to
+
+   A scan adding artwork runs alongside a clean, so an image the scan above found nothing
+   referring to can have come to be referenced before the caller acts on that. Asking again
+   leaves only the moment between this and the removal itself, rather than the whole of it.
+
+   \param images the images to ask about
+   \return those of them that are referenced
+   */
+  std::vector<std::string> GetUsedImages(const std::vector<std::string>& images) const;
+
 private:
   CImageCacheCleaner();
   bool m_valid;

--- a/xbmc/jobs/JobManager.cpp
+++ b/xbmc/jobs/JobManager.cpp
@@ -215,7 +215,7 @@ void CJobManager::StartWorkers(CJob::PRIORITY priority)
   std::unique_lock lock(m_section);
 
   // check how many free threads we have
-  if (m_processing.size() >= GetMaxWorkers(priority))
+  if (!CanStart(priority))
     return;
 
   // do we have any sleeping threads?
@@ -238,8 +238,7 @@ CJob* CJobManager::PopJob()
     if (priority == CJob::PRIORITY_LOW_PAUSABLE && m_pauseJobs)
       continue;
 
-    if (!m_jobQueue[priority].empty() &&
-        m_processing.size() < GetMaxWorkers(CJob::PRIORITY(priority)))
+    if (!m_jobQueue[priority].empty() && CanStart(CJob::PRIORITY(priority)))
     {
       // pop the job off the queue
       const CWorkItem job{m_jobQueue[priority].front()};
@@ -258,6 +257,12 @@ void CJobManager::PauseJobs()
 {
   std::unique_lock lock(m_section);
   m_pauseJobs = true;
+}
+
+bool CJobManager::ArePausableJobsPaused() const
+{
+  std::unique_lock lock(m_section);
+  return m_pauseJobs;
 }
 
 void CJobManager::UnPauseJobs()
@@ -410,4 +415,29 @@ unsigned int CJobManager::GetMaxWorkers(CJob::PRIORITY priority)
   if (priority == CJob::PRIORITY_DEDICATED)
     return 10000; // A large number..
   return max_workers - (CJob::PRIORITY_HIGH - priority);
+}
+
+unsigned int CJobManager::GetMaxPausableWorkers()
+{
+  // PRIORITY_LOW_PAUSABLE work waits on a source rather than on a core
+  constexpr unsigned int SOURCE_REQUEST_LIMIT{4};
+  constexpr unsigned int SMALL_DEVICE_LIMIT{2};
+
+  // hardware_concurrency() rather than CCPUInfo, to keep the job manager free of the service
+  // broker. It reports 0 when it cannot tell, which counts as "not many".
+  return std::thread::hardware_concurrency() >= 4 ? SOURCE_REQUEST_LIMIT : SMALL_DEVICE_LIMIT;
+}
+
+bool CJobManager::CanStart(CJob::PRIORITY priority) const
+{
+  // PRIORITY_LOW_PAUSABLE is background work that spends its time waiting on a source rather than
+  // on a core. Currently only used for texture cache.
+  const auto pausable{static_cast<size_t>(
+      std::ranges::count_if(m_processing, [](const CWorkItem& item)
+                            { return item.GetPriority() == CJob::PRIORITY_LOW_PAUSABLE; }))};
+
+  if (priority == CJob::PRIORITY_LOW_PAUSABLE)
+    return pausable < GetMaxPausableWorkers();
+
+  return m_processing.size() - pausable < GetMaxWorkers(priority);
 }

--- a/xbmc/jobs/JobManager.cpp
+++ b/xbmc/jobs/JobManager.cpp
@@ -218,15 +218,37 @@ void CJobManager::StartWorkers(CJob::PRIORITY priority)
   if (!CanStart(priority))
     return;
 
-  // do we have any sleeping threads?
-  if (m_processing.size() < m_workers.size())
+  // Workers not running a job (ie waiting for one, or between jobs and about to ask for the next)
+  const size_t free{m_workers.size() > m_processing.size() ? m_workers.size() - m_processing.size()
+                                                           : 0};
+
+  // Each job already waiting has a claim on those ahead of this one
+  const size_t wanted{std::min<size_t>(CountQueuedJobs(), GetMaxWorkers(priority))};
+
+  // Do we have any sleeping threads?
+  if (free >= wanted)
   {
     m_jobEvent.Set();
     return;
   }
 
-  // everyone is busy - we need more workers
+  // Everyone is busy - we need more workers
   m_workers.emplace_back(new CJobWorker(*this));
+}
+
+size_t CJobManager::CountQueuedJobs() const
+{
+  size_t queued{0};
+  for (unsigned int priority = CJob::PRIORITY_LOW_PAUSABLE; priority <= CJob::PRIORITY_DEDICATED;
+       ++priority)
+  {
+    // Nothing takes these until playback stops, so a worker made for one would only sit waiting
+    if (priority == CJob::PRIORITY_LOW_PAUSABLE && m_pauseJobs)
+      continue;
+
+    queued += m_jobQueue[priority].size();
+  }
+  return queued;
 }
 
 CJob* CJobManager::PopJob()
@@ -269,6 +291,10 @@ void CJobManager::UnPauseJobs()
 {
   std::unique_lock lock(m_section);
   m_pauseJobs = false;
+
+  // Nothing was made to run what was queued while paused, so it would sit until something else
+  // was asked for
+  StartWorkers(CJob::PRIORITY_LOW_PAUSABLE);
 }
 
 bool CJobManager::IsProcessing(const CJob::PRIORITY& priority) const
@@ -411,9 +437,12 @@ void CJobManager::RemoveWorker(const CJobWorker* worker)
 
 unsigned int CJobManager::GetMaxWorkers(CJob::PRIORITY priority)
 {
-  static const unsigned int max_workers = 5;
   if (priority == CJob::PRIORITY_DEDICATED)
     return 10000; // A large number..
+  if (priority == CJob::PRIORITY_LOW_PAUSABLE)
+    return GetMaxPausableWorkers();
+
+  static const unsigned int max_workers = 5;
   return max_workers - (CJob::PRIORITY_HIGH - priority);
 }
 
@@ -437,7 +466,7 @@ bool CJobManager::CanStart(CJob::PRIORITY priority) const
                             { return item.GetPriority() == CJob::PRIORITY_LOW_PAUSABLE; }))};
 
   if (priority == CJob::PRIORITY_LOW_PAUSABLE)
-    return pausable < GetMaxPausableWorkers();
+    return pausable < GetMaxWorkers(priority);
 
   return m_processing.size() - pausable < GetMaxWorkers(priority);
 }

--- a/xbmc/jobs/JobManager.h
+++ b/xbmc/jobs/JobManager.h
@@ -129,6 +129,18 @@ public:
    */
   void UnPauseJobs();
 
+  /*! \brief Whether jobs of priority PRIORITY_LOW_PAUSABLE are currently suspended
+   \sa PauseJobs, UnPauseJobs
+   */
+  bool ArePausableJobsPaused() const;
+
+  /*! \brief Maximum jobs to run at once at PRIORITY_LOW_PAUSABLE
+
+   \return the limit
+   \sa CJobQueue
+   */
+  static unsigned int GetMaxPausableWorkers();
+
   /*!
    \brief Checks to see if any jobs with specific priority are currently processing.
    \param priority to search for
@@ -228,7 +240,18 @@ private:
 
   void StartWorkers(CJob::PRIORITY priority);
   void RemoveWorker(const CJobWorker* worker);
+
+  /*! \brief Number of workers available to a priority, excluding PRIORITY_LOW_PAUSABLE
+   Each level leaves headroom for the ones above it, so that a busy background never stops
+   higher-priority work from starting.
+   */
   static unsigned int GetMaxWorkers(CJob::PRIORITY priority);
+
+  /*! \brief Whether another job of this priority may start now
+   \param priority priority of the job wanting to start
+   \return true if there is room for it
+   */
+  bool CanStart(CJob::PRIORITY priority) const;
 
   unsigned int m_jobCounter{0};
 

--- a/xbmc/jobs/JobManager.h
+++ b/xbmc/jobs/JobManager.h
@@ -241,11 +241,17 @@ private:
   void StartWorkers(CJob::PRIORITY priority);
   void RemoveWorker(const CJobWorker* worker);
 
-  /*! \brief Number of workers available to a priority, excluding PRIORITY_LOW_PAUSABLE
+  /*! \brief Number of workers available to a priority
    Each level leaves headroom for the ones above it, so that a busy background never stops
    higher-priority work from starting.
    */
   static unsigned int GetMaxWorkers(CJob::PRIORITY priority);
+
+  /*! \brief How many jobs are waiting to be picked up
+   Excludes those of a priority that is currently suspended, as nothing will take them.
+   \return the count, across every priority
+   */
+  size_t CountQueuedJobs() const;
 
   /*! \brief Whether another job of this priority may start now
    \param priority priority of the job wanting to start

--- a/xbmc/jobs/JobQueue.cpp
+++ b/xbmc/jobs/JobQueue.cpp
@@ -58,6 +58,7 @@ void CJobQueue::CancelJob(const CJob* job)
   {
     i->CancelJob();
     m_processing.erase(i);
+    UpdateIdleState();
     return;
   }
   const auto j = std::ranges::find_if(m_jobQueue, JobFinder(job));
@@ -65,6 +66,7 @@ void CJobQueue::CancelJob(const CJob* job)
   {
     j->FreeJob();
     m_jobQueue.erase(j);
+    UpdateIdleState();
   }
 }
 
@@ -112,13 +114,19 @@ void CJobQueue::QueueNextJob()
     CJobPointer& job = m_jobQueue.back();
     job.SetId(CServiceBroker::GetJobManager()->AddJob(job.GetJob(), this, m_priority));
     if (job.GetId() > 0)
-    {
       m_processing.emplace_back(job);
-      m_jobQueue.pop_back();
-      return;
-    }
     m_jobQueue.pop_back();
   }
+
+  UpdateIdleState();
+}
+
+void CJobQueue::UpdateIdleState()
+{
+  if (m_jobQueue.empty() && m_processing.empty())
+    m_idleEvent.Set();
+  else
+    m_idleEvent.Reset();
 }
 
 void CJobQueue::CancelJobs()
@@ -128,12 +136,25 @@ void CJobQueue::CancelJobs()
   std::ranges::for_each(m_jobQueue, [](CJobPointer& jp) { jp.FreeJob(); });
   m_jobQueue.clear();
   m_processing.clear();
+  UpdateIdleState();
 }
 
 bool CJobQueue::IsProcessing() const
 {
-  return CServiceBroker::GetJobManager()->IsRunning() &&
-         (!m_processing.empty() || !m_jobQueue.empty());
+  // What the queue holds is read under its own lock, the job manager asked outside it, so that
+  // the two are never held at once
+  const bool hasJobs{[this]
+                     {
+                       std::unique_lock lock(m_section);
+                       return !m_processing.empty() || !m_jobQueue.empty();
+                     }()};
+
+  return hasJobs && CServiceBroker::GetJobManager()->IsRunning();
+}
+
+bool CJobQueue::WaitForCompletion(std::chrono::milliseconds timeout)
+{
+  return m_idleEvent.Wait(timeout);
 }
 
 bool CJobQueue::QueueEmpty() const

--- a/xbmc/jobs/JobQueue.h
+++ b/xbmc/jobs/JobQueue.h
@@ -12,7 +12,9 @@
 #include "jobs/Job.h"
 #include "jobs/LambdaJob.h"
 #include "threads/CriticalSection.h"
+#include "threads/Event.h"
 
+#include <chrono>
 #include <queue>
 #include <vector>
 
@@ -93,6 +95,19 @@ public:
   bool IsProcessing() const;
 
   /*!
+   \brief Wait for every job added to this queue to finish
+
+   Returns as soon as nothing is queued or in progress, so a queue that was already idle returns
+   at once. Note that a queue whose priority is currently suspended will not drain: callers should
+   treat a timeout as a reason to check, rather than as a reason to keep waiting.
+
+   \param timeout how long to wait for
+   \return true if the queue is now idle, false if it timed out first
+   \sa IsProcessing
+   */
+  bool WaitForCompletion(std::chrono::milliseconds timeout);
+
+  /*!
    \brief The callback used when a job completes.
 
    CJobQueue implementation will cleanup the internal processing queue and then queue the next
@@ -152,10 +167,23 @@ private:
   void OnJobNotify(const CJob* job);
   void QueueNextJob();
 
+  /*! \brief Match the idle event to what the queue holds
+
+   Call with m_section held, from anywhere either container changes: a job can leave the queue
+   without finishing - cancelled, or refused by the job manager - and something waiting on the
+   queue draining still needs to be told.
+
+   \sa WaitForCompletion
+   */
+  void UpdateIdleState();
+
   using Queue = std::deque<CJobPointer>;
   using Processing = std::vector<CJobPointer>;
   Queue m_jobQueue;
   Processing m_processing;
+
+  //! Set whenever nothing is queued or in progress
+  CEvent m_idleEvent{true, true};
 
   unsigned int m_jobsAtOnce{1};
   CJob::PRIORITY m_priority{CJob::PRIORITY::PRIORITY_LOW};

--- a/xbmc/test/CMakeLists.txt
+++ b/xbmc/test/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES TestAutoSwitch.cpp
             TestMediaSource.cpp
             TestPasswordManager.cpp
             TestPlayListPlayer.cpp
+            TestTextureCacheJob.cpp
             TestURL.cpp
             TestUtil.cpp
             TestUtils.cpp)

--- a/xbmc/test/TestTextureCacheJob.cpp
+++ b/xbmc/test/TestTextureCacheJob.cpp
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "TextureCacheJob.h"
+
+#include <gtest/gtest.h>
+
+TEST(TestTextureCacheJob, MayBeAnImage)
+{
+  EXPECT_TRUE(CTextureCacheJob::MayBeAnImage("image/jpeg"));
+  EXPECT_TRUE(CTextureCacheJob::MayBeAnImage("image/png"));
+  EXPECT_TRUE(CTextureCacheJob::MayBeAnImage("IMAGE/JPEG"));
+
+  // What a source says when it doesn't know, which an image still has to be tried against
+  EXPECT_TRUE(CTextureCacheJob::MayBeAnImage("application/octet-stream"));
+
+  EXPECT_FALSE(CTextureCacheJob::MayBeAnImage("text/html"));
+  EXPECT_FALSE(CTextureCacheJob::MayBeAnImage("text/asp"));
+  EXPECT_FALSE(CTextureCacheJob::MayBeAnImage("video/mp4"));
+
+  // Nothing has said what it is, so there is nothing here to rule it in either
+  EXPECT_FALSE(CTextureCacheJob::MayBeAnImage(""));
+}

--- a/xbmc/utils/ArtUtils.cpp
+++ b/xbmc/utils/ArtUtils.cpp
@@ -11,6 +11,7 @@
 #include "FileItem.h"
 #include "FileItemList.h"
 #include "ServiceBroker.h"
+#include "TextureCache.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
 #include "filesystem/MultiPathDirectory.h"
@@ -25,10 +26,24 @@
 #include "utils/URIUtils.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoTag.h"
+#include "video/VideoThumbLoader.h"
 
 #include <fmt/format.h>
 
 using namespace XFILE;
+
+namespace
+{
+std::string GetArtTypeFromSize(unsigned int width, unsigned int height)
+{
+  std::string type = "thumb";
+  if (width * 5 < height * 4)
+    type = "poster";
+  else if (width > height * 4)
+    type = "banner";
+  return type;
+}
+} // unnamed namespace
 
 namespace KODI::ART
 {
@@ -434,6 +449,71 @@ std::string GetTBNFile(const CFileItem& item, int season /* = - 1 */, int episod
     thumbFile = url.Get();
   }
   return thumbFile;
+}
+
+void AddLocalItemArtwork(Artwork& itemArt,
+                         const std::vector<std::string>& wantedArtTypes,
+                         const std::string& itemPath,
+                         bool addAll,
+                         bool exactName,
+                         bool isInFolder)
+{
+  std::string path = URIUtils::GetDirectory(itemPath);
+  if (path.empty())
+    return;
+
+  CFileItemList availableArtFiles;
+  CDirectory::GetDirectory(path, availableArtFiles,
+                           CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(),
+                           DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+
+  std::string baseFilename{URIUtils::GetFileName(itemPath)};
+  if (!baseFilename.empty())
+  {
+    URIUtils::RemoveExtension(baseFilename);
+    baseFilename.append("-");
+  }
+
+  const bool caseSensitive{
+      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_caseSensitiveLocalArtMatch};
+
+  for (const auto& artFile : availableArtFiles)
+  {
+    std::string candidate{URIUtils::GetFileName(artFile->GetPath())};
+
+    bool matchesFilename{!baseFilename.empty() &&
+                         (caseSensitive ? StringUtils::StartsWith(candidate, baseFilename)
+                                        : StringUtils::StartsWithNoCase(candidate, baseFilename))};
+
+    if (!baseFilename.empty() && !matchesFilename && !isInFolder)
+      continue;
+
+    if (matchesFilename)
+      candidate.erase(0, baseFilename.length());
+    URIUtils::RemoveExtension(candidate);
+    StringUtils::ToLower(candidate);
+
+    // move 'folder' to thumb / poster / banner based on aspect ratio
+    // if such artwork doesn't already exist
+    if (!matchesFilename && StringUtils::EqualsNoCase(candidate, "folder") &&
+        !CVideoThumbLoader::IsArtTypeInWhitelist("folder", wantedArtTypes, exactName))
+    {
+      // cache the image to determine sizing
+      CTextureDetails details;
+      if (CServiceBroker::GetTextureCache()->CacheImage(artFile->GetPath(), details))
+      {
+        candidate = GetArtTypeFromSize(details.width, details.height);
+        if (itemArt.contains(candidate))
+          continue;
+      }
+    }
+
+    if ((addAll && CVideoThumbLoader::IsValidArtType(candidate)) ||
+        CVideoThumbLoader::IsArtTypeInWhitelist(candidate, wantedArtTypes, exactName))
+    {
+      itemArt[candidate] = artFile->GetPath();
+    }
+  }
 }
 
 } // namespace KODI::ART

--- a/xbmc/utils/ArtUtils.h
+++ b/xbmc/utils/ArtUtils.h
@@ -8,8 +8,11 @@
 
 #pragma once
 
+#include "utils/Artwork.h"
+
 #include <cstdint>
 #include <string>
+#include <vector>
 
 class CFileItem;
 
@@ -68,6 +71,22 @@ std::string GetLocalArtBaseFilename(
  \sa GetFolderThumb, GetTBNFile
  */
 std::string GetLocalFanart(const CFileItem& item);
+
+/*! \brief Add the art files sitting alongside an item to its artwork
+ \param itemArt [in/out] the item's artwork, added to
+ \param wantedArtTypes the art types to look for
+ \param itemPath path of the item whose folder is searched
+ \param addAll whether to take any valid art type found, rather than only those wanted
+ \param exactName whether an art type has to match a wanted one exactly
+ \param isInFolder whether the item is alone in its folder, so unprefixed art belongs to it
+ \sa GetLocalArtBaseFilename
+ */
+void AddLocalItemArtwork(Artwork& itemArt,
+                         const std::vector<std::string>& wantedArtTypes,
+                         const std::string& itemPath,
+                         bool addAll,
+                         bool exactName,
+                         bool isInFolder);
 
 /*! \brief Get the .tbn file associated with an item.
  \param item CFileItem containing the item path.

--- a/xbmc/utils/test/CMakeLists.txt
+++ b/xbmc/utils/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES TestAlarmClock.cpp
             TestHttpRangeUtils.cpp
             TestHttpResponse.cpp
             TestJobManager.cpp
+            TestJobQueue.cpp
             TestJSONVariantParser.cpp
             TestJSONVariantWriter.cpp
             TestLabelFormatter.cpp

--- a/xbmc/utils/test/TestJobManager.cpp
+++ b/xbmc/utils/test/TestJobManager.cpp
@@ -211,3 +211,134 @@ TEST_F(TestJobManager, IsProcessing)
 
   job->FinishAndStopBlocking();
 }
+
+namespace
+{
+/*! \brief Records how many of these run at once, holding each until released
+
+ CJob::Equals() is false by default, so several of these are distinct jobs rather than one the
+ manager collapses into the first.
+ */
+class CountingJob : public CJob
+{
+public:
+  struct Shared
+  {
+    std::atomic<int> running{0};
+    std::atomic<int> peak{0};
+    std::atomic<int> finished{0};
+    std::atomic<bool> release{false};
+  };
+
+  explicit CountingJob(Shared& shared) : m_shared(shared) {}
+
+  const char* GetType() const override { return "CountingJob"; }
+
+  bool DoWork() override
+  {
+    const int running{++m_shared.running};
+    for (int peak = m_shared.peak;
+         running > peak && !m_shared.peak.compare_exchange_weak(peak, running);)
+      ;
+
+    while (!m_shared.release)
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    --m_shared.running;
+    ++m_shared.finished;
+    return true;
+  }
+
+private:
+  Shared& m_shared;
+};
+
+void AddCountingJobs(CountingJob::Shared& shared, unsigned int count, CJob::PRIORITY priority)
+{
+  for (unsigned int i = 0; i < count; ++i)
+    CServiceBroker::GetJobManager()->AddJob(new CountingJob(shared), nullptr, priority);
+}
+
+/*! \brief Lets the jobs holding this finish, and waits until they have
+
+ A failed assertion returns from the test at once, so without this the jobs would be left waiting
+ to be released - which the fixture's CancelJobs() then waits on forever - and what they are
+ waiting on would go out of scope underneath them.
+ */
+class Releaser
+{
+public:
+  explicit Releaser(CountingJob::Shared& shared) : m_shared(shared) {}
+
+  ~Releaser()
+  {
+    m_shared.release = true;
+    poll([this]() { return m_shared.running == 0; });
+  }
+
+  Releaser(const Releaser&) = delete;
+  Releaser& operator=(const Releaser&) = delete;
+
+private:
+  CountingJob::Shared& m_shared;
+};
+} // namespace
+
+TEST_F(TestJobManager, PausableJobsRunInParallelFromCold)
+{
+  // Nothing has run yet, so there are no workers waiting for these and one has to be made for
+  // each of them
+  const auto expected{static_cast<int>(CJobManager::GetMaxPausableWorkers())};
+
+  CountingJob::Shared shared;
+  AddCountingJobs(shared, expected * 2, CJob::PRIORITY_LOW_PAUSABLE);
+
+  EXPECT_TRUE(poll([&shared, expected]() { return shared.peak == expected; }));
+
+  shared.release = true;
+  ASSERT_TRUE(poll([&shared, expected]() { return shared.finished == expected * 2; }));
+  EXPECT_EQ(expected, shared.peak);
+}
+
+TEST_F(TestJobManager, PausableJobsQueuedWhilePausedRunOnUnPause)
+{
+  CServiceBroker::GetJobManager()->PauseJobs();
+
+  CountingJob::Shared shared;
+  shared.release = true;
+  AddCountingJobs(shared, 1, CJob::PRIORITY_LOW_PAUSABLE);
+
+  EXPECT_FALSE(poll(500, [&shared]() { return shared.finished > 0; }));
+
+  CServiceBroker::GetJobManager()->UnPauseJobs();
+
+  EXPECT_TRUE(poll([&shared]() { return shared.finished == 1; }));
+}
+
+TEST_F(TestJobManager, PausableJobsDoNotConsumeTheBudgetOfOtherPriorities)
+{
+  const auto pausableLimit{CJobManager::GetMaxPausableWorkers()};
+
+  // One at a time, waiting for each to be running before asking for the next, so that reaching
+  // the limit doesn't depend on how a burst of them is dispatched
+  CountingJob::Shared pausable;
+  const Releaser releaser{pausable};
+  for (unsigned int i = 1; i <= pausableLimit; ++i)
+  {
+    AddCountingJobs(pausable, 1, CJob::PRIORITY_LOW_PAUSABLE);
+    ASSERT_TRUE(poll([&pausable, i]() { return pausable.running == static_cast<int>(i); }));
+  }
+
+  // PRIORITY_LOW has the smallest allowance of those sharing one, so it is the first to be
+  // starved were the jobs above counted against it
+  CountingJob::Shared low;
+  low.release = true;
+  AddCountingJobs(low, 1, CJob::PRIORITY_LOW);
+  EXPECT_TRUE(poll([&low]() { return low.finished == 1; }));
+
+  EXPECT_EQ(static_cast<int>(pausableLimit), pausable.peak);
+
+  pausable.release = true;
+  ASSERT_TRUE(poll([&pausable, pausableLimit]()
+                   { return pausable.finished == static_cast<int>(pausableLimit); }));
+}

--- a/xbmc/utils/test/TestJobQueue.cpp
+++ b/xbmc/utils/test/TestJobQueue.cpp
@@ -1,0 +1,145 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ServiceBroker.h"
+#include "jobs/Job.h"
+#include "jobs/JobManager.h"
+#include "jobs/JobQueue.h"
+#include "test/MtTestUtils.h"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+using namespace ConditionPoll;
+using namespace std::chrono_literals;
+
+namespace
+{
+//! \brief Holds until released, so that a test can decide when the queue drains
+class BlockingJob : public CJob
+{
+public:
+  struct Shared
+  {
+    std::atomic<int> started{0};
+    std::atomic<int> finished{0};
+    std::atomic<bool> release{false};
+  };
+
+  explicit BlockingJob(Shared& shared) : m_shared(shared) {}
+
+  const char* GetType() const override { return "BlockingJob"; }
+
+  bool DoWork() override
+  {
+    ++m_shared.started;
+    while (!m_shared.release)
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    ++m_shared.finished;
+    return true;
+  }
+
+private:
+  Shared& m_shared;
+};
+
+/*! \brief Lets the jobs holding this finish, and waits until they have
+
+ A failed assertion returns from the test at once, so without this the jobs would be left waiting
+ to be released - which the queue's destructor then waits on forever - and what they are waiting
+ on would go out of scope underneath them.
+ */
+class Releaser
+{
+public:
+  explicit Releaser(BlockingJob::Shared& shared) : m_shared(shared) {}
+
+  ~Releaser()
+  {
+    m_shared.release = true;
+    poll([this]() { return m_shared.finished == m_shared.started; });
+  }
+
+  Releaser(const Releaser&) = delete;
+  Releaser& operator=(const Releaser&) = delete;
+
+private:
+  BlockingJob::Shared& m_shared;
+};
+
+//! \brief How long a drained queue should take to report itself idle
+constexpr auto SETTLE{2000ms};
+
+//! \brief Long enough to show a queue is not reporting itself idle, short enough not to drag
+constexpr auto NOT_IDLE{300ms};
+} // namespace
+
+class TestJobQueue : public testing::Test
+{
+protected:
+  TestJobQueue() { CServiceBroker::RegisterJobManager(std::make_shared<CJobManager>()); }
+
+  ~TestJobQueue() override
+  {
+    CServiceBroker::GetJobManager()->CancelJobs();
+    CServiceBroker::GetJobManager()->Restart();
+    CServiceBroker::UnregisterJobManager();
+  }
+};
+
+TEST_F(TestJobQueue, WaitForCompletionReturnsWhenNothingWasEverQueued)
+{
+  CJobQueue queue{false, 1, CJob::PRIORITY_LOW};
+
+  EXPECT_TRUE(queue.WaitForCompletion(NOT_IDLE));
+}
+
+TEST_F(TestJobQueue, WaitForCompletionReturnsOnceJobsFinish)
+{
+  CJobQueue queue{false, 2, CJob::PRIORITY_LOW};
+
+  BlockingJob::Shared shared;
+  const Releaser releaser{shared};
+  ASSERT_TRUE(queue.AddJob(new BlockingJob(shared)));
+  ASSERT_TRUE(queue.AddJob(new BlockingJob(shared)));
+  ASSERT_TRUE(poll([&shared]() { return shared.started == 2; }));
+
+  EXPECT_FALSE(queue.WaitForCompletion(NOT_IDLE));
+
+  shared.release = true;
+  EXPECT_TRUE(queue.WaitForCompletion(SETTLE));
+  EXPECT_EQ(2, shared.finished);
+}
+
+TEST_F(TestJobQueue, WaitForCompletionReturnsOnceCancellingLeavesNothingQueued)
+{
+  CJobQueue queue{false, 1, CJob::PRIORITY_LOW};
+
+  BlockingJob::Shared shared;
+  const Releaser releaser{shared};
+  auto* running = new BlockingJob(shared);
+  auto* waiting = new BlockingJob(shared);
+
+  ASSERT_TRUE(queue.AddJob(running));
+  ASSERT_TRUE(poll([&shared]() { return shared.started == 1; }));
+
+  // One at a time, so this one is still held by the queue rather than handed to the manager
+  ASSERT_TRUE(queue.AddJob(waiting));
+
+  queue.CancelJob(waiting);
+  EXPECT_FALSE(queue.WaitForCompletion(NOT_IDLE));
+
+  // Nothing is left for the queue to report on, even though what it handed over is still going
+  queue.CancelJob(running);
+  EXPECT_TRUE(queue.WaitForCompletion(NOT_IDLE));
+}

--- a/xbmc/utils/test/TestMime.cpp
+++ b/xbmc/utils/test/TestMime.cpp
@@ -27,3 +27,26 @@ TEST(TestMime, GetMimeType_CFileItem)
   varstr = CMime::GetMimeType(item);
   EXPECT_STREQ(refstr.c_str(), varstr.c_str());
 }
+
+TEST(TestMime, GetMimeType_imageExtensions)
+{
+  // CTextureCacheJob takes the type of a remote image from its extension rather than asking the
+  // source for it, so these have to be what the source would have answered - an image decoder
+  // addon is chosen by an exact match on the type, and "image/jpg" is not a type anything uses
+  EXPECT_EQ("image/jpeg", CMime::GetMimeType("jpg"));
+  EXPECT_EQ("image/jpeg", CMime::GetMimeType("jpeg"));
+  EXPECT_EQ("image/tiff", CMime::GetMimeType("tif"));
+  EXPECT_EQ("image/tiff", CMime::GetMimeType("tiff"));
+  EXPECT_EQ("image/png", CMime::GetMimeType("png"));
+  EXPECT_EQ("image/webp", CMime::GetMimeType("webp"));
+  EXPECT_EQ("image/heic", CMime::GetMimeType("heic"));
+
+  // Kodi's own thumbnail extensions say nothing about the contents, so the source is still asked
+  EXPECT_EQ("", CMime::GetMimeType("tbn"));
+  EXPECT_EQ("", CMime::GetMimeType("dds"));
+
+  // An extension whose type isn't an image, so an image served under one has to be asked about
+  // rather than taken at its name
+  EXPECT_EQ("text/asp", CMime::GetMimeType("asp"));
+  EXPECT_EQ("text/html", CMime::GetMimeType("html"));
+}

--- a/xbmc/video/CMakeLists.txt
+++ b/xbmc/video/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES Bookmark.cpp
             VideoGeneratedImageFileLoader.cpp
             VideoInfoDownloader.cpp
             VideoInfoScanner.cpp
+            VideoInfoScannerArt.cpp
             VideoInfoTag.cpp
             VideoItemArtworkHandler.cpp
             VideoLibraryQueue.cpp
@@ -42,6 +43,7 @@ set(HEADERS Bookmark.h
             VideoGeneratedImageFileLoader.h
             VideoInfoDownloader.h
             VideoInfoScanner.h
+            VideoInfoScannerArt.h
             VideoInfoTag.h
             VideoItemArtworkHandler.h
             VideoLibraryQueue.h

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -18,6 +18,7 @@
 #include "URL.h"
 #include "Util.h"
 #include "VideoInfoScanner.h"
+#include "VideoInfoScannerArt.h"
 #include "XBDateTime.h"
 #include "addons/AddonManager.h"
 #include "dbwrappers/dataset.h"
@@ -11621,7 +11622,7 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
 
     // An import takes all of its information from local files, so honour the same setting as a
     // local scraper does and do not retrieve remote art when it is set
-    using UseRemoteArt = CVideoInfoScanner::UseRemoteArtWithLocalScraper;
+    using UseRemoteArt = CVideoInfoScannerArt::UseRemoteArtWithLocalScraper;
     const UseRemoteArt useRemoteArt{CServiceBroker::GetSettingsComponent()
                                             ->GetAdvancedSettings()
                                             ->m_bNoRemoteArtWithLocalScraper
@@ -11772,9 +11773,9 @@ void CVideoDatabase::ImportFromXML(const std::string &path)
         // season artwork
         KODI::ART::SeasonsArtwork seasonArt;
         artItem.GetVideoInfoTag()->m_strPath = artPath;
-        CVideoInfoScanner::GetSeasonThumbs(*artItem.GetVideoInfoTag(), seasonArt,
-                                           CVideoThumbLoader::GetArtTypes(MediaTypeSeason), true,
-                                           useRemoteArt, &regexpCache);
+        CVideoInfoScannerArt::GetSeasonThumbs(*artItem.GetVideoInfoTag(), seasonArt,
+                                              CVideoThumbLoader::GetArtTypes(MediaTypeSeason), true,
+                                              useRemoteArt, &regexpCache);
         for (const auto& [seasonNumber, art] : seasonArt)
         {
           const int seasonID = AddSeason(showID, seasonNumber);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -294,6 +294,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
       CLog::Log(LOGINFO, "VideoInfoScanner: Finished scan. Scanning for video info took {} ms",
                 duration.count());
+
+      // Deliberately after the scan is timed and the library is browsable, so that fetching the
+      // art doesn't hold either back
+      m_art.FlushDeferred();
     }
     catch (...)
     {
@@ -1690,8 +1694,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
             useLocal && !item->IsPlugin(), useRemoteArt, &m_regexpCache);
         for (const auto& [season, art] : seasonArt)
         {
-          for (const auto& url : art | std::views::values)
-            m_art.Cache(url);
+          m_art.Cache(art);
 
           const int seasonID{m_database.AddSeason(static_cast<int>(showID), season)};
           m_database.SetArtForItem(seasonID, MediaTypeSeason, art);
@@ -2210,8 +2213,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
               movieDetails, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason),
               useLocal && !pItem->IsPlugin(), useRemoteArt, &m_regexpCache);
           for (const auto& seasonArtwork : seasonArt | std::views::values)
-            for (const auto& url : seasonArtwork | std::views::values)
-              m_art.Cache(url);
+            m_art.Cache(seasonArtwork);
         }
 
         lResult = m_database.SetDetailsForTvShow(multipath, movieDetails, art, seasonArt);

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -14,8 +14,6 @@
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "SetInfoTag.h"
-#include "TextureCache.h"
-#include "TextureCacheJob.h"
 #include "URL.h"
 #include "Util.h"
 #include "VideoInfoDownloader.h"
@@ -32,7 +30,6 @@
 #include "filesystem/StackDirectory.h"
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
-#include "imagefiles/ImageFileURL.h"
 #include "interfaces/AnnouncementManager.h"
 #include "messaging/helpers/DialogHelper.h"
 #include "messaging/helpers/DialogOKHelper.h"
@@ -143,119 +140,12 @@ const char* SimilarVideoScanActionToStr(SimilarVideoScanAction action)
  \return "poster" if the aspect ratio is at most 4:5, "banner" if the aspect ratio
          is at least 1:4, "thumb" otherwise.
  */
-std::string GetArtTypeFromSize(unsigned int width, unsigned int height)
-{
-  std::string type = "thumb";
-  if (width * 5 < height * 4)
-    type = "poster";
-  else if (width > height * 4)
-    type = "banner";
-  return type;
-}
-
-void AddLocalItemArtwork(KODI::ART::Artwork& itemArt,
-                         const std::vector<std::string>& wantedArtTypes,
-                         const std::string& itemPath,
-                         bool addAll,
-                         bool exactName,
-                         bool isInFolder)
-{
-  std::string path = URIUtils::GetDirectory(itemPath);
-  if (path.empty())
-    return;
-
-  CFileItemList availableArtFiles;
-  CDirectory::GetDirectory(path, availableArtFiles,
-                           CServiceBroker::GetFileExtensionProvider().GetPictureExtensions(),
-                           DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
-
-  std::string baseFilename{URIUtils::GetFileName(itemPath)};
-  if (!baseFilename.empty())
-  {
-    URIUtils::RemoveExtension(baseFilename);
-    baseFilename.append("-");
-  }
-
-  const bool caseSensitive{
-      CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_caseSensitiveLocalArtMatch};
-
-  for (const auto& artFile : availableArtFiles)
-  {
-    std::string candidate{URIUtils::GetFileName(artFile->GetPath())};
-
-    bool matchesFilename{!baseFilename.empty() &&
-                         (caseSensitive ? StringUtils::StartsWith(candidate, baseFilename)
-                                        : StringUtils::StartsWithNoCase(candidate, baseFilename))};
-
-    if (!baseFilename.empty() && !matchesFilename && !isInFolder)
-      continue;
-
-    if (matchesFilename)
-      candidate.erase(0, baseFilename.length());
-    URIUtils::RemoveExtension(candidate);
-    StringUtils::ToLower(candidate);
-
-    // move 'folder' to thumb / poster / banner based on aspect ratio
-    // if such artwork doesn't already exist
-    if (!matchesFilename && StringUtils::EqualsNoCase(candidate, "folder") &&
-        !CVideoThumbLoader::IsArtTypeInWhitelist("folder", wantedArtTypes, exactName))
-    {
-      // cache the image to determine sizing
-      CTextureDetails details;
-      if (CServiceBroker::GetTextureCache()->CacheImage(artFile->GetPath(), details))
-      {
-        candidate = GetArtTypeFromSize(details.width, details.height);
-        if (itemArt.contains(candidate))
-          continue;
-      }
-    }
-
-    if ((addAll && CVideoThumbLoader::IsValidArtType(candidate)) ||
-        CVideoThumbLoader::IsArtTypeInWhitelist(candidate, wantedArtTypes, exactName))
-    {
-      itemArt[candidate] = artFile->GetPath();
-    }
-  }
-}
 
 void OnDirectoryScanned(const std::string& strDirectory)
 {
   CGUIMessage msg(GUI_MSG_DIRECTORY_SCANNED, 0, 0, 0);
   msg.SetStringParam(strDirectory);
   CServiceBroker::GetGUI()->GetWindowManager().SendThreadMessage(msg);
-}
-
-void CacheArtwork(const std::string& url,
-                  bool retrieveArtDuringScrape,
-                  const std::string& knownHash = "")
-{
-  if (url.empty())
-    return;
-
-  const auto& textureCache = CServiceBroker::GetTextureCache();
-  if (!retrieveArtDuringScrape)
-  {
-    textureCache->BackgroundCacheImage(url, knownHash);
-    return;
-  }
-
-  bool needsRecaching{false};
-  if (!textureCache->CheckCachedImage(url, needsRecaching).empty() && !needsRecaching)
-    return; // already cached
-
-  // Fetch art or recache as needed
-  // This will be slow, but that is the point of the setting - to get the art during scraping
-  constexpr int MAX_SYNC_CACHE_ATTEMPTS = 3;
-  for (int attempt = 1; attempt <= MAX_SYNC_CACHE_ATTEMPTS; ++attempt)
-  {
-    if (!textureCache->CacheImage(url, knownHash).empty())
-      return; // succeeded
-  }
-
-  // Synchronous fetch failed after several attempts (network timeout, etc.)
-  // Fall back to the resilient background path.
-  textureCache->BackgroundCacheImage(url, knownHash);
-  CLog::LogF(LOGDEBUG, "Synchronous art caching for {} failed", url);
 }
 
 } // namespace
@@ -273,8 +163,6 @@ CVideoInfoScanner::CVideoInfoScanner()
   m_similarVideoAction = static_cast<SimilarVideoScanAction>(
       settings->GetInt(CSettings::SETTING_VIDEOLIBRARY_SIMILARVIDEOACTION));
   m_ignoreVideoExtras = settings->GetBool(CSettings::SETTING_VIDEOLIBRARY_IGNOREVIDEOEXTRAS);
-  m_artRetrievalTiming = static_cast<ArtRetrievalTiming>(
-      settings->GetInt(CSettings::SETTING_VIDEOLIBRARY_ARTRETRIEVALTIMING));
 }
 
 CVideoInfoScanner::~CVideoInfoScanner()
@@ -863,7 +751,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
       // Look for local art files first
       const std::vector<std::string> movieSetArtTypes =
           CVideoThumbLoader::GetArtTypes(MediaTypeVideoCollection);
-      AddLocalItemArtwork(movieSetArt, movieSetArtTypes, movieSetInfoPath, true, false, true);
+      ART::AddLocalItemArtwork(movieSetArt, movieSetArtTypes, movieSetInfoPath, true, false, true);
 
       // If art specified in set.nfo use that next
       if (movieSetArt.empty() && tag.m_set.HasArt())
@@ -1793,16 +1681,17 @@ CVideoInfoScanner::~CVideoInfoScanner()
           loader.GetArtwork(tag); // Can alter other fields in the tag
           showInfo.m_strPictureURL = tag.m_strPictureURL; // We only want artwork
         }
-        const UseRemoteArtWithLocalScraper useRemoteArt{
+        const CVideoInfoScannerArt::UseRemoteArtWithLocalScraper useRemoteArt{
             scraper->ID() == "metadata.local" && m_advancedSettings->m_bNoRemoteArtWithLocalScraper
-                ? UseRemoteArtWithLocalScraper::NO
-                : UseRemoteArtWithLocalScraper::YES};
-        GetSeasonThumbs(showInfo, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason),
-                        useLocal && !item->IsPlugin(), useRemoteArt, &m_regexpCache);
+                ? CVideoInfoScannerArt::UseRemoteArtWithLocalScraper::NO
+                : CVideoInfoScannerArt::UseRemoteArtWithLocalScraper::YES};
+        CVideoInfoScannerArt::GetSeasonThumbs(
+            showInfo, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason),
+            useLocal && !item->IsPlugin(), useRemoteArt, &m_regexpCache);
         for (const auto& [season, art] : seasonArt)
         {
           for (const auto& url : art | std::views::values)
-            CacheArtwork(url, m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS);
+            m_art.Cache(url);
 
           const int seasonID{m_database.AddSeason(static_cast<int>(showID), season)};
           m_database.SetArtForItem(seasonID, MediaTypeSeason, art);
@@ -2127,10 +2016,10 @@ CVideoInfoScanner::~CVideoInfoScanner()
     const ContentType content{
         !scraper || contentOverride != ContentType::NONE ? contentOverride : scraper->Content()};
     const bool usingLocalScraper{!scraper || scraper->ID() == "metadata.local"};
-    const UseRemoteArtWithLocalScraper useRemoteArt{
+    const CVideoInfoScannerArt::UseRemoteArtWithLocalScraper useRemoteArt{
         usingLocalScraper && m_advancedSettings->m_bNoRemoteArtWithLocalScraper
-            ? UseRemoteArtWithLocalScraper::NO
-            : UseRemoteArtWithLocalScraper::YES};
+            ? CVideoInfoScannerArt::UseRemoteArtWithLocalScraper::NO
+            : CVideoInfoScannerArt::UseRemoteArtWithLocalScraper::YES};
 
     std::string path{pItem->GetDynPath()};
     const int playlist{pItem->GetProperty("bluray_playlist").asInteger32(-1)};
@@ -2146,9 +2035,9 @@ CVideoInfoScanner::~CVideoInfoScanner()
     }
 
     if (!libraryImport)
-      GetArtwork(pItem, content, videoFolder, useLocal && !pItem->IsPlugin(),
-                 showInfo ? URIUtils::AddFileToFolder(showInfo->m_strPath, ".actors") : "",
-                 useRemoteArt);
+      m_art.GetArtwork(pItem, content, videoFolder, useLocal && !pItem->IsPlugin(),
+                       showInfo ? URIUtils::AddFileToFolder(showInfo->m_strPath, ".actors") : "",
+                       useRemoteArt);
 
     // ensure the art map isn't completely empty by specifying an empty thumb
     KODI::ART::Artwork art = pItem->GetArt();
@@ -2210,7 +2099,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
         movieDetails.m_strTrailer = strTrailer;
 
       // Remove remote set art (if need)
-      if (useRemoteArt == UseRemoteArtWithLocalScraper::NO)
+      if (useRemoteArt == CVideoInfoScannerArt::UseRemoteArtWithLocalScraper::NO)
         std::erase_if(art,
                       [](const auto& artItem)
                       {
@@ -2317,11 +2206,12 @@ CVideoInfoScanner::~CVideoInfoScanner()
 
         if (!libraryImport)
         {
-          GetSeasonThumbs(movieDetails, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason),
-                          useLocal && !pItem->IsPlugin(), useRemoteArt, &m_regexpCache);
+          CVideoInfoScannerArt::GetSeasonThumbs(
+              movieDetails, seasonArt, CVideoThumbLoader::GetArtTypes(MediaTypeSeason),
+              useLocal && !pItem->IsPlugin(), useRemoteArt, &m_regexpCache);
           for (const auto& seasonArtwork : seasonArt | std::views::values)
             for (const auto& url : seasonArtwork | std::views::values)
-              CacheArtwork(url, m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS);
+              m_art.Cache(url);
         }
 
         lResult = m_database.SetDetailsForTvShow(multipath, movieDetails, art, seasonArt);
@@ -2375,22 +2265,6 @@ CVideoInfoScanner::~CVideoInfoScanner()
     CServiceBroker::GetAnnouncementManager()->Announce(ANNOUNCEMENT::VideoLibrary, "OnUpdate",
                                                        itemCopy, data);
     return lResult;
-  }
-
-  std::string ContentToMediaType(ContentType content, bool folder)
-  {
-    switch (content)
-    {
-      using enum ContentType;
-      case MOVIES:
-        return MediaTypeMovie;
-      case MUSICVIDEOS:
-        return MediaTypeMusicVideo;
-      case TVSHOWS:
-        return folder ? MediaTypeTvShow : MediaTypeEpisode;
-      default:
-        return "";
-    }
   }
 
   VideoDbContentType ContentToVideoDbType(ContentType content)
@@ -2455,180 +2329,6 @@ CVideoInfoScanner::~CVideoInfoScanner()
         setTitle,
         CURL::GetRedacted(path));
     return CDirectory::Exists(path) ? path : "";
-  }
-
-  void CVideoInfoScanner::GetArtwork(CFileItem* pItem,
-                                     ContentType content,
-                                     bool bApplyToDir,
-                                     bool useLocal,
-                                     const std::string& actorArtPath,
-                                     UseRemoteArtWithLocalScraper useRemoteArt /* = yes */) const
-  {
-    int artLevel = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-        CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL);
-    if (artLevel == CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_NONE)
-      return;
-
-    CVideoInfoTag &movieDetails = *pItem->GetVideoInfoTag();
-    movieDetails.m_fanart.Unpack();
-    movieDetails.m_strPictureURL.Parse();
-
-    KODI::ART::Artwork art = pItem->GetArt();
-
-    // get and cache thumb images
-    std::string mediaType = ContentToMediaType(content, pItem->IsFolder());
-    std::vector<std::string> artTypes = CVideoThumbLoader::GetArtTypes(mediaType);
-    bool moviePartOfSet = content == ContentType::MOVIES && movieDetails.m_set.HasTitle();
-    std::vector<std::string> movieSetArtTypes;
-    if (moviePartOfSet)
-    {
-      movieSetArtTypes = CVideoThumbLoader::GetArtTypes(MediaTypeVideoCollection);
-      for (const std::string& artType : movieSetArtTypes)
-        artTypes.push_back("set." + artType);
-    }
-    bool addAll = artLevel == CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_ALL;
-    bool exactName = artLevel == CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_BASIC;
-    // find local art
-    if (useLocal)
-    {
-      if (!pItem->SkipLocalArt())
-      {
-        bool useFolder = false;
-        if (bApplyToDir && (content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS))
-        {
-          std::string filename = ART::GetLocalArtBaseFilename(*pItem, useFolder);
-          std::string directory = URIUtils::GetDirectory(filename);
-          if (filename != directory)
-            AddLocalItemArtwork(art, artTypes, filename, addAll, exactName, bApplyToDir);
-        }
-
-        // Reset useFolder to false as GetLocalArtBaseFilename may modify it in
-        // the previous call.
-        useFolder = false;
-
-        std::string path;
-        if (content == ContentType::TVSHOWS)
-        {
-          path = ART::GetLocalArtBaseFilename(*pItem, useFolder,
-                                              pItem->GetProperty(MULTIPLE_EPISODES).asBoolean(false)
-                                                  ? ART::AdditionalIdentifiers::SEASON_AND_EPISODE
-                                                  : ART::AdditionalIdentifiers::NONE);
-        }
-        else if (content == ContentType::MOVIE_VERSIONS ||
-                 (pItem->HasVideoVersions() &&
-                  pItem->GetProperty("bluray_playlist").asInteger32(-1) > -1))
-        {
-          // Add playlist identifier only when there are multiple versions of the movie on the same disc
-          path =
-              ART::GetLocalArtBaseFilename(*pItem, useFolder, ART::AdditionalIdentifiers::PLAYLIST);
-        }
-        else
-          path = ART::GetLocalArtBaseFilename(*pItem, useFolder);
-        AddLocalItemArtwork(art, artTypes, path, addAll, exactName, bApplyToDir);
-      }
-
-      if (moviePartOfSet)
-      {
-        std::string movieSetInfoPath = GetMovieSetInfoFolder(movieDetails.m_set.GetTitle());
-        if (!movieSetInfoPath.empty())
-        {
-          KODI::ART::Artwork movieSetArt;
-          AddLocalItemArtwork(movieSetArt, movieSetArtTypes, movieSetInfoPath, addAll, exactName,
-                              true);
-          for (const auto& artItem : movieSetArt)
-          {
-            art["set." + artItem.first] = artItem.second;
-          }
-        }
-      }
-    }
-
-    // find embedded art
-    if (pItem->HasVideoInfoTag() && !pItem->GetVideoInfoTag()->m_coverArt.empty())
-    {
-      for (auto& it : pItem->GetVideoInfoTag()->m_coverArt)
-      {
-        if ((addAll || CVideoThumbLoader::IsArtTypeInWhitelist(it.m_type, artTypes, exactName)) &&
-            !art.contains(it.m_type))
-        {
-          std::string thumb = IMAGE_FILES::URLFromFile(pItem->GetPath(), "video_" + it.m_type);
-          art.insert(std::make_pair(it.m_type, thumb));
-        }
-      }
-    }
-
-    // add online fanart (treated separately due to it being stored in m_fanart)
-    if ((addAll || CVideoThumbLoader::IsArtTypeInWhitelist("fanart", artTypes, exactName)) &&
-        !art.contains("fanart"))
-    {
-      std::string fanart = pItem->GetVideoInfoTag()->m_fanart.GetImageURL();
-      if (!fanart.empty() &&
-          !(useRemoteArt == UseRemoteArtWithLocalScraper::NO && URIUtils::IsRemote(fanart)))
-        art.insert(std::make_pair("fanart", fanart));
-    }
-
-    // add online art
-    for (const auto& url : pItem->GetVideoInfoTag()->m_strPictureURL.GetUrls())
-    {
-      if (url.m_type != CScraperUrl::UrlType::General)
-        continue;
-      std::string aspect = url.m_aspect;
-      if (aspect.empty())
-        // Backward compatibility with Kodi 11 Eden NFO files
-        aspect = mediaType == MediaTypeEpisode ? "thumb" : "poster";
-
-      if ((addAll || CVideoThumbLoader::IsArtTypeInWhitelist(aspect, artTypes, exactName)) &&
-          !art.contains(aspect))
-      {
-        std::string image = GetImage(url, pItem->GetPath());
-        if (!image.empty() &&
-            !(useRemoteArt == UseRemoteArtWithLocalScraper::NO && URIUtils::IsRemote(image)))
-          art.insert(std::make_pair(aspect, image));
-      }
-    }
-
-    if (!art.contains("thumb") &&
-        CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-            CSettings::SETTING_MYVIDEOS_EXTRACTTHUMB) &&
-        CDVDFileInfo::CanExtract(*pItem))
-    {
-      art["thumb"] = CVideoThumbLoader::GetEmbeddedThumbURL(*pItem);
-    }
-
-    for (const auto& artType : artTypes)
-      if (art.contains(artType))
-        CacheArtwork(art.at(artType), m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS);
-
-    pItem->SetArt(art);
-
-    // parent folder to apply the thumb to and to search for local actor thumbs
-    std::string parentDir = URIUtils::GetParentPath(pItem->GetPath());
-    if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
-            CSettings::SETTING_VIDEOLIBRARY_ACTORTHUMBS))
-    {
-      // .actors sits alongside the nfo, so for a disc folder it is in BDMV/VIDEO_TS
-      const std::string mediaDir{URIUtils::IsOpticalMediaFile(pItem->GetPath())
-                                     ? URIUtils::GetDirectory(pItem->GetPath())
-                                     : parentDir};
-      FetchActorThumbs(movieDetails.m_cast,
-                       actorArtPath.empty() ? URIUtils::AddFileToFolder(mediaDir, ".actors")
-                                            : actorArtPath,
-                       useRemoteArt);
-    }
-    if (bApplyToDir)
-      ApplyThumbToFolder(parentDir, art["thumb"]);
-  }
-
-  std::string CVideoInfoScanner::GetImage(const CScraperUrl::SUrlEntry &image, const std::string& itemPath)
-  {
-    std::string thumb = CScraperUrl::GetThumbUrl(image);
-    if (!thumb.empty() && thumb.find('/') == std::string::npos &&
-        thumb.find('\\') == std::string::npos)
-    {
-      std::string strPath = URIUtils::GetDirectory(itemPath);
-      thumb = URIUtils::AddFileToFolder(strPath, thumb);
-    }
-    return thumb;
   }
 
   CInfoScanner::InfoRet CVideoInfoScanner::OnProcessSeriesFolder(
@@ -2931,17 +2631,6 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return false; // no info found, or cancelled
   }
 
-  void CVideoInfoScanner::ApplyThumbToFolder(const std::string &folder, const std::string &imdbThumb)
-  {
-    // copy icon to folder also;
-    if (!imdbThumb.empty())
-    {
-      CFileItem folderItem(folder, true);
-      CThumbLoader loader;
-      loader.SetCachedImage(folderItem, "thumb", imdbThumb);
-    }
-  }
-
   int CVideoInfoScanner::GetPathHash(const CFileItemList &items, std::string &hash)
   {
     // Create a hash based on the filenames, filesize and filedate.  Also count the number of files
@@ -3091,142 +2780,6 @@ CVideoInfoScanner::~CVideoInfoScanner()
     return "";
   }
 
-  void CVideoInfoScanner::GetSeasonThumbs(const CVideoInfoTag& show,
-                                          KODI::ART::SeasonsArtwork& seasonArt,
-                                          const std::vector<std::string>& artTypes,
-                                          bool useLocal /* = true */,
-                                          UseRemoteArtWithLocalScraper useRemoteArt /* = yes */,
-                                          KODI::REGEXP::RegExpCache* cache /* = nullptr*/)
-  {
-    int artLevel = CServiceBroker::GetSettingsComponent()->GetSettings()->
-      GetInt(CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL);
-    bool addAll = artLevel == CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_ALL;
-    bool exactName = artLevel == CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_BASIC;
-    if (useLocal)
-    {
-      // find the maximum number of seasons we have local thumbs for
-      int maxSeasons = 0;
-      CFileItemList items;
-      std::string extensions = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
-      if (!show.m_strPath.empty())
-      {
-        CDirectory::GetDirectory(show.m_strPath, items, extensions,
-                                 DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE |
-                                     DIR_FLAG_NO_FILE_INFO);
-      }
-      extensions.erase(std::remove(extensions.begin(), extensions.end(), '.'), extensions.end());
-      std::shared_ptr<CRegExp> reg;
-      const std::string pattern = "season([0-9]+)(-[a-z0-9]+)?\\.(" + extensions + ")";
-      if (!items.IsEmpty() && (reg = KODI::REGEXP::GetRegExp(pattern, cache)) != nullptr)
-      {
-        for (const auto& item : items)
-        {
-          std::string name = URIUtils::GetFileName(item->GetPath());
-          if (reg->RegFind(name) > -1)
-          {
-            int season = atoi(reg->GetMatch(1).c_str());
-            if (season > maxSeasons)
-              maxSeasons = season;
-          }
-        }
-      }
-      for (int season = -1; season <= maxSeasons; season++)
-      {
-        // Look for local art irrespective of scraper/existing art as it takes priority
-        KODI::ART::Artwork art;
-        std::string basePath;
-        if (season == -1)
-          basePath = "season-all";
-        else if (season == 0)
-          basePath = "season-specials";
-        else
-          basePath = StringUtils::Format("season{:02}", season);
-
-        AddLocalItemArtwork(art, artTypes, URIUtils::AddFileToFolder(show.m_strPath, basePath),
-                            addAll, exactName, false);
-
-        seasonArt[season] = art;
-      }
-    }
-    // add online art
-    for (const auto& url : show.m_strPictureURL.GetUrls())
-    {
-      if (url.m_type != CScraperUrl::UrlType::Season)
-        continue;
-      std::string aspect = url.m_aspect;
-      if (aspect.empty())
-        aspect = "thumb";
-      KODI::ART::Artwork& art = seasonArt[url.m_season];
-      if ((addAll || CVideoThumbLoader::IsArtTypeInWhitelist(aspect, artTypes, exactName)) &&
-          !art.contains(aspect))
-      {
-        std::string image = CScraperUrl::GetThumbUrl(url);
-        if (!image.empty() &&
-            !(useRemoteArt == UseRemoteArtWithLocalScraper::NO && URIUtils::IsRemote(image)))
-          art.insert(std::make_pair(aspect, image));
-      }
-    }
-  }
-
-  void CVideoInfoScanner::FetchActorThumbs(
-      std::vector<SActorInfo>& actors,
-      const std::string& actorsDir,
-      UseRemoteArtWithLocalScraper useRemoteArt /* = YES */) const
-  {
-    CFileItemList items;
-    // don't try to fetch anything local with plugin source
-    if (!URIUtils::IsPlugin(actorsDir) && CDirectory::Exists(actorsDir))
-      CDirectory::GetDirectory(actorsDir, items, ".png|.jpg|.tbn", DIR_FLAG_NO_FILE_DIRS);
-
-    // Index the thumbs by filename (without extension), and the hashes taken from the directory
-    // listing by url
-    std::map<std::string, std::string> thumbs;
-    std::map<std::string, std::string> listedHashes;
-    for (const auto& item : items)
-    {
-      if (item->IsFolder())
-        continue;
-
-      std::string name{URIUtils::GetFileName(item->GetPath())};
-      URIUtils::RemoveExtension(name);
-      thumbs.try_emplace(std::move(name), item->GetPath());
-      if (std::string hash{CTextureCacheJob::GetImageHash(*item)}; !hash.empty())
-        listedHashes.emplace(item->GetPath(), std::move(hash));
-    }
-
-    for (auto& actor : actors)
-    {
-      if (actor.thumb.empty())
-      {
-        // Must match how the name is turned into a filename when exporting (see
-        // CVideoDatabase::GetSafeFile()), or an actor whose name contains a character that is not
-        // legal in a filename (ie. a trailing '.') can never be matched to their own exported thumb
-        std::string thumbFile = actor.strName;
-        StringUtils::Replace(thumbFile, ' ', '_');
-        thumbFile = CUtil::MakeLegalFileName(std::move(thumbFile));
-        if (const auto thumb{thumbs.find(thumbFile)}; thumb != thumbs.end())
-          actor.thumb = thumb->second;
-        if (!actor.thumbUrl.GetFirstUrlByType().m_url.empty())
-        {
-          const std::string thumb{CScraperUrl::GetThumbUrl(actor.thumbUrl.GetFirstUrlByType())};
-          const bool notUsingThisRemoteArt{useRemoteArt == UseRemoteArtWithLocalScraper::NO &&
-                                           URIUtils::IsRemote(thumb)};
-          if (actor.thumb.empty() && !notUsingThisRemoteArt)
-            actor.thumb = thumb;
-          if (notUsingThisRemoteArt)
-            actor.thumbUrl.Clear();
-        }
-      }
-    }
-
-    for (const auto& actor : actors)
-    {
-      const auto hash{listedHashes.find(actor.thumb)};
-      CacheArtwork(actor.thumb, m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS,
-                   hash != listedHashes.end() ? hash->second : std::string{});
-    }
-  }
-
   bool CVideoInfoScanner::DownloadFailed(CGUIDialogProgress* pDialog)
   {
     if (CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_bVideoScannerIgnoreErrors)
@@ -3325,7 +2878,7 @@ CVideoInfoScanner::~CVideoInfoScanner()
                         CURL::GetRedacted(item->GetPath()));
             }
 
-            GetArtwork(item.get(), content, true, true, "");
+            m_art.GetArtwork(item.get(), content, true, true, "");
 
             if (m_database.AddVideoAsset(ContentToVideoDbType(content), dbId, idVideoAssetType,
                                          VideoAssetType::EXTRA, *item.get()))

--- a/xbmc/video/VideoInfoScanner.h
+++ b/xbmc/video/VideoInfoScanner.h
@@ -13,8 +13,8 @@
 #include "VideoManagerTypes.h"
 #include "addons/Scraper.h"
 #include "settings/VideoVersionsSettings.h"
-#include "utils/Artwork.h"
 #include "utils/RegExp.h"
+#include "video/VideoInfoScannerArt.h"
 
 #include <atomic>
 #include <cstdint>
@@ -56,14 +56,22 @@ namespace KODI::VIDEO
   class CVideoInfoScanner : public CInfoScanner
   {
   public:
-    enum class UseRemoteArtWithLocalScraper : bool
-    {
-      NO,
-      YES
-    };
-
     CVideoInfoScanner();
     ~CVideoInfoScanner() override;
+
+    /*! \brief Retrieve any artwork associated with an item
+     \sa CVideoInfoScannerArt::GetArtwork
+     */
+    void GetArtwork(CFileItem* pItem,
+                    ADDON::ContentType content,
+                    bool bApplyToDir = false,
+                    bool useLocal = true,
+                    const std::string& actorArtPath = "",
+                    CVideoInfoScannerArt::UseRemoteArtWithLocalScraper useRemoteArt =
+                        CVideoInfoScannerArt::UseRemoteArtWithLocalScraper::YES) const
+    {
+      m_art.GetArtwork(pItem, content, bApplyToDir, useLocal, actorArtPath, useRemoteArt);
+    }
 
     /*! \brief Scan a folder using the background scanner
      \param strDirectory path to scan
@@ -114,7 +122,6 @@ namespace KODI::VIDEO
                            bool fetchEpisodes = true,
                            CGUIDialogProgress* pDlgProgress = nullptr);
 
-    static void ApplyThumbToFolder(const std::string &folder, const std::string &imdbThumb);
     static bool DownloadFailed(CGUIDialogProgress* pDlgProgress);
 
     /*! \brief Update the set information from a SET.NFO in the Movie Set Information Folder
@@ -122,39 +129,6 @@ namespace KODI::VIDEO
      \param tag     info tag
      */
     static bool UpdateSetInTag(CVideoInfoTag& tag);
-
-    /*! \brief Retrieve any artwork associated with an item
-     \param pItem item to find artwork for.
-     \param content content type of the item.
-     \param bApplyToDir whether we should apply any thumbs to a folder.  Defaults to false.
-     \param useLocal whether we should use local thumbs. Defaults to true.
-     \param actorArtPath the directory containing actor thumbs. Defaults to empty.
-     \param useRemoteArt use remote art if also using local scraper. Defaults to yes.
-     */
-    void GetArtwork(
-        CFileItem* pItem,
-        ADDON::ContentType content,
-        bool bApplyToDir = false,
-        bool useLocal = true,
-        const std::string& actorArtPath = "",
-        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES) const;
-
-    /*! \brief Get season thumbs for a tvshow.
-     All seasons (regardless of whether the user has episodes) are added to the art map.
-     \param[in] show     tvshow info tag
-     \param[in] art      artwork map to which season thumbs are added.
-     \param[in] useLocal whether to use local thumbs, defaults to true
-     \param[in] useRemoteArt use remote art if also using local scraper. Defaults to yes.
-     \param[in] cache regexp cache to avoid repeated compilations
-     */
-    static void GetSeasonThumbs(
-        const CVideoInfoTag& show,
-        KODI::ART::SeasonsArtwork& art,
-        const std::vector<std::string>& artTypes,
-        bool useLocal = true,
-        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES,
-        KODI::REGEXP::RegExpCache* cache = nullptr);
-    static std::string GetImage(const CScraperUrl::SUrlEntry &image, const std::string& itemPath);
 
     static std::string GetMovieSetInfoFolder(const std::string& setTitle);
 
@@ -254,18 +228,6 @@ namespace KODI::VIDEO
      \return true on success (1 match), false on failure (no matches)
      */
     bool GetEpisodeTitleFromRegExp(CRegExp& reg, EPISODE& episodeInfo);
-
-    /*! \brief Fetch thumbs for actors
-     Updates each actor with their thumb (local or online)
-     \param actors - vector of SActorInfo
-     \param actorsDir - directory holding the local thumbs (ie. a .actors folder, or the actors
-            folder of a library export). Used as given, nothing is appended.
-     \param useRemoteArt - use remote art (ie. http://) even if derived from local .nfo file. Defaults to yes.
-     */
-    void FetchActorThumbs(
-        std::vector<SActorInfo>& actors,
-        const std::string& actorsDir,
-        UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES) const;
 
     static int GetPathHash(const CFileItemList &items, std::string &hash);
 
@@ -376,17 +338,13 @@ namespace KODI::VIDEO
     //! Whether the folder a movie is in names it (the scraper's "movies are in separate folders")
     bool m_useFolderNames{false};
 
-    enum class ArtRetrievalTiming : uint8_t
-    {
-      SYNCHRONOUS = 0, //!< retrieve art synchronously during scrape
-      BACKGROUND = 1 //!< retrieve art in background after scrape
-    };
-
-    ArtRetrievalTiming m_artRetrievalTiming{ArtRetrievalTiming::BACKGROUND};
     CVideoDatabase m_database;
     std::set<int> m_pathsToClean;
     std::shared_ptr<CAdvancedSettings> m_advancedSettings;
     CVideoDatabase::ScraperCache m_scraperCache;
+
+    //! The artwork side of the scan
+    CVideoInfoScannerArt m_art;
 
   private:
     /*!

--- a/xbmc/video/VideoInfoScannerArt.cpp
+++ b/xbmc/video/VideoInfoScannerArt.cpp
@@ -74,6 +74,26 @@ void CacheArtwork(const std::string& url,
   CLog::LogF(LOGDEBUG, "Synchronous art caching for {} failed", url);
 }
 
+//! \brief Drop the empty and duplicate urls from a set of artwork. Order is not preserved.
+void DedupeArt(std::vector<KODI::VIDEO::ArtToCache>& art)
+{
+  using KODI::VIDEO::ArtToCache;
+
+  std::erase_if(art, [](const ArtToCache& a) { return a.url.empty(); });
+
+  // Where the same url appears more than once, order the copy kept below first: the one seen
+  // earliest, and of those the one with a hash already known, which saves a stat
+  std::ranges::sort(art,
+                    [](const ArtToCache& a, const ArtToCache& b)
+                    {
+                      if (a.url != b.url)
+                        return a.url < b.url;
+                      if (a.priority != b.priority)
+                        return a.priority < b.priority;
+                      return !a.hash.empty() && b.hash.empty();
+                    });
+  art.erase(std::ranges::begin(std::ranges::unique(art, {}, &ArtToCache::url)), art.end());
+}
 std::string ContentToMediaType(ContentType content, bool folder)
 {
   switch (content)
@@ -101,9 +121,88 @@ CVideoInfoScannerArt::CVideoInfoScannerArt()
           CSettings::SETTING_VIDEOLIBRARY_ARTRETRIEVALTIMING));
 }
 
+CVideoInfoScannerArt::~CVideoInfoScannerArt()
+{
+  FlushDeferred();
+}
+
 void CVideoInfoScannerArt::Cache(const std::string& url, const std::string& knownHash) const
 {
   CacheArtwork(url, m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS, knownHash);
+}
+
+void CVideoInfoScannerArt::Cache(const KODI::ART::Artwork& art) const
+{
+  std::vector<ArtToCache> artToCache;
+  artToCache.reserve(art.size());
+  for (const auto& [artType, url] : art)
+    artToCache.push_back({url, {}, PriorityOfArtType(artType)});
+
+  Cache(std::move(artToCache));
+}
+
+void CVideoInfoScannerArt::Cache(std::vector<ArtToCache> art) const
+{
+  DedupeArt(art);
+
+  if (m_artRetrievalTiming != ArtRetrievalTiming::SYNCHRONOUS)
+  {
+    for (auto& a : art)
+    {
+      // Get artwork that is immediately visible to the user first, and defer the rest for later
+      if (a.priority == ArtPriority::LIST)
+        CacheArtwork(a.url, false, a.hash);
+      else
+        m_deferredArt.push_back(std::move(a));
+    }
+    return;
+  }
+
+  // Synchronous so fetch all now
+  for (const auto& a : art)
+    CacheArtwork(a.url, true, a.hash);
+}
+
+void CVideoInfoScannerArt::FlushDeferred()
+{
+  DedupeArt(m_deferredArt);
+  if (m_deferredArt.empty())
+    return;
+
+  // Fetched in the order the user is likely to view it, rather than the order it was found in
+  std::ranges::stable_sort(m_deferredArt, {}, &ArtToCache::priority);
+
+  const auto count = [this](ArtPriority priority)
+  { return std::ranges::count(m_deferredArt, priority, &ArtToCache::priority); };
+
+  // Broken down by priority, as one image looks like any other by the time it is fetched
+  CLog::LogF(LOGDEBUG,
+             "Queueing {} images found during the scan for caching "
+             "({} list, {} background, {} detail, {} actor)",
+             m_deferredArt.size(), count(ArtPriority::LIST), count(ArtPriority::BACKGROUND),
+             count(ArtPriority::DETAIL), count(ArtPriority::ACTOR));
+
+  const auto& textureCache = CServiceBroker::GetTextureCache();
+  for (const auto& art : m_deferredArt)
+    textureCache->BackgroundCacheImage(art.url, art.hash);
+
+  m_deferredArt.clear();
+}
+
+ArtPriority PriorityOfArtType(std::string_view artType)
+{
+  // A movie's set art is shown wherever the movie's own is
+  if (artType.starts_with("set."))
+    artType.remove_prefix(4);
+
+  // Numbered, where a scraper offers more than one eg. "fanart2"
+  if (artType.starts_with("fanart"))
+    return ArtPriority::BACKGROUND;
+
+  if (artType == "poster" || artType == "thumb" || artType == "banner" || artType == "keyart")
+    return ArtPriority::LIST;
+
+  return ArtPriority::DETAIL;
 }
 
 void CVideoInfoScannerArt::GetArtwork(CFileItem* pItem,
@@ -245,9 +344,11 @@ void CVideoInfoScannerArt::GetArtwork(CFileItem* pItem,
     art["thumb"] = CVideoThumbLoader::GetEmbeddedThumbURL(*pItem);
   }
 
+  std::vector<ArtToCache> artToCache;
   for (const auto& artType : artTypes)
     if (art.contains(artType))
-      CacheArtwork(art.at(artType), m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS);
+      artToCache.push_back({art.at(artType), {}, PriorityOfArtType(artType)});
+  Cache(std::move(artToCache));
 
   pItem->SetArt(art);
 
@@ -421,12 +522,15 @@ void CVideoInfoScannerArt::FetchActorThumbs(
     }
   }
 
+  std::vector<ArtToCache> artToCache;
+  artToCache.reserve(actors.size());
   for (const auto& actor : actors)
   {
     const auto hash{listedHashes.find(actor.thumb)};
-    CacheArtwork(actor.thumb, m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS,
-                 hash != listedHashes.end() ? hash->second : std::string{});
+    artToCache.push_back({actor.thumb, hash != listedHashes.end() ? hash->second : std::string{},
+                          ArtPriority::ACTOR});
   }
+  Cache(std::move(artToCache));
 }
 
 } // namespace KODI::VIDEO

--- a/xbmc/video/VideoInfoScannerArt.cpp
+++ b/xbmc/video/VideoInfoScannerArt.cpp
@@ -1,0 +1,432 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "VideoInfoScannerArt.h"
+
+#include "FileItem.h"
+#include "FileItemList.h"
+#include "ServiceBroker.h"
+#include "TextureCache.h"
+#include "TextureCacheJob.h"
+#include "ThumbLoader.h"
+#include "Util.h"
+#include "cores/VideoPlayer/DVDFileInfo.h"
+#include "filesystem/Directory.h"
+#include "imagefiles/ImageFileURL.h"
+#include "settings/Settings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/ArtUtils.h"
+#include "utils/FileExtensionProvider.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+#include "video/VideoInfoScanner.h"
+#include "video/VideoInfoTag.h"
+#include "video/VideoThumbLoader.h"
+
+#include <algorithm>
+#include <map>
+#include <ranges>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace XFILE;
+using namespace ADDON;
+
+namespace
+{
+void CacheArtwork(const std::string& url,
+                  bool retrieveArtDuringScrape,
+                  const std::string& knownHash = "")
+{
+  if (url.empty())
+    return;
+
+  const auto& textureCache = CServiceBroker::GetTextureCache();
+  if (!retrieveArtDuringScrape)
+  {
+    textureCache->BackgroundCacheImage(url, knownHash);
+    return;
+  }
+
+  bool needsRecaching{false};
+  if (!textureCache->CheckCachedImage(url, needsRecaching).empty() && !needsRecaching)
+    return; // already cached
+
+  // Fetch art or recache as needed
+  // This will be slow, but that is the point of the setting - to get the art during scraping
+  constexpr int MAX_SYNC_CACHE_ATTEMPTS = 3;
+  for (int attempt = 1; attempt <= MAX_SYNC_CACHE_ATTEMPTS; ++attempt)
+  {
+    if (!textureCache->CacheImage(url, knownHash).empty())
+      return; // succeeded
+  }
+
+  // Synchronous fetch failed after several attempts (network timeout, etc.)
+  // Fall back to the resilient background path.
+  textureCache->BackgroundCacheImage(url, knownHash);
+  CLog::LogF(LOGDEBUG, "Synchronous art caching for {} failed", url);
+}
+
+std::string ContentToMediaType(ContentType content, bool folder)
+{
+  switch (content)
+  {
+    using enum ContentType;
+    case MOVIES:
+      return MediaTypeMovie;
+    case MUSICVIDEOS:
+      return MediaTypeMusicVideo;
+    case TVSHOWS:
+      return folder ? MediaTypeTvShow : MediaTypeEpisode;
+    default:
+      return "";
+  }
+}
+} // unnamed namespace
+
+namespace KODI::VIDEO
+{
+
+CVideoInfoScannerArt::CVideoInfoScannerArt()
+{
+  m_artRetrievalTiming =
+      static_cast<ArtRetrievalTiming>(CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+          CSettings::SETTING_VIDEOLIBRARY_ARTRETRIEVALTIMING));
+}
+
+void CVideoInfoScannerArt::Cache(const std::string& url, const std::string& knownHash) const
+{
+  CacheArtwork(url, m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS, knownHash);
+}
+
+void CVideoInfoScannerArt::GetArtwork(CFileItem* pItem,
+                                      ContentType content,
+                                      bool bApplyToDir,
+                                      bool useLocal,
+                                      const std::string& actorArtPath,
+                                      UseRemoteArtWithLocalScraper useRemoteArt /* = yes */) const
+{
+  int artLevel = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL);
+  if (artLevel == CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_NONE)
+    return;
+
+  CVideoInfoTag& movieDetails = *pItem->GetVideoInfoTag();
+  movieDetails.m_fanart.Unpack();
+  movieDetails.m_strPictureURL.Parse();
+
+  KODI::ART::Artwork art = pItem->GetArt();
+
+  // get and cache thumb images
+  std::string mediaType = ContentToMediaType(content, pItem->IsFolder());
+  std::vector<std::string> artTypes = CVideoThumbLoader::GetArtTypes(mediaType);
+  bool moviePartOfSet = content == ContentType::MOVIES && movieDetails.m_set.HasTitle();
+  std::vector<std::string> movieSetArtTypes;
+  if (moviePartOfSet)
+  {
+    movieSetArtTypes = CVideoThumbLoader::GetArtTypes(MediaTypeVideoCollection);
+    for (const std::string& artType : movieSetArtTypes)
+      artTypes.push_back("set." + artType);
+  }
+  bool addAll = artLevel == CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_ALL;
+  bool exactName = artLevel == CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_BASIC;
+  // find local art
+  if (useLocal)
+  {
+    if (!pItem->SkipLocalArt())
+    {
+      bool useFolder = false;
+      if (bApplyToDir && (content == ContentType::MOVIES || content == ContentType::MUSICVIDEOS))
+      {
+        std::string filename = ART::GetLocalArtBaseFilename(*pItem, useFolder);
+        std::string directory = URIUtils::GetDirectory(filename);
+        if (filename != directory)
+          ART::AddLocalItemArtwork(art, artTypes, filename, addAll, exactName, bApplyToDir);
+      }
+
+      // Reset useFolder to false as GetLocalArtBaseFilename may modify it in
+      // the previous call.
+      useFolder = false;
+
+      std::string path;
+      if (content == ContentType::TVSHOWS)
+      {
+        path = ART::GetLocalArtBaseFilename(*pItem, useFolder,
+                                            pItem->GetProperty(MULTIPLE_EPISODES).asBoolean(false)
+                                                ? ART::AdditionalIdentifiers::SEASON_AND_EPISODE
+                                                : ART::AdditionalIdentifiers::NONE);
+      }
+      else if (content == ContentType::MOVIE_VERSIONS ||
+               (pItem->HasVideoVersions() &&
+                pItem->GetProperty("bluray_playlist").asInteger32(-1) > -1))
+      {
+        // Add playlist identifier only when there are multiple versions of the movie on the same disc
+        path =
+            ART::GetLocalArtBaseFilename(*pItem, useFolder, ART::AdditionalIdentifiers::PLAYLIST);
+      }
+      else
+        path = ART::GetLocalArtBaseFilename(*pItem, useFolder);
+      ART::AddLocalItemArtwork(art, artTypes, path, addAll, exactName, bApplyToDir);
+    }
+
+    if (moviePartOfSet)
+    {
+      std::string movieSetInfoPath =
+          CVideoInfoScanner::GetMovieSetInfoFolder(movieDetails.m_set.GetTitle());
+      if (!movieSetInfoPath.empty())
+      {
+        KODI::ART::Artwork movieSetArt;
+        ART::AddLocalItemArtwork(movieSetArt, movieSetArtTypes, movieSetInfoPath, addAll, exactName,
+                                 true);
+        for (const auto& artItem : movieSetArt)
+        {
+          art["set." + artItem.first] = artItem.second;
+        }
+      }
+    }
+  }
+
+  // find embedded art
+  if (pItem->HasVideoInfoTag() && !pItem->GetVideoInfoTag()->m_coverArt.empty())
+  {
+    for (auto& it : pItem->GetVideoInfoTag()->m_coverArt)
+    {
+      if ((addAll || CVideoThumbLoader::IsArtTypeInWhitelist(it.m_type, artTypes, exactName)) &&
+          !art.contains(it.m_type))
+      {
+        std::string thumb = IMAGE_FILES::URLFromFile(pItem->GetPath(), "video_" + it.m_type);
+        art.insert(std::make_pair(it.m_type, thumb));
+      }
+    }
+  }
+
+  // add online fanart (treated separately due to it being stored in m_fanart)
+  if ((addAll || CVideoThumbLoader::IsArtTypeInWhitelist("fanart", artTypes, exactName)) &&
+      !art.contains("fanart"))
+  {
+    std::string fanart = pItem->GetVideoInfoTag()->m_fanart.GetImageURL();
+    if (!fanart.empty() &&
+        !(useRemoteArt == UseRemoteArtWithLocalScraper::NO && URIUtils::IsRemote(fanart)))
+      art.insert(std::make_pair("fanart", fanart));
+  }
+
+  // add online art
+  for (const auto& url : pItem->GetVideoInfoTag()->m_strPictureURL.GetUrls())
+  {
+    if (url.m_type != CScraperUrl::UrlType::General)
+      continue;
+    std::string aspect = url.m_aspect;
+    if (aspect.empty())
+      // Backward compatibility with Kodi 11 Eden NFO files
+      aspect = mediaType == MediaTypeEpisode ? "thumb" : "poster";
+
+    if ((addAll || CVideoThumbLoader::IsArtTypeInWhitelist(aspect, artTypes, exactName)) &&
+        !art.contains(aspect))
+    {
+      std::string image = GetImage(url, pItem->GetPath());
+      if (!image.empty() &&
+          !(useRemoteArt == UseRemoteArtWithLocalScraper::NO && URIUtils::IsRemote(image)))
+        art.insert(std::make_pair(aspect, image));
+    }
+  }
+
+  if (!art.contains("thumb") &&
+      CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_MYVIDEOS_EXTRACTTHUMB) &&
+      CDVDFileInfo::CanExtract(*pItem))
+  {
+    art["thumb"] = CVideoThumbLoader::GetEmbeddedThumbURL(*pItem);
+  }
+
+  for (const auto& artType : artTypes)
+    if (art.contains(artType))
+      CacheArtwork(art.at(artType), m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS);
+
+  pItem->SetArt(art);
+
+  // parent folder to apply the thumb to and to search for local actor thumbs
+  std::string parentDir = URIUtils::GetParentPath(pItem->GetPath());
+  if (CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_VIDEOLIBRARY_ACTORTHUMBS))
+  {
+    // .actors sits alongside the nfo, so for a disc folder it is in BDMV/VIDEO_TS
+    const std::string mediaDir{URIUtils::IsOpticalMediaFile(pItem->GetPath())
+                                   ? URIUtils::GetDirectory(pItem->GetPath())
+                                   : parentDir};
+    FetchActorThumbs(movieDetails.m_cast,
+                     actorArtPath.empty() ? URIUtils::AddFileToFolder(mediaDir, ".actors")
+                                          : actorArtPath,
+                     useRemoteArt);
+  }
+  if (bApplyToDir)
+    ApplyThumbToFolder(parentDir, art["thumb"]);
+}
+
+std::string CVideoInfoScannerArt::GetImage(const CScraperUrl::SUrlEntry& image,
+                                           const std::string& itemPath)
+{
+  std::string thumb = CScraperUrl::GetThumbUrl(image);
+  if (!thumb.empty() && thumb.find('/') == std::string::npos &&
+      thumb.find('\\') == std::string::npos)
+  {
+    std::string strPath = URIUtils::GetDirectory(itemPath);
+    thumb = URIUtils::AddFileToFolder(strPath, thumb);
+  }
+  return thumb;
+}
+
+void CVideoInfoScannerArt::ApplyThumbToFolder(const std::string& folder,
+                                              const std::string& imdbThumb)
+{
+  // copy icon to folder also;
+  if (!imdbThumb.empty())
+  {
+    CFileItem folderItem(folder, true);
+    CThumbLoader loader;
+    loader.SetCachedImage(folderItem, "thumb", imdbThumb);
+  }
+}
+
+void CVideoInfoScannerArt::GetSeasonThumbs(const CVideoInfoTag& show,
+                                           KODI::ART::SeasonsArtwork& seasonArt,
+                                           const std::vector<std::string>& artTypes,
+                                           bool useLocal /* = true */,
+                                           UseRemoteArtWithLocalScraper useRemoteArt /* = yes */,
+                                           KODI::REGEXP::RegExpCache* cache /* = nullptr*/)
+{
+  int artLevel = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
+      CSettings::SETTING_VIDEOLIBRARY_ARTWORK_LEVEL);
+  bool addAll = artLevel == CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_ALL;
+  bool exactName = artLevel == CSettings::VIDEOLIBRARY_ARTWORK_LEVEL_BASIC;
+  if (useLocal)
+  {
+    // find the maximum number of seasons we have local thumbs for
+    int maxSeasons = 0;
+    CFileItemList items;
+    std::string extensions = CServiceBroker::GetFileExtensionProvider().GetPictureExtensions();
+    if (!show.m_strPath.empty())
+    {
+      CDirectory::GetDirectory(show.m_strPath, items, extensions,
+                               DIR_FLAG_NO_FILE_DIRS | DIR_FLAG_READ_CACHE | DIR_FLAG_NO_FILE_INFO);
+    }
+    extensions.erase(std::remove(extensions.begin(), extensions.end(), '.'), extensions.end());
+    std::shared_ptr<CRegExp> reg;
+    const std::string pattern = "season([0-9]+)(-[a-z0-9]+)?\\.(" + extensions + ")";
+    if (!items.IsEmpty() && (reg = KODI::REGEXP::GetRegExp(pattern, cache)) != nullptr)
+    {
+      for (const auto& item : items)
+      {
+        std::string name = URIUtils::GetFileName(item->GetPath());
+        if (reg->RegFind(name) > -1)
+        {
+          int season = atoi(reg->GetMatch(1).c_str());
+          if (season > maxSeasons)
+            maxSeasons = season;
+        }
+      }
+    }
+    for (int season = -1; season <= maxSeasons; season++)
+    {
+      // Look for local art irrespective of scraper/existing art as it takes priority
+      KODI::ART::Artwork art;
+      std::string basePath;
+      if (season == -1)
+        basePath = "season-all";
+      else if (season == 0)
+        basePath = "season-specials";
+      else
+        basePath = StringUtils::Format("season{:02}", season);
+
+      ART::AddLocalItemArtwork(art, artTypes, URIUtils::AddFileToFolder(show.m_strPath, basePath),
+                               addAll, exactName, false);
+
+      seasonArt[season] = art;
+    }
+  }
+  // add online art
+  for (const auto& url : show.m_strPictureURL.GetUrls())
+  {
+    if (url.m_type != CScraperUrl::UrlType::Season)
+      continue;
+    std::string aspect = url.m_aspect;
+    if (aspect.empty())
+      aspect = "thumb";
+    KODI::ART::Artwork& art = seasonArt[url.m_season];
+    if ((addAll || CVideoThumbLoader::IsArtTypeInWhitelist(aspect, artTypes, exactName)) &&
+        !art.contains(aspect))
+    {
+      std::string image = CScraperUrl::GetThumbUrl(url);
+      if (!image.empty() &&
+          !(useRemoteArt == UseRemoteArtWithLocalScraper::NO && URIUtils::IsRemote(image)))
+        art.insert(std::make_pair(aspect, image));
+    }
+  }
+}
+
+void CVideoInfoScannerArt::FetchActorThumbs(
+    std::vector<SActorInfo>& actors,
+    const std::string& actorsDir,
+    UseRemoteArtWithLocalScraper useRemoteArt /* = YES */) const
+{
+  CFileItemList items;
+  // don't try to fetch anything local with plugin source
+  if (!URIUtils::IsPlugin(actorsDir) && CDirectory::Exists(actorsDir))
+    CDirectory::GetDirectory(actorsDir, items, ".png|.jpg|.tbn", DIR_FLAG_NO_FILE_DIRS);
+
+  // Index the thumbs by filename (without extension), and the hashes taken from the directory
+  // listing by url
+  std::map<std::string, std::string> thumbs;
+  std::map<std::string, std::string> listedHashes;
+  for (const auto& item : items)
+  {
+    if (item->IsFolder())
+      continue;
+
+    std::string name{URIUtils::GetFileName(item->GetPath())};
+    URIUtils::RemoveExtension(name);
+    thumbs.try_emplace(std::move(name), item->GetPath());
+    if (std::string hash{CTextureCacheJob::GetImageHash(*item)}; !hash.empty())
+      listedHashes.emplace(item->GetPath(), std::move(hash));
+  }
+
+  for (auto& actor : actors)
+  {
+    if (actor.thumb.empty())
+    {
+      // Must match how the name is turned into a filename when exporting (see
+      // CVideoDatabase::GetSafeFile()), or an actor whose name contains a character that is not
+      // legal in a filename (ie. a trailing '.') can never be matched to their own exported thumb
+      std::string thumbFile = actor.strName;
+      StringUtils::Replace(thumbFile, ' ', '_');
+      thumbFile = CUtil::MakeLegalFileName(std::move(thumbFile));
+      if (const auto thumb{thumbs.find(thumbFile)}; thumb != thumbs.end())
+        actor.thumb = thumb->second;
+      if (!actor.thumbUrl.GetFirstUrlByType().m_url.empty())
+      {
+        const std::string thumb{CScraperUrl::GetThumbUrl(actor.thumbUrl.GetFirstUrlByType())};
+        const bool notUsingThisRemoteArt{useRemoteArt == UseRemoteArtWithLocalScraper::NO &&
+                                         URIUtils::IsRemote(thumb)};
+        if (actor.thumb.empty() && !notUsingThisRemoteArt)
+          actor.thumb = thumb;
+        if (notUsingThisRemoteArt)
+          actor.thumbUrl.Clear();
+      }
+    }
+  }
+
+  for (const auto& actor : actors)
+  {
+    const auto hash{listedHashes.find(actor.thumb)};
+    CacheArtwork(actor.thumb, m_artRetrievalTiming == ArtRetrievalTiming::SYNCHRONOUS,
+                 hash != listedHashes.end() ? hash->second : std::string{});
+  }
+}
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/VideoInfoScannerArt.cpp
+++ b/xbmc/video/VideoInfoScannerArt.cpp
@@ -18,6 +18,9 @@
 #include "cores/VideoPlayer/DVDFileInfo.h"
 #include "filesystem/Directory.h"
 #include "imagefiles/ImageFileURL.h"
+#include "jobs/Job.h"
+#include "jobs/JobManager.h"
+#include "jobs/JobQueue.h"
 #include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/ArtUtils.h"
@@ -30,6 +33,7 @@
 #include "video/VideoThumbLoader.h"
 
 #include <algorithm>
+#include <chrono>
 #include <map>
 #include <ranges>
 #include <string>
@@ -41,6 +45,9 @@ using namespace ADDON;
 
 namespace
 {
+//! \brief How often to check on a batch of art caching jobs while waiting for it to finish
+constexpr auto ART_CACHE_JOB_POLL_INTERVAL{std::chrono::milliseconds{1000}};
+
 void CacheArtwork(const std::string& url,
                   bool retrieveArtDuringScrape,
                   const std::string& knownHash = "")
@@ -158,9 +165,45 @@ void CVideoInfoScannerArt::Cache(std::vector<ArtToCache> art) const
     return;
   }
 
-  // Synchronous so fetch all now
+  // A single image has nothing to overlap with
+  if (art.size() < 2)
+  {
+    for (const auto& a : art)
+      CacheArtwork(a.url, true, a.hash);
+    return;
+  }
+
+  // Caching an image is mostly waiting on the source
+  CJobQueue queue{false, CJobManager::GetMaxPausableWorkers(), CJob::PRIORITY_LOW_PAUSABLE};
   for (const auto& a : art)
-    CacheArtwork(a.url, true, a.hash);
+    queue.Submit([a]() { CacheArtwork(a.url, true, a.hash); });
+
+  const auto jobManager{CServiceBroker::GetJobManager()};
+  while (true)
+  {
+    // Asked before waiting, as playback may already have paused the priority these were queued
+    // at, in which case there is nothing to wait for
+    if (!jobManager->IsRunning())
+    {
+      // Shutting down - whatever is left is abandoned when the queue goes out of scope
+      CLog::LogF(LOGDEBUG, "Abandoning art caching, the job manager has been shut down");
+      break;
+    }
+
+    if (jobManager->ArePausableJobsPaused())
+    {
+      // Playback has started, so nothing still queued here will be dispatched until it stops, and
+      // waiting that long would hold up the scrape. Hand what is left to the background path
+      // instead: its queue outlives this call, so the images are still cached once playback ends.
+      CLog::LogF(LOGDEBUG, "Handing remaining art to background caching, playback has started");
+      for (const auto& a : art)
+        CacheArtwork(a.url, false, a.hash);
+      break;
+    }
+
+    if (queue.WaitForCompletion(ART_CACHE_JOB_POLL_INTERVAL))
+      break;
+  }
 }
 
 void CVideoInfoScannerArt::FlushDeferred()

--- a/xbmc/video/VideoInfoScannerArt.h
+++ b/xbmc/video/VideoInfoScannerArt.h
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 class CFileItem;
@@ -22,6 +23,26 @@ struct SActorInfo;
 
 namespace KODI::VIDEO
 {
+//! \brief When an image is likely to be first seen by the user, and so the order to fetch it in
+enum class ArtPriority : uint8_t
+{
+  LIST = 0, //!< poster - shown in library
+  BACKGROUND, //!< fanart - shown behind a list
+  DETAIL, //!< shown once an item is opened
+  ACTOR, //!< shown once a cast list is opened
+};
+
+//! \brief An artwork url to cache, with the hash of its source file if that is already known
+struct ArtToCache
+{
+  std::string url;
+  std::string hash; //!< empty if unknown, leaving the texture cache to determine it
+  ArtPriority priority{ArtPriority::DETAIL};
+};
+
+//! \brief When art of the given type (a "poster", a "set.fanart") is first seen
+ArtPriority PriorityOfArtType(std::string_view artType);
+
 /*! \brief The artwork side of a video scan
 
  Finds the art belonging scraped items - local files, what the scraper offered, what
@@ -39,6 +60,12 @@ public:
   };
 
   CVideoInfoScannerArt();
+
+  /*! \brief Queues anything still held back, for a holder that doesn't do so itself
+   A library import, say, gathers art without ever running a scan to finish.
+   \sa FlushDeferred
+   */
+  ~CVideoInfoScannerArt();
 
   /*! \brief Retrieve any artwork associated with an item
    \param pItem item to find artwork for.
@@ -75,6 +102,27 @@ public:
    */
   void Cache(const std::string& url, const std::string& knownHash = "") const;
 
+  /*! \brief Have the texture cache fetch a set of an item's artwork
+   Each image is placed by the art type it is held under \sa PriorityOfArtType
+   \param art the artwork to cache
+   */
+  void Cache(const KODI::ART::Artwork& art) const;
+
+  /*! \brief Hand the artwork held back during the scan to the texture cache
+
+   Caching an image competes with the scan for the cpu to decode and store what it fetched, so
+   with ArtRetrievalTiming::BACKGROUND all but ArtPriority::LIST is collected as it is found and
+   queued here instead, once the library is browsable. The texture cache's own queue outlives this
+   object, so the images are still cached from that point rather than being left for something to
+   ask for them.
+
+   Queued in ArtPriority order, so that what the user comes to first is fetched first.
+
+   Duplicates are dropped, since one image - an actor, a set - often belongs to several items and
+   each would otherwise cost a lookup to find it already cached.
+   */
+  void FlushDeferred();
+
   /*! \brief Get season thumbs for a tvshow.
    All seasons (regardless of whether the user has episodes) are added to the art map.
    \param[in] show     tvshow info tag
@@ -102,7 +150,14 @@ private:
     BACKGROUND = 1 //!< retrieve art in background after scrape
   };
 
+  //! \brief Cache a group of artwork, or collect it for FlushDeferred() to
+  void Cache(std::vector<ArtToCache> art) const;
+
   ArtRetrievalTiming m_artRetrievalTiming{ArtRetrievalTiming::BACKGROUND};
+
+  //! Artwork found during the scan, to be cached once it has finished \sa FlushDeferred
+  //! Mutable, as the art is found by the const methods that gather it
+  mutable std::vector<ArtToCache> m_deferredArt;
 };
 
 } // namespace KODI::VIDEO

--- a/xbmc/video/VideoInfoScannerArt.h
+++ b/xbmc/video/VideoInfoScannerArt.h
@@ -1,0 +1,108 @@
+/*
+ *  Copyright (C) 2005-2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "addons/Scraper.h"
+#include "utils/Artwork.h"
+#include "utils/RegExp.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+class CFileItem;
+class CVideoInfoTag;
+struct SActorInfo;
+
+namespace KODI::VIDEO
+{
+/*! \brief The artwork side of a video scan
+
+ Finds the art belonging scraped items - local files, what the scraper offered, what
+ a folder or a .nfo names - and has the texture cache fetch it.
+
+ One class belongs to a scan, and lives as long as it does.
+ */
+class CVideoInfoScannerArt
+{
+public:
+  enum class UseRemoteArtWithLocalScraper : bool
+  {
+    NO,
+    YES
+  };
+
+  CVideoInfoScannerArt();
+
+  /*! \brief Retrieve any artwork associated with an item
+   \param pItem item to find artwork for.
+   \param content content type of the item.
+   \param bApplyToDir whether we should apply any thumbs to a folder.  Defaults to false.
+   \param useLocal whether we should use local thumbs. Defaults to true.
+   \param actorArtPath the directory containing actor thumbs. Defaults to empty.
+   \param useRemoteArt use remote art if also using local scraper. Defaults to yes.
+   */
+  void GetArtwork(
+      CFileItem* pItem,
+      ADDON::ContentType content,
+      bool bApplyToDir = false,
+      bool useLocal = true,
+      const std::string& actorArtPath = "",
+      UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES) const;
+
+  /*! \brief Fetch thumbs for actors
+   Updates each actor with their thumb (local or online)
+   \param actors - vector of SActorInfo
+   \param actorsDir - directory holding the local thumbs (ie. a .actors folder, or the actors
+          folder of a library export). Used as given, nothing is appended.
+   \param useRemoteArt - use remote art (ie. http://) even if derived from local .nfo file.
+          Defaults to yes.
+   */
+  void FetchActorThumbs(
+      std::vector<SActorInfo>& actors,
+      const std::string& actorsDir,
+      UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES) const;
+
+  /*! \brief Have the texture cache fetch an image
+   \param url the image to cache. Ignored when empty, so callers don't have to check.
+   \param knownHash hash of the source file, if the caller already knows it
+   */
+  void Cache(const std::string& url, const std::string& knownHash = "") const;
+
+  /*! \brief Get season thumbs for a tvshow.
+   All seasons (regardless of whether the user has episodes) are added to the art map.
+   \param[in] show     tvshow info tag
+   \param[in] art      artwork map to which season thumbs are added.
+   \param[in] useLocal whether to use local thumbs, defaults to true
+   \param[in] useRemoteArt use remote art if also using local scraper. Defaults to yes.
+   \param[in] cache regexp cache to avoid repeated compilations
+   */
+  static void GetSeasonThumbs(
+      const CVideoInfoTag& show,
+      KODI::ART::SeasonsArtwork& art,
+      const std::vector<std::string>& artTypes,
+      bool useLocal = true,
+      UseRemoteArtWithLocalScraper useRemoteArt = UseRemoteArtWithLocalScraper::YES,
+      KODI::REGEXP::RegExpCache* cache = nullptr);
+
+  static std::string GetImage(const CScraperUrl::SUrlEntry& image, const std::string& itemPath);
+
+  static void ApplyThumbToFolder(const std::string& folder, const std::string& imdbThumb);
+
+private:
+  enum class ArtRetrievalTiming : uint8_t
+  {
+    SYNCHRONOUS = 0, //!< retrieve art synchronously during scrape
+    BACKGROUND = 1 //!< retrieve art in background after scrape
+  };
+
+  ArtRetrievalTiming m_artRetrievalTiming{ArtRetrievalTiming::BACKGROUND};
+};
+
+} // namespace KODI::VIDEO

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -56,6 +56,7 @@
 #include "video/VideoDbUrl.h"
 #include "video/VideoFileItemClassify.h"
 #include "video/VideoInfoScanner.h"
+#include "video/VideoInfoScannerArt.h"
 #include "video/VideoInfoTag.h"
 #include "video/VideoItemArtworkHandler.h"
 #include "video/VideoLibraryQueue.h"
@@ -1993,8 +1994,8 @@ bool CGUIDialogVideoInfo::ManageVideoItemArtwork(const std::shared_ptr<CFileItem
   if (item->HasProperty("set_folder_thumb"))
   {
     // have a folder thumb to set as well
-    VIDEO::CVideoInfoScanner::ApplyThumbToFolder(item->GetProperty("set_folder_thumb").asString(),
-                                                 result);
+    VIDEO::CVideoInfoScannerArt::ApplyThumbToFolder(
+        item->GetProperty("set_folder_thumb").asString(), result);
   }
 
   CUtil::DeleteVideoDatabaseDirectoryCache();


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Looking now at usual use cases.
- 6 movies and 3 TV shows (1 season each)
- Online scraper
- Asynchronous (default) art retrieval

1 commit around form:
- one moves all art related code out of VideoInfoScraper and into a new VideoInfoScraperArt

5 commits around function:
- avoiding unnecessary online scraper retrieval of duplicate movies (ie. versions)
- avoid unnecessary MIME type GET's
- better thread management of background art retrieval - all outstanding asynchronous art is retrieved in about half the time
- ensuring all jobs start within the maximum number of threads allowed
- prioritie the earlier retrieval of art the user is likely to see first (posters etc..) and leaves actor thumbs until last - so poster thumbs are immediately visible in the GUI etc..

What the user will notice:
1) If scraping a source that contains multiple versions - the scrape will be quicker.
2) Art will be available quicker when looking at the details/actors of an item (on both synchronous and asynchronous settings).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

General improvement

# Video library scan performance

Five commits on top of `01574feef2`. One is a pure refactor; three are speedups; one changes the
order artwork is fetched in.

Measured end to end: **149.6 s → 41.7 s (3.6×)** on the test library described below, Release
builds, best run of three on each side.

| | Commit | Effect |
|---|---|---|
| 1 | `3a13b9b1ed` [VideoInfoScanner] Move the artwork side of a scan into its own class | none (refactor) |
| 2 | `80175225b1` [TextureCache] Skip the mime type lookup when the url already names an image type | ~halves per-image artwork cost |
| 3 | `b36a91dee7` [Scraper] Reuse a result the scraper has already been asked for | −3 s of scan time here, scales with duplicates |
| 4 | `0e115a1e48` [VideoInfoScannerArt] Cache the art a scan finds in the order it will be looked at | no throughput change; art arrives in a useful order |
| 5 | `921a8b3da3` [jobs] Let background caching overlap, and give it its own allowance | ~halves artwork wall clock |

---

## 1. Move the artwork side of a scan into its own class

`3a13b9b1ed` — pure refactor, no behaviour change.

`VideoInfoScanner.cpp` was 3459 lines and the art handling in it was hard to find, despite having
little to do with walking directories and reading a scraper's answers. Of the scanner's state, the
art code only ever read one thing: the setting saying when art should be fetched. No database, no
regexp cache.

So `CVideoInfoScannerArt` takes `GetArtwork`, `FetchActorThumbs`, `GetSeasonThumbs`, `GetImage` and
`ApplyThumbToFolder`, holding that setting, with a scan keeping one for as long as it runs.
`AddLocalItemArtwork` went to `ArtUtils` instead, next to the rest of the local art lookup it
belongs with, since both sides use it and neither owns it.

`VideoInfoScanner.cpp` drops to 3017 lines. The moved function bodies are byte-identical to before
apart from one forced qualification, which makes the commit reviewable as a move rather than a
rewrite.

This lands first so that the commits after it touch the art class rather than piling more onto
`VideoInfoScanner`. Commit 4 changes 10 lines of `VideoInfoScanner.cpp`; commit 5 changes none.

## 2. Skip the mime type lookup when the url already names an image type

`80175225b1` — the largest single win.

`CTextureCacheJob::LoadImage` called `CFileItem::FillInMimeType()`, which for an http(s) url fetches
the mime type from the source. So every image cached this way cost **two** round trips: a lookup,
then the download.

The result is mostly discarded. `CFFmpegImage::Initialize` identifies jpeg, png, tiff and webp from
the header of what it downloaded, and only falls back to the mime type when none of those match:

```cpp
// Some clients have pngs saved as jpeg or ask us for png but are jpeg
// mythv throws all mimetypes away and asks us with application/octet-stream
// this is poor man's fallback to at least identify the most important formats
```

A url ending in an image extension already tells us what the lookup would, so ask for it only when
the url doesn't say:

```cpp
file.FillInMimeType(!file.IsPicture());
```

Urls carrying no extension — where the lookup is the only thing identifying them as an image — fetch
it exactly as before, so nothing that used to be cached stops being cached.

**Measured:** 376 lookups → 0. Per-image serial cost drops from ~373 ms to ~186 ms. Both curl
timeouts seen across the baseline runs happened on this lookup, not on the download.

## 3. Reuse a result the scraper has already been asked for

`b36a91dee7`

Nothing remembered what a scraper returned, so a title reached more than once was searched and read
again from the source each time. A movie with two versions, or one held as a folder plus a disc per
subfolder, was scraped once per path — the same search, the same details, the same collection and
the same artwork lookups, for an answer already given.

In the test library, *Aliens (1986)* sits in a folder with a disc subfolder, and was scraped **three
times**: 21 of the 50 api requests a full scan made, 14 of them pure duplicates.

The scraper's own `cachepersistence` doesn't cover this. It caches pages fetched through
`Download()`, which python scrapers never reach — those make their requests themselves and return
the result to `FindMovie()`/`GetVideoDetails()`. (Confirmed in the logs: zero `CCurlFile` requests to
`api.themoviedb.org` against 36 addon-side ones.) `CVideoDatabase::ScraperCache` doesn't either — it
caches the scraper *object*, not its answers.

So keep the results in `CScraper`, in front of both entry points. A `CScraper` is built per addon
lookup, and it is `ScraperCache` holding one per scraper and path settings that gives a scan a
single instance to accumulate in — so results last exactly as long as the work that reuses them, and
a caller taking a scraper per call gets an empty cache and behaves as before. Path settings being
part of that key also keeps differently-configured paths apart without the cache having to know.

Bounded at 64 entries so a large scan doesn't hold a tag per episode. Repeats come from versions,
discs and folders of the same title, which are scraped close together and so are caught by a small
cache. Failures aren't cached, so a transient error is retried rather than remembered.

**Measured:** 50 api requests → 36. The two duplicate scrapes took 2.91 / 3.06 / 3.41 s across the
three baseline runs; the movie scan improved by 2,930 ms. Those match, so this commit accounts for
essentially the whole movie-scan gain. It scales with how many duplicates a library actually has —
zero benefit on a library with none.

## 4. Cache the art a scan finds in the order it will be looked at

`0e115a1e48` — not a throughput change. Included for what the user sees.

Art was handed to the texture cache as it was found, which means most of what a scan finds is
fetched before the little the user is about to look at. Cast thumbs are the bulk of it and nothing
shows those until a cast list is opened, so they were fetched ahead of the posters of the items the
user is about to scroll through.

Art is now collected and queued once the scan has finished and the library is browsable, ordered by
where each image is first seen:

| Priority | Types | Count here |
|---|---|---|
| `LIST` | poster, thumb, banner, keyart (+ `set.*`) | 59 |
| `BACKGROUND` | fanart | 12 |
| `DETAIL` | clearlogo, clearart, discart, landscape | 5 |
| `ACTOR` | cast thumbs | **301** |

`LIST` art is the exception and goes as it is found — it is a small part of the total, so it costs
the scan little, and it means a library just scanned isn't browsed with none of it cached.

Deduplicated over the whole scan rather than per item, since one image (an actor, a set) often
belongs to several and each would otherwise cost a lookup to find it already cached.

The split is logged, so it doesn't have to be guessed at:

```
CVideoInfoScannerArt: Queueing 162 images found during the scan for caching (0 list, 9 background, 0 detail, 153 actor)
CVideoInfoScannerArt: Queueing 156 images found during the scan for caching (0 list, 3 background, 5 detail, 148 actor)
```

**80% of what a scan fetches is cast thumbs**, and they are now last in the queue.

Anything still held back goes out when the class is destroyed, so a holder that gathers art without
a scan to finish — a library import via `ImportFromXML` — doesn't lose it.

**Measured:** no scan-time improvement on Release. On a Debug build this looked worth ~4 s, because
decode and store is the cpu-bound part and Debug exaggerates it several-fold; on Release, art
caching barely competes with the scan. The value here is the ordering, not throughput.

## 5. Let background caching overlap, and give it its own allowance

`921a8b3da3`

Caching an image is mostly waiting on the source, so running one at a time leaves that source idle
between requests. `CTextureCache` was a `CJobQueue` with `jobsAtOnce = 1`, and `PRIORITY_LOW_PAUSABLE`
was allowed `5 - (PRIORITY_HIGH - PRIORITY_LOW_PAUSABLE)` = 2 workers *shared with every other
priority* — including the scan job feeding it.

The texture cache is the only user of that priority and it waits on a source rather than on a core,
so count it separately from the budget the others share. Background work can then overlap without
taking worker slots from anything above it, and a scan no longer competes for slots with the caching
it is feeding.

`CJobQueue` gains a wait, so a caller can hand a batch over and know when it is done, and dispatches
up to its limit rather than one job per completion, so a queue starting up fills straight away. A
scrape set to fetch its art synchronously uses both to overlap a batch, handing back what is left if
playback starts and pauses the priority underneath it.

Whether a job caching an image is the one that claimed that url is now recorded rather than assumed,
since with more than one in flight the job that finishes is not necessarily the one that reserved it.

**Measured:** peak concurrency 1 → 2, and 93% of image fetches now overlap another. Per-image
effective cycle 391–590 ms → 105–136 ms.

---

## Measurements

Release builds of `01574feef2` (base) and `921a8b3da3` (new), three runs each, same machine, same
library, cache and database wiped between runs.

Library: 6 movies (Blu-ray folders, ISOs, VIDEO_TS, mkv, a multi-disc set and a two-part stack) and
3 TV shows (a rar archive, ISOs, VIDEO_TS), `artworklevel = all`,
`artretrievaltiming = background`.

### Every run did identical work

| | items | sets | AddVideo | bluray versions | images | unique image urls | dirs | api calls |
|---|---|---|---|---|---|---|---|---|
| base1–3 | 41 | 6 | 41 | 4 | 377 | 377 | 8 | 50 |
| new1–3 | 41 | 6 | 41 | 4 | 377 | 377 | 8 | **36** |

The set of cached image urls is identical across all six runs, as are the set names. The only
intended difference is the api request count.

### Timings

| | movie scan | tv scan | artwork wall | stalls | artwork net | total |
|---|---|---|---|---|---|---|
| base1 | 15,047 ms | 9,268 ms | 220.9 s | 92.2 s | 128.6 s | 227.8 s |
| base2 | 12,663 ms | 7,437 ms | 158.4 s | 24.0 s | 134.5 s | 161.8 s |
| base3 | 12,007 ms | 7,603 ms | 146.4 s | 44.6 s | 101.8 s | 149.6 s |
| new1 | 9,733 ms | 7,558 ms | 38.8 s | 0.0 s | 38.8 s | **41.7 s** |
| new2 | 7,962 ms | 7,932 ms | 42.2 s | 2.5 s | 39.7 s | 44.8 s |
| new3 | 11,569 ms | 16,152 ms | 50.3 s | 12.1 s | 38.1 s | 53.1 s |

"stalls" is time with no image request in flight for more than 2 s — upstream latency, not work.

| | base (best) | new (best) | |
|---|---|---|---|
| Movie scan | 12,007 ms | 7,962 ms | **−34%** |
| TV scan | 7,603 ms | 7,558 ms | unchanged |
| Artwork, stalls excluded | 101.8 s | 38.1 s | **−63%** |
| **Total** | **149.6 s** | **41.7 s** | **3.6×** |

Against the medians it is also 3.6× (161.8 s → 44.8 s).

### Caveats, honestly

**The baseline is noisy.** The base runs span 149.6–227.8 s, a 78 s spread, driven by 24–92 s of
network stalls. At concurrency 1 every one of ~754 requests' latency lands on the critical path, so
upstream jitter accumulates directly. Excluding stalls the base still spans 101.8–134.5 s. Prefer
base3 to the median, and treat the headline as approximate until there are more baseline runs.

The new runs are tight once stalls are excluded — 38.1 / 38.8 / 39.7 s, a 1.6 s spread. That
consistency is itself a result: the work is no longer latency-bound end to end.

**new3 is an outlier for an external reason.** Its 16.2 s tv scan contains a single 7,879 ms stall
inside `CPythonInvoker` for the TMDb tv scraper — the addon waiting on `api.themoviedb.org`.

**Commits 2 and 5 cannot be split additively.** They compose multiplicatively: dropping the mime
lookup removes ~187 ms of ~373 ms serial per-image work (roughly half the phase), and concurrency
1 → 2 halves whatever remains. Applied in either order one gets the large share and the other the
small. Together they take the artwork phase from 102 s to 38 s, 2.7×; neither alone would deliver
that.

**Commit 3's benefit is library-shaped.** It removes duplicate scrapes, so the gain is proportional
to how many a library has. This library has one multi-disc movie; a library with none sees no
change, and a library of multi-version movies would see considerably more.

**The scan-only gain is smaller than the total suggests.** Most of the 3.6× is the artwork phase.
Scan time itself improved 34% on movies and not at all on tv shows.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
