### PR TITLE
fixed: hide the file extension of a name that carries a percent escape

### DIFF
--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -339,7 +339,10 @@ std::string CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false *
   // use above to get the filename
   std::string path(url.Get());
   URIUtils::RemoveSlashAtEnd(path);
-  std::string strFilename = URIUtils::GetFileName(path);
+  // Only a URL can carry percent escapes.
+  std::string strFilename = URIUtils::IsURL(path)
+                                ? URIUtils::DecodePathEscapes(URIUtils::GetFileName(path))
+                                : URIUtils::GetFileName(path);
 
 #ifdef HAS_UPNP
   // UPNP
@@ -397,17 +400,16 @@ std::string CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false *
     strFilename = CServiceBroker::GetResourcesComponent().GetLocalizeStrings().Get(136);
 
   else if (URIUtils::HasParentInHostname(url) && strFilename.empty())
-    strFilename = URIUtils::GetFileName(url.GetHostName());
+    strFilename = URIUtils::DecodePathEscapes(URIUtils::GetFileName(url.GetHostName()));
 
   // now remove the extension if needed
-  if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_SHOWEXTENSIONS) && !bIsFolder)
+  if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_FILELISTS_SHOWEXTENSIONS) &&
+      !bIsFolder)
   {
     URIUtils::RemoveExtension(strFilename);
-    return strFilename;
   }
 
