### PR TITLE
[guilib] Guard focus recovery until window initialization

### DIFF
--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -338,11 +338,15 @@ void CGUIWindow::DoProcess(unsigned int currentTime, CDirtyRegionList &dirtyregi
   CGUIControlGroup::DoProcess(currentTime, dirtyregions);
   CServiceBroker::GetWinSystem()->GetGfxContext().RemoveTransform();
 
-  // check if currently focused control can have it
-  // and fallback to default control if not
-  CGUIControl* focusedControl = GetFocusedControl();
-  if (focusedControl && !focusedControl->CanFocus() && focusedControl->GetID() != m_defaultControl)
-    SET_CONTROL_FOCUS(m_defaultControl, 0);
+  if (m_active)
+  {
+    // check if currently focused control can have it
+    // and fallback to default control if not
+    CGUIControl* focusedControl = GetFocusedControl();
+    if (focusedControl && !focusedControl->CanFocus() &&
+        focusedControl->GetID() != m_defaultControl)
+      SET_CONTROL_FOCUS(m_defaultControl, 0);
+  }
 }
 
 void CGUIWindow::DoRender()

--- a/xbmc/guilib/test/TestGUIWindowOnAction.cpp
+++ b/xbmc/guilib/test/TestGUIWindowOnAction.cpp
@@ -6,11 +6,14 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "ServiceBroker.h"
 #include "guilib/GUIControl.h"
 #include "guilib/GUIControlGroup.h"
 #include "guilib/GUIWindow.h"
 #include "input/actions/Action.h"
 #include "input/actions/ActionIDs.h"
+#include "rendering/RenderSystem.h"
+#include "windowing/WinSystem.h"
 
 #include <functional>
 #include <memory>
@@ -24,6 +27,73 @@ namespace
 constexpr int WINDOW_ID = 5000;
 constexpr int GROUP_ID = 5001;
 constexpr int CHILD_ID = 5002;
