### PR TITLE
fixed: account for jobs in their completion phase and keep a cancelled job findable

### DIFF
--- a/xbmc/jobs/JobManager.cpp
+++ b/xbmc/jobs/JobManager.cpp
@@ -103,33 +103,55 @@ void CJobManager::Restart()
 
 void CJobManager::CancelJobs()
 {
-  std::unique_lock lock(m_section);
-  m_running = false;
-
-  // clear any pending jobs
-  for (unsigned int priority = CJob::PRIORITY_LOW_PAUSABLE; priority <= CJob::PRIORITY_DEDICATED;
-       ++priority)
   {
-    std::ranges::for_each(m_jobQueue[priority],
+    std::unique_lock lock(m_section);
+    m_running = false;
+
+    // queued jobs are aborted below, outside the lock; CancelJob still finds them in m_aborting
+    for (auto& queue : m_jobQueue)
+    {
+      for (auto& wi : queue)
+        m_aborting.emplace_back(std::move(wi));
+      queue.clear();
+    }
+
+    // cancel any callbacks on jobs still processing
+    std::ranges::for_each(m_processing,
                           [](CWorkItem& wi)
                           {
                             for (auto* callback : wi.GetCallbacks())
                               callback->OnJobAbort(wi.GetId(), wi.GetJob());
-                            wi.FreeJob();
+                            wi.Cancel();
                           });
-    m_jobQueue[priority].clear();
   }
 
-  // cancel any callbacks on jobs still processing
-  std::ranges::for_each(m_processing,
-                        [](CWorkItem& wi)
-                        {
-                          for (auto* callback : wi.GetCallbacks())
-                            callback->OnJobAbort(wi.GetId(), wi.GetJob());
-                          wi.Cancel();
-                        });
+  while (true)
+  {
+    std::optional<CWorkItem> item;
+    {
+      std::unique_lock lock(m_section);
+      if (m_aborting.empty())
+        break;
+
+      item.emplace(std::move(m_aborting.front()));
+      m_aborting.pop_front();
+      m_abortingId = item->GetId();
+      m_abortingThread = std::this_thread::get_id();
+    }
+
+    for (auto* callback : item->GetCallbacks())
+      callback->OnJobAbort(item->GetId(), item->GetJob());
+    item->FreeJob();
+
+    {
+      std::unique_lock lock(m_section);
+      m_abortingId.reset();
+    }
+    m_abortDone.notify_all();
+  }
 
   // tell our workers to finish
+  std::unique_lock lock(m_section);
   while (!m_workers.empty())
   {
     lock.unlock();
@@ -203,6 +225,30 @@ void CJobManager::CancelJob(unsigned int jobID)
       return;
     }
   }
+  // or CancelJobs holds it for its abort callback
+  const auto aborting =
+      std::ranges::find_if(m_aborting, [jobID](const auto& wi) { return wi.GetId() == jobID; });
+  if (aborting != m_aborting.cend())
+  {
+    aborting->Cancel();
+    return;
+  }
+
+  // or its abort callback is running on another thread, which the owner must outlive
+  if (m_abortingId == jobID && m_abortingThread != std::this_thread::get_id())
+  {
+    m_abortDone.wait(lock, [this, jobID] { return m_abortingId != jobID; });
+    return;
+  }
+
+  // or its completion callback is, which the owner must outlive just the same
+  const auto completing = m_completingJobs.find(jobID);
+  if (completing != m_completingJobs.cend() && completing->second != std::this_thread::get_id())
+  {
+    m_completeDone.wait(lock, [this, jobID] { return !m_completingJobs.contains(jobID); });
+    return;
+  }
+
   // or if we're processing it
   const auto it =
       std::ranges::find_if(m_processing, [jobID](const auto& wi) { return wi.GetId() == jobID; });
@@ -215,15 +261,18 @@ void CJobManager::StartWorkers(CJob::PRIORITY priority)
   std::unique_lock lock(m_section);
 
   // check how many free threads we have
-  if (m_processing.size() >= GetMaxWorkers(priority))
+  if (GetBusyCount() >= GetMaxWorkers(priority))
     return;
 
   // do we have any sleeping threads?
-  if (m_processing.size() < m_workers.size())
+  if (m_idleWorkers > 0)
   {
     m_jobEvent.Set();
     return;
   }
+
+  if (m_workers.size() >= GetMaxWorkers(priority))
+    return;
 
   // everyone is busy - we need more workers
   m_workers.emplace_back(new CJobWorker(*this));
@@ -238,8 +287,7 @@ CJob* CJobManager::PopJob()
     if (priority == CJob::PRIORITY_LOW_PAUSABLE && m_pauseJobs)
       continue;
 
-    if (!m_jobQueue[priority].empty() &&
-        m_processing.size() < GetMaxWorkers(CJob::PRIORITY(priority)))
+    if (!m_jobQueue[priority].empty() && GetBusyCount() < GetMaxWorkers(CJob::PRIORITY(priority)))
     {
       // pop the job off the queue
       const CWorkItem job{m_jobQueue[priority].front()};
@@ -300,9 +348,11 @@ CJob* CJobManager::GetNextJob()
     if (job)
       return job;
     // no jobs are left - sleep for 30 seconds to allow new jobs to come in
+    ++m_idleWorkers;
     lock.unlock();
     bool newJob = m_jobEvent.Wait(30000ms);
     lock.lock();
+    --m_idleWorkers;
     if (!newJob)
       break;
   }
@@ -343,6 +393,7 @@ void CJobManager::OnJobComplete(bool success, CJob* job)
       // when another thread modifies m_processing during callback execution
       item.emplace(std::move(*i));
       m_processing.erase(i);
+      m_completingJobs.emplace(item->GetId(), std::this_thread::get_id());
     }
     return item;
   }();
@@ -384,7 +435,14 @@ void CJobManager::OnJobComplete(bool success, CJob* job)
       }
     }
 
+    const unsigned int id = item->GetId();
     item->FreeJob();
+
+    {
+      std::unique_lock lock(m_section);
+      m_completingJobs.erase(id);
+    }
+    m_completeDone.notify_all();
   }
 }
 

--- a/xbmc/jobs/JobManager.h
+++ b/xbmc/jobs/JobManager.h
@@ -16,8 +16,11 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <condition_variable>
+#include <optional>
 #include <queue>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -226,6 +229,8 @@ private:
    */
   CJob* PopJob();
 
+  size_t GetBusyCount() const { return m_processing.size() + m_completingJobs.size(); }
+
   void StartWorkers(CJob::PRIORITY priority);
   void RemoveWorker(const CJobWorker* worker);
   static unsigned int GetMaxWorkers(CJob::PRIORITY priority);
@@ -240,6 +245,20 @@ private:
   bool m_pauseJobs{false};
   Processing m_processing;
   Workers m_workers;
+  size_t m_idleWorkers{0};
+
+  // Jobs CancelJobs has taken off the queues whose abort callbacks have not run yet, and the
+  // one whose callback is running now.
+  JobQueue m_aborting;
+  std::optional<unsigned int> m_abortingId;
+  std::thread::id m_abortingThread;
+  std::condition_variable_any m_abortDone;
+
+  // Jobs out of m_processing whose completion callbacks are running, against the thread
+  // running each. They are neither processing nor free, and an owner cancelling one has to
+  // outlive its callback.
+  std::unordered_map<unsigned int, std::thread::id> m_completingJobs;
+  std::condition_variable_any m_completeDone;
 
   mutable CCriticalSection m_section;
   CEvent m_jobEvent;

--- a/xbmc/jobs/JobQueue.cpp
+++ b/xbmc/jobs/JobQueue.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <mutex>
+#include <optional>
 
 void CJobQueue::CJobPointer::CancelJob()
 {
@@ -52,20 +53,30 @@ void CJobQueue::OnJobAbort(unsigned int jobID, CJob* job)
 
 void CJobQueue::CancelJob(const CJob* job)
 {
-  std::unique_lock lock(m_section);
-  const auto i = std::ranges::find_if(m_processing, JobFinder(job));
-  if (i != m_processing.cend())
+  // CJobManager::CancelJob waits for an abort callback that is still running, and that
+  // callback is OnJobNotify, which takes m_section. Cancel outside the lock.
+  std::optional<CJobPointer> cancelling;
   {
-    i->CancelJob();
-    m_processing.erase(i);
-    return;
+    std::unique_lock lock(m_section);
+    const auto i = std::ranges::find_if(m_processing, JobFinder(job));
+    if (i != m_processing.cend())
+    {
+      cancelling.emplace(*i);
+      m_processing.erase(i);
+    }
+    else
+    {
+      const auto j = std::ranges::find_if(m_jobQueue, JobFinder(job));
+      if (j != m_jobQueue.cend())
+      {
+        j->FreeJob();
+        m_jobQueue.erase(j);
+      }
+    }
   }
-  const auto j = std::ranges::find_if(m_jobQueue, JobFinder(job));
-  if (j != m_jobQueue.cend())
-  {
-    j->FreeJob();
-    m_jobQueue.erase(j);
-  }
+
+  if (cancelling)
+    cancelling->CancelJob();
 }
 
 bool CJobQueue::AddJob(CJob* job)
@@ -123,11 +134,26 @@ void CJobQueue::QueueNextJob()
 
 void CJobQueue::CancelJobs()
 {
-  std::unique_lock lock(m_section);
-  std::ranges::for_each(m_processing, [](CJobPointer& jp) { jp.CancelJob(); });
-  std::ranges::for_each(m_jobQueue, [](CJobPointer& jp) { jp.FreeJob(); });
-  m_jobQueue.clear();
-  m_processing.clear();
+  // CJobManager::CancelJob waits for an abort callback that is still running, and that
+  // callback is OnJobNotify, which takes m_section. Cancel outside the lock, and drain
+  // rather than clear: a callback running in that window queues the next job through
+  // OnJobNotify, and leaving it behind would outlive the queue it calls back into.
+  while (true)
+  {
+    Queue queued;
+    Processing processing;
+    {
+      std::unique_lock lock(m_section);
+      if (m_jobQueue.empty() && m_processing.empty())
+        return;
+
+      queued.swap(m_jobQueue);
+      processing.swap(m_processing);
+    }
+
+    std::ranges::for_each(processing, [](CJobPointer& jp) { jp.CancelJob(); });
+    std::ranges::for_each(queued, [](CJobPointer& jp) { jp.FreeJob(); });
+  }
 }
 
 bool CJobQueue::IsProcessing() const

--- a/xbmc/utils/test/TestJobManager.cpp
+++ b/xbmc/utils/test/TestJobManager.cpp
@@ -7,13 +7,19 @@
  */
 
 #include "ServiceBroker.h"
+#include "jobs/IJobCallback.h"
 #include "jobs/Job.h"
 #include "jobs/JobManager.h"
+#include "jobs/JobQueue.h"
 #include "test/MtTestUtils.h"
 #include "utils/XTimeUtils.h"
 
 #include <atomic>
+#include <chrono>
 #include <mutex>
+#include <thread>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -210,4 +216,237 @@ TEST_F(TestJobManager, IsProcessing)
   EXPECT_EQ(0, CServiceBroker::GetJobManager()->IsProcessing(""));
 
   job->FinishAndStopBlocking();
+}
+
+namespace
+{
+class BlockingCallback : public IJobCallback
+{
+public:
+  ~BlockingCallback() override { Release(); }
+
+  void OnJobComplete(unsigned int jobID, bool success, CJob* job) override { Block(); }
+
+  void OnJobAbort(unsigned int jobID, CJob* job) override { Block(); }
+
+  bool HasEntered() const { return m_entered; }
+
+  void Release()
+  {
+    m_blocked = false;
+    while (m_entered && !m_exited)
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+
+private:
+  void Block()
+  {
+    m_entered = true;
+    while (m_blocked)
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    m_exited = true;
+  }
+
+  std::atomic<bool> m_blocked{true};
+  std::atomic<bool> m_entered{false};
+  std::atomic<bool> m_exited{false};
+};
+
+unsigned int AddDumbJob(Flags& flags, IJobCallback* callback, CJob::PRIORITY priority)
+{
+  return CServiceBroker::GetJobManager()->AddJob(new ReallyDumbJob(&flags), callback, priority);
+}
+
+/*!
+ rief Owns the threads a test starts, releasing the callback and joining them however the
+        test exits.
+
+ A fatal assertion returns from the test body. A thread still joinable at that point calls
+ std::terminate, taking the whole test binary with it, and one blocked in the callback only
+ finishes once the callback is released.
+ */
+/*!
+ rief A queue whose abort callback can be held in flight, before it reaches the base class
+        and takes the queue's lock.
+ */
+class BlockingJobQueue : public CJobQueue
+{
+public:
+  BlockingJobQueue() : CJobQueue(false, 1, CJob::PRIORITY_LOW_PAUSABLE) {}
+  ~BlockingJobQueue() override { Unblock(); }
+
+  void OnJobAbort(unsigned int jobID, CJob* job) override
+  {
+    m_entered = true;
+    while (m_blocked)
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    CJobQueue::OnJobAbort(jobID, job);
+  }
+
+  bool HasEntered() const { return m_entered; }
+  void Unblock() { m_blocked = false; }
+
+private:
+  std::atomic<bool> m_blocked{true};
+  std::atomic<bool> m_entered{false};
+};
+
+class ScopedThreads
+{
+public:
+  explicit ScopedThreads(BlockingCallback& callback) : m_callback(callback) {}
+
+  ~ScopedThreads()
+  {
+    m_callback.Release();
+    for (auto& thread : m_threads)
+      thread.join();
+  }
+
+  template<typename F>
+  void Start(F&& function)
+  {
+    m_threads.emplace_back(std::forward<F>(function));
+  }
+
+private:
+  BlockingCallback& m_callback;
+  std::vector<std::thread> m_threads;
+};
+} // namespace
+
+TEST_F(TestJobManager, BlockedCallbackDoesNotStallOtherJobs)
+{
+  BlockingCallback callback;
+  Flags blockedFlags;
+  AddDumbJob(blockedFlags, &callback, CJob::PRIORITY_NORMAL);
+  ASSERT_TRUE(poll([&callback]() { return callback.HasEntered(); }));
+
+  Flags flags;
+  AddDumbJob(flags, nullptr, CJob::PRIORITY_NORMAL);
+  EXPECT_TRUE(poll([&flags]() { return flags.finished.load(); }));
+
+  callback.Release();
+}
+
+TEST_F(TestJobManager, BlockedCallbackDoesNotStallDedicatedJobs)
+{
+  BlockingCallback callback;
+  Flags blockedFlags;
+  AddDumbJob(blockedFlags, &callback, CJob::PRIORITY_NORMAL);
+  ASSERT_TRUE(poll([&callback]() { return callback.HasEntered(); }));
+
+  Flags flags;
+  AddDumbJob(flags, nullptr, CJob::PRIORITY_DEDICATED);
+  EXPECT_TRUE(poll([&flags]() { return flags.finished.load(); }));
+
+  callback.Release();
+}
+
+TEST_F(TestJobManager, CallbacksCountTowardsTheConcurrencyLimit)
+{
+  BlockingCallback firstCallback;
+  BlockingCallback secondCallback;
+  Flags firstFlags;
+  Flags secondFlags;
+
+  AddDumbJob(firstFlags, &firstCallback, CJob::PRIORITY_LOW_PAUSABLE);
+  ASSERT_TRUE(poll([&firstCallback]() { return firstCallback.HasEntered(); }));
+  AddDumbJob(secondFlags, &secondCallback, CJob::PRIORITY_LOW_PAUSABLE);
+  ASSERT_TRUE(poll([&secondCallback]() { return secondCallback.HasEntered(); }));
+
+  Flags thirdFlags;
+  AddDumbJob(thirdFlags, nullptr, CJob::PRIORITY_LOW_PAUSABLE);
+  EXPECT_FALSE(poll(1000, [&thirdFlags]() { return thirdFlags.finished.load(); }));
+
+  firstCallback.Release();
+  secondCallback.Release();
+
+  EXPECT_TRUE(poll([&thirdFlags]() { return thirdFlags.finished.load(); }));
+}
+
+TEST_F(TestJobManager, CancelJobsDoesNotRunCallbacksUnderTheLock)
+{
+  CServiceBroker::GetJobManager()->PauseJobs();
+
+  BlockingCallback callback;
+  Flags flags;
+  AddDumbJob(flags, &callback, CJob::PRIORITY_LOW_PAUSABLE);
+
+  ScopedThreads threads(callback);
+  threads.Start([]() { CServiceBroker::GetJobManager()->CancelJobs(); });
+  ASSERT_TRUE(poll([&callback]() { return callback.HasEntered(); }));
+
+  std::atomic<bool> queried{false};
+  threads.Start(
+      [&queried]()
+      {
+        CServiceBroker::GetJobManager()->IsProcessing(CJob::PRIORITY_NORMAL);
+        queried = true;
+      });
+
+  EXPECT_TRUE(poll(2000, [&queried]() { return queried.load(); }));
+}
+
+TEST_F(TestJobManager, CancelJobWaitsForAnAbortCallbackInFlight)
+{
+  CServiceBroker::GetJobManager()->PauseJobs();
+
+  BlockingCallback callback;
+  Flags flags;
+  const unsigned int id = AddDumbJob(flags, &callback, CJob::PRIORITY_LOW_PAUSABLE);
+
+  ScopedThreads threads(callback);
+  threads.Start([]() { CServiceBroker::GetJobManager()->CancelJobs(); });
+  ASSERT_TRUE(poll([&callback]() { return callback.HasEntered(); }));
+
+  std::atomic<bool> returned{false};
+  threads.Start(
+      [id, &returned]()
+      {
+        CServiceBroker::GetJobManager()->CancelJob(id);
+        returned = true;
+      });
+
+  // The callback is still blocked, so the owner must not have been told the job is gone.
+  EXPECT_FALSE(poll(500, [&returned]() { return returned.load(); }));
+
+  callback.Release();
+  EXPECT_TRUE(poll([&returned]() { return returned.load(); }));
+}
+
+/*!
+ The job manager runs an abort callback with its own lock dropped, but that callback is
+ CJobQueue::OnJobNotify, which takes the queue's lock. A queue cancelling its own jobs must
+ therefore not hold that lock while it waits on the manager.
+
+ Disabled because a regression wedges both threads instead of failing, which CI cannot
+ recover from. Run it by hand with
+   kodi-test --gtest_also_run_disabled_tests              --gtest_filter=TestJobManager.DISABLED_CancellingAQueueWaitsWithoutItsLock
+ */
+TEST_F(TestJobManager, DISABLED_CancellingAQueueWaitsWithoutItsLock)
+{
+  CServiceBroker::GetJobManager()->PauseJobs();
+
+  BlockingJobQueue queue;
+  Flags flags;
+  queue.AddJob(new ReallyDumbJob(&flags));
+
+  std::thread manager([]() { CServiceBroker::GetJobManager()->CancelJobs(); });
+  ASSERT_TRUE(poll([&queue]() { return queue.HasEntered(); }));
+
+  std::atomic<bool> returned{false};
+  std::thread canceller(
+      [&queue, &returned]()
+      {
+        queue.CancelJobs();
+        returned = true;
+      });
+
+  queue.Unblock();
+  EXPECT_TRUE(poll([&returned]() { return returned.load(); }));
+
+  canceller.join();
+  manager.join();
 }


### PR DESCRIPTION
**TL;DR:** Bug fix. `CJobManager::CancelJobs()` ran abort callbacks while holding the manager lock and left a cancelling job findable by nobody, so `CancelJob()` could return while the callback was still running against an owner about to be destroyed.

## Description

Three related defects in `CJobManager`:

- `CancelJobs()` invoked every queued job's `OnJobAbort` callback with `m_section` held. A callback that touches the job manager deadlocks.
- Between being taken off the queue and its abort callback returning, a job was in no collection, so `CancelJob(id)` for that job matched nothing and returned immediately — while the callback was still running. A caller that cancels a job in its own destructor could therefore be destroyed underneath its own callback.
- A job that had completed but whose callback had not yet run counted as neither processing nor free, so `GetMaxWorkers()` saw spare capacity that did not exist and started work with no worker to run it.

- A job running its *completion* callback was in no collection either, so the same window stayed open on that path.
- `CJobQueue` held its own `m_section` across every call into the manager, while its `OnJobNotify` — reached from `OnJobAbort` — takes that same lock. Once `CancelJob()` can wait, that is a deadlock.

Queued jobs are now moved to an `m_aborting` list before the lock is dropped, `CancelJob()` finds them there and waits on a condition variable for the in-flight one, and `GetBusyCount()` counts jobs in their completion phase. `CancelJob()` waits for a completion callback the same way it waits for an abort one, so the count of jobs in that phase became a map of them against the thread running each. `CJobQueue::CancelJob()` and `CancelJobs()` take what they are cancelling out of their collections under the lock and cancel outside it, draining rather than clearing once so a job queued by a callback in that window is not left behind.

## Motivation and context

Found while making the JSON-RPC server cancel outstanding work at shutdown. The window is small but the consequence is a use-after-free, and the deadlock is reachable from any callback that talks back to the manager.

## How has this been tested?

Built on Windows x64 (VS 2022) and ran the full `kodi-test` suite: 4081 tests in 319 suites, all passing. `xbmc/utils/test/TestJobManager.cpp` gains cases covering the abort-callback window and the completion-phase accounting.

The completion-phase wait is not optional: without it, cancelling outside `CJobQueue`'s lock let `TestCaptureService.CallbackRunsOnWorker` destroy its queue while a worker was still entering `OnJobNotify` on it, which showed up as a hang and then as heap corruption at teardown.

`DISABLED_CancellingAQueueWaitsWithoutItsLock` covers the lock-ordering fix. It is disabled because a regression wedges both threads rather than failing, which CI cannot recover from; it was verified both ways by hand — it passes with the fix and hangs without it, and the comment beside it gives the command to run it.

## What is the effect on users?

No visible change. Removes a potential crash and a potential hang during shutdown or any bulk job cancellation.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

