### PR TITLE
[Video] Harden stacking.

### DIFF
--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -786,7 +786,8 @@ void CFileItemList::Stack()
                                                       .remainder = {},
                                                       .size = item->GetSize(),
                                                       .index = i,
-                                                      .playPath = playPath});
+                                                      .playPath = playPath,
+                                                      .pattern = regExp.GetPattern()});
           break;
         }
       }
@@ -814,7 +815,8 @@ void CFileItemList::Stack()
                                                     .remainder = regExp.GetMatch(3),
                                                     .size = item->GetSize(),
                                                     .index = i,
-                                                    .playPath = {}});
+                                                    .playPath = {},
+                                                    .pattern = regExp.GetPattern()});
         break;
       }
     }
@@ -877,6 +879,9 @@ void CFileItemList::Stack()
     const std::string stackPath{baseItem->IsRAR()
                                     ? baseItem->GetPath()
                                     : CStackDirectory::ConstructStackPath(*this, stack)};
+
+    CLog::LogF(LOGDEBUG, "Stacked {} parts into '{}' (stack expression '{}')", stack.size(),
+               CURL::GetRedacted(stackPath), parts[0].pattern);
 
     // First item in stack becomes the stack
     std::string stackName{candidate.title};

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -779,9 +779,11 @@ void CFileItemList::Stack()
         if (fileFound)
         {
           // Add to stack vector
+          // Folder expressions capture no remainder, so folder parts group on their title alone
           stackCandidates.emplace_back(StackCandidate{.type = StackCandidateType::FOLDER_CANDIDATE,
                                                       .title = regExp.GetMatch(1),
                                                       .volume = regExp.GetMatch(2),
+                                                      .remainder = {},
                                                       .size = item->GetSize(),
                                                       .index = i,
                                                       .playPath = playPath});
@@ -809,6 +811,7 @@ void CFileItemList::Stack()
         stackCandidates.emplace_back(StackCandidate{.type = StackCandidateType::FILE_CANDIDATE,
                                                     .title = regExp.GetMatch(1),
                                                     .volume = regExp.GetMatch(2),
+                                                    .remainder = regExp.GetMatch(3),
                                                     .size = item->GetSize(),
                                                     .index = i,
                                                     .playPath = {}});
@@ -825,9 +828,10 @@ void CFileItemList::Stack()
   std::ranges::sort(stackCandidates);
 
   // Count stack candidates
+  // Parts of the same stack should differ only in their volume
   std::map<CountedStackCandidate, int> countedCandidates;
   for (const auto& s : stackCandidates)
-    ++countedCandidates[{s.type, s.title}];
+    ++countedCandidates[{s.type, s.title, s.remainder}];
 
   // Find stacks
   std::vector<int> deleteItems;
@@ -838,9 +842,12 @@ void CFileItemList::Stack()
     std::vector<int> stack;
     int64_t size{0};
     for (const auto& stackItem :
-         stackCandidates |
-             std::views::filter([type = candidate.type, title = candidate.title](const auto& item)
-                                { return item.type == type && item.title == title; }))
+         stackCandidates | std::views::filter(
+                               [type = candidate.type, title = candidate.title,
+            remainder = candidate.remainder](const auto& item) {
+                                 return item.type == type && item.title == title &&
+                                        item.remainder == remainder;
+                               }))
     {
       // Now the stack is known to have more than one part
       if (!stackItem.playPath.empty())

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -752,6 +752,7 @@ void CFileItemList::Stack()
           continue;
 
         bool fileFound{true};
+        std::string playPath;
         if (item->IsFolder())
         {
           // Look for media files in the folder
@@ -764,7 +765,7 @@ void CFileItemList::Stack()
 
           // Only expect one media file per folder (if >1 should be a file stack)
           if (items.GetFileCount() == 1)
-            ChangeFolderToFile(item, items[0]->GetPath());
+            playPath = items[0]->GetPath();
           else
           {
             CLog::LogF(LOGDEBUG,
@@ -782,7 +783,8 @@ void CFileItemList::Stack()
                                                       .title = regExp.GetMatch(1),
                                                       .volume = regExp.GetMatch(2),
                                                       .size = item->GetSize(),
-                                                      .index = i});
+                                                      .index = i,
+                                                      .playPath = playPath});
           break;
         }
       }
@@ -808,7 +810,8 @@ void CFileItemList::Stack()
                                                     .title = regExp.GetMatch(1),
                                                     .volume = regExp.GetMatch(2),
                                                     .size = item->GetSize(),
-                                                    .index = i});
+                                                    .index = i,
+                                                    .playPath = {}});
         break;
       }
     }
@@ -839,6 +842,10 @@ void CFileItemList::Stack()
              std::views::filter([type = candidate.type, title = candidate.title](const auto& item)
                                 { return item.type == type && item.title == title; }))
     {
+      // Now the stack is known to have more than one part
+      if (!stackItem.playPath.empty())
+        ChangeFolderToFile(Get(stackItem.index), stackItem.playPath);
+
       stack.emplace_back(stackItem.index);
       size += stackItem.size;
       if (stack.size() > 1)

--- a/xbmc/FileItemList.cpp
+++ b/xbmc/FileItemList.cpp
@@ -838,16 +838,28 @@ void CFileItemList::Stack()
   for (const auto& [candidate, count] :
        countedCandidates | std::views::filter([](const auto& c) { return c.second > 1; }))
   {
-    // Find all items in this stack
+    // Find all the parts of this stack (sorted by volume)
+    std::vector<StackCandidate> parts;
+    std::ranges::copy(stackCandidates | std::views::filter(
+                                            [type = candidate.type, title = candidate.title,
+                                             remainder = candidate.remainder](const auto& item) {
+                                              return item.type == type && item.title == title &&
+                                                     item.remainder == remainder;
+                                            }),
+                      std::back_inserter(parts));
+
+    // Every part of a stack should be a different volume
+    if (std::ranges::adjacent_find(parts, {}, &StackCandidate::volume) != parts.end())
+    {
+      CLog::LogF(LOGDEBUG,
+                 "Skipping stack '{}' - {} parts found, but not all of a different volume",
+                 candidate.title, parts.size());
+      continue;
+    }
+
     std::vector<int> stack;
     int64_t size{0};
-    for (const auto& stackItem :
-         stackCandidates | std::views::filter(
-                               [type = candidate.type, title = candidate.title,
-            remainder = candidate.remainder](const auto& item) {
-                                 return item.type == type && item.title == title &&
-                                        item.remainder == remainder;
-                               }))
+    for (const auto& stackItem : parts)
     {
       // Now the stack is known to have more than one part
       if (!stackItem.playPath.empty())

--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -60,6 +60,7 @@ public:
     int64_t size;
     int index; // index in m_items
     std::string playPath; // for a folder candidate: the file inside the folder
+    std::string pattern; // the stack expression that matched, for logging
 
     auto operator<=>(const StackCandidate&) const = default;
   };

--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -56,6 +56,7 @@ public:
     StackCandidateType type;
     std::string title;
     std::string volume;
+    std::string remainder; // the part of the name after the volume, excluding the extension
     int64_t size;
     int index; // index in m_items
     std::string playPath; // for a folder candidate: the file inside the folder
@@ -67,6 +68,7 @@ public:
   {
     StackCandidateType type;
     std::string title;
+    std::string remainder;
 
     auto operator<=>(const CountedStackCandidate& other) const = default;
   };

--- a/xbmc/FileItemList.h
+++ b/xbmc/FileItemList.h
@@ -58,6 +58,7 @@ public:
     std::string volume;
     int64_t size;
     int index; // index in m_items
+    std::string playPath; // for a folder candidate: the file inside the folder
 
     auto operator<=>(const StackCandidate&) const = default;
   };

--- a/xbmc/video/test/TestStacks.cpp
+++ b/xbmc/video/test/TestStacks.cpp
@@ -172,6 +172,9 @@ TEST_F(TestStacks, TestFilesOnlyStackWhenOnlyTheirVolumeDiffers)
 
   // ..including parts that are not in the same container
   EXPECT_EQ(SizeAfterStacking({"Movie (2001) cd1.avi", "Movie (2001) cd2.mkv"}), 1);
+
+  // but the same part in two containers is two versions of that part, not a stack
+  EXPECT_EQ(SizeAfterStacking({"Movie (2001) cd1.avi", "Movie (2001) cd1.mkv"}), 2);
 }
 
 TEST_F(TestStacks, TestFolderStacksIgnoreAnyFurtherCapturesOfTheirExpression)

--- a/xbmc/video/test/TestStacks.cpp
+++ b/xbmc/video/test/TestStacks.cpp
@@ -129,6 +129,31 @@ TEST_F(TestStacks, TestMovieFilesStackFolderFilesPart)
   }
 }
 
+TEST_F(TestStacks, TestLoneFolderStackPartStaysAFolder)
+{
+  // A folder that looks like a part of a folder stack but has no other part to stack with must
+  // stay a folder, so that it is still listed and scanned as a movie folder of its own
+  const std::string movieFolder{
+      XBMC_REF_FILE_PATH("xbmc/video/test/testdata/moviestack_subfolder_parts/Movie_(2001)")};
+  CFileItemList items{movieFolder};
+
+  const auto part{
+      std::make_shared<CFileItem>(URIUtils::AddFileToFolder(movieFolder, "part_1"), true)};
+  part->SetLabel("part_1");
+  items.Add(part);
+
+  // an unrelated movie, so that the list is not a single item
+  items.Add(std::make_shared<CFileItem>(
+      XBMC_REF_FILE_PATH("xbmc/video/test/testdata/moviestack_ab/Movie-(2001)/Movie-(2001)A.mp4"),
+      false));
+
+  items.Stack();
+
+  EXPECT_EQ(items.Size(), 2);
+  EXPECT_EQ(part->IsFolder(), true);
+  EXPECT_EQ(part->IsStack(), false);
+}
+
 TEST_F(TestStacks, TestMovieFilesStackFolderFilesPart2)
 {
   const std::string movieFolder =

--- a/xbmc/video/test/TestStacks.cpp
+++ b/xbmc/video/test/TestStacks.cpp
@@ -8,10 +8,14 @@
 
 #include "FileItem.h"
 #include "FileItemList.h"
+#include "ServiceBroker.h"
 #include "URL.h"
 #include "filesystem/Directory.h"
 #include "filesystem/StackDirectory.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/SettingsComponent.h"
 #include "test/TestUtils.h"
+#include "utils/RegExp.h"
 #include "utils/URIUtils.h"
 #include "video/VideoFileItemClassify.h"
 
@@ -29,7 +33,20 @@ using ::testing::WithParamInterface;
 namespace
 {
 const std::string VIDEO_EXTENSIONS = ".mpg|.mpeg|.mp4|.mkv|.mk3d|.iso";
+
+int SizeAfterStacking(const std::vector<std::string>& fileNames)
+{
+  CFileItemList items{R"(D:\Movies\Movie folder\)"};
+  for (const auto& name : fileNames)
+  {
+    const auto item{std::make_shared<CFileItem>(items.GetPath() + name, false)};
+    item->SetLabel(name);
+    items.Add(item);
+  }
+  items.Stack();
+  return items.Size();
 }
+} // namespace
 
 class TestStacks : public ::testing::Test
 {
@@ -127,6 +144,56 @@ TEST_F(TestStacks, TestMovieFilesStackFolderFilesPart)
     EXPECT_EQ(items.Get(0)->IsStack(), true);
     EXPECT_EQ(items.Get(0)->IsFolder(), false);
   }
+}
+
+TEST_F(TestStacks, TestFilesOnlyStackWhenOnlyTheirVolumeDiffers)
+{
+  // Parts of a stack differ only in their volume, so a file whose name matches a stack
+  // expression must not stack with one whose name differs elsewhere as well
+
+  // a movie and its trailer both yield the title 'it cha' and the volume 'pte'
+  EXPECT_EQ(SizeAfterStacking({"It Chapter Two (2019).mp4", "It Chapter Two (2019)-trailer.mp4"}),
+            2);
+
+  // three unrelated films all yield the title 'ca' and the volume 'pta'
+  EXPECT_EQ(SizeAfterStacking({"Captain America - The First Avenger (2011).mp4",
+                               "Captain Phillips (2013).mp4",
+                               "Captain America - The Winter Soldier (2014).mp4"}),
+            3);
+
+  // sequels are not parts of one another
+  EXPECT_EQ(
+      SizeAfterStacking({"John Wick - Chapter 2 (2017).mp4", "John Wick - Chapter 4 (2023).mp4"}),
+      2);
+
+  // real parts still stack, whatever else the name carries..
+  EXPECT_EQ(SizeAfterStacking({"Movie (2001) part1 [1080p].mkv", "Movie (2001) part2 [1080p].mkv"}),
+            1);
+
+  // ..including parts that are not in the same container
+  EXPECT_EQ(SizeAfterStacking({"Movie (2001) cd1.avi", "Movie (2001) cd2.mkv"}), 1);
+}
+
+TEST_F(TestStacks, TestFolderStacksIgnoreAnyFurtherCapturesOfTheirExpression)
+{
+  // A custom <folderstacking> expression may capture more than the title and the volume
+  const auto advancedSettings{CServiceBroker::GetSettingsComponent()->GetAdvancedSettings()};
+  const auto folderStackRegExps{advancedSettings->m_folderStackRegExps};
+
+  CRegExp regExp{true, CRegExp::autoUtf8};
+  EXPECT_TRUE(regExp.RegComp("()((?:p(?:(?:ar)?t)[ _.-]*([0-9])))$"));
+  advancedSettings->m_folderStackRegExps = {regExp};
+
+  const std::string movieFolder =
+      XBMC_REF_FILE_PATH("xbmc/video/test/testdata/moviestack_subfolder_parts/Movie_(2001)");
+  CFileItemList items;
+  CDirectory::GetDirectory(movieFolder, items, "", DIR_FLAG_DEFAULTS);
+  EXPECT_EQ(items.Size(), 3);
+
+  items.Stack();
+  EXPECT_EQ(items.Size(), 1);
+
+  advancedSettings->m_folderStackRegExps = folderStackRegExps;
 }
 
 TEST_F(TestStacks, TestLoneFolderStackPartStaysAFolder)


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Harden stacking:
- ensure that a folder that triggers the folder regex is actually part of a multi-part stack.
- ensure that the part of the filename that comes after the volume (eg. part 1) does not cause a false match (eg. -trailer)
- ensure each volume is unique (eg. not 2x part 1's etc..)

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix #29167.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally. Added tests. Confirmed working by bug reporter.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
