### PR TITLE
[VideoPlayer] record the demuxer keyframe flag and reallocate stale sysmem pool buffers

### DIFF
--- a/xbmc/cores/VideoPlayer/Buffers/VideoBuffer.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBuffer.cpp
@@ -283,6 +283,11 @@ bool CVideoBufferSysMem::Alloc()
   return true;
 }
 
+bool CVideoBufferSysMem::IsCompatible(AVPixelFormat format, int size) const
+{
+  return m_pixFormat == format && m_size >= size;
+}
+
 
 //-----------------------------------------------------------------------------
 // CVideoBufferPool
@@ -309,6 +314,13 @@ CVideoBuffer* CVideoBufferPoolSysMem::Get()
     m_free.pop_front();
     m_used.push_back(idx);
     buf = m_all[idx];
+    if (!buf->IsCompatible(m_pixFormat, m_size))
+    {
+      delete buf;
+      buf = new CVideoBufferSysMem(*this, idx, m_pixFormat, m_size);
+      buf->Alloc();
+      m_all[idx] = buf;
+    }
   }
   else
   {

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBuffer.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBuffer.h
@@ -156,6 +156,7 @@ public:
   void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES]) override;
   void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES], const int (&planeOffsets)[YuvImage::MAX_PLANES]) override;
   bool Alloc();
+  bool IsCompatible(AVPixelFormat format, int size) const;
 
 protected:
   int m_width = 0;

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1181,6 +1181,7 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
               ConvertTimestamp(m_pkt.pkt.dts, stream->time_base.den, stream->time_base.num);
           pPacket->duration = DVD_SEC_TO_TIME((double)m_pkt.pkt.duration * stream->time_base.num /
                                               stream->time_base.den);
+          pPacket->m_keyFrame = (m_pkt.pkt.flags & AV_PKT_FLAG_KEY) != 0;
 
           CDVDDemuxUtils::StoreSideData(pPacket, &m_pkt.pkt);
 

--- a/xbmc/cores/VideoPlayer/Interface/DemuxPacket.h
+++ b/xbmc/cores/VideoPlayer/Interface/DemuxPacket.h
@@ -43,6 +43,13 @@ extern "C"
 
     //! @brief PTS offset correction applied to the PTS and DTS.
     double m_ptsOffsetCorrection{0};
+
+    //! @brief Whether the packet holds a keyframe, as reported by the demuxer.
+    //! Unlike recoveryPoint this says nothing about where output may start: an
+    //! open GOP keyframe is followed by leading pictures that reference frames
+    //! before it. Packets from inputstream addons leave this false, since the
+    //! field is not part of the DEMUX_PACKET ABI.
+    bool m_keyFrame{false};
   };
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Description
Two small, independent VideoPlayer changes:

- `DemuxPacket` gains `m_keyFrame`, filled by `CDVDDemuxFFmpeg` from `AV_PKT_FLAG_KEY`. It records the demuxer's own keyframe flag, which answers a different question than `recoveryPoint` (where output may start). Packets from inputstream add-ons leave it `false`, since the field is not part of the `DEMUX_PACKET` ABI.
- `CVideoBufferPoolSysMem::Get()` checks a free buffer against the pool's current pixel format and size and reallocates it when it no longer fits. `Configure()` records a new configuration, but until now `Get()` handed out buffers allocated for the previous one.

## Motivation and context
Codecs that hand packets to an external decoder have to label each sample as key or delta. WebCodecs, used by the WebAssembly port, rejects a stream that does not start with a key chunk and requires one after a flush, so the codec needs the demuxer's flag rather than heuristics.

The pool change fixes a latent bug that any sysmem-producing decoder hits when its output format or resolution changes mid-stream: `Configure()` is called with the new size, but a recycled buffer sized for the old one is returned and the larger frame is written into it.

## How has this been tested?
Exercised by the downstream WebAssembly build, where the WebCodecs decoder uses both changes (Chrome on macOS, Samsung Tizen 9.0 TV). Compiled for the wasm target; native compilation relies on CI. No unit tests added.

## What is the effect on users?
None visible on existing platforms. The pool fix removes a potential out-of-bounds write on mid-stream format changes for decoders that return sysmem buffers.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [x] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
