### PR TITLE
Fix three environment-caused CI failures on jenkins.kodi.tv

### DIFF
--- a/tools/android/packaging/.gitignore
+++ b/tools/android/packaging/.gitignore
@@ -1,1 +1,2 @@
 /.gradle/
+/.gradle-home/

--- a/tools/android/packaging/Makefile.in
+++ b/tools/android/packaging/Makefile.in
@@ -26,6 +26,13 @@ ifeq ($(KODI_ANDROID_KEY_PASSWORD),)
 export KODI_ANDROID_KEY_PASSWORD:=android
 endif
 
+# Gradle takes exclusive locks on its user home, so parallel builds that share
+# one will time each other out. Override to share a warm cache between builds
+# that cannot overlap.
+ifeq ($(GRADLE_USER_HOME),)
+export GRADLE_USER_HOME:=$(CURDIR)/.gradle-home
+endif
+
 # libc++
 STLLIB=$(TOOLCHAIN)/sysroot/usr/lib/$(HOST)/libc++_shared.so
 

--- a/xbmc/threads/test/TestEvent.cpp
+++ b/xbmc/threads/test/TestEvent.cpp
@@ -489,16 +489,17 @@ TEST(TestEvent, GroupTimedWait)
   EXPECT_TRUE(!result1);
   EXPECT_TRUE(!result2);
 
-  EXPECT_TRUE(w3.waiting);
   EXPECT_TRUE(w3.result == NULL);
 
-  // this should end given the wait is for only 50 millis
-  EXPECT_TRUE(waitThread3.timed_join(200ms));
+  // nothing sets an event here, so the thread can only end by timing out
+  EXPECT_TRUE(waitThread3.timed_join(10000ms));
 
   EXPECT_TRUE(!w3.waiting);
   EXPECT_TRUE(w3.result == NULL);
 
-  group_wait w4(group, 50ms);
+  // this one is ended by event1 below rather than by its timeout, so the
+  // timeout only has to be long enough never to fire
+  group_wait w4(group, 60000ms);
   thread waitThread4(w4);
 
   EXPECT_TRUE(waitForWaiters(group, 1, 10000ms));


### PR DESCRIPTION
## Description

Three independent fixes for failures on jenkins.kodi.tv that are caused by the build environment rather than by the code being built. Each is a separate commit and they can be split into separate PRs if preferred — they are together here because they were all found in one pass over the same set of failing builds.

**`fix(windows)`** — `prepare-env.bat` ends on `git clean`, so git clean's exit code becomes the exit code of the batch step, and `git clean` returns 1 as soon as a single file resists deletion. On the WIN-32 PR workspace one does:

```
warning: failed to remove kodi-build.x86/build/build-liblzo2/src/build-liblzo2-build/CMakeFiles/CMakeConfigureLog.yaml: Invalid argument
Build step 'Execute Windows batch command' marked build as failure
```

`CMakeConfigureLog.yaml` is the log CMake ≥ 3.26 holds open for the duration of a configure, and it is left behind by a configure that was killed part way through — on Jenkins, any aborted build. Nothing ever removes it again, because the only thing that cleans `kodi-build.*` is the very `git clean` that now fails on it, so every later build reusing that workspace dies in the clean step within seconds without compiling anything.

The fix removes the CMake build trees up front with `rmdir /S /Q` — the same workaround already applied two lines above to `BUILD_WIN32` and the ffmpeg build dir, with the comment *"git clean has trouble to remove some times"*; the CMake build trees were simply never added — and stops treating a failed clean as fatal (retry once, then warn and let the build run).

**`fix(android)`** — the three Android jobs run concurrently on the same machine under the same user, so they all resolve `GRADLE_USER_HOME` to `~/.gradle` and contend on its cache locks:

```
Timeout waiting to lock journal cache (/home/jenkins/.gradle/caches/journal-1).
It is currently in use by another process. Owner PID: 16631 / Our PID: 16381
```

Defaults `GRADLE_USER_HOME` to a directory inside the build tree. It stays overridable, because a fresh build tree otherwise re-downloads the Gradle distribution — pointing it at a per-executor home keeps the caches warm and still avoids the contention.

**`fix(test)`** — `TestEvent.GroupTimedWait` asks a thread to wait 50 ms and then joins it within 200 ms. Neither number measures anything about `CEventGroup`; both are bets on how quickly a loaded build machine will reschedule a thread.

## Motivation and context

Measured over builds from 25–28 Aug:

| Job | Result |
|---|---|
| `BuildMulti-PR` | 35 SUCCESS / 13 FAILURE / 12 ABORTED (last 60) |
| `BuildMulti-All` (master nightly) | 1 SUCCESS / 6 UNSTABLE / 1 FAILURE (last 8) |
| `BuildMulti-Omega` | 1 SUCCESS / 4 FAILURE / 3 ABORTED (last 8) |

Attribution of the `BuildMulti-PR` failures:

* WIN-32 clean step — #40363, #40360, #40337, #40339, #40317, #40322. The underlying WIN-32 builds #44462, #44463, #44464, #44466 and #44467 all failed in 4–8 seconds. The nightly kept passing only because it runs in a separate `WIN-32_Omega` workspace on the same node.
* Gradle lock — #40350, #40340, #40339, #40337, #40331, #40321, usually taking out two ABIs of the same PR at once.
* `TestEvent.GroupTimedWait` — OSX-ARM64 #15680, failing a PR unrelated to threads.

All of these fail PRs that build perfectly well.

## How has this been tested?

Stated precisely, because the coverage is uneven:

* **test** — **not reproduced locally.** 150 repeats idle and 60 repeats under 4× CPU oversubscription all passed on an 18-core machine; the CI mac minis are far more contended. The diagnosis rests on the CI log naming the exact assertion and line. The test suite was not rebuilt.
* **windows** — reviewed, not executed on a Windows host. The `FOR /D` pattern is deliberately cwd-relative (the script `cd`s to `%WORKSPACE%` beforehand) to avoid the quoted-wildcard behaviour of `FOR /D`.
* **android** — reviewed, not executed. The `ifeq`/`export` form matches the `KODI_ANDROID_*` variables directly above it.

The real test is the CI run on this PR, and for the Windows change specifically: once merged, the next PR build on that workspace runs the new script and clears the stuck build tree by itself.

## What is the effect on users?

None. All three changes are confined to the build and test infrastructure.

## Screenshots (if appropriate):

n/a

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed

<sub>The last two are deliberately unticked: no new tests are added (one existing test is made less timing-sensitive), and the suite was not run locally — see *How has this been tested?* above.</sub>

---

### A fourth commit was dropped

This PR originally carried a `fix(cmake)` commit that disabled the CMake **user package registry**, to stop the Omega webOS nightly resolving a package out of a mid-build addon tree:

```
CMake Error at tools/depends/target/binary-addons/arm-webos-linux-gnueabi-release/build/rapidjson/src/rapidjson-build/RapidJSONConfig.cmake:3 (include):
  include could not find requested file: .../RapidJSON-targets.cmake
```

It has been dropped, because the culprit turned out to be identifiable and fixable at source rather than by disabling a CMake feature tree-wide.

The contamination comes from RapidJSON's own `CMakeLists.txt`, at the commit pinned by `inputstream.adaptive`:

```
line   1: CMAKE_MINIMUM_REQUIRED(VERSION 2.8.12)   → CMP0090 unset → OLD behaviour
line 230: EXPORT( PACKAGE ${PROJECT_NAME} )        → writes ~/.cmake/packages/RapidJSON/<hash>
```

Under CMP0090 OLD, `export(PACKAGE)` records the build tree in the user package registry — a location outside the build tree, shared by every job on the worker — and the `RapidJSONConfig.cmake` it writes there `include()`s a targets file that does not exist until later in the build.

Two things make this narrower than it first looked:

* Of the five dependencies `inputstream.adaptive` builds, RapidJSON is the **only** one that calls `export(PACKAGE)`. bento4 (3.15), googletest (3.16), nlohmann_json (3.5…4.0) and pugixml (3.5…3.30) all declare a minimum at or above 3.15, where the policy default already makes `export(PACKAGE)` a no-op.
* RapidJSON exists only on the **Omega** branch. On Piers, `inputstream.adaptive` has replaced it with nlohmann_json, and Kodi core references RapidJSON nowhere — so the failure this commit addressed cannot occur on the branch this PR targets.

The fix therefore belongs in `xbmc/inputstream.adaptive` on Omega, as a second patch in `depends/common/rapidjson/` alongside the existing `0001-cmake-standardise_config_installpath.patch` — `HandleDepends.cmake` globs `*.patch` from that directory, so removing line 230 needs no other change.

One caveat for whoever picks that up: the registry entries already written on the Omega workers live outside every build tree, so a source patch does not clean them. `~/.cmake/packages/RapidJSON` has to be removed on the affected nodes as well.

### Review updates

Of the four points raised by the automated review, two concerned the dropped `fix(cmake)` commit and are moot. The other two are reflected in the current branch:

1. **`TestEvent` still carried a scheduling deadline** — correct. Rewritten to remove the deadlines rather than widen them: the racy `w3.waiting` assertion is dropped (`waitForWaiters()` already proves the thread blocked), w3 returns to 50 ms, and w4 gets a timeout long enough never to fire since it is ended by an event, not by its timeout.
2. **Failed clean should stay fatal** — declined, with the underlying concern addressed. Failing there is precisely what took the gate down for days, and whitelisting one path just moves the problem to the next stuck file. The retry path now lists what survived the clean, so a dirty workspace is visible in the log instead of silent.

---

Not addressed here, because none of it lives in this repository, but found in the same pass and worth someone picking up:

* **RapidJSON's `export(PACKAGE)`** on the Omega branch of `inputstream.adaptive` — see above. This is the actual failure of Omega nightly #442, which failed four times on the same unchanged commit `f8815ee`, i.e. environment, not code.
* `visualization.projectm` fails to configure on every cross-compile target (`Could not find a valid OpenGL implementation` on tvOS/iOS, `pthreads not found` on linux-arm-gles). It is the sole reason `LINUX (arm)`, `TVOS` and `iOS-ARM64-StaticAnalysis` — and therefore both nightlies — go UNSTABLE. Belongs in `repo-binary-addons` or the addon itself.
* The clang warnings quality gate runs with no reference build (`No valid reference build found` / `All reported issues will be considered outstanding`) and gates on *total* rather than new issues, at a threshold of 1 on `webos-docker` and 4 on `OSX-64`. Both logged `found 0 new issues` and failed anyway. Jenkins job config.
* `OSX-M1Max-16-hadm` has been offline since 2026-08-25 10:52 with *"Connection was broken"* — 16 executors, the largest macOS node on the farm.
