### PR TITLE
fixed: check remote access permission before opening a file for a content provider

### DIFF
--- a/xbmc/platform/android/activity/JNIXBMCFile.cpp
+++ b/xbmc/platform/android/activity/JNIXBMCFile.cpp
@@ -51,6 +51,9 @@ jboolean CJNIXBMCFile::_open(JNIEnv *env, jobject thiz, jstring path)
   if (find_instance(thiz))
     return false;
 
+  if (!CFileUtils::CheckFileAccessAllowed(strPath))
+    return false;
+
   if (!XFILE::CFile::Exists(strPath))
     return false;
 


### PR DESCRIPTION
**TL;DR:** Security fix, Android. Any app on the device could read any file Kodi can read by naming it in a `content://` URI, because the content provider only checked that the path exists. It now applies the same remote-access check as JSON-RPC and UPnP.

## Description
`XBMCFileContentProvider.openFile()` takes the path from the content URI's fragment and passes it to `XBMCFile.Open()`, which lands in `CJNIXBMCFile::_open`. That only checked the file exists, so any application on the device could read any path the Kodi process can read by naming it in a `content://` URI, without holding an Android permission of its own.

`CFileUtils::RemoteAccessAllowed` is the predicate the other two surfaces that serve files to callers outside Kodi already apply — JSON-RPC's `Files` methods (`FileOperations.cpp`) and the UPnP server (`UPnPServer.cpp`) — and it limits a request to paths reachable from the user's configured sources. This applies the same check on the content provider path.

The check is placed before the existence test, so a path outside the sources is refused without revealing whether it exists.

`utils/FileUtils.h` was already included in the file, so the change is the call itself.

## Motivation and context
Fixes #28479.

## How has this been tested?
`clang-format` clean on the changed range. This file builds only for Android and I have no device, so it has not been compiled or run — the change is one call to a function already declared in an included header, and the reasoning above is what it rests on. Someone with an Android build should confirm before this merges.

## What is the effect on users?
On Android, other apps can only read files under the user's configured sources through Kodi's content provider, not arbitrary files.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
