### PR TITLE
changed: dispatch settings-loaded callbacks under the lock

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -31,6 +31,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <atomic>
 #include <climits>
 #include <regex>
 #include <string>
@@ -95,14 +96,25 @@ void CAdvancedSettings::OnSettingsLoaded()
   }
   CServiceBroker::GetLogging().SetLogLevel(m_logLevel);
 
-  std::vector<AdvancedSettingsCallback> callbacks;
+  // A callback must not run after its registrant unregistered and was destroyed.
+  std::lock_guard lock{m_listCritSection};
+
+  std::vector<int> handles;
+  handles.reserve(m_settingsLoadedCallbacks.size());
+  std::ranges::transform(m_settingsLoadedCallbacks, std::back_inserter(handles),
+                         [](const auto& pair) { return pair.first; });
+
+  for (const int handle : handles)
   {
-    std::lock_guard lock{m_listCritSection};
-    callbacks.reserve(m_settingsLoadedCallbacks.size());
-    std::ranges::transform(m_settingsLoadedCallbacks, std::back_inserter(callbacks),
-                           [](const auto& pair) { return pair.second; });
+    // A callback can unregister a later one, which must not then be called.
+    const auto it = m_settingsLoadedCallbacks.find(handle);
+    if (it == m_settingsLoadedCallbacks.end())
+      continue;
+
+    // A callback can unregister itself, which would destroy the entry it is running from.
+    const AdvancedSettingsCallback callback{it->second};
+    callback();
   }
-  std::ranges::for_each(callbacks, &AdvancedSettingsCallback::operator());
 }
 
 void CAdvancedSettings::OnSettingsUnloaded()
@@ -122,12 +134,13 @@ void CAdvancedSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& 
 
 int CAdvancedSettings::RegisterSettingsLoadedCallback(AdvancedSettingsCallback callback)
 {
+  // A handle handed out by one instance must never erase an entry in another.
+  static std::atomic<int> nextHandle{0};
+  const int handle{nextHandle++};
+
   std::lock_guard lock{m_listCritSection};
-  // The handle is read back from the inserted element, so it cannot drift from the key the
-  // callback is stored under and Unregister can never erase a different caller's callback.
-  const auto it =
-      m_settingsLoadedCallbacks.emplace(m_nextCallbackHandle++, std::move(callback)).first;
-  return it->first;
+  m_settingsLoadedCallbacks.emplace(handle, std::move(callback));
+  return handle;
 }
 
 void CAdvancedSettings::UnregisterSettingsLoadedCallback(int handle)

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -431,7 +431,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::vector<std::string> m_folderStackStrings;
 
     mutable CCriticalSection m_listCritSection;
