### PR TITLE
RetroPlayer: don't read the client's frame after unmapping it

### DIFF
--- a/xbmc/cores/RetroPlayer/buffers/BaseRenderBufferPool.cpp
+++ b/xbmc/cores/RetroPlayer/buffers/BaseRenderBufferPool.cpp
@@ -117,10 +117,18 @@ void CBaseRenderBufferPool::Return(IRenderBuffer* buffer)
 {
   std::unique_lock lock(m_bufferMutex);
 
+  std::unique_ptr<IRenderBuffer> bufferPtr(buffer);
+
+  // A buffer handed back after the pool was flushed belongs to the
+  // configuration that was thrown away. GetBuffer() matches on dimensions
+  // alone, so keeping it would let a stream of a different format be given an
+  // allocation made for the old one.
+  if (!m_bConfigured)
+    return;
+
   buffer->SetLoaded(false);
   buffer->SetRendered(false);
 
-  std::unique_ptr<IRenderBuffer> bufferPtr(buffer);
   m_free.emplace_back(std::move(bufferPtr));
 }
 

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -212,23 +212,26 @@ void CRPRenderManager::AddFrame(const uint8_t* data,
   if (data == nullptr || size == 0 || width == 0 || height == 0 || displayAspectRatio < 0.0f)
     return;
 
+  const unsigned int flushGeneration = m_flushGeneration;
+
   // Get render buffers to copy the frame into
   std::vector<IRenderBuffer*> renderBuffers;
 
-  // Check and consume pending buffers. The client has finished writing, so
-  // end any CPU access it opened before handing a submitted buffer to the GPU.
+  IRenderBuffer* submittedBuffer = nullptr;
+
+  // Check and consume pending buffers. The client has finished writing, so end
+  // any CPU access it opened, except on the buffer it submitted: data points
+  // into that mapping and the frame is still read out of it below.
   for (const PendingBuffer& pending : m_pendingBuffers)
   {
-    const bool bSubmitted = (pending.memory == data);
-
-    if (pending.memory != nullptr)
-      pending.buffer->ReleaseMemory();
-
-    if (bSubmitted)
+    if (pending.memory == data)
     {
+      submittedBuffer = pending.buffer;
       pending.buffer->Acquire();
       renderBuffers.emplace_back(pending.buffer);
     }
+    else if (pending.memory != nullptr)
+      pending.buffer->ReleaseMemory();
 
     pending.buffer->Release();
   }
@@ -256,18 +259,6 @@ void CRPRenderManager::AddFrame(const uint8_t* data,
 
   {
     std::unique_lock lock(m_bufferMutex);
-
-    // Set render buffers
-    for (auto renderBuffer : m_renderBuffers)
-      renderBuffer->Release();
-    m_renderBuffers = std::move(renderBuffers);
-
-    // Apply video properties to render buffers
-    for (auto renderBuffer : m_renderBuffers)
-    {
-      renderBuffer->SetDisplayAspectRatio(displayAspectRatio);
-      renderBuffer->SetRotation(orientationDegCCW);
-    }
 
     // Cache frame if it arrived after being paused
     if (m_speed == 0.0)
@@ -297,6 +288,35 @@ void CRPRenderManager::AddFrame(const uint8_t* data,
         m_cachedDisplayAspectRatio = displayAspectRatio;
         m_cachedRotationCCW = orientationDegCCW;
       }
+    }
+  }
+
+  // Only now may the buffer be seen by the render thread: the coherency
+  // workaround for DMAHeap and UDMABuf uploads from this same mapping and
+  // unmaps it afterwards, which would pull it from under the copy above.
+  if (submittedBuffer != nullptr)
+    submittedBuffer->ReleaseMemory();
+
+  {
+    std::unique_lock lock(m_bufferMutex);
+
+    if (m_flushGeneration != flushGeneration)
+    {
+      for (auto renderBuffer : renderBuffers)
+        renderBuffer->Release();
+      return;
+    }
+
+    // Set render buffers
+    for (auto renderBuffer : m_renderBuffers)
+      renderBuffer->Release();
+    m_renderBuffers = std::move(renderBuffers);
+
+    // Apply video properties to render buffers
+    for (auto renderBuffer : m_renderBuffers)
+    {
+      renderBuffer->SetDisplayAspectRatio(displayAspectRatio);
+      renderBuffer->SetRotation(orientationDegCCW);
     }
   }
 }
@@ -391,6 +411,8 @@ void CRPRenderManager::CheckFlush()
       m_cachedHeight = 0;
 
       m_bHasCachedFrame = false;
+
+      ++m_flushGeneration;
     }
 
     {

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -285,6 +285,15 @@ private:
   std::set<std::string> m_failedShaderPresets;
   std::atomic<bool> m_bFlush = {false};
 
+  /*!
+   * \brief Bumped by each completed flush
+   *
+   * A frame already in flight when a flush completes belongs to the stream
+   * that was discarded, and m_bFlush cannot say so: it is cleared again by
+   * the time the frame is ready to be published.
+   */
+  std::atomic<unsigned int> m_flushGeneration = {0};
+
   // Playback parameters
   std::atomic<double> m_speed = {1.0};
 


### PR DESCRIPTION
## Description

`CRPRenderManager::AddFrame()` ends CPU access on every pending buffer at the top
of the function, including the one the client submitted this frame:

```cpp
const bool bSubmitted = (pending.memory == data);

if (pending.memory != nullptr)
  pending.buffer->ReleaseMemory();
```

On the zero-copy path `pending.memory == data`, so that `ReleaseMemory()` is
applied to the very mapping `data` points into. `data` is then still read fifty
lines further down, in the branch that caches a frame arriving while paused:

```cpp
if (m_speed == 0.0)
{
  ...
  std::memcpy(cachedFrame.data(), data, size);
}
```

`CRenderBufferDMA::ReleaseMemory()` munmaps, so that `memcpy` reads an unmapped
page and the process dies with SIGSEGV on the game loop thread.

This fixes it by keeping CPU access open on the submitted buffer until the frame
has been read out of it, and publishing that buffer only once the access is
closed.

Both halves matter. `CRenderBufferDMA::UploadTexture()` runs a coherency
workaround for DMAHeap and UDMABuf which uploads from that same mapping and
calls `ReleaseMemory()` when it is done; the mapping is not reference counted,
so a buffer published while still mapped can be unmapped from under the copy by
the render thread — the same crash by a different route.

Publishing last leaves the frame in flight across a `Flush()`. `m_bFlush` cannot
describe that, because `CheckFlush()` clears it again before the frame is ready
to publish. So completed flushes are counted — in the same critical section as
the clear they belong to, or the comparison just races it — and a frame whose
stream has already been discarded is dropped rather than published. That also
keeps the pause decision where it was, at the end of the function, so a
`SetSpeed(0)` landing mid-frame still caches the last frame the loop produces.

Dropping the frame hands its buffer back to a pool that has since been flushed.
`CBaseRenderBufferPool::Return()` accepted those unconditionally, and
`GetBuffer()` matches on dimensions alone, so a buffer allocated for the
discarded configuration could later be handed to a stream of a different format.
A flushed pool now lets them go instead.

## Motivation and context

The crash needs a pause to land while a frame is in flight. That is exactly what
opening the in-game OSD does — `CGUIPlaybackControl::FrameMove()` moves to
`MENU_PAUSED` and pushes speed 0.0 into the render manager — so it presents as
"Kodi dies occasionally when I bring up the game OSD".

Backtrace:

```
#0  memcpy                                              libc
#1  KODI::RETRO::CRPRenderManager::AddFrame(...)
#2  KODI::GAME::CGameClientStreamVideo::AddData(...)
#5  retro_run()                                         fceumm
```

The last line logged before the dump is `Window Init (GameOSD.xml)`.

Scope: only `CRenderBufferDMA` overrides `ReleaseMemory()`;
`IRenderBuffer::ReleaseMemory()` is a no-op. So the crash is confined to
platforms using DMA render buffers, with a client that takes a buffer from
`GetVideoBuffer()` and hands the same pointer back — a libretro core using
`GET_CURRENT_SOFTWARE_FRAMEBUFFER`, which many do.

Introduced in #28983.

## How has this been tested?

The crash was diagnosed from a core dump taken on an embedded EGL/GBM target
using DMA render buffers with `game.libretro.fceumm`, with the backtrace and
the `Window Init (GameOSD.xml)` log line above. The faulting `memcpy` is the
paused-frame cache, and `pending.memory == data` on that path, so the read is
of the mapping `ReleaseMemory()` had already torn down.

The change compiles clean against master with the project's warning flags and has been retested with sucess

## What is the effect on users?

Fixes a crash when pausing a game — most commonly by opening the in-game OSD —
on platforms that use DMA render buffers.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed




