### PR TITLE
[tests][windows] Fixed: Make source matching tests drive-independent

### DIFF
--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -11,6 +11,8 @@
 #include "cores/VideoPlayer/Interface/StreamInfo.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "video/FilenameAttributes.h"
 
 #include <gtest/gtest-param-test.h>
@@ -827,18 +829,52 @@ constexpr TestMatchingSourceData SourcesToMatch[] = {
 
 TEST_P(TestMatchingSource, GetMatchingSource)
 {
+#if defined(TARGET_WINDOWS_DESKTOP)
+  // D: is often an optical drive. Use a non-optical letter so this fixture tests source matching
+  // rather than the intentional optical-source shortcut.
+  char dosDriveLetter{'D'};
+  if (URIUtils::IsOnDVD("D:\\"))
+  {
+    for (char candidate = 'C'; candidate <= 'Z'; ++candidate)
+    {
+      std::string driveRoot{"C:\\"};
+      driveRoot.front() = candidate;
+      if (!URIUtils::IsOnDVD(driveRoot))
+      {
+        dosDriveLetter = candidate;
+        break;
+      }
+    }
+  }
+  ASSERT_FALSE(URIUtils::IsOnDVD(std::string{dosDriveLetter} + ":\\"));
+#else
+  const char dosDriveLetter{'D'};
+#endif
+
+  const auto replaceOpticalTestDrive = [dosDriveLetter](const char* value)
+  {
+    std::string path{value};
+    const std::string drive{dosDriveLetter};
+    StringUtils::Replace(path, "D:\\", drive + ":\\");
+    StringUtils::Replace(path, "D%3a", drive + "%3a");
+    StringUtils::Replace(path, "D%253a", drive + "%253a");
+    return path;
+  };
+
   // Generate sources
   std::vector<CMediaSource> sources;
   for (const auto& source : Sources)
   {
+    const std::string sourcePath{replaceOpticalTestDrive(source.path)};
     CMediaSource mediaSource{
-        source.name,   "",    "",  source.path, SourceType::REMOTE, KODI::UTILS::CLockInfo{}, "",
-        {source.path}, false, true};
+        source.name, "",           "",    sourcePath, SourceType::REMOTE, KODI::UTILS::CLockInfo{},
+        "",          {sourcePath}, false, true};
     sources.emplace_back(mediaSource);
   }
 
   bool isSourceName{false};
-  int source{CUtil::GetMatchingSource(GetParam().path, sources, isSourceName)};
+  int source{
+      CUtil::GetMatchingSource(replaceOpticalTestDrive(GetParam().path), sources, isSourceName)};
   EXPECT_EQ(source, GetParam().matchingSource);
 }
 


### PR DESCRIPTION
## Description

A test case was failing and I scoped my agent to fix failing tests to not corrupt its work, so here we go.

AI use:

Make the `GetMatchingSource` test fixture independent of the host's drive layout.

When `D:` is an optical drive, the test now substitutes a non-optical drive letter in raw and URL-encoded DOS paths. Production source-matching behavior is unchanged.

## Motivation and context

The tests used `D:` as a synthetic local disk. On Windows systems where `D:` is a CD-ROM drive, `URIUtils::IsOnDVD()` correctly identifies those paths as optical media. `CUtil::GetMatchingSource()` then intentionally selects the first optical source, causing seven environment-dependent test failures.

This change ensures the fixture tests path matching rather than optical-drive handling.

## How has this been tested?

Tested with a Windows 11 25H2 x64 Debug build where `D:` reports `DRIVE_CDROM`.

- Focused `GetMatchingSource` suite: 68/68 passed
- Complete Kodi test suite: 4,286/4,286 enabled tests passed
- Global test teardown completed cleanly

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
