### PR TITLE
GUIWindowFullScreen: clear the screen while there is no renderer to clear it

### DIFF
--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -184,7 +184,8 @@ void CGUIWindowFullScreen::ClearBackground()
   const auto appPlayer = components.GetComponent<CApplicationPlayer>();
   if (appPlayer->IsRenderingVideoLayer())
     CServiceBroker::GetWinSystem()->GetGfxContext().Clear(0);
-  else if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiGeometryClear)
+  else if (!CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_guiGeometryClear ||
+           !appPlayer->IsRenderingVideo())
     CServiceBroker::GetWinSystem()->GetGfxContext().Clear(0xff000000);
   else
     CServiceBroker::GetWinSystem()->GetGfxContext().Clear();


### PR DESCRIPTION
## Motivation and context
See the attached videos. A video that is slow to start up ends up cycling unwritten GUI buffers causing a stuttering effect.

## Description

Starting a file that takes a few seconds to open leaves the screen flickering until the picture appears. On a 4K HEVC file, which takes around five seconds to reach its first frame, the item that was clicked flips between its focused and unfocused size, the busy spinner sits at a handful of angles instead of turning, and a notification slides part-way in over and over. It reads as animations being repeatedly reset.

Nothing is being animated. What is on screen is the last few frames of the window that was there when playback was asked for, cycling.

The window switches to fullscreen video about a third of a second after the request, long before the first picture. From then on ClearBackground() takes its third branch, which asks the graphics context to Clear() with no colour. That does not clear: InvalidateColorBuffer() clears the colour buffer only where the clear function is FIXED_FUNCTION, and it is GEOMETRY whenever the geometryclear advanced setting is true, which is the default. On that path only the depth buffer is touched. The name describes how the clear is meant to happen - not by a fixed function clear, but by drawing geometry over the buffer - and the geometry meant to do it is the renderer's, which Render() asks for a few lines further down:

    // FIXME: remove clearing pass from renderer, it should be its own, dedicated function.
    bool clear = ...m_guiGeometryClear;
    appPlayer->Render(clear, 255);

That pass covers the whole viewport, letterbox bars included, so the window is right not to clear as well - once the pass happens. CRenderManager::Render() returns at its first statement while m_renderState is not STATE_CONFIGURED, so for as long as the file is opening there is no pass, and no clear either: the window declined to clear on the promise of one that is never made.

Every frame of that wait is therefore presented without anything having been drawn into it, and what reaches the display is whatever the buffer last held. Several buffers are in rotation - four on this hardware - so each holds a different frame from just before the switch, with any animation that was running caught at a different point, and the display cycles through them at the refresh rate. Hence a spinner that appears to flicker rather than spin, and a slide that appears to restart.

So clear the colour buffer while the renderer is not configured. IsRenderingVideo() is CRenderManager::IsConfigured(), which is exactly the condition under which the clearing pass runs, so this covers the gap and nothing else: once the renderer is up, the geometry path is taken as before and the pass does the clearing. The direct-to-plane branch above is untouched - it clears to transparent so the video plane below shows through - and a viewer whose geometryclear is already false was never affected.

Only a slow open makes it visible. A file that reaches its first frame immediately leaves nothing on screen long enough to see, which is why this survived so long.

Not stereoscopic and not specific to this branch: it reproduces on an unmodified upstream build, with the stereoscopic playback mode set to ignore, and with refresh rate switching off. The GUI renders at a steady 60Hz throughout the wait, so it is not a stall; it reproduces with algorithmdirtyregions set to 0, so it is not the dirty region solver; and forcing the fixed function path with geometryclear false replaces the flicker with black, which is what identified the branch above.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
On a Pi4, after this PR the stuttering GUI is replaced with black screen 
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
No stuttery GUI when starting a slow video
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

Video of stutter with a 3d video (more obvious what is happening due to stereoscopic notification)
https://github.com/user-attachments/assets/0dc7031b-a7b1-4c34-89f1-822425cf08b1

It also happens with 2d video
https://github.com/user-attachments/assets/6eee6c6f-77fe-4da8-b290-925cded1c432


## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
