### PR TITLE
[Estuary] Use individual flags for audio/sub codec/properties/language

### DIFF
--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -387,7 +387,11 @@
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(ListItem.AudioChannels) + !Control.IsVisible(504)" />
-					<param name="flag_label" value="$VAR[AudioPropertyFlagVar]" />
+					<param name="flag_label" value="$VAR[AudioChannelsVar]" />
+				</include>
+				<include content="MediaFlag">
+					<param name="flag_visible" value="!String.IsEmpty(ListItem.AudioLanguage) + !String.IsEqual(ListItem.AudioLanguage,und) + !Control.IsVisible(504)" />
+					<param name="flag_label" value="$INFO[ListItem.AudioLanguage]" />
 				</include>
 			</control>
 			<control type="grouplist">
@@ -426,11 +430,19 @@
 				</include>
 				<include content="MediaFlag">
 					<param name="flag_visible" value="!String.IsEmpty(VideoPlayer.AudioChannels)" />
-					<param name="flag_label" value="$VAR[AudioPropertyFlagVar]" />
+					<param name="flag_label" value="$VAR[AudioChannelsVar]" />
 				</include>
 				<include content="MediaFlag">
-					<param name="flag_visible" value="VideoPlayer.SubtitlesEnabled + [!String.IsEmpty(VideoPlayer.SubtitleCodec) | !String.IsEmpty(VideoPlayer.SubtitlesLanguage)]" />
-					<param name="flag_label" value="$VAR[ActiveVideoPlayerSubtitleLanguage]" />
+					<param name="flag_visible" value="!String.IsEmpty(VideoPlayer.AudioLanguage) + !String.IsEqual(VideoPlayer.AudioLanguage,und)" />
+					<param name="flag_label" value="$INFO[VideoPlayer.AudioLanguage]" />
+				</include>
+				<include content="MediaFlag">
+					<param name="flag_visible" value="VideoPlayer.SubtitlesEnabled + !String.IsEmpty(VideoPlayer.SubtitleCodec) + !String.IsEmpty(VideoPlayer.SubtitlesLanguage) + !String.IsEqual(VideoPlayer.SubtitlesLanguage,und)" />
+					<param name="flag_label" value="$VAR[SubtitleCodecVar]" />
+				</include>
+				<include content="MediaFlag">
+					<param name="flag_visible" value="VideoPlayer.SubtitlesEnabled + !String.IsEmpty(VideoPlayer.SubtitleCodec) + !String.IsEmpty(VideoPlayer.SubtitlesLanguage) + !String.IsEqual(VideoPlayer.SubtitlesLanguage,und)" />
+					<param name="flag_label" value="$INFO[VideoPlayer.SubtitlesLanguage]" />
 				</include>
 			</control>
 			<control type="grouplist">

--- a/addons/skin.estuary/xml/Includes_SettingsDialog.xml
+++ b/addons/skin.estuary/xml/Includes_SettingsDialog.xml
@@ -61,7 +61,7 @@
 				<param name="width" value="1000" />
 			</include>
 			<label>$LOCALIZE[31112]</label>
-			<label2>[B]$VAR[ActiveVideoPlayerAudioLanguage]$VAR[AudioCodecVar, | ]$VAR[AudioChannelsVar, ][/B]</label2>
+			<label2>[B]$VAR[AudioCodecVar]$VAR[AudioChannelsVar, ]$VAR[ActiveVideoPlayerAudioLanguage, | ][/B]</label2>
 			<onclick>DialogSelectAudio</onclick>
 			<enable>Integer.IsGreater(VideoPlayer.AudioStreamCount,1)</enable>
 		</control>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -741,14 +741,12 @@
 	<variable name="ActiveVideoPlayerSubtitleLanguage">
 		<value condition="Window.IsActive(Custom_1101_SettingsDialog.xml) + !VideoPlayer.HasSubtitles">$LOCALIZE[36623]</value>
 		<value condition="Window.IsActive(Custom_1101_SettingsDialog.xml) + VideoPlayer.HasSubtitles + !VideoPlayer.SubtitlesEnabled">$LOCALIZE[1223]</value>
-        <value condition="Window.IsActive(Custom_1101_SettingsDialog.xml) + VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + [String.IsEmpty(VideoPlayer.SubtitlesLanguage) | String.IsEqual(VideoPlayer.SubtitlesLanguage,und)]">$LOCALIZE[13205]$VAR[SubtitleCodecVar, | ]</value>
-		<value condition="Window.IsActive(Custom_1101_SettingsDialog.xml) + VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + !String.IsEmpty(VideoPlayer.SubtitlesLanguage)">$INFO[VideoPlayer.SubtitlesLanguage]$VAR[SubtitleCodecVar, | ]</value>
-        <value condition="Window.IsActive(fullscreenvideo) + [String.IsEmpty(VideoPlayer.SubtitlesLanguage) | String.IsEqual(VideoPlayer.SubtitlesLanguage,und)] + !String.IsEmpty(VideoPlayer.SubtitleCodec)">$VAR[SubtitleCodecVar]</value>
-		<value condition="Window.IsActive(fullscreenvideo) + !String.IsEmpty(VideoPlayer.SubtitlesLanguage)">$INFO[VideoPlayer.SubtitlesLanguage]$VAR[SubtitleCodecVar, &#8226; ]</value>
+		<value condition="Window.IsActive(Custom_1101_SettingsDialog.xml) + VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + [String.IsEmpty(VideoPlayer.SubtitlesLanguage) | String.IsEqual(VideoPlayer.SubtitlesLanguage,und)]">$VAR[SubtitleCodecVar,, | $LOCALIZE[13205]]</value>
+		<value condition="Window.IsActive(Custom_1101_SettingsDialog.xml) + VideoPlayer.HasSubtitles + VideoPlayer.SubtitlesEnabled + !String.IsEmpty(VideoPlayer.SubtitlesLanguage)">$VAR[SubtitleCodecVar]$INFO[VideoPlayer.SubtitlesLanguage, | ]</value>
 	</variable>
 	<variable name="ActiveVideoPlayerAudioLanguage">
-		<value condition="!String.IsEmpty(VideoPlayer.AudioLanguage)">$INFO[VideoPlayer.AudioLanguage]</value>
-		<value condition="String.IsEmpty(VideoPlayer.AudioLanguage) | String.IsEqual(ListItem.AudioLanguage,und)">$LOCALIZE[13205]</value>
+		<value condition="!String.IsEmpty(VideoPlayer.AudioLanguage) + !String.IsEqual(VideoPlayer.AudioLanguage,und">$INFO[VideoPlayer.AudioLanguage]</value>
+		<value condition="String.IsEmpty(VideoPlayer.AudioLanguage) | String.IsEqual(VideoPlayer.AudioLanguage,und">$LOCALIZE[13205]</value>
 	</variable>
 	<variable name="AudioPropertyFlagVar">
 		<value condition="!Window.IsActive(fullscreenvideo) + [String.IsEmpty(ListItem.AudioLanguage) | String.IsEqual(ListItem.AudioLanguage,und)]">$VAR[AudioChannelsVar]</value>


### PR DESCRIPTION
## Description
For Audio seperate channels and language into inidvidual flags.
For Subs seperate Codec and language into inidvidual flags.

As language flag is after codec flag whether audio or subtitle, then the ordering on the Stream Selection menu was also changed to show codec first then language. 

## Motivation and context
After living with the way language was exposed via flags in Estuary for a while after language was introduced into the flags, it hasn't saved much space so I've come to the conclusion having language seperated into it's own flag looks better.

Then Stream Selection menu changed to match flag ordering.

## How has this been tested?
A mix of local files.

## What is the effect on users?
Flags shown by Estuary

## Screenshots (if appropriate):

**Before**

List
<img width="1917" height="310" alt="image" src="https://github.com/user-attachments/assets/e703b74e-6124-481d-a9b1-dbae49d02e4c" />

Video Info
<img width="1919" height="687" alt="image" src="https://github.com/user-attachments/assets/3eb8c17c-d3a0-492d-b1ac-ee24f19ab286" />

Stream Selection
<img width="996" height="292" alt="image" src="https://github.com/user-attachments/assets/b19ce3b4-519b-4310-94c2-fd56e7f6e1b0" />


**After**

List
<img width="1918" height="308" alt="image" src="https://github.com/user-attachments/assets/08e1a080-d93c-4a14-b4b9-9f38e5dc7b0e" />

Video Info
<img width="1916" height="682" alt="image" src="https://github.com/user-attachments/assets/8bd2fcfc-5efb-46cc-8485-f6e96fa14d91" />

Stream Selection
<img width="1000" height="283" alt="image" src="https://github.com/user-attachments/assets/a9bf0236-2512-41c5-8e46-92ccfaefefa5" />


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
