### PR TITLE
[osx] Defer monitor sync until render init

### DIFF
--- a/xbmc/windowing/osx/OpenGL/WinSystemOSXGL.h
+++ b/xbmc/windowing/osx/OpenGL/WinSystemOSXGL.h
@@ -22,6 +22,7 @@ public:
 
   // Implementation of CWinSystemBase via CWinSystemOSX
   CRenderSystemBase *GetRenderSystem() override { return this; }
+  bool InitRenderSystem() override;
   bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override;
   bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override;
 

--- a/xbmc/windowing/osx/OpenGL/WinSystemOSXGL.mm
+++ b/xbmc/windowing/osx/OpenGL/WinSystemOSXGL.mm
@@ -44,6 +44,18 @@ void CWinSystemOSXGL::SetVSyncImpl(bool enable)
   }
 }
 
+bool CWinSystemOSXGL::InitRenderSystem()
+{
+  if (!CRenderSystemGL::InitRenderSystem())
+    return false;
+
+  // Monitor synchronization may reset the video resolution, so the renderer must exist first.
+  if (m_bWindowCreated)
+    SynchronizeCurrentMonitor();
+
+  return true;
+}
+
 bool CWinSystemOSXGL::ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop)
 {
   CWinSystemOSX::ResizeWindow(newWidth, newHeight, newLeft, newTop);

--- a/xbmc/windowing/osx/WinSystemOSX.h
+++ b/xbmc/windowing/osx/WinSystemOSX.h
@@ -111,6 +111,7 @@ public:
 protected:
   std::unique_ptr<KODI::WINDOWING::IOSScreenSaver> GetOSScreenSaverImpl() override;
 
+  void SynchronizeCurrentMonitor();
   ScreenResolution GetScreenResolution(unsigned long screenIdx);
   void EnableVSync(bool enable);
   bool SwitchToVideoMode(RESOLUTION_INFO& res);

--- a/xbmc/windowing/osx/WinSystemOSX.mm
+++ b/xbmc/windowing/osx/WinSystemOSX.mm
@@ -187,16 +187,15 @@ NSString* screenNameForDisplay(NSUInteger screenIdx)
   return screenName;
 }
 
-void CheckAndUpdateCurrentMonitor(NSUInteger screenNumber)
+void CWinSystemOSX::SynchronizeCurrentMonitor()
 {
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
   const std::string storedScreenName = settings->GetString(CSettings::SETTING_VIDEOSCREEN_MONITOR);
   // OUTPUT_NAME_DEFAULT is a placeholder resolving to screen 0, not a stale name.
-  // Rewriting it before the render system exists leaves the GUI without a viewport.
-  if (storedScreenName == OUTPUT_NAME_DEFAULT && screenNumber == 0)
+  if (storedScreenName == OUTPUT_NAME_DEFAULT && m_lastDisplayNr == 0)
     return;
 
-  const std::string currentScreenName = screenNameForDisplay(screenNumber).UTF8String;
+  const std::string currentScreenName = screenNameForDisplay(m_lastDisplayNr).UTF8String;
   if (storedScreenName != currentScreenName)
   {
     CDisplaySettings::GetInstance().SetMonitor(currentScreenName);
@@ -741,8 +740,6 @@ bool CWinSystemOSX::CreateNewWindow(const std::string& name, bool fullScreen, RE
 
   m_bWindowCreated = true;
 
-  CheckAndUpdateCurrentMonitor(m_lastDisplayNr);
-
   // warning, we can order front but not become
   // key window or risk starting up with bad flicker
   // becoming key window must happen in completion block.
@@ -1199,7 +1196,7 @@ bool CWinSystemOSX::HasValidResolution() const
 void CWinSystemOSX::OnMove(int x, int y)
 {
   // check if the current screen/monitor settings needs to be updated
-  CheckAndUpdateCurrentMonitor(m_lastDisplayNr);
+  SynchronizeCurrentMonitor();
 
   // check if refresh rate needs to be updated
   static double oldRefreshRate = m_refreshRate;
@@ -1239,7 +1236,7 @@ void CWinSystemOSX::OnChangeScreen(unsigned int screenIdx)
   if (lastDisplay != m_lastDisplayNr && m_bFullScreen)
   {
     UnblankDisplay(m_lastDisplayNr);
-    CheckAndUpdateCurrentMonitor(m_lastDisplayNr);
+    SynchronizeCurrentMonitor();
   }
 }
 


### PR DESCRIPTION
## Description

https://github.com/xbmc/xbmc/pull/29016 did not fully fix the black GUI for me. Occasionally, on startup, I still get a black screen. Restarting Kodi always fixed the problem.

AI use:

#29016 fixed the common macOS black-GUI startup case, but I could still occasionally reproduce a black screen. Restarting Kodi always fixed it.

The underlying issue is that monitor synchronization ran from `CreateNewWindow()` before the OpenGL render system was initialized. If a stale saved monitor name was corrected, its setting callback could apply a video resolution too early, causing `ResetRenderSystem()` to skip viewport setup.

#28633 exposed this latent bug more broadly by changing `Default` into a monitor placeholder, while #29016 fixed only that specific `Default`/screen-0 case.

Defer monitor synchronization until after `InitRenderSystem()` succeeds so any resulting resolution change runs against an initialized renderer.

## Motivation and context

A stale saved monitor name could leave the GUI black on startup. Restarting worked because the corrected monitor name had already been saved.

## How has this been tested?

Tested on macOS with a built-in Retina display and an external HDMI monitor:

* Fullscreen and windowed startup with a stale monitor setting
* Startup with `Default` and valid monitor settings
* HiDPI startup
* Debug builds of `kodi` and `kodi-test`
* All 4,287 enabled unit tests passed

The issue is intermittent, so I'll continue running this setup to verify the black startup no longer occurs.

## What is the effect on users?

Prevents monitor-triggered resolution setup from running before the macOS OpenGL renderer is initialized, avoiding the black GUI startup case.

## Types of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)