### PR TITLE
CToneMappers: protection against bad HDR light metadata

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ToneMappers.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ToneMappers.cpp
@@ -14,9 +14,9 @@ float CToneMappers::GetLuminanceValue(bool hasDisplayMetadata,
                                       const AVContentLightMetadata& lightMetadata)
 {
   // default for bad quality HDR-PQ sources (missing or invalid metadata)
-  const float defaultLuminance = 400.0f;
-  float lum1 = defaultLuminance;
+  constexpr float defaultLuminance = 400.0f;
 
+  float result = defaultLuminance;
   unsigned int maxLuminance = static_cast<unsigned int>(defaultLuminance);
 
   if (hasDisplayMetadata && displayMetadata.has_luminance && displayMetadata.max_luminance.den)
@@ -29,26 +29,20 @@ float CToneMappers::GetLuminanceValue(bool hasDisplayMetadata,
 
   if (hasLightMetadata && lightMetadata.MaxCLL)
   {
-    float lum2;
-
-    if (lightMetadata.MaxCLL >= maxLuminance)
-    {
-      lum1 = static_cast<float>(maxLuminance);
-      lum2 = static_cast<float>(lightMetadata.MaxCLL);
-    }
-    else
-    {
-      lum1 = static_cast<float>(lightMetadata.MaxCLL);
-      lum2 = static_cast<float>(maxLuminance);
-    }
+    const float lum1 = (lightMetadata.MaxCLL >= maxLuminance)
+                           ? static_cast<float>(maxLuminance)
+                           : static_cast<float>(lightMetadata.MaxCLL);
+    const float lum2 = (lightMetadata.MaxCLL >= maxLuminance)
+                           ? static_cast<float>(lightMetadata.MaxCLL)
+                           : static_cast<float>(maxLuminance);
     const float lum3 = static_cast<float>(lightMetadata.MaxFALL);
 
-    lum1 = (lum1 * 0.5f) + (lum2 * 0.2f) + (lum3 * 0.3f);
+    result = (lum1 * 0.5f) + (lum2 * 0.2f) + (lum3 * 0.3f);
   }
   else if (hasDisplayMetadata && displayMetadata.has_luminance)
   {
-    lum1 = static_cast<float>(maxLuminance);
+    result = static_cast<float>(maxLuminance);
   }
 
-  return lum1;
+  return result;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ToneMappers.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/ToneMappers.cpp
@@ -27,7 +27,7 @@ float CToneMappers::GetLuminanceValue(bool hasDisplayMetadata,
       maxLuminance = lum;
   }
 
-  if (hasLightMetadata)
+  if (hasLightMetadata && lightMetadata.MaxCLL)
   {
     float lum2;
 


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
CToneMappers: protection against bad HDR light metadata.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
IA has found this in https://github.com/xbmc/xbmc/pull/29075#discussion_r3861178095.

Some bad authored HDR sources may contain empty data block of Light Metadata even when is signaled that source contains this metadata (hasLightMetadata true).

This is also handled properly in other places like: https://github.com/xbmc/xbmc/blob/429fdbdf6f8bae1be73c41b623ba55e2eb4892b0/xbmc/cores/VideoPlayer/VideoRenderers/windows/RendererBase.cpp#L43

The second commit is only improvements in variable names and code style, not changes the result.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with vide source that contains all metadata values. The result calculated not changes before / after this PR.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Better luminance value for tone mapping in some specific cases of sources with bad or corrupted HDR light metadata.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
