### PR TITLE
[games] Fix disc selection and slot reuse in Disc Manager

### DIFF
--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -221,6 +221,16 @@ bool CGameClientDiscs::AddDisc(const std::string& filePath)
   {
     if (!m_transport->ReplaceImageIndex(static_cast<unsigned int>(*removedIndex), filePath))
       return false;
+
+    const auto selected = m_discModel->GetSelectedDiscIndex();
+    auto discs = m_discModel->GetDiscs();
+    discs[*removedIndex] = {GameClientDiscEntry::DiscSlotType::Disc,
+                            filePath,
+                            CGameClientDiscModel::DeriveBasename(filePath),
+                            {}};
+    m_discModel->SetDiscs(discs);
+    if (selected)
+      m_discModel->SetSelectedDiscByIndex(*selected);
   }
   else
   {

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -291,6 +291,7 @@ bool CGameClientDiscs::RemoveDiscByIndex(size_t index)
 
   const std::optional<size_t> selectedIndex = m_discModel->GetSelectedDiscIndex();
   const bool wasSelected = selectedIndex.has_value() && *selectedIndex == index;
+  bool selectionUpdated = true;
 
   // Remove from the core by current index
   if (!m_transport->RemoveImageIndex(static_cast<unsigned int>(index)))
@@ -302,14 +303,14 @@ bool CGameClientDiscs::RemoveDiscByIndex(size_t index)
   if (wasSelected)
   {
     const unsigned int noDiscIndex = m_transport->GetImageCount();
-    m_transport->SetImageIndex(noDiscIndex);
+    selectionUpdated = m_transport->SetImageIndex(noDiscIndex);
   }
 
   m_discModel->MarkRemovedByIndex(index);
 
   RefreshDiscState();
 
-  return true;
+  return selectionUpdated;
 }
 
 bool CGameClientDiscs::InsertDisc(const std::string& filePath)

--- a/xbmc/games/addons/disc/test/CMakeLists.txt
+++ b/xbmc/games/addons/disc/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES TestGameClientDiscM3U.cpp
             TestGameClientDiscMergeUtils.cpp
             TestGameClientDiscModel.cpp
+            TestGameClientDiscMutations.cpp
             TestGameClientDiscXML.cpp
 )
 

--- a/xbmc/games/addons/disc/test/TestGameClientDiscMutations.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscMutations.cpp
@@ -1,0 +1,136 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "addons/Repository.h"
+#include "addons/addoninfo/AddonInfoBuilder.h"
+#include "filesystem/File.h"
+#include "games/addons/GameClient.h"
+#include "games/addons/disc/GameClientDiscModel.h"
+#include "games/addons/disc/GameClientDiscs.h"
+#include "test/TestUtils.h"
+#include "utils/XBMCTinyXML2.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace KODI::GAME;
+
+namespace
+{
+struct MutationCore
+{
+  std::vector<std::string> slots{"/roms/disc1.chd", "/roms/disc2.chd"};
+  unsigned int selected{0};
+  bool ejected{true};
+  bool failSetImageIndex{false};
+};
+
+MutationCore& Core(const AddonInstance_Game* instance)
+{
+  return *static_cast<MutationCore*>(instance->toAddon->addonInstance);
+}
+} // namespace
+
+class TestGameClientDiscMutations : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    CXBMCTinyXML2 xml;
+    const std::string addonXml =
+        R"(<addon id="game.test.discmutations" name="Disc mutation test" version="1.0.0">
+      <extension point="kodi.gameclient" library="test.so">
+        <supports_disc_control>true</supports_disc_control>
+        <extensions>chd|m3u</extensions>
+      </extension>
+      <extension point="xbmc.addon.metadata"><platform>all</platform></extension>
+    </addon>)";
+    ASSERT_TRUE(xml.Parse(addonXml));
+    const auto info =
+        ADDON::CAddonInfoBuilder::Generate(xml.RootElement(), ADDON::RepositoryDirInfo{});
+    ASSERT_NE(info, nullptr);
+    m_client = std::make_unique<CGameClient>(info);
+
+    auto* callbacks = m_client->GetInstanceInterface()->toAddon;
+    callbacks->addonInstance = &m_core;
+    callbacks->GetEjectState = [](const AddonInstance_Game* game) { return Core(game).ejected; };
+    callbacks->SetEjectState = [](const AddonInstance_Game* game, bool ejected)
+    {
+      Core(game).ejected = ejected;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->GetImageCount = [](const AddonInstance_Game* game)
+    { return static_cast<unsigned int>(Core(game).slots.size()); };
+    callbacks->GetImageIndex = [](const AddonInstance_Game* game) { return Core(game).selected; };
+    callbacks->SetImageIndex = [](const AddonInstance_Game* game, unsigned int index)
+    {
+      if (Core(game).failSetImageIndex)
+        return GAME_ERROR_FAILED;
+      Core(game).selected = index;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->AddImageIndex = [](const AddonInstance_Game* game)
+    {
+      Core(game).slots.emplace_back();
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->ReplaceImageIndex =
+        [](const AddonInstance_Game* game, unsigned int index, const char* path)
+    {
+      if (index >= Core(game).slots.size())
+        return GAME_ERROR_FAILED;
+      Core(game).slots[index] = path ? path : "";
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->RemoveImageIndex = [](const AddonInstance_Game* game, unsigned int index)
+    {
+      if (index >= Core(game).slots.size())
+        return GAME_ERROR_FAILED;
+      Core(game).slots[index].clear();
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->SetInitialImage = [](const AddonInstance_Game*, unsigned int, const char*)
+    { return GAME_ERROR_NO_ERROR; };
+    callbacks->GetImagePath = [](const AddonInstance_Game*, unsigned int) -> char*
+    { return nullptr; };
+    callbacks->GetImageLabel = [](const AddonInstance_Game*, unsigned int) -> char*
+    { return nullptr; };
+    callbacks->FreeString = [](const AddonInstance_Game*, char* value) { free(value); };
+
+    m_playlist.reset(XBMC_CREATETEMPFILE(".m3u"));
+    ASSERT_NE(m_playlist, nullptr);
+    constexpr char PLAYLIST[] = "/roms/disc1.chd\n/roms/disc2.chd\n";
+    ASSERT_EQ(m_playlist->Write(PLAYLIST, sizeof(PLAYLIST) - 1),
+              static_cast<ssize_t>(sizeof(PLAYLIST) - 1));
+    m_playlist->Close();
+    m_client->Discs().Initialize(XBMC_TEMPFILEPATH(m_playlist.get()));
+    m_client->Discs().RefreshDiscState();
+  }
+
+  void TearDown() override { EXPECT_TRUE(XBMC_DELETETEMPFILE(m_playlist.release())); }
+
+  MutationCore m_core;
+  std::unique_ptr<CGameClient> m_client;
+  std::unique_ptr<XFILE::CFile> m_playlist;
+};
+
+TEST_F(TestGameClientDiscMutations, ReusedRemovedSlotKeepsIdentityWithoutCoreMetadata)
+{
+  ASSERT_TRUE(m_client->Discs().RemoveDiscByIndex(1));
+  ASSERT_TRUE(m_client->Discs().AddDisc("/roms/disc3.chd"));
+
+  const CGameClientDiscModel model = m_client->Discs().GetDiscs();
+  ASSERT_EQ(model.Size(), 2U);
+  EXPECT_FALSE(model.IsRemovedSlotByIndex(1));
+  EXPECT_EQ(model.GetPathByIndex(1), "/roms/disc3.chd");
+}

--- a/xbmc/games/addons/disc/test/TestGameClientDiscMutations.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscMutations.cpp
@@ -134,3 +134,17 @@ TEST_F(TestGameClientDiscMutations, ReusedRemovedSlotKeepsIdentityWithoutCoreMet
   EXPECT_FALSE(model.IsRemovedSlotByIndex(1));
   EXPECT_EQ(model.GetPathByIndex(1), "/roms/disc3.chd");
 }
+
+TEST_F(TestGameClientDiscMutations,
+       FailedNoDiscSelectionAfterRemovalReportsFailureAndRefreshesModel)
+{
+  m_core.failSetImageIndex = true;
+
+  EXPECT_FALSE(m_client->Discs().RemoveDiscByIndex(0));
+
+  const CGameClientDiscModel model = m_client->Discs().GetDiscs();
+  ASSERT_EQ(model.Size(), 2U);
+  EXPECT_TRUE(model.IsRemovedSlotByIndex(0));
+  EXPECT_TRUE(model.IsSelectedNoDisc());
+  EXPECT_TRUE(m_core.slots[0].empty());
+}

--- a/xbmc/games/dialogs/disc/DialogGameDiscManager.cpp
+++ b/xbmc/games/dialogs/disc/DialogGameDiscManager.cpp
@@ -256,6 +256,11 @@ void CDialogGameDiscManager::OnDiscSelect(size_t discIndex, bool isNoDisc)
     m_deleteCallback(discIndex);
 }
 
+void CDialogGameDiscManager::NotifyDiscSelection()
+{
+  m_discGame->NotifyDiscSelection();
+}
+
 bool CDialogGameDiscManager::AllowSelectNoDisc() const
 {
   if (m_insertCallback)

--- a/xbmc/games/dialogs/disc/DialogGameDiscManager.h
+++ b/xbmc/games/dialogs/disc/DialogGameDiscManager.h
@@ -61,6 +61,7 @@ public:
                           std::function<void(std::optional<size_t>)> callback);
   void SelectDiscToDelete(std::function<void(size_t)> callback);
   void OnDiscSelect(size_t discIndex, bool isNoDisc);
+  void NotifyDiscSelection();
   bool AllowSelectNoDisc() const;
 
 protected:

--- a/xbmc/games/dialogs/disc/DiscManagerActions.cpp
+++ b/xbmc/games/dialogs/disc/DiscManagerActions.cpp
@@ -82,7 +82,10 @@ void CDiscManagerActions::OnSelectDisc()
 
                                      // Returning from a successful selection of a disc should land on Resume
                                      if (success)
+                                     {
+                                       m_discManager.NotifyDiscSelection();
                                        m_discManager.FocusMainMenuItem(MENU_INDEX_RESUME_GAME);
+                                     }
                                      else
                                        m_discManager.FocusMainMenuItem(MENU_INDEX_SELECT_DISC);
                                    });

--- a/xbmc/games/dialogs/disc/DiscManagerGame.cpp
+++ b/xbmc/games/dialogs/disc/DiscManagerGame.cpp
@@ -14,6 +14,7 @@
 #include "addons/addoninfo/AddonType.h"
 #include "cores/RetroPlayer/guibridge/GUIGameRenderManager.h"
 #include "cores/RetroPlayer/guibridge/GUIGameSettingsHandle.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "games/addons/GameClient.h"
 #include "games/addons/disc/GameClientDiscs.h"
 #include "resources/LocalizeStrings.h"
@@ -27,6 +28,7 @@ void CDiscManagerGame::Initialize(GameClientPtr gameClient)
 {
   m_gameClient = std::move(gameClient);
   m_initialDiscModel.Clear();
+  m_discSelectionRequested = false;
 
   if (m_gameClient)
   {
@@ -69,12 +71,24 @@ void CDiscManagerGame::Deinitialize()
     const std::vector<GameClientDiscEntry>& currentDiscs = currentModel.GetDiscs();
     bool discListChanged = (initialDiscs != currentDiscs);
 
-    if ((selectedDiscChanged || discListChanged) && m_gameClient->Discs().IsEjected())
-      m_gameClient->Discs().SetEjected(false);
+    if ((m_discSelectionRequested || selectedDiscChanged || discListChanged) &&
+        m_gameClient->Discs().IsEjected() && !m_gameClient->Discs().SetEjected(false))
+    {
+      auto& strings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
+      CLog::Log(LOGERROR, "Failed to insert selected disc when closing Disc Manager");
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, strings.Get(257),
+                                            strings.Get(35279));
+    }
   }
 
   m_gameClient.reset();
   m_initialDiscModel.Clear();
+  m_discSelectionRequested = false;
+}
+
+void CDiscManagerGame::NotifyDiscSelection()
+{
+  m_discSelectionRequested = true;
 }
 
 bool CDiscManagerGame::IsEjected() const

--- a/xbmc/games/dialogs/disc/DiscManagerGame.h
+++ b/xbmc/games/dialogs/disc/DiscManagerGame.h
@@ -32,6 +32,7 @@ public:
   // Lifecycle functions
   void Initialize(GameClientPtr gameClient);
   void Deinitialize();
+  void NotifyDiscSelection();
 
   // Game interface
   bool IsEjected() const;
@@ -46,6 +47,7 @@ private:
   // Game parameters
   GameClientPtr m_gameClient;
   CGameClientDiscModel m_initialDiscModel;
+  bool m_discSelectionRequested{false};
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/dialogs/disc/test/CMakeLists.txt
+++ b/xbmc/games/dialogs/disc/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SOURCES TestDiscManagerSortUtils.cpp
-)
+set(SOURCES TestDiscManagerGame.cpp
+            TestDiscManagerSortUtils.cpp)
 
 core_add_test_library(test_games_dialogs_disc)

