### PR TITLE
[games] Use the selected item for in-game menu actions

### DIFF
--- a/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
+++ b/xbmc/games/dialogs/osd/DialogGameVideoSelect.cpp
@@ -74,50 +74,40 @@ bool CDialogGameVideoSelect::OnMessage(CGUIMessage& message)
     case GUI_MSG_CLICKED:
     {
       const int actionId = message.GetParam1();
+      const int controlId = message.GetSenderId();
+      if (!m_viewControl->HasControl(controlId))
+        break;
+
+      const int selectedItem = m_viewControl->GetSelectedItem();
+      if (selectedItem < 0)
+        break;
+
+      OnItemFocus(static_cast<unsigned int>(selectedItem));
+
       if (actionId == ACTION_SELECT_ITEM || actionId == ACTION_MOUSE_LEFT_CLICK)
       {
-        const int controlId = message.GetSenderId();
-        if (m_viewControl->HasControl(controlId))
-        {
-          if (OnClickAction())
-            return true;
-        }
+        if (OnClickAction())
+          return true;
       }
       else if (actionId == ACTION_CONTEXT_MENU || actionId == ACTION_MOUSE_RIGHT_CLICK)
       {
-        const int controlId = message.GetSenderId();
-        if (m_viewControl->HasControl(controlId))
-        {
-          if (OnMenuAction())
-            return true;
-        }
+        if (OnMenuAction())
+          return true;
       }
       else if (actionId == ACTION_CREATE_BOOKMARK)
       {
-        const int controlId = message.GetSenderId();
-        if (m_viewControl->HasControl(controlId))
-        {
-          if (OnOverwriteAction())
-            return true;
-        }
+        if (OnOverwriteAction())
+          return true;
       }
       else if (actionId == ACTION_RENAME_ITEM)
       {
-        const int controlId = message.GetSenderId();
-        if (m_viewControl->HasControl(controlId))
-        {
-          if (OnRenameAction())
-            return true;
-        }
+        if (OnRenameAction())
+          return true;
       }
       else if (actionId == ACTION_DELETE_ITEM)
       {
-        const int controlId = message.GetSenderId();
-        if (m_viewControl->HasControl(controlId))
-        {
-          if (OnDeleteAction())
-            return true;
-        }
+        if (OnDeleteAction())
+          return true;
       }
 
       break;


### PR DESCRIPTION
## Description

This fixes remote input in the "video select" dialogs, like savestates, video filters, stretch mode, etc.

Remote input can move the list before the next GUI frame updates its cached focus. Read the selected item before dispatching load, overwrite, rename and delete actions.

## Motivation and context

Needed for background control of Kodi during agent automation.

## How has this been tested?

Verified five PCSX savestate loads with background input.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)
