### PR TITLE
[libUPnP] Prevent file server path traversal

### DIFF
--- a/lib/libUPnP/Platinum/Source/Core/PltHttpServer.cpp
+++ b/lib/libUPnP/Platinum/Source/Core/PltHttpServer.cpp
@@ -185,14 +185,22 @@ PLT_HttpServer::ServeFile(const NPT_HttpRequest&        request,
                           NPT_HttpResponse&             response,
                           NPT_String                    file_path) 
 {
+    return ServeFile(request, context, response, file_path, file_path);
+}
+
+/*----------------------------------------------------------------------
+|   PLT_HttpServer::ServeFile
++---------------------------------------------------------------------*/
+NPT_Result
+PLT_HttpServer::ServeFile(const NPT_HttpRequest&        request,
+                          const NPT_HttpRequestContext& context,
+                          NPT_HttpResponse&             response,
+                          NPT_String                    file_path,
+                          const NPT_String&             mime_path)
+{
     NPT_InputStreamReference stream;
     NPT_File                 file(file_path);
     NPT_FileInfo             file_info;
-    
-    // prevent hackers from accessing files outside of our root
-    if ((file_path.Find("/..") >= 0) || (file_path.Find("\\..") >= 0)) {
-        return NPT_ERROR_NO_SUCH_ITEM;
-    }
     
     // check for range requests
     const NPT_String* range_spec = request.GetHeaders().GetHeaderValue(NPT_HTTP_HEADER_RANGE);
@@ -236,7 +244,7 @@ PLT_HttpServer::ServeFile(const NPT_HttpRequest&        request,
     }
     
     PLT_HttpRequestContext tmp_context(request, context);
-    return ServeStream(request, context, response, stream, PLT_MimeType::GetMimeType(file_path, &tmp_context));
+    return ServeStream(request, context, response, stream, PLT_MimeType::GetMimeType(mime_path, &tmp_context));
 }
 
 /*----------------------------------------------------------------------

--- a/lib/libUPnP/Platinum/Source/Core/PltHttpServer.h
+++ b/lib/libUPnP/Platinum/Source/Core/PltHttpServer.h
@@ -68,6 +68,11 @@ public:
                                 const NPT_HttpRequestContext& context,
                                 NPT_HttpResponse&             response, 
                                 NPT_String                    file_path);
+    static NPT_Result ServeFile(const NPT_HttpRequest&        request,
+                                const NPT_HttpRequestContext& context,
+                                NPT_HttpResponse&             response,
+                                NPT_String                    file_path,
+                                const NPT_String&             mime_path);
     static NPT_Result ServeStream(const NPT_HttpRequest&        request, 
                                   const NPT_HttpRequestContext& context,
                                   NPT_HttpResponse&             response,

--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltFileMediaServer.cpp
+++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltFileMediaServer.cpp
@@ -45,7 +45,220 @@
 #include "PltVersion.h"
 #include "PltMimeType.h"
 
+#if defined(_WIN32)
+#include <filesystem>
+#include <windows.h>
+#else
+#include <cstdlib>
+#include <memory>
+#include <sys/stat.h>
+#endif
+
 NPT_SET_LOCAL_LOGGER("platinum.media.server.file.delegate")
+
+namespace {
+
+static bool
+PLT_IsPathSeparator(char value)
+{
+    return value == '/' || value == '\\';
+}
+
+static NPT_Result
+PLT_ValidatePathComponents(const NPT_String& path)
+{
+    const char* chars = path.GetChars();
+    NPT_Size length = path.GetLength();
+
+    NPT_Size component_start = 0;
+    for (NPT_Size i = 0; i <= length; ++i) {
+        if (i != length && !PLT_IsPathSeparator(chars[i])) {
+            if (chars[i] == '\0') return NPT_ERROR_INVALID_PARAMETERS;
+            continue;
+        }
+
+        if (i-component_start == 2 && chars[component_start] == '.' &&
+            chars[component_start+1] == '.') {
+            return NPT_ERROR_INVALID_PARAMETERS;
+        }
+        component_start = i+1;
+    }
+
+    return NPT_SUCCESS;
+}
+
+static NPT_Result
+PLT_ValidateRelativePath(const NPT_String& path)
+{
+    const char* chars = path.GetChars();
+    NPT_Size length = path.GetLength();
+
+    if (length && PLT_IsPathSeparator(chars[0])) return NPT_ERROR_INVALID_PARAMETERS;
+#if defined(_WIN32)
+    if (length >= 2 && ((chars[0] >= 'A' && chars[0] <= 'Z') ||
+                        (chars[0] >= 'a' && chars[0] <= 'z')) &&
+        chars[1] == ':') {
+        return NPT_ERROR_INVALID_PARAMETERS;
+    }
+#endif
+
+    return PLT_ValidatePathComponents(path);
+}
+
+#if defined(_WIN32)
+static std::filesystem::path
+PLT_PathFromUtf8(const NPT_String& path)
+{
+    const char8_t* begin = reinterpret_cast<const char8_t*>(path.GetChars());
+    return std::filesystem::path(std::u8string(begin, begin+path.GetLength()));
+}
+
+static NPT_String
+PLT_PathToUtf8(const std::filesystem::path& path)
+{
+    const std::u8string result = path.u8string();
+    return NPT_String(reinterpret_cast<const char*>(result.data()), result.size());
+}
+#endif
+
+static void
+PLT_TrimTrailingPathSeparators(NPT_String& path)
+{
+    try {
+#if defined(_WIN32)
+        NPT_Size root_length = PLT_PathToUtf8(PLT_PathFromUtf8(path).root_path()).GetLength();
+#else
+        NPT_Size root_length = path.StartsWith("/") ? 1 : 0;
+#endif
+        while (path.GetLength() > root_length &&
+               PLT_IsPathSeparator(path[path.GetLength()-1])) {
+            path.SetLength(path.GetLength()-1);
+        }
+    } catch (...) {
+        return;
+    }
+}
+
+static NPT_Size
+PLT_GetRelativePathOffset(const NPT_String& root, const NPT_String& path)
+{
+    NPT_Size offset = root.GetLength();
+    if (offset < path.GetLength() && PLT_IsPathSeparator(path[offset])) ++offset;
+    return offset;
+}
+
+#if defined(_WIN32)
+static bool
+PLT_IsPathLexicallyWithin(const std::filesystem::path& root,
+                          const std::filesystem::path& path)
+{
+    std::filesystem::path::const_iterator root_component = root.begin();
+    std::filesystem::path::const_iterator path_component = path.begin();
+    for (; root_component != root.end(); ++root_component, ++path_component) {
+        if (path_component == path.end() || *root_component != *path_component) return false;
+    }
+    return true;
+}
+
+static bool
+PLT_HasReparsePointBelowRoot(const std::filesystem::path& root,
+                             const std::filesystem::path& path)
+{
+    std::filesystem::path relative = path.lexically_relative(root);
+    if (relative.empty() && path != root) return true;
+
+    std::filesystem::path current = root;
+    for (const std::filesystem::path& component : relative) {
+        if (component == ".") continue;
+        if (component == "..") return true;
+        current /= component;
+
+        DWORD attributes = GetFileAttributesW(current.c_str());
+        if (attributes == INVALID_FILE_ATTRIBUTES ||
+            (attributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool
+PLT_IsFilesystemPathWithin(const std::filesystem::path& root,
+                           const std::filesystem::path& path,
+                           std::error_code&             error)
+{
+    std::filesystem::path ancestor = path;
+    while (true) {
+        error.clear();
+        if (std::filesystem::equivalent(root, ancestor, error)) return true;
+        if (error) return false;
+
+        std::filesystem::path parent = ancestor.parent_path();
+        if (parent == ancestor) return false;
+        ancestor = parent;
+    }
+}
+#endif
+
+static NPT_Result
+PLT_ResolvePathWithinRoot(const NPT_String& root,
+                          const NPT_String& path,
+                          NPT_String&       resolved_path)
+{
+    try {
+#if defined(_WIN32)
+        std::error_code error;
+        std::filesystem::path absolute_root = std::filesystem::absolute(PLT_PathFromUtf8(root), error);
+        if (error) return NPT_ERROR_NO_SUCH_ITEM;
+        absolute_root = absolute_root.lexically_normal();
+
+        std::filesystem::path absolute_path = std::filesystem::absolute(PLT_PathFromUtf8(path), error);
+        if (error) return NPT_ERROR_NO_SUCH_ITEM;
+        absolute_path = absolute_path.lexically_normal();
+
+        if (!PLT_IsPathLexicallyWithin(absolute_root, absolute_path) ||
+            PLT_HasReparsePointBelowRoot(absolute_root, absolute_path)) {
+            return NPT_ERROR_NO_SUCH_ITEM;
+        }
+
+        std::filesystem::path canonical_root = std::filesystem::canonical(absolute_root, error);
+        if (error) return NPT_ERROR_NO_SUCH_ITEM;
+        std::filesystem::path canonical_path = std::filesystem::canonical(absolute_path, error);
+        if (error || !PLT_IsFilesystemPathWithin(canonical_root, canonical_path, error)) {
+            return NPT_ERROR_NO_SUCH_ITEM;
+        }
+
+        resolved_path = PLT_PathToUtf8(canonical_path);
+        return NPT_SUCCESS;
+#else
+        std::unique_ptr<char, decltype(&std::free)> canonical_root(realpath(root, NULL), &std::free);
+        if (!canonical_root) return NPT_ERROR_NO_SUCH_ITEM;
+        std::unique_ptr<char, decltype(&std::free)> canonical_path(realpath(path, NULL), &std::free);
+        if (!canonical_path) return NPT_ERROR_NO_SUCH_ITEM;
+
+        struct stat root_info;
+        if (stat(canonical_root.get(), &root_info) != 0) return NPT_ERROR_NO_SUCH_ITEM;
+
+        NPT_String ancestor(canonical_path.get());
+        while (true) {
+            struct stat ancestor_info;
+            if (stat(ancestor, &ancestor_info) != 0) return NPT_ERROR_NO_SUCH_ITEM;
+            if (root_info.st_dev == ancestor_info.st_dev && root_info.st_ino == ancestor_info.st_ino) {
+                resolved_path = canonical_path.get();
+                return NPT_SUCCESS;
+            }
+
+            if (ancestor == "/") return NPT_ERROR_NO_SUCH_ITEM;
+            int separator = ancestor.ReverseFind('/');
+            ancestor.SetLength(separator > 0 ? separator : 1);
+        }
+#endif
+    } catch (...) {
+        return NPT_ERROR_NO_SUCH_ITEM;
+    }
+}
+
+}
 
 /*----------------------------------------------------------------------
 |   PLT_FileMediaServerDelegate::PLT_FileMediaServerDelegate
@@ -59,7 +272,7 @@ PLT_FileMediaServerDelegate::PLT_FileMediaServerDelegate(const char* url_root,
     m_UseCache(use_cache)
 {
     /* Trim excess separators */
-    m_FileRoot.TrimRight("/\\");
+    PLT_TrimTrailingPathSeparators(m_FileRoot);
 }
 
 /*----------------------------------------------------------------------
@@ -89,6 +302,7 @@ PLT_FileMediaServerDelegate::ProcessFileRequest(NPT_HttpRequest&              re
     /* Extract file path from url */
     NPT_String file_path;
     NPT_CHECK_LABEL_WARNING(ExtractResourcePath(request.GetUrl(), file_path), failure);
+    NPT_CHECK_LABEL_WARNING(PLT_ValidateRelativePath(file_path), failure);
     
     /* Serve file */
     NPT_CHECK_WARNING(ServeFile(request, context, response, NPT_FilePath::Create(m_FileRoot, file_path)));
@@ -108,7 +322,9 @@ PLT_FileMediaServerDelegate::ServeFile(const NPT_HttpRequest&        request,
                                        NPT_HttpResponse&             response,
                                        const NPT_String&             file_path)
 {
-    NPT_CHECK_WARNING(PLT_HttpServer::ServeFile(request, context, response, file_path));
+    NPT_String resolved_path;
+    NPT_CHECK_WARNING(PLT_ResolvePathWithinRoot(m_FileRoot, file_path, resolved_path));
+    NPT_CHECK_WARNING(PLT_HttpServer::ServeFile(request, context, response, resolved_path, file_path));
     return NPT_SUCCESS;
 }
 
@@ -317,15 +533,20 @@ PLT_FileMediaServerDelegate::GetFilePath(const char* object_id,
                                          NPT_String& filepath) 
 {
     if (!object_id) return NPT_ERROR_INVALID_PARAMETERS;
-    
-    filepath = m_FileRoot;
-    
-    /* object id is formatted as 0/<filepath> */
+
+    NPT_String object_path;
     if (NPT_StringLength(object_id) >= 1) {
-        filepath += (object_id + (object_id[0]=='0'?1:0));
+        object_path = object_id + (object_id[0]=='0'?1:0);
     }
-    
-    return NPT_SUCCESS;
+    NPT_CHECK(PLT_ValidatePathComponents(object_path));
+
+    filepath = m_FileRoot;
+
+    /* object id is formatted as 0/<filepath> */
+    filepath += object_path;
+
+    NPT_String resolved_path;
+    return PLT_ResolvePathWithinRoot(m_FileRoot, filepath, resolved_path);
 }
 
 /*----------------------------------------------------------------------
@@ -420,11 +641,14 @@ PLT_FileMediaServerDelegate::BuildFromFilePath(const NPT_String&             fil
     NPT_String            root = m_FileRoot;
     PLT_MediaItemResource resource;
     PLT_MediaObject*      object = NULL;
+    NPT_String            resolved_path;
+    NPT_FileInfo          info;
+
+    NPT_CHECK_LABEL_FATAL(PLT_ResolvePathWithinRoot(root, filepath, resolved_path), failure);
     
     NPT_LOG_FINEST_1("Building didl for file '%s'", (const char*)filepath);
     
     /* retrieve the entry type (directory or file) */
-    NPT_FileInfo info; 
     NPT_CHECK_LABEL_FATAL(NPT_File::GetInfo(filepath, &info), failure);
     
     if (info.m_Type == NPT_FileInfo::FILE_TYPE_REGULAR) {
@@ -449,7 +673,7 @@ PLT_FileMediaServerDelegate::BuildFromFilePath(const NPT_String&             fil
         resource.m_Size = info.m_Size;
         
         /* format the resource URI */
-        NPT_String url = filepath.SubString(root.GetLength()+1);
+        NPT_String url = filepath.SubString(PLT_GetRelativePathOffset(root, filepath));
         
         // get list of ip addresses
         NPT_List<NPT_IpAddress> ips;

--- a/lib/libUPnP/patches/0064-platinum-Prevent-file-server-path-traversal.patch
+++ b/lib/libUPnP/patches/0064-platinum-Prevent-file-server-path-traversal.patch
@@ -1,0 +1,399 @@
+From 8d7e2ce5a1e6fa9c84b4fda9c19b988d4c6a8f12 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Fri, 4 Sep 2026 15:30:00 -0700
+Subject: [PATCH] [Platinum] Prevent file server path traversal
+
+Validate decoded resource paths as relative path components before joining
+them to the configured file root. Canonicalize the root and target before
+serving and compare filesystem identities so symlinks, case variants and
+prefix collisions cannot escape the root.
+
+Use realpath and stat on POSIX to support iOS 12 without std::filesystem.
+Retain Windows UTF-8 path conversion and reparse-point checks.
+
+Apply the same root-aware validation to client-controlled browse object IDs
+and to objects built from directory entries. Convert filesystem path errors
+into normal not-found results at the path-resolution boundary.
+
+Preserve filesystem roots while trimming redundant trailing separators and
+derive resource URI paths without assuming the root was trimmed. Open
+validated canonical paths while retaining the requested filename for MIME
+detection and DLNA content features.
+
+Move the containment policy out of PLT_HttpServer::ServeFile, which has no
+knowledge of the configured root.
+---
+ lib/libUPnP/Platinum/Source/Core/PltHttpServer.cpp |  20 +-
+ lib/libUPnP/Platinum/Source/Core/PltHttpServer.h   |   5 +
+ .../Devices/MediaServer/PltFileMediaServer.cpp     | 246 ++++++++++++++++++++-
+ 3 files changed, 254 insertions(+), 17 deletions(-)
+
+diff --git a/lib/libUPnP/Platinum/Source/Core/PltHttpServer.cpp b/lib/libUPnP/Platinum/Source/Core/PltHttpServer.cpp
+index 2557f62851a..d7221822d45 100644
+--- a/lib/libUPnP/Platinum/Source/Core/PltHttpServer.cpp
++++ b/lib/libUPnP/Platinum/Source/Core/PltHttpServer.cpp
+@@ -184,16 +184,24 @@ PLT_HttpServer::ServeFile(const NPT_HttpRequest&        request,
+                           const NPT_HttpRequestContext& context,
+                           NPT_HttpResponse&             response,
+                           NPT_String                    file_path) 
++{
++    return ServeFile(request, context, response, file_path, file_path);
++}
++
++/*----------------------------------------------------------------------
++|   PLT_HttpServer::ServeFile
+++---------------------------------------------------------------------*/
++NPT_Result
++PLT_HttpServer::ServeFile(const NPT_HttpRequest&        request,
++                          const NPT_HttpRequestContext& context,
++                          NPT_HttpResponse&             response,
++                          NPT_String                    file_path,
++                          const NPT_String&             mime_path)
+ {
+     NPT_InputStreamReference stream;
+     NPT_File                 file(file_path);
+     NPT_FileInfo             file_info;
+     
+-    // prevent hackers from accessing files outside of our root
+-    if ((file_path.Find("/..") >= 0) || (file_path.Find("\\..") >= 0)) {
+-        return NPT_ERROR_NO_SUCH_ITEM;
+-    }
+-    
+     // check for range requests
+     const NPT_String* range_spec = request.GetHeaders().GetHeaderValue(NPT_HTTP_HEADER_RANGE);
+     
+@@ -236,7 +244,7 @@ PLT_HttpServer::ServeFile(const NPT_HttpRequest&        request,
+     }
+     
+     PLT_HttpRequestContext tmp_context(request, context);
+-    return ServeStream(request, context, response, stream, PLT_MimeType::GetMimeType(file_path, &tmp_context));
++    return ServeStream(request, context, response, stream, PLT_MimeType::GetMimeType(mime_path, &tmp_context));
+ }
+ 
+ /*----------------------------------------------------------------------
+diff --git a/lib/libUPnP/Platinum/Source/Core/PltHttpServer.h b/lib/libUPnP/Platinum/Source/Core/PltHttpServer.h
+index 04c47fce03b..fd4bf53d458 100644
+--- a/lib/libUPnP/Platinum/Source/Core/PltHttpServer.h
++++ b/lib/libUPnP/Platinum/Source/Core/PltHttpServer.h
+@@ -68,6 +68,11 @@ public:
+                                 const NPT_HttpRequestContext& context,
+                                 NPT_HttpResponse&             response, 
+                                 NPT_String                    file_path);
++    static NPT_Result ServeFile(const NPT_HttpRequest&        request,
++                                const NPT_HttpRequestContext& context,
++                                NPT_HttpResponse&             response,
++                                NPT_String                    file_path,
++                                const NPT_String&             mime_path);
+     static NPT_Result ServeStream(const NPT_HttpRequest&        request, 
+                                   const NPT_HttpRequestContext& context,
+                                   NPT_HttpResponse&             response,
+diff --git a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltFileMediaServer.cpp b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltFileMediaServer.cpp
+index 421d0c20427..7cab3e0ab75 100644
+--- a/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltFileMediaServer.cpp
++++ b/lib/libUPnP/Platinum/Source/Devices/MediaServer/PltFileMediaServer.cpp
+@@ -45,8 +45,221 @@
+ #include "PltVersion.h"
+ #include "PltMimeType.h"
+ 
++#if defined(_WIN32)
++#include <filesystem>
++#include <windows.h>
++#else
++#include <cstdlib>
++#include <memory>
++#include <sys/stat.h>
++#endif
++
+ NPT_SET_LOCAL_LOGGER("platinum.media.server.file.delegate")
+ 
++namespace {
++
++static bool
++PLT_IsPathSeparator(char value)
++{
++    return value == '/' || value == '\\';
++}
++
++static NPT_Result
++PLT_ValidatePathComponents(const NPT_String& path)
++{
++    const char* chars = path.GetChars();
++    NPT_Size length = path.GetLength();
++
++    NPT_Size component_start = 0;
++    for (NPT_Size i = 0; i <= length; ++i) {
++        if (i != length && !PLT_IsPathSeparator(chars[i])) {
++            if (chars[i] == '\0') return NPT_ERROR_INVALID_PARAMETERS;
++            continue;
++        }
++
++        if (i-component_start == 2 && chars[component_start] == '.' &&
++            chars[component_start+1] == '.') {
++            return NPT_ERROR_INVALID_PARAMETERS;
++        }
++        component_start = i+1;
++    }
++
++    return NPT_SUCCESS;
++}
++
++static NPT_Result
++PLT_ValidateRelativePath(const NPT_String& path)
++{
++    const char* chars = path.GetChars();
++    NPT_Size length = path.GetLength();
++
++    if (length && PLT_IsPathSeparator(chars[0])) return NPT_ERROR_INVALID_PARAMETERS;
++#if defined(_WIN32)
++    if (length >= 2 && ((chars[0] >= 'A' && chars[0] <= 'Z') ||
++                        (chars[0] >= 'a' && chars[0] <= 'z')) &&
++        chars[1] == ':') {
++        return NPT_ERROR_INVALID_PARAMETERS;
++    }
++#endif
++
++    return PLT_ValidatePathComponents(path);
++}
++
++#if defined(_WIN32)
++static std::filesystem::path
++PLT_PathFromUtf8(const NPT_String& path)
++{
++    const char8_t* begin = reinterpret_cast<const char8_t*>(path.GetChars());
++    return std::filesystem::path(std::u8string(begin, begin+path.GetLength()));
++}
++
++static NPT_String
++PLT_PathToUtf8(const std::filesystem::path& path)
++{
++    const std::u8string result = path.u8string();
++    return NPT_String(reinterpret_cast<const char*>(result.data()), result.size());
++}
++#endif
++
++static void
++PLT_TrimTrailingPathSeparators(NPT_String& path)
++{
++    try {
++#if defined(_WIN32)
++        NPT_Size root_length = PLT_PathToUtf8(PLT_PathFromUtf8(path).root_path()).GetLength();
++#else
++        NPT_Size root_length = path.StartsWith("/") ? 1 : 0;
++#endif
++        while (path.GetLength() > root_length &&
++               PLT_IsPathSeparator(path[path.GetLength()-1])) {
++            path.SetLength(path.GetLength()-1);
++        }
++    } catch (...) {
++        return;
++    }
++}
++
++static NPT_Size
++PLT_GetRelativePathOffset(const NPT_String& root, const NPT_String& path)
++{
++    NPT_Size offset = root.GetLength();
++    if (offset < path.GetLength() && PLT_IsPathSeparator(path[offset])) ++offset;
++    return offset;
++}
++
++#if defined(_WIN32)
++static bool
++PLT_IsPathLexicallyWithin(const std::filesystem::path& root,
++                          const std::filesystem::path& path)
++{
++    std::filesystem::path::const_iterator root_component = root.begin();
++    std::filesystem::path::const_iterator path_component = path.begin();
++    for (; root_component != root.end(); ++root_component, ++path_component) {
++        if (path_component == path.end() || *root_component != *path_component) return false;
++    }
++    return true;
++}
++
++static bool
++PLT_HasReparsePointBelowRoot(const std::filesystem::path& root,
++                             const std::filesystem::path& path)
++{
++    std::filesystem::path relative = path.lexically_relative(root);
++    if (relative.empty() && path != root) return true;
++
++    std::filesystem::path current = root;
++    for (const std::filesystem::path& component : relative) {
++        if (component == ".") continue;
++        if (component == "..") return true;
++        current /= component;
++
++        DWORD attributes = GetFileAttributesW(current.c_str());
++        if (attributes == INVALID_FILE_ATTRIBUTES ||
++            (attributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0) {
++            return true;
++        }
++    }
++    return false;
++}
++
++static bool
++PLT_IsFilesystemPathWithin(const std::filesystem::path& root,
++                           const std::filesystem::path& path,
++                           std::error_code&             error)
++{
++    std::filesystem::path ancestor = path;
++    while (true) {
++        error.clear();
++        if (std::filesystem::equivalent(root, ancestor, error)) return true;
++        if (error) return false;
++
++        std::filesystem::path parent = ancestor.parent_path();
++        if (parent == ancestor) return false;
++        ancestor = parent;
++    }
++}
++#endif
++
++static NPT_Result
++PLT_ResolvePathWithinRoot(const NPT_String& root,
++                          const NPT_String& path,
++                          NPT_String&       resolved_path)
++{
++    try {
++#if defined(_WIN32)
++        std::error_code error;
++        std::filesystem::path absolute_root = std::filesystem::absolute(PLT_PathFromUtf8(root), error);
++        if (error) return NPT_ERROR_NO_SUCH_ITEM;
++        absolute_root = absolute_root.lexically_normal();
++
++        std::filesystem::path absolute_path = std::filesystem::absolute(PLT_PathFromUtf8(path), error);
++        if (error) return NPT_ERROR_NO_SUCH_ITEM;
++        absolute_path = absolute_path.lexically_normal();
++
++        if (!PLT_IsPathLexicallyWithin(absolute_root, absolute_path) ||
++            PLT_HasReparsePointBelowRoot(absolute_root, absolute_path)) {
++            return NPT_ERROR_NO_SUCH_ITEM;
++        }
++
++        std::filesystem::path canonical_root = std::filesystem::canonical(absolute_root, error);
++        if (error) return NPT_ERROR_NO_SUCH_ITEM;
++        std::filesystem::path canonical_path = std::filesystem::canonical(absolute_path, error);
++        if (error || !PLT_IsFilesystemPathWithin(canonical_root, canonical_path, error)) {
++            return NPT_ERROR_NO_SUCH_ITEM;
++        }
++
++        resolved_path = PLT_PathToUtf8(canonical_path);
++        return NPT_SUCCESS;
++#else
++        std::unique_ptr<char, decltype(&std::free)> canonical_root(realpath(root, NULL), &std::free);
++        if (!canonical_root) return NPT_ERROR_NO_SUCH_ITEM;
++        std::unique_ptr<char, decltype(&std::free)> canonical_path(realpath(path, NULL), &std::free);
++        if (!canonical_path) return NPT_ERROR_NO_SUCH_ITEM;
++
++        struct stat root_info;
++        if (stat(canonical_root.get(), &root_info) != 0) return NPT_ERROR_NO_SUCH_ITEM;
++
++        NPT_String ancestor(canonical_path.get());
++        while (true) {
++            struct stat ancestor_info;
++            if (stat(ancestor, &ancestor_info) != 0) return NPT_ERROR_NO_SUCH_ITEM;
++            if (root_info.st_dev == ancestor_info.st_dev && root_info.st_ino == ancestor_info.st_ino) {
++                resolved_path = canonical_path.get();
++                return NPT_SUCCESS;
++            }
++
++            if (ancestor == "/") return NPT_ERROR_NO_SUCH_ITEM;
++            int separator = ancestor.ReverseFind('/');
++            ancestor.SetLength(separator > 0 ? separator : 1);
++        }
++#endif
++    } catch (...) {
++        return NPT_ERROR_NO_SUCH_ITEM;
++    }
++}
++
++}
++
+ /*----------------------------------------------------------------------
+ |   PLT_FileMediaServerDelegate::PLT_FileMediaServerDelegate
+ +---------------------------------------------------------------------*/
+@@ -59,7 +272,7 @@ PLT_FileMediaServerDelegate::PLT_FileMediaServerDelegate(const char* url_root,
+     m_UseCache(use_cache)
+ {
+     /* Trim excess separators */
+-    m_FileRoot.TrimRight("/\\");
++    PLT_TrimTrailingPathSeparators(m_FileRoot);
+ }
+ 
+ /*----------------------------------------------------------------------
+@@ -89,6 +302,7 @@ PLT_FileMediaServerDelegate::ProcessFileRequest(NPT_HttpRequest&              re
+     /* Extract file path from url */
+     NPT_String file_path;
+     NPT_CHECK_LABEL_WARNING(ExtractResourcePath(request.GetUrl(), file_path), failure);
++    NPT_CHECK_LABEL_WARNING(PLT_ValidateRelativePath(file_path), failure);
+     
+     /* Serve file */
+     NPT_CHECK_WARNING(ServeFile(request, context, response, NPT_FilePath::Create(m_FileRoot, file_path)));
+@@ -108,7 +322,9 @@ PLT_FileMediaServerDelegate::ServeFile(const NPT_HttpRequest&        request,
+                                        NPT_HttpResponse&             response,
+                                        const NPT_String&             file_path)
+ {
+-    NPT_CHECK_WARNING(PLT_HttpServer::ServeFile(request, context, response, file_path));
++    NPT_String resolved_path;
++    NPT_CHECK_WARNING(PLT_ResolvePathWithinRoot(m_FileRoot, file_path, resolved_path));
++    NPT_CHECK_WARNING(PLT_HttpServer::ServeFile(request, context, response, resolved_path, file_path));
+     return NPT_SUCCESS;
+ }
+ 
+@@ -317,15 +533,20 @@ PLT_FileMediaServerDelegate::GetFilePath(const char* object_id,
+                                          NPT_String& filepath) 
+ {
+     if (!object_id) return NPT_ERROR_INVALID_PARAMETERS;
+-    
+-    filepath = m_FileRoot;
+-    
+-    /* object id is formatted as 0/<filepath> */
++
++    NPT_String object_path;
+     if (NPT_StringLength(object_id) >= 1) {
+-        filepath += (object_id + (object_id[0]=='0'?1:0));
++        object_path = object_id + (object_id[0]=='0'?1:0);
+     }
+-    
+-    return NPT_SUCCESS;
++    NPT_CHECK(PLT_ValidatePathComponents(object_path));
++
++    filepath = m_FileRoot;
++
++    /* object id is formatted as 0/<filepath> */
++    filepath += object_path;
++
++    NPT_String resolved_path;
++    return PLT_ResolvePathWithinRoot(m_FileRoot, filepath, resolved_path);
+ }
+ 
+ /*----------------------------------------------------------------------
+@@ -420,11 +641,14 @@ PLT_FileMediaServerDelegate::BuildFromFilePath(const NPT_String&             fil
+     NPT_String            root = m_FileRoot;
+     PLT_MediaItemResource resource;
+     PLT_MediaObject*      object = NULL;
++    NPT_String            resolved_path;
++    NPT_FileInfo          info;
++
++    NPT_CHECK_LABEL_FATAL(PLT_ResolvePathWithinRoot(root, filepath, resolved_path), failure);
+     
+     NPT_LOG_FINEST_1("Building didl for file '%s'", (const char*)filepath);
+     
+     /* retrieve the entry type (directory or file) */
+-    NPT_FileInfo info; 
+     NPT_CHECK_LABEL_FATAL(NPT_File::GetInfo(filepath, &info), failure);
+     
+     if (info.m_Type == NPT_FileInfo::FILE_TYPE_REGULAR) {
+@@ -449,7 +673,7 @@ PLT_FileMediaServerDelegate::BuildFromFilePath(const NPT_String&             fil
+         resource.m_Size = info.m_Size;
+         
+         /* format the resource URI */
+-        NPT_String url = filepath.SubString(root.GetLength()+1);
++        NPT_String url = filepath.SubString(PLT_GetRelativePathOffset(root, filepath));
+         
+         // get list of ip addresses
+         NPT_List<NPT_IpAddress> ips;
+
+-- 
+2.53.0

--- a/xbmc/network/upnp/test/CMakeLists.txt
+++ b/xbmc/network/upnp/test/CMakeLists.txt
@@ -1,4 +1,6 @@
-set(SOURCES TestUPnPInternal.cpp)
+set(SOURCES TestUPnPFileMediaServer.cpp
+            TestUPnPInternal.cpp
+)
 
 core_add_test_library(network_upnp_test)
 if(ENABLE_STATIC_LIBS)

--- a/xbmc/network/upnp/test/TestUPnPFileMediaServer.cpp
+++ b/xbmc/network/upnp/test/TestUPnPFileMediaServer.cpp
@@ -1,0 +1,629 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include <fstream>
+#include <string>
+
+#if defined(_WIN32)
+#include <filesystem>
+#include <random>
+#else
+#include <cstdlib>
+#include <vector>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include <Platinum/Source/Devices/MediaServer/PltFileMediaServer.h>
+#include <gtest/gtest.h>
+
+namespace
+{
+
+#if defined(_WIN32)
+using FilePath = std::filesystem::path;
+
+std::string PathToUtf8(const FilePath& path)
+{
+  const std::u8string value = path.u8string();
+  return {reinterpret_cast<const char*>(value.data()), value.size()};
+}
+
+std::string GenericPathToUtf8(const FilePath& path)
+{
+  const std::u8string value = path.generic_u8string();
+  return {reinterpret_cast<const char*>(value.data()), value.size()};
+}
+
+FilePath PathFromUtf8(const NPT_String& path)
+{
+  const char8_t* begin = reinterpret_cast<const char8_t*>(path.GetChars());
+  return FilePath(std::u8string(begin, begin + path.GetLength()));
+}
+
+#else
+using FilePath = std::string;
+
+const std::string& PathToUtf8(const FilePath& path)
+{
+  return path;
+}
+
+FilePath PathFromUtf8(const NPT_String& path)
+{
+  return {path.GetChars(), path.GetLength()};
+}
+#endif
+
+FilePath ChildPath(const FilePath& parent, const char* child)
+{
+#if defined(_WIN32)
+  return parent / child;
+#else
+  return parent + "/" + child;
+#endif
+}
+
+FilePath FilesystemRoot(const FilePath& path)
+{
+#if defined(_WIN32)
+  return path.root_path();
+#else
+  NPT_COMPILER_UNUSED(path);
+  return "/";
+#endif
+}
+
+bool PathsEquivalent(const FilePath& first, const FilePath& second)
+{
+#if defined(_WIN32)
+  return std::filesystem::equivalent(first, second);
+#else
+  struct stat firstInfo;
+  struct stat secondInfo;
+  return stat(first.c_str(), &firstInfo) == 0 && stat(second.c_str(), &secondInfo) == 0 &&
+         firstInfo.st_dev == secondInfo.st_dev && firstInfo.st_ino == secondInfo.st_ino;
+#endif
+}
+
+class TestFileMediaServerDelegate : public PLT_FileMediaServerDelegate
+{
+public:
+  explicit TestFileMediaServerDelegate(const FilePath& root)
+    : PLT_FileMediaServerDelegate("/", PathToUtf8(root).c_str())
+  {
+  }
+
+  using PLT_FileMediaServerDelegate::ProcessFileRequest;
+
+  NPT_Result GetObjectPath(const char* objectId, NPT_String& path)
+  {
+    return GetFilePath(objectId, path);
+  }
+
+  bool CanBuildBrowseObject(const FilePath& path)
+  {
+    NPT_HttpUrl url;
+    NPT_HttpRequest request(url, NPT_HTTP_METHOD_GET);
+    PLT_HttpRequestContext context(request);
+    PLT_MediaObjectReference object(BuildFromFilePath(PathToUtf8(path).c_str(), context));
+    return !object.IsNull();
+  }
+
+  NPT_Result GetBrowseResourceUri(const FilePath& path, NPT_String& resourceUri)
+  {
+    NPT_HttpUrl url;
+    NPT_HttpRequest request(url, NPT_HTTP_METHOD_GET);
+    NPT_SocketAddress localAddress(NPT_IpAddress(127, 0, 0, 1), 1234);
+    NPT_HttpRequestContext httpContext(&localAddress, nullptr);
+    PLT_HttpRequestContext context(request, httpContext);
+    PLT_MediaObjectReference object(BuildFromFilePath(PathToUtf8(path).c_str(), context));
+    if (object.IsNull() || object->m_Resources.GetItemCount() == 0)
+      return NPT_FAILURE;
+
+    resourceUri = object->m_Resources[0].m_Uri;
+    return NPT_SUCCESS;
+  }
+
+  NPT_Result OnUpdateObject(PLT_ActionReference&,
+                            const char*,
+                            NPT_Map<NPT_String, NPT_String>&,
+                            NPT_Map<NPT_String, NPT_String>&,
+                            const PLT_HttpRequestContext&) override
+  {
+    return NPT_ERROR_NOT_IMPLEMENTED;
+  }
+};
+
+struct RequestResult
+{
+  NPT_Result result;
+  NPT_HttpStatusCode status;
+  std::string body;
+  std::string mimeType;
+  std::string contentFeatures;
+};
+
+class TestUPnPFileMediaServer : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+#if defined(_WIN32)
+    std::random_device random;
+    const FilePath base =
+        std::filesystem::temp_directory_path() /
+        ("kodi-upnp-file-server-" + std::to_string(random()) + std::to_string(random()));
+    ASSERT_TRUE(std::filesystem::create_directory(base));
+    m_base = base;
+#else
+    const char* temp = std::getenv("TMPDIR");
+    std::string directory =
+        std::string(temp && *temp ? temp : "/tmp") + "/kodi-upnp-file-server-XXXXXX";
+    ASSERT_NE(nullptr, mkdtemp(directory.data()));
+    m_base = directory;
+    m_directories.push_back(m_base);
+#endif
+    m_root = ChildPath(m_base, "root");
+    m_root2 = ChildPath(m_base, "root2");
+
+    ASSERT_NO_FATAL_FAILURE(CreateDirectory(m_root));
+    ASSERT_NO_FATAL_FAILURE(CreateDirectory(ChildPath(m_root, "nested")));
+    ASSERT_NO_FATAL_FAILURE(CreateDirectory(m_root2));
+    WriteFile(ChildPath(m_root, "movie..part.mkv"), "normal");
+    WriteFile(ChildPath(m_root, "..hidden"), "hidden");
+    WriteFile(ChildPath(m_root, "nested/song.flac"), "nested");
+    WriteFile(ChildPath(m_root2, "outside.txt"), "outside");
+    WriteFile(ChildPath(m_base, "outside.txt"), "outside");
+  }
+
+  void TearDown() override
+  {
+#if defined(_WIN32)
+    if (!m_base.empty())
+    {
+      std::error_code error;
+      std::filesystem::remove_all(m_base, error);
+      EXPECT_FALSE(error) << error.message();
+    }
+#else
+    if (m_workingDirectory >= 0)
+    {
+      EXPECT_EQ(0, fchdir(m_workingDirectory));
+      EXPECT_EQ(0, close(m_workingDirectory));
+    }
+    for (auto path = m_files.rbegin(); path != m_files.rend(); ++path)
+      EXPECT_EQ(0, unlink(path->c_str())) << *path;
+    for (auto path = m_directories.rbegin(); path != m_directories.rend(); ++path)
+      EXPECT_EQ(0, rmdir(path->c_str())) << *path;
+#endif
+  }
+
+  void CreateDirectory(const FilePath& path)
+  {
+#if defined(_WIN32)
+    ASSERT_TRUE(std::filesystem::create_directory(path));
+#else
+    ASSERT_EQ(0, mkdir(path.c_str(), 0700));
+    m_directories.push_back(path);
+#endif
+  }
+
+#if !defined(_WIN32)
+  int CreateSymlink(const FilePath& target, const FilePath& path)
+  {
+    const int result = symlink(target.c_str(), path.c_str());
+    if (result == 0)
+      m_files.push_back(path);
+    return result;
+  }
+#endif
+
+  void WriteFile(const FilePath& path, const char* contents)
+  {
+    std::ofstream stream(path, std::ios::binary);
+    ASSERT_TRUE(stream.is_open());
+#if !defined(_WIN32)
+    m_files.push_back(path);
+#endif
+    stream << contents;
+    ASSERT_TRUE(stream.good());
+  }
+
+  RequestResult Request(const char* rawPath) { return Request(m_root, rawPath); }
+
+  RequestResult Request(const FilePath& root,
+                        const char* rawPath,
+                        bool requestContentFeatures = false)
+  {
+    TestFileMediaServerDelegate delegate(root);
+    NPT_HttpUrl url;
+    EXPECT_EQ(NPT_SUCCESS, url.SetPath(rawPath, true));
+    NPT_HttpRequest request(url, NPT_HTTP_METHOD_GET);
+    if (requestContentFeatures)
+      request.GetHeaders().SetHeader("getcontentFeatures.dlna.org", "1");
+    NPT_HttpRequestContext context;
+    NPT_HttpResponse response(200, "OK");
+    response.SetEntity(new NPT_HttpEntity());
+
+    RequestResult requestResult{delegate.ProcessFileRequest(request, context, response),
+                                response.GetStatusCode(),
+                                {},
+                                {},
+                                {}};
+    requestResult.mimeType = response.GetEntity()->GetContentType().GetChars();
+    const NPT_String* contentFeatures =
+        response.GetHeaders().GetHeaderValue("ContentFeatures.DLNA.ORG");
+    if (contentFeatures)
+      requestResult.contentFeatures = contentFeatures->GetChars();
+    if (requestResult.result == NPT_SUCCESS && requestResult.status == 200)
+    {
+      NPT_DataBuffer data;
+      EXPECT_EQ(NPT_SUCCESS, response.GetEntity()->Load(data));
+      requestResult.body.assign(reinterpret_cast<const char*>(data.GetData()), data.GetDataSize());
+    }
+    return requestResult;
+  }
+
+  void ExpectRejected(const char* rawPath)
+  {
+    const RequestResult result = Request(rawPath);
+    EXPECT_EQ(NPT_SUCCESS, result.result);
+    EXPECT_EQ(404, result.status);
+  }
+
+  void ExpectServeFileRejected(const char* rawPath)
+  {
+    const RequestResult result = Request(rawPath);
+    EXPECT_EQ(NPT_ERROR_NO_SUCH_ITEM, result.result);
+    EXPECT_EQ(200, result.status);
+  }
+
+#if !defined(_WIN32)
+  int m_workingDirectory{-1};
+  std::vector<FilePath> m_files;
+  std::vector<FilePath> m_directories;
+#endif
+  FilePath m_base;
+  FilePath m_root;
+  FilePath m_root2;
+};
+
+TEST_F(TestUPnPFileMediaServer, ServesNormalFileBelowRoot)
+{
+  const RequestResult result = Request("/%25/movie..part.mkv");
+
+  EXPECT_EQ(NPT_SUCCESS, result.result);
+  EXPECT_EQ(200, result.status);
+  EXPECT_EQ("normal", result.body);
+}
+
+TEST_F(TestUPnPFileMediaServer, ServesFilenameBeginningWithTwoDots)
+{
+  const RequestResult result = Request("/%25/..hidden");
+
+  EXPECT_EQ(NPT_SUCCESS, result.result);
+  EXPECT_EQ(200, result.status);
+  EXPECT_EQ("hidden", result.body);
+}
+
+TEST_F(TestUPnPFileMediaServer, ServesNestedFileBelowRoot)
+{
+  const RequestResult result = Request("/%25/nested/song.flac");
+
+  EXPECT_EQ(NPT_SUCCESS, result.result);
+  EXPECT_EQ(200, result.status);
+  EXPECT_EQ("nested", result.body);
+}
+
+TEST_F(TestUPnPFileMediaServer, TrimsRedundantSeparatorsFromNonRoot)
+{
+  FilePath root = m_root;
+  root += NPT_FilePath::Separator;
+  root += NPT_FilePath::Separator;
+
+  const RequestResult result = Request(root, "/%25/movie..part.mkv");
+  EXPECT_EQ(NPT_SUCCESS, result.result);
+  EXPECT_EQ(200, result.status);
+  EXPECT_EQ("normal", result.body);
+}
+
+TEST_F(TestUPnPFileMediaServer, RoundTripsBrowseResourceUriFromFilesystemRoot)
+{
+  const FilePath filesystemRoot = FilesystemRoot(m_root);
+  const FilePath file = ChildPath(m_root, "nested/song.flac");
+  const std::string relativePath = PathToUtf8(file).substr(PathToUtf8(filesystemRoot).size());
+  const NPT_String encodedPath =
+      NPT_Uri::PercentEncode(relativePath.c_str(), NPT_Uri::PathCharsToEncode);
+  TestFileMediaServerDelegate delegate(filesystemRoot);
+  NPT_String resourceUri;
+
+  ASSERT_EQ(NPT_SUCCESS, delegate.GetBrowseResourceUri(file, resourceUri));
+  NPT_HttpUrl url(resourceUri.GetChars());
+  EXPECT_NE(NPT_STRING_SEARCH_FAILED, url.GetPath().Find(encodedPath));
+
+  const RequestResult result = Request(filesystemRoot, url.GetPath());
+  EXPECT_EQ(NPT_SUCCESS, result.result);
+  EXPECT_EQ(200, result.status);
+  EXPECT_EQ("nested", result.body);
+}
+
+#if !defined(_WIN32)
+TEST_F(TestUPnPFileMediaServer, TrimsMixedSeparatorsFromRelativeRoot)
+{
+  m_workingDirectory = open(".", O_RDONLY);
+  ASSERT_GE(m_workingDirectory, 0);
+  ASSERT_EQ(0, chdir(m_base.c_str()));
+
+  const RequestResult result = Request("root/\\/", "/%25/nested/song.flac");
+  EXPECT_EQ(NPT_SUCCESS, result.result);
+  EXPECT_EQ(200, result.status);
+  EXPECT_EQ("nested", result.body);
+
+  TestFileMediaServerDelegate delegate("root/\\/");
+  NPT_String path;
+  ASSERT_EQ(NPT_SUCCESS, delegate.GetObjectPath("0/nested/song.flac", path));
+  EXPECT_STREQ("root/nested/song.flac", path.GetChars());
+}
+
+TEST_F(TestUPnPFileMediaServer, PreservesPosixRootWithRedundantSeparators)
+{
+  const std::string relativePath = ChildPath(m_root, "nested/song.flac").substr(1);
+  const NPT_String encodedPath =
+      NPT_Uri::PercentEncode(relativePath.c_str(), NPT_Uri::PathCharsToEncode);
+  const std::string rawPath = "/%25/" + std::string(encodedPath.GetChars());
+
+  const RequestResult result = Request("///\\/", rawPath.c_str());
+  EXPECT_EQ(NPT_SUCCESS, result.result);
+  EXPECT_EQ(200, result.status);
+  EXPECT_EQ("nested", result.body);
+
+  TestFileMediaServerDelegate delegate("///\\/");
+  NPT_String path;
+  ASSERT_EQ(NPT_SUCCESS, delegate.GetObjectPath("0", path));
+  EXPECT_STREQ("/", path.GetChars());
+}
+
+TEST_F(TestUPnPFileMediaServer, ResolvesSymlinkedRoot)
+{
+  const FilePath root = ChildPath(m_base, "root-link");
+  ASSERT_EQ(0, CreateSymlink(m_root, root));
+
+  const RequestResult result = Request(root, "/%25/movie..part.mkv");
+  EXPECT_EQ(NPT_SUCCESS, result.result);
+  EXPECT_EQ(200, result.status);
+  EXPECT_EQ("normal", result.body);
+}
+
+TEST_F(TestUPnPFileMediaServer, AllowsInRootDirectorySymlinkForRequestsAndBrowse)
+{
+  ASSERT_EQ(0, CreateSymlink("nested", ChildPath(m_root, "nested-link")));
+  const RequestResult result = Request("/%25/nested-link/song.flac");
+  EXPECT_EQ(NPT_SUCCESS, result.result);
+  EXPECT_EQ(200, result.status);
+  EXPECT_EQ("nested", result.body);
+
+  TestFileMediaServerDelegate delegate(m_root);
+  NPT_String path;
+  ASSERT_EQ(NPT_SUCCESS, delegate.GetObjectPath("0/nested-link/song.flac", path));
+  EXPECT_EQ(PathToUtf8(ChildPath(m_root, "nested-link/song.flac")), path.GetChars());
+  EXPECT_TRUE(delegate.CanBuildBrowseObject(ChildPath(m_root, "nested-link/song.flac")));
+}
+
+TEST_F(TestUPnPFileMediaServer, RejectsDanglingAndLoopingSymlinks)
+{
+  ASSERT_EQ(0, CreateSymlink("missing", ChildPath(m_root, "dangling")));
+  ASSERT_EQ(0, CreateSymlink("loop", ChildPath(m_root, "loop")));
+  ExpectServeFileRejected("/%25/dangling");
+  ExpectServeFileRejected("/%25/loop");
+
+  TestFileMediaServerDelegate delegate(m_root);
+  NPT_String path;
+  EXPECT_EQ(NPT_ERROR_NO_SUCH_ITEM, delegate.GetObjectPath("0/dangling", path));
+  EXPECT_EQ(NPT_ERROR_NO_SUCH_ITEM, delegate.GetObjectPath("0/loop", path));
+  EXPECT_FALSE(delegate.CanBuildBrowseObject(ChildPath(m_root, "dangling")));
+}
+#endif
+
+TEST_F(TestUPnPFileMediaServer, RejectsUnresolvableRoot)
+{
+  const FilePath root = ChildPath(m_base, "missing-root");
+  const RequestResult result = Request(root, "/%25/movie..part.mkv");
+  EXPECT_EQ(NPT_ERROR_NO_SUCH_ITEM, result.result);
+  EXPECT_EQ(200, result.status);
+
+  TestFileMediaServerDelegate delegate(root);
+  NPT_String path;
+  EXPECT_EQ(NPT_ERROR_NO_SUCH_ITEM, delegate.GetObjectPath("0", path));
+  EXPECT_FALSE(delegate.CanBuildBrowseObject(ChildPath(m_root, "movie..part.mkv")));
+}
+
+TEST_F(TestUPnPFileMediaServer, RejectsMetadataOutsideRoot)
+{
+  TestFileMediaServerDelegate delegate(m_root);
+  EXPECT_FALSE(delegate.CanBuildBrowseObject(ChildPath(m_root2, "outside.txt")));
+  EXPECT_FALSE(delegate.CanBuildBrowseObject(ChildPath(m_base, "outside.txt")));
+  EXPECT_FALSE(delegate.CanBuildBrowseObject(FilesystemRoot(m_root)));
+}
+
+#if defined(_WIN32)
+TEST_F(TestUPnPFileMediaServer, PreservesWindowsDriveRoot)
+{
+  const FilePath driveRoot = FilesystemRoot(m_root);
+  ASSERT_FALSE(driveRoot.empty());
+  ASSERT_TRUE(driveRoot.is_absolute());
+
+  const FilePath file = ChildPath(m_root, "nested/song.flac");
+  const std::string relativePath = GenericPathToUtf8(file.lexically_relative(driveRoot));
+  const NPT_String encodedPath =
+      NPT_Uri::PercentEncode(relativePath.c_str(), NPT_Uri::PathCharsToEncode);
+  const std::string rawPath = "/%25/" + std::string(encodedPath.GetChars());
+  const RequestResult result = Request(driveRoot, rawPath.c_str());
+
+  EXPECT_EQ(NPT_SUCCESS, result.result);
+  EXPECT_EQ(200, result.status);
+  EXPECT_EQ("nested", result.body);
+}
+#endif
+
+TEST_F(TestUPnPFileMediaServer, UsesRequestedPathForMimeTypeOfInRootSymlink)
+{
+#if defined(_WIN32)
+  GTEST_SKIP() << "Windows reparse points are intentionally rejected";
+#else
+  WriteFile(ChildPath(m_root, "extensionless-target"), "symlink");
+  ASSERT_EQ(0, CreateSymlink("extensionless-target", ChildPath(m_root, "movie.mp4")));
+
+  const RequestResult result = Request(m_root, "/%25/movie.mp4", true);
+  EXPECT_EQ(NPT_SUCCESS, result.result);
+  EXPECT_EQ(200, result.status);
+  EXPECT_EQ("symlink", result.body);
+  EXPECT_EQ("video/mp4", result.mimeType);
+  EXPECT_NE(std::string::npos, result.contentFeatures.find("MPEG4_P2_SP_AAC"));
+#endif
+}
+
+TEST_F(TestUPnPFileMediaServer, AcceptsCaseVariantInRootSymlinkOnCaseInsensitiveFilesystem)
+{
+#if defined(_WIN32)
+  GTEST_SKIP() << "Windows reparse points are intentionally rejected";
+#else
+  const FilePath alternateRoot = ChildPath(m_base, "ROOT");
+  if (!PathsEquivalent(m_root, alternateRoot))
+    GTEST_SKIP() << "Filesystem is case-sensitive";
+
+  WriteFile(ChildPath(m_root, "case-target"), "case");
+  ASSERT_EQ(0,
+            CreateSymlink(ChildPath(alternateRoot, "case-target"), ChildPath(m_root, "case-link")));
+
+  const RequestResult result = Request("/%25/case-link");
+  EXPECT_EQ(NPT_SUCCESS, result.result);
+  EXPECT_EQ(200, result.status);
+  EXPECT_EQ("case", result.body);
+#endif
+}
+
+TEST_F(TestUPnPFileMediaServer, RejectsTraversalPaths)
+{
+  ExpectRejected("/%25/../outside.txt");
+  ExpectRejected("/%25/..\\outside.txt");
+  ExpectRejected("/%25/%2e%2e%2foutside.txt");
+  ExpectRejected("/%25/%2e%2e%5coutside.txt");
+  ExpectRejected("/%25/.%2e/outside.txt");
+  ExpectRejected("/%25/nested/../../outside.txt");
+  ExpectRejected("/%/../outside.txt");
+}
+
+TEST_F(TestUPnPFileMediaServer, RejectsAbsolutePaths)
+{
+  ExpectRejected("/%25//etc/passwd");
+#if defined(_WIN32)
+  ExpectRejected("/%25/C:%5cWindows%5cwin.ini");
+#endif
+  ExpectRejected("/%25/%5c%5cserver%5cshare%5cfile");
+}
+
+TEST_F(TestUPnPFileMediaServer, RejectsRootPrefixCollision)
+{
+  ExpectRejected("/%25/../root2/outside.txt");
+}
+
+TEST_F(TestUPnPFileMediaServer, DoesNotDecodePercentEncodingTwice)
+{
+  WriteFile(ChildPath(m_root, "%2e%2e%2fpercent.txt"), "percent");
+
+  const RequestResult result = Request("/%25/%252e%252e%252fpercent.txt");
+  EXPECT_EQ(NPT_SUCCESS, result.result);
+  EXPECT_EQ(200, result.status);
+  EXPECT_EQ("percent", result.body);
+}
+
+TEST_F(TestUPnPFileMediaServer, RejectsMalformedPathEncodingWithoutThrowing)
+{
+  EXPECT_NO_THROW(ExpectServeFileRejected("/%25/%ff"));
+  EXPECT_NO_THROW(ExpectServeFileRejected("/%25/%c3%28"));
+}
+
+TEST_F(TestUPnPFileMediaServer, PreservesServeFileFailureSemantics)
+{
+  ExpectServeFileRejected("/%25/missing-file");
+}
+
+TEST_F(TestUPnPFileMediaServer, RejectsSymlinkEscape)
+{
+#if defined(_WIN32)
+  std::error_code error;
+  std::filesystem::create_directory_symlink(m_root2, ChildPath(m_root, "outside-link"), error);
+  if (error)
+    GTEST_SKIP() << "Cannot create directory symlink: " << error.message();
+#else
+  ASSERT_EQ(0, CreateSymlink(m_root2, ChildPath(m_root, "outside-link")));
+#endif
+
+  ExpectServeFileRejected("/%25/outside-link/outside.txt");
+}
+
+TEST_F(TestUPnPFileMediaServer, ResolvesNormalBrowseObjectIdsBelowRoot)
+{
+  TestFileMediaServerDelegate delegate(m_root);
+  NPT_String path;
+
+  ASSERT_EQ(NPT_SUCCESS, delegate.GetObjectPath("0/nested/song.flac", path));
+  EXPECT_TRUE(PathsEquivalent(PathFromUtf8(path), ChildPath(m_root, "nested/song.flac")));
+}
+
+TEST_F(TestUPnPFileMediaServer, RejectsBrowseObjectIdTraversal)
+{
+  TestFileMediaServerDelegate delegate(m_root);
+  NPT_String path;
+
+  EXPECT_TRUE(NPT_FAILED(delegate.GetObjectPath("0/../outside.txt", path)));
+  EXPECT_TRUE(NPT_FAILED(delegate.GetObjectPath("0/..\\outside.txt", path)));
+  EXPECT_TRUE(NPT_FAILED(delegate.GetObjectPath("0/nested/../../outside.txt", path)));
+  EXPECT_TRUE(NPT_FAILED(delegate.GetObjectPath("0/../root2/outside.txt", path)));
+}
+
+TEST_F(TestUPnPFileMediaServer, RejectsMalformedBrowseObjectIdWithoutThrowing)
+{
+  TestFileMediaServerDelegate delegate(m_root);
+  NPT_String path;
+  const char malformedObjectId[] = {'0', '/', static_cast<char>(0xff), '\0'};
+
+  EXPECT_NO_THROW(EXPECT_TRUE(NPT_FAILED(delegate.GetObjectPath(malformedObjectId, path))));
+}
+
+TEST_F(TestUPnPFileMediaServer, DoesNotUrlDecodeBrowseObjectIds)
+{
+  WriteFile(ChildPath(m_root, "%2e%2e"), "percent-object-id");
+  TestFileMediaServerDelegate delegate(m_root);
+  NPT_String path;
+
+  ASSERT_EQ(NPT_SUCCESS, delegate.GetObjectPath("0/%2e%2e", path));
+  EXPECT_TRUE(PathsEquivalent(PathFromUtf8(path), ChildPath(m_root, "%2e%2e")));
+}
+
+TEST_F(TestUPnPFileMediaServer, RejectsBrowseObjectIdSymlinkEscape)
+{
+#if defined(_WIN32)
+  std::error_code error;
+  std::filesystem::create_directory_symlink(m_root2, ChildPath(m_root, "browse-link"), error);
+  if (error)
+    GTEST_SKIP() << "Cannot create directory symlink: " << error.message();
+#else
+  ASSERT_EQ(0, CreateSymlink(m_root2, ChildPath(m_root, "browse-link")));
+#endif
+
+  TestFileMediaServerDelegate delegate(m_root);
+  NPT_String path;
+  EXPECT_TRUE(NPT_FAILED(delegate.GetObjectPath("0/browse-link/outside.txt", path)));
+  EXPECT_FALSE(delegate.CanBuildBrowseObject(ChildPath(m_root, "browse-link")));
+}
+
+} // namespace


### PR DESCRIPTION
## Description

Replaces https://github.com/xbmc/xbmc/pull/26741.

AI use:

Fix path traversal vulnerabilities in the bundled Platinum file media server.

Resource paths are validated after URL decoding and resolved against the configured file root before files are served. The same root-aware containment is applied to UPnP browse object IDs and directory-entry metadata.

The change also replaces the old substring-based traversal check in `PLT_HttpServer::ServeFile()` with validation at the layer that actually knows the configured root.

The corresponding libUPnP vendor patch is included in `lib/libUPnP/patches/`.

## Motivation and context

The existing check in `PLT_HttpServer::ServeFile()` only searched for specific `..` string patterns and did not reliably guarantee that a requested path remained inside the configured file root.

This was previously discussed in #26741 and #21641. The simple upstream-style substring fix was considered insufficient because encoded paths and other filesystem traversal mechanisms could bypass that approach.

This change instead validates path components and verifies canonical filesystem containment, including protection against root-prefix collisions and symlink escapes.

Related:

* #26741
* #21641
* CVE-2020-19858

## How has this been tested?

Added UPnP file server regression tests covering:

* normal and nested files inside the configured root
* legitimate filenames containing `..`
* `/` and `\` traversal
* percent-encoded and mixed traversal paths
* absolute paths
* multiple-level traversal
* root-prefix collisions
* symlink escapes
* malformed path encoding
* prevention of unintended double URL decoding
* existing `ServeFile()` failure semantics
* traversal through UPnP browse object IDs
* symlink escapes through browse metadata

## What is the effect on users?

Prevents malicious UPnP requests from accessing files outside the configured media server root.

## Types of change

* [x] **Bug fix** (non-breaking change which fixes an issue)
* [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
* [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
* [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
* [ ] **New feature** (non-breaking change which adds functionality)
* [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
* [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
* [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
* [ ] **None of the above** (please explain below)
