### PR TITLE
strings.po: restore the msgstr that lets the catalogue compile

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -25386,6 +25386,7 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#40803"
 msgid "Monitor change may require restart."
+msgstr ""
 
 # Value formatting for ReplayGain Preamp settings
 #: system/settings/settings.xml


### PR DESCRIPTION
## Motivation and context
```
$ msgfmt --check addons/resource.language.en_gb/resources/strings.po
addons/resource.language.en_gb/resources/strings.po:25388: missing 'msgstr' section
msgfmt: found 1 fatal error
```

## Description

Entry #40803 "Monitor change may require restart." carries a msgid and no msgstr. An entry without one is not a soft omission, it is a parse error: gettext ends a message at the msgstr and treats its absence as fatal, so msgfmt rejects the whole file at that line and every other entry in it goes uncompiled. The catalogue cannot be validated, and the id after the gap is where any check stops rather than where the trouble ends.

It came from d5c22ed6f9 "Use PreAmp setting centered at 0, allow fractional dB". #40803 was the last entry in the file, so appending #40804 put the new block between #40803's msgid and the msgstr on the line below it, and the patch context reused that msgstr for #40804 instead. Nothing about the hunk looks wrong in review - the added lines are all well formed, and the entry it breaks is the one it does not touch.

The empty msgstr added here is what every other entry already carries - en_gb is the source language, so an empty translation is the normal state and nothing about the displayed string changes.

msgfmt --check now passes on the file, so the catalogue is available to tooling again.

<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
```
$ msgfmt --check addons/resource.language.en_gb/resources/strings.po
addons/resource.language.en_gb/resources/strings.po:3: warning: header field 'PO-Revision-Date' still has the initial default value
```

<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
