### PR TITLE
changed: enqueue a music scraping job through one entry point

### DIFF
--- a/xbmc/interfaces/builtins/LibraryBuiltins.cpp
+++ b/xbmc/interfaces/builtins/LibraryBuiltins.cpp
@@ -11,6 +11,7 @@
 #include "GUIUserMessages.h"
 #include "MediaSource.h"
 #include "ServiceBroker.h"
+#include "addons/Scraper.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "dialogs/GUIDialogYesNo.h"
 #include "guilib/GUIComponent.h"
@@ -365,7 +366,8 @@ static int RefreshArtist(const std::vector<std::string>& params)
   musicUrl.AddOption("artistid", params.front());
 
   // Start rescraping additional information for the given artist
-  CMusicLibraryQueue::GetInstance().StartArtistScan(musicUrl.ToString(), true);
+  CMusicLibraryQueue::GetInstance().StartScan(ADDON::ContentType::ARTISTS, musicUrl.ToString(),
+                                              true);
   return 0;
 }
 
@@ -386,7 +388,8 @@ static int RefreshAlbum(const std::vector<std::string>& params)
   musicUrl.AddOption("albumid", params.front());
 
   // Start rescraping additional information for the given album
-  CMusicLibraryQueue::GetInstance().StartAlbumScan(musicUrl.ToString(), true);
+  CMusicLibraryQueue::GetInstance().StartScan(ADDON::ContentType::ALBUMS, musicUrl.ToString(),
+                                              true);
   return 0;
 }
 

--- a/xbmc/music/MusicLibraryQueue.cpp
+++ b/xbmc/music/MusicLibraryQueue.cpp
@@ -139,19 +139,21 @@ void CMusicLibraryQueue::ScanLibrary(const std::string& strDirectory,
   AddJob(new CMusicLibraryScanningJob(strDirectory, flags, showProgress));
 }
 
-void CMusicLibraryQueue::StartAlbumScan(const std::string & strDirectory, bool refresh)
+void CMusicLibraryQueue::StartScan(ADDON::ContentType content,
+                                   const std::string& strDirectory,
+                                   bool refresh)
 {
-  int flags = MUSIC_INFO::CMusicInfoScanner::SCAN_ALBUMS;
-  if (refresh)
-    flags |= MUSIC_INFO::CMusicInfoScanner::SCAN_RESCAN;
-  AddJob(new CMusicLibraryScanningJob(strDirectory, flags, true));
-}
+  int flags = 0;
+  if (content == ADDON::ContentType::ALBUMS)
+    flags = MUSIC_INFO::CMusicInfoScanner::SCAN_ALBUMS;
+  else if (content == ADDON::ContentType::ARTISTS)
+    flags = MUSIC_INFO::CMusicInfoScanner::SCAN_ARTISTS;
+  else
+    return;
 
-void CMusicLibraryQueue::StartArtistScan(const std::string& strDirectory, bool refresh)
-{
-  int flags = MUSIC_INFO::CMusicInfoScanner::SCAN_ARTISTS;
   if (refresh)
     flags |= MUSIC_INFO::CMusicInfoScanner::SCAN_RESCAN;
+
   AddJob(new CMusicLibraryScanningJob(strDirectory, flags, true));
 }
 

--- a/xbmc/music/MusicLibraryQueue.h
+++ b/xbmc/music/MusicLibraryQueue.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "addons/Scraper.h"
 #include "jobs/JobQueue.h"
 #include "settings/LibExportSettings.h"
 #include "threads/CriticalSection.h"
@@ -58,18 +59,11 @@ public:
   void ScanLibrary(const std::string& strDirectory, int flags = 0, bool showProgress = true);
 
   /*!
-   \brief Enqueue an album scraping job fetching additional album data.
-   \param[in] strDirectory Virtual path that identifies which albums to process or "" (empty string) for all albums
-   \param[in] refresh Whether or not to refresh data for albums that have previously been scraped
+   \brief Enqueue a scraping job fetching additional album or artist data.
+   \param[in] content ALBUMS or ARTISTS
+   \param[in] strDirectory Virtual path or empty string
   */
