### PR TITLE
fixed: keep a top-level special:// start directory in the navigation history

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1489,6 +1489,10 @@ void CGUIMediaWindow::SetHistoryForPath(const std::string& strDirectory)
       strPath = strParentPath;
       URIUtils::RemoveSlashAtEnd(strPath);
     }
+
+    // A directory without a parent, such as a top-level special:// path, still goes on the stack
+    if (originalPath)
+      m_history.AddPathFront(strDirectory, m_strFilterPath);
   }
   else
     m_history.ClearPathHistory();


### PR DESCRIPTION
**TL;DR:** Bug fix. Opening a window with `return` on a top-level `special://` directory such as the playlists folder wiped that directory from the navigation history, so back from a playlist landed on the root. `SetHistoryForPath` now keeps the directory itself when it has no derivable parent.

## Description
With `return`, `CGUIMediaWindow::OnInitWindow` rebuilds the history from the start directory *after* `Refresh()` has listed it, by calling `SetHistoryForPath`. That function clears the history and only pushes the directory inside its `URIUtils::GetParentPath` loop. `GetParentPath` returns false for a top-level `special://` path, so for `special://musicplaylists/` the loop never runs and the entry `Refresh()` had just pushed is wiped. Opening a playlist then pushes only the playlist, and `GoParentFolder` finds nothing above it but the root.

`musicdb://albums/` survives because its parent resolves to `musicdb://`, so the rebuilt history is equivalent to what `Refresh()` pushed. Without `return` the rebuild runs in `WINDOW_INIT` before `Refresh()`, which re-pushes the entry afterwards — hence the reporter's "works without return".

`SetHistoryForPath` pushes the directory itself when the loop pushed nothing. Paths with a derivable parent are unchanged.

## Motivation and context
Fixes #20134.

`ActivateWindow(music,special://musicplaylists/,return)`, open a playlist, press back: Kodi lands on the music root instead of the playlists folder, then on home. Without `return` the same sequence goes playlist → playlists → root → home, and a `musicdb://` start directory behaves correctly with `return`. Video playlists are affected the same way. Reported on 19.1, confirmed by @kiboy6 on Nexus and Omega, and reproduced here on master.

## How has this been tested?
Driven over JSON-RPC on Windows (`GUI.ActivateWindow` + `Input.*`), reading `Container.FolderPath` after each back, with one `.m3u` in the profile's playlists folder:

| activation | before | after |
|---|---|---|
| `music, special://musicplaylists/, return` | playlist → **root** → home | playlist → playlists → home |
| `music, special://musicplaylists/` (no return) | playlist → playlists → root → home | unchanged |
| `videos, special://videoplaylists/, return` | — | playlist → playlists → home |

The `..` item inside the playlist also changed from the root to `special://musicplaylists/`.

Full gtest suite: 4041 tests, all passing. `clang-format` clean on the changed lines.

## What is the effect on users?
Back from a playlist opened through a skin's `ActivateWindow(..., return)` shortcut returns to the playlists folder rather than the library root.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed

---

Written with AI assistance; reviewed and tested by me before submitting.
