### PR TITLE
RetroAchievements: say why a login was rejected

### DIFF
--- a/xbmc/games/GameSettings.cpp
+++ b/xbmc/games/GameSettings.cpp
@@ -196,10 +196,15 @@ std::string CGameSettings::LoginToRA(const std::string& username,
 
   CLog::Log(LOGDEBUG, "CGameSettings::LoginToRA -- logging in as '{}'", username);
 
+  // The server names the reason in the body of a 401, which CCurlFile
+  // discards for any error status unless asked not to
+  CURL url{LOGIN_TO_RETRO_ACHIEVEMENTS_URL};
+  url.SetProtocolOption("failonerror", "false");
+
   XFILE::CCurlFile request;
   request.SetRequestHeader("User-Agent", CSysInfo::GetUserAgent());
   std::string strResponse;
-  if (request.Post(LOGIN_TO_RETRO_ACHIEVEMENTS_URL, postData, strResponse))
+  if (request.Post(url.Get(), postData, strResponse))
   {
     CVariant data(CVariant::VariantTypeObject);
     if (CJSONVariantParser::Parse(strResponse, data))


### PR DESCRIPTION
## Description

Signing in to RetroAchievements with a wrong user name or password reports **"Failed to contact server"** rather than saying the credentials were rejected.

The server does say so. It answers with HTTP 401 and a JSON body naming the reason:

```
{"Success":false,"Status":401,"Code":"invalid_credentials",
 "Error":"Invalid user\/password combination. Please try again."}
```

`CCurlFile` sets `CURLOPT_FAILONERROR` and `m_failOnError` defaults to true, so `Post()` returns false for any 4xx and discards the body. `CGameSettings::LoginToRA` then falls into its outermost `else`, which logs "failed to contact server" and shows string 35266. The branch that would surface the server's own message via `data["Error"]` is unreachable for the most common failure there is, a mistyped password.

`m_failOnError` has no setter; it is reachable only through the `failonerror` protocol option. So the fix builds a `CURL` for the endpoint, turns the option off, and posts that. The existing JSON parsing is unchanged and now does its job.

## Motivation and context

A rejected password looks exactly like a network outage, which sends anyone debugging it in the wrong direction.

## How has this been tested?

Manually. There is no existing test coverage of `CGameSettings::LoginToRA` to extend, and the change is a request option rather than logic.

- Verified the server's response directly against `dorequest.php?r=login2` with a throwaway user name: HTTP 401 with the body above, and 422 `missing_parameter` when parameters are omitted.
- Built and ran with the change; a rejected login now shows the server's message instead of the contact-server error.

## What is the effect on users?

A rejected sign-in says what was wrong with it. Nothing else changes: a genuine network failure still takes the same path, since `Post()` still returns false when no response arrives at all.

## Screenshots (if appropriate):

## Types of change

- [ ] Cleanup (non-breaking change which removes non-working, unmaintained functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the [Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md) of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
