### PR TITLE
[VideoStreamSelect] Better detection of streaming - pvr/live tv

### DIFF
--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -302,6 +302,15 @@ bool CApplicationPlayer::IsLiveStream() const
   return false;
 }
 
+bool CApplicationPlayer::IsStreaming() const
+{
+  std::shared_ptr<const IPlayer> player = GetInternal();
+  if (player)
+    return player->IsStreaming();
+
+  return false;
+}
+
 void CApplicationPlayer::Pause()
 {
   std::shared_ptr<IPlayer> player = GetInternal();

--- a/xbmc/application/ApplicationPlayer.h
+++ b/xbmc/application/ApplicationPlayer.h
@@ -136,6 +136,7 @@ public:
   bool IsPlayingGame() const;
   bool IsPlayingRDS() const;
   bool IsLiveStream() const;
+  bool IsStreaming() const;
   void LoadPage(int p, int sp, unsigned char* buffer);
   bool OnAction(const CAction &action);
   void OnNothingToQueueNotify();

--- a/xbmc/cores/IPlayer.h
+++ b/xbmc/cores/IPlayer.h
@@ -245,6 +245,7 @@ public:
    */
   virtual bool HasVisibleOverlay() const { return false; }
   virtual bool IsLiveStream() const { return false; }
+  virtual bool IsStreaming() const { return false; }
   virtual void GetRects(CRect& source, CRect& dest, CRect& view) const
   {
     source = {};

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemux.h
@@ -369,6 +369,8 @@ public:
    */
   virtual void SetVideoResolution(unsigned int width, unsigned int height) {}
 
+  virtual bool IsStreaming() const { return false; }
+
   /*
   * return the id of the demuxer
   */

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.cpp
@@ -737,6 +737,11 @@ void CDVDDemuxClient::SetVideoResolution(unsigned int width, unsigned int height
   }
 }
 
+bool CDVDDemuxClient::IsStreaming() const
+{
+  return true;
+}
+
 bool CDVDDemuxClient::CodecHasExtraData(AVCodecID id)
 {
   switch (id)

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxClient.h
@@ -43,6 +43,7 @@ public:
   void EnableStream(int id, bool enable) override;
   void OpenStream(int id) override;
   void SetVideoResolution(unsigned int width, unsigned int height) override;
+  bool IsStreaming() const override;
 
 protected:
   void RequestStreams();

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -20,7 +20,6 @@
 #include "commons/Exception.h"
 #include "cores/FFmpeg.h"
 #include "cores/MenuType.h"
-#include "cores/VideoPlayer/Interface/TimingConstants.h" // for DVD_TIME_BASE
 #include "filesystem/CurlFile.h"
 #include "filesystem/Directory.h"
 #include "filesystem/File.h"
@@ -234,6 +233,25 @@ bool CDVDDemuxFFmpeg::Aborted()
   std::shared_ptr<CDVDInputStreamFFmpeg> input = std::dynamic_pointer_cast<CDVDInputStreamFFmpeg>(m_pInput);
   if (input && input->Aborted())
     return true;
+
+  return false;
+}
+
+bool CDVDDemuxFFmpeg::IsStreaming() const
+{
+  if (m_pInput && m_pInput->IsStreaming())
+    return true;
+
+  if (m_pFormatContext && m_pFormatContext->iformat)
+  {
+    auto names = StringUtils::Split(m_pFormatContext->iformat->name, ",");
+    return std::ranges::any_of(names,
+                               [](const std::string& name)
+                               {
+                                 return name == "hls" || name == "applehttp" || name == "dash" ||
+                                        name == "rtsp" || name == "live_flv";
+                               });
+  }
 
   return false;
 }

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.h
@@ -112,6 +112,8 @@ public:
   std::chrono::milliseconds GetChapterPos(int chapterIdx = -1) override;
   std::string GetStreamCodecName(int iStreamId) override;
 
+  bool IsStreaming() const override;
+
   bool Aborted();
 
   AVFormatContext* m_pFormatContext;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.cpp
@@ -302,3 +302,8 @@ void CDVDInputStream::UpdateStackItem(CFileItem& item, std::chrono::milliseconds
     }
   }
 }
+
+bool CDVDInputStream::IsStreaming() const
+{
+  return m_streamType == DVDSTREAM_TYPE_ADDON || m_streamType == DVDSTREAM_TYPE_FFMPEG;
+}

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/DVDInputStream.h
@@ -199,6 +199,8 @@ public:
 
   virtual bool IsRealtime() { return m_realtime; }
 
