### PR TITLE
fixed: stop JSONRPC.SetConfiguration dropping namespaces it never listed

### DIFF
--- a/xbmc/interfaces/json-rpc/JSONRPC.cpp
+++ b/xbmc/interfaces/json-rpc/JSONRPC.cpp
@@ -182,38 +182,21 @@ JSONRPC_STATUS CJSONRPC::GetConfiguration(const std::string &method, ITransportL
 JSONRPC_STATUS CJSONRPC::SetConfiguration(const std::string &method, ITransportLayer *transport, IClient *client, const CVariant& parameterObject, CVariant &result)
 {
   int flags = 0;
-  int oldFlags = client->GetAnnouncementFlags();
+  const int oldFlags = client->GetAnnouncementFlags();
 
   if (parameterObject.isMember("notifications"))
   {
-    CVariant notifications = parameterObject["notifications"];
-    if ((notifications["Player"].isNull() && (oldFlags & ANNOUNCEMENT::Player)) ||
-        (notifications["Player"].isBoolean() && notifications["Player"].asBoolean()))
-      flags |= ANNOUNCEMENT::Player;
-    if ((notifications["Playlist"].isNull() && (oldFlags & ANNOUNCEMENT::Playlist)) ||
-        (notifications["Playlist"].isBoolean() && notifications["Playlist"].asBoolean()))
-      flags |= ANNOUNCEMENT::Playlist;
-    if ((notifications["GUI"].isNull() && (oldFlags & ANNOUNCEMENT::GUI)) ||
-        (notifications["GUI"].isBoolean() && notifications["GUI"].asBoolean()))
-      flags |= ANNOUNCEMENT::GUI;
-    if ((notifications["System"].isNull() && (oldFlags & ANNOUNCEMENT::System)) ||
-        (notifications["System"].isBoolean() && notifications["System"].asBoolean()))
-      flags |= ANNOUNCEMENT::System;
-    if ((notifications["VideoLibrary"].isNull() && (oldFlags & ANNOUNCEMENT::VideoLibrary)) ||
-        (notifications["VideoLibrary"].isBoolean() && notifications["VideoLibrary"].asBoolean()))
-      flags |= ANNOUNCEMENT::VideoLibrary;
-    if ((notifications["AudioLibrary"].isNull() && (oldFlags & ANNOUNCEMENT::AudioLibrary)) ||
-        (notifications["AudioLibrary"].isBoolean() && notifications["AudioLibrary"].asBoolean()))
-      flags |= ANNOUNCEMENT::AudioLibrary;
-    if ((notifications["Application"].isNull() && (oldFlags & ANNOUNCEMENT::Other)) ||
-        (notifications["Application"].isBoolean() && notifications["Application"].asBoolean()))
-      flags |= ANNOUNCEMENT::Application;
-    if ((notifications["Input"].isNull() && (oldFlags & ANNOUNCEMENT::Input)) ||
-        (notifications["Input"].isBoolean() && notifications["Input"].asBoolean()))
-      flags |= ANNOUNCEMENT::Input;
-    if ((notifications["Other"].isNull() && (oldFlags & ANNOUNCEMENT::Other)) ||
-        (notifications["Other"].isBoolean() && notifications["Other"].asBoolean()))
-      flags |= ANNOUNCEMENT::Other;
+    const CVariant& notifications = parameterObject["notifications"];
+    // a namespace the caller does not name keeps its current state
+    for (int flag = 1; flag <= ANNOUNCEMENT::ANNOUNCE_ALL; flag *= 2)
+    {
+      const CVariant& requested = notifications[ANNOUNCEMENT::AnnouncementFlagToString(
+          static_cast<ANNOUNCEMENT::AnnouncementFlag>(flag))];
+      const bool wanted = requested.isNull() ? (oldFlags & flag) != 0
+                                             : requested.isBoolean() && requested.asBoolean();
+      if (wanted)
+        flags |= flag;
+    }
   }
 
   if (!client->SetAnnouncementFlags(flags))

--- a/xbmc/interfaces/json-rpc/schema/methods.json
+++ b/xbmc/interfaces/json-rpc/schema/methods.json
@@ -205,7 +205,16 @@
           "Input": {
             "$ref": "Optional.Boolean"
           },
+          "PVR": {
+            "$ref": "Optional.Boolean"
+          },
           "Other": {
+            "$ref": "Optional.Boolean"
+          },
+          "Info": {
+            "$ref": "Optional.Boolean"
+          },
+          "Sources": {
             "$ref": "Optional.Boolean"
           }
         }

--- a/xbmc/interfaces/json-rpc/schema/types.json
+++ b/xbmc/interfaces/json-rpc/schema/types.json
@@ -150,6 +150,14 @@
       "Other": {
         "type": "boolean",
         "required": true
+      },
+      "Info": {
+        "type": "boolean",
+        "required": true
+      },
+      "Sources": {
+        "type": "boolean",
+        "required": true
       }
     },
     "additionalProperties": false

--- a/xbmc/interfaces/json-rpc/test/CMakeLists.txt
+++ b/xbmc/interfaces/json-rpc/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES TestAddonsExecuteAddon.cpp
             TestFileOperations.cpp
             TestJSONRPCPermission.cpp
             TestJSONRPCStatus.cpp
+            TestSetConfiguration.cpp
             TestVideoLibrarySetSourceContent.cpp)
 
 core_add_test_library(jsonrpc_test)

--- a/xbmc/interfaces/json-rpc/test/TestSetConfiguration.cpp
+++ b/xbmc/interfaces/json-rpc/test/TestSetConfiguration.cpp
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "interfaces/IAnnouncer.h"
+#include "interfaces/json-rpc/IClient.h"
+#include "interfaces/json-rpc/JSONRPC.h"
+#include "interfaces/json-rpc/JSONRPCUtils.h"
+#include "utils/Variant.h"
+
+#include <gtest/gtest.h>
+
+using namespace JSONRPC;
+
+namespace
+{
+class CFlagsClient : public IClient
+{
+public:
+  explicit CFlagsClient(int flags) : m_flags(flags) {}
+
+  int GetPermissionFlags() override { return OPERATION_PERMISSION_ALL; }
+  int GetAnnouncementFlags() override { return m_flags; }
+  bool SetAnnouncementFlags(int flags) override
+  {
+    m_flags = flags;
+    return true;
+  }
+
+private:
+  int m_flags;
+};
+
+int Configure(CFlagsClient& client, const CVariant& notifications)
+{
+  CVariant params(CVariant::VariantTypeObject);
+  params["notifications"] = notifications;
+  CVariant result;
+  EXPECT_EQ(
+      OK, CJSONRPC::SetConfiguration("JSONRPC.SetConfiguration", nullptr, &client, params, result));
+  return client.GetAnnouncementFlags();
+}
+
+const char* Name(int flag)
+{
+  return ANNOUNCEMENT::AnnouncementFlagToString(static_cast<ANNOUNCEMENT::AnnouncementFlag>(flag));
+}
+} // namespace
+
+TEST(TestSetConfiguration, OmittedNamespacesKeepTheirCurrentState)
+{
+  CFlagsClient client(ANNOUNCEMENT::ANNOUNCE_ALL);
+  CVariant notifications(CVariant::VariantTypeObject);
+  notifications["Player"] = false;
+
+  EXPECT_EQ(ANNOUNCEMENT::ANNOUNCE_ALL & ~ANNOUNCEMENT::Player, Configure(client, notifications));
+}
+
+TEST(TestSetConfiguration, EveryNamespaceCanBeEnabled)
+{
+  CFlagsClient client(0);
+  CVariant notifications(CVariant::VariantTypeObject);
+  for (int flag = 1; flag <= ANNOUNCEMENT::ANNOUNCE_ALL; flag *= 2)
+    notifications[Name(flag)] = true;
+
+  EXPECT_EQ(ANNOUNCEMENT::ANNOUNCE_ALL, Configure(client, notifications));
+}
+
+TEST(TestSetConfiguration, EveryNamespaceCanBeDisabled)
+{
+  CFlagsClient client(ANNOUNCEMENT::ANNOUNCE_ALL);
+  CVariant notifications(CVariant::VariantTypeObject);
+  for (int flag = 1; flag <= ANNOUNCEMENT::ANNOUNCE_ALL; flag *= 2)
+    notifications[Name(flag)] = false;
+
+  EXPECT_EQ(0, Configure(client, notifications));
+}
+
+TEST(TestSetConfiguration, ApplicationIsKeptByItsOwnBit)
+{
+  CVariant notifications(CVariant::VariantTypeObject);
+  notifications["Player"] = true;
+
+  CFlagsClient application(ANNOUNCEMENT::Application);
+  EXPECT_EQ(ANNOUNCEMENT::Application | ANNOUNCEMENT::Player,
+            Configure(application, notifications));
+
+  CFlagsClient other(ANNOUNCEMENT::Other);
+  EXPECT_EQ(ANNOUNCEMENT::Other | ANNOUNCEMENT::Player, Configure(other, notifications));
+}


### PR DESCRIPTION
**TL;DR:** Bug fix. `JSONRPC.SetConfiguration` silently unsubscribes every client from the `PVR`, `Info` and `Sources` notification namespaces, and keeps `Application` by the wrong bit.

## Description

`CJSONRPC::SetConfiguration` rebuilt a client's announcement flags from zero over a hand-written list of nine namespace names, testing each one as "the caller asked for it, or the caller said nothing and it was already on". The flag enum has twelve members and the schema declared nine, so the handler and the enum had drifted apart in two ways.

**Three namespaces were missing entirely.** `PVR`, `Info` and `Sources` were never tested, so their bits were never set on the rebuilt mask. `additionalProperties: false` on the parameter meant a client could not ask for them back either.

**`Application` kept itself by the wrong bit.** Its "the caller did not name it, keep what it had" arm consulted `ANNOUNCEMENT::Other`:

```cpp
if ((notifications["Application"].isNull() && (oldFlags & ANNOUNCEMENT::Other)) ||
```

So an omitted `Application` followed whatever `Other` happened to be, regardless of what `Application` was.

The handler now loops over `ANNOUNCE_ALL` and names each flag with `AnnouncementFlagToString`, which is how `CJSONRPC::GetConfiguration` twenty lines above has always enumerated them. A namespace added to the enum is handled without touching this function.

The schema gains the three missing properties on `SetConfiguration`'s parameter, and the two missing from `Configuration.Notifications`, so the declared return type covers what `GetConfiguration` already answers.

## Motivation and context

`SetConfiguration` is the only way a client narrows what it receives, and its documented shape is "tell me what to change, leave the rest alone". It did not leave the rest alone.

A connection starts at `ANNOUNCE_ALL` (`CTCPServer.cpp`), so every client has all twelve namespaces enabled. The first `SetConfiguration` call it makes — for any reason, including turning a namespace *on* — rebuilds the mask without `PVR`, `Info` and `Sources` and drops them for the life of that connection.

The loss is invisible from the answer. `GetConfiguration` reports by looping over every flag, so it reports the three correctly as `false`, which reads like a choice the client made rather than one made for it.

## How has this been tested?

New gtest cases in `xbmc/interfaces/json-rpc/test/TestSetConfiguration.cpp`, driving `CJSONRPC::SetConfiguration` through a stub `IClient`:

- `OmittedNamespacesKeepTheirCurrentState`
- `EveryNamespaceCanBeEnabled`
- `EveryNamespaceCanBeDisabled`
- `ApplicationIsKeptByItsOwnBit`

Three of the four fail against the previous handler with the schema change alone — `ApplicationIsKeptByItsOwnBit` expects `65` (`Application | Player`) and gets `1`, `Application` having been erased. All four pass with the fix.

Full suite green on a clean build: 4082 tests from 321 suites, all passed. `clang-format` clean on the changed lines.

## What is the effect on users?

A JSON-RPC client that calls `JSONRPC.SetConfiguration` keeps its PVR, Info and Sources notifications instead of losing them, and can now subscribe to them explicitly. A client that had only `Application` enabled no longer loses it when it enables something else.

## Screenshots (if appropriate):

## Types of change

- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