--- a/xbmc/games/dialogs/disc/test/TestDiscManagerGame.cpp
+++ b/xbmc/games/dialogs/disc/test/TestDiscManagerGame.cpp
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "addons/Repository.h"
+#include "addons/addoninfo/AddonInfoBuilder.h"
+#include "games/addons/GameClient.h"
+#include "games/dialogs/disc/DiscManagerGame.h"
+#include "utils/XBMCTinyXML2.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace KODI::GAME;
+
+namespace
+{
+struct DiscManagerCore
+{
+  std::vector<std::string> slots{"/roms/disc1.chd"};
+  unsigned int selected{0};
+  bool ejected{true};
+  bool failInsert{false};
+};
+
+DiscManagerCore& Core(const AddonInstance_Game* instance)
+{
+  return *static_cast<DiscManagerCore*>(instance->toAddon->addonInstance);
+}
+} // namespace
+
+class TestDiscManagerGame : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    CXBMCTinyXML2 xml;
+    const std::string addonXml =
+        R"(<addon id="game.test.discmanager" name="Disc manager test" version="1.0.0">
+      <extension point="kodi.gameclient" library="test.so">
+        <supports_disc_control>true</supports_disc_control>
+        <extensions>chd</extensions>
+      </extension>
+      <extension point="xbmc.addon.metadata"><platform>all</platform></extension>
+    </addon>)";
+    ASSERT_TRUE(xml.Parse(addonXml));
+    const auto info =
+        ADDON::CAddonInfoBuilder::Generate(xml.RootElement(), ADDON::RepositoryDirInfo{});
+    ASSERT_NE(info, nullptr);
+    m_client = std::make_shared<CGameClient>(info);
+
+    auto* callbacks = m_client->GetInstanceInterface()->toAddon;
+    callbacks->addonInstance = &m_core;
+    callbacks->GetEjectState = [](const AddonInstance_Game* game) { return Core(game).ejected; };
+    callbacks->SetEjectState = [](const AddonInstance_Game* game, bool ejected)
+    {
+      if (Core(game).failInsert && !ejected)
+        return GAME_ERROR_FAILED;
+      Core(game).ejected = ejected;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->GetImageCount = [](const AddonInstance_Game* game)
+    { return static_cast<unsigned int>(Core(game).slots.size()); };
+    callbacks->GetImageIndex = [](const AddonInstance_Game* game) { return Core(game).selected; };
+    callbacks->GetImagePath = [](const AddonInstance_Game* game, unsigned int index) -> char*
+    { return index < Core(game).slots.size() ? strdup(Core(game).slots[index].c_str()) : nullptr; };
+    callbacks->GetImageLabel = [](const AddonInstance_Game*, unsigned int) -> char*
+    { return nullptr; };
+    callbacks->FreeString = [](const AddonInstance_Game*, char* value) { free(value); };
+  }
+
+  DiscManagerCore m_core;
+  std::shared_ptr<CGameClient> m_client;
+};
+
+TEST_F(TestDiscManagerGame, ExplicitSameDiscSelectionClosesTrayOnDeinitialize)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  game.NotifyDiscSelection();
+
+  game.Deinitialize();
+
+  EXPECT_FALSE(m_core.ejected);
+}
+
+TEST_F(TestDiscManagerGame, FailedAutomaticInsertLeavesTrayOpen)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  game.NotifyDiscSelection();
+  m_core.failInsert = true;
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+}


### PR DESCRIPTION
## Description

This PR contains 3 fixes for the Disc Manager:

- Preserve the new disc’s identity when reusing a removed slot, including when the emulator cannot report disc paths.
- Report failure when removing the selected disc succeeds but selecting No Disc fails.
- Commit explicit selections when leaving Disc Manager, even when choosing the current disc or No Disc again. Show an error if closing the tray fails.

## Motivation and context

Disc Manager could lose track of a re-added disc, leave the tray open after an explicit selection, or silently ignore an emulator error. These fixes keep Kodi’s disc model and the reported result consistent with the operation.

## How has this been tested?

Tested with a Debug build on macOS, Apple Silicon.

- Regression tests cover slot reuse without emulator metadata, failed No Disc selection after removal, explicit same-disc selection, and failed automatic insertion.
- Live testing used Metal Gear Solid’s two-disc M3U with Beetle PSX and PCSX-ReARMed, exercising disc selection, removal, re-addition, No Disc, and tray changes.

## What is the effect on users?

Disc Manager reliably applies explicit selections when the menu closes, keeps re-added discs available, and reports failed operations instead of silently treating them as successful.

## Types of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)