### PR TITLE
Clarify AdvancedSettingsLoaded Event registration code, comments clarification, tighten destruction

### DIFF
--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -31,6 +31,7 @@
 #include "utils/log.h"
 
 #include <algorithm>
+#include <atomic>
 #include <climits>
 #include <regex>
 #include <string>
@@ -122,12 +123,11 @@ void CAdvancedSettings::OnSettingChanged(const std::shared_ptr<const CSetting>& 
 
 int CAdvancedSettings::RegisterSettingsLoadedCallback(AdvancedSettingsCallback callback)
 {
+  static std::atomic<int> nextHandle{0};
   std::lock_guard lock{m_listCritSection};
-  // The handle is read back from the inserted element, so it cannot drift from the key the
-  // callback is stored under and Unregister can never erase a different caller's callback.
-  const auto it =
-      m_settingsLoadedCallbacks.emplace(m_nextCallbackHandle++, std::move(callback)).first;
-  return it->first;
+  const int handle{nextHandle++};
+  m_settingsLoadedCallbacks.emplace(handle, std::move(callback));
+  return handle;
 }
 
 void CAdvancedSettings::UnregisterSettingsLoadedCallback(int handle)

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -96,14 +96,11 @@ void CAdvancedSettings::OnSettingsLoaded()
   }
   CServiceBroker::GetLogging().SetLogLevel(m_logLevel);
 
-  std::vector<AdvancedSettingsCallback> callbacks;
   {
     std::lock_guard lock{m_listCritSection};
-    callbacks.reserve(m_settingsLoadedCallbacks.size());
-    std::ranges::transform(m_settingsLoadedCallbacks, std::back_inserter(callbacks),
-                           [](const auto& pair) { return pair.second; });
+    for (const auto& [handle, callback] : m_settingsLoadedCallbacks)
+      callback();
   }
-  std::ranges::for_each(callbacks, &AdvancedSettingsCallback::operator());
 }
 
 void CAdvancedSettings::OnSettingsUnloaded()

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -136,7 +136,9 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     /*!
      * \brief Unregister a callback for notifications of advanced settings load.
-     * \param[in] handle of the callback
+     *        Note: unregistering a callback from callback context is not allowed and will cause
+     *              problems.
+     * \param[in] handle callback handle
      */
     void UnregisterSettingsLoadedCallback(int handle);
 
@@ -431,7 +433,6 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
     std::vector<std::string> m_folderStackStrings;
 
     mutable CCriticalSection m_listCritSection;
-    int m_nextCallbackHandle{0};
     std::map<int, AdvancedSettingsCallback> m_settingsLoadedCallbacks;
     std::string m_metadataSourcesPriv;
 };

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -128,9 +128,14 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
 
     /*!
      * \brief Register a callback to receive notifications when the advanced settings are loaded.
-     *        Note: the callback functions are invoked on the thread that loads the settings.
+     * 
      * \param[in] callback
      * \return opaque callback handle
+     * 
+     * \note The callback functions are invoked on the thread that loads the settings.
+     *       Callbacks should perform only fast non-blocking work to avoid holding up the execution
+     *       of other callbacks.
+     *       A callback must not acquire locks that may be held while registering or unregistering.
      */
     int RegisterSettingsLoadedCallback(AdvancedSettingsCallback callback);
 

--- a/xbmc/test/TestBasicEnvironment.cpp
+++ b/xbmc/test/TestBasicEnvironment.cpp
@@ -112,8 +112,8 @@ void TestBasicEnvironment::TearDown()
 {
   g_application.m_ServiceManager->DeinitTesting();
 
-  // The VFS machinery is not usable once the services are deinitialized. The path is UTF-8, which
-  // std::filesystem takes as the native narrow encoding unless told otherwise.
+  // Do not use the deinitialized VFS machinery.
+  // std::u8string cast to interpret the path as UTF-8 on all platforms.
   std::error_code ec;
   const std::filesystem::path tempPath{
       std::u8string{reinterpret_cast<const char8_t*>(m_tempPath.data()), m_tempPath.size()}};

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -465,6 +465,8 @@ bool CFileExtensionProvider::EncodedHostName(const std::string& protocol) const
 
 void CFileExtensionProvider::OnAdvancedSettingsLoaded()
 {
+  // Avoid lost invalidation for a nullptr list built at the same time
+  std::lock_guard lock{m_critSection};
   // m_fileFolderExtensions is built from the add-ons alone, so a settings reload keeps it.
   ReleaseSettingsDerivedLists();
 }

--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -74,9 +74,16 @@ void CFileExtensionProvider::Initialize(ADDON::CAddonMgr& addonManager)
   m_initialized = true;
 }
 
+CFileExtensionProvider::~CFileExtensionProvider()
+{
+  Deinitialize();
+}
+
 void CFileExtensionProvider::Deinitialize()
 {
-  // Both callbacks take m_critSection, so they are detached before it is held here.
+  if (!m_initialized)
+    return;
+
   if (m_callbackId.has_value())
   {
     m_advancedSettings->UnregisterSettingsLoadedCallback(m_callbackId.value());
@@ -89,9 +96,7 @@ void CFileExtensionProvider::Deinitialize()
     m_addonManager = nullptr;
   }
 
-  // A getter that has already passed the unlocked initialized check builds its list under this
-  // lock and checks again once it holds it, so nothing below is dropped while a list is being
-  // built from it.
+  // Lock needed against a concurrent getter
   std::lock_guard lock{m_critSection};
 
   m_initialized = false;
@@ -99,10 +104,8 @@ void CFileExtensionProvider::Deinitialize()
   m_addonExtensions.clear();
   m_addonFileFolderExtensions.clear();
 
+  // Deinitialization drops all lists
   ReleaseSettingsDerivedLists();
-
-  // Not built from the advanced settings, so a settings reload leaves it alone. Deinitialization
-  // is dropping everything, so it goes too.
   std::atomic_store(&m_fileFolderExtensions, {});
 }
 
@@ -462,7 +465,6 @@ bool CFileExtensionProvider::EncodedHostName(const std::string& protocol) const
 
 void CFileExtensionProvider::OnAdvancedSettingsLoaded()
 {
-  // m_fileFolderExtensions is deliberately not released here: it is built from the add-ons
-  // alone, so a settings reload cannot have changed it.
+  // m_fileFolderExtensions is built from the add-ons alone, so a settings reload keeps it.
   ReleaseSettingsDerivedLists();
 }

--- a/xbmc/utils/FileExtensionProvider.h
+++ b/xbmc/utils/FileExtensionProvider.h
@@ -30,7 +30,7 @@ class CFileExtensionProvider
 {
 public:
   CFileExtensionProvider() = default;
-  ~CFileExtensionProvider() = default;
+  ~CFileExtensionProvider();
 
   void Initialize(ADDON::CAddonMgr& addonManager);
   void Deinitialize();
@@ -110,17 +110,16 @@ private:
 
   void OnAdvancedSettingsLoaded();
 
-  /*! \brief Release the cached lists built from the advanced settings.
-
-   Deinitialize releases the add-on derived list as well; a settings reload must not, because
-   the add-ons have not changed.
+  /*!
+   * \brief Release the cached lists built from the advanced settings.
    */
   void ReleaseSettingsDerivedLists();
 
   // Construction properties
-  // Written by Initialize and Deinitialize, read by every getter, and those are not the same
-  // thread. Atomic for the getters' unlocked first check; Deinitialize clears it and the state
-  // below under m_critSection, which is what orders it against a list being built.
+
+  /*!
+   * \brief Initialization status of the class, guards against access while uninitialized.
+   */
   std::atomic<bool> m_initialized{false};
   std::shared_ptr<CAdvancedSettings> m_advancedSettings;
   ADDON::CAddonMgr* m_addonManager{nullptr};

--- a/xbmc/utils/test/TestFileExtensionProvider.cpp
+++ b/xbmc/utils/test/TestFileExtensionProvider.cpp
@@ -14,30 +14,26 @@
 
 #include <gtest/gtest.h>
 
-// The provider outlives its own deinitialization: it stays reachable through the service broker
-// until the process ends, and one-argument URIUtils::GetExtension consults the compound archive
-// extensions for any path containing a dot. Deinitialization drops the advanced settings that
-// the lazily built lists read, so a list not yet built was built against nothing.
-//
-// A local instance is used rather than the one the service broker holds, so deinitializing it
-// cannot disturb another test in this binary.
-TEST(TestFileExtensionProvider, GettersAnswerEmptyAfterDeinitializationRatherThanFaulting)
+TEST(TestFileExtensionProvider, GettersAnswerEmptyAfterDeinitialization)
 {
+  // Use local instances to avoid disturbing the global instance for other tests
+
+  // Check non-empty content of list to prove "cold" deinitialization behavior without a doubt
+  CFileExtensionProvider dummyProvider;
+  dummyProvider.Initialize(CServiceBroker::GetAddonMgr());
+  ASSERT_FALSE(dummyProvider.GetCompoundArchiveExtensions().empty())
+      << "the test requires a non-empty list (compound archive extensions).";
+  dummyProvider.Deinitialize();
+
   CFileExtensionProvider provider;
   provider.Initialize(CServiceBroker::GetAddonMgr());
 
-  // Build one list and leave another cold, so both states are covered after deinitialization.
+  // One list warm, one cold, so both states are covered after deinitialization.
   const std::string warmed = provider.GetVideoExtensions();
-  ASSERT_FALSE(warmed.empty()) << "the video extensions were not built while initialized, so the "
-                                  "warm case below would prove nothing";
+  ASSERT_FALSE(warmed.empty()) << "the test requires a non-empty list (video extensions).";
 
   provider.Deinitialize();
 
-  // The cold list is the case that faulted: nothing is cached, so it would be built, and the
-  // settings it reads are gone.
-  EXPECT_TRUE(provider.GetCompoundArchiveExtensions().empty());
-
-  // Deinitialize releases the warm list too, so it answers the same way rather than handing back
-  // a list built against settings that no longer exist.
+  EXPECT_TRUE(provider.GetCompoundArchiveExtensions().empty()); // "cold" list
   EXPECT_TRUE(provider.GetVideoExtensions().empty());
 }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Follow-up of #28936, alternative to #29131. Style and comment improvements.

The main purpose is to restore a more readable `CAdvancedSettings::RegisterSettingsLoadedCallback` function.

Clarify that an advanced settings callback should not attempt to unregister itself or another callback. Hopefully will keep AI from going overboard in the future.

Have the `CFileExtensionProvider()` destructor deinitialize so that callbacks are always unregistered, with early exit in `Deinitialize()` if already deinitialized (good addition of #29131).

Address small race window for advancedsettings callbacks running at the same time as unregistration.

Address small race window for lost invalidation when `OnAdvancedSettingsLoaded` executes while a list is being built and would retain stale data until next event (good addition of #29131).

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Follow-up of #28936

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The modified + existing unit tests pass.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

none

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [X] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