+constexpr int DEFAULT_CONTROL_ID = 5003;
+
+class CTestRenderSystem : public CRenderSystemBase
+{
+public:
+  bool InitRenderSystem() override { return true; }
+  bool DestroyRenderSystem() override { return true; }
+  bool ResetRenderSystem(int width, int height) override { return true; }
+  bool BeginRender() override { return true; }
+  bool EndRender() override { return true; }
+  void PresentRender(bool rendered, bool videoLayer) override {}
+  bool ClearBuffers(KODI::UTILS::COLOR::Color color) override { return true; }
+  bool IsExtSupported(const char* extension) const override { return false; }
+  void SetViewPort(const CRect& viewPort) override {}
+  void GetViewPort(CRect& viewPort) override {}
+  void SetScissors(const CRect& rect) override {}
+  void ResetScissors() override {}
+  void CaptureStateBlock() override {}
+  void ApplyStateBlock() override {}
+  void SetCameraPosition(const CPoint& camera,
+                         int screenWidth,
+                         int screenHeight,
+                         float stereoFactor) override
+  {
+  }
+};
+
+class CTestWinSystem : public CWinSystemBase
+{
+public:
+  CRenderSystemBase* GetRenderSystem() override { return &m_renderSystem; }
+  bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override
+  {
+    return true;
+  }
+  bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override { return true; }
+  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override
+  {
+    return true;
+  }
+  void Register(IDispResource* resource) override {}
+  void Unregister(IDispResource* resource) override {}
+
+private:
+  CTestRenderSystem m_renderSystem;
+};
+
+class CScopedWinSystemRegistration
+{
+public:
+  explicit CScopedWinSystemRegistration(CWinSystemBase& winSystem)
+    : m_previousWinSystem(CServiceBroker::GetWinSystem())
+  {
+    CServiceBroker::RegisterWinSystem(&winSystem);
+  }
+
+  ~CScopedWinSystemRegistration()
+  {
+    if (m_previousWinSystem)
+      CServiceBroker::RegisterWinSystem(m_previousWinSystem);
+    else
+      CServiceBroker::UnregisterWinSystem();
+  }
+
+private:
+  CWinSystemBase* m_previousWinSystem;
+};
 
 /*! \brief A focusable control that runs a callback when it is handed an action.
  *
@@ -99,6 +169,41 @@ public:
   }
 };
 
+class CUnfocusableControl : public CGUIControl
+{
+public:
+  CUnfocusableControl(int parentId, int id) : CGUIControl(parentId, id, 0.0f, 0.0f, 10.0f, 10.0f) {}
+
+  CUnfocusableControl* Clone() const override { return new CUnfocusableControl(*this); }
+
+  bool CanFocus() const override { return false; }
+};
+
+class CFocusRecoveryWindow : public CGUIWindow
+{
+public:
+  CFocusRecoveryWindow() : CGUIWindow(WINDOW_ID, "")
+  {
+    SetDefaultControl(DEFAULT_CONTROL_ID, true);
+
+    auto* control = new CUnfocusableControl(WINDOW_ID, CHILD_ID);
+    control->SetFocus(true);
+    AddControl(control);
+  }
+
+  bool OnMessage(CGUIMessage&) override
+  {
+    ++m_focusRequests;
+    return true;
+  }
+
+  int GetFocusRequests() const { return m_focusRequests; }
+  void MarkInitializedForTest() { m_active = true; }
+
+private:
+  int m_focusRequests{0};
+};
+
 } // namespace
 
 TEST(TestGUIWindowOnAction, PropagatesToTheParentWhenTheControlsSurvive)
@@ -131,4 +236,29 @@ TEST(TestGUIWindowOnAction, StopsPropagatingWhenTheControlsAreDestroyed)
 
   // the parent was freed by the teardown, so it must not have been offered the action
   EXPECT_FALSE(*parentOffered);
+}
+
+TEST(TestGUIWindowOnAction, DoesNotRecoverFocusBeforeInitialization)
+{
+  CTestWinSystem winSystem;
+  CScopedWinSystemRegistration registration(winSystem);
+  CFocusRecoveryWindow window;
+  CDirtyRegionList dirtyRegions;
+
+  window.DoProcess(0, dirtyRegions);
+
+  EXPECT_EQ(0, window.GetFocusRequests());
+}
+
+TEST(TestGUIWindowOnAction, RecoversFocusAfterInitialization)
+{
+  CTestWinSystem winSystem;
+  CScopedWinSystemRegistration registration(winSystem);
+  CFocusRecoveryWindow window;
+  CDirtyRegionList dirtyRegions;
+
+  window.MarkInitializedForTest();
+  window.DoProcess(0, dirtyRegions);
+
+  EXPECT_EQ(1, window.GetFocusRequests());
 }


### PR DESCRIPTION
## Description

AI use:

A window using asynchronous loading can enter the window history and be processed by a nested render loop while its derived `OnInitWindow()` is still running. At that point, the base `CGUIWindow::OnInitWindow()` has not marked the window active, and a control retaining focus from the previous activation may currently be unfocusable. The existing recovery in `CGUIWindow::DoProcess()` could therefore make a premature fallback-focus request and log that the requested control cannot be focused.

Gate focus recovery on `CGUIWindow`'s internal `m_active` lifecycle state. Recovery remains unchanged after initialization, while focus requests are suppressed during pre-initialization processing.

Add regression tests confirming that focus is not recovered before initialization and is still recovered afterward.

## Motivation and context

The problem was observed as:

```
error <general>: Control 55 in window 10821 has been asked to focus, but it can't
```

In this case, window 10821 is the Games window and control 55 is Estuary's WideList container.

The issue was exposed while testing [asynchronous initial media-window loading](https://github.com/ksooo/xbmc/commit/6ddd40da62f89c30d0311830913d10ae101ea6c9). During the initial refresh, `CGUIDialogBusy::Wait()` can process the render loop after the window has entered the history but before initialization has completed. This exposes an existing lifecycle gap; this change preserves asynchronous loading.

[PR #25999](https://github.com/xbmc/xbmc/pull/25999) previously guarded the same recovery path against retrying an unfocusable control when it was already the default control. That addressed a related source of the same error, but not processing before window initialization. This change complements that guard by requiring the window to be active before attempting recovery.

## How has this been tested?

Test environment: macOS 26.5.1 on arm64, using a Debug Xcode/CMake build with the macOS 26.5 SDK.

- Configured and built the `kodi-test` target successfully:

  ```
  cmake -S . -B build
  cmake --build build --target kodi-test --config Debug --parallel 8
  ```

- Ran the focused GUI window tests:

  ```
  build/Debug/kodi-test --gtest_filter='TestGUIWindowOnAction.*' --gtest_color=no
  ```

  All 4 tests passed, including:

  - `DoesNotRecoverFocusBeforeInitialization`
  - `RecoversFocusAfterInitialization`

- Ran the complete test executable:

  ```
  build/Debug/kodi-test --gtest_color=no
  ```

  All 4,031 enabled tests passed. 752 tests were disabled.

- Verified formatting with `git clang-format`; no changes were required.
- Verified the patch with `git diff --check`; no whitespace errors were reported.

## What is the effect on users?

Kodi no longer makes an invalid focus request or emits the corresponding error while an asynchronously loaded window is still initializing.

There is no intended visual or navigation change. Once a window is active, the existing fallback-focus behavior remains unchanged.

## Screenshots (if appropriate):

Not applicable.

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed