### PR TITLE
fixed: keep a file's orientation and centre mix level across a settings update

### DIFF
--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5380,10 +5380,12 @@ void CVideoDatabase::SetVideoSettings(int idFile, const CVideoSettings &setting)
       std::string strSQL2;
 
       strSQL2 = PrepareSQL("ResumeTime=%i,StereoMode=%i,StereoInvert=%i,VideoStream=%i,"
-                           "TonemapMethod=%i,TonemapParam=%f where idFile=%i\n",
+                           "TonemapMethod=%i,TonemapParam=%f,Orientation=%i,CenterMixLevel=%i "
+                           "where idFile=%i\n",
                            setting.m_ResumeTime, setting.m_StereoMode, setting.m_StereoInvert,
                            setting.m_VideoStream, setting.m_ToneMapMethod,
-                           static_cast<double>(setting.m_ToneMapParam), idFile);
+                           static_cast<double>(setting.m_ToneMapParam), setting.m_Orientation,
+                           setting.m_CenterMixLevel, idFile);
       strSQL += strSQL2;
       m_pDS->exec(strSQL);
       return ;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -11856,15 +11856,19 @@ void CVideoDatabase::InvalidatePathHash(const std::string& strPath)
 
 bool CVideoDatabase::CommitTransaction()
 {
-  if (CDatabase::CommitTransaction())
-  { // number of items in the db has likely changed, so recalculate
-    GUIINFO::CLibraryGUIInfo& guiInfo = CServiceBroker::GetGUI()->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider();
+  if (!CDatabase::CommitTransaction())
+    return false;
+
+  // number of items in the db has likely changed, so recalculate
+  if (CGUIComponent* gui = CServiceBroker::GetGUI())
+  {
+    GUIINFO::CLibraryGUIInfo& guiInfo =
+        gui->GetInfoManager().GetInfoProviders().GetLibraryInfoProvider();
     guiInfo.SetLibraryBool(LIBRARY_HAS_MOVIES, HasContent(VideoDbContentType::MOVIES));
     guiInfo.SetLibraryBool(LIBRARY_HAS_TVSHOWS, HasContent(VideoDbContentType::TVSHOWS));
     guiInfo.SetLibraryBool(LIBRARY_HAS_MUSICVIDEOS, HasContent(VideoDbContentType::MUSICVIDEOS));
-    return true;
   }
-  return false;
+  return true;
 }
 
 bool CVideoDatabase::SetSingleValue(VideoDbContentType type,

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES TestBookmark.cpp
             TestFilenameAttributes.cpp
             TestPlayerControllerActions.cpp
             TestStacks.cpp
+            TestVideoDatabase.cpp
             TestVideoDbUrl.cpp
             TestVideoFileItemClassify.cpp
             TestVideoInfoTag.cpp

--- a/xbmc/video/test/TestVideoDatabase.cpp
+++ b/xbmc/video/test/TestVideoDatabase.cpp
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/VideoSettings.h"
+#include "filesystem/File.h"
+#include "filesystem/SpecialProtocol.h"
+#include "settings/AdvancedSettings.h"
+#include "video/VideoDatabase.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr const char* DB_NAME = "TestVideoDatabase";
+
+class TestVideoDatabase : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    m_settings.type = "sqlite3";
+    m_settings.name = DB_NAME;
+    m_settings.host = CSpecialProtocol::TranslatePath("special://temp/");
+    ASSERT_EQ(CDatabase::ConnectionState::STATE_CONNECTED, m_db.Connect(DB_NAME, m_settings, true));
+  }
+
+  void TearDown() override
+  {
+    m_db.Close();
+    XFILE::CFile::Delete(m_settings.host + DB_NAME + ".db");
+  }
+
+  DatabaseSettings m_settings;
+  CVideoDatabase m_db;
+};
+} // namespace
+
+TEST_F(TestVideoDatabase, InsertStoresOrientationAndCenterMixLevel)
+{
+  const int idFile = m_db.AddFile("C:/videos/rotated.mkv");
+  ASSERT_GT(idFile, 0);
+
+  CVideoSettings rotated;
+  rotated.m_Orientation = 90;
+  rotated.m_CenterMixLevel = 3;
+  m_db.SetVideoSettings(idFile, rotated);
+
+  CVideoSettings stored;
+  ASSERT_TRUE(m_db.GetVideoSettings(idFile, stored));
+  EXPECT_EQ(90, stored.m_Orientation);
+  EXPECT_EQ(3, stored.m_CenterMixLevel);
+}
+
+TEST_F(TestVideoDatabase, UpdateStoresOrientationAndCenterMixLevel)
+{
+  const int idFile = m_db.AddFile("C:/videos/rotated.mkv");
+  ASSERT_GT(idFile, 0);
+
+  m_db.SetVideoSettings(idFile, CVideoSettings());
+
+  CVideoSettings rotated;
+  rotated.m_Orientation = 90;
+  rotated.m_CenterMixLevel = 3;
+  m_db.SetVideoSettings(idFile, rotated);
+
+  CVideoSettings stored;
+  ASSERT_TRUE(m_db.GetVideoSettings(idFile, stored));
+  EXPECT_EQ(90, stored.m_Orientation);
+  EXPECT_EQ(3, stored.m_CenterMixLevel);
+}


### PR DESCRIPTION
**TL;DR:** Bug fix. A file's rotation and centre mix level were only saved while its settings row was new, because the UPDATE statement stopped short of the two columns. Both are now written on update, with a real-database test.

## Description
`CVideoDatabase::SetVideoSettings` carries two hand-written column lists. The INSERT path writes `Orientation` and `CenterMixLevel`; the UPDATE path stops at `TonemapParam`. So a file's rotation and downmix centre mix level are remembered only while its settings row does not exist yet. Once any other per-file setting has been saved for that file, both keep whatever the row was created with.

Two commits:

1. `CVideoDatabase::CommitTransaction` refreshes the library info providers through `CServiceBroker::GetGUI()` unguarded. The unit-test environment has no GUI, so creating a video database in `kodi-test` (which commits the transaction that created its tables) dies with an access violation. The refresh now runs only when a GUI exists. This is the enabling change for the test in the second commit.
2. The UPDATE statement writes both columns, with a new `TestVideoDatabase` suite that stands up a real sqlite video database through `CDatabase::Connect` and covers the insert and update paths.

## Motivation and context
Rotating a video from the OSD, or changing its centre mix level, silently stops being remembered for that file after the first save of any other per-file setting, which makes the feature look intermittent. Found while extending the settings table; confirmed by the test in this PR, whose update case fails on the unmodified code.

## How has this been tested?
- `TestVideoDatabase.UpdateStoresOrientationAndCenterMixLevel` fails on master (both values read back as 0) and passes with the fix; `InsertStoresOrientationAndCenterMixLevel` passes on both as the control.
- Full gtest suite on Windows x64: 4046 tests from 314 suites, all passed.

## What is the effect on users?
Per-file video rotation and centre mix level are remembered after they have been changed once.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
