### PR TITLE
Games: Let an add-on name its own platforms

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -63,6 +63,7 @@ using namespace GAME;
 namespace
 {
 constexpr const char* GAME_PROPERTY_SUPPORTS_DISC_CONTROL = "supports_disc_control";
+constexpr const char* GAME_PROPERTY_PLATFORMS = "platforms";
 
 /*
  * \brief Convert to lower case and canonicalize with a leading "."
@@ -113,6 +114,11 @@ CGameClient::CGameClient(const ADDON::AddonInfoPtr& addonInfo)
                               .asBoolean();
 
   std::tie(m_emulatorName, m_platforms) = ParseLibretroName(Name());
+
+  const std::string platforms =
+      addonInfo->Type(AddonType::GAMEDLL)->GetValue(GAME_PROPERTY_PLATFORMS).asString();
+  if (!platforms.empty())
+    m_platforms = platforms;
 }
 
 CGameClient::~CGameClient(void)


### PR DESCRIPTION
## Description

`CGameClient` derives the platform it displays by splitting it back out of the add-on's name, in `ParseLibretroName()`. That works because libretro names its cores `Platforms (Emulator)`, but it is the only source we have — so an add-on that doesn't follow the convention has no way to describe itself correctly.

The `kodi.gameclient` extension point has carried a `<platforms>` element all along, and nothing reads it. This makes Kodi prefer it when it's set, falling back to the name parse when it's empty. `ParseLibretroName()` is unchanged.

## Motivation and context

Cores such as `ScummVM`, `VeMUlator` and `Oberon RISC Emulator` are not named for what they emulate, so Kodi shows no platform for them at all. Non-libretro game add-ons have the same problem, since the convention is a libretro one.

It also gives the tag a purpose: kodi-game/kodi-game-scripting#148 starts generating `<platforms>` for the packaged cores, where until now the value was copied forward from whatever had been typed in by hand. Of the 133 cores I have installed, 85 ship the element empty and none of the remainder agreed with the name.

Empty tags stay empty and change nothing: `CAddonInfoBuilder::ParseXMLExtension` only records child elements that have text, so `<platforms></platforms>` produces no override and falls through to the name as before.

## How has this been tested?

Compiled. I have not run a build with this change yet, so the behaviour below is reasoned from the code rather than observed:

- the 85 installed cores that ship `<platforms></platforms>` parse to no value, so `platforms.empty()` holds and `m_platforms` keeps the name-parsed result;
- a core with the element set overrides it.

## Types of change

- [x] **Improvement** — existing functionality made better

## Checklist

- [x] My code follows the Code Guidelines of this project
- [x] My change requires a change to the documentation — no
- [x] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md)** document
