### PR TITLE
GUI: Don't discard a window's identity when its XML is missing

### DIFF
--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -136,7 +136,6 @@ bool CGUIWindow::LoadXML(const std::string &strPath, const std::string &strLower
     {
       CLog::Log(LOGERROR, "Unable to load window XML: {}. Line {}\n{}", strPath, xmlDoc.ErrorRow(),
                 xmlDoc.ErrorDesc());
-      SetID(WINDOW_INVALID);
       return false;
     }
 


### PR DESCRIPTION
## Description

A window whose XML the loaded skin does not have gets its id replaced with `WINDOW_INVALID` by `CGUIWindow::LoadXML`, and never gets it back.

https://github.com/xbmc/xbmc/blob/master/xbmc/guilib/GUIWindow.cpp#L139

The window is still in the window manager's map, which is keyed on the ids it was registered under at construction and is not touched here, so it is still found and initialised on a later skin change. But its own `GetID()` answers `WINDOW_INVALID` from then on, so every control reports a parent of 9999, and the window can no longer focus anything or draw. In **every** skin from that point on, including ones whose copy of the file is perfectly good. The only cure is restarting Kodi.

That is not hypothetical. A skin shipped a window's XML, an update from its repository dropped the file, and from then on the window was dead everywhere. It looked exactly like the feature had never been installed. The tell is:

```
Control 110 in window 9999 has been asked to focus, but it can't
```

9999 being `WINDOW_INVALID`. Nothing else in the log suggests a skin is at fault, which makes it a long way from symptom to cause.

## Motivation and context

**Nothing reads it.** That `SetID(WINDOW_INVALID)` is the only such call in the tree, and no code anywhere tests a window's own id against `WINDOW_INVALID`, so it marks nothing for anybody. The failure is already carried by `LoadXML` returning false, which is what leaves `m_windowLoaded` false so the next skin change tries again. The second failure path ten lines below, for a file without a `<window>` root element, returns false without touching the id at all.

So the line does no work and costs the window its identity for the rest of the session. It dates back to the 2008 code reshuffle, well before the window manager kept its own id map.

This does not make an incomplete skin a supported thing. A skin without the file still gets no window, and the error is still logged exactly as before. It stops one incomplete skin breaking a window for the rest of the session in every other skin.

## How has this been tested?

Linux/X11, built clean from the existing build directory, and the GUI and window test suites pass (205 tests). No behaviour is added, so there is nothing new to cover; the change is the removal of a statement with no readers.

## What is the effect on users?

A window that failed to load under one skin works again when a skin that has its XML is loaded, instead of staying broken until Kodi is restarted.

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