-    int m_nextCallbackHandle{0};
     std::map<int, AdvancedSettingsCallback> m_settingsLoadedCallbacks;
     std::string m_metadataSourcesPriv;
 };

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -36,47 +36,59 @@ constexpr std::array ADDON_TYPES{AddonType::VFS, AddonType::IMAGEDECODER, AddonT
 
 void CFileExtensionProvider::Initialize(ADDON::CAddonMgr& addonManager)
 {
-  m_addonManager = &addonManager;
+  {
+    std::lock_guard lock{m_critSection};
 
-  m_advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
-  if (!m_advancedSettings)
-    m_advancedSettings = std::make_shared<CAdvancedSettings>();
+    m_addonManager = &addonManager;
 
-  SetAddonExtensions();
+    m_advancedSettings = CServiceBroker::GetSettingsComponent()->GetAdvancedSettings();
+    if (!m_advancedSettings)
+      m_advancedSettings = std::make_shared<CAdvancedSettings>();
 
-  m_addonManager->Events().Subscribe(this,
-                                     [this](const AddonEvent& event)
-                                     {
-                                       if (typeid(event) == typeid(AddonEvents::Enabled) ||
-                                           typeid(event) == typeid(AddonEvents::Disabled) ||
-                                           typeid(event) == typeid(AddonEvents::ReInstalled))
-                                       {
-                                         for (auto& type : ADDON_TYPES)
-                                         {
-                                           if (m_addonManager->HasType(event.addonId, type))
-                                           {
-                                             std::lock_guard lock{m_critSection};
-                                             SetAddonExtensions(type);
-                                             break;
-                                           }
-                                         }
-                                       }
-                                       else if (typeid(event) == typeid(AddonEvents::UnInstalled))
-                                       {
-                                         std::lock_guard lock{m_critSection};
-                                         SetAddonExtensions();
-                                       }
-                                     });
+    SetAddonExtensions();
+  }
+
+  // A settings-loaded callback is dispatched under the advanced settings' own lock, so
+  // subscribing under m_critSection would invert the two.
+  addonManager.Events().Subscribe(this,
+                                  [this](const AddonEvent& event)
+                                  {
+                                    if (typeid(event) == typeid(AddonEvents::Enabled) ||
+                                        typeid(event) == typeid(AddonEvents::Disabled) ||
+                                        typeid(event) == typeid(AddonEvents::ReInstalled))
+                                    {
+                                      for (auto& type : ADDON_TYPES)
+                                      {
+                                        if (m_addonManager->HasType(event.addonId, type))
+                                        {
+                                          std::lock_guard lock{m_critSection};
+                                          SetAddonExtensions(type);
+                                          break;
+                                        }
+                                      }
+                                    }
+                                    else if (typeid(event) == typeid(AddonEvents::UnInstalled))
+                                    {
+                                      std::lock_guard lock{m_critSection};
+                                      SetAddonExtensions();
+                                    }
+                                  });
 
   m_callbackId =
       m_advancedSettings->RegisterSettingsLoadedCallback([this]() { OnAdvancedSettingsLoaded(); });
 
+  std::lock_guard lock{m_critSection};
+
   m_initialized = true;
+}
+
+CFileExtensionProvider::~CFileExtensionProvider()
+{
+  Deinitialize();
 }
 
 void CFileExtensionProvider::Deinitialize()
 {
-  // Both callbacks take m_critSection, so they are detached before it is held here.
   if (m_callbackId.has_value())
   {
     m_advancedSettings->UnregisterSettingsLoadedCallback(m_callbackId.value());
@@ -89,9 +101,6 @@ void CFileExtensionProvider::Deinitialize()
     m_addonManager = nullptr;
   }
 
-  // A getter that has already passed the unlocked initialized check builds its list under this
-  // lock and checks again once it holds it, so nothing below is dropped while a list is being
-  // built from it.
   std::lock_guard lock{m_critSection};
 
   m_initialized = false;
@@ -101,8 +110,7 @@ void CFileExtensionProvider::Deinitialize()
 
   ReleaseSettingsDerivedLists();
 
-  // Not built from the advanced settings, so a settings reload leaves it alone. Deinitialization
-  // is dropping everything, so it goes too.
+  // Built from the add-ons rather than the settings, so a settings reload must not drop it.
   std::atomic_store(&m_fileFolderExtensions, {});
 }
 
@@ -142,8 +150,7 @@ std::string GetExtensions(const std::atomic<bool>& initialized,
   {
     std::lock_guard lock{mutex};
 
-    // Deinitialize drops the settings the list is built from under this lock, so the check is
-    // repeated once it is held: passing it unlocked above proves nothing by now.
+    // Deinitialize drops the settings the list is built from.
     if (!initialized)
       return NotInitialized();
 
@@ -462,7 +469,7 @@ bool CFileExtensionProvider::EncodedHostName(const std::string& protocol) const
 
 void CFileExtensionProvider::OnAdvancedSettingsLoaded()
 {
-  // m_fileFolderExtensions is deliberately not released here: it is built from the add-ons
-  // alone, so a settings reload cannot have changed it.
+  std::lock_guard lock{m_critSection};
+
   ReleaseSettingsDerivedLists();
 }

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -30,7 +30,10 @@ class CFileExtensionProvider
 {
 public:
   CFileExtensionProvider() = default;
-  ~CFileExtensionProvider() = default;
+
+  // Unregisters the callbacks that capture this, for a provider destroyed without an explicit
+  // Deinitialize().
+  ~CFileExtensionProvider();
 
   void Initialize(ADDON::CAddonMgr& addonManager);
   void Deinitialize();
@@ -110,17 +113,12 @@ private:
 
   void OnAdvancedSettingsLoaded();
 
-  /*! \brief Release the cached lists built from the advanced settings.
-
-   Deinitialize releases the add-on derived list as well; a settings reload must not, because
-   the add-ons have not changed.
-   */
+  // Call under m_critSection.
   void ReleaseSettingsDerivedLists();
 
   // Construction properties
-  // Written by Initialize and Deinitialize, read by every getter, and those are not the same
-  // thread. Atomic for the getters' unlocked first check; Deinitialize clears it and the state
-  // below under m_critSection, which is what orders it against a list being built.
+  // Atomic for the getters' unlocked first check; written under m_critSection, which is what
+  // orders it against a list being built.
   std::atomic<bool> m_initialized{false};
   std::shared_ptr<CAdvancedSettings> m_advancedSettings;
   ADDON::CAddonMgr* m_addonManager{nullptr};

--- a/xbmc/utils/test/TestFileExtensionProvider.cpp
+++ b/xbmc/utils/test/TestFileExtensionProvider.cpp
@@ -14,30 +14,30 @@
 
 #include <gtest/gtest.h>
 
-// The provider outlives its own deinitialization: it stays reachable through the service broker
-// until the process ends, and one-argument URIUtils::GetExtension consults the compound archive
-// extensions for any path containing a dot. Deinitialization drops the advanced settings that
-// the lazily built lists read, so a list not yet built was built against nothing.
-//
-// A local instance is used rather than the one the service broker holds, so deinitializing it
-// cannot disturb another test in this binary.
+// The provider stays reachable through the service broker after its own deinitialization, and a
+// one-argument URIUtils::GetExtension reaches it for any path containing a dot. Deinitializing
+// the provider the service broker holds would disturb every other test in this binary.
 TEST(TestFileExtensionProvider, GettersAnswerEmptyAfterDeinitializationRatherThanFaulting)
 {
   CFileExtensionProvider provider;
   provider.Initialize(CServiceBroker::GetAddonMgr());
 
-  // Build one list and leave another cold, so both states are covered after deinitialization.
+  // A cold list would be built from settings that are gone; a warm one must not be handed back.
   const std::string warmed = provider.GetVideoExtensions();
-  ASSERT_FALSE(warmed.empty()) << "the video extensions were not built while initialized, so the "
-                                  "warm case below would prove nothing";
+  ASSERT_FALSE(warmed.empty()) << "the video extensions were not built while initialized";
 
   provider.Deinitialize();
 
-  // The cold list is the case that faulted: nothing is cached, so it would be built, and the
-  // settings it reads are gone.
   EXPECT_TRUE(provider.GetCompoundArchiveExtensions().empty());
-
-  // Deinitialize releases the warm list too, so it answers the same way rather than handing back
-  // a list built against settings that no longer exist.
   EXPECT_TRUE(provider.GetVideoExtensions().empty());
+}
+
+// Guards the test above: an empty answer there must be deinitialization, not an unbuildable list.
+TEST(TestFileExtensionProvider, GettersAnswerTheBuiltListWhileInitialized)
+{
+  CFileExtensionProvider provider;
+  provider.Initialize(CServiceBroker::GetAddonMgr());
+
+  EXPECT_FALSE(provider.GetCompoundArchiveExtensions().empty());
+  EXPECT_FALSE(provider.GetVideoExtensions().empty());
 }


### PR DESCRIPTION
**TL;DR:** Follow-up to #28936, carrying the review points raised on it before and after it merged. It does **not** fix #28972 — #28936 did. `CAdvancedSettings::OnSettingsLoaded()` now dispatches under `m_listCritSection` and re-checks each registration before calling it, `CFileExtensionProvider` gains a destructor and the locking `Deinitialize()` already had, and the commentary the merged change added is cut back.

## Description
Follow-up to #28936. It carries the two review points that arrived shortly before that merge, the three Codex raised afterwards, and trims the commentary the merged change added.

**What this does not do.** It does not fix #28972. #28936 did: `~CRenderSystemBase` erases its own entry (`RenderSystem.cpp:46-52`), so the wayland render system destroyed at `Application.cpp:439` is out of the map before the x11 fallback registers. As @reardonia has since established, every register, unregister and dispatch of these callbacks runs on the main thread, so the lifetime window closed below is not reachable today. It hardens the contract; it is not a crash fix.

**The dispatch.** `CAdvancedSettings::OnSettingsLoaded()` copied the registered callbacks out under `m_listCritSection` and then invoked them with the lock released, so unregistration was not synchronous with invocation. The lock is now held across the dispatch.

Holding it is not enough on its own, because `CCriticalSection` is recursive: a callback can unregister a later one on the dispatching thread, and a copied list would still call it. So the dispatch copies the handles rather than the callbacks, and looks each one up again immediately before calling it. The callable is copied out of the map before it runs, which is what lets a callback unregister itself without destroying the entry it is running from.

Nothing takes `m_listCritSection` while holding a lock a callback takes, so the wider scope cannot invert an order. `CFileExtensionProvider` attaches and detaches both of its callbacks with `m_critSection` released, and `CRenderSystemBase` registers only after its constructor has released `m_settingsSection`.

**Review points from #28936.**

- **@CrystalP on `RegisterSettingsLoadedCallback`** — back to a function-local counter with the increment in the right place, and `m_nextCallbackHandle` is out of the class header. It is currently a `static std::atomic<int>`. @CrystalP's follow-up here, asking for a plain `static int` under the existing lock, is open and not yet taken.
- **@CrystalP on the test** — taken. `TestFileExtensionProvider` gains the initialized case, so an empty answer in the deinitialized one is deinitialization rather than a list that could not be built. It also covers the destructor below, having no `Deinitialize()` call of its own.

**`CFileExtensionProvider`.** It gains the locking `Deinitialize()` already had. `Initialize()` writes the advanced settings, the add-on manager and `m_initialized` under `m_critSection`, and `OnAdvancedSettingsLoaded()` releases the cached lists under it, so a list being built cannot be stored after the reload that cleared its slot. The order of `Initialize()` is unchanged — `m_initialized` was already published after both callbacks were attached. The destructor deinitializes, so a provider destroyed without an explicit `Deinitialize()` cannot leave a callback holding a freed `this`.

@CrystalP has raised that the `Initialize()` locking creates a problem of its own, and @reardonia that the destructor should be a `Deinitialize()` call in the test instead. Both are open.

**Comments.** The commentary the merged change added is cut back. Each comment left states a requirement or a hazard that the line it sits on does not show; the rest named what the code did, or repeated a reason already given where it belonged.

## Motivation and context
#28936 fixed the callback handle that let one registrant erase another's entry, which is what closed #28972. Two review comments arrived just before it merged and three more afterwards; this carries them.

## How has this been tested?
Full suite green on Windows: 4042 tests across 313 suites, clean teardown. `clang-format` clean on the touched lines of all five files.

## What is the effect on users?
None. The window closed here is not reachable on the current threading, and the crash behind #28972 was already fixed by #28936.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [X] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
