### PR TITLE
[RetroPlayer] Fix DirectX shader input handling

### DIFF
--- a/cmake/treedata/windows/tests.txt
+++ b/cmake/treedata/windows/tests.txt
@@ -1,1 +1,2 @@
 xbmc/platform/win32/test test/win32
+xbmc/cores/RetroPlayer/shaders/windows/test test/retroplayer/shaders/windows

--- a/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.cpp
@@ -9,9 +9,12 @@
 #include "RPWinOutputShader.h"
 
 #include "ShaderTypesDX.h"
+#include "ShaderUtilsDX.h"
 #include "filesystem/File.h"
 #include "rendering/dx/DeviceResources.h"
 #include "utils/log.h"
+
+#include "platform/win32/WIN32Util.h"
 
 using namespace KODI::SHADER;
 
@@ -31,18 +34,28 @@ bool CRPWinShader::CreateVertexBuffer(unsigned int count, unsigned int size)
   return true;
 }
 
-bool CRPWinShader::CreateInputLayout(D3D11_INPUT_ELEMENT_DESC* layout, unsigned numElements)
+bool CRPWinShader::CreateInputLayout(D3D11_INPUT_ELEMENT_DESC* layout,
+                                     unsigned numElements,
+                                     const char* techniqueName)
 {
   D3DX11_PASS_DESC desc = {};
-  if (FAILED(m_effect.Get()->GetTechniqueByIndex(0)->GetPassByIndex(0)->GetDesc(&desc)))
+  if (!GetShaderPassDescription(m_effect.Get(), techniqueName, 0, desc))
   {
-    CLog::LogF(LOGERROR, "Failed to get description");
+    CLog::LogF(LOGERROR, "Invalid or missing effect pass: technique={}, pass=0", techniqueName);
     return false;
   }
 
   Microsoft::WRL::ComPtr<ID3D11Device> pDevice = DX::DeviceResources::Get()->GetD3DDevice();
-  return SUCCEEDED(pDevice->CreateInputLayout(layout, numElements, desc.pIAInputSignature,
-                                              desc.IAInputSignatureSize, &m_inputLayout));
+  const HRESULT result = pDevice->CreateInputLayout(layout, numElements, desc.pIAInputSignature,
+                                                    desc.IAInputSignatureSize, &m_inputLayout);
+  if (FAILED(result))
+  {
+    CLog::LogF(LOGERROR, "D3D input layout creation failed: technique={}, result={}", techniqueName,
+               result);
+    return false;
+  }
+
+  return true;
 }
 
 bool CRPWinShader::LockVertexBuffer(void** data)
@@ -180,7 +193,7 @@ bool CRPWinOutputShader::Create(RETRO::SCALINGMETHOD scalingMethod)
       {"POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0},
       {"TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0},
   };
-  return CreateInputLayout(layout, ARRAYSIZE(layout));
+  return CreateInputLayout(layout, ARRAYSIZE(layout), "OUTPUT_T");
 }
 
 void CRPWinOutputShader::Render(CD3DTexture& sourceTexture,
@@ -223,24 +236,32 @@ void CRPWinOutputShader::PrepareParameters(unsigned int sourceWidth,
     v[0].z = 0.0f;
     v[0].tu = m_sourceRect.x1 / m_sourceWidth;
     v[0].tv = m_sourceRect.y1 / m_sourceHeight;
+    v[0].tu2 = 0.0f;
+    v[0].tv2 = 0.0f;
 
     v[1].x = m_destPoints[1].x;
     v[1].y = m_destPoints[1].y;
     v[1].z = 0.0f;
     v[1].tu = m_sourceRect.x2 / m_sourceWidth;
     v[1].tv = m_sourceRect.y1 / m_sourceHeight;
+    v[1].tu2 = 1.0f;
+    v[1].tv2 = 0.0f;
 
     v[2].x = m_destPoints[2].x;
     v[2].y = m_destPoints[2].y;
     v[2].z = 0.0f;
     v[2].tu = m_sourceRect.x2 / m_sourceWidth;
     v[2].tv = m_sourceRect.y2 / m_sourceHeight;
+    v[2].tu2 = 1.0f;
+    v[2].tv2 = 1.0f;
 
     v[3].x = m_destPoints[3].x;
     v[3].y = m_destPoints[3].y;
     v[3].z = 0.0f;
     v[3].tu = m_sourceRect.x1 / m_sourceWidth;
     v[3].tv = m_sourceRect.y2 / m_sourceHeight;
+    v[3].tu2 = 0.0f;
+    v[3].tv2 = 1.0f;
 
     UnlockVertexBuffer();
   }

--- a/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/RPWinOutputShader.h
@@ -30,7 +30,9 @@ public:
 
 protected:
   virtual bool CreateVertexBuffer(unsigned int vertCount, unsigned int vertSize);
-  virtual bool CreateInputLayout(D3D11_INPUT_ELEMENT_DESC* layout, unsigned numElements);
+  virtual bool CreateInputLayout(D3D11_INPUT_ELEMENT_DESC* layout,
+                                 unsigned numElements,
+                                 const char* techniqueName);
   virtual bool LockVertexBuffer(void** data);
   virtual bool UnlockVertexBuffer();
   virtual bool LoadEffect(const std::string& filename, DefinesMap* defines);

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderDX.cpp
@@ -74,6 +74,15 @@ bool CShaderDX::Create(unsigned int passIdx,
     return false;
   }
 
+  if (!m_effect.SetTechnique("TEQ"))
+  {
+    CLog::Log(LOGERROR,
+              "CShaderDX::Create: Shader has no valid FX11 technique: pass={}, alias={}, "
+              "shader={}, technique=TEQ",
+              m_passIdx, m_passAlias, m_shaderPath);
+    return false;
+  }
+
   return true;
 }
 
@@ -134,18 +143,26 @@ void CShaderDX::PrepareParameters(
   v[0].z = 0;
   v[0].tu = 0;
   v[0].tv = 0;
+  v[0].tu2 = 0.0f;
+  v[0].tv2 = 0.0f;
   // top right
   v[1].z = 0;
   v[1].tu = 1;
   v[1].tv = 0;
+  v[1].tu2 = 1.0f;
+  v[1].tv2 = 0.0f;
   // bottom right
   v[2].z = 0;
   v[2].tu = 1;
   v[2].tv = 1;
+  v[2].tu2 = 1.0f;
+  v[2].tv2 = 1.0f;
   // bottom left
   v[3].z = 0;
   v[3].tu = 0;
   v[3].tv = 1;
+  v[3].tu2 = 0.0f;
+  v[3].tv2 = 1.0f;
 
   UnlockVertexBuffer();
   UpdateInputBuffer(frameCount);
@@ -167,7 +184,7 @@ bool CShaderDX::CreateVertexBuffer(unsigned int vertCount, unsigned int vertSize
 
 bool CShaderDX::CreateInputLayout(D3D11_INPUT_ELEMENT_DESC* layout, unsigned int numElements)
 {
-  return CRPWinShader::CreateInputLayout(layout, numElements);
+  return CRPWinShader::CreateInputLayout(layout, numElements, "TEQ");
 }
 
 bool CShaderDX::CreateInputBuffer()

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderPresetDX.cpp
@@ -16,6 +16,7 @@
 #include "rendering/dx/RenderSystemDX.h"
 #include "utils/log.h"
 
+#include <cstddef>
 #include <regex>
 
 using namespace KODI::SHADER;
@@ -88,9 +89,12 @@ bool CShaderPresetDX::CreateLayouts()
 
     // Create input layout
     D3D11_INPUT_ELEMENT_DESC layout[] = {
-        {"SV_POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0},
-        {"TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0},
-        {"TEXCOORD", 1, DXGI_FORMAT_R32G32_FLOAT, 0, 20, D3D11_INPUT_PER_VERTEX_DATA, 0}};
+        {"SV_POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, offsetof(CUSTOMVERTEX, x),
+         D3D11_INPUT_PER_VERTEX_DATA, 0},
+        {"TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, offsetof(CUSTOMVERTEX, tu),
+         D3D11_INPUT_PER_VERTEX_DATA, 0},
+        {"TEXCOORD", 1, DXGI_FORMAT_R32G32_FLOAT, 0, offsetof(CUSTOMVERTEX, tu2),
+         D3D11_INPUT_PER_VERTEX_DATA, 0}};
 
     if (!videoShaderDX->CreateInputLayout(layout, ARRAYSIZE(layout)))
     {

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderTypesDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderTypesDX.h
@@ -8,17 +8,23 @@
 
 #pragma once
 
-#include <minwindef.h>
+#include <cstddef>
 
 namespace KODI::SHADER
 {
 struct CUSTOMVERTEX
 {
-  FLOAT x;
-  FLOAT y;
-  FLOAT z;
+  float x;
+  float y;
+  float z;
 
-  FLOAT tu;
-  FLOAT tv;
+  float tu;
+  float tv;
+
+  float tu2;
+  float tv2;
 };
+
+static_assert(offsetof(CUSTOMVERTEX, tu2) == 5 * sizeof(float));
+static_assert(sizeof(CUSTOMVERTEX) == 7 * sizeof(float));
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderUtilsDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderUtilsDX.cpp
@@ -36,3 +36,23 @@ DirectX::XMFLOAT2 CShaderUtilsDX::ToDXVector(const float2& vec)
 {
   return DirectX::XMFLOAT2(static_cast<float>(vec.x), static_cast<float>(vec.y));
 }
+
+bool KODI::SHADER::GetShaderPassDescription(ID3DX11Effect* effect,
+                                            const char* techniqueName,
+                                            unsigned int passIndex,
+                                            D3DX11_PASS_DESC& passDesc)
+{
+  passDesc = {};
+  if (effect == nullptr || techniqueName == nullptr)
+    return false;
+
+  ID3DX11EffectTechnique* technique = effect->GetTechniqueByName(techniqueName);
+  if (technique == nullptr || !technique->IsValid())
+    return false;
+
+  ID3DX11EffectPass* pass = technique->GetPassByIndex(passIndex);
+  if (pass == nullptr || !pass->IsValid())
+    return false;
+
+  return SUCCEEDED(pass->GetDesc(&passDesc));
+}

--- a/xbmc/cores/RetroPlayer/shaders/windows/ShaderUtilsDX.h
+++ b/xbmc/cores/RetroPlayer/shaders/windows/ShaderUtilsDX.h
@@ -12,6 +12,7 @@
 
 #include <DirectXMath.h>
 #include <d3d11.h>
+#include <d3dx11effect.h>
 
 namespace KODI::SHADER
 {
@@ -21,4 +22,9 @@ public:
   static D3D11_TEXTURE_ADDRESS_MODE TranslateWrapType(WrapType wrapType);
   static DirectX::XMFLOAT2 ToDXVector(const float2& vec);
 };
+
+bool GetShaderPassDescription(ID3DX11Effect* effect,
+                              const char* techniqueName,
+                              unsigned int passIndex,
+                              D3DX11_PASS_DESC& passDesc);
 } // namespace KODI::SHADER

--- a/xbmc/cores/RetroPlayer/shaders/windows/test/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/shaders/windows/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestShaderUtilsDX.cpp)
+
+core_add_test_library(retroplayer_shaders_windows_test)

--- a/xbmc/cores/RetroPlayer/shaders/windows/test/TestShaderUtilsDX.cpp
+++ b/xbmc/cores/RetroPlayer/shaders/windows/test/TestShaderUtilsDX.cpp
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/RetroPlayer/shaders/windows/ShaderUtilsDX.h"
+
+#include <cstring>
+#include <string>
+
+#include <d3d11.h>
+#include <d3dx11effect.h>
+#include <gtest/gtest.h>
+#include <windows.h>
+#include <wrl/client.h>
+
+using namespace KODI::SHADER;
+
+namespace
+{
+Microsoft::WRL::ComPtr<ID3D11Device> CreateWarpDevice()
+{
+  Microsoft::WRL::ComPtr<ID3D11Device> device;
+  const D3D_FEATURE_LEVEL featureLevels[] = {D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_1,
+                                             D3D_FEATURE_LEVEL_10_0};
+  D3D_FEATURE_LEVEL featureLevel{};
+
+  const HRESULT result = D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_WARP, nullptr, 0, featureLevels,
+                                           ARRAYSIZE(featureLevels), D3D11_SDK_VERSION,
+                                           device.GetAddressOf(), &featureLevel, nullptr);
+  EXPECT_TRUE(SUCCEEDED(result));
+  return device;
+}
+
+Microsoft::WRL::ComPtr<ID3DX11Effect> CompileEffect(ID3D11Device* device, const char* source)
+{
+  Microsoft::WRL::ComPtr<ID3DX11Effect> effect;
+  Microsoft::WRL::ComPtr<ID3DBlob> errors;
+  const HRESULT result =
+      D3DX11CompileEffectFromMemory(source, strlen(source), "TestShaderUtilsDX", nullptr, nullptr,
+                                    0, 0, device, effect.GetAddressOf(), errors.GetAddressOf());
+
+  std::string errorText;
+  if (errors)
+  {
+    errorText.assign(static_cast<const char*>(errors->GetBufferPointer()), errors->GetBufferSize());
+  }
+  EXPECT_TRUE(SUCCEEDED(result)) << errorText;
+  return effect;
+}
+} // namespace
+
+TEST(TestShaderUtilsDX, RejectsEffectWithoutNamedTechnique)
+{
+  constexpr const char* source = R"(
+float4 main_vertex(float4 position : POSITION) : SV_POSITION { return position; }
+float4 main_fragment() : SV_Target { return float4(1.0, 1.0, 1.0, 1.0); }
+)";
+
+  const auto device = CreateWarpDevice();
+  ASSERT_NE(nullptr, device);
+  const auto effect = CompileEffect(device.Get(), source);
+  ASSERT_NE(nullptr, effect);
+
+  D3DX11_PASS_DESC passDesc{};
+  EXPECT_FALSE(GetShaderPassDescription(effect.Get(), "TEQ", 0, passDesc));
+}
+
+TEST(TestShaderUtilsDX, ResolvesNamedTechniqueInsteadOfFirstTechnique)
+{
+  constexpr const char* source = R"(
+struct ExpectedInput
+{
+  float3 position : SV_POSITION;
+  float2 texCoord : TEXCOORD0;
+  float2 texCoord2 : TEXCOORD1;
+};
+
+float4 other_vertex(float4 position : POSITION) : SV_POSITION { return position; }
+float4 expected_vertex(ExpectedInput input) : SV_POSITION { return float4(input.position, 1.0); }
+float4 main_fragment() : SV_Target { return float4(1.0, 1.0, 1.0, 1.0); }
+
+technique11 OTHER
+{
+  pass P0
+  {
+    SetVertexShader(CompileShader(vs_4_0, other_vertex()));
+    SetPixelShader(CompileShader(ps_4_0, main_fragment()));
+  }
+}
+
+technique11 TEQ
+{
+  pass P0
+  {
+    SetVertexShader(CompileShader(vs_4_0, expected_vertex()));
+    SetPixelShader(CompileShader(ps_4_0, main_fragment()));
+  }
+}
+)";
+
+  const auto device = CreateWarpDevice();
+  ASSERT_NE(nullptr, device);
+  const auto effect = CompileEffect(device.Get(), source);
+  ASSERT_NE(nullptr, effect);
+
+  D3DX11_PASS_DESC passDesc{};
+  ASSERT_TRUE(GetShaderPassDescription(effect.Get(), "TEQ", 0, passDesc));
+
+  const D3D11_INPUT_ELEMENT_DESC layout[] = {
+      {"SV_POSITION", 0, DXGI_FORMAT_R32G32B32_FLOAT, 0, 0, D3D11_INPUT_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 0, DXGI_FORMAT_R32G32_FLOAT, 0, 12, D3D11_INPUT_PER_VERTEX_DATA, 0},
+      {"TEXCOORD", 1, DXGI_FORMAT_R32G32_FLOAT, 0, 20, D3D11_INPUT_PER_VERTEX_DATA, 0},
+  };
+  Microsoft::WRL::ComPtr<ID3D11InputLayout> inputLayout;
+  EXPECT_TRUE(SUCCEEDED(
+      device->CreateInputLayout(layout, ARRAYSIZE(layout), passDesc.pIAInputSignature,
+                                passDesc.IAInputSignatureSize, inputLayout.GetAddressOf())));
+}


