### PR TITLE
[GUI] Add Player.SeekStepValue info label

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -985,6 +985,17 @@ constexpr std::array<InfoMap, 2> player_param = {{
 ///     @skinning_v15 **[New Infolabel]** \link Player_SeekStepSize `Player.SeekStepSize`\endlink
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Player.SeekStepValue([format])`</b>,
+///                  \anchor Player_SeekStepValue_format
+///                  _string_,
+///     @return The current configured seek step value in a given format.
+///     @param format [opt] The format of the return time value.
+///     See \ref TIME_FORMAT for the list of possible values.
+///     <p>
+///     <hr>
+///     @skinning_v22 **[New Infolabel]** \link Player_SeekStepValue_format `Player.SeekStepValue`\endlink
+///     <p>
+///   }
 ///   \table_row3{   <b>`Player.TimeRemaining([format])`</b>,
 ///                  \anchor Player_TimeRemaining_format
 ///                  _string_,
@@ -1040,10 +1051,11 @@ constexpr std::array<InfoMap, 2> player_param = {{
 ///     <p>
 ///   }
 // clang-format off
-constexpr std::array<InfoMap, 10> player_times = {{
+constexpr std::array<InfoMap, 11> player_times = {{
     {"seektime",      PLAYER_SEEKTIME},
     {"seekoffset",    PLAYER_SEEKOFFSET},
     {"seekstepsize",  PLAYER_SEEKSTEPSIZE},
+    {"seekstepvalue", PLAYER_SEEKSTEPVALUE},
     {"timeremaining", PLAYER_TIME_REMAINING},
     {"timespeed",     PLAYER_TIME_SPEED},
     {"time",          PLAYER_TIME},

--- a/xbmc/SeekHandler.cpp
+++ b/xbmc/SeekHandler.cpp
@@ -43,7 +43,7 @@ using namespace KODI;
 
 void CSeekHandler::Configure()
 {
-  Reset();
+  ResetAndClearSeekStepValue();
 
   const std::shared_ptr<CSettings> settings = CServiceBroker::GetSettingsComponent()->GetSettings();
 
@@ -86,7 +86,29 @@ void CSeekHandler::Reset()
   m_timeCodePosition = 0;
 }
 
-int CSeekHandler::GetSeekStepSize(SeekType type, int step)
+void CSeekHandler::ClearSeekStepValue()
+{
+  m_seekStepValue = 0;
+}
+
+void CSeekHandler::CancelSeekAndClearSeekStepValue()
+{
+  std::unique_lock lock(m_critSection);
+  m_requireSeek = false;
+  m_analogSeek = false;
+  m_seekStep = 0;
+  m_seekSize = 0;
+  ClearSeekStepValue();
+}
+
+void CSeekHandler::ResetAndClearSeekStepValue()
+{
+  std::unique_lock lock(m_critSection);
+  Reset();
+  ClearSeekStepValue();
+}
+
+int CSeekHandler::GetSeekStepSize(SeekType type, int step) const
 {
   if (step == 0)
     return 0;
@@ -112,6 +134,24 @@ int CSeekHandler::GetSeekStepSize(SeekType type, int step)
   return seconds;
 }
 
+int CSeekHandler::GetSeekStepValue(SeekType type, int step) const
+{
+  if (step == 0)
+    return 0;
+
+  const std::vector<int>& seekSteps(step > 0 ? m_forwardSeekSteps.at(type)
+                                             : m_backwardSeekSteps.at(type));
+
+  if (seekSteps.empty())
+  {
+    CLog::LogF(LOGERROR, "No {} {} seek steps configured.",
+               (type == SeekType::VIDEO ? "video" : "music"), (step > 0 ? "forward" : "backward"));
+    return 0;
+  }
+
+  return seekSteps.at(std::min<size_t>(std::abs(step), seekSteps.size()) - 1);
+}
+
 void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bool analogSeek /* = false */, SeekType type /* = SEEK_TYPE_VIDEO */)
 {
   std::unique_lock lock(m_critSection);
@@ -122,7 +162,10 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
     // use only the first step forward/backward for a seek without a delay
     if (!analogSeek && m_seekDelays.at(type) == 0)
     {
-      SeekSeconds(GetSeekStepSize(type, forward ? 1 : -1));
+      const int step = forward ? 1 : -1;
+      const int seekSeconds = GetSeekStepSize(type, step);
+      const int seekStepValue = seekSeconds != 0 ? GetSeekStepValue(type, step) : 0;
+      SeekSeconds(seekSeconds, seekStepValue);
       return;
     }
 
@@ -134,6 +177,8 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
   // calculate our seek amount
   if (analogSeek)
   {
+    m_seekStepValue = 0;
+
     //100% over 1 second.
     float speed = 100.0f;
     if( duration )
@@ -157,11 +202,13 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
     const int seekSeconds = GetSeekStepSize(type, m_seekStep);
     if (seekSeconds != 0)
     {
+      m_seekStepValue = GetSeekStepValue(type, m_seekStep);
       SetSeekSize(seekSeconds);
     }
     else
     {
       // nothing to do, abort seeking
+      ClearSeekStepValue();
       Reset();
     }
   }
@@ -169,13 +216,14 @@ void CSeekHandler::Seek(bool forward, float amount, float duration /* = 0 */, bo
   m_timer.StartZero();
 }
 
-void CSeekHandler::SeekSeconds(int seconds)
+void CSeekHandler::SeekSeconds(int seconds, int seekStepValue)
 {
   // abort if we do not have a play time or already perform a seek
   if (seconds == 0)
     return;
 
   std::unique_lock lock(m_critSection);
+  m_seekStepValue = seekStepValue;
   SetSeekSize(seconds);
 
   // perform relative seek
@@ -188,7 +236,14 @@ void CSeekHandler::SeekSeconds(int seconds)
 
 int CSeekHandler::GetSeekSize() const
 {
+  std::unique_lock lock(m_critSection);
   return MathUtils::round_int(m_seekSize);
+}
+
+int CSeekHandler::GetSeekStepValue() const
+{
+  std::unique_lock lock(m_critSection);
+  return m_seekStepValue;
 }
 
 void CSeekHandler::SetSeekSize(double seekSize)
@@ -206,35 +261,52 @@ void CSeekHandler::SetSeekSize(double seekSize)
 
 bool CSeekHandler::InProgress() const
 {
-  return m_requireSeek || CServiceBroker::GetDataCacheCore().IsSeeking();
+  bool requireSeek = false;
+  {
+    std::unique_lock lock(m_critSection);
+    requireSeek = m_requireSeek;
+  }
+
+  return requireSeek || CServiceBroker::GetDataCacheCore().IsSeeking();
+}
+
+bool CSeekHandler::HasTimeCode() const
+{
+  std::unique_lock lock(m_critSection);
+  return m_timeCodePosition > 0;
 }
 
 void CSeekHandler::FrameMove()
 {
-  if (m_timer.GetElapsedMilliseconds() >= m_seekDelay && m_requireSeek)
+  bool seekChanged = false;
+
   {
     std::unique_lock lock(m_critSection);
 
-    // perform relative seek
-    auto& components = CServiceBroker::GetAppComponents();
-    const auto appPlayer = components.GetComponent<CApplicationPlayer>();
-    appPlayer->SeekTimeRelative(static_cast<int64_t>(m_seekSize * 1000));
+    if (m_timer.GetElapsedMilliseconds() >= m_seekDelay && m_requireSeek)
+    {
+      // perform relative seek
+      auto& components = CServiceBroker::GetAppComponents();
+      const auto appPlayer = components.GetComponent<CApplicationPlayer>();
+      appPlayer->SeekTimeRelative(static_cast<int64_t>(m_seekSize * 1000));
 
-    m_seekChanged = true;
+      m_seekChanged = true;
+      Reset();
+    }
 
-    Reset();
+    if (m_timeCodePosition > 0 && m_timerTimeCode.GetElapsedMilliseconds() >= 2500)
+      m_timeCodePosition = 0;
+
+    if (m_seekChanged)
+    {
+      seekChanged = true;
+      m_seekChanged = false;
+    }
   }
 
-  if (m_timeCodePosition > 0 && m_timerTimeCode.GetElapsedMilliseconds() >= 2500)
-  {
-    m_timeCodePosition = 0;
-  }
-
-  if (m_seekChanged)
-  {
-    m_seekChanged = false;
-    CServiceBroker::GetGUI()->GetWindowManager().SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_STATE_CHANGED);
-  }
+  if (seekChanged)
+    CServiceBroker::GetGUI()->GetWindowManager().SendMessage(GUI_MSG_NOTIFY_ALL, 0, 0,
+                                                             GUI_MSG_STATE_CHANGED);
 }
 
 void CSeekHandler::SettingOptionsSeekStepsFiller(const SettingConstPtr& setting,
@@ -344,6 +416,7 @@ bool CSeekHandler::OnAction(const CAction &action)
     {
       if (!g_application.CurrentFileItem().IsLiveTV())
       {
+        CancelSeekAndClearSeekStepValue();
         ChangeTimeCode(action.GetID());
         return true;
       }
@@ -358,7 +431,7 @@ bool CSeekHandler::OnAction(const CAction &action)
 
 bool CSeekHandler::SeekTimeCode(const CAction &action)
 {
-  if (m_timeCodePosition <= 0)
+  if (!HasTimeCode())
     return false;
 
   switch (action.GetID())
@@ -367,9 +440,11 @@ bool CSeekHandler::SeekTimeCode(const CAction &action)
     case ACTION_PLAYER_PLAY:
     case ACTION_PAUSE:
     {
+      const int seekSeconds = GetTimeCodeSeconds();
       std::unique_lock lock(m_critSection);
 
-      g_application.SeekTime(GetTimeCodeSeconds());
+      m_seekStepValue = 0;
+      g_application.SeekTime(seekSeconds);
       Reset();
       return true;
     }
@@ -398,6 +473,8 @@ bool CSeekHandler::SeekTimeCode(const CAction &action)
 
 void CSeekHandler::ChangeTimeCode(int remote)
 {
+  std::unique_lock lock(m_critSection);
+
   if (remote >= ACTION_JUMP_SMS2 && remote <= ACTION_JUMP_SMS9)
   {
     // cast to REMOTE_X
@@ -423,6 +500,8 @@ void CSeekHandler::ChangeTimeCode(int remote)
 
 int CSeekHandler::GetTimeCodeSeconds() const
 {
+  std::unique_lock lock(m_critSection);
+
   if (m_timeCodePosition > 0)
   {
     // Convert the timestamp into an integer

--- a/xbmc/SeekHandler.h
+++ b/xbmc/SeekHandler.h
@@ -42,15 +42,19 @@ public:
             float duration = 0,
             bool analogSeek = false,
             SeekType type = SeekType::VIDEO);
-  void SeekSeconds(int seconds);
+  void SeekSeconds(int seconds, int seekStepValue = 0);
   void FrameMove();
   void Reset();
   void Configure();
+  void ClearSeekStepValue();
+  void CancelSeekAndClearSeekStepValue();
+  void ResetAndClearSeekStepValue();
 
   int GetSeekSize() const;
+  int GetSeekStepValue() const;
   bool InProgress() const;
 
-  bool HasTimeCode() const { return m_timeCodePosition > 0; }
+  bool HasTimeCode() const;
   int GetTimeCodeSeconds() const;
 
 protected:
@@ -63,7 +67,8 @@ private:
   static const int analogSeekDelay = 500;
 
   void SetSeekSize(double seekSize);
-  int GetSeekStepSize(SeekType type, int step);
+  int GetSeekStepSize(SeekType type, int step) const;
+  int GetSeekStepValue(SeekType type, int step) const;
 
   int m_seekDelay = 500;
   std::map<SeekType, int> m_seekDelays;
@@ -72,6 +77,7 @@ private:
   bool m_analogSeek = false;
   double m_seekSize = 0;
   int m_seekStep = 0;
+  int m_seekStepValue = 0;
   std::map<SeekType, std::vector<int>> m_forwardSeekSteps;
   std::map<SeekType, std::vector<int>> m_backwardSeekSteps;
   CStopWatch m_timer;
@@ -79,5 +85,5 @@ private:
   std::array<int, 6> m_timeCodeStamp{};
   int m_timeCodePosition = 0;
 
-  CCriticalSection m_critSection;
+  mutable CCriticalSection m_critSection;
 };

--- a/xbmc/application/ApplicationPlayer.cpp
+++ b/xbmc/application/ApplicationPlayer.cpp
@@ -38,6 +38,7 @@ std::shared_ptr<IPlayer> CApplicationPlayer::GetInternal()
 
 void CApplicationPlayer::ClosePlayer()
 {
+  m_seekHandler.ResetAndClearSeekStepValue();
   m_nextItem.pItem.reset();
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
@@ -87,6 +88,8 @@ bool CApplicationPlayer::OpenFile(const CFileItem& item, const CPlayerOptions& o
                                   const CPlayerCoreFactory &factory,
                                   const std::string &playerName, IPlayerCallback& callback)
 {
+  m_seekHandler.ResetAndClearSeekStepValue();
+
   // get player type
   std::string newPlayer;
   if (!playerName.empty())
@@ -327,6 +330,8 @@ void CApplicationPlayer::SetVolume(float volume)
 
 void CApplicationPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride)
 {
+  m_seekHandler.ResetAndClearSeekStepValue();
+
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
     player->Seek(bPlus, bLargeStep, bChapterOverride);
@@ -334,6 +339,8 @@ void CApplicationPlayer::Seek(bool bPlus, bool bLargeStep, bool bChapterOverride
 
 void CApplicationPlayer::SeekPercentage(float fPercent)
 {
+  m_seekHandler.ResetAndClearSeekStepValue();
+
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
     player->SeekPercentage(fPercent);
@@ -353,12 +360,16 @@ bool CApplicationPlayer::CanSeek() const
 
 bool CApplicationPlayer::SeekScene(Direction seekDirection)
 {
+  m_seekHandler.ResetAndClearSeekStepValue();
+
   std::shared_ptr<IPlayer> player = GetInternal();
   return (player && player->SeekScene(seekDirection));
 }
 
 void CApplicationPlayer::SeekTime(int64_t iTime)
 {
+  m_seekHandler.ResetAndClearSeekStepValue();
+
   std::shared_ptr<IPlayer> player = GetInternal();
   if (player)
     player->SeekTime(iTime);

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -63,7 +63,7 @@ constexpr uint32_t PLAYER_CAN_SEEK                   = 51;
 constexpr uint32_t PLAYER_START_TIME                 = 52;
 // unused id 53
 constexpr uint32_t PLAYER_ISINTERNETSTREAM           = 54;
-// unused id 55
+constexpr uint32_t PLAYER_SEEKSTEPVALUE              = 55;
 constexpr uint32_t PLAYER_SEEKSTEPSIZE               = 56;
 constexpr uint32_t PLAYER_IS_CHANNEL_PREVIEW_ACTIVE  = 57;
 constexpr uint32_t PLAYER_SUPPORTS_TEMPO             = 58;

--- a/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/PlayerGUIInfo.cpp
@@ -279,6 +279,17 @@ bool CPlayerGUIInfo::GetLabel(std::string& value,
         value = "+" + strSeekSize;
       return true;
     }
+    case PLAYER_SEEKSTEPVALUE:
+    {
+      const int seekStepValue = m_appPlayer->GetSeekHandler().GetSeekStepValue();
+      const std::string strSeekStepValue = StringUtils::SecondsToTimeString(
+          abs(seekStepValue), static_cast<TIME_FORMAT>(info.GetData1()));
+      if (seekStepValue < 0)
+        value = "-" + strSeekStepValue;
+      if (seekStepValue > 0)
+        value = "+" + strSeekStepValue;
+      return true;
+    }
     case PLAYER_SEEKNUMERIC:
       value = GetSeekTime(static_cast<TIME_FORMAT>(info.GetData1()));
       return !value.empty();


### PR DESCRIPTION
## Description
Adds a new player info label, `Player.SeekStepValue([format])`, which exposes the individual configured seek step value.

This preserves the existing behavior of `Player.SeekStepSize`, which reports the cumulative seek size, and `Player.SeekOffset`, which reports the performed seek offset.

For configured forward seek steps such as `10, 30, 60`, repeated seek presses can now be displayed as:

`10, 30, 60, 60, 60`

instead of the cumulative seek size.

## Motivation and context
Skins currently only have access to the cumulative seek size via `Player.SeekStepSize`. This makes it difficult to display the actual configured seek step being applied during repeated skip-step seeks.

This adds a separate label for skins that want to show the configured seek step value while keeping existing labels and seeking behavior unchanged.

## How has this been tested?
Built successfully on Windows using:

`cmake --build C:\xbmc-build --target kodi --config Debug`

Tested manually with a local skin using repeated skip-step seeks and chapter/big-step jumps.

Also checked:

`git diff --check`

## What is the effect on users?
No direct effect on Kodi end-users unless their skin uses the new `Player.SeekStepValue` info label.

Skins can now display the configured seek step value independently from the cumulative seek offset.

## Screenshots (if appropriate):
N/A

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed