### PR TITLE
[PVR] Match the EPG search day bound without dividing in SQL

### DIFF
--- a/xbmc/pvr/epg/EpgDatabase.cpp
+++ b/xbmc/pvr/epg/EpgDatabase.cpp
@@ -21,6 +21,7 @@
 #include "utils/log.h"
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -721,8 +722,8 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTags(
     }
     else
     {
-      const unsigned int startDate{static_cast<unsigned int>(minStart) / ONE_DAY};
-      filter.AppendWhere(PrepareSQL("(iStartTime / %u) >= %u", ONE_DAY, startDate));
+      const uint64_t startDate{static_cast<unsigned int>(minStart) / ONE_DAY};
+      filter.AppendWhere(PrepareSQL("iStartTime >= %llu", startDate * ONE_DAY));
 
       const unsigned int startTime{static_cast<unsigned int>(minStart) % ONE_DAY};
       filter.AppendWhere(PrepareSQL("(iStartTime %% %u) >= %u", ONE_DAY, startTime));
@@ -744,8 +745,8 @@ std::vector<std::shared_ptr<CPVREpgInfoTag>> CPVREpgDatabase::GetEpgTags(
     }
     else
     {
-      const unsigned int endDate{static_cast<unsigned int>(maxEnd) / ONE_DAY};
-      filter.AppendWhere(PrepareSQL("(iEndTime / %u) <= %u", ONE_DAY, endDate));
+      const uint64_t endDate{static_cast<unsigned int>(maxEnd) / ONE_DAY};
+      filter.AppendWhere(PrepareSQL("iEndTime < %llu", (endDate + 1) * ONE_DAY));
 
       const unsigned int endTime{static_cast<unsigned int>(maxEnd) % ONE_DAY};
       filter.AppendWhere(PrepareSQL("(iEndTime %% %u) <= %u", ONE_DAY, endTime));


### PR DESCRIPTION
**TL;DR:** Bug fix, MySQL only. An EPG search with a date constraint divides in SQL to compare the day. MySQL's `/` yields a decimal where SQLite's yields an integer, so every programme on the last day of the searched range is silently dropped on MySQL. Comparing times instead of days removes the division.

## Description
`CPVREpgDatabase::GetEpgTags()` matches a search's date constraint by dividing the stored second count by a day and comparing the quotient:

```sql
(iEndTime / 86400) <= 84005
```

That relies on integer division. SQLite gives it; MySQL does not — `/` there is a decimal operator and returns `84005.8333`, so the comparison is false for every time on day 84005 itself.

Measured against `mysql:8.0.45`, rows around the day boundary, with the search's end bound on day 84005:

| `iEndTime` | | old form on SQLite | old form on MySQL | this PR, both |
|---|---|---|---|---|
| 7258031999 | day 84004 | 1 | 1 | 1 |
| 7258104000 | day 84005 | **1** | **0** | **1** |
| 7258118399 | day 84005, last second | **1** | **0** | **1** |
| 7258118400 | day 84006 | 0 | 0 | 0 |

So a MySQL user searching "up to and including this date" loses the whole final day. The lower bound never had the problem: `floor(x) >= n` and `x >= n` agree for an integer `n`, and I confirmed the old and new forms match on every row there, on both backends.

The fix compares the times rather than the days. "On or after this day" is "at or after the midnight that starts it"; "on or before this day" is "before the midnight that ends it" — the same predicate with both sides multiplied by a day, so no division is left to disagree about. The time-of-day half is untouched: `%` returns an integer on both backends.

A side benefit: `iStartTime >= <constant>` is sargable, so it can use `idx_epg_idEpg_iStartTime`. The divided form could not use the index at all.

## Motivation and context
Found while working on #29178, which rewrites these same four lines for a different reason (the 2038 width). The two will conflict trivially in `GetEpgTags()`; whichever lands second needs a small rebase. Keeping them apart because they are unrelated defects — this one is a MySQL/SQLite divergence and has nothing to do with the column width.

## How has this been tested?
Built on Windows x64 (VS 2022). Full `kodi-test` suite: 4078 tests in 320 suites, all passing.

**No unit test accompanies this**, and that is deliberate rather than an omission: on SQLite the old and new forms are equivalent — verified across the boundary rows above — so a test running on CI's SQLite would pass before and after the change and prove nothing. The divergence only exists on MySQL, which CI has no server for.

It was verified by hand instead, in a throwaway `mysql:8.0.45` container, evaluating both forms over the boundary rows: the old form disagrees with SQLite on exactly the two rows falling on the bound day, and the new form agrees with SQLite on all of them. That is the table above.

## What is the effect on users?
Users on a MySQL or MariaDB shared database get the programmes on the last day of an EPG search date range, which were previously missing. No change for SQLite users.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
