### PR TITLE
[Video] Use the dynamic path for generated video thumbnails

### DIFF
--- a/xbmc/video/VideoThumbLoader.cpp
+++ b/xbmc/video/VideoThumbLoader.cpp
@@ -594,7 +594,7 @@ std::string CVideoThumbLoader::GetLocalArt(const CFileItem &item, const std::str
 
 std::string CVideoThumbLoader::GetEmbeddedThumbURL(const CFileItem &item)
 {
-  std::string path(item.GetPath());
+  std::string path(item.GetDynPath());
   if (VIDEO::IsVideoDb(item) && item.HasVideoInfoTag())
     path = item.GetVideoInfoTag()->m_strFileNameAndPath;
   if (URIUtils::IsStack(path))

--- a/xbmc/video/test/CMakeLists.txt
+++ b/xbmc/video/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES TestBookmark.cpp
             TestVideoFileItemClassify.cpp
             TestVideoInfoTag.cpp
             TestVideoStreamSelect.cpp
+            TestVideoThumbLoader.cpp
             TestVideoUtils.cpp)
 
 core_add_test_library(video_test)

--- a/xbmc/video/test/TestVideoThumbLoader.cpp
+++ b/xbmc/video/test/TestVideoThumbLoader.cpp
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "FileItem.h"
+#include "imagefiles/ImageFileURL.h"
+#include "video/VideoThumbLoader.h"
+
+#include <gtest/gtest.h>
+
+TEST(TestVideoThumbLoader, EmbeddedThumbUsesDynamicPath)
+{
+  const std::string mediaPath{"smb://server/Videos/Movie.mkv"};
+  CFileItem item{"smb://server/Displayed source/Movie.mkv", false};
+  item.SetDynPath(mediaPath);
+
+  EXPECT_EQ(CVideoThumbLoader::GetEmbeddedThumbURL(item),
+            IMAGE_FILES::URLFromFile(mediaPath, "video"));
+}


### PR DESCRIPTION
## Description

A `CFileItem` can contain two different paths:

- `GetPath()` identifies the item in the current directory or UI.
- `GetDynPath()` identifies the resolved media resource that Kodi will actually play.

`CVideoThumbLoader::GetEmbeddedThumbURL()` currently creates generated
`image://video@...` thumbnail URLs using `GetPath()`.

When these paths differ, the generated URL references the logical item path instead of the playable video file. The URL can then be stored as artwork and returned unchanged by JSON-RPC, but Kodi cannot extract a frame from it through the `/image/` endpoint.

For example:
```text
Item path:    smb://jedi/Vidéos/Action/movie.mkv
Dynamic path: smb://jedi/Videos/Action/movie.mkv
```
Before this change, the generated thumbnail targets:
```image://video@smb%3a%2f%2fjedi%2fVid%c3%a9os%2fAction%2fmovie.mkv/```

After this change, it targets the actual playable file:
```image://video@smb%3a%2f%2fjedi%2fVideos%2fAction%2fmovie.mkv/```


## Motivation and context

Remote controls and other front-ends retrieve artwork URLs through JSON-RPC and pass them to Kodi's existing /image/ endpoint. JSON-RPC is not creating the incorrect URL; it is returning the artwork URL already generated and stored by Kodi. The problem must therefore be fixed when the generated video thumbnail URL is created.
Using the dynamic path also makes thumbnail generation consistent with the video scanner, which uses the resolved dynamic path as the media file path.


## How has this been tested?
A unit test creates a CFileItem with:
- a logical item path;
- a different dynamic media path.
The test verifies that GetEmbeddedThumbURL() creates the image://video@...
URL from the dynamic path.
The new test passes on Windows Release:
```
[ RUN      ] TestVideoThumbLoader.EmbeddedThumbUsesDynamicPath
[       OK ] TestVideoThumbLoader.EmbeddedThumbUsesDynamicPath
[  PASSED  ] 1 test
```
The Kodi test executable and Release build compile successfully.

## What is the effect on users?
Generated video thumbnail URLs now reference the media resource Kodi actually plays. JSON-RPC clients can therefore pass those URLs to the existing /image/ endpoint when an item's logical and dynamic paths differ.
Artwork URLs already stored with an incorrect path may need to be regenerated once; this change prevents new incorrect URLs from being created.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [ ] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [x] I have added tests to cover my change
- [x] All new and existing tests passed
