### PR TITLE
added: volume control during passthrough, for a room whose level lives outside Kodi

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -25652,3 +25652,15 @@ msgstr ""
 msgctxt "#40804"
 msgid "{0:.1f} dB"
 msgstr ""
+
+#. Setting "audiooutput.passthroughvolumecontrol"
+#: system/settings/settings.xml
+msgctxt "#40805"
+msgid "Volume control during passthrough"
+msgstr ""
+
+#. Help of setting "audiooutput.passthroughvolumecontrol"
+#: system/settings/settings.xml
+msgctxt "#40806"
+msgid "Adjust and display the volume level while audio is passed through. The level is not applied to the bitstream, but every change is announced, so an add-on or automation can apply it to an external audio processor."
+msgstr ""

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -389,7 +389,7 @@
 		<value condition="Player.Muted">dialogs/volume/mute.png</value>
 		<value condition="Integer.IsGreater(Player.Volume,66)">dialogs/volume/volume.png</value>
 		<value condition="Integer.IsGreater(Player.Volume,33)">dialogs/volume/volume2.png</value>
-		<value condition="player.passthrough">dialogs/volume/volume.png</value>
+		<value condition="player.passthrough + !System.GetBool(audiooutput.passthroughvolumecontrol)">dialogs/volume/volume.png</value>
 		<value>dialogs/volume/volume1.png</value>
 	</variable>
 	<variable name="ListSubLabelVar">

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -3487,6 +3487,20 @@
           </dependencies>
           <control type="toggle" />
         </setting>
+        <setting id="audiooutput.passthroughvolumecontrol" type="boolean" label="40805" help="40806">
+          <level>2</level>
+          <default>false</default>
+          <dependencies>
+            <dependency type="visible">
+              <and>
+                <condition on="property" name="aesettingvisible" setting="audiooutput.passthrough">audiooutput.passthrough</condition>
+                <condition on="property" name="aesettingvisible" setting="audiooutput.config">audiooutput.passthrough</condition>
+              </and>
+            </dependency>
+            <dependency type="enable" setting="audiooutput.passthrough" operator="is">true</dependency>
+          </dependencies>
+          <control type="toggle" />
+        </setting>
         <setting id="audiooutput.passthroughdevice" type="string" label="546" help="36372">
           <level>1</level>
           <default>Default</default> <!-- will be properly set on startup -->

--- a/xbmc/application/Application.cpp
+++ b/xbmc/application/Application.cpp
@@ -1446,7 +1446,13 @@ bool CApplication::OnAction(const CAction &action)
   if ((action.GetAmount() && (action.GetID() == ACTION_VOLUME_UP || action.GetID() == ACTION_VOLUME_DOWN)) || action.GetID() == ACTION_VOLUME_SET)
   {
     const auto appVolume = GetComponent<CApplicationVolumeHandling>();
-    if (!appPlayer->IsPassthrough())
+
+    // The level cannot be applied to a bitstream, but with volume control enabled
+    // it is still adjusted and announced, so an external processor can follow it
+    const bool volumeControl = !appPlayer->IsPassthrough() ||
+                               CServiceBroker::GetSettingsComponent()->GetSettings()->GetBool(
+                                   CSettings::SETTING_AUDIOOUTPUT_PASSTHROUGHVOLUMECONTROL);
+    if (volumeControl)
     {
       if (appVolume->IsMuted())
         appVolume->UnMute();

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -413,6 +413,8 @@ public:
   static constexpr auto SETTING_AUDIOOUTPUT_GUISOUNDMODE = "audiooutput.guisoundmode";
   static constexpr auto SETTING_AUDIOOUTPUT_GUISOUNDVOLUME = "audiooutput.guisoundvolume";
   static constexpr auto SETTING_AUDIOOUTPUT_PASSTHROUGH = "audiooutput.passthrough";
+  static constexpr auto SETTING_AUDIOOUTPUT_PASSTHROUGHVOLUMECONTROL =
+      "audiooutput.passthroughvolumecontrol";
   static constexpr auto SETTING_AUDIOOUTPUT_PASSTHROUGHDEVICE = "audiooutput.passthroughdevice";
   static constexpr auto SETTING_AUDIOOUTPUT_AC3PASSTHROUGH = "audiooutput.ac3passthrough";
   static constexpr auto SETTING_AUDIOOUTPUT_AC3TRANSCODE = "audiooutput.ac3transcode";


### PR DESCRIPTION
**TL;DR:** New feature, off by default. The volume keys keep working during pass-through. Nothing can attenuate a bitstream, so the level is not applied to it — but the level is adjusted and announced, so an add-on or automation can apply it to an external processor.

## Description
A bitstream cannot be attenuated, so during pass-through the volume keys show an indicator and change nothing. `audiooutput.passthroughvolumecontrol` makes them adjust and announce the application volume exactly as they do for decoded audio: the bar moves and `Application.OnVolumeChanged` fires. The bitstream itself is untouched, as it always was — the setting only decides whether the level keeps being adjustable while it plays.

While the setting is on, Estuary stops substituting the pass-through icon for the level icons, so the level the keys move is the level on screen.

Off by default. Without something downstream listening, a volume bar that moves while the loudness does not would be a lie.

Five files: the setting and its two strings, one condition in `CApplication::OnAction`, and one Estuary variable.

## Motivation and context
In a room where the level belongs to an external processor, suppressing the keys is wrong twice over: the viewer gets no feedback of any level, and an automation has nothing to follow. The processor is what changes the loudness, and it needs to be told what the viewer asked for.

## How has this been tested?
Built on Windows against current master, with the full test suite run. Exercised with pass-through enabled: with the setting off, the keys behave exactly as before; with it on, the volume bar tracks the keys, `Application.OnVolumeChanged` fires on each change over JSON-RPC, and what reaches the receiver is unchanged.

## What is the effect on users?
Nothing changes unless the setting is enabled. With it on, the volume keys move Kodi's own level during pass-through and announce it, so an add-on can drive an AV processor, amplifier or matrix from the same keys that work the rest of the time.

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [X] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
