### PR TITLE
fixed: stop the web server offering finite-field Diffie-Hellman key exchange

### DIFF
--- a/xbmc/network/WebServer.cpp
+++ b/xbmc/network/WebServer.cpp
@@ -1192,7 +1192,9 @@ bool CWebServer::LoadCert(std::string& skey, std::string& scert)
 struct MHD_Daemon* CWebServer::StartMHD(unsigned int flags, int port)
 {
   unsigned int timeout = 60 * 60 * 24;
-  const char* ciphers = "PFS:-VERS-TLS1.0:-VERS-TLS1.1";
+  // PFS covers ECDHE and DHE alike, so the finite-field exchanges RFC 10015 forbids for
+  // TLS 1.2 have to be subtracted from it by name.
+  const char* ciphers = "PFS:-VERS-TLS1.0:-VERS-TLS1.1:-DHE-RSA:-DHE-DSS:-DHE-PSK";
 
   MHD_set_panic_func(&panicHandlerForMHD, nullptr);
 


### PR DESCRIPTION
Fixes #29095.

#25493 moved the web server's hardcoded GnuTLS priority string from `NORMAL:-VERS-TLS1.0` to `PFS:-VERS-TLS1.0:-VERS-TLS1.1`. That was correct against RFC 9325, but GnuTLS documents `PFS` as covering **ECDHE and DHE alike**, and RFC 10015 (July 2026) raised ephemeral finite-field Diffie-Hellman for TLS 1.2 from RFC 9325's SHOULD NOT to a **MUST NOT**.

Because `PFS` expands to an abstract key-exchange list that GnuTLS resolves against whichever certificate is configured, `DHE-RSA` is genuinely offered and negotiable for the common RSA-certificate case. The three finite-field exchanges are now subtracted by name:

```c
const char* ciphers = "PFS:-VERS-TLS1.0:-VERS-TLS1.1:-DHE-RSA:-DHE-DSS:-DHE-PSK";
```

### Measured, not asserted

`gnutls-cli 3.8.13`, `--priority <string> --list`, so this is the real GnuTLS priority parser rather than a reading of the documentation.

| | outgoing string | this change |
|---|---|---|
| `TLS_DHE_RSA_*` suites offered | **7** | **0** |
| suites remaining | — | 16: 4 × TLS 1.3, 12 × ECDHE (ECDSA and RSA) |
| protocols | TLS 1.3, TLS 1.2 | TLS 1.3, TLS 1.2 (1.0/1.1 still excluded) |

The seven that go are `TLS_DHE_RSA_` `AES_256_GCM_SHA384`, `CHACHA20_POLY1305`, `AES_256_CCM`, `AES_256_CBC_SHA1`, `AES_128_GCM_SHA256`, `AES_128_CCM` and `AES_128_CBC_SHA1`. Nothing else moves — the string still parses, and no ECDHE or TLS 1.3 suite is lost.

### Deliberately not done

**The TLS 1.3 finite-field groups.** `GROUP-FFDHE2048` through `GROUP-FFDHE8192` are still offered, because TLS 1.3 negotiates key exchange by group rather than through these key-exchange tokens. Appending `:-GROUP-FFDHE2048:-GROUP-FFDHE3072:-GROUP-FFDHE4096:-GROUP-FFDHE6144:-GROUP-FFDHE8192` reduces the group list to `SECP256R1, SECP384R1, SECP521R1, X25519, X448`, which I have measured but not proposed: it is an interoperability decision rather than a restatement of the RFC the report cites.

**A configuration surface.** The report's second ask — exposing the priority string through `advancedsettings.xml`, per #19735 — is a new setting, which does not belong in an RC. This change is the part that can land now.

**A test.** There is no unit test. GnuTLS and libmicrohttpd are not exercised by the test suite, and a test asserting the literal string would only restate the line it is testing. The evidence above is the verification.

Full suite green, unchanged by this: 4041 tests, 313 suites.
