### PR TITLE
fixed: apply the deadline CUPnPPlayer sets on a renderer action

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -11,6 +11,7 @@ xbmc/cores/VideoPlayer/DVDDemuxers/test test/dvddemuxers
 xbmc/cores/VideoPlayer/Edl/test   test/edl
 xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/test test/videoshaders
 xbmc/dbwrappers/test              test/dbwrappers
+xbmc/dialogs/test                 test/dialogs
 xbmc/filesystem/test              test/filesystem
 xbmc/filesystem/VideoDatabaseDirectory/test test/videodatabasedirectory
 xbmc/games/addons/cheevos/test    test/games/addons/cheevos

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -12,8 +12,12 @@
 #include "guilib/GUIComponent.h"
 #include "guilib/GUIWindowManager.h"
 #include "threads/IRunnable.h"
+#include "threads/SystemClock.h"
 #include "threads/Thread.h"
 #include "utils/log.h"
+
+#include <algorithm>
+#include <optional>
 
 using namespace std::chrono_literals;
 
@@ -71,11 +75,27 @@ bool CGUIDialogBusy::Wait(IRunnable *runnable, unsigned int displaytime, bool al
   return true;
 }
 
-bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 100 */, bool allowCancel /* = true */)
+bool CGUIDialogBusy::WaitOnEvent(CEvent& event,
+                                 unsigned int displaytime /* = 100 */,
+                                 bool allowCancel /* = true */,
+                                 std::optional<std::chrono::milliseconds> timeout /* = {} */)
 {
+  XbmcThreads::EndTime<> deadline;
+  if (timeout)
+    deadline.Set(*timeout);
+
+  const auto initialWait{timeout ? std::min(std::chrono::milliseconds(displaytime), *timeout)
+                                 : std::chrono::milliseconds(displaytime)};
+
   bool cancelled = false;
-  if (!event.Wait(std::chrono::milliseconds(displaytime)))
+  bool timedout = false;
+  if (!event.Wait(initialWait))
   {
+    // Nothing below can change the answer once the deadline has passed, and the dialog is not
+    // worth looking up to abandon it.
+    if (timeout && deadline.IsTimePast())
+      return false;
+
     auto* dialog = static_cast<CGUIDialogBusy*>(
         CServiceBroker::GetGUI()->GetWindowManager().GetWindow(WINDOW_DIALOG_BUSY));
     if (dialog)
@@ -95,6 +115,11 @@ bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 10
           cancelled = true;
           break;
         }
+        if (timeout && deadline.IsTimePast())
+        {
+          timedout = true;
+          break;
+        }
       }
 
       if (--dialog->m_waiters == 0)