### PR DESCRIPTION
## Description

No C++ affected outside of xbmc/cores/RetroPlayer/shaders/windows.

AI use:

Fixes an invalid DirectX vertex-input contract by supplying the advertised TEXCOORD1 data, and consistently uses the named FX11 TEQ technique for reflection and rendering.

Provides valid `TEXCOORD1` vertex data and use the named FX11 technique when creating the input layout.

Effect:

* **SGB:** definitely affected by the `TEXCOORD1` fix. Before, UV1 came from beyond the old 20-byte vertex stride; afterward the border became visible. But SGB was **still broken** because of the separate final-pass FBO scaling issue. 
* **PSP 2x:** now gets legitimate `TEXCOORD1`, but remains broken because its shader lacks a valid FX11 `TEQ`/`P0`. 
* **FXAA:** not fixed by this commit alone. It required the shader wrapper `COMPAT_END` correction. 
* **Scale 2x / CRT Geom / NTSC / Game Boy:** these were regression-tested after the change and passed; that demonstrates the input change doesn't break existing shaders, not that this commit newly fixed them. 
he strongest claim for this PR is:

## Motivation and context

The DirectX shader input layout advertised a second texture coordinate without providing matching vertex data, allowing out-of-bounds vertex reads.

Input-layout reflection also used the first effect technique instead of the `TEQ` technique used for rendering.

## How has this been tested?

Tested on Windows with Direct3D 11.

Added WARP-based tests covering the shader vertex layout and FX11 technique/pass lookup.

## What is the effect on users?

* Fixes rendering failures in some DirectX game shaders.

## Types of change

* [x] **Bug fix** (non-breaking change which fixes an issue)
* [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
* [ ] **Improvement** (non-breaking change which improves existing functionality)
* [ ] **New feature** (non-breaking change which adds functionality)
* [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
* [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
* [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
* [ ] **None of the above** (please explain below)