### PR TITLE
[RetroPlayer] Improve GLSL shader failure handling

### DIFF
--- a/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/ShaderPreset.cpp
@@ -89,7 +89,7 @@ bool CShaderPreset::SetShaderPreset(const std::string& shaderPresetPath)
   auto updateFailed = [this](const std::string& msg)
   {
     m_failedPaths.insert(m_presetPath);
-    CLog::Log(LOGWARNING, "CShaderPreset::SetShaderPreset: {}", msg);
+    CLog::Log(LOGWARNING, "CShaderPreset::SetShaderPreset: {}: preset={}", msg, m_presetPath);
     DisposeShaders();
     return false;
   };
@@ -139,7 +139,7 @@ bool CShaderPreset::Update()
   auto updateFailed = [this](const std::string& msg)
   {
     m_failedPaths.insert(m_presetPath);
-    CLog::Log(LOGWARNING, "CShaderPreset::Update: {}", msg);
+    CLog::Log(LOGWARNING, "CShaderPreset::Update: {}: preset={}", msg, m_presetPath);
     DisposeShaders();
     return false;
   };

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -76,6 +76,8 @@ bool CShaderGL::Create(unsigned int passIdx,
     glGetShaderInfoLog(vShader, maxLength, &maxLength, errorLog.data());
     CLog::Log(LOGERROR, "CShaderGL::Create: Vertex shader compile error:\n{}",
               std::string(errorLog.begin(), errorLog.end()));
+    glDeleteShader(vShader);
+    return false;
   }
 
   fShader = glCreateShader(GL_FRAGMENT_SHADER);
@@ -91,6 +93,9 @@ bool CShaderGL::Create(unsigned int passIdx,
     glGetShaderInfoLog(fShader, maxLength, &maxLength, errorLog.data());
     CLog::Log(LOGERROR, "CShaderGL::Create: Fragment shader compile error:\n{}",
               std::string(errorLog.begin(), errorLog.end()));
+    glDeleteShader(vShader);
+    glDeleteShader(fShader);
+    return false;
   }
 
   glAttachShader(m_shaderProgram, vShader);

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderGL.cpp
@@ -74,8 +74,11 @@ bool CShaderGL::Create(unsigned int passIdx,
     glGetShaderiv(vShader, GL_INFO_LOG_LENGTH, &maxLength);
     std::vector<GLchar> errorLog(maxLength);
     glGetShaderInfoLog(vShader, maxLength, &maxLength, errorLog.data());
-    CLog::Log(LOGERROR, "CShaderGL::Create: Vertex shader compile error:\n{}",
-              std::string(errorLog.begin(), errorLog.end()));
+    CLog::Log(
+        LOGERROR,
+        "CShaderGL::Create: Failed to compile vertex shader: pass={}, alias={}, shader={}\n{}",
+        m_passIdx, m_passAlias.empty() ? "<none>" : m_passAlias, m_shaderPath,
+        std::string(errorLog.begin(), errorLog.end()));
     glDeleteShader(vShader);
     return false;
   }
