### PR TITLE
fixed: play to a renderer that does not event its ConnectionManager

### DIFF
--- a/xbmc/network/upnp/UPnP.cpp
+++ b/xbmc/network/upnp/UPnP.cpp
@@ -477,6 +477,25 @@ public:
                                                                                   userdata);
   }
 
+  /*!
+   * The sink list a resource is chosen against is populated only by ConnectionManager eventing,
+   * and an event naming its properties anything else leaves it empty. Ask the renderer outright.
+   */
+  void OnGetProtocolInfoResult(NPT_Result res,
+                               PLT_DeviceDataReference& device,
+                               PLT_StringList* sources,
+                               PLT_StringList* sinks,
+                               void* userdata) override
+  {
+    if (NPT_FAILED(res))
+      return;
+
+    if (sinks)
+      StoreProtocolInfo(device, "SinkProtocolInfo", *sinks);
+    if (sources)
+      StoreProtocolInfo(device, "SourceProtocolInfo", *sources);
+  }
+
   bool OnMRAdded(PLT_DeviceDataReference& device) override
   {
     if (device->GetUUID().IsEmpty() || device->GetUUID().GetChars() == NULL)
@@ -488,6 +507,8 @@ public:
                                          (const char*)device->GetFriendlyName());
 
     m_registeredRenderers.insert(std::string(device->GetUUID().GetChars()));
+
+    GetProtocolInfo(device, nullptr);
     return true;
   }
 
@@ -502,6 +523,28 @@ public:
   }
 
 private:
+  /*! rief Write a protocolInfo list where the state variable eventing would have put it. */
+  static void StoreProtocolInfo(PLT_DeviceDataReference& device,
+                                const char* variable,
+                                const PLT_StringList& values)
+  {
+    PLT_Service* service = nullptr;
+    if (NPT_FAILED(
+            device->FindServiceByType("urn:schemas-upnp-org:service:ConnectionManager:*", service)))
+      return;
+
+    NPT_String joined;
+    for (NPT_List<NPT_String>::Iterator value = values.GetFirstItem(); value; ++value)
+    {
+      if (!joined.IsEmpty())
+        joined += ",";
+      joined += *value;
+    }
+
+    if (!joined.IsEmpty())
+      service->SetStateVariable(variable, joined);
+  }
+
   void unregisterRenderer(const std::string& deviceUUID)
   {
     CPlayerCoreFactory& playerCoreFactory = CServiceBroker::GetPlayerCoreFactory();

--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2018 Team Kodi
+ *  Copyright (C) 2012-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -42,6 +42,8 @@
 #include <memory>
 #include <optional>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include <Platinum/Source/Platinum/Platinum.h>
 
@@ -271,6 +273,128 @@ const NPT_String GetProtocolInfo(const CFileItem& item,
   NPT_String mime = GetMimeType(item, context);
   proto += ":*:" + mime + ":" + PLT_ProtocolInfo::GetDlnaExtension(mime, context);
   return proto;
+}
+
+/*----------------------------------------------------------------------
+|   AddAlternateMimeResources
++---------------------------------------------------------------------*/
+void AddAlternateMimeResources(PLT_MediaObject& object)
+{
+  // Content types that are in common use under more than one name. A renderer selects a
+  // resource by matching its protocolInfo against the sink list it advertises, so a resource
+  // offered under one spelling is invisible to a renderer that names the other.
+  static constexpr std::pair<const char*, const char*> alternates[] = {
+      {"audio/x-flac", "audio/flac"},
+      {"audio/x-ms-wma", "audio/wma"},
+  };
+
+  // The loop appends to the list it reads, so the original count is taken first.
+  const NPT_Cardinal count = object.m_Resources.GetItemCount();
+
+  for (const auto& [name, alternate] : alternates)
+  {
+    for (NPT_Cardinal i = 0; i < count; i++)
+    {
+      const NPT_String contentType = object.m_Resources[i].m_ProtocolInfo.GetContentType();
+
+      NPT_String from;
+      NPT_String to;
+      if (contentType.Compare(name, true) == 0)
+      {
+        from = name;
+        to = alternate;
+      }
+      else if (contentType.Compare(alternate, true) == 0)
+      {
+        from = alternate;
+        to = name;
+      }
+      else
+      {
+        continue;
+      }
+
+      // Per resource, not per object: each carries its own uri, and only the one on the
+      // renderer's network is any use to it.
+      bool present = false;
+      for (NPT_Cardinal j = 0; j < object.m_Resources.GetItemCount(); j++)
+      {
+        if (object.m_Resources[j].m_Uri == object.m_Resources[i].m_Uri &&
+            object.m_Resources[j].m_ProtocolInfo.GetContentType().Compare(to, true) == 0)
+        {
+          present = true;
+          break;
+        }
+      }
+      if (present)
+        continue;
+
+      PLT_MediaItemResource resource = object.m_Resources[i];
+      NPT_String protocolInfo = resource.m_ProtocolInfo.ToString();
+      protocolInfo.Replace(":" + from + ":", ":" + to + ":");
+      resource.m_ProtocolInfo = PLT_ProtocolInfo(protocolInfo);
+      object.m_Resources.Add(resource);
+    }
+  }
+}
+
+/*----------------------------------------------------------------------
+|   PreferResourceAddresses
++---------------------------------------------------------------------*/
+void PreferResourceAddresses(PLT_MediaObject& object, const std::vector<NPT_UInt32>& preferred)
+{
+  if (preferred.empty())
+    return;
+
+  NPT_Array<PLT_MediaItemResource> front;
+  NPT_Array<PLT_MediaItemResource> back;
+
+  for (NPT_Cardinal i = 0; i < object.m_Resources.GetItemCount(); i++)
+  {
+    const PLT_MediaItemResource& resource = object.m_Resources[i];
+    NPT_IpAddress host;
+    const bool wanted =
+        NPT_SUCCEEDED(host.Parse(NPT_HttpUrl(resource.m_Uri).GetHost())) &&
+        std::find(preferred.begin(), preferred.end(), host.AsLong()) != preferred.end();
+    if (wanted)
+      front.Add(resource);
+    else
+      back.Add(resource);
+  }
+
+  if (front.GetItemCount() == 0)
+    return;
+
+  for (NPT_Cardinal i = 0; i < back.GetItemCount(); i++)
+    front.Add(back[i]);
+
+  object.m_Resources = front;
+}
+
+/*----------------------------------------------------------------------
+|   SortResourcesForRenderer
++---------------------------------------------------------------------*/
+void SortResourcesForRenderer(PLT_MediaObject& object, const NPT_IpAddress& renderer)
+{
+  NPT_List<NPT_NetworkInterface*> interfaces;
+  if (NPT_FAILED(NPT_NetworkInterface::GetNetworkInterfaces(interfaces)))
+    return;
+
+  std::vector<NPT_UInt32> reachable;
+  for (NPT_List<NPT_NetworkInterface*>::Iterator it = interfaces.GetFirstItem(); it; ++it)
+  {
+    const NPT_List<NPT_NetworkInterfaceAddress>& addresses = (*it)->GetAddresses();
+    for (NPT_List<NPT_NetworkInterfaceAddress>::Iterator addr = addresses.GetFirstItem(); addr;
+         ++addr)
+    {
+      NPT_NetworkInterfaceAddress candidate = *addr;
+      if (candidate.IsAddressInNetwork(renderer))
+        reachable.push_back(candidate.GetPrimaryAddress().AsLong());
+    }
+  }
+  interfaces.Apply(NPT_ObjectDeleter<NPT_NetworkInterface>());
+
+  PreferResourceAddresses(object, reachable);
 }
 
 /*----------------------------------------------------------------------
@@ -938,6 +1062,10 @@ PLT_MediaObject* BuildObject(CFileItem& item,
       upnp_server->AddSubtitleUriForSecResponse(movie_md5, subtitle_uri);
     }
   }
+
+  // Every producer of a DIDL benefits: a control point browsing Kodi, a queued track, and the
+  // item handed to a renderer all reach a device that may name a content type the other way.
+  AddAlternateMimeResources(*object);
 
   return object;
 

--- a/xbmc/network/upnp/UPnPInternal.h
+++ b/xbmc/network/upnp/UPnPInternal.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2012-2018 Team Kodi
+ *  Copyright (C) 2012-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -10,7 +10,9 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
+#include <Neptune/Source/Core/NptNetwork.h>
 #include <Neptune/Source/Core/NptReferences.h>
 #include <Neptune/Source/Core/NptStrings.h>
 #include <Neptune/Source/Core/NptTypes.h>
@@ -78,6 +80,18 @@ namespace UPNP
   NPT_String  GetMimeType(const char* filename, const PLT_HttpRequestContext* context = NULL);
   const NPT_String GetProtocolInfo(const CFileItem& item, const char* protocol, const PLT_HttpRequestContext* context = NULL);
 
+  /*! \brief Offer each resource under every spelling its content type is known by.
+      Renderers match a resource against the protocolInfo they advertise, so a resource carrying
+      only one of two names in common use cannot be selected by a renderer naming the other. */
+  void AddAlternateMimeResources(PLT_MediaObject& object);
+
+  /*! rief Move the resources reachable from `preferred` to the front, order preserved. */
+  void PreferResourceAddresses(PLT_MediaObject& object, const std::vector<NPT_UInt32>& preferred);
+
+  /*! rief Order an object's resources so a renderer is offered an address it can route to.
+      One resource is built per local address, in host enumeration order, and a renderer can only
+      fetch from one on its own network. */
+  void SortResourcesForRenderer(PLT_MediaObject& object, const NPT_IpAddress& renderer);
 
   const std::string& CorrectAllItemsSortHack(const std::string &item);
 

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -300,6 +300,24 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
         failed_stop);
     NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_resevent, timeout), failed_stop);
     NPT_CHECK_LABEL_SEVERE(m_delegate->m_resstatus, failed_stop);
+
+    // Stopping is acknowledged before the renderer has stopped, and until it has it keeps
+    // reporting the file being replaced as playing. Waiting for the transport to reach STOPPED
+    // is what makes the states seen from here on belong to the file about to be opened. Polled
+    // directly rather than through WaitOnEvent, which has no bound and shows a busy dialog.
+    XbmcThreads::EndTime<> stopping(3s);
+    while (!stopping.IsTimePast())
+    {
+      if (NPT_FAILED(m_control->GetTransportInfo(m_delegate->m_device, m_delegate->m_instance,
+                                                 m_delegate.get())))
+        break;
+      if (!m_delegate->m_traevnt.Wait(500ms))
+        continue;
+
+      const NPT_String stoppedState = m_delegate->GetTransportState();
+      if (stoppedState == "STOPPED" || stoppedState == "NO_MEDIA_PRESENT")
+        break;
+    }
   }
 
   timeout.Set(timeout.GetInitialTimeoutValue());
@@ -321,9 +339,13 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
   timeout.Set(timeout.GetInitialTimeoutValue());
   do
   {
+    // The reply must be awaited before the state is read, or the first pass evaluates the state
+    // left by the query at the top of this function - the renderer still playing what is being
+    // replaced - and stops waiting before the new file has started.
     NPT_CHECK_LABEL_SEVERE(
         m_control->GetTransportInfo(m_delegate->m_device, m_delegate->m_instance, m_delegate.get()),
         failed_waitplaying);
+    NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_traevnt, timeout), failed_waitplaying);
 
     const NPT_String transportStatus = m_delegate->GetTransportStatus();
     const NPT_String transportState = m_delegate->GetTransportState();
@@ -336,8 +358,6 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
       m_logger->error("OpenFile({}): remote player signalled error", file.GetPath());
       return NPT_FAILURE;
     }
-
-    NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_traevnt, timeout), failed_waitplaying);
 
   } while (!timeout.IsTimePast());
 
@@ -384,6 +404,8 @@ bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
 {
   XbmcThreads::EndTime<> timeout(10s);
 
+  m_playback.Opening();
+
   /* if no path we want to attach to a already playing player */
   if (file.GetPath().empty())
   {
@@ -407,7 +429,7 @@ bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
     Create();
 
   m_stopremote = true;
-  m_started = true;
+  m_playback.Started();
 
   if (VIDEO::IsVideo(file))
   {
@@ -482,11 +504,9 @@ bool CUPnPPlayer::CloseFile(bool reopen)
     NPT_CHECK_LABEL(m_delegate->m_resstatus, failed);
   }
 
-  if (m_started)
-  {
-    m_started = false;
+  if (m_playback.Finish())
     m_callback.OnPlayBackStopped();
-  }
+
   StopThread(true);
   CServiceBroker::GetDataCacheCore().Reset();
   return true;
@@ -559,7 +579,7 @@ void CUPnPPlayer::Process()
     NPT_CHECK_POINTER_LABEL_SEVERE(m_delegate, failed);
     m_delegate->UpdatePositionInfo();
 
-    if (m_started)
+    if (m_playback.IsStarted())
     {
       // Update player times
       CDataCacheCore& dataCacheCore = CDataCacheCore::GetInstance();
@@ -581,10 +601,10 @@ void CUPnPPlayer::Process()
         dataCacheCore.SetSpeed(1.0, 1.0);
       }
 
-      if (m_delegate->GetTransportState() == "STOPPED")
+      if (m_playback.HasEnded(m_delegate->GetTransportState().GetChars()))
       {
         m_logger->info("Transport state flagged as STOPPED. Triggering OnPlayBackEnded.");
-        m_started = false;
+        m_playback.Finish();
         m_callback.OnPlayBackEnded();
       }
     }
@@ -677,7 +697,7 @@ failed:
 
 void CUPnPPlayer::OnExit()
 {
-  if (m_started)
+  if (m_playback.IsStarted())
   {
     m_callback.OnPlayBackEnded();
   }

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -99,15 +99,6 @@ public:
     return m_trainfo.cur_transport_status;
   }
 
-  void OnGetMediaInfoResult(NPT_Result res,
-                            PLT_DeviceDataReference& device,
-                            PLT_MediaInfo* info,
-                            void* userdata) override
-  {
-    if (NPT_FAILED(res) || info == NULL)
-      m_logger->error("OnGetMediaInfoResult failed");
-  }
-
   void OnGetTransportInfoResult(NPT_Result res,
                                 PLT_DeviceDataReference& device,
                                 PLT_TransportInfo* info,
@@ -146,7 +137,7 @@ public:
 
     if (NPT_FAILED(res) || info == NULL)
     {
-      m_logger->error("OnGetMediaInfoResult failed");
+      m_logger->error("OnGetPositionInfoResult failed");
       m_posinfo = PLT_PositionInfo();
     }
     else
@@ -444,9 +435,6 @@ bool CUPnPPlayer::OpenFile(const CFileItem& file, const CPlayerOptions& options)
   m_callback.OnAVStarted(file);
   NPT_CHECK_LABEL_SEVERE(
       m_control->GetPositionInfo(m_delegate->m_device, m_delegate->m_instance, m_delegate.get()),
-      failed);
-  NPT_CHECK_LABEL_SEVERE(
-      m_control->GetMediaInfo(m_delegate->m_device, m_delegate->m_instance, m_delegate.get()),
       failed);
 
   m_updateTimer.Set(0ms);

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2006 elupus (Joakim Plate)
- *  Copyright (C) 2006-2018 Team Kodi
+ *  Copyright (C) 2006-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -235,6 +235,14 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
   if (obj.IsNull())
     goto failed;
 
+  // Before the DIDL is written, so the renderer is told about every address as well as being
+  // handed one of them. Scoped so it does not cross a goto.
+  {
+    NPT_IpAddress rendererAddress;
+    if (NPT_SUCCEEDED(rendererAddress.Parse(m_delegate->m_device->GetURLBase().GetHost())))
+      SortResourcesForRenderer(*obj, rendererAddress);
+  }
+
   NPT_CHECK_LABEL_SEVERE(PLT_Didl::ToDidl(*obj, "", tmp), failed_todidl);
   tmp.Insert(didl_header, 0);
   tmp.Append(didl_footer);
@@ -257,8 +265,23 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
   /* The resource uri's are stored in the Didl. We must choose the best resource
    * for the playback device */
   NPT_Cardinal res_index;
-  NPT_CHECK_LABEL_SEVERE(m_control->FindBestResource(m_delegate->m_device, *obj, res_index),
-                         failed_findbestresource);
+  if (NPT_FAILED(m_control->FindBestResource(m_delegate->m_device, *obj, res_index)))
+  {
+    /* An empty sink list means the renderer never told us what it accepts, which is not the same
+     * as it accepting nothing. Offer the first resource and let the device answer for itself. */
+    NPT_List<NPT_String> sinks;
+    const bool advertised =
+        NPT_SUCCEEDED(m_control->GetProtocolInfoSink(m_delegate->m_device->GetUUID(), sinks)) &&
+        sinks.GetItemCount() > 0 && !(*sinks.GetFirstItem()).IsEmpty();
+
+    if (advertised || obj->m_Resources.GetItemCount() == 0)
+      goto failed_findbestresource;
+
+    res_index = 0;
+    m_logger->warn("PlayFile({}): {} advertises no protocolInfo, offering '{}' unmatched",
+                   file.GetPath(), m_delegate->m_device->GetFriendlyName().GetChars(),
+                   obj->m_Resources[res_index].m_ProtocolInfo.ToString().GetChars());
+  }
 
   // get the transport info to evaluate the TransportState to be able to
   // determine whether we first need to call Stop()

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -1,6 +1,6 @@
 /*
  *  Copyright (c) 2006 elupus (Joakim Plate)
- *  Copyright (C) 2006-2018 Team Kodi
+ *  Copyright (C) 2006-2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -16,6 +16,8 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
+#include <utility>
 
 class PLT_MediaController;
 
@@ -23,6 +25,34 @@ namespace UPNP
 {
 
 class CUPnPPlayerController;
+
+//! \brief Tracks whether a transport state reported by a renderer ends the file Kodi asked it for.
+//!
+//! Starting a file on a renderer that is already playing stops it first, so a state of STOPPED is
+//! the end of playback only once it is known to belong to the file being watched.
+class CPlaybackState
+{
+public:
+  //! \brief An open is in flight, so the renderer still reports states belonging to the last file.
+  void Opening() { m_started = false; }
+
+  //! \brief The renderer is playing the file that was opened.
+  void Started() { m_started = true; }
+
+  //! \brief Stops watching, returning whether playback was being watched.
+  bool Finish() { return std::exchange(m_started, false); }
+
+  bool IsStarted() const { return m_started; }
+
+  //! \brief Whether \a transportState ends the file being watched.
+  bool HasEnded(std::string_view transportState) const
+  {
+    return m_started && transportState == "STOPPED";
+  }
+
+private:
+  bool m_started{false};
+};
 
 class CUPnPPlayer : public IPlayer, public CThread
 {
@@ -68,7 +98,7 @@ private:
   std::unique_ptr<CUPnPPlayerController> m_delegate;
   std::string m_current_uri;
   std::string m_current_meta;
-  bool m_started = false;
+  CPlaybackState m_playback;
   bool m_stopremote = false;
   bool m_hasVideo{false};
   bool m_hasAudio{false};

--- a/xbmc/network/upnp/UPnPPlayer.h
+++ b/xbmc/network/upnp/UPnPPlayer.h
@@ -96,8 +96,6 @@ private:
 
   PLT_MediaController* m_control = nullptr;
   std::unique_ptr<CUPnPPlayerController> m_delegate;
-  std::string m_current_uri;
-  std::string m_current_meta;
   CPlaybackState m_playback;
   bool m_stopremote = false;
   bool m_hasVideo{false};

--- a/xbmc/network/upnp/test/CMakeLists.txt
+++ b/xbmc/network/upnp/test/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(SOURCES TestUPnPInternal.cpp)
+set(SOURCES TestUPnPInternal.cpp
+            TestUPnPPlayer.cpp)
 
 core_add_test_library(network_upnp_test)
 if(ENABLE_STATIC_LIBS)

--- a/xbmc/network/upnp/test/TestUPnPInternal.cpp
+++ b/xbmc/network/upnp/test/TestUPnPInternal.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2018 Team Kodi
+ *  Copyright (C) 2026 Team Kodi
  *  This file is part of Kodi - https://kodi.tv
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
@@ -168,4 +168,171 @@ TEST(TestUPnPInternal, BuildObjectDatesFromDidlAreOrdered)
   ASSERT_TRUE(olderItem->GetDateTime().IsValid());
   ASSERT_TRUE(newerItem->GetDateTime().IsValid());
   EXPECT_LT(olderItem->GetDateTime(), newerItem->GetDateTime());
+}
+
+namespace
+{
+
+PLT_MediaItem MakeObjectWithResource(const char* protocolInfo)
+{
+  PLT_MediaItem object;
+  PLT_MediaItemResource resource;
+  resource.m_Uri = "http://192.0.2.1:8080/song";
+  resource.m_ProtocolInfo = PLT_ProtocolInfo(protocolInfo);
+  object.m_Resources.Add(resource);
+  return object;
+}
+
+void AddResource(PLT_MediaObject& object, const char* uri, const char* protocolInfo)
+{
+  PLT_MediaItemResource resource;
+  resource.m_Uri = uri;
+  resource.m_ProtocolInfo = PLT_ProtocolInfo(protocolInfo);
+  object.m_Resources.Add(resource);
+}
+
+NPT_UInt32 AddressOf(const char* literal)
+{
+  NPT_IpAddress address;
+  address.Parse(literal);
+  return address.AsLong();
+}
+
+bool HasContentType(const PLT_MediaObject& object, const char* contentType)
+{
+  for (NPT_Cardinal i = 0; i < object.m_Resources.GetItemCount(); i++)
+  {
+    if (object.m_Resources[i].m_ProtocolInfo.GetContentType().Compare(contentType, true) == 0)
+      return true;
+  }
+  return false;
+}
+
+} // namespace
+
+//! \brief A renderer naming only the registered type can select a FLAC Kodi offers.
+TEST(TestUPnPInternal, AddAlternateMimeResourcesOffersRegisteredFlacSpelling)
+{
+  PLT_MediaItem object = MakeObjectWithResource("http-get:*:audio/x-flac:*");
+
+  AddAlternateMimeResources(object);
+
+  EXPECT_EQ(2u, object.m_Resources.GetItemCount());
+  EXPECT_TRUE(HasContentType(object, "audio/x-flac"));
+  EXPECT_TRUE(HasContentType(object, "audio/flac"));
+}
+
+//! \brief The mapping runs both ways, so a server offering only the registered type also matches.
+TEST(TestUPnPInternal, AddAlternateMimeResourcesOffersLegacyFlacSpelling)
+{
+  PLT_MediaItem object = MakeObjectWithResource("http-get:*:audio/flac:*");
+
+  AddAlternateMimeResources(object);
+
+  EXPECT_EQ(2u, object.m_Resources.GetItemCount());
+  EXPECT_TRUE(HasContentType(object, "audio/flac"));
+  EXPECT_TRUE(HasContentType(object, "audio/x-flac"));
+}
+
+//! \brief The added resource is the same stream, so only the content type differs.
+TEST(TestUPnPInternal, AddAlternateMimeResourcesKeepsUriAndProtocol)
+{
+  PLT_MediaItem object = MakeObjectWithResource("http-get:*:audio/x-flac:DLNA.ORG_PN=FLAC");
+
+  AddAlternateMimeResources(object);
+
+  ASSERT_EQ(2u, object.m_Resources.GetItemCount());
+  EXPECT_STREQ("http://192.0.2.1:8080/song", object.m_Resources[1].m_Uri.GetChars());
+  EXPECT_STREQ("http-get", object.m_Resources[1].m_ProtocolInfo.GetProtocol().GetChars());
+  EXPECT_STREQ("audio/flac", object.m_Resources[1].m_ProtocolInfo.GetContentType().GetChars());
+}
+
+//! \brief An object already carrying both spellings is left alone rather than duplicated.
+TEST(TestUPnPInternal, AddAlternateMimeResourcesDoesNotDuplicate)
+{
+  PLT_MediaItem object = MakeObjectWithResource("http-get:*:audio/x-flac:*");
+  PLT_MediaItemResource other;
+  other.m_Uri = "http://192.0.2.1:8080/song";
+  other.m_ProtocolInfo = PLT_ProtocolInfo("http-get:*:audio/flac:*");
+  object.m_Resources.Add(other);
+
+  AddAlternateMimeResources(object);
+
+  EXPECT_EQ(2u, object.m_Resources.GetItemCount());
+}
+
+//! \brief A content type with no alternate spelling is untouched.
+TEST(TestUPnPInternal, AddAlternateMimeResourcesLeavesUnrelatedTypes)
+{
+  PLT_MediaItem object = MakeObjectWithResource("http-get:*:audio/mpeg:*");
+
+  AddAlternateMimeResources(object);
+
+  EXPECT_EQ(1u, object.m_Resources.GetItemCount());
+  EXPECT_TRUE(HasContentType(object, "audio/mpeg"));
+}
+
+/*!
+ * One resource is built per local address, in host enumeration order, so the first is routinely a
+ * virtual adapter the renderer cannot reach.
+ */
+TEST(TestUPnPInternal, PreferResourceAddressesPutsAReachableAddressFirst)
+{
+  PLT_MediaItem object;
+  AddResource(object, "http://10.20.100.8:1298/song", "http-get:*:audio/x-flac:*");
+  AddResource(object, "http://192.0.2.1:1298/song", "http-get:*:audio/x-flac:*");
+  AddResource(object, "http://169.254.96.137:1298/song", "http-get:*:audio/x-flac:*");
+
+  PreferResourceAddresses(object, {AddressOf("192.0.2.1")});
+
+  ASSERT_EQ(3u, object.m_Resources.GetItemCount());
+  EXPECT_STREQ("http://192.0.2.1:1298/song", object.m_Resources[0].m_Uri.GetChars());
+}
+
+//! rief The rest keep their order behind it, so nothing is lost or reshuffled.
+TEST(TestUPnPInternal, PreferResourceAddressesKeepsTheRestInOrder)
+{
+  PLT_MediaItem object;
+  AddResource(object, "http://10.20.100.8:1298/song", "http-get:*:audio/x-flac:*");
+  AddResource(object, "http://192.0.2.1:1298/song", "http-get:*:audio/x-flac:*");
+  AddResource(object, "http://169.254.96.137:1298/song", "http-get:*:audio/x-flac:*");
+
+  PreferResourceAddresses(object, {AddressOf("192.0.2.1")});
+
+  EXPECT_STREQ("http://10.20.100.8:1298/song", object.m_Resources[1].m_Uri.GetChars());
+  EXPECT_STREQ("http://169.254.96.137:1298/song", object.m_Resources[2].m_Uri.GetChars());
+}
+
+//! rief With nothing known to be reachable the order is left alone rather than guessed at.
+TEST(TestUPnPInternal, PreferResourceAddressesLeavesTheOrderAloneWhenNoneMatch)
+{
+  PLT_MediaItem object;
+  AddResource(object, "http://10.20.100.8:1298/song", "http-get:*:audio/x-flac:*");
+  AddResource(object, "http://192.0.2.1:1298/song", "http-get:*:audio/x-flac:*");
+
+  PreferResourceAddresses(object, {AddressOf("203.0.113.9")});
+
+  EXPECT_STREQ("http://10.20.100.8:1298/song", object.m_Resources[0].m_Uri.GetChars());
+}
+
+/*!
+ * The alternate carries the uri of the resource it was cloned from, so each address needs its own
+ * or the only spelling the renderer understands may name an address it cannot reach.
+ */
+TEST(TestUPnPInternal, AddAlternateMimeResourcesOffersEveryAddress)
+{
+  PLT_MediaItem object;
+  AddResource(object, "http://192.0.2.1:1298/song", "http-get:*:audio/x-flac:*");
+  AddResource(object, "http://192.0.2.2:1298/song", "http-get:*:audio/x-flac:*");
+
+  AddAlternateMimeResources(object);
+
+  ASSERT_EQ(4u, object.m_Resources.GetItemCount());
+  int alternates = 0;
+  for (NPT_Cardinal i = 0; i < object.m_Resources.GetItemCount(); i++)
+  {
+    if (object.m_Resources[i].m_ProtocolInfo.GetContentType().Compare("audio/flac", true) == 0)
+      alternates++;
+  }
+  EXPECT_EQ(2, alternates);
 }

--- a/xbmc/network/upnp/test/TestUPnPPlayer.cpp
+++ b/xbmc/network/upnp/test/TestUPnPPlayer.cpp
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "network/upnp/UPnPPlayer.h"
+
+#include <gtest/gtest.h>
+
+using namespace UPNP;
+
+TEST(TestUPnPPlaybackState, NothingIsWatchedBeforeAFileStarts)
+{
+  CPlaybackState state;
+
+  EXPECT_FALSE(state.IsStarted());
+  EXPECT_FALSE(state.HasEnded("STOPPED"));
+  EXPECT_FALSE(state.Finish());
+}
+
+TEST(TestUPnPPlaybackState, AStoppedRendererEndsTheFileItWasPlaying)
+{
+  CPlaybackState state;
+
+  state.Opening();
+  state.Started();
+
+  EXPECT_FALSE(state.HasEnded("PLAYING"));
+  EXPECT_FALSE(state.HasEnded("TRANSITIONING"));
+  EXPECT_TRUE(state.HasEnded("STOPPED"));
+}
+
+TEST(TestUPnPPlaybackState, PlaybackEndsOnlyOnce)
+{
+  CPlaybackState state;
+
+  state.Opening();
+  state.Started();
+
+  ASSERT_TRUE(state.HasEnded("STOPPED"));
+  EXPECT_TRUE(state.Finish());
+
+  EXPECT_FALSE(state.HasEnded("STOPPED"));
+  EXPECT_FALSE(state.Finish());
+}
+
+//! \brief Opening a file stops a renderer that is already playing, and that STOPPED belongs to the
+//!        file being replaced. Reading it as the end of playback advances the playlist, so the
+//!        renderer is handed a file the user did not pick.
+TEST(TestUPnPPlaybackState, TheStopThatStartsTheNextFileDoesNotEndPlayback)
+{
+  CPlaybackState state;
+
+  state.Opening();
+  state.Started();
+  ASSERT_FALSE(state.HasEnded("PLAYING"));
+
+  // the user picks another file while that one is playing
+  state.Opening();
+
+  EXPECT_FALSE(state.HasEnded("STOPPED"));
+
+  state.Started();
+
+  EXPECT_FALSE(state.HasEnded("PLAYING"));
+  EXPECT_TRUE(state.HasEnded("STOPPED"));
+}
+
+//! \brief An open that never reaches PLAYING leaves the previous file unwatched rather than
+//!        ending it a second time.
+TEST(TestUPnPPlaybackState, AnOpenThatFailsLeavesNothingWatched)
+{
+  CPlaybackState state;
+
+  state.Opening();
+  state.Started();
+  ASSERT_TRUE(state.IsStarted());
+
+  state.Opening();
+
+  EXPECT_FALSE(state.IsStarted());
+  EXPECT_FALSE(state.HasEnded("STOPPED"));
+  EXPECT_FALSE(state.Finish());
+}


### PR DESCRIPTION
**TL;DR:** Bug fix. Playing to a Linkplay-based renderer such as a WiiM always failed because the device events its ConnectionManager variables under the wrong name, so Kodi never learned what it accepts. Kodi now asks the device directly, treats an unknown sink list as unknown rather than as a refusal, and offers a resource on an address the renderer can reach.

## Description
Reproduced and fixed against a WiiM Amp. Three defects, all of which had to go.

### 1. The sink list was never obtained

`FindBestResource` matches each resource against the device's sink list, which `GetProtocolInfoSink` reads from the ConnectionManager's **`SinkProtocolInfo` state variable** (`PltMediaController.cpp:191`). That variable is populated only by GENA eventing.

Linkplay firmware names every evented property `LastChange` — the AVTransport/RenderingControl convention — instead of `SinkProtocolInfo`, `SourceProtocolInfo` and `CurrentConnectionIDs`. I subscribed to the device's ConnectionManager directly and captured the NOTIFY:

```xml
<e:propertyset xmlns:e="urn:schemas-upnp-org:event-1-0">
  <e:property><LastChange>http-get:*:audio/wav:DLNA.ORG_PN=LPCM,...,http-get:*:audio/flac:*,...</LastChange></e:property>
  <e:property><LastChange></LastChange></e:property>
  <e:property><LastChange>0</LastChange></e:property>
</e:propertyset>
```

The values are correct and in that order — the first is exactly the 21-entry list the `GetProtocolInfo` **action** returns as `Sink`, the second matches its empty `Source`. Only the names are wrong. `PltCtrlPoint.cpp:806` then does:

```cpp
var = service->FindStateVariable(property->GetTag());
if (var == NULL) continue;
```

ConnectionManager has no `LastChange`, so all three are **skipped in silence** — nothing stored, nothing logged. The sink list stays empty and no resource can ever match, whatever is offered.

Measured across four devices: two WiiM Amps and two WiiM Pro Receivers, all identical. Kodi→Kodi is unaffected, because Kodi's own renderer events the correct names.

**Fix:** the same service answers the `GetProtocolInfo` action correctly, so `CMediaController::OnMRAdded` now invokes it, and `OnGetProtocolInfoResult` writes the answer into the state variables — where eventing would have put it, so nothing downstream needs to know the device was quirky. No `lib/libUPnP` change: `PLT_Service::SetStateVariable` is public and calls the same `PLT_StateVariable::SetValue` the event path uses.

### 2. An empty list was read as a refusal

Not knowing what a renderer accepts is not the same as knowing it accepts nothing, but `PlayFile` treated both as fatal. It now falls back to offering a resource and letting the device answer, logging a warning that names the device and what was sent unmatched. That is a safety net for the next renderer with odd eventing, not the fix for this one.

### 3. The resource offered was on an unroutable address

One resource is built per local address. `BuildObject` moves the interface a request arrived on to the front, but `PlayFile` is initiating rather than responding and passes no request context, so they stayed in host enumeration order:

```
res[0] http://10.20.100.8:1298/...      remote-access adapter
res[1] http://192.168.0.53:1298/...     the only address the renderer can reach
res[2] http://169.254.96.137:1298/...   link-local
```

`FindBestResource` returns the first match, so the device would have been handed `10.20.100.8`. Six of the ten local addresses on this machine are link-local. Resources sharing a network with the renderer now come first, via the SDK's `NPT_NetworkInterfaceAddress::IsAddressInNetwork` so a routed subnet is not mistaken for an unreachable one — the LAN here is a `/22`, and a naive same-`/24` test would have rejected the only working address. With none reachable the order is left alone rather than guessed at.

The content-type alternates from the previous version are kept, with two changes. They are added **per resource** rather than once per object, since each carries its own uri — otherwise the only spelling the renderer understands would name whichever address happened to be enumerated first. And they are applied at the end of `BuildObject` rather than in `PlayFile`, so every producer of a DIDL gets them: a control point browsing Kodi, a queued track, and the item handed to a renderer alike. Both of those were called by the Codex review on the previous revision.

## Motivation and context
Fixes #29130.

**This replaces the earlier version of this PR, which was wrong.** It offered both spellings of the FLAC content type and claimed that fixed the issue. @makemeunsee built it, reported that the MIME type was now correct and playback still failed, and later that `mp3` fails identically — which rules the content type out on its own, since these devices advertise `audio/mpeg`. Thanks for both.

## How has this been tested?
End to end against a WiiM Amp, playing a FLAC from the library, confirmed audible and by querying the device rather than Kodi:

```
TransportState : PLAYING
TransportStatus: OK
CurrentURI     : http://192.168.0.53:1298/...01.%2520Daddy%2520Cool.flac
RelTime        : 00:01:29 / 00:03:28
```

No fallback warning was logged, so `FindBestResource` genuinely matched rather than the safety net firing, and the uri fetched is the LAN address.

Unit tests cover the resource ordering (reachable first, order preserved behind it, left alone when nothing matches) and the per-resource alternates. Full suite green: 4050 tests, 313 suites.

@makemeunsee — worth confirming your device reports the same three `LastChange` properties. I will post the script I used to capture that.

## What is the effect on users?
"Play using" a WiiM or other Linkplay-based renderer works. Renderers whose accepted formats Kodi cannot learn are offered the file rather than refused, and the file is served from an address on the renderer's own network.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
