### PR TITLE
changed: drop the CLangInfo members that have no callers

### DIFF
--- a/xbmc/LangInfo.cpp
+++ b/xbmc/LangInfo.cpp
@@ -286,7 +286,6 @@ void CLangInfo::CRegion::SetDefaults()
   m_strTimeFormat="HH:mm:ss";
   m_tempUnit = CTemperature::UnitCelsius;
   m_speedUnit = CSpeed::UnitKilometresPerHour;
-  m_strTimeZone.clear();
 }
 
 void CLangInfo::CRegion::SetTemperatureUnit(const std::string& strUnit)
@@ -297,11 +296,6 @@ void CLangInfo::CRegion::SetTemperatureUnit(const std::string& strUnit)
 void CLangInfo::CRegion::SetSpeedUnit(const std::string& strUnit)
 {
   m_speedUnit = StringToSpeedUnit(strUnit);
-}
-
-void CLangInfo::CRegion::SetTimeZone(const std::string& strTimeZone)
-{
-  m_strTimeZone = strTimeZone;
 }
 
 CLocale CLangInfo::CRegion::GetLocale() const
@@ -605,10 +599,6 @@ bool CLangInfo::Load(const std::string& strLanguage)
       const auto* pSpeedUnit = pRegion->FirstChildElement("speedunit");
       if (pSpeedUnit && !pSpeedUnit->NoChildren())
         region.SetSpeedUnit(pSpeedUnit->FirstChild()->Value());
-
-      const auto* pTimeZone = pRegion->FirstChildElement("timezone");
-      if (pTimeZone && !pTimeZone->NoChildren())
-        region.SetTimeZone(pTimeZone->FirstChild()->Value());
 
       const auto* pThousandsSep = pRegion->FirstChildElement("thousandsseparator");
       if (pThousandsSep)
@@ -1049,14 +1039,6 @@ const std::string& CLangInfo::GetDateFormat(bool bLongDate /* = false */) const
   return bLongDate ? GetLongDateFormat() : GetShortDateFormat();
 }
 
-void CLangInfo::SetDateFormat(const std::string& dateFormat, bool bLongDate /* = false */)
-{
-  if (bLongDate)
-    SetLongDateFormat(dateFormat);
-  else
-    SetShortDateFormat(dateFormat);
-}
-
 const std::string& CLangInfo::GetShortDateFormat() const
 {
   return m_shortDateFormat;
@@ -1129,11 +1111,6 @@ void CLangInfo::Set24HourClock(const std::string& str24HourClock)
     return;
 
   m_use24HourClock = use24HourClock;
-}
-
-const std::string& CLangInfo::GetTimeZone() const
-{
-  return m_currentRegion->m_strTimeZone;
 }
 
 // Returns the AM/PM symbol of the current language
@@ -1286,14 +1263,6 @@ CSpeed::Unit CLangInfo::GetSpeedUnit() const
   return m_speedUnit;
 }
 
-std::string CLangInfo::GetSpeedAsString(const CSpeed& speed) const
-{
-  if (!speed.IsValid())
-    return CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(13205); // "Unknown"
-
-  return StringUtils::Format("{}{}", speed.ToString(GetSpeedUnit()), GetSpeedUnitString());
-}
-
 // Returns the speed unit string for the current language
 const std::string& CLangInfo::GetSpeedUnitString() const
 {
@@ -1319,12 +1288,6 @@ bool CLangInfo::DetermineUse24HourClockFromTimeFormat(const std::string& timeFor
 {
   // if the time format contains a "h" it's 12-hour and otherwise 24-hour clock format
   return timeFormat.find('h') == std::string::npos;
-}
-
-bool CLangInfo::DetermineUseMeridiemFromTimeFormat(const std::string& timeFormat)
-{
-  // if the time format contains "xx" it's using meridiem
-  return timeFormat.find("xx") != std::string::npos;
 }
 
 std::string CLangInfo::PrepareTimeFormat(const std::string& timeFormat, bool use24HourClock)

--- a/xbmc/LangInfo.h
+++ b/xbmc/LangInfo.h
@@ -168,7 +168,6 @@ public:
   KODI::UTILS::CLanguageTag GetDVDMenuLanguage() const;
   KODI::UTILS::CLanguageTag GetDVDAudioLanguage() const;
   KODI::UTILS::CLanguageTag GetDVDSubtitleLanguage() const;
-  const std::string& GetTimeZone() const;
 
   const std::string& GetRegionLocale() const;
 
@@ -201,7 +200,6 @@ public:
   bool ForceUnicodeFont() const { return m_forceUnicodeFont; }
 
   const std::string& GetDateFormat(bool bLongDate = false) const;
-  void SetDateFormat(const std::string& dateFormat, bool bLongDate = false);
   const std::string& GetShortDateFormat() const;
   void SetShortDateFormat(const std::string& shortDateFormat);
   const std::string& GetLongDateFormat() const;
@@ -227,7 +225,6 @@ public:
   void SetSpeedUnit(const std::string& speedUnit);
   const std::string& GetSpeedUnitString() const;
   static const std::string& GetSpeedUnitString(CSpeed::Unit speedUnit);
-  std::string GetSpeedAsString(const CSpeed& speed) const;
 
   void GetRegionNames(std::vector<std::string>& array) const;
   void SetCurrentRegion(const std::string& strName);
@@ -295,7 +292,6 @@ protected:
   bool Load(const std::string& strLanguage);
 
   static bool DetermineUse24HourClockFromTimeFormat(const std::string& timeFormat);
-  static bool DetermineUseMeridiemFromTimeFormat(const std::string& timeFormat);
   static std::string PrepareTimeFormat(const std::string& timeFormat, bool use24HourClock);
   static void AddLanguages(std::vector<StringSettingOption> &list);
 
@@ -306,7 +302,6 @@ protected:
     void SetDefaults();
     void SetTemperatureUnit(const std::string& strUnit);
     void SetSpeedUnit(const std::string& strUnit);
-    void SetTimeZone(const std::string& strTimeZone);
 
     /*!
      * \brief The language and territory this region describes.
@@ -358,7 +353,6 @@ protected:
     std::string m_strDateFormatShort;
     std::string m_strTimeFormat;
     std::string m_strMeridiemSymbols[2];
-    std::string m_strTimeZone;
     std::string m_strGrouping;
     char m_cDecimalSep{'.'};
     char m_cThousandsSep{'.'};


### PR DESCRIPTION
**TL;DR:** Clean up. Four `CLangInfo` members that no caller reaches are removed, including the `<timezone>` value from the language packs that nothing ever read.

## Description
Four `CLangInfo` members that no caller reaches, each checked across the tree before removal.

**`GetTimeZone`**, and with it `CRegion::SetTimeZone`, the `m_strTimeZone` member and the `langinfo.xml` `<timezone>` parse that filled it. The getter arrived with the 2008 linuxport merge and the only commits to touch it since are the two tree-wide directory renames — nothing has ever read it. Kodi answers timezone questions from the platform, through `CDateTime::GetTimezoneBias` and the `locale.timezone` / `locale.timezonecountry` settings.

The values in the packs show what an unread field becomes. `resource.language.en_gb` declares seven, and among them Australia is `GMT`, while India is `GMT` on one region profile and `IST` on another that differs only in clock format. An abbreviation could not do the job in any case: `IST` is India, Ireland and Israel.

**`SetDateFormat`**, which only chooses between `SetLongDateFormat` and `SetShortDateFormat`, both of which callers use directly.

**`GetSpeedAsString`**. Its temperature counterpart `GetTemperatureAsString` is used; this one is not.

**`DetermineUseMeridiemFromTimeFormat`**, unused since it was added. Its sibling `DetermineUse24HourClockFromTimeFormat` is live and stays.

## Motivation and context
Found while auditing `CLangInfo`'s surface.

The language packs still declare `<timezone>` elements. Removing those touches add-ons with their own maintainers, so it follows separately rather than riding along here; nothing reads them either way once this lands.

## How has this been tested?
Full suite green, 4040/4040.

## What is the effect on users?
None. No behaviour is reachable through any of the removed members, and the `<timezone>` value they were the only consumer of was never used for anything.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
