### PR TITLE
fixed: play HLS streams whose segment names lack a media file extension

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -806,6 +806,10 @@ AVDictionary* CDVDDemuxFFmpeg::GetFFMpegOptionsFromInput()
   if (url.GetProtocol().empty() || url.IsProtocol("file"))
     av_dict_set(&options, "protocol_whitelist", "file,http,https,tcp,tls,crypto", 0);
 
+  // FFmpeg's HLS demuxer otherwise refuses segment URIs that do not end in a media file
+  // extension.
+  av_dict_set_int(&options, "extension_picky", 0, 0);
+
   if (url.IsProtocol("http") || url.IsProtocol("https"))
   {
     std::map<std::string, std::string> protocolOptions;


### PR DESCRIPTION
**TL;DR:** Bug fix. HLS streams whose segment names carry no media file extension stopped playing in Kodi 22 because FFmpeg 7.1+ rejects them by default. Kodi now passes `extension_picky=0` on its FFmpeg input path, as Kodi 21's FFmpeg 6.0 behaved.

## Description
Kodi 22 fails to open HLS playlists whose segment names do not end in a media file extension, such as tokenised CDN URIs with the query string percent-encoded into the path. FFmpeg's HLS demuxer has rejected those segments since 7.1 (`test_segment()` in `libavformat/hls.c`, controlled by `extension_picky`, which defaults to on). Kodi 21 shipped FFmpeg 6.0, which predates the check, so these streams played there.

This sets `extension_picky` to 0 in the options Kodi hands FFmpeg for the FFmpeg input-stream path, next to the existing `protocol_whitelist`. The demuxer's guard against `file://` segments (`allowed_extensions` in `open_url()`) does not depend on `extension_picky` and stays in force.

## Motivation and context
Fixes #29159. The reporter's log ends at `CVideoPlayer::OpenDemuxStream - Error creating demuxer` with nothing from FFmpeg, because FFmpeg errors only reach kodi.log with the ffmpeg log component enabled.

## How has this been tested?
- A local HTTP server serving the playlist from the report over a real MPEG-TS segment. ffprobe 8.1.1, whose `test_segment()` is identical to 9.0.1's, rejects it with `not in allowed_segment_extensions` and plays it with `-extension_picky 0`. `allowed_segment_extensions=ALL` alone is not enough: the second check in `test_segment()` (detected format against extension) still fails.
- Windows x64 build of this branch plays that playlist through VideoPlayer: `Player.OnAVStart` at 0.3 s, mpeg2video/mp2, 12 s duration, six segment fetches seen on the server.
- Full gtest suite on Windows x64: 4044 tests from 313 suites, all passed.

## What is the effect on users?
HLS streams whose segment URIs lack a recognised file extension play again, as they did in Kodi 21.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
