### PR TITLE
RetroPlayer - don't read the add-on repository when the emulator is already known

### DIFF
--- a/xbmc/games/GameUtils.cpp
+++ b/xbmc/games/GameUtils.cpp
@@ -87,7 +87,7 @@ bool CGameUtils::FillInGameClient(CFileItem& item, std::string& savestatePath)
         GameClientVector candidates;
         GameClientVector installable;
         bool bHasVfsGameClient;
-        GetGameClients(item, candidates, installable, bHasVfsGameClient);
+        GetInstalledGameClients(item, candidates, bHasVfsGameClient);
 
         // An emulator remembered for this game, or for a folder above it,
         // answers the question without asking
@@ -96,27 +96,32 @@ bool CGameUtils::FillInGameClient(CFileItem& item, std::string& savestatePath)
         {
           item.GetGameInfoTag()->SetGameClient(defaultClient);
         }
-        else if (candidates.empty() && installable.empty())
-        {
-          // if: "This game can only be played directly from a hard drive or partition. Compressed files must be extracted."
-          // else: "This game isn't compatible with any available emulators."
-          int errorTextId = bHasVfsGameClient ? 35214 : 35212;
-
-          // "Failed to play game"
-          MESSAGING::HELPERS::ShowOKDialogText(CVariant{35210}, CVariant{errorTextId});
-        }
-        else if (candidates.size() == 1 && installable.empty())
-        {
-          // Only 1 option, avoid prompting the user
-          item.GetGameInfoTag()->SetGameClient(candidates[0]->ID());
-        }
         else
         {
-          std::string gameClient = CGUIDialogSelectGameClient::ShowAndGetGameClient(
-              item.GetPath(), candidates, installable);
+          GetInstallableGameClients(item, installable, bHasVfsGameClient);
 
-          if (!gameClient.empty())
-            item.GetGameInfoTag()->SetGameClient(gameClient);
+          if (candidates.empty() && installable.empty())
+          {
+            // if: "This game can only be played directly from a hard drive or partition. Compressed files must be extracted."
+            // else: "This game isn't compatible with any available emulators."
+            int errorTextId = bHasVfsGameClient ? 35214 : 35212;
+
+            // "Failed to play game"
+            MESSAGING::HELPERS::ShowOKDialogText(CVariant{35210}, CVariant{errorTextId});
+          }
+          else if (candidates.size() == 1 && installable.empty())
+          {
+            // Only 1 option, avoid prompting the user
+            item.GetGameInfoTag()->SetGameClient(candidates[0]->ID());
+          }
+          else
+          {
+            std::string gameClient = CGUIDialogSelectGameClient::ShowAndGetGameClient(
+                item.GetPath(), candidates, installable);
+
+            if (!gameClient.empty())
+              item.GetGameInfoTag()->SetGameClient(gameClient);
+          }
         }
       }
     }
@@ -200,9 +205,8 @@ bool CGameUtils::ChooseAndSetDefaultGameClient(const CFileItem& item)
   }
   else
   {
-    GameClientVector installable;
     bool bHasVfsGameClient = false;
-    GetGameClients(item, emulators, installable, bHasVfsGameClient);
+    GetInstalledGameClients(item, emulators, bHasVfsGameClient);
   }
 
   CGUIDialogSelect* dialog =
@@ -267,10 +271,9 @@ bool CGameUtils::ChooseAndSetDefaultGameClient(const CFileItem& item)
   return true;
 }
 
-void CGameUtils::GetGameClients(const CFileItem& file,
-                                GameClientVector& candidates,
-                                GameClientVector& installable,
-                                bool& bHasVfsGameClient)
+void CGameUtils::GetInstalledGameClients(const CFileItem& file,
+                                         GameClientVector& candidates,
+                                         bool& bHasVfsGameClient)
 {
   using namespace ADDON;
 
@@ -279,38 +282,57 @@ void CGameUtils::GetGameClients(const CFileItem& file,
   // Try to resolve path to a local file, as not all game clients support VFS
   CURL translatedUrl(CSpecialProtocol::TranslatePath(file.GetPath()));
 
-  // Get local candidates
   VECADDONS localAddons;
   CBinaryAddonCache& addonCache = CServiceBroker::GetBinaryAddonCache();
   addonCache.GetAddons(localAddons, AddonType::GAMEDLL);
 
-  bool bVfs = false;
-  GetGameClients(localAddons, translatedUrl, candidates, bVfs);
-  bHasVfsGameClient |= bVfs;
-
-  // Get remote candidates
-  VECADDONS remoteAddons;
-  if (CServiceBroker::GetAddonMgr().GetInstallableAddons(remoteAddons, AddonType::GAMEDLL))
-  {
-    GetGameClients(remoteAddons, translatedUrl, installable, bVfs);
-    bHasVfsGameClient |= bVfs;
-  }
+  GetGameClients(localAddons, translatedUrl, candidates, bHasVfsGameClient);
 
   // Sort by name
   //! @todo Move to presentation code
-  auto SortByName = [](const GameClientPtr& lhs, const GameClientPtr& rhs)
-  {
-    std::string lhsName = lhs->Name();
-    std::string rhsName = rhs->Name();
+  std::sort(candidates.begin(), candidates.end(),
+            [](const GameClientPtr& lhs, const GameClientPtr& rhs)
+            {
+              std::string lhsName = lhs->Name();
+              std::string rhsName = rhs->Name();
 
-    StringUtils::ToLower(lhsName);
-    StringUtils::ToLower(rhsName);
+              StringUtils::ToLower(lhsName);
+              StringUtils::ToLower(rhsName);
 
-    return lhsName < rhsName;
-  };
+              return lhsName < rhsName;
+            });
+}
 
-  std::sort(candidates.begin(), candidates.end(), SortByName);
-  std::sort(installable.begin(), installable.end(), SortByName);
+void CGameUtils::GetInstallableGameClients(const CFileItem& file,
+                                           GameClientVector& installable,
+                                           bool& bHasVfsGameClient)
+{
+  using namespace ADDON;
+
+  // Try to resolve path to a local file, as not all game clients support VFS
+  CURL translatedUrl(CSpecialProtocol::TranslatePath(file.GetPath()));
+
+  VECADDONS remoteAddons;
+  if (!CServiceBroker::GetAddonMgr().GetInstallableAddons(remoteAddons, AddonType::GAMEDLL))
+    return;
+
+  bool bVfs = false;
+  GetGameClients(remoteAddons, translatedUrl, installable, bVfs);
+  bHasVfsGameClient |= bVfs;
+
+  // Sort by name
+  //! @todo Move to presentation code
+  std::sort(installable.begin(), installable.end(),
+            [](const GameClientPtr& lhs, const GameClientPtr& rhs)
+            {
+              std::string lhsName = lhs->Name();
+              std::string rhsName = rhs->Name();
+
+              StringUtils::ToLower(lhsName);
+              StringUtils::ToLower(rhsName);
+
+              return lhsName < rhsName;
+            });
 }
 
 void CGameUtils::GetGameClients(const ADDON::VECADDONS& addons,

--- a/xbmc/games/GameUtils.h
+++ b/xbmc/games/GameUtils.h
@@ -103,10 +103,19 @@ private:
   static std::string GetDefaultGameClient(const std::string& path,
                                           const GameClientVector& candidates);
 
-  static void GetGameClients(const CFileItem& file,
-                             GameClientVector& candidates,
-                             GameClientVector& installable,
-                             bool& bHasVfsGameClient);
+  static void GetInstalledGameClients(const CFileItem& file,
+                                      GameClientVector& candidates,
+                                      bool& bHasVfsGameClient);
+
+  /*!
+   * \brief Get the game clients that could be installed to open a file
+   *
+   * Reads the whole add-on repository, so it is only worth asking once the
+   * installed clients have failed to answer the question.
+   */
+  static void GetInstallableGameClients(const CFileItem& file,
+                                        GameClientVector& installable,
+                                        bool& bHasVfsGameClient);
   static void GetGameClients(const ADDON::VECADDONS& addons,
                              const CURL& translatedUrl,
                              GameClientVector& candidates,


### PR DESCRIPTION
## Description

Opening a game gathers two lists: the game clients installed, and the ones that
*could* be installed. The second calls `CAddonMgr::GetInstallableAddons()`,
which loads every add-on from every repository out of the database before
filtering down to game clients.

Both were gathered up front, but an emulator remembered for the game answers the
question on its own — and where one exists the second list is never read. This
asks for it only once the installed clients have failed to answer.

Nothing is cached: where the list is needed it is still read fresh, so a client
installed from the selection dialog, or newly added to a repository, is seen
exactly as before.

## Motivation and context

Follow-up to the game open times raised in #29031.

## How has this been tested?

Linux desktop build (X11, `APP_RENDER_SYSTEM=gl`), master with and without this
commit, instrumented with a timing log around `GetInstallableAddons()`. Same
profile, same game, opened via `PlayMedia`:

| | repository loads per open |
|---|---|
| master | 1 (12–15 ms) |
| this PR, emulator remembered | **0** |
| this PR, no emulator remembered | 1 |

The game opens and renders in all three, and with nothing remembered the
selection dialog still offers the same choices.

`kodi-test`: 4066/4067. The one failure, `TestZipFile.BigRead64`, is
pre-existing and environmental — it needs a 5 GB fixture and fails the same way
on an unmodified tree here.

The saving scales with the repository catalogue, not the number of game clients,
since the whole catalogue is loaded before game clients are filtered out of it.
This profile has 805 add-ons known to its repository database.

## What is the effect on users?

Games open faster when opened with the emulator used last time, which is the
common case. No change to which emulators are offered.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [X] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
