### PR TITLE
RetroPlayer: Keep DMA memory valid through paused-frame caching

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -205,6 +205,10 @@ void CRPRenderManager::AddFrame(const uint8_t* data,
                                 float displayAspectRatio,
                                 unsigned int orientationDegCCW)
 {
+  // Keep the submitted mapping alive through the last read, and close CPU access
+  // before rendering or flushing can acquire the buffer.
+  std::unique_lock lock(m_bufferMutex);
+
   if (m_bFlush || m_state != RENDER_STATE::CONFIGURED)
     return;
 
@@ -214,18 +218,18 @@ void CRPRenderManager::AddFrame(const uint8_t* data,
 
   // Get render buffers to copy the frame into
   std::vector<IRenderBuffer*> renderBuffers;
+  IRenderBuffer* submittedBuffer = nullptr;
 
-  // Check and consume pending buffers. The client has finished writing, so
-  // end any CPU access it opened before handing a submitted buffer to the GPU.
   for (const PendingBuffer& pending : m_pendingBuffers)
   {
     const bool bSubmitted = (pending.memory == data);
 
-    if (pending.memory != nullptr)
+    if (pending.memory != nullptr && !bSubmitted)
       pending.buffer->ReleaseMemory();
 
     if (bSubmitted)
     {
+      submittedBuffer = pending.buffer;
       pending.buffer->Acquire();
       renderBuffers.emplace_back(pending.buffer);
     }
@@ -246,6 +250,10 @@ void CRPRenderManager::AddFrame(const uint8_t* data,
       IRenderBuffer* renderBuffer = bufferPool->GetBuffer(width, height);
       if (renderBuffer != nullptr)
       {
+        // Keep copying locked so CheckFlush() cannot flush the pool before publication.
+        // The measured CPU submission cost is modest: warm AddFrame() medians on M2 Pro
+        // (-O2, packed BGR0, system memory, 1/2 pools) were ~5/11 us at 320x240,
+        // ~21/41 us at 640x480, and ~149/290 us at 1920x1080.
         CopyFrame(renderBuffer, m_format, data, size, width, height);
         renderBuffers.emplace_back(renderBuffer);
       }
@@ -254,51 +262,47 @@ void CRPRenderManager::AddFrame(const uint8_t* data,
     }
   }
 
+  // Set render buffers
+  for (auto renderBuffer : m_renderBuffers)
+    renderBuffer->Release();
+  m_renderBuffers = std::move(renderBuffers);
+
+  // Apply video properties to render buffers
+  for (auto renderBuffer : m_renderBuffers)
   {
-    std::unique_lock lock(m_bufferMutex);
+    renderBuffer->SetDisplayAspectRatio(displayAspectRatio);
+    renderBuffer->SetRotation(orientationDegCCW);
+  }
 
-    // Set render buffers
-    for (auto renderBuffer : m_renderBuffers)
-      renderBuffer->Release();
-    m_renderBuffers = std::move(renderBuffers);
+  // Cache frame if it arrived after being paused
+  if (m_speed == 0.0)
+  {
+    std::vector<uint8_t> cachedFrame = std::move(m_cachedFrame);
 
-    // Apply video properties to render buffers
-    for (auto renderBuffer : m_renderBuffers)
+    if (!m_bHasCachedFrame)
     {
-      renderBuffer->SetDisplayAspectRatio(displayAspectRatio);
-      renderBuffer->SetRotation(orientationDegCCW);
+      // In this case, cachedFrame is definitely empty (see invariant for
+      // m_bHasCachedFrame). Otherwise, cachedFrame may be empty if the frame
+      // is being copied in the rendering thread. In that case, we would want
+      // to leave cached frame empty to avoid caching another frame.
+
+      cachedFrame.resize(size);
+      m_bHasCachedFrame = true;
     }
 
-    // Cache frame if it arrived after being paused
-    if (m_speed == 0.0)
+    if (!cachedFrame.empty())
     {
-      std::vector<uint8_t> cachedFrame = std::move(m_cachedFrame);
-
-      if (!m_bHasCachedFrame)
-      {
-        // In this case, cachedFrame is definitely empty (see invariant for
-        // m_bHasCachedFrame). Otherwise, cachedFrame may be empty if the frame
-        // is being copied in the rendering thread. In that case, we would want
-        // to leave cached frame empty to avoid caching another frame.
-
-        cachedFrame.resize(size);
-        m_bHasCachedFrame = true;
-      }
-
-      if (!cachedFrame.empty())
-      {
-        {
-          CSingleExit exit(m_bufferMutex);
-          std::memcpy(cachedFrame.data(), data, size);
-        }
-        m_cachedFrame = std::move(cachedFrame);
-        m_cachedWidth = width;
-        m_cachedHeight = height;
-        m_cachedDisplayAspectRatio = displayAspectRatio;
-        m_cachedRotationCCW = orientationDegCCW;
-      }
+      std::memcpy(cachedFrame.data(), data, size);
+      m_cachedFrame = std::move(cachedFrame);
+      m_cachedWidth = width;
+      m_cachedHeight = height;
+      m_cachedDisplayAspectRatio = displayAspectRatio;
+      m_cachedRotationCCW = orientationDegCCW;
     }
   }
+
+  if (submittedBuffer != nullptr)
+    submittedBuffer->ReleaseMemory();
 }
 
 void CRPRenderManager::Flush()


### PR DESCRIPTION
## Description

Replaces https://github.com/xbmc/xbmc/pull/29174, redone from scratch with GPT-6 Astra Extra High.

AI use:

A zero-copy frame can arrive while the game is being paused. `AddFrame()` currently calls `CRenderBufferDMA::ReleaseMemory()` on the submitted DMA buffer before the late paused-frame cache reads from it. `ReleaseMemory()` ends CPU access and unmaps the buffer, leaving the later `memcpy()` reading unmapped memory.

Hold `m_bufferMutex` through frame preparation, making the frame current, paused-frame caching, and the submitted buffer's deferred `ReleaseMemory()`. This keeps the mapping valid through its final read and closes CPU access before rendering or flush processing can acquire the buffer state. The late pause observation and existing reference transfer are preserved, with no extra per-frame copy, flush generation, or pool-semantics change.

Introduced in #28983.

### Concurrency

Kodi serializes frame execution and stream shutdown: `CGameClient::RunFrame()` and `CloseFile()` hold the same game-client mutex, and player shutdown joins the game loop before unloading the client. Stream reconfiguration and frame submission are synchronous in the current supported caller sequence. `CRetroPlayerVideo::CloseStream()` is the production caller of `CRPRenderManager::Flush()`, so that sequence cannot concurrently enter `AddFrame()` and stream teardown.

A deterministic manager-level test deliberately delayed `AddFrame()` before it acquired `m_bufferMutex` until an entire flush had completed. Under this artificially stronger concurrency model, a pre-flush pending buffer and cached frame can be submitted after the flush. This ordering is **unreachable through the current supported caller sequence**. `CRPRenderManager` does not independently guarantee safety for arbitrary concurrent `AddFrame()`/`Flush()` callers.

Supporting that stronger contract would require additional admission/flush synchronization. It is not needed by the current caller model and would add synchronization state this fix avoids.

## How has this been tested?

* The affected `rp-rendering` target builds successfully.
* All 11 existing deterministic lifetime/order cases pass under ASan and UBSan.
* The additional manager-level admission probe confirms the stronger unsupported concurrency case described above; it is reported separately from the 11 passing cases.
* Hardware DMA/EGL validation remains outstanding.

## What is the effect on users?

Fixes an intermittent crash when pausing a game or opening the in-game OSD on platforms using DMA render buffers.

## Types of change

<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->

* [x] **Bug fix** (non-breaking change which fixes an issue)
* [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
* [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
* [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
* [ ] **New feature** (non-breaking change which adds functionality)
* [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
* [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
* [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
* [ ] **None of the above** (please explain below)