-  void StartAlbumScan(const std::string& strDirectory, bool refresh = false);
-
-  /*!
-   \brief Enqueue an artist scraping job fetching additional artist data.
-   \param[in] strDirectory Virtual path that identifies which artists to process or "" (empty string) for all artists
-   \param[in] refresh Whether or not to refresh data for artists that have previously been scraped
-   */
-  void StartArtistScan(const std::string& strDirectory, bool refresh = false);
+  void StartScan(ADDON::ContentType content, const std::string& strDirectory, bool refresh = false);
 
   /*!
    \brief Check if a library scan or cleaning is in progress.

--- a/xbmc/music/windows/GUIWindowMusicBase.cpp
+++ b/xbmc/music/windows/GUIWindowMusicBase.cpp
@@ -19,6 +19,7 @@
 #include "ServiceBroker.h"
 #include "URL.h"
 #include "Util.h"
+#include "addons/Scraper.h"
 #include "addons/gui/GUIDialogAddonInfo.h"
 #include "application/Application.h"
 #include "application/ApplicationComponents.h"
@@ -283,20 +284,18 @@ bool CGUIWindowMusicBase::OnAction(const CAction &action)
 
 void CGUIWindowMusicBase::OnItemInfoAll(const std::string& strPath, bool refresh)
 {
+  ADDON::ContentType content{ADDON::ContentType::NONE};
   if (StringUtils::EqualsNoCase(m_vecItems->GetContent(), "albums"))
-  {
-    if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
-      return;
-
-    CMusicLibraryQueue::GetInstance().StartAlbumScan(strPath, refresh);
-  }
+    content = ADDON::ContentType::ALBUMS;
   else if (StringUtils::EqualsNoCase(m_vecItems->GetContent(), "artists"))
-  {
-    if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
-      return;
+    content = ADDON::ContentType::ARTISTS;
+  else
+    return;
 
-    CMusicLibraryQueue::GetInstance().StartArtistScan(strPath, refresh);
-  }
+  if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
+    return;
+
+  CMusicLibraryQueue::GetInstance().StartScan(content, strPath, refresh);
 }
 
 void CGUIWindowMusicBase::OnItemInfo(int iItem)


### PR DESCRIPTION
**TL;DR:** Clean up. `CMusicLibraryQueue::StartAlbumScan` and `StartArtistScan` were five lines each differing by one flag; they become a single `StartScan` taking the content type.

## Description

`CMusicLibraryQueue::StartAlbumScan` and `StartArtistScan` were five lines each and differed by a single value — `SCAN_ALBUMS` against `SCAN_ARTISTS`. Everything else, including the `SCAN_RESCAN` handling and the job construction, was identical.

Every caller already knew which of the two it wanted, so the choice was being made twice: once by the caller picking a function, and once inside that function picking a flag. `StartScan(ADDON::ContentType, directory, refresh)` takes the content type instead, which is how `CMusicDatabase` already distinguishes the same two kinds of row, and there is now one job-building path. A content type that is neither `ALBUMS` nor `ARTISTS` enqueues nothing, so a caller cannot ask for a scan of something the scanner has no flag for.

`CGUIWindowMusicBase::OnItemInfoAll` is where this reads best. It branched on the view's content to pick the function and repeated the `IsScanningLibrary()` guard in both arms:

```cpp
if (StringUtils::EqualsNoCase(m_vecItems->GetContent(), "albums"))
{
  if (CMusicLibraryQueue::GetInstance().IsScanningLibrary())
    return;

  CMusicLibraryQueue::GetInstance().StartAlbumScan(strPath, refresh);
}
else if (StringUtils::EqualsNoCase(m_vecItems->GetContent(), "artists"))
{
  ... the same again ...
}
```

It now resolves the content once, checks once, and calls once.

## Motivation and context

Two functions that differ by one flag are two places to change when the scanning job grows an argument, and the compiler cannot tell you that you updated only one of them.

The comparisons in `OnItemInfoAll` deliberately stay as `StringUtils::EqualsNoCase` rather than becoming `ADDON::TranslateContent`, which would read better but is a case-sensitive `string == map.name` (`Scraper.cpp:105`). Swapping it in would have quietly narrowed which content strings the window accepts, so the mapping to the enum is spelled out instead.

## How has this been tested?

Full suite green: 4080 tests from 320 test suites, all passed. `clang-format` clean on the changed lines of all four files.

The change is a pure consolidation — no call site changes which flags it ends up passing to `CMusicLibraryScanningJob`, and no caller of the two removed functions remains anywhere in the tree.

## What is the effect on users?

None. This is internal refactoring with no behavioural change.

## Screenshots (if appropriate):

## Types of change

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [X] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:

- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [X] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
