### PR TITLE
fixed: run each JSON-RPC request on its connection's own thread

### DIFF
--- a/xbmc/network/TCPServer.cpp
+++ b/xbmc/network/TCPServer.cpp
@@ -18,9 +18,13 @@
 #include "utils/log.h"
 #include "websocket/WebSocketManager.h"
 
+#include <exception>
+#include <memory>
 #include <mutex>
 #include <stdio.h>
 #include <stdlib.h>
+#include <thread>
+#include <utility>
 
 #include <arpa/inet.h>
 #include <memory.h>
@@ -60,13 +64,15 @@ namespace
 constexpr size_t maxBufferLength = 64 * 1024;
 }
 
-CTCPServer *CTCPServer::ServerInstance = NULL;
+std::shared_ptr<CTCPServer> CTCPServer::ServerInstance;
 
 bool CTCPServer::StartServer(int port, bool nonlocal)
 {
   StopServer(true);
 
-  ServerInstance = new CTCPServer(port, nonlocal);
+  // The constructor is private, so make_shared cannot reach it.
+  ServerInstance = std::shared_ptr<CTCPServer>(new CTCPServer(port, nonlocal));
+  ServerInstance->m_self = ServerInstance;
   if (ServerInstance->Initialize())
   {
     ServerInstance->Create(false);
@@ -83,18 +89,19 @@ void CTCPServer::StopServer(bool bWait)
     ServerInstance->StopThread(bWait);
     if (bWait)
     {
-      delete ServerInstance;
-      ServerInstance = NULL;
+      // Deinitialize has told every worker to stop; one inside a modal dialog may not return
+      ServerInstance->WaitForWorkers(std::chrono::seconds(2));
+      ServerInstance.reset();
     }
   }
 }
 
 bool CTCPServer::IsRunning()
 {
-  if (ServerInstance == NULL)
+  if (!ServerInstance)
     return false;
 
-  return ((CThread*)ServerInstance)->IsRunning();
+  return ServerInstance->CThread::IsRunning();
 }
 
 CTCPServer::CTCPServer(int port, bool nonlocal) : CThread("TCPServer")
@@ -113,6 +120,7 @@ void CTCPServer::Process()
     SOCKET          max_fd = 0;
     fd_set          rfds;
     struct timeval  to     = {1, 0};
+    bool backlogged = false;
     FD_ZERO(&rfds);
 
     {
@@ -129,13 +137,36 @@ void CTCPServer::Process()
           max_fd = it;
       }
 
-      for (unsigned int i = 0; i < m_connections.size(); i++)
+      for (int i = static_cast<int>(m_connections.size()) - 1; i >= 0; i--)
       {
+        if (m_connections[i]->Closing())
+        {
+          CLog::Log(LOGINFO, "JSONRPC Server: Disconnection requested");
+          m_connections[i]->StopWorker();
+          m_connections[i]->Disconnect();
+          m_connections.erase(m_connections.begin() + i);
+          continue;
+        }
+
+        // Reading faster than the worker parses would queue without limit, so a connection
+        // that is far enough ahead is left unread until the worker catches up. Its receive
+        // window closes and the client waits.
+        if (m_connections[i]->Backlogged())
+        {
+          backlogged = true;
+          continue;
+        }
+
         FD_SET(m_connections[i]->m_socket, &rfds);
         if ((intptr_t)m_connections[i]->m_socket > (intptr_t)max_fd)
           max_fd = m_connections[i]->m_socket;
       }
     }
+
+    // A held-back connection is not in the set, so nothing wakes the select when its worker
+    // drains. Look again soon rather than after the idle timeout.
+    if (backlogged)
+      to = {0, 50000};
 
     int res = select((intptr_t)max_fd+1, &rfds, NULL, NULL, &to);
     if (res < 0)
@@ -149,7 +180,7 @@ void CTCPServer::Process()
       // Re-acquire for the I/O and accept passes; both modify m_connections.
       std::unique_lock lock(m_connectionsCritSection);
 
-      for (int i = m_connections.size() - 1; i >= 0; i--)
+      for (int i = static_cast<int>(m_connections.size()) - 1; i >= 0; i--)
       {
         int socket = m_connections[i]->m_socket;
         if (FD_ISSET(socket, &rfds))
@@ -171,17 +202,15 @@ void CTCPServer::Process()
               if (websocket != NULL)
               {
                 // Replace the CTCPClient with a CWebSocketClient
-                CWebSocketClient *websocketClient = new CWebSocketClient(websocket, *(m_connections[i]));
-                delete m_connections[i];
-                m_connections.erase(m_connections.begin() + i);
-                m_connections.insert(m_connections.begin() + i, websocketClient);
+                m_connections[i] =
+                    std::make_shared<CWebSocketClient>(websocket, *(m_connections[i]));
               }
             }
 
             if (response.empty())
