### PR TITLE
changed: drop the CPVRProvider members that have no callers

### DIFF
--- a/xbmc/pvr/providers/PVRProvider.cpp
+++ b/xbmc/pvr/providers/PVRProvider.cpp
@@ -14,7 +14,6 @@
 #include "pvr/addons/PVRClient.h"
 #include "pvr/addons/PVRClients.h"
 #include "utils/StringUtils.h"
-#include "utils/Variant.h"
 #include "utils/log.h"
 
 #include <memory>
@@ -61,40 +60,6 @@ CPVRProvider::CPVRProvider(int iClientId,
 bool CPVRProvider::operator==(const CPVRProvider& right) const
 {
   return (m_iUniqueId == right.m_iUniqueId && m_iClientId == right.m_iClientId);
-}
-
-void CPVRProvider::Serialize(CVariant& value) const
-{
-  value["providerid"] = m_iDatabaseId;
-  value["clientid"] = m_iClientId;
-  value["providername"] = m_strName;
-  switch (m_type)
-  {
-    case PVR_PROVIDER_TYPE_ADDON:
-      value["providertype"] = "addon";
-      break;
-    case PVR_PROVIDER_TYPE_SATELLITE:
-      value["providertype"] = "satellite";
-      break;
-    case PVR_PROVIDER_TYPE_CABLE:
-      value["providertype"] = "cable";
-      break;
-    case PVR_PROVIDER_TYPE_AERIAL:
-      value["providertype"] = "aerial";
-      break;
-    case PVR_PROVIDER_TYPE_IPTV:
-      value["providertype"] = "iptv";
-      break;
-    case PVR_PROVIDER_TYPE_OTHER:
-      value["providertype"] = "other";
-      break;
-    default:
-      value["state"] = "unknown";
-      break;
-  }
-  value["iconpath"] = GetClientIconPath();
-  value["countries"] = m_strCountries;
-  value["languages"] = m_strLanguages;
 }
 
 int CPVRProvider::GetDatabaseId() const
@@ -188,41 +153,6 @@ bool CPVRProvider::SetIconPath(const std::string& strIconPath)
   return false;
 }
 
-namespace
-{
-
-std::vector<std::string> Tokenize(const std::string& str)
-{
-  return StringUtils::Split(str, PROVIDER_STRING_TOKEN_SEPARATOR);
-}
-
-std::string DeTokenize(const std::vector<std::string>& tokens)
-{
-  return StringUtils::Join(tokens, PROVIDER_STRING_TOKEN_SEPARATOR);
-}
-
-} // unnamed namespace
-
-std::vector<std::string> CPVRProvider::GetCountries() const
-{
-  std::unique_lock lock(m_critSection);
-
-  return Tokenize(m_strCountries);
-}
-
-bool CPVRProvider::SetCountries(const std::vector<std::string>& countries)
-{
-  std::unique_lock lock(m_critSection);
-  const std::string strCountries = DeTokenize(countries);
-  if (m_strCountries != strCountries)
-  {
-    m_strCountries = strCountries;
-    return true;
-  }
-
-  return false;
-}
-
 std::string CPVRProvider::GetCountriesDBString() const
 {
   std::unique_lock lock(m_critSection);
@@ -235,25 +165,6 @@ bool CPVRProvider::SetCountriesFromDBString(std::string_view strCountries)
   if (m_strCountries != strCountries)
   {
     m_strCountries = strCountries;
-    return true;
-  }
-
-  return false;
-}
-
-std::vector<std::string> CPVRProvider::GetLanguages() const
-{
-  std::unique_lock lock(m_critSection);
-  return Tokenize(m_strLanguages);
-}
-
-bool CPVRProvider::SetLanguages(const std::vector<std::string>& languages)
-{
-  std::unique_lock lock(m_critSection);
-  const std::string strLanguages = DeTokenize(languages);
-  if (m_strLanguages != strLanguages)
-  {
-    m_strLanguages = strLanguages;
     return true;
   }
 

--- a/xbmc/pvr/providers/PVRProvider.h
+++ b/xbmc/pvr/providers/PVRProvider.h
@@ -11,13 +11,11 @@
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_providers.h"
 #include "pvr/PVRCachedImage.h"
 #include "threads/CriticalSection.h"
-#include "utils/ISerializable.h"
 #include "utils/ISortable.h"
 
 #include <memory>
 #include <string>
 #include <string_view>
-#include <vector>
 
 namespace PVR
 {
@@ -31,7 +29,7 @@ enum class ProviderUpdateMode
 static constexpr int PVR_PROVIDER_ADDON_UID = -1;
 static constexpr int PVR_PROVIDER_INVALID_DB_ID = -1;
 
-class CPVRProvider final : public ISerializable, public ISortable
+class CPVRProvider final : public ISortable
 {
 public:
   static const std::string IMAGE_OWNER_PATTERN;
@@ -44,8 +42,6 @@ public:
                const std::string& addonThumbPath);
 
   bool operator==(const CPVRProvider& right) const;
-
-  void Serialize(CVariant& value) const override;
 
   // ISortable implementation
   void ToSortable(SortItem& sortable, Field field) const override;
@@ -135,19 +131,6 @@ public:
    * @brief Get this provider's country codes (ISO 3166).
    * @return This provider's country codes.
    */
-  std::vector<std::string> GetCountries() const;
-
-  /*!
-   * @brief Set the country codes for this provider
-   * @param countries The new ISO 3166 country codes for this provider.
-   * @return true if the country codes were updated successfully
-   */
-  bool SetCountries(const std::vector<std::string>& countries);
-
-  /*!
-   * @brief Get this provider's country codes (ISO 3166) as a string.
-   * @return This provider's country codes.
-   */
   std::string GetCountriesDBString() const;
 
   /*!
@@ -159,19 +142,6 @@ public:
 
   /*!
    * @brief Get this provider's language codes (RFC 5646).
-   * @return This provider's language codes
-   */
-  std::vector<std::string> GetLanguages() const;
-
-  /*!
-   * @brief Set the language codes for this provider
-   * @param languages The new RFC 5646 language codes for this provider.
-   * @return true if the language codes were updated successfully
-   */
-  bool SetLanguages(const std::vector<std::string>& languages);
-
-  /*!
-   * @brief Get this provider's language codes (RFC 5646) as a string.
    * @return This provider's language codes.
    */
   std::string GetLanguagesDBString() const;


### PR DESCRIPTION
**TL;DR:** Clean up. `CPVRProvider`'s vector country/language accessors and its `ISerializable` implementation have no callers and no schema that could produce their output, so they are removed.

## Description
`CPVRProvider` carries a language/country surface that nothing reaches.

**The vector accessors.** `GetCountries`, `SetCountries`, `GetLanguages` and `SetLanguages` tokenize and rejoin the stored strings on `PROVIDER_STRING_TOKEN_SEPARATOR`. None of the four has a caller. Every live path uses the `GetCountriesDBString` / `GetLanguagesDBString` pair that `CPVRDatabase` reads and writes, or the `PVR_PROVIDER` constructor, which takes the strings as the client gave them.

**The serializer.** `CPVRProvider::Serialize` writes a full provider object — `providerid`, `clientid`, `providername`, `providertype`, `iconpath`, `countries`, `languages` — but there is no provider type in the JSON-RPC schema (`grep -c provider` over `types.json` and `methods.json` returns 0 for both), and `CFileItem::Serialize` does not reach `m_pvrProviderInfoTag`. Nothing can produce that object. With it gone, `CPVRProvider` has no reason to implement `ISerializable`.

The two file-local `Tokenize` / `DeTokenize` helpers went with the accessors that used them, and `utils/Variant.h` with the serializer.

## Motivation and context
Found while auditing where provider language values are read, for the notation they are stored in. The answer turned out to be that the typed half of that surface is not read at all.

If a JSON-RPC provider surface is added later, its serializer is better written against the schema that defines it than resurrected from here.

## How has this been tested?
Full suite green, 4040/4040. The removal is caller-driven rather than annotation-driven: each symbol was checked across the tree before deleting it.

## What is the effect on users?
None. No behaviour is reachable through any of the removed members.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
