### PR TITLE
fixed: back off sink retries while an HDMI receiver is unavailable

### DIFF
--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.cpp
@@ -26,6 +26,8 @@
 #include "utils/log.h"
 #include "windowing/WinSystem.h"
 
+#include <algorithm>
+#include <chrono>
 #include <memory>
 #include <mutex>
 
@@ -42,6 +44,19 @@ constexpr float MIN_WATER_LEVEL = 0.02f; // min buffer time to prevent underrun
 constexpr float MIN_WATER_LEVEL_RESAMPLE = 0.1f; // min buffer time in resample mode
 constexpr float BUFFER_LEVEL_INCREMENT = 0.0001f; // increment step for ramp-up
 constexpr double MAX_BUFFER_TIME = 0.1; // max time of a buffer in seconds;
+
+//! \brief Retry interval for a sink that will not open, doubling to a ceiling.
+//! A device that returns announces itself, so only a fault that clears by itself needs the
+//! interval to stay short.
+std::chrono::milliseconds ErrorRetryDelay(unsigned int consecutiveFailures)
+{
+  constexpr std::chrono::milliseconds FIRST{500};
+  constexpr std::chrono::milliseconds CEILING{30000};
+
+  const unsigned int doublings = std::min(consecutiveFailures ? consecutiveFailures - 1 : 0u, 8u);
+  const std::chrono::milliseconds delay{FIRST.count() * (1LL << doublings)};
+  return std::min(delay, CEILING);
+}
 
 bool IsDefaultDevice(const AESinkDevice& device)
 {
@@ -516,7 +531,25 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
       break;
 
     case AE_TOP_ERROR:
-      if (port == NULL) // timeout
+      if (port == &m_controlPort)
+      {
+        switch (signal)
+        {
+          case CActiveAEControlProtocol::DEVICECHANGE:
+          case CActiveAEControlProtocol::DEFAULTDEVICECHANGE:
+          case CActiveAEControlProtocol::DEVICECOUNTCHANGE:
+            if (m_extTimeout != 0ms)
+            {
+              m_sink.EnumerateSinkList(true, "");
+              m_extErrorRetries = 0;
+              m_extTimeout = 0ms;
+            }
+            return;
+          default:
+            break;
+        }
+      }
+      else if (port == NULL) // timeout
       {
         switch (signal)
         {
@@ -526,13 +559,14 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           Configure();
           if (!m_extError)
           {
+            m_extErrorRetries = 0;
             m_state = AE_TOP_CONFIGURED_PLAY;
             m_extTimeout = 0ms;
           }
           else
           {
             m_state = AE_TOP_ERROR;
-            m_extTimeout = 500ms;
+            m_extTimeout = ErrorRetryDelay(++m_extErrorRetries);
           }
           return;
         default:
@@ -683,6 +717,7 @@ void CActiveAE::StateMachine(int signal, Protocol *port, Message *msg)
           m_sink.EnumerateSinkList(true, "");
           LoadSettings();
           ValidateOutputDevices(false);
+          m_extErrorRetries = 0;
           m_extError = false;
           Configure();
           if (!m_extError)
@@ -2875,6 +2910,7 @@ void CActiveAE::HandleDeviceCountChange(const std::string& driver, bool defaultD
   UnconfigureSink();
   LoadSettings();
   ValidateOutputDevices(false);
+  m_extErrorRetries = 0;
   m_extError = false;
   Configure();
   if (!m_extError)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAE.h
@@ -354,6 +354,7 @@ protected:
   bool m_bStateMachineSelfTrigger;
   std::chrono::milliseconds m_extTimeout;
   bool m_extError;
+  unsigned int m_extErrorRetries{0};
   bool m_extDrain;
   XbmcThreads::EndTime<> m_extDrainTimer;
   std::chrono::milliseconds m_extKeepConfig;


### PR DESCRIPTION
**TL;DR:** Fix. When an HDMI receiver is switched off it takes its audio endpoint with it, and Kodi retries the sink every 500 ms for as long as the receiver is away — around 4.6 MB of log an hour. The retry now backs off to a 30 second ceiling.

## Description
The retry interval doubles from 500 ms to a 30 second ceiling. The first retry is unchanged, so a fault that clears by itself recovers just as quickly.

Backing off would otherwise slow recovery, because the signals that say a device has returned — `DEVICECHANGE`, `DEFAULTDEVICECHANGE`, `DEVICECOUNTCHANGE` — were handled only by the configured states and dropped by the error state a failing sink sits in. The error state now acts on them, so a receiver switched back on is picked up when it announces itself rather than on the next retry.

## Motivation and context
Measured on an idle machine after the room was switched off: 9258 attempts over 77 minutes, six log lines each, and still going.

## How has this been tested?
Built on Windows against current master, full test suite green. Exercised against a real chain: switched off at the wall the retries back off and the log settles; switched back on the sink reopens on the device-change signal.

## What is the effect on users?
A room switched off no longer fills the log, and a receiver switched back on is picked up as soon as it announces itself.

## Screenshots (if appropriate):

## Types of change
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement (v22 new feature polish)** (non-breaking change which improves a new feature in v22)
- [ ] **Improvement (other)** (non-breaking change which improves other existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be reviewed with support)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
