### PR TITLE
[test] Fix unnecessary lambda capture warning in TestMatchingSource

### DIFF
--- a/xbmc/test/TestUtil.cpp
+++ b/xbmc/test/TestUtil.cpp
@@ -829,10 +829,11 @@ constexpr TestMatchingSourceData SourcesToMatch[] = {
 
 TEST_P(TestMatchingSource, GetMatchingSource)
 {
+  char dosDriveLetter{'D'};
+
 #if defined(TARGET_WINDOWS_DESKTOP)
   // D: is often an optical drive. Use a non-optical letter so this fixture tests source matching
   // rather than the intentional optical-source shortcut.
-  char dosDriveLetter{'D'};
   if (URIUtils::IsOnDVD("D:\\"))
   {
     for (char candidate = 'C'; candidate <= 'Z'; ++candidate)
@@ -847,8 +848,6 @@ TEST_P(TestMatchingSource, GetMatchingSource)
     }
   }
   ASSERT_FALSE(URIUtils::IsOnDVD(std::string{dosDriveLetter} + ":\\"));
-#else
-  const char dosDriveLetter{'D'};
 #endif
 
   const auto replaceOpticalTestDrive = [dosDriveLetter](const char* value)


### PR DESCRIPTION
## Description

Fixes a clang warning breaking OSX-64 builds.

Warning was: https://jenkins.kodi.tv/job/OSX-64/45543/clang/folder.1980418881/source.53332da1-bafc-4bb4-94dd-c1cb80da62fe/#854

```
lambda capture 'dosDriveLetter' is not required to be captured for this use
```

## Motivation and context

Snuck in via https://github.com/xbmc/xbmc/pull/29104 while macOS builders were down.

## How has this been tested?

See CI results.

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)