@@ -103,8 +128,12 @@ bool CGUIDialogBusy::WaitOnEvent(CEvent &event, unsigned int displaytime /* = 10
         dialog->ProcessRenderLoop(false); // Force repaint.
       }
     }
+    else if (timeout)
+    {
+      timedout = !event.Wait(deadline.GetTimeLeft());
+    }
   }
-  return !cancelled;
+  return !cancelled && !timedout;
 }
 
 CGUIDialogBusy::CGUIDialogBusy(void)

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -10,7 +10,9 @@
 
 #include "guilib/GUIDialog.h"
 
+#include <chrono>
 #include <cstdint>
+#include <optional>
 
 class IRunnable;
 class CEvent;
@@ -35,9 +37,13 @@ public:
    \param event the CEvent to wait on.
    \param displaytime the time in ms to wait prior to showing the busy dialog (defaults to 100ms)
    \param allowCancel whether the user can cancel the wait, defaults to true.
-   \return true if the event completed, false if cancelled.
+   \param timeout how long to wait for the event, or wait indefinitely if unset.
+   \return true if the event completed, false if it was cancelled or timed out.
    */
-  static bool WaitOnEvent(CEvent &event, unsigned int displaytime = 100, bool allowCancel = true);
+  static bool WaitOnEvent(CEvent& event,
+                          unsigned int displaytime = 100,
+                          bool allowCancel = true,
+                          std::optional<std::chrono::milliseconds> timeout = {});
 
 private:
   CGUIDialogBusy();

--- a/xbmc/dialogs/test/CMakeLists.txt
+++ b/xbmc/dialogs/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(SOURCES TestGUIDialogBusy.cpp)
+set(HEADERS)
+
+core_add_test_library(dialogs_test)

--- a/xbmc/dialogs/test/TestGUIDialogBusy.cpp
+++ b/xbmc/dialogs/test/TestGUIDialogBusy.cpp
@@ -1,0 +1,213 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ServiceBroker.h"
+#include "dialogs/GUIDialogBusy.h"
+#include "guilib/GUIComponent.h"
+#include "guilib/GUIWindowManager.h"
+#include "rendering/RenderSystem.h"
+#include "threads/Event.h"
+#include "windowing/WinSystem.h"
+
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+// Every test here keeps the timeout at or under displaytime, so the wait is answered before the
+// busy dialog is looked up. That lookup needs a GUI component and a windowing system, and the test
+// environment registers neither. Raising the timeout past this would crash rather than fail.
+constexpr unsigned int DISPLAY_TIME{5000};
+
+std::chrono::milliseconds Elapsed(const std::chrono::steady_clock::time_point start)
+{
+  return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+                                                               start);
+}
+
+// Enough of a windowing system for CGUIWindowManager::GetWindow, which takes the graphics context
+// lock. Duplicated from xbmc/guilib/test/TestGUIWindowOnAction.cpp rather than shared, to keep this
+// change to the files it already touches.
+class CTestRenderSystem : public CRenderSystemBase
+{
+public:
+  bool InitRenderSystem() override { return true; }
+  bool DestroyRenderSystem() override { return true; }
+  bool ResetRenderSystem(int width, int height) override { return true; }
+  bool BeginRender() override { return true; }
+  bool EndRender() override { return true; }
+  void PresentRender(bool rendered, bool videoLayer) override {}
+  bool ClearBuffers(KODI::UTILS::COLOR::Color color) override { return true; }
+  bool IsExtSupported(const char* extension) const override { return false; }
+  void SetViewPort(const CRect& viewPort) override {}
+  void GetViewPort(CRect& viewPort) override {}
+  void SetScissors(const CRect& rect) override {}
+  void ResetScissors() override {}
+  void CaptureStateBlock() override {}
+  void ApplyStateBlock() override {}
+  void SetCameraPosition(const CPoint& camera,
+                         int screenWidth,
+                         int screenHeight,
+                         float stereoFactor) override
+  {
+  }
+};
+
+class CTestWinSystem : public CWinSystemBase
+{
+public:
+  CRenderSystemBase* GetRenderSystem() override { return &m_renderSystem; }
+  bool CreateNewWindow(const std::string& name, bool fullScreen, RESOLUTION_INFO& res) override
+  {
+    return true;
+  }
+  bool ResizeWindow(int newWidth, int newHeight, int newLeft, int newTop) override { return true; }
+  bool SetFullScreen(bool fullScreen, RESOLUTION_INFO& res, bool blankOtherDisplays) override
+  {
+    return true;
+  }
+  void Register(IDispResource* resource) override {}
+  void Unregister(IDispResource* resource) override {}
+
+private:
+  CTestRenderSystem m_renderSystem;
+};
+
+// A GUI carrying nothing but an empty window manager, so the busy dialog is looked up and not
+// found - the branch a caller reaches when the dialog is unavailable.
+class CTestGUIComponent : public CGUIComponent
+{
+public:
+  CTestGUIComponent() : CGUIComponent(false)
+  {
+    m_pWindowManager = std::make_unique<CGUIWindowManager>();
+    CServiceBroker::RegisterGUI(this);
+  }
+};
+} // unnamed namespace
+
+TEST(TestGUIDialogBusy, ATimeoutEndsTheWait)
+{
+  CEvent event;
+  const auto start{std::chrono::steady_clock::now()};
+
+  EXPECT_FALSE(CGUIDialogBusy::WaitOnEvent(event, DISPLAY_TIME, true, 200ms));
+
+  // the wait ends on its own deadline rather than running on to displaytime
+  const auto elapsed{Elapsed(start)};
+  EXPECT_GE(elapsed, 200ms);
+  EXPECT_LT(elapsed, 1000ms);
+}
+
+TEST(TestGUIDialogBusy, AZeroTimeoutEndsTheWaitAtOnce)
+{
+  CEvent event;
+  const auto start{std::chrono::steady_clock::now()};
+
+  EXPECT_FALSE(CGUIDialogBusy::WaitOnEvent(event, DISPLAY_TIME, true, 0ms));
+
+  EXPECT_LT(Elapsed(start), 200ms);
+}
+
+TEST(TestGUIDialogBusy, AnEventArrivingBeforeTheTimeoutIsNotATimeout)
+{
+  CEvent event;
+  std::thread setter(
+      [&event]()
+      {
+        std::this_thread::sleep_for(30ms);
+        event.Set();
+      });
+
+  const auto start{std::chrono::steady_clock::now()};
+
+  // the deadline is armed and must not be what ends this wait
+  EXPECT_TRUE(CGUIDialogBusy::WaitOnEvent(event, DISPLAY_TIME, true, 500ms));
+  EXPECT_LT(Elapsed(start), 500ms);
+
+  setter.join();
+}
+
+TEST(TestGUIDialogBusy, AnEventAlreadySetNeverWaits)
+{
+  CEvent event;
+  event.Set();
+
+  const auto start{std::chrono::steady_clock::now()};
+  EXPECT_TRUE(CGUIDialogBusy::WaitOnEvent(event, DISPLAY_TIME, true, 200ms));
+  EXPECT_LT(Elapsed(start), 200ms);
+}
+
+TEST(TestGUIDialogBusy, AZeroTimeoutStillSeesAnEventAlreadySet)
+{
+  CEvent event;
+  event.Set();
+
+  EXPECT_TRUE(CGUIDialogBusy::WaitOnEvent(event, DISPLAY_TIME, true, 0ms));
+}
+
+TEST(TestGUIDialogBusy, AnUnsetTimeoutIsNotEndedByADeadline)
+{
+  CEvent event;
+  std::thread setter(
+      [&event]()
+      {
+        std::this_thread::sleep_for(50ms);
+        event.Set();
+      });
+
+  // the three argument form every other caller uses
+  EXPECT_TRUE(CGUIDialogBusy::WaitOnEvent(event, DISPLAY_TIME, true));
+
+  setter.join();
+}
+
+TEST(TestGUIDialogBusy, ATimeoutEndsTheWaitWithNoBusyDialogToShow)
+{
+  CTestWinSystem winSystem;
+  CServiceBroker::RegisterWinSystem(&winSystem);
+  {
+    CTestGUIComponent gui;
+
+    CEvent event;
+    const auto start{std::chrono::steady_clock::now()};
+
+    // longer than displaytime, so the dialog is looked up: without one, master returned at once
+    // and reported the event had arrived
+    EXPECT_FALSE(CGUIDialogBusy::WaitOnEvent(event, 100, true, 400ms));
+    EXPECT_GE(Elapsed(start), 400ms);
+  }
+  CServiceBroker::UnregisterWinSystem();
+}
+
+TEST(TestGUIDialogBusy, AnEventArrivesWithNoBusyDialogToShow)
+{
+  CTestWinSystem winSystem;
+  CServiceBroker::RegisterWinSystem(&winSystem);
+  {
+    CTestGUIComponent gui;
+
+    CEvent event;
+    std::thread setter(
+        [&event]()
+        {
+          std::this_thread::sleep_for(150ms);
+          event.Set();
+        });
+
+    EXPECT_TRUE(CGUIDialogBusy::WaitOnEvent(event, 100, true, 2000ms));
+
+    setter.join();
+  }
+  CServiceBroker::UnregisterWinSystem();
+}

--- a/xbmc/network/upnp/UPnPPlayer.cpp
+++ b/xbmc/network/upnp/UPnPPlayer.cpp
@@ -198,7 +198,7 @@ static NPT_Result WaitOnEvent(CEvent& event, XbmcThreads::EndTime<>& timeout)
   if (event.Wait(0ms))
     return NPT_SUCCESS;
 
-  if (!CGUIDialogBusy::WaitOnEvent(event))
+  if (!CGUIDialogBusy::WaitOnEvent(event, 100, true, timeout.GetTimeLeft()))
     return NPT_FAILURE;
 
   return NPT_SUCCESS;
@@ -351,7 +351,15 @@ int CUPnPPlayer::PlayFile(const CFileItem& file,
     NPT_CHECK_LABEL_SEVERE(
         m_control->GetTransportInfo(m_delegate->m_device, m_delegate->m_instance, m_delegate.get()),
         failed_waitplaying);
-    NPT_CHECK_LABEL_SEVERE(WaitOnEvent(m_delegate->m_traevnt, timeout), failed_waitplaying);
+    if (NPT_FAILED(WaitOnEvent(m_delegate->m_traevnt, timeout)))
+    {
+      // Reaching the deadline ends this loop, it does not fail the open - that is what the loop
+      // condition below did before the wait honoured a deadline of its own. A wait that ends
+      // while the deadline is still live is the user cancelling.
+      if (timeout.IsTimePast())
+        break;
+      goto failed_waitplaying;
+    }
 
     const NPT_String transportStatus = m_delegate->GetTransportStatus();
     const NPT_String transportState = m_delegate->GetTransportState();


### PR DESCRIPTION
**TL;DR:** Bug fix. `CUPnPPlayer` builds a ten second deadline for the actions it sends a renderer and passes it into a wrapper that ignores it, so a stalled renderer costs at least sixty seconds behind a modal busy dialog — Platinum's own HTTP timeout — instead of ten. `CGUIDialogBusy::WaitOnEvent` now honours a timeout.

## Description
`CGUIDialogBusy::WaitOnEvent` ends when the event is signalled or the user cancels. `CUPnPPlayer` waits on it after six of the actions it sends a renderer, and `OpenFile` constructs an `XbmcThreads::EndTime<>` of ten seconds that each of those sites resets before waiting — a deadline that was then passed into a wrapper which never looked at it.

That deadline is not entirely without effect today: it bounds the loop that waits for the transport to reach `PLAYING`. It has no effect on the busy wait itself, which is where a stalled renderer is actually waited on.

### What happens without this

An earlier revision of this PR claimed the open wedges until somebody cancels the dialog. That was wrong, and thanks to @reardonia for catching it.

Platinum gives its HTTP client a sixty second connection, IO and name-resolver timeout in `PLT_HttpClientSocketTask`, so a renderer that accepts an action and never answers fails the SOAP call there. `PLT_CtrlPoint::ProcessActionResponse` still applies the listener with that failure, the delegate sets the event, and the wait ends. Sixty seconds is the timeout for one attempt rather than a ceiling: Neptune retries the request once when the connection came from the pool, so two attempts, against the ten seconds the player asked for.

### The change

`CGUIDialogBusy::WaitOnEvent` takes an optional timeout:

* the initial wait is clamped to `min(displaytime, timeout)`, so a deadline shorter than `displaytime` cannot be overshot before the dialog would appear
* a deadline that has already passed is answered there, rather than looking a dialog up only to abandon it
* the wait loop ends on the deadline as it already ends on cancel, checked once per pass, so any overshoot is bounded by a render pass
* where there is no busy dialog to show, the deadline is now waited out. That path previously returned `true` as soon as `displaytime` had passed, reporting an event that had not arrived
* a timeout is reported the way a cancel is, since to every caller both mean the event did not arrive

The timeout is unset by default, and with it unset the function is equivalent to what it replaces, so the seven other call sites across six functions are unchanged.

`CUPnPPlayer` passes what is left of its deadline. **Reaching that deadline inside the wait for `PLAYING` ends the loop rather than failing the open.** The loop is already written to end on that deadline, and `m_stopremote` is only set once `PlayFile` returns, so failing there would leave a renderer that had just been told to play running with nothing attached.

**This changes what a renderer that accepts `Play` and then stops answering reports.** On master the wait ran on to Platinum's own timeout, `OnGetTransportInfoResult` was applied with that failure and wrote `STOPPED` / `ERROR_OCCURED`, and the loop returned failure on reading them. Now the wait ends at the deadline with the reply still outstanding, the loop breaks on the transport info from the previous pass, and the open is reported as started until the late `STOPPED` arrives.

## Motivation and context
Found while working on #29130, but independent of it — that issue's fix is #29132 and the two do not overlap.

The per-action userdata work that was previously in this PR has moved to #29219, on @reardonia's suggestion.

## How has this been tested?
`TestGUIDialogBusy`, eight cases in a new `xbmc/dialogs/test`:

* a timeout ends the wait at its deadline rather than at `displaytime`
* a zero timeout ends it at once, and still reports an event that is already set
* an event arriving before the deadline returns true, with the deadline armed so a wrongly firing timeout fails the test
* an event already set never waits
* an unset timeout — the three argument form every other caller uses — is not ended by a deadline
* with no busy dialog to show, a timeout still ends the wait, and an event arriving still returns true

**Not covered:** the branch that opens the dialog. Reaching it needs a window manager holding a real `CGUIDialogBusy`, which the test environment cannot construct. The no-dialog branch is covered by registering a stub windowing system and a GUI component with an empty window manager; that stub is copied from `xbmc/guilib/test/TestGUIWindowOnAction.cpp` rather than shared, to keep this change to the files it already touches.

The sixty second figure is read from the source rather than timed: `PLT_HttpClientSocketTask` sets it, and the `failure:` label in `PLT_CtrlPoint::ProcessActionResponse` is what still delivers the callback that ends the wait.

Full gtest suite passes. clang-format clean on the changed lines.

## What is the effect on users?
Playing to a renderer that stops answering fails after ten seconds instead of sixty or more, so Kodi spends far less time behind a busy dialog before reporting the failure. A renderer that is merely slow to start playing is unaffected. The exception is a renderer that goes silent after accepting `Play`: that open is now reported as started at the deadline, rather than failed a minute later.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed

