### PR TITLE
[games] Persist disc state in savestates and rewind buffer

### DIFF
--- a/cmake/treedata/common/tests.txt
+++ b/cmake/treedata/common/tests.txt
@@ -1,7 +1,9 @@
 xbmc/addons/gui/skin/test         test/skin
 xbmc/addons/test                  test/addons
 xbmc/cores/AudioEngine/Sinks/test test/audioengine_sinks
+xbmc/cores/RetroPlayer/playback/test test/retroplayer_playback
 xbmc/cores/RetroPlayer/rendering/test test/retroplayer_rendering
+xbmc/cores/RetroPlayer/savestates/test test/retroplayer_savestates
 xbmc/cores/RetroPlayer/streams/memory/test test/retroplayer_memory
 xbmc/cores/VideoPlayer/Buffers/test test/videoplayer_buffers
 xbmc/cores/VideoPlayer/test       test/videoplayer

--- a/xbmc/cores/RetroPlayer/messages/savestate.fbs
+++ b/xbmc/cores/RetroPlayer/messages/savestate.fbs
@@ -11,7 +11,7 @@ include "video.fbs";
 namespace KODI.RETRO.SAVESTATE;
 
 // Savestate schema
-// Version 5
+// Version 6
 
 file_identifier "SAV_";
 
@@ -23,6 +23,24 @@ enum SaveType : uint8 {
 
 enum CompressionType : uint8 {
   None,
+}
+
+enum DiscSlotType : uint8 {
+  Unknown,
+  Disc,
+  Removed
+}
+
+table DiscSlot {
+  type:DiscSlotType (id: 0);
+  file_name:string (id: 1);
+  label:string (id: 2);
+}
+
+table DiscState {
+  slots:[DiscSlot] (id: 0);
+  selected_slot:int32 = -1 (id: 1);
+  tray_ejected:bool (id: 2);
 }
 
 table Savestate {
@@ -74,6 +92,9 @@ table Savestate {
 
   // Achievement properties
   achievement_data:[uint8] (id: 30);
+
+  // Disc properties
+  disc_state:DiscState (id: 31);
 }
 
 root_type Savestate;

--- a/xbmc/cores/RetroPlayer/playback/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/playback/CMakeLists.txt
@@ -1,7 +1,9 @@
-set(SOURCES GameLoop.cpp
+set(SOURCES DiscStateHistory.cpp
+            GameLoop.cpp
             ReversiblePlayback.cpp)
 
-set(HEADERS GameLoop.h
+set(HEADERS DiscStateHistory.h
+            GameLoop.h
             IPlayback.h
             IPlaybackControl.h
             RealtimePlayback.h

--- a/xbmc/cores/RetroPlayer/playback/DiscStateHistory.cpp
+++ b/xbmc/cores/RetroPlayer/playback/DiscStateHistory.cpp
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "DiscStateHistory.h"
+
+#include "utils/log.h"
+
+#include <algorithm>
+
+using namespace KODI;
+using namespace RETRO;
+
+uint32_t CDiscStateHistory::Intern(const GAME::CGameClientDiscModel& model)
+{
+  const auto it = std::find(m_states.begin(), m_states.end(), model);
+  if (it != m_states.end())
+    return static_cast<uint32_t>(it - m_states.begin()) + 1;
+
+  m_states.emplace_back(model);
+  const uint32_t id = static_cast<uint32_t>(m_states.size());
+  const int selectedSlot = model.GetSelectedDiscIndex().has_value()
+                               ? static_cast<int>(*model.GetSelectedDiscIndex())
+                               : -1;
+  CLog::Log(LOGDEBUG,
+            "RetroPlayer[DISC]: Interned rewind disc state {}: slots={} selected={} ejected={}", id,
+            model.Size(), selectedSlot, model.IsEjected());
+  return id;
+}
+
+const GAME::CGameClientDiscModel* CDiscStateHistory::Get(uint32_t id) const
+{
+  if (id == 0 || id > m_states.size())
+    return nullptr;
+
+  return &m_states[id - 1];
+}
+
+void CDiscStateHistory::Clear()
+{
+  m_states.clear();
+}

--- a/xbmc/cores/RetroPlayer/playback/DiscStateHistory.h
+++ b/xbmc/cores/RetroPlayer/playback/DiscStateHistory.h
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include "games/addons/disc/GameClientDiscModel.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace KODI
+{
+namespace RETRO
+{
+class CDiscStateHistory
+{
+public:
+  uint32_t Intern(const GAME::CGameClientDiscModel& model);
+  const GAME::CGameClientDiscModel* Get(uint32_t id) const;
+  void Clear();
+
+private:
+  std::vector<GAME::CGameClientDiscModel> m_states;
+};
+} // namespace RETRO
+} // namespace KODI

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.cpp
@@ -21,6 +21,8 @@
 #include "games/GameServices.h"
 #include "games/GameSettings.h"
 #include "games/addons/GameClient.h"
+#include "games/addons/disc/GameClientDiscModel.h"
+#include "games/addons/disc/GameClientDiscs.h"
 #include "utils/MathUtils.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -33,6 +35,7 @@
 
 using namespace KODI;
 using namespace RETRO;
+using GAME::RestoreResult;
 
 #define REWIND_FACTOR 0.25 // Rewind at 25% of gameplay speed
 
@@ -63,6 +66,7 @@ CReversiblePlayback::~CReversiblePlayback()
 
 void CReversiblePlayback::Initialize()
 {
+  UpdateMemoryStream();
   m_gameLoop.Start();
 }
 
@@ -74,10 +78,19 @@ void CReversiblePlayback::Deinitialize()
   m_savestateThreads.clear();
 
   m_gameLoop.Stop();
+
+  std::unique_lock lock(m_mutex);
+  m_memoryStream.reset();
+  m_discStateHistory.Clear();
 }
 
 void CReversiblePlayback::SeekTimeMs(unsigned int timeMs)
 {
+  std::unique_lock lock(m_mutex);
+  if (m_restoreFailed)
+    return;
+
+  const double previousSpeed = m_gameLoop.GetSpeed();
   const int offsetTimeMs = timeMs - GetTimeMs();
   const int offsetFrames = MathUtils::round_int(offsetTimeMs / 1000.0 * m_gameLoop.FPS());
 
@@ -87,8 +100,8 @@ void CReversiblePlayback::SeekTimeMs(unsigned int timeMs)
     if (frames > 0)
     {
       m_gameLoop.SetSpeed(0.0);
-      AdvanceFrames(frames);
-      m_gameLoop.SetSpeed(1.0);
+      if (AdvanceFrames(frames) != RestoreResult::StateUncertain)
+        m_gameLoop.SetSpeed(previousSpeed);
     }
   }
   else if (offsetFrames < 0)
@@ -97,8 +110,8 @@ void CReversiblePlayback::SeekTimeMs(unsigned int timeMs)
     if (frames > 0)
     {
       m_gameLoop.SetSpeed(0.0);
-      RewindFrames(frames);
-      m_gameLoop.SetSpeed(1.0);
+      if (RewindFrames(frames) != RestoreResult::StateUncertain)
+        m_gameLoop.SetSpeed(previousSpeed);
     }
   }
 }
@@ -110,6 +123,13 @@ double CReversiblePlayback::GetSpeed() const
 
 void CReversiblePlayback::SetSpeed(double speedFactor)
 {
+  std::unique_lock lock(m_mutex);
+  if (speedFactor != 0.0)
+  {
+    if (m_restoreFailed)
+      return;
+  }
+
   if (speedFactor >= 0.0)
     m_gameLoop.SetSpeed(speedFactor);
   else
@@ -124,6 +144,12 @@ void CReversiblePlayback::PauseAsync()
 std::string CReversiblePlayback::CreateSavestate(bool autosave,
                                                  const std::string& savestatePath /* = "" */)
 {
+  {
+    std::unique_lock lock(m_mutex);
+    if (m_restoreFailed)
+      return "";
+  }
+
   const size_t memorySize = m_gameClient->SerializeSize();
 
   // Game client must support serialization
@@ -138,9 +164,6 @@ std::string CReversiblePlayback::CreateSavestate(bool autosave,
 
   // Take a timestamp of the system clock
   const CDateTime nowUTC = CDateTime::GetUTCDateTime();
-
-  // Record the frame count
-  const uint64_t timestampFrames = m_totalFrameCount;
 
   // Get the savestate path
   std::string savePath(savestatePath);
@@ -179,9 +202,8 @@ std::string CReversiblePlayback::CreateSavestate(bool autosave,
                              m_savestateThreads.end());
 
     // Save async to not block game loop
-    std::future<void> task =
-        std::async(std::launch::async, [this, autosave, savePath, nowUTC, timestampFrames]()
-                   { CommitSavestate(autosave, savePath, nowUTC, timestampFrames); });
+    std::future<void> task = std::async(std::launch::async, [this, autosave, savePath, nowUTC]()
+                                        { CommitSavestate(autosave, savePath, nowUTC); });
 
     m_savestateThreads.emplace_back(std::move(task));
   }
@@ -191,8 +213,7 @@ std::string CReversiblePlayback::CreateSavestate(bool autosave,
 
 void CReversiblePlayback::CommitSavestate(bool autosave,
                                           const std::string& savePath,
-                                          const CDateTime& nowUTC,
-                                          uint64_t timestampFrames)
+                                          const CDateTime& nowUTC)
 {
   std::unique_ptr<ISavestate> savestate = CSavestateDatabase::AllocateSavestate();
   std::unique_ptr<ISavestate> loadedSavestate;
@@ -203,30 +224,64 @@ void CReversiblePlayback::CommitSavestate(bool autosave,
   // Separate from the emulator's memory; see savestate.fbs
   std::vector<uint8_t> achievementState;
 
-  // Both payloads under one client lock, so the game loop cannot advance
-  // between them and pair one frame's memory with another frame's progress.
-  //
-  // m_mutex before the client lock, which is the order the game loop uses:
-  // AddFrame() holds m_mutex across CGameClient::Serialize(), and that takes
-  // the client lock. Taking them the other way round here deadlocks the two
-  // against each other whenever an autosave lands mid-frame, which also hangs
-  // shutdown because Deinitialize() waits on the save.
+  uint64_t timestampFrames;
+  // Lock order: playback, then client. The client lock also guards entire disc-model mutations.
   {
     std::unique_lock lock(m_mutex);
     std::unique_lock clientLock = m_gameClient->LockForSnapshot();
 
-    // Copy the savestate memory
-    if (m_memoryStream && m_memoryStream->CurrentFrame() != nullptr)
+    if (m_restoreFailed)
+      return;
+
+    std::optional<GAME::GameClientDiscState> discState;
+    if (m_rewindFrameRendered)
     {
+      // Rewind runs a preview frame; save the cursor's machine, media and time together.
+      if (!m_memoryStream || !m_memoryStream->CurrentFrame() ||
+          m_memoryStream->FrameSize() != memorySize)
+      {
+        CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Rewind frame is unavailable for capture");
+        return;
+      }
+      const uint32_t discStateId = m_memoryStream->GetDiscStateID();
+      const auto* discModel = m_discStateHistory.Get(discStateId);
+      if (discStateId != 0 && !discModel)
+      {
+        CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Missing rewind disc state {}", discStateId);
+        return;
+      }
+      if (discModel)
+      {
+        if (!(m_gameClient->Discs().GetDiscsForSnapshot() == *discModel))
+        {
+          CLog::Log(LOGERROR,
+                    "RetroPlayer[SAVE]: Rewind cursor media changed before capture; save rejected");
+          return;
+        }
+        discState = discModel->GetState();
+      }
       std::memcpy(memoryData, m_memoryStream->CurrentFrame(), memorySize);
+      timestampFrames = m_memoryStream->GetFrameCounter();
+      // Rewind history has no matching achievement snapshot; loading will reset that runtime.
     }
     else
     {
       if (!m_gameClient->Serialize(memoryData, memorySize))
         return;
+      if (m_gameClient->SupportsDiscControl())
+      {
+        m_gameClient->Discs().RefreshDiscStateLive();
+        discState = m_gameClient->Discs().GetDiscsForSnapshot().GetState();
+      }
+      m_gameClient->SerializeAchievementState(achievementState);
+      timestampFrames = m_totalFrameCount;
     }
-
-    m_gameClient->SerializeAchievementState(achievementState);
+    if (discState)
+    {
+      savestate->SetDiscState(*discState);
+      CLog::Log(LOGDEBUG, "RetroPlayer[SAVE]: Captured disc state: slots={} selected={} ejected={}",
+                discState->slots.size(), discState->selectedSlot, discState->trayEjected);
+    }
   }
 
   if (!achievementState.empty())
@@ -309,17 +364,31 @@ bool CReversiblePlayback::LoadSavestate(const std::string& savestatePath)
     }
     else
     {
+      std::unique_lock lock(m_mutex);
+      std::unique_lock clientLock = m_gameClient->LockForSnapshot();
+      std::optional<GAME::CGameClientDiscModel> discModel;
+      if (const auto discState = savestate->GetDiscState())
       {
-        std::unique_lock lock(m_mutex);
-        if (m_memoryStream)
+        discModel.emplace();
+        if (!m_gameClient->SupportsDiscControl() ||
+            !m_gameClient->Discs().GetDiscsForSnapshot().ResolveState(*discState, *discModel))
         {
-          m_memoryStream->SetFrameCounter(savestate->TimestampFrames());
-          std::memcpy(m_memoryStream->BeginFrame(), savestate->GetMemoryData(), memorySize);
-          m_memoryStream->SubmitFrame();
+          CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Failed to resolve saved disc state");
+          return false;
         }
+        if (!m_gameClient->Discs().IsMediaSupported(*discModel))
+        {
+          CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Saved media is unsupported by the active core");
+          return false;
+        }
+        CLog::Log(LOGDEBUG,
+                  "RetroPlayer[SAVE]: Restoring disc state: slots={} selected={} ejected={}",
+                  discState->slots.size(), discState->selectedSlot, discState->trayEjected);
       }
 
-      if (m_gameClient->Deserialize(savestate->GetMemoryData(), memorySize))
+      const RestoreResult result = m_gameClient->Deserialize(savestate->GetMemoryData(), memorySize,
+                                                             discModel ? &*discModel : nullptr);
+      if (result == RestoreResult::Restored)
       {
         // After the emulator, so the runtime matches its machine state, and
         // unconditionally: a savestate written before this existed, or while
@@ -342,10 +411,32 @@ bool CReversiblePlayback::LoadSavestate(const std::string& savestatePath)
           m_gameClient->DeserializeAchievements(nullptr, 0);
         }
 
+        if (m_memoryStream)
+        {
+          const uint64_t maxFrames = m_memoryStream->MaxFrameCount();
+          m_memoryStream->Init(memorySize, maxFrames);
+          m_discStateHistory.Clear();
+          std::memcpy(m_memoryStream->BeginFrame(), savestate->GetMemoryData(), memorySize);
+          const uint32_t discStateId =
+              m_gameClient->SupportsDiscControl()
+                  ? m_discStateHistory.Intern(m_gameClient->Discs().GetDiscsForSnapshot())
+                  : 0;
+          m_memoryStream->SubmitFrame(discStateId, savestate->TimestampFrames());
+          UpdatePlaybackStats();
+        }
         m_totalFrameCount = savestate->TimestampFrames();
+        m_restoreFailed = false;
+        m_rewindFrameRendered = false;
         bSuccess = true;
         if (savestate->Type() == SAVE_TYPE::AUTO)
+        {
+          std::unique_lock savestateLock(m_savestateMutex);
           m_autosavePath = savestatePath;
+        }
+      }
+      else if (result == RestoreResult::StateUncertain)
+      {
+        LatchRestoreFailure();
       }
     }
   }
@@ -355,17 +446,41 @@ bool CReversiblePlayback::LoadSavestate(const std::string& savestatePath)
 
 void CReversiblePlayback::FrameEvent()
 {
-  m_gameClient->RunFrame();
-  UpdateFrameRate();
+  std::unique_lock lock(m_mutex);
+  if (!m_restoreFailed && !m_rewindFrameRendered)
+  {
+    // Input scanning calls back into the client from another thread.
+    lock.unlock();
+    m_gameClient->PollInput();
+    lock.lock();
+  }
+  std::unique_lock clientLock = m_gameClient->LockForSnapshot();
+
+  if (m_restoreFailed)
+    return;
+
+  // The rewind preview has already run and updated the frame rate.
+  if (!m_rewindFrameRendered)
+  {
+    m_gameClient->RunFrame(false);
+    UpdateFrameRate();
+  }
 
   AddFrame();
 }
 
 void CReversiblePlayback::RewindEvent()
 {
-  RewindFrames(1);
+  m_gameClient->PollInput();
 
-  m_gameClient->RunFrame();
+  std::unique_lock lock(m_mutex);
+  std::unique_lock clientLock = m_gameClient->LockForSnapshot();
+
+  if (m_restoreFailed || RewindFrames(1) != RestoreResult::Restored)
+    return;
+
+  m_gameClient->RunFrame(false);
+  m_rewindFrameRendered = true;
   UpdateFrameRate();
 }
 
@@ -382,12 +497,19 @@ void CReversiblePlayback::AddFrame()
   {
     if (m_gameClient->Serialize(m_memoryStream->BeginFrame(), m_memoryStream->FrameSize()))
     {
-      m_memoryStream->SubmitFrame();
+      uint32_t discStateId = 0;
+      if (m_gameClient->SupportsDiscControl())
+      {
+        m_gameClient->Discs().RefreshDiscStateLive();
+        discStateId = m_discStateHistory.Intern(m_gameClient->Discs().GetDiscsForSnapshot());
+      }
+      m_memoryStream->SubmitFrame(discStateId, m_totalFrameCount + 1);
       UpdatePlaybackStats();
     }
   }
 
   m_totalFrameCount++;
+  m_rewindFrameRendered = false;
 }
 
 void CReversiblePlayback::UpdateFrameRate()
@@ -399,32 +521,106 @@ void CReversiblePlayback::UpdateFrameRate()
     UpdateMemoryStream();
 }
 
-void CReversiblePlayback::RewindFrames(uint64_t frames)
+RestoreResult CReversiblePlayback::RewindFrames(uint64_t frames)
 {
   std::unique_lock lock(m_mutex);
+  std::unique_lock clientLock = m_gameClient->LockForSnapshot();
 
+  RestoreResult result = RestoreResult::Rejected;
   if (m_memoryStream)
   {
-    m_memoryStream->RewindFrames(frames);
-    m_gameClient->Deserialize(m_memoryStream->CurrentFrame(), m_memoryStream->FrameSize());
+    const uint64_t rewound = m_memoryStream->RewindFrames(frames);
+    if (rewound > 0)
+    {
+      const RestoreResult targetResult = RestoreFrame();
+      if (targetResult == RestoreResult::Restored)
+      {
+        m_totalFrameCount = m_memoryStream->GetFrameCounter();
+        UpdatePlaybackStats();
+        return RestoreResult::Restored;
+      }
+      else
+      {
+        const uint64_t rolledBack = m_memoryStream->AdvanceFrames(rewound);
+        if (rolledBack != rewound || (targetResult == RestoreResult::StateUncertain &&
+                                      RestoreFrame() != RestoreResult::Restored))
+        {
+          result = RestoreResult::StateUncertain;
+          LatchRestoreFailure();
+        }
+      }
+    }
     UpdatePlaybackStats();
   }
 
-  m_totalFrameCount -= std::min(m_totalFrameCount, frames);
+  return result;
 }
 
-void CReversiblePlayback::AdvanceFrames(uint64_t frames)
+RestoreResult CReversiblePlayback::AdvanceFrames(uint64_t frames)
 {
   std::unique_lock lock(m_mutex);
+  std::unique_lock clientLock = m_gameClient->LockForSnapshot();
 
+  RestoreResult result = RestoreResult::Rejected;
   if (m_memoryStream)
   {
-    m_memoryStream->AdvanceFrames(frames);
-    m_gameClient->Deserialize(m_memoryStream->CurrentFrame(), m_memoryStream->FrameSize());
+    const uint64_t advanced = m_memoryStream->AdvanceFrames(frames);
+    if (advanced > 0)
+    {
+      const RestoreResult targetResult = RestoreFrame();
+      if (targetResult == RestoreResult::Restored)
+      {
+        m_totalFrameCount = m_memoryStream->GetFrameCounter();
+        UpdatePlaybackStats();
+        return RestoreResult::Restored;
+      }
+      else
+      {
+        const uint64_t rolledBack = m_memoryStream->RewindFrames(advanced);
+        if (rolledBack != advanced || (targetResult == RestoreResult::StateUncertain &&
+                                       RestoreFrame() != RestoreResult::Restored))
+        {
+          result = RestoreResult::StateUncertain;
+          LatchRestoreFailure();
+        }
+      }
+    }
     UpdatePlaybackStats();
   }
 
-  m_totalFrameCount += frames;
+  return result;
+}
+
+RestoreResult CReversiblePlayback::RestoreFrame()
+{
+  const uint32_t discStateId = m_memoryStream->GetDiscStateID();
+  const auto* discModel = m_discStateHistory.Get(discStateId);
+  if (discStateId != 0 && !discModel)
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[DISC]: Missing rewind disc state {}", discStateId);
+    return RestoreResult::Rejected;
+  }
+  if (discModel && !(m_gameClient->Discs().GetDiscsForSnapshot() == *discModel))
+  {
+    const auto selected = discModel->GetSelectedDiscIndex();
+    CLog::Log(LOGDEBUG,
+              "RetroPlayer[DISC]: Restoring rewind disc state {}: slots={} selected={} ejected={}",
+              discStateId, discModel->Size(), selected ? static_cast<int64_t>(*selected) : -1,
+              discModel->IsEjected());
+  }
+  const RestoreResult result = m_gameClient->Deserialize(m_memoryStream->CurrentFrame(),
+                                                         m_memoryStream->FrameSize(), discModel);
+  if (result == RestoreResult::Restored)
+    m_rewindFrameRendered = false;
+  return result;
+}
+
+void CReversiblePlayback::LatchRestoreFailure()
+{
+  if (!m_restoreFailed)
+    CLog::Log(LOGERROR, "RetroPlayer[SAVE]: Machine state restore failed, pausing playback");
+  m_restoreFailed = true;
+  m_gameLoop.PauseAsync();
 }
 
 void CReversiblePlayback::UpdatePlaybackStats()
@@ -498,6 +694,7 @@ void CReversiblePlayback::UpdateMemoryStream()
   else
   {
     m_memoryStream.reset();
+    m_discStateHistory.Clear();
 
     // Reset playback stats
     m_pastFrameCount = 0;

--- a/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.h
+++ b/xbmc/cores/RetroPlayer/playback/ReversiblePlayback.h
@@ -8,8 +8,10 @@
 
 #pragma once
 
+#include "DiscStateHistory.h"
 #include "GameLoop.h"
 #include "IPlayback.h"
+#include "games/addons/GameClientRestoreResult.h"
 #include "threads/CriticalSection.h"
 #include "utils/Observer.h"
 
@@ -32,7 +34,7 @@ namespace RETRO
 class CGUIGameMessenger;
 class CRPRenderManager;
 class CSavestateDatabase;
-class IMemoryStream;
+class CDeltaPairMemoryStream;
 
 class CReversiblePlayback : public IPlayback, public IGameLoopCallback, public Observer
 {
@@ -71,14 +73,13 @@ public:
 private:
   void AddFrame();
   void UpdateFrameRate();
-  void RewindFrames(uint64_t frames);
-  void AdvanceFrames(uint64_t frames);
+  GAME::RestoreResult RewindFrames(uint64_t frames);
+  GAME::RestoreResult AdvanceFrames(uint64_t frames);
+  GAME::RestoreResult RestoreFrame();
+  void LatchRestoreFailure();
   void UpdatePlaybackStats();
   void UpdateMemoryStream();
-  void CommitSavestate(bool autosave,
-                       const std::string& savePath,
-                       const CDateTime& nowUTC,
-                       uint64_t timestampFrames);
+  void CommitSavestate(bool autosave, const std::string& savePath, const CDateTime& nowUTC);
 
   // Construction parameter
   GAME::CGameClient* const m_gameClient;
@@ -87,8 +88,11 @@ private:
 
   // Gameplay functionality
   CGameLoop m_gameLoop;
-  std::unique_ptr<IMemoryStream> m_memoryStream;
+  std::unique_ptr<CDeltaPairMemoryStream> m_memoryStream;
+  CDiscStateHistory m_discStateHistory;
   CCriticalSection m_mutex;
+  bool m_restoreFailed{false};
+  bool m_rewindFrameRendered{false};
 
   // Savestate functionality
   std::unique_ptr<CSavestateDatabase> m_savestateDatabase;

--- a/xbmc/cores/RetroPlayer/playback/test/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/playback/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(SOURCES TestDiscStateHistory.cpp)
+
+core_add_test_library(retroplayer_playback_test)

--- a/xbmc/cores/RetroPlayer/playback/test/TestDiscStateHistory.cpp
+++ b/xbmc/cores/RetroPlayer/playback/test/TestDiscStateHistory.cpp
@@ -1,0 +1,226 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/RetroPlayer/playback/DiscStateHistory.h"
+#include "cores/RetroPlayer/streams/memory/DeltaPairMemoryStream.h"
+#include "games/addons/disc/GameClientDiscModel.h"
+
+#include <algorithm>
+#include <cstring>
+#include <optional>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace KODI;
+using namespace RETRO;
+
+namespace
+{
+GAME::CGameClientDiscModel MakeModel()
+{
+  GAME::CGameClientDiscModel model;
+  model.AddDisc("/games/disc1.chd", "Disc One");
+  model.AddRemovedSlot();
+  model.AddDisc("/games/disc2.chd", "Disc Two");
+  model.SetSelectedDiscByIndex(2);
+  model.SetEjected(true);
+  return model;
+}
+
+struct TimelineFrame
+{
+  std::vector<uint8_t> memory;
+  GAME::CGameClientDiscModel model;
+};
+
+void Submit(CDeltaPairMemoryStream& stream, CDiscStateHistory& history, const TimelineFrame& frame)
+{
+  ASSERT_EQ(frame.memory.size(), stream.FrameSize());
+  std::memcpy(stream.BeginFrame(), frame.memory.data(), frame.memory.size());
+  stream.SubmitFrame(history.Intern(frame.model));
+}
+
+void ExpectCurrent(const CDeltaPairMemoryStream& stream,
+                   const CDiscStateHistory& history,
+                   const TimelineFrame& expected)
+{
+  ASSERT_NE(stream.CurrentFrame(), nullptr);
+  EXPECT_TRUE(std::equal(expected.memory.begin(), expected.memory.end(), stream.CurrentFrame()));
+
+  const GAME::CGameClientDiscModel* restored = history.Get(stream.GetDiscStateID());
+  ASSERT_NE(restored, nullptr);
+  EXPECT_EQ(*restored, expected.model);
+  EXPECT_EQ(restored->GetDiscs(), expected.model.GetDiscs());
+  EXPECT_EQ(restored->GetSelectedDiscIndex(), expected.model.GetSelectedDiscIndex());
+  EXPECT_EQ(restored->IsSelectedNoDisc(), expected.model.IsSelectedNoDisc());
+  EXPECT_EQ(restored->IsEjected(), expected.model.IsEjected());
+}
+
+GAME::CGameClientDiscModel TwoDiscModel(size_t selected, bool ejected)
+{
+  GAME::CGameClientDiscModel model;
+  model.AddDisc("/mgs/Metal Gear Solid (USA) (Disc 1).chd", "MGS Disc One");
+  model.AddDisc("/mgs/Metal Gear Solid (USA) (Disc 2).chd", "MGS Disc Two");
+  model.SetSelectedDiscByIndex(selected);
+  model.SetEjected(ejected);
+  return model;
+}
+} // unnamed namespace
+
+TEST(TestDiscStateHistory, EqualStatesReuseImmutableSnapshot)
+{
+  CDiscStateHistory history;
+  const GAME::CGameClientDiscModel model = MakeModel();
+  const uint32_t firstId = history.Intern(model);
+
+  EXPECT_NE(firstId, 0U);
+  EXPECT_EQ(history.Intern(model), firstId);
+  ASSERT_NE(history.Get(firstId), nullptr);
+  EXPECT_EQ(*history.Get(firstId), model);
+}
+
+TEST(TestDiscStateHistory, DiscTopologySelectionAndTrayProduceDistinctStates)
+{
+  CDiscStateHistory history;
+  const GAME::CGameClientDiscModel original = MakeModel();
+  const uint32_t originalId = history.Intern(original);
+  GAME::CGameClientDiscModel selection = original;
+  selection.SetSelectedNoDisc();
+  GAME::CGameClientDiscModel tray = original;
+  tray.SetEjected(false);
+  GAME::CGameClientDiscModel playlist = original;
+  playlist.EraseDiscByIndex(1);
+
+  EXPECT_NE(history.Intern(selection), originalId);
+  EXPECT_NE(history.Intern(tray), originalId);
+  EXPECT_NE(history.Intern(playlist), originalId);
+}
+
+TEST(TestDiscStateHistory, SnapshotsRemainImmutableAndClearInvalidatesIds)
+{
+  CDiscStateHistory history;
+  GAME::CGameClientDiscModel model = MakeModel();
+  const uint32_t id = history.Intern(model);
+  model.Clear();
+
+  ASSERT_NE(history.Get(id), nullptr);
+  EXPECT_EQ(history.Get(id)->Size(), 3U);
+  EXPECT_EQ(history.Get(0), nullptr);
+  EXPECT_EQ(history.Get(999), nullptr);
+  history.Clear();
+  EXPECT_EQ(history.Get(id), nullptr);
+}
+
+TEST(TestDiscStateTimeline, RewindAndAdvanceRestoreMemoryAndFullDiscModels)
+{
+  CDiscStateHistory history;
+  CDeltaPairMemoryStream stream;
+  stream.Init(5, 10);
+
+  GAME::CGameClientDiscModel disc1 = TwoDiscModel(0, false);
+  GAME::CGameClientDiscModel disc2 = TwoDiscModel(1, false);
+  GAME::CGameClientDiscModel ejected = disc2;
+  ejected.SetEjected(true);
+  GAME::CGameClientDiscModel noDisc = ejected;
+  noDisc.SetSelectedNoDisc();
+  GAME::CGameClientDiscModel added = disc2;
+  added.AddDisc("/mgs/bonus.chd", "Bonus Disc");
+  added.SetSelectedDiscByIndex(2);
+  GAME::CGameClientDiscModel removed = added;
+  removed.MarkRemovedByIndex(1);
+  GAME::CGameClientDiscModel reordered;
+  reordered.SetDiscs({removed.GetDiscs()[2], removed.GetDiscs()[1], removed.GetDiscs()[0]});
+  reordered.SetSelectedDiscByIndex(2);
+  GAME::CGameClientDiscModel reused;
+  reused.SetDiscs(
+      {reordered.GetDiscs()[0],
+       {GAME::GameClientDiscEntry::DiscSlotType::Disc, "/mgs/vr.chd", "vr.chd", "VR Missions"},
+       reordered.GetDiscs()[2]});
+  reused.SetSelectedDiscByIndex(1);
+
+  const std::vector<TimelineFrame> frames{{{1, 1, 1, 1, 1}, disc1},     {{2, 2, 2, 2, 2}, disc2},
+                                          {{3, 3, 3, 3, 3}, ejected},   {{4, 4, 4, 4, 4}, noDisc},
+                                          {{5, 5, 5, 5, 5}, added},     {{6, 6, 6, 6, 6}, removed},
+                                          {{7, 7, 7, 7, 7}, reordered}, {{8, 8, 8, 8, 8}, reused}};
+
+  for (const TimelineFrame& frame : frames)
+    Submit(stream, history, frame);
+
+  for (size_t index = frames.size() - 1; index > 0; --index)
+  {
+    ASSERT_EQ(stream.RewindFrames(1), 1U);
+    ExpectCurrent(stream, history, frames[index - 1]);
+  }
+  for (size_t index = 1; index < frames.size(); ++index)
+  {
+    ASSERT_EQ(stream.AdvanceFrames(1), 1U);
+    ExpectCurrent(stream, history, frames[index]);
+  }
+}
+
+TEST(TestDiscStateTimeline, BranchingCannotRestoreAbandonedDiscState)
+{
+  CDiscStateHistory history;
+  CDeltaPairMemoryStream stream;
+  stream.Init(3, 5);
+  const TimelineFrame disc1{{1, 1, 1}, TwoDiscModel(0, false)};
+  const TimelineFrame disc2{{2, 2, 2}, TwoDiscModel(1, false)};
+  GAME::CGameClientDiscModel oldFutureModel = disc2.model;
+  oldFutureModel.AddDisc("/mgs/old-future.chd", "Old Future");
+  const TimelineFrame oldFuture{{3, 3, 3}, oldFutureModel};
+
+  Submit(stream, history, disc1);
+  Submit(stream, history, disc2);
+  Submit(stream, history, oldFuture);
+  ASSERT_EQ(stream.RewindFrames(2), 2U);
+  ExpectCurrent(stream, history, disc1);
+
+  GAME::CGameClientDiscModel branchModel = disc1.model;
+  branchModel.MarkRemovedByIndex(1);
+  branchModel.AddDisc("/mgs/new-branch.chd", "New Branch");
+  branchModel.SetSelectedDiscByIndex(2);
+  const TimelineFrame branch{{9, 9, 9}, branchModel};
+  Submit(stream, history, branch);
+
+  EXPECT_EQ(stream.FutureFramesAvailable(), 0U);
+  ExpectCurrent(stream, history, branch);
+  ASSERT_EQ(stream.RewindFrames(1), 1U);
+  ExpectCurrent(stream, history, disc1);
+  ASSERT_EQ(stream.AdvanceFrames(1), 1U);
+  ExpectCurrent(stream, history, branch);
+}
+
+TEST(TestDiscStateTimeline, CapacityEvictionAndResetKeepModelLookupSynchronized)
+{
+  CDiscStateHistory history;
+  CDeltaPairMemoryStream stream;
+  stream.Init(1, 3);
+  const TimelineFrame disc1{{1}, TwoDiscModel(0, false)};
+  const TimelineFrame ejected{{2}, TwoDiscModel(0, true)};
+  const TimelineFrame disc2{{3}, TwoDiscModel(1, false)};
+  GAME::CGameClientDiscModel noDiscModel = disc2.model;
+  noDiscModel.SetSelectedNoDisc();
+  const TimelineFrame noDisc{{4}, noDiscModel};
+
+  Submit(stream, history, disc1);
+  Submit(stream, history, ejected);
+  Submit(stream, history, disc2);
+  Submit(stream, history, noDisc);
+  EXPECT_EQ(stream.PastFramesAvailable(), 2U);
+  ASSERT_EQ(stream.RewindFrames(2), 2U);
+  ExpectCurrent(stream, history, ejected);
+  ASSERT_EQ(stream.AdvanceFrames(2), 2U);
+  ExpectCurrent(stream, history, noDisc);
+
+  stream.Reset();
+  EXPECT_EQ(stream.GetDiscStateID(), 0U);
+  EXPECT_EQ(history.Get(stream.GetDiscStateID()), nullptr);
+  EXPECT_EQ(stream.PastFramesAvailable(), 0U);
+  EXPECT_EQ(stream.FutureFramesAvailable(), 0U);
+}

--- a/xbmc/cores/RetroPlayer/savestates/ISavestate.h
+++ b/xbmc/cores/RetroPlayer/savestates/ISavestate.h
@@ -9,7 +9,9 @@
 #pragma once
 
 #include "SavestateTypes.h"
+#include "games/addons/disc/GameClientDiscState.h"
 
+#include <optional>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -245,12 +247,15 @@ public:
    */
   virtual size_t GetAchievementSize() const = 0;
 
+  virtual std::optional<GAME::GameClientDiscState> GetDiscState() const = 0;
+
   /*!
    * \brief A buffer to write the achievement runtime's state into
    *
    * Sized by the caller from what the runtime reports, so it is not capped.
    */
   virtual uint8_t* GetAchievementBuffer(size_t size) = 0;
+  virtual void SetDiscState(const std::optional<GAME::GameClientDiscState>& state) = 0;
   virtual void Finalize() = 0;
   ///}
 

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -219,6 +219,8 @@ std::unique_ptr<ISavestate> CSavestateDatabase::RenameSavestate(const std::strin
   if (!savestate->CopyMemoryDataTo(*newSavestate))
     return {};
 
+  newSavestate->SetDiscState(savestate->GetDiscState());
+
   // Carried separately from the emulator's memory, which is all the copy above
   // moves; without this a rename would drop the player's achievement progress
   if (const size_t achievementSize = savestate->GetAchievementSize(); achievementSize > 0)

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.cpp
@@ -14,6 +14,7 @@
 #include "utils/log.h"
 #include "video_generated.h"
 
+#include <cctype>
 #include <cmath>
 #include <limits>
 #include <memory>
@@ -208,6 +209,56 @@ unsigned int TranslateRotation(SAVESTATE::VideoRotation rotationCCW)
 
   return 0;
 }
+
+SAVESTATE::DiscSlotType TranslateDiscSlotType(GAME::DiscSlotType type)
+{
+  switch (type)
+  {
+    case GAME::DiscSlotType::Disc:
+      return SAVESTATE::DiscSlotType_Disc;
+    case GAME::DiscSlotType::Removed:
+      return SAVESTATE::DiscSlotType_Removed;
+    case GAME::DiscSlotType::Unknown:
+    default:
+      return SAVESTATE::DiscSlotType_Unknown;
+  }
+}
+
+GAME::DiscSlotType TranslateDiscSlotType(SAVESTATE::DiscSlotType type)
+{
+  switch (type)
+  {
+    case SAVESTATE::DiscSlotType_Disc:
+      return GAME::DiscSlotType::Disc;
+    case SAVESTATE::DiscSlotType_Removed:
+      return GAME::DiscSlotType::Removed;
+    case SAVESTATE::DiscSlotType_Unknown:
+    default:
+      return GAME::DiscSlotType::Unknown;
+  }
+}
+
+std::string PortableFileName(const std::string& value)
+{
+  const size_t lastSeparator = value.find_last_of("/\\");
+  if (lastSeparator == std::string::npos)
+    return value;
+
+  return value.substr(lastSeparator + 1);
+}
+
+bool IsPathLabel(const std::string& value)
+{
+  if (value.empty())
+    return false;
+
+  if (value.front() == '/' || value.front() == '\\' || value.find("://") != std::string::npos ||
+      value.find('\\') != std::string::npos)
+    return true;
+
+  return value.size() >= 3 && std::isalpha(static_cast<unsigned char>(value[0])) &&
+         value[1] == ':' && (value[2] == '/' || value[2] == '\\');
+}
 } // namespace
 
 CSavestateFlatBuffer::CSavestateFlatBuffer()
@@ -247,6 +298,7 @@ void CSavestateFlatBuffer::Reset()
   m_rotationCCW = 0;
   m_memoryData.Clear();
   m_memoryDataDecompressed.clear();
+  m_discState.reset();
 }
 
 bool CSavestateFlatBuffer::Serialize(const uint8_t*& data, size_t& size) const
@@ -739,6 +791,50 @@ size_t CSavestateFlatBuffer::GetAchievementSize() const
   return 0;
 }
 
