### PR TITLE
fixed: fail at configure time when wayland protocol descriptions are missing

### DIFF
--- a/cmake/modules/FindWaylandProtocols.cmake
+++ b/cmake/modules/FindWaylandProtocols.cmake
@@ -6,15 +6,44 @@
 #
 # WAYLAND_PROTOCOLS_DIR - directory containing the additional Wayland protocols
 #                         from the wayland-protocols package
+# WAYLAND_PROTOCOLS_XMLS - the protocol descriptions C++ wrappers are generated from
 
 find_package(PkgConfig ${SEARCH_QUIET})
 pkg_check_modules(PC_WAYLAND_PROTOCOLS wayland-protocols ${SEARCH_QUIET})
 if(PC_WAYLAND_PROTOCOLS_FOUND)
   pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)
+
+  # pkgdatadir is defined in terms of ${pc_sysrootdir}, which pkg-config expands to "/" when
+  # no sysroot is set, leaving a doubled leading separator
+  string(REGEX REPLACE "^/+" "/" WAYLAND_PROTOCOLS_DIR "${WAYLAND_PROTOCOLS_DIR}")
+
+  set(WAYLAND_PROTOCOLS_XMLS "${WAYLAND_PROTOCOLS_DIR}/stable/viewporter/viewporter.xml"
+                             "${WAYLAND_PROTOCOLS_DIR}/staging/fractional-scale/fractional-scale-v1.xml"
+                             "${WAYLAND_PROTOCOLS_DIR}/unstable/xdg-shell/xdg-shell-unstable-v6.xml"
+                             "${WAYLAND_PROTOCOLS_DIR}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml")
+
+  if(PC_WAYLAND_PROTOCOLS_VERSION VERSION_GREATER_EQUAL 1.41)
+    list(APPEND WAYLAND_PROTOCOLS_XMLS "${WAYLAND_PROTOCOLS_DIR}/staging/color-management/color-management-v1.xml")
+  endif()
+
+  # pkg-config finding the package is not evidence the descriptions were installed with it
+  foreach(xml IN LISTS WAYLAND_PROTOCOLS_XMLS)
+    if(NOT EXISTS "${xml}")
+      list(APPEND _missing_xmls "${xml}")
+    endif()
+  endforeach()
+
+  if(_missing_xmls)
+    list(JOIN _missing_xmls "\n    " _missing_xmls)
+    set(WAYLAND_PROTOCOLS_REASON "wayland-protocols ${PC_WAYLAND_PROTOCOLS_VERSION} was found via pkg-config, but these protocol descriptions are not installed:\n    ${_missing_xmls}")
+    unset(WAYLAND_PROTOCOLS_XMLS)
+    unset(_missing_xmls)
+  endif()
 endif()
 
 # Promote to cache variables so all code can access it
 set(WAYLAND_PROTOCOLS_DIR ${WAYLAND_PROTOCOLS_DIR} CACHE INTERNAL "")
+set(WAYLAND_PROTOCOLS_XMLS ${WAYLAND_PROTOCOLS_XMLS} CACHE INTERNAL "")
 
 if(NOT VERBOSE_FIND)
    set(${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY TRUE)
@@ -25,5 +54,8 @@ find_package_handle_standard_args(WaylandProtocols
   REQUIRED_VARS
     PC_WAYLAND_PROTOCOLS_FOUND
     WAYLAND_PROTOCOLS_DIR
+    WAYLAND_PROTOCOLS_XMLS
   VERSION_VAR
-    PC_WAYLAND_PROTOCOLS_VERSION)
+    PC_WAYLAND_PROTOCOLS_VERSION
+  REASON_FAILURE_MESSAGE
+    "${WAYLAND_PROTOCOLS_REASON}")

--- a/cmake/modules/FindWaylandpp.cmake
+++ b/cmake/modules/FindWaylandpp.cmake
@@ -56,6 +56,25 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
   # Promote to cache variables so all code can access it
   set(WAYLANDPP_PROTOCOLS_DIR "${PC_WAYLANDPP_PKGDATADIR}/protocols" CACHE INTERNAL "")
 
