### PR TITLE
fixed: illustrate the provider language codes as RFC 5646 spells them

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Providers.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/pvr/Providers.h
@@ -137,7 +137,7 @@ public:
   /// @brief **optional**\n
   /// The language codes for the provider.
   ///
-  /// @note RFC 5646 standard codes required (e.g.: 'en_GB,fr_CA').
+  /// @note RFC 5646 standard codes required (e.g.: 'en-GB,fr-CA').
   void SetLanguages(const std::vector<std::string>& languages)
   {
     ReallocAndCopyString(

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_providers.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_providers.h
@@ -86,7 +86,7 @@ extern "C"
     /// (e.g 'GB,IE,FR,CA'), an empty string means this value is undefined
     const char* strCountries;
     //! @brief RFC 5646 language codes, separated by PROVIDER_STRING_TOKEN_SEPARATOR
-    /// (e.g. 'en_GB,fr_CA'), an empty string means this value is undefined
+    /// (e.g. 'en-GB,fr-CA'), an empty string means this value is undefined
     const char* strLanguages;
   } PVR_PROVIDER;
 


### PR DESCRIPTION
## Description

`PVR_PROVIDER::strLanguages` is documented as carrying RFC 5646 language codes, and then
illustrated with `'en_GB,fr_CA'`. That is the POSIX locale spelling — RFC 5646 separates the
region subtag with a hyphen, as `en-GB`.

Nothing on the Kodi side validates or corrects the separator, so an add-on author following the
example emits values that are not the notation the field asks for, and they reach the database
and the provider surface as written.

The country example beside it, `'GB,IE,FR,CA'`, is already correct.

Two comment lines, in the C API header and in the C++ wrapper that documents the same field.

## Motivation and context

Noticed while auditing where language values enter Kodi and in what notation.

## How has this been tested?

Comment-only change. Full suite green, 4040/4040.

## What is the effect on users?

None directly. Add-ons written against the corrected example will declare provider languages in
the notation the field is specified to carry.

## Types of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the Kodi [code guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)
- [x] I have read the [contributing document](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)
- [x] All new and existing tests passed
