### PR TITLE
changed: name the decoded-file-name idiom rather than repeating it

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1944,7 +1944,7 @@ std::string CFileItem::GetMovieName(bool bUseFolderNames /* = false */, int dept
 
   URIUtils::RemoveSlashAtEnd(strMovieName);
 
-  strMovieName = CURL::Decode(URIUtils::GetFileName(strMovieName));
+  strMovieName = URIUtils::GetDecodedFileName(strMovieName);
   URIUtils::RemoveExtension(strMovieName);
   return strMovieName;
 }

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -341,8 +341,8 @@ std::string CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false *
   URIUtils::RemoveSlashAtEnd(path);
   // A VFS path carries percent escapes; a local path and the friendly names assigned
   // below do not, so only this one is decoded.
-  std::string strFilename = URIUtils::IsURL(path) ? CURL::Decode(URIUtils::GetFileName(path))
-                                                  : URIUtils::GetFileName(path);
+  std::string strFilename =
+      URIUtils::IsURL(path) ? URIUtils::GetDecodedFileName(path) : URIUtils::GetFileName(path);
 
 #ifdef HAS_UPNP
   // UPNP

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -339,7 +339,10 @@ std::string CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false *
   // use above to get the filename
   std::string path(url.Get());
   URIUtils::RemoveSlashAtEnd(path);
-  std::string strFilename = URIUtils::GetFileName(path);
+  // A VFS path carries percent escapes; a local path and the friendly names assigned
+  // below do not, so only this one is decoded.
+  std::string strFilename = URIUtils::IsURL(path) ? CURL::Decode(URIUtils::GetFileName(path))
+                                                  : URIUtils::GetFileName(path);
 
 #ifdef HAS_UPNP
   // UPNP