@@ -91,8 +94,11 @@ bool CShaderGL::Create(unsigned int passIdx,
     glGetShaderiv(fShader, GL_INFO_LOG_LENGTH, &maxLength);
     std::vector<GLchar> errorLog(maxLength);
     glGetShaderInfoLog(fShader, maxLength, &maxLength, errorLog.data());
-    CLog::Log(LOGERROR, "CShaderGL::Create: Fragment shader compile error:\n{}",
-              std::string(errorLog.begin(), errorLog.end()));
+    CLog::Log(
+        LOGERROR,
+        "CShaderGL::Create: Failed to compile fragment shader: pass={}, alias={}, shader={}\n{}",
+        m_passIdx, m_passAlias.empty() ? "<none>" : m_passAlias, m_shaderPath,
+        std::string(errorLog.begin(), errorLog.end()));
     glDeleteShader(vShader);
     glDeleteShader(fShader);
     return false;
@@ -118,9 +124,10 @@ bool CShaderGL::Create(unsigned int passIdx,
     glGetProgramiv(m_shaderProgram, GL_INFO_LOG_LENGTH, &maxLength);
     std::vector<GLchar> errorLog(maxLength);
     glGetProgramInfoLog(m_shaderProgram, maxLength, &maxLength, errorLog.data());
-    CLog::Log(LOGERROR, "CShaderGL::Create: Shader program link error:\n{}",
+    CLog::Log(LOGERROR,
+              "CShaderGL::Create: Failed to link shader program: pass={}, alias={}, shader={}\n{}",
+              m_passIdx, m_passAlias.empty() ? "<none>" : m_passAlias, m_shaderPath,
               std::string(errorLog.begin(), errorLog.end()));
-    CLog::Log(LOGERROR, "CShaderGL::Create: Failed to load video shader: {}", m_shaderPath);
     return false;
   }
 

--- a/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gl/ShaderPresetGL.cpp
@@ -60,7 +60,10 @@ bool CShaderPresetGL::CreateShaders()
     if (!videoShader->Create(shaderIdx, pass.alias, shaderPath, shaderSource,
                              std::move(passParameters), presetLUTsGL, pass.frameCountMod))
     {
-      CLog::Log(LOGERROR, "CShaderPresetGL::CreateShaders: Couldn't create a video shader");
+      CLog::Log(LOGERROR,
+                "CShaderPresetGL::CreateShaders: Failed to create shader: preset={}, pass={}, "
+                "alias={}, shader={}",
+                m_presetPath, shaderIdx, pass.alias.empty() ? "<none>" : pass.alias, shaderPath);
       return false;
     }
     m_pShaders.push_back(std::move(videoShader));

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
@@ -74,8 +74,11 @@ bool CShaderGLES::Create(unsigned int passIdx,
     glGetShaderiv(vShader, GL_INFO_LOG_LENGTH, &maxLength);
     std::vector<GLchar> errorLog(maxLength);
     glGetShaderInfoLog(vShader, maxLength, &maxLength, errorLog.data());
-    CLog::Log(LOGERROR, "CShaderGLES::Create: Vertex shader compile error:\n{}",
-              std::string(errorLog.begin(), errorLog.end()));
+    CLog::Log(
+        LOGERROR,
+        "CShaderGLES::Create: Failed to compile vertex shader: pass={}, alias={}, shader={}\n{}",
+        m_passIdx, m_passAlias.empty() ? "<none>" : m_passAlias, m_shaderPath,
+        std::string(errorLog.begin(), errorLog.end()));
     glDeleteShader(vShader);
     return false;
   }
@@ -91,8 +94,11 @@ bool CShaderGLES::Create(unsigned int passIdx,
     glGetShaderiv(fShader, GL_INFO_LOG_LENGTH, &maxLength);
     std::vector<GLchar> errorLog(maxLength);
     glGetShaderInfoLog(fShader, maxLength, &maxLength, errorLog.data());
-    CLog::Log(LOGERROR, "CShaderGLES::Create: Fragment shader compile error:\n{}",
-              std::string(errorLog.begin(), errorLog.end()));
+    CLog::Log(
+        LOGERROR,
+        "CShaderGLES::Create: Failed to compile fragment shader: pass={}, alias={}, shader={}\n{}",
+        m_passIdx, m_passAlias.empty() ? "<none>" : m_passAlias, m_shaderPath,
+        std::string(errorLog.begin(), errorLog.end()));
     glDeleteShader(vShader);
     glDeleteShader(fShader);
     return false;
@@ -118,9 +124,11 @@ bool CShaderGLES::Create(unsigned int passIdx,
     glGetProgramiv(m_shaderProgram, GL_INFO_LOG_LENGTH, &maxLength);
     std::vector<GLchar> errorLog(maxLength);
     glGetProgramInfoLog(m_shaderProgram, maxLength, &maxLength, errorLog.data());
-    CLog::Log(LOGERROR, "CShaderGLES::Create: Shader program link error:\n{}",
-              std::string(errorLog.begin(), errorLog.end()));
-    CLog::Log(LOGERROR, "CShaderGLES::Create: Failed to load video shader: {}", m_shaderPath);
+    CLog::Log(
+        LOGERROR,
+        "CShaderGLES::Create: Failed to link shader program: pass={}, alias={}, shader={}\n{}",
+        m_passIdx, m_passAlias.empty() ? "<none>" : m_passAlias, m_shaderPath,
+        std::string(errorLog.begin(), errorLog.end()));
     return false;
   }
 

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderGLES.cpp
@@ -76,6 +76,8 @@ bool CShaderGLES::Create(unsigned int passIdx,
     glGetShaderInfoLog(vShader, maxLength, &maxLength, errorLog.data());
     CLog::Log(LOGERROR, "CShaderGLES::Create: Vertex shader compile error:\n{}",
               std::string(errorLog.begin(), errorLog.end()));
+    glDeleteShader(vShader);
+    return false;
   }
 
   fShader = glCreateShader(GL_FRAGMENT_SHADER);
@@ -91,6 +93,9 @@ bool CShaderGLES::Create(unsigned int passIdx,
     glGetShaderInfoLog(fShader, maxLength, &maxLength, errorLog.data());
     CLog::Log(LOGERROR, "CShaderGLES::Create: Fragment shader compile error:\n{}",
               std::string(errorLog.begin(), errorLog.end()));
+    glDeleteShader(vShader);
+    glDeleteShader(fShader);
+    return false;
   }
 
   glAttachShader(m_shaderProgram, vShader);

--- a/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/gles/ShaderPresetGLES.cpp
@@ -60,7 +60,10 @@ bool CShaderPresetGLES::CreateShaders()
     if (!videoShader->Create(shaderIdx, pass.alias, shaderPath, shaderSource,
                              std::move(passParameters), presetLUTsGL, pass.frameCountMod))
     {
-      CLog::Log(LOGERROR, "CShaderPresetGLES::CreateShaders: Couldn't create a video shader");
+      CLog::Log(LOGERROR,
+                "CShaderPresetGLES::CreateShaders: Failed to create shader: preset={}, pass={}, "
+                "alias={}, shader={}",
+                m_presetPath, shaderIdx, pass.alias.empty() ? "<none>" : pass.alias, shaderPath);
       return false;
     }
     m_pShaders.push_back(std::move(videoShader));


### PR DESCRIPTION
## Description

No C++ changes outside of `xbmc/cores/RetroPlayer`.

AI use:

Improve RetroPlayer shader failure handling and diagnostics on desktop OpenGL and GLES.

Kodi now stops shader setup immediately when either the vertex or fragment stage fails compilation instead of continuing to link the incomplete program and producing a misleading secondary linker error.

Shader failures also include the pass index, alias, shader source path, compilation/link stage, and driver error. The preset layer reports the owning preset without adding preset-path state or plumbing to individual shader objects.

This PR does not modify shader source versions or GLSL compatibility behavior.

## Motivation and context

While qualifying RetroPlayer shader presets, compiler failures in multipass shaders were difficult to associate with the exact preset and pass that caused them.

The previous failure path also continued into program linking after a shader stage had already failed compilation. This produced a secondary linker error that added noise while obscuring the actual compiler failure.

The updated diagnostics preserve the original driver error while adding enough context to identify the failing shader pass and its owning preset.

## How has this been tested?

Test environment:

* Apple Silicon / Apple M2 Pro
* macOS ARM64
* GL vendor: Apple
* GL renderer: Apple M2 Pro
* OpenGL: `4.1 Metal - 90.5`
* GLSL: `4.10`

Runtime shader qualification exercised Kodi's shipped desktop GL preset catalog, including known compiler failures in multipass presets.

Verified that:

* Vertex and fragment compilation failures stop before program linking
* Failed compilation no longer produces a misleading secondary linker error
* Compiler errors identify the stage, pass, alias, and shader source
* Preset-level errors identify the owning preset and failing pass
* Successful shader compilation and linking remain unchanged

The corresponding GLES path received the same control-flow and diagnostic changes. No GLES runtime testing was performed.

## What is the effect on users?

Shader compilation failures produce clearer and more actionable logs on desktop GL and GLES.

A failed shader stage no longer generates an additional misleading linker error, and the log contains enough context to identify the exact preset, pass, alias, and shader source involved.

There is no change to GLSL version handling or successful shader rendering behavior.

## Types of change

* [x] **Bug fix** (non-breaking change which fixes an issue)
* [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
* [x] **Improvement** (non-breaking change which improves existing functionality)
* [ ] **New feature** (non-breaking change which adds functionality)
* [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
* [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
* [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
* [ ] **None of the above** (please explain below)
