### PR TITLE
[Python] Update version to 3.1.0 for Beta 2 release

### DIFF
--- a/xbmc/interfaces/python/PythonSwig.cpp.template
+++ b/xbmc/interfaces/python/PythonSwig.cpp.template
@@ -913,7 +913,7 @@ namespace PythonBindings
    // constants
    PyModule_AddStringConstant(module, "__author__", "Team Kodi <http://kodi.tv>");
    PyModule_AddStringConstant(module, "__date__", CCompileInfo::GetBuildDate().c_str());
-   PyModule_AddStringConstant(module, "__version__", "3.0.2");
+   PyModule_AddStringConstant(module, "__version__", "3.1.0");
    PyModule_AddStringConstant(module, "__credits__", "Team Kodi");
    PyModule_AddStringConstant(module, "__platform__", "ALL");
 


### PR DESCRIPTION
## Description

Broken out from https://github.com/xbmc/xbmc/pull/29096.

Version was bumped to 3.1.0 in #28852. This PR syncs it with the Swig-generated `__version__`.

This brings the version in line with the proposal here: https://malard.github.io/xbmc/api-version-schedule/
