### PR TITLE
[Music] Support ReplayGain for Matroska Files

### DIFF
--- a/xbmc/music/tags/MatroskaTagMapping.cpp
+++ b/xbmc/music/tags/MatroskaTagMapping.cpp
@@ -9,6 +9,7 @@
 #include "MatroskaTagMapping.h"
 
 #include "MusicInfoTag.h"
+#include "ReplayGain.h"
 #include "utils/StringUtils.h"
 
 #include <algorithm>
@@ -110,6 +111,18 @@ void MUSIC_INFO::MatroskaTagMapping::MapTag(const std::string& key,
                                             const std::string& musicsep,
                                             CMusicInfoTag& tag)
 {
+  if (key == "REPLAYGAIN_GAIN" || key == "REPLAYGAIN_PEAK")
+  {
+    const ReplayGain::Type type =
+        level == TagLevel::Album ? ReplayGain::Type::ALBUM : ReplayGain::Type::TRACK;
+    ReplayGain replayGain = tag.GetReplayGain();
+    if (key == "REPLAYGAIN_GAIN")
+      replayGain.ParseGain(type, value);
+    else
+      replayGain.ParsePeak(type, value);
+    tag.SetReplayGain(replayGain);
+    return;
+  }
   /*!
   * The names whose field the level decides. Everything else means the same thing wherever it
   * sits, and a caller applies album level tags before track level ones so that a song naming

--- a/xbmc/music/tags/test/TestMatroskaTagMapping.cpp
+++ b/xbmc/music/tags/test/TestMatroskaTagMapping.cpp
@@ -389,3 +389,80 @@ TEST(TestMatroskaTagMapping, SurvivesNonNumericTrackAndDiscNumbers)
     EXPECT_EQ(Parse("DISCNUMBER", "").GetDiscNumber(), 0);
   });
 }
+
+/*!
+  * Matroska carries ReplayGain as REPLAYGAIN_GAIN / REPLAYGAIN_PEAK and lets the target type level
+  * say whether the figure is the track's or the album's - the same split TITLE and ARTIST get. This
+  * is what foobar2000 and rsgain write.
+  */
+TEST(TestMatroskaTagMapping, MapsReplayGainAgainstItsLevel)
+{
+  constexpr auto album = MatroskaTagMapping::TagLevel::Album;
+  constexpr auto track = MatroskaTagMapping::TagLevel::Track;
+
+  // A GAIN carries only one slot; a PEAK only the matching one.
+  EXPECT_FLOAT_EQ(
+      Parse("REPLAYGAIN_GAIN", "-7.89 dB", album).GetReplayGain().Get(ReplayGain::ALBUM).Gain(),
+      -7.89f);
+  EXPECT_FALSE(
+      Parse("REPLAYGAIN_GAIN", "-7.89 dB", album).GetReplayGain().Get(ReplayGain::TRACK).HasGain());
+
+  EXPECT_FLOAT_EQ(
+      Parse("REPLAYGAIN_GAIN", "-6.94 dB", track).GetReplayGain().Get(ReplayGain::TRACK).Gain(),
+      -6.94f);
+  EXPECT_FALSE(
+      Parse("REPLAYGAIN_GAIN", "-6.94 dB", track).GetReplayGain().Get(ReplayGain::ALBUM).HasGain());
+
+  EXPECT_FLOAT_EQ(
+      Parse("REPLAYGAIN_PEAK", "0.988", album).GetReplayGain().Get(ReplayGain::ALBUM).Peak(),
+      0.988f);
+  EXPECT_FLOAT_EQ(
+      Parse("REPLAYGAIN_PEAK", "0.976", track).GetReplayGain().Get(ReplayGain::TRACK).Peak(),
+      0.976f);
+}
+
+/*!
+  * The four tags arrive one at a time and each has to keep what the others wrote - a fresh
+  * ReplayGain per tag would leave only the last pair. atof stops at the trailing " dB".
+  */
+TEST(TestMatroskaTagMapping, TakesTrackAndAlbumReplayGainFromTheSameFile)
+{
+  constexpr auto album = MatroskaTagMapping::TagLevel::Album;
+  constexpr auto track = MatroskaTagMapping::TagLevel::Track;
+
+  CMusicInfoTag tag;
+  MatroskaTagMapping::MapTag("REPLAYGAIN_GAIN", "-6.94 dB", track, Separators, MusicSep, tag);
+  MatroskaTagMapping::MapTag("REPLAYGAIN_PEAK", "0.976", track, Separators, MusicSep, tag);
+  MatroskaTagMapping::MapTag("REPLAYGAIN_GAIN", "-7.89 dB", album, Separators, MusicSep, tag);
+  MatroskaTagMapping::MapTag("REPLAYGAIN_PEAK", "0.988", album, Separators, MusicSep, tag);
+
+  const ReplayGain& rg = tag.GetReplayGain();
+  ASSERT_TRUE(rg.Get(ReplayGain::TRACK).Valid());
+  ASSERT_TRUE(rg.Get(ReplayGain::ALBUM).Valid());
+  EXPECT_FLOAT_EQ(rg.Get(ReplayGain::TRACK).Gain(), -6.94f);
+  EXPECT_FLOAT_EQ(rg.Get(ReplayGain::TRACK).Peak(), 0.976f);
+  EXPECT_FLOAT_EQ(rg.Get(ReplayGain::ALBUM).Gain(), -7.89f);
+  EXPECT_FLOAT_EQ(rg.Get(ReplayGain::ALBUM).Peak(), 0.988f);
+}
+
+/*!
+  * A file that carries ReplayGain with no target level - older foobar2000 - is read as the track's.
+  */
+TEST(TestMatroskaTagMapping, ReadsUntargetedReplayGainAsTheTracks)
+{
+  constexpr auto file = MatroskaTagMapping::TagLevel::File;
+  EXPECT_FLOAT_EQ(
+      Parse("REPLAYGAIN_GAIN", "-6.94 dB", file).GetReplayGain().Get(ReplayGain::TRACK).Gain(),
+      -6.94f);
+}
+
+/*!
+  * ReplayGain is one of the names whose field the level decides, so it belongs with TITLE and
+  * ARTIST in ReadsANameAgainstItsLevel's "level tells two fields apart" half.
+  */
+TEST(TestMatroskaTagMapping, GainWithNoPeakIsNotYetValid)
+{
+  const CMusicInfoTag tag = Parse("REPLAYGAIN_GAIN", "-6.94 dB");
+  EXPECT_TRUE(tag.GetReplayGain().Get(ReplayGain::TRACK).HasGain());
+  EXPECT_FALSE(tag.GetReplayGain().Get(ReplayGain::TRACK).Valid()); // needs a peak too
+}


### PR DESCRIPTION
## Description
This PR adds ReplayGain support for Matroska files, via the `REPLAYGAIN_GAIN` and `REPLAYGAIN_PEAK` tags, with target type level determining whether they correspond to track or album level ReplayGain information. This is the format written by Foobar2000 and also my ReplayGain tagging utility `rsgain`. See below screenshot from MKVToolNix GUI for an example of valid formatting.

<img width="519" height="730" alt="screenshot" src="https://github.com/user-attachments/assets/5f4669f6-c422-4c89-8dd2-f3e50809106c" />


## Motivation and context
A new tag loading class `CMusicInfoTagLoaderMatroska` was recently added for reading Matroska metadata, but it did not include ReplayGain support.

## How has this been tested?
I added a properly tagged .mka file to my library. I verified that the ReplayGain values were correctly parsed by the tag reader by manually inspecting the `MyMusic84.db` database file. Also, checked the logs during playback of the file.

## What is the effect on users?
It extends a valuable existing feature to a new file format.

## Screenshots (if appropriate):
N/A

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
