### PR TITLE
changed: install the python modules that can use pip with pip

### DIFF
--- a/tools/depends/native/Mako/Makefile
+++ b/tools/depends/native/Mako/Makefile
@@ -12,7 +12,7 @@ all: .installed-$(PLATFORM)
 	touch $@
 
 .installed-$(PLATFORM): .configured-$(PLATFORM)
-	cd $(PLATFORM); $(PREFIX)/bin/python3 setup.py install --prefix=$(PREFIX)
+	cd $(PLATFORM); $(PREFIX)/bin/python3 -m pip install --no-deps --no-build-isolation --prefix=$(PREFIX) .
 	touch $@
 
 clean:

--- a/tools/depends/native/MarkupSafe/Makefile
+++ b/tools/depends/native/MarkupSafe/Makefile
@@ -14,7 +14,7 @@ all: .installed-$(PLATFORM)
 
 .installed-$(PLATFORM): .configured-$(PLATFORM)
 	cd $(PLATFORM); patch -p1 -i ../01-all-GH399-removedistutils.patch
-	cd $(PLATFORM); $(PREFIX)/bin/python3 setup.py install --prefix=$(PREFIX)
+	cd $(PLATFORM); $(PREFIX)/bin/python3 -m pip install --no-deps --no-build-isolation --prefix=$(PREFIX) .
 	touch $@
 
 clean:

--- a/tools/depends/native/meson/Makefile
+++ b/tools/depends/native/meson/Makefile
@@ -8,12 +8,10 @@ all: .installed-$(PLATFORM)
 .configured-$(PLATFORM): $(DEPS) | $(TARBALLS_LOCATION)/$(ARCHIVE).$(HASH_TYPE)
 	rm -rf $(PLATFORM)/*; mkdir -p $(PLATFORM)
 	cd $(PLATFORM); $(ARCHIVE_TOOL) $(ARCHIVE_TOOL_FLAGS) $(TARBALLS_LOCATION)/$(ARCHIVE)
-	cd $(PLATFORM); $(NATIVEPREFIX)/bin/python3 setup.py config
 	touch $@
 
 .installed-$(PLATFORM): .configured-$(PLATFORM)
-	cd $(PLATFORM); $(NATIVEPREFIX)/bin/python3 setup.py build
-	cd $(PLATFORM); $(NATIVEPREFIX)/bin/python3 setup.py install --prefix="$(NATIVEPREFIX)"
+	cd $(PLATFORM); $(NATIVEPREFIX)/bin/python3 -m pip install --no-deps --no-build-isolation --prefix="$(NATIVEPREFIX)" .
 	touch $@
 
 clean:

--- a/tools/depends/target/pythonmodule-setuptools/Makefile
+++ b/tools/depends/target/pythonmodule-setuptools/Makefile
@@ -11,7 +11,7 @@ all: .installed-$(PLATFORM)
 	touch $@
 
 .installed-$(PLATFORM): .configured-$(PLATFORM)
-	cd $(PLATFORM); PYTHONPATH="$(PYTHON_SITE_PKG)" $(NATIVEPREFIX)/bin/python3 setup.py install --prefix=$(PREFIX)
+	cd $(PLATFORM); PYTHONPATH="$(PYTHON_SITE_PKG)" $(NATIVEPREFIX)/bin/python3 -m pip install --no-deps --no-build-isolation --prefix=$(PREFIX) .
 	find $(PYTHON_SITE_PKG)/*setuptools* -type f -name "*.exe" -exec rm -f {} \;
 	touch $@
 


### PR DESCRIPTION
**TL;DR:** Bug fix, depends. Four depends recipes that ran the deprecated `setup.py install` now install with pip, silencing the `SetuptoolsDeprecationWarning` on every build. PIL and pycryptodome are left alone because their artifacts and cross-compile flags would have to change with them.

## Description
`setup.py install` has been deprecated by setuptools for some time and prints a `SetuptoolsDeprecationWarning` on every depends build. Four of the six call sites take a plain `setup.py install --prefix`, which `python3 -m pip install --prefix … .` replaces directly. That is the form `native/pythonmodule-pybind11` and `native/pythonmodule-setuptools` already use.

- `native/Mako`
- `native/MarkupSafe`
- `native/meson` — its separate `setup.py config` and `setup.py build` steps go too, since pip builds the project itself
- `target/pythonmodule-setuptools`

`--no-build-isolation` keeps pip from fetching a build backend, since depends builds the native setuptools it needs beforehand; `--no-deps` keeps it from resolving anything from the index.

**Not converted: `pythonmodule-pil` and `pythonmodule-pycryptodome`** — the two named in the report. pil runs `setup.py build build_py build_ext $(BUILD_OPTS) install --install-lib $(PILPATH) bdist_egg` and the Android and webOS branches then `unzip` the resulting `.egg`; pip produces a wheel, so the artifact and both unpacking steps have to change together. pycryptodome needs `build_ext --plat-name $(OS)-$(CPU)` for the cross-compile. Neither converts without changing what is produced, and neither can be tested without those devices, so this PR leaves them alone.

## Motivation and context
Addresses #28676 in part.

## How has this been tested?
In a container against the pinned versions. Mako installs an identical 33-file module tree either way and the deprecation warning goes from 1 to 0.

MarkupSafe installs one file fewer, which looks like a regression and is not: `setup.py install` produces an *egg*, and setuptools writes a `markupsafe/_speedups.py` bootstrap into it that loads the compiled extension through `pkg_resources`. pip installs the ordinary layout and imports the `.so` directly. The extension is present either way, so the module gains nothing and sheds a `pkg_resources` dependency.

## What is the effect on users?
None. Build-system change to the depends tree only.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
