### PR TITLE
[VideoPlayer] Support HDR overlays, including UHD PGS subtitles

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayCodecFFmpeg.cpp
@@ -281,6 +281,9 @@ std::shared_ptr<CDVDOverlay> CDVDOverlayCodecFFmpeg::GetOverlay()
     overlay->width = rect.w;
     overlay->height = rect.h;
     overlay->bForced = (rect.flags & AV_SUBTITLE_FLAG_FORCED);
+    //! @todo for now, set hint for PGS+PQ for UHD Bluray, update for DVB+HLG if needed
+    overlay->m_isHDROverlay = m_pCodecContext->codec_id == AV_CODEC_ID_HDMV_PGS_SUBTITLE &&
+                              m_pCodecContext->color_trc == AVCOL_TRC_SMPTE2084;
     overlay->source_width = m_width;
     overlay->source_height = m_height;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayImage.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Overlay/DVDOverlayImage.h
@@ -44,6 +44,7 @@ public:
     height = sub_h;
     source_width = src.source_width;
     source_height = src.source_height;
+    m_isHDROverlay = src.m_isHDROverlay;
 
     pixels.resize(sub_h * linesize);
 
@@ -75,6 +76,9 @@ public:
 
   std::vector<uint8_t> pixels;
   std::vector<uint32_t> palette;
+
+  // pixels are already HDR, matching video's colorimetry
+  bool m_isHDROverlay{false};
 
   int linesize{0};
   int x{0};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -150,6 +150,10 @@ void CRenderer::Render(int idx, float depth)
 {
   std::unique_lock lock(m_section);
 
+  // during HDR composite the m_isHDROverlay overlays render via
+  // RenderHDROverlays instead
+  const bool hdrComposite = CServiceBroker::GetWinSystem()->IsHdrComposite();
+
   std::vector<SElement>& list = m_buffers[idx];
   for(std::vector<SElement>::iterator it = list.begin(); it != list.end(); ++it)
   {
@@ -157,7 +161,31 @@ void CRenderer::Render(int idx, float depth)
     {
       std::shared_ptr<COverlay> o = Convert(*it);
 
-      if (o)
+      if (o && !(hdrComposite && o->m_isHDROverlay))
+        Render(o.get());
+    }
+  }
+
+  ReleaseUnused();
+}
+
+// drawn onto the back buffer right after the video, bypassing the GUI
+// FBO's sRGB->HDR conversion
+void CRenderer::RenderHDROverlays(int idx)
+{
+  if (!CServiceBroker::GetWinSystem()->IsHdrComposite())
+    return;
+
+  std::unique_lock lock(m_section);
+
+  std::vector<SElement>& list = m_buffers[idx];
+  for (std::vector<SElement>::iterator it = list.begin(); it != list.end(); ++it)
+  {
+    if (it->overlay_dvd)
+    {
+      std::shared_ptr<COverlay> o = Convert(*it);
+
+      if (o && o->m_isHDROverlay)
         Render(o.get());
     }
   }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -89,6 +89,9 @@ namespace OVERLAY {
     float m_source_width{0}; // Video source width resolution used to calculate aspect ratio
     float m_source_height{0}; // Video source height resolution used to calculate aspect ratio
 
+    // pixels are already HDR, matching video's colorimetry
+    bool m_isHDROverlay{false};
+
   protected:
     /*!
      * \brief Given the resolution ratio determines if it is a 4/3 resolution
@@ -109,6 +112,9 @@ namespace OVERLAY {
 
     void AddOverlay(std::shared_ptr<CDVDOverlay> o, double pts, int index);
     virtual void Render(int idx, float depth = 0.0f);
+
+    // render overlays already in HDR (not sRGB)
+    void RenderHDROverlays(int idx);
 
     /*!
      * \brief Pre-walk hook: render libass output for the present slot.

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRendererGLES.cpp
@@ -145,6 +145,8 @@ std::shared_ptr<COverlay> COverlay::Create(const CDVDOverlayImage& o, CRect& rSo
 
 COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlayImage& o, CRect& rSource)
 {
+  m_isHDROverlay = o.m_isHDROverlay;
+
   glGenTextures(1, &m_texture);
   glBindTexture(GL_TEXTURE_2D, m_texture);
 
@@ -164,6 +166,27 @@ COverlayTextureGLES::COverlayTextureGLES(const CDVDOverlayImage& o, CRect& rSour
     std::vector<uint32_t> rgba(o.width * o.height);
     m_pma = !!USE_PREMULTIPLIED_ALPHA;
     convert_rgba(o, m_pma, rgba);
+
+    // the direct back-buffer draw in Render bypasses the composite's
+    // limited-range encode, so apply it to the pixels here
+    //! @todo Move this into the overlay shader once limited-range and
+    //! full-range GUI shader variants are kept compiled in parallel and
+    //! selectable per draw; then this draw selects the limited variant.
+    if (m_isHDROverlay && CServiceBroker::GetWinSystem()->IsHdrComposite() &&
+        CServiceBroker::GetWinSystem()->UseLimitedColor())
+    {
+      for (uint32_t& px : rgba)
+      {
+        const uint32_t a = (px >> PIXEL_ASHIFT) & 0xff;
+        const uint32_t r = (px >> PIXEL_RSHIFT) & 0xff;
+        const uint32_t g = (px >> PIXEL_GSHIFT) & 0xff;
+        const uint32_t b = (px >> PIXEL_BSHIFT) & 0xff;
+        px = (a << PIXEL_ASHIFT) | (((r * 219 + a * 16 + 127) / 255) << PIXEL_RSHIFT) |
+             (((g * 219 + a * 16 + 127) / 255) << PIXEL_GSHIFT) |
+             (((b * 219 + a * 16 + 127) / 255) << PIXEL_BSHIFT);
+      }
+    }
+
     LoadTexture(GL_TEXTURE_2D, o.width, o.height, o.width * 4, &m_u, &m_v, false, rgba.data());
   }
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/RenderManager.cpp
@@ -636,6 +636,14 @@ void CRenderManager::Render(bool clear, DWORD flags, DWORD alpha, bool gui)
   if (presented)
     ServiceVideoCaptures();
 
+  if (presented && !gui)
+  {
+    CRect src, dst, view;
+    m_pRenderer->GetVideoRect(src, dst, view);
+    m_overlays.SetVideoRect(src, dst, view);
+    m_overlays.RenderHDROverlays(m_presentsource);
+  }
+
   if (gui)
   {
     if (!m_pRenderer->IsGuiLayer())


### PR DESCRIPTION
## Description

Depends on #29054, #29056

PGS graphic subtitles are authored in the video's colorimetry (BD-ROM Part 3). During HDR GUI compositing they are drawn into the GUI FBO, which expects only sRGB pixels, and then converted sRGB->HDR as part of Kodi's HDR support.  But since UHD PGS subtitles are _already_ in BT.2020/PQ colorspace, they should not be converted with the rest of sRGB GUI elements: a subtitle authored around 300 nits displays at about 72 nits.

Along with the two prior commits, properly support HDR native overlays. End-to-end requires changes to ffmpeg for BT.2020 and to various Kodi renderers for the PQ part.

Image overlays decoded from PGS on HDR video are marked m_isHDROverlay and render in the video pass instead, straight onto the back buffer after the video is presented, bypassing the GUI FBO. **Applies to GBM with GLES rendering (VAAPI, DRMPRIME, DRMPRIMEGLES)**; everything else is unchanged.

This updates the render loop. The frame sequence with HDR video, HDR PGS, and sRGB UI:

Single-plane:

1. BeginGuiComposite: bind GUI FBO, clear if stale
2. GUI walk: OSD/UI draw into the FBO as sRGB; the HDR PGS is skipped here
3. EndGuiComposite: unbind FBO, clear back buffer
4. RenderEx: video shader writes HDR video to the back buffer; RenderHDROverlays draws the HDR PGS (limited-encoded if configured) on top of it
5. CompositeGui: FBO drawn over the back buffer through the composite shader (sRGB -> linear -> BT.709-to-BT.2020 -> PQ or HLG, limited encode); alpha-0 texels discard, so video and PGS show through; OSD lands over the PGS
6. Flip

Direct-to-plane:

1. BeginGuiComposite: FBO bind/clear only when the GUI renders this frame
2. GUI walk (when dirty): OSD/UI into the FBO as sRGB; HDR PGS skipped
3. EndGuiComposite: clear back buffer to transparent black
4. RenderEx: RenderUpdate puts the video buffer on the video DRM plane (no GL draw); RenderHDROverlays draws the HDR PGS onto the back buffer
5. CompositeGui: FBO sRGB->HDR converted and blended over the back buffer, GUI alpha replacing stored alpha; alpha-0 discard keeps the PGS pixels
6. Flip; scanout hardware blends the GUI plane (premultiplied) over the video plane


## Motivation and context
Correct HDR playback for Linux Direct-to-plane (ARM SoC) and EGL (AMD/Intel)

See also #28603 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
Verified on AMD GBM: single-plane (VAAPI) and direct-to-plane (with local patch to support DRMPRIME) both show the subtitle at its authored brightness; SDR unchanged.  Verified with screenshots and numerical analysis.

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
Users will now see both the proper colors of colored subtitles (grey/white do not shift) and now finally see the correct SMPTE-spec brightness.

<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):
n/a

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