+  virtual bool IsStreaming() const;
+
   void SetRealtime(bool realtime) { m_realtime = realtime; }
 
   // interfaces

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.cpp
@@ -11,6 +11,7 @@
 #include "DVDFactoryInputStream.h"
 #include "utils/log.h"
 
+#include <algorithm>
 #include <map>
 
 using namespace XFILE;
@@ -138,4 +139,10 @@ void CInputStreamMultiSource::SetReadRate(uint32_t rate)
 {
   for (const auto& iter : m_InputStreams)
     iter->SetReadRate(rate);
+}
+
+bool CInputStreamMultiSource::IsStreaming() const
+{
+  return std::ranges::any_of(m_InputStreams,
+                             [](const auto& ptr) { return ptr != nullptr && ptr->IsStreaming(); });
 }

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamMultiSource.h
@@ -35,6 +35,7 @@ public:
   int Read(uint8_t* buf, int buf_size) override;
   int64_t Seek(int64_t offset, int whence) override;
   void SetReadRate(uint32_t rate) override;
+  bool IsStreaming() const override;
 
 protected:
   IVideoPlayer* m_pPlayer;

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -654,6 +654,20 @@ bool CProcessInfo::IsRealtimeStream()
   return m_realTimeStream;
 }
 
+void CProcessInfo::SetStateStreaming(bool isStreaming)
+{
+  std::unique_lock lock(m_stateSection);
+
+  m_isStreaming = isStreaming;
+}
+
+bool CProcessInfo::IsStreaming()
+{
+  std::unique_lock lock(m_stateSection);
+
+  return m_isStreaming;
+}
+
 void CProcessInfo::SetSpeed(float speed)
 {
   std::unique_lock lock(m_stateSection);

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.cpp
@@ -642,7 +642,7 @@ bool CProcessInfo::IsSeeking()
 
 void CProcessInfo::SetStateRealtime(bool state)
 {
-  std::unique_lock lock(m_renderSection);
+  std::unique_lock lock(m_stateSection);
 
   m_realTimeStream = state;
 }

--- a/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
+++ b/xbmc/cores/VideoPlayer/Process/ProcessInfo.h
@@ -109,6 +109,8 @@ public:
   bool IsSeeking();
   void SetStateRealtime(bool state);
   bool IsRealtimeStream();
+  void SetStateStreaming(bool isStreaming);
+  bool IsStreaming();
   void SetSpeed(float speed);
   void SetNewSpeed(float speed);
   float GetNewSpeed();
@@ -201,6 +203,7 @@ protected:
   int64_t m_timeMax;
   int64_t m_timeMin;
   bool m_realTimeStream;
+  bool m_isStreaming{false};
 
   // settings
   CCriticalSection m_settingsSection;

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -5934,6 +5934,13 @@ bool CVideoPlayer::IsLiveStream() const
   return m_processInfo->IsRealtimeStream();
 }
 
+bool CVideoPlayer::IsStreaming() const
+{
+  if (!m_processInfo)
+    return false;
+  return m_processInfo->IsStreaming();
+}
+
 bool CVideoPlayer::Supports(EINTERLACEMETHOD method) const
 {
   if (!m_processInfo)

--- a/xbmc/cores/VideoPlayer/VideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.cpp
@@ -36,6 +36,7 @@
 #include "cores/DataCacheCore.h"
 #include "cores/EdlEdit.h"
 #include "cores/FFmpeg.h"
+#include "cores/VideoPlayer/Interface/InputStreamConstants.h"
 #include "cores/VideoPlayer/Process/ProcessInfo.h"
 #include "cores/VideoPlayer/VideoRenderers/RenderManager.h"
 #include "guilib/GUIComponent.h"
@@ -1473,6 +1474,10 @@ void CVideoPlayer::Prepare()
     m_error = true;
     return;
   }
+
+  if (m_processInfo)
+    m_processInfo->SetStateStreaming(EvaluateIsStreaming());
+
   // give players a chance to reconsider now codecs are known
   CreatePlayers();
 
@@ -5939,6 +5944,46 @@ bool CVideoPlayer::IsStreaming() const
   if (!m_processInfo)
     return false;
   return m_processInfo->IsStreaming();
+}
+
+bool CVideoPlayer::EvaluateIsStreaming() const
+{
+  if (m_pInputStream && m_pInputStream->IsStreaming())
+    return true;
+
+  if (m_pDemuxer && m_pDemuxer->IsStreaming())
+    return true;
+
+  if (!m_item.GetProperty(STREAM_PROPERTY_INPUTSTREAM).empty())
+    return true;
+
+  const std::string& mime = m_item.GetMimeType();
+  if (mime == "application/vnd.apple.mpegurl" || mime == "vnd.apple.mpegurl" ||
+      mime == "application/x-mpegURL" || mime == "application/dash+xml" ||
+      mime == "application/vnd.ms-sstr+xml")
+  {
+    return true;
+  }
+
+  const std::string prot = URIUtils::Protocol(m_item.GetDynPath());
+  if (prot == "hls" || prot == "dash" || prot == "rtp" || prot == "rtsp" || prot == "rtsps" ||
+      prot == "sdp" || prot == "mms" || prot == "mmst" || prot == "mmsh")
+  {
+    return true;
+  }
+
+  // Dyn path extensions
+  if (m_item.IsType(".m3u8") || m_item.IsType(".mpd") || m_item.IsType(".ism") ||
+      m_item.IsType(".isml"))
+    return true;
+
+  // Smoothstreaming urls may look like https://server/path/subpath.ism/manifest?foo=bar
+  const std::string filename = m_item.GetDynURL().GetFileName();
+  if (StringUtils::EndsWithNoCase(filename, ".ism/manifest") ||
+      StringUtils::EndsWithNoCase(filename, ".isml/manifest"))
+    return true;
+
+  return false;
 }
 
 bool CVideoPlayer::Supports(EINTERLACEMETHOD method) const

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -552,6 +552,7 @@ protected:
   std::optional<SeekCandidate> GetChapterSeekCandidate(int64_t time, Direction direction);
   std::optional<SeekCandidate> GetBookmarkSeekCandidate(int64_t time, Direction direction);
   void ExecuteTimeSeek(int64_t target, Direction direction, bool accurate);
+  bool EvaluateIsStreaming() const;
 
   bool m_players_created;
 

--- a/xbmc/cores/VideoPlayer/VideoPlayer.h
+++ b/xbmc/cores/VideoPlayer/VideoPlayer.h
@@ -377,6 +377,7 @@ public:
   bool IsRenderingVideo() const override;
   bool HasVisibleOverlay() const override;
   bool IsLiveStream() const override;
+  bool IsStreaming() const override;
   bool Supports(EINTERLACEMETHOD method) const override;
   EINTERLACEMETHOD GetDeinterlacingMethodDefault() const override;
   bool Supports(ESCALINGMETHOD method) const override;

--- a/xbmc/cores/VideoPlayer/test/TestVideoPlayer.cpp
+++ b/xbmc/cores/VideoPlayer/test/TestVideoPlayer.cpp
@@ -6,8 +6,12 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "FileItem.h"
 #include "ServiceBroker.h"
 #include "cores/IPlayerCallback.h"
+#include "cores/VideoPlayer/DVDDemuxers/DVDDemux.h"
+#include "cores/VideoPlayer/DVDInputStreams/DVDInputStream.h"
+#include "cores/VideoPlayer/Interface/InputStreamConstants.h"
 #include "cores/VideoPlayer/VideoPlayer.h"
 #include "jobs/JobManager.h"
 #include "settings/AdvancedSettings.h"
@@ -18,8 +22,6 @@
 #include <gtest/gtest.h>
 
 using namespace std::chrono_literals;
-
-class CFileItem;
 
 class CTestPlayerCallback : public IPlayerCallback
 {
@@ -49,6 +51,7 @@ public:
   {
     return GetBookmarkPos(idx);
   }
+  bool InvokeEvaluateIsStreaming() const { return EvaluateIsStreaming(); }
 
   void SetCurrentVideoId(int id) { m_CurrentVideo.id = id; }
   void SetCurrentAudioId(int id) { m_CurrentAudio.id = id; }
@@ -57,6 +60,13 @@ public:
   bool GetHasVideo() const { return m_HasVideo; }
   bool GetHasAudio() const { return m_HasAudio; }
   void InvokeUpdateHasVideoAudio() { UpdateHasVideoAudio(); }
+
+  void SetItem(const CFileItem& item) { m_item = item; }
+  void SetInputStream(std::shared_ptr<CDVDInputStream> inputStream)
+  {
+    m_pInputStream = inputStream;
+  }
+  void SetDemuxer(std::unique_ptr<CDVDDemux> demuxer) { m_pDemuxer = std::move(demuxer); }
 
   constexpr static SeekStep ConvertTestSeekStep(TestSeekStep step)
   {
@@ -364,4 +374,155 @@ TEST_F(TestVideoPlayer, CalcTimeOrPercentSeekTargetSmooth)
   EXPECT_EQ(advancedSettings->m_videoTimeSeekBackward * 1000,
             CTestVideoPlayer::InvokeCalcTimeOrPercentSeekTarget(0, maxTime, Direction::BACKWARD,
                                                                 TestSeekStep::NORMAL));
+}
+
+namespace
+{
+class CTestInputStream : public CDVDInputStream
+{
+public:
+  CTestInputStream(DVDStreamType type, const CFileItem& item) : CDVDInputStream(type, item) {}
+  int Read(uint8_t* buf, int buf_size) override { return 0; }
+  int64_t Seek(int64_t offset, int whence) override { return 0; }
+  int64_t GetLength() override { return 0; }
+  bool IsEOF() override { return false; }
+};
+
+class CTestDemux : public CDVDDemux
+{
+public:
+  explicit CTestDemux(bool streaming = false) : m_isStreaming(streaming) {}
+  bool Reset() override { return true; }
+  void Flush() override {}
+  void Abort() override {}
+  DemuxPacket* Read() override { return nullptr; }
+  bool SeekTime(double time, bool backwards = false, double* startpts = nullptr) override
+  {
+    return true;
+  }
+  CDemuxStream* GetStream(int iStreamId) const override { return nullptr; }
+  std::vector<CDemuxStream*> GetStreams() const override { return {}; }
+  int GetNrOfStreams() const override { return 0; }
+  bool IsStreaming() const override { return m_isStreaming; }
+
+private:
+  bool m_isStreaming{false};
+};
+} // namespace
+
+TEST_F(TestVideoPlayer, IsStreamingLocalFileReturnsFalse)
+{
+  CTestPlayerCallback playercallback;
+  CTestVideoPlayer player(playercallback);
+
+  // Local files
+  player.SetItem(CFileItem("C:\\Videos\\movie.mkv", false));
+  EXPECT_FALSE(player.InvokeEvaluateIsStreaming());
+
+  player.SetItem(CFileItem("/home/user/video.mp4", false));
+  EXPECT_FALSE(player.InvokeEvaluateIsStreaming());
+
+  // Network shares
+  player.SetItem(CFileItem("smb://192.168.1.1/movies/video.mkv", false));
+  EXPECT_FALSE(player.InvokeEvaluateIsStreaming());
+
+  // Direct HTTP file playback
+  player.SetItem(CFileItem("http://example.com/video.mp4", false));
+  EXPECT_FALSE(player.InvokeEvaluateIsStreaming());
+}
+
+TEST_F(TestVideoPlayer, IsStreamingManifestExtensionsReturnsTrue)
+{
+  CTestPlayerCallback playercallback;
+  CTestVideoPlayer player(playercallback);
+
+  player.SetItem(CFileItem("http://example.com/playlist.m3u8", false));
+  EXPECT_TRUE(player.InvokeEvaluateIsStreaming());
+
+  player.SetItem(CFileItem("https://example.com/manifest.ism", false));
+  EXPECT_TRUE(player.InvokeEvaluateIsStreaming());
+
+  player.SetItem(CFileItem("https://example.com/path1/path2.ism/manifest?query=foo", false));
+  EXPECT_TRUE(player.InvokeEvaluateIsStreaming());
+
+  player.SetItem(CFileItem("http://example.com/PLAYLIST.MPD", false));
+  EXPECT_TRUE(player.InvokeEvaluateIsStreaming());
+}
+
+TEST_F(TestVideoPlayer, IsStreamingMimeTypesReturnsTrue)
+{
+  CTestPlayerCallback playercallback;
+  CTestVideoPlayer player(playercallback);
+
+  CFileItem itemHls("http://example.com/stream", false);
+  itemHls.SetMimeType("application/vnd.apple.mpegurl");
+  player.SetItem(itemHls);
+  EXPECT_TRUE(player.InvokeEvaluateIsStreaming());
+
+  CFileItem itemDash("http://example.com/stream", false);
+  itemDash.SetMimeType("application/dash+xml");
+  player.SetItem(itemDash);
+  EXPECT_TRUE(player.InvokeEvaluateIsStreaming());
+}
+
+TEST_F(TestVideoPlayer, IsStreamingProtocolsReturnsTrue)
+{
+  CTestPlayerCallback playercallback;
+  CTestVideoPlayer player(playercallback);
+
+  player.SetItem(CFileItem("hls://example.com/live", false));
+  EXPECT_TRUE(player.InvokeEvaluateIsStreaming());
+
+  player.SetItem(CFileItem("dash://example.com/live", false));
+  EXPECT_TRUE(player.InvokeEvaluateIsStreaming());
+
+  player.SetItem(CFileItem("rtp://239.255.0.1:5004", false));
+  EXPECT_TRUE(player.InvokeEvaluateIsStreaming());
+}
+
+TEST_F(TestVideoPlayer, IsStreamingItemPropertiesReturnsTrue)
+{
+  CTestPlayerCallback playercallback;
+  CTestVideoPlayer player(playercallback);
+
+  CFileItem itemAddon("http://example.com/stream", false);
+  itemAddon.SetProperty(STREAM_PROPERTY_INPUTSTREAM, "inputstream.adaptive");
+  player.SetItem(itemAddon);
+  EXPECT_TRUE(player.InvokeEvaluateIsStreaming());
+}
+
+TEST_F(TestVideoPlayer, IsStreamingInputStreamTypes)
+{
+  CTestPlayerCallback playercallback;
+  CTestVideoPlayer player(playercallback);
+  CFileItem item("http://example.com/generic", false);
+  player.SetItem(item);
+
+  //! @todo should partially move into InputStream unit tests and leave the test of IsStreaming here
+
+  // File inputstream -> false
+  player.SetInputStream(std::make_shared<CTestInputStream>(DVDSTREAM_TYPE_FILE, item));
+  EXPECT_FALSE(player.InvokeEvaluateIsStreaming());
+
+  // Addon inputstream (ex. inputstream.adaptive)
+  player.SetInputStream(std::make_shared<CTestInputStream>(DVDSTREAM_TYPE_ADDON, item));
+  EXPECT_TRUE(player.InvokeEvaluateIsStreaming());
+
+  // FFmpeg inputstream
+  player.SetInputStream(std::make_shared<CTestInputStream>(DVDSTREAM_TYPE_FFMPEG, item));
+  EXPECT_TRUE(player.InvokeEvaluateIsStreaming());
+}
+
+TEST_F(TestVideoPlayer, IsStreamingDemuxerReturnsTrue)
+{
+  CTestPlayerCallback playercallback;
+  CTestVideoPlayer player(playercallback);
+  CFileItem item("http://example.com/generic", false);
+  player.SetItem(item);
+
+  player.SetDemuxer(std::make_unique<CTestDemux>(false));
+  EXPECT_FALSE(player.InvokeEvaluateIsStreaming());
+
+  player.SetDemuxer(std::make_unique<CTestDemux>(true));
+  EXPECT_TRUE(player.InvokeEvaluateIsStreaming());
 }

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -902,6 +902,19 @@ std::string URIUtils::SubstitutePath(const std::string& strPath, bool reverse /*
   return strPath;
 }
 
+std::string URIUtils::Protocol(std::string_view url)
+{
+  std::string protocol;
+
+  std::size_t end = url.find("://");
+  if (end == std::string_view::npos)
+    return protocol;
+
+  protocol = url.substr(0, end);
+  StringUtils::ToLower(protocol);
+  return protocol;
+}
+
 bool URIUtils::IsProtocol(const std::string& url, const std::string &type)
 {
   return StringUtils::StartsWithNoCase(url, type + "://");

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -220,6 +220,14 @@ public:
   static CURL SubstitutePath(const CURL& url, bool reverse = false);
   static std::string SubstitutePath(const std::string& strPath, bool reverse = false);
 
+  /*!
+   * \brief Returns the protocol of a url
+   * \param[in] url The url to examine
+   * \return url lowercased scheme when \p url is an URL, empty string otherwise.
+   * \sa IsProtocol
+   */
+  static std::string Protocol(std::string_view url);
+
   /*! \brief Check whether a URL is a given URL scheme.
    Comparison is case-insensitive as per RFC1738
    \param url a std::string path.

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -2725,3 +2725,12 @@ TEST_F(TestURIUtils, GetDecodedPath)
   decoded = "bluray://smb://somepath/path//BDMV/PLAYLIST/00800.mpls";
   EXPECT_EQ(decoded, URIUtils::GetDecodedPath(encoded));
 }
+
+TEST_F(TestURIUtils, Protocol)
+{
+  EXPECT_EQ("smb", URIUtils::Protocol("smb://server/share/file.ext"));
+  EXPECT_EQ("smb", URIUtils::Protocol("SMB://server/share/file.ext"));
+  EXPECT_EQ("", URIUtils::Protocol("/media/movies/file.ext"));
+  EXPECT_EQ("", URIUtils::Protocol("D:\\media\\movies\\file.ext"));
+  EXPECT_EQ("", URIUtils::Protocol(""));
+}

--- a/xbmc/video/VideoStreamSelect.cpp
+++ b/xbmc/video/VideoStreamSelect.cpp
@@ -175,37 +175,9 @@ SubtitleStreamInfoExt::SubtitleStreamInfoExt(int id, const SubtitleStreamInfo& i
 
 namespace
 {
-// This attempts to distinguish videos files, with may have streams muxed in a meaningful order,
-// from videos where stream order is more random and always benefits from reordering, for example
-// internet streaming protocols.
-bool IsTrackOrderMeaningful()
+CVideoStreamSelect::TrackOrder GetTrackOrder(const CApplicationPlayer& appPlayer)
 {
-  //! @todo improve accuracy with detection in VideoPlayer
-
-  const auto item = g_application.CurrentFileItemPtr();
-
-  if (!item)
-    return true;
-
-  const std::string dynPath = item->GetDynPath();
-
-  // Detect file-based all protocols discretly since the macro test "IsNetworkFilesystem" interprets
-  // http as always file-based, which misidentifies masqueraded streaming
-  if (URIUtils::IsHD(dynPath) || URIUtils::IsSmb(dynPath) || URIUtils::IsNfs(dynPath) ||
-      URIUtils::IsFTP(dynPath) || URIUtils::IsProtocol(dynPath, "sftp") ||
-      URIUtils::IsProtocol(dynPath, "ssh") || URIUtils::IsDAV(dynPath))
-    return true;
-
-  const std::string path = item->GetPath();
-  if (URIUtils::IsUPnP(path))
-    return true;
-
-  return false;
-}
-
-CVideoStreamSelect::TrackOrder GetTrackOrder()
-{
-  if (!IsTrackOrderMeaningful())
+  if (appPlayer.IsStreaming() || appPlayer.IsLiveStream())
     return CVideoStreamSelect::TrackOrder::SORTED;
 
   const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
@@ -258,7 +230,7 @@ std::vector<StreamInfoExtT> GetStreams(const CApplicationPlayer* appPlayer,
   }
 
   // Sort the streams
-  std::invoke(orderer, streams, GetTrackOrder());
+  std::invoke(orderer, streams, GetTrackOrder(*appPlayer));
 
   return streams;
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Follow up of #28916, with detection of input stream adaptative streams in video player instead of filename based.

Most of the PR is plumbing to cross many layers. The detection itself is in the last commit.

Signals used to flag a stream as "streaming":
- usage of DVDDemuxClient
- protocol name detected by ffmpeg in CDVDDemuxFFmpeg is in a white list
- the videoplayer InputStream type is DVDSTREAM_TYPE_ADDON or DVDSTREAM_TYPE_FFMPEG (maybe redundant with the DvdDemux::IsStreaming?)
- item's mime type, protocol or extension are in white lists
See the last commit for the specific values used.

open questions:
- The function name "IsStreaming" seems a bit too generic, should it be "IsInternetStreaming", or ...?

- Should PVR/Live TV be included in the types of streams that automatically cause sorting in the stream selection dialog? Or is the media order meaningful?
Is the Videoplayer function IsLiveStream good enough to detect PVR/Live TV?

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Some sources disguise their streams and file name and attributes may not be enough to distinguish them.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added some unit tests - cannot cover everything.

I don't have many actual examples, this is not my area.
The detection did not react to the file based protocols, as expected.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

More reliable detection of "streaming" for a more consistent use of sorted stream order in the stream selection dialog

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
