### PR TITLE
[linux][cpuinfo] find the CPU temperature sensor on more SoCs

### DIFF
--- a/xbmc/platform/linux/CPUInfoLinux.cpp
+++ b/xbmc/platform/linux/CPUInfoLinux.cpp
@@ -8,16 +8,17 @@
 
 #include "CPUInfoLinux.h"
 
-#include "utils/Set.h"
 #include "utils/StringUtils.h"
 #include "utils/Temperature.h"
 
 #include "platform/linux/SysfsPath.h"
 
+#include <array>
 #include <exception>
 #include <fstream>
 #include <regex>
 #include <sstream>
+#include <string_view>
 #include <vector>
 
 #if (defined(__arm__) && defined(HAS_NEON)) || defined(__aarch64__)
@@ -96,27 +97,28 @@ CCPUInfoLinux::CCPUInfoLinux()
   if (freqPath.Exists())
     m_freqPath = freqStr;
 
-  static constexpr auto modules = make_set<std::string_view>({
-      "coretemp",
-      "k10temp",
-      "scpi_sensors",
-      "imx_thermal_zone",
-      "cpu_thermal",
-  });
+  // A hwmon device backed by a device tree thermal zone takes its name from the
+  // zone type with hyphens replaced by underscores. Listed in preference order:
+  // a platform can expose several of these, e.g. i.MX8MP has both cpu_thermal
+  // and soc_thermal.
+  static constexpr std::array<std::string_view, 7> modules = {
+      "coretemp",    "k10temp",     "scpi_sensors",    "imx_thermal_zone",
+      "cpu_thermal", "soc_thermal", "package_thermal",
+  };
 
-  for (int i = 0; i < 20; i++)
+  for (const auto& module : modules)
   {
-    CSysfsPath path{"/sys/class/hwmon/hwmon" + std::to_string(i) + "/name"};
-    if (!path.Exists())
-      continue;
-
-    auto name = path.Get<std::string>();
-
-    if (!name.has_value())
-      continue;
-
-    if (modules.contains(*name))
+    for (int i = 0; i < 20; i++)
     {
+      CSysfsPath path{"/sys/class/hwmon/hwmon" + std::to_string(i) + "/name"};
+      if (!path.Exists())
+        continue;
+
+      auto name = path.Get<std::string>();
+
+      if (!name.has_value() || *name != module)
+        continue;
+
       std::string tempStr{"/sys/class/hwmon/hwmon" + std::to_string(i) + "/temp1_input"};
       CSysfsPath tempPath{tempStr};
       if (!tempPath.Exists())
@@ -125,6 +127,9 @@ CCPUInfoLinux::CCPUInfoLinux()
       m_tempPath = tempStr;
       break;
     }
+
+    if (!m_tempPath.empty())
+      break;
   }
 
   m_cpuCount = sysconf(_SC_NPROCESSORS_ONLN);


### PR DESCRIPTION
## Description
The hwmon name search only accepted five names, so any SoC whose device tree spells its CPU thermal zone differently ended up with an empty m_tempPath and no temperature reported at all. A hwmon device backed by a thermal zone is named after the zone type with hyphens replaced by underscores, and Rockchip RK3328 uses soc-thermal while RK3576 and RK3588 use package-thermal, none of which were matched.

Add soc_thermal and package_thermal, and search the names in preference order instead of as an unordered set. A platform can expose more than one of them, and breaking on whichever happened to land on the lower hwmon index was arbitrary: i.MX8MP has both cpu_thermal and soc_thermal and wants the former.

## Motivation and context
LibreELEC images for some Rockchip SoC types were missing the System temp display after a local 'cputemp' script was removed at the distro level in the LE buildsystem "because Kodi detects the info via hwmon" which proves true for Generic x86_64 hardware and Raspberry Pi devices, but not most of the Rockchip SoC's; and those that did show the temp were displaying the NPU temp not CPU due to a lack of sensor order preference.

## How has this been tested?
Apply the patch, boot and check Kodi system info screens.

## What is the effect on users?
More Linux hardware reports a) temperature, b) the correct temperature

## Screenshots (if appropriate):
N/A

## Types of change
- [x] **Improvement (other)** (non-breaking change which improves other existing functionality)

## Checklist:
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