@@ -400,14 +403,11 @@ std::string CUtil::GetTitleFromPath(const CURL& url, bool bIsFolder /* = false *
     strFilename = URIUtils::GetFileName(url.GetHostName());
 
   // now remove the extension if needed
-  if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(CSettings::SETTING_FILELISTS_SHOWEXTENSIONS) && !bIsFolder)
-  {
+  if (!CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+          CSettings::SETTING_FILELISTS_SHOWEXTENSIONS) &&
+      !bIsFolder)
     URIUtils::RemoveExtension(strFilename);
-    return strFilename;
-  }
 
-  // URLDecode since the original path may be an URL
-  strFilename = CURL::Decode(strFilename);
   return strFilename;
 }
 

--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -153,7 +153,7 @@ bool CDAVDirectory::GetDirectory(const CURL& url, CFileItemList &items)
       {
         std::string name(itemPath);
         URIUtils::RemoveSlashAtEnd(name);
-        item.SetLabel(CURL::Decode(URIUtils::GetFileName(name)));
+        item.SetLabel(URIUtils::GetDecodedFileName(name));
       }
 
       if (item.IsFolder())

--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -10,6 +10,7 @@
 #include "Util.h"
 #include "cores/VideoPlayer/Interface/StreamInfo.h"
 #include "settings/AdvancedSettings.h"
+#include "settings/Settings.h"
 #include "settings/SettingsComponent.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -928,3 +929,40 @@ TEST_P(TestExternalStreamDetails, GetExternalStreamDetailsFromFilename)
 INSTANTIATE_TEST_SUITE_P(GetExternalStreamDetailsFromFilename,
                          TestExternalStreamDetails,
                          ValuesIn(ExternalStreams));
+
+/*!
+ * A percent-encoded path reaches here from any VFS that escapes its names - WebDAV among them.
+ * Hiding the extension must not hand back the escaped form.
+ */
+class TestTitleFromPath : public Test
+{
+protected:
+  void SetUp() override
+  {
+    const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+    m_showExtensions = settings->GetBool(CSettings::SETTING_FILELISTS_SHOWEXTENSIONS);
+    settings->SetBool(CSettings::SETTING_FILELISTS_SHOWEXTENSIONS, false);
+  }
+
+  void TearDown() override
+  {
+    CServiceBroker::GetSettingsComponent()->GetSettings()->SetBool(
+        CSettings::SETTING_FILELISTS_SHOWEXTENSIONS, m_showExtensions);
+  }
+
+private:
+  bool m_showExtensions{true};
+};
+
+TEST_F(TestTitleFromPath, DecodesAnEscapedNameWhileHidingTheExtension)
+{
+  EXPECT_EQ("file name", CUtil::GetTitleFromPath("davs://server/files/file%20name.mkv"));
+  EXPECT_EQ("file_name", CUtil::GetTitleFromPath("davs://server/files/file_name.mkv"));
+}
+
+/*! A local path is not escaped, so decoding one would corrupt every name holding a plus. */
+TEST_F(TestTitleFromPath, LeavesALocalNameAlone)
+{
+  EXPECT_EQ("C++ Media", CUtil::GetTitleFromPath("/path/to/C++ Media.mkv"));
+  EXPECT_EQ("100% proof", CUtil::GetTitleFromPath("/path/to/100% proof.mkv"));
+}

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -13,6 +13,7 @@
 #include "ServiceBroker.h"
 #include "StringUtils.h"
 #include "URIUtils.h"
+#include "URL.h"
 #include "Util.h"
 #include "Variant.h"
 #include "addons/IAddon.h"
@@ -214,13 +215,17 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     value = CUtil::GetTitleFromPath(item->GetPath(), item->IsFolder() && !item->IsFileFolder());
     break;
   case 'L':
+  {
     value = item->GetLabel();
-    // is the label the actual file or folder name?
-    if (value == URIUtils::GetFileName(item->GetPath()))
+    // is the label the actual file or folder name? A VFS that escapes its names hands the
+    // label over decoded, so the escaped form has to be compared as well.
+    const std::string fileName = URIUtils::GetFileName(item->GetPath());
+    if (value == fileName || value == CURL::Decode(fileName))
     { // label is the same as filename, clean it up as appropriate
       value = CUtil::GetTitleFromPath(item->GetPath(), item->IsFolder() && !item->IsFileFolder());
     }
     break;
+  }
   case 'D':
     { // duration
       int nDuration=0;

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -13,7 +13,6 @@
 #include "ServiceBroker.h"
 #include "StringUtils.h"
 #include "URIUtils.h"
-#include "URL.h"
 #include "Util.h"
 #include "Variant.h"
 #include "addons/IAddon.h"
@@ -219,8 +218,8 @@ std::string CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFile
     value = item->GetLabel();
     // is the label the actual file or folder name? A VFS that escapes its names hands the
     // label over decoded, so the escaped form has to be compared as well.
-    const std::string fileName = URIUtils::GetFileName(item->GetPath());
-    if (value == fileName || value == CURL::Decode(fileName))
+    const std::string& path = item->GetPath();
+    if (value == URIUtils::GetFileName(path) || value == URIUtils::GetDecodedFileName(path))
     { // label is the same as filename, clean it up as appropriate
       value = CUtil::GetTitleFromPath(item->GetPath(), item->IsFolder() && !item->IsFileFolder());
     }

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -344,6 +344,16 @@ std::string URIUtils::GetFileName(const CURL& url)
   return GetFileName(url.GetFileName());
 }
 
+std::string URIUtils::GetDecodedFileName(const CURL& url)
+{
+  return CURL::Decode(GetFileName(url));
+}
+
+std::string URIUtils::GetDecodedFileName(const std::string& strFileNameAndPath)
+{
+  return CURL::Decode(GetFileName(strFileNameAndPath));
+}
+
 /* returns a filename given an url */
 /* handles both / and \, and options in urls*/
 std::string URIUtils::GetFileName(const std::string& strFileNameAndPath)

--- a/xbmc/utils/URIUtils.h
+++ b/xbmc/utils/URIUtils.h
@@ -45,6 +45,10 @@ public:
 
   static std::string GetFileName(const CURL& url);
   static std::string GetFileName(const std::string& strFileNameAndPath);
+
+  /*! rief The file name with any percent escapes resolved, as a label carries it. */
+  static std::string GetDecodedFileName(const CURL& url);
+  static std::string GetDecodedFileName(const std::string& strFileNameAndPath);
   static std::string GetFileOrFolderName(std::string_view path);
 
   static std::string GetExtension(const CURL& url);

--- a/xbmc/utils/test/TestLabelFormatter.cpp
+++ b/xbmc/utils/test/TestLabelFormatter.cpp
@@ -67,3 +67,41 @@ TEST_F(TestLabelFormatter, FormatLabel2)
 
   EXPECT_TRUE(XBMC_DELETETEMPFILE(tmpfile));
 }
+
+class TestLabelFormatterHiddenExtensions : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    const auto settings = CServiceBroker::GetSettingsComponent()->GetSettings();
+    m_showExtensions = settings->GetBool(CSettings::SETTING_FILELISTS_SHOWEXTENSIONS);
+    settings->SetBool(CSettings::SETTING_FILELISTS_SHOWEXTENSIONS, false);
+  }
+
+  void TearDown() override
+  {
+    CServiceBroker::GetSettingsComponent()->GetSettings()->SetBool(
+        CSettings::SETTING_FILELISTS_SHOWEXTENSIONS, m_showExtensions);
+  }
+
+  static std::string LabelFor(const std::string& path, const std::string& label)
+  {
+    CFileItem item;
+    item.SetPath(path);
+    item.SetLabel(label);
+    item.SetFolder(false);
+
+    CLabelFormatter formatter("%L", "");
+    formatter.FormatLabel(&item);
+    return item.GetLabel();
+  }
+
+private:
+  bool m_showExtensions{true};
+};
+
+TEST_F(TestLabelFormatterHiddenExtensions, HidesTheExtensionOfAnEscapedName)
+{
+  EXPECT_EQ("file_name", LabelFor("davs://server/files/file_name.mkv", "file_name.mkv"));
+  EXPECT_EQ("file name", LabelFor("davs://server/files/file%20name.mkv", "file name.mkv"));
+}

--- a/xbmc/utils/test/TestURIUtils.cpp
+++ b/xbmc/utils/test/TestURIUtils.cpp
@@ -229,6 +229,13 @@ TEST_F(TestURIUtils, GetFileName)
   EXPECT_EQ("movie.avi", URIUtils::GetFileName("/path/to/movie.avi"));
 }
 
+TEST_F(TestURIUtils, GetDecodedFileName)
+{
+  EXPECT_EQ("movie.avi", URIUtils::GetDecodedFileName("/path/to/movie.avi"));
+  EXPECT_EQ("the movie.avi", URIUtils::GetDecodedFileName("davs://host/the%20movie.avi"));
+  EXPECT_EQ("100% proof.avi", URIUtils::GetDecodedFileName("davs://host/100%25%20proof.avi"));
+}
+
 TEST_F(TestURIUtils, RemoveExtension)
 {
   std::string ref;


### PR DESCRIPTION
**TL;DR:** Clean up, no behaviour change. Three call sites composed `CURL::Decode(URIUtils::GetFileName(path))` to ask what a file is called; `URIUtils::GetDecodedFileName` now answers it. Depends on #29138.

## Description
`CURL::Decode(URIUtils::GetFileName(path))` had three callers, all asking the same question — what is this file called, as a label carries it:

| call site | what it wanted the name for |
|---|---|
| `CDAVDirectory::ParseResponse` | the label of a directory entry |
| `CFileItem::GetMovieName` | a movie name derived from the file |
| `CLabelFormatter::GetMaskContent` | whether the label is the file's own name |

`URIUtils::GetDecodedFileName` now answers it, overloaded for `std::string` and `CURL` to mirror `GetFileName` immediately above it. `CLabelFormatter` also loses the `URL.h` include it needed only for the decode.

**No behaviour change** — the helper is exactly the composition it replaces.

**Depends on #29138.** Branched from it, because the `CLabelFormatter` call site this consolidates is introduced there. Until that merges this PR shows both commits; it will reduce to one once it does, and I will rebase if #29138 changes.

Milestoned for 23 Alpha rather than RC 1: nothing here fixes a defect, and a new `URIUtils` surface is not what an RC is for.

## Motivation and context
Follow-up to #29138, at @clementperon's suggestion there.

## How has this been tested?
`TestURIUtils.GetDecodedFileName` covers the unescaped name, an escaped space, and a literal `%` (`100%25%20proof.avi` → `100% proof.avi`), which is the case that makes the decode more than cosmetic.

Full suite green: 4044 tests, 315 suites.

## What is the effect on users?
None.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
