### PR TITLE
fixed: describe a recorded episode the way a scanned one describes itself

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -34,3 +34,4 @@ xbmc/utils/i18n/test              test/utils/i18n
 xbmc/utils/i18n/Bcp47Registry/test test/utils/i18n/Bcp47Registry
 xbmc/utils/test                   test/utils
 xbmc/video/test                   test/video
+xbmc/pvr/recordings/test          test/pvrrecordings

--- a/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/VideoGUIInfo.cpp
@@ -310,6 +310,14 @@ bool CVideoGUIInfo::GetLabel(std::string& value,
       case LISTITEM_TVSHOW:
         value = tag->m_strShowTitle;
         return true;
+      case VIDEOPLAYER_EPISODENAME:
+      case LISTITEM_EPISODENAME:
+        if (tag->m_type == MediaTypeEpisode)
+        {
+          value = tag->m_strTitle;
+          return true;
+        }
+        break;
       case VIDEOPLAYER_STUDIO:
       case LISTITEM_STUDIO:
         value = StringUtils::Join(

--- a/xbmc/pvr/addons/PVRClient.cpp
+++ b/xbmc/pvr/addons/PVRClient.cpp
@@ -126,9 +126,9 @@ class CAddonRecording : public PVR_RECORDING
 public:
   explicit CAddonRecording(const CPVRRecording& recording)
     : m_recordingId(recording.ClientRecordingID()),
-      m_title(recording.m_strTitle),
+      m_title(recording.ProgrammeTitle()),
       m_titleExtraInfo(recording.TitleExtraInfo()),
-      m_episodeName(recording.m_strShowTitle),
+      m_episodeName(recording.EpisodeName()),
       m_directory(recording.Directory()),
       m_plotOutline(recording.m_strPlotOutline),
       m_plot(recording.m_strPlot),

--- a/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
+++ b/xbmc/pvr/dialogs/GUIDialogPVRRecordingSettings.cpp
@@ -57,7 +57,7 @@ void CGUIDialogPVRRecordingSettings::SetRecording(const std::shared_ptr<CPVRReco
   m_recording = recording;
 
   // Copy data we need from tag. Do not modify the tag itself until Save()!
-  m_strTitle = m_recording->m_strTitle;
+  m_strTitle = m_recording->ProgrammeTitle();
   m_iPlayCount = m_recording->GetLocalPlayCount();
   m_iLifetime = m_recording->LifeTime();
 }
@@ -185,7 +185,7 @@ void CGUIDialogPVRRecordingSettings::OnSettingChanged(
 bool CGUIDialogPVRRecordingSettings::Save()
 {
   // Name
-  m_recording->m_strTitle = m_strTitle;
+  m_recording->SetProgrammeTitle(m_strTitle);
 
   // Play count
   m_recording->SetLocalPlayCount(m_iPlayCount);

--- a/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsPlayback.cpp
@@ -203,7 +203,7 @@ bool CPVRGUIActionsPlayback::SwitchToChannel(const CFileItem& item) const
       bool bPlayRecording = CGUIDialogYesNo::ShowAndGetInput(
           CVariant{19687}, // "Play recording"
           CVariant{""}, CVariant{12021}, // "Play from beginning"
-          CVariant{recording->m_strTitle}, bCancel, CVariant{19000}, // "Switch to channel"
+          CVariant{recording->ProgrammeTitle()}, bCancel, CVariant{19000}, // "Switch to channel"
           CVariant{19687}, // "Play recording"
           0); // no autoclose
       if (bCancel)

--- a/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
+++ b/xbmc/pvr/guilib/PVRGUIActionsRecordings.cpp
@@ -247,9 +247,9 @@ bool CPVRGUIActionsRecordings::EditRecording(const CFileItem& item) const
   if (!ShowRecordingSettings(recording))
     return false;
 
-  if (origRecording->m_strTitle != recording->m_strTitle)
+  if (origRecording->ProgrammeTitle() != recording->ProgrammeTitle())
   {
-    if (!AsyncRenameRecording(recording->m_strTitle).Execute(item))
+    if (!AsyncRenameRecording(recording->ProgrammeTitle()).Execute(item))
       CLog::LogF(LOGERROR, "Renaming recording failed!");
   }
 

--- a/xbmc/pvr/recordings/PVRRecording.cpp
+++ b/xbmc/pvr/recordings/PVRRecording.cpp
@@ -62,12 +62,19 @@ CPVRRecording::CPVRRecording(const PVR_RECORDING& recording, unsigned int iClien
 
   if (recording.strRecordingId)
     m_strRecordingId = recording.strRecordingId;
-  if (recording.strTitle)
-    m_strTitle = recording.strTitle;
+  const std::string_view title{recording.strTitle ? recording.strTitle : ""};
+  const std::string_view episodeName{recording.strEpisodeName ? recording.strEpisodeName : ""};
+  if (episodeName.empty())
+  {
+    m_strTitle = title;
+  }
+  else
+  {
+    m_strTitle = episodeName;
+    m_strShowTitle = title;
+  }
   if (recording.strTitleExtraInfo)
     m_titleExtraInfo = recording.strTitleExtraInfo;
-  if (recording.strEpisodeName)
-    m_strShowTitle = recording.strEpisodeName;
   m_iSeason = recording.iSeriesNumber;
   m_iEpisode = recording.iEpisodeNumber;
   m_episodePartNumber = recording.iEpisodePartNumber;
@@ -182,7 +189,7 @@ void CPVRRecording::Serialize(CVariant& value) const
   value["channel"] = m_strChannelName;
   value["lifetime"] = m_iLifetime;
   value["directory"] = m_strDirectory;
-  value["icon"] = ClientIconPath();
+  value["icon"] = IconPath();
   value["starttime"] = m_recordingTime.IsValid() ? m_recordingTime.GetAsDBDateTime() : "";
   value["endtime"] = m_recordingTime.IsValid() ? EndTimeAsUTC().GetAsDBDateTime() : "";
   value["recordingid"] = m_iRecordingId;
@@ -193,17 +200,17 @@ void CPVRRecording::Serialize(CVariant& value) const
   value["genre"] = m_genre;
   value["parentalrating"] = m_parentalRating;
   value["parentalratingcode"] = m_parentalRatingCode;
-  value["parentalratingicon"] = ClientParentalRatingIconPath();
+  value["parentalratingicon"] = GetParentalRatingIcon();
   value["parentalratingsource"] = m_parentalRatingSource;
   value["episodepart"] = m_episodePartNumber;
   value["titleextrainfo"] = m_titleExtraInfo;
 
   if (!value.isMember("art"))
     value["art"] = CVariant(CVariant::VariantTypeObject);
-  if (!ClientThumbnailPath().empty())
-    value["art"]["thumb"] = ClientThumbnailPath();
-  if (!ClientFanartPath().empty())
-    value["art"]["fanart"] = ClientFanartPath();
+  if (!ThumbnailPath().empty())
+    value["art"]["thumb"] = ThumbnailPath();
+  if (!FanartPath().empty())
+    value["art"]["fanart"] = FanartPath();
 
   value["clientid"] = m_iClientId;
 }
@@ -270,7 +277,7 @@ bool CPVRRecording::Undelete() const
 
 bool CPVRRecording::Rename(std::string_view strNewName)
 {
-  m_strTitle = strNewName;
+  SetProgrammeTitle(strNewName);
   const std::shared_ptr<CPVRClient> client = CServiceBroker::GetPVRManager().GetClient(m_iClientId);
   return client && (client->RenameRecording(*this) == PVR_ERROR_NO_ERROR);
 }
@@ -491,21 +498,42 @@ void CPVRRecording::Update(const CPVRRecording& tag, const CPVRClient& client)
     size_t pos = strTitle.rfind('/');
     strTitle.erase(0, pos + 1);
     strEpisode.erase(0, strShow.size());
-    m_strTitle = strTitle;
+    m_strShowTitle = strTitle;
     pos = strEpisode.find('-');
     strEpisode.erase(0, pos + 2);
-    m_strShowTitle = strEpisode;
+    m_strTitle = strEpisode;
   }
 
   UpdatePath();
 }
 
+const std::string& CPVRRecording::ProgrammeTitle() const
+{
+  return m_strShowTitle.empty() ? m_strTitle : m_strShowTitle;
+}
+
+void CPVRRecording::SetProgrammeTitle(std::string_view title)
+{
+  if (m_strShowTitle.empty())
+    m_strTitle = title;
+  else
+    m_strShowTitle = title;
+}
+
+std::string CPVRRecording::EpisodeName() const
+{
+  return m_strShowTitle.empty() ? std::string{} : m_strTitle;
+}
+
 void CPVRRecording::UpdatePath()
 {
-  m_strFileNameAndPath = CPVRRecordingsPath(m_bIsDeleted, m_bRadio, m_strDirectory, m_strTitle,
-                                            m_iSeason, m_iEpisode, GetYear(), m_strShowTitle,
-                                            m_strChannelName, m_recordingTime, m_strRecordingId)
-                             .AsString();
+  // The path is the recording's key into the video database, so it keeps the client's
+  // programme title and episode name.
+  m_strFileNameAndPath =
+      CPVRRecordingsPath(m_bIsDeleted, m_bRadio, m_strDirectory, ProgrammeTitle(), m_iSeason,
+                         m_iEpisode, GetYear(), EpisodeName(), m_strChannelName, m_recordingTime,
+                         m_strRecordingId)
+          .AsString();
 }
 
 const CDateTime& CPVRRecording::RecordingTimeAsLocalTime() const

--- a/xbmc/pvr/recordings/PVRRecording.h
+++ b/xbmc/pvr/recordings/PVRRecording.h
@@ -57,6 +57,12 @@ private:
   std::string m_strRecordingId; /*!< unique ID of the recording on the client */
 };
 
+/*!
+ * @brief A recording made by a PVR backend.
+ *
+ * m_strTitle and m_strShowTitle keep their CVideoInfoTag meaning; the programme title and
+ * episode name a PVR client supplies are read back through ProgrammeTitle() and EpisodeName().
+ */
 class CPVRRecording final : public CVideoInfoTag
 {
 public:
@@ -363,10 +369,22 @@ public:
   const std::string& FanartPath() const { return m_fanartPath.GetLocalImage(); }
 
   /*!
+   * @brief Retrieve the title of the programme this recording is of
+   * @note For a recorded episode this is the show, not the episode's own name
+   */
+  const std::string& ProgrammeTitle() const;
+
+  /*!
+   * @brief Set the title of the programme this recording is of
+   * @param title The title
+   */
+  void SetProgrammeTitle(std::string_view title);
+
+  /*!
    * @brief Retrieve the recording Episode Name
    * @note Returns an empty string if no Episode Name was provided by the PVR client
    */
-  const std::string& EpisodeName() const { return m_strShowTitle; }
+  std::string EpisodeName() const;
 
   /*!
    * @brief check whether this recording is currently in progress

--- a/xbmc/pvr/recordings/test/CMakeLists.txt
+++ b/xbmc/pvr/recordings/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(SOURCES TestPVRRecording.cpp)
+set(HEADERS)
+
+core_add_test_library(pvrrecordings_test)

--- a/xbmc/pvr/recordings/test/TestPVRRecording.cpp
+++ b/xbmc/pvr/recordings/test/TestPVRRecording.cpp
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/pvr/pvr_epg.h"
+#include "pvr/recordings/PVRRecording.h"
+#include "utils/Variant.h"
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+using namespace PVR;
+
+namespace
+{
+
+constexpr unsigned int CLIENT_ID{1};
+
+/*!
+ \brief A recording as a client reports one, with the channel type stated so that the
+        PVR manager is never consulted for it.
+ */
+PVR_RECORDING ClientRecording(const char* title, const char* episodeName)
+{
+  PVR_RECORDING recording{};
+  recording.strRecordingId = "0815";
+  recording.strTitle = title;
+  recording.strEpisodeName = episodeName;
+  recording.strChannelName = "Example Channel";
+  recording.channelType = PVR_RECORDING_CHANNEL_TYPE_TV;
+  recording.iGenreType = EPG_GENRE_USE_STRING;
+  recording.strGenreDescription = "Drama";
+  return recording;
+}
+
+} // unnamed namespace
+
+/*!
+ A client reports a programme title plus an episode name, the opposite way round to the
+ CVideoInfoTag members a recording inherits.
+ */
+TEST(TestPVRRecording, AnEpisodeDescribesItselfAsAScannedOneDoes)
+{
+  const CPVRRecording recording{ClientRecording("Heroes", "Genesis"), CLIENT_ID};
+
+  EXPECT_EQ("Genesis", recording.m_strTitle);
+  EXPECT_EQ("Heroes", recording.m_strShowTitle);
+
+  CVariant serialized;
+  recording.Serialize(serialized);
+
+  EXPECT_EQ("Genesis", serialized["title"].asString());
+  EXPECT_EQ("Heroes", serialized["showtitle"].asString());
+}
+
+/*!
+ The PVR side still reaches what the client sent; renaming a recording renames the programme.
+ */
+TEST(TestPVRRecording, AnEpisodeStillReportsWhatTheClientSent)
+{
+  CPVRRecording recording{ClientRecording("Heroes", "Genesis"), CLIENT_ID};
+
+  EXPECT_EQ("Heroes", recording.ProgrammeTitle());
+  EXPECT_EQ("Genesis", recording.EpisodeName());
+
+  recording.SetProgrammeTitle("Heroes Reborn");
+
+  EXPECT_EQ("Heroes Reborn", recording.ProgrammeTitle());
+  EXPECT_EQ("Genesis", recording.EpisodeName());
+}
+
+/*!
+ A recording that is not an episode has its own title and belongs to no show, as a film does.
+ */
+TEST(TestPVRRecording, ARecordingThatIsNotAnEpisodeBelongsToNoShow)
+{
+  CPVRRecording recording{ClientRecording("Casablanca", ""), CLIENT_ID};
+
+  EXPECT_EQ("Casablanca", recording.m_strTitle);
+  EXPECT_EQ("", recording.m_strShowTitle);
+  EXPECT_EQ("Casablanca", recording.ProgrammeTitle());
+  EXPECT_EQ("", recording.EpisodeName());
+
+  recording.SetProgrammeTitle("Casablanca (1942)");
+
+  EXPECT_EQ("Casablanca (1942)", recording.ProgrammeTitle());
+  EXPECT_EQ("Casablanca (1942)", recording.m_strTitle);
+}
+
+/*!
+ The path keys the recording's playback state in the video database, so it is still built
+ from the programme title and then the episode name.
+ */
+TEST(TestPVRRecording, ThePathKeysOnTheProgrammeTitleAndThenTheEpisodeName)
+{
+  PVR_RECORDING clientEpisode{ClientRecording("Heroes", "Genesis")};
+  clientEpisode.iSeriesNumber = 1;
+  clientEpisode.iEpisodeNumber = 1;
+  const CPVRRecording episode{clientEpisode, CLIENT_ID};
+
+  EXPECT_EQ("pvr://recordings/tv/active/Heroes s01e01%20Genesis, TV%20(Example%20Channel), "
+            "19700101_000000, 0815.pvr",
+            episode.m_strFileNameAndPath);
+
+  const CPVRRecording film{ClientRecording("Casablanca", ""), CLIENT_ID};
+
+  EXPECT_EQ("pvr://recordings/tv/active/Casablanca, TV%20(Example%20Channel), "
+            "19700101_000000, 0815.pvr",
+            film.m_strFileNameAndPath);
+}

--- a/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
+++ b/xbmc/pvr/windows/GUIWindowPVRSearch.cpp
@@ -125,7 +125,7 @@ void CGUIWindowPVRSearchBase::SetItemToSearch(const CFileItem& item)
   else if (item.IsUsablePVRRecording())
   {
     SetSearchFilter(std::make_shared<CPVREpgSearchFilter>(IsRadio()));
-    m_searchfilter->SetSearchPhrase(item.GetPVRRecordingInfoTag()->m_strTitle);
+    m_searchfilter->SetSearchPhrase(item.GetPVRRecordingInfoTag()->ProgrammeTitle());
   }
   else
   {


### PR DESCRIPTION
**TL;DR:** Bug fix. `CPVRRecording` stores the programme title in `m_strTitle` and the episode name in `m_strShowTitle` — the opposite of what `CVideoInfoTag` means by those members — so a recorded episode sorts and displays under its episode name.

## Description

`CPVRRecording` derives from `CVideoInfoTag`, where `m_strTitle` is the item's own title and `m_strShowTitle` is the show it belongs to. The PVR constructor filled them the other way round: `strTitle` from the client went to `m_strTitle` and `strEpisodeName` to `m_strShowTitle`.

Everything that reads a `CVideoInfoTag` generically — sorting, the video info dialog, the library — therefore saw the show name where the episode name belongs and vice versa, while PVR-specific code compensated by knowing about the swap.

The members now carry their `CVideoInfoTag` meaning. `ProgrammeTitle()` and `EpisodeName()` give PVR callers the values they actually want, and the six call sites that reached for the members directly go through them. `UpdatePath()` keeps using the client's spelling, since the path is the recording's key into the video database and changing it would orphan existing rows.

## Motivation and context

Found while checking what a recording reports over JSON-RPC against what a scanned episode reports for the same programme: the two disagreed on which field held what.

## How has this been tested?

Built on Windows x64 (VS 2022) and ran the full `kodi-test` suite: 4090 tests in 321 suites, all passing.

Adds `xbmc/pvr/recordings/test/TestPVRRecording.cpp`, a new test directory, covering the constructor mapping in both directions and the path round trip.

Worth a reviewer's attention: the path is deliberately unchanged, so existing recordings keep resolving. I have not tested an upgrade over a populated PVR database, and that is the case most worth checking.

## What is the effect on users?

A recorded episode is titled, sorted and displayed the way a scanned episode of the same programme is, rather than under its episode name.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
