### PR TITLE
[depends][python][wasm] build and run a statically linked CPython

### DIFF
--- a/cmake/scripts/wasm/ArchSetup.cmake
+++ b/cmake/scripts/wasm/ArchSetup.cmake
@@ -53,6 +53,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     "SHELL:-sMAX_WEBGL_VERSION=2"
     "SHELL:-sFULL_ES3=1"
     "SHELL:-sABORTING_MALLOC=0"
+    # CPython's call trampoline installs its wasm-gc adaptor with addFunction().
+    "SHELL:-sALLOW_TABLE_GROWTH"
     "SHELL:-lidbfs.js"
   )
 

--- a/cmake/scripts/wasm/ExtraTargets.cmake
+++ b/cmake/scripts/wasm/ExtraTargets.cmake
@@ -1,0 +1,28 @@
+# CPython is linked statically, so it has no install prefix to find on a real
+# filesystem. Ship its standard library inside the Emscripten VFS as the zip
+# landmark getpath() looks for at <PYTHONHOME>/lib/pythonXY.zip; XBPython points
+# PYTHONHOME at special://xbmc, which is WASM_VFS_PREFIX here.
+if(ENABLE_PYTHON AND TARGET ${APP_NAME_LC}::Python)
+  string(REPLACE "." "" PYTHON_ZIP_VERSION "${PYTHON_VERSION}")
+  set(PYTHON_STDLIB_DIR "${DEPENDS_PATH}/lib/python${PYTHON_VERSION}")
+  set(PYTHON_STDLIB_VFS_DIR "${CMAKE_BINARY_DIR}/python-stdlib/lib")
+  set(PYTHON_STDLIB_ZIP "${PYTHON_STDLIB_VFS_DIR}/python${PYTHON_ZIP_VERSION}.zip")
+
+  file(GLOB_RECURSE PYTHON_STDLIB_SOURCES "${PYTHON_STDLIB_DIR}/*.py")
+
+  add_custom_command(OUTPUT "${PYTHON_STDLIB_ZIP}"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${PYTHON_STDLIB_VFS_DIR}"
+    COMMAND ${CMAKE_COMMAND} -E rm -f "${PYTHON_STDLIB_ZIP}"
+    COMMAND ${CMAKE_COMMAND} -E chdir "${PYTHON_STDLIB_DIR}"
+            ${CMAKE_COMMAND} -E tar cf "${PYTHON_STDLIB_ZIP}" --format=zip .
+    DEPENDS ${PYTHON_STDLIB_SOURCES}
+    COMMENT "Packing the Python standard library for the WASM virtual filesystem"
+    VERBATIM)
+
+  add_custom_target(python-stdlib-zip DEPENDS "${PYTHON_STDLIB_ZIP}")
+  set_target_properties(python-stdlib-zip PROPERTIES FOLDER "Build Utilities")
+  add_dependencies(${APP_NAME_LC} python-stdlib-zip)
+
+  target_link_options(${APP_NAME_LC} PRIVATE
+    "SHELL:--preload-file ${PYTHON_STDLIB_VFS_DIR}@${WASM_VFS_PREFIX}/lib")
+endif()

--- a/tools/depends/target/python3/17-wasm-static-linking.patch
+++ b/tools/depends/target/python3/17-wasm-static-linking.patch
@@ -1,0 +1,354 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Clement Peron <peron.clem@gmail.com>
+Date: Tue, 1 Sep 2026 00:00:00 +0000
+Subject: [PATCH] Emscripten: support static linking
+
+Backport of python/cpython#156798 and #156781.
+---
+diff --git a/Makefile.pre.in b/Makefile.pre.in
+--- a/Makefile.pre.in
++++ b/Makefile.pre.in
+@@ -982,9 +982,12 @@
+ clinic-tests: check-clean-src $(srcdir)/Lib/test/clinic.test.c
+ 	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/clinic/clinic.py -f $(srcdir)/Lib/test/clinic.test.c
+ 
++# Objects linked into the interpreter only, not into libpython.
++PLATFORM_MAIN_OBJS=	@PLATFORM_MAIN_OBJS@
++
+ # Build the interpreter
+-$(BUILDPYTHON):	Programs/python.o $(LINK_PYTHON_DEPS)
+-	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(LINK_PYTHON_OBJS) $(LIBS) $(MODLIBS) $(SYSLIBS)
++$(BUILDPYTHON):	Programs/python.o $(PLATFORM_MAIN_OBJS) $(LINK_PYTHON_DEPS)
++	$(LINKCC) $(PY_CORE_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(PLATFORM_MAIN_OBJS) $(LINK_PYTHON_OBJS) $(LIBS) $(MODLIBS) $(SYSLIBS)
+ 
+ platform: $(PYTHON_FOR_BUILD_DEPS) pybuilddir.txt
+ 	$(RUNSHARED) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
+diff --git a/Programs/emscripten_beforemain.c b/Programs/emscripten_beforemain.c
+--- a/Programs/emscripten_beforemain.c
++++ b/Programs/emscripten_beforemain.c
+@@ -0,0 +1,118 @@
++/* Emscripten setup that only applies when Python is the program.
++ *
++ * Linked into the interpreter only, never into libpython, so an embedder whose
++ * main() is not Python's does not get it.
++ */
++
++#include "pyconfig.h"
++
++#include <emscripten.h>
++#include <errno.h>
++
++// Variant of EM_JS that does C preprocessor substitution on the body
++#define EM_JS_MACROS(ret, func_name, args, body...)                            \
++  EM_JS(ret, func_name, args, body)
++#ifdef Py_EMSCRIPTEN_DYNAMIC_LINKING
++#define _Py_EM_WRAP_MAIN                                                       \
++    const origResolveGlobalSymbol = resolveGlobalSymbol;                       \
++    resolveGlobalSymbol = function (name, direct = false) {                    \
++        const orig = origResolveGlobalSymbol(name, direct);                    \
++        if (name === "main") {                                                 \
++            orig.sym = _PyEM_promising(orig.sym);                              \
++        }                                                                      \
++        return orig;                                                           \
++    };
++#else
++// WebAssembly.promising() rejects the createExportWrapper() shim in _main, so
++// wrap the raw export.
++#define _Py_EM_WRAP_MAIN                                                       \
++    _main = _PyEM_promising(wasmExports["main"]);
++#endif
++
++EM_JS_MACROS(void, _PyEmscripten_BeforeMain_js, (void), {
++    // Define FS.createAsyncInputDevice(), This is quite similar to
++    // FS.createDevice() defined here:
++    // https://github.com/emscripten-core/emscripten/blob/4.0.11/src/lib/libfs.js?plain=1#L1642
++    // but instead of returning one byte at a time, the input() function should
++    // return a Uint8Array. This makes the handler code simpler, the
++    // `createAsyncInputDevice` simpler, and everything faster.
++    FS.createAsyncInputDevice = function(parent, name, input) {
++        parent = typeof parent == 'string' ? parent : FS.getPath(parent);
++        var path = PATH.join2(parent, name);
++        var mode = FS_getMode(true, false);
++        FS.createDevice.major ||= 64;
++        var dev = FS.makedev(FS.createDevice.major++, 0);
++        async function getDataBuf() {
++            var buf;
++            try {
++                buf = await input();
++            } catch (e) {
++                throw new FS.ErrnoError(EIO);
++            }
++            if (!buf?.byteLength) {
++                throw new FS.ErrnoError(EAGAIN);
++            }
++            ops._dataBuf = buf;
++        }
++
++        var ops = {
++            _dataBuf: new Uint8Array(0),
++            open(stream) {
++                stream.seekable = false;
++            },
++            async readAsync(stream, buffer, offset, length, pos /* ignored */) {
++                buffer = buffer.subarray(offset, offset + length);
++                if (!ops._dataBuf.byteLength) {
++                    await getDataBuf();
++                }
++                var toRead = Math.min(ops._dataBuf.byteLength, buffer.byteLength);
++                buffer.subarray(0, toRead).set(ops._dataBuf);
++                buffer = buffer.subarray(toRead);
++                ops._dataBuf = ops._dataBuf.subarray(toRead);
++                if (toRead) {
++                    stream.node.atime = Date.now();
++                }
++                return toRead;
++            },
++        };
++        FS.registerDevice(dev, ops);
++        return FS.mkdev(path, mode, dev);
++    };
++    if (!WebAssembly.promising) {
++        // No stack switching support =(
++        return;
++    }
++    if (ENVIRONMENT_IS_NODE && !Module.onExit) {
++        Module.onExit = (code) => process.exit(code);
++    }
++    _Py_EM_WRAP_MAIN
++}
++// * wrap the entry point with WebAssembly.promising,
++// * call exit_with_live_runtime() to prevent emscripten from shutting down
++//   the runtime before the promise resolves,
++// * call onExit / process.exit ourselves, since exit_with_live_runtime()
++//   prevented Emscripten from calling it normally.
++function _PyEM_promising(orig) {
++    const main = WebAssembly.promising(orig);
++    return (...args) => {
++        (async () => {
++            const ret = await main(...args);
++            Module.onExit?.(ret);
++        })();
++        _emscripten_exit_with_live_runtime();
++    };
++}
++)
++
++#ifdef Py_EMSCRIPTEN_DYNAMIC_LINKING
++EM_JS_DEPS(_PyEmscripten_BeforeMain,
++           "$FS,$PATH,$FS_getMode,$resolveGlobalSymbol,"
++           "emscripten_exit_with_live_runtime");
++#else
++EM_JS_DEPS(_PyEmscripten_BeforeMain,
++           "$FS,$PATH,$FS_getMode,emscripten_exit_with_live_runtime");
++#endif
++
++__attribute__((constructor)) void _PyEmscripten_BeforeMain(void) {
++    _PyEmscripten_BeforeMain_js();
++}
+diff --git a/Python/emscripten_syscalls.c b/Python/emscripten_syscalls.c
+--- a/Python/emscripten_syscalls.c
++++ b/Python/emscripten_syscalls.c
+@@ -47,89 +47,7 @@
+ #define EM_JS_MACROS(ret, func_name, args, body...)                            \
+   EM_JS(ret, func_name, args, body)
+ 
+-EM_JS_MACROS(void, _emscripten_promising_main_js, (void), {
+-    // Define FS.createAsyncInputDevice(), This is quite similar to
+-    // FS.createDevice() defined here:
+-    // https://github.com/emscripten-core/emscripten/blob/4.0.11/src/lib/libfs.js?plain=1#L1642
+-    // but instead of returning one byte at a time, the input() function should
+-    // return a Uint8Array. This makes the handler code simpler, the
+-    // `createAsyncInputDevice` simpler, and everything faster.
+-    FS.createAsyncInputDevice = function(parent, name, input) {
+-        parent = typeof parent == 'string' ? parent : FS.getPath(parent);
+-        var path = PATH.join2(parent, name);
+-        var mode = FS_getMode(true, false);
+-        FS.createDevice.major ||= 64;
+-        var dev = FS.makedev(FS.createDevice.major++, 0);
+-        async function getDataBuf() {
+-            var buf;
+-            try {
+-                buf = await input();
+-            } catch (e) {
+-                throw new FS.ErrnoError(EIO);
+-            }
+-            if (!buf?.byteLength) {
+-                throw new FS.ErrnoError(EAGAIN);
+-            }
+-            ops._dataBuf = buf;
+-        }
+ 
+-        var ops = {
+-            _dataBuf: new Uint8Array(0),
+-            open(stream) {
+-                stream.seekable = false;
+-            },
+-            async readAsync(stream, buffer, offset, length, pos /* ignored */) {
+-                buffer = buffer.subarray(offset, offset + length);
+-                if (!ops._dataBuf.byteLength) {
+-                    await getDataBuf();
+-                }
+-                var toRead = Math.min(ops._dataBuf.byteLength, buffer.byteLength);
+-                buffer.subarray(0, toRead).set(ops._dataBuf);
+-                buffer = buffer.subarray(toRead);
+-                ops._dataBuf = ops._dataBuf.subarray(toRead);
+-                if (toRead) {
+-                    stream.node.atime = Date.now();
+-                }
+-                return toRead;
+-            },
+-        };
+-        FS.registerDevice(dev, ops);
+-        return FS.mkdev(path, mode, dev);
+-    };
+-    if (!WebAssembly.promising) {
+-        // No stack switching support =(
+-        return;
+-    }
+-    const origResolveGlobalSymbol = resolveGlobalSymbol;
+-    if (ENVIRONMENT_IS_NODE && !Module.onExit) {
+-        Module.onExit = (code) => process.exit(code);
+-    }
+-    // * wrap the main symbol with WebAssembly.promising,
+-    // * call exit_with_live_runtime() to prevent emscripten from shutting down
+-    //   the runtime before the promise resolves,
+-    // * call onExit / process.exit ourselves, since exit_with_live_runtime()
+-    //   prevented Emscripten from calling it normally.
+-    resolveGlobalSymbol = function (name, direct = false) {
+-        const orig = origResolveGlobalSymbol(name, direct);
+-        if (name === "main") {
+-            const main = WebAssembly.promising(orig.sym);
+-            orig.sym = (...args) => {
+-                (async () => {
+-                    const ret = await main(...args);
+-                    Module.onExit?.(ret);
+-                })();
+-                _emscripten_exit_with_live_runtime();
+-            };
+-        }
+-        return orig;
+-    };
+-})
+-
+-__attribute__((constructor)) void _emscripten_promising_main(void) {
+-    _emscripten_promising_main_js();
+-}
+-
+-
+ #define IOVEC_T_BUF_OFFSET 0
+ #define IOVEC_T_BUF_LEN_OFFSET 4
+ #define IOVEC_T_SIZE 8
+@@ -192,6 +110,8 @@
+ };
+ );
+ 
++EM_JS_DEPS(__maybe_fd_read_async, "$SYSCALLS");
++
+ // Bind original fd_read syscall to __wasi_fd_read_orig().
+ __wasi_errno_t __wasi_fd_read_orig(__wasi_fd_t fd, const __wasi_iovec_t *iovs,
+                                    size_t iovs_len, __wasi_size_t *nread)
+@@ -234,6 +154,19 @@
+     if (!WebAssembly.promising) {
+         return null;
+     }
++    // Suspending with nothing to await still requires a promising stack, which
++    // an embedder that has not wrapped its entry point does not have.
++    var async = false;
++    for (var i = 0; i < nfds; i++) {
++        var s = FS.getStream(HEAP32[(fds + POLLFD_SIZE * i + POLLFD_FD)/4]);
++        if (s && s.stream_ops.pollAsync) {
++            async = true;
++            break;
++        }
++    }
++    if (!async) {
++        return null;
++    }
+     return (async function() {
+         try {
+             var nonzero = 0;
+@@ -272,6 +205,8 @@
+         }
+     })();
+ });
++
++EM_JS_DEPS(__maybe_poll_async, "$FS");
+ 
+ // Bind original poll syscall to syscall_poll_orig().
+ int syscall_poll_orig(intptr_t fds, int nfds, int timeout)
+diff --git a/Python/emscripten_trampoline.c b/Python/emscripten_trampoline.c
+--- a/Python/emscripten_trampoline.c
++++ b/Python/emscripten_trampoline.c
+@@ -47,6 +47,10 @@
+                                     PyObject* args,
+                                     PyObject* kw);
+ 
++// _PyRuntime is bound in the JS glue only when it is exported, which an
++// embedder linking libpython does not do. Export its address from here.
++EMSCRIPTEN_KEEPALIVE _PyRuntimeState *const _PyEM_runtime = &_PyRuntime;
++
+ /**
+  * Backwards compatible trampoline works with all JS runtimes
+  */
+@@ -90,9 +94,12 @@
+ addOnPreRun(function setEmscriptenTrampoline() {
+     const ptr = getPyEMTrampolinePtr();
+     const offset = HEAP32[__PyEM_EMSCRIPTEN_TRAMPOLINE_OFFSET / 4];
+-    HEAP32[(__PyRuntime + offset) / 4] = ptr;
++    HEAP32[(HEAPU32[__PyEM_runtime / 4] + offset) / 4] = ptr;
+ });
+ );
++
++EM_JS_DEPS(_PyEM_TrampolineCall,
++           "$wasmTable,$wasmMemory,$addFunction,$addOnPreRun");
+ 
+ PyObject*
+ _PyEM_TrampolineCall(PyCFunctionWithKeywords func,
+diff --git a/configure.ac b/configure.ac
+--- a/configure.ac
++++ b/configure.ac
+@@ -2376,6 +2376,11 @@
+ 
+     AS_VAR_IF([enable_wasm_dynamic_linking], [yes], [
+       AS_VAR_APPEND([LINKFORSHARED], [" -sMAIN_MODULE"])
++      AC_DEFINE([Py_EMSCRIPTEN_DYNAMIC_LINKING], [1],
++                [Define if the Emscripten build is linked with -sMAIN_MODULE.])
++    ], [
++      dnl MAIN_MODULE implies this; the call trampoline's addFunction() needs it.
++      AS_VAR_APPEND([LINKFORSHARED], [" -sALLOW_TABLE_GROWTH"])
+     ])
+ 
+     AS_VAR_IF([enable_wasm_pthreads], [yes], [
+@@ -5178,15 +5183,19 @@
+ dnl Platform-specific C and header files.
+ PLATFORM_HEADERS=
+ PLATFORM_OBJS=
++dnl Objects linked into the interpreter only, not into libpython.
++PLATFORM_MAIN_OBJS=
+ 
+ AS_CASE([$ac_sys_system],
+   [Emscripten], [
++    AS_VAR_APPEND([PLATFORM_MAIN_OBJS], [' Programs/emscripten_beforemain.o'])
+     AS_VAR_APPEND([PLATFORM_OBJS], [' Python/emscripten_signal.o Python/emscripten_trampoline.o Python/emscripten_trampoline_wasm.o Python/emscripten_syscalls.o'])
+     AS_VAR_APPEND([PLATFORM_HEADERS], [' $(srcdir)/Include/internal/pycore_emscripten_signal.h $(srcdir)/Include/internal/pycore_emscripten_trampoline.h'])
+   ],
+ )
+ AC_SUBST([PLATFORM_HEADERS])
+ AC_SUBST([PLATFORM_OBJS])
++AC_SUBST([PLATFORM_MAIN_OBJS])
+ 
+ # -I${DLINCLDIR} is added to the compile rule for importdl.o
+ AC_SUBST([DLINCLDIR])
+diff --git a/pyconfig.h.in b/pyconfig.h.in
+--- a/pyconfig.h.in
++++ b/pyconfig.h.in
+@@ -1727,6 +1727,9 @@
+ /* Define if you want to build an interpreter with many run-time checks. */
+ #undef Py_DEBUG
+ 
++/* Define if the Emscripten build is linked with -sMAIN_MODULE. */
++#undef Py_EMSCRIPTEN_DYNAMIC_LINKING
++
+ /* Defined if Python is built as a shared library. */
+ #undef Py_ENABLE_SHARED
+ 

--- a/tools/depends/target/python3/Makefile
+++ b/tools/depends/target/python3/Makefile
@@ -8,7 +8,8 @@ DEPS = ../../Makefile.include Makefile PYTHON3-VERSION ../../download-files.incl
                                  13-wasm-em-config-clang.patch \
                                  14-wasm-build-wasm-default.patch \
                                  15-wasm-static-hacl.patch \
-                                 16-ios-platform.patch
+                                 16-ios-platform.patch \
+                                 17-wasm-static-linking.patch
 
 ifeq ($(findstring apple-darwin, $(HOST)), apple-darwin)
   ifeq ($(OS), darwin_embedded)
@@ -47,6 +48,17 @@ ifeq ($(OS),wasm)
   EXTRA_CONFIGURE+= ax_cv_c_float_words_bigendian=no \
                     ac_cv_func_forkpty=no ac_cv_lib_util_forkpty=no \
                     ac_cv_func_memfd_create=no
+
+  # libpython is linked statically into the Kodi binary, so there is no dlopen()
+  # for extension modules; MODULE_BUILDTYPE=static builds them all into the
+  # archive. Saying so keeps configure from picking dynload_shlib.o, whose
+  # dlopen() emcc provides but which can never succeed here.
+  EXTRA_CONFIGURE+= --disable-wasm-dynamic-linking
+
+  # WebAssembly's indirect calls check the full signature, so the fpcasts
+  # CPython and its modules rely on trap without the call trampoline.
+  CFLAGS+= -DPY_CALL_TRAMPOLINE
+  export CFLAGS
 endif
 
 # Disabled c extension modules for all platforms
@@ -125,6 +137,7 @@ ifeq ($(OS),wasm)
 	cd $(PLATFORM); patch -p1 -i ../13-wasm-em-config-clang.patch
 	cd $(PLATFORM); patch -p1 -i ../14-wasm-build-wasm-default.patch
 	cd $(PLATFORM); patch -p1 -i ../15-wasm-static-hacl.patch
+	cd $(PLATFORM); patch -p1 -i ../17-wasm-static-linking.patch
 endif
 ifeq ($(findstring iphone,$(TARGET_PLATFORM)),iphone)
 	cd $(PLATFORM); patch -p1 -i ../16-ios-platform.patch

--- a/xbmc/interfaces/python/XBPython.cpp
+++ b/xbmc/interfaces/python/XBPython.cpp
@@ -47,7 +47,14 @@ XBPython::XBPython()
   // Info about interesting python envvars available
   // at http://docs.python.org/using/cmdline.html#environment-variables
 
-#if !defined(TARGET_WINDOWS) && !defined(TARGET_ANDROID)
+#if defined(TARGET_WASM)
+  // CPython is linked statically here, so it has no install prefix to find on a
+  // real filesystem. The standard library is preloaded into the Emscripten VFS
+  // as <PYTHONHOME>/lib/pythonXY.zip, which is the zip landmark getpath() looks
+  // for; see cmake/scripts/wasm/ExtraTargets.cmake.
+  setenv("PYTHONHOME", CSpecialProtocol::TranslatePath("special://xbmc").c_str(), 1);
+  CLog::Log(LOGDEBUG, "PYTHONHOME -> {}", CSpecialProtocol::TranslatePath("special://xbmc"));
+#elif !defined(TARGET_WINDOWS) && !defined(TARGET_ANDROID)
   // check if we are running as real xbmc.app or just binary
   if (!CUtil::GetFrameworksPath(true).empty())
   {


### PR DESCRIPTION
## Description
Build CPython for the Emscripten target so that it can be linked statically into the Kodi binary, and run the interpreter from that static build:

- `tools/depends/target/python3`: `17-wasm-static-linking.patch` backports python/cpython#156798 and #156781, which move the Emscripten-only startup code out of `libpython` into objects linked only into the `python` executable. The Makefile passes `--disable-wasm-dynamic-linking` (there is no `dlopen()` for extension modules; they are built into the archive) and enables the call trampoline (`PY_CALL_TRAMPOLINE`).
- `cmake/scripts/wasm/ExtraTargets.cmake` (new) packs the standard library into `<PYTHONHOME>/lib/pythonXY.zip` — the zip landmark `getpath()` looks for — and preloads it into the Emscripten virtual filesystem. `XBPython` points `PYTHONHOME` at `special://xbmc`, which is that prefix.
- `ArchSetup.cmake` adds `-sALLOW_TABLE_GROWTH`: the call trampoline installs its adaptor with `addFunction()`.

Everything is confined to the wasm target: `ifeq ($(OS),wasm)` in the Makefile, `#if defined(TARGET_WASM)` in `XBPython`, and the `cmake/scripts/wasm` directory.

## Motivation and context
The WebAssembly port links every dependency statically. Stock CPython assumes it is either the `python` program or a shared `libpython`, so its Emscripten startup code ends up in the library and its extension modules expect `dlopen()`. WebAssembly also checks the full signature on indirect calls, so the function-pointer casts CPython and its modules rely on trap without the trampoline.

## How has this been tested?
The downstream WebAssembly build links this CPython statically and starts with Python enabled, in Chrome on macOS and on a Samsung Tizen 9.0 TV. The depends recipe was built with the wasm depends toolchain. No other platform's build is affected; the Makefile block is wasm-only.

## What is the effect on users?
None on existing platforms. Enables Python add-ons on the WebAssembly target.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
