### PR TITLE
fixed: resolve Croatian and Serbian from their ISO 639-2 codes

### DIFF
--- a/xbmc/utils/i18n/Iso639_2_Table.h
+++ b/xbmc/utils/i18n/Iso639_2_Table.h
@@ -633,8 +633,12 @@ static_assert(std::ranges::all_of(
     [](std::string_view name) { return StringUtils::IsAsciiTrimmed(name); },
     &LCENTRY::name));
 
-// 20 pairs of active ISO 639-2/T and /B codes and 2 inactive pairs (deprecated B codes)
-inline static constexpr int ISO639_2_TB_COUNT = 22;
+// 20 pairs of active ISO 639-2/T and /B codes.
+//
+// Croatian and Serbian have no pair here: ISO withdrew their bibliographic codes scr and scc on
+// 2008-06-28, leaving hrv and srp as both forms, so neither language has two spellings to map
+// between.
+inline static constexpr int ISO639_2_TB_COUNT = 20;
 
 // clang-format off
 inline constexpr std::array<ISO639_2_TB, ISO639_2_TB_COUNT> ISO639_2_TB_Mappings = {{
@@ -646,7 +650,6 @@ inline constexpr std::array<ISO639_2_TB, ISO639_2_TB_COUNT> ISO639_2_TB_Mappings
     {StringToLongCode("eus"), StringToLongCode("baq")},
     {StringToLongCode("fas"), StringToLongCode("per")},
     {StringToLongCode("fra"), StringToLongCode("fre")},
-    {StringToLongCode("hrv"), StringToLongCode("scr")}, // 2008-06-28 scr was deprecated. The T code remains.
     {StringToLongCode("hye"), StringToLongCode("arm")},
     {StringToLongCode("isl"), StringToLongCode("ice")},
     {StringToLongCode("kat"), StringToLongCode("geo")},
@@ -658,7 +661,6 @@ inline constexpr std::array<ISO639_2_TB, ISO639_2_TB_COUNT> ISO639_2_TB_Mappings
     {StringToLongCode("ron"), StringToLongCode("rum")},
     {StringToLongCode("slk"), StringToLongCode("slo")},
     {StringToLongCode("sqi"), StringToLongCode("alb")},
-    {StringToLongCode("srp"), StringToLongCode("scc")}, // 2008-06-28 scc was deprecated. The T code remains.
     {StringToLongCode("zho"), StringToLongCode("chi")},
 }};
 // clang-format on

--- a/xbmc/utils/test/TestLangCodeExpander.cpp
+++ b/xbmc/utils/test/TestLangCodeExpander.cpp
@@ -199,6 +199,9 @@ const TestISO6392ToISO6391 ISO6392ToISO6391Tests[] = {
     {"zzz", false, ""},  // not assigned
     {" eng ", true, "en"},
     {"ENG", true, "en"}, // case-insensitive conversion
+    // ISO withdrew the bibliographic codes scr and scc in 2008 and hrv and srp became both forms
+    {"hrv", true, "hr"},
+    {"srp", true, "sr"},
 };
 // clang-format on
 


### PR DESCRIPTION
**TL;DR:** Bug fix. Two ISO 639-2 pairs withdrawn in 2008 made Croatian (`hrv`) resolve to Serbo-Croatian and Serbian (`srp`) resolve to nothing. Removing them lets each code be looked up as itself.

## Description
`CIso639_2`'s terminological-to-bibliographic map still carried the two pairs ISO withdrew on 2008-06-28:

```cpp
{StringToLongCode("hrv"), StringToLongCode("scr")},
{StringToLongCode("srp"), StringToLongCode("scc")},
```

`hrv` and `srp` became both forms of Croatian and Serbian when `scr` and `scc` were withdrawn, and `TableLanguageCodes` reflects that — it holds `{"hr", "hrv"}` and `{"sr", "srp"}`, with `scr` belonging to Serbo-Croatian.

`CLangCodeExpander::ConvertISO6392ToISO6391` maps the T form over *before* it searches that table:

```cpp
const std::string bCode = CIso639_2::TCodeToBCode(iso6392).value_or(iso6392);

const auto it = std::ranges::lower_bound(LanguageCodesByIso639_2b, bCode, {}, &ISO639::iso639_2b);
```

so the search ran for a code the table no longer holds for the language being asked about:

| input | mapped to | found | result |
|---|---|---|---|
| `hrv` (Croatian) | `scr` | `{"sh", "scr"}` | `sh` — Serbo-Croatian |
| `srp` (Serbian) | `scc` | nothing | conversion fails |

`CLanguageTag::AsIso6391` goes through the same conversion, so a stream declaring `hrv` — which is what ffmpeg reports for a Matroska track tagged Croatian — reached every language preference as `sh`. The subtag registry's own entry says why that is the wrong answer:

```
Subtag: sh
Description: Serbo-Croatian
Scope: macrolanguage
Comments: sr, hr, bs are preferred for most modern uses
```

Serbian fared worse: `srp` resolved to nothing, so Kodi held that Serbian has no ISO 639-1 code.

Removing the two pairs leaves each code to be looked up as itself, which is what a language with a single form needs.

`TCodeToBCode`'s other callers are unaffected. `ConvertToISO6392B` searches `LanguageCodesByIso639_2b` before it consults the map, and both codes are in that table, so they already resolved there.

## Motivation and context
Found while writing a table test over a separate language vocabulary. Croatian is the reason it is worth a test rather than an inspection: it *resolved*, to a plausible two-letter code, and only asserting **which** language it named exposed it.

## How has this been tested?
Two cases added to the existing `ISO6392ToISO6391Tests` table. Both fail on `master` before the change — `hrv` returns `sh`, `srp` returns `false` — and pass after it. Full suite green, 4042/4042.

## What is the effect on users?
Media tagged with the current ISO 639-2 code for Croatian or Serbian is matched by a preference for that language, where before Croatian was taken for Serbo-Croatian and Serbian for no language at all.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
