### PR TITLE
fixed: crash at startup on Windows with a DVD in the drive

### DIFF
--- a/xbmc/ServiceBroker.cpp
+++ b/xbmc/ServiceBroker.cpp
@@ -20,7 +20,6 @@
 #include <utility>
 
 using namespace KODI;
-using namespace KODI::UTILS::I18N;
 
 CServiceBroker::CServiceBroker()
 {
@@ -512,7 +511,3 @@ std::shared_ptr<XFILE::CBlurayDiscCache> CServiceBroker::GetBlurayDiscCache()
   return g_serviceBroker.m_blurayDiscCache;
 }
 
-CSubTagRegistryManager& CServiceBroker::GetSubTagRegistry()
-{
-  return g_application.m_ServiceManager->GetSubTagRegistryManager();
-}

--- a/xbmc/ServiceBroker.h
+++ b/xbmc/ServiceBroker.h
@@ -135,11 +135,6 @@ namespace XFILE
 class CBlurayDiscCache;
 }
 
-namespace KODI::UTILS::I18N
-{
-class CSubTagRegistryManager;
-}
-
 class CServiceBroker
 {
 public:
@@ -193,7 +188,6 @@ public:
   static CEventLog* GetEventLog();
   static CMediaManager& GetMediaManager();
   static CComponentContainer<IApplicationComponent>& GetAppComponents();
-  static KODI::UTILS::I18N::CSubTagRegistryManager& GetSubTagRegistry();
 
   static CGUIComponent* GetGUI();
   static const CGUIComponent* GetGUIConst();

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -46,7 +46,6 @@
 #include "pictures/SlideShowDelegator.h"
 #include "storage/MediaManager.h"
 #include "utils/FileExtensionProvider.h"
-#include "utils/i18n/Bcp47Registry/SubTagRegistryManager.h"
 #include "utils/log.h"
 #include "weather/WeatherManager.h"
 
@@ -87,9 +86,6 @@ bool CServiceManager::InitForTesting()
   m_extsMimeSupportList = std::make_unique<ADDONS::CExtsMimeSupportList>(*m_addonMgr);
   m_fileExtensionProvider->Initialize(*m_addonMgr);
 
-  m_subTagRegistryManager = std::make_unique<KODI::UTILS::I18N::CSubTagRegistryManager>();
-  m_subTagRegistryManager->Initialize();
-
   m_mediaManager = std::make_unique<CMediaManager>();
 
   init_level = 1;
@@ -100,7 +96,6 @@ void CServiceManager::DeinitTesting()
 {
   init_level = 0;
   m_mediaManager.reset();
-  m_subTagRegistryManager.reset();
   m_fileExtensionProvider->Deinitialize();
   m_extsMimeSupportList.reset();
   m_dataCacheCore.reset();
@@ -212,9 +207,6 @@ bool CServiceManager::InitStageTwo(const std::string& profilesUserDataFolder)
   m_WSDiscovery = WSDiscovery::IWSDiscovery::GetInstance();
 #endif
 
-  m_subTagRegistryManager = std::make_unique<KODI::UTILS::I18N::CSubTagRegistryManager>();
-  m_subTagRegistryManager->Initialize();
-
   if (!m_Platform->InitStageTwo())
     return false;
 
@@ -280,8 +272,6 @@ void CServiceManager::DeinitStageTwo()
     return;
 
   init_level = 1;
-
-  m_subTagRegistryManager.reset();
 
 #if defined(HAS_FILESYSTEM_SMB)
   m_WSDiscovery.reset();
@@ -481,9 +471,4 @@ CMediaManager& CServiceManager::GetMediaManager()
 CSlideShowDelegator& CServiceManager::GetSlideShowDelegator()
 {
   return *m_slideShowDelegator;
-}
-
-KODI::UTILS::I18N::CSubTagRegistryManager& CServiceManager::GetSubTagRegistryManager()
-{
-  return *m_subTagRegistryManager;
 }

--- a/xbmc/ServiceManager.h
+++ b/xbmc/ServiceManager.h
@@ -67,10 +67,6 @@ namespace RETRO
 {
 class CGUIGameRenderManager;
 }
-namespace UTILS::I18N
-{
-class CSubTagRegistryManager;
-} // namespace UTILS::I18N
 } // namespace KODI
 
 namespace MEDIA_DETECT
@@ -220,8 +216,6 @@ public:
   MEDIA_DETECT::CDetectDVDMedia& GetDetectDVDMedia();
 #endif
 
-  KODI::UTILS::I18N::CSubTagRegistryManager& GetSubTagRegistryManager();
-
 protected:
   std::unique_ptr<ADDON::CAddonMgr> m_addonMgr;
   std::unique_ptr<ADDON::CBinaryAddonManager> m_binaryAddonManager;
@@ -258,5 +252,4 @@ protected:
   std::unique_ptr<MEDIA_DETECT::CDetectDVDMedia> m_DetectDVDType;
 #endif
   std::unique_ptr<CSlideShowDelegator> m_slideShowDelegator;
-  std::unique_ptr<KODI::UTILS::I18N::CSubTagRegistryManager> m_subTagRegistryManager;
 };

