### PR TITLE
[Doxygen] Fix \param names that do not match the argument

### DIFF
--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -90,7 +90,7 @@ public:
   int GetNextItemIdx(int offset) const;
 
   /*! \brief Set the active playlist
-   \param id Id of playlist
+   \param playlistId Id of playlist
    \sa GetCurrentPlaylist
    */
   void SetCurrentPlaylist(Id playlistId);
@@ -102,7 +102,7 @@ public:
   Id GetCurrentPlaylist() const;
 
   /*! \brief Get a particular playlist object
-   \param id Id of playlist
+   \param playlistId Id of playlist
    \return A reference to the CPlayList object.
    \sa GetCurrentPlaylist
    */
@@ -125,7 +125,7 @@ public:
   /*! \brief Set shuffle state of a playlist.
    If the shuffle state changes, the playlist is shuffled or unshuffled.
    Has no effect if Party Mode is enabled.
-   \param playlist the playlist to (un)shuffle, PLAYLIST::TYPE_MUSIC or PLAYLIST::TYPE_VIDEO.
+   \param playlistId the playlist to (un)shuffle, PLAYLIST::TYPE_MUSIC or PLAYLIST::TYPE_VIDEO.
    \param shuffle set true to shuffle, false to unshuffle.
    \param notify notify the user with a Toast notification (defaults to false)
    \sa IsShuffled
@@ -134,7 +134,7 @@ public:
 
   /*! \brief Return whether a playlist is shuffled.
    If partymode is enabled, this always returns false.
-   \param playlist the playlist to query for shuffle state, PLAYLIST::TYPE_MUSIC or PLAYLIST::TYPE_VIDEO.
+   \param playlistId the playlist to query for shuffle state, PLAYLIST::TYPE_MUSIC or PLAYLIST::TYPE_VIDEO.
    \return true if the given playlist is shuffled and party mode isn't enabled, false otherwise.
    \sa SetShuffle
    */
@@ -147,7 +147,7 @@ public:
 
   /*! \brief Set repeat state of a playlist.
    If called while in Party Mode, repeat is disabled.
-   \param playlist the playlist to set repeat state for, PLAYLIST::TYPE_MUSIC or PLAYLIST::TYPE_VIDEO.
+   \param playlistId the playlist to set repeat state for, PLAYLIST::TYPE_MUSIC or PLAYLIST::TYPE_VIDEO.
    \param state set to RepeatState::NONE, RepeatState::ONE or RepeatState::ALL
    \param notify notify the user with a Toast notification
    \sa GetRepeat
@@ -171,13 +171,13 @@ public:
 
 protected:
   /*! \brief Returns true if the given is set to repeat all
-   \param playlist Playlist to be query
+   \param playlistId Playlist to be query
    \return true if the given playlist is set to repeat all, false otherwise.
    */
   bool Repeated(Id playlistId) const;
 
   /*! \brief Returns true if the given is set to repeat one
-   \param playlist Playlist to be query
+   \param playlistId Playlist to be query
    \return true if the given playlist is set to repeat one, false otherwise.
    */
   bool RepeatedOne(Id playlistId) const;

--- a/xbmc/TextureCache.h
+++ b/xbmc/TextureCache.h
@@ -147,7 +147,7 @@ public:
   void ClearCachedImage(const std::string &image, bool deleteSource = false);
 
   /*! \brief clear the cached version of the image with given id
-   \param database id of the image
+   \param textureID id of the image
    \sa GetCachedImage
    */
   bool ClearCachedImage(int textureID);
@@ -206,7 +206,7 @@ private:
 
   /*! \brief Get an image from the database
    Thread-safe wrapper of CTextureDatabase::GetCachedTexture
-   \param image url of the original image
+   \param url url of the original image
    \param details [out] texture details from the database (if available)
    \return true if we have a cached version of this image, false otherwise.
    */
@@ -214,7 +214,7 @@ private:
 
   /*! \brief Clear an image from the database
    Thread-safe wrapper of CTextureDatabase::ClearCachedTexture
-   \param image url of the original image
+   \param url url of the original image
    \param cacheFile [out] url of the cached original (if available)
    \return true if we had a cached version of this image, false otherwise.
    */
@@ -229,7 +229,7 @@ private:
 
   /*! \brief Set a previously cached texture as valid in the database
    Thread-safe wrapper of CTextureDatabase::SetCachedTextureValid
-   \param image url of the original image
+   \param url url of the original image
    \param updateable whether this image should be checked for updates
    \return true if successful, false otherwise.
    */


### PR DESCRIPTION
Reading `PlayListPlayer.h` and the `\param` names there are still the ones from before the argument became `playlistId`, seven of them across `SetCurrentPlaylist`, `GetPlaylist`, `SetShuffle`, `IsShuffled`, `SetRepeat` and the two `Repeated` helpers. `TextureCache.h` has the same thing in four places where the argument is `url` or `textureID` while the comment still says `image` or `database`. Doxygen drops a name it cannot match without a warning, so those arguments render with no description at all. I left the neighbouring blocks in `TextureCache.h` alone, `AddCachedTexture` and `Export` really do take an argument called `image`.
