### PR TITLE
UDMABufferObject: don't close a file that was never opened

### DIFF
--- a/xbmc/utils/UDMABufferObject.cpp
+++ b/xbmc/utils/UDMABufferObject.cpp
@@ -62,12 +62,15 @@ CUDMABufferObject::~CUDMABufferObject()
   ReleaseMemory();
   DestroyBufferObject();
 
-  int ret = close(m_udmafd);
-  if (ret < 0)
-    CLog::Log(LOGERROR, "CUDMABufferObject::{} - close /dev/udmabuf failed, errno={}", __FUNCTION__,
-              strerror(errno));
+  if (m_udmafd >= 0)
+  {
+    int ret = close(m_udmafd);
+    if (ret < 0)
+      CLog::Log(LOGERROR, "CUDMABufferObject::{} - close /dev/udmabuf failed, errno={}",
+                __FUNCTION__, strerror(errno));
 
-  m_udmafd = -1;
+    m_udmafd = -1;
+  }
 }
 
 bool CUDMABufferObject::CreateBufferObject(uint32_t format, uint32_t width, uint32_t height)


### PR DESCRIPTION
## Description

`/dev/udmabuf` is opened lazily, in `CreateBufferObject()`, but `~CUDMABufferObject()` closes the descriptor unconditionally. An object that never created a buffer still holds the initialiser's `-1`, so `close()` fails with `EBADF` and an error is logged for a file that was never open:

```
CUDMABufferObject::~CUDMABufferObject - close /dev/udmabuf failed, errno=Bad file descriptor
```

Close it only when it was opened.

## Motivation and context

`CBufferObjectFactory::CreateBufferObject()` reaches this on any system where udmabuf is present. Asked for a buffer that can be created by size, it constructs each registered implementation in turn to ask whether it can serve one, and discards those that cannot — and every discard logs the error. It is harmless beyond the noise, but it appears whenever a game or a video opens a DMA-backed buffer, which makes a normal load look like a failure.

## How has this been tested?

Noticed in a RetroPlayer log on a GBM/Wayland GLES build where `/dev/dma_heap` is not accessible to the user, so the factory falls through to udmabuf. The error appears once per discarded probe at game open, and is gone with this change. The file compiles clean.

## What is the effect on users?

One spurious error line stops appearing in the log. No behaviour change: a descriptor that was opened is still closed, and a genuine `close()` failure is still reported.

## Types of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Cosmetic

## Checklist

- [x] My code follows the Code Guidelines of this project
- [x] My change requires no change to the documentation
- [x] I have read the Contributing document
