### PR TITLE
changed: raise the minimum cmake version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.20)
 if(WIN32)
   cmake_minimum_required(VERSION 3.30.6)
 endif()


### PR DESCRIPTION
**TL;DR:** Improvement, build system. The general `cmake_minimum_required` rises from 3.18 to 3.20 now that Debian 11, the only platform pinned at 3.18, is out of support. Nothing in the tree needs 3.20 yet; ten policies become `NEW` with no warnings in any tested configuration.

## Description
Raises the general `cmake_minimum_required` from 3.18 to 3.20. The `WIN32` floor is already 3.30.6 and is untouched.

Ten policies become `NEW`: CMP0111 through CMP0120. Two were worth checking specifically:

- **CMP0114** (ExternalProject step target dependencies) — does not apply. There is no use of `ExternalProject_Add_Step`, `STEP_TARGETS` or `INDEPENDENT_STEP_TARGETS` anywhere in the tree.
- **CMP0115** (source file extensions must be listed explicitly) — no violations surfaced in any configuration tested below.

## Motivation and context
The 3.18 floor was set in 621dc468c3 for `cmake_language(EVAL)`. It happens to be exactly what Debian 11 "bullseye" ships — 3.18.4 — and bullseye's LTS ended on **31 August 2026**.

Every other distribution Kodi is built on already carries more than the floor asks for:

| distribution | cmake |
|---|---|
| Ubuntu 22.04 | 3.22.1 |
| Debian 12 | 3.25.1 |
| Ubuntu 24.04 | 3.28.3 |
| Debian 13 | 3.31.6 |

So 3.20 costs no currently supported platform anything.

To be straight about it: **nothing in the tree needs 3.20 today.** This is maintenance — dropping a floor pinned to a distribution that is now out of support, and making `cmake_path()`, `file(REAL_PATH)` and the 3.19/3.20 policy set available. If the team would rather keep the floor where it is until something actually requires moving it, that is a reasonable answer and I will close this.

## How has this been tested?
Configured in a `debian:trixie` container (cmake 3.31.6) across three platform/render combinations, with internal builds and `-DENABLE_TESTING=ON` where noted:

| CORE_PLATFORM_NAME | APP_RENDER_SYSTEM | testing | result | policy warnings |
|---|---|---|---|---|
| wayland | gl | OFF | configure + generate OK | 0 |
| x11 | gl | ON | configure + generate OK | 0 |
| gbm | gles | ON | configure + generate OK | 0 |

No `CMP####` warnings, deprecation notices or policy errors in any of them.

**Not covered:** this is configure and generate only, not a full compile, and Linux only. Android, macOS, iOS, tvOS and webOS have not been configured with this change. Windows is unaffected by construction — the `WIN32` branch already requires 3.30.6, so the edited line never applies there.

CI across the remaining platforms is what would establish the rest.

## What is the effect on users?
None. Building Kodi from source now needs cmake 3.20 or newer, which every supported distribution already ships.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [X] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