+std::optional<GAME::GameClientDiscState> CSavestateFlatBuffer::GetDiscState() const
+{
+  if (m_discState.has_value())
+    return m_discState;
+
+  if (m_savestate == nullptr || m_savestate->disc_state() == nullptr)
+    return std::nullopt;
+
+  const SAVESTATE::DiscState& storedState = *m_savestate->disc_state();
+  GAME::GameClientDiscState state;
+  state.selectedSlot = storedState.selected_slot();
+  state.trayEjected = storedState.tray_ejected();
+
+  if (const auto* slots = storedState.slots())
+  {
+    state.slots.reserve(slots->size());
+    for (const SAVESTATE::DiscSlot* slot : *slots)
+    {
+      if (slot == nullptr)
+        continue;
+
+      state.slots.push_back({TranslateDiscSlotType(slot->type()),
+                             slot->file_name() ? slot->file_name()->str() : std::string{},
+                             slot->label() ? slot->label()->str() : std::string{}});
+    }
+  }
+
+  return state;
+}
+
+void CSavestateFlatBuffer::SetDiscState(const std::optional<GAME::GameClientDiscState>& discState)
+{
+  m_discState = discState;
+  if (!m_discState.has_value())
+    return;
+
+  for (GAME::DiscSlot& slot : m_discState->slots)
+  {
+    slot.fileName = PortableFileName(slot.fileName);
+    if (IsPathLabel(slot.label))
+      slot.label = PortableFileName(slot.label);
+  }
+}
+
 uint8_t* CSavestateFlatBuffer::GetAchievementBuffer(size_t size)
 {
   m_achievementData.assign(size, 0);
@@ -760,6 +856,24 @@ void CSavestateFlatBuffer::Finalize()
   if (!m_achievementData.empty())
     achievementBlob = m_builder->CreateVector(m_achievementData);
 
+  flatbuffers::Offset<SAVESTATE::DiscState> discStateOffset = 0;
+  if (m_discState.has_value())
+  {
+    std::vector<flatbuffers::Offset<SAVESTATE::DiscSlot>> slotOffsets;
+    slotOffsets.reserve(m_discState->slots.size());
+    for (const GAME::DiscSlot& slot : m_discState->slots)
+    {
+      const auto fileName = m_builder->CreateString(slot.fileName);
+      const auto label = m_builder->CreateString(slot.label);
+      slotOffsets.emplace_back(
+          SAVESTATE::CreateDiscSlot(*m_builder, TranslateDiscSlotType(slot.type), fileName, label));
+    }
+
+    const auto slots = m_builder->CreateVector(slotOffsets);
+    discStateOffset = SAVESTATE::CreateDiscState(*m_builder, slots, m_discState->selectedSlot,
+                                                 m_discState->trayEjected);
+  }
+
   // Helper class to build the nested Savestate table
   SAVESTATE::SavestateBuilder savestateBuilder(*m_builder);
 
@@ -767,6 +881,9 @@ void CSavestateFlatBuffer::Finalize()
 
   if (!achievementBlob.IsNull())
     savestateBuilder.add_achievement_data(achievementBlob);
+
+  if (!discStateOffset.IsNull())
+    savestateBuilder.add_disc_state(discStateOffset);
 
   savestateBuilder.add_type(TranslateType(m_type));
 

--- a/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateFlatBuffer.h
@@ -85,7 +85,9 @@ public:
   uint8_t* GetMemoryBuffer(size_t size) override;
   const uint8_t* GetAchievementData() const override;
   size_t GetAchievementSize() const override;
+  std::optional<GAME::GameClientDiscState> GetDiscState() const override;
   uint8_t* GetAchievementBuffer(size_t size) override;
+  void SetDiscState(const std::optional<GAME::GameClientDiscState>& state) override;
   void Finalize() override;
   bool Deserialize(std::vector<uint8_t> data) override;
 
@@ -140,6 +142,7 @@ private:
   //! Small and written rarely, so it is stored as-is rather than through the
   //! compressing blob path the video and memory payloads use
   std::vector<uint8_t> m_achievementData;
+  std::optional<GAME::GameClientDiscState> m_discState;
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/savestates/test/CMakeLists.txt
+++ b/xbmc/cores/RetroPlayer/savestates/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(SOURCES TestSavestateDiscState.cpp)
+
+core_add_test_library(retroplayer_savestates_test)
+
+if(ENABLE_STATIC_LIBS)
+  add_dependencies(retroplayer_savestates_test retroplayer_messages)
+  target_link_libraries(retroplayer_savestates_test PRIVATE ${APP_NAME_LC}::FlatBuffers)
+endif()

--- a/xbmc/cores/RetroPlayer/savestates/test/TestSavestateDiscState.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/test/TestSavestateDiscState.cpp
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "cores/RetroPlayer/savestates/SavestateDatabase.h"
+#include "cores/RetroPlayer/savestates/SavestateFlatBuffer.h"
+#include "filesystem/File.h"
+#include "games/addons/disc/GameClientDiscState.h"
+#include "savestate_generated.h"
+#include "test/TestUtils.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <flatbuffers/flatbuffers.h>
+#include <gtest/gtest.h>
+
+using namespace KODI;
+using namespace GAME;
+using namespace RETRO;
+
+namespace
+{
+std::vector<uint8_t> Serialize(CSavestateFlatBuffer& savestate)
+{
+  savestate.Finalize();
+
+  const uint8_t* data = nullptr;
+  size_t size = 0;
+  EXPECT_TRUE(savestate.Serialize(data, size));
+  return {data, data + size};
+}
+
+GameClientDiscState MakeDiscState()
+{
+  GameClientDiscState state;
+  state.slots = {
+      {DiscSlotType::Disc, "/games/Multi Disc/Disc 1.chd", "Disc One"},
+      {DiscSlotType::Removed, {}, "Removed Disc"},
+      {DiscSlotType::Unknown, {}, "smb://server/share/Unknown Slot.chd"},
+      {DiscSlotType::Disc, "C:\\games\\Multi Disc\\Disc 2.chd", "Disc Two"},
+  };
+  state.selectedSlot = 3;
+  state.trayEjected = true;
+  return state;
+}
+} // namespace
+
+TEST(TestSavestateDiscState, RoundTripsTopologySelectionAndTrayState)
+{
+  CSavestateFlatBuffer writer;
+  writer.SetDiscState(MakeDiscState());
+
+  CSavestateFlatBuffer reader;
+  const auto bytes = Serialize(writer);
+  EXPECT_EQ(SAVESTATE::GetSavestate(bytes.data())->version(), 6);
+  ASSERT_TRUE(reader.Deserialize(bytes));
+
+  const std::optional<GameClientDiscState> state = reader.GetDiscState();
+  ASSERT_TRUE(state.has_value());
+  ASSERT_EQ(state->slots.size(), 4U);
+  EXPECT_EQ(state->slots[0], (DiscSlot{DiscSlotType::Disc, "Disc 1.chd", "Disc One"}));
+  EXPECT_EQ(state->slots[1], (DiscSlot{DiscSlotType::Removed, {}, "Removed Disc"}));
+  EXPECT_EQ(state->slots[2], (DiscSlot{DiscSlotType::Unknown, {}, "Unknown Slot.chd"}));
+  EXPECT_EQ(state->slots[3], (DiscSlot{DiscSlotType::Disc, "Disc 2.chd", "Disc Two"}));
+  EXPECT_EQ(state->selectedSlot, 3);
+  EXPECT_TRUE(state->trayEjected);
+}
+
+TEST(TestSavestateDiscState, RoundTripsNoDiscWithClosedTray)
+{
+  GameClientDiscState expected = MakeDiscState();
+  expected.selectedSlot = -1;
+  expected.trayEjected = false;
+
+  CSavestateFlatBuffer writer;
+  writer.SetDiscState(expected);
+
+  CSavestateFlatBuffer reader;
+  ASSERT_TRUE(reader.Deserialize(Serialize(writer)));
+  ASSERT_TRUE(reader.GetDiscState().has_value());
+  const GameClientDiscState expectedStored{{{DiscSlotType::Disc, "Disc 1.chd", "Disc One"},
+                                            {DiscSlotType::Removed, {}, "Removed Disc"},
+                                            {DiscSlotType::Unknown, {}, "Unknown Slot.chd"},
+                                            {DiscSlotType::Disc, "Disc 2.chd", "Disc Two"}},
+                                           -1,
+                                           false};
+  EXPECT_EQ(*reader.GetDiscState(), expectedStored);
+}
+
+TEST(TestSavestateDiscState, OldSavestateHasNoDiscState)
+{
+  for (uint8_t version = 1; version <= 5; ++version)
+  {
+    flatbuffers::FlatBufferBuilder builder;
+    SAVESTATE::SavestateBuilder savestateBuilder(builder);
+    savestateBuilder.add_version(version);
+    const auto root = savestateBuilder.Finish();
+    SAVESTATE::FinishSavestateBuffer(builder, root);
+
+    CSavestateFlatBuffer reader;
+    ASSERT_TRUE(reader.Deserialize(std::vector<uint8_t>(
+        builder.GetBufferPointer(), builder.GetBufferPointer() + builder.GetSize())));
+    EXPECT_EQ(reader.GetDiscState(), std::nullopt);
+  }
+}
+
+TEST(TestSavestateDiscState, SerializedDiscStateContainsNoDirectoryPaths)
+{
+  CSavestateFlatBuffer writer;
+  writer.SetDiscState(MakeDiscState());
+  const std::vector<uint8_t> bytes = Serialize(writer);
+  const std::string serialized(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+
+  EXPECT_EQ(serialized.find("/games/Multi Disc/"), std::string::npos);
+  EXPECT_EQ(serialized.find("C:\\games\\Multi Disc\\"), std::string::npos);
+  EXPECT_EQ(serialized.find("smb://server/share/"), std::string::npos);
+  EXPECT_NE(serialized.find("Disc 1.chd"), std::string::npos);
+  EXPECT_NE(serialized.find("Disc 2.chd"), std::string::npos);
+}
+
+TEST(TestSavestateDiscState, PortableStoragePreservesDisplayLabelsContainingSlashes)
+{
+  GameClientDiscState expected;
+  expected.slots = {{DiscSlotType::Disc, "/games/disc.chd", "Disc 1/2"}};
+
+  CSavestateFlatBuffer writer;
+  writer.SetDiscState(expected);
+
+  CSavestateFlatBuffer reader;
+  ASSERT_TRUE(reader.Deserialize(Serialize(writer)));
+  ASSERT_TRUE(reader.GetDiscState().has_value());
+  EXPECT_EQ(reader.GetDiscState()->slots[0].label, "Disc 1/2");
+}
+
+TEST(TestSavestateDiscState, RenamePreservesDiscState)
+{
+  std::unique_ptr<XFILE::CFile> tempFile(XBMC_CREATETEMPFILE(".sav"));
+  ASSERT_NE(tempFile, nullptr);
+  const std::string path = XBMC_TEMPFILEPATH(tempFile.get());
+  tempFile->Close();
+
+  CSavestateFlatBuffer writer;
+  writer.SetLabel("Before");
+  writer.SetDiscState(MakeDiscState());
+  ASSERT_NE(writer.GetMemoryBuffer(1), nullptr);
+  writer.Finalize();
+
+  CSavestateDatabase database;
+  ASSERT_TRUE(database.AddSavestate(path, {}, writer));
+  const std::unique_ptr<ISavestate> renamed = database.RenameSavestate(path, "After");
+  ASSERT_NE(renamed, nullptr);
+  EXPECT_EQ(renamed->Label(), "After");
+  ASSERT_TRUE(renamed->GetDiscState().has_value());
+
+  GameClientDiscState expected = MakeDiscState();
+  expected.slots[0].fileName = "Disc 1.chd";
+  expected.slots[2].label = "Unknown Slot.chd";
+  expected.slots[3].fileName = "Disc 2.chd";
+  EXPECT_EQ(*renamed->GetDiscState(), expected);
+
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(tempFile.release()));
+}

--- a/xbmc/cores/RetroPlayer/streams/memory/DeltaPairMemoryStream.cpp
+++ b/xbmc/cores/RetroPlayer/streams/memory/DeltaPairMemoryStream.cpp
@@ -8,7 +8,8 @@
 
 #include "DeltaPairMemoryStream.h"
 
-#include "utils/log.h"
+#include <algorithm>
+#include <utility>
 
 using namespace KODI;
 using namespace RETRO;
@@ -18,14 +19,75 @@ void CDeltaPairMemoryStream::Reset()
   CLinearMemoryStream::Reset();
 
   m_rewindBuffer.clear();
+  m_advanceBuffer.clear();
+  m_currentDiscStateId = 0;
+  m_nextDiscStateId = 0;
+  m_nextFrameHistory = 0;
+}
+
+void CDeltaPairMemoryStream::SetMaxFrameCount(uint64_t maxFrameCount)
+{
+  if (maxFrameCount == 0)
+  {
+    Reset();
+    return;
+  }
+
+  uint64_t framesToRemove =
+      PastFramesAvailable() + FutureFramesAvailable() + (m_bHasCurrentFrame ? 1 : 0) -
+      std::min(maxFrameCount,
+               PastFramesAvailable() + FutureFramesAvailable() + (m_bHasCurrentFrame ? 1 : 0));
+
+  const uint64_t pastToRemove = std::min(framesToRemove, PastFramesAvailable());
+  CullPastFrames(pastToRemove);
+  framesToRemove -= pastToRemove;
+
+  while (framesToRemove > 0 && !m_advanceBuffer.empty())
+  {
+    m_advanceBuffer.pop_back();
+    --framesToRemove;
+  }
+
+  m_maxFrames = maxFrameCount;
+}
+
+void CDeltaPairMemoryStream::SubmitFrame()
+{
+  SubmitFrame(0);
+}
+
+void CDeltaPairMemoryStream::SubmitFrame(uint32_t discStateId)
+{
+  SubmitFrame(discStateId, m_bHasCurrentFrame ? m_currentFrameHistory + 1 : m_currentFrameHistory);
+}
+
+void CDeltaPairMemoryStream::SubmitFrame(uint32_t discStateId, uint64_t frameCounter)
+{
+  if (!m_bHasCurrentFrame)
+  {
+    m_bHasCurrentFrame = true;
+    m_currentDiscStateId = discStateId;
+    m_currentFrameHistory = frameCounter;
+    return;
+  }
+
+  if (!m_bHasNextFrame)
+    m_bHasNextFrame = true;
+
+  m_nextDiscStateId = discStateId;
+  m_nextFrameHistory = frameCounter;
+  SubmitFrameInternal();
 }
 
 void CDeltaPairMemoryStream::SubmitFrameInternal()
 {
+  m_advanceBuffer.clear();
   MemoryFrame& frame = m_rewindBuffer.emplace_back();
 
-  // Record frame history
-  frame.frameHistoryCount = m_currentFrameHistory++;
+  frame.beforeFrameHistoryCount = m_currentFrameHistory;
+  frame.afterFrameHistoryCount = m_nextFrameHistory;
+  frame.beforeDiscStateId = m_currentDiscStateId;
+  frame.afterDiscStateId = m_nextDiscStateId;
 
   uint32_t* currentFrame = m_currentFrame.get();
   uint32_t* nextFrame = m_nextFrame.get();
@@ -42,6 +104,8 @@ void CDeltaPairMemoryStream::SubmitFrameInternal()
 
   // Delta is generated, bring the new frame forward (m_nextFrame is now disposable)
   std::swap(m_currentFrame, m_nextFrame);
+  m_currentFrameHistory = m_nextFrameHistory;
+  m_currentDiscStateId = m_nextDiscStateId;
 
   m_bHasNextFrame = false;
 
@@ -54,6 +118,31 @@ uint64_t CDeltaPairMemoryStream::PastFramesAvailable() const
   return static_cast<uint64_t>(m_rewindBuffer.size());
 }
 
+uint64_t CDeltaPairMemoryStream::FutureFramesAvailable() const
+{
+  return static_cast<uint64_t>(m_advanceBuffer.size());
+}
+
+uint64_t CDeltaPairMemoryStream::AdvanceFrames(uint64_t frameCount)
+{
+  uint64_t advanced = 0;
+
+  for (; advanced < frameCount && !m_advanceBuffer.empty(); ++advanced)
+  {
+    MemoryFrame frame = std::move(m_advanceBuffer.front());
+    m_advanceBuffer.pop_front();
+
+    for (const DeltaPair& pair : frame.buffer)
+      m_currentFrame[pair.pos] ^= pair.delta;
+
+    m_currentFrameHistory = frame.afterFrameHistoryCount;
+    m_currentDiscStateId = frame.afterDiscStateId;
+    m_rewindBuffer.emplace_back(std::move(frame));
+  }
+
+  return advanced;
+}
+
 uint64_t CDeltaPairMemoryStream::RewindFrames(uint64_t frameCount)
 {
   uint64_t rewound;
@@ -63,7 +152,8 @@ uint64_t CDeltaPairMemoryStream::RewindFrames(uint64_t frameCount)
     if (m_rewindBuffer.empty())
       break;
 
-    const MemoryFrame& frame = m_rewindBuffer.back();
+    MemoryFrame frame = std::move(m_rewindBuffer.back());
+    m_rewindBuffer.pop_back();
     const DeltaPair* buffer = frame.buffer.data();
 
     size_t bufferSize = frame.buffer.size();
@@ -74,9 +164,10 @@ uint64_t CDeltaPairMemoryStream::RewindFrames(uint64_t frameCount)
       m_currentFrame[buffer[i].pos] ^= buffer[i].delta;
 
     // Restore frame history
-    m_currentFrameHistory = frame.frameHistoryCount;
+    m_currentFrameHistory = frame.beforeFrameHistoryCount;
+    m_currentDiscStateId = frame.beforeDiscStateId;
 
-    m_rewindBuffer.pop_back();
+    m_advanceBuffer.emplace_front(std::move(frame));
   }
 
   return rewound;
@@ -87,12 +178,7 @@ void CDeltaPairMemoryStream::CullPastFrames(uint64_t frameCount)
   for (uint64_t removedCount = 0; removedCount < frameCount; removedCount++)
   {
     if (m_rewindBuffer.empty())
-    {
-      CLog::Log(LOGDEBUG,
-                "CDeltaPairMemoryStream: Tried to cull {} frames too many. Check your math!",
-                frameCount - removedCount);
       break;
-    }
     m_rewindBuffer.pop_front();
   }
 }

--- a/xbmc/cores/RetroPlayer/streams/memory/DeltaPairMemoryStream.h
+++ b/xbmc/cores/RetroPlayer/streams/memory/DeltaPairMemoryStream.h
@@ -29,8 +29,16 @@ public:
 
   // implementation of IMemoryStream via CLinearMemoryStream
   void Reset() override;
+  void SetMaxFrameCount(uint64_t maxFrameCount) override;
+  void SubmitFrame() override;
+  void SubmitFrame(uint32_t discStateId);
+  void SubmitFrame(uint32_t discStateId, uint64_t frameCounter);
+  uint64_t FutureFramesAvailable() const override;
+  uint64_t AdvanceFrames(uint64_t frameCount) override;
   uint64_t PastFramesAvailable() const override;
   uint64_t RewindFrames(uint64_t frameCount) override;
+
+  uint32_t GetDiscStateID() const { return m_currentDiscStateId; }
 
 protected:
   // implementation of CLinearMemoryStream
@@ -58,10 +66,17 @@ protected:
   struct MemoryFrame
   {
     DeltaPairVector buffer;
-    uint64_t frameHistoryCount;
+    uint64_t beforeFrameHistoryCount;
+    uint64_t afterFrameHistoryCount;
+    uint32_t beforeDiscStateId;
+    uint32_t afterDiscStateId;
   };
 
   std::deque<MemoryFrame> m_rewindBuffer;
+  std::deque<MemoryFrame> m_advanceBuffer;
+  uint32_t m_currentDiscStateId{0};
+  uint32_t m_nextDiscStateId{0};
+  uint64_t m_nextFrameHistory{0};
 };
 } // namespace RETRO
 } // namespace KODI

--- a/xbmc/cores/RetroPlayer/streams/memory/test/TestDeltaPairMemoryStream.cpp
+++ b/xbmc/cores/RetroPlayer/streams/memory/test/TestDeltaPairMemoryStream.cpp
@@ -34,7 +34,9 @@ protected:
   void ExpectZeroPadding(const uint8_t* frame) const
   {
     for (size_t i = m_stream.FrameSize(); i < m_stream.WordCount() * sizeof(uint32_t); ++i)
+    {
       EXPECT_EQ(0, frame[i]) << "Byte " << i;
+    }
   }
 
   TestMemoryStream m_stream;

--- a/xbmc/games/addons/CMakeLists.txt
+++ b/xbmc/games/addons/CMakeLists.txt
@@ -8,6 +8,7 @@ set(HEADERS GameClient.h
             GameClientCallbacks.h
             GameClientInGameSaves.h
             GameClientProperties.h
+            GameClientRestoreResult.h
             GameClientSubsystem.h
             GameClientTranslator.h)
 

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -23,6 +23,7 @@
 #include "filesystem/SpecialProtocol.h"
 #include "games/GameServices.h"
 #include "games/addons/cheevos/GameClientCheevos.h"
+#include "games/addons/disc/GameClientDiscModel.h"
 #include "games/addons/disc/GameClientDiscs.h"
 #include "games/addons/input/GameClientInput.h"
 #include "games/addons/streams/GameClientStreams.h"
@@ -277,13 +278,28 @@ bool CGameClient::OpenFile(const CFileItem& file,
   // Before the game loads: the client signs in as part of identifying it
   Cheevos().SendCredentials();
 
-  try
+  const auto loadGame = [this, &path]()
   {
-    LogError(error = m_ifc.game->toAddon->LoadGame(m_ifc.game, path.c_str()), "LoadGame()");
-  }
-  catch (...)
+    GAME_ERROR loadError = GAME_ERROR_FAILED;
+    try
+    {
+      LogError(loadError = m_ifc.game->toAddon->LoadGame(m_ifc.game, path.c_str()), "LoadGame()");
+    }
+    catch (...)
+    {
+      LogException("LoadGame()");
+    }
+    return loadError;
+  };
+
+  error = loadGame();
+
+  if (error != GAME_ERROR_NO_ERROR && SupportsDiscControl() && Discs().HasPersistedState())
   {
-    LogException("LoadGame()");
+    CLog::Log(LOGWARNING,
+              "GameClient: Load with persisted disc hint failed; retrying original source media");
+    Discs().Initialize(path, false);
+    error = loadGame();
   }
 
   if (error != GAME_ERROR_NO_ERROR)
@@ -354,28 +370,66 @@ bool CGameClient::InitializeGameplay(const std::string& gamePath,
                                      RETRO::IStreamManager& streamManager,
                                      IGameInputCallback* input)
 {
-  if (LoadGameInfo())
+  const auto unloadGame = [this]()
   {
-    if (SupportsDiscControl())
+    try
     {
-      Discs().RestoreDiscList();
-      Discs().RefreshDiscState();
+      return LogError(m_ifc.game->toAddon->UnloadGame(m_ifc.game), "UnloadGame()");
     }
+    catch (...)
+    {
+      LogException("UnloadGame()");
+      return false;
+    }
+  };
 
-    Input().Start(input);
+  bool gameInfoLoaded = LoadGameInfo();
+  if (SupportsDiscControl() && Discs().HasPersistedState() &&
+      (!gameInfoLoaded || !Discs().RestoreDiscList()))
+  {
+    CLog::Log(
+        LOGWARNING,
+        "GameClient: Startup with persisted disc state failed; reloading original source media");
+    if (!unloadGame() || gamePath.empty())
+      return false;
 
-    m_bIsPlaying = true;
-    m_hasFrameRun = false;
-    m_gamePath = gamePath;
-    m_input = input;
-
-    m_inGameSaves = std::make_unique<CGameClientInGameSaves>(this, m_ifc.game);
-    m_inGameSaves->Load();
-
-    return true;
+    Discs().Initialize(gamePath, false);
+    GAME_ERROR error = GAME_ERROR_FAILED;
+    try
+    {
+      LogError(error = m_ifc.game->toAddon->LoadGame(m_ifc.game, gamePath.c_str()), "LoadGame()");
+    }
+    catch (...)
+    {
+      LogException("LoadGame()");
+    }
+    if (error != GAME_ERROR_NO_ERROR)
+      return false;
+    gameInfoLoaded = LoadGameInfo();
   }
 
-  return false;
+  if (!gameInfoLoaded)
+  {
+    unloadGame();
+    return false;
+  }
+  if (SupportsDiscControl())
+    Discs().RefreshDiscStateLive();
+
+  Input().Start(input);
+
+  m_bIsPlaying = true;
+  m_hasFrameRun = false;
+  m_gamePath = gamePath;
+  m_input = input;
+
+  if (SupportsDiscControl())
+    Discs().SaveDiscState();
+
+  m_inGameSaves = std::make_unique<CGameClientInGameSaves>(this, m_ifc.game);
+  m_inGameSaves->Load();
+
+  return true;
 }
 
 bool CGameClient::LoadGameInfo()
@@ -564,7 +618,7 @@ void CGameClient::CloseFile()
   }
 }
 
-void CGameClient::RunFrame()
+void CGameClient::PollInput()
 {
   IGameInputCallback* input;
 
@@ -573,8 +627,15 @@ void CGameClient::RunFrame()
     input = m_input;
   }
 
+  // The event scanner calls back into the client on another thread while this waits.
   if (input)
     input->PollInput();
+}
+
+void CGameClient::RunFrame(bool pollInput)
+{
+  if (pollInput)
+    PollInput();
 
   std::unique_lock lock(m_critSection);
 
@@ -626,53 +687,94 @@ bool CGameClient::Serialize(uint8_t* data, size_t size)
   return bSuccess;
 }
 
-bool CGameClient::Deserialize(const uint8_t* data, size_t size)
+RestoreResult CGameClient::Deserialize(const uint8_t* data,
+                                       size_t size,
+                                       const CGameClientDiscModel* discState)
 {
   if (data == nullptr || size == 0)
-    return false;
+    return RestoreResult::Rejected;
 
-  bool bSuccess = false;
-  if (m_bIsPlaying)
+  std::unique_lock lock(m_critSection);
+  if (!m_bIsPlaying || (discState && !SupportsDiscControl()))
+    return RestoreResult::Rejected;
+
+  std::optional<CGameClientDiscModel> previousDiscs;
+  const auto restorePreviousDiscs = [&]()
   {
-    // Deserialization may result in stale disc state, so insert disc now
-    if (SupportsDiscControl())
-      Discs().SetEjected(false);
+    if (previousDiscs)
+      Discs().SetDiscModel(*previousDiscs);
+    if (!Discs().RestoreDiscList())
+    {
+      CLog::Log(LOGERROR,
+                "RetroPlayer[DISC]: Failed to roll back disc state after restore failure");
+      return false;
+    }
+    return true;
+  };
 
-    std::unique_lock lock(m_critSection);
+  if (discState)
+  {
+    if (!(Discs().GetDiscsForSnapshot() == *discState))
+      previousDiscs = Discs().GetDiscsForSnapshot();
+    Discs().SetDiscModel(*discState);
+
+    // Cores can validate saved media against their current image list.
+    if (!Discs().RestoreDiscList() || (!discState->IsEjected() && !Discs().PrepareForDeserialize()))
+    {
+      CLog::Log(LOGERROR, "RetroPlayer[DISC]: Failed to prepare media before deserializing");
+      return restorePreviousDiscs() ? RestoreResult::Rejected : RestoreResult::StateUncertain;
+    }
+  }
+  else if (SupportsDiscControl())
+  {
+    Discs().SetEjected(false);
+  }
+
+  const auto deserialize = [&]()
+  {
+    // The core may rebuild its image list while loading machine state.
+    if (SupportsDiscControl())
+      Discs().InvalidateRestoreCache();
 
     try
     {
-      bSuccess =
-          LogError(m_ifc.game->toAddon->Deserialize(m_ifc.game, data, size), "Deserialize()");
+      return LogError(m_ifc.game->toAddon->Deserialize(m_ifc.game, data, size), "Deserialize()");
     }
     catch (...)
     {
       LogException("Deserialize()");
+      return false;
     }
-  }
+  };
 
-  // Some cores, like Mupen64Plus-NX, initialize on the first frame, so run
-  // a frame and try again
+  bool bSuccess = deserialize();
+  // Some disc cores only accept machine states with the tray closed. Preserve the target model.
+  if (!bSuccess && discState && Discs().PrepareForDeserialize())
+    bSuccess = deserialize();
+
+  // Some cores initialize on their first frame.
   if (!bSuccess && !m_hasFrameRun)
   {
-    RunFrame();
-
-    std::unique_lock lock(m_critSection);
-
-    bSuccess = LogError(m_ifc.game->toAddon->Deserialize(m_ifc.game, data, size), "Deserialize()");
+    RunFrame(false);
+    bSuccess = deserialize();
   }
 
-  if (bSuccess)
+  if (bSuccess && SupportsDiscControl())
   {
-    // Deserialization may reset disc information, so restore it now
-    if (SupportsDiscControl())
+    bSuccess = Discs().RestoreDiscList();
+    if (discState)
     {
-      Discs().RestoreDiscList();
-      Discs().RefreshDiscState();
+      if (bSuccess && previousDiscs)
+        Discs().SaveDiscState();
     }
+    else if (bSuccess)
+      Discs().RefreshDiscState();
   }
 
-  return bSuccess;
+  if (!bSuccess && discState)
+    restorePreviousDiscs();
+  // Media rollback cannot undo machine memory changed by a failed deserialize.
+  return bSuccess ? RestoreResult::Restored : RestoreResult::StateUncertain;
 }
 
 bool CGameClient::SerializeAchievementState(std::vector<uint8_t>& data)

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "GameClientRestoreResult.h"
 #include "GameClientSubsystem.h"
 #include "addons/binary-addons/AddonDll.h"
 #include "addons/kodi-dev-kit/include/kodi/addon-instance/Game.h"
@@ -33,6 +34,7 @@ class IStreamManager;
 
 namespace GAME
 {
+class CGameClientDiscModel;
 
 class CGameClientCheevos;
 class CGameClientInGameSaves;
@@ -170,7 +172,8 @@ public:
   size_t GetSerializeSize() const { return m_serializeSize; }
   double GetFrameRate() const { return m_framerate.load(); }
   double GetSampleRate() const { return m_samplerate.load(); }
-  void RunFrame();
+  void PollInput();
+  void RunFrame(bool pollInput = true);
 
   /*!
    * \brief Tell the client what speed the player is running at
@@ -188,7 +191,9 @@ public:
   // Access memory
   size_t SerializeSize() const { return m_serializeSize; }
   bool Serialize(uint8_t* data, size_t size);
-  bool Deserialize(const uint8_t* data, size_t size);
+  RestoreResult Deserialize(const uint8_t* data,
+                            size_t size,
+                            const CGameClientDiscModel* discState = nullptr);
 
   /*!
    * \brief Hold the client still for the duration of a savestate snapshot

--- a/xbmc/games/addons/GameClientRestoreResult.h
+++ b/xbmc/games/addons/GameClientRestoreResult.h
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+namespace KODI::GAME
+{
+enum class RestoreResult
+{
+  Restored, // Target machine and media state restored.
+  Rejected, // Target rejected; the previous running state is still valid.
+  StateUncertain, // Machine or media state may be inconsistent.
+};
+} // namespace KODI::GAME

--- a/xbmc/games/addons/disc/CMakeLists.txt
+++ b/xbmc/games/addons/disc/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES GameClientDiscM3U.cpp
 set(HEADERS GameClientDiscM3U.h
             GameClientDiscPlaylist.h
             GameClientDiscModel.h
+            GameClientDiscState.h
             GameClientDiscMergeUtils.h
             GameClientDiscs.h
             GameClientDiscTransport.h

--- a/xbmc/games/addons/disc/GameClientDiscMergeUtils.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscMergeUtils.cpp
@@ -17,6 +17,8 @@ CGameClientDiscModel CGameClientDiscMergeUtils::ReconcileModels(
     const CGameClientDiscModel& frontendDiscs, const CGameClientDiscModel& coreDiscs)
 {
   CGameClientDiscModel mergedDiscs;
+  mergedDiscs.RememberDiscs(frontendDiscs);
+  mergedDiscs.RememberDiscs(coreDiscs);
 
   // Set ejected
   mergedDiscs.SetEjected(coreDiscs.IsEjected());

--- a/xbmc/games/addons/disc/GameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscModel.cpp
@@ -8,7 +8,9 @@
 
 #include "GameClientDiscModel.h"
 
+#include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/log.h"
 
 #include <algorithm>
 
@@ -23,8 +25,82 @@ bool GameClientDiscEntry::operator==(const GameClientDiscEntry& rhs) const
 
 bool CGameClientDiscModel::operator==(const CGameClientDiscModel& rhs) const
 {
+  // Resolver history does not affect reconciliation of the active disc state.
   return m_discs == rhs.m_discs && m_selectedType == rhs.m_selectedType &&
          m_selectedDiscIndex == rhs.m_selectedDiscIndex && m_isEjected == rhs.m_isEjected;
+}
+
+GameClientDiscState CGameClientDiscModel::GetState() const
+{
+  GameClientDiscState state;
+  for (size_t i = 0; i < Size(); ++i)
+  {
+    if (IsRemovedSlotByIndex(i))
+      state.slots.push_back({DiscSlotType::Removed, {}, {}});
+    else
+      state.slots.push_back(
+          {DiscSlotType::Disc, DeriveBasename(GetPathByIndex(i)), GetLabelByIndex(i)});
+  }
+  if (const auto selected = GetSelectedDiscIndex())
+    state.selectedSlot = static_cast<int32_t>(*selected);
+  state.trayEjected = IsEjected();
+  return state;
+}
+
+bool CGameClientDiscModel::ResolveState(const GameClientDiscState& state,
+                                        CGameClientDiscModel& model) const
+{
+  CGameClientDiscModel resolved;
+  resolved.RememberDiscs(*this);
+  for (size_t i = 0; i < state.slots.size(); ++i)
+  {
+    const DiscSlot& slot = state.slots[i];
+    if (slot.type == DiscSlotType::Removed)
+    {
+      resolved.AddRemovedSlot();
+      continue;
+    }
+    if (slot.type != DiscSlotType::Disc || slot.fileName.empty() ||
+        slot.fileName != DeriveBasename(slot.fileName))
+    {
+      CLog::Log(LOGERROR, "RetroPlayer[DISC]: Invalid saved disc in slot {}: '{}'", i,
+                slot.fileName);
+      return false;
+    }
+
+    const std::string* match = nullptr;
+    for (const std::string& path : m_knownDiscPaths)
+    {
+      if (DeriveBasename(path) != slot.fileName)
+        continue;
+      if (match && !URIUtils::PathEquals(*match, path))
+      {
+        CLog::Log(LOGERROR, "RetroPlayer[DISC]: Ambiguous saved disc in slot {}: '{}' ({})", i,
+                  slot.fileName, slot.label);
+        return false;
+      }
+      match = &path;
+    }
+    if (!match || !CFileUtils::Exists(*match, false))
+    {
+      CLog::Log(LOGERROR, "RetroPlayer[DISC]: Missing saved disc in slot {}: '{}' ({})", i,
+                slot.fileName, slot.label);
+      return false;
+    }
+    resolved.AddDisc(*match, slot.label);
+  }
+
+  resolved.SetSelectedNoDisc();
+  if (state.selectedSlot < -1 ||
+      (state.selectedSlot >= 0 &&
+       !resolved.SetSelectedDiscByIndex(static_cast<size_t>(state.selectedSlot))))
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[DISC]: Invalid saved selection {}", state.selectedSlot);
+    return false;
+  }
+  resolved.SetEjected(state.trayEjected);
+  model = std::move(resolved);
+  return true;
 }
 
 size_t CGameClientDiscModel::Size() const
@@ -40,6 +116,7 @@ bool CGameClientDiscModel::Empty() const
 void CGameClientDiscModel::Clear()
 {
   m_discs.clear();
+  m_knownDiscPaths.clear();
   m_selectedType = DiscSelectionType::NoDisc;
   m_selectedDiscIndex.reset();
   m_isEjected = false;
@@ -47,6 +124,8 @@ void CGameClientDiscModel::Clear()
 
 void CGameClientDiscModel::SetDiscs(const std::vector<GameClientDiscEntry>& discs)
 {
+  for (const GameClientDiscEntry& disc : discs)
+    RememberDiscPath(disc.path);
   m_discs = discs;
   m_selectedType = DiscSelectionType::NoDisc;
   m_selectedDiscIndex.reset();
@@ -54,6 +133,7 @@ void CGameClientDiscModel::SetDiscs(const std::vector<GameClientDiscEntry>& disc
 
 void CGameClientDiscModel::AddDisc(const std::string& path, const std::string& cachedLabel)
 {
+  RememberDiscPath(path);
   m_discs.emplace_back(GameClientDiscEntry{GameClientDiscEntry::DiscSlotType::Disc, path,
                                            DeriveBasename(path), cachedLabel});
 
@@ -71,9 +151,32 @@ bool CGameClientDiscModel::SetDiscByIndex(size_t index,
   if (index >= m_discs.size() || path.empty())
     return false;
 
+  RememberDiscPath(path);
   m_discs[index] = {GameClientDiscEntry::DiscSlotType::Disc, path, DeriveBasename(path),
                     cachedLabel};
   return true;
+}
+
+void CGameClientDiscModel::RememberDiscPath(const std::string& path)
+{
+  if (path.empty())
+    return;
+
+  if (std::none_of(m_knownDiscPaths.begin(), m_knownDiscPaths.end(),
+                   [&path](const std::string& knownPath)
+                   { return URIUtils::PathEquals(knownPath, path); }))
+    m_knownDiscPaths.push_back(path);
+}
+
+void CGameClientDiscModel::RememberDiscs(const CGameClientDiscModel& model)
+{
+  if (this == &model)
+    return;
+
+  for (const std::string& path : model.m_knownDiscPaths)
+    RememberDiscPath(path);
+  for (const GameClientDiscEntry& disc : model.m_discs)
+    RememberDiscPath(disc.path);
 }
 
 void CGameClientDiscModel::AddRemovedSlot()

--- a/xbmc/games/addons/disc/GameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscModel.cpp
@@ -18,7 +18,13 @@ using namespace GAME;
 bool GameClientDiscEntry::operator==(const GameClientDiscEntry& rhs) const
 {
   return slotType == rhs.slotType && URIUtils::PathEquals(path, rhs.path) &&
-         cachedLabel == rhs.cachedLabel;
+         basename == rhs.basename && cachedLabel == rhs.cachedLabel;
+}
+
+bool CGameClientDiscModel::operator==(const CGameClientDiscModel& rhs) const
+{
+  return m_discs == rhs.m_discs && m_selectedType == rhs.m_selectedType &&
+         m_selectedDiscIndex == rhs.m_selectedDiscIndex && m_isEjected == rhs.m_isEjected;
 }
 
 size_t CGameClientDiscModel::Size() const

--- a/xbmc/games/addons/disc/GameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscModel.cpp
@@ -64,6 +64,18 @@ void CGameClientDiscModel::AddDisc(const std::string& path, const std::string& c
   }
 }
 
+bool CGameClientDiscModel::SetDiscByIndex(size_t index,
+                                          const std::string& path,
+                                          const std::string& cachedLabel)
+{
+  if (index >= m_discs.size() || path.empty())
+    return false;
+
+  m_discs[index] = {GameClientDiscEntry::DiscSlotType::Disc, path, DeriveBasename(path),
+                    cachedLabel};
+  return true;
+}
+
 void CGameClientDiscModel::AddRemovedSlot()
 {
   m_discs.emplace_back(

--- a/xbmc/games/addons/disc/GameClientDiscModel.h
+++ b/xbmc/games/addons/disc/GameClientDiscModel.h
@@ -37,6 +37,8 @@ struct GameClientDiscEntry
 class CGameClientDiscModel
 {
 public:
+  bool operator==(const CGameClientDiscModel& rhs) const;
+
   // Selected disc state used by the frontend selector/workflow.
   // "No disc" is explicit and distinct from any real disc entry.
   enum class DiscSelectionType

--- a/xbmc/games/addons/disc/GameClientDiscModel.h
+++ b/xbmc/games/addons/disc/GameClientDiscModel.h
@@ -62,6 +62,7 @@ public:
   void SetDiscs(const std::vector<GameClientDiscEntry>& discs);
 
   void AddDisc(const std::string& path, const std::string& cachedLabel = "");
+  bool SetDiscByIndex(size_t index, const std::string& path, const std::string& cachedLabel = "");
   void AddRemovedSlot();
   bool RemoveDiscByPath(const std::string& path);
   bool RemoveDiscByIndex(size_t index);

--- a/xbmc/games/addons/disc/GameClientDiscModel.h
+++ b/xbmc/games/addons/disc/GameClientDiscModel.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "GameClientDiscState.h"
+
 #include <cstddef>
 #include <optional>
 #include <string>
@@ -38,6 +40,8 @@ class CGameClientDiscModel
 {
 public:
   bool operator==(const CGameClientDiscModel& rhs) const;
+  GameClientDiscState GetState() const;
+  bool ResolveState(const GameClientDiscState& state, CGameClientDiscModel& model) const;
 
   // Selected disc state used by the frontend selector/workflow.
   // "No disc" is explicit and distinct from any real disc entry.
@@ -70,6 +74,9 @@ public:
   bool EraseDiscByIndex(size_t index);
 
   const std::vector<GameClientDiscEntry>& GetDiscs() const { return m_discs; }
+  const std::vector<std::string>& GetKnownDiscPaths() const { return m_knownDiscPaths; }
+  void RememberDiscPath(const std::string& path);
+  void RememberDiscs(const CGameClientDiscModel& model);
 
   std::optional<size_t> GetDiscIndexByPath(const std::string& path) const;
   std::optional<size_t> GetDiscIndexByBasename(const std::string& basename) const;
@@ -99,6 +106,7 @@ public:
 
 private:
   std::vector<GameClientDiscEntry> m_discs;
+  std::vector<std::string> m_knownDiscPaths;
   DiscSelectionType m_selectedType{DiscSelectionType::NoDisc};
   std::optional<size_t> m_selectedDiscIndex;
   bool m_isEjected{false};

--- a/xbmc/games/addons/disc/GameClientDiscState.h
+++ b/xbmc/games/addons/disc/GameClientDiscState.h
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace KODI
+{
+namespace GAME
+{
+enum class DiscSlotType
+{
+  Unknown,
+  Disc,
+  Removed,
+};
+
+struct DiscSlot
+{
+  DiscSlotType type{DiscSlotType::Unknown};
+  std::string fileName;
+  std::string label;
+
+  bool operator==(const DiscSlot&) const = default;
+};
+
+struct GameClientDiscState
+{
+  std::vector<DiscSlot> slots;
+  int32_t selectedSlot{-1};
+  bool trayEjected{false};
+
+  bool operator==(const GameClientDiscState&) const = default;
+};
+} // namespace GAME
+} // namespace KODI

--- a/xbmc/games/addons/disc/GameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscXML.cpp
@@ -30,6 +30,8 @@ namespace
 constexpr auto XML_ROOT = "discstate";
 constexpr auto XML_SLOTS = "slots";
 constexpr auto XML_SLOT = "slot";
+constexpr auto XML_KNOWN_MEDIA = "knownmedia";
+constexpr auto XML_DISC = "disc";
 constexpr auto XML_SELECTED = "selected";
 constexpr auto XML_TRAY = "tray";
 constexpr auto XML_ATTR_TYPE = "type";
@@ -97,6 +99,7 @@ bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel&
     return false;
   }
   ReadTrayFromXML(rootElement, model);
+  ReadKnownMediaFromXML(rootElement, model);
 
   return true;
 }
@@ -134,6 +137,7 @@ bool CGameClientDiscXML::Save(const std::string& gamePath, const CGameClientDisc
   WriteSlotsToXML(xmlDoc, rootElement, model);
   WriteSelectedToXML(xmlDoc, rootElement, model);
   WriteTrayToXML(xmlDoc, rootElement, model);
+  WriteKnownMediaToXML(xmlDoc, rootElement, model);
 
   if (!xmlDoc.SaveFile(xmlPath))
   {
@@ -214,6 +218,36 @@ void CGameClientDiscXML::WriteSlotsToXML(CXBMCTinyXML2& xmlDoc,
     }
 
     slotsElement->InsertEndChild(slotElement);
+  }
+}
+
+void CGameClientDiscXML::ReadKnownMediaFromXML(const tinyxml2::XMLElement* rootElement,
+                                               CGameClientDiscModel& model)
+{
+  const tinyxml2::XMLElement* mediaElement = rootElement->FirstChildElement(XML_KNOWN_MEDIA);
+  if (mediaElement == nullptr)
+    return;
+
+  for (const tinyxml2::XMLElement* discElement = mediaElement->FirstChildElement(XML_DISC);
+       discElement != nullptr; discElement = discElement->NextSiblingElement(XML_DISC))
+  {
+    if (const char* path = discElement->Attribute(XML_ATTR_PATH))
+      model.RememberDiscPath(path);
+  }
+}
+
+void CGameClientDiscXML::WriteKnownMediaToXML(CXBMCTinyXML2& xmlDoc,
+                                              tinyxml2::XMLElement* rootElement,
+                                              const CGameClientDiscModel& model)
+{
+  tinyxml2::XMLElement* mediaElement = xmlDoc.NewElement(XML_KNOWN_MEDIA);
+  rootElement->InsertEndChild(mediaElement);
+
+  for (const std::string& path : model.GetKnownDiscPaths())
+  {
+    tinyxml2::XMLElement* discElement = xmlDoc.NewElement(XML_DISC);
+    discElement->SetAttribute(XML_ATTR_PATH, path.c_str());
+    mediaElement->InsertEndChild(discElement);
   }
 }
 

--- a/xbmc/games/addons/disc/GameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscXML.cpp
@@ -16,6 +16,7 @@
 #include "utils/XBMCTinyXML2.h"
 #include "utils/log.h"
 
+#include <charconv>
 #include <cstring>
 #include <optional>
 
@@ -81,9 +82,20 @@ bool CGameClientDiscXML::Load(const std::string& gamePath, CGameClientDiscModel&
     return false;
   }
 
-  model.SetDiscs(ReadSlotsFromXML(rootElement));
+  const auto discs = ReadSlotsFromXML(rootElement);
+  if (!discs)
+  {
+    CLog::Log(LOGWARNING, "Invalid slots in disc state XML {}", CURL::GetRedacted(xmlPath));
+    return false;
+  }
+  model.SetDiscs(*discs);
 
-  ReadSelectedFromXML(rootElement, model);
+  if (!ReadSelectedFromXML(rootElement, model))
+  {
+    CLog::Log(LOGWARNING, "Invalid selected disc in disc state XML {}", CURL::GetRedacted(xmlPath));
+    model.Clear();
+    return false;
+  }
   ReadTrayFromXML(rootElement, model);
 
   return true;
@@ -132,15 +144,16 @@ bool CGameClientDiscXML::Save(const std::string& gamePath, const CGameClientDisc
   return true;
 }
 
-std::vector<GameClientDiscEntry> CGameClientDiscXML::ReadSlotsFromXML(
+std::optional<std::vector<GameClientDiscEntry>> CGameClientDiscXML::ReadSlotsFromXML(
     const tinyxml2::XMLElement* rootElement)
 {
   std::vector<GameClientDiscEntry> discs;
 
   const tinyxml2::XMLElement* slotsElement =
       rootElement != nullptr ? rootElement->FirstChildElement(XML_SLOTS) : nullptr;
-  const tinyxml2::XMLElement* slotElement =
-      slotsElement != nullptr ? slotsElement->FirstChildElement(XML_SLOT) : nullptr;
+  if (slotsElement == nullptr)
+    return std::nullopt;
+  const tinyxml2::XMLElement* slotElement = slotsElement->FirstChildElement(XML_SLOT);
 
   while (slotElement != nullptr)
   {
@@ -153,15 +166,16 @@ std::vector<GameClientDiscEntry> CGameClientDiscXML::ReadSlotsFromXML(
     {
       discs.push_back({GameClientDiscEntry::DiscSlotType::RemovedSlot, "", "", ""});
     }
-    else
+    else if (type != nullptr && std::strcmp(type, TYPE_DISC) == 0)
     {
       const char* path = slotElement->Attribute(XML_ATTR_PATH);
-      if (path != nullptr)
-      {
-        discs.push_back({GameClientDiscEntry::DiscSlotType::Disc, path,
-                         CGameClientDiscModel::DeriveBasename(path), label});
-      }
+      if (path == nullptr || *path == '\0')
+        return std::nullopt;
+      discs.push_back({GameClientDiscEntry::DiscSlotType::Disc, path,
+                       CGameClientDiscModel::DeriveBasename(path), label});
     }
+    else
+      return std::nullopt;
 
     slotElement = slotElement->NextSiblingElement(XML_SLOT);
   }
@@ -223,31 +237,33 @@ void CGameClientDiscXML::WriteTrayToXML(CXBMCTinyXML2& xmlDoc,
   trayElement->SetAttribute(XML_ATTR_EJECTED, model.IsEjected());
 }
 
-void CGameClientDiscXML::ReadSelectedFromXML(const tinyxml2::XMLElement* rootElement,
+bool CGameClientDiscXML::ReadSelectedFromXML(const tinyxml2::XMLElement* rootElement,
                                              CGameClientDiscModel& model)
 {
-  const tinyxml2::XMLElement* selectedElement =
-      rootElement != nullptr ? rootElement->FirstChildElement(XML_SELECTED) : nullptr;
-  if (selectedElement != nullptr)
-  {
-    const char* selectedType = selectedElement->Attribute(XML_ATTR_TYPE);
-    if (selectedType != nullptr && std::strcmp(selectedType, TYPE_NONE) == 0)
-    {
-      model.SetSelectedNoDisc();
-    }
-    else
-    {
-      const int selectedIndex = selectedElement->IntAttribute(XML_ATTR_INDEX, -1);
-      if (selectedIndex >= 0)
-        model.SetSelectedDiscByIndex(static_cast<size_t>(selectedIndex));
-      else
-        model.SetSelectedNoDisc();
-    }
-  }
-  else
+  const tinyxml2::XMLElement* selectedElement = rootElement->FirstChildElement(XML_SELECTED);
+  if (selectedElement == nullptr)
+    return false;
+
+  const char* selectedType = selectedElement->Attribute(XML_ATTR_TYPE);
+  if (selectedType == nullptr)
+    return false;
+  if (std::strcmp(selectedType, TYPE_NONE) == 0)
   {
     model.SetSelectedNoDisc();
+    return true;
   }
+  if (std::strcmp(selectedType, TYPE_DISC) != 0)
+    return false;
+
+  const char* index = selectedElement->Attribute(XML_ATTR_INDEX);
+  if (index == nullptr)
+    return false;
+
+  size_t selectedIndex;
+  const char* end = index + std::strlen(index);
+  const auto result = std::from_chars(index, end, selectedIndex);
+  return result.ec == std::errc{} && result.ptr == end &&
+         model.SetSelectedDiscByIndex(selectedIndex);
 }
 
 void CGameClientDiscXML::WriteSelectedToXML(CXBMCTinyXML2& xmlDoc,

--- a/xbmc/games/addons/disc/GameClientDiscXML.h
+++ b/xbmc/games/addons/disc/GameClientDiscXML.h
@@ -11,6 +11,7 @@
 #include "games/addons/disc/GameClientDiscModel.h"
 #include "games/addons/disc/GameClientDiscPlaylist.h"
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -35,7 +36,8 @@ public:
   static bool Save(const std::string& gamePath, const CGameClientDiscModel& model);
 
 private:
-  static std::vector<GameClientDiscEntry> ReadSlotsFromXML(const tinyxml2::XMLElement* rootElement);
+  static std::optional<std::vector<GameClientDiscEntry>> ReadSlotsFromXML(
+      const tinyxml2::XMLElement* rootElement);
   static void WriteSlotsToXML(CXBMCTinyXML2& xmlDoc,
                               tinyxml2::XMLElement* rootElement,
                               const CGameClientDiscModel& model);
@@ -45,7 +47,7 @@ private:
                              tinyxml2::XMLElement* rootElement,
                              const CGameClientDiscModel& model);
 
-  static void ReadSelectedFromXML(const tinyxml2::XMLElement* rootElement,
+  static bool ReadSelectedFromXML(const tinyxml2::XMLElement* rootElement,
                                   CGameClientDiscModel& model);
   static void WriteSelectedToXML(CXBMCTinyXML2& xmlDoc,
                                  tinyxml2::XMLElement* rootElement,

--- a/xbmc/games/addons/disc/GameClientDiscXML.h
+++ b/xbmc/games/addons/disc/GameClientDiscXML.h
@@ -42,6 +42,12 @@ private:
                               tinyxml2::XMLElement* rootElement,
                               const CGameClientDiscModel& model);
 
+  static void ReadKnownMediaFromXML(const tinyxml2::XMLElement* rootElement,
+                                    CGameClientDiscModel& model);
+  static void WriteKnownMediaToXML(CXBMCTinyXML2& xmlDoc,
+                                   tinyxml2::XMLElement* rootElement,
+                                   const CGameClientDiscModel& model);
+
   static void ReadTrayFromXML(const tinyxml2::XMLElement* rootElement, CGameClientDiscModel& model);
   static void WriteTrayToXML(CXBMCTinyXML2& xmlDoc,
                              tinyxml2::XMLElement* rootElement,

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -221,6 +221,16 @@ bool CGameClientDiscs::AddDisc(const std::string& filePath)
   {
     if (!m_transport->ReplaceImageIndex(static_cast<unsigned int>(*removedIndex), filePath))
       return false;
+
+    const auto selected = m_discModel->GetSelectedDiscIndex();
+    auto discs = m_discModel->GetDiscs();
+    discs[*removedIndex] = {GameClientDiscEntry::DiscSlotType::Disc,
+                            filePath,
+                            CGameClientDiscModel::DeriveBasename(filePath),
+                            {}};
+    m_discModel->SetDiscs(discs);
+    if (selected)
+      m_discModel->SetSelectedDiscByIndex(*selected);
   }
   else
   {

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -222,15 +222,7 @@ bool CGameClientDiscs::AddDisc(const std::string& filePath)
     if (!m_transport->ReplaceImageIndex(static_cast<unsigned int>(*removedIndex), filePath))
       return false;
 
-    const auto selected = m_discModel->GetSelectedDiscIndex();
-    auto discs = m_discModel->GetDiscs();
-    discs[*removedIndex] = {GameClientDiscEntry::DiscSlotType::Disc,
-                            filePath,
-                            CGameClientDiscModel::DeriveBasename(filePath),
-                            {}};
-    m_discModel->SetDiscs(discs);
-    if (selected)
-      m_discModel->SetSelectedDiscByIndex(*selected);
+    m_discModel->SetDiscByIndex(*removedIndex, filePath);
   }
   else
   {
@@ -293,7 +285,7 @@ bool CGameClientDiscs::RemoveDiscByIndex(size_t index)
   const bool wasSelected = selectedIndex.has_value() && *selectedIndex == index;
   bool selectionUpdated = true;
 
-  // Remove from the core by current index
+  const unsigned int previousImageCount = m_transport->GetImageCount();
   if (!m_transport->RemoveImageIndex(static_cast<unsigned int>(index)))
     return false;
 
@@ -306,7 +298,11 @@ bool CGameClientDiscs::RemoveDiscByIndex(size_t index)
     selectionUpdated = m_transport->SetImageIndex(noDiscIndex);
   }
 
-  m_discModel->MarkRemovedByIndex(index);
+  const unsigned int imageCount = m_transport->GetImageCount();
+  if (previousImageCount > 0 && imageCount == previousImageCount - 1)
+    m_discModel->EraseDiscByIndex(index);
+  else
+    m_discModel->MarkRemovedByIndex(index);
 
   RefreshDiscState();
 

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -291,6 +291,7 @@ bool CGameClientDiscs::RemoveDiscByIndex(size_t index)
 
   const std::optional<size_t> selectedIndex = m_discModel->GetSelectedDiscIndex();
   const bool wasSelected = selectedIndex.has_value() && *selectedIndex == index;
+  bool selectionUpdated = true;
 
   // Remove from the core by current index
   if (!m_transport->RemoveImageIndex(static_cast<unsigned int>(index)))
@@ -302,14 +303,14 @@ bool CGameClientDiscs::RemoveDiscByIndex(size_t index)
   if (wasSelected)
   {
     const unsigned int noDiscIndex = m_transport->GetImageCount();
-    m_transport->SetImageIndex(noDiscIndex);
+    selectionUpdated = m_transport->SetImageIndex(noDiscIndex);
   }
 
   m_discModel->MarkRemovedByIndex(index);
 
   RefreshDiscState();
 
-  return true;
+  return selectionUpdated;
 }
 
 bool CGameClientDiscs::InsertDisc(const std::string& filePath)

--- a/xbmc/games/addons/disc/GameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/GameClientDiscs.cpp
@@ -8,6 +8,7 @@
 
 #include "GameClientDiscs.h"
 
+#include "URL.h"
 #include "addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h"
 #include "games/GameUtils.h"
 #include "games/addons/GameClient.h"
@@ -16,14 +17,26 @@
 #include "games/addons/disc/GameClientDiscModel.h"
 #include "games/addons/disc/GameClientDiscTransport.h"
 #include "games/addons/disc/GameClientDiscXML.h"
+#include "utils/FileUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/log.h"
 
 #include <algorithm>
 #include <climits>
+#include <mutex>
 #include <vector>
 
 using namespace KODI;
 using namespace GAME;
+
+namespace
+{
+std::set<std::string> GetSupportedExtensions(const CGameClient& gameClient)
+{
+  const auto& extensions = gameClient.GetExtensions();
+  return extensions.empty() ? CGameUtils::GetGameExtensions() : extensions;
+}
+} // namespace
 
 CGameClientDiscs::CGameClientDiscs(CGameClient& gameClient,
                                    AddonInstance_Game& addonStruct,
@@ -43,148 +56,319 @@ bool CGameClientDiscs::SupportsDiscControl() const
   return m_gameClient.SupportsDiscControl();
 }
 
-void CGameClientDiscs::Initialize(const std::string& gamePath)
+bool CGameClientDiscs::IsMediaSupported(const CGameClientDiscModel& model) const
 {
+  const auto supportedExtensions = GetSupportedExtensions(m_gameClient);
+  for (size_t i = 0; i < model.Size(); ++i)
+  {
+    if (model.IsRemovedSlotByIndex(i))
+      continue;
+
+    const auto path = model.GetPathByIndex(i);
+    if (std::none_of(supportedExtensions.begin(), supportedExtensions.end(),
+                     [&path](const std::string& ext) { return URIUtils::HasExtension(path, ext); }))
+    {
+      CLog::Log(LOGWARNING, "RetroPlayer[DISC]: Unsupported media in slot {}: {}", i,
+                CURL::GetRedacted(path));
+      return false;
+    }
+  }
+  return true;
+}
+
+void CGameClientDiscs::Initialize(const std::string& gamePath, bool usePersistedState)
+{
+  std::unique_lock lock(m_clientAccess);
+
+  const bool replaceInitialHint = m_initialHintAttempted;
   // Disc state is per running game session. Always reset the in-memory model
   // before loading persisted state for the game being started.
   ResetSessionState();
 
-  std::set<std::string> supportedExtensions = m_gameClient.GetExtensions();
-  if (supportedExtensions.empty())
-    supportedExtensions = CGameUtils::GetGameExtensions();
+  const auto supportedExtensions = GetSupportedExtensions(m_gameClient);
 
+  const bool persistedStateExists = CFileUtils::Exists(CGameClientDiscXML::GetXMLPath(gamePath));
   CGameClientDiscModel restoredModel;
-  if (m_discXml->Load(gamePath, restoredModel) && !restoredModel.Empty())
+  bool persistedStateValid = false;
+  if (usePersistedState && persistedStateExists && m_discXml->Load(gamePath, restoredModel))
   {
-    // Load successful
-    *m_discModel = restoredModel;
-    m_isEjected = m_discModel->IsEjected();
-
-    // Prune removed discs when the core is newly loaded
-    PruneRemovedDiscs(*m_discModel);
-
-    // Prune unsupported extensions
-    PruneExtensions(*m_discModel, supportedExtensions);
-
-    // Set the initial disc index, if supported by libretro
-    const std::optional<size_t> selectedIndex = m_discModel->GetSelectedDiscIndex();
-    if (selectedIndex.has_value())
+    persistedStateValid = IsMediaSupported(restoredModel);
+    for (size_t i = 0; persistedStateValid && i < restoredModel.Size(); ++i)
     {
-      const std::string startupPath = m_discModel->GetPathByIndex(*selectedIndex);
-      if (!startupPath.empty())
-        m_transport->SetInitialImage(static_cast<unsigned int>(*selectedIndex), startupPath);
+      if (restoredModel.IsRemovedSlotByIndex(i))
+        continue;
+
+      const std::string path = restoredModel.GetPathByIndex(i);
+      if (path.empty() || !CFileUtils::Exists(path))
+      {
+        CLog::Log(LOGWARNING,
+                  "RetroPlayer[DISC]: Ignoring persisted disc state: slot {} has {} media {}", i,
+                  path.empty() ? "empty" : "missing", CURL::GetRedacted(path));
+        persistedStateValid = false;
+        break;
+      }
+    }
+
+    if (persistedStateValid)
+    {
+      *m_discModel = restoredModel;
+      PruneRemovedDiscs(*m_discModel);
+      m_isEjected = m_discModel->IsEjected();
+      m_preserveSlotTopology = true;
+      m_hasPersistedState = true;
+
+      const std::optional<size_t> startupIndex = m_discModel->GetSelectedDiscIndex();
+      if (startupIndex)
+      {
+        m_initialHintAttempted = true;
+        m_transport->SetInitialImage(static_cast<unsigned int>(*startupIndex),
+                                     m_discModel->GetPathByIndex(*startupIndex));
+      }
     }
   }
 
-  // If launching a playlist directly, seed the disc model from that playlist
-  // file path
-  if (m_discModel->Empty() && URIUtils::HasExtension(gamePath, ".m3u"))
-  {
-    m_discM3u->Load(gamePath, *m_discModel);
+  if (usePersistedState && persistedStateExists && !persistedStateValid)
+    CLog::Log(LOGWARNING, "RetroPlayer[DISC]: Falling back to source media for {}",
+              CURL::GetRedacted(gamePath));
 
-    // Prune unsupported extensions
-    PruneExtensions(*m_discModel, supportedExtensions);
+  CGameClientDiscModel sourceModel;
+  if (URIUtils::HasExtension(gamePath, ".m3u"))
+  {
+    m_discM3u->Load(gamePath, sourceModel);
+    PruneExtensions(sourceModel, supportedExtensions);
+  }
+  if (sourceModel.Empty())
+    sourceModel.AddDisc(gamePath);
+
+  if (!m_hasPersistedState)
+  {
+    *m_discModel = sourceModel;
+    m_discModel->SetSelectedDiscByIndex(0);
+  }
+  else
+  {
+    // Source media can resolve older savestates without changing the current playlist.
+    m_discModel->RememberDiscs(sourceModel);
   }
 
-  // If the model is empty, seed it with the game path as the initial disc
-  if (m_discModel->Empty())
-    m_discModel->AddDisc(gamePath);
+  if (!m_hasPersistedState && replaceInitialHint && !m_discModel->Empty())
+  {
+    m_initialHintAttempted = true;
+    m_transport->SetInitialImage(0, m_discModel->GetPathByIndex(0));
+  }
 }
 
 void CGameClientDiscs::Deinitialize()
 {
+  std::unique_lock lock(m_clientAccess);
+
   // Stopping a game must discard all live disc UI/model state. Persisted state
   // remains keyed by game path and will be loaded explicitly for the next game.
   ResetSessionState();
 }
 
-void CGameClientDiscs::RestoreDiscList()
+CGameClientDiscModel CGameClientDiscs::GetDiscs() const
 {
-  if (m_discModel->Empty())
-    return;
+  std::unique_lock lock(m_clientAccess);
+  return *m_discModel;
+}
 
-  // Force eject of disc, to clear emulator state
-  if (!m_transport->SetEjectState(true))
-    return;
+void CGameClientDiscs::SetDiscModel(const CGameClientDiscModel& model)
+{
+  std::unique_lock lock(m_clientAccess);
+  if (!m_preserveSlotTopology || !(*m_discModel == model))
+    m_restoredImageCount.reset();
+  if (*m_discModel == model)
+    m_discModel->RememberDiscs(model);
+  else
+  {
+    CGameClientDiscModel next = model;
+    next.RememberDiscs(*m_discModel);
+    *m_discModel = std::move(next);
+  }
+  m_isEjected = model.IsEjected();
+  m_preserveSlotTopology = true;
+}
 
-  if (!m_transport->GetEjectState())
-    return;
+bool CGameClientDiscs::PrepareForDeserialize()
+{
+  std::unique_lock lock(m_clientAccess);
+  return !m_transport->GetEjectState() || m_transport->SetEjectState(false);
+}
+
+void CGameClientDiscs::InvalidateRestoreCache()
+{
+  std::unique_lock lock(m_clientAccess);
+  m_restoredImageCount.reset();
+}
+
+bool CGameClientDiscs::RestoreDiscList()
+{
+  std::unique_lock lock(m_clientAccess);
+  ++m_restoreGeneration;
 
   unsigned int imageCount = m_transport->GetImageCount();
-
-  // Restore disc list
-  for (size_t i = 0; i < m_discModel->Size(); ++i)
+  bool listMatches = imageCount >= m_discModel->Size();
+  for (unsigned int i = 0; i < imageCount; ++i)
   {
-    if (m_discModel->IsRemovedSlotByIndex(i))
-      continue;
-
-    const std::string imagePath = m_discModel->GetPathByIndex(i);
-    if (imagePath.empty())
-      continue;
-
-    while (i >= imageCount)
+    const std::string path = m_transport->GetImagePath(i);
+    const std::string targetPath = m_discModel->GetPathByIndex(i);
+    if (path.empty())
     {
-      if (!m_transport->AddImageIndex())
-        return;
+      // Missing path metadata cannot invalidate an unchanged, successfully restored model.
+      if (m_restoredImageCount != imageCount)
+        listMatches = false;
+    }
+    else if (!URIUtils::PathEquals(path, targetPath))
+      listMatches = false;
+  }
+  const auto selectedIndex = m_discModel->GetSelectedDiscIndex();
+  const unsigned int currentIndex = m_transport->GetImageIndex();
+  // Libretro permits any out-of-range index to represent no disc.
+  const bool selectionMatches =
+      selectedIndex ? currentIndex == *selectedIndex : currentIndex >= imageCount;
+  const bool finalEjected = m_discModel->IsEjected();
 
-      const unsigned int previousCount = imageCount;
-      imageCount = m_transport->GetImageCount();
-
-      if (imageCount <= previousCount)
-        return; // Prevent infinite loop if core doesn't increment
-
-      if (i >= imageCount && imageCount == 0)
-        return;
+  if (!listMatches || !selectionMatches)
+  {
+    if (!m_transport->GetEjectState() && !m_transport->SetEjectState(true))
+    {
+      CLog::Log(LOGERROR, "RetroPlayer[DISC]: Failed to eject before restoring disc list");
+      return false;
+    }
+    if (!m_transport->GetEjectState())
+    {
+      CLog::Log(LOGERROR, "RetroPlayer[DISC]: Core did not report an ejected tray");
+      return false;
     }
 
-    // Check what path is currently at the target index in the core before
-    // attempting to replace it
-    const std::string currentPath = m_transport->GetImagePath(static_cast<unsigned int>(i));
-    if (!currentPath.empty() && URIUtils::PathEquals(currentPath, imagePath))
-      continue;
+    if (!listMatches)
+    {
+      // Some cores retain removed slots. Empty excess slots must never re-enter the frontend model.
+      for (unsigned int i = imageCount; m_preserveSlotTopology && i > m_discModel->Size(); --i)
+      {
+        if (!m_transport->RemoveImageIndex(i - 1))
+        {
+          CLog::Log(LOGERROR, "RetroPlayer[DISC]: Failed to remove excess slot {}", i - 1);
+          return false;
+        }
+      }
+      imageCount = m_transport->GetImageCount();
+      while (imageCount < m_discModel->Size())
+      {
+        if (!m_transport->AddImageIndex())
+        {
+          CLog::Log(LOGERROR, "RetroPlayer[DISC]: Failed to add slot {}", imageCount);
+          return false;
+        }
+        const unsigned int newCount = m_transport->GetImageCount();
+        if (newCount <= imageCount)
+        {
+          CLog::Log(LOGERROR, "RetroPlayer[DISC]: Core did not add requested slot {}", imageCount);
+          return false;
+        }
+        imageCount = newCount;
+      }
 
-    if (!m_transport->ReplaceImageIndex(static_cast<unsigned int>(i), imagePath))
-      return;
+      for (size_t i = 0; i < m_discModel->Size(); ++i)
+      {
+        if (m_discModel->IsRemovedSlotByIndex(i))
+        {
+          if (!m_transport->RemoveImageIndex(static_cast<unsigned int>(i)))
+          {
+            CLog::Log(LOGERROR, "RetroPlayer[DISC]: Failed to clear removed slot {}", i);
+            return false;
+          }
+          if (m_transport->GetImageCount() != imageCount)
+          {
+            CLog::Log(LOGERROR, "RetroPlayer[DISC]: Core cannot restore removed slot {}", i);
+            return false;
+          }
+        }
+        else
+        {
+          const std::string imagePath = m_discModel->GetPathByIndex(i);
+          if (imagePath.empty())
+          {
+            CLog::Log(LOGERROR, "RetroPlayer[DISC]: Cannot restore empty media in slot {}", i);
+            return false;
+          }
+          const std::string currentPath = m_transport->GetImagePath(static_cast<unsigned int>(i));
+          if (!URIUtils::PathEquals(currentPath, imagePath) &&
+              !m_transport->ReplaceImageIndex(static_cast<unsigned int>(i), imagePath))
+          {
+            CLog::Log(LOGERROR, "RetroPlayer[DISC]: Failed to restore media in slot {}", i);
+            return false;
+          }
+        }
+      }
+    }
+
+    if (!m_transport->SetImageIndex(selectedIndex ? static_cast<unsigned int>(*selectedIndex)
+                                                  : m_transport->GetImageCount()))
+    {
+      CLog::Log(LOGERROR, "RetroPlayer[DISC]: Failed to restore selected disc");
+      return false;
+    }
   }
 
-  // Restore selected index
-  const std::optional<size_t> selectedIndex = m_discModel->GetSelectedDiscIndex();
-  if (selectedIndex.has_value())
-    m_transport->SetImageIndex(static_cast<unsigned int>(*selectedIndex));
-  else
-    m_transport->SetImageIndex(m_transport->GetImageCount());
-
-  // Restore ejected state
-  const bool finalEjected = m_discModel->IsEjected();
-  m_transport->SetEjectState(finalEjected);
+  if (m_transport->GetEjectState() != finalEjected && !m_transport->SetEjectState(finalEjected))
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[DISC]: Failed to restore tray state");
+    return false;
+  }
   m_isEjected = m_transport->GetEjectState();
+  const unsigned int restoredIndex = m_transport->GetImageIndex();
+  const bool restored = m_isEjected == finalEjected &&
+                        (selectedIndex ? restoredIndex == *selectedIndex
+                                       : restoredIndex >= m_transport->GetImageCount());
+  if (restored)
+    m_restoredImageCount = m_transport->GetImageCount();
+  return restored;
 }
 
 void CGameClientDiscs::RefreshDiscState()
 {
-  // Get fresh core state
+  std::unique_lock lock(m_clientAccess);
+  RefreshDiscStateLive();
+  SaveDiscState();
+}
+
+void CGameClientDiscs::RefreshDiscStateLive()
+{
+  std::unique_lock lock(m_clientAccess);
+
   CGameClientDiscModel coreModel;
   LoadModelFromCore(coreModel);
+  if (m_preserveSlotTopology)
+  {
+    // Libretro can clear media without shrinking its physical slot array.
+    while (coreModel.Size() > m_discModel->Size())
+      coreModel.EraseDiscByIndex(coreModel.Size() - 1);
+  }
 
-  // Reconcile frontend state with the fresh core model
   *m_discModel = CGameClientDiscMergeUtils::ReconcileModels(*m_discModel, coreModel);
   m_isEjected = m_discModel->IsEjected();
-
-  SaveDiscState();
 }
 
 std::string CGameClientDiscs::GetDiscLabel() const
 {
+  std::unique_lock lock(m_clientAccess);
+
   return m_discModel->GetSelectedDiscLabel();
 }
 
 bool CGameClientDiscs::IsTrayEmpty() const
 {
+  std::unique_lock lock(m_clientAccess);
+
   return m_discModel->IsSelectedNoDisc();
 }
 
 bool CGameClientDiscs::SetEjected(bool ejected)
 {
+  std::unique_lock lock(m_clientAccess);
+
   if (!m_transport->SetEjectState(ejected))
     return false;
 
@@ -195,6 +379,8 @@ bool CGameClientDiscs::SetEjected(bool ejected)
 
 bool CGameClientDiscs::AddDisc(const std::string& filePath)
 {
+  std::unique_lock lock(m_clientAccess);
+
   if (filePath.empty())
     return true;
 
@@ -228,23 +414,26 @@ bool CGameClientDiscs::AddDisc(const std::string& filePath)
   {
     const unsigned int currentImageCount = m_transport->GetImageCount();
 
-    // No removed slot available, so add a new slot in the core
-    if (!m_transport->AddImageIndex())
-      return false;
-
-    const unsigned int newImageCount = m_transport->GetImageCount();
-
-    if (currentImageCount >= UINT_MAX || newImageCount != currentImageCount + 1)
-      return false;
-
-    // New slot is the last one
-    const unsigned int newIndex = newImageCount - 1;
+    unsigned int newIndex;
+    bool slotAdded = false;
+    if (m_preserveSlotTopology && m_discModel->Size() < currentImageCount)
+      newIndex = static_cast<unsigned int>(m_discModel->Size());
+    else
+    {
+      if (!m_transport->AddImageIndex())
+        return false;
+      const unsigned int newImageCount = m_transport->GetImageCount();
+      if (currentImageCount >= UINT_MAX || newImageCount != currentImageCount + 1)
+        return false;
+      newIndex = newImageCount - 1;
+      slotAdded = true;
+    }
 
     // Populate the new slot
     if (!m_transport->ReplaceImageIndex(newIndex, filePath))
     {
-      // Best effort rollback in the core
-      m_transport->RemoveImageIndex(newIndex);
+      if (slotAdded)
+        m_transport->RemoveImageIndex(newIndex);
       return false;
     }
 
@@ -262,6 +451,8 @@ bool CGameClientDiscs::AddDisc(const std::string& filePath)
 
 bool CGameClientDiscs::RemoveDisc(const std::string& filePath)
 {
+  std::unique_lock lock(m_clientAccess);
+
   if (filePath.empty())
     return true;
 
@@ -274,6 +465,8 @@ bool CGameClientDiscs::RemoveDisc(const std::string& filePath)
 
 bool CGameClientDiscs::RemoveDiscByIndex(size_t index)
 {
+  std::unique_lock lock(m_clientAccess);
+
   // Libretro only allows mutating the image list while ejected
   if (!m_isEjected)
     return true;
@@ -311,6 +504,8 @@ bool CGameClientDiscs::RemoveDiscByIndex(size_t index)
 
 bool CGameClientDiscs::InsertDisc(const std::string& filePath)
 {
+  std::unique_lock lock(m_clientAccess);
+
   // Libretro only allows mutating the image list while ejected
   if (!m_isEjected)
     return true;
@@ -338,6 +533,8 @@ bool CGameClientDiscs::InsertDisc(const std::string& filePath)
 
 bool CGameClientDiscs::InsertDiscByIndex(size_t index)
 {
+  std::unique_lock lock(m_clientAccess);
+
   // Libretro only allows mutating the image list while ejected
   if (!m_isEjected)
     return true;
@@ -355,8 +552,13 @@ bool CGameClientDiscs::InsertDiscByIndex(size_t index)
 
 void CGameClientDiscs::ResetSessionState()
 {
+  ++m_restoreGeneration;
   m_discModel->Clear();
   m_isEjected = false;
+  m_preserveSlotTopology = false;
+  m_hasPersistedState = false;
+  m_initialHintAttempted = false;
+  m_restoredImageCount.reset();
 }
 
 void CGameClientDiscs::LoadModelFromCore(CGameClientDiscModel& model) const
@@ -393,6 +595,8 @@ void CGameClientDiscs::LoadModelFromCore(CGameClientDiscModel& model) const
 
 void CGameClientDiscs::SaveDiscState() const
 {
+  std::unique_lock lock(m_clientAccess);
+
   if (!m_gameClient.GetGamePath().empty())
   {
     m_discXml->Save(m_gameClient.GetGamePath(), *m_discModel);

--- a/xbmc/games/addons/disc/GameClientDiscs.h
+++ b/xbmc/games/addons/disc/GameClientDiscs.h
@@ -12,6 +12,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <set>
@@ -60,15 +61,25 @@ public:
 
   // Game client capabilities
   bool SupportsDiscControl() const;
+  bool IsMediaSupported(const CGameClientDiscModel& model) const;
 
   // Lifecycle interface
-  void Initialize(const std::string& gamePath);
+  void Initialize(const std::string& gamePath, bool usePersistedState = true);
   void Deinitialize();
+  bool HasPersistedState() const { return m_hasPersistedState; }
 
   // Disc interface
-  void RestoreDiscList();
+  bool RestoreDiscList();
+  bool PrepareForDeserialize();
+  void InvalidateRestoreCache();
   void RefreshDiscState();
-  const CGameClientDiscModel& GetDiscs() const { return *m_discModel; }
+  void RefreshDiscStateLive();
+  CGameClientDiscModel GetDiscs() const;
+  // The caller must hold CGameClient::LockForSnapshot() while using this reference.
+  const CGameClientDiscModel& GetDiscsForSnapshot() const { return *m_discModel; }
+  void SetDiscModel(const CGameClientDiscModel& model);
+  uint64_t GetRestoreGeneration() const { return m_restoreGeneration; }
+  void SaveDiscState() const;
   bool IsEjected() const { return m_isEjected; }
   std::string GetDiscLabel() const;
   bool IsTrayEmpty() const;
@@ -91,7 +102,6 @@ private:
   void ResetSessionState();
 
   void LoadModelFromCore(CGameClientDiscModel& model) const;
-  void SaveDiscState() const;
 
   static void PruneRemovedDiscs(CGameClientDiscModel& model);
   static void PruneExtensions(CGameClientDiscModel& model,
@@ -105,6 +115,11 @@ private:
   // Game parameters
   std::unique_ptr<CGameClientDiscModel> m_discModel;
   std::atomic<bool> m_isEjected{false};
+  std::atomic<uint64_t> m_restoreGeneration{0};
+  bool m_preserveSlotTopology{false};
+  bool m_hasPersistedState{false};
+  bool m_initialHintAttempted{false};
+  std::optional<unsigned int> m_restoredImageCount;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/addons/disc/test/CMakeLists.txt
+++ b/xbmc/games/addons/disc/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES TestGameClientDiscM3U.cpp
             TestGameClientDiscMergeUtils.cpp
             TestGameClientDiscModel.cpp
+            TestGameClientDiscMutations.cpp
             TestGameClientDiscXML.cpp
 )
 

--- a/xbmc/games/addons/disc/test/CMakeLists.txt
+++ b/xbmc/games/addons/disc/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES TestGameClientDiscM3U.cpp
             TestGameClientDiscMergeUtils.cpp
             TestGameClientDiscModel.cpp
             TestGameClientDiscMutations.cpp
+            TestGameClientDiscs.cpp
             TestGameClientDiscXML.cpp
 )
 

--- a/xbmc/games/addons/disc/test/TestGameClientDiscMergeUtils.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscMergeUtils.cpp
@@ -6,7 +6,11 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "filesystem/File.h"
 #include "games/addons/disc/GameClientDiscMergeUtils.h"
+#include "test/TestUtils.h"
+
+#include <memory>
 
 #include <gtest/gtest.h>
 
@@ -168,4 +172,47 @@ TEST(TestGameClientDiscMergeUtils, InvalidCoreSelectionIndexCanUnexpectedlyForce
   EXPECT_TRUE(mergedDiscs.IsSelectedNoDisc());
   EXPECT_FALSE(mergedDiscs.GetSelectedDiscIndex().has_value());
   EXPECT_EQ(mergedDiscs.GetSelectedDiscPath(), "");
+}
+
+TEST(TestGameClientDiscMergeUtils, EmptyCoreRetainsHistoricalFrontendMedia)
+{
+  const auto deleteFile = [](XFILE::CFile* file) { XBMC_DELETETEMPFILE(file); };
+  std::unique_ptr<XFILE::CFile, decltype(deleteFile)> file(XBMC_CREATETEMPFILE(".chd"), deleteFile);
+  ASSERT_NE(file, nullptr);
+  file->Close();
+  const std::string path = XBMC_TEMPFILEPATH(file.get());
+  CGameClientDiscModel frontend;
+  frontend.AddDisc(path);
+  const auto saved = frontend.GetState();
+  ASSERT_TRUE(frontend.MarkRemovedByIndex(0));
+  CGameClientDiscModel core;
+  core.SetEjected(true);
+
+  const auto merged = CGameClientDiscMergeUtils::ReconcileModels(frontend, core);
+  EXPECT_TRUE(merged.Empty());
+  EXPECT_TRUE(merged.IsSelectedNoDisc());
+  EXPECT_TRUE(merged.IsEjected());
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(merged.ResolveState(saved, restored));
+  EXPECT_EQ(restored.GetSelectedDiscPath(), path);
+}
+
+TEST(TestGameClientDiscMergeUtils, EmptyFrontendRetainsHistoricalCoreMedia)
+{
+  const auto deleteFile = [](XFILE::CFile* file) { XBMC_DELETETEMPFILE(file); };
+  std::unique_ptr<XFILE::CFile, decltype(deleteFile)> file(XBMC_CREATETEMPFILE(".chd"), deleteFile);
+  ASSERT_NE(file, nullptr);
+  file->Close();
+  const std::string path = XBMC_TEMPFILEPATH(file.get());
+  CGameClientDiscModel core;
+  core.AddDisc(path);
+  const auto saved = core.GetState();
+  ASSERT_TRUE(core.EraseDiscByIndex(0));
+
+  const auto merged = CGameClientDiscMergeUtils::ReconcileModels(CGameClientDiscModel{}, core);
+  EXPECT_TRUE(merged.Empty());
+  EXPECT_TRUE(merged.IsSelectedNoDisc());
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(merged.ResolveState(saved, restored));
+  EXPECT_EQ(restored.GetSelectedDiscPath(), path);
 }

--- a/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
@@ -85,3 +85,22 @@ TEST(TestGameClientDiscModel, DeriveBasenameHandlesUnixAndWindowsPaths)
   EXPECT_EQ(CGameClientDiscModel::DeriveBasename("C:\\roms\\disc2.chd"), "disc2.chd");
   EXPECT_EQ(CGameClientDiscModel::DeriveBasename("/roms/subdir/"), "subdir");
 }
+
+TEST(TestGameClientDiscModel, SnapshotEqualityIncludesAllMachineDiscState)
+{
+  CGameClientDiscModel first;
+  first.AddDisc("/roms/disc1.chd", "One");
+  CGameClientDiscModel second = first;
+  EXPECT_TRUE(first == second);
+  second.SetEjected(true);
+  EXPECT_FALSE(first == second);
+  second = first;
+  second.SetSelectedNoDisc();
+  EXPECT_FALSE(first == second);
+  second = first;
+  second.AddRemovedSlot();
+  EXPECT_FALSE(first == second);
+  second = first;
+  second.UpdateCachedLabel("/roms/disc1.chd", "Changed");
+  EXPECT_FALSE(first == second);
+}

--- a/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
@@ -104,3 +104,51 @@ TEST(TestGameClientDiscModel, SnapshotEqualityIncludesAllMachineDiscState)
   second.UpdateCachedLabel("/roms/disc1.chd", "Changed");
   EXPECT_FALSE(first == second);
 }
+
+TEST(TestGameClientDiscModel, IndexedReplacementReusesSlotAndPreservesOtherSelection)
+{
+  const std::string oldPath = "/roms/old.chd";
+  const std::string newPath = "/roms/new.chd";
+  CGameClientDiscModel model;
+  model.AddDisc("/roms/first.chd");
+  model.AddDisc(oldPath, "Old disc");
+  ASSERT_TRUE(model.MarkRemovedByIndex(1));
+
+  ASSERT_TRUE(model.SetDiscByIndex(1, newPath, "Replacement"));
+  EXPECT_EQ(model.Size(), 2U);
+  EXPECT_EQ(model.GetSelectedDiscIndex(), 0U);
+  EXPECT_FALSE(model.IsRemovedSlotByIndex(1));
+  EXPECT_EQ(model.GetPathByIndex(1), newPath);
+  EXPECT_EQ(model.GetLabelByIndex(1), "Replacement");
+  EXPECT_EQ(model.GetDiscByIndex(1)->basename, CGameClientDiscModel::DeriveBasename(newPath));
+}
+
+TEST(TestGameClientDiscModel, IndexedReplacementPreservesNoDiscAndSelectedSlot)
+{
+  CGameClientDiscModel model;
+  model.AddRemovedSlot();
+  model.SetEjected(true);
+  ASSERT_TRUE(model.SetDiscByIndex(0, "/roms/first.chd"));
+  EXPECT_TRUE(model.IsSelectedNoDisc());
+  EXPECT_TRUE(model.IsEjected());
+
+  ASSERT_TRUE(model.SetSelectedDiscByIndex(0));
+  const std::string path = "/roms/replacement.chd";
+  ASSERT_TRUE(model.SetDiscByIndex(0, path));
+  EXPECT_EQ(model.Size(), 1U);
+  EXPECT_EQ(model.GetSelectedDiscIndex(), 0U);
+  EXPECT_EQ(model.GetSelectedDiscPath(), path);
+  EXPECT_TRUE(model.IsEjected());
+}
+
+TEST(TestGameClientDiscModel, InvalidIndexedReplacementLeavesModelUnchanged)
+{
+  CGameClientDiscModel model;
+  model.AddDisc("/roms/first.chd");
+  const CGameClientDiscModel previous = model;
+  const std::string newPath = "/roms/new.chd";
+
+  EXPECT_FALSE(model.SetDiscByIndex(model.Size(), newPath));
+  EXPECT_FALSE(model.SetDiscByIndex(0, ""));
+  EXPECT_TRUE(model == previous);
+}

--- a/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscModel.cpp
@@ -6,16 +6,65 @@
  *  See LICENSES/README.md for more information.
  */
 
+#include "filesystem/Directory.h"
+#include "filesystem/File.h"
 #include "games/addons/disc/GameClientDiscModel.h"
+#include "test/TestUtils.h"
+#include "utils/URIUtils.h"
 
 #include <gtest/gtest.h>
 
 using namespace KODI;
 using namespace GAME;
 
-TEST(TestGameClientDiscModel, AddFirstDiscAutoSelectsFirstIndex)
+class TestGameClientDiscModel : public testing::Test
 {
-  // Verify adding the very first disc selects it by default.
+protected:
+  std::string CreateDisc()
+  {
+    XFILE::CFile* file = XBMC_CREATETEMPFILE(".chd");
+    EXPECT_NE(file, nullptr);
+    if (!file)
+      return {};
+    file->Close();
+    m_files.push_back(file);
+    return XBMC_TEMPFILEPATH(file);
+  }
+
+  std::string CreateDiscWithSameName(const std::string& path)
+  {
+    const std::string directory = CreateDisc() + ".dir";
+    EXPECT_TRUE(XFILE::CDirectory::Create(directory));
+    m_directories.push_back(directory);
+    const std::string otherPath =
+        URIUtils::AddFileToFolder(directory, CGameClientDiscModel::DeriveBasename(path));
+    XFILE::CFile file;
+    EXPECT_TRUE(file.OpenForWrite(otherPath, true));
+    file.Close();
+    m_additionalFiles.push_back(otherPath);
+    return otherPath;
+  }
+
+  void TearDown() override
+  {
+    for (const std::string& path : m_additionalFiles)
+      XFILE::CFile::Delete(path);
+    for (const std::string& directory : m_directories)
+    {
+      EXPECT_TRUE(XFILE::CDirectory::Remove(directory));
+    }
+    for (XFILE::CFile* file : m_files)
+      XBMC_DELETETEMPFILE(file);
+  }
+
+private:
+  std::vector<XFILE::CFile*> m_files;
+  std::vector<std::string> m_additionalFiles;
+  std::vector<std::string> m_directories;
+};
+
+TEST_F(TestGameClientDiscModel, AddFirstDiscAutoSelectsFirstIndex)
+{
   CGameClientDiscModel model;
   model.AddDisc("/roms/disc1.chd");
 
@@ -25,9 +74,8 @@ TEST(TestGameClientDiscModel, AddFirstDiscAutoSelectsFirstIndex)
   EXPECT_EQ(model.GetSelectedDiscPath(), "/roms/disc1.chd");
 }
 
-TEST(TestGameClientDiscModel, RemovedSlotsAreNotSelectable)
+TEST_F(TestGameClientDiscModel, RemovedSlotsAreNotSelectable)
 {
-  // Verify removed slots are tracked but can never be selected as active discs.
   CGameClientDiscModel model;
   model.AddRemovedSlot();
 
@@ -36,9 +84,8 @@ TEST(TestGameClientDiscModel, RemovedSlotsAreNotSelectable)
   EXPECT_FALSE(model.SetSelectedDiscByIndex(0));
 }
 
-TEST(TestGameClientDiscModel, MarkRemovedSelectedDiscClearsSelection)
+TEST_F(TestGameClientDiscModel, MarkRemovedSelectedDiscClearsSelection)
 {
-  // Verify removing the currently selected disc transitions selection to "No disc".
   CGameClientDiscModel model;
   model.AddDisc("/roms/disc1.chd");
   model.AddDisc("/roms/disc2.chd");
@@ -51,9 +98,8 @@ TEST(TestGameClientDiscModel, MarkRemovedSelectedDiscClearsSelection)
   EXPECT_TRUE(model.IsRemovedSlotByIndex(1));
 }
 
-TEST(TestGameClientDiscModel, EraseBeforeSelectedDiscShiftsSelectedIndex)
+TEST_F(TestGameClientDiscModel, EraseBeforeSelectedDiscShiftsSelectedIndex)
 {
-  // Verify erasing a lower slot keeps the same selected disc by shifting its index.
   CGameClientDiscModel model;
   model.AddDisc("/roms/disc1.chd");
   model.AddDisc("/roms/disc2.chd");
@@ -67,9 +113,8 @@ TEST(TestGameClientDiscModel, EraseBeforeSelectedDiscShiftsSelectedIndex)
   EXPECT_EQ(model.GetSelectedDiscPath(), "/roms/disc3.chd");
 }
 
-TEST(TestGameClientDiscModel, LabelFallsBackFromCachedLabelToBasename)
+TEST_F(TestGameClientDiscModel, LabelFallsBackFromCachedLabelToBasename)
 {
-  // Verify labels prefer cached labels and otherwise use path-derived basename.
   CGameClientDiscModel model;
   model.AddDisc("/roms/disc1.chd");
   model.AddDisc("/roms/disc2.chd", "Disc Two");
@@ -78,15 +123,98 @@ TEST(TestGameClientDiscModel, LabelFallsBackFromCachedLabelToBasename)
   EXPECT_EQ(model.GetLabelByIndex(1), "Disc Two");
 }
 
-TEST(TestGameClientDiscModel, DeriveBasenameHandlesUnixAndWindowsPaths)
+TEST_F(TestGameClientDiscModel, DeriveBasenameHandlesUnixAndWindowsPaths)
 {
-  // Verify basename extraction normalizes both slash styles and trailing separators.
   EXPECT_EQ(CGameClientDiscModel::DeriveBasename("/roms/disc1.chd"), "disc1.chd");
   EXPECT_EQ(CGameClientDiscModel::DeriveBasename("C:\\roms\\disc2.chd"), "disc2.chd");
   EXPECT_EQ(CGameClientDiscModel::DeriveBasename("/roms/subdir/"), "subdir");
 }
 
-TEST(TestGameClientDiscModel, SnapshotEqualityIncludesAllMachineDiscState)
+TEST_F(TestGameClientDiscModel, SavestateResolvesHistoricalOrderAndSelectionByFilename)
+{
+  const std::string disc1 = CreateDisc();
+  const std::string disc2 = CreateDisc();
+  CGameClientDiscModel saved;
+  saved.AddDisc("/old/" + CGameClientDiscModel::DeriveBasename(disc1), "One");
+  saved.AddRemovedSlot();
+  saved.AddDisc("/old/" + CGameClientDiscModel::DeriveBasename(disc2), "Two");
+  ASSERT_TRUE(saved.SetSelectedDiscByIndex(2));
+  saved.SetEjected(true);
+
+  const auto state = saved.GetState();
+  EXPECT_EQ(state.slots[0].fileName, CGameClientDiscModel::DeriveBasename(disc1));
+  EXPECT_EQ(state.slots[2].label, "Two");
+  CGameClientDiscModel current;
+  current.AddDisc(disc2, "New label");
+  current.AddDisc(CreateDisc());
+  current.AddDisc(disc1);
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(current.ResolveState(state, restored));
+  EXPECT_EQ(restored.Size(), 3U);
+  EXPECT_EQ(restored.GetPathByIndex(0), disc1);
+  EXPECT_TRUE(restored.IsRemovedSlotByIndex(1));
+  EXPECT_EQ(restored.GetSelectedDiscIndex(), 2U);
+  EXPECT_EQ(restored.GetSelectedDiscPath(), disc2);
+  EXPECT_EQ(restored.GetSelectedDiscLabel(), "Two");
+  EXPECT_TRUE(restored.IsEjected());
+}
+
+TEST_F(TestGameClientDiscModel, SavestateNeverSubstitutesReusedSlotOrAmbiguousFilename)
+{
+  CGameClientDiscModel saved;
+  saved.AddDisc("/old/disc2.chd", "Two");
+  const auto state = saved.GetState();
+  CGameClientDiscModel current;
+  current.AddDisc("/new/disc1.chd", "Two");
+  CGameClientDiscModel output = current;
+  EXPECT_FALSE(current.ResolveState(state, output));
+  EXPECT_TRUE(output == current);
+
+  current.AddDisc("/a/disc2.chd", "Two");
+  current.AddDisc("/b/disc2.chd", "Other label");
+  EXPECT_FALSE(current.ResolveState(state, output));
+  EXPECT_EQ(output.Size(), 1U);
+}
+
+TEST_F(TestGameClientDiscModel, SavestateNoDiscAndTrayAreIndependent)
+{
+  CGameClientDiscModel saved;
+  const std::string path = CreateDisc();
+  saved.AddDisc(path);
+  saved.SetSelectedNoDisc();
+  for (const bool ejected : {false, true})
+  {
+    saved.SetEjected(ejected);
+    CGameClientDiscModel restored;
+    ASSERT_TRUE(saved.ResolveState(saved.GetState(), restored));
+    EXPECT_TRUE(restored.IsSelectedNoDisc());
+    EXPECT_EQ(restored.IsEjected(), ejected);
+    EXPECT_EQ(saved.GetState().slots[0].fileName, CGameClientDiscModel::DeriveBasename(path));
+  }
+}
+
+TEST_F(TestGameClientDiscModel, SavestateRejectsInvalidSlotsAndSelection)
+{
+  CGameClientDiscModel model;
+  model.AddDisc(CreateDisc());
+  model.AddRemovedSlot();
+  auto state = model.GetState();
+  CGameClientDiscModel restored;
+  state.selectedSlot = 1;
+  EXPECT_FALSE(model.ResolveState(state, restored));
+  state.selectedSlot = -2;
+  EXPECT_FALSE(model.ResolveState(state, restored));
+  state.selectedSlot = 20;
+  EXPECT_FALSE(model.ResolveState(state, restored));
+  state.selectedSlot = -1;
+  state.slots[0].type = DiscSlotType::Unknown;
+  EXPECT_FALSE(model.ResolveState(state, restored));
+  state.slots[0].type = DiscSlotType::Disc;
+  state.slots[0].fileName = "/roms/disc1.chd";
+  EXPECT_FALSE(model.ResolveState(state, restored));
+}
+
+TEST_F(TestGameClientDiscModel, SnapshotEqualityIncludesAllMachineDiscState)
 {
   CGameClientDiscModel first;
   first.AddDisc("/roms/disc1.chd", "One");
@@ -105,13 +233,185 @@ TEST(TestGameClientDiscModel, SnapshotEqualityIncludesAllMachineDiscState)
   EXPECT_FALSE(first == second);
 }
 
-TEST(TestGameClientDiscModel, IndexedReplacementReusesSlotAndPreservesOtherSelection)
+TEST_F(TestGameClientDiscModel, RemovedDiscStillResolvesItsHistoricalSlot)
 {
-  const std::string oldPath = "/roms/old.chd";
-  const std::string newPath = "/roms/new.chd";
+  const std::string path = CreateDisc();
   CGameClientDiscModel model;
-  model.AddDisc("/roms/first.chd");
+  model.AddDisc(CreateDisc());
+  model.AddRemovedSlot();
+  model.AddDisc(path, "Second disc");
+  ASSERT_TRUE(model.SetSelectedDiscByIndex(2));
+  model.SetEjected(true);
+  const auto saved = model.GetState();
+
+  ASSERT_TRUE(model.MarkRemovedByIndex(2));
+  EXPECT_TRUE(model.IsSelectedNoDisc());
+  EXPECT_FALSE(model.SetSelectedDiscByIndex(2));
+  EXPECT_FALSE(model.GetDiscIndexByPath(path).has_value());
+  EXPECT_TRUE(model.GetPathByIndex(2).empty());
+  EXPECT_TRUE(model.GetLabelByIndex(2).empty());
+  EXPECT_EQ(model.GetState().slots[2].type, DiscSlotType::Removed);
+  EXPECT_TRUE(model.GetState().slots[2].fileName.empty());
+
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(model.ResolveState(saved, restored));
+  EXPECT_EQ(restored.Size(), 3U);
+  EXPECT_TRUE(restored.IsRemovedSlotByIndex(1));
+  EXPECT_EQ(restored.GetSelectedDiscIndex(), 2U);
+  EXPECT_EQ(restored.GetSelectedDiscPath(), path);
+  EXPECT_EQ(restored.GetSelectedDiscLabel(), "Second disc");
+  EXPECT_TRUE(restored.IsEjected());
+  EXPECT_TRUE(model.IsRemovedSlotByIndex(2));
+}
+
+TEST_F(TestGameClientDiscModel, ErasingEverySlotKeepsHistoricalMedia)
+{
+  const std::string firstPath = CreateDisc();
+  const std::string secondPath = CreateDisc();
+  CGameClientDiscModel model;
+  model.AddDisc(firstPath);
+  model.AddDisc(secondPath);
+  ASSERT_TRUE(model.SetSelectedDiscByIndex(1));
+  const auto saved = model.GetState();
+
+  ASSERT_TRUE(model.EraseDiscByIndex(0));
+  ASSERT_TRUE(model.EraseDiscByIndex(0));
+  EXPECT_TRUE(model.Empty());
+  EXPECT_TRUE(model.GetState().slots.empty());
+  EXPECT_TRUE(model.IsSelectedNoDisc());
+
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(model.ResolveState(saved, restored));
+  EXPECT_EQ(restored.Size(), 2U);
+  EXPECT_EQ(restored.GetPathByIndex(0), firstPath);
+  EXPECT_EQ(restored.GetSelectedDiscPath(), secondPath);
+  EXPECT_EQ(restored.GetSelectedDiscIndex(), 1U);
+}
+
+TEST_F(TestGameClientDiscModel, ReplacingRemovedSlotKeepsPreviousMediaIdentity)
+{
+  const std::string oldPath = CreateDisc();
+  const std::string newPath = CreateDisc();
+  CGameClientDiscModel model;
   model.AddDisc(oldPath, "Old disc");
+  const auto saved = model.GetState();
+  ASSERT_TRUE(model.MarkRemovedByIndex(0));
+
+  model.SetDiscs({{GameClientDiscEntry::DiscSlotType::Disc, newPath,
+                   CGameClientDiscModel::DeriveBasename(newPath), "New disc"}});
+  EXPECT_EQ(model.Size(), 1U);
+  EXPECT_EQ(model.GetPathByIndex(0), newPath);
+  EXPECT_FALSE(model.GetDiscIndexByPath(oldPath).has_value());
+
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(model.ResolveState(saved, restored));
+  EXPECT_EQ(restored.GetSelectedDiscPath(), oldPath);
+  EXPECT_EQ(restored.GetSelectedDiscLabel(), "Old disc");
+  EXPECT_EQ(model.GetPathByIndex(0), newPath);
+}
+
+TEST_F(TestGameClientDiscModel, ReplacingTheListWithEmptyKeepsHistoricalMedia)
+{
+  const std::string path = CreateDisc();
+  CGameClientDiscModel model;
+  model.SetDiscs({{GameClientDiscEntry::DiscSlotType::Disc,
+                   path,
+                   CGameClientDiscModel::DeriveBasename(path),
+                   {}}});
+  const auto saved = model.GetState();
+  model.SetDiscs({});
+  EXPECT_TRUE(model.Empty());
+
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(model.ResolveState(saved, restored));
+  EXPECT_EQ(restored.GetPathByIndex(0), path);
+}
+
+TEST_F(TestGameClientDiscModel, ResolvingEmptyStateKeepsHistoricalMedia)
+{
+  const std::string path = CreateDisc();
+  CGameClientDiscModel model;
+  model.AddDisc(path);
+  const auto saved = model.GetState();
+
+  CGameClientDiscModel empty;
+  ASSERT_TRUE(model.ResolveState(GameClientDiscState{}, empty));
+  EXPECT_TRUE(empty.Empty());
+  EXPECT_TRUE(empty.IsSelectedNoDisc());
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(empty.ResolveState(saved, restored));
+  EXPECT_EQ(restored.GetSelectedDiscPath(), path);
+}
+
+TEST_F(TestGameClientDiscModel, DeletedCurrentDiscCannotResolveAndLeavesOutputUnchanged)
+{
+  const std::string path = CreateDisc();
+  CGameClientDiscModel model;
+  model.AddDisc(path);
+  const auto saved = model.GetState();
+  ASSERT_TRUE(XFILE::CFile::Delete(path));
+
+  CGameClientDiscModel output;
+  output.AddDisc(CreateDisc());
+  output.SetEjected(true);
+  const CGameClientDiscModel previous = output;
+  EXPECT_FALSE(model.ResolveState(saved, output));
+  EXPECT_TRUE(output == previous);
+}
+
+TEST_F(TestGameClientDiscModel, RemovedMissingCandidateDoesNotDisambiguateSavedFilename)
+{
+  const std::string firstPath = CreateDisc();
+  const std::string secondPath = CreateDiscWithSameName(firstPath);
+  CGameClientDiscModel model;
+  model.AddDisc(firstPath);
+  const auto saved = model.GetState();
+  model.AddDisc(secondPath);
+  ASSERT_TRUE(model.MarkRemovedByIndex(1));
+  ASSERT_TRUE(XFILE::CFile::Delete(secondPath));
+
+  CGameClientDiscModel output;
+  output.AddDisc(CreateDisc());
+  const CGameClientDiscModel previous = output;
+  EXPECT_FALSE(model.ResolveState(saved, output));
+  EXPECT_TRUE(output == previous);
+}
+
+TEST_F(TestGameClientDiscModel, HistoricalMediaDoesNotChangeActiveModelEquality)
+{
+  CGameClientDiscModel current;
+  current.AddDisc(CreateDisc());
+  CGameClientDiscModel withHistory = current;
+  withHistory.AddDisc(CreateDisc());
+  const auto saved = withHistory.GetState();
+  ASSERT_TRUE(withHistory.EraseDiscByIndex(1));
+  EXPECT_TRUE(current == withHistory);
+
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(withHistory.ResolveState(saved, restored));
+  EXPECT_EQ(restored.Size(), 2U);
+}
+
+TEST_F(TestGameClientDiscModel, ClearForgetsPreviousSessionMedia)
+{
+  CGameClientDiscModel model;
+  model.AddDisc(CreateDisc());
+  const auto saved = model.GetState();
+  model.Clear();
+
+  CGameClientDiscModel restored;
+  EXPECT_FALSE(model.ResolveState(saved, restored));
+  EXPECT_TRUE(model.Empty());
+}
+
+TEST_F(TestGameClientDiscModel, IndexedReplacementReusesSlotAndPreservesOtherSelection)
+{
+  const std::string oldPath = CreateDisc();
+  const std::string newPath = CreateDisc();
+  CGameClientDiscModel model;
+  model.AddDisc(CreateDisc());
+  model.AddDisc(oldPath, "Old disc");
+  const auto saved = model.GetState();
   ASSERT_TRUE(model.MarkRemovedByIndex(1));
 
   ASSERT_TRUE(model.SetDiscByIndex(1, newPath, "Replacement"));
@@ -121,19 +421,23 @@ TEST(TestGameClientDiscModel, IndexedReplacementReusesSlotAndPreservesOtherSelec
   EXPECT_EQ(model.GetPathByIndex(1), newPath);
   EXPECT_EQ(model.GetLabelByIndex(1), "Replacement");
   EXPECT_EQ(model.GetDiscByIndex(1)->basename, CGameClientDiscModel::DeriveBasename(newPath));
+
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(model.ResolveState(saved, restored));
+  EXPECT_EQ(restored.GetPathByIndex(1), oldPath);
 }
 
-TEST(TestGameClientDiscModel, IndexedReplacementPreservesNoDiscAndSelectedSlot)
+TEST_F(TestGameClientDiscModel, IndexedReplacementPreservesNoDiscAndSelectedSlot)
 {
   CGameClientDiscModel model;
   model.AddRemovedSlot();
   model.SetEjected(true);
-  ASSERT_TRUE(model.SetDiscByIndex(0, "/roms/first.chd"));
+  ASSERT_TRUE(model.SetDiscByIndex(0, CreateDisc()));
   EXPECT_TRUE(model.IsSelectedNoDisc());
   EXPECT_TRUE(model.IsEjected());
 
   ASSERT_TRUE(model.SetSelectedDiscByIndex(0));
-  const std::string path = "/roms/replacement.chd";
+  const std::string path = CreateDisc();
   ASSERT_TRUE(model.SetDiscByIndex(0, path));
   EXPECT_EQ(model.Size(), 1U);
   EXPECT_EQ(model.GetSelectedDiscIndex(), 0U);
@@ -141,14 +445,45 @@ TEST(TestGameClientDiscModel, IndexedReplacementPreservesNoDiscAndSelectedSlot)
   EXPECT_TRUE(model.IsEjected());
 }
 
-TEST(TestGameClientDiscModel, InvalidIndexedReplacementLeavesModelUnchanged)
+TEST_F(TestGameClientDiscModel, InvalidIndexedReplacementLeavesModelAndKnownPathsUnchanged)
 {
   CGameClientDiscModel model;
-  model.AddDisc("/roms/first.chd");
+  model.AddDisc(CreateDisc());
   const CGameClientDiscModel previous = model;
-  const std::string newPath = "/roms/new.chd";
+  const std::string newPath = CreateDisc();
 
   EXPECT_FALSE(model.SetDiscByIndex(model.Size(), newPath));
   EXPECT_FALSE(model.SetDiscByIndex(0, ""));
   EXPECT_TRUE(model == previous);
+  EXPECT_EQ(model.GetKnownDiscPaths(), previous.GetKnownDiscPaths());
+}
+
+TEST_F(TestGameClientDiscModel, RememberingMediaDoesNotAddSlotsOrDuplicatePaths)
+{
+  const std::string firstPath = CreateDisc();
+  const std::string secondPath = CreateDisc();
+  CGameClientDiscModel model;
+  model.RememberDiscPath(firstPath);
+  model.RememberDiscPath("");
+  model.RememberDiscPath(firstPath);
+  model.RememberDiscPath(model.GetKnownDiscPaths().front());
+  model.RememberDiscs(model);
+
+  CGameClientDiscModel other;
+  other.AddDisc(firstPath);
+  other.AddDisc(secondPath);
+  const auto saved = other.GetState();
+  ASSERT_TRUE(other.EraseDiscByIndex(1));
+  model.RememberDiscs(other);
+  EXPECT_EQ(model.GetKnownDiscPaths(), (std::vector<std::string>{firstPath, secondPath}));
+  EXPECT_TRUE(model.Empty());
+  EXPECT_TRUE(model.IsSelectedNoDisc());
+  EXPECT_FALSE(model.SetSelectedDiscByIndex(0));
+  EXPECT_TRUE(model.GetState().slots.empty());
+
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(model.ResolveState(saved, restored));
+  EXPECT_EQ(restored.Size(), 2U);
+  model.Clear();
+  EXPECT_TRUE(model.GetKnownDiscPaths().empty());
 }

--- a/xbmc/games/addons/disc/test/TestGameClientDiscMutations.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscMutations.cpp
@@ -1,0 +1,136 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "addons/Repository.h"
+#include "addons/addoninfo/AddonInfoBuilder.h"
+#include "filesystem/File.h"
+#include "games/addons/GameClient.h"
+#include "games/addons/disc/GameClientDiscModel.h"
+#include "games/addons/disc/GameClientDiscs.h"
+#include "test/TestUtils.h"
+#include "utils/XBMCTinyXML2.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace KODI::GAME;
+
+namespace
+{
+struct MutationCore
+{
+  std::vector<std::string> slots{"/roms/disc1.chd", "/roms/disc2.chd"};
+  unsigned int selected{0};
+  bool ejected{true};
+  bool failSetImageIndex{false};
+};
+
+MutationCore& Core(const AddonInstance_Game* instance)
+{
+  return *static_cast<MutationCore*>(instance->toAddon->addonInstance);
+}
+} // namespace
+
+class TestGameClientDiscMutations : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    CXBMCTinyXML2 xml;
+    const std::string addonXml =
+        R"(<addon id="game.test.discmutations" name="Disc mutation test" version="1.0.0">
+      <extension point="kodi.gameclient" library="test.so">
+        <supports_disc_control>true</supports_disc_control>
+        <extensions>chd|m3u</extensions>
+      </extension>
+      <extension point="xbmc.addon.metadata"><platform>all</platform></extension>
+    </addon>)";
+    ASSERT_TRUE(xml.Parse(addonXml));
+    const auto info =
+        ADDON::CAddonInfoBuilder::Generate(xml.RootElement(), ADDON::RepositoryDirInfo{});
+    ASSERT_NE(info, nullptr);
+    m_client = std::make_unique<CGameClient>(info);
+
+    auto* callbacks = m_client->GetInstanceInterface()->toAddon;
+    callbacks->addonInstance = &m_core;
+    callbacks->GetEjectState = [](const AddonInstance_Game* game) { return Core(game).ejected; };
+    callbacks->SetEjectState = [](const AddonInstance_Game* game, bool ejected)
+    {
+      Core(game).ejected = ejected;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->GetImageCount = [](const AddonInstance_Game* game)
+    { return static_cast<unsigned int>(Core(game).slots.size()); };
+    callbacks->GetImageIndex = [](const AddonInstance_Game* game) { return Core(game).selected; };
+    callbacks->SetImageIndex = [](const AddonInstance_Game* game, unsigned int index)
+    {
+      if (Core(game).failSetImageIndex)
+        return GAME_ERROR_FAILED;
+      Core(game).selected = index;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->AddImageIndex = [](const AddonInstance_Game* game)
+    {
+      Core(game).slots.emplace_back();
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->ReplaceImageIndex =
+        [](const AddonInstance_Game* game, unsigned int index, const char* path)
+    {
+      if (index >= Core(game).slots.size())
+        return GAME_ERROR_FAILED;
+      Core(game).slots[index] = path ? path : "";
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->RemoveImageIndex = [](const AddonInstance_Game* game, unsigned int index)
+    {
+      if (index >= Core(game).slots.size())
+        return GAME_ERROR_FAILED;
+      Core(game).slots[index].clear();
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->SetInitialImage = [](const AddonInstance_Game*, unsigned int, const char*)
+    { return GAME_ERROR_NO_ERROR; };
+    callbacks->GetImagePath = [](const AddonInstance_Game*, unsigned int) -> char*
+    { return nullptr; };
+    callbacks->GetImageLabel = [](const AddonInstance_Game*, unsigned int) -> char*
+    { return nullptr; };
+    callbacks->FreeString = [](const AddonInstance_Game*, char* value) { free(value); };
+
+    m_playlist.reset(XBMC_CREATETEMPFILE(".m3u"));
+    ASSERT_NE(m_playlist, nullptr);
+    constexpr char PLAYLIST[] = "/roms/disc1.chd\n/roms/disc2.chd\n";
+    ASSERT_EQ(m_playlist->Write(PLAYLIST, sizeof(PLAYLIST) - 1),
+              static_cast<ssize_t>(sizeof(PLAYLIST) - 1));
+    m_playlist->Close();
+    m_client->Discs().Initialize(XBMC_TEMPFILEPATH(m_playlist.get()));
+    m_client->Discs().RefreshDiscState();
+  }
+
+  void TearDown() override { EXPECT_TRUE(XBMC_DELETETEMPFILE(m_playlist.release())); }
+
+  MutationCore m_core;
+  std::unique_ptr<CGameClient> m_client;
+  std::unique_ptr<XFILE::CFile> m_playlist;
+};
+
+TEST_F(TestGameClientDiscMutations, ReusedRemovedSlotKeepsIdentityWithoutCoreMetadata)
+{
+  ASSERT_TRUE(m_client->Discs().RemoveDiscByIndex(1));
+  ASSERT_TRUE(m_client->Discs().AddDisc("/roms/disc3.chd"));
+
+  const CGameClientDiscModel model = m_client->Discs().GetDiscs();
+  ASSERT_EQ(model.Size(), 2U);
+  EXPECT_FALSE(model.IsRemovedSlotByIndex(1));
+  EXPECT_EQ(model.GetPathByIndex(1), "/roms/disc3.chd");
+}

--- a/xbmc/games/addons/disc/test/TestGameClientDiscMutations.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscMutations.cpp
@@ -133,6 +133,60 @@ TEST_F(TestGameClientDiscMutations, ReusedRemovedSlotKeepsIdentityWithoutCoreMet
   ASSERT_EQ(model.Size(), 2U);
   EXPECT_FALSE(model.IsRemovedSlotByIndex(1));
   EXPECT_EQ(model.GetPathByIndex(1), "/roms/disc3.chd");
+  EXPECT_EQ(model.GetSelectedDiscIndex(), 0U);
+  EXPECT_EQ(m_core.slots, (std::vector<std::string>{"/roms/disc1.chd", "/roms/disc3.chd"}));
+}
+
+TEST_F(TestGameClientDiscMutations, FailedSlotReuseKeepsRemovedSlot)
+{
+  ASSERT_TRUE(m_client->Discs().RemoveDiscByIndex(1));
+  m_client->GetInstanceInterface()->toAddon->ReplaceImageIndex =
+      [](const AddonInstance_Game*, unsigned int, const char*) { return GAME_ERROR_FAILED; };
+
+  EXPECT_FALSE(m_client->Discs().AddDisc("/roms/disc3.chd"));
+
+  const CGameClientDiscModel model = m_client->Discs().GetDiscs();
+  EXPECT_EQ(model.Size(), 2U);
+  EXPECT_TRUE(model.IsRemovedSlotByIndex(1));
+  EXPECT_TRUE(model.GetPathByIndex(1).empty());
+  EXPECT_EQ(model.GetSelectedDiscIndex(), 0U);
+  EXPECT_EQ(m_core.slots, (std::vector<std::string>{"/roms/disc1.chd", ""}));
+}
+
+TEST_F(TestGameClientDiscMutations, ReusedRemovedSlotPreservesNoDiscSelection)
+{
+  ASSERT_TRUE(m_client->Discs().InsertDisc(""));
+  ASSERT_TRUE(m_client->Discs().RemoveDiscByIndex(1));
+  ASSERT_TRUE(m_client->Discs().AddDisc("/roms/disc3.chd"));
+
+  const CGameClientDiscModel model = m_client->Discs().GetDiscs();
+  EXPECT_EQ(model.Size(), 2U);
+  EXPECT_TRUE(model.IsSelectedNoDisc());
+  EXPECT_EQ(model.GetPathByIndex(1), "/roms/disc3.chd");
+  EXPECT_EQ(m_core.selected, 2U);
+}
+
+TEST_F(TestGameClientDiscMutations, CompactingRemovalKeepsIdentityWithoutCoreMetadata)
+{
+  m_client->GetInstanceInterface()->toAddon->RemoveImageIndex =
+      [](const AddonInstance_Game* game, unsigned int index)
+  {
+    auto& core = Core(game);
+    if (index >= core.slots.size())
+      return GAME_ERROR_FAILED;
+    core.slots.erase(core.slots.begin() + index);
+    if (core.selected > index)
+      --core.selected;
+    return GAME_ERROR_NO_ERROR;
+  };
+  ASSERT_TRUE(m_client->Discs().InsertDiscByIndex(1));
+
+  ASSERT_TRUE(m_client->Discs().RemoveDiscByIndex(0));
+
+  const CGameClientDiscModel model = m_client->Discs().GetDiscs();
+  ASSERT_EQ(model.Size(), 1U);
+  EXPECT_EQ(model.GetPathByIndex(0), "/roms/disc2.chd");
+  EXPECT_EQ(model.GetSelectedDiscIndex(), 0U);
 }
 
 TEST_F(TestGameClientDiscMutations,

--- a/xbmc/games/addons/disc/test/TestGameClientDiscMutations.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscMutations.cpp
@@ -134,3 +134,17 @@ TEST_F(TestGameClientDiscMutations, ReusedRemovedSlotKeepsIdentityWithoutCoreMet
   EXPECT_FALSE(model.IsRemovedSlotByIndex(1));
   EXPECT_EQ(model.GetPathByIndex(1), "/roms/disc3.chd");
 }
+
+TEST_F(TestGameClientDiscMutations,
+       FailedNoDiscSelectionAfterRemovalReportsFailureAndRefreshesModel)
+{
+  m_core.failSetImageIndex = true;
+
+  EXPECT_FALSE(m_client->Discs().RemoveDiscByIndex(0));
+
+  const CGameClientDiscModel model = m_client->Discs().GetDiscs();
+  ASSERT_EQ(model.Size(), 2U);
+  EXPECT_TRUE(model.IsRemovedSlotByIndex(0));
+  EXPECT_TRUE(model.IsSelectedNoDisc());
+  EXPECT_TRUE(m_core.slots[0].empty());
+}

--- a/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
@@ -235,7 +235,8 @@ TEST(TestGameClientDiscXML, LoadMissingEjectedDefaultsToFalse)
   XFILE::CFile file;
   ASSERT_TRUE(file.OpenForWrite(xmlPath, true));
   static constexpr char xml[] =
-      "<discstate><slots><slot type=\"disc\" path=\"/roms/disc1.chd\"/></slots></discstate>";
+      "<discstate><slots><slot type=\"disc\" path=\"/roms/disc1.chd\"/></slots>"
+      "<selected type=\"none\"/></discstate>";
   ASSERT_EQ(file.Write(xml, sizeof(xml) - 1), sizeof(xml) - 1);
   file.Close();
 
@@ -279,3 +280,73 @@ TEST(TestGameClientDiscXML, SaveCreatesPerGameStateFile)
 
   CleanupStateFile();
 }
+
+class TestGameClientDiscXMLInvalidSelection : public testing::TestWithParam<const char*>
+{
+protected:
+  void SetUp() override { CleanupStateFile(); }
+  void TearDown() override { CleanupStateFile(); }
+};
+
+TEST_P(TestGameClientDiscXMLInvalidSelection, RejectsInvalidSelection)
+{
+  EnsureStateSubdirectory();
+  const std::string xml =
+      std::string{"<discstate><slots><slot type=\"disc\" path=\"/roms/disc1.chd\"/>"
+                  "<slot type=\"removed\"/></slots>"} +
+      GetParam() + "</discstate>";
+  XFILE::CFile file;
+  ASSERT_TRUE(file.OpenForWrite(CGameClientDiscXML::GetXMLPath(GAME_PATH), true));
+  ASSERT_EQ(file.Write(xml.data(), xml.size()), static_cast<ssize_t>(xml.size()));
+  file.Close();
+
+  CGameClientDiscXML discXml;
+  CGameClientDiscModel loaded;
+  EXPECT_FALSE(discXml.Load(GAME_PATH, loaded));
+  EXPECT_TRUE(loaded.Empty());
+}
+
+INSTANTIATE_TEST_SUITE_P(InvalidMetadata,
+                         TestGameClientDiscXMLInvalidSelection,
+                         testing::Values("<selected type=\"disc\" index=\"2\"/>",
+                                         "<selected type=\"disc\" index=\"1\"/>",
+                                         "<selected type=\"disc\" index=\"-1\"/>",
+                                         "<selected type=\"disc\" index=\"abc\"/>",
+                                         "<selected type=\"disc\" index=\"0junk\"/>",
+                                         "<selected type=\"disc\" index=\"0.5\"/>",
+                                         "<selected type=\"disc\" index=\"18446744073709551616\"/>",
+                                         "<selected type=\"disc\" index=\"\"/>",
+                                         "<selected type=\"disc\"/>",
+                                         "<selected index=\"0\"/>",
+                                         "<selected type=\"unknown\" index=\"0\"/>",
+                                         ""));
+
+class TestGameClientDiscXMLInvalidSlots : public testing::TestWithParam<const char*>
+{
+protected:
+  void SetUp() override { CleanupStateFile(); }
+  void TearDown() override { CleanupStateFile(); }
+};
+
+TEST_P(TestGameClientDiscXMLInvalidSlots, RejectsMalformedSlotWithoutShiftingSelection)
+{
+  EnsureStateSubdirectory();
+  const std::string xml = std::string{"<discstate><slots>"} + GetParam() +
+                          R"(<slot type="disc" path="/roms/disc2.chd"/></slots>)" +
+                          R"(<selected type="disc" index="0"/></discstate>)";
+  XFILE::CFile file;
+  ASSERT_TRUE(file.OpenForWrite(CGameClientDiscXML::GetXMLPath(GAME_PATH), true));
+  ASSERT_EQ(file.Write(xml.data(), xml.size()), static_cast<ssize_t>(xml.size()));
+  file.Close();
+
+  CGameClientDiscModel loaded;
+  EXPECT_FALSE(CGameClientDiscXML::Load(GAME_PATH, loaded));
+  EXPECT_TRUE(loaded.Empty());
+}
+
+INSTANTIATE_TEST_SUITE_P(InvalidMetadata,
+                         TestGameClientDiscXMLInvalidSlots,
+                         testing::Values(R"(<slot type="disc"/>)",
+                                         R"(<slot type="disc" path=""/>)",
+                                         R"(<slot type="unknown" path="/roms/disc1.chd"/>)",
+                                         R"(<slot path="/roms/disc1.chd"/>)"));

--- a/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscXML.cpp
@@ -11,6 +11,7 @@
 #include "games/addons/disc/GameClientDiscMergeUtils.h"
 #include "games/addons/disc/GameClientDiscModel.h"
 #include "games/addons/disc/GameClientDiscXML.h"
+#include "test/TestUtils.h"
 #include "utils/FileUtils.h"
 #include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
@@ -65,7 +66,6 @@ std::string ReadStateXml()
 
 TEST(TestGameClientDiscXML, SaveLoadRoundtripPreservesSlotTypes)
 {
-  // Verify roundtripping keeps real and removed slots in their original order.
   CleanupStateFile();
 
   CGameClientDiscModel savedModel;
@@ -95,7 +95,6 @@ TEST(TestGameClientDiscXML, SaveLoadRoundtripPreservesSlotTypes)
 
 TEST(TestGameClientDiscXML, SaveLoadSelectedNonePreserved)
 {
-  // Verify explicit "No disc" selection survives XML serialization and load.
   CleanupStateFile();
 
   CGameClientDiscModel savedModel;
@@ -116,7 +115,6 @@ TEST(TestGameClientDiscXML, SaveLoadSelectedNonePreserved)
 
 TEST(TestGameClientDiscXML, MissingXmlIsNonErrorAndLeavesEmptyModel)
 {
-  // Verify loading with no persisted XML is treated as success with an empty model.
   CleanupStateFile();
 
   CGameClientDiscXML discXml;
@@ -128,7 +126,6 @@ TEST(TestGameClientDiscXML, MissingXmlIsNonErrorAndLeavesEmptyModel)
 
 TEST(TestGameClientDiscXML, MalformedXmlFailsAndClearsModel)
 {
-  // Verify malformed XML is rejected and the output model is reset.
   CleanupStateFile();
 
   const std::string xmlPath = CGameClientDiscXML::GetXMLPath(GAME_PATH);
@@ -152,7 +149,6 @@ TEST(TestGameClientDiscXML, MalformedXmlFailsAndClearsModel)
 
 TEST(TestGameClientDiscXML, SaveWritesEjectedTrue)
 {
-  // Verify saving with an ejected tray writes the true tray flag.
   CleanupStateFile();
 
   CGameClientDiscModel savedModel;
@@ -170,7 +166,6 @@ TEST(TestGameClientDiscXML, SaveWritesEjectedTrue)
 
 TEST(TestGameClientDiscXML, SaveWritesEjectedFalse)
 {
-  // Verify saving with an inserted tray writes the false tray flag.
   CleanupStateFile();
 
   CGameClientDiscModel savedModel;
@@ -188,7 +183,6 @@ TEST(TestGameClientDiscXML, SaveWritesEjectedFalse)
 
 TEST(TestGameClientDiscXML, LoadRestoresEjectedState)
 {
-  // Verify loading restores a previously persisted ejected tray state.
   CleanupStateFile();
 
   CGameClientDiscModel savedModel;
@@ -207,7 +201,6 @@ TEST(TestGameClientDiscXML, LoadRestoresEjectedState)
 
 TEST(TestGameClientDiscXML, LoadRestoresEjectedFalseState)
 {
-  // Verify loading restores a previously persisted non-ejected tray state.
   CleanupStateFile();
 
   CGameClientDiscModel savedModel;
@@ -226,7 +219,6 @@ TEST(TestGameClientDiscXML, LoadRestoresEjectedFalseState)
 
 TEST(TestGameClientDiscXML, LoadMissingEjectedDefaultsToFalse)
 {
-  // Verify older XML without tray metadata defaults to non-ejected.
   CleanupStateFile();
 
   const std::string xmlPath = CGameClientDiscXML::GetXMLPath(GAME_PATH);
@@ -251,7 +243,6 @@ TEST(TestGameClientDiscXML, LoadMissingEjectedDefaultsToFalse)
 
 TEST(TestGameClientDiscXML, GetXMLPathUsesPerGameDirectoryAndExtensionlessBaseName)
 {
-  // Verify XML save path uses "<base>_<crc>/<base>.xml" and does not keep source extensions.
   const std::string xmlPath = CGameClientDiscXML::GetXMLPath(GAME_PATH);
 
   EXPECT_EQ(URIUtils::GetFileName(xmlPath), "my_game.xml");
@@ -350,3 +341,86 @@ INSTANTIATE_TEST_SUITE_P(InvalidMetadata,
                                          R"(<slot type="disc" path=""/>)",
                                          R"(<slot type="unknown" path="/roms/disc1.chd"/>)",
                                          R"(<slot path="/roms/disc1.chd"/>)"));
+
+class TestGameClientDiscXMLHistory : public testing::Test
+{
+protected:
+  void SetUp() override { CleanupStateFile(); }
+  void TearDown() override
+  {
+    CleanupStateFile();
+    for (auto* file : m_files)
+    {
+      EXPECT_TRUE(XBMC_DELETETEMPFILE(file));
+    }
+  }
+
+  std::string CreateMedia()
+  {
+    auto* file = XBMC_CREATETEMPFILE(".chd");
+    EXPECT_NE(file, nullptr);
+    if (!file)
+      return {};
+    m_files.push_back(file);
+    file->Close();
+    return XBMC_TEMPFILEPATH(file);
+  }
+
+private:
+  std::vector<XFILE::CFile*> m_files;
+};
+
+TEST_F(TestGameClientDiscXMLHistory, RemovedAndErasedMediaRemainResolvable)
+{
+  const std::string first = CreateMedia();
+  const std::string second = CreateMedia();
+  ASSERT_FALSE(first.empty());
+  ASSERT_FALSE(second.empty());
+  CGameClientDiscModel model;
+  model.AddDisc(first, "One");
+  model.AddDisc(second, "Two");
+  const auto state = model.GetState();
+  ASSERT_TRUE(model.MarkRemovedByIndex(0));
+  ASSERT_TRUE(model.EraseDiscByIndex(1));
+
+  CGameClientDiscXML xml;
+  ASSERT_TRUE(xml.Save(GAME_PATH, model));
+  CGameClientDiscModel loaded;
+  ASSERT_TRUE(xml.Load(GAME_PATH, loaded));
+  ASSERT_EQ(loaded.Size(), 1U);
+  EXPECT_TRUE(loaded.IsRemovedSlotByIndex(0));
+  EXPECT_TRUE(loaded.GetPathByIndex(0).empty());
+  EXPECT_FALSE(loaded.SetSelectedDiscByIndex(0));
+
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(loaded.ResolveState(state, restored));
+  EXPECT_EQ(restored.GetPathByIndex(0), first);
+  EXPECT_EQ(restored.GetPathByIndex(1), second);
+  EXPECT_EQ(restored.GetLabelByIndex(1), "Two");
+}
+
+TEST_F(TestGameClientDiscXMLHistory, ReusedSlotRetainsFormerIdentity)
+{
+  const std::string former = CreateMedia();
+  const std::string replacement = CreateMedia();
+  ASSERT_FALSE(former.empty());
+  ASSERT_FALSE(replacement.empty());
+  CGameClientDiscModel model;
+  model.AddDisc(former);
+  const auto state = model.GetState();
+  ASSERT_TRUE(model.MarkRemovedByIndex(0));
+  model.SetDiscs({{GameClientDiscEntry::DiscSlotType::Disc,
+                   replacement,
+                   CGameClientDiscModel::DeriveBasename(replacement),
+                   {}}});
+
+  CGameClientDiscXML xml;
+  ASSERT_TRUE(xml.Save(GAME_PATH, model));
+  CGameClientDiscModel loaded;
+  ASSERT_TRUE(xml.Load(GAME_PATH, loaded));
+  EXPECT_EQ(loaded.GetPathByIndex(0), replacement);
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(loaded.ResolveState(state, restored));
+  EXPECT_EQ(restored.GetPathByIndex(0), former);
+  EXPECT_EQ(loaded.Size(), 1U);
+}

--- a/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
@@ -8,8 +8,15 @@
 
 #include "addons/Repository.h"
 #include "addons/addoninfo/AddonInfoBuilder.h"
+#include "cores/RetroPlayer/playback/ReversiblePlayback.h"
+#include "cores/RetroPlayer/playback/test/PlaybackTestEnvironment.h"
+#include "cores/RetroPlayer/savestates/SavestateDatabase.h"
+#include "cores/RetroPlayer/savestates/SavestateFlatBuffer.h"
+#include "cores/RetroPlayer/streams/IStreamManager.h"
+#include "cores/RetroPlayer/streams/memory/DeltaPairMemoryStream.h"
 #include "filesystem/File.h"
 #include "games/addons/GameClient.h"
+#include "games/addons/GameClientCallbacks.h"
 #include "games/addons/disc/GameClientDiscM3U.h"
 #include "games/addons/disc/GameClientDiscModel.h"
 #include "games/addons/disc/GameClientDiscXML.h"
@@ -17,12 +24,209 @@
 #include "test/TestUtils.h"
 #include "utils/XBMCTinyXML2.h"
 
+#include <algorithm>
+#include <cstring>
+#include <future>
+#include <limits>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
 
+using namespace KODI;
 using namespace KODI::GAME;
+
+namespace
+{
+// Explicit instantiation allows the fixture to access members without production test hooks.
+template<typename Tag, typename Tag::Type member>
+struct TestMemberAccess
+{
+  friend typename Tag::Type GetMember(Tag) { return member; }
+};
+
+template<typename Tag, typename Object>
+decltype(auto) TestMember(Object& object)
+{
+  return object.*GetMember(Tag{});
+}
+
+struct ClientPlaying
+{
+  using Type = std::atomic_bool CGameClient::*;
+  friend Type GetMember(ClientPlaying);
+};
+template struct TestMemberAccess<ClientPlaying, &CGameClient::m_bIsPlaying>;
+
+struct ClientInitializeGameplay
+{
+  using Type = bool (CGameClient::*)(const std::string&,
+                                     RETRO::IStreamManager&,
+                                     IGameInputCallback*);
+  friend Type GetMember(ClientInitializeGameplay);
+};
+template struct TestMemberAccess<ClientInitializeGameplay, &CGameClient::InitializeGameplay>;
+
+struct ClientInput
+{
+  using Type = IGameInputCallback* CGameClient::*;
+  friend Type GetMember(ClientInput);
+};
+template struct TestMemberAccess<ClientInput, &CGameClient::m_input>;
+
+struct ClientFrameRun
+{
+  using Type = std::atomic_bool CGameClient::*;
+  friend Type GetMember(ClientFrameRun);
+};
+template struct TestMemberAccess<ClientFrameRun, &CGameClient::m_hasFrameRun>;
+
+struct ClientSerializeSize
+{
+  using Type = size_t CGameClient::*;
+  friend Type GetMember(ClientSerializeSize);
+};
+template struct TestMemberAccess<ClientSerializeSize, &CGameClient::m_serializeSize>;
+
+struct ClientFrameRate
+{
+  using Type = std::atomic<double> CGameClient::*;
+  friend Type GetMember(ClientFrameRate);
+};
+template struct TestMemberAccess<ClientFrameRate, &CGameClient::m_framerate>;
+
+struct ClientGamePath
+{
+  using Type = std::string CGameClient::*;
+  friend Type GetMember(ClientGamePath);
+};
+template struct TestMemberAccess<ClientGamePath, &CGameClient::m_gamePath>;
+
+struct PlaybackMemory
+{
+  using Type =
+      std::unique_ptr<KODI::RETRO::CDeltaPairMemoryStream> KODI::RETRO::CReversiblePlayback::*;
+  friend Type GetMember(PlaybackMemory);
+};
+template struct TestMemberAccess<PlaybackMemory, &KODI::RETRO::CReversiblePlayback::m_memoryStream>;
+
+struct PlaybackDiscs
+{
+  using Type = KODI::RETRO::CDiscStateHistory KODI::RETRO::CReversiblePlayback::*;
+  friend Type GetMember(PlaybackDiscs);
+};
+template struct TestMemberAccess<PlaybackDiscs,
+                                 &KODI::RETRO::CReversiblePlayback::m_discStateHistory>;
+
+struct PlaybackTotalFrames
+{
+  using Type = uint64_t KODI::RETRO::CReversiblePlayback::*;
+  friend Type GetMember(PlaybackTotalFrames);
+};
+template struct TestMemberAccess<PlaybackTotalFrames,
+                                 &KODI::RETRO::CReversiblePlayback::m_totalFrameCount>;
+
+struct PlaybackRestoreFailed
+{
+  using Type = bool KODI::RETRO::CReversiblePlayback::*;
+  friend Type GetMember(PlaybackRestoreFailed);
+};
+template struct TestMemberAccess<PlaybackRestoreFailed,
+                                 &KODI::RETRO::CReversiblePlayback::m_restoreFailed>;
+
+struct PlaybackStats
+{
+  using Type = void (KODI::RETRO::CReversiblePlayback::*)();
+  friend Type GetMember(PlaybackStats);
+};
+template struct TestMemberAccess<PlaybackStats,
+                                 &KODI::RETRO::CReversiblePlayback::UpdatePlaybackStats>;
+
+struct PlaybackSaveTasks
+{
+  using Type = std::vector<std::future<void>> KODI::RETRO::CReversiblePlayback::*;
+  friend Type GetMember(PlaybackSaveTasks);
+};
+template struct TestMemberAccess<PlaybackSaveTasks,
+                                 &KODI::RETRO::CReversiblePlayback::m_savestateThreads>;
+
+struct DiscCore
+{
+  std::vector<std::string> slots;
+  unsigned int selected{0};
+  bool ejected{false};
+  unsigned int mutations{0};
+  unsigned int addCalls{0};
+  unsigned int removeCalls{0};
+  unsigned int modelQueries{0};
+  bool failReplace{false};
+  bool failClose{false};
+  uint8_t machineFrame{3};
+  uint8_t failedFrame{0};
+  bool failAllFrames{false};
+  bool failCloseAfterDeserialize{false};
+  bool changeDiscOnRun{false};
+  std::string rewindFramePath;
+  std::string replacementAfterDeserialize;
+  unsigned int runFrameCalls{0};
+  unsigned int inputPollCalls{0};
+  bool pendingInput{false};
+  bool polledInput{false};
+  std::vector<bool> frameInputs;
+  bool compactRemoval{false};
+  std::string initialPath;
+  unsigned int initialIndex{0};
+  bool failInitialImage{false};
+  unsigned int deserializeCalls{0};
+  std::vector<std::string> deserializedSlots;
+  std::string machinePath;
+};
+
+class TestStreams : public RETRO::IStreamManager
+{
+public:
+  RETRO::StreamPtr CreateStream(RETRO::StreamType) override { return {}; }
+  void CloseStream(RETRO::StreamPtr) override {}
+  void SetVideoFps(float) override {}
+  RETRO::HwProcedureAddress GetHwProcedureAddress(const char*) override { return nullptr; }
+};
+
+class TestInput : public IGameInputCallback
+{
+public:
+  TestInput(DiscCore& core, CCriticalSection& clientAccess)
+    : m_core(core),
+      m_clientAccess(clientAccess)
+  {
+  }
+
+  bool AcceptsInput() const override { return true; }
+
+  void PollInput() override
+  {
+    // The real event scanner calls back into the client on another thread.
+    EXPECT_TRUE(std::async(std::launch::async,
+                           [this]
+                           {
+                             std::unique_lock lock(m_clientAccess, std::try_to_lock);
+                             return lock.owns_lock();
+                           })
+                    .get());
+    ++m_core.inputPollCalls;
+    m_core.polledInput = std::exchange(m_core.pendingInput, false);
+  }
+
+private:
+  DiscCore& m_core;
+  CCriticalSection& m_clientAccess;
+};
+
+DiscCore& Core(const AddonInstance_Game* instance)
+{
+  return *static_cast<DiscCore*>(instance->toAddon->addonInstance);
+}
+} // namespace
 
 namespace KODI::GAME
 {
@@ -44,12 +248,95 @@ protected:
         ADDON::CAddonInfoBuilder::Generate(xml.RootElement(), ADDON::RepositoryDirInfo{});
     ASSERT_NE(info, nullptr);
     m_client = std::make_unique<CGameClient>(info);
-    m_client->GetInstanceInterface()->toAddon->SetInitialImage =
-        [](const AddonInstance_Game*, unsigned int, const char*) { return GAME_ERROR_NO_ERROR; };
+    auto* callbacks = m_client->GetInstanceInterface()->toAddon;
+    callbacks->addonInstance = &m_core;
+    callbacks->GetEjectState = [](const AddonInstance_Game* game) { return Core(game).ejected; };
+    callbacks->SetEjectState = [](const AddonInstance_Game* game, bool ejected)
+    {
+      if (!ejected && Core(game).failClose)
+        return GAME_ERROR_FAILED;
+      Core(game).ejected = ejected;
+      ++Core(game).mutations;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->GetImageCount = [](const AddonInstance_Game* game)
+    {
+      ++Core(game).modelQueries;
+      return static_cast<unsigned int>(Core(game).slots.size());
+    };
+    callbacks->GetImageIndex = [](const AddonInstance_Game* game) { return Core(game).selected; };
+    callbacks->SetImageIndex = [](const AddonInstance_Game* game, unsigned int index)
+    {
+      Core(game).selected = index;
+      ++Core(game).mutations;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->AddImageIndex = [](const AddonInstance_Game* game)
+    {
+      Core(game).slots.emplace_back();
+      ++Core(game).addCalls;
+      ++Core(game).mutations;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->ReplaceImageIndex =
+        [](const AddonInstance_Game* game, unsigned int index, const char* path)
+    {
+      auto& core = Core(game);
+      if (core.failReplace || index >= core.slots.size() || !core.ejected)
+        return GAME_ERROR_FAILED;
+      core.slots[index] = path ? path : "";
+      ++core.mutations;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->RemoveImageIndex = [](const AddonInstance_Game* game, unsigned int index)
+    {
+      ++Core(game).removeCalls;
+      if (index >= Core(game).slots.size())
+        return GAME_ERROR_FAILED;
+      if (Core(game).compactRemoval)
+        Core(game).slots.erase(Core(game).slots.begin() + index);
+      else
+        Core(game).slots[index].clear();
+      ++Core(game).mutations;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->SetInitialImage =
+        [](const AddonInstance_Game* game, unsigned int index, const char* path)
+    {
+      Core(game).initialIndex = index;
+      Core(game).initialPath = path ? path : "";
+      return Core(game).failInitialImage ? GAME_ERROR_FAILED : GAME_ERROR_NO_ERROR;
+    };
+    callbacks->GetImagePath = [](const AddonInstance_Game* game, unsigned int index) -> char*
+    {
+      return index < Core(game).slots.size() && !Core(game).slots[index].empty()
+                 ? strdup(Core(game).slots[index].c_str())
+                 : nullptr;
+    };
+    callbacks->GetImageLabel = [](const AddonInstance_Game*, unsigned int) -> char*
+    { return nullptr; };
+    callbacks->FreeString = [](const AddonInstance_Game*, char* string) { free(string); };
+    callbacks->Deserialize = [](const AddonInstance_Game* game, const uint8_t* data, size_t size)
+    {
+      auto& core = Core(game);
+      ++core.deserializeCalls;
+      core.deserializedSlots = core.slots;
+      if (size < 2 || core.selected != data[0] || core.selected >= core.slots.size())
+        return GAME_ERROR_FAILED;
+      const std::string path(reinterpret_cast<const char*>(data + 1), size - 1);
+      if (core.slots[core.selected] != path)
+        return GAME_ERROR_FAILED;
+      core.machinePath = path;
+      return GAME_ERROR_NO_ERROR;
+    };
   }
 
   void TearDown() override
   {
+    m_playback.reset();
+    m_playbackEnvironment.reset();
+    if (m_client)
+      TestMember<ClientPlaying>(*m_client) = false;
     for (auto* file : m_files)
     {
       const std::string path = XBMC_TEMPFILEPATH(file);
@@ -75,10 +362,578 @@ protected:
     return XBMC_TEMPFILEPATH(file);
   }
 
+  bool InitializeGameplay(const std::string& gamePath, bool validTiming = true)
+  {
+    m_playbackEnvironment = std::make_unique<RETRO::CPlaybackTestEnvironment>();
+    auto* callbacks = m_client->GetInstanceInterface()->toAddon;
+    callbacks->RequiresGameLoop = [](const AddonInstance_Game*) { return true; };
+    callbacks->GetGameTiming = [](const AddonInstance_Game*, game_system_timing* timing)
+    {
+      timing->fps = 1.0;
+      timing->sample_rate = 44100.0;
+      return GAME_ERROR_NO_ERROR;
+    };
+    if (!validTiming)
+      callbacks->GetGameTiming = [](const AddonInstance_Game*, game_system_timing*)
+      { return GAME_ERROR_FAILED; };
+    callbacks->GetRegion = [](const AddonInstance_Game*) { return GAME_REGION_NTSC; };
+    callbacks->SerializeSize = [](const AddonInstance_Game*) -> size_t { return 1; };
+    callbacks->UnloadGame = [](const AddonInstance_Game*) { return GAME_ERROR_NO_ERROR; };
+    callbacks->LoadGame = [](const AddonInstance_Game*, const char*) { return GAME_ERROR_FAILED; };
+    callbacks->GetMemory = [](const AddonInstance_Game*, GAME_MEMORY, uint8_t** data, size_t* size)
+    {
+      *data = nullptr;
+      *size = 0;
+      return GAME_ERROR_NO_ERROR;
+    };
+    TestStreams streams;
+    return (m_client.get()->*GetMember(ClientInitializeGameplay{}))(gamePath, streams, nullptr);
+  }
+
+  void StartPlaying()
+  {
+    TestMember<ClientPlaying>(*m_client) = true;
+    TestMember<ClientFrameRun>(*m_client) = true;
+    m_client->Discs().RefreshDiscState();
+  }
+
+  RestoreResult Deserialize(const CGameClientDiscModel& target,
+                            uint8_t selected,
+                            const std::string& path)
+  {
+    std::vector<uint8_t> data{selected};
+    data.insert(data.end(), path.begin(), path.end());
+    return m_client->Deserialize(data.data(), data.size(), &target);
+  }
+
+  void CreatePlayback(const CGameClientDiscModel* firstFrameDiscs = nullptr,
+                      const CGameClientDiscModel* lastFrameDiscs = nullptr)
+  {
+    TestMember<ClientSerializeSize>(*m_client) = 1;
+    TestMember<ClientFrameRate>(*m_client) = 1.0;
+    TestMember<ClientGamePath>(*m_client) = m_core.slots.front();
+    auto* callbacks = m_client->GetInstanceInterface()->toAddon;
+    callbacks->Deserialize = [](const AddonInstance_Game* game, const uint8_t* data, size_t)
+    {
+      auto& core = Core(game);
+      ++core.deserializeCalls;
+      core.machineFrame = 99;
+      if (core.failAllFrames || data[0] == core.failedFrame)
+        return GAME_ERROR_FAILED;
+      if (data[0] == 2 && !core.rewindFramePath.empty() &&
+          (core.ejected || core.selected >= core.slots.size() ||
+           core.slots[core.selected] != core.rewindFramePath))
+        return GAME_ERROR_FAILED;
+      core.machineFrame = data[0];
+      if (!core.replacementAfterDeserialize.empty())
+      {
+        core.slots[0] = core.replacementAfterDeserialize;
+        core.failReplace = true;
+      }
+      core.failClose = core.failCloseAfterDeserialize;
+      if (core.failClose)
+        core.ejected = true;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->Serialize = [](const AddonInstance_Game* game, uint8_t* data, size_t)
+    {
+      data[0] = Core(game).machineFrame;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->RunFrame = [](const AddonInstance_Game* game)
+    {
+      auto& core = Core(game);
+      ++core.runFrameCalls;
+      core.frameInputs.push_back(core.polledInput);
+      ++core.machineFrame;
+      if (core.changeDiscOnRun)
+      {
+        core.selected = 1;
+        core.ejected = true;
+      }
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->AudioAvailable = [](const AddonInstance_Game*)
+    { return GAME_ERROR_NOT_IMPLEMENTED; };
+    callbacks->AchievementStateSize = [](const AddonInstance_Game*) -> size_t { return 1; };
+    callbacks->SerializeAchievements = [](const AddonInstance_Game* game, uint8_t* data, size_t)
+    {
+      data[0] = Core(game).machineFrame;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->DeserializeAchievements = [](const AddonInstance_Game*, const uint8_t*, size_t)
+    { return GAME_ERROR_NO_ERROR; };
+    m_playbackEnvironment = std::make_unique<RETRO::CPlaybackTestEnvironment>();
+    m_playback = std::make_unique<RETRO::CReversiblePlayback>(
+        m_client.get(), m_playbackEnvironment->Renderer(), m_playbackEnvironment->Messenger(), 1.0,
+        1);
+    TestMember<PlaybackMemory>(*m_playback) = std::make_unique<RETRO::CDeltaPairMemoryStream>();
+    TestMember<PlaybackMemory>(*m_playback)->Init(1, 10);
+    const auto discID = TestMember<PlaybackDiscs>(*m_playback).Intern(m_client->Discs().GetDiscs());
+    for (uint8_t frame = 1; frame <= 3; ++frame)
+    {
+      *TestMember<PlaybackMemory>(*m_playback)->BeginFrame() = frame;
+      const auto* discs = frame == 1 ? firstFrameDiscs : frame == 3 ? lastFrameDiscs : nullptr;
+      const auto frameDiscID =
+          discs ? TestMember<PlaybackDiscs>(*m_playback).Intern(*discs) : discID;
+      TestMember<PlaybackMemory>(*m_playback)->SubmitFrame(frameDiscID, frame);
+    }
+    TestMember<PlaybackTotalFrames>(*m_playback) = 3;
+    (m_playback.get()->*GetMember(PlaybackStats{}))();
+    m_playback->SetSpeed(2.0);
+  }
+
+  bool RestoreFailureLatched() const { return TestMember<PlaybackRestoreFailed>(*m_playback); }
+
+  std::string WriteSavestate(const CGameClientDiscModel* discs)
+  {
+    RETRO::CSavestateFlatBuffer save;
+    *save.GetMemoryBuffer(1) = 1;
+    save.SetTimestampFrames(1);
+    if (discs)
+      save.SetDiscState(discs->GetState());
+    save.Finalize();
+    const std::string path = CreateFile(".sav");
+    EXPECT_TRUE(RETRO::CSavestateDatabase().AddSavestate(path, m_client->GetGamePath(), save));
+    return path;
+  }
+
+  std::string CaptureSavestate()
+  {
+    const auto path = CreateFile(".sav");
+    EXPECT_EQ(m_playback->CreateSavestate(false, path), path);
+    for (auto& task : TestMember<PlaybackSaveTasks>(*m_playback))
+      task.wait();
+    return path;
+  }
+
+  std::vector<uint8_t> ReadFile(const std::string& path)
+  {
+    std::vector<uint8_t> data;
+    XFILE::CFile file;
+    EXPECT_GT(file.LoadFile(path, data), 0);
+    return data;
+  }
+
+  struct DiscFileSnapshot
+  {
+    std::string path;
+    std::vector<uint8_t> contents;
+  };
+
+  std::vector<DiscFileSnapshot> SnapshotDiscFiles()
+  {
+    m_client->Discs().SaveDiscState();
+    std::vector<DiscFileSnapshot> files;
+    for (const auto& path : {CGameClientDiscXML::GetXMLPath(m_client->GetGamePath()),
+                             CGameClientDiscM3U::GetM3UPath(m_client->GetGamePath())})
+    {
+      files.push_back({path, ReadFile(path)});
+    }
+    return files;
+  }
+
+  void ExpectDiscFilesUnchanged(const std::vector<DiscFileSnapshot>& files)
+  {
+    for (const auto& file : files)
+    {
+      EXPECT_EQ(ReadFile(file.path), file.contents);
+    }
+  }
+
+  template<typename Edit>
+  void ExpectRewindCursorSaveRoundtrip(Edit edit)
+  {
+    m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+    m_core.rewindFramePath = m_core.slots[0];
+    StartPlaying();
+    CreatePlayback();
+    m_playback->RewindEvent();
+    m_playback->SetSpeed(0.0);
+    ASSERT_EQ(m_core.machineFrame, 3);
+    ASSERT_EQ(m_playback->GetTimeMs(), 2000U);
+    const auto historical = m_client->Discs().GetDiscs();
+    auto edited = historical;
+    edit(edited, CreateFile(".chd"));
+    m_client->Discs().SetDiscModel(edited);
+    ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+    ASSERT_TRUE(edited == historical);
+    const auto expected = historical.GetState();
+
+    const auto path = CaptureSavestate();
+
+    EXPECT_EQ(m_core.machineFrame, 3);
+    EXPECT_TRUE(m_client->Discs().GetDiscs() == edited);
+    const auto discID = TestMember<PlaybackMemory>(*m_playback)->GetDiscStateID();
+    const auto* cursorDiscs = TestMember<PlaybackDiscs>(*m_playback).Get(discID);
+    ASSERT_NE(cursorDiscs, nullptr);
+    EXPECT_TRUE(*cursorDiscs == historical);
+    RETRO::CSavestateFlatBuffer saved;
+    ASSERT_TRUE(RETRO::CSavestateDatabase().GetSavestate(path, saved));
+    ASSERT_TRUE(saved.PrepareMemoryData(1));
+    EXPECT_EQ(saved.GetMemoryData()[0], 2);
+    EXPECT_EQ(saved.TimestampFrames(), 2U);
+    ASSERT_TRUE(saved.GetDiscState().has_value());
+    EXPECT_EQ(*saved.GetDiscState(), expected);
+
+    m_core.machineFrame = 99;
+    m_client->Discs().SetDiscModel(historical);
+    ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+    ASSERT_TRUE(m_playback->LoadSavestate(path));
+    EXPECT_EQ(m_core.machineFrame, 2);
+    EXPECT_EQ(TestMember<PlaybackTotalFrames>(*m_playback), 2U);
+    const auto restored = m_client->Discs().GetDiscs();
+    EXPECT_EQ(restored.GetState(), expected);
+    EXPECT_EQ(m_core.ejected, expected.trayEjected);
+    if (expected.selectedSlot < 0)
+    {
+      EXPECT_GE(m_core.selected, m_core.slots.size());
+    }
+    else
+    {
+      EXPECT_EQ(m_core.selected, static_cast<unsigned int>(expected.selectedSlot));
+    }
+    for (size_t i = 0; i < edited.Size(); ++i)
+    {
+      EXPECT_EQ(restored.GetPathByIndex(i), edited.GetPathByIndex(i));
+      ASSERT_LT(i, m_core.slots.size());
+      EXPECT_EQ(m_core.slots[i], edited.GetPathByIndex(i));
+    }
+    EXPECT_FALSE(RestoreFailureLatched());
+  }
+
+  template<typename Edit>
+  void ExpectRewindDiscEditSaveRejected(Edit edit)
+  {
+    m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+    StartPlaying();
+    CreatePlayback();
+    m_playback->RewindEvent();
+    m_playback->SetSpeed(0.0);
+    const auto historical = m_client->Discs().GetDiscs();
+    auto edited = historical;
+    edit(edited, CreateFile(".chd"));
+    ASSERT_FALSE(edited == historical);
+    m_client->Discs().SetDiscModel(edited);
+    ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+    const auto slots = m_core.slots;
+    const auto selected = m_core.selected;
+    const auto ejected = m_core.ejected;
+    const auto mutations = m_core.mutations;
+    const auto calls = m_core.deserializeCalls;
+
+    const auto path = CaptureSavestate();
+
+    XFILE::CFile file;
+    ASSERT_TRUE(file.Open(path));
+    EXPECT_EQ(file.GetLength(), 0);
+    file.Close();
+    EXPECT_EQ(m_core.machineFrame, 3);
+    EXPECT_EQ(m_core.slots, slots);
+    EXPECT_EQ(m_core.selected, selected);
+    EXPECT_EQ(m_core.ejected, ejected);
+    EXPECT_EQ(m_core.mutations, mutations);
+    EXPECT_EQ(m_core.deserializeCalls, calls);
+    EXPECT_TRUE(m_client->Discs().GetDiscs() == edited);
+    EXPECT_EQ(m_client->Discs().GetDiscs().GetKnownDiscPaths(), edited.GetKnownDiscPaths());
+    EXPECT_EQ(m_playback->GetTimeMs(), 2000U);
+    EXPECT_EQ(m_playback->GetSpeed(), 0.0);
+    const auto& memory = TestMember<PlaybackMemory>(*m_playback);
+    EXPECT_EQ(*memory->CurrentFrame(), 2);
+    EXPECT_EQ(memory->GetFrameCounter(), 2U);
+    const auto* cursorDiscs = TestMember<PlaybackDiscs>(*m_playback).Get(memory->GetDiscStateID());
+    ASSERT_NE(cursorDiscs, nullptr);
+    EXPECT_TRUE(*cursorDiscs == historical);
+    EXPECT_FALSE(RestoreFailureLatched());
+
+    m_playback->SetSpeed(1.0);
+    EXPECT_EQ(m_playback->GetSpeed(), 1.0);
+    m_playback->FrameEvent();
+    EXPECT_EQ(m_core.machineFrame, 3);
+    RETRO::CSavestateFlatBuffer saved;
+    ASSERT_TRUE(RETRO::CSavestateDatabase().GetSavestate(CaptureSavestate(), saved));
+    ASSERT_TRUE(saved.PrepareMemoryData(1));
+    EXPECT_EQ(saved.GetMemoryData()[0], 3);
+    EXPECT_EQ(saved.TimestampFrames(), 3U);
+    ASSERT_TRUE(saved.GetDiscState().has_value());
+    EXPECT_EQ(*saved.GetDiscState(), edited.GetState());
+    EXPECT_FALSE(RestoreFailureLatched());
+  }
+
+  void ExpectRewindPreviewResume(bool changeDiscOnRun)
+  {
+    m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+    StartPlaying();
+    CreatePlayback();
+    m_input = std::make_unique<TestInput>(m_core, *m_client->LockForSnapshot().mutex());
+    TestMember<ClientInput>(*m_client) = m_input.get();
+    auto previewDiscs = m_client->Discs().GetDiscs();
+    m_core.changeDiscOnRun = changeDiscOnRun;
+    if (changeDiscOnRun)
+    {
+      ASSERT_TRUE(previewDiscs.SetSelectedDiscByIndex(1));
+      previewDiscs.SetEjected(true);
+    }
+
+    const auto persisted = SnapshotDiscFiles();
+    m_playback->RewindEvent();
+
+    const auto& memory = TestMember<PlaybackMemory>(*m_playback);
+    ASSERT_EQ(*memory->CurrentFrame(), 2);
+    ASSERT_EQ(memory->GetFrameCounter(), 2U);
+    ASSERT_EQ(memory->FutureFramesAvailable(), 1U);
+    ASSERT_EQ(TestMember<PlaybackTotalFrames>(*m_playback), 2U);
+    ASSERT_EQ(m_core.machineFrame, 3);
+    ASSERT_EQ(m_core.runFrameCalls, 1U);
+    ASSERT_EQ(m_core.inputPollCalls, 1U);
+    ASSERT_EQ(m_core.frameInputs, std::vector<bool>{false});
+    ASSERT_EQ(m_core.selected, changeDiscOnRun ? 1U : 0U);
+    ASSERT_EQ(m_core.ejected, changeDiscOnRun);
+
+    m_core.pendingInput = true;
+    m_playback->SetSpeed(1.0);
+    m_playback->FrameEvent();
+
+    EXPECT_EQ(m_core.machineFrame, 3);
+    EXPECT_EQ(m_core.runFrameCalls, 1U);
+    EXPECT_EQ(m_core.inputPollCalls, 1U);
+    EXPECT_TRUE(m_core.pendingInput);
+    EXPECT_EQ(m_core.frameInputs, std::vector<bool>{false});
+    EXPECT_EQ(*memory->CurrentFrame(), 3);
+    EXPECT_EQ(memory->GetFrameCounter(), 3U);
+    EXPECT_EQ(TestMember<PlaybackTotalFrames>(*m_playback), 3U);
+    EXPECT_EQ(memory->PastFramesAvailable(), 2U);
+    EXPECT_EQ(memory->FutureFramesAvailable(), 0U);
+    EXPECT_TRUE(m_client->Discs().GetDiscs() == previewDiscs);
+    const auto* committedDiscs =
+        TestMember<PlaybackDiscs>(*m_playback).Get(memory->GetDiscStateID());
+    ASSERT_NE(committedDiscs, nullptr);
+    EXPECT_TRUE(*committedDiscs == previewDiscs);
+    RETRO::CSavestateFlatBuffer saved;
+    ASSERT_TRUE(RETRO::CSavestateDatabase().GetSavestate(CaptureSavestate(), saved));
+    ASSERT_TRUE(saved.PrepareMemoryData(1));
+    EXPECT_EQ(saved.GetMemoryData()[0], 3);
+    EXPECT_EQ(saved.TimestampFrames(), 3U);
+    ASSERT_TRUE(saved.GetDiscState().has_value());
+    EXPECT_EQ(*saved.GetDiscState(), previewDiscs.GetState());
+    ASSERT_EQ(saved.GetAchievementSize(), 1U);
+    EXPECT_EQ(saved.GetAchievementData()[0], 3);
+
+    m_playback->FrameEvent();
+
+    EXPECT_EQ(m_core.machineFrame, 4);
+    EXPECT_EQ(m_core.runFrameCalls, 2U);
+    EXPECT_EQ(m_core.inputPollCalls, 2U);
+    EXPECT_EQ(m_core.frameInputs, (std::vector<bool>{false, true}));
+    EXPECT_EQ(*memory->CurrentFrame(), 4);
+    EXPECT_EQ(memory->GetFrameCounter(), 4U);
+    EXPECT_EQ(TestMember<PlaybackTotalFrames>(*m_playback), 4U);
+    EXPECT_EQ(memory->FutureFramesAvailable(), 0U);
+    ExpectDiscFilesUnchanged(persisted);
+    EXPECT_FALSE(RestoreFailureLatched());
+  }
+
+  void ExpectUnsupportedSavestateRejected(bool selectUnsupported)
+  {
+    const auto disc1 = CreateFile(".chd");
+    const auto disc2 = CreateFile(".unsupported");
+    m_core.slots = {disc1};
+    StartPlaying();
+    CreatePlayback();
+    auto current = m_client->Discs().GetDiscs();
+    current.RememberDiscPath(disc2);
+    m_client->Discs().SetDiscModel(current);
+    CGameClientDiscModel historical;
+    historical.AddDisc(disc1);
+    historical.AddDisc(disc2);
+    ASSERT_TRUE(historical.SetSelectedDiscByIndex(selectUnsupported ? 1 : 0));
+    CGameClientDiscModel resolved;
+    ASSERT_TRUE(current.ResolveState(historical.GetState(), resolved));
+    ASSERT_EQ(resolved.GetPathByIndex(1), disc2);
+    const auto path = WriteSavestate(&historical);
+    const auto mutations = m_core.mutations;
+    const auto calls = m_core.deserializeCalls;
+
+    EXPECT_FALSE(m_playback->LoadSavestate(path));
+
+    EXPECT_EQ(m_core.deserializeCalls, calls);
+    EXPECT_EQ(m_core.mutations, mutations);
+    EXPECT_EQ(m_core.machineFrame, 3);
+    EXPECT_EQ(m_core.slots, (std::vector<std::string>{disc1}));
+    EXPECT_EQ(m_core.selected, 0U);
+    EXPECT_FALSE(m_core.ejected);
+    EXPECT_TRUE(m_client->Discs().GetDiscs() == current);
+    EXPECT_EQ(m_client->Discs().GetDiscs().GetKnownDiscPaths(), current.GetKnownDiscPaths());
+    EXPECT_EQ(m_playback->GetSpeed(), 2.0);
+    EXPECT_FALSE(RestoreFailureLatched());
+  }
+
+  void ExpectFailedDiscAddition(bool compactRemoval, bool reuseTail)
+  {
+    CGameClientDiscModel current;
+    current.AddDisc("/roms/disc1.chd");
+    current.SetEjected(true);
+    m_core.slots = {"/roms/disc1.chd"};
+    if (reuseTail)
+      m_core.slots.emplace_back("/roms/existing-tail.chd");
+    m_core.compactRemoval = compactRemoval;
+    m_core.ejected = true;
+    m_core.failReplace = true;
+    m_client->Discs().SetDiscModel(current);
+    auto expectedSlots = m_core.slots;
+    if (!reuseTail && !compactRemoval)
+      expectedSlots.emplace_back();
+
+    EXPECT_FALSE(m_client->Discs().AddDisc("/roms/new-disc.chd"));
+
+    EXPECT_EQ(m_core.slots, expectedSlots);
+    EXPECT_EQ(m_core.addCalls, reuseTail ? 0U : 1U);
+    EXPECT_EQ(m_core.removeCalls, reuseTail ? 0U : 1U);
+    EXPECT_EQ(m_core.selected, 0U);
+    EXPECT_TRUE(m_core.ejected);
+    EXPECT_TRUE(m_client->Discs().GetDiscs() == current);
+    EXPECT_EQ(m_client->Discs().GetDiscs().GetKnownDiscPaths(), current.GetKnownDiscPaths());
+  }
+
+  void ExpectSavestateCanBeCreated()
+  {
+    const auto path = CreateFile(".sav");
+    EXPECT_EQ(m_playback->CreateSavestate(false, path), path);
+    m_playback->Deinitialize();
+    RETRO::CSavestateFlatBuffer save;
+    ASSERT_TRUE(RETRO::CSavestateDatabase().GetSavestate(path, save));
+    ASSERT_TRUE(save.PrepareMemoryData(1));
+    EXPECT_EQ(save.GetMemoryData()[0], 3);
+  }
+
+  std::unique_ptr<RETRO::CPlaybackTestEnvironment> m_playbackEnvironment;
+  std::unique_ptr<RETRO::CReversiblePlayback> m_playback;
+  DiscCore m_core;
+  std::unique_ptr<TestInput> m_input;
   std::unique_ptr<CGameClient> m_client;
   std::vector<XFILE::CFile*> m_files;
 };
 } // namespace KODI::GAME
+
+TEST_F(TestGameClientDiscs, OlderDiscModelKeepsLaterMediaIdentity)
+{
+  const std::string path = CreateFile(".chd");
+  ASSERT_FALSE(path.empty());
+  CGameClientDiscModel later;
+  later.AddDisc(path);
+  const auto state = later.GetState();
+  m_client->Discs().SetDiscModel(later);
+  m_client->Discs().SetDiscModel({});
+
+  const auto current = m_client->Discs().GetDiscs();
+  EXPECT_TRUE(current.Empty());
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(current.ResolveState(state, restored));
+  EXPECT_EQ(restored.GetPathByIndex(0), path);
+}
+
+TEST_F(TestGameClientDiscs, UnchangedDiscModelCanLearnMediaIdentity)
+{
+  const std::string path = CreateFile(".chd");
+  ASSERT_FALSE(path.empty());
+  CGameClientDiscModel history;
+  history.AddDisc(path);
+  const auto state = history.GetState();
+  ASSERT_TRUE(history.EraseDiscByIndex(0));
+  m_client->Discs().SetDiscModel(history);
+
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(m_client->Discs().GetDiscs().ResolveState(state, restored));
+  EXPECT_EQ(restored.GetPathByIndex(0), path);
+}
+
+TEST_F(TestGameClientDiscs, EmptyPersistedStateLearnsOriginalPlaylistWithoutActivatingIt)
+{
+  const std::string disc = CreateFile(".chd");
+  const std::string playlist = CreateFile(".m3u", disc + "\n");
+  ASSERT_FALSE(disc.empty());
+  ASSERT_FALSE(playlist.empty());
+  CGameClientDiscXML xml;
+  ASSERT_TRUE(xml.Save(playlist, {}));
+  CGameClientDiscModel historical;
+  historical.AddDisc(disc);
+
+  m_client->Discs().Initialize(playlist);
+
+  EXPECT_TRUE(m_client->Discs().HasPersistedState());
+  const auto current = m_client->Discs().GetDiscs();
+  EXPECT_TRUE(current.Empty());
+  EXPECT_TRUE(current.IsSelectedNoDisc());
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(current.ResolveState(historical.GetState(), restored));
+  EXPECT_EQ(restored.GetPathByIndex(0), disc);
+}
+
+TEST_F(TestGameClientDiscs, StartupPruningPreservesRemovedMediaFromXML)
+{
+  const std::string disc = CreateFile(".chd");
+  const std::string playlist = CreateFile(".m3u");
+  ASSERT_FALSE(disc.empty());
+  ASSERT_FALSE(playlist.empty());
+  CGameClientDiscModel previous;
+  previous.AddDisc(disc);
+  const auto state = previous.GetState();
+  ASSERT_TRUE(previous.MarkRemovedByIndex(0));
+  CGameClientDiscXML xml;
+  ASSERT_TRUE(xml.Save(playlist, previous));
+
+  m_client->Discs().Initialize(playlist);
+
+  EXPECT_TRUE(m_client->Discs().HasPersistedState());
+  const auto current = m_client->Discs().GetDiscs();
+  EXPECT_TRUE(current.Empty());
+  EXPECT_TRUE(current.IsSelectedNoDisc());
+  CGameClientDiscModel restored;
+  ASSERT_TRUE(current.ResolveState(state, restored));
+  EXPECT_EQ(restored.GetPathByIndex(0), disc);
+}
+
+TEST_F(TestGameClientDiscs, MissingHistoricalMediaDoesNotInvalidateCurrentPlaylist)
+{
+  const std::string disc = CreateFile(".chd");
+  const std::string playlist = CreateFile(".m3u", disc + "\n");
+  ASSERT_FALSE(disc.empty());
+  ASSERT_FALSE(playlist.empty());
+  CGameClientDiscModel persisted;
+  persisted.AddDisc(disc);
+  persisted.RememberDiscPath("/missing/historical-disc.chd");
+  persisted.SetEjected(true);
+  ASSERT_TRUE(CGameClientDiscXML::Save(playlist, persisted));
+
+  m_client->Discs().Initialize(playlist);
+
+  EXPECT_TRUE(m_client->Discs().HasPersistedState());
+  const auto current = m_client->Discs().GetDiscs();
+  EXPECT_EQ(current, persisted);
+  CGameClientDiscModel missing;
+  missing.AddDisc("/missing/historical-disc.chd");
+  CGameClientDiscModel resolved;
+  EXPECT_FALSE(current.ResolveState(missing.GetState(), resolved));
+}
+
+TEST_F(TestGameClientDiscs, NewSessionDiscardsPreviousMediaCatalog)
+{
+  const std::string previousDisc = CreateFile(".chd");
+  const std::string nextDisc = CreateFile(".chd");
+  ASSERT_FALSE(previousDisc.empty());
+  ASSERT_FALSE(nextDisc.empty());
+  m_client->Discs().Initialize(previousDisc);
+  const auto previousState = m_client->Discs().GetDiscs().GetState();
+  m_client->Discs().Deinitialize();
+  EXPECT_TRUE(m_client->Discs().GetDiscs().GetKnownDiscPaths().empty());
+
+  m_client->Discs().Initialize(nextDisc);
+
+  const auto current = m_client->Discs().GetDiscs();
+  EXPECT_EQ(current.GetKnownDiscPaths(), std::vector<std::string>{nextDisc});
+  CGameClientDiscModel resolved;
+  EXPECT_FALSE(current.ResolveState(previousState, resolved));
+}
 
 TEST_F(TestGameClientDiscs, InvalidPersistedSelectionFallsBackToSource)
 {
@@ -98,6 +953,7 @@ TEST_F(TestGameClientDiscs, InvalidPersistedSelectionFallsBackToSource)
 
   m_client->Discs().Initialize(playlist);
 
+  EXPECT_FALSE(m_client->Discs().HasPersistedState());
   const auto current = m_client->Discs().GetDiscs();
   EXPECT_EQ(current.GetPathByIndex(0), disc);
   EXPECT_EQ(current.GetSelectedDiscIndex(), 0U);
@@ -124,7 +980,1352 @@ TEST_F(TestGameClientDiscs, MalformedPersistedSlotCannotShiftSelectionOntoAnothe
 
   m_client->Discs().Initialize(playlist);
 
+  EXPECT_FALSE(m_client->Discs().HasPersistedState());
   const auto current = m_client->Discs().GetDiscs();
   EXPECT_EQ(current.Size(), 2U);
   EXPECT_EQ(current.GetSelectedDiscPath(), first);
+}
+
+TEST_F(TestGameClientDiscs, DeserializePreparesMediaAfterEmptyPlaylist)
+{
+  m_core.ejected = true;
+  StartPlaying();
+  CGameClientDiscModel target;
+  target.AddDisc("/roms/disc1.chd");
+  target.AddDisc("/roms/disc2.chd");
+  ASSERT_TRUE(target.SetSelectedDiscByIndex(1));
+
+  EXPECT_EQ(Deserialize(target, 1, "/roms/disc2.chd"), RestoreResult::Restored);
+
+  EXPECT_EQ(m_core.machinePath, "/roms/disc2.chd");
+  EXPECT_EQ(m_core.selected, 1U);
+  EXPECT_FALSE(m_core.ejected);
+}
+
+TEST_F(TestGameClientDiscs, DeserializePreparesReorderedMedia)
+{
+  m_core.slots = {"/roms/disc2.chd", "/roms/disc1.chd"};
+  StartPlaying();
+  CGameClientDiscModel target;
+  target.AddDisc("/roms/disc1.chd");
+  target.AddDisc("/roms/disc2.chd");
+  ASSERT_TRUE(target.SetSelectedDiscByIndex(1));
+
+  EXPECT_EQ(Deserialize(target, 1, "/roms/disc2.chd"), RestoreResult::Restored);
+
+  EXPECT_EQ(m_core.machinePath, "/roms/disc2.chd");
+  EXPECT_EQ(m_core.slots, (std::vector<std::string>{"/roms/disc1.chd", "/roms/disc2.chd"}));
+  EXPECT_EQ(m_core.selected, 1U);
+}
+
+TEST_F(TestGameClientDiscs, RejectedMediaPreparationSkipsDeserializeAndRestoresPreviousState)
+{
+  m_core.slots = {"/roms/disc1.chd"};
+  StartPlaying();
+  const CGameClientDiscModel previous = m_client->Discs().GetDiscs();
+  m_core.failReplace = true;
+  CGameClientDiscModel target;
+  target.AddDisc("/roms/disc2.chd");
+  target.SetEjected(true);
+
+  EXPECT_EQ(Deserialize(target, 0, "/roms/disc2.chd"), RestoreResult::Rejected);
+
+  EXPECT_EQ(m_core.deserializeCalls, 0U);
+  EXPECT_EQ(m_core.slots, (std::vector<std::string>{"/roms/disc1.chd"}));
+  EXPECT_EQ(m_core.selected, 0U);
+  EXPECT_FALSE(m_core.ejected);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == previous);
+}
+
+TEST_F(TestGameClientDiscs, FailedDeserializeRestoresPreviousMediaAndTray)
+{
+  m_core.slots = {"/roms/disc1.chd"};
+  m_core.ejected = true;
+  StartPlaying();
+  const CGameClientDiscModel previous = m_client->Discs().GetDiscs();
+  m_client->GetInstanceInterface()->toAddon->Deserialize =
+      [](const AddonInstance_Game* game, const uint8_t*, size_t)
+  {
+    ++Core(game).deserializeCalls;
+    Core(game).deserializedSlots = Core(game).slots;
+    return GAME_ERROR_FAILED;
+  };
+  CGameClientDiscModel target;
+  target.AddDisc("/roms/disc2.chd");
+
+  EXPECT_EQ(Deserialize(target, 0, "/roms/disc2.chd"), RestoreResult::StateUncertain);
+
+  EXPECT_EQ(m_core.deserializedSlots, (std::vector<std::string>{"/roms/disc2.chd"}));
+  EXPECT_EQ(m_core.slots, (std::vector<std::string>{"/roms/disc1.chd"}));
+  EXPECT_EQ(m_core.selected, 0U);
+  EXPECT_TRUE(m_core.ejected);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == previous);
+}
+
+TEST_F(TestGameClientDiscs, DeserializeReconcilesMediaChangedByCore)
+{
+  m_core.slots = {"/roms/disc1.chd", "/roms/disc2.chd"};
+  StartPlaying();
+  CGameClientDiscModel target = m_client->Discs().GetDiscs();
+  target.SetEjected(true);
+  m_client->GetInstanceInterface()->toAddon->Deserialize =
+      [](const AddonInstance_Game* game, const uint8_t*, size_t)
+  {
+    Core(game).slots = {"/roms/disc2.chd", "/roms/disc1.chd"};
+    Core(game).selected = 1;
+    Core(game).ejected = false;
+    return GAME_ERROR_NO_ERROR;
+  };
+
+  EXPECT_EQ(Deserialize(target, 0, "/roms/disc1.chd"), RestoreResult::Restored);
+
+  EXPECT_EQ(m_core.slots, (std::vector<std::string>{"/roms/disc1.chd", "/roms/disc2.chd"}));
+  EXPECT_EQ(m_core.selected, 0U);
+  EXPECT_TRUE(m_core.ejected);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == target);
+}
+
+TEST_F(TestGameClientDiscs, DeserializeReconcilesMediaWithoutPathMetadata)
+{
+  m_core.slots = {"/roms/disc1.chd", "/roms/disc2.chd"};
+  StartPlaying();
+  CGameClientDiscModel target = m_client->Discs().GetDiscs();
+  target.SetEjected(true);
+  m_client->GetInstanceInterface()->toAddon->GetImagePath =
+      [](const AddonInstance_Game*, unsigned int) -> char* { return nullptr; };
+  m_client->GetInstanceInterface()->toAddon->Deserialize =
+      [](const AddonInstance_Game* game, const uint8_t*, size_t)
+  {
+    Core(game).slots = {"/roms/disc2.chd", "/roms/disc1.chd"};
+    Core(game).selected = 1;
+    Core(game).ejected = false;
+    return GAME_ERROR_NO_ERROR;
+  };
+
+  EXPECT_EQ(Deserialize(target, 0, "/roms/disc1.chd"), RestoreResult::Restored);
+
+  EXPECT_EQ(m_core.slots, (std::vector<std::string>{"/roms/disc1.chd", "/roms/disc2.chd"}));
+  EXPECT_EQ(m_core.selected, 0U);
+  EXPECT_TRUE(m_core.ejected);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == target);
+}
+
+TEST_F(TestGameClientDiscs, FailedDeserializeRestoresUnchangedModelWithoutPathMetadata)
+{
+  m_core.slots = {"/roms/disc1.chd", "/roms/disc2.chd"};
+  StartPlaying();
+  const CGameClientDiscModel target = m_client->Discs().GetDiscs();
+  m_client->GetInstanceInterface()->toAddon->GetImagePath =
+      [](const AddonInstance_Game*, unsigned int) -> char* { return nullptr; };
+  m_client->GetInstanceInterface()->toAddon->Deserialize =
+      [](const AddonInstance_Game* game, const uint8_t*, size_t)
+  {
+    Core(game).slots = {"/roms/disc2.chd", "/roms/disc1.chd"};
+    return GAME_ERROR_FAILED;
+  };
+
+  EXPECT_EQ(Deserialize(target, 0, "/roms/disc1.chd"), RestoreResult::StateUncertain);
+
+  EXPECT_EQ(m_core.slots, (std::vector<std::string>{"/roms/disc1.chd", "/roms/disc2.chd"}));
+  EXPECT_EQ(m_core.selected, 0U);
+  EXPECT_FALSE(m_core.ejected);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == target);
+}
+
+TEST_F(TestGameClientDiscs, DeserializeRetriesClosedTrayWithoutLosingSavedOpenTray)
+{
+  m_core.slots = {"/roms/disc1.chd"};
+  m_core.ejected = true;
+  StartPlaying();
+  const CGameClientDiscModel target = m_client->Discs().GetDiscs();
+  m_client->GetInstanceInterface()->toAddon->Deserialize =
+      [](const AddonInstance_Game* game, const uint8_t*, size_t)
+  {
+    ++Core(game).deserializeCalls;
+    return Core(game).ejected ? GAME_ERROR_FAILED : GAME_ERROR_NO_ERROR;
+  };
+
+  EXPECT_EQ(Deserialize(target, 0, "/roms/disc1.chd"), RestoreResult::Restored);
+
+  EXPECT_EQ(m_core.deserializeCalls, 2U);
+  EXPECT_TRUE(m_core.ejected);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == target);
+}
+
+TEST_F(TestGameClientDiscs, LegacyDeserializeClosesTrayBeforeLoading)
+{
+  m_core.slots = {"/roms/disc1.chd"};
+  m_core.ejected = true;
+  StartPlaying();
+  m_client->GetInstanceInterface()->toAddon->Deserialize =
+      [](const AddonInstance_Game* game, const uint8_t*, size_t)
+  { return Core(game).ejected ? GAME_ERROR_FAILED : GAME_ERROR_NO_ERROR; };
+  const uint8_t data = 0;
+
+  EXPECT_EQ(m_client->Deserialize(&data, sizeof(data)), RestoreResult::Restored);
+
+  EXPECT_FALSE(m_core.ejected);
+}
+
+TEST_F(TestGameClientDiscs, RestoreHistoricalTopologyClearsRemovedAndExtraSlots)
+{
+  CGameClientDiscModel historical;
+  historical.AddDisc("/roms/disc1.chd", "One");
+  historical.AddRemovedSlot();
+  historical.AddDisc("/roms/disc2.chd", "Two");
+  ASSERT_TRUE(historical.SetSelectedDiscByIndex(2));
+  m_core.slots = {"/roms/disc2.chd", "/roms/reused.chd", "/roms/disc1.chd", "/roms/extra.chd"};
+  m_client->Discs().SetDiscModel(historical);
+  ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+  EXPECT_EQ(m_core.slots, (std::vector<std::string>{"/roms/disc1.chd", "", "/roms/disc2.chd", ""}));
+  EXPECT_EQ(m_core.selected, 2U);
+  EXPECT_FALSE(m_core.ejected);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == historical);
+  m_core.mutations = 0;
+  ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+  EXPECT_EQ(m_core.mutations, 0U);
+  m_client->Discs().RefreshDiscState();
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == historical);
+}
+
+TEST_F(TestGameClientDiscs, SourceRetryReplacesPersistedInitialHint)
+{
+  std::unique_ptr<XFILE::CFile> firstDisc(XBMC_CREATETEMPFILE(".chd"));
+  std::unique_ptr<XFILE::CFile> secondDisc(XBMC_CREATETEMPFILE(".chd"));
+  std::unique_ptr<XFILE::CFile> playlist(XBMC_CREATETEMPFILE(".m3u"));
+  ASSERT_NE(firstDisc, nullptr);
+  ASSERT_NE(secondDisc, nullptr);
+  ASSERT_NE(playlist, nullptr);
+  firstDisc->Close();
+  secondDisc->Close();
+  const std::string firstPath = XBMC_TEMPFILEPATH(firstDisc.get());
+  const std::string secondPath = XBMC_TEMPFILEPATH(secondDisc.get());
+  const std::string source = firstPath + "\n" + secondPath + "\n";
+  ASSERT_EQ(playlist->Write(source.data(), source.size()), static_cast<ssize_t>(source.size()));
+  playlist->Close();
+  const std::string gamePath = XBMC_TEMPFILEPATH(playlist.get());
+
+  CGameClientDiscModel persisted;
+  persisted.AddDisc(firstPath);
+  persisted.AddDisc(secondPath);
+  ASSERT_TRUE(persisted.SetSelectedDiscByIndex(1));
+  CGameClientDiscXML xml;
+  ASSERT_TRUE(xml.Save(gamePath, persisted));
+
+  m_client->Discs().Initialize(gamePath);
+  EXPECT_EQ(m_core.initialIndex, 1U);
+  EXPECT_EQ(m_core.initialPath, secondPath);
+
+  m_client->Discs().Initialize(gamePath, false);
+  EXPECT_EQ(m_core.initialIndex, 0U);
+  EXPECT_EQ(m_core.initialPath, firstPath);
+
+  XFILE::CFile::Delete(CGameClientDiscXML::GetXMLPath(gamePath));
+  XFILE::CFile::Delete(CGameClientDiscM3U::GetM3UPath(gamePath));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(playlist.release()));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(secondDisc.release()));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(firstDisc.release()));
+}
+
+TEST_F(TestGameClientDiscs, SourceRetryReplacesPersistedHintAfterCallbackFailure)
+{
+  std::unique_ptr<XFILE::CFile> firstDisc(XBMC_CREATETEMPFILE(".chd"));
+  std::unique_ptr<XFILE::CFile> secondDisc(XBMC_CREATETEMPFILE(".chd"));
+  std::unique_ptr<XFILE::CFile> playlist(XBMC_CREATETEMPFILE(".m3u"));
+  ASSERT_NE(firstDisc, nullptr);
+  ASSERT_NE(secondDisc, nullptr);
+  ASSERT_NE(playlist, nullptr);
+  firstDisc->Close();
+  secondDisc->Close();
+  const std::string firstPath = XBMC_TEMPFILEPATH(firstDisc.get());
+  const std::string secondPath = XBMC_TEMPFILEPATH(secondDisc.get());
+  const std::string source = firstPath + "\n" + secondPath + "\n";
+  ASSERT_EQ(playlist->Write(source.data(), source.size()), static_cast<ssize_t>(source.size()));
+  playlist->Close();
+  const std::string gamePath = XBMC_TEMPFILEPATH(playlist.get());
+
+  CGameClientDiscModel persisted;
+  persisted.AddDisc(firstPath);
+  persisted.AddDisc(secondPath);
+  ASSERT_TRUE(persisted.SetSelectedDiscByIndex(1));
+  CGameClientDiscXML xml;
+  ASSERT_TRUE(xml.Save(gamePath, persisted));
+
+  m_core.failInitialImage = true;
+  m_client->Discs().Initialize(gamePath);
+  EXPECT_EQ(m_core.initialIndex, 1U);
+  EXPECT_EQ(m_core.initialPath, secondPath);
+
+  m_client->Discs().Initialize(gamePath, false);
+  EXPECT_EQ(m_core.initialIndex, 0U);
+  EXPECT_EQ(m_core.initialPath, firstPath);
+
+  XFILE::CFile::Delete(CGameClientDiscXML::GetXMLPath(gamePath));
+  XFILE::CFile::Delete(CGameClientDiscM3U::GetM3UPath(gamePath));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(playlist.release()));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(secondDisc.release()));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(firstDisc.release()));
+}
+
+TEST_F(TestGameClientDiscs, RestoreSelectionAndTrayIndependently)
+{
+  for (const bool ejected : {false, true})
+  {
+    for (const bool noDisc : {false, true})
+    {
+      CGameClientDiscModel historical;
+      historical.AddDisc("/roms/disc1.chd");
+      historical.AddDisc("/roms/disc2.chd");
+      ASSERT_TRUE(historical.SetSelectedDiscByIndex(1));
+      if (noDisc)
+        historical.SetSelectedNoDisc();
+      historical.SetEjected(ejected);
+      m_core.slots = {"/roms/disc1.chd", "/roms/disc2.chd"};
+      m_core.selected = 0;
+      m_core.ejected = !ejected;
+      m_client->Discs().SetDiscModel(historical);
+      ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+      EXPECT_EQ(m_core.selected, noDisc ? 2U : 1U);
+      EXPECT_EQ(m_core.ejected, ejected);
+    }
+  }
+}
+
+TEST_F(TestGameClientDiscs, NoDiscAcceptsCoreSentinelBeyondImageCount)
+{
+  m_client->GetInstanceInterface()->toAddon->GetImageIndex = [](const AddonInstance_Game* game)
+  {
+    return Core(game).selected < Core(game).slots.size() ? Core(game).selected
+                                                         : std::numeric_limits<unsigned int>::max();
+  };
+  for (const bool ejected : {false, true})
+  {
+    CGameClientDiscModel historical;
+    historical.AddDisc("/roms/disc1.chd", "One");
+    historical.AddDisc("/roms/disc2.chd", "Two");
+    historical.SetSelectedNoDisc();
+    historical.SetEjected(ejected);
+    m_core.slots = {"/roms/disc1.chd", "/roms/disc2.chd"};
+    m_core.selected = 0;
+    m_core.ejected = !ejected;
+    m_client->Discs().SetDiscModel(historical);
+    ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+    EXPECT_EQ(m_core.selected, 2U);
+    EXPECT_EQ(m_core.ejected, ejected);
+    m_core.mutations = 0;
+    ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+    EXPECT_EQ(m_core.mutations, 0U);
+    m_client->Discs().RefreshDiscState();
+    EXPECT_TRUE(m_client->Discs().GetDiscs() == historical);
+  }
+}
+
+TEST_F(TestGameClientDiscs, PrepareDeserializePreservesHistoricalTrayModel)
+{
+  CGameClientDiscModel historical;
+  historical.AddDisc("/roms/disc1.chd");
+  historical.SetEjected(true);
+  m_client->Discs().SetDiscModel(historical);
+  m_core.ejected = true;
+  ASSERT_TRUE(m_client->Discs().PrepareForDeserialize());
+  EXPECT_FALSE(m_core.ejected);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == historical);
+  m_core.mutations = 0;
+  ASSERT_TRUE(m_client->Discs().PrepareForDeserialize());
+  EXPECT_EQ(m_core.mutations, 0U);
+}
+
+TEST_F(TestGameClientDiscs, RestoreEmptyPlaylistAndTrailingRemovedSlot)
+{
+  m_core.slots = {"/roms/disc1.chd"};
+  CGameClientDiscModel empty;
+  m_client->Discs().SetDiscModel(empty);
+  ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+  EXPECT_TRUE(m_core.slots[0].empty());
+  EXPECT_EQ(m_core.selected, m_core.slots.size());
+
+  CGameClientDiscModel historical;
+  historical.AddDisc("/roms/disc1.chd");
+  historical.AddRemovedSlot();
+  historical.AddRemovedSlot();
+  m_client->Discs().SetDiscModel(historical);
+  ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+  EXPECT_EQ(m_core.slots.size(), 3U);
+  EXPECT_TRUE(m_core.slots[2].empty());
+}
+
+TEST_F(TestGameClientDiscs, RefusedMediaRestoreReportsFailure)
+{
+  CGameClientDiscModel historical;
+  historical.AddDisc("/roms/disc2.chd");
+  m_core.slots = {"/roms/disc1.chd"};
+  m_core.failReplace = true;
+  m_client->Discs().SetDiscModel(historical);
+  EXPECT_FALSE(m_client->Discs().RestoreDiscList());
+}
+
+TEST_F(TestGameClientDiscs, PresentEmptyPersistedStateIsAuthoritative)
+{
+  std::unique_ptr<XFILE::CFile> playlist(XBMC_CREATETEMPFILE(".m3u"));
+  ASSERT_NE(playlist, nullptr);
+  playlist->Close();
+  const std::string gamePath = XBMC_TEMPFILEPATH(playlist.get());
+
+  CGameClientDiscXML xml;
+  CGameClientDiscModel empty;
+  ASSERT_TRUE(xml.Save(gamePath, empty));
+
+  m_client->Discs().Initialize(gamePath);
+  EXPECT_TRUE(m_client->Discs().HasPersistedState());
+  EXPECT_TRUE(m_client->Discs().GetDiscs().Empty());
+
+  XFILE::CFile::Delete(CGameClientDiscXML::GetXMLPath(gamePath));
+  XFILE::CFile::Delete(CGameClientDiscM3U::GetM3UPath(gamePath));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(playlist.release()));
+}
+
+TEST_F(TestGameClientDiscs, InvalidPersistedStateFallsBackToWholeSourcePlaylist)
+{
+  std::unique_ptr<XFILE::CFile> disc(XBMC_CREATETEMPFILE(".chd"));
+  ASSERT_NE(disc, nullptr);
+  disc->Close();
+  const std::string discPath = XBMC_TEMPFILEPATH(disc.get());
+
+  std::unique_ptr<XFILE::CFile> playlist(XBMC_CREATETEMPFILE(".m3u"));
+  ASSERT_NE(playlist, nullptr);
+  ASSERT_EQ(playlist->Write(discPath.data(), discPath.size()),
+            static_cast<ssize_t>(discPath.size()));
+  playlist->Close();
+  const std::string gamePath = XBMC_TEMPFILEPATH(playlist.get());
+
+  CGameClientDiscModel stale;
+  stale.AddDisc("/missing/disc.chd");
+  CGameClientDiscXML xml;
+  ASSERT_TRUE(xml.Save(gamePath, stale));
+
+  m_client->Discs().Initialize(gamePath);
+  const CGameClientDiscModel source = m_client->Discs().GetDiscs();
+  EXPECT_FALSE(m_client->Discs().HasPersistedState());
+  ASSERT_EQ(source.Size(), 1U);
+  EXPECT_EQ(source.GetPathByIndex(0), discPath);
+  EXPECT_EQ(source.GetSelectedDiscIndex(), 0U);
+
+  XFILE::CFile::Delete(CGameClientDiscXML::GetXMLPath(gamePath));
+  XFILE::CFile::Delete(CGameClientDiscM3U::GetM3UPath(gamePath));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(playlist.release()));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(disc.release()));
+}
+
+TEST_F(TestGameClientDiscs, UnsupportedPersistedMediaFallsBackToWholeSourcePlaylist)
+{
+  std::unique_ptr<XFILE::CFile> sourceDisc(XBMC_CREATETEMPFILE(".chd"));
+  std::unique_ptr<XFILE::CFile> unsupportedDisc(XBMC_CREATETEMPFILE(".iso"));
+  std::unique_ptr<XFILE::CFile> playlist(XBMC_CREATETEMPFILE(".m3u"));
+  ASSERT_NE(sourceDisc, nullptr);
+  ASSERT_NE(unsupportedDisc, nullptr);
+  ASSERT_NE(playlist, nullptr);
+  sourceDisc->Close();
+  unsupportedDisc->Close();
+  const std::string sourcePath = XBMC_TEMPFILEPATH(sourceDisc.get());
+  ASSERT_EQ(playlist->Write(sourcePath.data(), sourcePath.size()),
+            static_cast<ssize_t>(sourcePath.size()));
+  playlist->Close();
+  const std::string gamePath = XBMC_TEMPFILEPATH(playlist.get());
+
+  CGameClientDiscModel incompatible;
+  incompatible.AddDisc(XBMC_TEMPFILEPATH(unsupportedDisc.get()));
+  CGameClientDiscXML xml;
+  ASSERT_TRUE(xml.Save(gamePath, incompatible));
+
+  m_client->Discs().Initialize(gamePath);
+  const CGameClientDiscModel source = m_client->Discs().GetDiscs();
+  EXPECT_FALSE(m_client->Discs().HasPersistedState());
+  ASSERT_EQ(source.Size(), 1U);
+  EXPECT_EQ(source.GetPathByIndex(0), sourcePath);
+
+  XFILE::CFile::Delete(CGameClientDiscXML::GetXMLPath(gamePath));
+  XFILE::CFile::Delete(CGameClientDiscM3U::GetM3UPath(gamePath));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(playlist.release()));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(unsupportedDisc.release()));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(sourceDisc.release()));
+}
+
+TEST_F(TestGameClientDiscs, SourceOnlyInitializationIgnoresValidPersistedState)
+{
+  std::unique_ptr<XFILE::CFile> sourceDisc(XBMC_CREATETEMPFILE(".chd"));
+  std::unique_ptr<XFILE::CFile> persistedDisc(XBMC_CREATETEMPFILE(".chd"));
+  std::unique_ptr<XFILE::CFile> playlist(XBMC_CREATETEMPFILE(".m3u"));
+  ASSERT_NE(sourceDisc, nullptr);
+  ASSERT_NE(persistedDisc, nullptr);
+  ASSERT_NE(playlist, nullptr);
+  sourceDisc->Close();
+  persistedDisc->Close();
+  const std::string sourcePath = XBMC_TEMPFILEPATH(sourceDisc.get());
+  ASSERT_EQ(playlist->Write(sourcePath.data(), sourcePath.size()),
+            static_cast<ssize_t>(sourcePath.size()));
+  playlist->Close();
+  const std::string gamePath = XBMC_TEMPFILEPATH(playlist.get());
+
+  CGameClientDiscModel persisted;
+  persisted.AddDisc(XBMC_TEMPFILEPATH(persistedDisc.get()));
+  CGameClientDiscXML xml;
+  ASSERT_TRUE(xml.Save(gamePath, persisted));
+
+  m_client->Discs().Initialize(gamePath, false);
+  const CGameClientDiscModel source = m_client->Discs().GetDiscs();
+  EXPECT_FALSE(m_client->Discs().HasPersistedState());
+  ASSERT_EQ(source.Size(), 1U);
+  EXPECT_EQ(source.GetPathByIndex(0), sourcePath);
+
+  XFILE::CFile::Delete(CGameClientDiscXML::GetXMLPath(gamePath));
+  XFILE::CFile::Delete(CGameClientDiscM3U::GetM3UPath(gamePath));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(playlist.release()));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(persistedDisc.release()));
+  EXPECT_TRUE(XBMC_DELETETEMPFILE(sourceDisc.release()));
+}
+
+TEST_F(TestGameClientDiscs, PersistedEmptyAndShortModelsRestoreAcrossCoreRemovalBehaviors)
+{
+  for (const bool compactRemoval : {false, true})
+  {
+    std::unique_ptr<XFILE::CFile> disc(XBMC_CREATETEMPFILE(".chd"));
+    std::unique_ptr<XFILE::CFile> playlist(XBMC_CREATETEMPFILE(".m3u"));
+    ASSERT_NE(disc, nullptr);
+    ASSERT_NE(playlist, nullptr);
+    disc->Close();
+    playlist->Close();
+    const std::string gamePath = XBMC_TEMPFILEPATH(playlist.get());
+
+    for (const bool empty : {false, true})
+    {
+      CGameClientDiscModel persisted;
+      if (!empty)
+        persisted.AddDisc(XBMC_TEMPFILEPATH(disc.get()));
+      CGameClientDiscXML xml;
+      ASSERT_TRUE(xml.Save(gamePath, persisted));
+
+      m_core.compactRemoval = compactRemoval;
+      m_core.slots = {"/core/one.chd", "/core/two.chd", "/core/three.chd"};
+      m_core.selected = 0;
+      m_client->Discs().Initialize(gamePath);
+      ASSERT_TRUE(m_client->Discs().HasPersistedState());
+      ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+      m_client->Discs().RefreshDiscState();
+
+      const CGameClientDiscModel restored = m_client->Discs().GetDiscs();
+      EXPECT_EQ(restored.Size(), empty ? 0U : 1U);
+      EXPECT_EQ(m_core.slots.size(), compactRemoval ? (empty ? 0U : 1U) : 3U);
+      if (!compactRemoval)
+      {
+        for (size_t i = empty ? 0U : 1U; i < m_core.slots.size(); ++i)
+        {
+          EXPECT_TRUE(m_core.slots[i].empty());
+        }
+      }
+    }
+
+    XFILE::CFile::Delete(CGameClientDiscXML::GetXMLPath(gamePath));
+    XFILE::CFile::Delete(CGameClientDiscM3U::GetM3UPath(gamePath));
+    EXPECT_TRUE(XBMC_DELETETEMPFILE(playlist.release()));
+    EXPECT_TRUE(XBMC_DELETETEMPFILE(disc.release()));
+  }
+}
+
+TEST_F(TestGameClientDiscs, AddAfterHistoricalRestoreReusesClearedPhysicalTail)
+{
+  CGameClientDiscModel historical;
+  historical.AddDisc("/roms/disc1.chd");
+  historical.SetEjected(true);
+  m_core.slots = {"/roms/disc1.chd", "/roms/future.chd"};
+  m_client->Discs().SetDiscModel(historical);
+  ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+  ASSERT_TRUE(m_client->Discs().AddDisc("/roms/disc2.chd"));
+  const auto model = m_client->Discs().GetDiscs();
+  EXPECT_EQ(model.Size(), 2U);
+  EXPECT_EQ(model.GetPathByIndex(1), "/roms/disc2.chd");
+  EXPECT_EQ(m_core.slots.size(), 2U);
+}
+
+TEST_F(TestGameClientDiscs, ReusedRemovedSlotKeepsIdentityWithoutCoreMetadata)
+{
+  CGameClientDiscModel historical;
+  historical.AddDisc("/roms/disc1.chd");
+  historical.AddRemovedSlot();
+  historical.SetEjected(true);
+  m_core.slots = {"/roms/disc1.chd", ""};
+  m_core.ejected = true;
+  m_client->Discs().SetDiscModel(historical);
+  m_client->GetInstanceInterface()->toAddon->GetImagePath =
+      [](const AddonInstance_Game*, unsigned int) -> char* { return nullptr; };
+  ASSERT_TRUE(m_client->Discs().AddDisc("/roms/disc2.chd"));
+  const auto model = m_client->Discs().GetDiscs();
+  EXPECT_EQ(model.Size(), 2U);
+  EXPECT_FALSE(model.IsRemovedSlotByIndex(1));
+  EXPECT_EQ(model.GetPathByIndex(1), "/roms/disc2.chd");
+}
+
+TEST_F(TestGameClientDiscs, RepeatedRestoreWithoutCorePathMetadataDoesNotMutateMedia)
+{
+  CGameClientDiscModel historical;
+  historical.AddDisc("/roms/disc1.chd", "One");
+  historical.AddDisc("/roms/disc2.chd", "Two");
+  ASSERT_TRUE(historical.SetSelectedDiscByIndex(1));
+  m_core.slots = {"/roms/stale1.chd", "/roms/stale2.chd"};
+  m_core.selected = 1;
+  m_client->GetInstanceInterface()->toAddon->GetImagePath =
+      [](const AddonInstance_Game*, unsigned int) -> char* { return nullptr; };
+
+  m_client->Discs().SetDiscModel(historical);
+  ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+  EXPECT_GT(m_core.mutations, 0U);
+
+  m_core.mutations = 0;
+  m_client->Discs().SetDiscModel(historical);
+  ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+  EXPECT_EQ(m_core.mutations, 0U);
+}
+
+TEST_F(TestGameClientDiscs, UnknownCorePathsCannotBypassHistoricalRemoval)
+{
+  m_client->GetInstanceInterface()->toAddon->GetImagePath =
+      [](const AddonInstance_Game*, unsigned int) -> char* { return nullptr; };
+  for (const bool removedSlot : {false, true})
+  {
+    CGameClientDiscModel historical;
+    if (removedSlot)
+      historical.AddRemovedSlot();
+    m_core.slots = {"/roms/disc1.chd", "/roms/disc2.chd"};
+    m_client->Discs().SetDiscModel(historical);
+    ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+    EXPECT_TRUE(m_core.slots[0].empty());
+    EXPECT_TRUE(m_core.slots[1].empty());
+    EXPECT_EQ(m_core.selected, 2U);
+    m_client->Discs().RefreshDiscState();
+    EXPECT_EQ(m_client->Discs().GetDiscs().Size(), historical.Size());
+  }
+}
+
+TEST_F(TestGameClientDiscs, RejectedRewindResumesPreviousSpeedAfterRollback)
+{
+  m_core.slots = {CreateFile(".chd")};
+  StartPlaying();
+  CreatePlayback();
+  m_core.failedFrame = 1;
+
+  m_playback->SeekTimeMs(1000);
+
+  EXPECT_EQ(m_core.machineFrame, 3);
+  EXPECT_GE(m_core.deserializeCalls, 2U);
+  EXPECT_EQ(m_playback->GetTimeMs(), 3000U);
+  EXPECT_EQ(m_playback->GetSpeed(), 2.0);
+  EXPECT_FALSE(RestoreFailureLatched());
+}
+
+TEST_F(TestGameClientDiscs, RejectedAdvanceResumesPreviousSpeedAfterRollback)
+{
+  m_core.slots = {CreateFile(".chd")};
+  StartPlaying();
+  CreatePlayback();
+  m_playback->SeekTimeMs(1000);
+  ASSERT_EQ(m_core.machineFrame, 1);
+  m_core.failedFrame = 3;
+
+  m_playback->SeekTimeMs(3000);
+
+  EXPECT_EQ(m_core.machineFrame, 1);
+  EXPECT_EQ(m_playback->GetTimeMs(), 1000U);
+  EXPECT_EQ(m_playback->GetSpeed(), 2.0);
+  EXPECT_FALSE(RestoreFailureLatched());
+}
+
+TEST_F(TestGameClientDiscs, RejectedSavestateMediaDoesNotLatchOrBlockSaving)
+{
+  m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+  StartPlaying();
+  const auto previous = m_client->Discs().GetDiscs();
+  CreatePlayback();
+  CGameClientDiscModel target;
+  target.AddDisc(m_core.slots[1]);
+  target.AddDisc(m_core.slots[0]);
+  const auto path = WriteSavestate(&target);
+  m_core.failReplace = true;
+
+  EXPECT_FALSE(m_playback->LoadSavestate(path));
+
+  EXPECT_EQ(m_core.deserializeCalls, 0U);
+  EXPECT_EQ(m_core.machineFrame, 3);
+  EXPECT_EQ(m_core.slots[0], previous.GetPathByIndex(0));
+  EXPECT_EQ(m_core.slots[1], previous.GetPathByIndex(1));
+  EXPECT_EQ(m_core.selected, 0U);
+  EXPECT_FALSE(m_core.ejected);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == previous);
+  EXPECT_FALSE(RestoreFailureLatched());
+  EXPECT_EQ(m_playback->GetSpeed(), 2.0);
+  ExpectSavestateCanBeCreated();
+}
+
+TEST_F(TestGameClientDiscs, SavestateDeserializeFailureLeavesStateUncertainDespiteMediaRollback)
+{
+  m_core.slots = {CreateFile(".chd")};
+  StartPlaying();
+  const auto previous = m_client->Discs().GetDiscs();
+  CreatePlayback();
+  m_core.failAllFrames = true;
+
+  EXPECT_FALSE(m_playback->LoadSavestate(WriteSavestate(&previous)));
+
+  EXPECT_GT(m_core.deserializeCalls, 0U);
+  EXPECT_EQ(m_core.machineFrame, 99);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == previous);
+  EXPECT_TRUE(RestoreFailureLatched());
+  m_playback->SetSpeed(1.0);
+  EXPECT_EQ(m_playback->GetSpeed(), 0.0);
+  EXPECT_TRUE(m_playback->CreateSavestate(false).empty());
+}
+
+TEST_F(TestGameClientDiscs, SavestateDiscRollbackFailureLeavesStateUncertainBeforeDeserialize)
+{
+  m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+  StartPlaying();
+  CreatePlayback();
+  CGameClientDiscModel target;
+  target.AddDisc(m_core.slots[1]);
+  target.AddDisc(m_core.slots[0]);
+  const auto path = WriteSavestate(&target);
+  m_core.failReplace = true;
+  m_core.failClose = true;
+
+  EXPECT_FALSE(m_playback->LoadSavestate(path));
+
+  EXPECT_EQ(m_core.deserializeCalls, 0U);
+  EXPECT_TRUE(m_core.ejected);
+  EXPECT_TRUE(RestoreFailureLatched());
+  m_playback->SetSpeed(1.0);
+  EXPECT_EQ(m_playback->GetSpeed(), 0.0);
+}
+
+TEST_F(TestGameClientDiscs, SeekMachineRollbackFailureLeavesStateUncertain)
+{
+  m_core.slots = {CreateFile(".chd")};
+  StartPlaying();
+  CreatePlayback();
+  m_core.failAllFrames = true;
+
+  m_playback->SeekTimeMs(1000);
+
+  EXPECT_GE(m_core.deserializeCalls, 2U);
+  EXPECT_EQ(m_core.machineFrame, 99);
+  EXPECT_TRUE(RestoreFailureLatched());
+  m_playback->SetSpeed(1.0);
+  EXPECT_EQ(m_playback->GetSpeed(), 0.0);
+}
+
+TEST_F(TestGameClientDiscs, RestoredSeekAndSavestateKeepPlaybackUsable)
+{
+  m_core.slots = {CreateFile(".chd")};
+  StartPlaying();
+  CreatePlayback();
+  const auto discs = m_client->Discs().GetDiscs();
+
+  m_playback->SeekTimeMs(1000);
+  EXPECT_EQ(m_core.machineFrame, 1);
+  EXPECT_EQ(m_playback->GetTimeMs(), 1000U);
+  EXPECT_EQ(m_playback->GetSpeed(), 2.0);
+  m_playback->SeekTimeMs(3000);
+  EXPECT_EQ(m_core.machineFrame, 3);
+  EXPECT_EQ(m_playback->GetTimeMs(), 3000U);
+  EXPECT_EQ(m_playback->GetSpeed(), 2.0);
+
+  EXPECT_TRUE(m_playback->LoadSavestate(WriteSavestate(&discs)));
+  EXPECT_EQ(m_core.machineFrame, 1);
+  EXPECT_EQ(m_playback->GetSpeed(), 2.0);
+  EXPECT_FALSE(RestoreFailureLatched());
+}
+
+TEST_F(TestGameClientDiscs, LegacySavestateDeserializeFailureLeavesStateUncertain)
+{
+  m_core.slots = {CreateFile(".chd")};
+  StartPlaying();
+  CreatePlayback();
+  m_core.failAllFrames = true;
+
+  EXPECT_FALSE(m_playback->LoadSavestate(WriteSavestate(nullptr)));
+
+  EXPECT_EQ(m_core.deserializeCalls, 1U);
+  EXPECT_EQ(m_core.machineFrame, 99);
+  EXPECT_TRUE(RestoreFailureLatched());
+  m_playback->SetSpeed(1.0);
+  EXPECT_EQ(m_playback->GetSpeed(), 0.0);
+}
+
+TEST_F(TestGameClientDiscs, LegacySavestateMediaReconciliationFailureLeavesStateUncertain)
+{
+  m_core.slots = {CreateFile(".chd")};
+  StartPlaying();
+  CreatePlayback();
+  m_client->Discs().RefreshDiscState();
+  const auto previous = m_client->Discs().GetDiscs();
+  const auto xmlPath = CGameClientDiscXML::GetXMLPath(m_client->GetGamePath());
+  const auto m3uPath = CGameClientDiscM3U::GetM3UPath(m_client->GetGamePath());
+  const auto xml = ReadFile(xmlPath);
+  const auto m3u = ReadFile(m3uPath);
+  m_core.failCloseAfterDeserialize = true;
+  m_core.replacementAfterDeserialize = CreateFile(".chd");
+
+  EXPECT_FALSE(m_playback->LoadSavestate(WriteSavestate(nullptr)));
+
+  EXPECT_EQ(m_core.deserializeCalls, 1U);
+  EXPECT_EQ(m_core.machineFrame, 1);
+  EXPECT_TRUE(m_core.ejected);
+  EXPECT_EQ(m_core.slots[0], m_core.replacementAfterDeserialize);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == previous);
+  EXPECT_EQ(ReadFile(xmlPath), xml);
+  EXPECT_EQ(ReadFile(m3uPath), m3u);
+  EXPECT_TRUE(RestoreFailureLatched());
+  m_playback->SetSpeed(1.0);
+  EXPECT_EQ(m_playback->GetSpeed(), 0.0);
+}
+
+TEST_F(TestGameClientDiscs, OnlyRestoredSavestateClearsAnExistingRestoreLatch)
+{
+  m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+  StartPlaying();
+  CreatePlayback();
+  const auto previous = m_client->Discs().GetDiscs();
+  const auto validPath = WriteSavestate(&previous);
+  m_core.failAllFrames = true;
+  ASSERT_FALSE(m_playback->LoadSavestate(validPath));
+  ASSERT_TRUE(RestoreFailureLatched());
+  const auto calls = m_core.deserializeCalls;
+  m_core.failAllFrames = false;
+  m_core.failReplace = true;
+  CGameClientDiscModel target;
+  target.AddDisc(m_core.slots[1]);
+  target.AddDisc(m_core.slots[0]);
+
+  EXPECT_FALSE(m_playback->LoadSavestate(WriteSavestate(&target)));
+
+  EXPECT_EQ(m_core.deserializeCalls, calls);
+  EXPECT_TRUE(RestoreFailureLatched());
+  m_playback->SetSpeed(1.0);
+  EXPECT_EQ(m_playback->GetSpeed(), 0.0);
+
+  m_core.failReplace = false;
+  EXPECT_TRUE(m_playback->LoadSavestate(validPath));
+  EXPECT_FALSE(RestoreFailureLatched());
+  m_playback->SetSpeed(1.0);
+  EXPECT_EQ(m_playback->GetSpeed(), 1.0);
+}
+
+TEST_F(TestGameClientDiscs, RewindPreviewSavestateUsesHistoricalMachineDiscAndTimestamp)
+{
+  m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+  StartPlaying();
+  CreatePlayback();
+  const auto historical = m_client->Discs().GetDiscs();
+  m_core.changeDiscOnRun = true;
+  m_playback->SetSpeed(-4.0);
+
+  m_playback->RewindEvent();
+
+  ASSERT_EQ(m_core.runFrameCalls, 1U);
+  ASSERT_EQ(m_core.machineFrame, 3);
+  ASSERT_EQ(m_core.selected, 1U);
+  ASSERT_TRUE(m_core.ejected);
+  ASSERT_EQ(m_playback->GetTimeMs(), 2000U);
+  ASSERT_TRUE(m_client->Discs().GetDiscs() == historical);
+  const auto path = CaptureSavestate();
+  m_playback->SetSpeed(0.0);
+  const auto pausedPath = CaptureSavestate();
+  EXPECT_EQ(m_core.machineFrame, 3);
+  EXPECT_EQ(TestMember<PlaybackMemory>(*m_playback)->GetFrameCounter(), 2U);
+  EXPECT_EQ(TestMember<PlaybackMemory>(*m_playback)->FutureFramesAvailable(), 1U);
+
+  for (const auto& capturedPath : {path, pausedPath})
+  {
+    RETRO::CSavestateFlatBuffer saved;
+    ASSERT_TRUE(RETRO::CSavestateDatabase().GetSavestate(capturedPath, saved));
+    ASSERT_TRUE(saved.PrepareMemoryData(1));
+    EXPECT_EQ(saved.GetMemoryData()[0], 2);
+    EXPECT_EQ(saved.TimestampFrames(), 2U);
+    ASSERT_TRUE(saved.GetDiscState().has_value());
+    EXPECT_EQ(*saved.GetDiscState(), historical.GetState());
+    EXPECT_EQ(saved.GetAchievementSize(), 0U);
+  }
+
+  ASSERT_TRUE(m_playback->LoadSavestate(path));
+  EXPECT_EQ(m_core.machineFrame, 2);
+  EXPECT_EQ(TestMember<PlaybackTotalFrames>(*m_playback), 2U);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == historical);
+  EXPECT_EQ(m_core.selected, 0U);
+  EXPECT_FALSE(m_core.ejected);
+}
+
+TEST_F(TestGameClientDiscs, ForwardSavestateCapturesLiveMachineDiscAndTimestamp)
+{
+  m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+  StartPlaying();
+  CreatePlayback();
+  TestMember<PlaybackMemory>(*m_playback).reset();
+  const auto persisted = SnapshotDiscFiles();
+  auto expected = m_client->Discs().GetDiscs().GetState();
+  expected.selectedSlot = 1;
+  expected.trayEjected = true;
+  m_core.changeDiscOnRun = true;
+
+  m_playback->FrameEvent();
+
+  ASSERT_EQ(m_core.machineFrame, 4);
+  ASSERT_EQ(m_core.selected, 1U);
+  ASSERT_TRUE(m_core.ejected);
+  ASSERT_EQ(m_client->Discs().GetDiscs().GetState().selectedSlot, 0);
+  const auto path = CaptureSavestate();
+  RETRO::CSavestateFlatBuffer saved;
+  ASSERT_TRUE(RETRO::CSavestateDatabase().GetSavestate(path, saved));
+  ASSERT_TRUE(saved.PrepareMemoryData(1));
+  EXPECT_EQ(saved.GetMemoryData()[0], 4);
+  EXPECT_EQ(saved.TimestampFrames(), 4U);
+  ASSERT_EQ(saved.GetAchievementSize(), 1U);
+  EXPECT_EQ(saved.GetAchievementData()[0], 4);
+  ASSERT_TRUE(saved.GetDiscState().has_value());
+  EXPECT_EQ(*saved.GetDiscState(), expected);
+  ExpectDiscFilesUnchanged(persisted);
+}
+
+TEST_F(TestGameClientDiscs, SavestateAfterSeekCapturesLiveDiscEdits)
+{
+  m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+  StartPlaying();
+  CreatePlayback();
+  m_playback->RewindEvent();
+  m_playback->SeekTimeMs(1000);
+  ASSERT_EQ(m_core.machineFrame, 1);
+  auto edited = m_client->Discs().GetDiscs();
+  edited.SetSelectedNoDisc();
+  edited.SetEjected(true);
+  m_client->Discs().SetDiscModel(edited);
+  ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+
+  const auto path = CaptureSavestate();
+
+  RETRO::CSavestateFlatBuffer saved;
+  ASSERT_TRUE(RETRO::CSavestateDatabase().GetSavestate(path, saved));
+  ASSERT_TRUE(saved.PrepareMemoryData(1));
+  EXPECT_EQ(saved.GetMemoryData()[0], 1);
+  EXPECT_EQ(saved.TimestampFrames(), 1U);
+  ASSERT_TRUE(saved.GetDiscState().has_value());
+  EXPECT_EQ(*saved.GetDiscState(), edited.GetState());
+}
+
+TEST_F(TestGameClientDiscs, RejectedRewindMediaRestoresOnlyTheTimelineCursor)
+{
+  m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+  StartPlaying();
+  const auto previous = m_client->Discs().GetDiscs();
+  CGameClientDiscModel target;
+  target.AddDisc(m_core.slots[1]);
+  target.AddDisc(m_core.slots[0]);
+  CreatePlayback(&target);
+  const auto discID = TestMember<PlaybackMemory>(*m_playback)->GetDiscStateID();
+  m_core.failReplace = true;
+  m_core.failAllFrames = true;
+
+  m_playback->SeekTimeMs(1000);
+
+  EXPECT_EQ(m_core.deserializeCalls, 0U);
+  EXPECT_EQ(m_core.machineFrame, 3);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == previous);
+  EXPECT_EQ(TestMember<PlaybackMemory>(*m_playback)->GetFrameCounter(), 3U);
+  EXPECT_EQ(TestMember<PlaybackMemory>(*m_playback)->GetDiscStateID(), discID);
+  EXPECT_EQ(TestMember<PlaybackMemory>(*m_playback)->PastFramesAvailable(), 2U);
+  EXPECT_EQ(TestMember<PlaybackMemory>(*m_playback)->FutureFramesAvailable(), 0U);
+  EXPECT_EQ(m_playback->GetTimeMs(), 3000U);
+  EXPECT_EQ(m_playback->GetSpeed(), 2.0);
+  EXPECT_FALSE(RestoreFailureLatched());
+}
+
+TEST_F(TestGameClientDiscs, RejectedAdvanceMediaRestoresOnlyTheTimelineCursor)
+{
+  m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+  StartPlaying();
+  const auto previous = m_client->Discs().GetDiscs();
+  CGameClientDiscModel target;
+  target.AddDisc(m_core.slots[1]);
+  target.AddDisc(m_core.slots[0]);
+  CreatePlayback(nullptr, &target);
+  m_playback->SeekTimeMs(1000);
+  ASSERT_EQ(m_core.machineFrame, 1);
+  const auto discID = TestMember<PlaybackMemory>(*m_playback)->GetDiscStateID();
+  m_core.deserializeCalls = 0;
+  m_core.failReplace = true;
+  m_core.failAllFrames = true;
+
+  m_playback->SeekTimeMs(3000);
+
+  EXPECT_EQ(m_core.deserializeCalls, 0U);
+  EXPECT_EQ(m_core.machineFrame, 1);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == previous);
+  EXPECT_EQ(TestMember<PlaybackMemory>(*m_playback)->GetFrameCounter(), 1U);
+  EXPECT_EQ(TestMember<PlaybackMemory>(*m_playback)->GetDiscStateID(), discID);
+  EXPECT_EQ(TestMember<PlaybackMemory>(*m_playback)->PastFramesAvailable(), 0U);
+  EXPECT_EQ(TestMember<PlaybackMemory>(*m_playback)->FutureFramesAvailable(), 2U);
+  EXPECT_EQ(m_playback->GetTimeMs(), 1000U);
+  EXPECT_EQ(m_playback->GetSpeed(), 2.0);
+  EXPECT_FALSE(RestoreFailureLatched());
+}
+
+TEST_F(TestGameClientDiscs, RejectedSeekAfterRewindPreviewKeepsHistoricalCapture)
+{
+  m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+  StartPlaying();
+  CGameClientDiscModel target;
+  target.AddDisc(m_core.slots[1]);
+  target.AddDisc(m_core.slots[0]);
+  CreatePlayback(&target);
+  m_playback->RewindEvent();
+  ASSERT_EQ(m_core.machineFrame, 3);
+  ASSERT_EQ(m_playback->GetTimeMs(), 2000U);
+  m_core.deserializeCalls = 0;
+  m_core.failReplace = true;
+  m_core.failAllFrames = true;
+
+  m_playback->SeekTimeMs(1000);
+  const auto path = CaptureSavestate();
+
+  EXPECT_EQ(m_core.deserializeCalls, 0U);
+  EXPECT_EQ(m_core.machineFrame, 3);
+  EXPECT_EQ(m_playback->GetTimeMs(), 2000U);
+  EXPECT_FALSE(RestoreFailureLatched());
+  RETRO::CSavestateFlatBuffer saved;
+  ASSERT_TRUE(RETRO::CSavestateDatabase().GetSavestate(path, saved));
+  ASSERT_TRUE(saved.PrepareMemoryData(1));
+  EXPECT_EQ(saved.GetMemoryData()[0], 2);
+  EXPECT_EQ(saved.TimestampFrames(), 2U);
+}
+
+TEST_F(TestGameClientDiscs, RewindPreviewSaveWithoutHistoricalFrameIsRejected)
+{
+  m_core.slots = {CreateFile(".chd")};
+  StartPlaying();
+  CreatePlayback();
+  m_playback->RewindEvent();
+  ASSERT_EQ(m_core.machineFrame, 3);
+  TestMember<PlaybackMemory>(*m_playback).reset();
+
+  const auto path = CaptureSavestate();
+
+  RETRO::CSavestateFlatBuffer saved;
+  EXPECT_FALSE(RETRO::CSavestateDatabase().GetSavestate(path, saved));
+  EXPECT_EQ(m_core.machineFrame, 3);
+  EXPECT_FALSE(RestoreFailureLatched());
+}
+
+TEST_F(TestGameClientDiscs, RewindSavestateWithoutDiscEditsRoundtrips)
+{
+  ExpectRewindCursorSaveRoundtrip([](CGameClientDiscModel&, const std::string&) {});
+}
+
+TEST_F(TestGameClientDiscs, RewindSavestateRejectsSelectedDiscEdit)
+{
+  ExpectRewindDiscEditSaveRejected([](CGameClientDiscModel& model, const std::string&)
+                                   { ASSERT_TRUE(model.SetSelectedDiscByIndex(1)); });
+}
+
+TEST_F(TestGameClientDiscs, RewindSavestateRejectsNoDiscEdit)
+{
+  ExpectRewindDiscEditSaveRejected([](CGameClientDiscModel& model, const std::string&)
+                                   { model.SetSelectedNoDisc(); });
+}
+
+TEST_F(TestGameClientDiscs, RewindSavestateRejectsTrayEdit)
+{
+  ExpectRewindDiscEditSaveRejected([](CGameClientDiscModel& model, const std::string&)
+                                   { model.SetEjected(true); });
+}
+
+TEST_F(TestGameClientDiscs, RewindSavestateRejectsRemovedSlot)
+{
+  ExpectRewindDiscEditSaveRejected([](CGameClientDiscModel& model, const std::string&)
+                                   { ASSERT_TRUE(model.RemoveDiscByIndex(0)); });
+}
+
+TEST_F(TestGameClientDiscs, RewindSavestateRejectsAddedDisc)
+{
+  ExpectRewindDiscEditSaveRejected([](CGameClientDiscModel& model, const std::string& extraDisc)
+                                   { model.AddDisc(extraDisc, "Added disc"); });
+}
+
+TEST_F(TestGameClientDiscs, RewindSavestateRejectsReorderedPlaylist)
+{
+  ExpectRewindDiscEditSaveRejected(
+      [](CGameClientDiscModel& model, const std::string&)
+      {
+        auto discs = model.GetDiscs();
+        std::reverse(discs.begin(), discs.end());
+        model.SetDiscs(discs);
+        ASSERT_TRUE(model.SetSelectedDiscByIndex(1));
+      });
+}
+
+TEST_F(TestGameClientDiscs, RewindSavestateRejectsEmptyPlaylist)
+{
+  ExpectRewindDiscEditSaveRejected(
+      [](CGameClientDiscModel& model, const std::string&)
+      {
+        while (!model.Empty())
+        {
+          ASSERT_TRUE(model.EraseDiscByIndex(0));
+        }
+        model.SetEjected(true);
+      });
+}
+
+TEST_F(TestGameClientDiscs, RewindSavestateAllowsKnownMediaOnlyChanges)
+{
+  ExpectRewindCursorSaveRoundtrip(
+      [](CGameClientDiscModel& model, const std::string& extraDisc)
+      {
+        const auto active = model;
+        model.RememberDiscPath(extraDisc);
+        ASSERT_TRUE(model == active);
+      });
+}
+
+TEST_F(TestGameClientDiscs, RewindSavestateWithMismatchedMediaFailsCoreValidation)
+{
+  m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+  m_core.rewindFramePath = m_core.slots[0];
+  StartPlaying();
+  CreatePlayback();
+  m_playback->RewindEvent();
+  const auto historical = m_client->Discs().GetDiscs();
+  const auto validPath = CaptureSavestate();
+  RETRO::CSavestateFlatBuffer saved;
+  ASSERT_TRUE(RETRO::CSavestateDatabase().GetSavestate(validPath, saved));
+  ASSERT_TRUE(saved.PrepareMemoryData(1));
+  ASSERT_EQ(saved.GetMemoryData()[0], 2);
+  RETRO::CSavestateFlatBuffer mixed;
+  *mixed.GetMemoryBuffer(1) = saved.GetMemoryData()[0];
+  mixed.SetTimestampFrames(saved.TimestampFrames());
+  auto edited = historical;
+  ASSERT_TRUE(edited.SetSelectedDiscByIndex(1));
+  // A permissive core would hide a save that pairs cursor memory with later media edits.
+  mixed.SetDiscState(edited.GetState());
+  mixed.Finalize();
+  const auto mixedPath = CreateFile(".sav");
+  ASSERT_TRUE(RETRO::CSavestateDatabase().AddSavestate(mixedPath, m_client->GetGamePath(), mixed));
+  const auto calls = m_core.deserializeCalls;
+
+  EXPECT_FALSE(m_playback->LoadSavestate(mixedPath));
+
+  EXPECT_GT(m_core.deserializeCalls, calls);
+  EXPECT_TRUE(RestoreFailureLatched());
+  ASSERT_TRUE(m_playback->LoadSavestate(validPath));
+  EXPECT_EQ(m_core.machineFrame, 2);
+  EXPECT_EQ(TestMember<PlaybackTotalFrames>(*m_playback), 2U);
+  EXPECT_TRUE(m_client->Discs().GetDiscs() == historical);
+  EXPECT_FALSE(RestoreFailureLatched());
+}
+
+TEST_F(TestGameClientDiscs, ForwardResumeCommitsRewindPreviewWithoutRunningAgain)
+{
+  ExpectRewindPreviewResume(false);
+}
+
+TEST_F(TestGameClientDiscs, ForwardResumeCommitsRewindPreviewDiscAndTrayChanges)
+{
+  ExpectRewindPreviewResume(true);
+}
+
+TEST_F(TestGameClientDiscs, GameplayStartupPersistsKnownMediaBeforeAnyDiscMutation)
+{
+  const auto disc1 = CreateFile(".chd");
+  const auto disc2 = CreateFile(".chd");
+  const auto playlist = CreateFile(".m3u", disc1 + "\n" + disc2 + "\n");
+  m_core.slots = {disc1, disc2};
+  m_client->Discs().Initialize(playlist);
+  auto historical = m_client->Discs().GetDiscs();
+  ASSERT_TRUE(historical.SetSelectedDiscByIndex(1));
+  const auto state = historical.GetState();
+  ASSERT_TRUE(m_client->GetGamePath().empty());
+  ASSERT_FALSE(XFILE::CFile::Exists(CGameClientDiscXML::GetXMLPath(playlist)));
+
+  ASSERT_TRUE(InitializeGameplay(playlist));
+
+  ASSERT_TRUE(XFILE::CFile::Exists(CGameClientDiscXML::GetXMLPath(playlist)));
+  CXBMCTinyXML2 xml;
+  ASSERT_TRUE(xml.LoadFile(CGameClientDiscXML::GetXMLPath(playlist)));
+  ASSERT_NE(xml.RootElement()->FirstChildElement("knownmedia"), nullptr);
+  CGameClientDiscModel persisted;
+  ASSERT_TRUE(CGameClientDiscXML().Load(playlist, persisted));
+  EXPECT_EQ(persisted.GetKnownDiscPaths(), (std::vector<std::string>{disc1, disc2}));
+  XFILE::CFile source;
+  ASSERT_TRUE(source.OpenForWrite(playlist, true));
+  const auto shortened = disc1 + "\n";
+  ASSERT_EQ(source.Write(shortened.data(), shortened.size()),
+            static_cast<ssize_t>(shortened.size()));
+  source.Close();
+  ASSERT_TRUE(XFILE::CFile::Exists(disc2));
+  CGameClientDiscModel sourceOnly;
+  ASSERT_TRUE(CGameClientDiscM3U().Load(playlist, sourceOnly));
+  CGameClientDiscModel resolved;
+  EXPECT_FALSE(sourceOnly.ResolveState(state, resolved));
+  ASSERT_TRUE(persisted.ResolveState(state, resolved));
+  EXPECT_EQ(resolved.GetPathByIndex(1), disc2);
+  EXPECT_EQ(resolved.GetSelectedDiscIndex(), 1U);
+}
+
+TEST_F(TestGameClientDiscs, GameplayStartupKeepsEmptyPlaylistAndSourceMediaHistory)
+{
+  const auto disc1 = CreateFile(".chd");
+  const auto disc2 = CreateFile(".chd");
+  const auto playlist = CreateFile(".m3u", disc1 + "\n" + disc2 + "\n");
+  CGameClientDiscModel empty;
+  empty.SetEjected(true);
+  ASSERT_TRUE(CGameClientDiscXML().Save(playlist, empty));
+  m_core.slots = {disc1, disc2};
+  m_client->Discs().Initialize(playlist);
+  ASSERT_TRUE(m_client->Discs().HasPersistedState());
+
+  ASSERT_TRUE(InitializeGameplay(playlist));
+
+  CGameClientDiscModel persisted;
+  ASSERT_TRUE(CGameClientDiscXML().Load(playlist, persisted));
+  EXPECT_TRUE(persisted.Empty());
+  EXPECT_TRUE(persisted.IsSelectedNoDisc());
+  EXPECT_TRUE(persisted.IsEjected());
+  EXPECT_EQ(persisted.GetKnownDiscPaths(), (std::vector<std::string>{disc1, disc2}));
+}
+
+TEST_F(TestGameClientDiscs, FailedGameplayStartupDoesNotCreateDiscState)
+{
+  const auto disc = CreateFile(".chd");
+  const auto playlist = CreateFile(".m3u", disc + "\n");
+  m_core.slots = {disc};
+  m_client->Discs().Initialize(playlist);
+
+  EXPECT_FALSE(InitializeGameplay(playlist, false));
+
+  EXPECT_TRUE(m_client->GetGamePath().empty());
+  EXPECT_FALSE(XFILE::CFile::Exists(CGameClientDiscXML::GetXMLPath(playlist)));
+  EXPECT_FALSE(XFILE::CFile::Exists(CGameClientDiscM3U::GetM3UPath(playlist)));
+}
+
+TEST_F(TestGameClientDiscs, FailedGameplayStartupDoesNotReplaceDiscState)
+{
+  const auto disc = CreateFile(".chd");
+  const auto playlist = CreateFile(".m3u", disc + "\n");
+  m_core.slots = {disc};
+  CGameClientDiscModel persisted;
+  persisted.AddDisc(disc);
+  ASSERT_TRUE(CGameClientDiscXML().Save(playlist, persisted));
+  ASSERT_TRUE(CGameClientDiscM3U().Save(playlist, persisted));
+  const auto xml = ReadFile(CGameClientDiscXML::GetXMLPath(playlist));
+  const auto m3u = ReadFile(CGameClientDiscM3U::GetM3UPath(playlist));
+  m_client->Discs().Initialize(playlist);
+
+  EXPECT_FALSE(InitializeGameplay(playlist, false));
+
+  EXPECT_TRUE(m_client->GetGamePath().empty());
+  EXPECT_EQ(ReadFile(CGameClientDiscXML::GetXMLPath(playlist)), xml);
+  EXPECT_EQ(ReadFile(CGameClientDiscM3U::GetM3UPath(playlist)), m3u);
+}
+
+TEST_F(TestGameClientDiscs, ForwardFramesCaptureLiveDiscHistoryWithoutPersisting)
+{
+  m_core.slots = {CreateFile(".chd"), CreateFile(".chd")};
+  StartPlaying();
+  CreatePlayback();
+  const auto persisted = SnapshotDiscFiles();
+  m_core.changeDiscOnRun = true;
+  auto expected = m_client->Discs().GetDiscs().GetState();
+  expected.selectedSlot = 1;
+  expected.trayEjected = true;
+  const auto queries = m_core.modelQueries;
+
+  m_playback->FrameEvent();
+
+  const auto& memory = TestMember<PlaybackMemory>(*m_playback);
+  EXPECT_EQ(*memory->CurrentFrame(), 4);
+  EXPECT_EQ(memory->GetFrameCounter(), 4U);
+  const auto* discs = TestMember<PlaybackDiscs>(*m_playback).Get(memory->GetDiscStateID());
+  ASSERT_NE(discs, nullptr);
+  EXPECT_EQ(discs->GetState(), expected);
+  EXPECT_EQ(m_core.modelQueries, queries + 1);
+  m_playback->FrameEvent();
+  EXPECT_EQ(m_core.modelQueries, queries + 2);
+  ExpectDiscFilesUnchanged(persisted);
+
+  m_playback->SeekTimeMs(4000);
+  EXPECT_EQ(m_core.machineFrame, 4);
+  EXPECT_EQ(m_core.selected, 1U);
+  EXPECT_TRUE(m_core.ejected);
+  m_playback->SeekTimeMs(3000);
+  EXPECT_EQ(m_core.machineFrame, 3);
+  EXPECT_EQ(m_core.selected, 0U);
+  EXPECT_FALSE(m_core.ejected);
+  m_playback->SeekTimeMs(4000);
+  EXPECT_EQ(m_core.machineFrame, 4);
+  EXPECT_EQ(m_core.selected, 1U);
+  EXPECT_TRUE(m_core.ejected);
+  EXPECT_FALSE(RestoreFailureLatched());
+}
+
+TEST_F(TestGameClientDiscs, SavestateRejectsKnownMediaUnsupportedByActiveCore)
+{
+  ExpectUnsupportedSavestateRejected(true);
+}
+
+TEST_F(TestGameClientDiscs, SavestateRejectsUnsupportedUnselectedMedia)
+{
+  ExpectUnsupportedSavestateRejected(false);
+}
+
+TEST_F(TestGameClientDiscs, SavestateLoadsSupportedHistoryAndSkipsRemovedSlots)
+{
+  const auto disc1 = CreateFile(".chd");
+  const auto disc2 = CreateFile(".chd");
+  const auto unsupported = CreateFile(".unsupported");
+  m_core.slots = {disc1};
+  StartPlaying();
+  CreatePlayback();
+  auto current = m_client->Discs().GetDiscs();
+  current.RememberDiscPath(disc2);
+  current.RememberDiscPath(unsupported);
+  m_client->Discs().SetDiscModel(current);
+  CGameClientDiscModel historical;
+  historical.AddDisc(unsupported);
+  historical.AddDisc(disc2);
+  ASSERT_TRUE(historical.RemoveDiscByIndex(0));
+  ASSERT_TRUE(historical.SetSelectedDiscByIndex(1));
+
+  ASSERT_TRUE(m_playback->LoadSavestate(WriteSavestate(&historical)));
+
+  EXPECT_EQ(m_core.deserializeCalls, 1U);
+  EXPECT_EQ(m_core.machineFrame, 1);
+  EXPECT_EQ(m_core.slots, (std::vector<std::string>{"", disc2}));
+  EXPECT_EQ(m_core.selected, 1U);
+  EXPECT_FALSE(m_core.ejected);
+  EXPECT_EQ(m_client->Discs().GetDiscs().GetState(), historical.GetState());
+  EXPECT_FALSE(RestoreFailureLatched());
+}
+
+TEST_F(TestGameClientDiscs, FailedExcessSlotReuseDoesNotClearExistingTail)
+{
+  ExpectFailedDiscAddition(false, true);
+}
+
+TEST_F(TestGameClientDiscs, FailedExcessSlotReuseDoesNotCompactExistingTail)
+{
+  ExpectFailedDiscAddition(true, true);
+}
+
+TEST_F(TestGameClientDiscs, FailedNewSlotReplacementClearsCreatedSlot)
+{
+  ExpectFailedDiscAddition(false, false);
+}
+
+TEST_F(TestGameClientDiscs, FailedNewSlotReplacementRemovesCreatedSlot)
+{
+  ExpectFailedDiscAddition(true, false);
 }

--- a/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
+++ b/xbmc/games/addons/disc/test/TestGameClientDiscs.cpp
@@ -1,0 +1,130 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "addons/Repository.h"
+#include "addons/addoninfo/AddonInfoBuilder.h"
+#include "filesystem/File.h"
+#include "games/addons/GameClient.h"
+#include "games/addons/disc/GameClientDiscM3U.h"
+#include "games/addons/disc/GameClientDiscModel.h"
+#include "games/addons/disc/GameClientDiscXML.h"
+#include "games/addons/disc/GameClientDiscs.h"
+#include "test/TestUtils.h"
+#include "utils/XBMCTinyXML2.h"
+
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace KODI::GAME;
+
+namespace KODI::GAME
+{
+class TestGameClientDiscs : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    CXBMCTinyXML2 xml;
+    const std::string addonXml = R"(<addon id="game.test.discs" name="Disc test" version="1.0.0">
+      <extension point="kodi.gameclient" library="test.so">
+        <supports_disc_control>true</supports_disc_control>
+        <extensions>chd|m3u</extensions>
+      </extension>
+      <extension point="kodi.addon.metadata"><platform>all</platform></extension>
+    </addon>)";
+    ASSERT_TRUE(xml.Parse(addonXml));
+    const auto info =
+        ADDON::CAddonInfoBuilder::Generate(xml.RootElement(), ADDON::RepositoryDirInfo{});
+    ASSERT_NE(info, nullptr);
+    m_client = std::make_unique<CGameClient>(info);
+    m_client->GetInstanceInterface()->toAddon->SetInitialImage =
+        [](const AddonInstance_Game*, unsigned int, const char*) { return GAME_ERROR_NO_ERROR; };
+  }
+
+  void TearDown() override
+  {
+    for (auto* file : m_files)
+    {
+      const std::string path = XBMC_TEMPFILEPATH(file);
+      XFILE::CFile::Delete(CGameClientDiscXML::GetXMLPath(path));
+      XFILE::CFile::Delete(CGameClientDiscM3U::GetM3UPath(path));
+      EXPECT_TRUE(XBMC_DELETETEMPFILE(file));
+    }
+  }
+
+  std::string CreateFile(const std::string& extension, const std::string& contents = {})
+  {
+    auto* file = XBMC_CREATETEMPFILE(extension);
+    EXPECT_NE(file, nullptr);
+    if (!file)
+      return {};
+    m_files.push_back(file);
+    if (!contents.empty())
+    {
+      EXPECT_EQ(file->Write(contents.data(), contents.size()),
+                static_cast<ssize_t>(contents.size()));
+    }
+    file->Close();
+    return XBMC_TEMPFILEPATH(file);
+  }
+
+  std::unique_ptr<CGameClient> m_client;
+  std::vector<XFILE::CFile*> m_files;
+};
+} // namespace KODI::GAME
+
+TEST_F(TestGameClientDiscs, InvalidPersistedSelectionFallsBackToSource)
+{
+  const std::string disc = CreateFile(".chd");
+  const std::string playlist = CreateFile(".m3u", disc + "\n");
+  ASSERT_FALSE(disc.empty());
+  ASSERT_FALSE(playlist.empty());
+  CGameClientDiscModel previous;
+  previous.AddDisc(disc);
+  CGameClientDiscXML xml;
+  ASSERT_TRUE(xml.Save(playlist, previous));
+  CXBMCTinyXML2 document;
+  const std::string xmlPath = CGameClientDiscXML::GetXMLPath(playlist);
+  ASSERT_TRUE(document.LoadFile(xmlPath));
+  document.RootElement()->FirstChildElement("selected")->SetAttribute("index", 5);
+  ASSERT_TRUE(document.SaveFile(xmlPath));
+
+  m_client->Discs().Initialize(playlist);
+
+  const auto current = m_client->Discs().GetDiscs();
+  EXPECT_EQ(current.GetPathByIndex(0), disc);
+  EXPECT_EQ(current.GetSelectedDiscIndex(), 0U);
+}
+
+TEST_F(TestGameClientDiscs, MalformedPersistedSlotCannotShiftSelectionOntoAnotherDisc)
+{
+  const std::string first = CreateFile(".chd");
+  const std::string second = CreateFile(".chd");
+  const std::string playlist = CreateFile(".m3u", first + "\n" + second + "\n");
+  ASSERT_FALSE(first.empty());
+  ASSERT_FALSE(second.empty());
+  ASSERT_FALSE(playlist.empty());
+  CGameClientDiscModel previous;
+  previous.AddDisc(first);
+  previous.AddDisc(second);
+  ASSERT_TRUE(CGameClientDiscXML::Save(playlist, previous));
+  CXBMCTinyXML2 document;
+  const std::string xmlPath = CGameClientDiscXML::GetXMLPath(playlist);
+  ASSERT_TRUE(document.LoadFile(xmlPath));
+  document.RootElement()->FirstChildElement("slots")->FirstChildElement("slot")->DeleteAttribute(
+      "path");
+  ASSERT_TRUE(document.SaveFile(xmlPath));
+
+  m_client->Discs().Initialize(playlist);
+
+  const auto current = m_client->Discs().GetDiscs();
+  EXPECT_EQ(current.Size(), 2U);
+  EXPECT_EQ(current.GetSelectedDiscPath(), first);
+}

--- a/xbmc/games/dialogs/disc/DialogGameDiscManager.cpp
+++ b/xbmc/games/dialogs/disc/DialogGameDiscManager.cpp
@@ -256,6 +256,11 @@ void CDialogGameDiscManager::OnDiscSelect(size_t discIndex, bool isNoDisc)
     m_deleteCallback(discIndex);
 }
 
+void CDialogGameDiscManager::NotifyDiscSelection()
+{
+  m_discGame->NotifyDiscSelection();
+}
+
 bool CDialogGameDiscManager::AllowSelectNoDisc() const
 {
   if (m_insertCallback)

--- a/xbmc/games/dialogs/disc/DialogGameDiscManager.cpp
+++ b/xbmc/games/dialogs/disc/DialogGameDiscManager.cpp
@@ -256,9 +256,14 @@ void CDialogGameDiscManager::OnDiscSelect(size_t discIndex, bool isNoDisc)
     m_deleteCallback(discIndex);
 }
 
-void CDialogGameDiscManager::NotifyDiscSelection()
+void CDialogGameDiscManager::NotifyDiscChange()
 {
-  m_discGame->NotifyDiscSelection();
+  m_discGame->NotifyDiscChange();
+}
+
+void CDialogGameDiscManager::NotifyTrayChange()
+{
+  m_discGame->NotifyTrayChange();
 }
 
 bool CDialogGameDiscManager::AllowSelectNoDisc() const

--- a/xbmc/games/dialogs/disc/DialogGameDiscManager.h
+++ b/xbmc/games/dialogs/disc/DialogGameDiscManager.h
@@ -61,7 +61,8 @@ public:
                           std::function<void(std::optional<size_t>)> callback);
   void SelectDiscToDelete(std::function<void(size_t)> callback);
   void OnDiscSelect(size_t discIndex, bool isNoDisc);
-  void NotifyDiscSelection();
+  void NotifyDiscChange();
+  void NotifyTrayChange();
   bool AllowSelectNoDisc() const;
 
 protected:

--- a/xbmc/games/dialogs/disc/DialogGameDiscManager.h
+++ b/xbmc/games/dialogs/disc/DialogGameDiscManager.h
@@ -61,6 +61,7 @@ public:
                           std::function<void(std::optional<size_t>)> callback);
   void SelectDiscToDelete(std::function<void(size_t)> callback);
   void OnDiscSelect(size_t discIndex, bool isNoDisc);
+  void NotifyDiscSelection();
   bool AllowSelectNoDisc() const;
 
 protected:

--- a/xbmc/games/dialogs/disc/DiscManagerActions.cpp
+++ b/xbmc/games/dialogs/disc/DiscManagerActions.cpp
@@ -64,28 +64,23 @@ void CDiscManagerActions::OnSelectDisc()
                                    [this](std::optional<size_t> discIndex)
                                    {
                                      bool success = false;
-                                     if (discIndex.has_value())
                                      {
+                                       const auto lock = m_gameClient->LockForSnapshot();
                                        success =
-                                           m_gameClient->Discs().InsertDiscByIndex(*discIndex);
-                                       if (!success)
-                                         ShowInternalError();
+                                           discIndex.has_value()
+                                               ? m_gameClient->Discs().InsertDiscByIndex(*discIndex)
+                                               : m_gameClient->Discs().InsertDisc("");
+                                       if (success)
+                                         m_discManager.NotifyDiscChange();
                                      }
-                                     else
-                                     {
-                                       success = m_gameClient->Discs().InsertDisc("");
-                                       if (!success)
-                                         ShowInternalError();
-                                     }
+                                     if (!success)
+                                       ShowInternalError();
 
                                      m_discManager.UpdateMenu();
 
                                      // Returning from a successful selection of a disc should land on Resume
                                      if (success)
-                                     {
-                                       m_discManager.NotifyDiscSelection();
                                        m_discManager.FocusMainMenuItem(MENU_INDEX_RESUME_GAME);
-                                     }
                                      else
                                        m_discManager.FocusMainMenuItem(MENU_INDEX_SELECT_DISC);
                                    });
@@ -100,9 +95,15 @@ void CDiscManagerActions::OnEjectInsert()
 
   CGameClientDiscs& discs = m_gameClient->Discs();
 
-  const bool wasEjected = discs.IsEjected();
-
-  const bool success = discs.SetEjected(!wasEjected);
+  bool wasEjected;
+  bool success;
+  {
+    const auto lock = m_gameClient->LockForSnapshot();
+    wasEjected = discs.IsEjected();
+    success = discs.SetEjected(!wasEjected);
+    if (success)
+      m_discManager.NotifyTrayChange();
+  }
 
   if (!success)
   {
@@ -164,7 +165,14 @@ void CDiscManagerActions::OnAdd()
     return;
   }
 
-  const bool success = discs.AddDisc(filePath);
+  bool success;
+  {
+    const auto lock = m_gameClient->LockForSnapshot();
+    const CGameClientDiscModel previousModel = discs.GetDiscs();
+    success = discs.AddDisc(filePath);
+    if (success && !(previousModel == discs.GetDiscs()))
+      m_discManager.NotifyDiscChange();
+  }
   if (!success)
     ShowInternalError();
 
@@ -190,7 +198,15 @@ void CDiscManagerActions::OnDelete()
   m_discManager.SelectDiscToDelete(
       [this](size_t discIndex)
       {
-        const bool success = m_gameClient->Discs().RemoveDiscByIndex(discIndex);
+        bool success;
+        {
+          const auto lock = m_gameClient->LockForSnapshot();
+          CGameClientDiscs& discs = m_gameClient->Discs();
+          const CGameClientDiscModel previousModel = discs.GetDiscs();
+          success = discs.RemoveDiscByIndex(discIndex);
+          if (success && !(previousModel == discs.GetDiscs()))
+            m_discManager.NotifyDiscChange();
+        }
         if (!success)
           ShowInternalError();
 

--- a/xbmc/games/dialogs/disc/DiscManagerActions.cpp
+++ b/xbmc/games/dialogs/disc/DiscManagerActions.cpp
@@ -82,7 +82,10 @@ void CDiscManagerActions::OnSelectDisc()
 
                                      // Returning from a successful selection of a disc should land on Resume
                                      if (success)
+                                     {
+                                       m_discManager.NotifyDiscSelection();
                                        m_discManager.FocusMainMenuItem(MENU_INDEX_RESUME_GAME);
+                                     }
                                      else
                                        m_discManager.FocusMainMenuItem(MENU_INDEX_SELECT_DISC);
                                    });

--- a/xbmc/games/dialogs/disc/DiscManagerGame.cpp
+++ b/xbmc/games/dialogs/disc/DiscManagerGame.cpp
@@ -14,6 +14,7 @@
 #include "addons/addoninfo/AddonType.h"
 #include "cores/RetroPlayer/guibridge/GUIGameRenderManager.h"
 #include "cores/RetroPlayer/guibridge/GUIGameSettingsHandle.h"
+#include "dialogs/GUIDialogKaiToast.h"
 #include "games/addons/GameClient.h"
 #include "games/addons/disc/GameClientDiscs.h"
 #include "resources/LocalizeStrings.h"
@@ -27,6 +28,7 @@ void CDiscManagerGame::Initialize(GameClientPtr gameClient)
 {
   m_gameClient = std::move(gameClient);
   m_initialDiscModel.Clear();
+  m_discSelectionRequested = false;
 
   if (m_gameClient)
   {
@@ -69,12 +71,24 @@ void CDiscManagerGame::Deinitialize()
     const std::vector<GameClientDiscEntry>& currentDiscs = currentModel.GetDiscs();
     bool discListChanged = (initialDiscs != currentDiscs);
 
-    if ((selectedDiscChanged || discListChanged) && m_gameClient->Discs().IsEjected())
-      m_gameClient->Discs().SetEjected(false);
+    if ((m_discSelectionRequested || selectedDiscChanged || discListChanged) &&
+        m_gameClient->Discs().IsEjected() && !m_gameClient->Discs().SetEjected(false))
+    {
+      auto& strings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
+      CLog::Log(LOGERROR, "Failed to insert selected disc when closing Disc Manager");
+      CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Error, strings.Get(257),
+                                            strings.Get(35279));
+    }
   }
 
   m_gameClient.reset();
   m_initialDiscModel.Clear();
+  m_discSelectionRequested = false;
+}
+
+void CDiscManagerGame::NotifyDiscSelection()
+{
+  m_discSelectionRequested = true;
 }
 
 bool CDiscManagerGame::IsEjected() const

--- a/xbmc/games/dialogs/disc/DiscManagerGame.cpp
+++ b/xbmc/games/dialogs/disc/DiscManagerGame.cpp
@@ -27,8 +27,7 @@ using namespace GAME;
 void CDiscManagerGame::Initialize(GameClientPtr gameClient)
 {
   m_gameClient = std::move(gameClient);
-  m_initialDiscModel.Clear();
-  m_discSelectionRequested = false;
+  m_pendingDiscModel.reset();
 
   if (m_gameClient)
   {
@@ -36,9 +35,6 @@ void CDiscManagerGame::Initialize(GameClientPtr gameClient)
     {
       // Refresh discs from live core state
       m_gameClient->Discs().RefreshDiscState();
-
-      // Store initial disc state
-      m_initialDiscModel = m_gameClient->Discs().GetDiscs();
     }
     else
     {
@@ -55,24 +51,13 @@ void CDiscManagerGame::Initialize(GameClientPtr gameClient)
 
 void CDiscManagerGame::Deinitialize()
 {
-  // Handle disc state transitions
   if (m_gameClient && m_gameClient->SupportsDiscControl())
   {
-    const CGameClientDiscModel& currentModel = m_gameClient->Discs().GetDiscs();
+    const auto lock = m_gameClient->LockForSnapshot();
+    CGameClientDiscs& discs = m_gameClient->Discs();
 
-    // If selected disc changed, commit that change by forcing tray closed
-    const std::string initialSelectedDisc = m_initialDiscModel.GetSelectedDiscPath();
-    const std::string currentSelectedDisc = currentModel.GetSelectedDiscPath();
-    const bool selectedDiscChanged = (initialSelectedDisc != currentSelectedDisc);
-
-    // If the disc list has changed (a disc was added, removed or swapped),
-    // force the tray closed
-    const std::vector<GameClientDiscEntry>& initialDiscs = m_initialDiscModel.GetDiscs();
-    const std::vector<GameClientDiscEntry>& currentDiscs = currentModel.GetDiscs();
-    bool discListChanged = (initialDiscs != currentDiscs);
-
-    if ((m_discSelectionRequested || selectedDiscChanged || discListChanged) &&
-        m_gameClient->Discs().IsEjected() && !m_gameClient->Discs().SetEjected(false))
+    if (m_pendingDiscModel && *m_pendingDiscModel == discs.GetDiscs() && discs.IsEjected() &&
+        !discs.SetEjected(false))
     {
       auto& strings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
       CLog::Log(LOGERROR, "Failed to insert selected disc when closing Disc Manager");
@@ -82,13 +67,21 @@ void CDiscManagerGame::Deinitialize()
   }
 
   m_gameClient.reset();
-  m_initialDiscModel.Clear();
-  m_discSelectionRequested = false;
+  m_pendingDiscModel.reset();
 }
 
-void CDiscManagerGame::NotifyDiscSelection()
+void CDiscManagerGame::NotifyDiscChange()
 {
-  m_discSelectionRequested = true;
+  if (m_gameClient)
+  {
+    const auto lock = m_gameClient->LockForSnapshot();
+    m_pendingDiscModel = m_gameClient->Discs().GetDiscs();
+  }
+}
+
+void CDiscManagerGame::NotifyTrayChange()
+{
+  m_pendingDiscModel.reset();
 }
 
 bool CDiscManagerGame::IsEjected() const

--- a/xbmc/games/dialogs/disc/DiscManagerGame.cpp
+++ b/xbmc/games/dialogs/disc/DiscManagerGame.cpp
@@ -56,8 +56,9 @@ void CDiscManagerGame::Deinitialize()
     const auto lock = m_gameClient->LockForSnapshot();
     CGameClientDiscs& discs = m_gameClient->Discs();
 
-    if (m_pendingDiscModel && *m_pendingDiscModel == discs.GetDiscs() && discs.IsEjected() &&
-        !discs.SetEjected(false))
+    // A savestate or rewind can supersede the last edit made by this dialog.
+    if (m_pendingDiscModel && m_pendingRestoreGeneration == discs.GetRestoreGeneration() &&
+        *m_pendingDiscModel == discs.GetDiscs() && discs.IsEjected() && !discs.SetEjected(false))
     {
       auto& strings = CServiceBroker::GetResourcesComponent().GetLocalizeStrings();
       CLog::Log(LOGERROR, "Failed to insert selected disc when closing Disc Manager");
@@ -76,6 +77,7 @@ void CDiscManagerGame::NotifyDiscChange()
   {
     const auto lock = m_gameClient->LockForSnapshot();
     m_pendingDiscModel = m_gameClient->Discs().GetDiscs();
+    m_pendingRestoreGeneration = m_gameClient->Discs().GetRestoreGeneration();
   }
 }
 

--- a/xbmc/games/dialogs/disc/DiscManagerGame.h
+++ b/xbmc/games/dialogs/disc/DiscManagerGame.h
@@ -12,6 +12,7 @@
 #include "games/addons/disc/GameClientDiscModel.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -48,6 +49,7 @@ private:
   // Game parameters
   GameClientPtr m_gameClient;
   std::optional<CGameClientDiscModel> m_pendingDiscModel;
+  uint64_t m_pendingRestoreGeneration{0};
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/dialogs/disc/DiscManagerGame.h
+++ b/xbmc/games/dialogs/disc/DiscManagerGame.h
@@ -32,7 +32,8 @@ public:
   // Lifecycle functions
   void Initialize(GameClientPtr gameClient);
   void Deinitialize();
-  void NotifyDiscSelection();
+  void NotifyDiscChange();
+  void NotifyTrayChange();
 
   // Game interface
   bool IsEjected() const;
@@ -46,8 +47,7 @@ public:
 private:
   // Game parameters
   GameClientPtr m_gameClient;
-  CGameClientDiscModel m_initialDiscModel;
-  bool m_discSelectionRequested{false};
+  std::optional<CGameClientDiscModel> m_pendingDiscModel;
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/dialogs/disc/DiscManagerGame.h
+++ b/xbmc/games/dialogs/disc/DiscManagerGame.h
@@ -32,6 +32,7 @@ public:
   // Lifecycle functions
   void Initialize(GameClientPtr gameClient);
   void Deinitialize();
+  void NotifyDiscSelection();
 
   // Game interface
   bool IsEjected() const;
@@ -46,6 +47,7 @@ private:
   // Game parameters
   GameClientPtr m_gameClient;
   CGameClientDiscModel m_initialDiscModel;
+  bool m_discSelectionRequested{false};
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/games/dialogs/disc/test/CMakeLists.txt
+++ b/xbmc/games/dialogs/disc/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(SOURCES TestDiscManagerSortUtils.cpp
-)
+set(SOURCES TestDiscManagerGame.cpp
+            TestDiscManagerSortUtils.cpp)
 
 core_add_test_library(test_games_dialogs_disc)

--- a/xbmc/games/dialogs/disc/test/TestDiscManagerGame.cpp
+++ b/xbmc/games/dialogs/disc/test/TestDiscManagerGame.cpp
@@ -137,6 +137,106 @@ TEST_F(TestDiscManagerGame, FailedAutomaticInsertLeavesTrayOpen)
   EXPECT_TRUE(m_core.ejected);
 }
 
+TEST_F(TestDiscManagerGame, RestoredEmptyPlaylistKeepsTrayOpenOnDeinitialize)
+{
+  m_core.slots = {"/roms/disc2.chd", "/roms/disc1.chd"};
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+
+  CGameClientDiscModel restored;
+  restored.SetEjected(true);
+  m_client->Discs().SetDiscModel(restored);
+  ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+  EXPECT_TRUE(m_client->Discs().GetDiscs().Empty());
+  EXPECT_TRUE(m_client->Discs().GetDiscs().IsSelectedNoDisc());
+}
+
+TEST_F(TestDiscManagerGame, RestoredSelectionKeepsTrayOpenOnDeinitialize)
+{
+  m_core.slots = {"/roms/disc1.chd", "/roms/disc2.chd"};
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+
+  CGameClientDiscModel restored = m_client->Discs().GetDiscs();
+  ASSERT_TRUE(restored.SetSelectedDiscByIndex(1));
+  m_client->Discs().SetDiscModel(restored);
+  ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+  EXPECT_EQ(m_core.selected, 1U);
+}
+
+TEST_F(TestDiscManagerGame, RestoreSupersedesEarlierExplicitSelection)
+{
+  m_core.slots = {"/roms/disc1.chd", "/roms/disc2.chd"};
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  ASSERT_TRUE(m_client->Discs().InsertDiscByIndex(1));
+  game.NotifyDiscChange();
+
+  CGameClientDiscModel restored = m_client->Discs().GetDiscs();
+  ASSERT_TRUE(restored.SetSelectedDiscByIndex(0));
+  m_client->Discs().SetDiscModel(restored);
+  ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+  EXPECT_EQ(m_core.selected, 0U);
+}
+
+TEST_F(TestDiscManagerGame, RestoringSameStateSupersedesEarlierExplicitSelection)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  ASSERT_TRUE(m_client->Discs().InsertDiscByIndex(0));
+  game.NotifyDiscChange();
+
+  const CGameClientDiscModel restored = m_client->Discs().GetDiscs();
+  m_client->Discs().SetDiscModel(restored);
+  ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+  EXPECT_EQ(m_core.selected, 0U);
+}
+
+TEST_F(TestDiscManagerGame, SessionResetSupersedesEarlierExplicitSelection)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  ASSERT_TRUE(m_client->Discs().InsertDiscByIndex(0));
+  game.NotifyDiscChange();
+  m_client->Discs().Deinitialize();
+  m_client->Discs().RefreshDiscState();
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+}
+
+TEST_F(TestDiscManagerGame, SelectionAfterRestoreClosesTrayOnDeinitialize)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  const CGameClientDiscModel restored = m_client->Discs().GetDiscs();
+  m_client->Discs().SetDiscModel(restored);
+  ASSERT_TRUE(m_client->Discs().RestoreDiscList());
+  ASSERT_TRUE(m_client->Discs().InsertDiscByIndex(0));
+  game.NotifyDiscChange();
+
+  game.Deinitialize();
+
+  EXPECT_FALSE(m_core.ejected);
+}
+
 TEST_F(TestDiscManagerGame, DiscOperationsDoNotInvalidatePendingSelection)
 {
   CDiscManagerGame game;

--- a/xbmc/games/dialogs/disc/test/TestDiscManagerGame.cpp
+++ b/xbmc/games/dialogs/disc/test/TestDiscManagerGame.cpp
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (C) 2026 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "addons/Repository.h"
+#include "addons/addoninfo/AddonInfoBuilder.h"
+#include "games/addons/GameClient.h"
+#include "games/dialogs/disc/DiscManagerGame.h"
+#include "utils/XBMCTinyXML2.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace KODI::GAME;
+
+namespace
+{
+struct DiscManagerCore
+{
+  std::vector<std::string> slots{"/roms/disc1.chd"};
+  unsigned int selected{0};
+  bool ejected{true};
+  bool failInsert{false};
+};
+
+DiscManagerCore& Core(const AddonInstance_Game* instance)
+{
+  return *static_cast<DiscManagerCore*>(instance->toAddon->addonInstance);
+}
+} // namespace
+
+class TestDiscManagerGame : public testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    CXBMCTinyXML2 xml;
+    const std::string addonXml =
+        R"(<addon id="game.test.discmanager" name="Disc manager test" version="1.0.0">
+      <extension point="kodi.gameclient" library="test.so">
+        <supports_disc_control>true</supports_disc_control>
+        <extensions>chd</extensions>
+      </extension>
+      <extension point="xbmc.addon.metadata"><platform>all</platform></extension>
+    </addon>)";
+    ASSERT_TRUE(xml.Parse(addonXml));
+    const auto info =
+        ADDON::CAddonInfoBuilder::Generate(xml.RootElement(), ADDON::RepositoryDirInfo{});
+    ASSERT_NE(info, nullptr);
+    m_client = std::make_shared<CGameClient>(info);
+
+    auto* callbacks = m_client->GetInstanceInterface()->toAddon;
+    callbacks->addonInstance = &m_core;
+    callbacks->GetEjectState = [](const AddonInstance_Game* game) { return Core(game).ejected; };
+    callbacks->SetEjectState = [](const AddonInstance_Game* game, bool ejected)
+    {
+      if (Core(game).failInsert && !ejected)
+        return GAME_ERROR_FAILED;
+      Core(game).ejected = ejected;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->GetImageCount = [](const AddonInstance_Game* game)
+    { return static_cast<unsigned int>(Core(game).slots.size()); };
+    callbacks->GetImageIndex = [](const AddonInstance_Game* game) { return Core(game).selected; };
+    callbacks->GetImagePath = [](const AddonInstance_Game* game, unsigned int index) -> char*
+    { return index < Core(game).slots.size() ? strdup(Core(game).slots[index].c_str()) : nullptr; };
+    callbacks->GetImageLabel = [](const AddonInstance_Game*, unsigned int) -> char*
+    { return nullptr; };
+    callbacks->FreeString = [](const AddonInstance_Game*, char* value) { free(value); };
+  }
+
+  DiscManagerCore m_core;
+  std::shared_ptr<CGameClient> m_client;
+};
+
+TEST_F(TestDiscManagerGame, ExplicitSameDiscSelectionClosesTrayOnDeinitialize)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  game.NotifyDiscSelection();
+
+  game.Deinitialize();
+
+  EXPECT_FALSE(m_core.ejected);
+}
+
+TEST_F(TestDiscManagerGame, FailedAutomaticInsertLeavesTrayOpen)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  game.NotifyDiscSelection();
+  m_core.failInsert = true;
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+}

--- a/xbmc/games/dialogs/disc/test/TestDiscManagerGame.cpp
+++ b/xbmc/games/dialogs/disc/test/TestDiscManagerGame.cpp
@@ -9,6 +9,7 @@
 #include "addons/Repository.h"
 #include "addons/addoninfo/AddonInfoBuilder.h"
 #include "games/addons/GameClient.h"
+#include "games/addons/disc/GameClientDiscs.h"
 #include "games/dialogs/disc/DiscManagerGame.h"
 #include "utils/XBMCTinyXML2.h"
 
@@ -30,6 +31,9 @@ struct DiscManagerCore
   unsigned int selected{0};
   bool ejected{true};
   bool failInsert{false};
+  bool failSelection{false};
+  bool failReplace{false};
+  bool failRemove{false};
 };
 
 DiscManagerCore& Core(const AddonInstance_Game* instance)
@@ -71,6 +75,33 @@ protected:
     callbacks->GetImageCount = [](const AddonInstance_Game* game)
     { return static_cast<unsigned int>(Core(game).slots.size()); };
     callbacks->GetImageIndex = [](const AddonInstance_Game* game) { return Core(game).selected; };
+    callbacks->SetImageIndex = [](const AddonInstance_Game* game, unsigned int index)
+    {
+      if (Core(game).failSelection)
+        return GAME_ERROR_FAILED;
+      Core(game).selected = index;
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->AddImageIndex = [](const AddonInstance_Game* game)
+    {
+      Core(game).slots.emplace_back();
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->ReplaceImageIndex =
+        [](const AddonInstance_Game* game, unsigned int index, const char* path)
+    {
+      if (Core(game).failReplace || index >= Core(game).slots.size())
+        return GAME_ERROR_FAILED;
+      Core(game).slots[index] = path ? path : "";
+      return GAME_ERROR_NO_ERROR;
+    };
+    callbacks->RemoveImageIndex = [](const AddonInstance_Game* game, unsigned int index)
+    {
+      if (Core(game).failRemove || index >= Core(game).slots.size())
+        return GAME_ERROR_FAILED;
+      Core(game).slots[index].clear();
+      return GAME_ERROR_NO_ERROR;
+    };
     callbacks->GetImagePath = [](const AddonInstance_Game* game, unsigned int index) -> char*
     { return index < Core(game).slots.size() ? strdup(Core(game).slots[index].c_str()) : nullptr; };
     callbacks->GetImageLabel = [](const AddonInstance_Game*, unsigned int) -> char*
@@ -86,7 +117,8 @@ TEST_F(TestDiscManagerGame, ExplicitSameDiscSelectionClosesTrayOnDeinitialize)
 {
   CDiscManagerGame game;
   game.Initialize(m_client);
-  game.NotifyDiscSelection();
+  ASSERT_TRUE(m_client->Discs().InsertDiscByIndex(0));
+  game.NotifyDiscChange();
 
   game.Deinitialize();
 
@@ -97,10 +129,168 @@ TEST_F(TestDiscManagerGame, FailedAutomaticInsertLeavesTrayOpen)
 {
   CDiscManagerGame game;
   game.Initialize(m_client);
-  game.NotifyDiscSelection();
+  game.NotifyDiscChange();
   m_core.failInsert = true;
 
   game.Deinitialize();
 
   EXPECT_TRUE(m_core.ejected);
+}
+
+TEST_F(TestDiscManagerGame, DiscOperationsDoNotInvalidatePendingSelection)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  ASSERT_TRUE(m_client->Discs().InsertDiscByIndex(0));
+  game.NotifyDiscChange();
+  ASSERT_TRUE(m_client->Discs().SetEjected(false));
+  ASSERT_TRUE(m_client->Discs().SetEjected(true));
+  m_client->Discs().RefreshDiscState();
+
+  game.Deinitialize();
+
+  EXPECT_FALSE(m_core.ejected);
+}
+
+TEST_F(TestDiscManagerGame, ExplicitNoDiscSelectionClosesTrayOnDeinitialize)
+{
+  m_core.selected = 1;
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  ASSERT_TRUE(m_client->Discs().InsertDisc(""));
+  game.NotifyDiscChange();
+
+  game.Deinitialize();
+
+  EXPECT_FALSE(m_core.ejected);
+  EXPECT_TRUE(m_client->Discs().GetDiscs().IsSelectedNoDisc());
+}
+
+TEST_F(TestDiscManagerGame, SuccessfulAdditionClosesTrayOnDeinitialize)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  ASSERT_TRUE(m_client->Discs().AddDisc("/roms/disc2.chd"));
+  game.NotifyDiscChange();
+
+  game.Deinitialize();
+
+  EXPECT_FALSE(m_core.ejected);
+  EXPECT_EQ(m_client->Discs().GetDiscs().GetPathByIndex(1), "/roms/disc2.chd");
+}
+
+TEST_F(TestDiscManagerGame, SuccessfulRemovalClosesTrayOnDeinitialize)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  ASSERT_TRUE(m_client->Discs().RemoveDiscByIndex(0));
+  game.NotifyDiscChange();
+
+  game.Deinitialize();
+
+  EXPECT_FALSE(m_core.ejected);
+  EXPECT_TRUE(m_client->Discs().GetDiscs().IsSelectedNoDisc());
+}
+
+TEST_F(TestDiscManagerGame, FailedNoDiscSelectionAfterRemovalKeepsTrayOpen)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  m_core.failSelection = true;
+  ASSERT_FALSE(m_client->Discs().RemoveDiscByIndex(0));
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+}
+
+TEST_F(TestDiscManagerGame, FailedSelectionKeepsTrayOpen)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  m_core.failSelection = true;
+  ASSERT_FALSE(m_client->Discs().InsertDisc(""));
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+  EXPECT_EQ(m_core.selected, 0U);
+}
+
+TEST_F(TestDiscManagerGame, FailedAdditionKeepsTrayOpen)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  m_core.failReplace = true;
+  ASSERT_FALSE(m_client->Discs().AddDisc("/roms/disc2.chd"));
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+}
+
+TEST_F(TestDiscManagerGame, FailedRemovalKeepsTrayOpen)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  m_core.failRemove = true;
+  ASSERT_FALSE(m_client->Discs().RemoveDiscByIndex(0));
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+}
+
+TEST_F(TestDiscManagerGame, DuplicateAdditionKeepsTrayOpen)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  ASSERT_TRUE(m_client->Discs().AddDisc("/roms/disc1.chd"));
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+}
+
+TEST_F(TestDiscManagerGame, NoManagerEditKeepsTrayOpen)
+{
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+}
+
+TEST_F(TestDiscManagerGame, ExplicitInsertThenEjectSupersedesPendingSelection)
+{
+  m_core.slots = {"/roms/disc1.chd", "/roms/disc2.chd"};
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  ASSERT_TRUE(m_client->Discs().InsertDiscByIndex(1));
+  game.NotifyDiscChange();
+  ASSERT_TRUE(m_client->Discs().SetEjected(false));
+  game.NotifyTrayChange();
+  ASSERT_TRUE(m_client->Discs().SetEjected(true));
+  game.NotifyTrayChange();
+
+  game.Deinitialize();
+
+  EXPECT_TRUE(m_core.ejected);
+  EXPECT_EQ(m_core.selected, 1U);
+}
+
+TEST_F(TestDiscManagerGame, SelectionAfterExplicitEjectClosesTrayOnDeinitialize)
+{
+  m_core.ejected = false;
+  CDiscManagerGame game;
+  game.Initialize(m_client);
+  ASSERT_TRUE(m_client->Discs().SetEjected(true));
+  game.NotifyTrayChange();
+  ASSERT_TRUE(m_client->Discs().InsertDiscByIndex(0));
+  game.NotifyDiscChange();
+
+  game.Deinitialize();
+
+  EXPECT_FALSE(m_core.ejected);
 }


### PR DESCRIPTION
## Description

After changing discs, loading an earlier savestate or rewinding could restore the machine while leaving the wrong disc mounted. Playlist edits and tray changes also need to follow the restored state.

This PR fixes the problem by persisting the disc state in savestates and the rewind buffer.

* Save the playlist, selected disc (including No Disc), and tray state with savestates and rewind frames. Restore them together with the emulated machine state, including playlist additions, removals, and reordering.
* Savestates store portable filenames and validate media before loading. Older savestates without disc metadata remain supported.
* Validate and reconcile shared per-game disc state when switching cores. If persisted startup state cannot be restored safely, log the reason and reload from the original game path or source M3U.

Developed in conjunction with the following disc-related fixes:

* https://github.com/libretro/pcsx_rearmed/pull/937
* https://github.com/libretro/pcsx_rearmed/pull/934
* https://github.com/libretro/pcsx_rearmed/pull/935
* https://github.com/libretro/beetle-psx-libretro/pull/998
* https://github.com/libretro/swanstation/pull/182
* https://github.com/libretro/swanstation/pull/183
* https://github.com/libretro/swanstation/pull/184
* https://github.com/libretro/swanstation/pull/185

## Motivation and context

Different cores handle removed disc slots differently. Shared disc state must preserve disc identity across these differences, and unusable persisted state must not prevent the game from launching.

## How has this been tested?

Tested during development on macOS with Apple Silicon using native Debug builds of Kodi and kodi-test.

- Ran focused tests covering savestate metadata, legacy saves, filename resolution, disc restoration, rewind history, branching, and eviction.
- Tested Metal Gear Solid with Beetle PSX and PCSX ReARMed, restoring both discs with the tray open and closed, plus No Disc with either tray state.
- Exercised rewind and forward across disc and tray changes, and verified that resuming after rewind discards the old future.
- Switched between both cores using the same M3U and shared per-game discstate directory. Checked reordered playlists, removed slots, empty playlists, selected disc, and tray state.
- Verified fallback to the original M3U with malformed persisted XML, missing media, and a playlist exceeding PCSX ReARMed's slot capacity.

## What is the effect on users?

Loading a savestate or rewinding a multi-disc game also restores its playlist, selected disc, and tray state.

Shared disc state works across compatible emulators. Missing or ambiguous media prevents an unsafe savestate load, while unusable persisted startup state falls back to the original game.

## Types of change

- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [x] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)