-  // URLDecode since the original path may be an URL
-  strFilename = CURL::Decode(strFilename);
   return strFilename;
 }
 

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -72,7 +72,7 @@ void CDAVDirectory::ParseResponse(const tinyxml2::XMLElement* element, CFileItem
               else if (CDAVCommon::ValueWithoutNamespace(propChild, "displayname") &&
                        !propChild->NoChildren())
               {
-                item.SetLabel(CURL::Decode(propChild->FirstChild()->Value()));
+                item.SetLabel(URIUtils::DecodePathEscapes(propChild->FirstChild()->Value()));
               }
               else if (!item.GetDateTime().IsValid() &&
                        CDAVCommon::ValueWithoutNamespace(propChild, "creationdate") &&
@@ -153,7 +153,7 @@ bool CDAVDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       {
         std::string name(itemPath);
         URIUtils::RemoveSlashAtEnd(name);
-        item.SetLabel(CURL::Decode(URIUtils::GetFileName(name)));
+        item.SetLabel(URIUtils::DecodePathEscapes(URIUtils::GetFileName(name)));
       }
 
       if (item.IsFolder())

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -10,6 +10,7 @@
 #include "Util.h"
 #include "cores/VideoPlayer/Interface/StreamInfo.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -928,3 +929,75 @@ TEST_P(TestExternalStreamDetails, GetExternalStreamDetailsFromFilename)
 INSTANTIATE_TEST_SUITE_P(GetExternalStreamDetailsFromFilename,
                          TestExternalStreamDetails,
                          ValuesIn(ExternalStreams));
+
+class TestTitleFromPath : public Test
+{
+protected:
+  void SetUp() override
+  {
+    const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+    m_showExtensions = settings->GetBool(CSettings::SETTING_FILELISTS_SHOWEXTENSIONS);
+    settings->SetBool(CSettings::SETTING_FILELISTS_SHOWEXTENSIONS, false);
+  }
+
+  void TearDown() override
+  {
+    CServiceBroker::GetSettingsComponent()->GetSettings()->SetBool(
+        CSettings::SETTING_FILELISTS_SHOWEXTENSIONS, m_showExtensions);
+  }
+
+private:
+  bool m_showExtensions{true};
+};
+
+TEST_F(TestTitleFromPath, DecodesAnEscapedNameWhileHidingTheExtension)
+{
+  EXPECT_EQ("file name", CUtil::GetTitleFromPath("davs://server/files/file%20name.mkv"));
+}
+
+TEST_F(TestTitleFromPath, LeavesAnUnescapedNameAlone)
+{
+  EXPECT_EQ("file_name", CUtil::GetTitleFromPath("davs://server/files/file_name.mkv"));
+  EXPECT_EQ("C++ Media", CUtil::GetTitleFromPath("/path/to/C++ Media.mkv"));
+  EXPECT_EQ("100% proof", CUtil::GetTitleFromPath("/path/to/100% proof.mkv"));
+}
+
+TEST_F(TestTitleFromPath, KeepsAPlusInTheName)
+{
+  EXPECT_EQ("C++ Collection", CUtil::GetTitleFromPath("smb://server/share/C++ Collection.mkv"));
+  EXPECT_EQ("C++ Collection", CUtil::GetTitleFromPath("davs://server/files/C++ Collection.mkv"));
+}
+
+TEST_F(TestTitleFromPath, DecodesAnEscapedPercent)
+{
+  EXPECT_EQ("100% proof", CUtil::GetTitleFromPath("davs://server/files/100%25%20proof.mkv"));
+
+  // a name that itself contains the characters "%20"
+  EXPECT_EQ("100%20proof", CUtil::GetTitleFromPath("davs://server/files/100%2520proof.mkv"));
+
+  // the name is taken off the path before the decode, so an escaped separator stays in the leaf
+  EXPECT_EQ("file/name", CUtil::GetTitleFromPath("davs://server/files/file%2Fname.mkv"));
+}
+
+TEST_F(TestTitleFromPath, LeavesAMalformedEscapeAlone)
+{
+  EXPECT_EQ("file%2", CUtil::GetTitleFromPath("davs://server/files/file%2.mkv"));
+  EXPECT_EQ("file%zz", CUtil::GetTitleFromPath("davs://server/files/file%zz.mkv"));
+  EXPECT_EQ("file%", CUtil::GetTitleFromPath("davs://server/files/file%.mkv"));
+  EXPECT_EQ("100% off", CUtil::GetTitleFromPath("davs://server/files/100% off.mkv"));
+}
+
+TEST_F(TestTitleFromPath, LeavesANameOnANonEscapingProtocolAlone)
+{
+  EXPECT_EQ("file name", CUtil::GetTitleFromPath("smb://server/share/file name.mkv"));
+  EXPECT_EQ("file name", CUtil::GetTitleFromPath("nfs://server/export/file name.mkv"));
+  EXPECT_EQ("file name", CUtil::GetTitleFromPath("ftp://server/pub/file name.mkv"));
+  EXPECT_EQ("100% proof", CUtil::GetTitleFromPath("smb://server/share/100% proof.mkv"));
+}
+
+TEST_F(TestTitleFromPath, DecodesAnEscapeWhateverTheProtocol)
+{
+  // SMB, NFS and FTP put the server's name into the path unescaped, so a name that itself
+  // contains an escape triplet is decoded here. Showing the extension has always done this.
+  EXPECT_EQ("100 proof", CUtil::GetTitleFromPath("smb://server/share/100%20proof.mkv"));
+}

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -214,13 +214,17 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     value = CUtil::GetTitleFromPath(item->GetPath(), item->IsFolder() && !item->IsFileFolder());
     break;
   case 'L':
+  {
     value = item->GetLabel();
     // is the label the actual file or folder name?
-    if (value == URIUtils::GetFileName(item->GetPath()))
+    const std::string& path = item->GetPath();
+    const std::string fileName = URIUtils::GetFileName(path);
+    if (value == fileName || (URIUtils::IsURL(path) && value == URIUtils::DecodePathEscapes(fileName)))
     { // label is the same as filename, clean it up as appropriate
       value = CUtil::GetTitleFromPath(item->GetPath(), item->IsFolder() && !item->IsFileFolder());
     }
     break;
+  }
   case 'D':
     { // duration
       int nDuration=0;

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -55,6 +55,9 @@ namespace
 
 constexpr std::string_view DecodeURLSpecialChars{"+%"};
 
+// '+' means a space only in a query string, so a path decodes escape triplets alone
+constexpr std::string_view DecodePathSpecialChars{"%"};
+
 // Lookup table for URL encoding. This is more efficient than using fmt::format
 // for such a simple operation and this function has been identified as a hot path
 // during library scans; especially encoding the contents of nfo files into URL
@@ -95,9 +98,7 @@ std::optional<char> DecodeOctlet(std::string_view& encoded)
   return decimal;
 }
 
-} // Unnamed namespace
-
-std::string URIUtils::URLDecode(std::string_view encoded)
+std::string Decode(std::string_view encoded, std::string_view specialChars)
 {
   /* result will always be less than or equal to source */
   std::string decodedUrl{};
@@ -105,7 +106,7 @@ std::string URIUtils::URLDecode(std::string_view encoded)
 
   while (true)
   {
-    const auto special = encoded.find_first_of(DecodeURLSpecialChars);
+    const auto special = encoded.find_first_of(specialChars);
     decodedUrl += encoded.substr(0, special);
 
     if (special == std::string::npos)
@@ -121,6 +122,18 @@ std::string URIUtils::URLDecode(std::string_view encoded)
   }
 
   return decodedUrl;
+}
+
+} // Unnamed namespace
+
+std::string URIUtils::URLDecode(std::string_view encoded)
+{
+  return Decode(encoded, DecodeURLSpecialChars);
+}
+
+std::string URIUtils::DecodePathEscapes(std::string_view encoded)
+{
+  return Decode(encoded, DecodePathSpecialChars);
 }
 
 std::string URIUtils::URLEncode(std::string_view decoded, std::string_view URLSpec)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -38,6 +38,9 @@ public:
   static std::string URLEncode(std::string_view strURLData, std::string_view URLSpec = RFC1738);
   static std::string URLDecode(std::string_view strURLData);
 
+  /*! \brief Decode a path component, leaving a literal '+' alone. */
+  static std::string DecodePathEscapes(std::string_view strURLData);
+
   static void RegisterAdvancedSettings(const CAdvancedSettings& advancedSettings);
   static void UnregisterAdvancedSettings();
 

--- a/xbmc/utils/test/TestLabelFormatter.cpp
+++ b/xbmc/utils/test/TestLabelFormatter.cpp
@@ -67,3 +67,47 @@ TEST_F(TestLabelFormatter, FormatLabel2)
 
   EXPECT_TRUE(XBMC_DELETETEMPFILE(tmpfile));
 }
+
+class TestLabelFormatterHiddenExtensions : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+    m_showExtensions = settings->GetBool(CSettings::SETTING_FILELISTS_SHOWEXTENSIONS);
+    settings->SetBool(CSettings::SETTING_FILELISTS_SHOWEXTENSIONS, false);
+  }
+
+  void TearDown() override
+  {
+    CServiceBroker::GetSettingsComponent()->GetSettings()->SetBool(
+        CSettings::SETTING_FILELISTS_SHOWEXTENSIONS, m_showExtensions);
+  }
+
+  static std::string LabelFor(const std::string& path, const std::string& label)
+  {
+    CFileItem item;
+    item.SetPath(path);
+    item.SetLabel(label);
+    item.SetFolder(false);
+
+    CLabelFormatter formatter("%L", "");
+    formatter.FormatLabel(&item);
+    return item.GetLabel();
+  }
+
+private:
+  bool m_showExtensions{true};
+};
+
+TEST_F(TestLabelFormatterHiddenExtensions, HidesTheExtensionOfAnEscapedName)
+{
+  EXPECT_EQ("file_name", LabelFor("davs://server/files/file_name.mkv", "file_name.mkv"));
+  EXPECT_EQ("file name", LabelFor("davs://server/files/file%20name.mkv", "file name.mkv"));
+}
+
+TEST_F(TestLabelFormatterHiddenExtensions, KeepsAPlusInTheName)
+{
+  EXPECT_EQ("C++ Collection",
+            LabelFor("smb://server/share/C++ Collection.mkv", "C++ Collection.mkv"));
+}

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -2725,3 +2725,27 @@ TEST_F(TestURIUtils, GetDecodedPath)
   decoded = "bluray://smb://somepath/path//BDMV/PLAYLIST/00800.mpls";
   EXPECT_EQ(decoded, URIUtils::GetDecodedPath(encoded));
 }
+
+TEST_F(TestURIUtils, DecodePathEscapes)
+{
+  EXPECT_EQ("file name", URIUtils::DecodePathEscapes("file%20name"));
+  EXPECT_EQ("100% proof", URIUtils::DecodePathEscapes("100%25 proof"));
+
+  EXPECT_EQ("C++ Collection", URIUtils::DecodePathEscapes("C++ Collection"));
+  EXPECT_EQ("C   Collection", URIUtils::URLDecode("C++ Collection"));
+}
+
+TEST_F(TestURIUtils, ChangeBasePath)
+{
+  // http/https are the only protocols HasEncodedFilename() treats as encoded, so this is the
+  // decode direction. A subtitle download names the destination this way.
+  EXPECT_EQ("smb://server/share/file name.srt",
+            URIUtils::ChangeBasePath("http://host/videos/", "file%20name.srt",
+                                     "smb://server/share/"));
+
+  // This path decodes each segment with CURL::Decode, so a + becomes a space. Pinned because
+  // it is what the destination has always been given, not because it is the desirable rule.
+  EXPECT_EQ("smb://server/share/C   Collection.srt",
+            URIUtils::ChangeBasePath("http://host/videos/", "C++ Collection.srt",
+                                     "smb://server/share/"));
+}


### PR DESCRIPTION
**TL;DR:** Bug fix. With file extensions hidden, a WebDAV file whose name carries a percent escape kept its extension, because the label comparison never matched the escaped name and the title decode ran in the wrong place. Both are corrected, with tests pinning the unescaped and local cases.

## Description
There are two defects behind the report, one hiding the other.

### 1. The `%L` comparison never matches an escaped name

`CLabelFormatter::GetMaskContent`'s `case 'L'` keeps the existing label unless it *is* the file's own name, in which case it shortens it through `CUtil::GetTitleFromPath`:

```cpp
value = item->GetLabel();
if (value == URIUtils::GetFileName(item->GetPath()))
  value = CUtil::GetTitleFromPath(...);
```

`URIUtils::GetFileName` returns the escaped name (`file%20name.mkv`); the label arrives decoded, because `CDAVDirectory` sets it with `CURL::Decode`. The two never compare equal, so nothing is shortened. `file_name.mkv` has nothing to escape, matches, and works — which is exactly the asymmetry reported.

The comparison now accepts the decoded form as well. An unescaped name still matches on the first term and behaves as before.

### 2. `GetTitleFromPath` decoded in the wrong place

Fixing (1) alone gives `file%20name`, because the branch that removes the extension returns before the decode at the bottom of the function.

Moving that decode down was the obvious fix and the wrong one — thanks to the Codex review on #29141 for catching it. By the time control reaches the bottom, `strFilename` may not be a file name at all: the protocol branches above substitute friendly and localised text. A UPnP device called `C++ Media` comes back as `C   Media`, because `URIUtils::URLDecode` maps `+` to a space. That was already happening on the extensions-shown path; decoding unconditionally would have extended it to the other one, and to local paths, which carry no escapes to resolve.

So the decode moves to where the name is read off the path, and only when that path is a URL:

```cpp
std::string strFilename = URIUtils::IsURL(path) ? CURL::Decode(URIUtils::GetFileName(path))
                                                : URIUtils::GetFileName(path);
```

The escaped name resolves; friendly names, localised strings and local paths are left alone.

### 3. The label was still built with the wrong decoder

Fixing (1) and (2) leaves the reported bug alive for any name containing a `+`.
`CDAVDirectory` builds the label with `CURL::Decode`, which applies the query-string rule
and maps `+` to a space, while the comparison decodes the path with the path rule. So the
two still never match. Both label sites now use the path decoder.

Measured against a real WebDAV server serving `/C++%20Collection.mkv`, listed through
`Files.GetDirectory`. Binaries identical except `DAVDirectory.cpp`:

| | label |
|---|---|
| with this change | `C++ Collection.mkv` |
| with the old decoder | `C   Collection.mkv` |

### 4. The new helper hid an existing function of the same name

`URIUtils.cpp` already defines a free `URLDecodePath(const std::string&)` at namespace
scope, whose only caller is `URIUtils::ChangeBasePath`. A static member of the same name is
found first by unqualified lookup inside an out-of-class member definition, and `std::string`
converts to `std::string_view`, so that call silently rebound to the new member with no
warning - dropping the `+` rule for add-on installs, file copies and subtitle download
destinations. The member is named `DecodePathEscapes` instead.

`ChangeBasePath` had no test; one is added, pinning its existing behaviour.

### 5. Archive roots lost their decode

The `HasParentInHostname` branch assigns after the relocated decode, where the trailing
decode it replaced still reached it. A `zip://` or `bluray://` root on an escaping source
went from `My Zip.zip` to `My%20Zip.zip` - the same defect this PR exists to fix.
It is decoded again.

Nothing here is specific to WebDAV; any VFS that escapes its names reaches both paths.

## Motivation and context
Fixes #28171. @daspri reported that with **Show file extensions** off, a WebDAV file called `file name.mkv` keeps its extension while `file_name.mkv` loses it.

## How has this been tested?
- `TestLabelFormatterHiddenExtensions.HidesTheExtensionOfAnEscapedName` — was `file name.mkv`; the comparison never matched
- `TestTitleFromPath.DecodesAnEscapedNameWhileHidingTheExtension` — was `file%20name`; decoded but still escaped
- `TestTitleFromPath.LeavesALocalNameAlone` — `C++ Media.mkv` and `100% proof.mkv` keep their names, pinning the case above

Each also asserts an unescaped name, so existing behaviour is pinned rather than assumed.

Runtime, against a WebDAV server in Docker serving `C++ Collection.mkv`, `file name.mkv`
and `plain.mkv`, listed through `Files.GetDirectory` on the running application. With the
change the labels come back `C++ Collection.mkv` / `file name.mkv` / `plain.mkv`; with
`DAVDirectory.cpp` alone reverted, the first becomes `C   Collection.mkv`. The server returns no
`displayname`, so the href-based label path is the one exercised.

Full suite green.

## What is the effect on users?
With file extensions hidden, files on WebDAV and other escaping sources whose names contain spaces or other escaped characters are listed without their extension, like every other file.

Beyond the report: a WebDAV name containing a literal `+` is no longer corrupted into spaces
in the list itself, which is a visible change to labels on every WebDAV source, not only
with extensions hidden.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed

