### PR TITLE
[docs] Split "improvements" into "(v22 new feature polish)" and "(other)" for v22 release cycle

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@
 - [ ] **New feature** (non-breaking change which adds functionality)
 - [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
 - [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
-- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
+- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
 - [ ] **None of the above** (please explain below)
 
 ## Checklist:

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,8 @@
 <!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
 - [ ] **Bug fix** (non-breaking change which fixes an issue)
 - [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
-- [ ] **Improvement** (non-breaking change which improves existing functionality)
+- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
+- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
 - [ ] **New feature** (non-breaking change which adds functionality)
 - [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
 - [ ] **Cosmetic change** (non-breaking change that doesn't touch code)


### PR DESCRIPTION
## Description

PR splits:

- [ ] **Improvement**

into:

- [ ] **Improvement (v22 new feature polish)**
- [ ] **Improvement (other)**

Modifies the PR template to make this distinction clear.

Only for v22. To be reverted in v23 Alpha 1 after branching, I guess.

## Motivation and context

As can be seen at https://github.com/xbmc/xbmc/milestone/176, RC1 (and onward) are 'Open for fixes and risk-weighted "new feature polish"'.

Intention is to disallow general improvements during RC stage for safety, but we got cool shit in v22, so let's not block making it more polished, which will probably be required.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [x] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)