### PR TITLE
[Video][Database] Convert database fields to 'COLLATE NOCASE' so that queries can benefit from indexing using '=' and remain case insensitive.

### DIFF
--- a/xbmc/dbwrappers/mysqldataset.cpp
+++ b/xbmc/dbwrappers/mysqldataset.cpp
@@ -2008,6 +2008,8 @@ bool MysqlDataset::query(const std::string& query)
 
   MYSQL_RES* stmt = nullptr;
 
+  const auto start = std::chrono::steady_clock::now();
+
   if (static_cast<MysqlDatabase*>(db)->setErr(
           static_cast<MysqlDatabase*>(db)->query_with_reconnect(qry), qry.c_str()) != MYSQL_OK)
     throw DbErrors("%s", db->getErrorMsg());
@@ -2095,6 +2097,15 @@ bool MysqlDataset::query(const std::string& query)
     result.records.push_back(res);
   }
   mysql_free_result(stmt);
+
+  const auto end = std::chrono::steady_clock::now();
+
+  // fractions of a millisecond matter here: a select served by an index takes microseconds, and it
+  // is the sum over a whole library scan that tells whether one is served by an index at all
+  const std::chrono::duration<double, std::milli> duration{end - start};
+
+  CLog::LogFC(LOGDEBUG, LOGDATABASE, "{:.3f} ms for query: {}", duration.count(), qry);
+
   active = true;
   ds_state = dsSelect;
   this->first();

--- a/xbmc/dbwrappers/sqlitedataset.cpp
+++ b/xbmc/dbwrappers/sqlitedataset.cpp
@@ -943,6 +943,8 @@ bool SqliteDataset::query(const std::string& query)
 
   close();
 
+  const auto start = std::chrono::steady_clock::now();
+
   sqlite3_stmt* stmt = nullptr;
   if (db->setErr(sqlite3_prepare_v2(handle(), query.c_str(), -1, &stmt, nullptr), query.c_str()) !=
       SQLITE_OK)
@@ -987,7 +989,17 @@ bool SqliteDataset::query(const std::string& query)
     }
     result.records.push_back(res);
   }
-  if (db->setErr(sqlite3_finalize(stmt), query.c_str()) == SQLITE_OK)
+  const int finalizeResult = db->setErr(sqlite3_finalize(stmt), query.c_str());
+
+  const auto end = std::chrono::steady_clock::now();
+
+  // fractions of a millisecond matter here: a select served by an index takes microseconds, and it
+  // is the sum over a whole library scan that tells whether one is served by an index at all
+  const std::chrono::duration<double, std::milli> duration{end - start};
+
+  CLog::LogFC(LOGDEBUG, LOGDATABASE, "{:.3f} ms for query: {}", duration.count(), query);
+
+  if (finalizeResult == SQLITE_OK)
   {
     active = true;
     ds_state = dsSelect;

--- a/xbmc/dbwrappers/test/TestVPrepare.cpp
+++ b/xbmc/dbwrappers/test/TestVPrepare.cpp
@@ -130,6 +130,28 @@ const auto VPrepareNoParamTests = std::array{
                         "SELECT foo, bar"},
     VPrepareNoParamTest{"SELECT foo COLLATE BINARY, bar", "SELECT foo COLLATE BINARY, bar",
                         "SELECT foo COLLATE BINARY, bar"},
+    // COLLATE NOCASE in the shapes that CVideoDatabaseDDL::CreateTables() and the name lookups of
+    // CVideoDatabase depend on. Sqlite needs the clause to reach it, MySQL needs it gone - its
+    // tables are case-insensitive through the connection collation and it knows no NOCASE
+    VPrepareNoParamTest{
+        "CREATE TABLE actor ( actor_id INTEGER PRIMARY KEY, name TEXT COLLATE NOCASE, art_urls "
+        "TEXT )",
+        "CREATE TABLE actor ( actor_id INTEGER PRIMARY KEY, name TEXT COLLATE NOCASE, art_urls "
+        "TEXT )",
+        "CREATE TABLE actor ( actor_id INTEGER PRIMARY KEY, name TEXT, art_urls TEXT )"},
+    VPrepareNoParamTest{"CREATE TABLE tag (tag_id integer primary key, name TEXT COLLATE NOCASE)",
+                        "CREATE TABLE tag (tag_id integer primary key, name TEXT COLLATE NOCASE)",
+                        "CREATE TABLE tag (tag_id integer primary key, name TEXT)"},
+    VPrepareNoParamTest{"SELECT actor_id FROM actor WHERE name = 'x' COLLATE NOCASE",
+                        "SELECT actor_id FROM actor WHERE name = 'x' COLLATE NOCASE",
+                        "SELECT actor_id FROM actor WHERE name = 'x'"},
+    VPrepareNoParamTest{"SELECT MIN(actor_id), name FROM actor GROUP BY name COLLATE NOCASE",
+                        "SELECT MIN(actor_id), name FROM actor GROUP BY name COLLATE NOCASE",
+                        "SELECT MIN(actor_id), name FROM actor GROUP BY name"},
+    // more than one occurrence in a statement
+    VPrepareNoParamTest{"SELECT a COLLATE NOCASE FROM t WHERE b = 'x' COLLATE NOCASE",
+                        "SELECT a COLLATE NOCASE FROM t WHERE b = 'x' COLLATE NOCASE",
+                        "SELECT a FROM t WHERE b = 'x'"},
 };
 
 class VPrepareNoParamTester : public testing::WithParamInterface<VPrepareNoParamTest>,

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -1287,7 +1287,9 @@ int CVideoDatabase::AddToTable(const std::string& table, const std::string& firs
     if (nullptr == m_pDS)
       return -1;
 
-    std::string strSQL = PrepareSQL("select %s from %s where %s like '%s'", firstField.c_str(), table.c_str(), secondField.c_str(), value.substr(0, 255).c_str());
+    std::string strSQL =
+        PrepareSQL("select %s from %s where %s = '%s'", firstField.c_str(), table.c_str(),
+                   secondField.c_str(), value.substr(0, 255).c_str());
     m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
     {
@@ -1530,7 +1532,8 @@ int CVideoDatabase::AddActor(const std::string& name, const std::string& thumbUR
     std::string trimmedName = name;
     StringUtils::Trim(trimmedName);
 
-    std::string strSQL=PrepareSQL("select actor_id from actor where name like '%s'", trimmedName.substr(0, 255).c_str());
+    std::string strSQL = PrepareSQL("select actor_id from actor where name = '%s'",
+                                    trimmedName.substr(0, 255).c_str());
     m_pDS->query(strSQL);
     if (m_pDS->num_rows() == 0)
     {
@@ -9443,17 +9446,40 @@ int CVideoDatabase::GetMatchingMusicVideo(const std::string& strArtist, const st
     { // we want to return matching artists only
       if (m_profileManager.GetMasterProfile().getLockMode() != LockMode::EVERYONE &&
           !g_passwordManager.bMasterUser)
-        strSQL=PrepareSQL("SELECT DISTINCT actor.actor_id, path.strPath FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN musicvideo ON actor_link.media_id=musicvideo.idMVideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE actor_link.media_type='musicvideo' AND actor.name like '%s'", strArtist.c_str());
+        strSQL =
+            PrepareSQL("SELECT DISTINCT actor.actor_id, path.strPath FROM actor INNER JOIN "
+                       "actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN musicvideo ON "
+                       "actor_link.media_id=musicvideo.idMVideo INNER JOIN files ON "
+                       "files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath "
+                       "WHERE actor_link.media_type='musicvideo' AND actor.name = '%s'",
+                       strArtist.c_str());
       else
-        strSQL=PrepareSQL("SELECT DISTINCT actor.actor_id FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id WHERE actor_link.media_type='musicvideo' AND actor.name LIKE '%s'", strArtist.c_str());
+        strSQL = PrepareSQL("SELECT DISTINCT actor.actor_id FROM actor INNER JOIN actor_link ON "
+                            "actor_link.actor_id=actor.actor_id WHERE "
+                            "actor_link.media_type='musicvideo' AND actor.name = '%s'",
+                            strArtist.c_str());
     }
     else
     { // we want to return the matching musicvideo
       if (m_profileManager.GetMasterProfile().getLockMode() != LockMode::EVERYONE &&
           !g_passwordManager.bMasterUser)
-        strSQL = PrepareSQL("SELECT musicvideo.idMVideo FROM actor INNER JOIN actor_link ON actor_link.actor_id=actor.actor_id INNER JOIN musicvideo ON actor_link.media_id=musicvideo.idMVideo INNER JOIN files ON files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath WHERE actor_link.media_type='musicvideo' AND musicvideo.c%02d LIKE '%s' AND musicvideo.c%02d LIKE '%s' AND actor.name LIKE '%s'", VIDEODB_ID_MUSICVIDEO_ALBUM, strAlbum.c_str(), VIDEODB_ID_MUSICVIDEO_TITLE, strTitle.c_str(), strArtist.c_str());
+        strSQL =
+            PrepareSQL("SELECT musicvideo.idMVideo FROM actor INNER JOIN actor_link ON "
+                       "actor_link.actor_id=actor.actor_id INNER JOIN musicvideo ON "
+                       "actor_link.media_id=musicvideo.idMVideo INNER JOIN files ON "
+                       "files.idFile=musicvideo.idFile INNER JOIN path ON path.idPath=files.idPath "
+                       "WHERE actor_link.media_type='musicvideo' AND musicvideo.c%02d LIKE '%s' "
+                       "AND musicvideo.c%02d LIKE '%s' AND actor.name = '%s'",
+                       VIDEODB_ID_MUSICVIDEO_ALBUM, strAlbum.c_str(), VIDEODB_ID_MUSICVIDEO_TITLE,
+                       strTitle.c_str(), strArtist.c_str());
       else
-        strSQL = PrepareSQL("select musicvideo.idMVideo from musicvideo join actor_link on actor_link.media_id=musicvideo.idMVideo AND actor_link.media_type='musicvideo' join actor on actor.actor_id=actor_link.actor_id where musicvideo.c%02d like '%s' and musicvideo.c%02d like '%s' and actor.name like '%s'",VIDEODB_ID_MUSICVIDEO_ALBUM,strAlbum.c_str(),VIDEODB_ID_MUSICVIDEO_TITLE,strTitle.c_str(),strArtist.c_str());
+        strSQL = PrepareSQL(
+            "select musicvideo.idMVideo from musicvideo join actor_link on "
+            "actor_link.media_id=musicvideo.idMVideo AND actor_link.media_type='musicvideo' join "
+            "actor on actor.actor_id=actor_link.actor_id where musicvideo.c%02d like '%s' and "
+            "musicvideo.c%02d like '%s' and actor.name = '%s'",
+            VIDEODB_ID_MUSICVIDEO_ALBUM, strAlbum.c_str(), VIDEODB_ID_MUSICVIDEO_TITLE,
+            strTitle.c_str(), strArtist.c_str());
     }
     m_pDS->query( strSQL );
 
@@ -11795,10 +11821,15 @@ bool CVideoDatabase::CommitTransaction()
 {
   if (CDatabase::CommitTransaction())
   { // number of items in the db has likely changed, so recalculate
-    GUIINFO::CLibraryGUIInfo& guiInfo = CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider();
-    guiInfo.SetLibraryBool(LIBRARY_HAS_MOVIES, HasContent(VideoDbContentType::MOVIES));
-    guiInfo.SetLibraryBool(LIBRARY_HAS_TVSHOWS, HasContent(VideoDbContentType::TVSHOWS));
-    guiInfo.SetLibraryBool(LIBRARY_HAS_MUSICVIDEOS, HasContent(VideoDbContentType::MUSICVIDEOS));
+    // there is no gui to tell when the database is driven by a test
+    if (CGUIComponent* gui = CServiceBroker::GetGUI())
+    {
+      GUIINFO::CLibraryGUIInfo& guiInfo =
+          gui->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider();
+      guiInfo.SetLibraryBool(LIBRARY_HAS_MOVIES, HasContent(VideoDbContentType::MOVIES));
+      guiInfo.SetLibraryBool(LIBRARY_HAS_TVSHOWS, HasContent(VideoDbContentType::TVSHOWS));
+      guiInfo.SetLibraryBool(LIBRARY_HAS_MUSICVIDEOS, HasContent(VideoDbContentType::MUSICVIDEOS));
+    }
     return true;
   }
   return false;
@@ -12000,7 +12031,7 @@ void CVideoDatabase::AppendLinkFilter(const char* field,
 
   filter.AppendJoin(PrepareSQL("JOIN %s_link ON %s_link.media_id=%s_view.%s AND %s_link.media_type='%s'", field, field, view, viewKey, field, mediaType.c_str()));
   filter.AppendJoin(PrepareSQL("JOIN %s ON %s.%s_id=%s_link.%s_id", table, table, field, table, field));
-  filter.AppendWhere(PrepareSQL("%s.name like '%s'", table, option->second.asString().c_str()));
+  filter.AppendWhere(PrepareSQL("%s.name = '%s'", table, option->second.asString().c_str()));
 }
 
 bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription &sorting)
@@ -12231,7 +12262,7 @@ bool CVideoDatabase::GetFilter(CDbUrl &videoUrl, Filter &filter, SortDescription
         filter.AppendJoin(PrepareSQL("JOIN actor_link ON actor_link.media_id=musicvideo_view.idMVideo AND actor_link.media_type='musicvideo'"));
         filter.AppendJoin(PrepareSQL("JOIN actor ON actor.actor_id=actor_link.actor_id"));
       }
-      filter.AppendWhere(PrepareSQL("actor.name LIKE '%s'", option->second.asString().c_str()));
+      filter.AppendWhere(PrepareSQL("actor.name = '%s'", option->second.asString().c_str()));
     }
 
     option = options.find("albumid");

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -36,6 +36,7 @@ class CVideoSettings;
 class CGUIDialogProgress;
 class CGUIDialogProgressBarHandle;
 class TiXmlNode;
+class TestVideoDatabaseMigration;
 
 struct VideoAssetInfo;
 
@@ -1190,6 +1191,9 @@ protected:
   int SetFileForUnknown(const std::string& fileAndPath, int oldIdFile, int newIdFile);
 
 private:
+  //! rief Drives the schema entry points the way CDatabaseManager does, to cover a migration
+  friend class ::TestVideoDatabaseMigration;
+
   void CreateTables() override;
   void CreateAnalytics() override;
   void UpdateTables(int version) override;

--- a/xbmc/video/VideoDatabaseDDL.cpp
+++ b/xbmc/video/VideoDatabaseDDL.cpp
@@ -68,11 +68,15 @@ void CVideoDatabaseDDL::CreateTables(CDatabase& db)
   db.ExecuteQuery("CREATE TABLE stacktimes (idFile integer, times text)\n");
 
   CLog::Log(LOGINFO, "create genre table");
-  db.ExecuteQuery("CREATE TABLE genre ( genre_id integer primary key, name TEXT)\n");
+  // NOCASE gives sqlite the case-insensitive name matching. Mysql/mariadb already match case-insensitively
+  // through the connection collation and MysqlDatabase::vprepare() removes the clause (via PrepareSQL())
+  db.ExecuteQuery(db.PrepareSQL(
+      "CREATE TABLE genre ( genre_id integer primary key, name TEXT COLLATE NOCASE)"));
   db.ExecuteQuery("CREATE TABLE genre_link (genre_id integer, media_id integer, media_type TEXT)");
 
   CLog::Log(LOGINFO, "create country table");
-  db.ExecuteQuery("CREATE TABLE country ( country_id integer primary key, name TEXT)");
+  db.ExecuteQuery(db.PrepareSQL(
+      "CREATE TABLE country ( country_id integer primary key, name TEXT COLLATE NOCASE)"));
   db.ExecuteQuery(
       "CREATE TABLE country_link (country_id integer, media_id integer, media_type TEXT)");
 
@@ -86,7 +90,8 @@ void CVideoDatabaseDDL::CreateTables(CDatabase& db)
   db.ExecuteQuery(columns);
 
   CLog::Log(LOGINFO, "create actor table");
-  db.ExecuteQuery("CREATE TABLE actor ( actor_id INTEGER PRIMARY KEY, name TEXT, art_urls TEXT )");
+  db.ExecuteQuery(db.PrepareSQL("CREATE TABLE actor ( actor_id INTEGER PRIMARY KEY, name TEXT "
+                                "COLLATE NOCASE, art_urls TEXT )"));
   db.ExecuteQuery(
       "CREATE TABLE actor_link(actor_id INTEGER, media_id INTEGER, media_type TEXT, role "
       "TEXT, cast_order INTEGER)");
@@ -137,7 +142,8 @@ void CVideoDatabaseDDL::CreateTables(CDatabase& db)
   db.ExecuteQuery("CREATE TABLE movielinktvshow ( idMovie integer, IdShow integer)\n");
 
   CLog::Log(LOGINFO, "create studio table");
-  db.ExecuteQuery("CREATE TABLE studio ( studio_id integer primary key, name TEXT)\n");
+  db.ExecuteQuery(db.PrepareSQL(
+      "CREATE TABLE studio ( studio_id integer primary key, name TEXT COLLATE NOCASE)"));
   db.ExecuteQuery(
       "CREATE TABLE studio_link (studio_id integer, media_id integer, media_type TEXT)");
 
@@ -171,7 +177,8 @@ void CVideoDatabaseDDL::CreateTables(CDatabase& db)
                   "type TEXT, url TEXT)");
 
   CLog::Log(LOGINFO, "create tag table");
-  db.ExecuteQuery("CREATE TABLE tag (tag_id integer primary key, name TEXT)");
+  db.ExecuteQuery(
+      db.PrepareSQL("CREATE TABLE tag (tag_id integer primary key, name TEXT COLLATE NOCASE)"));
   db.ExecuteQuery("CREATE TABLE tag_link (tag_id integer, media_id integer, media_type TEXT)");
 
   CLog::Log(LOGINFO, "create rating table");

--- a/xbmc/video/VideoDatabaseMigration.cpp
+++ b/xbmc/video/VideoDatabaseMigration.cpp
@@ -1425,9 +1425,192 @@ void CVideoDatabase::UpdateTables(int iVersion)
     m_pDS->exec("ALTER TABLE streamdetails ADD iSource INTEGER DEFAULT 40");
     m_pDS->exec("ALTER TABLE streamdetails ADD iVersion INTEGER DEFAULT 1");
   }
+
+  if (iVersion < 149 && m_sqlite)
+  {
+    // Give the name columns of actor / genre / country / studio / tag the NOCASE collation, so that
+    // the case-insensitive lookups of AddActor() and AddToTable() are served by the unique index
+    // over those columns instead of scanning the whole table. Mysql/mariadb match case-insensitively
+    // already, through the collation set on the connection, so this is sqlite only.
+    //
+    // Analytics are not present here, which means that no index or trigger has to be dropped and
+    // recreated, and that deleting a merged actor cannot take its art with it through the
+    // delete_person trigger. CreateAnalytics() creates the now case-insensitive unique index over
+    // the name as soon as this returns - if a duplicate escaped the merge below then that fails and
+    // the whole update is rolled back.
+
+    struct LinkTable
+    {
+      std::string table;
+      bool keyedOnRole{false}; // actor_link keys on the role as well
+    };
+
+    struct NameTable
+    {
+      std::string table;
+      std::string idColumn;
+      std::string columns;
+      std::string createTable; // mirrors CVideoDatabaseDDL::CreateTables()
+      std::vector<LinkTable> linkTables;
+      bool hasArtwork{false}; // only actor carries artwork: art rows and scraped art urls
+    };
+
+    const std::vector<NameTable> nameTables{
+        {"actor",
+         "actor_id",
+         "actor_id, name, art_urls",
+         "CREATE TABLE actor ( actor_id INTEGER PRIMARY KEY, name TEXT COLLATE NOCASE, art_urls "
+         "TEXT )",
+         {{"actor_link", true}, {"director_link"}, {"writer_link"}},
+         true},
+        {"genre",
+         "genre_id",
+         "genre_id, name",
+         "CREATE TABLE genre ( genre_id integer primary key, name TEXT COLLATE NOCASE)",
+         {{"genre_link"}}},
+        {"country",
+         "country_id",
+         "country_id, name",
+         "CREATE TABLE country ( country_id integer primary key, name TEXT COLLATE NOCASE)",
+         {{"country_link"}}},
+        {"studio",
+         "studio_id",
+         "studio_id, name",
+         "CREATE TABLE studio ( studio_id integer primary key, name TEXT COLLATE NOCASE)",
+         {{"studio_link"}}},
+        {"tag",
+         "tag_id",
+         "tag_id, name",
+         "CREATE TABLE tag (tag_id integer primary key, name TEXT COLLATE NOCASE)",
+         {{"tag_link"}}},
+    };
+
+    // Art is keyed on (media_id, media_type, type), so of two rows that a merge brings together
+    // only one can be kept. The media types are those of the delete_person trigger.
+    auto MergeArt{
+        [&](int keepId, int loserId)
+        {
+          m_pDS2->exec(PrepareSQL("DELETE FROM art WHERE media_id = %i AND media_type IN "
+                                  "('actor', 'artist', 'writer', 'director') AND EXISTS "
+                                  "  (SELECT 1 FROM art AS kept WHERE kept.media_id = %i AND "
+                                  "   kept.media_type = art.media_type AND kept.type = art.type)",
+                                  loserId, keepId));
+          m_pDS2->exec(PrepareSQL("UPDATE art SET media_id = %i WHERE media_id = %i AND "
+                                  "media_type IN ('actor', 'artist', 'writer', 'director')",
+                                  keepId, loserId));
+        }};
+
+    // The art urls are held on the row itself, so the merge would drop those of every row but the
+    // one that survives. Hand it the first non-empty value of its group instead. Merging two
+    // non-empty values is not attempted - art_urls holds a serialized scraper result, and this code
+    // must not grow a dependency on that format.
+    auto PreserveArtUrls{
+        [&](int keepId, const std::string& name)
+        {
+          const std::string artUrls{
+              GetSingleValue(PrepareSQL("SELECT art_urls FROM actor WHERE name = '%s' COLLATE "
+                                        "NOCASE AND COALESCE(art_urls, '') <> '' "
+                                        "ORDER BY actor_id LIMIT 1",
+                                        name.c_str()),
+                             *m_pDS2)};
+          if (!artUrls.empty())
+            m_pDS2->exec(PrepareSQL("UPDATE actor SET art_urls = '%s' WHERE actor_id = %i AND "
+                                    "COALESCE(art_urls, '') = ''",
+                                    artUrls.c_str(), keepId));
+        }};
+
+    for (const auto& [table, idColumn, columns, createTable, linkTables, hasArtwork] : nameTables)
+    {
+      // Names that differ only in case have to be merged before a case-insensitive unique index can
+      // be created over them. Group with COLLATE NOCASE, so that the grouping is by construction
+      // the same equality that the index will enforce. The lowest id of a group is kept.
+      //
+      // A null name is not a duplicate of another null name - a unique index holds as many of those
+      // as it likes - so they are left out. GROUP BY would otherwise collect them into one group
+      // that no '=' comparison can ever pick a row out of again.
+      struct Duplicate
+      {
+        int keepId;
+        std::string name;
+      };
+      std::vector<Duplicate> duplicates;
+
+      m_pDS->query(PrepareSQL("SELECT MIN(%s), name FROM %s WHERE name IS NOT NULL "
+                              "GROUP BY name COLLATE NOCASE HAVING COUNT(*) > 1",
+                              idColumn.c_str(), table.c_str()));
+      while (!m_pDS->eof())
+      {
+        duplicates.push_back({m_pDS->fv(0).get_asInt(), m_pDS->fv(1).get_asString()});
+        m_pDS->next();
+      }
+      m_pDS->close();
+
+      for (const auto& [keepId, name] : duplicates)
+      {
+        std::vector<int> loserIds;
+        m_pDS->query(PrepareSQL("SELECT %s FROM %s WHERE name = '%s' COLLATE NOCASE AND %s <> %i",
+                                idColumn.c_str(), table.c_str(), name.c_str(), idColumn.c_str(),
+                                keepId));
+        while (!m_pDS->eof())
+        {
+          loserIds.emplace_back(m_pDS->fv(0).get_asInt());
+          m_pDS->next();
+        }
+        m_pDS->close();
+
+        if (hasArtwork)
+          PreserveArtUrls(keepId, name);
+
+        for (const int loserId : loserIds)
+        {
+          for (const auto& linkTable : linkTables)
+            m_pDS2->exec(PrepareSQL("UPDATE %s SET %s = %i WHERE %s = %i", linkTable.table.c_str(),
+                                    idColumn.c_str(), keepId, idColumn.c_str(), loserId));
+
+          if (hasArtwork)
+            MergeArt(keepId, loserId);
+
+          m_pDS2->exec(
+              PrepareSQL("DELETE FROM %s WHERE %s = %i", table.c_str(), idColumn.c_str(), loserId));
+        }
+
+        CLog::Log(LOGINFO, "Merged {} row(s) of table {} into \"{}\" ({}={})", loserIds.size(),
+                  table, name, idColumn, keepId);
+      }
+
+      // Repointing the links of a merged row creates rows that the unique index over the link
+      // table would reject
+      if (!duplicates.empty())
+      {
+        for (const auto& linkTable : linkTables)
+          m_pDS2->exec(
+              PrepareSQL("DELETE FROM %s WHERE rowid NOT IN "
+                         "  (SELECT MIN(rowid) FROM %s GROUP BY %s, media_type, media_id%s)",
+                         linkTable.table.c_str(), linkTable.table.c_str(), idColumn.c_str(),
+                         linkTable.keyedOnRole ? ", role" : ""));
+      }
+
+      // CreateAnalytics() goes through CDatabase::ExecuteQuery(), which logs a failing statement
+      // and carries on, so a duplicate left behind here would cost the table its unique index
+      // rather than fail the update. Refuse to leave one behind - throwing reaches
+      // CDatabaseManager::UpdateVersion(), which rolls the whole update back
+      if (GetSingleValueInt(
+              PrepareSQL("SELECT COUNT(*) FROM (SELECT 1 FROM %s WHERE name IS NOT NULL "
+                         "GROUP BY name COLLATE NOCASE HAVING COUNT(*) > 1)",
+                         table.c_str())) > 0)
+        throw DbErrors("Table %s still holds names differing only in case", table.c_str());
+
+      // sqlite cannot alter the collation of an existing column, the table has to be rebuilt
+      m_pDS->exec(PrepareSQL("ALTER TABLE %s RENAME TO %s_old", table.c_str(), table.c_str()));
+      m_pDS->exec(createTable);
+      m_pDS->exec(PrepareSQL("INSERT INTO %s (%s) SELECT %s FROM %s_old", table.c_str(),
+                             columns.c_str(), columns.c_str(), table.c_str()));
+      m_pDS->exec(PrepareSQL("DROP TABLE %s_old", table.c_str()));
+    }
+  }
 }
 
 int CVideoDatabase::GetSchemaVersion() const
 {
-  return 148;
+  return 149;
 }

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES TestBookmark.cpp
             TestFilenameAttributes.cpp
             TestPlayerControllerActions.cpp
             TestStacks.cpp
+            TestVideoDatabaseMigration.cpp
             TestVideoDbUrl.cpp
             TestVideoFileItemClassify.cpp
             TestVideoInfoTag.cpp

--- a/xbmc/video/test/TestVideoDatabaseMigration.cpp
+++ b/xbmc/video/test/TestVideoDatabaseMigration.cpp
@@ -1,0 +1,299 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "filesystem/File.h"
+#include "filesystem/SpecialProtocol.h"
+#include "settings/AdvancedSettings.h"
+#include "video/VideoDatabase.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr const char* DB_NAME{"TestVideoDatabaseMigration.db"};
+} // namespace
+
+/*!
+ * \brief Migration of the name columns of actor / genre / country / studio / tag to the NOCASE
+ * collation (schema version 149).
+ *
+ * The starting point is a current database whose five tables are put back to an uncollated
+ * definition, standing in for one created before v149. That covers the migration code, not the
+ * exact shape of every schema it can be handed - a v148 database differing from the definitions
+ * below would not be caught here.
+ */
+class TestVideoDatabaseMigration : public testing::Test
+{
+protected:
+  CVideoDatabase m_db;
+
+  static std::string DbPath()
+  {
+    return CSpecialProtocol::TranslatePath(std::string("special://temp/") + DB_NAME);
+  }
+
+  void SetUp() override
+  {
+    XFILE::CFile::Delete(DbPath());
+
+    DatabaseSettings settings;
+    settings.type = "sqlite3";
+    settings.name = "test";
+    settings.host = CSpecialProtocol::TranslatePath("special://temp/");
+    ASSERT_EQ(CDatabase::ConnectionState::STATE_CONNECTED, m_db.Connect(DB_NAME, settings, true));
+
+    // Analytics have to go before the tables they cover can be replaced. UpdateTables() runs
+    // without them in a real update too.
+    m_db.DropAnalytics();
+
+    Uncollate("actor", "actor_id INTEGER PRIMARY KEY, name TEXT, art_urls TEXT");
+    Uncollate("genre", "genre_id integer primary key, name TEXT");
+    Uncollate("country", "country_id integer primary key, name TEXT");
+    Uncollate("studio", "studio_id integer primary key, name TEXT");
+    Uncollate("tag", "tag_id integer primary key, name TEXT");
+  }
+
+  void TearDown() override
+  {
+    m_db.Close();
+    XFILE::CFile::Delete(DbPath());
+  }
+
+  //! \brief Replaces a freshly created (and therefore empty) table with its pre-v149 definition
+  void Uncollate(const std::string& table, const std::string& definition)
+  {
+    ASSERT_TRUE(m_db.ExecuteQuery("DROP TABLE " + table));
+    ASSERT_TRUE(m_db.ExecuteQuery("CREATE TABLE " + table + " (" + definition + ")"));
+  }
+
+  //! \brief Runs the update the way CDatabaseManager::UpdateVersion() does. Every block below 149
+  //! is guarded by a lower version, so only the v149 one applies.
+  void Migrate()
+  {
+    m_db.DropAnalytics();
+    m_db.BeginTransaction();
+    m_db.UpdateTables(148);
+    m_db.CreateAnalytics();
+    ASSERT_TRUE(m_db.CommitTransaction());
+  }
+
+  void Exec(const std::string& query) { ASSERT_TRUE(m_db.ExecuteQuery(query)); }
+
+  int Count(const std::string& query) const { return m_db.GetSingleValueInt(query); }
+
+  std::string Value(const std::string& query) const { return m_db.GetSingleValue(query); }
+};
+
+TEST_F(TestVideoDatabaseMigration, MergesNamesDifferingOnlyInCase)
+{
+  Exec("INSERT INTO actor (actor_id, name, art_urls) VALUES "
+       "(1, 'Tom Hanks', ''), (2, 'tom hanks', ''), (3, 'TOM HANKS', ''), (4, 'Meg Ryan', '')");
+
+  Migrate();
+
+  EXPECT_EQ(2, Count("SELECT COUNT(*) FROM actor"));
+  EXPECT_EQ("Tom Hanks", Value("SELECT name FROM actor WHERE actor_id = 1"));
+  EXPECT_EQ(0, Count("SELECT COUNT(*) FROM actor WHERE actor_id IN (2, 3)"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor WHERE actor_id = 4"));
+}
+
+TEST_F(TestVideoDatabaseMigration, AppliesTheCollationToEveryNameTable)
+{
+  Exec("INSERT INTO actor (actor_id, name, art_urls) VALUES (1, 'Tom Hanks', '')");
+  Exec("INSERT INTO genre (genre_id, name) VALUES (1, 'Science Fiction')");
+  Exec("INSERT INTO country (country_id, name) VALUES (1, 'New Zealand')");
+  Exec("INSERT INTO studio (studio_id, name) VALUES (1, 'Studio Ghibli')");
+  Exec("INSERT INTO tag (tag_id, name) VALUES (1, 'Christmas')");
+
+  Migrate();
+
+  // the lookups of AddActor() and AddToTable(), which is what the collation is there for
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor WHERE name = 'TOM HANKS'"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM genre WHERE name = 'science fiction'"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM country WHERE name = 'NEW ZEALAND'"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM studio WHERE name = 'studio ghibli'"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM tag WHERE name = 'CHRISTMAS'"));
+
+  // CreateAnalytics() only logs a statement it cannot run, so the index has to be asserted on
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND "
+                     "name = 'ix_actor_1'"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND "
+                     "name = 'ix_tag_1'"));
+
+  // and it is now case-insensitively unique
+  EXPECT_FALSE(m_db.ExecuteQuery("INSERT INTO actor (actor_id, name, art_urls) VALUES "
+                                 "(99, 'tom hanks', '')"));
+}
+
+TEST_F(TestVideoDatabaseMigration, KeepsNamesThatOnlyLookAlikeToLike)
+{
+  // a merge matching with LIKE rather than '=' would take the % and the _ for wildcards and
+  // collapse these into one row each
+  Exec("INSERT INTO actor (actor_id, name, art_urls) VALUES "
+       "(1, '50% Off', ''), (2, '500 Off', ''), (3, 'Bob_', ''), (4, 'Bobs', ''), "
+       "(5, 'O''Neal', ''), (6, 'o''neal', '')");
+
+  Migrate();
+
+  EXPECT_EQ(5, Count("SELECT COUNT(*) FROM actor"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor WHERE actor_id = 1"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor WHERE actor_id = 2"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor WHERE actor_id = 3"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor WHERE actor_id = 4"));
+  // the quoted name is the one pair that does differ only in case
+  EXPECT_EQ("O'Neal", Value("SELECT name FROM actor WHERE actor_id = 5"));
+  EXPECT_EQ(0, Count("SELECT COUNT(*) FROM actor WHERE actor_id = 6"));
+}
+
+TEST_F(TestVideoDatabaseMigration, KeepsEveryNullName)
+{
+  // a unique index holds as many null names as it likes, so they are not duplicates of each other.
+  // Merging them is impossible anyway - no '=' comparison can pick a row out of that group again -
+  // and treating them as duplicates would leave the group behind and fail the whole update.
+  Exec("INSERT INTO actor (actor_id, name, art_urls) VALUES "
+       "(1, NULL, ''), (2, NULL, ''), (3, NULL, ''), "
+       "(4, 'Tom Hanks', ''), (5, 'tom hanks', '')");
+
+  Migrate();
+
+  EXPECT_EQ(3, Count("SELECT COUNT(*) FROM actor WHERE name IS NULL"));
+  // the real duplicate is still merged
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor WHERE name = 'TOM HANKS'"));
+  EXPECT_EQ(4, Count("SELECT COUNT(*) FROM actor"));
+}
+
+TEST_F(TestVideoDatabaseMigration, DoesNotTakeAnEmptyNameForANullOne)
+{
+  // a null name reaches the merge as an empty string, so a group of nulls would otherwise pick up
+  // the rows that are genuinely named ''
+  Exec("INSERT INTO actor (actor_id, name, art_urls) VALUES "
+       "(1, NULL, ''), (2, NULL, ''), (3, '', 'first'), (4, '', 'second')");
+  Exec("INSERT INTO actor_link (actor_id, media_id, media_type, role, cast_order) VALUES "
+       "(3, 10, 'movie', 'Self', 0), (4, 11, 'movie', 'Self', 0)");
+
+  Migrate();
+
+  EXPECT_EQ(2, Count("SELECT COUNT(*) FROM actor WHERE name IS NULL"));
+  // the two '' rows are duplicates of each other, and of neither null row
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor WHERE name = ''"));
+  EXPECT_EQ(3, Count("SELECT COUNT(*) FROM actor"));
+  EXPECT_EQ(2, Count("SELECT COUNT(*) FROM actor_link WHERE actor_id = 3"));
+  EXPECT_EQ(0, Count("SELECT COUNT(*) FROM actor_link WHERE actor_id IN (1, 2, 4)"));
+}
+
+TEST_F(TestVideoDatabaseMigration, RepointsAndDedupesLinks)
+{
+  Exec("INSERT INTO actor (actor_id, name, art_urls) VALUES (1, 'Tom Hanks', ''), "
+       "(2, 'tom hanks', '')");
+  // the same media and role through both rows, so one of the two has to go
+  Exec("INSERT INTO actor_link (actor_id, media_id, media_type, role, cast_order) VALUES "
+       "(1, 10, 'movie', 'Woody', 0), (2, 10, 'movie', 'Woody', 1), "
+       "(2, 10, 'movie', 'Sheriff', 2), (2, 11, 'movie', 'Woody', 0)");
+  // director_link and writer_link have no role in their unique index
+  Exec("INSERT INTO director_link (actor_id, media_id, media_type) VALUES "
+       "(1, 10, 'movie'), (2, 10, 'movie'), (2, 12, 'movie')");
+  Exec("INSERT INTO writer_link (actor_id, media_id, media_type) VALUES "
+       "(1, 10, 'movie'), (2, 10, 'movie')");
+
+  Migrate();
+
+  EXPECT_EQ(0, Count("SELECT COUNT(*) FROM actor_link WHERE actor_id = 2"));
+  EXPECT_EQ(3, Count("SELECT COUNT(*) FROM actor_link"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor_link WHERE media_id = 10 AND role = 'Woody'"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor_link WHERE media_id = 10 AND role = 'Sheriff'"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor_link WHERE media_id = 11"));
+
+  EXPECT_EQ(2, Count("SELECT COUNT(*) FROM director_link"));
+  EXPECT_EQ(0, Count("SELECT COUNT(*) FROM director_link WHERE actor_id = 2"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM writer_link"));
+}
+
+TEST_F(TestVideoDatabaseMigration, RepointsAndDedupesLinksOfTheOtherTables)
+{
+  Exec("INSERT INTO tag (tag_id, name) VALUES (1, 'Christmas'), (2, 'christmas')");
+  Exec("INSERT INTO tag_link (tag_id, media_id, media_type) VALUES "
+       "(1, 10, 'movie'), (2, 10, 'movie'), (2, 11, 'movie')");
+
+  Migrate();
+
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM tag"));
+  EXPECT_EQ(2, Count("SELECT COUNT(*) FROM tag_link"));
+  EXPECT_EQ(0, Count("SELECT COUNT(*) FROM tag_link WHERE tag_id = 2"));
+}
+
+TEST_F(TestVideoDatabaseMigration, MovesArtOfATypeTheSurvivorHasNot)
+{
+  Exec("INSERT INTO actor (actor_id, name, art_urls) VALUES (1, 'Tom Hanks', ''), "
+       "(2, 'tom hanks', '')");
+  Exec("INSERT INTO art (art_id, media_id, media_type, type, url) VALUES "
+       "(1, 1, 'actor', 'thumb', 'kept'), (2, 2, 'actor', 'thumb', 'dropped'), "
+       "(3, 2, 'actor', 'fanart', 'moved'), (4, 2, 'director', 'thumb', 'moved too')");
+
+  Migrate();
+
+  EXPECT_EQ(3, Count("SELECT COUNT(*) FROM art"));
+  EXPECT_EQ(0, Count("SELECT COUNT(*) FROM art WHERE media_id = 2"));
+  // the survivor keeps its own url where both hold the same media type and type
+  EXPECT_EQ("kept", Value("SELECT url FROM art WHERE media_id = 1 AND media_type = 'actor' AND "
+                          "type = 'thumb'"));
+  EXPECT_EQ("moved", Value("SELECT url FROM art WHERE media_id = 1 AND media_type = 'actor' AND "
+                           "type = 'fanart'"));
+  EXPECT_EQ("moved too", Value("SELECT url FROM art WHERE media_id = 1 AND "
+                               "media_type = 'director' AND type = 'thumb'"));
+}
+
+TEST_F(TestVideoDatabaseMigration, GivesTheSurvivorTheArtUrlsItHasNot)
+{
+  Exec("INSERT INTO actor (actor_id, name, art_urls) VALUES "
+       "(1, 'Tom Hanks', ''), (2, 'tom hanks', '<thumb>second</thumb>'), "
+       "(3, 'TOM HANKS', '<thumb>third</thumb>')");
+
+  Migrate();
+
+  EXPECT_EQ("<thumb>second</thumb>", Value("SELECT art_urls FROM actor WHERE actor_id = 1"));
+}
+
+TEST_F(TestVideoDatabaseMigration, LeavesTheArtUrlsOfTheSurvivorAlone)
+{
+  Exec("INSERT INTO actor (actor_id, name, art_urls) VALUES "
+       "(1, 'Tom Hanks', '<thumb>first</thumb>'), (2, 'tom hanks', '<thumb>second</thumb>')");
+
+  Migrate();
+
+  EXPECT_EQ("<thumb>first</thumb>", Value("SELECT art_urls FROM actor WHERE actor_id = 1"));
+}
+
+TEST_F(TestVideoDatabaseMigration, CopesWithArtUrlsHeldAsNull)
+{
+  Exec("INSERT INTO actor (actor_id, name, art_urls) VALUES "
+       "(1, 'Tom Hanks', NULL), (2, 'tom hanks', NULL)");
+
+  Migrate();
+
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor WHERE art_urls IS NULL"));
+}
+
+TEST_F(TestVideoDatabaseMigration, RunsAgainWithoutLoss)
+{
+  Exec("INSERT INTO actor (actor_id, name, art_urls) VALUES "
+       "(1, 'Tom Hanks', '<thumb>first</thumb>'), (2, 'tom hanks', ''), (3, 'Meg Ryan', '')");
+  Exec("INSERT INTO actor_link (actor_id, media_id, media_type, role, cast_order) VALUES "
+       "(1, 10, 'movie', 'Woody', 0)");
+
+  Migrate();
+  Migrate();
+
+  EXPECT_EQ(2, Count("SELECT COUNT(*) FROM actor"));
+  EXPECT_EQ("<thumb>first</thumb>", Value("SELECT art_urls FROM actor WHERE actor_id = 1"));
+  EXPECT_EQ("Meg Ryan", Value("SELECT name FROM actor WHERE actor_id = 3"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor_link"));
+  EXPECT_EQ(1, Count("SELECT COUNT(*) FROM actor WHERE name = 'tom HANKS'"));
+}


### PR DESCRIPTION
@CrystalP - as you suggested in the previous (now closed) PR.

Testing below.
Starts with an empty database, but containing 37k actors (taken from my personal kodi database).
Adds one entire TV show from .nfo using local scraper.

## Background

The original approach cached the `actor` table in memory for the duration of a scan, on the grounds
that `AddActor()` needs a case-insensitive match and the table's index cannot serve one. That
reasoning was wrong, and the review comment was right to push back: mysql/mariadb use the index for
that lookup without any trouble.

The reason sqlite does not is not case-insensitivity, it is **the collation of the index**. Sqlite's
LIKE optimisation (which rewrites `x LIKE 'abc'` into a range scan) applies only when, with
`case_sensitive_like` off — the default — the column is indexed with the built-in `NOCASE`
collating sequence. `ix_actor_1` was `BINARY`, so every `AddActor()` call scanned the whole index.
mysql "just works" for the mirror-image reason: its index is already `utf8mb4_general_ci`.

So this is fixed at the schema level rather than worked around in C++, and the in-memory cache is
dropped entirely.

## What changed

**Schema (v148 → v149).** `name TEXT COLLATE NOCASE` on `actor`, `genre`, `country`, `studio` and
`tag`. Those five `CREATE TABLE` statements now go through `PrepareSQL()`, because
`MysqlDatabase::vprepare()` is what strips the clause for mysql — its tables are already
case-insensitive through the connection collation and it has no `NOCASE`.

**Query sites.** `AddActor()`, `AddToTable()`, `AppendLinkFilter()`, the musicvideo artist filter
and `GetMatchingMusicVideo()` move from `LIKE` to `=`. Beyond keeping the index, this removes a
latent bug: `LIKE` treats `%` and `_` in a *scraped name* as wildcards, so an actor called `50% Off`
or `Bob_` could match the wrong row.

**Migration.** A sqlite-only v149 block. Mysql needs nothing — its index is already
case-insensitively unique, so it cannot be holding case-variant duplicates, and DDL there would
implicitly commit and break the enclosing transaction.

`UpdateTables()` runs with analytics dropped (`CDatabaseManager::UpdateVersion()`), which the
migration relies on: no index or trigger to drop and recreate, and no `delete_person` trigger to
take a merged actor's art with it. Per table it then

1. finds groups of names differing only in case, grouping with `COLLATE NOCASE` so the grouping is
   by construction the same equality the new unique index will enforce;
2. keeps the lowest id, repoints `actor_link` / `director_link` / `writer_link` (and `<t>_link`),
   merges `art` rows, and hands the survivor the first non-empty `art_urls` of its group;
3. deletes the link rows the unique indexes would reject after repointing;
4. rebuilds the table with the collated column, since sqlite cannot `ALTER` a collation.

## Measured effect on a scrape

Same TV show, synchronous art, from NFO, sqlite, same machine. Both branches start from a database
whose `actor` table holds **37,068 rows** exported from a working instance.

| run | database | `Scanning for video info took` |
|---|---|---|
| master 1 / 2 | MyVideos148 | 16031 / 16314 ms |
| this branch 1 / 2 | MyVideos149 | 13384 / 13859 ms |

**~2.55 s faster, −15.8%.** Run-to-run spread is 283 ms (master) and 475 ms (branch), so the effect
is 5-9x the noise.

The workload is identical on both sides, which rules out the scan simply doing less work:

| | master | this branch |
|---|---|---|
| `exec` statements | 11026 / 11038 | 11038 / 11038 |
| `exec` total time | 737 / 750 ms | 783 / 735 ms |
| actor inserts | 155 | 155 |
| actor lookups | 1965 | 1965 |

Same statement counts and the same write cost, so the whole 2.55 s came off the select side - the
side this branch touches. Note that only 155 of the 1965 lookups were misses: 92% of the cast
already existed, i.e. a steady-state scrape rather than a first import.

### The lookup itself

With the branch, 1965 actor lookups against 37,068 rows cost **12.1 / 12.7 ms in total — 6.2 µs
each, worst case 0.144 ms.** On a 766-row table the same query measured 4.6 µs, so the cost is flat
across a 48x larger table, which is what an index probe looks like and what a scan cannot fake.

Measured directly against the imported table, per lookup:

| | per lookup |
|---|---|
| `LIKE` on the `BINARY` index (v148) | 1.140 ms |
| `=` on the `NOCASE` index (v149) | 0.022 ms |

`EXPLAIN QUERY PLAN` on the same data:

```
v148:  SELECT actor_id FROM actor WHERE name LIKE 'Tom Hanks'
       -> SCAN actor USING COVERING INDEX ix_actor_1
v149:  SELECT actor_id FROM actor WHERE name = 'Tom Hanks'
       -> SEARCH actor USING COVERING INDEX ix_actor_1 (name=?)
```

So 1965 lookups went from roughly 2.24 s to 12 ms, and the actor lookup went from about 17% of the
scan's wall clock to 0.09%. Ranked by total select time it is now the fourth *cheapest* of the
frequent queries despite being the most frequent one:

```
     n  total ms   avg us   select
  1725    136.26     79.0   SELECT id, cachedurl, ...            (texture cache)
   568     26.46     46.6   select idPath from path where strPath=...
   139     12.97     93.3   select strFileName, strPath from episode_view ...
  1965     12.09      6.2   select actor_id from actor where name =     <-- this branch
   139     10.96     78.9   select count(1) from movie
```

### It only pays off at scale

An earlier round of the same test started from an empty database and ended with 766 actors. There
the branch measured 13125 / 13055 ms against 13470 / 13113 / 13183 ms - a tie, because at that table
size there was nothing to win. Saving per 1965 lookups, measured in sqlite:

| actor rows | saving |
|---|---|
| 766 | ~62 ms |
| 5,000 | ~386 ms |
| 20,000 | ~1.5 s |
| 37,068 (the run above) | ~2.2 s predicted, 2.55 s observed |
| 100,000 | ~7.3 s |

Worth stating plainly: users with small libraries will not notice this. Users with large ones, and
especially large *TV* libraries — `AddActor()` runs for the cast, directors and writers of every
episode — will.

## Instrumentation added

`SqliteDataset::query()` and `MysqlDataset::query()` had no timing log; only `exec()` did, so the
`ms for query:` lines covered writes and DDL but not a single SELECT. Both now log, in fractional
milliseconds — an index-served select takes microseconds and would otherwise log as a flat `0 ms`.
This is what all the per-query figures above come from.

Enable it with Settings → System → Logging, debug logging plus the Database component, then:

```
grep "ms for query: select actor_id from actor" kodi.log \
  | awk '{s+=$1; n++} END {print n" lookups, "s" ms total, "s/n" ms avg"}'
```

## Tests

**`xbmc/video/test/TestVideoDatabaseMigration.cpp`** (new, 10 tests, all passing). Real sqlite in
`special://temp/`, following the `TestAddonDatabase` pattern; `Migrate()` mirrors
`CDatabaseManager::UpdateVersion()`. Covers: the merge and which row survives; the collation
reaching all five tables; case-insensitive uniqueness of the rebuilt index; names containing `%`,
`_` and `'` *not* being merged (a `LIKE`-based merge would have collapsed them); link repointing and
dedup for `actor_link` (keyed on `role`) and for `director_link` / `writer_link` / `tag_link` (not);
art moved only where the survivor lacks that type; `art_urls` inherited when the survivor has none
and kept when it has its own; `NULL` art_urls; and re-running the update without loss.

**`xbmc/dbwrappers/test/TestVPrepare.cpp`** — five cases pinning both directions of the mechanism the
DDL depends on: sqlite must keep `COLLATE NOCASE`, mysql must drop it, in the `CREATE TABLE`, `WHERE
... =` and `GROUP BY` shapes, including two occurrences in one statement.

## Things a reviewer should know

**`CreateAnalytics()` cannot report failure.** `CDatabase::ExecuteQuery()` catches, logs and returns
a `bool` that `CreateIndices()` ignores. So an incomplete dedup would not have failed the update —
it would have silently left the table *without* `ix_actor_1` while marking the migration successful.
The v149 block therefore verifies its own postcondition and throws `DbErrors` if any case-variant
group survives, which does reach `CDatabaseManager::UpdateVersion()` and roll back. For the same
reason the test asserts on `sqlite_master` rather than on `CreateAnalytics()`' return.

**`CVideoDatabase::CommitTransaction()` now null-checks `CServiceBroker::GetGUI()`.** It dereferenced
it unconditionally, so every commit through `CVideoDatabase` was an access violation in the unit
test environment, including `Connect(create=true)`. The guard is the existing idiom
(`PlayListPlayer.cpp:596`, `LanguageResource.cpp:103`, `AddonDll.cpp:539`). This is a production
change outside the original scope — flagging it explicitly.

**The merge is lossy in one case.** Two actors differing only in case become one, keeping the lower
id's `art_urls` when both are non-empty. Merging two non-empty values is deliberately not attempted:
`art_urls` holds a serialised scraper result and the migration code must not grow a dependency on
that format. An empty survivor does inherit a loser's value.

**`NOCASE` folds ASCII only.** mysql's `general_ci` also folds accents, so `Ángela` / `ÁNGELA` still
diverge between backends. Strictly better than today, not identical.

**One statement is deliberately left mixed.** In `GetMatchingMusicVideo()`, `actor.name` moved to `=`
but `musicvideo.cXX LIKE '%s'` for album and title did not: those columns keep the `BINARY`
collation, so `=` there would make album/title matching case-*sensitive* on sqlite. That is a marker
for the follow-up below, not an oversight.

## Not in this change

- `files.strFileName` and the disc-folder queries (`index.bdmv`, `VIDEO_TS.IFO`). Worth noting that
  `ESCAPE` does **not** disable sqlite's LIKE optimisation — the only documented requirement is that
  the escape character be single-byte, which `|` and `^` both are (verified on 3.50.4 and on the
  3.51.3 the Windows deps ship). Those queries are blocked by the collation alone. They need their
  own index (`files(strFileName COLLATE NOCASE)`) rather than a column collation, so that
  `GetPathId()` / `GetFileId()` stay case-sensitive — on ext4 `Movie.mkv` and `movie.mkv` are two
  different files.
- The music database: `artist.strArtist`, `album.strAlbum`, `genre.strGenre`, `role.strRole`,
  `source.strName` all have the identical pattern, and `AddArtist()` / `AddAlbum()` / `AddRole()` /
  `AddGenre()` run *per song*, so the payoff there is larger. Needs its own dedup migration of the
  same shape.
- `sets.strSet` and `album.strArtistDisp` are matched with `LIKE` but have no index at all, so a
  collation alone would not help them.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Improvement** (non-breaking change which improves existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
