### PR TITLE
[wasm] add a Web Audio worklet sink

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -90,4 +90,5 @@ SpacesInSquareBrackets: false
 Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never
+WhitespaceSensitiveMacros: ['EM_ASM', 'EM_JS', 'EM_ASM_INT', 'EM_ASM_DOUBLE', 'EM_ASM_PTR', 'MAIN_THREAD_EM_ASM', 'MAIN_THREAD_EM_ASM_INT', 'MAIN_THREAD_EM_ASM_DOUBLE', 'MAIN_THREAD_ASYNC_EM_ASM']
 ...

--- a/cmake/scripts/wasm/ArchSetup.cmake
+++ b/cmake/scripts/wasm/ArchSetup.cmake
@@ -29,31 +29,29 @@ set(HOST_CAN_EXECUTE_TARGET FALSE)
 # Prefer internal libs when cross-compiling to wasm (typical for depends builds)
 set(USE_INTERNAL_LIBS ON)
 
-list(APPEND AUDIO_BACKENDS_LIST "webaudio")
-
 set(APP_BINARY_SUFFIX ".js")
 
+# emcc --profiling keeps function names in the build so browser DevTools can
+# attribute samples; it is off by default because it inflates the binary.
+option(ENABLE_WASM_PROFILING "Enable Emscripten --profiling (CPU profiling in browser DevTools)" OFF)
+
 # Threading + memory (COOP/COEP headers required in HTML for pthreads).
-# PROXY_TO_PTHREAD: Kodi's init is synchronous/blocking; it must run on a
-# pthread so the browser main thread stays responsive.
-# OFFSCREEN_FRAMEBUFFER: required for WebGL to work from a pthread. Without it,
-# emscripten_webgl_make_context_current silently fails on worker threads.
-# The newRenderingFrameStarted crash (GL.currentContext null on main thread) is
-# fixed by calling MAIN_THREAD_EM_ASM to mirror the context current state on the
-# main thread right after emscripten_webgl_make_context_current (see
-# WinSystemWasmGLESContext.cpp).
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   add_link_options(
     "SHELL:-sUSE_PTHREADS=1"
-    "SHELL:-sPTHREAD_POOL_SIZE=8"
-    "SHELL:-sINITIAL_MEMORY=2GB"
+    "SHELL:-sPTHREAD_POOL_SIZE=16"
+    "SHELL:-sAUDIO_WORKLET"
+    "SHELL:-sWASM_WORKERS"
+    "SHELL:-sINITIAL_MEMORY=512MB"
+    "SHELL:-sMAXIMUM_MEMORY=4GB"
+    "SHELL:-sALLOW_MEMORY_GROWTH=1"
+    "SHELL:-sSTACK_SIZE=5MB"
     "SHELL:-sPROXY_TO_PTHREAD"
-    "SHELL:-sOFFSCREEN_FRAMEBUFFER"
     "SHELL:-sMIN_WEBGL_VERSION=2"
     "SHELL:-sMAX_WEBGL_VERSION=2"
     "SHELL:-sFULL_ES3=1"
-    "SHELL:-sABORTING_MALLOC=0"
     "SHELL:-lidbfs.js"
+    "SHELL:-lembind"
   )
 
   # ---------------------------------------------------------------------------
@@ -84,6 +82,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     message(STATUS "WASM: Debug build — SAFE_HEAP + DWARF symbols + source maps enabled")
   else()
     add_link_options("SHELL:-sASSERTIONS=1")
+  endif()
+
+  if(ENABLE_WASM_PROFILING)
+    add_compile_options(--profiling)
+    add_link_options(--profiling)
+    message(STATUS "WASM: Emscripten --profiling enabled (ENABLE_WASM_PROFILING=ON)")
   endif()
 endif()
 

--- a/cmake/treedata/wasm/wasm.txt
+++ b/cmake/treedata/wasm/wasm.txt
@@ -1,10 +1,6 @@
-xbmc/cores/AudioEngine/Sinks/webaudio  cores_AudioEngine_Sinks_webaudio
 xbmc/cores/RetroPlayer/shaders/gles   cores/RetroPlayer/shaders/gles
-xbmc/cores/VideoPlayer/Process/wasm   videoplayer_process_wasm
-xbmc/filesystem/wasm                  filesystem_wasm
 xbmc/input/touch                      input_touch
 xbmc/input/touch/generic              input_touch_generic
-xbmc/interfaces/json-rpc/wasm         interfaces_jsonrpc_wasm
 xbmc/platform/common/speech           platform/common/speech
 xbmc/platform/posix                   platform/posix
 xbmc/platform/posix/filesystem        platform/posix/filesystem
@@ -13,4 +9,3 @@ xbmc/platform/posix/utils             platform/posix/utils
 xbmc/platform/wasm                    platform/wasm
 xbmc/platform/wasm/network            platform/wasm/network
 xbmc/platform/wasm/storage            platform/wasm/storage
-xbmc/windowing/wasm                   windowing/wasm

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -182,6 +182,10 @@
 #include <memory>
 #include <mutex>
 
+#ifdef TARGET_WASM
+#include <emscripten.h>
+#endif
+
 #include <tinyxml.h>
 
 //TODO: XInitThreads
@@ -1651,10 +1655,6 @@ int CApplication::Run()
 {
   CLog::Log(LOGINFO, "Running the application...");
 
-  std::chrono::time_point<std::chrono::steady_clock> lastFrameTime;
-  std::chrono::milliseconds frameTime;
-  const unsigned int noRenderFrameTime = 15; // Simulates ~66fps
-
   CFileItemList& playlist = CServiceBroker::GetAppParams()->GetPlaylist();
   if (playlist.Size() > 0)
   {
@@ -1662,6 +1662,14 @@ int CApplication::Run()
     CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST::Id::TYPE_MUSIC);
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_PLAYLISTPLAYER_PLAY, -1);
   }
+
+#ifdef TARGET_WASM
+  emscripten_set_main_loop([]() { g_application.WasmRunIteration(); }, 0, 1);
+  return m_ExitCode;
+#else
+  std::chrono::time_point<std::chrono::steady_clock> lastFrameTime;
+  std::chrono::milliseconds frameTime;
+  const unsigned int noRenderFrameTime = 15; // Simulates ~66fps
 
   // Run the app
   while (!m_bStop)
@@ -1694,6 +1702,7 @@ int CApplication::Run()
 
   CLog::Log(LOGINFO, "Exiting the application...");
   return m_ExitCode;
+#endif
 }
 
 bool CApplication::Cleanup()

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -102,6 +102,11 @@ public:
   int Run();
   bool Cleanup();
 
+#ifdef TARGET_WASM
+  /*! \brief Single frame for Emscripten main loop (browser). */
+  void WasmRunIteration();
+#endif
+
   void FrameMove(bool processEvents, bool processGUI = true) override;
   void Render() override;
 

--- a/xbmc/application/CMakeLists.txt
+++ b/xbmc/application/CMakeLists.txt
@@ -14,6 +14,10 @@ set(SOURCES AppEnvironment.cpp
             AppParamParser.cpp
             AppParams.cpp)
 
+if(CORE_SYSTEM_NAME STREQUAL wasm)
+  list(APPEND SOURCES ${CMAKE_SOURCE_DIR}/xbmc/platform/wasm/ApplicationWasm.cpp)
+endif()
+
 set(HEADERS AppEnvironment.h
             AppInboundProtocol.h
             Application.h

--- a/xbmc/cores/AudioEngine/CMakeLists.txt
+++ b/xbmc/cores/AudioEngine/CMakeLists.txt
@@ -159,6 +159,11 @@ if(CORE_SYSTEM_NAME STREQUAL freebsd)
   list(APPEND HEADERS Sinks/AESinkOSS.h)
 endif()
 
+if(CORE_SYSTEM_NAME STREQUAL wasm)
+  list(APPEND SOURCES Sinks/AESinkWasmAudioWorklet.cpp)
+  list(APPEND HEADERS Sinks/AESinkWasmAudioWorklet.h)
+endif()
+
 core_add_library(audioengine)
 target_include_directories(${CORE_LIBRARY} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 if(NOT CORE_SYSTEM_NAME STREQUAL windows AND NOT CORE_SYSTEM_NAME STREQUAL windowsstore)

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWasmAudioWorklet.cpp
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWasmAudioWorklet.cpp
@@ -1,0 +1,200 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "AESinkWasmAudioWorklet.h"
+
+#include "cores/AudioEngine/AESinkFactory.h"
+#include "cores/AudioEngine/Utils/AEChannelInfo.h"
+#include "cores/AudioEngine/Utils/AEDeviceInfo.h"
+#include "platform/wasm/WasmAudioWorkletManager.h"
+#include "utils/log.h"
+#include "utils/TimeUtils.h"
+
+#include <algorithm>
+
+using KODI::PLATFORM::WASM::CWasmAudioWorkletManager;
+
+namespace
+{
+// Web Audio only defines speaker mixing for 1, 2, 4 and 6 channels; other counts are
+// mixed as "discrete", dropping every channel the destination lacks.
+AEStdChLayout ResolveSinkLayout(unsigned int requestedChannels, unsigned int maxOutputChannels)
+{
+  if (requestedChannels > 6 && maxOutputChannels >= 8)
+    return AE_CH_LAYOUT_7_1;
+  if (requestedChannels > 2 && maxOutputChannels >= 6)
+    return AE_CH_LAYOUT_5_1;
+  return AE_CH_LAYOUT_2_0;
+}
+} // namespace
+
+void CAESinkWasmAudioWorklet::Register()
+{
+  AE::AESinkRegEntry entry;
+  entry.sinkName = "WASM";
+  entry.createFunc = CAESinkWasmAudioWorklet::Create;
+  entry.enumerateFunc = CAESinkWasmAudioWorklet::EnumerateDevicesEx;
+  entry.cleanupFunc = CAESinkWasmAudioWorklet::Cleanup;
+  AE::CAESinkFactory::RegisterSink(entry);
+}
+
+void CAESinkWasmAudioWorklet::Cleanup()
+{
+  CWasmAudioWorkletManager::Instance().Shutdown();
+}
+
+std::unique_ptr<IAESink> CAESinkWasmAudioWorklet::Create(std::string& device,
+                                                         AEAudioFormat& desiredFormat)
+{
+  auto sink = std::make_unique<CAESinkWasmAudioWorklet>();
+  if (sink->Initialize(desiredFormat, device))
+    return sink;
+
+  return {};
+}
+
+void CAESinkWasmAudioWorklet::EnumerateDevicesEx(AEDeviceInfoList& list, bool)
+{
+  list.clear();
+
+  CAEDeviceInfo info;
+  info.m_deviceName = "default";
+  info.m_displayName = "Browser Audio";
+  info.m_displayNameExtra = "Wasm Audio Worklet";
+  info.m_deviceType = AE_DEVTYPE_PCM;
+  info.m_channels = ResolveSinkLayout(
+      CWasmAudioWorkletManager::kMaxChannels,
+      CWasmAudioWorkletManager::Instance().GetMaxOutputChannels());
+  info.m_sampleRates = {44100, 48000};
+  info.m_dataFormats = {AE_FMT_FLOATP};
+  info.m_wantsIECPassthrough = false;
+  info.m_onlyPCM = true;
+  list.push_back(info);
+}
+
+bool CAESinkWasmAudioWorklet::Initialize(AEAudioFormat& format, std::string& device)
+{
+  if (format.m_dataFormat == AE_FMT_RAW)
+  {
+    CLog::Log(LOGERROR, "CAESinkWasmAudioWorklet::Initialize - passthrough is not supported");
+    return false;
+  }
+
+  const unsigned int maxOutputChannels =
+      CWasmAudioWorkletManager::Instance().GetMaxOutputChannels();
+  format.m_channelLayout =
+      CAEChannelInfo(ResolveSinkLayout(format.m_channelLayout.Count(), maxOutputChannels));
+  const unsigned int channels = format.m_channelLayout.Count();
+
+  if (!CWasmAudioWorkletManager::Instance().Initialize(channels, format.m_sampleRate))
+    return false;
+
+  device = "default";
+  format.m_dataFormat = AE_FMT_FLOATP;
+  format.m_sampleRate = CWasmAudioWorkletManager::Instance().GetSampleRate();
+
+  constexpr unsigned int TARGET_PERIOD_MS = 20;
+  const unsigned int quantum = CWasmAudioWorkletManager::Instance().GetQuantumSize();
+  const unsigned int targetFrames = (format.m_sampleRate * TARGET_PERIOD_MS + 999U) / 1000U;
+  unsigned int periodFrames = targetFrames;
+  if (quantum > 0)
+    periodFrames = ((targetFrames + quantum - 1U) / quantum) * quantum;
+  format.m_frames = std::max<unsigned int>(periodFrames, quantum);
+
+  format.m_frameSize = channels * static_cast<unsigned int>(sizeof(float));
+  m_initialized = true;
+
+  CLog::Log(LOGINFO,
+            "CAESinkWasmAudioWorklet: sink period set to {} frames ({:.2f} ms) "
+            "from worklet quantum {} @ {} Hz",
+            format.m_frames,
+            static_cast<double>(format.m_frames) * 1000.0 /
+                static_cast<double>(format.m_sampleRate),
+            quantum, format.m_sampleRate);
+
+  return true;
+}
+
+void CAESinkWasmAudioWorklet::Deinitialize()
+{
+  if (!m_initialized)
+    return;
+
+  CWasmAudioWorkletManager::Instance().Shutdown();
+  m_initialized = false;
+}
+
+double CAESinkWasmAudioWorklet::GetCacheTotal()
+{
+  return CWasmAudioWorkletManager::Instance().GetBufferCapacitySeconds();
+}
+
+unsigned int CAESinkWasmAudioWorklet::AddPackets(uint8_t** data, unsigned int frames, unsigned int offset)
+{
+  if (!m_initialized || !data || !data[0])
+    return 0;
+
+  const unsigned int channels = CWasmAudioWorkletManager::Instance().GetChannels();
+  if (channels == 0)
+    return 0;
+
+  // Build a plane-pointer array for the manager. ActiveAE passes planar data
+  // as one pointer per channel in data[0..channels-1] when the sink format is
+  // AE_FMT_FLOATP, and a single interleaved pointer in data[0] otherwise.
+  // Since we advertise AE_FMT_FLOATP we always take the planar path.
+  const float* planes[CWasmAudioWorkletManager::kMaxChannels]{};
+  for (unsigned int ch = 0; ch < channels; ++ch)
+  {
+    if (!data[ch])
+      return 0;
+    planes[ch] = reinterpret_cast<const float*>(data[ch]);
+  }
+
+  const unsigned int written =
+      CWasmAudioWorkletManager::Instance().WritePlanar(planes, channels, frames, offset);
+  DrainUnderrunLog();
+  return written;
+}
+
+void CAESinkWasmAudioWorklet::GetDelay(AEDelayStatus& status)
+{
+  const double totalDelay = CWasmAudioWorkletManager::Instance().GetTotalDelaySeconds();
+  status.SetDelay(totalDelay);
+  status.maxcorrection = totalDelay;
+  status.tick = CurrentHostCounter();
+}
+
+void CAESinkWasmAudioWorklet::Drain()
+{
+  if (!m_initialized)
+    return;
+
+  CWasmAudioWorkletManager::Instance().Drain();
+  DrainUnderrunLog();
+}
+
+void CAESinkWasmAudioWorklet::DrainUnderrunLog()
+{
+  m_pendingUnderrunFrames += CWasmAudioWorkletManager::Instance().ConsumeUnderrunFrames();
+  if (m_pendingUnderrunFrames == 0)
+    return;
+
+  const unsigned int sampleRate = CWasmAudioWorkletManager::Instance().GetSampleRate();
+  if (sampleRate == 0)
+    return;
+
+  constexpr uint64_t LOG_THRESHOLD_MS = 10;
+  const uint64_t thresholdFrames = (static_cast<uint64_t>(sampleRate) * LOG_THRESHOLD_MS) / 1000;
+  if (thresholdFrames == 0 || m_pendingUnderrunFrames < thresholdFrames)
+    return;
+
+  const double missingMs =
+      static_cast<double>(m_pendingUnderrunFrames) * 1000.0 / static_cast<double>(sampleRate);
+  CLog::Log(LOGWARNING,
+            "CAESinkWasmAudioWorklet: worklet underrun, {} frames ({:.2f} ms) of silence "
+            "emitted since last report",
+            m_pendingUnderrunFrames, missingMs);
+  m_pendingUnderrunFrames = 0;
+}

--- a/xbmc/cores/AudioEngine/Sinks/AESinkWasmAudioWorklet.h
+++ b/xbmc/cores/AudioEngine/Sinks/AESinkWasmAudioWorklet.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include "cores/AudioEngine/Interfaces/AESink.h"
+#include "cores/AudioEngine/Utils/AEDeviceInfo.h"
+
+#include <cstdint>
+#include <memory>
+
+class CAESinkWasmAudioWorklet : public IAESink
+{
+public:
+  const char* GetName() override { return "WasmAudioWorklet"; }
+
+  CAESinkWasmAudioWorklet() = default;
+  ~CAESinkWasmAudioWorklet() override = default;
+
+  static void Register();
+  static void Cleanup();
+  static std::unique_ptr<IAESink> Create(std::string& device, AEAudioFormat& desiredFormat);
+  static void EnumerateDevicesEx(AEDeviceInfoList& list, bool force = false);
+
+  bool Initialize(AEAudioFormat& format, std::string& device) override;
+  void Deinitialize() override;
+
+  double GetCacheTotal() override;
+  unsigned int AddPackets(uint8_t** data, unsigned int frames, unsigned int offset) override;
+  void GetDelay(AEDelayStatus& status) override;
+  void Drain() override;
+
+private:
+  void DrainUnderrunLog();
+
+  bool m_initialized{false};
+  uint64_t m_pendingUnderrunFrames{0};
+};

--- a/xbmc/platform/wasm/ApplicationWasm.cpp
+++ b/xbmc/platform/wasm/ApplicationWasm.cpp
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "application/AppEnvironment.h"
+#include "application/Application.h"
+#include "application/ApplicationPowerHandling.h"
+#include "utils/XTimeUtils.h"
+#include "utils/log.h"
+
+#include <chrono>
+
+#include <emscripten.h>
+
+// Built only for CORE_SYSTEM_NAME==wasm (see application/CMakeLists.txt).
+void CApplication::WasmRunIteration()
+{
+  if (m_bStop)
+  {
+    emscripten_cancel_main_loop();
+    CLog::Log(LOGINFO, "Exiting the application (WASM)...");
+    Cleanup();
+    CAppEnvironment::TearDown();
+    return;
+  }
+
+  static std::chrono::time_point<std::chrono::steady_clock> lastFrameTime =
+      std::chrono::steady_clock::now();
+  std::chrono::milliseconds frameTime;
+  const unsigned int noRenderFrameTime = 15;
+
+  Process();
+
+  bool renderGUI = GetComponent<CApplicationPowerHandling>()->GetRenderGUI();
+  if (!m_bStop)
+    FrameMove(true, renderGUI);
+
+  if (renderGUI && !m_bStop)
+    Render();
+  else if (!renderGUI)
+  {
+    auto now = std::chrono::steady_clock::now();
+    frameTime = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastFrameTime);
+    if (frameTime.count() < noRenderFrameTime)
+    {
+      KODI::TIME::Sleep(std::chrono::milliseconds(noRenderFrameTime - frameTime.count()));
+    }
+  }
+  lastFrameTime = std::chrono::steady_clock::now();
+}

--- a/xbmc/platform/wasm/CMakeLists.txt
+++ b/xbmc/platform/wasm/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(SOURCES CPUInfoWasm.cpp
+            GPUInfoWasm.cpp
+            MemUtils.cpp
+            PlatformWasm.cpp)
+
+set(HEADERS CPUInfoWasm.h
+            GPUInfoWasm.h
+            PlatformWasm.h)
+
+core_add_library(platform_wasm)

--- a/xbmc/platform/wasm/CMakeLists.txt
+++ b/xbmc/platform/wasm/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(SOURCES CPUInfoWasm.cpp
             GPUInfoWasm.cpp
             MemUtils.cpp
-            PlatformWasm.cpp)
+            PlatformWasm.cpp
+            WasmAudioWorkletManager.cpp)
 
 set(HEADERS CPUInfoWasm.h
             GPUInfoWasm.h
-            PlatformWasm.h)
+            PlatformWasm.h
+            WasmAudioWorkletManager.h)
 
 core_add_library(platform_wasm)

--- a/xbmc/platform/wasm/CPUInfoWasm.cpp
+++ b/xbmc/platform/wasm/CPUInfoWasm.cpp
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "CPUInfoWasm.h"
+
+std::shared_ptr<CCPUInfo> CCPUInfo::GetCPUInfo()
+{
+  return std::make_shared<CCPUInfoWasm>();
+}
+
+CCPUInfoWasm::CCPUInfoWasm()
+{
+  m_cpuCount = 1;
+  m_cpuModel = "WebAssembly";
+  m_cores.emplace_back();
+  m_cores.back().m_id = 0;
+}
+
+int CCPUInfoWasm::GetUsedPercentage()
+{
+  return 0;
+}
+
+float CCPUInfoWasm::GetCPUFrequency()
+{
+  return 0.0f;
+}

--- a/xbmc/platform/wasm/CPUInfoWasm.cpp
+++ b/xbmc/platform/wasm/CPUInfoWasm.cpp
@@ -8,6 +8,8 @@
 
 #include "CPUInfoWasm.h"
 
+#include <emscripten.h>
+
 std::shared_ptr<CCPUInfo> CCPUInfo::GetCPUInfo()
 {
   return std::make_shared<CCPUInfoWasm>();
@@ -15,10 +17,22 @@ std::shared_ptr<CCPUInfo> CCPUInfo::GetCPUInfo()
 
 CCPUInfoWasm::CCPUInfoWasm()
 {
-  m_cpuCount = 1;
+  m_cpuCount = EM_ASM_INT({
+    if (typeof navigator !== "undefined" && Number.isFinite(navigator.hardwareConcurrency) &&
+        navigator.hardwareConcurrency > 0)
+      return Math.floor(navigator.hardwareConcurrency);
+
+    return 1;
+  });
+
   m_cpuModel = "WebAssembly";
-  m_cores.emplace_back();
-  m_cores.back().m_id = 0;
+
+  for (int core = 0; core < m_cpuCount; core++)
+  {
+    CoreInfo coreInfo;
+    coreInfo.m_id = core;
+    m_cores.emplace_back(coreInfo);
+  }
 }
 
 int CCPUInfoWasm::GetUsedPercentage()

--- a/xbmc/platform/wasm/CPUInfoWasm.h
+++ b/xbmc/platform/wasm/CPUInfoWasm.h
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/CPUInfoPosix.h"
+
+class CCPUInfoWasm : public CCPUInfoPosix
+{
+public:
+  CCPUInfoWasm();
+  ~CCPUInfoWasm() = default;
+
+  int GetUsedPercentage() override;
+  float GetCPUFrequency() override;
+};

--- a/xbmc/platform/wasm/GPUInfoWasm.cpp
+++ b/xbmc/platform/wasm/GPUInfoWasm.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GPUInfoWasm.h"
+
+std::unique_ptr<CGPUInfo> CGPUInfo::GetGPUInfo()
+{
+  return std::make_unique<CGPUInfoWasm>();
+}
+
+bool CGPUInfoWasm::SupportsPlatformTemperature() const
+{
+  return false;
+}
+
+bool CGPUInfoWasm::GetGPUPlatformTemperature(CTemperature& temperature) const
+{
+  return false;
+}

--- a/xbmc/platform/wasm/GPUInfoWasm.h
+++ b/xbmc/platform/wasm/GPUInfoWasm.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/GPUInfoPosix.h"
+
+class CGPUInfoWasm : public CGPUInfoPosix
+{
+public:
+  CGPUInfoWasm() = default;
+  ~CGPUInfoWasm() = default;
+
+private:
+  bool SupportsPlatformTemperature() const override;
+  bool GetGPUPlatformTemperature(CTemperature& temperature) const override;
+};

--- a/xbmc/platform/wasm/MemUtils.cpp
+++ b/xbmc/platform/wasm/MemUtils.cpp
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/MemUtils.h"
+
+#include <cstdint>
+#include <cstdlib>
+
+#include <emscripten/heap.h>
+
+namespace KODI
+{
+namespace MEMORY
+{
+
+void* AlignedMalloc(size_t s, size_t alignTo)
+{
+  void* p = nullptr;
+  int res = posix_memalign(&p, alignTo, s);
+  if (res == EINVAL)
+    throw std::runtime_error("Failed to align memory, alignment is not a multiple of 2");
+  else if (res == ENOMEM)
+    throw std::runtime_error("Failed to align memory, insufficient memory available");
+  return p;
+}
+
+void AlignedFree(void* p)
+{
+  if (!p)
+    return;
+  free(p);
+}
+
+void GetMemoryStatus(MemoryStatus* buffer)
+{
+  if (!buffer)
+    return;
+
+  // The sbrk break, not the linear-memory size, is what the allocator has claimed.
+  const uint64_t heapMax = static_cast<uint64_t>(emscripten_get_heap_max());
+  const uint64_t heapUsed = static_cast<uint64_t>(*emscripten_get_sbrk_ptr());
+  buffer->totalPhys = heapMax;
+  buffer->availPhys = (heapMax > heapUsed) ? (heapMax - heapUsed) : 0;
+}
+
+} // namespace MEMORY
+} // namespace KODI

--- a/xbmc/platform/wasm/PlatformWasm.cpp
+++ b/xbmc/platform/wasm/PlatformWasm.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PlatformWasm.h"
+
+#include <cstdlib>
+
+CPlatform* CPlatform::CreateInstance()
+{
+  return new CPlatformWasm();
+}
+
+bool CPlatformWasm::InitStageOne()
+{
+  if (!std::getenv("HOME"))
+    setenv("HOME", "/home/web_user", 1);
+
+  return CPlatformPosix::InitStageOne();
+}

--- a/xbmc/platform/wasm/PlatformWasm.cpp
+++ b/xbmc/platform/wasm/PlatformWasm.cpp
@@ -8,6 +8,8 @@
 
 #include "PlatformWasm.h"
 
+#include "cores/AudioEngine/Sinks/AESinkWasmAudioWorklet.h"
+
 #include <cstdlib>
 
 CPlatform* CPlatform::CreateInstance()
@@ -20,5 +22,10 @@ bool CPlatformWasm::InitStageOne()
   if (!std::getenv("HOME"))
     setenv("HOME", "/home/web_user", 1);
 
-  return CPlatformPosix::InitStageOne();
+  if (!CPlatformPosix::InitStageOne())
+    return false;
+
+  CAESinkWasmAudioWorklet::Register();
+
+  return true;
 }

--- a/xbmc/platform/wasm/PlatformWasm.h
+++ b/xbmc/platform/wasm/PlatformWasm.h
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/PlatformPosix.h"
+
+class CPlatformWasm : public CPlatformPosix
+{
+public:
+  bool InitStageOne() override;
+};

--- a/xbmc/platform/wasm/WasmAudioWorkletManager.cpp
+++ b/xbmc/platform/wasm/WasmAudioWorkletManager.cpp
@@ -1,0 +1,834 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "WasmAudioWorkletManager.h"
+
+#include "utils/log.h"
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+
+#include <emscripten.h>
+#include <emscripten/em_asm.h>
+#include <emscripten/threading.h>
+#include <emscripten/webaudio.h>
+
+namespace
+{
+constexpr char AUDIO_PROCESSOR_NAME[] = "kodi-audio-worklet";
+constexpr unsigned int BUFFER_TARGET_MS = 100;
+constexpr unsigned int MIN_BUFFER_QUANTA = 2;
+constexpr unsigned int PREBUFFER_TARGET_MS = 40;
+constexpr unsigned int WORKLET_STALL_LIMIT_MS = 500;
+constexpr auto ASYNC_TIMEOUT = std::chrono::seconds(5);
+
+int CreateAudioContextOnMain(int requestedSampleRate)
+{
+  EmscriptenWebAudioCreateAttributes attrs{};
+  attrs.latencyHint = "interactive";
+  attrs.sampleRate = static_cast<uint32_t>(std::max(requestedSampleRate, 0));
+  attrs.renderSizeHint = AUDIO_CONTEXT_RENDER_SIZE_DEFAULT;
+  return emscripten_create_audio_context(&attrs);
+}
+
+int GetAudioContextSampleRateOnMain(int audioContext)
+{
+  return emscripten_audio_context_sample_rate(audioContext);
+}
+
+int GetAudioContextQuantumSizeOnMain(int audioContext)
+{
+  return emscripten_audio_context_quantum_size(audioContext);
+}
+
+int GetAudioContextLatencyUsOnMain(int audioContext)
+{
+  const double totalSeconds = EM_ASM_DOUBLE(
+      {
+        const ctx = emscriptenGetAudioObject($0);
+        if (!ctx)
+          return 0.0;
+        let total = 0.0;
+        if (typeof ctx.baseLatency === "number" && isFinite(ctx.baseLatency))
+          total += ctx.baseLatency;
+        if (typeof ctx.outputLatency === "number" && isFinite(ctx.outputLatency))
+          total += ctx.outputLatency;
+        return total;
+      },
+      audioContext);
+
+  if (!(totalSeconds > 0.0))
+    return 0;
+  const double us = totalSeconds * 1'000'000.0;
+  if (us > static_cast<double>(std::numeric_limits<int>::max()))
+    return std::numeric_limits<int>::max();
+  return static_cast<int>(us);
+}
+
+void StartWorkletThreadOnMain(int audioContext,
+                              uintptr_t stackBase,
+                              int stackSize,
+                              uintptr_t callback,
+                              uintptr_t userData)
+{
+  emscripten_start_wasm_audio_worklet_thread_async(
+      audioContext, reinterpret_cast<void*>(stackBase), static_cast<uint32_t>(stackSize),
+      reinterpret_cast<EmscriptenStartWebAudioWorkletCallback>(callback),
+      reinterpret_cast<void*>(userData));
+}
+
+void CreateProcessorOnMain(int audioContext,
+                           uintptr_t options,
+                           uintptr_t callback,
+                           uintptr_t userData)
+{
+  emscripten_create_wasm_audio_worklet_processor_async(
+      audioContext, reinterpret_cast<const WebAudioWorkletProcessorCreateOptions*>(options),
+      reinterpret_cast<EmscriptenWorkletProcessorCreatedCallback>(callback),
+      reinterpret_cast<void*>(userData));
+}
+
+int CreateNodeOnMain(int audioContext,
+                     uintptr_t name,
+                     uintptr_t options,
+                     uintptr_t processCallback,
+                     uintptr_t userData)
+{
+  return emscripten_create_wasm_audio_worklet_node(
+      audioContext, reinterpret_cast<const char*>(name),
+      reinterpret_cast<const EmscriptenAudioWorkletNodeCreateOptions*>(options),
+      reinterpret_cast<EmscriptenWorkletNodeProcessCallback>(processCallback),
+      reinterpret_cast<void*>(userData));
+}
+
+void ConnectAudioNodeOnMain(int source, int destination, int outputIndex, int inputIndex)
+{
+  emscripten_audio_node_connect(source, destination, outputIndex, inputIndex);
+}
+
+void DestroyAudioContextOnMain(int audioContext)
+{
+  emscripten_destroy_audio_context(audioContext);
+}
+
+int QueryMaxOutputChannelsOnMain(int audioContext)
+{
+  return EM_ASM_INT(
+      {
+        let ctx = $0 ? emscriptenGetAudioObject($0) : null;
+        const temporary = !ctx;
+        try
+        {
+          if (!ctx)
+            ctx = new AudioContext();
+          return ctx.destination.maxChannelCount | 0;
+        }
+        catch (e)
+        {
+          return 0;
+        }
+        finally
+        {
+          if (temporary && ctx)
+            ctx.close().catch(() => {});
+        }
+      },
+      audioContext);
+}
+
+// AudioDestinationNode.channelCount defaults to 2 regardless of the hardware, which
+// would fold a 5.1 node to stereo.
+void SetDestinationChannelCountOnMain(int audioContext, int channels)
+{
+  EM_ASM(
+      {
+        const ctx = emscriptenGetAudioObject($0);
+        if (!ctx)
+          return;
+        const dest = ctx.destination;
+        try
+        {
+          dest.channelCount = Math.min($1, dest.maxChannelCount);
+        }
+        catch (e)
+        {
+          console.warn("WASM AudioWorklet: cannot set destination channelCount", e);
+        }
+      },
+      audioContext, channels);
+}
+
+void DestroyAudioNodeOnMain(int audioNode)
+{
+  emscripten_destroy_web_audio_node(audioNode);
+}
+
+void ClearResumeHooksOnMain(int audioContext)
+{
+  EM_ASM(
+      {
+        const ctx = emscriptenGetAudioObject($0);
+        if (!ctx || !ctx.__kodiResumeHandler)
+          return;
+        const handler = ctx.__kodiResumeHandler;
+        window.removeEventListener("pointerdown", handler, true);
+        window.removeEventListener("keydown", handler, true);
+        window.removeEventListener("touchstart", handler, true);
+        document.removeEventListener("visibilitychange", handler, true);
+        ctx.__kodiResumeHandler = null;
+        ctx.__kodiResumeHooksInstalled = false;
+      },
+      audioContext);
+}
+
+} // namespace
+
+namespace KODI::PLATFORM::WASM
+{
+CWasmAudioWorkletManager& CWasmAudioWorkletManager::Instance()
+{
+  static CWasmAudioWorkletManager instance;
+  return instance;
+}
+
+bool CWasmAudioWorkletManager::Initialize(unsigned int channels, unsigned int requestedSampleRate)
+{
+  if (channels == 0 || channels > kMaxChannels)
+  {
+    CLog::Log(LOGERROR, "WASM AudioWorklet: unsupported channel count {}", channels);
+    return false;
+  }
+
+  m_ready.store(false, std::memory_order_release);
+
+  if (!EnsureContext(requestedSampleRate))
+  {
+    Shutdown();
+    return false;
+  }
+
+  if (!EnsureWorkletProcessor())
+  {
+    Shutdown();
+    return false;
+  }
+
+  if (!ConfigureNode(channels))
+  {
+    Shutdown();
+    return false;
+  }
+
+  EnsureBufferAllocated();
+  ResetBuffer();
+  InstallResumeHooks();
+  RefreshPipelineLatency();
+
+  m_ready.store(true, std::memory_order_release);
+  const unsigned int sampleRateNow = std::max(m_sampleRate.load(std::memory_order_relaxed), 1U);
+  const double prebufMs =
+      static_cast<double>(m_prebufferFrames) * 1000.0 / static_cast<double>(sampleRateNow);
+  CLog::Log(LOGINFO,
+            "WASM AudioWorklet: initialized (channels={}, sampleRate={}, quantum={}, "
+            "pipelineLatency={:.3f} ms, ringCapacity={:.3f} ms, prebuffer={:.1f} ms)",
+            channels, m_sampleRate.load(std::memory_order_relaxed),
+            m_quantumSize.load(std::memory_order_relaxed),
+            GetPipelineLatencySeconds() * 1000.0, GetBufferCapacitySeconds() * 1000.0,
+            prebufMs);
+  return true;
+}
+
+void CWasmAudioWorkletManager::ResetBuffer()
+{
+  const uint64_t currentWrite = m_writeFrame.load(std::memory_order_acquire);
+  m_readFrame.store(currentWrite, std::memory_order_release);
+  m_underrunFrames.store(0, std::memory_order_relaxed);
+  m_prebufferComplete.store(false, std::memory_order_release);
+}
+
+void CWasmAudioWorkletManager::Shutdown()
+{
+  WaitForWorkletIdle();
+
+  if (m_workletNode != 0)
+  {
+    emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VI, DestroyAudioNodeOnMain,
+                                               m_workletNode);
+    m_workletNode = 0;
+  }
+  if (m_audioContext != 0)
+  {
+    ClearResumeHooks();
+    emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VI, DestroyAudioContextOnMain,
+                                               m_audioContext);
+    m_audioContext = 0;
+  }
+
+  m_workletThreadCreated.store(false, std::memory_order_release);
+  m_processorCreated.store(false, std::memory_order_release);
+  m_bufferCapacityFrames = 0;
+  m_bufferChannels = 0;
+  m_bufferSampleRate = 0;
+  m_bufferQuantumSize = 0;
+  m_prebufferFrames = 0;
+  m_prebufferComplete.store(false, std::memory_order_release);
+  m_ringBuffer.clear();
+  m_ringBuffer.shrink_to_fit();
+  m_readFrame.store(0, std::memory_order_release);
+  m_writeFrame.store(0, std::memory_order_release);
+  m_pipelineLatencyUs.store(0, std::memory_order_relaxed);
+  m_underrunFrames.store(0, std::memory_order_relaxed);
+}
+
+unsigned int CWasmAudioWorkletManager::WritePlanar(const float* const* planes,
+                                                   unsigned int channels,
+                                                   unsigned int frames,
+                                                   unsigned int offsetFrames)
+{
+
+  if (!planes || frames == 0 || !IsReady())
+  {
+    return 0;
+  }
+
+  const unsigned int configuredChannels = m_channels.load(std::memory_order_relaxed);
+  if (configuredChannels == 0 || configuredChannels > kMaxChannels)
+    return 0;
+
+  const unsigned int copyChannels = std::min(channels, configuredChannels);
+  if (copyChannels == 0)
+    return 0;
+
+  const int quantumMs = QuantumSleepMs();
+
+  unsigned int writtenFrames = 0;
+  unsigned int stalledMs = 0;
+  while (writtenFrames < frames)
+  {
+    if (!IsReady())
+      return writtenFrames;
+
+    const unsigned int capacityFrames = m_bufferCapacityFrames;
+    if (capacityFrames == 0 || m_ringBuffer.empty())
+      return writtenFrames;
+
+    const uint64_t readFrame = m_readFrame.load(std::memory_order_acquire);
+    const uint64_t writeFrame = m_writeFrame.load(std::memory_order_relaxed);
+    const uint64_t usedFrames = writeFrame - readFrame;
+    if (usedFrames >= capacityFrames)
+    {
+      stalledMs += static_cast<unsigned int>(quantumMs);
+      if (stalledMs >= WORKLET_STALL_LIMIT_MS)
+        return writtenFrames;
+      emscripten_thread_sleep(quantumMs);
+      continue;
+    }
+    stalledMs = 0;
+
+    const uint64_t freeFrames = capacityFrames - usedFrames;
+    const uint64_t toWrite = std::min<uint64_t>(frames - writtenFrames, freeFrames);
+    const uint64_t dstStart = writeFrame % capacityFrames;
+    const uint64_t firstChunk = std::min<uint64_t>(toWrite, capacityFrames - dstStart);
+    const uint64_t secondChunk = toWrite - firstChunk;
+
+    for (unsigned int ch = 0; ch < copyChannels; ++ch)
+    {
+      if (!planes[ch])
+        return writtenFrames;
+      float* const dstPlane = &m_ringBuffer[static_cast<size_t>(ch) * capacityFrames];
+      const float* const srcPlane = planes[ch] + offsetFrames + writtenFrames;
+      std::memcpy(dstPlane + dstStart, srcPlane, firstChunk * sizeof(float));
+      if (secondChunk > 0)
+        std::memcpy(dstPlane, srcPlane + firstChunk, secondChunk * sizeof(float));
+    }
+    // Zero any ring planes the writer did not fill (e.g. upmix headroom) so
+    // stale data never leaks into the browser output.
+    for (unsigned int ch = copyChannels; ch < configuredChannels; ++ch)
+    {
+      float* const dstPlane = &m_ringBuffer[static_cast<size_t>(ch) * capacityFrames];
+      std::memset(dstPlane + dstStart, 0, firstChunk * sizeof(float));
+      if (secondChunk > 0)
+        std::memset(dstPlane, 0, secondChunk * sizeof(float));
+    }
+
+    m_writeFrame.store(writeFrame + toWrite, std::memory_order_release);
+    writtenFrames += static_cast<unsigned int>(toWrite);
+  }
+
+  return writtenFrames;
+}
+
+// Sleeping for one audio quantum wakes a waiting thread right when the worklet has
+// consumed a block, rather than busy-looping on 1 ms sleeps.
+int CWasmAudioWorkletManager::QuantumSleepMs() const
+{
+  const unsigned int sampleRate = std::max(m_sampleRate.load(std::memory_order_relaxed), 1U);
+  const unsigned int quantum = std::max(m_quantumSize.load(std::memory_order_relaxed), 1U);
+  return std::max(1,
+                  static_cast<int>((static_cast<uint64_t>(quantum) * 1000ULL + sampleRate - 1ULL) /
+                                   sampleRate));
+}
+
+void CWasmAudioWorkletManager::Drain()
+{
+  const int quantumMs = QuantumSleepMs();
+  uint64_t lastReadFrame = m_readFrame.load(std::memory_order_acquire);
+  unsigned int stalledMs = 0;
+
+  while (IsReady() && GetBufferedSeconds() > 0.0)
+  {
+    emscripten_thread_sleep(quantumMs);
+
+    const uint64_t readFrame = m_readFrame.load(std::memory_order_acquire);
+    if (readFrame != lastReadFrame)
+    {
+      lastReadFrame = readFrame;
+      stalledMs = 0;
+      continue;
+    }
+
+    // An AudioContext that no user gesture has resumed yet never drains the ring,
+    // so stop waiting rather than hold up the sink thread until a fixed deadline.
+    stalledMs += static_cast<unsigned int>(quantumMs);
+    if (stalledMs >= WORKLET_STALL_LIMIT_MS)
+      return;
+  }
+}
+
+double CWasmAudioWorkletManager::GetBufferedSeconds() const
+{
+  const unsigned int rate = m_sampleRate.load(std::memory_order_relaxed);
+  if (rate == 0)
+    return 0.0;
+
+  const uint64_t readFrame = m_readFrame.load(std::memory_order_acquire);
+  const uint64_t writeFrame = m_writeFrame.load(std::memory_order_relaxed);
+  const uint64_t queuedFrames = writeFrame - readFrame;
+  return static_cast<double>(queuedFrames) / static_cast<double>(rate);
+}
+
+double CWasmAudioWorkletManager::GetBufferCapacitySeconds() const
+{
+  const unsigned int rate = m_sampleRate.load(std::memory_order_relaxed);
+  if (rate == 0 || m_bufferCapacityFrames == 0)
+    return 0.0;
+
+  return static_cast<double>(m_bufferCapacityFrames) / static_cast<double>(rate);
+}
+
+double CWasmAudioWorkletManager::GetPipelineLatencySeconds() const
+{
+  return static_cast<double>(m_pipelineLatencyUs.load(std::memory_order_relaxed)) / 1'000'000.0;
+}
+
+double CWasmAudioWorkletManager::GetTotalDelaySeconds() const
+{
+  return GetBufferedSeconds() + GetPipelineLatencySeconds();
+}
+
+uint64_t CWasmAudioWorkletManager::ConsumeUnderrunFrames()
+{
+  return m_underrunFrames.exchange(0, std::memory_order_relaxed);
+}
+
+unsigned int CWasmAudioWorkletManager::GetSampleRate() const
+{
+  return m_sampleRate.load(std::memory_order_relaxed);
+}
+
+unsigned int CWasmAudioWorkletManager::GetQuantumSize() const
+{
+  return m_quantumSize.load(std::memory_order_relaxed);
+}
+
+unsigned int CWasmAudioWorkletManager::GetChannels() const
+{
+  return m_channels.load(std::memory_order_relaxed);
+}
+
+unsigned int CWasmAudioWorkletManager::GetMaxOutputChannels() const
+{
+  const int channels = emscripten_sync_run_in_main_runtime_thread(
+      EM_FUNC_SIG_II, QueryMaxOutputChannelsOnMain, m_audioContext);
+  return channels > 0 ? static_cast<unsigned int>(channels) : 2U;
+}
+
+// seq_cst pairs with ProcessAudio(), which increments m_activeCallbacks before loading
+// m_ready: either the worklet sees the flag or we see the callback and wait for it.
+void CWasmAudioWorkletManager::WaitForWorkletIdle()
+{
+  m_ready.store(false, std::memory_order_seq_cst);
+  for (unsigned int i = 0; i < 100 && m_activeCallbacks.load(std::memory_order_seq_cst) > 0; ++i)
+    emscripten_thread_sleep(1);
+}
+
+bool CWasmAudioWorkletManager::IsReady() const
+{
+  return m_ready.load(std::memory_order_acquire);
+}
+
+bool CWasmAudioWorkletManager::EnsureContext(unsigned int requestedSampleRate)
+{
+  if (m_audioContext != 0)
+    return true;
+
+  m_audioContext = emscripten_sync_run_in_main_runtime_thread(
+      EM_FUNC_SIG_II, CreateAudioContextOnMain, static_cast<int>(requestedSampleRate));
+
+  if (m_audioContext == 0)
+  {
+    CLog::Log(LOGERROR, "WASM AudioWorklet: failed to create AudioContext");
+    return false;
+  }
+
+  const int sampleRate = emscripten_sync_run_in_main_runtime_thread(
+      EM_FUNC_SIG_II, GetAudioContextSampleRateOnMain, m_audioContext);
+  const int quantumSize = emscripten_sync_run_in_main_runtime_thread(
+      EM_FUNC_SIG_II, GetAudioContextQuantumSizeOnMain, m_audioContext);
+
+  m_sampleRate.store(static_cast<unsigned int>(sampleRate), std::memory_order_relaxed);
+  m_quantumSize.store(static_cast<unsigned int>(quantumSize), std::memory_order_relaxed);
+
+  return true;
+}
+
+bool CWasmAudioWorkletManager::EnsureWorkletProcessor()
+{
+  if (m_audioContext == 0)
+    return false;
+
+  alignas(16) static std::array<uint8_t, 16384> workletStack{};
+
+  if (!m_workletThreadCreated.load(std::memory_order_acquire))
+  {
+    m_asyncDone.store(false, std::memory_order_release);
+    m_asyncResult.store(false, std::memory_order_release);
+
+    emscripten_sync_run_in_main_runtime_thread(
+        EM_FUNC_SIG_VIIIII, StartWorkletThreadOnMain, m_audioContext,
+        reinterpret_cast<uintptr_t>(workletStack.data()), static_cast<int>(workletStack.size()),
+        reinterpret_cast<uintptr_t>(&CWasmAudioWorkletManager::OnWorkletThreadStarted),
+        reinterpret_cast<uintptr_t>(this));
+
+    if (!WaitForState(m_asyncDone, "thread"))
+      return false;
+
+    if (!m_asyncResult.load(std::memory_order_acquire))
+    {
+      CLog::Log(LOGERROR, "WASM AudioWorklet: failed to create worklet thread");
+      return false;
+    }
+    m_workletThreadCreated.store(true, std::memory_order_release);
+  }
+
+  if (!m_processorCreated.load(std::memory_order_acquire))
+  {
+    WebAudioWorkletProcessorCreateOptions opts{};
+    opts.name = AUDIO_PROCESSOR_NAME;
+
+    m_asyncDone.store(false, std::memory_order_release);
+    m_asyncResult.store(false, std::memory_order_release);
+    emscripten_sync_run_in_main_runtime_thread(
+        EM_FUNC_SIG_VIIII, CreateProcessorOnMain, m_audioContext,
+        reinterpret_cast<uintptr_t>(&opts),
+        reinterpret_cast<uintptr_t>(&CWasmAudioWorkletManager::OnProcessorCreated),
+        reinterpret_cast<uintptr_t>(this));
+
+    if (!WaitForState(m_asyncDone, "processor"))
+      return false;
+
+    if (!m_asyncResult.load(std::memory_order_acquire))
+    {
+      CLog::Log(LOGERROR, "WASM AudioWorklet: failed to create processor");
+      return false;
+    }
+    m_processorCreated.store(true, std::memory_order_release);
+  }
+
+  return true;
+}
+
+bool CWasmAudioWorkletManager::ConfigureNode(unsigned int channels)
+{
+  m_channels.store(channels, std::memory_order_release);
+
+  if (m_workletNode != 0)
+  {
+    emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VI, DestroyAudioNodeOnMain,
+                                               m_workletNode);
+    m_workletNode = 0;
+  }
+
+  int outputChannelCounts[1] = {static_cast<int>(channels)};
+  EmscriptenAudioWorkletNodeCreateOptions options{};
+  options.numberOfInputs = 0;
+  options.numberOfOutputs = 1;
+  options.outputChannelCounts = outputChannelCounts;
+  options.channelCount = channels;
+  options.channelCountMode = WEBAUDIO_CHANNEL_COUNT_MODE_EXPLICIT;
+  options.channelInterpretation = WEBAUDIO_CHANNEL_INTERPRETATION_SPEAKERS;
+
+  m_workletNode = emscripten_sync_run_in_main_runtime_thread(
+      EM_FUNC_SIG_IIIIII, CreateNodeOnMain, m_audioContext,
+      reinterpret_cast<uintptr_t>(AUDIO_PROCESSOR_NAME), reinterpret_cast<uintptr_t>(&options),
+      reinterpret_cast<uintptr_t>(reinterpret_cast<EmscriptenWorkletNodeProcessCallback>(
+          &CWasmAudioWorkletManager::ProcessAudio)),
+      reinterpret_cast<uintptr_t>(this));
+  if (m_workletNode == 0)
+  {
+    CLog::Log(LOGERROR, "WASM AudioWorklet: failed to create node");
+    return false;
+  }
+
+  emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VII, SetDestinationChannelCountOnMain,
+                                             m_audioContext, static_cast<int>(channels));
+  emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VIIII, ConnectAudioNodeOnMain,
+                                             m_workletNode, m_audioContext, 0, 0);
+  RefreshPipelineLatency();
+  return true;
+}
+
+void CWasmAudioWorkletManager::RefreshPipelineLatency()
+{
+  if (m_audioContext == 0)
+    return;
+
+  const int latencyUs = emscripten_sync_run_in_main_runtime_thread(
+      EM_FUNC_SIG_II, GetAudioContextLatencyUsOnMain, m_audioContext);
+  if (latencyUs < 0)
+    return;
+
+  m_pipelineLatencyUs.store(static_cast<uint32_t>(latencyUs), std::memory_order_relaxed);
+}
+
+void CWasmAudioWorkletManager::InstallResumeHooks() const
+{
+  MAIN_THREAD_ASYNC_EM_ASM(
+      ({
+        const ctx = emscriptenGetAudioObject($0);
+        if (!ctx)
+          return;
+        if (ctx.state === "running")
+          return;
+        if (ctx.__kodiResumeHooksInstalled)
+          return;
+
+        ctx.__kodiResumeHooksInstalled = true;
+        const tryResume = () => {
+          if (ctx.state !== "running")
+            ctx.resume().catch(() => {});
+          if (ctx.state === "running")
+          {
+            window.removeEventListener("pointerdown", tryResume, true);
+            window.removeEventListener("keydown", tryResume, true);
+            window.removeEventListener("touchstart", tryResume, true);
+            document.removeEventListener("visibilitychange", tryResume, true);
+            ctx.__kodiResumeHooksInstalled = false;
+            ctx.__kodiResumeHandler = null;
+          }
+        };
+        ctx.__kodiResumeHandler = tryResume;
+
+        window.addEventListener("pointerdown", tryResume, true);
+        window.addEventListener("keydown", tryResume, true);
+        window.addEventListener("touchstart", tryResume, true);
+        document.addEventListener("visibilitychange", tryResume, true);
+      }),
+      m_audioContext);
+}
+
+void CWasmAudioWorkletManager::ClearResumeHooks() const
+{
+  if (m_audioContext == 0)
+    return;
+
+  emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VI, ClearResumeHooksOnMain,
+                                             m_audioContext);
+}
+
+void CWasmAudioWorkletManager::EnsureBufferAllocated()
+{
+  const unsigned int sampleRate = std::max(m_sampleRate.load(std::memory_order_relaxed), 1U);
+  const unsigned int quantumSize = std::max(m_quantumSize.load(std::memory_order_relaxed), 1U);
+  const unsigned int channels = std::max(m_channels.load(std::memory_order_relaxed), 1U);
+  const uint64_t targetFrames =
+      (static_cast<uint64_t>(sampleRate) * BUFFER_TARGET_MS + 999ULL) / 1000ULL;
+  const uint64_t minFrames = static_cast<uint64_t>(quantumSize) * MIN_BUFFER_QUANTA;
+  const unsigned int capacityFrames =
+      static_cast<unsigned int>(std::max(targetFrames, minFrames));
+  if (m_bufferCapacityFrames == capacityFrames && m_bufferChannels == channels &&
+      m_bufferSampleRate == sampleRate && m_bufferQuantumSize == quantumSize)
+    return;
+
+  WaitForWorkletIdle();
+  m_bufferCapacityFrames = capacityFrames;
+  m_bufferChannels = channels;
+  m_bufferSampleRate = sampleRate;
+  m_bufferQuantumSize = quantumSize;
+  const size_t sampleCount = static_cast<size_t>(capacityFrames) * channels;
+  m_ringBuffer.assign(sampleCount, 0.0f);
+
+  // Compute the prebuffer watermark. Clamp to half the ring so we always
+  // have room for new writes before output resumes.
+  const uint64_t prebuf =
+      (static_cast<uint64_t>(sampleRate) * PREBUFFER_TARGET_MS + 999ULL) / 1000ULL;
+  const uint64_t quantaInPrebuf = (prebuf + quantumSize - 1ULL) / quantumSize;
+  const uint64_t prebufRounded = quantaInPrebuf * quantumSize;
+  m_prebufferFrames =
+      static_cast<unsigned int>(std::min<uint64_t>(prebufRounded, capacityFrames / 2));
+  m_prebufferComplete.store(false, std::memory_order_release);
+}
+
+bool CWasmAudioWorkletManager::WaitForState(std::atomic<bool>& readyFlag, const char* stageName)
+{
+  std::unique_lock<std::mutex> lock(m_stateMutex);
+  const bool completed =
+      m_stateCv.wait_for(lock, ASYNC_TIMEOUT, [&readyFlag] { return readyFlag.load(); });
+  if (!completed)
+  {
+    CLog::Log(LOGERROR, "WASM AudioWorklet: timeout waiting for {}", stageName);
+    return false;
+  }
+  return true;
+}
+
+void CWasmAudioWorkletManager::OnWorkletThreadStarted(int audioContext,
+                                                      bool success,
+                                                      void* userData)
+{
+  auto* self = static_cast<CWasmAudioWorkletManager*>(userData);
+  if (!self)
+    return;
+
+  self->m_asyncResult.store(success && audioContext != 0, std::memory_order_release);
+  self->m_asyncDone.store(true, std::memory_order_release);
+  self->m_stateCv.notify_all();
+}
+
+void CWasmAudioWorkletManager::OnProcessorCreated(int, bool success, void* userData)
+{
+  auto* self = static_cast<CWasmAudioWorkletManager*>(userData);
+  if (!self)
+    return;
+
+  self->m_asyncResult.store(success, std::memory_order_release);
+  self->m_asyncDone.store(true, std::memory_order_release);
+  self->m_stateCv.notify_all();
+}
+
+bool CWasmAudioWorkletManager::ProcessAudio(
+    int, const void*, int numOutputs, void* outputs, int, const void*, void* userData)
+{
+  auto* self = static_cast<CWasmAudioWorkletManager*>(userData);
+  if (!self)
+    return false;
+
+  self->m_activeCallbacks.fetch_add(1, std::memory_order_seq_cst);
+  const bool result = self->ProcessAudioImpl(numOutputs, outputs);
+  self->m_activeCallbacks.fetch_sub(1, std::memory_order_seq_cst);
+  return result;
+}
+
+bool CWasmAudioWorkletManager::ProcessAudioImpl(int numOutputs, void* outputsRaw)
+{
+
+  auto* outputs = static_cast<AudioSampleFrame*>(outputsRaw);
+  if (numOutputs <= 0 || !outputs)
+  {
+    return true;
+  }
+
+  const int samplesPerChannel = outputs[0].samplesPerChannel;
+  if (samplesPerChannel <= 0 || !outputs[0].data)
+    return true;
+
+  const int outputChannels = outputs[0].numberOfChannels;
+  if (outputChannels <= 0)
+    return true;
+
+  float* outputData = outputs[0].data;
+
+  auto zeroOutput = [&]()
+  {
+    const int totalSamples = outputChannels * samplesPerChannel;
+    std::fill(outputData, outputData + totalSamples, 0.0f);
+  };
+
+  if (!m_ready.load(std::memory_order_seq_cst))
+  {
+    zeroOutput();
+    return true;
+  }
+
+  const unsigned int channels = m_channels.load(std::memory_order_relaxed);
+  const unsigned int capacityFrames = m_bufferCapacityFrames;
+  if (channels == 0 || capacityFrames == 0 || m_ringBuffer.empty())
+  {
+    zeroOutput();
+    return true;
+  }
+
+  const unsigned int copyChannels = std::min<unsigned int>(channels, outputChannels);
+
+  const uint64_t readFrame = m_readFrame.load(std::memory_order_relaxed);
+  const uint64_t writeFrame = m_writeFrame.load(std::memory_order_acquire);
+  const uint64_t availableFrames = writeFrame - readFrame;
+  const uint64_t wantedFrames = static_cast<uint64_t>(samplesPerChannel);
+
+  if (!m_prebufferComplete.load(std::memory_order_acquire))
+  {
+    if (m_prebufferFrames == 0 || availableFrames >= m_prebufferFrames)
+      m_prebufferComplete.store(true, std::memory_order_release);
+    else
+    {
+      zeroOutput();
+      return true;
+    }
+  }
+
+  const uint64_t toRead = std::min<uint64_t>(availableFrames, wantedFrames);
+  if (toRead < wantedFrames)
+    m_underrunFrames.fetch_add(wantedFrames - toRead, std::memory_order_relaxed);
+  if (toRead == 0)
+  {
+    zeroOutput();
+    return true;
+  }
+
+  // Planar memcpy per channel: ring buffer is laid out as
+  // [ch0 capacityFrames | ch1 capacityFrames | ...]. The browser's output
+  // buffer follows the same planar convention (outputs[0].data[ch*N + frame]).
+  // No per-sample reshuffling.
+  const uint64_t srcStart = readFrame % capacityFrames;
+  const uint64_t firstChunk = std::min<uint64_t>(toRead, capacityFrames - srcStart);
+  const uint64_t secondChunk = toRead - firstChunk;
+  for (unsigned int ch = 0; ch < copyChannels; ++ch)
+  {
+    const float* const srcPlane = &m_ringBuffer[static_cast<size_t>(ch) * capacityFrames];
+    float* const dstPlane = outputData + static_cast<size_t>(ch) * samplesPerChannel;
+    std::memcpy(dstPlane, srcPlane + srcStart, firstChunk * sizeof(float));
+    if (secondChunk > 0)
+      std::memcpy(dstPlane + firstChunk, srcPlane, secondChunk * sizeof(float));
+
+    if (toRead < wantedFrames)
+      std::fill(dstPlane + toRead, dstPlane + wantedFrames, 0.0f);
+  }
+
+  for (unsigned int ch = copyChannels; ch < static_cast<unsigned int>(outputChannels); ++ch)
+  {
+    float* const dstPlane = outputData + static_cast<size_t>(ch) * samplesPerChannel;
+    std::fill(dstPlane, dstPlane + wantedFrames, 0.0f);
+  }
+
+  m_readFrame.store(readFrame + toRead, std::memory_order_release);
+  return true;
+}
+} // namespace KODI::PLATFORM::WASM

--- a/xbmc/platform/wasm/WasmAudioWorkletManager.h
+++ b/xbmc/platform/wasm/WasmAudioWorkletManager.h
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+namespace KODI::PLATFORM::WASM
+{
+class CWasmAudioWorkletManager
+{
+public:
+  static constexpr unsigned int kMaxChannels = 8;
+
+  static CWasmAudioWorkletManager& Instance();
+
+  bool Initialize(unsigned int channels, unsigned int requestedSampleRate);
+  void Shutdown();
+
+  unsigned int WritePlanar(const float* const* planes,
+                           unsigned int channels,
+                           unsigned int frames,
+                           unsigned int offsetFrames);
+  void Drain();
+
+  double GetBufferedSeconds() const;
+  double GetBufferCapacitySeconds() const;
+  double GetPipelineLatencySeconds() const;
+  double GetTotalDelaySeconds() const;
+
+  unsigned int GetSampleRate() const;
+  unsigned int GetQuantumSize() const;
+  unsigned int GetChannels() const;
+  unsigned int GetMaxOutputChannels() const;
+  bool IsReady() const;
+
+  // Returns and resets the number of underrun frames.
+  uint64_t ConsumeUnderrunFrames();
+
+private:
+  CWasmAudioWorkletManager() = default;
+  ~CWasmAudioWorkletManager() = default;
+  CWasmAudioWorkletManager(const CWasmAudioWorkletManager&) = delete;
+  CWasmAudioWorkletManager& operator=(const CWasmAudioWorkletManager&) = delete;
+
+  bool EnsureContext(unsigned int requestedSampleRate);
+  bool EnsureWorkletProcessor();
+  bool ConfigureNode(unsigned int channels);
+  void InstallResumeHooks() const;
+  void ClearResumeHooks() const;
+  void EnsureBufferAllocated();
+  void ResetBuffer();
+  void WaitForWorkletIdle();
+  int QuantumSleepMs() const;
+  void RefreshPipelineLatency();
+
+  bool WaitForState(std::atomic<bool>& readyFlag, const char* stageName);
+  static void OnWorkletThreadStarted(int audioContext, bool success, void* userData);
+  static void OnProcessorCreated(int audioContext, bool success, void* userData);
+  static bool ProcessAudio(int numInputs,
+                           const void* inputs,
+                           int numOutputs,
+                           void* outputs,
+                           int numParams,
+                           const void* params,
+                           void* userData);
+  bool ProcessAudioImpl(int numOutputs, void* outputs);
+
+  mutable std::mutex m_stateMutex;
+  std::condition_variable m_stateCv;
+
+  int m_audioContext{0};
+  int m_workletNode{0};
+
+  std::atomic<bool> m_ready{false};
+  std::atomic<bool> m_workletThreadCreated{false};
+  std::atomic<bool> m_processorCreated{false};
+  std::atomic<bool> m_asyncResult{false};
+  std::atomic<bool> m_asyncDone{false};
+
+  std::atomic<unsigned int> m_channels{2};
+  std::atomic<unsigned int> m_sampleRate{48000};
+  std::atomic<unsigned int> m_quantumSize{128};
+
+  // SPSC ring: the sink thread writes m_writeFrame and (re)allocates, only after
+  // WaitForWorkletIdle(); the worklet thread writes m_readFrame.
+  std::vector<float> m_ringBuffer;
+  unsigned int m_bufferCapacityFrames{0};
+  unsigned int m_bufferChannels{0};
+  unsigned int m_bufferSampleRate{0};
+  unsigned int m_bufferQuantumSize{0};
+  std::atomic<uint64_t> m_readFrame{0};
+  std::atomic<uint64_t> m_writeFrame{0};
+
+  std::atomic<uint32_t> m_pipelineLatencyUs{0};
+
+  std::atomic<uint64_t> m_underrunFrames{0};
+  std::atomic<unsigned int> m_activeCallbacks{0};
+
+  // Prebuffer watermark
+  unsigned int m_prebufferFrames{0};
+  std::atomic<bool> m_prebufferComplete{false};
+};
+} // namespace KODI::PLATFORM::WASM

--- a/xbmc/platform/wasm/main.cpp
+++ b/xbmc/platform/wasm/main.cpp
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "application/AppEnvironment.h"
+#include "application/AppParamParser.h"
+#include "application/AppParams.h"
+#include "platform/xbmc.h"
+
+#include <locale.h>
+#include <stdlib.h>
+
+int main(int argc, char* argv[])
+{
+  setlocale(LC_NUMERIC, "C");
+
+  // Emscripten VFS: data is preloaded under /kodi via --preload-file
+  setenv("KODI_HOME", "/kodi", 0);
+
+  CAppParamParser appParamParser;
+  appParamParser.Parse(argv, argc);
+  appParamParser.GetAppParams()->SetLogTarget("console");
+
+  CAppEnvironment::SetUp(appParamParser.GetAppParams());
+  const int status = XBMC_Run(true);
+  // Only reached when startup failed: emscripten_set_main_loop(..., 1) never returns.
+  CAppEnvironment::TearDown();
+  return status;
+}

--- a/xbmc/platform/wasm/network/CMakeLists.txt
+++ b/xbmc/platform/wasm/network/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES NetworkWasm.cpp)
+
+set(HEADERS NetworkWasm.h)
+
+core_add_library(platform_wasm_network)

--- a/xbmc/platform/wasm/network/NetworkWasm.cpp
+++ b/xbmc/platform/wasm/network/NetworkWasm.cpp
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "NetworkWasm.h"
+
+#include <cstring>
+
+#include <emscripten.h>
+
+bool CNetworkInterfaceWasm::IsConnected() const
+{
+  return EM_ASM_INT({
+    return (typeof navigator !== "undefined" && typeof navigator.onLine === "boolean")
+             ? (navigator.onLine ? 1 : 0)
+             : 1;
+  }) != 0;
+}
+
+void CNetworkInterfaceWasm::GetMacAddressRaw(char rawMac[6]) const
+{
+  std::memset(rawMac, 0, 6);
+}
+
+CNetworkWasm::CNetworkWasm()
+{
+  m_interfaces.push_back(&m_iface);
+}
+
+CNetworkWasm::~CNetworkWasm() = default;
+
+std::unique_ptr<CNetworkBase> CNetworkBase::GetNetwork()
+{
+  return std::make_unique<CNetworkWasm>();
+}
+
+std::vector<CNetworkInterface*>& CNetworkWasm::GetInterfaceList()
+{
+  return m_interfaces;
+}
+
+bool CNetworkWasm::PingHost(unsigned long /*host*/, unsigned int /*timeout_ms*/)
+{
+  return false;
+}
+
+std::vector<std::string> CNetworkWasm::GetNameServers()
+{
+  return {};
+}

--- a/xbmc/platform/wasm/network/NetworkWasm.h
+++ b/xbmc/platform/wasm/network/NetworkWasm.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "network/Network.h"
+
+#include <string>
+#include <vector>
+
+class CNetworkInterfaceWasm : public CNetworkInterface
+{
+public:
+  CNetworkInterfaceWasm() = default;
+  ~CNetworkInterfaceWasm() override = default;
+
+  bool IsEnabled() const override { return true; }
+  bool IsConnected() const override;
+
+  std::string GetMacAddress() const override { return "00:00:00:00:00:00"; }
+  void GetMacAddressRaw(char rawMac[6]) const override;
+
+  bool GetHostMacAddress(unsigned long host, std::string& mac) const override { return false; }
+
+  // The browser doesn't expose the real interface addresses; loopback at least
+  // gives CNetworkBase::HasInterfaceForIP() a subnet to match against.
+  std::string GetCurrentIPAddress() const override { return "127.0.0.1"; }
+  std::string GetCurrentNetmask() const override { return "255.0.0.0"; }
+  std::string GetCurrentDefaultGateway() const override { return "127.0.0.1"; }
+};
+
+class CNetworkWasm : public CNetworkBase
+{
+public:
+  CNetworkWasm();
+  ~CNetworkWasm() override;
+
+  std::vector<CNetworkInterface*>& GetInterfaceList() override;
+  bool PingHost(unsigned long host, unsigned int timeout_ms = 2000) override;
+  std::vector<std::string> GetNameServers() override;
+
+private:
+  CNetworkInterfaceWasm m_iface;
+  std::vector<CNetworkInterface*> m_interfaces;
+};

--- a/xbmc/platform/wasm/storage/CMakeLists.txt
+++ b/xbmc/platform/wasm/storage/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES WasmStorageProvider.cpp)
+
+set(HEADERS WasmStorageProvider.h)
+
+core_add_library(platform_wasm_storage)

--- a/xbmc/platform/wasm/storage/WasmStorageProvider.cpp
+++ b/xbmc/platform/wasm/storage/WasmStorageProvider.cpp
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "WasmStorageProvider.h"
+
+std::unique_ptr<IStorageProvider> IStorageProvider::CreateInstance()
+{
+  return std::make_unique<CWasmStorageProvider>();
+}
+
+void CWasmStorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDrives)
+{
+  CMediaSource share;
+  share.strPath = "/";
+  share.strName = "Root";
+  share.m_iDriveType = SourceType::LOCAL;
+  localDrives.push_back(share);
+}
+
+std::vector<std::string> CWasmStorageProvider::GetDiskUsage()
+{
+  return {};
+}

--- a/xbmc/platform/wasm/storage/WasmStorageProvider.h
+++ b/xbmc/platform/wasm/storage/WasmStorageProvider.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "storage/IStorageProvider.h"
+
+#include <string>
+#include <vector>
+
+class CWasmStorageProvider : public IStorageProvider
+{
+public:
+  CWasmStorageProvider() = default;
+  ~CWasmStorageProvider() override = default;
+
+  void Initialize() override {}
+  void Stop() override {}
+
+  void GetLocalDrives(std::vector<CMediaSource>& localDrives) override;
+  void GetRemovableDrives(std::vector<CMediaSource>& removableDrives) override {}
+
+  bool Eject(const std::string& mountpath) override { return false; }
+
+  std::vector<std::string> GetDiskUsage() override;
+
+  bool PumpDriveChangeEvents(IStorageEventsCallback* callback) override { return false; }
+};


### PR DESCRIPTION
> Stacked on #28226 (wasm platform skeleton): the sink registers in `CPlatformWasm::InitStageOne` and the worklet manager lives in `xbmc/platform/wasm/`. Only the last commit is new here.

## Description
Adds audio output for the WebAssembly target through a Web Audio `AudioWorklet`.

- `CAESinkWasmAudioWorklet` (`cores/AudioEngine/Sinks`) advertises planar float at 44.1/48 kHz, resolves the requested layout to 2.0 / 5.1 / 7.1 against `AudioDestinationNode.maxChannelCount`, reports ring fill plus the context's base and output latency as delay, and is built only for `CORE_SYSTEM_NAME wasm`.
- `CWasmAudioWorkletManager` (`platform/wasm`) owns the `AudioContext`, the Emscripten worklet thread and a planar ring buffer. The ring is single-producer/single-consumer with no lock on either hot path: the sink thread is the only writer of `m_writeFrame` and the only thread that (re)allocates, the worklet thread the only writer of `m_readFrame`, and reallocation waits for in-flight callbacks through a seq_cst `m_ready`/`m_activeCallbacks` handshake. Output starts after a 40 ms prebuffer.
- The worklet renders 128-frame quanta on a realtime thread the browser owns and must never block, so the `process()` callback only does a planar memcpy from the ring.

## Motivation and context
The browser exposes no other realtime audio path. Web Audio's mixing rules also matter for correctness: speaker up/down-mixing is only defined for 1, 2, 4 and 6 channels and everything else is folded as "discrete", dropping the channels the destination lacks — so an unconstrained 7.1 request on stereo hardware loses centre, LFE and surrounds. Hence the layout resolution and the explicit `destination.channelCount`, which otherwise defaults to 2 regardless of hardware.

An `AudioContext` created before a user gesture starts suspended; the manager resumes it on the first pointer, key or touch event.

## How has this been tested?
Downstream WebAssembly build, Chrome on macOS and a Samsung Tizen 9.0 TV: GUI sounds and music playback with A/V sync, no underruns from the worklet after the lock-free ring (an earlier `try_lock` in the callback emitted a quantum of silence whenever the writer held the lock). The translation units compile for wasm; no other platform builds these files.

## What is the effect on users?
None on existing platforms. Audio output for the WebAssembly target.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
