### PR TITLE
fixed: open the subtitle browser at the root for streams outside every source

### DIFF
--- a/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
+++ b/xbmc/video/dialogs/GUIDialogSubtitleSettings.cpp
@@ -13,6 +13,7 @@
 #include "GUIPassword.h"
 #include "ServiceBroker.h"
 #include "URL.h"
+#include "Util.h"
 #include "addons/Skin.h"
 #include "addons/VFSEntry.h"
 #include "application/Application.h"
@@ -128,6 +129,8 @@ std::string CGUIDialogSubtitleSettings::BrowseForSubtitle()
       extras += '|' + vfsAddon->GetExtensions();
   }
 
+  std::vector<CMediaSource> shares(*CMediaSourceSettings::GetInstance().GetSources("video"));
+
   const auto currentItem{g_application.CurrentFileItem()};
   std::string strPath{currentItem.GetProperty("BasePath").asString("")};
   if (strPath.empty())
@@ -143,6 +146,15 @@ std::string CGUIDialogSubtitleSettings::BrowseForSubtitle()
     }
   }
 
+  // A stream belonging to no source has no parent directory worth listing, and trying to list
+  // one is what hangs the dialog. An empty path opens the browser at the root instead.
+  bool isSourceName{false}; // GetMatchingSource requires it; the answer is not used here
+  if (URIUtils::IsInternetStream(strPath) &&
+      CUtil::GetMatchingSource(strPath, shares, isSourceName) < 0)
+  {
+    strPath.clear();
+  }
+
   std::string strMask =
       ".utf|.utf8|.utf-8|.sub|.srt|.smi|.rt|.txt|.ssa|.aqt|.jss|.ass|.vtt|.idx|.zip|.sup";
 
@@ -151,7 +163,6 @@ std::string CGUIDialogSubtitleSettings::BrowseForSubtitle()
 
   strMask += extras;
 
-  std::vector<CMediaSource> shares(*CMediaSourceSettings::GetInstance().GetSources("video"));
   if (CMediaSettings::GetInstance().GetAdditionalSubtitleDirectoryChecked() != -1 && !CServiceBroker::GetSettingsComponent()->GetSettings()->GetString(CSettings::SETTING_SUBTITLES_CUSTOMPATH).empty())
   {
     CMediaSource share;


### PR DESCRIPTION
**TL;DR:** Bug fix. Browse for subtitle no longer tries to list an internet stream's parent URL as an HTTP directory, which left the browser stuck on a busy dialog.

## Description
`CGUIDialogSubtitleSettings::BrowseForSubtitle()` seeds the file browser with the playing item's path so it opens next to the video. For an item played by URL that path is the stream itself, and the browser then lists the stream's parent URL as an HTTP directory index. `CHTTPDirectory::GetDirectory` requests that URL and reads the whole response before parsing it. Against an HLS proxy, or any HTTP server that is not a file index, the request can block indefinitely.

Since #27627 the listing runs behind a modal busy dialog. Cancelling closes the dialog, but `CHTTPDirectory` has no `CancelDirectory`, so the browser is left empty at "0 items" while the request carries on. Before #27627 the same call froze the GUI thread.

The fix skips the seed when the path is an internet stream that is not inside a configured video source. Items browsed from an `http://` source keep the parent-directory listing, which is a real index there. A bare URL opens the browser at the root, i.e. the video sources and the custom subtitle folder.

## Motivation and context
Fixes #29161. Playing `http://127.0.0.1:8899/index.m3u8` from the command line and choosing "Browse for subtitle..." left the reporter on a spinner with no items, so no external subtitle could be picked.

## How has this been tested?
- Windows 11, MSVC 19.42, master at 61d9aba528.
- Full `kodi-test` suite: 4076 tests pass.
- Live check with a portable build and no video sources configured, playing an `.mp4` over HTTP from a local server that never answers a request for its root. Before the change, Browse for subtitle opened the busy dialog (window 10138) and the server showed the request for `/` being held open; the dialog was still up a minute later. After the change, the file browser (window 10126) opened at its root immediately and the server saw no request beyond the playback traffic.

## What is the effect on users?
Browse for subtitle opens immediately when the playing item is a network stream that is not inside one of the configured video sources, starting at the source list instead of next to the stream. Items played from an `http://` source behave as before.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