-              m_connections[i]->PushBuffer(this, buffer, nread);
-
-            close = m_connections[i]->Closing();
+            {
+              m_connections[i]->Enqueue(m_connections[i], this, buffer, nread);
+            }
           }
           else
             close = true;
@@ -189,8 +218,8 @@ void CTCPServer::Process()
           if (close)
           {
             CLog::Log(LOGINFO, "JSONRPC Server: Disconnection detected");
+            m_connections[i]->StopWorker();
             m_connections[i]->Disconnect();
-            delete m_connections[i];
             m_connections.erase(m_connections.begin() + i);
           }
         }
@@ -201,7 +230,7 @@ void CTCPServer::Process()
         if (FD_ISSET(it, &rfds))
         {
           CLog::Log(LOGDEBUG, "JSONRPC Server: New connection detected");
-          CTCPClient *newconnection = new CTCPClient();
+          auto newconnection = std::make_shared<CTCPClient>();
           newconnection->m_socket =
               accept(it, (sockaddr*)&newconnection->m_cliaddr, &newconnection->m_addrlen);
 
@@ -218,7 +247,7 @@ void CTCPServer::Process()
           else
           {
             CLog::Log(LOGINFO, "JSONRPC Server: New connection added");
-            m_connections.push_back(newconnection);
+            m_connections.push_back(std::move(newconnection));
           }
         }
       }
@@ -248,26 +277,28 @@ void CTCPServer::Announce(ANNOUNCEMENT::AnnouncementFlag flag,
                           const std::string& message,
                           const CVariant& data)
 {
-  // Hold m_connectionsCritSection across the whole iteration so the Process
-  // thread cannot erase a connection out from under us while we Send to it.
-  // Without this lock, a client that disconnects right after receiving its
-  // response (e.g. `nc -q1`) crashes Announce on use-after-free.
-  std::unique_lock lock(m_connectionsCritSection);
+  // Take a snapshot under the lock and send outside it. Each entry is a shared_ptr, so a
+  // connection the Process thread drops mid-iteration stays alive until we are done with it.
+  std::vector<std::shared_ptr<CTCPClient>> connections;
+  {
+    std::unique_lock lock(m_connectionsCritSection);
+    if (m_connections.empty())
+      return;
 
-  if (m_connections.empty())
-    return;
+    connections = m_connections;
+  }
 
   std::string str = IJSONRPCAnnouncer::AnnouncementToJSONRPC(flag, sender, message, data, CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_jsonOutputCompact);
 
-  for (unsigned int i = 0; i < m_connections.size(); i++)
+  for (const auto& connection : connections)
   {
     {
-      std::unique_lock connLock(m_connections[i]->m_critSection);
-      if ((m_connections[i]->GetAnnouncementFlags() & flag) == 0)
+      std::unique_lock connLock(connection->m_critSection);
+      if ((connection->GetAnnouncementFlags() & flag) == 0)
         continue;
     }
 
-    m_connections[i]->Send(str.c_str(), str.size());
+    connection->Send(str.c_str(), str.size());
   }
 }
 
@@ -501,10 +532,10 @@ void CTCPServer::Deinitialize()
 
   std::unique_lock lock(m_connectionsCritSection);
 
-  for (unsigned int i = 0; i < m_connections.size(); i++)
+  for (const auto& connection : m_connections)
   {
-    m_connections[i]->Disconnect();
-    delete m_connections[i];
+    connection->StopWorker();
+    connection->Disconnect();
   }
 
   m_connections.clear();
@@ -556,23 +587,165 @@ int CTCPServer::CTCPClient::GetAnnouncementFlags()
 
 bool CTCPServer::CTCPClient::SetAnnouncementFlags(int flags)
 {
+  std::unique_lock lock(m_critSection);
   m_announcementflags = flags;
   return true;
 }
 
 void CTCPServer::CTCPClient::Send(const char *data, unsigned int size)
 {
+  std::unique_lock lock(m_critSection);
   unsigned int sent = 0;
-  do
+  while (sent < size)
   {
-    std::unique_lock lock(m_critSection);
-    sent += send(m_socket, data + sent, size - sent, 0);
-  } while (sent < size);
+    const auto written = send(m_socket, data + sent, size - sent, 0);
+    if (written <= 0)
+    {
+      // The server thread can close the socket while a send is in progress. send() then
+      // returns -1, which must not reach the unsigned counter below.
+      CLog::Log(LOGERROR, "JSONRPC Server: Send failed, dropping {} of {} bytes", size - sent,
+                size);
+      return;
+    }
+
+    sent += static_cast<unsigned int>(written);
+  }
 }
 