+  set(WAYLANDPP_PROTOCOLS_XMLS "${WAYLANDPP_PROTOCOLS_DIR}/presentation-time.xml"
+                               "${WAYLANDPP_PROTOCOLS_DIR}/xdg-shell.xml")
+
+  # pkg-config finding the package is not evidence the descriptions were installed with it
+  foreach(xml IN LISTS WAYLANDPP_PROTOCOLS_XMLS)
+    if(NOT EXISTS "${xml}")
+      list(APPEND _missing_xmls "${xml}")
+    endif()
+  endforeach()
+
+  if(_missing_xmls)
+    list(JOIN _missing_xmls "\n    " _missing_xmls)
+    set(WAYLANDPP_REASON "waylandpp was found via pkg-config, but these protocol descriptions are not installed:\n    ${_missing_xmls}")
+    unset(WAYLANDPP_PROTOCOLS_XMLS)
+    unset(_missing_xmls)
+  endif()
+
+  set(WAYLANDPP_PROTOCOLS_XMLS ${WAYLANDPP_PROTOCOLS_XMLS} CACHE INTERNAL "")
+
   if(NOT VERBOSE_FIND)
      set(${CMAKE_FIND_PACKAGE_NAME}_FIND_QUIETLY TRUE)
    endif()
@@ -66,7 +85,9 @@ if(NOT TARGET ${APP_NAME_LC}::${CMAKE_FIND_PACKAGE_NAME})
                                                   WAYLANDPP_CLIENT_LIBRARY
                                                   WAYLANDPP_CURSOR_LIBRARY
                                                   WAYLANDPP_EGL_LIBRARY
-                                    VERSION_VAR WAYLANDPP_wayland-client++_VERSION)
+                                                  WAYLANDPP_PROTOCOLS_XMLS
+                                    VERSION_VAR WAYLANDPP_wayland-client++_VERSION
+                                    REASON_FAILURE_MESSAGE "${WAYLANDPP_REASON}")
 
   if(WAYLANDPP_FOUND)
 

--- a/cmake/scripts/linux/ExtraTargets.cmake
+++ b/cmake/scripts/linux/ExtraTargets.cmake
@@ -16,18 +16,8 @@ if(ENABLE_EVENTCLIENTS AND TARGET ${APP_NAME_LC}::Bluetooth)
 endif()
 
 if("wayland" IN_LIST CORE_PLATFORM_NAME_LC)
-  # This cannot go into wayland.cmake since it requires the Wayland dependencies
-  # to already be resolved
-  set(PROTOCOL_XMLS "${WAYLANDPP_PROTOCOLS_DIR}/presentation-time.xml"
-                    "${WAYLANDPP_PROTOCOLS_DIR}/xdg-shell.xml"
-                    "${WAYLAND_PROTOCOLS_DIR}/stable/viewporter/viewporter.xml"
-                    "${WAYLAND_PROTOCOLS_DIR}/staging/fractional-scale/fractional-scale-v1.xml"
-                    "${WAYLAND_PROTOCOLS_DIR}/unstable/xdg-shell/xdg-shell-unstable-v6.xml"
-                    "${WAYLAND_PROTOCOLS_DIR}/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml")
-
-  if(PC_WAYLAND_PROTOCOLS_VERSION VERSION_GREATER_EQUAL 1.41)
-    list(APPEND PROTOCOL_XMLS "${WAYLAND_PROTOCOLS_DIR}/staging/color-management/color-management-v1.xml")
-  endif()
+  # Both lists are assembled and checked by the find modules that locate their directories
+  set(PROTOCOL_XMLS ${WAYLANDPP_PROTOCOLS_XMLS} ${WAYLAND_PROTOCOLS_XMLS})
 
   add_custom_command(OUTPUT "${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-extra-protocols.hpp" "${WAYLAND_EXTRA_PROTOCOL_GENERATED_DIR}/wayland-extra-protocols.cpp"
                      COMMAND wayland::waylandppscanner


### PR DESCRIPTION
## Description

`FindWaylandProtocols` and `FindWaylandpp` take the `pkgdatadir` pkg-config reports and pass it straight to `ExtraTargets.cmake`, which builds seven protocol description paths from it. Nothing checks that any of those files exist.

pkg-config answering for a package is not evidence that the package's data was installed alongside it. An installation carrying the `.pc` file but not the descriptions configures cleanly, then fails during generation with a message that names a make target rather than an unmet dependency, several minutes into the build.

`FindWaylandProtocolsWebOS` already avoids this — it locates its descriptions with `find_path(NAMES webos-shell.xml ... REQUIRED)`. The two generic modules had no equivalent.

Each module now owns the list of descriptions it is responsible for, checks every one exists, and reports the missing paths via `REQUIRED_VARS` and `REASON_FAILURE_MESSAGE`. `ExtraTargets` consumes the two checked lists instead of assembling the paths itself, which also puts the wayland-protocols 1.41 gate next to the version variable it tests.

The doubled leading separator is collapsed too. On a stock Debian trixie:

```
$ grep pkgdatadir /usr/share/pkgconfig/wayland-protocols.pc
pkgdatadir=${pc_sysrootdir}${datarootdir}/wayland-protocols

$ pkg-config --variable=pkgdatadir wayland-protocols
//usr/share/wayland-protocols
```

pkg-config expands `pc_sysrootdir` to `/` when no sysroot is set, so *every* Linux install reports the doubled separator, not just broken ones. It resolves correctly, so this only changes how the path reads in diagnostics. `wayland-client++.pc` does not use `pc_sysrootdir` and gets no equivalent.

## Motivation and context

Reported in #28864, where a partially-written `/usr/local` install produced this. The reporter's install is their own environment's problem; what the report exposes is that the build system cannot distinguish "wayland-protocols is installed" from "pkg-config knows about wayland-protocols", and defers the difference to an unreadable error much later in the build.

## How has this been tested

Configured in a `debian:trixie` container (cmake 3.31.6, wayland-protocols 1.44, waylandpp 1.0.0) with `-DCORE_PLATFORM_NAME=wayland -DAPP_RENDER_SYSTEM=gl`.

**Healthy install, this branch** — configure completes and the generator target builds:

```
-- Configuring done (13.5s)
-- Generating done (2.5s)
Generating wayland-protocols C++ wrappers
Built target generate-wayland-extra-protocols
```

All seven descriptions reach `build.make` with normalised paths, color-management included since 1.44 ≥ 1.41:

```
/usr/share/wayland-protocols/stable/viewporter/viewporter.xml
/usr/share/wayland-protocols/staging/color-management/color-management-v1.xml
/usr/share/wayland-protocols/staging/fractional-scale/fractional-scale-v1.xml
/usr/share/wayland-protocols/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml
/usr/share/wayland-protocols/unstable/xdg-shell/xdg-shell-unstable-v6.xml
/usr/share/waylandpp/protocols/presentation-time.xml
/usr/share/waylandpp/protocols/xdg-shell.xml
```

**Broken install** — `idle-inhibit-unstable-v1.xml` deleted, everything else untouched.

On current master, configure *succeeds*, and the failure arrives at build time as #28864 describes:

```
-- Configuring done (13.6s)
-- Generating done (2.6s)
-- Build files have been written to: /tmp/kb3

$ make generate-wayland-extra-protocols
make[3]: *** No rule to make target '//usr/share/wayland-protocols/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml', needed by 'wayland-extra-protocols.hpp'.  Stop.
```

On this branch the same tree stops at configure, naming the file:

```
  Could NOT find WaylandProtocols (missing: WAYLAND_PROTOCOLS_XMLS) (found
  suitable version "1.44", minimum required is "1.7")

      Reason given by package: wayland-protocols 1.44 was found via pkg-config, but these
      protocol descriptions are not installed:
      /usr/share/wayland-protocols/unstable/idle-inhibit/idle-inhibit-unstable-v1.xml
```

Not covered: a full Kodi compile (configure and the protocol generation target only), and platforms other than Linux/wayland — though `ExtraTargets.cmake`'s wayland block is guarded by `"wayland" IN_LIST CORE_PLATFORM_NAME_LC`, and both find modules are only reached through `cmake/platform/linux/wayland.cmake`. Everything used is available at the current 3.18 floor (`REASON_FAILURE_MESSAGE` is 3.17, `list(JOIN)` is 3.12).

## Types of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature
- [ ] Breaking change
- [x] Cosmetic (redundant, mostly rearranged code)

## Checklist

- [x] My code follows the Kodi [code guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)
- [ ] I have read the [contributing document](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)
- [x] My change requires a change to the documentation — no
- [x] I have added tests to cover my change — not applicable; verified by configuring against a real install, above
- [x] All new and existing tests passed — not run; this change cannot reach the gtest suite
