### PR TITLE
fixed: hold m_critSection while a settings reload releases the cached extension lists

### DIFF
--- a/xbmc/utils/FileExtensionProvider.cpp
+++ b/xbmc/utils/FileExtensionProvider.cpp
@@ -462,6 +462,9 @@ bool CFileExtensionProvider::EncodedHostName(const std::string& protocol) const
 
 void CFileExtensionProvider::OnAdvancedSettingsLoaded()
 {
+  // A getter can otherwise store a list built from the old settings after this release.
+  std::lock_guard lock{m_critSection};
+
   // m_fileFolderExtensions is deliberately not released here: it is built from the add-ons
   // alone, so a settings reload cannot have changed it.
   ReleaseSettingsDerivedLists();


### PR DESCRIPTION
**TL;DR:** Bug fix. `CFileExtensionProvider::OnAdvancedSettingsLoaded()` released the cached extension lists without `m_critSection`, so a getter could refill a slot with a list built from the settings the reload had already replaced.

## Description

`CFileExtensionProvider` builds each extension list lazily and caches it. `GetExtensions()` takes `m_critSection`, reads the list out of `CAdvancedSettings`, and stores what it built under that lock. `OnAdvancedSettingsLoaded()` released those cached lists without taking it.

A getter runs on any thread; the reload runs on the main thread. When the release lands between a getter reading the advanced settings and storing its result, the getter fills the slot the release has just cleared with a list built from the settings that were replaced. Nothing rebuilds it, so the stale list is served until the next settings reload or add-on event.

Holding `m_critSection` across the release serialises the two, so a list built from the old settings can only be stored before the release that drops it.

Nothing takes `m_listCritSection` while holding `m_critSection`, so the wider scope cannot invert the two locks. `Deinitialize()` unregisters the callback before it acquires `m_critSection`, which is what keeps that true.

This is the one point from #29131 that #29189 does not carry. @reardonia asked for it to be kept there; the rest of that branch is superseded by #29189, which is why #29131 is now closed.

## Motivation and context

Follow-up to #28936, which introduced `ReleaseSettingsDerivedLists()` and its unlocked call site.

## How has this been tested?

Full suite green on Windows: 4078 tests across 320 suites. `clang-format` clean on the touched lines.

The race is a timing window between two threads and is not reproducible on demand, so there is no test for it.

## What is the effect on users?

A settings reload could leave a stale extension list cached, so a file type added or removed in advancedsettings.xml would keep the behaviour it had before the reload until the next reload or add-on event. Rare, and it corrects itself; it no longer happens.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
