### PR TITLE
fixed: stop offering withdrawn ISO 639-1 codes as language choices

### DIFF
--- a/xbmc/utils/i18n/Iso639_1.cpp
+++ b/xbmc/utils/i18n/Iso639_1.cpp
@@ -62,9 +62,5 @@ bool CIso639_1::ListLanguages(std::map<std::string, std::string>& langMap)
                          [](const LCENTRY& e)
                          { return std::make_pair(LongCodeToString(e.code), std::string{e.name}); });
 
-  std::ranges::transform(TableISO639_1_DeprByName, std::inserter(langMap, langMap.end()),
-                         [](const LCENTRY& e)
-                         { return std::make_pair(LongCodeToString(e.code), std::string{e.name}); });
-
   return true;
 }

--- a/xbmc/utils/i18n/Iso639_1.h
+++ b/xbmc/utils/i18n/Iso639_1.h
@@ -43,7 +43,8 @@ public:
   static std::optional<std::string> LookupByName(std::string_view name);
 
   /*!
-   * \brief Provide a list of defined ISO 639-1 languages
+   * \brief Provide the languages offered as a choice: active ISO 639-1 codes and Kodi's
+   *        additions, excluding codes ISO 639-1 has withdrawn.
    * \param[in] langMap map to add languages to
    * \return true for success, false otherwise
    */

--- a/xbmc/utils/i18n/test/TestIso639_1.cpp
+++ b/xbmc/utils/i18n/test/TestIso639_1.cpp
@@ -9,6 +9,10 @@
 #include "utils/i18n/Iso639.h"
 #include "utils/i18n/Iso639_1.h"
 
+#include <map>
+#include <string>
+#include <string_view>
+
 #include <gtest/gtest.h>
 
 using namespace KODI::UTILS::I18N;
@@ -81,4 +85,22 @@ TEST(TestI18nIso639_1, LookupByName)
 
   result = CIso639_1::LookupByName("not a language");
   EXPECT_FALSE(result.has_value());
+}
+
+TEST(TestI18nIso639_1, ListLanguages)
+{
+  std::map<std::string, std::string> langMap;
+  EXPECT_TRUE(CIso639_1::ListLanguages(langMap));
+
+  ASSERT_TRUE(langMap.contains("aa"));
+  EXPECT_EQ(langMap.at("aa"), "Afar");
+  ASSERT_TRUE(langMap.contains("zu"));
+  EXPECT_EQ(langMap.at("zu"), "Zulu");
+
+  // The codes ISO 639-1 has withdrawn.
+  for (const std::string_view code : {"bh", "in", "iw", "ji", "jw", "mo", "sh"})
+  {
+    EXPECT_FALSE(langMap.contains(std::string{code})) << code;
+    EXPECT_TRUE(CIso639_1::LookupByCode(code).has_value()) << code;
+  }
 }


### PR DESCRIPTION
**TL;DR:** Bug fix. Withdrawn ISO 639-1 codes are no longer offered in the language pickers, so Moldavian stops appearing as a language of its own.

## Description

`CIso639_1::ListLanguages()` merged `TableISO639_1_Depr` — the codes ISO 639-1 has withdrawn — into the list built from the active table. That list is the sole input to `CLangCodeExpander::GetLanguageNames()`, which fills the audio, subtitle and subtitle-download language pickers, so every withdrawn code was offered as a choice. This drops the withdrawn half from the list and leaves the lookups alone.

## Motivation and context

Fixes #29183.

Withdrawn codes are carried so that media tagged with one is still understood, not so that a language ISO 639-1 no longer recognises can be picked from a list.

Moldavian is the case that was reported. ISO 639-1 withdrew `mo` in 2008 when Moldavian was merged into Romanian; Kodi never carried the code at all before the table was split into an active and a withdrawn half, so it is new in v22 and now sits in the audio language list next to Romanian.

Of the other six withdrawn codes, four (`ji` Yiddish, `in` Indonesian, `iw` Hebrew, `jw` Javanese) share a name with their replacement and collapse onto it when `GetLanguageNames()` deduplicates by name, so they were never visible either before or after this change. The remaining two are worth a reviewer's attention: **`sh` Serbo-Croatian and `bh` Bihari were active entries in v21 and do disappear from the picker here.** Both are genuinely withdrawn (2000 and 2021), and the alternative — keeping two withdrawn codes because an old table happened to list them — did not look like the more defensible line. Say if you would rather see only `mo` removed.

Lookups are untouched. `LookupByCode()` and `LookupByName()` still resolve all seven withdrawn codes, so media tagged with one still reads correctly, and a name already stored in `guisettings.xml` keeps working: these settings use a dynamic options filler, and `CSettingString::CheckValidity()` validates only against the static options declared in `settings.xml`, so a stored value that is no longer offered is preserved rather than reset.

## How has this been tested?

Windows x64, VS 2022.

Added `TestI18nIso639_1.ListLanguages`, which asserts the listed set holds the active codes and none of the seven withdrawn ones, and that each withdrawn code still resolves through `LookupByCode()`. It fails on all seven before the change and passes after it. Full suite green afterwards: 4079 tests, no failures.

Checked the running application over JSON-RPC. `Settings.GetSettings` on the player/language category returns 187 options for `locale.audiolanguage` and 188 for `locale.subtitlelanguage`, with Moldavian, Serbo-Croatian and Bihari absent and Romanian, Yiddish, Indonesian, Hebrew and Javanese all still present.

Checked that an existing setting survives: `Settings.SetSettingValue` on `locale.audiolanguage` with `"Moldavian"` is still accepted and reads back unchanged, so a profile written by an earlier v22 build is not disturbed.

## What is the effect on users?

Moldavian no longer appears in the audio, subtitle and subtitle-download language lists. Serbo-Croatian and Bihari, which ISO 639-1 has also withdrawn, are removed from the same lists. An existing setting that names one of them is left alone and continues to work, and media tagged with a withdrawn code is still recognised.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed
