### PR TITLE
[AE] Fix ALSA error recovery and add BitstreamPacker unit tests (rebase of #28115)

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -1,6 +1,7 @@
 xbmc/addons/gui/skin/test         test/skin
 xbmc/addons/test                  test/addons
 xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
+xbmc/cores/AudioEngine/Utils/test test/audioengine_utils
 xbmc/cores/RetroPlayer/playback/test test/retroplayer_playback
 xbmc/cores/RetroPlayer/rendering/test test/retroplayer_rendering
 xbmc/cores/RetroPlayer/savestates/test test/retroplayer_savestates

--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
@@ -979,6 +979,9 @@ void CAESinkALSA::HandleError(const char* name, int err)
     default:
       CLog::Log(LOGERROR, "CAESinkALSA::HandleError({}) - snd_pcm_writei returned {} ({})", name,
                 err, snd_strerror(err));
+      if ((err = snd_pcm_prepare(m_pcm)) < 0)
+        CLog::Log(LOGERROR, "CAESinkALSA::HandleError({}) - snd_pcm_prepare returned {} ({})", name,
+                  err, snd_strerror(err));
       break;
   }
 }

--- a/xbmc/cores/AudioEngine/Utils/test/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/Utils/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestAEBitstreamPacker.cpp)
+
+core_add_test_library(audioengine_utils_test)

--- a/xbmc/cores/AudioEngine/Utils/test/TestAEBitstreamPacker.cpp
+++ b/xbmc/cores/AudioEngine/Utils/test/TestAEBitstreamPacker.cpp
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/AudioEngine/Utils/AEBitstreamPacker.h"
+#include "cores/AudioEngine/Utils/AEStreamInfo.h"
+
+#include <gtest/gtest.h>
+
+TEST(TestAEBitstreamPacker, TrueHDOutputRate192kAt48k)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_TRUEHD;
+  info.m_sampleRate = 48000;
+  EXPECT_EQ(192000u, CAEBitstreamPacker::GetOutputRate(info));
+}
+
+TEST(TestAEBitstreamPacker, TrueHDOutputRate192kAt96k)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_TRUEHD;
+  info.m_sampleRate = 96000;
+  EXPECT_EQ(192000u, CAEBitstreamPacker::GetOutputRate(info));
+}
+
+TEST(TestAEBitstreamPacker, TrueHDOutputRate176kAt44k)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_TRUEHD;
+  info.m_sampleRate = 44100;
+  EXPECT_EQ(176400u, CAEBitstreamPacker::GetOutputRate(info));
+}
+
+TEST(TestAEBitstreamPacker, TrueHDOutputChannels8)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_TRUEHD;
+  CAEChannelInfo channels = CAEBitstreamPacker::GetOutputChannelMap(info);
+  EXPECT_EQ(8u, channels.Count());
+}
+
+TEST(TestAEBitstreamPacker, DTSHDMAOutputRate192k)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD_MA;
+  info.m_sampleRate = 48000;
+  EXPECT_EQ(192000u, CAEBitstreamPacker::GetOutputRate(info));
+}
+
+TEST(TestAEBitstreamPacker, DTSHDMAOutputChannels8)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD_MA;
+  CAEChannelInfo channels = CAEBitstreamPacker::GetOutputChannelMap(info);
+  EXPECT_EQ(8u, channels.Count());
+}
+
+TEST(TestAEBitstreamPacker, AC3OutputChannels2)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_AC3;
+  CAEChannelInfo channels = CAEBitstreamPacker::GetOutputChannelMap(info);
+  EXPECT_EQ(2u, channels.Count());
+}
+
+TEST(TestAEBitstreamPacker, EAC3OutputRate192kAt48k)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_EAC3;
+  info.m_sampleRate = 48000;
+  EXPECT_EQ(192000u, CAEBitstreamPacker::GetOutputRate(info));
+}
+
+TEST(TestAEBitstreamPacker, DTS512OutputChannels2)
+{
+  CAEStreamInfo info;
+  info.m_type = CAEStreamInfo::STREAM_TYPE_DTS_512;
+  CAEChannelInfo channels = CAEBitstreamPacker::GetOutputChannelMap(info);
+  EXPECT_EQ(2u, channels.Count());
+}


### PR DESCRIPTION
**TL;DR:** Bug fix, carried rebase of #28115. ALSA now recovers the PCM after any write error, not only `-EPIPE` and `-ESTRPIPE`, and the bitstream packer's output rate and channel map gain nine unit tests.

## Description
Rebase of #28115 by @nunogt onto current master, carried so it can make RC1. The commit keeps his authorship.

The `AESinkALSA.cpp` change is his, byte for byte. Everything else the commit carries beyond the rebase itself was done here, and is listed so it is not read as his:

- the copyright year on the new test file (2025 -> 2026);
- in `TestAEBitstreamPacker.cpp`, dropping `info.m_sampleRate = 0;` from the four channel-map tests (the function under test does not read it), putting the `EXPECT_EQ` arguments in expected/actual order, and renaming `EAC3OutputRate4x` to `EAC3OutputRate192kAt48k`.

Changes:

- `CAESinkALSA::HandleError()`: call `snd_pcm_prepare()` in the `default` branch too, so an error `snd_pcm_writei` reports that is neither `-EPIPE` nor `-ESTRPIPE` leaves the PCM in a state the next write can use, the same recovery the other two branches already perform.
- New `xbmc/cores/AudioEngine/Utils/test/TestAEBitstreamPacker.cpp` with nine tests over `CAEBitstreamPacker::GetOutputRate()` and `GetOutputChannelMap()` for TrueHD, DTS-HD MA, EAC3, AC3 and DTS, registered as `test/audioengine_utils`.

The only conflict was the neighbouring lines in `cmake/treedata/common/tests.txt`.

fritsch reviewed the ALSA change inline on #28115 and said two things:

> This change is fine. Out of curiosity: which error did you get that you now recover?

The first half is an approval of the change. The second was never answered, and I cannot answer it either: I have no reproduction, and the `default` branch is reachable in principle for any error `snd_pcm_recover()` does not convert (`-EIO`, `-ENODEV`, a failed `prepare`/`resume`), but I have not observed one. Treat the ALSA half as hardening rather than as a fix for a reported fault, and hold or drop it if that is not wanted on RC1. The test half carries no runtime risk either way.

## Motivation and context
#28115 has been mergeable in content since April but needed a rebase and its author has been away since 2026-04-02. It is on the RC1 milestone.

## How has this been tested?
- The nine new tests build and pass on Windows (`kodi-test --gtest_filter=TestAEBitstreamPacker*`), and the full suite is green.
- `AESinkALSA.cpp` compiles with the Linux toolchain (Debian trixie, wayland/gl configure). The ALSA path was not exercised at runtime here.

## What is the effect on users?
On Linux with ALSA output, an unusual write error no longer leaves the audio device stuck until playback is restarted.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
