### PR TITLE
[Filesystem][Win32] Futher improvements and fixes to optical drive handling.

### DIFF
--- a/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/SystemGUIInfo.cpp
@@ -530,9 +530,18 @@ bool CSystemGUIInfo::GetBool(bool& value,
 #endif
     case SYSTEM_MEDIA_BLURAY_PLAYLIST:
 #if defined(HAS_OPTICAL_DRIVE) && defined(HAVE_LIBBLURAY)
-      if (CServiceBroker::GetMediaManager().IsDiscInDrive())
+    {
+      std::string devicePath;
+      if (gitem && gitem->IsFileItem())
       {
-        value = CServiceBroker::GetMediaManager().HasMediaBlurayPlaylist();
+        const auto* item{static_cast<const CFileItem*>(gitem)};
+        if (item->IsDVD())
+          devicePath = item->GetPath();
+      }
+
+      if (CServiceBroker::GetMediaManager().IsDiscInDrive(devicePath))
+      {
+        value = CServiceBroker::GetMediaManager().HasMediaBlurayPlaylist(devicePath);
       }
       else
 #endif
@@ -540,6 +549,7 @@ bool CSystemGUIInfo::GetBool(bool& value,
         value = false;
       }
       return true;
+    }
     case SYSTEM_CAN_POWERDOWN:
       value = CServiceBroker::GetPowerManager().CanPowerdown();
       return true;

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -552,7 +552,7 @@ HRESULT CWIN32Util::ToggleTray(const char cDriveLetter)
   }
 
   auto strVolFormat = ToW(StringUtils::Format("\\\\.\\{}:", cDL));
