### PR TITLE
changed: share one web server across each test suite instead of starting one per test

### DIFF
--- a/xbmc/filesystem/test/TestHTTPDirectory.cpp
+++ b/xbmc/filesystem/test/TestHTTPDirectory.cpp
@@ -21,6 +21,7 @@
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
 
+#include <memory>
 #include <stdlib.h>
 
 #include <gtest/gtest.h>
@@ -72,25 +73,40 @@ protected:
   ~TestHTTPDirectory() override = default;
 
 protected:
+  //! CWebServer's constructor needs the service broker's logger, which does not exist
+  //! during static initialisation.
+  static void SetUpTestSuite()
+  {
+    s_webServer = std::make_unique<CWebServer>();
+    s_vfsHandler = std::make_unique<CHTTPVfsHandler>();
+
+    ASSERT_TRUE(s_webServer->Start(0, "", ""));
+    s_baseUrl = StringUtils::Format("http://" WEBSERVER_HOST ":{}", s_webServer->GetPort());
+
+    s_webServer->RegisterRequestHandler(s_vfsHandler.get());
+  }
+
+  static void TearDownTestSuite()
+  {
+    if (s_webServer->IsStarted())
+      s_webServer->Stop();
+
+    s_webServer->UnregisterRequestHandler(s_vfsHandler.get());
+
+    s_vfsHandler.reset();
+    s_webServer.reset();
+    s_baseUrl.clear();
+  }
+
   void SetUp() override
   {
     CServiceBroker::RegisterDNSNameCache(std::make_shared<CDNSNameCache>());
 
     SetupMediaSources();
-
-    ASSERT_TRUE(m_webServer.Start(0, "", ""));
-    m_baseUrl = StringUtils::Format("http://" WEBSERVER_HOST ":{}", m_webServer.GetPort());
-
-    m_webServer.RegisterRequestHandler(&m_vfsHandler);
   }
 
   void TearDown() override
   {
-    if (m_webServer.IsStarted())
-      m_webServer.Stop();
-
-    m_webServer.UnregisterRequestHandler(&m_vfsHandler);
-
     TearDownMediaSources();
 
     CServiceBroker::UnregisterDNSNameCache();
@@ -115,9 +131,9 @@ protected:
   std::string GetUrl(const std::string& path)
   {
     if (path.empty())
-      return m_baseUrl;
+      return s_baseUrl;
 
-    return URIUtils::AddFileToFolder(m_baseUrl, path);
+    return URIUtils::AddFileToFolder(s_baseUrl, path);
   }
 
   std::string GetUrlOfTestFile(const std::string& testFile)
@@ -204,16 +220,20 @@ protected:
     CheckFileItemSizes(items);
   }
 
-  CWebServer m_webServer;
-  std::string m_baseUrl;
+  static std::unique_ptr<CWebServer> s_webServer;
+  static std::string s_baseUrl;
   std::string const m_sourcePath;
-  CHTTPVfsHandler m_vfsHandler;
+  static std::unique_ptr<CHTTPVfsHandler> s_vfsHandler;
   CHTTPDirectory m_httpDirectory;
 };
 
+std::unique_ptr<CWebServer> TestHTTPDirectory::s_webServer;
+std::string TestHTTPDirectory::s_baseUrl;
+std::unique_ptr<CHTTPVfsHandler> TestHTTPDirectory::s_vfsHandler;
+
 TEST_F(TestHTTPDirectory, IsStarted)
 {
-  ASSERT_TRUE(m_webServer.IsStarted());
+  ASSERT_TRUE(s_webServer->IsStarted());
 }
 
 TEST_F(TestHTTPDirectory, ApacheDefaultIndex)

--- a/xbmc/network/test/TestWebServer.cpp
+++ b/xbmc/network/test/TestWebServer.cpp
@@ -28,7 +28,9 @@
 #include "utils/Variant.h"
 
 #include <errno.h>
+#include <memory>
 #include <stdlib.h>
+#include <string_view>
 
 #include <gtest/gtest.h>
 
@@ -46,39 +48,56 @@ using namespace XFILE;
 class TestWebServer : public testing::Test
 {
 protected:
-  TestWebServer()
-    : webserver(),
-      sourcePath(XBMC_REF_FILE_PATH("xbmc/network/test/data/webserver/"))
-  {
-  }
+  TestWebServer() : sourcePath(XBMC_REF_FILE_PATH("xbmc/network/test/data/webserver/")) {}
   ~TestWebServer() override = default;
 
 protected:
+  //! CWebServer's constructor needs the service broker's logger, which does not exist
+  //! during static initialisation.
+  static void StartSuiteServer(std::string_view username, std::string_view password)
+  {
+    s_webserver = std::make_unique<CWebServer>();
+    s_jsonRpcHandler = std::make_unique<CHTTPJsonRpcHandler>();
+    s_vfsHandler = std::make_unique<CHTTPVfsHandler>();
+
+    ASSERT_TRUE(s_webserver->Start(0, std::string{username}, std::string{password}));
+    s_baseUrl = StringUtils::Format("http://" WEBSERVER_HOST ":{}", s_webserver->GetPort());
+
+    s_webserver->RegisterRequestHandler(s_jsonRpcHandler.get());
+    s_webserver->RegisterRequestHandler(s_vfsHandler.get());
+  }
+
+  static void StopSuiteServer()
+  {
+    if (s_webserver->IsStarted())
+      s_webserver->Stop();
+
+    s_webserver->UnregisterRequestHandler(s_vfsHandler.get());
+    s_webserver->UnregisterRequestHandler(s_jsonRpcHandler.get());
+
+    s_vfsHandler.reset();
+    s_jsonRpcHandler.reset();
+    s_webserver.reset();
+    s_baseUrl.clear();
+  }
+
+  static void SetUpTestSuite() { StartSuiteServer(SERVER_USERNAME, SERVER_PASSWORD); }
+
+  static void TearDownTestSuite() { StopSuiteServer(); }
+
   void SetUp() override
   {
     CServiceBroker::RegisterDNSNameCache(std::make_shared<CDNSNameCache>());
 
     SetupMediaSources();
-
-    ASSERT_TRUE(webserver.Start(0, GetServerUsername(), GetServerPassword()));
-    baseUrl = StringUtils::Format("http://" WEBSERVER_HOST ":{}", webserver.GetPort());
-
-    webserver.RegisterRequestHandler(&m_jsonRpcHandler);
-    webserver.RegisterRequestHandler(&m_vfsHandler);
   }
 
-  //! \brief Credentials the test web server requires. Empty means no authentication.
-  virtual std::string GetServerUsername() const { return ""; }
-  virtual std::string GetServerPassword() const { return ""; }
+  // Credentials this suite's server requires. Empty means no authentication.
+  static constexpr std::string_view SERVER_USERNAME{""};
+  static constexpr std::string_view SERVER_PASSWORD{""};
 
   void TearDown() override
   {
-    if (webserver.IsStarted())
-      webserver.Stop();
-
-    webserver.UnregisterRequestHandler(&m_vfsHandler);
-    webserver.UnregisterRequestHandler(&m_jsonRpcHandler);
-
     TearDownMediaSources();
 
     CServiceBroker::UnregisterDNSNameCache();
@@ -106,9 +125,9 @@ protected:
   std::string GetUrl(const std::string& path)
   {
     if (path.empty())
-      return baseUrl;
+      return s_baseUrl;
 
-    return URIUtils::AddFileToFolder(baseUrl, path);
+    return URIUtils::AddFileToFolder(s_baseUrl, path);
   }
 
   std::string GetUrlOfTestFile(const std::string& testFile)
@@ -353,22 +372,39 @@ protected:
     return StringUtils::Format("bytes={}-{}", start, end);
   }
 
-  CWebServer webserver;
-  CHTTPJsonRpcHandler m_jsonRpcHandler;
-  CHTTPVfsHandler m_vfsHandler;
-  std::string baseUrl;
+  static std::unique_ptr<CWebServer> s_webserver;
+  static std::unique_ptr<CHTTPJsonRpcHandler> s_jsonRpcHandler;
+  static std::unique_ptr<CHTTPVfsHandler> s_vfsHandler;
+  static std::string s_baseUrl;
   std::string sourcePath;
 };
 
-TEST_F(TestWebServer, IsStarted)
+std::unique_ptr<CWebServer> TestWebServer::s_webserver;
+std::unique_ptr<CHTTPJsonRpcHandler> TestWebServer::s_jsonRpcHandler;
+std::unique_ptr<CHTTPVfsHandler> TestWebServer::s_vfsHandler;
+std::string TestWebServer::s_baseUrl;
+
+TEST(TestWebServerLifecycle, IsStarted)
 {
-  ASSERT_TRUE(webserver.IsStarted());
+  CWebServer server;
+  EXPECT_FALSE(server.IsStarted());
+
+  ASSERT_TRUE(server.Start(0, "", ""));
+  EXPECT_TRUE(server.IsStarted());
+
+  server.Stop();
+  EXPECT_FALSE(server.IsStarted());
 }
 
-TEST_F(TestWebServer, ReportsThePortAssignedByTheOperatingSystem)
+TEST(TestWebServerLifecycle, ReportsThePortAssignedByTheOperatingSystem)
 {
-  ASSERT_TRUE(webserver.IsStarted());
-  EXPECT_NE(0, webserver.GetPort());
+  CWebServer server;
+  ASSERT_TRUE(server.Start(0, "", ""));
+
+  EXPECT_TRUE(server.IsStarted());
+  EXPECT_NE(0, server.GetPort());
+
+  server.Stop();
 }
 
 TEST_F(TestWebServer, TwoServersDoNotShareAPort)
@@ -377,7 +413,7 @@ TEST_F(TestWebServer, TwoServersDoNotShareAPort)
   ASSERT_TRUE(other.Start(0, "", ""));
 
   EXPECT_NE(0, other.GetPort());
-  EXPECT_NE(webserver.GetPort(), other.GetPort());
+  EXPECT_NE(s_webserver->GetPort(), other.GetPort());
 
   other.Stop();
   EXPECT_EQ(0, other.GetPort());
@@ -954,8 +990,12 @@ TEST_F(TestWebServer, CanGetCachedRangedFileWithNewerIfRange)
 class TestWebServerAuth : public TestWebServer
 {
 protected:
-  std::string GetServerUsername() const override { return "kodi"; }
-  std::string GetServerPassword() const override { return "secret"; }
+  static constexpr std::string_view SERVER_USERNAME{"kodi"};
+  static constexpr std::string_view SERVER_PASSWORD{"secret"};
+
+  static void SetUpTestSuite() { StartSuiteServer(SERVER_USERNAME, SERVER_PASSWORD); }
+
+  static void TearDownTestSuite() { StopSuiteServer(); }
 
   void SetUp() override
   {
@@ -963,9 +1003,9 @@ protected:
     TestWebServer::SetUp();
 
     // remember the credentials for the server, as saving a source with a username/password does
-    CURL authenticatedUrl{baseUrl};
-    authenticatedUrl.SetUserName(GetServerUsername());
-    authenticatedUrl.SetPassword(GetServerPassword());
+    CURL authenticatedUrl{s_baseUrl};
+    authenticatedUrl.SetUserName(std::string{SERVER_USERNAME});
+    authenticatedUrl.SetPassword(std::string{SERVER_PASSWORD});
     CPasswordManager::GetInstance().SaveAuthenticatedURL(authenticatedUrl, false);
   }
 


### PR DESCRIPTION
**TL;DR:** Improvement, test-only. `TestWebServer` and `TestHTTPDirectory` start one web server per suite instead of one per test, cutting about a hundred libmicrohttpd daemon starts from every run with no change to what is asserted.

## Description
`TestWebServer` and `TestHTTPDirectory` each build a complete `CWebServer` in `SetUp` and tear it down again in `TearDown`. Across the two fixtures that is 49 servers started and stopped per run, to support assertions that need *a* server to answer requests rather than a server of their own.

`CWebServer::Start` brings up two libmicrohttpd daemons - an IPv6 one, then an IPv4 one on the port the first was assigned - so the actual cost is around a hundred daemon starts per run, and it is by far the most expensive thing either fixture does.

This moves the server into `SetUpTestSuite` / `TearDownTestSuite`, so each suite starts one. The state that genuinely is per-test - the DNS name cache and the media sources - stays in `SetUp` / `TearDown`, and the request handlers are registered once, alongside the server they belong to.

Three tests deliberately keep starting their own server, because the server lifecycle is what they are testing and sharing one already brought up by the fixture would leave them asserting nothing:

- `IsStarted` - now covers the transition in both directions rather than only the started state
- `ReportsThePortAssignedByTheOperatingSystem`
- `TwoServersDoNotShareAPort` - which needs two live servers by definition

`TestWebServerAuth` needs a server that demands credentials, so it starts its own rather than sharing the unauthenticated one. The credentials become named constants so the server and the password manager cannot drift apart.

The server is held in a `unique_ptr` created in `SetUpTestSuite` rather than in a static object, because `CWebServer`'s constructor takes a logger from the service broker, which does not exist yet during static initialisation.

## Motivation and context
Test fixture cost only. No production code is touched and no test coverage changes - the same 49 tests run, making the same assertions.

Beyond the time saved, a test that quietly depends on having a private server is a coupling worth making explicit: after this change the three tests that really do need one say so, and the rest are clearly independent of server startup.

## How has this been tested?
- Full suite on Windows x64: **3972 tests, all passing**
- The two affected fixtures: **49 tests from 4 test suites, 240 ms** (previously ~380 ms), with no change in which tests run or what they assert
- `clang-format` clean on the changed lines

## What is the effect on users?
None. Test-only change.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [X] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
