### PR TITLE
[AESinkAUDIOTRACK][AudioEngine] Fix fatal retry loop and notify when passthrough is unsupported

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -13,8 +13,10 @@
 #include "cores/AudioEngine/Utils/AEBitstreamPacker.h"
 #include "cores/AudioEngine/Utils/AEStreamInfo.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "utils/EndianSwap.h"
 #include "utils/MemUtils.h"
+#include "utils/StringUtils.h"
 #include "utils/log.h"
 
 #include <algorithm>
@@ -993,6 +995,45 @@ void CActiveAESink::OpenSink()
   CLog::Log(LOGDEBUG, "  Channel Layout: {}", ((std::string)m_sinkFormat.m_channelLayout));
   CLog::Log(LOGDEBUG, "  Frames        : {}", m_sinkFormat.m_frames);
   CLog::Log(LOGDEBUG, "  Frame Size    : {}", m_sinkFormat.m_frameSize);
+
+  if (m_sink->IsSilentFallback())
+  {
+    // Notify the user from the orchestration layer rather than inside
+    // the platform-specific sink. QueueNotification is thread-safe.
+    std::string formatName;
+    switch (m_sinkFormat.m_streamInfo.m_type)
+    {
+      case CAEStreamInfo::STREAM_TYPE_AC3:
+        formatName = "DD (AC3)";
+        break;
+      case CAEStreamInfo::STREAM_TYPE_EAC3:
+        formatName = "DD+ (E‑AC3)";
+        break;
+      case CAEStreamInfo::STREAM_TYPE_DTS_512:
+      case CAEStreamInfo::STREAM_TYPE_DTS_1024:
+      case CAEStreamInfo::STREAM_TYPE_DTS_2048:
+      case CAEStreamInfo::STREAM_TYPE_DTSHD_CORE:
+        formatName = "DTS";
+        break;
+      case CAEStreamInfo::STREAM_TYPE_DTSHD:
+      case CAEStreamInfo::STREAM_TYPE_DTSHD_MA:
+        formatName = "DTS‑HD";
+        break;
+      case CAEStreamInfo::STREAM_TYPE_TRUEHD:
+        formatName = "TrueHD";
+        break;
+      default:
+        // Fallback to the internal name for any unexpected type.
+        formatName = CAEUtil::StreamTypeToStr(m_sinkFormat.m_streamInfo.m_type);
+        break;
+    }
+
+    CGUIDialogKaiToast::QueueNotification(
+        CGUIDialogKaiToast::Warning, "Passthrough unsupported",
+        StringUtils::Format(
+            "{} audio cannot be used with current settings on this device. Playing silently.",
+            formatName));
+  }
 
   // init sample of silence
   SampleConfig config;

--- a/xbmc/cores/AudioEngine/Interfaces/AESink.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AESink.h
@@ -47,6 +47,13 @@ public:
   virtual double GetLatency() { return 0.0; }
 
   /*!
+   * @brief True if the sink is operating without an actual hardware audio path
+   * (e.g. passthrough failed and data is swallowed to keep the pipeline alive).
+   * @return true if this sink is a silent stand-in
+   */
+  virtual bool IsSilentFallback() { return false; }
+
+  /*!
    * @brief Adds packets to be sent out, this routine MUST block or sleep.
    * @param data array of pointers to planes holding audio data
    * @param frames number of audio frames in data

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
@@ -388,7 +388,10 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
   m_format.m_channelLayout  = AUDIOTRACKChannelMaskToAEChannelMap(atChannelMask);
   if (m_encoding == CJNIAudioFormat::ENCODING_IEC61937)
   {
-    // keep above channel output if we do IEC61937 and got DTSHD or TrueHD by AudioEngine
+    // Most IEC formats require CHANNEL_OUT_STEREO, but DTS-HD MA and TrueHD
+    // need an 8-channel carrier (2ch@192kHz cannot carry their bitrate).
+    // This is supported on specific hardware (Shield, Fire TV Cube 3rd gen).
+    // Do not simplify to always-stereo - it breaks passthrough on that hardware.
     if (m_format.m_streamInfo.m_type != CAEStreamInfo::STREAM_TYPE_DTSHD_MA && m_format.m_streamInfo.m_type != CAEStreamInfo::STREAM_TYPE_TRUEHD)
       atChannelMask = CJNIAudioFormat::CHANNEL_OUT_STEREO;
   }
@@ -577,6 +580,16 @@ bool CAESinkAUDIOTRACK::Initialize(AEAudioFormat &format, std::string &device)
           usleep(200 * 1000);
           continue;
         }
+        if (m_info.m_wantsIECPassthrough || !m_hasIEC)
+        {
+          // No remaining device string to try for this stream.
+          // Return true to prevent ActiveAE from entering a fatal retry loop.
+          CLog::Log(LOGERROR, "AESinkAUDIOTRACK - Unable to create AudioTrack for passthrough - "
+                              "continuing with no audio for this stream");
+          format = m_format;
+          return true;
+        }
+        // RAW failed - fall through to return false so CActiveAESink tries IEC next.
       }
       CLog::Log(LOGERROR, "AESinkAUDIOTRACK - Unable to create AudioTrack");
       Deinitialize();
@@ -635,7 +648,9 @@ void CAESinkAUDIOTRACK::GetDelay(AEDelayStatus& status)
 {
   if (!m_at_jni)
   {
-    status.SetDelay(0);
+    // Definitively failed passthrough: report the configured buffer time
+    // so sync logic sees a stable delay instead of zero.
+    status.SetDelay(m_passthrough && m_audiotrackbuffer_sec > 0.0 ? m_audiotrackbuffer_sec : 0);
     return;
   }
 
@@ -792,6 +807,15 @@ double CAESinkAUDIOTRACK::GetCacheTotal()
 // when it returns ActiveAESink will take the next buffer out of a queue
 unsigned int CAESinkAUDIOTRACK::AddPackets(uint8_t **data, unsigned int frames, unsigned int offset)
 {
+  if (!m_at_jni && m_passthrough)
+  {
+    // Passthrough definitively failed - no AudioTrack to write to.
+    // Report data as consumed to avoid CActiveAESink treating this
+    // as an error and repeatedly rebuilding the sink. No throttling
+    // here because an explicit sleep caused video lag on some devices.
+    m_duration_written += static_cast<double>(frames) / m_format.m_sampleRate;
+    return frames;
+  }
   if (!IsInitialized())
     return INT_MAX;
 
@@ -1182,7 +1206,9 @@ void CAESinkAUDIOTRACK::UpdateAvailablePassthroughCapabilities(bool isRaw)
             m_info.m_streamTypes.push_back(CAEStreamInfo::STREAM_TYPE_DTSHD);
             CLog::Log(LOGDEBUG, "E-AC3 and DTSHD-HR via IEC61937 is supported");
           }
-          // Check for IEC 8 channel 192 khz PT DTS-HD-MA and TrueHD
+          // DTS-HD MA/TrueHD need an 8-channel IEC carrier at 192kHz.
+          // 2ch@192kHz cannot carry their bitrate, so this must probe 7.1
+          // unlike the stereo IEC probes above. Keep in sync with Initialize().
           int atChannelMask = AEChannelMapToAUDIOTRACKChannelMask(AE_CH_LAYOUT_7_1);
           if (VerifySinkConfiguration(192000, atChannelMask, CJNIAudioFormat::ENCODING_IEC61937))
           {

--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
@@ -38,6 +38,7 @@ public:
   unsigned int AddPackets(uint8_t** data, unsigned int frames, unsigned int offset) override;
   void AddPause(unsigned int millis) override;
   void Drain() override;
+  bool IsSilentFallback() override { return !m_at_jni && m_passthrough; }
   static void          EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
   static void Register();
   static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
PR #27464 introduced a regression where any passthrough format that fails to open causes video playback to freeze or lag, and breaks audio for the GUI and subsequent files in the same session.

The root cause is in how `CActiveAESink` handles sink initialization failure. When `Initialize()` returns false, `CActiveAESink` reports the error to `CActiveAE`, which enters `AE_TOP_ERROR` and retries the exact same configuration every 500 ms. There is no format-downgrade path, so the retry loop continues indefinitely.

Before PR #27464, this loop was accidentally avoided because a failed `AudioTrack` pointer was left non-NULL. `Initialize()` returned `true`, video played, and audio was silent. That PR correctly deleted the failed pointer, but this exposed the fatal retry loop.

**Fix details**:
1. **Graceful fallback on final passthrough failure.** When passthrough definitively cannot be opened (IEC device failed, or no IEC device exists on this Android version), `Initialize()` returns `true` instead of `false`. This keeps `CActiveAESink` alive and prevents the `ActiveAE` retry storm.
2. **Silent fallback handling.**
- `AddPackets()` reports data as consumed when operating in silent fallback mode (`m_at_jni == NULL`). Returning `INT_MAX` would make `CActiveAESink` treat this as a sink error and repeatedly rebuild the sink, which never settles during clock resync (e.g. after every seek).
- `GetDelay()` reports the configured buffer time instead of zero in silent fallback mode, giving `ActiveAE`’s sync logic a stable, non‑zero delay to pace against.
3. **User notification for silent playback.** A new virtual method `IAESink::IsSilentFallback()` allows a sink to report that it is operating without an actual audio path. The Android sink overrides this when passthrough creation has failed and it is consuming data silently. `CActiveAESink` uses this state to show a one‑time notification. This keeps platform‑specific sink code free of UI logic.

No channel mask or enumeration changes are included. The original 7.1 IEC configuration for TrueHD/DTS-HD MA is preserved for devices that support it (e.g., Shield, Fire TV Cube). Comments have been added to document why those formats require an 8‑channel carrier and must not be forced to stereo. The fallback only activates after `AudioTrack` creation has definitively failed on the last available device string for the stream.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On many Android devices, the firmware advertises passthrough formats (especially TrueHD and DTS-HD MA) as supported during enumeration, but `AudioTrack` creation fails at runtime. A previous Shield workaround that verified formats at enumeration time was removed, leaving all formats advertised as available.

Before PR #27464, this was harmless: video played and audio was silent. After that PR, the same files cause player misbehavior and require a restart to recover.

While users can work around this by disabling specific formats in settings, Kodi should degrade gracefully when a format turns out to be unsupported at runtime. This PR restores that graceful degradation without affecting devices where these formats actually work.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TrueHD and DTS-HD MA files on Android phone, tablet, and Sony TV:
- video plays smoothly, GUI responsive, no retry storms in logs
- TrueHD silent on mobile; DTS-HD MA silent on mobile, plays as DTS core on TV
- seeking, track switching, and file switching work without crash or stale state
- a notification is shown when playback continues without audio

Current upstream behavior for comparison:
- video freezes or stutters severely on the first frame
- UI stays on top of video; no audio
- after stopping, audio is broken for the session

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->
Users with Android devices that do not support certain passthrough formats can play those files again without Kodi freezing or lagging. Video plays normally; audio falls back to silent (or DTS core where applicable), and a clear notification explains why.

Users with Android devices that do support TrueHD/DTS-HD MA via IEC61937 (e.g., NVIDIA Shield, Fire TV Cube) are unaffected. The original 7.1 channel configuration is preserved and passthrough continues to work.
**Testing on such devices is still needed, as I don't have any.**

No negative effect on any other audio path (PCM, AC3, DTS, E-AC3).

## Screenshots (if appropriate):
<img width="2400" height="1080" alt="no-pt" src="https://github.com/user-attachments/assets/c41773eb-3230-4940-b8bd-90414a21b66d" />

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
