### PR TITLE
[wasm] add a WebCodecs video decoder

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -90,4 +90,5 @@ SpacesInSquareBrackets: false
 Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never
+WhitespaceSensitiveMacros: ['EM_ASM', 'EM_JS', 'EM_ASM_INT', 'EM_ASM_DOUBLE', 'EM_ASM_PTR', 'MAIN_THREAD_EM_ASM', 'MAIN_THREAD_EM_ASM_INT', 'MAIN_THREAD_EM_ASM_DOUBLE', 'MAIN_THREAD_ASYNC_EM_ASM']
 ...

--- a/cmake/scripts/wasm/ArchSetup.cmake
+++ b/cmake/scripts/wasm/ArchSetup.cmake
@@ -29,31 +29,29 @@ set(HOST_CAN_EXECUTE_TARGET FALSE)
 # Prefer internal libs when cross-compiling to wasm (typical for depends builds)
 set(USE_INTERNAL_LIBS ON)
 
-list(APPEND AUDIO_BACKENDS_LIST "webaudio")
-
 set(APP_BINARY_SUFFIX ".js")
 
+# emcc --profiling keeps function names in the build so browser DevTools can
+# attribute samples; it is off by default because it inflates the binary.
+option(ENABLE_WASM_PROFILING "Enable Emscripten --profiling (CPU profiling in browser DevTools)" OFF)
+
 # Threading + memory (COOP/COEP headers required in HTML for pthreads).
-# PROXY_TO_PTHREAD: Kodi's init is synchronous/blocking; it must run on a
-# pthread so the browser main thread stays responsive.
-# OFFSCREEN_FRAMEBUFFER: required for WebGL to work from a pthread. Without it,
-# emscripten_webgl_make_context_current silently fails on worker threads.
-# The newRenderingFrameStarted crash (GL.currentContext null on main thread) is
-# fixed by calling MAIN_THREAD_EM_ASM to mirror the context current state on the
-# main thread right after emscripten_webgl_make_context_current (see
-# WinSystemWasmGLESContext.cpp).
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   add_link_options(
     "SHELL:-sUSE_PTHREADS=1"
-    "SHELL:-sPTHREAD_POOL_SIZE=8"
-    "SHELL:-sINITIAL_MEMORY=2GB"
+    "SHELL:-sPTHREAD_POOL_SIZE=16"
+    "SHELL:-sAUDIO_WORKLET"
+    "SHELL:-sWASM_WORKERS"
+    "SHELL:-sINITIAL_MEMORY=512MB"
+    "SHELL:-sMAXIMUM_MEMORY=4GB"
+    "SHELL:-sALLOW_MEMORY_GROWTH=1"
+    "SHELL:-sSTACK_SIZE=5MB"
     "SHELL:-sPROXY_TO_PTHREAD"
-    "SHELL:-sOFFSCREEN_FRAMEBUFFER"
     "SHELL:-sMIN_WEBGL_VERSION=2"
     "SHELL:-sMAX_WEBGL_VERSION=2"
     "SHELL:-sFULL_ES3=1"
-    "SHELL:-sABORTING_MALLOC=0"
     "SHELL:-lidbfs.js"
+    "SHELL:-lembind"
   )
 
   # ---------------------------------------------------------------------------
@@ -84,6 +82,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     message(STATUS "WASM: Debug build — SAFE_HEAP + DWARF symbols + source maps enabled")
   else()
     add_link_options("SHELL:-sASSERTIONS=1")
+  endif()
+
+  if(ENABLE_WASM_PROFILING)
+    add_compile_options(--profiling)
+    add_link_options(--profiling)
+    message(STATUS "WASM: Emscripten --profiling enabled (ENABLE_WASM_PROFILING=ON)")
   endif()
 endif()
 

--- a/cmake/scripts/wasm/ArchSetup.cmake
+++ b/cmake/scripts/wasm/ArchSetup.cmake
@@ -52,6 +52,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
     "SHELL:-sFULL_ES3=1"
     "SHELL:-lidbfs.js"
     "SHELL:-lembind"
+    "SHELL:--js-library ${CMAKE_SOURCE_DIR}/xbmc/cores/VideoPlayer/DVDCodecs/Video/webcodecs_bridge.js"
   )
 
   # ---------------------------------------------------------------------------

--- a/cmake/treedata/wasm/wasm.txt
+++ b/cmake/treedata/wasm/wasm.txt
@@ -1,10 +1,6 @@
-xbmc/cores/AudioEngine/Sinks/webaudio  cores_AudioEngine_Sinks_webaudio
 xbmc/cores/RetroPlayer/shaders/gles   cores/RetroPlayer/shaders/gles
-xbmc/cores/VideoPlayer/Process/wasm   videoplayer_process_wasm
-xbmc/filesystem/wasm                  filesystem_wasm
 xbmc/input/touch                      input_touch
 xbmc/input/touch/generic              input_touch_generic
-xbmc/interfaces/json-rpc/wasm         interfaces_jsonrpc_wasm
 xbmc/platform/common/speech           platform/common/speech
 xbmc/platform/posix                   platform/posix
 xbmc/platform/posix/filesystem        platform/posix/filesystem
@@ -13,4 +9,3 @@ xbmc/platform/posix/utils             platform/posix/utils
 xbmc/platform/wasm                    platform/wasm
 xbmc/platform/wasm/network            platform/wasm/network
 xbmc/platform/wasm/storage            platform/wasm/storage
-xbmc/windowing/wasm                   windowing/wasm

--- a/cmake/treedata/wasm/wasm.txt
+++ b/cmake/treedata/wasm/wasm.txt
@@ -1,4 +1,5 @@
 xbmc/cores/RetroPlayer/shaders/gles   cores/RetroPlayer/shaders/gles
+xbmc/cores/VideoPlayer/Process/wasm   videoplayer_process_wasm
 xbmc/input/touch                      input_touch
 xbmc/input/touch/generic              input_touch_generic
 xbmc/platform/common/speech           platform/common/speech

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -182,6 +182,10 @@
 #include <memory>
 #include <mutex>
 
+#ifdef TARGET_WASM
+#include <emscripten.h>
+#endif
+
 #include <tinyxml.h>
 
 //TODO: XInitThreads
@@ -1651,10 +1655,6 @@ int CApplication::Run()
 {
   CLog::Log(LOGINFO, "Running the application...");
 
-  std::chrono::time_point<std::chrono::steady_clock> lastFrameTime;
-  std::chrono::milliseconds frameTime;
-  const unsigned int noRenderFrameTime = 15; // Simulates ~66fps
-
   CFileItemList& playlist = CServiceBroker::GetAppParams()->GetPlaylist();
   if (playlist.Size() > 0)
   {
@@ -1662,6 +1662,14 @@ int CApplication::Run()
     CServiceBroker::GetPlaylistPlayer().SetCurrentPlaylist(PLAYLIST::Id::TYPE_MUSIC);
     CServiceBroker::GetAppMessenger()->PostMsg(TMSG_PLAYLISTPLAYER_PLAY, -1);
   }
+
+#ifdef TARGET_WASM
+  emscripten_set_main_loop([]() { g_application.WasmRunIteration(); }, 0, 1);
+  return m_ExitCode;
+#else
+  std::chrono::time_point<std::chrono::steady_clock> lastFrameTime;
+  std::chrono::milliseconds frameTime;
+  const unsigned int noRenderFrameTime = 15; // Simulates ~66fps
 
   // Run the app
   while (!m_bStop)
@@ -1694,6 +1702,7 @@ int CApplication::Run()
 
   CLog::Log(LOGINFO, "Exiting the application...");
   return m_ExitCode;
+#endif
 }
 
 bool CApplication::Cleanup()

--- a/xbmc/application/Application.h
+++ b/xbmc/application/Application.h
@@ -102,6 +102,11 @@ public:
   int Run();
   bool Cleanup();
 
+#ifdef TARGET_WASM
+  /*! \brief Single frame for Emscripten main loop (browser). */
+  void WasmRunIteration();
+#endif
+
   void FrameMove(bool processEvents, bool processGUI = true) override;
   void Render() override;
 

--- a/xbmc/application/CMakeLists.txt
+++ b/xbmc/application/CMakeLists.txt
@@ -14,6 +14,10 @@ set(SOURCES AppEnvironment.cpp
             AppParamParser.cpp
             AppParams.cpp)
 
+if(CORE_SYSTEM_NAME STREQUAL wasm)
+  list(APPEND SOURCES ${CMAKE_SOURCE_DIR}/xbmc/platform/wasm/ApplicationWasm.cpp)
+endif()
+
 set(HEADERS AppEnvironment.h
             AppInboundProtocol.h
             Application.h

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBuffer.cpp
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBuffer.cpp
@@ -283,6 +283,11 @@ bool CVideoBufferSysMem::Alloc()
   return true;
 }
 
+bool CVideoBufferSysMem::IsCompatible(AVPixelFormat format, int size) const
+{
+  return m_pixFormat == format && m_size >= size;
+}
+
 
 //-----------------------------------------------------------------------------
 // CVideoBufferPool
@@ -309,6 +314,13 @@ CVideoBuffer* CVideoBufferPoolSysMem::Get()
     m_free.pop_front();
     m_used.push_back(idx);
     buf = m_all[idx];
+    if (!buf->IsCompatible(m_pixFormat, m_size))
+    {
+      delete buf;
+      buf = new CVideoBufferSysMem(*this, idx, m_pixFormat, m_size);
+      buf->Alloc();
+      m_all[idx] = buf;
+    }
   }
   else
   {

--- a/xbmc/cores/VideoPlayer/Buffers/VideoBuffer.h
+++ b/xbmc/cores/VideoPlayer/Buffers/VideoBuffer.h
@@ -156,6 +156,7 @@ public:
   void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES]) override;
   void SetDimensions(int width, int height, const int (&strides)[YuvImage::MAX_PLANES], const int (&planeOffsets)[YuvImage::MAX_PLANES]) override;
   bool Alloc();
+  bool IsCompatible(AVPixelFormat format, int size) const;
 
 protected:
   int m_width = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/CMakeLists.txt
@@ -37,6 +37,12 @@ if(CORE_SYSTEM_NAME STREQUAL android)
   list(APPEND HEADERS DVDVideoCodecAndroidMediaCodec.h)
 endif()
 
+if(CORE_SYSTEM_NAME STREQUAL wasm)
+  list(APPEND SOURCES DVDVideoCodecWebCodecs.cpp)
+  list(APPEND HEADERS DVDVideoCodecWebCodecs.h
+                      DVDVideoCodecWebCodecsBridge.h)
+endif()
+
 if(("gbm" IN_LIST CORE_PLATFORM_NAME_LC OR "wayland" IN_LIST CORE_PLATFORM_NAME_LC) AND
    TARGET ${APP_NAME_LC}::OpenGLES)
   list(APPEND SOURCES DVDVideoCodecDRMPRIME.cpp)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecWebCodecs.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecWebCodecs.cpp
@@ -1,0 +1,746 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "DVDVideoCodecWebCodecs.h"
+
+#include "DVDCodecs/DVDFactoryCodec.h"
+#include "DVDStreamInfo.h"
+#include "DVDVideoCodecWebCodecsBridge.h"
+#include "cores/VideoPlayer/Buffers/VideoBuffer.h"
+#include "cores/VideoPlayer/Interface/TimingConstants.h"
+#include "utils/log.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+#include <emscripten/bind.h>
+#include <emscripten/threading.h>
+
+// Expose the bridge enums to JavaScript via Embind so the JS bridge can read
+// the canonical C++ values (Module.WebCodecsPixelFormat.NV12 etc.) instead of
+// duplicating them. Must live at global scope, hence outside any namespace.
+EMSCRIPTEN_BINDINGS(kodi_webcodecs_bridge)
+{
+  emscripten::enum_<WebCodecsPixelFormat>("WebCodecsPixelFormat")
+      .value("UNKNOWN", WEBCODECS_PIXFMT_UNKNOWN)
+      .value("YUV420P", WEBCODECS_PIXFMT_YUV420P)
+      .value("NV12", WEBCODECS_PIXFMT_NV12);
+
+  emscripten::enum_<WebCodecsPushStatus>("WebCodecsPushStatus")
+      .value("QUEUED", WEBCODECS_PUSH_QUEUED)
+      .value("EMPTY", WEBCODECS_PUSH_EMPTY)
+      .value("HANDLE_NOT_FOUND", WEBCODECS_PUSH_HANDLE_NOT_FOUND)
+      .value("DECODER_FAILED", WEBCODECS_PUSH_DECODER_FAILED)
+      .value("NOT_CONFIGURED", WEBCODECS_PUSH_NOT_CONFIGURED)
+      .value("DECODE_THREW", WEBCODECS_PUSH_DECODE_THREW)
+      .value("BUSY", WEBCODECS_PUSH_BUSY);
+}
+
+namespace
+{
+constexpr int INVALID_DECODER_HANDLE = 0;
+constexpr int DEFAULT_ALIGNMENT = 64;
+constexpr int DECODER_ERROR_BUFFER_SIZE = 512;
+constexpr int DISPLAY_WIDTH_ALIGN_MASK = -3;
+constexpr double FRAME_WAIT_MS = 20.0;
+constexpr auto DRAIN_TIMEOUT = std::chrono::milliseconds(1000);
+constexpr auto COPY_TIMEOUT = std::chrono::milliseconds(500);
+constexpr int DROPPED_FRAMES_LOG_THRESHOLD = 8;
+constexpr int PICTURE_COLOR_BITS = 8;
+
+constexpr int CODEC_STRING_BUFFER_SIZE = 24;
+constexpr int H264_AVCC_MIN_EXTRADATA_SIZE = 7;
+constexpr uint8_t H264_AVCC_CONFIG_VERSION = 1;
+constexpr int H264_AVCC_PROFILE_OFFSET = 1;
+constexpr int H264_AVCC_COMPAT_OFFSET = 2;
+constexpr int H264_AVCC_LEVEL_OFFSET = 3;
+constexpr int H264_AVCC_LENGTH_SIZE_OFFSET = 4;
+constexpr uint8_t H264_AVCC_LENGTH_SIZE_MASK = 0x03;
+
+constexpr uint8_t H264_NAL_TYPE_MASK = 0x1F;
+constexpr uint8_t H264_NAL_TYPE_IDR = 5;
+
+constexpr uint8_t ANNEXB_START_CODE_BYTE = 0x01;
+
+constexpr int VP9_FRAME_MARKER = 2;
+constexpr int VP9_PROFILE_WITH_RESERVED_BIT = 3;
+constexpr int VP9_FRAME_TYPE_KEY = 0;
+
+int AlignUp(int value, int alignment)
+{
+  return ((value + alignment - 1) / alignment) * alignment;
+}
+
+// An AVCDecoderConfigurationRecord is only complete once numOfSequenceParameterSets,
+// its last fixed field, is present at byte 6.
+bool HasAVCCExtradata(const CDVDStreamInfo& hints)
+{
+  return hints.extradata.GetSize() >= H264_AVCC_MIN_EXTRADATA_SIZE &&
+         hints.extradata.GetData()[0] == H264_AVCC_CONFIG_VERSION;
+}
+
+std::string BuildH264CodecString(const CDVDStreamInfo& hints)
+{
+  const auto& extradata = hints.extradata;
+  if (HasAVCCExtradata(hints))
+  {
+    const uint8_t profile = extradata.GetData()[H264_AVCC_PROFILE_OFFSET];
+    const uint8_t compat = extradata.GetData()[H264_AVCC_COMPAT_OFFSET];
+    const uint8_t level = extradata.GetData()[H264_AVCC_LEVEL_OFFSET];
+
+    char buffer[CODEC_STRING_BUFFER_SIZE];
+    std::snprintf(buffer, sizeof(buffer), "avc1.%02X%02X%02X", profile, compat, level);
+    return buffer;
+  }
+
+  return "avc1.42E01E";
+}
+
+int ClampTwoDigitCodecValue(int value, int fallback)
+{
+  if (value < 0)
+    value = fallback;
+  return std::clamp(value, 0, 99);
+}
+
+int VP9ProfileFromHints(const CDVDStreamInfo& hints)
+{
+  switch (hints.profile)
+  {
+    case AV_PROFILE_VP9_0:
+      return 0;
+    case AV_PROFILE_VP9_1:
+      return 1;
+    case AV_PROFILE_VP9_2:
+      return 2;
+    case AV_PROFILE_VP9_3:
+      return 3;
+    default:
+      return hints.bitdepth > 8 ? 2 : 0;
+  }
+}
+
+std::string BuildVP9CodecString(const CDVDStreamInfo& hints)
+{
+  const int profile = ClampTwoDigitCodecValue(VP9ProfileFromHints(hints), 0);
+  const int level = ClampTwoDigitCodecValue(hints.level, 10);
+  const int bitDepth = ClampTwoDigitCodecValue(hints.bitdepth > 0 ? hints.bitdepth : 8, 8);
+
+  char buffer[CODEC_STRING_BUFFER_SIZE];
+  std::snprintf(buffer, sizeof(buffer), "vp09.%02d.%02d.%02d", profile, level, bitDepth);
+  return buffer;
+}
+
+// Returns true if the H.264 sample contains an IDR NAL unit.
+bool H264SampleContainsIDR(const uint8_t* data, int size, int nalLengthSize)
+{
+  if (!data || size <= 0)
+    return false;
+
+  if (nalLengthSize > 0)
+  {
+    int offset = 0;
+    while (offset + nalLengthSize <= size)
+    {
+      uint32_t nalSize = 0;
+      for (int i = 0; i < nalLengthSize; ++i)
+        nalSize = (nalSize << 8) | data[offset + i];
+      offset += nalLengthSize;
+      if (nalSize == 0 || offset + static_cast<int>(nalSize) > size)
+        break;
+      if ((data[offset] & H264_NAL_TYPE_MASK) == H264_NAL_TYPE_IDR)
+        return true;
+      offset += nalSize;
+    }
+    return false;
+  }
+
+  for (int i = 0; i + 3 < size; ++i)
+  {
+    const bool threeByteStart = data[i] == 0x00 && data[i + 1] == 0x00 &&
+                                data[i + 2] == ANNEXB_START_CODE_BYTE;
+    const bool fourByteStart = data[i] == 0x00 && data[i + 1] == 0x00 && data[i + 2] == 0x00 &&
+                               data[i + 3] == ANNEXB_START_CODE_BYTE;
+    if (!threeByteStart && !fourByteStart)
+      continue;
+
+    const int nalStart = threeByteStart ? i + 3 : i + 4;
+    if (nalStart < size && (data[nalStart] & H264_NAL_TYPE_MASK) == H264_NAL_TYPE_IDR)
+      return true;
+  }
+  return false;
+}
+
+bool VP8SampleIsKeyFrame(const uint8_t* data, int size)
+{
+  return data && size > 0 && (data[0] & 0x01) == 0;
+}
+
+bool VP9SampleIsKeyFrame(const uint8_t* data, int size)
+{
+  if (!data || size <= 0)
+    return false;
+
+  // The VP9 uncompressed header is a plain f(n) bit stream, read MSB first, so the
+  // first field starts at bit 7. Everything needed to classify the frame fits in the
+  // first byte.
+  const uint8_t firstByte = data[0];
+  int bit = 7;
+  const auto readBit = [&firstByte, &bit]() { return (firstByte >> bit--) & 0x01; };
+
+  const int markerHigh = readBit();
+  const int markerLow = readBit();
+  if (((markerHigh << 1) | markerLow) != VP9_FRAME_MARKER)
+    return false;
+
+  const int profileLowBit = readBit();
+  const int profileHighBit = readBit();
+  if (((profileHighBit << 1) | profileLowBit) == VP9_PROFILE_WITH_RESERVED_BIT)
+    readBit(); // reserved_zero
+
+  const bool showExistingFrame = readBit() != 0;
+  if (showExistingFrame)
+    return false;
+
+  return readBit() == VP9_FRAME_TYPE_KEY;
+}
+
+// WebCodecs needs 'key' to mean "decodable on its own". The demuxer flag is not
+// that: FFmpeg sets AV_PKT_FLAG_KEY on non-IDR I-frames (open GOP), whose
+// leading pictures reference frames the decoder never saw. Parse the bitstream
+// where we can and only trust the demuxer for codecs we don't parse.
+bool PacketIsKeyFrame(const CDVDStreamInfo& hints, const DemuxPacket& packet, int nalLengthSize)
+{
+  switch (hints.codec)
+  {
+    case AV_CODEC_ID_H264:
+      return H264SampleContainsIDR(packet.pData, packet.iSize, nalLengthSize);
+    case AV_CODEC_ID_VP8:
+      return VP8SampleIsKeyFrame(packet.pData, packet.iSize);
+    case AV_CODEC_ID_VP9:
+      return VP9SampleIsKeyFrame(packet.pData, packet.iSize);
+    default:
+      return packet.m_keyFrame;
+  }
+}
+
+// Reads any pending diagnostic string from the JS decoder side.
+std::string ReadDecoderError(int decoderHandle)
+{
+  if (decoderHandle == INVALID_DECODER_HANDLE)
+    return {};
+  char buffer[DECODER_ERROR_BUFFER_SIZE];
+  const int written = webcodecs_take_error(decoderHandle, buffer, sizeof(buffer));
+  if (written <= 0)
+    return {};
+  buffer[sizeof(buffer) - 1] = '\0';
+  return std::string(buffer);
+}
+
+const char* PushStatusToString(int status)
+{
+  switch (status)
+  {
+    case WEBCODECS_PUSH_QUEUED:
+      return "queued";
+    case WEBCODECS_PUSH_EMPTY:
+      return "empty packet";
+    case WEBCODECS_PUSH_HANDLE_NOT_FOUND:
+      return "decoder handle not found";
+    case WEBCODECS_PUSH_DECODER_FAILED:
+      return "decoder in failed state";
+    case WEBCODECS_PUSH_NOT_CONFIGURED:
+      return "decoder not configured";
+    case WEBCODECS_PUSH_DECODE_THREW:
+      return "decode threw";
+    case WEBCODECS_PUSH_BUSY:
+      return "decoder busy (backpressure)";
+  }
+  return "unknown";
+}
+
+AVPixelFormat PixelFormatFromWebCodecs(int pixelFormat)
+{
+  switch (pixelFormat)
+  {
+    case WEBCODECS_PIXFMT_YUV420P:
+      return AV_PIX_FMT_YUV420P;
+    case WEBCODECS_PIXFMT_NV12:
+      return AV_PIX_FMT_NV12;
+    case WEBCODECS_PIXFMT_UNKNOWN:
+    default:
+      return AV_PIX_FMT_NONE;
+  }
+}
+} // namespace
+
+CDVDVideoCodecWebCodecs::CDVDVideoCodecWebCodecs(CProcessInfo& processInfo)
+  : CDVDVideoCodec(processInfo)
+{
+  m_videoBufferPool = std::make_shared<CVideoBufferPoolSysMem>();
+}
+
+CDVDVideoCodecWebCodecs::~CDVDVideoCodecWebCodecs()
+{
+  Dispose();
+}
+
+std::unique_ptr<CDVDVideoCodec> CDVDVideoCodecWebCodecs::Create(CProcessInfo& processInfo)
+{
+  return std::make_unique<CDVDVideoCodecWebCodecs>(processInfo);
+}
+
+bool CDVDVideoCodecWebCodecs::Register()
+{
+  CDVDFactoryCodec::RegisterHWVideoCodec("webcodecs_dec", CDVDVideoCodecWebCodecs::Create);
+  return true;
+}
+
+bool CDVDVideoCodecWebCodecs::SupportsCodec(const CDVDStreamInfo& hints) const
+{
+  return hints.codec == AV_CODEC_ID_H264 || hints.codec == AV_CODEC_ID_VP8 ||
+         hints.codec == AV_CODEC_ID_VP9;
+}
+
+bool CDVDVideoCodecWebCodecs::BuildCodecConfiguration(const CDVDStreamInfo& hints)
+{
+  m_codecString.clear();
+  m_annexB = false;
+  m_nalLengthSize = 0;
+
+  if (hints.codec == AV_CODEC_ID_H264)
+  {
+    m_codecString = BuildH264CodecString(hints);
+    if (HasAVCCExtradata(hints))
+    {
+      m_annexB = false;
+      m_nalLengthSize =
+          (hints.extradata.GetData()[H264_AVCC_LENGTH_SIZE_OFFSET] & H264_AVCC_LENGTH_SIZE_MASK) +
+          1;
+    }
+    else
+    {
+      m_annexB = true;
+      m_nalLengthSize = 0;
+    }
+    return true;
+  }
+
+  if (hints.codec == AV_CODEC_ID_VP9)
+  {
+    m_codecString = BuildVP9CodecString(hints);
+    return true;
+  }
+
+  if (hints.codec == AV_CODEC_ID_VP8)
+  {
+    m_codecString = "vp8";
+    return true;
+  }
+
+  return false;
+}
+
+bool CDVDVideoCodecWebCodecs::CreateDecoder()
+{
+  const uint8_t* extraData = m_hints.extradata.GetData();
+  const int extraDataSize = static_cast<int>(m_hints.extradata.GetSize());
+
+  m_shared = {};
+  m_decoderHandle = webcodecs_create_decoder(m_codecString.c_str(), m_hints.width, m_hints.height,
+                                             extraData, extraDataSize, m_annexB ? 1 : 0, &m_shared);
+  if (m_decoderHandle == INVALID_DECODER_HANDLE)
+  {
+    CLog::Log(LOGDEBUG,
+              "CDVDVideoCodecWebCodecs::CreateDecoder - unable to configure decoder for {} "
+              "(annexB={}, extradataSize={}, {}x{}): check that VideoDecoder is available and "
+              "that the codec/description match the stream",
+              m_codecString, m_annexB, extraDataSize, m_hints.width, m_hints.height);
+    return false;
+  }
+
+  return true;
+}
+
+void CDVDVideoCodecWebCodecs::Dispose()
+{
+  ReleaseCopyBuffer();
+  if (m_decoderHandle != INVALID_DECODER_HANDLE)
+  {
+    webcodecs_destroy_decoder(m_decoderHandle);
+    m_decoderHandle = INVALID_DECODER_HANDLE;
+  }
+  m_opened = false;
+  m_waitingForKeyFrame = true;
+  m_drainSubmitted = false;
+  m_lastLoggedDroppedFrames = 0;
+  m_highWaterMark = 0;
+}
+
+bool CDVDVideoCodecWebCodecs::Open(CDVDStreamInfo& hints, CDVDCodecOptions& options)
+{
+  if (!SupportsCodec(hints))
+    return false;
+
+  (void)options;
+  Dispose();
+
+  m_hints = hints;
+  if (!BuildCodecConfiguration(hints))
+    return false;
+
+  if (!CreateDecoder())
+    return false;
+
+  m_name = "webcodecs-" + m_codecString;
+  m_opened = true;
+  m_waitingForKeyFrame = true;
+  m_drainSubmitted = false;
+  m_codecControlFlags = 0;
+  m_lastLoggedDroppedFrames = 0;
+  m_highWaterMark = 0;
+  m_processInfo.SetVideoDecoderName(m_name, true);
+  m_processInfo.SetVideoDimensions(hints.width, hints.height);
+  CLog::Log(LOGINFO,
+            "CDVDVideoCodecWebCodecs::Open - Using WebCodecs for video decoding: {} ({}x{}, annexB={})",
+            m_codecString, hints.width, hints.height, m_annexB);
+  return true;
+}
+
+bool CDVDVideoCodecWebCodecs::AddData(const DemuxPacket& packet)
+{
+  if (!m_opened || m_decoderHandle == INVALID_DECODER_HANDLE)
+    return false;
+
+  if (packet.iSize <= 0 || packet.pData == nullptr)
+    return true;
+
+  const bool isKeyFrame = PacketIsKeyFrame(m_hints, packet, m_nalLengthSize);
+
+  // Feeding a delta before the first IDR would permanently fail the decoder.
+  if (m_waitingForKeyFrame && !isKeyFrame)
+    return true;
+
+  if (SharedLoad(m_shared.busy))
+    return false;
+
+  double ptsSeconds = 0.0;
+  if (packet.pts != DVD_NOPTS_VALUE && std::isfinite(packet.pts))
+    ptsSeconds = packet.pts / static_cast<double>(DVD_TIME_BASE);
+
+  double durationSeconds = 0.0;
+  if (packet.duration > 0.0 && std::isfinite(packet.duration))
+    durationSeconds = packet.duration / static_cast<double>(DVD_TIME_BASE);
+
+  const int status = webcodecs_push_packet(m_decoderHandle, packet.pData, packet.iSize,
+                                           isKeyFrame ? 1 : 0, ptsSeconds, durationSeconds);
+
+  // Backpressure: decoder is saturated, let VideoPlayer re-queue this packet.
+  if (status == WEBCODECS_PUSH_BUSY)
+    return false;
+
+  m_drainSubmitted = false;
+
+  if (status <= 0)
+  {
+    if (status == WEBCODECS_PUSH_EMPTY)
+      return true;
+
+    const std::string error = ReadDecoderError(m_decoderHandle);
+    CLog::Log(LOGDEBUG,
+              "CDVDVideoCodecWebCodecs::AddData - decode rejected packet (size={}, pts={:.6f}s, "
+              "key={}, status={} [{}]): {}",
+              packet.iSize, ptsSeconds, isKeyFrame, status, PushStatusToString(status),
+              error.empty() ? "<no js error>" : error);
+    return false;
+  }
+
+  if (isKeyFrame)
+    m_waitingForKeyFrame = false;
+
+  return true;
+}
+
+void CDVDVideoCodecWebCodecs::Reset()
+{
+  if (m_decoderHandle == INVALID_DECODER_HANDLE)
+    return;
+
+  ReleaseCopyBuffer();
+  webcodecs_reset_decoder(m_decoderHandle);
+  m_waitingForKeyFrame = true;
+  m_drainSubmitted = false;
+  m_lastLoggedDroppedFrames = 0;
+  m_highWaterMark = 0;
+  CLog::Log(LOGDEBUG, "CDVDVideoCodecWebCodecs::Reset - decoder reset after seek/flush");
+}
+
+void CDVDVideoCodecWebCodecs::SetCodecControl(int flags)
+{
+  m_codecControlFlags = flags;
+}
+
+void CDVDVideoCodecWebCodecs::PollDecoderStats()
+{
+  if (m_decoderHandle == INVALID_DECODER_HANDLE)
+    return;
+
+  int droppedFrames = 0;
+  int highWaterMark = 0;
+  if (!webcodecs_read_stats(m_decoderHandle, &droppedFrames, &highWaterMark))
+    return;
+
+  if (highWaterMark > m_highWaterMark)
+    m_highWaterMark = highWaterMark;
+
+  if ((droppedFrames - m_lastLoggedDroppedFrames) < DROPPED_FRAMES_LOG_THRESHOLD)
+    return;
+
+  CLog::Log(LOGWARNING,
+            "CDVDVideoCodecWebCodecs::GetPicture - dropped {} queued WebCodecs frames "
+            "(totalDropped={}, queueHighWater={})",
+            droppedFrames - m_lastLoggedDroppedFrames, droppedFrames, m_highWaterMark);
+  m_lastLoggedDroppedFrames = droppedFrames;
+}
+
+int32_t CDVDVideoCodecWebCodecs::SharedLoad(const int32_t& field)
+{
+  return __atomic_load_n(&field, __ATOMIC_ACQUIRE);
+}
+
+// Callers sample `seenSignal` before checking the shared state, so a change that
+// lands in between makes the futex wait return immediately.
+void CDVDVideoCodecWebCodecs::WaitForDecoderSignal(uint32_t seenSignal, double maxWaitMs)
+{
+  emscripten_futex_wait(&m_shared.signal, seenSignal, maxWaitMs);
+}
+
+// VideoPlayerVideo stops draining at the first VC_BUFFER, so in-flight decodes
+// have to be waited for here rather than reported as "need more data".
+void CDVDVideoCodecWebCodecs::WaitForDrain()
+{
+  const auto deadline = std::chrono::steady_clock::now() + DRAIN_TIMEOUT;
+  while (std::chrono::steady_clock::now() < deadline)
+  {
+    const auto seen = static_cast<uint32_t>(SharedLoad(m_shared.signal));
+    if (SharedLoad(m_shared.queuedFrames) > 0 || SharedLoad(m_shared.inflight) <= 0 ||
+        SharedLoad(m_shared.failed))
+      return;
+    WaitForDecoderSignal(seen, FRAME_WAIT_MS);
+  }
+}
+
+bool CDVDVideoCodecWebCodecs::WaitForCopy()
+{
+  const auto deadline = std::chrono::steady_clock::now() + COPY_TIMEOUT;
+  while (true)
+  {
+    const auto seen = static_cast<uint32_t>(SharedLoad(m_shared.signal));
+    const int32_t result = SharedLoad(m_shared.copyResult);
+    if (result != 0)
+      return result > 0;
+    if (std::chrono::steady_clock::now() >= deadline)
+      return false;
+    WaitForDecoderSignal(seen, FRAME_WAIT_MS);
+  }
+}
+
+void CDVDVideoCodecWebCodecs::ReleaseCopyBuffer()
+{
+  if (!m_copyBuffer)
+    return;
+  WaitForCopy();
+  m_copyBuffer->Release();
+  m_copyBuffer = nullptr;
+}
+
+CVideoBuffer* CDVDVideoCodecWebCodecs::AcquirePictureBuffer(AVPixelFormat pixelFormat,
+                                                            int bufferSize)
+{
+  m_videoBufferPool->Configure(pixelFormat, AlignUp(bufferSize, DEFAULT_ALIGNMENT));
+  CVideoBuffer* buffer = m_videoBufferPool->Get();
+  if (buffer && !buffer->GetMemPtr())
+  {
+    buffer->Release();
+    return nullptr;
+  }
+  return buffer;
+}
+
+void CDVDVideoCodecWebCodecs::FillPictureMetadata(VideoPicture* pVideoPicture,
+                                                  CVideoBuffer* videoBuffer,
+                                                  AVPixelFormat pixelFormat,
+                                                  int width,
+                                                  int height,
+                                                  bool keyFrame,
+                                                  double ptsSeconds,
+                                                  double durationSeconds) const
+{
+  pVideoPicture->Reset();
+  pVideoPicture->videoBuffer = videoBuffer;
+  pVideoPicture->pixelFormat = pixelFormat;
+  pVideoPicture->iWidth = width;
+  pVideoPicture->iHeight = height;
+
+  double aspect = m_hints.aspect > 0.0 ? m_hints.aspect
+                                       : (height > 0 ? static_cast<double>(width) / height : 1.0);
+  pVideoPicture->iDisplayWidth =
+      static_cast<int>(std::lrint(height * aspect)) & DISPLAY_WIDTH_ALIGN_MASK;
+  pVideoPicture->iDisplayHeight = height;
+  if (pVideoPicture->iDisplayWidth > static_cast<unsigned int>(width))
+  {
+    pVideoPicture->iDisplayWidth = width;
+    pVideoPicture->iDisplayHeight =
+        static_cast<int>(std::lrint(width / aspect)) & DISPLAY_WIDTH_ALIGN_MASK;
+  }
+
+  // VideoPicture::pts / iDuration are in DVD_TIME_BASE units (microseconds).
+  pVideoPicture->pts = std::isfinite(ptsSeconds) ? ptsSeconds * DVD_TIME_BASE : DVD_NOPTS_VALUE;
+  pVideoPicture->dts = DVD_NOPTS_VALUE;
+  pVideoPicture->iDuration = durationSeconds > 0.0 ? durationSeconds * DVD_TIME_BASE : 0.0;
+  pVideoPicture->iRepeatPicture = 0.0;
+  pVideoPicture->iFlags = 0;
+  pVideoPicture->iFrameType = keyFrame ? FRAME_TYPE_I : FRAME_TYPE_P;
+
+  pVideoPicture->color_space = m_hints.colorSpace == AVCOL_SPC_UNSPECIFIED
+                                   ? AVCOL_SPC_BT709
+                                   : m_hints.colorSpace;
+  pVideoPicture->color_primaries = m_hints.colorPrimaries == AVCOL_PRI_UNSPECIFIED
+                                       ? AVCOL_PRI_BT709
+                                       : m_hints.colorPrimaries;
+  pVideoPicture->color_transfer =
+      m_hints.colorTransferCharacteristic == AVCOL_TRC_UNSPECIFIED
+          ? AVCOL_TRC_BT709
+          : m_hints.colorTransferCharacteristic;
+  pVideoPicture->m_originalColorPrimaries = pVideoPicture->color_primaries;
+  pVideoPicture->color_range = m_hints.colorRange == AVCOL_RANGE_JPEG;
+  pVideoPicture->chroma_position = AVCHROMA_LOC_LEFT;
+  pVideoPicture->colorBits = PICTURE_COLOR_BITS;
+}
+
+CDVDVideoCodec::VCReturn CDVDVideoCodecWebCodecs::GetPicture(VideoPicture* pVideoPicture)
+{
+  if (!m_opened || m_decoderHandle == INVALID_DECODER_HANDLE)
+    return VC_ERROR;
+
+  const bool draining = (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN) != 0;
+  if (draining && !m_drainSubmitted)
+  {
+    m_drainSubmitted = true;
+    m_waitingForKeyFrame = true;
+    webcodecs_flush_decoder(m_decoderHandle);
+    CLog::Log(LOGDEBUG, "CDVDVideoCodecWebCodecs::GetPicture - drain requested, flushing");
+  }
+  else if (!draining)
+    m_drainSubmitted = false;
+
+  if (draining)
+    WaitForDrain();
+  else
+  {
+    const auto seen = static_cast<uint32_t>(SharedLoad(m_shared.signal));
+    if (SharedLoad(m_shared.queuedFrames) == 0 && SharedLoad(m_shared.busy))
+      WaitForDecoderSignal(seen, FRAME_WAIT_MS);
+  }
+
+  if (SharedLoad(m_shared.failed))
+  {
+    const std::string error = ReadDecoderError(m_decoderHandle);
+    CLog::Log(LOGERROR, "CDVDVideoCodecWebCodecs::GetPicture - decoder entered failed state: {}",
+              error.empty() ? "<no js error>" : error);
+    return VC_ERROR;
+  }
+
+  if (SharedLoad(m_shared.queuedFrames) == 0)
+  {
+    if (!draining)
+      return VC_BUFFER;
+
+    PollDecoderStats();
+    const int32_t inflight = SharedLoad(m_shared.inflight);
+    if (inflight > 0)
+      CLog::Log(LOGWARNING,
+                "CDVDVideoCodecWebCodecs::GetPicture - drain timed out with {} pending "
+                "WebCodecs operations",
+                inflight);
+    else
+      CLog::Log(LOGDEBUG, "CDVDVideoCodecWebCodecs::GetPicture - drain completed (EOF)");
+    return VC_EOF;
+  }
+
+  const AVPixelFormat pixelFormat = PixelFormatFromWebCodecs(SharedLoad(m_shared.nextPixelFormat));
+  const int payloadSize = SharedLoad(m_shared.nextPayloadSize);
+  if (pixelFormat == AV_PIX_FMT_NONE || payloadSize <= 0)
+  {
+    CLog::Log(LOGERROR,
+              "CDVDVideoCodecWebCodecs::GetPicture - invalid queued frame metadata "
+              "(pixelFormat={}, payloadSize={})",
+              SharedLoad(m_shared.nextPixelFormat), payloadSize);
+    return VC_ERROR;
+  }
+
+  CVideoBuffer* videoBuffer = AcquirePictureBuffer(pixelFormat, payloadSize);
+  if (!videoBuffer)
+    return VC_NOBUFFER;
+
+  WebCodecsFrameInfo info{};
+  const int copyStatus =
+      webcodecs_copy_next_frame(m_decoderHandle, videoBuffer->GetMemPtr(), payloadSize, &info);
+  if (copyStatus != 1)
+  {
+    videoBuffer->Release();
+    if (copyStatus == 0)
+      return VC_BUFFER;
+
+    const std::string error = ReadDecoderError(m_decoderHandle);
+    CLog::Log(LOGERROR,
+              "CDVDVideoCodecWebCodecs::GetPicture - cannot start frame copy (status={}, "
+              "payloadSize={} vs published {}): {}",
+              copyStatus, info.payloadSize, payloadSize,
+              error.empty() ? "<no js error>" : error);
+    return VC_ERROR;
+  }
+
+  m_copyBuffer = videoBuffer;
+  if (!WaitForCopy())
+  {
+    if (SharedLoad(m_shared.copyResult) == 0)
+    {
+      CLog::Log(LOGERROR, "CDVDVideoCodecWebCodecs::GetPicture - frame copy did not complete "
+                          "within {} ms",
+                COPY_TIMEOUT.count());
+      return VC_ERROR;
+    }
+
+    ReleaseCopyBuffer();
+    const std::string error = ReadDecoderError(m_decoderHandle);
+    CLog::Log(LOGERROR, "CDVDVideoCodecWebCodecs::GetPicture - frame copy failed: {}",
+              error.empty() ? "<no js error>" : error);
+    return VC_ERROR;
+  }
+  m_copyBuffer = nullptr;
+
+  const AVPixelFormat framePixelFormat = PixelFormatFromWebCodecs(info.pixelFormat);
+  if (framePixelFormat == AV_PIX_FMT_NONE)
+  {
+    videoBuffer->Release();
+    CLog::Log(LOGERROR, "CDVDVideoCodecWebCodecs::GetPicture - unsupported pixel format id {}",
+              info.pixelFormat);
+    return VC_ERROR;
+  }
+
+  const int strides[YuvImage::MAX_PLANES] = {info.yStride, info.uStride, info.vStride};
+  const int planeOffsets[YuvImage::MAX_PLANES] = {0, info.uOffset, info.vOffset};
+  videoBuffer->SetPixelFormat(framePixelFormat);
+  videoBuffer->SetDimensions(info.width, info.height, strides, planeOffsets);
+
+  FillPictureMetadata(pVideoPicture, videoBuffer, framePixelFormat, info.width, info.height,
+                      info.keyFrame != 0, info.ptsSeconds, info.durationSeconds);
+  return VC_PICTURE;
+}

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecWebCodecs.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecWebCodecs.h
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include "DVDVideoCodec.h"
+#include "DVDVideoCodecWebCodecsBridge.h"
+#include "cores/VideoPlayer/DVDStreamInfo.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+class CVideoBufferPoolSysMem;
+
+class CDVDVideoCodecWebCodecs : public CDVDVideoCodec
+{
+public:
+  explicit CDVDVideoCodecWebCodecs(CProcessInfo& processInfo);
+  ~CDVDVideoCodecWebCodecs() override;
+
+  static std::unique_ptr<CDVDVideoCodec> Create(CProcessInfo& processInfo);
+  static bool Register();
+
+  bool Open(CDVDStreamInfo& hints, CDVDCodecOptions& options) override;
+  bool AddData(const DemuxPacket& packet) override;
+  void Reset() override;
+  VCReturn GetPicture(VideoPicture* pVideoPicture) override;
+  const char* GetName() override { return m_name.c_str(); }
+  void SetCodecControl(int flags) override;
+
+private:
+  bool CreateDecoder();
+  void Dispose();
+  bool SupportsCodec(const CDVDStreamInfo& hints) const;
+  bool BuildCodecConfiguration(const CDVDStreamInfo& hints);
+  void PollDecoderStats();
+  static int32_t SharedLoad(const int32_t& field);
+  void WaitForDecoderSignal(uint32_t seenSignal, double maxWaitMs);
+  void WaitForDrain();
+  bool WaitForCopy();
+  void ReleaseCopyBuffer();
+  CVideoBuffer* AcquirePictureBuffer(AVPixelFormat pixelFormat, int bufferSize);
+  void FillPictureMetadata(VideoPicture* pVideoPicture,
+                           CVideoBuffer* videoBuffer,
+                           AVPixelFormat pixelFormat,
+                           int width,
+                           int height,
+                           bool keyFrame,
+                           double ptsSeconds,
+                           double durationSeconds) const;
+
+  std::string m_name{"webcodecs"};
+  CDVDStreamInfo m_hints;
+  std::shared_ptr<CVideoBufferPoolSysMem> m_videoBufferPool;
+
+  int m_decoderHandle{0};
+  bool m_opened{false};
+  bool m_drainSubmitted{false};
+  bool m_waitingForKeyFrame{true};
+  bool m_annexB{false};
+  int m_nalLengthSize{0};
+  int m_codecControlFlags{0};
+  int m_lastLoggedDroppedFrames{0};
+  int m_highWaterMark{0};
+
+  // Written by the JS bridge for the lifetime of m_decoderHandle.
+  WebCodecsSharedState m_shared{};
+  // Handed to the JS bridge as copy destination; owned here until the copy settles.
+  CVideoBuffer* m_copyBuffer{nullptr};
+
+  std::string m_codecString;
+};

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecWebCodecsBridge.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecWebCodecsBridge.h
@@ -1,0 +1,159 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+// Shared ABI between the C++ video codec and the Emscripten JS library that
+// drives WebCodecs. All functions declared here are implemented in
+// webcodecs_bridge.js and linked via --js-library.
+//
+// The VideoDecoder lives on the browser main thread, so the JS library proxies
+// every call there via Emscripten's __proxy: 'sync' attribute; callers may
+// invoke these functions from any pthread.
+
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// Pixel format ids, shared with JS (must stay in sync with webcodecs_bridge.js).
+enum WebCodecsPixelFormat
+{
+  WEBCODECS_PIXFMT_UNKNOWN = 0,
+  WEBCODECS_PIXFMT_YUV420P = 1,
+  WEBCODECS_PIXFMT_NV12 = 2,
+};
+
+// Status codes returned by webcodecs_push_packet.
+enum WebCodecsPushStatus
+{
+  WEBCODECS_PUSH_QUEUED = 1,
+  WEBCODECS_PUSH_EMPTY = 0,
+  WEBCODECS_PUSH_HANDLE_NOT_FOUND = -1,
+  WEBCODECS_PUSH_DECODER_FAILED = -2,
+  WEBCODECS_PUSH_NOT_CONFIGURED = -3,
+  WEBCODECS_PUSH_DECODE_THREW = -4,
+  WEBCODECS_PUSH_BUSY = -5,
+};
+
+// Metadata written by webcodecs_copy_next_frame. Field offsets are locked
+// down by static_assert below and mirrored as byte offsets in JS.
+struct WebCodecsFrameInfo
+{
+  int32_t pixelFormat;
+  int32_t width;
+  int32_t height;
+  int32_t yStride;
+  int32_t uStride;
+  int32_t vStride;
+  int32_t uOffset;
+  int32_t vOffset;
+  int32_t keyFrame;
+  int32_t payloadSize;
+  double ptsSeconds;
+  double durationSeconds;
+};
+
+// Decoder state mirrored into wasm memory by the JS side with Atomics so the
+// codec can poll it without a main-thread round trip. `signal` is incremented
+// and Atomics.notify'd on every change, so callers can futex-wait on it.
+struct WebCodecsSharedState
+{
+  int32_t signal;
+  int32_t queuedFrames;
+  int32_t inflight; // decodeQueueSize + frame copies still in progress
+  int32_t busy; // webcodecs_push_packet would return WEBCODECS_PUSH_BUSY
+  int32_t failed;
+  int32_t nextPayloadSize; // of the frame webcodecs_copy_next_frame returns next
+  int32_t nextPixelFormat;
+  int32_t copyResult; // 0 while a webcodecs_copy_next_frame copy runs, then 1 or -1
+};
+
+#ifdef __cplusplus
+} // extern "C"
+
+#include <cstddef>
+
+static_assert(sizeof(WebCodecsSharedState) == 32, "WebCodecsSharedState must be 32 bytes");
+static_assert(offsetof(WebCodecsSharedState, signal) == 0, "signal offset");
+static_assert(offsetof(WebCodecsSharedState, queuedFrames) == 4, "queuedFrames offset");
+static_assert(offsetof(WebCodecsSharedState, inflight) == 8, "inflight offset");
+static_assert(offsetof(WebCodecsSharedState, busy) == 12, "busy offset");
+static_assert(offsetof(WebCodecsSharedState, failed) == 16, "failed offset");
+static_assert(offsetof(WebCodecsSharedState, nextPayloadSize) == 20, "nextPayloadSize offset");
+static_assert(offsetof(WebCodecsSharedState, nextPixelFormat) == 24, "nextPixelFormat offset");
+static_assert(offsetof(WebCodecsSharedState, copyResult) == 28, "copyResult offset");
+
+static_assert(sizeof(WebCodecsFrameInfo) == 56, "WebCodecsFrameInfo must be 56 bytes");
+static_assert(offsetof(WebCodecsFrameInfo, pixelFormat) == 0, "pixelFormat offset");
+static_assert(offsetof(WebCodecsFrameInfo, width) == 4, "width offset");
+static_assert(offsetof(WebCodecsFrameInfo, height) == 8, "height offset");
+static_assert(offsetof(WebCodecsFrameInfo, yStride) == 12, "yStride offset");
+static_assert(offsetof(WebCodecsFrameInfo, uStride) == 16, "uStride offset");
+static_assert(offsetof(WebCodecsFrameInfo, vStride) == 20, "vStride offset");
+static_assert(offsetof(WebCodecsFrameInfo, uOffset) == 24, "uOffset offset");
+static_assert(offsetof(WebCodecsFrameInfo, vOffset) == 28, "vOffset offset");
+static_assert(offsetof(WebCodecsFrameInfo, keyFrame) == 32, "keyFrame offset");
+static_assert(offsetof(WebCodecsFrameInfo, payloadSize) == 36, "payloadSize offset");
+static_assert(offsetof(WebCodecsFrameInfo, ptsSeconds) == 40, "ptsSeconds offset");
+static_assert(offsetof(WebCodecsFrameInfo, durationSeconds) == 48, "durationSeconds offset");
+
+extern "C"
+{
+#endif
+
+// Returns a positive decoder handle on success, 0 on failure. `shared` must stay
+// valid until webcodecs_destroy_decoder.
+int webcodecs_create_decoder(const char* codec,
+                             int codedWidth,
+                             int codedHeight,
+                             const uint8_t* description,
+                             int descriptionSize,
+                             int annexB,
+                             struct WebCodecsSharedState* shared);
+
+// Closes and unregisters the decoder. Handle becomes invalid.
+void webcodecs_destroy_decoder(int handle);
+
+// reset() drops pending work and requires reconfigure(); the bridge handles both.
+int webcodecs_reset_decoder(int handle);
+
+// Starts VideoDecoder.flush(), which releases every frame the decoder is still
+// holding. Completion is reflected in WebCodecsSharedState::inflight. The
+// decoder then requires a key chunk, so the caller must skip deltas until one
+// arrives. Returns 1 if a flush is running, 0 otherwise.
+int webcodecs_flush_decoder(int handle);
+
+// Feeds one encoded packet. Returns a WebCodecsPushStatus.
+int webcodecs_push_packet(int handle,
+                          const uint8_t* data,
+                          int size,
+                          int keyFrame,
+                          double ptsSeconds,
+                          double durationSeconds);
+
+// Fills *info and starts copying the next queued frame into [dst, dst+dstSize);
+// completion is reported through WebCodecsSharedState::copyResult and dst must
+// stay valid until then. Returns 1 if a copy was started, 0 if no frame is
+// available yet, -1 on decoder failure, and -2 if dst is too small for
+// info->payloadSize.
+int webcodecs_copy_next_frame(int handle,
+                              uint8_t* dst,
+                              int dstSize,
+                              struct WebCodecsFrameInfo* info);
+
+// Reads accumulated queue stats.
+int webcodecs_read_stats(int handle, int* droppedFrames, int* highWaterMark);
+
+// Writes a NUL-terminated UTF-8 diagnostic string ("<state>|<error>") of at
+// most (dstSize-1) bytes into dst. Returns the number of bytes written
+// (excluding the NUL). A return of 0 means "nothing to report".
+int webcodecs_take_error(int handle, char* dst, int dstSize);
+
+#ifdef __cplusplus
+}
+#endif

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/webcodecs_bridge.js
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/webcodecs_bridge.js
@@ -1,0 +1,577 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+//
+// Emscripten JS library implementing the WebCodecs bridge declared in
+// DVDVideoCodecWebCodecsBridge.h. Linked via --js-library (see
+// cmake/scripts/wasm/ArchSetup.cmake).
+//
+// Every exported function has __proxy:'sync' so calls from any pthread are
+// automatically marshalled to the main browser thread, where the VideoDecoder
+// lives. Decoder state the C++ side polls is mirrored into WebCodecsSharedState
+// with Atomics instead (see publishState) so polling needs no round trip.
+//
+// Function signatures must match the C prototypes; mismatched __sig will
+// silently corrupt arguments on threaded builds.
+//
+
+mergeInto(LibraryManager.library, {
+
+  // ---------------------------------------------------------------------------
+  // Internal module: shared state + helpers, attached only if any bridge
+  // function is used (Emscripten dead-strips unreferenced $-symbols).
+  // ---------------------------------------------------------------------------
+  $WebCodecsBridge: {
+    MICROSECONDS_PER_SECOND: 1000000.0,
+    FRAME_QUEUE_HIGH_WATER: 24,
+    // Cap on decoder frames alive at once: queued for decode, held open
+    // awaiting copy, or being copied. Beyond this push_packet reports BUSY so
+    // VideoPlayer re-queues the packet; hardware decoders stall when too many
+    // output frames stay open.
+    MAX_INFLIGHT: 12,
+
+    // Enum values below are pulled from the C++-owned Embind registrations
+    // (Module.WebCodecsPixelFormat / Module.WebCodecsPushStatus) on first use
+    // by syncEnumsFromEmbind(). The C++ header (DVDVideoCodecWebCodecsBridge.h)
+    // is the single source of truth; do not hardcode these here.
+    PIXFMT_UNKNOWN: 0,
+    PIXFMT_YUV420P: 0,
+    PIXFMT_NV12: 0,
+    PUSH_QUEUED: 0,
+    PUSH_EMPTY: 0,
+    PUSH_HANDLE_NOT_FOUND: 0,
+    PUSH_DECODER_FAILED: 0,
+    PUSH_NOT_CONFIGURED: 0,
+    PUSH_DECODE_THREW: 0,
+    PUSH_BUSY: 0,
+    _enumsReady: false,
+
+    // Byte offsets inside struct WebCodecsFrameInfo (kept in sync with the
+    // static_asserts in DVDVideoCodecWebCodecsBridge.h).
+    FI_PIXFMT: 0,
+    FI_WIDTH: 4,
+    FI_HEIGHT: 8,
+    FI_Y_STRIDE: 12,
+    FI_U_STRIDE: 16,
+    FI_V_STRIDE: 20,
+    FI_U_OFFSET: 24,
+    FI_V_OFFSET: 28,
+    FI_KEYFRAME: 32,
+    FI_PAYLOAD_SIZE: 36,
+    FI_PTS: 40,
+    FI_DURATION: 48,
+
+    // Int32 indices inside struct WebCodecsSharedState (offsets / 4).
+    SS_SIGNAL: 0,
+    SS_QUEUED_FRAMES: 1,
+    SS_INFLIGHT: 2,
+    SS_BUSY: 3,
+    SS_FAILED: 4,
+    SS_NEXT_PAYLOAD_SIZE: 5,
+    SS_NEXT_PIXFMT: 6,
+    SS_COPY_RESULT: 7,
+
+    // Registry is lazily created on first decoder creation; this library file
+    // is merged into both the main thread and every pthread module, but only
+    // the main thread ever touches the maps (__proxy:'sync' on every entry).
+    registry: null,
+    nextId: 1,
+
+    ensureRegistry: function() {
+      if (!this.registry)
+        this.registry = new Map();
+      return this.registry;
+    },
+
+    // Pull the canonical enum numeric values out of the Embind bindings
+    // registered by EMSCRIPTEN_BINDINGS(kodi_webcodecs_bridge) in
+    // DVDVideoCodecWebCodecs.cpp. Embind exposes each C++ enum value as an
+    // object with a .value property holding the underlying integer.
+    syncEnumsFromEmbind: function() {
+      if (this._enumsReady)
+        return;
+      const pf = Module['WebCodecsPixelFormat'];
+      const ps = Module['WebCodecsPushStatus'];
+      if (!pf || !ps)
+        throw new Error('WebCodecs bridge enums missing from Module (Embind not linked?)');
+      this.PIXFMT_UNKNOWN = pf.UNKNOWN.value;
+      this.PIXFMT_YUV420P = pf.YUV420P.value;
+      this.PIXFMT_NV12 = pf.NV12.value;
+      this.PUSH_QUEUED = ps.QUEUED.value;
+      this.PUSH_EMPTY = ps.EMPTY.value;
+      this.PUSH_HANDLE_NOT_FOUND = ps.HANDLE_NOT_FOUND.value;
+      this.PUSH_DECODER_FAILED = ps.DECODER_FAILED.value;
+      this.PUSH_NOT_CONFIGURED = ps.NOT_CONFIGURED.value;
+      this.PUSH_DECODE_THREW = ps.DECODE_THREW.value;
+      this.PUSH_BUSY = ps.BUSY.value;
+      this._enumsReady = true;
+    },
+
+    getState: function(handle) {
+      return this.registry ? this.registry.get(handle) : null;
+    },
+
+    inflight: function(state) {
+      const decoder = state.decoder;
+      const queueSize = decoder && decoder.state === 'configured' ? decoder.decodeQueueSize : 0;
+      return queueSize + (state.copying ? 1 : 0) + (state.flushing ? 1 : 0);
+    },
+
+    publishState: function(state) {
+      if (!state.sharedPtr)
+        return;
+      const base = state.sharedPtr >> 2;
+      const inflight = this.inflight(state);
+      const next = state.frames.length > 0 ? state.frames[0] : null;
+      Atomics.store(HEAP32, base + this.SS_QUEUED_FRAMES, state.frames.length);
+      Atomics.store(HEAP32, base + this.SS_INFLIGHT, inflight);
+      Atomics.store(HEAP32, base + this.SS_BUSY,
+                    inflight + state.frames.length >= this.MAX_INFLIGHT ? 1 : 0);
+      Atomics.store(HEAP32, base + this.SS_FAILED, state.failed ? 1 : 0);
+      Atomics.store(HEAP32, base + this.SS_NEXT_PAYLOAD_SIZE, next ? next.payloadSize : 0);
+      Atomics.store(HEAP32, base + this.SS_NEXT_PIXFMT, next ? next.pixelFormat : this.PIXFMT_UNKNOWN);
+      Atomics.store(HEAP32, base + this.SS_COPY_RESULT, state.copyResult);
+      Atomics.add(HEAP32, base + this.SS_SIGNAL, 1);
+      Atomics.notify(HEAP32, base + this.SS_SIGNAL);
+    },
+
+    // Plane layout for the formats we accept, with tightly packed strides.
+    describeFrame: function(frame, width, height) {
+      const format = frame.format || 'I420';
+      const yStride = width;
+      const uvHeight = (height + 1) >> 1;
+      const ySize = yStride * height;
+
+      if (format === 'NV12') {
+        const uvSize = yStride * uvHeight;
+        return {
+          pixelFormat: this.PIXFMT_NV12,
+          payloadSize: ySize + uvSize,
+          yStride, uStride: yStride, vStride: 0,
+          uOffset: ySize, vOffset: 0,
+          layout: [{ offset: 0, stride: yStride }, { offset: ySize, stride: yStride }],
+        };
+      }
+
+      if (format === 'I420') {
+        const uvStride = (width + 1) >> 1;
+        const uvSize = uvStride * uvHeight;
+        return {
+          pixelFormat: this.PIXFMT_YUV420P,
+          payloadSize: ySize + uvSize * 2,
+          yStride, uStride: uvStride, vStride: uvStride,
+          uOffset: ySize, vOffset: ySize + uvSize,
+          layout: [
+            { offset: 0, stride: yStride },
+            { offset: ySize, stride: uvStride },
+            { offset: ySize + uvSize, stride: uvStride },
+          ],
+        };
+      }
+
+      return null;
+    },
+
+    // Copies straight into wasm memory: under pthreads the heap is a
+    // SharedArrayBuffer and existing views stay valid across growth. Browsers
+    // whose copyTo() still rejects shared views fall back to a scratch buffer
+    // plus one memcpy.
+    copyFrame: async function(state, entry, dstPtr) {
+      const options = { layout: entry.layout };
+      if (entry.visibleRect)
+        options.rect = entry.visibleRect;
+
+      if (state.directCopy) {
+        try {
+          await entry.frame.copyTo(HEAPU8.subarray(dstPtr, dstPtr + entry.payloadSize), options);
+          return;
+        } catch (e) {
+          if (!(e instanceof TypeError))
+            throw e;
+          state.directCopy = false;
+        }
+      }
+
+      if (!state.scratch || state.scratch.byteLength < entry.payloadSize)
+        state.scratch = new Uint8Array(entry.payloadSize);
+      const scratch = state.scratch.subarray(0, entry.payloadSize);
+      await entry.frame.copyTo(scratch, options);
+      HEAPU8.set(scratch, dstPtr);
+    },
+
+    // Build the configure() dictionary from the stored codec parameters.
+    buildConfig: function(state, width, height) {
+      const config = {
+        codec: state.codec,
+        optimizeForLatency: true,
+        hardwareAcceleration: 'prefer-hardware',
+      };
+      if (width > 0) config.codedWidth = width;
+      if (height > 0) config.codedHeight = height;
+      if (state.codec.startsWith('avc1'))
+        config.avc = { format: state.annexB ? 'annexb' : 'avc' };
+      if (state.description)
+        config.description = state.description;
+      return config;
+    },
+
+    writeFrameInfo: function(infoPtr, frame) {
+      HEAP32[(infoPtr + this.FI_PIXFMT) >> 2] = frame.pixelFormat | 0;
+      HEAP32[(infoPtr + this.FI_WIDTH) >> 2] = frame.width | 0;
+      HEAP32[(infoPtr + this.FI_HEIGHT) >> 2] = frame.height | 0;
+      HEAP32[(infoPtr + this.FI_Y_STRIDE) >> 2] = frame.yStride | 0;
+      HEAP32[(infoPtr + this.FI_U_STRIDE) >> 2] = frame.uStride | 0;
+      HEAP32[(infoPtr + this.FI_V_STRIDE) >> 2] = frame.vStride | 0;
+      HEAP32[(infoPtr + this.FI_U_OFFSET) >> 2] = frame.uOffset | 0;
+      HEAP32[(infoPtr + this.FI_V_OFFSET) >> 2] = frame.vOffset | 0;
+      HEAP32[(infoPtr + this.FI_KEYFRAME) >> 2] = frame.keyFrame ? 1 : 0;
+      HEAP32[(infoPtr + this.FI_PAYLOAD_SIZE) >> 2] = frame.payloadSize | 0;
+      HEAPF64[(infoPtr + this.FI_PTS) >> 3] = frame.ptsSeconds;
+      HEAPF64[(infoPtr + this.FI_DURATION) >> 3] = frame.durationSeconds;
+    },
+  },
+
+  // ---------------------------------------------------------------------------
+  // webcodecs_create_decoder: build + configure a VideoDecoder.
+  // sig: i (ret) | string*, i, i, u8*, i, i, WebCodecsSharedState*
+  // ---------------------------------------------------------------------------
+  webcodecs_create_decoder__deps: ['$WebCodecsBridge'],
+  webcodecs_create_decoder__proxy: 'sync',
+  webcodecs_create_decoder__sig: 'iiiiiiii',
+  webcodecs_create_decoder: function(codecPtr, width, height, extraPtr, extraSize, annexB, sharedPtr) {
+    if (typeof VideoDecoder === 'undefined' || typeof EncodedVideoChunk === 'undefined') {
+      console.warn('WASM WebCodecs: VideoDecoder / EncodedVideoChunk not available');
+      return 0;
+    }
+
+    try {
+      WebCodecsBridge.syncEnumsFromEmbind();
+    } catch (e) {
+      console.warn('WASM WebCodecs:', e);
+      return 0;
+    }
+
+    const registry = WebCodecsBridge.ensureRegistry();
+    const id = WebCodecsBridge.nextId++;
+    const codec = UTF8ToString(codecPtr);
+
+    const state = {
+      id,
+      codec,
+      sharedPtr,
+      annexB: !!annexB,
+      failed: false,
+      errorMessage: '',
+      lastTimestamp: 0,
+      frames: [],
+      copying: false,
+      copyResult: 0,
+      scratch: null,
+      directCopy: true,
+      flushing: false,
+      generation: 0,
+      droppedFrames: 0,
+      highWaterMark: 0,
+      decoder: null,
+      description: null,
+      configured: false,
+    };
+
+    const errorCallback = (error) => {
+      state.failed = true;
+      state.errorMessage = 'VideoDecoder error: ' + (error && error.message ? error.message : error);
+      console.warn('WASM WebCodecs:', state.errorMessage);
+      WebCodecsBridge.publishState(state);
+    };
+
+    const outputCallback = (frame) => {
+      const visibleRect = frame.visibleRect || null;
+      const width = visibleRect ? visibleRect.width : frame.codedWidth;
+      const height = visibleRect ? visibleRect.height : frame.codedHeight;
+      const timestampMicros = Number.isFinite(frame.timestamp) ? Number(frame.timestamp)
+                                                                : state.lastTimestamp;
+      const durationMicros = Number.isFinite(frame.duration) ? Number(frame.duration) : 0;
+      state.lastTimestamp = timestampMicros;
+
+      const described = WebCodecsBridge.describeFrame(frame, width, height);
+      if (!described) {
+        state.failed = true;
+        state.errorMessage = 'unsupported frame format: ' + frame.format;
+        frame.close();
+        WebCodecsBridge.publishState(state);
+        return;
+      }
+
+      // Safety valve: push_packet reports BUSY long before this is reached.
+      if (state.frames.length >= WebCodecsBridge.FRAME_QUEUE_HIGH_WATER) {
+        state.droppedFrames += 1;
+        frame.close();
+        WebCodecsBridge.publishState(state);
+        return;
+      }
+
+      state.frames.push(Object.assign({
+        frame,
+        visibleRect,
+        width,
+        height,
+        ptsSeconds: timestampMicros / WebCodecsBridge.MICROSECONDS_PER_SECOND,
+        durationSeconds: durationMicros / WebCodecsBridge.MICROSECONDS_PER_SECOND,
+        keyFrame: frame.type === 'key',
+      }, described));
+      if (state.frames.length > state.highWaterMark)
+        state.highWaterMark = state.frames.length;
+      WebCodecsBridge.publishState(state);
+    };
+
+    try {
+      if (extraSize > 0)
+        state.description = HEAPU8.slice(extraPtr, extraPtr + extraSize);
+
+      state.decoder = new VideoDecoder({ output: outputCallback, error: errorCallback });
+      state.decoder.addEventListener('dequeue', () => WebCodecsBridge.publishState(state));
+
+      const config = WebCodecsBridge.buildConfig(state, width, height);
+
+      // isConfigSupported is advisory: we log but don't block on it because
+      // it's async and we need a synchronous return here. A failed config
+      // will surface via the decoder's error callback.
+      try {
+        VideoDecoder.isConfigSupported(config).then((support) => {
+          if (!support || !support.supported) {
+            state.failed = true;
+            state.errorMessage = 'isConfigSupported rejected config for ' + codec;
+            console.warn('WASM WebCodecs: isConfigSupported rejected', codec, support);
+            WebCodecsBridge.publishState(state);
+          }
+        }).catch((error) => {
+          state.failed = true;
+          state.errorMessage = 'isConfigSupported threw: ' + String(error);
+          WebCodecsBridge.publishState(state);
+        });
+      } catch (probeError) {
+        console.warn('WASM WebCodecs: isConfigSupported threw synchronously', probeError);
+      }
+
+      state.decoder.configure(config);
+      state.configured = true;
+      registry.set(id, state);
+      WebCodecsBridge.publishState(state);
+
+      console.info('WASM WebCodecs: configured VideoDecoder', {
+        codec, annexB: !!annexB, descriptionBytes: extraSize, width, height,
+      });
+      return id;
+    } catch (e) {
+      console.warn('WASM WebCodecs: create/configure decoder failed', e);
+      // The state never reached the registry, so webcodecs_destroy_decoder cannot
+      // reach the decoder to close it.
+      try {
+        if (state.decoder) state.decoder.close();
+      } catch (closeError) {
+        console.warn('WASM WebCodecs: decoder close failed', closeError);
+      }
+      return 0;
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  webcodecs_destroy_decoder__deps: ['$WebCodecsBridge'],
+  webcodecs_destroy_decoder__proxy: 'sync',
+  webcodecs_destroy_decoder__sig: 'vi',
+  webcodecs_destroy_decoder: function(handle) {
+    const state = WebCodecsBridge.getState(handle);
+    if (!state) return;
+    state.generation += 1;
+    for (const entry of state.frames) entry.frame.close();
+    state.frames.length = 0;
+    try {
+      if (state.decoder) state.decoder.close();
+    } catch (e) {
+      console.warn('WASM WebCodecs: decoder close failed', e);
+    }
+    // A copy still in flight finishes on its own; it must not publish into
+    // memory the codec may have freed by then.
+    state.sharedPtr = 0;
+    WebCodecsBridge.registry.delete(handle);
+  },
+
+  // ---------------------------------------------------------------------------
+  webcodecs_reset_decoder__deps: ['$WebCodecsBridge'],
+  webcodecs_reset_decoder__proxy: 'sync',
+  webcodecs_reset_decoder__sig: 'ii',
+  webcodecs_reset_decoder: function(handle) {
+    const state = WebCodecsBridge.getState(handle);
+    if (!state || !state.decoder) return 0;
+    try {
+      state.decoder.reset();
+      state.generation += 1;
+      for (const entry of state.frames) entry.frame.close();
+      state.frames.length = 0;
+      state.flushing = false;
+      state.droppedFrames = 0;
+      state.highWaterMark = 0;
+      state.failed = false;
+      state.errorMessage = '';
+      // reset() returns the decoder to 'unconfigured'; we must configure again.
+      state.decoder.configure(WebCodecsBridge.buildConfig(state, 0, 0));
+      WebCodecsBridge.publishState(state);
+      return 1;
+    } catch (e) {
+      state.failed = true;
+      state.errorMessage = 'reset failed: ' + String(e);
+      WebCodecsBridge.publishState(state);
+      return 0;
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  webcodecs_flush_decoder__deps: ['$WebCodecsBridge'],
+  webcodecs_flush_decoder__proxy: 'sync',
+  webcodecs_flush_decoder__sig: 'ii',
+  webcodecs_flush_decoder: function(handle) {
+    const B = WebCodecsBridge;
+    const state = B.getState(handle);
+    if (!state || state.failed || !state.decoder || state.decoder.state !== 'configured')
+      return 0;
+    if (state.flushing)
+      return 1;
+
+    const generation = state.generation;
+    state.flushing = true;
+    state.decoder.flush().then(() => {
+      if (state.generation !== generation) return;
+      state.flushing = false;
+      B.publishState(state);
+    }).catch((e) => {
+      // reset() rejects a pending flush with AbortError; that is not a failure.
+      if (state.generation !== generation) return;
+      state.flushing = false;
+      if (!e || e.name !== 'AbortError') {
+        state.failed = true;
+        state.errorMessage = 'flush failed: ' + String(e);
+      }
+      B.publishState(state);
+    });
+    B.publishState(state);
+    return 1;
+  },
+
+  // ---------------------------------------------------------------------------
+  webcodecs_push_packet__deps: ['$WebCodecsBridge'],
+  webcodecs_push_packet__proxy: 'sync',
+  webcodecs_push_packet__sig: 'iiiiidd',
+  webcodecs_push_packet: function(handle, dataPtr, dataSize, keyFrame, ptsSeconds, durationSeconds) {
+    const B = WebCodecsBridge;
+    const state = B.getState(handle);
+    if (!state) return B.PUSH_HANDLE_NOT_FOUND;
+    if (state.failed) return B.PUSH_DECODER_FAILED;
+    if (!state.decoder || state.decoder.state !== 'configured') {
+      if (!state.errorMessage)
+        state.errorMessage = 'decoder not configured (state=' +
+          (state.decoder ? state.decoder.state : 'null') + ')';
+      return B.PUSH_NOT_CONFIGURED;
+    }
+
+    if (dataSize <= 0)
+      return B.PUSH_EMPTY;
+
+    if (B.inflight(state) >= B.MAX_INFLIGHT)
+      return B.PUSH_BUSY;
+
+    const tsMicros = Math.round(ptsSeconds * B.MICROSECONDS_PER_SECOND);
+    const durMicros = Math.max(0, Math.round(durationSeconds * B.MICROSECONDS_PER_SECOND));
+    const payload = HEAPU8.slice(dataPtr, dataPtr + dataSize);
+
+    try {
+      state.decoder.decode(new EncodedVideoChunk({
+        type: keyFrame ? 'key' : 'delta',
+        timestamp: tsMicros,
+        duration: durMicros > 0 ? durMicros : undefined,
+        data: payload,
+      }));
+      B.publishState(state);
+      return B.PUSH_QUEUED;
+    } catch (e) {
+      state.failed = true;
+      state.errorMessage = 'decode threw: ' + String(e);
+      B.publishState(state);
+      return B.PUSH_DECODE_THREW;
+    }
+  },
+
+  // ---------------------------------------------------------------------------
+  webcodecs_copy_next_frame__deps: ['$WebCodecsBridge'],
+  webcodecs_copy_next_frame__proxy: 'sync',
+  webcodecs_copy_next_frame__sig: 'iiiii',
+  webcodecs_copy_next_frame: function(handle, dstPtr, dstSize, infoPtr) {
+    const B = WebCodecsBridge;
+    const state = B.getState(handle);
+    if (!state) return 0;
+    if (state.failed) return -1;
+    if (state.copying || state.frames.length === 0) return 0;
+
+    const entry = state.frames[0];
+    B.writeFrameInfo(infoPtr, entry);
+    if (entry.payloadSize > dstSize)
+      return -2;
+
+    state.frames.shift();
+    state.copying = true;
+    state.copyResult = 0;
+    const generation = state.generation;
+    B.publishState(state);
+
+    B.copyFrame(state, entry, dstPtr).then(() => {
+      state.copyResult = 1;
+    }, (e) => {
+      state.copyResult = -1;
+      if (state.generation === generation) {
+        state.failed = true;
+        state.errorMessage = 'frame copy failed: ' + String(e);
+      }
+    }).finally(() => {
+      entry.frame.close();
+      state.copying = false;
+      B.publishState(state);
+    });
+    return 1;
+  },
+
+  // ---------------------------------------------------------------------------
+  webcodecs_read_stats__deps: ['$WebCodecsBridge'],
+  webcodecs_read_stats__proxy: 'sync',
+  webcodecs_read_stats__sig: 'iiii',
+  webcodecs_read_stats: function(handle, droppedPtr, highWaterPtr) {
+    const state = WebCodecsBridge.getState(handle);
+    if (!state) return 0;
+    HEAP32[droppedPtr >> 2] = state.droppedFrames | 0;
+    HEAP32[highWaterPtr >> 2] = state.highWaterMark | 0;
+    return 1;
+  },
+
+  // ---------------------------------------------------------------------------
+  webcodecs_take_error__deps: ['$WebCodecsBridge'],
+  webcodecs_take_error__proxy: 'sync',
+  webcodecs_take_error__sig: 'iiii',
+  webcodecs_take_error: function(handle, dstPtr, dstSize) {
+    if (dstSize <= 1) return 0;
+    const state = WebCodecsBridge.getState(handle);
+    if (!state) return 0;
+    const decoderState = state.decoder ? state.decoder.state : 'none';
+    const message = state.errorMessage || '';
+    if (!message && decoderState === 'configured')
+      return 0;
+
+    state.errorMessage = '';
+    const text = decoderState + '|' + message;
+    const encoded = new TextEncoder().encode(text);
+    const maxCopy = Math.min(encoded.length, dstSize - 1);
+    HEAPU8.set(encoded.subarray(0, maxCopy), dstPtr);
+    HEAPU8[dstPtr + maxCopy] = 0;
+    return maxCopy;
+  },
+
+});

--- a/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxFFmpeg.cpp
@@ -1181,6 +1181,7 @@ DemuxPacket* CDVDDemuxFFmpeg::ReadInternal(bool keep)
               ConvertTimestamp(m_pkt.pkt.dts, stream->time_base.den, stream->time_base.num);
           pPacket->duration = DVD_SEC_TO_TIME((double)m_pkt.pkt.duration * stream->time_base.num /
                                               stream->time_base.den);
+          pPacket->m_keyFrame = (m_pkt.pkt.flags & AV_PKT_FLAG_KEY) != 0;
 
           CDVDDemuxUtils::StoreSideData(pPacket, &m_pkt.pkt);
 

--- a/xbmc/cores/VideoPlayer/Interface/DemuxPacket.h
+++ b/xbmc/cores/VideoPlayer/Interface/DemuxPacket.h
@@ -43,6 +43,13 @@ extern "C"
 
     //! @brief PTS offset correction applied to the PTS and DTS.
     double m_ptsOffsetCorrection{0};
+
+    //! @brief Whether the packet holds a keyframe, as reported by the demuxer.
+    //! Unlike recoveryPoint this says nothing about where output may start: an
+    //! open GOP keyframe is followed by leading pictures that reference frames
+    //! before it. Packets from inputstream addons leave this false, since the
+    //! field is not part of the DEMUX_PACKET ABI.
+    bool m_keyFrame{false};
   };
 
 #ifdef __cplusplus

--- a/xbmc/cores/VideoPlayer/Process/wasm/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/Process/wasm/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES ProcessInfoWasm.cpp)
+
+set(HEADERS ProcessInfoWasm.h)
+
+core_add_library(videoplayer_process_wasm)

--- a/xbmc/cores/VideoPlayer/Process/wasm/ProcessInfoWasm.cpp
+++ b/xbmc/cores/VideoPlayer/Process/wasm/ProcessInfoWasm.cpp
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "ProcessInfoWasm.h"
+
+CProcessInfo* CProcessInfoWasm::Create()
+{
+  return new CProcessInfoWasm();
+}
+
+void CProcessInfoWasm::Register()
+{
+  CProcessInfo::RegisterProcessControl("wasm", CProcessInfoWasm::Create);
+}
+
+EINTERLACEMETHOD CProcessInfoWasm::GetFallbackDeintMethod()
+{
+  return EINTERLACEMETHOD::VS_INTERLACEMETHOD_DEINTERLACE_HALF;
+}

--- a/xbmc/cores/VideoPlayer/Process/wasm/ProcessInfoWasm.h
+++ b/xbmc/cores/VideoPlayer/Process/wasm/ProcessInfoWasm.h
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include "cores/VideoPlayer/Process/ProcessInfo.h"
+
+class CProcessInfoWasm : public CProcessInfo
+{
+public:
+  static CProcessInfo* Create();
+  static void Register();
+
+  EINTERLACEMETHOD GetFallbackDeintMethod() override;
+};

--- a/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/CMakeLists.txt
@@ -42,7 +42,8 @@ if(TARGET ${APP_NAME_LC}::OpenGLES AND ("android" IN_LIST CORE_PLATFORM_NAME_LC 
                             "tvos" IN_LIST CORE_PLATFORM_NAME_LC OR
                             "gbm" IN_LIST CORE_PLATFORM_NAME_LC OR
                             "x11" IN_LIST CORE_PLATFORM_NAME_LC OR
-                            "wayland" IN_LIST CORE_PLATFORM_NAME_LC))
+                            "wayland" IN_LIST CORE_PLATFORM_NAME_LC OR
+                            "wasm" IN_LIST CORE_PLATFORM_NAME_LC))
   list(APPEND SOURCES LinuxRendererGLES.cpp
                       OverlayRendererGLES.cpp)
   list(APPEND HEADERS LinuxRendererGLES.h

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/CMakeLists.txt
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/CMakeLists.txt
@@ -35,7 +35,8 @@ if(TARGET ${APP_NAME_LC}::OpenGLES AND ("android" IN_LIST CORE_PLATFORM_NAME_LC 
                             "tvos" IN_LIST CORE_PLATFORM_NAME_LC OR
                             "gbm" IN_LIST CORE_PLATFORM_NAME_LC OR
                             "x11" IN_LIST CORE_PLATFORM_NAME_LC OR
-                            "wayland" IN_LIST CORE_PLATFORM_NAME_LC))
+                            "wayland" IN_LIST CORE_PLATFORM_NAME_LC OR
+                            "wasm" IN_LIST CORE_PLATFORM_NAME_LC))
   list(APPEND SOURCES VideoFilterShaderGLES.cpp
                       YUV2RGBShaderGLES.cpp)
   list(APPEND HEADERS VideoFilterShaderGLES.h

--- a/xbmc/platform/wasm/ApplicationWasm.cpp
+++ b/xbmc/platform/wasm/ApplicationWasm.cpp
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "application/AppEnvironment.h"
+#include "application/Application.h"
+#include "application/ApplicationPowerHandling.h"
+#include "utils/XTimeUtils.h"
+#include "utils/log.h"
+
+#include <chrono>
+
+#include <emscripten.h>
+
+// Built only for CORE_SYSTEM_NAME==wasm (see application/CMakeLists.txt).
+void CApplication::WasmRunIteration()
+{
+  if (m_bStop)
+  {
+    emscripten_cancel_main_loop();
+    CLog::Log(LOGINFO, "Exiting the application (WASM)...");
+    Cleanup();
+    CAppEnvironment::TearDown();
+    return;
+  }
+
+  static std::chrono::time_point<std::chrono::steady_clock> lastFrameTime =
+      std::chrono::steady_clock::now();
+  std::chrono::milliseconds frameTime;
+  const unsigned int noRenderFrameTime = 15;
+
+  Process();
+
+  bool renderGUI = GetComponent<CApplicationPowerHandling>()->GetRenderGUI();
+  if (!m_bStop)
+    FrameMove(true, renderGUI);
+
+  if (renderGUI && !m_bStop)
+    Render();
+  else if (!renderGUI)
+  {
+    auto now = std::chrono::steady_clock::now();
+    frameTime = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastFrameTime);
+    if (frameTime.count() < noRenderFrameTime)
+    {
+      KODI::TIME::Sleep(std::chrono::milliseconds(noRenderFrameTime - frameTime.count()));
+    }
+  }
+  lastFrameTime = std::chrono::steady_clock::now();
+}

--- a/xbmc/platform/wasm/CMakeLists.txt
+++ b/xbmc/platform/wasm/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(SOURCES CPUInfoWasm.cpp
+            GPUInfoWasm.cpp
+            MemUtils.cpp
+            PlatformWasm.cpp)
+
+set(HEADERS CPUInfoWasm.h
+            GPUInfoWasm.h
+            PlatformWasm.h)
+
+core_add_library(platform_wasm)

--- a/xbmc/platform/wasm/CPUInfoWasm.cpp
+++ b/xbmc/platform/wasm/CPUInfoWasm.cpp
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "CPUInfoWasm.h"
+
+std::shared_ptr<CCPUInfo> CCPUInfo::GetCPUInfo()
+{
+  return std::make_shared<CCPUInfoWasm>();
+}
+
+CCPUInfoWasm::CCPUInfoWasm()
+{
+  m_cpuCount = 1;
+  m_cpuModel = "WebAssembly";
+  m_cores.emplace_back();
+  m_cores.back().m_id = 0;
+}
+
+int CCPUInfoWasm::GetUsedPercentage()
+{
+  return 0;
+}
+
+float CCPUInfoWasm::GetCPUFrequency()
+{
+  return 0.0f;
+}

--- a/xbmc/platform/wasm/CPUInfoWasm.cpp
+++ b/xbmc/platform/wasm/CPUInfoWasm.cpp
@@ -8,6 +8,8 @@
 
 #include "CPUInfoWasm.h"
 
+#include <emscripten.h>
+
 std::shared_ptr<CCPUInfo> CCPUInfo::GetCPUInfo()
 {
   return std::make_shared<CCPUInfoWasm>();
@@ -15,10 +17,22 @@ std::shared_ptr<CCPUInfo> CCPUInfo::GetCPUInfo()
 
 CCPUInfoWasm::CCPUInfoWasm()
 {
-  m_cpuCount = 1;
+  m_cpuCount = EM_ASM_INT({
+    if (typeof navigator !== "undefined" && Number.isFinite(navigator.hardwareConcurrency) &&
+        navigator.hardwareConcurrency > 0)
+      return Math.floor(navigator.hardwareConcurrency);
+
+    return 1;
+  });
+
   m_cpuModel = "WebAssembly";
-  m_cores.emplace_back();
-  m_cores.back().m_id = 0;
+
+  for (int core = 0; core < m_cpuCount; core++)
+  {
+    CoreInfo coreInfo;
+    coreInfo.m_id = core;
+    m_cores.emplace_back(coreInfo);
+  }
 }
 
 int CCPUInfoWasm::GetUsedPercentage()

--- a/xbmc/platform/wasm/CPUInfoWasm.h
+++ b/xbmc/platform/wasm/CPUInfoWasm.h
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/CPUInfoPosix.h"
+
+class CCPUInfoWasm : public CCPUInfoPosix
+{
+public:
+  CCPUInfoWasm();
+  ~CCPUInfoWasm() = default;
+
+  int GetUsedPercentage() override;
+  float GetCPUFrequency() override;
+};

--- a/xbmc/platform/wasm/GPUInfoWasm.cpp
+++ b/xbmc/platform/wasm/GPUInfoWasm.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "GPUInfoWasm.h"
+
+std::unique_ptr<CGPUInfo> CGPUInfo::GetGPUInfo()
+{
+  return std::make_unique<CGPUInfoWasm>();
+}
+
+bool CGPUInfoWasm::SupportsPlatformTemperature() const
+{
+  return false;
+}
+
+bool CGPUInfoWasm::GetGPUPlatformTemperature(CTemperature& temperature) const
+{
+  return false;
+}

--- a/xbmc/platform/wasm/GPUInfoWasm.h
+++ b/xbmc/platform/wasm/GPUInfoWasm.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/GPUInfoPosix.h"
+
+class CGPUInfoWasm : public CGPUInfoPosix
+{
+public:
+  CGPUInfoWasm() = default;
+  ~CGPUInfoWasm() = default;
+
+private:
+  bool SupportsPlatformTemperature() const override;
+  bool GetGPUPlatformTemperature(CTemperature& temperature) const override;
+};

--- a/xbmc/platform/wasm/MemUtils.cpp
+++ b/xbmc/platform/wasm/MemUtils.cpp
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "utils/MemUtils.h"
+
+#include <cstdint>
+#include <cstdlib>
+
+#include <emscripten/heap.h>
+
+namespace KODI
+{
+namespace MEMORY
+{
+
+void* AlignedMalloc(size_t s, size_t alignTo)
+{
+  void* p = nullptr;
+  int res = posix_memalign(&p, alignTo, s);
+  if (res == EINVAL)
+    throw std::runtime_error("Failed to align memory, alignment is not a multiple of 2");
+  else if (res == ENOMEM)
+    throw std::runtime_error("Failed to align memory, insufficient memory available");
+  return p;
+}
+
+void AlignedFree(void* p)
+{
+  if (!p)
+    return;
+  free(p);
+}
+
+void GetMemoryStatus(MemoryStatus* buffer)
+{
+  if (!buffer)
+    return;
+
+  // The sbrk break, not the linear-memory size, is what the allocator has claimed.
+  const uint64_t heapMax = static_cast<uint64_t>(emscripten_get_heap_max());
+  const uint64_t heapUsed = static_cast<uint64_t>(*emscripten_get_sbrk_ptr());
+  buffer->totalPhys = heapMax;
+  buffer->availPhys = (heapMax > heapUsed) ? (heapMax - heapUsed) : 0;
+}
+
+} // namespace MEMORY
+} // namespace KODI

--- a/xbmc/platform/wasm/PlatformWasm.cpp
+++ b/xbmc/platform/wasm/PlatformWasm.cpp
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "PlatformWasm.h"
+
+#include <cstdlib>
+
+CPlatform* CPlatform::CreateInstance()
+{
+  return new CPlatformWasm();
+}
+
+bool CPlatformWasm::InitStageOne()
+{
+  if (!std::getenv("HOME"))
+    setenv("HOME", "/home/web_user", 1);
+
+  return CPlatformPosix::InitStageOne();
+}

--- a/xbmc/platform/wasm/PlatformWasm.cpp
+++ b/xbmc/platform/wasm/PlatformWasm.cpp
@@ -8,6 +8,9 @@
 
 #include "PlatformWasm.h"
 
+#include "cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecWebCodecs.h"
+#include "cores/VideoPlayer/Process/wasm/ProcessInfoWasm.h"
+
 #include <cstdlib>
 
 CPlatform* CPlatform::CreateInstance()
@@ -20,5 +23,11 @@ bool CPlatformWasm::InitStageOne()
   if (!std::getenv("HOME"))
     setenv("HOME", "/home/web_user", 1);
 
-  return CPlatformPosix::InitStageOne();
+  if (!CPlatformPosix::InitStageOne())
+    return false;
+
+  CProcessInfoWasm::Register();
+  CDVDVideoCodecWebCodecs::Register();
+
+  return true;
 }

--- a/xbmc/platform/wasm/PlatformWasm.h
+++ b/xbmc/platform/wasm/PlatformWasm.h
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "platform/posix/PlatformPosix.h"
+
+class CPlatformWasm : public CPlatformPosix
+{
+public:
+  bool InitStageOne() override;
+};

--- a/xbmc/platform/wasm/main.cpp
+++ b/xbmc/platform/wasm/main.cpp
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "application/AppEnvironment.h"
+#include "application/AppParamParser.h"
+#include "application/AppParams.h"
+#include "platform/xbmc.h"
+
+#include <locale.h>
+#include <stdlib.h>
+
+int main(int argc, char* argv[])
+{
+  setlocale(LC_NUMERIC, "C");
+
+  // Emscripten VFS: data is preloaded under /kodi via --preload-file
+  setenv("KODI_HOME", "/kodi", 0);
+
+  CAppParamParser appParamParser;
+  appParamParser.Parse(argv, argc);
+  appParamParser.GetAppParams()->SetLogTarget("console");
+
+  CAppEnvironment::SetUp(appParamParser.GetAppParams());
+  const int status = XBMC_Run(true);
+  // Only reached when startup failed: emscripten_set_main_loop(..., 1) never returns.
+  CAppEnvironment::TearDown();
+  return status;
+}

--- a/xbmc/platform/wasm/network/CMakeLists.txt
+++ b/xbmc/platform/wasm/network/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES NetworkWasm.cpp)
+
+set(HEADERS NetworkWasm.h)
+
+core_add_library(platform_wasm_network)

--- a/xbmc/platform/wasm/network/NetworkWasm.cpp
+++ b/xbmc/platform/wasm/network/NetworkWasm.cpp
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "NetworkWasm.h"
+
+#include <cstring>
+
+#include <emscripten.h>
+
+bool CNetworkInterfaceWasm::IsConnected() const
+{
+  return EM_ASM_INT({
+    return (typeof navigator !== "undefined" && typeof navigator.onLine === "boolean")
+             ? (navigator.onLine ? 1 : 0)
+             : 1;
+  }) != 0;
+}
+
+void CNetworkInterfaceWasm::GetMacAddressRaw(char rawMac[6]) const
+{
+  std::memset(rawMac, 0, 6);
+}
+
+CNetworkWasm::CNetworkWasm()
+{
+  m_interfaces.push_back(&m_iface);
+}
+
+CNetworkWasm::~CNetworkWasm() = default;
+
+std::unique_ptr<CNetworkBase> CNetworkBase::GetNetwork()
+{
+  return std::make_unique<CNetworkWasm>();
+}
+
+std::vector<CNetworkInterface*>& CNetworkWasm::GetInterfaceList()
+{
+  return m_interfaces;
+}
+
+bool CNetworkWasm::PingHost(unsigned long /*host*/, unsigned int /*timeout_ms*/)
+{
+  return false;
+}
+
+std::vector<std::string> CNetworkWasm::GetNameServers()
+{
+  return {};
+}

--- a/xbmc/platform/wasm/network/NetworkWasm.h
+++ b/xbmc/platform/wasm/network/NetworkWasm.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "network/Network.h"
+
+#include <string>
+#include <vector>
+
+class CNetworkInterfaceWasm : public CNetworkInterface
+{
+public:
+  CNetworkInterfaceWasm() = default;
+  ~CNetworkInterfaceWasm() override = default;
+
+  bool IsEnabled() const override { return true; }
+  bool IsConnected() const override;
+
+  std::string GetMacAddress() const override { return "00:00:00:00:00:00"; }
+  void GetMacAddressRaw(char rawMac[6]) const override;
+
+  bool GetHostMacAddress(unsigned long host, std::string& mac) const override { return false; }
+
+  // The browser doesn't expose the real interface addresses; loopback at least
+  // gives CNetworkBase::HasInterfaceForIP() a subnet to match against.
+  std::string GetCurrentIPAddress() const override { return "127.0.0.1"; }
+  std::string GetCurrentNetmask() const override { return "255.0.0.0"; }
+  std::string GetCurrentDefaultGateway() const override { return "127.0.0.1"; }
+};
+
+class CNetworkWasm : public CNetworkBase
+{
+public:
+  CNetworkWasm();
+  ~CNetworkWasm() override;
+
+  std::vector<CNetworkInterface*>& GetInterfaceList() override;
+  bool PingHost(unsigned long host, unsigned int timeout_ms = 2000) override;
+  std::vector<std::string> GetNameServers() override;
+
+private:
+  CNetworkInterfaceWasm m_iface;
+  std::vector<CNetworkInterface*> m_interfaces;
+};

--- a/xbmc/platform/wasm/storage/CMakeLists.txt
+++ b/xbmc/platform/wasm/storage/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES WasmStorageProvider.cpp)
+
+set(HEADERS WasmStorageProvider.h)
+
+core_add_library(platform_wasm_storage)

--- a/xbmc/platform/wasm/storage/WasmStorageProvider.cpp
+++ b/xbmc/platform/wasm/storage/WasmStorageProvider.cpp
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "WasmStorageProvider.h"
+
+std::unique_ptr<IStorageProvider> IStorageProvider::CreateInstance()
+{
+  return std::make_unique<CWasmStorageProvider>();
+}
+
+void CWasmStorageProvider::GetLocalDrives(std::vector<CMediaSource>& localDrives)
+{
+  CMediaSource share;
+  share.strPath = "/";
+  share.strName = "Root";
+  share.m_iDriveType = SourceType::LOCAL;
+  localDrives.push_back(share);
+}
+
+std::vector<std::string> CWasmStorageProvider::GetDiskUsage()
+{
+  return {};
+}

--- a/xbmc/platform/wasm/storage/WasmStorageProvider.h
+++ b/xbmc/platform/wasm/storage/WasmStorageProvider.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "storage/IStorageProvider.h"
+
+#include <string>
+#include <vector>
+
+class CWasmStorageProvider : public IStorageProvider
+{
+public:
+  CWasmStorageProvider() = default;
+  ~CWasmStorageProvider() override = default;
+
+  void Initialize() override {}
+  void Stop() override {}
+
+  void GetLocalDrives(std::vector<CMediaSource>& localDrives) override;
+  void GetRemovableDrives(std::vector<CMediaSource>& removableDrives) override {}
+
+  bool Eject(const std::string& mountpath) override { return false; }
+
+  std::vector<std::string> GetDiskUsage() override;
+
+  bool PumpDriveChangeEvents(IStorageEventsCallback* callback) override { return false; }
+};


### PR DESCRIPTION
> Stacked on #28226 (wasm platform skeleton) and #29168 (`DemuxPacket::m_keyFrame`, sysmem pool reallocation), whose two commits are carried here until it merges. Only the last commit is new.

## Description
Adds hardware video decoding for the WebAssembly target through WebCodecs.

- `CDVDVideoCodecWebCodecs` registers as a hardware codec for H.264, VP8 and VP9 and drives a `VideoDecoder` on the browser main thread through an Emscripten JS library (`webcodecs_bridge.js`, every entry `__proxy:'sync'`). Frames come back as sysmem YUV420P/NV12 pictures for `CLinuxRendererGLES`, which is also built for the target here.
- The codec never polls through the proxy. The bridge mirrors decoder state — queued frames, in-flight work, backpressure, failure, the next frame's size and format — into a `WebCodecsSharedState` struct in wasm memory with `Atomics`, and bumps a signal word the VideoPlayer thread `futex`-waits on, so a main-thread round trip happens only when a frame exists.
- Frames stay open in the bridge until requested; `copyTo()` then writes straight into the `CVideoBuffer`'s memory (the heap is a `SharedArrayBuffer` under pthreads), with a scratch-buffer fallback for engines whose `copyTo()` still rejects shared views. Open frames count towards the busy threshold, so the decoder's own output pool provides backpressure.
- Keyframes are classified from the bitstream (IDR NAL, VP8/VP9 frame header); the demuxer flag is only trusted for codecs that are not parsed. `DVD_CODEC_CTRL_DRAIN` calls `flush()`, matching FFmpeg's null-packet drain and MediaCodec's EOS, and the codec skips deltas until the key chunk WebCodecs then requires.
- `CProcessInfoWasm` provides the platform process info. Registration is in `CPlatformWasm::InitStageOne`; unlike MediaCodec, WebCodecs has no dependency on the window system.

## Motivation and context
Software decoding in wasm is CPU-bound and the target hardware (TVs) gives the browser one or two cores; WebCodecs is the only route to the platform's hardware decoder. The shared-state protocol exists because a synchronous proxy call per poll made the VideoPlayer thread's re-queue loop cost two main-thread round trips per millisecond while the decoder was saturated.

## How has this been tested?
Downstream WebAssembly build, Chrome on macOS and a Samsung Tizen 9.0 TV: H.264 playback with A/V sync, seek, stream change and EOF (the flush-on-drain change fixed lost tail frames and still frames). Translation units compile for wasm and the JS library parses; the renderer CMake additions only add the wasm case to existing platform lists.

## What is the effect on users?
None on existing platforms. Hardware video decoding for the WebAssembly target.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
