### PR TITLE
fixed: establish the subtitle position from playback start, not the first line

### DIFF
--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.cpp
@@ -428,6 +428,9 @@ void CRenderer::PrepareOverlays(int idx)
   if (idx < 0 || idx >= NUM_BUFFERS)
     return;
 
+  SubtitleResolution resolution;
+  const bool updateStyle = UpdateSubtitleStyleAndPosition(resolution);
+
   bool doMarkDirty = false;
   bool hasImageSpu = false;
   for (auto& e : m_buffers[idx])
@@ -462,14 +465,6 @@ void CRenderer::PrepareOverlays(int idx)
     if (!ovAss.GetLibassHandler())
       continue;
 
-    bool updateStyle = !m_overlayStyle || m_isSettingsChanged;
-    if (updateStyle)
-    {
-      m_isSettingsChanged = false;
-      LoadSettings();
-      CreateSubtitlesStyle();
-    }
-
     // rOpts setup moved from CRenderer::ConvertLibass; duplicated in CDebugRenderer::CRenderer::Render.
     SUBTITLES::STYLE::renderOpts rOpts;
 
@@ -497,27 +492,7 @@ void CRenderer::PrepareOverlays(int idx)
         rOpts.sourceHeight = m_rs.Height() * 2;
     }
 
-    // Set position of subtitles based on video calibration settings
-    RESOLUTION_INFO resInfo = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
-    // Keep track of subtitle position value change,
-    // can be changed by GUI Calibration or by window mode/resolution change or
-    // by user manual change (e.g. keyboard shortcut)
-    if (m_subtitlePosResInfo != resInfo.iSubtitles)
-    {
-      if (m_subtitlePosResInfo == POSRESINFO_SAVE_CHANGES)
-      {
-        // m_subtitlePosition has been changed
-        // and has been requested to save the value to resInfo
-        resInfo.iSubtitles = m_subtitlePosition + m_subtitleVerticalMargin;
-        CServiceBroker::GetWinSystem()->GetGfxContext().SetResInfo(
-            CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution(), resInfo);
-        m_subtitlePosResInfo = m_subtitlePosition + m_subtitleVerticalMargin;
-      }
-      else
-        ResetSubtitlePosition();
-    }
-
-    rOpts.m_par = resInfo.fPixelRatio;
+    rOpts.m_par = resolution.pixelRatio;
 
     // rOpts.position and margins (set to style) can invalidate the text
     // positions to subtitles type that make use of margins to position text on
@@ -536,7 +511,7 @@ void CRenderer::PrepareOverlays(int idx)
       // match the bar, this calculation compensates for the displacement.
       // Note also that the displacement compensation will cause a different
       // default position of the text, different from the other alignment positions
-      double posPx = static_cast<double>(m_subtitlePosition - resInfo.Overscan.top);
+      double posPx = static_cast<double>(m_subtitlePosition - resolution.overscanTop);
 
       int assPlayResY = ovAss.GetLibassHandler()->GetPlayResY();
       double assVertMargin = static_cast<double>(m_overlayStyle->marginVertical) *
@@ -551,8 +526,8 @@ void CRenderer::PrepareOverlays(int idx)
     {
       // To keep consistent the position of text as other alignment positions
       // we avoid apply the displacement compensation
-      double posPx =
-          static_cast<double>(m_subtitlePosition + m_subtitleVerticalMargin - resInfo.Overscan.top);
+      double posPx = static_cast<double>(m_subtitlePosition + m_subtitleVerticalMargin -
+                                         resolution.overscanTop);
       rOpts.position = 100 - posPx / static_cast<double>(rOpts.frameHeight) * 100;
     }
     else if (m_subtitleAlign == SUBTITLES::Align::BOTTOM_INSIDE ||
@@ -581,6 +556,10 @@ void CRenderer::PrepareOverlays(int idx)
     int currentChange = 0;
     e.renderedImages = ovAss.GetLibassHandler()->RenderImage(e.pts, rOpts, updateStyle,
                                                              m_overlayStyle, &currentChange);
+    // A handler whose track is not built yet returns without applying the style, so the
+    // request has to stand.
+    if (e.renderedImages)
+      m_stylePendingApply = false;
     if (currentChange > 0)
     {
       // Persist on the overlay so a skipped GUI render does not drop the change.
@@ -701,4 +680,48 @@ void CRenderer::LoadSettings()
   m_subtitleHorizontalAlign = settings->GetHorizontalAlignment();
   m_subtitleAlign = settings->GetAlignment();
   ResetSubtitlePosition();
+}
+
+bool CRenderer::UpdateSubtitleStyleAndPosition(SubtitleResolution& resolution)
+{
+  if (!m_overlayStyle || m_isSettingsChanged)
+  {
+    m_isSettingsChanged = false;
+    m_stylePendingApply = true;
+    LoadSettings();
+    CreateSubtitlesStyle();
+  }
+
+  RESOLUTION_INFO resInfo = CServiceBroker::GetWinSystem()->GetGfxContext().GetResInfo();
+  resolution.pixelRatio = resInfo.fPixelRatio;
+  resolution.overscanTop = resInfo.Overscan.top;
+
+  // m_rv is set after this runs on the first frame of a playback.
+  if (m_subtitleAlign != SUBTITLES::Align::MANUAL && m_rv.IsEmpty())
+    return m_stylePendingApply;
+
+  // Keep track of subtitle position value change,
+  // can be changed by GUI Calibration or by window mode/resolution change or
+  // by user manual change (e.g. keyboard shortcut).
+  // ResetSubtitlePosition() records the calibration line for MANUAL, the frame height
+  // otherwise.
+  const int posResInfo = m_subtitleAlign == SUBTITLES::Align::MANUAL
+                             ? resInfo.iSubtitles
+                             : static_cast<int>(m_rv.Height());
+  if (m_subtitlePosResInfo != posResInfo)
+  {
+    if (m_subtitlePosResInfo == POSRESINFO_SAVE_CHANGES)
+    {
+      // m_subtitlePosition has been changed
+      // and has been requested to save the value to resInfo
+      resInfo.iSubtitles = m_subtitlePosition + m_subtitleVerticalMargin;
+      CServiceBroker::GetWinSystem()->GetGfxContext().SetResInfo(
+          CServiceBroker::GetWinSystem()->GetGfxContext().GetVideoResolution(), resInfo);
+      m_subtitlePosResInfo = m_subtitlePosition + m_subtitleVerticalMargin;
+    }
+    else
+      ResetSubtitlePosition();
+  }
+
+  return m_stylePendingApply;
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/OverlayRenderer.h
@@ -201,6 +201,20 @@ namespace OVERLAY {
      */
     void LoadSettings();
 
+    //! \brief The display values the overlays need
+    struct SubtitleResolution
+    {
+      float pixelRatio{1.0f};
+      int overscanTop{0};
+    };
+
+    /*!
+     * \brief Establish the subtitle style and position for the current frame.
+     * \param[out] resolution the display values read while doing so
+     * \return True if the style was rebuilt and must be re-applied to libass
+     */
+    bool UpdateSubtitleStyleAndPosition(SubtitleResolution& resolution);
+
     enum PositonResInfoState
     {
       POSRESINFO_UNSET = -1,
@@ -217,8 +231,8 @@ namespace OVERLAY {
     std::string m_stereomode;
     // Current subtitle position
     int m_subtitlePosition{0};
-    // Current subtitle position from resolution info,
-    // or PositonResInfoState enum values for deferred processing
+    // The calibration line for MANUAL alignment and the frame height otherwise,
+    // or a PositonResInfoState value for deferred processing
     int m_subtitlePosResInfo{POSRESINFO_UNSET};
     int m_subtitleVerticalMargin{0};
     bool m_saveSubtitlePosition{false}; // To save subtitle position permanently
@@ -228,6 +242,8 @@ namespace OVERLAY {
 
     std::shared_ptr<struct KODI::SUBTITLES::STYLE::style> m_overlayStyle;
     std::atomic<bool> m_isSettingsChanged{false};
+    // Set when the style is rebuilt, cleared once a libass handler has been given it.
+    bool m_stylePendingApply{false};
     // Whether last frame had any image/SPU overlay. Used by PrepareOverlays
     // to detect arrival/disappearance transitions (image/SPU have no
     // per-frame change signal of their own, unlike libass detect_change).

--- a/xbmc/cores/VideoSettings.cpp
+++ b/xbmc/cores/VideoSettings.cpp
@@ -57,10 +57,6 @@ bool CVideoSettings::operator!=(const CVideoSettings &right) const
   if (m_AudioStream != right.m_AudioStream) return true;
   if (m_SubtitleStream != right.m_SubtitleStream) return true;
   if (m_SubtitleDelay != right.m_SubtitleDelay) return true;
-  if (m_subtitleVerticalPosition != right.m_subtitleVerticalPosition)
-    return true;
-  if (m_subtitleVerticalPositionSave != right.m_subtitleVerticalPositionSave)
-    return true;
   if (m_SubtitleOn != right.m_SubtitleOn) return true;
   if (m_Brightness != right.m_Brightness) return true;
   if (m_Contrast != right.m_Contrast) return true;


### PR DESCRIPTION
**TL;DR:** Bug fix. The subtitle position was only computed once a subtitle line rendered, so until then the position slider read zero and any adjustment was discarded. Settings and position are now established every frame from playback start.

## Description
The subtitle position was only ever computed from inside `PrepareOverlays`' loop over the overlays being rendered. That loop skips everything until it reaches a text or SSA overlay with a libass handler, so with no subtitle line on screen neither the settings load nor the position calculation ran at all, and `m_subtitlePosition` kept its initial `0` with `m_subtitlePosResInfo` at `POSRESINFO_UNSET`.

`SubtitleShiftUp`/`SubtitleShiftDown` were therefore not inert — they were moving a baseline that had never been established. The position slider opened reading zero instead of the configured position, and whatever the user set was discarded as soon as the first line rendered and the real position was finally computed. With forced subtitles the first line can be many minutes in, which is where the reporter hit it.

Both halves move out of the loop into `UpdateSubtitleStyleAndPosition()`, called once at the top of `PrepareOverlays`. That runs every frame from `CRenderManager::FrameMove` regardless of what is on screen, so the position now exists from playback start.

They have to travel together: `LoadSettings()` sets the alignment that decides which baseline `ResetSubtitlePosition()` computes, and it consumes `m_isSettingsChanged`, so hoisting one without the other would leave the style never rebuilt.

**Two things worth a reviewer's attention.**

*The first call each playback lands before a video rect exists.* `CRenderManager::Render` supplies it after `FrameMove`, so on the first frame `m_rv` is still empty and the frame-relative alignments compute from zero. That self-corrects on the next frame: those alignments store `m_rv.Height()` in `m_subtitlePosResInfo`, which does not match `resInfo.iSubtitles`, so the guard stays true and recomputes. Measured at 13 ms — one frame. The calibration-relative (`MANUAL`) path does not use `m_rv` and is correct from the first call.

*`updateStyle` is now decided once per frame rather than per overlay.* When the style is rebuilt, every libass overlay in that frame now has it re-applied instead of only the first. This is a deliberate consequence of the hoist and looks like the more correct behaviour, but it is a change and I would rather flag it than have it found.

**A per-file settings row, and why `CVideoSettings::operator!=` changes here.**
Computing the position every frame made it non-default on every playback, and
`StoreVideoSettings` writes a per-file `settings` row whenever
`vs != GetDefaultVideoSettings()`. That comparison included
`m_subtitleVerticalPosition` and `m_subtitleVerticalPositionSave`.

Neither is a column in the `settings` table. They are never written and never read
back - the saved subtitle position persists through calibration, per resolution, not per
file. `operator!=` has one caller, that store-or-erase decision. So comparing those
two fields could never produce a correct store or a correct restore; its only reachable
effect was to turn an erase into a write, creating a `files` row and a `settings`
row. The mere existence of such a row sets `m_isDefaultVideoSettings = false`, which
`CVideoPlayer::OpenDefaultStreams` reads when deciding whether the language preference
may suppress a subtitle stream - so from the second play of a file, automatic subtitle
selection took a different branch.

Both fields are dropped from the comparison. **This is a behaviour change beyond the
reported bug and is deliberate:** on master today, any video that displays a text subtitle
already writes a spurious `settings` row for the same reason. That stops too.
Nothing is lost, because the position was never in the row to begin with.

Measured on the running application, same movie and profile, binaries identical except
`VideoSettings.cpp`. The title reports `"subtitles": []` - no subtitle streams at all:

| | `settings` rows | row for its `idFile` |
|---|---|---|
| with this change | 5 -> 5 | none |
| with the comparison restored | 5 -> 6 | created |

**Fixed after review.** Three defects the hoist exposed, all fixed here because running
the block every frame is what makes them reachable:

- the position guard compared `m_subtitlePosResInfo` against `resInfo.iSubtitles` for every alignment, but `ResetSubtitlePosition()` only stores that for `MANUAL`; the frame-relative ones store `m_rv.Height()`. They coincide only while a resolution is uncalibrated. Calibrated, the guard never matches and the position is recomputed every frame over an unsaved shift - which would have undercut this PR's own claim. The comparison now uses the value the active alignment records.
- `m_isSettingsChanged` was consumed on frames with no libass handler to receive it, so a style changed while subtitles were hidden never reached the handler afterwards. The rebuilt style is now held until a handler has been given it.
- that hold was then released whether or not the style had actually been applied. `CDVDSubtitlesLibass::RenderImage` returns early, before `ApplyStyle`, when the track is not built yet, so a handler that exists but is not ready consumed the request and lost the style - the exact failure the flag was added to prevent. It now clears only on a non-null return.

## Motivation and context
Fixes #24885.

## How has this been tested?
Verified against the running application on Windows with temporary instrumentation in `ResetSubtitlePosition` (not part of this diff), on two titles:

| | before playback | first frame | one frame later |
|---|---|---|---|
| probe fired | never | `pos=0 rvHeight=0` | `pos=1012 rvHeight=1064` |

The second title carries **no subtitle streams at all** (`Player.SetSubtitle` rejects every index), and the position is still established at playback start — that case could not reach `ResetSubtitlePosition` before this change. The value then settles rather than recomputing per frame.

Caveat on coverage: both titles I had to hand carry PGS (image) subtitles, so the libass text path was not exercised by a rendered line. The `updateStyle` change above therefore rests on the compile, the suite, and the fact that `m_overlayStyle` is guaranteed non-null before the loop exactly as it was before.

**A correction to the testing above.** The "settles rather than recomputing per frame" claim held only because this machine is uncalibrated and both values are 1064, so the run could not distinguish them. That the fixed guard settles for any `iSubtitles` follows from both sides now being the same expression for the frame-relative alignments - a code-level argument, not an observed one. The divergent case cannot be produced here: the windowed resolution forces `iSubtitles = iHeight` in `CWinSystemBase::UpdateResolutions`.

Full gtest suite: 4041 tests, all passing. `clang-format` clean on every changed line.

## What is the effect on users?
The subtitle position slider shows the configured position from the start of playback, and a shift made before the first subtitle line appears is kept.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed

---

Written with AI assistance; reviewed and tested by me before submitting.