-  HANDLE hDrive= CreateFile( strVolFormat.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+  HANDLE hDrive= CreateFile( strVolFormat.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
                              NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
   auto strRootFormat = ToW(StringUtils::Format("{}:\\", cDL));
   if( ( hDrive != INVALID_HANDLE_VALUE || GetLastError() == NO_ERROR) &&

--- a/xbmc/platform/win32/WIN32Util.cpp
+++ b/xbmc/platform/win32/WIN32Util.cpp
@@ -105,8 +105,6 @@ int CWIN32Util::GetDriveStatus(const std::string &strPath, bool bStatusEx)
   T_SPDT_SBUF sptd_sb = {}; // SCSI Pass Through Direct variable.
   byte DataBuf[8] = {}; // Buffer for holding data to/from drive.
 
-  CLog::LogF(LOGDEBUG, "Requesting status for drive {}.", strPath);
-
   hDevice = CreateFile( strPathW.c_str(),                  // drive
                         0,                                // no access to the drive
                         FILE_SHARE_READ,                  // share mode
@@ -121,7 +119,6 @@ int CWIN32Util::GetDriveStatus(const std::string &strPath, bool bStatusEx)
     return -1;
   }
 
-  CLog::LogF(LOGDEBUG, "Requesting media status for drive {}.", strPath);
   iResult = DeviceIoControl((HANDLE) hDevice,             // handle to device
                              IOCTL_STORAGE_CHECK_VERIFY2, // dwIoControlCode
                              NULL,                        // lpInBuffer

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -400,10 +400,33 @@ MEDIA_DETECT::STORAGE::StorageDevice CWin32StorageProvider::GetStorageDevice(
   return device;
 }
 
+bool CWin32StorageProvider::IsSameChange(StorageEventType a, StorageEventType b)
+{
+  const auto normalize = [](StorageEventType t)
+  { return t == StorageEventType::UNSAFELY_REMOVED ? StorageEventType::SAFELY_REMOVED : t; };
+  return normalize(a) == normalize(b);
+}
+
+void CWin32StorageProvider::ForgetLastEvent(const std::string& devicePath)
+{
+  std::unique_lock lock(m_eventsSection);
+  m_lastQueuedEvent.erase(devicePath);
+}
+
 void CWin32StorageProvider::QueueStorageEvent(StorageEventType type,
                                               const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
   std::unique_lock lock(m_eventsSection);
+
+  const auto it{m_lastQueuedEvent.find(device.path)};
+  if (it != m_lastQueuedEvent.end() && IsSameChange(it->second, type))
+  {
+    CLog::LogF(LOGDEBUG, "Ignoring repeated event for {} - already reported by another channel",
+               device.path);
+    return;
+  }
+
+  m_lastQueuedEvent.insert_or_assign(device.path, type);
   m_events.emplace_back(StorageEvent{type, device});
 }
 

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -226,8 +226,11 @@ void CWin32StorageProvider::GetDrivesByType(std::vector<CMediaSource>& localDriv
         wchar_t cVolumeName[100] = {};
         int nResult = 0;
         // don't use GetVolumeInformation on fdd's as the floppy controller may be enabled in Bios but
-        // no floppy HW is attached which causes huge delays.
-        if (uDriveType != DRIVE_REMOTE && !letter.empty() && letter != L"A:" && letter != L"B:")
+        // no floppy HW is attached which causes huge delays. Nor on optical drives when only the
+        // drive letters are wanted, as it waits on a drive that is spinning up.
+        const bool wantVolumeInfo{eDriveType != DVD_DRIVES || bonlywithmedia};
+        if (wantVolumeInfo && uDriveType != DRIVE_REMOTE && !letter.empty() && letter != L"A:" &&
+            letter != L"B:")
         {
           DWORD len = sizeof(cVolumeName) / sizeof(wchar_t);
           nResult = GetVolumeInformationW(strWdrive.c_str(), cVolumeName, len, 0, 0, 0, nullptr, 0);

--- a/xbmc/platform/win32/storage/Win32StorageProvider.cpp
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.cpp
@@ -427,7 +427,25 @@ void CWin32StorageProvider::QueueStorageEvent(StorageEventType type,
   }
 
   m_lastQueuedEvent.insert_or_assign(device.path, type);
+  m_arrivingDrives.erase(device.path);
   m_events.emplace_back(StorageEvent{type, device});
+}
+
+void CWin32StorageProvider::NoteOpticalArrival(const std::string& devicePath)
+{
+  std::unique_lock lock(m_eventsSection);
+
+  const auto last{m_lastQueuedEvent.find(devicePath)};
+  if (last != m_lastQueuedEvent.end() && last->second == StorageEventType::ADDED)
+    return;
+
+  m_arrivingDrives.insert(devicePath);
+}
+
+bool CWin32StorageProvider::ConfirmOpticalArrival(const std::string& devicePath)
+{
+  std::unique_lock lock(m_eventsSection);
+  return m_arrivingDrives.erase(devicePath) != 0;
 }
 
 bool CWin32StorageProvider::PumpDriveChangeEvents(IStorageEventsCallback* callback)

--- a/xbmc/platform/win32/storage/Win32StorageProvider.h
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.h
@@ -12,6 +12,7 @@
 #include "threads/CriticalSection.h"
 
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -56,9 +57,8 @@ public:
 
   /*! \brief Called from the windowing thread to queue a change
    *
-   * Optical media changes can reach us over both WM_DEVICECHANGE and the shell's
-   * WM_MEDIA_CHANGE. A change matching the last one queued for the same drive is dropped,
-   * until ForgetLastEvent() says otherwise.
+   * Optical media changes can reach us over more than one channel. A change matching the last
+   * one queued for the same drive is dropped, until ForgetLastEvent() says otherwise.
    * \sa ForgetLastEvent
    */
   static void QueueStorageEvent(StorageEventType type,
@@ -68,6 +68,22 @@ public:
    * \param devicePath The drive path, as it appears in the events queued for it
    */
   static void ForgetLastEvent(const std::string& devicePath);
+
+  /*! \brief Note that a drive has reported media arriving
+   *
+   * The drive reports this before the volume is mounted, so nothing is queued until the mount
+   * follows. \sa ConfirmOpticalArrival
+   * \param devicePath The drive path (e.g. "D:")
+   */
+  static void NoteOpticalArrival(const std::string& devicePath);
+
+  /*! \brief Whether a volume mount on a drive follows an arrival it reported
+   *
+   * A drive also reports a mount for every attempt to read it while empty, so a mount only counts
+   * as an arrival when the drive has announced one since its last removal.
+   * \param devicePath The drive path (e.g. "D:")
+   */
+  static bool ConfirmOpticalArrival(const std::string& devicePath);
 
   static void SetEvent() { xbevent = true; }
   static bool xbevent;
@@ -88,5 +104,7 @@ private:
 
   inline static std::vector<StorageEvent> m_events;
   inline static std::map<std::string, StorageEventType> m_lastQueuedEvent;
+  /*! Drives that have reported media arriving and whose volume has yet to mount */
+  inline static std::set<std::string> m_arrivingDrives;
   inline static CCriticalSection m_eventsSection;
 };

--- a/xbmc/platform/win32/storage/Win32StorageProvider.h
+++ b/xbmc/platform/win32/storage/Win32StorageProvider.h
@@ -11,6 +11,8 @@
 #include "storage/IStorageProvider.h"
 #include "threads/CriticalSection.h"
 
+#include <map>
+#include <string>
 #include <vector>
 
 #include <Cfgmgr32.h>
@@ -52,9 +54,20 @@ public:
   // Build a StorageDevice descriptor from a drive root (eg. "D:")
   static MEDIA_DETECT::STORAGE::StorageDevice GetStorageDevice(const std::string& drive);
 
-  // Called from the windowing thread to queue a change for the next pump
+  /*! \brief Called from the windowing thread to queue a change
+   *
+   * Optical media changes can reach us over both WM_DEVICECHANGE and the shell's
+   * WM_MEDIA_CHANGE. A change matching the last one queued for the same drive is dropped,
+   * until ForgetLastEvent() says otherwise.
+   * \sa ForgetLastEvent
+   */
   static void QueueStorageEvent(StorageEventType type,
                                 const MEDIA_DETECT::STORAGE::StorageDevice& device);
+
+  /*! \brief Discard what was last queued for a drive, so the next event is not taken for a repeat
+   * \param devicePath The drive path, as it appears in the events queued for it
+   */
+  static void ForgetLastEvent(const std::string& devicePath);
 
   static void SetEvent() { xbevent = true; }
   static bool xbevent;
@@ -71,6 +84,9 @@ private:
     MEDIA_DETECT::STORAGE::StorageDevice device;
   };
 
+  static bool IsSameChange(StorageEventType a, StorageEventType b);
+
   inline static std::vector<StorageEvent> m_events;
+  inline static std::map<std::string, StorageEventType> m_lastQueuedEvent;
   inline static CCriticalSection m_eventsSection;
 };

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -486,13 +486,55 @@ DriveState CMediaManager::GetDriveStatus(const std::string& devicePath)
   if (!m_bOpticalDrivePresent || !m_platformDiscDriveHander)
     return DriveState::NOT_READY;
 
-  std::string translatedDevicePath = TranslateDevicePath(devicePath, true);
-  return m_platformDiscDriveHander->GetDriveState(translatedDevicePath);
+  const std::string translatedDevicePath{TranslateDevicePath(devicePath, true)};
+
+  // SYSTEM_MEDIA_DVD, SYSTEM_DVDREADY and SYSTEM_TRAYOPEN are evaluated by the GUI on every
+  // frame while a skin exposes them, so answer from what was last seen. Everything that can
+  // change a drive's state clears this first - see ResetDriveStatusCache()
+  {
+    std::unique_lock lock(m_driveStatusSection);
+    const auto it{m_driveStatusCache.find(translatedDevicePath)};
+    if (it != m_driveStatusCache.end())
+      return it->second;
+  }
+
+  // Deliberately queried without holding m_driveStatusSection - this can block for seconds on a
+  // drive that is spinning up, and no other caller should have to wait behind it.
+  const DriveState state{m_platformDiscDriveHander->GetDriveState(translatedDevicePath)};
+
+  {
+    std::unique_lock lock(m_driveStatusSection);
+    m_driveStatusCache.insert_or_assign(translatedDevicePath, state);
+
+    const auto logged{m_driveStatusLogged.find(translatedDevicePath)};
+    if (logged == m_driveStatusLogged.end() || logged->second != state)
+    {
+      m_driveStatusLogged.insert_or_assign(translatedDevicePath, state);
+      CLog::LogF(LOGDEBUG, "Drive {} state is now {}", translatedDevicePath,
+                 static_cast<int>(state));
+    }
+  }
+
+  return state;
 #else
   return MEDIA_DETECT::CDetectDVDMedia::GetDriveState();
 #endif
 #else
   return DriveState::NOT_READY;
+#endif
+}
+
+void CMediaManager::ResetDriveStatusCache(const std::string& devicePath)
+{
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+  const std::string translatedDevicePath{devicePath.empty() ? std::string{}
+                                                           : TranslateDevicePath(devicePath, true)};
+
+  std::unique_lock lock(m_driveStatusSection);
+  if (translatedDevicePath.empty())
+    m_driveStatusCache.clear();
+  else
+    m_driveStatusCache.erase(translatedDevicePath);
 #endif
 }
 
@@ -703,8 +745,14 @@ std::shared_ptr<IDiscDriveHandler> CMediaManager::GetDiscDriveHandler()
 
 void CMediaManager::SetHasOpticalDrive(bool bstatus)
 {
-  std::unique_lock waitLock(m_muAutoSource);
-  m_bOpticalDrivePresent = bstatus;
+  bool changed{false};
+  {
+    std::unique_lock waitLock(m_muAutoSource);
+    changed = m_bOpticalDrivePresent != bstatus;
+    m_bOpticalDrivePresent = bstatus;
+  }
+  if (changed)
+    ResetDriveStatusCache();
 }
 
 bool CMediaManager::Eject(const std::string& mountpath)
@@ -713,7 +761,9 @@ bool CMediaManager::Eject(const std::string& mountpath)
 #ifdef HAVE_LIBBLURAY
   m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
 #endif
-  return m_platformStorage->Eject(mountpath);
+  const bool ejected{m_platformStorage->Eject(mountpath)};
+  ResetDriveStatusCache(mountpath);
+  return ejected;
 }
 
 void CMediaManager::EjectTray( const bool bEject, const char cDriveLetter )
@@ -724,7 +774,9 @@ void CMediaManager::EjectTray( const bool bEject, const char cDriveLetter )
 #ifdef HAVE_LIBBLURAY
     m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
 #endif
-    m_platformDiscDriveHander->EjectDriveTray(TranslateDevicePath(""));
+    const std::string devicePath{TranslateDevicePath("")};
+    m_platformDiscDriveHander->EjectDriveTray(devicePath);
+    ResetDriveStatusCache(devicePath);
   }
 #endif
 }
@@ -737,7 +789,9 @@ void CMediaManager::CloseTray(const char cDriveLetter)
 #ifdef HAVE_LIBBLURAY
     m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
 #endif
-    m_platformDiscDriveHander->ToggleDriveTray(TranslateDevicePath(""));
+    const std::string devicePath{TranslateDevicePath("")};
+    m_platformDiscDriveHander->ToggleDriveTray(devicePath);
+    ResetDriveStatusCache(devicePath);
   }
 #endif
 }
@@ -750,7 +804,9 @@ void CMediaManager::ToggleTray(const char cDriveLetter)
 #ifdef HAVE_LIBBLURAY
     m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
 #endif
-    m_platformDiscDriveHander->ToggleDriveTray(TranslateDevicePath(""));
+    const std::string devicePath{TranslateDevicePath("")};
+    m_platformDiscDriveHander->ToggleDriveTray(devicePath);
+    ResetDriveStatusCache(devicePath);
   }
 #endif
 }
@@ -767,13 +823,21 @@ void CMediaManager::ProcessEvents()
     // so we have to refresh m_strFirstAvailDrive when this happens after Initialize
     // was called (e.x. the disc was inserted after the start of xbmc)
     // else TranslateDevicePath wouldn't give the correct device
-    m_strFirstAvailDrive = m_platformStorage->GetFirstOpticalDeviceFileName();
+    {
+      const std::string firstDrive{m_platformStorage->GetFirstOpticalDeviceFileName()};
+      std::unique_lock waitLock(m_muAutoSource);
+      m_strFirstAvailDrive = firstDrive;
+    }
 #elif defined(TARGET_WINDOWS)
     // On Windows, virtual drives can appear or disappear at any time.
     // Re-scan to get the current state of optical drives and update
     // m_bhasoptical and m_strFirstAvailDrive accordingly.
-    m_strFirstAvailDrive = m_platformStorage->GetFirstOpticalDeviceFileName();
-    SetHasOpticalDrive(!m_strFirstAvailDrive.empty());
+    const std::string firstDrive{m_platformStorage->GetFirstOpticalDeviceFileName()};
+    {
+      std::unique_lock waitLock(m_muAutoSource);
+      m_strFirstAvailDrive = firstDrive;
+    }
+    SetHasOpticalDrive(!firstDrive.empty());
 #endif
 #endif
 
@@ -816,13 +880,17 @@ void CMediaManager::AddOpticalSource(const std::string& devicePath)
 
 void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
+  ResetDriveStatusCache(device.path);
 #ifdef HAS_OPTICAL_DRIVE
   if (device.type == MEDIA_DETECT::STORAGE::Type::OPTICAL)
   {
 #ifdef TARGET_WINDOWS
     SetHasOpticalDrive(true); // In case drive appeared after startup (eg. virtual drive)
-    if (m_strFirstAvailDrive.empty())
-      m_strFirstAvailDrive = device.path;
+    {
+      std::unique_lock waitLock(m_muAutoSource);
+      if (m_strFirstAvailDrive.empty())
+        m_strFirstAvailDrive = device.path;
+    }
     AddOpticalSource(device.path);
 #endif
 
@@ -905,6 +973,7 @@ void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& d
 
 void CMediaManager::OnStorageSafelyRemoved(const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
+  ResetDriveStatusCache(device.path);
 #ifdef TARGET_WINDOWS
   if (device.type == MEDIA_DETECT::STORAGE::Type::OPTICAL)
   {
@@ -922,6 +991,7 @@ void CMediaManager::OnStorageSafelyRemoved(const MEDIA_DETECT::STORAGE::StorageD
 
 void CMediaManager::OnStorageUnsafelyRemoved(const MEDIA_DETECT::STORAGE::StorageDevice& device)
 {
+  ResetDriveStatusCache(device.path);
 #ifdef TARGET_WINDOWS
   if (device.type == MEDIA_DETECT::STORAGE::Type::OPTICAL)
   {

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -421,6 +421,19 @@ std::string CMediaManager::TranslateDevicePath(const std::string& devicePath, bo
   return strDevice;
 }
 
+#ifdef HAS_OPTICAL_DRIVE
+std::string CMediaManager::TranslateDriveLetter(const char cDriveLetter)
+{
+#ifdef TARGET_WINDOWS
+  // A drive letter only identifies a drive on Windows. Elsewhere the device path is not
+  // letter based and callers always leave cDriveLetter at its default.
+  if (cDriveLetter != '\0')
+    return TranslateDevicePath(StringUtils::Format("{}:", cDriveLetter));
+#endif
+  return TranslateDevicePath("");
+}
+#endif
+
 bool CMediaManager::IsDiscInDrive(const std::string& devicePath)
 {
 #ifdef HAS_OPTICAL_DRIVE
@@ -800,9 +813,12 @@ void CMediaManager::EjectTray( const bool bEject, const char cDriveLetter )
 #ifdef HAS_OPTICAL_DRIVE
   if (m_platformDiscDriveHander)
   {
-    ResetBlurayPlaylistStatus();
-    const std::string devicePath{TranslateDevicePath("")};
-    m_platformDiscDriveHander->EjectDriveTray(devicePath);
+    const std::string devicePath{TranslateDriveLetter(cDriveLetter)};
+    ResetBlurayPlaylistStatus(devicePath);
+    if (bEject)
+      m_platformDiscDriveHander->EjectDriveTray(devicePath);
+    else
+      m_platformDiscDriveHander->CloseDriveTray(devicePath);
     ResetDriveStatusCache(devicePath);
   }
 #endif
@@ -813,9 +829,9 @@ void CMediaManager::CloseTray(const char cDriveLetter)
 #ifdef HAS_OPTICAL_DRIVE
   if (m_platformDiscDriveHander)
   {
-    ResetBlurayPlaylistStatus();
-    const std::string devicePath{TranslateDevicePath("")};
-    m_platformDiscDriveHander->ToggleDriveTray(devicePath);
+    const std::string devicePath{TranslateDriveLetter(cDriveLetter)};
+    ResetBlurayPlaylistStatus(devicePath);
+    m_platformDiscDriveHander->CloseDriveTray(devicePath);
     ResetDriveStatusCache(devicePath);
   }
 #endif
@@ -826,8 +842,8 @@ void CMediaManager::ToggleTray(const char cDriveLetter)
 #ifdef HAS_OPTICAL_DRIVE
   if (m_platformDiscDriveHander)
   {
-    ResetBlurayPlaylistStatus();
-    const std::string devicePath{TranslateDevicePath("")};
+    const std::string devicePath{TranslateDriveLetter(cDriveLetter)};
+    ResetBlurayPlaylistStatus(devicePath);
     m_platformDiscDriveHander->ToggleDriveTray(devicePath);
     ResetDriveStatusCache(devicePath);
   }

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -53,6 +53,10 @@
 #endif
 #endif
 
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+#include "platform/win32/storage/Win32StorageProvider.h"
+#endif
+
 #include <string>
 #include <vector>
 
@@ -878,6 +882,16 @@ void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& d
       if (m_strFirstAvailDrive.empty())
         m_strFirstAvailDrive = device.path;
     }
+
+    // Windows reports a tray closing on nothing as an arrival
+    // Have to identify from the drive (otherwise we would announce an empty drive)
+    const DriveState state{GetDriveStatus(device.path)};
+    if (state == DriveState::CLOSED_NO_MEDIA || state == DriveState::OPEN)
+    {
+      CWin32StorageProvider::ForgetLastEvent(device.path);
+      return;
+    }
+
     AddOpticalSource(device.path);
 #endif
 

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -519,7 +519,7 @@ void CMediaManager::InvalidateDiscInfo(const std::string& devicePath)
   RemoveCdInfo(devicePath);
   // Also clears the bluray disc cache for this drive
   RemoveDiscInfo(devicePath);
-  ResetBlurayPlaylistStatus();
+  ResetBlurayPlaylistStatus(devicePath);
   {
     std::unique_lock lock(m_muAutoSource);
     m_volumeLabel.erase(TranslateDevicePath(devicePath));
@@ -698,32 +698,51 @@ bool CMediaManager::HasMediaBlurayPlaylist(const std::string& devicePath)
 #ifdef HAVE_LIBBLURAY
   // When the disc node is displayed, this gets called by the GUI via SYSTEM_MEDIA_BLURAY_PLAYLIST
   // in CSystemCGUIInfo at every refresh - so cache result until eject.
-  if (m_hasBlurayPlaylist != HasBlurayPlaylist::UNKNOWN)
-    return m_hasBlurayPlaylist == HasBlurayPlaylist::YES;
-
   const std::string mediaPath{TranslateDevicePath(devicePath)};
+
+  {
+    std::unique_lock lock(m_muAutoSource);
+    const auto cached{m_blurayPlaylist.find(mediaPath)};
+    if (cached != m_blurayPlaylist.end() && cached->second != HasBlurayPlaylist::UNKNOWN)
+      return cached->second == HasBlurayPlaylist::YES;
+  }
+
+  HasBlurayPlaylist status{HasBlurayPlaylist::NO};
   UTILS::DISCS::DiscInfo info{GetDiscInfo(mediaPath)};
   if (!info.empty() && info.type == UTILS::DISCS::DiscType::BLURAY)
   {
-    const std::string blurayPath{GetDiskUniqueId()};
+    const std::string blurayPath{GetDiskUniqueId(devicePath)};
     CVideoDatabase db;
     if (db.Open())
     {
       const std::string path{db.GetRemovableBlurayPath(blurayPath)};
       db.Close();
-      m_hasBlurayPlaylist = path.empty() ? HasBlurayPlaylist::NO : HasBlurayPlaylist::YES;
-      return !path.empty();
+      status = path.empty() ? HasBlurayPlaylist::NO : HasBlurayPlaylist::YES;
     }
   }
-  m_hasBlurayPlaylist = HasBlurayPlaylist::NO;
-#endif
+
+  {
+    std::unique_lock lock(m_muAutoSource);
+    m_blurayPlaylist.insert_or_assign(mediaPath, status);
+  }
+
+  return status == HasBlurayPlaylist::YES;
+#else
   return false;
+#endif
 }
 
-void CMediaManager::ResetBlurayPlaylistStatus()
+void CMediaManager::ResetBlurayPlaylistStatus(const std::string& devicePath)
 {
 #ifdef HAVE_LIBBLURAY
-  m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
+  const std::string mediaPath{devicePath.empty() ? std::string{}
+                                                 : TranslateDevicePath(devicePath)};
+
+  std::unique_lock lock(m_muAutoSource);
+  if (mediaPath.empty())
+    m_blurayPlaylist.clear();
+  else
+    m_blurayPlaylist.erase(mediaPath);
 #endif
 }
 
@@ -768,8 +787,8 @@ void CMediaManager::SetHasOpticalDrive(bool bstatus)
 bool CMediaManager::Eject(const std::string& mountpath)
 {
   std::unique_lock lock(m_CritSecStorageProvider);
-#ifdef HAVE_LIBBLURAY
-  m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
+#ifdef HAS_OPTICAL_DRIVE
+  ResetBlurayPlaylistStatus(mountpath);
 #endif
   const bool ejected{m_platformStorage->Eject(mountpath)};
   ResetDriveStatusCache(mountpath);
@@ -781,9 +800,7 @@ void CMediaManager::EjectTray( const bool bEject, const char cDriveLetter )
 #ifdef HAS_OPTICAL_DRIVE
   if (m_platformDiscDriveHander)
   {
-#ifdef HAVE_LIBBLURAY
-    m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
-#endif
+    ResetBlurayPlaylistStatus();
     const std::string devicePath{TranslateDevicePath("")};
     m_platformDiscDriveHander->EjectDriveTray(devicePath);
     ResetDriveStatusCache(devicePath);
@@ -796,9 +813,7 @@ void CMediaManager::CloseTray(const char cDriveLetter)
 #ifdef HAS_OPTICAL_DRIVE
   if (m_platformDiscDriveHander)
   {
-#ifdef HAVE_LIBBLURAY
-    m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
-#endif
+    ResetBlurayPlaylistStatus();
     const std::string devicePath{TranslateDevicePath("")};
     m_platformDiscDriveHander->ToggleDriveTray(devicePath);
     ResetDriveStatusCache(devicePath);
@@ -811,9 +826,7 @@ void CMediaManager::ToggleTray(const char cDriveLetter)
 #ifdef HAS_OPTICAL_DRIVE
   if (m_platformDiscDriveHander)
   {
-#ifdef HAVE_LIBBLURAY
-    m_hasBlurayPlaylist = HasBlurayPlaylist::UNKNOWN;
-#endif
+    ResetBlurayPlaylistStatus();
     const std::string devicePath{TranslateDevicePath("")};
     m_platformDiscDriveHander->ToggleDriveTray(devicePath);
     ResetDriveStatusCache(devicePath);

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -389,9 +389,7 @@ void CMediaManager::RemoveAutoSource(const CMediaSource &share)
     gui->GetWindowManager().SendThreadMessage(msg);
 
 #ifdef HAS_OPTICAL_DRIVE
-  // delete cached CdInfo if any
-  RemoveCdInfo(TranslateDevicePath(share.strPath, true));
-  RemoveDiscInfo(TranslateDevicePath(share.strPath, true));
+  InvalidateDiscInfo(share.strPath);
 #endif
 }
 
@@ -515,6 +513,20 @@ DriveState CMediaManager::GetDriveStatus(const std::string& devicePath)
 #endif
 }
 
+void CMediaManager::InvalidateDiscInfo(const std::string& devicePath)
+{
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+  RemoveCdInfo(devicePath);
+  // Also clears the bluray disc cache for this drive
+  RemoveDiscInfo(devicePath);
+  ResetBlurayPlaylistStatus();
+  {
+    std::unique_lock lock(m_muAutoSource);
+    m_volumeLabel.erase(TranslateDevicePath(devicePath));
+  }
+#endif
+}
+
 void CMediaManager::ResetDriveStatusCache(const std::string& devicePath)
 {
 #if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
@@ -591,9 +603,16 @@ std::string CMediaManager::GetDiskLabel(const std::string& devicePath)
 
   std::string mediaPath = CServiceBroker::GetMediaManager().TranslateDevicePath(devicePath);
 
-  auto cached = m_mapDiscInfo.find(mediaPath);
-  if (cached != m_mapDiscInfo.end())
-    return cached->second.name;
+  {
+    std::unique_lock lock(m_muAutoSource);
+    const auto cached{m_mapDiscInfo.find(mediaPath)};
+    if (cached != m_mapDiscInfo.end() && !cached->second.name.empty())
+      return cached->second.name;
+
+    const auto label{m_volumeLabel.find(mediaPath)};
+    if (label != m_volumeLabel.end())
+      return label->second;
+  }
 
   // try to minimize the chance of a "device not ready" dialog
   std::string drivePath = CServiceBroker::GetMediaManager().TranslateDevicePath(devicePath, true);
@@ -601,13 +620,10 @@ std::string CMediaManager::GetDiskLabel(const std::string& devicePath)
       DriveState::CLOSED_MEDIA_PRESENT)
     return "";
 
-  UTILS::DISCS::DiscInfo info;
-  info = GetDiscInfo(mediaPath);
+  // GetDiscInfo() caches, so this only probes the first time for a given disc
+  const UTILS::DISCS::DiscInfo info{GetDiscInfo(mediaPath)};
   if (!info.name.empty())
-  {
-    m_mapDiscInfo[mediaPath] = info;
     return info.name;
-  }
 
   std::string strDevice = TranslateDevicePath(devicePath);
   WCHAR cVolumenName[128];
@@ -618,11 +634,14 @@ std::string CMediaManager::GetDiskLabel(const std::string& devicePath)
   if(GetVolumeInformationW(strDeviceW.c_str(), cVolumenName, 127, NULL, NULL, NULL, cFSName, 127)==0)
     return "";
   g_charsetConverter.wToUTF8(cVolumenName, strDevice);
-  info.name = StringUtils::TrimRight(strDevice, " ");
-  if (!info.name.empty())
-    m_mapDiscInfo[mediaPath] = info;
 
-  return info.name;
+  const std::string label{StringUtils::TrimRight(strDevice, " ")};
+  {
+    std::unique_lock lock(m_muAutoSource);
+    m_volumeLabel.insert_or_assign(mediaPath, label);
+  }
+
+  return label;
 #else
   return MEDIA_DETECT::CDetectDVDMedia::GetDVDLabel();
 #endif
@@ -646,7 +665,7 @@ std::string CMediaManager::GetDiskUniqueId(const std::string& devicePath)
     mediaPath = devicePath;
 
 #ifdef TARGET_WINDOWS
-  if (mediaPath.empty() || mediaPath == "iso9660://")
+  if (mediaPath.empty() || mediaPath == "iso9660://" || mediaPath == devicePath)
   {
     mediaPath = CServiceBroker::GetMediaManager().TranslateDevicePath(devicePath);
   }
@@ -875,6 +894,8 @@ void CMediaManager::OnStorageAdded(const MEDIA_DETECT::STORAGE::StorageDevice& d
 #ifdef HAS_OPTICAL_DRIVE
   if (device.type == MEDIA_DETECT::STORAGE::Type::OPTICAL)
   {
+    InvalidateDiscInfo(device.path);
+
 #ifdef TARGET_WINDOWS
     SetHasOpticalDrive(true); // In case drive appeared after startup (eg. virtual drive)
     {
@@ -982,6 +1003,7 @@ void CMediaManager::OnStorageSafelyRemoved(const MEDIA_DETECT::STORAGE::StorageD
     share.strPath = device.path;
     share.strName = device.path;
     RemoveAutoSource(share);
+    InvalidateDiscInfo(device.path);
   }
 #endif
   CGUIDialogKaiToast::QueueNotification(
@@ -1000,6 +1022,7 @@ void CMediaManager::OnStorageUnsafelyRemoved(const MEDIA_DETECT::STORAGE::Storag
     share.strPath = device.path;
     share.strName = device.path;
     RemoveAutoSource(share);
+    InvalidateDiscInfo(device.path);
   }
 #endif
   CGUIDialogKaiToast::QueueNotification(
@@ -1014,6 +1037,17 @@ UTILS::DISCS::DiscInfo CMediaManager::GetDiscInfo(const std::string& mediaPath)
   if (mediaPath.empty())
     return info;
 
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+  // Probing a Blu-ray means loading libaacs and opening the disc with it, which is expensive.
+  // So report from cache (if available)
+  {
+    std::unique_lock lock(m_muAutoSource);
+    const auto cached{m_mapDiscInfo.find(mediaPath)};
+    if (cached != m_mapDiscInfo.end())
+      return cached->second;
+  }
+#endif
+
   // Try finding VIDEO_TS/VIDEO_TS.IFO - this indicates a DVD disc is inserted
   std::string pathVideoTS = URIUtils::AddFileToFolder(mediaPath, "VIDEO_TS", "VIDEO_TS.IFO");
   // correct the filename if needed
@@ -1027,14 +1061,21 @@ UTILS::DISCS::DiscInfo CMediaManager::GetDiscInfo(const std::string& mediaPath)
   if (CFileUtils::Exists(pathVideoTS))
   {
     info = UTILS::DISCS::ProbeDVDDiscInfo(pathVideoTS);
-    if (!info.empty())
-      return info;
   }
   // check for Blu-ray discs
-  if (CFileUtils::Exists(URIUtils::AddFileToFolder(mediaPath, "BDMV", "index.bdmv")))
+  if (info.empty() &&
+      CFileUtils::Exists(URIUtils::AddFileToFolder(mediaPath, "BDMV", "index.bdmv")))
   {
     info = UTILS::DISCS::ProbeBlurayDiscInfo(mediaPath);
   }
+
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+  if (!info.empty())
+  {
+    std::unique_lock lock(m_muAutoSource);
+    m_mapDiscInfo.insert_or_assign(mediaPath, info);
+  }
+#endif
 
   return info;
 }
@@ -1043,9 +1084,10 @@ void CMediaManager::RemoveDiscInfo(const std::string& devicePath)
 {
   std::string strDevice = TranslateDevicePath(devicePath, false);
 
-  auto it = m_mapDiscInfo.find(strDevice);
-  if (it != m_mapDiscInfo.end())
-    m_mapDiscInfo.erase(it);
+  {
+    std::unique_lock lock(m_muAutoSource);
+    m_mapDiscInfo.erase(strDevice);
+  }
 
 #ifdef HAVE_LIBBLURAY
   CServiceBroker::GetBlurayDiscCache()->ClearDisc(strDevice);

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -423,19 +423,6 @@ bool CMediaManager::IsDiscInDrive(const std::string& devicePath)
 {
 #ifdef HAS_OPTICAL_DRIVE
 #ifdef TARGET_WINDOWS
-  if (!m_bOpticalDrivePresent)
-    return false;
-
-  std::string strDevice = TranslateDevicePath(devicePath, false);
-
-  // m_mapCdInfo is only populated for audio CDs
-  {
-    std::unique_lock waitLock(m_muAutoSource);
-    if (m_mapCdInfo.contains(strDevice))
-      return true;
-  }
-
-  // Check physical drive state (for video discs)
   return GetDriveStatus(devicePath) == DriveState::CLOSED_MEDIA_PRESENT;
 #else
   if(URIUtils::IsDVD(devicePath) || devicePath.empty())

--- a/xbmc/storage/MediaManager.cpp
+++ b/xbmc/storage/MediaManager.cpp
@@ -791,9 +791,13 @@ std::vector<std::string> CMediaManager::GetDiskUsage()
 #if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
 void CMediaManager::AddOpticalSource(const std::string& devicePath)
 {
+  // Standardise device path - the storage events carry "D:", while the
+  // startup enumeration passes what GetLogicalDriveStringsW() returns - "D:\"
+  const std::string drivePath{TranslateDevicePath(devicePath)};
+
   CMediaSource share;
-  share.strPath = devicePath;
-  share.strName = devicePath;
+  share.strPath = drivePath;
+  share.strName = drivePath;
 
   RemoveAutoSource(share);
 

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -85,8 +85,10 @@ public:
    * This is needed as HasMediaBlurayPlaylist() is called every screen refresh when
    * the disc node is highlighted.
    * It needs to be reset whenever a disc is ejected or played (as a playlist may have been selected).
-  */
-  void ResetBlurayPlaylistStatus();
+   *
+   * \param devicePath The optical drive it changed for, or empty for every drive
+   */
+  void ResetBlurayPlaylistStatus(const std::string& devicePath = "");
 
   /*! \brief Gets the platform disc drive handler
   * @todo this likely doesn't belong here but in some discsupport component owned by media manager
@@ -180,6 +182,6 @@ private:
   CCriticalSection m_driveStatusSection;
 #endif
 #ifdef HAVE_LIBBLURAY
-  HasBlurayPlaylist m_hasBlurayPlaylist{HasBlurayPlaylist::UNKNOWN};
+  std::map<std::string, HasBlurayPlaylist> m_blurayPlaylist;
 #endif
 };

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -175,6 +175,14 @@ private:
 
   std::map<std::string, UTILS::DISCS::DiscInfo> m_mapDiscInfo;
   std::map<std::string, std::string> m_volumeLabel;
+#ifdef HAS_OPTICAL_DRIVE
+  /*! \brief Resolve a drive letter to the device path of that drive
+   * \param cDriveLetter The drive letter (e.g. 'D'), or '\0' for the first available drive
+   * \return The device path of that drive (e.g. "D:"), or of the first available optical
+   *         drive when no letter is given
+   */
+  std::string TranslateDriveLetter(char cDriveLetter);
+#endif
 #if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
   /*! Last known state of each optical drive, to keep the GUI off the hardware - see GetDriveStatus */
   std::map<std::string, DriveState> m_driveStatusCache;

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -168,7 +168,11 @@ private:
 #endif
 
   void RemoveDiscInfo(const std::string& devicePath);
+
+  void InvalidateDiscInfo(const std::string& devicePath);
+
   std::map<std::string, UTILS::DISCS::DiscInfo> m_mapDiscInfo;
+  std::map<std::string, std::string> m_volumeLabel;
 #if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
   /*! Last known state of each optical drive, to keep the GUI off the hardware - see GetDriveStatus */
   std::map<std::string, DriveState> m_driveStatusCache;

--- a/xbmc/storage/MediaManager.h
+++ b/xbmc/storage/MediaManager.h
@@ -72,6 +72,8 @@ public:
   bool HasOpticalDrive();
   std::string TranslateDevicePath(const std::string& devicePath, bool bReturnAsDevice=false);
   DriveState GetDriveStatus(const std::string& devicePath = "");
+
+  void ResetDriveStatusCache(const std::string& devicePath = "");
 #ifdef HAS_OPTICAL_DRIVE
   MEDIA_DETECT::CCdInfo* GetCdInfo(const std::string& devicePath="");
   bool RemoveCdInfo(const std::string& devicePath="");
@@ -167,6 +169,12 @@ private:
 
   void RemoveDiscInfo(const std::string& devicePath);
   std::map<std::string, UTILS::DISCS::DiscInfo> m_mapDiscInfo;
+#if defined(TARGET_WINDOWS) && defined(HAS_OPTICAL_DRIVE)
+  /*! Last known state of each optical drive, to keep the GUI off the hardware - see GetDriveStatus */
+  std::map<std::string, DriveState> m_driveStatusCache;
+  std::map<std::string, DriveState> m_driveStatusLogged;
+  CCriticalSection m_driveStatusSection;
+#endif
 #ifdef HAVE_LIBBLURAY
   HasBlurayPlaylist m_hasBlurayPlaylist{HasBlurayPlaylist::UNKNOWN};
 #endif

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -40,11 +40,16 @@
 #include "platform/win32/powermanagement/Win32PowerSyscall.h"
 #include "platform/win32/storage/Win32StorageProvider.h"
 
+#include <algorithm>
 #include <array>
+#include <iterator>
+#include <map>
 #include <math.h>
 
 #include <Shlobj.h>
 #include <dbt.h>
+#include <initguid.h>
+#include <ioevent.h>
 
 HWND g_hWnd = nullptr;
 
@@ -83,29 +88,175 @@ SHChangeNotifyEntry shcne;
 
 namespace
 {
-/*! \brief Queue an optical media change reported by the shell notification
- *
- * WM_DEVICECHANGE is the preferred channel for optical media because it does not need
- * explorer.exe, but some systems don't broadcast it - in which case this is the only
- * notification Kodi gets. Feed it from here as well; QueueStorageEvent() deduplicates.
- *
- * \param drivePath The drive root as reported by the shell (e.g. "D:\")
- * \param bArrived true for media inserted, false for media removed
- */
-void QueueOpticalStorageEvent(const wchar_t* drivePath, const bool bArrived)
+struct OpticalDriveNotification
 {
-  std::string strDrive{KODI::PLATFORM::WINDOWS::FromW(drivePath)};
-  URIUtils::RemoveSlashAtEnd(strDrive); // "D:\" -> "D:"
+  char letter{'\0'};
+  HANDLE device{INVALID_HANDLE_VALUE};
+};
 
-  MEDIA_DETECT::STORAGE::StorageDevice device{CWin32StorageProvider::GetStorageDevice(strDrive)};
+std::map<HDEVNOTIFY, OpticalDriveNotification> g_opticalDriveNotifications;
+
+std::string DriveFromShellPath(const wchar_t* drivePath)
+{
+  std::string drive{KODI::PLATFORM::WINDOWS::FromW(drivePath)};
+  URIUtils::RemoveSlashAtEnd(drive);
+  return drive;
+}
+
+/*! \brief Queue an optical media change
+ *
+ * Optical media changes reach Kodi over more than one channel: the volume broadcast, the shell
+ * notification (which needs explorer.exe) and the drive's own device notification.
+ * QueueStorageEvent() drops repeats.
+ *
+ * \param drive The drive (e.g. "D:")
+ * \param bArrived true for media inserted, false for media removed
+ * \param channel Which notification this came from, for the log
+ */
+void QueueOpticalStorageEvent(const std::string& drive, const bool bArrived, const char* channel)
+{
+  MEDIA_DETECT::STORAGE::StorageDevice device{CWin32StorageProvider::GetStorageDevice(drive)};
   device.type = MEDIA_DETECT::STORAGE::Type::OPTICAL;
 
-  CLog::Log(LOGDEBUG, "CWinEventsWin32: Drive {} Media {} (shell notification).", strDrive,
-            bArrived ? "has arrived" : "was removed");
+  CLog::Log(LOGDEBUG, "CWinEventsWin32: Drive {} Media {} ({}).", drive,
+            bArrived ? "has arrived" : "was removed", channel);
   CWin32StorageProvider::QueueStorageEvent(
       bArrived ? CWin32StorageProvider::StorageEventType::ADDED
                : CWin32StorageProvider::StorageEventType::SAFELY_REMOVED,
       device);
+}
+
+void RegisterOpticalDrive(HWND hWnd, char letter)
+{
+  if (std::ranges::any_of(g_opticalDriveNotifications,
+                          [letter](const auto& entry) { return entry.second.letter == letter; }))
+    return;
+
+  const std::wstring path{
+      KODI::PLATFORM::WINDOWS::ToW(StringUtils::Format("\\\\.\\{}:", letter))};
+  HANDLE device{CreateFileW(path.c_str(), 0, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+                            OPEN_EXISTING, 0, nullptr)};
+  if (device == INVALID_HANDLE_VALUE)
+  {
+    CLog::LogF(LOGDEBUG, "Could not open drive {}: for media notifications ({})", letter,
+               GetLastError());
+    return;
+  }
+
+  DEV_BROADCAST_HANDLE filter{};
+  filter.dbch_size = sizeof(filter);
+  filter.dbch_devicetype = DBT_DEVTYP_HANDLE;
+  filter.dbch_handle = device;
+  HDEVNOTIFY notify{RegisterDeviceNotification(hWnd, &filter, DEVICE_NOTIFY_WINDOW_HANDLE)};
+  if (!notify)
+  {
+    CLog::LogF(LOGDEBUG, "Could not register drive {}: for media notifications ({})", letter,
+               GetLastError());
+    CloseHandle(device);
+    return;
+  }
+
+  g_opticalDriveNotifications.emplace(notify, OpticalDriveNotification{letter, device});
+  CLog::LogF(LOGDEBUG, "Registered drive {}: for media notifications", letter);
+}
+
+void RegisterOpticalDrives(HWND hWnd)
+{
+  DWORD drives{GetLogicalDrives()};
+  for (char letter = 'A'; letter <= 'Z'; ++letter, drives >>= 1)
+  {
+    if (!(drives & 1))
+      continue;
+
+    const std::wstring root{KODI::PLATFORM::WINDOWS::ToW(StringUtils::Format("{}:\\", letter))};
+    if (GetDriveTypeW(root.c_str()) == DRIVE_CDROM)
+      RegisterOpticalDrive(hWnd, letter);
+  }
+}
+
+void UnregisterOpticalDrive(HDEVNOTIFY notify)
+{
+  const auto it{g_opticalDriveNotifications.find(notify)};
+  if (it == g_opticalDriveNotifications.end())
+    return;
+
+  UnregisterDeviceNotification(it->first);
+  if (it->second.device != INVALID_HANDLE_VALUE)
+    CloseHandle(it->second.device);
+  CLog::LogF(LOGDEBUG, "Unregistered drive {}: from media notifications", it->second.letter);
+  g_opticalDriveNotifications.erase(it);
+}
+
+void UnregisterOpticalDrives()
+{
+  while (!g_opticalDriveNotifications.empty())
+    UnregisterOpticalDrive(g_opticalDriveNotifications.begin()->first);
+}
+
+/*! \brief Handle a WM_DEVICECHANGE about a drive registered with RegisterOpticalDrive()
+ * \return Whether the message concerned one of those drives
+ */
+bool OnOpticalDriveNotification(HWND hWnd, WPARAM wParam, const DEV_BROADCAST_HANDLE& hdr)
+{
+  const auto it{g_opticalDriveNotifications.find(hdr.dbch_hdevnotify)};
+  if (it == g_opticalDriveNotifications.end())
+    return false;
+
+  const char letter{it->second.letter};
+  const std::string drive{StringUtils::Format("{}:", letter)};
+
+  switch (wParam)
+  {
+    case DBT_CUSTOMEVENT:
+      if (IsEqualGUID(hdr.dbch_eventguid, GUID_IO_MEDIA_REMOVAL))
+      {
+        QueueOpticalStorageEvent(drive, false, "device notification");
+      }
+      else if (IsEqualGUID(hdr.dbch_eventguid, GUID_IO_MEDIA_ARRIVAL))
+      {
+        CLog::LogF(LOGDEBUG, "Drive {} Media has arrived (device notification).", drive);
+        CWin32StorageProvider::NoteOpticalArrival(drive);
+      }
+      else if (IsEqualGUID(hdr.dbch_eventguid, GUID_IO_DEVICE_BECOMING_READY))
+      {
+        CLog::LogF(LOGDEBUG, "Drive {} is becoming ready", drive);
+      }
+      else if (IsEqualGUID(hdr.dbch_eventguid, GUID_IO_VOLUME_MOUNT))
+      {
+        if (CWin32StorageProvider::ConfirmOpticalArrival(drive))
+          QueueOpticalStorageEvent(drive, true, "device notification");
+        else
+          CLog::LogF(LOGDEBUG, "Drive {} volume mounted", drive);
+      }
+      else
+      {
+        wchar_t guid[40]{};
+        StringFromGUID2(hdr.dbch_eventguid, guid, static_cast<int>(std::size(guid)));
+        CLog::LogF(LOGDEBUG, "Drive {} device notification {} ignored", drive,
+                   KODI::PLATFORM::WINDOWS::FromW(guid));
+      }
+      break;
+    case DBT_DEVICEQUERYREMOVE:
+      CLog::LogF(LOGDEBUG, "Drive {} is being removed - releasing it", drive);
+      if (it->second.device != INVALID_HANDLE_VALUE)
+      {
+        CloseHandle(it->second.device);
+        it->second.device = INVALID_HANDLE_VALUE;
+      }
+      break;
+    case DBT_DEVICEQUERYREMOVEFAILED:
+      CLog::LogF(LOGDEBUG, "Drive {} removal was cancelled", drive);
+      UnregisterOpticalDrive(hdr.dbch_hdevnotify);
+      RegisterOpticalDrive(hWnd, letter);
+      break;
+    case DBT_DEVICEREMOVECOMPLETE:
+      UnregisterOpticalDrive(hdr.dbch_hdevnotify);
+      CWin32StorageProvider::SetEvent();
+      break;
+    default:
+      break;
+  }
+  return true;
 }
 } // unnamed namespace
 
@@ -279,6 +430,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
     long fEvents = SHCNE_DRIVEADD | SHCNE_DRIVEREMOVED | SHCNE_MEDIAREMOVED | SHCNE_MEDIAINSERTED;
     SHChangeNotifyRegister(hWnd, SHCNRF_ShellLevel | SHCNRF_NewDelivery, fEvents, WM_MEDIA_CHANGE, 1, &shcne);
     RegisterDeviceInterfaceToHwnd(USB_HID_GUID, hWnd, &hDeviceNotify);
+    RegisterOpticalDrives(hWnd);
     return 0;
   }
 
@@ -302,6 +454,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
         else
           CLog::LogF(LOGINFO, "UnregisterDeviceNotification failed ({})", GetLastError());
       }
+      UnregisterOpticalDrives();
       newEvent.type = XBMC_QUIT;
       if (appPort)
         appPort->OnEvent(newEvent);
@@ -776,7 +929,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 CWin32StorageProvider::SetEvent();
               }
               else
-                QueueOpticalStorageEvent(drivePath, true);
+                QueueOpticalStorageEvent(DriveFromShellPath(drivePath), true, "shell notification");
               break;
 
             case SHCNE_DRIVEREMOVED:
@@ -787,7 +940,7 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 CWin32StorageProvider::SetEvent();
               }
               else
-                QueueOpticalStorageEvent(drivePath, false);
+                QueueOpticalStorageEvent(DriveFromShellPath(drivePath), false, "shell notification");
               break;
             default:;
           }
@@ -814,8 +967,21 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
           case DBT_DEVNODES_CHANGED:
             CServiceBroker::GetPeripherals().TriggerDeviceScan(PERIPHERALS::PERIPHERAL_BUS_USB);
             break;
+          case DBT_CUSTOMEVENT:
+          case DBT_DEVICEQUERYREMOVE:
+          case DBT_DEVICEQUERYREMOVEFAILED:
+            if (lParam && ((_DEV_BROADCAST_HEADER*)lParam)->dbcd_devicetype == DBT_DEVTYP_HANDLE)
+              OnOpticalDriveNotification(hWnd, wParam,
+                                         *reinterpret_cast<DEV_BROADCAST_HANDLE*>(lParam));
+            break;
           case DBT_DEVICEARRIVAL:
           case DBT_DEVICEREMOVECOMPLETE:
+            if (((_DEV_BROADCAST_HEADER*)lParam)->dbcd_devicetype == DBT_DEVTYP_HANDLE)
+            {
+              OnOpticalDriveNotification(hWnd, wParam,
+                                         *reinterpret_cast<DEV_BROADCAST_HANDLE*>(lParam));
+              break;
+            }
             if (((_DEV_BROADCAST_HEADER*) lParam)->dbcd_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
             {
               CServiceBroker::GetPeripherals().TriggerDeviceScan(PERIPHERALS::PERIPHERAL_BUS_USB);
@@ -825,8 +991,8 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
             {
               PDEV_BROADCAST_VOLUME lpdbv = (PDEV_BROADCAST_VOLUME)((_DEV_BROADCAST_HEADER*)lParam);
 
-              std::string strdrive =
-                  StringUtils::Format("{}:", CWIN32Util::FirstDriveFromMask(lpdbv->dbcv_unitmask));
+              const char letter{CWIN32Util::FirstDriveFromMask(lpdbv->dbcv_unitmask)};
+              std::string strdrive = StringUtils::Format("{}:", letter);
 
               MEDIA_DETECT::STORAGE::StorageDevice device =
                   CWin32StorageProvider::GetStorageDevice(strdrive);
@@ -834,6 +1000,11 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
               // DBTF_MEDIA set => optical disc (media) change rather than a USB volume
               if (lpdbv->dbcv_flags & DBTF_MEDIA)
                 device.type = MEDIA_DETECT::STORAGE::Type::OPTICAL;
+
+              if (wParam == DBT_DEVICEARRIVAL &&
+                  GetDriveTypeW(KODI::PLATFORM::WINDOWS::ToW(strdrive + "\\").c_str()) ==
+                      DRIVE_CDROM)
+                RegisterOpticalDrive(hWnd, letter);
 
               if (wParam == DBT_DEVICEARRIVAL)
               {

--- a/xbmc/windowing/windows/WinEventsWin32.cpp
+++ b/xbmc/windowing/windows/WinEventsWin32.cpp
@@ -12,7 +12,6 @@
 #include "WinEventsWin32.h"
 
 #include "ServiceBroker.h"
-#include "Util.h"
 #include "WinKeyMap.h"
 #include "application/AppInboundProtocol.h"
 #include "application/Application.h"
@@ -28,17 +27,15 @@
 #include "input/mouse/MouseStat.h"
 #include "input/touch/generic/GenericTouchActionHandler.h"
 #include "input/touch/generic/GenericTouchSwipeDetector.h"
-#include "jobs/JobManager.h"
 #include "messaging/ApplicationMessenger.h"
 #include "network/Zeroconf.h"
 #include "network/ZeroconfBrowser.h"
 #include "peripherals/Peripherals.h"
 #include "rendering/dx/RenderContext.h"
-#include "storage/MediaManager.h"
 #include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
 #include "utils/log.h"
 
-#include "platform/win32/CharsetConverter.h"
 #include "platform/win32/WIN32Util.h"
 #include "platform/win32/powermanagement/Win32PowerSyscall.h"
 #include "platform/win32/storage/Win32StorageProvider.h"
@@ -83,6 +80,34 @@ CGenericTouchSwipeDetector* CWinEventsWin32::m_touchSwipeDetector = nullptr;
 // seen at http://www.codeproject.com/Messages/2897423/Re-No-message-triggered-on-SD-card-insertion-remov.aspx
 #define WM_MEDIA_CHANGE (WM_USER + 666)
 SHChangeNotifyEntry shcne;
+
+namespace
+{
+/*! \brief Queue an optical media change reported by the shell notification
+ *
+ * WM_DEVICECHANGE is the preferred channel for optical media because it does not need
+ * explorer.exe, but some systems don't broadcast it - in which case this is the only
+ * notification Kodi gets. Feed it from here as well; QueueStorageEvent() deduplicates.
+ *
+ * \param drivePath The drive root as reported by the shell (e.g. "D:\")
+ * \param bArrived true for media inserted, false for media removed
+ */
+void QueueOpticalStorageEvent(const wchar_t* drivePath, const bool bArrived)
+{
+  std::string strDrive{KODI::PLATFORM::WINDOWS::FromW(drivePath)};
+  URIUtils::RemoveSlashAtEnd(strDrive); // "D:\" -> "D:"
+
+  MEDIA_DETECT::STORAGE::StorageDevice device{CWin32StorageProvider::GetStorageDevice(strDrive)};
+  device.type = MEDIA_DETECT::STORAGE::Type::OPTICAL;
+
+  CLog::Log(LOGDEBUG, "CWinEventsWin32: Drive {} Media {} (shell notification).", strDrive,
+            bArrived ? "has arrived" : "was removed");
+  CWin32StorageProvider::QueueStorageEvent(
+      bArrived ? CWin32StorageProvider::StorageEventType::ADDED
+               : CWin32StorageProvider::StorageEventType::SAFELY_REMOVED,
+      device);
+}
+} // unnamed namespace
 
 static int XBMC_MapVirtualKey(int scancode, WPARAM vkey)
 {
@@ -728,8 +753,9 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
         // It only works if the explorer.exe process is started. Because this
         // isn't the case for all setups we use WM_DEVICECHANGE for usb and
         // optical media because this event is also triggered without the
-        // explorer process. Since WM_DEVICECHANGE doesn't detect sd card changes
-        // we still use this event only for sd.
+        // explorer process. WM_DEVICECHANGE doesn't detect sd card changes, and
+        // doesn't always report optical media, so this event covers sd and is a
+        // second channel for optical.
         long lEvent;
         PIDLIST_ABSOLUTE *ppidl;
         HANDLE hLock = SHChangeNotification_Lock(reinterpret_cast<HANDLE>(wParam), static_cast<DWORD>(lParam), &ppidl, &lEvent);
@@ -749,6 +775,8 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 CLog::LogF(LOGDEBUG, "Drive {} Media has arrived.", FromW(drivePath));
                 CWin32StorageProvider::SetEvent();
               }
+              else
+                QueueOpticalStorageEvent(drivePath, true);
               break;
 
             case SHCNE_DRIVEREMOVED:
@@ -758,6 +786,8 @@ LRESULT CALLBACK CWinEventsWin32::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 CLog::LogF(LOGDEBUG, "Drive {} Media was removed.", FromW(drivePath));
                 CWin32StorageProvider::SetEvent();
               }
+              else
+                QueueOpticalStorageEvent(drivePath, false);
               break;
             default:;
           }


### PR DESCRIPTION
## Description
<!--- Provide a general summary of your change in the Pull Request title above -->
<!--- Describe your change in detail here. -->

Fixes:
- Context menu -> Eject always ejects the first optical drive irrespective of the drive selected in Video -> Files
- Excess logging (once per GUI frame)
- Disc insertions and removals sometimes not detected at all, when WM_DEVICECHANGE doesn't arrive.
- A disc present at startup could stay in Video → Files after it was ejected
- Blu-ray playlist status was shared across all drives rather than per disc

Note - the GUI freezes whilst disc loaded/ejected commits were getting a bit big so I'll do those as a follow up ? v22/v23.

Commit notes

1 — Key an optical source by the standardised path Startup passes "D:\" from GetLogicalDriveStringsW() while storage events carry "D:", so a source added at startup could not be matched by the removal that followed it. A disc present when Kodi started therefore stayed listed in Video → Files after being ejected, correcting itself only when the next disc arrived. Both paths now key on the same standardised form.

2 — Cache the win32 optical drive state Since #28191 IsDiscInDrive() falls through to GetDriveStatus(), which on Windows is an uncached CreateFile plus IOCTL_STORAGE_CHECK_VERIFY2 straight to the hardware — and the GUI asks it every frame while the disc node is on screen, so an idle drive was probed continuously and could never spin down. The state is now remembered per drive and the drive asked only after something that could have changed it: a disc arriving or leaving, a tray operation, or the optical drive list being rescanned.

3 — Don't use m_mapCdInfo as a disc presence check on win32 IsDiscInDrive() treated any entry in m_mapCdInfo as proof of a disc, but that map only holds discs libcdio could analyse and was cleared only on a storage removal event. A drive could report a disc that had already gone; presence now comes from the drive state alone.

4 — Feed optical media changes from the shell notification too Optical media was left entirely to WM_DEVICECHANGE, which does not always arrive, so an insertion or removal could go unnoticed indefinitely. SHCNE_MEDIAINSERTED/SHCNE_MEDIAREMOVED now feed the same queue, with a repeat from the second channel dropped so one disc is not identified or autorun twice. Windows also reports a tray closing on nothing as an arrival, so a drive that turns out to be empty retracts the event rather than leaving it to swallow the next real insertion.

5 — Cache the probed disc information GetDiscInfo() re-probed the disc on every call, and four separate paths reach it for the same disc — over a second each on an AACS Blu-ray. The result is now held per drive and dropped when the disc changes, reducing startup and insertion to a single probe.

6 — Keep the bluray playlist status per drive The playlist flag was global, so with discs in two drives whichever was identified last answered for both — the "Play playlist" button could appear for a disc that has no stored playlist. It is now recorded per drive, and dropping it names the drive it changed for, so untouched drives keep the answer they already had.

7 — IOCTL_STORAGE_EJECT_MEDIA / _LOAD_MEDIA only need GENERIC_READ Both IOCTLs are declared FILE_READ_ACCESS, but the device was being opened for read and write, which requires privileges an ordinary user may not hold. Opening read-only lets the tray operate without them.

8 — Eject correct drive All three tray calls went to TranslateDevicePath(""), which resolves to the first optical drive, so the caller's drive letter was thrown away and on a machine with more than one drive the tray that moved was rarely the one asked for. Two of them did not do what their names said either: CloseTray called ToggleDriveTray, so it did nothing on an already-closed tray, and EjectTray ignored its bEject argument.

9 — Subscribes Kodi to the CD-ROM class driver's own media events by opening a zero-access handle on each optical drive and registering it with RegisterDeviceNotification, giving a third notification channel that depends on neither explorer.exe nor the mount manager and costs no hardware access of its own. A driver-reported removal is queued as a storage event immediately, while a driver-reported arrival first refreshes the cached drive state and then, if the volume broadcast has not arrived within about three seconds, synthesises the ADDED itself so the disc still gets a source and autorun. This is the alternative to regular polling that could keep the drive spinning.

10 — Don't read the volume label when only the optical drive letters are wanted - stops GetDrivesByType calling GetVolumeInformationW when it is enumerating DVD_DRIVES without the media-only filter, since its two callers, Initialize and GetFirstOpticalDeviceFileName, use only the drive letter. That query blocks until a spinning-up drive can answer, and because ProcessEvents calls GetFirstOpticalDeviceFileName on every storage event it can freeze the GUI.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Investigating excess logging. Noticed other issues.

## How has this been tested?
<!--- Please describe in detail how you tested your change. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally on a Windows 11 PC with 3 optical drives attached.

## What is the effect on users?
<!--- Summarize the effect of this change on Kodi end-users. -->
<!--- If the PR does not have a noticeable impact (e.g., if it only changes documentation), -->
<!--- just leave it empty. Put in more detail the bigger the impact is. -->
<!--- This section may be used for automatic creation of release notes. -->

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Improvement (other)** (non-breaking change which improves other existing functionality)

## Checklist:
<!--- Go over all the following points, and put an `X` with no space in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] All new and existing tests passed
