### PR TITLE
[webOS] webOS 26 audio fix

### DIFF
--- a/xbmc/cores/AudioEngine/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SOURCES AEResampleFactory.cpp
             Engines/ActiveAE/ActiveAEStream.cpp
             Engines/ActiveAE/ActiveAESound.cpp
             Engines/ActiveAE/ActiveAESettings.cpp
+            Sinks/AESinkNULL.cpp
             Utils/AEBitstreamPacker.cpp
             Utils/AEChannelInfo.cpp
             Utils/AEDeviceInfo.cpp
@@ -36,6 +37,7 @@ set(HEADERS AEResampleFactory.h
             Interfaces/AEStream.h
             Interfaces/IAudioCallback.h
             Interfaces/ThreadedAE.h
+            Sinks/AESinkNULL.h
             Utils/AEAudioFormat.h
             Utils/AEBitstreamPacker.h
             Utils/AEChannelData.h

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -393,6 +393,21 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
         case CActiveAEControlProtocol::APPFOCUSED:
           m_sink.m_controlPort.SendOutMessage(CSinkControlProtocol::APPFOCUSED, msg->data, sizeof(bool));
           return;
+        case CActiveAEControlProtocol::YIELDDEVICE:
+        {
+          Message* sinkReply = nullptr;
+          bool success = false;
+          if (m_sink.m_controlPort.SendOutMessageSync(CSinkControlProtocol::RESERVE, &sinkReply, 1s,
+                                                      msg->data, sizeof(bool)))
+          {
+            success = sinkReply->signal == CSinkControlProtocol::ACC;
+            sinkReply->Release();
+          }
+          if (!success)
+            CLog::LogF(LOGERROR, "sink failed to handle the yield request");
+          msg->Reply(success ? CActiveAEControlProtocol::ACC : CActiveAEControlProtocol::ERR);
+          return;
+        }
         case CActiveAEControlProtocol::STREAMRESAMPLEMODE:
           MsgStreamParameter *par;
           par = reinterpret_cast<MsgStreamParameter*>(msg->data);
@@ -3092,6 +3107,31 @@ bool CActiveAE::Resume()
 bool CActiveAE::IsSuspended()
 {
   return m_stats.IsSuspended();
+}
+
+bool CActiveAE::YieldDevice()
+{
+  return SendYieldDevice(true);
+}
+
+bool CActiveAE::ReclaimDevice()
+{
+  return SendYieldDevice(false);
+}
+
+bool CActiveAE::SendYieldDevice(bool yield)
+{
+  Message* reply = nullptr;
+  if (!m_controlPort.SendOutMessageSync(CActiveAEControlProtocol::YIELDDEVICE, &reply, 2s, &yield,
+                                        sizeof(bool)))
+  {
+    CLog::LogF(LOGERROR, "timed out");
+    return false;
+  }
+
+  const bool success = reply->signal == CActiveAEControlProtocol::ACC;
+  reply->Release();
+  return success;
 }
 
 float CActiveAE::GetVolume()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -100,6 +100,7 @@ public:
     DISPLAYRESET,
     APPFOCUSED,
     KEEPCONFIG,
+    YIELDDEVICE,
     TIMEOUT,
   };
   enum InSignal
@@ -244,6 +245,8 @@ public:
   bool Suspend() override;
   bool Resume() override;
   bool IsSuspended() override;
+  bool YieldDevice() override;
+  bool ReclaimDevice() override;
   void OnSettingsChange();
 
   float GetVolume() override;
@@ -308,6 +311,7 @@ protected:
   void Process() override;
   void StateMachine(int signal, Protocol *port, Message *msg);
   bool InitSink();
+  bool SendYieldDevice(bool yield);
   void DrainSink();
   void UnconfigureSink();
   void Dispose();

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.cpp
@@ -10,6 +10,7 @@
 
 #include "ActiveAE.h"
 #include "cores/AudioEngine/AEResampleFactory.h"
+#include "cores/AudioEngine/Sinks/AESinkNULL.h"
 #include "cores/AudioEngine/Utils/AEBitstreamPacker.h"
 #include "cores/AudioEngine/Utils/AEStreamInfo.h"
 #include "cores/AudioEngine/Utils/AEUtil.h"
@@ -57,12 +58,7 @@ void CActiveAESink::Dispose()
   m_controlPort.Purge();
   m_dataPort.Purge();
 
-  if (m_sink)
-  {
-    m_sink->Drain();
-    m_sink->Deinitialize();
-    m_sink.reset();
-  }
+  CloseSink();
 
   m_sampleOfSilence.pkt.reset();
 
@@ -181,6 +177,10 @@ bool CActiveAESink::SupportsFormat(const std::string &device, AEAudioFormat &for
 
 bool CActiveAESink::NeedIECPacking()
 {
+  // the null sink only handles pcm, let a raw stream be packed for it
+  if (m_extReserved)
+    return true;
+
   const AESinkDevice dev = CAESinkFactory::ParseDevice(m_device);
 
   for (auto itt = m_sinkInfoList.begin(); itt != m_sinkInfoList.end(); ++itt)
@@ -296,12 +296,7 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
 
         case CSinkControlProtocol::UNCONFIGURE:
           ReturnBuffers();
-          if (m_sink)
-          {
-            m_sink->Drain();
-            m_sink->Deinitialize();
-            m_sink.reset();
-          }
+          CloseSink();
           m_state = S_TOP_UNCONFIGURED;
           msg->Reply(CSinkControlProtocol::ACC);
           return;
@@ -316,6 +311,24 @@ void CActiveAESink::StateMachine(int signal, Protocol *port, Message *msg)
           SetSilenceTimer();
           m_extTimeout = 0ms;
           return;
+
+        case CSinkControlProtocol::RESERVE:
+        {
+          const bool reserve = *reinterpret_cast<bool*>(msg->data);
+          if (reserve != m_extReserved)
+          {
+            m_extReserved = reserve;
+            CloseSink(false);
+            if (m_state == S_TOP_CONFIGURED_IDLE || m_state == S_TOP_CONFIGURED_PLAY ||
+                m_state == S_TOP_CONFIGURED_SILENCE)
+            {
+              m_state = S_TOP_CONFIGURED_SUSPEND;
+              m_extTimeout = 0ms;
+            }
+          }
+          msg->Reply(CSinkControlProtocol::ACC);
+          return;
+        }
 
         case CSinkControlProtocol::STREAMING:
           m_extStreaming = *(bool*)msg->data;
@@ -613,6 +626,7 @@ void CActiveAESink::Process()
   m_extTimeout = 1000ms;
   m_bStateMachineSelfTrigger = false;
   m_extAppFocused = true;
+  m_extReserved = false;
 
   while (!m_bStop)
   {
@@ -928,14 +942,9 @@ void CActiveAESink::OpenSink()
     }
   }
 
-  CLog::Log(LOGINFO, "CActiveAESink::OpenSink - initialize sink");
+  CLog::LogF(LOGINFO, "initialize sink");
 
-  if (m_sink)
-  {
-    m_sink->Drain();
-    m_sink->Deinitialize();
-    m_sink.reset();
-  }
+  CloseSink();
 
   // get the display name of the device
   GetDeviceFriendlyName(dev.name);
@@ -945,24 +954,35 @@ void CActiveAESink::OpenSink()
 
   // WARNING: this changes format and does not use passthrough
   m_sinkFormat = m_requestedFormat;
-  CLog::Log(LOGDEBUG, "CActiveAESink::OpenSink - trying to open device {}", device);
-  m_sink = CAESinkFactory::Create(device, m_sinkFormat);
 
-  // try first device in out list
-  if (!m_sink && !m_sinkInfoList.empty())
+  if (m_extReserved)
   {
-    dev.driver = m_sinkInfoList.front().m_sinkName;
-    dev.name = m_sinkInfoList.front().m_deviceInfoList.front().m_deviceName;
-    GetDeviceFriendlyName(dev.name);
-    device = dev.driver.empty() ? dev.name : dev.driver + ":" + dev.name;
-    m_sinkFormat = m_requestedFormat;
-    CLog::Log(LOGDEBUG, "CActiveAESink::OpenSink - trying to open device {}", device);
+    CLog::LogF(LOGDEBUG, "device {} is reserved, discarding output", device);
+    auto nullSink = std::make_unique<CAESinkNULL>(m_reservedCacheTotal, m_reservedLatency);
+    if (nullSink->Initialize(m_sinkFormat, device))
+      m_sink = std::move(nullSink);
+  }
+  else
+  {
+    CLog::LogF(LOGDEBUG, "trying to open device {}", device);
     m_sink = CAESinkFactory::Create(device, m_sinkFormat);
+
+    // try first device in out list
+    if (!m_sink && !m_sinkInfoList.empty())
+    {
+      dev.driver = m_sinkInfoList.front().m_sinkName;
+      dev.name = m_sinkInfoList.front().m_deviceInfoList.front().m_deviceName;
+      GetDeviceFriendlyName(dev.name);
+      device = dev.driver.empty() ? dev.name : dev.driver + ":" + dev.name;
+      m_sinkFormat = m_requestedFormat;
+      CLog::LogF(LOGDEBUG, "trying to open device {}", device);
+      m_sink = CAESinkFactory::Create(device, m_sinkFormat);
+    }
   }
 
   if (!m_sink)
   {
-    CLog::Log(LOGERROR, "CActiveAESink::OpenSink - no sink was returned");
+    CLog::LogF(LOGERROR, "no sink was returned");
     m_extError = true;
     return;
   }
@@ -985,7 +1005,13 @@ void CActiveAESink::OpenSink()
     m_sinkFormat.m_dataFormat = AE_FMT_S32NE;
 #endif
 
-  CLog::Log(LOGDEBUG, "CActiveAESink::OpenSink - {} Initialized:", m_sink->GetName());
+  if (!m_extReserved)
+  {
+    m_reservedCacheTotal = std::chrono::duration<double>(m_sink->GetCacheTotal());
+    m_reservedLatency = std::chrono::duration<double>(m_sink->GetLatency());
+  }
+
+  CLog::LogF(LOGDEBUG, "{} Initialized:", m_sink->GetName());
   CLog::Log(LOGDEBUG, "  Output Device : {}", m_deviceFriendlyName);
   CLog::Log(LOGDEBUG, "  Sample Rate   : {}", m_sinkFormat.m_sampleRate);
   CLog::Log(LOGDEBUG, "  Sample Format : {}", CAEUtil::DataFormatToStr(m_sinkFormat.m_dataFormat));
@@ -1015,6 +1041,18 @@ void CActiveAESink::OpenSink()
   }
 
   m_swapState = CHECK_SWAP;
+}
+
+void CActiveAESink::CloseSink(const bool drain)
+{
+  if (!m_sink)
+    return;
+
+  if (drain)
+    m_sink->Drain();
+
+  m_sink->Deinitialize();
+  m_sink.reset();
 }
 
 void CActiveAESink::ReturnBuffers()

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAESink.h
@@ -57,6 +57,7 @@ public:
     UNCONFIGURE,
     STREAMING,
     APPFOCUSED,
+    RESERVE,
     VOLUME,
     FLUSH,
     TIMEOUT,
@@ -117,6 +118,7 @@ protected:
   void PrintSinks(std::string& driver);
   void GetDeviceFriendlyName(const std::string& device);
   void OpenSink();
+  void CloseSink(bool drain = true);
   void ReturnBuffers();
   void SetSilenceTimer();
   bool NeedIECPacking();
@@ -136,6 +138,9 @@ protected:
   std::chrono::milliseconds m_extSilenceTimeout;
   bool m_extAppFocused;
   bool m_extStreaming;
+  bool m_extReserved{false};
+  std::chrono::duration<double> m_reservedCacheTotal{};
+  std::chrono::duration<double> m_reservedLatency{};
   XbmcThreads::EndTime<> m_extSilenceTimer;
 
   CSampleBuffer m_sampleOfSilence;

