### PR TITLE
[PVR][CDateTime] Store and read EPG times at a width that survives 2038

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -30,6 +30,7 @@ xbmc/network/test                 test/network
 xbmc/pictures/metadata/test       test/pictures/metadata
 xbmc/playlists/test               test/playlists
 xbmc/pvr/channels/test            test/pvrchannels
+xbmc/pvr/epg/test                 test/pvrepg
 xbmc/rendering/capture/test       test/rendering_capture
 xbmc/settings/test                test/settings
 xbmc/settings/lib/test            test/lib/settings

--- a/xbmc/XBDateTime.cpp
+++ b/xbmc/XBDateTime.cpp
@@ -20,6 +20,7 @@
 #include "utils/log.h"
 
 #include <charconv>
+#include <cstdint>
 #include <cstdlib>
 #include <mutex>
 
@@ -865,6 +866,12 @@ void CDateTime::GetAsTime(time_t& time) const
   time=(time_t)((ll - UNIX_BASE_TIME) / 10000000);
 }
 
+int64_t CDateTime::GetAsSecondsSinceEpoch() const
+{
+  const int64_t ll{(static_cast<int64_t>(m_time.highDateTime) << 32) + m_time.lowDateTime};
+  return (ll - UNIX_BASE_TIME) / 10000000;
+}
+
 void CDateTime::GetAsTm(tm& time) const
 {
   KODI::TIME::SystemTime st;
@@ -1239,6 +1246,25 @@ CDateTime CDateTime::FromUTCDateTime(const time_t &dateTime)
   CDateTime dt;
   dt.SetFromUTCDateTime(dateTime);
   return dt;
+}
+
+CDateTime CDateTime::FromSecondsSinceEpoch(int64_t seconds)
+{
+  constexpr int64_t FIRST_SECOND{-11644473600}; // 1601-01-01, where a FileTime starts counting
+  constexpr int64_t LAST_SECOND{910692730085}; // 30828-09-14, where the 100ns count leaves int64
+
+  // a count read out of a database column can be anything, and the multiply below overflows
+  // outside this range
+  if (seconds < FIRST_SECOND || seconds > LAST_SECOND)
+    return {};
+
+  const int64_t ll{seconds * 10000000LL + UNIX_BASE_TIME};
+
+  KODI::TIME::FileTime fileTime{};
+  fileTime.lowDateTime = static_cast<uint32_t>(ll & 0xFFFFFFFF);
+  fileTime.highDateTime = static_cast<uint32_t>(ll >> 32);
+
+  return CDateTime(fileTime);
 }
 
 CDateTime CDateTime::FromRFC1123DateTime(const std::string &dateTime)

--- a/xbmc/XBDateTime.h
+++ b/xbmc/XBDateTime.h
@@ -12,6 +12,7 @@
 #include "utils/TimeFormat.h"
 #include "utils/XTimeUtils.h"
 
+#include <cstdint>
 #include <optional>
 #include <string>
 
@@ -86,6 +87,18 @@ public:
   static CDateTime FromUTCDateTime(const CDateTime &dateTime);
   static CDateTime FromUTCDateTime(const time_t &dateTime);
   static CDateTime FromRFC1123DateTime(const std::string &dateTime);
+
+  /*!
+   * \brief Create from a count of seconds since the UNIX epoch.
+   *
+   * Carries a date past 2038-01-19 on the targets where time_t is 32 bits. The result is a UTC
+   * time.
+   *
+   * \param seconds The seconds since 1970-01-01 00:00:00 UTC.
+   * \return The time those seconds name, or an invalid time if they name one the underlying
+   *         FileTime cannot hold, which is anything outside 1601-01-01 to 30828-09-14.
+   */
+  static CDateTime FromSecondsSinceEpoch(int64_t seconds);
 
   const CDateTime& operator=(const KODI::TIME::SystemTime& right);
   const CDateTime& operator=(const KODI::TIME::FileTime& right);
@@ -179,6 +192,16 @@ public:
   void GetAsTime(time_t& time) const;
   void GetAsTm(tm& time) const;
   void GetAsTimeStamp(KODI::TIME::FileTime& time) const;
+
+  /*!
+   * \brief The count of seconds since the UNIX epoch.
+   *
+   * Carries a date past 2038-01-19 on the targets where time_t is 32 bits. The stored time is
+   * read as UTC, so a local time gives a count that is out by the timezone bias.
+   *
+   * \return The seconds since 1970-01-01 00:00:00 UTC.
+   */
+  int64_t GetAsSecondsSinceEpoch() const;
 
   enum class ReturnFormat : bool
   {

--- a/xbmc/dbwrappers/test/TestVPrepare.cpp
+++ b/xbmc/dbwrappers/test/TestVPrepare.cpp
@@ -12,6 +12,7 @@
 #endif
 
 #include <array>
+#include <cstdint>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -196,3 +197,67 @@ TEST_P(VPrepareStringParamTester, Sqlite)
 INSTANTIATE_TEST_SUITE_P(TestDbWrappers,
                          VPrepareStringParamTester,
                          testing::ValuesIn(VPrepareStringParamTests));
+
+/*!
+ * Both backends, because a column holding a count of seconds is written on both, and a conversion
+ * narrower than the value moves the row it names to another date without saying so.
+ */
+struct VPrepareInt64ParamTest
+{
+  std::string format;
+  int64_t param;
+  std::string expected;
+};
+
+const auto VPrepareInt64ParamTests = std::array{
+    VPrepareInt64ParamTest{"WHERE iEndTime > %lld", 0, "WHERE iEndTime > 0"},
+    // past the signed 32-bit ceiling of 2038-01-19
+    VPrepareInt64ParamTest{"WHERE iEndTime > %lld", 4102444740, "WHERE iEndTime > 4102444740"},
+    // past the unsigned one of 2106-02-07
+    VPrepareInt64ParamTest{"WHERE iEndTime > %lld", 7258118400, "WHERE iEndTime > 7258118400"},
+    // and below the epoch, which a conversion read as unsigned would wrap
+    VPrepareInt64ParamTest{"WHERE iEndTime > %lld", -2208988800, "WHERE iEndTime > -2208988800"},
+};
+
+class VPrepareInt64ParamTester : public testing::WithParamInterface<VPrepareInt64ParamTest>,
+                                 public testing::Test
+{
+};
+
+TEST_P(VPrepareInt64ParamTester, Sqlite)
+{
+  const auto params = GetParam();
+  EXPECT_EQ(params.expected, TestPrepareSQL<dbiplus::SqliteDatabase>(params.format, params.param));
+}
+
+#if defined(HAS_MYSQL) || defined(HAS_MARIADB)
+TEST_P(VPrepareInt64ParamTester, MySql)
+{
+  const auto params = GetParam();
+  EXPECT_EQ(params.expected, TestPrepareSQL<dbiplus::MysqlDatabase>(params.format, params.param));
+}
+#endif
+
+INSTANTIATE_TEST_SUITE_P(TestDbWrappers,
+                         VPrepareInt64ParamTester,
+                         testing::ValuesIn(VPrepareInt64ParamTests));
+
+/*!
+ * A literal percent next to two 64-bit conversions: the escaping pass steps over a conversion two
+ * characters at a time, so this is where it would lose its place and swap the arguments.
+ */
+TEST(VPrepareInt64Param, ALiteralPercentBetweenConversionsSqlite)
+{
+  EXPECT_EQ("(iStartTime % 86400) >= 7258118400",
+            TestPrepareSQL<dbiplus::SqliteDatabase>("(iStartTime %% %lld) >= %lld", int64_t{86400},
+                                                    int64_t{7258118400}));
+}
+
+#if defined(HAS_MYSQL) || defined(HAS_MARIADB)
+TEST(VPrepareInt64Param, ALiteralPercentBetweenConversionsMySql)
+{
+  EXPECT_EQ("(iStartTime % 86400) >= 7258118400",
+            TestPrepareSQL<dbiplus::MysqlDatabase>("(iStartTime %% %lld) >= %lld", int64_t{86400},
+                                                   int64_t{7258118400}));
+}
+#endif

--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -22,6 +22,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -30,6 +31,34 @@
 
 using namespace dbiplus;
 using namespace PVR;
+
+namespace
+{
+// The time columns hold a 64-bit count of seconds since the epoch. Nothing on either side of a
+// column goes through time_t, which is 32 bits on some targets.
+
+int64_t ToStoredTime(const CDateTime& time)
+{
+  return time.GetAsSecondsSinceEpoch();
+}
+
+int64_t NowAsStoredTime()
+{
+  return std::chrono::duration_cast<std::chrono::seconds>(
+             std::chrono::system_clock::now().time_since_epoch())
+      .count();
+}
+
+CDateTime FromStoredTime(const std::string& value)
+{
+  return CDateTime::FromSecondsSinceEpoch(std::strtoll(value.c_str(), nullptr, 10));
+}
+
+CDateTime FromStoredTime(const field_value& value)
+{
+  return CDateTime::FromSecondsSinceEpoch(value.get_asInt64());
+}
+} // unnamed namespace
 
 CPVREpgDatabase::CPVREpgDatabase() : CDatabase(KODI::DATABASE::TYPE_EPG)
 {
@@ -87,8 +116,8 @@ void CPVREpgDatabase::CreateTables()
               "iYear           integer, "
               "sIMDBNumber     varchar(50), "
               "sIconPath       varchar(255), "
-              "iStartTime      integer, "
-              "iEndTime        integer, "
+              "iStartTime      bigint, "
+              "iEndTime        bigint, "
               "iGenreType      integer, "
               "iGenreSubType   integer, "
               "sGenre          varchar(128), "
@@ -353,6 +382,17 @@ void CPVREpgDatabase::UpdateTables(int iVersion)
     m_pDS->exec("ALTER TABLE epgtags ADD sTitleExtraInfo varchar(128);");
     m_pDS->exec("UPDATE epgtags SET sTitleExtraInfo = ''");
   }
+
+  if (iVersion < 22)
+  {
+    // MySQL's integer is 32 bits, which cannot hold a time past 2038-01-19. SQLite's is already
+    // 64 bits, and it has no ALTER TABLE ... MODIFY.
+    if (!m_sqlite)
+    {
+      m_pDS->exec("ALTER TABLE epgtags MODIFY iStartTime bigint");
+      m_pDS->exec("ALTER TABLE epgtags MODIFY iEndTime bigint");
+    }
+  }
 }
 
 bool CPVREpgDatabase::DeleteEpg()
@@ -444,13 +484,8 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::CreateEpgTag(dbiplus::Dataset& 
         m_pDS->fv("idEpg").get_asInt(), m_pDS->fv("sIconPath").get_asString(),
         m_pDS->fv("sParentalRatingIcon").get_asString())};
 
-    auto iStartTime{static_cast<time_t>(m_pDS->fv("iStartTime").get_asInt())};
-    const CDateTime startTime(iStartTime);
-    newTag->m_startTime = startTime;
-
-    auto iEndTime{static_cast<time_t>(m_pDS->fv("iEndTime").get_asInt())};
-    const CDateTime endTime(iEndTime);
-    newTag->m_endTime = endTime;
+    newTag->m_startTime = FromStoredTime(m_pDS->fv("iStartTime"));
+    newTag->m_endTime = FromStoredTime(m_pDS->fv("iEndTime"));
 
     const std::string sFirstAired = m_pDS->fv("sFirstAired").get_asString();
     if (!sFirstAired.empty())
@@ -506,7 +541,7 @@ CDateTime CPVREpgDatabase::GetLastEndTime(int iEpgID) const
       PrepareSQL("SELECT MAX(iEndTime) FROM epgtags WHERE idEpg = %u;", iEpgID);
   std::string strValue = GetSingleValue(strQuery);
   if (!strValue.empty())
-    return CDateTime(static_cast<time_t>(std::atoi(strValue.c_str())));
+    return FromStoredTime(strValue);
 
   return {};
 }
@@ -523,48 +558,42 @@ std::pair<CDateTime, CDateTime> CPVREpgDatabase::GetFirstAndLastEPGDate() const
 
   std::string strValue = GetSingleValue(strQuery);
   if (!strValue.empty())
-    first = CDateTime(static_cast<time_t>(std::atoi(strValue.c_str())));
+    first = FromStoredTime(strValue);
 
   // 2nd query: get max end time
   strQuery = PrepareSQL("SELECT MAX(iEndTime) FROM epgtags;");
 
   strValue = GetSingleValue(strQuery);
   if (!strValue.empty())
-    last = CDateTime(static_cast<time_t>(std::atoi(strValue.c_str())));
+    last = FromStoredTime(strValue);
 
   return {first, last};
 }
 
 CDateTime CPVREpgDatabase::GetMinStartTime(int iEpgID, const CDateTime& minStart) const
 {
-  time_t t;
-  minStart.GetAsTime(t);
-
   std::unique_lock lock(m_critSection);
   const std::string strQuery = PrepareSQL("SELECT MIN(iStartTime) "
                                           "FROM epgtags "
-                                          "WHERE idEpg = %u AND iStartTime > %u;",
-                                          iEpgID, static_cast<unsigned int>(t));
+                                          "WHERE idEpg = %u AND iStartTime > %lld;",
+                                          iEpgID, ToStoredTime(minStart));
   std::string strValue = GetSingleValue(strQuery);
   if (!strValue.empty())
-    return CDateTime(static_cast<time_t>(std::atoi(strValue.c_str())));
+    return FromStoredTime(strValue);
 
   return {};
 }
 
 CDateTime CPVREpgDatabase::GetMaxEndTime(int iEpgID, const CDateTime& maxEnd) const
 {
-  time_t t;
-  maxEnd.GetAsTime(t);
-
   std::unique_lock lock(m_critSection);
   const std::string strQuery = PrepareSQL("SELECT MAX(iEndTime) "
                                           "FROM epgtags "
-                                          "WHERE idEpg = %u AND iEndTime <= %u;",
-                                          iEpgID, static_cast<unsigned int>(t));
+                                          "WHERE idEpg = %u AND iEndTime <= %lld;",
+                                          iEpgID, ToStoredTime(maxEnd));
   std::string strValue = GetSingleValue(strQuery);
   if (!strValue.empty())
-    return CDateTime(static_cast<time_t>(std::atoi(strValue.c_str())));
+    return FromStoredTime(strValue);
 
   return {};
 }
@@ -709,24 +738,23 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTags(
   // min start datetime
   /////////////////////////////////////////////////////////////////////////////////////////////
 
-  static constexpr unsigned int ONE_DAY{60 * 60 * 24};
+  static constexpr int64_t ONE_DAY{60 * 60 * 24};
 
   if (searchData.m_startDateTime.IsValid())
   {
-    time_t minStart;
-    searchData.m_startDateTime.GetAsTime(minStart);
+    const int64_t minStart{ToStoredTime(searchData.m_startDateTime)};
 
     if (searchData.m_startAnyTime)
     {
-      filter.AppendWhere(PrepareSQL("iStartTime >= %u", static_cast<unsigned int>(minStart)));
+      filter.AppendWhere(PrepareSQL("iStartTime >= %lld", minStart));
     }
     else
     {
-      const uint64_t startDate{static_cast<unsigned int>(minStart) / ONE_DAY};
-      filter.AppendWhere(PrepareSQL("iStartTime >= %llu", startDate * ONE_DAY));
+      const int64_t startDate{minStart / ONE_DAY};
+      filter.AppendWhere(PrepareSQL("iStartTime >= %lld", startDate * ONE_DAY));
 
-      const unsigned int startTime{static_cast<unsigned int>(minStart) % ONE_DAY};
-      filter.AppendWhere(PrepareSQL("(iStartTime %% %u) >= %u", ONE_DAY, startTime));
+      const int64_t startTime{minStart % ONE_DAY};
+      filter.AppendWhere(PrepareSQL("(iStartTime %% %lld) >= %lld", ONE_DAY, startTime));
     }
   }
 
@@ -736,20 +764,19 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTags(
 
   if (searchData.m_endDateTime.IsValid())
   {
-    time_t maxEnd;
-    searchData.m_endDateTime.GetAsTime(maxEnd);
+    const int64_t maxEnd{ToStoredTime(searchData.m_endDateTime)};
 
     if (searchData.m_endAnyTime)
     {
-      filter.AppendWhere(PrepareSQL("iEndTime <= %u", static_cast<unsigned int>(maxEnd)));
+      filter.AppendWhere(PrepareSQL("iEndTime <= %lld", maxEnd));
     }
     else
     {
-      const uint64_t endDate{static_cast<unsigned int>(maxEnd) / ONE_DAY};
-      filter.AppendWhere(PrepareSQL("iEndTime < %llu", (endDate + 1) * ONE_DAY));
+      const int64_t endDate{maxEnd / ONE_DAY};
+      filter.AppendWhere(PrepareSQL("iEndTime < %lld", (endDate + 1) * ONE_DAY));
 
-      const unsigned int endTime{static_cast<unsigned int>(maxEnd) % ONE_DAY};
-      filter.AppendWhere(PrepareSQL("(iEndTime %% %u) <= %u", ONE_DAY, endTime));
+      const int64_t endTime{maxEnd % ONE_DAY};
+      filter.AppendWhere(PrepareSQL("(iEndTime %% %lld) <= %lld", ONE_DAY, endTime));
     }
   }
 
@@ -759,9 +786,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTags(
 
   if (searchData.m_bIgnoreFinishedBroadcasts)
   {
-    const auto now{std::chrono::system_clock::now()};
-    filter.AppendWhere(PrepareSQL(
-        "iEndTime > %u", static_cast<unsigned int>(std::chrono::system_clock::to_time_t(now))));
+    filter.AppendWhere(PrepareSQL("iEndTime > %lld", NowAsStoredTime()));
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////
@@ -770,9 +795,7 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTags(
 
   if (searchData.m_bIgnoreFutureBroadcasts)
   {
-    const auto now{std::chrono::system_clock::now()};
-    filter.AppendWhere(PrepareSQL(
-        "iStartTime < %u", static_cast<unsigned int>(std::chrono::system_clock::to_time_t(now))));
+    filter.AppendWhere(PrepareSQL("iStartTime < %lld", NowAsStoredTime()));
   }
 
   /////////////////////////////////////////////////////////////////////////////////////////////
@@ -901,14 +924,11 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByDatabaseID(int iEpgI
 std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByStartTime(
     int iEpgID, const CDateTime& startTime) const
 {
-  time_t start;
-  startTime.GetAsTime(start);
-
   std::unique_lock lock(m_critSection);
   const std::string strQuery = PrepareSQL("SELECT * "
                                           "FROM epgtags "
-                                          "WHERE idEpg = %u AND iStartTime = %u;",
-                                          iEpgID, static_cast<unsigned int>(start));
+                                          "WHERE idEpg = %u AND iStartTime = %lld;",
+                                          iEpgID, ToStoredTime(startTime));
 
   if (ResultQuery(strQuery))
   {
@@ -931,15 +951,12 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByStartTime(
 std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByMinStartTime(
     int iEpgID, const CDateTime& minStartTime) const
 {
-  time_t minStart;
-  minStartTime.GetAsTime(minStart);
-
   std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("SELECT * "
                  "FROM epgtags "
-                 "WHERE idEpg = %u AND iStartTime >= %u ORDER BY iStartTime ASC LIMIT 1;",
-                 iEpgID, static_cast<unsigned int>(minStart));
+                 "WHERE idEpg = %u AND iStartTime >= %lld ORDER BY iStartTime ASC LIMIT 1;",
+                 iEpgID, ToStoredTime(minStartTime));
 
   if (ResultQuery(strQuery))
   {
@@ -962,15 +979,12 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByMinStartTime(
 std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByMaxEndTime(
     int iEpgID, const CDateTime& maxEndTime) const
 {
-  time_t maxEnd;
-  maxEndTime.GetAsTime(maxEnd);
-
   std::unique_lock lock(m_critSection);
   const std::string strQuery =
       PrepareSQL("SELECT * "
                  "FROM epgtags "
-                 "WHERE idEpg = %u AND iEndTime <= %u ORDER BY iStartTime DESC LIMIT 1;",
-                 iEpgID, static_cast<unsigned int>(maxEnd));
+                 "WHERE idEpg = %u AND iEndTime <= %lld ORDER BY iStartTime DESC LIMIT 1;",
+                 iEpgID, ToStoredTime(maxEndTime));
 
   if (ResultQuery(strQuery))
   {
@@ -993,18 +1007,12 @@ std::shared_ptr<CPVREpgInfoTag> CPVREpgDatabase::GetEpgTagByMaxEndTime(
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTagsByMinStartMaxEndTime(
     int iEpgID, const CDateTime& minStartTime, const CDateTime& maxEndTime) const
 {
-  time_t minStart;
-  minStartTime.GetAsTime(minStart);
-
-  time_t maxEnd;
-  maxEndTime.GetAsTime(maxEnd);
-
   std::unique_lock lock(m_critSection);
-  const std::string strQuery =
-      PrepareSQL("SELECT * "
-                 "FROM epgtags "
-                 "WHERE idEpg = %u AND iStartTime >= %u AND iEndTime <= %u ORDER BY iStartTime;",
-                 iEpgID, static_cast<unsigned int>(minStart), static_cast<unsigned int>(maxEnd));
+  const std::string strQuery = PrepareSQL(
+      "SELECT * "
+      "FROM epgtags "
+      "WHERE idEpg = %u AND iStartTime >= %lld AND iEndTime <= %lld ORDER BY iStartTime;",
+      iEpgID, ToStoredTime(minStartTime), ToStoredTime(maxEndTime));
 
   if (ResultQuery(strQuery))
   {
@@ -1033,18 +1041,12 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTagsByMinSta
 std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTagsByMinEndMaxStartTime(
     int iEpgID, const CDateTime& minEndTime, const CDateTime& maxStartTime) const
 {
-  time_t minEnd;
-  minEndTime.GetAsTime(minEnd);
-
-  time_t maxStart;
-  maxStartTime.GetAsTime(maxStart);
-
   std::unique_lock lock(m_critSection);
-  const std::string strQuery =
-      PrepareSQL("SELECT * "
-                 "FROM epgtags "
-                 "WHERE idEpg = %u AND iEndTime >= %u AND iStartTime <= %u ORDER BY iStartTime;",
-                 iEpgID, static_cast<unsigned int>(minEnd), static_cast<unsigned int>(maxStart));
+  const std::string strQuery = PrepareSQL(
+      "SELECT * "
+      "FROM epgtags "
+      "WHERE idEpg = %u AND iEndTime >= %lld AND iStartTime <= %lld ORDER BY iStartTime;",
+      iEpgID, ToStoredTime(minEndTime), ToStoredTime(maxStartTime));
 
   if (ResultQuery(strQuery))
   {
@@ -1074,18 +1076,11 @@ bool CPVREpgDatabase::QueueDeleteEpgTagsByMinEndMaxStartTimeQuery(int iEpgID,
                                                                   const CDateTime& minEndTime,
                                                                   const CDateTime& maxStartTime)
 {
-  time_t minEnd;
-  minEndTime.GetAsTime(minEnd);
-
-  time_t maxStart;
-  maxStartTime.GetAsTime(maxStart);
-
   Filter filter;
 
   std::unique_lock lock(m_critSection);
-  filter.AppendWhere(PrepareSQL("idEpg = %u AND iEndTime >= %u AND iStartTime <= %u", iEpgID,
-                                static_cast<unsigned int>(minEnd),
-                                static_cast<unsigned int>(maxStart)));
+  filter.AppendWhere(PrepareSQL("idEpg = %u AND iEndTime >= %lld AND iStartTime <= %lld", iEpgID,
+                                ToStoredTime(minEndTime), ToStoredTime(maxStartTime)));
 
   std::string strQuery;
   if (BuildSQL("DELETE FROM epgtags", filter, strQuery))
@@ -1252,14 +1247,11 @@ int CPVREpgDatabase::Persist(const CPVREpg& epg, bool bQueueWrite)
 
 bool CPVREpgDatabase::DeleteEpgTags(int iEpgId, const CDateTime& maxEndTime)
 {
-  time_t iMaxEndTime;
-  maxEndTime.GetAsTime(iMaxEndTime);
-
   Filter filter;
 
   std::unique_lock lock(m_critSection);
   filter.AppendWhere(
-      PrepareSQL("idEpg = %u AND iEndTime < %u", iEpgId, static_cast<unsigned int>(iMaxEndTime)));
+      PrepareSQL("idEpg = %u AND iEndTime < %lld", iEpgId, ToStoredTime(maxEndTime)));
   return DeleteValues("epgtags", filter);
 }
 
@@ -1292,11 +1284,8 @@ bool CPVREpgDatabase::QueuePersistQuery(const CPVREpgInfoTag& tag)
     return false;
   }
 
-  time_t iStartTime{0};
-  tag.StartAsUTC().GetAsTime(iStartTime);
-
-  time_t iEndTime{0};
-  tag.EndAsUTC().GetAsTime(iEndTime);
+  const int64_t iStartTime{ToStoredTime(tag.StartAsUTC())};
+  const int64_t iEndTime{ToStoredTime(tag.EndAsUTC())};
 
   std::string sFirstAired;
   if (tag.FirstAired().IsValid())
@@ -1317,11 +1306,11 @@ bool CPVREpgDatabase::QueuePersistQuery(const CPVREpgInfoTag& tag)
         "iSeriesId, "
         "iEpisodeId, iEpisodePart, sEpisodeName, iFlags, sSeriesLink, sParentalRatingCode, "
         "iBroadcastUid, sParentalRatingIcon, sParentalRatingSource, sTitleExtraInfo) "
-        "VALUES (%u, %u, %u, '%s', '%s', '%s', '%s', '%s', '%s', '%s', %i, '%s', '%s', %i, %i, "
+        "VALUES (%u, %lld, %lld, '%s', '%s', '%s', '%s', '%s', '%s', '%s', %i, '%s', '%s', %i, %i, "
         "'%s', '%s', %i, %i, %i, %i, %i, '%s', %i, '%s', '%s', %i, '%s', '%s', '%s');",
-        tag.EpgID(), static_cast<unsigned int>(iStartTime), static_cast<unsigned int>(iEndTime),
-        tag.Title().c_str(), tag.PlotOutline().c_str(), tag.Plot().c_str(),
-        tag.OriginalTitle().c_str(), CPVREpgInfoTag::DeTokenize(tag.Cast()).c_str(),
+        tag.EpgID(), iStartTime, iEndTime, tag.Title().c_str(), tag.PlotOutline().c_str(),
+        tag.Plot().c_str(), tag.OriginalTitle().c_str(),
+        CPVREpgInfoTag::DeTokenize(tag.Cast()).c_str(),
         CPVREpgInfoTag::DeTokenize(tag.Directors()).c_str(),
         CPVREpgInfoTag::DeTokenize(tag.Writers()).c_str(), tag.Year(), tag.IMDBNumber().c_str(),
         tag.ClientIconPath().c_str(), tag.GenreType(), tag.GenreSubType(),
@@ -1341,11 +1330,11 @@ bool CPVREpgDatabase::QueuePersistQuery(const CPVREpgInfoTag& tag)
         "iSeriesId, "
         "iEpisodeId, iEpisodePart, sEpisodeName, iFlags, sSeriesLink, sParentalRatingCode, "
         "iBroadcastUid, idBroadcast, sParentalRatingIcon, sParentalRatingSource, sTitleExtraInfo) "
-        "VALUES (%u, %u, %u, '%s', '%s', '%s', '%s', '%s', '%s', '%s', %i, '%s', '%s', %i, %i, "
+        "VALUES (%u, %lld, %lld, '%s', '%s', '%s', '%s', '%s', '%s', '%s', %i, '%s', '%s', %i, %i, "
         "'%s', '%s', %i, %i, %i, %i, %i, '%s', %i, '%s', '%s', %i, %i, '%s', '%s', '%s');",
-        tag.EpgID(), static_cast<unsigned int>(iStartTime), static_cast<unsigned int>(iEndTime),
-        tag.Title().c_str(), tag.PlotOutline().c_str(), tag.Plot().c_str(),
-        tag.OriginalTitle().c_str(), CPVREpgInfoTag::DeTokenize(tag.Cast()).c_str(),
+        tag.EpgID(), iStartTime, iEndTime, tag.Title().c_str(), tag.PlotOutline().c_str(),
+        tag.Plot().c_str(), tag.OriginalTitle().c_str(),
+        CPVREpgInfoTag::DeTokenize(tag.Cast()).c_str(),
         CPVREpgInfoTag::DeTokenize(tag.Directors()).c_str(),
         CPVREpgInfoTag::DeTokenize(tag.Writers()).c_str(), tag.Year(), tag.IMDBNumber().c_str(),
         tag.ClientIconPath().c_str(), tag.GenreType(), tag.GenreSubType(),

--- a/xbmc/pvr/epg/EpgDatabase.h
+++ b/xbmc/pvr/epg/EpgDatabase.h
@@ -66,7 +66,7 @@ public:
    * @brief Get the minimal database version that is required to operate correctly.
    * @return The minimal database version.
    */
-  int GetSchemaVersion() const override { return 21; }
+  int GetSchemaVersion() const override { return 22; }
 
   /*!
    * @brief Get the default sqlite database filename.

--- a/xbmc/pvr/epg/test/CMakeLists.txt
+++ b/xbmc/pvr/epg/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(SOURCES TestEpgDatabase.cpp)
+set(HEADERS)
+
+core_add_test_library(pvrepg_test)

--- a/xbmc/pvr/epg/test/TestEpgDatabase.cpp
+++ b/xbmc/pvr/epg/test/TestEpgDatabase.cpp
@@ -1,0 +1,176 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "ServiceBroker.h"
+#include "XBDateTime.h"
+#include "dbwrappers/Database.h"
+#include "filesystem/SpecialProtocol.h"
+#include "pvr/epg/EpgDatabase.h"
+#include "pvr/epg/EpgInfoTag.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
+#include "utils/StringUtils.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+using namespace PVR;
+
+namespace
+{
+
+constexpr int EPG_ID = 1;
+constexpr unsigned int BROADCAST_UID = 4242;
+constexpr unsigned int PERSISTED_BROADCAST_UID = 4243;
+
+// Past the unsigned 32-bit ceiling of 2106-02-07, and so past the signed one of 2038-01-19 as
+// well: a value this size survives neither width, whichever way it is converted.
+constexpr int64_t START = 7258114800; // 2199-12-31 23:00:00 UTC
+constexpr int64_t END = 7258118400; // 2200-01-01 00:00:00 UTC
+
+// the persisted tag gets its own slot, because (idEpg, iStartTime) is unique and a REPLACE on the
+// seeded row would delete it
+constexpr int64_t PERSISTED_START = START + 7200;
+constexpr int64_t PERSISTED_END = END + 7200;
+
+class TestEpgDatabase : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // the tag constructor shifts by this and the read path does not, so the round trip through
+    // the database is an identity only at zero
+    auto& correction{
+        CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection};
+    m_savedTimeCorrection = correction;
+    correction = 0;
+
+    DatabaseSettings settings;
+    settings.type = "sqlite3";
+    settings.host = CSpecialProtocol::TranslatePath("special://temp/");
+
+    m_database = std::make_shared<CPVREpgDatabase>();
+    ASSERT_EQ(CDatabase::ConnectionState::STATE_CONNECTED,
+              m_database->Connect("TestEpgDatabase", settings, true));
+
+    // the database file outlives a single test, and a test that persists a tag leaves it behind,
+    // so start every one of them from the same single row
+    ASSERT_TRUE(m_database->ExecuteQuery("DELETE FROM epgtags;"));
+
+    // inserted directly, so that a read can be tested without depending on the write
+    ASSERT_TRUE(m_database->ExecuteQuery(
+        StringUtils::Format("REPLACE INTO epgtags (idEpg, iBroadcastUid, iStartTime, iEndTime, "
+                            "sTitle) VALUES ({}, {}, {}, {}, 'Far Future Programme');",
+                            EPG_ID, BROADCAST_UID, START, END)));
+  }
+
+  void TearDown() override
+  {
+    CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()->m_iPVRTimeCorrection =
+        m_savedTimeCorrection;
+  }
+
+  std::shared_ptr<CPVREpgDatabase> m_database;
+
+private:
+  int m_savedTimeCorrection{0};
+};
+
+// A count of seconds is the assertion, not a rendered date: CDateTime renders through gmtime_r on
+// POSIX, which is bound to time_t. The rendering is worth printing when one fails, though, since
+// it names the year.
+std::string AsText(const CDateTime& value)
+{
+  return value.IsValid() ? value.GetAsDBDateTime() : "invalid";
+}
+
+} // unnamed namespace
+
+/*!
+ The column holds a 64-bit count, so a far future time reads back as stored.
+ */
+TEST_F(TestEpgDatabase, ATagKeepsAFarFutureTime)
+{
+  const std::shared_ptr<CPVREpgInfoTag> tag{
+      m_database->GetEpgTagByUniqueBroadcastID(EPG_ID, BROADCAST_UID)};
+
+  ASSERT_NE(nullptr, tag);
+  EXPECT_EQ(END, tag->EndAsUTC().GetAsSecondsSinceEpoch()) << AsText(tag->EndAsUTC());
+  EXPECT_EQ(START, tag->StartAsUTC().GetAsSecondsSinceEpoch()) << AsText(tag->StartAsUTC());
+}
+
+/*!
+ The write is the other half: a tag persisted with a far future time reads back as itself.
+ */
+TEST_F(TestEpgDatabase, APersistedTagKeepsAFarFutureTime)
+{
+  CPVREpgInfoTag written{nullptr, EPG_ID, CDateTime::FromSecondsSinceEpoch(PERSISTED_START),
+                         CDateTime::FromSecondsSinceEpoch(PERSISTED_END), false};
+  written.SetUniqueBroadcastID(PERSISTED_BROADCAST_UID);
+
+  ASSERT_TRUE(m_database->QueuePersistQuery(written));
+  ASSERT_TRUE(m_database->CommitInsertQueries());
+
+  const std::shared_ptr<CPVREpgInfoTag> read{
+      m_database->GetEpgTagByUniqueBroadcastID(EPG_ID, PERSISTED_BROADCAST_UID)};
+
+  ASSERT_NE(nullptr, read);
+  EXPECT_EQ(PERSISTED_END, read->EndAsUTC().GetAsSecondsSinceEpoch()) << AsText(read->EndAsUTC());
+  EXPECT_EQ(PERSISTED_START, read->StartAsUTC().GetAsSecondsSinceEpoch())
+      << AsText(read->StartAsUTC());
+}
+
+/*!
+ A far future time is written into a query at the width the column holds, so it selects the row it
+ names rather than one an overflow landed on.
+ */
+TEST_F(TestEpgDatabase, ATagIsFoundByAFarFutureStartTime)
+{
+  const std::shared_ptr<CPVREpgInfoTag> tag{
+      m_database->GetEpgTagByStartTime(EPG_ID, CDateTime::FromSecondsSinceEpoch(START))};
+
+  ASSERT_NE(nullptr, tag);
+  EXPECT_EQ(END, tag->EndAsUTC().GetAsSecondsSinceEpoch()) << AsText(tag->EndAsUTC());
+}
+
+/*!
+ The guide window is sized from the last end time.
+ */
+TEST_F(TestEpgDatabase, TheLastEndTimeIsNotWrapped)
+{
+  const CDateTime last{m_database->GetLastEndTime(EPG_ID)};
+
+  EXPECT_EQ(END, last.GetAsSecondsSinceEpoch()) << AsText(last);
+}
+
+TEST_F(TestEpgDatabase, TheFirstAndLastDatesAreNotWrapped)
+{
+  const auto [first, last] = m_database->GetFirstAndLastEPGDate();
+
+  EXPECT_EQ(START, first.GetAsSecondsSinceEpoch()) << AsText(first);
+  EXPECT_EQ(END, last.GetAsSecondsSinceEpoch()) << AsText(last);
+}
+
+TEST_F(TestEpgDatabase, TheMaxEndTimeIsNotWrapped)
+{
+  const CDateTime maxEnd{
+      m_database->GetMaxEndTime(EPG_ID, CDateTime::FromSecondsSinceEpoch(END + 1))};
+
+  EXPECT_EQ(END, maxEnd.GetAsSecondsSinceEpoch()) << AsText(maxEnd);
+}
+
+TEST_F(TestEpgDatabase, TheMinStartTimeIsNotWrapped)
+{
+  const CDateTime minStart{
+      m_database->GetMinStartTime(EPG_ID, CDateTime::FromSecondsSinceEpoch(START - 1))};
+
+  EXPECT_EQ(START, minStart.GetAsSecondsSinceEpoch()) << AsText(minStart);
+}

--- a/xbmc/test/TestDateTime.cpp
+++ b/xbmc/test/TestDateTime.cpp
@@ -14,6 +14,7 @@
 #include "resources/ResourcesComponent.h"
 
 #include <array>
+#include <cstdint>
 #include <iostream>
 
 #include <gtest/gtest.h>
@@ -668,6 +669,53 @@ TEST_F(TestDateTime, GetAsTime)
   dateTime.GetAsTime(time);
 
   EXPECT_TRUE(dateTime == time);
+}
+
+//! \brief Whether a rendered date can name the times below. CDateTime renders through gmtime_r on
+//! POSIX, so a 32-bit time_t cannot reach either of them, and only the round trip is assertable.
+constexpr bool RENDERS_BEYOND_32_BITS{sizeof(time_t) >= 8};
+
+TEST_F(TestDateTime, SecondsSinceEpoch)
+{
+  // 2200-01-01 00:00:00 UTC, past the unsigned 32-bit ceiling of 2106-02-07
+  constexpr int64_t seconds{7258118400};
+
+  const CDateTime dateTime{CDateTime::FromSecondsSinceEpoch(seconds)};
+
+  EXPECT_TRUE(dateTime.IsValid());
+  EXPECT_EQ(seconds, dateTime.GetAsSecondsSinceEpoch());
+
+  if constexpr (RENDERS_BEYOND_32_BITS)
+  {
+    EXPECT_EQ("2200-01-01 00:00:00", dateTime.GetAsDBDateTime());
+  }
+}
+
+TEST_F(TestDateTime, SecondsSinceEpochOutOfRange)
+{
+  // a count read out of a database column can be anything, and one this size overflows the
+  // conversion rather than naming a time
+  EXPECT_FALSE(CDateTime::FromSecondsSinceEpoch(9000000000000000000).IsValid());
+  EXPECT_FALSE(CDateTime::FromSecondsSinceEpoch(-9000000000000000000).IsValid());
+
+  // the ends of the range the conversion does hold
+  EXPECT_TRUE(CDateTime::FromSecondsSinceEpoch(-11644473600).IsValid());
+  EXPECT_TRUE(CDateTime::FromSecondsSinceEpoch(910692730085).IsValid());
+}
+
+TEST_F(TestDateTime, SecondsSinceEpochBeforeTheEpoch)
+{
+  constexpr int64_t seconds{-2208988800}; // 1900-01-01 00:00:00 UTC
+
+  const CDateTime dateTime{CDateTime::FromSecondsSinceEpoch(seconds)};
+
+  EXPECT_TRUE(dateTime.IsValid());
+  EXPECT_EQ(seconds, dateTime.GetAsSecondsSinceEpoch());
+
+  if constexpr (RENDERS_BEYOND_32_BITS)
+  {
+    EXPECT_EQ("1900-01-01 00:00:00", dateTime.GetAsDBDateTime());
+  }
 }
 
 TEST_F(TestDateTime, GetAsTm)


### PR DESCRIPTION
**TL;DR:** Bug fix. The EPG database wrote its time columns as unsigned 32-bit and read them back signed, so a time from 2038-01-19 came back negative and one from 2106-02-08 came back as a small positive. Both directions are now 64-bit, which on MySQL needs the columns widened too.

## Description
`CPVREpgDatabase` stores `iStartTime` / `iEndTime` as a count of seconds. They were written with `%u` and read back signed — through `get_asInt()` when a tag is built, and through `std::atoi` in `GetLastEndTime`, `GetFirstAndLastEPGDate`, `GetMinStartTime` and `GetMaxEndTime`. A time from 2038-01-19 03:14:08 UTC read back negative; one from 2106-02-08 wrapped to a small positive. Either way the tag landed on a nonsense date.

Three things were needed to fix it properly, and only the first was obvious:

**The read and write widths.** Both directions now go through one pair of helpers, so they cannot drift apart again.

**The MySQL schema.** `iStartTime` / `iEndTime` are declared `integer`, which is 32 bits on MySQL, so a far-future write is not merely narrowed — on a strict server it fails outright with `ERROR 1264 Out of range value`, and on a non-strict one it clamps. Widening the read alone fixes nothing there. Schema 22 alters both columns to `bigint`. SQLite's `integer` is already 64 bits and it has no `ALTER TABLE ... MODIFY`, so the migration is guarded on the backend. A row clamped by an earlier version keeps its clamped time until cleanup passes it; nothing here repairs one.

**`time_t`.** Converting through it discards the same range on targets where it is 32 bits, so `CDateTime` gains `FromSecondsSinceEpoch()` and `GetAsSecondsSinceEpoch()` and nothing on either side of a time column goes through `time_t` now.

On what that last point does **not** buy, so nobody has to take the claim on trust: a 32-bit-`time_t` target is not fixed by this. `EPG_TAG` carries `time_t` across the binary add-on ABI, so the value is already gone before it reaches the database, and `FileTimeToSystemTime()` on POSIX renders through `gmtime_r`, so it is gone again on the way out. Both ends of that chain are outside this change. Worth noting for whoever picks that up: the forward conversion already has a `timegm64` branch for 32-bit Android (`xbmc/platform/posix/XTimeUtils.cpp`), and the reverse has no matching `gmtime64_r` one. The value here is on 64-bit targets, where the whole chain is now correct, plus a storage boundary that no longer narrows for no reason.

Two smaller consequences, both deliberate:

- `FromSecondsSinceEpoch()` rejects a count it cannot represent instead of overflowing on it. The column is 64 bits wide now and its content reaches the conversion unclipped, where the old 32-bit read left nothing out of range.
- An invalid `CDateTime` used to reach SQL as `1240428288` — 2009-04-22 — so `DeleteEpgTags()` with an invalid `maxEndTime` deleted every tag before that date. It now reaches SQL as a pre-epoch value and matches nothing. No caller passes one either way.

## Motivation and context
Not reachable from today's schedules, but an EPG with a far-future entry — some providers publish placeholder end times — hits it now, and every guide hits it in 2038. The failure is silent: the tag simply appears at the wrong date.

On SQLite the value was stored correctly and only the read was narrow, so a migrated database repairs itself for the 2038–2106 range. On MySQL it was never stored correctly in the first place.

## How has this been tested?
Built on Windows x64 (VS 2022). Full `kodi-test` suite: 4096 tests in 322 suites, all passing.

Adds `xbmc/pvr/epg/test/TestEpgDatabase.cpp` in a new test directory, covering a round trip past 2038 through the affected getters, the persist path, and a lookup by a far-future start time. The times it uses sit past the **unsigned** 32-bit ceiling as well as the signed one, so a narrowing on either side of the column moves them — with the earlier sub-2³² values, reverting the write half left the suite green. Verified by reintroducing only the write-side narrowing: five of the seven cases fail.

The assertions compare counts of seconds rather than rendered dates, because `CDateTime` renders through `gmtime_r` on POSIX and a rendered date could not be asserted on a 32-bit-`time_t` target. `TestDateTime` pins the absolute dates instead, guarded on `sizeof(time_t)`.

`TestVPrepare` gains 64-bit format cases on both backends, including a literal `%%` between two `%lld` — the shape the escaping pass steps over two characters at a time.

The MySQL migration cannot be reached from CI, so it was run by hand against `mysql:8.0.45` on a table built to the real v21 schema: the pre-fix write fails with `ERROR 1264` under stock strict mode, `ALTER TABLE epgtags MODIFY iStartTime bigint` succeeds and preserves the primary key and both indexes including the unique one on `iStartTime DESC`, and a post-migration far-future value stores, reads back and survives `MAX()` intact.

## What is the effect on users?
An EPG entry with a time beyond 2038 is stored and read back correctly instead of appearing at a nonsense date. On MySQL such an entry can be stored at all, which it previously could not.

First start after upgrading copies the EPG database to `Epg22`, as any schema bump does. For SQLite that copy is the whole cost, since the migration itself is a no-op there.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