-void CTCPServer::CTCPClient::PushBuffer(CTCPServer *host, const char *buffer, int length)
+void CTCPServer::CTCPClient::Enqueue(const std::shared_ptr<CTCPClient>& self,
+                                     CTCPServer* host,
+                                     const char* buffer,
+                                     int length)
 {
+  // Cleared on the server thread so a second read cannot re-enter the WebSocket handshake
+  // before the first buffer is parsed.
   m_new = false;
+
+  bool start = false;
+  {
+    std::unique_lock<std::mutex> lock(m_inboundMutex);
+    m_inbound.emplace_back(buffer, length);
+    m_inboundBytes += static_cast<size_t>(length);
+    if (!m_workerStarted)
+    {
+      m_workerStarted = true;
+      start = true;
+    }
+  }
+
+  m_inboundEvent.notify_one();
+
+  if (start)
+  {
+    {
+      std::lock_guard lock(host->m_workersMutex);
+      ++host->m_activeWorkers;
+    }
+
+    try
+    {
+      std::thread(&CTCPClient::RunWorker, self, host->m_self.lock()).detach();
+    }
+    catch (const std::exception& error)
+    {
+      // Out of threads. The count was reserved for a worker that will never run, and letting
+      // this reach the server thread would end it: CThread swallows the exception, so Process()
+      // would return without deinitializing and no connection would ever be served again.
+      {
+        std::lock_guard lock(host->m_workersMutex);
+        --host->m_activeWorkers;
+      }
+      host->m_workersDone.notify_all();
+
+      {
+        std::unique_lock<std::mutex> lock(m_inboundMutex);
+        m_workerStarted = false;
+        m_inbound.clear();
+        m_inboundBytes = 0;
+      }
+
+      CLog::Log(LOGERROR,
+                "JSONRPC Server: Could not start a request worker ({}), dropping the "
+                "connection",
+                error.what());
+      RequestClose();
+    }
+  }
+}
+
+bool CTCPServer::CTCPClient::Backlogged()
+{
+  std::unique_lock<std::mutex> lock(m_inboundMutex);
+  return m_inboundBytes >= maxBufferLength;
+}
+
+void CTCPServer::CTCPClient::StopWorker()
+{
+  {
+    std::unique_lock<std::mutex> lock(m_inboundMutex);
+    m_workerStop = true;
+  }
+
+  m_inboundEvent.notify_one();
+}
+
+void CTCPServer::CTCPClient::RunWorker(std::shared_ptr<CTCPClient> self,
+                                       std::shared_ptr<CTCPServer> host)
+{
+  // This is a bare thread entry point: an escaping exception calls std::terminate. Executing
+  // inline used to run under CThread, which catches, so nothing below has been asked to.
+  try
+  {
+    RunRequests(self, host.get());
+  }
+  catch (const std::exception& error)
+  {
+    CLog::Log(LOGERROR, "JSONRPC Server: Request worker failed: {}", error.what());
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "JSONRPC Server: Request worker failed");
+  }
+
+  {
+    std::lock_guard lock(host->m_workersMutex);
+    --host->m_activeWorkers;
+  }
+  host->m_workersDone.notify_all();
+}
+
+void CTCPServer::CTCPClient::RunRequests(const std::shared_ptr<CTCPClient>& self, CTCPServer* host)
+{
+  while (true)
+  {
+    std::string buffer;
+    {
+      std::unique_lock<std::mutex> lock(self->m_inboundMutex);
+      self->m_inboundEvent.wait(lock,
+                                [&self] { return !self->m_inbound.empty() || self->m_workerStop; });
+
+      // Drain what has already been accepted before exiting, so a client that sends a command
+      // and closes immediately still gets it executed.
+      if (self->m_inbound.empty())
+        return;
+
+      buffer = std::move(self->m_inbound.front());
+      self->m_inbound.pop_front();
+      self->m_inboundBytes -= buffer.size();
+    }
+
+    self->PushBuffer(host, buffer.data(), static_cast<int>(buffer.size()));
+  }
+}
+
+void CTCPServer::WaitForWorkers(std::chrono::milliseconds timeout)
+{
+  std::unique_lock lock(m_workersMutex);
+  m_workersDone.wait_for(lock, timeout, [this] { return m_activeWorkers == 0; });
+}
+
+void CTCPServer::CTCPClient::PushBuffer(CTCPServer* host, const char* buffer, int length)
+{
   bool inObject = false;
   bool inString = false;
   bool escapeNext = false;
@@ -646,8 +819,11 @@ void CTCPServer::CTCPClient::Disconnect()
 {
   if (m_socket > 0)
   {
-    std::unique_lock lock(m_critSection);
+    // Send() holds m_critSection across a blocking send(), so a peer that has stopped reading
+    // would hold the server thread here. Shutting the socket down first makes that send fail.
     shutdown(m_socket, SHUT_RDWR);
+
+    std::unique_lock lock(m_critSection);
     closesocket(m_socket);
     m_socket = INVALID_SOCKET;
   }
@@ -705,6 +881,10 @@ CTCPServer::CWebSocketClient& CTCPServer::CWebSocketClient::operator=(const CWeb
 
 void CTCPServer::CWebSocketClient::Send(const char *data, unsigned int size)
 {
+  // The announcement thread and this connection's worker both send here, so framing and the
+  // writes that carry one message have to stay together.
+  std::unique_lock lock(m_critSection);
+
   const CWebSocketMessage *msg = m_websocket->Send(WebSocketTextFrame, data, size);
   if (msg == NULL || !msg->IsComplete())
     return;
@@ -718,49 +898,62 @@ void CTCPServer::CWebSocketClient::PushBuffer(CTCPServer *host, const char *buff
 {
   bool send;
   const CWebSocketMessage *msg = NULL;
+  std::vector<std::string> payloads;
 
-  if (m_buffer.size() + length > maxBufferLength)
   {
-    CLog::Log(LOGINFO, "WebSocket: client buffer size {} exceeded", maxBufferLength);
-    return Disconnect();
-  }
+    // Unframing shares the websocket with the announcement thread and is locked; the JSON-RPC
+    // calls below are not, as one may sit in a modal dialog.
+    std::unique_lock lock(m_critSection);
 
-  m_buffer.append(buffer, length);
-
-  const char* buf = m_buffer.data();
-  size_t len = m_buffer.size();
-
-  do
-  {
-    if ((msg = m_websocket->Handle(buf, len, send)) != NULL && msg->IsComplete())
+    if (m_buffer.size() + length > maxBufferLength)
     {
-      std::vector<const CWebSocketFrame *> frames = msg->GetFrames();
-      if (send)
-      {
-        for (unsigned int index = 0; index < frames.size(); index++)
-          CTCPClient::Send(frames.at(index)->GetFrameData(),
-                           static_cast<unsigned int>(frames.at(index)->GetFrameLength()));
-      }
-      else
-      {
-        for (unsigned int index = 0; index < frames.size(); index++)
-          CTCPClient::PushBuffer(host, frames.at(index)->GetApplicationData(), (int)frames.at(index)->GetLength());
-      }
-
-      delete msg;
+      CLog::Log(LOGINFO, "WebSocket: client buffer size {} exceeded", maxBufferLength);
+      RequestClose();
+      return;
     }
+
+    m_buffer.append(buffer, length);
+
+    const char* buf = m_buffer.data();
+    size_t len = m_buffer.size();
+
+    do
+    {
+      if ((msg = m_websocket->Handle(buf, len, send)) != NULL && msg->IsComplete())
+      {
+        std::vector<const CWebSocketFrame*> frames = msg->GetFrames();
+        if (send)
+        {
+          for (unsigned int index = 0; index < frames.size(); index++)
+            CTCPClient::Send(frames.at(index)->GetFrameData(),
+                             static_cast<unsigned int>(frames.at(index)->GetFrameLength()));
+        }
+        else
+        {
+          for (unsigned int index = 0; index < frames.size(); index++)
+            payloads.emplace_back(frames.at(index)->GetApplicationData(),
+                                  static_cast<size_t>(frames.at(index)->GetLength()));
+        }
+
+        delete msg;
+      }
+    } while (len > 0 && msg != NULL);
+
+    if (len < m_buffer.size())
+      m_buffer = m_buffer.substr(m_buffer.size() - len);
+
+    if (m_websocket->GetState() == WebSocketStateClosed)
+      RequestClose();
   }
-  while (len > 0 && msg != NULL);
 
-  if (len < m_buffer.size())
-    m_buffer = m_buffer.substr(m_buffer.size() - len);
-
-  if (m_websocket->GetState() == WebSocketStateClosed)
-    Disconnect();
+  for (const auto& payload : payloads)
+    CTCPClient::PushBuffer(host, payload.data(), static_cast<int>(payload.size()));
 }
 
 void CTCPServer::CWebSocketClient::Disconnect()
 {
+  std::unique_lock lock(m_critSection);
+
   if (m_socket > 0)
   {
     if (m_websocket->GetState() != WebSocketStateClosed && m_websocket->GetState() != WebSocketStateNotConnected)
@@ -770,7 +963,8 @@ void CTCPServer::CWebSocketClient::Disconnect()
         Send(closeFrame->GetFrameData(), (unsigned int)closeFrame->GetFrameLength());
     }
 
-    if (m_websocket->GetState() == WebSocketStateClosed)
-      CTCPClient::Disconnect();
+    // The caller is dropping this connection, so the descriptor goes with it even when the
+    // peer never answers the close frame.
+    CTCPClient::Disconnect();
   }
 }

--- a/xbmc/network/TCPServer.h
+++ b/xbmc/network/TCPServer.h
@@ -15,6 +15,13 @@
 #include "threads/Thread.h"
 #include "websocket/WebSocket.h"
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
 #include <vector>
 
 #include <sys/socket.h>
@@ -56,6 +63,7 @@ namespace JSONRPC
       CTCPClient();
       //Copying a CCriticalSection is not allowed, so copy everything but that
       //when adding a member variable, make sure to copy it in CTCPClient::Copy
+      // worker state is deliberately not copied
       CTCPClient(const CTCPClient& client);
       CTCPClient& operator=(const CTCPClient& client);
       ~CTCPClient() override = default;
@@ -68,8 +76,36 @@ namespace JSONRPC
       virtual void PushBuffer(CTCPServer *host, const char *buffer, int length);
       virtual void Disconnect();
 
+      /*!
+       * \brief Hand a received buffer to this connection's own thread, starting it if needed.
+       *
+       * The server thread never executes a request itself: a handler may block in a modal
+       * dialog, and every other client would wait behind it.
+       *
+       * \param self shared ownership of this client, kept alive by the worker
+       * \param host the server, kept alive by the worker through its own shared_ptr
+       */
+      void Enqueue(const std::shared_ptr<CTCPClient>& self,
+                   CTCPServer* host,
+                   const char* buffer,
+                   int length);
+
+      /*!
+       * \brief Ask the worker to finish; never joins, as the worker may be blocked in a dialog.
+       */
+      void StopWorker();
+
       virtual bool IsNew() const { return m_new; }
-      virtual bool Closing() const { return false; }
+      virtual bool Closing() const { return m_closing; }
+
+      /*!
+       * \brief Whether this connection has more accepted but unparsed input than it should.
+       *
+       * The server thread stops reading a backlogged connection, which closes the receive
+       * window and holds the client back. Running the request on the server thread used to do
+       * that on its own.
+       */
+      bool Backlogged();
 
       SOCKET m_socket{INVALID_SOCKET};
       sockaddr_storage m_cliaddr;
@@ -78,12 +114,32 @@ namespace JSONRPC
 
     protected:
       void Copy(const CTCPClient& client);
+
+      /*!
+       * \brief Ask the server thread to drop this connection.
+       *
+       * Only the server thread closes a socket: it may be in select() on that descriptor.
+       */
+      void RequestClose() { m_closing = true; }
+
     private:
+      static void RunWorker(std::shared_ptr<CTCPClient> self, std::shared_ptr<CTCPServer> host);
+      static void RunRequests(const std::shared_ptr<CTCPClient>& self, CTCPServer* host);
+
       bool m_new;
       int m_announcementflags;
       int m_beginBrackets, m_endBrackets;
       char m_beginChar, m_endChar;
       std::string m_buffer;
+
+      std::atomic<bool> m_closing{false};
+
+      std::mutex m_inboundMutex;
+      std::condition_variable m_inboundEvent;
+      std::deque<std::string> m_inbound;
+      size_t m_inboundBytes{0};
+      bool m_workerStop{false};
+      bool m_workerStarted{false};
     };
 
     class CWebSocketClient : public CTCPClient
@@ -100,20 +156,30 @@ namespace JSONRPC
       void Disconnect() override;
 
       bool IsNew() const override { return m_websocket == NULL; }
-      bool Closing() const override { return m_websocket != NULL && m_websocket->GetState() == WebSocketStateClosed; }
 
     private:
       CWebSocket *m_websocket;
       std::string m_buffer;
     };
 
-    std::vector<CTCPClient*> m_connections;
+    std::vector<std::shared_ptr<CTCPClient>> m_connections;
     std::vector<SOCKET> m_servers;
     CCriticalSection m_connectionsCritSection;
     int m_port;
     bool m_nonlocal;
     void* m_sdpd;
 
-    static CTCPServer *ServerInstance;
+    // Handed to each worker, so a request still running when StopServer() drops ServerInstance
+    // keeps the server alive until it returns.
+    std::weak_ptr<CTCPServer> m_self;
+
+    //! \brief Wait for every worker to finish, for at most the given time
+    void WaitForWorkers(std::chrono::milliseconds timeout);
+
+    std::mutex m_workersMutex;
+    std::condition_variable m_workersDone;
+    unsigned int m_activeWorkers{0};
+
+    static std::shared_ptr<CTCPServer> ServerInstance;
   };
 }


### PR DESCRIPTION
**TL;DR:** Bug fix. A JSON-RPC request ran on the TCP server's own thread, so a handler that opened a modal dialog blocked every other client — and the announcement path — until the dialog was dismissed.

## Description

`CTCPServer::Process()` read a request and executed it inline. Any handler that raises a modal dialog (`Player.Open` on a PVR channel, a settings write that prompts) parks that thread inside the dialog's nested render loop, so no other connection is polled and no announcement is sent until a human answers.

Each connection now owns a thread, started on its first buffer and living until the connection closes. The server thread only polls, accepts and hands buffers over. Backpressure that came free from running inline is restored explicitly: a connection with more accepted-but-unparsed input than the buffer limit is left out of the `select()` set, so its receive window closes and the client waits.

Also in scope, all in the same file and all consequences of the same change:

- `Send()` looped on an unsigned counter and added `send()`'s `-1` to it on failure, spinning forever. It now stops and logs.
- `Send()` took the client lock per iteration, so two threads could interleave halves of a message. It holds it for the whole send.
- Only the server thread closes a socket, since it may be inside `select()` on that descriptor; workers ask for a close instead.
- Shutdown waits a bounded two seconds for workers, because one may be inside a dialog and will never return. This bounds the wait rather than solving it: a worker that resumes after that can still touch application services being torn down. Joining instead would hang shutdown on any dialog nobody answers.

Four further defects, found reviewing the change itself and all in the same file:

- `RunWorker` is a bare thread entry point, so an exception escaping a handler called `std::terminate` and took the process with it. Executing inline used to run under `CThread`, which catches. It now catches, and the active-worker count falls whether or not it does.
- Dropping a connection whose WebSocket close handshake had not completed erased the client without closing its socket, because `CWebSocketClient::Disconnect()` only closed the descriptor once the peer had answered. A dropped connection now closes regardless.
- `SetAnnouncementFlags()` wrote the flags with no lock while `Announce()` read them under the client lock. Running the request inline used to exclude the two; the setter now takes the same lock.
- `Disconnect()` took the client lock before shutting the socket down, so a peer that had stopped reading could hold the server thread behind a blocked `send()`. The shutdown comes first now, which makes that send fail and release the lock.

A blocking `send()` to a stalled peer can still hold `CWebSocketClient::Disconnect()`, which takes the client lock before it frames the close. Bounding that needs a send timeout on the socket, which would truncate a large response to a legitimately slow reader, so it is left as it is on master.

## Motivation and context

The modal case is the one that bites: a client sends `Player.Open`, Kodi raises "Play recording or switch to channel?", and every other JSON-RPC client hangs until someone picks. Reported behaviour, not theoretical.

## How has this been tested?

Built on Windows x64 (VS 2022) and ran the full `kodi-test` suite: 4076 tests in 319 suites, all passing.

The suite does not cover the threading itself — there is no harness for a live TCP client in the test build — so the concurrency behaviour has not been verified automatically. Reviewer testing against a running instance would be welcome, particularly a handler that raises a modal dialog while a second client is connected.

## What is the effect on users?

A JSON-RPC client no longer blocks other clients while Kodi is showing a dialog raised by its request. Remote controls and add-ons that poll stay responsive.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