--- a/xbmc/cores/AudioEngine/Interfaces/AE.h
+++ b/xbmc/cores/AudioEngine/Interfaces/AE.h
@@ -129,6 +129,24 @@ public:
   virtual bool IsSuspended() {return true;}
 
   /*!
+   * \brief Stop using the audio device so an external media pipeline can have it
+   *
+   * The device is closed but, unlike Suspend(), the engine stays configured and running.
+   * Streams and sounds can still be created, their output is discarded until the device is
+   * reclaimed. On true the device has been released when the call returns.
+   *
+   * \return True if the request was handled by the engine
+   */
+  virtual bool YieldDevice() { return false; }
+
+  /*!
+   * \brief Take the audio device back after it was yielded
+   *
+   * \return True if the request was handled by the engine
+   */
+  virtual bool ReclaimDevice() { return false; }
+
+  /*!
    * \brief Returns the current master volume level of the AudioEngine
    *
    * \return The volume level between 0.0 and 1.0

--- a/xbmc/cores/AudioEngine/Sinks/AESinkNULL.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkNULL.cpp
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "AESinkNULL.h"
+
+#include "cores/AudioEngine/Utils/AEUtil.h"
+#include "utils/log.h"
+
+#include <algorithm>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+constexpr auto DEFAULT_BUFFER_TIME = 250ms;
+constexpr auto DEFAULT_PERIOD_TIME = 50ms;
+} // namespace
+
+CAESinkNULL::CAESinkNULL(const std::chrono::duration<double> cacheTotal,
+                         const std::chrono::duration<double> latency)
+  : m_cacheTotal(cacheTotal),
+    m_latency(latency)
+{
+  if (m_cacheTotal <= 0s)
+    m_cacheTotal = DEFAULT_BUFFER_TIME;
+}
+
+bool CAESinkNULL::Initialize(AEAudioFormat& format, std::string& device)
+{
+  m_format = format;
+
+  if (m_format.m_sampleRate == 0)
+  {
+    CLog::LogF(LOGERROR, "invalid sample rate");
+    return false;
+  }
+
+  // a raw stream is IEC packed before it reaches the sink, report back what is written
+  if (m_format.m_dataFormat == AE_FMT_RAW)
+    m_format.m_dataFormat = AE_FMT_S16NE;
+
+  if (m_format.m_frameSize == 0)
+  {
+    m_format.m_frameSize =
+        m_format.m_channelLayout.Count() * (CAEUtil::DataFormatToBits(m_format.m_dataFormat) >> 3);
+    if (m_format.m_frameSize == 0)
+    {
+      CLog::LogF(LOGERROR, "invalid frame size");
+      return false;
+    }
+  }
+
+  if (m_format.m_frames == 0)
+  {
+    m_format.m_frames = static_cast<unsigned int>(
+        m_format.m_sampleRate * std::chrono::duration<double>(DEFAULT_PERIOD_TIME).count());
+  }
+
+  format = m_format;
+
+  m_bufferLevel = 0s;
+  m_lastUpdate = std::chrono::steady_clock::now();
+
+  CLog::LogF(LOGDEBUG, "discarding {} at {} Hz, buffer {} ms",
+             CAEUtil::DataFormatToStr(m_format.m_dataFormat), m_format.m_sampleRate,
+             std::chrono::duration_cast<std::chrono::milliseconds>(m_cacheTotal).count());
+
+  return true;
+}
+
+void CAESinkNULL::UpdateBufferLevel()
+{
+  const auto now = std::chrono::steady_clock::now();
+  const auto elapsed = now - m_lastUpdate;
+  m_lastUpdate = now;
+
+  m_bufferLevel -= elapsed;
+  m_bufferLevel = std::max(m_bufferLevel, std::chrono::duration<double>::zero());
+}
+
+unsigned int CAESinkNULL::AddPackets(uint8_t** data, unsigned int frames, unsigned int offset)
+{
+  UpdateBufferLevel();
+
+  const std::chrono::duration<double> duration(static_cast<double>(frames) / m_format.m_sampleRate);
+
+  if (m_bufferLevel + duration > m_cacheTotal)
+  {
+    std::this_thread::sleep_for(m_bufferLevel + duration - m_cacheTotal);
+    UpdateBufferLevel();
+  }
+
+  m_bufferLevel += duration;
+
+  return frames;
+}
+
+void CAESinkNULL::GetDelay(AEDelayStatus& status)
+{
+  UpdateBufferLevel();
+  status.SetDelay((m_bufferLevel + m_latency).count());
+}
+
+void CAESinkNULL::Drain()
+{
+  UpdateBufferLevel();
+  std::this_thread::sleep_for(m_bufferLevel);
+  UpdateBufferLevel();
+}

--- a/xbmc/cores/AudioEngine/Sinks/AESinkNULL.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkNULL.h
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "cores/AudioEngine/Interfaces/AESink.h"
+
+#include <chrono>
+
+/**
+ * @brief Sink that discards everything it is given.
+ *
+ * Takes over the configuration of the real device while that is handed over to an external
+ * media pipeline. Not registered with CAESinkFactory, it never shows up as a device.
+ */
+class CAESinkNULL : public IAESink
+{
+public:
+  const char* GetName() override { return "NULL"; }
+
+  CAESinkNULL(std::chrono::duration<double> cacheTotal, std::chrono::duration<double> latency);
+
+  bool Initialize(AEAudioFormat& format, std::string& device) override;
+  void Deinitialize() override {}
+
+  double GetCacheTotal() override { return m_cacheTotal.count(); }
+  double GetLatency() override { return m_latency.count(); }
+
+  unsigned int AddPackets(uint8_t** data, unsigned int frames, unsigned int offset) override;
+  void GetDelay(AEDelayStatus& status) override;
+  void Drain() override;
+
+private:
+  void UpdateBufferLevel();
+
+  AEAudioFormat m_format{};
+  std::chrono::duration<double> m_cacheTotal;
+  std::chrono::duration<double> m_latency;
+
+  std::chrono::duration<double> m_bufferLevel{};
+  std::chrono::steady_clock::time_point m_lastUpdate{};
+};

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.cpp
@@ -211,6 +211,7 @@ CMediaPipelineWebOS::CMediaPipelineWebOS(CProcessInfo& processInfo,
 CMediaPipelineWebOS::~CMediaPipelineWebOS()
 {
   Unload(false);
+  RequestAudioDevice(false);
   if (const auto buffer = static_cast<CStarfishVideoBuffer*>(m_picture.videoBuffer))
     buffer->ResetAcbHandle();
 }
@@ -220,19 +221,24 @@ int CMediaPipelineWebOS::GetVideoBitrate() const
   return static_cast<int>(m_videoStats.GetBitrate());
 }
 
-void CMediaPipelineWebOS::UpdateGUISounds(const bool playing)
+void CMediaPipelineWebOS::RequestAudioDevice(const bool pipelineOwns)
 {
-  IAE* activeAE = CServiceBroker::GetActiveAE();
-  const int guiSoundMode = CServiceBroker::GetSettingsComponent()->GetSettings()->GetInt(
-      CSettings::SETTING_AUDIOOUTPUT_GUISOUNDMODE);
+  std::unique_lock lock(m_audioDeviceMutex);
 
-  if (guiSoundMode != AE_SOUND_IDLE)
+  if (!m_hasAudio || m_ownsAudioDevice == pipelineOwns)
     return;
 
-  if (playing)
-    activeAE->SetVolume(0.0);
-  else
-    activeAE->SetVolume(1.0);
+  IAE* const activeAE = CServiceBroker::GetActiveAE();
+  if (!activeAE)
+    return;
+
+  if (!(pipelineOwns ? activeAE->YieldDevice() : activeAE->ReclaimDevice()))
+  {
+    CLog::LogF(LOGERROR, "Failed to {} the audio device", pipelineOwns ? "acquire" : "release");
+    return;
+  }
+
+  m_ownsAudioDevice = pipelineOwns;
 }
 
 std::string CMediaPipelineWebOS::GetAudioInfo() const
@@ -297,6 +303,7 @@ void CMediaPipelineWebOS::FlushAudioMessages()
 bool CMediaPipelineWebOS::OpenAudioStream(CDVDStreamInfo& audioHint)
 {
   m_audioHint = audioHint;
+  m_hasAudio = true;
 
   if (m_loaded)
   {
@@ -318,6 +325,8 @@ bool CMediaPipelineWebOS::OpenAudioStream(CDVDStreamInfo& audioHint)
       if (!m_mediaAPIs->changeAudioCodec(codecName, output))
         CLog::LogF(LOGERROR, "Failed to change audio codec to {}", codecName);
       FlushAudioMessages();
+
+      RequestAudioDevice(true);
 
       m_processInfo.SetAudioChannels(CAEUtil::GetAEChannelLayout(audioHint.channellayout));
       m_processInfo.SetAudioSampleRate(audioHint.samplerate);
@@ -513,10 +522,16 @@ void CMediaPipelineWebOS::SetSpeed(const int speed)
       CLog::LogF(LOGERROR, "Pause failed");
     return;
   }
+
+  RequestAudioDevice(true);
+
   if (speed == DVD_PLAYSPEED_NORMAL)
   {
     if (!m_mediaAPIs->Play())
+    {
       CLog::LogF(LOGERROR, "Play failed");
+      RequestAudioDevice(false);
+    }
   }
 
   CVariant payload;
@@ -725,12 +740,15 @@ bool CMediaPipelineWebOS::Load(CDVDStreamInfo videoHint, CDVDStreamInfo audioHin
   std::string payload;
   CJSONVariantWriter::Write(payloadArgs, payload, true);
 
+  RequestAudioDevice(true);
+
   if (!m_mediaAPIs->notifyForeground())
     CLog::LogF(LOGERROR, "notifyForeground failed");
   CLog::LogFC(LOGDEBUG, LOGVIDEO, "Sending Load payload {}", payload);
   if (!m_mediaAPIs->Load(payload.c_str(), &CMediaPipelineWebOS::PlayerCallback, this))
   {
     CLog::LogF(LOGERROR, "Load failed");
+    RequestAudioDevice(false);
     m_messageQueueParent.Put(std::make_shared<CDVDMsg>(CDVDMsg::PLAYER_ABORT));
     return false;
   }
@@ -1694,12 +1712,12 @@ void CMediaPipelineWebOS::PlayerCallback(int32_t type, const int64_t numValue, c
         m_audioThread.join();
       m_loaded = false;
       m_pipeline = nullptr;
-      UpdateGUISounds(false);
+      RequestAudioDevice(false);
       break;
     case PF_EVENT_TYPE_STR_STATE_UPDATE__PAUSED:
       if (acb)
         AcbAPI_setState(acb->Id(), APPSTATE_FOREGROUND, PLAYSTATE_PAUSED, &acb->TaskId());
-      UpdateGUISounds(false);
+      RequestAudioDevice(false);
       break;
     case PF_EVENT_TYPE_STR_STATE_UPDATE__PLAYING:
     {
@@ -1714,7 +1732,6 @@ void CMediaPipelineWebOS::PlayerCallback(int32_t type, const int64_t numValue, c
           std::make_shared<CDVDMsgType<SStartMsg>>(CDVDMsg::PLAYER_STARTED, msg));
       if (acb)
         AcbAPI_setState(acb->Id(), APPSTATE_FOREGROUND, PLAYSTATE_PLAYING, &acb->TaskId());
-      UpdateGUISounds(true);
       break;
     }
     case PF_EVENT_TYPE_STR_BUFFERFULL:

--- a/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
+++ b/xbmc/cores/VideoPlayer/MediaPipelineWebOS.h
@@ -409,10 +409,10 @@ private:
   void SetupBitstreamConverter(CDVDStreamInfo& hint);
 
   /**
-   * @brief Updates ActiveAE volume setting based on current audio state.
-   * @param playing True if media is currently playing, false otherwise.
+   * @brief Claims the audio device for the pipeline or hands it back to ActiveAE.
+   * @param pipelineOwns True while the pipeline needs exclusive access to the audio device.
    */
-  void UpdateGUISounds(bool playing);
+  void RequestAudioDevice(bool pipelineOwns);
 
   /**
    * @brief Callback for media events.
@@ -514,7 +514,10 @@ private:
   CRenderManager& m_renderManager;
   CDVDClock& m_clock;
   CDVDOverlayContainer& m_overlayContainer;
-  bool m_hasAudio{true};
+  std::atomic<bool> m_hasAudio{true};
+
+  std::mutex m_audioDeviceMutex;
+  bool m_ownsAudioDevice{false};
 
   std::atomic<bool> m_videoClosed{true};
   std::atomic<bool> m_audioClosed{true};


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->
Somewhere during the webOS 26 firmware release cycle, ALSA and the starfish audio output handling has changed. 

ActiveAE generates a lot of errors that it is trying to send samples during playback:
```
error <general>: CAESinkALSA - snd_pcm_writei(-32) Broken pipe - trying to recover
```

This is happening because ALSA and the starfish pipeline are both trying to claim the device resulting in severe audio stutter. The Starfish media pipeline decodes and outputs audio itself, so Kodi must not hold the audio device at the same time. So far this was papered over in UpdateGUISounds() by setting ActiveAE's master volume to 0 while playing, and only when the GUI sound mode was AE_SOUND_IDLE. That does not free the device: the sink keeps writing silence to the very output the pipeline wants, it silently overwrites the user's volume, and it does nothing at all in the other sound modes.

This PR gives ActiveAE a way to hand the device over, and uses it on webOS.                                             

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #29008
Fixes https://forum.kodi.tv/showthread.php?tid=388453
Fixes https://forum.kodi.tv/showthread.php?tid=388276

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
webOS 26

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [x] All new and existing tests passed