--- a/xbmc/utils/LangCodeExpander.cpp
+++ b/xbmc/utils/LangCodeExpander.cpp
@@ -298,7 +298,7 @@ bool CLangCodeExpander::ReverseLookup(const std::string& desc, std::string& code
     return true;
   }
 
-  const CSubTagRegistryManager& registry{CServiceBroker::GetSubTagRegistry()};
+  const CSubTagRegistryManager& registry{CSubTagRegistryManager::GetInstance()};
   if (const auto ret = registry.GetLanguageSubTags().LookupByDescription(descTmp); ret.has_value())
   {
     code = ret->m_subTag;

--- a/xbmc/utils/i18n/Bcp47.cpp
+++ b/xbmc/utils/i18n/Bcp47.cpp
@@ -8,7 +8,6 @@
 
 #include "utils/i18n/Bcp47.h"
 
-#include "ServiceBroker.h"
 #include "utils/RegExp.h"
 #include "utils/StringUtils.h"
 #include "utils/i18n/Bcp47Formatter.h"
@@ -37,7 +36,7 @@ std::optional<CBcp47> CBcp47::ParseTag(std::string str, const CSubTagRegistryMan
     return std::nullopt;
 
   if (registry == nullptr)
-    registry = &CServiceBroker::GetSubTagRegistry();
+    registry = &CSubTagRegistryManager::GetInstance();
 
   CBcp47 tag;
   tag.m_registry = registry;

--- a/xbmc/utils/i18n/Bcp47Registry/SubTagRegistryManager.cpp
+++ b/xbmc/utils/i18n/Bcp47Registry/SubTagRegistryManager.cpp
@@ -38,6 +38,19 @@ CSubTagRegistryManager::~CSubTagRegistryManager()
   Deinitialize();
 }
 
+const CSubTagRegistryManager& CSubTagRegistryManager::GetInstance()
+{
+  // Never destroyed: tags are parsed until process exit, after logging has been torn down
+  static const CSubTagRegistryManager* const instance = []
+  {
+    auto* registry = new CSubTagRegistryManager();
+    if (!registry->Initialize())
+      CLog::Log(LOGERROR, "IANA Language Subtag Registry: not loaded, tags will not validate");
+    return registry;
+  }();
+  return *instance;
+}
+
 bool CSubTagRegistryManager::Initialize(std::unique_ptr<IRegistryRecordProvider> provider)
 {
   if (provider == nullptr)

--- a/xbmc/utils/i18n/Bcp47Registry/SubTagRegistryManager.h
+++ b/xbmc/utils/i18n/Bcp47Registry/SubTagRegistryManager.h
@@ -21,6 +21,11 @@ class CSubTagRegistryManager
 public:
   ~CSubTagRegistryManager();
 
+  /*!
+   * \brief The registry every tag is validated against, loaded on first use.
+   */
+  static const CSubTagRegistryManager& GetInstance();
+
   bool Initialize(std::unique_ptr<IRegistryRecordProvider> provider = nullptr);
   void Deinitialize();
 

--- a/xbmc/utils/test/TestLanguageTag.cpp
+++ b/xbmc/utils/test/TestLanguageTag.cpp
@@ -6,7 +6,12 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "ServiceManager.h"
+#include "application/Application.h"
 #include "utils/LanguageTag.h"
+
+#include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 
@@ -286,4 +291,35 @@ TEST(TestLanguageTag, NarrowingDropsTheRegionFromTheEnglishName)
 
   // A tag with nothing to drop names the same language either way
   EXPECT_EQ(CLanguageTag::Parse("eng").GetEnglishLanguageName(), "English");
+}
+
+namespace
+{
+//! \brief Stands an uninitialised service manager in, and puts the real one back on every path
+class CServiceManagerSwap
+{
+public:
+  CServiceManagerSwap() { std::swap(m_saved, g_application.m_ServiceManager); }
+  ~CServiceManagerSwap() { std::swap(m_saved, g_application.m_ServiceManager); }
+
+  CServiceManagerSwap(const CServiceManagerSwap&) = delete;
+  CServiceManagerSwap& operator=(const CServiceManagerSwap&) = delete;
+
+private:
+  std::unique_ptr<CServiceManager> m_saved{std::make_unique<CServiceManager>()};
+};
+} // namespace
+
+TEST(TestLanguageTag, ParsesBeforeAnyServiceExists)
+{
+  // A disc in the drive at startup is probed while the service manager is still initialising,
+  // so a language must parse with no service available
+  CLanguageTag tag;
+  {
+    const CServiceManagerSwap noServices;
+    tag = CLanguageTag::Parse("en-GB");
+  }
+
+  EXPECT_EQ(tag.AsBcp47(), "en-GB");
+  EXPECT_EQ(tag.AsIso6391(), "en");
 }


### PR DESCRIPTION
**TL;DR:** Bug fix. Kodi 22 Beta 2 on Windows crashes at startup when a DVD is in the drive, because the language subtag registry is created after the disc probe that needs it. The registry now loads on first use.

## Description
`CSubTagRegistryManager` gains `GetInstance()`, which loads the IANA subtag registry on first use. The instance is never destroyed: tags are parsed until process exit, after `CAppEnvironment::TearDown()` has destroyed the logging its destructor would report through. The service-manager member, its two creation sites, both resets and the broker accessor `CServiceBroker::GetSubTagRegistry()` are removed. The two callers, `CBcp47::ParseTag()` and `CLangCodeExpander::ReverseLookup()`, use the instance directly.

A test, `TestLanguageTag.ParsesBeforeAnyServiceExists`, swaps a bare `CServiceManager` into the application and parses a tag, which is the state the disc probe runs in.

## Motivation and context
22.0 Beta 2 on Windows dies with an access violation before the splash screen whenever a DVD, or any disc with a `VIDEO_TS` folder, is in the drive at launch (reported by @KarellenX on Slack). Remove the disc and it starts.

Since #28191 the Windows storage provider adds a disc that is already present as an optical source synchronously, inside `CMediaManager::Initialize()`. That runs in `CServiceManager::InitStageTwo()` a few lines **before** the BCP 47 subtag registry was created, and adding the source probes the disc through `CDVDInputStreamNavigator::Open()`, which resolves the DVD menu language. The symbolised main-thread stack from the Beta 2 minidump:

```
CSubTagsCollection<LanguageSubTag>::LookupByDescription   <- this == nullptr
CLangCodeExpander::ReverseLookup
CBcp47::ParseTag
CLangCodeExpander::ConvertToBcp47
CLanguageTag::Parse
CLangInfo::GetDVDMenuLanguage
CDVDInputStreamNavigator::Open
UTILS::DISCS::ProbeDVDDiscInfo
CMediaManager::GetDiscInfo
CMediaManager::GetDiskLabel
CMediaManager::AddOpticalSource
CWin32StorageProvider::Initialize
CMediaManager::Initialize
CServiceManager::InitStageTwo
CApplication::Create
```

A Blu-ray takes the libbluray probe and never parses a language, and an empty drive never probes, which is why it did not reproduce with a Blu-ray. Beta 1 queued the same probe as a job, which ran after stage two had finished.

The registry is reference data with no dependency on any service, so giving it a service lifetime only created a window in which every tag parsed was either a crash or silently "not valid". Loading it on first use removes the window, so the order the services come up in cannot matter to it again. Moving the two creation lines above the media manager would fix this report but leave every earlier caller with the same trap.

## How has this been tested?
- The new test fails before the fix with the same access violation as the crash:
  ```
  [ RUN      ] TestLanguageTag.ParsesBeforeAnyServiceExists
  unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
  [  FAILED  ] TestLanguageTag.ParsesBeforeAnyServiceExists (0 ms)
  ```
- With the fix, the full gtest suite passes on Windows x64 (MSVC), 4045 tests.
- clang-format is clean on the touched lines.

## What is the effect on users?
Kodi starts normally on Windows with a DVD in the drive.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
